### PR TITLE
Linux: use nanosleep for CPU yield

### DIFF
--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -139,7 +139,10 @@ const char *AGSLinux::GetAppOutputDirectory()
 }
 
 void AGSLinux::Delay(int millis) {
-  usleep(millis);
+  struct timespec ts;
+  ts.tv_sec = 0;
+  ts.tv_nsec = millis * 1000000;
+  nanosleep(&ts, NULL);
 }
 
 unsigned long AGSLinux::GetDiskFreeSpaceMB() {


### PR DESCRIPTION
This replaces the sleep function in the Linux platform driver, which is called by platform->YieldCPU() in the main game loop. In testing I'm seeing a CPU usage reduction of between 5% and 10% and no other side effects, having built against the AGS Allegro fork. The kernel has supported this for a long time so I think it's pretty safe to switch.