### PR TITLE
AGS 3: serialize room's design-time data

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -94,8 +94,8 @@ namespace AGS.Editor
         private const string XML_USER_DATA_ROOT_NODE_NAME = "AGSEditorUserData";
         private const string XML_ROOT_NODE_NAME = "AGSEditorDocument";
         private const string XML_ATTRIBUTE_VERSION = "Version";
-        private const string XML_ATTRIBUTE_VERSION_INDEX = "VersionIndex";
-        private const string XML_ATTRIBUTE_EDITOR_VERSION = "EditorVersion";
+        public const string XML_ATTRIBUTE_VERSION_INDEX = "VersionIndex";
+        public const string XML_ATTRIBUTE_EDITOR_VERSION = "EditorVersion";
         public const string COMPILED_DTA_FILE_NAME = "game28.dta";
         public const string CONFIG_FILE_NAME = "acsetup.cfg";
         public const string ENGINE_EXE_FILE_NAME = "acwin.exe";

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Components\LipSyncComponent.cs" />
     <Compile Include="Components\PaletteComponent.cs" />
     <Compile Include="Components\PluginsComponent.cs" />
+    <Compile Include="Components\RoomDesignData.cs" />
     <Compile Include="Components\ScriptsComponent.cs" />
     <Compile Include="Components\SpriteManagerComponent.cs" />
     <Compile Include="Components\TextParserComponent.cs" />

--- a/Editor/AGS.Editor/Components/RoomDesignData.cs
+++ b/Editor/AGS.Editor/Components/RoomDesignData.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Windows.Forms;
+using AGS.Types;
+
+namespace AGS.Editor.Components
+{
+    public static class RoomDesignData
+    {
+        private const string XML_DATA_ROOT_NODE = "AGSRoomUserData";
+        private const string XML_ROOM_NODE = "Room";
+        private const string XML_ROOM_LAYERS_NODE = "Layers";
+        private const string XML_LAYER_ELEM_VISIBLE = "Visible";
+        private const string XML_LAYER_ELEM_LOCKED = "Locked";
+        private const string XML_LAYER_ITEMS_NODE = "Items";
+        private const string XML_LAYER_ITEM_NODE = "Item";
+        private const string XML_ITEM_ATTRIB_ID = "ID";
+        private const int CURRENT_DATA_VERSION_INDEX = 1;
+
+        /// <summary>
+        /// Load a previously saved design-time user data for the current room.
+        /// </summary>
+        public static void LoadFromUserFile(Room room, RoomSettingsEditor editor)
+        {
+            string fileName = room.UserFileName;
+
+            // User file missing is a valid case, and we simply skip deserialization
+            if (!File.Exists(fileName))
+                return;
+
+            XmlNode docNode = null;
+            try
+            {
+                XmlDocument doc = new XmlDocument();
+                doc.Load(fileName);
+                // Copy header style from Game.agf and Game.agf.user
+                // TODO: unify all xml header read/write?
+                if (doc.DocumentElement.Name != XML_DATA_ROOT_NODE)
+                {
+                    throw new AGSEditorException("Invalid room user data file. The file was corrupted, edited by hand or saved by incompatible version of AGS.");
+                }
+                string userDataSavedWithEditorVersion = null;
+                XmlAttribute editorVersionNode = doc.DocumentElement.Attributes[AGSEditor.XML_ATTRIBUTE_EDITOR_VERSION];
+                if (editorVersionNode != null)
+                {
+                    userDataSavedWithEditorVersion = editorVersionNode.InnerText;
+                }
+                int? versionIndex = null;
+                XmlAttribute versionIndexNode = doc.DocumentElement.Attributes[AGSEditor.XML_ATTRIBUTE_VERSION_INDEX];
+                if (versionIndexNode != null)
+                    versionIndex = Convert.ToInt32(versionIndexNode.InnerText);
+                if (!versionIndex.HasValue || (versionIndex < 1) || (versionIndex > CURRENT_DATA_VERSION_INDEX))
+                {
+                    throw new AGSEditorException("This game's user data file is from " +
+                        ((userDataSavedWithEditorVersion == null) ? "a newer version" : ("version " + userDataSavedWithEditorVersion))
+                        + " of AGS or an unsupported beta version. Please check the AGS website for a newer version of the editor.");
+                }
+                docNode = doc.DocumentElement;
+            }
+            catch (Exception ex)
+            {
+                Factory.GUIController.ShowMessage("Unable to read the room design-time preferences. This SHOULD NOT affect the actual game data, but the design-time state of all room items will be reset." + Environment.NewLine + Environment.NewLine + "The error was: " + ex.Message, MessageBoxIcon.Warning);
+                return;
+            }
+
+            // Now do load data
+            LoadDataFromXML(room, editor, docNode);
+        }
+
+        private static void LoadDataFromXML(Room room, RoomSettingsEditor editor, XmlNode node)
+        {
+            if (node == null)
+                return;
+            node = node.SelectSingleNode(XML_ROOM_NODE);
+            if (node == null)
+                return;
+            node = node.SelectSingleNode(XML_ROOM_LAYERS_NODE);
+            if (node == null)
+                return;
+            // Search for the layer node, if they exist then read layer preferences
+            XmlNode collectionNode = node;
+            foreach (IRoomEditorFilter layer in editor.Layers)
+            {
+                node = collectionNode.SelectSingleNode(layer.Name);
+                if (node == null)
+                    continue;
+
+                // We do not have a distinct class which would only describe necessary fields,
+                // so we do this part by hand for now, trying to be compliant with SerializeUtils.
+                foreach (XmlNode child in node.ChildNodes)
+                {
+                    string elementName = child.Name;
+                    string elementValue = child.InnerText;
+                    if (elementName == XML_LAYER_ELEM_VISIBLE) layer.Visible = Convert.ToBoolean(elementValue);
+                    else if (elementName == XML_LAYER_ELEM_LOCKED) layer.Locked = Convert.ToBoolean(elementValue);
+                    else if (elementName == XML_LAYER_ITEMS_NODE)
+                    {
+                        foreach (XmlNode itemNode in child.ChildNodes)
+                        {
+                            string id = itemNode.Attributes[XML_ITEM_ATTRIB_ID].InnerText;
+                            if (string.IsNullOrEmpty(id))
+                                continue; // no ID, no way to apply the data
+                            DesignTimeProperties props;
+                            if (!layer.DesignItems.TryGetValue(id, out props))
+                                continue; // no matching item
+                            // Now read the design-time properties
+                            SerializeUtils.DeserializePropertiesFromXML(props, itemNode);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Save design-time user data for the current room.
+        /// </summary>
+        public static void SaveToUserFile(Room room, RoomSettingsEditor editor)
+        {
+            string fileName = room.UserFileName;
+
+            StringWriter sw = new StringWriter();
+            XmlTextWriter writer = new XmlTextWriter(sw);
+            // Copy header style from Game.agf and Game.agf.user
+            // TODO: unify all xml header read/write?
+            writer.Formatting = Formatting.Indented;
+            writer.WriteProcessingInstruction("xml", "version=\"1.0\" encoding=\"" + Encoding.Default.WebName + "\"");
+            writer.WriteComment("DO NOT EDIT THIS FILE. It is automatically generated by the AGS Editor, changing it manually could break your game");
+            writer.WriteStartElement(XML_DATA_ROOT_NODE);
+            writer.WriteAttributeString(AGSEditor.XML_ATTRIBUTE_VERSION_INDEX, CURRENT_DATA_VERSION_INDEX.ToString());
+            writer.WriteAttributeString(AGSEditor.XML_ATTRIBUTE_EDITOR_VERSION, AGS.Types.Version.AGS_EDITOR_FRIENDLY_VERSION);
+
+            SaveDataToXML(room, editor, writer);
+
+            writer.WriteEndElement(); // Root node
+            writer.Flush(); // Finish writing
+
+            try
+            {
+                StreamWriter fileOutput = new StreamWriter(fileName, false, Encoding.Default);
+                fileOutput.Write(sw.ToString());
+                fileOutput.Close();
+                writer.Close();
+            }
+            catch (Exception ex)
+            {
+                Factory.GUIController.ShowMessage("Unable to write the room design-time preferences. Ensure that you have write access to the game folder, and that the file is not already open.\n\n" + ex.Message, MessageBoxIcon.Warning);
+            }
+        }
+
+        private static void SaveDataToXML(Room room, RoomSettingsEditor editor, XmlTextWriter writer)
+        {
+            // We do not have a distinct class which would only describe necessary fields,
+            // so we do this part by hand for now, trying to be compliant with SerializeUtils.
+            writer.WriteStartElement(XML_ROOM_NODE);
+            writer.WriteStartElement(XML_ROOM_LAYERS_NODE);
+            foreach (IRoomEditorFilter layer in editor.Layers)
+            {
+                writer.WriteStartElement(layer.Name);
+                writer.WriteElementString(XML_LAYER_ELEM_VISIBLE, layer.Visible.ToString());
+                writer.WriteElementString(XML_LAYER_ELEM_LOCKED, layer.Locked.ToString());
+                writer.WriteStartElement(XML_LAYER_ITEMS_NODE);
+                foreach (var item in layer.DesignItems)
+                {
+                    writer.WriteStartElement(XML_LAYER_ITEM_NODE);
+                    writer.WriteAttributeString(XML_ITEM_ATTRIB_ID, item.Key);
+                    // Let our generic serializer handle this
+                    SerializeUtils.SerializePropertiesToXML(item.Value, writer);
+                    writer.WriteEndElement(); // item node
+                }
+                writer.WriteEndElement(); // Items collection node
+                writer.WriteEndElement(); // Layer node
+            }
+            writer.WriteEndElement(); // Layers collection node
+            writer.WriteEndElement(); // Room node
+        }
+    }
+}

--- a/Editor/AGS.Editor/Components/RoomDesignData.cs
+++ b/Editor/AGS.Editor/Components/RoomDesignData.cs
@@ -58,15 +58,14 @@ namespace AGS.Editor.Components
                         + " of AGS or an unsupported beta version. Please check the AGS website for a newer version of the editor.");
                 }
                 docNode = doc.DocumentElement;
+
+                // Now parse actual data
+                LoadDataFromXML(room, editor, docNode);
             }
             catch (Exception ex)
             {
                 Factory.GUIController.ShowMessage("Unable to read the room design-time preferences. This SHOULD NOT affect the actual game data, but the design-time state of all room items will be reset." + Environment.NewLine + Environment.NewLine + "The error was: " + ex.Message, MessageBoxIcon.Warning);
-                return;
             }
-
-            // Now do load data
-            LoadDataFromXML(room, editor, docNode);
         }
 
         private static void LoadDataFromXML(Room room, RoomSettingsEditor editor, XmlNode node)

--- a/Editor/AGS.Editor/Components/RoomDesignData.cs
+++ b/Editor/AGS.Editor/Components/RoomDesignData.cs
@@ -7,6 +7,24 @@ using AGS.Types;
 
 namespace AGS.Editor.Components
 {
+    /// <summary>
+    /// Manages serialization of the design-time room data.
+    /// -----------------------------------------------------------------------
+    /// [ivan-mogilko] As of now design-time information is stored separately
+    /// from the room objects, inside the IRoomEditorFilter classes. This is a
+    /// temporary solution based on @tzachshabtay's original UI code. Partially
+    /// the reason I kept this approach is that I was not confident in the best
+    /// direction at this time.
+    /// 
+    /// In the future it would be a good idea to develop a concept of a
+    /// design-time only properties "layer" over game objects. The question is
+    /// how these properties should be implemented. They could be added
+    /// directly in the entity classes, but in such case there has to be a way
+    /// to distinct which of the properties are serialized as a game data and
+    /// which as "user" data (property attributes?). On the other hand they
+    /// could be implemented as a separate class paired with game entity and
+    /// linked by some kind of a table, or attached otherwise (as component).
+    /// </summary>
     public static class RoomDesignData
     {
         private const string XML_DATA_ROOT_NODE = "AGSRoomUserData";
@@ -68,6 +86,12 @@ namespace AGS.Editor.Components
             }
         }
 
+        /// <summary>
+        /// Loads room user data from the given XML node.
+        /// </summary>
+        /// <param name="room"></param>
+        /// <param name="editor"></param>
+        /// <param name="node"></param>
         private static void LoadDataFromXML(Room room, RoomSettingsEditor editor, XmlNode node)
         {
             if (node == null)
@@ -150,6 +174,12 @@ namespace AGS.Editor.Components
             }
         }
 
+        /// <summary>
+        /// Saves room user data into the current XML node.
+        /// </summary>
+        /// <param name="room"></param>
+        /// <param name="editor"></param>
+        /// <param name="writer"></param>
         private static void SaveDataToXML(Room room, RoomSettingsEditor editor, XmlTextWriter writer)
         {
             // We do not have a distinct class which would only describe necessary fields,

--- a/Editor/AGS.Editor/Components/RoomDesignData.cs
+++ b/Editor/AGS.Editor/Components/RoomDesignData.cs
@@ -116,7 +116,7 @@ namespace AGS.Editor.Components
         /// <summary>
         /// Save design-time user data for the current room.
         /// </summary>
-        public static void SaveToUserFile(Room room, RoomSettingsEditor editor)
+        public static void SaveToUserFile(Room room, RoomSettingsEditor editor, CompileMessages errors)
         {
             string fileName = room.UserFileName;
 
@@ -145,7 +145,9 @@ namespace AGS.Editor.Components
             }
             catch (Exception ex)
             {
-                Factory.GUIController.ShowMessage("Unable to write the room design-time preferences. Ensure that you have write access to the game folder, and that the file is not already open.\n\n" + ex.Message, MessageBoxIcon.Warning);
+                // TODO: had to break long message into two separate warnings, because Output panel is not suited for line breaks.
+                errors.Add(new CompileWarning("Unable to write the room design-time preferences. Ensure that you have write access to the game folder, and that the file is not already open"));
+                errors.Add(new CompileWarning(ex.Message, ex));
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -216,6 +216,10 @@ namespace AGS.Editor.Components
             {
                 filesToDelete.Add(roomToDelete.ScriptFileName);
             }
+            if (File.Exists(roomToDelete.UserFileName))
+            {
+                filesToDelete.Add(roomToDelete.UserFileName);
+            }
 
             try
             {

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -144,6 +144,7 @@ namespace AGS.Editor
 		}
 
         public bool SupportVisibleItems { get { return false; } }
+        public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -100,6 +100,7 @@ namespace AGS.Editor
             InitGameEntities();
         }
 
+        public abstract string Name { get; }
         public abstract string DisplayName { get; }
 
         public SortedDictionary<string, DesignTimeProperties> DesignItems { get; private set; }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -376,6 +376,7 @@ namespace AGS.Editor
             }
         }
 
+        public string Name { get { return "Characters"; } }
         public string DisplayName { get { return "Characters"; } }
 
         public RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -385,6 +385,7 @@ namespace AGS.Editor
         }
 
         public bool SupportVisibleItems { get { return true; } }
+        public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -37,6 +37,7 @@ namespace AGS.Editor
             InitGameEntities();
         }
 
+        public string Name { get { return "Edges"; } }
         public string DisplayName { get { return "Edges"; } }
 
         public RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -52,6 +52,7 @@ namespace AGS.Editor
         private SortedDictionary<string, SelectedEdge> RoomItemRefs { get; set; }
 
         public bool SupportVisibleItems { get { return true; } }
+        public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -33,6 +33,7 @@ namespace AGS.Editor
         public SortedDictionary<string, DesignTimeProperties> DesignItems { get; private set; }
 
         public bool SupportVisibleItems { get { return false; } }
+        public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -22,6 +22,7 @@ namespace AGS.Editor
             DesignItems = new SortedDictionary<string, DesignTimeProperties>();
         }
 
+        public string Name { get { return "Nothing"; } }
         public string DisplayName { get { return "Nothing"; } }
 
         public RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -14,6 +14,7 @@ namespace AGS.Editor
         {
         }
 
+        public override string Name { get { return "Hotspots"; } }
         public override string DisplayName { get { return "Hotspots"; } }
 
         public override RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -9,6 +9,13 @@ namespace AGS.Editor
 {
     public interface IRoomEditorFilter : IDisposable
     {
+        /// <summary>
+        /// Internal ID of the filter.
+        /// </summary>
+        string Name { get; }
+        /// <summary>
+        /// Displayed name of the filter.
+        /// </summary>
         string DisplayName { get; }
         RoomAreaMaskType MaskToDraw { get; }
         int ItemCount { get; }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -25,6 +25,11 @@ namespace AGS.Editor
         bool SupportVisibleItems { get; }
 
         /// <summary>
+        /// Tells that the design-time properties of the layer or items were modified.
+        /// </summary>
+        bool Modified { get; set; }
+
+        /// <summary>
         /// Gets/sets if this layer is visible.
         /// </summary>
         bool Visible { get; set; }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -37,6 +37,7 @@ namespace AGS.Editor
             InitGameEntities();
         }
 
+        public string Name { get { return "Objects"; } }
         public string DisplayName { get { return "Objects"; } }
 
         public RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -46,6 +46,7 @@ namespace AGS.Editor
         }
 
         public bool SupportVisibleItems { get { return true; } }
+        public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
@@ -15,6 +15,7 @@ namespace AGS.Editor
         {
         }
 
+        public override string Name { get { return "Regions"; } }
         public override string DisplayName { get { return "Regions"; } }
 
         public override RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
@@ -18,6 +18,7 @@ namespace AGS.Editor
         {
         }
 
+        public override string Name { get { return "WalkBehinds"; } }
         public override string DisplayName { get { return "Walk-behinds"; } }
 
         public override RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
@@ -15,6 +15,7 @@ namespace AGS.Editor
         {
         }
 
+        public override string Name { get { return "WalkableAreas"; } }
         public override string DisplayName { get { return "Walkable areas"; } }
 
         public override RoomAreaMaskType MaskToDraw

--- a/Editor/AGS.Editor/Panes/Room/RoomEditNode.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditNode.cs
@@ -130,7 +130,8 @@ namespace AGS.Editor.Panes.Room
                     parentFilter.DesignItems[RoomItemID].Visible = _control.IsVisible;
                 else
                     Layer.Visible = _control.IsVisible;
-                parentFilter.Invalidate();
+                parentFilter.Modified = true;
+                parentFilter.Invalidate(); // repaint, since visibility changed
             }
         }
 
@@ -143,6 +144,7 @@ namespace AGS.Editor.Panes.Room
                     parentFilter.DesignItems[RoomItemID].Locked = _control.IsLocked;
                 else
                     Layer.Locked = _control.IsLocked;
+                parentFilter.Modified = true;
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -18,7 +18,7 @@ namespace AGS.Editor
     {
         private const int SCROLLBAR_WIDTH_BUFFER = 40;
 
-        public delegate bool SaveRoomHandler(Room room);
+        public delegate bool SaveRoomHandler(Room room, RoomSettingsEditor editor);
         public event SaveRoomHandler SaveRoom;
         public delegate void AbandonChangesHandler(Room room);
         public event AbandonChangesHandler AbandonChanges;
@@ -35,6 +35,12 @@ namespace AGS.Editor
         private int ZOOM_STEP_VALUE = 25;
         private int ZOOM_MAX_VALUE = 600;
         private RoomEditorState _state = new RoomEditorState();
+
+        /// <summary>
+        /// Room editor item layers.
+        /// </summary>
+        public IEnumerable<IRoomEditorFilter> Layers { get { return _layers; } }
+
 
         public RoomSettingsEditor(Room room)
         {
@@ -78,7 +84,13 @@ namespace AGS.Editor
             _editorConstructed = true;
         }
 
-        private void RefreshLayersTree()
+        /// <summary>
+        /// Update the breadcrumb navigation bar, make all nodes correspond to the design-time state
+        /// of the room layers and items.
+        /// </summary>
+        /// TODO: currently this is the only way to sync navbar with the design-time properties.
+        /// find a better solution, perhaps tie each DesignTimeProperties object to a bar node.
+        public void RefreshLayersTree()
         {
             IAddressNode currentNode = _editAddressBar.CurrentNode;
             IAddressNode[] layers = new IAddressNode[_layers.Count];
@@ -768,7 +780,7 @@ namespace AGS.Editor
                 {
                     if (SaveRoom != null)
                     {
-                        cancelClose = !SaveRoom(_room);
+                        cancelClose = !SaveRoom(_room, this);
                     }
                 }
                 else if (AbandonChanges != null)

--- a/Editor/AGS.Types/Interfaces/IRoom.cs
+++ b/Editor/AGS.Types/Interfaces/IRoom.cs
@@ -12,7 +12,8 @@ namespace AGS.Types
 		bool StateSaving { get; }
 		string ScriptFileName { get; }
 		Script Script { get; }
-		void LoadScript();
+        string UserFileName { get; }
+        void LoadScript();
         void UnloadScript();
 	}
 }

--- a/Editor/AGS.Types/SerializeUtils.cs
+++ b/Editor/AGS.Types/SerializeUtils.cs
@@ -59,9 +59,30 @@ namespace AGS.Types
             SerializeToXML(obj, writer, true);
         }
 
+        /// <summary>
+        /// Serializes whole object, creates parent node for its data.
+        /// Optionally may close the node or keep it open to let external code write more data into it.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="writer"></param>
+        /// <param name="writeEndElement"></param>
         public static void SerializeToXML(object obj, XmlTextWriter writer, bool writeEndElement)
         {
             writer.WriteStartElement(obj.GetType().Name);
+            SerializePropertiesToXML(obj, writer);
+            if (writeEndElement)
+            {
+                writer.WriteEndElement();
+            }
+        }
+
+        /// <summary>
+        /// Serializes properties of the object into the current node.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="writer"></param>
+        public static void SerializePropertiesToXML(object obj, XmlTextWriter writer)
+        {
             PropertyInfo[] properties = obj.GetType().GetProperties();
             foreach (PropertyInfo prop in properties)
             {
@@ -129,12 +150,13 @@ namespace AGS.Types
                     }
                 }
             }
-            if (writeEndElement)
-            {
-                writer.WriteEndElement();
-            }
         }
 
+        /// <summary>
+        /// Deserializes whole object from the node.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="node"></param>
         public static void DeserializeFromXML(object obj, XmlNode node)
         {
             XmlNode mainNode = node;
@@ -148,10 +170,20 @@ namespace AGS.Types
                 }
             }
 
+            DeserializePropertiesFromXML(obj, mainNode);
+        }
+
+        /// <summary>
+        /// Deserializes properties of the given object from the node.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="node"></param>
+        public static void DeserializePropertiesFromXML(object obj, XmlNode node)
+        {
             DeserializeIgnoreAttribute[] ignoreAttributes =
                 (DeserializeIgnoreAttribute[])obj.GetType().GetCustomAttributes(typeof(DeserializeIgnoreAttribute), true);
 
-            foreach (XmlNode child in mainNode.ChildNodes)
+            foreach (XmlNode child in node.ChildNodes)
             {
                 string elementValue = child.InnerText;
                 PropertyInfo prop = obj.GetType().GetProperty(child.Name);

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -11,6 +11,7 @@ namespace AGS.Types
     {
         private const string ROOM_FILE_NAME_FORMAT = "room{0}.crm";
         private const string ROOM_SCRIPT_FILE_NAME_FORMAT = "room{0}.asc";
+        private const string ROOM_USER_FILE_NAME_FORMAT = "room{0}.crm.user";
 
 		public const int NON_STATE_SAVING_INDEX = 300;
 		public const int HIGHEST_ROOM_NUMBER_ALLOWED = 999;
@@ -66,6 +67,13 @@ namespace AGS.Types
         public string FileName
         {
             get { return string.Format(ROOM_FILE_NAME_FORMAT, _number); }
+        }
+
+        [AGSNoSerialize]
+        [Browsable(false)]
+        public string UserFileName
+        {
+            get { return string.Format(ROOM_USER_FILE_NAME_FORMAT, _number); }
         }
 
 		[Description("Whether the state of the room is saved when the player leaves the room and comes back")]


### PR DESCRIPTION
This implements saving and restoring the design-time state of a room editor. At the moment that includes "visible" and "locked" flags for room layers and items, which are set using breadcrumb navigation bar.

Data is saved into XML file called "roomXXX.crm.user", where XXX is a room number (complementing "roomXXX.crm" room data file and "room.asc" script file).

Saving is done whenever room is saved, loading is performed right after main room data was loaded into the editor. I tried to comply to the main project data format.

Since this data is optional, the trivial checks are made that prevent attempts to apply data to non-existant layers and objects. If the file exists but could not be loaded or parsed a mere warning is displayed to user.

---

A few thoughts regarding potential compatibility issues. In my opinion these properties are not bound directly to the current UI and may be still useful and kept even if the UI is completely changed in the future. For the sake of the possible upgrade the XML is supplied with "format version" index. In the worst case these files may be safely dumped during game project upgrade, since the data they contain is for user convenience only and not cruicial for the game itself.