### PR TITLE
Hide recent games which are currently missing

### DIFF
--- a/Editor/AGS.Editor/GUI/WelcomeScreen.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
+using System.IO;
 using System.Windows.Forms;
 using AGS.Editor.Preferences;
 
@@ -24,7 +20,10 @@ namespace AGS.Editor
 
             foreach (RecentGame game in Factory.AGSEditor.Settings.RecentGames)
             {
-                lstRecentGames.Items.Add(game.Name).SubItems.Add(game.Path);
+                if (Directory.Exists(game.Path))
+                {
+                    lstRecentGames.Items.Add(game.Name).SubItems.Add(game.Path);
+                }
             }
 
             if (lstRecentGames.Items.Count == 0)


### PR DESCRIPTION
Hides recent game references where the game path doesn't exist.

- When a game folder is removed or renamed, it now won't appear in the recent game list
- The entry remains in the settings file, so that if a game is on a volume which isn't mounted it will be listed again when the game folder returns