### PR TITLE
Issue: Function in struct, error msg

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3367,6 +3367,10 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
 
                     if (sym.get_type(targ.peeknext()) == SYM_OPENPARENTHESIS) {
                         // member function
+                        if (!member_is_import) {
+                            cc_error("function in a struct requires the import keyword");
+                            return -1;
+                        }
                         if (member_is_writeprotected) {
                             cc_error("'writeprotected' does not apply to functions");
                             return -1;


### PR DESCRIPTION
Provide a better description of what's wrong when a developer tries to
enter the following:
struct foo {
function bar ();
};

Reported by Radiant here: http://www.adventuregamestudio.co.uk/forums/index.php?issue=503.0
