### PR TITLE
Scripting: Write correct loop increment info

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -4520,7 +4520,7 @@ startvarbit:
                     // if it's a for loop, drop the yanked chunk (loop increment) back in
                     if(nested_chunk_size[loop_level] > 0)
                     {
-                        scrip->write_chunk(nested_chunk, loop_level, nested_chunk_size[loop_level], false, nested_fixup_start[nested_level], nested_fixup_stop[nested_level], scrip->codesize - nested_assign_addr[nested_level]);
+                        scrip->write_chunk(nested_chunk, loop_level, nested_chunk_size[loop_level], false, nested_fixup_start[loop_level], nested_fixup_stop[loop_level], scrip->codesize - nested_assign_addr[loop_level]);
                     }
                     scrip->flush_line_numbers();
                     scrip->write_cmd2(SCMD_LITTOREG,SREG_AX,0); // Clear out the AX register so that the jump works correctly


### PR DESCRIPTION
Some of the info written when inserting the loop increment chunk incorrectly referred to `nested_level`, which may or may not have been initialised. The correct location is `loop_level` (as can be seen in the
rest of the function call. This was a typo and/or bad copy+paste on my part. It's possible I originally had `nested_level` and changed some variables but not others on that line.