### PR TITLE
Added additive blend mode to DrawingSurface

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -322,6 +322,11 @@ enum CharacterDirection {
   eDirectionNone = SCR_NO_VALUE
 };
 
+enum eBlendMode {
+  eBlendModeAlpha = 0,
+  eBlendModeAdditive = 1
+};
+
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
   import static String Format(const string format, ...);    // $AUTOCOMPLETESTATICONLY$
@@ -422,6 +427,8 @@ builtin managed struct DrawingSurface {
   import attribute bool UseHighResCoordinates;
   /// Gets the width of the surface.
   readonly import attribute int Width;
+  /// Gets/sets the current Blending mode that AGS will use when drawing sprites onto it.
+  import attribute eBlendMode BlendMode;
 };
 
 builtin managed struct Room {

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -807,7 +807,7 @@ void putpixel_compensate (Bitmap *ds, int xx,int yy, int col) {
 
 
 
-void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Bitmap *image, bool src_has_alpha, int alpha)
+void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Bitmap *image, bool src_has_alpha, int alpha, int blendmode)
 {
     if (alpha <= 0)
     {
@@ -820,15 +820,24 @@ void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos
     if (src_has_alpha &&
         (use_new_sprite_alpha_blending || alpha == 0xFF))
     {
-        if (use_new_sprite_alpha_blending)
-           set_argb2argb_alpha_blender(alpha);
-        else
-            set_alpha_blender();
-        ds->TransBlendBlt(image, xpos, ypos);
+		if (blendmode == 1)
+		{
+			
+			set_additive_color_blender(alpha);
+		}
+		else if (use_new_sprite_alpha_blending)
+		{
+			set_argb2argb_alpha_blender(alpha);
+		}
+		else
+		{
+			set_alpha_blender();
+		}
+		ds->TransBlendBlt(image, xpos, ypos);
     }
     else
     {
-        GfxUtil::DrawSpriteWithTransparency(ds, image, xpos, ypos, alpha);
+		GfxUtil::DrawSpriteWithTransparency(ds, image, xpos, ypos, alpha, blendmode);
     }
 }
 

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -65,7 +65,7 @@ void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = NULL, int ext
 void construct_virtual_screen(bool fullRedraw) ;
 void add_to_sprite_list(Engine::IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, int sprNum, bool isWalkBehind = false);
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
-void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha, int alpha = 0xFF);
+void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha, int alpha = 0xFF, int blendmode = 0);
 void draw_sprite_slot_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot, int alpha = 0xFF);
 void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true);
 void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -262,7 +262,7 @@ void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slo
     }
 
     draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, xx, yy, sourcePic, (game.spriteflags[slot] & SPF_ALPHACHANNEL) != 0,
-        GfxUtil::Trans100ToAlpha255(trans));
+        GfxUtil::Trans100ToAlpha255(trans), sds->blendMode);
 
     sds->FinishedDrawing();
 
@@ -319,6 +319,16 @@ int DrawingSurface_GetWidth(ScriptDrawingSurface *sds)
     sds->FinishedDrawingReadOnly();
     sds->UnMultiplyThickness(&width);
     return width;
+}
+
+void DrawingSurface_SetBlendMode(ScriptDrawingSurface *sds, int mode)
+{
+	sds->SetBlendMode(mode);
+}
+
+int DrawingSurface_GetBlendMode(ScriptDrawingSurface *sds)
+{
+	return sds->blendMode;
 }
 
 void DrawingSurface_Clear(ScriptDrawingSurface *sds, int colour)
@@ -593,6 +603,18 @@ RuntimeScriptValue Sc_DrawingSurface_GetDrawingColor(void *self, const RuntimeSc
     API_OBJCALL_INT(ScriptDrawingSurface, DrawingSurface_GetDrawingColor);
 }
 
+// int (ScriptDrawingSurface *sds)
+RuntimeScriptValue Sc_DrawingSurface_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptDrawingSurface, DrawingSurface_GetBlendMode);
+}
+
+// void (ScriptDrawingSurface *sds, int blendMode)
+RuntimeScriptValue Sc_DrawingSurface_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptDrawingSurface, DrawingSurface_SetBlendMode);
+}
+
 // void (ScriptDrawingSurface *sds, int newColour)
 RuntimeScriptValue Sc_DrawingSurface_SetDrawingColor(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -661,6 +683,8 @@ void RegisterDrawingSurfaceAPI()
     ccAddExternalObjectFunction("DrawingSurface::get_UseHighResCoordinates", Sc_DrawingSurface_GetUseHighResCoordinates);
     ccAddExternalObjectFunction("DrawingSurface::set_UseHighResCoordinates", Sc_DrawingSurface_SetUseHighResCoordinates);
     ccAddExternalObjectFunction("DrawingSurface::get_Width",            Sc_DrawingSurface_GetWidth);
+	ccAddExternalObjectFunction("DrawingSurface::get_BlendMode",		Sc_DrawingSurface_GetBlendMode);
+    ccAddExternalObjectFunction("DrawingSurface::set_BlendMode",		Sc_DrawingSurface_SetBlendMode);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
@@ -684,4 +708,6 @@ void RegisterDrawingSurfaceAPI()
     ccAddExternalFunctionForPlugin("DrawingSurface::get_UseHighResCoordinates", (void*)DrawingSurface_GetUseHighResCoordinates);
     ccAddExternalFunctionForPlugin("DrawingSurface::set_UseHighResCoordinates", (void*)DrawingSurface_SetUseHighResCoordinates);
     ccAddExternalFunctionForPlugin("DrawingSurface::get_Width",            (void*)DrawingSurface_GetWidth);
+	ccAddExternalFunctionForPlugin("DrawingSurface::get_BlendMode",		   (void*)DrawingSurface_GetBlendMode);
+    ccAddExternalFunctionForPlugin("DrawingSurface::set_BlendMode",		   (void*)DrawingSurface_SetBlendMode);
 }

--- a/Engine/ac/dynobj/scriptdrawingsurface.cpp
+++ b/Engine/ac/dynobj/scriptdrawingsurface.cpp
@@ -63,6 +63,13 @@ void ScriptDrawingSurface::FinishedDrawing()
     modified = 1;
 }
 
+void ScriptDrawingSurface::SetBlendMode(int mode)
+{
+	// TODO: alpha check for certain modes
+	blendMode = mode;
+}
+
+
 int ScriptDrawingSurface::Dispose(const char *address, bool force) {
 
     // dispose the drawing surface
@@ -86,6 +93,7 @@ int ScriptDrawingSurface::Serialize(const char *address, char *buffer, int bufsi
     SerializeInt(modified);
     SerializeInt(hasAlphaChannel);
     SerializeInt(isLinkedBitmapOnly ? 1 : 0);
+	SerializeInt(blendMode);
     return EndSerialize();
 }
 
@@ -100,6 +108,7 @@ void ScriptDrawingSurface::Unserialize(int index, const char *serializedData, in
     modified = UnserializeInt();
     hasAlphaChannel = UnserializeInt();
     isLinkedBitmapOnly = (UnserializeInt() != 0);
+	blendMode = UnserializeInt();
     ccRegisterUnserializedObject(index, this, this);
 }
 
@@ -115,6 +124,7 @@ ScriptDrawingSurface::ScriptDrawingSurface()
     modified = 0;
     hasAlphaChannel = 0;
     highResCoordinates = 0;
+	blendMode = 0;
 
     if ((game.options[OPT_NATIVECOORDINATES] != 0) &&
         (game.IsHiRes()))

--- a/Engine/ac/dynobj/scriptdrawingsurface.h
+++ b/Engine/ac/dynobj/scriptdrawingsurface.h
@@ -30,6 +30,7 @@ struct ScriptDrawingSurface : AGSCCDynamicObject {
     int highResCoordinates;
     int modified;
     int hasAlphaChannel;
+	int blendMode;
     //Common::Bitmap* abufBackup;
 
     virtual int Dispose(const char *address, bool force);
@@ -43,6 +44,7 @@ struct ScriptDrawingSurface : AGSCCDynamicObject {
     void MultiplyCoordinates(int *xcoord, int *ycoord);
     void FinishedDrawing();
     void FinishedDrawingReadOnly();
+	void SetBlendMode(int mode);
 
     ScriptDrawingSurface();
 };

--- a/Engine/gfx/blender.cpp
+++ b/Engine/gfx/blender.cpp
@@ -237,3 +237,28 @@ void set_opaque_alpha_blender()
 {
     set_blender_mode(NULL, NULL, _opaque_alpha_blender, 0, 0, 0, 0);
 }
+
+unsigned long _additive_color_blender_32(unsigned long x, unsigned long y, unsigned long n)
+{
+
+	int srcAlpha = geta32(x);
+
+	int r = getr32(y) + getr32(x) * n * srcAlpha / 256 / 256;
+	int g = getg32(y) + getg32(x) * n * srcAlpha / 256 / 256;
+	int b = getb32(y) + getb32(x) * n * srcAlpha / 256 / 256;
+	int a = geta32(y) + srcAlpha * n / 256;
+
+    r = MIN(r, 255);
+	g = MIN(g, 255);
+	b = MIN(b, 255);
+	a = MIN(a, 255);
+
+	return makeacol32(r, g, b, a);	
+
+}
+
+void set_additive_color_blender(int alpha)
+{
+	set_blender_mode(NULL, NULL, _additive_color_blender_32,0,0,0,alpha);
+}
+

--- a/Engine/gfx/blender.h
+++ b/Engine/gfx/blender.h
@@ -65,4 +65,6 @@ void set_additive_alpha_blender();
 // Opaque alpha blender plain copies src over, applying opaque alpha value.
 void set_opaque_alpha_blender();
 
+void set_additive_color_blender(int alpha);
+
 #endif // __AC_BLENDER_H

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -13,6 +13,7 @@
 //=============================================================================
 
 #include "gfx/gfx_util.h"
+#include "gfx/blender.h"
 
 // CHECKME: is this hack still relevant?
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION) || defined(WINDOWS_VERSION)
@@ -27,7 +28,7 @@ namespace Engine
 namespace GfxUtil
 {
 
-void DrawSpriteWithTransparency(Bitmap *ds, Bitmap *sprite, int x, int y, int alpha)
+void DrawSpriteWithTransparency(Bitmap *ds, Bitmap *sprite, int x, int y, int alpha, int blendmode)
 {
     if (alpha <= 0)
     {
@@ -80,9 +81,16 @@ void DrawSpriteWithTransparency(Bitmap *ds, Bitmap *sprite, int x, int y, int al
     }
     else
     {
-        if (alpha < 0xFF && surface_depth > 8 && sprite_depth > 8) 
+        if ((alpha < 0xFF || blendmode > 0) && surface_depth > 8 && sprite_depth > 8) 
         {
-            set_trans_blender(0, 0, 0, alpha);
+			if (blendmode == 0) {
+				//set_trans_blender(0, 0, 0, alpha);
+				set_argb2argb_alpha_blender(alpha);
+			}
+			else if (blendmode == 1) {
+				set_additive_color_blender(alpha);
+			}
+			
             ds->TransBlendBlt(sprite, x, y);
         }
         else

--- a/Engine/gfx/gfx_util.h
+++ b/Engine/gfx/gfx_util.h
@@ -110,7 +110,7 @@ namespace GfxUtil
 
     // Draws a bitmap over another one with given alpha level (0 - 255);
     // selects proper drawing method depending on respected color depths.
-    void DrawSpriteWithTransparency(Bitmap *ds, Bitmap *sprite, int x, int y, int alpha = 0xFF);
+    void DrawSpriteWithTransparency(Bitmap *ds, Bitmap *sprite, int x, int y, int alpha = 0xFF, int blendmode = 0);
 } // namespace GfxUtil
 
 } // namespace Engine


### PR DESCRIPTION
Adds a BlendMode property to DrawingSurface.

Currently include eBlendModeAlpha (the default) and eBlendModeAdditive.

Built on develop-3.4.0
