### PR TITLE
Scripting API: Added Room.GetProperty

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -426,6 +426,8 @@ builtin managed struct DrawingSurface {
 
 builtin managed struct Room {
   /// Gets a Custom Property associated with this room.
+  import static int GetProperty(const string property);
+  /// Gets a custom text property associated with this room.
   import static String GetTextProperty(const string property);
   /// Gets a drawing surface that allows you to manipulate the room background.
   import static DrawingSurface* GetDrawingSurfaceForBackground(int backgroundNumber=SCR_NO_VALUE);
@@ -614,8 +616,10 @@ import LocationType GetLocationType(int x, int y);
 import int  GetWalkableAreaAt(int screenX, int screenY);
 /// Returns the scaling level at the specified position within the room.
 import int  GetScalingAt (int x, int y);
+#ifndef STRICT
 /// Gets the specified Custom Property for the current room.
 import int  GetRoomProperty(const string property);
+#endif
 /// Locks the viewport to stop the screen scrolling automatically.
 import void SetViewport(int x, int y);
 /// Allows AGS to scroll the screen automatically to follow the player character.

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -64,6 +64,7 @@
 #include "ac/mouse.h"
 #include "ac/parser.h"
 #include "ac/string.h"
+#include "ac/room.h"
 #include "media/audio/audio.h"
 #include "util/string_utils.h"
 
@@ -734,7 +735,7 @@ RuntimeScriptValue Sc_GetRegionAt(const RuntimeScriptValue *params, int32_t para
 // int  (const char *property)
 RuntimeScriptValue Sc_GetRoomProperty(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_POBJ(GetRoomProperty, const char);
+    API_SCALL_INT_POBJ(Room_GetProperty, const char);
 }
 
 // void  (const char *property, char *bufer)
@@ -2777,7 +2778,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("GetPlayerCharacter",       (void*)GetPlayerCharacter);
     ccAddExternalFunctionForPlugin("GetRawTime",               (void*)GetRawTime);
     ccAddExternalFunctionForPlugin("GetRegionAt",              (void*)GetRegionAt);
-    ccAddExternalFunctionForPlugin("GetRoomProperty",          (void*)GetRoomProperty);
+    ccAddExternalFunctionForPlugin("GetRoomProperty",          (void*)Room_GetProperty);
     ccAddExternalFunctionForPlugin("GetRoomPropertyText",      (void*)GetRoomPropertyText);
     ccAddExternalFunctionForPlugin("GetSaveSlotDescription",   (void*)GetSaveSlotDescription);
     ccAddExternalFunctionForPlugin("GetScalingAt",             (void*)GetScalingAt);

--- a/Engine/ac/global_room.cpp
+++ b/Engine/ac/global_room.cpp
@@ -184,10 +184,6 @@ int HasBeenToRoom (int roomnum) {
         return 0;
 }
 
-int GetRoomProperty (const char *property) {
-    return get_int_property (&thisroom.roomProps, property);
-}
-
 void GetRoomPropertyText (const char *property, char *bufer) {
     get_text_property (&thisroom.roomProps, property, bufer);
 }

--- a/Engine/ac/global_room.h
+++ b/Engine/ac/global_room.h
@@ -26,7 +26,6 @@ void ResetRoom(int nrnum);
 int  HasPlayerBeenInRoom(int roomnum);
 void CallRoomScript (int value);
 int  HasBeenToRoom (int roomnum);
-int GetRoomProperty (const char *property);
 void GetRoomPropertyText (const char *property, char *bufer);
 
 void SetBackgroundFrame(int frnum);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -194,6 +194,10 @@ const char* Room_GetTextProperty(const char *property) {
     return get_text_property_dynamic_string(&thisroom.roomProps, property);
 }
 
+int Room_GetProperty (const char *property) {
+    return get_int_property(&thisroom.roomProps, property);
+}
+
 const char* Room_GetMessages(int index) {
     if ((index < 0) || (index >= thisroom.nummes)) {
         return NULL;
@@ -1125,6 +1129,12 @@ RuntimeScriptValue Sc_Room_GetDrawingSurfaceForBackground(const RuntimeScriptVal
     API_SCALL_OBJAUTO_PINT(ScriptDrawingSurface, Room_GetDrawingSurfaceForBackground);
 }
 
+// int (const char *property)
+RuntimeScriptValue Sc_Room_GetProperty(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_POBJ(Room_GetProperty, const char);
+}
+
 // const char* (const char *property)
 RuntimeScriptValue Sc_Room_GetTextProperty(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1195,6 +1205,7 @@ RuntimeScriptValue Sc_Room_GetWidth(const RuntimeScriptValue *params, int32_t pa
 void RegisterRoomAPI()
 {
     ccAddExternalStaticFunction("Room::GetDrawingSurfaceForBackground^1",   Sc_Room_GetDrawingSurfaceForBackground);
+    ccAddExternalStaticFunction("Room::GetProperty^1",                      Sc_Room_GetProperty);
     ccAddExternalStaticFunction("Room::GetTextProperty^1",                  Sc_Room_GetTextProperty);
     ccAddExternalStaticFunction("Room::get_BottomEdge",                     Sc_Room_GetBottomEdge);
     ccAddExternalStaticFunction("Room::get_ColorDepth",                     Sc_Room_GetColorDepth);
@@ -1210,6 +1221,7 @@ void RegisterRoomAPI()
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
     ccAddExternalFunctionForPlugin("Room::GetDrawingSurfaceForBackground^1",   (void*)Room_GetDrawingSurfaceForBackground);
+    ccAddExternalFunctionForPlugin("Room::GetProperty^1",                      (void*)Room_GetProperty);
     ccAddExternalFunctionForPlugin("Room::GetTextProperty^1",                  (void*)Room_GetTextProperty);
     ccAddExternalFunctionForPlugin("Room::get_BottomEdge",                     (void*)Room_GetBottomEdge);
     ccAddExternalFunctionForPlugin("Room::get_ColorDepth",                     (void*)Room_GetColorDepth);

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -33,6 +33,7 @@ int Room_GetTopEdge();
 int Room_GetBottomEdge();
 int Room_GetMusicOnLoad();
 const char* Room_GetTextProperty(const char *property);
+int Room_GetProperty(const char *property);
 const char* Room_GetMessages(int index);
 
 //=============================================================================


### PR DESCRIPTION
Added Room.GetProperty to supersede the old GetRoomProperty global
function. GetRoomProperty is hidden behind a check for strict mode for
backwards compatibility.
