### PR TITLE
Moved stdtr1compat to a header file

### DIFF
--- a/Common/game/customproperties.h
+++ b/Common/game/customproperties.h
@@ -25,17 +25,8 @@
 #ifndef __AGS_CN_GAME__CUSTOMPROPERTIES_H
 #define __AGS_CN_GAME__CUSTOMPROPERTIES_H
 
-#if __cplusplus >= 201103L
-#include <unordered_map>
-namespace stdtr1compat = std;
-#else
-#if defined (_MSC_VER)
-#include <unordered_map>
-#else
-#include <tr1/unordered_map>
-#endif
-namespace stdtr1compat = std::tr1;
-#endif
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(unordered_map)
 
 #include "util/string.h"
 #include "util/string_types.h"

--- a/Common/util/stdtr1compat.h
+++ b/Common/util/stdtr1compat.h
@@ -1,0 +1,45 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__STDTR1COMPAT_H
+#define __AGS_CN_UTIL__STDTR1COMPAT_H
+
+#define MAKE_HEADER(arg) <arg>
+#define TR1INCLUDE(arg) MAKE_HEADER(arg) // default for C++11 compilers and MSVC (no tr1 folder)
+
+#if __cplusplus >= 201103L
+// C++11, doesn't need TR1
+namespace std {}
+namespace stdtr1compat = std;
+#elif defined(_MSC_VER)
+#if _MSC_VER < 1900
+// MSVC prior to VS2015 needs TR1
+#define AGS_NEEDS_TR1
+#define AGS_NEEDS_TR1_MSVC // additional macro because MSVC headers aren't in tr1 folder
+namespace std { namespace tr1 {} }
+namespace stdtr1compat = std::tr1;
+#else
+// MSVC2015 and later do not need TR1
+namespace std {}
+namespace stdtr1compat = std;
+#endif // _MSC_VER < 1900
+#else // !_MSC_VER
+// not C++11, needs TR1
+#define AGS_NEEDS_TR1
+#undef TR1INCLUDE
+#define TR1INCLUDE(arg) MAKE_HEADER(tr1/arg) // non-MSVC compilers prior to C++11 need tr1 folder
+namespace std { namespace tr1 {} }
+namespace stdtr1compat = std::tr1;
+#endif // C++11
+
+#endif // __AGS_CN_UTIL__STDTR1COMPAT_H

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -15,21 +15,9 @@
 #define __AGS_CN_UTIL__STRINGTYPES_H
 
 #include <cctype>
-
-#if __cplusplus >= 201103L
-#include <functional>
-#include <unordered_map>
-namespace stdtr1compat = std;
-#else
-#if defined (_MSC_VER)
-#include <functional>
-#include <unordered_map>
-#else
-#include <tr1/functional>
-#include <tr1/unordered_map>
-#endif
-namespace stdtr1compat = std::tr1;
-#endif
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(functional)
+#include TR1INCLUDE(unordered_map)
 
 #include <vector>
 #include "util/string.h"
@@ -62,7 +50,7 @@ inline size_t Hash_LowerCase(const char *data, const size_t len)
 // A std::hash specialization for AGS String
 namespace std
 {
-#if __cplusplus < 201103L
+#ifdef AGS_NEEDS_TR1
 namespace tr1
 {
 #endif
@@ -74,7 +62,7 @@ struct hash<AGS::Common::String> : public unary_function<AGS::Common::String, si
         return FNV::Hash(key.GetCStr(), key.GetLength());
     }
 };
-#if __cplusplus < 201103L
+#ifdef AGS_NEEDS_TR1
 }
 #endif
 }

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -19,18 +19,9 @@
 #ifndef __CC_INSTANCE_H
 #define __CC_INSTANCE_H
 
-#if __cplusplus >= 201103L
-#include <unordered_map>
-namespace stdtr1compat = std;
-#else
-#if defined (_MSC_VER)
-#include <unordered_map>
-#else
-#include <tr1/memory>
-#include <tr1/unordered_map>
-#endif
-namespace stdtr1compat = std::tr1;
-#endif
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
+#include TR1INCLUDE(unordered_map)
 
 #include "script/script_common.h"
 #include "script/cc_script.h"  // ccScript

--- a/Solutions/Common.Lib/Common.Lib.vcproj
+++ b/Solutions/Common.Lib/Common.Lib.vcproj
@@ -850,6 +850,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\Common\util\stdtr1compat.h"
+					>
+				</File>
+				<File
 					RelativePath="..\..\Common\util\stream.h"
 					>
 				</File>


### PR DESCRIPTION
Also checks for VS2015, which is the earliest version of Visual Studio which doesn't need the TR1 namespace for these headers (AFAICT).