### PR TITLE
Prevent crashes when dealing with unprintable symbols

### DIFF
--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -149,19 +149,27 @@ int symbolTable::find(const char*ntf) {
 }
 
 std::string symbolTable::get_friendly_name(int idx) {
-    std::string result = entries[idx & STYPE_MASK].sname;
+    std::string result;
 
-    if (idx & STYPE_POINTER) {
-        result = result + std::string("*");
-    }
+    idx &= STYPE_MASK;
+    if(idx > -1 && idx < entries.size()) {
+        result = entries[idx].sname;
 
-    if (idx & STYPE_DYNARRAY) {
-        result = result + std::string("[]");
-    }
+        if (idx & STYPE_POINTER) {
+            result = result + std::string("*");
+        }
 
-    if (idx & STYPE_CONST) {
-        result = std::string("const ") + result;
+        if (idx & STYPE_DYNARRAY) {
+            result = result + std::string("[]");
+        }
+
+        if (idx & STYPE_CONST) {
+            result = std::string("const ") + result;
+        }
+
     }
+    else
+        result = std::string("(invalid symbol)");
 
     return result;
 }

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -3367,6 +3367,8 @@ int parse_variable_declaration(long cursym,int *next_type,int isglobal,
     targ->getnext();  // skip the comma
     return 2;
     }
+  if (check_not_eof(*targ))
+    return -1;
   if (next_type[0] != SYM_SEMICOLON) {
     cc_error("Expected ',' or ';', not '%s'",sym.get_friendly_name(targ->peeknext()).c_str());
     return -1;
@@ -4212,6 +4214,8 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                     sym.entries[cursym].soffs, sym.entries[cursym].sscope) == -1) {
                         return -1;
                 }
+                if (check_not_eof(targ))
+                  return -1;
                 cursym = targ.getnext();
                 if (sym.get_type(cursym) == SYM_SEMICOLON) break;
                 if (sym.get_type(cursym) != SYM_COMMA) {


### PR DESCRIPTION
This relates to the bug reported here:

http://www.adventuregamestudio.co.uk/forums/index.php?issue=825.0

The behaviour of get_friendly_name did not exactly match the get_name it replaced.

There are some areas in the compiler where it assumes the next symbol is valid to print. These are errors in the compiler's logic, but whereas get_name would give the reasonable output "const (null)", get_friendly_name causes a crash.

Note: This was likely because sprintf dealt with a null c-style string pointer and output "(null)".

This new behaviour isn't perfect, but it's better than hard crashes when there are errors in the compiler logic. When there is a problem getting the name of a symbol, it will now be shown as "(invalid symbol)", and we can fix these issues as we find them.

I also added two EOF checks to address the specific cases mentioned on the bug report page.