### PR TITLE
ScriptAPI: exposed properties for getting animated button's state

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1525,6 +1525,16 @@ builtin managed struct Button extends GUIControl {
   /// Runs the OnClick event handler for this Button.
   import void Click(MouseButton);
 #endif
+#ifdef SCRIPT_API_v341
+  /// Gets whether the button is currently animating.
+  readonly import attribute bool Animating;
+  /// Gets the current frame number during an animation.
+  readonly import attribute int  Frame;
+  /// Gets the current loop number during an animation.
+  readonly import attribute int  Loop;
+  /// Gets the current view number during an animation.
+  readonly import attribute int  View;
+#endif
 };
 
 builtin managed struct Slider extends GUIControl {

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -235,21 +235,55 @@ void StopButtonAnimation(int idxn) {
     }
 }
 
-void FindAndRemoveButtonAnimation(int guin, int objn) {
-
-    for (int ii = 0; ii < numAnimButs; ii++) {
-        if ((animbuts[ii].ongui == guin) && (animbuts[ii].onguibut == objn)) {
-            StopButtonAnimation(ii);
-            ii--;
-        }
-
+// Returns the index of the AnimatingGUIButton object corresponding to the
+// given button ID; returns -1 if no such animation exists
+int FindAnimatedButton(int guin, int objn)
+{
+    for (int i = 0; i < numAnimButs; ++i)
+    {
+        if (animbuts[i].ongui == guin && animbuts[i].onguibut == objn)
+            return i;
     }
+    return -1;
+}
+
+void FindAndRemoveButtonAnimation(int guin, int objn)
+{
+    int idx = FindAnimatedButton(guin, objn);
+    if (idx >= 0)
+        StopButtonAnimation(idx);
 }
 // ** end animating buttons code
 
 void Button_Click(GUIButton *butt, int mbut)
 {
     process_interface_click(butt->guin, butt->objn, mbut);
+}
+
+bool Button_IsAnimating(GUIButton *butt)
+{
+    return FindAnimatedButton(butt->guin, butt->objn) >= 0;
+}
+
+// NOTE: in correspondance to similar functions for Character & Object,
+// GetView returns (view index + 1), while GetLoop and GetFrame return
+// zero-based index and 0 in case of no animation.
+int Button_GetAnimView(GUIButton *butt)
+{
+    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    return idx >= 0 ? animbuts[idx].view + 1 : 0;
+}
+
+int Button_GetAnimLoop(GUIButton *butt)
+{
+    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    return idx >= 0 ? animbuts[idx].loop : 0;
+}
+
+int Button_GetAnimFrame(GUIButton *butt)
+{
+    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    return idx >= 0 ? animbuts[idx].frame : 0;
 }
 
 //=============================================================================
@@ -372,27 +406,51 @@ RuntimeScriptValue Sc_Button_Click(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(GUIButton, Button_Click);
 }
 
+RuntimeScriptValue Sc_Button_GetAnimating(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(GUIButton, Button_IsAnimating);
+}
+
+RuntimeScriptValue Sc_Button_GetFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetAnimFrame);
+}
+
+RuntimeScriptValue Sc_Button_GetLoop(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetAnimLoop);
+}
+
+RuntimeScriptValue Sc_Button_GetView(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIButton, Button_GetAnimView);
+}
+
 void RegisterButtonAPI()
 {
     ccAddExternalObjectFunction("Button::Animate^4",            Sc_Button_Animate);
     ccAddExternalObjectFunction("Button::Click^1",              Sc_Button_Click);
-	ccAddExternalObjectFunction("Button::GetText^1",            Sc_Button_GetText);
-	ccAddExternalObjectFunction("Button::SetText^1",            Sc_Button_SetText);
-	ccAddExternalObjectFunction("Button::get_ClipImage",        Sc_Button_GetClipImage);
-	ccAddExternalObjectFunction("Button::set_ClipImage",        Sc_Button_SetClipImage);
-	ccAddExternalObjectFunction("Button::get_Font",             Sc_Button_GetFont);
-	ccAddExternalObjectFunction("Button::set_Font",             Sc_Button_SetFont);
-	ccAddExternalObjectFunction("Button::get_Graphic",          Sc_Button_GetGraphic);
-	ccAddExternalObjectFunction("Button::get_MouseOverGraphic", Sc_Button_GetMouseOverGraphic);
-	ccAddExternalObjectFunction("Button::set_MouseOverGraphic", Sc_Button_SetMouseOverGraphic);
-	ccAddExternalObjectFunction("Button::get_NormalGraphic",    Sc_Button_GetNormalGraphic);
-	ccAddExternalObjectFunction("Button::set_NormalGraphic",    Sc_Button_SetNormalGraphic);
-	ccAddExternalObjectFunction("Button::get_PushedGraphic",    Sc_Button_GetPushedGraphic);
-	ccAddExternalObjectFunction("Button::set_PushedGraphic",    Sc_Button_SetPushedGraphic);
-	ccAddExternalObjectFunction("Button::get_Text",             Sc_Button_GetText_New);
-	ccAddExternalObjectFunction("Button::set_Text",             Sc_Button_SetText);
-	ccAddExternalObjectFunction("Button::get_TextColor",        Sc_Button_GetTextColor);
-	ccAddExternalObjectFunction("Button::set_TextColor",        Sc_Button_SetTextColor);
+    ccAddExternalObjectFunction("Button::GetText^1",            Sc_Button_GetText);
+    ccAddExternalObjectFunction("Button::SetText^1",            Sc_Button_SetText);
+    ccAddExternalObjectFunction("Button::get_Animating",        Sc_Button_GetAnimating);
+    ccAddExternalObjectFunction("Button::get_ClipImage",        Sc_Button_GetClipImage);
+    ccAddExternalObjectFunction("Button::set_ClipImage",        Sc_Button_SetClipImage);
+    ccAddExternalObjectFunction("Button::get_Font",             Sc_Button_GetFont);
+    ccAddExternalObjectFunction("Button::set_Font",             Sc_Button_SetFont);
+    ccAddExternalObjectFunction("Button::get_Frame",            Sc_Button_GetFrame);
+    ccAddExternalObjectFunction("Button::get_Graphic",          Sc_Button_GetGraphic);
+    ccAddExternalObjectFunction("Button::get_Loop",             Sc_Button_GetLoop);
+    ccAddExternalObjectFunction("Button::get_MouseOverGraphic", Sc_Button_GetMouseOverGraphic);
+    ccAddExternalObjectFunction("Button::set_MouseOverGraphic", Sc_Button_SetMouseOverGraphic);
+    ccAddExternalObjectFunction("Button::get_NormalGraphic",    Sc_Button_GetNormalGraphic);
+    ccAddExternalObjectFunction("Button::set_NormalGraphic",    Sc_Button_SetNormalGraphic);
+    ccAddExternalObjectFunction("Button::get_PushedGraphic",    Sc_Button_GetPushedGraphic);
+    ccAddExternalObjectFunction("Button::set_PushedGraphic",    Sc_Button_SetPushedGraphic);
+    ccAddExternalObjectFunction("Button::get_Text",             Sc_Button_GetText_New);
+    ccAddExternalObjectFunction("Button::set_Text",             Sc_Button_SetText);
+    ccAddExternalObjectFunction("Button::get_TextColor",        Sc_Button_GetTextColor);
+    ccAddExternalObjectFunction("Button::set_TextColor",        Sc_Button_SetTextColor);
+    ccAddExternalObjectFunction("Button::get_View",             Sc_Button_GetView);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 


### PR DESCRIPTION
These are readonly properties for getting current state of animating button, complying to similar properties of (Room)Object and Character:
* Button.Animating
* Button.View
* Button.Loop
* Button.Frame

Buttons are animated using Button.Animate function, but there were no means to read current state of the animation.