### PR TITLE
Don't require out parameter in ScriptAndHeader look-up

### DIFF
--- a/Editor/AGS.Types/ScriptsAndHeaders.cs
+++ b/Editor/AGS.Types/ScriptsAndHeaders.cs
@@ -114,6 +114,12 @@ namespace AGS.Types
             return scriptAndHeader.Script;
         }
 
+        public ScriptAndHeader GetScriptAndHeaderByFilename(string filename)
+        {
+            int index;
+            return GetScriptAndHeaderByFilename(filename, out index);
+        }
+
         public ScriptAndHeader GetScriptAndHeaderByFilename(string filename, out int index)
         {
             index = 0;


### PR DESCRIPTION
The majority of use cases probably won't need the index when looking up a ScriptAndHeader by filename, so don't require it.