### PR TITLE
AGS 3: updated data formats to make use of 64-bit file offsets

### DIFF
--- a/Common/ac/roomstruct.cpp
+++ b/Common/ac/roomstruct.cpp
@@ -166,7 +166,7 @@ int usesmisccond = 0;
 void load_main_block(roomstruct *rstruc, const char *files, Stream *in, room_file_header rfh) {
   int   f, gsmod, NUMREAD;
   char  buffre[3000];
-  long  tesl;
+  soff_t tesl;
 
   usesmisccond = 0;
   rstruc->width = 320;
@@ -601,7 +601,7 @@ void load_room(const char *files, roomstruct *rstruc, bool gameIsHighRes) {
   }
 
   int   thisblock = 0;
-  int   bloklen;
+  soff_t bloklen;
 
   while (thisblock != BLOCKTYPE_EOF) {
     update_polled_stuff_if_runtime();
@@ -610,7 +610,10 @@ void load_room(const char *files, roomstruct *rstruc, bool gameIsHighRes) {
     if (thisblock == BLOCKTYPE_EOF)
       break;
 
-    bloklen = opty->ReadInt32();
+    if (rfh.version < kRoomVersion_3422)
+        bloklen = opty->ReadInt32();
+    else
+        bloklen = opty->ReadInt64();
     bloklen += opty->GetPosition();  // make it the new position for after block read
 
     if (thisblock == BLOCKTYPE_MAIN)
@@ -665,7 +668,7 @@ void load_room(const char *files, roomstruct *rstruc, bool gameIsHighRes) {
     }
     else if (thisblock == BLOCKTYPE_ANIMBKGRND) {
       int   ct;
-      long  fpos;
+      soff_t fpos;
 
       rstruc->num_bscenes = opty->ReadByte();
       rstruc->bscene_anim_speed = opty->ReadByte();

--- a/Common/ac/roomstruct.h
+++ b/Common/ac/roomstruct.h
@@ -57,6 +57,7 @@ using AGS::Common::InteractionVariable;
 29:  v3.0.3 - high-res coords for object x/y, edges and hotspot walk-to point
 30:  v3.4.0.4 - tint luminance for regions
 31:  v3.4.1.5 - removed room object and hotspot name length limits
+32:  v3.4.2.2 - 64-bit file offsets
 */
 enum RoomFileVersion
 {
@@ -89,7 +90,8 @@ enum RoomFileVersion
     kRoomVersion_303b       = 29,
     kRoomVersion_3404       = 30,
     kRoomVersion_3415       = 31,
-    kRoomVersion_Current    = kRoomVersion_3415
+    kRoomVersion_3422       = 32,
+    kRoomVersion_Current    = kRoomVersion_3422
 };
 
 // thisroom.options[0] = startup music

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -47,6 +47,24 @@ extern int spritewidth[], spriteheight[];
 const char *spindexid = "SPRINDEX";
 const char *spindexfilename = "sprindex.dat";
 
+// TODO: research old version differences
+enum SpriteFileVersion
+{
+    kSprfVersion_Uncompressed   = 4,
+    kSprfVersion_Compressed     = 5,
+    kSprfVersion_Last32bit      = 6,
+    kSprfVersion_64bit          = 10,
+    kSprfVersion_Current        = kSprfVersion_64bit
+};
+
+enum SpriteIndexFileVersion
+{
+    kSpridxfVersion_Initial     = 1,
+    kSpridxfVersion_Last32bit   = 2,
+    kSpridxfVersion_64bit       = 10,
+    kSpridxfVersion_Current     = kSpridxfVersion_64bit
+};
+
 
 SpriteCache::SpriteCache(int32_t maxElements)
 {
@@ -68,12 +86,12 @@ void SpriteCache::changeMaxSize(int32_t maxElements) {
     free(sizes);
     free(flags);
   }
-  offsets = (int32_t *)calloc(elements, sizeof(int32_t));
-  memset(offsets, 0, elements*sizeof(int32_t));
+  offsets = (soff_t *)calloc(elements, sizeof(soff_t));
+  memset(offsets, 0, elements*sizeof(soff_t));
   images = (Bitmap **) calloc(elements, sizeof(Bitmap *));
   mrulist = (int *)calloc(elements, sizeof(int));
   mrubacklink = (int *)calloc(elements, sizeof(int));
-  sizes = (int *)calloc(elements, sizeof(int));
+  sizes = (soff_t *)calloc(elements, sizeof(soff_t));
   flags = (unsigned char *)calloc(elements, sizeof(unsigned char));
 }
 
@@ -137,11 +155,11 @@ int SpriteCache::enlargeTo(int32_t newsize) {
 
   int elementsWas = elements;
   elements = newsize;
-  offsets = (int32_t *)realloc(offsets, elements * sizeof(int32_t));
+  offsets = (soff_t *)realloc(offsets, elements * sizeof(soff_t));
   images = (Bitmap **)realloc(images, elements * sizeof(Bitmap *));
   mrulist = (int *)realloc(mrulist, elements * sizeof(int));
   mrubacklink = (int *)realloc(mrubacklink, elements * sizeof(int));
-  sizes = (int *)realloc(sizes, elements * sizeof(int));
+  sizes = (soff_t *)realloc(sizes, elements * sizeof(soff_t));
   flags = (unsigned char*)realloc(flags, elements * sizeof(unsigned char));
 
   for (int i = elementsWas; i < elements; i++) {
@@ -314,7 +332,7 @@ void SpriteCache::precache(int index)
   if ((index < 0) || (index >= elements))
     return;
 
-  int sprSize = 0;
+  soff_t sprSize = 0;
 
   if (images[index] == NULL) {
     sprSize = loadSprite(index);
@@ -339,7 +357,7 @@ void SpriteCache::seekToSprite(int index) {
       cache_stream->Seek(offsets[index], kSeekBegin);
 }
 
-int SpriteCache::loadSprite(int index)
+soff_t SpriteCache::loadSprite(int index)
 {
   int hh = 0;
 
@@ -415,7 +433,7 @@ int SpriteCache::loadSprite(int index)
   lastLoad = index;
 
   // Stop it adding the sprite to the used list just because it's loaded
-  int32_t offs = offsets[index];
+  soff_t offs = offsets[index];
   offsets[index] = SPRITE_LOCKED;
 
   initialize_sprite(index);
@@ -429,7 +447,7 @@ int SpriteCache::loadSprite(int index)
   cachesize += sizes[index];
 
 #ifdef DEBUG_SPRITECACHE
-  Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %d, size now %d KB", index, cachesize / 1024);
+  Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %d, size now %lld KB", index, cachesize / 1024);
 #endif
 
   return sizes[index];
@@ -472,8 +490,8 @@ int SpriteCache::saveToFile(const char *filnam, int lastElement, bool compressOu
 
   int spriteFileIDCheck = (int)time(NULL);
 
-  // version 6
-  output->WriteInt16(6);
+  // sprite file version
+  output->WriteInt16(kSprfVersion_Current);
 
   output->WriteArray(spriteFileSig, strlen(spriteFileSig), 1);
 
@@ -496,7 +514,7 @@ int SpriteCache::saveToFile(const char *filnam, int lastElement, bool compressOu
   int numsprits = lastslot + 1;
   short *spritewidths = (short*)malloc(numsprits * sizeof(short));
   short *spriteheights = (short*)malloc(numsprits * sizeof(short));
-  int32_t *spriteoffs = (int32_t*)malloc(numsprits * sizeof(int32_t));
+  soff_t *spriteoffs = (soff_t*)malloc(numsprits * sizeof(soff_t));
 
   const int memBufferSize = 100000;
   char *memBuffer = (char*)malloc(memBufferSize);
@@ -602,8 +620,8 @@ int SpriteCache::saveToFile(const char *filnam, int lastElement, bool compressOu
   Stream *spindex_out = File::CreateFile(spindexfilename);
   // write "SPRINDEX" id
   spindex_out->WriteArray(&spindexid[0], strlen(spindexid), 1);
-  // write version (1)
-  spindex_out->WriteInt32(2);
+  // write version
+  spindex_out->WriteInt32(kSpridxfVersion_Current);
   spindex_out->WriteInt32(spriteFileIDCheck);
   // write last sprite number and num sprites, to verify that
   // it matches the spr file
@@ -611,7 +629,7 @@ int SpriteCache::saveToFile(const char *filnam, int lastElement, bool compressOu
   spindex_out->WriteInt32(numsprits);
   spindex_out->WriteArrayOfInt16(&spritewidths[0], numsprits);
   spindex_out->WriteArrayOfInt16(&spriteheights[0], numsprits);
-  spindex_out->WriteArrayOfInt32(&spriteoffs[0], numsprits);
+  spindex_out->WriteArrayOfInt64(&spriteoffs[0], numsprits);
   delete spindex_out;
 
   free(spritewidths);
@@ -645,7 +663,7 @@ int SpriteCache::initFile(const char *filnam)
   // read the "Sprite File" signature
   cache_stream->ReadArray(&buff[0], 13, 1);
 
-  if ((vers < 4) || (vers > 6)) {
+  if ((vers < kSprfVersion_Uncompressed) || (vers > kSprfVersion_64bit)) {
     delete cache_stream;
     cache_stream = NULL;
     return -1;
@@ -659,24 +677,24 @@ int SpriteCache::initFile(const char *filnam)
     return -1;
   }
 
-  if (vers == 4)
+  if (vers == kSprfVersion_Uncompressed)
     this->spritesAreCompressed = false;
-  else if (vers == 5)
+  else if (vers == kSprfVersion_Compressed)
     this->spritesAreCompressed = true;
-  else if (vers >= 6)
+  else if (vers >= kSprfVersion_Last32bit)
   {
     this->spritesAreCompressed = (cache_stream->ReadInt8() == 1);
     spriteFileID = cache_stream->ReadInt32();
   }
 
-  if (vers < 5) {
+  if (vers < kSprfVersion_Compressed) {
     // skip the palette
       cache_stream->Seek(256 * 3);
   }
 
   numspri = cache_stream->ReadInt16();
 
-  if (vers < 4)
+  if (vers < kSprfVersion_Uncompressed)
     numspri = 200;
 
   initFile_adjustBuffers(numspri);
@@ -728,10 +746,10 @@ int SpriteCache::initFile(const char *filnam)
     get_new_size_for_sprite(vv, wdd, htt, spritewidth[vv], spriteheight[vv]);
 
     int32_t spriteDataSize;
-    if (vers == 5) {
+    if (vers == kSprfVersion_Compressed) {
       spriteDataSize = cache_stream->ReadInt32();
     }
-    else if (vers >= 6)
+    else if (vers >= kSprfVersion_Last32bit)
     {
       spriteDataSize = this->spritesAreCompressed ? cache_stream->ReadInt32() :
         wdd * coldep * htt;
@@ -747,7 +765,7 @@ int SpriteCache::initFile(const char *filnam)
   return 0;
 }
 
-bool SpriteCache::loadSpriteIndexFile(int expectedFileID, int32_t spr_initial_offs, short numspri)
+bool SpriteCache::loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, short numspri)
 {
   short numspri_index = 0;
   int vv;
@@ -766,12 +784,12 @@ bool SpriteCache::loadSpriteIndexFile(int expectedFileID, int32_t spr_initial_of
     return false;
   }
   // check version
-  int fileVersion = fidx->ReadInt32();
-  if ((fileVersion < 1) || (fileVersion > 2)) {
+  SpriteIndexFileVersion fileVersion = (SpriteIndexFileVersion)fidx->ReadInt32();
+  if ((fileVersion < kSpridxfVersion_Initial) || (fileVersion > kSpridxfVersion_Current)) {
     delete fidx;
     return false;
   }
-  if (fileVersion >= 2)
+  if (fileVersion >= kSpridxfVersion_Last32bit)
   {
     if (fidx->ReadInt32() != expectedFileID)
     {
@@ -798,7 +816,15 @@ bool SpriteCache::loadSpriteIndexFile(int expectedFileID, int32_t spr_initial_of
 
   fidx->ReadArrayOfInt16(&rspritewidths[0], numsprits);
   fidx->ReadArrayOfInt16(&rspriteheights[0], numsprits);
-  fidx->ReadArrayOfInt32(&offsets[0], numsprits);
+  if (fileVersion <= kSprfVersion_Last32bit)
+  {
+      for (int i = 0; i < numsprits; ++i)
+          offsets[i] = fidx->ReadInt32();
+  }
+  else // large file support
+  {
+      fidx->ReadArrayOfInt64(&offsets[0], numsprits);
+  }
 
   for (vv = 0; vv <= numspri; vv++) {
     flags[vv] = 0;

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -45,7 +45,7 @@ public:
   SpriteCache(int32_t maxElements);
 
   int  initFile(const char *);
-  int  loadSprite(int);
+  soff_t loadSprite(int);
   void seekToSprite(int index);
   void precache(int);           // preloads and locks in memory
   void set(int, Common::Bitmap *);
@@ -65,24 +65,24 @@ public:
 
   Common::Bitmap *operator[] (int index);
 
-  int32_t *offsets;
-  int32_t sprite0InitialOffset;
+  soff_t *offsets;
+  soff_t sprite0InitialOffset;
   int32_t elements;                // size of offsets/images arrays
   Common::Bitmap **images;
-  int *sizes;
+  soff_t *sizes;
   unsigned char *flags;
   Common::Stream *cache_stream;
   bool spritesAreCompressed;
-  int32_t cachesize;               // size in bytes of currently cached images
+  soff_t cachesize;               // size in bytes of currently cached images
   int *mrulist, *mrubacklink;
   int liststart, listend;
   int lastLoad;
-  int32_t maxCacheSize;
-  int32_t lockedSize;              // size in bytes of currently locked images
+  soff_t maxCacheSize;
+  soff_t lockedSize;              // size in bytes of currently locked images
 
 private:
     void compressSprite(Common::Bitmap *sprite, Common::Stream *out);
-  bool loadSpriteIndexFile(int expectedFileID, int32_t spr_initial_offs, short numspri);
+  bool loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, short numspri);
 
   void initFile_adjustBuffers(short numspri);
   void initFile_initNullSpriteParams(int vv);

--- a/Common/core/asset.h
+++ b/Common/core/asset.h
@@ -20,6 +20,7 @@
 #define __AGS_CN_CORE__ASSET_H
 
 #include <vector>
+#include "api/stream_api.h"
 #include "util/string.h"
 
 namespace AGS
@@ -33,8 +34,8 @@ struct AssetInfo
     // A pair of filename and libuid is assumed to be unique in game scope
     String      FileName;   // filename associated with asset
     int32_t     LibUid;     // uid of library, containing this asset
-    int         Offset;     // asset's position in library file (in bytes)
-    int         Size;       // asset's size (in bytes)
+    soff_t      Offset;     // asset's position in library file (in bytes)
+    soff_t      Size;       // asset's size (in bytes)
 
     AssetInfo();
 };

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -107,19 +107,19 @@ AssetError AssetManager::ReadDataFileTOC(const String &data_file, AssetLibInfo &
     return _theAssetManager ? _theAssetManager->_GetLibraryForAsset(asset_name) : "";
 }
 
-/* static */ long AssetManager::GetAssetOffset(const String &asset_name)
+/* static */ soff_t AssetManager::GetAssetOffset(const String &asset_name)
 {
     assert(_theAssetManager != NULL);
     return _theAssetManager ? _theAssetManager->_GetAssetOffset(asset_name) : 0;
 }
 
-/* static */ long AssetManager::GetAssetSize(const String &asset_name)
+/* static */ soff_t AssetManager::GetAssetSize(const String &asset_name)
 {
     assert(_theAssetManager != NULL);
     return _theAssetManager ? _theAssetManager->_GetAssetSize(asset_name) : 0;
 }
 
-/* static */ long AssetManager::GetLastAssetSize()
+/* static */ soff_t AssetManager::GetLastAssetSize()
 {
     assert(_theAssetManager != NULL);
     return _theAssetManager ? _theAssetManager->_GetLastAssetSize() : 0;
@@ -223,7 +223,7 @@ String AssetManager::_GetLibraryForAsset(const String &asset_name)
     return MakeLibraryFileNameForAsset(asset);
 }
 
-long AssetManager::_GetAssetOffset(const String &asset_name)
+soff_t AssetManager::_GetAssetOffset(const String &asset_name)
 {
     if (asset_name.IsEmpty())
     {
@@ -237,7 +237,7 @@ long AssetManager::_GetAssetOffset(const String &asset_name)
     return -1;
 }
 
-long AssetManager::_GetAssetSize(const String &asset_name)
+soff_t AssetManager::_GetAssetSize(const String &asset_name)
 {
     if (asset_name.IsEmpty())
     {
@@ -251,7 +251,7 @@ long AssetManager::_GetAssetSize(const String &asset_name)
     return -1;
 }
 
-long AssetManager::_GetLastAssetSize()
+soff_t AssetManager::_GetLastAssetSize()
 {
     return _lastAssetSize;
 }

--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -68,8 +68,8 @@ enum AssetError
 struct AssetLocation
 {
     String      FileName;   // file where asset is located
-    int         Offset;     // asset's position in file (in bytes)
-    int         Size;       // asset's size (in bytes)
+    soff_t      Offset;     // asset's position in file (in bytes)
+    soff_t      Size;       // asset's size (in bytes)
 
     AssetLocation();
 };
@@ -97,10 +97,10 @@ public:
     static int          GetAssetCount();
     static String       GetLibraryForAsset(const String &asset_name);
     static String       GetAssetFileByIndex(int index);
-    static long         GetAssetOffset(const String &asset_name);
-    static long         GetAssetSize(const String &asset_name);
+    static soff_t       GetAssetOffset(const String &asset_name);
+    static soff_t       GetAssetSize(const String &asset_name);
     // TODO: instead of this support streams that work in a file subsection, limited by size
-    static long         GetLastAssetSize();
+    static soff_t       GetLastAssetSize();
     // TODO: this is a workaround that lets us use back-end specific kind of streams
     // to read the asset data. This is not ideal, because it limits us to reading from file.
     // The better solution could be returning a standart stream object (like std::stream,
@@ -124,9 +124,9 @@ private:
     int         _GetAssetCount();    
     String      _GetLibraryForAsset(const String &asset_name);
     String      _GetAssetFileByIndex(int index);
-    long        _GetAssetOffset(const String &asset_name);
-    long        _GetAssetSize(const String &asset_name);
-    long        _GetLastAssetSize();
+    soff_t      _GetAssetOffset(const String &asset_name);
+    soff_t      _GetAssetSize(const String &asset_name);
+    soff_t      _GetLastAssetSize();
 
     AssetError  RegisterAssetLib(const String &data_file, const String &password);
 
@@ -145,7 +145,7 @@ private:
 
     AssetLibInfo            &_assetLib;
     String                  _basePath;          // library's parent path (directory)
-    long                    _lastAssetSize;     // size of asset that was opened last time
+    soff_t                  _lastAssetSize;     // size of asset that was opened last time
 };
 
 } // namespace Common

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -38,10 +38,7 @@ struct color
 };
 #endif
 
-#ifndef __CJONES_H
-long csavecompressed(char *, __block, color[256], long = 0);
-long cloadcompressed(char *, __block, color *, long = 0);
-#endif
+soff_t csavecompressed(char *, __block, color[256], soff_t = 0);
 
 void cpackbitl(unsigned char *line, int size, Stream *out)
 {
@@ -152,7 +149,7 @@ void cpackbitl32(unsigned int *line, int size, Stream *out)
 }
 
 
-long csavecompressed(char *finam, __block tobesaved, color pala[256], long exto)
+soff_t csavecompressed(char *finam, __block tobesaved, color pala[256], soff_t exto)
 {
   Stream *outpt;
 
@@ -164,7 +161,7 @@ long csavecompressed(char *finam, __block tobesaved, color pala[256], long exto)
     outpt = ci_fopen(finam, Common::kFile_CreateAlways, Common::kFile_Write);
 
   int widt, hit;
-  long ofes;
+  soff_t ofes;
   widt = *tobesaved++;
   widt += (*tobesaved++) * 256;
   hit = *tobesaved++;
@@ -323,9 +320,9 @@ int bmp_bpp(Bitmap*bmpt) {
   return bmpt->GetColorDepth() / 8;
 }
 
-long save_lzw(char *fnn, Bitmap *bmpp, color *pall, long offe) {
+soff_t save_lzw(char *fnn, Bitmap *bmpp, color *pall, soff_t offe) {
   Stream  *lz_temp_s, *out;
-  long  fll, toret, gobacto;
+  soff_t  fll, toret, gobacto;
 
   lz_temp_s = ci_fopen(lztempfnm, Common::kFile_CreateAlways, Common::kFile_Write);
   lz_temp_s->WriteInt32(bmpp->GetWidth() * bmpp->GetBPP());
@@ -356,13 +353,9 @@ long save_lzw(char *fnn, Bitmap *bmpp, color *pall, long offe) {
   return toret;
 }
 
-/*long load_lzw(char*fnn,Bitmap*bmm,color*pall,long ooff) {
-  recalced=bmm;
-  FILE*iii=clibfopen(fnn,"rb");
-  Seek(iii,ooff,SEEK_SET);*/
-
-long load_lzw(Stream *in, Common::Bitmap *bmm, color *pall) {
-  int          uncompsiz, *loptr;
+soff_t load_lzw(Stream *in, Common::Bitmap *bmm, color *pall) {
+  soff_t        uncompsiz;
+  int           *loptr;
   unsigned char *membuffer;
   int           arin;
 
@@ -445,10 +438,10 @@ long load_lzw(Stream *in, Common::Bitmap *bmm, color *pall) {
   return uncompsiz;
 }
 
-long savecompressed_allegro(char *fnn, Common::Bitmap *bmpp, color *pall, long write_at) {
+soff_t savecompressed_allegro(char *fnn, Common::Bitmap *bmpp, color *pall, soff_t write_at) {
   unsigned char *wgtbl = (unsigned char *)malloc(bmpp->GetWidth() * bmpp->GetHeight() + 4);
   short         *sss = (short *)wgtbl;
-  long          toret;
+  soff_t         toret;
 
   sss[0] = bmpp->GetWidth();
   sss[1] = bmpp->GetHeight();
@@ -460,7 +453,7 @@ long savecompressed_allegro(char *fnn, Common::Bitmap *bmpp, color *pall, long w
   return toret;
 }
 
-long loadcompressed_allegro(Stream *in, Common::Bitmap **bimpp, color *pall, long read_at) {
+soff_t loadcompressed_allegro(Stream *in, Common::Bitmap **bimpp, color *pall, soff_t /* read_at */) {
   short widd,hitt;
   int   ii;
 
@@ -484,5 +477,3 @@ long loadcompressed_allegro(Stream *in, Common::Bitmap **bimpp, color *pall, lon
 
   return in->GetPosition();
 }
-
-

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -15,6 +15,7 @@
 #ifndef __AC_COMPRESS_H
 #define __AC_COMPRESS_H
 
+#include "core/types.h"
 #include "util/wgt2allg.h" // color (allegro RGB)
 
 namespace AGS { namespace Common { class Stream; class Bitmap; } }
@@ -26,8 +27,6 @@ using namespace AGS; // FIXME later
 #endif
 typedef unsigned char * __block;
 
-long csavecompressed(char *finam, __block tobesaved, color pala[256], long exto);
-
 void cpackbitl(unsigned char *line, int size, Common::Stream *out);
 void cpackbitl16(unsigned short *line, int size, Common::Stream *out);
 void cpackbitl32(unsigned int *line, int size, Common::Stream *out);
@@ -37,12 +36,10 @@ int  cunpackbitl32(unsigned int *line, int size, Common::Stream *in);
 
 //=============================================================================
 
-long save_lzw(char *fnn, Common::Bitmap *bmpp, color *pall, long offe);
-
-/*long load_lzw(char*fnn,Common::Bitmap*bmm,color*pall,long ooff);*/
-long load_lzw(Common::Stream *in, Common::Bitmap *bmm, color *pall);
-long savecompressed_allegro(char *fnn, Common::Bitmap *bmpp, color *pall, long write_at);
-long loadcompressed_allegro(Common::Stream *in, Common::Bitmap **bimpp, color *pall, long read_at);
+soff_t save_lzw(char *fnn, Common::Bitmap *bmpp, color *pall, soff_t offe);
+soff_t load_lzw(Common::Stream *in, Common::Bitmap *bmm, color *pall);
+soff_t savecompressed_allegro(char *fnn, Common::Bitmap *bmpp, color *pall, soff_t write_at);
+soff_t loadcompressed_allegro(Common::Stream *in, Common::Bitmap **bimpp, color *pall, soff_t read_at);
 
 //extern char *lztempfnm;
 extern Common::Bitmap *recalced;

--- a/Common/util/multifilelib.h
+++ b/Common/util/multifilelib.h
@@ -46,14 +46,25 @@ namespace MFLUtil
         kMFLErrLibAssetCount  = -4, // too many assets in library
     };
 
-    extern const String HeadSig;
-    extern const String TailSig;
+    enum MFLVersion
+    {
+        kMFLVersion_SingleLib   = 6,
+        kMFLVersion_MultiV10    = 10,
+        kMFLVersion_MultiV11    = 11,
+        kMFLVersion_MultiV15    = 15, // unknown differences
+        kMFLVersion_MultiV20    = 20,
+        kMFLVersion_MultiV21    = 21,
+        kMFLVersion_MultiV30    = 30  // 64-bit file support, loose limits
+    };
+
+    // Maximal number of the data files in one library chain (1-byte index)
+    const size_t MaxMultiLibFiles = 256;
 
     MFLError TestIsMFL(Stream *in, bool test_is_main = false);
     MFLError ReadHeader(AssetLibInfo &lib, Stream *in);
 
-    const int EncryptionRandSeed = 9338638;
-    int      GetNextPseudoRand(int &rand_val);
+    void     WriteHeader(const AssetLibInfo &lib, MFLVersion lib_version, int lib_index, Stream *out);
+    void     WriteEnder(soff_t lib_offset, MFLVersion lib_index, Stream *out);
 };
 
 } // namespace Common

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -212,7 +212,7 @@ namespace AGS.Editor
                     using (FileStream ostream = File.Open(GetCompiledPath(baseGameFileName + ".exe"), FileMode.Append,
                         FileAccess.Write))
                     {
-                        int startPosition = (int)ostream.Position;
+                        long startPosition = ostream.Position;
                         using (FileStream istream = File.Open(fileName, FileMode.Open, FileAccess.Read))
                         {
                             const int bufferSize = 4096;
@@ -223,11 +223,12 @@ namespace AGS.Editor
                                 ostream.Write(buffer, 0, count);
                             }
                         }
+                        // TODO: use functions shared with DataFileWriter
                         // write the offset into the EXE where the first data file resides
-                        ostream.Write(BitConverter.GetBytes(startPosition), 0, 4);
+                        ostream.Write(BitConverter.GetBytes(startPosition), 0, 8);
                         // write the CLIB end signature so the engine knows this is a valid EXE
-                        ostream.Write(Encoding.UTF8.GetBytes(NativeConstants.CLIB_END_SIGNATURE.ToCharArray()), 0,
-                            NativeConstants.CLIB_END_SIGNATURE.Length);
+                        ostream.Write(Encoding.UTF8.GetBytes(DataFileWriter.CLIB_END_SIGNATURE.ToCharArray()), 0,
+                            DataFileWriter.CLIB_END_SIGNATURE.Length);
                     }
                 }
                 else if (!fileName.EndsWith(AGSEditor.CONFIG_FILE_NAME))

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -40,11 +40,7 @@ namespace AGS.Editor
         public static readonly int MAXTOPICOPTIONS = (int)Factory.NativeProxy.GetNativeConstant("MAXTOPICOPTIONS");
         public static readonly short UNIFORM_WALK_SPEED = (short)(int)Factory.NativeProxy.GetNativeConstant("UNIFORM_WALK_SPEED");
         public static readonly int GAME_RESOLUTION_CUSTOM = (int)Factory.NativeProxy.GetNativeConstant("GAME_RESOLUTION_CUSTOM");
-        public static readonly int MAXMULTIFILES = (int)Factory.NativeProxy.GetNativeConstant("MAXMULTIFILES");
-        public static readonly int RAND_SEED_SALT = (int)Factory.NativeProxy.GetNativeConstant("RAND_SEED_SALT");
         public static readonly int CHUNKSIZE = (int)Factory.NativeProxy.GetNativeConstant("CHUNKSIZE");
-        public static readonly string CLIB_END_SIGNATURE = (string)Factory.NativeProxy.GetNativeConstant("CLIB_END_SIGNATURE");
-        public static readonly int MAX_FILENAME_LENGTH = (int)Factory.NativeProxy.GetNativeConstant("MAX_FILENAME_LENGTH");
         public static readonly string SPRSET_NAME = (string)Factory.NativeProxy.GetNativeConstant("SPRSET_NAME");
         public static readonly byte SPF_640x400 = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_640x400");
         public static readonly byte SPF_ALPHACHANNEL = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_ALPHACHANNEL");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -674,11 +674,7 @@ namespace AGS
             if (name->Equals("MAXTOPICOPTIONS")) return MAXTOPICOPTIONS;
             if (name->Equals("UNIFORM_WALK_SPEED")) return UNIFORM_WALK_SPEED;
             if (name->Equals("GAME_RESOLUTION_CUSTOM")) return (int)kGameResolution_Custom;
-            if (name->Equals("MAXMULTIFILES")) return MAXMULTIFILES;
-            if (name->Equals("RAND_SEED_SALT")) return Common::MFLUtil::EncryptionRandSeed;
             if (name->Equals("CHUNKSIZE")) return CHUNKSIZE;
-            if (name->Equals("CLIB_END_SIGNATURE")) return gcnew String(Common::MFLUtil::TailSig);
-            if (name->Equals("MAX_FILENAME_LENGTH")) return MAX_FILENAME_LENGTH;
             if (name->Equals("SPRSET_NAME")) return gcnew String(sprsetname);
             if (name->Equals("SPF_640x400")) return SPF_640x400;
             if (name->Equals("SPF_ALPHACHANNEL")) return SPF_ALPHACHANNEL;

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -23,7 +23,7 @@ see the license.txt for details.
 extern const char* make_data_file(int numFiles, char * const*fileNames, long splitSize, const char *baseFileName, bool makeFileNameAssumptionsForEXE);
 extern void ReplaceIconFromFile(const char *iconName, const char *exeName);
 extern void ReplaceResourceInEXE(const char *exeName, const char *resourceName, const unsigned char *data, int dataLength, const char *resourceType);
-extern void make_old_style_data_file(const AGSString &dataFileName, const std::vector<AGSString> &fileNames);
+extern void make_single_lib_data_file(const AGSString &dataFileName, const std::vector<AGSString> &fileNames);
 static const char *GAME_DEFINITION_FILE_RESOURCE = "__GDF_XML";
 static const char *GAME_DEFINITION_THUMBNAIL_RESOURCE = "__GDF_THUMBNAIL";
 
@@ -138,7 +138,7 @@ namespace AGS
 				fileNames.push_back(ConvertFileNameToNativeString(fileList[i]));
 			}
 			AGSString baseFileNameChars = ConvertFileNameToNativeString(fileName);
-			make_old_style_data_file(baseFileNameChars, fileNames);
+            make_single_lib_data_file(baseFileNameChars, fileNames);
 		}
 
 		void NativeMethods::UpdateFileIcon(String ^fileToUpdate, String ^iconName)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2092,63 +2092,8 @@ void save_room_file(const char*rtsa)
 
 namespace MFLUtil = AGS::Common::MFLUtil;
 
-#define MAX_FILES 10000
-#define MAX_DATAFILENAME_LENGTH 50
-struct MultiFileLibNew {
-  char data_filenames[MAXMULTIFILES][MAX_DATAFILENAME_LENGTH];
-  int  num_data_files;
-  char filenames[MAX_FILES][MAX_FILENAME_LENGTH];
-  long offset[MAX_FILES];
-  long length[MAX_FILES];
-  char file_datafile[MAX_FILES];  // number of datafile
-  int  num_files;
-  };
-MultiFileLibNew ourlib;
 
-//static const char *tempSetting = "My\x1\xde\x4Jibzle";  // clib password
-//extern void init_pseudo_rand_gen(int seed);
-//extern int get_pseudo_rand();
-
-void fwrite_data_enc(const void *data, int dataSize, int dataCount, Stream *ooo, int &rand_val)
-{
-  const unsigned char *dataChar = (const unsigned char*)data;
-  for (int i = 0; i < dataSize * dataCount; i++)
-  {
-    ooo->WriteByte(dataChar[i] + MFLUtil::GetNextPseudoRand(rand_val));
-  }
-}
-
-void fputstring_enc(const char *sss, Stream *ooo, int &rand_val) 
-{
-  fwrite_data_enc(sss, 1, strlen(sss) + 1, ooo, rand_val);
-}
-
-void putw_enc(int numberToWrite, Stream *ooo, int &rand_val)
-{
-  fwrite_data_enc(&numberToWrite, 4, 1, ooo, rand_val);
-}
-
-void write_clib_header(Stream*wout) {
-  int ff;
-  int randSeed = (int)time(NULL);
-  wout->WriteInt32(randSeed - MFLUtil::EncryptionRandSeed);
-  putw_enc(ourlib.num_data_files, wout, randSeed);
-  for (ff = 0; ff < ourlib.num_data_files; ff++)
-  {
-    fputstring_enc(ourlib.data_filenames[ff], wout, randSeed);
-  }
-  putw_enc(ourlib.num_files, wout, randSeed);
-  for (ff = 0; ff < ourlib.num_files; ff++) 
-  {
-    fputstring_enc(ourlib.filenames[ff], wout, randSeed);
-  }
-  fwrite_data_enc(&ourlib.offset[0],4,ourlib.num_files, wout, randSeed);
-  fwrite_data_enc(&ourlib.length[0],4,ourlib.num_files, wout, randSeed);
-  fwrite_data_enc(&ourlib.file_datafile[0],1,ourlib.num_files, wout, randSeed);
-}
-
-
-int copy_file_across(Stream*inlibb,Stream*coppy,long leftforthis) {
+int copy_file_across(Stream*inlibb,Stream*coppy, soff_t leftforthis) {
   int success = 1;
   char*diskbuffer=(char*)malloc(CHUNKSIZE+10);
   while (leftforthis>0) {
@@ -2169,44 +2114,40 @@ int copy_file_across(Stream*inlibb,Stream*coppy,long leftforthis) {
   return success;
 }
 
-// TODO: upgrade this "old style data file" to "new style data file" (would require engine update too)
-void make_old_style_data_file(const AGSString &dataFileName, const std::vector<AGSString> &filenames)
+// NOTE: this is used for audio.vox and speech.vox
+void make_single_lib_data_file(const AGSString &dataFileName, const std::vector<AGSString> &filenames)
 {
-    const int passwmod = 20;
-    std::vector<int32_t> filesizes(filenames.size());
-    std::vector<AGSString> writefname(filenames.size());
     size_t numfile = filenames.size();
+    AGS::Common::AssetLibInfo lib;
 
-    for (size_t fi = 0; fi < numfile; ++fi)
+    lib.AssetInfos.resize(numfile);
+    for (size_t i = 0; i < numfile; ++i)
     {
-        writefname[fi] = get_filename(filenames[fi]);
-
-        if (strlen(writefname[fi]) > 12)
-            ThrowManagedException(AGSString::FromFormat("Filename too long (limit is 12 chars): '%s'", writefname[fi].GetCStr()));
-        int filesize = Common::File::GetFileSize(filenames[fi]);
+        AGS::Common::AssetInfo &asset = lib.AssetInfos[i];
+        soff_t filesize = Common::File::GetFileSize(filenames[i]);
         if (filesize < 0)
-            ThrowManagedException(AGSString::FromFormat("Unable to retrieve file size: '%s'", writefname[fi].GetCStr()));
-        filesizes[fi] = filesize;
-
-        for (size_t c = 0; c < writefname[fi].GetLength(); ++c)
-            writefname[fi].SetAt(c, writefname[fi][c] + passwmod);
+            ThrowManagedException(AGSString::FromFormat("Unable to retrieve file size: '%s'", filenames[i].GetCStr()));
+        asset.FileName = get_filename(filenames[i]);
+        asset.Size = filesize;
     }
 
     // Write the header
     Stream *wout = Common::File::CreateFile(dataFileName);
     if (!wout)
         ThrowManagedException(AGSString::FromFormat("Failed to open data file for writing: '%s'", dataFileName.GetCStr()));
-    wout->Write(MFLUtil::HeadSig, MFLUtil::HeadSig.GetLength());
-    wout->WriteByte(6);  // version
-    wout->WriteByte(passwmod);  // password modifier
-    wout->WriteByte(0);  // reserved
-    wout->WriteInt16((int16_t)numfile);
-    for (int i = 0; i < 13; ++i) wout->WriteByte(0);  // the password
+
+    MFLUtil::WriteHeader(lib, MFLUtil::kMFLVersion_MultiV30, 0, wout);
+
+    // Recalculate offsets (knowing that asset data will be positioned in sequence) and rewrite header again
+    // TODO: this is not a very pleasant way to do things, need to refactor writing process to fix this
+    lib.AssetInfos[0].Offset = wout->GetPosition();
+    // set offsets (assets are positioned in sequence)
     for (size_t i = 0; i < numfile; ++i)
-        writefname[i].WriteCount(wout, 13);
-    for (size_t i = 0; i < numfile; ++i)
-        wout->WriteInt32(filesizes[i]);
-    wout->WriteByteCount(0, 2 * numfile);  // comp.ratio
+    {
+        lib.AssetInfos[i].Offset = lib.AssetInfos[i - 1].Offset + lib.AssetInfos[i - 1].Size;
+    }
+    wout->Seek(0, AGS::Common::kSeekBegin);
+    MFLUtil::WriteHeader(lib, MFLUtil::kMFLVersion_MultiV30, 0, wout);
 
     // now copy the data
     AGSString err_msg;
@@ -2218,7 +2159,7 @@ void make_old_style_data_file(const AGSString &dataFileName, const std::vector<A
             err_msg.Format("Unable to open asset file for reading: '%s'", filenames[i].GetCStr());
             break;
         }
-        int res = copy_file_across(in, wout, filesizes[i]);
+        int res = copy_file_across(in, wout, lib.AssetInfos[i].Size);
         delete in;
         if (res < 1)
         {
@@ -2257,20 +2198,20 @@ Stream* find_file_in_path(char *buffer, const char *fileName)
 	return iii;
 }
 
+// TODO: find out why this function is still used in some cases, instead of the method in C# class DataFileWriter
 const char* make_data_file(int numFiles, char * const*fileNames, long splitSize, const char *baseFileName, bool makeFileNameAssumptionsForEXE)
 {
-  int a,b;
   Stream*wout;
   char tomake[MAX_PATH];
-  ourlib.num_data_files = 0;
-  ourlib.num_files = numFiles;
+  AGS::Common::AssetLibInfo lib;
+  lib.AssetInfos.resize(numFiles);
   Common::AssetManager::SetSearchPriority(Common::kAssetPriorityDir);
 
   int currentDataFile = 0;
   long sizeSoFar = 0;
   bool doSplitting = false;
 
-  for (a = 0; a < numFiles; a++)
+  for (size_t a = 0; a < numFiles; a++)
   {
 	  if (splitSize > 0)
 	  {
@@ -2282,42 +2223,36 @@ const char* make_data_file(int numFiles, char * const*fileNames, long splitSize,
 			  sizeSoFar = 0;
 		  }
 		  else if ((sizeSoFar > splitSize) && (doSplitting) && 
-			  (currentDataFile < MAXMULTIFILES - 1))
+			  (currentDataFile < MFLUtil::MaxMultiLibFiles - 1))
 		  {
 			  currentDataFile++;
 			  sizeSoFar = 0;
 		  }
 	  }
-	  long thisFileSize = 0;
+	  soff_t thisFileSize = 0;
 	  Stream *tf = Common::File::OpenFileRead(fileNames[a]);
 	  thisFileSize = tf->GetLength();
 	  delete tf;
 	  
 	  sizeSoFar += thisFileSize;
 
-    const char *fileNameSrc = fileNames[a];
-
-  	if (strrchr(fileNames[a], '\\') != NULL)
-		  fileNameSrc = strrchr(fileNames[a], '\\') + 1;
+      const char *fileNameSrc = fileNames[a];
+  	  if (strrchr(fileNames[a], '\\') != NULL)
+	    fileNameSrc = strrchr(fileNames[a], '\\') + 1;
 	  else if (strrchr(fileNames[a], '/') != NULL)
 		  fileNameSrc = strrchr(fileNames[a], '/') + 1;
-
-    if (strlen(fileNameSrc) >= MAX_FILENAME_LENGTH)
-    {
-      char buffer[500];
-      sprintf(buffer, "Filename too long: %s", fileNames[a]);
-      ThrowManagedException(buffer);
-    }
-		strcpy(ourlib.filenames[a], fileNameSrc);
-
-	  ourlib.file_datafile[a] = currentDataFile;
-	  ourlib.length[a] = thisFileSize;
+      if (strlen(fileNameSrc) >= MAX_PATH)
+      {
+          ThrowManagedException(AGSString::FromFormat("Filename too long: %s", fileNames[a]));
+      }
+      lib.AssetInfos[a].FileName = fileNameSrc;
+      lib.AssetInfos[a].LibUid = currentDataFile;
+      lib.AssetInfos[a].Size = thisFileSize;
   }
 
-  ourlib.num_data_files = currentDataFile + 1;
+  lib.LibFileNames.resize(currentDataFile + 1);
 
-  long startOffset = 0;
-  long mainHeaderOffset = 0;
+  soff_t startOffset = 0;
   char outputFileName[MAX_PATH];
   char firstDataFileFullPath[MAX_PATH];
 
@@ -2328,47 +2263,50 @@ const char* make_data_file(int numFiles, char * const*fileNames, long splitSize,
 
   // First, set up the ourlib.data_filenames array with all the filenames
   // so that write_clib_header will write the correct amount of data
-  for (a = 0; a < ourlib.num_data_files; a++) 
+  for (size_t a = 0; a < lib.LibFileNames.size(); a++)
   {
 	  if (makeFileNameAssumptionsForEXE) 
 	  {
-		  sprintf(ourlib.data_filenames[a], "%s.%03d", baseFileName, a);
+          lib.LibFileNames[a].Format("%s.%03d", baseFileName, a);
 		  if (a == 0)
 		  {
-			  strcpy(&ourlib.data_filenames[a][strlen(ourlib.data_filenames[a]) - 3], "exe");
+              // TODO: this is a very bad assumption that may cause failure in certain conditions
+              // we do not need to save first file extension!
+              // (but fixing this will require mirror fix in the engine.
+			  lib.LibFileNames[a].ReplaceMid(lib.LibFileNames[a].GetLength() - 3, 3, "exe");
 		  }
 	  }
 	  else 
 	  {
     	if (strrchr(baseFileName, '\\') != NULL)
-		    strcpy(ourlib.data_filenames[a], strrchr(baseFileName, '\\') + 1);
+		    lib.LibFileNames[a] = strrchr(baseFileName, '\\') + 1;
 	    else if (strrchr(baseFileName, '/') != NULL)
-		    strcpy(ourlib.data_filenames[a], strrchr(baseFileName, '/') + 1);
+            lib.LibFileNames[a] = strrchr(baseFileName, '/') + 1;
 	    else
-		    strcpy(ourlib.data_filenames[a], baseFileName);
+            lib.LibFileNames[a] = baseFileName;
 	  }
   }
 
   // adjust the file paths if necessary, so that write_clib_header will
   // write the correct amount of data
-  for (b = 0; b < ourlib.num_files; b++) 
+  for (size_t b = 0; b < lib.AssetInfos.size(); b++) 
   {
-	Stream *iii = find_file_in_path(tomake, ourlib.filenames[b]);
+	Stream *iii = find_file_in_path(tomake, lib.AssetInfos[b].FileName);
 	if (iii != NULL)
 	{
 		delete iii;
 
 		if (!makeFileNameAssumptionsForEXE)
-		  strcpy(ourlib.filenames[b], tomake);
+            lib.AssetInfos[b].FileName = tomake;
 	}
   }
 
   // now, create the actual files
-  for (a = 0; a < ourlib.num_data_files; a++) 
+  for (size_t a = 0; a < lib.LibFileNames.size(); a++)
   {
 	  if (makeFileNameAssumptionsForEXE) 
 	  {
-		  sprintf(outputFileName, "Compiled\\%s", ourlib.data_filenames[a]);
+		  sprintf(outputFileName, "Compiled\\%s", lib.LibFileNames[a]);
 	  }
 	  else 
 	  {
@@ -2384,31 +2322,27 @@ const char* make_data_file(int numFiles, char * const*fileNames, long splitSize,
 	  }
 
 	  startOffset = wout->GetLength();
-    wout->Write(MFLUtil::HeadSig, MFLUtil::HeadSig.GetLength());
-    wout->WriteByte(21);  // version
-    wout->WriteByte(a);   // file number
 
-    if (a == 0) 
-	{
-      mainHeaderOffset = wout->GetPosition();
-      write_clib_header(wout);
-    }
+      MFLUtil::WriteHeader(lib, MFLUtil::kMFLVersion_MultiV30, a, wout);
 
-    for (b=0;b<ourlib.num_files;b++) {
-      if (ourlib.file_datafile[b] == a) {
-        ourlib.offset[b] = wout->GetPosition() - startOffset;
+    
 
-		Stream *iii = find_file_in_path(NULL, ourlib.filenames[b]);
+    for (size_t b=0;b<lib.AssetInfos.size();b++) {
+      AGS::Common::AssetInfo &asset = lib.AssetInfos[b];
+      if (asset.LibUid == a) {
+          asset.Offset = wout->GetPosition() - startOffset;
+
+		Stream *iii = find_file_in_path(NULL, asset.FileName);
         if (iii == NULL) {
           delete wout;
           unlink(outputFileName);
 
 		  char buffer[500];
-		  sprintf(buffer, "Unable to find file '%s' for compilation. Do not remove files during the compilation process.", ourlib.filenames[b]);
+		  sprintf(buffer, "Unable to find file '%s' for compilation. Do not remove files during the compilation process.", asset.FileName.GetCStr());
 		  ThrowManagedException(buffer);
         }
-
-        if (copy_file_across(iii,wout,ourlib.length[b]) < 1) {
+    
+        if (copy_file_across(iii,wout,asset.Size) < 1) {
           delete iii;
           return "Error writing file: possibly disk full";
         }
@@ -2417,15 +2351,14 @@ const char* make_data_file(int numFiles, char * const*fileNames, long splitSize,
     }
 	if (startOffset > 0)
 	{
-		wout->WriteInt32(startOffset);
-        wout->Write(MFLUtil::TailSig, MFLUtil::TailSig.GetLength());
+        MFLUtil::WriteEnder(startOffset, MFLUtil::kMFLVersion_MultiV30, wout);
 	}
     delete wout;
   }
 
   wout = Common::File::OpenFile(firstDataFileFullPath, Common::kFile_Open, Common::kFile_ReadWrite);
-  wout->Seek(mainHeaderOffset, Common::kSeekBegin);
-  write_clib_header(wout);
+  wout->Seek(startOffset, Common::kSeekBegin);
+  MFLUtil::WriteHeader(lib, MFLUtil::kMFLVersion_MultiV30, 0, wout);
   delete wout;
   return NULL;
 }

--- a/Editor/AGS.Native/agsnative.h
+++ b/Editor/AGS.Native/agsnative.h
@@ -27,9 +27,7 @@
 #include "Common/gui/guidefines.h"
 #include "Common/game/customproperties.h"
 
-#define MAXMULTIFILES 25
 #define CHUNKSIZE 256000
-#define MAX_FILENAME_LENGTH 100
 #define MAX_PLUGINS 40
 
 extern const char *sprsetname;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -179,9 +179,9 @@ void SkipSaveImage(Stream *in)
 HSaveError ReadDescription(Stream *in, SavegameVersion &svg_ver, SavegameDescription &desc, SavegameDescElem elems)
 {
     svg_ver = (SavegameVersion)in->ReadInt32();
-    if (svg_ver < kSvgVersion_LowestSupported || svg_ver > kSvgVersion_Current)
+    if (svg_ver < kSvgVersion_LowestSupported || svg_ver > kSvgVersion_Current || svg_ver == kSvgVersion_Components)
         return new SavegameError(kSvgErr_FormatVersionNotSupported,
-            String::FromFormat("Required: %d, supported: %d - %d.", svg_ver, kSvgVersion_LowestSupported, kSvgVersion_Current));
+            String::FromFormat("Required: %d, supported: %d - %d (except 9).", svg_ver, kSvgVersion_LowestSupported, kSvgVersion_Current));
 
     // Enviroment information
     if (elems & kSvgDesc_EnvInfo)
@@ -191,6 +191,7 @@ HSaveError ReadDescription(Stream *in, SavegameVersion &svg_ver, SavegameDescrip
         desc.GameGuid = StrUtil::ReadString(in);
         desc.GameTitle = StrUtil::ReadString(in);
         desc.MainDataFilename = StrUtil::ReadString(in);
+        desc.MainDataVersion = (GameDataVersion)in->ReadInt32();
         desc.ColorDepth = in->ReadInt32();
     }
     else
@@ -200,6 +201,7 @@ HSaveError ReadDescription(Stream *in, SavegameVersion &svg_ver, SavegameDescrip
         StrUtil::SkipString(in);
         StrUtil::SkipString(in);
         StrUtil::SkipString(in);
+        in->ReadInt32(); // game data version
         in->ReadInt32(); // color depth
     }
     // User description
@@ -313,6 +315,7 @@ HSaveError OpenSavegameBase(const String &filename, SavegameSource *src, Savegam
             desc->GameGuid = temp_desc.GameGuid;
             desc->GameTitle = temp_desc.GameTitle;
             desc->MainDataFilename = temp_desc.MainDataFilename;
+            desc->MainDataVersion = temp_desc.MainDataVersion;
             desc->ColorDepth = temp_desc.ColorDepth;
         }
         if (elems & kSvgDesc_UserText)
@@ -667,6 +670,7 @@ void WriteDescription(Stream *out, const String &user_text, const Bitmap *user_i
     StrUtil::WriteString(game.guid, out);
     StrUtil::WriteString(game.gamename, out);
     StrUtil::WriteString(usetup.main_data_filename, out);
+    out->WriteInt32(loaded_game_file_version);
     out->WriteInt32(game.GetColorDepth());
     // User description
     StrUtil::WriteString(user_text, out);

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -17,6 +17,7 @@
 
 #include "util/stdtr1compat.h"
 #include TR1INCLUDE(memory)
+#include "ac/game_version.h"
 #include "util/error.h"
 #include "util/version.h"
 
@@ -48,8 +49,9 @@ enum SavegameVersion
 {
     kSvgVersion_Undefined = 0,
     kSvgVersion_321       = 8,
-    kSvgVersion_Components= 9,
-    kSvgVersion_Current   = kSvgVersion_Components,
+    kSvgVersion_Components= 9, // temp format, not supported anymore
+    kSvgVersion_Cmp_64bit = 10,
+    kSvgVersion_Current   = kSvgVersion_Cmp_64bit,
     kSvgVersion_LowestSupported = kSvgVersion_321 // change if support dropped
 };
 
@@ -131,7 +133,10 @@ struct SavegameDescription
     // Name of the main data file used; this is needed to properly
     // load saves made by "minigames"
     String              MainDataFilename;
-    // Color depth the engine was running in; this is required to
+    // Game's main data version; should be checked early to know
+    // if the save was made for the supported game format
+    GameDataVersion     MainDataVersion;
+    // Native color depth of the game; this is required to
     // properly restore dynamic graphics from the save
     int                 ColorDepth;
     

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -625,7 +625,7 @@ HSaveError ReadViews(PStream in, int32_t cmp_ver, const PreservedParams &pp, Res
 
 HSaveError WriteDynamicSprites(PStream out)
 {
-    const size_t ref_pos = out->GetPosition();
+    const soff_t ref_pos = out->GetPosition();
     out->WriteInt32(0); // number of dynamic sprites
     out->WriteInt32(0); // top index
     int count = 0;
@@ -641,7 +641,7 @@ HSaveError WriteDynamicSprites(PStream out)
             serialize_bitmap(spriteset[i], out.get());
         }
     }
-    const size_t end_pos = out->GetPosition();
+    const soff_t end_pos = out->GetPosition();
     out->Seek(ref_pos, kSeekBegin);
     out->WriteInt32(count);
     out->WriteInt32(top_index);
@@ -1100,22 +1100,21 @@ struct ComponentInfo
 {
     String  Name;
     int32_t Version;
-    size_t  Offset;     // offset at which an opening tag is located
-    size_t  DataOffset; // offset at which component data begins
-    size_t  DataSize;   // expected size of component data
+    soff_t  Offset;     // offset at which an opening tag is located
+    soff_t  DataOffset; // offset at which component data begins
+    soff_t  DataSize;   // expected size of component data
 
     ComponentInfo() : Version(-1), Offset(0), DataOffset(0), DataSize(0) {}
 };
 
 HSaveError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &info)
 {
-    size_t pos = in->GetPosition();
     info = ComponentInfo(); // reset in case of early error
     info.Offset = in->GetPosition();
     if (!ReadFormatTag(in, info.Name, true))
         return new SavegameError(kSvgErr_ComponentOpeningTagFormat);
     info.Version = in->ReadInt32();
-    info.DataSize = in->ReadInt32();
+    info.DataSize = in->ReadInt64();
     info.DataOffset = in->GetPosition();
 
     const ComponentHandler *handler = NULL;
@@ -1131,7 +1130,7 @@ HSaveError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &info)
     if (!err)
         return err;
     if (in->GetPosition() - info.DataOffset != info.DataSize)
-        return new SavegameError(kSvgErr_ComponentSizeMismatch, String::FromFormat("Expected: %d, actual: %d", info.DataSize, in->GetPosition() - info.DataOffset));
+        return new SavegameError(kSvgErr_ComponentSizeMismatch, String::FromFormat("Expected: %lld, actual: %lld", info.DataSize, in->GetPosition() - info.DataOffset));
     if (!AssertFormatTag(in, info.Name, false))
         return new SavegameError(kSvgErr_ComponentClosingTagFormat);
     return HSaveError::None();
@@ -1150,7 +1149,7 @@ HSaveError ReadAll(PStream in, SavegameVersion svg_version, const PreservedParam
     {
         // Look out for the end of the component list:
         // this is the only way how this function ends with success
-        size_t off = in->GetPosition();
+        soff_t off = in->GetPosition();
         if (AssertFormatTag(in, ComponentListTag, false))
             return HSaveError::None();
         // If the list's end was not detected, then seek back and continue reading
@@ -1176,12 +1175,12 @@ HSaveError WriteComponent(PStream out, ComponentHandler &hdlr)
 {
     WriteFormatTag(out, hdlr.Name, true);
     out->WriteInt32(hdlr.Version);
-    size_t ref_pos = out->GetPosition();
-    out->WriteInt32(0); // size
+    soff_t ref_pos = out->GetPosition();
+    out->WriteInt64(0); // placeholder for the component size
     HSaveError err = hdlr.Serialize(out);
-    size_t end_pos = out->GetPosition();
+    soff_t end_pos = out->GetPosition();
     out->Seek(ref_pos, kSeekBegin);
-    out->WriteInt32(end_pos - ref_pos - sizeof(int32_t)); // size of serialized component data
+    out->WriteInt64(end_pos - ref_pos - sizeof(int64_t)); // size of serialized component data
     out->Seek(end_pos, kSeekBegin);
     if (err)
         WriteFormatTag(out, hdlr.Name, false);


### PR DESCRIPTION
Formats updated:
1. Assets library (main game data, audio.vox, speech.vox);
2. Sprites file.
3. Room file.
4. Savedgame (just in case).

Also removed encryption from new asset library TOC (it retained very little sense after source code was opened).