### PR TITLE
new jump point search routing with path refinement

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -97,9 +97,6 @@ OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 49 : 3.4.1.2
 Font custom line spacing.
 
-50 : 3.4.1.3
-New movelist format.
-
 */
 
 enum GameDataVersion
@@ -132,8 +129,7 @@ enum GameDataVersion
     kGameVersion_340_4          = 47,
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
-    kGameVersion_341_3          = 50,
-    kGameVersion_Current        = kGameVersion_341_3
+    kGameVersion_Current        = kGameVersion_341_2
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -97,6 +97,9 @@ OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 49 : 3.4.1.2
 Font custom line spacing.
 
+50 : 3.4.1.3
+New movelist format.
+
 */
 
 enum GameDataVersion
@@ -129,7 +132,8 @@ enum GameDataVersion
     kGameVersion_340_4          = 47,
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
-    kGameVersion_Current        = kGameVersion_341_2
+    kGameVersion_341_3          = 50,
+    kGameVersion_Current        = kGameVersion_341_3
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1343,10 +1343,7 @@ void ReadMoveList_Aligned(Stream *in)
     AlignedStream align_s(in, Common::kAligned_Read);
     for (int i = 0; i < game.numcharacters + MAX_INIT_SPR + 1; ++i)
     {
-        if (loaded_game_file_version >= kGameVersion_341_3)
-            mls[i].ReadFromFile(&align_s);
-        else
-            mls[i].ReadFromFile_Legacy(&align_s);
+        mls[i].ReadFromFile(&align_s);
 
         align_s.Reset();
     }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1343,7 +1343,7 @@ void ReadMoveList_Aligned(Stream *in)
     AlignedStream align_s(in, Common::kAligned_Read);
     for (int i = 0; i < game.numcharacters + MAX_INIT_SPR + 1; ++i)
     {
-        mls[i].ReadFromFile(&align_s);
+        mls[i].ReadFromFile_Legacy(&align_s);
 
         align_s.Reset();
     }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1343,7 +1343,11 @@ void ReadMoveList_Aligned(Stream *in)
     AlignedStream align_s(in, Common::kAligned_Read);
     for (int i = 0; i < game.numcharacters + MAX_INIT_SPR + 1; ++i)
     {
-        mls[i].ReadFromFile(&align_s);
+        if (loaded_game_file_version >= kGameVersion_341_3)
+            mls[i].ReadFromFile(&align_s);
+        else
+            mls[i].ReadFromFile_Legacy(&align_s);
+
         align_s.Reset();
     }
 }

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -13,16 +13,17 @@
 //=============================================================================
 
 #include "ac/movelist.h"
+#include "ac/common.h"
 #include "util/stream.h"
 
 using AGS::Common::Stream;
 
 void MoveList::ReadFromFile(Stream *in)
 {
-    in->ReadArrayOfInt32(pos, MAXNEEDSTAGES);
+    in->ReadArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
     numstage = in->ReadInt32();
-    in->ReadArrayOfInt32(xpermove, MAXNEEDSTAGES);
-    in->ReadArrayOfInt32(ypermove, MAXNEEDSTAGES);
+    in->ReadArrayOfInt32(xpermove, MAXNEEDSTAGES_LEGACY);
+    in->ReadArrayOfInt32(ypermove, MAXNEEDSTAGES_LEGACY);
     fromx = in->ReadInt32();
     fromy = in->ReadInt32();
     onstage = in->ReadInt32();
@@ -31,14 +32,27 @@ void MoveList::ReadFromFile(Stream *in)
     lasty = in->ReadInt32();
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
+
+    if (numstage > MAXNEEDSTAGES)
+        quit("attempt to read a movelist with too many stages");
+
+    // new version
+    int remaining = numstage - MAXNEEDSTAGES_LEGACY;
+
+    if (remaining > 0)
+    {
+        in->ReadArrayOfInt32(pos + MAXNEEDSTAGES_LEGACY, remaining);
+        in->ReadArrayOfInt32(xpermove + MAXNEEDSTAGES_LEGACY, remaining);
+        in->ReadArrayOfInt32(ypermove + MAXNEEDSTAGES_LEGACY, remaining);
+    }
 }
 
 void MoveList::WriteToFile(Stream *out)
 {
-    out->WriteArrayOfInt32(pos, MAXNEEDSTAGES);
+    out->WriteArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
     out->WriteInt32(numstage);
-    out->WriteArrayOfInt32(xpermove, MAXNEEDSTAGES);
-    out->WriteArrayOfInt32(ypermove, MAXNEEDSTAGES);
+    out->WriteArrayOfInt32(xpermove, MAXNEEDSTAGES_LEGACY);
+    out->WriteArrayOfInt32(ypermove, MAXNEEDSTAGES_LEGACY);
     out->WriteInt32(fromx);
     out->WriteInt32(fromy);
     out->WriteInt32(onstage);
@@ -47,4 +61,14 @@ void MoveList::WriteToFile(Stream *out)
     out->WriteInt32(lasty);
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
+
+    // new version
+    int remaining = numstage - MAXNEEDSTAGES_LEGACY;
+
+    if (remaining > 0)
+    {
+        out->WriteArrayOfInt32(pos + MAXNEEDSTAGES_LEGACY, remaining);
+        out->WriteArrayOfInt32(xpermove + MAXNEEDSTAGES_LEGACY, remaining);
+        out->WriteArrayOfInt32(ypermove + MAXNEEDSTAGES_LEGACY, remaining);
+    }
 }

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -34,9 +34,9 @@ void MoveList::ReadFromFile_Legacy(Stream *in)
     direct = in->ReadInt8();
 }
 
-void MoveList::ReadFromFile(Stream *in)
+void MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
-    if (loaded_game_file_version < kGameVersion_341_3)
+    if (cmp_ver < 1)
         return ReadFromFile_Legacy(in);
 
     numstage = in->ReadInt32();

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -18,7 +18,7 @@
 
 using AGS::Common::Stream;
 
-void MoveList::ReadFromFile(Stream *in)
+void MoveList::ReadFromFile_Legacy(Stream *in)
 {
     in->ReadArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
     numstage = in->ReadInt32();
@@ -32,27 +32,32 @@ void MoveList::ReadFromFile(Stream *in)
     lasty = in->ReadInt32();
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
+}
+
+void MoveList::ReadFromFile(Stream *in)
+{
+    numstage = in->ReadInt32();
 
     if (numstage > MAXNEEDSTAGES)
         quit("attempt to read a movelist with too many stages");
 
-    // new version
-    int remaining = numstage - MAXNEEDSTAGES_LEGACY;
+    fromx = in->ReadInt32();
+    fromy = in->ReadInt32();
+    onstage = in->ReadInt32();
+    onpart = in->ReadInt32();
+    lastx = in->ReadInt32();
+    lasty = in->ReadInt32();
+    doneflag = in->ReadInt8();
+    direct = in->ReadInt8();
 
-    if (remaining > 0)
-    {
-        in->ReadArrayOfInt32(pos + MAXNEEDSTAGES_LEGACY, remaining);
-        in->ReadArrayOfInt32(xpermove + MAXNEEDSTAGES_LEGACY, remaining);
-        in->ReadArrayOfInt32(ypermove + MAXNEEDSTAGES_LEGACY, remaining);
-    }
+    in->ReadArrayOfInt32(pos, numstage);
+    in->ReadArrayOfInt32(xpermove, numstage);
+    in->ReadArrayOfInt32(ypermove, numstage);
 }
 
 void MoveList::WriteToFile(Stream *out)
 {
-    out->WriteArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
     out->WriteInt32(numstage);
-    out->WriteArrayOfInt32(xpermove, MAXNEEDSTAGES_LEGACY);
-    out->WriteArrayOfInt32(ypermove, MAXNEEDSTAGES_LEGACY);
     out->WriteInt32(fromx);
     out->WriteInt32(fromy);
     out->WriteInt32(onstage);
@@ -62,13 +67,7 @@ void MoveList::WriteToFile(Stream *out)
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
 
-    // new version
-    int remaining = numstage - MAXNEEDSTAGES_LEGACY;
-
-    if (remaining > 0)
-    {
-        out->WriteArrayOfInt32(pos + MAXNEEDSTAGES_LEGACY, remaining);
-        out->WriteArrayOfInt32(xpermove + MAXNEEDSTAGES_LEGACY, remaining);
-        out->WriteArrayOfInt32(ypermove + MAXNEEDSTAGES_LEGACY, remaining);
-    }
+    out->WriteArrayOfInt32(pos, numstage);
+    out->WriteArrayOfInt32(xpermove, numstage);
+    out->WriteArrayOfInt32(ypermove, numstage);
 }

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -36,6 +36,9 @@ void MoveList::ReadFromFile_Legacy(Stream *in)
 
 void MoveList::ReadFromFile(Stream *in)
 {
+    if (loaded_game_file_version < kGameVersion_341_3)
+        return ReadFromFile_Legacy(in);
+
     numstage = in->ReadInt32();
 
     if (numstage > MAXNEEDSTAGES)

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -21,7 +21,9 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-#define MAXNEEDSTAGES 40
+#define MAXNEEDSTAGES 256
+#define MAXNEEDSTAGES_LEGACY 40
+
 struct MoveList {
     int   pos[MAXNEEDSTAGES];
     int   numstage;

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -34,6 +34,7 @@ struct MoveList {
     char  doneflag;
     char  direct;  // MoveCharDirect was used or not
 
+    void ReadFromFile_Legacy(Common::Stream *in);
     void ReadFromFile(Common::Stream *in);
     void WriteToFile(Common::Stream *out);
 };

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -35,7 +35,7 @@ struct MoveList {
     char  direct;  // MoveCharDirect was used or not
 
     void ReadFromFile_Legacy(Common::Stream *in);
-    void ReadFromFile(Common::Stream *in);
+    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);
 };
 

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -78,13 +78,7 @@ int can_see_from(int x1, int y1, int x2, int y2)
 
   sync_nav_wallscreen();
 
-  NAV_THREAD_LOCAL std::vector<int> rpath;
-  int res = !nav.TraceLine(x1, y1, x2, y2, rpath);
-
-  if (!rpath.empty())
-    nav.UnpackSquare(rpath.back(), lastcx, lastcy);
-
-  return res;
+  return !nav.TraceLine(x1, y1, x2, y2, lastcx, lastcy);
 }
 
 // new routing using JPS
@@ -92,11 +86,11 @@ int find_route_jps(int fromx, int fromy, int destx, int desty)
 {
   sync_nav_wallscreen();
 
-  NAV_THREAD_LOCAL std::vector<int> path, cpath;
+  static std::vector<int> path, cpath;
   path.clear();
   cpath.clear();
 
-  if (!nav.NavigateRefined(fromx, fromy, destx, desty, path, cpath))
+  if (nav.NavigateRefined(fromx, fromy, destx, desty, path, cpath) == Navigation::NAV_UNREACHABLE)
     return 0;
 
   num_navpoints = 0;

--- a/Engine/ac/route_finder_jps.inl
+++ b/Engine/ac/route_finder_jps.inl
@@ -1,0 +1,917 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// jump point search grid navigation with navpoint refinement
+// (c) 2018 Martin Sedlak
+//
+//=============================================================================
+
+#include <queue>
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <assert.h>
+#include <stddef.h>
+#include <math.h>
+
+// note: change this to thread_local if C++11 allowed
+#define NAV_THREAD_LOCAL static
+
+// TODO: this could be cleaned up/simplified ...
+
+class Navigation
+{
+public:
+	Navigation();
+
+	void Resize(int width, int height);
+
+	// ncpath = navpoint-compressed path
+	// opath = path composed of individual grid elements
+	bool NavigateRefined(int sx, int sy, int ex, int ey, std::vector<int> &opath,
+		std::vector<int> &ncpath);
+
+	bool Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath);
+
+	bool TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> &rpath) const;
+
+	inline void SetMapRow(int y, const unsigned char *row) {map[y] = row;}
+
+	inline static int PackSquare(int x, int y);
+	inline static void UnpackSquare(int sq, int &x, int &y);
+
+private:
+	// priority queue entry
+	struct Entry
+	{
+		float cost;
+		int index;
+
+		inline Entry() {}
+
+		inline Entry(float ncost, int nindex)
+			: cost(ncost)
+			, index(nindex)
+		{
+		}
+
+		inline bool operator <(const Entry &b) const
+		{
+			return cost < b.cost;
+		}
+
+		inline bool operator >(const Entry &b) const
+		{
+			return cost > b.cost;
+		}
+	};
+
+	int mapWidth;
+	int mapHeight;
+	std::vector<const unsigned char *> map;
+
+	typedef unsigned char tFrameId;
+	typedef char tPrev;
+
+	struct NodeInfo
+	{
+		// quantized min distance from origin
+		unsigned short dist;
+		// frame id (counter to detect new search)
+		tFrameId frameId;
+		// previous node index (packed, relative to current node)
+		tPrev prev;
+
+		inline NodeInfo()
+			: dist(0)
+			, frameId(0)
+			, prev(-1)
+		{
+		}
+	};
+
+	std::vector<NodeInfo> mapNodes;
+	tFrameId frameId;
+
+	std::priority_queue<Entry, std::vector<Entry>, std::greater<Entry> > pq;
+	std::vector<int> path, npath, cpath;
+
+	// temps for routing towards unreachable areas
+	int cnode;
+	int closest;
+
+	// orthogonal only (this should correspond to what AGS is doing)
+	bool nodiag;
+
+	bool navLock;
+
+	void IncFrameId();
+
+	inline static tPrev PackPrev(int px, int py, int x, int y);
+	inline int UnpackPrev(int x, int y, tPrev prev) const;
+
+	// stronger inside test
+	bool Passable(int x, int y) const;
+	// plain access, unchecked
+	bool Walkable(int x, int y) const;
+
+	void AddPruned(int *buf, int &bcount, int x, int y) const;
+	bool HasForcedNeighbor(int x, int y, int dx, int dy) const;
+	int FindJump(int x, int y, int dx, int dy, int ex, int ey);
+	int FindOrthoJump(int x, int y, int dx, int dy, int ex, int ey);
+
+	// neighbor reachable (nodiag only)
+	bool Reachable(int x0, int y0, int x1, int y1) const;
+
+	static inline int sign(int n)
+	{
+		return n < 0 ? -1 : (n > 0 ? 1 : 0);
+	}
+
+	static inline int iabs(int n)
+	{
+		return n < 0 ? -n : n;
+	}
+
+	static inline int iclamp(int v, int min, int max)
+	{
+		return v < min ? min : (v > max ? max : v);
+	}
+
+	static inline int ClosestDist(int dx, int dy)
+	{
+		return dx*dx + dy*dy;
+		// Manhattan?
+		//return iabs(dx) + iabs(dy);
+	}
+};
+
+// Navigation
+
+Navigation::Navigation()
+	: mapWidth(0)
+	, mapHeight(0)
+	, frameId(1)
+	, cnode(0)
+	, closest(0)
+	// no diagonal route - this should correspond to what AGS does
+	, nodiag(true)
+	, navLock(false)
+{
+}
+
+void Navigation::Resize(int width, int height)
+{
+	mapWidth = width;
+	mapHeight = height;
+
+	int size = mapWidth*mapHeight;
+
+	map.resize(mapHeight);
+	mapNodes.resize(size);
+}
+
+void Navigation::IncFrameId()
+{
+	if (++frameId == 0)
+	{
+		for (int i=0; i<(int)mapNodes.size(); i++)
+			mapNodes[i].frameId = 0;
+
+		frameId = 1;
+	}
+}
+
+inline Navigation::tPrev Navigation::PackPrev(int px, int py, int x, int y)
+{
+	int dx = px - x;
+	int dy = py - y;
+
+	dx = iclamp(dx, -1, 1);
+	dy = iclamp(dy, -1, 1);
+
+	return (dy+1)*4 + (dx+1);
+}
+
+inline int Navigation::UnpackPrev(int x, int y, tPrev prev) const
+{
+	if (prev < 0)
+		return -1;
+
+	int dx = (prev & 3) - 1;
+	int dy = (prev >> 2) - 1;
+
+	// we need to scan back to get previous node
+	// we trade efficiency (O(1) lookup) for 4x memory savings
+
+	// scan in reverse direction because we used jumps
+	for (;;)
+	{
+		x += dx;
+		y += dy;
+
+		int sq = y*mapWidth + x;
+
+		const NodeInfo &node = mapNodes[sq];
+
+		if (node.frameId == frameId)
+			return PackSquare(x, y);
+	}
+}
+
+inline int Navigation::PackSquare(int x, int y)
+{
+	return (y << 15) + x;
+}
+
+inline void Navigation::UnpackSquare(int sq, int &x, int &y)
+{
+	y = sq >> 15;
+	x = sq & ((1 << 15)-1);
+}
+
+bool Navigation::Walkable(int x, int y) const
+{
+	// invert condition because of AGS
+	return map[y][x] != 0;
+}
+
+bool Navigation::Passable(int x, int y) const
+{
+	if ((unsigned)x >= (unsigned)mapWidth ||
+		(unsigned)y >= (unsigned)mapHeight)
+		return false;
+
+	return Walkable(x, y);
+}
+
+bool Navigation::Reachable(int x0, int y0, int x1, int y1) const
+{
+	assert(nodiag);
+
+	return Passable(x1, y1) &&
+		(Passable(x1, y0) || Passable(x0, y1));
+}
+
+// A* using jump point search (JPS)
+// reference: http://users.cecs.anu.edu.au/~dharabor/data/papers/harabor-grastien-aaai11.pdf
+void Navigation::AddPruned(int *buf, int &bcount, int x, int y) const
+{
+	assert(buf && bcount < 8);
+
+	if ((unsigned)x >= (unsigned)mapWidth ||
+		(unsigned)y >= (unsigned)mapHeight || !Walkable(x, y))
+		return;
+
+	buf[bcount++] = PackSquare(x, y);
+}
+
+bool Navigation::HasForcedNeighbor(int x, int y, int dx, int dy) const
+{
+	if (!dy)
+	{
+		return  (!Passable(x, y-1) && Passable(x+dx, y-1)) ||
+				(!Passable(x, y+1) && Passable(x+dx, y+1));
+	}
+
+	if (!dx)
+	{
+		return  (!Passable(x-1, y) && Passable(x-1, y+dy)) ||
+				(!Passable(x+1, y) && Passable(x+1, y+dy));
+	}
+
+	return
+		(!Passable(x - dx, y) && Passable(x - dx, y + dy)) ||
+		(!Passable(x, y - dy) && Passable(x + dx, y - dy));
+}
+
+int Navigation::FindOrthoJump(int x, int y, int dx, int dy, int ex, int ey)
+{
+	assert((!dx || !dy) && (dx || dy));
+
+	for (;;)
+	{
+		x += dx;
+		y += dy;
+
+		if ((unsigned)x >= (unsigned)mapWidth ||
+			(unsigned)y >= (unsigned)mapHeight || !Walkable(x, y))
+			break;
+
+		int edx = x - ex;
+		int edy = y - ey;
+		int edist = ClosestDist(edx, edy);
+
+		if (edist < closest)
+		{
+			closest = edist;
+			cnode = PackSquare(x, y);
+		}
+
+		if ((x == ex && y == ey) || HasForcedNeighbor(x, y, dx, dy))
+			return PackSquare(x, y);
+	}
+
+	return -1;
+}
+
+int Navigation::FindJump(int x, int y, int dx, int dy, int ex, int ey)
+{
+	if (!(dx && dy))
+		return FindOrthoJump(x, y, dx, dy, ex, ey);
+
+	if (nodiag && !Reachable(x, y, x+dx, y+dy))
+		return -1;
+
+	x += dx;
+	y += dy;
+
+	if ((unsigned)x >= (unsigned)mapWidth ||
+		(unsigned)y >= (unsigned)mapHeight || !Walkable(x, y))
+		return -1;
+
+	int edx = x - ex;
+	int edy = y - ey;
+	int edist = ClosestDist(edx, edy);
+
+	if (edist < closest)
+	{
+		closest = edist;
+		cnode = PackSquare(x, y);
+	}
+
+	if ((x == ex && y == ey) || HasForcedNeighbor(x, y, dx, dy))
+		return PackSquare(x, y);
+
+	if (dx && dy)
+	{
+		if (FindOrthoJump(x, y, dx, 0, ex, ey) ||
+			FindOrthoJump(x, y, 0, dy, ex, ey))
+			return PackSquare(x, y);
+	}
+
+	return nodiag ? -1 : FindJump(x, y, dx, dy, ex, ey);
+}
+
+bool Navigation::Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath)
+{
+	IncFrameId();
+
+	if (!Walkable(sx, sy))
+	{
+		opath.clear();
+		return false;
+	}
+
+	// try ray first, if reachable, no need for A* at all
+	if (!TraceLine(sx, sy, ex, ey, opath))
+		return true;
+
+	NodeInfo &ni = mapNodes[sy*mapWidth+sx];
+	ni.dist = 0;
+	ni.frameId = frameId;
+	ni.prev = -1;
+
+	closest = 0x7fffffff;
+	cnode = PackSquare(sx, sy);
+
+	// no clear for priority queue, like, really?!
+	while (!pq.empty())
+			pq.pop();
+
+	pq.push(Entry(0.0, cnode));
+
+	while (!pq.empty())
+	{
+		Entry e = pq.top();
+		pq.pop();
+
+		int x, y;
+		UnpackSquare(e.index, x, y);
+
+		int dx = x - ex;
+		int dy = y - ey;
+		int edist = ClosestDist(dx, dy);
+
+		if (edist < closest)
+		{
+			closest = edist;
+			cnode = e.index;
+		}
+
+		if (x == ex && y == ey)
+		{
+			// done
+			break;
+		}
+
+		const NodeInfo &node = mapNodes[y*mapWidth+x];
+
+		float dist = (float)node.dist;
+
+		int pneig[8];
+		int ncount = 0;
+
+		int prev = UnpackPrev(x, y, node.prev);
+
+		if (prev < 0)
+		{
+			for (int ny = y-1; ny <= y+1; ny++)
+			{
+				if ((unsigned)ny >= (unsigned)mapHeight)
+					continue;
+
+				for (int nx = x-1; nx <= x+1; nx++)
+				{
+					if (nx == x && ny == y)
+						continue;
+
+					if ((unsigned)nx >= (unsigned)mapWidth)
+						continue;
+
+					if (!Walkable(nx, ny))
+						continue;
+
+					if (nodiag && !Reachable(x, y, nx, ny))
+						continue;
+
+					pneig[ncount++] = PackSquare(nx, ny);
+				}
+			}
+		}
+		else
+		{
+			// filter
+			int px, py;
+			UnpackSquare(prev, px, py);
+			int dx = sign(x - px);
+			int dy = sign(y - py);
+			assert(dx || dy);
+
+			if (!dy)
+			{
+				AddPruned(pneig, ncount, x+dx, y);
+
+				// add corners
+				if (!nodiag || Passable(x+dx, y))
+				{
+					if (!Passable(x, y+1))
+						AddPruned(pneig, ncount, x+dx, y+1);
+
+					if (!Passable(x, y-1))
+						AddPruned(pneig, ncount, x+dx, y-1);
+				}
+			}
+			else if (!dx)
+			{
+				// same as above but transposed
+				AddPruned(pneig, ncount, x, y+dy);
+
+				// add corners
+				if (!nodiag || Passable(x, y+dy))
+				{
+					if (!Passable(x+1, y))
+						AddPruned(pneig, ncount, x+1, y+dy);
+
+					if (!Passable(x-1, y))
+						AddPruned(pneig, ncount, x-1, y+dy);
+				}
+			}
+			else
+			{
+				// diagonal case
+				AddPruned(pneig, ncount, x, y+dy);
+				AddPruned(pneig, ncount, x+dx, y);
+
+				if (!nodiag || Reachable(x, y, x+dx, y+dy))
+					AddPruned(pneig, ncount, x+dx, y+dy);
+
+				if (!Passable(x - dx, y) &&
+					(nodiag || Reachable(x, y, x-dx, y+dy)))
+					AddPruned(pneig, ncount, x-dx, y+dy);
+
+				if (!Passable(x, y-dy) &&
+					(nodiag || Reachable(x, y, x+dx, y-dy)))
+					AddPruned(pneig, ncount, x+dx, y-dy);
+			}
+		}
+
+		// sort by heuristics
+		Entry sort[8];
+
+		for (int ni = 0; ni < ncount; ni++)
+		{
+			int nx, ny;
+			UnpackSquare(pneig[ni], nx, ny);
+			float edx = (float)(nx - ex);
+			float edy = (float)(ny - ey);
+			sort[ni].cost = sqrt(edx*edx + edy*edy);
+			sort[ni].index = pneig[ni];
+		}
+
+		std::sort(sort, sort+ncount);
+
+		int succ[8];
+		int nsucc = 0;
+
+		for (int ni=0; ni<ncount; ni++)
+			pneig[ni] = sort[ni].index;
+
+		for (int ni = 0; ni < ncount; ni ++)
+		{
+			int nx, ny;
+			UnpackSquare(pneig[ni], nx, ny);
+
+			int dx = nx - x;
+			int dy = ny - y;
+			int j = FindJump(x, y, dx, dy, ex, ey);
+
+			if (j < 0)
+				continue;
+
+			succ[nsucc++] = j;
+		}
+
+		for (int ni = 0; ni < nsucc; ni ++)
+		{
+			int nx, ny;
+			UnpackSquare(succ[ni], nx, ny);
+			assert(Walkable(nx, ny));
+
+			NodeInfo &node = mapNodes[ny*mapWidth+nx];
+
+			float ndist = node.frameId != frameId ? INFINITY : (float)node.dist;
+
+			float dx = (float)(nx - x);
+			float dy = (float)(ny - y);
+			// FIXME: can do better here
+			float cost = sqrt(dx*dx + dy*dy);
+			float ecost = dist + cost;
+
+			float edx = (float)(nx - ex);
+			float edy = (float)(ny - ey);
+			float heur = sqrt(edx*edx + edy*edy);
+
+			if (ecost < ndist)
+			{
+				// assert because we use 16-bit quantized min distance from start to save memory
+				assert(ecost <= 65535.0f);
+
+				if (ecost > 65535.0f)
+					continue;
+
+				node.dist = (unsigned short)(ecost + 0.5f);
+				node.frameId = frameId;
+				node.prev = PackPrev(x, y, nx, ny);
+				pq.push(Entry(ecost + heur, PackSquare(nx, ny)));
+			}
+		}
+	}
+
+	opath.clear();
+
+	// now since we allow approx routing even if dst
+	// isn't directly reachable
+	// note: not sure if this provides optimal results even if we update
+	// cnode during jump search
+	int nex, ney;
+	UnpackSquare(cnode, nex, ney);
+
+	if ((nex != sx || ney != sy) && (nex != ex || ney != ey))
+	{
+		// target not directly reachable => move closer to target
+		TraceLine(nex, ney, ex, ey, opath);
+		UnpackSquare(opath.back(), nex, ney);
+
+		bool res = true;
+
+		// note: navLock => better safe than sorry
+		// infinite recursion should never happen but... better safe than sorry
+		assert(!navLock);
+
+		if (!navLock)
+		{
+			// and re-route
+			opath.clear();
+
+			navLock = true;
+			res = Navigate(sx, sy, nex, ney, opath);
+			navLock = false;
+		}
+
+		// refine this a bit further; find path point closest
+		// to original target and truncate
+
+		int best = 0x7fffffff;
+		int bestSize = (int)opath.size();
+
+		for (int i=0; i<(int)opath.size(); i++)
+		{
+			int x, y;
+			UnpackSquare(opath[i], x, y);
+			int dx = x-ex, dy = y-ey;
+			int cost = ClosestDist(dx, dy);
+
+			if (cost < best)
+			{
+				best = cost;
+				bestSize = i+1;
+			}
+		}
+
+		opath.resize(bestSize);
+
+		return res;
+	}
+
+	if (mapNodes[ey*mapWidth+ex].frameId != frameId)
+	{
+		// path not found
+		return false;
+	}
+
+	int tx = ex;
+	int ty = ey;
+	// add end
+	opath.push_back(PackSquare(tx, ty));
+
+	for (;;)
+	{
+		int prev = UnpackPrev(tx, ty, mapNodes[ty*mapWidth+tx].prev);
+
+		if (prev < 0)
+			break;
+
+		// unpack because we use JPS
+		int px, py;
+		UnpackSquare(prev, px, py);
+		int dx = sign(px - tx);
+		int dy = sign(py - ty);
+
+		while (tx != px || ty != py)
+		{
+			tx += dx;
+			ty += dy;
+			opath.push_back(PackSquare(tx, ty));
+		}
+	}
+
+	std::reverse(opath.begin(), opath.end());
+	return true;
+}
+
+bool Navigation::NavigateRefined(int sx, int sy, int ex, int ey,
+	std::vector<int> &opath, std::vector<int> &ncpath)
+{
+	ncpath.clear();
+
+	if (!Navigate(sx, sy, ex, ey, opath))
+		return false;
+
+	NAV_THREAD_LOCAL std::vector<int> tmp;
+	tmp.clear();
+
+	tmp.reserve(opath.size());
+	int fx = sx;
+	int fy = sy;
+
+	NAV_THREAD_LOCAL std::vector<int> fpath;
+	NAV_THREAD_LOCAL std::vector<int> ncpathIndex;
+	fpath.clear();
+	ncpathIndex.clear();
+
+	fpath.reserve(opath.size());
+	fpath.push_back(opath[0]);
+	ncpath.push_back(opath[0]);
+	ncpathIndex.push_back(0);
+
+	NAV_THREAD_LOCAL std::vector<int> rayPath, orayPath;
+
+	rayPath.clear();
+	orayPath.clear();
+
+	rayPath.reserve(opath.size());
+	orayPath.reserve(opath.size());
+
+	for (int i=1; i<(int)opath.size(); i++)
+	{
+		// trying to optimize path
+		int tx, ty;
+		UnpackSquare(opath[i], tx, ty);
+
+		bool last = i == (int)opath.size()-1;
+
+		if (!TraceLine(fx, fy, tx, ty, rayPath))
+		{
+			assert(rayPath.back() == opath[i]);
+			std::swap(rayPath, orayPath);
+
+			if (!last)
+				continue;
+		}
+
+		// copy orayPath
+		for (int j=1; j<(int)orayPath.size(); j++)
+			fpath.push_back(orayPath[j]);
+
+		if (!orayPath.empty())
+		{
+			assert(ncpath.back() == orayPath[0]);
+			ncpath.push_back(orayPath.back());
+			ncpathIndex.push_back((int)fpath.size()-1);
+
+			if (!last)
+			{
+				UnpackSquare(orayPath.back(), fx, fy);
+				orayPath.clear();
+				i--;
+				continue;
+			}
+		}
+
+		if (fpath.back() != opath[i])
+			fpath.push_back(opath[i]);
+
+		if (ncpath.back() != opath[i])
+		{
+			ncpath.push_back(opath[i]);
+			ncpathIndex.push_back((int)fpath.size()-1);
+		}
+
+		fx = tx;
+		fy = ty;
+	}
+
+	std::swap(opath, fpath);
+
+	// validate cpath
+	for (int i=0; i<(int)ncpath.size()-1; i++)
+	{
+		int tx, ty;
+		UnpackSquare(ncpath[i], fx, fy);
+		UnpackSquare(ncpath[i+1], tx, ty);
+		assert(!TraceLine(fx, fy, tx, ty, rayPath));
+	}
+
+	assert(ncpath.size() == ncpathIndex.size());
+
+	// so now we have opath, ncpath and ncpathIndex
+	// we want to gradually move ncpath node towards previous to see
+	// if we can raycast from prev ncpath node to moved and from moved
+	// to the end
+
+	bool adjusted = false;
+
+	for (int i=(int)ncpath.size()-2; i>0; i--)
+	{
+		int px, py;
+		int nx, ny;
+
+		int pidx = ncpathIndex[i-1];
+		int idx = ncpathIndex[i];
+
+		UnpackSquare(ncpath[i-1], px, py);
+		UnpackSquare(ncpath[i+1], nx, ny);
+
+		for (int j=idx-1; j >= pidx; j--)
+		{
+			int x, y;
+			UnpackSquare(opath[j], x, y);
+
+			// if we can raycast px,py => x,y and x,y => nx,ny,
+			// we can move ncPath node!
+			if (TraceLine(px, py, x, y, rayPath))
+				continue;
+
+			if (TraceLine(x, y, nx, ny, rayPath))
+				continue;
+
+			ncpath[i] = opath[j];
+			ncpathIndex[i] = j;
+			adjusted = true;
+		}
+
+		if (ncpath[i] == ncpath[i-1])
+		{
+			// if we get here, we need to remove ncpath[i]
+			// because we reached the previous node
+			ncpath.erase(ncpath.begin()+i);
+			ncpathIndex.erase(ncpathIndex.begin()+i);
+			adjusted = true;
+		}
+	}
+
+	if (!adjusted)
+		return true;
+
+	// final step (if necessary) is to reconstruct path from compressed path
+
+	opath.clear();
+	opath.push_back(ncpath[0]);
+
+	for (int i=1; i<(int)ncpath.size(); i++)
+	{
+		int fx, fy;
+		int tx, ty;
+
+		UnpackSquare(ncpath[i-1], fx, fy);
+		UnpackSquare(ncpath[i], tx, ty);
+
+		TraceLine(fx, fy, tx, ty, rayPath);
+
+		for (int j=1; j<(int)rayPath.size(); j++)
+			opath.push_back(rayPath[j]);
+	}
+
+	return true;
+}
+
+bool Navigation::TraceLine(int srcx, int srcy, int targx, int targy,
+	std::vector<int> &rpath) const
+{
+	rpath.clear();
+
+	// DDA
+	int x0 = (srcx << 16) + 0x8000;
+	int y0 = (srcy << 16) + 0x8000;
+	int x1 = (targx << 16) + 0x8000;
+	int y1 = (targy << 16) + 0x8000;
+
+	int dx = x1 - x0;
+	int dy = y1 - y0;
+
+	if (!dx && !dy)
+	{
+		if (!Passable(srcx, srcy))
+			return true;
+
+		rpath.push_back(PackSquare(srcx, srcy));
+		return false;
+	}
+
+	int xinc, yinc;
+
+	if (iabs(dx) >= iabs(dy))
+	{
+		// step along x
+		xinc = sign(dx) * 65536;
+		yinc = (int)((double)dy * 65536 / iabs(dx));
+	}
+	else
+	{
+		// step along y
+		yinc = sign(dy) * 65536;
+		xinc = (int)((double)dx * 65536 / iabs(dy));
+	}
+
+	int fx = x0;
+	int fy = y0;
+	int x = x0 >> 16;
+	int y = y0 >> 16;
+	int ex = x1 >> 16;
+	int ey = y1 >> 16;
+
+	while (x != ex || y != ey)
+	{
+		if (!Passable(x, y))
+			return true;
+
+		rpath.push_back(PackSquare(x, y));
+
+		fx += xinc;
+		fy += yinc;
+		int ox = x;
+		int oy = y;
+		x = fx >> 16;
+		y = fy >> 16;
+
+		if (nodiag && !Reachable(ox, oy, x, y))
+			return true;
+	}
+
+	assert(iabs(x - ex) <= 1 && iabs(y - ey) <= 1);
+
+	if (nodiag && !Reachable(x, y, ex, ey))
+		return false;
+
+	if (!Passable(ex, ey))
+		return true;
+
+	int sq = PackSquare(ex, ey);
+
+	if (rpath.empty() || rpath.back() != sq)
+		rpath.push_back(sq);
+
+	return false;
+}

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -368,7 +368,7 @@ SavegameError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams 
         if (loaded_game_file_version <= kGameVersion_272)
             game.intrChar[i]->ReadTimesRunFromSavedgame(in.get());
         // character movement path cache
-        mls[CHMLSOFFS + i].ReadFromFile(in.get());
+        mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver);
     }
     return kSvgErr_NoError;
 }
@@ -877,7 +877,7 @@ SavegameError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &p
         return kSvgErr_IncompatibleEngine;
     for (int i = 0; i < objmls_count; ++i)
     {
-        mls[i].ReadFromFile(in.get());
+        mls[i].ReadFromFile(in.get(), cmp_ver);
     }
 
     // save the new room music vol for later use
@@ -947,7 +947,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Characters",
-        0,
+        1,
         WriteCharacters,
         ReadCharacters
     },
@@ -1013,7 +1013,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Loaded Room State",
-        0,
+        1,
         WriteThisRoom,
         ReadThisRoom
     },


### PR DESCRIPTION
Hi guys, I forked AGS to try my jump point search A* study and it seems to work well so far.

What's the benefit:
+ faster (up to much faster) pathfinding
+ somewhat nicer paths (better refinement especially at path end)
+ when clicking unreachable walls the player moves somewhat closer to destination using the new algorithm
+ amortized heap allocation elimination when pathfinding
+ eliminating old pathfinding code

What's the price to pay:
- 4 times more memory scratch memory required (4xwall bitmap dims), for 3kx1k bitmap, original AGS used 3 megs of extra RAM while my new pathfinder uses 12 megs; probably not a bit deal even on mobiles
- not thoroughly tested (3 games only - King's Quest II, Resonance Demo and Eternally us), may contain bugs

Performance of original AGS (runtime polling disabled):

King's Quest II
routing: 2828.739462 usec
routing: 3104.942280 usec
routing: 1496.928715 usec
routing: 8.753969 usec
routing: 1469.157503 usec
routing: 2791.610558 usec

Eternally us
routing: 44596.944623 usec
routing: 46470.897732 usec
routing: 44568.871550 usec
routing: 60039.247968 usec
routing: 44669.994986 usec
routing: 43908.701536 usec

Performance of my new JPS refined pathfinder (doesn't poll at all):
(note that first request is outlier due to scratch memory allocation)

King's Quest II
routing: 1969.039324 usec
routing: 527.954895 usec
routing: 1580.846074 usec
routing: 0.301861 usec
routing: 324.198718 usec
routing: 1015.762276 usec

Eternally Us:
routing: 6435.374729 usec
routing: 283.447482 usec
routing: 565.083798 usec
routing: 521.917675 usec
routing: 308.501945 usec

So we can see the new pathfinder is 1.5 times faster on simple path and almost two orders of magnitude faster on large bitmaps.

The patch still needs more testings but I think it'd be worth it.