### PR TITLE
Scripting: Do not push 0-size structs onto the stack

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3358,8 +3358,10 @@ int parse_variable_declaration(long cursym,int *next_type,int isglobal,
       sym.entries[cursym].flags |= SFLG_STRBUFFER;
       scrip->fixup_previous(FIXUP_STACK);
     }
-    scrip->cur_sp += varsize;
-    scrip->write_cmd2(SCMD_ADD,SREG_SP,varsize);
+    if(varsize > 0) {
+      scrip->cur_sp += varsize;
+      scrip->write_cmd2(SCMD_ADD,SREG_SP,varsize);
+    }
   }
   if ((getsvalue != &lbuffer) && (getsvalue != NULL))
     free(getsvalue);


### PR DESCRIPTION
If a function contained an instance of a struct with no fields, exiting the function would cause a stack underflow. This bug has been present since at least 3.2.1, possibly earlier.

Note: I am specifically talking about non-managed structs.

It could be argued that the engine's stack pointer handling should know how to properly deal with 0-size structs, but I think not pushing them to the stack is the simplest solution.

Here is a quick example of what I mean:
```
struct MyStruct {};

function OffendingFunction() { MyStruct a; }
```

Also, I am still working on the switch/case string comparison bug. This was in a stash and annoying me, so I thought I'd commit it.