### PR TITLE
Game.agf: Wrote faulty timestamps to audio files

### DIFF
--- a/Editor/AGS.Types/SerializeUtils.cs
+++ b/Editor/AGS.Types/SerializeUtils.cs
@@ -195,7 +195,17 @@ namespace AGS.Types
                     // Must use CultureInfo.InvariantCulture otherwise DateTime.Parse
                     // crashes if the system regional settings short date format has
                     // spaces in it (.NET bug)
-					prop.SetValue(obj, DateTime.Parse(elementValue, CultureInfo.InvariantCulture), null);
+                    DateTime dateTime = DateTime.MinValue;
+                    if(DateTime.TryParseExact(elementValue, "u", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime))
+                    {
+                        // Get and set audio files time stamps
+                        prop.SetValue(obj, dateTime, null);
+                    }
+                    else
+                    {
+                        // Release Date timestamp doesn't store time of the day, and as such it ends up in the else-statement
+                        prop.SetValue(obj, DateTime.Parse(elementValue, CultureInfo.InvariantCulture), null);
+                    }					                    
 				}
                 else if (prop.PropertyType.IsEnum)
                 {


### PR DESCRIPTION
Timestamps are written to the file Game.agf with the UTC time standard, which adds an 'Z' at the end of the time stamp. However the read from Game.agf did not account for this and was thrown off by the 'Z' character, adding a couple of hours to the time stamp every time the editor was booted up. This should now be fixed.