### PR TITLE
Font vertical offset property

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -92,7 +92,7 @@ Custom properties changed at runtime.
 Ambient lighting
 
 48 : 3.4.1
-OPT_RENDERATSCREENRES, extended engine caps check.
+OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 
 */
 

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -52,10 +52,12 @@ void GameSetupStruct::read_savegame_info(Common::Stream *in, GameDataVersion dat
     }
 }
 
-void GameSetupStruct::read_font_flags(Common::Stream *in)
+void GameSetupStruct::read_font_flags(Common::Stream *in, GameDataVersion data_ver)
 {
     in->Read(&fontflags[0], numfonts);
     in->Read(&fontoutline[0], numfonts);
+    if (data_ver >= kGameVersion_341)
+        in->ReadArrayOfInt32(fontvoffset, numfonts);
 }
 
 MainGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDataVersion data_ver)

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -38,6 +38,7 @@ using AGS::Common::MainGameFileError;
 struct GameSetupStruct: public GameSetupStructBase {
     unsigned char     fontflags[MAX_FONTS];
     char              fontoutline[MAX_FONTS];
+    int               fontvoffset[MAX_FONTS]; // vertical font offset
     unsigned char     spriteflags[MAX_SPRITES];
     InventoryItemInfo invinfo[MAX_INV];
     MouseCursor       mcurs[MAX_CURSOR];
@@ -88,7 +89,7 @@ struct GameSetupStruct: public GameSetupStructBase {
     //------------------------------
     // Part 1
     void read_savegame_info(Common::Stream *in, GameDataVersion data_ver);
-    void read_font_flags(Common::Stream *in);
+    void read_font_flags(Common::Stream *in, GameDataVersion data_ver);
     MainGameFileError read_sprite_flags(Common::Stream *in, GameDataVersion data_ver);
     MainGameFileError read_cursors(Common::Stream *in, GameDataVersion data_ver);
     void read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -18,11 +18,9 @@
 struct BITMAP;
 
 // WARNING: this interface is exposed for plugins and declared for the second time in agsplugin.h
-class IAGSFontRenderer {
+class IAGSFontRenderer
+{
 public:
-  // TODO: This pure virtual class should really define a virtual destructor,
-  // but I'm unsure how it would affect existing plugins using this interface.
-
   virtual bool LoadFromDisk(int fontNumber, int fontSize) = 0;
   virtual void FreeMemory(int fontNumber) = 0;
   virtual bool SupportsExtendedCharacters(int fontNumber) = 0;
@@ -35,6 +33,17 @@ public:
   virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) = 0;
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) = 0;
   virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
+};
+
+
+struct FontRenderParams;
+
+// NOTE: this extending interface is not yet exposed to plugins
+class IAGSFontRenderer2
+{
+public:
+  // Load font, applying extended font rendering parameters
+  virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params) = 0;
 };
 
 #endif // __AC_AGSFONTRENDERER_H

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -33,6 +33,7 @@ namespace BitmapHelper = AGS::Common::BitmapHelper;
 int wtext_multiply = 1;
 
 static IAGSFontRenderer* fontRenderers[MAX_FONTS];
+static IAGSFontRenderer2* fontRenderers2[MAX_FONTS];
 static TTFFontRenderer ttfRenderer;
 static WFNFontRenderer wfnRenderer;
 
@@ -44,7 +45,10 @@ void init_font_renderer()
 #endif
 
   for (int i = 0; i < MAX_FONTS; i++)
+  {
     fontRenderers[i] = NULL;
+    fontRenderers2[i] = NULL;
+  }
 }
 
 void shutdown_font_renderer()
@@ -68,6 +72,7 @@ IAGSFontRenderer* font_replace_renderer(int fontNumber, IAGSFontRenderer* render
 {
   IAGSFontRenderer* oldRender = fontRenderers[fontNumber];
   fontRenderers[fontNumber] = renderer;
+  fontRenderers2[fontNumber] = NULL;
   return oldRender;
 }
 
@@ -103,19 +108,20 @@ void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t te
 }
 
 // Loads a font from disk
-bool wloadfont_size(int fontNumber, int fsize)
+bool wloadfont_size(int fontNumber, int fsize, const FontRenderParams *params)
 {
-  if (ttfRenderer.LoadFromDisk(fontNumber, fsize))
+  if (ttfRenderer.LoadFromDiskEx(fontNumber, fsize, params))
   {
     fontRenderers[fontNumber] = &ttfRenderer;
+    fontRenderers2[fontNumber] = &ttfRenderer;
     return true;
   }
-  else if (wfnRenderer.LoadFromDisk(fontNumber, fsize))
+  else if (wfnRenderer.LoadFromDiskEx(fontNumber, fsize, params))
   {
     fontRenderers[fontNumber] = &wfnRenderer;
+    fontRenderers2[fontNumber] = &wfnRenderer;
     return true;
   }
-
   return false;
 }
 

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -20,6 +20,19 @@
 using namespace AGS;
 
 class IAGSFontRenderer;
+class IAGSFontRenderer2;
+
+// Font render params, mainly for dealing with various compatibility
+// issues and broken fonts.
+struct FontRenderParams
+{
+    int YOffset; // vertical offset for the line of text (can be negative)
+
+    FontRenderParams()
+        : YOffset(0)
+    {
+    }
+};
 
 void init_font_renderer();
 void shutdown_font_renderer();
@@ -32,7 +45,7 @@ int wgettextwidth(const char *texx, int fontNumber);
 int wgettextheight(const char *text, int fontNumber);
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, const char *texx);
 // Loads a font from disk
-bool wloadfont_size(int fontNumber, int fsize);
+bool wloadfont_size(int fontNumber, int fsize, const FontRenderParams *params = NULL);
 void wgtprintf(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, char *fmt, ...);
 void wfreefont(int fontNumber);
 

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -20,9 +20,11 @@
 #include <map>
 
 struct ALFONT_FONT;
+struct FontRenderParams;
 
-class TTFFontRenderer : public IAGSFontRenderer {
+class TTFFontRenderer : public IAGSFontRenderer, public IAGSFontRenderer2 {
 public:
+  // IAGSFontRenderer implementation
   virtual bool LoadFromDisk(int fontNumber, int fontSize);
   virtual void FreeMemory(int fontNumber);
   virtual bool SupportsExtendedCharacters(int fontNumber) { return true; }
@@ -32,8 +34,16 @@ public:
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber);
   virtual void EnsureTextValidForFont(char *text, int fontNumber);
 
+  // IAGSFontRenderer2 implementation
+  virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params);
+
 private:
-    std::map<int, ALFONT_FONT*> _fontData;
+    struct FontData
+    {
+        ALFONT_FONT     *AlFont;
+        FontRenderParams Params;
+    };
+    std::map<int, FontData> _fontData;
 };
 
 #endif // __AC_TTFFONTRENDERER_H

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -20,7 +20,7 @@
 
 #include <map>
 
-class WFNFontRenderer : public IAGSFontRenderer {
+class WFNFontRenderer : public IAGSFontRenderer, public IAGSFontRenderer2 {
 public:
   virtual bool LoadFromDisk(int fontNumber, int fontSize);
   virtual void FreeMemory(int fontNumber);
@@ -31,8 +31,15 @@ public:
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber);
   virtual void EnsureTextValidForFont(char *text, int fontNumber);
 
+  virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params);
+
 private:
-  std::map<int, WFNFont*> _fontData;
+  struct FontData
+  {
+    WFNFont         *Font;
+    FontRenderParams Params;
+  };
+  std::map<int, FontData> _fontData;
 };
 
 #endif // __AC_WFNFONTRENDERER_H

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -657,7 +657,7 @@ MainGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVer
         return kMGFErr_TooManyFonts;
 
     game.read_savegame_info(in, data_ver);
-    game.read_font_flags(in);
+    game.read_font_flags(in, data_ver);
     MainGameFileError err = game.read_sprite_flags(in, data_ver);
     if (err != kMGFErr_NoError)
         return err;

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1317,6 +1317,10 @@ namespace AGS.Editor
                     writer.Write((byte)game.Fonts[i].OutlineFont);
                 }
             }
+            for (int i = 0; i < game.Fonts.Count; ++i)
+            {
+                writer.Write(game.Fonts[i].VerticalOffset);
+            }
             writer.Write(NativeConstants.MAX_SPRITES);
             byte[] spriteFlags = new byte[NativeConstants.MAX_SPRITES];
             UpdateSpriteFlags(game.RootSpriteFolder, spriteFlags);

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -15,6 +15,7 @@ namespace AGS.Types
         private int _outlineFont;
         private FontOutlineStyle _outlineStyle;
 		private string _sourceFilename = string.Empty;
+        private int _verticalOffset;
 
         public Font()
         {
@@ -108,6 +109,14 @@ namespace AGS.Types
 			get { return _sourceFilename; }
 			set { _sourceFilename = value; }
 		}
+
+        [Description("Vertical offset to render font letters at, in pixels (can be negative)")]
+        [Category("Appearance")]
+        public int VerticalOffset
+        {
+            get { return _verticalOffset; }
+            set { _verticalOffset = value; }
+        }
 
 		[Browsable(false)]
 		public string WFNFileName

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -323,7 +323,10 @@ void LoadFonts()
         if ((game.options[OPT_NOSCALEFNT] == 0) && game.IsHiRes())
             fontsize *= 2;
 
-        if (!wloadfont_size(i, fontsize))
+        FontRenderParams params;
+        params.YOffset = game.fontvoffset[i];
+
+        if (!wloadfont_size(i, fontsize, &params))
             quitprintf("Unable to load font %d, no renderer could load a matching file", i);
     }
 }


### PR DESCRIPTION
The ALFont library currently used by AGS to draw TTF is built around very old version of the FreeType font, and also have some additional tweaks done by Chris Jones. It has an issue that it ignores font's descent parameter while keeping its real height, thus aligning font's baseline to the bottom line. This results in some fonts rendered lower than expected.

This pull request adds an optional vertical offset property to fonts, which is applied when a text line is drawn. It works for fine relative positioning of the line of text.

A note should be made that even after we upgrade or fix fonts library, this property may still come handy for dealing with backwards-compatibility cases and imperfectly designed fonts.