### PR TITLE
Allow methods with global names

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -190,7 +190,7 @@ int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip) {
             if (bracedepth <= 0)
                 in_struct_declr = -1;
         }
-        else if ((sym.stype[towrite] == 0) && (in_struct_declr >= 0) &&
+        else if ((sym.stype[towrite] == 0 || sym.stype[towrite] == SYM_FUNCTION) && (in_struct_declr >= 0) &&
             (parenthesisdepth == 0) && (bracedepth > 0)) {
                 // change the name of structure members so that the same member name
                 // can be used in multiple structs
@@ -207,7 +207,8 @@ int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip) {
                     (towrite != in_struct_declr)) {
                         const char *new_name = get_member_full_name(in_struct_declr, towrite);
                         //      printf("changed '%s' to '%s'\n",sym.get_name(towrite),new_name);
-                        towrite = sym.add((char*)new_name);
+                        towrite = sym.find((char *) new_name);
+                        if (towrite < 0) towrite = sym.add((char *) new_name);
                 }
         }
 


### PR DESCRIPTION
Previously, you weren't able to define a struct member function that shared a name with an already defined global variable (e.g. AbortGame). This patch forces the tokeniser to rename struct member functions even if the base name was used previously as a function. Also, if a renamed struct member function already existed, "sym.add" would return -1, causing the parser to break with a syntax error (Invalid syntax near 'int') instead of the real error ('MyStruct::XXX' is already defined). To fix this problem, the tokeniser now attempts to find an existing renamed function before adding a renamed symbol entry.
