### PR TITLE
Editor: Allow room objects to be locked like GUI controls

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -115,7 +115,7 @@
 #define OBJF_USEREGIONTINTS    8  // obey region tints/light areas
 #define OBJF_USEROOMSCALING 0x10  // obey room scaling areas
 #define OBJF_SOLID          0x20  // blocks characters from moving
-#define OBJF_DELETED        0x40  // object has been deleted
+#define OBJF_LOCKED         0x40  // object position is locked in the editor
 #define OBJF_HASLIGHT       0x80  // the tint_light is valid and treated as brightness
 
 #endif // __AC_DEFINES_H

--- a/Editor/AGS.Editor/Panes/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/RoomEditFilters/ObjectsEditorFilter.cs
@@ -55,17 +55,20 @@ namespace AGS.Editor
 		public bool KeyPressed(Keys key)
 		{
             if (_selectedObject == null) return false;
-            int step = GetArrowMoveStepSize();
-            switch (key)
+            if (!_selectedObject.Locked)
             {
-                case Keys.Right:
-                    return MoveObject(_selectedObject.StartX + step, _selectedObject.StartY);                    
-                case Keys.Left:
-                    return MoveObject(_selectedObject.StartX - step, _selectedObject.StartY);                    
-                case Keys.Down:
-                    return MoveObject(_selectedObject.StartX, _selectedObject.StartY + step);
-                case Keys.Up:
-                    return MoveObject(_selectedObject.StartX, _selectedObject.StartY - step);                    
+                int step = GetArrowMoveStepSize();
+                switch (key)
+                {
+                    case Keys.Right:
+                        return MoveObject(_selectedObject.StartX + step, _selectedObject.StartY);
+                    case Keys.Left:
+                        return MoveObject(_selectedObject.StartX - step, _selectedObject.StartY);
+                    case Keys.Down:
+                        return MoveObject(_selectedObject.StartX, _selectedObject.StartY + step);
+                    case Keys.Up:
+                        return MoveObject(_selectedObject.StartX, _selectedObject.StartY - step);
+                }
             }
             return false;
 		}
@@ -128,12 +131,15 @@ namespace AGS.Editor
 
         public virtual void Paint(Graphics graphics, RoomEditorState state)
         {
+            int xPos;
+            int yPos;
+
             if (_selectedObject != null)
             {
                 int width = GetSpriteWidthForGameResolution(_selectedObject.Image);
 				int height = GetSpriteHeightForGameResolution(_selectedObject.Image);
-				int xPos = AdjustXCoordinateForWindowScroll(_selectedObject.StartX, state);
-				int yPos = AdjustYCoordinateForWindowScroll(_selectedObject.StartY, state) - (height * state.ScaleFactor);
+				xPos = AdjustXCoordinateForWindowScroll(_selectedObject.StartX, state);
+				yPos = AdjustYCoordinateForWindowScroll(_selectedObject.StartY, state) - (height * state.ScaleFactor);
                 Pen pen = new Pen(Color.Goldenrod);
                 pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
                 graphics.DrawRectangle(pen, xPos, yPos, width * state.ScaleFactor, height * state.ScaleFactor);
@@ -150,6 +156,18 @@ namespace AGS.Editor
 
                     graphics.DrawString(toDraw, font, pen.Brush, (float)scaledx, (float)scaledy);
                 }
+                else
+                    if (_selectedObject.Locked)
+                    {
+                        pen = new Pen(Color.Goldenrod, 2);
+                        xPos = AdjustXCoordinateForWindowScroll(_selectedObject.StartX, state) + (GetSpriteWidthForGameResolution(_selectedObject.Image) / 2 * state.ScaleFactor);
+                        yPos = AdjustYCoordinateForWindowScroll(_selectedObject.StartY, state) - (GetSpriteHeightForGameResolution(_selectedObject.Image) / 2 * state.ScaleFactor);
+                        Point center = new Point(xPos, yPos);
+
+                        graphics.DrawLine(pen, center.X - 3, center.Y - 3, center.X + 3, center.Y + 3);
+                        graphics.DrawLine(pen, center.X - 3, center.Y + 3, center.X + 3, center.Y - 3);
+
+                    }
             }
         }
 
@@ -184,11 +202,12 @@ namespace AGS.Editor
                         ShowContextMenu(e, state);
                     }
                     else
-                    {
-                        _movingObjectWithMouse = true;
-                        _mouseOffsetX = x - obj.StartX;
-                        _mouseOffsetY = y - obj.StartY;
-                    }
+                        if (!obj.Locked)
+                        {
+                            _movingObjectWithMouse = true;
+                            _mouseOffsetX = x - obj.StartX;
+                            _mouseOffsetY = y - obj.StartY;
+                        }
                     break;
                 }
             }

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -4348,6 +4348,7 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
       obj->StartY += GetSpriteHeight(thisroom.sprs[i].sprnum);
 		obj->Visible = (thisroom.sprs[i].on != 0);
 		obj->Clickable = ((thisroom.objectFlags[i] & OBJF_NOINTERACT) == 0);
+		obj->Locked = ((thisroom.objectFlags[i] & OBJF_LOCKED) != 0);
 		obj->Baseline = thisroom.objbaseline[i];
 		obj->Name = gcnew String(jibbledScriptName);
 		obj->Description = gcnew String(thisroom.objectnames[i]);
@@ -4519,6 +4520,7 @@ void save_crm_file(Room ^room)
 		if (obj->UseRoomAreaScaling) thisroom.objectFlags[i] |= OBJF_USEROOMSCALING;
 		if (obj->UseRoomAreaLighting) thisroom.objectFlags[i] |= OBJF_USEREGIONTINTS;
 		if (!obj->Clickable) thisroom.objectFlags[i] |= OBJF_NOINTERACT;
+		if (obj->Locked) thisroom.objectFlags[i] |= OBJF_LOCKED;
 		CompileCustomProperties(obj->Properties, &thisroom.objProps[i]);
 	}
 

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -19,6 +19,7 @@ namespace AGS.Types
         private int _x;
         private int _y;
         private bool _clickable = true;
+        private bool _locked;
         private bool _visible = true;
         private int _baseline;
         private int _effectiveBaseline;
@@ -110,6 +111,14 @@ namespace AGS.Types
         {
             get { return _effectiveBaseline; }
             set { _effectiveBaseline = value; }
+        }
+
+        [Description("Whether the object can be moved in the editor")]
+        [Category("Design")]
+        public bool Locked
+        {
+            get { return _locked; }
+            set { _locked = value; }
         }
 
         [Description("X co-ordinate within the room of the left side of the object")]


### PR DESCRIPTION
Thanks to CalinLeafshade's prior work, AGS allows the user to lock GUI controls. This commit implements locking for room objects with consistent appearance and behaviour to locked GUI controls. Locked objects can't be moved by mouse or keyboard and have an X in the centre. The unused flag, `OBJF_DELETED` has been repurposed as `OBJF_LOCKED`.