### PR TITLE
Refactor: picked out and cleaned up code surrounding reading and writing of game save

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include "gui/guidefines.h"
+#include "util/math.h"
 #include "util/string_utils.h"
 #include "util/stream.h"
 
@@ -201,6 +202,11 @@ void StrUtil::WriteString(const String &s, Stream *out)
     out->WriteInt32(len);
     if (len > 0)
         out->Write(s.GetCStr(), len);
+}
+
+void StrUtil::WriteCStr(const String &s, Stream *out)
+{
+    out->Write(s.GetCStr(), s.GetLength() + 1);
 }
 
 } // namespace Common

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -57,9 +57,15 @@ void split_lines(const char *todis, int wii, int fonnt);
 
 //=============================================================================
 
-// FIXME: remove later when arrays of chars are replaced by string class
+// TODO: remove later when arrays of chars are replaced by string class
+// fputstring writes c-string with null terminator
 void fputstring(const char *sss, Common::Stream *out);
+// fgetstring_limit limits number of bytes stored in the buffer, but it does NOT limit
+// number of bytes being read; the string is continued to be read until null terminator
+// is reached
 void fgetstring_limit(char *sss, Common::Stream *in, int bufsize);
+// fgestring is similar to fgetstring_limit, but it assumes very large arbitrary buffer limit
+// TODO: replace this function, because it should not exist >:[
 void fgetstring(char *sss, Common::Stream *in);
 
 #include "util/string.h"
@@ -92,6 +98,9 @@ namespace StrUtil
     // length is presented as int32 integer
     String          ReadString(Stream *in);
     void            WriteString(const String &s, Stream *out);
+
+    // Serializes string as c-string (null-terminated sequence)
+    void            WriteCStr(const String &s, Stream *out);
 }
 } // namespace Common
 } // namespace AGS

--- a/Engine/Makefile-objs
+++ b/Engine/Makefile-objs
@@ -6,6 +6,7 @@ ac/statobj \
 debug \
 device \
 font \
+game \
 gfx \
 gui \
 main \

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -821,7 +821,7 @@ void DialogOptions::Redraw()
     update_polled_stuff_if_runtime();
 
     subBitmap = recycle_bitmap(subBitmap, tempScrn->GetColorDepth(), dirtywidth, dirtyheight);
-    subBitmap = gfxDriver->ConvertBitmapToSupportedColourDepth(subBitmap);
+    subBitmap = ReplaceBitmapWithSupportedFormat(subBitmap);
 
     update_polled_stuff_if_runtime();
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -345,7 +345,13 @@ Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
     return tempbl;
 }
 
-
+Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *bitmap)
+{
+    Bitmap *new_bitmap = gfxDriver->ConvertBitmapToSupportedColourDepth(bitmap);
+    if (new_bitmap != bitmap)
+        delete bitmap;
+    return new_bitmap;
+}
 
 
 
@@ -2118,7 +2124,7 @@ void draw_fps()
     if (fpsDisplay == NULL)
     {
         fpsDisplay = BitmapHelper::CreateBitmap(get_fixed_pixel_size(100), (wgetfontheight(FONT_SPEECH) + get_fixed_pixel_size(5)), ScreenResolution.ColorDepth);
-        fpsDisplay = gfxDriver->ConvertBitmapToSupportedColourDepth(fpsDisplay);
+        fpsDisplay = ReplaceBitmapWithSupportedFormat(fpsDisplay);
     }
     fpsDisplay->ClearTransparent();
     //Bitmap *oldAbuf = ds;

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -102,4 +102,11 @@ Common::Bitmap *convert_16_to_15(Common::Bitmap *iii);
 Common::Bitmap *convert_16_to_16bgr(Common::Bitmap *tempbl);
 Common::Bitmap *convert_32_to_32bgr(Common::Bitmap *tempbl);
 
+// Checks if the bitmap needs to be converted and **deletes original** if a new bitmap
+// had to be created (by default).
+// TODO: this helper function was meant to remove bitmap deletion from the GraphicsDriver's
+// implementations while keeping code changes to minimum. The proper solution would probably
+// be to use shared pointers when storing Bitmaps, or make Bitmap reference-counted object.
+Common::Bitmap *ReplaceBitmapWithSupportedFormat(Common::Bitmap *bitmap);
+
 #endif // __AGS_EE_AC__DRAW_H

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -349,7 +349,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
     }
 
     // replace the bitmap in the sprite set
-    add_dynamic_sprite(gotSlot, gfxDriver->ConvertBitmapToSupportedColourDepth(newPic));
+    add_dynamic_sprite(gotSlot, ReplaceBitmapWithSupportedFormat(newPic));
     ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(gotSlot);
     return new_spr;
 }
@@ -421,7 +421,7 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
     if ((alphaChannel) && (ScreenResolution.ColorDepth < 32))
         alphaChannel = false;
 
-    add_dynamic_sprite(gotSlot, gfxDriver->ConvertBitmapToSupportedColourDepth(newPic), alphaChannel != 0);
+    add_dynamic_sprite(gotSlot, ReplaceBitmapWithSupportedFormat(newPic), alphaChannel != 0);
     ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(gotSlot);
     return new_spr;
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -64,6 +64,7 @@
 #include "device/mousew32.h"
 #include "font/fonts.h"
 #include "game/savegame.h"
+#include "game/savegame_internal.h"
 #include "gui/animatingguibutton.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxfilter.h"

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1794,10 +1794,7 @@ void restore_game_overlays(Stream *in)
     ReadOverlays_Aligned(in);
     for (int bb=0;bb<numscreenover;bb++) {
         if (screenover[bb].hasSerializedBitmap)
-        {
             screenover[bb].pic = read_serialized_bitmap(in);
-            screenover[bb].bmp = gfxDriver->CreateDDBFromBitmap(screenover[bb].pic, false);
-        }
     }
 }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1758,7 +1758,7 @@ void ReadRoomStatus_Aligned(RoomStatus *roomstat, Stream *in)
     roomstat->ReadFromFile_v321(&align_s);
 }
 
-void restore_game_room_state(Stream *in, const char *nametouse)
+void restore_game_room_state(Stream *in)
 {
     int vv;
 
@@ -2130,8 +2130,8 @@ void restore_game_audioclips_and_crossfade(Stream *in, int crossfadeInChannelWas
     crossFadeVolumeAtStart = in->ReadInt32();
 }
 
-int restore_game_data (Stream *in, const char *nametouse, SavedGameVersion svg_version) {
-
+int restore_game_data (Stream *in, SavedGameVersion svg_version)
+{
     int bb, vv;
 
     int sg_cur_mode = 0, sg_cur_cursor = 0;
@@ -2158,7 +2158,7 @@ int restore_game_data (Stream *in, const char *nametouse, SavedGameVersion svg_v
     scriptModuleDataBuffers.resize(numScriptModules);
     scriptModuleDataSize.resize(numScriptModules);
     restore_game_scripts(in, /*out*/ gdatasize,&newglobaldatabuffer, scriptModuleDataBuffers, scriptModuleDataSize);
-    restore_game_room_state(in, nametouse);
+    restore_game_room_state(in);
 
     restore_game_play(in);
 
@@ -2446,9 +2446,9 @@ int restore_game_data (Stream *in, const char *nametouse, SavedGameVersion svg_v
     return 0;
 }
 
-int restore_game_data (Common::Stream *in, const char *nametouse)
+int restore_game_data(Common::Stream *in)
 {
-    return restore_game_data (in, nametouse, kSvgVersion_321);
+    return restore_game_data(in, kSvgVersion_321);
 }
 
 int gameHasBeenRestored = 0;
@@ -2592,7 +2592,7 @@ int load_game(const Common::String &path, int slotNumber)
     }
 
     // do the actual restore
-    error_code = restore_game_data(in, path, svg_version);
+    error_code = restore_game_data(in, svg_version);
     delete in;
     our_eip = oldeip;
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2454,12 +2454,6 @@ int restore_game_data (Common::Stream *in, const char *nametouse)
 int gameHasBeenRestored = 0;
 int oldeip;
 
-void ReadRichMediaHeader_Aligned(RICH_GAME_MEDIA_HEADER &rich_media_header, Stream *in)
-{
-    AlignedStream align_s(in, Common::kAligned_Read);
-    rich_media_header.ReadFromFile(&align_s);
-}
-
 Stream *open_savedgame(const char *savedgame, int &error_code, SavedGameVersion *out_svg_version = NULL)
 {
     error_code = 0;
@@ -2472,7 +2466,7 @@ Stream *open_savedgame(const char *savedgame, int &error_code, SavedGameVersion 
 
     // skip Vista header
     RICH_GAME_MEDIA_HEADER rich_media_header;
-    ReadRichMediaHeader_Aligned(rich_media_header, in);
+    rich_media_header.ReadFromFile(in);
 
     // check saved game signature
     in->Read(rbuffer, sgsiglen);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2418,7 +2418,7 @@ int restore_game_data (Stream *in, const char *nametouse, SavedGameVersion svg_v
 
     for (vv = 0; vv < game.numgui; vv++) {
         guibg[vv] = BitmapHelper::CreateBitmap (guis[vv].Width, guis[vv].Height, ScreenResolution.ColorDepth);
-        guibg[vv] = gfxDriver->ConvertBitmapToSupportedColourDepth(guibg[vv]);
+        guibg[vv] = ReplaceBitmapWithSupportedFormat(guibg[vv]);
     }
 
     if (gfxDriver->SupportsGammaControl())

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1135,15 +1135,6 @@ void WriteRoomStatus_Aligned(RoomStatus *roomstat, Stream *out)
 void save_game_room_state(Stream *out)
 {
     out->WriteInt32(displayed_room);
-    if (displayed_room >= 0) {
-        // update the current room script's data segment copy
-        if (roominst!=NULL)
-            save_room_data_segment();
-
-        // Update the saved interaction variable values
-        for (int ff = 0; ff < thisroom.numLocalVars; ff++)
-            croom->interactionVariableValues[ff] = thisroom.localvars[ff].Value;
-    }
 
     // write the room state for all the rooms the player has been in
     RoomStatus* roomstat;
@@ -1384,11 +1375,6 @@ void save_game_data(Stream *out)
 
     update_polled_stuff_if_runtime();
 
-    if (play.cur_music_number >= 0) {
-        if (IsMusicPlaying() == 0)
-            play.cur_music_number = -1;
-    }
-
     //----------------------------------------------------------------
     WriteGameState_Aligned(out);
 
@@ -1516,7 +1502,7 @@ void save_game(int slotn, const char*descript) {
     update_polled_stuff_if_runtime();
 
     // Actual dynamic game data is saved here
-    save_game_data(out);
+    SaveGameState(out);
 
     if (screenShot != NULL)
     {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2191,31 +2191,6 @@ int restore_game_data (Stream *in, SavedGameVersion svg_version)
     // Modified custom properties are read separately to keep existing save format
     play.ReadCustomProperties(in);
 
-    //
-    //in->ReadArray(&game.invinfo[0], sizeof(InventoryItemInfo), game.numinvitems);
-    //in->ReadArray(&game.mcurs[0], sizeof(MouseCursor), game.numcursors);
-    //
-    //if (game.invScripts == NULL)
-    //{
-    //  for (bb = 0; bb < game.numinvitems; bb++)
-    //    in->ReadArray (&game.intrInv[bb]->timesRun[0], sizeof (int), MAX_NEWINTERACTION_EVENTS);
-    //  for (bb = 0; bb < game.numcharacters; bb++)
-    //    in->ReadArray (&game.intrChar[bb]->timesRun[0], sizeof (int), MAX_NEWINTERACTION_EVENTS);
-    //}
-    //
-    //// restore pointer members
-    //game.globalscript=gswas;
-    //game.compiled_script=compsc;
-    //game.chars=chwas;
-    //game.dict = olddict;
-    //for (vv=0;vv<MAXGLOBALMES;vv++) game.messages[vv]=mesbk[vv];
-    //
-    //in->ReadArray(&game.options[0], sizeof(int), OPT_HIGHESTOPTION+1);
-    //game.options[OPT_LIPSYNCTEXT] = in->ReadByte();
-    //
-    //in->ReadArray(&game.chars[0],sizeof(CharacterInfo),game.numcharacters);
-    //
-
     ReadCharacterExtras_Aligned(in);
     if (roominst!=NULL) {  // so it doesn't overwrite the tsdata
         delete roominstFork;

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -117,7 +117,6 @@ void set_game_speed(int fps);
 void setup_for_dialog();
 void restore_after_dialog();
 Common::String get_save_game_path(int slotNum);
-int  load_game_and_print_error(int toload);
 void restore_game_dialog();
 void save_game_dialog();
 void setup_sierra_interface();
@@ -125,18 +124,18 @@ GameFileError load_game_file();
 void free_do_once_tokens();
 // Free all the memory associated with the game
 void unload_game_file();
-void save_game_data (Common::Stream *out, Common::Bitmap *screenshot);
+void save_game_data(Common::Stream *out);
 void save_game(int slotn, const char*descript);
-int  restore_game_data(Common::Stream *in);
-int read_savedgame_description(const Common::String &savedgame, Common::String &description);
-int read_savedgame_screenshot(const Common::String &savedgame, int &want_shot);
-int  load_game(int slotNumber);
-int  load_game(const Common::String &path, int slotNumber);
-void serialize_bitmap(Common::Bitmap *thispic, Common::Stream *out);
-void safeguard_string (Common::String &descript);
+bool read_savedgame_description(const Common::String &savedgame, Common::String &description);
+bool read_savedgame_screenshot(const Common::String &savedgame, int &want_shot);
+bool load_game_and_print_error(int slot);
+bool load_game_or_quit(int slot);
+bool load_game_or_quit(const Common::String &path, int slot);
+void serialize_bitmap(const Common::Bitmap *thispic, Common::Stream *out);
 // On Windows we could just use IIDFromString but this is platform-independant
 void convert_guid_from_text_to_binary(const char *guidText, unsigned char *buffer);
 Common::Bitmap *read_serialized_bitmap(Common::Stream *in);
+void skip_serialized_bitmap(Common::Stream *in);
 long write_screen_shot_for_vista(Common::Stream *out, Common::Bitmap *screenshot);
 
 void start_skipping_cutscene ();

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -124,7 +124,6 @@ GameFileError load_game_file();
 void free_do_once_tokens();
 // Free all the memory associated with the game
 void unload_game_file();
-void save_game_data(Common::Stream *out);
 void save_game(int slotn, const char*descript);
 bool read_savedgame_description(const Common::String &savedgame, Common::String &description);
 bool read_savedgame_screenshot(const Common::String &savedgame, int &want_shot);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -127,7 +127,7 @@ void free_do_once_tokens();
 void unload_game_file();
 void save_game_data (Common::Stream *out, Common::Bitmap *screenshot);
 void save_game(int slotn, const char*descript);
-int  restore_game_data (Common::Stream *in, const char *nametouse);
+int  restore_game_data(Common::Stream *in);
 int read_savedgame_description(const Common::String &savedgame, Common::String &description);
 int read_savedgame_screenshot(const Common::String &savedgame, int &want_shot);
 int  load_game(int slotNumber);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -128,9 +128,10 @@ void save_game_data(Common::Stream *out);
 void save_game(int slotn, const char*descript);
 bool read_savedgame_description(const Common::String &savedgame, Common::String &description);
 bool read_savedgame_screenshot(const Common::String &savedgame, int &want_shot);
-bool load_game_and_print_error(int slot);
-bool load_game_or_quit(int slot);
-bool load_game_or_quit(const Common::String &path, int slot);
+// Tries to restore saved game and displays an error on failure; if the error occured
+// too late, when the game data was already overwritten, shuts engine down.
+bool try_restore_save(int slot);
+bool try_restore_save(const Common::String &path, int slot);
 void serialize_bitmap(const Common::Bitmap *thispic, Common::Stream *out);
 // On Windows we could just use IIDFromString but this is platform-independant
 void convert_guid_from_text_to_binary(const char *guidText, unsigned char *buffer);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -161,7 +161,9 @@ void get_message_text (int msnum, char *buffer, char giveErr = 1);
 void register_audio_script_objects();
 bool unserialize_audio_script_object(int index, const char *objectType, const char *serializedData, int dataSize);
 
+extern int in_new_room;
 extern int new_room_pos;
 extern int new_room_x, new_room_y, new_room_loop;
+extern int displayed_room;
 
 #endif // __AGS_EE_AC__GAME_H

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -428,6 +428,14 @@ void GameState::WriteQueuedAudioItems_Aligned(Common::Stream *out)
     }
 }
 
+void GameState::FreeProperties()
+{
+    for (int i = 0; i < game.numcharacters; ++i)
+        charProps[i].clear();
+    for (int i = 0; i < game.numinvitems; ++i)
+        invProps[i].clear();
+}
+
 void GameState::ReadCustomProperties(Common::Stream *in)
 {
     if (loaded_game_file_version >= kGameVersion_340_4)
@@ -437,15 +445,9 @@ void GameState::ReadCustomProperties(Common::Stream *in)
         // this save is made by an older game version which had different
         // properties.
         for (int i = 0; i < game.numcharacters; ++i)
-        {
-            charProps[i].clear();
             Properties::ReadValues(charProps[i], in);
-        }
         for (int i = 0; i < game.numinvitems; ++i)
-        {
-            invProps[i].clear();
             Properties::ReadValues(invProps[i], in);
-        }
     }
 }
 
@@ -457,12 +459,8 @@ void GameState::WriteCustomProperties(Common::Stream *out)
         // just for the saving data time to avoid getting lots of 
         // redundant data into saved games
         for (int i = 0; i < game.numcharacters; ++i)
-        {
             Properties::WriteValues(charProps[i], out);
-        }
         for (int i = 0; i < game.numinvitems; ++i)
-        {
             Properties::WriteValues(invProps[i], out);
-        }
     }
 }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -213,6 +213,7 @@ struct GameState {
     void WriteQueuedAudioItems_Aligned(Common::Stream *out);
     void ReadCustomProperties(Common::Stream *in);
     void WriteCustomProperties(Common::Stream *out);
+    void FreeProperties();
 };
 
 extern GameState play;

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -14,6 +14,7 @@
 
 #include "ac/global_dynamicsprite.h"
 #include "util/wgt2allg.h" // Allegro RGB, PALETTE
+#include "ac/draw.h"
 #include "ac/dynamicsprite.h"
 #include "ac/file.h"
 #include "ac/spritecache.h"
@@ -41,7 +42,7 @@ int LoadImageFile(const char *filename) {
     if (gotSlot <= 0)
         return 0;
 
-    add_dynamic_sprite(gotSlot, gfxDriver->ConvertBitmapToSupportedColourDepth(loadedFile));
+    add_dynamic_sprite(gotSlot, ReplaceBitmapWithSupportedFormat(loadedFile));
 
     return gotSlot;
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -106,7 +106,7 @@ void restart_game() {
         curscript->queue_action(ePSARestartGame, 0, "RestartGame");
         return;
     }
-    load_game_or_quit(RESTART_POINT_SAVE_GAME_NUMBER);
+    try_restore_save(RESTART_POINT_SAVE_GAME_NUMBER);
 }
 
 void RestoreGameSlot(int slnum) {
@@ -118,7 +118,7 @@ void RestoreGameSlot(int slnum) {
         curscript->queue_action(ePSARestoreGame, slnum, "RestoreGameSlot");
         return;
     }
-    load_game_and_print_error(slnum);
+    try_restore_save(slnum);
 }
 
 void DeleteSaveSlot (int slnum) {
@@ -292,7 +292,7 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
     play.screen_is_faded_out = 1;
 
     if (load_new_game_restore >= 0) {
-        load_game_and_print_error(load_new_game_restore);
+        try_restore_save(load_new_game_restore);
         load_new_game_restore = -1;
     }
     else

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -106,10 +106,7 @@ void restart_game() {
         curscript->queue_action(ePSARestartGame, 0, "RestartGame");
         return;
     }
-    int errcod;
-    if ((errcod = load_game(RESTART_POINT_SAVE_GAME_NUMBER))!=0)
-        quitprintf("unable to restart game (error:%s)", load_game_errors[-errcod]);
-
+    load_game_or_quit(RESTART_POINT_SAVE_GAME_NUMBER);
 }
 
 void RestoreGameSlot(int slnum) {
@@ -121,7 +118,7 @@ void RestoreGameSlot(int slnum) {
         curscript->queue_action(ePSARestoreGame, slnum, "RestoreGameSlot");
         return;
     }
-    load_game(slnum);
+    load_game_and_print_error(slnum);
 }
 
 void DeleteSaveSlot (int slnum) {
@@ -161,7 +158,7 @@ int IsGamePaused() {
 int GetSaveSlotDescription(int slnum,char*desbuf) {
     VALIDATE_STRING(desbuf);
     String description;
-    if (read_savedgame_description(get_save_game_path(slnum), description) == 0)
+    if (read_savedgame_description(get_save_game_path(slnum), description))
     {
         strcpy(desbuf, description);
         return 1;
@@ -174,7 +171,7 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
     int gotSlot;
     multiply_up_coordinates(&width, &height);
 
-    if (read_savedgame_screenshot(get_save_game_path(slnum), gotSlot) != 0)
+    if (!read_savedgame_screenshot(get_save_game_path(slnum), gotSlot))
         return 0;
 
     if (gotSlot == 0)
@@ -295,7 +292,7 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
     play.screen_is_faded_out = 1;
 
     if (load_new_game_restore >= 0) {
-        load_game (load_new_game_restore);
+        load_game_and_print_error(load_new_game_restore);
         load_new_game_restore = -1;
     }
     else

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -510,7 +510,7 @@ void recreate_guibg_image(GUIMain *tehgui)
   guibg[ifn] = BitmapHelper::CreateBitmap(tehgui->Width, tehgui->Height, ScreenResolution.ColorDepth);
   if (guibg[ifn] == NULL)
     quit("SetGUISize: internal error: unable to reallocate gui cache");
-  guibg[ifn] = gfxDriver->ConvertBitmapToSupportedColourDepth(guibg[ifn]);
+  guibg[ifn] = ReplaceBitmapWithSupportedFormat(guibg[ifn]);
 
   if (guibgbmp[ifn] != NULL)
   {

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -259,6 +259,19 @@ void get_overlay_position(int overlayidx, int *x, int *y) {
     *y = tdyp;
 }
 
+void recreate_overlay_ddbs()
+{
+    for (int i = 0; i < numscreenover; ++i)
+    {
+        if (screenover[i].bmp)
+            gfxDriver->DestroyDDB(screenover[i].bmp);
+        if (screenover[i].pic)
+            screenover[i].bmp = gfxDriver->CreateDDBFromBitmap(screenover[i].pic, false);
+        else
+            screenover[i].bmp = NULL;
+    }
+}
+
 //=============================================================================
 //
 // Script API Functions

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -38,6 +38,7 @@ void remove_screen_overlay(int type);
 void get_overlay_position(int overlayidx, int *x, int *y);
 int  add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
 void remove_screen_overlay_index(int cc);
+void recreate_overlay_ddbs();
 
 extern int is_complete_overlay;
 extern int is_text_overlay;

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -39,4 +39,7 @@ void get_overlay_position(int overlayidx, int *x, int *y);
 int  add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
 void remove_screen_overlay_index(int cc);
 
+extern int is_complete_overlay;
+extern int is_text_overlay;
+
 #endif // __AGS_EE_AC__OVERLAY_H

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -338,7 +338,7 @@ void start_recording() {
 
 void start_replay_record () {
     Stream *replay_s = Common::File::CreateFile(replayTempFile);
-    save_game_data(replay_s);
+    SaveGameState(replay_s);
     delete replay_s;
     start_recording();
     play.recording = 1;

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -465,7 +465,7 @@ void start_playback()
             if (replayver >= 3) {
                 int issave = in->ReadInt32();
                 if (issave) {
-                    if (restore_game_data (in, replayfile))
+                    if (restore_game_data(in))
                         quit("!Error running replay... could be incorrect game version");
                     replay_last_second = loopcounter;
                 }

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -23,6 +23,7 @@
 #include "ac/keycode.h"
 #include "ac/mouse.h"
 #include "ac/record.h"
+#include "game/savegame.h"
 #include "main/main.h"
 #include "media/audio/soundclip.h"
 #include "util/string_utils.h"
@@ -30,8 +31,8 @@
 #include "device/mousew32.h"
 #include "util/filestream.h"
 
-using AGS::Common::Stream;
-using AGS::Common::String;
+using namespace AGS::Common;
+using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern GameState play;
@@ -337,7 +338,7 @@ void start_recording() {
 
 void start_replay_record () {
     Stream *replay_s = Common::File::CreateFile(replayTempFile);
-    save_game_data (replay_s, NULL);
+    save_game_data(replay_s);
     delete replay_s;
     start_recording();
     play.recording = 1;
@@ -465,7 +466,7 @@ void start_playback()
             if (replayver >= 3) {
                 int issave = in->ReadInt32();
                 if (issave) {
-                    if (restore_game_data(in))
+                    if (RestoreGameState(in, kSvgVersion_321) != kSvgErr_NoError)
                         quit("!Error running replay... could be incorrect game version");
                     replay_last_second = loopcounter;
                 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -82,7 +82,6 @@ extern RoomStatus*croom;
 extern RoomStatus troom;    // used for non-saveable rooms, eg. intro
 extern int displayed_room;
 extern RoomObject*objs;
-extern roomstruct thisroom;
 extern ccInstance *roominst;
 extern AGSPlatformDriver *platform;
 extern int numevents;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -497,7 +497,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             thisroom.ebscene[cc] = convert_32_to_32bgr(thisroom.ebscene[cc]);
 #endif
 
-        thisroom.ebscene[cc] = gfxDriver->ConvertBitmapToSupportedColourDepth(thisroom.ebscene[cc]);
+        thisroom.ebscene[cc] = ReplaceBitmapWithSupportedFormat(thisroom.ebscene[cc]);
     }
 
     if ((thisroom.ebscene[0]->GetColorDepth() == 8) &&

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -51,4 +51,6 @@ void  check_new_room();
 void  compile_room_script();
 void  on_background_frame_change ();
 
+extern roomstruct thisroom;
+
 #endif // __AGS_EE_AC__ROOM_H

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -89,7 +89,7 @@ IDriverDependantBitmap* prepare_screen_for_transition_in()
     if (temp_virtual == NULL)
         quit("Crossfade: buffer is null attempting transition");
 
-    temp_virtual = gfxDriver->ConvertBitmapToSupportedColourDepth(temp_virtual);
+    temp_virtual = ReplaceBitmapWithSupportedFormat(temp_virtual);
     if (temp_virtual->GetHeight() < play.viewport.GetHeight())
     {
         Bitmap *enlargedBuffer = BitmapHelper::CreateBitmap(temp_virtual->GetWidth(), play.viewport.GetHeight(), temp_virtual->GetColorDepth());

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -20,6 +20,8 @@ using AGS::Common::Stream;
 void ScreenOverlay::ReadFromFile(Stream *in)
 {
     // Skipping bmp and pic pointer values
+    bmp = NULL;
+    pic = NULL;
     in->ReadInt32(); // bmp
     hasSerializedBitmap = in->ReadInt32() != 0;
     type = in->ReadInt32();

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -244,7 +244,7 @@ void initialize_sprite (int ee) {
         if ((spcoldep == 8) && (ScreenResolution.ColorDepth > 8))
             select_palette(palette);
 
-        spriteset.set(ee, gfxDriver->ConvertBitmapToSupportedColourDepth(spriteset[ee]));
+        spriteset.set(ee, ReplaceBitmapWithSupportedFormat(spriteset[ee]));
 
         if ((spcoldep == 8) && (ScreenResolution.ColorDepth > 8))
             unselect_palette();

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -465,6 +465,8 @@ SavegameError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_da
         guibg[i] = ReplaceBitmapWithSupportedFormat(guibg[i]);
     }
 
+    recreate_overlay_ddbs();
+
     if (gfxDriver->SupportsGammaControl())
         gfxDriver->SetGamma(play.gamma_adjustment);
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -1,0 +1,219 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#include "ac/game.h"
+#include "ac/gamesetupstruct.h"
+#include "ac/richgamemedia.h"
+#include "ac/gamesetup.h"
+#include "gfx/bitmap.h"
+#include "game/savegame.h"
+#include "main/main.h"
+#include "main/version.h"
+#include "platform/base/agsplatformdriver.h"
+#include "plugin/agsplugin.h"
+#include "util/alignedstream.h"
+#include "util/file.h"
+#include "util/stream.h"
+#include "util/string_utils.h"
+
+using namespace Common;
+using namespace Engine;
+
+// function is currently implemented in game.cpp
+AGS::Engine::SavegameError restore_game_data(Stream *in, SavegameVersion svg_version);
+extern GameSetupStruct game;
+
+
+namespace AGS
+{
+namespace Engine
+{
+
+const String SavegameSource::Signature = "Adventure Game Studio saved game";
+
+
+String GetSavegameErrorText(SavegameError err)
+{
+    switch (err)
+    {
+    case kSvgErr_NoError:
+        return "No error";
+    case kSvgErr_FileNotFound:
+        return "File not found";
+    case kSvgErr_SignatureFailed:
+        return "Not an AGS saved game or unsupported format";
+    case kSvgErr_FormatVersionNotSupported:
+        return "Save format version not supported";
+    case kSvgErr_IncompatibleEngine:
+        return "Saved game was written by incompatible interpreter";
+    case kSvgErr_DifferentColorDepth:
+        return "Saved with different colour depth";
+    }
+    return "Unknown error";
+}
+
+Bitmap *RestoreSaveImage(Stream *in)
+{
+    if (in->ReadInt32())
+        return read_serialized_bitmap(in);
+    return NULL;
+}
+
+void SkipSaveImage(Stream *in)
+{
+    if (in->ReadInt32())
+        skip_serialized_bitmap(in);
+}
+
+SavegameError OpenSavegameBase(const String &filename, SavegameSource *src, SavegameDescription *desc, SavegameDescElem elems)
+{
+    AStream in(File::OpenFileRead(filename));
+    if (!in.get())
+        return kSvgErr_FileNotFound;
+
+    // Skip MS Windows Vista rich media header
+    RICH_GAME_MEDIA_HEADER rich_media_header;
+    rich_media_header.ReadFromFile(in.get());
+
+    // Check saved game signature
+    String svg_sig = String::FromStreamCount(in.get(), SavegameSource::Signature.GetLength());
+    if (svg_sig.Compare(SavegameSource::Signature))
+        return kSvgErr_SignatureFailed;
+
+    String desc_text;
+    if (desc && elems == kSvgDesc_UserText)
+        desc_text.Read(in.get());
+    else
+        for (; in->ReadByte(); ); // skip until null terminator
+    SavegameVersion svg_ver = (SavegameVersion)in->ReadInt32();
+
+    // Check saved game format version
+    if (svg_ver < kSvgVersion_LowestSupported ||
+        svg_ver > kSvgVersion_Current)
+    {
+        return kSvgErr_FormatVersionNotSupported;
+    }
+
+    ABitmap image;
+    if (desc && elems == kSvgDesc_UserImage)
+        image.reset(RestoreSaveImage(in.get()));
+    else
+        SkipSaveImage(in.get());
+
+    String version_str = String::FromStream(in.get());
+    Version eng_version(version_str);
+    if (eng_version > EngineVersion ||
+        eng_version < SavedgameLowestBackwardCompatVersion)
+    {
+        // Engine version is either non-forward or non-backward compatible
+        return kSvgErr_IncompatibleEngine;
+    }
+    String main_file;
+    if (desc && elems == kSvgDesc_EnvInfo)
+        main_file.Read(in.get());
+    else
+        for (; in->ReadByte(); ); // skip until null terminator
+
+    if (src)
+    {
+        src->Filename = filename;
+        src->Version = svg_ver;
+        src->InputStream.reset(in.release());
+    }
+    if (desc)
+    {
+        if (elems == kSvgDesc_EnvInfo)
+        {
+            desc->EngineVersion = eng_version;
+            desc->MainDataFilename = main_file;
+        }
+        if (elems == kSvgDesc_UserText)
+            desc->UserText = desc_text;
+        if (elems == kSvgDesc_UserImage)
+            desc->UserImage.reset(image.release());
+    }
+    return kSvgErr_NoError;
+}
+
+SavegameError OpenSavegame(const String &filename, SavegameSource &src, SavegameDescription &desc, SavegameDescElem elems)
+{
+    return OpenSavegameBase(filename, &src, &desc, elems);
+}
+
+SavegameError OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems)
+{
+    return OpenSavegameBase(filename, NULL, &desc, elems);
+}
+
+SavegameError RestoreGameState(Stream *in, SavegameVersion svg_version)
+{
+    return restore_game_data(in, svg_version);
+}
+
+void WriteSaveImage(Stream *out, const Bitmap *screenshot)
+{
+    // store the screenshot at the start to make it easily accesible
+    out->WriteInt32((screenshot == NULL) ? 0 : 1);
+
+    if (screenshot)
+        serialize_bitmap(screenshot, out);
+}
+
+Stream *StartSavegame(const String &filename, const String &desc, const Bitmap *image)
+{
+    Stream *out = Common::File::CreateFile(filename);
+    if (!out)
+        return NULL;
+
+    // Initialize and write Vista header
+    RICH_GAME_MEDIA_HEADER vistaHeader;
+    memset(&vistaHeader, 0, sizeof(RICH_GAME_MEDIA_HEADER));
+    memcpy(&vistaHeader.dwMagicNumber, RM_MAGICNUMBER, sizeof(int));
+    vistaHeader.dwHeaderVersion = 1;
+    vistaHeader.dwHeaderSize = sizeof(RICH_GAME_MEDIA_HEADER);
+    vistaHeader.dwThumbnailOffsetHigherDword = 0;
+    vistaHeader.dwThumbnailOffsetLowerDword = 0;
+    vistaHeader.dwThumbnailSize = 0;
+    convert_guid_from_text_to_binary(game.guid, &vistaHeader.guidGameId[0]);
+    uconvert(game.gamename, U_ASCII, (char*)&vistaHeader.szGameName[0], U_UNICODE, RM_MAXLENGTH);
+    uconvert(desc, U_ASCII, (char*)&vistaHeader.szSaveName[0], U_UNICODE, RM_MAXLENGTH);
+    vistaHeader.szLevelName[0] = 0;
+    vistaHeader.szComments[0] = 0;
+
+    // MS Windows Vista rich media header
+    vistaHeader.WriteToFile(out);
+
+    // Savegame signature
+    out->Write(SavegameSource::Signature, SavegameSource::Signature.GetLength());
+    // Description
+    StrUtil::WriteCStr(desc, out);
+
+    platform->RunPluginHooks(AGSE_PRESAVEGAME, 0);
+    out->WriteInt32(kSvgVersion_Current);
+    WriteSaveImage(out, image);
+
+    // Write lowest forward-compatible version string, so that
+    // earlier versions could load savedgames made by current engine
+    String compat_version;
+    if (SavedgameLowestForwardCompatVersion <= Version::LastOldFormatVersion)
+        compat_version = SavedgameLowestForwardCompatVersion.BackwardCompatibleString;
+    else
+        compat_version = SavedgameLowestForwardCompatVersion.LongString;
+    StrUtil::WriteCStr(compat_version, out);
+    StrUtil::WriteCStr(usetup.main_data_filename, out);
+    return out;
+}
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -38,6 +38,7 @@
 #include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
 #include "game/savegame.h"
+#include "game/savegame_internal.h"
 #include "main/main.h"
 #include "main/version.h"
 #include "media/audio/audio.h"

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -112,6 +112,12 @@ String GetSavegameErrorText(SavegameError err)
         return "Save format version not supported";
     case kSvgErr_IncompatibleEngine:
         return "Save was written by incompatible engine, or file is corrupted";
+    case kSvgErr_InconsistentFormat:
+        return "Inconsistent format, or file is corrupted";
+    case kSvgErr_GameContentAssertion:
+        return "Saved content does not match current game";
+    case kSvgErr_InconsistentPlugin:
+        return "One of the game plugins did not restore its game data correctly.";
     case kSvgErr_DifferentColorDepth:
         return "Saved with different colour depth";
     case kSvgErr_GameObjectInitFailed:

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -263,6 +263,8 @@ void DoBeforeRestore(PreservedParams &pp, RestoredData &r_data)
         moduleInst[i] = NULL;
     }
 
+    play.FreeProperties();
+
     delete roominstFork;
     delete roominst;
     roominstFork = NULL;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -237,6 +237,7 @@ void DoBeforeRestore(PreservedParams &pp)
     is_text_overlay = 0;
 
     // cleanup dynamic sprites
+    // NOTE: sprite 0 is a special constant sprite that cannot be dynamic
     for (int i = 1; i < spriteset.elements; ++i)
     {
         if (game.spriteflags[i] & SPF_DYNAMICALLOC)
@@ -294,6 +295,7 @@ void DoBeforeRestore(PreservedParams &pp)
         unexport_gui_controls(i);
     }
 
+    // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
         stop_and_destroy_channel_ex(i, false);
@@ -431,6 +433,7 @@ SavegameError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_da
     const int cf_out_chan = play.crossfading_out_channel;
     play.crossfading_in_channel = 0;
     play.crossfading_out_channel = 0;
+    // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
         const RestoredData::ChannelInfo &chan_info = r_data.AudioChans[i];
@@ -458,6 +461,7 @@ SavegameError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_da
 
     // If there were synced audio tracks, the time taken to load in the
     // different channels will have thrown them out of sync, so re-time it
+    // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
         int pos = r_data.AudioChans[i].Pos;
@@ -467,6 +471,7 @@ SavegameError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_da
         }
     }
 
+    // TODO: investigate loop range
     for (int i = 1; i < MAX_SOUND_CHANNELS; ++i)
     {
         if (r_data.DoAmbient[i])

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -116,6 +116,9 @@ SavegameError  RestoreGameState(Stream *in, SavegameVersion svg_version);
 // Opens savegame for writing and puts in savegame description
 Stream        *StartSavegame(const String &filename, const String &desc, const Bitmap *image);
 
+// Prepares game for saving state and writes data into the save stream
+void           SaveGameState(Stream *out);
+
 } // namespace Engine
 } // namespace AGS
 

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -113,10 +113,24 @@ struct SavegameDescription
     ABitmap             UserImage;
 };
 
+// PreservedParams keeps old values of particular gameplay
+// parameters that are saved before the save restoration
+// and either applied or compared to new values after
+// loading save data
+struct PreservedParams
+{
+    // Whether speech and audio packages available
+    int SpeechVOX;
+    int MusicVOX;
+
+    PreservedParams();
+};
+
 // RestoredData keeps certain temporary data to help with
 // the restoration process
 struct RestoredData
 {
+    int                     FPS;
     // Unserialized bitmaps for dynamic surfaces
     std::vector<Bitmap*>    DynamicSurfaces;
     // Scripts global data
@@ -139,6 +153,20 @@ struct RestoredData
     // Mouse cursor parameters
     int                     CursorID;
     int                     CursorMode;
+    // General audio
+    struct ChannelInfo
+    {
+        int ClipID;
+        int Pos;
+        int Priority;
+        int Repeat;
+        int Vol;
+        int VolAsPercent;
+        int Pan;
+        int PanAsPercent;
+        int Speed;
+    };
+    ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
     // Ambient sounds
     int                     DoAmbient[MAX_SOUND_CHANNELS];
 

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -15,20 +15,6 @@
 #ifndef __AGS_EE_GAME__SAVEGAME_H
 #define __AGS_EE_GAME__SAVEGAME_H
 
-#if __cplusplus >= 201103L
-#include <memory>
-namespace stdtr1compat = std;
-#else
-#if defined (_MSC_VER)
-#include <memory>
-#elif defined (__GNUC__)
-#include <tr1/memory>
-#endif
-namespace stdtr1compat = std::tr1;
-#endif
-
-#include "ac/common_defines.h"
-#include "media/audio/audiodefines.h"
 #include "main/version.h"
 
 
@@ -114,69 +100,6 @@ struct SavegameDescription
     
     String              UserText;
     ABitmap             UserImage;
-};
-
-// PreservedParams keeps old values of particular gameplay
-// parameters that are saved before the save restoration
-// and either applied or compared to new values after
-// loading save data
-struct PreservedParams
-{
-    // Whether speech and audio packages available
-    int SpeechVOX;
-    int MusicVOX;
-    // Script global data sizes
-    int GlScDataSize;
-    std::vector<int> ScMdDataSize;
-
-    PreservedParams();
-};
-
-// RestoredData keeps certain temporary data to help with
-// the restoration process
-struct RestoredData
-{
-    int                     FPS;
-    // Unserialized bitmaps for dynamic surfaces
-    std::vector<Bitmap*>    DynamicSurfaces;
-    // Scripts global data
-    struct ScriptData
-    {
-        stdtr1compat::shared_ptr<char> Data;
-        size_t              Len;
-
-        ScriptData();
-    };
-    ScriptData              GlobalScript;
-    std::vector<ScriptData> ScriptModules;
-    // Room data (has to be be preserved until room is loaded)
-    Bitmap                 *RoomBkgScene[MAX_BSCENE];
-    short                   RoomLightLevels[MAX_REGIONS];
-    int                     RoomTintLevels[MAX_REGIONS];
-    short                   RoomZoomLevels1[MAX_WALK_AREAS + 1];
-    short                   RoomZoomLevels2[MAX_WALK_AREAS + 1];
-    int                     RoomVolume;
-    // Mouse cursor parameters
-    int                     CursorID;
-    int                     CursorMode;
-    // General audio
-    struct ChannelInfo
-    {
-        int ClipID;
-        int Pos;
-        int Priority;
-        int Repeat;
-        int Vol;
-        int VolAsPercent;
-        int Pan;
-        int PanAsPercent;
-        int Speed;
-    };
-    ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
-    // Ambient sounds
-    int                     DoAmbient[MAX_SOUND_CHANNELS];
-
-    RestoredData();
 };
 
 

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -66,6 +66,9 @@ enum SavegameError
     kSvgErr_SignatureFailed,
     kSvgErr_FormatVersionNotSupported,
     kSvgErr_IncompatibleEngine,
+    kSvgErr_InconsistentFormat,
+    kSvgErr_GameContentAssertion,
+    kSvgErr_InconsistentPlugin,
     kSvgErr_DifferentColorDepth,
     kSvgErr_GameObjectInitFailed,
     kNumSavegameError

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -125,6 +125,9 @@ struct PreservedParams
     // Whether speech and audio packages available
     int SpeechVOX;
     int MusicVOX;
+    // Script global data sizes
+    int GlScDataSize;
+    std::vector<int> ScMdDataSize;
 
     PreservedParams();
 };

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -1,0 +1,118 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#ifndef __AGS_EE_GAME__SAVEGAME_H
+#define __AGS_EE_GAME__SAVEGAME_H
+
+#include "main/version.h"
+
+
+namespace AGS
+{
+
+namespace Common { class Bitmap; class Stream; }
+
+namespace Engine
+{
+
+using Common::Bitmap;
+using Common::Stream;
+using Common::String;
+
+//-----------------------------------------------------------------------------
+// Savegame version history
+//
+// 8      last old style saved game format (of AGS 3.2.1)
+//-----------------------------------------------------------------------------
+enum SavegameVersion
+{
+    kSvgVersion_Undefined = 0,
+    kSvgVersion_321       = 8,
+    kSvgVersion_Current   = kSvgVersion_321,
+    kSvgVersion_LowestSupported = kSvgVersion_321
+};
+
+// Error codes for save restoration routine
+enum SavegameError
+{
+    kSvgErr_NoError,
+    kSvgErr_FileNotFound,
+    kSvgErr_NoStream,
+    kSvgErr_SignatureFailed,
+    kSvgErr_FormatVersionNotSupported,
+    kSvgErr_IncompatibleEngine,
+    kSvgErr_DifferentColorDepth,
+    kNumSavegameError
+};
+
+typedef std::auto_ptr<Stream> AStream;
+typedef std::auto_ptr<Bitmap> ABitmap;
+
+// SavegameSource defines a successfully opened savegame stream
+struct SavegameSource
+{
+    // Signature of the current savegame format
+    static const String Signature;
+
+    // Name of the savefile
+    String              Filename;
+    // Savegame format version
+    SavegameVersion     Version;
+    // A ponter to the opened stream
+    AStream             InputStream;
+};
+
+// Supported elements of savegame description;
+// these may be used as flags to define valid fields
+enum SavegameDescElem
+{
+    kSvgDesc_None       = 0,
+    kSvgDesc_EnvInfo    = 0x0001,
+    kSvgDesc_UserText   = 0x0002,
+    kSvgDesc_UserImage  = 0x0004,
+    kSvgDesc_All        = kSvgDesc_EnvInfo | kSvgDesc_UserText | kSvgDesc_UserImage
+};
+
+// SavegameDescription describes savegame with information about the enviroment
+// it was created in, and custom data provided by user
+struct SavegameDescription
+{
+    // Version of the engine that saved the game
+    Version             EngineVersion;
+    // Name of the main data file used; this is needed to properly
+    // load saves made by "minigames"
+    String              MainDataFilename;
+    
+    String              UserText;
+    ABitmap             UserImage;
+};
+
+
+String         GetSavegameErrorText(SavegameError err);
+// Opens savegame for reading; optionally reads description, if any is provided
+SavegameError  OpenSavegame(const String &filename, SavegameSource &src,
+                            SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
+// Opens savegame and reads the savegame description
+SavegameError  OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
+
+// Reads the game data from the save stream and reinitializes game state
+SavegameError  RestoreGameState(Stream *in, SavegameVersion svg_version);
+
+// Opens savegame for writing and puts in savegame description
+Stream        *StartSavegame(const String &filename, const String &desc, const Bitmap *image);
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_GAME__SAVEGAME_H

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -15,6 +15,20 @@
 #ifndef __AGS_EE_GAME__SAVEGAME_H
 #define __AGS_EE_GAME__SAVEGAME_H
 
+#if __cplusplus >= 201103L
+#include <memory>
+namespace stdtr1compat = std;
+#else
+#if defined (_MSC_VER)
+#include <memory>
+#elif defined (__GNUC__)
+#include <tr1/memory>
+#endif
+namespace stdtr1compat = std::tr1;
+#endif
+
+#include "ac/common_defines.h"
+#include "media/audio/audiodefines.h"
 #include "main/version.h"
 
 
@@ -53,6 +67,7 @@ enum SavegameError
     kSvgErr_FormatVersionNotSupported,
     kSvgErr_IncompatibleEngine,
     kSvgErr_DifferentColorDepth,
+    kSvgErr_GameObjectInitFailed,
     kNumSavegameError
 };
 
@@ -96,6 +111,38 @@ struct SavegameDescription
     
     String              UserText;
     ABitmap             UserImage;
+};
+
+// RestoredData keeps certain temporary data to help with
+// the restoration process
+struct RestoredData
+{
+    // Unserialized bitmaps for dynamic surfaces
+    std::vector<Bitmap*>    DynamicSurfaces;
+    // Scripts global data
+    struct ScriptData
+    {
+        stdtr1compat::shared_ptr<char> Data;
+        size_t              Len;
+
+        ScriptData();
+    };
+    ScriptData              GlobalScript;
+    std::vector<ScriptData> ScriptModules;
+    // Room data (has to be be preserved until room is loaded)
+    Bitmap                 *RoomBkgScene[MAX_BSCENE];
+    short                   RoomLightLevels[MAX_REGIONS];
+    int                     RoomTintLevels[MAX_REGIONS];
+    short                   RoomZoomLevels1[MAX_WALK_AREAS + 1];
+    short                   RoomZoomLevels2[MAX_WALK_AREAS + 1];
+    int                     RoomVolume;
+    // Mouse cursor parameters
+    int                     CursorID;
+    int                     CursorMode;
+    // Ambient sounds
+    int                     DoAmbient[MAX_SOUND_CHANNELS];
+
+    RestoredData();
 };
 
 

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -75,6 +75,8 @@ struct SavegameSource
     SavegameVersion     Version;
     // A ponter to the opened stream
     AStream             InputStream;
+
+    SavegameSource();
 };
 
 // Supported elements of savegame description;
@@ -97,9 +99,14 @@ struct SavegameDescription
     // Name of the main data file used; this is needed to properly
     // load saves made by "minigames"
     String              MainDataFilename;
+    // Color depth the engine was running in; this is required to
+    // properly restore dynamic graphics from the save
+    int                 ColorDepth;
     
     String              UserText;
     ABitmap             UserImage;
+
+    SavegameDescription();
 };
 
 

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -1,0 +1,104 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#ifndef __AGS_EE_GAME__SAVEGAMEINTERNAL_H
+#define __AGS_EE_GAME__SAVEGAMEINTERNAL_H
+
+#if __cplusplus >= 201103L
+#include <memory>
+namespace stdtr1compat = std;
+#else
+#if defined (_MSC_VER)
+#include <memory>
+#elif defined (__GNUC__)
+#include <tr1/memory>
+#endif
+namespace stdtr1compat = std::tr1;
+#endif
+
+#include "media/audio/audiodefines.h"
+
+
+namespace AGS
+{
+namespace Engine
+{
+
+// PreservedParams keeps old values of particular gameplay
+// parameters that are saved before the save restoration
+// and either applied or compared to new values after
+// loading save data
+struct PreservedParams
+{
+    // Whether speech and audio packages available
+    int SpeechVOX;
+    int MusicVOX;
+    // Script global data sizes
+    int GlScDataSize;
+    std::vector<int> ScMdDataSize;
+
+    PreservedParams();
+};
+
+// RestoredData keeps certain temporary data to help with
+// the restoration process
+struct RestoredData
+{
+    int                     FPS;
+    // Unserialized bitmaps for dynamic surfaces
+    std::vector<Bitmap*>    DynamicSurfaces;
+    // Scripts global data
+    struct ScriptData
+    {
+        stdtr1compat::shared_ptr<char> Data;
+        size_t              Len;
+
+        ScriptData();
+    };
+    ScriptData              GlobalScript;
+    std::vector<ScriptData> ScriptModules;
+    // Room data (has to be be preserved until room is loaded)
+    Bitmap                 *RoomBkgScene[MAX_BSCENE];
+    short                   RoomLightLevels[MAX_REGIONS];
+    int                     RoomTintLevels[MAX_REGIONS];
+    short                   RoomZoomLevels1[MAX_WALK_AREAS + 1];
+    short                   RoomZoomLevels2[MAX_WALK_AREAS + 1];
+    int                     RoomVolume;
+    // Mouse cursor parameters
+    int                     CursorID;
+    int                     CursorMode;
+    // General audio
+    struct ChannelInfo
+    {
+        int ClipID;
+        int Pos;
+        int Priority;
+        int Repeat;
+        int Vol;
+        int VolAsPercent;
+        int Pan;
+        int PanAsPercent;
+        int Speed;
+    };
+    ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
+    // Ambient sounds
+    int                     DoAmbient[MAX_SOUND_CHANNELS];
+
+    RestoredData();
+};
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_GAME__SAVEGAMEINTERNAL_H

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1228,7 +1228,6 @@ Bitmap *OGLGraphicsDriver::ConvertBitmapToSupportedColourDepth(Bitmap *bitmap)
    {
      // we need 32-bit colour
      Bitmap *tempBmp = BitmapHelper::CreateBitmapCopy(bitmap, 32);
-     delete bitmap;
      set_color_conversion(colorConv);
      return tempBmp;
    }

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -15,6 +15,7 @@
 #include <cctype>
 #include "util/wgt2allg.h"
 #include "ac/common.h"
+#include "ac/draw.h"
 #include "ac/gamesetup.h"
 #include "ac/gamestate.h"
 #include "ac/gui.h"
@@ -145,7 +146,7 @@ int WINAPI _export CSCIWaitMessage(Bitmap *ds, CSCIMessage * cscim)
     }
 
     windowBuffer = BitmapHelper::CreateBitmap(windowPosWidth, windowPosHeight, ds->GetColorDepth());
-    windowBuffer = gfxDriver->ConvertBitmapToSupportedColourDepth(windowBuffer);
+    windowBuffer = ReplaceBitmapWithSupportedFormat(windowBuffer);
     dialogBmp = gfxDriver->CreateDDBFromBitmap(windowBuffer, false, true);
 
     while (1) {

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -195,7 +195,7 @@ void CreateBlankImage()
     try
     {
         Bitmap *blank = BitmapHelper::CreateBitmap(16, 16, ScreenResolution.ColorDepth);
-        blank = gfxDriver->ConvertBitmapToSupportedColourDepth(blank);
+        blank = ReplaceBitmapWithSupportedFormat(blank);
         blank->Clear();
         blankImage = gfxDriver->CreateDDBFromBitmap(blank, false, true);
         blankSidebarImage = gfxDriver->CreateDDBFromBitmap(blank, false, true);

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -93,11 +93,7 @@ void start_game_load_savegame_on_startup()
             sscanf(sgName, "agssave.%03d", &saveGameNumber);
         }
         current_fade_out_effect();
-        int loadGameErrorCode = load_game(loadSaveGameOnStartup, saveGameNumber);
-        if (loadGameErrorCode)
-        {
-            quitprintf("Unable to resume the save game. Try starting the game over. (Error: %s)", load_game_errors[-loadGameErrorCode]);
-        }
+        load_game_or_quit(loadSaveGameOnStartup, saveGameNumber);
     }
 }
 

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -93,7 +93,7 @@ void start_game_load_savegame_on_startup()
             sscanf(sgName, "agssave.%03d", &saveGameNumber);
         }
         current_fade_out_effect();
-        load_game_or_quit(loadSaveGameOnStartup, saveGameNumber);
+        try_restore_save(loadSaveGameOnStartup, saveGameNumber);
     }
 }
 

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -34,6 +34,9 @@ extern AGS::Engine::Version SavedgameLowestForwardCompatVersion;
 //=============================================================================
 
 #ifdef WINDOWS_VERSION
+#ifndef _WINNT_
+typedef void *LPWSTR;
+#endif
 extern int wArgc;
 extern LPWSTR *wArgv;
 #endif

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -253,14 +253,6 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
     return soundClip;
 }
 
-void recache_queued_clips_after_loading_save_game()
-{
-    for (int i = 0; i < play.new_music_queue_size; i++)
-    {
-        play.new_music_queue[i].cachedClip = NULL;
-    }
-}
-
 void audio_update_polled_stuff()
 {
     play.crossfade_step++;

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1386,7 +1386,6 @@ Bitmap *D3DGraphicsDriver::ConvertBitmapToSupportedColourDepth(Bitmap *bitmap)
      // Most 3D cards don't support 8-bit; and we need 15-bit colour
      Bitmap *tempBmp = BitmapHelper::CreateBitmap(bitmap->GetWidth(), bitmap->GetHeight(), 15);
      tempBmp->Blit(bitmap, 0, 0, 0, 0, tempBmp->GetWidth(), tempBmp->GetHeight());
-     delete bitmap;
      set_color_conversion(colorConv);
      return tempBmp;
    }
@@ -1395,7 +1394,6 @@ Bitmap *D3DGraphicsDriver::ConvertBitmapToSupportedColourDepth(Bitmap *bitmap)
      // we need 32-bit colour
      Bitmap* tempBmp = BitmapHelper::CreateBitmap(bitmap->GetWidth(), bitmap->GetHeight(), 32);
      tempBmp->Blit(bitmap, 0, 0, 0, 0, tempBmp->GetWidth(), tempBmp->GetHeight());
-     delete bitmap;
      set_color_conversion(colorConv);
      return tempBmp;
    }

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -362,7 +362,7 @@ void post_script_cleanup() {
         break;
     case ePSARestoreGame:
         cancel_all_scripts();
-        load_game_and_print_error(thisData);
+        try_restore_save(thisData);
         return;
     case ePSARestoreGameDialog:
         restore_game_dialog();

--- a/Solutions/Engine.App/Engine.App.vcproj
+++ b/Solutions/Engine.App/Engine.App.vcproj
@@ -1176,6 +1176,14 @@
 					>
 				</File>
 			</Filter>
+			<Filter
+				Name="game"
+				>
+				<File
+					RelativePath="..\..\Engine\game\savegame.cpp"
+					>
+				</File>
+			</Filter>
 		</Filter>
 		<Filter
 			Name="Header Files"
@@ -2211,6 +2219,14 @@
 				>
 				<File
 					RelativePath="..\..\Engine\platform\windows\setup\winsetup.h"
+					>
+				</File>
+			</Filter>
+			<Filter
+				Name="game"
+				>
+				<File
+					RelativePath="..\..\Engine\game\savegame.h"
 					>
 				</File>
 			</Filter>

--- a/Solutions/Engine.App/Engine.App.vcproj
+++ b/Solutions/Engine.App/Engine.App.vcproj
@@ -2229,6 +2229,10 @@
 					RelativePath="..\..\Engine\game\savegame.h"
 					>
 				</File>
+				<File
+					RelativePath="..\..\Engine\game\savegame_internal.h"
+					>
+				</File>
 			</Filter>
 		</Filter>
 		<Filter


### PR DESCRIPTION
This picks out data processing that precedes and follows writing and restoring game data of the game's save. General purpose is to separate complemetary tasks from reading and writing actual data. Currently they are spread all around reading/writing code.
These tasks include:
* Preparing game for writing;
* Opening savegame file and checking its header information (format, description);
* Preparing game for reading (releasing particular runtime objects mostly);
* Preparing game for running again after reading save (recreating runtime objects with new data, loading new room, and so on).

Additionally introduced savegame error enumeration and made reading function return those error codes instead of quitting the game.
Merged several different pieces of code into common function that deduces what to do if restoration failed, depending on how far engine went (display on-screen message or quit).