### PR TITLE
Changed String class to use size_t for lengths and indexes instead of int

### DIFF
--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -46,8 +46,8 @@ namespace Common
 
 /* static */ String GUIMain::FixupGUIName(const String &name)
 {
-    if (name.GetLength() > 0 && name[0] != 'g')
-        return String::FromFormat("g%c%s", name[0], name.Mid(1).Lower().GetCStr());
+    if (name.GetLength() > 0 && name[0u] != 'g')
+        return String::FromFormat("g%c%s", name[0u], name.Mid(1).Lower().GetCStr());
     return name;
 }
 

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -88,7 +88,7 @@ bool File::GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, F
     // Default mode is open/read for safety reasons
     open_mode = kFile_Open;
     work_mode = kFile_Read;
-    for (int c = 0; c < cmode.GetLength(); ++c)
+    for (size_t c = 0; c < cmode.GetLength(); ++c)
     {
         if (read_base_mode)
         {

--- a/Common/util/math.h
+++ b/Common/util/math.h
@@ -61,7 +61,13 @@ namespace Math
         length = Min<T>(length, height - from);
     }
 
-
+    // Get a measure of how value A is greater than value B;
+    // if A is smaller than or equal to B, returns 0.
+    template <class T>
+    inline T Surplus(const T &larger, const T &smaller)
+    {
+        return larger > smaller ? larger - smaller : 0;
+    }
 } // namespace Math
 
 } // namespace Common

--- a/Common/util/mutifilelib.cpp
+++ b/Common/util/mutifilelib.cpp
@@ -112,14 +112,14 @@ MFLUtil::MFLError MFLUtil::ReadSigsAndVersion(Stream *in, int *p_lib_version, lo
     if (HeadSig.Compare(sig) != 0)
     {
         // signature not found, check signature at the end of file
-        in->Seek(-TailSig.GetLength(), kSeekEnd);
+        in->Seek(-(int)TailSig.GetLength(), kSeekEnd);
         sig.ReadCount(in, TailSig.GetLength());
         // signature not found, return error code
         if (TailSig.Compare(sig) != 0)
             return kMFLErrNoLibSig;
 
         // it's an appended-to-end-of-exe thing
-        in->Seek(-TailSig.GetLength() - sizeof(int32_t), kSeekEnd);
+        in->Seek(-(int)TailSig.GetLength() - sizeof(int32_t), kSeekEnd);
         // read multifile lib offset value
         abs_offset = in->ReadInt32();
         in->Seek(abs_offset + HeadSig.GetLength(), kSeekBegin);
@@ -303,7 +303,7 @@ MFLUtil::MFLError MFLUtil::ReadV21(AssetLibInfo &lib, Stream *in)
 
 void MFLUtil::DecryptText(char *text)
 {
-    int adx = 0;
+    size_t adx = 0;
     while (true)
     {
         text[0] -= EncryptionString[adx];

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -53,13 +53,13 @@ String::String(const char *cstr)
     *this = cstr;
 }
 
-String::String(const char *cstr, int length)
+String::String(const char *cstr, size_t length)
     : _data(NULL)
 {
     SetString(cstr, length);
 }
 
-String::String(char c, int count)
+String::String(char c, size_t count)
     : _data(NULL)
 {
     FillString(c, count);
@@ -70,21 +70,20 @@ String::~String()
     Free();
 }
 
-void String::Read(Stream *in, int max_chars, bool stop_at_limit)
+void String::Read(Stream *in, size_t max_chars, bool stop_at_limit)
 {
     Empty();
     if (!in)
     {
         return;
     }
-    max_chars = max_chars >= 0 ? max_chars : 0;
-    if (!max_chars && stop_at_limit)
+    if (max_chars == 0 && stop_at_limit)
     {
         return;
     }
 
     char *read_ptr = _internalBuffer;
-    int read_size = 0;
+    size_t read_size = 0;
     int ichar;
     do
     {
@@ -109,7 +108,7 @@ void String::Read(Stream *in, int max_chars, bool stop_at_limit)
     while(ichar > 0 && !(stop_at_limit && read_size == max_chars));
 }
 
-void String::ReadCount(Stream *in, int count)
+void String::ReadCount(Stream *in, size_t count)
 {
     Empty();
     if (in && count > 0)
@@ -129,14 +128,14 @@ void String::Write(Stream *out) const
     }
 }
 
-void String::WriteCount(Stream *out, int count) const
+void String::WriteCount(Stream *out, size_t count) const
 {
     if (out)
     {
-        int str_out_len = Math::Min(count - 1, GetLength());
+        size_t str_out_len = Math::Min(count - 1, GetLength());
         if (str_out_len > 0)
             out->Write(GetCStr(), str_out_len);
-        int null_out_len = count - str_out_len;
+        size_t null_out_len = count - str_out_len;
         if (null_out_len > 0)
             out->WriteByteCount(0, null_out_len);
     }
@@ -161,67 +160,66 @@ int String::CompareNoCase(const char *cstr) const
     return stricmp(GetCStr(), cstr ? cstr : "");
 }
 
-int String::CompareLeft(const char *cstr, int count) const
+int String::CompareLeft(const char *cstr, size_t count) const
 {
     cstr = cstr ? cstr : "";
-    return strncmp(GetCStr(), cstr, count >= 0 ? count : strlen(cstr));
+    return strncmp(GetCStr(), cstr, count != -1 ? count : strlen(cstr));
 }
 
-int String::CompareLeftNoCase(const char *cstr, int count) const
+int String::CompareLeftNoCase(const char *cstr, size_t count) const
 {
     cstr = cstr ? cstr : "";
-    return strnicmp(GetCStr(), cstr, count >= 0 ? count : strlen(cstr));
+    return strnicmp(GetCStr(), cstr, count != -1 ? count : strlen(cstr));
 }
 
-int String::CompareMid(const char *cstr, int from, int count) const
-{
-    cstr = cstr ? cstr : "";
-    from = Math::Min(from, GetLength());
-    return strncmp(GetCStr() + from, cstr, count >= 0 ? count : strlen(cstr));
-}
-
-int String::CompareMidNoCase(const char *cstr, int from, int count) const
+int String::CompareMid(const char *cstr, size_t from, size_t count) const
 {
     cstr = cstr ? cstr : "";
     from = Math::Min(from, GetLength());
-    return strnicmp(GetCStr() + from, cstr, count >= 0 ? count : strlen(cstr));
+    return strncmp(GetCStr() + from, cstr, count != -1 ? count : strlen(cstr));
 }
 
-int String::CompareRight(const char *cstr, int count) const
+int String::CompareMidNoCase(const char *cstr, size_t from, size_t count) const
 {
     cstr = cstr ? cstr : "";
-    count = count >= 0 ? count : strlen(cstr);
-    int from = Math::Max(0, GetLength() - count);
-    return strncmp(GetCStr() + from, cstr, count);
+    from = Math::Min(from, GetLength());
+    return strnicmp(GetCStr() + from, cstr, count != -1 ? count : strlen(cstr));
 }
 
-int String::CompareRightNoCase(const char *cstr, int count) const
+int String::CompareRight(const char *cstr, size_t count) const
 {
     cstr = cstr ? cstr : "";
-    count = count >= 0 ? count : strlen(cstr);
-    int from = Math::Max(0, GetLength() - count);
-    return strnicmp(GetCStr() + from, cstr, count);
+    count = count != -1 ? count : strlen(cstr);
+    size_t off = Math::Min(GetLength(), count);
+    return strncmp(GetCStr() + GetLength() - off, cstr, count);
 }
 
-int String::FindChar(char c, int from) const
+int String::CompareRightNoCase(const char *cstr, size_t count) const
+{
+    cstr = cstr ? cstr : "";
+    count = count != -1 ? count : strlen(cstr);
+    size_t off = Math::Min(GetLength(), count);
+    return strnicmp(GetCStr() + GetLength() - off, cstr, count);
+}
+
+size_t String::FindChar(char c, size_t from) const
 {
     if (_meta && c && from < _meta->Length)
     {
-        from = from >= 0 ? from : 0;
         const char * found_cstr = strchr(_meta->CStr + from, c);
         return found_cstr ? found_cstr - _meta->CStr : -1;
     }
     return -1;
 }
 
-int String::FindCharReverse(char c, int from) const
+size_t String::FindCharReverse(char c, size_t from) const
 {
     if (!_meta || !c)
     {
         return -1;
     }
 
-    from = from >= 0 ? Math::Min(from, _meta->Length - 1) : _meta->Length - 1;
+    from = Math::Min(from, _meta->Length - 1);
     const char *seek_ptr = _meta->CStr + from;
     while (seek_ptr >= _meta->CStr)
     {
@@ -234,19 +232,18 @@ int String::FindCharReverse(char c, int from) const
     return -1;
 }
 
-int String::FindString(const char *cstr, int from) const
+size_t String::FindString(const char *cstr, size_t from) const
 {
     if (_meta && cstr && from < _meta->Length)
     {
-        from = from >= 0 ? from : 0;
         const char * found_cstr = strstr(_meta->CStr + from, cstr);
         return found_cstr ? found_cstr - _meta->CStr : -1;
     }
     return -1;
 }
 
-bool String::FindSection(char separator, int first, int last, bool exclude_first_sep, bool exclude_last_sep,
-                        int &from, int &to) const
+bool String::FindSection(char separator, size_t first, size_t last, bool exclude_first_sep, bool exclude_last_sep,
+                        size_t &from, size_t &to) const
 {
     if (!_meta || !separator)
     {
@@ -257,14 +254,14 @@ bool String::FindSection(char separator, int first, int last, bool exclude_first
         return false;
     }
 
-    int this_field = 0;
-    int slice_from = 0;
-    int slice_to = 0;
-    int slice_at = -1;
+    size_t this_field = 0;
+    size_t slice_from = 0;
+    size_t slice_to = 0;
+    size_t slice_at = -1;
     do
     {
         slice_at = FindChar(separator, slice_at + 1);
-        if (slice_at < 0)
+        if (slice_at == -1)
             slice_at = _meta->Length;
         // found where previous field ends
         if (this_field == last)
@@ -291,8 +288,8 @@ bool String::FindSection(char separator, int first, int last, bool exclude_first
     {
         // correct the indices to stay in the [0; length] range
         assert(slice_from <= slice_to);
-        from = Math::Clamp(0, _meta->Length, slice_from);
-        to   = Math::Clamp(0, _meta->Length, slice_to);
+        from = Math::Clamp((size_t)0, _meta->Length, slice_from);
+        to   = Math::Clamp((size_t)0, _meta->Length, slice_to);
         return true;
     }
     return false;
@@ -309,7 +306,7 @@ int String::ToInt() const
     String str;
     va_list argptr;
     va_start(argptr, fcstr);
-    int length = vsnprintf(NULL, 0, fcstr, argptr);
+    int length = vsnprintf(NULL, 0u, fcstr, argptr);
     str.ReserveAndShift(false, length);
     va_start(argptr, fcstr);
     vsprintf(str._meta->CStr, fcstr, argptr);
@@ -319,14 +316,14 @@ int String::ToInt() const
     return str;
 }
 
-/* static */ String String::FromStream(Stream *in, int max_chars, bool stop_at_limit)
+/* static */ String String::FromStream(Stream *in, size_t max_chars, bool stop_at_limit)
 {
     String str;
     str.Read(in, max_chars, stop_at_limit);
     return str;
 }
 
-/* static */ String String::FromStreamCount(Stream *in, int count)
+/* static */ String String::FromStreamCount(Stream *in, size_t count)
 {
     String str;
     str.ReadCount(in, count);
@@ -347,22 +344,21 @@ String String::Upper() const
     return str;
 }
 
-String String::Left(int count) const
+String String::Left(size_t count) const
 {
-    count = count >= 0 ? Math::Min(count, GetLength()) : GetLength();
+    count = Math::Min(count, GetLength());
     return count == GetLength() ? *this : String(GetCStr(), count);
 }
 
-String String::Mid(int from, int count) const
+String String::Mid(size_t from, size_t count) const
 {
-    count = count >= 0 ? count : GetLength();
-    Math::ClampLength(0, GetLength(), from, count);
+    Math::ClampLength((size_t)0, GetLength(), from, count);
     return count == GetLength() ? *this : String(GetCStr() + from, count);
 }
 
-String String::Right(int count) const
+String String::Right(size_t count) const
 {
-    count = count >= 0 ? Math::Min(count, GetLength()) : GetLength();
+    count = Math::Min(count, GetLength());
     return count == GetLength() ? *this : String(GetCStr() + GetLength() - count, count);
 }
 
@@ -370,8 +366,8 @@ String String::LeftSection(char separator, bool exclude_separator) const
 {
     if (_meta && separator)
     {
-        int slice_at = FindChar(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindChar(separator);
+        if (slice_at != -1)
         {
             slice_at = exclude_separator ? slice_at : slice_at + 1;
             return Left(slice_at);
@@ -384,17 +380,17 @@ String String::RightSection(char separator, bool exclude_separator) const
 {
     if (_meta && separator)
     {
-        int slice_at = FindCharReverse(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindCharReverse(separator);
+        if (slice_at != -1)
         {
-            int count = exclude_separator ? _meta->Length - slice_at - 1 : _meta->Length - slice_at;
+            size_t count = exclude_separator ? _meta->Length - slice_at - 1 : _meta->Length - slice_at;
             return Right(count);
         }
     }
     return *this;
 }
 
-String String::Section(char separator, int first, int last,
+String String::Section(char separator, size_t first, size_t last,
                           bool exclude_first_sep, bool exclude_last_sep) const
 {
     if (!_meta || !separator)
@@ -402,8 +398,8 @@ String String::Section(char separator, int first, int last,
         return String();
     }
 
-    int slice_from;
-    int slice_to;
+    size_t slice_from;
+    size_t slice_to;
     if (FindSection(separator, first, last, exclude_first_sep, exclude_last_sep,
         slice_from, slice_to))
     {
@@ -412,15 +408,14 @@ String String::Section(char separator, int first, int last,
     return String();
 }
 
-void String::Reserve(int max_length)
+void String::Reserve(size_t max_length)
 {
-    max_length = max_length >= 0 ? max_length : 0;
     if (_meta)
     {
         if (max_length > _meta->Capacity)
         {
-            // grow by 50% or at least to total_size
-            int grow_length = _meta->Capacity + (_meta->Capacity >> 1);
+            // grow by 50%
+            size_t grow_length = _meta->Capacity + (_meta->Capacity / 2);
             Copy(Math::Max(max_length, grow_length));
         }
     }
@@ -430,7 +425,7 @@ void String::Reserve(int max_length)
     }
 }
 
-void String::ReserveMore(int more_length)
+void String::ReserveMore(size_t more_length)
 {
     Reserve(GetLength() + more_length);
 }
@@ -447,7 +442,7 @@ void String::Append(const char *cstr)
 {
     if (cstr)
     {
-        int length = strlen(cstr);
+        size_t length = strlen(cstr);
         if (length > 0)
         {
             ReserveAndShift(false, length);
@@ -468,7 +463,7 @@ void String::AppendChar(char c)
     }
 }
 
-void String::ClipLeft(int count)
+void String::ClipLeft(size_t count)
 {
     if (_meta && _meta->Length > 0 && count > 0)
     {
@@ -479,12 +474,11 @@ void String::ClipLeft(int count)
     }
 }
 
-void String::ClipMid(int from, int count)
+void String::ClipMid(size_t from, size_t count)
 {
-    if (_meta && _meta->Length > 0)
+    if (_meta && from < _meta->Length)
     {
-        count = count >= 0 ? count : _meta->Length - from;
-        Math::ClampLength(0, _meta->Length, from, count);
+        count = Math::Min(count, _meta->Length - from);
         if (count > 0)
         {
             BecomeUnique();
@@ -508,7 +502,7 @@ void String::ClipMid(int from, int count)
     }
 }
 
-void String::ClipRight(int count)
+void String::ClipRight(size_t count)
 {
     if (_meta && count > 0)
     {
@@ -523,8 +517,8 @@ void String::ClipLeftSection(char separator, bool include_separator)
 {
     if (_meta && separator)
     {
-        int slice_at = FindChar(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindChar(separator);
+        if (slice_at != -1)
         {
             ClipLeft(include_separator ? slice_at + 1 : slice_at);
         }
@@ -537,8 +531,8 @@ void String::ClipRightSection(char separator, bool include_separator)
 {
     if (_meta && separator)
     {
-        int slice_at = FindCharReverse(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindCharReverse(separator);
+        if (slice_at != -1)
         {
             ClipRight(include_separator ? _meta->Length - slice_at : _meta->Length - slice_at - 1);
         }
@@ -547,7 +541,7 @@ void String::ClipRightSection(char separator, bool include_separator)
     }
 }
 
-void String::ClipSection(char separator, int first, int last,
+void String::ClipSection(char separator, size_t first, size_t last,
                               bool include_first_sep, bool include_last_sep)
 {
     if (!_meta || !separator)
@@ -555,8 +549,8 @@ void String::ClipSection(char separator, int first, int last,
         return;
     }
 
-    int slice_from;
-    int slice_to;
+    size_t slice_from;
+    size_t slice_to;
     if (FindSection(separator, first, last, !include_first_sep, !include_last_sep,
         slice_from, slice_to))
     {
@@ -574,7 +568,7 @@ void String::Empty()
     }
 }
 
-void String::FillString(char c, int count)
+void String::FillString(char c, size_t count)
 {
     Empty();
     if (count > 0)
@@ -591,8 +585,8 @@ void String::Format(const char *fcstr, ...)
     fcstr = fcstr ? fcstr : "";
     va_list argptr;
     va_start(argptr, fcstr);
-    int length = vsnprintf(NULL, 0, fcstr, argptr);
-    ReserveAndShift(false, Math::Max(0, length - GetLength()));
+    size_t length = vsnprintf(NULL, 0u, fcstr, argptr);
+    ReserveAndShift(false, Math::Surplus(length, GetLength()));
     va_start(argptr, fcstr);
     vsprintf(_meta->CStr, fcstr, argptr);
     _meta->Length = length;
@@ -636,7 +630,7 @@ void String::Prepend(const char *cstr)
 {
     if (cstr)
     {
-        int length = strlen(cstr);
+        size_t length = strlen(cstr);
         if (length > 0)
         {
             ReserveAndShift(true, length);
@@ -675,38 +669,35 @@ void String::Replace(char what, char with)
     }
 }
 
-void String::ReplaceMid(int from, int count, const char *cstr)
+void String::ReplaceMid(size_t from, size_t count, const char *cstr)
 {
     if (!cstr)
         cstr = "";
-    int length = strlen(cstr);
-    Math::ClampLength(0, GetLength(), from, count);
-    if (count >= 0)
-    {
-        ReserveAndShift(false, Math::Max(0, length - count));
-        memmove(_meta->CStr + from + length, _meta->CStr + from + count, GetLength() - (from + count) + 1);
-        memcpy(_meta->CStr + from, cstr, length);
-        _meta->Length += length - count;
-    }
+    size_t length = strlen(cstr);
+    Math::ClampLength((size_t)0, GetLength(), from, count);
+    ReserveAndShift(false, Math::Surplus(length, count));
+    memmove(_meta->CStr + from + length, _meta->CStr + from + count, GetLength() - (from + count) + 1);
+    memcpy(_meta->CStr + from, cstr, length);
+    _meta->Length += length - count;
 }
 
-void String::SetAt(int index, char c)
+void String::SetAt(size_t index, char c)
 {
-    if (_meta && index >= 0 && index < GetLength() && c)
+    if (_meta && index < GetLength() && c)
     {
         BecomeUnique();
         _meta->CStr[index] = c;
     }
 }
 
-void String::SetString(const char *cstr, int length)
+void String::SetString(const char *cstr, size_t length)
 {
     if (cstr)
     {
-        length = length >= 0 ? Math::Min((size_t)length, strlen(cstr)) : strlen(cstr);
+        length = Math::Min(length, strlen(cstr));
         if (length > 0)
         {
-            ReserveAndShift(false, Math::Max(0, length - GetLength()));
+            ReserveAndShift(false, Math::Surplus(length, GetLength()));
             memcpy(_meta->CStr, cstr, length);
             _meta->Length = length;
             _meta->CStr[length] = 0;
@@ -742,7 +733,7 @@ void String::TrimLeft(char c)
     {
         trim_ptr++;
     }
-    int trimmed = trim_ptr - _meta->CStr;
+    size_t trimmed = trim_ptr - _meta->CStr;
     if (trimmed > 0)
     {
         BecomeUnique();
@@ -765,7 +756,7 @@ void String::TrimRight(char c)
     {
         trim_ptr--;
     }
-    int trimmed = (_meta->CStr + _meta->Length - 1) - trim_ptr;
+    size_t trimmed = (_meta->CStr + _meta->Length - 1) - trim_ptr;
     if (trimmed > 0)
     {
         BecomeUnique();
@@ -774,9 +765,9 @@ void String::TrimRight(char c)
     }
 }
 
-void String::TruncateToLeft(int count)
+void String::TruncateToLeft(size_t count)
 {
-    if (_meta && count >= 0)
+    if (_meta)
     {
         count = Math::Min(count, _meta->Length);
         if (count < _meta->Length)
@@ -788,12 +779,11 @@ void String::TruncateToLeft(int count)
     }
 }
 
-void String::TruncateToMid(int from, int count)
+void String::TruncateToMid(size_t from, size_t count)
 {
     if (_meta)
     {
-        count = count >= 0 ? count : _meta->Length - from;
-        Math::ClampLength(0, _meta->Length, from, count);
+        Math::ClampLength((size_t)0, _meta->Length, from, count);
         if (from > 0 || count < _meta->Length)
         {
             BecomeUnique();
@@ -804,9 +794,9 @@ void String::TruncateToMid(int from, int count)
     }
 }
 
-void String::TruncateToRight(int count)
+void String::TruncateToRight(size_t count)
 {
-    if (_meta && count >= 0)
+    if (_meta)
     {
         count = Math::Min(count, GetLength());
         if (count < _meta->Length)
@@ -822,8 +812,8 @@ void String::TruncateToLeftSection(char separator, bool exclude_separator)
 {
     if (_meta && separator)
     {
-        int slice_at = FindChar(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindChar(separator);
+        if (slice_at != -1)
         {
             TruncateToLeft(exclude_separator ? slice_at : slice_at + 1);
         }
@@ -834,15 +824,15 @@ void String::TruncateToRightSection(char separator, bool exclude_separator)
 {
     if (_meta && separator)
     {
-        int slice_at = FindCharReverse(separator);
-        if (slice_at >= 0)
+        size_t slice_at = FindCharReverse(separator);
+        if (slice_at != -1)
         {
             TruncateToRight(exclude_separator ? _meta->Length - slice_at - 1 : _meta->Length - slice_at);
         }
     }
 }
 
-void String::TruncateToSection(char separator, int first, int last,
+void String::TruncateToSection(char separator, size_t first, size_t last,
                           bool exclude_first_sep, bool exclude_last_sep)
 {
     if (!_meta || !separator)
@@ -850,8 +840,8 @@ void String::TruncateToSection(char separator, int first, int last,
         return;
     }
 
-    int slice_from;
-    int slice_to;
+    size_t slice_from;
+    size_t slice_to;
     if (FindSection(separator, first, last, exclude_first_sep, exclude_last_sep,
         slice_from, slice_to))
     {
@@ -886,7 +876,7 @@ String &String::operator=(const char *cstr)
     return *this;
 }
 
-void String::Create(int max_length)
+void String::Create(size_t max_length)
 {
     _data = new char[sizeof(String::Header) + max_length + 1];
     _meta->RefCount = 1;
@@ -896,7 +886,7 @@ void String::Create(int max_length)
     _meta->CStr[_meta->Length] = 0;
 }
 
-void String::Copy(int max_length, int offset)
+void String::Copy(size_t max_length, size_t offset)
 {
     if (!_meta)
     {
@@ -907,7 +897,7 @@ void String::Copy(int max_length, int offset)
     // remember, that _meta->CStr may point to any address in buffer
     char *cstr_head = new_data + sizeof(String::Header) + offset;
     memcpy(new_data, _data, sizeof(String::Header));
-    int copy_length = Math::Min(_meta->Length, max_length);
+    size_t copy_length = Math::Min(_meta->Length, max_length);
     memcpy(cstr_head, _meta->CStr, copy_length);
     Free();
     _data = new_data;
@@ -918,7 +908,7 @@ void String::Copy(int max_length, int offset)
     _meta->CStr[_meta->Length] = 0;
 }
 
-void String::Align(int offset)
+void String::Align(size_t offset)
 {
     char *cstr_head = _data + sizeof(String::Header) + offset;
     memmove(cstr_head, _meta->CStr, _meta->Length + 1);
@@ -933,26 +923,26 @@ void String::BecomeUnique()
     }
 }
 
-void String::ReserveAndShift(bool left, int more_length)
+void String::ReserveAndShift(bool left, size_t more_length)
 {
     if (_meta)
     {
-        int total_length = _meta->Length + more_length;
+        size_t total_length = _meta->Length + more_length;
         if (_meta->Capacity < total_length)
         {
             // grow by 50% or at least to total_size
-            int grow_length = _meta->Capacity + (_meta->Capacity >> 1);
-            Copy(Math::Max(total_length, grow_length), left ? more_length : 0);
+            size_t grow_length = _meta->Capacity + (_meta->Capacity >> 1);
+            Copy(Math::Max(total_length, grow_length), left ? more_length : 0u);
         }
         else if (_meta->RefCount > 1)
         {
-            Copy(total_length, left ? more_length : 0);
+            Copy(total_length, left ? more_length : 0u);
         }
         else
         {
             // make sure we make use of all of our space
             const char *cstr_head = _data + sizeof(String::Header);
-            int free_space = left ?
+            size_t free_space = left ?
                 _meta->CStr - cstr_head :
                 (cstr_head + _meta->Capacity) - (_meta->CStr + _meta->Length);
             if (free_space < more_length)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -155,7 +155,7 @@ public:
     // Get Nth character with bounds check (as opposed to subscript operator)
     inline char GetAt(int index) const
     {
-        return (_meta && index >= 0 && index <= _meta->Length) ? _meta->CStr[index] : 0;
+        return (_meta && index >= 0 && index < _meta->Length) ? _meta->CStr[index] : 0;
     }
     inline char GetLast() const
     {
@@ -302,7 +302,7 @@ public:
     String &operator=(const char *cstr);
     inline char operator[](int index) const
     {
-        assert(_meta && index >= 0 && index <= _meta->Length);
+        assert(_meta && index >= 0 && index < _meta->Length);
         return _meta->CStr[index];
     }
     inline bool operator==(const char *cstr) const

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -58,9 +58,9 @@ public:
     // Initialize with C-string
     String(const char *cstr);
     // Initialize by copying up to N chars from C-string
-    String(const char *cstr, int length);
+    String(const char *cstr, size_t length);
     // Initialize by filling N chars with certain value
-    String(char c, int count);
+    String(char c, size_t count);
     ~String();
 
     // Get underlying C-string for reading
@@ -69,7 +69,7 @@ public:
         return _meta ? _meta->CStr : "";
     }
     // Get character count
-    inline int  GetLength() const
+    inline size_t GetLength() const
     {
         return _meta ? _meta->Length : 0;
     }
@@ -86,12 +86,12 @@ public:
         return _data;
     }
 
-    inline int GetCapacity() const
+    inline size_t GetCapacity() const
     {
         return _meta ? _meta->Capacity : 0;
     }
 
-    inline int GetRefCount() const
+    inline size_t GetRefCount() const
     {
         return _meta ? _meta->RefCount : 0;
     }
@@ -104,16 +104,16 @@ public:
     // the data will be read until null-terminator or EOS is met, and buffer
     // will contain only leftmost part of the longer string that fits in.
     // This method is better fit for reading from binary streams.
-    void    Read(Stream *in, int max_chars = 5000000, bool stop_at_limit = false);
+    void    Read(Stream *in, size_t max_chars = 5000000, bool stop_at_limit = false);
     // ReadCount() reads up to N characters from stream, ignoring null-
     // terminator. This method is better fit for reading from text
     // streams, or when the length of string is known beforehand.
-    void    ReadCount(Stream *in, int count);
+    void    ReadCount(Stream *in, size_t count);
     // Write() puts the null-terminated string into the stream.
     void    Write(Stream *out) const;
     // WriteCount() writes N characters to stream, filling the remaining
     // space with null-terminators when needed.
-    void    WriteCount(Stream *out, int count) const;
+    void    WriteCount(Stream *out, size_t count) const;
 
     static void WriteString(const char *cstr, Stream *out);
 
@@ -125,18 +125,18 @@ public:
     int     Compare(const char *cstr) const;
     int     CompareNoCase(const char *cstr) const;
     // Compares the leftmost part of this string with given C-string
-    int     CompareLeft(const char *cstr, int count = -1) const;
-    int     CompareLeftNoCase(const char *cstr, int count = -1) const;
+    int     CompareLeft(const char *cstr, size_t count = -1) const;
+    int     CompareLeftNoCase(const char *cstr, size_t count = -1) const;
     // Compares any part of this string with given C-string
-    int     CompareMid(const char *cstr, int from, int count = -1) const;
-    int     CompareMidNoCase(const char *cstr, int from, int count = -1) const;
+    int     CompareMid(const char *cstr, size_t from, size_t count = -1) const;
+    int     CompareMidNoCase(const char *cstr, size_t from, size_t count = -1) const;
     // Compares the rightmost part of this string with given C-string
-    int     CompareRight(const char *cstr, int count = -1) const;
-    int     CompareRightNoCase(const char *cstr, int count = -1) const;
+    int     CompareRight(const char *cstr, size_t count = -1) const;
+    int     CompareRightNoCase(const char *cstr, size_t count = -1) const;
 
-    int     FindChar(char c, int from = 0) const;
-    int     FindCharReverse(char c, int from = -1) const;
-    int     FindString(const char *cstr, int from = 0) const;
+    size_t  FindChar(char c, size_t from = 0) const;
+    size_t  FindCharReverse(char c, size_t from = -1) const;
+    size_t  FindString(const char *cstr, size_t from = 0) const;
 
     // Section methods treat string as a sequence of 'fields', separated by
     // special character. They search for a substring consisting of all such
@@ -149,13 +149,13 @@ public:
     // field beyond that.
     // This also means that there's always at least one section in any string,
     // even if there are no separating chars.
-    bool    FindSection(char separator, int first, int last, bool exclude_first_sep, bool exclude_last_sep,
-                        int &from, int &to) const;
+    bool    FindSection(char separator, size_t first, size_t last, bool exclude_first_sep, bool exclude_last_sep,
+                        size_t &from, size_t &to) const;
 
     // Get Nth character with bounds check (as opposed to subscript operator)
-    inline char GetAt(int index) const
+    inline char GetAt(size_t index) const
     {
-        return (_meta && index >= 0 && index < _meta->Length) ? _meta->CStr[index] : 0;
+        return (_meta && index < _meta->Length) ? _meta->CStr[index] : 0;
     }
     inline char GetLast() const
     {
@@ -174,9 +174,9 @@ public:
 
     static String FromFormat(const char *fcstr, ...);
     // Reads stream until null-terminator or EOS
-    static String FromStream(Stream *in, int max_chars = 5000000, bool stop_at_limit = false);
+    static String FromStream(Stream *in, size_t max_chars = 5000000, bool stop_at_limit = false);
     // Reads up to N chars from stream
-    static String FromStreamCount(Stream *in, int count);
+    static String FromStreamCount(Stream *in, size_t count);
 
     // Creates a lowercased copy of the string
     String  Lower() const;
@@ -184,11 +184,11 @@ public:
     String  Upper() const;
 
     // Extract N leftmost characters as a new string
-    String  Left(int count) const;
+    String  Left(size_t count) const;
     // Extract up to N characters starting from given index
-    String  Mid(int from, int count = -1) const;
+    String  Mid(size_t from, size_t count = -1) const;
     // Extract N rightmost characters
-    String  Right(int count) const;
+    String  Right(size_t count) const;
 
     // Extract leftmost part, separated by the given char; if no separator was
     // found returns the whole string
@@ -197,7 +197,7 @@ public:
     // found returns the whole string
     String  RightSection(char separator, bool exclude_separator = true) const;
     // Extract the range of Xth to Yth fields, separated by the given character
-    String  Section(char separator, int first, int last,
+    String  Section(char separator, size_t first, size_t last,
                               bool exclude_first_sep = true, bool exclude_last_sep = true) const;
 
     //-------------------------------------------------------------------------
@@ -206,9 +206,9 @@ public:
 
     // Ensure string has at least space to store N chars;
     // this does not change string contents, nor length
-    void    Reserve(int max_length);
+    void    Reserve(size_t max_length);
     // Ensure string has at least space to store N additional chars
-    void    ReserveMore(int more_length);
+    void    ReserveMore(size_t more_length);
     // Make string's buffer as small as possible to hold current data
     void    Compact();
 
@@ -219,11 +219,11 @@ public:
     void    AppendChar(char c);
     // Clip* methods decrease the string, removing defined part
     // Cuts off leftmost N characters
-    void    ClipLeft(int count);
+    void    ClipLeft(size_t count);
     // Cuts out N characters starting from given index
-    void    ClipMid(int from, int count = -1);
+    void    ClipMid(size_t from, size_t count = -1);
     // Cuts off rightmost N characters
-    void    ClipRight(int count);
+    void    ClipRight(size_t count);
     // Cuts off leftmost part, separated by the given char; if no separator was
     // found cuts whole string, leaving empty string
     void    ClipLeftSection(char separator, bool include_separator = true);
@@ -231,12 +231,12 @@ public:
     // was found cuts whole string, leaving empty string
     void    ClipRightSection(char separator, bool include_separator = true);
     // Cuts out the range of Xth to Yth fields separated by the given character
-    void    ClipSection(char separator, int first, int last,
+    void    ClipSection(char separator, size_t first, size_t last,
                               bool include_first_sep = true, bool include_last_sep = true);
     // Sets string length to zero
     void    Empty();
     // Makes a new string by filling N chars with certain value
-    void    FillString(char c, int count);
+    void    FillString(char c, size_t count);
     // Makes a new string by putting in parameters according to format string
     void    Format(const char *fcstr, ...);
     // Decrement ref counter and deallocate data if must.
@@ -257,11 +257,11 @@ public:
     void    Replace(char what, char with);
     // Replaces particular substring with another substring; new substring
     // may have different length
-    void    ReplaceMid(int from, int count, const char *cstr);
+    void    ReplaceMid(size_t from, size_t count, const char *cstr);
     // Overwrite the Nth character of the string; does not change string's length
-    void    SetAt(int index, char c);
+    void    SetAt(size_t index, char c);
     // Makes a new string by copying up to N chars from C-string
-    void    SetString(const char *cstr, int length = -1);
+    void    SetString(const char *cstr, size_t length = -1);
     // For all Trim functions, if given character value is 0, all whitespace
     // characters (space, tabs, CRLF) are removed.
     // Remove heading and trailing characters from the string
@@ -272,11 +272,11 @@ public:
     void    TrimRight(char c = 0);
     // Truncate* methods decrease the string to the part of itself
     // Truncate the string to the leftmost N characters
-    void    TruncateToLeft(int count);
+    void    TruncateToLeft(size_t count);
     // Truncate the string to the middle N characters
-    void    TruncateToMid(int from, int count = -1);
+    void    TruncateToMid(size_t from, size_t count = -1);
     // Truncate the string to the rightmost N characters
-    void    TruncateToRight(int count);
+    void    TruncateToRight(size_t count);
     // Truncate the string to the leftmost part, separated by the given char;
     // if no separator was found leaves string unchanged
     void    TruncateToLeftSection(char separator, bool exclude_separator = true);
@@ -285,7 +285,7 @@ public:
     void    TruncateToRightSection(char separator, bool exclude_separator = true);
     // Truncate the string to range of Xth to Yth fields separated by the
     // given character
-    void    TruncateToSection(char separator, int first, int last,
+    void    TruncateToSection(char separator, size_t first, size_t last,
                               bool exclude_first_sep = true, bool exclude_last_sep = true);
 
     //-------------------------------------------------------------------------
@@ -300,9 +300,9 @@ public:
     String &operator=(const String&);
     // Assign C-string by copying contents
     String &operator=(const char *cstr);
-    inline char operator[](int index) const
+    inline char operator[](size_t index) const
     {
-        assert(_meta && index >= 0 && index < _meta->Length);
+        assert(_meta && index < _meta->Length);
         return _meta->CStr[index];
     }
     inline bool operator==(const char *cstr) const
@@ -320,26 +320,26 @@ public:
 
 private:
     // Creates new empty string with buffer enough to fit given length
-    void    Create(int buffer_length);
+    void    Create(size_t buffer_length);
     // Release string and copy data to the new buffer
-    void    Copy(int buffer_length, int offset = 0);
+    void    Copy(size_t buffer_length, size_t offset = 0);
     // Aligns data at given offset
-    void    Align(int offset);
+    void    Align(size_t offset);
 
     // Ensure this string is a compact independent copy, with ref counter = 1
     void    BecomeUnique();
     // Ensure this string is independent, and there's enough space before
     // or after the current string data
-    void    ReserveAndShift(bool left, int more_length);
+    void    ReserveAndShift(bool left, size_t more_length);
 
     struct Header
     {
         Header();
 
-        int32_t RefCount;   // reference count
+        size_t  RefCount;   // reference count
         // Capacity and Length do not include null-terminator
-        int32_t Capacity;   // available space, in characters
-        int32_t Length;     // used space
+        size_t  Capacity;   // available space, in characters
+        size_t  Length;     // used space
         char    *CStr;      // pointer to string data start
     };
 
@@ -349,7 +349,7 @@ private:
         Header  *_meta;
     };
 
-    static const int _internalBufferLength = 3000;
+    static const size_t _internalBufferLength = 3000;
     static char _internalBuffer[3001];
 };
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -414,7 +414,7 @@ bool ResolveScriptPath(const String &sc_path, bool read_only, String &path, Stri
         }
     }
 
-    if (child_path[0] == '\\' || child_path[0] == '/')
+    if (child_path[0u] == '\\' || child_path[0u] == '/')
         child_path.ClipLeft(1);
 
     path = String::FromFormat("%s%s", parent_dir.GetCStr(), child_path.GetCStr());

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -45,7 +45,7 @@ int FindGUIID (const char* GUIName) {
             continue;
         if (strcmp(guis[ii].Name, GUIName) == 0)
             return ii;
-        if ((guis[ii].Name[0] == 'g') && (stricmp(guis[ii].Name.GetCStr() + 1, GUIName) == 0))
+        if ((guis[ii].Name[0u] == 'g') && (stricmp(guis[ii].Name.GetCStr() + 1, GUIName) == 0))
             return ii;
     }
     quit("FindGUIID: No matching GUI found: GUI may have been deleted");

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -227,7 +227,7 @@ void read_game_data_location(const ConfigTree &cfg)
         AGS::Common::Path::FixupPath(usetup.data_files_dir);
 #if defined (WINDOWS_VERSION)
         // if the path is just x:\ don't strip the slash
-        if (!(usetup.data_files_dir.GetLength() < 4 && usetup.data_files_dir[1] == ':'))
+        if (!(usetup.data_files_dir.GetLength() < 4 && usetup.data_files_dir[1u] == ':'))
         {
             usetup.data_files_dir.TrimRight('/');
         }

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -190,12 +190,12 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 // (eg. a room change occured)
 int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int isInv) {
 
-    if ((nint->ScriptFuncNames[evnt] == NULL) || (nint->ScriptFuncNames[evnt][0] == 0)) {
+    if ((nint->ScriptFuncNames[evnt] == NULL) || (nint->ScriptFuncNames[evnt][0u] == 0)) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
         if (chkAny < 0) ;
-        else if ((nint->ScriptFuncNames[chkAny] != NULL) && (nint->ScriptFuncNames[chkAny][0] != 0))
+        else if ((nint->ScriptFuncNames[chkAny] != NULL) && (nint->ScriptFuncNames[chkAny][0u] != 0))
             return 0;
 
         // Otherwise, run unhandled_event

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -205,8 +205,8 @@ void Test_String()
     // Test Section
     {
         String s = "_123_567_";
-        int from;
-        int to;
+        size_t from;
+        size_t to;
         assert(s.FindSection('_', 0, 0, true, true, from, to));
         assert(from == 0 && to == 0);
         assert(s.FindSection('_', 0, 0, false, true, from, to));
@@ -258,7 +258,7 @@ void Test_String()
         str2.ClipRight(6);
         str3.ClipMid(5, 12);
         str4.ClipMid(5, 0);
-        str5.ClipMid(-1);
+        str5.ClipMid(0);
         assert(strcmp(str1, " truncateable string") == 0);
         assert(strcmp(str2, "long truncateable ") == 0);
         assert(strcmp(str3, "long  string") == 0);
@@ -405,7 +405,7 @@ void Test_String()
         str2.TruncateToRight(6);
         str3.TruncateToMid(5, 12);
         str4.TruncateToMid(5, 0);
-        str5.TruncateToMid(-1);
+        str5.TruncateToMid(0);
         assert(strcmp(str1, "long") == 0);
         assert(strcmp(str2, "string") == 0);
         assert(strcmp(str3, "truncateable") == 0);


### PR DESCRIPTION
Initially I wrote String class using ints for buffer length and indexes for some reasons, now changing to size_t.
This is long overdue, but something distracted me all the time from committing.

NOTE: We currently have string tests in the engine, which are only built in Debug configuration, and run at program startup. I was referencing to them to check that this conversion is correct.