### PR TITLE
Minor improvements related to logging to standard output

### DIFF
--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -185,7 +185,7 @@ void process_event(EventHappened*evp) {
 
             evblockbasename="hotspot%d";
             evblocknum=evp->data2;
-            //platform->WriteStdOut("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
+            //Out::FPrint("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
         }
         else if (evp->data1==EVB_ROOM) {
 
@@ -200,7 +200,7 @@ void process_event(EventHappened*evp) {
                 run_on_event (GE_ENTER_ROOM, RuntimeScriptValue().SetInt32(displayed_room));
 
             }
-            //platform->WriteStdOut("Running room interaction, event %d", evp->data3);
+            //Out::FPrint("Running room interaction, event %d", evp->data3);
         }
 
         if (scriptPtr != NULL)

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -490,7 +490,7 @@ int my_readkey() {
 
     /*  char message[200];
     sprintf(message, "Scancode: %04X", gott);
-    OutputDebugString(message);*/
+    Out::FPrint(message);*/
 
     /*if ((scancode >= KEY_0_PAD) && (scancode <= KEY_9_PAD)) {
     // fix numeric pad keys if numlock is off (allegro 4.2 changed this behaviour)
@@ -550,7 +550,7 @@ int my_readkey() {
     }
 
     //sprintf(message, "Keypress: %d", gott);
-    //OutputDebugString(message);
+    //Out::FPrint(message);
 
     return gott;
 }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -161,7 +161,7 @@ void write_log(char*msg) {
     fprintf(ooo,"%s\n",msg);
     fclose(ooo);
     */
-    platform->WriteStdOut(msg);
+    Out::FPrint(msg);
 }
 
 /* The idea of this is that non-essential errors such as "sound file not

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -340,8 +340,8 @@ int check_for_messages_from_editor()
 
         if (strncmp(msg, "<Engine Command=\"", 17) != 0) 
         {
-            //OutputDebugString("Faulty message received from editor:");
-            //OutputDebugString(msg);
+            //Out::FPrint("Faulty message received from editor:");
+            //Out::FPrint(msg);
             free(msg);
             return 0;
         }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -534,7 +534,7 @@ int engine_init_speech()
                 delete speechsync;
             }
             Common::AssetManager::SetDataFile(game_file_name);
-            platform->WriteStdOut("Speech sample file found and initialized.\n");
+            Out::FPrint("Speech sample file found and initialized.");
             play.want_speech=1;
         }
     }
@@ -574,7 +574,7 @@ int engine_init_music()
             return EXIT_NORMAL;
         }
         Common::AssetManager::SetDataFile(game_file_name);
-        platform->WriteStdOut("Audio vox found and initialized.\n");
+        Out::FPrint("Audio vox found and initialized.");
         play.seperate_music_lib = 1;
     }
 
@@ -652,7 +652,6 @@ bool try_install_sound(int digi_id, int midi_id)
 
 void engine_init_sound()
 {
-    platform->WriteStdOut("Checking sound inits.\n");
     if (opts.mod_player)
         reserve_voices(16, -1);
 #if ALLEGRO_DATE > 19991010

--- a/Engine/media/audio/soundcache.cpp
+++ b/Engine/media/audio/soundcache.cpp
@@ -57,7 +57,7 @@ void sound_cache_free(char* buffer, bool is_wave)
     AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("sound_cache_free(%d %d)\n", (unsigned int)buffer, (unsigned int)is_wave);
+    Out::FPrint("sound_cache_free(%d %d)\n", (unsigned int)buffer, (unsigned int)is_wave);
 #endif
     int i;
     for (i = 0; i < psp_audio_cachesize; i++)
@@ -68,14 +68,14 @@ void sound_cache_free(char* buffer, bool is_wave)
                 sound_cache_entries[i].reference--;
 
 #ifdef SOUND_CACHE_DEBUG
-            platform->WriteStdOut("..decreased reference count of slot %d to %d\n", i, sound_cache_entries[i].reference);
+            Out::FPrint("..decreased reference count of slot %d to %d\n", i, sound_cache_entries[i].reference);
 #endif
             return;
         }
     }
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("..freeing uncached sound\n");
+    Out::FPrint("..freeing uncached sound\n");
 #endif
 
     // Sound is uncached
@@ -94,7 +94,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
 	AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    platform->WriteStdOut("get_cached_sound(%s %d)\n", filename, (unsigned int)is_wave);
+    Out::FPrint("get_cached_sound(%s %d)\n", filename, (unsigned int)is_wave);
 #endif
 
     *size = 0;
@@ -108,7 +108,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
         if (strcmp(filename, sound_cache_entries[i].file_name) == 0)
         {
 #ifdef SOUND_CACHE_DEBUG
-            platform->WriteStdOut("..found in slot %d\n", i);
+            Out::FPrint("..found in slot %d\n", i);
 #endif
             sound_cache_entries[i].reference++;
             sound_cache_entries[i].last_used = sound_cache_counter++;
@@ -195,7 +195,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
     {
         // No cache slot empty, return uncached data
 #ifdef SOUND_CACHE_DEBUG
-        platform->WriteStdOut("..loading uncached\n");
+        Out::FPrint("..loading uncached\n");
 #endif
         return newdata;  
     }
@@ -203,7 +203,7 @@ char* get_cached_sound(const char* filename, bool is_wave, long* size)
     {
         // Add to cache, free old sound first
 #ifdef SOUND_CACHE_DEBUG
-        platform->WriteStdOut("..loading cached in slot %d\n", i);
+        Out::FPrint("..loading cached in slot %d\n", i);
 #endif	
 
         if (sound_cache_entries[i].data) {

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -55,7 +55,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
+  virtual void WriteStdOut(const char *fmt, ...);
 };
 
 
@@ -716,16 +716,16 @@ void AGSAndroid::SetGameWindowIcon() {
   // do nothing
 }
 
-void AGSAndroid::WriteStdOut(const char *text, ...)
+void AGSAndroid::WriteStdOut(const char *fmt, ...)
 {
+  // TODO: this check should probably be done once when setting up output targets for logging
   if (psp_debug_write_to_logcat)
   {
-    char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-    va_list ap;
-    va_start(ap,text);
-    vsprintf(&displbuf[5],text,ap);
-    va_end(ap);
-    __android_log_print(ANDROID_LOG_DEBUG, "AGSNative", "%s", displbuf);
+    va_list args;
+    va_start(args, fmt);
+    __android_log_vprint(ANDROID_LOG_DEBUG, "AGSNative", fmt, args);
+    // NOTE: __android_log_* functions add trailing '\n'
+    va_end(args);
   }
 }
 

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -20,6 +20,7 @@
 #include "util/wgt2allg.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/common.h"
+#include "ac/runtime_defines.h"
 #include "util/string_utils.h"
 #include "util/stream.h"
 #include "gfx/bitmap.h"
@@ -63,6 +64,14 @@ void AGSPlatformDriver::GetSystemTime(ScriptDateTime *sdt) {
     sdt->day = newtime->tm_mday;
     sdt->month = newtime->tm_mon + 1;
     sdt->year = newtime->tm_year + 1900;
+}
+
+void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    va_end(args);
+    printf("\n");
 }
 
 void AGSPlatformDriver::YieldCPU() {
@@ -136,7 +145,7 @@ void AGSPlatformDriver::UnlockMouse() { }
 // IOutputTarget implementation
 //-----------------------------------------------
 void AGSPlatformDriver::Out(const char *sz_fullmsg) {
-    this->WriteStdOut(sz_fullmsg);
+    this->WriteStdOut("%s", sz_fullmsg);
 }
 
 // ********** CD Player Functions common to Win and Linux ********

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -77,7 +77,9 @@ struct AGSPlatformDriver
     virtual void FinishedUsingGraphicsMode();
     virtual SetupReturnValue RunSetup(Common::ConfigTree &cfg) { return kSetup_Cancel; }
     virtual void SetGameWindowIcon();
-    virtual void WriteStdOut(const char*, ...) = 0;
+    // Formats message and writes to standard platform's output;
+    // Always adds trailing '\n' after formatted string
+    virtual void WriteStdOut(const char *fmt, ...);
     virtual void YieldCPU();
     virtual void DisplaySwitchOut();
     virtual void DisplaySwitchIn();
@@ -104,6 +106,7 @@ struct AGSPlatformDriver
     //-----------------------------------------------
     // IOutputTarget implementation
     //-----------------------------------------------
+    // Writes to the standard platform's output, prepending "AGS: " prefix to the message
     virtual void Out(const char *sz_fullmsg);
 
 private:

--- a/Engine/platform/dos/acpldos.cpp
+++ b/Engine/platform/dos/acpldos.cpp
@@ -38,7 +38,6 @@ struct AGSDOS : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual int  RunSetup();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
   virtual void YieldCPU();
   virtual void InitialiseAbufAtStartup();
   virtual void FinishedUsingGraphicsMode();
@@ -149,16 +148,6 @@ int AGSDOS::RunSetup() {
 
 void AGSDOS::ShutdownCDPlayer() {
   cd_exit();
-}
-
-void AGSDOS::WriteStdOut(const char *text, ...) {
-  char displbuf[2000];
-  va_list ap;
-  va_start(ap, text);
-  vsprintf(displbuf, text, ap);
-  va_end(ap);
-  
-  printf("%s", displbuf);
 }
 
 void AGSDOS::YieldCPU() {

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -127,7 +127,6 @@ struct AGSIOS : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
 };
 
 
@@ -535,18 +534,6 @@ bool ReadConfiguration(char* filename, bool read_everything)
 
 extern void ios_show_message_box(char* buffer);
 volatile int ios_wait_for_ui = 0;
-
-void AGSIOS::WriteStdOut(const char *text, ...)
-{
-  {
-    char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-    va_list ap;
-    va_start(ap,text);
-    vsprintf(&displbuf[5],text,ap);
-    va_end(ap);
-    printf("%s\n", displbuf);
-  }
-}
 
 
 void startEngine(char* filename, char* directory, int loadLastSave)

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -56,7 +56,6 @@ struct AGSLinux : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
   virtual bool LockMouseToWindow();
   virtual void UnlockMouse();
 };
@@ -163,17 +162,6 @@ void AGSLinux::PostAllegroExit() {
 
 void AGSLinux::SetGameWindowIcon() {
   // do nothing
-}
-
-void AGSLinux::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
 }
 
 void AGSLinux::ShutdownCDPlayer() {

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -45,7 +45,6 @@ struct AGSMac : AGSPlatformDriver {
   virtual int  RunSetup();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
   virtual void ReplaceSpecialPaths(const char*, char*);
 };
 
@@ -108,17 +107,6 @@ int AGSMac::RunSetup() {
 
 void AGSMac::SetGameWindowIcon() {
   // do nothing
-}
-
-void AGSMac::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
 }
 
 void AGSMac::ShutdownCDPlayer() {

--- a/Engine/platform/psp/acplpsp.cpp
+++ b/Engine/platform/psp/acplpsp.cpp
@@ -73,7 +73,6 @@ struct AGSPSP : AGSPlatformDriver {
   virtual void PostAllegroExit();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
-  virtual void WriteStdOut(const char*, ...);
 };
 
 
@@ -519,17 +518,6 @@ void AGSPSP::PostAllegroExit() {
 
 void AGSPSP::SetGameWindowIcon() {
   // do nothing
-}
-
-void AGSPSP::WriteStdOut(const char *text, ...) {
-  char displbuf[STD_BUFFER_SIZE] = "AGS: ";
-  va_list ap;
-  va_start(ap,text);
-  vsprintf(&displbuf[5],text,ap);
-  va_end(ap);
-  strcat(displbuf, "\n");
-
-  printf(displbuf);
 }
 
 void AGSPSP::ShutdownCDPlayer() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -388,7 +388,7 @@ void AGSWin32::update_game_explorer(bool add)
   HRESULT hr = CoCreateInstance( __uuidof(GameExplorer), NULL, CLSCTX_INPROC_SERVER, __uuidof(IGameExplorer), (void**)&pFwGameExplorer);
   if( FAILED(hr) || pFwGameExplorer == NULL ) 
   {
-    OutputDebugString("Game Explorer not found to register game, Windows Vista required");
+    Out::FPrint("Game Explorer not found to register game, Windows Vista required");
   }
   else 
   {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -136,9 +136,12 @@ private:
   void create_shortcut(const char *pathToEXE, const char *workingFolder, const char *arguments, const char *shortcutPath);
   void register_file_extension(const char *exePath);
   void unregister_file_extension();
+
+  bool _isDebuggerPresent; // indicates if the win app is running in the context of a debugger
 };
 
 AGSWin32::AGSWin32() {
+  _isDebuggerPresent = ::IsDebuggerPresent() != FALSE;
   allegro_wnd = NULL;
 }
 
@@ -832,16 +835,23 @@ void AGSWin32::SetGameWindowIcon() {
 }
 
 void AGSWin32::WriteStdOut(const char *fmt, ...) {
-  // Add "AGS:" prefix when outputting to debugger, to make it clear that this
-  // is a text from the program log
-  char buf[STD_BUFFER_SIZE] = "AGS: ";
   va_list ap;
   va_start(ap, fmt);
-  vsnprintf(buf + 5, STD_BUFFER_SIZE - 5, fmt, ap);
+  if (_isDebuggerPresent)
+  {
+    // Add "AGS:" prefix when outputting to debugger, to make it clear that this
+    // is a text from the program log
+    char buf[STD_BUFFER_SIZE] = "AGS: ";
+    vsnprintf(buf + 5, STD_BUFFER_SIZE - 5, fmt, ap);
+    OutputDebugString(buf);
+    OutputDebugString("\n");
+  }
+  else
+  {
+    vprintf(fmt, ap);
+    printf("\n");
+  }
   va_end(ap);
-
-  OutputDebugString(buf);
-  OutputDebugString("\n");
 }
 
 void AGSWin32::ShutdownCDPlayer() {

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -22,6 +22,7 @@
 #include <winalleg.h>
 #include <allegro/platform/aintwin.h>
 #include <d3d9.h>
+#include "debug/out.h"
 #include "gfx/ali3d.h"
 #include "gfx/gfxfilter_d3d.h"
 #include "platform/base/agsplatformdriver.h"
@@ -32,11 +33,7 @@
 #include "util/library.h"
 #include "util/string.h"
 
-using AGS::Common::Bitmap;
-using AGS::Common::String;
-using AGS::Engine::Library;
-namespace BitmapHelper = AGS::Common::BitmapHelper;
-using namespace AGS; // FIXME later
+using namespace AGS::Common;
 
 extern int dxmedia_play_video_3d(const char*filename, IDirect3DDevice9 *device, bool useAVISound, int canskip, int stretch);
 extern void dxmedia_shutdown_3d();
@@ -745,18 +742,18 @@ int D3DGraphicsDriver::_resetDeviceIfNecessary()
 
   if (hr == D3DERR_DEVICELOST)
   {
-    OutputDebugString("AGS -- D3D Device Lost");
+    Out::FPrint("D3DGraphicsDriver: D3D Device Lost");
     // user has alt+tabbed away from the game
     return 1;
   }
 
   if (hr == D3DERR_DEVICENOTRESET)
   {
-    OutputDebugString("AGS -- D3D Device Not Reset");
+    Out::FPrint("D3DGraphicsDriver: D3D Device Not Reset");
     hr = direct3ddevice->Reset(&d3dpp);
     if (hr != D3D_OK)
     {
-      OutputDebugString("AGS -- Failed to reset D3D device");
+      Out::FPrint("D3DGraphicsDriver: Failed to reset D3D device");
       // can't throw exception because we're in the wrong thread,
       // so just return a value instead
       return 2;
@@ -929,7 +926,7 @@ int D3DGraphicsDriver::_initDLLCallback()
 
 void D3DGraphicsDriver::InitializeD3DState()
 {
-  OutputDebugString("AGS -- InitializeD3DState()");
+  Out::FPrint("D3DGraphicsDriver: InitializeD3DState()");
 
   D3DMATRIX matOrtho = {
     (2.0 / (float)_newmode_width), 0.0, 0.0, 0.0,


### PR DESCRIPTION
This simplifies printing functions in the platform "driver" classes by removing duplicated code and limiting them to distinct implementations, and also by getting rid of intermediate string buffers where possible.

In short, only Android and Windows now override common "printf" behavior.

Additionally made Windows version write to stdout if not run under debugger (prior it was always writing to the debugger output, even if it was not present).