### PR TITLE
Find / Replace Dialogue Issues

### DIFF
--- a/Editor/AGS.Editor/GUI/FindReplaceDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/FindReplaceDialog.Designer.cs
@@ -88,7 +88,7 @@ namespace AGS.Editor
             this.cmdToggleReplace.Location = new System.Drawing.Point(298, 15);
             this.cmdToggleReplace.Name = "cmdToggleReplace";
             this.cmdToggleReplace.Size = new System.Drawing.Size(75, 21);
-            this.cmdToggleReplace.TabIndex = 2;
+            this.cmdToggleReplace.TabIndex = 5;
             this.cmdToggleReplace.Text = ">> R&eplace";
             this.cmdToggleReplace.UseVisualStyleBackColor = true;
             this.cmdToggleReplace.Click += new System.EventHandler(this.cmdToggleReplace_Click);
@@ -111,7 +111,7 @@ namespace AGS.Editor
             this.chkCaseSensitive.Location = new System.Drawing.Point(15, 115);
             this.chkCaseSensitive.Name = "chkCaseSensitive";
             this.chkCaseSensitive.Size = new System.Drawing.Size(96, 17);
-            this.chkCaseSensitive.TabIndex = 5;
+            this.chkCaseSensitive.TabIndex = 4;
             this.chkCaseSensitive.Text = "C&ase Sensitive";
             this.chkCaseSensitive.UseVisualStyleBackColor = true;
             // 
@@ -131,7 +131,7 @@ namespace AGS.Editor
             this.cmbLookIn.Location = new System.Drawing.Point(89, 81);
             this.cmbLookIn.Name = "cmbLookIn";
             this.cmbLookIn.Size = new System.Drawing.Size(203, 21);
-            this.cmbLookIn.TabIndex = 4;
+            this.cmbLookIn.TabIndex = 3;
             // 
             // lblLookIn
             // 
@@ -149,7 +149,7 @@ namespace AGS.Editor
             this.cmbReplace.Location = new System.Drawing.Point(89, 48);
             this.cmbReplace.Name = "cmbReplace";
             this.cmbReplace.Size = new System.Drawing.Size(203, 21);
-            this.cmbReplace.TabIndex = 3;
+            this.cmbReplace.TabIndex = 2;
             // 
             // FindReplaceDialog
             // 

--- a/Editor/AGS.Editor/GUI/FindReplaceDialog.cs
+++ b/Editor/AGS.Editor/GUI/FindReplaceDialog.cs
@@ -23,6 +23,7 @@ namespace AGS.Editor
         private const string LOOK_IN_CURRENT_PROJECT = "Current Project";
 
         private static string _lastSelectedLookIn;
+        private static bool _lastSelectedCaseSensitive;
 
         public FindReplaceDialog(string defaultSearchText, 
             string defaultReplaceText, EditorPreferences preferences,
@@ -42,6 +43,8 @@ namespace AGS.Editor
             cmbLookIn.Items.Add(LOOK_IN_CURRENT_DOCUMENT);
             cmbLookIn.Items.Add(LOOK_IN_CURRENT_PROJECT);
             cmbLookIn.Text = _lastSelectedLookIn ?? LOOK_IN_CURRENT_DOCUMENT;
+
+            chkCaseSensitive.Checked = _lastSelectedCaseSensitive;
             
             cmbFind.Text = defaultSearchText;
 			cmbReplace.Text = defaultReplaceText;
@@ -78,7 +81,6 @@ namespace AGS.Editor
         public bool CaseSensitive
         {
             get { return chkCaseSensitive.Checked; }
-            set { chkCaseSensitive.Checked = value; }
         }
 
 		public bool ShowingReplaceDialog
@@ -182,6 +184,7 @@ namespace AGS.Editor
         private void onFormClosed(object sender, FormClosedEventArgs e)
         {
             _lastSelectedLookIn = cmbLookIn.Text;
+            _lastSelectedCaseSensitive = chkCaseSensitive.Checked;
         }
 
         private void onFormDeactivated(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -615,7 +615,7 @@ namespace AGS.Editor
             int nextPos = -1;
             if (currentPos < documentText.Length)
             {
-                nextPos = documentText.IndexOf(text, currentPos + 1, comparisonType);
+                nextPos = documentText.IndexOf(text, currentPos, comparisonType);
             }
             if (nextPos < 0)
             {

--- a/Editor/AGS.Editor/TextProcessing/FindReplace.cs
+++ b/Editor/AGS.Editor/TextProcessing/FindReplace.cs
@@ -13,7 +13,6 @@ namespace AGS.Editor.TextProcessing
         private IScript _script;
         private AGSEditor _agsEditor;
         private static string _lastSearchText, _lastReplaceText;
-        private bool _lastCaseSensitive;
         private static bool _creatingDialog;
         private static FindReplaceDialog _dialog;
 
@@ -29,7 +28,6 @@ namespace AGS.Editor.TextProcessing
             {
                 _lastSearchText = lastSearchText;
             }
-            this._lastCaseSensitive = lastCaseSensitive;
         }
 
         public static void CloseDialogIfNeeded()
@@ -49,7 +47,6 @@ namespace AGS.Editor.TextProcessing
             bool showAll = _dialog.ShowingAllDialog;
 
             _lastReplaceText = _dialog.TextToReplaceWith;
-            _lastCaseSensitive = _dialog.CaseSensitive;
 
             if (_dialog.TextToFind.Length > 0)
             {
@@ -147,7 +144,6 @@ namespace AGS.Editor.TextProcessing
                     _lastReplaceText, _agsEditor.Preferences, this);
                 _dialog.ShowingReplaceDialog = showReplace;
                 _dialog.ShowingAllDialog = showAll;
-                _dialog.CaseSensitive = _lastCaseSensitive;
             }            
         }
 


### PR DESCRIPTION
1. "Case sensitive" check box does not remember its value.
    Rewrote the handling for remembering checked value of "Case Sensitive". Mimicking the behaviour of the same feature in Visual Studio it will now remember the value when checked, regardless if a search / replace was made or not.

2. The order of cycling (tabbing) though controls is wrong: "Search for" field is followed by "<< Find" button; must be followed by "Replace with" field instead ("<< Find" button should probably go after all setup fields).
    Implemented exactly as described. Setup fields first., then "<<Find/Replace" button, and finally "Find", "Replace" and "Cancel" buttons.

3. Replace / Find All doesn't look at the first line
    When attempting a replace / find all, the index position of the search was set to 0, and then incremented by 1. By doing this the first word in the processed text will ALWAYS be skipped. This should now be fixed.