### PR TITLE
Redirected main output files to Compiled/Data

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -34,6 +34,7 @@ namespace AGS.Editor
 
 		public const string BUILT_IN_HEADER_FILE_NAME = "_BuiltInScriptHeader.ash";
         public const string OUTPUT_DIRECTORY = "Compiled";
+        public const string DATA_OUTPUT_DIRECTORY = ""; // subfolder in OUTPUT_DIRECTORY for data file outputs (TODO: change to "Data")
         public const string DEBUG_OUTPUT_DIRECTORY = "_Debug";
         //public const string DEBUG_EXE_FILE_NAME = "_debug.exe";
         public const string GAME_FILE_NAME = "Game.agf";
@@ -80,7 +81,7 @@ namespace AGS.Editor
          * 2: 3.4.0.1    - WorkspaceState section
         */
         public const int LATEST_USER_DATA_XML_VERSION_INDEX = 2;
-        public static readonly string AUDIO_VOX_FILE_NAME = OUTPUT_DIRECTORY + Path.DirectorySeparatorChar + "audio.vox";
+        public const string AUDIO_VOX_FILE_NAME = "audio.vox";
 
         private const string USER_DATA_FILE_NAME = GAME_FILE_NAME + USER_DATA_FILE_SUFFIX;
         private const string USER_DATA_FILE_SUFFIX = ".user";
@@ -945,7 +946,8 @@ namespace AGS.Editor
         private void CreateAudioVOXFile(bool forceRebuild)
         {
             List<string> fileListForVox = new List<string>();
-            bool rebuildVox = (!File.Exists(AUDIO_VOX_FILE_NAME)) || (forceRebuild);
+            string audioVox = Path.Combine(OUTPUT_DIRECTORY, Path.Combine(DATA_OUTPUT_DIRECTORY, AUDIO_VOX_FILE_NAME));
+            bool rebuildVox = (!File.Exists(audioVox)) || (forceRebuild);
 
             foreach (AudioClip clip in _game.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
             {
@@ -961,15 +963,15 @@ namespace AGS.Editor
                 }
             }
 
-            if (File.Exists(AUDIO_VOX_FILE_NAME) && 
+            if (File.Exists(audioVox) && 
                 (fileListForVox.Count == 0) || (rebuildVox))
             {
-                File.Delete(AUDIO_VOX_FILE_NAME);
+                File.Delete(audioVox);
             }
 
             if ((rebuildVox) && (fileListForVox.Count > 0))
             {
-                Factory.NativeProxy.CreateVOXFile(AUDIO_VOX_FILE_NAME, fileListForVox.ToArray());
+                Factory.NativeProxy.CreateVOXFile(audioVox, fileListForVox.ToArray());
             }
         }
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -34,7 +34,7 @@ namespace AGS.Editor
 
 		public const string BUILT_IN_HEADER_FILE_NAME = "_BuiltInScriptHeader.ash";
         public const string OUTPUT_DIRECTORY = "Compiled";
-        public const string DATA_OUTPUT_DIRECTORY = ""; // subfolder in OUTPUT_DIRECTORY for data file outputs (TODO: change to "Data")
+        public const string DATA_OUTPUT_DIRECTORY = "Data"; // subfolder in OUTPUT_DIRECTORY for data file outputs
         public const string DEBUG_OUTPUT_DIRECTORY = "_Debug";
         //public const string DEBUG_EXE_FILE_NAME = "_debug.exe";
         public const string GAME_FILE_NAME = "Game.agf";
@@ -136,10 +136,6 @@ namespace AGS.Editor
         private AGSEditor()
         {
             _editorExePath = Process.GetCurrentProcess().MainModule.FileName;
-            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDataFile());
-            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetWindows());
-            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDebug());
-            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetLinux());
         }
 
         static AGSEditor()
@@ -154,6 +150,10 @@ namespace AGS.Editor
             {
                 _scriptCompatLevelMacros[(int)v] = "SCRIPT_COMPAT_" + v.ToString();
             }
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDataFile());
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetWindows());
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDebug());
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetLinux());
         }
 
         public Game CurrentGame
@@ -937,7 +937,8 @@ namespace AGS.Editor
 
         private void DeleteAnyExistingSplitResourceFiles()
         {
-            foreach (string fileName in Utilities.GetDirectoryFileList(OUTPUT_DIRECTORY, this.BaseGameFileName + ".0*"))
+            string dir = Path.Combine(OUTPUT_DIRECTORY, DATA_OUTPUT_DIRECTORY);
+            foreach (string fileName in Utilities.GetDirectoryFileList(dir, this.BaseGameFileName + ".0*"))
             {
                 File.Delete(fileName);
             }
@@ -1513,7 +1514,7 @@ namespace AGS.Editor
 
         private object SaveGameFilesProcess(object parameter)
         {
-			WriteConfigFile(OUTPUT_DIRECTORY);
+			WriteConfigFile(Path.Combine(OUTPUT_DIRECTORY, DATA_OUTPUT_DIRECTORY));
 
             SaveUserDataFile();
 

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -21,7 +21,7 @@ namespace AGS.Editor
 
         private void DeleteAnyExistingSplitResourceFiles()
         {
-            foreach (string fileName in Utilities.GetDirectoryFileList(AGSEditor.OUTPUT_DIRECTORY, Factory.AGSEditor.BaseGameFileName + ".0*"))
+            foreach (string fileName in Utilities.GetDirectoryFileList(GetCompiledPath(), Factory.AGSEditor.BaseGameFileName + ".0*"))
             {
                 File.Delete(fileName);
             }
@@ -106,7 +106,7 @@ namespace AGS.Editor
             File.Delete(AGSEditor.COMPILED_DTA_FILE_NAME);
             CreateAudioVOXFile(forceRebuild);
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(AGSEditor.OUTPUT_DIRECTORY);
+            Factory.AGSEditor.WriteConfigFile(GetCompiledPath());
             return true;
         }
 

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -59,7 +59,8 @@ namespace AGS.Editor
         private void CreateAudioVOXFile(bool forceRebuild)
         {
             List<string> fileListForVox = new List<string>();
-            bool rebuildVox = (!File.Exists(AGSEditor.AUDIO_VOX_FILE_NAME)) || (forceRebuild);
+            string audioVox = GetCompiledPath(AGSEditor.AUDIO_VOX_FILE_NAME);
+            bool rebuildVox = (!File.Exists(audioVox)) || (forceRebuild);
 
             foreach (AudioClip clip in Factory.AGSEditor.CurrentGame.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
             {
@@ -75,15 +76,15 @@ namespace AGS.Editor
                 }
             }
 
-            if (File.Exists(AGSEditor.AUDIO_VOX_FILE_NAME) &&
+            if (File.Exists(audioVox) &&
                 (fileListForVox.Count == 0) || (rebuildVox))
             {
-                File.Delete(AGSEditor.AUDIO_VOX_FILE_NAME);
+                File.Delete(audioVox);
             }
 
             if ((rebuildVox) && (fileListForVox.Count > 0))
             {
-                Factory.NativeProxy.CreateVOXFile(AGSEditor.AUDIO_VOX_FILE_NAME, fileListForVox.ToArray());
+                Factory.NativeProxy.CreateVOXFile(audioVox, fileListForVox.ToArray());
             }
         }
 
@@ -129,7 +130,7 @@ namespace AGS.Editor
         {
             get
             {
-                return "";
+                return AGSEditor.DATA_OUTPUT_DIRECTORY;
             }
         }
     }

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -120,7 +120,7 @@ namespace AGS.Editor
                 errors.Add(new CompileError("Could not build for Linux due to missing plugins."));
                 return false;
             }
-            foreach (string fileName in Directory.GetFiles(AGSEditor.OUTPUT_DIRECTORY))
+            foreach (string fileName in Directory.GetFiles(Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY)))
             {
                 if ((!fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) &&
                     (!Path.GetFileName(fileName).Equals("winsetup.exe", StringComparison.OrdinalIgnoreCase)) &&

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -191,7 +191,7 @@ namespace AGS.Editor
         public override bool Build(CompileMessages errors, bool forceRebuild)
         {
             if (!base.Build(errors, forceRebuild)) return false;
-            string compiledDir = AGSEditor.OUTPUT_DIRECTORY;
+            string compiledDataDir = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY);
             string baseGameFileName = Factory.AGSEditor.BaseGameFileName;
             string newExeName = GetCompiledPath(baseGameFileName + ".exe");
             string sourceEXE = Path.Combine(Factory.AGSEditor.EditorDirectory, AGSEditor.ENGINE_EXE_FILE_NAME);
@@ -199,7 +199,7 @@ namespace AGS.Editor
             UpdateWindowsEXE(newExeName, errors);
             CreateCompiledSetupProgram();
             Environment.CurrentDirectory = Factory.AGSEditor.CurrentGame.DirectoryPath;
-            foreach (string fileName in Utilities.GetDirectoryFileList(compiledDir, "*"))
+            foreach (string fileName in Utilities.GetDirectoryFileList(compiledDataDir, "*"))
             {
                 if (fileName.EndsWith(".ags"))
                 {

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -308,7 +308,8 @@ namespace AGS.Editor.Components
                 newClip.FileType = _fileTypeMappings[fileExtension];
                 newClip.FileLastModifiedDate = File.GetLastWriteTimeUtc(sourceFileName);
                 Utilities.CopyFileAndSetDestinationWritable(sourceFileName, newClip.CacheFileName);
-                Utilities.DeleteFileIfExists(AGSEditor.AUDIO_VOX_FILE_NAME);
+                Utilities.DeleteFileIfExists(Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
+                    Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, AGSEditor.AUDIO_VOX_FILE_NAME)));
                 _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
                 return newClip;
             }
@@ -732,7 +733,8 @@ namespace AGS.Editor.Components
             }
             _agsEditor.DeleteFileOnDiskAndSourceControl(filesToDelete.ToArray());
             _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
-            Utilities.DeleteFileIfExists(AGSEditor.AUDIO_VOX_FILE_NAME);
+            Utilities.DeleteFileIfExists(Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
+                Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, AGSEditor.AUDIO_VOX_FILE_NAME)));
         }
     }
 }

--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -19,7 +19,7 @@ namespace AGS.Editor.Components
         private static readonly string MP3_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.mp3";
         private static readonly string WAVEFORM_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.wav";
         private const string LIP_SYNC_DATA_OUTPUT = "syncdata.dat";
-        private static readonly string SPEECH_VOX_FILE_NAME = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, "speech.vox");
+        private static readonly string SPEECH_VOX_FILE_NAME = "speech.vox";
 
         private Dictionary<string, DateTime> _speechVoxStatus = new Dictionary<string, DateTime>();
 		private Dictionary<string, DateTime> _pamFileStatus = new Dictionary<string, DateTime>();
@@ -59,7 +59,8 @@ namespace AGS.Editor.Components
         private void _agsEditor_ExtraOutputCreationStep()
         {
             string[] speechFileList = ConstructFileListForSpeechVOX();
-            RebuildVOXFileIfRequired(SPEECH_VOX_FILE_NAME, speechFileList, _speechVoxStatus);
+            RebuildVOXFileIfRequired(Path.Combine(AGSEditor.OUTPUT_DIRECTORY, Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, SPEECH_VOX_FILE_NAME)),
+                speechFileList, _speechVoxStatus);
         }
 
         public override string ComponentID

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -76,7 +76,8 @@ namespace AGS.Editor.Components
             {
                 if (File.Exists(translation.FileName))
                 {
-                    string compiledPath = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, translation.CompiledFileName);
+                    string compiledPath = Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
+                        Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, translation.CompiledFileName));
 
                     if ((evArgs.ForceRebuild) ||
 						(Utilities.DoesFileNeedRecompile(translation.FileName, compiledPath)))
@@ -103,7 +104,8 @@ namespace AGS.Editor.Components
                 return;
             }
 
-            string compiledFile = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, translation.CompiledFileName);
+            string compiledFile = Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
+                Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, translation.CompiledFileName));
             bool foundTranslatedLine = false;
 
             using (BinaryWriter bw = new BinaryWriter(new FileStream(compiledFile, FileMode.Create, FileAccess.Write)))

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -288,9 +288,10 @@ namespace AGS.Editor
             long mainHeaderOffset = 0;
             string outputFileName;
             string firstDataFileFullPath = null;
+            string outputDir = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY);
             if (makeFileNameAssumptions)
             {
-                Directory.CreateDirectory("Compiled");
+                Directory.CreateDirectory(outputDir);
             }
             // First, set up ourlib.data_filenames array with all the filenames
             // so that write_clib_header will write the correct amount of data
@@ -325,7 +326,7 @@ namespace AGS.Editor
             {
                 if (makeFileNameAssumptions)
                 {
-                    outputFileName = Path.Combine("Compiled", ourlib.DataFilenames[i]);
+                    outputFileName = Path.Combine(outputDir, ourlib.DataFilenames[i]);
                 }
                 else
                 {

--- a/Editor/AGS.Editor/Panes/GeneralSettings.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettings.cs
@@ -35,7 +35,8 @@ namespace AGS.Editor
         {
             foreach (Translation translation in Factory.AGSEditor.CurrentGame.Translations)
             {
-                string compiledPath = Path.Combine(AGSEditor.OUTPUT_DIRECTORY, translation.CompiledFileName);
+                string compiledPath = Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
+                    Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, translation.CompiledFileName));
                 if (File.Exists(compiledPath))
                 {
                     File.Delete(compiledPath);


### PR DESCRIPTION
This is equal parts clean-up and a feature-fix for the AndroidBuilder plugin I am working on. Everything appears to build and run properly, including audio and speech VOX files and debug.

Particularly, the `jobb` tool used in Android deployment takes an entire directory (recursively) as input, so the data files need to be in a separate directory.