### PR TITLE
Refactor GUI Control classes

### DIFF
--- a/Common/ac/interfacebutton.h
+++ b/Common/ac/interfacebutton.h
@@ -16,8 +16,6 @@
 #define __AC_INTERFACEBUTTON_H
 
 #define MAXBUTTON       20
-#define IBACT_SETMODE   1
-#define IBACT_SCRIPT    2
 #define IBFLG_ENABLED   1
 #define IBFLG_INVBOX    2
 struct InterfaceButton {

--- a/Common/core/types.h
+++ b/Common/core/types.h
@@ -82,6 +82,13 @@
 #endif // WINDOWS_VERSION
 
 
+// Suppress override keyword for compilers that do not support it
+// TODO: this should be reviewed if project would demand C++11 or higher
+#if !(defined (_MSC_VER) && _MSC_VER >= 1700 || __cplusplus >= 201103L)
+#define override
+#endif
+
+
 #define fixed_t int32_t // fixed point type
 #define color_t int32_t
 

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -56,6 +56,12 @@ void adjust_y_coordinate_for_text(int* ypos, int fontnum);
 IAGSFontRenderer* font_replace_renderer(int fontNumber, IAGSFontRenderer* renderer);
 bool font_first_renderer_loaded();
 bool font_supports_extended_characters(int fontNumber);
+// TODO: with changes to WFN font renderer that implemented safe rendering of
+// strings containing invalid chars (since 3.3.1) this function is not
+// important, except for (maybe) few particular cases.
+// Furthermore, its use complicated things, because AGS could modify some texts
+// at random times (usually - drawing routines).
+// Need to check whether it is safe to completely remove it.
 void ensure_text_valid_for_font(char *text, int fontnum);
 int wgettextwidth(const char *texx, int fontNumber);
 // Calculates actual height of a line of text

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -696,7 +696,8 @@ MainGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVer
 
     ReadDialogs(ents.Dialogs, ents.OldDialogScripts, ents.OldDialogSources, ents.OldSpeechLines,
                 in, data_ver, game.numdialog);
-    read_gui(in, guis, &game);
+    GUI::ReadGUI(guis, in);
+    game.numgui = guis.size();
 
     if (data_ver >= kGameVersion_260)
     {

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -26,6 +26,33 @@ namespace AGS
 namespace Common
 {
 
+FrameAlignment ConvertLegacyButtonAlignment(int32_t align)
+{
+    switch (align)
+    {
+    case kLegacyButtonAlign_TopCenter:
+        return kAlignTopCenter;
+    case kLegacyButtonAlign_TopLeft:
+        return kAlignTopLeft;
+    case kLegacyButtonAlign_TopRight:
+        return kAlignTopRight;
+    case kLegacyButtonAlign_CenterLeft:
+        return kAlignCenterLeft;
+    case kLegacyButtonAlign_Centered:
+        return kAlignCentered;
+    case kLegacyButtonAlign_CenterRight:
+        return kAlignCenterRight;
+    case kLegacyButtonAlign_BottomLeft:
+        return kAlignBottomLeft;
+    case kLegacyButtonAlign_BottomCenter:
+        return kAlignBottomCenter;
+    case kLegacyButtonAlign_BottomRight:
+        return kAlignBottomRight;
+    }
+    return kAlignNone;
+}
+
+
 GUIButton::GUIButton()
 {
     Image = -1;
@@ -34,7 +61,7 @@ GUIButton::GUIButton()
     CurrentImage = -1;
     Font = 0;
     TextColor = 0;
-    TextAlignment = kButtonAlign_TopCenter;
+    TextAlignment = kLegacyButtonAlign_TopCenter;
     ClickAction[kMouseLeft] = kGUIAction_RunScript;
     ClickAction[kMouseRight] = kGUIAction_RunScript;
     ClickData[kMouseLeft] = 0;
@@ -187,7 +214,7 @@ void GUIButton::ReadFromFile(Stream *in, GuiVersion gui_version)
     }
     else
     {
-        TextAlignment = kButtonAlign_TopCenter;
+        TextAlignment = kLegacyButtonAlign_TopCenter;
     }
 
     if (TextColor == 0)
@@ -257,60 +284,18 @@ void GUIButton::DrawText(Bitmap *ds, bool draw_disabled)
     // but that will require to update all gui controls when translation is changed in game
     PrepareTextToDraw();
 
-    int at_x = X;
-    int at_y = Y;
+    Rect frame = RectWH(X + 2, Y + 2, Width - 4, Height - 4);
     if (IsPushed && IsMouseOver)
     {
         // move the Text a bit while pushed
-        at_x++;
-        at_y++;
+        frame.Left++;
+        frame.Top++;
     }
-
-    // TODO: replace with generic alignment-in-rect
-    switch (TextAlignment)
-    {
-    case kButtonAlign_TopCenter:
-        at_x += (Width / 2 - wgettextwidth(_textToDraw, Font) / 2);
-        at_y += 2;
-        break;
-    case kButtonAlign_TopLeft:
-        at_x += 2;
-        at_y += 2;
-        break;
-    case kButtonAlign_TopRight:
-        at_x += (Width - wgettextwidth(_textToDraw, Font)) - 2;
-        at_y += 2;
-        break;
-    case kButtonAlign_CenterLeft:
-        at_x += 2;
-        at_y += (Height / 2 - (wgettextheight(_textToDraw, Font) + 1) / 2);
-        break;
-    case kButtonAlign_Centered:
-        at_x += (Width / 2 - wgettextwidth(_textToDraw, Font) / 2);
-        at_y += (Height / 2 - (wgettextheight(_textToDraw, Font) + 1) / 2);
-        break;
-    case kButtonAlign_CenterRight:
-        at_x += (Width - wgettextwidth(_textToDraw, Font)) - 2;
-        at_y += (Height / 2 - (wgettextheight(_textToDraw, Font) + 1) / 2);
-        break;
-    case kButtonAlign_BottomLeft:
-        at_x += 2;
-        at_y += (Height - wgettextheight(_textToDraw, Font)) - 2;
-        break;
-    case kButtonAlign_BottomCenter:
-        at_x += (Width / 2 - wgettextwidth(_textToDraw, Font) / 2);
-        at_y += (Height - wgettextheight(_textToDraw, Font)) - 2;
-        break;
-    case kButtonAlign_BottomRight:
-        at_x += (Width - wgettextwidth(_textToDraw, Font)) - 2;
-        at_y += (Height - wgettextheight(_textToDraw, Font)) - 2;
-        break;
-    }
-
     color_t text_color = ds->GetCompatibleColor(TextColor);
     if (draw_disabled)
         text_color = ds->GetCompatibleColor(8);
-    wouttext_outline(ds, at_x, at_y, Font, text_color, _textToDraw);
+    GUI::DrawTextAligned(ds, _textToDraw, Font, text_color, frame,
+        ConvertLegacyButtonAlignment(TextAlignment));
 }
 
 void GUIButton::DrawTextButton(Bitmap *ds, bool draw_disabled)

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -237,18 +237,10 @@ void GUIButton::DrawImageButton(Bitmap *ds, bool draw_disabled)
 
     if ((draw_disabled) && (gui_disabled_style == GUIDIS_GREYOUT))
     {
-        color_t draw_color = ds->GetCompatibleColor(8);
         // darken the button when disabled
-        // TODO: move this to a separate function?
-        int32_t sprite_width = spriteset[CurrentImage]->GetWidth();
-        int32_t sprite_height = spriteset[CurrentImage]->GetHeight();
-        for (int at_x = 0; at_x < sprite_width; ++at_x)
-        {
-            for (int at_y = at_x % 2; at_y < sprite_height; at_y += 2)
-            {
-                ds->PutPixel(X + at_x, Y + at_y, draw_color);
-            }
-        }
+        GUI::DrawDisabledEffect(ds, Rect(X, Y,
+            spriteset[CurrentImage]->GetWidth(),
+            spriteset[CurrentImage]->GetHeight()));
     }
     ds->SetClip(Rect(0, 0, ds->GetWidth() - 1, ds->GetHeight() - 1));
 

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -17,96 +17,93 @@
 
 #include <vector>
 #include "gui/guiobject.h"
+#include "util/string.h"
 
-#define GBUT_ALIGN_TOPMIDDLE    0
-#define GBUT_ALIGN_TOPLEFT      1
-#define GBUT_ALIGN_TOPRIGHT     2
-#define GBUT_ALIGN_MIDDLELEFT   3 
-#define GBUT_ALIGN_CENTRED      4
-#define GBUT_ALIGN_MIDDLERIGHT  5
-#define GBUT_ALIGN_BOTTOMLEFT   6
-#define GBUT_ALIGN_BOTTOMMIDDLE 7
-#define GBUT_ALIGN_BOTTOMRIGHT  8
+#define GUIBUTTON_TEXTLENGTH 50
 
-struct GUIButton:public GUIObject
+namespace AGS
 {
-  char text[50];
-  int pic, overpic, pushedpic;
-  int usepic, ispushed, isover;
-  int font, textcol;
-  int leftclick, rightclick;
-  int lclickdata, rclickdata;
-  int textAlignment, reserved1;
+namespace Common
+{
 
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  virtual void Draw(Common::Bitmap *ds);
-  void MouseUp();
-
-  void MouseMove(int x, int y)
-  {
-  }
-
-  void MouseOver()
-  {
-    if (ispushed)
-      usepic = pushedpic;
-    else
-      usepic = overpic;
-
-    isover = 1;
-  }
-
-  void MouseLeave()
-  {
-    usepic = pic;
-    isover = 0;
-  }
-
-  virtual int MouseDown()
-  {
-    if (pushedpic > 0)
-      usepic = pushedpic;
-
-    ispushed = 1;
-    return 0;
-  }
-
-  void KeyPress(int keycode)
-  {
-  }
-
-  void reset()
-  {
-    GUIObject::init();
-    usepic = -1;
-    pic = -1;
-    overpic = -1;
-    pushedpic = -1;
-    ispushed = 0;
-    isover = 0;
-    text[0] = 0;
-    font = 0;
-    textcol = 0;
-    leftclick = 2;
-    rightclick = 0;
-    lclickdata = rclickdata = 0;
-    textAlignment = GBUT_ALIGN_TOPMIDDLE;
-    activated = 0;
-    numSupportedEvents = 1;
-    supportedEvents[0] = "Click";
-    supportedEventArgs[0] = "GUIControl *control, MouseButton button";
-  }
-
-  GUIButton() {
-    reset();
-  }
-
-private:
-  void Draw_set_oritext(char *oritext, const char *text);
+enum MouseButton
+{
+    kMouseNone  = -1,
+    kMouseLeft  =  0,
+    kMouseRight =  1,
 };
 
-extern std::vector<GUIButton> guibuts;
+enum GUIClickAction
+{
+    kGUIAction_None       = 0,
+    kGUIAction_SetMode    = 1,
+    kGUIAction_RunScript  = 2,
+};
+
+enum GUIButtonAlignment
+{
+    kButtonAlign_TopCenter     = 0,
+    kButtonAlign_TopLeft       = 1,
+    kButtonAlign_TopRight      = 2,
+    kButtonAlign_CenterLeft    = 3,
+    kButtonAlign_Centered      = 4,
+    kButtonAlign_CenterRight   = 5,
+    kButtonAlign_BottomLeft    = 6,
+    kButtonAlign_BottomCenter  = 7,
+    kButtonAlign_BottomRight   = 8,
+};
+
+class GUIButton : public GUIObject
+{
+public:
+    GUIButton();
+
+    const String &GetText() const;
+
+    // Operations
+    virtual void Draw(Bitmap *ds) override;
+    void         SetText(const String &text);
+
+    // Events
+    virtual int  MouseDown() override;
+    virtual void MouseLeave() override;
+    virtual void MouseOver() override;
+    virtual void MouseUp() override;
+  
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
+
+// TODO: these members are currently public; hide them later
+public:
+    int32_t     Image;
+    int32_t     MouseOverImage;
+    int32_t     PushedImage;
+    int32_t     CurrentImage;
+    int32_t     Font;
+    color_t     TextColor;
+    int32_t     TextAlignment;
+    // Click actions for left and right mouse buttons
+    // NOTE: only left click is currently in use
+    static const int ClickCount = kMouseRight + 1;
+    GUIClickAction ClickAction[ClickCount];
+    int32_t        ClickData[ClickCount];
+
+    bool        IsPushed;
+    bool        IsMouseOver;
+
+private:
+    void PrepareTextToDraw();
+
+    String _text;
+    // prepared text buffer/cache
+    String _textToDraw;
+};
+
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUIButton> guibuts;
 extern int numguibuts;
 
 int UpdateAnimatingButton(int bu);

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -40,6 +40,7 @@ enum GUIClickAction
     kGUIAction_RunScript  = 2,
 };
 
+// TODO: generic alignment
 enum GUIButtonAlignment
 {
     kButtonAlign_TopCenter     = 0,
@@ -65,10 +66,10 @@ public:
     void         SetText(const String &text);
 
     // Events
-    virtual int  MouseDown() override;
-    virtual void MouseLeave() override;
-    virtual void MouseOver() override;
-    virtual void MouseUp() override;
+    virtual bool OnMouseDown() override;
+    virtual void OnMouseEnter() override;
+    virtual void OnMouseLeave() override;
+    virtual void OnMouseUp() override;
   
     // Serialization
     virtual void WriteToFile(Stream *out) override;

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -93,10 +93,30 @@ public:
     bool        IsMouseOver;
 
 private:
+    void DrawImageButton(Bitmap *ds, bool draw_disabled);
+    void DrawText(Bitmap *ds, bool draw_disabled);
+    void DrawTextButton(Bitmap *ds, bool draw_disabled);
     void PrepareTextToDraw();
 
+    // Defines button placeholder mode; the mode is set
+    // depending on special tags found in button text
+    enum GUIButtonPlaceholder
+    {
+        kButtonPlace_None,
+        kButtonPlace_InvItemStretch,
+        kButtonPlace_InvItemCenter,
+        kButtonPlace_InvItemAuto
+    };
+
+    // Text property set by user
     String _text;
-    // prepared text buffer/cache
+    // type of content placeholder, if any
+    GUIButtonPlaceholder _placeholder;
+    // A flag indicating unnamed button; this is a convenience trick:
+    // buttons are created named "New Button" in the editor, and users
+    // often do not clear text when they want a graphic button.
+    bool _unnamed;
+    // Prepared text buffer/cache
     String _textToDraw;
 };
 

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -40,18 +40,17 @@ enum GUIClickAction
     kGUIAction_RunScript  = 2,
 };
 
-// TODO: generic alignment
-enum GUIButtonAlignment
+enum LegacyButtonAlignment
 {
-    kButtonAlign_TopCenter     = 0,
-    kButtonAlign_TopLeft       = 1,
-    kButtonAlign_TopRight      = 2,
-    kButtonAlign_CenterLeft    = 3,
-    kButtonAlign_Centered      = 4,
-    kButtonAlign_CenterRight   = 5,
-    kButtonAlign_BottomLeft    = 6,
-    kButtonAlign_BottomCenter  = 7,
-    kButtonAlign_BottomRight   = 8,
+    kLegacyButtonAlign_TopCenter = 0,
+    kLegacyButtonAlign_TopLeft = 1,
+    kLegacyButtonAlign_TopRight = 2,
+    kLegacyButtonAlign_CenterLeft = 3,
+    kLegacyButtonAlign_Centered = 4,
+    kLegacyButtonAlign_CenterRight = 5,
+    kLegacyButtonAlign_BottomLeft = 6,
+    kLegacyButtonAlign_BottomCenter = 7,
+    kLegacyButtonAlign_BottomRight = 8,
 };
 
 class GUIButton : public GUIObject
@@ -83,6 +82,7 @@ public:
     int32_t     CurrentImage;
     int32_t     Font;
     color_t     TextColor;
+    // TODO: use FrameAlignment type (will require changing GUI data format)
     int32_t     TextAlignment;
     // Click actions for left and right mouse buttons
     // NOTE: only left click is currently in use

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -15,7 +15,6 @@
 #ifndef __AC_GUIDEFINES_H
 #define __AC_GUIDEFINES_H
 
-#define MAX_GUILABEL_TEXT_LEN 2048
 #define GUIMAGIC          0xcafebeef
 // GUI Control flags (32-bit)
 #define GUIF_DEFAULT    0x0001

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -16,16 +16,6 @@
 #define __AC_GUIDEFINES_H
 
 #define GUIMAGIC          0xcafebeef
-// GUI Control flags (32-bit)
-#define GUIF_DEFAULT    0x0001
-#define GUIF_CANCEL     0x0002 // obsolete?
-#define GUIF_DISABLED   0x0004
-#define GUIF_TABSTOP    0x0008 // obsolete?
-#define GUIF_INVISIBLE  0x0010
-#define GUIF_CLIP       0x0020
-#define GUIF_NOCLICKS   0x0040
-#define GUIF_TRANSLATED 0x0080 // 3.3.0.1132
-#define GUIF_DELETED    0x8000
 #define MAX_GUIOBJ_SCRIPTNAME_LEN 25
 #define MAX_GUIOBJ_EVENTS 10
 #define MAX_GUIOBJ_EVENTHANDLER_LEN 30
@@ -53,7 +43,7 @@
 //                   ListBox.SaveGameSlots[] array instead.
 // 2.7.2.???? (115): Added GUI Control z-order support.
 //
-// 3.3.0.1132 (116): Added GUIF_TRANSLATED flag.
+// 3.3.0.1132 (116): Added kGUICtrl_Translated flag.
 // 3.3.1.???? (117): Added padding variable for text window GUIs.
 // 3.4.0      (118): Removed GUI limits
 //
@@ -129,6 +119,19 @@ enum GUIControlType
     kGUISlider      = 4,
     kGUITextBox     = 5,
     kGUIListBox     = 6
+};
+
+enum GUIControlFlags
+{
+    kGUICtrl_Default    = 0x0001,
+    kGUICtrl_Cancel     = 0x0002, // unused
+    kGUICtrl_Disabled   = 0x0004,
+    kGUICtrl_TabStop    = 0x0008, // unused
+    kGUICtrl_Invisible  = 0x0010,
+    kGUICtrl_Clip       = 0x0020,
+    kGUICtrl_NoClicks   = 0x0040,
+    kGUICtrl_Translated = 0x0080, // 3.3.0.1132
+    kGUICtrl_Deleted    = 0x8000, // unused
 };
 
 enum GUIListBoxFlags

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -15,7 +15,6 @@
 #ifndef __AC_GUIDEFINES_H
 #define __AC_GUIDEFINES_H
 
-#define MAX_LISTBOX_ITEMS 200
 #define MAX_GUILABEL_TEXT_LEN 2048
 #define GUIMAGIC          0xcafebeef
 // GUI Control flags (32-bit)
@@ -32,10 +31,6 @@
 #define MAX_GUIOBJ_EVENTS 10
 #define MAX_GUIOBJ_EVENTHANDLER_LEN 30
 #define TEXTWINDOW_PADDING_DEFAULT  3
-// ListBox flags
-#define GLF_NOBORDER     1
-#define GLF_NOARROWS     2
-#define GLF_SGINDEXVALID 4
 //#define MAX_OBJ_EACH_TYPE 251
 
 #define MAXLINE 50
@@ -135,6 +130,13 @@ enum GUIControlType
     kGUISlider      = 4,
     kGUITextBox     = 5,
     kGUIListBox     = 6
+};
+
+enum GUIListBoxFlags
+{
+    kListBox_NoBorder = 0x01,
+    kListBox_NoArrows = 0x02,
+    kListBox_SvgIndex = 0x04,
 };
 
 enum GUITextBoxFlags

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -36,8 +36,6 @@
 #define GLF_NOBORDER     1
 #define GLF_NOARROWS     2
 #define GLF_SGINDEXVALID 4
-// TextBox flags
-#define GTF_NOBORDER  1
 //#define MAX_OBJ_EACH_TYPE 251
 
 #define MAXLINE 50
@@ -137,6 +135,11 @@ enum GUIControlType
     kGUISlider      = 4,
     kGUITextBox     = 5,
     kGUIListBox     = 6
+};
+
+enum GUITextBoxFlags
+{
+    kTextBox_NoBorder = 0x0001
 };
 
 } // namespace Common

--- a/Common/gui/guiinv.cpp
+++ b/Common/gui/guiinv.cpp
@@ -37,26 +37,26 @@ GUIInvWindow::GUIInvWindow()
     TopItem = 0;
     CalculateNumCells();
 
-    numSupportedEvents = 0;
+    _scEventCount = 0;
 }
 
-void GUIInvWindow::MouseOver()
+void GUIInvWindow::OnMouseEnter()
 {
     IsMouseOver = true;
 }
 
-void GUIInvWindow::MouseLeave()
+void GUIInvWindow::OnMouseLeave()
 {
     IsMouseOver = false;
 }
 
-void GUIInvWindow::MouseUp()
+void GUIInvWindow::OnMouseUp()
 {
     if (IsMouseOver)
-        activated = 1;
+        IsActivated = true;
 }
 
-void GUIInvWindow::Resized()
+void GUIInvWindow::OnResized()
 {
     CalculateNumCells();
 }
@@ -91,10 +91,10 @@ void GUIInvWindow::ReadFromFile(Stream *in, GuiVersion gui_version)
     if (loaded_game_file_version >= kGameVersion_270)
     {
         // ensure that some items are visible
-        if (ItemWidth > wid)
-            ItemWidth = wid;
-        if (ItemHeight > hit)
-            ItemHeight = hit;
+        if (ItemWidth > Width)
+            ItemWidth = Width;
+        if (ItemHeight > Height)
+            ItemHeight = Height;
     }
 
     CalculateNumCells();
@@ -104,13 +104,13 @@ void GUIInvWindow::CalculateNumCells()
 {
     if (loaded_game_file_version >= kGameVersion_270)
     {
-        ColCount = wid / multiply_up_coordinate(ItemWidth);
-        RowCount = hit / multiply_up_coordinate(ItemHeight);
+        ColCount = Width / multiply_up_coordinate(ItemWidth);
+        RowCount = Height / multiply_up_coordinate(ItemHeight);
     }
     else
     {
-        ColCount = floor((float)wid / (float)multiply_up_coordinate(ItemWidth) + 0.5f);
-        RowCount = floor((float)hit / (float)multiply_up_coordinate(ItemHeight) + 0.5f);
+        ColCount = floor((float)Width / (float)multiply_up_coordinate(ItemWidth) + 0.5f);
+        RowCount = floor((float)Height / (float)multiply_up_coordinate(ItemHeight) + 0.5f);
     }
 }
 

--- a/Common/gui/guiinv.h
+++ b/Common/gui/guiinv.h
@@ -36,10 +36,10 @@ public:
     virtual void Draw(Bitmap *ds) override;
 
     // Events
-    virtual void MouseLeave() override;
-    virtual void MouseOver() override;
-    virtual void MouseUp() override;
-    virtual void Resized() override;
+    virtual void OnMouseEnter() override;
+    virtual void OnMouseLeave() override;
+    virtual void OnMouseUp() override;
+    virtual void OnResized() override;
 
     // Serialization
     virtual void WriteToFile(Stream *out) override;

--- a/Common/gui/guiinv.h
+++ b/Common/gui/guiinv.h
@@ -18,65 +18,51 @@
 #include <vector>
 #include "gui/guiobject.h"
 
-struct GUIInv:public GUIObject
+namespace AGS
 {
-  int isover;
-  int charId;   // whose inventory (-1 = current player)
-  int itemWidth, itemHeight;
-  int topIndex;
+namespace Common
+{
 
-  int itemsPerLine, numLines;  // not persisted
+class GUIInvWindow : public GUIObject
+{
+public:
+    GUIInvWindow();
 
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
+    // This function has distinct implementations in Engine and Editor
+    int          GetCharacterId() const;
 
-  void CalculateNumCells();
+    // Operations
+    // This function has distinct implementations in Engine and Editor
+    virtual void Draw(Bitmap *ds) override;
 
-  virtual void Resized() {
-    CalculateNumCells();
-  }
+    // Events
+    virtual void MouseLeave() override;
+    virtual void MouseOver() override;
+    virtual void MouseUp() override;
+    virtual void Resized() override;
 
-  int CharToDisplay();
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
 
-  // This function has distinct implementations in Engine and Editor
-  virtual void Draw(Common::Bitmap *ds);
+// TODO: these members are currently public; hide them later
+public:
+    bool    IsMouseOver;
+    int32_t CharId; // whose inventory (-1 = current player)
+    int32_t ItemWidth;
+    int32_t ItemHeight;
+    int32_t ColCount;
+    int32_t RowCount;
+    int32_t TopItem;
 
-  void MouseMove(int x, int y)
-  {
-  }
-
-  void MouseOver()
-  {
-    isover = 1;
-  }
-
-  void MouseLeave()
-  {
-    isover = 0;
-  }
-
-  void MouseUp()
-  {
-    if (isover)
-      activated = 1;
-  }
-
-  void KeyPress(int kp)
-  {
-  }
-
-  GUIInv() {
-    isover = 0;
-    numSupportedEvents = 0;
-    charId = -1;
-    itemWidth = 40;
-    itemHeight = 22;
-    topIndex = 0;
-    CalculateNumCells();
-  }
+private:
+    void CalculateNumCells();
 };
 
-extern std::vector<GUIInv> guiinv;
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUIInvWindow> guiinv;
 extern int numguiinv;
 
 #endif // __AC_GUIINV_H

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -32,7 +32,7 @@ GUILabel::GUILabel()
 {
     Font = 0;
     TextColor = 0;
-    TextAlignment = kGUIAlign_Left;
+    TextAlignment = kLegacyGUIAlign_Left;
 
     _scEventCount = 0;
 }
@@ -59,23 +59,14 @@ void GUILabel::Draw(Common::Bitmap *ds)
         i < numlines && (!limit_by_label_frame || at_y <= Y + Height);
         ++i, at_y += linespacing)
     {
-        DrawAlignedText(ds, at_y, text_color, lines[i]);
+        GUI::DrawTextAlignedHor(ds, lines[i], Font, text_color, X, X + Width - 1, at_y,
+            ConvertLegacyGUIAlignment(TextAlignment));
     }
 }
 
 void GUILabel::SetText(const String &text)
 {
     Text = text;
-}
-
-void GUILabel::DrawAlignedText(Common::Bitmap *ds, int at_y, color_t text_color, const char *text)
-{
-    int at_x = X;
-    if (TextAlignment == kGUIAlign_Center)
-        at_x += Width / 2 - wgettextwidth(text, Font) / 2;
-    else if (TextAlignment == kGUIAlign_Right)
-        at_x += Width - wgettextwidth(text, Font);
-    wouttext_outline(ds, at_x, at_y, Font, text_color, text);
 }
 
 // TODO: replace string serialization with StrUtil::ReadString and WriteString

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -32,9 +32,9 @@ GUILabel::GUILabel()
 {
     Font = 0;
     TextColor = 0;
-    TextAlignment = GALIGN_LEFT;
+    TextAlignment = kGUIAlign_Left;
 
-    numSupportedEvents = 0;
+    _scEventCount = 0;
 }
 
 String GUILabel::GetText() const
@@ -55,8 +55,8 @@ void GUILabel::Draw(Common::Bitmap *ds)
     const int linespacing = getfontlinespacing(Font) + 1;
     // < 2.72 labels did not limit vertical size of text
     const bool limit_by_label_frame = loaded_game_file_version >= kGameVersion_272;
-    for (int i = 0, at_y = y;
-        i < numlines && (!limit_by_label_frame || at_y <= y + hit);
+    for (int i = 0, at_y = Y;
+        i < numlines && (!limit_by_label_frame || at_y <= Y + Height);
         ++i, at_y += linespacing)
     {
         DrawAlignedText(ds, at_y, text_color, lines[i]);
@@ -70,11 +70,11 @@ void GUILabel::SetText(const String &text)
 
 void GUILabel::DrawAlignedText(Common::Bitmap *ds, int at_y, color_t text_color, const char *text)
 {
-    int at_x = x;
-    if (TextAlignment == GALIGN_CENTRE)
-        at_x += wid / 2 - wgettextwidth(text, Font) / 2;
-    else if (TextAlignment == GALIGN_RIGHT)
-        at_x += wid - wgettextwidth(text, Font);
+    int at_x = X;
+    if (TextAlignment == kGUIAlign_Center)
+        at_x += Width / 2 - wgettextwidth(text, Font) / 2;
+    else if (TextAlignment == kGUIAlign_Right)
+        at_x += Width - wgettextwidth(text, Font);
     wouttext_outline(ds, at_x, at_y, Font, text_color, text);
 }
 
@@ -106,7 +106,7 @@ void GUILabel::ReadFromFile(Stream *in, GuiVersion gui_version)
     if (TextColor == 0)
         TextColor = 16;
     // All labels are translated at the moment
-    flags |= GUIF_TRANSLATED;
+    Flags |= kGUICtrl_Translated;
 }
 
 } // namespace Common

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -19,60 +19,46 @@
 #include "gui/guiobject.h"
 #include "util/string.h"
 
-struct GUILabel:public GUIObject
+namespace AGS
 {
-private:
-  AGS::Common::String text;
+namespace Common
+{
+
+class GUILabel:public GUIObject
+{
 public:
-  int font, textcol, align;
+    GUILabel();
+    
+    String       GetText() const;
 
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  virtual void Draw(Common::Bitmap *ds);
-  void printtext_align(Common::Bitmap *g, int yy, color_t text_color, char *teptr);
-  void SetText(const char *newText);
-  const char *GetText();
+    // Operations
+    virtual void Draw(Bitmap *ds) override;
+    void         SetText(const String &text);
 
-  void MouseMove(int x, int y)
-  {
-  }
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
 
-  void MouseOver()
-  {
-  }
-
-  void MouseLeave()
-  {
-  }
-
-  void MouseUp()
-  {
-  }
-
-  void KeyPress(int kp)
-  {
-  }
-
-  void reset()
-  {
-    GUIObject::init();
-    align = GALIGN_LEFT;
-    font = 0;
-    textcol = 0;
-    numSupportedEvents = 0;
-  }
-
-  GUILabel() {
-    reset();
-  }
+// TODO: these members are currently public; hide them later
+public:
+    String  Text;
+    int32_t Font;
+    color_t TextColor;
+    int32_t TextAlignment;
 
 private:
-    // CHECKME: for some reason this function calls dest string "oritext"
-  void Draw_replace_macro_tokens(char *oritext, const char *text);
-  void Draw_split_lines(char *teptr, int wid, int font, int &numlines);
+    void DrawAlignedText(Bitmap *g, int at_y, color_t text_color, const char *text);
+    void PrepareTextToDraw();
+    int  SplitLinesForDrawing();
+
+    // prepared text buffer/cache
+    String _textToDraw;
 };
 
-extern std::vector<GUILabel> guilabels;
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUILabel> guilabels;
 extern int numguilabels;
 
 #endif // __AC_GUILABEL_H

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -44,10 +44,10 @@ public:
     String  Text;
     int32_t Font;
     color_t TextColor;
+    // TODO: use FrameAlignment type (will require changing GUI data format)
     int32_t TextAlignment;
 
 private:
-    void DrawAlignedText(Bitmap *g, int at_y, color_t text_color, const char *text);
     void PrepareTextToDraw();
     int  SplitLinesForDrawing();
 

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -39,9 +39,9 @@ GUIListBox::GUIListBox()
     SelectedBgColor = 16;
     TextAlignment = 0;
 
-    numSupportedEvents = 1;
-    supportedEvents[0] = "SelectionChanged";
-    supportedEventArgs[0] = "GUIControl *control";
+    _scEventCount = 1;
+    _scEventNames[0] = "SelectionChanged";
+    _scEventArgs[0] = "GUIControl *control";
 }
 
 int GUIListBox::GetItemAt(int x, int y) const
@@ -55,9 +55,9 @@ int GUIListBox::GetItemAt(int x, int y) const
     return index;
 }
 
-bool GUIListBox::IsInRightMargin(int x_) const
+bool GUIListBox::IsInRightMargin(int x) const
 {
-    if (x_ >= (wid - get_fixed_pixel_size(6)) && (ListBoxFlags & kListBox_NoBorder) == 0 && (ListBoxFlags & kListBox_NoArrows) == 0)
+    if (x >= (Width - get_fixed_pixel_size(6)) && (ListBoxFlags & kListBox_NoBorder) == 0 && (ListBoxFlags & kListBox_NoArrows) == 0)
         return 1;
     return 0;
 }
@@ -83,20 +83,20 @@ void GUIListBox::Clear()
 
 void GUIListBox::Draw(Common::Bitmap *ds)
 {
-    const int width  = wid - 1;
-    const int height = hit - 1;
+    const int width  = Width - 1;
+    const int height = Height - 1;
     const int pixel_size = get_fixed_pixel_size(1);
 
     check_font(&Font);
     color_t text_color = ds->GetCompatibleColor(TextColor);
     color_t draw_color = ds->GetCompatibleColor(TextColor);
     if ((ListBoxFlags & kListBox_NoBorder) == 0) {
-        ds->DrawRect(Rect(x, y, x + width + (pixel_size - 1), y + height + (pixel_size - 1)), draw_color);
+        ds->DrawRect(Rect(X, Y, X + width + (pixel_size - 1), Y + height + (pixel_size - 1)), draw_color);
         if (pixel_size > 1)
-            ds->DrawRect(Rect(x + 1, y + 1, x + width, y + height), draw_color);
+            ds->DrawRect(Rect(X + 1, Y + 1, X + width, Y + height), draw_color);
     }
 
-    int right_hand_edge = (x + width) - pixel_size - 1;
+    int right_hand_edge = (X + width) - pixel_size - 1;
 
     // use SetFont to update the RowHeight and VisibleItemCount
     SetFont(Font);
@@ -105,18 +105,18 @@ void GUIListBox::Draw(Common::Bitmap *ds)
     if (ItemCount > VisibleItemCount && (ListBoxFlags & kListBox_NoBorder) == 0 && (ListBoxFlags & kListBox_NoArrows) == 0)
     {
         int xstrt, ystrt;
-        ds->DrawRect(Rect(x + width - get_fixed_pixel_size(7), y, (x + (pixel_size - 1) + width) - get_fixed_pixel_size(7), y + height), draw_color);
-        ds->DrawRect(Rect(x + width - get_fixed_pixel_size(7), y + height / 2, x + width, y + height / 2 + (pixel_size - 1)), draw_color);
+        ds->DrawRect(Rect(X + width - get_fixed_pixel_size(7), Y, (X + (pixel_size - 1) + width) - get_fixed_pixel_size(7), Y + height), draw_color);
+        ds->DrawRect(Rect(X + width - get_fixed_pixel_size(7), Y + height / 2, X + width, Y + height / 2 + (pixel_size - 1)), draw_color);
 
-        xstrt = (x + width - get_fixed_pixel_size(6)) + (pixel_size - 1);
-        ystrt = (y + height - 3) - get_fixed_pixel_size(5);
+        xstrt = (X + width - get_fixed_pixel_size(6)) + (pixel_size - 1);
+        ystrt = (Y + height - 3) - get_fixed_pixel_size(5);
 
         draw_color = ds->GetCompatibleColor(TextColor);
         ds->DrawTriangle(Triangle(xstrt, ystrt, xstrt + get_fixed_pixel_size(4), ystrt, 
                  xstrt + get_fixed_pixel_size(2),
                  ystrt + get_fixed_pixel_size(5)), draw_color);
 
-        ystrt = y + 3;
+        ystrt = Y + 3;
         ds->DrawTriangle(Triangle(xstrt, ystrt + get_fixed_pixel_size(5), 
                  xstrt + get_fixed_pixel_size(4), 
                  ystrt + get_fixed_pixel_size(5),
@@ -132,19 +132,19 @@ void GUIListBox::Draw(Common::Bitmap *ds)
         if (item + TopItem >= ItemCount)
             break;
 
-        int at_y = y + pixel_size + item * RowHeight;
+        int at_y = Y + pixel_size + item * RowHeight;
         if (item + TopItem == SelectedItem)
         {
             text_color = ds->GetCompatibleColor(BgColor);
             if (SelectedBgColor > 0)
             {
-                int stretch_to = (x + width) - pixel_size;
+                int stretch_to = (X + width) - pixel_size;
                 // draw the SelectedItem item bar (if colour not transparent)
                 draw_color = ds->GetCompatibleColor(SelectedBgColor);
                 if ((VisibleItemCount < ItemCount) && ((ListBoxFlags & kListBox_NoBorder) == 0) && ((ListBoxFlags & kListBox_NoArrows) == 0))
                     stretch_to -= get_fixed_pixel_size(7);
 
-                ds->FillRect(Rect(x + pixel_size, at_y, stretch_to, at_y + RowHeight - pixel_size), draw_color);
+                ds->FillRect(Rect(X + pixel_size, at_y, stretch_to, at_y + RowHeight - pixel_size), draw_color);
             }
         }
         else
@@ -153,15 +153,15 @@ void GUIListBox::Draw(Common::Bitmap *ds)
         int item_index = item + TopItem;
         PrepareTextToDraw(Items[item_index]);
 
-        if (TextAlignment == GALIGN_LEFT)
-            wouttext_outline(ds, x + 1 + pixel_size, at_y + 1, Font, text_color, _textToDraw);
+        if (TextAlignment == kGUIAlign_Left)
+            wouttext_outline(ds, X + 1 + pixel_size, at_y + 1, Font, text_color, _textToDraw);
         else
         {
             int text_width = wgettextwidth(_textToDraw, Font);
-            if (TextAlignment == GALIGN_RIGHT)
+            if (TextAlignment == kGUIAlign_Right)
                 wouttext_outline(ds, right_hand_edge - text_width, at_y + 1, Font, text_color, _textToDraw);
             else
-                wouttext_outline(ds, ((right_hand_edge - x) / 2) + x - (text_width / 2), at_y + 1, Font, text_color, _textToDraw);
+                wouttext_outline(ds, ((right_hand_edge - X) / 2) + X - (text_width / 2), at_y + 1, Font, text_color, _textToDraw);
         }
     }
 
@@ -203,7 +203,7 @@ void GUIListBox::SetFont(int Font)
 {
     Font = Font;
     RowHeight = getfontheight(Font) + get_fixed_pixel_size(2);
-    VisibleItemCount = hit / RowHeight;
+    VisibleItemCount = Height / RowHeight;
 }
 
 void GUIListBox::SetItemText(int index, const String &text)
@@ -215,32 +215,32 @@ void GUIListBox::SetItemText(int index, const String &text)
     }
 }
 
-int GUIListBox::MouseDown()
+bool GUIListBox::OnMouseDown()
 {
     if (IsInRightMargin(MousePos.X))
     {
-        if (MousePos.Y < hit / 2 && TopItem > 0)
+        if (MousePos.Y < Height / 2 && TopItem > 0)
             TopItem--;
-        if (MousePos.Y >= hit / 2 && ItemCount > TopItem + VisibleItemCount)
+        if (MousePos.Y >= Height / 2 && ItemCount > TopItem + VisibleItemCount)
             TopItem++;
-        return 0;
+        return false;
     }
 
     int sel = GetItemAt(MousePos.X, MousePos.Y);
     if (sel < 0)
-        return 0;
+        return false;
     SelectedItem = sel;
-    activated = 1;
-    return 0;
+    IsActivated = true;
+    return false;
 }
 
-void GUIListBox::MouseMove(int x_, int y_)
+void GUIListBox::OnMouseMove(int x_, int y_)
 {
-    MousePos.X = x_ - x;
-    MousePos.Y = y_ - y;
+    MousePos.X = x_ - X;
+    MousePos.Y = y_ - Y;
 }
 
-void GUIListBox::Resized() 
+void GUIListBox::OnResized() 
 {
     if (RowHeight == 0)
     {
@@ -248,7 +248,7 @@ void GUIListBox::Resized()
         SetFont(Font);
     }
     if (RowHeight > 0)
-        VisibleItemCount = hit / RowHeight;
+        VisibleItemCount = Height / RowHeight;
 }
 
 // TODO: replace string serialization with StrUtil::ReadString and WriteString
@@ -306,7 +306,7 @@ void GUIListBox::ReadFromFile(Stream *in, GuiVersion gui_version)
     }
     else
     {
-        TextAlignment = GALIGN_LEFT;
+        TextAlignment = kGUIAlign_Left;
     }
 
     if (gui_version >= kGuiVersion_unkn_107)

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -153,16 +153,8 @@ void GUIListBox::Draw(Common::Bitmap *ds)
         int item_index = item + TopItem;
         PrepareTextToDraw(Items[item_index]);
 
-        if (TextAlignment == kGUIAlign_Left)
-            wouttext_outline(ds, X + 1 + pixel_size, at_y + 1, Font, text_color, _textToDraw);
-        else
-        {
-            int text_width = wgettextwidth(_textToDraw, Font);
-            if (TextAlignment == kGUIAlign_Right)
-                wouttext_outline(ds, right_hand_edge - text_width, at_y + 1, Font, text_color, _textToDraw);
-            else
-                wouttext_outline(ds, ((right_hand_edge - X) / 2) + X - (text_width / 2), at_y + 1, Font, text_color, _textToDraw);
-        }
+        GUI::DrawTextAlignedHor(ds, _textToDraw, Font, text_color, X + 1 + pixel_size, right_hand_edge, at_y + 1,
+            ConvertLegacyGUIAlignment(TextAlignment));
     }
 
     DrawItemsUnfix();
@@ -306,7 +298,7 @@ void GUIListBox::ReadFromFile(Stream *in, GuiVersion gui_version)
     }
     else
     {
-        TextAlignment = kGUIAlign_Left;
+        TextAlignment = kLegacyGUIAlign_Left;
     }
 
     if (gui_version >= kGuiVersion_unkn_107)

--- a/Common/gui/guilistbox.h
+++ b/Common/gui/guilistbox.h
@@ -56,6 +56,7 @@ public:
     color_t               BgColor;
     int32_t               Font;
     color_t               TextColor;
+    // TODO: use FrameAlignment type (will require changing GUI data format)
     int32_t               TextAlignment;
     color_t               SelectedBgColor;
     int32_t               RowHeight;

--- a/Common/gui/guilistbox.h
+++ b/Common/gui/guilistbox.h
@@ -42,9 +42,9 @@ public:
     void         SetItemText(int index, const String &textt);
 
     // Events
-    virtual int  MouseDown() override;
-    virtual void MouseMove(int x, int y) override;
-    virtual void Resized() override;
+    virtual bool OnMouseDown() override;
+    virtual void OnMouseMove(int x, int y) override;
+    virtual void OnResized() override;
 
     // Serialization
     virtual void WriteToFile(Stream *out) override;

--- a/Common/gui/guilistbox.h
+++ b/Common/gui/guilistbox.h
@@ -19,93 +19,71 @@
 #include "gui/guiobject.h"
 #include "util/string.h"
 
-struct GUIListBox:public GUIObject
+namespace AGS
 {
-  AGS::Common::String items[MAX_LISTBOX_ITEMS];
-  short saveGameIndex[MAX_LISTBOX_ITEMS];
-  int numItems, selected, topItem, mousexp, mouseyp;
-  int rowheight, num_items_fit;
-  int font, textcol, backcol, exflags;
-  int selectedbgcol;
-  int alignment, reserved1;
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  int  AddItem(const char *toadd);
-  int  InsertItem(int index, const char *toadd);
-  void SetItemText(int index, const char *newtext);
-  void RemoveItem(int index);
-  void Clear();
-  virtual void Draw(Common::Bitmap *ds);
-  int  IsInRightMargin(int x);
-  int  GetIndexFromCoordinates(int x, int y);
-  void ChangeFont(int newFont);
-  virtual int MouseDown();
-  
-  void MouseMove(int nx, int ny)
-  {
-    mousexp = nx - x;
-    mouseyp = ny - y;
-  }
+namespace Common
+{
 
-  void MouseOver()
-  {
-  }
+class GUIListBox : public GUIObject
+{
+public:
+    GUIListBox();
 
-  void MouseLeave()
-  {
-  }
+    bool         IsInRightMargin(int x) const;
+    int          GetItemAt(int x, int y) const;
 
-  void MouseUp()
-  {
-  }
+    // Operations
+    int          AddItem(const String &text);
+    void         Clear();
+    virtual void Draw(Bitmap *ds) override;
+    int          InsertItem(int index, const String &text);
+    void         RemoveItem(int index);
+    void         SetFont(int font);
+    void         SetItemText(int index, const String &textt);
 
-  void KeyPress(int kp)
-  {
-  }
+    // Events
+    virtual int  MouseDown() override;
+    virtual void MouseMove(int x, int y) override;
+    virtual void Resized() override;
 
-  virtual void Resized();
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
 
-  void reset()
-  {
-    GUIObject::init();
-    mousexp = 0;
-    mouseyp = 0;
-    activated = 0;
-    numItems = 0;
-    topItem = 0;
-    selected = 0;
-    font = 0;
-    textcol = 0;
-    selectedbgcol = 16;
-    backcol = 7;
-    exflags = 0;
-    rowheight = 0;
-    num_items_fit = 0;
-    alignment = GALIGN_LEFT;
-    numSupportedEvents = 1;
-    supportedEvents[0] = "SelectionChanged";
-    supportedEventArgs[0] = "GUIControl *control";
-  }
+// TODO: these members are currently public; hide them later
+public:
+    int32_t               ListBoxFlags;
+    color_t               BgColor;
+    int32_t               Font;
+    color_t               TextColor;
+    int32_t               TextAlignment;
+    color_t               SelectedBgColor;
+    int32_t               RowHeight;
+    int32_t               VisibleItemCount;
+    
+    std::vector<String>   Items;
+    std::vector<int16_t>  SavedGameIndex;
+    int32_t               SelectedItem;
+    int32_t               TopItem;
+    Point                 MousePos;
 
-  GUIListBox() {
-    reset();
-  }
-
-  virtual ~GUIListBox()
-  {
-    for (int i = 0; i < numItems; i++)
-      items[i].Free();
-  }
+    // TODO: remove these later
+    int32_t               ItemCount;
 
 private:
-  int numItemsTemp;
+    // A temporary solution for special drawing in the Editor
+    void DrawItemsFix();
+    void DrawItemsUnfix();
+    void PrepareTextToDraw(const String &text);
 
-  void Draw_items_fix();
-  void Draw_items_unfix();
-  void Draw_set_oritext(char *oritext, const char *text);
+    // prepared text buffer/cache
+    String _textToDraw;
 };
 
-extern std::vector<GUIListBox> guilist;
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUIListBox> guilist;
 extern int numguilist;
 
 #endif // __AC_GUILISTBOX_H

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -562,6 +562,21 @@ void DrawDisabledEffect(Bitmap *ds, const Rect &rc)
     }
 }
 
+void DrawTextAligned(Bitmap *ds, const char *text, int font, color_t text_color, const Rect &frame, FrameAlignment align)
+{
+    int text_height = wgettextheight(text, font);
+    if (align & kAlignVCenter)
+        text_height++; // CHECKME
+    Rect item = AlignInRect(frame, RectWH(0, 0, wgettextwidth(text, font), text_height), align);
+    wouttext_outline(ds, item.Left, item.Top, font, text_color, text);
+}
+
+void DrawTextAlignedHor(Bitmap *ds, const char *text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align)
+{
+    int x = AlignInHRange(x1, x2, 0, wgettextwidth(text, font), align);
+    wouttext_outline(ds, x, y, font, text_color, text);
+}
+
 void ResortGUI(std::vector<GUIMain> &guis, bool bwcompat_ctrl_zorder = false)
 {
     // set up the reverse-lookup array

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -550,6 +550,18 @@ namespace GUI
 
 GuiVersion GameGuiVersion = kGuiVersion_Initial;
 
+void DrawDisabledEffect(Bitmap *ds, const Rect &rc)
+{
+    color_t draw_color = ds->GetCompatibleColor(8);
+    for (int at_x = rc.Left; at_x < rc.GetWidth(); ++at_x)
+    {
+        for (int at_y = rc.Top + at_x % 2; at_y < rc.GetHeight(); at_y += 2)
+        {
+            ds->PutPixel(at_x, at_y, draw_color);
+        }
+    }
+}
+
 void ResortGUI(std::vector<GUIMain> &guis, bool bwcompat_ctrl_zorder = false)
 {
     // set up the reverse-lookup array

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -147,6 +147,9 @@ namespace GUI
 {
     extern GuiVersion GameGuiVersion;
 
+    // Draw standart "shading" effect over rectangle
+    void DrawDisabledEffect(Bitmap *ds, const Rect &rc);
+
     void ReadGUI(std::vector<GUIMain> &guis, Stream *in);
     void WriteGUI(const std::vector<GUIMain> &guis, Stream *out, bool savedgame);
 }

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -149,6 +149,10 @@ namespace GUI
 
     // Draw standart "shading" effect over rectangle
     void DrawDisabledEffect(Bitmap *ds, const Rect &rc);
+    // Draw text aligned inside rectangle
+    void DrawTextAligned(Bitmap *ds, const char *text, int font, color_t text_color, const Rect &frame, FrameAlignment align);
+    // Draw text aligned horizontally inside given bounds
+    void DrawTextAlignedHor(Bitmap *ds, const char *text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align);
 
     void ReadGUI(std::vector<GUIMain> &guis, Stream *in);
     void WriteGUI(const std::vector<GUIMain> &guis, Stream *out, bool savedgame);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -98,8 +98,8 @@ public:
     void    OnControlPositionChanged();
   
     // Serialization
-    void    ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-    void    WriteToFile(Common::Stream *out, GuiVersion gui_version) const;
+    void    ReadFromFile(Stream *in, GuiVersion gui_version);
+    void    WriteToFile(Stream *out, GuiVersion gui_version) const;
 
 private:
     void    DrawBlob(Bitmap *ds, int x, int y, color_t draw_color);
@@ -142,18 +142,23 @@ private:
     GUIVisibilityState _visibility;
 };
 
+
+namespace GUI
+{
+    extern GuiVersion GameGuiVersion;
+
+    void ReadGUI(std::vector<GUIMain> &guis, Stream *in);
+    void WriteGUI(const std::vector<GUIMain> &guis, Stream *out, bool savedgame);
+}
+
 } // namespace Common
 } // namespace AGS
 
-extern GuiVersion GameGuiVersion;
 extern std::vector<Common::GUIMain> guis;
 extern int all_buttons_disabled, gui_inv_pic;
 extern int gui_disabled_style;
 extern char lines[MAXLINE][200];
 extern int  numlines;
-
-extern void read_gui(Common::Stream *in, std::vector<Common::GUIMain> &guiread, GameSetupStruct * gss);
-extern void write_gui(Common::Stream *out, const std::vector<Common::GUIMain> &guiwrite, GameSetupStruct * gss, bool savedgame);
 
 extern int mousex, mousey;
 

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -141,5 +141,19 @@ void GUIObject::ReadFromFile(Stream *in, GuiVersion gui_version)
 }
 
 
+FrameAlignment ConvertLegacyGUIAlignment(int32_t align)
+{
+    switch (align)
+    {
+    case kLegacyGUIAlign_Left:
+        return kAlignLeft;
+    case kLegacyGUIAlign_Right:
+        return kAlignRight;
+    case kLegacyGUIAlign_Center:
+        return kAlignHCenter;
+    }
+    return kAlignNone;
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -12,72 +12,134 @@
 //
 //=============================================================================
 
-#include <stdio.h>
+#include "ac/common.h"
 #include "gui/guiobject.h"
 #include "gui/guimain.h"
-#include "util/string_utils.h"  // fputstring, etc
-#include "ac/common.h"		// quit()
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+namespace AGS
+{
+namespace Common
+{
 
 GUIObject::GUIObject()
 {
-  guin = objn = 0;
-  flags = 0;
-  x = y = 0;
-  wid = hit = 0;
-  zorder = 0;
-  activated = 0;
-  init();
+    Id          = 0;
+    ParentId    = 0;
+    Flags       = 0;
+    X           = 0;
+    Y           = 0;
+    Width       = 0;
+    Height      = 0;
+    ZOrder      = -1;
+    IsActivated    = false;
 }
 
-void GUIObject::init() {
-  int jj;
-  scriptName[0] = 0;
-  for (jj = 0; jj < MAX_GUIOBJ_EVENTS; jj++)
-    eventHandlers[jj][0] = 0;
+int GUIObject::GetEventCount() const
+{
+    return _scEventCount;
 }
 
-int GUIObject::IsDisabled() {
-  if (flags & GUIF_DISABLED)
-    return 1;
-  if (all_buttons_disabled)
-    return 1;
-  return 0;
+String GUIObject::GetEventName(int event) const
+{
+    if (event < 0 || event >= _scEventCount)
+        return "";
+    return _scEventNames[event];
 }
 
+String GUIObject::GetEventArgs(int event) const
+{
+    if (event < 0 || event >= _scEventCount)
+        return "";
+    return _scEventArgs[event];
+}
+
+bool GUIObject::IsEnabled() const
+{
+    // TODO: a global variable should not be checked by control
+    return !((Flags & kGUICtrl_Disabled) || all_buttons_disabled);
+}
+
+bool GUIObject::IsOverControl(int x, int y, int leeway) const
+{
+    return x >= X && y >= Y && x < (X + Width + leeway) && y < (Y + Height + leeway);
+}
+
+void GUIObject::Disable()
+{
+    Flags |= kGUICtrl_Disabled;
+}
+
+void GUIObject::Enable()
+{
+    Flags &= ~kGUICtrl_Disabled;
+}
+
+void GUIObject::Hide()
+{
+    Flags |= kGUICtrl_Invisible;
+}
+
+void GUIObject::SetClickable(bool clickable)
+{
+    if (clickable)
+        Flags &= ~kGUICtrl_NoClicks;
+    else
+        Flags |= kGUICtrl_NoClicks;
+}
+
+void GUIObject::Show()
+{
+    Flags &= ~kGUICtrl_Invisible;
+}
+
+// TODO: replace string serialization with StrUtil::ReadString and WriteString
+// methods in the future, to keep this organized.
 void GUIObject::WriteToFile(Stream *out)
 {
-  // MACPORT FIX: swap
-  out->WriteArrayOfInt32((int32_t*)&flags, BASEGOBJ_SIZE);
-  fputstring(scriptName, out);
-
-  out->WriteInt32(GetNumEvents());
-  for (int kk = 0; kk < GetNumEvents(); kk++)
-    fputstring(eventHandlers[kk], out);
+    out->WriteInt32(Flags);
+    out->WriteInt32(X);
+    out->WriteInt32(Y);
+    out->WriteInt32(Width);
+    out->WriteInt32(Height);
+    out->WriteInt32(ZOrder);
+    out->WriteInt32(IsActivated);
+    Name.Write(out);
+    out->WriteInt32(_scEventCount);
+    for (int i = 0; i < _scEventCount; ++i)
+        EventHandlers[i].Write(out);
 }
 
 void GUIObject::ReadFromFile(Stream *in, GuiVersion gui_version)
 {
-  // MACPORT FIX: swap
-  in->ReadArrayOfInt32((int32_t*)&flags, BASEGOBJ_SIZE);
-  if (gui_version >= kGuiVersion_unkn_106)
-    fgetstring_limit(scriptName, in, MAX_GUIOBJ_SCRIPTNAME_LEN);
-  else
-    scriptName[0] = 0;
+    Flags    = in->ReadInt32();
+    X        = in->ReadInt32();
+    Y        = in->ReadInt32();
+    Width    = in->ReadInt32();
+    Height   = in->ReadInt32();
+    ZOrder   = in->ReadInt32();
+    IsActivated = in->ReadInt32() != 0;
 
-  int kk;
-  for (kk = 0; kk < GetNumEvents(); kk++)
-    eventHandlers[kk][0] = 0;
+    if (gui_version >= kGuiVersion_unkn_106)
+        Name.Read(in);
 
-  if (gui_version >= kGuiVersion_unkn_108) {
-    int numev = in->ReadInt32();
-    if (numev > GetNumEvents())
-      quit("Error: too many control events, need newer version");
+    for (int i = 0; i < _scEventCount; ++i)
+    {
+        EventHandlers[i].Free();
+    }
 
-    // read in the event handler names
-    for (kk = 0; kk < numev; kk++)
-      fgetstring_limit(eventHandlers[kk], in, MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
-  }
+    if (gui_version >= kGuiVersion_unkn_108)
+    {
+        int evt_count = in->ReadInt32();
+        if (evt_count > _scEventCount)
+            quit("Error: too many control events, need newer version");
+        for (int i = 0; i < evt_count; ++i)
+        {
+            EventHandlers[i].Read(in);
+        }
+    }
 }
+
+
+} // namespace Common
+} // namespace AGS

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -33,12 +33,11 @@ namespace AGS
 namespace Common
 {
 
-// TODO: generic alignment
-enum GUIAlignment
+enum LegacyGUIAlignment
 {
-    kGUIAlign_Left   = 0,
-    kGUIAlign_Right  = 1,
-    kGUIAlign_Center = 2
+    kLegacyGUIAlign_Left   = 0,
+    kLegacyGUIAlign_Right  = 1,
+    kLegacyGUIAlign_Center = 2
 };
 
 class GUIObject
@@ -110,6 +109,9 @@ protected:
     String   _scEventNames[MAX_GUIOBJ_EVENTS]; // script event names
     String   _scEventArgs[MAX_GUIOBJ_EVENTS];  // script handler params
 };
+
+
+FrameAlignment ConvertLegacyGUIAlignment(int32_t align);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -18,105 +18,100 @@
 #include "core/types.h"
 #include "gfx/bitmap.h"
 #include "gui/guidefines.h"
-
-namespace AGS { namespace Common { class Stream; } }
-using namespace AGS; // FIXME later
+#include "util/string.h"
 
 #define GUIDIS_GREYOUT   1
 #define GUIDIS_BLACKOUT  2
 #define GUIDIS_UNCHANGED 4
 #define GUIDIS_GUIOFF  0x80
 
-#define BASEGOBJ_SIZE 7
-#define GALIGN_LEFT   0
-#define GALIGN_RIGHT  1
-#define GALIGN_CENTRE 2
 
-struct GUIObject
+
+
+namespace AGS
 {
-  int guin, objn;    // gui and object number of this object
-  unsigned int flags;
-  int x, y;
-  int wid, hit;
-  int zorder;
-  int activated;
-  char scriptName[MAX_GUIOBJ_SCRIPTNAME_LEN + 1];
-  char eventHandlers[MAX_GUIOBJ_EVENTS][MAX_GUIOBJ_EVENTHANDLER_LEN + 1];
+namespace Common
+{
 
-  GUIObject();
-  virtual ~GUIObject(){}
-  virtual void MouseMove(int, int) {}; // x,y relative to gui
-  virtual void MouseOver() {}; // mouse moves onto object
-  virtual void MouseLeave() {};        // mouse moves off object
-  virtual int  MouseDown() { // button down - return 1 to lock focus
-    return 0;
-  }
-  virtual void MouseUp() {};   // button up
-  virtual void KeyPress(int) {};
-  virtual void Draw(Common::Bitmap *ds) = 0;
-  // overridable routine to determine whether the mouse is over
-  // the control
-  virtual int  IsOverControl(int p_x, int p_y, int p_extra) {
-    if ((p_x >= x) && (p_y >= y) && (p_x < x + wid + p_extra) && (p_y < y + hit + p_extra))
-      return 1;
-    return 0;
-  }
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  // called when the control is resized
-  virtual void Resized() { }
-  virtual int  GetNumEvents() {
-    return numSupportedEvents;
-  }
-  virtual const char *GetEventName(int idx) {
-    if ((idx < 0) || (idx >= numSupportedEvents))
-      return NULL;
-    return supportedEvents[idx];
-  }
-  virtual const char *GetEventArgs(int idx) {
-    if ((idx < 0) || (idx >= numSupportedEvents))
-      return NULL;
-    return supportedEventArgs[idx];
-  }
-  void init();
-
-  int IsDeleted() {
-    return flags & GUIF_DELETED;
-  }
-  int IsDisabled();
-  void Enable() {
-    flags &= ~GUIF_DISABLED;
-  }
-  void Disable() {
-    flags |= GUIF_DISABLED;
-  }
-  int IsVisible() {
-    if (flags & GUIF_INVISIBLE)
-      return 0;
-    return 1;
-  }
-  void Show() {
-    flags &= ~GUIF_INVISIBLE;
-  }
-  void Hide() {
-    flags |= GUIF_INVISIBLE;
-  }
-  int IsClickable();
-  void SetClickable(bool newValue) {
-    flags &= ~GUIF_NOCLICKS;
-    if (!newValue)
-      flags |= GUIF_NOCLICKS;
-  }
-
-  inline bool IsTranslated() const
-  {
-     return (flags & GUIF_TRANSLATED) != 0;
-  }
-
-protected:
-  const char *supportedEvents[MAX_GUIOBJ_EVENTS];
-  const char *supportedEventArgs[MAX_GUIOBJ_EVENTS];
-  int numSupportedEvents;
+// TODO: generic alignment
+enum GUIAlignment
+{
+    kGUIAlign_Left   = 0,
+    kGUIAlign_Right  = 1,
+    kGUIAlign_Center = 2
 };
+
+class GUIObject
+{
+public:
+    GUIObject();
+    virtual ~GUIObject(){}
+    
+    String          GetEventArgs(int event) const;
+    int             GetEventCount() const;
+    String          GetEventName(int event) const;
+    bool            IsDeleted() const { return (Flags & kGUICtrl_Deleted) != 0; }
+    // checks both control flag and global variable
+    bool            IsEnabled() const;
+    // overridable routine to determine whether the mouse is over the control
+    virtual bool    IsOverControl(int x, int y, int leeway) const;
+    inline bool     IsTranslated() const { return (Flags & kGUICtrl_Translated) != 0; }
+    inline bool     IsVisible() const { return (Flags & kGUICtrl_Invisible) == 0; }
+    // implemented separately in engine and editor
+    bool            IsClickable() const;
+    
+    // Operations
+    void            Disable();
+    virtual void    Draw(Bitmap *ds) { }
+    void            Enable();
+    void            Hide();
+    void            SetClickable(bool clickable);
+    void            Show();
+
+    // Events
+    // Key pressed for control
+    virtual void    OnKeyPress(int keycode) { }
+    // Mouse button down - return 'True' to lock focus
+    virtual bool    OnMouseDown() { return false; }
+    // Mouse moves onto control
+    virtual void    OnMouseEnter() { }
+    // Mouse moves off control
+    virtual void    OnMouseLeave() { }
+    // Mouse moves over control - x,y relative to gui
+    virtual void    OnMouseMove(int x, int y) { }
+    // Mouse button up
+    virtual void    OnMouseUp() { }
+    // Control was resized
+    virtual void    OnResized() { }
+
+    // Serialization
+    virtual void    WriteToFile(Common::Stream *out);
+    virtual void    ReadFromFile(Common::Stream *in, GuiVersion gui_version);
+
+// TODO: these members are currently public; hide them later
+public:
+    int32_t  Id;         // GUI object's identifier
+    int32_t  ParentId;   // id of parent GUI
+    String   Name;       // script name
+    uint32_t Flags;      // generic style and behavior flags
+
+    int32_t  X;
+    int32_t  Y;
+    int32_t  Width;
+    int32_t  Height;
+    int32_t  ZOrder;
+    bool     IsActivated; // signals user interaction
+
+    String   EventHandlers[MAX_GUIOBJ_EVENTS]; // script function names
+  
+protected:
+    // TODO: explicit event names & handlers for every event
+    int32_t  _scEventCount;                    // number of supported script events
+    String   _scEventNames[MAX_GUIOBJ_EVENTS]; // script event names
+    String   _scEventArgs[MAX_GUIOBJ_EVENTS];  // script handler params
+};
+
+} // namespace Common
+} // namespace AGS
 
 #endif // __AC_GUIOBJECT_H

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -45,14 +45,14 @@ struct GUIObject
 
   GUIObject();
   virtual ~GUIObject(){}
-  virtual void MouseMove(int, int) = 0; // x,y relative to gui
-  virtual void MouseOver() = 0; // mouse moves onto object
-  virtual void MouseLeave() = 0;        // mouse moves off object
+  virtual void MouseMove(int, int) {}; // x,y relative to gui
+  virtual void MouseOver() {}; // mouse moves onto object
+  virtual void MouseLeave() {};        // mouse moves off object
   virtual int  MouseDown() { // button down - return 1 to lock focus
     return 0;
   }
-  virtual void MouseUp() = 0;   // button up
-  virtual void KeyPress(int) = 0;
+  virtual void MouseUp() {};   // button up
+  virtual void KeyPress(int) {};
   virtual void Draw(Common::Bitmap *ds) = 0;
   // overridable routine to determine whether the mouse is over
   // the control

--- a/Common/gui/guislider.cpp
+++ b/Common/gui/guislider.cpp
@@ -35,23 +35,23 @@ GUISlider::GUISlider()
     HandleOffset = 0;
     IsMousePressed = false;
 
-    numSupportedEvents = 1;
-    supportedEvents[0] = "Change";
-    supportedEventArgs[0] = "GUIControl *control";
+    _scEventCount = 1;
+    _scEventNames[0] = "Change";
+    _scEventArgs[0] = "GUIControl *control";
 }
 
 bool GUISlider::IsHorizontal() const
 {
-    return wid > hit;
+    return Width > Height;
 }
 
-int GUISlider::IsOverControl(int x, int y, int leeway)
+bool GUISlider::IsOverControl(int X, int Y, int leeway) const
 {
     // check the overall boundary
-    if (GUIObject::IsOverControl(x, y, leeway))
+    if (GUIObject::IsOverControl(X, Y, leeway))
         return true;
     // now check the handle too
-    return _cachedHandle.IsInside(Point(x, y));
+    return _cachedHandle.IsInside(Point(X, Y));
 }
 
 void GUISlider::Draw(Common::Bitmap *ds)
@@ -67,12 +67,12 @@ void GUISlider::Draw(Common::Bitmap *ds)
     // it's a horizontal slider
     if (IsHorizontal())
     {
-        thickness = hit / 3;
-        bar.Left = x + 1;
-        bar.Top = y + hit / 2 - thickness;
-        bar.Right = x + wid - 1;
-        bar.Bottom = y + hit / 2 + thickness + 1;
-        handle.Left = (int)(((float)(Value - MinValue) / (float)(MaxValue - MinValue)) * (float)(wid - 4) - 2) + bar.Left + 1;
+        thickness = Height / 3;
+        bar.Left = X + 1;
+        bar.Top = Y + Height / 2 - thickness;
+        bar.Right = X + Width - 1;
+        bar.Bottom = Y + Height / 2 + thickness + 1;
+        handle.Left = (int)(((float)(Value - MinValue) / (float)(MaxValue - MinValue)) * (float)(Width - 4) - 2) + bar.Left + 1;
         handle.Top = bar.Top - (thickness - 1);
         handle.Right = handle.Left + get_fixed_pixel_size(4);
         handle.Bottom = bar.Bottom + (thickness - 1);
@@ -88,12 +88,12 @@ void GUISlider::Draw(Common::Bitmap *ds)
     // vertical slider
     else
     {
-        thickness = wid / 3;
-        bar.Left = x + wid / 2 - thickness;
-        bar.Top = y + 1;
-        bar.Right = x + wid / 2 + thickness + 1;
-        bar.Bottom = y + hit - 1;
-        handle.Top = (int)(((float)(MaxValue - Value) / (float)(MaxValue - MinValue)) * (float)(hit - 4) - 2) + bar.Top + 1;
+        thickness = Width / 3;
+        bar.Left = X + Width / 2 - thickness;
+        bar.Top = Y + 1;
+        bar.Right = X + Width / 2 + thickness + 1;
+        bar.Bottom = Y + Height - 1;
+        handle.Top = (int)(((float)(MaxValue - Value) / (float)(MaxValue - MinValue)) * (float)(Height - 4) - 2) + bar.Top + 1;
         handle.Left = bar.Left - (thickness - 1);
         handle.Bottom = handle.Top + get_fixed_pixel_size(4);
         handle.Right = bar.Right + (thickness - 1);
@@ -117,13 +117,13 @@ void GUISlider::Draw(Common::Bitmap *ds)
         {
             x_inc = get_adjusted_spritewidth(BgImage);
             // centre the image vertically
-            bar.Top = y + (hit / 2) - get_adjusted_spriteheight(BgImage) / 2;
+            bar.Top = Y + (Height / 2) - get_adjusted_spriteheight(BgImage) / 2;
         }
         else
         {
             y_inc = get_adjusted_spriteheight(BgImage);
             // centre the image horizontally
-            bar.Left = x + (wid / 2) - get_adjusted_spritewidth(BgImage) / 2;
+            bar.Left = X + (Width / 2) - get_adjusted_spritewidth(BgImage) / 2;
         }
         int cx = bar.Left;
         int cy = bar.Top;
@@ -178,29 +178,29 @@ void GUISlider::Draw(Common::Bitmap *ds)
     _cachedHandle = handle;
 }
 
-int GUISlider::MouseDown()
+bool GUISlider::OnMouseDown()
 {
     IsMousePressed = true;
     // lock focus to ourselves
     return true;
 }
 
-void GUISlider::MouseMove(int xp, int yp)
+void GUISlider::OnMouseMove(int x, int y)
 {
     if (!IsMousePressed)
         return;
 
     if (IsHorizontal())
-        Value = (int)(((float)((xp - x) - 2) / (float)(wid - 4)) * (float)(MaxValue - MinValue)) + MinValue;
+        Value = (int)(((float)((x - X) - 2) / (float)(Width - 4)) * (float)(MaxValue - MinValue)) + MinValue;
     else
-        Value = (int)(((float)(((y + hit) - yp) - 2) / (float)(hit - 4)) * (float)(MaxValue - MinValue)) + MinValue;
+        Value = (int)(((float)(((Y + Height) - y) - 2) / (float)(Height - 4)) * (float)(MaxValue - MinValue)) + MinValue;
 
     Value = Math::Clamp(MinValue, MaxValue, Value);
     guis_need_update = 1;
-    activated = 1;
+    IsActivated = true;
 }
 
-void GUISlider::MouseUp()
+void GUISlider::OnMouseUp()
 {
     IsMousePressed = false;
 }

--- a/Common/gui/guislider.h
+++ b/Common/gui/guislider.h
@@ -18,80 +18,52 @@
 #include <vector>
 #include "gui/guiobject.h"
 
-struct GUISlider:public GUIObject
+namespace AGS
 {
-  int min, max;
-  int value, mpressed;
-  int handlepic, handleoffset, bgimage;
-  // The following variables are not persisted on disk
-  // Cached (x1, x2, y1, y2) co-ordinates of slider handle
-  int cached_handtlx, cached_handbrx;
-  int cached_handtly, cached_handbry;
+namespace Common
+{
 
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  virtual void Draw(Common::Bitmap *ds);
-  void MouseMove(int xp, int yp);
+class GUISlider : public GUIObject
+{
+public:
+    GUISlider();
 
-  void MouseOver()
-  {
-  }
+    // Tells if the slider is horizontal (otherwise - vertical)
+    bool         IsHorizontal() const;
+    virtual int  IsOverControl(int x, int y, int leeway) override;
 
-  void MouseLeave()
-  {
-  }
+    // Operations
+    virtual void Draw(Bitmap *ds) override;
 
-  virtual int MouseDown()
-  {
-    mpressed = 1;
-    // lock focus to ourselves
-    return 1;
-  }
+    // Events
+    virtual int  MouseDown() override;
+    virtual void MouseMove(int xp, int yp) override;
+    virtual void MouseUp() override;
 
-  void MouseUp()
-  {
-    mpressed = 0;
-  }
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
 
-  void KeyPress(int kp)
-  {
-  }
+// TODO: these members are currently public; hide them later
+public:
+    int32_t MinValue;
+    int32_t MaxValue;
+    int32_t Value;
+    int32_t BgImage;
+    int32_t HandleImage;
+    int32_t HandleOffset;
+    bool    IsMousePressed;
 
-  virtual int IsOverControl(int p_x, int p_y, int p_extra) {
-    // check the overall boundary
-    if (GUIObject::IsOverControl(p_x, p_y, p_extra))
-      return 1;
-    // now check the handle too
-    if ((p_x >= cached_handtlx) && (p_y >= cached_handtly) &&
-        (p_x < cached_handbrx) && (p_y < cached_handbry))
-      return 1;
-    return 0;
-  }
-
-  void reset()
-  {
-    GUIObject::init();
-    min = 0;
-    max = 10;
-    value = 0;
-    mpressed = 0;
-    handlepic = -1;
-    handleoffset = 0;
-    bgimage = 0;
-    activated = 0;
-    cached_handtlx = cached_handbrx = 0;
-    cached_handtly = cached_handbry = 0;
-    numSupportedEvents = 1;
-    supportedEvents[0] = "Change";
-    supportedEventArgs[0] = "GUIControl *control";
-  }
-
-  GUISlider() {
-    reset();
-  }
+private:
+    // The following variables are not persisted on disk
+    // Cached coordinates of slider handle
+    Rect    _cachedHandle;
 };
 
-extern std::vector<GUISlider> guislider;
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUISlider> guislider;
 extern int numguislider;
 
 #endif // __AC_GUISLIDER_H

--- a/Common/gui/guislider.h
+++ b/Common/gui/guislider.h
@@ -30,15 +30,15 @@ public:
 
     // Tells if the slider is horizontal (otherwise - vertical)
     bool         IsHorizontal() const;
-    virtual int  IsOverControl(int x, int y, int leeway) override;
+    virtual bool IsOverControl(int x, int y, int leeway) const override;
 
     // Operations
     virtual void Draw(Bitmap *ds) override;
 
     // Events
-    virtual int  MouseDown() override;
-    virtual void MouseMove(int xp, int yp) override;
-    virtual void MouseUp() override;
+    virtual bool OnMouseDown() override;
+    virtual void OnMouseMove(int xp, int yp) override;
+    virtual void OnMouseUp() override;
 
     // Serialization
     virtual void WriteToFile(Stream *out) override;

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -34,9 +34,9 @@ GUITextBox::GUITextBox()
     TextColor = 0;
     TextBoxFlags = 0;
 
-    numSupportedEvents = 1;
-    supportedEvents[0] = "Activate";
-    supportedEventArgs[0] = "GUIControl *control";
+    _scEventCount = 1;
+    _scEventNames[0] = "Activate";
+    _scEventArgs[0] = "GUIControl *control";
 }
 
 void GUITextBox::Draw(Bitmap *ds)
@@ -46,16 +46,16 @@ void GUITextBox::Draw(Bitmap *ds)
     color_t draw_color = ds->GetCompatibleColor(TextColor);
     if ((TextBoxFlags & kTextBox_NoBorder) == 0)
     {
-        ds->DrawRect(RectWH(x, y, wid, hit), draw_color);
+        ds->DrawRect(RectWH(X, Y, Width, Height), draw_color);
         if (get_fixed_pixel_size(1) > 1)
         {
-            ds->DrawRect(Rect(x + 1, y + 1, x + wid - get_fixed_pixel_size(1), y + hit - get_fixed_pixel_size(1)), draw_color);
+            ds->DrawRect(Rect(X + 1, Y + 1, X + Width - get_fixed_pixel_size(1), Y + Height - get_fixed_pixel_size(1)), draw_color);
         }
     }
     DrawTextBoxContents(ds, text_color);
 }
 
-void GUITextBox::KeyPress(int keycode)
+void GUITextBox::OnKeyPress(int keycode)
 {
     guis_need_update = 1;
     // TODO: use keycode constants
@@ -71,13 +71,13 @@ void GUITextBox::KeyPress(int keycode)
     // return/enter
     if (keycode == 13)
     {
-        activated++;
+        IsActivated = true;
         return;
     }
 
     Text.AppendChar(keycode);
     // if the new string is too long, remove the new character
-    if (wgettextwidth(Text, Font) > (wid - (6 + get_fixed_pixel_size(5))))
+    if (wgettextwidth(Text, Font) > (Width - (6 + get_fixed_pixel_size(5))))
         Text.ClipRight(1);
 }
 

--- a/Common/gui/guitextbox.h
+++ b/Common/gui/guitextbox.h
@@ -17,54 +17,43 @@
 
 #include <vector>
 #include "gui/guiobject.h"
+#include "util/string.h"
 
-struct GUITextBox:public GUIObject
+namespace AGS
 {
-  char text[200];
-  int font, textcol, exflags;
+namespace Common
+{
 
-  virtual void WriteToFile(Common::Stream *out);
-  virtual void ReadFromFile(Common::Stream *in, GuiVersion gui_version);
-  virtual void Draw(Common::Bitmap *ds);
-  void KeyPress(int);
+class GUITextBox : public GUIObject
+{
+public:
+    GUITextBox();
 
-  void MouseMove(int x, int y)
-  {
-  }
-
-  void MouseOver()
-  {
-  }
-
-  void MouseLeave()
-  {
-  }
-
-  void MouseUp()
-  {
-  }
-
-  void reset()
-  {
-    GUIObject::init();
-    font = 0;
-    textcol = 0;
-    text[0] = 0;
-    exflags = 0;
-    numSupportedEvents = 1;
-    supportedEvents[0] = "Activate";
-    supportedEventArgs[0] = "GUIControl *control";
-  }
-
-  GUITextBox() {
-    reset();
-  }
+    // Operations
+    virtual void Draw(Bitmap *ds) override;
+ 
+    // Events
+    virtual void KeyPress(int keycode) override;
+ 
+    // Serialization
+    virtual void WriteToFile(Stream *out) override;
+    virtual void ReadFromFile(Stream *in, GuiVersion gui_version) override;
+ 
+// TODO: these members are currently public; hide them later
+public:
+    int32_t Font;
+    String  Text;
+    int32_t TextBoxFlags;
+    color_t TextColor;
 
 private:
-  void Draw_text_box_contents(Common::Bitmap *ds, color_t text_color);
+    void DrawTextBoxContents(Bitmap *ds, color_t text_color);
 };
 
-extern std::vector<GUITextBox> guitext;
+} // namespace Common
+} // namespace AGS
+
+extern std::vector<AGS::Common::GUITextBox> guitext;
 extern int numguitext;
 
 #endif // __AC_GUITEXTBOX_H

--- a/Common/gui/guitextbox.h
+++ b/Common/gui/guitextbox.h
@@ -33,7 +33,7 @@ public:
     virtual void Draw(Bitmap *ds) override;
  
     // Events
-    virtual void KeyPress(int keycode) override;
+    virtual void OnKeyPress(int keycode) override;
  
     // Serialization
     virtual void WriteToFile(Stream *out) override;

--- a/Common/util/geometry.cpp
+++ b/Common/util/geometry.cpp
@@ -35,6 +35,34 @@ Size ProportionalStretch(const Size &dest, const Size &item)
     return ProportionalStretch(dest.Width, dest.Height, item.Width, item.Height);
 }
 
+int AlignInHRange(int x1, int x2, int off_x, int width, FrameAlignment align)
+{
+    if (align & kAlignRight)
+        return off_x + x2 - width;
+    else if (align & kAlignHCenter)
+        return off_x + x1 + ((x2 - x1 + 1) >> 1) - (width >> 1);
+    return off_x + x1; // kAlignLeft is default
+}
+
+int AlignInVRange(int y1, int y2, int off_y, int height, FrameAlignment align)
+{
+    if (align & kAlignBottom)
+        return off_y + y2 - height;
+    else if (align & kAlignVCenter)
+        return off_y + y1 + ((y2 - y1 + 1) >> 1) - (height >> 1);
+    return off_y + y1; // kAlignTop is default
+}
+
+Rect AlignInRect(const Rect &frame, const Rect &item, FrameAlignment align)
+{
+    int x = AlignInHRange(frame.Left, frame.Right, item.Left, item.GetWidth(), align);
+    int y = AlignInVRange(frame.Top, frame.Bottom, item.Top, item.GetHeight(), align);
+
+    Rect dst_item = item;
+    dst_item.MoveTo(Point(x, y));
+    return dst_item;
+}
+
 Rect OffsetRect(const Rect &r, const Point off)
 {
     return Rect(r.Left + off.X, r.Top + off.Y, r.Right + off.X, r.Bottom + off.Y);

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -26,6 +26,31 @@ namespace AGSMath = AGS::Common::Math;
 //namespace Common
 //{
 
+enum FrameAlignment
+{
+    kAlignNone     = 0x00,
+    kAlignLeft     = 0x01,
+    kAlignRight    = 0x02,
+    kAlignHCenter  = 0x04,
+    kAlignTop      = 0x10,
+    kAlignBottom   = 0x20,
+    kAlignVCenter  = 0x40,
+
+    kAlignTopLeft      = kAlignTop     | kAlignLeft,
+    kAlignTopCenter    = kAlignTop     | kAlignHCenter,
+    kAlignTopRight     = kAlignTop     | kAlignRight,
+    kAlignCenterLeft   = kAlignVCenter | kAlignLeft,
+    kAlignCentered     = kAlignVCenter | kAlignHCenter,
+    kAlignCenterRight  = kAlignVCenter | kAlignRight,
+    kAlignBottomLeft   = kAlignBottom  | kAlignLeft,
+    kAlignBottomCenter = kAlignBottom  | kAlignHCenter,
+    kAlignBottomRight  = kAlignBottom  | kAlignRight,
+
+    // Masks
+    kAlignHor      = kAlignLeft | kAlignRight | kAlignHCenter,
+    kAlignVer      = kAlignTop | kAlignBottom | kAlignVCenter,
+};
+
 enum RectPlacement
 {
     kPlaceOffset,
@@ -229,6 +254,12 @@ struct Rect
         Top = y;
     }
 
+    inline void MoveTo(const Point &pt)
+    {
+        MoveToX(pt.X);
+        MoveToY(pt.Y);
+    }
+
     inline void SetWidth(int width)
     {
         Right = Left + width - 1;
@@ -304,6 +335,11 @@ struct Circle
 
 };
 
+
+
+int AlignInHRange(int x1, int x2, int off_x, int width, FrameAlignment align);
+int AlignInVRange(int y1, int y2, int off_y, int height, FrameAlignment align);
+Rect AlignInRect(const Rect &frame, const Rect &item, FrameAlignment align);
 
 Size ProportionalStretch(int dest_w, int dest_h, int item_w, int item_h);
 Size ProportionalStretch(const Size &dest, const Size &item);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1069,7 +1069,7 @@ namespace AGS.Editor
                 foreach (GUILabel label in GUILabels)
                 {
                     WriteGUIControl(label, 0);
-                    string text = SafeTruncate(label.Text, NativeConstants.MAX_GUILABEL_TEXT_LEN);
+                    string text = label.Text;
                     writer.Write(text.Length + 1);
                     FilePutNullTerminatedString(text, text.Length + 1, writer);
                     writer.Write(label.Font);

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -63,7 +63,6 @@ namespace AGS.Editor
         public static readonly int GUIMAIN_TEXTWINDOW = (int)Factory.NativeProxy.GetNativeConstant("GUIMAIN_TEXTWINDOW");
         public static readonly byte GUIMAIN_LEGACYTEXTWINDOW = (byte)(int)Factory.NativeProxy.GetNativeConstant("GUIMAIN_LEGACYTEXTWINDOW");
         public static readonly int GTF_NOBORDER = (int)Factory.NativeProxy.GetNativeConstant("GTF_NOBORDER");
-        public static readonly int MAX_GUILABEL_TEXT_LEN = (int)Factory.NativeProxy.GetNativeConstant("MAX_GUILABEL_TEXT_LEN");
         public static readonly int MAX_GUIOBJ_SCRIPTNAME_LEN = (int)Factory.NativeProxy.GetNativeConstant("MAX_GUIOBJ_SCRIPTNAME_LEN");
         public static readonly int MAX_GUIOBJ_EVENTHANDLER_LEN = (int)Factory.NativeProxy.GetNativeConstant("MAX_GUIOBJ_EVENTHANDLER_LEN");
         public static readonly int GOBJ_BUTTON = (int)Factory.NativeProxy.GetNativeConstant("GOBJ_BUTTON");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -710,7 +710,7 @@ namespace AGS
             if (name->Equals("GUI_POPUP_MODAL")) return (int)Common::kGUIPopupModal;
             if (name->Equals("GUIMAIN_TEXTWINDOW")) return (int)Common::kGUIMain_TextWindow;
             if (name->Equals("GUIMAIN_LEGACYTEXTWINDOW")) return (int)Common::kGUIMain_LegacyTextWindow;
-            if (name->Equals("GTF_NOBORDER")) return GTF_NOBORDER;
+            if (name->Equals("GTF_NOBORDER")) return (int)Common::kTextBox_NoBorder;
             if (name->Equals("MAX_GUILABEL_TEXT_LEN")) return MAX_GUILABEL_TEXT_LEN;
             if (name->Equals("MAX_GUIOBJ_SCRIPTNAME_LEN")) return MAX_GUIOBJ_SCRIPTNAME_LEN;
             if (name->Equals("MAX_GUIOBJ_EVENTHANDLER_LEN")) return MAX_GUIOBJ_EVENTHANDLER_LEN;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -711,7 +711,6 @@ namespace AGS
             if (name->Equals("GUIMAIN_TEXTWINDOW")) return (int)Common::kGUIMain_TextWindow;
             if (name->Equals("GUIMAIN_LEGACYTEXTWINDOW")) return (int)Common::kGUIMain_LegacyTextWindow;
             if (name->Equals("GTF_NOBORDER")) return (int)Common::kTextBox_NoBorder;
-            if (name->Equals("MAX_GUILABEL_TEXT_LEN")) return MAX_GUILABEL_TEXT_LEN;
             if (name->Equals("MAX_GUIOBJ_SCRIPTNAME_LEN")) return MAX_GUIOBJ_SCRIPTNAME_LEN;
             if (name->Equals("MAX_GUIOBJ_EVENTHANDLER_LEN")) return MAX_GUIOBJ_EVENTHANDLER_LEN;
             if (name->Equals("GOBJ_BUTTON")) return (int)Common::kGUIButton;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -705,8 +705,8 @@ namespace AGS
             if (name->Equals("GUIMAIN_NOCLICK")) return (int)Common::kGUIMain_NoClick;
             if (name->Equals("GUIF_CLIP")) return GUIF_CLIP;
             if (name->Equals("GUIF_TRANSLATED")) return GUIF_TRANSLATED;
-            if (name->Equals("GLF_NOBORDER")) return GLF_NOBORDER;
-            if (name->Equals("GLF_NOARROWS")) return GLF_NOARROWS;
+            if (name->Equals("GLF_NOBORDER")) return (int)Common::kListBox_NoBorder;
+            if (name->Equals("GLF_NOARROWS")) return (int)Common::kListBox_NoArrows;
             if (name->Equals("GUI_POPUP_MODAL")) return (int)Common::kGUIPopupModal;
             if (name->Equals("GUIMAIN_TEXTWINDOW")) return (int)Common::kGUIMain_TextWindow;
             if (name->Equals("GUIMAIN_LEGACYTEXTWINDOW")) return (int)Common::kGUIMain_LegacyTextWindow;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -703,8 +703,8 @@ namespace AGS
             if (name->Equals("GUIMAGIC")) return GUIMAGIC;
             if (name->Equals("SAVEBUFFERSIZE")) return PLUGIN_SAVEBUFFERSIZE;
             if (name->Equals("GUIMAIN_NOCLICK")) return (int)Common::kGUIMain_NoClick;
-            if (name->Equals("GUIF_CLIP")) return GUIF_CLIP;
-            if (name->Equals("GUIF_TRANSLATED")) return GUIF_TRANSLATED;
+            if (name->Equals("GUIF_CLIP")) return (int)Common::kGUICtrl_Clip;
+            if (name->Equals("GUIF_TRANSLATED")) return (int)Common::kGUICtrl_Translated;
             if (name->Equals("GLF_NOBORDER")) return (int)Common::kListBox_NoBorder;
             if (name->Equals("GLF_NOARROWS")) return (int)Common::kListBox_NoArrows;
             if (name->Equals("GUI_POPUP_MODAL")) return (int)Common::kGUIPopupModal;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3183,13 +3183,13 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (slider)
 	  {
-          guislider.push_back(::GUISlider());
-		  guislider[numguislider].min = slider->MinValue;
-		  guislider[numguislider].max = slider->MaxValue;
-		  guislider[numguislider].value = slider->Value;
-		  guislider[numguislider].handlepic = slider->HandleImage;
-		  guislider[numguislider].handleoffset = slider->HandleOffset;
-		  guislider[numguislider].bgimage = slider->BackgroundImage;
+          guislider.push_back(Common::GUISlider());
+		  guislider[numguislider].MinValue = slider->MinValue;
+		  guislider[numguislider].MaxValue = slider->MaxValue;
+		  guislider[numguislider].Value = slider->Value;
+		  guislider[numguislider].HandleImage = slider->HandleImage;
+		  guislider[numguislider].HandleOffset = slider->HandleOffset;
+		  guislider[numguislider].BgImage = slider->BackgroundImage;
 		  ConvertStringToCharArray(slider->OnChange, guislider[numguislider].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUISlider << 16) | numguislider;
@@ -3992,14 +3992,14 @@ Game^ import_compiled_game_dta(const char *fileName)
 			case Common::kGUISlider:
 				{
 				  AGS::Types::GUISlider^ newSlider = gcnew AGS::Types::GUISlider();
-				  ::GUISlider *copyFrom = (::GUISlider*)curObj;
+				  Common::GUISlider *copyFrom = (Common::GUISlider*)curObj;
 				  newControl = newSlider;
-				  newSlider->MinValue = copyFrom->min;
-				  newSlider->MaxValue = copyFrom->max;
-				  newSlider->Value = copyFrom->value;
-				  newSlider->HandleImage = copyFrom->handlepic;
-			  	  newSlider->HandleOffset = copyFrom->handleoffset;
-				  newSlider->BackgroundImage = copyFrom->bgimage;
+				  newSlider->MinValue = copyFrom->MinValue;
+				  newSlider->MaxValue = copyFrom->MaxValue;
+				  newSlider->Value = copyFrom->Value;
+				  newSlider->HandleImage = copyFrom->HandleImage;
+			  	  newSlider->HandleOffset = copyFrom->HandleOffset;
+				  newSlider->BackgroundImage = copyFrom->BgImage;
 				  newSlider->OnChange = gcnew String(copyFrom->eventHandlers[0]);
 				  break;
 				}

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3151,12 +3151,11 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (textbox)
 	  {
-          guitext.push_back(::GUITextBox());
-		  guitext[numguitext].textcol = textbox->TextColor;
-		  guitext[numguitext].font = textbox->Font;
+          guitext.push_back(Common::GUITextBox());
+		  guitext[numguitext].TextColor = textbox->TextColor;
+		  guitext[numguitext].Font = textbox->Font;
 		  guitext[numguitext].flags = 0;
-		  guitext[numguitext].exflags = (textbox->ShowBorder) ? 0 : GTF_NOBORDER;
-		  guitext[numguitext].text[0] = 0;
+          guitext[numguitext].TextBoxFlags = (textbox->ShowBorder) ? 0 : Common::kTextBox_NoBorder;
 		  ConvertStringToCharArray(textbox->OnActivate, guitext[numguitext].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUITextBox << 16) | numguitext;
@@ -3965,12 +3964,12 @@ Game^ import_compiled_game_dta(const char *fileName)
 			case Common::kGUITextBox:
 				{
 				  AGS::Types::GUITextBox^ newTextbox = gcnew AGS::Types::GUITextBox();
-				  ::GUITextBox *copyFrom = (::GUITextBox*)curObj;
+				  Common::GUITextBox *copyFrom = (Common::GUITextBox*)curObj;
 				  newControl = newTextbox;
-				  newTextbox->TextColor = copyFrom->textcol;
-				  newTextbox->Font = copyFrom->font;
-				  newTextbox->ShowBorder = (copyFrom->exflags & GTF_NOBORDER) ? false : true;
-				  newTextbox->Text = gcnew String(copyFrom->text);
+				  newTextbox->TextColor = copyFrom->TextColor;
+				  newTextbox->Font = copyFrom->Font;
+                  newTextbox->ShowBorder = (copyFrom->TextBoxFlags & Common::kTextBox_NoBorder) ? false : true;
+				  newTextbox->Text = gcnew String(copyFrom->Text);
 				  newTextbox->OnActivate = gcnew String(copyFrom->eventHandlers[0]);
 				  break;
 				}

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -117,11 +117,6 @@ void drawBlockScaledAt(int hdc, Common::Bitmap *todraw ,int x, int y, int scaleF
 // this is to shut up the linker, it's used by CSRUN.CPP
 void write_log(const char *) { }
 
-void GUIInv::Draw(Common::Bitmap *ds) {
-  color_t draw_color = ds->GetCompatibleColor(15);
-  ds->DrawRect(Rect(x,y,x+wid,y+hit), draw_color);
-}
-
 int multiply_up_coordinate(int coord)
 {
 	return coord * sxmult;
@@ -3199,10 +3194,10 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (invwindow)
 	  {
-          guiinv.push_back(::GUIInv());
-		  guiinv[numguiinv].charId = invwindow->CharacterID;
-		  guiinv[numguiinv].itemWidth = invwindow->ItemWidth;
-		  guiinv[numguiinv].itemHeight = invwindow->ItemHeight;
+          guiinv.push_back(Common::GUIInvWindow());
+		  guiinv[numguiinv].CharId = invwindow->CharacterID;
+		  guiinv[numguiinv].ItemWidth = invwindow->ItemWidth;
+		  guiinv[numguiinv].ItemHeight = invwindow->ItemHeight;
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUIInvWindow << 16) | numguiinv;
 		  gui->Controls[gui->ControlCount] = &guiinv[numguiinv];
@@ -4006,11 +4001,11 @@ Game^ import_compiled_game_dta(const char *fileName)
 			case Common::kGUIInvWindow:
 				{
 					AGS::Types::GUIInventory^ invwindow = gcnew AGS::Types::GUIInventory();
-				    ::GUIInv *copyFrom = (::GUIInv*)curObj;
+				    Common::GUIInvWindow *copyFrom = (Common::GUIInvWindow*)curObj;
 				    newControl = invwindow;
-					invwindow->CharacterID = copyFrom->charId;
-					invwindow->ItemWidth = copyFrom->itemWidth;
-					invwindow->ItemHeight = copyFrom->itemHeight;
+					invwindow->CharacterID = copyFrom->CharId;
+					invwindow->ItemWidth = copyFrom->ItemWidth;
+					invwindow->ItemHeight = copyFrom->ItemHeight;
 					break;
 				}
 			default:

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3130,14 +3130,14 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (label)
 	  {
-          guilabels.push_back(::GUILabel());
-		  guilabels[numguilabels].textcol = label->TextColor;
-		  guilabels[numguilabels].font = label->Font;
-		  guilabels[numguilabels].align = (int)label->TextAlignment;
+          guilabels.push_back(Common::GUILabel());
+		  guilabels[numguilabels].TextColor = label->TextColor;
+		  guilabels[numguilabels].Font = label->Font;
+		  guilabels[numguilabels].TextAlignment = (int)label->TextAlignment;
 		  guilabels[numguilabels].flags = 0;
-		  char textBuffer[MAX_GUILABEL_TEXT_LEN];
-		  ConvertStringToCharArray(label->Text, textBuffer, MAX_GUILABEL_TEXT_LEN);
-		  guilabels[numguilabels].SetText(textBuffer);
+          Common::String text;
+		  ConvertStringToNativeString(label->Text, text);
+		  guilabels[numguilabels].SetText(text);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUILabel << 16) | numguilabels;
 		  gui->Controls[gui->ControlCount] = &guilabels[numguilabels];
@@ -3948,11 +3948,11 @@ Game^ import_compiled_game_dta(const char *fileName)
 			case Common::kGUILabel:
 				{
 				AGS::Types::GUILabel^ newLabel = gcnew AGS::Types::GUILabel();
-				::GUILabel *copyFrom = (::GUILabel*)curObj;
+				Common::GUILabel *copyFrom = (Common::GUILabel*)curObj;
 				newControl = newLabel;
-				newLabel->TextColor = copyFrom->textcol;
-				newLabel->Font = copyFrom->font;
-				newLabel->TextAlignment = (LabelTextAlignment)copyFrom->align;
+				newLabel->TextColor = copyFrom->TextColor;
+				newLabel->Font = copyFrom->Font;
+				newLabel->TextAlignment = (LabelTextAlignment)copyFrom->TextAlignment;
 				newLabel->Text = gcnew String(copyFrom->GetText());
 				break;
 				}

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3109,18 +3109,20 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  AGS::Types::GUITextWindowEdge^ textwindowedge = dynamic_cast<AGS::Types::GUITextWindowEdge^>(control);
 	  if (button)
 	  {
-          guibuts.push_back(::GUIButton());
-		  guibuts[numguibuts].textcol = button->TextColor;
-		  guibuts[numguibuts].font = button->Font;
-		  guibuts[numguibuts].pic = button->Image;
-		  guibuts[numguibuts].usepic = guibuts[numguibuts].pic;
-		  guibuts[numguibuts].overpic = button->MouseoverImage;
-		  guibuts[numguibuts].pushedpic = button->PushedImage;
-		  guibuts[numguibuts].textAlignment = (int)button->TextAlignment;
-		  guibuts[numguibuts].leftclick = (int)button->ClickAction;
-		  guibuts[numguibuts].lclickdata = button->NewModeNumber;
+          guibuts.push_back(Common::GUIButton());
+		  guibuts[numguibuts].TextColor = button->TextColor;
+		  guibuts[numguibuts].Font = button->Font;
+		  guibuts[numguibuts].Image = button->Image;
+		  guibuts[numguibuts].CurrentImage = guibuts[numguibuts].Image;
+		  guibuts[numguibuts].MouseOverImage = button->MouseoverImage;
+		  guibuts[numguibuts].PushedImage = button->PushedImage;
+		  guibuts[numguibuts].TextAlignment = (int)button->TextAlignment;
+          guibuts[numguibuts].ClickAction[Common::kMouseLeft] = (Common::GUIClickAction)button->ClickAction;
+		  guibuts[numguibuts].ClickData[Common::kMouseLeft] = button->NewModeNumber;
 		  guibuts[numguibuts].flags = (button->ClipImage) ? GUIF_CLIP : 0;
-		  ConvertStringToCharArray(button->Text, guibuts[numguibuts].text, 50);
+          Common::String text;
+		  ConvertStringToNativeString(button->Text, text, GUIBUTTON_TEXTLENGTH);
+          guibuts[numguibuts].SetText(text);
 		  ConvertStringToCharArray(button->OnClick, guibuts[numguibuts].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 		  
           gui->CtrlRefs[gui->ControlCount] = (Common::kGUIButton << 16) | numguibuts;
@@ -3206,11 +3208,10 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (textwindowedge)
 	  {
-          guibuts.push_back(::GUIButton());
-		  guibuts[numguibuts].pic = textwindowedge->Image;
-		  guibuts[numguibuts].usepic = guibuts[numguibuts].pic;
+          guibuts.push_back(Common::GUIButton());
+		  guibuts[numguibuts].Image = textwindowedge->Image;
+		  guibuts[numguibuts].CurrentImage = guibuts[numguibuts].Image;
 		  guibuts[numguibuts].flags = 0;
-		  guibuts[numguibuts].text[0] = 0;
 		  
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUIButton << 16) | numguibuts;
 		  gui->Controls[gui->ControlCount] = &guibuts[numguibuts];
@@ -3922,25 +3923,25 @@ Game^ import_compiled_game_dta(const char *fileName)
 				if (guis[i].IsTextWindow())
 				{
 					AGS::Types::GUITextWindowEdge^ edge = gcnew AGS::Types::GUITextWindowEdge();
-					::GUIButton *copyFrom = (::GUIButton*)curObj;
+					Common::GUIButton *copyFrom = (Common::GUIButton*)curObj;
 					newControl = edge;
-					edge->Image = copyFrom->pic;
+					edge->Image = copyFrom->Image;
 				}
 				else
 				{
 					AGS::Types::GUIButton^ newButton = gcnew AGS::Types::GUIButton();
-					::GUIButton *copyFrom = (::GUIButton*)curObj;
+					Common::GUIButton *copyFrom = (Common::GUIButton*)curObj;
 					newControl = newButton;
-					newButton->TextColor = copyFrom->textcol;
-					newButton->Font = copyFrom->font;
-					newButton->Image = copyFrom->pic;
-					newButton->MouseoverImage = copyFrom->overpic;
-					newButton->PushedImage = copyFrom->pushedpic;
-					newButton->TextAlignment = (TextAlignment)copyFrom->textAlignment;
-					newButton->ClickAction = (GUIClickAction)copyFrom->leftclick;
-					newButton->NewModeNumber = copyFrom->lclickdata;
+					newButton->TextColor = copyFrom->TextColor;
+					newButton->Font = copyFrom->Font;
+					newButton->Image = copyFrom->Image;
+					newButton->MouseoverImage = copyFrom->MouseOverImage;
+					newButton->PushedImage = copyFrom->PushedImage;
+					newButton->TextAlignment = (TextAlignment)copyFrom->TextAlignment;
+                    newButton->ClickAction = (GUIClickAction)copyFrom->ClickAction[Common::kMouseLeft];
+					newButton->NewModeNumber = copyFrom->ClickData[Common::kMouseLeft];
 					newButton->ClipImage = (copyFrom->flags & GUIF_CLIP) ? true : false;
-					newButton->Text = gcnew String(copyFrom->text);
+					newButton->Text = gcnew String(copyFrom->GetText());
 					newButton->OnClick = gcnew String(copyFrom->eventHandlers[0]);
 				}
 				break;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3119,11 +3119,11 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 		  guibuts[numguibuts].TextAlignment = (int)button->TextAlignment;
           guibuts[numguibuts].ClickAction[Common::kMouseLeft] = (Common::GUIClickAction)button->ClickAction;
 		  guibuts[numguibuts].ClickData[Common::kMouseLeft] = button->NewModeNumber;
-		  guibuts[numguibuts].flags = (button->ClipImage) ? GUIF_CLIP : 0;
+          guibuts[numguibuts].Flags = (button->ClipImage) ? Common::kGUICtrl_Clip : 0;
           Common::String text;
 		  ConvertStringToNativeString(button->Text, text, GUIBUTTON_TEXTLENGTH);
           guibuts[numguibuts].SetText(text);
-		  ConvertStringToCharArray(button->OnClick, guibuts[numguibuts].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
+		  ConvertStringToNativeString(button->OnClick, guibuts[numguibuts].EventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 		  
           gui->CtrlRefs[gui->ControlCount] = (Common::kGUIButton << 16) | numguibuts;
 		  gui->Controls[gui->ControlCount] = &guibuts[numguibuts];
@@ -3136,7 +3136,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 		  guilabels[numguilabels].TextColor = label->TextColor;
 		  guilabels[numguilabels].Font = label->Font;
 		  guilabels[numguilabels].TextAlignment = (int)label->TextAlignment;
-		  guilabels[numguilabels].flags = 0;
+		  guilabels[numguilabels].Flags = 0;
           Common::String text;
 		  ConvertStringToNativeString(label->Text, text);
 		  guilabels[numguilabels].SetText(text);
@@ -3151,9 +3151,9 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
           guitext.push_back(Common::GUITextBox());
 		  guitext[numguitext].TextColor = textbox->TextColor;
 		  guitext[numguitext].Font = textbox->Font;
-		  guitext[numguitext].flags = 0;
+		  guitext[numguitext].Flags = 0;
           guitext[numguitext].TextBoxFlags = (textbox->ShowBorder) ? 0 : Common::kTextBox_NoBorder;
-		  ConvertStringToCharArray(textbox->OnActivate, guitext[numguitext].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
+		  ConvertStringToNativeString(textbox->OnActivate, guitext[numguitext].EventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUITextBox << 16) | numguitext;
 		  gui->Controls[gui->ControlCount] = &guitext[numguitext];
@@ -3168,10 +3168,10 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 		  guilist[numguilist].BgColor = listbox->SelectedTextColor;
 		  guilist[numguilist].SelectedBgColor = listbox->SelectedBackgroundColor;
 		  guilist[numguilist].TextAlignment = (int)listbox->TextAlignment;
-          guilist[numguilist].flags = listbox->Translated ? GUIF_TRANSLATED : 0;
+          guilist[numguilist].Flags = listbox->Translated ? Common::kGUICtrl_Translated : 0;
           guilist[numguilist].ListBoxFlags = (listbox->ShowBorder) ? 0 : Common::kListBox_NoBorder;
 		  guilist[numguilist].ListBoxFlags |= (listbox->ShowScrollArrows) ? 0 : Common::kListBox_NoArrows;
-		  ConvertStringToCharArray(listbox->OnSelectionChanged, guilist[numguilist].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
+		  ConvertStringToNativeString(listbox->OnSelectionChanged, guilist[numguilist].EventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUIListBox << 16) | numguilist;
 		  gui->Controls[gui->ControlCount] = &guilist[numguilist];
@@ -3187,7 +3187,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 		  guislider[numguislider].HandleImage = slider->HandleImage;
 		  guislider[numguislider].HandleOffset = slider->HandleOffset;
 		  guislider[numguislider].BgImage = slider->BackgroundImage;
-		  ConvertStringToCharArray(slider->OnChange, guislider[numguislider].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
+		  ConvertStringToNativeString(slider->OnChange, guislider[numguislider].EventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUISlider << 16) | numguislider;
 		  gui->Controls[gui->ControlCount] = &guislider[numguislider];
@@ -3211,7 +3211,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
           guibuts.push_back(Common::GUIButton());
 		  guibuts[numguibuts].Image = textwindowedge->Image;
 		  guibuts[numguibuts].CurrentImage = guibuts[numguibuts].Image;
-		  guibuts[numguibuts].flags = 0;
+		  guibuts[numguibuts].Flags = 0;
 		  
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUIButton << 16) | numguibuts;
 		  gui->Controls[gui->ControlCount] = &guibuts[numguibuts];
@@ -3219,14 +3219,14 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 		  numguibuts++;
 	  }
 
-	  GUIObject *newObj = gui->Controls[gui->ControlCount - 1];
-	  newObj->x = control->Left;
-	  newObj->y = control->Top;
-	  newObj->wid = control->Width;
-	  newObj->hit = control->Height;
-	  newObj->objn = control->ID;
-	  newObj->zorder = control->ZOrder;
-	  ConvertStringToCharArray(control->Name, newObj->scriptName, MAX_GUIOBJ_SCRIPTNAME_LEN + 1);
+      Common::GUIObject *newObj = gui->Controls[gui->ControlCount - 1];
+	  newObj->X = control->Left;
+	  newObj->Y = control->Top;
+	  newObj->Width = control->Width;
+	  newObj->Height = control->Height;
+	  newObj->Id = control->ID;
+	  newObj->ZOrder = control->ZOrder;
+	  ConvertStringToNativeString(control->Name, newObj->Name, MAX_GUIOBJ_SCRIPTNAME_LEN + 1);
   }
 
   gui->RebuildArray();
@@ -3914,7 +3914,7 @@ Game^ import_compiled_game_dta(const char *fileName)
 
 		for (int j = 0; j < guis[i].ControlCount; j++)
 		{
-			GUIObject* curObj = guis[i].Controls[j];
+            Common::GUIObject* curObj = guis[i].Controls[j];
 			GUIControl ^newControl = nullptr;
 			switch (guis[i].CtrlRefs[j] >> 16)
 			{
@@ -3940,9 +3940,9 @@ Game^ import_compiled_game_dta(const char *fileName)
 					newButton->TextAlignment = (TextAlignment)copyFrom->TextAlignment;
                     newButton->ClickAction = (GUIClickAction)copyFrom->ClickAction[Common::kMouseLeft];
 					newButton->NewModeNumber = copyFrom->ClickData[Common::kMouseLeft];
-					newButton->ClipImage = (copyFrom->flags & GUIF_CLIP) ? true : false;
+                    newButton->ClipImage = (copyFrom->Flags & Common::kGUICtrl_Clip) ? true : false;
 					newButton->Text = gcnew String(copyFrom->GetText());
-					newButton->OnClick = gcnew String(copyFrom->eventHandlers[0]);
+					newButton->OnClick = gcnew String(copyFrom->EventHandlers[0]);
 				}
 				break;
 				}
@@ -3966,7 +3966,7 @@ Game^ import_compiled_game_dta(const char *fileName)
 				  newTextbox->Font = copyFrom->Font;
                   newTextbox->ShowBorder = (copyFrom->TextBoxFlags & Common::kTextBox_NoBorder) ? false : true;
 				  newTextbox->Text = gcnew String(copyFrom->Text);
-				  newTextbox->OnActivate = gcnew String(copyFrom->eventHandlers[0]);
+				  newTextbox->OnActivate = gcnew String(copyFrom->EventHandlers[0]);
 				  break;
 				}
 			case Common::kGUIListBox:
@@ -3981,8 +3981,8 @@ Game^ import_compiled_game_dta(const char *fileName)
 				  newListbox->TextAlignment = (ListBoxTextAlignment)copyFrom->TextAlignment;
 				  newListbox->ShowBorder = ((copyFrom->ListBoxFlags & Common::kListBox_NoBorder) == 0);
 				  newListbox->ShowScrollArrows = ((copyFrom->ListBoxFlags & Common::kListBox_NoArrows) == 0);
-                  newListbox->Translated = (copyFrom->flags & GUIF_TRANSLATED) != 0;
-				  newListbox->OnSelectionChanged = gcnew String(copyFrom->eventHandlers[0]);
+                  newListbox->Translated = (copyFrom->Flags & Common::kGUICtrl_Translated) != 0;
+				  newListbox->OnSelectionChanged = gcnew String(copyFrom->EventHandlers[0]);
 				  break;
 				}
 			case Common::kGUISlider:
@@ -3996,7 +3996,7 @@ Game^ import_compiled_game_dta(const char *fileName)
 				  newSlider->HandleImage = copyFrom->HandleImage;
 			  	  newSlider->HandleOffset = copyFrom->HandleOffset;
 				  newSlider->BackgroundImage = copyFrom->BgImage;
-				  newSlider->OnChange = gcnew String(copyFrom->eventHandlers[0]);
+				  newSlider->OnChange = gcnew String(copyFrom->EventHandlers[0]);
 				  break;
 				}
 			case Common::kGUIInvWindow:
@@ -4012,13 +4012,13 @@ Game^ import_compiled_game_dta(const char *fileName)
 			default:
 				throw gcnew AGSEditorException("Unknown control type found: " + (guis[i].CtrlRefs[j] >> 16));
 			}
-			newControl->Width = (curObj->wid > 0) ? curObj->wid : 1;
-			newControl->Height = (curObj->hit > 0) ? curObj->hit : 1;
-			newControl->Left = curObj->x;
-			newControl->Top = curObj->y;
-			newControl->ZOrder = curObj->zorder;
+			newControl->Width = (curObj->Width > 0) ? curObj->Width : 1;
+			newControl->Height = (curObj->Height > 0) ? curObj->Height : 1;
+			newControl->Left = curObj->X;
+			newControl->Top = curObj->Y;
+			newControl->ZOrder = curObj->ZOrder;
 			newControl->ID = j;
-			newControl->Name = gcnew String(curObj->scriptName);
+			newControl->Name = gcnew String(curObj->Name);
 			newGui->Controls->Add(newControl);
 		}
 		

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3165,15 +3165,15 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
 	  }
 	  else if (listbox)
 	  {
-          guilist.push_back(::GUIListBox());
-		  guilist[numguilist].textcol = listbox->TextColor;
-		  guilist[numguilist].font = listbox->Font;
-		  guilist[numguilist].backcol = listbox->SelectedTextColor;
-		  guilist[numguilist].selectedbgcol = listbox->SelectedBackgroundColor;
-		  guilist[numguilist].alignment = (int)listbox->TextAlignment;
+          guilist.push_back(Common::GUIListBox());
+		  guilist[numguilist].TextColor = listbox->TextColor;
+		  guilist[numguilist].Font = listbox->Font;
+		  guilist[numguilist].BgColor = listbox->SelectedTextColor;
+		  guilist[numguilist].SelectedBgColor = listbox->SelectedBackgroundColor;
+		  guilist[numguilist].TextAlignment = (int)listbox->TextAlignment;
           guilist[numguilist].flags = listbox->Translated ? GUIF_TRANSLATED : 0;
-		  guilist[numguilist].exflags = (listbox->ShowBorder) ? 0 : GLF_NOBORDER;
-		  guilist[numguilist].exflags |= (listbox->ShowScrollArrows) ? 0 : GLF_NOARROWS;
+          guilist[numguilist].ListBoxFlags = (listbox->ShowBorder) ? 0 : Common::kListBox_NoBorder;
+		  guilist[numguilist].ListBoxFlags |= (listbox->ShowScrollArrows) ? 0 : Common::kListBox_NoArrows;
 		  ConvertStringToCharArray(listbox->OnSelectionChanged, guilist[numguilist].eventHandlers[0], MAX_GUIOBJ_EVENTHANDLER_LEN + 1);
 
 		  gui->CtrlRefs[gui->ControlCount] = (Common::kGUIListBox << 16) | numguilist;
@@ -3976,15 +3976,15 @@ Game^ import_compiled_game_dta(const char *fileName)
 			case Common::kGUIListBox:
 				{
 				  AGS::Types::GUIListBox^ newListbox = gcnew AGS::Types::GUIListBox();
-				  ::GUIListBox *copyFrom = (::GUIListBox*)curObj;
+				  Common::GUIListBox *copyFrom = (Common::GUIListBox*)curObj;
 				  newControl = newListbox;
-				  newListbox->TextColor = copyFrom->textcol;
-				  newListbox->Font = copyFrom->font; 
-				  newListbox->SelectedTextColor = copyFrom->backcol;
-				  newListbox->SelectedBackgroundColor = copyFrom->selectedbgcol;
-				  newListbox->TextAlignment = (ListBoxTextAlignment)copyFrom->alignment;
-				  newListbox->ShowBorder = ((copyFrom->exflags & GLF_NOBORDER) == 0);
-				  newListbox->ShowScrollArrows = ((copyFrom->exflags & GLF_NOARROWS) == 0);
+				  newListbox->TextColor = copyFrom->TextColor;
+				  newListbox->Font = copyFrom->Font; 
+				  newListbox->SelectedTextColor = copyFrom->BgColor;
+				  newListbox->SelectedBackgroundColor = copyFrom->SelectedBgColor;
+				  newListbox->TextAlignment = (ListBoxTextAlignment)copyFrom->TextAlignment;
+				  newListbox->ShowBorder = ((copyFrom->ListBoxFlags & Common::kListBox_NoBorder) == 0);
+				  newListbox->ShowScrollArrows = ((copyFrom->ListBoxFlags & Common::kListBox_NoArrows) == 0);
                   newListbox->Translated = (copyFrom->flags & GUIF_TRANSLATED) != 0;
 				  newListbox->OnSelectionChanged = gcnew String(copyFrom->eventHandlers[0]);
 				  break;

--- a/Editor/AGS.Types/Enums/LabelTextAlignment.cs
+++ b/Editor/AGS.Types/Enums/LabelTextAlignment.cs
@@ -4,7 +4,8 @@ using System.Text;
 
 namespace AGS.Types
 {
-    public enum LabelTextAlignment
+	// TODO: deprecate in favour of generic alignment style
+	public enum LabelTextAlignment
     {
         TopLeft = 0,
         TopRight = 1,

--- a/Editor/AGS.Types/Enums/ListBoxTextAlignment.cs
+++ b/Editor/AGS.Types/Enums/ListBoxTextAlignment.cs
@@ -4,7 +4,8 @@ using System.Text;
 
 namespace AGS.Types
 {
-    public enum ListBoxTextAlignment
+	// TODO: deprecate in favour of generic alignment style
+	public enum ListBoxTextAlignment
     {
         Left = 0,
         Right = 1,

--- a/Editor/AGS.Types/Enums/TextAlignment.cs
+++ b/Editor/AGS.Types/Enums/TextAlignment.cs
@@ -4,7 +4,8 @@ using System.Text;
 
 namespace AGS.Types
 {
-    public enum TextAlignment
+	// TODO: use as generic alignment style for all text-align properties
+	public enum TextAlignment
     {
         TopMiddle = 0,
         TopLeft = 1,

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -85,11 +85,19 @@ void GUILabel::Draw_split_lines(char *teptr, int wid, int font, int &numlines)
   split_lines(teptr, wid, font);
 }
 
-void GUITextBox::Draw_text_box_contents(Common::Bitmap *ds, color_t text_color)
+namespace AGS
 {
-  // print something fake so we can see what it looks like
-  wouttext_outline(ds, x + 2, y + 2, font, text_color, "Text Box Contents");
+namespace Common
+{
+
+void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
+{
+    // print something fake so we can see what it looks like
+    wouttext_outline(ds, x + 2, y + 2, Font, text_color, "Text Box Contents");
 }
+
+} // namespace Common
+} // namespace AGS
 
 void GUIListBox::Draw_items_fix()
 {

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -122,15 +122,10 @@ void GUIInvWindow::Draw(Bitmap *ds)
     ds->DrawRect(Rect(x,y,x+wid,y+hit), draw_color);
 }
 
+void GUIButton::PrepareTextToDraw()
+{
+    _textToDraw = _text;
+}
+
 } // namespace Common
 } // namespace AGS
-
-void GUIButton::Draw_set_oritext(char *oritext, const char *text)
-{
-  strcpy(oritext, text);
-
-  // original code was:
-  //      oritext = text; 
-  // it seems though the 'text' variable is assumed to be a null-terminated string
-  // oritext is assumed to be made long enough by caller function
-}

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -8,6 +8,7 @@
 #include "font/fonts.h"
 #include "gui/guimain.h"
 #include "gui/guibutton.h"
+#include "gui/guiinv.h"
 #include "gui/guilabel.h"
 #include "gui/guilistbox.h"
 #include "gui/guitextbox.h"
@@ -114,6 +115,12 @@ void GUIListBox::DrawItemsUnfix()
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
     _textToDraw = text;
+}
+
+void GUIInvWindow::Draw(Bitmap *ds)
+{
+    color_t draw_color = ds->GetCompatibleColor(15);
+    ds->DrawRect(Rect(x,y,x+wid,y+hit), draw_color);
 }
 
 } // namespace Common

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -36,12 +36,6 @@ bool AGS::Common::GUIMain::HasAlphaChannel() const
 // AGS.Native-specific implementation split out of acgui.h
 //=============================================================================
 
-int GUIObject::IsClickable()
-{
-  // make sure the button can be selected in the editor
-  return 1;
-}
-
 void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx)
 {
   wouttextxy(ds, xxp, yyp, usingfont, text_color, texx);
@@ -78,6 +72,12 @@ namespace AGS
 namespace Common
 {
 
+bool GUIObject::IsClickable() const
+{
+    // make sure the button can be selected in the editor
+    return true;
+}
+
 void GUILabel::PrepareTextToDraw()
 {
     _textToDraw = Text;
@@ -86,14 +86,14 @@ void GUILabel::PrepareTextToDraw()
 int GUILabel::SplitLinesForDrawing()
 {
     numlines = 0;
-    split_lines(_textToDraw, wid, Font);
+    split_lines(_textToDraw, Width, Font);
     return numlines;
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
 {
     // print something fake so we can see what it looks like
-    wouttext_outline(ds, x + 2, y + 2, Font, text_color, "Text Box Contents");
+    wouttext_outline(ds, X + 2, Y + 2, Font, text_color, "Text Box Contents");
 }
 
 static int num_items_temp;
@@ -119,7 +119,7 @@ void GUIListBox::PrepareTextToDraw(const String &text)
 void GUIInvWindow::Draw(Bitmap *ds)
 {
     color_t draw_color = ds->GetCompatibleColor(15);
-    ds->DrawRect(Rect(x,y,x+wid,y+hit), draw_color);
+    ds->DrawRect(Rect(X, Y, X + Width, Y + Height), draw_color);
 }
 
 void GUIButton::PrepareTextToDraw()

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -96,26 +96,28 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
     wouttext_outline(ds, x + 2, y + 2, Font, text_color, "Text Box Contents");
 }
 
+static int num_items_temp;
+void GUIListBox::DrawItemsFix()
+{
+    num_items_temp = ItemCount;
+    ItemCount = 2;
+    Items.push_back("Sample selected");
+    Items.push_back("Sample item");
+}
+
+void GUIListBox::DrawItemsUnfix()
+{
+    Items.clear();
+    ItemCount = num_items_temp;
+}
+
+void GUIListBox::PrepareTextToDraw(const String &text)
+{
+    _textToDraw = text;
+}
+
 } // namespace Common
 } // namespace AGS
-
-void GUIListBox::Draw_items_fix()
-{
-  numItemsTemp = numItems;
-  numItems = 2;
-  items[0] = "Sample selected";
-  items[1] = "Sample item";
-}
-
-void GUIListBox::Draw_items_unfix()
-{
-  numItems = numItemsTemp;
-}
-
-void GUIListBox::Draw_set_oritext(char *oritext, const char *text)
-{
-  strcpy(oritext, text);
-}
 
 void GUIButton::Draw_set_oritext(char *oritext, const char *text)
 {

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -73,23 +73,22 @@ int wgettextwidth_compensate(const char *tex, int font)
   return wgettextwidth(tex, font);
 }
 
-void GUILabel::Draw_replace_macro_tokens(char *oritext, const char *text)
-{
-  strcpy(oritext, text);
-}
-
-//-----------------------------------------------------------------------------
-
-void GUILabel::Draw_split_lines(char *teptr, int wid, int font, int &numlines)
-{
-  numlines=0;
-  split_lines(teptr, wid, font);
-}
-
 namespace AGS
 {
 namespace Common
 {
+
+void GUILabel::PrepareTextToDraw()
+{
+    _textToDraw = Text;
+}
+
+int GUILabel::SplitLinesForDrawing()
+{
+    numlines = 0;
+    split_lines(_textToDraw, wid, Font);
+    return numlines;
+}
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
 {

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -24,6 +24,8 @@
 #include "gui/animatingguibutton.h"
 #include "gui/guimain.h"
 
+using namespace AGS::Common;
+
 extern GameSetupStruct game;
 extern ViewStruct*views;
 extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
@@ -34,8 +36,8 @@ AnimatingGUIButton animbuts[MAX_ANIMATING_BUTTONS];
 int numAnimButs;
 
 void Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat) {
-    int guin = butt->guin;
-    int objn = butt->objn;
+    int guin = butt->ParentId;
+    int objn = butt->Id;
 
     if ((view < 1) || (view > game.numviews))
         quit("!AnimateButton: invalid view specified");
@@ -103,15 +105,15 @@ int Button_GetFont(GUIButton *butt) {
 }
 
 int Button_GetClipImage(GUIButton *butt) {
-    if (butt->flags & GUIF_CLIP)
+    if (butt->Flags & kGUICtrl_Clip)
         return 1;
     return 0;
 }
 
 void Button_SetClipImage(GUIButton *butt, int newval) {
-    butt->flags &= ~GUIF_CLIP;
+    butt->Flags &= ~kGUICtrl_Clip;
     if (newval)
-        butt->flags |= GUIF_CLIP;
+        butt->Flags |= kGUICtrl_Clip;
 
     guis_need_update = 1;
 }
@@ -128,14 +130,14 @@ int Button_GetMouseOverGraphic(GUIButton *butt) {
 }
 
 void Button_SetMouseOverGraphic(GUIButton *guil, int slotn) {
-    debug_script_log("GUI %d Button %d mouseover set to slot %d", guil->guin, guil->objn, slotn);
+    debug_script_log("GUI %d Button %d mouseover set to slot %d", guil->ParentId, guil->Id, slotn);
 
     if ((guil->IsMouseOver != 0) && (guil->IsPushed == 0))
         guil->CurrentImage = slotn;
     guil->MouseOverImage = slotn;
 
     guis_need_update = 1;
-    FindAndRemoveButtonAnimation(guil->guin, guil->objn);
+    FindAndRemoveButtonAnimation(guil->ParentId, guil->Id);
 }
 
 int Button_GetNormalGraphic(GUIButton *butt) {
@@ -143,17 +145,17 @@ int Button_GetNormalGraphic(GUIButton *butt) {
 }
 
 void Button_SetNormalGraphic(GUIButton *guil, int slotn) {
-    debug_script_log("GUI %d Button %d normal set to slot %d", guil->guin, guil->objn, slotn);
+    debug_script_log("GUI %d Button %d normal set to slot %d", guil->ParentId, guil->Id, slotn);
     // normal pic - update if mouse is not over, or if there's no MouseOverImage
     if (((guil->IsMouseOver == 0) || (guil->MouseOverImage < 1)) && (guil->IsPushed == 0))
         guil->CurrentImage = slotn;
     guil->Image = slotn;
     // update the clickable area to the same size as the graphic
-    guil->wid = spritewidth[slotn];
-    guil->hit = spriteheight[slotn];
+    guil->Width = spritewidth[slotn];
+    guil->Height = spriteheight[slotn];
 
     guis_need_update = 1;
-    FindAndRemoveButtonAnimation(guil->guin, guil->objn);
+    FindAndRemoveButtonAnimation(guil->ParentId, guil->Id);
 }
 
 int Button_GetPushedGraphic(GUIButton *butt) {
@@ -161,14 +163,14 @@ int Button_GetPushedGraphic(GUIButton *butt) {
 }
 
 void Button_SetPushedGraphic(GUIButton *guil, int slotn) {
-    debug_script_log("GUI %d Button %d pushed set to slot %d", guil->guin, guil->objn, slotn);
+    debug_script_log("GUI %d Button %d pushed set to slot %d", guil->ParentId, guil->Id, slotn);
 
     if (guil->IsPushed)
         guil->CurrentImage = slotn;
     guil->PushedImage = slotn;
 
     guis_need_update = 1;
-    FindAndRemoveButtonAnimation(guil->guin, guil->objn);
+    FindAndRemoveButtonAnimation(guil->ParentId, guil->Id);
 }
 
 int Button_GetTextColor(GUIButton *butt) {
@@ -257,12 +259,12 @@ void FindAndRemoveButtonAnimation(int guin, int objn)
 
 void Button_Click(GUIButton *butt, int mbut)
 {
-    process_interface_click(butt->guin, butt->objn, mbut);
+    process_interface_click(butt->ParentId, butt->Id, mbut);
 }
 
 bool Button_IsAnimating(GUIButton *butt)
 {
-    return FindAnimatedButton(butt->guin, butt->objn) >= 0;
+    return FindAnimatedButton(butt->ParentId, butt->Id) >= 0;
 }
 
 // NOTE: in correspondance to similar functions for Character & Object,
@@ -270,19 +272,19 @@ bool Button_IsAnimating(GUIButton *butt)
 // zero-based index and 0 in case of no animation.
 int Button_GetAnimView(GUIButton *butt)
 {
-    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    int idx = FindAnimatedButton(butt->ParentId, butt->Id);
     return idx >= 0 ? animbuts[idx].view + 1 : 0;
 }
 
 int Button_GetAnimLoop(GUIButton *butt)
 {
-    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    int idx = FindAnimatedButton(butt->ParentId, butt->Id);
     return idx >= 0 ? animbuts[idx].loop : 0;
 }
 
 int Button_GetAnimFrame(GUIButton *butt)
 {
-    int idx = FindAnimatedButton(butt->guin, butt->objn);
+    int idx = FindAnimatedButton(butt->ParentId, butt->Id);
     return idx >= 0 ? animbuts[idx].frame : 0;
 }
 

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -52,8 +52,8 @@ void Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat) 
 
     int buttonId = guis[guin].CtrlRefs[objn] & 0x000ffff;
 
-    guibuts[buttonId].pushedpic = 0;
-    guibuts[buttonId].overpic = 0;
+    guibuts[buttonId].PushedImage = 0;
+    guibuts[buttonId].MouseOverImage = 0;
 
     animbuts[numAnimButs].ongui = guin;
     animbuts[numAnimButs].onguibut = objn;
@@ -71,20 +71,20 @@ void Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat) 
 }
 
 const char* Button_GetText_New(GUIButton *butt) {
-    return CreateNewScriptString(butt->text);
+    return CreateNewScriptString(butt->GetText());
 }
 
 void Button_GetText(GUIButton *butt, char *buffer) {
-    strcpy(buffer, butt->text);
+    strcpy(buffer, butt->GetText());
 }
 
 void Button_SetText(GUIButton *butt, const char *newtx) {
     newtx = get_translation(newtx);
     if (strlen(newtx) > 49) quit("!SetButtonText: text too long, button has 50 chars max");
 
-    if (strcmp(butt->text, newtx)) {
+    if (strcmp(butt->GetText(), newtx)) {
         guis_need_update = 1;
-        strcpy(butt->text,newtx);
+        butt->SetText(newtx);
     }
 }
 
@@ -92,14 +92,14 @@ void Button_SetFont(GUIButton *butt, int newFont) {
     if ((newFont < 0) || (newFont >= game.numfonts))
         quit("!Button.Font: invalid font number.");
 
-    if (butt->font != newFont) {
-        butt->font = newFont;
+    if (butt->Font != newFont) {
+        butt->Font = newFont;
         guis_need_update = 1;
     }
 }
 
 int Button_GetFont(GUIButton *butt) {
-    return butt->font;
+    return butt->Font;
 }
 
 int Button_GetClipImage(GUIButton *butt) {
@@ -118,36 +118,36 @@ void Button_SetClipImage(GUIButton *butt, int newval) {
 
 int Button_GetGraphic(GUIButton *butt) {
     // return currently displayed pic
-    if (butt->usepic < 0)
-        return butt->pic;
-    return butt->usepic;
+    if (butt->CurrentImage < 0)
+        return butt->Image;
+    return butt->CurrentImage;
 }
 
 int Button_GetMouseOverGraphic(GUIButton *butt) {
-    return butt->overpic;
+    return butt->MouseOverImage;
 }
 
 void Button_SetMouseOverGraphic(GUIButton *guil, int slotn) {
     debug_script_log("GUI %d Button %d mouseover set to slot %d", guil->guin, guil->objn, slotn);
 
-    if ((guil->isover != 0) && (guil->ispushed == 0))
-        guil->usepic = slotn;
-    guil->overpic = slotn;
+    if ((guil->IsMouseOver != 0) && (guil->IsPushed == 0))
+        guil->CurrentImage = slotn;
+    guil->MouseOverImage = slotn;
 
     guis_need_update = 1;
     FindAndRemoveButtonAnimation(guil->guin, guil->objn);
 }
 
 int Button_GetNormalGraphic(GUIButton *butt) {
-    return butt->pic;
+    return butt->Image;
 }
 
 void Button_SetNormalGraphic(GUIButton *guil, int slotn) {
     debug_script_log("GUI %d Button %d normal set to slot %d", guil->guin, guil->objn, slotn);
-    // normal pic - update if mouse is not over, or if there's no overpic
-    if (((guil->isover == 0) || (guil->overpic < 1)) && (guil->ispushed == 0))
-        guil->usepic = slotn;
-    guil->pic = slotn;
+    // normal pic - update if mouse is not over, or if there's no MouseOverImage
+    if (((guil->IsMouseOver == 0) || (guil->MouseOverImage < 1)) && (guil->IsPushed == 0))
+        guil->CurrentImage = slotn;
+    guil->Image = slotn;
     // update the clickable area to the same size as the graphic
     guil->wid = spritewidth[slotn];
     guil->hit = spriteheight[slotn];
@@ -157,27 +157,27 @@ void Button_SetNormalGraphic(GUIButton *guil, int slotn) {
 }
 
 int Button_GetPushedGraphic(GUIButton *butt) {
-    return butt->pushedpic;
+    return butt->PushedImage;
 }
 
 void Button_SetPushedGraphic(GUIButton *guil, int slotn) {
     debug_script_log("GUI %d Button %d pushed set to slot %d", guil->guin, guil->objn, slotn);
 
-    if (guil->ispushed)
-        guil->usepic = slotn;
-    guil->pushedpic = slotn;
+    if (guil->IsPushed)
+        guil->CurrentImage = slotn;
+    guil->PushedImage = slotn;
 
     guis_need_update = 1;
     FindAndRemoveButtonAnimation(guil->guin, guil->objn);
 }
 
 int Button_GetTextColor(GUIButton *butt) {
-    return butt->textcol;
+    return butt->TextColor;
 }
 
 void Button_SetTextColor(GUIButton *butt, int newcol) {
-    if (butt->textcol != newcol) {
-        butt->textcol = newcol;
+    if (butt->TextColor != newcol) {
+        butt->TextColor = newcol;
         guis_need_update = 1;
     }
 }
@@ -218,10 +218,10 @@ int UpdateAnimatingButton(int bu) {
     CheckViewFrame(animbuts[bu].view, animbuts[bu].loop, animbuts[bu].frame);
 
     // update the button's image
-    guibuts[animbuts[bu].buttonid].pic = tview->loops[animbuts[bu].loop].frames[animbuts[bu].frame].pic;
-    guibuts[animbuts[bu].buttonid].usepic = guibuts[animbuts[bu].buttonid].pic;
-    guibuts[animbuts[bu].buttonid].pushedpic = 0;
-    guibuts[animbuts[bu].buttonid].overpic = 0;
+    guibuts[animbuts[bu].buttonid].Image = tview->loops[animbuts[bu].loop].frames[animbuts[bu].frame].pic;
+    guibuts[animbuts[bu].buttonid].CurrentImage = guibuts[animbuts[bu].buttonid].Image;
+    guibuts[animbuts[bu].buttonid].PushedImage = 0;
+    guibuts[animbuts[bu].buttonid].MouseOverImage = 0;
     guis_need_update = 1;
 
     animbuts[bu].wait = animbuts[bu].speed + tview->loops[animbuts[bu].loop].frames[animbuts[bu].frame].speed;

--- a/Engine/ac/button.h
+++ b/Engine/ac/button.h
@@ -20,6 +20,8 @@
 
 #include "gui/guibutton.h"
 
+using AGS::Common::GUIButton;
+
 void		Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat);
 const char* Button_GetText_New(GUIButton *butt);
 void		Button_GetText(GUIButton *butt, char *buffer);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -527,8 +527,8 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
   if ((dtop->topicFlags & DTFLG_SHOWPARSER) && (play.disable_dialog_parser == 0)) {
     parserInput = new GUITextBox();
     parserInput->hit = lineheight + get_fixed_pixel_size(4);
-    parserInput->exflags = 0;
-    parserInput->font = usingfont;
+    parserInput->TextBoxFlags = 0;
+    parserInput->Font = usingfont;
   }
 
   numdisp=0;
@@ -800,9 +800,9 @@ void DialogOptions::Redraw()
       // Set up the text box, if present
       parserInput->y = curyp + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);
       parserInput->wid = areawid - get_fixed_pixel_size(10);
-      parserInput->textcol = playerchar->talkcolor;
+      parserInput->TextColor = playerchar->talkcolor;
       if (mouseison == DLG_OPTION_PARSER)
-        parserInput->textcol = forecol;
+        parserInput->TextColor = forecol;
 
       if (game.dialog_bullet)  // the parser X will get moved in a second
       {
@@ -886,9 +886,9 @@ bool DialogOptions::Run()
         if (parserInput) {
           wantRefresh = true;
           // type into the parser 
-          if ((gkey == 361) || ((gkey == ' ') && (strlen(parserInput->text) == 0))) {
+          if ((gkey == 361) || ((gkey == ' ') && (strlen(parserInput->Text) == 0))) {
             // write previous contents into textbox (F3 or Space when box is empty)
-            for (unsigned int i = strlen(parserInput->text); i < strlen(play.lastParserEntry); i++) {
+            for (unsigned int i = strlen(parserInput->Text); i < strlen(play.lastParserEntry); i++) {
               parserInput->KeyPress(play.lastParserEntry[i]);
             }
             //domouse(2);
@@ -1027,7 +1027,7 @@ bool DialogOptions::Run()
 
       if (parserActivated) {
         // They have selected a custom parser-based option
-        if (parserInput->text[0] != 0) {
+        if (!parserInput->Text.IsEmpty() != 0) {
           chose = DLG_OPTION_PARSER;
           return false; // end dialog options running loop
         }
@@ -1067,8 +1067,8 @@ void DialogOptions::Close()
 
   if (parserActivated) 
   {
-    strcpy (play.lastParserEntry, parserInput->text);
-    ParseText (parserInput->text);
+    strcpy (play.lastParserEntry, parserInput->Text);
+    ParseText (parserInput->Text);
     chose = CHOSE_TEXTPARSER;
   }
 

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -393,7 +393,7 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
     break_up_text_into_lines(areawid-(2*padding+2+bullet_wid),usingfont,get_translation(dtop->optionnames[disporder[i]]));\
     needheight += getheightoflines(usingfont, numlines) + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
   }\
-  if (parserInput) needheight += parserInput->hit + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
+  if (parserInput) needheight += parserInput->Height + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);\
  }
 
 
@@ -526,7 +526,7 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
   parserActivated = 0;
   if ((dtop->topicFlags & DTFLG_SHOWPARSER) && (play.disable_dialog_parser == 0)) {
     parserInput = new GUITextBox();
-    parserInput->hit = lineheight + get_fixed_pixel_size(4);
+    parserInput->Height = lineheight + get_fixed_pixel_size(4);
     parserInput->TextBoxFlags = 0;
     parserInput->Font = usingfont;
   }
@@ -677,7 +677,7 @@ void DialogOptions::Redraw()
 
       if (parserInput)
       {
-        parserInput->x = multiply_up_coordinate(ccDialogOptionsRendering.parserTextboxX);
+        parserInput->X = multiply_up_coordinate(ccDialogOptionsRendering.parserTextboxX);
         curyp = multiply_up_coordinate(ccDialogOptionsRendering.parserTextboxY);
         areawid = multiply_up_coordinate(ccDialogOptionsRendering.parserTextboxWidth);
         if (areawid == 0)
@@ -738,7 +738,7 @@ void DialogOptions::Redraw()
       dlgyp = tyoffs;
       curyp = write_dialog_options(ds, options_surface_has_alpha, txoffs,tyoffs,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
       if (parserInput)
-        parserInput->x = txoffs;
+        parserInput->X = txoffs;
     }
     else {
 
@@ -793,27 +793,27 @@ void DialogOptions::Redraw()
         goto redraw_options;
       }*/
       if (parserInput)
-        parserInput->x = dlgxp;
+        parserInput->X = dlgxp;
     }
 
     if (parserInput) {
       // Set up the text box, if present
-      parserInput->y = curyp + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);
-      parserInput->wid = areawid - get_fixed_pixel_size(10);
+      parserInput->Y = curyp + multiply_up_coordinate(game.options[OPT_DIALOGGAP]);
+      parserInput->Width = areawid - get_fixed_pixel_size(10);
       parserInput->TextColor = playerchar->talkcolor;
       if (mouseison == DLG_OPTION_PARSER)
         parserInput->TextColor = forecol;
 
       if (game.dialog_bullet)  // the parser X will get moved in a second
       {
-          draw_gui_sprite_v330(ds, game.dialog_bullet, parserInput->x, parserInput->y, options_surface_has_alpha);
+          draw_gui_sprite_v330(ds, game.dialog_bullet, parserInput->X, parserInput->Y, options_surface_has_alpha);
       }
 
-      parserInput->wid -= bullet_wid;
-      parserInput->x += bullet_wid;
+      parserInput->Width -= bullet_wid;
+      parserInput->X += bullet_wid;
 
       parserInput->Draw(ds);
-      parserInput->activated = 0;
+      parserInput->IsActivated = false;
     }
 
     wantRefresh = false;
@@ -889,15 +889,15 @@ bool DialogOptions::Run()
           if ((gkey == 361) || ((gkey == ' ') && (strlen(parserInput->Text) == 0))) {
             // write previous contents into textbox (F3 or Space when box is empty)
             for (unsigned int i = strlen(parserInput->Text); i < strlen(play.lastParserEntry); i++) {
-              parserInput->KeyPress(play.lastParserEntry[i]);
+              parserInput->OnKeyPress(play.lastParserEntry[i]);
             }
             //domouse(2);
             Redraw();
             return true; // continue running loop
           }
           else if ((gkey >= 32) || (gkey == 13) || (gkey == 8)) {
-            parserInput->KeyPress(gkey);
-            if (!parserInput->activated) {
+            parserInput->OnKeyPress(gkey);
+            if (!parserInput->IsActivated) {
               //domouse(2);
               Redraw();
               return true; // continue running loop
@@ -958,11 +958,11 @@ bool DialogOptions::Run()
         if (usingCustomRendering)
           relativeMousey -= dirtyy;
 
-        if ((relativeMousey > parserInput->y) && 
-            (relativeMousey < parserInput->y + parserInput->hit))
+        if ((relativeMousey > parserInput->Y) && 
+            (relativeMousey < parserInput->Y + parserInput->Height))
           mouseison = DLG_OPTION_PARSER;
 
-        if (parserInput->activated)
+        if (parserInput->IsActivated)
           parserActivated = 1;
       }
 
@@ -1033,7 +1033,7 @@ bool DialogOptions::Run()
         }
         else {
           parserActivated = 0;
-          parserInput->activated = 0;
+          parserInput->IsActivated = 0;
         }
       }
       if (mousewason != mouseison) {

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -429,7 +429,7 @@ bool ShouldAntiAliasText() {
     return (game.options[OPT_ANTIALIASFONTS] != 0);
 }
 
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char*texx) {
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx) {
     
     color_t outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
     if (get_font_outline(usingfont) >= 0) {

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -535,7 +535,7 @@ void do_corner(Bitmap *ds, int sprn, int x, int y, int offx, int offy) {
 }
 
 int get_but_pic(GUIMain*guo,int indx) {
-    return guibuts[guo->CtrlRefs[indx] & 0x000ffff].pic;
+    return guibuts[guo->CtrlRefs[indx] & 0x000ffff].Image;
 }
 
 void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*iep) {

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -26,7 +26,7 @@ int  _display_main(int xx,int yy,int wii,const char*todis,int blocking,int using
 void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
 bool ShouldAntiAliasText();
 int GetTextDisplayTime (const char *text, int canberel=0);
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char*texx);
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, int align);
 // TODO: GUI classes located in Common library do not make use of outlining,
 // need to find a way to make all code use same functions.

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -508,14 +508,14 @@ void free_dynamic_sprite (int gotSlot) {
   for (tt = 0; tt < numguibuts; tt++) {
     if (guibuts[tt].IsDeleted())
       continue;
-    if (guibuts[tt].pic == gotSlot)
-      guibuts[tt].pic = 0;
-    if (guibuts[tt].usepic == gotSlot)
-      guibuts[tt].usepic = 0;
-    if (guibuts[tt].overpic == gotSlot)
-      guibuts[tt].overpic = 0;
-    if (guibuts[tt].pushedpic == gotSlot)
-      guibuts[tt].pushedpic = 0;
+    if (guibuts[tt].Image == gotSlot)
+      guibuts[tt].Image = 0;
+    if (guibuts[tt].CurrentImage == gotSlot)
+      guibuts[tt].CurrentImage = 0;
+    if (guibuts[tt].MouseOverImage == gotSlot)
+      guibuts[tt].MouseOverImage = 0;
+    if (guibuts[tt].PushedImage == gotSlot)
+      guibuts[tt].PushedImage = 0;
   }
 
   // force refresh of any object caches using the sprite

--- a/Engine/ac/dynobj/cc_guiobject.cpp
+++ b/Engine/ac/dynobj/cc_guiobject.cpp
@@ -15,6 +15,9 @@
 #include "ac/dynobj/cc_guiobject.h"
 #include "ac/dynobj/scriptgui.h"
 #include "gui/guimain.h"
+
+using AGS::Common::GUIObject;
+
 // return the type name of the object
 const char *CCGUIObject::GetType() {
     return "GUIObject";
@@ -25,8 +28,8 @@ const char *CCGUIObject::GetType() {
 int CCGUIObject::Serialize(const char *address, char *buffer, int bufsize) {
     GUIObject *guio = (GUIObject*)address;
     StartSerialize(buffer);
-    SerializeInt(guio->guin);
-    SerializeInt(guio->objn);
+    SerializeInt(guio->ParentId);
+    SerializeInt(guio->Id);
     return EndSerialize();
 }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1243,7 +1243,7 @@ void WriteAnimatedButtons_Aligned(Stream *out)
 
 void save_game_gui(Stream *out)
 {
-    write_gui(out,guis,&game,true);
+    GUI::WriteGUI(guis, out, true);
     out->WriteInt32(numAnimButs);
     WriteAnimatedButtons_Aligned(out);
 }
@@ -1750,7 +1750,8 @@ void ReadAnimatedButtons_Aligned(Stream *in)
 
 SavegameError restore_game_gui(Stream *in, int numGuisWas)
 {
-    read_gui(in,guis,&game);
+    GUI::ReadGUI(guis, in);
+    game.numgui = guis.size();
 
     if (numGuisWas != game.numgui)
     {

--- a/Engine/ac/global_button.cpp
+++ b/Engine/ac/global_button.cpp
@@ -59,20 +59,20 @@ int GetButtonPic(int guin, int objn, int ptype) {
 
     if (ptype == 0) {
         // currently displayed pic
-        if (guil->usepic < 0)
-            return guil->pic;
-        return guil->usepic;
+        if (guil->CurrentImage < 0)
+            return guil->Image;
+        return guil->CurrentImage;
     }
     else if (ptype==1) {
         // nomal pic
-        return guil->pic;
+        return guil->Image;
     }
     else if (ptype==2) {
         // mouseover pic
-        return guil->overpic;
+        return guil->MouseOverImage;
     }
     else { // pushed pic
-        return guil->pushedpic;
+        return guil->PushedImage;
     }
 
     quit("internal error in getbuttonpic");

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -83,7 +83,7 @@ void InterfaceOff(int ifn) {
   guis[ifn].SetVisibility(kGUIVisibility_Off);
   if (guis[ifn].MouseOverCtrl>=0) {
     // Make sure that the overpic is turned off when the GUI goes off
-    guis[ifn].Controls[guis[ifn].MouseOverCtrl]->MouseLeave();
+    guis[ifn].Controls[guis[ifn].MouseOverCtrl]->OnMouseLeave();
     guis[ifn].MouseOverCtrl = -1;
   }
   guis[ifn].OnControlPositionChanged();
@@ -227,7 +227,7 @@ int GetGUIObjectAt (int xx, int yy) {
     if (toret == NULL)
         return -1;
 
-    return toret->objn;
+    return toret->Id;
 }
 
 int GetGUIAt (int xx,int yy) {

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -75,8 +75,8 @@ int GetInvAt (int xxx, int yyy) {
     mousey = multiply_up_coordinate(yyy) - guis[ongui].Y;
     int onobj = guis[ongui].FindControlUnderMouse();
     if (onobj>=0) {
-      mouse_ifacebut_xoffs = mousex-(guis[ongui].Controls[onobj]->x);
-      mouse_ifacebut_yoffs = mousey-(guis[ongui].Controls[onobj]->y);
+      mouse_ifacebut_xoffs = mousex-(guis[ongui].Controls[onobj]->X);
+      mouse_ifacebut_yoffs = mousey-(guis[ongui].Controls[onobj]->Y);
     }
     mousex = mxwas;
     mousey = mywas;

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -81,7 +81,7 @@ int GetInvAt (int xxx, int yyy) {
     mousex = mxwas;
     mousey = mywas;
     if ((onobj>=0) && ((guis[ongui].CtrlRefs[onobj] >> 16)==kGUIInvWindow))
-      return offset_over_inv((GUIInv*)guis[ongui].Controls[onobj]);
+      return offset_over_inv((GUIInvWindow*)guis[ongui].Controls[onobj]);
   }
   return -1;
 }

--- a/Engine/ac/global_invwindow.cpp
+++ b/Engine/ac/global_invwindow.cpp
@@ -34,7 +34,7 @@ void SetInvDimensions(int ww,int hh) {
     for (int i = 0; i < numguiinv; i++) {
         guiinv[i].ItemWidth = ww;
         guiinv[i].ItemHeight = hh;
-        guiinv[i].Resized();
+        guiinv[i].OnResized();
     }
     guis_need_update = 1;
 }

--- a/Engine/ac/global_invwindow.cpp
+++ b/Engine/ac/global_invwindow.cpp
@@ -32,8 +32,8 @@ void SetInvDimensions(int ww,int hh) {
     play.inv_numdisp = 0;
     // backwards compatibility
     for (int i = 0; i < numguiinv; i++) {
-        guiinv[i].itemWidth = ww;
-        guiinv[i].itemHeight = hh;
+        guiinv[i].ItemWidth = ww;
+        guiinv[i].ItemHeight = hh;
         guiinv[i].Resized();
     }
     guis_need_update = 1;

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -588,7 +588,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
         else if (cttype == kGUIInvWindow) {
             mouse_ifacebut_xoffs=mousex-(guis[wasongui].Controls[i]->x)-guis[wasongui].X;
             mouse_ifacebut_yoffs=mousey-(guis[wasongui].Controls[i]->y)-guis[wasongui].Y;
-            int iit=offset_over_inv((GUIInv*)guis[wasongui].Controls[i]);
+            int iit=offset_over_inv((GUIInvWindow*)guis[wasongui].Controls[i]);
             if (iit>=0) {
                 evblocknum=iit;
                 play.used_inv_on = iit;

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -296,16 +296,16 @@ void process_interface_click(int ifce, int btn, int mbut) {
         GUIObject *theObj = guis[ifce].Controls[btn];
         // if the object has a special handler script then run it;
         // otherwise, run interface_click
-        if ((theObj->GetNumEvents() > 0) &&
-            (theObj->eventHandlers[0][0] != 0) &&
-            (!gameinst->GetSymbolAddress(theObj->eventHandlers[0]).IsNull())) {
+        if ((theObj->GetEventCount() > 0) &&
+            (!theObj->EventHandlers[0].IsEmpty()) &&
+            (!gameinst->GetSymbolAddress(theObj->EventHandlers[0]).IsNull())) {
                 // control-specific event handler
                 if (strchr(theObj->GetEventArgs(0), ',') != NULL)
-                    QueueScriptFunction(kScInstGame, theObj->eventHandlers[0], 2,
+                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0], 2,
                         RuntimeScriptValue().SetDynamicObject(theObj, &ccDynamicGUIObject),
                         RuntimeScriptValue().SetInt32(mbut));
                 else
-                    QueueScriptFunction(kScInstGame, theObj->eventHandlers[0], 1,
+                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0], 1,
                         RuntimeScriptValue().SetDynamicObject(theObj, &ccDynamicGUIObject));
         }
         else
@@ -400,8 +400,8 @@ void update_gui_zorder() {
 void export_gui_controls(int ee) {
 
     for (int ff = 0; ff < guis[ee].ControlCount; ff++) {
-        if (guis[ee].Controls[ff]->scriptName[0] != 0)
-            ccAddExternalDynamicObject(guis[ee].Controls[ff]->scriptName, guis[ee].Controls[ff], &ccDynamicGUIObject);
+        if (!guis[ee].Controls[ff]->Name.IsEmpty())
+            ccAddExternalDynamicObject(guis[ee].Controls[ff]->Name, guis[ee].Controls[ff], &ccDynamicGUIObject);
 
         ccRegisterManagedObject(guis[ee].Controls[ff], &ccDynamicGUIObject);
     }
@@ -410,8 +410,8 @@ void export_gui_controls(int ee) {
 void unexport_gui_controls(int ee) {
 
     for (int ff = 0; ff < guis[ee].ControlCount; ff++) {
-        if (guis[ee].Controls[ff]->scriptName[0] != 0)
-            ccRemoveExternalSymbol(guis[ee].Controls[ff]->scriptName);
+        if (!guis[ee].Controls[ff]->Name.IsEmpty())
+            ccRemoveExternalSymbol(guis[ee].Controls[ff]->Name);
 
         if (!ccUnRegisterManagedObject(guis[ee].Controls[ff]))
             quit("unable to unregister guicontrol object");
@@ -563,10 +563,10 @@ int gui_on_mouse_move()
 void gui_on_mouse_hold(const int wasongui, const int wasbutdown)
 {
     for (int i=0;i<guis[wasongui].ControlCount;i++) {
-        if (guis[wasongui].Controls[i]->activated<1) continue;
+        if (!guis[wasongui].Controls[i]->IsActivated) continue;
         if (guis[wasongui].GetControlType(i)!=kGUISlider) continue;
         // GUI Slider repeatedly activates while being dragged
-        guis[wasongui].Controls[i]->activated=0;
+        guis[wasongui].Controls[i]->IsActivated = false;
         force_event(EV_IFACECLICK, wasongui, i, wasbutdown);
         break;
     }
@@ -577,8 +577,8 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
     guis[wasongui].OnMouseButtonUp();
 
     for (int i=0;i<guis[wasongui].ControlCount;i++) {
-        if (guis[wasongui].Controls[i]->activated<1) continue;
-        guis[wasongui].Controls[i]->activated=0;
+        if (!guis[wasongui].Controls[i]->IsActivated) continue;
+        guis[wasongui].Controls[i]->IsActivated = false;
         if (!IsInterfaceEnabled()) break;
 
         int cttype=guis[wasongui].GetControlType(i);
@@ -586,8 +586,8 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
             force_event(EV_IFACECLICK, wasongui, i, wasbutdown);
         }
         else if (cttype == kGUIInvWindow) {
-            mouse_ifacebut_xoffs=mousex-(guis[wasongui].Controls[i]->x)-guis[wasongui].X;
-            mouse_ifacebut_yoffs=mousey-(guis[wasongui].Controls[i]->y)-guis[wasongui].Y;
+            mouse_ifacebut_xoffs=mousex-(guis[wasongui].Controls[i]->X)-guis[wasongui].X;
+            mouse_ifacebut_yoffs=mousey-(guis[wasongui].Controls[i]->Y)-guis[wasongui].Y;
             int iit=offset_over_inv((GUIInvWindow*)guis[wasongui].Controls[i]);
             if (iit>=0) {
                 evblocknum=iit;

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -316,11 +316,11 @@ void process_interface_click(int ifce, int btn, int mbut) {
 }
 
 
-void replace_macro_tokens(const char*statusbarformat,char*cur_stb_text) {
-    const char*curptr=&statusbarformat[0];
+void replace_macro_tokens(const char *text, String &fixed_text) {
+    const char*curptr=&text[0];
     char tmpm[3];
-    const char*endat = curptr + strlen(statusbarformat);
-    cur_stb_text[0]=0;
+    const char*endat = curptr + strlen(text);
+    fixed_text.Empty();
     char tempo[STD_BUFFER_SIZE];
 
     while (1) {
@@ -363,11 +363,11 @@ void replace_macro_tokens(const char*statusbarformat,char*cur_stb_text) {
                 strcpy(tempo, "@");
             }
 
-            strcat(cur_stb_text,tempo);
+            fixed_text.Append(tempo);
         }
         else {
             tmpm[0]=curptr[0]; tmpm[1]=0;
-            strcat(cur_stb_text,tmpm);
+            fixed_text.Append(tmpm);
             curptr++;
         }
     }

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -279,20 +279,20 @@ void process_interface_click(int ifce, int btn, int mbut) {
     }
 
     int btype=(guis[ifce].CtrlRefs[btn] >> 16) & 0x000ffff;
-    int rtype=0,rdata;
+    int rtype=kGUIAction_None,rdata;
     if (btype==kGUIButton) {
         GUIButton*gbuto=(GUIButton*)guis[ifce].Controls[btn];
-        rtype=gbuto->leftclick;
-        rdata=gbuto->lclickdata;
+        rtype=gbuto->ClickAction[kMouseLeft];
+        rdata=gbuto->ClickData[kMouseLeft];
     }
     else if ((btype==kGUISlider) || (btype == kGUITextBox) || (btype == kGUIListBox))
-        rtype = IBACT_SCRIPT;
+        rtype = kGUIAction_RunScript;
     else quit("unknown GUI object triggered process_interface");
 
-    if (rtype==0) ;
-    else if (rtype==IBACT_SETMODE)
+    if (rtype==kGUIAction_None) ;
+    else if (rtype==kGUIAction_SetMode)
         set_cursor_mode(rdata);
-    else if (rtype==IBACT_SCRIPT) {
+    else if (rtype==kGUIAction_RunScript) {
         GUIObject *theObj = guis[ifce].Controls[btn];
         // if the object has a special handler script then run it;
         // otherwise, run interface_click

--- a/Engine/ac/gui.h
+++ b/Engine/ac/gui.h
@@ -51,7 +51,7 @@ ScriptGUI *GetGUIAtLocation(int xx, int yy);
 
 void	remove_popup_interface(int ifacenum);
 void	process_interface_click(int ifce, int btn, int mbut);
-void	replace_macro_tokens(const char*statusbarformat,char*cur_stb_text);
+void	replace_macro_tokens(const char *text, AGS::Common::String &fixed_text);
 void	update_gui_zorder();
 void	export_gui_controls(int ee);
 void	unexport_gui_controls(int ee);

--- a/Engine/ac/gui.h
+++ b/Engine/ac/gui.h
@@ -22,6 +22,7 @@
 #include "gui/guimain.h"
 
 using AGS::Common::GUIMain;
+using AGS::Common::GUIObject;
 
 void	GUI_SetVisible(ScriptGUI *tehgui, int isvisible);
 int		GUI_GetVisible(ScriptGUI *tehgui);

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -119,11 +119,11 @@ GUIButton* GUIControl_GetAsButton(GUIObject *guio) {
   return (GUIButton*)guio;
 }
 
-GUIInv* GUIControl_GetAsInvWindow(GUIObject *guio) {
+GUIInvWindow* GUIControl_GetAsInvWindow(GUIObject *guio) {
   if (guis[guio->guin].GetControlType(guio->objn) != kGUIInvWindow)
     return NULL;
 
-  return (GUIInv*)guio;
+  return (GUIInvWindow*)guio;
 }
 
 GUILabel* GUIControl_GetAsLabel(GUIObject *guio) {
@@ -278,10 +278,10 @@ RuntimeScriptValue Sc_GUIControl_GetAsButton(void *self, const RuntimeScriptValu
     API_OBJCALL_OBJ(GUIObject, GUIButton, ccDynamicGUI, GUIControl_GetAsButton);
 }
 
-// GUIInv* (GUIObject *guio)
+// GUIInvWindow* (GUIObject *guio)
 RuntimeScriptValue Sc_GUIControl_GetAsInvWindow(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_OBJ(GUIObject, GUIInv, ccDynamicGUI, GUIControl_GetAsInvWindow);
+    API_OBJCALL_OBJ(GUIObject, GUIInvWindow, ccDynamicGUI, GUIControl_GetAsInvWindow);
 }
 
 // GUILabel* (GUIObject *guio)

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -59,14 +59,15 @@ int GUIControl_GetVisible(GUIObject *guio) {
 
 void GUIControl_SetVisible(GUIObject *guio, int visible) 
 {
-  if (visible != guio->IsVisible()) 
+  const bool is_visible = visible != 0;
+  if (is_visible != guio->IsVisible()) 
   {
-    if (visible)
+    if (is_visible)
       guio->Show();
     else
       guio->Hide();
 
-    guis[guio->guin].OnControlPositionChanged();
+    guis[guio->ParentId].OnControlPositionChanged();
     guis_need_update = 1;
   }
 }
@@ -83,14 +84,12 @@ void GUIControl_SetClickable(GUIObject *guio, int enabled) {
   else
     guio->SetClickable(false);
 
-  guis[guio->guin].OnControlPositionChanged();
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
 int GUIControl_GetEnabled(GUIObject *guio) {
-  if (guio->IsDisabled())
-    return 0;
-  return 1;
+  return guio->IsEnabled() ? 1 : 0;
 }
 
 void GUIControl_SetEnabled(GUIObject *guio, int enabled) {
@@ -99,89 +98,89 @@ void GUIControl_SetEnabled(GUIObject *guio, int enabled) {
   else
     guio->Disable();
 
-  guis[guio->guin].OnControlPositionChanged();
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
 
 int GUIControl_GetID(GUIObject *guio) {
-  return guio->objn;
+  return guio->Id;
 }
 
 ScriptGUI* GUIControl_GetOwningGUI(GUIObject *guio) {
-  return &scrGui[guio->guin];
+  return &scrGui[guio->ParentId];
 }
 
 GUIButton* GUIControl_GetAsButton(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUIButton)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIButton)
     return NULL;
 
   return (GUIButton*)guio;
 }
 
 GUIInvWindow* GUIControl_GetAsInvWindow(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUIInvWindow)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIInvWindow)
     return NULL;
 
   return (GUIInvWindow*)guio;
 }
 
 GUILabel* GUIControl_GetAsLabel(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUILabel)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUILabel)
     return NULL;
 
   return (GUILabel*)guio;
 }
 
 GUIListBox* GUIControl_GetAsListBox(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUIListBox)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIListBox)
     return NULL;
 
   return (GUIListBox*)guio;
 }
 
 GUISlider* GUIControl_GetAsSlider(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUISlider)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUISlider)
     return NULL;
 
   return (GUISlider*)guio;
 }
 
 GUITextBox* GUIControl_GetAsTextBox(GUIObject *guio) {
-  if (guis[guio->guin].GetControlType(guio->objn) != kGUITextBox)
+  if (guis[guio->ParentId].GetControlType(guio->Id) != kGUITextBox)
     return NULL;
 
   return (GUITextBox*)guio;
 }
 
 int GUIControl_GetX(GUIObject *guio) {
-  return divide_down_coordinate(guio->x);
+  return divide_down_coordinate(guio->X);
 }
 
 void GUIControl_SetX(GUIObject *guio, int xx) {
-  guio->x = multiply_up_coordinate(xx);
-  guis[guio->guin].OnControlPositionChanged();
+  guio->X = multiply_up_coordinate(xx);
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
 int GUIControl_GetY(GUIObject *guio) {
-  return divide_down_coordinate(guio->y);
+  return divide_down_coordinate(guio->Y);
 }
 
 void GUIControl_SetY(GUIObject *guio, int yy) {
-  guio->y = multiply_up_coordinate(yy);
-  guis[guio->guin].OnControlPositionChanged();
+  guio->Y = multiply_up_coordinate(yy);
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
 int GUIControl_GetZOrder(GUIObject *guio)
 {
-    return guio->zorder;
+    return guio->ZOrder;
 }
 
 void GUIControl_SetZOrder(GUIObject *guio, int zorder)
 {
-    if (guis[guio->guin].SetControlZOrder(guio->objn, zorder))
+    if (guis[guio->ParentId].SetControlZOrder(guio->Id, zorder))
         guis_need_update = 1;
 }
 
@@ -192,24 +191,24 @@ void GUIControl_SetPosition(GUIObject *guio, int xx, int yy) {
 
 
 int GUIControl_GetWidth(GUIObject *guio) {
-  return divide_down_coordinate(guio->wid);
+  return divide_down_coordinate(guio->Width);
 }
 
 void GUIControl_SetWidth(GUIObject *guio, int newwid) {
-  guio->wid = multiply_up_coordinate(newwid);
-  guio->Resized();
-  guis[guio->guin].OnControlPositionChanged();
+  guio->Width = multiply_up_coordinate(newwid);
+  guio->OnResized();
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
 int GUIControl_GetHeight(GUIObject *guio) {
-  return divide_down_coordinate(guio->hit);
+  return divide_down_coordinate(guio->Height);
 }
 
 void GUIControl_SetHeight(GUIObject *guio, int newhit) {
-  guio->hit = multiply_up_coordinate(newhit);
-  guio->Resized();
-  guis[guio->guin].OnControlPositionChanged();
+  guio->Height = multiply_up_coordinate(newhit);
+  guio->OnResized();
+  guis[guio->ParentId].OnControlPositionChanged();
   guis_need_update = 1;
 }
 
@@ -217,18 +216,18 @@ void GUIControl_SetSize(GUIObject *guio, int newwid, int newhit) {
   if ((newwid < 2) || (newhit < 2))
     quit("!SetGUIObjectSize: new size is too small (must be at least 2x2)");
 
-  debug_script_log("SetGUIObject %d,%d size %d,%d", guio->guin, guio->objn, newwid, newhit);
+  debug_script_log("SetGUIObject %d,%d size %d,%d", guio->ParentId, guio->Id, newwid, newhit);
   GUIControl_SetWidth(guio, newwid);
   GUIControl_SetHeight(guio, newhit);
 }
 
 void GUIControl_SendToBack(GUIObject *guio) {
-  if (guis[guio->guin].SendControlToBack(guio->objn))
+  if (guis[guio->ParentId].SendControlToBack(guio->Id))
     guis_need_update = 1;
 }
 
 void GUIControl_BringToFront(GUIObject *guio) {
-  if (guis[guio->guin].BringControlToFront(guio->objn))
+  if (guis[guio->ParentId].BringControlToFront(guio->Id))
     guis_need_update = 1;
 }
 

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,8 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUITextBox;
+
 GUIObject	*GetGUIControlAtLocation(int xx, int yy);
 int			GUIControl_GetVisible(GUIObject *guio);
 void		GUIControl_SetVisible(GUIObject *guio, int visible);

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,7 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUISlider;
 using AGS::Common::GUITextBox;
 
 GUIObject	*GetGUIControlAtLocation(int xx, int yy);

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,7 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUIObject;
 using AGS::Common::GUIButton;
 using AGS::Common::GUIInvWindow;
 using AGS::Common::GUILabel;

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,7 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUIListBox;
 using AGS::Common::GUISlider;
 using AGS::Common::GUITextBox;
 

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,7 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUIButton;
 using AGS::Common::GUIInvWindow;
 using AGS::Common::GUILabel;
 using AGS::Common::GUIListBox;

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -27,6 +27,7 @@
 #include "gui/guitextbox.h"
 #include "ac/dynobj/scriptgui.h"
 
+using AGS::Common::GUIInvWindow;
 using AGS::Common::GUIListBox;
 using AGS::Common::GUISlider;
 using AGS::Common::GUITextBox;
@@ -41,7 +42,7 @@ void		GUIControl_SetEnabled(GUIObject *guio, int enabled);
 int			GUIControl_GetID(GUIObject *guio);
 ScriptGUI*	GUIControl_GetOwningGUI(GUIObject *guio);
 GUIButton*	GUIControl_GetAsButton(GUIObject *guio);
-GUIInv*		GUIControl_GetAsInvWindow(GUIObject *guio);
+GUIInvWindow* GUIControl_GetAsInvWindow(GUIObject *guio);
 GUILabel*	GUIControl_GetAsLabel(GUIObject *guio);
 GUIListBox* GUIControl_GetAsListBox(GUIObject *guio);
 GUISlider*	GUIControl_GetAsSlider(GUIObject *guio);

--- a/Engine/ac/guicontrol.h
+++ b/Engine/ac/guicontrol.h
@@ -28,6 +28,7 @@
 #include "ac/dynobj/scriptgui.h"
 
 using AGS::Common::GUIInvWindow;
+using AGS::Common::GUILabel;
 using AGS::Common::GUIListBox;
 using AGS::Common::GUISlider;
 using AGS::Common::GUITextBox;

--- a/Engine/ac/guiinv.cpp
+++ b/Engine/ac/guiinv.cpp
@@ -84,16 +84,8 @@ void GUIInvWindow::Draw(Bitmap *ds)
         gui_disabled_style == GUIDIS_GREYOUT && 
         play.inventory_greys_out == 1)
     {
-        color_t draw_color = ds->GetCompatibleColor(8);
         // darken the inventory when disabled
-        // TODO: move this to a separate function?
-        for (at_x = 0; at_x < Width; at_x++)
-        {
-            for (at_y = at_x % 2; at_y < Height; at_y += 2)
-            {
-                ds->PutPixel(X + at_x, Y + at_y, draw_color);
-            }
-        }
+        GUI::DrawDisabledEffect(ds, Rect(X, Y, Width, Height));
     }
 }
 

--- a/Engine/ac/guiinv.cpp
+++ b/Engine/ac/guiinv.cpp
@@ -44,7 +44,7 @@ int GUIInvWindow::GetCharacterId() const
 
 void GUIInvWindow::Draw(Bitmap *ds)
 {
-    if ((IsDisabled()) && (gui_disabled_style == GUIDIS_BLACKOUT))
+    if ((!IsEnabled()) && (gui_disabled_style == GUIDIS_BLACKOUT))
         return;
 
     // backwards compatibility
@@ -59,9 +59,9 @@ void GUIInvWindow::Draw(Bitmap *ds)
         TopItem = play.inv_top;
 
     // draw the items
-    const int leftmost_x = x;
-    int at_x = x;
-    int at_y = y;
+    const int leftmost_x = X;
+    int at_x = X;
+    int at_y = Y;
     int lastItem = TopItem + (ColCount * RowCount);
     if (lastItem > charextra[GetCharacterId()].invorder_count)
         lastItem = charextra[GetCharacterId()].invorder_count;
@@ -80,18 +80,18 @@ void GUIInvWindow::Draw(Bitmap *ds)
         }
     }
 
-    if (IsDisabled() &&
+    if (!IsEnabled() &&
         gui_disabled_style == GUIDIS_GREYOUT && 
         play.inventory_greys_out == 1)
     {
         color_t draw_color = ds->GetCompatibleColor(8);
         // darken the inventory when disabled
         // TODO: move this to a separate function?
-        for (at_x = 0; at_x < wid; at_x++)
+        for (at_x = 0; at_x < Width; at_x++)
         {
-            for (at_y = at_x % 2; at_y < hit; at_y += 2)
+            for (at_y = at_x % 2; at_y < Height; at_y += 2)
             {
-                ds->PutPixel(x + at_x, y + at_y, draw_color);
+                ds->PutPixel(X + at_x, Y + at_y, draw_color);
             }
         }
     }

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -77,7 +77,7 @@ CharacterInfo* InvWindow_GetCharacterToUse(GUIInvWindow *guii) {
 
 void InvWindow_SetItemWidth(GUIInvWindow *guii, int newwidth) {
   guii->ItemWidth = newwidth;
-  guii->Resized();
+  guii->OnResized();
 }
 
 int InvWindow_GetItemWidth(GUIInvWindow *guii) {
@@ -86,7 +86,7 @@ int InvWindow_GetItemWidth(GUIInvWindow *guii) {
 
 void InvWindow_SetItemHeight(GUIInvWindow *guii, int newhit) {
   guii->ItemHeight = newhit;
-  guii->Resized();
+  guii->OnResized();
 }
 
 int InvWindow_GetItemHeight(GUIInvWindow *guii) {

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -57,106 +57,106 @@ int in_inv_screen = 0, inv_screen_newroom = -1;
 
 // *** INV WINDOW FUNCTIONS
 
-void InvWindow_SetCharacterToUse(GUIInv *guii, CharacterInfo *chaa) {
+void InvWindow_SetCharacterToUse(GUIInvWindow *guii, CharacterInfo *chaa) {
   if (chaa == NULL)
-    guii->charId = -1;
+    guii->CharId = -1;
   else
-    guii->charId = chaa->index_id;
+    guii->CharId = chaa->index_id;
   // reset to top of list
-  guii->topIndex = 0;
+  guii->TopItem = 0;
 
   guis_need_update = 1;
 }
 
-CharacterInfo* InvWindow_GetCharacterToUse(GUIInv *guii) {
-  if (guii->charId < 0)
+CharacterInfo* InvWindow_GetCharacterToUse(GUIInvWindow *guii) {
+  if (guii->CharId < 0)
     return NULL;
 
-  return &game.chars[guii->charId];
+  return &game.chars[guii->CharId];
 }
 
-void InvWindow_SetItemWidth(GUIInv *guii, int newwidth) {
-  guii->itemWidth = newwidth;
+void InvWindow_SetItemWidth(GUIInvWindow *guii, int newwidth) {
+  guii->ItemWidth = newwidth;
   guii->Resized();
 }
 
-int InvWindow_GetItemWidth(GUIInv *guii) {
-  return guii->itemWidth;
+int InvWindow_GetItemWidth(GUIInvWindow *guii) {
+  return guii->ItemWidth;
 }
 
-void InvWindow_SetItemHeight(GUIInv *guii, int newhit) {
-  guii->itemHeight = newhit;
+void InvWindow_SetItemHeight(GUIInvWindow *guii, int newhit) {
+  guii->ItemHeight = newhit;
   guii->Resized();
 }
 
-int InvWindow_GetItemHeight(GUIInv *guii) {
-  return guii->itemHeight;
+int InvWindow_GetItemHeight(GUIInvWindow *guii) {
+  return guii->ItemHeight;
 }
 
-void InvWindow_SetTopItem(GUIInv *guii, int topitem) {
-  if (guii->topIndex != topitem) {
-    guii->topIndex = topitem;
+void InvWindow_SetTopItem(GUIInvWindow *guii, int topitem) {
+  if (guii->TopItem != topitem) {
+    guii->TopItem = topitem;
     guis_need_update = 1;
   }
 }
 
-int InvWindow_GetTopItem(GUIInv *guii) {
-  return guii->topIndex;
+int InvWindow_GetTopItem(GUIInvWindow *guii) {
+  return guii->TopItem;
 }
 
-int InvWindow_GetItemsPerRow(GUIInv *guii) {
-  return guii->itemsPerLine;
+int InvWindow_GetItemsPerRow(GUIInvWindow *guii) {
+  return guii->ColCount;
 }
 
-int InvWindow_GetItemCount(GUIInv *guii) {
-  return charextra[guii->CharToDisplay()].invorder_count;
+int InvWindow_GetItemCount(GUIInvWindow *guii) {
+  return charextra[guii->GetCharacterId()].invorder_count;
 }
 
-int InvWindow_GetRowCount(GUIInv *guii) {
-  return guii->numLines;
+int InvWindow_GetRowCount(GUIInvWindow *guii) {
+  return guii->RowCount;
 }
 
-void InvWindow_ScrollDown(GUIInv *guii) {
-  if ((charextra[guii->CharToDisplay()].invorder_count) >
-      (guii->topIndex + (guii->itemsPerLine * guii->numLines))) { 
-    guii->topIndex += guii->itemsPerLine;
+void InvWindow_ScrollDown(GUIInvWindow *guii) {
+  if ((charextra[guii->GetCharacterId()].invorder_count) >
+      (guii->TopItem + (guii->ColCount * guii->RowCount))) { 
+    guii->TopItem += guii->ColCount;
     guis_need_update = 1;
   }
 }
 
-void InvWindow_ScrollUp(GUIInv *guii) {
-  if (guii->topIndex > 0) {
-    guii->topIndex -= guii->itemsPerLine;
-    if (guii->topIndex < 0)
-      guii->topIndex = 0;
+void InvWindow_ScrollUp(GUIInvWindow *guii) {
+  if (guii->TopItem > 0) {
+    guii->TopItem -= guii->ColCount;
+    if (guii->TopItem < 0)
+      guii->TopItem = 0;
 
     guis_need_update = 1;
   }
 }
 
-ScriptInvItem* InvWindow_GetItemAtIndex(GUIInv *guii, int index) {
-  if ((index < 0) || (index >= charextra[guii->CharToDisplay()].invorder_count))
+ScriptInvItem* InvWindow_GetItemAtIndex(GUIInvWindow *guii, int index) {
+  if ((index < 0) || (index >= charextra[guii->GetCharacterId()].invorder_count))
     return NULL;
-  return &scrInv[charextra[guii->CharToDisplay()].invorder[index]];
+  return &scrInv[charextra[guii->GetCharacterId()].invorder[index]];
 }
 
 //=============================================================================
 
-int offset_over_inv(GUIInv *inv) {
+int offset_over_inv(GUIInvWindow *inv) {
 
-    int mover = mouse_ifacebut_xoffs / multiply_up_coordinate(inv->itemWidth);
+    int mover = mouse_ifacebut_xoffs / multiply_up_coordinate(inv->ItemWidth);
     // if it's off the edge of the visible items, ignore
-    if (mover >= inv->itemsPerLine)
+    if (mover >= inv->ColCount)
         return -1;
-    mover += (mouse_ifacebut_yoffs / multiply_up_coordinate(inv->itemHeight)) * inv->itemsPerLine;
-    if (mover >= inv->itemsPerLine * inv->numLines)
-        return -1;
-
-    mover += inv->topIndex;
-    if ((mover < 0) || (mover >= charextra[inv->CharToDisplay()].invorder_count))
+    mover += (mouse_ifacebut_yoffs / multiply_up_coordinate(inv->ItemHeight)) * inv->ColCount;
+    if (mover >= inv->ColCount * inv->RowCount)
         return -1;
 
-    return charextra[inv->CharToDisplay()].invorder[mover];
+    mover += inv->TopItem;
+    if ((mover < 0) || (mover >= charextra[inv->GetCharacterId()].invorder_count))
+        return -1;
+
+    return charextra[inv->GetCharacterId()].invorder[mover];
 }
 
 //
@@ -522,88 +522,88 @@ int invscreen() {
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
-// void (GUIInv *guii)
+// void (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_ScrollDown(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID(GUIInv, InvWindow_ScrollDown);
+    API_OBJCALL_VOID(GUIInvWindow, InvWindow_ScrollDown);
 }
 
-// void (GUIInv *guii)
+// void (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_ScrollUp(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID(GUIInv, InvWindow_ScrollUp);
+    API_OBJCALL_VOID(GUIInvWindow, InvWindow_ScrollUp);
 }
 
-// CharacterInfo* (GUIInv *guii)
+// CharacterInfo* (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetCharacterToUse(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_OBJ(GUIInv, CharacterInfo, ccDynamicCharacter, InvWindow_GetCharacterToUse);
+    API_OBJCALL_OBJ(GUIInvWindow, CharacterInfo, ccDynamicCharacter, InvWindow_GetCharacterToUse);
 }
 
-// void (GUIInv *guii, CharacterInfo *chaa)
+// void (GUIInvWindow *guii, CharacterInfo *chaa)
 RuntimeScriptValue Sc_InvWindow_SetCharacterToUse(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_POBJ(GUIInv, InvWindow_SetCharacterToUse, CharacterInfo);
+    API_OBJCALL_VOID_POBJ(GUIInvWindow, InvWindow_SetCharacterToUse, CharacterInfo);
 }
 
-// ScriptInvItem* (GUIInv *guii, int index)
+// ScriptInvItem* (GUIInvWindow *guii, int index)
 RuntimeScriptValue Sc_InvWindow_GetItemAtIndex(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_OBJ_PINT(GUIInv, ScriptInvItem, ccDynamicInv, InvWindow_GetItemAtIndex);
+    API_OBJCALL_OBJ_PINT(GUIInvWindow, ScriptInvItem, ccDynamicInv, InvWindow_GetItemAtIndex);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetItemCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetItemCount);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetItemCount);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetItemHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetItemHeight);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetItemHeight);
 }
 
-// void (GUIInv *guii, int newhit)
+// void (GUIInvWindow *guii, int newhit)
 RuntimeScriptValue Sc_InvWindow_SetItemHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT(GUIInv, InvWindow_SetItemHeight);
+    API_OBJCALL_VOID_PINT(GUIInvWindow, InvWindow_SetItemHeight);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetItemWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetItemWidth);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetItemWidth);
 }
 
-// void (GUIInv *guii, int newwidth)
+// void (GUIInvWindow *guii, int newwidth)
 RuntimeScriptValue Sc_InvWindow_SetItemWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT(GUIInv, InvWindow_SetItemWidth);
+    API_OBJCALL_VOID_PINT(GUIInvWindow, InvWindow_SetItemWidth);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetItemsPerRow(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetItemsPerRow);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetItemsPerRow);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetRowCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetRowCount);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetRowCount);
 }
 
-// int (GUIInv *guii)
+// int (GUIInvWindow *guii)
 RuntimeScriptValue Sc_InvWindow_GetTopItem(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_INT(GUIInv, InvWindow_GetTopItem);
+    API_OBJCALL_INT(GUIInvWindow, InvWindow_GetTopItem);
 }
 
-// void (GUIInv *guii, int topitem)
+// void (GUIInvWindow *guii, int topitem)
 RuntimeScriptValue Sc_InvWindow_SetTopItem(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT(GUIInv, InvWindow_SetTopItem);
+    API_OBJCALL_VOID_PINT(GUIInvWindow, InvWindow_SetTopItem);
 }
 
 

--- a/Engine/ac/invwindow.h
+++ b/Engine/ac/invwindow.h
@@ -22,24 +22,26 @@
 #include "ac/dynobj/scriptinvitem.h"
 #include "gui/guiinv.h"
 
-void			InvWindow_SetCharacterToUse(GUIInv *guii, CharacterInfo *chaa);
-CharacterInfo*	InvWindow_GetCharacterToUse(GUIInv *guii);
-void			InvWindow_SetItemWidth(GUIInv *guii, int newwidth);
-int				InvWindow_GetItemWidth(GUIInv *guii);
-void			InvWindow_SetItemHeight(GUIInv *guii, int newhit);
-int				InvWindow_GetItemHeight(GUIInv *guii);
-void			InvWindow_SetTopItem(GUIInv *guii, int topitem);
-int				InvWindow_GetTopItem(GUIInv *guii);
-int				InvWindow_GetItemsPerRow(GUIInv *guii);
-int				InvWindow_GetItemCount(GUIInv *guii);
-int				InvWindow_GetRowCount(GUIInv *guii);
-void			InvWindow_ScrollDown(GUIInv *guii);
-void			InvWindow_ScrollUp(GUIInv *guii);
-ScriptInvItem*	InvWindow_GetItemAtIndex(GUIInv *guii, int index);
+using AGS::Common::GUIInvWindow;
+
+void            InvWindow_SetCharacterToUse(GUIInvWindow *guii, CharacterInfo *chaa);
+CharacterInfo*  InvWindow_GetCharacterToUse(GUIInvWindow *guii);
+void            InvWindow_SetItemWidth(GUIInvWindow *guii, int newwidth);
+int             InvWindow_GetItemWidth(GUIInvWindow *guii);
+void            InvWindow_SetItemHeight(GUIInvWindow *guii, int newhit);
+int             InvWindow_GetItemHeight(GUIInvWindow *guii);
+void            InvWindow_SetTopItem(GUIInvWindow *guii, int topitem);
+int             InvWindow_GetTopItem(GUIInvWindow *guii);
+int             InvWindow_GetItemsPerRow(GUIInvWindow *guii);
+int             InvWindow_GetItemCount(GUIInvWindow *guii);
+int             InvWindow_GetRowCount(GUIInvWindow *guii);
+void            InvWindow_ScrollDown(GUIInvWindow *guii);
+void            InvWindow_ScrollUp(GUIInvWindow *guii);
+ScriptInvItem*  InvWindow_GetItemAtIndex(GUIInvWindow *guii, int index);
 
 //=============================================================================
 
-int				offset_over_inv(GUIInv *inv);
+int				offset_over_inv(GUIInvWindow *inv);
 // NOTE: This function is valid for AGS 2.72 and lower
 int             invscreen();
 

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -41,26 +41,26 @@ void Label_SetText(GUILabel *labl, const char *newtx) {
 }
 
 int Label_GetColor(GUILabel *labl) {
-    return labl->textcol;
+    return labl->TextColor;
 }
 
 void Label_SetColor(GUILabel *labl, int colr) {
-    if (labl->textcol != colr) {
-        labl->textcol = colr;
+    if (labl->TextColor != colr) {
+        labl->TextColor = colr;
         guis_need_update = 1;
     }
 }
 
 int Label_GetFont(GUILabel *labl) {
-    return labl->font;
+    return labl->Font;
 }
 
 void Label_SetFont(GUILabel *guil, int fontnum) {
     if ((fontnum < 0) || (fontnum >= game.numfonts))
         quit("!SetLabelFont: invalid font number.");
 
-    if (fontnum != guil->font) {
-        guil->font = fontnum;
+    if (fontnum != guil->Font) {
+        guil->Font = fontnum;
         guis_need_update = 1;
     }
 }

--- a/Engine/ac/label.h
+++ b/Engine/ac/label.h
@@ -20,6 +20,8 @@
 
 #include "gui/guilabel.h"
 
+using AGS::Common::GUILabel;
+
 const char* Label_GetText_New(GUILabel *labl);
 void		Label_GetText(GUILabel *labl, char *buffer);
 void		Label_SetText(GUILabel *labl, const char *newtx);

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -154,14 +154,14 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
 
 int ListBox_GetItemAtLocation(GUIListBox *listbox, int x, int y) {
 
-  if (!guis[listbox->guin].IsVisible())
+  if (!guis[listbox->ParentId].IsVisible())
     return -1;
 
   multiply_up_coordinates(&x, &y);
-  x = (x - listbox->x) - guis[listbox->guin].X;
-  y = (y - listbox->y) - guis[listbox->guin].Y;
+  x = (x - listbox->X) - guis[listbox->ParentId].X;
+  y = (y - listbox->Y) - guis[listbox->ParentId].Y;
 
-  if ((x < 0) || (y < 0) || (x >= listbox->wid) || (y >= listbox->hit))
+  if ((x < 0) || (y < 0) || (x >= listbox->Width) || (y >= listbox->Height))
     return -1;
   
   return listbox->GetItemAt(x, y);

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -83,10 +83,10 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
 }
 
 int ListBox_GetSaveGameSlots(GUIListBox *listbox, int index) {
-  if ((index < 0) || (index >= listbox->numItems))
+  if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBox.SaveGameSlot: index out of range");
 
-  return listbox->saveGameIndex[index];
+  return listbox->SavedGameIndex[index];
 }
 
 int ListBox_FillSaveGameList(GUIListBox *listbox) {
@@ -115,7 +115,7 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
     int saveGameSlot = atoi(numberExtension);
     GetSaveSlotDescription(saveGameSlot, buff);
     listbox->AddItem(buff);
-    listbox->saveGameIndex[numsaves] = saveGameSlot;
+    listbox->SavedGameIndex[numsaves] = saveGameSlot;
     filedates[numsaves]=(long int)ffb.time;
     numsaves++;
     don = al_findnext(&ffb);
@@ -127,12 +127,12 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
     for (int kk=0;kk<numsaves-1;kk++) {  // Date order the games
 
       if (filedates[kk] < filedates[kk+1]) {   // swap them round
-        String tempptr = listbox->items[kk];
-        listbox->items[kk] = listbox->items[kk+1];
-        listbox->items[kk+1] = tempptr;
-        int numtem = listbox->saveGameIndex[kk];
-        listbox->saveGameIndex[kk] = listbox->saveGameIndex[kk+1];
-        listbox->saveGameIndex[kk+1] = numtem;
+        String tempptr = listbox->Items[kk];
+        listbox->Items[kk] = listbox->Items[kk+1];
+        listbox->Items[kk+1] = tempptr;
+        int numtem = listbox->SavedGameIndex[kk];
+        listbox->SavedGameIndex[kk] = listbox->SavedGameIndex[kk+1];
+        listbox->SavedGameIndex[kk+1] = numtem;
         long numted=filedates[kk]; filedates[kk]=filedates[kk+1];
         filedates[kk+1]=numted;
       }
@@ -141,11 +141,11 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
 
   // update the global savegameindex[] array for backward compatibilty
   for (nn = 0; nn < numsaves; nn++) {
-    play.filenumbers[nn] = listbox->saveGameIndex[nn];
+    play.filenumbers[nn] = listbox->SavedGameIndex[nn];
   }
 
   guis_need_update = 1;
-  listbox->exflags |= GLF_SGINDEXVALID;
+  listbox->ListBoxFlags |= kListBox_SvgIndex;
 
   if (numsaves >= MAXSAVEGAMES)
     return 1;
@@ -164,29 +164,29 @@ int ListBox_GetItemAtLocation(GUIListBox *listbox, int x, int y) {
   if ((x < 0) || (y < 0) || (x >= listbox->wid) || (y >= listbox->hit))
     return -1;
   
-  return listbox->GetIndexFromCoordinates(x, y);
+  return listbox->GetItemAt(x, y);
 }
 
 char *ListBox_GetItemText(GUIListBox *listbox, int index, char *buffer) {
-  if ((index < 0) || (index >= listbox->numItems))
+  if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBoxGetItemText: invalid item specified");
-  strncpy(buffer, listbox->items[index],198);
+  strncpy(buffer, listbox->Items[index],198);
   buffer[199] = 0;
   return buffer;
 }
 
 const char* ListBox_GetItems(GUIListBox *listbox, int index) {
-  if ((index < 0) || (index >= listbox->numItems))
+  if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBox.Items: invalid index specified");
 
-  return CreateNewScriptString(listbox->items[index]);
+  return CreateNewScriptString(listbox->Items[index]);
 }
 
 void ListBox_SetItemText(GUIListBox *listbox, int index, const char *newtext) {
-  if ((index < 0) || (index >= listbox->numItems))
+  if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBoxSetItemText: invalid item specified");
 
-  if (strcmp(listbox->items[index], newtext)) {
+  if (strcmp(listbox->Items[index], newtext)) {
     listbox->SetItemText(index, newtext);
     guis_need_update = 1;
   }
@@ -194,7 +194,7 @@ void ListBox_SetItemText(GUIListBox *listbox, int index, const char *newtext) {
 
 void ListBox_RemoveItem(GUIListBox *listbox, int itemIndex) {
   
-  if ((itemIndex < 0) || (itemIndex >= listbox->numItems))
+  if ((itemIndex < 0) || (itemIndex >= listbox->ItemCount))
     quit("!ListBoxRemove: invalid listindex specified");
 
   listbox->RemoveItem(itemIndex);
@@ -202,11 +202,11 @@ void ListBox_RemoveItem(GUIListBox *listbox, int itemIndex) {
 }
 
 int ListBox_GetItemCount(GUIListBox *listbox) {
-  return listbox->numItems;
+  return listbox->ItemCount;
 }
 
 int ListBox_GetFont(GUIListBox *listbox) {
-  return listbox->font;
+  return listbox->Font;
 }
 
 void ListBox_SetFont(GUIListBox *listbox, int newfont) {
@@ -214,53 +214,53 @@ void ListBox_SetFont(GUIListBox *listbox, int newfont) {
   if ((newfont < 0) || (newfont >= game.numfonts))
     quit("!ListBox.Font: invalid font number.");
 
-  if (newfont != listbox->font) {
-    listbox->ChangeFont(newfont);
+  if (newfont != listbox->Font) {
+    listbox->SetFont(newfont);
     guis_need_update = 1;
   }
 
 }
 
 int ListBox_GetHideBorder(GUIListBox *listbox) {
-  return (listbox->exflags & GLF_NOBORDER) ? 1 : 0;
+  return (listbox->ListBoxFlags & kListBox_NoBorder) ? 1 : 0;
 }
 
 void ListBox_SetHideBorder(GUIListBox *listbox, int newValue) {
-  listbox->exflags &= ~GLF_NOBORDER;
+  listbox->ListBoxFlags &= ~kListBox_NoBorder;
   if (newValue)
-    listbox->exflags |= GLF_NOBORDER;
+    listbox->ListBoxFlags |= kListBox_NoBorder;
   guis_need_update = 1;
 }
 
 int ListBox_GetHideScrollArrows(GUIListBox *listbox) {
-  return (listbox->exflags & GLF_NOARROWS) ? 1 : 0;
+  return (listbox->ListBoxFlags & kListBox_NoArrows) ? 1 : 0;
 }
 
 void ListBox_SetHideScrollArrows(GUIListBox *listbox, int newValue) {
-  listbox->exflags &= ~GLF_NOARROWS;
+  listbox->ListBoxFlags &= ~kListBox_NoArrows;
   if (newValue)
-    listbox->exflags |= GLF_NOARROWS;
+    listbox->ListBoxFlags |= kListBox_NoArrows;
   guis_need_update = 1;
 }
 
 int ListBox_GetSelectedIndex(GUIListBox *listbox) {
-  if ((listbox->selected < 0) || (listbox->selected >= listbox->numItems))
+  if ((listbox->SelectedItem < 0) || (listbox->SelectedItem >= listbox->ItemCount))
     return -1;
-  return listbox->selected;
+  return listbox->SelectedItem;
 }
 
 void ListBox_SetSelectedIndex(GUIListBox *guisl, int newsel) {
 
-  if (newsel >= guisl->numItems)
+  if (newsel >= guisl->ItemCount)
     newsel = -1;
 
-  if (guisl->selected != newsel) {
-    guisl->selected = newsel;
+  if (guisl->SelectedItem != newsel) {
+    guisl->SelectedItem = newsel;
     if (newsel >= 0) {
-      if (newsel < guisl->topItem)
-        guisl->topItem = newsel;
-      if (newsel >= guisl->topItem + guisl->num_items_fit)
-        guisl->topItem = (newsel - guisl->num_items_fit) + 1;
+      if (newsel < guisl->TopItem)
+        guisl->TopItem = newsel;
+      if (newsel >= guisl->TopItem + guisl->VisibleItemCount)
+        guisl->TopItem = (newsel - guisl->VisibleItemCount) + 1;
     }
     guis_need_update = 1;
   }
@@ -268,33 +268,33 @@ void ListBox_SetSelectedIndex(GUIListBox *guisl, int newsel) {
 }
 
 int ListBox_GetTopItem(GUIListBox *listbox) {
-  return listbox->topItem;
+  return listbox->TopItem;
 }
 
 void ListBox_SetTopItem(GUIListBox *guisl, int item) {
-  if ((guisl->numItems == 0) && (item == 0))
+  if ((guisl->ItemCount == 0) && (item == 0))
     ;  // allow resetting an empty box to the top
-  else if ((item >= guisl->numItems) || (item < 0))
+  else if ((item >= guisl->ItemCount) || (item < 0))
     quit("!ListBoxSetTopItem: tried to set top to beyond top or bottom of list");
 
-  guisl->topItem = item;
+  guisl->TopItem = item;
   guis_need_update = 1;
 }
 
 int ListBox_GetRowCount(GUIListBox *listbox) {
-  return listbox->num_items_fit;
+  return listbox->VisibleItemCount;
 }
 
 void ListBox_ScrollDown(GUIListBox *listbox) {
-  if (listbox->topItem + listbox->num_items_fit < listbox->numItems) {
-    listbox->topItem++;
+  if (listbox->TopItem + listbox->VisibleItemCount < listbox->ItemCount) {
+    listbox->TopItem++;
     guis_need_update = 1;
   }
 }
 
 void ListBox_ScrollUp(GUIListBox *listbox) {
-  if (listbox->topItem > 0) {
-    listbox->topItem--;
+  if (listbox->TopItem > 0) {
+    listbox->TopItem--;
     guis_need_update = 1;
   }
 }

--- a/Engine/ac/listbox.h
+++ b/Engine/ac/listbox.h
@@ -20,6 +20,8 @@
 
 #include "gui/guilistbox.h"
 
+using AGS::Common::GUIListBox;
+
 int			ListBox_AddItem(GUIListBox *lbb, const char *text);
 int			ListBox_InsertItemAt(GUIListBox *lbb, int index, const char *text);
 void		ListBox_Clear(GUIListBox *listbox);

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -236,8 +236,8 @@ void enable_cursor_mode(int modd) {
         for (ww=0;ww<guis[uu].ControlCount;ww++) {
             if ((guis[uu].CtrlRefs[ww] >> 16)!=kGUIButton) continue;
             GUIButton*gbpt=(GUIButton*)guis[uu].Controls[ww];
-            if (gbpt->leftclick!=IBACT_SETMODE) continue;
-            if (gbpt->lclickdata!=modd) continue;
+            if (gbpt->ClickAction[kMouseLeft]!=kGUIAction_SetMode) continue;
+            if (gbpt->ClickData[kMouseLeft]!=modd) continue;
             gbpt->Enable();
         }
     }
@@ -253,8 +253,8 @@ void disable_cursor_mode(int modd) {
         for (ww=0;ww<guis[uu].ControlCount;ww++) {
             if ((guis[uu].CtrlRefs[ww] >> 16)!=kGUIButton) continue;
             GUIButton*gbpt=(GUIButton*)guis[uu].Controls[ww];
-            if (gbpt->leftclick!=IBACT_SETMODE) continue;
-            if (gbpt->lclickdata!=modd) continue;
+            if (gbpt->ClickAction[kMouseLeft]!=kGUIAction_SetMode) continue;
+            if (gbpt->ClickData[kMouseLeft]!=modd) continue;
             gbpt->Disable();
         }
     }

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -35,14 +35,14 @@ const char* Parser_SaidUnknownWord() {
     return CreateNewScriptString(play.bad_parsed_word);
 }
 
-void ParseText (char*text) {
+void ParseText (const char*text) {
     parse_sentence (text, &play.num_parsed_words, play.parsed_words, NULL, 0);
 }
 
 // Said: call with argument for example "get apple"; we then check
 // word by word if it matches (using dictonary ID equivalence to match
 // synonyms). Returns 1 if it does, 0 if not.
-int Said (char*checkwords) {
+int Said (const char *checkwords) {
     int numword = 0;
     short words[MAX_PARSED_WORDS];
     return parse_sentence (checkwords, &numword, &words[0], play.parsed_words, play.num_parsed_words);
@@ -82,7 +82,7 @@ int is_valid_word_char(char theChar) {
     return 0;
 }
 
-int FindMatchingMultiWordWord(char *thisword, char **text) {
+int FindMatchingMultiWordWord(char *thisword, const char **text) {
     // see if there are any multi-word words
     // that match -- if so, use them
     const char *tempptr = *text;
@@ -127,7 +127,8 @@ int FindMatchingMultiWordWord(char *thisword, char **text) {
 
 // parse_sentence: pass compareto as NULL to parse the sentence, or
 // compareto as non-null to check if it matches the passed sentence
-int parse_sentence (char*text, int *numwords, short*wordarray, short*compareto, int comparetonum) {
+char gl_ParserBuffer[1024]; // FIXME: might need to refactor the whole parser
+int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*compareto, int comparetonum) {
     char thisword[150] = "\0";
     int  i = 0, comparing = 0;
     char in_optional = 0, do_word_now = 0;
@@ -136,10 +137,11 @@ int parse_sentence (char*text, int *numwords, short*wordarray, short*compareto, 
     numwords[0] = 0;
     if (compareto == NULL)
         play.bad_parsed_word[0] = 0;
-    // [IKM] Now, this is extremely not smart; this string could come
-    // from anywhere, including script data, and we are changing it here
-    // FIXME!!!
-    strlwr(text);
+
+    snprintf(gl_ParserBuffer, sizeof(gl_ParserBuffer) - 1, "%s", src_text);
+    strlwr(gl_ParserBuffer);
+    const char *text = gl_ParserBuffer;
+
     while (1) {
         if ((compareto != NULL) && (compareto[comparing] == RESTOFLINE))
             return 1;

--- a/Engine/ac/parser.h
+++ b/Engine/ac/parser.h
@@ -20,14 +20,14 @@
 
 int Parser_FindWordID(const char *wordToFind);
 const char* Parser_SaidUnknownWord();
-void ParseText (char*text);
-int Said (char*checkwords);
+void ParseText (const char*text);
+int Said (const char*checkwords);
 
 //=============================================================================
 
 int find_word_in_dictionary (char *lookfor);
 int is_valid_word_char(char theChar);
-int FindMatchingMultiWordWord(char *thisword, char **text);
-int parse_sentence (char*text, int *numwords, short*wordarray, short*compareto, int comparetonum);
+int FindMatchingMultiWordWord(char *thisword, const char **text);
+int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*compareto, int comparetonum);
 
 #endif // __AGS_EE_AC__PARSER_H

--- a/Engine/ac/slider.cpp
+++ b/Engine/ac/slider.cpp
@@ -19,12 +19,12 @@
 
 void Slider_SetMax(GUISlider *guisl, int valn) {
 
-    if (valn != guisl->max) {
-        guisl->max = valn;
+    if (valn != guisl->MaxValue) {
+        guisl->MaxValue = valn;
 
-        if (guisl->value > guisl->max)
-            guisl->value = guisl->max;
-        if (guisl->min > guisl->max)
+        if (guisl->Value > guisl->MaxValue)
+            guisl->Value = guisl->MaxValue;
+        if (guisl->MinValue > guisl->MaxValue)
             quit("!Slider.Max: minimum cannot be greater than maximum");
 
         guis_need_update = 1;
@@ -33,17 +33,17 @@ void Slider_SetMax(GUISlider *guisl, int valn) {
 }
 
 int Slider_GetMax(GUISlider *guisl) {
-    return guisl->max;
+    return guisl->MaxValue;
 }
 
 void Slider_SetMin(GUISlider *guisl, int valn) {
 
-    if (valn != guisl->min) {
-        guisl->min = valn;
+    if (valn != guisl->MinValue) {
+        guisl->MinValue = valn;
 
-        if (guisl->value < guisl->min)
-            guisl->value = guisl->min;
-        if (guisl->min > guisl->max)
+        if (guisl->Value < guisl->MinValue)
+            guisl->Value = guisl->MinValue;
+        if (guisl->MinValue > guisl->MaxValue)
             quit("!Slider.Min: minimum cannot be greater than maximum");
 
         guis_need_update = 1;
@@ -52,58 +52,58 @@ void Slider_SetMin(GUISlider *guisl, int valn) {
 }
 
 int Slider_GetMin(GUISlider *guisl) {
-    return guisl->min;
+    return guisl->MinValue;
 }
 
 void Slider_SetValue(GUISlider *guisl, int valn) {
-    if (valn > guisl->max) valn = guisl->max;
-    if (valn < guisl->min) valn = guisl->min;
+    if (valn > guisl->MaxValue) valn = guisl->MaxValue;
+    if (valn < guisl->MinValue) valn = guisl->MinValue;
 
-    if (valn != guisl->value) {
-        guisl->value = valn;
+    if (valn != guisl->Value) {
+        guisl->Value = valn;
         guis_need_update = 1;
     }
 }
 
 int Slider_GetValue(GUISlider *guisl) {
-    return guisl->value;
+    return guisl->Value;
 }
 
 int Slider_GetBackgroundGraphic(GUISlider *guisl) {
-    return (guisl->bgimage > 0) ? guisl->bgimage : 0;
+    return (guisl->BgImage > 0) ? guisl->BgImage : 0;
 }
 
 void Slider_SetBackgroundGraphic(GUISlider *guisl, int newImage) 
 {
-    if (newImage != guisl->bgimage)
+    if (newImage != guisl->BgImage)
     {
-        guisl->bgimage = newImage;
+        guisl->BgImage = newImage;
         guis_need_update = 1;
     }
 }
 
 int Slider_GetHandleGraphic(GUISlider *guisl) {
-    return (guisl->handlepic > 0) ? guisl->handlepic : 0;
+    return (guisl->HandleImage > 0) ? guisl->HandleImage : 0;
 }
 
 void Slider_SetHandleGraphic(GUISlider *guisl, int newImage) 
 {
-    if (newImage != guisl->handlepic)
+    if (newImage != guisl->HandleImage)
     {
-        guisl->handlepic = newImage;
+        guisl->HandleImage = newImage;
         guis_need_update = 1;
     }
 }
 
 int Slider_GetHandleOffset(GUISlider *guisl) {
-    return guisl->handleoffset;
+    return guisl->HandleOffset;
 }
 
 void Slider_SetHandleOffset(GUISlider *guisl, int newOffset) 
 {
-    if (newOffset != guisl->handleoffset)
+    if (newOffset != guisl->HandleOffset)
     {
-        guisl->handleoffset = newOffset;
+        guisl->HandleOffset = newOffset;
         guis_need_update = 1;
     }
 }

--- a/Engine/ac/slider.h
+++ b/Engine/ac/slider.h
@@ -20,6 +20,8 @@
 
 #include "gui/guislider.h"
 
+using AGS::Common::GUISlider;
+
 void	Slider_SetMax(GUISlider *guisl, int valn);
 int		Slider_GetMax(GUISlider *guisl);
 void	Slider_SetMin(GUISlider *guisl, int valn);

--- a/Engine/ac/textbox.cpp
+++ b/Engine/ac/textbox.cpp
@@ -24,46 +24,46 @@ extern GameSetupStruct game;
 // ** TEXT BOX FUNCTIONS
 
 const char* TextBox_GetText_New(GUITextBox *texbox) {
-    return CreateNewScriptString(texbox->text);
+    return CreateNewScriptString(texbox->Text);
 }
 
 void TextBox_GetText(GUITextBox *texbox, char *buffer) {
-    strcpy(buffer, texbox->text);
+    strcpy(buffer, texbox->Text);
 }
 
 void TextBox_SetText(GUITextBox *texbox, const char *newtex) {
     if (strlen(newtex) > 190)
         quit("!SetTextBoxText: text too long");
 
-    if (strcmp(texbox->text, newtex)) {
-        strcpy(texbox->text, newtex);
+    if (strcmp(texbox->Text, newtex)) {
+        texbox->Text = newtex;
         guis_need_update = 1;
     }
 }
 
 int TextBox_GetTextColor(GUITextBox *guit) {
-    return guit->textcol;
+    return guit->TextColor;
 }
 
 void TextBox_SetTextColor(GUITextBox *guit, int colr)
 {
-    if (guit->textcol != colr) 
+    if (guit->TextColor != colr) 
     {
-        guit->textcol = colr;
+        guit->TextColor = colr;
         guis_need_update = 1;
     }
 }
 
 int TextBox_GetFont(GUITextBox *guit) {
-    return guit->font;
+    return guit->Font;
 }
 
 void TextBox_SetFont(GUITextBox *guit, int fontnum) {
     if ((fontnum < 0) || (fontnum >= game.numfonts))
         quit("!SetTextBoxFont: invalid font number.");
 
-    if (guit->font != fontnum) {
-        guit->font = fontnum;
+    if (guit->Font != fontnum) {
+        guit->Font = fontnum;
         guis_need_update = 1;
     }
 }

--- a/Engine/ac/textbox.h
+++ b/Engine/ac/textbox.h
@@ -20,6 +20,8 @@
 
 #include "gui/guitextbox.h"
 
+using AGS::Common::GUITextBox;
+
 const char*	TextBox_GetText_New(GUITextBox *texbox);
 void		TextBox_GetText(GUITextBox *texbox, char *buffer);
 void		TextBox_SetText(GUITextBox *texbox, const char *newtex);

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -160,21 +160,13 @@ void GUIListBox::PrepareTextToDraw(const String &text)
         _textToDraw = text;
 }
 
+void GUIButton::PrepareTextToDraw()
+{
+    if (flags & GUIF_TRANSLATED)
+        _textToDraw = get_translation(_text);
+    else
+        _textToDraw = _text;
+}
+
 } // namespace Common
 } // namespace AGS
-
-void GUIButton::Draw_set_oritext(char *oritext, const char *text)
-{
-  // Allow it to change the string to unicode if it's TTF
-    if (flags & GUIF_TRANSLATED)
-    {
-        strcpy(oritext, get_translation(text));
-    }
-    else
-    {
-        strcpy(oritext, text);
-    }
-    ensure_text_valid_for_font(oritext, font);
-
-  // oritext is assumed to be made long enough by caller function
-}

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -145,34 +145,26 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
     }
 }
 
+void GUIListBox::DrawItemsFix()
+{
+  // do nothing
+}
+
+void GUIListBox::DrawItemsUnfix()
+{
+  // do nothing
+}
+
+void GUIListBox::PrepareTextToDraw(const String &text)
+{
+    if (flags & GUIF_TRANSLATED)
+        _textToDraw = get_translation(text);
+    else
+        _textToDraw = text;
+}
+
 } // namespace Common
 } // namespace AGS
-
-void GUIListBox::Draw_items_fix()
-{
-  // do nothing
-}
-
-void GUIListBox::Draw_items_unfix()
-{
-  // do nothing
-}
-
-void GUIListBox::Draw_set_oritext(char *oritext, const char *text)
-{
-    // Allow it to change the string to unicode if it's TTF
-    if (flags & GUIF_TRANSLATED)
-    {
-        strcpy(oritext, get_translation(text));
-    }
-    else
-    {
-        strcpy(oritext, text);
-    }
-    ensure_text_valid_for_font(oritext, font);
-
-    // oritext is assumed to be made long enough by caller function
-}
 
 void GUIButton::Draw_set_oritext(char *oritext, const char *text)
 {

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -34,11 +34,11 @@
 #include "gfx/bitmap.h"
 #include "gfx/blender.h"
 
-using namespace Common;
+using namespace AGS::Common;
 
 // For engine these are defined in ac.cpp
 extern int eip_guiobj;
-extern void replace_macro_tokens(const char*,char*);
+extern void replace_macro_tokens(const char*, String&);
 
 // For engine these are defined in acfonts.cpp
 extern void ensure_text_valid_for_font(char *, int);
@@ -112,26 +112,23 @@ int get_eip_guiobj()
 
 bool outlineGuiObjects = false;
 
-void GUILabel::Draw_replace_macro_tokens(char *oritext, const char *text)
-{
-  replace_macro_tokens(flags & GUIF_TRANSLATED ? get_translation(text) : text, oritext);
-  ensure_text_valid_for_font(oritext, font);
-}
-
-void GUILabel::Draw_split_lines(char *teptr, int wid, int font, int &numlines)
-{
-  // Use the engine's word wrap tool, to have hebrew-style writing
-  // and other features
-
-  break_up_text_into_lines (wid, font, teptr);
-
-  // [IKM] numlines not used in engine's implementation
-}
-
 namespace AGS
 {
 namespace Common
 {
+
+void GUILabel::PrepareTextToDraw()
+{
+    replace_macro_tokens(flags & GUIF_TRANSLATED ? get_translation(Text) : Text, _textToDraw);
+}
+
+int GUILabel::SplitLinesForDrawing()
+{
+    // Use the engine's word wrap tool, to have hebrew-style writing
+    // and other features
+    break_up_text_into_lines(wid, Font, _textToDraw);
+    return numlines;
+}
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
 {

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -128,19 +128,25 @@ void GUILabel::Draw_split_lines(char *teptr, int wid, int font, int &numlines)
   // [IKM] numlines not used in engine's implementation
 }
 
-void GUITextBox::Draw_text_box_contents(Bitmap *ds, color_t text_color)
+namespace AGS
 {
-  int startx, starty;
+namespace Common
+{
 
-  wouttext_outline(ds, x + 1 + get_fixed_pixel_size(1), y + 1 + get_fixed_pixel_size(1), font, text_color, text);
-  
-  if (!IsDisabled()) {
-    // draw a cursor
-    startx = wgettextwidth(text, font) + x + 3;
-    starty = y + 1 + getfontheight(font);
-    ds->DrawRect(Rect(startx, starty, startx + get_fixed_pixel_size(5), starty + (get_fixed_pixel_size(1) - 1)), text_color);
-  }
+void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
+{
+    wouttext_outline(ds, x + 1 + get_fixed_pixel_size(1), y + 1 + get_fixed_pixel_size(1), Font, text_color, Text);
+    if (!IsDisabled())
+    {
+        // draw a cursor
+        int draw_at_x = wgettextwidth(Text, Font) + x + 3;
+        int draw_at_y = y + 1 + getfontheight(Font);
+        ds->DrawRect(Rect(draw_at_x, draw_at_y, draw_at_x + get_fixed_pixel_size(5), draw_at_y + (get_fixed_pixel_size(1) - 1)), text_color);
+    }
 }
+
+} // namespace Common
+} // namespace AGS
 
 void GUIListBox::Draw_items_fix()
 {

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -71,11 +71,6 @@ bool GUIMain::HasAlphaChannel() const
 // Engine-specific implementation split out of acgui.h
 //=============================================================================
 
-int GUIObject::IsClickable()
-{
-  return !(flags & GUIF_NOCLICKS);
-}
-
 void check_font(int *fontnum)
 {
     // do nothing
@@ -117,27 +112,32 @@ namespace AGS
 namespace Common
 {
 
+bool GUIObject::IsClickable() const
+{
+    return !(Flags & kGUICtrl_NoClicks);
+}
+
 void GUILabel::PrepareTextToDraw()
 {
-    replace_macro_tokens(flags & GUIF_TRANSLATED ? get_translation(Text) : Text, _textToDraw);
+    replace_macro_tokens(Flags & kGUICtrl_Translated ? get_translation(Text) : Text, _textToDraw);
 }
 
 int GUILabel::SplitLinesForDrawing()
 {
     // Use the engine's word wrap tool, to have hebrew-style writing
     // and other features
-    break_up_text_into_lines(wid, Font, _textToDraw);
+    break_up_text_into_lines(Width, Font, _textToDraw);
     return numlines;
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
 {
-    wouttext_outline(ds, x + 1 + get_fixed_pixel_size(1), y + 1 + get_fixed_pixel_size(1), Font, text_color, Text);
-    if (!IsDisabled())
+    wouttext_outline(ds, X + 1 + get_fixed_pixel_size(1), Y + 1 + get_fixed_pixel_size(1), Font, text_color, Text);
+    if (IsEnabled())
     {
         // draw a cursor
-        int draw_at_x = wgettextwidth(Text, Font) + x + 3;
-        int draw_at_y = y + 1 + getfontheight(Font);
+        int draw_at_x = wgettextwidth(Text, Font) + X + 3;
+        int draw_at_y = Y + 1 + getfontheight(Font);
         ds->DrawRect(Rect(draw_at_x, draw_at_y, draw_at_x + get_fixed_pixel_size(5), draw_at_y + (get_fixed_pixel_size(1) - 1)), text_color);
     }
 }
@@ -154,7 +154,7 @@ void GUIListBox::DrawItemsUnfix()
 
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
-    if (flags & GUIF_TRANSLATED)
+    if (Flags & kGUICtrl_Translated)
         _textToDraw = get_translation(text);
     else
         _textToDraw = text;
@@ -162,7 +162,7 @@ void GUIListBox::PrepareTextToDraw(const String &text)
 
 void GUIButton::PrepareTextToDraw()
 {
-    if (flags & GUIF_TRANSLATED)
+    if (Flags & kGUICtrl_Translated)
         _textToDraw = get_translation(_text);
     else
         _textToDraw = _text;

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -101,9 +101,9 @@ void adjust_sizes_for_resolution(int filever)
 
         for (ff = 0; ff < cgp->ControlCount; ff++) 
         {
-            adjust_pixel_sizes_for_loaded_data(&cgp->Controls[ff]->x, &cgp->Controls[ff]->y, filever);
-            adjust_pixel_sizes_for_loaded_data(&cgp->Controls[ff]->wid, &cgp->Controls[ff]->hit, filever);
-            cgp->Controls[ff]->activated=0;
+            adjust_pixel_sizes_for_loaded_data(&cgp->Controls[ff]->X, &cgp->Controls[ff]->Y, filever);
+            adjust_pixel_sizes_for_loaded_data(&cgp->Controls[ff]->Width, &cgp->Controls[ff]->Height, filever);
+            cgp->Controls[ff]->IsActivated = false;
         }
     }
 

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -120,8 +120,8 @@ void adjust_sizes_for_resolution(int filever)
 
         for (ee = 0; ee < numguiinv; ee++)
         {
-            guiinv[ee].itemWidth /= 2;
-            guiinv[ee].itemHeight /= 2;
+            guiinv[ee].ItemWidth /= 2;
+            guiinv[ee].ItemHeight /= 2;
         }
     }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -470,11 +470,11 @@ void check_controls() {
                             continue;
                         GUITextBox*guitex=(GUITextBox*)guis[uu].Controls[ww];
                         // if the text box is disabled, it cannot except keypresses
-                        if ((guitex->IsDisabled()) || (!guitex->IsVisible()))
+                        if ((!guitex->IsEnabled()) || (!guitex->IsVisible()))
                             continue;
-                        guitex->KeyPress(kgn);
-                        if (guitex->activated) {
-                            guitex->activated = 0;
+                        guitex->OnKeyPress(kgn);
+                        if (guitex->IsActivated) {
+                            guitex->IsActivated = false;
                             setevent(EV_IFACECLICK, uu, ww, 1);
                         }
                         keywasprocessed = 1;


### PR DESCRIPTION
I am awfully sorry for doing this (sort of), but it was too hard to "let it go" when you have an almost ready piece of work that took you many days to do. So, I decided to recreate the (almost 2 years old) branch which refactors GUI Control classes.

Luckily, there were only several conflicts to resolve (the related code did not change much since the old branch was first made), and I found and fixed only couple of minor mistakes so far.

As this is refactoring, the new code is supposed to be functionally similar to an old one. Classes are tidied, and brought to general code style; some optimization is done along the way.

Notable addition is an introduction of generic FrameAlignment flags which substitute varied alignment types in Buttons, Labels and ListBox.

The code in this branch was written with the idea to keep compatibility in all known ways; but I guess it won't be hard to remove if wanted. (Adjustments to how Editor saves GUI would be required too in such case)