### PR TITLE
Editor: Mouse flickering in the code editor

### DIFF
--- a/Editor/AGS.Controls/ScintillaNET/ScintillaControl.cs
+++ b/Editor/AGS.Controls/ScintillaNET/ScintillaControl.cs
@@ -640,12 +640,18 @@ namespace Scintilla
         #region Event Dispatch Mechanism
         protected override void WndProc(ref Message m)
         {
-            //	Uh-oh. Code based on undocumented unsupported .NET behavior coming up!
-            //	Windows Forms Sends Notify messages back to the originating
-            //	control ORed with 0x2000. This is way cool becuase we can listen for
-            //	WM_NOTIFY messages originating form our own hWnd (from Scintilla)
-            if ((m.Msg ^ 0x2000) != WinAPI.WM_NOTIFY)
+            if (m.Msg == WinAPI.WM_SETCURSOR)
             {
+                base.DefWndProc(ref m); // Make sure message is sent to Scintilla
+                return;
+            }
+            else if ((m.Msg ^ 0x2000) != WinAPI.WM_NOTIFY)
+            {
+                //	Uh-oh. Code based on undocumented unsupported .NET behavior coming up!
+                //	Windows Forms Sends Notify messages back to the originating
+                //	control ORed with 0x2000. This is way cool becuase we can listen for
+                //	WM_NOTIFY messages originating form our own hWnd (from Scintilla)
+
                 base.WndProc(ref m);
                 return;
             }

--- a/Editor/AGS.Controls/ScintillaNET/WinAPI.cs
+++ b/Editor/AGS.Controls/ScintillaNET/WinAPI.cs
@@ -16,6 +16,7 @@ namespace Scintilla
     public class WinAPI
     {
         public const int WM_NOTIFY = 0x004e;
+        public const int WM_SETCURSOR = 0x0020;
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool MessageBeep(BeepType type);


### PR DESCRIPTION
In reference to: http://www.adventuregamestudio.co.uk/forums/index.php?topic=52805.0

The Scintilla Control uses the text edit mouse cursor, but when WM_SETCURSOR was sent back to WinForms it was overriden and set to the default arrow cursor. This commit makes sure that WM_SETCURSOR is not sent back to WinForms.