### PR TITLE
Custom font line spacing

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -94,6 +94,9 @@ Ambient lighting
 48 : 3.4.1
 OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 
+49 : 3.4.1.2
+Font custom line spacing.
+
 */
 
 enum GameDataVersion
@@ -125,7 +128,8 @@ enum GameDataVersion
     kGameVersion_340_2          = 46,
     kGameVersion_340_4          = 47,
     kGameVersion_341            = 48,
-    kGameVersion_Current        = kGameVersion_341
+    kGameVersion_341_2          = 49,
+    kGameVersion_Current        = kGameVersion_341_2
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -56,8 +56,15 @@ void GameSetupStruct::read_font_flags(Common::Stream *in, GameDataVersion data_v
 {
     in->Read(&fontflags[0], numfonts);
     in->Read(&fontoutline[0], numfonts);
-    if (data_ver >= kGameVersion_341)
-        in->ReadArrayOfInt32(fontvoffset, numfonts);
+    if (data_ver < kGameVersion_341)
+        return;
+    // Extended font parameters
+    for (int i = 0; i < numfonts; ++i)
+    {
+        fontvoffset[i] = in->ReadInt32();
+        if (data_ver >= kGameVersion_341_2)
+            fontlnspace[i] = in->ReadInt32();
+    }
 }
 
 MainGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDataVersion data_ver)

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -57,7 +57,11 @@ void GameSetupStruct::read_font_flags(Common::Stream *in, GameDataVersion data_v
     in->Read(&fontflags[0], numfonts);
     in->Read(&fontoutline[0], numfonts);
     if (data_ver < kGameVersion_341)
+    {
+        memset(fontvoffset, 0, sizeof(fontvoffset));
+        memset(fontlnspace, 0, sizeof(fontlnspace));
         return;
+    }
     // Extended font parameters
     for (int i = 0; i < numfonts; ++i)
     {

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -42,6 +42,7 @@ struct GameSetupStruct: public GameSetupStructBase {
     unsigned char     fontflags[MAX_FONTS];
     char              fontoutline[MAX_FONTS];
     int               fontvoffset[MAX_FONTS]; // vertical font offset
+    int               fontlnspace[MAX_FONTS]; // font's line spacing (0 = default)
     //
     unsigned char     spriteflags[MAX_SPRITES];
     InventoryItemInfo invinfo[MAX_INV];

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -25,6 +25,7 @@ public:
   virtual void FreeMemory(int fontNumber) = 0;
   virtual bool SupportsExtendedCharacters(int fontNumber) = 0;
   virtual int GetTextWidth(const char *text, int fontNumber) = 0;
+  // Get actual height of the given line of text
   virtual int GetTextHeight(const char *text, int fontNumber) = 0;
   // [IKM] An important note: the AGS font renderers do not use 'destination' parameter at all, probably
   // for simplicity (although that causes confusion): the parameter passed is always a global 'virtual screen'

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -64,6 +64,7 @@ FontInfo::FontInfo()
     , SizePt(0)
     , Outline(-1)
     , YOffset(0)
+    , LineSpacing(0)
 {}
 
 
@@ -128,6 +129,24 @@ int get_font_outline(int font_number)
 void set_font_outline(int font_number, int outline_type)
 {
     fonts[font_number].Info.Outline = FONT_OUTLINE_AUTO;
+}
+
+int getfontheight(int fontNumber)
+{
+  // There is no explicit method for getting maximal possible height of any
+  // random font renderer at the moment; the implementations of GetTextHeight
+  // are allowed to return varied results depending on the text parameter.
+  // We use special line of text to get more or less reliable font height.
+  const char *height_test_string = "ZHwypgfjqhkilIK";
+  return fonts[fontNumber].Renderer->GetTextHeight(height_test_string, fontNumber);
+}
+
+int getfontlinespacing(int fontNumber)
+{
+  int spacing = fonts[fontNumber].Info.LineSpacing;
+  // If the spacing parameter is not provided, then return default
+  // spacing, that is font's height.
+  return spacing > 0 ? spacing : getfontheight(fontNumber);
 }
 
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, const char *texx)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -149,6 +149,11 @@ int getfontlinespacing(int fontNumber)
   return spacing > 0 ? spacing : getfontheight(fontNumber);
 }
 
+bool use_default_linespacing(int fontNumber)
+{
+    return fonts[fontNumber].Info.LineSpacing == 0;
+}
+
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, const char *texx)
 {
   yyy += fonts[fontNumber].Info.YOffset;

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -39,6 +39,8 @@ struct FontInfo
     char          Outline;
     // Custom vertical render offset, used mainly for fixing broken fonts
     int           YOffset;
+    // custom line spacing between two lines of text (0 = use font height)
+    int           LineSpacing;
 
     FontInfo();
 };
@@ -56,10 +58,16 @@ bool font_first_renderer_loaded();
 bool font_supports_extended_characters(int fontNumber);
 void ensure_text_valid_for_font(char *text, int fontnum);
 int wgettextwidth(const char *texx, int fontNumber);
+// Calculates actual height of a line of text
 int wgettextheight(const char *text, int fontNumber);
+// Get font's height (maximal height of any line of text printed with this font)
+int getfontheight(int fontNumber);
+// Get font's line spacing
+int getfontlinespacing(int fontNumber);
 int  get_font_outline(int font_number);
 void set_font_outline(int font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters
+int getfontlinespacing(int fontNumber);
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, const char *texx);
 // Loads a font from disk
 bool wloadfont_size(int fontNumber, const FontInfo &font_info, const FontRenderParams *params = NULL);

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -64,6 +64,8 @@ int wgettextheight(const char *text, int fontNumber);
 int getfontheight(int fontNumber);
 // Get font's line spacing
 int getfontlinespacing(int fontNumber);
+// Get is font is meant to use default line spacing
+bool use_default_linespacing(int fontNumber);
 int  get_font_outline(int font_number);
 void set_font_outline(int font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -81,7 +81,7 @@ void GUILabel::printtext_align(Common::Bitmap *ds, int yy, color_t text_color, c
 
 void GUILabel::Draw(Common::Bitmap *ds)
 {
-  int cyp = y, TEXT_HT;
+  int cyp = y, linespacing;
   char oritext[MAX_GUILABEL_TEXT_LEN], *teptr;
 
   check_font(&font);
@@ -89,7 +89,7 @@ void GUILabel::Draw(Common::Bitmap *ds)
   Draw_replace_macro_tokens(oritext, text);
 
   teptr = &oritext[0];
-  TEXT_HT = wgettextheight("ZhypjIHQFb", font) + 1;
+  linespacing = getfontlinespacing(font) + 1;
 
   color_t text_color = ds->GetCompatibleColor(textcol);
 
@@ -99,7 +99,7 @@ void GUILabel::Draw(Common::Bitmap *ds)
   const bool limit_by_label_frame = loaded_game_file_version >= kGameVersion_272;
   for (int aa = 0; aa < numlines; aa++) {
     printtext_align(ds, cyp, text_color, lines[aa]);
-    cyp += TEXT_HT;
+    cyp += linespacing;
     if (limit_by_label_frame && cyp > y + hit)
       break;
   }

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -30,7 +30,7 @@ int numguilist = 0;
 
 void GUIListBox::ChangeFont(int newfont) {
   font = newfont;
-  rowheight = wgettextheight("YpyjIHgMNWQ", font) + get_fixed_pixel_size(2);
+  rowheight = getfontheight(font) + get_fixed_pixel_size(2);
   num_items_fit = hit / rowheight;
 }
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1321,6 +1321,7 @@ namespace AGS.Editor
             for (int i = 0; i < game.Fonts.Count; ++i)
             {
                 writer.Write(game.Fonts[i].VerticalOffset);
+                writer.Write(game.Fonts[i].LineSpacing);
             }
             writer.Write(NativeConstants.MAX_SPRITES);
             byte[] spriteFlags = new byte[NativeConstants.MAX_SPRITES];

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1033,6 +1033,10 @@ import void RawRestoreScreen ();
 import int  GetTextWidth(const string text, FontType);
 /// Gets the height of the specified text in the specified font when wrapped at the specified width
 import int  GetTextHeight(const string text, FontType, int width);
+/// Gets the font's height, in pixels
+import int  GetFontHeight(FontType);
+/// Gets the default step between two lines of text for the specified font
+import int  GetFontLineSpacing(FontType);
 /// Adds to the player's score and plays the score sound, if set.
 import void GiveScore(int points);
 /// Refreshes the on-screen inventory display.

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2548,6 +2548,8 @@ void SetGameResolution(Game ^game)
 }
 
 void GameUpdated(Game ^game) {
+  // TODO: this function may get called when only one item is added/removed or edited;
+  // probably it would be best to split it up into several callbacks at some point.
   thisgame.color_depth = (int)game->Settings->ColorDepth;
   SetGameResolution(game);
 
@@ -2572,12 +2574,14 @@ void GameUpdated(Game ^game) {
     }
   }
 
+  // Reload native fonts and update font information in the managed component
   thisgame.numfonts = game->Fonts->Count;
   for (int i = 0; i < thisgame.numfonts; i++) 
   {
 	  thisgame.fontflags[i] &= ~FFLG_SIZEMASK;
 	  thisgame.fontflags[i] |= game->Fonts[i]->PointSize;
 	  reload_font(i);
+	  game->Fonts[i]->Height = getfontheight(i);
   }
 }
 

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -16,6 +16,7 @@ namespace AGS.Types
         private FontOutlineStyle _outlineStyle;
 		private string _sourceFilename = string.Empty;
         private int _verticalOffset;
+        private int _lineSpacing;
 
         public Font()
         {
@@ -23,6 +24,7 @@ namespace AGS.Types
             _outlineFont = 0;
             _name = string.Empty;
             _pointSize = 0;
+            _lineSpacing = 0;
         }
 
         [Description("The ID number of the font")]
@@ -116,6 +118,14 @@ namespace AGS.Types
         {
             get { return _verticalOffset; }
             set { _verticalOffset = value; }
+        }
+
+        [Description("Default step between successive lines of text, in pixels. Setting it lower than font's height will make lines partially overlap. Put 0 to use default spacing (usually - font height).")]
+        [Category("Appearance")]
+        public int LineSpacing
+        {
+            get { return _lineSpacing; }
+            set { _lineSpacing = value; }
         }
 
 		[Browsable(false)]

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -12,6 +12,7 @@ namespace AGS.Types
         private int _id;
         private string _name;
         private int _pointSize;
+        private int _fontHeight;
         private int _outlineFont;
         private FontOutlineStyle _outlineStyle;
 		private string _sourceFilename = string.Empty;
@@ -24,6 +25,7 @@ namespace AGS.Types
             _outlineFont = 0;
             _name = string.Empty;
             _pointSize = 0;
+            _fontHeight = 0;
             _lineSpacing = 0;
         }
 
@@ -49,6 +51,17 @@ namespace AGS.Types
         public string PointSizeDescription
         {
             get { return (_pointSize < 1) ? "N/A" : "" + _pointSize + " pt"; }
+        }
+
+        [AGSNoSerialize]
+        [Description("The actual height of a font, in pixels")]
+        [Category("Appearance")]
+        [DisplayName("Font Height")]
+        [ReadOnly(true)]
+        public int Height
+        {
+            get { return _fontHeight; }
+            set { _fontHeight = value; }
         }
 
         [Description("The name of the font")]

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -338,7 +338,7 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
 
 int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, int numdisp, int mouseison, int areawid,
     int bullet_wid, int usingfont, DialogTopic*dtop, char*disporder, short*dispyp,
-    int txthit, int utextcol, int padding) {
+    int linespacing, int utextcol, int padding) {
   int ww;
 
   color_t text_color;
@@ -378,7 +378,7 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
     }
     for (cc=0;cc<numlines;cc++) {
       wouttext_outline(ds, dlgxp+((cc==0) ? 0 : 9)+bullet_wid, curyp, usingfont, text_color, lines[cc]);
-      curyp+=txthit;
+      curyp+=linespacing;
     }
     if (ww < numdisp-1)
       curyp += multiply_up_coordinate(game.options[OPT_DIALOGGAP]);
@@ -392,7 +392,7 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
   needheight = 0;\
   for (int i = 0; i < numdisp; ++i) {\
     break_up_text_into_lines(areawid-(2*padding+2+bullet_wid),usingfont,get_translation(dtop->optionnames[disporder[i]]));\
-    needheight += (numlines * txthit) + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
+    needheight += getheightoflines(usingfont, numlines) + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
   }\
   if (parserInput) needheight += parserInput->hit + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
  }
@@ -436,7 +436,8 @@ struct DialogOptions
     int dialog_abs_x; // absolute dialog position on screen
     int padding;
     int usingfont;
-    int txthit;
+    int lineheight;
+    int linespacing;
     int curswas;
     int bullet_wid;
     int needheight;
@@ -485,7 +486,8 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
 
   dlgyp = get_fixed_pixel_size(160);
   usingfont=FONT_NORMAL;
-  txthit = wgetfontheight(usingfont);
+  lineheight = getfontheight_outlined(usingfont);
+  linespacing = getfontspacing_outlined(usingfont);
   curswas=cur_cursor;
   bullet_wid = 0;
   ddb = NULL;
@@ -525,7 +527,7 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
   parserActivated = 0;
   if ((dtop->topicFlags & DTFLG_SHOWPARSER) && (play.disable_dialog_parser == 0)) {
     parserInput = new GUITextBox();
-    parserInput->hit = txthit + get_fixed_pixel_size(4);
+    parserInput->hit = lineheight + get_fixed_pixel_size(4);
     parserInput->exflags = 0;
     parserInput->font = usingfont;
   }
@@ -735,7 +737,7 @@ void DialogOptions::Redraw()
       txoffs += xspos;
       tyoffs += yspos;
       dlgyp = tyoffs;
-      curyp = write_dialog_options(ds, options_surface_has_alpha, txoffs,tyoffs,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,txthit,forecol,padding);
+      curyp = write_dialog_options(ds, options_surface_has_alpha, txoffs,tyoffs,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
       if (parserInput)
         parserInput->x = txoffs;
     }
@@ -784,7 +786,7 @@ void DialogOptions::Redraw()
 
       //curyp = dlgyp + 1;
       curyp = dlgyp;
-      curyp = write_dialog_options(ds, options_surface_has_alpha, dlgxp,curyp,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,txthit,forecol,padding);
+      curyp = write_dialog_options(ds, options_surface_has_alpha, dlgxp,curyp,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
 
       /*if (curyp > play.viewport.GetHeight()) {
         dlgyp = play.viewport.GetHeight() - (curyp - dlgyp);

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -28,7 +28,16 @@ bool ShouldAntiAliasText();
 int GetTextDisplayTime (const char *text, int canberel=0);
 void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char*texx);
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, int align);
-int wgetfontheight(int font);
+// TODO: GUI classes located in Common library do not make use of outlining,
+// need to find a way to make all code use same functions.
+// Get the maximal height of the given font, with possible outlining in mind
+int getfontheight_outlined(int font);
+// Get line spacing for the given font, with possible outlining in mind
+int getfontspacing_outlined(int font);
+// Get the distance between bottom one one line and top of the next line (may be negative!)
+int getfontlinegap(int font);
+// Gets the total maximal height of the given number of lines printed with the given font
+int getheightoflines(int font, int numlines);
 int wgettextwidth_compensate(const char *tex, int font);
 void do_corner(Common::Bitmap *ds, int sprn,int xx1,int yy1,int typx,int typy);
 int get_but_pic(GUIMain*guo,int indx);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -670,7 +670,7 @@ void invalidate_sprite(int x1, int y1, IDriverDependantBitmap *pic) {
 
 void draw_and_invalidate_text(Bitmap *ds, int x1, int y1, int font, color_t text_color, const char *text) {
     wouttext_outline(ds, x1, y1, font, text_color, (char*)text);
-    invalidate_rect(x1, y1, x1 + wgettextwidth_compensate(text, font), y1 + wgetfontheight(font) + get_fixed_pixel_size(1));
+    invalidate_rect(x1, y1, x1 + wgettextwidth_compensate(text, font), y1 + getfontheight_outlined(font) + get_fixed_pixel_size(1));
 }
 
 void invalidate_screen() {
@@ -2130,7 +2130,7 @@ void draw_fps()
 
     if (fpsDisplay == NULL)
     {
-        fpsDisplay = BitmapHelper::CreateBitmap(get_fixed_pixel_size(100), (wgetfontheight(FONT_SPEECH) + get_fixed_pixel_size(5)), ScreenResolution.ColorDepth);
+        fpsDisplay = BitmapHelper::CreateBitmap(get_fixed_pixel_size(100), (getfontheight_outlined(FONT_SPEECH) + get_fixed_pixel_size(5)), ScreenResolution.ColorDepth);
         fpsDisplay = ReplaceBitmapWithSupportedFormat(fpsDisplay);
     }
     fpsDisplay->ClearTransparent();
@@ -2422,8 +2422,8 @@ void update_screen() {
     {
         //int otextc = ds->GetTextColor();
         int ypp = 1;
-        int txtheight = wgetfontheight(0);
-        int barheight = (DEBUG_CONSOLE_NUMLINES - 1) * txtheight + 4;
+        int txtspacing= getfontspacing_outlined(0);
+        int barheight = getheightoflines(0, DEBUG_CONSOLE_NUMLINES - 1) + 4;
 
         if (debugConsoleBuffer == NULL)
         {
@@ -2439,7 +2439,7 @@ void update_screen() {
         color_t text_color = debugConsoleBuffer->GetCompatibleColor(16);
         for (int jj = first_debug_line; jj != last_debug_line; jj = (jj + 1) % DEBUG_CONSOLE_NUMLINES) {
             wouttextxy(debugConsoleBuffer, 1, ypp, 0, text_color, debug_line[jj]);
-            ypp += txtheight;
+            ypp += txtspacing;
         }
         //buf_graphics.text_color = otextc;
         //ds = pop_screen();

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -383,7 +383,7 @@ void DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int fo
 }
 
 void DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy, int wid, int font, int alignment, const char *msg) {
-    int texthit = wgetfontheight(font);
+    int linespacing = getfontspacing_outlined(font);
     sds->MultiplyCoordinates(&xx, &yy);
     sds->MultiplyThickness(&wid);
 
@@ -405,7 +405,7 @@ void DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy,
             drawAtX = (xx + wid) - wgettextwidth(lines[i], font);
         }
 
-        wouttext_outline(ds, drawAtX, yy + texthit*i, font, text_color, lines[i]);
+        wouttext_outline(ds, drawAtX, yy + linespacing*i, font, text_color, lines[i]);
     }
 
     sds->FinishedDrawing();

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -39,7 +39,7 @@ struct GameSetup {
     int digicard;
     int midicard;
     int mod_player;
-    int textheight;
+    int textheight; // text height used on the certain built-in GUI
     int mp3_player;
     bool  no_speech_pack;
     bool  enable_antialiasing;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -775,6 +775,16 @@ RuntimeScriptValue Sc_GetTextWidth(const RuntimeScriptValue *params, int32_t par
     API_SCALL_INT_POBJ_PINT(GetTextWidth, const char);
 }
 
+RuntimeScriptValue Sc_GetFontHeight(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(GetFontHeight);
+}
+
+RuntimeScriptValue Sc_GetFontLineSpacing(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(GetFontLineSpacing);
+}
+
 // int (int whatti)
 RuntimeScriptValue Sc_sc_GetTime(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2383,6 +2393,8 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("GetTextBoxText",           Sc_GetTextBoxText);
 	ccAddExternalStaticFunction("GetTextHeight",            Sc_GetTextHeight);
 	ccAddExternalStaticFunction("GetTextWidth",             Sc_GetTextWidth);
+	ccAddExternalStaticFunction("GetFontHeight",            Sc_GetFontHeight);
+	ccAddExternalStaticFunction("GetFontLineSpacing",       Sc_GetFontLineSpacing);
 	ccAddExternalStaticFunction("GetTime",                  Sc_sc_GetTime);
 	ccAddExternalStaticFunction("GetTranslation",           Sc_get_translation);
 	ccAddExternalStaticFunction("GetTranslationName",       Sc_GetTranslationName);

--- a/Engine/ac/global_display.cpp
+++ b/Engine/ac/global_display.cpp
@@ -67,7 +67,7 @@ void DisplayTopBar(int ypos, int ttexcol, int backcol, const char *title, const 
 
     topBar.wantIt = 1;
     topBar.font = FONT_NORMAL;
-    topBar.height = wgetfontheight(topBar.font);
+    topBar.height = getfontheight_outlined(topBar.font);
     topBar.height += multiply_up_coordinate(play.top_bar_borderwidth) * 2 + get_fixed_pixel_size(1);
 
     // they want to customize the font

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -158,7 +158,7 @@ void RawPrint (int xx, int yy, const char *text) {
 }
 void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
     char displbuf[3000];
-    int texthit = wgetfontheight(font);
+    int linespacing = getfontspacing_outlined(font);
     multiply_up_coordinates(&xx, &yy);
     wid = multiply_up_coordinate(wid);
 
@@ -171,7 +171,7 @@ void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
     RAW_START();
     color_t text_color = play.raw_color;
     for (int i = 0; i < numlines; i++)
-        wouttext_outline(RAW_SURFACE(), xx, yy + texthit*i, font, text_color, lines[i]);
+        wouttext_outline(RAW_SURFACE(), xx, yy + linespacing*i, font, text_color, lines[i]);
     invalidate_screen();
     mark_current_background_dirty();
     RAW_END();

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -182,6 +182,20 @@ int GetTextHeight(const char *text, int fontnum, int width) {
   return divide_down_coordinate(getheightoflines(fontnum, numlines));
 }
 
+int GetFontHeight(int fontnum)
+{
+  if ((fontnum < 0) || (fontnum >= game.numfonts))
+    quit("!GetFontHeight: invalid font number.");
+  return divide_down_coordinate(getfontheight_outlined(fontnum));
+}
+
+int GetFontLineSpacing(int fontnum)
+{
+  if ((fontnum < 0) || (fontnum >= game.numfonts))
+    quit("!GetFontLineSpacing: invalid font number.");
+  return divide_down_coordinate(getfontspacing_outlined(fontnum));
+}
+
 void SetGUIBackgroundPic (int guin, int slotn) {
   if ((guin<0) | (guin>=game.numgui))
     quit("!SetGUIBackgroundPic: invalid GUI number");

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -177,11 +177,9 @@ int GetTextHeight(const char *text, int fontnum, int width) {
   if ((fontnum < 0) || (fontnum >= game.numfonts))
     quit("!GetTextHeight: invalid font number.");
 
-  int texthit = wgetfontheight(fontnum);
-
   break_up_text_into_lines(multiply_up_coordinate(width), fontnum, text);
 
-  return divide_down_coordinate(texthit * numlines);
+  return divide_down_coordinate(getheightoflines(fontnum, numlines));
 }
 
 void SetGUIBackgroundPic (int guin, int slotn) {

--- a/Engine/ac/global_gui.h
+++ b/Engine/ac/global_gui.h
@@ -27,6 +27,8 @@ void InterfaceOff(int ifn);
 void CentreGUI (int ifn);
 int  GetTextWidth(const char *text, int fontnum);
 int  GetTextHeight(const char *text, int fontnum, int width);
+int  GetFontHeight(int fontnum);
+int  GetFontLineSpacing(int fontnum);
 void SetGUIBackgroundPic (int guin, int slotn);
 void DisableInterface();
 void EnableInterface();

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -321,6 +321,7 @@ void LoadFonts()
         finfo.SizePt  = game.fontflags[i] &  FFLG_SIZEMASK;
         finfo.Outline = game.fontoutline[i];
         finfo.YOffset = game.fontvoffset[i];
+        finfo.LineSpacing = game.fontlnspace[i];
 
         // Apply compatibility adjustments
         if (finfo.SizePt == 0)

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -321,7 +321,7 @@ void LoadFonts()
         finfo.SizePt  = game.fontflags[i] &  FFLG_SIZEMASK;
         finfo.Outline = game.fontoutline[i];
         finfo.YOffset = game.fontvoffset[i];
-        finfo.LineSpacing = game.fontlnspace[i];
+        finfo.LineSpacing = Math::Max(0, game.fontlnspace[i]);
 
         // Apply compatibility adjustments
         if (finfo.SizePt == 0)

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -138,7 +138,7 @@ void GUITextBox::Draw_text_box_contents(Bitmap *ds, color_t text_color)
   if (!IsDisabled()) {
     // draw a cursor
     startx = wgettextwidth(text, font) + x + 3;
-    starty = y + 1 + wgettextheight("BigyjTEXT", font);
+    starty = y + 1 + getfontheight(font);
     ds->DrawRect(Rect(startx, starty, startx + get_fixed_pixel_size(5), starty + (get_fixed_pixel_size(1) - 1)), text_color);
   }
 }

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -147,7 +147,7 @@ void engine_init_resolution_settings(const Size game_size)
         wtext_multiply = 1;
     }
 
-    usetup.textheight = wgetfontheight(0) + 1;
+    usetup.textheight = getfontheight_outlined(0) + 1;
     current_screen_resolution_multiplier = game_size.Width / play.native_size.Width;
 
     if (game.IsHiRes() &&

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -307,7 +307,8 @@ int IAGSEngine::FWrite (void *buffer, int32 len, int32 handle) {
     return fwrite (buffer, 1, len, (FILE*)handle);
 }
 void IAGSEngine::DrawTextWrapped (int32 xx, int32 yy, int32 wid, int32 font, int32 color, const char*text) {
-    int texthit = wgetfontheight(font);
+    // TODO: use generic function from the engine instead of having copy&pasted code here
+    int linespacing = getfontspacing_outlined(font);
 
     break_up_text_into_lines (wid, font, (char*)text);
 
@@ -315,7 +316,7 @@ void IAGSEngine::DrawTextWrapped (int32 xx, int32 yy, int32 wid, int32 font, int
     color_t text_color = ds->GetCompatibleColor(color);
     multiply_up_coordinates((int*)&xx, (int*)&yy); // stupid! quick tweak
     for (int i = 0; i < numlines; i++)
-        draw_and_invalidate_text(ds, xx, yy + texthit*i, font, text_color, lines[i]);
+        draw_and_invalidate_text(ds, xx, yy + linespacing*i, font, text_color, lines[i]);
 }
 void IAGSEngine::SetVirtualScreen (BITMAP *bmp) {
 	// [IKM] Very, very dangerous :'(


### PR DESCRIPTION
This pull request does two things:

1) Introduces new customizable Font property LineSpacing, which defines an automatic height of step between two lines of text. Default value is 0, which actually means "use font's height".

2) Reworks the internal engine's algorithm of text drawing, using line spacing where font height was previously used for calculating steps between lines. Since default value for line spacing is "font height", old games and new games which did not have custom line spacing set should keep identical text looks.

Also added two script functions: GetFontHeight(int font) and GetFontLineSpacing(int font), which are self explanatory.