### PR TITLE
Engine: Fix return value for GetVoiceMode

### DIFF
--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -439,7 +439,7 @@ void SetVoiceMode (int newmod) {
 
 int GetVoiceMode()
 {
-    return play.want_speech >= 0 ? play.want_speech : (-play.want_speech + 1);
+    return play.want_speech >= 0 ? play.want_speech : -(play.want_speech + 1);
 }
 
 int IsVoxAvailable() {


### PR DESCRIPTION
Ensure that GetVoiceMode (the Speech.VoiceMode getter) returns the correct value when a vox file isn't available. Operations need to be done in reverse order of those in SetVoiceMode.