### PR TITLE
Engine: D3D use GetBackBuffer instead of GetFrontBufferData

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -800,7 +800,7 @@ int D3DGraphicsDriver::_initDLLCallback()
   d3dpp.hDeviceWindow = allegro_wnd;
   d3dpp.Windowed = _newmode_windowed;
   d3dpp.EnableAutoDepthStencil = FALSE;
-  d3dpp.Flags = 0;
+  d3dpp.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER; // we need this flag to access the backbuffer with lockrect
   d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
   if(_newmode_vsync)
     d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
@@ -1156,15 +1156,22 @@ void D3DGraphicsDriver::GetCopyOfScreenIntoBitmap(Bitmap *destination)
     if (_pollingCallback)
       _pollingCallback();
 
+    /*
     // This call is v. slow (known DX9 issue)
     if (direct3ddevice->GetFrontBufferData(0, surface) != D3D_OK)
     {
       throw Ali3DException("GetFrontBufferData failed");
     }
+    */
+    if ( direct3ddevice->GetBackBuffer(0,0,D3DBACKBUFFER_TYPE_MONO,&surface)!=D3D_OK)
+    {
+      throw Ali3DException("IDirect3DSurface9::GetBackBuffer failed");
+    }
 
     if (_pollingCallback)
       _pollingCallback();
 
+    /*
     WINDOWINFO windowInfo;
     RECT *areaToCapture = NULL;
 
@@ -1176,6 +1183,7 @@ void D3DGraphicsDriver::GetCopyOfScreenIntoBitmap(Bitmap *destination)
       GetWindowInfo(win_get_window(), &windowInfo);
       areaToCapture = &windowInfo.rcClient;
     }
+    */
 
     Bitmap *finalImage = NULL;
 
@@ -1198,7 +1206,7 @@ void D3DGraphicsDriver::GetCopyOfScreenIntoBitmap(Bitmap *destination)
     }
 
     D3DLOCKED_RECT lockedRect;
-    if (surface->LockRect(&lockedRect, areaToCapture, D3DLOCK_READONLY) != D3D_OK)
+    if (surface->LockRect(&lockedRect, NULL, D3DLOCK_READONLY ) != D3D_OK)
     {
       throw Ali3DException("IDirect3DSurface9::LockRect failed");
     }


### PR DESCRIPTION
Uses the much faster and allegedly reliable GetBackBuffer instead of GetFrontBufferData inside the D3D version of GetCopyOfScreenIntoBitmap()

I wonder if the D3DPRESENTFLAG_LOCKABLE_BACKBUFFER flag might cause issues on stuff like video reproduction, so some testing may be in order.

Note: it would need some tinkering to make bitdepths != 32 to work, but since that was broken to begin with this should be an outright improvement.
