### PR TITLE
Scripting: Fix dynamic array parsing in structs

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3764,7 +3764,6 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                 do {
                     int vname = targ.getnext();
                     bool isDynamicArray = false;
-                    bool isFunction = sym.get_type(targ.peeknext()) == SYM_OPENPARENTHESIS;
                     if (sym.get_type(vname) == SYM_COMMA)
                         vname = targ.getnext();
 
@@ -3773,6 +3772,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                         targ.getnext();
                         vname = targ.getnext();
                     }
+                    bool isFunction = sym.get_type(targ.peeknext()) == SYM_OPENPARENTHESIS;
                     const char *memberExt = sym.get_name(vname);
                     memberExt = strstr(memberExt, "::");
                     if (!isFunction && sym.get_type(vname) == SYM_VARTYPE && vname > sym.normalFloatSym && memberExt == NULL) {

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -295,6 +295,28 @@ TEST(Compile, DefaultParametersLargeInts) {
     EXPECT_EQ(-2, sym.entries[funcidx].funcParamDefaultValues[9]);
 }
 
+TEST(Compile, ImportFunctionReturningDynamicArray) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        struct A\
+        {\
+            import static int[] MyFunc();\
+        };\
+        ";
+
+    last_seen_cc_error = 0;
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(0, compileResult);
+
+    int funcidx;
+    funcidx = sym.find("A::MyFunc");
+
+    ASSERT_TRUE(funcidx != -1);
+
+    EXPECT_EQ(STYPE_DYNARRAY, sym.entries[funcidx].funcparamtypes[0] & STYPE_DYNARRAY);
+}
+
 TEST(Compile, DoubleNegatedConstant) {
     ccCompiledScript *scrip = newScriptFixture();
 


### PR DESCRIPTION
My recent pull request to allow struct members to share names with global types included a Boolean variable to simplify some checks. The check was performed a bit too early and broke function parsing for methods that return dynamic arrays.
 - Moved the check to the correct location
 - Added a test for parsing structs with methods returning dynamic arrays so it doesn't happen again