### PR TITLE
Editor: Don't highlight the line after go to

### DIFF
--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -200,7 +200,6 @@ namespace AGS.Editor
                 };
                 if (gotoLineDialog.ShowDialog() != DialogResult.OK) return;
                 scintillaEditor.GoToLine(gotoLineDialog.LineNumber);
-                scintillaEditor.SelectCurrentLine();
             }
         }
 

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -325,6 +325,7 @@ namespace AGS.Editor
 		{
 			scintillaControl1.GotoPos(scintillaControl1.PositionFromLine(this.CurrentLine));
 			scintillaControl1.LineEndExtend();
+			scintillaControl1.LineScroll(0 - scintillaControl1.GetSelText().Length, 0);
 		}
 
         public void AddBreakpoint(int lineNumber)

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -470,7 +470,7 @@ namespace AGS.Editor
 
 		public void GoToLine(int lineNumber)
 		{
-			GoToLine(lineNumber, true, false);
+			GoToLine(lineNumber, false, false);
 		}
 
         public void GoToLine(int lineNumber, bool selectLine, bool goToLineAfterOpeningBrace)


### PR DESCRIPTION
This removes the line selection behaviour after "Go to Line...". Also a
minor fix to ensure that the window does not scroll to the end of the
line after it gets selected.
