### PR TITLE
Scripting: Fixed reuse of fixups in write_chunk

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -263,11 +263,18 @@ void ccCompiledScript::write_chunk(intptr_t **nested_chunk, int index, intptr_t 
         if(dispose)
             free(nested_chunk[index]);
     }
-    while(fixup_start < fixup_stop)
-    {
-        fixups[fixup_start] = fixups[fixup_start] + adjust;
-        fixup_start++;
-    }
+    if(dispose)
+        while(fixup_start < fixup_stop)
+        {
+            fixups[fixup_start] += adjust;
+            fixup_start++;
+        }
+    else
+        while(fixup_start < fixup_stop)
+        {
+            add_fixup(fixups[fixup_start] + adjust, fixuptypes[fixup_start]);
+            fixup_start++;
+        }
 }
 
 const char* ccCompiledScript::start_new_section(const char *name) {


### PR DESCRIPTION
Fixups were not being adjusted correctly when inserted multiple times in a for loop. Here's a simplified test case (crashes 3.4.0.5):
```
/* Global scope */
int j;

...

/* Somewhere in a function scope */
for(j = 0; j < 5; j++)
    continue;
```