### PR TITLE
Fixed debian rules: make debian revision optional

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 # Keep this list of folders that are not included in the
 # orig syncronized with the one in debian/source/local-options!
 ORIG_CONTENT := $(shell git ls-tree --name-only HEAD | grep -Ev '^(Android|Editor|iOS|OSX|PSP|Windows|debian|\.git.*)')
-VERSION := $(shell dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)-.\+@\1@')
+VERSION := $(shell dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)@\1@')
 MAKE = make --directory=Engine
 GENCONTROL_SUBSTVARS = -Vbuildinfo:Date="$(shell date -R)" -Vbuildinfo:Git-Object="$(shell git show HEAD | head -n1)"
 


### PR DESCRIPTION
Rebased #300 on master branch, and made debian revision optional instead of removing it. Version info returned by sed will include debian revision, but this does not prevent build scripts from running.