### PR TITLE
Dev 3.3.5  tidy font

### DIFF
--- a/Common/font/agsfontrenderer.cpp
+++ b/Common/font/agsfontrenderer.cpp
@@ -19,5 +19,4 @@
 #include "alfont.h"
 #include "font/agsfontrenderer.h"
 
-IAGSFontRenderer* fontRenderers[MAX_FONTS];
 wgtfont fonts[MAX_FONTS];

--- a/Common/font/agsfontrenderer.cpp
+++ b/Common/font/agsfontrenderer.cpp
@@ -19,4 +19,4 @@
 #include "alfont.h"
 #include "font/agsfontrenderer.h"
 
-wgtfont fonts[MAX_FONTS];
+// TODO: Remove file?

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -15,14 +15,14 @@
 #ifndef __AC_AGSFONTRENDERER_H
 #define __AC_AGSFONTRENDERER_H
 
-#include "ac/gamestructdefines.h"
-
-typedef unsigned char* wgtfont;
 struct BITMAP;
 
 // WARNING: this interface is exposed for plugins and declared for the second time in agsplugin.h
 class IAGSFontRenderer {
 public:
+  // TODO: This pure virtual class should really define a virtual destructor,
+  // but I'm unsure how it would affect existing plugins using this interface.
+
   virtual bool LoadFromDisk(int fontNumber, int fontSize) = 0;
   virtual void FreeMemory(int fontNumber) = 0;
   virtual bool SupportsExtendedCharacters(int fontNumber) = 0;
@@ -36,7 +36,5 @@ public:
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) = 0;
   virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
 };
-
-extern wgtfont fonts[MAX_FONTS];
 
 #endif // __AC_AGSFONTRENDERER_H

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -37,7 +37,6 @@ public:
   virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
 };
 
-extern IAGSFontRenderer* fontRenderers[MAX_FONTS];
 extern wgtfont fonts[MAX_FONTS];
 
 #endif // __AC_AGSFONTRENDERER_H

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -20,6 +20,7 @@
 #include "alfont.h"
 
 #include "ac/common.h"
+#include "ac/gamestructdefines.h"
 #include "font/fonts.h"
 #include "font/agsfontrenderer.h"
 #include "font/ttffontrenderer.h"

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -31,6 +31,8 @@ namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 int wtext_multiply = 1;
 
+static IAGSFontRenderer* fontRenderers[MAX_FONTS];
+
 void init_font_renderer()
 {
 #ifdef USE_ALFONT
@@ -53,6 +55,22 @@ void shutdown_font_renderer()
 void adjust_y_coordinate_for_text(int* ypos, int fontnum)
 {
   fontRenderers[fontnum]->AdjustYCoordinateForFont(ypos, fontnum);
+}
+
+bool font_first_renderer_loaded() {
+    return fontRenderers[0] != NULL;
+}
+
+IAGSFontRenderer* font_replace_renderer(int fontNumber, IAGSFontRenderer* renderer)
+{
+  IAGSFontRenderer* oldRender = fontRenderers[fontNumber];
+  fontRenderers[fontNumber] = renderer;
+  return oldRender;
+}
+
+bool font_supports_extended_characters(int fontNumber)
+{
+  return fontRenderers[fontNumber]->SupportsExtendedCharacters(fontNumber);
 }
 
 void ensure_text_valid_for_font(char *text, int fontnum)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -33,6 +33,8 @@ namespace BitmapHelper = AGS::Common::BitmapHelper;
 int wtext_multiply = 1;
 
 static IAGSFontRenderer* fontRenderers[MAX_FONTS];
+static TTFFontRenderer ttfRenderer;
+static WFNFontRenderer wfnRenderer;
 
 void init_font_renderer()
 {

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -19,9 +19,14 @@
 
 using namespace AGS;
 
+class IAGSFontRenderer;
+
 void init_font_renderer();
 void shutdown_font_renderer();
 void adjust_y_coordinate_for_text(int* ypos, int fontnum);
+IAGSFontRenderer* font_replace_renderer(int fontNumber, IAGSFontRenderer* renderer);
+bool font_first_renderer_loaded();
+bool font_supports_extended_characters(int fontNumber);
 void ensure_text_valid_for_font(char *text, int fontnum);
 int wgettextwidth(const char *texx, int fontNumber);
 int wgettextheight(const char *text, int fontNumber);

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -44,8 +44,6 @@ off_t _filelength(int fd) {
 // Defined in the engine or editor (currently needed only for non-windows versions)
 extern void set_font_outline(int font_number, int outline_type);
 
-TTFFontRenderer ttfRenderer;
-
 #ifdef USE_ALFONT
 ALFONT_FONT *tempttffnt;
 ALFONT_FONT *get_ttf_block(unsigned char* fontptr)

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -36,6 +36,4 @@ private:
     std::map<int, ALFONT_FONT*> _fontData;
 };
 
-extern TTFFontRenderer ttfRenderer;
-
 #endif // __AC_TTFFONTRENDERER_H

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -17,6 +17,10 @@
 
 #include "font/agsfontrenderer.h"
 
+#include <map>
+
+struct ALFONT_FONT;
+
 class TTFFontRenderer : public IAGSFontRenderer {
 public:
     virtual bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -27,6 +31,9 @@ public:
     virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
     virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
     virtual void EnsureTextValidForFont(char *text, int fontNumber) override;
+
+private:
+    std::map<int, ALFONT_FONT*> _fontData;
 };
 
 extern TTFFontRenderer ttfRenderer;

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -19,14 +19,14 @@
 
 class TTFFontRenderer : public IAGSFontRenderer {
 public:
-  virtual bool LoadFromDisk(int fontNumber, int fontSize);
-  virtual void FreeMemory(int fontNumber);
-  virtual bool SupportsExtendedCharacters(int fontNumber) { return true; }
-  virtual int GetTextWidth(const char *text, int fontNumber);
-  virtual int GetTextHeight(const char *text, int fontNumber);
-  virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) ;
-  virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber);
-  virtual void EnsureTextValidForFont(char *text, int fontNumber);
+    virtual bool LoadFromDisk(int fontNumber, int fontSize) override;
+    virtual void FreeMemory(int fontNumber) override;
+    virtual bool SupportsExtendedCharacters(int fontNumber) override { return true; }
+    virtual int GetTextWidth(const char *text, int fontNumber) override;
+    virtual int GetTextHeight(const char *text, int fontNumber) override;
+    virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
+    virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
+    virtual void EnsureTextValidForFont(char *text, int fontNumber) override;
 };
 
 extern TTFFontRenderer ttfRenderer;

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -41,7 +41,6 @@ static int printchar(Common::Bitmap *ds, int xxx, int yyy, const unsigned char* 
 // **** WFN Renderer ****
 
 const char *WFN_FILE_SIGNATURE = "WGT Font File  ";
-WFNFontRenderer wfnRenderer;
 
 
 void WFNFontRenderer::AdjustYCoordinateForFont(int *ycoord, int fontNumber)

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -17,6 +17,9 @@
 
 #include "font/agsfontrenderer.h"
 
+#include <map>
+#include <vector>
+
 class WFNFontRenderer : public IAGSFontRenderer {
 public:
     virtual bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -29,7 +32,7 @@ public:
     virtual void EnsureTextValidForFont(char *text, int fontNumber) override;
 
 private:
-    int printchar(Common::Bitmap *ds, int xxx, int yyy, wgtfont foo, color_t text_color, int charr);
+    std::map<int, std::vector<unsigned char>> _fontData;
 };
 
 extern WFNFontRenderer wfnRenderer;

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -35,6 +35,4 @@ private:
     std::map<int, std::vector<unsigned char>> _fontData;
 };
 
-extern WFNFontRenderer wfnRenderer;
-
 #endif // __AC_WFNFONTRENDERER_H

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -19,14 +19,14 @@
 
 class WFNFontRenderer : public IAGSFontRenderer {
 public:
-  virtual bool LoadFromDisk(int fontNumber, int fontSize);
-  virtual void FreeMemory(int fontNumber);
-  virtual bool SupportsExtendedCharacters(int fontNumber) { return false; }
-  virtual int GetTextWidth(const char *text, int fontNumber);
-  virtual int GetTextHeight(const char *text, int fontNumber);
-  virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) ;
-  virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber);
-  virtual void EnsureTextValidForFont(char *text, int fontNumber);
+    virtual bool LoadFromDisk(int fontNumber, int fontSize) override;
+    virtual void FreeMemory(int fontNumber) override;
+    virtual bool SupportsExtendedCharacters(int fontNumber) override { return false; }
+    virtual int GetTextWidth(const char *text, int fontNumber) override;
+    virtual int GetTextHeight(const char *text, int fontNumber) override;
+    virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
+    virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
+    virtual void EnsureTextValidForFont(char *text, int fontNumber) override;
 
 private:
     int printchar(Common::Bitmap *ds, int xxx, int yyy, wgtfont foo, color_t text_color, int charr);

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -16,7 +16,6 @@
 #include "font/fonts.h"
 #include "gui/guitextbox.h"
 #include "gui/guimain.h"
-#include "font/agsfontrenderer.h"	// fontRenderers;
 #include "util/stream.h"
 #include "gfx/bitmap.h"
 #include "util/wgt2allg.h"
@@ -71,7 +70,7 @@ void GUITextBox::KeyPress(int kp)
     return;
 
   // other key, continue
-  if ((kp >= 128) && (!fontRenderers[font]->SupportsExtendedCharacters(font)))
+  if ((kp >= 128) && (!font_supports_extended_characters(font)))
     return;
 
   if (kp == 13) {

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -58,7 +58,6 @@ extern int time_between_timers;
 extern int offsetx, offsety;
 extern int frames_per_second;
 extern int loops_per_character;
-extern IAGSFontRenderer* fontRenderers[MAX_FONTS];
 extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern DynamicArray<GUIButton> guibuts;
@@ -425,7 +424,7 @@ void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color
     else if (game.fontoutline[usingfont] == FONT_OUTLINE_AUTO) {
         int outlineDist = 1;
 
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!fontRenderers[usingfont]->SupportsExtendedCharacters(usingfont))) {
+        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(usingfont))) {
             // if it's a scaled up SCI font, move the outline out more
             outlineDist = get_fixed_pixel_size(1);
         }
@@ -463,7 +462,7 @@ int wgetfontheight(int font) {
     // automatic outline fonts are 2 pixels taller
     if (game.fontoutline[font] == FONT_OUTLINE_AUTO) {
         // scaled up SCI font, push outline further out
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!fontRenderers[font]->SupportsExtendedCharacters(font)))
+        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(font)))
             htof += get_fixed_pixel_size(2);
         // otherwise, just push outline by 1 pixel
         else
@@ -478,7 +477,7 @@ int wgettextwidth_compensate(const char *tex, int font) {
 
     if (game.fontoutline[font] == FONT_OUTLINE_AUTO) {
         // scaled up SCI font, push outline further out
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!fontRenderers[font]->SupportsExtendedCharacters(font)))
+        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(font)))
             wdof += get_fixed_pixel_size(2);
         // otherwise, just push outline by 1 pixel
         else

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -878,8 +878,7 @@ int engine_check_disk_space()
     return RETURN_CONTINUE;
 }
 
-// [IKM] I have a feeling this should be merged with engine_init_fonts
-int engine_check_fonts()
+int engine_check_font_was_loaded()
 {
     if (fontRenderers[0] == NULL) 
     {
@@ -1484,9 +1483,10 @@ int initialize_engine(int argc,char*argv[])
         return res;
     }
 
-    // [IKM] I do not really understand why is this checked only now;
-    // should not it be checked right after fonts initialization?
-    res = engine_check_fonts();
+    // Make sure that at least one font was loaded in the process of loading
+    // the game data.
+    // TODO: Fold this check into engine_load_game_data()
+    res = engine_check_font_was_loaded();
     if (res != RETURN_CONTINUE) {
         return res;
     }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -880,7 +880,7 @@ int engine_check_disk_space()
 
 int engine_check_font_was_loaded()
 {
-    if (fontRenderers[0] == NULL) 
+    if (!font_first_renderer_loaded())
     {
         platform->DisplayAlert("No fonts found. If you're trying to run the game from the Debug directory, this is not supported. Use the Build EXE command to create an executable in the Compiled folder.");
         proper_exit = 1;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -117,7 +117,6 @@ extern color palette[256];
 extern int offsetx, offsety;
 extern PluginObjectReader pluginReaders[MAX_PLUGIN_OBJECT_READERS];
 extern int numPluginReaders;
-extern IAGSFontRenderer* fontRenderers[MAX_FONTS];
 extern RuntimeScriptValue GlobalReturnValue;
 extern ScriptString myScriptStringImpl;
 
@@ -553,7 +552,7 @@ int IAGSEngine::GetFontType(int32 fontNum) {
     if ((fontNum < 0) || (fontNum >= game.numfonts))
         return FNT_INVALID;
 
-    if (fontRenderers[fontNum]->SupportsExtendedCharacters(fontNum))
+    if (font_supports_extended_characters(fontNum))
         return FNT_TTF;
 
     return FNT_SCI;
@@ -788,9 +787,7 @@ void IAGSEngine::BreakIntoDebugger()
 
 IAGSFontRenderer* IAGSEngine::ReplaceFontRenderer(int fontNumber, IAGSFontRenderer *newRenderer)
 {
-    IAGSFontRenderer* oldOne = fontRenderers[fontNumber];
-    fontRenderers[fontNumber] = newRenderer;
-    return oldOne;
+    return font_replace_renderer(fontNumber, newRenderer);
 }
 
 


### PR DESCRIPTION
Just trying to tidy up some code in the font renderers:

* Eliminate some globals
* Limit some globals to static scope
* Prefer RAII to malloc
* Use const more
* Eliminate some unnecessary casts

Please let me know if this sort of thing is helpful.