### PR TITLE
Fixing the cases of redundant consequent vsprintfs and text translation in the Script API functions

### DIFF
--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -118,7 +118,7 @@ extern AGS_INLINE void multiply_up_coordinates(int *x, int *y);
 extern AGS_INLINE int get_fixed_pixel_size(int pixels);
 
 // Those function have distinct implementations in Engine and Editor
-extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, char *texx);
+extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);
 extern int wgettextwidth_compensate(Common::Bitmap *ds, const char *tex, int font) ;
 extern void check_font(int *fontnum);
 

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -38,7 +38,7 @@ int GUIObject::IsClickable()
   return 1;
 }
 
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, char *texx)
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx)
 {
   wouttextxy(ds, xxp, yyp, usingfont, text_color, texx);
 }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -114,7 +114,7 @@ bool facetalk_qfg4_override_placement_y = false;
 // lip-sync speech settings
 int loops_per_character, text_lips_offset, char_speaking = -1;
 int char_thinking = -1;
-char *text_lips_text = NULL;
+const char *text_lips_text = NULL;
 SpeechLipSyncLine *splipsync = NULL;
 int numLipLines = 0, curLipLine = -1, curLipLinePhoneme = 0;
 
@@ -693,16 +693,8 @@ int Character_GetHasExplicitTint(CharacterInfo *chaa) {
     return 0;
 }
 
-void Character_Say(CharacterInfo *chaa, const char *texx, ...) {
-
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    _DisplaySpeechCore(chaa->index_id, displbuf);
-
+void Character_Say(CharacterInfo *chaa, const char *text) {
+    _DisplaySpeechCore(chaa->index_id, text);
 }
 
 void Character_SayAt(CharacterInfo *chaa, int x, int y, int width, const char *texx) {
@@ -889,15 +881,8 @@ void Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opaci
     chaa->flags |= CHF_HASTINT;
 }
 
-void Character_Think(CharacterInfo *chaa, const char *texx, ...) {
-
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    _DisplayThoughtCore(chaa->index_id, displbuf);
+void Character_Think(CharacterInfo *chaa, const char *text) {
+    _DisplayThoughtCore(chaa->index_id, text);
 }
 
 void Character_UnlockView(CharacterInfo *chaa) {
@@ -2167,7 +2152,7 @@ int check_click_on_character(int xx,int yy,int mood) {
     return 0;
 }
 
-void _DisplaySpeechCore(int chid, char *displbuf) {
+void _DisplaySpeechCore(int chid, const char *displbuf) {
     if (displbuf[0] == 0) {
         // no text, just update the current character who's speaking
         // this allows the portrait side to be switched with an empty
@@ -2206,7 +2191,7 @@ void _DisplayThoughtCore(int chid, const char *displbuf) {
     _displayspeech ((char*)displbuf, chid, xpp, ypp, width, 1);
 }
 
-void _displayspeech(char*texx, int aschar, int xx, int yy, int widd, int isThought) {
+void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int isThought) {
     if (!is_valid_character(aschar))
         quit("!DisplaySpeech: invalid character");
 
@@ -2684,13 +2669,13 @@ int get_character_currently_talking() {
     return -1;
 }
 
-void DisplaySpeech(char*texx, int aschar) {
+void DisplaySpeech(const char*texx, int aschar) {
     _displayspeech (texx, aschar, -1, -1, -1, 0);
 }
 
 // Calculate which frame of the loop to use for this character of
 // speech
-int GetLipSyncFrame (char *curtex, int *stroffs) {
+int GetLipSyncFrame (const char *curtex, int *stroffs) {
     /*char *frameletters[MAXLIPSYNCFRAMES] =
     {"./,/ ", "A", "O", "F/V", "D/N/G/L/R", "B/P/M",
     "Y/H/K/Q/C", "I/T/E/X/th", "U/W", "S/Z/J/ch", NULL,
@@ -2725,7 +2710,7 @@ int update_lip_sync(int talkview, int talkloop, int *talkframeptr) {
     int talkwait = 0;
 
     // lip-sync speech
-    char *nowsaying = &text_lips_text[text_lips_offset];
+    const char *nowsaying = &text_lips_text[text_lips_offset];
     // if it's an apostraphe, skip it (we'll, I'll, etc)
     if (nowsaying[0] == '\'') {
         text_lips_offset++;
@@ -2913,7 +2898,7 @@ RuntimeScriptValue Sc_Character_RunInteraction(void *self, const RuntimeScriptVa
 RuntimeScriptValue Sc_Character_Say(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_SCRIPT_SPRINTF(Character_Say, 1);
-    Character_Say((CharacterInfo*)self, "%s", scsf_buffer);
+    Character_Say((CharacterInfo*)self, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -2963,7 +2948,7 @@ RuntimeScriptValue Sc_Character_StopMoving(void *self, const RuntimeScriptValue 
 RuntimeScriptValue Sc_Character_Think(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_SCRIPT_SPRINTF(Character_Think, 1);
-    Character_Think((CharacterInfo*)self, "%s", scsf_buffer);
+    Character_Think((CharacterInfo*)self, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -3473,14 +3458,14 @@ RuntimeScriptValue Sc_Character_SetZ(void *self, const RuntimeScriptValue *param
 void ScPl_Character_Say(CharacterInfo *chaa, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    Character_Say(chaa, "%s", scsf_buffer);
+    Character_Say(chaa, scsf_buffer);
 }
 
 // void (CharacterInfo *chaa, const char *texx, ...)
 void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    Character_Think(chaa, "%s", scsf_buffer);
+    Character_Think(chaa, scsf_buffer);
 }
 
 void RegisterCharacterAPI()

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3472,20 +3472,14 @@ RuntimeScriptValue Sc_Character_SetZ(void *self, const RuntimeScriptValue *param
 // void (CharacterInfo *chaa, const char *texx, ...)
 void ScPl_Character_Say(CharacterInfo *chaa, const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     Character_Say(chaa, "%s", scsf_buffer);
 }
 
 // void (CharacterInfo *chaa, const char *texx, ...)
 void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     Character_Think(chaa, "%s", scsf_buffer);
 }
 

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -46,7 +46,7 @@ void    Character_LoseInventory(CharacterInfo *chap, ScriptInvItem *invi);
 void    Character_PlaceOnWalkableArea(CharacterInfo *chap);
 void    Character_RemoveTint(CharacterInfo *chaa);
 int     Character_GetHasExplicitTint(CharacterInfo *chaa);
-void    Character_Say(CharacterInfo *chaa, const char *texx, ...);
+void    Character_Say(CharacterInfo *chaa, const char *text);
 void    Character_SayAt(CharacterInfo *chaa, int x, int y, int width, const char *texx);
 ScriptOverlay* Character_SayBackground(CharacterInfo *chaa, const char *texx);
 void    Character_SetAsPlayer(CharacterInfo *chaa);
@@ -55,7 +55,7 @@ void    Character_SetOption(CharacterInfo *chaa, int flag, int yesorno);
 void    Character_SetSpeed(CharacterInfo *chaa, int xspeed, int yspeed);
 void    Character_StopMoving(CharacterInfo *charp);
 void    Character_Tint(CharacterInfo *chaa, int red, int green, int blue, int opacity, int luminance);
-void    Character_Think(CharacterInfo *chaa, const char *texx, ...);
+void    Character_Think(CharacterInfo *chaa, const char *text);
 void    Character_UnlockView(CharacterInfo *chaa);
 void    Character_Walk(CharacterInfo *chaa, int x, int y, int blocking, int direct);
 void    Character_Move(CharacterInfo *chaa, int x, int y, int blocking, int direct);
@@ -183,12 +183,12 @@ int my_getpixel(Common::Bitmap *blk, int x, int y);
 // X and Y co-ordinates must be in 320x200 format
 int check_click_on_character(int xx,int yy,int mood);
 int is_pos_on_character(int xx,int yy);
-void _DisplaySpeechCore(int chid, char *displbuf);
+void _DisplaySpeechCore(int chid, const char *displbuf);
 void _DisplayThoughtCore(int chid, const char *displbuf);
 
-void _displayspeech(char*texx, int aschar, int xx, int yy, int widd, int isThought);
+void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int isThought);
 int get_character_currently_talking();
-void DisplaySpeech(char*texx, int aschar);
+void DisplaySpeech(const char*texx, int aschar);
 
 int update_lip_sync(int talkview, int talkloop, int *talkframeptr);
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -40,6 +40,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "ac/spritecache.h"
 #include "gfx/gfx_util.h"
+#include "util/string_utils.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;
@@ -73,9 +74,11 @@ int texthit;
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
 // pass blocking=2 to create permanent overlay
-int _display_main(int xx,int yy,int wii,char*todis,int blocking,int usingfont,int asspch, int isThought, int allowShrink, bool overlayPositionFixed) 
+int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfont,int asspch, int isThought, int allowShrink, bool overlayPositionFixed) 
 {
     bool alphaChannel = false;
+    char todis[STD_BUFFER_SIZE];
+    snprintf(todis, STD_BUFFER_SIZE - 1, "%s", text);
     ensure_text_valid_for_font(todis, usingfont);
     break_up_text_into_lines(wii-6,usingfont,todis);
     texthit = wgetfontheight(usingfont);
@@ -335,7 +338,7 @@ int _display_main(int xx,int yy,int wii,char*todis,int blocking,int usingfont,in
     return 0;
 }
 
-void _display_at(int xx,int yy,int wii,char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed) {
+void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed) {
     int usingfont=FONT_NORMAL;
     if (asspch) usingfont=FONT_SPEECH;
     int needStopSpeech = 0;
@@ -415,7 +418,7 @@ bool ShouldAntiAliasText() {
     return (game.options[OPT_ANTIALIASFONTS] != 0);
 }
 
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, char*texx) {
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char*texx) {
     
     color_t outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
     if (game.fontoutline[usingfont] >= 0) {

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -20,11 +20,11 @@
 
 #include "gui/guimain.h"
 
-int  _display_main(int xx,int yy,int wii,char*todis,int blocking,int usingfont,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
-void _display_at(int xx,int yy,int wii,char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
+int  _display_main(int xx,int yy,int wii,const char*todis,int blocking,int usingfont,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
+void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
 bool ShouldAntiAliasText();
 int GetTextDisplayTime (const char *text, int canberel=0);
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, char*texx);
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char*texx);
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, int align);
 int wgetfontheight(int font);
 int wgettextwidth_compensate(const char *tex, int font);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -369,14 +369,8 @@ void DrawingSurface_DrawTriangle(ScriptDrawingSurface *sds, int x1, int y1, int 
     sds->FinishedDrawing();
 }
 
-void DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
+void DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* text)
 {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-    
     sds->MultiplyCoordinates(&xx, &yy);
     Bitmap *ds = sds->StartDrawing();
     // don't use wtextcolor because it will do a 16->32 conversion
@@ -385,7 +379,7 @@ void DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int fo
         text_color = ds->GetCompatibleColor(1);
         debug_log ("RawPrint: Attempted to use hi-color on 256-col background");
     }
-    wouttext_outline(ds, xx, yy, font, text_color, displbuf);
+    wouttext_outline(ds, xx, yy, font, text_color, text);
     sds->FinishedDrawing();
 }
 
@@ -554,7 +548,7 @@ RuntimeScriptValue Sc_DrawingSurface_DrawRectangle(void *self, const RuntimeScri
 RuntimeScriptValue Sc_DrawingSurface_DrawString(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_SCRIPT_SPRINTF(DrawingSurface_DrawString, 4);
-    DrawingSurface_DrawString((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue, "%s", scsf_buffer);
+    DrawingSurface_DrawString((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -634,7 +628,7 @@ RuntimeScriptValue Sc_DrawingSurface_GetWidth(void *self, const RuntimeScriptVal
 void ScPl_DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    DrawingSurface_DrawString(sds, xx, yy, font, "%s", scsf_buffer);
+    DrawingSurface_DrawString(sds, xx, yy, font, scsf_buffer);
 }
 
 void RegisterDrawingSurfaceAPI()

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -633,10 +633,7 @@ RuntimeScriptValue Sc_DrawingSurface_GetWidth(void *self, const RuntimeScriptVal
 // void (ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
 void ScPl_DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     DrawingSurface_DrawString(sds, xx, yy, font, "%s", scsf_buffer);
 }
 

--- a/Engine/ac/drawingsurface.h
+++ b/Engine/ac/drawingsurface.h
@@ -35,7 +35,7 @@ void	DrawingSurface_Clear(ScriptDrawingSurface *sds, int colour);
 void	DrawingSurface_DrawCircle(ScriptDrawingSurface *sds, int x, int y, int radius);
 void	DrawingSurface_DrawRectangle(ScriptDrawingSurface *sds, int x1, int y1, int x2, int y2);
 void	DrawingSurface_DrawTriangle(ScriptDrawingSurface *sds, int x1, int y1, int x2, int y2, int x3, int y3);
-void	DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...);
+void	DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* text);
 void	DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy, int wid, int font, int alignment, const char *msg);
 void	DrawingSurface_DrawMessageWrapped(ScriptDrawingSurface *sds, int xx, int yy, int wid, int font, int msgm);
 void	DrawingSurface_DrawLine(ScriptDrawingSurface *sds, int fromx, int fromy, int tox, int toy, int thickness);

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -74,7 +74,7 @@ extern ScriptString myScriptStringImpl;
 RuntimeScriptValue Sc_sc_AbortGame(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(_sc_AbortGame, 1);
-    _sc_AbortGame("%s", scsf_buffer);
+    _sc_AbortGame(scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -190,7 +190,7 @@ RuntimeScriptValue Sc_CreateTextOverlay(const RuntimeScriptValue *params, int32_
     API_SCALL_SCRIPT_SPRINTF(CreateTextOverlay, 6);
     return RuntimeScriptValue().SetInt32(
         CreateTextOverlay(params[0].IValue, params[1].IValue, params[2].IValue,
-            params[3].IValue, params[4].IValue, "%s", scsf_buffer));
+            params[3].IValue, params[4].IValue, scsf_buffer));
 }
 
 // void (int strt,int eend)
@@ -247,7 +247,7 @@ RuntimeScriptValue Sc_DisableRegion(const RuntimeScriptValue *params, int32_t pa
 RuntimeScriptValue Sc_Display(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(Display, 1);
-    Display("%s", scsf_buffer);
+    DisplaySimple(scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -255,7 +255,7 @@ RuntimeScriptValue Sc_Display(const RuntimeScriptValue *params, int32_t param_co
 RuntimeScriptValue Sc_DisplayAt(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(DisplayAt, 4);
-    DisplayAt(params[0].IValue, params[1].IValue, params[2].IValue, "%s", scsf_buffer);
+    DisplayAt(params[0].IValue, params[1].IValue, params[2].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -307,7 +307,7 @@ RuntimeScriptValue Sc_DisplaySpeechBackground(const RuntimeScriptValue *params, 
 RuntimeScriptValue Sc_DisplayThought(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(DisplayThought, 2);
-    DisplayThought(params[0].IValue, "%s", scsf_buffer);
+    DisplayThought(params[0].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -315,7 +315,7 @@ RuntimeScriptValue Sc_DisplayThought(const RuntimeScriptValue *params, int32_t p
 RuntimeScriptValue Sc_DisplayTopBar(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(DisplayTopBar, 5);
-    DisplayTopBar(params[0].IValue, params[1].IValue, params[2].IValue, params[3].Ptr, "%s", scsf_buffer);
+    DisplayTopBar(params[0].IValue, params[1].IValue, params[2].IValue, params[3].Ptr, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -1303,7 +1303,7 @@ RuntimeScriptValue Sc_RawDrawTriangle(const RuntimeScriptValue *params, int32_t 
 RuntimeScriptValue Sc_RawPrint(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(RawPrint, 3);
-    RawPrint(params[0].IValue, params[1].IValue, "%s", scsf_buffer);
+    RawPrint(params[0].IValue, params[1].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -1953,7 +1953,7 @@ RuntimeScriptValue Sc_SetTextOverlay(const RuntimeScriptValue *params, int32_t p
 {
     API_SCALL_SCRIPT_SPRINTF(SetTextOverlay, 7);
     SetTextOverlay(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue,
-                   params[4].IValue, params[5].IValue, "%s", scsf_buffer);
+                   params[4].IValue, params[5].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -2099,7 +2099,7 @@ RuntimeScriptValue Sc_sc_strcpy(const RuntimeScriptValue *params, int32_t param_
 RuntimeScriptValue Sc_sc_sprintf(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(_sc_sprintf, 2);
-    _sc_sprintf(params[0].Ptr, "%s", scsf_buffer);
+    _sc_strcpy(params[0].Ptr, scsf_buffer);
     return params[0];
 }
 
@@ -2197,14 +2197,14 @@ RuntimeScriptValue Sc_WaitMouseKey(const RuntimeScriptValue *params, int32_t par
 void ScPl_sc_AbortGame(const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    _sc_AbortGame("%s", scsf_buffer);
+    _sc_AbortGame(scsf_buffer);
 }
 
 // int (int xx,int yy,int wii,int fontid,int clr,char*texx, ...)
 int ScPl_CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    return CreateTextOverlay(xx, yy, wii, fontid, clr, "%s", scsf_buffer);
+    return CreateTextOverlay(xx, yy, wii, fontid, clr, scsf_buffer);
 }
 
 // void (char*texx, ...)
@@ -2218,7 +2218,7 @@ void ScPl_Display(char *texx, ...)
 void ScPl_DisplayAt(int xxp, int yyp, int widd, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    DisplayAt(xxp, yyp, widd, "%s", scsf_buffer);
+    DisplayAt(xxp, yyp, widd, scsf_buffer);
 }
 
 // void (int chid,char*texx, ...)
@@ -2232,35 +2232,35 @@ void ScPl_sc_displayspeech(int chid, char *texx, ...)
 void ScPl_DisplayThought(int chid, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    DisplayThought(chid, "%s", scsf_buffer);
+    DisplayThought(chid, scsf_buffer);
 }
 
 // void (int ypos, int ttexcol, int backcol, char *title, char*texx, ...)
 void ScPl_DisplayTopBar(int ypos, int ttexcol, int backcol, char *title, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    DisplayTopBar(ypos, ttexcol, backcol, title, "%s", scsf_buffer);
+    DisplayTopBar(ypos, ttexcol, backcol, title, scsf_buffer);
 }
 
 // void  (int xx, int yy, char*texx, ...)
 void ScPl_RawPrint(int xx, int yy, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    RawPrint(xx, yy, "%s", scsf_buffer);
+    RawPrint(xx, yy, scsf_buffer);
 }
 
 // void (int ovrid,int xx,int yy,int wii,int fontid,int clr,char*texx,...)
 void ScPl_SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int clr, char*texx,...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    SetTextOverlay(ovrid, xx, yy, wii, fontid, clr, "%s", scsf_buffer);
+    SetTextOverlay(ovrid, xx, yy, wii, fontid, clr, scsf_buffer);
 }
 
 // void (char*destt, const char*texx, ...);
 void ScPl_sc_sprintf(char *destt, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    _sc_sprintf(destt, "%s", scsf_buffer);
+    _sc_strcpy(destt, scsf_buffer);
 }
 
 

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2196,100 +2196,70 @@ RuntimeScriptValue Sc_WaitMouseKey(const RuntimeScriptValue *params, int32_t par
 // void (char*texx, ...)
 void ScPl_sc_AbortGame(const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     _sc_AbortGame("%s", scsf_buffer);
 }
 
 // int (int xx,int yy,int wii,int fontid,int clr,char*texx, ...)
 int ScPl_CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     return CreateTextOverlay(xx, yy, wii, fontid, clr, "%s", scsf_buffer);
 }
 
 // void (char*texx, ...)
 void ScPl_Display(char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     Display("%s", scsf_buffer);
 }
 
 // void (int xxp,int yyp,int widd,char*texx, ...)
 void ScPl_DisplayAt(int xxp, int yyp, int widd, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     DisplayAt(xxp, yyp, widd, "%s", scsf_buffer);
 }
 
 // void (int chid,char*texx, ...)
 void ScPl_sc_displayspeech(int chid, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     __sc_displayspeech(chid, "%s", scsf_buffer);
 }
 
 // void (int chid, const char*texx, ...)
 void ScPl_DisplayThought(int chid, const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     DisplayThought(chid, "%s", scsf_buffer);
 }
 
 // void (int ypos, int ttexcol, int backcol, char *title, char*texx, ...)
 void ScPl_DisplayTopBar(int ypos, int ttexcol, int backcol, char *title, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     DisplayTopBar(ypos, ttexcol, backcol, title, "%s", scsf_buffer);
 }
 
 // void  (int xx, int yy, char*texx, ...)
 void ScPl_RawPrint(int xx, int yy, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     RawPrint(xx, yy, "%s", scsf_buffer);
 }
 
 // void (int ovrid,int xx,int yy,int wii,int fontid,int clr,char*texx,...)
 void ScPl_SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int clr, char*texx,...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     SetTextOverlay(ovrid, xx, yy, wii, fontid, clr, "%s", scsf_buffer);
 }
 
 // void (char*destt, const char*texx, ...);
 void ScPl_sc_sprintf(char *destt, const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     _sc_sprintf(destt, "%s", scsf_buffer);
 }
 

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -287,7 +287,7 @@ RuntimeScriptValue Sc_DisplayMessageBar(const RuntimeScriptValue *params, int32_
 RuntimeScriptValue Sc_sc_displayspeech(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(DisplayAt, 2);
-    __sc_displayspeech(params[0].IValue, "%s", scsf_buffer);
+    __sc_displayspeech(params[0].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -2211,7 +2211,7 @@ int ScPl_CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, char *t
 void ScPl_Display(char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    Display("%s", scsf_buffer);
+    DisplaySimple(scsf_buffer);
 }
 
 // void (int xxp,int yyp,int widd,char*texx, ...)
@@ -2225,7 +2225,7 @@ void ScPl_DisplayAt(int xxp, int yyp, int widd, char *texx, ...)
 void ScPl_sc_displayspeech(int chid, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    __sc_displayspeech(chid, "%s", scsf_buffer);
+    __sc_displayspeech(chid, scsf_buffer);
 }
 
 // void (int chid, const char*texx, ...)

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -522,17 +522,11 @@ void LoseInventoryFromCharacter(int charid, int inum) {
     Character_LoseInventory(&game.chars[charid], &scrInv[inum]);
 }
 
-void DisplayThought(int chid, const char*texx, ...) {
+void DisplayThought(int chid, const char *text) {
     if ((chid < 0) || (chid >= game.numcharacters))
         quit("!DisplayThought: invalid character specified");
 
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    _DisplayThoughtCore(chid, displbuf);
+    _DisplayThoughtCore(chid, text);
 }
 
 void __sc_displayspeech(int chid, const char*texx, ...) {

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -529,18 +529,11 @@ void DisplayThought(int chid, const char *text) {
     _DisplayThoughtCore(chid, text);
 }
 
-void __sc_displayspeech(int chid, const char*texx, ...) {
+void __sc_displayspeech(int chid, const char *text) {
     if ((chid<0) || (chid>=game.numcharacters))
         quit("!DisplaySpeech: invalid character specified");
 
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    _DisplaySpeechCore(chid, displbuf);
-
+    _DisplaySpeechCore(chid, text);
 }
 
 // **** THIS IS UNDOCUMENTED BECAUSE IT DOESN'T WORK PROPERLY

--- a/Engine/ac/global_character.h
+++ b/Engine/ac/global_character.h
@@ -79,7 +79,7 @@ void update_invorder();
 void add_inventory(int inum);
 void lose_inventory(int inum);
 
-void DisplayThought(int chid, const char*texx, ...);
+void DisplayThought(int chid, const char *text);
 void __sc_displayspeech(int chid, const char*texx, ...);
 void DisplaySpeechAt (int xx, int yy, int wii, int aschar, const char*spch);
 int DisplaySpeechBackground(int charid, const char*speel);

--- a/Engine/ac/global_character.h
+++ b/Engine/ac/global_character.h
@@ -80,7 +80,7 @@ void add_inventory(int inum);
 void lose_inventory(int inum);
 
 void DisplayThought(int chid, const char *text);
-void __sc_displayspeech(int chid, const char*texx, ...);
+void __sc_displayspeech(int chid, const char *text);
 void DisplaySpeechAt (int xx, int yy, int wii, int aschar, const char*spch);
 int DisplaySpeechBackground(int charid, const char*speel);
 

--- a/Engine/ac/global_display.cpp
+++ b/Engine/ac/global_display.cpp
@@ -50,15 +50,14 @@ void Display(const char*texx, ...) {
     DisplayAtY (-1, displbuf);
 }
 
-void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const char*texx, ...) {
+void DisplaySimple(const char *text)
+{
+    DisplayAtY (-1, text);
+}
+
+void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const char*text) {
 
     strcpy(topBar.text, get_translation(title));
-
-    char displbuf[3001];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
 
     if (ypos > 0)
         play.top_bar_ypos = ypos;
@@ -78,16 +77,16 @@ void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const 
 
     // DisplaySpeech normally sets this up, but since we're not going via it...
     if (play.cant_skip_speech & SKIP_AUTOTIMER)
-        play.messagetime = GetTextDisplayTime(texx);
+        play.messagetime = GetTextDisplayTime(text);
 
-    DisplayAtY(play.top_bar_ypos, displbuf);
+    DisplayAtY(play.top_bar_ypos, text);
 }
 
 // Display a room/global message in the bar
 void DisplayMessageBar(int ypos, int ttexcol, int backcol, const char *title, int msgnum) {
     char msgbufr[3001];
     get_message_text(msgnum, msgbufr);
-    DisplayTopBar(ypos, ttexcol, backcol, title, "%s", msgbufr);
+    DisplayTopBar(ypos, ttexcol, backcol, title, msgbufr);
 }
 
 void DisplayMessageAtY(int msnum, int ypos) {
@@ -140,19 +139,13 @@ void DisplayMessage(int msnum) {
     DisplayMessageAtY (msnum, -1);
 }
 
-void DisplayAt(int xxp,int yyp,int widd, const char*texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
+void DisplayAt(int xxp,int yyp,int widd, const char* text) {
     multiply_up_coordinates(&xxp, &yyp);
     widd = multiply_up_coordinate(widd);
 
     if (widd<1) widd=scrnwid/2;
     if (xxp<0) xxp=scrnwid/2-widd/2;
-    _display_at(xxp,yyp,widd,displbuf,1,0, 0, 0, false);
+    _display_at(xxp,yyp,widd,text,1,0, 0, 0, false);
 }
 
 void DisplayAtY (int ypos, const char *texx) {

--- a/Engine/ac/global_display.h
+++ b/Engine/ac/global_display.h
@@ -20,12 +20,13 @@
 
 #include "ac/speech.h"
 
-void Display(const char*texx, ...);
-void DisplayAt(int xxp,int yyp,int widd, const char*texx, ...);
+void Display(const char*texx, ...); // applies translation
+void DisplaySimple(const char* text); // does not apply translation
+void DisplayAt(int xxp,int yyp,int widd, const char*text);
 void DisplayAtY (int ypos, const char *texx);
 void DisplayMessage(int msnum);
 void DisplayMessageAtY(int msnum, int ypos);
-void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const char*texx, ...);
+void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const char *text);
 // Display a room/global message in the bar
 void DisplayMessageBar(int ypos, int ttexcol, int backcol, const char *title, int msgnum);
 

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -140,12 +140,7 @@ void RawSetColorRGB(int red, int grn, int blu) {
 
     play.raw_color = makecol_depth(thisroom.ebscene[play.bg_frame]->GetColorDepth(), red, grn, blu);
 }
-void RawPrint (int xx, int yy, const char*texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
+void RawPrint (int xx, int yy, const char *text) {
     RAW_START();
     // don't use wtextcolor because it will do a 16->32 conversion
     color_t text_color = play.raw_color;
@@ -154,7 +149,7 @@ void RawPrint (int xx, int yy, const char*texx, ...) {
         debug_log ("RawPrint: Attempted to use hi-color on 256-col background");
     }
     multiply_up_coordinates(&xx, &yy);
-    wouttext_outline(RAW_SURFACE(), xx, yy, play.normal_font, text_color, displbuf);
+    wouttext_outline(RAW_SURFACE(), xx, yy, play.normal_font, text_color, text);
     // we must invalidate the entire screen because these are room
     // co-ordinates, not screen co-ords which it works with
     invalidate_screen();

--- a/Engine/ac/global_drawingsurface.h
+++ b/Engine/ac/global_drawingsurface.h
@@ -29,7 +29,7 @@ void RawDrawFrameTransparent (int frame, int translev);
 void RawClear (int clr);
 void RawSetColor (int clr);
 void RawSetColorRGB(int red, int grn, int blu);
-void RawPrint (int xx, int yy, const char*texx, ...);
+void RawPrint (int xx, int yy, const char *text);
 void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm);
 void RawDrawImageCore(int xx, int yy, int slot, int alpha = 0xFF);
 void RawDrawImage(int xx, int yy, int slot);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -54,6 +54,7 @@
 #include "gfx/graphicsdriver.h"
 #include "core/assetmanager.h"
 #include "main/game_file.h"
+#include "util/string_utils.h"
 
 using AGS::Common::String;
 using AGS::Common::Bitmap;
@@ -892,13 +893,9 @@ void SetNormalFont (int fontnum) {
     play.normal_font = fontnum;
 }
 
-void _sc_AbortGame(const char*texx, ...) {
+void _sc_AbortGame(const char* text) {
     char displbuf[STD_BUFFER_SIZE] = "!?";
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(&displbuf[2], get_translation(texx), ap);
-    va_end(ap);
-
+    snprintf(&displbuf[2], STD_BUFFER_SIZE - 3, "%s", text);
     quit(displbuf);
 }
 

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -73,7 +73,7 @@ void GetMessageText (int msg, char *buffer);
 void SetSpeechFont (int fontnum);
 void SetNormalFont (int fontnum);
 
-void _sc_AbortGame(const char*texx, ...);
+void _sc_AbortGame(const char* text);
 
 int GetGraphicalVariable (const char *varName);
 void SetGraphicalVariable (const char *varName, int p_value);

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -68,13 +68,7 @@ int CreateTextOverlayCore(int xx, int yy, int wii, int fontid, int clr, const ch
     return _display_main(xx,yy,wii, (char*)tex, blcode,fontid,-clr, 0, allowShrink, false);
 }
 
-int CreateTextOverlay(int xx,int yy,int wii,int fontid,int clr, const char*texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
+int CreateTextOverlay(int xx,int yy,int wii,int fontid,int clr, const char* text) {
     int allowShrink = 0;
 
     if (xx != OVR_AUTOPLACE) {
@@ -84,18 +78,13 @@ int CreateTextOverlay(int xx,int yy,int wii,int fontid,int clr, const char*texx,
     else  // allow DisplaySpeechBackground to be shrunk
         allowShrink = 1;
 
-    return CreateTextOverlayCore(xx, yy, wii, fontid, clr, displbuf, allowShrink);
+    return CreateTextOverlayCore(xx, yy, wii, fontid, clr, text, allowShrink);
 }
 
-void SetTextOverlay(int ovrid,int xx,int yy,int wii,int fontid,int clr, const char*texx,...) {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
+void SetTextOverlay(int ovrid,int xx,int yy,int wii,int fontid,int clr, const char *text) {
     RemoveOverlay(ovrid);
     crovr_id=ovrid;
-    if (CreateTextOverlay(xx,yy,wii,fontid,clr,displbuf)!=ovrid)
+    if (CreateTextOverlay(xx,yy,wii,fontid,clr,text)!=ovrid)
         quit("SetTextOverlay internal error: inconsistent type ids");
 }
 

--- a/Engine/ac/global_overlay.h
+++ b/Engine/ac/global_overlay.h
@@ -21,8 +21,8 @@
 void RemoveOverlay(int ovrid);
 int  CreateGraphicOverlay(int xx,int yy,int slott,int trans);
 int  CreateTextOverlayCore(int xx, int yy, int wii, int fontid, int clr, const char *tex, int allowShrink);
-int  CreateTextOverlay(int xx,int yy,int wii,int fontid,int clr, const char*texx, ...);
-void SetTextOverlay(int ovrid,int xx,int yy,int wii,int fontid,int clr, const char*texx,...);
+int  CreateTextOverlay(int xx,int yy,int wii,int fontid,int clr, const char* text);
+void SetTextOverlay(int ovrid,int xx,int yy,int wii,int fontid,int clr, const char *text);
 void MoveOverlay(int ovrid, int newx,int newy);
 int  IsOverlayValid(int ovrid);
 

--- a/Engine/ac/global_string.cpp
+++ b/Engine/ac/global_string.cpp
@@ -46,11 +46,6 @@ void _sc_strcat(char*s1, const char*s2) {
     my_strncpy(&s1[strlen(s1)], s2, mosttocopy);
 }
 
-void _sc_strcpy(char*s1, const char*s2) {
-    check_strlen(s1);
-    my_strncpy(s1, s2, MAXSTRLEN - 1);
-}
-
 void _sc_strlower (char *desbuf) {
     VALIDATE_STRING(desbuf);
     check_strlen (desbuf);
@@ -71,14 +66,8 @@ int _sc_stricmp (char *s1, char *s2) {
 return stricmp (get_translation (s1), get_translation(s2));
 }*/
 
-void _sc_sprintf(char*destt, const char*texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
+void _sc_strcpy(char*destt, const char *text) {
     VALIDATE_STRING(destt);
     check_strlen(destt);
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    my_strncpy(destt, displbuf, MAXSTRLEN - 1);
+    my_strncpy(destt, text, MAXSTRLEN - 1);
 }

--- a/Engine/ac/global_string.h
+++ b/Engine/ac/global_string.h
@@ -21,9 +21,8 @@
 int StrGetCharAt (const char *strin, int posn);
 void StrSetCharAt (char *strin, int posn, int nchar);
 void _sc_strcat(char*s1, const char*s2);
-void _sc_strcpy(char*s1, const char*s2);
 void _sc_strlower (char *desbuf);
 void _sc_strupper (char *desbuf);
-void _sc_sprintf(char*destt, const char*texx, ...);
+void _sc_strcpy(char*destt, const char*text);
 
 #endif // __AGS_EE_AC__GLOBALSTRING_H

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -52,13 +52,7 @@ void Overlay_Remove(ScriptOverlay *sco) {
     sco->Remove();
 }
 
-void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const char*texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf,get_translation(texx),ap);
-    va_end(ap);
-
+void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const char*text) {
     int ovri=find_overlay_of_type(scover->overlayId);
     if (ovri<0)
         quit("!Overlay.SetText: invalid overlay ID specified");
@@ -68,7 +62,7 @@ void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const 
     RemoveOverlay(scover->overlayId);
     crovr_id = scover->overlayId;
 
-    if (CreateTextOverlay(xx,yy,wii,fontid,clr,displbuf) != scover->overlayId)
+    if (CreateTextOverlay(xx,yy,wii,fontid,clr,text) != scover->overlayId)
         quit("SetTextOverlay internal error: inconsistent type ids");
 }
 
@@ -300,7 +294,7 @@ RuntimeScriptValue Sc_Overlay_CreateTextual(const RuntimeScriptValue *params, in
 RuntimeScriptValue Sc_Overlay_SetText(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_SCRIPT_SPRINTF(Overlay_SetText, 4);
-    Overlay_SetText((ScriptOverlay*)self, params[0].IValue, params[1].IValue, params[2].IValue, "%s", scsf_buffer);
+    Overlay_SetText((ScriptOverlay*)self, params[0].IValue, params[1].IValue, params[2].IValue, scsf_buffer);
     return RuntimeScriptValue();
 }
 
@@ -357,7 +351,7 @@ ScriptOverlay* ScPl_Overlay_CreateTextual(int x, int y, int width, int font, int
 void ScPl_Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    Overlay_SetText(scover, wii, fontid, clr, "%s", scsf_buffer);
+    Overlay_SetText(scover, wii, fontid, clr, scsf_buffer);
 }
 
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -62,7 +62,7 @@ void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const 
     RemoveOverlay(scover->overlayId);
     crovr_id = scover->overlayId;
 
-    if (CreateTextOverlay(xx,yy,wii,fontid,clr,text) != scover->overlayId)
+    if (CreateTextOverlay(xx,yy,wii,fontid,clr,get_translation(text)) != scover->overlayId)
         quit("SetTextOverlay internal error: inconsistent type ids");
 }
 
@@ -127,19 +127,13 @@ ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent) 
     return sco;
 }
 
-ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text, ...) {
+ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text) {
     ScriptOverlay *sco = new ScriptOverlay();
-
-    char displbuf[STD_BUFFER_SIZE];
-    va_list ap;
-    va_start(ap,text);
-    vsprintf(displbuf,get_translation(text),ap);
-    va_end(ap);
 
     multiply_up_coordinates(&x, &y);
     width = multiply_up_coordinate(width);
 
-    sco->overlayId = CreateTextOverlayCore(x, y, width, font, colour, displbuf, 0);
+    sco->overlayId = CreateTextOverlayCore(x, y, width, font, colour, text, 0);
 
     int ovri = find_overlay_of_type(sco->overlayId);
     sco->borderWidth = divide_down_coordinate(screenover[ovri].x - x);
@@ -286,7 +280,7 @@ RuntimeScriptValue Sc_Overlay_CreateTextual(const RuntimeScriptValue *params, in
 {
     API_SCALL_SCRIPT_SPRINTF(Overlay_CreateTextual, 6);
     ScriptOverlay *overlay = Overlay_CreateTextual(params[0].IValue, params[1].IValue, params[2].IValue,
-                                                   params[3].IValue, params[4].IValue, "%s", scsf_buffer);
+                                                   params[3].IValue, params[4].IValue, scsf_buffer);
     return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
 }
 
@@ -344,7 +338,7 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
 ScriptOverlay* ScPl_Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char *text, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(text);
-    return Overlay_CreateTextual(x, y, width, font, colour, "%s", scsf_buffer);
+    return Overlay_CreateTextual(x, y, width, font, colour, scsf_buffer);
 }
 
 // void (ScriptOverlay *scover, int wii, int fontid, int clr, char*texx, ...)

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -349,20 +349,14 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
 // ScriptOverlay* (int x, int y, int width, int font, int colour, const char* text, ...)
 ScriptOverlay* ScPl_Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char *text, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, text);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(text), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(text);
     return Overlay_CreateTextual(x, y, width, font, colour, "%s", scsf_buffer);
 }
 
 // void (ScriptOverlay *scover, int wii, int fontid, int clr, char*texx, ...)
 void ScPl_Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     Overlay_SetText(scover, wii, fontid, clr, "%s", scsf_buffer);
 }
 

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -24,7 +24,7 @@ namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 
 void Overlay_Remove(ScriptOverlay *sco);
-void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const char*texx, ...);
+void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, const char*text);
 int  Overlay_GetX(ScriptOverlay *scover);
 void Overlay_SetX(ScriptOverlay *scover, int newx);
 int  Overlay_GetY(ScriptOverlay *scover);

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -31,7 +31,7 @@ int  Overlay_GetY(ScriptOverlay *scover);
 void Overlay_SetY(ScriptOverlay *scover, int newy);
 int  Overlay_GetValid(ScriptOverlay *scover);
 ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent);
-ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text, ...);
+ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
 
 int  find_overlay_of_type(int typ);
 void remove_screen_overlay(int type);

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -181,17 +181,6 @@ const char* String_UpperCase(const char *thisString) {
     return CreateNewScriptString(buffer, false);
 }
 
-const char* String_Format(const char *texx, ...) {
-    char displbuf[STD_BUFFER_SIZE];
-
-    va_list ap;
-    va_start(ap,texx);
-    vsprintf(displbuf, get_translation(texx), ap);
-    va_end(ap);
-
-    return CreateNewScriptString(displbuf);
-}
-
 int String_GetChars(const char *texx, int index) {
     if ((index < 0) || (index >= (int)strlen(texx)))
         return 0;
@@ -421,7 +410,7 @@ RuntimeScriptValue Sc_String_EndsWith(void *self, const RuntimeScriptValue *para
 RuntimeScriptValue Sc_String_Format(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(String_Format, 1);
-    return RuntimeScriptValue().SetDynamicObject((void*)String_Format("%s", scsf_buffer), &myScriptStringImpl);
+    return RuntimeScriptValue().SetDynamicObject((void*)CreateNewScriptString(scsf_buffer), &myScriptStringImpl);
 }
 
 // const char* (const char *thisString)
@@ -500,7 +489,7 @@ RuntimeScriptValue Sc_strlen(void *self, const RuntimeScriptValue *params, int32
 const char *ScPl_String_Format(const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
-    return String_Format("%s", scsf_buffer);
+    return CreateNewScriptString(scsf_buffer);
 }
 
 

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -499,10 +499,7 @@ RuntimeScriptValue Sc_strlen(void *self, const RuntimeScriptValue *params, int32
 // const char* (const char *texx, ...)
 const char *ScPl_String_Format(const char *texx, ...)
 {
-    va_list arg_ptr;
-    va_start(arg_ptr, texx);
-    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, 3000, get_translation(texx), arg_ptr);
-    va_end(arg_ptr);
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
     return String_Format("%s", scsf_buffer);
 }
 

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -36,7 +36,6 @@ int String_EndsWith(const char *thisString, const char *checkForString, bool cas
 const char* String_Replace(const char *thisString, const char *lookForText, const char *replaceWithText, bool caseSensitive);
 const char* String_LowerCase(const char *thisString);
 const char* String_UpperCase(const char *thisString);
-const char* String_Format(const char *texx, ...);
 int String_GetChars(const char *texx, int index);
 int StringToInt(const char*stino);
 int StrContains (const char *s1, const char *s2);

--- a/Engine/script/script_api.cpp
+++ b/Engine/script/script_api.cpp
@@ -26,7 +26,7 @@ namespace Math = AGS::Common::Math;
 #define snprintf _snprintf
 #endif
 
-char ScSfBuffer[3000];
+char ScSfBuffer[STD_BUFFER_SIZE];
 
 enum FormatParseResult
 {

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -21,6 +21,7 @@
 
 #include <stdarg.h>
 #include "core/types.h"
+#include "ac/runtime_defines.h"
 #include "ac/statobj/agsstaticobject.h"
 
 struct RuntimeScriptValue;
@@ -34,7 +35,7 @@ const char *ScriptSprintf(char *buffer, size_t buf_length, const char *format, c
 // Variadic sprintf (needed, because all arguments are pushed as pointer-sized values). Currently used only when plugin calls
 // exported engine function. Should be removed when this plugin issue is resolved.
 const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *format, va_list &arg_ptr);
-extern char ScSfBuffer[3000];
+extern char ScSfBuffer[STD_BUFFER_SIZE];
 
 // Helper macros for script functions
 #define ASSERT_SELF(METHOD) \
@@ -78,11 +79,20 @@ extern char ScSfBuffer[3000];
 
 #define API_SCALL_SCRIPT_SPRINTF(FUNCTION, PARAM_COUNT) \
     ASSERT_PARAM_COUNT(FUNCTION, PARAM_COUNT) \
-    const char *scsf_buffer = ScriptSprintf(ScSfBuffer, 3000, get_translation(params[PARAM_COUNT - 1].Ptr), params + PARAM_COUNT, param_count - PARAM_COUNT)
+    const char *scsf_buffer = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, get_translation(params[PARAM_COUNT - 1].Ptr), params + PARAM_COUNT, param_count - PARAM_COUNT)
 
 #define API_OBJCALL_SCRIPT_SPRINTF(METHOD, PARAM_COUNT) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, PARAM_COUNT) \
-    const char *scsf_buffer = ScriptSprintf(ScSfBuffer, 3000, get_translation(params[PARAM_COUNT - 1].Ptr), params + PARAM_COUNT, param_count - PARAM_COUNT)
+    const char *scsf_buffer = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, get_translation(params[PARAM_COUNT - 1].Ptr), params + PARAM_COUNT, param_count - PARAM_COUNT)
+
+//-----------------------------------------------------------------------------
+// Calls to ScriptSprintfV (unsafe plugin variant)
+
+#define API_PLUGIN_SCRIPT_SPRINTF(FORMAT_STR) \
+    va_list args; \
+    va_start(args, FORMAT_STR); \
+    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, STD_BUFFER_SIZE, get_translation(FORMAT_STR), args); \
+    va_end(args)
 
 //-----------------------------------------------------------------------------
 // Calls to static functions

--- a/Engine/test/test_sprintf.cpp
+++ b/Engine/test/test_sprintf.cpp
@@ -30,22 +30,22 @@ void Test_ScriptSprintf()
 
     // Correct format, extra placeholder
     const char *result = 
-        ScriptSprintf(ScSfBuffer, 3000,
+        ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE,
                       "testing ScriptSprintf:\nThis is int: %10d\nThis is float: %.4f\nThis is string: '%s'\nThis placeholder will be ignored: %d",
                       params, 3);
     assert(strcmp(result, "testing ScriptSprintf:\nThis is int:        123\nThis is float: 0.4560\nThis is string: 'string literal'\nThis placeholder will be ignored: %d") == 0);
     // Literal percent sign
-    result = ScriptSprintf(ScSfBuffer, 3000, "aaa%%aaa", params, 3);
+    result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "aaa%%aaa", params, 3);
     assert(strcmp(result, "aaa%aaa") == 0);
 
     // Invalid format
-    result = ScriptSprintf(ScSfBuffer, 3000, "%zzzzzz", params, 3);
+    result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%zzzzzz", params, 3);
     assert(strcmp(result, "%zzzzzz") == 0);
-    result = ScriptSprintf(ScSfBuffer, 3000, "%12.34%d", params, 3);
+    result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%12.34%d", params, 3);
     assert(strcmp(result, "%12.34123") == 0);
 
     // Not enough arguments
-    result = ScriptSprintf(ScSfBuffer, 3000, "%5d%0.5f%s", params, 0);
+    result = ScriptSprintf(ScSfBuffer, STD_BUFFER_SIZE, "%5d%0.5f%s", params, 0);
     assert(strcmp(result, "%5d%0.5f%s") == 0);
 
     // Not enough buffer space


### PR DESCRIPTION
This fixes my oversight made long ago when I was rewriting Script interpreter, introducing safer argument list.

A number of engine functions kept redundant variadic parameter list and string printf-to-buffer operations, while they were always called with "%s" format string in every practical case, and required just a constant string.

Additionally, *get_translation()* was being called for the "%s" string in all those functions.

Aside from doing excess work, this caused a bug. A *source_text_length* global variable is set inside *get_translation()* to remember pre-translated text length, which in turn could be used to calculate time required to display the text message on screen. Of course, since get_translation was being called for the second time for "%s" string, this length was always considered to be 2 symbols; hence messages were displayed on screen for a minimal time, making it hard to read them.
(This behavior depends on game parameters, and does not take effect in every game.)

In this pull request these redundant operations are removed, and bug fixed.