### PR TITLE
Scripting: Switch statement improvements

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -235,52 +235,6 @@ void ccCompiledScript::write_code(intptr_t byy) {
     codesize++;
 }
 
-intptr_t ccCompiledScript::yank_chunk(int32_t start, intptr_t **nested_chunk, int index) {
-    intptr_t chunk_size;
-    intptr_t chunk_index;
-
-    if (start < codesize) {
-        chunk_index = chunk_size = codesize - start;
-        nested_chunk[index] = (intptr_t *) malloc(chunk_size * sizeof(intptr_t));
-        while(chunk_index-- > 0) // speed up with memcpy?
-            nested_chunk[index][chunk_index] = code[start + chunk_index];
-        codesize = start;
-    }
-    else
-        chunk_size = 0;
-
-    return chunk_size;
-}
-
-void ccCompiledScript::write_chunk(intptr_t **nested_chunk, int index, intptr_t chunk_size, bool dispose, int fixup_start, int fixup_stop, int32_t adjust) {
-    intptr_t chunk_index;
-    if(chunk_size > 0)
-    {
-        if(codesize + chunk_size >= codeallocated) {
-            codeallocated += chunk_size + 500;
-            code = (intptr_t *) realloc(code, codeallocated * sizeof(intptr_t));
-        }
-        chunk_index = chunk_size;
-        while(chunk_index-- > 0) // speed up with memcpy?
-            code[codesize + chunk_index] = nested_chunk[index][chunk_index];
-        codesize += chunk_size;
-        if(dispose)
-            free(nested_chunk[index]);
-    }
-    if(dispose)
-        while(fixup_start < fixup_stop)
-        {
-            fixups[fixup_start] += adjust;
-            fixup_start++;
-        }
-    else
-        while(fixup_start < fixup_stop)
-        {
-            add_fixup(fixups[fixup_start] + adjust, fixuptypes[fixup_start]);
-            fixup_start++;
-        }
-}
-
 const char* ccCompiledScript::start_new_section(const char *name) {
 
     if ((numSections == 0) ||

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -4754,9 +4754,9 @@ startvarbit:
             else if (sym.get_type(cursym) == SYM_CONTINUE) {
                 int loop_level;
                 loop_level = nested_level;
-                while(loop_level > 0 && nested_start[loop_level] == 0)
+                while(loop_level > 0 && (nested_start[loop_level] == 0 || nested_type[loop_level] == NEST_SWITCH))
                     loop_level--;
-                if (loop_level > 0 && nested_type[loop_level] != NEST_SWITCH) {
+                if (loop_level > 0) {
                     if (sym.get_type(targ.getnext()) != SYM_SEMICOLON) {
                         cc_error("expected ';'");
                         return -1;

--- a/Compiler/script/cs_parser.h
+++ b/Compiler/script/cs_parser.h
@@ -35,7 +35,17 @@ start
 #define __CS_PARSER_H
 
 #include "cc_compiledscript.h"
+#include <vector>
 
 extern int cc_compile(const char*inpl, ccCompiledScript*scrip);
+
+// A section of compiled code that needs to be moved or copied to a new location
+struct ccChunk {
+    std::vector<intptr_t> code;
+    std::vector<int32_t> fixups;
+    std::vector<char> fixuptypes;
+    int codeoffset;
+    int fixupoffset;
+};
 
 #endif // __CS_PARSER_H


### PR DESCRIPTION
A couple of things left out of the previous implementation. Continue statements inside switch blocks were being incorrectly rejected as outside a loop. A `case` statement immediately following a `default` label would be evaluated.

Note: I understand there is a big merge from 3.3.x -> 3.4.0 happening right now, so I don't expect this to be merged right away.