### PR TITLE
Fixed output directory for Windows plugins

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1224,7 +1224,14 @@ namespace AGS.Editor
 
                 foreach (Plugin plugin in _game.Plugins)
                 {
-                    File.Copy(Path.Combine(this.EditorDirectory, plugin.FileName), Path.Combine(OUTPUT_DIRECTORY, plugin.FileName), true);
+                    string outputDir = OUTPUT_DIRECTORY;
+                    if (!Factory.AGSEditor.Preferences.UseLegacyCompiler)
+                    {
+                        IBuildTarget targetWin = BuildTargetsInfo.FindBuildTargetByName("Windows");
+                        if (targetWin != null)
+                            outputDir = targetWin.GetCompiledPath();
+                    }
+                    File.Copy(Path.Combine(this.EditorDirectory, plugin.FileName), Path.Combine(outputDir, plugin.FileName), true);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
This was previously overlooked when the build target interface was added.

Although this only affects building for Windows, this code should not be moved to BuildTargetWindows (for the time being) because BuildTargetWindows is not invoked if using the "legacy compiler" setting. It also doesn't make sense to move this into BuildTargetDataFile (which is invoked, respecting the legacy setting) as this has nothing to do with building the data file.

If the "legacy compiler" setting is later removed, then it makes sense for this to be moved into BuildTargetWindows at that time.