### PR TITLE
3.4.1: implemented scrollbars and zoom for the GUI editor

### DIFF
--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -84,9 +84,9 @@ namespace AGS.Editor
 			}
         }
 
-        public void DrawGUI(IntPtr hdc, int x, int y, GUI gui, int scaleFactor, int selectedControl)
+        public void DrawGUI(IntPtr hdc, int x, int y, GUI gui, int resolutionFactor, float scale, int selectedControl)
         {
-            _native.DrawGUI((int)hdc, x, y, gui, scaleFactor, selectedControl);
+            _native.DrawGUI((int)hdc, x, y, gui, resolutionFactor, scale, selectedControl);
         }
 
         public void DrawSprite(IntPtr hdc, int x, int y, int spriteNum)

--- a/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
@@ -28,28 +28,77 @@ namespace AGS.Editor
         /// </summary>
         private void InitializeComponent()
         {
+            this.ctrlPanel = new System.Windows.Forms.Panel();
+            this.lblZoomInfo = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.sldZoomLevel = new System.Windows.Forms.TrackBar();
             this.bgPanel = new AGS.Editor.BufferedPanel();
             this.lblDummyScrollSizer = new System.Windows.Forms.Label();
+            this.ctrlPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
             this.bgPanel.SuspendLayout();
             this.SuspendLayout();
             // 
+            // ctrlPanel
+            // 
+            this.ctrlPanel.Controls.Add(this.lblZoomInfo);
+            this.ctrlPanel.Controls.Add(this.label3);
+            this.ctrlPanel.Controls.Add(this.sldZoomLevel);
+            this.ctrlPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.ctrlPanel.Location = new System.Drawing.Point(0, 0);
+            this.ctrlPanel.Name = "ctrlPanel";
+            this.ctrlPanel.Size = new System.Drawing.Size(702, 51);
+            this.ctrlPanel.TabIndex = 0;
+            // 
+            // lblZoomInfo
+            // 
+            this.lblZoomInfo.AutoSize = true;
+            this.lblZoomInfo.Location = new System.Drawing.Point(206, 15);
+            this.lblZoomInfo.Name = "lblZoomInfo";
+            this.lblZoomInfo.Size = new System.Drawing.Size(33, 13);
+            this.lblZoomInfo.TabIndex = 2;
+            this.lblZoomInfo.Text = "100%";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(3, 15);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(37, 13);
+            this.label3.TabIndex = 0;
+            this.label3.Text = "Zoom:";
+            // 
+            // sldZoomLevel
+            // 
+            this.sldZoomLevel.LargeChange = 1;
+            this.sldZoomLevel.Location = new System.Drawing.Point(46, 6);
+            this.sldZoomLevel.Minimum = 1;
+            this.sldZoomLevel.Name = "sldZoomLevel";
+            this.sldZoomLevel.Size = new System.Drawing.Size(154, 42);
+            this.sldZoomLevel.TabIndex = 1;
+            this.sldZoomLevel.Value = 1;
+            this.sldZoomLevel.Scroll += new System.EventHandler(this.sldZoomLevel_Scroll);
+            // 
             // bgPanel
             // 
+            this.bgPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                        | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
             this.bgPanel.AutoScroll = true;
             this.bgPanel.BackColor = System.Drawing.Color.Transparent;
             this.bgPanel.Controls.Add(this.lblDummyScrollSizer);
-            this.bgPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bgPanel.Location = new System.Drawing.Point(0, 0);
+            this.bgPanel.Location = new System.Drawing.Point(0, 57);
             this.bgPanel.Name = "bgPanel";
-            this.bgPanel.Size = new System.Drawing.Size(702, 459);
+            this.bgPanel.Size = new System.Drawing.Size(702, 402);
             this.bgPanel.TabIndex = 1;
+            this.bgPanel.TabStop = true;
             this.bgPanel.MouseLeave += new System.EventHandler(this.bgPanel_MouseLeave);
-            this.bgPanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseDown);
+            this.bgPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.bgPanel_Paint);
             this.bgPanel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseMove);
             this.bgPanel.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseDoubleClick);
-            this.bgPanel.MouseEnter += new System.EventHandler(this.bgPanel_MouseEnter);
-            this.bgPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.bgPanel_Paint);
+            this.bgPanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseDown);
             this.bgPanel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseUp);
+            this.bgPanel.MouseEnter += new System.EventHandler(this.bgPanel_MouseEnter);
             // 
             // lblDummyScrollSizer
             // 
@@ -57,15 +106,19 @@ namespace AGS.Editor
             this.lblDummyScrollSizer.Location = new System.Drawing.Point(351, 223);
             this.lblDummyScrollSizer.Name = "lblDummyScrollSizer";
             this.lblDummyScrollSizer.Size = new System.Drawing.Size(0, 13);
-            this.lblDummyScrollSizer.TabIndex = 1;
+            this.lblDummyScrollSizer.TabIndex = 0;
             // 
             // GUIEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.ctrlPanel);
             this.Controls.Add(this.bgPanel);
             this.Name = "GUIEditor";
             this.Size = new System.Drawing.Size(702, 459);
+            this.ctrlPanel.ResumeLayout(false);
+            this.ctrlPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();
             this.bgPanel.ResumeLayout(false);
             this.bgPanel.PerformLayout();
             this.ResumeLayout(false);
@@ -76,5 +129,9 @@ namespace AGS.Editor
 
         private BufferedPanel bgPanel;
         private System.Windows.Forms.Label lblDummyScrollSizer;
+        private System.Windows.Forms.Panel ctrlPanel;
+        private System.Windows.Forms.Label lblZoomInfo;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.TrackBar sldZoomLevel;
     }
 }

--- a/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
@@ -29,11 +29,15 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.bgPanel = new AGS.Editor.BufferedPanel();
+            this.lblDummyScrollSizer = new System.Windows.Forms.Label();
+            this.bgPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // bgPanel
             // 
+            this.bgPanel.AutoScroll = true;
             this.bgPanel.BackColor = System.Drawing.Color.Transparent;
+            this.bgPanel.Controls.Add(this.lblDummyScrollSizer);
             this.bgPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.bgPanel.Location = new System.Drawing.Point(0, 0);
             this.bgPanel.Name = "bgPanel";
@@ -47,6 +51,14 @@ namespace AGS.Editor
             this.bgPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.bgPanel_Paint);
             this.bgPanel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.bgPanel_MouseUp);
             // 
+            // lblDummyScrollSizer
+            // 
+            this.lblDummyScrollSizer.AutoSize = true;
+            this.lblDummyScrollSizer.Location = new System.Drawing.Point(351, 223);
+            this.lblDummyScrollSizer.Name = "lblDummyScrollSizer";
+            this.lblDummyScrollSizer.Size = new System.Drawing.Size(0, 13);
+            this.lblDummyScrollSizer.TabIndex = 1;
+            // 
             // GUIEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -54,6 +66,8 @@ namespace AGS.Editor
             this.Controls.Add(this.bgPanel);
             this.Name = "GUIEditor";
             this.Size = new System.Drawing.Size(702, 459);
+            this.bgPanel.ResumeLayout(false);
+            this.bgPanel.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -61,5 +75,6 @@ namespace AGS.Editor
         #endregion
 
         private BufferedPanel bgPanel;
+        private System.Windows.Forms.Label lblDummyScrollSizer;
     }
 }

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -228,11 +228,7 @@ namespace AGS.Editor
         private void UpdateScrollableWindowSize()
         {
             bgPanel.AutoScroll = true;
-            NormalGUI ngui = _gui as NormalGUI;
-            if (ngui == null)
-                lblDummyScrollSizer.Location = new Point(1, 1);
-            else
-                lblDummyScrollSizer.Location = new Point(_state.GUISizeToWindow(ngui.Width), _state.GUISizeToWindow(ngui.Height));
+            lblDummyScrollSizer.Location = new Point(_state.GUISizeToWindow(_gui.EditorWidth), _state.GUISizeToWindow(_gui.EditorHeight));
         }
 
         private void bgPanel_Paint(object sender, PaintEventArgs e)
@@ -241,9 +237,7 @@ namespace AGS.Editor
             {
                 _state.UpdateScroll(bgPanel.AutoScrollPosition);
 
-                NormalGUI ngui = _gui as NormalGUI;
-                if (ngui != null)
-                    e.Graphics.SetClip(new Rectangle(0, 0, _state.GUISizeToWindow(ngui.Width), _state.GUISizeToWindow(ngui.Height)));
+                e.Graphics.SetClip(new Rectangle(0, 0, _state.GUISizeToWindow(_gui.EditorWidth), _state.GUISizeToWindow(_gui.EditorHeight)));
 
                 int drawOffsX = _state.GUIXToWindow(0);
                 int drawOffsY = _state.GUIYToWindow(0);

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -61,6 +61,7 @@ namespace AGS.Editor
             PreviewKeyDown += new PreviewKeyDownEventHandler(GUIEditor_PreviewKeyDown);
             MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
             bgPanel.MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
+            sldZoomLevel.MouseWheel += new MouseEventHandler(GUIEditor_MouseWheel);
             
             _drawSnapPen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
 
@@ -101,6 +102,10 @@ namespace AGS.Editor
                 }
             }
             sldZoomLevel_Scroll(null, null);
+            // Ridiculous solution, found on stackoverflow.com
+            // TODO: check again later, how reliable this is?!
+            HandledMouseEventArgs ee = (HandledMouseEventArgs)e;
+            ee.Handled = true;
         }
 
         public GUIEditor()

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -30,7 +30,7 @@ extern bool reload_font(int curFont);
 // may be called with hdc = 0 to get required height without drawing anything
 extern int drawFontAt (int hdc, int fontnum, int x, int y, int width);
 extern Dictionary<int, Sprite^>^ load_sprite_dimensions();
-extern void drawGUI(int hdc, int x,int y, GUI^ gui, int scaleFactor, int selectedControl);
+extern void drawGUI(int hdc, int x,int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl);
 extern void drawSprite(int hdc, int x,int y, int spriteNum, bool flipImage);
 extern void drawSpriteStretch(int hdc, int x,int y, int width, int height, int spriteNum);
 extern void drawBlockOfColour(int hdc, int x,int y, int width, int height, int colNum);
@@ -170,9 +170,9 @@ namespace AGS
 			GameUpdated(game);
 		}
 
-		void NativeMethods::DrawGUI(int hDC, int x, int y, GUI^ gui, int scaleFactor, int selectedControl)
+		void NativeMethods::DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl)
 		{
-			drawGUI(hDC, x, y, gui, scaleFactor, selectedControl);
+			drawGUI(hDC, x, y, gui, resolutionFactor, scale, selectedControl);
 		}
 
 		void NativeMethods::DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -29,7 +29,7 @@ namespace AGS
 			void SaveGame(Game^ game);
 			void GameSettingsChanged(Game^ game);
 			void PaletteColoursUpdated(Game ^game);
-			void DrawGUI(int hDC, int x, int y, GUI^ gui, int scaleFactor, int selectedControl);
+			void DrawGUI(int hDC, int x, int y, GUI^ gui, int resolutionFactor, float scale, int selectedControl);
 			void DrawSprite(int hDC, int x, int y, int width, int height, int spriteNum);
 			void DrawSprite(int hDC, int x, int y, int spriteNum, bool flipImage);
 			// Draws font char sheet on the provided context and returns the height of drawn object;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3106,8 +3106,8 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
   else
   {
     TextWindowGUI^ twGui = dynamic_cast<TextWindowGUI^>(guiObj);
-	gui->Width = 200;
-	gui->Height = 100;
+	gui->Width = twGui->EditorWidth;
+	gui->Height = twGui->EditorHeight;
     gui->Flags = Common::kGUIMain_TextWindow;
     gui->PopupStyle = Common::kGUIPopupModal;
 	gui->Padding = twGui->Padding;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -115,7 +115,7 @@ int BaseColorDepth;
 
 
 bool reload_font(int curFont);
-void drawBlockScaledAt(int hdc, Common::Bitmap *todraw ,int x, int y, int scaleFactor);
+void drawBlockScaledAt(int hdc, Common::Bitmap *todraw ,int x, int y, float scaleFactor);
 // this is to shut up the linker, it's used by CSRUN.CPP
 void write_log(const char *) { }
 
@@ -1265,7 +1265,7 @@ void shutdown_native()
     Common::AssetManager::DestroyInstance();
 }
 
-void drawBlockScaledAt (int hdc, Common::Bitmap *todraw ,int x, int y, int scaleFactor) {
+void drawBlockScaledAt (int hdc, Common::Bitmap *todraw ,int x, int y, float scaleFactor) {
   if (todraw->GetColorDepth () == 8)
     set_palette_to_hdc ((HDC)hdc, palette);
 
@@ -1314,21 +1314,17 @@ void drawSpriteStretch(int hdc, int x, int y, int width, int height, int spriteN
   delete tempBlock;
 }
 
-void drawGUIAt (int hdc, int x,int y,int x1,int y1,int x2,int y2, int scaleFactor) {
+void drawGUIAt (int hdc, int x,int y,int x1,int y1,int x2,int y2, int resolutionFactor, float scale) {
 
   if ((tempgui.Width < 1) || (tempgui.Height < 1))
     return;
 
-  //update_font_sizes();
-
-  if (scaleFactor == 1) {
+  if (resolutionFactor == 1) {
     dsc_want_hires = 1;
   }
 
   Common::Bitmap *tempblock = Common::BitmapHelper::CreateBitmap(tempgui.Width, tempgui.Height, thisgame.color_depth*8);
   tempblock->Clear(tempblock->GetMaskColor ());
-  //Common::Bitmap *abufWas = abuf;
-  //abuf = tempblock;
 
   tempgui.DrawAt (tempblock, 0, 0);
 
@@ -1337,10 +1333,8 @@ void drawGUIAt (int hdc, int x,int y,int x1,int y1,int x2,int y2, int scaleFacto
   if (x1 >= 0) {
     tempblock->DrawRect(Rect (x1, y1, x2, y2), 14);
   }
-  //abuf = abufWas;
 
-  drawBlockScaledAt (hdc, tempblock, x, y, scaleFactor);
-  //drawBlockDoubleAt (hdc, tempblock, x, y);
+  drawBlockScaledAt(hdc, tempblock, x, y, scale);
   delete tempblock;
 }
 
@@ -3257,7 +3251,7 @@ void ConvertGUIToBinaryFormat(GUI ^guiObj, GUIMain *gui)
   gui->ResortZOrder();
 }
 
-void drawGUI(int hdc, int x,int y, GUI^ guiObj, int scaleFactor, int selectedControl) {
+void drawGUI(int hdc, int x,int y, GUI^ guiObj, int resolutionFactor, float scale, int selectedControl) {
   numguibuts = 0;
   numguilabels = 0;
   numguitext = 0;
@@ -3275,7 +3269,7 @@ void drawGUI(int hdc, int x,int y, GUI^ guiObj, int scaleFactor, int selectedCon
 
   tempgui.HighlightCtrl = selectedControl;
 
-  drawGUIAt(hdc, x, y, -1, -1, -1, -1, scaleFactor);
+  drawGUIAt(hdc, x, y, -1, -1, -1, -1, resolutionFactor, scale);
 }
 
 Dictionary<int, Sprite^>^ load_sprite_dimensions()

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -26,6 +26,26 @@ namespace AGS.Types
         protected int _bgimage;
         protected List<GUIControl> _controls = new List<GUIControl>();
 
+        /// <summary>
+        /// Width of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public virtual int EditorWidth
+        {
+            get { return 0; }
+        }
+
+        /// <summary>
+        /// Height of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public virtual int EditorHeight
+        {
+            get { return 0; }
+        }
+
         [Description("Background color of the GUI (0 for transparent)")]
         [Category("Appearance")]
         [DisplayName("BackgroundColourNumber")]

--- a/Editor/AGS.Types/NormalGUI.cs
+++ b/Editor/AGS.Types/NormalGUI.cs
@@ -32,6 +32,26 @@ namespace AGS.Types
         private int _transparency = 0;
 		private string _clickEventHandler = string.Empty;
 
+        /// <summary>
+        /// Width of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public override int EditorWidth
+        {
+            get { return Width; }
+        }
+
+        /// <summary>
+        /// Height of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public override int EditorHeight
+        {
+            get { return Height; }
+        }
+
         [Description("Script function to run when the GUI is clicked")]
         [Category("Events")]
         [Browsable(false)]

--- a/Editor/AGS.Types/TextWindowGUI.cs
+++ b/Editor/AGS.Types/TextWindowGUI.cs
@@ -12,6 +12,26 @@ namespace AGS.Types
 		private int _textColor;
 		private int _padding = 3;
 
+        /// <summary>
+        /// Width of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public override int EditorWidth
+        {
+            get { return 200; }
+        }
+
+        /// <summary>
+        /// Height of the GUI, as displayed in the Editor.
+        /// </summary>
+        [Browsable(false)]
+        [AGSNoSerialize]
+        public override int EditorHeight
+        {
+            get { return 100; }
+        }
+
 		[Description("Colour of the text when drawn on this text window")]
 		[Category("Appearance")]
 		public int TextColor


### PR DESCRIPTION
This adds scrollbars and zoom control to the GUI editor (lack of those was causing suffering for high-resolution game developers).

The code ended up tad bloated, perhaps it could be improved in the future by implementing a parent class for the scrollable/zoomable editor pane, and sharing the code with the room editor.