### PR TITLE
Fixed debian rules: version no longer has -1 at the end

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 # Keep this list of folders that are not included in the
 # orig syncronized with the one in debian/source/local-options!
 ORIG_CONTENT := $(shell git ls-tree --name-only HEAD | grep -Ev '^(Android|Editor|iOS|OSX|PSP|Windows|debian|\.git.*)')
-VERSION := $(shell dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)-.\+@\1@')
+VERSION := $(shell dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)@\1@')
 MAKE = make --directory=Engine
 GENCONTROL_SUBSTVARS = -Vbuildinfo:Date="$(shell date -R)" -Vbuildinfo:Git-Object="$(shell git show HEAD | head -n1)"
 


### PR DESCRIPTION
With the addition of the debian/git-archive-all.sh script (3a234c8), I noticed that the make_ags+libraries.sh script stopped working. As we are no longer appending the "-1" to the version string (360015a), there is no longer a need to check for it. Removing this allows make_ags+libraries to run properly, and AFAICT doesn't affect anything else in the debian build process.