### PR TITLE
Various bug fixes for the Go to Line feature

### DIFF
--- a/Editor/AGS.Editor/GUI/GotoLineDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/GotoLineDialog.Designer.cs
@@ -50,7 +50,6 @@
             this.upDownLineNumber.Name = "upDownLineNumber";
             this.upDownLineNumber.Size = new System.Drawing.Size(199, 20);
             this.upDownLineNumber.TabIndex = 1;
-            this.upDownLineNumber.ThousandsSeparator = true;
             // 
             // btnOk
             // 

--- a/Editor/AGS.Editor/GUI/GotoLineDialog.cs
+++ b/Editor/AGS.Editor/GUI/GotoLineDialog.cs
@@ -13,6 +13,17 @@ namespace AGS.Editor
         public GotoLineDialog()
         {
             InitializeComponent();
+            (this.upDownLineNumber.Controls[1] as TextBox).Enter += upDownLineNumber_Controls1_Enter;
+        }
+
+        private delegate void Action();
+
+        private void upDownLineNumber_Controls1_Enter(object sender, EventArgs e)
+        {
+            BeginInvoke((Action)(() =>
+            {
+                (this.upDownLineNumber.Controls[1] as TextBox).SelectAll();
+            }));
         }
 
         public int LineNumber

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -194,12 +194,13 @@ namespace AGS.Editor
             {
                 GotoLineDialog gotoLineDialog = new GotoLineDialog 
                 {
-                    Minimum = 0,
+                    Minimum = 1,
                     Maximum = scintillaEditor.LineCount,
-                    LineNumber = scintillaEditor.CurrentLine
+                    LineNumber = scintillaEditor.CurrentLine + 1
                 };
                 if (gotoLineDialog.ShowDialog() != DialogResult.OK) return;
-                scintillaEditor.GoToLine(gotoLineDialog.LineNumber); 
+                scintillaEditor.GoToLine(gotoLineDialog.LineNumber);
+                scintillaEditor.SelectCurrentLine();
             }
         }
 

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -323,8 +323,8 @@ namespace AGS.Editor
 
 		public void SelectCurrentLine()
 		{
-			int curLine = this.CurrentLine;
-			scintillaControl1.SetSel(scintillaControl1.PositionFromLine(curLine), scintillaControl1.PositionFromLine(curLine + 1) - 1);
+			scintillaControl1.GotoPos(scintillaControl1.PositionFromLine(this.CurrentLine));
+			scintillaControl1.LineEndExtend();
 		}
 
         public void AddBreakpoint(int lineNumber)

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -124,7 +124,7 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(new MenuCommand(SHOW_AUTOCOMPLETE_COMMAND, "Show Autocomplete", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Space, "ShowAutocompleteMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(TOGGLE_BREAKPOINT_COMMAND, "Toggle Breakpoint", System.Windows.Forms.Keys.F9, "ToggleBreakpointMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(MATCH_BRACE_COMMAND, "Match Brace", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B));
-            _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Goto Line", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G));
+            _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Go to Line...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G));
             _extraMenu.Commands.Add(new MenuCommand(SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND, "Switch to Matching Script or Header", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M));
 
             this.Resize += new EventHandler(ScriptEditor_Resize);
@@ -618,9 +618,9 @@ namespace AGS.Editor
             {
                 GotoLineDialog gotoLineDialog = new GotoLineDialog
                 {
-                    Minimum = 0,
+                    Minimum = 1,
                     Maximum = scintilla.LineCount,
-                    LineNumber = scintilla.CurrentLine
+                    LineNumber = scintilla.CurrentLine + 1
                 };
                 if (gotoLineDialog.ShowDialog() != DialogResult.OK) return;
                 GoToLine(gotoLineDialog.LineNumber);


### PR DESCRIPTION
Fixed grammar ("Goto Line" -> "Go to Line...")
Corrected the minimum and current line number in go to dialogues (off by
one)
Made "Go to Line..." for the dialogue editor select the line to match
the script editor's behaviour
Removed the thousands separator from the "Go to Line..." number spinner
The number in "Go to Line..." is now selected whenever it receives the
focus
Reimplemented SelectCurrentLine() so it now works correctly with double
char line endings (chr(13)+chr(10)) and selecting the last line of the
file
This addresses concerns outlined in:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=436.0
