### PR TITLE
Editor: improved Room pane's zoom

### DIFF
--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -299,9 +299,9 @@ namespace AGS.Editor
             _native.RenderBufferToHDC((int)hDC);
         }
 
-        public void DrawSpriteToBuffer(int spriteNum, int x, int y, int scaleFactor)
+        public void DrawSpriteToBuffer(int spriteNum, int x, int y, float scale)
         {
-            _native.DrawSpriteToBuffer(spriteNum, x, y, scaleFactor);
+            _native.DrawSpriteToBuffer(spriteNum, x, y, scale);
         }
 
         public void DrawLineOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int x2, int y2, int color)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -104,8 +104,8 @@ namespace AGS.Editor
 			ContextMenuStrip menu = new ContextMenuStrip();
 			menu.Items.Add(new ToolStripMenuItem("Copy mouse coordinates to clipboard", null, onClick, MENU_ITEM_COPY_COORDS));
 
-			_menuClickX = (e.X + state.ScrollOffsetX) / state.ScaleFactor;
-			_menuClickY = (e.Y + state.ScrollOffsetY) / state.ScaleFactor;
+			_menuClickX = state.WindowXToRoom(e.X);
+			_menuClickY = state.WindowYToRoom(e.Y);
 
             if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
                 (_room.Resolution == RoomResolution.HighRes))

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -41,8 +41,8 @@ namespace AGS.Editor
             {
                 if ((hotspot.WalkToPoint.X > 0) && (hotspot.WalkToPoint.Y > 0))
                 {
-                    int x = (hotspot.WalkToPoint.X * state.ScaleFactor) - state.ScrollOffsetX;
-                    int y = (hotspot.WalkToPoint.Y * state.ScaleFactor) - state.ScrollOffsetY;
+                    int x = state.RoomXToWindow(hotspot.WalkToPoint.X);
+                    int y = state.RoomYToWindow(hotspot.WalkToPoint.Y);
                     graphics.DrawLine(Pens.Red, x - 4, y - 4, x + 4, y + 4);
                     graphics.DrawLine(Pens.RosyBrown, x - 4, y + 4, x + 4, y - 4);
                     graphics.DrawString(hotspot.ID.ToString(), new System.Drawing.Font(FontFamily.GenericSansSerif, 10, FontStyle.Bold), Brushes.Gold, x + 4, y - 7);

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -20,7 +20,9 @@ namespace AGS.Editor
         private RoomObject _selectedObject;
 		private RoomObject _lastSelectedObject;
         private bool _movingObjectWithMouse;
+        // mouse offset in ROOM's coordinates
         private int _mouseOffsetX, _mouseOffsetY;
+        // mouse click location in ROOM's coordinates
         private int _menuClickX, _menuClickY;
         private List<RoomObject> _objectBaselines = new List<RoomObject>();
 
@@ -388,7 +390,7 @@ namespace AGS.Editor
         {
             if (!_movingObjectWithMouse) return false;
             int realX = state.WindowXToRoom(x);
-            int realY = state.WindowXToRoom(y);
+            int realY = state.WindowYToRoom(y);
 
             if ((_movingObjectWithMouse) && (realY < _room.Height) &&
                 (realX < _room.Width) && (realY >= 0) && (realX >= 0))

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -115,8 +115,8 @@ namespace AGS.Editor
             {
                 if (!VisibleItems.Contains(GetUniqueName(obj))) continue;
                 int height = GetSpriteHeightForGameResolution(obj.Image);
-                int ypos = AdjustYCoordinateForWindowScroll(obj.StartY, state) - (height * state.ScaleFactor);
-				Factory.NativeProxy.DrawSpriteToBuffer(obj.Image, AdjustXCoordinateForWindowScroll(obj.StartX, state), ypos, state.ScaleFactor);
+                int ypos = state.RoomYToWindow(obj.StartY - height);
+				Factory.NativeProxy.DrawSpriteToBuffer(obj.Image, state.RoomXToWindow(obj.StartX), ypos, state.Scale);
             }
             
         }
@@ -158,20 +158,20 @@ namespace AGS.Editor
 
             if (_selectedObject != null && VisibleItems.Contains(GetUniqueName(_selectedObject)))
             {
-                int width = GetSpriteWidthForGameResolution(_selectedObject.Image);
-				int height = GetSpriteHeightForGameResolution(_selectedObject.Image);
-				xPos = AdjustXCoordinateForWindowScroll(_selectedObject.StartX, state);
-				yPos = AdjustYCoordinateForWindowScroll(_selectedObject.StartY, state) - (height * state.ScaleFactor);
+                int width = state.RoomSizeToWindow(GetSpriteWidthForGameResolution(_selectedObject.Image));
+				int height = state.RoomSizeToWindow(GetSpriteHeightForGameResolution(_selectedObject.Image));
+				xPos = state.RoomXToWindow(_selectedObject.StartX);
+				yPos = state.RoomYToWindow(_selectedObject.StartY) - height;
                 Pen pen = new Pen(Color.Goldenrod);
                 pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
-                graphics.DrawRectangle(pen, xPos, yPos, width * state.ScaleFactor, height * state.ScaleFactor);
+                graphics.DrawRectangle(pen, xPos, yPos, width, height);
 
                 if (_movingObjectWithMouse)
                 {
                     System.Drawing.Font font = new System.Drawing.Font("Arial", 10.0f);
                     string toDraw = String.Format("X:{0}, Y:{1}", _selectedObject.StartX, _selectedObject.StartY);
 
-                    int scaledx = xPos + (width * state.ScaleFactor / 2) - ((int)graphics.MeasureString(toDraw, font).Width / 2);
+                    int scaledx = xPos + (width / 2) - ((int)graphics.MeasureString(toDraw, font).Width / 2);
                     int scaledy = yPos - (int)graphics.MeasureString(toDraw, font).Height;
                     if (scaledx < 0) scaledx = 0;
                     if (scaledy < 0) scaledy = 0;
@@ -182,8 +182,8 @@ namespace AGS.Editor
                     if (_selectedObject.Locked)
                     {
                         pen = new Pen(Color.Goldenrod, 2);
-                        xPos = AdjustXCoordinateForWindowScroll(_selectedObject.StartX, state) + (GetSpriteWidthForGameResolution(_selectedObject.Image) / 2 * state.ScaleFactor);
-                        yPos = AdjustYCoordinateForWindowScroll(_selectedObject.StartY, state) - (GetSpriteHeightForGameResolution(_selectedObject.Image) / 2 * state.ScaleFactor);
+                        xPos = state.RoomXToWindow(_selectedObject.StartX) + (width / 2);
+                        yPos = state.RoomYToWindow(_selectedObject.StartY) - (height / 2);
                         Point center = new Point(xPos, yPos);
 
                         graphics.DrawLine(pen, center.X - 3, center.Y - 3, center.X + 3, center.Y + 3);
@@ -193,16 +193,6 @@ namespace AGS.Editor
             }
         }
 
-		private int AdjustXCoordinateForWindowScroll(int x, RoomEditorState state)
-		{
-			return (x - (state.ScrollOffsetX / state.ScaleFactor)) * state.ScaleFactor;
-		}
-
-		private int AdjustYCoordinateForWindowScroll(int y, RoomEditorState state)
-		{
-			return (y - (state.ScrollOffsetY / state.ScaleFactor)) * state.ScaleFactor;
-		}
-
         public void MouseDownAlways(MouseEventArgs e, RoomEditorState state)
         {
             _selectedObject = null;
@@ -210,8 +200,8 @@ namespace AGS.Editor
 
         public virtual bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
-            int x = (e.X + state.ScrollOffsetX) / state.ScaleFactor;
-            int y = (e.Y + state.ScrollOffsetY) / state.ScaleFactor;
+            int x = state.WindowXToRoom(e.X);
+            int y = state.WindowYToRoom(e.Y);
             RoomObject obj = GetObject(x, y);
             
             if (obj != null)
@@ -284,8 +274,8 @@ namespace AGS.Editor
             ContextMenuStrip menu = new ContextMenuStrip();
             menu.Items.Add(new ToolStripMenuItem("Copy mouse coordinates to clipboard", null, onClick, MENU_ITEM_COPY_COORDS));
 
-            _menuClickX = (e.X + state.ScrollOffsetX) / state.ScaleFactor;
-            _menuClickY = (e.Y + state.ScrollOffsetY) / state.ScaleFactor;
+            _menuClickX = state.WindowXToRoom(e.X);
+            _menuClickY = state.WindowYToRoom(e.Y);
 
             menu.Show(_panel, e.X, e.Y);
         }
@@ -362,8 +352,8 @@ namespace AGS.Editor
             {
                 menu.Items.Add(new ToolStripMenuItem("Copy Object Coordinates to Clipboard", null, onClick, MENU_ITEM_OBJECT_COORDS));
             }
-            _menuClickX = (e.X + state.ScrollOffsetX) / state.ScaleFactor;
-            _menuClickY = (e.Y + state.ScrollOffsetY) / state.ScaleFactor;
+            _menuClickX = state.WindowXToRoom(e.X);
+            _menuClickY = state.WindowYToRoom(e.Y);
 
             menu.Show(_panel, e.X, e.Y);
         }
@@ -397,8 +387,8 @@ namespace AGS.Editor
         public virtual bool MouseMove(int x, int y, RoomEditorState state)
         {
             if (!_movingObjectWithMouse) return false;
-            int realX = (x + state.ScrollOffsetX) / state.ScaleFactor;
-            int realY = (y + state.ScrollOffsetY) / state.ScaleFactor;
+            int realX = state.WindowXToRoom(x);
+            int realY = state.WindowXToRoom(y);
 
             if ((_movingObjectWithMouse) && (realY < _room.Height) &&
                 (realX < _room.Width) && (realY >= 0) && (realX >= 0))
@@ -500,8 +490,8 @@ namespace AGS.Editor
         public Cursor GetCursor(int x, int y, RoomEditorState state)
         {
             if (_movingObjectWithMouse) return Cursors.Hand;
-            x = (x + state.ScrollOffsetX) / state.ScaleFactor;
-            y = (y + state.ScrollOffsetY) / state.ScaleFactor;
+            x = state.WindowXToRoom(x);
+            y = state.WindowYToRoom(y);
             if (GetObject(x, y) != null) return Cursors.Default;
             return null;
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
@@ -38,7 +38,7 @@ namespace AGS.Editor
 			Pen pen = (Pen)GetPenForArea(SelectedArea).Clone();
 			pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dash;
 
-			for (int i = 0; i < state.ScaleFactor; i++)
+			for (int i = 0; i < (int)state.Scale; i++)
 			{
 				graphics.DrawLine(pen, 0, lineYPos + i, graphics.VisibleClipBounds.Right, lineYPos + i);
 			}
@@ -60,7 +60,7 @@ namespace AGS.Editor
 		{
 			if (_draggingBaseline)
 			{
-				int newBaseline = (y + state.ScrollOffsetY) / state.ScaleFactor;
+				int newBaseline = state.WindowYToRoom(y);
 				if (newBaseline < 0)
 				{
 					newBaseline = 0;
@@ -121,12 +121,12 @@ namespace AGS.Editor
 
 		private int GetCurrentAreaBaselineScreenY(RoomEditorState state)
 		{
-			return (_room.WalkBehinds[SelectedArea].Baseline * state.ScaleFactor) - state.ScrollOffsetY;
+			return state.RoomYToWindow(_room.WalkBehinds[SelectedArea].Baseline);
 		}
 
 		private bool IsCursorOnHorizontalEdge(int cursorY, int edgeY, RoomEditorState state)
 		{
-			return ((cursorY >= edgeY - 1) && (cursorY <= edgeY + state.ScaleFactor));
+			return ((cursorY >= edgeY - 1) && (cursorY <= edgeY + (int)state.Scale));
 		}
 
         protected override void SelectedAreaChanged(int areaNumber)

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -45,6 +45,7 @@ namespace AGS.Editor
             this.lblDummyScrollSizer = new System.Windows.Forms.Label();
             this.sldZoomLevel = new System.Windows.Forms.TrackBar();
             this.sldTransparency = new System.Windows.Forms.TrackBar();
+            this.lblZoomInfo = new System.Windows.Forms.Label();
             this.mainFrame.SuspendLayout();
             this.bufferedPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
@@ -53,6 +54,7 @@ namespace AGS.Editor
             // 
             // mainFrame
             // 
+            this.mainFrame.Controls.Add(this.lblZoomInfo);
             this.mainFrame.Controls.Add(this._editAddressBar);
             this.mainFrame.Controls.Add(this.chkCharacterOffset);
             this.mainFrame.Controls.Add(this.coordbox);
@@ -70,16 +72,17 @@ namespace AGS.Editor
             this.mainFrame.Controls.Add(this.sldTransparency);
             this.mainFrame.Location = new System.Drawing.Point(3, 3);
             this.mainFrame.Name = "mainFrame";
-            this.mainFrame.Size = new System.Drawing.Size(693, 593);
+            this.mainFrame.Size = new System.Drawing.Size(769, 593);
             this.mainFrame.TabIndex = 4;
             this.mainFrame.TabStop = false;
             this.mainFrame.Text = "Room details";
             // 
             // _editAddressBar
             // 
-            this._editAddressBar.BackColor = System.Drawing.Color.White;
             this._editAddressBar.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this._editAddressBar.CurrentNode = null;
+            this._editAddressBar.DropDownBackColor = System.Drawing.Color.Empty;
+            this._editAddressBar.DropDownForeColor = System.Drawing.Color.Empty;
             this._editAddressBar.ForeColor = System.Drawing.SystemColors.InfoText;
             this._editAddressBar.Location = new System.Drawing.Point(93, 40);
             this._editAddressBar.MinimumSize = new System.Drawing.Size(331, 23);
@@ -116,7 +119,7 @@ namespace AGS.Editor
             // lblTransparency
             // 
             this.lblTransparency.AutoSize = true;
-            this.lblTransparency.Location = new System.Drawing.Point(568, 46);
+            this.lblTransparency.Location = new System.Drawing.Point(622, 46);
             this.lblTransparency.Name = "lblTransparency";
             this.lblTransparency.Size = new System.Drawing.Size(38, 13);
             this.lblTransparency.TabIndex = 15;
@@ -208,10 +211,10 @@ namespace AGS.Editor
             this.bufferedPanel1.Size = new System.Drawing.Size(640, 480);
             this.bufferedPanel1.TabIndex = 1;
             this.bufferedPanel1.TabStop = true;
-            this.bufferedPanel1.DoubleClick += new System.EventHandler(this.bufferedPanel1_DoubleClick);
             this.bufferedPanel1.Paint += new System.Windows.Forms.PaintEventHandler(this.bufferedPanel1_Paint);
-            this.bufferedPanel1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseMove);
+            this.bufferedPanel1.DoubleClick += new System.EventHandler(this.bufferedPanel1_DoubleClick);
             this.bufferedPanel1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseDown);
+            this.bufferedPanel1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseMove);
             this.bufferedPanel1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseUp);
             // 
             // lblDummyScrollSizer
@@ -229,7 +232,7 @@ namespace AGS.Editor
             this.sldZoomLevel.Maximum = 6;
             this.sldZoomLevel.Minimum = 1;
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(84, 45);
+            this.sldZoomLevel.Size = new System.Drawing.Size(91, 42);
             this.sldZoomLevel.TabIndex = 12;
             this.sldZoomLevel.Value = 1;
             this.sldZoomLevel.Scroll += new System.EventHandler(this.sldZoomLevel_Scroll);
@@ -237,17 +240,26 @@ namespace AGS.Editor
             // sldTransparency
             // 
             this.sldTransparency.LargeChange = 20;
-            this.sldTransparency.Location = new System.Drawing.Point(610, 37);
+            this.sldTransparency.Location = new System.Drawing.Point(664, 37);
             this.sldTransparency.Margin = new System.Windows.Forms.Padding(1);
             this.sldTransparency.Maximum = 100;
             this.sldTransparency.Name = "sldTransparency";
-            this.sldTransparency.Size = new System.Drawing.Size(81, 45);
+            this.sldTransparency.Size = new System.Drawing.Size(91, 42);
             this.sldTransparency.SmallChange = 5;
             this.sldTransparency.TabIndex = 14;
             this.sldTransparency.TickFrequency = 20;
             this.sldTransparency.Value = 70;
             this.sldTransparency.Visible = false;
             this.sldTransparency.Scroll += new System.EventHandler(this.sldTransparency_Scroll);
+            // 
+            // lblZoomInfo
+            // 
+            this.lblZoomInfo.AutoSize = true;
+            this.lblZoomInfo.Location = new System.Drawing.Point(575, 46);
+            this.lblZoomInfo.Name = "lblZoomInfo";
+            this.lblZoomInfo.Size = new System.Drawing.Size(36, 13);
+            this.lblZoomInfo.TabIndex = 19;
+            this.lblZoomInfo.Text = "100%";
             // 
             // RoomSettingsEditor
             // 
@@ -256,7 +268,7 @@ namespace AGS.Editor
             this.Controls.Add(this.mainFrame);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "RoomSettingsEditor";
-            this.Size = new System.Drawing.Size(731, 614);
+            this.Size = new System.Drawing.Size(780, 614);
             this.Resize += new System.EventHandler(this.RoomSettingsEditor_Resize);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();
@@ -287,5 +299,6 @@ namespace AGS.Editor
         public  System.Windows.Forms.CheckBox coordbox;
         private System.Windows.Forms.CheckBox chkCharacterOffset;
         private AddressBarExt.Controls.AddressBarExt _editAddressBar;
+        private System.Windows.Forms.Label lblZoomInfo;
     }
 }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -54,6 +54,9 @@ namespace AGS.Editor
             // 
             // mainFrame
             // 
+            this.mainFrame.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.mainFrame.Controls.Add(this.lblZoomInfo);
             this.mainFrame.Controls.Add(this._editAddressBar);
             this.mainFrame.Controls.Add(this.chkCharacterOffset);
@@ -72,7 +75,7 @@ namespace AGS.Editor
             this.mainFrame.Controls.Add(this.sldTransparency);
             this.mainFrame.Location = new System.Drawing.Point(3, 3);
             this.mainFrame.Name = "mainFrame";
-            this.mainFrame.Size = new System.Drawing.Size(769, 593);
+            this.mainFrame.Size = new System.Drawing.Size(759, 485);
             this.mainFrame.TabIndex = 4;
             this.mainFrame.TabStop = false;
             this.mainFrame.Text = "Room details";
@@ -204,11 +207,15 @@ namespace AGS.Editor
             // 
             // bufferedPanel1
             // 
+            this.bufferedPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.bufferedPanel1.AutoScroll = true;
+            this.bufferedPanel1.BackColor = System.Drawing.SystemColors.Control;
             this.bufferedPanel1.Controls.Add(this.lblDummyScrollSizer);
             this.bufferedPanel1.Location = new System.Drawing.Point(12, 93);
             this.bufferedPanel1.Name = "bufferedPanel1";
-            this.bufferedPanel1.Size = new System.Drawing.Size(640, 480);
+            this.bufferedPanel1.Size = new System.Drawing.Size(741, 384);
             this.bufferedPanel1.TabIndex = 1;
             this.bufferedPanel1.TabStop = true;
             this.bufferedPanel1.Paint += new System.Windows.Forms.PaintEventHandler(this.bufferedPanel1_Paint);
@@ -268,8 +275,7 @@ namespace AGS.Editor
             this.Controls.Add(this.mainFrame);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "RoomSettingsEditor";
-            this.Size = new System.Drawing.Size(780, 614);
-            this.Resize += new System.EventHandler(this.RoomSettingsEditor_Resize);
+            this.Size = new System.Drawing.Size(768, 491);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();
             this.bufferedPanel1.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -501,7 +501,6 @@ namespace AGS.Editor
             ImportBackground(cmbBackgrounds.SelectedIndex);
             bufferedPanel1.Invalidate();
             Factory.GUIController.RefreshPropertyGrid();
-			ResizePaneToMatchWindowAndRoomSize();
         }
 
         private void btnDelete_Click(object sender, EventArgs e)
@@ -816,37 +815,7 @@ namespace AGS.Editor
             }
         }
 
-		private void ResizePaneToMatchWindowAndRoomSize()
-		{
-            if (_room == null)
-            {
-                return;
-            }
-
-			if (this.Width >= 200)
-			{
-				int requiredRoomWidth = (int)(_room.Width * _state.Scale) + SCROLLBAR_WIDTH_BUFFER + bufferedPanel1.Left;
-				mainFrame.Width = this.Width - 10;
-				mainFrame.Width = Math.Min(mainFrame.Width, requiredRoomWidth);
-				mainFrame.Width = Math.Max(mainFrame.Width, lblTransparency.Right + 10);
-			}
-			if (this.Height >= 200)
-			{
-				int requiredRoomHeight = (int)(_room.Height * _state.Scale) + SCROLLBAR_WIDTH_BUFFER + bufferedPanel1.Top;
-				mainFrame.Height = this.Height - 10;
-				mainFrame.Height = Math.Min(mainFrame.Height, requiredRoomHeight);
-			}
-			bufferedPanel1.Size = new Size(mainFrame.DisplayRectangle.Width - bufferedPanel1.Left,
-										   mainFrame.DisplayRectangle.Height - bufferedPanel1.Top);
-
-		}
-
-        private void RoomSettingsEditor_Resize(object sender, EventArgs e)
-        {
-			ResizePaneToMatchWindowAndRoomSize();
-        }
-
-		private void sldZoomLevel_Scroll(object sender, EventArgs e)
+        private void sldZoomLevel_Scroll(object sender, EventArgs e)
 		{
             float oldScale = _state.Scale;
             _state.Scale = sldZoomLevel.Value * ZOOM_STEP_VALUE * 0.01f;
@@ -858,7 +827,6 @@ namespace AGS.Editor
 
             lblZoomInfo.Text = String.Format("{0}%", sldZoomLevel.Value * ZOOM_STEP_VALUE);
             
-			ResizePaneToMatchWindowAndRoomSize();
 			UpdateScrollableWindowSize();
 			bufferedPanel1.Invalidate();
 		}

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -253,9 +253,11 @@ namespace AGS.Editor
             int backgroundNumber = cmbBackgrounds.SelectedIndex;
             if (backgroundNumber < _room.BackgroundCount)
             {
-				e.Graphics.SetClip(new Rectangle(0, 0, _state.RoomSizeToWindow(_room.Width), _state.RoomSizeToWindow(_room.Height)));
+                int bufWidth = _state.RoomSizeToWindow(_room.Width);
+                int bufHeight = _state.RoomSizeToWindow(_room.Height);
+                e.Graphics.SetClip(new Rectangle(0, 0, bufWidth, bufHeight));
                 IntPtr hdc = e.Graphics.GetHdc();
-				Factory.NativeProxy.CreateBuffer(bufferedPanel1.ClientSize.Width, bufferedPanel1.ClientSize.Height);
+				Factory.NativeProxy.CreateBuffer(bufWidth, bufHeight);
 				// Adjust co-ordinates using original scale factor so that it lines
 				// up with objects, etc
 				int drawOffsX = _state.RoomXToWindow(0);
@@ -281,6 +283,7 @@ namespace AGS.Editor
                     layer.Paint(e.Graphics, _state);
                 }
             }
+            base.OnPaint(e);
         }
 
         private IRoomEditorFilter GetCurrentMaskFilter()
@@ -847,6 +850,8 @@ namespace AGS.Editor
             ForeColor = t.GetColor("room-editor/foreground");
             mainFrame.BackColor = t.GetColor("room-editor/box/background");
             mainFrame.ForeColor = t.GetColor("room-editor/box/foreground");
+            bufferedPanel1.BackColor = mainFrame.BackColor;
+            bufferedPanel1.ForeColor = mainFrame.ForeColor;
             btnChangeImage.BackColor = t.GetColor("room-editor/btn-change-image/background");
             btnChangeImage.ForeColor = t.GetColor("room-editor/btn-change-image/foreground");
             btnChangeImage.FlatStyle = (FlatStyle)t.GetInt("room-editor/btn-change-image/flat/style");

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.resx
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -71,7 +71,7 @@ extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool
 extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void CreateBuffer(int width, int height);
 extern void RenderBufferToHDC(int hdc);
-extern void DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor);
+extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
 extern void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
@@ -443,9 +443,9 @@ namespace AGS
 			::CreateBuffer(width, height);
 		}
 
-		void NativeMethods::DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor) 
+		void NativeMethods::DrawSpriteToBuffer(int sprNum, int x, int y, float scale) 
 		{
-			::DrawSpriteToBuffer(sprNum, x, y, scaleFactor);
+			::DrawSpriteToBuffer(sprNum, x, y, scale);
 		}
 
 		void NativeMethods::RenderBufferToHDC(int hDC) 

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -78,7 +78,7 @@ namespace AGS
       void RestoreFromUndoBuffer(Room ^room, RoomAreaMaskType maskType);
       void SetGreyedOutMasksEnabled(bool enabled);
 			void CreateBuffer(int width, int height) ;
-			void DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor) ;
+			void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) ;
 			void RenderBufferToHDC(int hDC) ;
 			String ^LoadRoomScript(String ^roomFileName);
 			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, bool isRoomScript);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2469,7 +2469,7 @@ void CreateBuffer(int width, int height)
 	drawBuffer->Clear(0x00D0D0D0);
 }
 
-void DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor) {
+void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) {
 	Common::Bitmap *todraw = spriteset[sprNum];
 	if (todraw == NULL)
 	  todraw = spriteset[0];
@@ -2477,7 +2477,7 @@ void DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor) {
 	if (((thisgame.spriteflags[sprNum] & SPF_640x400) == 0) &&
 		thisgame.IsHiRes())
 	{
-		scaleFactor *= 2;
+		scale *= 2.0f;
 	}
 
 	Common::Bitmap *imageToDraw = todraw;
@@ -2492,12 +2492,12 @@ void DrawSpriteToBuffer(int sprNum, int x, int y, int scaleFactor) {
 		imageToDraw = depthConverted;
 	}
 
-	int drawWidth = imageToDraw->GetWidth() * scaleFactor;
-	int drawHeight = imageToDraw->GetHeight() * scaleFactor;
+	int drawWidth = imageToDraw->GetWidth() * scale;
+	int drawHeight = imageToDraw->GetHeight() * scale;
 
 	if ((thisgame.spriteflags[sprNum] & SPF_ALPHACHANNEL) != 0)
 	{
-		if (scaleFactor > 1)
+		if (scale > 1.0f)
 		{
 			Common::Bitmap *resizedImage = Common::BitmapHelper::CreateBitmap(drawWidth, drawHeight, imageToDraw->GetColorDepth());
 			resizedImage->StretchBlt(imageToDraw, RectWH(0, 0, imageToDraw->GetWidth(), imageToDraw->GetHeight()),


### PR DESCRIPTION
This improves how room's zoom works, making it similar to how I did GUI zoom previously.
Now it may have non-integer multipliers and supports downscale.

Removed unnecessary resizing of a room pane after zoom out (which could hide some of controls).

Notably, fixed a severe case of code duplication: window<->room coordinate conversions were done in-place all around the room code.

**PS.** the branch is named "release-3.4.1--roomzoomfix2", but ignore that, I simply called it wrong.