### PR TITLE
Exposed editor panes to plugin API

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -297,6 +297,14 @@ namespace AGS.Editor
             _mainForm.RemovePaneIfExists(pane);
         }
 
+        public IList<ContentDocument> Panes
+        {
+            get
+            {
+                return _mainForm.Panes;
+            }
+        }
+
         public void ShowOutputPanel(CompileMessages errors)
         {
             _mainForm.pnlOutput.ErrorsToList = errors;

--- a/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
+++ b/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
@@ -86,6 +86,14 @@ namespace AGS.Editor
             get { return _currentPane; }
         }
 
+        public IList<ContentDocument> Documents
+        {
+            get
+            {
+                return _panes.AsReadOnly();
+            }
+        }
+
         public void SetActiveDocument(ContentDocument pane)
         {
             SetActiveDocument(pane, true);

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -213,6 +213,14 @@ namespace AGS.Editor
             }
         }
 
+        public IList<ContentDocument> Panes
+        {
+            get
+            {
+                return tabbedDocumentContainer1.Documents;
+            }
+        }
+
 		/*public void SetProjectTreeLocation(bool rightHandSide)
 		{
 			SplitterPanel leftHandPanel = this.mainContainer.Panel1;

--- a/Editor/AGS.Types/Interfaces/IGUIController.cs
+++ b/Editor/AGS.Types/Interfaces/IGUIController.cs
@@ -22,6 +22,10 @@ namespace AGS.Types
 		/// exist there, nothing happens.
 		/// </summary>
         void RemovePaneIfExists(ContentDocument pane);
+        /// <summary>
+        /// Returns a read-only list of the currently open panes.
+        /// </summary>
+        IList<ContentDocument> Panes { get; }
 		/// <summary>
 		/// Shows a message box with the specified message and icon
 		/// </summary>


### PR DESCRIPTION
Previously the active pane was the only one which was exposed, but it may be useful for plugin authors to know if a certain pane exists even if it is not currently active. As the active pane was always accessible (regardless of owner), this does not violate the security of the collection, which is now exposed as read-only.