### PR TITLE
Engine: fix for idle animation potentially animating the wrong view

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -290,6 +290,12 @@ void Character_ChangeView(CharacterInfo *chap, int vii) {
     if ((chap->flags & CHF_FIXVIEW) && (chap->idleleft >= 0))
         debug_log("Warning: ChangeCharacterView was used while the view was fixed - call ReleaseCharView first");
 
+    // if the idle animation is playing we should release the view
+    if ( chap->idleleft < 0) {
+      Character_UnlockView(chap);
+      chap->idleleft = chap->idletime;
+    }
+
     DEBUG_CONSOLE("%s: Change view to %d", chap->scrname, vii+1);
     chap->defview = vii;
     chap->view = vii;


### PR DESCRIPTION
Calling ChangeView during the playback of an idle animation animates the wrong view.

Can be easily tested with something like this:
`	cEgo.SetIdleView(15, 0);
	Wait(50);
	cEgo.ChangeView(10);`

This is unexpected behaviour, other functions that change the view make sure to check if the idle is playing and if so unlocks the view and resets the "idleleft" timer.

I've also tested against LockedView() and all performs as expected.