### PR TITLE
Engine: Pathfinding on horizontal/vertical/diagonal lines

### DIFF
--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -237,109 +237,11 @@ int is_route_possible(int fromx, int fromy, int tox, int toy, Bitmap *wss)
 }
 
 extern Bitmap *mousecurs[10];
-int leftorright = 0;
-int nesting = 0;
 int pathbackstage = 0;
 int finalpartx = 0, finalparty = 0;
 short **beenhere = NULL;     //[200][320];
 int beenhere_array_size = 0;
 const int BEENHERE_SIZE = 2;
-
-#define DIR_LEFT  0
-#define DIR_RIGHT 2
-#define DIR_UP    1
-#define DIR_DOWN  3
-
-int try_this_square(int srcx, int srcy, int tox, int toy)
-{
-  if (beenhere[srcy][srcx] & 0x80)
-    return 0;
-
-  // nesting of 8040 leads to stack overflow
-  if (nesting > 7000)
-    return 0;
-
-  nesting++;
-  if (can_see_from(srcx, srcy, tox, toy)) {
-    finalpartx = srcx;
-    finalparty = srcy;
-    nesting--;
-    pathbackstage = 0;
-    return 2;
-  }
-
-#ifdef DEBUG_PATHFINDER
-  wputblock(lastcx, lastcy, mousecurs[C_CROSS], 1);
-#endif
-
-  int trydir = DIR_UP;
-  int xdiff = abs(srcx - tox), ydiff = abs(srcy - toy);
-  if (ydiff > xdiff) {
-    if (srcy > toy)
-      trydir = DIR_UP;
-    else
-      trydir = DIR_DOWN;
-  } else if (srcx > tox)
-    trydir = DIR_LEFT;
-  else if (srcx < tox)
-    trydir = DIR_RIGHT;
-
-  int iterations = 0;
-
-try_again:
-  int nextx = srcx, nexty = srcy;
-  if (trydir == DIR_LEFT)
-    nextx--;
-  else if (trydir == DIR_RIGHT)
-    nextx++;
-  else if (trydir == DIR_DOWN)
-    nexty++;
-  else if (trydir == DIR_UP)
-    nexty--;
-
-  iterations++;
-  if (iterations > 5) {
-//    fprintf(stderr,"not found: %d,%d  beenhere 0x%X\n",srcx,srcy,beenhere[srcy][srcx]);
-    nesting--;
-    return 0;
-  }
-
-  if (((nextx < 0) | (nextx >= wallscreen->GetWidth()) | (nexty < 0) | (nexty >= wallscreen->GetHeight())) ||
-      (wallscreen->GetPixel(nextx, nexty) == 0) || ((beenhere[srcy][srcx] & (1 << trydir)) != 0)) {
-
-    if (leftorright == 0) {
-      trydir++;
-      if (trydir > 3)
-        trydir = 0;
-    } else {
-      trydir--;
-      if (trydir < 0)
-        trydir = 3;
-    }
-    goto try_again;
-  }
-  beenhere[srcy][srcx] |= (1 << trydir);
-//  srcx=nextx; srcy=nexty;
-  beenhere[srcy][srcx] |= 0x80; // being processed
-
-  int retcod = try_this_square(nextx, nexty, tox, toy);
-  if (retcod == 0)
-    goto try_again;
-
-  nesting--;
-  beenhere[srcy][srcx] &= 0x7f;
-  if (retcod == 2) {
-    pathbackx[pathbackstage] = srcx;
-    pathbacky[pathbackstage] = srcy;
-    pathbackstage++;
-    if (pathbackstage >= MAXPATHBACK - 1)
-      return 0;
-
-    return 2;
-  }
-  return 1;
-}
-
 
 #define CHECK_MIN(cellx, celly) { \
   if (beenhere[celly][cellx] == -1) {\
@@ -386,10 +288,6 @@ void round_down_coords(int &tmpx, int &tmpy)
 int find_route_dijkstra(int fromx, int fromy, int destx, int desty)
 {
   int i, j;
-
-  // This algorithm doesn't behave differently the second time, so ignore
-  if (leftorright == 1)
-    return 0;
 
   for (i = 0; i < wallscreen->GetHeight(); i++)
     memset(&beenhere[i][0], 0xff, wallscreen->GetWidth() * BEENHERE_SIZE);
@@ -570,49 +468,29 @@ int __find_route(int srcx, int srcy, short *tox, short *toy, int noredx)
   if ((noredx == 0) && (wallscreen->GetPixel(tox[0], toy[0]) == 0))
     return 0; // clicked on a wall
 
-  int is_straight = 0;
-  if ((srcx - tox[0] == 0) || (srcy - toy[0] == 0) || (abs(srcx - tox[0]) == abs(srcy - toy[0])))
-    is_straight = 1;
-
   pathbackstage = 0;
 
-  if (leftorright == 0) {
-    waspossible = 1;
+  waspossible = 1;
 
 findroutebk:
-    if ((srcx == tox[0]) && (srcy == toy[0])) {
-      pathbackstage = 0;
-      return 1;
-    }
-
-    if ((waspossible = is_route_possible(srcx, srcy, tox[0], toy[0], wallscreen)) == 0) {
-      if (suggestx >= 0) {
-        tox[0] = suggestx;
-        toy[0] = suggesty;
-        goto findroutebk;
-      }
-      return 0;
-    }
-  }
-
-  if (leftorright == 1) {
-    if (waspossible == 0)
-      return 0;
-  }
-
-  if (is_straight)
-    ;            // don't use new algo on arrow key presses
-  else if (find_route_dijkstra(srcx, srcy, tox[0], toy[0])) {
+  if ((srcx == tox[0]) && (srcy == toy[0])) {
+    pathbackstage = 0;
     return 1;
   }
 
-  // if the new pathfinder failed, try the old one
-  pathbackstage = 0;
-  memset(&beenhere[0][0], 0, wallscreen->GetWidth() * wallscreen->GetHeight() * BEENHERE_SIZE);
-  if (try_this_square(srcx, srcy, tox[0], toy[0]) == 0)
+  if ((waspossible = is_route_possible(srcx, srcy, tox[0], toy[0], wallscreen)) == 0) {
+    if (suggestx >= 0) {
+      tox[0] = suggestx;
+      toy[0] = suggesty;
+      goto findroutebk;
+    }
     return 0;
+  }
 
-  return 1;
+  if (find_route_dijkstra(srcx, srcy, tox[0], toy[0]))
+    return 1;
+
+  return 0;
 }
 
 void set_route_move_speed(int speed_x, int speed_y)
@@ -725,7 +603,6 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   __wnormscreen();
 #endif
   wallscreen = onscreen;
-  leftorright = 0;
   int aaa;
 
   if (wallscreen->GetHeight() > beenhere_array_size)
@@ -753,8 +630,6 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
       beenhere[aaa] = beenhere[0] + aaa * (wallscreen->GetWidth());
 
     if (__find_route(srcx, srcy, &xx, &yy, nocross) == 0) {
-      leftorright = 1;
-      if (__find_route(srcx, srcy, &xx, &yy, nocross) == 0)
         pathbackstage = -1;
     }
     free(beenhere[0]);


### PR DESCRIPTION
This fixes a bug that has been reported by several forum folks:
http://www.adventuregamestudio.co.uk/forums/index.php?topic=48529

Bug tracker here:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=418.0

The pathfinding algorithm often fails to find a path when navigating in a straight line from the player's current location. My thread above contains a simple test case for replicating the problem:
http://www.adventuregamestudio.co.uk/forums/index.php?topic=50487

Whether or not it fails depends on the complexity of the walkable area mask. If the walkable area mask is too complicated for the old pathfinder, pathfinding fails.

The culprit is some code in __find_route that prevents AGS from using the Dijkstra pathfinder when navigating along a vertical or horizontal path. The consequences of using Dijkstra in these cases aren't clear, but the current check for vertical and horizontal lines appears to make a faulty assumption:

```
;            // don't use new algo on arrow key presses
```

I think this is bogus because:

1) Keyboard movement modules bundled with AGS use WalkStraight. WalkStraight calls can_see_from, but does not use the main find_route function. (It's possible that this is an old comment. In the past, there might have been some code that called find_route from WalkStraight.)

This commit removes the old pathfinding code. can_see_from (essentially a best-first search) gets called before all pathfinding and is the only thing called for keyboard movement. There's no reason to keep the old pathfinding code.
