### PR TITLE
Error class

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -71,7 +71,7 @@ void GameSetupStruct::read_font_flags(Common::Stream *in, GameDataVersion data_v
     }
 }
 
-MainGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDataVersion data_ver)
+HGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDataVersion data_ver)
 {
     int numToRead;
     if (data_ver < kGameVersion_256)
@@ -80,10 +80,10 @@ MainGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDat
         numToRead = in->ReadInt32();
 
     if (numToRead > MAX_SPRITES)
-        return kMGFErr_TooManySprites;
+        return new MainGameFileError(kMGFErr_TooManySprites, String::FromFormat("Count: %d, max: %d", numToRead, MAX_SPRITES));
     in->Read(&spriteflags[0], numToRead);
     memset(spriteflags + numToRead, 0, MAX_SPRITES - numToRead);
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 void GameSetupStruct::ReadInvInfo_Aligned(Stream *in)
@@ -106,13 +106,13 @@ void GameSetupStruct::WriteInvInfo_Aligned(Stream *out)
     }
 }
 
-MainGameFileError GameSetupStruct::read_cursors(Common::Stream *in, GameDataVersion data_ver)
+HGameFileError GameSetupStruct::read_cursors(Common::Stream *in, GameDataVersion data_ver)
 {
     if (numcursors > MAX_CURSOR)
-        return kMGFErr_TooManyCursors;
+        return new MainGameFileError(kMGFErr_TooManyCursors, String::FromFormat("Count: %d, max: %d", numcursors, MAX_CURSOR));
 
     ReadMouseCursors_Aligned(in);
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver)
@@ -247,14 +247,14 @@ void GameSetupStruct::WriteCharacters_Aligned(Stream *out)
 //-----------------------------------------------------------------------------
 // Reading Part 3
 
-MainGameFileError GameSetupStruct::read_customprops(Common::Stream *in, GameDataVersion data_ver)
+HGameFileError GameSetupStruct::read_customprops(Common::Stream *in, GameDataVersion data_ver)
 {
     dialogScriptNames.resize(numdialog);
     viewNames.resize(numviews);
     if (data_ver >= kGameVersion_260) // >= 2.60
     {
         if (Properties::ReadSchema(propSchema, in) != kPropertyErr_NoError)
-            return kMGFErr_InvalidPropertySchema;
+            return new MainGameFileError(kMGFErr_InvalidPropertySchema);
 
         int errors = 0;
 
@@ -269,7 +269,7 @@ MainGameFileError GameSetupStruct::read_customprops(Common::Stream *in, GameData
         }
 
         if (errors > 0)
-            return kMGFErr_InvalidPropertyValues;
+            return new MainGameFileError(kMGFErr_InvalidPropertyValues);
 
         for (int i = 0; i < numviews; ++i)
             viewNames[i] = String::FromStream(in);
@@ -280,10 +280,10 @@ MainGameFileError GameSetupStruct::read_customprops(Common::Stream *in, GameData
         for (int i = 0; i < numdialog; ++i)
             dialogScriptNames[i] = String::FromStream(in);
     }
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
-MainGameFileError GameSetupStruct::read_audio(Common::Stream *in, GameDataVersion data_ver)
+HGameFileError GameSetupStruct::read_audio(Common::Stream *in, GameDataVersion data_ver)
 {
     if (data_ver >= kGameVersion_320)
     {
@@ -301,7 +301,7 @@ MainGameFileError GameSetupStruct::read_audio(Common::Stream *in, GameDataVersio
         
         scoreClipID = in->ReadInt32();
     }
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 // Temporarily copied this from acruntim.h;

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -34,7 +34,7 @@ namespace AGS { namespace Common { struct AssetLibInfo; } }
 
 using AGS::Common::Interaction;
 using AGS::Common::InteractionScripts;
-using AGS::Common::MainGameFileError;
+using AGS::Common::HGameFileError;
 
 // TODO: split GameSetupStruct into struct used to hold loaded game data, and actual runtime object
 struct GameSetupStruct: public GameSetupStructBase {
@@ -99,8 +99,8 @@ struct GameSetupStruct: public GameSetupStructBase {
     // Part 1
     void read_savegame_info(Common::Stream *in, GameDataVersion data_ver);
     void read_font_flags(Common::Stream *in, GameDataVersion data_ver);
-    MainGameFileError read_sprite_flags(Common::Stream *in, GameDataVersion data_ver);
-    MainGameFileError read_cursors(Common::Stream *in, GameDataVersion data_ver);
+    HGameFileError read_sprite_flags(Common::Stream *in, GameDataVersion data_ver);
+    HGameFileError read_cursors(Common::Stream *in, GameDataVersion data_ver);
     void read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);
     void read_words_dictionary(Common::Stream *in);
 
@@ -118,8 +118,8 @@ struct GameSetupStruct: public GameSetupStructBase {
     void WriteCharacters_Aligned(Common::Stream *out);
     //------------------------------
     // Part 3
-    MainGameFileError read_customprops(Common::Stream *in, GameDataVersion data_ver);
-    MainGameFileError read_audio(Common::Stream *in, GameDataVersion data_ver);
+    HGameFileError read_customprops(Common::Stream *in, GameDataVersion data_ver);
+    HGameFileError read_audio(Common::Stream *in, GameDataVersion data_ver);
     void read_room_names(Common::Stream *in, GameDataVersion data_ver);
 
     void ReadAudioClips_Aligned(Common::Stream *in);

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -39,50 +39,50 @@ MainGameSource::MainGameSource()
 {
 }
 
-String GetMainGameFileErrorText(MainGameFileError err)
+String GetMainGameFileErrorText(MainGameFileErrorType err)
 {
     switch (err)
     {
     case kMGFErr_NoError:
-        return "No error";
+        return "No error.";
     case kMGFErr_FileNotFound:
-        return "Main game file not found";
+        return "Main game file not found.";
     case kMGFErr_NoStream:
-        return "Failed to open input stream";
+        return "Failed to open input stream.";
     case kMGFErr_SignatureFailed:
-        return "Not an AGS main game file or unsupported format";
+        return "Not an AGS main game file or unsupported format.";
     case kMGFErr_FormatVersionTooOld:
-        return "Format version is too old; this engine can only run games made with AGS 2.5 or later";
+        return "Format version is too old; this engine can only run games made with AGS 2.5 or later.";
     case kMGFErr_FormatVersionNotSupported:
-        return "Format version not supported";
+        return "Format version not supported.";
     case kMGFErr_CapsNotSupported:
-        return "Required engine caps are not supported";
+        return "Required engine caps are not supported.";
     case kMGFErr_InvalidNativeResolution:
-        return "Unable to determine native game resolution";
+        return "Unable to determine native game resolution.";
     case kMGFErr_TooManyFonts:
-        return "Too many fonts for this engine to handle";
+        return "Too many fonts for this engine to handle.";
     case kMGFErr_TooManySprites:
-        return "Too many sprites for this engine to handle";
+        return "Too many sprites for this engine to handle.";
     case kMGFErr_TooManyCursors:
-        return "Too many cursors for this engine to handle";
+        return "Too many cursors for this engine to handle.";
     case kMGFErr_InvalidPropertySchema:
-        return "load room: unable to deserialize properties schema";
+        return "load room: unable to deserialize properties schema.";
     case kMGFErr_InvalidPropertyValues:
-        return "Errors encountered when reading custom properties";
+        return "Errors encountered when reading custom properties.";
     case kMGFErr_NoGlobalScript:
-        return "No global script in game";
+        return "No global script in game.";
     case kMGFErr_CreateGlobalScriptFailed:
-        return String::FromFormat("Failed to load global script: %s", ccErrorString);
+        return String::FromFormat("Failed to load global script.");
     case kMGFErr_CreateDialogScriptFailed:
-        return String::FromFormat("Failed to load dialog script: %s", ccErrorString);
+        return String::FromFormat("Failed to load dialog script.");
     case kMGFErr_CreateScriptModuleFailed:
-        return String::FromFormat("Failed to load script module: %s", ccErrorString);
+        return String::FromFormat("Failed to load script module.");
     case kMGFErr_PluginDataFmtNotSupported:
-        return "Format version of plugin data is not supported";
+        return "Format version of plugin data is not supported.";
     case kMGFErr_PluginDataSizeTooLarge:
-        return "Plugin data size is too large";
+        return "Plugin data size is too large.";
     }
-    return "Unknown error";
+    return "Unknown error.";
 }
 
 LoadedGameEntities::LoadedGameEntities(GameSetupStruct &game, DialogTopic *&dialogs, ViewStruct *&views)
@@ -113,21 +113,22 @@ bool IsMainGameLibrary(const String &filename)
 }
 
 // Begins reading main game file from a generic stream
-MainGameFileError OpenMainGameFileBase(PStream &in, MainGameSource &src)
+HGameFileError OpenMainGameFileBase(PStream &in, MainGameSource &src)
 {
     if (!in)
-        return kMGFErr_NoStream;
+        return HGameFileError::None();
     // Check data signature
     String data_sig = String::FromStreamCount(in.get(), MainGameSource::Signature.GetLength());
     if (data_sig.Compare(MainGameSource::Signature))
-        return kMGFErr_SignatureFailed;
+        return new MainGameFileError(kMGFErr_SignatureFailed);
     // Read data format version and requested engine version
     src.DataVersion = (GameDataVersion)in->ReadInt32();
     if (src.DataVersion < kGameVersion_250)
-        return kMGFErr_FormatVersionTooOld;
+        return new MainGameFileError(kMGFErr_FormatVersionTooOld, String::FromFormat("Required format version: %d, supported %d - %d", src.DataVersion, kGameVersion_250, kGameVersion_Current));
     src.CompiledWith = StrUtil::ReadString(in.get());
     if (src.DataVersion > kGameVersion_Current)
-        return kMGFErr_FormatVersionNotSupported;
+        return new MainGameFileError(kMGFErr_FormatVersionNotSupported,
+            String::FromFormat("Game was compiled with %s. Required format version: %d, supported %d - %d", src.CompiledWith.GetCStr(), src.DataVersion, kGameVersion_250, kGameVersion_Current));
     // Read required capabilities
     if (src.DataVersion >= kGameVersion_341)
     {
@@ -142,22 +143,22 @@ MainGameFileError OpenMainGameFileBase(PStream &in, MainGameSource &src)
     // rid of it too easily; the easy way is to set it whenever the main
     // game file is opened.
     loaded_game_file_version = src.DataVersion;
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
-MainGameFileError OpenMainGameFile(const String &filename, MainGameSource &src)
+HGameFileError OpenMainGameFile(const String &filename, MainGameSource &src)
 {
     // Cleanup source struct
     src = MainGameSource();
     // Try to open given file
     PStream in(File::OpenFileRead(filename));
     if (!in)
-        return kMGFErr_FileNotFound;
+        return new MainGameFileError(kMGFErr_FileNotFound, String::FromFormat("Filename: %s.", filename.GetCStr()));
     src.Filename = filename;
     return OpenMainGameFileBase(in, src);
 }
 
-MainGameFileError OpenMainGameFileFromDefaultAsset(MainGameSource &src)
+HGameFileError OpenMainGameFileFromDefaultAsset(MainGameSource &src)
 {
     // Cleanup source struct
     src = MainGameSource();
@@ -170,28 +171,27 @@ MainGameFileError OpenMainGameFileFromDefaultAsset(MainGameSource &src)
         in = PStream(AssetManager::OpenAsset(filename));
     }
     if (!in)
-        return kMGFErr_FileNotFound;
-
+        return new MainGameFileError(kMGFErr_FileNotFound, String::FromFormat("Filename: %s.", filename.GetCStr()));
     src.Filename = filename;
     return OpenMainGameFileBase(in, src);
 }
 
-MainGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVersion data_ver)
+HGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVersion data_ver)
 {
     if (data_ver > kGameVersion_310) // 3.1.1+ dialog script
     {
         dialog_script.reset(ccScript::CreateFromStream(in));
         if (dialog_script == NULL)
-            return kMGFErr_CreateDialogScriptFailed;
+            return new MainGameFileError(kMGFErr_CreateDialogScriptFailed, ccErrorString);
     }
     else // 2.x and < 3.1.1 dialog
     {
         dialog_script.reset();
     }
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
-MainGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, GameDataVersion data_ver)
+HGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, GameDataVersion data_ver)
 {
     if (data_ver >= kGameVersion_270) // 2.7.0+ script modules
     {
@@ -201,14 +201,14 @@ MainGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, G
         {
             sc_mods[i].reset(ccScript::CreateFromStream(in));
             if (sc_mods[i] == NULL)
-                return kMGFErr_CreateScriptModuleFailed;
+                return new MainGameFileError(kMGFErr_CreateScriptModuleFailed, ccErrorString);
         }
     }
     else
     {
         sc_mods.resize(0);
     }
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 void ReadViewStruct272_Aligned(std::vector<ViewStruct272> &oldv, Stream *in, size_t count)
@@ -354,10 +354,11 @@ void ReadDialogs(DialogTopic *&dialog,
     }
 }
 
-MainGameFileError ReadPlugins(std::vector<PluginInfo> &infos, Stream *in)
+HGameFileError ReadPlugins(std::vector<PluginInfo> &infos, Stream *in)
 {
-    if (in->ReadInt32() != 1)
-        return kMGFErr_PluginDataFmtNotSupported;
+    int fmt_ver = in->ReadInt32();
+    if (fmt_ver != 1)
+        return new MainGameFileError(kMGFErr_PluginDataFmtNotSupported, String::FromFormat("Version: %d, supported: %d", fmt_ver, 1));
 
     int pl_count = in->ReadInt32();
     for (int i = 0; i < pl_count; ++i)
@@ -366,7 +367,7 @@ MainGameFileError ReadPlugins(std::vector<PluginInfo> &infos, Stream *in)
         size_t datasize = in->ReadInt32();
         // just check for silly datasizes
         if (datasize > PLUGIN_SAVEBUFFERSIZE)
-            return kMGFErr_PluginDataSizeTooLarge;
+            return new MainGameFileError(kMGFErr_PluginDataSizeTooLarge, String::FromFormat("Required: %u, max: %u", datasize, PLUGIN_SAVEBUFFERSIZE));
 
         PluginInfo info;
         info.Name = name;
@@ -378,7 +379,7 @@ MainGameFileError ReadPlugins(std::vector<PluginInfo> &infos, Stream *in)
         info.DataLen = datasize;
         infos.push_back(info);
     }
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 // Create the missing audioClips data structure for 3.1.x games.
@@ -633,7 +634,7 @@ void FixupSaveDirectory(GameSetupStruct &game)
     snprintf(game.saveGameFolderName, MAX_SG_FOLDER_LEN, "%s", s.GetCStr());
 }
 
-MainGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver)
+HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver)
 {
     GameSetupStruct &game = ents.Game;
 
@@ -643,32 +644,32 @@ MainGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVer
     }
 
     if (game.size.IsNull())
-        return kMGFErr_InvalidNativeResolution;
+        return new MainGameFileError(kMGFErr_InvalidNativeResolution);
     if (game.numfonts > MAX_FONTS)
-        return kMGFErr_TooManyFonts;
+        return new MainGameFileError(kMGFErr_TooManyFonts, String::FromFormat("Count: %d, max: %d", game.numfonts, MAX_FONTS));
 
     game.read_savegame_info(in, data_ver);
     game.read_font_flags(in, data_ver);
-    MainGameFileError err = game.read_sprite_flags(in, data_ver);
-    if (err != kMGFErr_NoError)
+    HGameFileError err = game.read_sprite_flags(in, data_ver);
+    if (!err)
         return err;
     game.ReadInvInfo_Aligned(in);
     err = game.read_cursors(in, data_ver);
-    if (err != kMGFErr_NoError)
+    if (!err)
         return err;
     game.read_interaction_scripts(in, data_ver);
     game.read_words_dictionary(in);
 
     if (!game.load_compiled_script)
-        return kMGFErr_NoGlobalScript;
+        return new MainGameFileError(kMGFErr_NoGlobalScript);
     ents.GlobalScript.reset(ccScript::CreateFromStream(in));
     if (!ents.GlobalScript)
-        return kMGFErr_CreateGlobalScriptFailed;
+        return new MainGameFileError(kMGFErr_CreateGlobalScriptFailed, ccErrorString);
     err = ReadDialogScript(ents.DialogScript, in, data_ver);
-    if (err != kMGFErr_NoError)
+    if (!err)
         return err;
     err = ReadScriptModules(ents.ScriptModules, in, data_ver);
-    if (err != kMGFErr_NoError)
+    if (!err)
         return err;
 
     ReadViews(game, ents.Views, in, data_ver);
@@ -692,21 +693,21 @@ MainGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVer
     if (data_ver >= kGameVersion_260)
     {
         err = ReadPlugins(ents.PluginInfos, in);
-        if (err != kMGFErr_NoError)
+        if (!err)
             return err;
     }
 
     err = game.read_customprops(in, data_ver);
-    if (err != kMGFErr_NoError)
+    if (!err)
         return err;
     err = game.read_audio(in, data_ver);
-    if (err != kMGFErr_NoError)
+    if (!err)
         return err;
     game.read_room_names(in, data_ver);
-    return kMGFErr_NoError;
+    return err;
 }
 
-MainGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver)
+HGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver)
 {
     GameSetupStruct &game = ents.Game;
     UpgradeAudio(game, data_ver);
@@ -729,7 +730,7 @@ MainGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_
     if (data_ver < kGameVersion_340_2)
         game.options[OPT_DIALOGOPTIONSAPI] = -1;
     FixupSaveDirectory(game);
-    return kMGFErr_NoError;
+    return HGameFileError::None();
 }
 
 } // namespace Common

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -27,6 +27,7 @@
 #include "ac/game_version.h"
 #include "game/plugininfo.h"
 #include "script/cc_script.h"
+#include "util/error.h"
 #include "util/stream.h"
 #include "util/string.h"
 #include "util/version.h"
@@ -41,7 +42,7 @@ namespace Common
 {
 
 // Error codes for main game file reading
-enum MainGameFileError
+enum MainGameFileErrorType
 {
     kMGFErr_NoError,
     kMGFErr_FileNotFound,
@@ -65,6 +66,10 @@ enum MainGameFileError
     kMGFErr_PluginDataSizeTooLarge
 };
 
+String GetMainGameFileErrorText(MainGameFileErrorType err);
+
+typedef TypedCodeError<MainGameFileErrorType, GetMainGameFileErrorText> MainGameFileError;
+typedef ErrorHandle<MainGameFileError> HGameFileError;
 typedef stdtr1compat::shared_ptr<Stream> PStream;
 
 // MainGameSource defines a successfully opened main game file
@@ -118,18 +123,17 @@ struct LoadedGameEntities
     LoadedGameEntities(GameSetupStruct &game, DialogTopic *&dialogs, ViewStruct *&views);
 };
 
-String             GetMainGameFileErrorText(MainGameFileError err);
 // Tells if the given path (library filename) contains main game file
 bool               IsMainGameLibrary(const String &filename);
 // Opens main game file for reading from an arbitrary file
-MainGameFileError  OpenMainGameFile(const String &filename, MainGameSource &src);
+HGameFileError     OpenMainGameFile(const String &filename, MainGameSource &src);
 // Opens main game file for reading from the asset library (uses default asset name)
-MainGameFileError  OpenMainGameFileFromDefaultAsset(MainGameSource &src);
+HGameFileError     OpenMainGameFileFromDefaultAsset(MainGameSource &src);
 // Reads game data, applies necessary conversions to match current format version
-MainGameFileError  ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver);
+HGameFileError     ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver);
 // Applies necessary updates, conversions and fixups to the loaded data
 // making it compatible with current engine
-MainGameFileError  UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver);
+HGameFileError     UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver);
 // Ensures that the game saves directory path is valid
 void               FixupSaveDirectory(GameSetupStruct &game);
 

--- a/Common/util/error.h
+++ b/Common/util/error.h
@@ -111,10 +111,14 @@ private:
 };
 
 
+// Basic error handle, containing Error object
+typedef ErrorHandle<Error> HError;
+
+
 // TypedCodeError is the Error's subclass, which only purpose is to override
 // error code type in constructor and Code() getter, that may be useful if
 // you'd like to restrict code values to particular enumerator.
-template <typename CodeType, typedef String (*GetErrorText)(CodeType)>
+template <typename CodeType, String (*GetErrorText)(CodeType)>
 class TypedCodeError : public Error
 {
 public:
@@ -122,7 +126,7 @@ public:
     TypedCodeError(CodeType code, String comment, PError inner_error = PError()) :
         Error(code, GetErrorText(code), comment, inner_error) {}
 
-    CodeType Code() const { return (CodeType)_code; }
+    CodeType Code() const { return (CodeType)Error::Code(); }
 };
 
 } // namespace Common

--- a/Common/util/error.h
+++ b/Common/util/error.h
@@ -1,0 +1,113 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Universal error class, that may be used both as a return value or
+// thrown as an exception.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__ERROR_H
+#define __AGS_CN_UTIL__ERROR_H
+
+#include "util/stdtr1compat.h"
+#include TR1INCLUDE(memory)
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+//
+// A simple struct, that provides several fields to describe an error in the program.
+// If wanted, may be reworked into subclass of std::exception.
+//
+class Error
+{
+public:
+    Error(int code) : _code(code) {}
+    Error(String general) : _general(general) {}
+    Error(int code, String general) : _code(code), _general(general) {}
+    Error(int code, String general, String comment) : _code(code), _general(general), _comment(comment) {}
+    Error(String general, String comment) : _general(general), _comment(comment) {}
+
+    // Error code is a number, defining error subtype. It is not much use to the end-user,
+    // but may be checked in the code to know more precise cause of the error.
+    int    Code() const { return _code; }
+    // General description of this error type and subtype.
+    String General() const { return _general; }
+    // Any complementary information.
+    String Comment() const { return _comment; }
+    // Full error message combines general description and comment.
+    // NOTE: if made a child of std::exception, FullMessage may be substituted
+    // or complemented with virtual const char* what().
+    String FullMessage() const
+    {
+        if (_comment.IsEmpty())
+            return _general;
+        return String::FromFormat("%s\n%s", _general.GetCStr(), _comment.GetCStr());
+    }
+
+private:
+    int    _code; // numeric code, for specific uses
+    String _general; // general description of this error class
+    String _comment; // additional information about particular case
+};
+
+
+// ErrorHandle is a helper class that lets you have an Error object
+// wrapped in a smart pointer. ErrorHandle's only data member is a
+// shared_ptr, which means that it does not cause too much data copying
+// when used as a function's return value.
+// Note, that the reason to have distinct class instead of a shared_ptr's
+// typedef is an inverted boolean comparison:
+// shared_ptr converts to 'true' when it contains an object, but ErrorHandle
+// returns 'true' when it *does NOT* contain an object, meaning there
+// is no error.
+template <class T> class ErrorHandle
+{
+public:
+    static ErrorHandle<T> None() { return ErrorHandle(); }
+
+    ErrorHandle() {}
+    ErrorHandle(T *err) : _error(err) {}
+    ErrorHandle(std::shared_ptr<T> err) : _error(err) {}
+
+    bool HasError() const { return _error; }
+    explicit operator bool() const { return !_error; }
+    T *operator ->() const { return _error.operator->(); }
+    T &operator *() const { return _error.operator*(); }
+
+private:
+    std::shared_ptr<T> _error;
+};
+
+
+// TypedCodeError is the Error's subclass, which only purpose is to override
+// error code type in constructor and Code() getter, that may be useful if
+// you'd like to restrict code values to particular enumerator.
+template <typename CodeType, typedef String (*GetErrorText)(CodeType)>
+class TypedCodeError : public Error
+{
+public:
+    TypedCodeError(CodeType code) : Error(code, GetErrorText(code)) {}
+    TypedCodeError(CodeType code, String comment) :
+        Error(code, GetErrorText(code), comment) {}
+
+    CodeType Code() const { return (CodeType)_code; }
+};
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__ERROR_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1197,7 +1197,7 @@ void save_game(int slotn, const char*descript) {
 
 char rbuffer[200];
 
-SavegameError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
+HSaveError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
 {
     r_data.FPS = in->ReadInt32();
     r_data.CursorMode = in->ReadInt32();
@@ -1205,8 +1205,7 @@ SavegameError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
     offsetx = in->ReadInt32();
     offsety = in->ReadInt32();
     loopcounter = in->ReadInt32();
-
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 void restore_game_spriteset(Stream *in)
@@ -1224,14 +1223,13 @@ void restore_game_spriteset(Stream *in)
     }
 }
 
-SavegameError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredData &r_data)
+HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredData &r_data)
 {
     // read the global script data segment
     int gdatasize = in->ReadInt32();
     if (pp.GlScDataSize != gdatasize)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching size of global script data");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching size of global script data");
     }
     r_data.GlobalScript.Len = gdatasize;
     r_data.GlobalScript.Data.reset(new char[gdatasize]);
@@ -1239,8 +1237,7 @@ SavegameError restore_game_scripts(Stream *in, const PreservedParams &pp, Restor
 
     if (in->ReadInt32() != numScriptModules)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of script modules");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of script modules");
     }
     r_data.ScriptModules.resize(numScriptModules);
     for (int i = 0; i < numScriptModules; ++i)
@@ -1248,14 +1245,13 @@ SavegameError restore_game_scripts(Stream *in, const PreservedParams &pp, Restor
         size_t module_size = in->ReadInt32();
         if (pp.ScMdDataSize[i] != module_size)
         {
-            Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching size of script module data, module %d", i);
-            return kSvgErr_GameContentAssertion;
+            return new SavegameError(kSvgErr_GameContentAssertion, String::FromFormat("Mismatching size of script module data, module %d", i));
         }
         r_data.ScriptModules[i].Len = module_size;
         r_data.ScriptModules[i].Data.reset(new char[module_size]);
         in->Read(r_data.ScriptModules[i].Data.get(), module_size);
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 void ReadRoomStatus_Aligned(RoomStatus *roomstat, Stream *in)
@@ -1395,35 +1391,33 @@ void ReadAnimatedButtons_Aligned(Stream *in)
     }
 }
 
-SavegameError restore_game_gui(Stream *in, int numGuisWas)
+HSaveError restore_game_gui(Stream *in, int numGuisWas)
 {
     GUI::ReadGUI(guis, in);
     game.numgui = guis.size();
 
     if (numGuisWas != game.numgui)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of GUI");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of GUI");
     }
 
     numAnimButs = in->ReadInt32();
     ReadAnimatedButtons_Aligned(in);
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError restore_game_audiocliptypes(Stream *in)
+HSaveError restore_game_audiocliptypes(Stream *in)
 {
     if (in->ReadInt32() != game.audioClipTypeCount)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Audio Clip Types");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clip Types");
     }
 
     for (int i = 0; i < game.audioClipTypeCount; ++i)
     {
         game.audioClipTypes[i].ReadFromFile(in);
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 void restore_game_thisroom(Stream *in, RestoredData &r_data)
@@ -1522,27 +1516,25 @@ void restore_game_displayed_room_status(Stream *in, RestoredData &r_data)
     }
 }
 
-SavegameError restore_game_globalvars(Stream *in)
+HSaveError restore_game_globalvars(Stream *in)
 {
     if (in->ReadInt32() != numGlobalVars)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Global Variables");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Restore game error: mismatching number of Global Variables");
     }
 
     for (int i = 0; i < numGlobalVars; ++i)
     {
         globalvars[i].Read(in);
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError restore_game_views(Stream *in)
+HSaveError restore_game_views(Stream *in)
 {
     if (in->ReadInt32() != game.numviews)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Views");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views");
     }
 
     for (int bb = 0; bb < game.numviews; bb++) {
@@ -1554,15 +1546,14 @@ SavegameError restore_game_views(Stream *in)
             }
         }
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_data)
+HSaveError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_data)
 {
     if (in->ReadInt32() != game.audioClipCount)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Audio Clips");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clips");
     }
 
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
@@ -1574,8 +1565,7 @@ SavegameError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_
         {
             if (chan_info.ClipID >= game.audioClipCount)
             {
-                Debug::Printf(kDbgMsg_Error, "Restore game error: invalid audio clip index");
-                return kSvgErr_GameObjectInitFailed;
+                return new SavegameError(kSvgErr_GameObjectInitFailed, "Invalid audio clip index");
             }
 
             chan_info.Pos = in->ReadInt32();
@@ -1596,22 +1586,22 @@ SavegameError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_
     crossFadeVolumePerStep = in->ReadInt32();
     crossFadeStep = in->ReadInt32();
     crossFadeVolumeAtStart = in->ReadInt32();
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError restore_game_data(Stream *in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data)
+HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data)
 {
     int vv;
 
-    SavegameError err = restore_game_head_dynamic_values(in, r_data);
-    if (err != kSvgErr_NoError)
+    HSaveError err = restore_game_head_dynamic_values(in, r_data);
+    if (!err)
         return err;
     restore_game_spriteset(in);
 
     update_polled_stuff_if_runtime();
 
     err = restore_game_scripts(in, pp, r_data);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     restore_game_room_state(in);
     restore_game_play(in);
@@ -1639,23 +1629,19 @@ SavegameError restore_game_data(Stream *in, SavegameVersion svg_version, const P
 
     if (game.numdialog!=numdiwas)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Dialogs");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Dialogs");
     }
     if (numchwas != game.numcharacters)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Characters");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Characters");
     }
     if (numinvwas != game.numinvitems)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Inventory Items");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Inventory Items");
     }
     if (game.numviews != numviewswas)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of Views");
-        return kSvgErr_GameContentAssertion;
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views");
     }
 
     game.ReadFromSaveGame_v321(in, gswas, compsc, chwas, olddict, mesbk);
@@ -1668,10 +1654,10 @@ SavegameError restore_game_data(Stream *in, SavegameVersion svg_version, const P
     restore_game_dialogs(in);
     restore_game_more_dynamic_values(in);
     err = restore_game_gui(in, numGuisWas);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     err = restore_game_audiocliptypes(in);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     restore_game_thisroom(in, r_data);
     restore_game_ambientsounds(in, r_data);
@@ -1685,40 +1671,39 @@ SavegameError restore_game_data(Stream *in, SavegameVersion svg_version, const P
 
     restore_game_displayed_room_status(in, r_data);
     err = restore_game_globalvars(in);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     err = restore_game_views(in);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
 
     if (in->ReadInt32() != MAGICNUMBER+1)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: MAGICNUMBER not found before Audio Clips");
-        return kSvgErr_InconsistentFormat;
+        return new SavegameError(kSvgErr_InconsistentFormat, "MAGICNUMBER not found before Audio Clips");
     }
 
     err = restore_game_audioclips_and_crossfade(in, r_data);
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
 
     // [IKM] Plugins expect FILE pointer! // TODO something with this later
     pl_run_plugin_hooks(AGSE_RESTOREGAME, (long)((Common::FileStream*)in)->GetHandle());
     if (in->ReadInt32() != (unsigned)MAGICNUMBER)
-        return kSvgErr_InconsistentPlugin;
+        return new SavegameError(kSvgErr_InconsistentPlugin);
 
     // save the new room music vol for later use
     r_data.RoomVolume = in->ReadInt32();
 
     if (ccUnserializeAllObjects(in, &ccUnserializer))
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: managed pool deserialization failed: %s", ccErrorString);
-        return kSvgErr_GameObjectInitFailed;
+        return new SavegameError(kSvgErr_GameObjectInitFailed,
+            String::FromFormat("Managed pool deserialization failed: %s", ccErrorString));
     }
 
     // preserve legacy music type setting
     current_music_type = in->ReadInt32();
 
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 int gameHasBeenRestored = 0;
@@ -1727,8 +1712,7 @@ int oldeip;
 bool read_savedgame_description(const String &savedgame, String &description)
 {
     SavegameDescription desc;
-    SavegameError err = OpenSavegame(savedgame, desc, kSvgDesc_UserText);
-    if (err == kSvgErr_NoError)
+    if (OpenSavegame(savedgame, desc, kSvgDesc_UserText))
     {
         description = desc.UserText;
         return true;
@@ -1741,8 +1725,8 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot)
     want_shot = 0;
 
     SavegameDescription desc;
-    SavegameError err = OpenSavegame(savedgame, desc, kSvgDesc_UserImage);
-    if (err != kSvgErr_NoError)
+    HSaveError err = OpenSavegame(savedgame, desc, kSvgDesc_UserImage);
+    if (!err)
         return false;
 
     if (desc.UserImage.get())
@@ -1758,7 +1742,7 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot)
     return true;
 }
 
-SavegameError load_game(const String &path, int slotNumber, bool &data_overwritten)
+HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
 {
     data_overwritten = false;
     gameHasBeenRestored++;
@@ -1766,21 +1750,19 @@ SavegameError load_game(const String &path, int slotNumber, bool &data_overwritt
     oldeip = our_eip;
     our_eip = 2050;
 
-    SavegameError err;
+    HSaveError err;
     SavegameSource src;
     SavegameDescription desc;
     err = OpenSavegame(path, src, desc, kSvgDesc_EnvInfo);
 
-    our_eip = 2051;
-
     // saved in incompatible enviroment
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     // CHECKME: is this color depth test still essential? if yes, is there possible workaround?
     else if (desc.ColorDepth != System_GetColorDepth())
-        return kSvgErr_DifferentColorDepth;
+        return new SavegameError(kSvgErr_DifferentColorDepth);
     else if (!src.InputStream.get())
-        return kSvgErr_NoStream;
+        return new SavegameError(kSvgErr_NoStream);
 
     // saved with different game file
     if (Path::ComparePaths(desc.MainDataFilename, usetup.main_data_filename))
@@ -1793,7 +1775,7 @@ SavegameError load_game(const String &path, int slotNumber, bool &data_overwritt
         {
             RunAGSGame (desc.MainDataFilename, 0, 0);
             load_new_game_restore = slotNumber;
-            return kSvgErr_NoError;
+            return HSaveError::None();
         }
         Common::Debug::Printf(kDbgMsg_Warn, "WARNING: the saved game '%s' references game file '%s', but it cannot be found in the current directory. Trying to restore in the running game instead.",
             path.GetCStr(), desc.MainDataFilename.GetCStr());
@@ -1802,7 +1784,7 @@ SavegameError load_game(const String &path, int slotNumber, bool &data_overwritt
     // do the actual restore
     err = RestoreGameState(src.InputStream, src.Version);
     data_overwritten = true;
-    if (err != kSvgErr_NoError)
+    if (!err)
         return err;
     src.InputStream.reset();
     our_eip = oldeip;
@@ -1813,7 +1795,7 @@ SavegameError load_game(const String &path, int slotNumber, bool &data_overwritt
     while (keypressed()) readkey();
     // call "After Restore" event callback
     run_on_event(GE_RESTORE_GAME, RuntimeScriptValue().SetInt32(slotNumber));
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 bool try_restore_save(int slot)
@@ -1824,10 +1806,11 @@ bool try_restore_save(int slot)
 bool try_restore_save(const Common::String &path, int slot)
 {
     bool data_overwritten;
-    SavegameError err = load_game(path, slot, data_overwritten);
-    if (err != kSvgErr_NoError)
+    HSaveError err = load_game(path, slot, data_overwritten);
+    if (!err)
     {
-        String error = String::FromFormat("Unable to restore game:\n%s", GetSavegameErrorText(err).GetCStr());
+        String error = String::FromFormat("Unable to restore game:\n%s",
+            err->FullMessage().GetCStr());
         // currently AGS cannot properly revert to stable state if some of the
         // game data was released or overwritten by the data from save file,
         // this is why we tell engine to shutdown if that happened.

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1229,7 +1229,7 @@ HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredD
     int gdatasize = in->ReadInt32();
     if (pp.GlScDataSize != gdatasize)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching size of global script data");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching size of global script data.");
     }
     r_data.GlobalScript.Len = gdatasize;
     r_data.GlobalScript.Data.reset(new char[gdatasize]);
@@ -1237,7 +1237,7 @@ HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredD
 
     if (in->ReadInt32() != numScriptModules)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of script modules");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of script modules.");
     }
     r_data.ScriptModules.resize(numScriptModules);
     for (int i = 0; i < numScriptModules; ++i)
@@ -1245,7 +1245,7 @@ HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredD
         size_t module_size = in->ReadInt32();
         if (pp.ScMdDataSize[i] != module_size)
         {
-            return new SavegameError(kSvgErr_GameContentAssertion, String::FromFormat("Mismatching size of script module data, module %d", i));
+            return new SavegameError(kSvgErr_GameContentAssertion, String::FromFormat("Mismatching size of script module data, module %d.", i));
         }
         r_data.ScriptModules[i].Len = module_size;
         r_data.ScriptModules[i].Data.reset(new char[module_size]);
@@ -1398,7 +1398,7 @@ HSaveError restore_game_gui(Stream *in, int numGuisWas)
 
     if (numGuisWas != game.numgui)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of GUI");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of GUI.");
     }
 
     numAnimButs = in->ReadInt32();
@@ -1410,7 +1410,7 @@ HSaveError restore_game_audiocliptypes(Stream *in)
 {
     if (in->ReadInt32() != game.audioClipTypeCount)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clip Types");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clip Types.");
     }
 
     for (int i = 0; i < game.audioClipTypeCount; ++i)
@@ -1520,7 +1520,7 @@ HSaveError restore_game_globalvars(Stream *in)
 {
     if (in->ReadInt32() != numGlobalVars)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Restore game error: mismatching number of Global Variables");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Restore game error: mismatching number of Global Variables.");
     }
 
     for (int i = 0; i < numGlobalVars; ++i)
@@ -1534,7 +1534,7 @@ HSaveError restore_game_views(Stream *in)
 {
     if (in->ReadInt32() != game.numviews)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views.");
     }
 
     for (int bb = 0; bb < game.numviews; bb++) {
@@ -1553,7 +1553,7 @@ HSaveError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_dat
 {
     if (in->ReadInt32() != game.audioClipCount)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clips");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clips.");
     }
 
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
@@ -1565,7 +1565,7 @@ HSaveError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_dat
         {
             if (chan_info.ClipID >= game.audioClipCount)
             {
-                return new SavegameError(kSvgErr_GameObjectInitFailed, "Invalid audio clip index");
+                return new SavegameError(kSvgErr_GameObjectInitFailed, "Invalid audio clip index.");
             }
 
             chan_info.Pos = in->ReadInt32();
@@ -1629,19 +1629,19 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
 
     if (game.numdialog!=numdiwas)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Dialogs");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Dialogs.");
     }
     if (numchwas != game.numcharacters)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Characters");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Characters.");
     }
     if (numinvwas != game.numinvitems)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Inventory Items");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Inventory Items.");
     }
     if (game.numviews != numviewswas)
     {
-        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views");
+        return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Views.");
     }
 
     game.ReadFromSaveGame_v321(in, gswas, compsc, chwas, olddict, mesbk);
@@ -1679,7 +1679,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
 
     if (in->ReadInt32() != MAGICNUMBER+1)
     {
-        return new SavegameError(kSvgErr_InconsistentFormat, "MAGICNUMBER not found before Audio Clips");
+        return new SavegameError(kSvgErr_InconsistentFormat, "MAGICNUMBER not found before Audio Clips.");
     }
 
     err = restore_game_audioclips_and_crossfade(in, r_data);
@@ -1697,7 +1697,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     if (ccUnserializeAllObjects(in, &ccUnserializer))
     {
         return new SavegameError(kSvgErr_GameObjectInitFailed,
-            String::FromFormat("Managed pool deserialization failed: %s", ccErrorString));
+            String::FromFormat("Managed pool deserialization failed: %s.", ccErrorString));
     }
 
     // preserve legacy music type setting
@@ -1760,7 +1760,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
         return err;
     // CHECKME: is this color depth test still essential? if yes, is there possible workaround?
     else if (desc.ColorDepth != System_GetColorDepth())
-        return new SavegameError(kSvgErr_DifferentColorDepth);
+        return new SavegameError(kSvgErr_DifferentColorDepth, String::FromFormat("Running: %d-bit, saved in: %d-bit.", System_GetColorDepth(), desc.ColorDepth));
     else if (!src.InputStream.get())
         return new SavegameError(kSvgErr_NoStream);
 
@@ -1809,7 +1809,7 @@ bool try_restore_save(const Common::String &path, int slot)
     HSaveError err = load_game(path, slot, data_overwritten);
     if (!err)
     {
-        String error = String::FromFormat("Unable to restore game:\n%s",
+        String error = String::FromFormat("Unable to restore the saved game.\n%s",
             err->FullMessage().GetCStr());
         // currently AGS cannot properly revert to stable state if some of the
         // game data was released or overwritten by the data from save file,

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -275,9 +275,9 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
     ds->Fill(0);
     show_preload();
 
-    String err_str;
-    if (!load_game_file(err_str))
-        quitprintf("!RunAGSGame: error loading new game file:\n%s", err_str.GetCStr());
+    HError err = load_game_file();
+    if (!err)
+        quitprintf("!RunAGSGame: error loading new game file:\n%s", err->FullMessage().GetCStr());
 
     spriteset.reset();
     if (spriteset.initFile ("acsprset.spr"))

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -16,6 +16,7 @@
 #define __AC_MOVE_H
 
 #include "util/wgt2allg.h" // fixed type
+#include "game/savegame.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
@@ -35,7 +36,7 @@ struct MoveList {
     char  direct;  // MoveCharDirect was used or not
 
     void ReadFromFile_Legacy(Common::Stream *in);
-    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
+    AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);
 };
 

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -464,7 +464,7 @@ void start_playback()
             if (replayver >= 3) {
                 int issave = in->ReadInt32();
                 if (issave) {
-                    if (RestoreGameState(in, kSvgVersion_321) != kSvgErr_NoError)
+                    if (!RestoreGameState(in, kSvgVersion_321))
                         quit("!Error running replay... could be incorrect game version");
                     replay_last_second = loopcounter;
                 }

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -107,24 +107,24 @@ namespace AGS
 namespace Engine
 {
 
-String GetGameInitErrorText(GameInitError err)
+String GetGameInitErrorText(GameInitErrorType err)
 {
     switch (err)
     {
     case kGameInitErr_NoError:
-        return "No error";
+        return "No error.";
     case kGameInitErr_NoFonts:
-        return "No fonts specified to be used in this game";
+        return "No fonts specified to be used in this game.";
     case kGameInitErr_TooManyAudioTypes:
-        return "Too many audio types for this engine to handle";
+        return "Too many audio types for this engine to handle.";
     case kGameInitErr_TooManyPlugins:
-        return "Too many plugins for this engine to handle";
+        return "Too many plugins for this engine to handle.";
     case kGameInitErr_PluginNameInvalid:
-        return "Plugin name is invalid";
+        return "Plugin name is invalid.";
     case kGameInitErr_ScriptLinkFailed:
-        return String::FromFormat("Script link failed: %s", ccErrorString);
+        return "Script link failed.";
     }
-    return "Unknown error";
+    return "Unknown error.";
 }
 
 // Initializes audio channels and clips and registers them in the script system
@@ -354,7 +354,7 @@ void AllocScriptModules()
     }
 }
 
-GameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver)
+HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver)
 {
     if (data_ver >= kGameVersion_341)
     {
@@ -375,9 +375,9 @@ GameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data
     // engine capabilities.
     //
     if (game.numfonts == 0)
-        return kGameInitErr_NoFonts;
+        return new GameInitError(kGameInitErr_NoFonts);
     if (game.audioClipTypeCount > MAX_AUDIO_TYPES)
-        return kGameInitErr_TooManyAudioTypes;
+        return new GameInitError(kGameInitErr_TooManyAudioTypes, String::FromFormat("Required: %d, max: %d", game.audioClipTypeCount, MAX_AUDIO_TYPES));
 
     //
     // 2. Apply overriding config settings
@@ -469,9 +469,9 @@ GameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion data
     scriptModules = ents.ScriptModules;
     AllocScriptModules();
     if (create_global_script())
-        return kGameInitErr_ScriptLinkFailed;
+        return new GameInitError(kGameInitErr_ScriptLinkFailed, ccErrorString);
 
-    return kGameInitErr_NoError;
+    return HGameInitError::None();
 }
 
 } // namespace Engine

--- a/Engine/game/game_init.h
+++ b/Engine/game/game_init.h
@@ -31,7 +31,7 @@ namespace Engine
 using namespace Common;
 
 // Error codes for initializing the game
-enum GameInitError
+enum GameInitErrorType
 {
     kGameInitErr_NoError,
     // currently AGS requires at least one font to be present in game
@@ -42,9 +42,13 @@ enum GameInitError
     kGameInitErr_ScriptLinkFailed
 };
 
-String          GetGameInitErrorText(GameInitError err);
+String GetGameInitErrorText(GameInitErrorType err);
+
+typedef TypedCodeError<GameInitErrorType, GetGameInitErrorText> GameInitError;
+typedef ErrorHandle<GameInitError> HGameInitError;
+
 // Sets up game state for play using preloaded data
-GameInitError   InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver);
+HGameInitError  InitGameState(const LoadedGameEntities &ents, GameDataVersion data_ver);
 
 } // namespace Engine
 } // namespace AGS

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -17,6 +17,7 @@
 
 #include "util/stdtr1compat.h"
 #include TR1INCLUDE(memory)
+#include "util/error.h"
 #include "util/version.h"
 
 
@@ -29,6 +30,8 @@ namespace Engine
 {
 
 using Common::Bitmap;
+using Common::ErrorHandle;
+using Common::TypedCodeError;
 using Common::Stream;
 using Common::String;
 using Common::Version;
@@ -51,7 +54,7 @@ enum SavegameVersion
 };
 
 // Error codes for save restoration routine
-enum SavegameError
+enum SavegameErrorType
 {
     kSvgErr_NoError,
     kSvgErr_FileNotFound,
@@ -76,6 +79,10 @@ enum SavegameError
     kNumSavegameError
 };
 
+String GetSavegameErrorText(SavegameErrorType err);
+
+typedef TypedCodeError<SavegameErrorType, GetSavegameErrorText> SavegameError;
+typedef ErrorHandle<SavegameError> HSaveError;
 typedef std::unique_ptr<Stream> UStream;
 typedef std::unique_ptr<Bitmap> UBitmap;
 
@@ -134,15 +141,14 @@ struct SavegameDescription
 };
 
 
-String         GetSavegameErrorText(SavegameError err);
 // Opens savegame for reading; optionally reads description, if any is provided
-SavegameError  OpenSavegame(const String &filename, SavegameSource &src,
+HSaveError     OpenSavegame(const String &filename, SavegameSource &src,
                             SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 // Opens savegame and reads the savegame description
-SavegameError  OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
+HSaveError     OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems = kSvgDesc_All);
 
 // Reads the game data from the save stream and reinitializes game state
-SavegameError  RestoreGameState(PStream in, SavegameVersion svg_version);
+HSaveError     RestoreGameState(PStream in, SavegameVersion svg_version);
 
 // Opens savegame for writing and puts in savegame description
 PStream        StartSavegame(const String &filename, const String &user_text, const Bitmap *user_image);

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -69,6 +69,8 @@ enum SavegameErrorType
     kSvgErr_ComponentClosingTagFormat,
     kSvgErr_ComponentSizeMismatch,
     kSvgErr_UnsupportedComponent,
+    kSvgErr_ComponentSerialization,
+    kSvgErr_ComponentUnserialization,
     kSvgErr_InconsistentFormat,
     kSvgErr_UnsupportedComponentVersion,
     kSvgErr_GameContentAssertion,

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -389,7 +389,9 @@ HSaveError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams &pp
         if (loaded_game_file_version <= kGameVersion_272)
             game.intrChar[i]->ReadTimesRunFromSavedgame(in.get());
         // character movement path cache
-        mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver);
+        err = mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver > 0 ? 1 : 0);
+        if (!err)
+            return err;
     }
     return err;
 }
@@ -909,7 +911,9 @@ HSaveError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
         return err;
     for (int i = 0; i < objmls_count; ++i)
     {
-        mls[i].ReadFromFile(in.get(), cmp_ver);
+        err = mls[i].ReadFromFile(in.get(), cmp_ver > 0 ? 1 : 0);
+        if (!err)
+            return err;
     }
 
     // save the new room music vol for later use

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -109,65 +109,83 @@ bool AssertFormatTag(PStream in, const String &tag, bool open = true)
     return read_tag.Compare(tag) == 0;
 }
 
-inline bool AssertCompatLimit(int count, int max_count, const char *content_name)
+bool AssertFormatTagStrict(HSaveError &err, PStream in, const String &tag, bool open = true)
+{
+    
+    String read_tag;
+    if (!ReadFormatTag(in, read_tag, open) || read_tag.Compare(tag) != 0)
+    {
+        err = new SavegameError(kSvgErr_InconsistentFormat,
+            String::FromFormat("Mismatching tag: %s", tag.GetCStr()));
+        return false;
+    }
+    return true;
+}
+
+inline bool AssertCompatLimit(HSaveError &err, int count, int max_count, const char *content_name)
 {
     if (count > max_count)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: incompatible number of %s (count: %d, max: %d)",
-            content_name, count, max_count);
+        err = new SavegameError(kSvgErr_IncompatibleEngine,
+            String::FromFormat("Incompatible number of %s (count: %d, max: %d)",
+            content_name, count, max_count));
         return false;
     }
     return true;
 }
 
-inline bool AssertCompatRange(int value, int min_value, int max_value, const char *content_name)
+inline bool AssertCompatRange(HSaveError &err, int value, int min_value, int max_value, const char *content_name)
 {
     if (value < min_value || value > max_value)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: incompatible %s (id: %d, range: %d - %d)",
-            content_name, value, min_value, max_value);
+        err = new SavegameError(kSvgErr_IncompatibleEngine,
+            String::FromFormat("Restore game error: incompatible %s (id: %d, range: %d - %d)",
+            content_name, value, min_value, max_value));
         return false;
     }
     return true;
 }
 
-inline bool AssertGameContent(int new_val, int original_val, const char *content_name)
+inline bool AssertGameContent(HSaveError &err, int new_val, int original_val, const char *content_name)
 {
     if (new_val != original_val)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of %s (game: %d, save: %d)",
-            content_name, original_val, new_val);
+        err = new SavegameError(kSvgErr_GameContentAssertion,
+            String::FromFormat("Mismatching number of %s (game: %d, save: %d)",
+            content_name, original_val, new_val));
         return false;
     }
     return true;
 }
 
-inline bool AssertGameObjectContent(int new_val, int original_val, const char *content_name,
+inline bool AssertGameObjectContent(HSaveError &err, int new_val, int original_val, const char *content_name,
                                     const char *obj_type, int obj_id)
 {
     if (new_val != original_val)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of %s, %s #%d (game: %d, save: %d)",
-            content_name, obj_type, obj_id, original_val, new_val);
+        err = new SavegameError(kSvgErr_GameContentAssertion,
+            String::FromFormat("Mismatching number of %s, %s #%d (game: %d, save: %d)",
+            content_name, obj_type, obj_id, original_val, new_val));
         return false;
     }
     return true;
 }
 
-inline bool AssertGameObjectContent2(int new_val, int original_val, const char *content_name,
+inline bool AssertGameObjectContent2(HSaveError &err, int new_val, int original_val, const char *content_name,
                                     const char *obj1_type, int obj1_id, const char *obj2_type, int obj2_id)
 {
     if (new_val != original_val)
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: mismatching number of %s, %s #%d, %s #%d (game: %d, save: %d)",
-            content_name, obj1_type, obj1_id, obj2_type, obj2_id, original_val, new_val);
+        err = new SavegameError(kSvgErr_GameContentAssertion,
+            String::FromFormat("Mismatching number of %s, %s #%d, %s #%d (game: %d, save: %d)",
+            content_name, obj1_type, obj1_id, obj2_type, obj2_id, original_val, new_val));
         return false;
     }
     return true;
 }
 
 
-SavegameError WriteGameState(PStream out)
+HSaveError WriteGameState(PStream out)
 {
     // Game base
     game.WriteForSavegame(out);
@@ -197,11 +215,12 @@ SavegameError WriteGameState(PStream out)
     // Viewport
     out->WriteInt32(offsetx);
     out->WriteInt32(offsety);
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     // Game base
     game.ReadFromSavegame(in);
     // Game palette
@@ -210,8 +229,8 @@ SavegameError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &
     if (loaded_game_file_version <= kGameVersion_272)
     {
         // Legacy interaction global variables
-        if (!AssertGameContent(in->ReadInt32(), numGlobalVars, "Global Variables"))
-            return kSvgErr_GameContentAssertion;
+        if (!AssertGameContent(err, in->ReadInt32(), numGlobalVars, "Global Variables"))
+            return err;
         for (int i = 0; i < numGlobalVars; ++i)
             globalvars[i].Read(in.get());
     }
@@ -231,10 +250,10 @@ SavegameError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &
     // Viewport state
     offsetx = in->ReadInt32();
     offsety = in->ReadInt32();
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteAudio(PStream out)
+HSaveError WriteAudio(PStream out)
 {
     // Game content assertion
     out->WriteInt32(game.audioClipTypeCount);
@@ -276,16 +295,17 @@ SavegameError WriteAudio(PStream out)
     // Ambient sound
     for (int i = 0; i < MAX_SOUND_CHANNELS; ++i)
         ambient[i].WriteToFile(out.get());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadAudio(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadAudio(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     // Game content assertion
-    if (!AssertGameContent(in->ReadInt32(), game.audioClipTypeCount, "Audio Clip Types"))
-        return kSvgErr_GameContentAssertion;
-    if (!AssertGameContent(in->ReadInt32(), game.audioClipCount, "Audio Clips"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertGameContent(err, in->ReadInt32(), game.audioClipTypeCount, "Audio Clip Types"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.audioClipCount, "Audio Clips"))
+        return err;
 
     // Audio types
     for (int i = 0; i < game.audioClipTypeCount; ++i)
@@ -337,10 +357,10 @@ SavegameError ReadAudio(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
             ambient[i].channel = 0;
         }
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteCharacters(PStream out)
+HSaveError WriteCharacters(PStream out)
 {
     out->WriteInt32(game.numcharacters);
     for (int i = 0; i < game.numcharacters; ++i)
@@ -353,13 +373,14 @@ SavegameError WriteCharacters(PStream out)
         // character movement path cache
         mls[CHMLSOFFS + i].WriteToFile(out.get());
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertGameContent(in->ReadInt32(), game.numcharacters, "Characters"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numcharacters, "Characters"))
+        return err;
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].ReadFromFile(in.get());
@@ -370,31 +391,32 @@ SavegameError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams 
         // character movement path cache
         mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver);
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteDialogs(PStream out)
+HSaveError WriteDialogs(PStream out)
 {
     out->WriteInt32(game.numdialog);
     for (int i = 0; i < game.numdialog; ++i)
     {
         dialog[i].WriteToSavegame(out.get());
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadDialogs(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDialogs(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertGameContent(in->ReadInt32(), game.numdialog, "Dialogs"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numdialog, "Dialogs"))
+        return err;
     for (int i = 0; i < game.numdialog; ++i)
     {
         dialog[i].ReadFromSavegame(in.get());
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteGUI(PStream out)
+HSaveError WriteGUI(PStream out)
 {
     // GUI state
     WriteFormatTag(out, "GUIs");
@@ -437,74 +459,75 @@ SavegameError WriteGUI(PStream out)
     out->WriteInt32(numAnimButs);
     for (int i = 0; i < numAnimButs; ++i)
         animbuts[i].WriteToFile(out.get());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadGUI(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadGUI(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     // GUI state
-    if (!AssertFormatTag(in, "GUIs"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), game.numgui, "GUIs"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUIs"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numgui, "GUIs"))
+        return err;
     for (int i = 0; i < game.numgui; ++i)
         guis[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUIButtons"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguibuts, "GUI Buttons"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUIButtons"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguibuts, "GUI Buttons"))
+        return err;
     for (int i = 0; i < numguibuts; ++i)
         guibuts[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUILabels"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguilabels, "GUI Labels"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUILabels"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguilabels, "GUI Labels"))
+        return err;
     for (int i = 0; i < numguilabels; ++i)
         guilabels[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUIInvWindows"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguiinv, "GUI InvWindows"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUIInvWindows"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguiinv, "GUI InvWindows"))
+        return err;
     for (int i = 0; i < numguiinv; ++i)
         guiinv[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUISliders"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguislider, "GUI Sliders"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUISliders"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguislider, "GUI Sliders"))
+        return err;
     for (int i = 0; i < numguislider; ++i)
         guislider[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUITextBoxes"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguitext, "GUI TextBoxes"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUITextBoxes"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguitext, "GUI TextBoxes"))
+        return err;
     for (int i = 0; i < numguitext; ++i)
         guitext[i].ReadFromSavegame(in.get());
 
-    if (!AssertFormatTag(in, "GUIListBoxes"))
-        return kSvgErr_InconsistentFormat;
-    if (!AssertGameContent(in->ReadInt32(), numguilist, "GUI ListBoxes"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertFormatTagStrict(err, in, "GUIListBoxes"))
+        return err;
+    if (!AssertGameContent(err, in->ReadInt32(), numguilist, "GUI ListBoxes"))
+        return err;
     for (int i = 0; i < numguilist; ++i)
         guilist[i].ReadFromSavegame(in.get());
 
     // Animated buttons
-    if (!AssertFormatTag(in, "AnimatedButtons"))
-        return kSvgErr_InconsistentFormat;
+    if (!AssertFormatTagStrict(err, in, "AnimatedButtons"))
+        return err;
     int anim_count = in->ReadInt32();
-    if (!AssertCompatLimit(anim_count, MAX_ANIMATING_BUTTONS, "animated buttons"))
-        return kSvgErr_IncompatibleEngine;
+    if (!AssertCompatLimit(err, anim_count, MAX_ANIMATING_BUTTONS, "animated buttons"))
+        return err;
     numAnimButs = anim_count;
     for (int i = 0; i < numAnimButs; ++i)
         animbuts[i].ReadFromFile(in.get());
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteInventory(PStream out)
+HSaveError WriteInventory(PStream out)
 {
     out->WriteInt32(game.numinvitems);
     for (int i = 0; i < game.numinvitems; ++i)
@@ -514,13 +537,14 @@ SavegameError WriteInventory(PStream out)
         if (loaded_game_file_version <= kGameVersion_272)
             game.intrInv[i]->WriteTimesRunToSavedgame(out.get());
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadInventory(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadInventory(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertGameContent(in->ReadInt32(), game.numinvitems, "Inventory Items"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numinvitems, "Inventory Items"))
+        return err;
     for (int i = 0; i < game.numinvitems; ++i)
     {
         game.invinfo[i].ReadFromSavegame(in.get());
@@ -528,31 +552,32 @@ SavegameError ReadInventory(PStream in, int32_t cmp_ver, const PreservedParams &
         if (loaded_game_file_version <= kGameVersion_272)
             game.intrInv[i]->ReadTimesRunFromSavedgame(in.get());
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteMouseCursors(PStream out)
+HSaveError WriteMouseCursors(PStream out)
 {
     out->WriteInt32(game.numcursors);
     for (int i = 0; i < game.numcursors; ++i)
     {
         game.mcurs[i].WriteToSavegame(out.get());
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadMouseCursors(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadMouseCursors(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertGameContent(in->ReadInt32(), game.numcursors, "Mouse Cursors"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numcursors, "Mouse Cursors"))
+        return err;
     for (int i = 0; i < game.numcursors; ++i)
     {
         game.mcurs[i].ReadFromSavegame(in.get());
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteViews(PStream out)
+HSaveError WriteViews(PStream out)
 {
     out->WriteInt32(game.numviews);
     for (int view = 0; view < game.numviews; ++view)
@@ -568,23 +593,24 @@ SavegameError WriteViews(PStream out)
             }
         }
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadViews(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadViews(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertGameContent(in->ReadInt32(), game.numviews, "Views"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertGameContent(err, in->ReadInt32(), game.numviews, "Views"))
+        return err;
     for (int view = 0; view < game.numviews; ++view)
     {
-        if (!AssertGameObjectContent(in->ReadInt32(), views[view].numLoops,
+        if (!AssertGameObjectContent(err, in->ReadInt32(), views[view].numLoops,
             "Loops", "View", view))
-            return kSvgErr_GameContentAssertion;
+            return err;
         for (int loop = 0; loop < views[view].numLoops; ++loop)
         {
-            if (!AssertGameObjectContent2(in->ReadInt32(), views[view].loops[loop].numFrames,
+            if (!AssertGameObjectContent2(err, in->ReadInt32(), views[view].loops[loop].numFrames,
                 "Frame", "View", view, "Loop", loop))
-                return kSvgErr_GameContentAssertion;
+                return err;
             for (int frame = 0; frame < views[view].loops[loop].numFrames; ++frame)
             {
                 views[view].loops[loop].frames[frame].sound = in->ReadInt32();
@@ -592,10 +618,10 @@ SavegameError ReadViews(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
             }
         }
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteDynamicSprites(PStream out)
+HSaveError WriteDynamicSprites(PStream out)
 {
     const size_t ref_pos = out->GetPosition();
     out->WriteInt32(0); // number of dynamic sprites
@@ -618,31 +644,32 @@ SavegameError WriteDynamicSprites(PStream out)
     out->WriteInt32(count);
     out->WriteInt32(top_index);
     out->Seek(end_pos, kSeekBegin);
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     const int spr_count = in->ReadInt32();
     // ensure the sprite set is at least large enough
     // to accomodate top dynamic sprite index
     const int top_index = in->ReadInt32();
-    if (!AssertCompatRange(top_index, 1, MAX_SPRITES - 1, "sprite top index"))
-        return kSvgErr_IncompatibleEngine;
+    if (!AssertCompatRange(err, top_index, 1, MAX_SPRITES - 1, "sprite top index"))
+        return err;
     spriteset.enlargeTo(top_index);
     for (int i = 0; i < spr_count; ++i)
     {
         int id = in->ReadInt32();
-        if (!AssertCompatRange(id, 1, MAX_SPRITES - 1, "sprite index"))
-            return kSvgErr_IncompatibleEngine;
+        if (!AssertCompatRange(err, id, 1, MAX_SPRITES - 1, "sprite index"))
+            return err;
         int flags = in->ReadInt32();
         add_dynamic_sprite(id, read_serialized_bitmap(in.get()));
         game.spriteflags[id] = flags;
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteOverlays(PStream out)
+HSaveError WriteOverlays(PStream out)
 {
     out->WriteInt32(numscreenover);
     for (int i = 0; i < numscreenover; ++i)
@@ -650,14 +677,15 @@ SavegameError WriteOverlays(PStream out)
         screenover[i].WriteToFile(out.get());
         serialize_bitmap(screenover[i].pic, out.get());
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadOverlays(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadOverlays(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     int over_count = in->ReadInt32();
-    if (!AssertCompatLimit(over_count, MAX_SCREEN_OVERLAYS, "overlays"))
-        return kSvgErr_IncompatibleEngine;
+    if (!AssertCompatLimit(err, over_count, MAX_SCREEN_OVERLAYS, "overlays"))
+        return err;
     numscreenover = over_count;
     for (int i = 0; i < numscreenover; ++i)
     {
@@ -665,10 +693,10 @@ SavegameError ReadOverlays(PStream in, int32_t cmp_ver, const PreservedParams &p
         if (screenover[i].hasSerializedBitmap)
             screenover[i].pic = read_serialized_bitmap(in.get());
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteDynamicSurfaces(PStream out)
+HSaveError WriteDynamicSurfaces(PStream out)
 {
     out->WriteInt32(MAX_DYNAMIC_SURFACES);
     for (int i = 0; i < MAX_DYNAMIC_SURFACES; ++i)
@@ -683,13 +711,14 @@ SavegameError WriteDynamicSurfaces(PStream out)
             serialize_bitmap(dynamicallyCreatedSurfaces[i], out.get());
         }
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadDynamicSurfaces(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDynamicSurfaces(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    if (!AssertCompatLimit(in->ReadInt32(), MAX_DYNAMIC_SURFACES, "Dynamic Surfaces"))
-        return kSvgErr_GameContentAssertion;
+    HSaveError err;
+    if (!AssertCompatLimit(err, in->ReadInt32(), MAX_DYNAMIC_SURFACES, "Dynamic Surfaces"))
+        return err;
     // Load the surfaces into a temporary array since ccUnserialiseObjects will destroy them otherwise
     r_data.DynamicSurfaces.resize(MAX_DYNAMIC_SURFACES);
     for (int i = 0; i < MAX_DYNAMIC_SURFACES; ++i)
@@ -699,10 +728,10 @@ SavegameError ReadDynamicSurfaces(PStream in, int32_t cmp_ver, const PreservedPa
         else
             r_data.DynamicSurfaces[i] = read_serialized_bitmap(in.get());
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteScriptModules(PStream out)
+HSaveError WriteScriptModules(PStream out)
 {
     // write the data segment of the global script
     int data_len = gameinst->globaldatasize;
@@ -718,35 +747,36 @@ SavegameError WriteScriptModules(PStream out)
         if (data_len > 0)
             out->Write(moduleInst[i]->globaldata, data_len);
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadScriptModules(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadScriptModules(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     // read the global script data segment
     int data_len = in->ReadInt32();
-    if (!AssertGameContent(data_len, pp.GlScDataSize, "global script data"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertGameContent(err, data_len, pp.GlScDataSize, "global script data"))
+        return err;
     r_data.GlobalScript.Len = data_len;
     r_data.GlobalScript.Data.reset(new char[data_len]);
     in->Read(r_data.GlobalScript.Data.get(), data_len);
 
-    if (!AssertGameContent(in->ReadInt32(), numScriptModules, "Script Modules"))
-        return kSvgErr_GameContentAssertion;
+    if (!AssertGameContent(err, in->ReadInt32(), numScriptModules, "Script Modules"))
+        return err;
     r_data.ScriptModules.resize(numScriptModules);
     for (int i = 0; i < numScriptModules; ++i)
     {
         data_len = in->ReadInt32();
-        if (!AssertGameObjectContent(data_len, pp.ScMdDataSize[i], "script module data", "module", i))
-            return kSvgErr_GameContentAssertion;
+        if (!AssertGameObjectContent(err, data_len, pp.ScMdDataSize[i], "script module data", "module", i))
+            return err;
         r_data.ScriptModules[i].Len = data_len;
         r_data.ScriptModules[i].Data.reset(new char[data_len]);
         in->Read(r_data.ScriptModules[i].Data.get(), data_len);
     }
-    return kSvgErr_NoError;
+    return err;
 }
 
-SavegameError WriteRoomStates(PStream out)
+HSaveError WriteRoomStates(PStream out)
 {
     // write the room state for all the rooms the player has been in
     out->WriteInt32(MAX_ROOMS);
@@ -768,11 +798,12 @@ SavegameError WriteRoomStates(PStream out)
         else
             out->WriteInt32(-1);
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadRoomStates(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadRoomStates(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     int roomstat_count = in->ReadInt32();
     for (; roomstat_count > 0; --roomstat_count)
     {
@@ -780,24 +811,24 @@ SavegameError ReadRoomStates(PStream in, int32_t cmp_ver, const PreservedParams 
         // If id == -1, then the player has not been there yet (or room state was reset)
         if (id != -1)
         {
-            if (!AssertCompatRange(id, 0, MAX_ROOMS - 1, "room index"))
-                return kSvgErr_IncompatibleEngine;
-            if (!AssertFormatTag(in, "RoomState", true))
-                return kSvgErr_InconsistentFormat;
+            if (!AssertCompatRange(err, id, 0, MAX_ROOMS - 1, "room index"))
+                return err;
+            if (!AssertFormatTagStrict(err, in, "RoomState", true))
+                return err;
             RoomStatus *roomstat = getRoomStatus(id);
             roomstat->ReadFromSavegame(in.get());
-            if (!AssertFormatTag(in, "RoomState", false))
-                return kSvgErr_InconsistentFormat;
+            if (!AssertFormatTagStrict(err, in, "RoomState", false))
+                return err;
         }
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError WriteThisRoom(PStream out)
+HSaveError WriteThisRoom(PStream out)
 {
     out->WriteInt32(displayed_room);
     if (displayed_room < 0)
-        return kSvgErr_NoError;
+        return HSaveError::None();
 
     // modified room backgrounds
     for (int i = 0; i < MAX_BSCENE; ++i)
@@ -838,14 +869,15 @@ SavegameError WriteThisRoom(PStream out)
     // write the current troom state, in case they save in temporary room
     if (!persist)
         troom.WriteToSavegame(out.get());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
+    HSaveError err;
     displayed_room = in->ReadInt32();
     if (displayed_room < 0)
-        return kSvgErr_NoError;
+        return err;
 
     // modified room backgrounds
     for (int i = 0; i < MAX_BSCENE; ++i)
@@ -873,8 +905,8 @@ SavegameError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &p
 
     // room object movement paths cache
     int objmls_count = in->ReadInt32();
-    if (!AssertCompatLimit(objmls_count, CHMLSOFFS, "room object move lists"))
-        return kSvgErr_IncompatibleEngine;
+    if (!AssertCompatLimit(err, objmls_count, CHMLSOFFS, "room object move lists"))
+        return err;
     for (int i = 0; i < objmls_count; ++i)
     {
         mls[i].ReadFromFile(in.get(), cmp_ver);
@@ -887,37 +919,37 @@ SavegameError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &p
     if (!in->ReadBool())
         troom.ReadFromSavegame(in.get());
 
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError WriteManagedPool(PStream out)
+HSaveError WriteManagedPool(PStream out)
 {
     ccSerializeAllObjects(out.get());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadManagedPool(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadManagedPool(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
     if (ccUnserializeAllObjects(in.get(), &ccUnserializer))
     {
-        Debug::Printf(kDbgMsg_Error, "Restore game error: managed pool deserialization failed: %s", ccErrorString);
-        return kSvgErr_GameObjectInitFailed;
+        return new SavegameError(kSvgErr_GameObjectInitFailed,
+            String::FromFormat("Managed pool deserialization failed: %s", ccErrorString));
     }
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError WritePluginData(PStream out)
+HSaveError WritePluginData(PStream out)
 {
     // [IKM] Plugins expect FILE pointer! // TODO something with this later...
     pl_run_plugin_hooks(AGSE_SAVEGAME, (long)((Common::FileStream*)out.get())->GetHandle());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
-SavegameError ReadPluginData(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadPluginData(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
     // [IKM] Plugins expect FILE pointer! // TODO something with this later
     pl_run_plugin_hooks(AGSE_RESTOREGAME, (long)((Common::FileStream*)in.get())->GetHandle());
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 
@@ -926,8 +958,8 @@ struct ComponentHandler
 {
     String             Name;
     int32_t            Version;
-    SavegameError      (*Serialize)  (PStream);
-    SavegameError      (*Unserialize)(PStream, int32_t cmp_ver, const PreservedParams&, RestoredData&);
+    HSaveError       (*Serialize)  (PStream);
+    HSaveError       (*Unserialize)(PStream, int32_t cmp_ver, const PreservedParams&, RestoredData&);
 };
 
 // Array of supported components
@@ -1071,13 +1103,13 @@ struct ComponentInfo
     ComponentInfo() : Version(-1), Offset(0), DataOffset(0), DataSize(0) {}
 };
 
-SavegameError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &info)
+HSaveError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &info)
 {
     size_t pos = in->GetPosition();
     info = ComponentInfo(); // reset in case of early error
     info.Offset = in->GetPosition();
     if (!ReadFormatTag(in, info.Name, true))
-        return kSvgErr_ComponentOpeningTagFormat;
+        return new SavegameError(kSvgErr_ComponentOpeningTagFormat);
     info.Version = in->ReadInt32();
     info.DataSize = in->ReadInt32();
     info.DataOffset = in->GetPosition();
@@ -1088,20 +1120,20 @@ SavegameError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &in
         handler = &it_hdr->second;
 
     if (!handler || !handler->Unserialize)
-        return kSvgErr_UnsupportedComponent;
+        return new SavegameError(kSvgErr_UnsupportedComponent);
     if (info.Version > handler->Version)
-        return kSvgErr_UnsupportedComponentVersion;
-    SavegameError err = handler->Unserialize(in, info.Version, hlp.PP, hlp.RData);
-    if (err != kSvgErr_NoError)
+        return new SavegameError(kSvgErr_UnsupportedComponentVersion);
+    HSaveError err = handler->Unserialize(in, info.Version, hlp.PP, hlp.RData);
+    if (!err)
         return err;
     if (in->GetPosition() - info.DataOffset != info.DataSize)
-        return kSvgErr_ComponentSizeMismatch;
+        return new SavegameError(kSvgErr_ComponentSizeMismatch);
     if (!AssertFormatTag(in, info.Name, false))
-        return kSvgErr_ComponentClosingTagFormat;
-    return kSvgErr_NoError;
+        return new SavegameError(kSvgErr_ComponentClosingTagFormat);
+    return HSaveError::None();
 }
 
-SavegameError ReadAll(PStream in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadAll(PStream in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data)
 {
     // Prepare a helper struct we will be passing to the block reading proc
     SvgCmpReadHelper hlp(svg_version, pp, r_data);
@@ -1109,20 +1141,20 @@ SavegameError ReadAll(PStream in, SavegameVersion svg_version, const PreservedPa
 
     size_t idx = 0;
     if (!AssertFormatTag(in, ComponentListTag, true))
-        return kSvgErr_ComponentListOpeningTagFormat;
+        return new SavegameError(kSvgErr_ComponentListOpeningTagFormat);
     do
     {
         // Look out for the end of the component list:
         // this is the only way how this function ends with success
         size_t off = in->GetPosition();
         if (AssertFormatTag(in, ComponentListTag, false))
-            return kSvgErr_NoError;
+            return HSaveError::None();
         // If the list's end was not detected, then seek back and continue reading
         in->Seek(off, kSeekBegin);
 
         ComponentInfo info;
-        SavegameError err = ReadComponent(in, hlp, info);
-        if (err != kSvgErr_NoError)
+        HSaveError err = ReadComponent(in, hlp, info);
+        if (!err)
         {
             Debug::Printf(kDbgMsg_Error, "ERROR: failed to read savegame component: index = %d, type = %s, version = %i, at offset = %u",
                 idx, info.Name.IsEmpty() ? "unknown" : info.Name.GetCStr(), info.Version, info.Offset);
@@ -1132,32 +1164,32 @@ SavegameError ReadAll(PStream in, SavegameVersion svg_version, const PreservedPa
         idx++;
     }
     while (!in->EOS());
-    return kSvgErr_ComponentListClosingTagMissing;
+    return new SavegameError(kSvgErr_ComponentListClosingTagMissing);
 }
 
-SavegameError WriteComponent(PStream out, ComponentHandler &hdlr)
+HSaveError WriteComponent(PStream out, ComponentHandler &hdlr)
 {
     WriteFormatTag(out, hdlr.Name, true);
     out->WriteInt32(hdlr.Version);
     size_t ref_pos = out->GetPosition();
     out->WriteInt32(0); // size
-    SavegameError err = hdlr.Serialize(out);
+    HSaveError err = hdlr.Serialize(out);
     size_t end_pos = out->GetPosition();
     out->Seek(ref_pos, kSeekBegin);
     out->WriteInt32(end_pos - ref_pos - sizeof(int32_t)); // size of serialized component data
     out->Seek(end_pos, kSeekBegin);
-    if (err == kSvgErr_NoError)
+    if (err)
         WriteFormatTag(out, hdlr.Name, false);
     return err;
 }
 
-SavegameError WriteAllCommon(PStream out)
+HSaveError WriteAllCommon(PStream out)
 {
     WriteFormatTag(out, ComponentListTag, true);
     for (int type = 0; !ComponentHandlers[type].Name.IsEmpty(); ++type)
     {
-        SavegameError err = WriteComponent(out, ComponentHandlers[type]);
-        if (err != kSvgErr_NoError)
+        HSaveError err = WriteComponent(out, ComponentHandlers[type]);
+        if (!err)
         {
             Debug::Printf(kDbgMsg_Error, "ERROR: failed to write savegame component: type = %s", ComponentHandlers[type].Name.GetCStr());
             return err;
@@ -1165,7 +1197,7 @@ SavegameError WriteAllCommon(PStream out)
         update_polled_stuff_if_runtime();
     }
     WriteFormatTag(out, ComponentListTag, false);
-    return kSvgErr_NoError;
+    return HSaveError::None();
 }
 
 } // namespace SavegameBlocks

--- a/Engine/game/savegame_components.h
+++ b/Engine/game/savegame_components.h
@@ -37,9 +37,9 @@ typedef stdtr1compat::shared_ptr<Stream> PStream;
 namespace SavegameComponents
 {
     // Reads all available components from the stream
-    SavegameError ReadAll(PStream in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data);
+    HSaveError    ReadAll(PStream in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data);
     // Writes a full list of common components to the stream
-    SavegameError WriteAllCommon(PStream out);
+    HSaveError    WriteAllCommon(PStream out);
 }
 
 } // namespace Engine

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -44,7 +44,6 @@
 #include "debug/out.h"
 #include "font/agsfontrenderer.h"
 #include "font/fonts.h"
-#include "game/main_game_file.h"
 #include "main/config.h"
 #include "main/game_start.h"
 #include "main/engine.h"
@@ -726,12 +725,12 @@ int engine_load_game_data()
     Debug::Printf("Load game data");
 
     our_eip=-17;
-    String err_str;
-    if (!load_game_file(err_str))
+    HError err = load_game_file();
+    if (!err)
     {
         proper_exit=1;
         platform->FinishedUsingGraphicsMode();
-        display_game_file_error(err_str);
+        display_game_file_error(err);
         return EXIT_NORMAL;
     }
 
@@ -1303,10 +1302,10 @@ bool engine_init_gamefile(const String &exe_path)
     // TODO: research if that is possible to avoid this step and just
     // read the full head game data at this point. This might require
     // further changes of the order of initialization.
-    String err_str;
-    if (!preload_game_data(err_str))
+    HError err = preload_game_data();
+    if (!err)
     {
-        display_game_file_error(err_str);
+        display_game_file_error(err);
         return false;
     }
     return true;

--- a/Engine/main/game_file.h
+++ b/Engine/main/game_file.h
@@ -18,16 +18,19 @@
 #ifndef __AGS_EE_MAIN__GAMEFILE_H
 #define __AGS_EE_MAIN__GAMEFILE_H
 
+#include "util/error.h"
 #include "util/string.h"
+
+using AGS::Common::HError;
 
 void set_default_glmsg (int msgnum, const char* val);
 
 extern AGS::Common::String game_file_name;
 
 // Preload particular game-describing parameters from the game data header (title, save game dir name, etc)
-bool preload_game_data(AGS::Common::String &err_str);
+HError preload_game_data();
 // Loads game data and reinitializes the game state; assigns error message in case of failure
-bool load_game_file(AGS::Common::String &err_str);
-void display_game_file_error(const AGS::Common::String &err_str);
+HError load_game_file();
+void display_game_file_error(HError err);
 
 #endif // __AGS_EE_MAIN__GAMEFILE_H

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -339,6 +339,7 @@
     <ClInclude Include="..\..\Common\util\compress.h" />
     <ClInclude Include="..\..\Common\util\datastream.h" />
     <ClInclude Include="..\..\Common\util\directory.h" />
+    <ClInclude Include="..\..\Common\util\error.h" />
     <ClInclude Include="..\..\Common\util\file.h" />
     <ClInclude Include="..\..\Common\util\filestream.h" />
     <ClInclude Include="..\..\Common\util\geometry.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -535,5 +535,8 @@
     <ClInclude Include="..\..\Common\game\plugininfo.h">
       <Filter>Header Files\game</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\error.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Error class is a basic structure which describes an error, with optional error code, general error message and additional comments. It also supports error nesting, by passing a shared pointer to inner error in constructor.

In theory it could be thrown as an exception type, even inherit std::exception, but I did not do that for now, because AGS lacks proper exception catching at the moment (adding that may require more code cleanup first). This may be still done in future if wanted.

Instead, for now it is supposed to be used with a thin wrapper called ErrorHandle. ErrorHandle only has std::shared_ptr inside, there is no problem in using it as a function return value. Since we expect no errors in majority of cases, this also saves a tiny bit on memory allocation.

The main reason to have a distinct ErrorHandle class instead of just using shared_ptr is that its conversion to bool is inverted; that is - when there is no error pointer in it the "handle" returns 'true', and if there is one then it returns 'false':
<pre>
HError err = SomeFunction();
if (!err) // result is bad
    return err;
</pre>
This is opposite to shared_ptr's behavior, but similar to the way regular "bool" return values are tested.