### PR TITLE
3.4.1: hotfix script editor to let Undo work after save

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -605,7 +605,11 @@ namespace AGS.Editor
 
         public bool CanUndo()
         {
-            return this.scintillaControl1.CanUndo;
+            bool shouldBeReadOnly = scintillaControl1.IsReadOnly;
+            scintillaControl1.IsReadOnly = false;
+            bool res = scintillaControl1.CanUndo;
+            scintillaControl1.IsReadOnly = shouldBeReadOnly;
+            return res;
         }
 
         public void Undo()
@@ -615,7 +619,11 @@ namespace AGS.Editor
 
         public bool CanRedo()
         {
-            return this.scintillaControl1.CanRedo;
+            bool shouldBeReadOnly = scintillaControl1.IsReadOnly;
+            scintillaControl1.IsReadOnly = false;
+            bool res = scintillaControl1.CanRedo;
+            scintillaControl1.IsReadOnly = shouldBeReadOnly;
+            return res;
         }
 
         public void Redo()


### PR DESCRIPTION
Resolves #462 .

I honestly do not understand why, but Editor keeps Scintilla component in Read-only state most of the time, manually toggling it when the user types/pastes text.
Scintilla checks for ReadOnly when asked if it can Undo/Redo and may reply negative even when there are entries in the Undo buffer.

This fix is a hack, that similarily turns ReadOnly mode off before asking Scintilla if Undo is allowed.