### PR TITLE
C99-compliant snprintf replacement for MSVC

### DIFF
--- a/Common/util/c99_snprintf.h
+++ b/Common/util/c99_snprintf.h
@@ -1,0 +1,60 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+// borrowed and modified from [Stack Overflow](http://stackoverflow.com/q/34912145/1136311)
+//
+// Visual Studio's _snprintf is not C99-compliant as it does not
+// null-terminate the buffer, which may result in unexpected bad memory
+// access. This provides a C99-compliant alternative. From VS2015 this is
+// no longer needed as a compliant snprintf function is implemented.
+
+#ifndef __AGS_CN_UTIL__C99_SNPRINTF_H
+#define __AGS_CN_UTIL__C99_SNPRINTF_H
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+__inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+{
+	int count = -1;
+
+	if (size != 0)
+		count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+	if (count == -1)
+		count = _vscprintf(format, ap);
+
+	return count;
+}
+
+__inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+	int count;
+	va_list ap;
+
+	va_start(ap, format);
+	count = c99_vsnprintf(outBuf, size, format, ap);
+	va_end(ap);
+
+	return count;
+}
+
+#endif // _MSC_VER
+
+#endif // __AGS_CN_UTIL__C99_SNPRINTF_H

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -45,9 +45,7 @@ extern "C" char *strupr(char *s);
 
 #else
 
-#if !defined (snprintf)
-#define snprintf _snprintf
-#endif
+#include "util/c99_snprintf.h"
 
 #endif // !WINDOWS_VERSION
 

--- a/Engine/libsrc/apeg-1.2.1/audio/mpg123.c
+++ b/Engine/libsrc/apeg-1.2.1/audio/mpg123.c
@@ -10,7 +10,7 @@
 #endif
 
 #ifndef __GNUC__
-#define snprintf _snprintf
+#include "util/c99_snprintf.h"
 #endif
 #include <string.h>
 #include <stdio.h>

--- a/Engine/script/script_api.cpp
+++ b/Engine/script/script_api.cpp
@@ -23,7 +23,7 @@
 namespace Math = AGS::Common::Math;
 
 #if defined (WINDOWS_VERSION)
-#define snprintf _snprintf
+#include "util/c99_snprintf.h"
 #endif
 
 char ScSfBuffer[STD_BUFFER_SIZE];

--- a/Solutions/Common.Lib/Common.Lib.vcproj
+++ b/Solutions/Common.Lib/Common.Lib.vcproj
@@ -790,6 +790,10 @@
 					>
 				</File>
 				<File
+					RelativePath="..\..\Common\util\c99_snprintf.h"
+					>
+				</File>
+				<File
 					RelativePath="..\..\Common\util\compress.h"
 					>
 				</File>


### PR DESCRIPTION
MSVC's "_snprintf" is **not** C99-compliant as it does not truncate the buffer on overflow (correction: it does limit how much it writes, but does not null-terminate the buffer). As such it is not a safe replacement for snprintf (as is currently implemented). This provides an alternative that is C99-compliant. Additionally, VS2015 implements a C99-compliant snprintf which causes the existing macro to fail with a compile error. This does not supply the macro if not building with MSVC or if using VS2015 or later.