### PR TITLE
Editor: Rebuild all when the debug state changes

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1104,6 +1104,23 @@ namespace AGS.Editor
 			throw new AGSEditorException("Unable to find drive for game path: " + _game.DirectoryPath);
 		}
 
+		public bool NeedsRebuildForDebugMode()
+		{
+			bool result;
+			BuildConfiguration pending;
+
+			pending = this._game.Settings.DebugMode ? BuildConfiguration.Debug : BuildConfiguration.Release;
+			if (this._game.Settings.LastBuildConfiguration != pending)
+			{
+				result = true;
+				this._game.Settings.LastBuildConfiguration = pending;
+			}
+			else
+				result = false;
+
+			return result;
+		}
+
 		public CompileMessages CompileGame(bool forceRebuild, bool createMiniExeForDebug)
         {
             Factory.GUIController.ClearOutputPanel();

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -161,9 +161,12 @@ namespace AGS.Editor.Components
 
         private void TestGame(bool withDebugger)
         {
+            bool forceRebuild;
+
+            forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
             if (_agsEditor.SaveGameFiles())
             {
-                if (!_agsEditor.CompileGame(false, true).HasErrors)
+                if (!_agsEditor.CompileGame(forceRebuild, true).HasErrors)
                 {
                     _testGameInProgress = true;
                     _guiController.InteractiveTasks.TestGame(withDebugger);
@@ -231,6 +234,7 @@ namespace AGS.Editor.Components
 
 		private void CompileGame(bool forceRebuild)
 		{
+			forceRebuild = _agsEditor.NeedsRebuildForDebugMode() || forceRebuild;
 			if (_agsEditor.SaveGameFiles())
 			{
 				if (_agsEditor.CompileGame(forceRebuild, false).Count == 0)

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -809,6 +809,7 @@ namespace AGS.Editor
 		private bool ProcessCommandLineArgumentsAndReturnWhetherToShowWelcomeScreen()
 		{
 			bool compileAndExit = false;
+			bool forceRebuild;
 
 			foreach (string arg in _commandLineArgs)
 			{
@@ -830,7 +831,10 @@ namespace AGS.Editor
 					{
 						if (compileAndExit)
 						{
-							if (!_agsEditor.CompileGame(false, false).HasErrors)
+							forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
+							if (forceRebuild)
+								_agsEditor.SaveGameFiles();
+							if (!_agsEditor.CompileGame(forceRebuild, false).HasErrors)
 							{
 								_batchProcessShutdown = true;
 								this.ExitApplication();
@@ -976,6 +980,7 @@ namespace AGS.Editor
                     _agsEditor.CurrentGame.Settings.SaveGameFolderName = newGameName;
                     _agsEditor.CurrentGame.Settings.GenerateNewGameID();
                     Factory.GUIController.GameNameUpdated();
+                    _agsEditor.CurrentGame.Settings.LastBuildConfiguration = _agsEditor.CurrentGame.Settings.DebugMode ? BuildConfiguration.Debug : BuildConfiguration.Release;
                     if (_agsEditor.SaveGameFiles())
                     {
                         // Force a rebuild to remove the key in the room

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -238,6 +238,7 @@
     <Compile Include="AGSColor.cs" />
     <Compile Include="AudioClipType.cs" />
     <Compile Include="BaseFolderCollection.cs" />
+    <Compile Include="Enums\BuildConfiguration.cs" />
     <Compile Include="Enums\SpriteAlphaStyle.cs" />
     <Compile Include="HelperTypes\BindingListWithRemoving.cs" />
     <Compile Include="CharacterFolder.cs" />

--- a/Editor/AGS.Types/Enums/BuildConfiguration.cs
+++ b/Editor/AGS.Types/Enums/BuildConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AGS.Types
+{
+	public enum BuildConfiguration
+	{
+		Unknown = 1,
+		Release = 2,
+		Debug = 3
+	}
+}

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -30,6 +30,7 @@ namespace AGS.Types
         private GameColorDepth _colorDepth = GameColorDepth.HighColor;
 		private GraphicsDriver _graphicsDriver = GraphicsDriver.DX5;
         private bool _debugMode = true;
+        private BuildConfiguration _lastBuildConfiguration = BuildConfiguration.Unknown;
         private bool _antiGlideMode = true;
         private bool _walkInLookMode = false;
         private InterfaceDisabledAction _whenInterfaceDisabled = InterfaceDisabledAction.GreyOut;
@@ -385,6 +386,13 @@ namespace AGS.Types
         {
             get { return _debugMode; }
             set { _debugMode = value; }
+        }
+
+        [Browsable(false)]
+        public BuildConfiguration LastBuildConfiguration
+        {
+            get { return _lastBuildConfiguration; }
+            set { _lastBuildConfiguration = value; }
         }
 
         [DisplayName("Use selected inventory graphic for cursor")]


### PR DESCRIPTION
This forces recompilation of all files if the debug state differs from
the one previously used to compile the project. Old projects will be
fully rebuilt the first time they're saved+compiled with this new
setting. This ensures that the first rebuild after opening an old
project will always be correct. A side effect of this commit is that the
/compile command line switch will now save the project if it is fully
rebuilt. I don't see this as particularly harmful. Every other way to
compile the project was saving it, so if anything this homogenises
things a bit.
