### PR TITLE
Common: Corrected return value for GetPosition at start of stream

### DIFF
--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -93,8 +93,7 @@ size_t FileStream::GetPosition() const
 {
     if (IsValid())
     {
-        long pos = ftell(_file);
-        return pos > 0 ? (size_t)pos : -1;
+        return (size_t) ftell(_file);
     }
     return -1;
 }


### PR DESCRIPTION
I found a bug that was causing the sprite cache of my project to fail to load. Seems like the sprite cache relies on the return value prior to b2b5d79.

My apologies CW. I assumed earlier that it was the back buffer stuff.
