### PR TITLE
Add method to fix MIDI playback

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -63,6 +63,11 @@ http://www.eglebbk.dds.nl/program/download/digmid.dat
 Rename that file to **patches.dat** and place it into the **ags**
 directory alongside your games.
 
+*If MIDI music fails to play, attempt using an archive manager such as 7-Zip to extract the patches.dat file.
+    Extract the patches[1] file from patches.dat into the AGS directory
+    Remove patches.dat from the AGS directory
+    Rename the patches[1] file to patches.dat
+This method should fix MIDI playback due to compression on the raw files.
 
 
 #Building the engine


### PR DESCRIPTION
I am proposing this change as I have a Galaxy S5 running Cyanogenmod 13 (Android 6.0.1) and couldn't get AGS Android to play MIDI files despite having the patches.dat file downloaded from this link: http://alleg.sourceforge.net/digmid.html The game I tried was Yahtzee's Five Days a Stranger

I found out that the actual patches.dat is compressed, I opened the file with 7-Zip and found a patches[1] (I assume compressed name derives from container filename.)

So I extracted this patches[1] file, copied it to ags, deleted old patches.dat, renamed patches[1] to patches.dat. From there, I tried running Five Days a Stranger again, and sound worked perfectly. The original patches.dat file is 19MB, but after extracting, it grew to 25MB.