### PR TITLE
Read and remove Zone Identifier on the help file.

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -328,6 +328,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="Resources\ResourceManager.cs" />
+    <Compile Include="Utils\AlternateStreams.cs" />
     <Compile Include="Utils\SourceControlProvider.cs" />
     <Compile Include="Enums\SpriteImportMethod.cs" />
     <Compile Include="GUI\TabbedDocumentManager.cs">

--- a/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
@@ -67,27 +67,36 @@ namespace AGS.Editor.Components
 
         public override void CommandClick(string controlID)
         {
-            if (controlID == ABOUT_AGS_COMMAND)
+            if (controlID == CRASH_EDITOR_COMMAND)
+            {
+                throw new AGSEditorException("Crash test");
+            }
+            else if (controlID == ABOUT_AGS_COMMAND)
             {
                 AboutDialog dialog = new AboutDialog();
                 dialog.ShowDialog();
                 dialog.Dispose();
+                return;
             }
             else if (controlID == VISIT_AGS_WEBSITE)
             {
                 LaunchBrowserAtAGSWebsite();
+                return;
             }
             else if (controlID == VISIT_AGS_FORUMS)
             {
                 LaunchBrowserAtAGSForums();
+                return;
             }
             else if (controlID == CHECK_FOR_UPDATES)
             {
                 CheckForUpdates();
+                return;
             }
             else if (!File.Exists(_helpFileName))
             {
                 _guiController.ShowMessage("The help file '" + _helpFileName + "' is missing. You may need to reinstall AGS.", MessageBoxIcon.Warning);
+                return;
             }
             else if (Utils.AlternateStreams.GetZoneIdentifier(_helpFileName) > Utils.AlternateStreams.URLZONE_LOCAL_MACHINE)
             {
@@ -100,10 +109,15 @@ namespace AGS.Editor.Components
                     else
                     {
                         _guiController.ShowMessage("The help file couldn't be unblocked. Please try running the AGS editor using 'Run as administrator' and try to unblock the file again.", MessageBoxIcon.Warning);
+                        return;
                     }
-                }  
+                }
+                else
+                {
+                    return;
+                }
             }
-            else if (controlID == LAUNCH_HELP_COMMAND)
+            if (controlID == LAUNCH_HELP_COMMAND)
             {
                 string keyword = string.Empty;
                 if (_guiController.ActivePane != null)
@@ -119,10 +133,6 @@ namespace AGS.Editor.Components
             else if (controlID == HELP_INDEX_COMMAND)
             {
                 Help.ShowHelpIndex(GetHelpParentWindow(), _helpFileName);
-            }
-            else if (controlID == CRASH_EDITOR_COMMAND)
-            {
-                throw new AGSEditorException("Crash test");
             }
         }
 

--- a/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
@@ -89,6 +89,20 @@ namespace AGS.Editor.Components
             {
                 _guiController.ShowMessage("The help file '" + _helpFileName + "' is missing. You may need to reinstall AGS.", MessageBoxIcon.Warning);
             }
+            else if (Utils.AlternateStreams.GetZoneIdentifier(_helpFileName) > Utils.AlternateStreams.URLZONE_LOCAL_MACHINE)
+            {
+                if (_guiController.ShowQuestion("The help file '" + _helpFileName + "' has a restrictive Zone Identifier which needs to be removed." + Environment.NewLine + Environment.NewLine + "Do you want to try unblocking this file?") == DialogResult.Yes)
+                {
+                    if (Utils.AlternateStreams.DeleteZoneIdentifier(_helpFileName))
+                    {
+                        _guiController.ShowMessage("The help file was unblocked successfully.", MessageBoxIcon.Warning);
+                    }
+                    else
+                    {
+                        _guiController.ShowMessage("The help file couldn't be unblocked. Please try running the AGS editor using 'Run as administrator' and try to unblock the file again.", MessageBoxIcon.Warning);
+                    }
+                }  
+            }
             else if (controlID == LAUNCH_HELP_COMMAND)
             {
                 string keyword = string.Empty;

--- a/Editor/AGS.Editor/Utils/AlternateStreams.cs
+++ b/Editor/AGS.Editor/Utils/AlternateStreams.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace AGS.Editor.Utils
+{
+    internal class AlternateStreams
+    {
+        public const uint URLZONE_PREDEFINED_MIN = 0;
+        public const uint URLZONE_LOCAL_MACHINE = 0;
+        public const uint URLZONE_INTRANET = 1;
+        public const uint URLZONE_TRUSTED = 2;
+        public const uint URLZONE_INTERNET = 3;
+        public const uint URLZONE_UNTRUSTED = 4;
+        public const uint URLZONE_PREDEFINED_MAX = 999;
+        public const uint URLZONE_USER_MIN = 1000;
+        public const uint URLZONE_USER_MAX = 10000;
+
+        private const uint FILE_ATTRIBUTE_NORMAL = 0x80;
+        private const uint GENERIC_ALL = 0x10000000;
+        private const uint FILE_SHARE_READ = 0x00000001;
+        private const uint OPEN_EXISTING = 3;
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        static extern SafeFileHandle CreateFile(string lpFileName, uint dwDesiredAccess,
+            uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition,
+            uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool DeleteFile(string name);
+
+        private static SafeFileHandle GetSafeFileHandle(string path, string streamName)
+        {
+            string streamPath = path + ":" + streamName;
+
+            SafeFileHandle handle = CreateFile(streamPath, GENERIC_ALL,
+                FILE_SHARE_READ, IntPtr.Zero, OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL, IntPtr.Zero);
+                
+            return handle;
+        }
+
+        private static string[] ReadTextFromAlternateStream(string path, string streamName)
+        {
+            List<string> alternateStreamText = new List<string>();
+
+            using (SafeFileHandle handle = GetSafeFileHandle(path, streamName))
+            {
+                if (handle.IsInvalid)
+                {
+                    return alternateStreamText.ToArray();
+                }
+                using (FileStream fileStream = new FileStream(handle, FileAccess.Read))
+                {
+                    using (StreamReader reader = new StreamReader(fileStream))
+                    {
+                        string line;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            alternateStreamText.Add(line);
+                        }
+
+                    }
+                }
+            }
+            
+            return alternateStreamText.ToArray();
+        }
+
+        public static uint GetZoneIdentifier(string path)
+        {
+            string[] text = ReadTextFromAlternateStream(path, "Zone.Identifier");
+            string[] keyValue;
+
+            try
+            {
+                keyValue = text[1].Split('=');
+            }
+            catch
+            {
+                return URLZONE_LOCAL_MACHINE;
+            }
+
+            if (keyValue[0].ToLower() == "zoneid" && keyValue.Length == 2)
+            {
+                uint zoneNumber;
+                if (UInt32.TryParse(keyValue[1], out zoneNumber))
+                {
+                    return zoneNumber;
+                }
+            }
+            
+            return URLZONE_LOCAL_MACHINE;
+        }
+
+        public static bool DeleteZoneIdentifier(string path)
+        {
+            return DeleteAlternateStream(path, "Zone.Identifier");
+        }
+
+        private static bool DeleteAlternateStream(string path, string streamName)
+        {
+            return DeleteFile(path + ":" + streamName);
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/AlternateStreams.cs
+++ b/Editor/AGS.Editor/Utils/AlternateStreams.cs
@@ -20,7 +20,7 @@ namespace AGS.Editor.Utils
         public const uint URLZONE_USER_MAX = 10000;
 
         private const uint FILE_ATTRIBUTE_NORMAL = 0x80;
-        private const uint GENERIC_ALL = 0x10000000;
+        private const uint GENERIC_READ = 0x80000000;
         private const uint FILE_SHARE_READ = 0x00000001;
         private const uint OPEN_EXISTING = 3;
 
@@ -37,7 +37,7 @@ namespace AGS.Editor.Utils
         {
             string streamPath = path + ":" + streamName;
 
-            SafeFileHandle handle = CreateFile(streamPath, GENERIC_ALL,
+            SafeFileHandle handle = CreateFile(streamPath, GENERIC_READ,
                 FILE_SHARE_READ, IntPtr.Zero, OPEN_EXISTING,
                 FILE_ATTRIBUTE_NORMAL, IntPtr.Zero);
                 


### PR DESCRIPTION
Add utility class to read and delete NTFS alternate streams. If the help
file exists check it's zone identifier, remove if it's potentially
restrictive.