### PR TITLE
Remove changelog dependency from debian/make_ags+libraries script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ags (3.3.4.2) UNRELEASED; urgency=low
+ags (3~git-1) UNRELEASED; urgency=low
 
   * some release
 

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -46,7 +46,9 @@ sed -i -r "5s/.*/BIT=32/" $BASEPATH/debian/ags+libraries/hooks/B00_copy_libs.sh
 
 # Build the source package:
 cd $BASEPATH
-VERSION=$(dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)@\1@')
+CHANGELOG_VERSION=$(head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/')
+VERSION=$(grep '#define ACI_VERSION_STR' Common/core/def_version.h | sed 's/.*"\(.*\)".*/\1/')
+sed -i -- "s/$CHANGELOG_VERSION/$VERSION/" debian/changelog
 debian/rules get-orig-source
 debuild -us -uc -S
 
@@ -94,3 +96,6 @@ cd $BASEPATH && tar -cf - ags+libraries/ | xz -9 -c - > ags+libraries_$(date +%Y
 # Delete the ags+libraries folder, because some of the subfolders and files are owned by root.
 # Extracting the .tar.xz yields the folder with proper owner/permissions.
 sudo rm -rf $BASEPATH/ags+libraries/
+
+# Restore changelog version to prevent unnecessary commits
+sed -i -- "s/$VERSION/$CHANGELOG_VERSION/" $BASEPATH/debian/changelog

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 # Keep this list of folders that are not included in the
 # orig syncronized with the one in debian/source/local-options!
 ORIG_CONTENT := $(shell git ls-tree --name-only HEAD | grep -Ev '^(Android|Editor|iOS|OSX|PSP|Windows|debian|\.git.*)')
-VERSION := $(shell dpkg-parsechangelog | grep -x "Version:.*" | sed 's@Version: \(.\+\)@\1@')
+VERSION := $(shell head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/')
 MAKE = make --directory=Engine
 GENCONTROL_SUBSTVARS = -Vbuildinfo:Date="$(shell date -R)" -Vbuildinfo:Git-Object="$(shell git show HEAD | head -n1)"
 


### PR DESCRIPTION
As noted in #301 the debian/changelog file is actually a *fake* changelog which only exists to allow the debian package tools to function correctly. With this change, the make_ags+libraries script will now read the version info from Common/core/def_version.h, update the changelog file so the debian package tools can run, then reset the changelog file to prevent unnecessary commits.

This also removes the use of dpkg-parsechangelog from debian/rules, because I found that it requires loading several external libraries just to parse the version info. This could be made as a separate commit, if necessary.

It may additionally be worth noting in the debian readme that the changelog is not meant to be changed or updated.