### PR TITLE
Editor: Show modern Windows versions in About

### DIFF
--- a/Editor/AGS.Editor/GUI/AboutDialog.cs
+++ b/Editor/AGS.Editor/GUI/AboutDialog.cs
@@ -59,16 +59,25 @@ namespace AGS.Editor
                 }
                 else if (Environment.OSVersion.Version.Major == 6)
                 {
-                    osName = "Windows Vista";
-
-                    if (Environment.OSVersion.Version.Minor > 0)
+                    switch (Environment.OSVersion.Version.Minor)
                     {
-                        osName = "Windows 7";
+                        case 3:
+                            osName = "Windows 8.1";
+                            break;
+                        case 2:
+                            osName = "Windows 8";
+                            break;
+                        case 1:
+                            osName = "Windows 7";
+                            break;
+                        default:
+                            osName = "Windows Vista";
+                            break;
                     }
                 }
                 else if (Environment.OSVersion.Version.Major > 6)
                 {
-                    osName = "Windows";
+                    osName = "Windows " + Environment.OSVersion.Version.Major + (Environment.OSVersion.Version.Minor > 0 ? "." + Environment.OSVersion.Version.Minor : "");
                 }
             }
             return osName + " " + Environment.OSVersion.ServicePack;


### PR DESCRIPTION
Added support for Windows 8, Windows 8.1 and Windows 10 (and onwards?) detection to the about dialogue box.

I wanted to post about this on #398 , but it got merged before I got a chance to comment. The addition of a manifest file allows us to get the correct values for the about dialogue box. I have updated the code to populate the relevant field according to this table:

https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832%28v=vs.85%29.aspx