### PR TITLE
Engine: Correct right/bottom boundaries for GUI.GetAtScreenXY()

### DIFF
--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -142,7 +142,7 @@ bool GUIMain::IsInteractableAt(int x, int y) const
         return false;
     if (Flags & kGUIMain_NoClick)
         return false;
-    if ((x >= X) & (y >= Y) & (x <= X + Width) & (y <= Y + Height))
+    if ((x >= X) & (y >= Y) & (x < X + Width) & (y < Y + Height))
         return true;
     return false;
 }


### PR DESCRIPTION
The boundaries in the checks used by GUI.GetAtScreenXY() are incorrect. They are inclusive of the bottom/right edges, which means that the row after the bottom of a GUI is considered part of the GUI, and likewise for the column after the right of a GUI.

Here's a screenshot from my test project that hopefully illustrates the problem:

![Screenshot of the problem](http://i.imgur.com/is4pcnd.png)

There is one GUI on the screen -- grey with a green border. The mouse is on the very bottom row, shown as a single red dot. The "(190, 199) = 1" indicates that AGS thinks this row is within the GUI. Project files for the curious: http://goo.gl/dlkymd (3.4.0.x)

This is just a simple commit to make GUI.GetAtScreenXY() check the bottom and right edges with `<` rather than `<=`.

Should this be behind a backwards compatibility check? I tend to think it's unnecessary, but I'm not sure how much old games might care about this.