### PR TITLE
Scripting: Allow variable declarations in for loop initialisers

### DIFF
--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -13,6 +13,7 @@
 #define NEST_STRUCT     7
 #define NEST_DO         8 // Do statement (to be followed by a while)
 #define NEST_DOSINGLE   9 // Single Do statement
+#define NEST_FOR        10 // For statement
 #define MAX_FUNCTIONS 2000
 #define MAXSYMBOLS 10000
 #define MAX_FUNCTION_PARAMETERS 15


### PR DESCRIPTION
This allows syntax like `for(int i = 0; i < 10; i++)` where `i` is a variable local to the for loop. I started this a long time ago when someone complained about for loops not really being useful in their current state. I thought it would be good for completeness.