### PR TITLE
3.4.1: Separate native and displayed image formats; support actual 16-bit native mode again

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -79,6 +79,8 @@ struct GameSetupStruct: public GameSetupStructBase {
     // TODO: find out why OPT_SCORESOUND option cannot be used to store this in >=3.2 games
     int               scoreClipID;
 
+    // Get game's native color depth
+    inline int GetColorDepth() const { return color_depth * 8; }
 
 
     // [IKM] Game struct loading code is moved here from Engine's load_game_file

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1704,7 +1704,7 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
     set_route_move_speed(move_speed_x, move_speed_y);
     set_color_depth(8);
     int mslot=find_route(charX, charY, tox, toy, prepare_walkable_areas(chac), chac+CHMLSOFFS, 1, ignwal);
-    set_color_depth(System_GetColorDepth());
+    set_color_depth(game.GetColorDepth());
     if (mslot>0) {
         chin->walking = mslot;
         mls[mslot].direct = ignwal;

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -513,7 +513,7 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
 
   update_polled_stuff_if_runtime();
 
-  tempScrn = BitmapHelper::CreateBitmap(BitmapHelper::GetScreenBitmap()->GetWidth(), BitmapHelper::GetScreenBitmap()->GetHeight(), System_GetColorDepth());
+  tempScrn = BitmapHelper::CreateBitmap(BitmapHelper::GetScreenBitmap()->GetWidth(), BitmapHelper::GetScreenBitmap()->GetHeight(), game.GetColorDepth());
 
   set_mouse_cursor(CURS_ARROW);
 
@@ -644,7 +644,7 @@ void DialogOptions::Redraw()
 
     if (usingCustomRendering)
     {
-      tempScrn = recycle_bitmap(tempScrn, System_GetColorDepth(), 
+      tempScrn = recycle_bitmap(tempScrn, game.GetColorDepth(), 
         multiply_up_coordinate(ccDialogOptionsRendering.width), 
         multiply_up_coordinate(ccDialogOptionsRendering.height));
     }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -170,7 +170,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
     if (blocking < 2)
         remove_screen_overlay(OVER_TEXTMSG);
 
-    Bitmap *text_window_ds = BitmapHelper::CreateTransparentBitmap((wii > 0) ? wii : 2, disp.fulltxtheight + extraHeight, System_GetColorDepth());
+    Bitmap *text_window_ds = BitmapHelper::CreateTransparentBitmap((wii > 0) ? wii : 2, disp.fulltxtheight + extraHeight, game.GetColorDepth());
     SetVirtualScreen(text_window_ds);
 
     // inform draw_text_window to free the old bitmap
@@ -200,7 +200,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 alphaChannel = guis[usingGui].HasAlphaChannel();
             }
         }
-        else if ((ShouldAntiAliasText()) && (System_GetColorDepth() >= 24))
+        else if ((ShouldAntiAliasText()) && (game.GetColorDepth() >= 24))
             alphaChannel = true;
 
         for (ee=0;ee<numlines;ee++) {
@@ -690,7 +690,7 @@ void draw_text_window(Bitmap **text_window_ds, bool should_free_ds,
         if (should_free_ds)
             delete *text_window_ds;
         int padding = get_textwindow_padding(ifnum);
-        *text_window_ds = BitmapHelper::CreateTransparentBitmap(wii[0],ovrheight+(padding*2)+spriteheight[tbnum]*2,System_GetColorDepth());
+        *text_window_ds = BitmapHelper::CreateTransparentBitmap(wii[0],ovrheight+(padding*2)+spriteheight[tbnum]*2,game.GetColorDepth());
         ds = SetVirtualScreen(*text_window_ds);
         int xoffs=spritewidth[tbnum],yoffs=spriteheight[tbnum];
         draw_button_background(ds, xoffs,yoffs,(ds->GetWidth() - xoffs) - 1,(ds->GetHeight() - yoffs) - 1,&guis[ifnum]);
@@ -711,7 +711,7 @@ void draw_text_window_and_bar(Bitmap **text_window_ds, bool should_free_ds,
         // top bar on the dialog window with character's name
         // create an enlarged window, then free the old one
         Bitmap *ds = *text_window_ds;
-        Bitmap *newScreenop = BitmapHelper::CreateBitmap(ds->GetWidth(), ds->GetHeight() + topBar.height, System_GetColorDepth());
+        Bitmap *newScreenop = BitmapHelper::CreateBitmap(ds->GetWidth(), ds->GetHeight() + topBar.height, game.GetColorDepth());
         newScreenop->Blit(ds, 0, 0, 0, topBar.height, ds->GetWidth(), ds->GetHeight());
         delete *text_window_ds;
         *text_window_ds = newScreenop;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -207,9 +207,6 @@ void setpal() {
     set_palette_range(palette, 0, 255, 0);
 }
 
-
-#ifdef USE_15BIT_FIX
-
 int _places_r = 3, _places_g = 2, _places_b = 3;
 
 // convert RGB to BGR for strange graphics cards
@@ -238,9 +235,6 @@ Bitmap *convert_16_to_16bgr(Bitmap *tempbl) {
 
     return tempbl;
 }
-#endif
-
-
 
 // PSP: convert 32 bit RGB to BGR.
 Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
@@ -324,13 +318,11 @@ Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
         else // else simply convert bitmap
             new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, game_col_depth);
     }
-#ifdef USE_15BIT_FIX
     // Special case when we must convert 16-bit RGB to BGR
     else if (convert_16bit_bgr == 1 && bmp_col_depth == 16)
     {
         new_bitmap = convert_16_to_16bgr(bitmap);
     }
-#endif
     return new_bitmap;
 }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -221,14 +221,14 @@ Bitmap *convert_16_to_15(Bitmap *iii) {
 
     if (iii->GetColorDepth() > 16) {
         // we want a 32-to-24 conversion
-        Bitmap *tempbl = BitmapHelper::CreateBitmap(iwid,ihit,System_GetColorDepth());
-        if (System_GetColorDepth() < 24) {
+        Bitmap *tempbl = BitmapHelper::CreateBitmap(iwid,ihit,game.GetColorDepth());
+        if (game.GetColorDepth() < 24) {
             // 32-to-16
             tempbl->Blit(iii, 0, 0, 0, 0, iwid, ihit);
             return tempbl;
         }
 
-        GFX_VTABLE *vtable = _get_vtable(System_GetColorDepth());
+        GFX_VTABLE *vtable = _get_vtable(game.GetColorDepth());
         if (vtable == NULL) {
             quit("unable to get 24-bit bitmap vtable");
         }
@@ -365,7 +365,7 @@ Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
     const bool software_driver = !gfxDriver->HasAcceleratedStretchAndFlip();
     const int bmp_col_depth = bitmap->GetColorDepth();
     const int sys_col_depth = System_GetColorDepth();
-    const int game_col_depth = game.color_depth * 8;
+    const int game_col_depth = game.GetColorDepth();
     Bitmap *new_bitmap = bitmap;
 
     if ((bmp_col_depth == 32) && (sys_col_depth == 32))
@@ -417,7 +417,7 @@ Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *bitmap)
 
 Bitmap *PrepareSpriteForUse(Bitmap* bitmap, bool has_alpha)
 {
-    bool must_switch_palette = bitmap->GetColorDepth() == 8 && System_GetColorDepth() > 8;
+    bool must_switch_palette = bitmap->GetColorDepth() == 8 && game.GetColorDepth() > 8;
     if (must_switch_palette)
         select_palette(palette);
 
@@ -1374,7 +1374,7 @@ void apply_tint_or_light(int actspsindex, int light_level,
  }
 
  // we can only do tint/light if the colour depths match
- if (System_GetColorDepth() == actsps[actspsindex]->GetColorDepth()) {
+ if (game.GetColorDepth() == actsps[actspsindex]->GetColorDepth()) {
      Bitmap *oldwas;
      // if the caller supplied a source bitmap, ->Blit from it
      // (used as a speed optimisation where possible)
@@ -2189,7 +2189,7 @@ void draw_fps()
 
     if (fpsDisplay == NULL)
     {
-        fpsDisplay = BitmapHelper::CreateBitmap(get_fixed_pixel_size(100), (getfontheight_outlined(FONT_SPEECH) + get_fixed_pixel_size(5)), System_GetColorDepth());
+        fpsDisplay = BitmapHelper::CreateBitmap(get_fixed_pixel_size(100), (getfontheight_outlined(FONT_SPEECH) + get_fixed_pixel_size(5)), game.GetColorDepth());
         fpsDisplay = ReplaceBitmapWithSupportedFormat(fpsDisplay);
     }
     fpsDisplay->ClearTransparent();
@@ -2485,7 +2485,7 @@ void update_screen() {
 
         if (debugConsoleBuffer == NULL)
         {
-            debugConsoleBuffer = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), barheight,System_GetColorDepth());
+            debugConsoleBuffer = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), barheight,game.GetColorDepth());
             debugConsoleBuffer = ReplaceBitmapWithSupportedFormat(debugConsoleBuffer);
         }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -210,87 +210,6 @@ void setpal() {
 
 #ifdef USE_15BIT_FIX
 
-extern "C" {
-    AL_FUNC(GFX_VTABLE *, _get_vtable, (int color_depth));
-}
-
-Bitmap *convert_16_to_15(Bitmap *iii) {
-    //  int xx,yy,rpix;
-    int iwid = iii->GetWidth(), ihit = iii->GetHeight();
-    int x,y;
-
-    if (iii->GetColorDepth() > 16) {
-        // we want a 32-to-24 conversion
-        Bitmap *tempbl = BitmapHelper::CreateBitmap(iwid,ihit,game.GetColorDepth());
-        if (game.GetColorDepth() < 24) {
-            // 32-to-16
-            tempbl->Blit(iii, 0, 0, 0, 0, iwid, ihit);
-            return tempbl;
-        }
-
-        GFX_VTABLE *vtable = _get_vtable(game.GetColorDepth());
-        if (vtable == NULL) {
-            quit("unable to get 24-bit bitmap vtable");
-        }
-
-		// TODO
-        ((BITMAP*)tempbl->GetAllegroBitmap())->vtable = vtable;
-
-        for (y=0; y < tempbl->GetHeight(); y++) {
-            unsigned char*p32 = (unsigned char *)iii->GetScanLine(y);
-            unsigned char*p24 = (unsigned char *)tempbl->GetScanLine(y);
-
-            // strip out the alpha channel bit and copy the rest across
-            for (x=0; x < tempbl->GetWidth(); x++) {
-                memcpy(&p24[x * 3], &p32[x * 4], 3);
-            }
-        }
-
-        return tempbl;
-    }
-
-    // we want a 16-to-15 converstion
-
-    unsigned short c,r,ds,b;
-    // we do this process manually - no allegro color conversion
-    // because we store the RGB in a particular order in the data files
-    Bitmap *tempbl = BitmapHelper::CreateBitmap(iwid,ihit,15);
-
-    GFX_VTABLE *vtable = _get_vtable(15);
-
-    if (vtable == NULL) {
-        quit("unable to get 15-bit bitmap vtable");
-    }
-
-	// TODO
-    ((BITMAP*)tempbl->GetAllegroBitmap())->vtable = vtable;
-
-    for (y=0; y < tempbl->GetHeight(); y++) {
-        unsigned short*p16 = (unsigned short *)iii->GetScanLine(y);
-        unsigned short*p15 = (unsigned short *)tempbl->GetScanLine(y);
-
-        for (x=0; x < tempbl->GetWidth(); x++) {
-            c = p16[x];
-            b = _rgb_scale_5[c & 0x1F];
-            ds = _rgb_scale_6[(c >> 5) & 0x3F];
-            r = _rgb_scale_5[(c >> 11) & 0x1F];
-            p15[x] = makecol15(r, ds, b);
-        }
-    }
-    /*
-    // the auto color conversion doesn't seem to work
-    for (xx=0;xx<iwid;xx++) {
-    for (yy=0;yy<ihit;yy++) {
-    rpix = _getpixel16(iii,xx,yy);
-    rpix = (rpix & 0x001f) | ((rpix >> 1) & 0x7fe0);
-    // again putpixel16 because the dest is actually 16bit
-    _putpixel15(tempbl,xx,yy,rpix);
-    }
-    }*/
-
-    return tempbl;
-}
-
 int _places_r = 3, _places_g = 2, _places_b = 3;
 
 // convert RGB to BGR for strange graphics cards
@@ -351,7 +270,7 @@ Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
 // D3D and OpenGL rendering, for two reasons:
 // 1) certain raw drawing operations are still performed by software
 // Allegro methods, hence bitmaps should be kept compatible to any native
-// software operations.
+// software operations, such as blitting two bitmaps of different formats.
 // 2) mobile ports feature an OpenGL renderer built in Allegro library,
 // that assumes native bitmaps are in OpenGL-compatible format, so that it
 // could copy them to texture without additional changes.
@@ -362,44 +281,52 @@ Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
 //
 Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
 {
-    const bool software_driver = !gfxDriver->HasAcceleratedStretchAndFlip();
     const int bmp_col_depth = bitmap->GetColorDepth();
     const int sys_col_depth = System_GetColorDepth();
     const int game_col_depth = game.GetColorDepth();
     Bitmap *new_bitmap = bitmap;
 
-    if ((bmp_col_depth == 32) && (sys_col_depth == 32))
-    {
+    //
+    // The only special case when bitmap needs to be prepared for graphics driver
+    //
+    // In 32-bit display mode, 32-bit bitmaps may require component conversion
+    // to match graphics driver expectation about pixel format.
+    // TODO: make GetCompatibleBitmapFormat tell this somehow
 #if defined (AGS_INVERTED_COLOR_ORDER)
-        // Convert RGB to BGR color order.
+    if (sys_col_depth > 16 && bmp_col_depth == 32)
+    {
+        // Convert RGB to BGR.
         new_bitmap = convert_32_to_32bgr(bitmap);
+    }
 #endif
-        if (has_alpha) // this adjustment is probably needed for DrawingSurface ops
+
+    //
+    // The rest is about bringing bitmaps to the native game's format
+    // (has no dependency on display mode).
+    //
+    // In 32-bit game 32-bit bitmaps should have transparent pixels marked
+    // (this adjustment is probably needed for DrawingSurface ops)
+    if (game_col_depth == 32 && bmp_col_depth == 32)
+    {
+        if (has_alpha) 
             set_rgb_mask_using_alpha_channel(new_bitmap);
     }
-    else if (((bmp_col_depth > 16) && (sys_col_depth <= 16)) ||
-             ((bmp_col_depth == 16) && (sys_col_depth > 16)))
+    // In 32-bit game hicolor bitmaps must be converted to the true color
+    else if (game_col_depth == 32 && (bmp_col_depth > 8 && bmp_col_depth <= 16))
     {
-            // 16-bit sprite in 32-bit game or vice versa - convert
-            // so that scaling and blit calls work properly
-            if (has_alpha) // 32-bit source only
-                new_bitmap = remove_alpha_channel(bitmap);
-            else if (software_driver) // non-software drivers do this on their own
-                new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, sys_col_depth);
+        new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, game_col_depth);
+    }
+    // In non-32-bit game truecolor bitmaps must be downgraded
+    else if (game_col_depth <= 16 && bmp_col_depth > 16)
+    {
+        if (has_alpha) // if has valid alpha channel, convert it to regular transparency mask
+            new_bitmap = remove_alpha_channel(bitmap);
+        else // else simply convert bitmap
+            new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, game_col_depth);
     }
 #ifdef USE_15BIT_FIX
-    // TODO: review this later, it may also happen e.g. when running 32-bit game in 24-bit mode
-    // This is software driver only fix
-    else if ((sys_col_depth != game_col_depth) && (bmp_col_depth == game_col_depth))
-    {
-        // running in 15-bit mode with a 16-bit game, convert sprites
-        if (has_alpha)
-            // 32-to-24 with alpha channel
-            new_bitmap = remove_alpha_channel(bitmap);
-        else
-            new_bitmap = convert_16_to_15(bitmap);
-    }
-    else if ((convert_16bit_bgr == 1) && (bmp_col_depth == 16))
+    // Special case when we must convert 16-bit RGB to BGR
+    else if (convert_16bit_bgr == 1 && bmp_col_depth == 16)
     {
         new_bitmap = convert_16_to_16bgr(bitmap);
     }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -357,8 +357,8 @@ Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
 // could copy them to texture without additional changes.
 // AGS own OpenGL renderer tries to sync its behavior with the former one.
 //
-// TODO: find out if we may safely move software-driver only related parts
-// to ALSoftwareGraphicsDriver::ConvertBitmapToSupportedColourDepth()
+// TODO: make gfxDriver->GetCompatibleBitmapFormat describe all necessary
+// conversions, so that we did not have to guess.
 //
 Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
 {
@@ -409,7 +409,7 @@ Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
 
 Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *bitmap)
 {
-    Bitmap *new_bitmap = gfxDriver->ConvertBitmapToSupportedColourDepth(bitmap);
+    Bitmap *new_bitmap = GfxUtil::ConvertBitmap(bitmap, gfxDriver->GetCompatibleBitmapFormat(bitmap->GetColorDepth()));
     if (new_bitmap != bitmap)
         delete bitmap;
     return new_bitmap;

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -29,12 +29,6 @@ using namespace AGS; // FIXME later
 
 #define IS_ANTIALIAS_SPRITES usetup.enable_antialiasing && (play.disable_antialiasing == 0)
 
-// Allegro 4 has switched 15-bit colour to BGR instead of RGB, so
-// in this case we need to convert the graphics on load
-#if ALLEGRO_DATE > 19991010
-#define USE_15BIT_FIX
-#endif
-
 // [IKM] WARNING: these definitions has to be made AFTER Allegro headers
 // were included, because they override few Allegro function names;
 // otherwise Allegro headers should not be included at all to the same

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -320,14 +320,14 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
     if (!gfxDriver->UsesMemoryBackBuffer()) 
     {
         // D3D driver
-        Bitmap *scrndump = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), play.viewport.GetHeight(), System_GetColorDepth());
+        Bitmap *scrndump = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), play.viewport.GetHeight(), game.GetColorDepth());
         gfxDriver->GetCopyOfScreenIntoBitmap(scrndump);
 
         update_polled_stuff_if_runtime();
 
         if ((play.viewport.GetWidth() != width) || (play.viewport.GetHeight() != height))
         {
-            newPic = BitmapHelper::CreateBitmap(width, height, System_GetColorDepth());
+            newPic = BitmapHelper::CreateBitmap(width, height, game.GetColorDepth());
             newPic->StretchBlt(scrndump,
                 RectWH(0, 0, scrndump->GetWidth(), scrndump->GetHeight()),
                 RectWH(0, 0, width, height));
@@ -413,11 +413,11 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
     if (gotSlot <= 0)
         return NULL;
 
-    Bitmap *newPic = BitmapHelper::CreateTransparentBitmap(width, height, System_GetColorDepth());
+    Bitmap *newPic = BitmapHelper::CreateTransparentBitmap(width, height, game.GetColorDepth());
     if (newPic == NULL)
         return NULL;
 
-    if ((alphaChannel) && (System_GetColorDepth() < 32))
+    if ((alphaChannel) && (game.GetColorDepth() < 32))
         alphaChannel = false;
 
     add_dynamic_sprite(gotSlot, ReplaceBitmapWithSupportedFormat(newPic), alphaChannel != 0);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1482,9 +1482,9 @@ void create_savegame_screenshot(Bitmap *&screenShot)
         {
             // FIXME this weird stuff! (related to incomplete OpenGL renderer)
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
-            int color_depth = (psp_gfx_renderer > 0) ? 32 : System_GetColorDepth();
+            int color_depth = (psp_gfx_renderer > 0) ? 32 : game.GetColorDepth();
 #else
-            int color_depth = System_GetColorDepth();
+            int color_depth = game.GetColorDepth();
 #endif
             Bitmap *tempBlock = BitmapHelper::CreateBitmap(virtual_screen->GetWidth(), virtual_screen->GetHeight(), color_depth);
             gfxDriver->GetCopyOfScreenIntoBitmap(tempBlock);
@@ -2134,7 +2134,7 @@ SavegameError load_game(const String &path, int slotNumber, bool &data_overwritt
     if (err != kSvgErr_NoError)
         return err;
     // CHECKME: is this color depth test still essential? if yes, is there possible workaround?
-    else if (desc.ColorDepth != System_GetColorDepth())
+    else if (desc.ColorDepth != game.GetColorDepth())
         return kSvgErr_DifferentColorDepth;
     else if (!src.InputStream.get())
         return kSvgErr_NoStream;

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -22,7 +22,6 @@ GameSetup::GameSetup()
     mod_player=1;
     no_speech_pack = false;
     enable_antialiasing = false;
-    force_hicolor_mode = false;
     disable_exception_handling = false;
     mouse_auto_lock = false;
     override_script_os = -1;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -42,7 +42,6 @@ struct GameSetup {
     int textheight; // text height used on the certain built-in GUI
     bool  no_speech_pack;
     bool  enable_antialiasing;
-    bool  force_hicolor_mode;
     bool  disable_exception_handling;
     AGS::Common::String data_files_dir;
     AGS::Common::String main_data_filename;

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -66,10 +66,10 @@ String GetRuntimeInfo()
     PGfxFilter filter = gfxDriver->GetGraphicsFilter();
     String runtimeInfo = String::FromFormat(
         "Adventure Game Studio run-time engine[ACI version %s"
-        "[Game resolution %d x %d"
+        "[Game resolution %d x %d (%d-bit)"
         "[Running %d x %d at %d-bit%s%s[GFX: %s; %s[Draw frame %d x %d["
         "Sprite cache size: %d KB (limit %d KB; %d locked)",
-        EngineVersion.LongString.GetCStr(), game.size.Width, game.size.Height,
+        EngineVersion.LongString.GetCStr(), game.size.Width, game.size.Height, game.GetColorDepth(),
         mode.Width, mode.Height, mode.ColorDepth, (convert_16bit_bgr) ? " BGR" : "",
         mode.Windowed ? " W" : "",
         gfxDriver->GetDriverName(), filter->GetInfo().Name.GetCStr(),

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -750,9 +750,9 @@ int SaveScreenShot(const char*namm) {
     {
         // FIXME this weird stuff! (related to incomplete OpenGL renderer)
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
-        int color_depth = (psp_gfx_renderer > 0) ? 32 : System_GetColorDepth();
+        int color_depth = (psp_gfx_renderer > 0) ? 32 : game.GetColorDepth();
 #else
-        int color_depth = System_GetColorDepth();
+        int color_depth = game.GetColorDepth();
 #endif
         Bitmap *buffer = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), play.viewport.GetHeight(), color_depth);
         gfxDriver->GetCopyOfScreenIntoBitmap(buffer);

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -48,7 +48,7 @@ void RemoveOverlay(int ovrid) {
 int CreateGraphicOverlay(int xx,int yy,int slott,int trans) {
     multiply_up_coordinates(&xx, &yy);
 
-    Bitmap *screeno=BitmapHelper::CreateTransparentBitmap(spritewidth[slott],spriteheight[slott], System_GetColorDepth());
+    Bitmap *screeno=BitmapHelper::CreateTransparentBitmap(spritewidth[slott],spriteheight[slott], game.GetColorDepth());
     Bitmap *ds = SetVirtualScreen(screeno);
     wputblock(ds, 0,0,spriteset[slott],trans);
 

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -501,7 +501,7 @@ void recreate_guibg_image(GUIMain *tehgui)
 {
   int ifn = tehgui->Id;
   delete guibg[ifn];
-  guibg[ifn] = BitmapHelper::CreateBitmap(tehgui->Width, tehgui->Height, System_GetColorDepth());
+  guibg[ifn] = BitmapHelper::CreateBitmap(tehgui->Width, tehgui->Height, game.GetColorDepth());
   if (guibg[ifn] == NULL)
     quit("SetGUISize: internal error: unable to reallocate gui cache");
   guibg[ifn] = ReplaceBitmapWithSupportedFormat(guibg[ifn]);

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -353,7 +353,7 @@ void set_new_cursor_graphic (int spriteslot) {
     {
         if (blank_mouse_cursor == NULL)
         {
-            blank_mouse_cursor = BitmapHelper::CreateTransparentBitmap(1, 1, System_GetColorDepth());
+            blank_mouse_cursor = BitmapHelper::CreateTransparentBitmap(1, 1, game.GetColorDepth());
         }
         mousecurs[0] = blank_mouse_cursor;
     }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -395,7 +395,7 @@ void move_object(int objj,int tox,int toy,int spee,int ignwal) {
     set_route_move_speed(spee, spee);
     set_color_depth(8);
     int mslot=find_route(objX, objY, tox, toy, prepare_walkable_areas(-1), objj+1, 1, ignwal);
-    set_color_depth(System_GetColorDepth());
+    set_color_depth(game.GetColorDepth());
     if (mslot>0) {
         objs[objj].moving = mslot;
         mls[mslot].direct = ignwal;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -582,7 +582,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     thisroom.object = fix_bitmap_size(thisroom.object);
     update_polled_stuff_if_runtime();
 
-    set_color_depth(System_GetColorDepth());
+    set_color_depth(game.GetColorDepth());
     // convert backgrounds to current res
     if (thisroom.resolution != get_fixed_pixel_size(1)) {
         for (cc=0;cc<thisroom.num_bscenes;cc++)

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -77,7 +77,7 @@ void set_rgb_mask_using_alpha_channel(Bitmap *image)
 
 // from is a 32-bit RGBA image, to is a 15/16/24-bit destination image
 Bitmap *remove_alpha_channel(Bitmap *from) {
-    int depth = System_GetColorDepth();
+    int depth = game.GetColorDepth();
 
     Bitmap *to = BitmapHelper::CreateBitmap(from->GetWidth(), from->GetHeight(),depth);
     int maskcol = to->GetMaskColor();
@@ -196,7 +196,7 @@ void initialize_sprite (int ee) {
 
         spriteset.set(ee, PrepareSpriteForUse(spriteset[ee], (game.spriteflags[ee] & SPF_ALPHACHANNEL) != 0));
 
-        if (System_GetColorDepth() < 32) {
+        if (game.GetColorDepth() < 32) {
             game.spriteflags[ee] &= ~SPF_ALPHACHANNEL;
             // save the fact that it had one for the next time this
             // is re-loaded from disk

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -503,7 +503,7 @@ SavegameError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_da
 
     for (int i = 0; i < game.numgui; ++i)
     {
-        guibg[i] = BitmapHelper::CreateBitmap(guis[i].Width, guis[i].Height, System_GetColorDepth());
+        guibg[i] = BitmapHelper::CreateBitmap(guis[i].Width, guis[i].Height, game.GetColorDepth());
         guibg[i] = ReplaceBitmapWithSupportedFormat(guibg[i]);
     }
 
@@ -610,7 +610,7 @@ Stream *StartSavegame(const String &filename, const String &desc, const Bitmap *
 
     // Write current display mode parameters
     out->WriteInt32(play.viewport.GetHeight()); // for compatibility with old engines
-    out->WriteInt32(System_GetColorDepth());
+    out->WriteInt32(game.GetColorDepth());
     return out;
 }
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1739,7 +1739,6 @@ void OGLGraphicsDriver::create_screen_tint_bitmap()
     return;
   
   _screenTintLayer = BitmapHelper::CreateBitmap(16, 16, _mode.ColorDepth);
-  _screenTintLayer = ReplaceBitmapWithSupportedFormat(_screenTintLayer);
   _screenTintLayerDDB = (OGLBitmap*)this->CreateDDBFromBitmap(_screenTintLayer, false, false);
   _screenTintSprite.bitmap = _screenTintLayerDDB;
 }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -247,6 +247,12 @@ OGLGraphicsDriver::OGLGraphicsDriver()
   _do_render_to_texture = false;
   _super_sampling = 1;
   SetupDefaultVertices();
+
+  // Shifts comply to GL_RGBA
+  _vmem_r_shift_32 = 0;
+  _vmem_g_shift_32 = 8;
+  _vmem_b_shift_32 = 16;
+  _vmem_a_shift_32 = 24;
 }
 
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1455,6 +1455,8 @@ void OGLGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpda
 
 int OGLGraphicsDriver::GetCompatibleBitmapFormat(int color_depth)
 {
+  if (color_depth == 8)
+    return 8;
   if (color_depth > 8 && color_depth <= 16)
     return 16;
   return 32;
@@ -1494,9 +1496,8 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   int allocatedWidth = bitmap->GetWidth();
   int allocatedHeight = bitmap->GetHeight();
   // NOTE: original bitmap object is not modified in this function
-  Bitmap *old_bitmap = bitmap;
-  Bitmap *tempBmp = GfxUtil::ConvertBitmap(bitmap, GetCompatibleBitmapFormat(bitmap->GetColorDepth()));
-  bitmap = tempBmp;
+  if (bitmap->GetColorDepth() != GetCompatibleBitmapFormat(bitmap->GetColorDepth()))
+    throw Ali3DException("CreateDDBFromBitmap: bitmap colour depth not supported");
   int colourDepth = bitmap->GetColorDepth();
 
   OGLBitmap *ddb = new OGLBitmap(bitmap->GetWidth(), bitmap->GetHeight(), colourDepth, opaque);
@@ -1606,9 +1607,6 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   ddb->_tiles = tiles;
 
   UpdateDDBFromBitmap(ddb, bitmap, hasAlpha);
-
-  if (old_bitmap != tempBmp)
-    delete tempBmp;
 
   return ddb;
 }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -19,6 +19,7 @@
 #include "gfx/ali3dogl.h"
 #include "gfx/gfxfilter_ogl.h"
 #include "gfx/gfxfilter_aaogl.h"
+#include "gfx/gfx_util.h"
 #include "main/main_allegro.h"
 #include "platform/base/agsplatformdriver.h"
 
@@ -149,14 +150,6 @@ namespace OGL
 using namespace AGS::Common;
 
 void ogl_dummy_vsync() { }
-
-#define algetr32(xx) ((xx >> _rgb_r_shift_32) & 0xFF)
-#define algetg32(xx) ((xx >> _rgb_g_shift_32) & 0xFF)
-#define algetb32(xx) ((xx >> _rgb_b_shift_32) & 0xFF)
-#define algeta32(xx) ((xx >> _rgb_a_shift_32) & 0xFF)
-#define algetr15(xx) ((xx >> _rgb_r_shift_15) & 0x1F)
-#define algetg15(xx) ((xx >> _rgb_g_shift_15) & 0x1F)
-#define algetb15(xx) ((xx >> _rgb_b_shift_15) & 0x1F)
 
 #define GFX_OPENGL  AL_ID('O','G','L',' ')
 
@@ -1397,37 +1390,14 @@ void OGLGraphicsDriver::DestroyDDB(IDriverDependantBitmap* bitmap)
   delete bitmap;
 }
 
-__inline void get_pixel_if_not_transparent15(unsigned short *pixel, unsigned short *red, unsigned short *green, unsigned short *blue, unsigned short *divisor)
-{
-  if (pixel[0] != MASK_COLOR_15)
-  {
-    *red += algetr15(pixel[0]);
-    *green += algetg15(pixel[0]);
-    *blue += algetb15(pixel[0]);
-    divisor[0]++;
-  }
-}
 
-__inline void get_pixel_if_not_transparent32(unsigned int *pixel, unsigned int *red, unsigned int *green, unsigned int *blue, unsigned int *divisor)
-{
-  if (pixel[0] != MASK_COLOR_32)
-  {
-    *red += algetr32(pixel[0]);
-    *green += algetg32(pixel[0]);
-    *blue += algetb32(pixel[0]);
-    divisor[0]++;
-  }
-}
-
-#define D3DCOLOR_RGBA(r,g,b,a) \
-  (((((a)&0xff)<<24)|(((b)&0xff)<<16)|(((g)&0xff)<<8)|((r)&0xff)))
-
-
-void OGLGraphicsDriver::UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha)
+void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha)
 {
   int textureHeight = tile->height;
   int textureWidth = tile->width;
 
+  // TODO: this seem to be tad overcomplicated, these conversions were made
+  // when texture is just created. Check later if this operation here may be removed.
   AdjustSizeToNearestSupportedByCard(&textureWidth, &textureHeight);
 
   int tileWidth = (textureWidth > tile->width) ? tile->width + 1 : tile->width;
@@ -1435,128 +1405,25 @@ void OGLGraphicsDriver::UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, O
 
   bool usingLinearFiltering = _filter->UseLinearFiltering();
   bool lastPixelWasTransparent = false;
-  char *origPtr = (char*)malloc(4 * tileWidth * tileHeight);
+  char *origPtr = (char*)malloc(sizeof(int) * tileWidth * tileHeight);
   char *memPtr = origPtr;
-  for (int y = 0; y < tileHeight; y++)
+
+  TextureTile fixedTile;
+  fixedTile.x = tile->x;
+  fixedTile.y = tile->y;
+  fixedTile.width = Math::Min(tile->width, tileWidth);
+  fixedTile.height = Math::Min(tile->height, tileHeight);
+  int pitch = tileWidth * sizeof(int);
+  BitmapToVideoMem(bitmap, hasAlpha, &fixedTile, target, memPtr, pitch, usingLinearFiltering);
+
+  // Mimic the behaviour of GL_CLAMP_EDGE for the bottom line
+  if (tile->height < tileHeight)
   {
-    // Mimic the behaviour of GL_CLAMP_EDGE for the bottom line
-    if (y == tile->height)
-    {
-      unsigned int* memPtrLong = (unsigned int*)memPtr;
-      unsigned int* memPtrLong_previous = (unsigned int*)(memPtr - tileWidth * 4);
+    unsigned int* memPtrLong = (unsigned int*)(memPtr + pitch * tile->height);
+    unsigned int* memPtrLong_previous = (unsigned int*)(memPtr + pitch * (tile->height - 1));
 
       for (int x = 0; x < tileWidth; x++)
         memPtrLong[x] = memPtrLong_previous[x] & 0x00FFFFFF;
-
-      continue;
-    }
-
-    lastPixelWasTransparent = false;
-    const uint8_t *scanline_before = bitmap->GetScanLine(y + tile->y - 1);
-    const uint8_t *scanline_at     = bitmap->GetScanLine(y + tile->y);
-    const uint8_t *scanline_after  = bitmap->GetScanLine(y + tile->y + 1);
-    for (int x = 0; x < tileWidth; x++)
-    {
-
-/*    if (target->_colDepth == 15)
-      {
-        unsigned short* memPtrShort = (unsigned short*)memPtr;
-        unsigned short* srcData = (unsigned short*)&bitmap->GetScanLine[y + tile->y][(x + tile->x) * 2];
-        if (*srcData == MASK_COLOR_15) 
-        {
-          if (target->_opaque)  // set to black if opaque
-            memPtrShort[x] = 0x8000;
-          else if (!usingLinearFiltering)
-            memPtrShort[x] = 0;
-          // set to transparent, but use the colour from the neighbouring 
-          // pixel to stop the linear filter doing black outlines
-          else
-          {
-            unsigned short red = 0, green = 0, blue = 0, divisor = 0;
-            if (x > 0)
-              get_pixel_if_not_transparent15(&srcData[-1], &red, &green, &blue, &divisor);
-            if (x < tile->width - 1)
-              get_pixel_if_not_transparent15(&srcData[1], &red, &green, &blue, &divisor);
-            if (y > 0)
-              get_pixel_if_not_transparent15((unsigned short*)&bitmap->GetScanLine[y + tile->y - 1][(x + tile->x) * 2], &red, &green, &blue, &divisor);
-            if (y < tile->height - 1)
-              get_pixel_if_not_transparent15((unsigned short*)&bitmap->GetScanLine[y + tile->y + 1][(x + tile->x) * 2], &red, &green, &blue, &divisor);
-            if (divisor > 0)
-              memPtrShort[x] = ((red / divisor) << 10) | ((green / divisor) << 5) | (blue / divisor);
-            else
-              memPtrShort[x] = 0;
-          }
-          lastPixelWasTransparent = true;
-        }
-        else
-        {
-          memPtrShort[x] = 0x8000 | (algetr15(*srcData) << 10) | (algetg15(*srcData) << 5) | algetb15(*srcData);
-          if (lastPixelWasTransparent)
-          {
-            // update the colour of the previous tranparent pixel, to
-            // stop black outlines when linear filtering
-            memPtrShort[x - 1] = memPtrShort[x] & 0x7FFF;
-            lastPixelWasTransparent = false;
-          }
-        }
-      }
-      else if (target->_colDepth == 32)
-*/
-      {
-        unsigned int* memPtrLong = (unsigned int*)memPtr;
-
-        if (x == tile->width)
-        {
-          memPtrLong[x] = memPtrLong[x - 1] & 0x00FFFFFF;
-          continue;
-        }
-
-        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) << 2];
-        if (*srcData == MASK_COLOR_32)
-        {
-          if (target->_opaque)  // set to black if opaque
-            memPtrLong[x] = 0xFF000000;
-          else if (!usingLinearFiltering)
-            memPtrLong[x] = 0;
-          // set to transparent, but use the colour from the neighbouring 
-          // pixel to stop the linear filter doing black outlines
-          else
-          {
-            unsigned int red = 0, green = 0, blue = 0, divisor = 0;
-            if (x > 0)
-              get_pixel_if_not_transparent32(&srcData[-1], &red, &green, &blue, &divisor);
-            if (x < tile->width - 1)
-              get_pixel_if_not_transparent32(&srcData[1], &red, &green, &blue, &divisor);
-            if (y > 0)
-              get_pixel_if_not_transparent32((unsigned int*)&scanline_before[(x + tile->x) << 2], &red, &green, &blue, &divisor);
-            if (y < tile->height - 1)
-              get_pixel_if_not_transparent32((unsigned int*)&scanline_after[(x + tile->x) << 2], &red, &green, &blue, &divisor);
-            if (divisor > 0)
-              memPtrLong[x] = ((red / divisor) << 16) | ((green / divisor) << 8) | (blue / divisor);
-            else
-              memPtrLong[x] = 0;
-          }
-          lastPixelWasTransparent = true;
-        }
-        else if (hasAlpha)
-        {
-          memPtrLong[x] = D3DCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData), algeta32(*srcData));
-        }
-        else
-        {
-          memPtrLong[x] = D3DCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData), 0xff);
-          if (lastPixelWasTransparent)
-          {
-            // update the colour of the previous tranparent pixel, to
-            // stop black outlines when linear filtering
-            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
-            lastPixelWasTransparent = false;
-          }
-        }
-      }
-    }
-
-    memPtr += tileWidth * 4;
   }
 
   glBindTexture(GL_TEXTURE_2D, tile->texture);
@@ -1568,36 +1435,23 @@ void OGLGraphicsDriver::UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, O
 void OGLGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha)
 {
   OGLBitmap *target = (OGLBitmap*)bitmapToUpdate;
-  if ((target->_width == bitmap->GetWidth()) &&
-     (target->_height == bitmap->GetHeight()))
+  if (target->_width != bitmap->GetWidth() || target->_height != bitmap->GetHeight())
+    throw Ali3DException("UpdateDDBFromBitmap: mismatched bitmap size");
+  if (bitmap->GetColorDepth() != target->_colDepth)
+    throw Ali3DException("UpdateDDBFromBitmap: mismatched colour depths");
+
+  target->_hasAlpha = hasAlpha;
+  for (int i = 0; i < target->_numTiles; i++)
   {
-    if (bitmap->GetColorDepth() != target->_colDepth)
-    {
-      throw Ali3DException("Mismatched colour depths");
-    }
-
-    target->_hasAlpha = hasAlpha;
-
-    for (int i = 0; i < target->_numTiles; i++)
-    {
-      UpdateTextureRegion(&target->_tiles[i], bitmap, target, hasAlpha);
-    }
+    UpdateTextureRegion(&target->_tiles[i], bitmap, target, hasAlpha);
   }
 }
 
-Bitmap *OGLGraphicsDriver::ConvertBitmapToSupportedColourDepth(Bitmap *bitmap)
+int OGLGraphicsDriver::GetCompatibleBitmapFormat(int color_depth)
 {
-   int colourDepth = bitmap->GetColorDepth();
-   if (colourDepth != 32)
-   {
-     int old_conv = get_color_conversion();
-     set_color_conversion(COLORCONV_KEEP_TRANS | COLORCONV_TOTAL);
-     // we need 32-bit colour
-     Bitmap *tempBmp = BitmapHelper::CreateBitmapCopy(bitmap, 32);
-     set_color_conversion(old_conv);
-     return tempBmp;
-   }
-   return bitmap;
+  if (color_depth > 8 && color_depth <= 16)
+    return 16;
+  return 32;
 }
 
 void OGLGraphicsDriver::AdjustSizeToNearestSupportedByCard(int *width, int *height)
@@ -1634,7 +1488,8 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   int allocatedWidth = bitmap->GetWidth();
   int allocatedHeight = bitmap->GetHeight();
   // NOTE: original bitmap object is not modified in this function
-  Bitmap *tempBmp = ConvertBitmapToSupportedColourDepth(bitmap);
+  Bitmap *old_bitmap = bitmap;
+  Bitmap *tempBmp = GfxUtil::ConvertBitmap(bitmap, GetCompatibleBitmapFormat(bitmap->GetColorDepth()));
   bitmap = tempBmp;
   int colourDepth = bitmap->GetColorDepth();
 
@@ -1668,8 +1523,8 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   AdjustSizeToNearestSupportedByCard(&tileAllocatedWidth, &tileAllocatedHeight);
 
   int numTiles = tilesAcross * tilesDown;
-  TextureTile *tiles = (TextureTile*)malloc(sizeof(TextureTile) * numTiles);
-  memset(tiles, 0, sizeof(TextureTile) * numTiles);
+  OGLTextureTile *tiles = (OGLTextureTile*)malloc(sizeof(OGLTextureTile) * numTiles);
+  memset(tiles, 0, sizeof(OGLTextureTile) * numTiles);
 
   OGLCUSTOMVERTEX *vertices = NULL;
 
@@ -1692,7 +1547,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   {
     for (int y = 0; y < tilesDown; y++)
     {
-      TextureTile *thisTile = &tiles[y * tilesAcross + x];
+      OGLTextureTile *thisTile = &tiles[y * tilesAcross + x];
       int thisAllocatedWidth = tileAllocatedWidth;
       int thisAllocatedHeight = tileAllocatedHeight;
       thisTile->x = x * tileWidth;
@@ -1735,6 +1590,8 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+      // NOTE: pay attention that the texture format depends on the **display mode**'s format,
+      // rather than source bitmap's color depth!
       glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, thisAllocatedWidth, thisAllocatedHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
     }
   }
@@ -1744,7 +1601,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
 
   UpdateDDBFromBitmap(ddb, bitmap, hasAlpha);
 
-  if (tempBmp != bitmap)
+  if (old_bitmap != tempBmp)
     delete tempBmp;
 
   return ddb;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -55,14 +55,12 @@ struct OGLCUSTOMVERTEX
     float tv;
 };
 
-struct TextureTile
+struct OGLTextureTile : public TextureTile
 {
-    int x, y;
-    int width, height;
     unsigned int texture;
 };
 
-class OGLBitmap : public IDriverDependantBitmap
+class OGLBitmap : public VideoMemDDB
 {
 public:
     // Transparency is a bit counter-intuitive
@@ -75,9 +73,6 @@ public:
         _stretchToHeight = height;
         _useResampler = useResampler;
     }
-    virtual int GetWidth() { return _width; }
-    virtual int GetHeight() { return _height; }
-    virtual int GetColorDepth() { return _colDepth; }
     virtual void SetLightLevel(int lightLevel)  { _lightLevel = lightLevel; }
     virtual void SetTint(int red, int green, int blue, int tintSaturation) 
     {
@@ -87,19 +82,16 @@ public:
         _tintSaturation = tintSaturation;
     }
 
-    int _width, _height;
-    int _colDepth;
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
     bool _useResampler;
     int _red, _green, _blue;
     int _tintSaturation;
     int _lightLevel;
-    bool _opaque;
     bool _hasAlpha;
     int _transparency;
     OGLCUSTOMVERTEX* _vertex;
-    TextureTile *_tiles;
+    OGLTextureTile *_tiles;
     int _numTiles;
 
     OGLBitmap(int width, int height, int colDepth, bool opaque)
@@ -179,7 +171,7 @@ public:
     virtual PGfxFilter GetGraphicsFilter() const;
     virtual void UnInit();
     virtual void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse);
-    virtual Bitmap *ConvertBitmapToSupportedColourDepth(Bitmap *bitmap);
+    virtual int  GetCompatibleBitmapFormat(int color_depth);
     virtual IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque);
     virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha);
     virtual void DestroyDDB(IDriverDependantBitmap* bitmap);
@@ -313,7 +305,7 @@ private:
     // Unset parameters and release resources related to the display mode
     void ReleaseDisplayMode();
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
-    void UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha);
+    void UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha);
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void create_screen_tint_bitmap();

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -347,9 +347,9 @@ void ALSoftwareGraphicsDriver::SetGamma(int newGamma)
 #endif
 }
 
-Bitmap *ALSoftwareGraphicsDriver::ConvertBitmapToSupportedColourDepth(Bitmap *bitmap)
+int ALSoftwareGraphicsDriver::GetCompatibleBitmapFormat(int color_depth)
 {
-  return bitmap;
+  return color_depth;
 }
 
 IDriverDependantBitmap* ALSoftwareGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque)

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -138,7 +138,7 @@ public:
     virtual PGfxFilter GetGraphicsFilter() const;
     virtual void UnInit();
     virtual void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse);
-    virtual Bitmap *ConvertBitmapToSupportedColourDepth(Bitmap *bitmap);
+    virtual int  GetCompatibleBitmapFormat(int color_depth);
     virtual IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque);
     virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha);
     virtual void DestroyDDB(IDriverDependantBitmap* bitmap);

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -30,6 +30,22 @@ using namespace Common;
 namespace GfxUtil
 {
 
+Bitmap *ConvertBitmap(Bitmap *src, int dst_color_depth)
+{
+    int src_col_depth = src->GetColorDepth();
+    if (src_col_depth != dst_color_depth)
+    {
+        int old_conv = get_color_conversion();
+        // TODO: find out what is this, and why do we need to call this every time (do we?)
+        set_color_conversion(COLORCONV_KEEP_TRANS | COLORCONV_TOTAL);
+        Bitmap *dst = BitmapHelper::CreateBitmapCopy(src, dst_color_depth);
+        set_color_conversion(old_conv);
+        return dst;
+    }
+    return src;
+}
+
+
 typedef BLENDER_FUNC PfnBlenderCb;
 
 struct BlendModeSetter

--- a/Engine/gfx/gfx_util.h
+++ b/Engine/gfx/gfx_util.h
@@ -36,6 +36,9 @@ using Common::Bitmap;
 
 namespace GfxUtil
 {
+    // Creates a COPY of the source bitmap, converted to the given format.
+    Bitmap *ConvertBitmap(Bitmap *src, int dst_color_depth);
+
     // Considers the given information about source and destination surfaces,
     // then draws a bimtap over another either using requested blending mode,
     // or fallbacks to common "magic pink" transparency mode;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -121,14 +121,6 @@ void GraphicsDriverBase::OnSetFilter()
     _filterRect = GetGraphicsFilter()->SetTranslation(Size(_srcRect.GetSize()), _dstRect);
 }
 
-Bitmap *GraphicsDriverBase::ReplaceBitmapWithSupportedFormat(Bitmap *old_bmp)
-{
-    Bitmap *new_bitmap = GfxUtil::ConvertBitmap(old_bmp, GetCompatibleBitmapFormat(old_bmp->GetColorDepth()));
-    if (new_bitmap != old_bmp)
-        delete old_bmp;
-    return new_bitmap;
-}
-
 
 VideoMemoryGraphicsDriver::VideoMemoryGraphicsDriver()
     : _stageVirtualScreen(NULL)
@@ -172,8 +164,7 @@ void VideoMemoryGraphicsDriver::CreateStageScreen()
         this->DestroyDDB(_stageVirtualScreenDDB);
     _stageVirtualScreenDDB = NULL;
     delete _stageVirtualScreen;
-    _stageVirtualScreen = ReplaceBitmapWithSupportedFormat(
-    BitmapHelper::CreateBitmap(_srcRect.GetWidth(), _srcRect.GetHeight(), _mode.ColorDepth));
+    _stageVirtualScreen = BitmapHelper::CreateBitmap(_srcRect.GetWidth(), _srcRect.GetHeight(), _mode.ColorDepth);
     BitmapHelper::SetScreenBitmap(_stageVirtualScreen);
 }
 

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -17,6 +17,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/gfxfilter.h"
 #include "gfx/gfxdriverbase.h"
+#include "gfx/gfx_util.h"
 
 using namespace AGS::Common;
 
@@ -122,7 +123,7 @@ void GraphicsDriverBase::OnSetFilter()
 
 Bitmap *GraphicsDriverBase::ReplaceBitmapWithSupportedFormat(Bitmap *old_bmp)
 {
-    Bitmap *new_bitmap = ConvertBitmapToSupportedColourDepth(old_bmp);
+    Bitmap *new_bitmap = GfxUtil::ConvertBitmap(old_bmp, GetCompatibleBitmapFormat(old_bmp->GetColorDepth()));
     if (new_bitmap != old_bmp)
         delete old_bmp;
     return new_bitmap;
@@ -199,6 +200,156 @@ bool VideoMemoryGraphicsDriver::DoNullSpriteCallback(int x, int y)
         return true;
     }
     return false;
+}
+
+#define algetr32(xx) getr32(xx)
+#define algetg32(xx) getg32(xx)
+#define algetb32(xx) getb32(xx)
+#define algeta32(xx) geta32(xx)
+
+#define algetr16(xx) getr16(xx)
+#define algetg16(xx) getg16(xx)
+#define algetb16(xx) getb16(xx)
+
+
+__inline void get_pixel_if_not_transparent16(unsigned short *pixel, unsigned short *red, unsigned short *green, unsigned short *blue, unsigned short *divisor)
+{
+  if (pixel[0] != MASK_COLOR_16)
+  {
+    *red += algetr16(pixel[0]);
+    *green += algetg16(pixel[0]);
+    *blue += algetb16(pixel[0]);
+    divisor[0]++;
+  }
+}
+
+__inline void get_pixel_if_not_transparent32(unsigned int *pixel, unsigned int *red, unsigned int *green, unsigned int *blue, unsigned int *divisor)
+{
+  if (pixel[0] != MASK_COLOR_32)
+  {
+    *red += algetr32(pixel[0]);
+    *green += algetg32(pixel[0]);
+    *blue += algetb32(pixel[0]);
+    divisor[0]++;
+  }
+}
+
+// OPENGL:
+/*
+#define D3DCOLOR_RGBA(r,g,b,a) \
+  (((((a)&0xff)<<24)|(((b)&0xff)<<16)|(((g)&0xff)<<8)|((r)&0xff)))
+*/
+// D3D9:
+#define D3DCOLOR_ARGB(a,r,g,b) \
+    (((((a)&0xff)<<24)|(((r)&0xff)<<16)|(((g)&0xff)<<8)|((b)&0xff)))
+#define D3DCOLOR_RGBA(r,g,b,a) D3DCOLOR_ARGB(a,r,g,b)
+
+
+void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile, const VideoMemDDB *target,
+                                                 char *dst_ptr, const int dst_pitch, const bool usingLinearFiltering)
+{
+  bool lastPixelWasTransparent = false;
+  for (int y = 0; y < tile->height; y++)
+  {
+    lastPixelWasTransparent = false;
+    const uint8_t *scanline_before = bitmap->GetScanLine(y + tile->y - 1);
+    const uint8_t *scanline_at     = bitmap->GetScanLine(y + tile->y);
+    const uint8_t *scanline_after  = bitmap->GetScanLine(y + tile->y + 1);
+    unsigned int* memPtrLong = (unsigned int*)dst_ptr;
+
+    for (int x = 0; x < tile->width; x++)
+    {
+      if (bitmap->GetColorDepth() == 16)
+      {
+        unsigned short* srcData = (unsigned short*)&scanline_at[(x + tile->x) * sizeof(short)];
+        if (*srcData == MASK_COLOR_16) 
+        {
+          if (target->_opaque)  // set to black if opaque
+            memPtrLong[x] = 0xFF000000;
+          else if (!usingLinearFiltering)
+            memPtrLong[x] = 0;
+          // set to transparent, but use the colour from the neighbouring 
+          // pixel to stop the linear filter doing black outlines
+          else
+          {
+            unsigned short red = 0, green = 0, blue = 0, divisor = 0;
+            if (x > 0)
+              get_pixel_if_not_transparent16(&srcData[-1], &red, &green, &blue, &divisor);
+            if (x < tile->width - 1)
+              get_pixel_if_not_transparent16(&srcData[1], &red, &green, &blue, &divisor);
+            if (y > 0)
+              get_pixel_if_not_transparent16((unsigned short*)&scanline_before[(x + tile->x) * sizeof(short)], &red, &green, &blue, &divisor);
+            if (y < tile->height - 1)
+              get_pixel_if_not_transparent16((unsigned short*)&scanline_after[(x + tile->x) * sizeof(short)], &red, &green, &blue, &divisor);
+            if (divisor > 0)
+              memPtrLong[x] = D3DCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
+            else
+              memPtrLong[x] = 0;
+          }
+          lastPixelWasTransparent = true;
+        }
+        else
+        {
+          memPtrLong[x] = D3DCOLOR_RGBA(algetr16(*srcData), algetg16(*srcData), algetb16(*srcData), 0xff);
+          if (lastPixelWasTransparent)
+          {
+            // update the colour of the previous tranparent pixel, to
+            // stop black outlines when linear filtering
+            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
+            lastPixelWasTransparent = false;
+          }
+        }
+      }
+      else if (bitmap->GetColorDepth() == 32)
+      {
+        unsigned int* memPtrLong = (unsigned int*)dst_ptr;
+        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
+        if (*srcData == MASK_COLOR_32)
+        {
+          if (target->_opaque)  // set to black if opaque
+            memPtrLong[x] = 0xFF000000;
+          else if (!usingLinearFiltering)
+            memPtrLong[x] = 0;
+          // set to transparent, but use the colour from the neighbouring 
+          // pixel to stop the linear filter doing black outlines
+          else
+          {
+            unsigned int red = 0, green = 0, blue = 0, divisor = 0;
+            if (x > 0)
+              get_pixel_if_not_transparent32(&srcData[-1], &red, &green, &blue, &divisor);
+            if (x < tile->width - 1)
+              get_pixel_if_not_transparent32(&srcData[1], &red, &green, &blue, &divisor);
+            if (y > 0)
+              get_pixel_if_not_transparent32((unsigned int*)&scanline_before[(x + tile->x) * sizeof(int)], &red, &green, &blue, &divisor);
+            if (y < tile->height - 1)
+              get_pixel_if_not_transparent32((unsigned int*)&scanline_after[(x + tile->x) * sizeof(int)], &red, &green, &blue, &divisor);
+            if (divisor > 0)
+              memPtrLong[x] = D3DCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
+            else
+              memPtrLong[x] = 0;
+          }
+          lastPixelWasTransparent = true;
+        }
+        else if (has_alpha)
+        {
+          memPtrLong[x] = D3DCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData), algeta32(*srcData));
+        }
+        else
+        {
+          memPtrLong[x] = D3DCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData), 0xff);
+          if (lastPixelWasTransparent)
+          {
+            // update the colour of the previous tranparent pixel, to
+            // stop black outlines when linear filtering
+            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
+            lastPixelWasTransparent = false;
+          }
+        }
+      }
+    }
+
+    dst_ptr += dst_pitch;
+  }
 }
 
 } // namespace Engine

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_GFX__GFXDRIVERBASE_H
 #define __AGS_EE_GFX__GFXDRIVERBASE_H
 
+#include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
 #include "util/scaling.h"
 
@@ -115,6 +116,28 @@ protected:
 };
 
 
+
+// Generic TextureTile base
+struct TextureTile
+{
+    int x, y;
+    int width, height;
+};
+
+// Parent class for the video memory DDBs
+class VideoMemDDB : public IDriverDependantBitmap
+{
+public:
+    virtual int GetWidth() { return _width; }
+    virtual int GetHeight() { return _height; }
+    virtual int GetColorDepth() { return _colDepth; }
+
+    int _width, _height;
+    int _colDepth;
+    bool _opaque;
+};
+
+
 // VideoMemoryGraphicsDriver - is the parent class for the graphic drivers
 // which drawing method is based on passing the sprite stack into GPU,
 // rather than blitting to flat screen bitmap.
@@ -135,6 +158,10 @@ protected:
     // returns true if the sprite was provided onto the virtual screen,
     // and false if this entry should be skipped.
     bool DoNullSpriteCallback(int x, int y);
+
+    // Prepares bitmap to be applied to the texture, copies pixels to the provided buffer
+    void BitmapToVideoMem(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile, const VideoMemDDB *target,
+                            char *dst_ptr, const int dst_pitch, const bool usingLinearFiltering);
 
     // Stage virtual screen is used to let plugins draw custom graphics
     // in between render stages (between room and GUI, after GUI, and so on)

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -168,6 +168,12 @@ protected:
     Bitmap *_stageVirtualScreen;
     IDriverDependantBitmap *_stageVirtualScreenDDB;
 
+    // Color component shifts in video bitmap format (set by implementations)
+    int _vmem_a_shift_32;
+    int _vmem_r_shift_32;
+    int _vmem_g_shift_32;
+    int _vmem_b_shift_32;
+
 private:
     // Flag which indicates whether stage screen was drawn upon during engine
     // callback and has to be inserted into sprite stack.

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -94,9 +94,6 @@ protected:
     virtual void OnSetFilter();
 
     void    OnScalingChanged();
-    // Checks if the bitmap needs to be converted and **deletes original** if a new bitmap
-    // had to be created
-    Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *old_bmp);
 
     DisplayMode         _mode;          // display mode settings
     Rect                _srcRect;       // rendering source rect

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -93,7 +93,9 @@ public:
   // process.
   virtual void SetCallbackForNullSprite(GFXDRV_CLIENTCALLBACKXY callback) = 0;
   virtual void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) = 0;
-  virtual Common::Bitmap *ConvertBitmapToSupportedColourDepth(Common::Bitmap *bitmap) = 0;
+  // Gets closest recommended bitmap format (currently - only color depth) for the given original format.
+  // Engine needs to have game bitmaps brought to the certain range of formats, easing conversion into the video bitmaps.
+  virtual int  GetCompatibleBitmapFormat(int color_depth) = 0;
   virtual IDriverDependantBitmap* CreateDDBFromBitmap(Common::Bitmap *bitmap, bool hasAlpha, bool opaque = false) = 0;
   virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Common::Bitmap *bitmap, bool hasAlpha) = 0;
   virtual void DestroyDDB(IDriverDependantBitmap* bitmap) = 0;

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -60,7 +60,7 @@ bool GUIMain::HasAlphaChannel() const
         return false;
     }
     // transparent background, enable alpha blending
-    return System_GetColorDepth() >= 24 &&
+    return game.GetColorDepth() >= 24 &&
         // transparent background have alpha channel only since 3.2.0;
         // "classic" gui rendering mode historically had non-alpha transparent backgrounds
         // (3.2.0 broke the compatibility, now we restore it)

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -464,8 +464,6 @@ void apply_config(const ConfigTree &cfg)
         usetup.Supersampling = INIreadint(cfg, "graphics", "supersampling", 1);
 
         usetup.enable_antialiasing = INIreadint(cfg, "misc", "antialias") > 0;
-        if (!usetup.force_hicolor_mode)
-            usetup.force_hicolor_mode = INIreadint(cfg, "misc", "notruecolor") > 0;
 
         // This option is backwards (usevox is 0 if no_speech_pack)
         usetup.no_speech_pack = INIreadint(cfg, "sound", "usespeech", 1) == 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1526,7 +1526,7 @@ bool engine_try_set_gfxmode_any(const ScreenSetup &setup)
     engine_shutdown_gfxmode();
 
     const Size init_desktop = get_desktop_size();
-    if (!graphics_mode_init_any(game.size, setup, engine_get_color_depth()))
+    if (!graphics_mode_init_any(game.size, setup, ColorDepthOption(game.GetColorDepth())))
         return false;
 
     engine_post_gfxmode_setup(init_desktop);

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -49,7 +49,6 @@ extern Bitmap *_old_screen;
 extern Bitmap *_sub_screen;
 extern Bitmap *virtual_screen;
 
-int debug_15bit_mode = 0, debug_24bit_mode = 0;
 int convert_16bit_bgr = 0;
 
 int ff; // whatever!
@@ -164,27 +163,11 @@ void engine_init_resolution_settings(const Size game_size)
         play.native_size.Height *= 2;
     }
 
-    // don't allow them to force a 256-col game to hi-color
-    if (game.color_depth < 2)
-        usetup.force_hicolor_mode = false;
-
     Debug::Printf(kDbgMsg_Init, "Game native resolution: %d x %d (%d bit)%s", game_size.Width, game_size.Height, game.color_depth * 8,
         game.options[OPT_LETTERBOX] == 0 ? "": " letterbox-by-design");
 
     adjust_sizes_for_resolution(loaded_game_file_version);
     engine_setup_system_gamesize();
-}
-
-ColorDepthOption engine_get_color_depth()
-{
-    if (debug_15bit_mode)
-        return ColorDepthOption(15, true);
-    else if (debug_24bit_mode)
-        return ColorDepthOption(24, true);
-    else if (usetup.force_hicolor_mode)
-        return ColorDepthOption(16, true);
-    else
-        return ColorDepthOption(game.color_depth * 8);
 }
 
 // Setup gfx driver callbacks and options

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -362,7 +362,7 @@ void engine_post_gfxmode_draw_setup(const DisplayMode &dm)
     if (gfxDriver->HasAcceleratedStretchAndFlip()) 
     {
         walkBehindMethod = DrawAsSeparateSprite;
-        CreateBlankImage(dm.ColorDepth);
+        CreateBlankImage(game.GetColorDepth());
     }
     else
     {

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -320,7 +320,7 @@ void engine_setup_color_conversions(int coldepth)
 #endif
     }
 
-    set_color_conversion(COLORCONV_MOST | COLORCONV_EXPAND_256 | COLORCONV_REDUCE_16_TO_15);
+    set_color_conversion(COLORCONV_MOST | COLORCONV_EXPAND_256);
 }
 
 // Create blank (black) images used to repaint borders around game frame

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -72,7 +72,6 @@ extern GameState play;
 extern int our_eip;
 extern AGSPlatformDriver *platform;
 extern int debug_flags;
-extern int debug_15bit_mode, debug_24bit_mode;
 extern int convert_16bit_bgr;
 extern int display_fps;
 extern int editor_debugging_enabled;
@@ -228,8 +227,6 @@ int main_process_cmdline(int argc,char*argv[])
             force_window = 1;
         else if (stricmp(argv[ee],"-fullscreen") == 0 || stricmp(argv[ee],"--fullscreen") == 0)
             force_window = 2;
-        else if (stricmp(argv[ee],"-hicolor") == 0 || stricmp(argv[ee],"--hicolor") == 0)
-            usetup.force_hicolor_mode = true;
         else if (stricmp(argv[ee],"-record") == 0)
             play.recording = 1;
         else if (stricmp(argv[ee],"-playback") == 0)
@@ -260,8 +257,6 @@ int main_process_cmdline(int argc,char*argv[])
             strcpy(return_to_room, argv[ee+2]);
             ee+=2;
         }
-        else if (stricmp(argv[ee],"--15bit")==0) debug_15bit_mode = 1;
-        else if (stricmp(argv[ee],"--24bit")==0) debug_24bit_mode = 1;
         else if (stricmp(argv[ee],"--fps")==0) display_fps = 2;
         else if (stricmp(argv[ee],"--test")==0) debug_flags|=DBG_DEBUGMODE;
         else if (stricmp(argv[ee],"-noiface")==0) debug_flags|=DBG_NOIFACE;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -147,7 +147,7 @@ void play_flc_file(int numb,int playflags) {
     delete in;
 
     if (game.color_depth > 1) {
-        hicol_buf=BitmapHelper::CreateBitmap(fliwidth,fliheight,System_GetColorDepth());
+        hicol_buf=BitmapHelper::CreateBitmap(fliwidth,fliheight,game.GetColorDepth());
         hicol_buf->Clear();
     }
     // override the stretch option if necessary
@@ -167,7 +167,7 @@ void play_flc_file(int numb,int playflags) {
     }
 
     video_type = kVideoFlic;
-    fli_target = BitmapHelper::CreateBitmap(screen_bmp->GetWidth(), screen_bmp->GetHeight(), System_GetColorDepth());
+    fli_target = BitmapHelper::CreateBitmap(screen_bmp->GetWidth(), screen_bmp->GetHeight(), game.GetColorDepth());
     fli_ddb = gfxDriver->CreateDDBFromBitmap(fli_target, false, true);
 
     // TODO: find a better solution.
@@ -405,7 +405,7 @@ void play_theora_video(const char *name, int skip, int flags)
 
     if ((stretch_flc) && (!gfxDriver->HasAcceleratedStretchAndFlip()))
     {
-        fli_target = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), play.viewport.GetHeight(), System_GetColorDepth());
+        fli_target = BitmapHelper::CreateBitmap(play.viewport.GetWidth(), play.viewport.GetHeight(), game.GetColorDepth());
         fli_target->Clear();
         fli_ddb = gfxDriver->CreateDDBFromBitmap(fli_target, false, true);
     }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1417,6 +1417,8 @@ void D3DGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpda
 
 int D3DGraphicsDriver::GetCompatibleBitmapFormat(int color_depth)
 {
+  if (color_depth == 8)
+    return 8;
   if (color_depth > 8 && color_depth <= 16)
     return 16;
   return 32;
@@ -1480,10 +1482,8 @@ IDriverDependantBitmap* D3DGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
 {
   int allocatedWidth = bitmap->GetWidth();
   int allocatedHeight = bitmap->GetHeight();
-  // NOTE: original bitmap object is not modified in this function
-  Bitmap *old_bitmap = bitmap;
-  Bitmap *tempBmp = GfxUtil::ConvertBitmap(bitmap, GetCompatibleBitmapFormat(bitmap->GetColorDepth()));
-  bitmap = tempBmp;
+  if (bitmap->GetColorDepth() != GetCompatibleBitmapFormat(bitmap->GetColorDepth()))
+    throw Ali3DException("CreateDDBFromBitmap: bitmap colour depth not supported");
   int colourDepth = bitmap->GetColorDepth();
 
   D3DBitmap *ddb = new D3DBitmap(bitmap->GetWidth(), bitmap->GetHeight(), colourDepth, opaque);
@@ -1608,9 +1608,6 @@ IDriverDependantBitmap* D3DGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   ddb->_tiles = tiles;
 
   UpdateDDBFromBitmap(ddb, bitmap, hasAlpha);
-
-  if (old_bitmap != tempBmp)
-    delete tempBmp;
 
   return ddb;
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -197,6 +197,12 @@ D3DGraphicsDriver::D3DGraphicsDriver(IDirect3D9 *d3d)
   _pixelRenderYOffset = 0;
   _renderSprAtScreenRes = false;
   flipTypeLastTime = kFlip_None;
+
+  // Shifts comply to D3DFMT_A8R8G8B8
+  _vmem_a_shift_32 = 24;
+  _vmem_r_shift_32 = 16;
+  _vmem_g_shift_32 = 8;
+  _vmem_b_shift_32 = 0;
 }
 
 void D3DGraphicsDriver::set_up_default_vertices()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1743,7 +1743,6 @@ void D3DGraphicsDriver::create_screen_tint_bitmap()
     return;
 
   _screenTintLayer = BitmapHelper::CreateBitmap(16, 16, this->_mode.ColorDepth);
-  _screenTintLayer = ReplaceBitmapWithSupportedFormat(_screenTintLayer);
   _screenTintLayerDDB = (D3DBitmap*)this->CreateDDBFromBitmap(_screenTintLayer, false, false);
   _screenTintSprite.bitmap = _screenTintLayerDDB;
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -46,14 +46,12 @@ using AGS::Common::Bitmap;
 using AGS::Common::String;
 class D3DGfxFilter;
 
-struct TextureTile
+struct D3DTextureTile : public TextureTile
 {
-    int x, y;
-    int width, height;
     IDirect3DTexture9* texture;
 };
 
-class D3DBitmap : public IDriverDependantBitmap
+class D3DBitmap : public VideoMemDDB
 {
 public:
     // Transparency is a bit counter-intuitive
@@ -66,9 +64,6 @@ public:
         _stretchToHeight = height;
         _useResampler = useResampler;
     }
-    virtual int GetWidth() { return _width; }
-    virtual int GetHeight() { return _height; }
-    virtual int GetColorDepth() { return _colDepth; }
     virtual void SetLightLevel(int lightLevel)  { _lightLevel = lightLevel; }
     virtual void SetTint(int red, int green, int blue, int tintSaturation) 
     {
@@ -78,19 +73,16 @@ public:
         _tintSaturation = tintSaturation;
     }
 
-    int _width, _height;
-    int _colDepth;
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
     bool _useResampler;
     int _red, _green, _blue;
     int _tintSaturation;
     int _lightLevel;
-    bool _opaque;
     bool _hasAlpha;
     int _transparency;
     IDirect3DVertexBuffer9* _vertex;
-    TextureTile *_tiles;
+    D3DTextureTile *_tiles;
     int _numTiles;
 
     D3DBitmap(int width, int height, int colDepth, bool opaque)
@@ -176,7 +168,7 @@ public:
     virtual PGfxFilter GetGraphicsFilter() const;
     virtual void UnInit();
     virtual void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse);
-    virtual Bitmap *ConvertBitmapToSupportedColourDepth(Bitmap *bitmap);
+    virtual int  GetCompatibleBitmapFormat(int color_depth);
     virtual IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque);
     virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha);
     virtual void DestroyDDB(IDriverDependantBitmap* bitmap);
@@ -254,7 +246,7 @@ private:
     void set_up_default_vertices();
     void make_translated_scaling_matrix(D3DMATRIX *matrix, float x, float y, float xScale, float yScale);
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
-    void UpdateTextureRegion(TextureTile *tile, Bitmap *bitmap, D3DBitmap *target, bool hasAlpha);
+    void UpdateTextureRegion(D3DTextureTile *tile, Bitmap *bitmap, D3DBitmap *target, bool hasAlpha);
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     bool IsTextureFormatOk( D3DFORMAT TextureFormat, D3DFORMAT AdapterFormat );

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -91,7 +91,6 @@ struct WinConfig
     bool   Windowed;
     bool   VSync;
     bool   RenderAtScreenRes;
-    bool   Reduce32to16;
     bool   AntialiasSprites;
 
     int    DigiWinIdx;
@@ -133,7 +132,6 @@ void WinConfig::SetDefaults()
     VSync = false;
     RenderAtScreenRes = false;
     AntialiasSprites = false;
-    Reduce32to16 = false;
 
     MouseAutoLock = false;
     MouseSpeed = 1.f;
@@ -174,7 +172,6 @@ void WinConfig::Load(const ConfigTree &cfg)
     VSync = INIreadint(cfg, "graphics", "vsync", VSync ? 1 : 0) != 0;
     RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
 
-    Reduce32to16 = INIreadint(cfg, "misc","notruecolor", Reduce32to16 ? 1 : 0) != 0;
     AntialiasSprites = INIreadint(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0) != 0;
 
     DigiWinIdx = INIreadint(cfg, "sound", "digiwinindx", DigiWinIdx);
@@ -209,7 +206,6 @@ void WinConfig::Save(ConfigTree &cfg)
     INIwriteint(cfg, "graphics", "vsync", VSync ? 1 : 0);
     INIwriteint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0);
 
-    INIwriteint(cfg, "misc", "notruecolor", Reduce32to16 ? 1 : 0);
     INIwriteint(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0);
 
     INIwriteint(cfg, "sound", "digiwinindx", DigiWinIdx);
@@ -517,7 +513,6 @@ private:
     HWND _hRenderAtScreenRes;
     HWND _hRefresh85Hz;
     HWND _hAntialiasSprites;
-    HWND _hReduce32to16;
     HWND _hUseVoicePack;
     HWND _hAdvanced;
     HWND _hGameResolutionText;
@@ -580,7 +575,6 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
     _hRenderAtScreenRes     = GetDlgItem(_hwnd, IDC_RENDERATSCREENRES);
     _hRefresh85Hz           = GetDlgItem(_hwnd, IDC_REFRESH_85HZ);
     _hAntialiasSprites      = GetDlgItem(_hwnd, IDC_ANTIALIAS);
-    _hReduce32to16          = GetDlgItem(_hwnd, IDC_REDUCE32TO16);
     _hUseVoicePack          = GetDlgItem(_hwnd, IDC_VOICEPACK);
     _hAdvanced              = GetDlgItem(_hwnd, IDC_ADVANCED);
     _hGameResolutionText    = GetDlgItem(_hwnd, IDC_RESOLUTION);
@@ -696,11 +690,6 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
     SetCheck(_hAntialiasSprites, _winCfg.AntialiasSprites);
     SetCheck(_hUseVoicePack, _winCfg.UseVoicePack);
 
-    if (_winCfg.GameColourDepth < 32)
-        EnableWindow(_hReduce32to16, FALSE);
-    else
-        SetCheck(_hReduce32to16, _winCfg.Reduce32to16);
-
     if (!File::TestReadFile("speech.vox"))
         EnableWindow(_hUseVoicePack, FALSE);
     else
@@ -708,8 +697,6 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
 
     if (INIreadint(_cfgIn, "disabled", "speechvox", 0) != 0)
         EnableWindow(_hUseVoicePack, FALSE);
-    if (INIreadint(_cfgIn, "disabled", "16bit", 0) != 0)
-        EnableWindow(_hReduce32to16, FALSE);
     if (INIreadint(_cfgIn, "disabled", "filters", 0) != 0)
         EnableWindow(_hGfxFilterList, FALSE);
 
@@ -1184,7 +1171,6 @@ void WinSetupDialog::SaveSetup()
     _winCfg.RenderAtScreenRes = GetCheck(_hRenderAtScreenRes);
     _winCfg.AntialiasSprites = GetCheck(_hAntialiasSprites);
     _winCfg.RefreshRate = GetCheck(_hRefresh85Hz) ? 85 : 0;
-    _winCfg.Reduce32to16 = GetCheck(_hReduce32to16);
     _winCfg.GfxFilterId = (LPCTSTR)GetCurItemData(_hGfxFilterList);
 
     _winCfg.MouseAutoLock = GetCheck(_hMouseLock);

--- a/Engine/resource/version.rc
+++ b/Engine/resource/version.rc
@@ -142,13 +142,10 @@ BEGIN
     GROUPBOX        "Graphics options",IDC_STATIC,264,7,247,81
     CONTROL         "Vertical sync",IDC_VSYNC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,20,135,9
     CONTROL         "Use 85 Hz display (CRT monitors only)",IDC_REFRESH_85HZ,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,34,138,8
-    CONTROL         "Smooth scaled sprites (fast CPUs only)",IDC_ANTIALIAS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,47,138,8
-    CONTROL         "Downgrade 32-bit graphics to 16-bit",IDC_REDUCE32TO16,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,59,135,9
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,33,138,9
+    CONTROL         "Smooth scaled sprites",IDC_ANTIALIAS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,271,46,138,9
     CONTROL         "Render sprites at screen resolution",IDC_RENDERATSCREENRES,
-                    "Button",BS_AUTOCHECKBOX | BS_LEFT | BS_VCENTER | WS_TABSTOP,271,72,172,9
+                    "Button",BS_AUTOCHECKBOX | BS_LEFT | BS_VCENTER | WS_TABSTOP,271,59,172,9
     GROUPBOX        "Sound options",IDC_STATIC,264,91,247,64
     LTEXT           "Digital Sound:",IDC_STATIC,271,106,46,9
     COMBOBOX        IDC_DIGISOUND,320,104,176,70,CBS_DROPDOWNLIST | WS_GROUP | WS_TABSTOP


### PR DESCRIPTION
Before 3.4.1 AGS had certain issues when running 16-bit games in Direct3D and OpenGL renderers (loss of color hue precision, and something else), and also sometimes software renderer had trouble running in 16-bit display mode on latest Windows systems (where it uses DirectDraw 5 interface).

For 3.4.1 we've made a decision to force all renderers to run in 32-bit display mode always (except for 8-bit games in software mode, but these are very special case anyway), and to convert all game bitmaps to 32-bit ones on load, for simplicity (and for simplier conversion from bitmap to texture).

While the first half of this decision (32-bit display mode) is rational on its own, the second half was a lazy thinking on my part. The problem here is that if the game was developed and scripted as 16-bit, having its resources converted to 32-bit changes the way drawing operations work, although slightly, but causing occasional mistakes and differences, notably when it comes to sprite transparency and scripted raw drawing (since color range is different). Unfortunately, actual bugs were not found until after 3.4.1 was already released.

This pull request suggests different and, I hope, more logical approach to the problem. Instead of converting game resources to the bitness of display mode, it keeps them in native game's color depth (converting varying bitmaps to **game's** bitness when necessary), and hardware-accelerated renderers are taught to correctly convert three main bitmap types (8, 16 and 32 bit) to the 32-bit RGBA texture.

**NOTE 1:** This change mainly affects how 16-bit games work. But my belief is that another big benefit is in keeping native game format clearly separated from the renderer mode.

**NOTE 2:** There may be a difference in how 8-bit games will be rendered with Direct3D and OpenGL with this change. But they did not quite work before, and they still won't quite work, only visual issues may be different.

**PS.** The main problem with running 8-bit games with Direct3D and OpenGL seem to be that the engine cannot correctly tell *when to update the texture*, and large parts of the game may get rendered using uninitialized or non-matching palette (usually this results in parts of the game scene being completely black).