### PR TITLE
3.4.1: make sure that service key commands work everywhere in game

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -879,8 +879,8 @@ bool DialogOptions::Run()
         run_function_on_non_blocking_thread(&runDialogOptionRepExecFunc);
       }
 
-      if (kbhit()) {
-        int gkey = getch();
+      int gkey;
+      if (run_service_key_controls(gkey)) {
         if (parserInput) {
           wantRefresh = true;
           // type into the parser 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -287,11 +287,8 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 if (skip_setting & SKIP_MOUSECLICK)
                     break;
             }
-            if (kbhit()) {
-                // discard keypress, and don't leave extended keys over
-                int kp = getch();
-                if (kp == 0) getch();
-
+            int kp;
+            if (run_service_key_controls(kp)) {
                 // let them press ESC to skip the cutscene
                 check_skip_cutscene_keypress (kp);
                 if (play.fast_forward)

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -120,8 +120,7 @@ void script_debug(int cmdd,int dataa) {
         delete tempw;
         delete stretched;
         gfxDriver->DestroyDDB(ddb);
-        while (!kbhit()) ;
-        getch();
+        clear_input_buffer();
         invalidate_screen();
     }
     else if (cmdd==3) 
@@ -172,8 +171,7 @@ void script_debug(int cmdd,int dataa) {
 			Common::kBitmap_Transparency);
         render_to_screen(BitmapHelper::GetScreenBitmap(), 0, 0);
         delete tempw;
-        while (!kbhit()) ;
-        getch();
+        clear_input_buffer();
     }
     else if (cmdd == 99)
         ccSetOption(SCOPT_DEBUGRUN, dataa);

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -152,11 +152,8 @@ int WINAPI _export CSCIWaitMessage(Bitmap *ds, CSCIMessage * cscim)
         cscim->id = -1;
         cscim->code = 0;
         smcode = 0;
-        if (kbhit()) {
-            int keywas = getch();
-            if (keywas == 0)
-                keywas = getch() + AGS_EXT_KEY_SHIFT;
-
+        int keywas;
+        if (run_service_key_controls(keywas)) {
             if (keywas == 13) {
                 cscim->id = finddefaultcontrol(CNF_DEFAULT);
                 cscim->code = CM_COMMAND;

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -32,4 +32,8 @@ void RunGameUntilAborted();
 // Update everything game related
 void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = NULL, int extraX = 0, int extraY = 0);
 
+// Runs service key controls, returns false if service key combinations were handled
+// and no more processing required, otherwise returns true and provides current keycode and key shifts.
+bool run_service_key_controls(int &kgn);
+
 #endif // __AGS_EE_MAIN__GAMERUN_H

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -32,6 +32,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
+#include "main/game_run.h"
 #include "media/audio/audio.h"
 #include "util/stream.h"
 
@@ -64,8 +65,9 @@ int fliTargetWidth, fliTargetHeight;
 int check_if_user_input_should_cancel_video()
 {
     NEXT_ITERATION();
-    if (kbhit()) {
-        if ((getch()==27) && (canabort==1))
+    int key;
+    if (run_service_key_controls(key)) {
+        if ((key==27) && (canabort==1))
             return 1;
         if (canabort >= 2)
             return 1;  // skip on any key

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -31,6 +31,7 @@
 //#include <dsound.h>
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
+#include "main/game_run.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -41,8 +42,6 @@ using namespace AGS::Engine;
 extern void update_polled_audio_and_crossfade();
 extern void update_polled_stuff_if_runtime();
 extern int rec_mgetbutton();
-extern int rec_kbhit();
-extern int rec_getch();
 extern void NextIteration();
 extern void update_music_volume();
 extern void render_to_screen(Bitmap *toRender, int atx, int aty);
@@ -391,9 +390,8 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
     NextIteration();
     RenderToSurface(vscreen);
     //Sleep(0);
-    if (rec_kbhit()) {
-      int key = rec_getch();
-      
+    int key;
+    if (run_service_key_controls(key)) {
       if ((canskip == 1) && (key == 27))
         break;
       if (canskip >= 2)

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -30,6 +30,7 @@
 #define _D3DTYPES_H_
 #define _STRSAFE_H_INCLUDED_
 typedef float D3DVALUE, *LPD3DVALUE;
+#include "main/game_run.h"
 #include "media/video/VMR9Graph.h"
 #include "platform/base/agsplatformdriver.h"
 //#include <atlbase.h>
@@ -91,8 +92,6 @@ inline LPWSTR WINAPI AtlA2WHelper(LPWSTR lpw, LPCSTR lpa, int nChars)
 // Interface from main game
 
 extern int rec_mgetbutton();
-extern int rec_kbhit();
-extern int rec_getch();
 extern void update_polled_audio_and_crossfade();
 extern volatile char want_exit;
 extern volatile int timerloop;
@@ -150,9 +149,8 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
     NextIteration();
     filterState = graph->GetState();
 
-    if (rec_kbhit()) {
-      int key = rec_getch();
-      
+    int key;
+    if (run_service_key_controls(key)) {
       if ((canskip == 1) && (key == 27))
         break;
       if (canskip >= 2)

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -42,6 +42,7 @@
 #include "debug/debugger.h"
 #include "device/mousew32.h"
 #include "gui/guidefines.h"
+#include "main/game_run.h"
 #include "main/engine.h"
 #include "media/audio/audio.h"
 #include "media/audio/sound.h"
@@ -352,9 +353,8 @@ void IAGSEngine::PollSystem () {
     if (mbut > NONE)
         pl_run_plugin_hooks (AGSE_MOUSECLICK, mbut);
 
-    if (rec_kbhit()) {
-        int kp = rec_getch();
-        if (kp == 0) kp = rec_getch()+AGS_EXT_KEY_SHIFT;
+    int kp;
+    if (run_service_key_controls(kp)) {
         pl_run_plugin_hooks (AGSE_KEYPRESS, kp);
     }
 


### PR DESCRIPTION
Picked out a function that polls current key presses and handles service shortcuts (mouse cursor lock, display mode switch). Call this function in all places where game checks for keyboard input to make things consistent.

This fixes windowed/fullscreen switch not working during video playback and dialog options (and couple more places probably).