### PR TITLE
Scripting: Clarify the unclosed brace error message

### DIFF
--- a/Common/script/cc_error.cpp
+++ b/Common/script/cc_error.cpp
@@ -19,6 +19,7 @@
 #include "script/script_common.h"  // current_line
 
 extern void cc_error_at_line(char *buffer, const char *error_msg);
+extern void cc_error_without_line(char *buffer, const char *error_msg);
 
 int ccError = 0;
 int ccErrorLine = 0;
@@ -49,7 +50,7 @@ void cc_error(const char *descr, ...)
         cc_error_at_line(ccErrorString, displbuf);
     }
     else
-        sprintf(ccErrorString, "Runtime error: %s", displbuf);
+        cc_error_without_line(ccErrorString, displbuf);
 
     ccError = 1;
     ccErrorLine = currentline;

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -4774,6 +4774,7 @@ startvarbit:
         }
     }
     if ((in_func >= 0) || (nested_level > 0)) {
+        currentline = targ.lineAtEnd;
         cc_error("Function still open, missing }");
         return -1;
     }

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -13,6 +13,11 @@ void cc_error_at_line(char *buffer, const char *error_msg)
     last_seen_cc_error = _strdup(error_msg);
 }
 
+void cc_error_without_line(char *buffer, const char *error_msg)
+{
+    last_seen_cc_error = _strdup(error_msg);
+}
+
 ccCompiledScript *newScriptFixture() {
     // TODO: investigate proper google test fixtures.
     ccCompiledScript *scrip = new ccCompiledScript();

--- a/Editor/Native/script_agsnative.cpp
+++ b/Editor/Native/script_agsnative.cpp
@@ -11,3 +11,8 @@ void cc_error_at_line(char *buffer, const char *error_msg)
 {
     sprintf(ccErrorString, "Error (line %d): %s", currentline, error_msg);
 }
+
+void cc_error_without_line(char *buffer, const char *error_msg)
+{
+    sprintf(ccErrorString, "Error (line unknown): %s", error_msg);
+}

--- a/Engine/script/script_engine.cpp
+++ b/Engine/script/script_engine.cpp
@@ -47,6 +47,11 @@ void cc_error_at_line(char *buffer, const char *error_msg)
     }
 }
 
+void cc_error_without_line(char *buffer, const char *error_msg)
+{
+    sprintf(ccErrorString, "Runtime error: %s", error_msg);
+}
+
 void save_script_configuration(Stream *out)
 {
     quit("ScriptEdit: run-time version can't save");


### PR DESCRIPTION
Addresses the issue reported here:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=718.0

AGS will now distinguish between runtime errors and errors where the line number is not known. Additionally, the line number is now reported for "Function still open, missing }" compilation errors.

Note: I understand there is a big merge from 3.3.x -> 3.4.0 happening right now, so I don't expect this to be merged right away.