### PR TITLE
Add quotes to "copy" command

### DIFF
--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -103,7 +103,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(TargetPath) $(SolutionDir)..\Editor\References</Command>
+      <Command>copy "$(TargetPath)" "$(SolutionDir)..\Editor\References"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
If the path to the source code repository contains spaces, then the copy command will parse the parameters wrongly. Adding quotes fixes the problem. For further details, see http://www.adventuregamestudio.co.uk/forums/index.php?topic=56238.msg636590243#msg636590243