### PR TITLE
Fix focus when navigating the document tabs with Ctrl+Tab

### DIFF
--- a/Editor/AGS.Editor/GUI/Docking/DockingPane.cs
+++ b/Editor/AGS.Editor/GUI/Docking/DockingPane.cs
@@ -17,6 +17,11 @@ namespace AGS.Editor
             _floatWindow = new FloatingWindow(dockPane.FloatWindow);
         }
 
+        public void Refresh()
+        {
+            _dockPane.Refresh();
+        }
+
         public IFloatWindow FloatWindow { get { return _floatWindow; } }
     }
 }

--- a/Editor/AGS.Editor/GUI/Docking/DockingPanel.cs
+++ b/Editor/AGS.Editor/GUI/Docking/DockingPanel.cs
@@ -17,6 +17,8 @@ namespace AGS.Editor
 
         public DockPanel DockPanel { get { return _dockPanel; } }
 
+        public IDockingPane ActivePane { get { return new DockingPane(_dockPanel.ActivePane); } }
+
         #region IDockingPanel Members
 
         public event EventHandler ActiveContentChanged

--- a/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
+++ b/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
@@ -46,19 +46,20 @@ namespace AGS.Editor
 
         void _dockPanel_ActiveContentChanged(object sender, EventArgs e)
         {
-            List<ContentDocument> documentsToRemove = new List<ContentDocument>();
-            foreach (ContentDocument document in _panes)
-            {
-                if (document.Control == _dockPanel.ActiveContent)
+            /* When Ctrl+Tabbing, ActiveDocument is still the previously active tab, so let's double check which tab is actually active (i.e. has focus). */
+            foreach (ContentDocument focusDocument in _panes)
+                if (focusDocument.Control.ContainsFocus || focusDocument.Control.DockingContainer.ContainsFocus)
                 {
-                    if (document == ActiveDocument)
-                    {                        
-                        return;
-                    }                    
-                    SetActiveDocument(document, false);
-                    return;
-                }                
-            }            
+                    if (focusDocument != ActiveDocument)
+                    {
+                        SetActiveDocument(focusDocument, false);
+                        focusDocument.Control.DockingContainer.Refresh();
+                        _dockPanel.ActivePane.Refresh();
+                    }
+                    break;
+                }
+
+            return;
         }        
 
         public TabbedDocumentManager()

--- a/Editor/AGS.Types/Interfaces/Docking/IDockingContainer.cs
+++ b/Editor/AGS.Types/Interfaces/Docking/IDockingContainer.cs
@@ -37,6 +37,7 @@ namespace AGS.Types
         ContextMenuStrip TabPageContextMenuStrip { get; set; }
         string Text { get; set; }
         bool IsDisposed { get; }
+        bool ContainsFocus { get; }
 
         void Show(IDockingPanel panel, DockData dockData);
         void Hide();

--- a/Editor/AGS.Types/Interfaces/Docking/IDockingPane.cs
+++ b/Editor/AGS.Types/Interfaces/Docking/IDockingPane.cs
@@ -6,6 +6,7 @@ namespace AGS.Types
 {
     public interface IDockingPane
     {
+        void Refresh();
         IFloatWindow FloatWindow { get; }
     }
 }

--- a/Editor/AGS.Types/Interfaces/Docking/IDockingPanel.cs
+++ b/Editor/AGS.Types/Interfaces/Docking/IDockingPanel.cs
@@ -9,6 +9,7 @@ namespace AGS.Types
         event EventHandler ActiveContentChanged;
 
         bool IsDisposed { get; }
+        IDockingPane ActivePane { get; }
         IDockingContent ActiveContent { get; }
     }
 }


### PR DESCRIPTION
As discussed earlier with tzachs, this fixes Ctrl+Tab when moving between document tabs, but it might be little hacky. I've tested it thoroughly and upon tzachs' recommendation, it also removes the old tabbing code that scanned through panes.
