### PR TITLE
Encase whole savedgame's component list in tags

### DIFF
--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -131,6 +131,10 @@ String GetSavegameErrorText(SavegameError err)
         return "Save was written by incompatible engine, or file is corrupted";
     case kSvgErr_GameGuidMismatch:
         return "Game GUID does not match, saved by a different game";
+    case kSvgErr_ComponentListOpeningTagFormat:
+        return "Failed to parse opening tag of the components list";
+    case kSvgErr_ComponentListClosingTagMissing:
+        return "Closing tag of the components list was not met";
     case kSvgErr_ComponentOpeningTagFormat:
         return "Failed to parse opening component tag";
     case kSvgErr_ComponentClosingTagFormat:

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -60,6 +60,8 @@ enum SavegameError
     kSvgErr_FormatVersionNotSupported,
     kSvgErr_IncompatibleEngine,
     kSvgErr_GameGuidMismatch,
+    kSvgErr_ComponentListOpeningTagFormat,
+    kSvgErr_ComponentListClosingTagMissing,
     kSvgErr_ComponentOpeningTagFormat,
     kSvgErr_ComponentClosingTagFormat,
     kSvgErr_ComponentSizeMismatch,
@@ -71,7 +73,6 @@ enum SavegameError
     kSvgErr_InconsistentPlugin,
     kSvgErr_DifferentColorDepth,
     kSvgErr_GameObjectInitFailed,
-    kSvgErr_ExpectedEOS,
     kNumSavegameError
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -76,6 +76,8 @@ namespace Engine
 namespace SavegameComponents
 {
 
+const String ComponentListTag = "Components";
+
 void WriteFormatTag(PStream out, const String &tag, bool open = true)
 {
     String full_tag = String::FromFormat(open ? "<%s>" : "</%s>", tag.GetCStr());
@@ -1074,11 +1076,8 @@ SavegameError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &in
     size_t pos = in->GetPosition();
     info = ComponentInfo(); // reset in case of early error
     info.Offset = in->GetPosition();
-    if (!ReadFormatTag(in, info.Name, true)) {
-        if (in->EOS())
-            return kSvgErr_ExpectedEOS; // report end of stream (expected case)
+    if (!ReadFormatTag(in, info.Name, true))
         return kSvgErr_ComponentOpeningTagFormat;
-    }
     info.Version = in->ReadInt32();
     info.DataSize = in->ReadInt32();
     info.DataOffset = in->GetPosition();
@@ -1108,21 +1107,32 @@ SavegameError ReadAll(PStream in, SavegameVersion svg_version, const PreservedPa
     SvgCmpReadHelper hlp(svg_version, pp, r_data);
     GenerateHandlersMap(hlp.Handlers);
 
-    while (!in->EOS())
+    size_t idx = 0;
+    if (!AssertFormatTag(in, ComponentListTag, true))
+        return kSvgErr_ComponentListOpeningTagFormat;
+    do
     {
+        // Look out for the end of the component list:
+        // this is the only way how this function ends with success
+        size_t off = in->GetPosition();
+        if (AssertFormatTag(in, ComponentListTag, false))
+            return kSvgErr_NoError;
+        // If the list's end was not detected, then seek back and continue reading
+        in->Seek(off, kSeekBegin);
+
         ComponentInfo info;
         SavegameError err = ReadComponent(in, hlp, info);
-        if (err == kSvgErr_ExpectedEOS)
-            break; // this is normal
         if (err != kSvgErr_NoError)
         {
-            Debug::Printf(kDbgMsg_Error, "ERROR: failed to read savegame component: type = %s, version = %i, at offset = %u",
-                info.Name.GetCStr(), info.Version, info.Offset);
+            Debug::Printf(kDbgMsg_Error, "ERROR: failed to read savegame component: index = %d, type = %s, version = %i, at offset = %u",
+                idx, info.Name.IsEmpty() ? "unknown" : info.Name.GetCStr(), info.Version, info.Offset);
             return err;
         }
         update_polled_stuff_if_runtime();
+        idx++;
     }
-    return kSvgErr_NoError;
+    while (!in->EOS());
+    return kSvgErr_ComponentListClosingTagMissing;
 }
 
 SavegameError WriteComponent(PStream out, ComponentHandler &hdlr)
@@ -1143,6 +1153,7 @@ SavegameError WriteComponent(PStream out, ComponentHandler &hdlr)
 
 SavegameError WriteAllCommon(PStream out)
 {
+    WriteFormatTag(out, ComponentListTag, true);
     for (int type = 0; !ComponentHandlers[type].Name.IsEmpty(); ++type)
     {
         SavegameError err = WriteComponent(out, ComponentHandlers[type]);
@@ -1153,6 +1164,7 @@ SavegameError WriteAllCommon(PStream out)
         }
         update_polled_stuff_if_runtime();
     }
+    WriteFormatTag(out, ComponentListTag, false);
     return kSvgErr_NoError;
 }
 


### PR DESCRIPTION
Added tags which explicitly mark the beginning and the end of the components data list in the savedgame.
Components are now read until the end of list is found, as opposed to end of file.

This should resolve the error caused by screenshots with the new save format (https://github.com/adventuregamestudio/ags/pull/413#issuecomment-339395427), which are appended to the end of file.