### PR TITLE
Editor: Papagayo .dat File Support for Lip-syncing

### DIFF
--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -67,7 +67,7 @@ namespace AGS.Editor.Components
             get { return ComponentIDs.Speech; }
         }
 
-        private int FindFrameNumberForPhenome(string phenomeCode)
+        private int FindFrameNumberForPhoneme(string phonemeCode)
         {
             int frameID = -1;
             for (int i = 0; i < (_agsEditor.CurrentGame.LipSync.CharactersPerFrame.Length) && (frameID < 0); i++)
@@ -75,7 +75,7 @@ namespace AGS.Editor.Components
                 string[] codesForThisFrame = _agsEditor.CurrentGame.LipSync.CharactersPerFrame[i].Split('/');
                 foreach (string code in codesForThisFrame)
                 {
-                    if (code.ToUpper() == phenomeCode)
+                    if (code.ToUpper() == phonemeCode)
                     {
                         frameID = i;
                         break;
@@ -87,17 +87,17 @@ namespace AGS.Editor.Components
 
         private void AlignPhonemeOffsets(SpeechLipSyncLine syncDataForThisFile)
         {
-            syncDataForThisFile.Phenomes.Sort();
+            syncDataForThisFile.Phonemes.Sort();
 
             // The PAM/DAT files contain start times: Convert to end times
-            for (int i = 0; i < syncDataForThisFile.Phenomes.Count - 1; i++)
+            for (int i = 0; i < syncDataForThisFile.Phonemes.Count - 1; i++)
             {
-                syncDataForThisFile.Phenomes[i].EndTimeOffset = syncDataForThisFile.Phenomes[i + 1].EndTimeOffset;
+                syncDataForThisFile.Phonemes[i].EndTimeOffset = syncDataForThisFile.Phonemes[i + 1].EndTimeOffset;
             }
 
-            if (syncDataForThisFile.Phenomes.Count > 1)
+            if (syncDataForThisFile.Phonemes.Count > 1)
             {
-                syncDataForThisFile.Phenomes[syncDataForThisFile.Phenomes.Count - 1].EndTimeOffset = syncDataForThisFile.Phenomes[syncDataForThisFile.Phenomes.Count - 2].EndTimeOffset + 1000;
+                syncDataForThisFile.Phonemes[syncDataForThisFile.Phonemes.Count - 1].EndTimeOffset = syncDataForThisFile.Phonemes[syncDataForThisFile.Phonemes.Count - 2].EndTimeOffset + 1000;
             }
         }
 
@@ -131,16 +131,16 @@ namespace AGS.Editor.Components
                         string[] parts = thisLine.Split(':');
                         // Convert from Pamela XPOS into milliseconds
                         int milliSeconds = ((Convert.ToInt32(parts[0]) / 15) * 1000) / 24;
-                        string phenomeCode = parts[1].Trim().ToUpper();
-                        int frameID = FindFrameNumberForPhenome(phenomeCode);
+                        string phonemeCode = parts[1].Trim().ToUpper();
+                        int frameID = FindFrameNumberForPhoneme(phonemeCode);
                         if (frameID < 0)
                         {
                             string friendlyFileName = Path.GetFileName(fileName);
-                            errors.Add(new CompileError("No frame found to match phenome code '" + phenomeCode + "'", friendlyFileName, lineNumber));
+                            errors.Add(new CompileError("No frame found to match phoneme code '" + phonemeCode + "'", friendlyFileName, lineNumber));
                         }
                         else
                         {
-                            syncDataForThisFile.Phenomes.Add(new SpeechLipSyncPhenome(milliSeconds, (short)frameID));
+                            syncDataForThisFile.Phonemes.Add(new SpeechLipSyncPhoneme(milliSeconds, (short)frameID));
                         }
                     }
                 }
@@ -172,16 +172,16 @@ namespace AGS.Editor.Components
                         if (xpos < 0) // Clamp negative XPOS to 0
                             xpos = 0;
                         int milliSeconds = (Convert.ToInt32(parts[0]) * 1000) / 24;
-                        string phenomeCode = parts[1].Trim().ToUpper();
-                        int frameID = FindFrameNumberForPhenome(phenomeCode);
+                        string phonemeCode = parts[1].Trim().ToUpper();
+                        int frameID = FindFrameNumberForPhoneme(phonemeCode);
                         if (frameID < 0)
                         {
                             string friendlyFileName = Path.GetFileName(fileName);
-                            errors.Add(new CompileError("No frame found to match phenome code '" + phenomeCode + "'", friendlyFileName, lineNumber));
+                            errors.Add(new CompileError("No frame found to match phoneme code '" + phonemeCode + "'", friendlyFileName, lineNumber));
                         }
                         else
                         {
-                            syncDataForThisFile.Phenomes.Add(new SpeechLipSyncPhenome(milliSeconds, (short)frameID));
+                            syncDataForThisFile.Phonemes.Add(new SpeechLipSyncPhoneme(milliSeconds, (short)frameID));
                         }
                     }
                 }
@@ -218,7 +218,7 @@ namespace AGS.Editor.Components
 
                 foreach (SpeechLipSyncLine line in lipSyncDataLines)
                 {
-					bw.Write((short)line.Phenomes.Count);
+					bw.Write((short)line.Phonemes.Count);
 
 					byte[] fileNameBytes = Encoding.Default.GetBytes(line.FileName);
 					byte[] paddedFileNameBytes = new byte[14];
@@ -226,13 +226,13 @@ namespace AGS.Editor.Components
 					paddedFileNameBytes[fileNameBytes.Length] = 0;
 					bw.Write(paddedFileNameBytes);
 
-                    for (int i = 0; i < line.Phenomes.Count; i++)
+                    for (int i = 0; i < line.Phonemes.Count; i++)
                     {
-						bw.Write((int)line.Phenomes[i].EndTimeOffset);
+						bw.Write((int)line.Phonemes[i].EndTimeOffset);
                     }
-					for (int i = 0; i < line.Phenomes.Count; i++)
+					for (int i = 0; i < line.Phonemes.Count; i++)
 					{
-						bw.Write((short)line.Phenomes[i].Frame);
+						bw.Write((short)line.Phonemes[i].Frame);
 					}
 				}
 

--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -13,7 +13,10 @@ namespace AGS.Editor.Components
 {
     class SpeechComponent : BaseComponent
     {
-        private static readonly string PAM_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.pam";
+        private static readonly string PAMELA_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.pam";
+        private static readonly string OGG_VORBIS_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.ogg";
+        private static readonly string MP3_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.mp3";
+        private static readonly string WAVEFORM_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.wav";
         private const string LIP_SYNC_DATA_OUTPUT = "syncdata.dat";
         private static readonly string SPEECH_VOX_FILE_NAME = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, "speech.vox");
 
@@ -32,10 +35,10 @@ namespace AGS.Editor.Components
         {
             if (_agsEditor.CurrentGame.Settings.BinaryFilesInSourceControl)
             {
-                Utilities.AddAllMatchingFiles(fileNames, "Speech" + Path.DirectorySeparatorChar + "*.ogg", true);
-                Utilities.AddAllMatchingFiles(fileNames, "Speech" + Path.DirectorySeparatorChar + "*.mp3", true);
-                Utilities.AddAllMatchingFiles(fileNames, "Speech" + Path.DirectorySeparatorChar + "*.wav", true);
-                Utilities.AddAllMatchingFiles(fileNames, "Speech" + Path.DirectorySeparatorChar + "*.pam", true);
+                Utilities.AddAllMatchingFiles(fileNames, OGG_VORBIS_FILE_FILTER, true);
+                Utilities.AddAllMatchingFiles(fileNames, MP3_FILE_FILTER, true);
+                Utilities.AddAllMatchingFiles(fileNames, WAVEFORM_FILE_FILTER, true);
+                Utilities.AddAllMatchingFiles(fileNames, PAMELA_FILE_FILTER, true);
             }
         }
 
@@ -145,7 +148,7 @@ namespace AGS.Editor.Components
         {
             List<SpeechLipSyncLine> lipSyncDataLines = new List<SpeechLipSyncLine>();
 
-            foreach (string fileName in Utilities.GetDirectoryFileList(Directory.GetCurrentDirectory(), PAM_FILE_FILTER))
+            foreach (string fileName in Utilities.GetDirectoryFileList(Directory.GetCurrentDirectory(), PAMELA_FILE_FILTER))
             {
                 lipSyncDataLines.Add(CompilePAMFile(fileName, errors));
             }
@@ -200,16 +203,16 @@ namespace AGS.Editor.Components
         {
             List<string> files = new List<string>();
             Utilities.AddAllMatchingFiles(files, LIP_SYNC_DATA_OUTPUT);
-            Utilities.AddAllMatchingFiles(files, "Speech" + Path.DirectorySeparatorChar + "*.mp3");
-            Utilities.AddAllMatchingFiles(files, "Speech" + Path.DirectorySeparatorChar + "*.ogg");
-            Utilities.AddAllMatchingFiles(files, "Speech" + Path.DirectorySeparatorChar + "*.wav");
+            Utilities.AddAllMatchingFiles(files, MP3_FILE_FILTER);
+            Utilities.AddAllMatchingFiles(files, OGG_VORBIS_FILE_FILTER);
+            Utilities.AddAllMatchingFiles(files, WAVEFORM_FILE_FILTER);
             return files.ToArray();
         }
 
 		private string[] ConstructFileListForSyncData()
 		{
 			List<string> files = new List<string>();
-			Utilities.AddAllMatchingFiles(files, PAM_FILE_FILTER);
+			Utilities.AddAllMatchingFiles(files, PAMELA_FILE_FILTER);
 			return files.ToArray();
 		}
 

--- a/Editor/AGS.Editor/Entities/SpeechLipSyncLine.cs
+++ b/Editor/AGS.Editor/Entities/SpeechLipSyncLine.cs
@@ -8,12 +8,12 @@ namespace AGS.Editor
     internal class SpeechLipSyncLine
     {
         public string FileName;
-        public List<SpeechLipSyncPhenome> Phenomes = new List<SpeechLipSyncPhenome>();
+        public List<SpeechLipSyncPhoneme> Phonemes = new List<SpeechLipSyncPhoneme>();
     }
 
-    internal class SpeechLipSyncPhenome : IComparable<SpeechLipSyncPhenome>
+    internal class SpeechLipSyncPhoneme : IComparable<SpeechLipSyncPhoneme>
     {
-        public SpeechLipSyncPhenome(int endTimeOffset, short frame)
+        public SpeechLipSyncPhoneme(int endTimeOffset, short frame)
         {
             this.EndTimeOffset = endTimeOffset;
             this.Frame = frame;
@@ -22,7 +22,7 @@ namespace AGS.Editor
         public int EndTimeOffset;
         public short Frame;
 
-        public int CompareTo(SpeechLipSyncPhenome other)
+        public int CompareTo(SpeechLipSyncPhoneme other)
         {
             return EndTimeOffset - other.EndTimeOffset;
         }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -111,7 +111,7 @@ bool facetalk_qfg4_override_placement_y = false;
 int loops_per_character, text_lips_offset, char_speaking = -1;
 char *text_lips_text = NULL;
 SpeechLipSyncLine *splipsync = NULL;
-int numLipLines = 0, curLipLine = -1, curLipLinePhenome = 0;
+int numLipLines = 0, curLipLine = -1, curLipLinePhoneme = 0;
 
 // **** CHARACTER: FUNCTIONS ****
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -92,7 +92,7 @@ extern int time_between_timers;
 extern Bitmap *virtual_screen;
 extern int cur_mode,cur_cursor;
 extern SpeechLipSyncLine *splipsync;
-extern int numLipLines, curLipLine, curLipLinePhenome;
+extern int numLipLines, curLipLine, curLipLinePhoneme;
 
 extern CharacterExtras *charextra;
 extern DialogTopic *dialog;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -33,7 +33,7 @@ extern GameSetupStruct game;
 extern roomstruct thisroom;
 extern char *speech_file;
 extern SpeechLipSyncLine *splipsync;
-extern int numLipLines, curLipLine, curLipLinePhenome;
+extern int numLipLines, curLipLine, curLipLinePhoneme;
 
 void StopAmbientSound (int channel) {
     if ((channel < 0) || (channel >= MAX_SOUND_CHANNELS))
@@ -493,7 +493,7 @@ int play_speech(int charid,int sndid) {
     int ii;  // Compare the base file name to the .pam file name
     char *basefnptr = strchr (&finame[4], '~') + 1;
     curLipLine = -1;  // See if we have voice lip sync for this line
-    curLipLinePhenome = -1;
+    curLipLinePhoneme = -1;
     for (ii = 0; ii < numLipLines; ii++) {
         if (stricmp(splipsync[ii].filename, basefnptr) == 0) {
             curLipLine = ii;

--- a/Engine/ac/lipsync.h
+++ b/Engine/ac/lipsync.h
@@ -19,7 +19,7 @@ struct SpeechLipSyncLine {
     char  filename[14];
     int  *endtimeoffs;
     short*frame;
-    short numPhenomes;
+    short numPhonemes;
 };
 
 #endif // __AC_LIPSYNC_H

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -81,7 +81,7 @@ extern int eip_guinum;
 extern int eip_guiobj;
 extern const char *replayTempFile;
 extern SpeechLipSyncLine *splipsync;
-extern int numLipLines, curLipLine, curLipLinePhenome;
+extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScriptSystem scsystem;
 extern IGraphicsDriver *gfxDriver;
 extern Bitmap *virtual_screen;
@@ -509,12 +509,12 @@ int engine_init_speech()
                     splipsync = (SpeechLipSyncLine*)malloc (sizeof(SpeechLipSyncLine) * numLipLines);
                     for (int ee = 0; ee < numLipLines; ee++)
                     {
-                        splipsync[ee].numPhenomes = speechsync->ReadInt16();
+                        splipsync[ee].numPhonemes = speechsync->ReadInt16();
                         speechsync->Read(splipsync[ee].filename, 14);
-                        splipsync[ee].endtimeoffs = (int*)malloc(splipsync[ee].numPhenomes * sizeof(int));
-                        speechsync->ReadArrayOfInt32(splipsync[ee].endtimeoffs, splipsync[ee].numPhenomes);
-                        splipsync[ee].frame = (short*)malloc(splipsync[ee].numPhenomes * sizeof(short));
-                        speechsync->ReadArrayOfInt16(splipsync[ee].frame, splipsync[ee].numPhenomes);
+                        splipsync[ee].endtimeoffs = (int*)malloc(splipsync[ee].numPhonemes * sizeof(int));
+                        speechsync->ReadArrayOfInt32(splipsync[ee].endtimeoffs, splipsync[ee].numPhonemes);
+                        splipsync[ee].frame = (short*)malloc(splipsync[ee].numPhonemes * sizeof(short));
+                        speechsync->ReadArrayOfInt16(splipsync[ee].frame, splipsync[ee].numPhonemes);
                     }
                 }
                 delete speechsync;

--- a/Engine/main/udpate.cpp
+++ b/Engine/main/udpate.cpp
@@ -60,7 +60,7 @@ extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement
 extern volatile unsigned long globalTimerCounter;
 extern int time_between_timers;
 extern SpeechLipSyncLine *splipsync;
-extern int numLipLines, curLipLine, curLipLinePhenome;
+extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern int numscreenover;
 extern int is_text_overlay;
@@ -331,19 +331,19 @@ void update_sierra_speech()
     if (curLipLine >= 0) {
       // check voice lip sync
       int spchOffs = channels[SCHAN_SPEECH]->get_pos_ms ();
-      if (curLipLinePhenome >= splipsync[curLipLine].numPhenomes) {
+      if (curLipLinePhoneme >= splipsync[curLipLine].numPhonemes) {
         // the lip-sync has finished, so just stay idle
       }
       else 
       {
-        while ((curLipLinePhenome < splipsync[curLipLine].numPhenomes) &&
-          ((curLipLinePhenome < 0) || (spchOffs >= splipsync[curLipLine].endtimeoffs[curLipLinePhenome])))
+        while ((curLipLinePhoneme < splipsync[curLipLine].numPhonemes) &&
+          ((curLipLinePhoneme < 0) || (spchOffs >= splipsync[curLipLine].endtimeoffs[curLipLinePhoneme])))
         {
-          curLipLinePhenome ++;
-          if (curLipLinePhenome >= splipsync[curLipLine].numPhenomes)
+          curLipLinePhoneme ++;
+          if (curLipLinePhoneme >= splipsync[curLipLine].numPhonemes)
             facetalkframe = game.default_lipsync_frame;
           else
-            facetalkframe = splipsync[curLipLine].frame[curLipLinePhenome];
+            facetalkframe = splipsync[curLipLine].frame[curLipLinePhoneme];
 
           if (facetalkframe >= views[facetalkview].loops[facetalkloop].numFrames)
             facetalkframe = 0;


### PR DESCRIPTION
This issue was originally submitted by AGD2. The AGS bug tracker entry can be found here:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=628.0

As stated in the bug tracker entry, Pamela has long been superseded as a method for generating lip sync files. It's buggy and creating the lip sync data is a very manual process. The authors of the software that Pamela was built for have created their own tool called Papagayo. This patch adds support for its .dat file format (which is extremely similar and even a bit simpler than the Pamela format). As AGD2 is the guy who originally suggested Pamela, I think we can trust his research that Papagayo is a worthwhile replacement tool.

AGD2 gave me a test project that can be used to verify support:
http://www.himalayastudios.com/scratch/PapagayoTest.rar

Note 1: The test project comes with the disclaimer that nobody uses the dialog portrait images or audio in any other projects/games, etc.

Note 2: The Pamela lip sync looks slightly different to the Papagayo lip sync in the test project because the data points are actually different. The Pamela data was created by hand and the Papagayo data was created automatically.