### PR TITLE
Scripting: Implemented System.RuntimeInfo

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1823,6 +1823,8 @@ builtin struct System {
   import static attribute bool VSync;
   /// Gets whether the game is running in a window.
   readonly import static attribute bool Windowed;
+  /// Gets a report about the runtime engine the game is running under.
+  readonly import static attribute String RuntimeInfo;
 };
 
 enum BlockingStyle {

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -59,6 +59,35 @@ extern int displayed_room, starting_room;
 extern MoveList *mls;
 extern char transFileName[MAX_PATH];
 
+String GetRuntimeInfo()
+{
+    DisplayMode mode = gfxDriver->GetDisplayMode();
+    Rect render_frame = gfxDriver->GetRenderDestination();
+    String runtimeInfo = String::FromFormat(
+        "Adventure Game Studio run-time engine[ACI version %s"
+        "[Game resolution %d x %d"
+        "[Running %d x %d at %d-bit%s%s[GFX: %s; %s[Draw frame %d x %d["
+        "Sprite cache size: %d KB (limit %d KB; %d locked)",
+        EngineVersion.LongString.GetCStr(), game.size.Width, game.size.Height,
+        mode.Width, mode.Height, mode.ColorDepth, (convert_16bit_bgr) ? " BGR" : "",
+        mode.Windowed ? " W" : "",
+        gfxDriver->GetDriverName(), filter->GetInfo().Name.GetCStr(),
+        render_frame.GetWidth(), render_frame.GetHeight(),
+        spriteset.cachesize / 1024, spriteset.maxCacheSize / 1024, spriteset.lockedSize / 1024);
+    if (play.separate_music_lib)
+        runtimeInfo.Append("[AUDIO.VOX enabled");
+    if (play.want_speech >= 1)
+        runtimeInfo.Append("[SPEECH.VOX enabled");
+    if (transtree != NULL) {
+        runtimeInfo.Append("[Using translation ");
+        runtimeInfo.Append(transFileName);
+    }
+    if (opts.mod_player == 0)
+        runtimeInfo.Append("[(mod/xm player discarded)");
+
+    return runtimeInfo;
+}
+
 void script_debug(int cmdd,int dataa) {
     if (play.debug_mode==0) return;
     int rr;
@@ -69,30 +98,8 @@ void script_debug(int cmdd,int dataa) {
         //    Display("invorder decided there are %d items[display %d",play.inv_numorder,play.inv_numdisp);
     }
     else if (cmdd==1) {
-        char toDisplay[STD_BUFFER_SIZE];
-        DisplayMode mode = gfxDriver->GetDisplayMode();
-        Rect render_frame = gfxDriver->GetRenderDestination();
-        sprintf(toDisplay,"Adventure Game Studio run-time engine[ACI version %s"
-            "[Game resolution %d x %d"
-            "[Running %d x %d at %d-bit%s%s[GFX: %s; %s[Draw frame %d x %d["
-            "Sprite cache size: %d KB (limit %d KB; %d locked)",
-            EngineVersion.LongString.GetCStr(), game.size.Width, game.size.Height,
-            mode.Width, mode.Height, mode.ColorDepth, (convert_16bit_bgr) ? " BGR" : "",
-            mode.Windowed ? " W" : "",
-            gfxDriver->GetDriverName(), filter->GetInfo().Name.GetCStr(),
-            render_frame.GetWidth(), render_frame.GetHeight(),
-            spriteset.cachesize / 1024, spriteset.maxCacheSize / 1024, spriteset.lockedSize / 1024);
-        if (play.separate_music_lib)
-            strcat(toDisplay,"[AUDIO.VOX enabled");
-        if (play.want_speech >= 1)
-            strcat(toDisplay,"[SPEECH.VOX enabled");
-        if (transtree != NULL) {
-            strcat(toDisplay,"[Using translation ");
-            strcat(toDisplay, transFileName);
-        }
-        if (opts.mod_player == 0)
-            strcat(toDisplay,"[(mod/xm player discarded)");
-        Display(toDisplay);
+        String toDisplay = GetRuntimeInfo();
+        Display(toDisplay.GetCStr());
         //    Display("shftR: %d  shftG: %d  shftB: %d", _rgb_r_shift_16, _rgb_g_shift_16, _rgb_b_shift_16);
         //    Display("Remaining memory: %d kb",_go32_dpmi_remaining_virtual_memory()/1024);
         //Display("Play char bcd: %d",->GetColorDepth(spriteset[views[playerchar->view].frames[playerchar->loop][playerchar->frame].pic]));

--- a/Engine/ac/global_debug.h
+++ b/Engine/ac/global_debug.h
@@ -18,6 +18,9 @@
 #ifndef __AGS_EE_AC__GLOBALDEBUG_H
 #define __AGS_EE_AC__GLOBALDEBUG_H
 
+#include "util/string.h"
+
+AGS::Common::String GetRuntimeInfo();
 void script_debug(int cmdd,int dataa);
 
 #endif // __AGS_EE_AC__GLOBALDEBUG_H

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -28,6 +28,7 @@
 #include "gfx/graphicsdriver.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "main/graphics_mode.h"
+#include "ac/global_debug.h"
 
 using namespace AGS::Engine;
 
@@ -197,6 +198,13 @@ void System_SetVolume(int newvol)
     }
 }
 
+const char* System_GetRuntimeInfo()
+{
+    String runtimeInfo = GetRuntimeInfo();
+
+    return CreateNewScriptString(runtimeInfo.GetCStr());
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -342,6 +350,12 @@ RuntimeScriptValue Sc_System_GetWindowed(const RuntimeScriptValue *params, int32
     API_SCALL_INT(System_GetWindowed);
 }
 
+// const char *()
+RuntimeScriptValue Sc_System_GetRuntimeInfo(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, System_GetRuntimeInfo);
+}
+
 
 void RegisterSystemAPI()
 {
@@ -355,6 +369,7 @@ void RegisterSystemAPI()
     ccAddExternalStaticFunction("System::get_NumLock",              Sc_System_GetNumLock);
     ccAddExternalStaticFunction("System::set_NumLock",              Sc_System_SetNumLock);
     ccAddExternalStaticFunction("System::get_OperatingSystem",      Sc_System_GetOS);
+    ccAddExternalStaticFunction("System::get_RuntimeInfo",          Sc_System_GetRuntimeInfo);
     ccAddExternalStaticFunction("System::get_ScreenHeight",         Sc_System_GetScreenHeight);
     ccAddExternalStaticFunction("System::get_ScreenWidth",          Sc_System_GetScreenWidth);
     ccAddExternalStaticFunction("System::get_ScrollLock",           Sc_System_GetScrollLock);
@@ -381,6 +396,7 @@ void RegisterSystemAPI()
     ccAddExternalFunctionForPlugin("System::get_NumLock",              (void*)System_GetNumLock);
     ccAddExternalFunctionForPlugin("System::set_NumLock",              (void*)System_SetNumLock);
     ccAddExternalFunctionForPlugin("System::get_OperatingSystem",      (void*)System_GetOS);
+    ccAddExternalFunctionForPlugin("System::get_RuntimeInfo",          (void*)System_GetRuntimeInfo);
     ccAddExternalFunctionForPlugin("System::get_ScreenHeight",         (void*)System_GetScreenHeight);
     ccAddExternalFunctionForPlugin("System::get_ScreenWidth",          (void*)System_GetScreenWidth);
     ccAddExternalFunctionForPlugin("System::get_ScrollLock",           (void*)System_GetScrollLock);

--- a/Engine/ac/system.h
+++ b/Engine/ac/system.h
@@ -42,6 +42,7 @@ int     System_GetAudioChannelCount();
 ScriptAudioChannel* System_GetAudioChannels(int index);
 int     System_GetVolume();
 void    System_SetVolume(int newvol);
+const char *System_GetRuntimeInfo();
 
 
 #endif // __AGS_EE_AC_SYSTEMAUDIO_H


### PR DESCRIPTION
Implemented a read-only System.RuntimeInfo String property that returns the information formerly displayed when pressing Ctrl+V in a game. Placed the old Ctrl+V shortcut behind a game file version check to ensure that Ctrl+V isn't intercepted by default for newer games. The debug implementation of `debug(1, 0)` still works in debug mode. Internally, it just calls System_GetRuntimeInfo and displays the info. The System.RuntimeInfo property exists in debug or release mode. The user may implement the display of this info however s/he likes.
