### PR TITLE
Fixed incorrect ordering when inserting an item into a FolderListHybrid

### DIFF
--- a/Editor/AGS.Types/HelperTypes/FolderListHybrid.cs
+++ b/Editor/AGS.Types/HelperTypes/FolderListHybrid.cs
@@ -74,7 +74,7 @@ namespace AGS.Types
         {
             _items.Insert(index, item);
             UnregisterFolderChange();
-            _folder.Items.Add(item);
+            _folder.Items.Insert(index, item);
             RegisterFolderChange();
         }
         
@@ -99,7 +99,7 @@ namespace AGS.Types
                 _items[index] = value;
                 UnregisterFolderChange();
                 _folder.Remove(item);
-                _folder.Items.Add(value);
+                _folder.Items.Insert(index, value);
                 RegisterFolderChange();
             }
         }


### PR DESCRIPTION
**Issue:** When inserting an item into a FolderListHybrid (specifically, the ScriptFolders collection backing a ScriptsAndHeaders object), the _folder_ collection does not accurately reflect the same ordering as the _items_ collection. This can later lead to incorrect ordering overall, for example, when calling RePopulateTreeView which references the ordering of the _folder_ collection.

_Example:_

When calling ScriptsAndHeaders.AddAt(script, 0), the ScriptsAndHeaders collection will show the newly inserted object at the top of the list. The project tree will not immediately refresh. When then calling RePopulateTreeView **or** adding/renaming a script in the Scripts branch of the project pane, the script previously inserted at the _top_ of the list will appear at the bottom of the list.

Similarly, ScriptsAndHeaders.MoveScriptAndHeaderUp and MoveScriptAndHeaderDown are reflected in the ScriptsAndHeaders object, but the ordering is lost the next time the project tree is repopulated.

**Proposed solution:** Have the underlying _folder_ collection observe the same logical ordering as the _items_ collection.

This warrants some scrutiny for any overlooked side-effects, but as far as I can tell, this works properly while respecting the folder/list hybrid structure.
