### PR TITLE
AGS 3: deprecate RoomObject.Locked property and use DesignTimeProperties instead

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -115,7 +115,7 @@
 #define OBJF_USEREGIONTINTS    8  // obey region tints/light areas
 #define OBJF_USEROOMSCALING 0x10  // obey room scaling areas
 #define OBJF_SOLID          0x20  // blocks characters from moving
-#define OBJF_LOCKED         0x40  // object position is locked in the editor
+#define OBJF_LEGACY_LOCKED  0x40  // object position is locked in the editor (OBSOLETE since 3.4.2)
 #define OBJF_HASLIGHT       0x80  // the tint_light is valid and treated as brightness
 
 #endif // __AC_DEFINES_H

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -4169,7 +4169,6 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
       obj->StartY += GetSpriteHeight(thisroom.sprs[i].sprnum);
 		obj->Visible = (thisroom.sprs[i].on != 0);
 		obj->Clickable = ((thisroom.objectFlags[i] & OBJF_NOINTERACT) == 0);
-		obj->Locked = ((thisroom.objectFlags[i] & OBJF_LOCKED) != 0);
 		obj->Baseline = thisroom.objbaseline[i];
 		obj->Name = gcnew String(jibbledScriptName);
 		obj->Description = gcnew String(thisroom.objectnames[i]);
@@ -4349,7 +4348,6 @@ void save_crm_file(Room ^room)
 		if (obj->UseRoomAreaScaling) thisroom.objectFlags[i] |= OBJF_USEROOMSCALING;
 		if (obj->UseRoomAreaLighting) thisroom.objectFlags[i] |= OBJF_USEREGIONTINTS;
 		if (!obj->Clickable) thisroom.objectFlags[i] |= OBJF_NOINTERACT;
-		if (obj->Locked) thisroom.objectFlags[i] |= OBJF_LOCKED;
 		CompileCustomProperties(obj->Properties, &thisroom.objProps[i]);
 	}
 

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -112,15 +112,6 @@ namespace AGS.Types
             set { _effectiveBaseline = value; }
         }
 
-        // TODO: perhaps separate into design-time entity?
-        [Description("Whether the object can be moved in the editor")]
-        [Category("Design")]
-        public bool Locked
-        {
-            get { return _locked; }
-            set { _locked = value; }
-        }
-
         [Description("X co-ordinate within the room of the left side of the object")]
         [Category("Design")]
         public int StartX


### PR DESCRIPTION
Since locking room items in the editor is done using general UI now, removed Locked property from the RoomObject class as unnecessary duplicate.

NOTE: this won't result in data format change, only one flag in the compiled room data will become deprecated.