### PR TITLE
Scripting: Fix segfault when compiling functions returning String[]

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -142,7 +142,7 @@ int ccCompiledScript::remove_any_import (char*namm, SymbolDef *oldSym) {
         oldSym->sscope = sym.sscope[sidx];
         // Return size may have been unknown at the time of forward declaration. Check the actual return type for those cases.
         if(sym.ssize[sidx] == 0)
-            oldSym->ssize = sym.ssize[sym.funcparamtypes[sidx][0]];
+            oldSym->ssize = sym.ssize[sym.funcparamtypes[sidx][0] & ~(STYPE_POINTER | STYPE_DYNARRAY)];
         else
             oldSym->ssize = sym.ssize[sidx];
         oldSym->arrsize = sym.arrsize[sidx];


### PR DESCRIPTION
The variables inside a dynamic string array have a size of 0, causing another lookup to take place on the return type. The compiler was treating them as though they were references to forward-declared structs types with a previously unknown size. This would be fine under normal circumstances, but the `STYPE_POINTER` and `STYPE_DYNARRAY` flags were causing the lookup to occur well outside the boundaries of the symbol size array. Stripping these flags on the lookup allows this lookup (albeit somewhat unnecessary) to find the correct size of the variables in a string array.
