### PR TITLE
Fix gcc-6 compilation

### DIFF
--- a/Plugins/AGSflashlight/agsflashlight.cpp
+++ b/Plugins/AGSflashlight/agsflashlight.cpp
@@ -16,12 +16,6 @@ but a workalike plugin created by JJS for the AGS engine PSP port.
 #define THIS_IS_THE_PLUGIN
 #endif
 
-#include "plugin/agsplugin.h"
-
-#if defined(BUILTIN_PLUGINS)
-namespace agsflashlight {
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,6 +26,12 @@ namespace agsflashlight {
 #include <pspmath.h>
 #include <pspdisplay.h>
 #define sin(x) vfpu_sinf(x)
+#endif
+
+#include "plugin/agsplugin.h"
+
+#if defined(BUILTIN_PLUGINS)
+namespace agsflashlight {
 #endif
 
 #if defined(__GNUC__)
@@ -946,5 +946,5 @@ void AGS_EditorLoadGame(char* buffer, int bufsize)
 
 
 #if defined(BUILTIN_PLUGINS)
-}
+} // namespace agsflashlight
 #endif

--- a/Plugins/ags_parallax/ags_parallax.cpp
+++ b/Plugins/ags_parallax/ags_parallax.cpp
@@ -16,16 +16,16 @@ but a workalike plugin created by JJS for the AGS engine ports.
 #define THIS_IS_THE_PLUGIN
 #endif
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
 #include "plugin/agsplugin.h"
 
 #if defined(BUILTIN_PLUGINS)
 namespace ags_parallax {
 #endif
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
 
 //#define DEBUG
 //#define ENABLE_SAVING // The original plugin does not save any data!
@@ -343,5 +343,5 @@ void AGS_EditorLoadGame(char* buffer, int bufsize)
 
 
 #if defined(BUILTIN_PLUGINS)
-}
+} // namespace ags_parallax
 #endif

--- a/Plugins/ags_snowrain/ags_snowrain.cpp
+++ b/Plugins/ags_snowrain/ags_snowrain.cpp
@@ -16,12 +16,6 @@ but a workalike plugin created by JJS for the AGS engine PSP port.
 #define THIS_IS_THE_PLUGIN
 #endif
 
-#include "plugin/agsplugin.h"
-
-#if defined(BUILTIN_PLUGINS)
-namespace ags_snowrain {
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -31,6 +25,12 @@ namespace ags_snowrain {
 #include <pspsdk.h>
 #include <pspmath.h>
 #define sin(x) vfpu_sinf(x)
+#endif
+
+#include "plugin/agsplugin.h"
+
+#if defined(BUILTIN_PLUGINS)
+namespace ags_snowrain {
 #endif
 
 //#define DEBUG
@@ -960,5 +960,5 @@ void AGS_EditorLoadGame(char* buffer, int bufsize)
 
 
 #if defined(BUILTIN_PLUGINS)
-}
+} // namespace ags_snowrain
 #endif


### PR DESCRIPTION
This fixes compilation errors when using gnu gcc-6. The root of the problem is that the standard library headers were included inside plugin namespaces.