### PR TITLE
AGS 3: remove the fonts limit

### DIFF
--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -38,12 +38,9 @@ using AGS::Common::HGameFileError;
 
 // TODO: split GameSetupStruct into struct used to hold loaded game data, and actual runtime object
 struct GameSetupStruct: public GameSetupStructBase {
-    // These arrays are used only to read data into;
+    // This array is used only to read data into;
     // font parameters are then put and queried in the fonts module
-    unsigned char     fontflags[MAX_FONTS];
-    char              fontoutline[MAX_FONTS];
-    int               fontvoffset[MAX_FONTS]; // vertical font offset
-    int               fontlnspace[MAX_FONTS]; // font's line spacing (0 = default)
+    std::vector<FontInfo> fonts;
     //
     unsigned char     spriteflags[MAX_SPRITES];
     InventoryItemInfo invinfo[MAX_INV];
@@ -134,7 +131,6 @@ struct GameSetupStruct: public GameSetupStructBase {
 };
 
 //=============================================================================
-
 // TODO: find out how this function was supposed to be used
 void ConvertOldGameStruct (OldGameSetupStruct *ogss, GameSetupStruct *gss);
 // Finds an audio clip using legacy convention index

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -25,7 +25,7 @@
 #define PAL_BACKGROUND      2
 #define MAXGLOBALMES        500
 #define MAXLANGUAGE         5
-#define MAX_FONTS           30
+#define LEGACY_MAX_FONTS    30
 #define OPT_DEBUGMODE       0
 #define OPT_SCORESOUND      1
 #define OPT_WALKONLOOK      2
@@ -96,6 +96,7 @@
 #define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
 //#define FFLG_NOSCALE        1
 #define FFLG_SIZEMASK 0x003f
+#define FONT_OUTLINE_NONE -1
 #define FONT_OUTLINE_AUTO -10
 #define MAX_FONT_SIZE 63
 #define DIALOG_OPTIONS_HIGHLIGHT_COLOR_DEFAULT  14 // Yellow
@@ -165,6 +166,27 @@ enum RenderAtScreenRes
     kRenderAtScreenRes_UserDefined  = 0,
     kRenderAtScreenRes_Enabled      = 1,
     kRenderAtScreenRes_Disabled     = 2,
+};
+
+// Various font parameters, defining and extending font rendering behavior.
+// While FontRenderer object's main goal is to render single line of text at
+// the strictly determined position on canvas, FontInfo may additionally
+// provide instructions on adjusting drawing position, as well as arranging
+// multiple lines, and similar cases.
+struct FontInfo
+{
+    // General font's loading and rendering flags
+    unsigned char Flags;
+    // Font size, in points (basically means pixels in AGS)
+    int           SizePt;
+    // Outlining font index, or auto-outline flag
+    char          Outline;
+    // Custom vertical render offset, used mainly for fixing broken fonts
+    int           YOffset;
+    // custom line spacing between two lines of text (0 = use font height)
+    int           LineSpacing;
+
+    FontInfo();
 };
 
 #endif // __AGS_CN_AC__GAMESTRUCTDEFINES_H

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -23,28 +23,7 @@ using namespace AGS;
 
 class IAGSFontRenderer;
 class IAGSFontRenderer2;
-struct GameSetupStruct;
-
-// Various font parameters, defining and extending font rendering behavior.
-// While FontRenderer object's main goal is to render single line of text at
-// the strictly determined position on canvas, FontInfo may additionally
-// provide instructions on adjusting drawing position, as well as arranging
-// multiple lines, and similar cases.
-struct FontInfo
-{
-    // General font's loading and rendering flags
-    unsigned char Flags;
-    // Font size, in points (basically means pixels in AGS)
-    int           SizePt;
-    // Outlining font index, or auto-outline flag
-    char          Outline;
-    // Custom vertical render offset, used mainly for fixing broken fonts
-    int           YOffset;
-    // custom line spacing between two lines of text (0 = use font height)
-    int           LineSpacing;
-
-    FontInfo();
-};
+struct FontInfo;
 
 // Font render params, mainly for dealing with various compatibility issues and
 // broken fonts. NOTE: currently left empty as a result of rewrite, but may be
@@ -78,8 +57,6 @@ void set_font_outline(int font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters
 int getfontlinespacing(int fontNumber);
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, int fontNumber, color_t text_color, const char *texx);
-// Fills in FontInfo structure from the GameSetupStruct data
-void make_fontinfo(const GameSetupStruct &game, int fontNumber, FontInfo &font_info);
 // Assigns FontInfo to the font
 void set_fontinfo(int fontNumber, const FontInfo &finfo);
 // Loads a font from disk

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -59,8 +59,6 @@ String GetMainGameFileErrorText(MainGameFileErrorType err)
         return "Required engine caps are not supported.";
     case kMGFErr_InvalidNativeResolution:
         return "Unable to determine native game resolution.";
-    case kMGFErr_TooManyFonts:
-        return "Too many fonts for this engine to handle.";
     case kMGFErr_TooManySprites:
         return "Too many sprites for this engine to handle.";
     case kMGFErr_TooManyCursors:
@@ -643,8 +641,6 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
 
     if (game.size.IsNull())
         return new MainGameFileError(kMGFErr_InvalidNativeResolution);
-    if (game.numfonts > MAX_FONTS)
-        return new MainGameFileError(kMGFErr_TooManyFonts, String::FromFormat("Count: %d, max: %d", game.numfonts, MAX_FONTS));
 
     game.read_savegame_info(in, data_ver);
     game.read_font_flags(in, data_ver);

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -53,7 +53,6 @@ enum MainGameFileErrorType
     kMGFErr_FormatVersionNotSupported,
     kMGFErr_CapsNotSupported,
     kMGFErr_InvalidNativeResolution,
-    kMGFErr_TooManyFonts,
     kMGFErr_TooManySprites,
     kMGFErr_TooManyCursors,
     kMGFErr_InvalidPropertySchema,

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -72,8 +72,9 @@ namespace AGS.Editor
          * 13: 3.4.0.9    - Settings.ScriptCompatLevel
          * 14: 3.4.1      - Settings.RenderAtScreenResolution
          * 15: 3.4.1.2    - DefaultSetup node
+         * 16: 3.4.2      - Unlimited fonts (need separate version to prevent crashes in older editors)
         */
-        public const int    LATEST_XML_VERSION_INDEX = 15;
+        public const int    LATEST_XML_VERSION_INDEX = 16;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -39,11 +39,6 @@ namespace AGS.Editor.Components
         {
             if (controlID == COMMAND_NEW_ITEM)
             {
-                if (_agsEditor.CurrentGame.Fonts.Count == Game.MAX_FONTS)
-                {
-                    Factory.GUIController.ShowMessage("You already have the maximum number of fonts in your game, and cannot add any more.", MessageBoxIcon.Warning);
-                    return;
-                }
                 IList<AGS.Types.Font> items = _agsEditor.CurrentGame.Fonts;
                 AGS.Types.Font newItem = new AGS.Types.Font();
                 newItem.ID = items.Count;

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1356,11 +1356,6 @@ namespace AGS.Editor
             WriteString(game.Settings.GUIDAsString, NativeConstants.MAX_GUID_LENGTH, writer);
             WriteString(game.Settings.SaveGameFileExtension, NativeConstants.MAX_SG_EXT_LENGTH, writer);
             WriteString(game.Settings.SaveGameFolderName, NativeConstants.MAX_SG_FOLDER_LEN, writer);
-            if (game.Fonts.Count > NativeConstants.MAX_FONTS)
-            {
-                errors.Add(new CompileError("Too many fonts"));
-                return false;
-            }
             for (int i = 0; i < game.Fonts.Count; ++i)
             {
                 writer.Write((byte)(game.Fonts[i].PointSize & NativeConstants.FFLG_SIZEMASK));

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -31,7 +31,6 @@ namespace AGS.Editor
         public static readonly int DFLG_NOREPEAT = (int)Factory.NativeProxy.GetNativeConstant("DFLG_NOREPEAT");
         public static readonly int DTFLG_SHOWPARSER = (int)Factory.NativeProxy.GetNativeConstant("DTFLG_SHOWPARSER");
         public static readonly sbyte FONT_OUTLINE_AUTO = (sbyte)(int)Factory.NativeProxy.GetNativeConstant("FONT_OUTLINE_AUTO");
-        public static readonly int MAX_FONTS = (int)Factory.NativeProxy.GetNativeConstant("MAX_FONTS");
         public static readonly int MAX_SPRITES = (int)Factory.NativeProxy.GetNativeConstant("MAX_SPRITES");
         public static readonly int MAX_CURSOR = (int)Factory.NativeProxy.GetNativeConstant("MAX_CURSOR");
         public static readonly int MAX_PARSER_WORD_LENGTH = (int)Factory.NativeProxy.GetNativeConstant("MAX_PARSER_WORD_LENGTH");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -665,7 +665,6 @@ namespace AGS
             if (name->Equals("DFLG_NOREPEAT")) return DFLG_NOREPEAT;
             if (name->Equals("DTFLG_SHOWPARSER")) return DTFLG_SHOWPARSER;
             if (name->Equals("FONT_OUTLINE_AUTO")) return FONT_OUTLINE_AUTO;
-            if (name->Equals("MAX_FONTS")) return MAX_FONTS;
             if (name->Equals("MAX_SPRITES")) return MAX_SPRITES;
             if (name->Equals("MAX_CURSOR")) return MAX_CURSOR;
             if (name->Equals("MAX_PARSER_WORD_LENGTH")) return MAX_PARSER_WORD_LENGTH;

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -22,7 +22,6 @@ namespace AGS.Types
 
         public const int MAX_CURSORS = 20;
         public const int MAX_DIALOGS = 500;
-        public const int MAX_FONTS = 30;
         public const int MAX_INV_ITEMS = 300;
         public const int MAX_SPRITES = 30000;
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -316,8 +316,7 @@ void LoadFonts()
 {
     for (int i = 0; i < game.numfonts; ++i) 
     {
-        FontInfo finfo;
-        make_fontinfo(game, i, finfo);
+        FontInfo finfo = game.fonts[i];
 
         // Apply compatibility adjustments
         if (finfo.SizePt == 0)


### PR DESCRIPTION
This removes the arbitrary font limit (and does tiny bit of refactoring).

NOTE: this is done for the ags3 branch by request from a user. Later this may be merged to ags4 without much problem.