### PR TITLE
Patch Linux makefile

### DIFF
--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -3,7 +3,7 @@ LIBDIR =
 CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(shell pkg-config --cflags freetype2) $(CFLAGS)
 CXXFLAGS := -fno-rtti -Wno-write-strings $(CXXFLAGS)
 LIBS := -rdynamic -laldmb -ldumb -Wl,-Bdynamic
-LIBS += $(shell pkg-config --libs --static allegro)
+LIBS += $(shell pkg-config --libs allegro)
 LIBS += $(shell pkg-config --libs x11)
 LIBS += $(shell pkg-config --libs ogg)
 LIBS += $(shell pkg-config --libs theora)
@@ -16,7 +16,7 @@ else
 endif
 LIBS += $(shell pkg-config --libs vorbisfile)
 LIBS += $(shell pkg-config --libs freetype2)
-LIBS += -lc -lstdc++
+LIBS += -ldl -lpthread -lc -lstdc++
 
 ifeq ($(ALLEGRO_MAGIC_DRV), 1)
   CFLAGS += -DALLEGRO_MAGIC_DRV

--- a/debian/README.md
+++ b/debian/README.md
@@ -47,7 +47,7 @@ Download the sources with git and change into the **ags** directory:
 Build the package and install it with gdebi:
 
     fakeroot debian/rules binary
-    sudo gdebi ../ags_3.30.0-1_*.deb
+    sudo gdebi ../ags_3~git-1_*.deb
 
 #Using the engine
 To start an AGS game, just run ags with the game directory or the game
@@ -165,4 +165,4 @@ Build the package with pbuilder and install it and its dependencies with gdebi:
 
     cd ags
     pdebuild
-    sudo gdebi /var/cache/pbuilder/result/ags_3.30.0-1_i386.deb
+    sudo gdebi /var/cache/pbuilder/result/ags_3~git-1_i386.deb


### PR DESCRIPTION
This removes redundant linking options from the Linux makefile.
Notably, libice and libsm libraries are no longer required to be linked on Debian and Ubuntu systems.

Additionally, corrected debian package name in the debian/README.