### PR TITLE
Vsync

### DIFF
--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -20,6 +20,7 @@ GameSetup::GameSetup()
     digicard=DIGI_AUTODETECT; midicard=MIDI_AUTODETECT;
     mod_player=1; mp3_player=1;
     want_letterbox=0; windowed = 0;
+    vsync = 0;
     no_speech_pack = 0;
     refresh = 0;
     enable_antialiasing = 0;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -28,6 +28,7 @@ struct GameSetup {
     int mp3_player;
     int want_letterbox;
     int windowed;
+    int vsync;
     int base_width, base_height;
     short refresh;
     char  no_speech_pack;

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -103,7 +103,8 @@ int System_GetVsync() {
 }
 
 void System_SetVsync(int newValue) {
-    scsystem.vsync = newValue;
+    if(stricmp(gfxDriver->GetDriverID(), "D3D9") != 0)
+        scsystem.vsync = newValue;
 }
 
 int System_GetWindowed() {

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -386,8 +386,8 @@ public:
   virtual const char*GetDriverID() { return "OGL"; }
   virtual void SetGraphicsFilter(GFXFilter *filter);
   virtual void SetTintMethod(TintMethod method);
-  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer);
-  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer);
+  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync);
+  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync);
   virtual IGfxModeList *GetSupportedModeList(int color_depth);
   virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) { _pollingCallback = callback; }
   virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) { _drawScreenCallback = callback; }
@@ -808,12 +808,12 @@ void OGLGraphicsDriver::InitOpenGl()
   create_backbuffer_arrays();
 }
 
-bool OGLGraphicsDriver::Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer) 
+bool OGLGraphicsDriver::Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync) 
 {
-  return this->Init(width, height, width, height, colourDepth, windowed, loopTimer);
+  return this->Init(width, height, width, height, colourDepth, windowed, loopTimer, vsync);
 }
 
-bool OGLGraphicsDriver::Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer)
+bool OGLGraphicsDriver::Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync)
 {
 #if defined(ANDROID_VERSION)
   android_create_screen(realWidth, realHeight, colourDepth);

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -177,8 +177,8 @@ public:
   virtual const char*GetDriverID() { return "DX5"; }
   virtual void SetGraphicsFilter(GFXFilter *filter);
   virtual void SetTintMethod(TintMethod method);
-  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer);
-  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer);
+  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync);
+  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync);
   virtual IGfxModeList *GetSupportedModeList(int color_depth);
   virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) { _callback = callback; }
   virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) { _drawScreenCallback = callback; }
@@ -330,12 +330,12 @@ void ALSoftwareGraphicsDriver::SetTintMethod(TintMethod method)
   // TODO: support new D3D-style tint method
 }
 
-bool ALSoftwareGraphicsDriver::Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer)
+bool ALSoftwareGraphicsDriver::Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync)
 {
   throw Ali3DException("this overload is not supported, you must use the normal Init method");
 }
 
-bool ALSoftwareGraphicsDriver::Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer)
+bool ALSoftwareGraphicsDriver::Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync)
 {
   _screenWidth = width;
   _screenHeight = height;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -67,8 +67,8 @@ public:
   virtual const char*GetDriverID() = 0;
   virtual void SetGraphicsFilter(GFXFilter *filter) = 0;
   virtual void SetTintMethod(TintMethod method) = 0;
-  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer) = 0;
-  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer) = 0;
+  virtual bool Init(int width, int height, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync) = 0;
+  virtual bool Init(int virtualWidth, int virtualHeight, int realWidth, int realHeight, int colourDepth, bool windowed, volatile int *loopTimer, bool vsync) = 0;
   virtual IGfxModeList *GetSupportedModeList(int color_depth) = 0;
   virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) = 0;
   virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) = 0;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -235,6 +235,7 @@ void read_config_file(char *argv0) {
         usetup.enable_antialiasing = INIreadint ("misc", "antialias", 0);
         usetup.force_hicolor_mode = INIreadint("misc", "notruecolor", 0);
         usetup.enable_side_borders = INIreadint("misc", "sideborders", 0);
+        usetup.vsync = INIreadint("misc", "vsync", 0);
 
 #if defined(IOS_VERSION) || defined(PSP_VERSION) || defined(ANDROID_VERSION)
         // PSP: Letterboxing is not useful on the PSP.

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1231,6 +1231,8 @@ void engine_init_game_shit()
 
     if (usetup.windowed)
         scsystem.windowed = 1;
+    if (usetup.vsync)
+        scsystem.vsync = 1;
 
 #if defined (DOS_VERSION)
     filter->SetMouseArea(0,0,BASEWIDTH-1,BASEHEIGHT-1);

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -587,7 +587,7 @@ int init_gfx_mode(int wid,int hit,int cdep) {
         set_color_depth(cdep);
     }
 
-    working_gfx_mode_status = (gfxDriver->Init(wid, hit, final_col_dep, usetup.windowed > 0, &timerloop) ? 0 : -1);
+    working_gfx_mode_status = (gfxDriver->Init(wid, hit, final_col_dep, usetup.windowed > 0, &timerloop, usetup.vsync) ? 0 : -1);
 
     if (working_gfx_mode_status == 0) 
         Out::FPrint("Succeeded. Using gfx mode %d x %d (%d-bit)", wid, hit, final_col_dep);

--- a/Engine/resource/resource.h
+++ b/Engine/resource/resource.h
@@ -29,9 +29,10 @@
 #define IDC_GFXDRIVER                   1024
 #define IDC_RESOLUTION                  1025
 #define IDC_SIDEBORDERS                 1026
+#define IDC_VSYNC                       1027
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        108

--- a/Engine/resource/version.rc
+++ b/Engine/resource/version.rc
@@ -110,7 +110,7 @@ IDI_ICON2               ICON                    "game-1.ico"
 // Dialog
 //
 
-IDD_DIALOG1 DIALOGEX 0, 0, 360, 285
+IDD_DIALOG1 DIALOGEX 0, 0, 360, 294
 STYLE DS_SETFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "AGS Game Settings"
 FONT 8, "Tahoma", 400, 0, 0x0
@@ -131,28 +131,30 @@ BEGIN
     PUSHBUTTON      "&Save and Run",IDOKRUN,67,102,56,14
     PUSHBUTTON      "Cancel",IDCANCEL,127,102,56,14
     PUSHBUTTON      "Ad&vanced  >>>",IDC_ADVANCED,282,101,70,15
-    GROUPBOX        "Sound options",IDC_STATIC,7,121,185,89
+    GROUPBOX        "Sound options",IDC_STATIC,7,121,185,96
     LTEXT           "Digital Sound:",IDC_STATIC,13,136,46,9
     COMBOBOX        IDC_COMBO1,68,134,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_GROUP | WS_TABSTOP
     LTEXT           "MIDI music:",IDC_STATIC,13,152,47,10
     COMBOBOX        IDC_COMBO2,68,150,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_TABSTOP
     CONTROL         "Use voice pack if available",IDC_SPEECHPACK,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,13,169,160,9
-    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,89
+    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,96
     CONTROL         "Use 85 &Hz display (CRT monitors only)",IDC_REFRESH,
                     "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,136,138,8
     CONTROL         "Side borders on widescreen monitors",IDC_SIDEBORDERS,
-                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,150,135,9
+                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,149,135,9
     CONTROL         "S&mooth scaled sprites (fast CPUs only)",IDC_ANTIALIAS,
-                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,165,138,8
+                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,162,138,8
     CONTROL         "Downgra&de 32-bit graphics to 16-bit",IDC_REDUCESPR,
-                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,179,135,9
+                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,175,135,9
     CONTROL         "Force alternate &letterbox resolution",IDC_LETTERBOX,
-                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,194,132,9
-    GROUPBOX        "Sprite cache",IDC_STATICADV,7,212,345,55,NOT WS_VISIBLE
-    LTEXT           "Maximum size:",IDC_STATICADV3,15,225,50,10,NOT WS_VISIBLE
-    COMBOBOX        IDC_COMBO4,68,223,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,239,323,26,NOT WS_VISIBLE
-    CTEXT           "Static",IDC_VERSION,91,270,176,9
+                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,188,132,9
+    CONTROL         "Vertical sync",IDC_VSYNC,
+                    "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,201,132,9
+    GROUPBOX        "Sprite cache",IDC_STATICADV,7,221,345,55,NOT WS_VISIBLE
+    LTEXT           "Maximum size:",IDC_STATICADV3,15,234,50,10,NOT WS_VISIBLE
+    COMBOBOX        IDC_COMBO4,68,232,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,248,323,26,NOT WS_VISIBLE
+    CTEXT           "Static",IDC_VERSION,91,279,176,9
 END
 
 

--- a/Engine/setup/acwsetup.CPP
+++ b/Engine/setup/acwsetup.CPP
@@ -40,7 +40,7 @@ extern int  INIreadint(const char*, const char*, int=0);
 extern void fgetstring_limit (char *, Stream *, int);
 extern char* ac_config_file;
 const char*setupstring, *enginever;
-int curscrn=-1,csendto,curdigi=0,curmidi=0,windowed=0,useletterbox = 0;
+int curscrn=-1,csendto,curdigi=0,curmidi=0,windowed=0,useletterbox = 0,vsync = 0;
 int defaultRes = -1, mustBeLetterbox = 0, gameColDep = 0;
 int refresh = 0, antialias = 0, reduce32to16 = 0;
 int sideBorders = 1;
@@ -300,6 +300,9 @@ void InitializeDialog(HWND hDlg) {
   if (windowed > 0)
     SendDlgItemMessage(hDlg,IDC_WINDOWED,BM_SETCHECK,BST_CHECKED,0);
 
+  if (vsync > 0)
+    SendDlgItemMessage(hDlg,IDC_VSYNC,BM_SETCHECK,BST_CHECKED,0);
+
   if (refresh > 0)
     SendDlgItemMessage(hDlg,IDC_REFRESH,BM_SETCHECK,BST_CHECKED,0);
 
@@ -380,6 +383,7 @@ LRESULT CALLBACK callback_settings(HWND hDlg, UINT message, WPARAM wParam, LPARA
         ShowWindow (GetDlgItem(hDlg, IDC_ANTIALIAS), SW_SHOW);
         ShowWindow (GetDlgItem(hDlg, IDC_REDUCESPR), SW_SHOW);
         ShowWindow (GetDlgItem(hDlg, IDC_LETTERBOX), SW_SHOW);
+        ShowWindow (GetDlgItem(hDlg, IDC_VSYNC), SW_SHOW);
         ShowWindow (GetDlgItem(hDlg, IDC_COMBO4), SW_SHOW);
 
         MoveWindow (hDlg, winsize.left, winsize.top - (wheight - base_height) / 2, wwidth, wheight, TRUE);
@@ -481,6 +485,11 @@ LRESULT CALLBACK callback_settings(HWND hDlg, UINT message, WPARAM wParam, LPARA
           else
             WritePrivateProfileString("misc","windowed","0",ac_config_file);
 
+          if (SendDlgItemMessage(hDlg,IDC_VSYNC,BM_GETCHECK,0,0) == BST_CHECKED)
+            WritePrivateProfileString("misc","vsync","1",ac_config_file);
+          else
+            WritePrivateProfileString("misc","vsync","0",ac_config_file);
+
           if (SendDlgItemMessage(hDlg,IDC_ANTIALIAS,BM_GETCHECK,0,0) == BST_CHECKED)
             WritePrivateProfileString("misc","antialias","1",ac_config_file);
           else
@@ -546,6 +555,7 @@ int acwsetup(const char*vername, const char*enbuild) {
     if (curmidi < 0) curmidi=0;
 
     windowed = INIreadint("misc","windowed",0);
+    vsync = INIreadint("misc","vsync",0);
     useletterbox = INIreadint("misc","forceletterbox",0);
 
     reduce32to16 = INIreadint("misc","notruecolor",0);


### PR DESCRIPTION
Direct3D requires that vsync be initialised when the game is started. I've added a configuration option to winsetup.exe that determines whether vsync is active when the game starts. In DirectX 5 mode, this can be toggled using the System.VSync property. In Direct3D, the property is now read-only.
