### PR TITLE
Absolute / Relative Paths for Resources

### DIFF
--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -304,7 +304,7 @@ namespace AGS.Editor.Components
             {
                 string newScriptName = EnsureScriptNameIsUnique(Path.GetFileNameWithoutExtension(sourceFileName));
                 AudioClip newClip = new AudioClip(newScriptName, _agsEditor.CurrentGame.GetNextAudioIndex());
-                newClip.SourceFileName = sourceFileName;
+                newClip.SourceFileName = sourceFileName.Replace(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar, string.Empty);
                 newClip.FileType = _fileTypeMappings[fileExtension];
                 newClip.FileLastModifiedDate = File.GetLastWriteTimeUtc(sourceFileName);
                 Utilities.CopyFileAndSetDestinationWritable(sourceFileName, newClip.CacheFileName);

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -61,7 +61,7 @@ namespace AGS.Editor
                     }
                     Factory.NativeProxy.ReloadTTFFont(_item.ID);
                     _item.PointSize = fontSize;
-                    _item.SourceFilename = fileName;
+                    _item.SourceFilename = fileName.Replace(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar, string.Empty);
                 }
                 catch (AGSEditorException ex)
                 {
@@ -81,7 +81,7 @@ namespace AGS.Editor
                 }
                 Factory.NativeProxy.ImportSCIFont(fileName, _item.ID);
                 _item.PointSize = 0;
-                _item.SourceFilename = fileName;
+                _item.SourceFilename = fileName.Replace(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar, string.Empty);
             }
             catch (AGSEditorException ex)
             {

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -439,7 +439,7 @@ namespace AGS.Editor
 					if ((bmpToImport.Width == bmp.Width) &&
 						(bmpToImport.Height == bmp.Height))
 					{
-						newSprite.SourceFile = sourceFileName;
+                        newSprite.SourceFile = sourceFileName.Replace(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar, string.Empty);
 					}
                 }
                 RefreshSpriteDisplay();


### PR DESCRIPTION
Reference: http://www.adventuregamestudio.co.uk/forums/index.php?issue=520.0

Importing sprites, audio and fonts would always store absolute file path in the property "SourceFileName". It now stores relative path if the file is found inside the Game Project, or absolute path if it is fount outside of the game project. This is useful if the the game project is moved to another place on a local computer, or if the game project is shared between multiple collaberators on each their private computer.

Examples:
  Relative Path: Resources/Sprites/MySprite.bmp
  Absloute Path: D:/MyGameProject/Resources/Sprites/MySprite.bmp