### PR TITLE
Mouse lock option

### DIFF
--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -2,15 +2,21 @@ INCDIR = ../Engine ../Common ../Common/libinclude ../Plugins
 LIBDIR =
 CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(shell pkg-config --cflags freetype2) $(CFLAGS)
 CXXFLAGS := -fno-rtti -Wno-write-strings $(CXXFLAGS)
-LIBS := -rdynamic $(shell allegro-config --libs) -laldmb -ldumb -Wl,-Bdynamic -ltheora -logg 
+LIBS := -rdynamic -laldmb -ldumb -Wl,-Bdynamic
+LIBS += $(shell pkg-config --libs --static allegro)
+LIBS += $(shell pkg-config --libs x11)
+LIBS += $(shell pkg-config --libs ogg)
+LIBS += $(shell pkg-config --libs theora)
 
 ifeq ($(USE_TREMOR), 1)
   LIBS += -lvorbisidec
   CFLAGS += -DUSE_TREMOR
 else
-  LIBS += -lvorbis
+  LIBS += $(shell pkg-config --libs vorbis)
 endif
-LIBS += -lvorbisfile -lfreetype -logg -ldl -lpthread -lm -lc -lstdc++
+LIBS += $(shell pkg-config --libs vorbisfile)
+LIBS += $(shell pkg-config --libs freetype2)
+LIBS += -lc -lstdc++
 
 ifeq ($(ALLEGRO_MAGIC_DRV), 1)
   CFLAGS += -DALLEGRO_MAGIC_DRV

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -62,6 +62,7 @@
 #include "ac/dynobj/all_scriptclasses.h"
 #include "debug/debug_log.h"
 #include "debug/out.h"
+#include "device/mousew32.h"
 #include "font/fonts.h"
 #include "gfx/ali3d.h"
 #include "gui/animatingguibutton.h"
@@ -2685,10 +2686,18 @@ int __GetLocationType(int xxx,int yyy, int allowHotspot0) {
     return winner;
 }
 
-void display_switch_out() {
+void display_switch_out()
+{
     switched_away = true;
+    // Always unlock mouse when switching out from the game
+    Mouse::UnlockFromWindow();
+}
+
+void display_switch_out_suspend()
+{
     // this is only called if in SWITCH_PAUSE mode
     //debug_log("display_switch_out");
+    display_switch_out();
 
     switching_away_from_game++;
 
@@ -2713,8 +2722,18 @@ void display_switch_out() {
     switching_away_from_game--;
 }
 
-void display_switch_in() {
+void display_switch_in()
+{
     switched_away = false;
+    // If auto lock option is set, lock mouse to the game window
+    if (usetup.mouse_auto_lock && usetup.windowed)
+        Mouse::TryLockToWindow();
+}
+
+void display_switch_in_resume()
+{
+    display_switch_in();
+
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) {
         if ((channels[i] != NULL) && (channels[i]->done == 0)) {
             channels[i]->resume();

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -144,8 +144,14 @@ void stop_fast_forwarding();
 
 int __GetLocationType(int xxx,int yyy, int allowHotspot0);
 
+// Called whenever game looses input focus
 void display_switch_out();
+// Called whenever game gets input focus
 void display_switch_in();
+// Called when the game looses input focus and must suspend
+void display_switch_out_suspend();
+// Called when the game gets input focus and should resume
+void display_switch_in_resume();
 
 void replace_tokens(char*srcmes,char*destm, int maxlen = 99999);
 char *get_global_message (int msnum);

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -32,6 +32,7 @@ GameSetup::GameSetup()
     prefer_letterbox = true;
     base_width = 320;
     base_height = 200;
+    mouse_auto_lock = false;
     override_script_os = -1;
     override_multitasking = -1;
     override_upscale = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -47,6 +47,7 @@ struct GameSetup {
     AGS::Common::String translation;
     AGS::Common::String gfxFilterID;
     AGS::Common::String gfxDriverID;
+    bool  mouse_auto_lock;
     int   override_script_os;
     char  override_multitasking;
     bool  override_upscale;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -789,12 +789,14 @@ void SetMultitasking (int mode) {
         if (set_display_switch_mode(SWITCH_PAUSE) == -1)
             set_display_switch_mode(SWITCH_AMNESIA);
         // install callbacks to stop the sound when switching away
-        set_display_switch_callback(SWITCH_IN, display_switch_in);
-        set_display_switch_callback(SWITCH_OUT, display_switch_out);
+        set_display_switch_callback(SWITCH_IN, display_switch_in_resume);
+        set_display_switch_callback(SWITCH_OUT, display_switch_out_suspend);
     }
     else {
         if (set_display_switch_mode (SWITCH_BACKGROUND) == -1)
             set_display_switch_mode(SWITCH_BACKAMNESIA);
+        set_display_switch_callback(SWITCH_IN, display_switch_in);
+        set_display_switch_callback(SWITCH_OUT, display_switch_out);
     }
 }
 

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -41,6 +41,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/gfx_util.h"
 #include "main/graphics_mode.h"
+#include "platform/base/agsplatformdriver.h"
 #include "util/math.h"
 
 using namespace AGS::Common;
@@ -70,6 +71,9 @@ IMouseGetPosCallback *callback = NULL;
 
 namespace Mouse
 {
+    // Tells whether mouse was locked to the game window
+    bool LockedToWindow = false;
+
     // Screen rectangle, in which the mouse movement is controlled by engine
     Rect  ControlRect;
     // Mouse control enabled flag
@@ -341,6 +345,24 @@ int minstalled()
     nbuts = 2;
 
   return nbuts;
+}
+
+bool Mouse::IsLockedToWindow()
+{
+    return LockedToWindow;
+}
+
+bool Mouse::TryLockToWindow()
+{
+    if (!LockedToWindow)
+        LockedToWindow = platform->LockMouseToWindow();
+    return LockedToWindow;
+}
+
+void Mouse::UnlockFromWindow()
+{
+    platform->UnlockMouse();
+    LockedToWindow = false;
 }
 
 void Mouse::EnableControl(bool confine)

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -49,6 +49,13 @@ int minstalled();
 
 namespace Mouse
 {
+    // Get if mouse is locked to the game window
+    bool IsLockedToWindow();
+    // Try locking mouse to the game window
+    bool TryLockToWindow();
+    // Unlock mouse from the game window
+    void UnlockFromWindow();
+
     // Enable mouse movement control
     void EnableControl(bool confine);
     // Disable mouse movement control

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -263,6 +263,8 @@ void read_config_file(char *argv0) {
         else
             play.playback = 0;
 
+        usetup.mouse_auto_lock = INIreadint(cfg, "mouse", "auto_lock") > 0;
+
         usetup.mouse_speed = INIreadfloat(cfg, "mouse", "speed", 1.f);
         if (usetup.mouse_speed <= 0.f)
             usetup.mouse_speed = 1.f;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1481,6 +1481,10 @@ int initialize_engine(int argc,char*argv[])
 
     SetMultitasking(0);
 
+    // If auto lock option is set, lock mouse to the game window
+    if (usetup.mouse_auto_lock && usetup.windowed)
+        Mouse::TryLockToWindow();
+
     engine_show_preload();
 
     res = engine_init_sprites();

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -22,6 +22,7 @@
 #include "ac/draw.h"
 #include "ac/event.h"
 #include "ac/game.h"
+#include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/global_character.h"
 #include "ac/global_debug.h"
@@ -196,6 +197,23 @@ int game_loop_check_ground_level_interactions()
     return RETURN_CONTINUE;
 }
 
+void lock_mouse_on_click()
+{
+    if (usetup.mouse_auto_lock && usetup.windowed)
+        Mouse::TryLockToWindow();
+}
+
+void toggle_mouse_lock()
+{
+    if (usetup.windowed)
+    {
+        if (Mouse::IsLockedToWindow())
+            Mouse::UnlockFromWindow();
+        else
+            Mouse::TryLockToWindow();
+    }
+}
+
 // check_controls: checks mouse & keyboard interface
 void check_controls() {
     int numevents_was = numevents;
@@ -293,6 +311,8 @@ void check_controls() {
 
     aa=mgetbutton();
     if (aa>NONE) {
+        lock_mouse_on_click();
+
         if ((play.in_cutscene == 3) || (play.in_cutscene == 4))
             start_skipping_cutscene();
         if ((play.in_cutscene == 5) && (aa == RIGHT))
@@ -327,12 +347,15 @@ void check_controls() {
         //    else RunTextScriptIParam(gameinst,"on_mouse_click",aa+1);
     }
     aa = check_mouse_wheel();
+    if (aa !=0)
+        lock_mouse_on_click();
     if (aa < 0)
         setevent (EV_TEXTSCRIPT, TS_MCLICK, 9);
     else if (aa > 0)
         setevent (EV_TEXTSCRIPT, TS_MCLICK, 8);
 
     // check keypresses
+    static int old_key_shifts = 0;
     if (kbhit()) {
         // in case they press the finish-recording button, make sure we know
         int was_playing = play.playback;
@@ -489,6 +512,17 @@ void check_controls() {
             }
         }
         //    RunTextScriptIParam(gameinst,"on_key_press",kgn);
+    }
+    // check extended keys
+    else
+    {
+        // Toggle mouse lock on Ctrl + Alt release
+        if (!key[KEY_ALT] && !(key[KEY_LCONTROL] || key[KEY_RCONTROL]) &&
+            old_key_shifts == (KB_ALT_FLAG | KB_CTRL_FLAG))
+        {
+            toggle_mouse_lock();
+        }
+        old_key_shifts = key_shifts & ~(KB_SCROLOCK_FLAG | KB_NUMLOCK_FLAG | KB_CAPSLOCK_FLAG);
     }
 
     if ((IsInterfaceEnabled()) && (IsGamePaused() == 0) &&

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -100,6 +100,8 @@ void quit_check_dynamic_sprites(char *qmsg)
 
 void quit_shutdown_platform(char *qmsg)
 {
+    // Be sure to unlock mouse on exit, or users will hate us
+    platform->UnlockMouse();
     platform->AboutToQuitGame();
 
     our_eip = 9016;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -146,6 +146,9 @@ int AGSPlatformDriver::ConvertKeycodeToScanCode(int keycode)
     return keycode;
 }
 
+bool AGSPlatformDriver::LockMouseToWindow() { return false; }
+void AGSPlatformDriver::UnlockMouse() { }
+
 //-----------------------------------------------
 // IOutputTarget implementation
 //-----------------------------------------------

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -79,6 +79,9 @@ struct AGSPlatformDriver
     virtual int  RunPluginDebugHooks(const char *scriptfile, int linenum);
     virtual void ShutdownPlugins();
 
+    virtual bool LockMouseToWindow();
+    virtual void UnlockMouse();
+
     static AGSPlatformDriver *GetDriver();
 
     //-----------------------------------------------

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <allegro.h>
+#include <xalleg.h>
 #include "gfx/ali3d.h"
 #include "ac/runtime_defines.h"
 #include "platform/base/agsplatformdriver.h"
@@ -57,6 +58,8 @@ struct AGSLinux : AGSPlatformDriver {
   virtual void ShutdownCDPlayer();
   virtual void WriteStdOut(const char*, ...);
   virtual void ReplaceSpecialPaths(const char *sourcePath, char *destPath, size_t destSize);
+  virtual bool LockMouseToWindow();
+  virtual void UnlockMouse();
 };
 
 
@@ -206,4 +209,16 @@ void AGSLinux::ReplaceSpecialPaths(const char *sourcePath, char *destPath, size_
   {
     snprintf(destPath, destSize, "%s", sourcePath);
   }
+}
+
+bool AGSLinux::LockMouseToWindow()
+{
+    return XGrabPointer(_xwin.display, _xwin.window, False,
+        PointerMotionMask | ButtonPressMask | ButtonReleaseMask,
+        GrabModeAsync, GrabModeAsync, _xwin.window, None, CurrentTime) == GrabSuccess;
+}
+
+void AGSLinux::UnlockMouse()
+{
+    XUngrabPointer(_xwin.display, CurrentTime);
 }

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -121,6 +121,8 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void RegisterGameWithGameExplorer();
   virtual void UnRegisterGameWithGameExplorer();
   virtual int  ConvertKeycodeToScanCode(int keyCode);
+  virtual bool LockMouseToWindow();
+  virtual void UnlockMouse();
 
 private:
   void add_game_to_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers);
@@ -847,6 +849,22 @@ int AGSWin32::ConvertKeycodeToScanCode(int keycode)
   if ((scancode >= 0) && (scancode < 256))
     keycode = hw_to_mycode[scancode];
   return keycode;
+}
+
+bool AGSWin32::LockMouseToWindow()
+{
+    RECT rc;
+    GetClientRect(allegro_wnd, &rc);
+    ClientToScreen(allegro_wnd, (POINT*)&rc);
+    ClientToScreen(allegro_wnd, (POINT*)&rc.right);
+    --rc.right;
+    --rc.bottom;
+    return ::ClipCursor(&rc) != 0;
+}
+
+void AGSWin32::UnlockMouse()
+{
+    ::ClipCursor(NULL);
 }
 
 AGSPlatformDriver* AGSPlatformDriver::GetDriver() {

--- a/Engine/resource/resource.h
+++ b/Engine/resource/resource.h
@@ -31,6 +31,7 @@
 #define IDC_SIDEBORDERS                 1026
 #define IDC_MOUSESPEED                  1028
 #define IDC_MOUSESPEED_TEXT             1032
+#define IDC_MOUSE_AUTOLOCK              1033
 
 // Next default values for new objects
 // 
@@ -38,7 +39,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        108
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1033
+#define _APS_NEXT_CONTROL_VALUE         1035
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/Engine/resource/version.rc
+++ b/Engine/resource/version.rc
@@ -114,7 +114,7 @@ IDI_ICON2               ICON                    "game-1.ico"
 // Dialog
 //
 
-IDD_DIALOG1 DIALOGEX 0, 0, 360, 295
+IDD_DIALOG1 DIALOGEX 0, 0, 360, 317
 STYLE DS_SETFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "AGS Game Settings"
 FONT 8, "Tahoma", 400, 0, 0x0
@@ -135,13 +135,13 @@ BEGIN
     PUSHBUTTON      "&Save and Run",IDOKRUN,67,102,56,14
     PUSHBUTTON      "Cancel",IDCANCEL,127,102,56,14
     PUSHBUTTON      "Ad&vanced  >>>",IDC_ADVANCED,282,101,70,15
-    GROUPBOX        "Sound options",IDC_STATIC,7,122,185,60
+    GROUPBOX        "Sound options",IDC_STATIC,7,122,185,63
     CONTROL         "Digital Sound:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,13,136,46,9
     COMBOBOX        IDC_COMBO1,68,134,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_GROUP | WS_TABSTOP
     CONTROL         "MIDI music:",IDC_STATIC,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,13,152,47,10
     COMBOBOX        IDC_COMBO2,68,150,118,70,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_TABSTOP
     CONTROL         "Use voice pack if available",IDC_SPEECHPACK,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,13,169,160,9
-    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,99
+    GROUPBOX        "Graphics options",IDC_STATIC,198,121,154,122
     CONTROL         "Enable side borders",IDC_SIDEBORDERS,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,136,135,9
     CONTROL         "Enable top && bottom borders",IDC_LETTERBOX,"Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,150,132,9
     CONTROL         "S&mooth scaled sprites (fast CPUs only)",IDC_ANTIALIAS,
@@ -150,13 +150,15 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,178,135,9
     CONTROL         "Use 85 &Hz display (CRT monitors only)",IDC_REFRESH,
                     "Button",BS_AUTOCHECKBOX | NOT WS_VISIBLE | WS_TABSTOP,205,192,138,9
-    GROUPBOX        "Sprite cache",IDC_STATICADV,7,222,345,55,NOT WS_VISIBLE
-    CONTROL         "Maximum size:",IDC_STATICADV3,"Static",SS_LEFTNOWORDWRAP | NOT WS_VISIBLE | WS_GROUP,15,235,50,10
-    COMBOBOX        IDC_COMBO4,68,233,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,249,323,26,NOT WS_VISIBLE
-    CTEXT           "Static",IDC_VERSION,91,280,176,9
-    CONTROL         "",IDC_MOUSESPEED,"msctls_trackbar32", WS_TABSTOP,10,197,180,21
-    GROUPBOX        "Mouse speed: Default",IDC_MOUSESPEED_TEXT,7,185,186,35
+    GROUPBOX        "Sprite cache",IDC_STATICADV,7,245,345,55,NOT WS_VISIBLE
+    CONTROL         "Maximum size:",IDC_STATICADV3,"Static",SS_LEFTNOWORDWRAP | NOT WS_VISIBLE | WS_GROUP,15,258,50,10
+    COMBOBOX        IDC_COMBO4,68,256,108,100,CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "You can limit the maximum amount of memory that the game will use for its sprite cache. Smaller values may make the game run slower but use less RAM; higher values may be faster but use more RAM. You should not normally need to adjust this.",IDC_STATICADV2,13,272,323,26,NOT WS_VISIBLE
+    CTEXT           "Static",IDC_VERSION,91,303,176,9
+    CONTROL         "",IDC_MOUSESPEED,"msctls_trackbar32",WS_TABSTOP,10,225,180,14
+    GROUPBOX        "Mouse options",IDC_STATIC,7,185,186,58
+    CONTROL         "Auto lock to window",IDC_MOUSE_AUTOLOCK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,200,80,10
+    LTEXT           "Cursor speed: Default",IDC_MOUSESPEED_TEXT,15,214,176,8
 END
 
 
@@ -173,7 +175,7 @@ BEGIN
         LEFTMARGIN, 7
         RIGHTMARGIN, 352
         TOPMARGIN, 7
-        BOTTOMMARGIN, 290
+        BOTTOMMARGIN, 312
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/Engine/setup/acwsetup.CPP
+++ b/Engine/setup/acwsetup.CPP
@@ -262,6 +262,10 @@ void InitializeDialog(HWND hDlg) {
     _findclose( hFile );
   }
 
+  bool mouse_autolock = INIreadint(wincfg, "mouse", "auto_lock") > 0;
+  if (mouse_autolock)
+      SendDlgItemMessage(hDlg, IDC_MOUSE_AUTOLOCK, BM_SETCHECK, BST_CHECKED, 0);
+
   SendDlgItemMessage(hDlg, IDC_MOUSESPEED, TBM_SETRANGE, (WPARAM)TRUE,
       (LPARAM)MAKELONG(MOUSE_SPEED_MIN, MOUSE_SPEED_MAX));
   float mouse_speed = INIreadfloat(wincfg, "mouse", "speed", 1.f);
@@ -515,6 +519,8 @@ LRESULT CALLBACK callback_settings(HWND hDlg, UINT message, WPARAM wParam, LPARA
           const char *filter_id = get_filter_id(idx);
           WritePrivateProfileString("misc", "gfxfilter", filter_id, ac_config_file);
 
+          bool mouse_autolock = SendDlgItemMessage(hDlg, IDC_MOUSE_AUTOLOCK, BM_GETCHECK, 0, 0) == BST_CHECKED;
+          WritePrivateProfileString("mouse", "auto_lock", mouse_autolock ? "1" : "0", ac_config_file);
           int slider_pos = SendDlgItemMessage(hDlg,IDC_MOUSESPEED, TBM_GETPOS, 0, 0);
           float mouse_speed = (float)slider_pos / 10.f;
           sprintf(tbuf, "%0.1f", mouse_speed);


### PR DESCRIPTION
This pull request implements an optional mouse lock (aka mouse grab) in game window.

This option was requested by numerous players, because most of AGS games are mouse controlled, and if the game object is located close to the edge of the screen, it is possible to occasionally click outside of the window and loose control over game.
This is even more essential for games where character, or other entity is controlled by cursor movement in real time.

* Mouse lock only activates in windowed mode (fullscreen mode grabs mouse by definition).
* Manual mouse lock is toggled with Alt + Ctrl key combination anytime game has input focus.
* Automatic lock is enabled in config: section "mouse", entry "auto_lock". Automatic lock is performed whenever game receives input focus or user clicked inside window (if lock was previously removed with Alt + Ctrl combo).
* Mouse lock is always removed when game window looses input focus, and (obviously) when game exits.

The pull requests contains lock implementation for Windows and Linux.