### PR TITLE
Script API: Implemented Mouse.GetModeView method

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -178,13 +178,23 @@ void GameSetupStruct::read_cursors(Common::Stream *in, GAME_STRUCT_READ_DATA &re
     if (read_data.filever <= kGameVersion_272) // 2.x
     {
         // Change cursor.view from 0 to -1 for non-animating cursors.
+        // Add the animation flag to everything to emulate old behaviour.
         int i;
         for (i = 0; i < numcursors; i++)
         {
             if (mcurs[i].view == 0)
                 mcurs[i].view = -1;
+            mcurs[i].flags |= MCF_ANIMATE;
         }
     }
+    else
+        if (read_data.filever <= kGameVersion_330)
+        {
+            // Add the animation flag to everything to emulate old behaviour.
+            int i;
+            for (i = 0; i < numcursors; i++)
+                mcurs[i].flags |= MCF_ANIMATE;
+        }
 }
 
 void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GAME_STRUCT_READ_DATA &read_data)

--- a/Common/ac/mousecursor.h
+++ b/Common/ac/mousecursor.h
@@ -22,6 +22,7 @@ using namespace AGS; // FIXME later
 #define MCF_DISABLED 2
 #define MCF_STANDARD 4
 #define MCF_HOTSPOT  8  // only animate when over hotspot
+#define MCF_ANIMATE  16
 // this struct is also in the plugin header file
 struct MouseCursor {
     int   pic;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -646,7 +646,9 @@ struct Mouse {
   /// Re-enables the specified cursor mode.
   import static void EnableMode(CursorMode);
   /// Gets the sprite used for the specified mouse cursor.
-  import static int  GetModeGraphic(CursorMode);
+  import static int GetModeGraphic(CursorMode);
+  /// Gets the view used to animate the specified mouse cursor.
+  import static int GetModeView(CursorMode);
   /// Checks whether the specified mouse button is currently pressed.
   import static bool IsButtonDown(MouseButton);
   /// Remembers the current mouse cursor and restores it when the mouse leaves the current area.

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -5107,14 +5107,11 @@ void save_game_to_dta_file(Game^ game, const char *fileName)
 		thisgame.mcurs[i].flags = 0;
 		if (cursor->Animate) 
 		{
-			thisgame.mcurs[i].view = cursor->View - 1;
+			thisgame.mcurs[i].flags |= MCF_ANIMATE;
 			if (cursor->AnimateOnlyOnHotspots) thisgame.mcurs[i].flags |= MCF_HOTSPOT;
 			if (cursor->AnimateOnlyWhenMoving) thisgame.mcurs[i].flags |= MCF_ANIMMOVE;
 		}
-		else 
-		{
-			thisgame.mcurs[i].view = -1;
-		}
+		thisgame.mcurs[i].view = cursor->View - 1;
 		if (cursor->StandardMode) thisgame.mcurs[i].flags |= MCF_STANDARD;
 		thisgame.mcurs[i].pic = cursor->Image;
 		thisgame.mcurs[i].hotx = cursor->HotspotX;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2394,7 +2394,7 @@ void update_screen() {
     Bitmap *ds = GetVirtualScreen();
 
     // update animating mouse cursor
-    if (game.mcurs[cur_cursor].view>=0) {
+    if (game.mcurs[cur_cursor].view>=0 && (game.mcurs[cur_cursor].flags & MCF_ANIMATE)) {
         domouse (DOMOUSE_NOCURSOR);
         // only on mousemove, and it's not moving
         if (((game.mcurs[cur_cursor].flags & MCF_ANIMMOVE)!=0) &&

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -170,6 +170,13 @@ int Mouse_GetModeGraphic(int curs) {
     return game.mcurs[curs].pic;
 }
 
+int Mouse_GetModeView(int curs) {
+    if ((curs < 0) || (curs >= game.numcursors))
+        quit("!Mouse.GetModeView: invalid mouse cursor");
+
+    return game.mcurs[curs].view + 1;
+}
+
 void ChangeCursorHotspot (int curs, int x, int y) {
     if ((curs < 0) || (curs >= game.numcursors))
         quit("!ChangeCursorHotspot: invalid mouse cursor");
@@ -430,6 +437,12 @@ RuntimeScriptValue Sc_Mouse_GetModeGraphic(const RuntimeScriptValue *params, int
     API_SCALL_INT_PINT(Mouse_GetModeGraphic);
 }
 
+// int (int curs)
+RuntimeScriptValue Sc_Mouse_GetModeView(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(Mouse_GetModeView);
+}
+
 // int (int which)
 RuntimeScriptValue Sc_IsButtonDown(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -511,6 +524,7 @@ void RegisterMouseAPI()
     ccAddExternalStaticFunction("Mouse::DisableMode^1",             Sc_disable_cursor_mode);
     ccAddExternalStaticFunction("Mouse::EnableMode^1",              Sc_enable_cursor_mode);
     ccAddExternalStaticFunction("Mouse::GetModeGraphic^1",          Sc_Mouse_GetModeGraphic);
+    ccAddExternalStaticFunction("Mouse::GetModeView^1",             Sc_Mouse_GetModeView);
     ccAddExternalStaticFunction("Mouse::IsButtonDown^1",            Sc_IsButtonDown);
     ccAddExternalStaticFunction("Mouse::SaveCursorUntilItLeaves^0", Sc_SaveCursorForLocationChange);
     ccAddExternalStaticFunction("Mouse::SelectNextMode^0",          Sc_SetNextCursor);
@@ -532,6 +546,7 @@ void RegisterMouseAPI()
     ccAddExternalFunctionForPlugin("Mouse::DisableMode^1",             (void*)disable_cursor_mode);
     ccAddExternalFunctionForPlugin("Mouse::EnableMode^1",              (void*)enable_cursor_mode);
     ccAddExternalFunctionForPlugin("Mouse::GetModeGraphic^1",          (void*)Mouse_GetModeGraphic);
+    ccAddExternalFunctionForPlugin("Mouse::GetModeView^1",             (void*)Mouse_GetModeView);
     ccAddExternalFunctionForPlugin("Mouse::IsButtonDown^1",            (void*)IsButtonDown);
     ccAddExternalFunctionForPlugin("Mouse::SaveCursorUntilItLeaves^0", (void*)SaveCursorForLocationChange);
     ccAddExternalFunctionForPlugin("Mouse::SelectNextMode^0",          (void*)SetNextCursor);

--- a/Engine/ac/mouse.h
+++ b/Engine/ac/mouse.h
@@ -32,6 +32,7 @@
 void Mouse_SetVisible(int isOn);
 int Mouse_GetVisible();
 int Mouse_GetModeGraphic(int curs);
+int Mouse_GetModeView(int curs);
 void Mouse_ChangeModeView(int curs, int newview);
 // The Mouse:: functions are static so the script doesn't pass
 // in an object parameter


### PR DESCRIPTION
This implements Mouse.GetModeView. This rounds out the Mouse API for views and graphics (ChangeModeGraphic/GetModeGraphic, ChangeModeView/GetModeView). It also passes the value of the Animate flag through to the runtime mouse cursor. Essentially it decouples the Animate flag from the value of a cursor's view. Here's a summary of the changes. Note: Old behaviour is preserved for old game files.

Old:
- ChangeModeView to > 0 could be used to make any cursor animated
- ChangeModeView to 0 could be used to "turn off" an animated cursor
- The view of an animated cursor would initially be the value set in the editor
- The view of a non-animated cursor would initially be 0

New:
- ChangeModeView to > 0 will animate a cursor if it has Animated = true set in the editor
- ChangeModeView to 0 will "turn off" an animated cursor
- The view of an animated cursor will initially be the value set in the editor
- The view of a non-animated cursor will initially be the value set in the editor

I'm happy to commit this again without the Animate flag change if anyone disagrees with it. We could instead simplify the implementation and document that the initial view of an non-animated cursor is always 0.
