### PR TITLE
Provide means for the alternate versions of AGS to indicate their games

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -91,6 +91,9 @@ Custom dialog option rendering extension.
 Custom properties changed at runtime.
 Ambient lighting
 
+48 : 3.4.1
+OPT_RENDERATSCREENRES, extended engine caps check.
+
 */
 
 enum GameDataVersion
@@ -121,7 +124,8 @@ enum GameDataVersion
     kGameVersion_340_1          = 45,
     kGameVersion_340_2          = 46,
     kGameVersion_340_4          = 47,
-    kGameVersion_Current        = kGameVersion_340_4
+    kGameVersion_341            = 48,
+    kGameVersion_Current        = kGameVersion_341
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -155,7 +155,8 @@ enum ScriptAPIVersion
     kScriptAPI_v334 = 2,
     kScriptAPI_v335 = 3,
     kScriptAPI_v340 = 4,
-    kScriptAPI_v341 = 5
+    kScriptAPI_v341 = 5,
+    kScriptAPI_Current = kScriptAPI_v341
 };
 
 // Determines whether the graphics renderer should scale sprites at the final

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -125,8 +125,7 @@ MainGameFileError OpenMainGameFileBase(PStream &in, MainGameSource &src)
     src.DataVersion = (GameDataVersion)in->ReadInt32();
     if (src.DataVersion < kGameVersion_250)
         return kMGFErr_FormatVersionTooOld;
-    String version_str = StrUtil::ReadString(in.get());
-    src.EngineVersion.SetFromString(version_str);
+    src.CompiledWith = StrUtil::ReadString(in.get());
     if (src.DataVersion > kGameVersion_Current)
         return kMGFErr_FormatVersionNotSupported;
     // Read required capabilities

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -55,6 +55,8 @@ String GetMainGameFileErrorText(MainGameFileError err)
         return "Format version is too old; this engine can only run games made with AGS 2.5 or later";
     case kMGFErr_FormatVersionNotSupported:
         return "Format version not supported";
+    case kMGFErr_CapsNotSupported:
+        return "Required engine caps are not supported";
     case kMGFErr_InvalidNativeResolution:
         return "Unable to determine native game resolution";
     case kMGFErr_TooManyFonts:
@@ -127,6 +129,13 @@ MainGameFileError OpenMainGameFileBase(PStream &in, MainGameSource &src)
     src.EngineVersion.SetFromString(version_str);
     if (src.DataVersion > kGameVersion_Current)
         return kMGFErr_FormatVersionNotSupported;
+    // Read required capabilities
+    if (src.DataVersion >= kGameVersion_341)
+    {
+        size_t count = in->ReadInt32();
+        for (size_t i = 0; i < count; ++i)
+            src.Caps.insert(StrUtil::ReadString(in.get()));
+    }
     // Everything is fine, return opened stream
     src.InputStream = in;
     // Remember loaded game data version

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -80,8 +80,8 @@ struct MainGameSource
     String              Filename;
     // Savegame format version
     GameDataVersion     DataVersion;
-    // Engine version this game was intended for
-    Version             EngineVersion;
+    // Tool identifier (like version) this game was compiled with
+    String              CompiledWith;
     // Extended engine capabilities required by the game; their primary use
     // currently is to let "alternate" game formats indicate themselves
     std::set<String>    Caps;

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -23,6 +23,7 @@
 
 #include "util/stdtr1compat.h"
 #include TR1INCLUDE(memory)
+#include <set>
 #include "ac/game_version.h"
 #include "game/plugininfo.h"
 #include "script/cc_script.h"
@@ -49,6 +50,7 @@ enum MainGameFileError
     // separate error given for "too old" format to provide clarifying message
     kMGFErr_FormatVersionTooOld,
     kMGFErr_FormatVersionNotSupported,
+    kMGFErr_CapsNotSupported,
     kMGFErr_InvalidNativeResolution,
     kMGFErr_TooManyFonts,
     kMGFErr_TooManySprites,
@@ -80,6 +82,9 @@ struct MainGameSource
     GameDataVersion     DataVersion;
     // Engine version this game was intended for
     Version             EngineVersion;
+    // Extended engine capabilities required by the game; their primary use
+    // currently is to let "alternate" game formats indicate themselves
+    std::set<String>    Caps;
     // A ponter to the opened stream
     PStream             InputStream;
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1282,6 +1282,13 @@ namespace AGS.Editor
             writer.Write(NativeConstants.GAME_DATA_VERSION_CURRENT);
             writer.Write(AGS.Types.Version.AGS_EDITOR_VERSION.Length);
             WriteString(AGS.Types.Version.AGS_EDITOR_VERSION, AGS.Types.Version.AGS_EDITOR_VERSION.Length, writer);
+            // Write extended engine caps; none for this version
+            writer.Write((int)0);
+            // An example of writing caps (pseduo-code):
+            //   writer.Write(caps.Count);
+            //   foreach (cap in caps)
+            //       FilePutString(cap.Name);
+            //
             WriteGameSetupStructBase_Aligned(writer, game);
             WriteString(game.Settings.GUIDAsString, NativeConstants.MAX_GUID_LENGTH, writer);
             WriteString(game.Settings.SaveGameFileExtension, NativeConstants.MAX_SG_EXT_LENGTH, writer);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -349,6 +349,20 @@ void AllocScriptModules()
 
 GameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver)
 {
+    if (data_ver >= kGameVersion_341)
+    {
+        const char * const scapi_names[] = {"v3.2.1", "v3.3.0", "v3.3.4", "v3.3.5", "v3.4.0", "v3.4.1"};
+        const ScriptAPIVersion base_api = (ScriptAPIVersion)game.options[OPT_BASESCRIPTAPI];
+        const ScriptAPIVersion compat_api = (ScriptAPIVersion)game.options[OPT_SCRIPTCOMPATLEV];
+        Out::FPrint("Requested script API: %s (%d), compat level: %s (%d)",
+                    base_api >= 0 && base_api <= kScriptAPI_Current ? scapi_names[base_api] : "unknown", base_api,
+                    compat_api >= 0 && compat_api <= kScriptAPI_Current ? scapi_names[compat_api] : "unknown", compat_api);
+    }
+    // If the game was compiled using unsupported version of the script API,
+    // we warn about potential incompatibilities but proceed further.
+    if (game.options[OPT_BASESCRIPTAPI] > kScriptAPI_Current)
+        platform->DisplayAlert("Warning: this game requests a higher version of AGS script API, it may not run correctly or run at all.");
+
     //
     // 1. Check that the loaded data is valid and compatible with the current
     // engine capabilities.

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -93,7 +93,7 @@ MainGameFileError game_file_first_open(MainGameSource &src)
         // Log data description for debugging
         Out::FPrint("Opened game data file: %s", src.Filename.GetCStr());
         Out::FPrint("Game data version: %d", src.DataVersion);
-        Out::FPrint("Requested engine version: %s", src.EngineVersion.LongString.GetCStr());
+        Out::FPrint("Compiled with: %s", src.CompiledWith.GetCStr());
         if (src.Caps.size() > 0)
         {
             String caps_list = get_caps_list(src.Caps);
@@ -103,8 +103,8 @@ MainGameFileError game_file_first_open(MainGameSource &src)
     // Quit in case of error
     if (err == kMGFErr_FormatVersionTooOld || err == kMGFErr_FormatVersionNotSupported)
     {
-        platform->DisplayAlert("This game requires an incompatible version of AGS (%s). It cannot be run.",
-            src.EngineVersion.LongString.GetCStr());
+        platform->DisplayAlert("This game format is not supported by the engine (game compiled with: %s).\n\nIt cannot be run.",
+            src.CompiledWith.GetCStr());
         return err;
     }
     else if (err != kMGFErr_NoError)
@@ -119,13 +119,6 @@ MainGameFileError game_file_first_open(MainGameSource &src)
             caps_list.GetCStr());
         return kMGFErr_CapsNotSupported;
     }
-
-    // If the game was compiled for higher version of the engine, and yet has
-    // supported data format, we warn about potential incompatibilities and
-    // proceed
-    if (src.EngineVersion > EngineVersion)
-        platform->DisplayAlert("This game suggests a different version of AGS (%s). It may not run correctly.",
-        src.EngineVersion.LongString.GetCStr());
     return kMGFErr_NoError;
 }
 


### PR DESCRIPTION
There is an issue with alternate versions of AGS Editor that they have no means to tag their games so that original engine could at least detect that the game does not work as expected before trying to load and run it. General data format number is not suitable for this purpose, because there is no guarantee that it won't be duplicated by "official" engine, or another alternate editor.

While there are not so many alternate versions, sometimes users try to run such games with regular engine or its port, and they receive no elaborate message why had this happened.

This change adds simply an *optional* list of strings at the game data header, called "extended capabilities". When the game is opened engine tests the required list of caps with the caps it supports.

It is true that there is no way for us to force alternate version use these to mark their, but we may at least provide means for them to tag their games with custom strings, and recommend to do it.
This set of strings may also come handy to mark any experimental builds, or perhaps for other unusual purposes in the future.