### PR TITLE
Scripting: Prevent arrays of structs with dynamic array members

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3167,6 +3167,11 @@ int parse_variable_declaration(long cursym,int *next_type,int isglobal,
         return -1;
       }
 
+      if (sym.entries[vtwas].flags & SFLG_HASDYNAMICARRAY) {
+        cc_error("Cannot declare an array of a type containing dynamic array(s)");
+        return -1;
+      }
+
       if (array_size < 1) {
         cc_error("Array size must be >=1");
         return -1;
@@ -3934,6 +3939,7 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                                     cc_error("Member variable of managed struct cannot be dynamic array");
                                     return -1;
                                 }
+                                sym.entries[stname].flags |= SFLG_HASDYNAMICARRAY;
                                 sym.entries[vname].flags |= SFLG_DYNAMICARRAY;
                                 array_size = 0;
                                 size_so_far += 4;

--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -97,6 +97,12 @@
 #define SFLG_AUTOPTR   0x20000  // automatically convert definition to pointer
 #define SFLG_DYNAMICARRAY 0x40000  // array allocated at runtime
 #define SFLG_BUILTIN   0x80000  // direct instantiation/extension not allowed
+/*
+   The flag below is only present because the variable path parser
+   (e.g. something[2].something[3].something = 17) cannot yet handle
+   arrays within arrays
+*/
+#define SFLG_HASDYNAMICARRAY  0x100000
 #define TEMP_SYMLIST_LENGTH 100
 
 extern int is_whitespace(char cht);


### PR DESCRIPTION
Give an error on the declaration of such a variable. This closes a hole in the compiler for now.