### PR TITLE
Android: upgraded OpenGL renderer to GLES2 and fixed compilation

### DIFF
--- a/Android/library/jni/Android.mk
+++ b/Android/library/jni/Android.mk
@@ -16,7 +16,7 @@ LOCAL_MODULE    := agsengine
 LOCAL_SRC_FILES := $(BASE) $(BASE_PLATFORM) $(COMMON) $(COMMON_PLATFORM) $(ALFONT) $(ALMP3) $(ALOGG) $(APEG) $(AASTR) $(AL_MIDI_PATCH)
 LOCAL_CFLAGS    := -g -ffast-math -fsigned-char -Wall -Wfatal-errors -Wno-deprecated-declarations -Wno-psabi -DAGS_INVERTED_COLOR_ORDER -DALLEGRO_STATICLINK -DANDROID_VERSION -DDISABLE_MPEG_AUDIO -DUSE_TREMOR -I$(ADDITIONAL_LIBRARY_PATH)/include -I$(ADDITIONAL_LIBRARY_PATH)/include/freetype2 -I$(AGS_ENGINE_PATH) -I$(AGS_COMMON_PATH) -I$(AGS_COMMON_PATH)/libinclude
 LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
-LOCAL_LDLIBS    := -Wl,-Bstatic -lalleg -lfreetype -lvorbisidec -ltheora -logg -laldmb -ldumb -lstdc++ -Wl,-Bdynamic -lc -ldl -lm -lz -llog -lGLESv1_CM
+LOCAL_LDLIBS    := -Wl,-Bstatic -lalleg -lfreetype -lvorbisidec -ltheora -logg -laldmb -ldumb -lstdc++ -Wl,-Bdynamic -lc -ldl -lm -lz -llog -lGLESv1_CM -lGLESv2
 LOCAL_LDFLAGS   := -Wl,-L$(ADDITIONAL_LIBRARY_PATH)/lib,--allow-multiple-definition
 LOCAL_ARM_MODE  := arm
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -120,6 +120,9 @@ const char* fbo_extension_string = "GL_OES_framebuffer_object";
 #define glGenerateMipmapEXT glGenerateMipmapOES
 #define glFramebufferTexture2DEXT glFramebufferTexture2DOES
 #define glFramebufferRenderbufferEXT glFramebufferRenderbufferOES
+// TODO: probably should use EGL and function eglSwapInterval on Android to support setting swap interval
+// For now this is a dummy function pointer which is only used to test that function is not supported
+const void (*glSwapIntervalEXT)(int) = NULL;
 
 #define GL_FRAMEBUFFER_EXT GL_FRAMEBUFFER_OES
 #define GL_COLOR_ATTACHMENT0_EXT GL_COLOR_ATTACHMENT0_OES
@@ -160,6 +163,9 @@ const char* fbo_extension_string = "GL_OES_framebuffer_object";
 #define glGenerateMipmapEXT glGenerateMipmapOES
 #define glFramebufferTexture2DEXT glFramebufferTexture2DOES
 #define glFramebufferRenderbufferEXT glFramebufferRenderbufferOES
+// TODO: find out how to support swap interval setting on iOS
+// For now this is a dummy function pointer which is only used to test that function is not supported
+const void (*glSwapIntervalEXT)(int) = NULL;
 
 #define GL_FRAMEBUFFER_EXT GL_FRAMEBUFFER_OES
 #define GL_COLOR_ATTACHMENT0_EXT GL_COLOR_ATTACHMENT0_OES
@@ -531,22 +537,25 @@ void OGLGraphicsDriver::DeleteGlContext()
 
 void OGLGraphicsDriver::TestVSync()
 {
+// TODO: find out how to implement SwapInterval on other platforms, and how to check if it's supported
+#if defined(WINDOWS_VERSION)
   const char* extensions = (const char*)glGetString(GL_EXTENSIONS);
   const char* extensionsARB = NULL;
-#if defined(WINDOWS_VERSION)
+//#if defined(WINDOWS_VERSION)
   PFNWGLGETEXTENSIONSSTRINGARBPROC wglGetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
   extensionsARB = wglGetExtensionsStringARB ? (const char*)wglGetExtensionsStringARB(_hDC) : NULL;
-#endif
+//#endif
 
   if (extensions && strstr(extensions, vsync_extension_string) != NULL ||
         extensionsARB && strstr(extensionsARB, vsync_extension_string) != NULL)
   {
-#if defined(WINDOWS_VERSION)
+//#if defined(WINDOWS_VERSION)
     glSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
-#endif
+//#endif
   }
   if (!glSwapIntervalEXT)
     Debug::Printf(kDbgMsg_Warn, "WARNING: OpenGL extension '%s' not supported, vertical sync will be kept at driver default.", vsync_extension_string);
+#endif
 }
 
 void OGLGraphicsDriver::TestRenderToTexture()

--- a/Engine/gfx/ogl_headers.h
+++ b/Engine/gfx/ogl_headers.h
@@ -33,11 +33,13 @@
 #elif defined(ANDROID_VERSION)
 
 #include <GLES/gl.h>
+#include <GLES2/gl2.h>
 
 #ifndef GL_GLEXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES
 #endif
 
+// TODO: we probably should not use GLExt since we use GLES2
 #include <GLES/glext.h>
 
 #define HDC void*


### PR DESCRIPTION
Upgrade OpenGL renderer to use GLES2 on Android, which fixes compilation of the engine v3.4.1.
This should partially solve #420 (still not resolved for iOS).

According to the statistics [posted on Android devs page](https://developer.android.com/about/dashboards/index.html#OpenGL) GLES2 is supposed to be present on more than 99% of devices in use.