### PR TITLE
Global (all-games) user configuration

### DIFF
--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -223,6 +223,12 @@ String find_default_cfg_file(const char *alt_cfg_file)
     return filename;
 }
 
+String find_user_global_cfg_file()
+{
+    String parent_dir = PathOrCurDir(platform->GetUserGlobalConfigDirectory());
+    return String::FromFormat("%s/%s", parent_dir.GetCStr(), DefaultConfigFileName.GetCStr());
+}
+
 String find_user_cfg_file()
 {
     String parent_dir = MakeSpecialSubDir(PathOrCurDir(platform->GetUserConfigDirectory()));

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -28,6 +28,8 @@ using AGS::Common::ConfigTree;
 void config_defaults();
 // Find and default configuration file (usually located in the game installation directory)
 String find_default_cfg_file(const char *alt_cfg_file);
+// Find all-games user configuration file
+String find_user_global_cfg_file();
 // Find and game-specific user configuration file (located into writable user directory)
 String find_user_cfg_file();
 // Read optional data file name and location from config

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -24,11 +24,12 @@
 using AGS::Common::String;
 using AGS::Common::ConfigTree;
 
-extern String ac_config_file;
-// Find and load default configuration file (usually located in the game installation directory)
-void load_default_config_file(AGS::Common::ConfigTree &cfg, const char *alt_cfg_file);
-// Find and load user configuration file (located into writable user location)
-void load_user_config_file(AGS::Common::ConfigTree &cfg);
+// Set up default config settings
+void config_defaults();
+// Find and default configuration file (usually located in the game installation directory)
+String find_default_cfg_file(const char *alt_cfg_file);
+// Find and game-specific user configuration file (located into writable user directory)
+String find_user_cfg_file();
 // Read optional data file name and location from config
 void read_game_data_location(const AGS::Common::ConfigTree &cfg);
 // Setup game using final config tree

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1342,9 +1342,15 @@ bool engine_read_config(const String &exe_path, ConfigTree &cfg)
         return false;
     }
 
+    // Read user global configuration file
+    String user_global_cfg_file = find_user_global_cfg_file();
+    if (Path::ComparePaths(user_global_cfg_file, def_cfg_file) != 0)
+        IniUtil::Read(user_global_cfg_file, cfg);
+
     // Read user configuration file
     String user_cfg_file = find_user_cfg_file();
-    if (Path::ComparePaths(user_cfg_file, def_cfg_file) != 0)
+    if (Path::ComparePaths(user_cfg_file, def_cfg_file) != 0 &&
+        Path::ComparePaths(user_cfg_file, user_global_cfg_file) != 0)
         IniUtil::Read(user_cfg_file, cfg);
 
     // TODO: override config tree with all the command-line args.

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -49,12 +49,14 @@ struct AGSPlatformDriver
     virtual void Delay(int millis) = 0;
     virtual void DisplayAlert(const char*, ...) = 0;
     virtual int  GetLastSystemError() { return errno; }
-    // Get directory for storing shared game data
+    // Get root directory for storing per-game shared data
     virtual const char *GetAllUsersDataDirectory() { return "."; }
-    // Get directory for storing user's saved games
+    // Get root directory for storing per-game saved games
     virtual const char *GetUserSavedgamesDirectory() { return "."; }
-    // Get directory for storing user configuration files
+    // Get root directory for storing per-game user configuration files
     virtual const char *GetUserConfigDirectory() { return "."; }
+    // Get directory for storing all-games user configuration files
+    virtual const char *GetUserGlobalConfigDirectory()  { return "."; }
     // Get default directory for program output (logs)
     virtual const char *GetAppOutputDirectory() { return "."; }
     // Returns array of characters illegal to use in file names

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -45,6 +45,8 @@ struct AGSLinux : AGSPlatformDriver {
   virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
   virtual const char *GetUserSavedgamesDirectory();
+  virtual const char *GetUserConfigDirectory();
+  virtual const char *GetUserGlobalConfigDirectory();
   virtual const char *GetAppOutputDirectory();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
@@ -118,6 +120,16 @@ const char *AGSLinux::GetUserSavedgamesDirectory()
 {
   DetermineAppOutputDirectory();
   return LinuxOutputDirectory;
+}
+
+const char *AGSLinux::GetUserConfigDirectory()
+{
+  return GetUserSavedgamesDirectory();
+}
+
+const char *AGSLinux::GetUserGlobalConfigDirectory()
+{
+  return GetUserSavedgamesDirectory();
 }
 
 const char *AGSLinux::GetAppOutputDirectory()

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -103,6 +103,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual const char *GetAllUsersDataDirectory();
   virtual const char *GetUserSavedgamesDirectory();
   virtual const char *GetUserConfigDirectory();
+  virtual const char *GetUserGlobalConfigDirectory();
   virtual const char *GetAppOutputDirectory();
   virtual const char *GetIllegalFileChars();
   virtual const char *GetFileWriteTroubleshootingText();
@@ -642,6 +643,12 @@ const char *AGSWin32::GetUserConfigDirectory()
 {
   determine_saved_games_folder();
   return win32SavedGamesDirectory;
+}
+
+const char *AGSWin32::GetUserGlobalConfigDirectory()
+{
+  DetermineAppOutputDirectory();
+  return win32OutputDirectory;
 }
 
 const char *AGSWin32::GetAppOutputDirectory()


### PR DESCRIPTION
As of (rather old) feature request (#287), this adds support for user's global configuration file, that is - a single file that is applied for every game.

The suggested rule is that config files are read in following order, every next one overridding previous ones (only options that are included in the current file are overridden, options that are not included keep their values from previous configs):
* config file inside game installation directory (aka "default game config");
* user's global, all-games config file;
* user's game-specific config file.

The latest is also one that is allowed to be modified by the engine (for example, to write config options that could be changed at runtime, such as game translation).

Actual config location is different for every platform. At the moment only two supported desktop platforms have such locations specified, but they could be easily added for other OSes if needed.

*Linux*
* user's global config: $XDG_DATA_HOME/ags/acsetup.cfg
* user's game config: $XDG_DATA_HOME/ags/GAMENAME/acsetup.cfg

NOTE: if $XDG_DATA_HOME is not defined, then "$HOME/.local/share" is used instead, similar as for saved games.

*Windows*
* user's global config: %USERPROFILE%/Saved Games/.ags/acsetup.cfg
* user's game config: %USERPROFILE%/Saved Games/GAMENAME/acsetup.cfg