### PR TITLE
Installer: support for optional extra version tag

### DIFF
--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -2,25 +2,36 @@
 #define AgsName "Adventure Game Studio"
 #define AgsUrl "http://www.adventuregamestudio.co.uk/"
 #define VcRedistInstaller "vcredist_x86-9.0.30729.6161.exe"
-; requires AgsVersion to be passed in since innosetup is interested in 4 digit version numbers
+; requires following macros to be passed by command line:
+;   AgsVersion - 4 digit version number
+;   AgsFriendlyVersion - 3 digit 'user-friendly' version number
+;   AgsSpVersion - special version tag (can be empty)
+
+#if "" == AgsSpVersion
+#define AgsVerNameStr AgsName + ' ' + AgsFriendlyVersion
+#define AgsOutputFile 'AGS-' + AgsFriendlyVersion
+#else
+#define AgsVerNameStr AgsName + ' ' + AgsFriendlyVersion + ' ' + AgsSpVersion
+#define AgsOutputFile 'AGS-' + AgsFriendlyVersion + '-' + AgsSpVersion
+#endif 
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={#AgsAppId}
-AppName={#AgsName} {#AgsVersion}
-AppVersion={#AgsVersion}
-AppVerName={#AgsName} {#AgsVersion}
+AppName={#AgsName} {#AgsFriendlyVersion}
+AppVersion={#AgsFullVersion}
+AppVerName={#AgsVerNameStr}
 AppPublisher=AGS Project Team
 AppPublisherURL={#AgsUrl}
 AppSupportURL={#AgsUrl}
 AppUpdatesURL={#AgsUrl}
-DefaultDirName={pf}\{#AgsName} {#AgsVersion}
-DefaultGroupName={#AgsName} {#AgsVersion}
+DefaultDirName={pf}\{#AgsName} {#AgsFriendlyVersion}
+DefaultGroupName={#AgsVerNameStr}
 AllowNoIcons=yes
 LicenseFile=License.txt
-OutputBaseFilename=AGS-{#AgsVersion}
+OutputBaseFilename={#AgsOutputFile}
 Compression=lzma
 SolidCompression=yes
 ChangesAssociations=yes
@@ -84,8 +95,8 @@ Name: "{group}\AGS Manual"; Filename: "{app}\ags-help.chm"; Comment: "Online hel
 Name: "{group}\{cm:UninstallProgram,Adventure Game Studio}"; Filename: "{uninstallexe}"; Comment: ":~(  Ah well, nothing lasts forever. Turn off the light on your way out."
 Name: "{group}\Visit the AGS Website"; Filename: "{app}\Docs\AGS Website.url"; Comment: "See the latest AGS-related news. Find games to play."
 Name: "{group}\Visit the AGS Forums"; Filename: "{app}\Docs\AGS Forums.url"; Comment: "Join the madness! Come on down and party on the forums."
-Name: "{commondesktop}\AGS {#AgsVersion}"; Filename: "{app}\AGSEditor.exe"; Tasks: desktopicon
-Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\AGS {#AgsVersion}"; Filename: "{app}\AGSEditor.exe"; Tasks: quicklaunchicon
+Name: "{commondesktop}\AGS {#AgsFriendlyVersion}"; Filename: "{app}\AGSEditor.exe"; Tasks: desktopicon
+Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\AGS {#AgsFriendlyVersion}"; Filename: "{app}\AGSEditor.exe"; Tasks: quicklaunchicon
 
 
 [Registry]

--- a/Windows/Installer/build.py
+++ b/Windows/Installer/build.py
@@ -15,7 +15,7 @@ ISCC="C:/Program Files (x86)/Inno Setup 5/iscc.exe"
 SCRIPT_LOC=os.path.dirname(os.path.realpath(__file__))
 WORKSPACE_DIR=os.path.join(SCRIPT_LOC, "../..")
 
-AgsVersion = namedtuple('AgsVersion', ['version', 'version_friendly', 'app_id'])
+AgsVersion = namedtuple('AgsVersion', ['version', 'version_friendly', 'version_sp', 'app_id'])
 
 def main():
     docs_dir = workspace_rel("Windows/Installer/Source/Docs")
@@ -32,10 +32,12 @@ def main():
     if project_ver_check != editor_ver_check:
         raise Exception("Versions differ - editor:{0} version.json:{1}".format(editor_ver_check, project_ver_check))
 
-    project_ver_str = ".".join(project_ver.version_friendly)
+    project_titlever_str = ".".join(project_ver.version_friendly)
+    project_fullver_str = ".".join(project_ver.version)
+    project_spver_str = project_ver.version_sp
     project_app_id = ".".join(project_ver.app_id)
 
-    compile_installer("ags.iss", {"AgsVersion": project_ver_str, "AgsAppId": project_app_id})
+    compile_installer("ags.iss", {"AgsFriendlyVersion": project_titlever_str, "AgsFullVersion": project_fullver_str, "AgsSpVersion": project_spver_str, "AgsAppId": project_app_id})
 
 def workspace_rel(path):
     return os.path.join(workspace_dir(), path)
@@ -58,8 +60,9 @@ def load_project_version(path):
 
     version = j['version'].split('.')
     version_friendly = j['versionFriendly'].split('.')
+    version_sp = j['versionSp']
     app_id = j['appID']
-    return AgsVersion(version, version_friendly, app_id)
+    return AgsVersion(version, version_friendly, version_sp, app_id)
 
 def compile_installer(script, params):
     with dir_context(workspace_rel("Windows/Installer")):

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
     "version": "3.3.5.8",
     "versionFriendly": "3.3.5",
+    "versionSp": "",
     "appID": "f535517a-6c99-4d36-b23c-ca42d59e48d6"
 }


### PR DESCRIPTION
This adds an optional version tag which is appended to the package/installer file names (as well as app name the Editor is registered on Windows with when installed). This tag can be used, for example, to specify beta version, or patch number to make it easier for end users to distinguish updates of same public release.