### PR TITLE
Scripting: Do not parse *= as one entity in parameter declarations

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -168,6 +168,12 @@ int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip) {
             else
                 sym.stype[towrite] = SYM_LITERALVALUE;
         }
+        if (sym.stype[towrite] == SYM_MASSIGN && thischar == '*' && sym.stype[last_time] == SYM_VARTYPE) {
+            // Break up *= when a parameter is declared with only the type and an initial value
+            // e.g. import void someMethod(InventoryItem *= 0);
+            targ->write(sym.find("*"));
+            towrite = sym.find("=");
+        }
 
         if (sym.stype[towrite] == SYM_OPENPARENTHESIS)
             parenthesisdepth++;


### PR DESCRIPTION
This handles *= as a special case inside a parameter declaration. I wasn't aware of this initially, but the inclusion of a *= symbol breaks compatibility with one particular syntax for parameter declarations available in older versions of AGS. The symbol is now broken into two when it occurs directly after a variable type.