### PR TITLE
Fix check for CAFEBEEF magic value

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -340,7 +340,7 @@ void ReadDialogs(DialogTopic *&dialog,
         while (1)
         {
             size_t newlen = in->ReadInt32();
-            if (newlen == 0xCAFEBEEF)  // GUI magic
+            if (static_cast<int32_t>(newlen) == 0xCAFEBEEF)  // GUI magic
             {
                 in->Seek(-4);
                 break;


### PR DESCRIPTION
gcc 6.2 and clang 4.0 optimize away the previous check because an
unsigned variable (size_t newlen) is compared to an signed
negative constant (0xCAFEBEEF).

Solves part of issue #366.