### PR TITLE
Compiler: Copy default value flag on forward declared structs

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3997,6 +3997,7 @@ startvarbit:
 
                             // copy the default values from the function prototype
                             sym.funcParamDefaultValues[cursym][ii] = oldDefinition.funcParamDefaultValues[ii];
+                            sym.funcParamHasDefaultValues[cursym][ii] = oldDefinition.funcParamHasDefaultValues[ii];
                         }
                     }
                 }


### PR DESCRIPTION
Copies the 'default value exists' flag when structs are forward declared, fixing the incorrect 'Not enough parameters in call to function' error when member functions were invoked without all parameters (required or not).