### PR TITLE
Engine: Implemented default_translation_name config option

### DIFF
--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -89,6 +89,7 @@ struct WinConfig
     bool   UseVoicePack;
 
     int    SpriteCacheSize;
+    String DefaultLanguageName;
     String Language;
 
     WinConfig();
@@ -125,6 +126,7 @@ void WinConfig::SetDefaults()
     UseVoicePack = true;
 
     SpriteCacheSize = 1024 * 20;
+    DefaultLanguageName = "Game Default";
 
     Title = "Game Setup";
 }
@@ -199,6 +201,7 @@ void WinConfig::Load()
 
     SpriteCacheSize = ReadPPInt("misc", "cachemax", SpriteCacheSize);
     Language = ReadPPString("language", "translation", Language);
+    DefaultLanguageName = ReadPPString("language", "default_translation_name", DefaultLanguageName);
 
     Title = ReadPPString("misc", "titletext", Title);
 }
@@ -864,7 +867,7 @@ void WinSetupDialog::FillGfxModeList()
 void WinSetupDialog::FillLanguageList()
 {
     ResetContent(_hLanguageList);
-    AddString(_hLanguageList, "Game Default");
+    AddString(_hLanguageList, _winCfg.DefaultLanguageName.GetCStr());
     SetCurSel(_hLanguageList, 0);
 
     String path_mask = String::FromFormat("%s\\*.tra", _winCfg.DataDirectory.GetCStr());


### PR DESCRIPTION
Allows the user to specify the name of the default language for a game via the acsetup.cfg file. Also allows the user to refer to this language's name when calling ChangeTranslation.
