### PR TITLE
Bug Tracker: Add "Clickable" option to Objects in Editor.

### DIFF
--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -4331,6 +4331,7 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
     if (thisroom.wasversion <= kRoomVersion_300a)
       obj->StartY += GetSpriteHeight(thisroom.sprs[i].sprnum);
 		obj->Visible = (thisroom.sprs[i].on != 0);
+		obj->Clickable = ((thisroom.objectFlags[i] & OBJF_NOINTERACT) == 0);
 		obj->Baseline = thisroom.objbaseline[i];
 		obj->Name = gcnew String(jibbledScriptName);
 		obj->Description = gcnew String(thisroom.objectnames[i]);
@@ -4500,6 +4501,7 @@ void save_crm_file(Room ^room)
 		thisroom.objectFlags[i] = 0;
 		if (obj->UseRoomAreaScaling) thisroom.objectFlags[i] |= OBJF_USEROOMSCALING;
 		if (obj->UseRoomAreaLighting) thisroom.objectFlags[i] |= OBJF_USEREGIONTINTS;
+		if (!obj->Clickable) thisroom.objectFlags[i] |= OBJF_NOINTERACT;
 		CompileCustomProperties(obj->Properties, &thisroom.objProps[i]);
 	}
 

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -253,7 +253,7 @@ namespace AGS.Types
             set { _clickable = value; }
         }
 
-        [Description("Whether the character should be effected by walkable area scaling")]
+        [Description("Whether the character should be affected by walkable area scaling")]
         [Category("Appearance")]
         public bool UseRoomAreaScaling
         {
@@ -261,7 +261,7 @@ namespace AGS.Types
             set { _useRoomAreaScaling = value; }
         }
 
-        [Description("Whether the character should be effected by walkable area lighting")]
+        [Description("Whether the character should be affected by walkable area lighting")]
         [Category("Appearance")]
         public bool UseRoomAreaLighting
         {

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -17,6 +17,7 @@ namespace AGS.Types
         private int _image;
         private int _x;
         private int _y;
+        private bool _clickable = true;
         private bool _visible = true;
         private int _baseline;
         private int _effectiveBaseline;
@@ -74,6 +75,14 @@ namespace AGS.Types
         {
             get { return _baseline; }
             set { _baseline = value; }
+        }
+
+        [Description("Determines whether the object can be clicked on, or whether mouse clicks pass straight through it")]
+        [Category("Design")]
+        public bool Clickable
+        {
+            get { return _clickable; }
+            set { _clickable = value; }
         }
 
 		[Description("Allows you to manually specify this object's position in the front-to-back z-order, rather than the default behaviour of using its Y co-ordinate.")]
@@ -135,7 +144,7 @@ namespace AGS.Types
             set { _name = Utilities.ValidateScriptName(value, MAX_NAME_LENGTH); }
         }
 
-        [Description("Whether the object should be effected by walkable area scaling")]
+        [Description("Whether the object should be affected by walkable area scaling")]
         [Category("Appearance")]
         public bool UseRoomAreaScaling
         {
@@ -143,7 +152,7 @@ namespace AGS.Types
             set { _useRoomAreaScaling = value; }
         }
 
-        [Description("Whether the object should be effected by walkable area lighting")]
+        [Description("Whether the object should be affected by walkable area lighting")]
         [Category("Appearance")]
         public bool UseRoomAreaLighting
         {


### PR DESCRIPTION
Allows the .Clickable property of objects to be toggled via the editor's
Properties UI. This functionality was already built into room objects,
I'm just exposing it. This commit also corrects some spelling errors.
