### PR TITLE
Editor: Fixed .vox/.tra copying when compiling for Windows

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -177,9 +177,13 @@ namespace AGS.Editor
                 File.Copy(Path.Combine(compiledDir, AGSEditor.CONFIG_FILE_NAME),
                     GetCompiledPath(AGSEditor.CONFIG_FILE_NAME));
             }
-            foreach (string fileName in Utilities.GetDirectoryFileList(AGSEditor.OUTPUT_DIRECTORY, "*.vox"))
+            foreach (string fileName in Utilities.GetDirectoryFileList(compiledDir, "*.vox"))
             {
-                Utilities.CreateHardLink(GetCompiledPath(fileName), Path.Combine(compiledDir, fileName), true);
+                Utilities.CreateHardLink(GetCompiledPath(fileName.Split('\\')), fileName, true);
+            }
+            foreach (string fileName in Utilities.GetDirectoryFileList(compiledDir, "*.tra"))
+            {
+                Utilities.CreateHardLink(GetCompiledPath(fileName.Split('\\')), fileName, true);
             }
             string baseGameFileName = Factory.AGSEditor.BaseGameFileName;
             using (FileStream ostream = File.Open(GetCompiledPath(baseGameFileName + ".exe"), FileMode.Append,

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -445,7 +445,7 @@ namespace AGS.Editor
             }
             if (!File.Exists(sourceFileName))
             {
-                throw new FileNotFoundException("Cannot create hard link! Source file does not exist.");
+                throw new FileNotFoundException("Cannot create hard link! Source file does not exist. (" + sourceFileName + ")");
             }
             ProcessStartInfo si = new ProcessStartInfo("cmd.exe");
             si.RedirectStandardInput = false;


### PR DESCRIPTION
Referenced path was incorrect (did not need to be combined) and
destination path needed to be split to be parsed properly. This might
also fix the 'Source file does not exist' error reported in forum
threads. Added more info to the 'Source file does not exist' error
message.
