### PR TITLE
Absolute Paths for Resources

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -28,6 +28,7 @@ namespace AGS.Editor
             _pluginEditorController = new AGSEditorController(_componentController, _agsEditor, _guiController);
 
             _events.GameLoad += new EditorEvents.GameLoadHandler(_events_GameLoad);
+            _events.GamePostLoad += new EditorEvents.GamePostLoadHandler(_events_GamePostLoad);
             _events.GameSettingsChanged += new EditorEvents.ParameterlessDelegate(_events_GameSettingsChanged);
             _events.ImportedOldGame += new EditorEvents.ParameterlessDelegate(_events_ImportedOldGame);
             _events.RefreshAllComponentsFromGame += new EditorEvents.ParameterlessDelegate(_events_RefreshAllComponentsFromGame);
@@ -80,6 +81,26 @@ namespace AGS.Editor
             foreach (string componentID in missingComponents)
             {
                 _guiController.ShowMessage("This game contains data from a plugin or component '" + componentID + "' which you do not have installed. If you save the game, this data will be lost.", AGS.Types.MessageBoxIconType.Warning);
+            }
+        }
+
+        private void _events_GamePostLoad()
+        {
+            Game game = Factory.AGSEditor.CurrentGame;
+
+            // Convert absolute paths to relative paths. This is an automatic fixup from when the
+            // editor stored absolute paths only
+            foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+            {
+                sprite.SourceFile = Utilities.GetRelativeToProjectPath(sprite.SourceFile);
+            }
+            foreach (Types.Font font in game.Fonts)
+            {
+                font.SourceFilename = Utilities.GetRelativeToProjectPath(font.SourceFilename);
+            }
+            foreach (AudioClip audio in game.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
+            {
+                audio.SourceFileName = Utilities.GetRelativeToProjectPath(audio.SourceFileName);
             }
         }
 

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -304,7 +304,7 @@ namespace AGS.Editor.Components
             {
                 string newScriptName = EnsureScriptNameIsUnique(Path.GetFileNameWithoutExtension(sourceFileName));
                 AudioClip newClip = new AudioClip(newScriptName, _agsEditor.CurrentGame.GetNextAudioIndex());
-                newClip.SourceFileName = sourceFileName;
+                newClip.SourceFileName = Utilities.GetRelativeToProjectPath(sourceFileName);
                 newClip.FileType = _fileTypeMappings[fileExtension];
                 newClip.FileLastModifiedDate = File.GetLastWriteTimeUtc(sourceFileName);
                 Utilities.CopyFileAndSetDestinationWritable(sourceFileName, newClip.CacheFileName);

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -50,7 +50,7 @@ namespace AGS.Editor.Components
                 newItem.Name = "Font " + newItem.ID;
                 newItem.OutlineStyle = FontOutlineStyle.None;
                 newItem.PointSize = items[0].PointSize;
-                newItem.SourceFilename = items[0].SourceFilename;
+                newItem.SourceFilename = Utilities.GetRelativeToProjectPath(items[0].SourceFilename);
                 items.Add(newItem);
                 Utilities.CopyFont(0, newItem.ID);
                 Factory.NativeProxy.GameSettingsChanged(_agsEditor.CurrentGame);

--- a/Editor/AGS.Editor/EditorEvents.cs
+++ b/Editor/AGS.Editor/EditorEvents.cs
@@ -14,6 +14,8 @@ namespace AGS.Editor
         public event ParameterlessDelegate RefreshAllComponentsFromGame;
         public delegate void GameLoadHandler(XmlNode rootNode);
         public event GameLoadHandler GameLoad;
+        public delegate void GamePostLoadHandler();
+        public event GamePostLoadHandler GamePostLoad;
         public delegate void SavingGameHandler(XmlTextWriter writer);
         public event SavingGameHandler SavingGame;
         public delegate void SavingUserDataHandler(XmlTextWriter writer);
@@ -48,6 +50,14 @@ namespace AGS.Editor
             if (GameLoad != null)
             {
                 GameLoad(rootNode);
+            }
+        }
+
+        public void OnGamePostLoad()
+        {
+            if (GamePostLoad != null)
+            {
+                GamePostLoad();
             }
         }
 

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -61,7 +61,7 @@ namespace AGS.Editor
                     }
                     Factory.NativeProxy.ReloadTTFFont(_item.ID);
                     _item.PointSize = fontSize;
-                    _item.SourceFilename = fileName;
+                    _item.SourceFilename = Utilities.GetRelativeToProjectPath(fileName);
                 }
                 catch (AGSEditorException ex)
                 {
@@ -81,7 +81,7 @@ namespace AGS.Editor
                 }
                 Factory.NativeProxy.ImportSCIFont(fileName, _item.ID);
                 _item.PointSize = 0;
-                _item.SourceFilename = fileName;
+                _item.SourceFilename = Utilities.GetRelativeToProjectPath(fileName);
             }
             catch (AGSEditorException ex)
             {

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -439,7 +439,7 @@ namespace AGS.Editor
                     if ((bmpToImport.Width == bmp.Width) &&
                         (bmpToImport.Height == bmp.Height))
                     {
-                        newSprite.SourceFile = sourceFileName;
+                        newSprite.SourceFile = Utilities.GetRelativeToProjectPath(sourceFileName);
                     }
                 }
                 RefreshSpriteDisplay();
@@ -459,7 +459,7 @@ namespace AGS.Editor
                 if ((bmpToImport.Width == bmp.Width) &&
                     (bmpToImport.Height == bmp.Height))
                 {
-                    sprite.SourceFile = sourceFileName;
+                    sprite.SourceFile = Utilities.GetRelativeToProjectPath(sourceFileName);
                 }
                 else
                 {
@@ -1137,7 +1137,7 @@ namespace AGS.Editor
                     alphaChannel = true;
                 }
                 Sprite newSprite = CreateSpriteForBitmap(bmp, true, false, alphaChannel);
-                newSprite.SourceFile = fileName;
+                newSprite.SourceFile = Utilities.GetRelativeToProjectPath(fileName);
                 bmp.Dispose();
             }
             catch (Exception ex)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -131,6 +131,7 @@ namespace AGS.Editor
                 game.DirectoryPath = gameDirectory;
                 Utilities.EnsureStandardSubFoldersExist();
                 Factory.AGSEditor.RecentGames.AddRecentGame(gameDirectory, game.Settings.GameName);
+                Factory.Events.OnGamePostLoad();
 
                 Factory.AGSEditor.RefreshEditorAfterGameLoad(game);
                 if (needToSave)

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -114,6 +114,19 @@ namespace AGS.Editor
             }
         }
 
+        public static string GetRelativeToProjectPath(string absolutePath)
+        {
+            if (!absolutePath.Contains(Factory.AGSEditor.CurrentGame.DirectoryPath))
+            {
+                return absolutePath;
+            }
+
+            Uri currentProjectUri = new Uri(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar);
+            Uri currentPathUri = new Uri(absolutePath);
+
+            return Uri.UnescapeDataString(currentProjectUri.MakeRelativeUri(currentPathUri).OriginalString);
+        }
+
         /// <summary>
         /// Wraps Directory.GetFiles in a handler to deal with an exception
         /// erroneously being thrown on Linux network shares if no files match.

--- a/Editor/AGS.Types/Interfaces/ISpriteFolder.cs
+++ b/Editor/AGS.Types/Interfaces/ISpriteFolder.cs
@@ -38,5 +38,13 @@ namespace AGS.Types
         /// </summary>
         /// <param name="spriteNumber">Sprite number to look for</param>
         SpriteFolder FindFolderThatContainsSprite(int spriteNumber);
+
+        /// <summary>
+        /// Assembles a list of all the sprites in the current folder and sub-folders
+        /// </summary>
+        /// <returns>
+        /// Returns an IList with all sprites from this folder and sub-folders
+        /// </returns>
+        IList<Sprite> GetAllSpritesFromAllSubFolders();
     }
 }

--- a/Editor/AGS.Types/SpriteFolder.cs
+++ b/Editor/AGS.Types/SpriteFolder.cs
@@ -106,6 +106,25 @@ namespace AGS.Types
         }
 
         /// <summary>
+        /// Assembles a list of all the sprites in the current folder and sub-folders
+        /// </summary>
+        /// <returns>
+        /// Returns an IList with all sprites from this folder and sub-folders
+        /// </returns>
+        public IList<Sprite> GetAllSpritesFromAllSubFolders()
+        {
+            List<Sprite> sprites = new List<Sprite>();
+            sprites.AddRange(Sprites);
+
+            foreach (ISpriteFolder folder in SubFolders)
+            {
+                sprites.AddRange(folder.GetAllSpritesFromAllSubFolders());
+            }
+
+            return sprites;
+        }
+
+        /// <summary>
         /// Causes the SpritesUpdated event to be fired. You should call this
         /// if you modify the sprites and need the Sprite Manager window
         /// to update to reflect the changes.


### PR DESCRIPTION
Reference: http://www.adventuregamestudio.co.uk/forums/index.php?issue=520.0

Importing sprites, audio and fonts would always store absolute file path in the property "SourceFileName". It now stores relative path if the file is found inside the Game Project, or absolute path if it is from outside of the game project. This is useful if the the game project is moved to another place on a local computer, or if the game project is shared between multiple collaberators on each their private computer.

Examples:
  Relative Path: Resources/Sprites/MySprite.bmp
  Absloute Path: D:/MyGameProject/Resources/Sprites/MySprite.bmp