### PR TITLE
Prompt dialog when "closing all tabs" and "closing all other tabs"

### DIFF
--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -26,6 +26,7 @@ namespace AGS.Editor
         private bool _remapPalettizedBackgrounds = true;
         private List<string> _previousSearches = new List<string>();
         private bool _keepHelpOnTop = true;
+        private bool _dialogOnMultibleTabsClose = true;
         private bool _useLegacyCompiler = false;
 
         private string _registryKey;
@@ -54,6 +55,7 @@ namespace AGS.Editor
                 _lastBackupWarning = ReadDateFromRegistry(key, "LastBackupWarning", _lastBackupWarning);
                 _remapPalettizedBackgrounds = Convert.ToInt32(key.GetValue("RemapPaletteBackgrounds", _remapPalettizedBackgrounds)) != 0;
                 _keepHelpOnTop = Convert.ToInt32(key.GetValue("KeepHelpOnTop", _keepHelpOnTop)) != 0;
+                _dialogOnMultibleTabsClose = Convert.ToInt32(key.GetValue("DialogOnMultipleTabsClose", _dialogOnMultibleTabsClose)) != 0;
                 _useLegacyCompiler = Convert.ToInt32(key.GetValue("UseLegacyCompiler", _useLegacyCompiler)) != 0;
                 ReadRecentSearchesList(key);
                 key.Close();
@@ -129,6 +131,7 @@ namespace AGS.Editor
                 key.SetValue("LastBackupWarning", _lastBackupWarning.ToString("u"));
                 key.SetValue("RemapPaletteBackgrounds", _remapPalettizedBackgrounds ? "1" : "0");
                 key.SetValue("KeepHelpOnTop", _keepHelpOnTop ? "1" : "0");
+                key.SetValue("DialogOnMultipleTabsClose", _dialogOnMultibleTabsClose ? "1" : "0");
                 key.SetValue("UseLegacyCompiler", _useLegacyCompiler ? "1" : "0");
                 WriteRecentSearchesList(key);
                 key.Close();
@@ -255,7 +258,13 @@ namespace AGS.Editor
         public bool KeepHelpOnTop
         {
             get { return _keepHelpOnTop; }
-            set { _keepHelpOnTop = value; }
+            set { _keepHelpOnTop = value; }            
+        }
+
+        public bool DialogOnMultibleTabsClose
+        {
+            get { return _dialogOnMultibleTabsClose; }
+            set { _dialogOnMultibleTabsClose = value; }
         }
 
         public bool UseLegacyCompiler

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -79,6 +79,7 @@ namespace AGS.Editor
             this.chkRemapBgImport = new System.Windows.Forms.CheckBox();
             this.groupBox10 = new System.Windows.Forms.GroupBox();
             this.chkUseLegacyCompiler = new System.Windows.Forms.CheckBox();
+            this.chkPromptDialogOnTabsClose = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udTabWidth)).BeginInit();
@@ -96,7 +97,7 @@ namespace AGS.Editor
             // btnOK
             // 
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(12, 499);
+            this.btnOK.Location = new System.Drawing.Point(12, 519);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(98, 27);
             this.btnOK.TabIndex = 0;
@@ -107,7 +108,7 @@ namespace AGS.Editor
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(116, 499);
+            this.btnCancel.Location = new System.Drawing.Point(116, 519);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(100, 27);
             this.btnCancel.TabIndex = 1;
@@ -237,7 +238,7 @@ namespace AGS.Editor
             this.label8.Size = new System.Drawing.Size(340, 26);
             this.label8.TabIndex = 2;
             this.label8.Text = "Changing these settings require you to restart the editor for them to take effect" +
-                ".";
+    ".";
             // 
             // label2
             // 
@@ -250,6 +251,7 @@ namespace AGS.Editor
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.chkPromptDialogOnTabsClose);
             this.groupBox3.Controls.Add(this.chkKeepHelpOnTop);
             this.groupBox3.Controls.Add(this.chkAlwaysShowViewPreview);
             this.groupBox3.Controls.Add(this.cmbMessageOnCompile);
@@ -258,7 +260,7 @@ namespace AGS.Editor
             this.groupBox3.Controls.Add(this.label5);
             this.groupBox3.Location = new System.Drawing.Point(7, 116);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(365, 128);
+            this.groupBox3.Size = new System.Drawing.Size(365, 148);
             this.groupBox3.TabIndex = 4;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Editor appearance";
@@ -462,7 +464,7 @@ namespace AGS.Editor
             this.label11.Size = new System.Drawing.Size(339, 26);
             this.label11.TabIndex = 2;
             this.label11.Text = "When you double-click a sprite, what program do you want to use to edit it? This " +
-                "program must support PNG and BMP files.";
+    "program must support PNG and BMP files.";
             // 
             // radPaintProgram
             // 
@@ -558,7 +560,7 @@ namespace AGS.Editor
             // 
             this.groupBox7.Controls.Add(this.lnkUsageInfo);
             this.groupBox7.Controls.Add(this.chkUsageInfo);
-            this.groupBox7.Location = new System.Drawing.Point(7, 250);
+            this.groupBox7.Location = new System.Drawing.Point(7, 270);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(365, 68);
             this.groupBox7.TabIndex = 8;
@@ -591,7 +593,7 @@ namespace AGS.Editor
             this.groupBox8.Controls.Add(this.udBackupInterval);
             this.groupBox8.Controls.Add(this.label14);
             this.groupBox8.Controls.Add(this.chkBackupReminders);
-            this.groupBox8.Location = new System.Drawing.Point(7, 325);
+            this.groupBox8.Location = new System.Drawing.Point(7, 345);
             this.groupBox8.Name = "groupBox8";
             this.groupBox8.Size = new System.Drawing.Size(365, 53);
             this.groupBox8.TabIndex = 9;
@@ -645,7 +647,7 @@ namespace AGS.Editor
             // groupBox9
             // 
             this.groupBox9.Controls.Add(this.chkRemapBgImport);
-            this.groupBox9.Location = new System.Drawing.Point(7, 386);
+            this.groupBox9.Location = new System.Drawing.Point(7, 406);
             this.groupBox9.Name = "groupBox9";
             this.groupBox9.Size = new System.Drawing.Size(365, 54);
             this.groupBox9.TabIndex = 10;
@@ -659,13 +661,13 @@ namespace AGS.Editor
             this.chkRemapBgImport.Size = new System.Drawing.Size(330, 30);
             this.chkRemapBgImport.TabIndex = 8;
             this.chkRemapBgImport.Text = "Remap palette of room backgrounds into allocated background palette slots (8-bit " +
-                "games only)";
+    "games only)";
             this.chkRemapBgImport.UseVisualStyleBackColor = true;
             // 
             // groupBox10
             // 
             this.groupBox10.Controls.Add(this.chkUseLegacyCompiler);
-            this.groupBox10.Location = new System.Drawing.Point(7, 446);
+            this.groupBox10.Location = new System.Drawing.Point(7, 466);
             this.groupBox10.Name = "groupBox10";
             this.groupBox10.Size = new System.Drawing.Size(365, 47);
             this.groupBox10.TabIndex = 11;
@@ -682,13 +684,23 @@ namespace AGS.Editor
             this.chkUseLegacyCompiler.Text = "Use legacy compiler";
             this.chkUseLegacyCompiler.UseVisualStyleBackColor = true;
             // 
+            // chkPromptDialogOnTabsClose
+            // 
+            this.chkPromptDialogOnTabsClose.AutoSize = true;
+            this.chkPromptDialogOnTabsClose.Location = new System.Drawing.Point(14, 123);
+            this.chkPromptDialogOnTabsClose.Name = "chkPromptDialogOnTabsClose";
+            this.chkPromptDialogOnTabsClose.Size = new System.Drawing.Size(204, 17);
+            this.chkPromptDialogOnTabsClose.TabIndex = 9;
+            this.chkPromptDialogOnTabsClose.Text = "Prompt dialog on closing multiple tabs";
+            this.chkPromptDialogOnTabsClose.UseVisualStyleBackColor = true;
+            // 
             // PreferencesEditor
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(754, 534);
+            this.ClientSize = new System.Drawing.Size(754, 554);
             this.Controls.Add(this.groupBox10);
             this.Controls.Add(this.groupBox9);
             this.Controls.Add(this.groupBox8);
@@ -786,5 +798,6 @@ namespace AGS.Editor
         private System.Windows.Forms.CheckBox chkKeepHelpOnTop;
         private System.Windows.Forms.GroupBox groupBox10;
         private System.Windows.Forms.CheckBox chkUseLegacyCompiler;
+        private System.Windows.Forms.CheckBox chkPromptDialogOnTabsClose;
     }
 }

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -45,6 +45,7 @@ namespace AGS.Editor
             udBackupInterval.Enabled = chkBackupReminders.Checked;
             chkRemapBgImport.Checked = _preferences.RemapPalettizedBackgrounds;
             chkKeepHelpOnTop.Checked = _preferences.KeepHelpOnTop;
+            chkPromptDialogOnTabsClose.Checked = _preferences.DialogOnMultibleTabsClose;
             chkUseLegacyCompiler.Checked = _preferences.UseLegacyCompiler;
             Utilities.CheckLabelWidthsOnForm(this);
 		}
@@ -82,6 +83,7 @@ namespace AGS.Editor
             _preferences.BackupWarningInterval = (chkBackupReminders.Checked ? (int)udBackupInterval.Value : 0);
             _preferences.RemapPalettizedBackgrounds = chkRemapBgImport.Checked;
             _preferences.KeepHelpOnTop = chkKeepHelpOnTop.Checked;
+            _preferences.DialogOnMultibleTabsClose = chkPromptDialogOnTabsClose.Checked;
             _preferences.UseLegacyCompiler = chkUseLegacyCompiler.Checked;
 		}
 

--- a/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
+++ b/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
@@ -496,10 +496,16 @@ namespace AGS.Editor
             }
             else if (item.Name == MENU_ITEM_CLOSE_ALL)
             {
+                if (Factory.AGSEditor.Preferences.DialogOnMultibleTabsClose && MessageBox.Show("Are you sure you want to close all tabs?", "Confirm close", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+                    return;                
+                    
                 RemoveAllDocuments(null); // null -> Remove all documents, no exceptions
             }
             else if (item.Name == MENU_ITEM_CLOSE_ALL_BUT_THIS)
             {
+                if (Factory.AGSEditor.Preferences.DialogOnMultibleTabsClose && MessageBox.Show("Are you sure you want to close all other tabs?", "Confirm close", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+                    return;
+
                 RemoveAllDocuments(document);
             }
             else if (item.Name == MENU_ITEM_NAVIGATE)


### PR DESCRIPTION
In reference to this http://www.adventuregamestudio.co.uk/forums/index.php?topic=51050.msg636513768#msg636513768 

> Also, regarding removal of the confirmation prompt when closing all other tabs, can I make a request for that to be reimplemented (or at least optional in the settings)? Many's the time I've had numerous important tabs open (sometimes 30+) when I accidentally mis-clicked "close all tabs". That confirmation prompt saved my skin and prevented me from losing my place during complex coding sessions. Since 'closing all other tabs' doesn't seem to be an action the user will be performing very frequently, I think the usefulness of the safeguard outweighs the minor hindrance of having to click an extra dialog button from time to time.

- Added a checkmark in Preferences for if a dialog should show on closing multiple tabs
- Added a dialog on closing multiple tabs