### PR TITLE
Apply Editor message box preferences to 'successful compilation'

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1020,9 +1020,9 @@ namespace AGS.Editor
 			}
 			else if (errors.Count > 0)
 			{
-				if (_applicationSettings.MessageBoxOnCompile == MessageBoxOnCompile.WarningsAndErrors)
-				{
-					Factory.GUIController.ShowMessage("There were warnings compiling your game. See the output window for details.", MessageBoxIcon.Warning);
+				if (_applicationSettings.MessageBoxOnCompile != MessageBoxOnCompile.Never && _applicationSettings.MessageBoxOnCompile != MessageBoxOnCompile.OnlyErrors)
+                {
+                    Factory.GUIController.ShowMessage("There were warnings compiling your game. See the output window for details.", MessageBoxIcon.Warning);
 				}
 			}
 		}

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
+using AGS.Editor.Preferences;
 
 namespace AGS.Editor.Components
 {
@@ -237,7 +238,14 @@ namespace AGS.Editor.Components
 			{
 				if (_agsEditor.CompileGame(forceRebuild, false).Count == 0)
 				{
-					_guiController.ShowMessage("Compile successful!", MessageBoxIcon.Information);
+					string success = "Compilation successful!";
+					string[] messages = new string[] { success };
+					Factory.GUIController.ShowOutputPanel(messages);
+
+					if (_agsEditor.Settings.MessageBoxOnCompile == MessageBoxOnCompile.Always)
+					{
+						_guiController.ShowMessage(success, MessageBoxIcon.Information);
+					}
 				}
 			}
 		}

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -18,9 +18,10 @@ namespace AGS.Editor.Preferences
     [Flags]
     public enum MessageBoxOnCompile
     {
-        WarningsAndErrors = 0,
-        OnlyErrors = 1,
-        Never = 2
+        Always = 0,
+        WarningsAndErrors = 1,
+        OnlyErrors = 2,
+        Never = 3
     }
 
     [Flags]

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -316,6 +316,12 @@ namespace AGS.Editor
             }
         }
 
+        public void ShowOutputPanel(string[] messages)
+        {
+            _mainForm.pnlOutput.SetMessages(messages);
+            _mainForm.pnlOutput.Show();
+        }
+
         public void ClearOutputPanel()
         {
             _mainForm.pnlOutput.ErrorsToList = null;
@@ -752,6 +758,7 @@ namespace AGS.Editor
                 AutoComplete.BackgroundCacheUpdateStatusChanged += new AutoComplete.BackgroundCacheUpdateStatusChangedHandler(AutoComplete_BackgroundCacheUpdateStatusChanged);
 				SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanging);
 
+                RegisterIcon("BuildIcon", Resources.ResourceManager.GetIcon("menu_build_rebuild-files.ico"));
                 RegisterIcon("GameIcon", Resources.ResourceManager.GetIcon("game.ico"));
 				RegisterIcon("CompileErrorIcon", Resources.ResourceManager.GetIcon("eventlogError.ico"));
 				RegisterIcon("CompileWarningIcon", Resources.ResourceManager.GetIcon("eventlogWarn.ico"));

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -26,6 +26,15 @@ namespace AGS.Editor
 			lvwResults.SmallImageList = list;
 		}
 
+        public void SetMessages(string[] messages)
+        {
+            foreach (string message in messages)
+            {
+                ListViewItem newItem = lvwResults.Items.Add(message);
+                newItem.ImageKey = "BuildIcon";
+            }
+        }
+
         public CompileMessages ErrorsToList
         {
             get { return _errors; }

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -334,6 +334,7 @@ namespace AGS.Editor
             this.cmbMessageOnCompile.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbMessageOnCompile.FormattingEnabled = true;
             this.cmbMessageOnCompile.Items.AddRange(new object[] {
+            "Always",
             "When there are warnings or errors",
             "When there are errors",
             "Never"});


### PR DESCRIPTION
Previously the Editor message boxes preference didn't apply to the 'successful compilation' message box.
This makes the following changes:

- adds a default enum 'Always' (previous default 'WarningsAndErrors' was already allowing success messages)
- suppress the 'successful compilation' message box unless using 'Always'
- write the successful compilation message to the output pane

The main benefit being, if you set the option to 'Never', you now get faster testing. As an added bonus, this stops the Windows sound effect that accompany message boxes being played, every time the game is compiled.

Potential problem: With preference set to 'Never' and then reverting to an older AGS version, the index is out of range. I'm not sure if there is any safer way to extend a preference item with a new value? At the moment it seems existing preferences are not validated.