### PR TITLE
ScriptAPI: Character and Object properties for getting tint values

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -88,6 +88,9 @@ struct CharacterInfo {
     int get_blocking_top();    // return Y - BlockingHeight/2
     int get_blocking_bottom(); // return Y + BlockingHeight/2
 
+    inline bool has_explicit_light() const { return (flags & CHF_HASLIGHT) != 0; }
+    inline bool has_explicit_tint()  const { return (flags & CHF_HASTINT) != 0; }
+
 	// [IKM] 2012-06-28: I still have to pass char_index to some of those functions
 	// either because they use it to set some variables with it,
 	// or because they pass it further to other functions, that are called from various places

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -141,4 +141,20 @@ enum DialogOptionNumbering
     kDlgOptNumbering   =  1  // draw option indices and use key shortcuts
 };
 
+// Version of the script api (OPT_BASESCRIPTAPI and OPT_SCRIPTCOMPATLEV).
+// If the existing script function meaning had changed, that may be
+// possible to find out which implementation to use by checking one of those
+// two options.
+// NOTE: please remember that those values are valid only for games made with
+// 3.4.0 final and above.
+enum ScriptAPIVersion
+{
+    kScriptAPI_v321 = 0,
+    kScriptAPI_v330 = 1,
+    kScriptAPI_v334 = 2,
+    kScriptAPI_v335 = 3,
+    kScriptAPI_v340 = 4,
+    kScriptAPI_v341 = 5
+};
+
 #endif // __AGS_CN_AC__GAMESTRUCTDEFINES_H

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2035,6 +2035,24 @@ builtin managed struct Object {
   /// Sets a text custom property for this object.
   import bool SetTextProperty(const string property, const string value);
 #endif
+#ifdef SCRIPT_API_v341
+  /// Gets whether the object has an explicit light level set.
+  readonly import attribute bool HasExplicitLight;
+  /// Gets whether the object has an explicit tint set.
+  readonly import attribute bool HasExplicitTint;
+  /// Gets the individual light level for this object.
+  readonly import attribute int  LightLevel;
+  /// Gets the Blue component of this object's colour tint.
+  readonly import attribute int  TintBlue;
+  /// Gets the Green component of this object's colour tint.
+  readonly import attribute int  TintGreen;
+  /// Gets the Red component of this object's colour tint.
+  readonly import attribute int  TintRed;
+  /// Gets the Saturation of this object's colour tint.
+  readonly import attribute int  TintSaturation;
+  /// Gets the Luminance of this object's colour tint.
+  readonly import attribute int  TintLuminance;
+#endif
 
   int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
@@ -2253,6 +2271,22 @@ builtin managed struct Character {
   readonly import attribute int DestinationX;
   /// Gets the Y position this character is currently moving towards.
   readonly import attribute int DestinationY;
+#endif
+#ifdef SCRIPT_API_v341
+  /// Gets whether the character has an explicit light level set.
+  readonly import attribute bool HasExplicitLight;
+  /// Gets the individual light level for this character.
+  readonly import attribute int  LightLevel;
+  /// Gets the Blue component of this character's colour tint.
+  readonly import attribute int  TintBlue;
+  /// Gets the Green component of this character's colour tint.
+  readonly import attribute int  TintGreen;
+  /// Gets the Red component of this character's colour tint.
+  readonly import attribute int  TintRed;
+  /// Gets the Saturation of this character's colour tint.
+  readonly import attribute int  TintSaturation;
+  /// Gets the Luminance of this character's colour tint.
+  readonly import attribute int  TintLuminance;
 #endif
 #ifdef STRICT
   /// The character's current X-position.

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -13,14 +13,14 @@ namespace AGS.Types
         [Description("3.2.1")]
         v321 = 0,
         [Description("3.3.0")]
-        v330,
+        v330 = 1,
         [Description("3.3.4")]
-        v334,
+        v334 = 2,
         [Description("3.3.5")]
-        v335,
+        v335 = 3,
         [Description("3.4.0")]
-        v340,
+        v340 = 4,
         [Description("3.4.1")]
-        v341
+        v341 = 5
     }
 }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -755,12 +755,9 @@ void Character_RemoveTint(CharacterInfo *chaa) {
     }
 }
 
-int Character_GetHasExplicitTint(CharacterInfo *chaa) {
-
-    if (chaa->flags & (CHF_HASTINT | CHF_HASLIGHT))
-        return 1;
-
-    return 0;
+int Character_GetHasExplicitTint(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() || ((game.options[OPT_BASESCRIPTAPI] < kScriptAPI_v341) && ch->has_explicit_light());
 }
 
 void Character_Say(CharacterInfo *chaa, const char *text) {
@@ -871,6 +868,16 @@ void Character_SetIdleView(CharacterInfo *chaa, int iview, int itime) {
 
 }
 
+bool Character_GetHasExplicitLight(CharacterInfo *ch)
+{
+    return ch->has_explicit_light();
+}
+
+int Character_GetLightLevel(CharacterInfo *ch)
+{
+    return ch->has_explicit_light() ? charextra[ch->index_id].tint_light : 0;
+}
+
 void Character_SetLightLevel(CharacterInfo *chaa, int light_level)
 {
     light_level = Math::Clamp(-100, 100, light_level);
@@ -878,6 +885,31 @@ void Character_SetLightLevel(CharacterInfo *chaa, int light_level)
     charextra[chaa->index_id].tint_light = light_level;
     chaa->flags &= ~CHF_HASTINT;
     chaa->flags |= CHF_HASLIGHT;
+}
+
+int Character_GetTintRed(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() ? charextra[ch->index_id].tint_r : 0;
+}
+
+int Character_GetTintGreen(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() ? charextra[ch->index_id].tint_g : 0;
+}
+
+int Character_GetTintBlue(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() ? charextra[ch->index_id].tint_b : 0;
+}
+
+int Character_GetTintSaturation(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() ? charextra[ch->index_id].tint_level : 0;
+}
+
+int Character_GetTintLuminance(CharacterInfo *ch)
+{
+    return ch->has_explicit_tint() ? ((charextra[ch->index_id].tint_light * 10) / 25) : 0;
 }
 
 void Character_SetOption(CharacterInfo *chaa, int flag, int yesorno) {
@@ -3102,9 +3134,44 @@ RuntimeScriptValue Sc_Character_SetIdleView(void *self, const RuntimeScriptValue
     API_OBJCALL_VOID_PINT2(CharacterInfo, Character_SetIdleView);
 }
 
+RuntimeScriptValue Sc_Character_HasExplicitLight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(CharacterInfo, Character_GetHasExplicitLight);
+}
+
+RuntimeScriptValue Sc_Character_GetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetLightLevel);
+}
+
 RuntimeScriptValue Sc_Character_SetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetLightLevel);
+}
+
+RuntimeScriptValue Sc_Character_GetTintBlue(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTintBlue);
+}
+
+RuntimeScriptValue Sc_Character_GetTintGreen(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTintGreen);
+}
+
+RuntimeScriptValue Sc_Character_GetTintRed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTintRed);
+}
+
+RuntimeScriptValue Sc_Character_GetTintSaturation(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTintSaturation);
+}
+
+RuntimeScriptValue Sc_Character_GetTintLuminance(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetTintLuminance);
 }
 
 /*
@@ -3307,7 +3374,6 @@ RuntimeScriptValue Sc_Character_SetFrame(void *self, const RuntimeScriptValue *p
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetFrame);
 }
 
-// int (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetHasExplicitTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(CharacterInfo, Character_GetHasExplicitTint);
@@ -3808,6 +3874,14 @@ void RegisterCharacterAPI()
 	ccAddExternalObjectFunction("Character::set_Z",                     Sc_Character_SetZ);
 	ccAddExternalObjectFunction("Character::get_z",                     Sc_Character_GetZ);
 	ccAddExternalObjectFunction("Character::set_z",                     Sc_Character_SetZ);
+
+    ccAddExternalObjectFunction("Character::get_HasExplicitLight",      Sc_Character_HasExplicitLight);
+    ccAddExternalObjectFunction("Character::get_LightLevel",            Sc_Character_GetLightLevel);
+    ccAddExternalObjectFunction("Character::get_TintBlue",              Sc_Character_GetTintBlue);
+    ccAddExternalObjectFunction("Character::get_TintGreen",             Sc_Character_GetTintGreen);
+    ccAddExternalObjectFunction("Character::get_TintRed",               Sc_Character_GetTintRed);
+    ccAddExternalObjectFunction("Character::get_TintSaturation",        Sc_Character_GetTintSaturation);
+    ccAddExternalObjectFunction("Character::get_TintLuminance",         Sc_Character_GetTintLuminance);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -194,6 +194,21 @@ int Object_GetMoving(ScriptObject *objj) {
     return IsObjectMoving(objj->id);
 }
 
+bool Object_HasExplicitLight(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_light();
+}
+
+bool Object_HasExplicitTint(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_tint();
+}
+
+int Object_GetLightLevel(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_light() ? objs[obj->id].tint_light : 0;
+}
+
 void Object_SetLightLevel(ScriptObject *objj, int light_level)
 {
     int obj = objj->id;
@@ -203,6 +218,31 @@ void Object_SetLightLevel(ScriptObject *objj, int light_level)
     objs[obj].tint_light = light_level;
     objs[obj].flags &= ~OBJF_HASTINT;
     objs[obj].flags |= OBJF_HASLIGHT;
+}
+
+int Object_GetTintRed(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_r : 0;
+}
+
+int Object_GetTintGreen(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_g : 0;
+}
+
+int Object_GetTintBlue(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_b : 0;
+}
+
+int Object_GetTintSaturation(ScriptObject *obj)
+{
+     return objs[obj->id].has_explicit_tint() ? objs[obj->id].tint_level : 0;
+}
+
+int Object_GetTintLuminance(ScriptObject *obj)
+{
+    return objs[obj->id].has_explicit_tint() ? ((objs[obj->id].tint_light * 10) / 25) : 0;
 }
 
 void Object_SetPosition(ScriptObject *objj, int xx, int yy) {
@@ -570,9 +610,49 @@ RuntimeScriptValue Sc_Object_RunInteraction(void *self, const RuntimeScriptValue
     API_OBJCALL_VOID_PINT(ScriptObject, Object_RunInteraction);
 }
 
+RuntimeScriptValue Sc_Object_HasExplicitLight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptObject, Object_HasExplicitLight);
+}
+
+RuntimeScriptValue Sc_Object_HasExplicitTint(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptObject, Object_HasExplicitTint);
+}
+
+RuntimeScriptValue Sc_Object_GetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetLightLevel);
+}
+
 RuntimeScriptValue Sc_Object_SetLightLevel(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptObject, Object_SetLightLevel);
+}
+
+RuntimeScriptValue Sc_Object_GetTintBlue(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetTintBlue);
+}
+
+RuntimeScriptValue Sc_Object_GetTintGreen(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetTintGreen);
+}
+
+RuntimeScriptValue Sc_Object_GetTintRed(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetTintRed);
+}
+
+RuntimeScriptValue Sc_Object_GetTintSaturation(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetTintSaturation);
+}
+
+RuntimeScriptValue Sc_Object_GetTintLuminance(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetTintLuminance);
 }
 
 // void (ScriptObject *objj, int xx, int yy)
@@ -855,6 +935,16 @@ void RegisterObjectAPI()
     ccAddExternalObjectFunction("Object::set_X",                    Sc_Object_SetX);
     ccAddExternalObjectFunction("Object::get_Y",                    Sc_Object_GetY);
     ccAddExternalObjectFunction("Object::set_Y",                    Sc_Object_SetY);
+
+    ccAddExternalObjectFunction("Object::get_HasExplicitLight",     Sc_Object_HasExplicitLight);
+    ccAddExternalObjectFunction("Object::get_HasExplicitTint",      Sc_Object_HasExplicitTint);
+    ccAddExternalObjectFunction("Object::get_LightLevel",           Sc_Object_GetLightLevel);
+    ccAddExternalObjectFunction("Object::set_LightLevel",           Sc_Object_SetLightLevel);
+    ccAddExternalObjectFunction("Object::get_TintBlue",             Sc_Object_GetTintBlue);
+    ccAddExternalObjectFunction("Object::get_TintGreen",            Sc_Object_GetTintGreen);
+    ccAddExternalObjectFunction("Object::get_TintRed",              Sc_Object_GetTintRed);
+    ccAddExternalObjectFunction("Object::get_TintSaturation",       Sc_Object_GetTintSaturation);
+    ccAddExternalObjectFunction("Object::get_TintLuminance",        Sc_Object_GetTintLuminance);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -18,6 +18,8 @@
 #ifndef __AGS_EE_AC__ROOMOBJECT_H
 #define __AGS_EE_AC__ROOMOBJECT_H
 
+#include "ac/common_defines.h"
+
 namespace AGS { namespace Common { class Stream; }}
 using namespace AGS; // FIXME later
 
@@ -46,6 +48,9 @@ struct RoomObject {
     int get_width();
     int get_height();
     int get_baseline();
+
+    inline bool has_explicit_light() const { return (flags & OBJF_HASLIGHT) != 0; }
+    inline bool has_explicit_tint()  const { return (flags & OBJF_HASTINT) != 0; }
 
 	void UpdateCyclingView();
 	void update_cycle_view_forwards();


### PR DESCRIPTION
Added **properties for getting Tint component values** from Characters and room Objects.
Added **LightLevel readonly property** (SetLightLevel is still used to explicitly set light level).
Added **HasExplicitLight** to Character to complement **HasExplicitTint**, and add both of same properties to the Object.
This makes Character and Object's tint API compliant to the Region API in ways to read currently applied light & tint parameteres, and complementary to each other.


An explanation is due, why I propose to still have SetLightLevel to set light for characters and objects, as opposed to Region.LightLevel property serving as both setter and getter of a light level.

Unlike Region, which always has **some** light level set (even if default 0, meaning no change in lighting), Character and Object has a distiction between "explicit light level" and "no individual light level". The former overrides regions and ambient tint, the latter does not. Explicit light level of 0 is a thing, so setting character's LightLevel to 0 would not turn individual lighting off, instead it would still override area lighting with default value.

Therefore, in my opinion, having SetLightLevel function to change char's and object's light would better indicate that we do not only change some value, but also toggling lighting mode (even though at a cost of people get slightly annoyed that they cannot assign values to LightLevel property).