### PR TITLE
Use only one #define for getch() / rec_getch()

### DIFF
--- a/Engine/gui/guidialoginternaldefs.h
+++ b/Engine/gui/guidialoginternaldefs.h
@@ -25,8 +25,6 @@
 #define _getcwd getcwd
 #endif
 
-#define domouse rec_domouse
-
 #define _export
 #ifdef WINAPI
 #undef WINAPI


### PR DESCRIPTION
This fixes two more compile time warnings. Seven left to go.
