### PR TITLE
Minor improvements related to logging to standard output

### DIFF
--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -185,7 +185,7 @@ void process_event(EventHappened*evp) {
 
             evblockbasename="hotspot%d";
             evblocknum=evp->data2;
-            //platform->WriteStdOut("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
+            //Out::FPrint("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
         }
         else if (evp->data1==EVB_ROOM) {
 
@@ -200,7 +200,7 @@ void process_event(EventHappened*evp) {
                 run_on_event (GE_ENTER_ROOM, RuntimeScriptValue().SetInt32(displayed_room));
 
             }
-            //platform->WriteStdOut("Running room interaction, event %d", evp->data3);
+            //Out::FPrint("Running room interaction, event %d", evp->data3);
         }
 
         if (scriptPtr != NULL)

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -490,7 +490,7 @@ int my_readkey() {
 
     /*  char message[200];
     sprintf(message, "Scancode: %04X", gott);
-    OutputDebugString(message);*/
+    Out::FPrint(message);*/
 
     /*if ((scancode >= KEY_0_PAD) && (scancode <= KEY_9_PAD)) {
     // fix numeric pad keys if numlock is off (allegro 4.2 changed this behaviour)
@@ -550,7 +550,7 @@ int my_readkey() {
     }
 
     //sprintf(message, "Keypress: %d", gott);
-    //OutputDebugString(message);
+    //Out::FPrint(message);
 
     return gott;
 }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -340,8 +340,8 @@ int check_for_messages_from_editor()
 
         if (strncmp(msg, "<Engine Command=\"", 17) != 0) 
         {
-            //OutputDebugString("Faulty message received from editor:");
-            //OutputDebugString(msg);
+            //Out::FPrint("Faulty message received from editor:");
+            //Out::FPrint(msg);
             free(msg);
             return 0;
         }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -116,7 +116,7 @@ void apply_output_configuration()
         logfile_path.Append("/ags.log");
         if (DebugLogFile->OpenFile(logfile_path))
         {
-            platform->WriteStdOut("Logging to %s", logfile_path.GetCStr());
+            platform->WriteStdOutF("AGS: Logging to %s", logfile_path.GetCStr());
         }
         else
         {
@@ -161,7 +161,7 @@ void write_log(char*msg) {
     fprintf(ooo,"%s\n",msg);
     fclose(ooo);
     */
-    platform->WriteStdOut(msg);
+    Out::FPrint(msg);
 }
 
 /* The idea of this is that non-essential errors such as "sound file not
@@ -229,7 +229,7 @@ void debug_write_console (const char *msg, ...) {
     }
     else debug_line[last_debug_line].script[0] = 0;
 
-    platform->WriteStdOut("%s (%s)", displbuf, debug_line[last_debug_line].script);
+    platform->WriteStdOutF("AGS: %s (%s)", displbuf, debug_line[last_debug_line].script);
 
     last_debug_line = (last_debug_line + 1) % DEBUG_CONSOLE_NUMLINES;
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -534,7 +534,7 @@ int engine_init_speech()
                 delete speechsync;
             }
             Common::AssetManager::SetDataFile(game_file_name);
-            platform->WriteStdOut("Speech sample file found and initialized.\n");
+            Out::FPrint("Speech sample file found and initialized.");
             play.want_speech=1;
         }
     }
@@ -574,7 +574,7 @@ int engine_init_music()
             return EXIT_NORMAL;
         }
         Common::AssetManager::SetDataFile(game_file_name);
-        platform->WriteStdOut("Audio vox found and initialized.\n");
+        Out::FPrint("Audio vox found and initialized.");
         play.seperate_music_lib = 1;
     }
 
@@ -652,7 +652,6 @@ bool try_install_sound(int digi_id, int midi_id)
 
 void engine_init_sound()
 {
-    platform->WriteStdOut("Checking sound inits.\n");
     if (opts.mod_player)
         reserve_voices(16, -1);
 #if ALLEGRO_DATE > 19991010

--- a/Engine/media/audio/soundcache.cpp
+++ b/Engine/media/audio/soundcache.cpp
@@ -57,7 +57,7 @@ void sound_cache_free(char* buffer, bool is_wave)
     AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("sound_cache_free(%d %d)\n", (unsigned int)buffer, (unsigned int)is_wave);
+    Out::FPrint("sound_cache_free(%d %d)\n", (unsigned int)buffer, (unsigned int)is_wave);
 #endif
     int i;
     for (i = 0; i < psp_audio_cachesize; i++)
@@ -68,14 +68,14 @@ void sound_cache_free(char* buffer, bool is_wave)
                 sound_cache_entries[i].reference--;
 
 #ifdef SOUND_CACHE_DEBUG
-            platform->WriteStdOut("..decreased reference count of slot %d to %d\n", i, sound_cache_entries[i].reference);
+            Out::FPrint("..decreased reference count of slot %d to %d\n", i, sound_cache_entries[i].reference);
 #endif
             return;
         }
     }
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("..freeing uncached sound\n");
+    Out::FPrint("..freeing uncached sound\n");
 #endif
 
     // Sound is uncached
@@ -94,7 +94,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
 	AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("get_cached_sound(%s %d)\n", filename, (unsigned int)is_wave);
+    Out::FPrint("get_cached_sound(%s %d)\n", filename, (unsigned int)is_wave);
 #endif
 
     *size = 0;
@@ -108,7 +108,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
         if (strcmp(filename, sound_cache_entries[i].file_name) == 0)
         {
 #ifdef SOUND_CACHE_DEBUG
-            platform->WriteStdOut("..found in slot %d\n", i);
+            Out::FPrint("..found in slot %d\n", i);
 #endif
             sound_cache_entries[i].reference++;
             sound_cache_entries[i].last_used = sound_cache_counter++;
@@ -195,7 +195,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
     {
         // No cache slot empty, return uncached data
 #ifdef SOUND_CACHE_DEBUG
-        platform->WriteStdOut("..loading uncached\n");
+        Out::FPrint("..loading uncached\n");
 #endif
         return newdata;  
     }
@@ -203,7 +203,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
     {
         // Add to cache, free old sound first
 #ifdef SOUND_CACHE_DEBUG
-        platform->WriteStdOut("..loading cached in slot %d\n", i);
+        Out::FPrint("..loading cached in slot %d\n", i);
 #endif	
 
         if (sound_cache_entries[i].data) {

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -55,7 +55,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
 };
 
 
@@ -716,16 +716,11 @@ void AGSAndroid::SetGameWindowIcon() {
   // do nothing
 }
 
-void AGSAndroid::WriteStdOut(const char *text, ...)
+void AGSAndroid::WriteStdOut(const char *text)
 {
   if (psp_debug_write_to_logcat)
   {
-    char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-    va_list ap;
-    va_start(ap,text);
-    vsprintf(&displbuf[5],text,ap);
-    va_end(ap);
-    __android_log_print(ANDROID_LOG_DEBUG, "AGSNative", "%s", displbuf);
+    __android_log_print(ANDROID_LOG_DEBUG, "AGSNative", "%s", text);
   }
 }
 

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -20,6 +20,7 @@
 #include "util/wgt2allg.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/common.h"
+#include "ac/runtime_defines.h"
 #include "util/string_utils.h"
 #include "util/stream.h"
 #include "gfx/bitmap.h"
@@ -132,11 +133,22 @@ int AGSPlatformDriver::ConvertKeycodeToScanCode(int keycode)
 bool AGSPlatformDriver::LockMouseToWindow() { return false; }
 void AGSPlatformDriver::UnlockMouse() { }
 
+void AGSPlatformDriver::WriteStdOutF(const char *fmt, ...)
+{
+    char displbuf[STD_BUFFER_SIZE];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(displbuf, STD_BUFFER_SIZE, fmt, ap);
+    va_end(ap);
+    WriteStdOut(displbuf);
+}
+
 //-----------------------------------------------
 // IOutputTarget implementation
 //-----------------------------------------------
-void AGSPlatformDriver::Out(const char *sz_fullmsg) {
-    this->WriteStdOut(sz_fullmsg);
+void AGSPlatformDriver::Out(const char *sz_fullmsg)
+{
+    this->WriteStdOutF("AGS: %s", sz_fullmsg);
 }
 
 // ********** CD Player Functions common to Win and Linux ********

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -77,7 +77,8 @@ struct AGSPlatformDriver
     virtual void FinishedUsingGraphicsMode();
     virtual SetupReturnValue RunSetup(Common::ConfigTree &cfg) { return kSetup_Cancel; }
     virtual void SetGameWindowIcon();
-    virtual void WriteStdOut(const char*, ...) = 0;
+    // Writes exact line to the standard platform's output
+    virtual void WriteStdOut(const char*) = 0;
     virtual void YieldCPU();
     virtual void DisplaySwitchOut();
     virtual void DisplaySwitchIn();
@@ -99,11 +100,15 @@ struct AGSPlatformDriver
     virtual bool LockMouseToWindow();
     virtual void UnlockMouse();
 
+    // Formats message and writes to standard platform's output
+    void         WriteStdOutF(const char* , ...);
+
     static AGSPlatformDriver *GetDriver();
 
     //-----------------------------------------------
     // IOutputTarget implementation
     //-----------------------------------------------
+    // Writes to the standard platform's output, prepending "AGS: " prefix to the message
     virtual void Out(const char *sz_fullmsg);
 
 private:

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -127,7 +127,7 @@ struct AGSIOS : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
 };
 
 
@@ -536,16 +536,9 @@ bool ReadConfiguration(char* filename, bool read_everything)
 extern void ios_show_message_box(char* buffer);
 volatile int ios_wait_for_ui = 0;
 
-void AGSIOS::WriteStdOut(const char *text, ...)
+void AGSIOS::WriteStdOut(const char *text)
 {
-  {
-    char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-    va_list ap;
-    va_start(ap,text);
-    vsprintf(&displbuf[5],text,ap);
-    va_end(ap);
-    printf("%s\n", displbuf);
-  }
+  printf("%s\n", text);
 }
 
 

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -56,7 +56,7 @@ struct AGSLinux : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
   virtual bool LockMouseToWindow();
   virtual void UnlockMouse();
 };
@@ -165,15 +165,8 @@ void AGSLinux::SetGameWindowIcon() {
   // do nothing
 }
 
-void AGSLinux::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
+void AGSLinux::WriteStdOut(const char *text) {
+  printf("%s\n", text);
 }
 
 void AGSLinux::ShutdownCDPlayer() {

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -45,7 +45,7 @@ struct AGSMac : AGSPlatformDriver {
   virtual int  RunSetup();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
   virtual void ReplaceSpecialPaths(const char*, char*);
 };
 
@@ -110,15 +110,8 @@ void AGSMac::SetGameWindowIcon() {
   // do nothing
 }
 
-void AGSMac::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
+void AGSMac::WriteStdOut(const char *text) {
+  printf("%s\n", text);
 }
 
 void AGSMac::ShutdownCDPlayer() {

--- a/Engine/platform/psp/acplpsp.cpp
+++ b/Engine/platform/psp/acplpsp.cpp
@@ -73,7 +73,7 @@ struct AGSPSP : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
 };
 
 
@@ -521,15 +521,8 @@ void AGSPSP::SetGameWindowIcon() {
   // do nothing
 }
 
-void AGSPSP::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
+void AGSPSP::WriteStdOut(const char *text) {
+  printf("%s\n", text);
 }
 
 void AGSPSP::ShutdownCDPlayer() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -28,6 +28,7 @@
 #include "ac/global_display.h"
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
+#include "debug/out.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "main/engine.h"
@@ -117,7 +118,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual SetupReturnValue RunSetup(ConfigTree &cfg);
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char*);
   virtual void DisplaySwitchOut() ;
   virtual void DisplaySwitchIn() ;
   virtual void RegisterGameWithGameExplorer();
@@ -519,7 +520,7 @@ void AGSWin32::PostAllegroInit(bool windowed)
   // Sleep() don't take more time than specified
   MMRESULT result = timeBeginPeriod(win32TimerPeriod);
   if (result != TIMERR_NOERROR)
-    platform->WriteStdOut("Failed to set the timer resolution to %d ms", win32TimerPeriod);
+    Out::FPrint("Failed to set the timer resolution to %d ms", win32TimerPeriod);
 }
 
 typedef UINT (CALLBACK* Dynamic_SHGetKnownFolderPathType) (GUID& rfid, DWORD dwFlags, HANDLE hToken, PWSTR *ppszPath); 
@@ -830,15 +831,9 @@ void AGSWin32::SetGameWindowIcon() {
   set_icon();
 }
 
-void AGSWin32::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  OutputDebugString(displbuf);
+void AGSWin32::WriteStdOut(const char *text) {
+  OutputDebugString(text);
+  OutputDebugString("\n");
 }
 
 void AGSWin32::ShutdownCDPlayer() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -388,7 +388,7 @@ void AGSWin32::update_game_explorer(bool add)
   HRESULT hr = CoCreateInstance( __uuidof(GameExplorer), NULL, CLSCTX_INPROC_SERVER, __uuidof(IGameExplorer), (void**)&pFwGameExplorer);
   if( FAILED(hr) || pFwGameExplorer == NULL ) 
   {
-    OutputDebugString("AGS: Game Explorer not found to register game, Windows Vista required");
+    Out::FPrint("Game Explorer not found to register game, Windows Vista required");
   }
   else 
   {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -136,9 +136,12 @@ private:
   void create_shortcut(const char *pathToEXE, const char *workingFolder, const char *arguments, const char *shortcutPath);
   void register_file_extension(const char *exePath);
   void unregister_file_extension();
+
+  bool _isDebuggerPresent; // indicates if the win app is running in the context of a debugger
 };
 
 AGSWin32::AGSWin32() {
+  _isDebuggerPresent = ::IsDebuggerPresent() != FALSE;
   allegro_wnd = NULL;
 }
 
@@ -832,8 +835,15 @@ void AGSWin32::SetGameWindowIcon() {
 }
 
 void AGSWin32::WriteStdOut(const char *text) {
-  OutputDebugString(text);
-  OutputDebugString("\n");
+  if (_isDebuggerPresent)
+  {
+    OutputDebugString(text);
+    OutputDebugString("\n");
+  }
+  else
+  {
+    printf("%s\n", text);
+  }
 }
 
 void AGSWin32::ShutdownCDPlayer() {

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -22,6 +22,7 @@
 #include <winalleg.h>
 #include <allegro/platform/aintwin.h>
 #include <d3d9.h>
+#include "debug/out.h"
 #include "gfx/ali3d.h"
 #include "gfx/gfxfilter_d3d.h"
 #include "platform/base/agsplatformdriver.h"
@@ -32,11 +33,7 @@
 #include "util/library.h"
 #include "util/string.h"
 
-using AGS::Common::Bitmap;
-using AGS::Common::String;
-using AGS::Engine::Library;
-namespace BitmapHelper = AGS::Common::BitmapHelper;
-using namespace AGS; // FIXME later
+using namespace AGS::Common;
 
 extern int dxmedia_play_video_3d(const char*filename, IDirect3DDevice9 *device, bool useAVISound, int canskip, int stretch);
 extern void dxmedia_shutdown_3d();
@@ -745,18 +742,18 @@ int D3DGraphicsDriver::_resetDeviceIfNecessary()
 
   if (hr == D3DERR_DEVICELOST)
   {
-    OutputDebugString("AGS -- D3D Device Lost");
+    Out::FPrint("D3DGraphicsDriver: D3D Device Lost");
     // user has alt+tabbed away from the game
     return 1;
   }
 
   if (hr == D3DERR_DEVICENOTRESET)
   {
-    OutputDebugString("AGS -- D3D Device Not Reset");
+    Out::FPrint("D3DGraphicsDriver: D3D Device Not Reset");
     hr = direct3ddevice->Reset(&d3dpp);
     if (hr != D3D_OK)
     {
-      OutputDebugString("AGS -- Failed to reset D3D device");
+      Out::FPrint("D3DGraphicsDriver: Failed to reset D3D device");
       // can't throw exception because we're in the wrong thread,
       // so just return a value instead
       return 2;
@@ -929,7 +926,7 @@ int D3DGraphicsDriver::_initDLLCallback()
 
 void D3DGraphicsDriver::InitializeD3DState()
 {
-  OutputDebugString("AGS -- InitializeD3DState()");
+  Out::FPrint("D3DGraphicsDriver: InitializeD3DState()");
 
   D3DMATRIX matOrtho = {
     (2.0 / (float)_newmode_width), 0.0, 0.0, 0.0,

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -485,7 +485,7 @@ void IAGSEngine::GetTextExtent (int32 font, const char *text, int32 *width, int3
 }
 void IAGSEngine::PrintDebugConsole (const char *text) {
     DEBUG_CONSOLE("[PLUGIN] %s", text);
-    platform->WriteStdOut("[PLUGIN] %s", text);
+    platform->WriteStdOutF("AGS: [PLUGIN] %s", text);
 }
 int IAGSEngine::IsChannelPlaying (int32 channel) {
     return ::IsChannelPlaying (channel);


### PR DESCRIPTION
This picks out message formatting from platform-dependant code and keeps only simple string output in the respective platform "drivers".

Additionally made Windows version write to stdout if not run under debugger (prior it was always writing to the debugger output, even if it was not present).