### PR TITLE
Access player struct via raw pointer if game version is <27

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2010,7 +2010,7 @@ void setup_player_character(int charid) {
     game.playercharacter = charid;
     playerchar = &game.chars[charid];
     _sc_PlayerCharPtr = ccGetObjectHandleFromAddress((char*)playerchar);
-    if (loaded_game_file_version < 27) {
+    if (loaded_game_file_version < 31) {
         ccAddExternalSymbol("player", playerchar);
     }
 }

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -67,7 +67,8 @@ GetRegionAt() clips the input values to the screen size
 27 : 2.6.2
 
 Script modules. Fixes bug in the inventory display.
-Clickable GUI is selected with regard for the drawing order
+Clickable GUI is selected with regard for the drawing order.
+Pointer to the "player" variable is now accessed via a dynamic object.
 31 : 2.7.0
 32 : 2.7.2
 
@@ -569,7 +570,7 @@ void init_and_register_game_objects()
 
     ccAddExternalSymbol("character",&game.chars[0]);
     setup_player_character(game.playercharacter);
-    if (loaded_game_file_version >= 27) {
+    if (loaded_game_file_version >= 31) {
         ccAddExternalSymbol("player", &_sc_PlayerCharPtr);
     }
     ccAddExternalSymbol("object",&scrObj[0]);


### PR DESCRIPTION
In older ags games the "player" struct seems to be accessed via raw pointer and not managed object as it's done now in the ags engine.

To reproduce run "Apprentice 1" or "Apprentice 2" take scroll in the first room, and try using it on anything. You'll see  description of the used object changing to "Cup of water".

Somehow I cannot make it fail using old engine versions, but as I'm running them under wine on ubuntu perhaps I'm doing something wrong.

I cannot trigger this behaviour on games versions higher then 27 so I'm assuming it's limited to versions <27, but perhaps there is other trigger for this behaviour.

If you have any advise how to verify this change I'm glad to follow it.
