### PR TITLE
Compiler: Better parsing of negative numbers

### DIFF
--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -178,7 +178,7 @@ TEST(Compile, ParsingIntOverflow) {
     last_seen_cc_error = 0;
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_EQ(-1, compileResult);
-    EXPECT_STREQ("Error while parsing integer symbol '4200000000000000000000'.", last_seen_cc_error);
+    EXPECT_STREQ("Could not parse integer symbol '4200000000000000000000' because of overflow.", last_seen_cc_error);
 }
 
 TEST(Compile, ParsingNegIntOverflow) {
@@ -191,7 +191,7 @@ TEST(Compile, ParsingNegIntOverflow) {
     last_seen_cc_error = 0;
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_EQ(-1, compileResult);
-    EXPECT_STREQ("Error while parsing integer symbol '-4200000000000000000000'.", last_seen_cc_error);
+    EXPECT_STREQ("Could not parse integer symbol '-4200000000000000000000' because of overflow.", last_seen_cc_error);
 }
 
 
@@ -288,4 +288,94 @@ TEST(Compile, DefaultParametersLargeInts) {
 
     EXPECT_EQ(true, sym.funcParamHasDefaultValues[funcidx][9]);
     EXPECT_EQ(-2, sym.funcParamDefaultValues[funcidx][9]);
+}
+
+TEST(Compile, DoubleNegatedConstant) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        import int MyFunction(\
+            int data0 = - -69\
+            );\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Parameter default value must be literal", last_seen_cc_error);
+}
+
+TEST(Compile, SubtractionWithoutSpaces) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        int MyFunction()\
+        {\
+            int data0 = 2-4;\
+        }\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(0, compileResult);
+}
+
+TEST(Compile, NegationLHSOfExpression) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        enum MyEnum\
+        {\
+            cat\
+        };\
+        \
+        int MyFunctionA()\
+        {\
+            return 0;\
+        }\
+        \
+        int MyFunctionB()\
+        {\
+            int data0 = - 4 * 4;\
+            int data1 = - MyFunctionA() * 4;\
+            int data2 = -cat * 4;\
+            \
+            return 0;\
+        }\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+    printf("Error: %s\n", last_seen_cc_error);
+    ASSERT_EQ(0, compileResult);
+}
+
+TEST(Compile, NegationRHSOfExpression) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        enum MyEnum\
+        {\
+            cat\
+        };\
+        \
+        int MyFunctionA()\
+        {\
+            return 0;\
+        }\
+        \
+        int MyFunctionB()\
+        {\
+            int data0 = 3 - - 4 * 4;\
+            int data1 = 3 - - MyFunctionA() * 4;\
+            int data2 = 3 - -cat * 4;\
+            \
+            return 0;\
+        }\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+    printf("Error: %s\n", last_seen_cc_error);
+    ASSERT_EQ(0, compileResult);
 }


### PR DESCRIPTION
This fixes #295 

The tokeniser will now recognise negative numbers as single symbols. `-` continues to be the unary negation operator for situations where the sign and number are separated by a space, e.g. `int x = - 4;`. The specific case of someone negating a negative constant is disallowed.

Some interesting edge cases:
```
int a = 3 - -4; // Legal, previously not allowed
int a = a - -2147483648; // Ditto
int a = a - 2147483648; // Not legal, +2147483648 is out of range
int a = - 2147483648; // Legal (unary negation)
```

Note: This behaviour is in line with C#.