### PR TITLE
Scripting: Struct namespacing

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -211,8 +211,8 @@ int cc_tokenize(const char*inpl, ccInternalList*targ, ccCompiledScript*scrip) {
             if (bracedepth <= 0)
                 in_struct_declr = -1;
         }
-        else if ((sym.entries[towrite].stype == 0 || sym.entries[towrite].stype == SYM_FUNCTION) && (in_struct_declr >= 0) &&
-            (parenthesisdepth == 0) && (bracedepth > 0)) {
+        else if ((sym.entries[towrite].stype == 0 || sym.entries[towrite].stype == SYM_FUNCTION || sym.entries[towrite].stype == SYM_GLOBALVAR) &&
+            (in_struct_declr >= 0) && (parenthesisdepth == 0) && (bracedepth > 0)) {
                 // change the name of structure members so that the same member name
                 // can be used in multiple structs
                 // (but only if not currently in a function params list


### PR DESCRIPTION
Continuing the work here:
https://github.com/adventuregamestudio/ags/pull/154

And addressing concerns here:
http://www.adventuregamestudio.co.uk/forums/index.php?issue=361.0

I see two other situations where global names might conflict with struct member names.
1. A struct member has the same name as a global variable, e.g. a GUI
2. A struct member has the same name as a type, e.g. `function MyStruct::Object()`

This is an attempt to tidy up the namespacing of struct members and allow for both of these cases. 

Allowing global variables was easy to achieve. Most namespacing is done at the tokenise step. We just needed to allow tokens of that type to be prefixed with the struct name.

Allowing type names had to happen later in the process (during parsing). It's not known at the point of tokenisation whether someone means `Object` as a return type or `Object` as a method name. Furthermore, it's not clear in some cases what the purpose of such a token is until after we've determined that it's an extender method.

Even though it's technically possible, for the purposes of language clarity, I've left language elements like `for` and `if` disallowed as member names. Similarly, primitive types like `int` and `float` are rejected.

These are the only remaining namespacing issues I could think of. If there are any more that come to mind, please mention them here and I'll amend this pull request to allow them.

Also, general disclaimer, I don't think this is best merged until after the 3.3.x->3.4.0 merge is complete.