### PR TITLE
Check GUI type is NormalGUI when deleting controls

### DIFF
--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -784,7 +784,7 @@ namespace AGS.Editor
 
         private void DeleteControlClick(object sender, EventArgs e)
         {
-            if (_selectedControl != null && !_selectedControl.Locked)
+            if (_gui is NormalGUI && _selectedControl != null && !_selectedControl.Locked)
             {
                 Factory.AGSEditor.CurrentGame.NotifyClientsGUIControlAddedOrRemoved(_gui, _selectedControl);
                 _selected.Remove(_selectedControl);


### PR DESCRIPTION
This should fix #443 by removing the delete option for Text Window GUIs.