### PR TITLE
Engine: Only parse "\[" once

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -21,8 +21,8 @@ using AGS::Common::Stream;
 #define STD_BUFFER_SIZE 3000
 
 void removeBackslashBracket(char *lbuffer) {
-    char *slashoffs;
-    while ((slashoffs = strstr(lbuffer, "\\[")) != NULL) {
+    char *slashoffs = lbuffer;
+    while ((slashoffs = strstr(slashoffs, "\\[")) != NULL) {
         // remove the backslash
         memmove(slashoffs, slashoffs + 1, strlen(slashoffs));
     }


### PR DESCRIPTION
It's not currently possible to display the sequence "\[" using a display function, e.g. DrawStringWrapped. The engine consumes all \ before the [, so that "\\\\\\[" results in just "[" being displayed. This corrects the escaping code for "\[" so that its behaviour is more standard -- only replace the \[ once.

The problem is documented here:
http://www.adventuregamestudio.co.uk/wiki/Escaping_characters

See the examples labelled "aaa\\[bbb".
