### PR TITLE
Compiler symbol fixes

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -47,7 +47,7 @@ ccCompiledScript::~ccCompiledScript() {
     shutdown();
 }
 
-int ccCompiledScript::add_global(int siz,char*vall) {
+int ccCompiledScript::add_global(int siz,const char*vall) {
     //  printf("Add global size %d at %d\n",siz,globaldatasize);
     //  if (remove_any_import (vall)) return -2;
     globaldata = (char*)realloc(globaldata, globaldatasize + siz);
@@ -58,20 +58,22 @@ int ccCompiledScript::add_global(int siz,char*vall) {
     globaldatasize += siz;
     return toret;
 }
-int ccCompiledScript::add_string(char*strr) {
+int ccCompiledScript::add_string(const char*strr) {
     strings = (char*)realloc(strings, stringssize + strlen(strr) + 5);
     unsigned int la,opi=0;
     for (la = 0; la <= strlen(strr); la++) {
+        char ch = strr[la];
         if (strr[la]=='\\') {
             la++;
-            if (strr[la] == 'n') strr[la]=10;
-            else if (strr[la] == 'r') strr[la]=13;
+            ch = strr[la];
+            if (strr[la] == 'n') {ch=10;}
+            else if (strr[la] == 'r') {ch=13;}
             else if (strr[la] == '[') { // pass through as \[
                 strings[stringssize + opi] = '\\';
                 opi++;
             }
         }
-        strings[stringssize+opi]=strr[la];
+        strings[stringssize+opi]=ch;
         opi++;
     }
     //  memcpy(&strings[stringssize],strr,strlen(strr)+1);
@@ -89,7 +91,7 @@ void ccCompiledScript::add_fixup(int32_t locc, char ftype) {
 void ccCompiledScript::fixup_previous(char ftype) {
     add_fixup(codesize-1,ftype);
 }
-int ccCompiledScript::add_new_function(char*namm, int *idx) {
+int ccCompiledScript::add_new_function(const char*namm, int *idx) {
     if (numfunctions >= MAX_FUNCTIONS) return -1;
     //  if (remove_any_import (namm)) return -2;
     functions[numfunctions] = (char*)malloc(strlen(namm)+20);
@@ -102,7 +104,7 @@ int ccCompiledScript::add_new_function(char*namm, int *idx) {
     numfunctions++;
     return codesize;
 }
-int ccCompiledScript::add_new_import(char*namm) 
+int ccCompiledScript::add_new_import(const char*namm)
 {
     if (numimports >= importsCapacity) 
     {
@@ -114,7 +116,7 @@ int ccCompiledScript::add_new_import(char*namm)
     numimports++;
     return numimports-1;
 }
-int ccCompiledScript::remove_any_import (char*namm, SymbolDef *oldSym) {
+int ccCompiledScript::remove_any_import (const char*namm, SymbolDef *oldSym) {
     // Remove any import with the specified name
     int i, sidx;
     sidx = sym.find(namm);
@@ -176,7 +178,7 @@ int ccCompiledScript::remove_any_import (char*namm, SymbolDef *oldSym) {
     return 0;
 }
 
-int ccCompiledScript::add_new_export(char*namm,int etype,long eoffs, int numArgs) 
+int ccCompiledScript::add_new_export(const char*namm,int etype,long eoffs, int numArgs)
 {
     if (numexports >= exportsCapacity) 
     {

--- a/Compiler/script/cc_compiledscript.h
+++ b/Compiler/script/cc_compiledscript.h
@@ -20,17 +20,17 @@ struct ccCompiledScript: public ccScript {
     void init();
     void shutdown();
     void free_extra();
-    int  add_global(int,char*);
-    int  add_string(char*);
+    int  add_global(int,const char*);
+    int  add_string(const char*);
     void add_fixup(int32_t,char);
     void fixup_previous(char);
-    int  add_new_function(char*, int *idx);
-    int  add_new_import(char*);
-    int  add_new_export(char*,int,long, int);
+    int  add_new_function(const char*, int *idx);
+    int  add_new_import(const char*);
+    int  add_new_export(const char*,int,long, int);
     void write_code(intptr_t);
     void set_line_number(int nlum) { next_line=nlum; }
     void flush_line_numbers();
-    int  remove_any_import(char*, SymbolDef *oldSym);
+    int  remove_any_import(const char*, SymbolDef *oldSym);
     const char* start_new_section(const char *name);
 
     void write_cmd(int cmdd);

--- a/Compiler/script/cc_symboldef.h
+++ b/Compiler/script/cc_symboldef.h
@@ -6,15 +6,17 @@
 #define STYPE_DYNARRAY  0x10000000
 #define STYPE_CONST     0x20000000
 #define STYPE_POINTER   0x40000000
+#define STYPE_MASK      (0xFFFFFFF)
 #define SYM_TEMPORARYTYPE -99
+
 struct SymbolDef {
     short stype;
     long  flags;
     long  ssize;  // or return type size for function
     short sscope;  // or num arguments for function
     long  arrsize;
-    unsigned long funcparamtypes[MAX_FUNCTION_PARAMETERS+1]; 
-    short funcParamDefaultValues[MAX_FUNCTION_PARAMETERS+1]; 
+    unsigned long funcparamtypes[MAX_FUNCTION_PARAMETERS+1];
+    short funcParamDefaultValues[MAX_FUNCTION_PARAMETERS+1];
 };
 
 #endif // __CC_SYMBOLDEF_H

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -151,6 +151,26 @@ int symbolTable::find(const char*ntf) {
     return -1;*/
 }
 
+
+std::string symbolTable::get_friendly_name(int idx) {
+    std::string result = sname[idx & STYPE_MASK];
+
+    if (idx & STYPE_POINTER) {
+        result = result + std::string("*");
+    }
+
+    if (idx & STYPE_DYNARRAY) {
+        result = result + std::string("[]");
+    }
+
+    if (idx & STYPE_CONST) {
+        result = std::string("const ") + result;
+    }
+
+    return result;
+}
+
+
 std::string symbolTable::get_name_string(int idx) {
     if (idx & STYPE_CONST) {
         idx &= ~STYPE_CONST;
@@ -167,7 +187,7 @@ std::string symbolTable::get_name_string(int idx) {
         return get_name_string(idx) + std::string("*");
     }
 
-    return sname[idx];
+    return sname[idx & STYPE_MASK];
 }
 
 char *symbolTable::get_name(int idx) {

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -7,7 +7,7 @@
 #include "cc_symboldef.h"   // macro definitions
 
 
-symbolTable::symbolTable() { numsymbols=0; currentscope=0; usingTempBuffer = 0; stringStructSym = 0; }
+symbolTable::symbolTable() { numsymbols=0; currentscope=0; stringStructSym = 0; }
 int symbolTable::get_num_args(int funcSym) {
     return sscope[funcSym] % 100;
 }

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -45,8 +45,13 @@ int symbolTable::get_propset(int symb) {
 
 
 void symbolTable::reset() {
-    int rr;
-    for (rr=0;rr<numsymbols;rr++) free(sname[rr]);
+    for (int rr=0;rr<numsymbols;rr++) { free(symbolTreeNames[rr]); }
+
+    for (std::map<int, char *>::iterator it = nameGenCache.begin(); it != nameGenCache.end(); ++it) {
+        free(it->second);
+    }
+    nameGenCache.clear();
+    symbolTreeNames.resize(0);
     sname.resize(0);
     stype.resize(0);
     flags.resize(0);
@@ -145,57 +150,52 @@ int symbolTable::find(const char*ntf) {
     }
     return -1;*/
 }
-char*symbolTable::get_name(int idx) {
 
+std::string symbolTable::get_name_string(int idx) {
     if (idx & STYPE_CONST) {
-        // return "const" version of name, using alternating buffer
-        // so that this can be called twice by the caller
         idx &= ~STYPE_CONST;
-
-        int bufferIdx = usingTempBuffer;
-        usingTempBuffer = (usingTempBuffer + 1) % 2;
-        sprintf(tempBuffer[bufferIdx], "const %s", get_name(idx));
-        return &tempBuffer[bufferIdx][0];
+        return std::string("const ") + get_name_string(idx);
     }
 
     if (idx & STYPE_DYNARRAY) {
-        // dynamic array
         idx &= ~(STYPE_DYNARRAY | STYPE_POINTER);
-        if ((idx >= 0) && (idx < numsymbols)) {
-            int bufferIdx = usingTempBuffer;
-            usingTempBuffer = (usingTempBuffer + 1) % 2;
-            sprintf(tempBuffer[bufferIdx], "%s[]", get_name(idx));
-            return &tempBuffer[bufferIdx][0];
-        }
-        return NULL;
+        return get_name_string(idx) + std::string("[]");
     }
 
     if (idx & STYPE_POINTER) {
-        // it's a pointer -- return the secret pointer version
-        // of the name
         idx &= ~STYPE_POINTER;
-        if ((idx >= 0) && (idx < numsymbols)) {
-            return &sname[idx][strlen(sname[idx]) + 1];
-        }
-        return NULL;
+        return get_name_string(idx) + std::string("*");
     }
 
-    if ((idx >= 0) && (idx < numsymbols))
-        return sname[idx];
-    return NULL;
+    return sname[idx];
 }
+
+char *symbolTable::get_name(int idx) {
+    if (nameGenCache.count(idx) > 0) {
+        return nameGenCache[idx];
+    }
+
+    std::size_t actualIdx = idx & STYPE_MASK;
+    if (actualIdx < 0 || actualIdx >= sname.size()) { return NULL; }
+
+    std::string resultString = get_name_string(idx);
+    char *result = (char *)malloc(resultString.length() + 1);
+    strcpy(result, resultString.c_str());
+    nameGenCache[idx] = result;
+    return result;
+}
+
 int symbolTable::add(char*nta) {
     return add_ex(nta,0,0);
 }
 int symbolTable::add_ex(char*nta,int typo,char sizee) {
     if (find(nta) >= 0) return -1;
-    char *fullname = (char*)malloc(sizeof(char) * (strlen(nta) * 2 + 5));
-    // put the name, followed by the pointer-equivalent
-    strcpy(fullname, nta);
-    strcpy(&fullname[strlen(nta) + 1], nta);
-    strcat(&fullname[strlen(nta) + 1], "*");
-    sname.push_back(fullname);
 
+    char *fullname = (char*)malloc(sizeof(char) * (strlen(nta) + 1));
+    strcpy(fullname, nta);
+    symbolTreeNames.push_back(fullname);
+
+    sname.push_back(std::string(nta));
     stype.push_back(typo);
     flags.push_back(0);
     vartype.push_back(0);

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -190,7 +190,7 @@ std::string symbolTable::get_name_string(int idx) {
     return sname[idx & STYPE_MASK];
 }
 
-char *symbolTable::get_name(int idx) {
+const char *symbolTable::get_name(int idx) {
     if (nameGenCache.count(idx) > 0) {
         return nameGenCache[idx];
     }
@@ -205,10 +205,10 @@ char *symbolTable::get_name(int idx) {
     return result;
 }
 
-int symbolTable::add(char*nta) {
+int symbolTable::add(const char*nta) {
     return add_ex(nta,0,0);
 }
-int symbolTable::add_ex(char*nta,int typo,char sizee) {
+int symbolTable::add_ex(const char*nta,int typo,char sizee) {
     if (find(nta) >= 0) return -1;
 
     char *fullname = (char*)malloc(sizeof(char) * (strlen(nta) + 1));
@@ -230,7 +230,7 @@ int symbolTable::add_ex(char*nta,int typo,char sizee) {
     numsymbols++;
     return numsymbols-1;
 }
-int symbolTable::add_operator(char *nta, int priority, int vcpucmd) {
+int symbolTable::add_operator(const char *nta, int priority, int vcpucmd) {
     int nss = add_ex(nta, SYM_OPERATOR, priority);
     if (nss >= 0)
         vartype[nss] = vcpucmd;

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -34,13 +34,13 @@ struct symbolTable {
     symbolTable();
     void reset();    // clears table
     int  find(const char*);  // returns ID of symbol, or -1
-    int  add_ex(char*,int,char);  // adds new symbol of type and size
-    int  add_operator(char*, int priority, int vcpucmd); // adds new operator
-    int  add(char*);   // adds new symbol, returns -1 if already exists
+    int  add_ex(const char*,int,char);  // adds new symbol of type and size
+    int  add_operator(const char*, int priority, int vcpucmd); // adds new operator
+    int  add(const char*);   // adds new symbol, returns -1 if already exists
     int  get_num_args(int funcSym);
     std::string symbolTable::get_friendly_name(int idx);  // inclue ptr
     std::string symbolTable::get_name_string(int idx);
-    char *get_name(int idx); // gets symbol name of index
+    const char *get_name(int idx); // gets symbol name of index
     int  get_type(int ii);
     int  operatorToVCPUCmd(int opprec);
     int  is_loadable_variable(int symm);

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -3,6 +3,9 @@
 
 #include "cs_parser_common.h"   // macro definitions
 #include "script/cc_treemap.h"
+
+#include <map>
+#include <string>
 #include <vector>
 
 struct symbolTable {
@@ -14,7 +17,6 @@ struct symbolTable {
     int normalVoidSym;
     int nullSym;
     int stringStructSym;
-    std::vector<char *> sname;
     std::vector<short> stype;
     std::vector<long> flags;
     std::vector<short> vartype;
@@ -38,7 +40,8 @@ struct symbolTable {
     int  add_operator(char*, int priority, int vcpucmd); // adds new operator
     int  add(char*);   // adds new symbol, returns -1 if already exists
     int  get_num_args(int funcSym);
-    char*get_name(int); // gets symbol name of index
+    std::string symbolTable::get_name_string(int idx);
+    char *get_name(int idx); // gets symbol name of index
     int  get_type(int ii);
     int  operatorToVCPUCmd(int opprec);
     int  is_loadable_variable(int symm);
@@ -46,6 +49,12 @@ struct symbolTable {
     void set_propfuncs(int symb, int propget, int propset);
     int get_propget(int symb);
     int get_propset(int symb);
+
+private:
+    std::vector<std::string> sname;
+    std::vector<char *> symbolTreeNames;
+
+    std::map<int, char *> nameGenCache;
 };
 
 

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -28,8 +28,6 @@ struct symbolTable {
     // functions only, save types of return value and all parameters
     std::vector<std::vector<unsigned long> > funcparamtypes;
     std::vector<std::vector<short> > funcParamDefaultValues;
-    char tempBuffer[2][MAX_SYM_LEN];
-    int  usingTempBuffer;
 
     ccTreeMap symbolTree;
 

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -40,6 +40,7 @@ struct symbolTable {
     int  add_operator(char*, int priority, int vcpucmd); // adds new operator
     int  add(char*);   // adds new symbol, returns -1 if already exists
     int  get_num_args(int funcSym);
+    std::string symbolTable::get_friendly_name(int idx);  // inclue ptr
     std::string symbolTable::get_name_string(int idx);
     char *get_name(int idx); // gets symbol name of index
     int  get_type(int ii);

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -119,7 +119,7 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
         if (sym.flags[t] & SFLG_IMPORTED) continue;
         if (ccGetOption(SCOPT_SHOWWARNINGS)==0) ;
         else if ((sym.flags[t] & SFLG_ACCESSED)==0) {
-            printf("warning: variable '%s' is never used\n",sym.get_name(t));
+            printf("warning: variable '%s' is never used\n",sym.get_friendly_name(t).c_str());
         }
     }
 

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -93,7 +93,7 @@ const char *get_member_full_name(int structSym, int memberSym) {
 int sym_find_or_add(symbolTable &sym, const char *sname) {
     int symdex = sym.find(sname);
     if (symdex < 0) {
-        symdex = sym.add((char *)sname);  // "safe" to cast since it doesn't get modified.
+        symdex = sym.add(sname);
     }
     return symdex;
 }
@@ -379,7 +379,7 @@ int find_member_sym(int structSym, long *memSym, int allowProtected) {
     int oriname = *memSym;
     const char *possname = get_member_full_name(structSym, oriname);
 
-    oriname = sym.find((char*)possname);
+    oriname = sym.find(possname);
     if (oriname < 0) {
         if (sym.extends[structSym] > 0) {
             // walk the inheritance tree to find the member
@@ -2954,7 +2954,7 @@ int parse_variable_declaration(long cursym,int *next_type,int isglobal,
     }
   else if (isglobal) {
     // a global variable
-    sym.soffs[cursym] = scrip->add_global(varsize,(char*)&getsvalue[0]);
+    sym.soffs[cursym] = scrip->add_global(varsize,reinterpret_cast<const char*>(&getsvalue[0]));
     if (sym.soffs[cursym] < 0)
       return -1;
     if (need_fixup == 1) scrip->add_fixup(sym.soffs[cursym],FIXUP_DATADATA);
@@ -3373,7 +3373,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                         // check that we haven't already inherited a member
                         // with the same name
                         long member = vname;
-                        char *memberExt = sym.get_name(vname);
+                        const char *memberExt = sym.get_name(vname);
                         memberExt = strstr(memberExt, "::");
                         if (memberExt == NULL) {
                             cc_error("Internal compiler error dbc");
@@ -3479,7 +3479,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                             }
                             // the variable name will have been jibbled with
                             // the struct name added to it -- strip it back off
-                            char *memberPart = strstr(sym.get_name(vname), "::");
+                            const char *memberPart = strstr(sym.get_name(vname), "::");
                             if (memberPart == NULL) {
                                 cc_error("internal error: property has no struct name");
                                 return -1;
@@ -3816,7 +3816,7 @@ startvarbit:
                 structSym = cursym;
                 // change cursym to be the full function name
                 const char *mfullname = get_member_full_name(cursym, whichmember);
-                cursym = sym.find((char*)mfullname);
+                cursym = sym.find(mfullname);
                 if (cursym < 0) {
                     cc_error("'%s' does not contain a function '%s'", sym.get_friendly_name(structSym).c_str(), sym.get_friendly_name(whichmember).c_str());
                     return -1;

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -210,7 +210,7 @@ int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip) {
                     (sym.stype[last_time] != SYM_OPENBRACKET) &&
                     (towrite != in_struct_declr)) {
                         const char *new_name = get_member_full_name(in_struct_declr, towrite);
-                        //      printf("changed '%s' to '%s'\n",sym.get_name(towrite),new_name);
+                        //      printf("changed '%s' to '%s'\n",sym.get_friendly_name(towrite).c_str(),new_name);
                         towrite = sym_find_or_add(sym, new_name);
                         if (towrite < 0) {
                             cc_error("symbol table error - could not ensure new struct symbol.");
@@ -388,11 +388,11 @@ int find_member_sym(int structSym, long *memSym, int allowProtected) {
             // the inherited member was not found, so fall through to
             // the error message
         }
-        cc_error("'%s' is not a public member of '%s'. Are you sure you spelt it correctly (remember, capital letters are important)?",sym.get_name(*memSym),sym.get_name(structSym));
+        cc_error("'%s' is not a public member of '%s'. Are you sure you spelt it correctly (remember, capital letters are important)?",sym.get_friendly_name(*memSym).c_str(),sym.get_friendly_name(structSym).c_str());
         return -1;
     }
     if ((!allowProtected) && (sym.flags[oriname] & SFLG_PROTECTED)) {
-        cc_error("Cannot access protected member '%s'", sym.get_name(oriname));
+        cc_error("Cannot access protected member '%s'", sym.get_friendly_name(oriname).c_str());
         return -1;
     }
     *memSym = oriname;
@@ -730,11 +730,11 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
       next_type = sym.get_type(cursym=targ.getnext());
       if (next_type == SYM_CLOSEPARENTHESIS) break;
       else if (next_type == SYM_GLOBALVAR) {
-        cc_error("'%s' is a global var; cannot use as name for local",sym.get_name(cursym));
+        cc_error("'%s' is a global var; cannot use as name for local",sym.get_friendly_name(cursym).c_str());
         return -1;
       }
       else if (next_type != SYM_COMMA) {
-        cc_error("PE02: Parse error at '%s'",sym.get_name(cursym));
+        cc_error("PE02: Parse error at '%s'",sym.get_friendly_name(cursym).c_str());
         return -1;
       }
 
@@ -742,7 +742,7 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
     }
     else {
       // something odd was inside the parentheses
-      cc_error("PE03: Parse error at '%s'",sym.get_name(cursym));
+      cc_error("PE03: Parse error at '%s'",sym.get_friendly_name(cursym).c_str());
       return -1;
     }
   }
@@ -1041,7 +1041,7 @@ int check_type_mismatch(int typeIs, int typeWantsToBe, int orderMatters) {
         return -1;
     }
     else {
-      cc_error("Type mismatch: cannot convert '%s' to '%s'", sym.get_name(typeIsOriginally), sym.get_name(typeWantsToBeOriginally));
+      cc_error("Type mismatch: cannot convert '%s' to '%s'", sym.get_friendly_name(typeIsOriginally).c_str(), sym.get_friendly_name(typeWantsToBeOriginally).c_str());
       return -1;
     }
   }
@@ -1195,7 +1195,7 @@ long extract_variable_name(int fsym, ccInternalList*targ,long*slist, int *funcAt
         return -1;
         }
       if ((sym.flags[slist[sslen-2]] & SFLG_ARRAY)==0) {
-        cc_error("%s is not an array",sym.get_name(slist[sslen-2]));
+        cc_error("%s is not an array",sym.get_friendly_name(slist[sslen-2]).c_str());
         return -1;
         }
       int braclevel = 0, linenumWas = currentline;
@@ -1392,7 +1392,7 @@ int get_array_index_into_ax(ccCompiledScript *scrip, long *symlist, int openBrac
   int arrSym = symlist[openBracketOffs - 1];
 
   if ((sym.flags[arrSym] & SFLG_ARRAY) == 0) {
-    cc_error("Internal error: not an array: '%s'", sym.get_name(arrSym));
+    cc_error("Internal error: not an array: '%s'", sym.get_friendly_name(arrSym).c_str());
     return -1;
   }
 
@@ -1539,7 +1539,7 @@ int process_arrays_and_members(int slilen,long*syml,int*soffset,int*extraoffset,
         }
         else if (iswrite) {
           if (sym.flags[syml[onoffs+1]] & SFLG_READONLY) {
-            cc_error("property '%s' is read-only", sym.get_name(syml[onoffs + 1]));
+            cc_error("property '%s' is read-only", sym.get_friendly_name(syml[onoffs + 1]).c_str());
             return -1;
           }
         }
@@ -1562,7 +1562,7 @@ int process_arrays_and_members(int slilen,long*syml,int*soffset,int*extraoffset,
         // if one of the struct members in the path is read-only, don't allow it
         if ((iswrite) || (mustBeWritable)) {
           if (sym.flags[syml[onoffs+1]] & SFLG_READONLY) {
-            cc_error("variable '%s' is read-only", sym.get_name(syml[onoffs + 1]));
+            cc_error("variable '%s' is read-only", sym.get_friendly_name(syml[onoffs + 1]).c_str());
             return -1;
           }
         }
@@ -1788,7 +1788,7 @@ int do_variable_memory_access(ccCompiledScript *scrip, int variableSym,
     gotValType = sym.normalStringSym | STYPE_CONST;
   }
   else if (mainVariableType == SYM_STRUCTMEMBER) {
-    cc_error("must include parent structure of member '%s'",sym.get_name(mainVariableSym));
+    cc_error("must include parent structure of member '%s'",sym.get_friendly_name(mainVariableSym).c_str());
     return -1;
     }
   else if (mainVariableType == SYM_NULL) {
@@ -1800,7 +1800,7 @@ int do_variable_memory_access(ccCompiledScript *scrip, int variableSym,
     gotValType = sym.nullSym | STYPE_POINTER;
   }
   else {
-    cc_error("read/write ax called with non-variable parameter ('%s')",sym.get_name(variableSym));
+    cc_error("read/write ax called with non-variable parameter ('%s')",sym.get_friendly_name(variableSym).c_str());
     return -1;
     }
 
@@ -1913,7 +1913,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
         // normally, the whole array can be used as a pointer.
         // this is not the case with an property array, so catch
         // it here and give an error
-        cc_error("Expected array index after '%s'", sym.get_name(variableSym));
+        cc_error("Expected array index after '%s'", sym.get_friendly_name(variableSym).c_str());
         return -1;
       }
 
@@ -1930,7 +1930,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
       else if (writing) {
 
         if ((writingThisTime) && (sym.flags[variableSym] & SFLG_READONLY)) {
-          cc_error("property '%s' is read-only", sym.get_name(variableSym));
+          cc_error("property '%s' is read-only", sym.get_friendly_name(variableSym).c_str());
           return -1;
         }
 
@@ -1957,7 +1957,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
           }
           else
           {
-            cc_error("Expected array index after '%s'", sym.get_name(variableSym));
+            cc_error("Expected array index after '%s'", sym.get_friendly_name(variableSym).c_str());
             return -1;
           }
         }
@@ -2066,7 +2066,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
       // a property being accessed
       if ((sym.flags[variableSym] & SFLG_POINTER) && (!isLastClause)) { }
       else if (sym.flags[variableSym] & SFLG_READONLY) {
-        cc_error("variable '%s' is read-only", sym.get_name(variableSym));
+        cc_error("variable '%s' is read-only", sym.get_friendly_name(variableSym).c_str());
         return -1;
       }
       else if (sym.flags[variableSym] & SFLG_WRITEPROTECTED) {
@@ -2074,7 +2074,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
         // the this ptr
         if ((ee > 0) && (sym.flags[variablePath[ee - 1].syml[0]] & SFLG_THISPTR)) { }
         else {
-          cc_error("variable '%s' is write-protected", sym.get_name(variableSym));
+          cc_error("variable '%s' is write-protected", sym.get_friendly_name(variableSym).c_str());
           return -1;
         }
 
@@ -2111,7 +2111,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
 
     if ((writing) && (cannotAssign)) {
       // an entire array or struct cannot be assigned to
-      cc_error("cannot assign to '%s'", sym.get_name(variableSym));
+      cc_error("cannot assign to '%s'", sym.get_friendly_name(variableSym).c_str());
       return -1;
     }
 
@@ -2168,7 +2168,7 @@ int do_variable_ax(int slilen,long*syml,ccCompiledScript*scrip,int writing, int 
           isPointer = true;
         }
         else {
-          cc_error("Invalid pathing: unexpected '%s'", sym.get_name(variablePath[ee + 1].syml[0]));
+          cc_error("Invalid pathing: unexpected '%s'", sym.get_friendly_name(variablePath[ee + 1].syml[0]).c_str());
           return -1;
         }
 
@@ -2204,7 +2204,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
 /*  printf("Parse expression: '");
   int j;
   for (j=0;j<listlen;j++)
-    printf("%s ",sym.get_name(symlist[j]));
+    printf("%s ",sym.get_friendly_name(symlist[j]).c_str());
   printf("'\n");*/
 
   if (listlen == 0) {
@@ -2303,7 +2303,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
     }
     else {
       // this operator needs a left hand side
-      cc_error("Parse error: unexpected operator '%s'",sym.get_name(symlist[oploc]));
+      cc_error("Parse error: unexpected operator '%s'",sym.get_friendly_name(symlist[oploc]).c_str());
       return -1;
     }
   }
@@ -2323,7 +2323,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
 
     if (oploc + 1 >= listlen) {
       // there is no right hand side for the expression
-      cc_error("Parse error: invalid use of operator '%s'",sym.get_name(symlist[oploc]));
+      cc_error("Parse error: invalid use of operator '%s'",sym.get_friendly_name(symlist[oploc]).c_str());
       return -1;
     }
 
@@ -2390,7 +2390,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
   if (lilen < 0)
     return -1;
 /*  printf("lilen: %d, list is ");
-  for (j=0;j<lilen;j++) printf("%s ",sym.get_name(vnlist[j]));
+  for (j=0;j<lilen;j++) printf("%s ",sym.get_friendly_name(vnlist[j]).c_str());
   printf("\n");*/
 
   if (sym.get_type(symlist[0]) == SYM_OPENPARENTHESIS) {
@@ -2426,7 +2426,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
       scrip->push_reg(SREG_AX);
       int op = symlist[0];
       if (sym.get_type(op) != SYM_OPERATOR) {
-        cc_error("expected operator, not '%s'",sym.get_name(op));
+        cc_error("expected operator, not '%s'",sym.get_friendly_name(op).c_str());
         return -1;
         }
       if (parse_sub_expr(&symlist[1],listlen-1,scrip) < 0) return -1;
@@ -2439,11 +2439,11 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
     return 0;
     }
   else if (sym.get_type(symlist[0]) == 0) {
-    cc_error("undefined symbol '%s'",sym.get_name(symlist[0]));
+    cc_error("undefined symbol '%s'",sym.get_friendly_name(symlist[0]).c_str());
     return -1;
     }
   else if (sym.get_type(symlist[0]) == SYM_OPERATOR) {
-    cc_error("Parse error: unexpected '%s'",sym.get_name(symlist[0]));
+    cc_error("Parse error: unexpected '%s'",sym.get_friendly_name(symlist[0]).c_str());
     return -1;
     }
   else if ((sym.get_type(symlist[0]) == SYM_FUNCTION) || (funcAtOffs > 0)) {
@@ -2508,7 +2508,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
       num_supplied_args = 0;
 
     if (bdepth >= 0) {
-      cc_error("parser confused near '%s'",sym.get_name(usingList[-2]));
+      cc_error("parser confused near '%s'",sym.get_friendly_name(usingList[-2]).c_str());
       return -1;
     }
 
@@ -2608,7 +2608,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
     if ((sym.sscope[funcsym] >= 100) && (numargs >= sym.sscope[funcsym] - 100)) ;
     else if (sym.sscope[funcsym] == numargs) ;
     else {
-      cc_error("wrong number of parameters in call to '%s'",sym.get_name(funcsym));
+      cc_error("wrong number of parameters in call to '%s'",sym.get_friendly_name(funcsym).c_str());
       return -1;
       }
     sym.flags[funcsym] |= SFLG_ACCESSED;
@@ -2652,7 +2652,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
 
     // make sure there's nothing left to process in this clause
     if (usingListLen > 0) {
-      cc_error("expected semicolon after '%s'",sym.get_name(usingList[-1]));
+      cc_error("expected semicolon after '%s'",sym.get_friendly_name(usingList[-1]).c_str());
       return -1;
     }
   }
@@ -2663,7 +2663,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
     if (read_variable_into_ax(1,&symlist[0],scrip)) return -1;
     }
   else {
-    cc_error("Parse error in expr near '%s'",sym.get_name(symlist[0]));
+    cc_error("Parse error in expr near '%s'",sym.get_friendly_name(symlist[0]).c_str());
     return -1;
     }
 
@@ -2704,7 +2704,7 @@ int evaluate_expression(ccInternalList*targ,ccCompiledScript*scrip,int countbrac
           || ((brackdepth == 0) && (countbrackets!=0))) {
       ourlen = j - targ->pos;
       if ((ourlen < 1) || (hadMetaOnly == 1)) {
-        cc_error("PE01: Parse error at '%s'",sym.get_name(targ->script[j]));
+        cc_error("PE01: Parse error at '%s'",sym.get_friendly_name(targ->script[j]).c_str());
         return -1;
         }
       ours.script = (long*)malloc(ourlen * sizeof(long));
@@ -2988,7 +2988,7 @@ int parse_variable_declaration(long cursym,int *next_type,int isglobal,
     return 2;
     }
   if (next_type[0] != SYM_SEMICOLON) {
-    cc_error("Expected ',' or ';', not '%s'",sym.get_name(targ->peeknext()));
+    cc_error("Expected ',' or ';', not '%s'",sym.get_friendly_name(targ->peeknext()).c_str());
     return -1;
     }
   targ->getnext();  // skip the semicolon
@@ -3180,7 +3180,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
             int stname = targ.getnext();
             if ((sym.get_type(stname) != 0) &&
                 (sym.get_type(stname) != SYM_UNDEFINEDSTRUCT)) {
-                    cc_error("'%s' is already defined",sym.get_name(stname));
+                    cc_error("'%s' is already defined",sym.get_friendly_name(stname).c_str());
                     return -1;
             }
             int size_so_far = 0;
@@ -3305,7 +3305,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                 }
 
                 if (targ.peeknext() < 0) {
-                    cc_error("Invalid syntax near '%s'", sym.get_name(cursym));
+                    cc_error("Invalid syntax near '%s'", sym.get_friendly_name(cursym).c_str());
                     return -1;
                 }
 
@@ -3345,7 +3345,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                         vname = targ.getnext();
 
                     if (sym.get_type(vname) != 0) {
-                        cc_error("'%s' is already defined",sym.get_name(vname));
+                        cc_error("'%s' is already defined",sym.get_friendly_name(vname).c_str());
                         return -1;
                     }
                     if (extendsWhat > 0) {
@@ -3367,7 +3367,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                             member = sym.add_ex(memberExt, 0, 0);
 
                         if (find_member_sym(extendsWhat, &member, true) == 0) {
-                            cc_error("'%s' already defined by inherited class", sym.get_name(member));
+                            cc_error("'%s' already defined by inherited class", sym.get_friendly_name(member).c_str());
                             return -1;
                         }
                         // not found -- a good thing, but find_member_sym will
@@ -3408,7 +3408,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                     else if ((cursym == stname) && (!member_is_pointer)) {
                         // cannot do  struct A { A a; }
                         // since we don't know the size of A, recursiveness
-                        cc_error("struct '%s' cannot be a member of itself", sym.get_name(cursym));
+                        cc_error("struct '%s' cannot be a member of itself", sym.get_friendly_name(cursym).c_str());
                         return -1;
                     }
                     else {
@@ -3537,7 +3537,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
 
             int enumName = targ.getnext();
             if (sym.get_type(enumName) != 0) {
-                cc_error("'%s' is already defined",sym.get_name(enumName));
+                cc_error("'%s' is already defined",sym.get_friendly_name(enumName).c_str());
                 return -1;
             }
             sym.stype[enumName] = SYM_VARTYPE;
@@ -3598,13 +3598,13 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                         break;
                     }
                     else if (sym.get_type(nextSym) != SYM_COMMA) {
-                        cc_error("enum parse error at '%s'", sym.get_name(nextSym));
+                        cc_error("enum parse error at '%s'", sym.get_friendly_name(nextSym).c_str());
                         return -1;
                     }
 
                 }
                 else {
-                    cc_error("unexpected '%s'", sym.get_name(nextOne));
+                    cc_error("unexpected '%s'", sym.get_friendly_name(nextOne).c_str());
                     return -1;
                 }
             }
@@ -3653,7 +3653,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
 
             if ((sym.get_type(targ.peeknext()) != SYM_VARTYPE) &&
                 (sym.get_type(targ.peeknext()) != SYM_READONLY)) {
-                    cc_error("expected variable or function after import, not '%s'", sym.get_name(targ.peeknext()));
+                    cc_error("expected variable or function after import, not '%s'", sym.get_friendly_name(targ.peeknext()).c_str());
                     return -1;
             }
         }
@@ -3699,11 +3699,11 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
             while (sym.get_type(cursym) != SYM_SEMICOLON) {
                 int nextype = sym.get_type(cursym);
                 if (nextype == 0) {
-                    cc_error("cannot export undefined symbol '%s'",sym.get_name(cursym));
+                    cc_error("cannot export undefined symbol '%s'",sym.get_friendly_name(cursym).c_str());
                     return -1;
                 }
                 if ((nextype != SYM_GLOBALVAR) && (nextype != SYM_FUNCTION)) {
-                    cc_error("invalid export symbol '%s'",sym.get_name(cursym));
+                    cc_error("invalid export symbol '%s'",sym.get_friendly_name(cursym).c_str());
                     return -1;
                 }
                 if (sym.flags[cursym] & SFLG_IMPORTED) {
@@ -3725,7 +3725,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                 cursym = targ.getnext();
                 if (sym.get_type(cursym) == SYM_SEMICOLON) break;
                 if (sym.get_type(cursym) != SYM_COMMA) {
-                    cc_error("export parse error at '%s'",sym.get_name(cursym));
+                    cc_error("export parse error at '%s'",sym.get_friendly_name(cursym).c_str());
                     return -1;
                 }
                 cursym = targ.getnext();
@@ -3737,7 +3737,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
             int vtwas = cursym;
             if ((nested_type[nested_level] == NEST_IFSINGLE) ||
                 (nested_type[nested_level] == NEST_ELSESINGLE)) {
-                    cc_error("Unexpected '%s'",sym.get_name(cursym));
+                    cc_error("Unexpected '%s'",sym.get_friendly_name(cursym).c_str());
                     return -1;
             }
 
@@ -3797,7 +3797,7 @@ startvarbit:
                 const char *mfullname = get_member_full_name(cursym, whichmember);
                 cursym = sym.find((char*)mfullname);
                 if (cursym < 0) {
-                    cc_error("'%s' does not contain a function '%s'", sym.get_name(structSym), sym.get_name(whichmember));
+                    cc_error("'%s' does not contain a function '%s'", sym.get_friendly_name(structSym).c_str(), sym.get_friendly_name(whichmember).c_str());
                     return -1;
                 }
                 isMemberFunction = structSym;
@@ -3813,7 +3813,7 @@ startvarbit:
                     return -1;
             }
             if (sym.get_type(cursym) != 0) {
-                cc_error("Variable '%s' is already defined",sym.get_name(cursym));
+                cc_error("Variable '%s' is already defined",sym.get_friendly_name(cursym).c_str());
                 return -1;
             }
 
@@ -3920,7 +3920,7 @@ startvarbit:
             continue;
         }
         else if (in_func < 0) {
-            cc_error("Parse error: unexpected '%s'",sym.get_name(cursym));
+            cc_error("Parse error: unexpected '%s'",sym.get_friendly_name(cursym).c_str());
             return -1;
         }
         else if (symType == 0) {
@@ -3995,7 +3995,7 @@ startvarbit:
                     }
                     /*
                     if (sym.flags[cursym] & SFLG_READONLY) {
-                    cc_error("variable '%s' is read-only", sym.get_name(cursym));
+                    cc_error("variable '%s' is read-only", sym.get_friendly_name(cursym).c_str());
                     return -1;
                     }
                     */
@@ -4101,7 +4101,7 @@ startvarbit:
                     }
                 }
                 else if ((functionReturnType != sym.normalIntSym) && (functionReturnType != sym.normalVoidSym)) {
-                    cc_error("Must return a '%s' value from function", sym.get_name(functionReturnType));
+                    cc_error("Must return a '%s' value from function", sym.get_friendly_name(functionReturnType).c_str());
                     return -1;
                 }
                 else {
@@ -4158,7 +4158,7 @@ startvarbit:
                     continue;
             }
             else {
-                cc_error("PE04: parse error at '%s'",sym.get_name(cursym));
+                cc_error("PE04: parse error at '%s'",sym.get_friendly_name(cursym).c_str());
                 return -1;
             }
             // sort out jumps when a single-line if or else has finished

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3250,35 +3250,52 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                 int member_is_protected = 0;
                 int member_is_writeprotected = 0;
 
-                if (sym.get_type(cursym) == SYM_PROTECTED) {
-                    // protected
-                    member_is_protected = 1;
-                    cursym = targ.getnext();
+                // loop for all qualifiers.
+                bool foundQualifier;
+                do {
+                    foundQualifier = false;
+
+                    if (sym.get_type(cursym) == SYM_PROTECTED) {
+                        // protected
+                        member_is_protected = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                    if (sym.get_type(cursym) == SYM_WRITEPROTECTED) {
+                        // write-protected
+                        member_is_writeprotected = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                    if (sym.get_type(cursym) == SYM_READONLY) {
+                        // read only member, carry on
+                        member_is_readonly = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                    if (sym.get_type(cursym) == SYM_IMPORT) {
+                        member_is_import = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                    if (sym.get_type(cursym) == SYM_STATIC) {
+                        member_is_static = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                    if (sym.get_type(cursym) == SYM_PROPERTY) {
+                        // a "property" is a member variable that is actually a pair of functions
+                        member_is_property = 1;
+                        foundQualifier = true;
+                        cursym = targ.getnext();
+                    }
+                } while (foundQualifier);
+
+                if (member_is_protected && member_is_writeprotected) {
+                    cc_error("Field cannot be both protected and write-protected.");
+                    return -1;
                 }
-                else if (sym.get_type(cursym) == SYM_WRITEPROTECTED) {
-                    // write-protected
-                    member_is_writeprotected = 1;
-                    cursym = targ.getnext();
-                }
-                if (sym.get_type(cursym) == SYM_READONLY) {
-                    // read only member, carry on
-                    member_is_readonly = 1;
-                    cursym = targ.getnext();
-                }
-                if (sym.get_type(cursym) == SYM_IMPORT) {
-                    member_is_import = 1;
-                    cursym = targ.getnext();
-                }
-                if (sym.get_type(cursym) == SYM_STATIC) {
-                    member_is_static = 1;
-                    cursym = targ.getnext();
-                }
-                // a "property" is a member variable that is actually
-                // a pair of functions
-                if (sym.get_type(cursym) == SYM_PROPERTY) {
-                    member_is_property = 1;
-                    cursym = targ.getnext();
-                }
+
                 if ((sym.get_type(cursym) != SYM_VARTYPE) &&
                     (sym.get_type(cursym) != SYM_UNDEFINEDSTRUCT)) {
 

--- a/Compiler/test/cc_symboltable_test.cpp
+++ b/Compiler/test/cc_symboltable_test.cpp
@@ -1,0 +1,94 @@
+#include "gtest/gtest.h"
+
+#include "script/cc_symboltable.h"
+#include "script/cc_symboldef.h"
+
+TEST(SymbolTable, GetNameNonExistent) {
+    symbolTable testSym;
+
+    // symbol must be >= 0. Max symbols 0x10000000 due to type flags
+    EXPECT_EQ (NULL, testSym.get_name(0));
+    EXPECT_EQ (NULL, testSym.get_name(1));
+    EXPECT_EQ (NULL, testSym.get_name(2));
+
+    // check edge conditions. index immediately after 'c' should be null
+    int a_sym = testSym.add_ex("a",0,0);
+    int b_sym = testSym.add_ex("b",0,0);
+    int c_sym = testSym.add_ex("c",0,0);
+    EXPECT_EQ (NULL, testSym.get_name(c_sym + 1));
+}
+
+TEST(SymbolTable, GetNameNormal) {
+    symbolTable testSym;
+
+    int foo_sym = testSym.add_ex("foo",0,0);
+
+    EXPECT_STREQ("foo", testSym.get_name(foo_sym));
+}
+
+TEST(SymbolTable, GetNameFlags) {
+    symbolTable testSym;
+
+    int foo_sym = testSym.add_ex("foo",0,0);
+
+    // const
+    EXPECT_STREQ("const foo", testSym.get_name(foo_sym | STYPE_CONST));
+
+    // dynarray
+    EXPECT_STREQ("foo[]", testSym.get_name(foo_sym | STYPE_DYNARRAY));
+
+    // dynarray + pointer is just a dynarray
+    EXPECT_STREQ("foo[]", testSym.get_name(foo_sym | STYPE_DYNARRAY | STYPE_POINTER));
+
+    // pointer
+    EXPECT_STREQ("foo*", testSym.get_name(foo_sym | STYPE_POINTER));
+
+
+    int bar_sym = testSym.add_ex("bar",0,0);
+
+    // const dynarray
+    EXPECT_STREQ("const bar[]", testSym.get_name(bar_sym | STYPE_CONST | STYPE_DYNARRAY));
+
+    // const pointer
+    EXPECT_STREQ("const bar*", testSym.get_name(bar_sym | STYPE_CONST | STYPE_POINTER));
+
+    // const dynarray/pointer
+    EXPECT_STREQ("const bar[]", testSym.get_name(bar_sym | STYPE_CONST | STYPE_DYNARRAY | STYPE_POINTER));
+}
+
+
+TEST(SymbolTable, GetNameNonExistentFlags) {
+    symbolTable testSym;
+
+    int no_exist_sym = 5000;
+
+    // on their own
+    // -------------------
+
+    // normal
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym));
+
+    // const
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_CONST));
+
+    // dynarray
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_DYNARRAY));
+
+    // dynarray + pointer is just a dynarray
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_DYNARRAY | STYPE_POINTER));
+
+    // pointer
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_POINTER));
+
+    // combinations
+    // -------------------
+
+    // const dynarray
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_CONST | STYPE_DYNARRAY));
+
+    // const pointer
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_CONST | STYPE_POINTER));
+
+    // const dynarray/pointer
+    EXPECT_EQ (NULL, testSym.get_name(no_exist_sym | STYPE_CONST | STYPE_DYNARRAY | STYPE_POINTER));
+}

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -13,6 +13,7 @@ char *last_seen_cc_error = 0;
 
 void cc_error_at_line(char *buffer, const char *error_msg)
 {
+    // printf("error: %s\n", error_msg);
     last_seen_cc_error = _strdup(error_msg);
 }
 
@@ -98,3 +99,25 @@ TEST(Compile, DynamicTypeReturnNonPointerManaged) {
     ASSERT_EQ(-1, compileResult);
     EXPECT_STREQ("cannot pass non-pointer struct array", last_seen_cc_error);
 }
+
+TEST(Compile, StructMemberQualifierOrder) {
+    ccCompiledScript *scrip = new ccCompiledScript();
+    scrip->init();
+
+    sym.reset();  // <-- global
+
+    char *inpl = "\
+        struct BothOrders { \
+            protected readonly import _tryimport static attribute int something; \
+            attribute static _tryimport import readonly writeprotected int another; \
+            readonly import attribute int MyAttrib; \
+            import readonly attribute int YourAttrib; \
+        };\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_EQ(0, compileResult);
+}
+

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -52,3 +52,29 @@ TEST(Compile, UnknownKeywordAfterReadonly) {
 
     ASSERT_EQ(-1, compileResult);
     EXPECT_STREQ("Syntax error at 'MyStruct::int2'; expected variable type", last_seen_cc_error);
+}
+
+TEST(Compile, DynamicArrayReturnValueErrorText) {
+    ccCompiledScript *scrip = new ccCompiledScript();
+    scrip->init();
+
+    sym.reset();  // <-- global
+
+    char *inpl = "\
+        managed struct DynamicSprite { };\
+        \
+        int[] Func()\
+        {\
+          DynamicSprite *r[] = new DynamicSprite[10];\
+          return r;\
+        }";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Type mismatch: cannot convert 'DynamicSprite*[]' to 'int[]'", last_seen_cc_error);
+}
+
+// TODO: "DynamicSprite[]" type in the function declaration should cause error on its own, because managed types are
+// only allowed to be referenced by pointers.

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -6,3 +6,49 @@
 TEST(Parser, Test) {
     ASSERT_EQ(0, 0);
 }
+
+extern int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip);
+
+char *last_seen_cc_error = 0;
+
+void cc_error_at_line(char *buffer, const char *error_msg)
+{
+    last_seen_cc_error = _strdup(error_msg);
+}
+
+TEST(Tokenize, UnknownKeywordAfterReadonly) {
+    ccCompiledScript *scrip = new ccCompiledScript();
+    scrip->init();
+
+    sym.reset();  // <-- global
+
+    ccInternalList targ;
+
+    char *inpl = "struct MyStruct \
+        {\
+          readonly int2 a; \
+          readonly int2 b; \
+        };";
+
+    int tokenizeResult = cc_tokenize(inpl, &targ, scrip);
+
+    ASSERT_EQ(0, tokenizeResult);
+}
+
+TEST(Compile, UnknownKeywordAfterReadonly) {
+    ccCompiledScript *scrip = new ccCompiledScript();
+    scrip->init();
+
+    sym.reset();  // <-- global
+
+    char *inpl = "struct MyStruct \
+        {\
+          readonly int2 a; \
+          readonly int2 b; \
+        };";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Syntax error at 'MyStruct::int2'; expected variable type", last_seen_cc_error);

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -76,5 +76,25 @@ TEST(Compile, DynamicArrayReturnValueErrorText) {
     EXPECT_STREQ("Type mismatch: cannot convert 'DynamicSprite*[]' to 'int[]'", last_seen_cc_error);
 }
 
-// TODO: "DynamicSprite[]" type in the function declaration should cause error on its own, because managed types are
-// only allowed to be referenced by pointers.
+TEST(Compile, DynamicTypeReturnNonPointerManaged) {
+    // "DynamicSprite[]" type in the function declaration should cause error on its own, because managed types are
+    // only allowed to be referenced by pointers.
+
+    ccCompiledScript *scrip = new ccCompiledScript();
+    scrip->init();
+
+    sym.reset();  // <-- global
+
+    char *inpl = "\
+        managed struct DynamicSprite { };\
+        \
+        DynamicSprite[] Func()\
+        {\
+        }";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("cannot pass non-pointer struct array", last_seen_cc_error);
+}

--- a/Solutions/Compiler.Lib/Compiler.Lib.Test.vcproj
+++ b/Solutions/Compiler.Lib/Compiler.Lib.Test.vcproj
@@ -177,6 +177,10 @@
 			UniqueIdentifier="{4FC737F1-C7A5-4376-A066-2A32D752A2FF}"
 			>
 			<File
+				RelativePath="..\..\Compiler\test\cc_symboltable_test.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\Compiler\test\cs_parser_test.cpp"
 				>
 			</File>


### PR DESCRIPTION
* Allow record member qualifiers to be in any order
* friendly names for types in error messages
* fix readonly crashes