### PR TITLE
Fixed: Auto-complete definitions not populated

### DIFF
--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -246,8 +246,11 @@ namespace AGS.Editor
                 if (thisWord == "(")
                 {
                     List<ScriptFunction> functionList = functions;
-                    bool isExtenderMethod = AdjustFunctionListForExtenderFunction(structs, ref functionList, ref script);
-                    if (AddFunctionDeclaration(functionList, ref script, thisWord, state, isExtenderMethod))
+                    bool isStaticExtender = script.StartsWith("static ");
+                    bool isExtenderMethod = isStaticExtender || script.StartsWith("this ");
+                    if(isExtenderMethod)
+                        AdjustFunctionListForExtenderFunction(structs, ref functionList, ref script);
+                    if (AddFunctionDeclaration(functionList, ref script, thisWord, state, isExtenderMethod, isStaticExtender, isStaticExtender))
                     {
                         lastFunction = functionList[functionList.Count - 1];
                     }
@@ -331,36 +334,32 @@ namespace AGS.Editor
 			scriptToCache.AutoCompleteData.Populated = true;
         }
 
-        private static bool AdjustFunctionListForExtenderFunction(List<ScriptStruct> structs, ref List<ScriptFunction> functionList, ref FastString script)
+        private static void AdjustFunctionListForExtenderFunction(List<ScriptStruct> structs, ref List<ScriptFunction> functionList, ref FastString script)
         {
-            if (script.StartsWith("this "))
+            GetNextWord(ref script);
+            string structName = GetNextWord(ref script);
+            while ((script.Length > 0) && (script[0] != ',') && (script[0] != ')'))
             {
-                GetNextWord(ref script);
-                string structName = GetNextWord(ref script);
-                while ((script.Length > 0) && (script[0] != ',') && (script[0] != ')'))
-                {
-                    script = script.Substring(1);
-                }
-                if ((script.Length > 0) && script[0] == ',')
-                {
-                    script = script.Substring(1);
-                }
-                script = script.Trim();
-
-                foreach (ScriptStruct struc in structs)
-                {
-                    if (struc.Name == structName)
-                    {
-                        functionList = struc.Functions;
-                        return true;
-                    }
-                }
-                ScriptStruct newStruct = new ScriptStruct(structName);
-                functionList = newStruct.Functions;
-                structs.Add(newStruct);
-                return true;
+                script = script.Substring(1);
             }
-            return false;
+            if ((script.Length > 0) && script[0] == ',')
+            {
+                script = script.Substring(1);
+            }
+            script = script.Trim();
+
+            foreach (ScriptStruct struc in structs)
+            {
+                if (struc.Name == structName)
+                {
+                    functionList = struc.Functions;
+                    return;
+                }
+            }
+            ScriptStruct newStruct = new ScriptStruct(structName);
+            functionList = newStruct.Functions;
+            structs.Add(newStruct);
+            return;
         }
 
         private static ScriptStruct CreateInheritedStruct(ScriptStruct baseStruct, AutoCompleteParserState state)
@@ -460,7 +459,7 @@ namespace AGS.Editor
             return false;
         }
 
-        private static bool AddFunctionDeclaration(List<ScriptFunction> functions, ref FastString script, string thisWord, AutoCompleteParserState state, bool isExtenderMethod)
+        private static bool AddFunctionDeclaration(List<ScriptFunction> functions, ref FastString script, string thisWord, AutoCompleteParserState state, bool isExtenderMethod, bool isStatic, bool isStaticOnly)
         {
             bool succeeded = false;
 
@@ -471,7 +470,6 @@ namespace AGS.Editor
                     string functionName = state.LastWord;
                     string type = state.WordBeforeLast;
                     bool isPointer = false, isNoInherit = false;
-                    bool isStatic = false, isStaticOnly = false;
                     bool isProtected = false;
                     if (type == "::")
                     {


### PR DESCRIPTION
Auto-complete definitions were not being populated for new static extenders.
