### PR TITLE
Created proper managers for the script structs containing raw variables

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -47,8 +47,7 @@ using namespace AGS; // FIXME later
 #define FOLLOW_ALWAYSONTOP  0x7ffe
 
 struct CharacterExtras; // forward declaration
-// remember - if change this struct, also change AGSDEFNS.SH and
-// plugin header file struct
+// remember - if change this struct, also change plugin header file struct
 struct CharacterInfo {
     int   defview;
     int   talkview;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -788,7 +788,7 @@ builtin managed struct File {
   import int Seek(int offset, FileSeek origin = eSeekCurrent);
   /// Gets current cursor position inside the file.
   readonly import attribute int Position;
-  int reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct InventoryItem {
@@ -814,7 +814,7 @@ builtin managed struct InventoryItem {
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this item.
   import bool SetTextProperty(const string property, const string value);
-  int reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct Overlay {
@@ -1194,7 +1194,7 @@ builtin managed struct GUI {
   import void Click(MouseButton);
   /// Performs default processing of a mouse click at the specified co-ordinates.
   import static void ProcessClick(int x, int y, MouseButton);
-  int   reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct Hotspot {
@@ -1222,7 +1222,7 @@ builtin managed struct Hotspot {
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this hotspot.
   import bool SetTextProperty(const string property, const string value);
-  int reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct Region {
@@ -1250,7 +1250,7 @@ builtin managed struct Region {
   readonly import attribute int  TintSaturation;
   /// Gets the Luminance of this region's colour tint.
   readonly import attribute int  TintLuminance;
-  int reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct Dialog {
@@ -1275,7 +1275,7 @@ builtin managed struct Dialog {
   /// Manually marks whether the option was chosen before or not.
   import void SetHasOptionBeenChosen(int option, bool chosen);
   
-  int reserved[2];   // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 #define IsSpeechVoxAvailable IsVoxAvailable
@@ -1570,7 +1570,7 @@ builtin managed struct Object {
   /// Gets the Luminance of this object's colour tint.
   readonly import attribute int  TintLuminance;
 
-  int reserved[2];  // $AUTOCOMPLETEIGNORE$
+  readonly int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
 
 enum StopMovementStyle
@@ -1778,8 +1778,9 @@ builtin managed struct Character {
   readonly int reserved_a[28];   // $AUTOCOMPLETEIGNORE$
   readonly short reserved_f[MAX_INV];  // $AUTOCOMPLETEIGNORE$
   readonly int   reserved_e;   // $AUTOCOMPLETEIGNORE$
-  char  reserved_g[40];   // $AUTOCOMPLETEIGNORE$
-  readonly char  scrname[20];
+  readonly char  reserved_g[40];   // $AUTOCOMPLETEIGNORE$
+  readonly char  reserved_h[20];   // $AUTOCOMPLETEIGNORE$
+  // TODO: find out if Visible property may work as a proper analogue, otherwise add new one
   char  on;  // $AUTOCOMPLETEIGNORE$
   };
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1904,9 +1904,10 @@ import Mouse mouse;
 import System system;
 import GameState  game;
 import Object object[MAX_ROOM_OBJECTS];
+import ColorType palette[PALETTE_SIZE];
+// [OBSOLETE]
 import int   gs_globals[MAX_LEGACY_GLOBAL_VARS];
 import short savegameindex[MAX_LISTBOX_SAVED_GAMES];
-import ColorType palette[PALETTE_SIZE];
 
 #undef CursorMode
 #undef FontType

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -24,9 +24,8 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
+// TODO: now safe to merge with CharacterInfo into one class
 struct CharacterExtras {
-    // UGLY UGLY UGLY!! The CharacterInfo struct size is fixed because it's
-    // used in the scripts, therefore overflowing stuff has to go here
     short invorder[MAX_INVORDER];
     short invorder_count;
     short width;

--- a/Engine/ac/dynobj/cc_character.cpp
+++ b/Engine/ac/dynobj/cc_character.cpp
@@ -17,6 +17,7 @@
 #include "ac/global_character.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/game_version.h"
+#include "script/cc_error.h"
 
 extern GameSetupStruct game;
 
@@ -40,6 +41,26 @@ void CCCharacter::Unserialize(int index, const char *serializedData, int dataSiz
     ccRegisterUnserializedObject(index, &game.chars[num], this);
 }
 
+uint8_t CCCharacter::ReadInt8(const char *address, intptr_t offset)
+{
+    // The only supported variable remaining in 3.4.*
+    const int on_offset = 28 * sizeof(int32_t) + 301 * sizeof(int16_t) /* inventory */ + sizeof(int32_t) + 40 + 20;
+    if (offset == on_offset)
+        return ((CharacterInfo*)address)->on;
+    cc_error("CCCharacter: unsupported variable offset %d", offset);
+    return 0;
+}
+
+void CCCharacter::WriteInt8(const char *address, intptr_t offset, uint8_t val)
+{
+    // The only supported variable remaining in 3.4.*
+    const int on_offset = 28 * sizeof(int32_t) + 301 * sizeof(int16_t) /* inventory */ + sizeof(int32_t) + 40 + 20;
+    if (offset == on_offset)
+        ((CharacterInfo*)address)->on = val;
+    else
+        cc_error("CCCharacter: unsupported variable offset %d", offset);
+}
+
 void CCCharacter::WriteInt16(const char *address, intptr_t offset, int16_t val)
 {
     *(int16_t*)(address + offset) = val;
@@ -49,7 +70,7 @@ void CCCharacter::WriteInt16(const char *address, intptr_t offset, int16_t val)
     // inventory for older games that reply on the previous behaviour.
     if (loaded_game_file_version < kGameVersion_270)
     {
-        const int invoffset = 112;
+        const int invoffset = 28 * sizeof(int32_t);
         if (offset >= invoffset && offset < (invoffset + MAX_INV * sizeof(short)))
         {
             update_invorder();

--- a/Engine/ac/dynobj/cc_character.h
+++ b/Engine/ac/dynobj/cc_character.h
@@ -28,7 +28,9 @@ struct CCCharacter : AGSCCDynamicObject {
 
     virtual void Unserialize(int index, const char *serializedData, int dataSize);
 
-    void WriteInt16(const char *address, intptr_t offset, int16_t val);
+    virtual uint8_t ReadInt8(const char *address, intptr_t offset) override;
+    virtual void    WriteInt8(const char *address, intptr_t offset, uint8_t val) override;
+    virtual void    WriteInt16(const char *address, intptr_t offset, int16_t val) override;
 };
 
 #endif // __AC_CCCHARACTER_H

--- a/Engine/ac/dynobj/scriptmouse.cpp
+++ b/Engine/ac/dynobj/scriptmouse.cpp
@@ -1,0 +1,26 @@
+#include "ac/dynobj/scriptmouse.h"
+#include "script/cc_error.h"
+
+int32_t ScriptMouse::ReadInt32(const char *address, intptr_t offset)
+{
+    switch (offset)
+    {
+    case 0: return x;
+    case 4: return y;
+    }
+    cc_error("ScriptMouse: unsupported variable offset %d", offset);
+    return 0;
+}
+
+void ScriptMouse::WriteInt32(const char *address, intptr_t offset, int32_t val)
+{
+    switch (offset)
+    {
+    case 0:
+    case 4:
+        cc_error("ScriptMouse: attempt to write readonly variable at offset %d", offset);
+        break;
+    default:
+        cc_error("ScriptMouse: unsupported variable offset %d", offset);
+    }
+}

--- a/Engine/ac/dynobj/scriptmouse.h
+++ b/Engine/ac/dynobj/scriptmouse.h
@@ -12,15 +12,21 @@
 //
 //=============================================================================
 //
-//
+// Wrapper around script "Mouse" struct, managing access to its variables.
 //
 //=============================================================================
 #ifndef __AGS_EE_DYNOBJ__SCRIPTMOUSE_H
 #define __AGS_EE_DYNOBJ__SCRIPTMOUSE_H
 
-// The text script's "mouse" struct
-struct ScriptMouse {
-    int x,y;
+#include "ac/statobj/agsstaticobject.h"
+
+struct ScriptMouse : public AGSStaticObject
+{
+    int x;
+    int y;
+
+    virtual int32_t ReadInt32(const char *address, intptr_t offset) override;
+    virtual void    WriteInt32(const char *address, intptr_t offset, int32_t val) override;
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTMOUSE_H

--- a/Engine/ac/dynobj/scriptsystem.cpp
+++ b/Engine/ac/dynobj/scriptsystem.cpp
@@ -1,0 +1,40 @@
+#include "ac/dynobj/scriptsystem.h"
+#include "script/cc_error.h"
+
+int32_t ScriptSystem::ReadInt32(const char *address, intptr_t offset)
+{
+    int index = offset / sizeof(int32_t);
+    switch (index)
+    {
+    case 0: return width;
+    case 1: return height;
+    case 2: return coldepth;
+    case 3: return os;
+    case 4: return windowed;
+    case 5: return vsync;
+    case 6: return viewport_width;
+    case 7: return viewport_height;
+    }
+    cc_error("ScriptSystem: unsupported variable offset %d", offset);
+    return 0;
+}
+
+void ScriptSystem::WriteInt32(const char *address, intptr_t offset, int32_t val)
+{
+    int index = offset / sizeof(int32_t);
+    switch (index)
+    {
+    case 5: vsync = val; break;
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 6:
+    case 7:
+        cc_error("ScriptSystem: attempt to write readonly variable at offset %d", offset);
+        break;
+    default:
+        cc_error("ScriptSystem: unsupported variable offset %d", offset);
+    }
+}

--- a/Engine/ac/dynobj/scriptsystem.h
+++ b/Engine/ac/dynobj/scriptsystem.h
@@ -12,22 +12,27 @@
 //
 //=============================================================================
 //
-//
+// Wrapper around script "System" struct, managing access to its variables.
 //
 //=============================================================================
 #ifndef __AGS_EE_DYNOBJ__SCRIPTSYSTEM_H
 #define __AGS_EE_DYNOBJ__SCRIPTSYSTEM_H
 
+#include "ac/statobj/agsstaticobject.h"
+
 // The text script's "system" struct
-struct ScriptSystem {
+struct ScriptSystem : public AGSStaticObject
+{
     int width,height;
     int coldepth;
     int os;
     int windowed;
     int vsync;
-    int viewport_width, viewport_height;
-    char aci_version[10]; // FIXME this when possible, version format is different now
-    int reserved[5];  // so that future scripts don't overwrite data
+    int viewport_width;
+    int viewport_height;
+
+    virtual int32_t ReadInt32(const char *address, intptr_t offset) override;
+    virtual void    WriteInt32(const char *address, intptr_t offset, int32_t val) override;
 };
 
 #endif // __AGS_EE_DYNOBJ__SCRIPTSYSTEM_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2491,9 +2491,10 @@ void RegisterGameAPI()
 void RegisterStaticObjects()
 {
     ccAddExternalStaticObject("game",&play, &GameStaticManager);
-	ccAddExternalStaticObject("gs_globals",&play.globalvars[0], &GlobalStaticManager);
 	ccAddExternalStaticObject("mouse",&scmouse, &scmouse);
-	ccAddExternalStaticObject("palette",&palette[0], &GlobalStaticManager);
+	ccAddExternalStaticObject("palette",&palette[0], &GlobalStaticManager); // TODO: proper manager
 	ccAddExternalStaticObject("system",&scsystem, &scsystem);
+    // [OBSOLETE] legacy arrays
+    ccAddExternalStaticObject("gs_globals", &play.globalvars[0], &GlobalStaticManager);
 	ccAddExternalStaticObject("savegameindex",&play.filenumbers[0], &GlobalStaticManager);
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -59,6 +59,7 @@
 #include "ac/dynobj/all_scriptclasses.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "ac/dynobj/cc_audioclip.h"
+#include "ac/statobj/staticgame.h"
 #include "debug/debug_log.h"
 #include "debug/out.h"
 #include "device/mousew32.h"

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2492,7 +2492,7 @@ void RegisterStaticObjects()
 {
     ccAddExternalStaticObject("game",&play, &GameStaticManager);
 	ccAddExternalStaticObject("gs_globals",&play.globalvars[0], &GlobalStaticManager);
-	ccAddExternalStaticObject("mouse",&scmouse, &GlobalStaticManager);
+	ccAddExternalStaticObject("mouse",&scmouse, &scmouse);
 	ccAddExternalStaticObject("palette",&palette[0], &GlobalStaticManager);
 	ccAddExternalStaticObject("system",&scsystem, &GlobalStaticManager);
 	ccAddExternalStaticObject("savegameindex",&play.filenumbers[0], &GlobalStaticManager);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2494,6 +2494,6 @@ void RegisterStaticObjects()
 	ccAddExternalStaticObject("gs_globals",&play.globalvars[0], &GlobalStaticManager);
 	ccAddExternalStaticObject("mouse",&scmouse, &scmouse);
 	ccAddExternalStaticObject("palette",&palette[0], &GlobalStaticManager);
-	ccAddExternalStaticObject("system",&scsystem, &GlobalStaticManager);
+	ccAddExternalStaticObject("system",&scsystem, &scsystem);
 	ccAddExternalStaticObject("savegameindex",&play.filenumbers[0], &GlobalStaticManager);
 }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -27,7 +27,6 @@ using namespace AGS; // FIXME later
 
 #define GAME_STATE_RESERVED_INTS 5
 
-// Adding to this might need to modify AGSDEFNS.SH and AGSPLUGIN.H
 struct GameState {
     int  score;      // player's current score
     int  usedmode;   // set by ProcessClick to last cursor mode used
@@ -109,7 +108,6 @@ struct GameState {
                                       // no speech animation is supposed to be played at this time
     int  dialog_options_highlight_color; // The colour used for highlighted (hovered over) text in dialog options
     int  reserved[GAME_STATE_RESERVED_INTS];  // make sure if a future version adds a var, it doesn't mess anything up
-    // ** up to here is referenced in the script "game." object
     int   recording;   // user is recording their moves
     int   playback;    // playing back recording
     short gamestep;    // step number for matching recordings

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -33,7 +33,7 @@ struct GameState {
     int  disabled_user_interface;  // >0 while in cutscene/etc
     int  gscript_timer;    // obsolete
     int  debug_mode;       // whether we're in debug mode
-    int  globalvars[MAXGLOBALVARS];  // obsolete
+    int  globalvars[MAXGLOBALVARS];  // [OBSOLETE]
     int  messagetime;      // time left for auto-remove messages
     int  usedinv;          // inventory item last used
     int  inv_top,inv_numdisp,obsolete_inv_numorder,inv_numinline;
@@ -145,7 +145,7 @@ struct GameState {
     char  bad_parsed_word[100];
     int   raw_color;
     int   raw_modified[MAX_BSCENE];
-    short filenumbers[MAXSAVEGAMES];
+    short filenumbers[MAXSAVEGAMES]; // [OBSOLETE]
     int   room_changes;
     int   mouse_cursor_hidden;
     int   silent_midi;

--- a/Engine/ac/statobj/agsstaticobject.cpp
+++ b/Engine/ac/statobj/agsstaticobject.cpp
@@ -1,10 +1,8 @@
 
 #include <string.h>
 #include "ac/statobj/agsstaticobject.h"
-#include "ac/game.h"
 
 AGSStaticObject GlobalStaticManager;
-StaticGame      GameStaticManager;
 
 void AGSStaticObject::Read(const char *address, intptr_t offset, void *dest, int size)
 {
@@ -54,16 +52,4 @@ void AGSStaticObject::WriteInt32(const char *address, intptr_t offset, int32_t v
 void AGSStaticObject::WriteFloat(const char *address, intptr_t offset, float val)
 {
     *(float*)(address + offset) = val;
-}
-
-void StaticGame::WriteInt32(const char *address, intptr_t offset, int32_t val)
-{
-    if (offset == 4 * sizeof(int32_t))
-    { // game.debug_mode
-        set_debug_mode(val != 0);
-    }
-    else
-    {
-        *(int32_t*)(address + offset) = val;
-    }
 }

--- a/Engine/ac/statobj/agsstaticobject.h
+++ b/Engine/ac/statobj/agsstaticobject.h
@@ -36,12 +36,6 @@ struct AGSStaticObject : public ICCStaticObject {
     virtual void    WriteFloat(const char *address, intptr_t offset, float val);
 };
 
-// Wrapper around script's "Game" struct, managing access to its variables
-struct StaticGame : public AGSStaticObject {
-    virtual void    WriteInt32(const char *address, intptr_t offset, int32_t val);
-};
-
 extern AGSStaticObject GlobalStaticManager;
-extern StaticGame      GameStaticManager;
 
 #endif // __AGS_EE_STATOBJ__AGSSTATICOBJECT_H

--- a/Engine/ac/statobj/staticarray.cpp
+++ b/Engine/ac/statobj/staticarray.cpp
@@ -3,36 +3,36 @@
 #include "ac/statobj/staticarray.h"
 #include "ac/dynobj/cc_dynamicobject.h"
 
-void StaticArray::Create(int elem_legacy_size, int elem_real_size, int elem_count)
+void StaticArray::Create(int elem_script_size, int elem_real_size, int elem_count)
 {
     _staticMgr      = NULL;
     _dynamicMgr     = NULL;
-    _elemLegacySize = elem_legacy_size;
+    _elemScriptSize = elem_script_size;
     _elemRealSize   = elem_real_size;
     _elemCount      = elem_count;
 }
 
-void StaticArray::Create(ICCStaticObject *stcmgr, int elem_legacy_size, int elem_real_size, int elem_count)
+void StaticArray::Create(ICCStaticObject *stcmgr, int elem_script_size, int elem_real_size, int elem_count)
 {
     _staticMgr      = stcmgr;
     _dynamicMgr     = NULL;
-    _elemLegacySize = elem_legacy_size;
+    _elemScriptSize = elem_script_size;
     _elemRealSize   = elem_real_size;
     _elemCount      = elem_count;
 }
 
-void StaticArray::Create(ICCDynamicObject *dynmgr, int elem_legacy_size, int elem_real_size, int elem_count)
+void StaticArray::Create(ICCDynamicObject *dynmgr, int elem_script_size, int elem_real_size, int elem_count)
 {
     _staticMgr      = NULL;
     _dynamicMgr     = dynmgr;
-    _elemLegacySize = elem_legacy_size;
+    _elemScriptSize = elem_script_size;
     _elemRealSize   = elem_real_size;
     _elemCount      = elem_count;
 }
 
 const char *StaticArray::GetElementPtr(const char *address, intptr_t legacy_offset)
 {
-    return address + (legacy_offset / _elemLegacySize) * _elemRealSize;
+    return address + (legacy_offset / _elemScriptSize) * _elemRealSize;
 }
 
 void StaticArray::Read(const char *address, intptr_t offset, void *dest, int size)
@@ -40,13 +40,13 @@ void StaticArray::Read(const char *address, intptr_t offset, void *dest, int siz
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->Read(el_ptr, offset % _elemLegacySize, dest, size);
+        return _staticMgr->Read(el_ptr, offset % _elemScriptSize, dest, size);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->Read(el_ptr, offset % _elemLegacySize, dest, size);
+        return _dynamicMgr->Read(el_ptr, offset % _elemScriptSize, dest, size);
     }
-    memcpy(dest, el_ptr + offset % _elemLegacySize, size);
+    memcpy(dest, el_ptr + offset % _elemScriptSize, size);
 }
 
 uint8_t StaticArray::ReadInt8(const char *address, intptr_t offset)
@@ -54,13 +54,13 @@ uint8_t StaticArray::ReadInt8(const char *address, intptr_t offset)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->ReadInt8(el_ptr, offset % _elemLegacySize);
+        return _staticMgr->ReadInt8(el_ptr, offset % _elemScriptSize);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->ReadInt8(el_ptr, offset % _elemLegacySize);
+        return _dynamicMgr->ReadInt8(el_ptr, offset % _elemScriptSize);
     }
-    return *(uint8_t*)(el_ptr + offset % _elemLegacySize);
+    return *(uint8_t*)(el_ptr + offset % _elemScriptSize);
 }
 
 int16_t StaticArray::ReadInt16(const char *address, intptr_t offset)
@@ -68,13 +68,13 @@ int16_t StaticArray::ReadInt16(const char *address, intptr_t offset)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->ReadInt16(el_ptr, offset % _elemLegacySize);
+        return _staticMgr->ReadInt16(el_ptr, offset % _elemScriptSize);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->ReadInt16(el_ptr, offset % _elemLegacySize);
+        return _dynamicMgr->ReadInt16(el_ptr, offset % _elemScriptSize);
     }
-    return *(uint16_t*)(el_ptr + offset % _elemLegacySize);
+    return *(uint16_t*)(el_ptr + offset % _elemScriptSize);
 }
 
 int32_t StaticArray::ReadInt32(const char *address, intptr_t offset)
@@ -82,13 +82,13 @@ int32_t StaticArray::ReadInt32(const char *address, intptr_t offset)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->ReadInt32(el_ptr, offset % _elemLegacySize);
+        return _staticMgr->ReadInt32(el_ptr, offset % _elemScriptSize);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->ReadInt32(el_ptr, offset % _elemLegacySize);
+        return _dynamicMgr->ReadInt32(el_ptr, offset % _elemScriptSize);
     }
-    return *(uint32_t*)(el_ptr + offset % _elemLegacySize);
+    return *(uint32_t*)(el_ptr + offset % _elemScriptSize);
 }
 
 float StaticArray::ReadFloat(const char *address, intptr_t offset)
@@ -96,13 +96,13 @@ float StaticArray::ReadFloat(const char *address, intptr_t offset)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->ReadFloat(el_ptr, offset % _elemLegacySize);
+        return _staticMgr->ReadFloat(el_ptr, offset % _elemScriptSize);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->ReadFloat(el_ptr, offset % _elemLegacySize);
+        return _dynamicMgr->ReadFloat(el_ptr, offset % _elemScriptSize);
     }
-    return *(float*)(el_ptr + offset % _elemLegacySize);
+    return *(float*)(el_ptr + offset % _elemScriptSize);
 }
 
 void StaticArray::Write(const char *address, intptr_t offset, void *src, int size)
@@ -110,15 +110,15 @@ void StaticArray::Write(const char *address, intptr_t offset, void *src, int siz
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->Write(el_ptr, offset % _elemLegacySize, src, size);
+        return _staticMgr->Write(el_ptr, offset % _elemScriptSize, src, size);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->Write(el_ptr, offset % _elemLegacySize, src, size);
+        return _dynamicMgr->Write(el_ptr, offset % _elemScriptSize, src, size);
     }
     else
     {
-        memcpy((void*)(el_ptr + offset % _elemLegacySize), src, size);
+        memcpy((void*)(el_ptr + offset % _elemScriptSize), src, size);
     }
 }
 
@@ -127,15 +127,15 @@ void StaticArray::WriteInt8(const char *address, intptr_t offset, uint8_t val)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->WriteInt8(el_ptr, offset % _elemLegacySize, val);
+        return _staticMgr->WriteInt8(el_ptr, offset % _elemScriptSize, val);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->WriteInt8(el_ptr, offset % _elemLegacySize, val);
+        return _dynamicMgr->WriteInt8(el_ptr, offset % _elemScriptSize, val);
     }
     else
     {
-        *(uint8_t*)(el_ptr + offset % _elemLegacySize) = val;
+        *(uint8_t*)(el_ptr + offset % _elemScriptSize) = val;
     }
 }
 
@@ -144,15 +144,15 @@ void StaticArray::WriteInt16(const char *address, intptr_t offset, int16_t val)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->WriteInt16(el_ptr, offset % _elemLegacySize, val);
+        return _staticMgr->WriteInt16(el_ptr, offset % _elemScriptSize, val);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->WriteInt16(el_ptr, offset % _elemLegacySize, val);
+        return _dynamicMgr->WriteInt16(el_ptr, offset % _elemScriptSize, val);
     }
     else
     {
-        *(uint16_t*)(el_ptr + offset % _elemLegacySize) = val;
+        *(uint16_t*)(el_ptr + offset % _elemScriptSize) = val;
     }
 }
 
@@ -161,15 +161,15 @@ void StaticArray::WriteInt32(const char *address, intptr_t offset, int32_t val)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->WriteInt32(el_ptr, offset % _elemLegacySize, val);
+        return _staticMgr->WriteInt32(el_ptr, offset % _elemScriptSize, val);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->WriteInt32(el_ptr, offset % _elemLegacySize, val);
+        return _dynamicMgr->WriteInt32(el_ptr, offset % _elemScriptSize, val);
     }
     else
     {
-        *(uint32_t*)(el_ptr + offset % _elemLegacySize) = val;
+        *(uint32_t*)(el_ptr + offset % _elemScriptSize) = val;
     }
 }
 
@@ -178,14 +178,14 @@ void StaticArray::WriteFloat(const char *address, intptr_t offset, float val)
     const char *el_ptr = GetElementPtr(address, offset);
     if (_staticMgr)
     {
-        return _staticMgr->WriteFloat(el_ptr, offset % _elemLegacySize, val);
+        return _staticMgr->WriteFloat(el_ptr, offset % _elemScriptSize, val);
     }
     else if (_dynamicMgr)
     {
-        return _dynamicMgr->WriteFloat(el_ptr, offset % _elemLegacySize, val);
+        return _dynamicMgr->WriteFloat(el_ptr, offset % _elemScriptSize, val);
     }
     else
     {
-        *(float*)(el_ptr + offset % _elemLegacySize) = val;
+        *(float*)(el_ptr + offset % _elemScriptSize) = val;
     }
 }

--- a/Engine/ac/statobj/staticarray.h
+++ b/Engine/ac/statobj/staticarray.h
@@ -26,9 +26,9 @@ struct StaticArray : public ICCStaticObject {
 public:
     virtual ~StaticArray(){}
 
-    void Create(int elem_legacy_size, int elem_real_size, int elem_count = -1 /*unknown*/);
-    void Create(ICCStaticObject *stcmgr, int elem_legacy_size, int elem_real_size, int elem_count = -1 /*unknown*/);
-    void Create(ICCDynamicObject *dynmgr, int elem_legacy_size, int elem_real_size, int elem_count = -1 /*unknown*/);
+    void Create(int elem_script_size, int elem_real_size, int elem_count = -1 /*unknown*/);
+    void Create(ICCStaticObject *stcmgr, int elem_script_size, int elem_real_size, int elem_count = -1 /*unknown*/);
+    void Create(ICCDynamicObject *dynmgr, int elem_script_size, int elem_real_size, int elem_count = -1 /*unknown*/);
 
     inline ICCStaticObject *GetStaticManager() const
     {
@@ -55,7 +55,7 @@ public:
 private:
     ICCStaticObject     *_staticMgr;
     ICCDynamicObject    *_dynamicMgr;
-    int                 _elemLegacySize;
+    int                 _elemScriptSize;
     int                 _elemRealSize;
     int                 _elemCount;
 };

--- a/Engine/ac/statobj/staticgame.cpp
+++ b/Engine/ac/statobj/staticgame.cpp
@@ -1,0 +1,201 @@
+#include "ac/statobj/staticgame.h"
+#include "ac/game.h"
+#include "ac/gamestate.h"
+#include "script/cc_error.h"
+
+extern GameState play;
+
+StaticGame GameStaticManager;
+
+int32_t StaticGame::ReadInt32(const char *address, intptr_t offset)
+{
+    int index = offset / sizeof(int32_t);
+    if (index >= 5 && index < 5 + MAXGLOBALVARS)
+        return play.globalvars[index - 5];
+
+    switch (index)
+    {
+    case 0: return play.score;
+    case 1: return play.usedmode;
+    case 2: return play.disabled_user_interface;
+    case 3: return play.gscript_timer;
+    case 4: return play.debug_mode;
+        // 5 -> 54: play.globalvars
+    case 55: return play.messagetime;
+    case 56: return play.usedinv;
+    case 57: return play.inv_top;
+    case 58: return play.inv_numdisp;
+    case 59: return play.obsolete_inv_numorder;
+    case 60: return play.inv_numinline;
+    case 61: return play.text_speed;
+    case 62: return play.sierra_inv_color;
+    case 63: return play.talkanim_speed;
+    case 64: return play.inv_item_wid;
+    case 65: return play.inv_item_hit;
+    case 66: return play.speech_text_shadow;
+    case 67: return play.swap_portrait_side;
+    case 68: return play.speech_textwindow_gui;
+    case 69: return play.follow_change_room_timer;
+    case 70: return play.totalscore;
+    case 71: return play.skip_display;
+    case 72: return play.no_multiloop_repeat;
+    case 73: return play.roomscript_finished;
+    case 74: return play.used_inv_on;
+    case 75: return play.no_textbg_when_voice;
+    case 76: return play.max_dialogoption_width;
+    case 77: return play.no_hicolor_fadein;
+    case 78: return play.bgspeech_game_speed;
+    case 79: return play.bgspeech_stay_on_display;
+    case 80: return play.unfactor_speech_from_textlength;
+    case 81: return play.mp3_loop_before_end;
+    case 82: return play.speech_music_drop;
+    case 83: return play.in_cutscene;
+    case 84: return play.fast_forward;
+    case 85: return play.room_width;
+    case 86: return play.room_height;
+    case 87: return play.game_speed_modifier;
+    case 88: return play.score_sound;
+    case 89: return play.takeover_data;
+    case 90: return play.replay_hotkey;
+    case 91: return play.dialog_options_x;
+    case 92: return play.dialog_options_y;
+    case 93: return play.narrator_speech;
+    case 94: return play.ambient_sounds_persist;
+    case 95: return play.lipsync_speed;
+    case 96: return play.close_mouth_speech_time;
+    case 97: return play.disable_antialiasing;
+    case 98: return play.text_speed_modifier;
+    case 99: return play.text_align;
+    case 100: return play.speech_bubble_width;
+    case 101: return play.min_dialogoption_width;
+    case 102: return play.disable_dialog_parser;
+    case 103: return play.anim_background_speed;
+    case 104: return play.top_bar_backcolor;
+    case 105: return play.top_bar_textcolor;
+    case 106: return play.top_bar_bordercolor;
+    case 107: return play.top_bar_borderwidth;
+    case 108: return play.top_bar_ypos;
+    case 109: return play.screenshot_width;
+    case 110: return play.screenshot_height;
+    case 111: return play.top_bar_font;
+    case 112: return play.speech_text_align;
+    case 113: return play.auto_use_walkto_points;
+    case 114: return play.inventory_greys_out;
+    case 115: return play.skip_speech_specific_key;
+    case 116: return play.abort_key;
+    case 117: return play.fade_to_red;
+    case 118: return play.fade_to_green;
+    case 119: return play.fade_to_blue;
+    case 120: return play.show_single_dialog_option;
+    case 121: return play.keep_screen_during_instant_transition;
+    case 122: return play.read_dialog_option_colour;
+    case 123: return play.stop_dialog_at_end;
+    case 124: return play.speech_portrait_placement;
+    case 125: return play.speech_portrait_x;
+    case 126: return play.speech_portrait_y;
+    case 127: return play.speech_display_post_time_ms;
+    case 128: return play.dialog_options_highlight_color;
+    }
+    cc_error("StaticGame: unsupported variable offset %d", offset);
+    return 0;
+}
+
+void StaticGame::WriteInt32(const char *address, intptr_t offset, int32_t val)
+{
+    int index = offset / sizeof(int32_t);
+    if (index >= 5 && index < 5 + MAXGLOBALVARS)
+    {
+        play.globalvars[index - 5] = val;
+        return;
+    }
+
+    switch (index)
+    {
+    case 0:  play.score = val; break;
+    case 1:  play.usedmode = val; break;
+    case 2:  play.disabled_user_interface = val; break;
+    case 3:  play.gscript_timer = val; break;
+    case 4:  set_debug_mode(val != 0); break; // play.debug_mode
+        // 5 -> 54: play.globalvars
+    case 55:  play.messagetime = val; break;
+    case 56:  play.usedinv = val; break;
+    case 57:  play.inv_top = val; break;
+    case 58:  play.inv_numdisp = val; break;
+    case 59:  play.obsolete_inv_numorder = val; break;
+    case 60:  play.inv_numinline = val; break;
+    case 61:  play.text_speed = val; break;
+    case 62:  play.sierra_inv_color = val; break;
+    case 63:  play.talkanim_speed = val; break;
+    case 64:  play.inv_item_wid = val; break;
+    case 65:  play.inv_item_hit = val; break;
+    case 66:  play.speech_text_shadow = val; break;
+    case 67:  play.swap_portrait_side = val; break;
+    case 68:  play.speech_textwindow_gui = val; break;
+    case 69:  play.follow_change_room_timer = val; break;
+    case 70:  play.totalscore = val; break;
+    case 71:  play.skip_display = val; break;
+    case 72:  play.no_multiloop_repeat = val; break;
+    case 73:  play.roomscript_finished = val; break;
+    case 74:  play.used_inv_on = val; break;
+    case 75:  play.no_textbg_when_voice = val; break;
+    case 76:  play.max_dialogoption_width = val; break;
+    case 77:  play.no_hicolor_fadein = val; break;
+    case 78:  play.bgspeech_game_speed = val; break;
+    case 79:  play.bgspeech_stay_on_display = val; break;
+    case 80:  play.unfactor_speech_from_textlength = val; break;
+    case 81:  play.mp3_loop_before_end = val; break;
+    case 82:  play.speech_music_drop = val; break;
+    case 83:
+    case 84:
+    case 85:
+    case 86:
+        cc_error("StaticGame: attempt to write readonly variable at offset %d", offset);
+        break;
+    case 87:  play.game_speed_modifier = val; break;
+    case 88:  play.score_sound = val; break;
+    case 89:  play.takeover_data = val; break;
+    case 90:  play.replay_hotkey = val; break;
+    case 91:  play.dialog_options_x = val; break;
+    case 92:  play.dialog_options_y = val; break;
+    case 93:  play.narrator_speech = val; break;
+    case 94:  play.ambient_sounds_persist = val; break;
+    case 95:  play.lipsync_speed = val; break;
+    case 96:  play.close_mouth_speech_time = val; break;
+    case 97:  play.disable_antialiasing = val; break;
+    case 98:  play.text_speed_modifier = val; break;
+    case 99:  play.text_align = val; break;
+    case 100:  play.speech_bubble_width = val; break;
+    case 101:  play.min_dialogoption_width = val; break;
+    case 102:  play.disable_dialog_parser = val; break;
+    case 103:  play.anim_background_speed = val; break;
+    case 104:  play.top_bar_backcolor = val; break;
+    case 105:  play.top_bar_textcolor = val; break;
+    case 106:  play.top_bar_bordercolor = val; break;
+    case 107:  play.top_bar_borderwidth = val; break;
+    case 108:  play.top_bar_ypos = val; break;
+    case 109:  play.screenshot_width = val; break;
+    case 110:  play.screenshot_height = val; break;
+    case 111:  play.top_bar_font = val; break;
+    case 112:  play.speech_text_align = val; break;
+    case 113:  play.auto_use_walkto_points = val; break;
+    case 114:  play.inventory_greys_out = val; break;
+    case 115:  play.skip_speech_specific_key = val; break;
+    case 116:  play.abort_key = val; break;
+    case 117:
+    case 118:
+    case 119:
+        cc_error("StaticGame: attempt to write readonly variable at offset %d", offset);
+        break;
+    case 120:  play.show_single_dialog_option = val; break;
+    case 121:  play.keep_screen_during_instant_transition = val; break;
+    case 122:  play.read_dialog_option_colour = val; break;
+    case 123:  play.stop_dialog_at_end = val; break;
+    case 124:  play.speech_portrait_placement = val; break;
+    case 125:  play.speech_portrait_x = val; break;
+    case 126:  play.speech_portrait_y = val; break;
+    case 127:  play.speech_display_post_time_ms = val; break;
+    case 128:  play.dialog_options_highlight_color = val; break;
+    default:
+        cc_error("StaticGame: unsupported variable offset %d", offset);
+    }
+}

--- a/Engine/ac/statobj/staticgame.h
+++ b/Engine/ac/statobj/staticgame.h
@@ -1,0 +1,31 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Wrapper around script "GameState" struct, managing access to its variables.
+//
+//=============================================================================
+#ifndef __AGS_EE_STATOBJ__STATICGAME_H
+#define __AGS_EE_STATOBJ__STATICGAME_H
+
+#include "ac/statobj/agsstaticobject.h"
+
+struct StaticGame : public AGSStaticObject
+{
+    virtual int32_t ReadInt32(const char *address, intptr_t offset) override;
+    virtual void    WriteInt32(const char *address, intptr_t offset, int32_t val) override;
+};
+
+extern StaticGame GameStaticManager;
+
+#endif // __AGS_EE_STATOBJ__STATICGAME_H

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -270,13 +270,26 @@ void InitAndRegisterRegions()
 // Registers static entity arrays in the script system
 void RegisterStaticArrays()
 {
-    StaticCharacterArray.Create(&ccDynamicCharacter, sizeof(CharacterInfo), sizeof(CharacterInfo));
-    StaticObjectArray.Create(&ccDynamicObject, sizeof(ScriptObject), sizeof(ScriptObject));
-    StaticGUIArray.Create(&ccDynamicGUI, sizeof(ScriptGUI), sizeof(ScriptGUI));
-    StaticHotspotArray.Create(&ccDynamicHotspot, sizeof(ScriptHotspot), sizeof(ScriptHotspot));
-    StaticRegionArray.Create(&ccDynamicRegion, sizeof(ScriptRegion), sizeof(ScriptRegion));
-    StaticInventoryArray.Create(&ccDynamicInv, sizeof(ScriptInvItem), sizeof(ScriptInvItem));
-    StaticDialogArray.Create(&ccDynamicDialog, sizeof(ScriptDialog), sizeof(ScriptDialog));
+    // We need to know sizes of related script structs to convert memory offsets into object indexes.
+    // These sized are calculated by the compiler based on script struct declaration.
+    // Note, that only regular variables count to the struct size, NOT properties and NOT methods.
+    // Currently there is no way to read the type sizes from script, so we have to define them by hand.
+    // If the struct size changes in script, we must change the numbers here.
+    // If we are going to support multiple different versions of same struct, then the "script size"
+    // should be chosen depending on the script api version.
+    const int charScriptSize = sizeof(int32_t) * 28 + sizeof(int16_t) * MAX_INV + sizeof(int32_t) + 61;
+    const int dummyScriptSize = sizeof(int32_t) * 2; // 32-bit id + reserved int32
+
+    // The current implementation of the StaticArray assumes we are dealing with regular C-arrays.
+    // Therefore we need to know real struct size too. If we will change to std containers, then
+    // (templated) telling real size will no longer be necessary.
+    StaticCharacterArray.Create(&ccDynamicCharacter, charScriptSize, sizeof(CharacterInfo));
+    StaticObjectArray.Create(&ccDynamicObject, dummyScriptSize, sizeof(ScriptObject));
+    StaticGUIArray.Create(&ccDynamicGUI, dummyScriptSize, sizeof(ScriptGUI));
+    StaticHotspotArray.Create(&ccDynamicHotspot, dummyScriptSize, sizeof(ScriptHotspot));
+    StaticRegionArray.Create(&ccDynamicRegion, dummyScriptSize, sizeof(ScriptRegion));
+    StaticInventoryArray.Create(&ccDynamicInv, dummyScriptSize, sizeof(ScriptInvItem));
+    StaticDialogArray.Create(&ccDynamicDialog, dummyScriptSize, sizeof(ScriptDialog));
 
     ccAddExternalStaticArray("character",&game.chars[0], &StaticCharacterArray);
     ccAddExternalStaticArray("object",&scrObj[0], &StaticObjectArray);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -277,7 +277,8 @@ void RegisterStaticArrays()
     // If the struct size changes in script, we must change the numbers here.
     // If we are going to support multiple different versions of same struct, then the "script size"
     // should be chosen depending on the script api version.
-    const int charScriptSize = sizeof(int32_t) * 28 + sizeof(int16_t) * MAX_INV + sizeof(int32_t) + 61;
+    const int charScriptSize = sizeof(int32_t) * 28 + sizeof(int16_t) * MAX_INV + sizeof(int32_t) + 61
+        + 1; // + 1 for mem align
     const int dummyScriptSize = sizeof(int32_t) * 2; // 32-bit id + reserved int32
 
     // The current implementation of the StaticArray assumes we are dealing with regular C-arrays.

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1218,8 +1218,6 @@ void engine_init_game_settings()
 
 void engine_setup_scsystem_auxiliary()
 {
-    // ScriptSystem::aci_version is only 10 chars long
-    strncpy(scsystem.aci_version, EngineVersion.LongString, 10);
     if (usetup.override_script_os >= 0)
     {
         scsystem.os = usetup.override_script_os;

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptoverlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptstring.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptsystem.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptuserobject.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptviewframe.cpp" />
     <ClCompile Include="..\..\Engine\ac\event.cpp" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdrawingsurface.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdynamicsprite.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptfile.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptoverlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptstring.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptuserobject.cpp" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -267,6 +267,7 @@
     <ClCompile Include="..\..\Engine\ac\spritecache_engine.cpp" />
     <ClCompile Include="..\..\Engine\ac\statobj\agsstaticobject.cpp" />
     <ClCompile Include="..\..\Engine\ac\statobj\staticarray.cpp" />
+    <ClCompile Include="..\..\Engine\ac\statobj\staticgame.cpp" />
     <ClCompile Include="..\..\Engine\ac\string.cpp" />
     <ClCompile Include="..\..\Engine\ac\system.cpp" />
     <ClCompile Include="..\..\Engine\ac\textbox.cpp" />
@@ -586,6 +587,7 @@
     <ClInclude Include="..\..\Engine\ac\spritelistentry.h" />
     <ClInclude Include="..\..\Engine\ac\statobj\agsstaticobject.h" />
     <ClInclude Include="..\..\Engine\ac\statobj\staticarray.h" />
+    <ClInclude Include="..\..\Engine\ac\statobj\staticgame.h" />
     <ClInclude Include="..\..\Engine\ac\statobj\staticobject.h" />
     <ClInclude Include="..\..\Engine\ac\string.h" />
     <ClInclude Include="..\..\Engine\ac\system.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -990,6 +990,9 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptsystem.cpp">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -987,6 +987,9 @@
     <ClCompile Include="..\..\Engine\ac\statobj\staticgame.cpp">
       <Filter>Header Files\ac\statobj</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -985,13 +985,13 @@
       <Filter>Source Files\game</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\statobj\staticgame.cpp">
-      <Filter>Header Files\ac\statobj</Filter>
+      <Filter>Source Files\ac\statobj</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp">
-      <Filter>Header Files\ac\dynobj</Filter>
+      <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptsystem.cpp">
-      <Filter>Header Files\ac\dynobj</Filter>
+      <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -984,6 +984,9 @@
     <ClCompile Include="..\..\Engine\game\savegame_components.cpp">
       <Filter>Source Files\game</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\statobj\staticgame.cpp">
+      <Filter>Header Files\ac\statobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1825,6 +1828,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\game\savegame_components.h">
       <Filter>Header Files\game</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\statobj\staticgame.h">
+      <Filter>Header Files\ac\statobj</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Long story short, this properly wraps script variable access in runtime in a way that no longer restricts internal data size or layout.
For more detailed explanation of a problem: [wiki page](https://github.com/adventuregamestudio/ags/wiki/Engine-data-structure-restrictions#engine-memory-exposed-to-scripts)
Pull request affects GameState, CharacterInfo, ScriptMouse and ScriptSystem structs.
Only ones remaining are palette array (which is probably okay as it is), and couple of legacy arrays that probably should be removed for now (I marked them in script header).

After this and #452 it must be absolutely safe to modify game classes in the engine code.