### PR TITLE
Scripting: Only look up final struct sizes for functions

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -141,7 +141,7 @@ int ccCompiledScript::remove_any_import (char*namm, SymbolDef *oldSym) {
         oldSym->stype = sym.stype[sidx];
         oldSym->sscope = sym.sscope[sidx];
         // Return size may have been unknown at the time of forward declaration. Check the actual return type for those cases.
-        if(sym.ssize[sidx] == 0)
+        if(sym.stype[sidx] == SYM_FUNCTION && sym.ssize[sidx] == 0)
             oldSym->ssize = sym.ssize[sym.funcparamtypes[sidx][0] & ~(STYPE_POINTER | STYPE_DYNARRAY)];
         else
             oldSym->ssize = sym.ssize[sidx];


### PR DESCRIPTION
This was supposed to be a check for functions with prototypes inside a managed struct that returned a pointer to that struct, e.g.
```
managed struct myStruct
{
    import myStruct *getOne();
    int x;
};
```
The struct size is unknown at the time of the `getOne()` declaration. At the time of parsing the function body, the check was supposed to grab the real struct size from the return type of the function. Unfortunately, this was occurring with lots of symbols, not just function bodies. Those other symbols don't really have return types (or even an initialised funcparamtypes array for that matter).

This was the cause of cat's bug report in the main 3.4.0.x thread:
http://www.adventuregamestudio.co.uk/forums/index.php?topic=51050.msg636507341#msg636507341
(I sent her a test build and she's confirmed that it's fixed now.)