### PR TITLE
Large file support

### DIFF
--- a/Common/ac/messageinfo.cpp
+++ b/Common/ac/messageinfo.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/messageinfo.h"
 #include "util/stream.h"
 

--- a/Common/ac/mousecursor.cpp
+++ b/Common/ac/mousecursor.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/mousecursor.h"
 #include "util/stream.h"
 

--- a/Common/ac/point.cpp
+++ b/Common/ac/point.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/point.h"
 #include "ac/common.h"    // quit()
 #include "util/stream.h"

--- a/Common/ac/roomstruct.cpp
+++ b/Common/ac/roomstruct.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/roomstruct.h"
 #include "ac/common.h"
 #include "ac/wordsdictionary.h"

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -22,6 +22,7 @@
 #pragma warning (disable: 4996 4312)  // disable deprecation warnings
 #endif
 
+#include <stdio.h> // sprintf
 #include "ac/common.h"
 #include "ac/spritecache.h"
 #include "core/assetmanager.h"

--- a/Common/ac/view.cpp
+++ b/Common/ac/view.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "ac/view.h"
 #include "util/alignedstream.h"

--- a/Common/ac/wordsdictionary.cpp
+++ b/Common/ac/wordsdictionary.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ac/wordsdictionary.h"

--- a/Common/api/stream_api.h
+++ b/Common/api/stream_api.h
@@ -48,8 +48,8 @@ public:
 
     virtual bool        IsValid() const = 0;
     virtual bool        EOS() const = 0;
-    virtual size_t      GetLength() const = 0;
-    virtual size_t      GetPosition() const = 0;
+    virtual soff_t      GetLength() const = 0;
+    virtual soff_t      GetPosition() const = 0;
     virtual bool        CanRead() const = 0;
     virtual bool        CanWrite() const = 0;
     virtual bool        CanSeek() const = 0;
@@ -81,7 +81,7 @@ public:
     virtual size_t      WriteArrayOfInt32(const int32_t *buffer, size_t count) = 0;
     virtual size_t      WriteArrayOfInt64(const int64_t *buffer, size_t count) = 0;
 
-    virtual size_t      Seek(int offset, StreamSeek origin = kSeekCurrent) = 0;
+    virtual soff_t      Seek(soff_t offset, StreamSeek origin = kSeekCurrent) = 0;
 };
 
 } // namespace Common

--- a/Common/core/types.h
+++ b/Common/core/types.h
@@ -81,6 +81,9 @@
 
 #endif // WINDOWS_VERSION
 
+// Stream offset type
+typedef int64_t soff_t;
+
 
 // Suppress override keyword for compilers that do not support it
 // TODO: this should be reviewed if project would demand C++11 or higher

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -16,7 +16,6 @@
 #define USE_ALFONT
 #endif
 
-#include <stdio.h>
 #include "alfont.h"
 
 #include "ac/common.h"

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -16,7 +16,6 @@
 #define USE_ALFONT
 #endif
 
-#include <stdio.h>
 #include "alfont.h"
 #include "ac/gamestructdefines.h" //FONT_OUTLINE_AUTO
 #include "core/assetmanager.h"

--- a/Common/script/cc_error.cpp
+++ b/Common/script/cc_error.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
 #include "cc_error.h"

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "cc_script.h"

--- a/Common/util/alignedstream.cpp
+++ b/Common/util/alignedstream.cpp
@@ -290,7 +290,7 @@ size_t AlignedStream::WriteArrayOfInt64(const int64_t *buffer, size_t count)
     return 0;
 }
 
-size_t AlignedStream::Seek(int offset, StreamSeek origin)
+soff_t AlignedStream::Seek(soff_t offset, StreamSeek origin)
 {
     // TODO: split out Seekable Stream interface
     assert(false); // aligned stream should not be used in cases

--- a/Common/util/alignedstream.h
+++ b/Common/util/alignedstream.h
@@ -84,7 +84,7 @@ public:
     virtual size_t  WriteArrayOfInt32(const int32_t *buffer, size_t count);
     virtual size_t  WriteArrayOfInt64(const int64_t *buffer, size_t count);
 
-    virtual size_t  Seek(int offset, StreamSeek origin);
+    virtual soff_t  Seek(soff_t offset, StreamSeek origin);
 
 protected:
     void            ReadPadding(size_t next_type);

--- a/Common/util/c99_snprintf.h
+++ b/Common/util/c99_snprintf.h
@@ -26,7 +26,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdio.h>
+#include <stdio.h> // sprintf
 
 #define snprintf c99_snprintf
 #define vsnprintf c99_vsnprintf

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "ac/common.h"	// quit()
 #include "ac/roomstruct.h"
@@ -28,7 +27,6 @@
 
 #include "util/misc.h"
 #include "util/stream.h"
-#include "util/filestream.h"
 #include "gfx/bitmap.h"
 
 using namespace AGS::Common;

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -204,8 +204,7 @@ int cunpackbitl(unsigned char *line, int size, Stream *in)
 
   while (n < size) {
     int ix = in->ReadByte();     // get index byte
-    // TODO: revise when new error handling system is implemented
-    if (ferror(((Common::FileStream*)in)->GetHandle()))
+    if (in->HasErrors())
       break;
 
     char cx = ix;
@@ -234,8 +233,7 @@ int cunpackbitl(unsigned char *line, int size, Stream *in)
     }
   }
 
-  // TODO: revise when new error handling system is implemented
-  return ferror(((Common::FileStream*)in)->GetHandle());
+  return in->HasErrors() ? -1 : 0;
 }
 
 int cunpackbitl16(unsigned short *line, int size, Stream *in)
@@ -244,8 +242,7 @@ int cunpackbitl16(unsigned short *line, int size, Stream *in)
 
   while (n < size) {
     int ix = in->ReadByte();     // get index byte
-    // TODO: revise when new error handling system is implemented
-    if (ferror(((Common::FileStream*)in)->GetHandle()))
+    if (in->HasErrors())
       break;
 
     char cx = ix;
@@ -274,8 +271,7 @@ int cunpackbitl16(unsigned short *line, int size, Stream *in)
     }
   }
 
-  // TODO: revise when new error handling system is implemented
-  return ferror(((Common::FileStream*)in)->GetHandle());
+  return in->HasErrors() ? -1 : 0;
 }
 
 int cunpackbitl32(unsigned int *line, int size, Stream *in)
@@ -284,8 +280,7 @@ int cunpackbitl32(unsigned int *line, int size, Stream *in)
 
   while (n < size) {
     int ix = in->ReadByte();     // get index byte
-    // TODO: revise when new error handling system is implemented
-    if (ferror(((Common::FileStream*)in)->GetHandle()))
+    if (in->HasErrors())
       break;
 
     char cx = ix;
@@ -314,8 +309,7 @@ int cunpackbitl32(unsigned int *line, int size, Stream *in)
     }
   }
 
-  // TODO: revise when new error handling system is implemented
-  return ferror(((Common::FileStream*)in)->GetHandle());
+  return in->HasErrors() ? -1 : 0;
 }
 
 //=============================================================================

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -15,7 +15,6 @@
 #ifndef __AC_COMPRESS_H
 #define __AC_COMPRESS_H
 
-#include <stdio.h>
 #include "util/wgt2allg.h" // color (allegro RGB)
 
 namespace AGS { namespace Common { class Stream; class Bitmap; } }

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -23,15 +23,24 @@
 #include "util/file.h"
 #include "util/filestream.h"
 
+#if defined(_MSC_VER) // MSVC
+    #define stat_t      _stat64
+    #define stat_fn     _stati64
+#else
+    #define stat_t      stat
+    #define stat_fn     stat
+#endif
+
+
 namespace AGS
 {
 namespace Common
 {
 
-int File::GetFileSize(const String &filename)
+soff_t File::GetFileSize(const String &filename)
 {
-    struct stat st;
-    if (stat(filename, &st) == 0)
+    struct stat_t st;
+    if (stat_fn(filename, &st) == 0)
         return st.st_size;
     return -1;
 }

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -18,19 +18,9 @@
 #include <unistd.h> // for unlink()
 #endif
 #include <errno.h>
-#include <stdio.h>
-#include <sys/stat.h>
 #include "util/file.h"
 #include "util/filestream.h"
-
-#if defined(_MSC_VER) // MSVC
-    #define stat_t      _stat64
-    #define stat_fn     _stati64
-#else
-    #define stat_t      stat
-    #define stat_fn     stat
-#endif
-
+#include "util/stdio_compat.h"
 
 namespace AGS
 {

--- a/Common/util/file.h
+++ b/Common/util/file.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_CN_UTIL__FILE_H
 #define __AGS_CN_UTIL__FILE_H
 
+#include "api/stream_api.h"
 #include "util/string.h"
 
 namespace AGS
@@ -45,7 +46,7 @@ enum FileWorkMode
 namespace File
 {
     // Returns size of a file, or -1 if no such file found
-    int         GetFileSize(const String &filename);
+    soff_t      GetFileSize(const String &filename);
     // Tests if file could be opened for reading
     bool        TestReadFile(const String &filename);
     // Opens a file for writing or creates new one if it does not exist; deletes file if it was created during test

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -50,6 +50,11 @@ FileStream::~FileStream()
     Close();
 }
 
+bool FileStream::HasErrors() const
+{
+    return IsValid() && ferror(_file) != 0;
+}
+
 void FileStream::Close()
 {
     if (_file)

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -12,22 +12,10 @@
 //
 //=============================================================================
 
-#if defined(WINDOWS_VERSION)
-#include <io.h>
-#endif
 #include <stdio.h>
 #include "util/filestream.h"
 #include "util/math.h"
 
-// TODO: use fstat on Windows too?
-#if !defined (WINDOWS_VERSION)
-#include <sys/stat.h>
-long int filelength(int fhandle)
-{
-    struct stat statbuf;
-    fstat(fhandle, &statbuf);
-    return statbuf.st_size;
-}
 #endif
 
 namespace AGS
@@ -87,8 +75,11 @@ size_t FileStream::GetLength() const
 {
     if (IsValid())
     {
-        long len = filelength(fileno(_file));
-        return len > 0 ? (size_t)len : 0;
+        size_t pos = (size_t)ftell(_file);
+        fseek(_file, 0, SEEK_END);
+        size_t end = (size_t)ftell(_file);
+        fseek(_file, pos, SEEK_SET);
+        return end;
     }
 
     return 0;

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -12,22 +12,8 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "util/filestream.h"
 #include "util/math.h"
-
-#if defined(HAVE_FSEEKO) // Contemporary POSIX libc
-    #define file_off_t  off_t
-    #define fseek       fseeko
-    #define ftell       ftello
-#elif defined(_MSC_VER) // MSVC
-    #define file_off_t  __int64
-    #define fseek       _fseeki64
-    #define ftell       _ftelli64
-#else // No distinct interface with off_t
-    #define file_off_t  long
-#endif
-
 
 namespace AGS
 {

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -18,9 +18,9 @@
 #ifndef __AGS_CN_UTIL__FILESTREAM_H
 #define __AGS_CN_UTIL__FILESTREAM_H
 
-#include <stdio.h>
 #include "util/datastream.h"
 #include "util/file.h"
+#include "util/stdio_compat.h"
 
 namespace AGS
 {

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -34,6 +34,7 @@ public:
         DataEndianess stream_endianess = kLittleEndian);
     virtual ~FileStream();
 
+    virtual bool    HasErrors() const;
     virtual void    Close();
     virtual bool    Flush();
 

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -51,9 +51,9 @@ public:
     // Is end of stream
     virtual bool    EOS() const;
     // Total length of stream (if known)
-    virtual size_t  GetLength() const;
+    virtual soff_t  GetLength() const;
     // Current position (if known)
-    virtual size_t  GetPosition() const;
+    virtual soff_t  GetPosition() const;
     virtual bool    CanRead() const;
     virtual bool    CanWrite() const;
     virtual bool    CanSeek() const;
@@ -63,7 +63,7 @@ public:
     virtual size_t  Write(const void *buffer, size_t size);
     virtual int32_t WriteByte(uint8_t b);
 
-    virtual size_t  Seek(int offset, StreamSeek origin);
+    virtual soff_t  Seek(soff_t offset, StreamSeek origin);
 
 protected:
     void            Open(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode);

--- a/Common/util/lzw.cpp
+++ b/Common/util/lzw.cpp
@@ -18,7 +18,6 @@
 
 #define MSS
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "ac/common.h"
 #include "util/stream.h"

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -41,9 +41,15 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "allegro.h"
+#if !defined (WINDOWS_VERSION)
+#include <unistd.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/stat.h>
+#endif
+#include <allegro.h>
 #include "util/misc.h"
-#include "util/filestream.h"
+#include "util/stdio_compat.h"
 
 using AGS::Common::Stream;
 

--- a/Common/util/misc.h
+++ b/Common/util/misc.h
@@ -44,15 +44,6 @@
 #ifndef __MISC_H
 #define __MISC_H
 
-#include <stdio.h>
-
-#if !defined (WINDOWS_VERSION)
-#include <unistd.h>
-#include <dirent.h>
-#include <string.h>
-#include <sys/stat.h>
-#endif
-
 #include "util/file.h"
 
 namespace AGS { namespace Common { class Stream; } }

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -1,11 +1,10 @@
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #if defined (WINDOWS_VERSION)
 #include <windows.h>
 #endif
-#include "util/path.h"
 #include "allegro/file.h"
+#include "util/path.h"
+#include "util/stdio_compat.h"
 
 // TODO: implement proper portable path length
 #ifndef MAX_PATH
@@ -22,10 +21,10 @@ namespace Path
 
 bool IsDirectory(const String &filename)
 {
-    struct stat st;
+    struct stat_t st;
     // stat() does not like trailing slashes, remove them
     String fixed_path = MakePathNoSlash(filename);
-    if (stat(fixed_path, &st) == 0)
+    if (stat_fn(fixed_path, &st) == 0)
     {
         return (st.st_mode & S_IFMT) == S_IFDIR;
     }
@@ -34,8 +33,8 @@ bool IsDirectory(const String &filename)
 
 bool IsFile(const String &filename)
 {
-    struct stat st;
-    if (stat(filename, &st) == 0)
+    struct stat_t st;
+    if (stat_fn(filename, &st) == 0)
     {
         return (st.st_mode & S_IFMT) == S_IFREG;
     }

--- a/Common/util/proxystream.cpp
+++ b/Common/util/proxystream.cpp
@@ -45,12 +45,12 @@ bool ProxyStream::EOS() const
     return _stream ? _stream->EOS() : true;
 }
 
-size_t ProxyStream::GetLength() const
+soff_t ProxyStream::GetLength() const
 {
     return _stream ? _stream->GetLength() : 0;
 }
 
-size_t ProxyStream::GetPosition() const
+soff_t ProxyStream::GetPosition() const
 {
     return _stream ? _stream->GetPosition() : -1;
 }
@@ -160,7 +160,7 @@ size_t ProxyStream::WriteArrayOfInt64(const int64_t *buffer, size_t count)
     return _stream ? _stream->WriteArrayOfInt64(buffer, count) : 0;
 }
 
-size_t ProxyStream::Seek(int offset, StreamSeek origin)
+soff_t ProxyStream::Seek(soff_t offset, StreamSeek origin)
 {
     return _stream ? _stream->Seek(offset, origin) : -1;
 }

--- a/Common/util/proxystream.h
+++ b/Common/util/proxystream.h
@@ -46,9 +46,9 @@ public:
     // Is end of stream
     virtual bool    EOS() const;
     // Total length of stream (if known)
-    virtual size_t  GetLength() const;
+    virtual soff_t  GetLength() const;
     // Current position (if known)
-    virtual size_t  GetPosition() const;
+    virtual soff_t  GetPosition() const;
 
     virtual bool    CanRead() const;
     virtual bool    CanWrite() const;
@@ -74,7 +74,7 @@ public:
     virtual size_t  WriteArrayOfInt32(const int32_t *buffer, size_t count);
     virtual size_t  WriteArrayOfInt64(const int64_t *buffer, size_t count);
 
-    virtual size_t  Seek(int offset, StreamSeek origin);
+    virtual soff_t  Seek(soff_t offset, StreamSeek origin);
 
 protected:
     Stream                  *_stream;

--- a/Common/util/stdio_compat.h
+++ b/Common/util/stdio_compat.h
@@ -1,0 +1,43 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__STDIOCOMPAT_H
+#define __AGS_CN_UTIL__STDIOCOMPAT_H
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+// 64-bit fseek/ftell
+#if defined(HAVE_FSEEKO) // Contemporary POSIX libc
+#define file_off_t  off_t
+#define fseek       fseeko
+#define ftell       ftello
+#elif defined(_MSC_VER) // MSVC
+#define file_off_t  __int64
+#define fseek       _fseeki64
+#define ftell       _ftelli64
+#else // No distinct interface with off_t
+#define file_off_t  long
+#endif
+
+// 64-bit stat support for MSVC
+#if defined(_MSC_VER) // MSVC
+#define stat_t      _stat64
+#define stat_fn     _stati64
+#else
+#define stat_t      stat
+#define stat_fn     stat
+#endif
+
+#endif // __AGS_CN_UTIL__STDIOCOMPAT_H

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -34,6 +34,8 @@ namespace Common
 class Stream : public IAGSStream
 {
 public:
+    // Tells if the stream has errors
+    virtual bool HasErrors() const { return false; }
     // Flush stream buffer to the underlying device
     virtual bool Flush() = 0;
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 
-#include <stdio.h>
+#include <stdio.h> // sprintf
 #include <stdlib.h>
 #include <string.h>
 #include "debug/assert.h"

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -18,7 +18,6 @@
 #ifndef __AGS_CN_UTIL__STRINGUTILS_H
 #define __AGS_CN_UTIL__STRINGUTILS_H
 
-#include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
 

--- a/Common/util/textreader.h
+++ b/Common/util/textreader.h
@@ -35,11 +35,11 @@ public:
     // Read single character
     virtual char    ReadChar()              = 0;
     // Read defined number of characters
-    virtual String ReadString(int length)  = 0;
+    virtual String  ReadString(size_t length) = 0;
     // Read till line break
-    virtual String ReadLine()              = 0;
+    virtual String  ReadLine()              = 0;
     // Read till end of available data
-    virtual String ReadAll()               = 0;
+    virtual String  ReadAll()               = 0;
 };
 
 } // namespace Common

--- a/Common/util/textstreamreader.cpp
+++ b/Common/util/textstreamreader.cpp
@@ -68,7 +68,7 @@ char TextStreamReader::ReadChar()
     return '\0';
 }
 
-String TextStreamReader::ReadString(int length)
+String TextStreamReader::ReadString(size_t length)
 {
     if (!_stream)
     {
@@ -144,7 +144,8 @@ String TextStreamReader::ReadAll()
 {
     if (_stream)
     {
-        return ReadString(_stream->GetLength() - _stream->GetPosition());
+        soff_t len = _stream->GetLength() - _stream->GetPosition();
+        return ReadString(len > SIZE_MAX ? SIZE_MAX : (size_t)len);
     }
     return "";
 }

--- a/Common/util/textstreamreader.h
+++ b/Common/util/textstreamreader.h
@@ -44,11 +44,11 @@ public:
     // Read single character
     virtual char    ReadChar();
     // Read defined number of characters
-    virtual String ReadString(int length);
+    virtual String  ReadString(size_t length);
     // Read till line break
-    virtual String ReadLine();
+    virtual String  ReadLine();
     // Read till end of available data
-    virtual String ReadAll();
+    virtual String  ReadAll();
 
 private:
     Stream *_stream;

--- a/Common/util/textstreamwriter.cpp
+++ b/Common/util/textstreamwriter.cpp
@@ -13,7 +13,7 @@
 //=============================================================================
 
 #include <stdarg.h>
-#include <stdio.h>
+#include <stdio.h> // sprintf
 #include "util/textstreamwriter.h"
 #include "util/stream.h"
 

--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -1,6 +1,6 @@
 INCDIR = ../Engine ../Common ../Common/libinclude ../Plugins
 LIBDIR =
-CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(shell pkg-config --cflags freetype2) $(CFLAGS)
+CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -D_FILE_OFFSET_BITS=64 -DHAVE_FSEEKO -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(shell pkg-config --cflags freetype2) $(CFLAGS)
 CXXFLAGS := -std=c++11 -fno-rtti -Wno-write-strings $(CXXFLAGS)
 LIBS := -rdynamic -laldmb -ldumb -Wl,-Bdynamic
 LIBS += $(shell pkg-config --libs allegro)

--- a/Engine/Makefile-defs.osx
+++ b/Engine/Makefile-defs.osx
@@ -1,6 +1,6 @@
 INCDIR = ../Engine ../Common ../Common/libinclude ../Plugins /sw/include /sw/lib/freetype2/include /sw/lib/freetype2/include/freetype2
 LIBDIR = /sw/lib /sw/lib/freetype2/lib
-CFLAGS = -m32 -O2 -g -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DALLEGRO_STATICLINK -DMAC_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT
+CFLAGS = -m32 -O2 -g -Wfatal-errors -DNDEBUG -DAGS_RUNTIME_PATCH_ALLEGRO -DALLEGRO_STATICLINK -D_FILE_OFFSET_BITS=64 -DHAVE_FSEEKO -DMAC_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT
 CXXFLAGS = -std=c++11 -fno-rtti -Wno-write-strings $(CXXFLAGS)
 ASFLAGS = $(CFLAGS)
 LIBS = -m32 -framework Cocoa -lalleg-main -lalleg -laldmb -ldumb -ltheora -logg -lvorbis -lvorbisfile -lfreetype -logg -lz -ldl -lpthread -lm -lc -lstdc++

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/dialog.h"
 #include "ac/common.h"
 #include "ac/character.h"

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/draw.h"
 #include "ac/drawingsurface.h"
 #include "ac/common.h"

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <string.h>
 #include "cc_dynamicarray.h"
 

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -26,7 +26,6 @@
 
 //#define DEBUG_MANAGED_OBJECTS
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ac/dynobj/cc_dynamicobject.h"

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <string.h>
 #include "ac/dynobj/cc_serializer.h"
 #include "ac/dynobj/all_dynamicclasses.h"

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ac/dynobj/managedobjectpool.h"

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "event.h"
 #include "ac/common.h"
 #include "ac/draw.h"

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -81,7 +81,7 @@
 #include "script/script_runtime.h"
 #include "util/alignedstream.h"
 #include "util/directory.h"
-#include "util/filestream.h"
+#include "util/filestream.h" // TODO: needed only because plugins expect file handle
 #include "util/path.h"
 #include "util/string_utils.h"
 

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/common.h"
 #include "ac/game.h"
 #include "ac/gamesetup.h"

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -16,7 +16,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/global_character.h"
 #include "ac/common.h"
 #include "ac/view.h"

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/global_debug.h"
 #include "ac/common.h"
 #include "ac/characterinfo.h"

--- a/Engine/ac/global_display.cpp
+++ b/Engine/ac/global_display.cpp
@@ -13,7 +13,6 @@
 //=============================================================================
 
 #include <stdarg.h>
-#include <stdio.h>
 #include "ac/common.h"
 #include "ac/character.h"
 #include "ac/display.h"

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/common.h"
 #include "ac/display.h"
 #include "ac/draw.h"

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -107,7 +107,7 @@ int FileIsEOF (int32_t handle) {
     return 1;
 
   // TODO: stream errors
-  if (ferror (((Common::FileStream*)stream)->GetHandle()))
+  if (stream->HasErrors())
     return 1;
 
   if (stream->GetPosition () >= stream->GetLength())
@@ -118,7 +118,7 @@ int FileIsError(int32_t handle) {
   Stream *stream = get_valid_file_stream_from_handle(handle,"FileIsError");
 
   // TODO: stream errors
-  if (ferror(((Common::FileStream*)stream)->GetHandle()))
+  if (stream->HasErrors())
     return 1;
 
   return 0;

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -19,7 +19,7 @@
 #include "ac/path_helper.h"
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
-#include "util/filestream.h"
+#include "util/stream.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -13,7 +13,6 @@
 //=============================================================================
 
 #define USE_CLIB
-#include <stdio.h>
 #include "ac/global_game.h"
 #include "ac/common.h"
 #include "ac/view.h"

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/global_object.h"
 #include "ac/common.h"
 #include "ac/object.h"

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/global_overlay.h"
 #include "ac/common.h"
 #include "ac/display.h"

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/global_region.h"
 #include "ac/common.h"
 #include "ac/draw.h"

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/gui.h"
 #include "ac/common.h"
 #include "ac/draw.h"

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/common.h"
 #include "ac/guicontrol.h"
 #include "ac/global_gui.h"

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -13,7 +13,6 @@
 //=============================================================================
 
 #include <set>
-#include <stdio.h>
 #include "ac/listbox.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/overlay.h"
 #include "ac/common.h"
 #include "ac/view.h"

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -29,7 +29,7 @@
 #include "util/string_utils.h"
 #include "gfx/gfxfilter.h"
 #include "device/mousew32.h"
-#include "util/filestream.h"
+#include "util/file.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "ac/roomobject.h"
 #include "ac/common.h"
 #include "ac/common_defines.h"

--- a/Engine/debug/consoleoutputtarget.cpp
+++ b/Engine/debug/consoleoutputtarget.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <string.h>
 #include "consoleoutputtarget.h"
 #include "debug/debug_log.h"

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -13,7 +13,6 @@
 //=============================================================================
 
 #include <memory>
-#include <stdio.h>
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/roomstruct.h"
@@ -32,7 +31,6 @@
 #include "script/script.h"
 #include "script/script_common.h"
 #include "script/cc_error.h"
-#include "util/filestream.h"
 #include "util/textstreamwriter.h"
 
 using namespace AGS::Common;

--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -14,7 +14,7 @@
 
 #include "debug/filebasedagsdebugger.h"
 #include "ac/file.h"                    // filelength()
-#include "util/filestream.h"
+#include "util/stream.h"
 #include "util/textstreamwriter.h"
 #include "util/wgt2allg.h"              // exists()
 

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -27,8 +27,6 @@
 #include <process.h>
 #endif
 
-#include <stdio.h>
-
 #include "util/wgt2allg.h"
 
 #ifndef TRUE

--- a/Engine/gfx/gfxfilter_allegro.cpp
+++ b/Engine/gfx/gfxfilter_allegro.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "gfx/gfxfilter_allegro.h"
 
 namespace AGS

--- a/Engine/gfx/gfxfilter_d3d.cpp
+++ b/Engine/gfx/gfxfilter_d3d.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "gfx/gfxfilter_d3d.h"
 #ifdef WINDOWS_VERSION
 #include <d3d9.h>

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "gui/guidialog.h"
 #include "ac/common.h"
 #include "ac/draw.h"

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -29,7 +29,6 @@
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/override_defines.h" //_getcwd()
 #include "util/directory.h"
-#include "util/filestream.h"
 #include "util/ini_util.h"
 #include "util/textstreamreader.h"
 #include "util/path.h"

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -53,7 +53,6 @@
 #include "main/main_allegro.h"
 #include "media/audio/sound.h"
 #include "ac/spritecache.h"
-#include "util/filestream.h"
 #include "gfx/graphicsdriver.h"
 #include "core/assetmanager.h"
 #include "util/misc.h"

--- a/Engine/main/mainheader.h
+++ b/Engine/main/mainheader.h
@@ -21,7 +21,6 @@
 #include "main/maindefines_ex.h"
 
 #define USE_CLIB
-#include <stdio.h>
 #include "ac/math.h"
 #include "script/script_runtime.h"
 #include "gui/animatingguibutton.h"

--- a/Engine/main/minidump.cpp
+++ b/Engine/main/minidump.cpp
@@ -12,10 +12,9 @@
 //
 //=============================================================================
 
-#include <stdio.h>
-
 #ifdef WINDOWS_VERSION
 #define UNICODE
+#include <stdio.h> // sprintf
 #include "windows.h"
 #include <crtdbg.h>
 #include "main/main.h"

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "util/wgt2allg.h"
 #include "media/audio/audio.h"
 #include "ac/gamesetupstruct.h"

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "video.h"
 #include "apeg.h"
 #include "debug/debug_log.h"

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -16,7 +16,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include "util/wgt2allg.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/common.h"

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -18,7 +18,6 @@
 
 // ********* WINDOWS *********
 
-#include <stdio.h>
 #include <string.h>
 #include <allegro.h>
 #include <allegro/platform/aintwin.h>

--- a/Engine/platform/windows/debug/namedpipesagsdebugger.cpp
+++ b/Engine/platform/windows/debug/namedpipesagsdebugger.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 
-#include <stdio.h>
+#include <stdio.h> // sprintf
 #include "platform/windows/debug/namedpipesagsdebugger.h"
 
 void NamedPipesAGSDebugger::SendAcknowledgement()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -18,7 +18,6 @@
 
 #include <allegro.h>
 #include <allegro/platform/aintwin.h>
-#include <stdio.h>
 #include "debug/assert.h"
 #include "debug/out.h"
 #include "gfx/ali3dexception.h"

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -23,7 +23,6 @@
 #include <winalleg.h>
 #include <windows.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <amstream.h>
 #include <mmstream.h>	// Multimedia stream interfaces
 #include <ddstream.h>	// DirectDraw multimedia stream interfaces

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -18,7 +18,6 @@
 //=============================================================================
 
 //#define ALLEGRO_STATICLINK  // already defined in project settings
-#include <stdio.h>
 #include <allegro.h>
 #include <winalleg.h>
 #include <allegro/platform/aintwin.h>

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <string.h>
 #include "ac/common.h"
 #include "ac/event.h"

--- a/Engine/script/script_api.cpp
+++ b/Engine/script/script_api.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <string.h>
 #include "ac/game_version.h"
 #include "script/cc_error.h"

--- a/Engine/script/script_engine.cpp
+++ b/Engine/script/script_engine.cpp
@@ -21,12 +21,12 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "ac/roomstruct.h"
-#include "util/filestream.h"
 #include "script/cc_instance.h"
 #include "script/cc_error.h"
+#include "util/file.h"
+#include "util/stream.h"
 
 using namespace AGS::Common;
 
@@ -91,7 +91,7 @@ void load_graphical_scripts(Stream *in, roomstruct * rst)
 
         char thisscn[20];
         sprintf(thisscn, scripttempn, ct);
-        Stream *te = Common::File::CreateFile(thisscn);
+        Stream *te = File::CreateFile(thisscn);
 
         char *scnf = (char *)malloc(lee);
         // MACPORT FIX: swap size and nmemb

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -24,7 +24,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>

--- a/Engine/script/systemimports.cpp
+++ b/Engine/script/systemimports.cpp
@@ -12,7 +12,6 @@
 //
 //=============================================================================
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "script/systemimports.h"

--- a/Engine/test/test_file.cpp
+++ b/Engine/test/test_file.cpp
@@ -14,11 +14,10 @@
 
 #ifdef _DEBUG
 
-#include <stdio.h>
 #include <string.h>
-#include "util/alignedstream.h"
-#include "util/filestream.h"
 #include "debug/assert.h"
+#include "util/alignedstream.h"
+#include "util/file.h"
 
 using namespace AGS::Common;
 

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -14,7 +14,6 @@
 
 #ifdef _DEBUG
 
-#include <stdio.h>
 #include <string.h>
 #include "util/path.h"
 #include "util/string.h"

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -352,6 +352,7 @@
     <ClInclude Include="..\..\Common\util\multifilelib.h" />
     <ClInclude Include="..\..\Common\util\path.h" />
     <ClInclude Include="..\..\Common\util\proxystream.h" />
+    <ClInclude Include="..\..\Common\util\stdio_compat.h" />
     <ClInclude Include="..\..\Common\util\stdtr1compat.h" />
     <ClInclude Include="..\..\Common\util\stream.h" />
     <ClInclude Include="..\..\Common\util\string.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -538,5 +538,8 @@
     <ClInclude Include="..\..\Common\util\error.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\stdio_compat.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This implements large file (64-bit offsets) support in the AGS engine.

I used SDL2 rwops code for the reference to define different variants of function names. This works on MS Windows but I'd need help setting this up for ports. For example, is it safe to declare HAVE_FSEEKO64 in the Linux Makefile as a default?