### PR TITLE
Implement switching graphic modes at runtime

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1060,7 +1060,7 @@ bool DialogOptions::Run()
 
 void DialogOptions::Close()
 {
-  while (kbhit()) getch(); // empty keyboard buffer
+  clear_input_buffer();
   //leave_real_screen();
   construct_virtual_screen(true);
 

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -474,8 +474,7 @@ int __actual_invscreen()
         return InvScr.break_code;
     }
 
-    // Clear buffered keypresses
-    while (kbhit()) getch();
+    clear_input_buffer();
 
     InvScr.Close();
     return InvScr.toret;

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -561,3 +561,9 @@ int my_readkey() {
 
     return gott;
 }
+
+void clear_input_buffer()
+{
+    while (rec_kbhit()) rec_getch();
+    while (mgetbutton() != NONE);
+}

--- a/Engine/ac/record.h
+++ b/Engine/ac/record.h
@@ -54,5 +54,7 @@ void start_replay_record ();
 void stop_recording();
 void start_playback();
 int  my_readkey();
+// Clears buffered keypresses and mouse clicks, if any
+void clear_input_buffer();
 
 #endif // __AGS_EE_AC__RECORD_H

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -970,8 +970,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     play.gscript_timer=-1;  // avoid screw-ups with changing screens
     play.player_on_region = 0;
     // trash any input which they might have done while it was loading
-    while (kbhit()) { if (getch()==0) getch(); }
-    while (mgetbutton()!=NONE) ;
+    clear_input_buffer();
     // no fade in, so set the palette immediately in case of 256-col sprites
     if (game.color_depth > 1)
         setpal();

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -678,9 +678,15 @@ void OGLGraphicsDriver::CreateVirtualScreen()
   BitmapHelper::SetScreenBitmap(_dummyVirtualScreen);
 }
 
-bool OGLGraphicsDriver::SetRenderFrame(const Size &src_size, const Rect &dst_rect)
+bool OGLGraphicsDriver::SetNativeSize(const Size &src_size)
 {
-  OnSetRenderFrame(src_size, dst_rect);
+  OnSetNativeSize(src_size);
+  return !_srcRect.IsEmpty();
+}
+
+bool OGLGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
+{
+  OnSetRenderFrame(dst_rect);
   // If we already have a gfx mode set, then update virtual screen immediately
   CreateVirtualScreen();
   // Also make sure viewport and backbuffer mappings are updated using new native & destination rectangles

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -550,8 +550,10 @@ void OGLGraphicsDriver::SetupViewport()
   }
 }
 
-bool OGLGraphicsDriver::Init(const DisplayMode &mode_, volatile int *loopTimer)
+bool OGLGraphicsDriver::SetDisplayMode(const DisplayMode &mode_, volatile int *loopTimer)
 {
+  ReleaseDisplayMode();
+
   // TODO: OpenGL renderer is incomplete and requires to do certain hacks to work,
   // like forcing windowed mode, this is why we create mutable DisplayMode here
   DisplayMode mode = mode_;
@@ -659,7 +661,8 @@ bool OGLGraphicsDriver::Init(const DisplayMode &mode_, volatile int *loopTimer)
       set_allegro_error(exception._message);
     return false;
   }
-  OnInit(mode, loopTimer);
+  OnInit(loopTimer);
+  OnModeSet(mode);
   CreateVirtualScreen();
   return true;
 }
@@ -683,7 +686,7 @@ bool OGLGraphicsDriver::SetRenderFrame(const Size &src_size, const Rect &dst_rec
   // Also make sure viewport and backbuffer mappings are updated using new native & destination rectangles
   SetupViewport();
   create_backbuffer_arrays();
-  return true;
+  return !_dstRect.IsEmpty();;
 }
 
 IGfxModeList *OGLGraphicsDriver::GetSupportedModeList(int color_depth)
@@ -697,9 +700,9 @@ PGfxFilter OGLGraphicsDriver::GetGraphicsFilter() const
     return _filter;
 }
 
-void OGLGraphicsDriver::UnInit() 
+void OGLGraphicsDriver::ReleaseDisplayMode()
 {
-  OnUnInit();
+  OnModeReleased();
 
   if (_screenTintLayerDDB != NULL) 
   {
@@ -713,6 +716,12 @@ void OGLGraphicsDriver::UnInit()
   _dummyVirtualScreen = NULL;
 
   gfx_driver = NULL;
+}
+
+void OGLGraphicsDriver::UnInit() 
+{
+  OnUnInit();
+  ReleaseDisplayMode();
 }
 
 OGLGraphicsDriver::~OGLGraphicsDriver()

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -188,7 +188,7 @@ public:
     virtual const char*GetDriverName() { return "OpenGL"; }
     virtual const char*GetDriverID() { return "OGL"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
@@ -276,6 +276,8 @@ private:
 
     void InitOpenGl();
     void set_up_default_vertices();
+    // Unset parameters and release resources related to the display mode
+    void ReleaseDisplayMode();
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
     void UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha);
     void CreateVirtualScreen();

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -189,7 +189,8 @@ public:
     virtual const char*GetDriverID() { return "OGL"; }
     virtual void SetTintMethod(TintMethod method);
     virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
-    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
+    virtual bool SetNativeSize(const Size &src_size);
+    virtual bool SetRenderFrame(const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual PGfxFilter GetGraphicsFilter() const;

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -230,7 +230,7 @@ bool ALSoftwareGraphicsDriver::SetDisplayMode(const DisplayMode &mode, volatile 
 
 void ALSoftwareGraphicsDriver::CreateVirtualScreen()
 {
-  if (!IsModeSet() || !IsRenderFrameValid() || !_filter)
+  if (!IsModeSet() || !IsRenderFrameValid() || !IsNativeSizeValid() || !_filter)
     return;
   BitmapHelper::SetScreenBitmap( _filter->InitVirtualScreen(BitmapHelper::GetScreenBitmap(), _srcRect.GetSize(), _dstRect) );
   virtualScreen = BitmapHelper::GetScreenBitmap();
@@ -263,9 +263,17 @@ void ALSoftwareGraphicsDriver::ReleaseDisplayMode()
   BitmapHelper::SetScreenBitmap(NULL);
 }
 
-bool ALSoftwareGraphicsDriver::SetRenderFrame(const Size &src_size, const Rect &dst_rect)
+bool ALSoftwareGraphicsDriver::SetNativeSize(const Size &src_size)
 {
-  OnSetRenderFrame(src_size, dst_rect);
+  OnSetNativeSize(src_size);
+  // If we already have a gfx mode and gfx filter set, then use it to update virtual screen immediately
+  CreateVirtualScreen();
+  return !_srcRect.IsEmpty();
+}
+
+bool ALSoftwareGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
+{
+  OnSetRenderFrame(dst_rect);
   // If we already have a gfx mode and gfx filter set, then use it to update virtual screen immediately
   CreateVirtualScreen();
   return !_dstRect.IsEmpty();

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -71,6 +71,26 @@ bool ALSoftwareGfxModeList::GetMode(int index, DisplayMode &mode) const
 unsigned long _trans_alpha_blender32(unsigned long x, unsigned long y, unsigned long n);
 RGB faded_out_palette[256];
 
+
+ALSoftwareGraphicsDriver::ALSoftwareGraphicsDriver()
+{ 
+  _callback = NULL; 
+  _drawScreenCallback = NULL;
+  _nullSpriteCallback = NULL;
+  _initGfxCallback = NULL;
+  _tint_red = 0;
+  _tint_green = 0;
+  _tint_blue = 0;
+  _autoVsync = false;
+  _spareTintingScreen = NULL;
+  numToDraw = 0;
+  _gfxModeList = NULL;
+#ifdef _WIN32
+  dxGammaControl = NULL;
+#endif
+  _allegroScreenWrapper = NULL;
+}
+
 bool ALSoftwareGraphicsDriver::IsModeSupported(const DisplayMode &mode)
 {
   if (mode.Width <= 0 || mode.Height <= 0 || mode.ColorDepth <= 0)
@@ -159,8 +179,10 @@ void ALSoftwareGraphicsDriver::SetTintMethod(TintMethod method)
   // TODO: support new D3D-style tint method
 }
 
-bool ALSoftwareGraphicsDriver::Init(const DisplayMode &mode, volatile int *loopTimer)
+bool ALSoftwareGraphicsDriver::SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer)
 {
+  ReleaseDisplayMode();
+
   const int driver = GetAllegroGfxDriverID(mode.Windowed);
 
   set_color_depth(mode.ColorDepth);
@@ -171,7 +193,8 @@ bool ALSoftwareGraphicsDriver::Init(const DisplayMode &mode, volatile int *loopT
   if (!IsModeSupported(mode) || set_gfx_mode(driver, mode.Width, mode.Height, 0, 0) != 0)
     return false;
 
-  OnInit(mode, loopTimer);
+  OnInit(loopTimer);
+  OnModeSet(mode);
   // [IKM] 2012-09-07
   // set_gfx_mode is an allegro function that creates screen bitmap;
   // following code assumes the screen is already created, therefore we should
@@ -213,12 +236,39 @@ void ALSoftwareGraphicsDriver::CreateVirtualScreen()
   virtualScreen = BitmapHelper::GetScreenBitmap();
 }
 
+void ALSoftwareGraphicsDriver::ReleaseDisplayMode()
+{
+  OnModeReleased();
+  numToDraw = 0;
+
+#ifdef _WIN32
+  if (dxGammaControl != NULL) 
+  {
+    dxGammaControl->Release();
+    dxGammaControl = NULL;
+  }
+#endif
+
+  if (BitmapHelper::GetScreenBitmap())
+    BitmapHelper::SetScreenBitmap( _filter->ShutdownAndReturnRealScreen() );
+
+  // [IKM] 2012-09-07
+  // We do not need the wrapper any longer;
+  // this does not destroy the underlying allegro screen bitmap, only wrapper.
+  delete _allegroScreenWrapper;
+  _allegroScreenWrapper = NULL;
+  // Nullify the global screen object (for safety reasons); note this yet does
+  // not change allegro screen pointer (at this moment it should point at the
+  // original internally created allegro bitmap which will be destroyed by Allegro).
+  BitmapHelper::SetScreenBitmap(NULL);
+}
+
 bool ALSoftwareGraphicsDriver::SetRenderFrame(const Size &src_size, const Rect &dst_rect)
 {
   OnSetRenderFrame(src_size, dst_rect);
   // If we already have a gfx mode and gfx filter set, then use it to update virtual screen immediately
   CreateVirtualScreen();
-  return true;
+  return !_dstRect.IsEmpty();
 }
 
 void ALSoftwareGraphicsDriver::ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse)
@@ -237,35 +287,13 @@ ALSoftwareGraphicsDriver::~ALSoftwareGraphicsDriver()
 void ALSoftwareGraphicsDriver::UnInit()
 {
   OnUnInit();
-
-#ifdef _WIN32
-
-  if (dxGammaControl != NULL) 
-  {
-    dxGammaControl->Release();
-    dxGammaControl = NULL;
-  }
-
-#endif
+  ReleaseDisplayMode();
 
   if (_gfxModeList != NULL)
   {
     destroy_gfx_mode_list(_gfxModeList);
     _gfxModeList = NULL;
   }
-
-  if (BitmapHelper::GetScreenBitmap())
-   BitmapHelper::SetScreenBitmap( _filter->ShutdownAndReturnRealScreen(BitmapHelper::GetScreenBitmap()) );
-
-  // [IKM] 2012-09-07
-  // We do not need the wrapper any longer;
-  // this does not destroy the underlying allegro screen bitmap, only wrapper.
-  delete _allegroScreenWrapper;
-  _allegroScreenWrapper = NULL;
-  // Nullify the global screen object (for safety reasons); note this yet does
-  // not change allegro screen pointer (at this moment it should point at the
-  // original internally created allegro bitmap which will be destroyed by Allegro).
-  BitmapHelper::SetScreenBitmap(NULL);
 }
 
 bool ALSoftwareGraphicsDriver::SupportsGammaControl() 

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -130,7 +130,8 @@ public:
     virtual const char*GetDriverID() { return "DX5"; }
     virtual void SetTintMethod(TintMethod method);
     virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
-    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
+    virtual bool SetNativeSize(const Size &src_size);
+    virtual bool SetRenderFrame(const Rect &dst_rect);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual PGfxFilter GetGraphicsFilter() const;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -124,28 +124,12 @@ private:
 class ALSoftwareGraphicsDriver : public GraphicsDriverBase
 {
 public:
-    ALSoftwareGraphicsDriver() { 
-        _callback = NULL; 
-        _drawScreenCallback = NULL;
-        _nullSpriteCallback = NULL;
-        _initGfxCallback = NULL;
-        _tint_red = 0;
-        _tint_green = 0;
-        _tint_blue = 0;
-        _autoVsync = false;
-        _spareTintingScreen = NULL;
-        numToDraw = 0;
-        _gfxModeList = NULL;
-#ifdef _WIN32
-        dxGammaControl = NULL;
-#endif
-        _allegroScreenWrapper = NULL;
-    }
+    ALSoftwareGraphicsDriver();
 
     virtual const char*GetDriverName() { return "Allegro/DX5"; }
     virtual const char*GetDriverID() { return "DX5"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
@@ -222,6 +206,8 @@ private:
 
     // Use gfx filter to create a new virtual screen
     void CreateVirtualScreen();
+    // Unset parameters and release resources related to the display mode
+    void ReleaseDisplayMode();
 
     void highcolor_fade_out(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void highcolor_fade_in(Bitmap *bmp_orig, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -35,6 +35,11 @@ bool GraphicsDriverBase::IsModeSet() const
     return _mode.Width != 0 && _mode.Height != 0 && _mode.ColorDepth != 0;
 }
 
+bool GraphicsDriverBase::IsNativeSizeValid() const
+{
+    return !_srcRect.IsEmpty();
+}
+
 bool GraphicsDriverBase::IsRenderFrameValid() const
 {
     return !_srcRect.IsEmpty() && !_dstRect.IsEmpty();
@@ -43,6 +48,11 @@ bool GraphicsDriverBase::IsRenderFrameValid() const
 DisplayMode GraphicsDriverBase::GetDisplayMode() const
 {
     return _mode;
+}
+
+Size GraphicsDriverBase::GetNativeSize() const
+{
+    return _srcRect.GetSize();
 }
 
 Rect GraphicsDriverBase::GetRenderDestination() const
@@ -76,16 +86,26 @@ void GraphicsDriverBase::OnModeReleased()
     _dstRect = Rect();
 }
 
-void GraphicsDriverBase::OnSetRenderFrame(const Size &src_size, const Rect &dst_rect)
+void GraphicsDriverBase::OnScalingChanged()
 {
-    _srcRect = RectWH(0, 0, src_size.Width, src_size.Height);
-    _dstRect = dst_rect;
     PGfxFilter filter = GetGraphicsFilter();
     if (filter)
-        _filterRect = filter->SetTranslation(src_size, dst_rect);
+        _filterRect = filter->SetTranslation(_srcRect.GetSize(), _dstRect);
     else
         _filterRect = Rect();
-    _scaling.Init(src_size, dst_rect);
+    _scaling.Init(_srcRect.GetSize(), _dstRect);
+}
+
+void GraphicsDriverBase::OnSetNativeSize(const Size &src_size)
+{
+    _srcRect = RectWH(0, 0, src_size.Width, src_size.Height);
+    OnScalingChanged();
+}
+
+void GraphicsDriverBase::OnSetRenderFrame(const Rect &dst_rect)
+{
+    _dstRect = dst_rect;
+    OnScalingChanged();
 }
 
 void GraphicsDriverBase::OnSetFilter()

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -56,14 +56,24 @@ void GraphicsDriverBase::SetRenderOffset(int x, int y)
     _global_y_offset = y;
 }
 
-void GraphicsDriverBase::OnInit(const DisplayMode &mode, volatile int *loopTimer)
+void GraphicsDriverBase::OnInit(volatile int *loopTimer)
 {
-    _mode = mode;
     _loopTimer = loopTimer;
 }
 
 void GraphicsDriverBase::OnUnInit()
 {
+}
+
+void GraphicsDriverBase::OnModeSet(const DisplayMode &mode)
+{
+    _mode = mode;
+}
+
+void GraphicsDriverBase::OnModeReleased()
+{
+    _mode = DisplayMode();
+    _dstRect = Rect();
 }
 
 void GraphicsDriverBase::OnSetRenderFrame(const Size &src_size, const Rect &dst_rect)

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -34,8 +34,10 @@ public:
     GraphicsDriverBase();
 
     virtual bool        IsModeSet() const;
+    virtual bool        IsNativeSizeValid() const;
     virtual bool        IsRenderFrameValid() const;
     virtual DisplayMode GetDisplayMode() const;
+    virtual Size        GetNativeSize() const;
     virtual Rect        GetRenderDestination() const;
     virtual void        SetRenderOffset(int x, int y);
 
@@ -47,13 +49,16 @@ protected:
     virtual void OnUnInit();
     // Called after new mode was successfully initialized
     virtual void OnModeSet(const DisplayMode &mode);
+    // Called when the new native size is set
+    virtual void OnSetNativeSize(const Size &src_size);
     // Called before display mode is going to be released
     virtual void OnModeReleased();
     // Called when new render frame is set
-    virtual void OnSetRenderFrame(const Size &src_size, const Rect &dst_rect);
+    virtual void OnSetRenderFrame(const Rect &dst_rect);
     // Called when the new filter is set
     virtual void OnSetFilter();
 
+    void    OnScalingChanged();
     // Checks if the bitmap needs to be converted and **deletes original** if a new bitmap
     // had to be created
     Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *old_bmp);

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -40,10 +40,15 @@ public:
     virtual void        SetRenderOffset(int x, int y);
 
 protected:
-    // Called after new mode was successfully initialized
-    virtual void OnInit(const DisplayMode &mode, volatile int *loopTimer);
-    // Called after graphics mode was uninitialized
+    // Called after graphics driver was initialized for use for the first time
+    virtual void OnInit(volatile int *loopTimer);
+    // Called just before graphics mode is going to be uninitialized and its
+    // resources released
     virtual void OnUnInit();
+    // Called after new mode was successfully initialized
+    virtual void OnModeSet(const DisplayMode &mode);
+    // Called before display mode is going to be released
+    virtual void OnModeReleased();
     // Called when new render frame is set
     virtual void OnSetRenderFrame(const Size &src_size, const Rect &dst_rect);
     // Called when the new filter is set

--- a/Engine/gfx/gfxfilter_allegro.cpp
+++ b/Engine/gfx/gfxfilter_allegro.cpp
@@ -43,6 +43,8 @@ const GfxFilterInfo &AllegroGfxFilter::GetInfo() const
 
 Bitmap* AllegroGfxFilter::InitVirtualScreen(Bitmap *screen, const Size src_size, const Rect dst_rect)
 {
+    ShutdownAndReturnRealScreen();
+
     realScreen = screen;
     SetTranslation(src_size, dst_rect);
 
@@ -60,14 +62,16 @@ Bitmap* AllegroGfxFilter::InitVirtualScreen(Bitmap *screen, const Size src_size,
     return virtualScreen;
 }
 
-Bitmap *AllegroGfxFilter::ShutdownAndReturnRealScreen(Bitmap *currentScreen)
+Bitmap *AllegroGfxFilter::ShutdownAndReturnRealScreen()
 {
     if (virtualScreen != realScreen)
         delete virtualScreen;
     delete realScreenSizedBuffer;
     virtualScreen = NULL;
     realScreenSizedBuffer = NULL;
-    return realScreen;
+    Bitmap *real_scr = realScreen;
+    realScreen = NULL;
+    return real_scr;
 }
 
 void AllegroGfxFilter::RenderScreen(Bitmap *toRender, int x, int y) {

--- a/Engine/gfx/gfxfilter_allegro.h
+++ b/Engine/gfx/gfxfilter_allegro.h
@@ -40,7 +40,7 @@ public:
     virtual const GfxFilterInfo &GetInfo() const;
     
     virtual Bitmap *InitVirtualScreen(Bitmap *screen, const Size src_size, const Rect dst_rect);
-    virtual Bitmap *ShutdownAndReturnRealScreen(Bitmap *currentScreen);
+    virtual Bitmap *ShutdownAndReturnRealScreen();
     virtual void RenderScreen(Bitmap *toRender, int x, int y);
     virtual void RenderScreenFlipped(Bitmap *toRender, int x, int y, GlobalFlipType flipType);
     virtual void ClearRect(int x1, int y1, int x2, int y2, int color);

--- a/Engine/gfx/gfxfilter_hqx.cpp
+++ b/Engine/gfx/gfxfilter_hqx.cpp
@@ -70,9 +70,9 @@ Bitmap* HqxGfxFilter::InitVirtualScreen(Bitmap *screen, const Size src_size, con
     return virtual_screen;
 }
 
-Bitmap *HqxGfxFilter::ShutdownAndReturnRealScreen(Bitmap *currentScreen)
+Bitmap *HqxGfxFilter::ShutdownAndReturnRealScreen()
 {
-    Bitmap *real_screen = AllegroGfxFilter::ShutdownAndReturnRealScreen(currentScreen);
+    Bitmap *real_screen = AllegroGfxFilter::ShutdownAndReturnRealScreen();
     delete _hqxScalingBuffer;
     _hqxScalingBuffer = NULL;
     return real_screen;

--- a/Engine/gfx/gfxfilter_hqx.h
+++ b/Engine/gfx/gfxfilter_hqx.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool Initialize(const int color_depth, String &err_str);
     virtual Bitmap *InitVirtualScreen(Bitmap *screen, const Size src_size, const Rect dst_rect);
-    virtual Bitmap *ShutdownAndReturnRealScreen(Bitmap *currentScreen);
+    virtual Bitmap *ShutdownAndReturnRealScreen();
 
     static const GfxFilterInfo FilterInfo;
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -66,13 +66,17 @@ public:
   virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer) = 0;
   // Gets if a graphics mode was initialized
   virtual bool IsModeSet() const = 0;
+  // Set the size of the native image size
+  virtual bool SetNativeSize(const Size &src_size) = 0;
+  virtual bool IsNativeSizeValid() const = 0;
   // Set game render frame and translation
-  virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect) = 0;
+  virtual bool SetRenderFrame(const Rect &dst_rect) = 0;
   virtual bool IsRenderFrameValid() const = 0;
   virtual IGfxModeList *GetSupportedModeList(int color_depth) = 0;
   virtual bool IsModeSupported(const DisplayMode &mode) = 0;
   virtual DisplayMode GetDisplayMode() const = 0;
   virtual PGfxFilter GetGraphicsFilter() const = 0;
+  virtual Size GetNativeSize() const = 0;
   virtual Rect GetRenderDestination() const = 0;
   virtual void SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) = 0;
   virtual void SetCallbackToDrawScreen(GFXDRV_CLIENTCALLBACK callback) = 0;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -63,7 +63,7 @@ public:
   virtual const char*GetDriverID() = 0;
   virtual void SetTintMethod(TintMethod method) = 0;
   // Initialize given display mode
-  virtual bool Init(const DisplayMode &mode, volatile int *loopTimer) = 0;
+  virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer) = 0;
   // Gets if a graphics mode was initialized
   virtual bool IsModeSet() const = 0;
   // Set game render frame and translation
@@ -81,7 +81,6 @@ public:
   // null sprite is encountered. You can use this to hook into the rendering
   // process.
   virtual void SetCallbackForNullSprite(GFXDRV_CLIENTCALLBACKXY callback) = 0;
-  virtual void UnInit() = 0;
   virtual void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) = 0;
   virtual Common::Bitmap *ConvertBitmapToSupportedColourDepth(Common::Bitmap *bitmap) = 0;
   virtual IDriverDependantBitmap* CreateDDBFromBitmap(Common::Bitmap *bitmap, bool hasAlpha, bool opaque = false) = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -30,6 +30,7 @@
 #include "ac/gui.h"
 #include "ac/lipsync.h"
 #include "ac/objectcache.h"
+#include "ac/record.h"
 #include "ac/roomstatus.h"
 #include "ac/speech.h"
 #include "ac/translation.h"
@@ -1556,19 +1557,21 @@ bool engine_try_switch_windowed_gfxmode()
     if (old_dm.Windowed)
         init_desktop = get_desktop_size();
 
-    if (graphics_mode_set_dm_any(game.size, dm_setup, old_dm.ColorDepth, frame_setup) &&
-        graphics_mode_set_render_frame(frame_setup))
+    bool res = graphics_mode_set_dm_any(game.size, dm_setup, old_dm.ColorDepth, frame_setup) &&
+               graphics_mode_set_render_frame(frame_setup);
+    if (res)
     {
         if (dm_setup.Windowed)
             init_desktop = get_desktop_size();
         engine_post_gfxmode_setup(init_desktop);
-        return true;
     }
     else
     {
         // TODO: switch back!!!
     }
-    return false;
+
+    clear_input_buffer();
+    return res;
 }
 
 void engine_shutdown_gfxmode()

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1538,6 +1538,39 @@ bool engine_try_set_gfxmode_any(const ScreenSetup &setup)
     return true;
 }
 
+bool engine_try_switch_windowed_gfxmode()
+{
+    if (!gfxDriver || !gfxDriver->IsModeSet())
+        return false;
+
+    // TODO: if there are saved parameters for given mode (fullscreen/windowed)
+    // then use them, if there are not, get default setup for the new mode
+
+    DisplayMode old_dm = gfxDriver->GetDisplayMode();
+    engine_pre_gfxmode_shutdown();
+
+    Size init_desktop;
+    DisplayModeSetup dm_setup;
+    GameFrameSetup frame_setup;
+    graphics_mode_get_defaults(!old_dm.Windowed, dm_setup, frame_setup);
+    if (old_dm.Windowed)
+        init_desktop = get_desktop_size();
+
+    if (graphics_mode_set_dm_any(game.size, dm_setup, old_dm.ColorDepth, frame_setup) &&
+        graphics_mode_set_render_frame(frame_setup))
+    {
+        if (dm_setup.Windowed)
+            init_desktop = get_desktop_size();
+        engine_post_gfxmode_setup(init_desktop);
+        return true;
+    }
+    else
+    {
+        // TODO: switch back!!!
+    }
+    return false;
+}
+
 void engine_shutdown_gfxmode()
 {
     if (!gfxDriver)

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1548,28 +1548,31 @@ bool engine_try_switch_windowed_gfxmode()
     // then use them, if there are not, get default setup for the new mode
 
     DisplayMode old_dm = gfxDriver->GetDisplayMode();
+    GameFrameSetup old_frame = graphics_mode_get_render_frame();
+
     engine_pre_gfxmode_shutdown();
 
     Size init_desktop;
     DisplayModeSetup dm_setup;
     GameFrameSetup frame_setup;
     graphics_mode_get_defaults(!old_dm.Windowed, dm_setup, frame_setup);
-    if (old_dm.Windowed)
-        init_desktop = get_desktop_size();
+    init_desktop = get_desktop_size();
 
     bool res = graphics_mode_set_dm_any(game.size, dm_setup, old_dm.ColorDepth, frame_setup) &&
                graphics_mode_set_render_frame(frame_setup);
+    if (!res)
+    {
+        // switch back to previous gfx mode
+        res = graphics_mode_set_dm(old_dm) &&
+              graphics_mode_set_render_frame(old_frame);
+    }
+
     if (res)
     {
         if (dm_setup.Windowed)
             init_desktop = get_desktop_size();
         engine_post_gfxmode_setup(init_desktop);
     }
-    else
-    {
-        // TODO: switch back!!!
-    }
-
     clear_input_buffer();
     return res;
 }

--- a/Engine/main/engine.h
+++ b/Engine/main/engine.h
@@ -29,6 +29,9 @@ struct ScreenSetup;
 // if requested mode fails, tries to find any compatible mode close to the
 // requested one.
 bool        engine_try_set_gfxmode_any(const ScreenSetup &setup);
+// Tries to switch between fullscreen and windowed mode; uses previously saved
+// setup if it is available, or default settings for the new mode
+bool        engine_try_switch_windowed_gfxmode();
 // Shutdown graphics mode (used before shutting down tha application)
 void        engine_shutdown_gfxmode();
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -45,6 +45,7 @@
 #include "gui/guimain.h"
 #include "gui/guitextbox.h"
 #include "main/mainheader.h"
+#include "main/engine.h"
 #include "main/game_run.h"
 #include "main/update.h"
 #include "media/audio/soundclip.h"
@@ -282,6 +283,13 @@ void check_controls() {
         //if (kgn == 2) SetCharacterIdle (game.playercharacter, 5, 0);
         //if (kgn == 2) Display("Some for?ign text");
         //if (kgn == 2) do_conversation(5);
+
+        // NOTE: for some reason Alt + Enter produces same code as F9
+        if (kgn == 367 && !key[KEY_F9])
+        {
+            engine_try_switch_windowed_gfxmode();
+            return;
+        }
 
         if (kgn == play.replay_hotkey) {
             // start/stop recording

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -205,7 +205,6 @@ void toggle_mouse_lock()
 
 // check_controls: checks mouse & keyboard interface
 void check_controls() {
-    int numevents_was = numevents;
     our_eip = 1007;
     NEXT_ITERATION();
 
@@ -437,7 +436,10 @@ void check_controls() {
         }
         old_key_shifts = key_shifts & ~(KB_SCROLOCK_FLAG | KB_NUMLOCK_FLAG | KB_CAPSLOCK_FLAG);
     }
+}  // end check_controls
 
+void check_room_edges(int numevents_was)
+{
     if ((IsInterfaceEnabled()) && (IsGamePaused() == 0) &&
         (in_new_room == 0) && (new_room_was == 0)) {
             // Only allow walking off edges if not in wait mode, and
@@ -473,14 +475,16 @@ void check_controls() {
     }
     our_eip = 1008;
 
-}  // end check_controls
+}
 
 void game_loop_check_controls(bool checkControls)
 {
     // don't let the player do anything before the screen fades in
     if ((in_new_room == 0) && (checkControls)) {
         int inRoom = displayed_room;
+        int numevents_was = numevents;
         check_controls();
+        check_room_edges(numevents_was);
         // If an inventory interaction changed the room
         if (inRoom != displayed_room)
             check_new_room();

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -526,7 +526,7 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
     if (dm.RefreshRate >= 50)
         request_refresh_rate(dm.RefreshRate);
 
-    if (!gfxDriver->Init(dm, &timerloop))
+    if (!gfxDriver->SetDisplayMode(dm, &timerloop))
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init gfx mode. %s", get_allegro_error());
         return false;

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -608,6 +608,11 @@ bool graphics_mode_set_native_size(const Size &native_size)
     return true;
 }
 
+GameFrameSetup graphics_mode_get_render_frame()
+{
+    return CurFrameSetup;
+}
+
 bool graphics_mode_set_render_frame(const GameFrameSetup &frame_setup)
 {
     if (!frame_setup.IsValid())

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -125,6 +125,8 @@ bool graphics_mode_set_dm_any(const Size &game_size, const DisplayModeSetup &dm_
 bool graphics_mode_set_dm(const AGS::Engine::DisplayMode &dm);
 // Set the native image size
 bool graphics_mode_set_native_size(const Size &native_size);
+// Get current render frame setup
+GameFrameSetup graphics_mode_get_render_frame();
 // Set the render frame position inside the window
 bool graphics_mode_set_render_frame(const GameFrameSetup &frame_setup);
 // Set requested graphics filter, or default filter if the requested one failed

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -106,22 +106,30 @@ struct ColorDepthOption
 {
     int32_t Prime;
     int32_t Alternate;
+
+    ColorDepthOption() : Prime(0), Alternate(0) {}
+    ColorDepthOption(int32_t prime, int32_t alt = 0) : Prime(prime), Alternate(alt > 0 ? alt : prime) {}
 };
 
 // Initializes any possible gfx mode, using user config as a recommendation;
 // may try all available renderers and modes before succeeding (or failing)
 bool graphics_mode_init_any(const Size game_size, const ScreenSetup &setup, const ColorDepthOption &color_depths);
 // Fill in setup structs with default settings for the given mode (windowed or fullscreen)
-void graphics_mode_get_defaults(bool windowed, DisplayModeSetup &dm_setup, GameFrameSetup &frame_setup, GfxFilterSetup &filter_setup);
+void graphics_mode_get_defaults(bool windowed, DisplayModeSetup &dm_setup, GameFrameSetup &frame_setup);
 // Creates graphics driver of given id
 bool graphics_mode_create_renderer(const String &driver_id);
+// Try to find and initialize compatible display mode as close to given setup
+bool graphics_mode_set_dm_any(const Size &game_size, const DisplayModeSetup &dm_setup,
+                              const ColorDepthOption &color_depths, const GameFrameSetup &frame_setup);
 // Set the display mode with given parameters
 bool graphics_mode_set_dm(const AGS::Engine::DisplayMode &dm);
 // Set the native image size
 bool graphics_mode_set_native_size(const Size &native_size);
 // Set the render frame position inside the window
 bool graphics_mode_set_render_frame(const GameFrameSetup &frame_setup);
-// Set the scaling filter
+// Set requested graphics filter, or default filter if the requested one failed
+bool graphics_mode_set_filter_any(const GfxFilterSetup &setup);
+// Set the scaling filter with given ID
 bool graphics_mode_set_filter(const String &filter_id);
 // Releases current graphic mode and shuts down renderer
 void graphics_mode_shutdown();

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -60,6 +60,9 @@ struct GameFrameSetup
 {
     FrameScaleDefinition ScaleDef;    // a method used to determine game frame scaling
     int                  ScaleFactor; // explicit scale factor
+
+    GameFrameSetup();
+    bool IsValid() const;
 };
 
 enum ScreenSizeDefinition
@@ -80,6 +83,8 @@ struct DisplayModeSetup
     int                  RefreshRate;   // gfx mode refresh rate
     bool                 VSync;         // vertical sync
     bool                 Windowed;      // is mode windowed
+
+    DisplayModeSetup();
 };
 
 // General display configuration
@@ -92,6 +97,8 @@ struct ScreenSetup
     GameFrameSetup       GameFrame;     // definition of the game frame's position on screen
 
     bool                 RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
+
+    ScreenSetup();
 };
 
 // Display mode color depth variants allowed to be used
@@ -110,9 +117,10 @@ void graphics_mode_get_defaults(bool windowed, DisplayModeSetup &dm_setup, GameF
 bool graphics_mode_create_renderer(const String &driver_id);
 // Set the display mode with given parameters
 bool graphics_mode_set_dm(const AGS::Engine::DisplayMode &dm);
+// Set the native image size
+bool graphics_mode_set_native_size(const Size &native_size);
 // Set the render frame position inside the window
-bool graphics_mode_set_render_frame(const Size &native_size, const GameFrameSetup &frame_setup);
-bool graphics_mode_set_render_frame(const Size &native_size, const Rect &render_frame);
+bool graphics_mode_set_render_frame(const GameFrameSetup &frame_setup);
 // Set the scaling filter
 bool graphics_mode_set_filter(const String &filter_id);
 // Releases current graphic mode and shuts down renderer

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -24,6 +24,7 @@
 #include "gfx/ali3dexception.h"
 #include "gfx/gfxfilter_d3d.h"
 #include "gfx/gfxfilter_aad3d.h"
+#include "gfx/gfx_util.h"
 #include "main/main_allegro.h"
 #include "platform/base/agsplatformdriver.h"
 #include "platform/windows/gfx/ali3dd3d.h"
@@ -205,6 +206,13 @@ D3DGraphicsDriver::D3DGraphicsDriver(IDirect3D9 *d3d)
   set_up_default_vertices();
   pNativeSurface = NULL;
   _skipPresent = false;
+  availableVideoMemory = 0;
+  _nullSpriteCallback = NULL;
+  _smoothScaling = false;
+  _pixelRenderXOffset = 0;
+  _pixelRenderYOffset = 0;
+  _renderSprAtScreenRes = false;
+  flipTypeLastTime = kFlip_None;
 }
 
 void D3DGraphicsDriver::set_up_default_vertices()
@@ -252,9 +260,9 @@ void D3DGraphicsDriver::Vsync()
   // do nothing on D3D
 }
 
-void D3DGraphicsDriver::OnInit(const DisplayMode &mode, volatile int *loopTimer)
+void D3DGraphicsDriver::OnModeSet(const DisplayMode &mode)
 {
-  GraphicsDriverBase::OnInit(mode, loopTimer);
+  GraphicsDriverBase::OnModeSet(mode);
 
   // The display mode has been set up successfully, save the
   // final refresh rate that we are using
@@ -265,7 +273,136 @@ void D3DGraphicsDriver::OnInit(const DisplayMode &mode, volatile int *loopTimer)
   else {
     _mode.RefreshRate = 0;
   }
-  create_screen_tint_bitmap();
+}
+
+void D3DGraphicsDriver::ReleaseDisplayMode()
+{
+  OnModeReleased();
+
+  numToDraw = 0;
+  numToDrawLastTime = 0;
+  flipTypeLastTime = kFlip_None;
+
+  if (pNativeSurface)
+  {
+    pNativeSurface->Release();
+    pNativeSurface = NULL;
+  }
+
+  if (_screenTintLayerDDB != NULL) 
+  {
+    this->DestroyDDB(_screenTintLayerDDB);
+    _screenTintLayerDDB = NULL;
+    _screenTintSprite.bitmap = NULL;
+  }
+  delete _screenTintLayer;
+  _screenTintLayer = NULL;
+
+  delete _dummyVirtualScreen;
+  _dummyVirtualScreen = NULL;
+
+  gfx_driver = NULL;
+
+  // Restore allegro window styles in case we modified them
+  restore_window_style();
+  // For uncertain reasons WS_EX_TOPMOST (applied when creating fullscreen)
+  // cannot be removed with style altering functions; here use SetWindowPos
+  // as a workaround
+  SetWindowPos(win_get_window(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+}
+
+int D3DGraphicsDriver::FirstTimeInit()
+{
+  HRESULT hr;
+
+  direct3ddevice->GetDeviceCaps(&direct3ddevicecaps);
+
+  // the PixelShader.fx uses ps_1_4
+  // the PixelShaderLegacy.fx needs ps_2_0
+  int requiredPSMajorVersion = 1;
+  int requiredPSMinorVersion = 4;
+  if (_legacyPixelShader) {
+    requiredPSMajorVersion = 2;
+    requiredPSMinorVersion = 0;
+  }
+
+  if (direct3ddevicecaps.PixelShaderVersion < D3DPS_VERSION(requiredPSMajorVersion, requiredPSMinorVersion))  
+  {
+    direct3ddevice->Release();
+    direct3ddevice = NULL;
+    previousError = 
+        set_allegro_error("Graphics card does not support Pixel Shader %d.%d", requiredPSMajorVersion, requiredPSMinorVersion);
+    return -1;
+  }
+
+  // Load the pixel shader!!
+  HMODULE exeHandle = GetModuleHandle(NULL);
+  HRSRC hRes = FindResource(exeHandle, (_legacyPixelShader) ? "PIXEL_SHADER_LEGACY" : "PIXEL_SHADER", "DATA");
+  if (hRes)
+  {
+    HGLOBAL hGlobal = LoadResource(exeHandle, hRes);
+    if (hGlobal)
+    {
+      DWORD resourceSize = SizeofResource(exeHandle, hRes);
+      DWORD *dataPtr = (DWORD*)LockResource(hGlobal);
+      hr = direct3ddevice->CreatePixelShader(dataPtr, &pixelShader);
+      if (hr != D3D_OK)
+      {
+        direct3ddevice->Release();
+        direct3ddevice = NULL;
+        previousError = set_allegro_error("Failed to create pixel shader: 0x%08X", hr);
+        return -1;
+      }
+      UnlockResource(hGlobal);
+    }
+  }
+  
+  if (pixelShader == NULL)
+  {
+    direct3ddevice->Release();
+    direct3ddevice = NULL;
+    previousError = set_allegro_error("Failed to load pixel shader resource");
+    return -1;
+  }
+
+  if (direct3ddevice->CreateVertexBuffer(4*sizeof(CUSTOMVERTEX), D3DUSAGE_WRITEONLY,
+          D3DFVF_CUSTOMVERTEX, D3DPOOL_MANAGED, &vertexbuffer, NULL) != D3D_OK) 
+  {
+    direct3ddevice->Release();
+    direct3ddevice = NULL;
+    previousError = set_allegro_error("Failed to create vertex buffer");
+    return -1;
+  }
+
+  // This line crashes because my card doesn't support 8-bit textures
+  //direct3ddevice->SetCurrentTexturePalette(0);
+
+  CUSTOMVERTEX *vertices;
+  vertexbuffer->Lock(0, 0, (void**)&vertices, D3DLOCK_DISCARD);
+
+  for (int i = 0; i < 4; i++)
+  {
+    vertices[i] = defaultVertices[i];
+  }
+
+  vertexbuffer->Unlock();
+
+  direct3ddevice->GetGammaRamp(0, &defaultgammaramp);
+
+  if (defaultgammaramp.red[255] < 256)
+  {
+    // correct bug in some gfx drivers that returns gamma ramp
+    // values from 0-255 instead of 0-65535
+    for (int i = 0; i < 256; i++)
+    {
+      defaultgammaramp.red[i] *= 256;
+      defaultgammaramp.green[i] *= 256;
+      defaultgammaramp.blue[i] *= 256;
+    }
+  }
+  currentgammaramp = defaultgammaramp;
+
+  return 0;
 }
 
 void D3DGraphicsDriver::initD3DDLL(const DisplayMode &mode) 
@@ -497,9 +634,6 @@ int D3DGraphicsDriver::_resetDeviceIfNecessary()
 
 int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
 {
-  int i = 0;
-  CUSTOMVERTEX *vertices;
-
   HWND allegro_wnd = win_get_window();
 
   if (!mode.Windowed)
@@ -533,7 +667,12 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   if (_initGfxCallback != NULL)
     _initGfxCallback(&d3dpp);
 
-  HRESULT hr = direct3d->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, allegro_wnd,
+  bool first_time_init = direct3ddevice == NULL;
+  HRESULT hr = 0;
+  if (direct3ddevice)
+    hr = direct3ddevice->Reset(&d3dpp);
+  else
+    hr = direct3d->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, allegro_wnd,
                       D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_MULTITHREADED,  // multithreaded required for AVI player
                       &d3dpp, &direct3ddevice);
   if (hr != D3D_OK)
@@ -558,91 +697,12 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
 
   win_grab_input();
 
-  direct3ddevice->GetDeviceCaps(&direct3ddevicecaps);
-
-  // the PixelShader.fx uses ps_1_4
-  // the PixelShaderLegacy.fx needs ps_2_0
-  int requiredPSMajorVersion = 1;
-  int requiredPSMinorVersion = 4;
-  if (_legacyPixelShader) {
-    requiredPSMajorVersion = 2;
-    requiredPSMinorVersion = 0;
-  }
-
-  if (direct3ddevicecaps.PixelShaderVersion < D3DPS_VERSION(requiredPSMajorVersion, requiredPSMinorVersion))  
+  if (first_time_init)
   {
-    direct3ddevice->Release();
-    direct3ddevice = NULL;
-    previousError = 
-        set_allegro_error("Graphics card does not support Pixel Shader %d.%d", requiredPSMajorVersion, requiredPSMinorVersion);
-    return -1;
+    int ft_res = FirstTimeInit();
+    if (ft_res != 0)
+      return ft_res;
   }
-
-  // Load the pixel shader!!
-  HMODULE exeHandle = GetModuleHandle(NULL);
-  HRSRC hRes = FindResource(exeHandle, (_legacyPixelShader) ? "PIXEL_SHADER_LEGACY" : "PIXEL_SHADER", "DATA");
-  if (hRes)
-  {
-    HGLOBAL hGlobal = LoadResource(exeHandle, hRes);
-    if (hGlobal)
-    {
-      DWORD resourceSize = SizeofResource(exeHandle, hRes);
-      DWORD *dataPtr = (DWORD*)LockResource(hGlobal);
-      hr = direct3ddevice->CreatePixelShader(dataPtr, &pixelShader);
-      if (hr != D3D_OK)
-      {
-        direct3ddevice->Release();
-        direct3ddevice = NULL;
-        previousError = set_allegro_error("Failed to create pixel shader: 0x%08X", hr);
-        return -1;
-      }
-      UnlockResource(hGlobal);
-    }
-  }
-  
-  if (pixelShader == NULL)
-  {
-    direct3ddevice->Release();
-    direct3ddevice = NULL;
-    previousError = set_allegro_error("Failed to load pixel shader resource");
-    return -1;
-  }
-
-  // This line crashes because my card doesn't support 8-bit textures
-  //direct3ddevice->SetCurrentTexturePalette(0);
-
-  if (direct3ddevice->CreateVertexBuffer(4*sizeof(CUSTOMVERTEX), D3DUSAGE_WRITEONLY,
-          D3DFVF_CUSTOMVERTEX, D3DPOOL_MANAGED, &vertexbuffer, NULL) != D3D_OK) 
-  {
-    direct3ddevice->Release();
-    direct3ddevice = NULL;
-    previousError = set_allegro_error("Failed to create vertex buffer");
-    return -1;
-  }
-
-  vertexbuffer->Lock(0, 0, (void**)&vertices, D3DLOCK_DISCARD);
-
-  for (i = 0; i < 4; i++)
-  {
-    vertices[i] = defaultVertices[i];
-  }
-
-  vertexbuffer->Unlock();
-
-  direct3ddevice->GetGammaRamp(0, &defaultgammaramp);
-
-  if (defaultgammaramp.red[255] < 256)
-  {
-    // correct bug in some gfx drivers that returns gamma ramp
-    // values from 0-255 instead of 0-65535
-    for (i = 0; i < 256; i++)
-    {
-      defaultgammaramp.red[i] *= 256;
-      defaultgammaramp.green[i] *= 256;
-      defaultgammaramp.blue[i] *= 256;
-    }
-  }
-  currentgammaramp = defaultgammaramp;
   return 0;
 }
 
@@ -775,6 +835,7 @@ void D3DGraphicsDriver::SetupViewport()
   {
     throw Ali3DException("CreateRenderTarget failed");
   }
+
   direct3ddevice->ColorFill(pNativeSurface, NULL, 0);
 }
 
@@ -792,8 +853,10 @@ void D3DGraphicsDriver::SetTintMethod(TintMethod method)
   _legacyPixelShader = (method == TintReColourise);
 }
 
-bool D3DGraphicsDriver::Init(const DisplayMode &mode, volatile int *loopTimer)
+bool D3DGraphicsDriver::SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer)
 {
+  ReleaseDisplayMode();
+
   if (mode.ColorDepth < 15)
   {
     set_allegro_error("Direct3D driver does not support 256-colour games");
@@ -810,9 +873,11 @@ bool D3DGraphicsDriver::Init(const DisplayMode &mode, volatile int *loopTimer)
       set_allegro_error(exception._message);
     return false;
   }
-  OnInit(mode, loopTimer);
+  OnInit(loopTimer);
+  OnModeSet(mode);
   InitializeD3DState();
   CreateVirtualScreen();
+  create_screen_tint_bitmap();
   return true;
 }
 
@@ -822,6 +887,7 @@ void D3DGraphicsDriver::CreateVirtualScreen()
     return;
   // create dummy screen bitmap
   // TODO: find out why we are doing this
+  delete _dummyVirtualScreen;
   _dummyVirtualScreen = ReplaceBitmapWithSupportedFormat(
       BitmapHelper::CreateBitmap(_srcRect.GetWidth(), _srcRect.GetHeight(), _mode.ColorDepth));
   BitmapHelper::SetScreenBitmap(_dummyVirtualScreen);
@@ -834,7 +900,7 @@ bool D3DGraphicsDriver::SetRenderFrame(const Size &src_size, const Rect &dst_rec
   CreateVirtualScreen();
   // Also make sure viewport is updated using new native & destination rectangles
   SetupViewport();
-  return true;
+  return !_dstRect.IsEmpty();
 }
 
 IGfxModeList *D3DGraphicsDriver::GetSupportedModeList(int color_depth)
@@ -851,20 +917,11 @@ PGfxFilter D3DGraphicsDriver::GetGraphicsFilter() const
 void D3DGraphicsDriver::UnInit() 
 {
   OnUnInit();
+  ReleaseDisplayMode();
 
-  if (_screenTintLayerDDB != NULL) 
-  {
-    this->DestroyDDB(_screenTintLayerDDB);
-    _screenTintLayerDDB = NULL;
-    _screenTintSprite.bitmap = NULL;
-  }
-  delete _screenTintLayer;
-  _screenTintLayer = NULL;
   delete _dummyVirtualScreen;
   _dummyVirtualScreen = NULL;
-
   dxmedia_shutdown_3d();
-  gfx_driver = NULL;
 
   if (vertexbuffer)
   {
@@ -878,24 +935,11 @@ void D3DGraphicsDriver::UnInit()
     pixelShader = NULL;
   }
 
-  if (pNativeSurface)
-  {
-    pNativeSurface->Release();
-    pNativeSurface = NULL;
-  }
-
   if (direct3ddevice)
   {
     direct3ddevice->Release();
     direct3ddevice = NULL;
   }
-
-  // Restore allegro window styles in case we modified them
-  restore_window_style();
-  // For uncertain reasons WS_EX_TOPMOST (applied when creating fullscreen)
-  // cannot be removed with style altering functions; here use SetWindowPos
-  // as a workaround
-  SetWindowPos(win_get_window(), HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 
 D3DGraphicsDriver::~D3DGraphicsDriver()

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -172,7 +172,7 @@ public:
     virtual const char*GetDriverName() { return "Direct3D 9"; }
     virtual const char*GetDriverID() { return "D3D9"; }
     virtual void SetTintMethod(TintMethod method);
-    virtual bool Init(const DisplayMode &mode, volatile int *loopTimer);
+    virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
     virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
@@ -261,11 +261,14 @@ private:
     GlobalFlipType flipTypeLastTime;
 
     // Called after new mode was successfully initialized
-    virtual void OnInit(const DisplayMode &mode, volatile int *loopTimer);
-
+    virtual void OnModeSet(const DisplayMode &mode);
+    // Called when the direct3d device is created for the first time
+    int  FirstTimeInit();
     void initD3DDLL(const DisplayMode &mode);
     void InitializeD3DState();
     void SetupViewport();
+    // Unset parameters and release resources related to the display mode
+    void ReleaseDisplayMode();
     void set_up_default_vertices();
     void make_translated_scaling_matrix(D3DMATRIX *matrix, float x, float y, float xScale, float yScale);
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -173,7 +173,8 @@ public:
     virtual const char*GetDriverID() { return "D3D9"; }
     virtual void SetTintMethod(TintMethod method);
     virtual bool SetDisplayMode(const DisplayMode &mode, volatile int *loopTimer);
-    virtual bool SetRenderFrame(const Size &src_size, const Rect &dst_rect);
+    virtual bool SetNativeSize(const Size &src_size);
+    virtual bool SetRenderFrame(const Rect &dst_rect);
     virtual IGfxModeList *GetSupportedModeList(int color_depth);
     virtual bool IsModeSupported(const DisplayMode &mode);
     virtual PGfxFilter GetGraphicsFilter() const;
@@ -267,6 +268,7 @@ private:
     void initD3DDLL(const DisplayMode &mode);
     void InitializeD3DState();
     void SetupViewport();
+    HRESULT ResetD3DDevice();
     // Unset parameters and release resources related to the display mode
     void ReleaseDisplayMode();
     void set_up_default_vertices();


### PR DESCRIPTION
This implements method for switching between windowed and fullscreen modes at runtime.
Default Alt+Enter key combination is used to trigger the switch.