### PR TITLE
Fixed missing standard header for std::shared_ptr

### DIFF
--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -20,10 +20,12 @@
 #define __CC_INSTANCE_H
 
 #if __cplusplus >= 201103L
+#include <memory>
 #include <unordered_map>
 namespace stdtr1compat = std;
 #else
 #if defined (_MSC_VER)
+#include <memory>
 #include <unordered_map>
 #else
 #include <tr1/memory>


### PR DESCRIPTION
std::shared_ptr/std::tr1::shared_ptr is defined only in the `<memory>`
header file, which is not guaranteed to be included by `<unordered_map>`.
On MSVC2008, `<unordered_map>` does include `<memory>` but this is an
implementation detail and not a standard inclusion.