### PR TITLE
Engine: More DirectX help on fatal graphics error

### DIFF
--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -896,12 +896,9 @@ void display_gfx_mode_error()
 
     platform->DisplayAlert("There was a problem initializing graphics mode %d x %d (%d-bit).\n"
         "(Problem: '%s')\n"
-        "Try to correct the problem, or seek help from the AGS homepage.\n"
-        "\nPossible causes:\n* your graphics card drivers do not support this resolution. "
-        "Run the game setup program and try the other resolution.\n"
-        "* the graphics driver you have selected does not work. Try switching between Direct3D and DirectDraw.\n"
-        "* the graphics filter you have selected does not work. Try another filter.",
-        initasx, initasy, firstDepth, get_allegro_error());
+        "Try to correct the problem, or seek help from the AGS homepage."
+        "%s",
+        initasx, initasy, firstDepth, get_allegro_error(), platform->GetGraphicsTroubleshootingText());
 }
 
 int graphics_mode_init()

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -46,6 +46,7 @@ struct AGSPlatformDriver
     virtual const char *GetAllUsersDataDirectory() { return NULL; }
     // Get default directory for program output (logs)
     virtual const char *GetAppOutputDirectory() { return "."; }
+    virtual const char *GetGraphicsTroubleshootingText() { return ""; }
     virtual unsigned long GetDiskFreeSpaceMB() = 0;
     virtual const char* GetNoMouseErrorString() = 0;
     virtual eScriptSystemOSID GetSystemOSID() = 0;

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -102,6 +102,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void DisplayAlert(const char*, ...);
   virtual const char *GetAllUsersDataDirectory();
   virtual const char *GetAppOutputDirectory();
+  virtual const char *GetGraphicsTroubleshootingText();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
   virtual eScriptSystemOSID GetSystemOSID();
@@ -643,6 +644,19 @@ const char *AGSWin32::GetAppOutputDirectory()
 {
   DetermineAppOutputDirectory();
   return win32OutputDirectory;
+}
+
+const char *AGSWin32::GetGraphicsTroubleshootingText()
+{
+  return "\n\nPossible causes:\n"
+    "* your graphics card drivers do not support this resolution. "
+    "Run the game setup program and try another resolution.\n"
+    "* the graphics driver you have selected does not work. Try switching between Direct3D and DirectDraw.\n"
+    "* the graphics filter you have selected does not work. Try another filter.\n"
+    "* your graphics card drivers are out of date. "
+    "Try downloading updated graphics card drivers from your manufacturer's website.\n"
+    "* there is a problem with your graphics card driver configuration. "
+    "Run DXDiag using the Run command (Start->Run, type \"dxdiag.exe\") and correct any problems reported there.";
 }
 
 void AGSWin32::DisplaySwitchOut() {


### PR DESCRIPTION
Display more information prompting the user to check his/her drivers
when the game can't initialise the requested graphics mode.

This pertains to the following bug tracker issue:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=487.0
