### PR TITLE
IniFile class and reading game config from the generic key-value map

### DIFF
--- a/Common/util/ini_util.cpp
+++ b/Common/util/ini_util.cpp
@@ -1,0 +1,175 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#include <memory>
+#include "util/file.h"
+#include "util/ini_util.h"
+#include "util/inifile.h"
+#include "util/stream.h"
+#include "util/textstreamwriter.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+typedef std::auto_ptr<Stream>         AStream;
+typedef IniFile::SectionIterator      SectionIterator;
+typedef IniFile::ConstSectionIterator CSectionIterator;
+typedef IniFile::ItemIterator         ItemIterator;
+typedef IniFile::ConstItemIterator    CItemIterator;
+
+static bool ReadIni(const String &file, IniFile &ini)
+{
+    AStream fs(File::OpenFileRead(file));
+    if (fs.get())
+    {
+        ini.Read(fs.get());
+        return true;
+    }
+    return false;
+}
+
+bool IniUtil::Read(const String &file, ConfigTree &tree)
+{
+    // Read ini content
+    IniFile ini;
+    if (!ReadIni(file, ini))
+        return false;
+
+    // Copy items into key-value tree
+    for (CSectionIterator sec = ini.CBegin(); sec != ini.CEnd(); ++sec)
+    {
+        if (!sec->GetItemCount())
+            continue; // skip empty sections
+        StringMap &subtree = tree[sec->GetName()];
+        for (CItemIterator item = sec->CBegin(); item != sec->CEnd(); ++item)
+        {
+            if (!item->IsKeyValue())
+                continue; // skip non key-value items
+            subtree[item->GetKey()] = item->GetValue();
+        }
+    }
+    return true;
+}
+
+void IniUtil::Write(const String &file, const ConfigTree &tree)
+{
+    AStream fs(File::CreateFile(file));
+    TextStreamWriter writer(fs.get());
+
+    for (ConfigNode it_sec = tree.begin(); it_sec != tree.end(); ++it_sec)
+    {
+        const String &sec_key     = it_sec->first;
+        const StringMap &sec_tree = it_sec->second;
+
+        if (!sec_tree.size())
+            continue; // skip empty sections
+        // write section name
+        if (!sec_key.IsEmpty())
+        {
+            writer.WriteFormat("[%s]", sec_key.GetCStr());
+            writer.WriteLineBreak();
+        }
+        // write all items
+        for (StrStrIter keyval = sec_tree.begin(); keyval != sec_tree.end(); ++keyval)
+        {
+            const String &item_key   = keyval->first;
+            const String &item_value = keyval->second;
+
+            writer.WriteFormat("%s = %s", item_key.GetCStr(), item_value.GetCStr());
+            writer.WriteLineBreak();
+        }
+    }
+
+    writer.ReleaseStream();
+}
+
+void IniUtil::Merge(const String &file, const ConfigTree &tree)
+{
+    // Read ini content
+    IniFile ini;
+    ReadIni(file, ini); // NOTE: missing file is a valid case
+
+    // Remember the sections we find in file, if some sections are not found,
+    // they will be appended to the end of file.
+    std::map<String, bool> sections_found;
+    for (ConfigNode it = tree.begin(); it != tree.end(); ++it)
+        sections_found[it->first] = false;
+
+    // Merge existing sections
+    for (SectionIterator sec = ini.Begin(); sec != ini.End(); ++sec)
+    {
+        if (!sec->GetItemCount())
+            continue; // skip empty sections
+        String secname = sec->GetName();
+        ConfigNode tree_node = tree.find(secname);
+        if (tree_node == tree.end())
+            continue; // this section is not interesting for us
+
+        // Remember the items we find in this section, if some items are not found,
+        // they will be appended to the end of section.
+        const StringMap &subtree = tree_node->second;
+        std::map<String, bool> items_found;
+        for (StrStrIter keyval = subtree.begin(); keyval != subtree.end(); ++keyval)
+            items_found[keyval->first] = false;
+
+        // Replace matching items
+        for (ItemIterator item = sec->Begin(); item != sec->End(); ++item)
+        {
+            String key        = item->GetKey();
+            StrStrIter keyval = subtree.find(key);
+            if (keyval == subtree.end())
+                continue; // this item is not interesting for us
+
+            String old_value = item->GetValue();
+            String new_value = keyval->second;
+            if (old_value != new_value)
+                item->SetValue(new_value);
+            items_found[key] = true;
+        }
+
+        // Append new items
+        if (!sections_found[secname])
+        {
+            int added_count = 0;
+            for (std::map<String, bool>::const_iterator item_f = items_found.begin(); item_f != items_found.end(); ++item_f)
+            {
+                if (item_f->second)
+                    continue; // item was already found
+                StrStrIter keyval = subtree.find(item_f->first);
+                ini.InsertItem(sec, sec->End(), keyval->first, keyval->second);
+            }
+            sections_found[secname] = true; // mark section as known
+        }
+    }
+
+    // Add new sections
+    for (std::map<String, bool>::const_iterator sec_f = sections_found.begin(); sec_f != sections_found.end(); ++sec_f)
+    {
+        if (sec_f->second)
+            continue;
+        SectionIterator sec = ini.InsertSection(ini.End(), sec_f->first);
+        const StringMap &subtree = tree.find(sec_f->first)->second;
+        for (StrStrIter keyval = subtree.begin(); keyval != subtree.end(); ++keyval)
+            ini.InsertItem(sec, sec->End(), keyval->first, keyval->second);
+    }
+
+    // Write the resulting set of lines
+    AStream fs(File::CreateFile(file));
+    ini.Write(fs.get());
+}
+
+} // namespace Common
+} // namespace AGS

--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -1,0 +1,60 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Functions for exchanging configuration data between key-value tree and
+// INI file.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__INIUTIL_H
+#define __AGS_CN_UTIL__INIUTIL_H
+
+#include <map>
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+typedef std::map<String, String>    StringMap;
+typedef StringMap::const_iterator   StrStrIter;
+
+typedef std::map<String, StringMap> ConfigTree;
+typedef ConfigTree::const_iterator  ConfigNode;
+
+namespace IniUtil
+{
+    // Parse the contents of given file as INI format and insert values
+    // into the tree. The pre-existing tree items, if any, are NOT erased.
+    bool Read(const String &file, ConfigTree &tree);
+    // Serialize given tree to the stream in INI text format.
+    // The INI format suggests only one nested level (group - items).
+    // The first level values are treated as a global section items.
+    // The sub-nodes beyond 2nd level are ignored completely.
+    void Write(const String &file, const ConfigTree &tree);
+    // Parse the contents of given source stream as INI format and merge
+    // with values of the given tree while doing only minimal replaces;
+    // write the result into destination stream.
+    // If item already exists, only value is overwrited, if section exists,
+    // new items are appended to the end of it; completely new sections are
+    // appended to the end of text.
+    // Source and destination streams may refer either to different objects,
+    // or same stream opened for both reading and writing.
+    void Merge(const String &file, const ConfigTree &tree);
+};
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__INIUTIL_H

--- a/Common/util/inifile.cpp
+++ b/Common/util/inifile.cpp
@@ -1,0 +1,301 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#include <cctype>
+#include <cstring>
+#include "util/inifile.h"
+#include "util/textstreamreader.h"
+#include "util/textstreamwriter.h"
+
+// TODO: replace with C++11 std::isblank library function
+namespace agsstd
+{
+inline int isblank(int ch)
+{
+    return ch == ' ' || ch == '\t';
+}
+} // std
+
+namespace AGS
+{
+namespace Common
+{
+
+inline static void ReplaceSubString(String &line, IniFile::StrPos &sub_pos, const String &new_sub)
+{
+    line.ReplaceMid(sub_pos.first, sub_pos.second - sub_pos.first, new_sub);
+}
+
+IniFile::ItemDef::ItemDef(const String &key, const String &value)
+{
+    Line = String::FromFormat("%s=%s", key.GetCStr(), value.GetCStr());
+    Key.first = 0;
+    Key.second = Key.first + key.GetLength();
+    SepAt = Key.second;
+    Value.first = Key.second + 1;
+    Value.second = Value.first + value.GetLength();
+}
+
+IniFile::ItemDef::ItemDef(const String &line, const StrPos &key, const StrPos &value, int sep_at)
+{
+    Line = line;
+    Key = key;
+    Value = value;
+    SepAt = sep_at;
+}
+
+void IniFile::ItemDef::SetKey(const String &key)
+{
+    if (key.IsEmpty())
+        return;
+
+    if (IsKeyValue())
+    {
+        int diff = key.GetLength() - (Key.second - Key.first);
+        ReplaceSubString(Line, Key, key);
+        Key.second += diff;
+        Value.first += diff;
+        Value.second += diff;
+    }
+    else
+    {
+        *this = ItemDef(key, "");
+    }
+}
+
+void IniFile::ItemDef::SetValue(const String &value)
+{
+    if (!IsKeyValue())
+        return; // no key
+
+    if (SepAt > 0)
+    {   // replacing existing value
+        int diff = value.GetLength() - (Value.second - Value.first);
+        ReplaceSubString(Line, Value, value);
+        Value.second += diff;
+    }
+    else
+    {   // inserting value behind the key
+        StrPos valpos(Key.second, Key.second);
+        ReplaceSubString(Line, valpos, String::FromFormat("=%s", value.GetCStr()));
+    }
+}
+
+IniFile::SectionDef::SectionDef(const String &name)
+{
+    if (name.IsEmpty())
+    {
+        // global section
+        Name = StrPos(0,0);
+    }
+    else
+    {
+        // named section
+        Header = String::FromFormat("[%s]", name.GetCStr());
+        Name.first = 1;
+        Name.second = 1 + Header.GetLength();
+    }
+}
+
+IniFile::SectionDef::SectionDef(const String &line, const StrPos &name)
+{
+    Header = line;
+    Name = name;
+}
+
+void IniFile::SectionDef::SetName(const String &sec_name)
+{
+    if (sec_name.IsEmpty())
+        return;
+
+    int diff = sec_name.GetLength() - (Name.second - Name.first);
+    ReplaceSubString(Header, Name, sec_name);
+    Name.second += diff;
+}
+
+void IniFile::SectionDef::Clear()
+{
+    Items.clear();
+}
+
+IniFile::ItemIterator IniFile::SectionDef::InsertItem(ItemIterator item, const ItemDef &itemdef)
+{
+    return Items.insert(item, itemdef);
+}
+
+void IniFile::SectionDef::EraseItem(ItemIterator item)
+{
+    Items.erase(item);
+}
+
+IniFile::ItemIterator IniFile::InsertItem(SectionIterator sec, ItemIterator item, const String &key, const String &value)
+{
+    ItemDef itemdef(key, value);
+    return sec->InsertItem(item, itemdef);
+}
+
+IniFile::SectionIterator IniFile::InsertSection(SectionIterator sec, const String &name)
+{
+    if (name.IsEmpty())
+        return _sections.end(); // do not allow adding random global sections
+
+    SectionDef secdef(name);
+    return _sections.insert(sec, secdef);
+}
+
+void IniFile::RemoveItem(SectionIterator sec, ItemIterator item)
+{
+    sec->EraseItem(item);
+}
+
+void IniFile::RemoveSection(SectionIterator sec)
+{
+    if (sec == _sections.begin())
+        // do not remove global section, clear items instead
+        sec->Clear();
+    else
+        _sections.erase(sec);
+}
+
+
+// Moves string pointer forward to the first non-space character
+const char *SkipSpace(const char *line, const char *endl)
+{
+    for (; line != endl && isspace(*line); ++line);
+    return line;
+}
+
+// Parse given line and extract a meaningful string;
+// Parses line from 'line' to 'endl', skips padding (spaces)
+// at the beginning and the end. Assignes the starting and ending
+// pointers of the string. Returns pointer to where parsing stopped.
+// The 'endl' must point beyond the last character of the string
+// (e.g. terminator).
+const char *ParsePaddedString(const char *line, const char *endl,
+                              const char *&str_at, const char *&str_end)
+{
+    // skip left padding
+    for (; line != endl && agsstd::isblank(*line); ++line);
+    str_at = line;
+    // skip right padding
+    const char *p_value = line;
+    for (line = endl; line != p_value && agsstd::isblank(*(line - 1)); --line);
+    str_end = line;
+    return line;
+}
+
+IniFile::IniFile()
+{
+    // precreate global section
+    _sections.push_back(SectionDef(""));
+}
+
+void IniFile::Read(Stream *in)
+{
+    TextStreamReader reader(in);
+    
+    _sections.clear();
+    // Create a global section;
+    // all the items we meet before explicit section declaration
+    // will be treated as "global" items.
+    _sections.push_back(SectionDef(""));
+    SectionDef *cur_section = &_sections.back();
+
+    do
+    {
+        String line = reader.ReadLine();
+        if (line.IsEmpty() && reader.EOS())
+            break;
+
+        const char *cstr = line.GetCStr();
+        const char *pstr = cstr;
+        const char *endl = cstr + line.GetLength();
+
+        // Find first non-space character
+        pstr = SkipSpace(pstr, endl);
+        if (pstr == endl)
+            continue; // empty line
+
+        // Detect the kind of string we found
+        if ((endl - pstr >= 2 && *pstr == '/' && *(pstr + 1) == '/') ||
+            (endl - pstr >= 1 && (*pstr == '#' || *pstr == ';')))
+        {
+            StrPos nullpos(0,0);
+            cur_section->InsertItem(cur_section->End(), ItemDef(line, nullpos, nullpos, -1));
+            continue;
+        }
+
+        if (*pstr == '[')
+        {
+            // Parse this as section
+            const char *pstr_end = strrchr(pstr, ']');
+            if (pstr_end < pstr)
+                continue; // no closing bracket
+            // Parse the section name
+            const char *str_at, *str_end;
+            ParsePaddedString(++pstr, pstr_end, str_at, str_end);
+            if (str_end == str_at)
+                continue; // inappropriate data or empty string
+            StrPos namepos(str_at - cstr, str_end - cstr);
+            _sections.push_back(SectionDef(line, namepos));
+            cur_section = &_sections.back();
+        }
+        else
+        {
+            // Parse this as a key-value pair
+            const char *pstr_end = strchr(pstr, '=');
+            if (pstr_end == pstr)
+                continue; // no key part, skip the line
+            if (!pstr_end)
+                pstr_end = endl; // no value part
+            // Parse key
+            const char *str_at, *str_end;
+            ParsePaddedString(pstr, pstr_end, str_at, str_end);
+            pstr = pstr_end;
+            if (str_end == str_at)
+                continue; // inappropriate data or empty string
+            // Create an item and parse value, if any
+            StrPos keypos(str_at - cstr, str_end - cstr);
+            StrPos valpos(0, 0);
+            int sep_at = -1;
+            if (pstr != endl)
+            {
+                sep_at = pstr - cstr;
+                ParsePaddedString(++pstr, endl, str_at, str_end);
+                valpos.first = str_at - cstr;
+                valpos.second = str_end - cstr;
+            }
+            cur_section->InsertItem(cur_section->End(), ItemDef(line, keypos, valpos, sep_at));
+        }
+    }
+    while (!reader.EOS());
+
+    reader.ReleaseStream();
+}
+
+void IniFile::Write(Stream *out) const
+{
+    TextStreamWriter writer(out);
+    for (ConstSectionIterator sec = _sections.begin(); sec != _sections.end(); ++sec)
+    {
+        if (sec != _sections.begin()) // do not write global section's name
+            writer.WriteLine(sec->GetLine());
+        for (ConstItemIterator item = sec->CBegin(); item != sec->CEnd(); ++item)
+            writer.WriteLine(item->GetLine());
+    }
+    writer.ReleaseStream();
+}
+
+} // namespace Common
+} // namespace AGS

--- a/Common/util/inifile.h
+++ b/Common/util/inifile.h
@@ -1,0 +1,136 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// IniFile class defines contents of the configuration file.
+// It serves as a INI parser and plain enumerator of all the sections and items
+// found in file, or, oppositely, as INI file constructor.
+// But is not much suitable for regular key/value lookup. It is suggested to
+// create a proper map to store items, from IniFile contents.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__INIFILE_H
+#define __AGS_CN_UTIL__INIFILE_H
+
+#include <list>
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+class IniFile
+{
+public:
+    // Position of a string in the line of text:
+    // is defined by a pair of first and next-after-last character indices
+    typedef std::pair<int, int> StrPos;
+    // Location of section in the array of text lines:
+    // is defined by a pair of first and next-after-last line indices
+    typedef std::pair<int, int> SectionPos;
+
+    // Item definition
+    // Valid key indicates a key-value line; no key means unparsed
+    // line of text, e.g. comment or incorrectly formatted item.
+    class ItemDef
+    {
+    public:
+        ItemDef(const String &key, const String &value);
+        ItemDef(const String &line, const StrPos &key, const StrPos &value, int sep_at);
+        String GetLine()  const { return Line; }
+        String GetKey()   const { return SubString(Line, Key); }
+        String GetValue() const { return SubString(Line, Value); }
+        bool   IsKeyValue() const { return Key.second - Key.first > 0; }
+        void SetKey(const String &key);
+        void SetValue(const String &value);
+
+    private:
+        String  Line;  // actual text
+        StrPos  Key;   // position of item key
+        int     SepAt; // position of the separator (assignment) symbol
+        StrPos  Value; // position of item value
+    };
+    // Linked list of items
+    typedef std::list<ItemDef> LItems;
+    typedef LItems::iterator          ItemIterator;
+    typedef LItems::const_iterator    ConstItemIterator;
+
+    // Section definition
+    class SectionDef
+    {
+    public:
+        SectionDef(const String &name);
+        SectionDef(const String &line, const StrPos &name);
+        String GetLine() const { return Header; }
+        String GetName() const { return SubString(Header, Name); }
+        size_t GetItemCount() const { return Items.size(); }
+        bool   IsGlobal() const { return Name.second - Name.first <= 0; }
+        ItemIterator Begin() { return Items.begin(); }
+        ItemIterator End()   { return Items.end(); }
+        ConstItemIterator CBegin() const { return Items.begin(); }
+        ConstItemIterator CEnd()   const { return Items.end(); }
+        void SetName(const String &sec_name);
+        void Clear();
+        ItemIterator InsertItem(ItemIterator item, const ItemDef &itemdef);
+        void EraseItem(ItemIterator item);
+
+    private:
+        String      Header;// section's heading line
+        StrPos      Name;  // location of section name in the header line
+        LItems      Items; // linked list of items belonging to the section
+    };
+    // Linked list of sections
+    typedef std::list<SectionDef>     LSections;
+    typedef LSections::iterator       SectionIterator;
+    typedef LSections::const_iterator ConstSectionIterator;
+
+private:
+    inline static String SubString(const String &line, const StrPos &pos)
+    {
+        return line.Mid(pos.first, pos.second - pos.first);
+    }
+
+public:
+    IniFile();
+
+    SectionIterator Begin() { return _sections.begin(); }
+    SectionIterator End()   { return _sections.end(); }
+    ConstSectionIterator CBegin() const { return _sections.begin(); }
+    ConstSectionIterator CEnd()   const { return _sections.end(); }
+
+    void Read(Stream *in);
+    void Write(Stream *out) const;
+
+    // Return number of sections
+    size_t GetSectionCount() const { return _sections.size(); }
+    // Insert new item *before* existing item
+    ItemIterator InsertItem(SectionIterator sec, ItemIterator item, const String &key, const String &value);
+    // Insert new section *before* existing section
+    SectionIterator InsertSection(SectionIterator sec, const String &name);
+    // Remove a single item
+    void RemoveItem(SectionIterator sec, ItemIterator item);
+    // Completely remove whole section; this removes all lines between section
+    // header and the last item found in that section (inclusive).
+    void RemoveSection(SectionIterator sec);
+
+private:
+    void MakeItemDef(const String &key, const String &value, ItemDef &itemdef);
+
+    LSections _sections;
+};
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__INIFILE_H

--- a/Common/util/math.h
+++ b/Common/util/math.h
@@ -53,7 +53,7 @@ namespace Math
         }
         else if (from >= floor + height)
         {
-            from = 0;
+            from = floor + height;
             length = 0;
         }
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -634,6 +634,21 @@ void String::Replace(char what, char with)
     }
 }
 
+void String::ReplaceMid(int from, int count, const char *cstr)
+{
+    if (!cstr)
+        cstr = "";
+    int length = strlen(cstr);
+    Math::ClampLength(0, GetLength(), from, count);
+    if (count >= 0)
+    {
+        ReserveAndShift(false, Math::Max(0, length - count));
+        memmove(_meta->CStr + from + length, _meta->CStr + from + count, GetLength() - (from + count) + 1);
+        memcpy(_meta->CStr + from, cstr, length);
+        _meta->Length += length - count;
+    }
+}
+
 void String::SetAt(int index, char c)
 {
     if (_meta && index >= 0 && index < GetLength() && c)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -216,6 +216,9 @@ public:
     void    PrependChar(char c);
     // Replaces all occurences of one character with another character
     void    Replace(char what, char with);
+    // Replaces particular substring with another substring; new substring
+    // may have different length
+    void    ReplaceMid(int from, int count, const char *cstr);
     // Overwrite the Nth character of the string; does not change string's length
     void    SetAt(int index, char c);
     // Makes a new string by copying up to N chars from C-string

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -271,6 +271,10 @@ public:
     {
         return Compare(cstr) != 0;
     }
+    inline bool operator <(const char *cstr) const
+    {
+        return Compare(cstr) < 0;
+    }
 
 private:
     // Creates new empty string with buffer enough to fit given length

--- a/Common/util/textstreamreader.cpp
+++ b/Common/util/textstreamreader.cpp
@@ -101,8 +101,6 @@ String TextStreamReader::ReadLine()
     {
         chars_read_last = _stream->Read(char_buffer, single_chunk_length);
         char *seek_ptr = char_buffer;
-        // CHECKME: is finding '\n' is enough to deduce line end?
-        // Should it be strict "\r\n" instead? Or platform-dependant line-break?
         int c;
         for (c = 0; c < chars_read_last && *seek_ptr != '\n'; ++c, ++seek_ptr);
 
@@ -138,7 +136,7 @@ String TextStreamReader::ReadLine()
         _stream->Seek(kSeekCurrent, line_break_position - chars_read_last + 1 /* beyond line feed */);
     }
 
-    str.TrimRight('\r');
+    str.TrimRight('\r'); // skip carriage-return, if any
     return str;
 }
 

--- a/Common/util/textstreamwriter.cpp
+++ b/Common/util/textstreamwriter.cpp
@@ -22,6 +22,13 @@ namespace AGS
 namespace Common
 {
 
+#if defined (WINDOWS_VERSION)
+static const char Endl[2] = {'\r', '\n'};
+#else
+static const char Endl[1] = {'\n'};
+#endif
+
+
 TextStreamWriter::TextStreamWriter(Stream *stream)
     : _stream(stream)
 {
@@ -55,13 +62,6 @@ bool TextStreamWriter::EOS() const
 
 void TextStreamWriter::WriteChar(char c)
 {
-    // Substitute line-feed character with platform-specific line break
-    if (c == '\n')
-    {
-        WriteLineBreak();
-        return;
-    }
-
     if (_stream)
     {
         _stream->WriteByte(c);
@@ -86,7 +86,7 @@ void TextStreamWriter::WriteLine(const String &str)
 
     // TODO: replace line-feed characters in string with platform-specific line break
     _stream->Write(str.GetCStr(), str.GetLength());
-    WriteLineBreak();
+    _stream->Write(Endl, sizeof(Endl));
 }
 
 void TextStreamWriter::WriteFormat(const char *fmt, ...)
@@ -113,11 +113,7 @@ void TextStreamWriter::WriteFormat(const char *fmt, ...)
 void TextStreamWriter::WriteLineBreak()
 {
     if (_stream)
-    {
-        // CHECKME: should this be platform-dependant?
-        // carriage-return & line-feed
-        _stream->Write("\r\n", 2);
-    }
+        _stream->Write(Endl, sizeof(Endl));
 }
 
 } // namespace Common

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -40,7 +40,7 @@ struct GameSetup {
     bool  prefer_letterbox;  // defines whether it is preferred to have letterbox
     AGS::Common::String data_files_dir;
     AGS::Common::String main_data_filename;
-    char *translation;
+    AGS::Common::String translation;
     AGS::Common::String gfxFilterID;
     AGS::Common::String gfxDriverID;
     int   override_script_os;

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -18,6 +18,12 @@
 #ifndef __AGS_EE_MAIN__CONFIG_H
 #define __AGS_EE_MAIN__CONFIG_H
 
+#include "util/ini_util.h"
+
 void read_config_file(char *argv0);
+
+bool INIreaditem(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item, AGS::Common::String &value);
+int INIreadint(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item);
+
 
 #endif // __AGS_EE_MAIN__CONFIG_H

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -20,6 +20,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/override_defines.h"
 #include "ac/runtime_defines.h"
+#include "main/config.h"
 #include "plugin/agsplugin.h"
 #include <stdio.h>
 #include <dirent.h>
@@ -33,12 +34,10 @@
 #include <jni.h>
 #include <android/log.h>
 
+using namespace AGS::Common;
 
 #define ANDROID_CONFIG_FILENAME "android.cfg"
 
-extern char filetouse[];
-char *INIreaditem(const char *sectn, const char *entry);
-int INIreadint (const char *sectn, const char *item, int errornosect = 1);
 bool ReadConfiguration(char* filename, bool read_everything);
 void ResetConfiguration();
 
@@ -554,7 +553,7 @@ void selectLatestSavegame()
 }
 
 
-int ReadInteger(int* variable, char* section, char* name, int minimum, int maximum, int default_value)
+int ReadInteger(int* variable, const ConfigTree &cfg, char* section, char* name, int minimum, int maximum, int default_value)
 {
   if (reset_configuration)
   {
@@ -562,7 +561,7 @@ int ReadInteger(int* variable, char* section, char* name, int minimum, int maxim
     return 0;
   }
 
-  int temp = INIreadint(section, name);
+  int temp = INIreadint(cfg, section, name);
 
   if (temp == -1)
     return 0;
@@ -577,7 +576,7 @@ int ReadInteger(int* variable, char* section, char* name, int minimum, int maxim
 
 
 
-int ReadString(char* variable, char* section, char* name, char* default_value)
+int ReadString(char* variable, const ConfigTree &cfg, char* section, char* name, char* default_value)
 {
   if (reset_configuration)
   {
@@ -585,9 +584,8 @@ int ReadString(char* variable, char* section, char* name, char* default_value)
     return 0;
   }
 
-  char* temp = INIreaditem(section, name);
-
-  if (temp == NULL)
+  String temp;
+  if (!INIreaditem(cfg, section, name, temp))
     temp = default_value;
 
   strcpy(variable, temp);
@@ -610,54 +608,47 @@ void ResetConfiguration()
 
 bool ReadConfiguration(char* filename, bool read_everything)
 {
-  FILE* test = fopen(filename, "rb");
-  if (test || reset_configuration)
+  ConfigTree cfg;
+  if (IniUtil::Read(filename, cfg) || reset_configuration)
   {
-    if (test)
-      fclose(test);
-
-    strcpy(filetouse, filename);
-
 //    ReadInteger((int*)&psp_disable_powersaving, "misc", "disable_power_saving", 0, 1, 1);
 
 //    ReadInteger((int*)&psp_return_to_menu, "misc", "return_to_menu", 0, 1, 1);
 
-    ReadString(&psp_translation[0], "misc", "translation", "default");
+    ReadString(&psp_translation[0], cfg, "misc", "translation", "default");
 
-    ReadInteger((int*)&psp_config_enabled, "misc", "config_enabled", 0, 1, 0);
+    ReadInteger((int*)&psp_config_enabled, cfg, "misc", "config_enabled", 0, 1, 0);
     if (!psp_config_enabled && !read_everything)
       return true;
 
-    ReadInteger(&psp_debug_write_to_logcat, "debug", "logging", 0, 1, 0);
-    ReadInteger(&display_fps, "debug", "show_fps", 0, 1, 0);
+    ReadInteger(&psp_debug_write_to_logcat, cfg, "debug", "logging", 0, 1, 0);
+    ReadInteger(&display_fps, cfg, "debug", "show_fps", 0, 1, 0);
     if (display_fps == 1)
       display_fps = 2;
 
-    ReadInteger((int*)&psp_rotation, "misc", "rotation", 0, 2, 0);
+    ReadInteger((int*)&psp_rotation, cfg, "misc", "rotation", 0, 2, 0);
 
 //    ReadInteger((int*)&psp_ignore_acsetup_cfg_file, "compatibility", "ignore_acsetup_cfg_file", 0, 1, 0);
-    ReadInteger((int*)&psp_clear_cache_on_room_change, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
+    ReadInteger((int*)&psp_clear_cache_on_room_change, cfg, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
 
-    ReadInteger((int*)&psp_audio_samplerate, "sound", "samplerate", 0, 44100, 44100);
-    ReadInteger((int*)&psp_audio_enabled, "sound", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_multithreaded, "sound", "threaded", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_cachesize, "sound", "cache_size", 1, 50, 10);
+    ReadInteger((int*)&psp_audio_samplerate, cfg, "sound", "samplerate", 0, 44100, 44100);
+    ReadInteger((int*)&psp_audio_enabled, cfg, "sound", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_multithreaded, cfg, "sound", "threaded", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_cachesize, cfg, "sound", "cache_size", 1, 50, 10);
 
-    ReadInteger((int*)&psp_midi_enabled, "midi", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_midi_preload_patches, "midi", "preload_patches", 0, 1, 0);
+    ReadInteger((int*)&psp_midi_enabled, cfg, "midi", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_midi_preload_patches, cfg, "midi", "preload_patches", 0, 1, 0);
 
-    ReadInteger((int*)&psp_video_framedrop, "video", "framedrop", 0, 1, 0);
+    ReadInteger((int*)&psp_video_framedrop, cfg, "video", "framedrop", 0, 1, 0);
 
-    ReadInteger((int*)&psp_gfx_renderer, "graphics", "renderer", 0, 2, 0);
-    ReadInteger((int*)&psp_gfx_smoothing, "graphics", "smoothing", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_scaling, "graphics", "scaling", 0, 2, 1);
-    ReadInteger((int*)&psp_gfx_super_sampling, "graphics", "super_sampling", 0, 1, 0);
-    ReadInteger((int*)&psp_gfx_smooth_sprites, "graphics", "smooth_sprites", 0, 1, 0);
+    ReadInteger((int*)&psp_gfx_renderer, cfg, "graphics", "renderer", 0, 2, 0);
+    ReadInteger((int*)&psp_gfx_smoothing, cfg, "graphics", "smoothing", 0, 1, 1);
+    ReadInteger((int*)&psp_gfx_scaling, cfg, "graphics", "scaling", 0, 2, 1);
+    ReadInteger((int*)&psp_gfx_super_sampling, cfg, "graphics", "super_sampling", 0, 1, 0);
+    ReadInteger((int*)&psp_gfx_smooth_sprites, cfg, "graphics", "smooth_sprites", 0, 1, 0);
 
-    ReadInteger((int*)&config_mouse_control_mode, "controls", "mouse_method", 0, 1, 0);
-    ReadInteger((int*)&config_mouse_longclick, "controls", "mouse_longclick", 0, 1, 1);
-
-    strcpy(filetouse, "nofile");
+    ReadInteger((int*)&config_mouse_control_mode, cfg, "controls", "mouse_method", 0, 1, 0);
+    ReadInteger((int*)&config_mouse_longclick, cfg, "controls", "mouse_longclick", 0, 1, 1);
 
     return true;
   }

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -25,16 +25,16 @@
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/override_defines.h"
 #include "ac/runtime_defines.h"
+#include "main/config.h"
 #include "plugin/agsplugin.h"
 #include "util/string_utils.h"
+
+using namespace AGS::Common;
 
 #define IOS_CONFIG_FILENAME "ios.cfg"
 
 extern char* ios_document_directory;
 
-extern char filetouse[];
-char *INIreaditem(const char *sectn, const char *entry);
-int INIreadint (const char *sectn, const char *item, int errornosect = 1);
 bool ReadConfiguration(char* filename, bool read_everything);
 void ResetConfiguration();
 
@@ -430,7 +430,7 @@ void selectLatestSavegame()
 }
 
 
-int ReadInteger(int* variable, char* section, char* name, int minimum, int maximum, int default_value)
+int ReadInteger(int* variable, const ConfigTree &cfg, char* section, char* name, int minimum, int maximum, int default_value)
 {
   if (reset_configuration)
   {
@@ -438,7 +438,7 @@ int ReadInteger(int* variable, char* section, char* name, int minimum, int maxim
     return 0;
   }
 
-  int temp = INIreadint(section, name);
+  int temp = INIreadint(cfg, section, name);
 
   if (temp == -1)
     return 0;
@@ -453,7 +453,7 @@ int ReadInteger(int* variable, char* section, char* name, int minimum, int maxim
 
 
 
-int ReadString(char* variable, char* section, char* name, char* default_value)
+int ReadString(char* variable, const ConfigTree &cfg, char* section, char* name, char* default_value)
 {
   if (reset_configuration)
   {
@@ -461,9 +461,8 @@ int ReadString(char* variable, char* section, char* name, char* default_value)
     return 0;
   }
 
-  char* temp = INIreaditem(section, name);
-
-  if (temp == NULL)
+  String temp;
+  if (!INIreaditem(cfg, section, name, temp))
     temp = default_value;
 
   strcpy(variable, temp);
@@ -485,54 +484,47 @@ void ResetConfiguration()
 
 bool ReadConfiguration(char* filename, bool read_everything)
 {
-  FILE* test = fopen(filename, "rb");
-  if (test || reset_configuration)
+  ConfigTree cfg;
+  if (IniUtil::Read(filename, cfg) || reset_configuration)
   {
-    if (test)
-      fclose(test);
-
-    strcpy(filetouse, filename);
-
 //    ReadInteger((int*)&psp_disable_powersaving, "misc", "disable_power_saving", 0, 1, 1);
 
 //    ReadInteger((int*)&psp_return_to_menu, "misc", "return_to_menu", 0, 1, 1);
 
-    ReadString(&psp_translation[0], "misc", "translation", "default");
+    ReadString(&psp_translation[0], cfg, "misc", "translation", "default");
 
-    ReadInteger((int*)&psp_config_enabled, "misc", "config_enabled", 0, 1, 0);
+    ReadInteger((int*)&psp_config_enabled, cfg, "misc", "config_enabled", 0, 1, 0);
     if (!psp_config_enabled && !read_everything)
       return true;
 
-    ReadInteger(&psp_debug_write_to_logcat, "debug", "logging", 0, 1, 0);
-    ReadInteger(&display_fps, "debug", "show_fps", 0, 1, 0);
+    ReadInteger(&psp_debug_write_to_logcat, cfg, "debug", "logging", 0, 1, 0);
+    ReadInteger(&display_fps, cfg, "debug", "show_fps", 0, 1, 0);
     if (display_fps == 1)
       display_fps = 2;
 
-    ReadInteger((int*)&psp_rotation, "misc", "rotation", 0, 2, 0);
+    ReadInteger((int*)&psp_rotation, cfg, "misc", "rotation", 0, 2, 0);
 
 //    ReadInteger((int*)&psp_ignore_acsetup_cfg_file, "compatibility", "ignore_acsetup_cfg_file", 0, 1, 0);
-    ReadInteger((int*)&psp_clear_cache_on_room_change, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
+    ReadInteger((int*)&psp_clear_cache_on_room_change, cfg, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
 
-    ReadInteger((int*)&psp_audio_samplerate, "sound", "samplerate", 0, 44100, 44100);
-    ReadInteger((int*)&psp_audio_enabled, "sound", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_multithreaded, "sound", "threaded", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_cachesize, "sound", "cache_size", 1, 50, 10);
+    ReadInteger((int*)&psp_audio_samplerate, cfg, "sound", "samplerate", 0, 44100, 44100);
+    ReadInteger((int*)&psp_audio_enabled, cfg, "sound", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_multithreaded, cfg, "sound", "threaded", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_cachesize, cfg, "sound", "cache_size", 1, 50, 10);
 
-    ReadInteger((int*)&psp_midi_enabled, "midi", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_midi_preload_patches, "midi", "preload_patches", 0, 1, 0);
+    ReadInteger((int*)&psp_midi_enabled, cfg, "midi", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_midi_preload_patches, cfg, "midi", "preload_patches", 0, 1, 0);
 
-    ReadInteger((int*)&psp_video_framedrop, "video", "framedrop", 0, 1, 0);
+    ReadInteger((int*)&psp_video_framedrop, cfg, "video", "framedrop", 0, 1, 0);
 
-    ReadInteger((int*)&psp_gfx_renderer, "graphics", "renderer", 0, 2, 0);
-    ReadInteger((int*)&psp_gfx_smoothing, "graphics", "smoothing", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_scaling, "graphics", "scaling", 0, 2, 1);
-    ReadInteger((int*)&psp_gfx_super_sampling, "graphics", "super_sampling", 0, 1, 0);
-    ReadInteger((int*)&psp_gfx_smooth_sprites, "graphics", "smooth_sprites", 0, 1, 0);
+    ReadInteger((int*)&psp_gfx_renderer, cfg, "graphics", "renderer", 0, 2, 0);
+    ReadInteger((int*)&psp_gfx_smoothing, cfg, "graphics", "smoothing", 0, 1, 1);
+    ReadInteger((int*)&psp_gfx_scaling, cfg, "graphics", "scaling", 0, 2, 1);
+    ReadInteger((int*)&psp_gfx_super_sampling, cfg, "graphics", "super_sampling", 0, 1, 0);
+    ReadInteger((int*)&psp_gfx_smooth_sprites, cfg, "graphics", "smooth_sprites", 0, 1, 0);
 
-    ReadInteger((int*)&config_mouse_control_mode, "controls", "mouse_method", 0, 1, 0);
-    ReadInteger((int*)&config_mouse_longclick, "controls", "mouse_longclick", 0, 1, 1);
-
-    strcpy(filetouse, "nofile");
+    ReadInteger((int*)&config_mouse_control_mode, cfg, "controls", "mouse_method", 0, 1, 0);
+    ReadInteger((int*)&config_mouse_longclick, cfg, "controls", "mouse_longclick", 0, 1, 1);
 
     return true;
   }

--- a/Engine/platform/psp/acplpsp.cpp
+++ b/Engine/platform/psp/acplpsp.cpp
@@ -32,6 +32,7 @@
 #include <allegro.h>
 
 #include "ac/runtime_defines.h"
+#include "main/config.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 
@@ -47,7 +48,7 @@ extern "C" {
 
 #include <util/string.h>
 
-using AGS::Common::String;
+using namespace AGS::Common;
 
 
 #ifdef PSP_ENABLE_PROFILING
@@ -81,10 +82,6 @@ String pspOutputDirectory;
 
 int psp_standalone;
 char psp_game_file_name[256];
-extern char filetouse[];
-
-char *INIreaditem(const char *sectn, const char *entry);
-int INIreadint (const char *sectn, const char *item, int errornosect = 1);
 
 extern void clear_sound_cache();
 
@@ -207,7 +204,7 @@ char* psp_buttons_name[] =
 };
 
 
-int GetScancodeFromKeyname(char* keyname)
+int GetScancodeFromKeyname(const char* keyname)
 {
   if (!keyname)
     return -1;
@@ -235,16 +232,14 @@ void ResetButtonConfiguration()
 }
 
 
-void ReadButtonMapping(char* section, psp_button_mapping_t* button_mapping, unsigned int &button_mapping_count, psp_mouse_config_t* mouse_mapping, psp_keyboard_config_t* keyboard_mapping)
+void ReadButtonMapping(const ConfigTree &cfg, char* section, psp_button_mapping_t* button_mapping, unsigned int &button_mapping_count, psp_mouse_config_t* mouse_mapping, psp_keyboard_config_t* keyboard_mapping)
 {
-  char* value;
+  String value;
   int scancode;
 
   for (int i = 0; i < sizeof(psp_buttons_value) / 4; i++)
   {
-    value = INIreaditem(section, psp_buttons_name[i]);
-
-    if (!value)
+    if (!INIreaditem(cfg, section, psp_buttons_name[i], value))
       continue;
 
     // Check for key command
@@ -254,7 +249,7 @@ void ReadButtonMapping(char* section, psp_button_mapping_t* button_mapping, unsi
       button_mapping[button_mapping_count].button = psp_buttons_value[i];
       button_mapping[button_mapping_count].scancode = scancode;
       button_mapping_count++;
-      printf("%s = %s (%d)\n", psp_buttons_name[i], value, scancode);
+      printf("%s = %s (%d)\n", psp_buttons_name[i], value.GetCStr(), scancode);
       continue;
     }    
 
@@ -292,15 +287,13 @@ void ReadButtonMapping(char* section, psp_button_mapping_t* button_mapping, unsi
       else if (stricmp(value, "keyboard_previous_keyset") == 0)
         keyboard_mapping->previous_keyset = psp_buttons_value[i];
     }
-
-    free(value);
   }
 }
 
 
-int ReadInteger(int* variable, char* section, char* name, int minimum, int maximum, int default_value)
+int ReadInteger(int* variable, const ConfigTree &cfg, char* section, char* name, int minimum, int maximum, int default_value)
 {
-  int temp = INIreadint(section, name);
+  int temp = INIreadint(cfg, section, name);
 
   if (temp == -1)
     return 0;
@@ -315,11 +308,10 @@ int ReadInteger(int* variable, char* section, char* name, int minimum, int maxim
 
 
 
-int ReadString(char* variable, char* section, char* name, char* default_value)
+int ReadString(char* variable, const ConfigTree &cfg, char* section, char* name, char* default_value)
 {
-  char* temp = INIreaditem(section, name);
-
-  if (temp == NULL)
+  String temp;
+  if (!INIreaditem(cfg, section, name, temp))
     temp = default_value;
 
   strcpy(variable, temp);
@@ -332,55 +324,50 @@ int ReadString(char* variable, char* section, char* name, char* default_value)
 
 void ReadConfiguration(char* filename)
 {
-  FILE* test = fopen(filename, "rb");
-  if (test)
+  ConfigTree cfg;
+  if (IniUtil::Read(filename, cfg))
   {
-    fclose(test);
-    strcpy(filetouse, filename);
-
     ResetButtonConfiguration();
 
-    ReadButtonMapping("button_mapping", psp_to_scancode, psp_to_scancode_count, &psp_mouse_mapping, NULL);
-    ReadButtonMapping("onscreen_keyboard", psp_to_scancode_osk, psp_to_scancode_osk_count, &psp_mouse_mapping_osk, &psp_keyboard_mapping);
+    ReadButtonMapping(cfg, "button_mapping", psp_to_scancode, psp_to_scancode_count, &psp_mouse_mapping, NULL);
+    ReadButtonMapping(cfg, "onscreen_keyboard", psp_to_scancode_osk, psp_to_scancode_osk_count, &psp_mouse_mapping_osk, &psp_keyboard_mapping);
 
-    ReadString(&psp_translation[0], "misc", "translation", "default");
+    ReadString(&psp_translation[0], cfg, "misc", "translation", "default");
 
-    ReadInteger((int*)&psp_disable_powersaving, "misc", "disable_power_saving", 0, 1, 1);
+    ReadInteger((int*)&psp_disable_powersaving, cfg, "misc", "disable_power_saving", 0, 1, 1);
 
-    ReadInteger((int*)&psp_return_to_menu, "misc", "return_to_menu", 0, 1, 1);
+    ReadInteger((int*)&psp_return_to_menu, cfg, "misc", "return_to_menu", 0, 1, 1);
 
-    ReadInteger(&display_fps, "misc", "show_fps", 0, 1, 0);
+    ReadInteger(&display_fps, cfg, "misc", "show_fps", 0, 1, 0);
     if (display_fps == 1)
       display_fps = 2;
 
-    ReadInteger((int*)&psp_ignore_acsetup_cfg_file, "compatibility", "ignore_acsetup_cfg_file", 0, 1, 0);
-    ReadInteger((int*)&psp_enable_extra_memory, "compatibility", "enable_extra_memory", 0, 1, 0);
-    ReadInteger((int*)&psp_clear_cache_on_room_change, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
+    ReadInteger((int*)&psp_ignore_acsetup_cfg_file, cfg, "compatibility", "ignore_acsetup_cfg_file", 0, 1, 0);
+    ReadInteger((int*)&psp_enable_extra_memory, cfg, "compatibility", "enable_extra_memory", 0, 1, 0);
+    ReadInteger((int*)&psp_clear_cache_on_room_change, cfg, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
 
-    ReadInteger((int*)&psp_audio_samplerate, "sound", "samplerate", 0, 44100, 44100);
-    ReadInteger((int*)&psp_audio_enabled, "sound", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_multithreaded, "sound", "threaded", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_samplerate, cfg, "sound", "samplerate", 0, 44100, 44100);
+    ReadInteger((int*)&psp_audio_enabled, cfg, "sound", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_audio_multithreaded, cfg, "sound", "threaded", 0, 1, 1);
 
-    ReadInteger((int*)&psp_midi_enabled, "midi", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_midi_preload_patches, "midi", "preload_patches", 0, 1, 0);
+    ReadInteger((int*)&psp_midi_enabled, cfg, "midi", "enabled", 0, 1, 1);
+    ReadInteger((int*)&psp_midi_preload_patches, cfg, "midi", "preload_patches", 0, 1, 0);
 
     int audio_cachesize;
-    if (ReadInteger((int*)&audio_cachesize, "sound", "cache_size", 1, 50, 10));
+    if (ReadInteger((int*)&audio_cachesize, cfg, "sound", "cache_size", 1, 50, 10));
       psp_audio_cachesize = audio_cachesize;
 
     int mouse_sensitivity;
-    if (ReadInteger((int*)&mouse_sensitivity, "analog_stick", "sensitivity", 0, 500, 50))
+    if (ReadInteger((int*)&mouse_sensitivity, cfg, "analog_stick", "sensitivity", 0, 500, 50))
       psp_mouse_analog_sensitivity = (float)mouse_sensitivity / 25.0f;
 
-    ReadInteger((int*)&psp_mouse_analog_deadzone, "analog_stick", "deadzone", 0, 128, 20);
+    ReadInteger((int*)&psp_mouse_analog_deadzone, cfg, "analog_stick", "deadzone", 0, 128, 20);
 
-    ReadInteger((int*)&psp_video_framedrop, "video", "framedrop", 0, 1, 0);
+    ReadInteger((int*)&psp_video_framedrop, cfg, "video", "framedrop", 0, 1, 0);
 
-    ReadInteger((int*)&psp_gfx_smoothing, "graphics", "smoothing", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_scaling, "graphics", "scaling", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_smooth_sprites, "graphics", "smooth_sprites", 0, 1, 0);
-
-    strcpy(filetouse, "nofile");
+    ReadInteger((int*)&psp_gfx_smoothing, cfg, "graphics", "smoothing", 0, 1, 1);
+    ReadInteger((int*)&psp_gfx_scaling, cfg, "graphics", "scaling", 0, 1, 1);
+    ReadInteger((int*)&psp_gfx_smooth_sprites, cfg, "graphics", "smooth_sprites", 0, 1, 0);
   }
 }
 

--- a/Engine/setup/acwsetup.CPP
+++ b/Engine/setup/acwsetup.CPP
@@ -21,8 +21,7 @@
 #include "gfx/gfxfilter.h"
 #include "util/filestream.h"
 
-using AGS::Common::Stream;
-using namespace AGS; // FIXME later
+using namespace AGS::Common;
 
 #define AL_ID(a,b,c,d)     (((a)<<24) | ((b)<<16) | ((c)<<8) | (d))
 
@@ -37,7 +36,6 @@ using namespace AGS; // FIXME later
 #define MIDI_WIN32MAPPER         AL_ID('W','3','2','M')
 
 extern "C" HWND allegro_wnd;
-extern int  INIreadint(const char*, const char*, int=0);
 extern void fgetstring_limit (char *, Stream *, int);
 extern char* ac_config_file;
 const char*setupstring, *enginever;
@@ -58,6 +56,13 @@ GFXFilter **filterList = NULL;
 const int specialFilterListIndex = 1;
 const char *specialFilterName = "Max nearest-neighbour filter";
 const char *specialFilterID = "max";
+
+static int INIreadint(const char *sectn, const char *item)
+{
+    char buf[11];
+    GetPrivateProfileString(sectn, item, "-1", buf, sizeof(buf), ac_config_file);
+    return atoi(buf);
+}
 
 int get_filter_real_index(int list_index)
 {
@@ -87,7 +92,7 @@ const char *get_filter_id(int list_index)
 
 void update_resolution_texts(HWND hDlg) {
   
-  bool letterbox_by_design = INIreadint("misc", "letterbox", 0) > 0;
+  bool letterbox_by_design = INIreadint("misc", "letterbox") > 0;
   Size res_size = ResolutionTypeToSize(defaultRes, letterbox_by_design);
   int resx = res_size.Width;
   int resy = res_size.Height;
@@ -137,7 +142,7 @@ void populate_drop_down_with_filters(HWND hDlg)
   int selected_filter = 0;
   while (thisFilter != NULL) {
 
-    if ((idx != 0) && (INIreadint("disabled", thisFilter->GetFilterID(), 0) == 1)) {
+    if ((idx != 0) && (INIreadint("disabled", thisFilter->GetFilterID()) == 1)) {
       // this filter is disabled
       delete thisFilter;
       // remove from list of filters
@@ -296,16 +301,16 @@ void InitializeDialog(HWND hDlg) {
     SendDlgItemMessage(hDlg, IDC_REDUCESPR, BM_SETCHECK, BST_CHECKED,0);
 
   // if no speech pack, disable the checkbox
-  if (!Common::File::TestReadFile("speech.vox"))
+  if (!File::TestReadFile("speech.vox"))
     EnableWindow (GetDlgItem (hDlg, IDC_SPEECHPACK), FALSE);
 
-  if (INIreadint("disabled", "speechvox", 0) == 1)
+  if (INIreadint("disabled", "speechvox") == 1)
     EnableWindow (GetDlgItem (hDlg, IDC_SPEECHPACK), FALSE);
 
-  if (INIreadint("disabled", "16bit", 0) == 1)
+  if (INIreadint("disabled", "16bit") == 1)
     EnableWindow (GetDlgItem (hDlg, IDC_REDUCESPR), FALSE);
 
-  if (INIreadint("disabled", "filters", 0) == 1)
+  if (INIreadint("disabled", "filters") == 1)
     EnableWindow (GetDlgItem(hDlg, IDC_GFXFILTER), FALSE);
 
   RECT win_rect, client_rect;
@@ -506,11 +511,11 @@ LRESULT CALLBACK callback_settings(HWND hDlg, UINT message, WPARAM wParam, LPARA
 int acwsetup(const char*vername, const char*enbuild) {
   setupstring = vername;
   enginever = enbuild;
-  if (Common::File::TestReadFile(ac_config_file)) {
+  if (File::TestReadFile(ac_config_file)) {
     curscrn=INIreadint("misc","screenres");
     if (curscrn > 1)
       curscrn = 1;
-    defaultRes = (GameResolutionType)INIreadint ("misc", "defaultres", 0);
+    defaultRes = (GameResolutionType)INIreadint ("misc", "defaultres");
     if (defaultRes < 1)
       defaultRes = kGameResolution_Default;
 
@@ -521,30 +526,30 @@ int acwsetup(const char*vername, const char*enbuild) {
     if (curdigi > 3) curdigi = 0;
     if (curmidi < 0) curmidi=0;
 
-    windowed = INIreadint("misc","windowed",0);
-    useletterbox = INIreadint("misc","prefer_letterbox", 1) != 0;
+    windowed = INIreadint("misc","windowed");
+    useletterbox = INIreadint("misc","prefer_letterbox") != 0;
 
-    reduce32to16 = INIreadint("misc","notruecolor",0);
+    reduce32to16 = INIreadint("misc","notruecolor");
     if (reduce32to16 < 0)
       reduce32to16 = 0;
 
-    gameColDep = INIreadint("misc", "gamecolordepth", 0);
+    gameColDep = INIreadint("misc", "gamecolordepth");
     if (gameColDep < 0)
       gameColDep = 0;
 
-    refresh = INIreadint("misc","refresh",0);
+    refresh = INIreadint("misc","refresh");
     if (refresh < 1)
       refresh = 0;
-    antialias = INIreadint("misc","antialias",0);
+    antialias = INIreadint("misc","antialias");
     if (antialias < 1)
       antialias = 0;
 
-    sideBorders = INIreadint("misc","prefer_sideborders", 1) != 0;
+    sideBorders = INIreadint("misc","prefer_sideborders") != 0;
 
-    int cacheval = INIreadint ("misc", "cachemax", 0);
+    int cacheval = INIreadint ("misc", "cachemax");
     if (cacheval > 0)
       curmaxcache = cacheval;
-    curusespeech = INIreadint ("sound", "usespeech", 0);
+    curusespeech = INIreadint ("sound", "usespeech");
     if (curusespeech < 0)
       curusespeech = 1;
 

--- a/Engine/test/test_all.cpp
+++ b/Engine/test/test_all.cpp
@@ -24,6 +24,7 @@ void Test_DoAllTests()
     Test_String();
     Test_Version();
     Test_File();
+    Test_IniFile();
 
     Test_Gfx();
 }

--- a/Engine/test/test_file.h
+++ b/Engine/test/test_file.h
@@ -15,5 +15,6 @@
 #ifdef _DEBUG
 
 void Test_File();
+void Test_IniFile();
 
 #endif // _DEBUG

--- a/Engine/test/test_inifile.cpp
+++ b/Engine/test/test_inifile.cpp
@@ -1,0 +1,194 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#ifdef _DEBUG
+
+#include <string.h>
+#include <algorithm>
+#include "debug/assert.h"
+#include "util/file.h"
+#include "util/inifile.h"
+#include "util/stream.h"
+
+using namespace AGS::Common;
+
+#if defined (WINDOWS_VERSION)
+#define ENDL "\r\n"
+#else
+#define ENDL "\n"
+#endif
+
+const char *IniFileText = ""
+"global_item=global_value"ENDL
+"[section1]"ENDL
+"item1"ENDL
+"//this is comment"ENDL
+"item2="ENDL
+"item3=value"ENDL
+"item4=another value"ENDL
+"[this_section_should_be_deleted]"ENDL
+"item1=value1"ENDL
+"item2=value2"ENDL
+";this is comment"ENDL
+"[section3]"ENDL
+"item_to_be_deleted=value"ENDL
+"item_to_be_kept=another value"ENDL
+"     [     section4     ]      "ENDL
+"        item1     =     value  "ENDL;
+
+const char *IniFileText2 = ""
+"global_item=global_value"ENDL
+"[section1]"ENDL
+"item1=value1"ENDL
+"//this is comment"ENDL
+"item2=value2"ENDL
+"item3=value3"ENDL
+"new_item=new_value"ENDL
+"[section3]"ENDL
+"item_to_be_kept=another value"ENDL
+"     [     section4     ]      "ENDL
+"new_item1=new_value1"ENDL
+"        item1     =     value  "ENDL
+"new_item2=new_value2"ENDL
+"[section5]"ENDL
+"item5_1=value5_1"ENDL
+"item5_2=value5_2"ENDL
+"item5_3=value5_3"ENDL;
+
+
+void Test_IniFile()
+{
+    Stream *fs = File::CreateFile("test.ini");
+    fs->Write(IniFileText, strlen(IniFileText));
+    delete fs;
+
+    IniFile ini;
+    fs = File::OpenFileRead("test.ini");
+    ini.Read(fs);
+    delete fs;
+
+    // there are explicit sections and 1 implicit global one
+    const int section_count = 5;
+    // Test reading from the custom ini file
+    {
+        assert(ini.GetSectionCount() == section_count);
+        IniFile::ConstSectionIterator sec = ini.CBegin();
+
+        assert(sec->GetItemCount() == 1);
+        IniFile::ConstItemIterator item = sec->CBegin();
+        assert(item->GetKey() == "global_item");
+        assert(item->GetValue() == "global_value");
+
+        ++sec;
+        assert(sec->GetName() == "section1");
+        assert(sec->GetItemCount() == 5);
+        item = sec->CBegin();
+        assert(item->GetKey() == "item1");
+        assert(item->GetValue() == "");
+        ++item;
+        assert(item->GetLine() == "//this is comment");
+        ++item;
+        assert(item->GetKey() == "item2");
+        assert(item->GetValue() == "");
+        ++item;
+        assert(item->GetKey() == "item3");
+        assert(item->GetValue() == "value");
+        ++item;
+        assert(item->GetKey() == "item4");
+        assert(item->GetValue() == "another value");
+
+        ++sec;
+        assert(sec->GetName() == "this_section_should_be_deleted");
+        assert(sec->GetItemCount() == 3);
+        item = sec->CBegin();
+        assert(item->GetKey() == "item1");
+        assert(item->GetValue() == "value1");
+        ++item;
+        assert(item->GetKey() == "item2");
+        assert(item->GetValue() == "value2");
+        ++item;
+        assert(item->GetLine() == ";this is comment");
+
+        ++sec;
+        assert(sec->GetName() == "section3");
+        assert(sec->GetItemCount() == 2);
+        item = sec->CBegin();
+        assert(item->GetKey() == "item_to_be_deleted");
+        assert(item->GetValue() == "value");
+        ++item;
+        assert(item->GetKey() == "item_to_be_kept");
+        assert(item->GetValue() == "another value");
+
+        ++sec;
+        assert(sec->GetName() == "section4");
+        assert(sec->GetItemCount() == 1);
+        item = sec->CBegin();
+        assert(item->GetKey() == "item1");
+        assert(item->GetValue() == "value");
+    }
+
+    // Test altering INI data and saving to file
+    {
+        // Modiying item values
+        IniFile::SectionIterator sec = ini.Begin();
+        ++sec;
+        IniFile::ItemIterator item = sec->Begin();
+        item->SetValue("value1");
+        ++item; ++item;
+        item->SetValue("value2");
+        ++item;
+        item->SetValue("value3");
+        ++item;
+        item->SetKey("new_item");
+        item->SetValue("new_value");
+
+        // Removing a section
+        sec = ini.Begin(); ++sec; ++sec;
+        ini.RemoveSection(sec);
+        assert(ini.GetSectionCount() == section_count - 1);
+
+        // Removing an item
+        sec = ini.Begin(); ++sec; ++sec;
+        assert(sec->GetName() == "section3");
+        item = sec->Begin();
+        assert(item->GetKey() == "item_to_be_deleted");
+        sec->EraseItem(item);
+
+        // Inserting new items
+        ++sec;
+        assert(sec->GetName() == "section4");
+        ini.InsertItem(sec, sec->Begin(), "new_item1", "new_value1");
+        ini.InsertItem(sec, sec->End(), "new_item2", "new_value2");
+
+        // Append new section
+        sec = ini.InsertSection(ini.End(), "section5");
+        ini.InsertItem(sec, sec->End(), "item5_1","value5_1");
+        ini.InsertItem(sec, sec->End(), "item5_2","value5_2");
+        ini.InsertItem(sec, sec->End(), "item5_3","value5_3");
+
+        fs = File::CreateFile("test.ini");
+        ini.Write(fs);
+        delete fs;
+
+        fs = File::OpenFileRead("test.ini");
+        String ini_content;
+        ini_content.ReadCount(fs, fs->GetLength());
+        
+        assert(ini_content == IniFileText2);
+    }
+
+    File::DeleteFile("test.ini");
+}
+
+#endif // _DEBUG

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -301,6 +301,21 @@ void Test_String()
         assert(strcmp(s1, "much much bigger! !make it bigger - a string to enlarge") == 0);
     }
 
+    // Test ReplaceMid
+    {
+        String s1 = "we need to replace PRECISELY THIS PART in this string";
+        String s2 = s1;
+        String new_long = "WITH A NEW TAD LONGER SUBSTRING";
+        String new_short = "SMALL STRING";
+        s1.ReplaceMid(19, 19, new_long);
+        assert(strcmp(s1, "we need to replace WITH A NEW TAD LONGER SUBSTRING in this string") == 0);
+        s2.ReplaceMid(19, 19, new_short);
+        assert(strcmp(s2, "we need to replace SMALL STRING in this string") == 0);
+        String s3 = "insert new string here: ";
+        s3.ReplaceMid(s3.GetLength(), 0, "NEW STRING");
+        assert(strcmp(s3, "insert new string here: NEW STRING") == 0);
+    }
+
     // Test SetAt
     {
         String s1 = "strimg wiyh typos";

--- a/Solutions/Common.Lib/Common.Lib.vcproj
+++ b/Solutions/Common.Lib/Common.Lib.vcproj
@@ -496,6 +496,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\Common\util\ini_util.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\..\Common\util\inifile.cpp"
 					>
 				</File>
@@ -807,6 +811,10 @@
 				</File>
 				<File
 					RelativePath="..\..\Common\util\geometry.h"
+					>
+				</File>
+				<File
+					RelativePath="..\..\Common\util\ini_util.h"
 					>
 				</File>
 				<File

--- a/Solutions/Common.Lib/Common.Lib.vcproj
+++ b/Solutions/Common.Lib/Common.Lib.vcproj
@@ -496,6 +496,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\Common\util\inifile.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\..\Common\util\lzw.cpp"
 					>
 				</File>
@@ -803,6 +807,10 @@
 				</File>
 				<File
 					RelativePath="..\..\Common\util\geometry.h"
+					>
+				</File>
+				<File
+					RelativePath="..\..\Common\util\inifile.h"
 					>
 				</File>
 				<File

--- a/Solutions/Engine.App/Engine.App.vcproj
+++ b/Solutions/Engine.App/Engine.App.vcproj
@@ -1144,6 +1144,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\Engine\test\test_inifile.cpp"
+					>
+				</File>
+				<File
 					RelativePath="..\..\Engine\test\test_sprintf.cpp"
 					>
 				</File>

--- a/iOS/xcode/ags/ags.xcodeproj/project.pbxproj
+++ b/iOS/xcode/ags/ags.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		16A98D9E1BCA2ED700254F37 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A98D9D1BCA2ED700254F37 /* UIKit.framework */; };
 		16A98DA01BCA2EE700254F37 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A98D9F1BCA2EE700254F37 /* OpenGLES.framework */; };
 		16A98DA21BCA2F2D00254F37 /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A98DA11BCA2F2D00254F37 /* libbz2.tbd */; };
+		16EA269B1BDC760300DADE0D /* ini_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16EA26971BDC760300DADE0D /* ini_util.cpp */; settings = {ASSET_TAGS = (); }; };
+		16EA269C1BDC760300DADE0D /* inifile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16EA26991BDC760300DADE0D /* inifile.cpp */; settings = {ASSET_TAGS = (); }; };
 		1D3623260D0F684500981E51 /* agsAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* agsAppDelegate.mm */; };
 		1D60589B0D05DD56006BFB54 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.mm */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -344,6 +346,10 @@
 		16A98D9D1BCA2ED700254F37 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		16A98D9F1BCA2EE700254F37 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/OpenGLES.framework; sourceTree = DEVELOPER_DIR; };
 		16A98DA11BCA2F2D00254F37 /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/usr/lib/libbz2.tbd; sourceTree = DEVELOPER_DIR; };
+		16EA26971BDC760300DADE0D /* ini_util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ini_util.cpp; sourceTree = "<group>"; };
+		16EA26981BDC760300DADE0D /* ini_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ini_util.h; sourceTree = "<group>"; };
+		16EA26991BDC760300DADE0D /* inifile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inifile.cpp; sourceTree = "<group>"; };
+		16EA269A1BDC760300DADE0D /* inifile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inifile.h; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* agsAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsAppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* agsAppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = agsAppDelegate.mm; sourceTree = "<group>"; };
@@ -1507,6 +1513,10 @@
 		60CA3A46160713D300CFB3BD /* util */ = {
 			isa = PBXGroup;
 			children = (
+				16EA26971BDC760300DADE0D /* ini_util.cpp */,
+				16EA26981BDC760300DADE0D /* ini_util.h */,
+				16EA26991BDC760300DADE0D /* inifile.cpp */,
+				16EA269A1BDC760300DADE0D /* inifile.h */,
 				16164DED1BC52C87004FE07F /* multifilelib.h */,
 				16164DEE1BC52C87004FE07F /* mutifilelib.cpp */,
 				600C369016C454C400D0CC4F /* stream.cpp */,
@@ -2427,6 +2437,7 @@
 				60CA3D58160713FF00CFB3BD /* gamestate.cpp in Sources */,
 				60CA3D59160713FF00CFB3BD /* global_audio.cpp in Sources */,
 				60CA3D5A160713FF00CFB3BD /* global_button.cpp in Sources */,
+				16EA269B1BDC760300DADE0D /* ini_util.cpp in Sources */,
 				60CA3D5B160713FF00CFB3BD /* global_character.cpp in Sources */,
 				60CA3D5C160713FF00CFB3BD /* global_datetime.cpp in Sources */,
 				60CA3D5D160713FF00CFB3BD /* global_debug.cpp in Sources */,
@@ -2614,6 +2625,7 @@
 				60898DCC160785DD009E152F /* gfxfilter_hq3x.cpp in Sources */,
 				60898DD6160787FF009E152F /* hq2x3x.cpp in Sources */,
 				6080428E1614DE8F00D33732 /* assetmanager.cpp in Sources */,
+				16EA269C1BDC760300DADE0D /* inifile.cpp in Sources */,
 				608B4E57163BF27B00547FAA /* libc.c in Sources */,
 				60DC154116675B2B002D0474 /* cc_error_engine.cpp in Sources */,
 				60DC154216675B2B002D0474 /* cc_instance.cpp in Sources */,


### PR DESCRIPTION
Few planned future updates requires writing certain options back to config file on exit.
Unfortunately, config write functions provided by Allegro 4 library proved to not be fully reliable: they fail if the config file format is slightly different from their expectations; besides there is a chance we will be moving away from Allegro 4 in the future.

This pull request introduces IniFile class that constructs a description of INI either by parsing a file or by user command, allows to iterate sections and items, and write the contents back into file. IniFile supports merging changes into existing file; this is implemented by remembering precise locations of items in the text. If a single existing item value was changed by user, it is replaced while keeping the rest of the contents unchanged.

Also provided utility functions which exchange data between IniFile and a key-value tree (a map of maps of strings) in both directions. The named tree is then used during actual game setup routine.
The advantage of separating the configuration tree from IniFile is that the config tree may be easily filled from other sources as well, for example - from command line arguments.

Advanced changes that would follow this request:
* Saving necessary config options back to the config file on game exit;
* Combining options from multiple sources (general config, platform-specific config, command line parameters) into the single configuration map.