### PR TITLE
Editor: Ignore lip sync files with invalid data

### DIFF
--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -129,8 +129,11 @@ namespace AGS.Editor.Components
                     if (thisLine.IndexOf(':') > 0)
                     {
                         string[] parts = thisLine.Split(':');
+                        int part0;
                         // Convert from Pamela XPOS into milliseconds
-                        int milliSeconds = ((Convert.ToInt32(parts[0]) / 15) * 1000) / 24;
+                        if (!Int32.TryParse(parts[0], out part0))
+                            break; // Encountered invalid data in a lip sync file
+                        int milliSeconds = ((part0 / 15) * 1000) / 24;
                         string phonemeCode = parts[1].Trim().ToUpper();
                         int frameID = FindFrameNumberForPhoneme(phonemeCode);
                         if (frameID < 0)
@@ -167,11 +170,13 @@ namespace AGS.Editor.Components
                     if (thisLine.IndexOf(' ') > 0)
                     {
                         string[] parts = thisLine.Split(' ');
-                        // Convert from Pamela XPOS into milliseconds
-                        int xpos = Convert.ToInt32(parts[0]);
+                        int part0;
+                        if (!Int32.TryParse(parts[0], out part0))
+                            break; // Encountered invalid data in a lip sync file
+                        int xpos = part0;
                         if (xpos < 0) // Clamp negative XPOS to 0
                             xpos = 0;
-                        int milliSeconds = (Convert.ToInt32(parts[0]) * 1000) / 24;
+                        int milliSeconds = (part0 * 1000) / 24;
                         string phonemeCode = parts[1].Trim().ToUpper();
                         int frameID = FindFrameNumberForPhoneme(phonemeCode);
                         if (frameID < 0)


### PR DESCRIPTION
Any lip sync data files that contain a non-number where a number would
be expected will now be silently ignored. It is assumed that these are
files not related to Pamela or Papagayo.