### PR TITLE
Compiled script must be newer than source

### DIFF
--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -194,7 +194,7 @@ namespace AGS.Editor
             {
                 return true;
             }
-            return (File.GetLastWriteTime(sourceFile) > File.GetLastWriteTime(destinationFile));
+            return (File.GetLastWriteTime(sourceFile) >= File.GetLastWriteTime(destinationFile));
         }
 
         public static void DeleteFileIfExists(string fileName)


### PR DESCRIPTION
This should fix #451, as scripts were not recompiled if the last write time for the compiled file was exactly the same as the source file. It should also ensure that files are recompiled if version control or the filesystem has reset the timestamps.