### PR TITLE
Add builtin stubs for AGSteam and AGSGalaxy

### DIFF
--- a/Engine/plugin/global_plugin.cpp
+++ b/Engine/plugin/global_plugin.cpp
@@ -50,9 +50,19 @@ RuntimeScriptValue Sc_PluginStub_IntNeg1(const RuntimeScriptValue *params, int32
     return RuntimeScriptValue().SetInt32(-1);
 }
 
+RuntimeScriptValue Sc_PluginStub_NullStr(const RuntimeScriptValue *params, int32_t param_count)
+{
+	return RuntimeScriptValue().SetStringLiteral(NULL);
+}
+
 bool RegisterPluginStubs(const char* name)
 {
   // Stubs for plugin functions.
+
+  bool is_agsteam = (stricmp(name, "agsteam") == 0) || (stricmp(name, "agsteam-unified") == 0) ||
+    (stricmp(name, "agsteam-disjoint") == 0);
+  bool is_agsgalaxy = (stricmp(name, "agsgalaxy") == 0) || (stricmp(name, "agsgalaxy-unified") == 0) ||
+    (stricmp(name, "agsgalaxy-disjoint") == 0);
 
   if (stricmp(name, "ags_shell") == 0)
   {
@@ -158,6 +168,78 @@ bool RegisterPluginStubs(const char* name)
     ccAddExternalStaticFunction("IosGetAchievementValue",       Sc_PluginStub_IntNeg1);
     ccAddExternalStaticFunction("IosShowAchievements",          Sc_PluginStub_Void);
     ccAddExternalStaticFunction("IosResetAchievements",         Sc_PluginStub_Void);
+    return true;
+  }
+  else if (is_agsteam || is_agsgalaxy)
+  {
+    // agsteam.dll or agsgalaxy.dll
+    ccAddExternalStaticFunction("AGS2Client::IsAchievementAchieved^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::SetAchievementAchieved^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::ResetAchievement^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::GetIntStat^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::GetFloatStat^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::GetAverageRateStat^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::SetIntStat^2", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::SetFloatStat^2", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::UpdateAverageRateStat^3", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::ResetStatsAndAchievements^0", Sc_PluginStub_Void);
+    ccAddExternalStaticFunction("AGS2Client::get_Initialized", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::get_CurrentLeaderboardName", Sc_PluginStub_NullStr);
+    ccAddExternalStaticFunction("AGS2Client::RequestLeaderboard^3", Sc_PluginStub_Void);
+    ccAddExternalStaticFunction("AGS2Client::UploadScore^1", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::geti_LeaderboardNames", Sc_PluginStub_NullStr);
+    ccAddExternalStaticFunction("AGS2Client::geti_LeaderboardScores", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::get_LeaderboardCount", Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("AGS2Client::GetUserName^0", Sc_PluginStub_NullStr);
+    ccAddExternalStaticFunction("AGS2Client::GetCurrentGameLanguage^0", Sc_PluginStub_NullStr);
+    ccAddExternalStaticFunction("AGS2Client::FindLeaderboard^1", Sc_PluginStub_Void);
+    ccAddExternalStaticFunction("AGS2Client::Initialize^2", Sc_PluginStub_Int0);
+    if (is_agsteam)
+    {
+      ccAddExternalStaticFunction("AGSteam::IsAchievementAchieved^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::SetAchievementAchieved^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::ResetAchievement^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::GetIntStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::GetFloatStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::GetAverageRateStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::SetIntStat^2", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::SetFloatStat^2", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::UpdateAverageRateStat^3", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::ResetStatsAndAchievements^0", Sc_PluginStub_Void);
+      ccAddExternalStaticFunction("AGSteam::get_Initialized", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::get_CurrentLeaderboardName", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSteam::RequestLeaderboard^3", Sc_PluginStub_Void);
+      ccAddExternalStaticFunction("AGSteam::UploadScore^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::geti_LeaderboardNames", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSteam::geti_LeaderboardScores", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::get_LeaderboardCount", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSteam::GetUserName^0", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSteam::GetCurrentGameLanguage^0", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSteam::FindLeaderboard^1", Sc_PluginStub_Void);
+    }
+    else // agsgalaxy
+    {
+      ccAddExternalStaticFunction("AGSGalaxy::IsAchievementAchieved^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::SetAchievementAchieved^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::ResetAchievement^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::GetIntStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::GetFloatStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::GetAverageRateStat^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::SetIntStat^2", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::SetFloatStat^2", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::UpdateAverageRateStat^3", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::ResetStatsAndAchievements^0", Sc_PluginStub_Void);
+      ccAddExternalStaticFunction("AGSGalaxy::get_Initialized", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::get_CurrentLeaderboardName", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSGalaxy::RequestLeaderboard^3", Sc_PluginStub_Void);
+      ccAddExternalStaticFunction("AGSGalaxy::UploadScore^1", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::geti_LeaderboardNames", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSGalaxy::geti_LeaderboardScores", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::get_LeaderboardCount", Sc_PluginStub_Int0);
+      ccAddExternalStaticFunction("AGSGalaxy::GetUserName^0", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSGalaxy::GetCurrentGameLanguage^0", Sc_PluginStub_NullStr);
+      ccAddExternalStaticFunction("AGSGalaxy::Initialize^2", Sc_PluginStub_Int0);
+    }
     return true;
   }
 


### PR DESCRIPTION
The AGSteam and AGSGalaxy client plugins are beyond the scope of this project, but function stubs for them should not require much maintenance as their APIs are not expected to change much. This could also serve as a complete replacement for [ags2clientstub](https://github.com/monkey0506/ags2clientstub).

I'm not sure if I knew plugins could be stubbed this way, but this seems appropriate based on the other existing stubs. I had started writing ags2clientstub as a builtin plugin when I found this file.