### PR TITLE
Split graphics mode initialization into three distinct steps

### DIFF
--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -157,6 +157,8 @@ struct Size
     }
 };
 
+// TODO: consider making Rect have right-bottom coordinate with +1 offset
+// to comply with many other libraries (i.e. Right - Left == Width)
 struct Rect
 {
 	int Left;
@@ -168,8 +170,8 @@ struct Rect
 	{
 		Left	= 0;
 		Top		= 0;
-		Right	= 0;
-		Bottom	= 0;
+		Right	= -1;
+		Bottom	= -1;
 	}
 
 	Rect(int l, int t, int r, int b)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -472,6 +472,8 @@ void init_invalid_regions(int scrnHit) {
 void destroy_invalid_regions()
 {
     delete [] dirtyRow;
+    dirtyRow = 0;
+    _dirtyRowSize = 0;
 }
 
 void update_invalid_region(Bitmap *ds, int x, int y, Bitmap *src) {

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -461,12 +461,17 @@ int IRSpan::mergeSpan(int tx1, int tx2) {
 
 void init_invalid_regions(int scrnHit) {
     numDirtyRegions = WHOLESCREENDIRTY;
-    dirtyRow = (IRRow*)malloc(sizeof(IRRow) * scrnHit);
+    dirtyRow = new IRRow[scrnHit];
     memset(dirtyRow, 0, sizeof(IRRow) * scrnHit);
 
     for (int e = 0; e < scrnHit; e++)
         dirtyRow[e].numSpans = 0;
     _dirtyRowSize = scrnHit;
+}
+
+void destroy_invalid_regions()
+{
+    delete [] dirtyRow;
 }
 
 void update_invalid_region(Bitmap *ds, int x, int y, Bitmap *src) {

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -78,6 +78,7 @@ void write_screen();
 void GfxDriverOnInitCallback(void *data);
 bool GfxDriverNullSpriteCallback(int x, int y);
 void init_invalid_regions(int scrnHit);
+void destroy_invalid_regions();
 void putpixel_compensate (Common::Bitmap *g, int xx,int yy, int col);
 // create the actsps[aa] image with the object drawn correctly
 // returns 1 if nothing at all has changed and actsps is still

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -33,11 +33,11 @@ GameSetup::GameSetup()
     mouse_control = kMouseCtrl_Fullscreen;
     mouse_speed_def = kMouseSpeed_CurrentDisplay;
 
-    Screen.MatchDeviceRatio = false;
-    Screen.SizeDef = kScreenDef_MaxDisplay;
-    Screen.RefreshRate = 0;
-    Screen.VSync = false;
-    Screen.Windowed = false;
+    Screen.DisplayMode.MatchDeviceRatio = false;
+    Screen.DisplayMode.SizeDef = kScreenDef_MaxDisplay;
+    Screen.DisplayMode.RefreshRate = 0;
+    Screen.DisplayMode.VSync = false;
+    Screen.DisplayMode.Windowed = false;
     Screen.GameFrame.ScaleDef = kFrame_MaxRound;
     Screen.GameFrame.ScaleFactor = 0;
     Screen.RenderAtScreenRes = false;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -66,6 +66,7 @@
 #include "ac/string.h"
 #include "ac/room.h"
 #include "media/audio/audio.h"
+#include "media/video/video.h"
 #include "util/string_utils.h"
 
 #include "ac/dynobj/scriptstring.h"

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -63,6 +63,7 @@ String GetRuntimeInfo()
 {
     DisplayMode mode = gfxDriver->GetDisplayMode();
     Rect render_frame = gfxDriver->GetRenderDestination();
+    PGfxFilter filter = gfxDriver->GetGraphicsFilter();
     String runtimeInfo = String::FromFormat(
         "Adventure Game Studio run-time engine[ACI version %s"
         "[Game resolution %d x %d"

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -12,128 +12,18 @@
 //
 //=============================================================================
 
-#define USE_CLIB
-#include <stdio.h>
-#include "ac/global_video.h"
-#include "ac/common.h"
-#include "ac/draw.h"
+#include <allegro.h>
+#include "ac/file.h"
 #include "ac/gamesetup.h"
-#include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
+#include "ac/global_audio.h"
 #include "ac/global_game.h"
-#include "ac/mouse.h"
-#include "ac/record.h"
+#include "ac/global_video.h"
+#include "debug/agseditordebugger.h"
 #include "debug/debug_log.h"
-#include "debug/debugger.h"
-#include "debug/out.h"
+#include "media/audio/audio.h"
 #include "media/video/video.h"
-#include "util/stream.h"
-#include "gfx/graphicsdriver.h"
-#include "gfx/bitmap.h"
-#include "core/assetmanager.h"
-#include "main/graphics_mode.h"
 
-using namespace AGS::Common;
-using namespace AGS::Engine;
-
-extern GameSetup usetup;
-extern GameSetupStruct game;
-extern GameState play;
-
-// defined in media/video/video.h
-extern int canabort, stretch_flc;
-extern short fliwidth,fliheight;
-extern Bitmap *hicol_buf;
-extern Bitmap *fli_buffer;
-extern IDriverDependantBitmap *fli_ddb;
-extern Bitmap *fli_target;
-extern IGraphicsDriver *gfxDriver;
-
-void play_flc_file(int numb,int playflags) {
-    color oldpal[256];
-
-    // AGS 2.x: If the screen is faded out, fade in again when playing a movie.
-    if (loaded_game_file_version <= kGameVersion_272)
-        play.screen_is_faded_out = 0;
-
-    if (play.fast_forward)
-        return;
-
-    get_palette_range(oldpal, 0, 255);
-
-    int clearScreenAtStart = 1;
-    canabort = playflags % 10;
-    playflags -= canabort;
-
-    if (canabort == 2) // convert to PlayVideo-compatible setting
-        canabort = 3;
-
-    if (playflags % 100 == 0)
-        stretch_flc = 1;
-    else
-        stretch_flc = 0;
-
-    if (playflags / 100)
-        clearScreenAtStart = 0;
-
-    char flicnam[20]; sprintf(flicnam,"flic%d.flc",numb);
-    Stream*in=Common::AssetManager::OpenAsset(flicnam);
-    if (in==NULL) { sprintf(flicnam,"flic%d.fli",numb);
-    in=Common::AssetManager::OpenAsset(flicnam); }
-    if (in==NULL) {
-        debug_log("FLIC animation FLIC%d.FLC not found",numb);
-        return;
-    }
-    in->Seek(8);
-    fliwidth = in->ReadInt16();
-    fliheight = in->ReadInt16();
-    delete in;
-    if (game.color_depth > 1) {
-        hicol_buf=BitmapHelper::CreateBitmap(fliwidth,fliheight,ScreenResolution.ColorDepth);
-        hicol_buf->Clear();
-    }
-    // override the stretch option if necessary
-    if ((fliwidth==play.viewport.GetWidth()) && (fliheight==play.viewport.GetHeight()))
-        stretch_flc = 0;
-    else if ((fliwidth > play.viewport.GetWidth()) || (fliheight > play.viewport.GetHeight()))
-        stretch_flc = 1;
-    fli_buffer=BitmapHelper::CreateBitmap(fliwidth,fliheight,8); //640,400); //play.viewport.GetWidth(),play.viewport.GetHeight());
-    if (fli_buffer==NULL) quit("Not enough memory to play animation");
-    fli_buffer->Clear();
-
-	Bitmap *screen_bmp = BitmapHelper::GetScreenBitmap();
-
-    if (clearScreenAtStart) {
-		screen_bmp->Clear();
-        render_to_screen(screen_bmp, 0, 0);
-    }
-
-    fli_target = BitmapHelper::CreateBitmap(screen_bmp->GetWidth(), screen_bmp->GetHeight(), ScreenResolution.ColorDepth);
-    fli_ddb = gfxDriver->CreateDDBFromBitmap(fli_target, false, true);
-
-	if (play_fli(flicnam,(BITMAP*)fli_buffer->GetAllegroBitmap(),0,fli_callback)==FLI_ERROR)
-    {
-        // This is not a fatal error that should prevent the game from continuing
-        //quit("FLI/FLC animation play error");
-        Out::FPrint("FLI/FLC animation play error");
-    }
-
-    delete fli_buffer;
-	screen_bmp->Clear();
-    set_palette_range(oldpal, 0, 255, 0);
-    render_to_screen(screen_bmp, 0, 0);
-
-    delete fli_target;
-    gfxDriver->DestroyDDB(fli_ddb);
-    fli_ddb = NULL;
-
-    
-    delete hicol_buf;
-    hicol_buf=NULL;
-    //  SetVirtualScreen(screen); wputblock(0,0,backbuffer,0);
-    while (mgetbutton()!=NONE) ;
-    invalidate_screen();
-}
 
 void scrPlayVideo(const char* name, int skip, int flags) {
     EndSkippingUntilCharStops();
@@ -150,4 +40,36 @@ void scrPlayVideo(const char* name, int skip, int flags) {
     }
 
     pause_sound_if_necessary_and_play_video(name, skip, flags);
+}
+
+void pause_sound_if_necessary_and_play_video(const char *name, int skip, int flags)
+{
+    int musplaying = play.cur_music_number, i;
+    int ambientWas[MAX_SOUND_CHANNELS];
+    for (i = 1; i < MAX_SOUND_CHANNELS; i++)
+        ambientWas[i] = ambient[i].channel;
+
+    if ((strlen(name) > 3) && (stricmp(&name[strlen(name) - 3], "ogv") == 0))
+    {
+        play_theora_video(name, skip, flags);
+    }
+    else
+    {
+        char videoFilePath[MAX_PATH];
+        get_current_dir_path(videoFilePath, name);
+
+        platform->PlayVideo(videoFilePath, skip, flags);
+    }
+
+    if (flags < 10) 
+    {
+        update_music_volume();
+        // restart the music
+        if (musplaying >= 0)
+            newmusic (musplaying);
+        for (i = 1; i < MAX_SOUND_CHANNELS; i++) {
+            if (ambientWas[i] > 0)
+                PlayAmbientSound(ambientWas[i], ambient[i].num, ambient[i].vol, ambient[i].x, ambient[i].y);
+        }
+    }
 }

--- a/Engine/ac/global_video.h
+++ b/Engine/ac/global_video.h
@@ -18,7 +18,7 @@
 #ifndef __AGS_EE_AC__GLOBALVIDEO_H
 #define __AGS_EE_AC__GLOBALVIDEO_H
 
-void play_flc_file(int numb,int playflags);
 void scrPlayVideo(const char* name, int skip, int flags);
+void pause_sound_if_necessary_and_play_video(const char *name, int skip, int flags);
 
 #endif // __AGS_EE_AC__GLOBALVIDEO_H

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1049,7 +1049,7 @@ void OGLGraphicsDriver::DestroyDDB(IDriverDependantBitmap* bitmap)
       drawListLastTime[i].skip = true;
     }
   }
-  delete ((OGLBitmap*)bitmap);
+  delete bitmap;
 }
 
 __inline void get_pixel_if_not_transparent15(unsigned short *pixel, unsigned short *red, unsigned short *green, unsigned short *blue, unsigned short *divisor)

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -253,7 +253,6 @@ OGLGraphicsDriver::OGLGraphicsDriver()
   _tint_red = 0;
   _tint_green = 0;
   _tint_blue = 0;
-  _filter = NULL;
   _screenTintLayer = NULL;
   _screenTintLayerDDB = NULL;
   _screenTintSprite.skip = true;
@@ -314,7 +313,7 @@ void OGLGraphicsDriver::SetGamma(int newGamma)
 {
 }
 
-void OGLGraphicsDriver::SetGraphicsFilter(OGLGfxFilter *filter)
+void OGLGraphicsDriver::SetGraphicsFilter(POGLFilter filter)
 {
   _filter = filter;
   OnSetFilter();
@@ -694,7 +693,7 @@ IGfxModeList *OGLGraphicsDriver::GetSupportedModeList(int color_depth)
     return NULL;
 }
 
-IGfxFilter *OGLGraphicsDriver::GetGraphicsFilter() const
+PGfxFilter OGLGraphicsDriver::GetGraphicsFilter() const
 {
     return _filter;
 }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -551,12 +551,6 @@ void OGLGraphicsDriver::SetupViewport()
 
 bool OGLGraphicsDriver::Init(const DisplayMode &mode_, volatile int *loopTimer)
 {
-#if defined(ANDROID_VERSION)
-  android_create_screen(mode.Width, mode.Height, mode.ColorDepth);
-#elif defined(IOS_VERSION)
-  ios_create_screen();
-#endif
-
   // TODO: OpenGL renderer is incomplete and requires to do certain hacks to work,
   // like forcing windowed mode, this is why we create mutable DisplayMode here
   DisplayMode mode = mode_;
@@ -565,8 +559,13 @@ bool OGLGraphicsDriver::Init(const DisplayMode &mode_, volatile int *loopTimer)
     set_allegro_error("OpenGL driver does not support 256-colour games");
     return false;
   }
-  
   mode.Windowed = true;
+
+#if defined(ANDROID_VERSION)
+  android_create_screen(mode.Width, mode.Height, mode.ColorDepth);
+#elif defined(IOS_VERSION)
+  ios_create_screen();
+#endif
 
   if (psp_gfx_renderer == 2)
   {

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -19,6 +19,8 @@
 #ifndef __AGS_EE_GFX__ALI3DOGL_H
 #define __AGS_EE_GFX__ALI3DOGL_H
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include <allegro.h>
 #include "gfx/bitmap.h"
 #include "gfx/ddb.h"
@@ -190,7 +192,7 @@ public:
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
-    virtual IGfxFilter *GetGraphicsFilter() const;
+    virtual PGfxFilter GetGraphicsFilter() const;
     virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) { _pollingCallback = callback; }
     virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) { _drawScreenCallback = callback; }
     virtual void SetCallbackOnInit(GFXDRV_CLIENTCALLBACKINITGFX callback) { _initGfxCallback = callback; }
@@ -224,7 +226,9 @@ public:
     virtual void SetMemoryBackBuffer(Bitmap *backBuffer) {  }
     virtual void SetScreenTint(int red, int green, int blue);
 
-    void SetGraphicsFilter(OGLGfxFilter *filter);
+    typedef stdtr1compat::shared_ptr<OGLGfxFilter> POGLFilter;
+
+    void SetGraphicsFilter(POGLFilter filter);
 
     // Internal
     void _render(GlobalFlipType flip, bool clearDrawListAfterwards);
@@ -232,9 +236,9 @@ public:
     OGLGraphicsDriver();
     virtual ~OGLGraphicsDriver();
 
-    OGLGfxFilter *_filter;
-
 private:
+    POGLFilter _filter;
+
     HDC _hDC;
     HGLRC _hRC;
     HWND _hWnd;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -186,7 +186,8 @@ public:
     virtual const char*GetDriverName() { return "OpenGL"; }
     virtual const char*GetDriverID() { return "OGL"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer);
+    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxFilter *GetGraphicsFilter() const;
@@ -272,9 +273,11 @@ private:
     void set_up_default_vertices();
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
     void UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha);
+    void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void create_screen_tint_bitmap();
     void _renderSprite(SpriteDrawListEntry *entry, bool globalLeftRightFlip, bool globalTopBottomFlip);
+    void SetupViewport();
     void create_backbuffer_arrays();
 };
 

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -318,8 +318,7 @@ void ALSoftwareGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitma
 
 void ALSoftwareGraphicsDriver::DestroyDDB(IDriverDependantBitmap* bitmap)
 {
-  ALSoftwareBitmap* bmpToDelete = (ALSoftwareBitmap*)bitmap;
-  delete bmpToDelete;
+  delete bitmap;
 }
 
 void ALSoftwareGraphicsDriver::DrawSprite(int x, int y, IDriverDependantBitmap* bitmap)

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -123,7 +123,7 @@ IGfxModeList *ALSoftwareGraphicsDriver::GetSupportedModeList(int color_depth)
   return new ALSoftwareGfxModeList(_gfxModeList);
 }
 
-IGfxFilter *ALSoftwareGraphicsDriver::GetGraphicsFilter() const
+PGfxFilter ALSoftwareGraphicsDriver::GetGraphicsFilter() const
 {
     return _filter;
 }
@@ -145,7 +145,7 @@ int ALSoftwareGraphicsDriver::GetAllegroGfxDriverID(bool windowed)
 #endif
 }
 
-void ALSoftwareGraphicsDriver::SetGraphicsFilter(AllegroGfxFilter *filter)
+void ALSoftwareGraphicsDriver::SetGraphicsFilter(PALSWFilter filter)
 {
   _filter = filter;
   OnSetFilter();

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -144,7 +144,8 @@ public:
     virtual const char*GetDriverName() { return "Allegro/DX5"; }
     virtual const char*GetDriverID() { return "DX5"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer);
+    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual IGfxFilter *GetGraphicsFilter() const;
@@ -190,6 +191,9 @@ public:
 private:
     bool _autoVsync;
     Bitmap *_allegroScreenWrapper;
+    // Virtual screen bitmap is either a wrapper over Allegro's real screen
+    // bitmap, or bitmap provided by the graphics filter. It should not be
+    // disposed by the renderer: it is up to filter object to manage it.
     Bitmap *virtualScreen;
     Bitmap *_spareTintingScreen;
     GFXDRV_CLIENTCALLBACK _callback;
@@ -212,6 +216,9 @@ private:
     DDGAMMARAMP defaultGammaRamp;
     DDCAPS ddrawCaps;
 #endif
+
+    // Use gfx filter to create a new virtual screen
+    void CreateVirtualScreen();
 
     void highcolor_fade_out(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void highcolor_fade_in(Bitmap *bmp_orig, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -19,6 +19,8 @@
 #ifndef __AGS_EE_GFX__ALI3DSW_H
 #define __AGS_EE_GFX__ALI3DSW_H
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include <allegro.h>
 #if defined (WINDOWS_VERSION)
 #include <winalleg.h>
@@ -123,7 +125,6 @@ class ALSoftwareGraphicsDriver : public GraphicsDriverBase
 {
 public:
     ALSoftwareGraphicsDriver() { 
-        _filter = NULL; 
         _callback = NULL; 
         _drawScreenCallback = NULL;
         _nullSpriteCallback = NULL;
@@ -148,7 +149,7 @@ public:
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
-    virtual IGfxFilter *GetGraphicsFilter() const;
+    virtual PGfxFilter GetGraphicsFilter() const;
     virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) { _callback = callback; }
     virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) { _drawScreenCallback = callback; }
     virtual void SetCallbackOnInit(GFXDRV_CLIENTCALLBACKINITGFX callback) { _initGfxCallback = callback; }
@@ -184,11 +185,13 @@ public:
         _tint_red = red; _tint_green = green; _tint_blue = blue; }
     virtual ~ALSoftwareGraphicsDriver();
 
-    void SetGraphicsFilter(AllegroGfxFilter *filter);
+    typedef stdtr1compat::shared_ptr<AllegroGfxFilter> PALSWFilter;
 
-    AllegroGfxFilter *_filter;
+    void SetGraphicsFilter(PALSWFilter filter);
 
 private:
+    PALSWFilter _filter;
+
     bool _autoVsync;
     Bitmap *_allegroScreenWrapper;
     // Virtual screen bitmap is either a wrapper over Allegro's real screen

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -26,6 +26,8 @@ namespace Engine
 class IDriverDependantBitmap
 {
 public:
+  virtual ~IDriverDependantBitmap(){}
+
   virtual void SetTransparency(int transparency) = 0;  // 0-255
   virtual void SetFlippedLeftRight(bool isFlipped) = 0;
   virtual void SetStretch(int width, int height) = 0;

--- a/Engine/gfx/gfxdefines.h
+++ b/Engine/gfx/gfxdefines.h
@@ -30,6 +30,7 @@ enum GlobalFlipType
     kFlip_Both
 };
 
+// GraphicResolution dtruct determines image size and color depth
 struct GraphicResolution
 {
     int32_t Width;
@@ -50,6 +51,28 @@ struct GraphicResolution
         ColorDepth = color_depth;
     }
 };
+
+// DisplayMode struct provides extended description of display mode
+struct DisplayMode : public GraphicResolution
+{
+    int32_t RefreshRate;
+    bool    Vsync;
+    bool    Windowed;
+
+    DisplayMode()
+        : RefreshRate(0)
+        , Vsync(false)
+        , Windowed(false)
+    {}
+
+    DisplayMode(const GraphicResolution &res, bool windowed, int32_t refresh, bool vsync)
+        : GraphicResolution(res)
+        , RefreshRate(refresh)
+        , Vsync(vsync)
+        , Windowed(windowed)
+    {}
+};
+
 
 } // namespace Engine
 } // namespace AGS

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -69,7 +69,7 @@ void GraphicsDriverBase::OnSetRenderFrame(const Size &src_size, const Rect &dst_
 {
     _srcRect = RectWH(0, 0, src_size.Width, src_size.Height);
     _dstRect = dst_rect;
-    IGfxFilter *filter = GetGraphicsFilter();
+    PGfxFilter filter = GetGraphicsFilter();
     if (filter)
         _filterRect = filter->SetTranslation(src_size, dst_rect);
     else

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -29,6 +29,16 @@ GraphicsDriverBase::GraphicsDriverBase()
 {
 }
 
+bool GraphicsDriverBase::IsModeSet() const
+{
+    return _mode.Width != 0 && _mode.Height != 0 && _mode.ColorDepth != 0;
+}
+
+bool GraphicsDriverBase::IsRenderFrameValid() const
+{
+    return !_srcRect.IsEmpty() && !_dstRect.IsEmpty();
+}
+
 DisplayMode GraphicsDriverBase::GetDisplayMode() const
 {
     return _mode;
@@ -45,18 +55,31 @@ void GraphicsDriverBase::SetRenderOffset(int x, int y)
     _global_y_offset = y;
 }
 
-void GraphicsDriverBase::_Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer)
+void GraphicsDriverBase::OnInit(const DisplayMode &mode, volatile int *loopTimer)
 {
     _mode = mode;
+    _loopTimer = loopTimer;
+}
+
+void GraphicsDriverBase::OnUnInit()
+{
+}
+
+void GraphicsDriverBase::OnSetRenderFrame(const Size &src_size, const Rect &dst_rect)
+{
     _srcRect = RectWH(0, 0, src_size.Width, src_size.Height);
     _dstRect = dst_rect;
-    _loopTimer = loopTimer;
-    _filterRect = GetGraphicsFilter()->SetTranslation(src_size, dst_rect);
+    IGfxFilter *filter = GetGraphicsFilter();
+    if (filter)
+        _filterRect = filter->SetTranslation(src_size, dst_rect);
+    else
+        _filterRect = Rect();
     _scaling.Init(src_size, dst_rect);
 }
 
-void GraphicsDriverBase::_UnInit()
+void GraphicsDriverBase::OnSetFilter()
 {
+    _filterRect = GetGraphicsFilter()->SetTranslation(Size(_srcRect.GetSize()), _dstRect);
 }
 
 } // namespace Engine

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -31,13 +31,21 @@ class GraphicsDriverBase : public IGraphicsDriver
 public:
     GraphicsDriverBase();
 
+    virtual bool        IsModeSet() const;
+    virtual bool        IsRenderFrameValid() const;
     virtual DisplayMode GetDisplayMode() const;
     virtual Rect        GetRenderDestination() const;
     virtual void        SetRenderOffset(int x, int y);
 
 protected:
-    void _Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer);
-    void _UnInit();
+    // Called after new mode was successfully initialized
+    virtual void OnInit(const DisplayMode &mode, volatile int *loopTimer);
+    // Called after graphics mode was uninitialized
+    virtual void OnUnInit();
+    // Called when new render frame is set
+    virtual void OnSetRenderFrame(const Size &src_size, const Rect &dst_rect);
+    // Called when the new filter is set
+    virtual void OnSetFilter();
 
     DisplayMode         _mode;          // display mode settings
     Rect                _srcRect;       // rendering source rect

--- a/Engine/gfx/gfxdriverfactory.h
+++ b/Engine/gfx/gfxdriverfactory.h
@@ -60,7 +60,7 @@ public:
     virtual String               GetDefaultFilterID() const = 0;
 
     // Assign specified filter to graphics driver
-    virtual IGfxFilter *         SetFilter(const String &id) = 0;
+    virtual IGfxFilter *         SetFilter(const String &id, String &filter_error) = 0;
 };
 
 // Query the available graphics factory names

--- a/Engine/gfx/gfxdriverfactory.h
+++ b/Engine/gfx/gfxdriverfactory.h
@@ -23,6 +23,8 @@
 #ifndef __AGS_EE_GFX__GFXDRIVERFACTORY_H
 #define __AGS_EE_GFX__GFXDRIVERFACTORY_H
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include "util/string.h"
 #include "util/string_types.h"
 
@@ -36,6 +38,8 @@ using Common::StringV;
 class IGraphicsDriver;
 class IGfxFilter;
 struct GfxFilterInfo;
+typedef stdtr1compat::shared_ptr<IGfxFilter> PGfxFilter;
+
 
 class IGfxDriverFactory
 {
@@ -60,7 +64,7 @@ public:
     virtual String               GetDefaultFilterID() const = 0;
 
     // Assign specified filter to graphics driver
-    virtual IGfxFilter *         SetFilter(const String &id, String &filter_error) = 0;
+    virtual PGfxFilter           SetFilter(const String &id, String &filter_error) = 0;
 };
 
 // Query the available graphics factory names

--- a/Engine/gfx/gfxdriverfactorybase.h
+++ b/Engine/gfx/gfxdriverfactorybase.h
@@ -60,33 +60,32 @@ public:
         _driver = NULL;
     }
 
-    virtual IGfxFilter *SetFilter(const String &id, String &filter_error)
+    virtual PGfxFilter SetFilter(const String &id, String &filter_error)
     {
         TGfxDriverClass *driver = EnsureDriverCreated();
         if (!driver)
         {
             filter_error = "Graphics driver was not created";
-            return NULL;
+            return PGfxFilter();
         }
 
         const int color_depth = driver->GetDisplayMode().ColorDepth;
         if (color_depth == 0)
         {
             filter_error = "Graphics mode is not set";
-            return NULL;
+            return PGfxFilter();
         }
 
-        TGfxFilterClass *filter = CreateFilter(id);
+        stdtr1compat::shared_ptr<TGfxFilterClass> filter(CreateFilter(id));
         if (!filter)
         {
             filter_error = "Filter does not exist";
-            return NULL;
+            return PGfxFilter();
         }
 
         if (!filter->Initialize(color_depth, filter_error))
         {
-            delete filter;
-            return NULL;
+            return PGfxFilter();
         }
 
         driver->SetGraphicsFilter(filter);

--- a/Engine/gfx/gfxdriverfactorybase.h
+++ b/Engine/gfx/gfxdriverfactorybase.h
@@ -60,15 +60,36 @@ public:
         _driver = NULL;
     }
 
-    virtual IGfxFilter *SetFilter(const String &id)
+    virtual IGfxFilter *SetFilter(const String &id, String &filter_error)
     {
         TGfxDriverClass *driver = EnsureDriverCreated();
         if (!driver)
+        {
+            filter_error = "Graphics driver was not created";
             return NULL;
+        }
+
+        const int color_depth = driver->GetDisplayMode().ColorDepth;
+        if (color_depth == 0)
+        {
+            filter_error = "Graphics mode is not set";
+            return NULL;
+        }
 
         TGfxFilterClass *filter = CreateFilter(id);
-        if (filter)
-            driver->SetGraphicsFilter(filter);
+        if (!filter)
+        {
+            filter_error = "Filter does not exist";
+            return NULL;
+        }
+
+        if (!filter->Initialize(color_depth, filter_error))
+        {
+            delete filter;
+            return NULL;
+        }
+
+        driver->SetGraphicsFilter(filter);
         return filter;
     }
 

--- a/Engine/gfx/gfxfilter.h
+++ b/Engine/gfx/gfxfilter.h
@@ -19,6 +19,8 @@
 #ifndef __AGS_EE_GFX__GFXFILTER_H
 #define __AGS_EE_GFX__GFXFILTER_H
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include "util/geometry.h"
 #include "util/string.h"
 
@@ -61,6 +63,8 @@ public:
     // Get defined destination rect for this filter
     virtual Rect GetDestination() const = 0;
 };
+
+typedef stdtr1compat::shared_ptr<IGfxFilter> PGfxFilter;
 
 } // namespace Engine
 } // namespace AGS

--- a/Engine/gfx/gfxmodelist.h
+++ b/Engine/gfx/gfxmodelist.h
@@ -19,31 +19,12 @@
 #define __AGS_EE_GFX__GFXMODELIST_H
 
 #include "core/types.h"
+#include "gfx/gfxdefines.h"
 
 namespace AGS
 {
 namespace Engine
 {
-
-struct DisplayMode : public GraphicResolution
-{
-    int32_t RefreshRate;
-    bool    Vsync;
-    bool    Windowed;
-
-    DisplayMode()
-        : RefreshRate(0)
-        , Vsync(false)
-        , Windowed(false)
-    {}
-
-    DisplayMode(const GraphicResolution &res, bool windowed, int32_t refresh, bool vsync)
-        : GraphicResolution(res)
-        , RefreshRate(refresh)
-        , Vsync(vsync)
-        , Windowed(windowed)
-    {}
-};
 
 class IGfxModeList
 {

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -19,6 +19,8 @@
 #ifndef __AGS_EE_GFX__GRAPHICSDRIVER_H
 #define __AGS_EE_GFX__GRAPHICSDRIVER_H
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include "gfx/gfxdefines.h"
 #include "gfx/gfxmodelist.h"
 #include "util/geometry.h"
@@ -34,6 +36,7 @@ namespace Engine
 // Forward declaration
 class IDriverDependantBitmap;
 class IGfxFilter;
+typedef stdtr1compat::shared_ptr<IGfxFilter> PGfxFilter;
 
 enum TintMethod
 {
@@ -69,7 +72,7 @@ public:
   virtual IGfxModeList *GetSupportedModeList(int color_depth) = 0;
   virtual bool IsModeSupported(const DisplayMode &mode) = 0;
   virtual DisplayMode GetDisplayMode() const = 0;
-  virtual IGfxFilter *GetGraphicsFilter() const = 0;
+  virtual PGfxFilter GetGraphicsFilter() const = 0;
   virtual Rect GetRenderDestination() const = 0;
   virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) = 0;
   virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) = 0;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -59,7 +59,13 @@ public:
   virtual const char*GetDriverName() = 0;
   virtual const char*GetDriverID() = 0;
   virtual void SetTintMethod(TintMethod method) = 0;
-  virtual bool Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer) = 0;
+  // Initialize given display mode
+  virtual bool Init(const DisplayMode &mode, volatile int *loopTimer) = 0;
+  // Gets if a graphics mode was initialized
+  virtual bool IsModeSet() const = 0;
+  // Set game render frame and translation
+  virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect) = 0;
+  virtual bool IsRenderFrameValid() const = 0;
   virtual IGfxModeList *GetSupportedModeList(int color_depth) = 0;
   virtual bool IsModeSupported(const DisplayMode &mode) = 0;
   virtual DisplayMode GetDisplayMode() const = 0;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -265,7 +265,7 @@ void read_game_data_location(const ConfigTree &cfg)
 
 void read_legacy_graphics_config(const ConfigTree &cfg, const bool should_read_filter)
 {
-    usetup.Screen.Windowed = INIreadint(cfg, "misc", "windowed") > 0;
+    usetup.Screen.DisplayMode.Windowed = INIreadint(cfg, "misc", "windowed") > 0;
     usetup.Screen.DriverID = INIreadstring(cfg, "misc", "gfxdriver");
 
     if (should_read_filter)
@@ -273,7 +273,7 @@ void read_legacy_graphics_config(const ConfigTree &cfg, const bool should_read_f
         String legacy_filter = INIreadstring(cfg, "misc", "gfxfilter");
         if (!legacy_filter.IsEmpty())
         {
-            usetup.Screen.SizeDef = kScreenDef_ByGameScaling;
+            usetup.Screen.DisplayMode.SizeDef = kScreenDef_ByGameScaling;
 
             int scale_factor;
             if (parse_legacy_frame_config(legacy_filter, usetup.Screen.Filter.ID, usetup.Screen.GameFrame.ScaleDef, scale_factor))
@@ -282,16 +282,16 @@ void read_legacy_graphics_config(const ConfigTree &cfg, const bool should_read_f
             }
 
             // AGS 3.2.1 and 3.3.0 aspect ratio preferences
-            if (!usetup.Screen.Windowed)
+            if (!usetup.Screen.DisplayMode.Windowed)
             {
-                usetup.Screen.MatchDeviceRatio =
+                usetup.Screen.DisplayMode.MatchDeviceRatio =
                     (INIreadint(cfg, "misc", "sideborders") > 0 || INIreadint(cfg, "misc", "forceletterbox") > 0 ||
                      INIreadint(cfg, "misc", "prefer_sideborders") > 0 || INIreadint(cfg, "misc", "prefer_letterbox") > 0);
             }
         }
     }
 
-    usetup.Screen.RefreshRate = INIreadint(cfg, "misc", "refresh");
+    usetup.Screen.DisplayMode.RefreshRate = INIreadint(cfg, "misc", "refresh");
 }
 
 void read_config(const ConfigTree &cfg)
@@ -340,22 +340,22 @@ void read_config(const ConfigTree &cfg)
 #else
         usetup.Screen.DriverID = "DX5";
 #endif
-        usetup.Screen.Windowed = INIreadint(cfg, "graphics", "windowed") > 0;
+        usetup.Screen.DisplayMode.Windowed = INIreadint(cfg, "graphics", "windowed") > 0;
         const char *screen_sz_def_options[kNumScreenDef] = { "explicit", "scaling", "max" };
-        usetup.Screen.SizeDef = kScreenDef_MaxDisplay;
+        usetup.Screen.DisplayMode.SizeDef = kScreenDef_MaxDisplay;
         String screen_sz_def_str = INIreadstring(cfg, "graphics", "screen_def");
         for (int i = 0; i < kNumScreenDef; ++i)
         {
             if (screen_sz_def_str.CompareNoCase(screen_sz_def_options[i]) == 0)
             {
-                usetup.Screen.SizeDef = (ScreenSizeDefinition)i;
+                usetup.Screen.DisplayMode.SizeDef = (ScreenSizeDefinition)i;
                 break;
             }
         }
 
-        usetup.Screen.Size.Width = INIreadint(cfg, "graphics", "screen_width");
-        usetup.Screen.Size.Height = INIreadint(cfg, "graphics", "screen_height");
-        usetup.Screen.MatchDeviceRatio = INIreadint(cfg, "graphics", "match_device_ratio", 1) != 0;
+        usetup.Screen.DisplayMode.Size.Width = INIreadint(cfg, "graphics", "screen_width");
+        usetup.Screen.DisplayMode.Size.Height = INIreadint(cfg, "graphics", "screen_height");
+        usetup.Screen.DisplayMode.MatchDeviceRatio = INIreadint(cfg, "graphics", "match_device_ratio", 1) != 0;
 #if defined(IOS_VERSION) || defined(PSP_VERSION) || defined(ANDROID_VERSION)
         // PSP: No graphic filters are available.
         usetup.Screen.Filter.ID = "";
@@ -370,8 +370,8 @@ void read_config(const ConfigTree &cfg)
         }
 #endif
 
-        usetup.Screen.RefreshRate = INIreadint(cfg, "graphics", "refresh");
-        usetup.Screen.VSync = INIreadint(cfg, "graphics", "vsync") > 0;
+        usetup.Screen.DisplayMode.RefreshRate = INIreadint(cfg, "graphics", "refresh");
+        usetup.Screen.DisplayMode.VSync = INIreadint(cfg, "graphics", "vsync") > 0;
         usetup.Screen.RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres") > 0;
 
         usetup.enable_antialiasing = INIreadint(cfg, "misc", "antialias") > 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -215,13 +215,14 @@ bool engine_check_run_setup(ConfigTree &cfg, int argc,char*argv[])
 void engine_force_window()
 {
     // Force to run in a window, override the config file
+    // TODO: actually overwrite config tree instead
     if (force_window == 1)
     {
-        usetup.Screen.Windowed = true;
-        usetup.Screen.SizeDef = kScreenDef_ByGameScaling;
+        usetup.Screen.DisplayMode.Windowed = true;
+        usetup.Screen.DisplayMode.SizeDef = kScreenDef_ByGameScaling;
     }
     else if (force_window == 2)
-        usetup.Screen.Windowed = false;
+        usetup.Screen.DisplayMode.Windowed = false;
 }
 
 void init_game_file_name_from_cmdline()
@@ -1520,7 +1521,7 @@ bool engine_try_set_gfxmode_any(const ScreenSetup &setup)
 
     ColorDepthOption color_depths;
     engine_get_color_depths(color_depths);
-    if (!graphics_mode_init_any(setup, color_depths))
+    if (!graphics_mode_init_any(game.size, setup, color_depths))
         return false;
 
     engine_post_gfxmode_setup(init_desktop);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1520,7 +1520,7 @@ bool engine_try_set_gfxmode_any(const ScreenSetup &setup)
 
     ColorDepthOption color_depths;
     engine_get_color_depths(color_depths);
-    if (!graphics_mode_init(setup, color_depths))
+    if (!graphics_mode_init_any(setup, color_depths))
         return false;
 
     engine_post_gfxmode_setup(init_desktop);

--- a/Engine/main/engine.h
+++ b/Engine/main/engine.h
@@ -24,6 +24,14 @@ void		engine_init_game_settings();
 int         initialize_engine(int argc,char*argv[]);
 int			initialize_engine_with_exception_handling(int argc,char*argv[]);
 
+struct ScreenSetup;
+// Try to set new graphics mode deduced from given configuration;
+// if requested mode fails, tries to find any compatible mode close to the
+// requested one.
+bool        engine_try_set_gfxmode_any(const ScreenSetup &setup);
+// Shutdown graphics mode (used before shutting down tha application)
+void        engine_shutdown_gfxmode();
+
 extern char *music_file;
 extern char *speech_file;
 

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -422,10 +422,21 @@ void engine_post_gfxmode_mouse_setup(const Size &init_desktop)
     Out::FPrint("Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",
         Mouse::GetSpeedUnit(), Mouse::GetSpeed());
 
+    // The virtual->real conversion ratios could have change after new gfx mode is set,
+    // thus we need to reset mouse graphic area and bounds
     Mouse::SetGraphicArea();
+    Mouse::SetMoveLimit(Rect(play.mboundx1, play.mboundy1, play.mboundx2, play.mboundy2));
     // If auto lock option is set, lock mouse to the game window
     if (usetup.mouse_auto_lock && scsystem.windowed != 0)
         Mouse::TryLockToWindow();
+}
+
+// Reset mouse controls before changing gfx mode
+void engine_pre_gfxmode_mouse_cleanup()
+{
+    // Always disable mouse control unlock mouse when shutting down gfx mode
+    Mouse::DisableControl();
+    Mouse::UnlockFromWindow();
 }
 
 // Fill in scsystem struct with display mode parameters
@@ -460,6 +471,7 @@ void engine_post_gfxmode_setup(const Size &init_desktop)
 
 void engine_pre_gfxmode_shutdown()
 {
+    engine_pre_gfxmode_mouse_cleanup();
     engine_pre_gfxmode_draw_cleanup();
     engine_pre_gfxmode_screen_cleanup();
     engine_pre_gfxmode_driver_cleanup();

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -31,6 +31,7 @@
 #include "gui/guiinv.h"
 #include "main/graphics_mode.h"
 #include "main/engine_setup.h"
+#include "media/video/video.h"
 #include "platform/base/agsplatformdriver.h"
 
 using namespace AGS::Common;
@@ -449,6 +450,8 @@ void engine_post_gfxmode_setup(const Size &init_desktop)
     // has anything to do with graphics mode at all. It is quite possible
     // that we may split it into two functions, or remove parameter.
     platform->PostAllegroInit(scsystem.windowed != 0);
+
+    video_on_gfxmode_changed();
 }
 
 void engine_pre_gfxmode_shutdown()

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -379,6 +379,10 @@ void engine_post_gfxmode_draw_setup()
         walkBehindMethod = DrawAsSeparateSprite;
         CreateBlankImage();
     }
+    else
+    {
+        walkBehindMethod = DrawOverCharSprite;
+    }
     init_invalid_regions(game.size.Height);
 }
 

--- a/Engine/main/engine_setup.h
+++ b/Engine/main/engine_setup.h
@@ -18,10 +18,14 @@
 
 struct ColorDepthOption;
 
+// Get color depth settings depending on game settings and user config
+void engine_get_color_depths(ColorDepthOption &color_depths);
 // Sets up game viewport and object scaling parameters depending on game and
 // user config; fills in color depth options.
-void engine_init_resolution_settings(const Size game_size, ColorDepthOption &color_depths);
-// Setup rendering callbacks and color conversions depending on initialized gfx mode
+void engine_init_resolution_settings(const Size game_size);
+// Setup engine after the graphics mode has changed
 void engine_post_gfxmode_setup(const Size &init_desktop);
+// Prepare engine to the graphics mode shutdown and gfx driver destruction
+void engine_pre_gfxmode_shutdown();
 
 #endif // __AGS_EE_MAIN__ENGINESETUP_H

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -44,7 +44,6 @@ extern volatile int timerloop;
 
 
 IGfxDriverFactory *GfxFactory = NULL;
-IGfxFilter *filter;
 
 struct GameSizeDef
 {
@@ -424,6 +423,7 @@ void display_gfx_mode_error(const Size game_size, const GfxFilterSetup &setup, c
 
     String main_error;
     Size screen_size(ScreenResolution.Width, ScreenResolution.Height);
+    PGfxFilter filter = gfxDriver ? gfxDriver->GetGraphicsFilter() : PGfxFilter();
     if (screen_size.IsNull())
         main_error.Format("There was a problem finding appropriate graphics mode for game size %d x %d (%d-bit) and requested filter '%s'.",
             game_size.Width, game_size.Height, color_depth, setup.UserRequest.IsEmpty() ? "Undefined" : setup.UserRequest.GetCStr());
@@ -490,6 +490,7 @@ bool graphics_mode_init_any(const ScreenSetup &setup, const ColorDepthOption &co
     DisplayMode dm   = gfxDriver->GetDisplayMode();
 
     Rect dst_rect    = gfxDriver->GetRenderDestination();
+    PGfxFilter filter = gfxDriver->GetGraphicsFilter();
     Rect filter_rect = filter->GetDestination();
     Out::FPrint("Succeeded. Using gfx mode %d x %d (%d-bit) %s\n\t"
                 "filter dest (%d, %d, %d, %d : %d x %d), render dest (%d, %d, %d, %d : %d x %d)",
@@ -556,7 +557,7 @@ bool graphics_mode_set_filter(const String &filter_id)
         return false;
 
     String filter_error;
-    filter = GfxFactory->SetFilter(filter_id, filter_error);
+    PGfxFilter filter = GfxFactory->SetFilter(filter_id, filter_error);
     if (!filter)
     {
         Out::FPrint("Unable to set graphics filter '%s'. Error: %s", filter_id.GetCStr(), filter_error.GetCStr());
@@ -571,9 +572,6 @@ void graphics_mode_shutdown()
         GfxFactory->Shutdown();
     GfxFactory = NULL;
     gfxDriver = NULL;
-
-    delete filter;
-    filter = NULL;
 
     // Tell Allegro that we are no longer in graphics mode
     set_gfx_mode(GFX_TEXT, 0, 0, 0, 0);

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -52,7 +52,6 @@ struct GameSizeDef
     Size Box;  // bounding box
 };
 
-
 GraphicResolution ScreenResolution;
 PlaneScaling      GameScaling;
 

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -31,8 +31,6 @@ namespace AGS { namespace Engine { class IGfxModeList; }}
 bool find_nearest_supported_mode(const AGS::Engine::IGfxModeList &modes, Size &wanted_size, int *mode_index,
                                  const int color_depth, const Size *ratio_reference = NULL, const Size *upper_bound = NULL);
 
-namespace AGS { namespace Engine { class IGfxFilter; } }
-extern AGS::Engine::IGfxFilter *filter;
 
 // The actual game screen resolution
 extern AGS::Engine::GraphicResolution ScreenResolution;

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -95,8 +95,17 @@ struct ColorDepthOption
     int32_t Alternate;
 };
 
-// Makes an attempt to deduce and set a new gfx mode from user config
-bool graphics_mode_init(const ScreenSetup &setup, const ColorDepthOption &color_depths);
+// Initializes any possible gfx mode, using user config as a recommendation;
+// may try all available renderers and modes before succeeding (or failing)
+bool graphics_mode_init_any(const ScreenSetup &setup, const ColorDepthOption &color_depths);
+// Creates graphics driver of given id
+bool graphics_mode_create_renderer(const String &driver_id);
+// Initialize graphics mode with given parameters
+bool graphics_mode_set(const AGS::Engine::DisplayMode &dm);
+// Set the render frame position inside the window
+bool graphics_mode_set_render_frame(const Size &native_size, const Rect &render_frame);
+// Set the scaling filter
+bool graphics_mode_set_filter(const String &filter_id);
 // Releases current graphic mode and shuts down renderer
 void graphics_mode_shutdown();
 

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -28,8 +28,9 @@ Size get_desktop_size();
 String make_scaling_factor_string(uint32_t scaling);
 
 namespace AGS { namespace Engine { class IGfxModeList; }}
-bool find_nearest_supported_mode(const AGS::Engine::IGfxModeList &modes, Size &wanted_size, int *mode_index,
-                                 const int color_depth, const Size *ratio_reference = NULL, const Size *upper_bound = NULL);
+bool find_nearest_supported_mode(const AGS::Engine::IGfxModeList &modes, const Size &wanted_size,
+                                 const int color_depth, const Size *ratio_reference, const Size *upper_bound,
+                                 AGS::Engine::DisplayMode &dm, int *mode_index = NULL);
 
 
 // The actual game screen resolution
@@ -69,10 +70,9 @@ enum ScreenSizeDefinition
     kNumScreenDef
 };
 
-// General display configuration
-struct ScreenSetup
+// Display mode configuration
+struct DisplayModeSetup
 {
-    String               DriverID;      // graphics driver ID
     ScreenSizeDefinition SizeDef;       // a method used to determine screen size
     ::Size               Size;          // explicitly defined screen metrics
     bool                 MatchDeviceRatio; // choose resolution matching device aspect ratio
@@ -80,6 +80,13 @@ struct ScreenSetup
     int                  RefreshRate;   // gfx mode refresh rate
     bool                 VSync;         // vertical sync
     bool                 Windowed;      // is mode windowed
+};
+
+// General display configuration
+struct ScreenSetup
+{
+    String               DriverID;      // graphics driver ID
+    DisplayModeSetup     DisplayMode;   // definition of the display mode
 
     GfxFilterSetup       Filter;        // graphics filter definition
     GameFrameSetup       GameFrame;     // definition of the game frame's position on screen
@@ -87,6 +94,7 @@ struct ScreenSetup
     bool                 RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
 };
 
+// Display mode color depth variants allowed to be used
 struct ColorDepthOption
 {
     int32_t Prime;
@@ -95,12 +103,15 @@ struct ColorDepthOption
 
 // Initializes any possible gfx mode, using user config as a recommendation;
 // may try all available renderers and modes before succeeding (or failing)
-bool graphics_mode_init_any(const ScreenSetup &setup, const ColorDepthOption &color_depths);
+bool graphics_mode_init_any(const Size game_size, const ScreenSetup &setup, const ColorDepthOption &color_depths);
+// Fill in setup structs with default settings for the given mode (windowed or fullscreen)
+void graphics_mode_get_defaults(bool windowed, DisplayModeSetup &dm_setup, GameFrameSetup &frame_setup, GfxFilterSetup &filter_setup);
 // Creates graphics driver of given id
 bool graphics_mode_create_renderer(const String &driver_id);
-// Initialize graphics mode with given parameters
-bool graphics_mode_set(const AGS::Engine::DisplayMode &dm);
+// Set the display mode with given parameters
+bool graphics_mode_set_dm(const AGS::Engine::DisplayMode &dm);
 // Set the render frame position inside the window
+bool graphics_mode_set_render_frame(const Size &native_size, const GameFrameSetup &frame_setup);
 bool graphics_mode_set_render_frame(const Size &native_size, const Rect &render_frame);
 // Set the scaling filter
 bool graphics_mode_set_filter(const String &filter_id);

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -28,7 +28,7 @@
 #include "debug/out.h"
 #include "font/fonts.h"
 #include "main/config.h"
-#include "main/graphics_mode.h"
+#include "main/engine.h"
 #include "main/main.h"
 #include "main/mainheader.h"
 #include "main/quit.h"
@@ -53,8 +53,6 @@ extern char check_dynamic_sprites_at_exit;
 extern int editor_debugging_initialized;
 extern IAGSEditorDebugger *editor_debugger;
 extern int need_to_stop_cd;
-extern Bitmap *_old_screen;
-extern Bitmap *_sub_screen;
 extern int use_cdplayer;
 extern IGraphicsDriver *gfxDriver;
 
@@ -106,11 +104,6 @@ void quit_shutdown_platform(QuitReason qreason)
     pl_stop_plugins();
 
     quit_check_dynamic_sprites(qreason);
-
-    // allegro_exit assumes screen is correct
-	if (_old_screen) {
-		BitmapHelper::SetScreenBitmap( _old_screen );
-	}
 
     platform->FinishedUsingGraphicsMode();
 
@@ -188,13 +181,6 @@ QuitReason quit_check_for_error_state(const char *&qmsg, String &alertis)
         "\nError: ", EngineVersion.LongString.GetCStr());
         return kQuit_FatalError;
     }
-}
-
-void quit_destroy_subscreen()
-{
-    // close graphics mode (Win) or return to text mode (DOS)
-    delete _sub_screen;
-	_sub_screen = NULL;
 }
 
 void quit_message_on_exit(const char *qmsg, String &alertis, QuitReason qreason)
@@ -298,15 +284,13 @@ void quit(const char *quitmsg)
     shutdown_font_renderer();
     our_eip = 9902;
 
-    quit_destroy_subscreen();
-
     our_eip = 9907;
 
     close_translation();
 
     our_eip = 9908;
 
-    graphics_mode_shutdown();
+    engine_shutdown_gfxmode();
 
     quit_message_on_exit(qmsg, alertis, qreason);
 

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -44,12 +44,12 @@ extern int psp_video_framedrop;
 
 
 // FLIC player start
-Bitmap *fli_buffer;
+Bitmap *fli_buffer = NULL;
 short fliwidth,fliheight;
 int canabort=0, stretch_flc = 1;
 Bitmap *hicol_buf=NULL;
-IDriverDependantBitmap *fli_ddb;
-Bitmap *fli_target;
+IDriverDependantBitmap *fli_ddb = NULL;
+Bitmap *fli_target = NULL;
 int fliTargetWidth, fliTargetHeight;
 int check_if_user_input_should_cancel_video()
 {
@@ -161,12 +161,14 @@ void play_flc_file(int numb,int playflags) {
     }
 
     delete fli_buffer;
+    fli_buffer = NULL;
     screen_bmp->Clear();
     set_palette_range(oldpal, 0, 255, 0);
     render_to_screen(screen_bmp, 0, 0);
 
     delete fli_target;
     gfxDriver->DestroyDDB(fli_ddb);
+    fli_target = NULL;
     fli_ddb = NULL;
 
 
@@ -295,7 +297,6 @@ void play_theora_video(const char *name, int skip, int flags)
         stop_all_sound_and_music();
     }
 
-    fli_target = NULL;
     //fli_buffer = BitmapHelper::CreateBitmap_(ScreenResolution.ColorDepth, videoWidth, videoHeight);
     calculate_destination_size_maintain_aspect_ratio(videoWidth, videoHeight, &fliTargetWidth, &fliTargetHeight);
 
@@ -329,6 +330,7 @@ void play_theora_video(const char *name, int skip, int flags)
     //destroy_bitmap(fli_buffer);
     delete fli_target;
     gfxDriver->DestroyDDB(fli_ddb);
+    fli_target = NULL;
     fli_ddb = NULL;
     invalidate_screen();
 }

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <stdio.h>
 #include "video.h"
 #include "apeg.h"
 #include "debug/debug_log.h"

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -18,14 +18,7 @@
 #ifndef __AGS_EE_MEDIA__VIDEO_H
 #define __AGS_EE_MEDIA__VIDEO_H
 
-void calculate_destination_size_maintain_aspect_ratio(int vidWidth, int vidHeight, int *targetWidth, int *targetHeight);
 void play_theora_video(const char *name, int skip, int flags);
-void pause_sound_if_necessary_and_play_video(const char *name, int skip, int flags);
-
-#if defined(WINDOWS_VERSION)
-int __cdecl fli_callback();
-#else
-extern "C" int fli_callback();
-#endif
+void play_flc_file(int numb,int playflags);
 
 #endif // __AGS_EE_MEDIA__VIDEO_H

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -21,4 +21,7 @@
 void play_theora_video(const char *name, int skip, int flags);
 void play_flc_file(int numb,int playflags);
 
+// Update video playback if the display mode has changed
+void video_on_gfxmode_changed();
+
 #endif // __AGS_EE_MEDIA__VIDEO_H

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -200,7 +200,6 @@ D3DGraphicsDriver::D3DGraphicsDriver(IDirect3D9 *d3d)
   _screenTintSprite.y = 0;
   pixelShader = NULL;
   _legacyPixelShader = false;
-  _allegroOriginalWindowStyle = 0;
   set_up_default_vertices();
   pNativeSurface = NULL;
   _skipPresent = false;
@@ -505,12 +504,7 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   {
     // Remove the border in full-screen mode, otherwise if the player
     // clicks near the edge of the screen it goes back to Windows
-    if (_allegroOriginalWindowStyle == 0)
-    {
-      _allegroOriginalWindowStyle = GetWindowLong(allegro_wnd, GWL_STYLE);
-    }
-    LONG windowStyle = WS_POPUP;
-    SetWindowLong(allegro_wnd, GWL_STYLE, windowStyle);
+    SetWindowLong(allegro_wnd, GWL_STYLE, WS_POPUP);
   }
 
   memset( &d3dpp, 0, sizeof(d3dpp) );
@@ -893,15 +887,8 @@ void D3DGraphicsDriver::UnInit()
     direct3ddevice = NULL;
   }
 
-  if (_allegroOriginalWindowStyle != 0)
-  {
-    HWND allegro_wnd = win_get_window();
-    if (allegro_wnd)
-    {
-      SetWindowLong(allegro_wnd, GWL_STYLE, _allegroOriginalWindowStyle);
-    }
-    _allegroOriginalWindowStyle = 0;
-  }
+  // Restore allegro window styles in case we modified them
+  restore_window_style();
 }
 
 D3DGraphicsDriver::~D3DGraphicsDriver()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -889,6 +889,10 @@ void D3DGraphicsDriver::UnInit()
 
   // Restore allegro window styles in case we modified them
   restore_window_style();
+  // For uncertain reasons WS_EX_TOPMOST (applied when creating fullscreen)
+  // cannot be removed with style altering functions; here use SetWindowPos
+  // as a workaround
+  SetWindowPos(win_get_window(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 
 D3DGraphicsDriver::~D3DGraphicsDriver()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -193,7 +193,6 @@ D3DGraphicsDriver::D3DGraphicsDriver(IDirect3D9 *d3d)
   _tint_red = 0;
   _tint_green = 0;
   _tint_blue = 0;
-  _filter = NULL;
   _screenTintLayer = NULL;
   _screenTintLayerDDB = NULL;
   _screenTintSprite.skip = true;
@@ -783,7 +782,7 @@ void D3DGraphicsDriver::SetupViewport()
   direct3ddevice->ColorFill(pNativeSurface, NULL, 0);
 }
 
-void D3DGraphicsDriver::SetGraphicsFilter(D3DGfxFilter *filter)
+void D3DGraphicsDriver::SetGraphicsFilter(PD3DFilter filter)
 {
   _filter = filter;
   OnSetFilter();
@@ -849,7 +848,7 @@ IGfxModeList *D3DGraphicsDriver::GetSupportedModeList(int color_depth)
   return new D3DGfxModeList(direct3d, color_depth_to_d3d_format(color_depth, false));
 }
 
-IGfxFilter *D3DGraphicsDriver::GetGraphicsFilter() const
+PGfxFilter D3DGraphicsDriver::GetGraphicsFilter() const
 {
     return _filter;
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1346,7 +1346,7 @@ void D3DGraphicsDriver::DestroyDDB(IDriverDependantBitmap* bitmap)
       drawListLastTime[i].skip = true;
     }
   }
-  delete ((D3DBitmap*)bitmap);
+  delete bitmap;
 }
 
 __inline void get_pixel_if_not_transparent15(unsigned short *pixel, unsigned short *red, unsigned short *green, unsigned short *blue, unsigned short *divisor)

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -259,8 +259,6 @@ private:
     int numToDrawLastTime;
     GlobalFlipType flipTypeLastTime;
 
-    LONG _allegroOriginalWindowStyle;
-
     // Called after new mode was successfully initialized
     virtual void OnInit(const DisplayMode &mode, volatile int *loopTimer);
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -170,7 +170,8 @@ public:
     virtual const char*GetDriverName() { return "Direct3D 9"; }
     virtual const char*GetDriverID() { return "D3D9"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, const Size src_size, const Rect dst_rect, volatile int *loopTimer);
+    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxFilter *GetGraphicsFilter() const;
@@ -210,7 +211,7 @@ public:
     void SetGraphicsFilter(D3DGfxFilter *filter);
 
     // Internal
-    int _initDLLCallback();
+    int _initDLLCallback(const DisplayMode &mode);
     int _resetDeviceIfNecessary();
     void _render(GlobalFlipType flip, bool clearDrawListAfterwards);
     void _reDrawLastFrame();
@@ -256,12 +257,17 @@ private:
 
     LONG _allegroOriginalWindowStyle;
 
-    void initD3DDLL();
+    // Called after new mode was successfully initialized
+    virtual void OnInit(const DisplayMode &mode, volatile int *loopTimer);
+
+    void initD3DDLL(const DisplayMode &mode);
     void InitializeD3DState();
+    void SetupViewport();
     void set_up_default_vertices();
     void make_translated_scaling_matrix(D3DMATRIX *matrix, float x, float y, float xScale, float yScale);
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
     void UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, D3DBitmap *target, bool hasAlpha);
+    void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     bool IsTextureFormatOk( D3DFORMAT TextureFormat, D3DFORMAT AdapterFormat );
     void create_screen_tint_bitmap();

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -23,6 +23,8 @@
 #error This file should only be included on the Windows build
 #endif
 
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
 #include <allegro.h>
 #include <winalleg.h>
 #include <d3d9.h>
@@ -174,7 +176,7 @@ public:
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
-    virtual IGfxFilter *GetGraphicsFilter() const;
+    virtual PGfxFilter GetGraphicsFilter() const;
     virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) { _pollingCallback = callback; }
     virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) { _drawScreenCallback = callback; }
     virtual void SetCallbackOnInit(GFXDRV_CLIENTCALLBACKINITGFX callback) { _initGfxCallback = callback; }
@@ -208,7 +210,9 @@ public:
     virtual void SetMemoryBackBuffer(Bitmap *backBuffer) {  }
     virtual void SetScreenTint(int red, int green, int blue);
 
-    void SetGraphicsFilter(D3DGfxFilter *filter);
+    typedef stdtr1compat::shared_ptr<D3DGfxFilter> PD3DFilter;
+
+    void SetGraphicsFilter(PD3DFilter filter);
 
     // Internal
     int _initDLLCallback(const DisplayMode &mode);
@@ -218,9 +222,9 @@ public:
     D3DGraphicsDriver(IDirect3D9 *d3d);
     virtual ~D3DGraphicsDriver();
 
-    D3DGfxFilter *_filter;
-
 private:
+    PD3DFilter _filter;
+
     IDirect3D9 *direct3d;
     D3DPRESENT_PARAMETERS d3dpp;
     IDirect3DDevice9* direct3ddevice;

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -1170,9 +1170,10 @@ void WinSetupDialog::SelectNearestGfxMode(const Size screen_size)
     else
     {
         // Look up for the nearest supported mode
-        Size found_size = screen_size;
         int index = -1;
-        if (find_nearest_supported_mode(_drvDesc->GfxModeList, found_size, &index, _winCfg.GameColourDepth != 0 ? _winCfg.GameColourDepth : 32))
+        DisplayMode dm;
+        if (find_nearest_supported_mode(_drvDesc->GfxModeList, screen_size, _winCfg.GameColourDepth != 0 ? _winCfg.GameColourDepth : 32,
+                                        NULL, NULL, dm, &index))
         {
             SetCurSelToItemData(_hGfxModeList, (DWORD_PTR)&_drvDesc->GfxModeList.Modes[index], NULL, kGfxMode_Desktop);
         }

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -31,7 +31,6 @@
 #include "ac/global_hotspot.h"
 #include "ac/global_object.h"
 #include "ac/global_room.h"
-#include "ac/global_video.h"
 #include "ac/invwindow.h"
 #include "ac/mouse.h"
 #include "ac/room.h"
@@ -42,6 +41,7 @@
 #include "main/game_run.h"
 #include "media/audio/audio.h"
 #include "media/audio/soundclip.h"
+#include "media/video/video.h"
 #include "script/script_runtime.h"
 #include "util/string_utils.h"
 


### PR DESCRIPTION
Although the free display mode support was previously implemented into AGS engine, the code still retained older trait of being straitforward one-way initialization of everything at once, with little support to change anything during the game.

This pull request refactors the related code and breaks gfx mode init routine into three distinct steps, which (in theory) could be called again at runtime separately or altogether:
* Setting screen (window) resolution;
* Setting render frame (the final rectangle game is stretched to);
* Setting scaling filter (which is used at stretching when needed).