### PR TITLE
PSP: Fix build scripts for building in linux.

### DIFF
--- a/PSP/Makefile
+++ b/PSP/Makefile
@@ -1,88 +1,79 @@
-DISTRIB_NAME = AGS_Runtime_for_PSP_3.21_R9
-PSP_AGS_FOLDER = "j:/psp/game/ags"
+DISTRIB_NAME?=AGS_Runtime_for_PSP_3.21_R9
+PSP_AGS_FOLDER?=j:/psp/game/ags
+COPY?=0
+
+export DISTRIB_NAME
+export PSP_AGS_FOLDER
+export COPY
+
+DIST_PREFIX=../PSP/dist/$(DISTRIB_NAME)
 
 .PHONY: kernelprx exceptionprx launchereboot engineprx allplugins \
         cleankernelprx cleanexceptionprx cleanlaunchereboot cleanengineprx cleanallplugins \
         distrib
 
-all:
-	make kernelprx
-	make exceptionprx
-	make launchereboot
-	make engineprx
-	make allplugins
+all: kernelprx exceptionprx launchereboot engineprx allplugins
 
 kernelprx:
-	@make -C "kernel"
+	@$(MAKE) -C "kernel"
 	@cp "kernel/kernel.prx" "bin"
 ifeq ($(COPY), 1)
 	@cp "kernel/kernel.prx" $(PSP_AGS_FOLDER)
 endif
 
 exceptionprx:
-	@make -C "exception/prx"
+	@$(MAKE) -C "exception/prx"
 	@cp "exception/prx/exception.prx" "bin"
 ifeq ($(COPY), 1)
 	@cp "exception/prx/exception.prx" $(PSP_AGS_FOLDER)
 endif
 
 launchereboot:
-	@make -C "launcher"
+	@$(MAKE) -C "launcher"
 	@cp "launcher/EBOOT.PBP" "bin"
 ifeq ($(COPY), 1)
 	@cp "launcher/EBOOT.PBP" $(PSP_AGS_FOLDER)
 endif
 
 engineprx:
-	@make -C "../Engine" -f Makefile.psp
+	@$(MAKE) -C "../Engine" -f Makefile.psp
 	@cp "../Engine/ags321.prx" "bin"
 ifeq ($(COPY), 1)
 	@cp "../Engine/ags321.prx" $(PSP_AGS_FOLDER)
 endif
 
 allplugins:
-ifeq ($(COPY), 1)
-	@make -C "../Plugins" -f Makefile.psp COPY=1
-else
-	@make -C "../Plugins" -f Makefile.psp
-endif
-	
+	@$(MAKE) -C "../Plugins" -f Makefile.psp
 
 cleankernelprx:
-	@make clean -C "kernel"
+	@$(MAKE) -C "kernel" clean
 	@rm -f "bin/kernel.prx"
-	
+
 cleanexceptionprx:
-	@make clean -C "exception/prx"
+	@$(MAKE) -C "exception/prx" clean
 	@rm -f "bin/exception.prx"
 
 cleanlaunchereboot:
-	@make clean -C "launcher"
+	@$(MAKE) -C "launcher" clean
 	@rm -f "bin/EBOOT.PBP"
 
 cleanengineprx:
-	@make clean -C "../Engine" -f Makefile.psp
+	@$(MAKE) C "../Engine" -f Makefile.psp clean
 	@rm -f "bin/ags321.prx"
 
 cleanallplugins:
-	@make clean -C "../Plugins" -f Makefile.psp
+	@$(MAKE) -C "../Plugins" -f Makefile.psp clean
 
 distrib: all
-	@mkdir "dist" || true
-	@mkdir "dist/$(DISTRIB_NAME)" || true
-	@cp "bin/EBOOT.PBP" "dist/$(DISTRIB_NAME)/EBOOT.PBP"
-	@cp "bin/ags321.prx" "dist/$(DISTRIB_NAME)/ags321.prx"
-	@cp "bin/kernel.prx" "dist/$(DISTRIB_NAME)/kernel.prx"
-	@cp "bin/exception.prx" "dist/$(DISTRIB_NAME)/exception.prx"
-	@cp "bin/psp.cfg" "dist/$(DISTRIB_NAME)/psp.cfg"
-	@cp "readme.md" "dist/$(DISTRIB_NAME)/readme.txt"
-	@cp "../License.txt" "dist/$(DISTRIB_NAME)/License.txt"
-	@cp "../Copyright.txt" "dist/$(DISTRIB_NAME)/License.txt"
-	@make distrib -C "../Plugins" -f Makefile.psp
+	@mkdir -p "$(DIST_PREFIX)"
+	@cp "bin/EBOOT.PBP" "$(DIST_PREFIX)/EBOOT.PBP"
+	@cp "bin/ags321.prx" "$(DIST_PREFIX)/ags321.prx"
+	@cp "bin/kernel.prx" "$(DIST_PREFIX)/kernel.prx"
+	@cp "bin/exception.prx" "$(DIST_PREFIX)/exception.prx"
+	@cp "bin/psp.cfg" "$(DIST_PREFIX)/psp.cfg"
+	@cp "README.md" "$(DIST_PREFIX)/readme.txt"
+	@cp "../License.txt" "$(DIST_PREFIX)/License.txt"
+	@cp "../Copyright.txt" "$(DIST_PREFIX)/License.txt"
+	@$(MAKE) -C "../Plugins" -f Makefile.psp distrib
 
-clean:
-	make cleankernelprx
-	make cleanexceptionprx
-	make cleanlaunchereboot
-	make cleanengineprx
-	make cleanallplugins
+clean: cleankernelprx cleanexceptionprx cleanlaunchereboot cleanengineprx cleanallplugins

--- a/Plugins/Makefile.psp
+++ b/Plugins/Makefile.psp
@@ -1,83 +1,85 @@
-DISTRIB_NAME = AGS_Runtime_for_PSP_3.21_R9
-PSP_AGS_FOLDER = "j:/psp/game/ags"
+DISTRIB_NAME?=AGS_Runtime_for_PSP_3.21_R9
+PSP_AGS_FOLDER?=j:/psp/game/ags
+COPY?=0
+
+DIST_PREFIX=../PSP/dist/$(DISTRIB_NAME)
 
 all: blend snowrain flashlight lua spritefont parallax
 
 blend:
-	@make -C "agsblend" -f Makefile.psp
+	@$(MAKE) -C "agsblend" -f Makefile.psp
 	@cp "agsblend/agsblend.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "agsblend/agsblend.prx" $(PSP_AGS_FOLDER)
 endif
 
 snowrain:
-	@make -f Makefile.psp -C "ags_snowrain"
+	@$(MAKE) -C "ags_snowrain" -f Makefile.psp
 	@cp "ags_snowrain/ags_snowrain.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "ags_snowrain/ags_snowrain.prx" $(PSP_AGS_FOLDER)
 endif
 
 flashlight:
-	@make -f Makefile.psp -C "AGSflashlight"
+	@$(MAKE) -C "AGSflashlight" -f Makefile.psp
 	@cp "AGSflashlight/agsflashlight.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "AGSflashlight/agsflashlight.prx" $(PSP_AGS_FOLDER)
 endif
 
 lua:
-	@make -f Makefile.psp -C "agslua"
+	@$(MAKE) -C "agslua" -f Makefile.psp
 	@cp "agslua/agslua.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "agslua/agslua.prx" $(PSP_AGS_FOLDER)
 endif
 
 spritefont:
-	@make -f Makefile.psp -C "AGSSpriteFont"
+	@$(MAKE) -C "AGSSpriteFont" -f Makefile.psp
 	@cp "AGSSpriteFont/agsspritefont.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "AGSSpriteFont/agsspritefont.prx" $(PSP_AGS_FOLDER)
 endif
 
 parallax:
-	@make -f Makefile.psp -C "ags_parallax"
+	@$(MAKE) -C "ags_parallax" -f Makefile.psp
 	@cp "ags_parallax/ags_parallax.prx" "../PSP/bin"
 ifeq ($(COPY), 1)
 	@cp "ags_parallax/ags_parallax.prx" $(PSP_AGS_FOLDER)
 endif
 
 cleanblend:
-	@make clean -f Makefile.psp -C "agsblend"
+	@$(MAKE) -C "agsblend" -f Makefile.psp clean
 	@rm -f "../PSP/bin/agsblend.prx"
-	
+
 cleansnowrain:
-	@make clean -f Makefile.psp -C "ags_snowrain"
+	@$(MAKE) -C "ags_snowrain" -f Makefile.psp clean
 	@rm -f "../PSP/bin/ags_snowrain.prx"
 
 cleanflashlight:
-	@make clean -f Makefile.psp -C "agsflashlight"
+	@$(MAKE) -C "agsflashlight" -f Makefile.psp clean
 	@rm -f "../PSP/bin/agsflashlight.prx"
 
 cleanlua:
-	@make clean -f Makefile.psp -C "agslua"
+	@$(MAKE) -C "agslua" -f Makefile.psp clean
 	@rm -f "../PSP/bin/agslua.prx"
 
 cleanspritefont:
-	@make clean -f Makefile.psp -C "agsspritefont"
+	@$(MAKE) -C "agsspritefont" -f Makefile.psp clean
 	@rm -f "../PSP/bin/agsspritefont.prx"
 
 cleanparallax:
-	@make clean -f Makefile.psp -C "ags_parallax"
+	@$(MAKE) -C "ags_parallax" -f Makefile.psp clean
 	@rm -f "../PSP/bin/ags_parallax.prx"
 
 distrib:
-	@mkdir "../PSP/dist" || true
-	@mkdir "../PSP/dist/$(DISTRIB_NAME)" || true
-	@cp "../PSP/bin/ags_snowrain.prx" "../PSP/dist/$(DISTRIB_NAME)/ags_snowrain.prx"
-	@cp "../PSP/bin/agsblend.prx" "../PSP/dist/$(DISTRIB_NAME)/agsblend.prx"
-	@cp "../PSP/bin/agsflashlight.prx" "../PSP/dist/$(DISTRIB_NAME)/agsflashlight.prx"
-	@cp "../PSP/bin/agslua.prx" "../PSP/dist/$(DISTRIB_NAME)/agslua.prx"
-	@cp "../PSP/bin/agsspritefont.prx" "../PSP/dist/$(DISTRIB_NAME)/agsspritefont.prx"
-	@cp "../PSP/bin/ags_parallax.prx" "../PSP/dist/$(DISTRIB_NAME)/ags_parallax.prx"
-	@cp "agsblend/License.txt" "../PSP/dist/$(DISTRIB_NAME)/License_AGSBlend.txt"
+	@mkdir -p "$(DIST_PREFIX)"
+	@cp "../PSP/bin/ags_snowrain.prx" "$(DIST_PREFIX)/ags_snowrain.prx"
+	@cp "../PSP/bin/agsblend.prx" "$(DIST_PREFIX)/agsblend.prx"
+	@cp "../PSP/bin/agsflashlight.prx" "$(DIST_PREFIX)/agsflashlight.prx"
+	@cp "../PSP/bin/agslua.prx" "$(DIST_PREFIX)/agslua.prx"
+	@cp "../PSP/bin/agsspritefont.prx" "$(DIST_PREFIX)/agsspritefont.prx"
+	@cp "../PSP/bin/ags_parallax.prx" "$(DIST_PREFIX)/ags_parallax.prx"
+	@cp "agsblend/License.txt" "$(DIST_PREFIX)/License_AGSBlend.txt"
 
 clean: cleanblend cleansnowrain cleanflashlight cleanlua cleanspritefont cleanparallax

--- a/Plugins/ags_parallax/ags_parallax.cpp
+++ b/Plugins/ags_parallax/ags_parallax.cpp
@@ -55,6 +55,13 @@ typedef struct
 #define MAX_SPRITES 100
 sprite_t sprites[MAX_SPRITES];
 
+// workaround to fix this error:
+//   psp-fixup-imports ags_parallax.elf
+//   Error, no .lib.stub section found
+void dummy()
+{
+  void *tmp = new int;
+}
 
 #if defined(ENABLE_SAVING)
 void RestoreGame(FILE* file)


### PR DESCRIPTION
Changes to assist in building PSP builds in teamcity.

(against master so it can be merged into develop-* branches)