### PR TITLE
this commit updates the Android port to use ndk-bundle/platforms/andr…

### DIFF
--- a/Android/buildlibs/armeabi-v7a/ndkenv
+++ b/Android/buildlibs/armeabi-v7a/ndkenv
@@ -5,7 +5,7 @@ get_abs_path() {
 
 unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
 
-export NDK_PLATFORM_ROOT=/opt/android-ndk-r10e-standalone/android-9/arm
+export NDK_PLATFORM_ROOT=~/Android/Sdk/ndk-bundle/platforms/android-14/arm
 export NDK_PLATFORM_NAME=armeabi-v7a
 export NDK_HOST_NAME=arm-linux-androideabi
 export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
@@ -15,3 +15,5 @@ export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
 
 export NDK_CFLAGS=" -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 "
 export NDK_LDFLAGS=" -march=armv7-a -Wl,--fix-cortex-a8 "
+export CC=~/Android/Sdk/ndk-bundle/platforms/android-14/arm/bin/arm-linux-androideabi-gcc
+export CXX=~/Android/Sdk/ndk-bundle/platforms/android-14/arm/bin/arm-linux-androideabi-g++ 

--- a/Android/buildlibs/armeabi-v7a/ogg.sh
+++ b/Android/buildlibs/armeabi-v7a/ogg.sh
@@ -11,7 +11,7 @@ tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
 
 pushd $SRC_DIR
 
-export CFLAGS="$NDK_CFLAGS -fsigned-char"
+export CFLAGS="$NDK_CFLAGS -fsigned-char -D__ANDROID_API__=\$API"
 export LDFLAGS="$NDK_LDFLAGS"
 
 ./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared

--- a/Android/buildlibs/armeabi/ndkenv
+++ b/Android/buildlibs/armeabi/ndkenv
@@ -5,7 +5,7 @@ get_abs_path() {
 
 unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
 
-export NDK_PLATFORM_ROOT=/opt/android-ndk-r10e-standalone/android-9/arm
+export NDK_PLATFORM_ROOT=~/Android/Sdk/ndk-bundle/platforms/android-14/arm
 export NDK_PLATFORM_NAME=armeabi
 export NDK_HOST_NAME=arm-linux-androideabi
 export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
@@ -14,3 +14,5 @@ export PKG_CONFIG_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/lib/pkgconfig
 export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
 
 export NDK_CFLAGS=" -mthumb "
+export CC=~/Android/Sdk/ndk-bundle/platforms/android-14/arm/bin/arm-linux-androideabi-gcc
+export CXX=~/Android/Sdk/ndk-bundle/platforms/android-14/arm/bin/arm-linux-androideabi-g++  

--- a/Android/buildlibs/armeabi/ogg.sh
+++ b/Android/buildlibs/armeabi/ogg.sh
@@ -11,7 +11,7 @@ tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
 
 pushd $SRC_DIR
 
-export CFLAGS="$NDK_CFLAGS -fsigned-char" 
+export CFLAGS="$NDK_CFLAGS -fsigned-char -D__ANDROID_API__=\$API" 
 export LDFLAGS="$NDK_LDFLAGS"
 
 ./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared

--- a/Android/buildlibs/makestandalones.sh
+++ b/Android/buildlibs/makestandalones.sh
@@ -5,18 +5,18 @@
 set -e
 
 # Last committed pre-compiled libs were with R8
-NDK_HOME=/opt/android-ndk-r10e
+NDK_HOME=~/Android/Sdk/ndk-bundle
 
 # android-9 is minimum to support mips and x86
-PLATFORM=android-9
+PLATFORM=android-14
 
 # standalone toolchains cannot share same directory
-NDK_STANDALONE=/opt/android-ndk-r10e-standalone/$PLATFORM
+NDK_STANDALONE=~/Android/Sdk/ndk-bundle/platforms/$PLATFORM
 
 for arch in arm x86 mips
 do
     INSTALL_DIR=$NDK_STANDALONE/$arch
     mkdir -p $INSTALL_DIR
-    $NDK_HOME/build/tools/make-standalone-toolchain.sh --platform=$PLATFORM --install-dir=$INSTALL_DIR --arch=$arch
+    $NDK_HOME/build/tools/make-standalone-toolchain.sh  --force --platform=$PLATFORM --install-dir=$INSTALL_DIR --arch=$arch
 done
 

--- a/Android/buildlibs/mips/ndkenv
+++ b/Android/buildlibs/mips/ndkenv
@@ -5,7 +5,7 @@ get_abs_path() {
 
 unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
 
-export NDK_PLATFORM_ROOT=/opt/android-ndk-r10e-standalone/android-9/mips
+export NDK_PLATFORM_ROOT=~/Android/Sdk/ndk-bundle/platforms/android-14/mips
 export NDK_PLATFORM_NAME=mips
 export NDK_HOST_NAME=mipsel-linux-android
 export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
@@ -15,3 +15,5 @@ export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
 
 # NDK before R8b turns on "-mno-shared" in MIPS toolchain which disables -fpic
 export NDK_CFLAGS=" -fpic "
+export CC=~/Android/Sdk/ndk-bundle/platforms/android-14/mips/bin/mipsel-linux-android-gcc
+export CXX=~/Android/Sdk/ndk-bundle/platforms/android-14/mips/bin/mipsel-linux-android-g++  

--- a/Android/buildlibs/mips/ogg.sh
+++ b/Android/buildlibs/mips/ogg.sh
@@ -11,7 +11,7 @@ tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
 
 pushd $SRC_DIR
 
-export CFLAGS="$NDK_CFLAGS -fsigned-char"
+export CFLAGS="$NDK_CFLAGS -fsigned-char -D__ANDROID_API__=\$API"
 export LDFLAGS="$NDK_LDFLAGS"
 
 ./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared

--- a/Android/buildlibs/x86/ndkenv
+++ b/Android/buildlibs/x86/ndkenv
@@ -5,10 +5,14 @@ get_abs_path() {
 
 unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
 
-export NDK_PLATFORM_ROOT=/opt/android-ndk-r10e-standalone/android-9/x86
+export NDK_PLATFORM_ROOT=~/Android/Sdk/ndk-bundle/platforms/android-14/x86
 export NDK_PLATFORM_NAME=x86
 export NDK_HOST_NAME=i686-linux-android
 export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
 export PATH=$NDK_PLATFORM_ROOT/bin:$PATH
 export PKG_CONFIG_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/lib/pkgconfig
 export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
+
+
+export CC=~/Android/Sdk/ndk-bundle/platforms/android-14/x86/bin/i686-linux-android-gcc
+export CXX=~/Android/Sdk/ndk-bundle/platforms/android-14/x86/bin/i686-linux-android-g++  

--- a/Android/buildlibs/x86/ogg.sh
+++ b/Android/buildlibs/x86/ogg.sh
@@ -11,7 +11,7 @@ tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
 
 pushd $SRC_DIR
 
-export CFLAGS="$NDK_CFLAGS -fsigned-char"
+export CFLAGS="$NDK_CFLAGS -fsigned-char -D__ANDROID_API__=\$API"
 export LDFLAGS="$NDK_LDFLAGS"
 
 ./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared

--- a/Android/patches/liblua.patch
+++ b/Android/patches/liblua.patch
@@ -20,7 +20,8 @@ diff -Naur src/Makefile src/Makefile
  PLAT= none
  
 -CC= gcc
- CFLAGS= -O2 -Wall $(MYCFLAGS)
+-CFLAGS= -O2 -Wall $(MYCFLAGS)
++CFLAGS= -O2 -Wall $(MYCFLAGS) -D__ANDROID_API__=$AP
  AR= ar rcu
  RANLIB= ranlib
  RM= rm -f


### PR DESCRIPTION
pull request for building AGS Engine for Android 

Forum Thread here: http://www.adventuregamestudio.co.uk/forums/index.php?topic=44768.msg636581163#msg636581163

My environment is Ubuntu 16.04 and I used the Android Sdk and ndk installed through Android Studio 3.0.1.

    uname -a
    Linux  4.13.0-32-generic #35~16.04.1-Ubuntu SMP Thu Jan 25 10:13:43 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

details of my Android Studio : 

    Android Studio 3.0.1
    Build #AI-171.4443003, built on November 9, 2017
    JRE: 1.8.0_152-release-915-b01 amd64
    JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
    Linux 4.13.0-32-generic

Commands I used to build:

    export PATH=$PATH:~/Android/Sdk/ndk-bundle/
    cd git/ags/Android/buildlibs/
    ./makestandalones.sh 
    ./buildall.sh 
    cd ../library/
    ndk-build 
