### PR TITLE
Mouse speed setting

### DIFF
--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -153,6 +153,11 @@ struct Rect
 	{
 		return Bottom - Top + 1;
 	}
+
+    inline bool IsInside(int x, int y) const
+    {
+        return x >= Left && y >= Top && (x <= Right) && (y <= Bottom);
+    }
 };
 
 // Helper factory function

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -646,8 +646,12 @@ struct Mouse {
   import static void UseDefaultGraphic();
   /// Changes the mouse cursor to use the graphic for a different non-active cursor mode.
   import static void UseModeGraphic(CursorMode);
+  /// Gets/sets whether the user-defined factors are applied to mouse movement
+  import static attribute bool ControlEnabled;
   /// Gets/sets the current mouse cursor mode.
   import static attribute CursorMode Mode;
+  /// Gets/sets the mouse speed
+  import static attribute float Speed;
   /// Gets/sets whether the mouse cursor is visible.
   import static attribute bool Visible;
   /// Gets the current mouse position.

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -146,6 +146,7 @@ RoomStatus*croom=NULL;
 roomstruct thisroom;
 
 volatile int switching_away_from_game = 0;
+volatile bool switched_away = false;
 volatile char want_exit = 0, abort_engine = 0;
 GameDataVersion loaded_game_file_version = kGameVersion_Undefined;
 int frames_per_second=40;
@@ -2685,6 +2686,7 @@ int __GetLocationType(int xxx,int yyy, int allowHotspot0) {
 }
 
 void display_switch_out() {
+    switched_away = true;
     // this is only called if in SWITCH_PAUSE mode
     //debug_log("display_switch_out");
 
@@ -2712,6 +2714,7 @@ void display_switch_out() {
 }
 
 void display_switch_in() {
+    switched_away = false;
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) {
         if ((channels[i] != NULL) && (channels[i]->done == 0)) {
             channels[i]->resume();

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -35,4 +35,5 @@ GameSetup::GameSetup()
     override_script_os = -1;
     override_multitasking = -1;
     override_upscale = false;
+    mouse_speed = 1.f;
 }

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -36,4 +36,5 @@ GameSetup::GameSetup()
     override_multitasking = -1;
     override_upscale = false;
     mouse_speed = 1.f;
+    mouse_speed_def = kMouseSpeed_CurrentDisplay;
 }

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -17,6 +17,14 @@
 
 #include "util/string.h"
 
+// Mouse speed definition, specifies how the speed setting is applied to the mouse movement
+enum MouseSpeedDef
+{
+    kMouseSpeed_Absolute,       // apply speed multiplier directly
+    kMouseSpeed_CurrentDisplay, // keep speed/resolution relation based on current system display mode
+    kNumMouseSpeedDefs
+};
+
 struct GameSetup {
     int digicard;
     int midicard;
@@ -43,6 +51,7 @@ struct GameSetup {
     char  override_multitasking;
     bool  override_upscale;
     float mouse_speed;
+    MouseSpeedDef mouse_speed_def;
     GameSetup();
 };
 

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -17,10 +17,6 @@
 
 #include "util/string.h"
 
-// game setup, read in from CFG file
-// this struct is redefined in acdialog.cpp, any changes might
-// need to be reflected there
-// [IKM] 2012-06-27: now it isn't
 struct GameSetup {
     int digicard;
     int midicard;
@@ -46,6 +42,7 @@ struct GameSetup {
     int   override_script_os;
     char  override_multitasking;
     bool  override_upscale;
+    float mouse_speed;
     GameSetup();
 };
 

--- a/Engine/ac/global_screen.cpp
+++ b/Engine/ac/global_screen.cpp
@@ -44,7 +44,7 @@ extern unsigned int loopcounter;
 int scrnwid,scrnhit;
 int current_screen_resolution_multiplier = 1;
 
-int final_scrn_wid=0,final_scrn_hit=0,final_col_dep=0, game_frame_y_offset = 0;
+int final_scrn_wid=0,final_scrn_hit=0,final_col_dep=0, game_frame_x_offset = 0, game_frame_y_offset = 0;
 int screen_reset = 0;
 
 int GetMaxScreenHeight () {

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -382,6 +382,14 @@ int find_next_enabled_cursor(int startwith) {
     return testing;
 }
 
+void Mouse_EnableControl(bool on)
+{
+    if (on)
+        Mouse::EnableControl(!usetup.windowed);
+    else
+        Mouse::DisableControl();
+}
+
 
 //=============================================================================
 //
@@ -503,6 +511,28 @@ RuntimeScriptValue Sc_Mouse_SetVisible(const RuntimeScriptValue *params, int32_t
 }
 
 
+RuntimeScriptValue Sc_Mouse_GetControlEnabled(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_BOOL(Mouse::IsControlEnabled);
+}
+
+RuntimeScriptValue Sc_Mouse_SetControlEnabled(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PBOOL(Mouse_EnableControl);
+}
+
+RuntimeScriptValue Sc_Mouse_GetSpeed(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_FLOAT(Mouse::GetSpeed);
+}
+
+RuntimeScriptValue Sc_Mouse_SetSpeed(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_VARIABLE_VALUE("Mouse::Speed");
+    Mouse::SetSpeed(params[0].FValue);
+    return RuntimeScriptValue();
+}
+
 void RegisterMouseAPI()
 {
     ccAddExternalStaticFunction("Mouse::ChangeModeGraphic^2",       Sc_ChangeCursorGraphic);
@@ -519,8 +549,12 @@ void RegisterMouseAPI()
     ccAddExternalStaticFunction("Mouse::Update^0",                  Sc_RefreshMouse);
     ccAddExternalStaticFunction("Mouse::UseDefaultGraphic^0",       Sc_set_default_cursor);
     ccAddExternalStaticFunction("Mouse::UseModeGraphic^1",          Sc_set_mouse_cursor);
+    ccAddExternalStaticFunction("Mouse::get_ControlEnabled",        Sc_Mouse_GetControlEnabled);
+    ccAddExternalStaticFunction("Mouse::set_ControlEnabled",        Sc_Mouse_SetControlEnabled);
     ccAddExternalStaticFunction("Mouse::get_Mode",                  Sc_GetCursorMode);
     ccAddExternalStaticFunction("Mouse::set_Mode",                  Sc_set_cursor_mode);
+    ccAddExternalStaticFunction("Mouse::get_Speed",                 Sc_Mouse_GetSpeed);
+    ccAddExternalStaticFunction("Mouse::set_Speed",                 Sc_Mouse_SetSpeed);
     ccAddExternalStaticFunction("Mouse::get_Visible",               Sc_Mouse_GetVisible);
     ccAddExternalStaticFunction("Mouse::set_Visible",               Sc_Mouse_SetVisible);
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -63,6 +63,7 @@
 #include "gfx/bitmap.h"
 #include "util/math.h"
 #include "main/graphics_mode.h"
+#include "device/mousew32.h"
 
 using AGS::Common::Bitmap;
 using AGS::Common::Stream;
@@ -541,6 +542,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
 		scrnhit = BitmapHelper::GetScreenBitmap()->GetHeight();
         vesa_yres = scrnhit;
+        game_frame_x_offset = (final_scrn_wid - scrnwid) / 2;
         game_frame_y_offset = (final_scrn_hit - scrnhit) / 2;
 
         filter->SetMouseArea(0,0, scrnwid-1, vesa_yres-1);

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -36,35 +36,15 @@
 #define FALSE 0
 #endif
 
+#include "ac/system.h"
 #include "device/mousew32.h"
 #include "gfx/bitmap.h"
 #include "gfx/gfx_util.h"
+#include "main/graphics_mode.h"
+#include "util/math.h"
 
-using AGS::Common::Bitmap;
+using namespace AGS::Common;
 
-
-/*
-int  minstalled();    // this returns number of buttons (or 0)
-void minst();   // this exits if not installed
-void mshow();
-void mhide();
-int  mgetbutton();
-void mchangestyle(int,int);
-void mgetpos();
-void mgetgraphpos();
-void msetpos(int,int);
-void mconfine(int,int,int,int); // left top right bottom
-void mgraphconfine(int,int,int,int);
-int  mbutrelease(int);
-void domouse(int=0);   // graphics mode cursor
-void mfreemem();
-void mloadcursor(char*);  // load from file
-void mloadwcursor(char*);
-void mnewcursor(char);
-int  ismouseinbox(int,int,int,int);
-void msethotspot(int,int);   // Graphics mode only. Useful for crosshair.
-*/
-void msetgraphpos(int,int);
 
 extern char lib_file_name[13];
 
@@ -72,7 +52,10 @@ char *mouselibcopyr = "MouseLib32 (c) 1994, 1998 Chris Jones";
 const int NONE = -1, LEFT = 0, RIGHT = 1, MIDDLE = 2;
 int aa;
 char mouseturnedon = FALSE, currentcursor = 0;
+// virtual mouse cursor coordinates
 int mousex = 0, mousey = 0, numcurso = -1, hotx = 0, hoty = 0;
+// real mouse coordinates and bounds
+int real_mouse_x = 0, real_mouse_y = 0;
 int boundx1 = 0, boundx2 = 99999, boundy1 = 0, boundy2 = 99999;
 int disable_mgetgraphpos = 0;
 char ignore_bounds = 0;
@@ -80,9 +63,27 @@ extern char alpha_blend_cursor ;
 Bitmap *savebk = NULL, *mousecurs[MAXCURSORS];
 extern int vesa_xres, vesa_yres;
 extern color palette[256];
+extern volatile bool switched_away;
 
 
 IMouseGetPosCallback *callback = NULL;
+
+namespace Mouse
+{
+    // Screen rectangle, in which the mouse movement is controlled by engine
+    Rect  ControlRect;
+    // Mouse control enabled flag
+    bool  ControlEnabled = false;
+    // Flag that tells whether the mouse must be forced to stay inside control rect
+    bool  ConfineInCtrlRect = false;
+    // Mouse speed value provided by user
+    float SpeedVal = 1.f;
+    // Mouse speed unit
+    float SpeedUnit = 1.f;
+    // Actual speed factor (cached)
+    float Speed = 1.f;
+}
+
 
 void msetcallback(IMouseGetPosCallback *gpCallback) {
   callback = gpCallback;
@@ -90,40 +91,95 @@ void msetcallback(IMouseGetPosCallback *gpCallback) {
 
 void mgraphconfine(int x1, int y1, int x2, int y2)
 {
+  Mouse::ControlRect = Rect(x1 + game_frame_x_offset, y1 + game_frame_y_offset,
+      x2 + game_frame_x_offset, y2 + game_frame_y_offset);
   set_mouse_range(x1, y1, x2, y2);
 }
 
 void mgetgraphpos()
 {
-  poll_mouse();
-  if (!disable_mgetgraphpos) {
-    mousex = mouse_x;
-    mousey = mouse_y;
-  }
-
-  if (!ignore_bounds) {
-
-    if (mousex < boundx1) {
-      mousex = boundx1;
-      msetgraphpos(mousex, mousey);
-    }
-    if (mousey < boundy1) {
-      mousey = boundy1;
-      msetgraphpos(mousex, mousey);
-    }
-    if (mousex > boundx2) {
-      mousex = boundx2;
-      msetgraphpos(mousex, mousey);
-    }
-    if (mousey > boundy2) {
-      mousey = boundy2;
-      msetgraphpos(mousex, mousey);
+    poll_mouse();
+    if (disable_mgetgraphpos)
+    {
+        // The cursor coordinates are provided from alternate source;
+        // in this case we completely ignore actual cursor movement.
+        if (!ignore_bounds &&
+            (mousex < boundx1 || mousey < boundy1 || mousex > boundx2 || mousey > boundy2))
+        {
+            mousex = Math::Clamp(boundx1, boundx2, mousex);
+            mousey = Math::Clamp(boundy1, boundy2, mousey);
+            msetgraphpos(mousex, mousey);
+        }
+        return;
     }
 
-  }
+    if (!switched_away && Mouse::ControlEnabled)
+    {
+        // Control mouse movement by querying mouse mickeys (movement deltas)
+        // and applying them to saved mouse coordinates.
+        int mickey_x, mickey_y;
+        get_mouse_mickeys(&mickey_x, &mickey_y);
+        
+        // Apply mouse speed
+        int dx = Mouse::Speed * mickey_x;
+        int dy = Mouse::Speed * mickey_y;
 
-  if ((callback) && (!disable_mgetgraphpos))
-    callback->AdjustPosition(&mousex, &mousey);
+        //
+        // Perform actual cursor update
+        //---------------------------------------------------------------------
+        // If the real cursor is inside the control rectangle (read - game window),
+        // then apply sensitivity factors and adjust real cursor position
+        if (Mouse::ControlRect.IsInside(real_mouse_x + dx, real_mouse_y + dy))
+        {
+            real_mouse_x += dx;
+            real_mouse_y += dy;
+            position_mouse(real_mouse_x, real_mouse_y);
+        }
+        // Otherwise, if real cursor was moved outside the control rect, yet we
+        // are required to confine cursor inside one, then adjust cursor position
+        // to stay inside the rect's bounds.
+        else if (Mouse::ConfineInCtrlRect)
+        {
+            real_mouse_x = Math::Clamp(Mouse::ControlRect.Left, Mouse::ControlRect.Right, real_mouse_x + dx);
+            real_mouse_y = Math::Clamp(Mouse::ControlRect.Top, Mouse::ControlRect.Bottom, real_mouse_y + dy);
+            position_mouse(real_mouse_x, real_mouse_y);
+        }
+        // Lastly, if the real cursor is out of the control rect, simply add
+        // actual movement to keep up with the system cursor coordinates.
+        else
+        {
+            real_mouse_x += mickey_x;
+            real_mouse_y += mickey_y;
+        }
+
+        // Do not update the game cursor if the real cursor is beyond the control rect
+        if (!Mouse::ControlRect.IsInside(real_mouse_x, real_mouse_y))
+            return;
+    }
+    else
+    {
+        // Save real cursor coordinates provided by system
+        real_mouse_x = mouse_x;
+        real_mouse_y = mouse_y;
+    }
+
+    // Set game cursor position, and apply real->virtual coordinate translation
+    mousex = real_mouse_x;
+    mousey = real_mouse_y;
+
+    mousex -= Mouse::ControlRect.Left;
+    mousey -= Mouse::ControlRect.Top;
+
+    if (!ignore_bounds &&
+        (mousex < boundx1 || mousey < boundy1 || mousex > boundx2 || mousey > boundy2))
+    {
+        mousex = Math::Clamp(boundx1, boundx2, mousex);
+        mousey = Math::Clamp(boundy1, boundy2, mousey);
+        msetgraphpos(mousex, mousey);
+    }
+
+    if (callback)
+        callback->AdjustPosition(&mousex, &mousey);
 }
 
 void msetcursorlimit(int x1, int y1, int x2, int y2)
@@ -262,8 +318,10 @@ int misbuttondown(int buno)
 }
 
 void msetgraphpos(int xa, int ya)
-{ 
-  position_mouse(xa, ya); // xa -= hotx; ya -= hoty;
+{
+  real_mouse_x = xa + Mouse::ControlRect.Left;
+  real_mouse_y = ya + Mouse::ControlRect.Top;
+  position_mouse(real_mouse_x, real_mouse_y); // xa -= hotx; ya -= hoty;
 }
 
 void msethotspot(int xx, int yy)
@@ -283,4 +341,42 @@ int minstalled()
     nbuts = 2;
 
   return nbuts;
+}
+
+void Mouse::EnableControl(bool confine)
+{
+    ControlEnabled = true;
+    ConfineInCtrlRect = confine;
+}
+
+void Mouse::DisableControl()
+{
+    ControlEnabled = false;
+}
+
+bool Mouse::IsControlEnabled()
+{
+    return ControlEnabled;
+}
+
+void Mouse::SetSpeedUnit(float f)
+{
+    SpeedUnit = f;
+    Speed = SpeedVal / SpeedUnit;
+}
+
+float Mouse::GetSpeedUnit()
+{
+    return SpeedUnit;
+}
+
+void Mouse::SetSpeed(float speed)
+{
+    SpeedVal = Math::Max(0.f, speed);
+    Speed = SpeedUnit * SpeedVal;
+}
+
+float Mouse::GetSpeed()
+{
+    return SpeedVal;
 }

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -21,6 +21,8 @@
 //
 //=============================================================================
 
+#include "util/geometry.h"
+
 #define MAXCURSORS 20
 
 namespace AGS { namespace Common { class Bitmap; } }
@@ -45,6 +47,23 @@ void msetgraphpos(int xa, int ya);
 void msethotspot(int xx, int yy);
 int minstalled();
 
+namespace Mouse
+{
+    // Enable mouse movement control
+    void EnableControl(bool confine);
+    // Disable mouse movement control
+    void DisableControl();
+    // Tell if the mouse movement control is enabled
+    bool IsControlEnabled();
+    // Set base speed factor, which would serve as a mouse speed unit
+    void SetSpeedUnit(float f);
+    // Get base speed factor
+    float GetSpeedUnit();
+    // Set speed factors
+    void SetSpeed(float speed);
+    // Get speed factor
+    float GetSpeed();
+}
 
 extern int mousex, mousey;
 extern int hotx, hoty;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -107,10 +107,11 @@ float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &ite
     return atof(str);
 }
 
-String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item)
+String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value = "")
 {
     String str;
-    INIreaditem(cfg, sectn, item, str);
+    if (!INIreaditem(cfg, sectn, item, str))
+        return def_value;
     return str;
 }
 
@@ -265,6 +266,13 @@ void read_config_file(char *argv0) {
         usetup.mouse_speed = INIreadfloat(cfg, "mouse", "speed", 1.f);
         if (usetup.mouse_speed <= 0.f)
             usetup.mouse_speed = 1.f;
+        const char *mouse_speed_options[kNumMouseSpeedDefs] = { "absolute", "current_display" };
+        String mouse_str = INIreadstring(cfg, "mouse", "speed_def", "current_display");
+        for (int i = 0; i < kNumMouseSpeedDefs; ++i)
+        {
+            if (mouse_str.CompareNoCase(mouse_speed_options[i]) == 0)
+                usetup.mouse_speed_def = (MouseSpeedDef)i;
+        }
 
         usetup.override_multitasking = INIreadint(cfg, "override", "multitasking");
         String override_os = INIreadstring(cfg, "override", "os");

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -311,3 +311,12 @@ void read_config_file(char *argv0) {
         usetup.gfxDriverID = "DX5";
 
 }
+
+void save_config_file()
+{
+    ConfigTree cfg;
+
+    cfg["mouse"]["speed"] = String::FromFormat("%f", Mouse::GetSpeed());
+
+    IniUtil::Merge(ac_config_file, cfg);
+}

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -98,6 +98,15 @@ int INIreadint(const ConfigTree &cfg, const String &sectn, const String &item)
     return atoi(str);
 }
 
+float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value)
+{
+    String str;
+    if (!INIreaditem(cfg, sectn, item, str))
+        return def_value;
+
+    return atof(str);
+}
+
 String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item)
 {
     String str;
@@ -252,6 +261,10 @@ void read_config_file(char *argv0) {
         }
         else
             play.playback = 0;
+
+        usetup.mouse_speed = INIreadfloat(cfg, "mouse", "speed", 1.f);
+        if (usetup.mouse_speed <= 0.f)
+            usetup.mouse_speed = 1.f;
 
         usetup.override_multitasking = INIreadint(cfg, "override", "multitasking");
         String override_os = INIreadstring(cfg, "override", "os");

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -25,6 +25,7 @@ void save_config_file();
 
 bool INIreaditem(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item, AGS::Common::String &value);
 int INIreadint(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item);
+float INIreadfloat(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item, float def_value = 0.f);
 
 
 #endif // __AGS_EE_MAIN__CONFIG_H

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -21,6 +21,7 @@
 #include "util/ini_util.h"
 
 void read_config_file(char *argv0);
+void save_config_file();
 
 bool INIreaditem(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item, AGS::Common::String &value);
 int INIreadint(const AGS::Common::ConfigTree &cfg, const AGS::Common::String &sectn, const AGS::Common::String &item);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -139,6 +139,12 @@ int engine_init_allegro()
             user_hint);
         return EXIT_NORMAL;
     }
+
+    // Setup allegro using constructed config string
+    String al_config_data = "[mouse]\n";
+    al_config_data.Append(String::FromFormat("mouse_accel_factor = %d\n", 0));
+    set_config_data(al_config_data, al_config_data.GetLength());
+
     return RETURN_CONTINUE;
 }
 

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -743,6 +743,7 @@ bool init_gfx_mode(const Size &game_size, const Size &screen_size, int cdep)
     final_scrn_wid = game_size.Width;
     final_scrn_hit = game_size.Height;
     final_col_dep = cdep;
+    game_frame_x_offset = (final_scrn_wid - scrnwid) / 2;
     game_frame_y_offset = (final_scrn_hit - scrnhit) / 2;
     usetup.want_letterbox = final_scrn_hit > scrnhit;
 
@@ -980,6 +981,16 @@ int create_gfx_driver_and_init_mode(const String &gfx_driver_id, Size &game_size
     {
         return res;
     }
+
+    // Assign mouse control parameters
+    const bool control_sens = !usetup.windowed;
+    if (control_sens)
+    {
+        Mouse::EnableControl(!usetup.windowed);
+        Mouse::SetSpeed(usetup.mouse_speed);
+    }
+    Out::FPrint("Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",
+        Mouse::GetSpeedUnit(), Mouse::GetSpeed());
     return RETURN_CONTINUE;
 }
 

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -963,6 +963,9 @@ void log_out_driver_modes(const int color_depth)
 
 int create_gfx_driver_and_init_mode(const String &gfx_driver_id, Size &game_size, Size &screen_size)
 {
+    Size init_desktop;
+    get_desktop_resolution(&init_desktop.Width, &init_desktop.Height);
+
     if (!create_gfx_driver(gfx_driver_id))
         return EXIT_NORMAL;
     // Log out supported driver modes
@@ -987,6 +990,12 @@ int create_gfx_driver_and_init_mode(const String &gfx_driver_id, Size &game_size
     if (control_sens)
     {
         Mouse::EnableControl(!usetup.windowed);
+        if (usetup.mouse_speed_def == kMouseSpeed_CurrentDisplay)
+        {
+            Size cur_desktop;
+            get_desktop_resolution(&cur_desktop.Width, &cur_desktop.Height);
+            Mouse::SetSpeedUnit(Math::Max((float)cur_desktop.Width / (float)init_desktop.Width, (float)cur_desktop.Height / (float)init_desktop.Height));
+        }
         Mouse::SetSpeed(usetup.mouse_speed);
     }
     Out::FPrint("Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -23,6 +23,6 @@ void graphics_mode_shutdown();
 
 extern Size GameSize;
 extern Size LetterboxedGameSize; // size of the game combined with letterbox borders
-extern int final_scrn_wid, final_scrn_hit, final_col_dep, game_frame_y_offset;
+extern int final_scrn_wid, final_scrn_hit, final_col_dep, game_frame_x_offset, game_frame_y_offset;
 
 #endif // __AGS_EE_MAIN__GRAPHICSMODE_H

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -28,6 +28,7 @@
 #include "debug/debugger.h"
 #include "debug/out.h"
 #include "font/fonts.h"
+#include "main/config.h"
 #include "main/graphics_mode.h"
 #include "main/main.h"
 #include "main/mainheader.h"
@@ -259,6 +260,8 @@ void quit(const char *quitmsg) {
     strncpy(qmsgbufr, quitmsg, STD_BUFFER_SIZE);
     qmsgbufr[STD_BUFFER_SIZE - 1] = 0;
     char *qmsg = &qmsgbufr[0];
+
+    save_config_file();
 
 	allegro_bitmap_test_release();
 

--- a/Engine/resource/resource.h
+++ b/Engine/resource/resource.h
@@ -29,6 +29,8 @@
 #define IDC_GFXDRIVER                   1024
 #define IDC_RESOLUTION                  1025
 #define IDC_SIDEBORDERS                 1026
+#define IDC_MOUSESPEED                  1028
+#define IDC_MOUSESPEED_TEXT             1032
 
 // Next default values for new objects
 // 
@@ -36,7 +38,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        108
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1026
+#define _APS_NEXT_CONTROL_VALUE         1033
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/Engine/resource/version.rc
+++ b/Engine/resource/version.rc
@@ -114,7 +114,7 @@ IDI_ICON2               ICON                    "game-1.ico"
 // Dialog
 //
 
-IDD_DIALOG1 DIALOGEX 0, 0, 360, 285
+IDD_DIALOG1 DIALOGEX 0, 0, 360, 295
 STYLE DS_SETFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "AGS Game Settings"
 FONT 8, "Tahoma", 400, 0, 0x0
@@ -135,13 +135,13 @@ BEGIN
     PUSHBUTTON      "&Save and Run",IDOKRUN,67,102,56,14
     PUSHBUTTON      "Cancel",IDCANCEL,127,102,56,14
     PUSHBUTTON      "Ad&vanced  >>>",IDC_ADVANCED,282,101,70,15
-    GROUPBOX        "Sound options",IDC_STATIC,7,121,185,89
+    GROUPBOX        "Sound options",IDC_STATIC,7,122,185,60
     CONTROL         "Digital Sound:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,13,136,46,9
     COMBOBOX        IDC_COMBO1,68,134,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_GROUP | WS_TABSTOP
     CONTROL         "MIDI music:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,13,152,47,10
     COMBOBOX        IDC_COMBO2,68,150,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_TABSTOP
     CONTROL         "Use voice pack if available",IDC_SPEECHPACK,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,13,169,160,9
-    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,89
+    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,99
     CONTROL         "Enable side borders",IDC_SIDEBORDERS,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,136,135,9
     CONTROL         "Enable top && bottom borders",IDC_LETTERBOX,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,150,132,9
     CONTROL         "S&mooth scaled sprites (fast CPUs only)",IDC_ANTIALIAS,
@@ -150,11 +150,13 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,178,135,9
     CONTROL         "Use 85 &Hz display (CRT monitors only)",IDC_REFRESH,
                     "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,192,138,9
-    GROUPBOX        "Sprite cache",IDC_STATICADV,7,212,345,55,NOT WS_VISIBLE
-    CONTROL         "Maximum size:",IDC_STATICADV3,"Static",SS_LEFTNOWORDWRAP | NOT WS_VISIBLE | WS_GROUP,15,225,50,10
-    COMBOBOX        IDC_COMBO4,68,223,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,239,323,26,NOT WS_VISIBLE
-    CTEXT           "Static",IDC_VERSION,91,270,176,9
+    GROUPBOX        "Sprite cache",IDC_STATICADV,7,222,345,55,NOT WS_VISIBLE
+    CONTROL         "Maximum size:",IDC_STATICADV3,"Static",SS_LEFTNOWORDWRAP | NOT WS_VISIBLE | WS_GROUP,15,235,50,10
+    COMBOBOX        IDC_COMBO4,68,233,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,249,323,26,NOT WS_VISIBLE
+    CTEXT           "Static",IDC_VERSION,91,280,176,9
+    CONTROL         "",IDC_MOUSESPEED,"msctls_trackbar32", WS_TABSTOP,10,197,180,21
+    GROUPBOX        "Mouse speed: Default",IDC_MOUSESPEED_TEXT,7,185,186,35
 END
 
 
@@ -171,7 +173,7 @@ BEGIN
         LEFTMARGIN, 7
         RIGHTMARGIN, 352
         TOPMARGIN, 7
-        BOTTOMMARGIN, 280
+        BOTTOMMARGIN, 290
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -91,6 +91,11 @@ extern char ScSfBuffer[3000];
     FUNCTION(); \
     return RuntimeScriptValue()
 
+#define API_SCALL_VOID_PBOOL(FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 1) \
+    FUNCTION(params[0].GetAsBool()); \
+    return RuntimeScriptValue()
+
 #define API_SCALL_VOID_PINT(FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 1) \
     FUNCTION(params[0].IValue); \
@@ -144,6 +149,11 @@ extern char ScSfBuffer[3000];
 #define API_SCALL_VOID_PINT4_POBJ(FUNCTION, P1CLASS) \
     ASSERT_PARAM_COUNT(FUNCTION, 5) \
     FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, (P1CLASS*)params[4].Ptr); \
+    return RuntimeScriptValue()
+
+#define API_SCALL_VOID_PFLOAT2(FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 2) \
+    FUNCTION(params[0].FValue, params[1].FValue); \
     return RuntimeScriptValue()
 
 #define API_SCALL_VOID_POBJ(FUNCTION, P1CLASS) \
@@ -212,6 +222,9 @@ extern char ScSfBuffer[3000];
 #define API_SCALL_INT_PINT_POBJ(FUNCTION, P1CLASS) \
     ASSERT_PARAM_COUNT(FUNCTION, 2) \
     return RuntimeScriptValue().SetInt32(FUNCTION(params[0].IValue, (P1CLASS*)params[1].Ptr))
+
+#define API_SCALL_FLOAT(FUNCTION) \
+    return RuntimeScriptValue().SetFloat(FUNCTION())
 
 #define API_SCALL_BOOL(FUNCTION) \
     return RuntimeScriptValue().SetInt32AsBool(FUNCTION())

--- a/Engine/setup/acwsetup.CPP
+++ b/Engine/setup/acwsetup.CPP
@@ -13,6 +13,7 @@
 //=============================================================================
 
 #include <windows.h>
+#include <commctrl.h>
 #include <stdio.h>
 #include <io.h>
 #include <stdlib.h>
@@ -35,6 +36,9 @@ using namespace AGS::Common;
 #define MIDI_AUTODETECT       -1 
 #define MIDI_NONE             0 
 #define MIDI_WIN32MAPPER         AL_ID('W','3','2','M')
+
+#define MOUSE_SPEED_MIN     1
+#define MOUSE_SPEED_MAX     100
 
 extern "C" HWND allegro_wnd;
 extern void fgetstring_limit (char *, Stream *, int);
@@ -197,6 +201,14 @@ void update_gfx_filter_box_enabled(HWND hDlg)
   update_resolution_texts(hDlg);
 }
 
+void update_mouse_speed_text(HWND hDlg)
+{
+  int slider_pos = SendDlgItemMessage(hDlg,IDC_MOUSESPEED, TBM_GETPOS, 0, 0);
+  float mouse_speed = (float)slider_pos / 10.f;
+  String text = mouse_speed == 1.f ? "Mouse speed: x 1.0 (Default)" : String::FromFormat("Mouse speed: x %0.1f", mouse_speed);
+  SendDlgItemMessage(hDlg, IDC_MOUSESPEED_TEXT, WM_SETTEXT, 0, (LPARAM)text.GetCStr());
+}
+
 void InitializeDialog(HWND hDlg) {
   struct _finddata_t c_file;
   long hFile;
@@ -249,6 +261,16 @@ void InitializeDialog(HWND hDlg) {
 
     _findclose( hFile );
   }
+
+  SendDlgItemMessage(hDlg, IDC_MOUSESPEED, TBM_SETRANGE, (WPARAM)TRUE,
+      (LPARAM)MAKELONG(MOUSE_SPEED_MIN, MOUSE_SPEED_MAX));
+  float mouse_speed = INIreadfloat(wincfg, "mouse", "speed", 1.f);
+  if (mouse_speed <= 0.f)
+      mouse_speed = 1.f;
+  int slider_pos = (int)(mouse_speed * 10.f + .5f);
+  SendDlgItemMessage(hDlg,IDC_MOUSESPEED, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)slider_pos);
+  update_mouse_speed_text(hDlg);
+
   SendDlgItemMessage(hDlg,IDC_COMBO4,CB_ADDSTRING,0,(LPARAM)"10 MB");
   SendDlgItemMessage(hDlg,IDC_COMBO4,CB_ADDSTRING,0,(LPARAM)"20 MB (default)");
   SendDlgItemMessage(hDlg,IDC_COMBO4,CB_ADDSTRING,0,(LPARAM)"50 MB");
@@ -492,11 +514,19 @@ LRESULT CALLBACK callback_settings(HWND hDlg, UINT message, WPARAM wParam, LPARA
           idx = SendDlgItemMessage(hDlg, IDC_GFXFILTER, CB_GETCURSEL, 0, 0);
           const char *filter_id = get_filter_id(idx);
           WritePrivateProfileString("misc", "gfxfilter", filter_id, ac_config_file);
+
+          int slider_pos = SendDlgItemMessage(hDlg,IDC_MOUSESPEED, TBM_GETPOS, 0, 0);
+          float mouse_speed = (float)slider_pos / 10.f;
+          sprintf(tbuf, "%0.1f", mouse_speed);
+          WritePrivateProfileString("mouse", "speed", tbuf, ac_config_file);
         }
 	EndDialog(hDlg, LOWORD(wParam));
  	return TRUE;
       }
       return FALSE;
+    case WM_HSCROLL:
+      update_mouse_speed_text(hDlg);
+      return TRUE;
     default: return FALSE;
     }
   return TRUE;

--- a/Solutions/Engine.App/Engine.App.vcproj
+++ b/Solutions/Engine.App/Engine.App.vcproj
@@ -2185,6 +2185,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\Engine\resource\resource.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\Engine\resource\tintshader.fxo"
 				>
 			</File>


### PR DESCRIPTION
Implemented mouse speed setting with Script API binding.

* Mouse speed is a multiplier of type 'float'.
* The multiplier is applied only when game is run in Fullscreen mode.
* Initial value is taken from configuration file (section 'mouse', entry 'speed'). There are two modes, defining how the user setting is converted into real multiplier: absolute (1:1) and relative to display mode, which tries to keep speed/resolution relation based on current desktop resolution.
* Added Mouse.Speed property to Script API (allows game developers to implement a mouse speed slider in their game, if they like to).
* On game exit current mouse speed is saved back to the configuration file.
* Related slider control added to Windows setup program.

Notably, this pull request also disables Allegro's mouse acceleration. For unknown reasons it is only implemented in Windows version of library, and is impossible to setup finely. This acceleration caused trouble to the significant number of players who has mouse acceleration enabled by their mouse driver.