### PR TITLE
AGS 3: removed sprite number limit in the engine

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -94,7 +94,8 @@
 #define LEGACY_MAXOBJNAMELEN 30
 #define MAX_BSCENE    5   // max number of frames in animating bg scene
 
-#define MAX_SPRITES         30000
+#define LEGACY_MAX_SPRITES_V25  6000
+#define LEGACY_MAX_SPRITES      30000
 #define MAX_CURSOR          20
 
 #ifndef int32

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -77,21 +77,6 @@ void GameSetupStruct::read_font_flags(Common::Stream *in, GameDataVersion data_v
     }
 }
 
-HGameFileError GameSetupStruct::read_sprite_flags(Common::Stream *in, GameDataVersion data_ver)
-{
-    int numToRead;
-    if (data_ver < kGameVersion_256)
-        numToRead = 6000; // Fixed number of sprites on < 2.56
-    else
-        numToRead = in->ReadInt32();
-
-    if (numToRead > MAX_SPRITES)
-        return new MainGameFileError(kMGFErr_TooManySprites, String::FromFormat("Count: %d, max: %d", numToRead, MAX_SPRITES));
-    in->Read(&spriteflags[0], numToRead);
-    memset(spriteflags + numToRead, 0, MAX_SPRITES - numToRead);
-    return HGameFileError::None();
-}
-
 void GameSetupStruct::ReadInvInfo_Aligned(Stream *in)
 {
     AlignedStream align_s(in, Common::kAligned_Read);
@@ -403,7 +388,12 @@ void ConvertOldGameStruct (OldGameSetupStruct *ogss, GameSetupStruct *gss) {
         SetFontInfoFromSerializedFlags(gss->fonts[i], ogss->fontflags[i]);
         gss->fonts[i].Outline = ogss->fontoutline[i];
     }
-    memcpy (&gss->spriteflags[0], &ogss->spriteflags[0], 6000);
+
+    for (int i = 0; i < LEGACY_MAX_SPRITES_V25; ++i)
+    {
+        gss->SpriteInfos[i].Flags = ogss->spriteflags[i];
+    }
+
     memcpy (&gss->invinfo[0], &ogss->invinfo[0], 100 * sizeof(InventoryItemInfo));
     memcpy (&gss->mcurs[0], &ogss->mcurs[0], 10 * sizeof(MouseCursor));
     for (int i = 0; i < MAXGLOBALMES; i++)

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -41,8 +41,6 @@ struct GameSetupStruct: public GameSetupStructBase {
     // This array is used only to read data into;
     // font parameters are then put and queried in the fonts module
     std::vector<FontInfo> fonts;
-    //
-    unsigned char     spriteflags[MAX_SPRITES];
     InventoryItemInfo invinfo[MAX_INV];
     MouseCursor       mcurs[MAX_CURSOR];
     Interaction     **intrChar;
@@ -75,6 +73,18 @@ struct GameSetupStruct: public GameSetupStructBase {
     // A clip to play when player gains score in game
     // TODO: find out why OPT_SCORESOUND option cannot be used to store this in >=3.2 games
     int               scoreClipID;
+    
+    // TODO: I converted original array of sprite infos to vector here, because
+    // statistically in most games sprites go in long continious sequences with minimal
+    // gaps, and standard hash-map will have relatively big memory overhead compared.
+    // Of course vector will not behave very well if user has created e.g. only
+    // sprite #1 and sprite #1000000. For that reason I decided to still limit static
+    // sprite count to some reasonable number for the time being. Dynamic sprite IDs are
+    // added in sequence, so there won't be any issue with these.
+    // There could be other collection types, more optimal for this case. For example,
+    // we could use a kind of hash map containing fixed-sized arrays, where size of
+    // array is calculated based on key spread factor.
+    std::vector<SpriteInfo> SpriteInfos;
 
     // Get game's native color depth
     inline int GetColorDepth() const { return color_depth * 8; }
@@ -98,7 +108,6 @@ struct GameSetupStruct: public GameSetupStructBase {
     // Part 1
     void read_savegame_info(Common::Stream *in, GameDataVersion data_ver);
     void read_font_flags(Common::Stream *in, GameDataVersion data_ver);
-    HGameFileError read_sprite_flags(Common::Stream *in, GameDataVersion data_ver);
     HGameFileError read_cursors(Common::Stream *in, GameDataVersion data_ver);
     void read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);
     void read_words_dictionary(Common::Stream *in);

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -179,6 +179,8 @@ struct SpriteInfo
     uint32_t Flags;
     int      Width;
     int      Height;
+
+    SpriteInfo();
 };
 
 // Various font parameters, defining and extending font rendering behavior.

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -19,6 +19,7 @@
 #define __AGS_CN_AC__GAMESTRUCTDEFINES_H
 
 #include "util/geometry.h"
+#include "core/types.h"
 
 #define PAL_GAMEWIDE        0
 #define PAL_LOCKED          1
@@ -88,12 +89,7 @@
 #define FADE_BOXOUT         3
 #define FADE_CROSSFADE      4
 #define FADE_LAST           4   // this should equal the last one
-#define SPF_640x400         1
-#define SPF_HICOLOR         2
-#define SPF_DYNAMICALLOC    4
-#define SPF_TRUECOLOR       8
-#define SPF_ALPHACHANNEL 0x10
-#define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
+
 //#define FFLG_NOSCALE        1
 #define FFLG_SIZEMASK 0x003f
 #define FONT_OUTLINE_NONE -1
@@ -166,6 +162,23 @@ enum RenderAtScreenRes
     kRenderAtScreenRes_UserDefined  = 0,
     kRenderAtScreenRes_Enabled      = 1,
     kRenderAtScreenRes_Disabled     = 2,
+};
+
+
+// Sprite flags
+#define SPF_640x400         0x01  // sized for high native resolution
+#define SPF_HICOLOR         0x02  // is 16-bit
+#define SPF_DYNAMICALLOC    0x04  // created by runtime script
+#define SPF_TRUECOLOR       0x08  // is 32-bit
+#define SPF_ALPHACHANNEL    0x10  // has alpha-channel
+#define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
+
+// General information about sprite (properties, size)
+struct SpriteInfo
+{
+    uint32_t Flags;
+    int      Width;
+    int      Height;
 };
 
 // Various font parameters, defining and extending font rendering behavior.

--- a/Common/ac/oldgamesetupstruct.h
+++ b/Common/ac/oldgamesetupstruct.h
@@ -72,7 +72,7 @@ struct OriGameSetupStruct2 : public OriGameSetupStruct {
 };
 
 struct OldGameSetupStruct : public OriGameSetupStruct2 {
-    unsigned char spriteflags[6000];
+    unsigned char spriteflags[LEGACY_MAX_SPRITES_V25];
 };
 
 #endif // __AGS_CN_AC__OLDGAMESETUPSTRUCT_H

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -22,7 +22,6 @@
 #pragma warning (disable: 4996 4312)  // disable deprecation warnings
 #endif
 
-#include <stdio.h> // sprintf
 #include "ac/common.h"
 #include "ac/spritecache.h"
 #include "core/assetmanager.h"
@@ -39,7 +38,6 @@ extern void initialize_sprite(int);
 extern void pre_save_sprite(int);
 extern void get_new_size_for_sprite(int, int, int, int &, int &);
 
-#define SPRITE_LOCKED -1
 #define START_OF_LIST -1
 #define END_OF_LIST   -1
 
@@ -49,809 +47,872 @@ const char *spindexfilename = "sprindex.dat";
 // TODO: research old version differences
 enum SpriteFileVersion
 {
-    kSprfVersion_Uncompressed   = 4,
-    kSprfVersion_Compressed     = 5,
-    kSprfVersion_Last32bit      = 6,
-    kSprfVersion_64bit          = 10,
-    kSprfVersion_Current        = kSprfVersion_64bit
+    kSprfVersion_Uncompressed = 4,
+    kSprfVersion_Compressed = 5,
+    kSprfVersion_Last32bit = 6,
+    kSprfVersion_64bit = 10,
+    kSprfVersion_Current = kSprfVersion_64bit
 };
 
 enum SpriteIndexFileVersion
 {
-    kSpridxfVersion_Initial     = 1,
-    kSpridxfVersion_Last32bit   = 2,
-    kSpridxfVersion_64bit       = 10,
-    kSpridxfVersion_Current     = kSpridxfVersion_64bit
+    kSpridxfVersion_Initial = 1,
+    kSpridxfVersion_Last32bit = 2,
+    kSpridxfVersion_64bit = 10,
+    kSpridxfVersion_Current = kSpridxfVersion_64bit
 };
 
 
-SpriteCache::SpriteCache(int32_t maxElements, std::vector<SpriteInfo> &sprInfos)
+
+SpriteInfo::SpriteInfo()
+    : Flags(0)
+    , Width(0)
+    , Height(0)
+{
+}
+
+SpriteCache::SpriteData::SpriteData()
+    : Offset(0)
+    , Size(0)
+    , Flags(SPRCACHEFLAG_DOESNOTEXIST)
+    , Image(NULL)
+{
+}
+
+SpriteCache::SpriteData::~SpriteData()
+{
+    // TODO: investigate, if it's actually safe/preferred to delete bitmap here
+    // (some of these bitmaps may be assigned from outside of the cache)
+}
+
+
+SpriteCache::SpriteCache(sprkey_t reserve_count, std::vector<SpriteInfo> &sprInfos)
     : _sprInfos(sprInfos)
+    , _stream(NULL)
 {
-  elements = maxElements;
-  cache_stream = NULL;
-  offsets = NULL;
-  sprite0InitialOffset = 0;
-  spritesAreCompressed = false;
-  init();
+    _sprite0InitialOffset = 0;
+    _compressed = false;
+    init(reserve_count);
 }
 
-void SpriteCache::changeMaxSize(int32_t maxElements) {
-  elements = maxElements;
-  if (offsets) {
-    free(offsets);
-    free(images);
-    free(mrulist);
-    free(mrubacklink);
-    free(sizes);
-    free(flags);
-  }
-  offsets = (soff_t *)calloc(elements, sizeof(soff_t));
-  memset(offsets, 0, elements*sizeof(soff_t));
-  images = (Bitmap **) calloc(elements, sizeof(Bitmap *));
-  mrulist = (int *)calloc(elements, sizeof(int));
-  mrubacklink = (int *)calloc(elements, sizeof(int));
-  sizes = (soff_t *)calloc(elements, sizeof(soff_t));
-  flags = (unsigned char *)calloc(elements, sizeof(unsigned char));
+size_t SpriteCache::GetCacheSize() const
+{
+    return _cacheSize;
 }
 
-void SpriteCache::init()
+size_t SpriteCache::GetLockedSize() const
 {
-  delete cache_stream;
-  cache_stream = NULL;
-  changeMaxSize(elements);
-  cachesize = 0;
-  lockedSize = 0;
-  liststart = -1;
-  listend = -1;
-  lastLoad = -2;
-  maxCacheSize = DEFAULTCACHESIZE;
+    return _lockedSize;
 }
 
-void SpriteCache::reset()
+size_t SpriteCache::GetMaxCacheSize() const
 {
-  int ii;
-  for (ii = 0; ii < elements; ii++) {
-    if (images[ii] != NULL) {
-      delete images[ii];
-      images[ii] = NULL;
+    return _maxCacheSize;
+}
+
+sprkey_t SpriteCache::GetSpriteSlotCount() const
+{
+    return _spriteData.size();
+}
+
+void SpriteCache::SetMaxCacheSize(size_t size)
+{
+    _maxCacheSize = size;
+}
+
+void SpriteCache::init(sprkey_t reserve_count)
+{
+    delete _stream;
+    _stream = NULL;
+    EnlargeTo(reserve_count);
+    _cacheSize = 0;
+    _lockedSize = 0;
+    _maxCacheSize = DEFAULTCACHESIZE;
+    _liststart = -1;
+    _listend = -1;
+    _lastLoad = -2;
+}
+
+void SpriteCache::Reset()
+{
+    // TODO: find out if it's safe to simply always delete _spriteData.Image with array element
+    for (size_t i = 0; i < _spriteData.size(); ++i)
+    {
+        if (_spriteData[i].Image)
+        {
+            delete _spriteData[i].Image;
+            _spriteData[i].Image = NULL;
+        }
     }
-  }
+    _spriteData.clear();
 
-  free(offsets);
-  free(images);
-  free(mrulist);
-  free(mrubacklink);
-  free(sizes);
-  free(flags);
-  offsets = NULL;
+    _mrulist.clear();
+    _mrubacklink.clear();
 
-  init();
+    init();
 }
 
-void SpriteCache::set(int index, Bitmap *sprite)
+void SpriteCache::Set(sprkey_t index, Bitmap *sprite)
 {
-  images[index] = sprite;
+    EnlargeTo(index + 1);
+    _spriteData[index].Image = sprite;
 }
 
-void SpriteCache::setNonDiscardable(int index, Bitmap *sprite)
+void SpriteCache::setNonDiscardable(sprkey_t index, Bitmap *sprite)
 {
-  images[index] = sprite;
-  offsets[index] = SPRITE_LOCKED;
+    EnlargeTo(index + 1);
+    _spriteData[index].Image = sprite;
+    _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
 }
 
-void SpriteCache::removeSprite(int index, bool freeMemory)
+void SpriteCache::removeSprite(sprkey_t index, bool freeMemory)
 {
-  if ((images[index] != NULL) && (freeMemory))
-    delete images[index];
+    if ((_spriteData[index].Image != NULL) && (freeMemory))
+        delete _spriteData[index].Image;
 
-  images[index] = NULL;
-  offsets[index] = 0;
+    _spriteData[index].Image = NULL;
+    _spriteData[index].Offset = 0;
 }
 
-int SpriteCache::enlargeTo(int32_t newsize) {
-  if (newsize <= elements)
-    return 0;
-
-  int elementsWas = elements;
-  elements = newsize;
-  offsets = (soff_t *)realloc(offsets, elements * sizeof(soff_t));
-  images = (Bitmap **)realloc(images, elements * sizeof(Bitmap *));
-  mrulist = (int *)realloc(mrulist, elements * sizeof(int));
-  mrubacklink = (int *)realloc(mrubacklink, elements * sizeof(int));
-  sizes = (soff_t *)realloc(sizes, elements * sizeof(soff_t));
-  flags = (unsigned char*)realloc(flags, elements * sizeof(unsigned char));
-
-  for (int i = elementsWas; i < elements; i++) {
-    offsets[i] = 0;
-    images[i] = 0;
-    mrulist[i] = 0;
-    mrubacklink[i] = 0;
-    sizes[i] = 0;
-    flags[i] = SPRCACHEFLAG_DOESNOTEXIST;
-  }
-
-  return elementsWas;
-}
-
-int SpriteCache::findFreeSlot()
+sprkey_t SpriteCache::EnlargeTo(sprkey_t newsize)
 {
-  int i;
-  for (i = 1; i < elements; i++) {
-    // slot empty
-    if ((images[i] == NULL) && ((offsets[i] == 0) || (offsets[i] == sprite0InitialOffset)))
-      return i;
-  }
-  // no free slot found yet
-  // enlarge the sprite bank to find a free slot
-  // and return the first new free slot
-  return enlargeTo(elements + 100);
+    if (newsize < 0 || (size_t)newsize <= _spriteData.size())
+        return 0;
+    if (newsize > MAX_SPRITE_INDEX + 1)
+        newsize = MAX_SPRITE_INDEX + 1;
+
+    sprkey_t elementsWas = (sprkey_t)_spriteData.size();
+    _sprInfos.resize(newsize);
+    _spriteData.resize(newsize);
+    _mrulist.resize(newsize);
+    _mrubacklink.resize(newsize);
+    return elementsWas;
 }
 
-int SpriteCache::doesSpriteExist(int index) {
-  if (images[index] != NULL)
-    return 1;
-  
-  if (flags[index] & SPRCACHEFLAG_DOESNOTEXIST)
-    return 0;
-
-  if (offsets[index] > 0)
-    return 1;
-
-  return 0;
-}
-
-Bitmap *SpriteCache::operator [] (int index)
+sprkey_t SpriteCache::AddNewSprite()
 {
-  // invalid sprite slot
-  if ((index < 0) || (index >= elements))
-    return NULL;
-
-  // Dynamically added sprite, don't put it on the sprite list
-  if ((images[index] != NULL) && 
-      ((offsets[index] == 0) || ((flags[index] & SPRCACHEFLAG_DOESNOTEXIST) != 0)))
-    return images[index];
-
-  // if sprite exists in file but is not in mem, load it
-  if ((images[index] == NULL) && (offsets[index] > 0))
-    loadSprite(index);
-
-  // Locked sprite, eg. mouse cursor, that shouldn't be discarded
-  if (offsets[index] == SPRITE_LOCKED)
-    return images[index];
-
-  if (liststart < 0) {
-    liststart = index;
-    listend = index;
-    mrulist[index] = END_OF_LIST;
-    mrubacklink[index] = START_OF_LIST;
-  } 
-  else if (listend != index) {
-    // this is the oldest element being bumped to newest, so update start link
-    if (index == liststart) {
-      liststart = mrulist[index];
-      mrubacklink[liststart] = START_OF_LIST;
+    if (_spriteData.size() == MAX_SPRITE_INDEX + 1)
+        return -1; // no more sprite allowed
+    for (size_t i = MIN_SPRITE_INDEX; i < _spriteData.size(); ++i)
+    {
+        // slot empty
+        if ((_spriteData[i].Image == NULL) && ((_spriteData[i].Offset == 0) || (_spriteData[i].Offset == _sprite0InitialOffset)))
+        {
+            _sprInfos[i] = SpriteInfo();
+            _spriteData[i] = SpriteData();
+            return i;
+        }
     }
-    // already in list, link previous to next
-    else if (mrulist[index] > 0) {
-      mrulist[mrubacklink[index]] = mrulist[index];
-      mrubacklink[mrulist[index]] = mrubacklink[index];
+    // enlarge the sprite bank to find a free slot and return the first new free slot
+    return EnlargeTo(_spriteData.size() + 1); // we use +1 here to let std container decide the actual reserve size
+}
+
+bool SpriteCache::DoesSpriteExist(sprkey_t index)
+{
+    if (_spriteData[index].Image != NULL)
+        return true;
+    if (_spriteData[index].Flags & SPRCACHEFLAG_DOESNOTEXIST)
+        return false;
+    if (_spriteData[index].Offset > 0)
+        return true;
+    return false;
+}
+
+Bitmap *SpriteCache::operator [] (sprkey_t index)
+{
+    // invalid sprite slot
+    if (index < 0 || (size_t)index >= _spriteData.size())
+        return NULL;
+
+    // Dynamically added sprite, don't put it on the sprite list
+    if ((_spriteData[index].Image != NULL) &&
+        ((_spriteData[index].Offset == 0) || ((_spriteData[index].Flags & SPRCACHEFLAG_DOESNOTEXIST) != 0)))
+        return _spriteData[index].Image;
+
+    // if sprite exists in file but is not in mem, load it
+    if ((_spriteData[index].Image == NULL) && (_spriteData[index].Offset > 0))
+        loadSprite(index);
+
+    // Locked sprite, eg. mouse cursor, that shouldn't be discarded
+    if (_spriteData[index].Flags & SPRCACHEFLAG_LOCKED)
+        return _spriteData[index].Image;
+
+    if (_liststart < 0)
+    {
+        _liststart = index;
+        _listend = index;
+        _mrulist[index] = END_OF_LIST;
+        _mrubacklink[index] = START_OF_LIST;
+    } 
+    else if (_listend != index)
+    {
+        // this is the oldest element being bumped to newest, so update start link
+        if (index == _liststart)
+        {
+            _liststart = _mrulist[index];
+            _mrubacklink[_liststart] = START_OF_LIST;
+        }
+        // already in list, link previous to next
+        else if (_mrulist[index] > 0)
+        {
+            _mrulist[_mrubacklink[index]] = _mrulist[index];
+            _mrubacklink[_mrulist[index]] = _mrubacklink[index];
+        }
+
+        // set this as the newest element in the list
+        _mrulist[index] = END_OF_LIST;
+        _mrulist[_listend] = index;
+        _mrubacklink[index] = _listend;
+        _listend = index;
     }
 
-    // set this as the newest element in the list
-    mrulist[index] = END_OF_LIST;
-    mrulist[listend] = index;
-    mrubacklink[index] = listend;
-    listend = index;
-  }
-
-  return images[index];
+    return _spriteData[index].Image;
 }
 
 // Remove the oldest cache element
 void SpriteCache::removeOldest()
 {
+    if (_liststart < 0)
+        return;
 
-  if (liststart < 0)
-    return;
+    sprkey_t sprnum = _liststart;
 
-  int sprnum = liststart;
+    if ((_spriteData[sprnum].Image != NULL) && !(_spriteData[sprnum].Flags & SPRCACHEFLAG_LOCKED)) {
+        // Free the memory
+        if (_spriteData[sprnum].Flags & SPRCACHEFLAG_DOESNOTEXIST)
+        {
+            char msgg[150];
+            sprintf(msgg, "SpriteCache::removeOldest: Attempted to remove sprite %d that does not exist", sprnum);
+            quit(msgg);
+        }
+        _cacheSize -= _spriteData[sprnum].Size;
 
-  if ((images[sprnum] != NULL) && (offsets[sprnum] != SPRITE_LOCKED)) {
-    // Free the memory
-    if (flags[sprnum] & SPRCACHEFLAG_DOESNOTEXIST)
+        delete _spriteData[sprnum].Image;
+        _spriteData[sprnum].Image = NULL;
+    }
+
+    if (_liststart == _listend)
     {
-      char msgg[150];
-      sprintf(msgg, "SpriteCache::removeOldest: Attempted to remove sprite %d that does not exist", sprnum);
-      quit(msgg);
-    }
-    cachesize -= sizes[sprnum];
-
-    delete images[sprnum];
-    images[sprnum] = NULL;
-  }
-
-  if (liststart == listend)
-  {
-    // there was one huge sprite, removing it has now emptied the cache completely
-    if (cachesize > 0)
-    {
-      Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "SPRITE CACHE ERROR: Sprite cache should be empty, but still has %d bytes", cachesize);
-    }
-    mrulist[liststart] = 0;
-    liststart = -1;
-    listend = -1;
-  }
-  else
-  {
-    int oldstart = liststart;
-    liststart = mrulist[liststart];
-    mrulist[oldstart] = 0;
-    mrubacklink[liststart] = START_OF_LIST;
-    if (oldstart == liststart) {
-      // Somehow, we have got a recursive link to itself, so we
-      // the game will freeze (since it is not actually freeing any
-      // memory)
-      // There must be a bug somewhere causing this, but for now
-      // let's just reset the cache
-      Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: CACHE INCONSISTENT: RESETTING\n\tAt size %d (of %d), start %d end %d  fwdlink=%d",
-                    cachesize, maxCacheSize, oldstart, listend, liststart);
-      removeAll();
-    }
-  }
-
-#ifdef DEBUG_SPRITECACHE
-  Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Removed %d, size now %d KB", sprnum, cachesize / 1024);
-#endif
-}
-
-void SpriteCache::removeAll()
-{
-  int ii;
-
-  liststart = -1;
-  listend = -1;
-  for (ii = 0; ii < elements; ii++) {
-    if ((offsets[ii] != SPRITE_LOCKED) && (images[ii] != NULL) &&
-        ((flags[ii] & SPRCACHEFLAG_DOESNOTEXIST) == 0)) 
-    {
-      delete images[ii];
-      images[ii] = NULL;
-    }
-    mrulist[ii] = 0;
-    mrubacklink[ii] = 0;
-  }
-  cachesize = lockedSize;
-}
-
-void SpriteCache::precache(int index)
-{
-  if ((index < 0) || (index >= elements))
-    return;
-
-  soff_t sprSize = 0;
-
-  if (images[index] == NULL) {
-    sprSize = loadSprite(index);
-  }
-  else if (offsets[index] != SPRITE_LOCKED) {
-    sprSize = sizes[index];
-  }
-
-  // make sure locked sprites can't fill the cache
-  maxCacheSize += sprSize;
-  lockedSize += sprSize;
-
-  offsets[index] = SPRITE_LOCKED;
-
-#ifdef DEBUG_SPRITECACHE
-  Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Precached %d", index);
-#endif
-}
-
-void SpriteCache::seekToSprite(int index) {
-  if (index - 1 != lastLoad)
-      cache_stream->Seek(offsets[index], kSeekBegin);
-}
-
-soff_t SpriteCache::loadSprite(int index)
-{
-  int hh = 0;
-
-  while (cachesize > maxCacheSize) {
-    removeOldest();
-    hh++;
-    if (hh > 1000) {
-      Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: STUCK IN FREE_UP_MEM; RESETTING CACHE");
-      removeAll();
-    }
-
-  }
-
-  if ((index < 0) || (index >= elements))
-    quit("sprite cache array index out of bounds");
-
-  // If we didn't just load the previous sprite, seek to it
-  seekToSprite(index);
-
-  int coldep = cache_stream->ReadInt16();
-
-  if (coldep == 0) {
-    lastLoad = index;
-    return 0;
-  }
-
-  int wdd = cache_stream->ReadInt16();
-  int htt = cache_stream->ReadInt16();
-  // update the stored width/height
-  _sprInfos[index].Width = wdd;
-  _sprInfos[index].Height = htt;
-
-  images[index] = BitmapHelper::CreateBitmap(wdd, htt, coldep * 8);
-  if (images[index] == NULL) {
-    offsets[index] = 0;
-    return 0;
-  }
-
-  if (this->spritesAreCompressed) 
-  {
-    cache_stream->ReadInt32(); // skip data size
-    if (coldep == 1) {
-      for (hh = 0; hh < htt; hh++)
-        cunpackbitl(&images[index]->GetScanLineForWriting(hh)[0], wdd, cache_stream);
-    }
-    else if (coldep == 2) {
-      for (hh = 0; hh < htt; hh++)
-        cunpackbitl16((unsigned short*)&images[index]->GetScanLine(hh)[0], wdd, cache_stream);
-    }
-    else {
-      for (hh = 0; hh < htt; hh++)
-        cunpackbitl32((unsigned int*)&images[index]->GetScanLine(hh)[0], wdd, cache_stream);
-    }
-  }
-  else {
-    if (coldep == 1)
-    {
-      for (hh = 0; hh < htt; hh++)
-        cache_stream->ReadArray(&images[index]->GetScanLineForWriting(hh)[0], coldep, wdd);
-    }
-    else if (coldep == 2)
-    {
-      for (hh = 0; hh < htt; hh++)
-        cache_stream->ReadArrayOfInt16((int16_t*)&images[index]->GetScanLineForWriting(hh)[0], wdd);
+        // there was one huge sprite, removing it has now emptied the cache completely
+        if (_cacheSize > 0)
+        {
+            Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "SPRITE CACHE ERROR: Sprite cache should be empty, but still has %d bytes", _cacheSize);
+        }
+        _mrulist[_liststart] = 0;
+        _liststart = -1;
+        _listend = -1;
     }
     else
     {
-      for (hh = 0; hh < htt; hh++)
-        cache_stream->ReadArrayOfInt32((int32_t*)&images[index]->GetScanLineForWriting(hh)[0], wdd);
+        sprkey_t oldstart = _liststart;
+        _liststart = _mrulist[_liststart];
+        _mrulist[oldstart] = 0;
+        _mrubacklink[_liststart] = START_OF_LIST;
+        if (oldstart == _liststart)
+        {
+            // Somehow, we have got a recursive link to itself, so we
+            // the game will freeze (since it is not actually freeing any
+            // memory)
+            // There must be a bug somewhere causing this, but for now
+            // let's just reset the cache
+            Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: CACHE INCONSISTENT: RESETTING\n\tAt size %d (of %d), start %d end %d  fwdlink=%d",
+                        _cacheSize, _maxCacheSize, oldstart, _listend, _liststart);
+            RemoveAll();
+        }
     }
-  }
-
-  lastLoad = index;
-
-  // Stop it adding the sprite to the used list just because it's loaded
-  soff_t offs = offsets[index];
-  offsets[index] = SPRITE_LOCKED;
-
-  initialize_sprite(index);
-
-  if (index != 0)  // leave sprite 0 locked
-    offsets[index] = offs;
-
-  // we need to store this because the main program might
-  // alter spritewidth/height if it resizes stuff
-  sizes[index] = _sprInfos[index].Width * _sprInfos[index].Height * coldep;
-  cachesize += sizes[index];
 
 #ifdef DEBUG_SPRITECACHE
-  Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %d, size now %lld KB", index, cachesize / 1024);
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Removed %d, size now %d KB", sprnum, _cacheSize / 1024);
+#endif
+}
+
+void SpriteCache::RemoveAll()
+{
+    _liststart = -1;
+    _listend = -1;
+    for (size_t i = 0; i < _spriteData.size(); ++i)
+    {
+        if (!(_spriteData[i].Flags & SPRCACHEFLAG_LOCKED) && (_spriteData[i].Image != NULL) &&
+            ((_spriteData[i].Flags & SPRCACHEFLAG_DOESNOTEXIST) == 0))
+        {
+            delete _spriteData[i].Image;
+            _spriteData[i].Image = NULL;
+        }
+        _mrulist[i] = 0;
+        _mrubacklink[i] = 0;
+    }
+    _cacheSize = _lockedSize;
+}
+
+void SpriteCache::Precache(sprkey_t index)
+{
+    if (index < 0 || (size_t)index >= _spriteData.size())
+        return;
+
+    soff_t sprSize = 0;
+
+    if (_spriteData[index].Image == NULL)
+        sprSize = loadSprite(index);
+    else if (!(_spriteData[index].Flags & SPRCACHEFLAG_LOCKED))
+        sprSize = _spriteData[index].Size;
+
+    // make sure locked sprites can't fill the cache
+    _maxCacheSize += sprSize;
+    _lockedSize += sprSize;
+
+    _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
+
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Precached %d", index);
+#endif
+}
+
+void SpriteCache::seekToSprite(sprkey_t index)
+{
+    if (index - 1 != _lastLoad)
+        _stream->Seek(_spriteData[index].Offset, kSeekBegin);
+}
+
+size_t SpriteCache::loadSprite(sprkey_t index)
+{
+    int hh = 0;
+
+    while (_cacheSize > _maxCacheSize)
+    {
+        removeOldest();
+        hh++;
+        if (hh > 1000)
+        {
+            Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: STUCK IN FREE_UP_MEM; RESETTING CACHE");
+            RemoveAll();
+        }
+    }
+
+    if (index < 0 || (size_t)index >= _spriteData.size())
+        quit("sprite cache array index out of bounds");
+
+    // If we didn't just load the previous sprite, seek to it
+    seekToSprite(index);
+
+    int coldep = _stream->ReadInt16();
+
+    if (coldep == 0)
+    {
+        _lastLoad = index;
+        return 0;
+    }
+
+    int wdd = _stream->ReadInt16();
+    int htt = _stream->ReadInt16();
+    // update the stored width/height
+    _sprInfos[index].Width = wdd;
+    _sprInfos[index].Height = htt;
+
+    _spriteData[index].Image = BitmapHelper::CreateBitmap(wdd, htt, coldep * 8);
+    if (_spriteData[index].Image == NULL)
+    {
+        _spriteData[index].Offset = 0;
+        return 0;
+    }
+
+    Bitmap *image = _spriteData[index].Image;
+    if (this->_compressed) 
+    {
+        _stream->ReadInt32(); // skip data size
+        if (coldep == 1)
+        {
+            for (hh = 0; hh < htt; hh++)
+                cunpackbitl(&image->GetScanLineForWriting(hh)[0], wdd, _stream);
+        }
+        else if (coldep == 2)
+        {
+            for (hh = 0; hh < htt; hh++)
+                cunpackbitl16((unsigned short*)&image->GetScanLine(hh)[0], wdd, _stream);
+        }
+        else
+        {
+            for (hh = 0; hh < htt; hh++)
+                cunpackbitl32((unsigned int*)&image->GetScanLine(hh)[0], wdd, _stream);
+        }
+    }
+    else
+    {
+        if (coldep == 1)
+        {
+            for (hh = 0; hh < htt; hh++)
+                _stream->ReadArray(&image->GetScanLineForWriting(hh)[0], coldep, wdd);
+        }
+        else if (coldep == 2)
+        {
+            for (hh = 0; hh < htt; hh++)
+                _stream->ReadArrayOfInt16((int16_t*)&image->GetScanLineForWriting(hh)[0], wdd);
+        }
+        else
+        {
+            for (hh = 0; hh < htt; hh++)
+                _stream->ReadArrayOfInt32((int32_t*)&image->GetScanLineForWriting(hh)[0], wdd);
+        }
+    }
+
+    _lastLoad = index;
+
+    // Stop it adding the sprite to the used list just because it's loaded
+    // TODO: this messy hack is required, because initialize_sprite calls operator[]
+    // which puts the sprite to the MRU list.
+    _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
+
+    // TODO: this is ugly: asks the engine to convert the sprite using its own knowledge.
+    // And engine assigns new bitmap using SpriteCache::Set().
+    // Perhaps change to the callback function pointer?
+    initialize_sprite(index);
+
+    if (index != 0)  // leave sprite 0 locked
+        _spriteData[index].Flags &= ~SPRCACHEFLAG_LOCKED;
+
+    // we need to store this because the main program might
+    // alter spritewidth/height if it resizes stuff
+    size_t size = _sprInfos[index].Width * _sprInfos[index].Height * coldep;
+    _spriteData[index].Size = size;
+    _cacheSize += size;
+
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %lld, size now %u KB", index, _cacheSize / 1024);
 #endif
 
-  return sizes[index];
+    return size;
 }
 
 const char *spriteFileSig = " Sprite File ";
 
-void SpriteCache::compressSprite(Bitmap *sprite, Stream *out) {
+void SpriteCache::compressSprite(Bitmap *sprite, Stream *out)
+{
+    int depth = sprite->GetColorDepth() / 8;
 
-  int depth = sprite->GetColorDepth() / 8;
-
-  if (depth == 1) {
-    for (int yy = 0; yy < sprite->GetHeight(); yy++)
-      cpackbitl(&sprite->GetScanLineForWriting(yy)[0], sprite->GetWidth(), out);
-  }
-  else if (depth == 2) {
-    for (int yy = 0; yy < sprite->GetHeight(); yy++)
-      cpackbitl16((unsigned short *)&sprite->GetScanLine(yy)[0], sprite->GetWidth(), out);
-  }
-  else {
-    for (int yy = 0; yy < sprite->GetHeight(); yy++)
-      cpackbitl32((unsigned int *)&sprite->GetScanLine(yy)[0], sprite->GetWidth(), out);
-  }
-
+    if (depth == 1)
+    {
+        for (int yy = 0; yy < sprite->GetHeight(); yy++)
+            cpackbitl(&sprite->GetScanLineForWriting(yy)[0], sprite->GetWidth(), out);
+    }
+    else if (depth == 2)
+    {
+        for (int yy = 0; yy < sprite->GetHeight(); yy++)
+            cpackbitl16((unsigned short *)&sprite->GetScanLine(yy)[0], sprite->GetWidth(), out);
+    }
+    else
+    {
+        for (int yy = 0; yy < sprite->GetHeight(); yy++)
+            cpackbitl32((unsigned int *)&sprite->GetScanLine(yy)[0], sprite->GetWidth(), out);
+    }
 }
 
-int SpriteCache::saveToFile(const char *filnam, int lastElement, bool compressOutput)
+int SpriteCache::saveToFile(const char *filnam, sprkey_t lastElement, bool compressOutput)
 {
-  Stream *output = Common::File::CreateFile(filnam);
-  if (output == NULL)
-    return -1;
-
-  if (compressOutput) {
-    // re-open the file so that it can be seeked
-    delete output;
-    output = File::OpenFile(filnam, Common::kFile_Open, Common::kFile_ReadWrite); // CHECKME why mode was "r+" here?
+    Stream *output = Common::File::CreateFile(filnam);
     if (output == NULL)
-      return -1;
-  }
+        return -1;
 
-  int spriteFileIDCheck = (int)time(NULL);
-
-  // sprite file version
-  output->WriteInt16(kSprfVersion_Current);
-
-  output->WriteArray(spriteFileSig, strlen(spriteFileSig), 1);
-
-  output->WriteInt8(compressOutput ? 1 : 0);
-  output->WriteInt32(spriteFileIDCheck);
-
-  int i, lastslot = 0;
-  if (elements < lastElement)
-    lastElement = elements;
-
-  for (i = 1; i < lastElement; i++) {
-    // slot empty
-    if ((images[i] != NULL) || ((offsets[i] != 0) && (offsets[i] != sprite0InitialOffset)))
-      lastslot = i;
-  }
-
-  output->WriteInt16(lastslot);
-
-  // allocate buffers to store the indexing info
-  int numsprits = lastslot + 1;
-  short *spritewidths = (short*)malloc(numsprits * sizeof(short));
-  short *spriteheights = (short*)malloc(numsprits * sizeof(short));
-  soff_t *spriteoffs = (soff_t*)malloc(numsprits * sizeof(soff_t));
-
-  const int memBufferSize = 100000;
-  char *memBuffer = (char*)malloc(memBufferSize);
-
-  for (i = 0; i <= lastslot; i++) {
-
-    spriteoffs[i] = output->GetPosition();
-
-    // if compressing uncompressed sprites, load the sprite into memory
-    if ((images[i] == NULL) && (this->spritesAreCompressed != compressOutput))
-      (*this)[i];
-
-    if (images[i] != NULL) {
-      // image in memory -- write it out
-      pre_save_sprite(i);
-      int bpss = images[i]->GetColorDepth() / 8;
-      spritewidths[i] = images[i]->GetWidth();
-      spriteheights[i] = images[i]->GetHeight();
-      output->WriteInt16(bpss);
-      output->WriteInt16(spritewidths[i]);
-      output->WriteInt16(spriteheights[i]);
-
-      if (compressOutput) {
-        size_t lenloc = output->GetPosition();
-        // write some space for the length data
-        output->WriteInt32(0);
-
-        compressSprite(images[i], output);
-
-        size_t fileSizeSoFar = output->GetPosition();
-        // write the length of the compressed data
-        output->Seek(lenloc, kSeekBegin);
-        output->WriteInt32((fileSizeSoFar - lenloc) - 4);
-        output->Seek(0, kSeekEnd);
-      }
-      else
-        output->WriteArray(images[i]->GetDataForWriting(), spritewidths[i] * bpss, spriteheights[i]);
-
-      continue;
+    if (compressOutput)
+    {
+        // re-open the file so that it can be seeked
+        delete output;
+        output = File::OpenFile(filnam, Common::kFile_Open, Common::kFile_ReadWrite); // CHECKME why mode was "r+" here?
+        if (output == NULL)
+            return -1;
     }
 
-    if ((offsets[i] == 0) || ((offsets[i] == sprite0InitialOffset) && (i > 0))) {
-      // sprite doesn't exist
-      output->WriteInt16(0);
-      spritewidths[i] = 0;
-      spriteheights[i] = 0;
-      spriteoffs[i] = 0;
-      continue;
+    int spriteFileIDCheck = (int)time(NULL);
+
+    // sprite file version
+    output->WriteInt16(kSprfVersion_Current);
+
+    output->WriteArray(spriteFileSig, strlen(spriteFileSig), 1);
+
+    output->WriteInt8(compressOutput ? 1 : 0);
+    output->WriteInt32(spriteFileIDCheck);
+
+    sprkey_t lastslot = 0;
+    if (lastElement < 0)
+        lastElement = 0;
+    if (_spriteData.size() < (size_t)lastElement)
+        lastElement = (sprkey_t)_spriteData.size();
+
+    for (sprkey_t i = 1; i < lastElement; i++)
+    {
+        // slot empty
+        if ((_spriteData[i].Image != NULL) || ((_spriteData[i].Offset != 0) && (_spriteData[i].Offset != _sprite0InitialOffset)))
+            lastslot = i;
     }
 
-    // not in memory -- seek to it in the source file
-    seekToSprite(i);
-    lastLoad = i;
+    output->WriteInt16(lastslot);
 
-    short colDepth = cache_stream->ReadInt16();
-    output->WriteInt16(colDepth);
+    // allocate buffers to store the indexing info
+    sprkey_t numsprits = lastslot + 1;
+    short *spritewidths = new short[numsprits];
+    short *spriteheights = new short[numsprits];
+    soff_t *spriteoffs = new soff_t[numsprits];
 
-    if (colDepth == 0) {
-      continue;
+    const int memBufferSize = 100000;
+    char *memBuffer = new char[memBufferSize];
+
+    for (sprkey_t i = 0; i <= lastslot; i++)
+    {
+        spriteoffs[i] = output->GetPosition();
+
+        // if compressing uncompressed sprites, load the sprite into memory
+        if ((_spriteData[i].Image == NULL) && (this->_compressed != compressOutput))
+            (*this)[i];
+
+        if (_spriteData[i].Image != NULL)
+        {
+            // image in memory -- write it out
+            pre_save_sprite(i);
+            Bitmap *image = _spriteData[i].Image;
+            int bpss = image->GetColorDepth() / 8;
+            spritewidths[i] = image->GetWidth();
+            spriteheights[i] = image->GetHeight();
+            output->WriteInt16(bpss);
+            output->WriteInt16(spritewidths[i]);
+            output->WriteInt16(spriteheights[i]);
+
+            if (compressOutput)
+            {
+                size_t lenloc = output->GetPosition();
+                // write some space for the length data
+                output->WriteInt32(0);
+
+                compressSprite(image, output);
+
+                size_t fileSizeSoFar = output->GetPosition();
+                // write the length of the compressed data
+                output->Seek(lenloc, kSeekBegin);
+                output->WriteInt32((fileSizeSoFar - lenloc) - 4);
+                output->Seek(0, kSeekEnd);
+            }
+            else
+            {
+                output->WriteArray(image->GetDataForWriting(), spritewidths[i] * bpss, spriteheights[i]);
+            }
+            continue;
+        }
+
+        if ((_spriteData[i].Offset == 0) || ((_spriteData[i].Offset == _sprite0InitialOffset) && (i > 0)))
+        {
+            // sprite doesn't exist
+            output->WriteInt16(0);
+            spritewidths[i] = 0;
+            spriteheights[i] = 0;
+            spriteoffs[i] = 0;
+            continue;
+        }
+
+        // not in memory -- seek to it in the source file
+        seekToSprite(i);
+        _lastLoad = i;
+
+        short colDepth = _stream->ReadInt16();
+        output->WriteInt16(colDepth);
+
+        if (colDepth == 0)
+            continue;
+
+        if (this->_compressed != compressOutput)
+        {
+            // shouldn't be able to get here
+            delete [] memBuffer;
+            delete output;
+            return -2;
+        }
+
+        // and copy the data across
+        int width = _stream->ReadInt16();
+        int height = _stream->ReadInt16();
+
+        spritewidths[i] = width;
+        spriteheights[i] = height;
+
+        output->WriteInt16(width);
+        output->WriteInt16(height);
+
+        int sizeToCopy;
+        if (this->_compressed)
+        {
+            sizeToCopy = _stream->ReadInt32();
+            output->WriteInt32(sizeToCopy);
+        }
+        else
+        {
+            sizeToCopy = width * height * (int)colDepth;
+        }
+
+        while (sizeToCopy > memBufferSize)
+        {
+            _stream->ReadArray(memBuffer, memBufferSize, 1);
+            output->WriteArray(memBuffer, memBufferSize, 1);
+            sizeToCopy -= memBufferSize;
+        }
+
+        _stream->ReadArray(memBuffer, sizeToCopy, 1);
+        output->WriteArray(memBuffer, sizeToCopy, 1);
     }
 
-    if (this->spritesAreCompressed != compressOutput) {
-      // shouldn't be able to get here
-      free(memBuffer);
-      delete output;
-      return -2;
-    }
+    delete [] memBuffer;
+    delete output;
 
-    // and copy the data across
-    int width = cache_stream->ReadInt16();
-    int height = cache_stream->ReadInt16();
+    // write the sprite index file
+    Stream *spindex_out = File::CreateFile(spindexfilename);
+    // write "SPRINDEX" id
+    spindex_out->WriteArray(&spindexid[0], strlen(spindexid), 1);
+    // write version
+    spindex_out->WriteInt32(kSpridxfVersion_Current);
+    spindex_out->WriteInt32(spriteFileIDCheck);
+    // write last sprite number and num sprites, to verify that
+    // it matches the spr file
+    spindex_out->WriteInt32(lastslot);
+    spindex_out->WriteInt32(numsprits);
+    spindex_out->WriteArrayOfInt16(&spritewidths[0], numsprits);
+    spindex_out->WriteArrayOfInt16(&spriteheights[0], numsprits);
+    spindex_out->WriteArrayOfInt64(&spriteoffs[0], numsprits);
+    delete spindex_out;
 
-    spritewidths[i] = width;
-    spriteheights[i] = height;
-
-    output->WriteInt16(width);
-    output->WriteInt16(height);
-
-    int sizeToCopy;
-    if (this->spritesAreCompressed) {
-      sizeToCopy = cache_stream->ReadInt32();
-      output->WriteInt32(sizeToCopy);
-    }
-    else {
-      sizeToCopy = width * height * (int)colDepth;
-    }
-
-    while (sizeToCopy > memBufferSize) {
-      cache_stream->ReadArray(memBuffer, memBufferSize, 1);
-      output->WriteArray(memBuffer, memBufferSize, 1);
-      sizeToCopy -= memBufferSize;
-    }
-
-    cache_stream->ReadArray(memBuffer, sizeToCopy, 1);
-    output->WriteArray(memBuffer, sizeToCopy, 1);
-  }
-
-  free(memBuffer);
-
-  delete output;
-
-  // write the sprite index file
-  Stream *spindex_out = File::CreateFile(spindexfilename);
-  // write "SPRINDEX" id
-  spindex_out->WriteArray(&spindexid[0], strlen(spindexid), 1);
-  // write version
-  spindex_out->WriteInt32(kSpridxfVersion_Current);
-  spindex_out->WriteInt32(spriteFileIDCheck);
-  // write last sprite number and num sprites, to verify that
-  // it matches the spr file
-  spindex_out->WriteInt32(lastslot);
-  spindex_out->WriteInt32(numsprits);
-  spindex_out->WriteArrayOfInt16(&spritewidths[0], numsprits);
-  spindex_out->WriteArrayOfInt16(&spriteheights[0], numsprits);
-  spindex_out->WriteArrayOfInt64(&spriteoffs[0], numsprits);
-  delete spindex_out;
-
-  free(spritewidths);
-  free(spriteheights);
-  free(spriteoffs);
-
-  return 0;
+    delete [] spritewidths;
+    delete [] spriteheights;
+    delete [] spriteoffs;
+    return 0;
 }
 
-int SpriteCache::initFile(const char *filnam)
+int SpriteCache::InitFile(const char *filnam)
 {
-  short vers;
-  char buff[20];
-  short numspri = 0;
-  int vv, wdd, htt;
-  int32_t spr_initial_offs = 0;
-  int spriteFileID = 0;
+    SpriteFileVersion vers;
+    char buff[20];
+    sprkey_t numspri = 0;
+    int wdd, htt;
+    soff_t spr_initial_offs = 0;
+    int spriteFileID = 0;
 
-  for (vv = 0; vv < elements; vv++) {
-    images[vv] = NULL;
-    offsets[vv] = 0;
-  }
-
-  cache_stream = Common::AssetManager::OpenAsset((char *)filnam);
-  if (cache_stream == NULL)
-    return -1;
-
-  spr_initial_offs = cache_stream->GetPosition();
-
-  vers = cache_stream->ReadInt16();
-  // read the "Sprite File" signature
-  cache_stream->ReadArray(&buff[0], 13, 1);
-
-  if ((vers < kSprfVersion_Uncompressed) || (vers > kSprfVersion_64bit)) {
-    delete cache_stream;
-    cache_stream = NULL;
-    return -1;
-  }
-
-  // unknown version
-  buff[13] = 0;
-  if (strcmp(buff, spriteFileSig)) {
-    delete cache_stream;
-    cache_stream = NULL;
-    return -1;
-  }
-
-  if (vers == kSprfVersion_Uncompressed)
-    this->spritesAreCompressed = false;
-  else if (vers == kSprfVersion_Compressed)
-    this->spritesAreCompressed = true;
-  else if (vers >= kSprfVersion_Last32bit)
-  {
-    this->spritesAreCompressed = (cache_stream->ReadInt8() == 1);
-    spriteFileID = cache_stream->ReadInt32();
-  }
-
-  if (vers < kSprfVersion_Compressed) {
-    // skip the palette
-      cache_stream->Seek(256 * 3);
-  }
-
-  numspri = cache_stream->ReadInt16();
-
-  if (vers < kSprfVersion_Uncompressed)
-    numspri = 200;
-
-  initFile_adjustBuffers(numspri);
-
-  // if there is a sprite index file, use it
-  if (loadSpriteIndexFile(spriteFileID, spr_initial_offs, numspri))
-  {
-    // Succeeded
-    return 0;
-  }
-
-  // failed, delete the index file because it's invalid
-  unlink(spindexfilename);
-
-  // no sprite index file, manually index it
-
-  for (vv = 0; vv <= numspri; vv++) {
-
-    offsets[vv] = cache_stream->GetPosition();
-    flags[vv] = 0;
-
-    int coldep = cache_stream->ReadInt16();
-
-    if (coldep == 0) {
-      offsets[vv] = 0;
-      images[vv] = NULL;
-
-      initFile_initNullSpriteParams(vv);
-
-      if (cache_stream->EOS())
-        break;
-
-      continue;
+    for (size_t i = 0; i < _spriteData.size(); ++i)
+    {
+        _spriteData[i] = SpriteData();
     }
 
-    if (cache_stream->EOS())
-      break;
+    _stream = Common::AssetManager::OpenAsset((char *)filnam);
+    if (_stream == NULL)
+        return -1;
 
-    if (vv >= elements)
-      break;
+    spr_initial_offs = _stream->GetPosition();
 
-    images[vv] = NULL;
+    vers = (SpriteFileVersion)_stream->ReadInt16();
+    // read the "Sprite File" signature
+    _stream->ReadArray(&buff[0], 13, 1);
 
-    wdd = cache_stream->ReadInt16();
-    htt = cache_stream->ReadInt16();
+    if (vers < kSprfVersion_Uncompressed || vers > kSprfVersion_64bit)
+    {
+        delete _stream;
+        _stream = NULL;
+        return -1;
+    }
 
-    _sprInfos[vv].Width = wdd;
-    _sprInfos[vv].Height = htt;
-    get_new_size_for_sprite(vv, wdd, htt, _sprInfos[vv].Width, _sprInfos[vv].Height);
+    // unknown version
+    buff[13] = 0;
+    if (strcmp(buff, spriteFileSig))
+    {
+        delete _stream;
+        _stream = NULL;
+        return -1;
+    }
 
-    int32_t spriteDataSize;
-    if (vers == kSprfVersion_Compressed) {
-      spriteDataSize = cache_stream->ReadInt32();
+    if (vers == kSprfVersion_Uncompressed)
+    {
+        this->_compressed = false;
+    }
+    else if (vers == kSprfVersion_Compressed)
+    {
+        this->_compressed = true;
     }
     else if (vers >= kSprfVersion_Last32bit)
     {
-      spriteDataSize = this->spritesAreCompressed ? cache_stream->ReadInt32() :
-        wdd * coldep * htt;
-    }
-    else {
-      spriteDataSize = wdd * coldep * htt;
+        this->_compressed = (_stream->ReadInt8() == 1);
+        spriteFileID = _stream->ReadInt32();
     }
 
-    cache_stream->Seek(spriteDataSize);
-  }
-
-  sprite0InitialOffset = offsets[0];
-  return 0;
-}
-
-bool SpriteCache::loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, short numspri)
-{
-  short numspri_index = 0;
-  int vv;
-  Stream *fidx = Common::AssetManager::OpenAsset((char*)spindexfilename);
-  if (fidx == NULL) 
-  {
-    return false;
-  }
-
-  char buffer[9];
-  // check "SPRINDEX" id
-  fidx->ReadArray(&buffer[0], strlen(spindexid), 1);
-  buffer[8] = 0;
-  if (strcmp(buffer, spindexid)) {
-    delete fidx;
-    return false;
-  }
-  // check version
-  SpriteIndexFileVersion fileVersion = (SpriteIndexFileVersion)fidx->ReadInt32();
-  if ((fileVersion < kSpridxfVersion_Initial) || (fileVersion > kSpridxfVersion_Current)) {
-    delete fidx;
-    return false;
-  }
-  if (fileVersion >= kSpridxfVersion_Last32bit)
-  {
-    if (fidx->ReadInt32() != expectedFileID)
+    if (vers < kSprfVersion_Compressed)
     {
-      delete fidx;
-      return false;
+        // skip the palette
+        _stream->Seek(256 * 3); // sizeof(RGB) * 256
     }
-  }
-  numspri_index = fidx->ReadInt32();
 
-  // end index+1 should be the same as num sprites
-  if (fidx->ReadInt32() != numspri_index + 1) {
+    numspri = _stream->ReadInt16();
+    if (vers < kSprfVersion_Uncompressed)
+        numspri = 200;
+
+    initFile_adjustBuffers(numspri);
+
+    // if there is a sprite index file, use it
+    if (loadSpriteIndexFile(spriteFileID, spr_initial_offs, numspri))
+    {
+        // Succeeded
+        return 0;
+    }
+
+    // failed, delete the index file because it's invalid
+    // TODO: refactor loading process and make it NOT delete file running the game!!
+    unlink(spindexfilename);
+
+    // no sprite index file, manually index it
+    for (sprkey_t i = 0; i <= numspri; ++i)
+    {
+        _spriteData[i].Offset = _stream->GetPosition();
+        _spriteData[i].Flags = 0;
+
+        int coldep = _stream->ReadInt16();
+
+        if (coldep == 0)
+        {
+            _spriteData[i].Offset = 0;
+            _spriteData[i].Image = NULL;
+
+            initFile_initNullSpriteParams(i);
+
+            if (_stream->EOS())
+                break;
+
+            continue;
+        }
+
+        if (_stream->EOS())
+            break;
+
+        if ((size_t)i >= _spriteData.size())
+            break;
+
+        _spriteData[i].Image = NULL;
+
+        wdd = _stream->ReadInt16();
+        htt = _stream->ReadInt16();
+
+        _sprInfos[i].Width = wdd;
+        _sprInfos[i].Height = htt;
+        get_new_size_for_sprite(i, wdd, htt, _sprInfos[i].Width, _sprInfos[i].Height);
+
+        size_t spriteDataSize;
+        if (vers == kSprfVersion_Compressed)
+        {
+            spriteDataSize = _stream->ReadInt32();
+        }
+        else if (vers >= kSprfVersion_Last32bit)
+        {
+            spriteDataSize = this->_compressed ? _stream->ReadInt32() :
+            wdd * coldep * htt;
+        }
+        else
+        {
+            spriteDataSize = wdd * coldep * htt;
+        }
+
+        _stream->Seek(spriteDataSize);
+    }
+
+    _sprite0InitialOffset = _spriteData[0].Offset;
+    return 0;
+}
+
+bool SpriteCache::loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t numspri)
+{
+    sprkey_t numspri_index = 0;
+    Stream *fidx = Common::AssetManager::OpenAsset((char*)spindexfilename);
+    if (fidx == NULL) 
+    {
+        return false;
+    }
+
+    char buffer[9];
+    // check "SPRINDEX" id
+    fidx->ReadArray(&buffer[0], strlen(spindexid), 1);
+    buffer[8] = 0;
+    if (strcmp(buffer, spindexid))
+    {
+        delete fidx;
+        return false;
+    }
+    // check version
+    SpriteIndexFileVersion fileVersion = (SpriteIndexFileVersion)fidx->ReadInt32();
+    if (fileVersion < kSpridxfVersion_Initial || fileVersion > kSpridxfVersion_Current)
+    {
+        delete fidx;
+        return false;
+    }
+    if (fileVersion >= kSpridxfVersion_Last32bit)
+    {
+        if (fidx->ReadInt32() != expectedFileID)
+        {
+            delete fidx;
+            return false;
+        }
+    }
+
+    numspri_index = fidx->ReadInt32();
+    // end index+1 should be the same as num sprites
+    if (fidx->ReadInt32() != numspri_index + 1)
+    {
+        delete fidx;
+        return false;
+    }
+
+    if (numspri_index != numspri)
+    {
+        delete fidx;
+        return false;
+    }
+
+    sprkey_t numsprits = numspri + 1;
+    short *rspritewidths = new short[numsprits];
+    short *rspriteheights = new short[numsprits];
+    soff_t *spriteoffs = new soff_t[numsprits];
+
+    fidx->ReadArrayOfInt16(&rspritewidths[0], numsprits);
+    fidx->ReadArrayOfInt16(&rspriteheights[0], numsprits);
+    if (fileVersion <= kSpridxfVersion_Last32bit)
+    {
+        for (sprkey_t i = 0; i < numsprits; ++i)
+            spriteoffs[i] = fidx->ReadInt32();
+    }
+    else // large file support
+    {
+        fidx->ReadArrayOfInt64(spriteoffs, numsprits);
+    }
+
+    for (sprkey_t i = 0; i <= numspri; ++i)
+    {
+        _spriteData[i].Flags = 0;
+        if (spriteoffs[i] != 0)
+        {
+            _spriteData[i].Offset = spriteoffs[i] + spr_initial_offs;
+            get_new_size_for_sprite(i, rspritewidths[i], rspriteheights[i], _sprInfos[i].Width, _sprInfos[i].Height);
+        }
+        else if (i > 0)
+        {
+            initFile_initNullSpriteParams(i);
+        }
+    }
+
+    _sprite0InitialOffset = _spriteData[0].Offset;
+    delete [] rspritewidths;
+    delete [] rspriteheights;
+    delete [] spriteoffs;
     delete fidx;
-    return false;
-  }
-
-  if (numspri_index != numspri) {
-    delete fidx;
-    return false;
-  }
-
-  short numsprits = numspri + 1;
-  short *rspritewidths = (short*)malloc(numsprits * sizeof(short));
-  short *rspriteheights = (short*)malloc(numsprits * sizeof(short));
-
-  fidx->ReadArrayOfInt16(&rspritewidths[0], numsprits);
-  fidx->ReadArrayOfInt16(&rspriteheights[0], numsprits);
-  if (fileVersion <= kSpridxfVersion_Last32bit)
-  {
-      for (int i = 0; i < numsprits; ++i)
-          offsets[i] = fidx->ReadInt32();
-  }
-  else // large file support
-  {
-      fidx->ReadArrayOfInt64(&offsets[0], numsprits);
-  }
-
-  for (vv = 0; vv <= numspri; vv++) {
-    flags[vv] = 0;
-    if (offsets[vv] != 0) {
-      offsets[vv] += spr_initial_offs;
-      get_new_size_for_sprite(vv, rspritewidths[vv], rspriteheights[vv], _sprInfos[vv].Width, _sprInfos[vv].Height);
-    }
-    else if (vv > 0) {
-      initFile_initNullSpriteParams(vv);
-    }
-  }
-
-  sprite0InitialOffset = offsets[0];
-  free(rspritewidths);
-  free(rspriteheights);
-
-  delete fidx;
-  return true;
+    return true;
 }
 
-void SpriteCache::detachFile() {
-  delete cache_stream;
-  cache_stream = NULL;
-  lastLoad = -2;
+void SpriteCache::detachFile()
+{
+    delete _stream;
+    _stream = NULL;
+    _lastLoad = -2;
 }
 
-int SpriteCache::attachFile(const char *filename) {
-  cache_stream = Common::AssetManager::OpenAsset((char *)filename);
-  if (cache_stream == NULL)
-    return -1;
-  return 0;
+int SpriteCache::attachFile(const char *filename)
+{
+    _stream = Common::AssetManager::OpenAsset((char *)filename);
+    if (_stream == NULL)
+        return -1;
+    return 0;
 }
-

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -158,14 +158,14 @@ void SpriteCache::Set(sprkey_t index, Bitmap *sprite)
     _spriteData[index].Image = sprite;
 }
 
-void SpriteCache::setNonDiscardable(sprkey_t index, Bitmap *sprite)
+void SpriteCache::SetSpriteAndLock(sprkey_t index, Bitmap *sprite)
 {
     EnlargeTo(index + 1);
     _spriteData[index].Image = sprite;
     _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
 }
 
-void SpriteCache::removeSprite(sprkey_t index, bool freeMemory)
+void SpriteCache::RemoveSprite(sprkey_t index, bool freeMemory)
 {
     if ((_spriteData[index].Image != NULL) && (freeMemory))
         delete _spriteData[index].Image;
@@ -505,7 +505,7 @@ void SpriteCache::compressSprite(Bitmap *sprite, Stream *out)
     }
 }
 
-int SpriteCache::saveToFile(const char *filnam, sprkey_t lastElement, bool compressOutput)
+int SpriteCache::SaveToFile(const char *filnam, sprkey_t lastElement, bool compressOutput)
 {
     Stream *output = Common::File::CreateFile(filnam);
     if (output == NULL)
@@ -902,17 +902,22 @@ bool SpriteCache::loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_off
     return true;
 }
 
-void SpriteCache::detachFile()
+void SpriteCache::DetachFile()
 {
     delete _stream;
     _stream = NULL;
     _lastLoad = -2;
 }
 
-int SpriteCache::attachFile(const char *filename)
+int SpriteCache::AttachFile(const char *filename)
 {
     _stream = Common::AssetManager::OpenAsset((char *)filename);
     if (_stream == NULL)
         return -1;
     return 0;
+}
+
+bool SpriteCache::IsFileCompressed() const
+{
+    return _compressed;
 }

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -76,6 +76,8 @@ public:
     sprkey_t    EnlargeTo(sprkey_t newsize);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
     sprkey_t    AddNewSprite();
+    // Assigns bitmap to the given slot and locks it to prevent release from cache
+    void        SetSpriteAndLock(sprkey_t index, Common::Bitmap *);
     // Returns current size of the cache, in bytes
     size_t      GetCacheSize() const;
     // Gets the total size of the locked sprites, in bytes
@@ -84,10 +86,10 @@ public:
     size_t      GetMaxCacheSize() const;
     // Returns number of sprite slots in the bank (this includes both actual sprites and free slots)
     sprkey_t    GetSpriteSlotCount() const;
-    // Loads sprite reference information and inits sprite stream
-    int         InitFile(const char *);
     // Loads sprite and and locks in memory (so it cannot get removed implicitly)
     void        Precache(sprkey_t index);
+    // Unregisters sprite from the bank and optionally deletes bitmap
+    void        RemoveSprite(sprkey_t index, bool freeMemory);
     // Removes all loaded images from the cache
     void        RemoveAll();
     // Deletes all data and resets cache to the clear state
@@ -97,19 +99,25 @@ public:
     // Sets max cache size in bytes
     void        SetMaxCacheSize(size_t size);
 
+    // Loads sprite reference information and inits sprite stream
+    int         InitFile(const char *filename);
+    // Tells if bitmaps in the file are compressed
+    bool        IsFileCompressed() const;
+    // Opens file stream
+    int         AttachFile(const char *filename);
+    // Closes file stream
+    void        DetachFile();
+    // Saves all sprites until lastElement (exclusive) to file 
+    int         SaveToFile(const char *filename, sprkey_t lastElement, bool compressOutput);
+
     // Loads (if it's not in cache yet) and returns bitmap by the sprite index
     Common::Bitmap *operator[] (sprkey_t index);
 
 private:
     size_t loadSprite(sprkey_t);
     void seekToSprite(sprkey_t index);
-    void setNonDiscardable(sprkey_t, Common::Bitmap *);
-    void removeSprite(sprkey_t, bool);
     void removeOldest();
     void init(sprkey_t reserve_count = 1);
-    int  saveToFile(const char *, sprkey_t lastElement, bool compressOutput);
-    void detachFile();
-    int  attachFile(const char *);
 
     // Information required for the sprite streaming
     // TODO: make compatible with large (over 2GB) files

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -84,8 +84,8 @@ typedef int32_t sprkey_t;
 class SpriteCache
 {
 public:
-    const sprkey_t MIN_SPRITE_INDEX = 1; // 0 is reserved for "empty sprite"
-    const sprkey_t MAX_SPRITE_INDEX = INT32_MAX - 1;
+    static const sprkey_t MIN_SPRITE_INDEX = 1; // 0 is reserved for "empty sprite"
+    static const sprkey_t MAX_SPRITE_INDEX = INT32_MAX - 1;
 
     SpriteCache(sprkey_t reserve_count, std::vector<SpriteInfo> &sprInfos);
 

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -90,7 +90,7 @@ public:
     SpriteCache(sprkey_t reserve_count, std::vector<SpriteInfo> &sprInfos);
 
     // Tells if there is a sprite registered for the given index
-    bool        DoesSpriteExist(sprkey_t index);
+    bool        DoesSpriteExist(sprkey_t index) const;
     // Makes sure sprite cache has registered slots for all sprites up to the given exclusive limit
     sprkey_t    EnlargeTo(sprkey_t newsize);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
@@ -105,6 +105,8 @@ public:
     size_t      GetMaxCacheSize() const;
     // Returns number of sprite slots in the bank (this includes both actual sprites and free slots)
     sprkey_t    GetSpriteSlotCount() const;
+    // Finds the topmost occupied slot index. Warning: may be slow.
+    sprkey_t    FindTopmostSprite() const;
     // Loads sprite and and locks in memory (so it cannot get removed implicitly)
     void        Precache(sprkey_t index);
     // Unregisters sprite from the bank and optionally deletes bitmap
@@ -127,7 +129,7 @@ public:
     // Closes file stream
     void        DetachFile();
     // Saves all sprites until lastElement (exclusive) to file 
-    int         SaveToFile(const char *filename, sprkey_t lastElement, bool compressOutput);
+    int         SaveToFile(const char *filename, bool compressOutput);
     // Saves sprite index table in a separate file
     int         SaveSpriteIndex(const char *filename, int spriteFileIDCheck, sprkey_t lastslot, sprkey_t numsprits,
         const std::vector<int16_t> &spritewidths, const std::vector<int16_t> &spriteheights, const std::vector<soff_t> &spriteoffs);
@@ -181,13 +183,12 @@ private:
     int _listend;
 
     // Loads sprite index file
-    bool        LoadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t numspri);
+    bool        LoadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t topmost);
     // Rebuilds sprite index from the main sprite file
-    int         RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t numspri, SpriteFileVersion vers);
+    int         RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost, SpriteFileVersion vers);
     // Writes compressed sprite to the stream
     void        CompressSprite(Common::Bitmap *sprite, Common::Stream *out);
 
-    void initFile_adjustBuffers(sprkey_t numspri);
     void initFile_initNullSpriteParams(sprkey_t index);
 };
 

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -19,7 +19,8 @@
 #ifndef __SPRCACHE_H
 #define __SPRCACHE_H
 
-#include "core/types.h"
+#include <vector>
+#include "ac/gamestructdefines.h"
 
 namespace AGS { namespace Common { class Stream; class Bitmap; } }
 using namespace AGS; // FIXME later
@@ -42,7 +43,7 @@ using namespace AGS; // FIXME later
 class SpriteCache
 {
 public:
-  SpriteCache(int32_t maxElements);
+  SpriteCache(int32_t maxElements, std::vector<SpriteInfo> &sprInfos);
 
   int  initFile(const char *);
   soff_t loadSprite(int);
@@ -86,6 +87,8 @@ private:
 
   void initFile_adjustBuffers(short numspri);
   void initFile_initNullSpriteParams(int vv);
+
+  std::vector<SpriteInfo> &_sprInfos;
 };
 
 extern SpriteCache spriteset;

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -12,7 +12,25 @@
 //
 //=============================================================================
 //
-// sprite caching system
+// Sprite caching system.
+//
+// TODO: split out sprite serialization into something like "SpriteFile" class.
+// SpriteCache should only manage caching and provide bitmaps by demand.
+// There should be a separate unit which manages streaming and decompressing.
+// Perhaps an interface which would allow multiple implementation depending
+// on compression type.
+//
+// TODO: use 64-bit file offsets for over 2GB files.
+//
+// TODO: store sprite data in a specialized container type that is optimized
+// for having most keys allocated in large continious sequences by default.
+//
+// Only for the reference: one of the ideas is for container to have a table
+// of arrays of fixed size internally. When getting an item the hash would be
+// first divided on array size to find the array the item resides in, then the
+// item is taken from item from slot index = (hash - arrsize * arrindex).
+// TODO: find out if there is already a hash table kind that follows similar
+// principle.
 //
 //=============================================================================
 
@@ -28,7 +46,9 @@ using namespace AGS; // FIXME later
 // We can't rely on offsets[slot]==0 because when the engine is running
 // this is changed to reference the Bluecup sprite. Therefore we need
 // a definite way of knowing whether the sprite existed in the sprite file.
-#define SPRCACHEFLAG_DOESNOTEXIST 1
+#define SPRCACHEFLAG_DOESNOTEXIST   0x01
+// Locked sprites are ones that should not be freed when clearing cache space.
+#define SPRCACHEFLAG_LOCKED         0x02
 
 // Max size of the sprite cache, in bytes
 #if defined (PSP_VERSION)
@@ -40,55 +60,101 @@ using namespace AGS; // FIXME later
 #define DEFAULTCACHESIZE 128 * 1024 * 1024
 #endif
 
+typedef int32_t sprkey_t;
+
 class SpriteCache
 {
 public:
-  SpriteCache(int32_t maxElements, std::vector<SpriteInfo> &sprInfos);
+    const sprkey_t MIN_SPRITE_INDEX = 1; // 0 is reserved for "empty sprite"
+    const sprkey_t MAX_SPRITE_INDEX = INT32_MAX - 1;
 
-  int  initFile(const char *);
-  soff_t loadSprite(int);
-  void seekToSprite(int index);
-  void precache(int);           // preloads and locks in memory
-  void set(int, Common::Bitmap *);
-  void setNonDiscardable(int, Common::Bitmap *);
-  void removeSprite(int, bool);
-  void removeOldest();
-  void reset();                 // wipes all data 
-  void init();
-  void changeMaxSize(int32_t);
-  int  enlargeTo(int32_t);
-  void removeAll();             // removes all items from the cache
-  int  findFreeSlot();
-  int  saveToFile(const char *, int lastElement, bool compressOutput);
-  int  doesSpriteExist(int index);
-  void detachFile();
-  int  attachFile(const char *);
+    SpriteCache(sprkey_t reserve_count, std::vector<SpriteInfo> &sprInfos);
 
-  Common::Bitmap *operator[] (int index);
+    // Tells if there is a sprite registered for the given index
+    bool        DoesSpriteExist(sprkey_t index);
+    // Makes sure sprite cache has registered slots for all sprites up to the given exclusive limit
+    sprkey_t    EnlargeTo(sprkey_t newsize);
+    // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
+    sprkey_t    AddNewSprite();
+    // Returns current size of the cache, in bytes
+    size_t      GetCacheSize() const;
+    // Gets the total size of the locked sprites, in bytes
+    size_t      GetLockedSize() const;
+    // Returns maximal size limit of the cache, in bytes
+    size_t      GetMaxCacheSize() const;
+    // Returns number of sprite slots in the bank (this includes both actual sprites and free slots)
+    sprkey_t    GetSpriteSlotCount() const;
+    // Loads sprite reference information and inits sprite stream
+    int         InitFile(const char *);
+    // Loads sprite and and locks in memory (so it cannot get removed implicitly)
+    void        Precache(sprkey_t index);
+    // Removes all loaded images from the cache
+    void        RemoveAll();
+    // Deletes all data and resets cache to the clear state
+    void        Reset();
+    // Assigns new bitmap for the given sprite index
+    void        Set(sprkey_t index, Common::Bitmap *);
+    // Sets max cache size in bytes
+    void        SetMaxCacheSize(size_t size);
 
-  soff_t *offsets;
-  soff_t sprite0InitialOffset;
-  int32_t elements;                // size of offsets/images arrays
-  Common::Bitmap **images;
-  soff_t *sizes;
-  unsigned char *flags;
-  Common::Stream *cache_stream;
-  bool spritesAreCompressed;
-  soff_t cachesize;               // size in bytes of currently cached images
-  int *mrulist, *mrubacklink;
-  int liststart, listend;
-  int lastLoad;
-  soff_t maxCacheSize;
-  soff_t lockedSize;              // size in bytes of currently locked images
+    // Loads (if it's not in cache yet) and returns bitmap by the sprite index
+    Common::Bitmap *operator[] (sprkey_t index);
 
 private:
+    size_t loadSprite(sprkey_t);
+    void seekToSprite(sprkey_t index);
+    void setNonDiscardable(sprkey_t, Common::Bitmap *);
+    void removeSprite(sprkey_t, bool);
+    void removeOldest();
+    void init(sprkey_t reserve_count = 1);
+    int  saveToFile(const char *, sprkey_t lastElement, bool compressOutput);
+    void detachFile();
+    int  attachFile(const char *);
+
+    // Information required for the sprite streaming
+    // TODO: make compatible with large (over 2GB) files
+    // (may need some data conversion when loading sprite index file)
+    // TODO: split into sprite cache and sprite stream data
+    struct SpriteData
+    {
+        soff_t          Offset; // data offset
+        soff_t          Size;   // cache size of element, in bytes
+        uint8_t         Flags;
+        // TODO: investigate if we may safely use unique_ptr here
+        // (some of these bitmaps may be assigned from outside of the cache)
+        Common::Bitmap *Image; // actual bitmap
+
+        SpriteData();
+        ~SpriteData();
+    };
+
+    // Provided map of sprite infos, to fill in loaded sprite properties
+    std::vector<SpriteInfo> &_sprInfos;
+    // Array of sprite references
+    std::vector<SpriteData> _spriteData;
+    bool _compressed;        // are sprites compressed
+    soff_t _sprite0InitialOffset; // offset of the first sprite in the stream
+
+    Common::Stream *_stream; // the sprite stream
+    sprkey_t _lastLoad; // last loaded sprite index
+
+    size_t _maxCacheSize;  // cache size limit
+    size_t _lockedSize;    // size in bytes of currently locked images
+    size_t _cacheSize;     // size in bytes of currently cached images
+
+    // MRU list: the way to track which sprites were used recently.
+    // When clearing up space for new sprites, cache first deletes the sprites
+    // that were last time used long ago.
+    std::vector<sprkey_t> _mrulist;
+    std::vector<sprkey_t> _mrubacklink;
+    int _liststart;
+    int _listend;
+
     void compressSprite(Common::Bitmap *sprite, Common::Stream *out);
-  bool loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, short numspri);
+    bool loadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t numspri);
 
-  void initFile_adjustBuffers(short numspri);
-  void initFile_initNullSpriteParams(int vv);
-
-  std::vector<SpriteInfo> &_sprInfos;
+    void initFile_adjustBuffers(sprkey_t numspri);
+    void initFile_initNullSpriteParams(sprkey_t index);
 };
 
 extern SpriteCache spriteset;

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -109,6 +109,10 @@ struct LoadedGameEntities
     std::vector<PScript>    ScriptModules;
     std::vector<PluginInfo> PluginInfos;
 
+    // Original sprite data (when it was read into const-sized arrays)
+    size_t                  SpriteCount;
+    std::unique_ptr<char[]> SpriteFlags;
+
     // Old dialog support
     // legacy compiled dialog script of its own format,
     // requires separate interpreting
@@ -119,6 +123,7 @@ struct LoadedGameEntities
     std::vector<String>     OldSpeechLines;
 
     LoadedGameEntities(GameSetupStruct &game, DialogTopic *&dialogs, ViewStruct *&views);
+    ~LoadedGameEntities();
 };
 
 // Tells if the given path (library filename) contains main game file

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -96,7 +96,7 @@ namespace AGS.Editor.Components
                 Game game = _agsEditor.CurrentGame;
                 StringBuilder sb = new StringBuilder(1000);
                 int numSprites = CountSprites(game.RootSpriteFolder);
-                sb.AppendFormat("Total sprites:\t{0} / {1}\n", numSprites, Game.MAX_SPRITES);
+                sb.AppendFormat("Total sprites:\t{0} / {1}\n", numSprites, NativeConstants.MAX_STATIC_SPRITES);
                 int numSpriteFolders = CountSpriteFolders(game.RootSpriteFolder);
                 sb.AppendFormat("Sprite folders:\t{0}\n", numSpriteFolders);
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1413,10 +1413,10 @@ namespace AGS.Editor
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
             }
-            writer.Write(NativeConstants.MAX_SPRITES);
-            byte[] spriteFlags = new byte[NativeConstants.MAX_SPRITES];
+            writer.Write(NativeConstants.MAX_STATIC_SPRITES);
+            byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];
             UpdateSpriteFlags(game.RootSpriteFolder, spriteFlags);
-            for (int i = 0; i < NativeConstants.MAX_SPRITES; ++i)
+            for (int i = 0; i < NativeConstants.MAX_STATIC_SPRITES; ++i)
             {
                 writer.Write(spriteFlags[i]);
             }

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -601,17 +601,21 @@ namespace AGS.Editor
             // no final padding required
         }
 
-        private static void UpdateSpriteFlags(SpriteFolder folder, byte[] flags)
+        private static void UpdateSpriteFlags(SpriteFolder folder, byte[] flags, out int mostTopmost)
         {
+            mostTopmost = -1;
             foreach (Sprite sprite in folder.Sprites)
             {
+                mostTopmost = Math.Max(sprite.Number, mostTopmost);
                 flags[sprite.Number] = 0;
                 if (sprite.Resolution == SpriteImportResolution.HighRes) flags[sprite.Number] |= NativeConstants.SPF_640x400;
                 if (sprite.AlphaChannel) flags[sprite.Number] |= NativeConstants.SPF_ALPHACHANNEL;
             }
             foreach (SpriteFolder subfolder in folder.SubFolders)
             {
-                UpdateSpriteFlags(subfolder, flags);
+                int topmost;
+                UpdateSpriteFlags(subfolder, flags, out topmost);
+                mostTopmost = Math.Max(topmost, mostTopmost);
             }
         }
 
@@ -1413,10 +1417,11 @@ namespace AGS.Editor
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
             }
-            writer.Write(NativeConstants.MAX_STATIC_SPRITES);
+            int topmostSprite;
             byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];
-            UpdateSpriteFlags(game.RootSpriteFolder, spriteFlags);
-            for (int i = 0; i < NativeConstants.MAX_STATIC_SPRITES; ++i)
+            UpdateSpriteFlags(game.RootSpriteFolder, spriteFlags, out topmostSprite);
+            writer.Write(topmostSprite + 1);
+            for (int i = 0; i <= topmostSprite; ++i)
             {
                 writer.Write(spriteFlags[i]);
             }

--- a/Editor/AGS.Editor/GUI/NumberEntryDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/NumberEntryDialog.Designer.cs
@@ -70,11 +70,6 @@ namespace AGS.Editor
             // udNumber
             // 
             this.udNumber.Location = new System.Drawing.Point(22, 49);
-            this.udNumber.Maximum = new decimal(new int[] {
-            30000,
-            0,
-            0,
-            0});
             this.udNumber.Name = "udNumber";
             this.udNumber.Size = new System.Drawing.Size(115, 20);
             this.udNumber.TabIndex = 5;

--- a/Editor/AGS.Editor/GUI/NumberEntryDialog.cs
+++ b/Editor/AGS.Editor/GUI/NumberEntryDialog.cs
@@ -10,12 +10,14 @@ namespace AGS.Editor
 {
     public partial class NumberEntryDialog : Form
     {
-        private NumberEntryDialog(string titleText, string headerText, int initialValue)
+        private NumberEntryDialog(string titleText, string headerText, int initialValue, int minValue, int maxValue)
         {
             InitializeComponent();
             this.Text = titleText;
             lblHeader.Text = headerText;
             udNumber.Value = initialValue;
+            udNumber.Minimum = minValue;
+            udNumber.Maximum = maxValue;
             udNumber.Select();
             udNumber.Select(0, ((int)udNumber.Value).ToString().Length);
         }
@@ -26,10 +28,10 @@ namespace AGS.Editor
             set { udNumber.Value = value; }
         }
 
-        public static int Show(string titleBar, string headerText, int currentValue)
+        public static int Show(string titleBar, string headerText, int currentValue, int minValue = Int32.MinValue, int maxValue = Int32.MaxValue)
         {
             int result = -1;
-            NumberEntryDialog dialog = new NumberEntryDialog(titleBar, headerText, currentValue);
+            NumberEntryDialog dialog = new NumberEntryDialog(titleBar, headerText, currentValue, minValue, maxValue);
             if (dialog.ShowDialog() == DialogResult.OK)
             {
                 result = dialog.Number;

--- a/Editor/AGS.Editor/GUI/NumberEntryDialog.resx
+++ b/Editor/AGS.Editor/GUI/NumberEntryDialog.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -66,7 +66,7 @@ namespace AGS.Editor
 
         private void ImportTTFFont(string fileName, string newTTFName, string newWFNName)
         {
-            int fontSize = NumberEntryDialog.Show("Font size", "Select the font size to import this TTF font at:", DEFAULT_IMPORTED_FONT_SIZE);
+            int fontSize = NumberEntryDialog.Show("Font size", "Select the font size to import this TTF font at:", DEFAULT_IMPORTED_FONT_SIZE, 1);
             if (fontSize > 0)
             {
                 File.Copy(fileName, newTTFName, true);

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -731,7 +731,7 @@ namespace AGS.Editor
                     }
 
                     Sprite sprite = FindSpriteByNumber(_spriteNumberOnMenuActivation);
-                    int newNumber = NumberEntryDialog.Show("Change Sprite Number", "Enter the new sprite number in the box below:", sprite.Number);
+                    int newNumber = NumberEntryDialog.Show("Change Sprite Number", "Enter the new sprite number in the box below:", sprite.Number, 0, NativeConstants.MAX_STATIC_SPRITES);
                     if (newNumber == -1)
                     {
                         // Dialog cancelled

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -31,7 +31,7 @@ namespace AGS.Editor
         public static readonly int DFLG_NOREPEAT = (int)Factory.NativeProxy.GetNativeConstant("DFLG_NOREPEAT");
         public static readonly int DTFLG_SHOWPARSER = (int)Factory.NativeProxy.GetNativeConstant("DTFLG_SHOWPARSER");
         public static readonly sbyte FONT_OUTLINE_AUTO = (sbyte)(int)Factory.NativeProxy.GetNativeConstant("FONT_OUTLINE_AUTO");
-        public static readonly int MAX_SPRITES = (int)Factory.NativeProxy.GetNativeConstant("MAX_SPRITES");
+        public static readonly int MAX_STATIC_SPRITES = (int)Factory.NativeProxy.GetNativeConstant("MAX_STATIC_SPRITES");
         public static readonly int MAX_CURSOR = (int)Factory.NativeProxy.GetNativeConstant("MAX_CURSOR");
         public static readonly int MAX_PARSER_WORD_LENGTH = (int)Factory.NativeProxy.GetNativeConstant("MAX_PARSER_WORD_LENGTH");
         public static readonly int MAX_INV = (int)Factory.NativeProxy.GetNativeConstant("MAX_INV");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -665,7 +665,7 @@ namespace AGS
             if (name->Equals("DFLG_NOREPEAT")) return DFLG_NOREPEAT;
             if (name->Equals("DTFLG_SHOWPARSER")) return DTFLG_SHOWPARSER;
             if (name->Equals("FONT_OUTLINE_AUTO")) return FONT_OUTLINE_AUTO;
-            if (name->Equals("MAX_SPRITES")) return MAX_SPRITES;
+            if (name->Equals("MAX_SPRITES")) return MAX_STATIC_SPRITES;
             if (name->Equals("MAX_CURSOR")) return MAX_CURSOR;
             if (name->Equals("MAX_PARSER_WORD_LENGTH")) return MAX_PARSER_WORD_LENGTH;
             if (name->Equals("MAX_INV")) return MAX_INV;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -665,7 +665,7 @@ namespace AGS
             if (name->Equals("DFLG_NOREPEAT")) return DFLG_NOREPEAT;
             if (name->Equals("DTFLG_SHOWPARSER")) return DTFLG_SHOWPARSER;
             if (name->Equals("FONT_OUTLINE_AUTO")) return FONT_OUTLINE_AUTO;
-            if (name->Equals("MAX_SPRITES")) return MAX_STATIC_SPRITES;
+            if (name->Equals("MAX_STATIC_SPRITES")) return MAX_STATIC_SPRITES;
             if (name->Equals("MAX_CURSOR")) return MAX_CURSOR;
             if (name->Equals("MAX_PARSER_WORD_LENGTH")) return MAX_PARSER_WORD_LENGTH;
             if (name->Equals("MAX_INV")) return MAX_INV;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -67,14 +67,13 @@ inline void Cstretch_sprite(Common::Bitmap *dst, Common::Bitmap *src, int x, int
 	Cstretch_sprite(dst->GetAllegroBitmap(), src->GetAllegroBitmap(), x, y, w, h);
 }
 
-
 int sxmult = 1, symult = 1;
 int dsc_want_hires = 0;
 bool enable_greyed_out_masks = true;
 bool outlineGuiObjects;
 color*palette;
 GameSetupStruct thisgame;
-SpriteCache spriteset(MAX_SPRITES + 2);
+SpriteCache spriteset(MAX_STATIC_SPRITES + 2, thisgame.SpriteInfos);
 GUIMain tempgui;
 const char*sprsetname = "acsprset.spr";
 const char *old_editor_data_file = "editor.dat";
@@ -168,12 +167,12 @@ Common::Bitmap *get_sprite (int spnr) {
 void SetNewSprite(int slot, Common::Bitmap *sprit) {
   delete spriteset[slot];
 
-  spriteset.setNonDiscardable(slot, sprit);
+  spriteset.SetSpriteAndLock(slot, sprit);
   spritesModified = true;
 }
 
 void deleteSprite (int sprslot) {
-  spriteset.removeSprite(sprslot, true);
+  spriteset.RemoveSprite(sprslot, true);
   
   spritesModified = true;
 }
@@ -194,7 +193,7 @@ bool DoesSpriteExist(int slot) {
 }
 
 int GetMaxSprites() {
-	return MAX_SPRITES;
+	return MAX_STATIC_SPRITES;
 }
 
 int GetSpriteWidth(int slot) {
@@ -206,16 +205,16 @@ int GetSpriteHeight(int slot) {
 }
 
 int GetRelativeSpriteWidth(int slot) {
-	return GetSpriteWidth(slot) / ((thisgame.spriteflags[slot] & SPF_640x400) ? 2 : 1);
+	return GetSpriteWidth(slot) / ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 2 : 1);
 }
 
 int GetRelativeSpriteHeight(int slot) {
-	return GetSpriteHeight(slot) / ((thisgame.spriteflags[slot] & SPF_640x400) ? 2 : 1);
+	return GetSpriteHeight(slot) / ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 2 : 1);
 }
 
 int GetSpriteResolutionMultiplier(int slot)
 {
-	return ((thisgame.spriteflags[slot] & SPF_640x400) ? 1 : 2);
+	return ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 1 : 2);
 }
 
 unsigned char* GetRawSpriteData(int spriteSlot) {
@@ -235,32 +234,25 @@ void transform_string(char *text) {
 }
 
 int find_free_sprite_slot() {
-  int rr = spriteset.findFreeSlot();
-  if (rr < 0) {
-    return -1;
-  }
-  spriteset.images[rr] = NULL;
-  spriteset.offsets[rr] = 0;
-  spriteset.sizes[rr] = 0;
-  return rr;
+  return spriteset.AddNewSprite();
 }
 
 void update_sprite_resolution(int spriteNum, bool isHighRes)
 {
-	thisgame.spriteflags[spriteNum] &= ~SPF_640x400;
+	thisgame.SpriteInfos[spriteNum].Flags &= ~SPF_640x400;
 	if (isHighRes)
 	{
-		thisgame.spriteflags[spriteNum] |= SPF_640x400;
+		thisgame.SpriteInfos[spriteNum].Flags |= SPF_640x400;
 	}
 }
 
 void change_sprite_number(int oldNumber, int newNumber) {
 
-  spriteset.setNonDiscardable(newNumber, spriteset[oldNumber]);
-  spriteset.removeSprite(oldNumber, false);
+  spriteset.SetSpriteAndLock(newNumber, spriteset[oldNumber]);
+  spriteset.RemoveSprite(oldNumber, false);
 
-  thisgame.spriteflags[newNumber] = thisgame.spriteflags[oldNumber];
-  thisgame.spriteflags[oldNumber] = 0;
+  thisgame.SpriteInfos[newNumber].Flags = thisgame.SpriteInfos[oldNumber].Flags;
+  thisgame.SpriteInfos[oldNumber].Flags = 0;
 
   spritesModified = true;
 }
@@ -357,7 +349,7 @@ int crop_sprite_edges(int numSprites, int *sprites, bool symmetric) {
     newsprit->Blit(sprit, left, top, 0, 0, newWidth, newHeight);
     delete sprit;
 
-    spriteset.setNonDiscardable(sprites[aa], newsprit);
+    spriteset.SetSpriteAndLock(sprites[aa], newsprit);
   }
 
   spritesModified = true;
@@ -570,25 +562,25 @@ const char* save_sprites(bool compressSprites)
   char backupname[100];
   sprintf(backupname, "backup_%s", sprsetname);
 
-  if ((spritesModified) || (compressSprites != spriteset.spritesAreCompressed))
+  if ((spritesModified) || (compressSprites != spriteset.IsFileCompressed()))
   {
-    spriteset.detachFile();
+    spriteset.DetachFile();
     if (exists(backupname) && (unlink(backupname) != 0)) {
       errorMsg = "Unable to overwrite the old backup file. Make sure the backup sprite file is not read-only";
     }
     else if (rename(sprsetname, backupname)) {
       errorMsg = "Unable to create the backup sprite file. Make sure the backup sprite file is not read-only";
     }
-    else if (spriteset.attachFile(backupname)) {
+    else if (spriteset.AttachFile(backupname)) {
       errorMsg = "An error occurred attaching to the backup sprite file. Check write permissions on your game folder";
     }
-    else if (spriteset.saveToFile(sprsetname, MAX_SPRITES, compressSprites)) {
+    else if (spriteset.SaveToFile(sprsetname, MAX_STATIC_SPRITES, compressSprites)) {
       errorMsg = "Unable to save the sprites. An error occurred writing the sprite file.";
     }
 
     // reset the sprite cache
-    spriteset.reset();
-    if (spriteset.initFile(sprsetname))
+    spriteset.Reset();
+    if (spriteset.InitFile(sprsetname))
     {
       if (errorMsg == NULL)
         errorMsg = "Unable to re-initialize sprite file after save.";
@@ -642,7 +634,7 @@ void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use
     }
 
   int nwid=towrite->GetWidth(),nhit=towrite->GetHeight();
-  if (thisgame.spriteflags[sprnum] & SPF_640x400) {
+  if (thisgame.SpriteInfos[sprnum].Flags & SPF_640x400) {
     if (dsc_want_hires == 0) {
       nwid/=2;
       nhit/=2;
@@ -1158,7 +1150,7 @@ int get_adjusted_spritewidth(int spr) {
 
   int retval = tsp->GetWidth();
 
-  if (thisgame.spriteflags[spr] & SPF_640x400) {
+  if (thisgame.SpriteInfos[spr].Flags & SPF_640x400) {
     if (sxmult == 1)
       retval /= 2;
   }
@@ -1175,7 +1167,7 @@ int get_adjusted_spriteheight(int spr) {
 
   int retval = tsp->GetHeight();
 
-  if (thisgame.spriteflags[spr] & SPF_640x400) {
+  if (thisgame.SpriteInfos[spr].Flags & SPF_640x400) {
     if (symult == 1)
       retval /= 2;
   }
@@ -1230,10 +1222,10 @@ bool initialize_native()
 	thisgame.numfonts = 0;
 	new_font();
 
-	spriteset.reset();
-	if (spriteset.initFile(sprsetname))
+	spriteset.Reset();
+	if (spriteset.InitFile(sprsetname))
 	  return false;
-	spriteset.maxCacheSize = 100000000;  // 100 mb cache
+	spriteset.SetMaxCacheSize(100 * 1024 * 1024);  // 100 mb cache // TODO: set this up in preferences?
 
 	if (!Scintilla_RegisterClasses (GetModuleHandle(NULL)))
       return false;
@@ -1260,7 +1252,7 @@ void drawBlockScaledAt (int hdc, Common::Bitmap *todraw ,int x, int y, float sca
 }
 
 void drawSprite(int hdc, int x, int y, int spriteNum, bool flipImage) {
-	int scaleFactor = ((thisgame.spriteflags[spriteNum] & SPF_640x400) != 0) ? 1 : 2;
+	int scaleFactor = ((thisgame.SpriteInfos[spriteNum].Flags & SPF_640x400) != 0) ? 1 : 2;
 	Common::Bitmap *theSprite = get_sprite(spriteNum);
 
   if (theSprite == NULL)
@@ -1438,10 +1430,10 @@ bool reload_font(int curFont)
 }
 
 bool reset_sprite_file() {
-  spriteset.reset();
-  if (spriteset.initFile(sprsetname))
+  spriteset.Reset();
+  if (spriteset.InitFile(sprsetname))
     return false;
-  spriteset.maxCacheSize = 100000000;  // 100 mb cache
+  spriteset.SetMaxCacheSize(100 * 1024 * 1024);  // 100 mb cache // TODO: set in preferences?
   return true;
 }
 
@@ -2405,7 +2397,7 @@ void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) {
 	if (todraw == NULL)
 	  todraw = spriteset[0];
 
-	if (((thisgame.spriteflags[sprNum] & SPF_640x400) == 0) &&
+	if (((thisgame.SpriteInfos[sprNum].Flags & SPF_640x400) == 0) &&
 		thisgame.IsHiRes())
 	{
 		scale *= 2.0f;
@@ -2426,7 +2418,7 @@ void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) {
 	int drawWidth = imageToDraw->GetWidth() * scale;
 	int drawHeight = imageToDraw->GetHeight() * scale;
 
-	if ((thisgame.spriteflags[sprNum] & SPF_ALPHACHANNEL) != 0)
+	if ((thisgame.SpriteInfos[sprNum].Flags & SPF_ALPHACHANNEL) != 0)
 	{
 		if (scale > 1.0f)
 		{
@@ -2460,11 +2452,11 @@ void UpdateSpriteFlags(SpriteFolder ^folder)
 {
 	for each (Sprite ^sprite in folder->Sprites)
 	{
-		thisgame.spriteflags[sprite->Number] = 0;
+		thisgame.SpriteInfos[sprite->Number].Flags = 0;
 		if (sprite->Resolution == SpriteImportResolution::HighRes)
-			thisgame.spriteflags[sprite->Number] |= SPF_640x400;
+			thisgame.SpriteInfos[sprite->Number].Flags |= SPF_640x400;
 		if (sprite->AlphaChannel)
-			thisgame.spriteflags[sprite->Number] |= SPF_ALPHACHANNEL;
+			thisgame.SpriteInfos[sprite->Number].Flags |= SPF_ALPHACHANNEL;
 	}
 
 	for each (SpriteFolder^ subFolder in folder->SubFolders) 
@@ -2838,14 +2830,14 @@ int SetNewSpriteFromBitmap(int slot, System::Drawing::Bitmap^ bmp, int spriteImp
 		sort_out_transparency(tempsprite, spriteImportMethod, imgPalBuf, useRoomBackgroundColours, importedColourDepth);
 	}
 
-	thisgame.spriteflags[slot] = 0;
+	thisgame.SpriteInfos[slot].Flags = 0;
 	if (thisgame.IsHiRes())
 	{
-		thisgame.spriteflags[slot] |= SPF_640x400;
+		thisgame.SpriteInfos[slot].Flags |= SPF_640x400;
 	}
 	if (alphaChannel)
 	{
-		thisgame.spriteflags[slot] |= SPF_ALPHACHANNEL;
+		thisgame.SpriteInfos[slot].Flags |= SPF_ALPHACHANNEL;
 
 		if (tempsprite->GetColorDepth() == 32)
 		{
@@ -2969,7 +2961,7 @@ System::Drawing::Bitmap^ ConvertAreaMaskToBitmap(Common::Bitmap *mask)
 
 System::Drawing::Bitmap^ getSpriteAsBitmap(int spriteNum) {
   Common::Bitmap *todraw = get_sprite(spriteNum);
-  return ConvertBlockToBitmap(todraw, (thisgame.spriteflags[spriteNum] & SPF_ALPHACHANNEL) != 0);
+  return ConvertBlockToBitmap(todraw, (thisgame.SpriteInfos[spriteNum].Flags & SPF_ALPHACHANNEL) != 0);
 }
 
 System::Drawing::Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height) {
@@ -2978,7 +2970,7 @@ System::Drawing::Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int he
   {
 	  throw gcnew AGSEditorException(String::Format("getSpriteAsBitmap32bit: Unable to find sprite {0}", spriteNum));
   }
-  return ConvertBlockToBitmap32(todraw, width, height, (thisgame.spriteflags[spriteNum] & SPF_ALPHACHANNEL) != 0);
+  return ConvertBlockToBitmap32(todraw, width, height, (thisgame.SpriteInfos[spriteNum].Flags & SPF_ALPHACHANNEL) != 0);
 }
 
 System::Drawing::Bitmap^ getBackgroundAsBitmap(Room ^room, int backgroundNumber) {
@@ -3193,12 +3185,12 @@ Dictionary<int, Sprite^>^ load_sprite_dimensions()
 {
 	Dictionary<int, Sprite^>^ sprites = gcnew Dictionary<int, Sprite^>();
 
-	for (int i = 0; i < spriteset.elements; i++)
+	for (int i = 0; i < spriteset.GetSpriteSlotCount(); i++)
 	{
 		Common::Bitmap *spr = spriteset[i];
 		if (spr != NULL)
 		{
-			sprites->Add(i, gcnew Sprite(i, spr->GetWidth(), spr->GetHeight(), spr->GetColorDepth(), (thisgame.spriteflags[i] & SPF_640x400) ? SpriteImportResolution::HighRes : SpriteImportResolution::LowRes, (thisgame.spriteflags[i] & SPF_ALPHACHANNEL) ? true : false));
+			sprites->Add(i, gcnew Sprite(i, spr->GetWidth(), spr->GetHeight(), spr->GetColorDepth(), (thisgame.SpriteInfos[i].Flags & SPF_640x400) ? SpriteImportResolution::HighRes : SpriteImportResolution::LowRes, (thisgame.SpriteInfos[i].Flags & SPF_ALPHACHANNEL) ? true : false));
 		}
 	}
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -574,7 +574,7 @@ const char* save_sprites(bool compressSprites)
     else if (spriteset.AttachFile(backupname)) {
       errorMsg = "An error occurred attaching to the backup sprite file. Check write permissions on your game folder";
     }
-    else if (spriteset.SaveToFile(sprsetname, MAX_STATIC_SPRITES, compressSprites)) {
+    else if (spriteset.SaveToFile(sprsetname, compressSprites)) {
       errorMsg = "Unable to save the sprites. An error occurred writing the sprite file.";
     }
 

--- a/Editor/AGS.Native/agsnative.h
+++ b/Editor/AGS.Native/agsnative.h
@@ -30,4 +30,8 @@
 #define CHUNKSIZE 256000
 #define MAX_PLUGINS 40
 
+// TODO: maybe remove this limit completely when engine's sprite cache
+// implements optimized container; see comments for SpriteCache class.
+#define MAX_STATIC_SPRITES 30000
+
 extern const char *sprsetname;

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -23,7 +23,6 @@ namespace AGS.Types
         public const int MAX_CURSORS = 20;
         public const int MAX_DIALOGS = 500;
         public const int MAX_INV_ITEMS = 300;
-        public const int MAX_SPRITES = 30000;
 
         public delegate void GUIAddedOrRemovedHandler(GUI theGUI);
         public delegate void GUIControlAddedOrRemovedHandler(GUI owningGUI, GUIControl control);

--- a/Editor/Native/sprcache_agsnative.cpp
+++ b/Editor/Native/sprcache_agsnative.cpp
@@ -16,15 +16,10 @@
 // AGS.Native-specific implementation split out of sprcache.cpp
 //=============================================================================
 
-void get_new_size_for_sprite(int ee, int ww, int hh, int &newwid, int &newhit) {
+void get_new_size_for_sprite(int ee, int ww, int hh, int &newwid, int &newhit)
+{
   newwid = ww;
   newhit = hh;
-}
-
-void SpriteCache::initFile_adjustBuffers(sprkey_t numspri)
-{
-    // adjust the buffers to the sprite file size
-    EnlargeTo(numspri + 1);
 }
 
 void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)

--- a/Editor/Native/sprcache_agsnative.cpp
+++ b/Editor/Native/sprcache_agsnative.cpp
@@ -20,17 +20,16 @@ void get_new_size_for_sprite(int ee, int ww, int hh, int &newwid, int &newhit) {
   newwid = ww;
   newhit = hh;
 }
-int spritewidth[MAX_SPRITES + 5], spriteheight[MAX_SPRITES + 5];
 
-void SpriteCache::initFile_adjustBuffers(short numspri)
+void SpriteCache::initFile_adjustBuffers(sprkey_t numspri)
 {
-  // do nothing
+    // adjust the buffers to the sprite file size
+    EnlargeTo(numspri + 1);
 }
 
-void SpriteCache::initFile_initNullSpriteParams(int vv)
+void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
 {
-  // no sprite ... blank it out
-  spritewidth[vv] = 0;
-  spriteheight[vv] = 0;
-  offsets[vv] = 0;
+    // no sprite ... blank it out
+    _sprInfos[index] = SpriteInfo();
+    _spriteData[index] = SpriteData();
 }

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -28,7 +28,6 @@ using namespace AGS::Common;
 
 extern GameSetupStruct game;
 extern ViewStruct*views;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 
 // *** BUTTON FUNCTIONS
 
@@ -151,8 +150,8 @@ void Button_SetNormalGraphic(GUIButton *guil, int slotn) {
         guil->CurrentImage = slotn;
     guil->Image = slotn;
     // update the clickable area to the same size as the graphic
-    guil->Width = spritewidth[slotn];
-    guil->Height = spriteheight[slotn];
+    guil->Width = game.SpriteInfos[slotn].Width;
+    guil->Height = game.SpriteInfos[slotn].Height;
 
     guis_need_update = 1;
     FindAndRemoveButtonAnimation(guil->ParentId, guil->Id);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -69,7 +69,6 @@ extern roomstruct thisroom;
 extern MoveList *mls;
 extern ViewStruct*views;
 extern RoomObject*objs;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern ScriptInvItem scrInv[MAX_INV];
 extern SpriteCache spriteset;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
@@ -635,7 +634,7 @@ void Character_LockViewAlignedEx(CharacterInfo *chap, int vii, int loop, int ali
         quit("!SetCharacterLoop: character has invalid old view number");
 
     int sppic = views[chap->view].loops[chap->loop].frames[chap->frame].pic;
-    int leftSide = multiply_up_coordinate(chap->x) - spritewidth[sppic] / 2;
+    int leftSide = multiply_up_coordinate(chap->x) - game.SpriteInfos[sppic].Width / 2;
 
     Character_LockViewEx(chap, vii, stopMoving);
 
@@ -645,7 +644,7 @@ void Character_LockViewAlignedEx(CharacterInfo *chap, int vii, int loop, int ali
     chap->loop = loop;
     chap->frame = 0;
     int newpic = views[chap->view].loops[chap->loop].frames[chap->frame].pic;
-    int newLeft = multiply_up_coordinate(chap->x) - spritewidth[newpic] / 2;
+    int newLeft = multiply_up_coordinate(chap->x) - game.SpriteInfos[newpic].Width / 2;
     int xdiff = 0;
 
     if (align == SCALIGN_LEFT)
@@ -653,7 +652,7 @@ void Character_LockViewAlignedEx(CharacterInfo *chap, int vii, int loop, int ali
     else if (align == SCALIGN_CENTRE)
         xdiff = 0;
     else if (align == SCALIGN_RIGHT)
-        xdiff = (leftSide + spritewidth[sppic]) - (newLeft + spritewidth[newpic]);
+        xdiff = (leftSide + game.SpriteInfos[sppic].Width) - (newLeft + game.SpriteInfos[newpic].Width);
     else
         quit("!SetCharacterViewEx: invalid alignment type specified");
 
@@ -2203,8 +2202,8 @@ int is_pos_on_character(int xx,int yy) {
         sppic=views[chin->view].loops[chin->loop].frames[chin->frame].pic;
         int usewid = charextra[cc].width;
         int usehit = charextra[cc].height;
-        if (usewid==0) usewid=spritewidth[sppic];
-        if (usehit==0) usehit=spriteheight[sppic];
+        if (usewid==0) usewid=game.SpriteInfos[sppic].Width;
+        if (usehit==0) usehit= game.SpriteInfos[sppic].Height;
         int xxx = chin->x - divide_down_coordinate(usewid) / 2;
         int yyy = chin->get_effective_y() - divide_down_coordinate(usehit);
 
@@ -2500,7 +2499,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             int sppic = views[speakingChar->view].loops[speakingChar->loop].frames[0].pic;
             tdyp = multiply_up_coordinate(speakingChar->get_effective_y()) - offsety - get_fixed_pixel_size(5);
             if (charextra[aschar].height < 1)
-                tdyp -= spriteheight[sppic];
+                tdyp -= game.SpriteInfos[sppic].Height;
             else
                 tdyp -= charextra[aschar].height;
             // if it's a thought, lift it a bit further up
@@ -2589,9 +2588,9 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             ViewStruct*viptr=&views[useview];
             for (kk = 0; kk < viptr->loops[0].numFrames; kk++) 
             {
-                int tw = spritewidth[viptr->loops[0].frames[kk].pic];
+                int tw = game.SpriteInfos[viptr->loops[0].frames[kk].pic].Width;
                 if (tw > bigx) bigx=tw;
-                tw = spriteheight[viptr->loops[0].frames[kk].pic];
+                tw = game.SpriteInfos[viptr->loops[0].frames[kk].pic].Height;
                 if (tw > bigy) bigy=tw;
             }
 
@@ -2626,7 +2625,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
                 }
                 else
                 {
-                    view_frame_y = play.viewport.GetHeight()/2 - spriteheight[viptr->loops[0].frames[0].pic]/2;
+                    view_frame_y = play.viewport.GetHeight()/2 - game.SpriteInfos[viptr->loops[0].frames[0].pic].Height/2;
                 }
                 bigx = play.viewport.GetWidth()/2 - get_fixed_pixel_size(20);
                 ovr_type = OVER_COMPLETE;
@@ -2651,7 +2650,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
                     tdyp = ovr_yp + get_textwindow_top_border_height(play.speech_textwindow_gui);
             }
             const ViewFrame *vf = &viptr->loops[0].frames[0];
-            const bool closeupface_has_alpha = (game.spriteflags[vf->pic] & SPF_ALPHACHANNEL) != 0;
+            const bool closeupface_has_alpha = (game.SpriteInfos[vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
             DrawViewFrame(closeupface, vf, view_frame_x, view_frame_y);
 
             int overlay_x = get_fixed_pixel_size(10);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -58,7 +58,6 @@ extern ccInstance *dialogScriptsInst;
 extern int in_new_room;
 extern CharacterInfo*playerchar;
 extern SpriteCache spriteset;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern volatile int timerloop;
 extern AGSPlatformDriver *platform;
 extern int cur_mode,cur_cursor;
@@ -368,7 +367,7 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
       char tempbfr[20];
       int actualpicwid = 0;
       if (game.dialog_bullet > 0)
-        actualpicwid = spritewidth[game.dialog_bullet]+3;
+        actualpicwid = game.SpriteInfos[game.dialog_bullet].Width+3;
 
       sprintf (tempbfr, "%d.", ww + 1);
       wouttext_outline (ds, dlgxp + actualpicwid, curyp, usingfont, text_color, tempbfr);
@@ -502,7 +501,7 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
   update_polled_stuff_if_runtime();
 
   if (game.dialog_bullet > 0)
-    bullet_wid = spritewidth[game.dialog_bullet]+3;
+    bullet_wid = game.SpriteInfos[game.dialog_bullet].Width+3;
 
   // numbered options, leave space for the numbers
   if (game.options[OPT_DIALOGNUMBERED] == kDlgOptNumbering)

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -57,7 +57,6 @@ extern int time_between_timers;
 extern int offsetx, offsety;
 extern int frames_per_second;
 extern int loops_per_character;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 
 int display_message_aschar=0;
@@ -526,8 +525,8 @@ void do_corner(Bitmap *ds, int sprn, int x, int y, int offx, int offy) {
         sprn = 0;
     }
 
-    x = x + offx * spritewidth[sprn];
-    y = y + offy * spriteheight[sprn];
+    x = x + offx * game.SpriteInfos[sprn].Width;
+    y = y + offy * game.SpriteInfos[sprn].Height;
     draw_gui_sprite_v330(ds, sprn, x, y);
 }
 
@@ -562,8 +561,8 @@ void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*
         if (iep->BgColor > 0)
             ds->FillRect(Rect(xx1,yy1,xx2,yy2), draw_color);
 
-        int leftRightWidth = spritewidth[get_but_pic(iep,4)];
-        int topBottomHeight = spriteheight[get_but_pic(iep,6)];
+        int leftRightWidth = game.SpriteInfos[get_but_pic(iep,4)].Width;
+        int topBottomHeight = game.SpriteInfos[get_but_pic(iep,6)].Height;
         if (iep->BgImage>0) {
             if ((loaded_game_file_version <= kGameVersion_272) // 2.xx
                 && (spriteset[iep->BgImage]->GetWidth() == 1)
@@ -589,20 +588,20 @@ void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*
                     while (bgoffsy <= bgfinishy)
                     {
                         draw_gui_sprite_v330(ds, iep->BgImage, bgoffsx, bgoffsy);
-                        bgoffsy += spriteheight[iep->BgImage];
+                        bgoffsy += game.SpriteInfos[iep->BgImage].Height;
                     }
-                    bgoffsx += spritewidth[iep->BgImage];
+                    bgoffsx += game.SpriteInfos[iep->BgImage].Width;
                 }
                 // return to normal clipping rectangle
                 ds->SetClip(Rect(0, 0, ds->GetWidth() - 1, ds->GetHeight() - 1));
             }
         }
         int uu;
-        for (uu=yy1;uu <= yy2;uu+=spriteheight[get_but_pic(iep,4)]) {
+        for (uu=yy1;uu <= yy2;uu+= game.SpriteInfos[get_but_pic(iep,4)].Height) {
             do_corner(ds, get_but_pic(iep,4),xx1,uu,-1,0);   // left side
             do_corner(ds, get_but_pic(iep,5),xx2+1,uu,0,0);  // right side
         }
-        for (uu=xx1;uu <= xx2;uu+=spritewidth[get_but_pic(iep,6)]) {
+        for (uu=xx1;uu <= xx2;uu+=game.SpriteInfos[get_but_pic(iep,6)].Width) {
             do_corner(ds, get_but_pic(iep,6),uu,yy1,0,-1);  // top side
             do_corner(ds, get_but_pic(iep,7),uu,yy2+1,0,0); // bottom side
         }
@@ -622,8 +621,8 @@ int get_textwindow_border_width (int twgui) {
     if (!guis[twgui].IsTextWindow())
         quit("!GUI set as text window but is not actually a text window GUI");
 
-    int borwid = spritewidth[get_but_pic(&guis[twgui], 4)] + 
-        spritewidth[get_but_pic(&guis[twgui], 5)];
+    int borwid = game.SpriteInfos[get_but_pic(&guis[twgui], 4)].Width + 
+        game.SpriteInfos[get_but_pic(&guis[twgui], 5)].Width;
 
     return borwid;
 }
@@ -636,7 +635,7 @@ int get_textwindow_top_border_height (int twgui) {
     if (!guis[twgui].IsTextWindow())
         quit("!GUI set as text window but is not actually a text window GUI");
 
-    return spriteheight[get_but_pic(&guis[twgui], 6)];
+    return game.SpriteInfos[get_but_pic(&guis[twgui], 6)].Height;
 }
 
 // Get the padding for a text window
@@ -679,17 +678,17 @@ void draw_text_window(Bitmap **text_window_ds, bool should_free_ds,
         int tbnum = get_but_pic(&guis[ifnum], 0);
 
         wii[0] += get_textwindow_border_width (ifnum);
-        xx[0]-=spritewidth[tbnum];
-        yy[0]-=spriteheight[tbnum];
+        xx[0]-=game.SpriteInfos[tbnum].Width;
+        yy[0]-=game.SpriteInfos[tbnum].Height;
         if (ovrheight == 0)
             ovrheight = disp.fulltxtheight;
 
         if (should_free_ds)
             delete *text_window_ds;
         int padding = get_textwindow_padding(ifnum);
-        *text_window_ds = BitmapHelper::CreateTransparentBitmap(wii[0],ovrheight+(padding*2)+spriteheight[tbnum]*2,game.GetColorDepth());
+        *text_window_ds = BitmapHelper::CreateTransparentBitmap(wii[0],ovrheight+(padding*2)+ game.SpriteInfos[tbnum].Height*2,game.GetColorDepth());
         ds = SetVirtualScreen(*text_window_ds);
-        int xoffs=spritewidth[tbnum],yoffs=spriteheight[tbnum];
+        int xoffs=game.SpriteInfos[tbnum].Width,yoffs= game.SpriteInfos[tbnum].Height;
         draw_button_background(ds, xoffs,yoffs,(ds->GetWidth() - xoffs) - 1,(ds->GetHeight() - yoffs) - 1,&guis[ifnum]);
         if (set_text_color)
             *set_text_color = ds->GetCompatibleColor(guis[ifnum].FgColor);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -94,7 +94,6 @@ extern IDriverDependantBitmap *walkBehindBitmap[MAX_OBJ];
 extern int walkBehindsCachedForBgNum;
 extern WalkBehindMethodEnum walkBehindMethod;
 extern int walk_behind_baselines_changed;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern RoomStatus*croom;
 extern int our_eip;
@@ -849,7 +848,7 @@ void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos
 void draw_sprite_slot_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot,
                                     BlendMode blend_mode, int alpha)
 {
-    draw_sprite_support_alpha(ds, ds_has_alpha, xpos, ypos, spriteset[src_slot], (game.spriteflags[src_slot] & SPF_ALPHACHANNEL) != 0,
+    draw_sprite_support_alpha(ds, ds_has_alpha, xpos, ypos, spriteset[src_slot], (game.SpriteInfos[src_slot].Flags & SPF_ALPHACHANNEL) != 0,
         blend_mode, alpha);
 }
 
@@ -1056,7 +1055,7 @@ void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baselin
         return;
 
     SpriteListEntry sprite;
-    if ((sprNum >= 0) && ((game.spriteflags[sprNum] & SPF_ALPHACHANNEL) != 0))
+    if ((sprNum >= 0) && ((game.SpriteInfos[sprNum].Flags & SPF_ALPHACHANNEL) != 0))
         sprite.hasAlphaChannel = true;
     else
         sprite.hasAlphaChannel = false;
@@ -1098,7 +1097,7 @@ void draw_gui_sprite(Bitmap *ds, int pic, int x, int y, bool use_alpha, BlendMod
 {
     Bitmap *sprite = spriteset[pic];
     const bool ds_has_alpha  = ds->GetColorDepth() == 32;
-    const bool src_has_alpha = (game.spriteflags[pic] & SPF_ALPHACHANNEL) != 0;
+    const bool src_has_alpha = (game.SpriteInfos[pic].Flags & SPF_ALPHACHANNEL) != 0;
 
     if (use_alpha && game.options[OPT_NEWGUIALPHA] == kGuiAlphaRender_Improved)
     {
@@ -1374,14 +1373,14 @@ int scale_and_flip_sprite(int useindx, int coldept, int zoom_level,
       if (isMirrored) {
           Bitmap *tempspr = BitmapHelper::CreateBitmap(newwidth, newheight,coldept);
           tempspr->Fill (actsps[useindx]->GetMaskColor());
-          if ((IS_ANTIALIAS_SPRITES) && ((game.spriteflags[sppic] & SPF_ALPHACHANNEL) == 0))
+          if ((IS_ANTIALIAS_SPRITES) && ((game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) == 0))
               tempspr->AAStretchBlt (spriteset[sppic], RectWH(0, 0, newwidth, newheight), Common::kBitmap_Transparency);
           else
               tempspr->StretchBlt (spriteset[sppic], RectWH(0, 0, newwidth, newheight), Common::kBitmap_Transparency);
           active_spr->FlipBlt(tempspr, 0, 0, Common::kBitmap_HFlip);
           delete tempspr;
       }
-      else if ((IS_ANTIALIAS_SPRITES) && ((game.spriteflags[sppic] & SPF_ALPHACHANNEL) == 0))
+      else if ((IS_ANTIALIAS_SPRITES) && ((game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) == 0))
           active_spr->AAStretchBlt(spriteset[sppic],RectWH(0,0,newwidth,newheight), Common::kBitmap_Transparency);
       else
           active_spr->StretchBlt(spriteset[sppic],RectWH(0,0,newwidth,newheight), Common::kBitmap_Transparency);
@@ -1442,8 +1441,8 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
         quitprintf("There was an error drawing object %d. Its current sprite, %d, is invalid.", aa, objs[aa].num);
 
     int coldept = spriteset[objs[aa].num]->GetColorDepth();
-    int sprwidth = spritewidth[objs[aa].num];
-    int sprheight = spriteheight[objs[aa].num];
+    int sprwidth = game.SpriteInfos[objs[aa].num].Width;
+    int sprheight = game.SpriteInfos[objs[aa].num].Height;
 
     int tint_red, tint_green, tint_blue;
     int tint_level, tint_light, light_level;
@@ -1576,7 +1575,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
     else
     {
         // ensure actsps exists
-        actsps[useindx] = recycle_bitmap(actsps[useindx], coldept, spritewidth[objs[aa].num], spriteheight[objs[aa].num]);
+        actsps[useindx] = recycle_bitmap(actsps[useindx], coldept, game.SpriteInfos[objs[aa].num].Width, game.SpriteInfos[objs[aa].num].Height);
     }
 
     // direct read from source bitmap, where possible
@@ -1594,7 +1593,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
             comeFrom);
     }
     else if (!actspsUsed) {
-        actsps[useindx]->Blit(spriteset[objs[aa].num],0,0,0,0,spritewidth[objs[aa].num],spriteheight[objs[aa].num]);
+        actsps[useindx]->Blit(spriteset[objs[aa].num],0,0,0,0,game.SpriteInfos[objs[aa].num].Width, game.SpriteInfos[objs[aa].num].Height);
     }
 
     // Re-use the bitmap if it's the same size
@@ -1662,7 +1661,7 @@ void prepare_objects_for_drawing() {
 
         if ((!actspsIntact) || (actspsbmp[useindx] == NULL))
         {
-            bool hasAlpha = (game.spriteflags[objs[aa].num] & SPF_ALPHACHANNEL) != 0;
+            bool hasAlpha = (game.SpriteInfos[objs[aa].num].Flags & SPF_ALPHACHANNEL) != 0;
 
             if (actspsbmp[useindx] != NULL)
                 gfxDriver->DestroyDDB(actspsbmp[useindx]);
@@ -1775,7 +1774,7 @@ void prepare_characters_for_drawing() {
         }
 
         sppic=views[chin->view].loops[chin->loop].frames[chin->frame].pic;
-        if ((sppic < 0) || (sppic >= MAX_SPRITES))
+        if (sppic < 0)
             sppic = 0;  // in case it's screwed up somehow
         our_eip = 331;
         // sort out the stretching if required
@@ -1881,8 +1880,8 @@ void prepare_characters_for_drawing() {
             // draw at original size, so just use the sprite width and height
             charextra[aa].width=0;
             charextra[aa].height=0;
-            newwidth = spritewidth[sppic];
-            newheight = spriteheight[sppic];
+            newwidth = game.SpriteInfos[sppic].Width;
+            newheight = game.SpriteInfos[sppic].Height;
         }
 
         our_eip = 3336;
@@ -1915,7 +1914,7 @@ void prepare_characters_for_drawing() {
             else 
             {
                 // ensure actsps exists
-                actsps[useindx] = recycle_bitmap(actsps[useindx], coldept, spritewidth[sppic], spriteheight[sppic]);
+                actsps[useindx] = recycle_bitmap(actsps[useindx], coldept, game.SpriteInfos[sppic].Width, game.SpriteInfos[sppic].Height);
             }
 
             our_eip = 335;
@@ -1973,7 +1972,7 @@ void prepare_characters_for_drawing() {
 
         if ((!usingCachedImage) || (actspsbmp[useindx] == NULL))
         {
-            bool hasAlpha = (game.spriteflags[sppic] & SPF_ALPHACHANNEL) != 0;
+            bool hasAlpha = (game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) != 0;
 
             actspsbmp[useindx] = recycle_ddb_bitmap(actspsbmp[useindx], actsps[useindx], hasAlpha);
         }

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -43,7 +43,6 @@ extern RoomObject*objs;
 extern CharacterCache *charcache;
 extern ObjectCache objcache[MAX_INIT_SPR];
 extern SpriteCache spriteset;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern Bitmap *dynamicallyCreatedSurfaces[MAX_DYNAMIC_SURFACES];
 
 extern int current_screen_resolution_multiplier;
@@ -219,7 +218,7 @@ void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurfa
 
 void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
 {
-    if ((slot < 0) || (slot >= MAX_SPRITES) || (spriteset[slot] == NULL))
+    if ((slot < 0) || (spriteset[slot] == NULL))
         quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
 
     if ((trans < 0) || (trans > 100))
@@ -245,7 +244,7 @@ void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slo
         Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, sourcePic->GetColorDepth());
 
         newPic->StretchBlt(sourcePic,
-            RectWH(0, 0, spritewidth[slot], spriteheight[slot]),
+            RectWH(0, 0, game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height),
             RectWH(0, 0, width, height));
 
         sourcePic = newPic;
@@ -260,7 +259,7 @@ void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slo
         debug_script_warn("RawDrawImage: Sprite %d colour depth %d-bit not same as background depth %d-bit", slot, spriteset[slot]->GetColorDepth(), ds->GetColorDepth());
     }
 
-    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, xx, yy, sourcePic, (game.spriteflags[slot] & SPF_ALPHACHANNEL) != 0,
+    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, xx, yy, sourcePic, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0,
         kBlendMode_Alpha, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -301,7 +301,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromFile(const char *filename) {
 
 ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
 
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return NULL;
 
@@ -354,11 +354,11 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
 
 ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preserveAlphaChannel) {
 
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return NULL;
 
-    if (!spriteset.doesSpriteExist(slot))
+    if (!spriteset.DoesSpriteExist(slot))
         quitprintf("DynamicSprite.CreateFromExistingSprite: sprite %d does not exist", slot);
 
     // create a new sprite as a copy of the existing one
@@ -376,7 +376,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preser
 
 ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface *sds, int x, int y, int width, int height) 
 {
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return NULL;
 
@@ -408,7 +408,7 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
 {
     multiply_up_coordinates(&width, &height);
 
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return NULL;
 
@@ -450,7 +450,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y
     multiply_up_coordinates(&x1, &y1);
     multiply_up_coordinates(&width, &height);
 
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return NULL;
 
@@ -471,7 +471,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y
 
 void add_dynamic_sprite(int gotSlot, Bitmap *redin, bool hasAlpha) {
 
-  spriteset.set(gotSlot, redin);
+  spriteset.Set(gotSlot, redin);
 
   game.SpriteInfos[gotSlot].Flags = SPF_DYNAMICALLOC;
 
@@ -489,14 +489,14 @@ void add_dynamic_sprite(int gotSlot, Bitmap *redin, bool hasAlpha) {
 void free_dynamic_sprite (int gotSlot) {
   int tt;
 
-  if ((gotSlot < 0) || (gotSlot >= spriteset.elements))
+  if ((gotSlot < 0) || (gotSlot >= spriteset.GetSpriteSlotCount()))
     quit("!FreeDynamicSprite: invalid slot number");
 
   if ((game.SpriteInfos[gotSlot].Flags & SPF_DYNAMICALLOC) == 0)
     quitprintf("!DeleteSprite: Attempted to free static sprite %d that was not loaded by the script", gotSlot);
 
   delete spriteset[gotSlot];
-  spriteset.set(gotSlot, NULL);
+  spriteset.Set(gotSlot, NULL);
 
   game.SpriteInfos[gotSlot].Flags = 0;
   game.SpriteInfos[gotSlot].Width = 0;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -746,7 +746,7 @@ int Game_GetSpriteWidth(int spriteNum) {
     if (spriteNum < 0)
         return 0;
 
-    if (!spriteset.doesSpriteExist(spriteNum))
+    if (!spriteset.DoesSpriteExist(spriteNum))
         return 0;
 
     return divide_down_coordinate(game.SpriteInfos[spriteNum].Width);
@@ -756,7 +756,7 @@ int Game_GetSpriteHeight(int spriteNum) {
     if (spriteNum < 0)
         return 0;
 
-    if (!spriteset.doesSpriteExist(spriteNum))
+    if (!spriteset.DoesSpriteExist(spriteNum))
         return 0;
 
     return divide_down_coordinate(game.SpriteInfos[spriteNum].Height);
@@ -1209,7 +1209,7 @@ void restore_game_spriteset(Stream *in)
 {
     // ensure the sprite set is at least as large as it was
     // when the game was saved
-    spriteset.enlargeTo(in->ReadInt32());
+    spriteset.EnlargeTo(in->ReadInt32());
     // get serialized dynamic sprites
     int sprnum = in->ReadInt32();
     while (sprnum) {
@@ -1728,7 +1728,7 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot)
 
     if (desc.UserImage.get())
     {
-        int slot = spriteset.findFreeSlot();
+        int slot = spriteset.AddNewSprite();
         if (slot > 0)
         {
             // add it into the sprite set

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -152,11 +152,8 @@ int new_room_pos=0;
 int new_room_x = SCR_NO_VALUE, new_room_y = SCR_NO_VALUE;
 int new_room_loop = SCR_NO_VALUE;
 
-//Bitmap *spriteset[MAX_SPRITES+1];
-//SpriteCache spriteset (MAX_SPRITES+1);
 // initially size 1, this will be increased by the initFile function
-int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
-SpriteCache spriteset(1);
+SpriteCache spriteset(1, game.SpriteInfos);
 int proper_exit=0,our_eip=0;
 
 std::vector<GUIMain> guis;
@@ -746,23 +743,23 @@ int Game_GetUseNativeCoordinates()
 }
 
 int Game_GetSpriteWidth(int spriteNum) {
-    if ((spriteNum < 0) || (spriteNum >= MAX_SPRITES))
+    if (spriteNum < 0)
         return 0;
 
     if (!spriteset.doesSpriteExist(spriteNum))
         return 0;
 
-    return divide_down_coordinate(spritewidth[spriteNum]);
+    return divide_down_coordinate(game.SpriteInfos[spriteNum].Width);
 }
 
 int Game_GetSpriteHeight(int spriteNum) {
-    if ((spriteNum < 0) || (spriteNum >= MAX_SPRITES))
+    if (spriteNum < 0)
         return 0;
 
     if (!spriteset.doesSpriteExist(spriteNum))
         return 0;
 
-    return divide_down_coordinate(spriteheight[spriteNum]);
+    return divide_down_coordinate(game.SpriteInfos[spriteNum].Height);
 }
 
 int Game_GetLoopCountForView(int viewNumber) {
@@ -1218,7 +1215,7 @@ void restore_game_spriteset(Stream *in)
     while (sprnum) {
         unsigned char spriteflag = in->ReadByte();
         add_dynamic_sprite(sprnum, read_serialized_bitmap(in));
-        game.spriteflags[sprnum] = spriteflag;
+        game.SpriteInfos[sprnum].Flags = spriteflag;
         sprnum = in->ReadInt32();
     }
 }

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -40,7 +40,6 @@
 
 extern GameSetupStruct game;
 extern ViewStruct*views;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern RoomObject*objs;
 extern roomstruct thisroom;
 extern GameState play;
@@ -115,7 +114,7 @@ int GetCharacterWidth(int ww) {
             return multiply_up_coordinate(4);
         }
 
-        return spritewidth[views[char1->view].loops[char1->loop].frames[char1->frame].pic];
+        return game.SpriteInfos[views[char1->view].loops[char1->loop].frames[char1->frame].pic].Width;
     }
     else 
         return charextra[ww].width;
@@ -134,7 +133,7 @@ int GetCharacterHeight(int charid) {
             return multiply_up_coordinate(2);
         }
 
-        return spriteheight[views[char1->view].loops[char1->loop].frames[char1->frame].pic];
+        return game.SpriteInfos[views[char1->view].loops[char1->loop].frames[char1->frame].pic].Height;
     }
     else
         return charextra[charid].height;

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -73,7 +73,7 @@ String GetRuntimeInfo()
         mode.Windowed ? " W" : "",
         gfxDriver->GetDriverName(), filter->GetInfo().Name.GetCStr(),
         render_frame.GetWidth(), render_frame.GetHeight(),
-        spriteset.cachesize / 1024, spriteset.maxCacheSize / 1024, spriteset.lockedSize / 1024);
+        spriteset.GetCacheSize() / 1024, spriteset.GetMaxCacheSize() / 1024, spriteset.GetLockedSize() / 1024);
     if (play.separate_music_lib)
         runtimeInfo.Append("[AUDIO.VOX enabled");
     if (play.want_speech >= 1)

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -37,7 +37,6 @@ extern roomstruct thisroom;
 extern GameState play;
 extern char lines[MAXLINE][200];
 extern int  numlines;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern GameSetupStruct game;
 extern int current_screen_resolution_multiplier;
@@ -177,7 +176,7 @@ void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
 }
 
 void RawDrawImageCore(int xx, int yy, int slot, int alpha) {
-    if ((slot < 0) || (slot >= MAX_SPRITES) || (spriteset[slot] == NULL))
+    if ((slot < 0) || (spriteset[slot] == NULL))
         quit("!RawDrawImage: invalid sprite slot number specified");
     RAW_START();
 
@@ -245,7 +244,7 @@ void RawDrawImageTransparent(int xx, int yy, int slot, int legacy_transparency) 
     update_polled_stuff_if_runtime();  // this operation can be slow so stop music skipping
 }
 void RawDrawImageResized(int xx, int yy, int gotSlot, int width, int height) {
-    if ((gotSlot < 0) || (gotSlot >= MAX_SPRITES) || (spriteset[gotSlot] == NULL))
+    if ((gotSlot < 0) || (spriteset[gotSlot] == NULL))
         quit("!RawDrawImageResized: invalid sprite slot number specified");
     // very small, don't draw it
     if ((width < 1) || (height < 1))
@@ -257,7 +256,7 @@ void RawDrawImageResized(int xx, int yy, int gotSlot, int width, int height) {
     // resize the sprite to the requested size
     Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, spriteset[gotSlot]->GetColorDepth());
     newPic->StretchBlt(spriteset[gotSlot],
-        RectWH(0, 0, spritewidth[gotSlot], spriteheight[gotSlot]),
+        RectWH(0, 0, game.SpriteInfos[gotSlot].Width, game.SpriteInfos[gotSlot].Height),
         RectWH(0, 0, width, height));
 
     RAW_START();

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -40,7 +40,7 @@ int LoadImageFile(const char *filename)
     if (!loadedFile)
         return 0;
 
-    int gotSlot = spriteset.findFreeSlot();
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return 0;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -277,8 +277,8 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
     if (!err)
         quitprintf("!RunAGSGame: error loading new game file:\n%s", err->FullMessage().GetCStr());
 
-    spriteset.reset();
-    if (spriteset.initFile ("acsprset.spr"))
+    spriteset.Reset();
+    if (spriteset.InitFile("acsprset.spr"))
         quit("!RunAGSGame: error loading new sprites");
 
     if ((mode & RAGMODE_PRESERVEGLOBALINT) == 0) {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -65,7 +65,6 @@ extern GameState play;
 extern ExecutingScript*curscript;
 extern int displayed_room;
 extern int game_paused;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern int frames_per_second;
 extern int time_between_timers;
@@ -177,13 +176,13 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
     if (gotSlot == 0)
         return 0;
 
-    if ((spritewidth[gotSlot] == width) && (spriteheight[gotSlot] == height))
+    if ((game.SpriteInfos[gotSlot].Width == width) && (game.SpriteInfos[gotSlot].Height == height))
         return gotSlot;
 
     // resize the sprite to the requested size
     Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, spriteset[gotSlot]->GetColorDepth());
     newPic->StretchBlt(spriteset[gotSlot],
-        RectWH(0, 0, spritewidth[gotSlot], spriteheight[gotSlot]),
+        RectWH(0, 0, game.SpriteInfos[gotSlot].Width, game.SpriteInfos[gotSlot].Height),
         RectWH(0, 0, width, height));
 
     update_polled_stuff_if_runtime();

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -258,7 +258,7 @@ void MergeObject(int obn) {
     int xpos = multiply_up_coordinate(objs[obn].x);
     int ypos = (multiply_up_coordinate(objs[obn].y) - theHeight);
 
-    draw_sprite_support_alpha(bg_frame, false, xpos, ypos, actsps[obn], (game.spriteflags[objs[obn].num] & SPF_ALPHACHANNEL) != 0);
+    draw_sprite_support_alpha(bg_frame, false, xpos, ypos, actsps[obn], (game.SpriteInfos[objs[obn].num].Flags & SPF_ALPHACHANNEL) != 0);
     invalidate_screen();
     mark_current_background_dirty();
 

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -30,7 +30,6 @@
 using namespace Common;
 using namespace Engine;
 
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern GameSetupStruct game;
 extern Bitmap *virtual_screen;
@@ -47,11 +46,11 @@ void RemoveOverlay(int ovrid) {
 int CreateGraphicOverlay(int xx,int yy,int slott,int trans) {
     multiply_up_coordinates(&xx, &yy);
 
-    Bitmap *screeno=BitmapHelper::CreateTransparentBitmap(spritewidth[slott],spriteheight[slott], game.GetColorDepth());
+    Bitmap *screeno=BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slott].Width, game.SpriteInfos[slott].Height, game.GetColorDepth());
     Bitmap *ds = SetVirtualScreen(screeno);
     wputblock(ds, 0,0,spriteset[slott],trans);
 
-    bool hasAlpha = (game.spriteflags[slott] & SPF_ALPHACHANNEL) != 0;
+    bool hasAlpha = (game.SpriteInfos[slott].Flags & SPF_ALPHACHANNEL) != 0;
     int nse = add_screen_overlay(xx, yy, OVER_CUSTOM, screeno, hasAlpha);
 
     SetVirtualScreen(virtual_screen);

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -43,7 +43,6 @@ extern GameState play;
 extern CharacterExtras *charextra;
 extern ScriptInvItem scrInv[MAX_INV];
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern int mousex,mousey;
 extern volatile int timerloop;
@@ -256,8 +255,8 @@ int InventoryScreen::Redraw()
             dii[numitems].num = charextra[game.playercharacter].invorder[i];
             dii[numitems].sprnum = game.invinfo[charextra[game.playercharacter].invorder[i]].pic;
             int snn=dii[numitems].sprnum;
-            if (spritewidth[snn] > widest) widest=spritewidth[snn];
-            if (spriteheight[snn] > highest) highest=spriteheight[snn];
+            if (game.SpriteInfos[snn].Width > widest) widest=game.SpriteInfos[snn].Width;
+            if (game.SpriteInfos[snn].Height > highest) highest= game.SpriteInfos[snn].Height;
             numitems++;
         }
     }
@@ -293,7 +292,7 @@ int InventoryScreen::Redraw()
         wputblock(ds, barxp+1+((i-top_item)%4)*widest+widest/2-spof->GetWidth()/2,
             bartop+1+((i-top_item)/4)*highest+highest/2-spof->GetHeight()/2,spof,1);
     }
-#define BUTTONWID Math::Max(1, spritewidth[btn_select_sprite])
+#define BUTTONWID Math::Max(1, game.SpriteInfos[btn_select_sprite].Width)
     // Draw select, look and OK buttons
     wputblock(ds, windowxp+2, buttonyp + get_fixed_pixel_size(2), spriteset[btn_look_sprite], 1);
     wputblock(ds, windowxp+3+BUTTONWID, buttonyp + get_fixed_pixel_size(2), spriteset[btn_select_sprite], 1);

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -163,7 +163,7 @@ void ChangeCursorGraphic (int curs, int newslot) {
         debug_script_warn("Mouse.ChangeModeGraphic should not be used on the Inventory cursor when the cursor is linked to the active inventory item");
 
     game.mcurs[curs].pic = newslot;
-    spriteset.precache (newslot);
+    spriteset.Precache(newslot);
     if (curs == cur_mode)
         set_mouse_cursor (curs);
 }
@@ -327,7 +327,7 @@ void update_inv_cursor(int invnum) {
 
         game.mcurs[MODE_USE].pic = cursorSprite;
         // all cursor images must be pre-cached
-        spriteset.precache(cursorSprite);
+        spriteset.Precache(cursorSprite);
 
         if ((game.invinfo[invnum].hotx > 0) || (game.invinfo[invnum].hoty > 0)) {
             // if the hotspot was set (unfortunately 0,0 isn't a valid co-ord)

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -41,7 +41,6 @@ extern GameSetupStruct game;
 extern GameState play;
 extern ScriptSystem scsystem;
 extern Bitmap *mousecurs[MAXCURSORS];
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern CharacterInfo*playerchar;
 extern IGraphicsDriver *gfxDriver;
@@ -117,16 +116,11 @@ void set_mouse_cursor(int newcurs) {
             dotted_mouse_cursor = BitmapHelper::CreateBitmapCopy(mousecurs[0]);
 
             if (game.invhotdotsprite > 0) {
-                //Bitmap *abufWas = abuf;
-                //abuf = dotted_mouse_cursor;
-
                 draw_sprite_slot_support_alpha(dotted_mouse_cursor,
-                    (game.spriteflags[game.mcurs[newcurs].pic] & SPF_ALPHACHANNEL) != 0,
-                    hotspotx - spritewidth[game.invhotdotsprite] / 2,
-                    hotspoty - spriteheight[game.invhotdotsprite] / 2,
+                    (game.SpriteInfos[game.mcurs[newcurs].pic].Flags & SPF_ALPHACHANNEL) != 0,
+                    hotspotx - game.SpriteInfos[game.invhotdotsprite].Width / 2,
+                    hotspoty - game.SpriteInfos[game.invhotdotsprite].Height / 2,
                     game.invhotdotsprite);
-
-                //abuf = abufWas;
             }
             else {
                 putpixel_compensate (dotted_mouse_cursor, hotspotx, hotspoty,
@@ -341,8 +335,8 @@ void update_inv_cursor(int invnum) {
             game.mcurs[MODE_USE].hoty=game.invinfo[invnum].hoty;
         }
         else {
-            game.mcurs[MODE_USE].hotx = spritewidth[cursorSprite] / 2;
-            game.mcurs[MODE_USE].hoty = spriteheight[cursorSprite] / 2;
+            game.mcurs[MODE_USE].hotx = game.SpriteInfos[cursorSprite].Width / 2;
+            game.mcurs[MODE_USE].hoty = game.SpriteInfos[cursorSprite].Height / 2;
         }
     }
 }
@@ -368,7 +362,7 @@ void set_new_cursor_graphic (int spriteslot) {
         mousecurs[0] = blank_mouse_cursor;
     }
 
-    if (game.spriteflags[spriteslot] & SPF_ALPHACHANNEL)
+    if (game.SpriteInfos[spriteslot].Flags & SPF_ALPHACHANNEL)
         alpha_blend_cursor = 1;
     else
         alpha_blend_cursor = 0;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -34,7 +34,6 @@ using namespace AGS::Engine;
 extern GameSetupStruct game;
 extern int offsetx, offsety;
 extern int displayed_room;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern int face_talking;
 extern ViewStruct*views;
 extern CharacterExtras *charextra;
@@ -228,7 +227,7 @@ void get_overlay_position(int overlayidx, int *x, int *y) {
 
         tdyp = multiply_up_coordinate(game.chars[charid].get_effective_y()) - offsety - 5;
         if (charextra[charid].height<1)
-            tdyp -= spriteheight[charpic];
+            tdyp -= game.SpriteInfos[charpic].Height;
         else
             tdyp -= charextra[charid].height;
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -94,7 +94,6 @@ extern int our_eip;
 extern Bitmap *walkareabackup, *walkable_areas_temp;
 extern ScriptObject scrObj[MAX_INIT_SPR];
 extern SpriteCache spriteset;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern int in_new_room, new_room_was;  // 1 in new room, 2 first time in new room, 3 loading saved game
 extern ScriptHotspot scrHotspot[MAX_HOTSPOTS];
 extern int in_leaves_screen;
@@ -637,7 +636,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             croom->obj[cc].y=thisroom.sprs[cc].y;
 
             if (thisroom.wasversion <= kRoomVersion_300a)
-                croom->obj[cc].y += divide_down_coordinate(spriteheight[thisroom.sprs[cc].sprnum]);
+                croom->obj[cc].y += divide_down_coordinate(game.SpriteInfos[thisroom.sprs[cc].sprnum].Height);
 
             croom->obj[cc].num=thisroom.sprs[cc].sprnum;
             croom->obj[cc].on=thisroom.sprs[cc].on;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -996,7 +996,7 @@ void new_room(int newnum,CharacterInfo*forchar) {
     if (psp_clear_cache_on_room_change)
     {
         // Delete all cached sprites
-        spriteset.removeAll();
+        spriteset.RemoveAll();
 
         // Delete all gui background images
         for (int i = 0; i < game.numgui; i++)

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -15,6 +15,7 @@
 #include "ac/roomobject.h"
 #include "ac/common.h"
 #include "ac/common_defines.h"
+#include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/runtime_defines.h"
 #include "ac/viewframe.h"
@@ -23,10 +24,9 @@
 
 using AGS::Common::Stream;
 
-
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern ViewStruct*views;
 extern GameState play;
+extern GameSetupStruct game;
 
 RoomObject::RoomObject()
 {
@@ -50,12 +50,12 @@ RoomObject::RoomObject()
 
 int RoomObject::get_width() {
     if (last_width == 0)
-        return spritewidth[num];
+        return game.SpriteInfos[num].Width;
     return last_width;
 }
 int RoomObject::get_height() {
     if (last_height == 0)
-        return spriteheight[num];
+        return game.SpriteInfos[num].Height;
     return last_height;
 }
 int RoomObject::get_baseline() {

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -134,13 +134,12 @@ Bitmap *tmpdbl, *curspr;
 int newwid, newhit;
 void initialize_sprite (int ee) {
 
-    if ((ee < 0) || (ee > spriteset.elements))
+    if ((ee < 0) || (ee > spriteset.GetSpriteSlotCount()))
         quit("initialize_sprite: invalid sprite number");
 
     if ((spriteset[ee] == NULL) && (ee > 0)) {
         // replace empty sprites with blue cups, to avoid crashes
-        //spriteset[ee] = spriteset[0];
-        spriteset.set (ee, spriteset[0]);
+        spriteset.Set(ee, spriteset[0]);
         game.SpriteInfos[ee].Width = game.SpriteInfos[0].Width;
         game.SpriteInfos[ee].Height = game.SpriteInfos[0].Height;
     }
@@ -187,13 +186,13 @@ void initialize_sprite (int ee) {
             curspr->Release ();
             tmpdbl->Release ();
             delete curspr;
-            spriteset.set (ee, tmpdbl);
+            spriteset.Set(ee, tmpdbl);
         }
 
         game.SpriteInfos[ee].Width=spriteset[ee]->GetWidth();
         game.SpriteInfos[ee].Height=spriteset[ee]->GetHeight();
 
-        spriteset.set(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
+        spriteset.Set(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
 
         if (game.GetColorDepth() < 32) {
             game.SpriteInfos[ee].Flags &= ~SPF_ALPHACHANNEL;

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -29,7 +29,6 @@ using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern int current_screen_resolution_multiplier;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern int our_eip, eip_guinum, eip_guiobj;
 extern color palette[256];
@@ -39,7 +38,7 @@ extern AGSPlatformDriver *platform;
 void get_new_size_for_sprite (int ee, int ww, int hh, int &newwid, int &newhit) {
     newwid = ww * current_screen_resolution_multiplier;
     newhit = hh * current_screen_resolution_multiplier;
-    if (game.spriteflags[ee] & SPF_640x400) 
+    if (game.SpriteInfos[ee].Flags & SPF_640x400) 
     {
         if (current_screen_resolution_multiplier == 2) {
             newwid = ww;
@@ -142,22 +141,22 @@ void initialize_sprite (int ee) {
         // replace empty sprites with blue cups, to avoid crashes
         //spriteset[ee] = spriteset[0];
         spriteset.set (ee, spriteset[0]);
-        spritewidth[ee] = spritewidth[0];
-        spriteheight[ee] = spriteheight[0];
+        game.SpriteInfos[ee].Width = game.SpriteInfos[0].Width;
+        game.SpriteInfos[ee].Height = game.SpriteInfos[0].Height;
     }
     else if (spriteset[ee]==NULL) {
-        spritewidth[ee]=0;
-        spriteheight[ee]=0;
+        game.SpriteInfos[ee].Width=0;
+        game.SpriteInfos[ee].Height=0;
     }
     else {
         // stretch sprites to correct resolution
         int oldeip = our_eip;
         our_eip = 4300;
 
-        if (game.spriteflags[ee] & SPF_HADALPHACHANNEL) {
+        if (game.SpriteInfos[ee].Flags & SPF_HADALPHACHANNEL) {
             // we stripped the alpha channel out last time, put
             // it back so that we can remove it properly again
-            game.spriteflags[ee] |= SPF_ALPHACHANNEL;
+            game.SpriteInfos[ee].Flags |= SPF_ALPHACHANNEL;
         }
 
         curspr = spriteset[ee];
@@ -191,16 +190,16 @@ void initialize_sprite (int ee) {
             spriteset.set (ee, tmpdbl);
         }
 
-        spritewidth[ee]=spriteset[ee]->GetWidth();
-        spriteheight[ee]=spriteset[ee]->GetHeight();
+        game.SpriteInfos[ee].Width=spriteset[ee]->GetWidth();
+        game.SpriteInfos[ee].Height=spriteset[ee]->GetHeight();
 
-        spriteset.set(ee, PrepareSpriteForUse(spriteset[ee], (game.spriteflags[ee] & SPF_ALPHACHANNEL) != 0));
+        spriteset.set(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
 
         if (game.GetColorDepth() < 32) {
-            game.spriteflags[ee] &= ~SPF_ALPHACHANNEL;
+            game.SpriteInfos[ee].Flags &= ~SPF_ALPHACHANNEL;
             // save the fact that it had one for the next time this
             // is re-loaded from disk
-            game.spriteflags[ee] |= SPF_HADALPHACHANNEL;
+            game.SpriteInfos[ee].Flags |= SPF_HADALPHACHANNEL;
         }
 
         pl_run_plugin_hooks(AGSE_SPRITELOAD, ee);

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -25,11 +25,6 @@
 
 #include "ac/spritecache.h"
 #include "util/compress.h"
-//
-
-// For engine these are defined in ac.cpp
-extern int spritewidth[], spriteheight[];
-//
 
 //=============================================================================
 // Engine-specific implementation split out of sprcache.cpp
@@ -44,8 +39,8 @@ void SpriteCache::initFile_adjustBuffers(short numspri)
 void SpriteCache::initFile_initNullSpriteParams(int vv)
 {
   // make it a blue cup, to avoid crashes
-  spritewidth[vv] = spritewidth[0];
-  spriteheight[vv] = spriteheight[0];
+  _sprInfos[vv].Width = _sprInfos[0].Width;
+  _sprInfos[vv].Height = _sprInfos[0].Height;
   offsets[vv] = offsets[0];
   flags[vv] = SPRCACHEFLAG_DOESNOTEXIST;
 }

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -30,17 +30,17 @@
 // Engine-specific implementation split out of sprcache.cpp
 //=============================================================================
 
-void SpriteCache::initFile_adjustBuffers(short numspri)
+void SpriteCache::initFile_adjustBuffers(sprkey_t numspri)
 {
-  // adjust the buffers to the sprite file size
-  changeMaxSize(numspri + 1);
+    // adjust the buffers to the sprite file size
+    EnlargeTo(numspri + 1);
 }
 
-void SpriteCache::initFile_initNullSpriteParams(int vv)
+void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
 {
-  // make it a blue cup, to avoid crashes
-  _sprInfos[vv].Width = _sprInfos[0].Width;
-  _sprInfos[vv].Height = _sprInfos[0].Height;
-  offsets[vv] = offsets[0];
-  flags[vv] = SPRCACHEFLAG_DOESNOTEXIST;
+    // make it a blue cup, to avoid crashes
+    _sprInfos[index].Width = _sprInfos[0].Width;
+    _sprInfos[index].Height = _sprInfos[0].Height;
+    _spriteData[index].Offset = _spriteData[0].Offset;
+    _spriteData[index].Flags = SPRCACHEFLAG_DOESNOTEXIST;
 }

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -30,12 +30,6 @@
 // Engine-specific implementation split out of sprcache.cpp
 //=============================================================================
 
-void SpriteCache::initFile_adjustBuffers(sprkey_t numspri)
-{
-    // adjust the buffers to the sprite file size
-    EnlargeTo(numspri + 1);
-}
-
 void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
 {
     // make it a blue cup, to avoid crashes

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -163,7 +163,7 @@ void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha
             src = new Bitmap(vf_bmp->GetWidth(), vf_bmp->GetHeight(), vf_bmp->GetColorDepth());
             src->FlipBlt(vf_bmp, 0, 0, Common::kBitmap_HFlip);
         }
-        draw_sprite_support_alpha(ds, true, x, y, src, (game.spriteflags[vframe->pic] & SPF_ALPHACHANNEL) != 0);
+        draw_sprite_support_alpha(ds, true, x, y, src, (game.SpriteInfos[vframe->pic].Flags & SPF_ALPHACHANNEL) != 0);
         if (src != vf_bmp)
             delete src;
     }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -113,7 +113,7 @@ void precache_view(int view)
 
     for (int i = 0; i < views[view].numLoops; i++) {
         for (int j = 0; j < views[view].loops[i].numFrames; j++)
-            spriteset.precache (views[view].loops[i].frames[j].pic);
+            spriteset.Precache(views[view].loops[i].frames[j].pic);
     }
 }
 

--- a/Engine/ac/walkablearea.cpp
+++ b/Engine/ac/walkablearea.cpp
@@ -30,7 +30,6 @@ using AGS::Common::Bitmap;
 extern roomstruct thisroom;
 extern GameState play;
 extern GameSetupStruct game;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern int displayed_room;
 extern RoomStatus*croom;
 extern RoomObject*objs;
@@ -105,8 +104,8 @@ int get_area_scaling (int onarea, int xx, int yy) {
 }
 
 void scale_sprite_size(int sppic, int zoom_level, int *newwidth, int *newheight) {
-    newwidth[0] = (spritewidth[sppic] * zoom_level) / 100;
-    newheight[0] = (spriteheight[sppic] * zoom_level) / 100;
+    newwidth[0] = (game.SpriteInfos[sppic].Width * zoom_level) / 100;
+    newheight[0] = (game.SpriteInfos[sppic].Height * zoom_level) / 100;
     if (newwidth[0] < 1)
         newwidth[0] = 1;
     if (newheight[0] < 1)

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -353,7 +353,7 @@ void DoBeforeRestore(PreservedParams &pp)
     // NOTE: sprite 0 is a special constant sprite that cannot be dynamic
     for (int i = 1; i < spriteset.elements; ++i)
     {
-        if (game.spriteflags[i] & SPF_DYNAMICALLOC)
+        if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
         {
             // do this early, so that it changing guibuts doesn't
             // affect the restored data

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -351,7 +351,7 @@ void DoBeforeRestore(PreservedParams &pp)
 
     // cleanup dynamic sprites
     // NOTE: sprite 0 is a special constant sprite that cannot be dynamic
-    for (int i = 1; i < spriteset.elements; ++i)
+    for (int i = 1; i < spriteset.GetSpriteSlotCount(); ++i)
     {
         if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
         {
@@ -501,7 +501,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     if (r_data.CursorMode == MODE_USE)
         SetActiveInventory(playerchar->activeinv);
     // ensure that the current cursor is locked
-    spriteset.precache(game.mcurs[r_data.CursorID].pic);
+    spriteset.Precache(game.mcurs[r_data.CursorID].pic);
 
 #if (ALLEGRO_DATE > 19990103)
     set_window_title(play.game_name);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -656,7 +656,7 @@ HSaveError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams
     // ensure the sprite set is at least large enough
     // to accomodate top dynamic sprite index
     const int top_index = in->ReadInt32();
-    spriteset.EnlargeTo(top_index);
+    spriteset.EnlargeTo(top_index + 1);
     for (int i = 0; i < spr_count; ++i)
     {
         int id = in->ReadInt32();

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -630,7 +630,7 @@ HSaveError WriteDynamicSprites(PStream out)
     out->WriteInt32(0); // top index
     int count = 0;
     int top_index = 1;
-    for (int i = 1; i < spriteset.elements; ++i)
+    for (int i = 1; i < spriteset.GetSpriteSlotCount(); ++i)
     {
         if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
         {
@@ -656,7 +656,7 @@ HSaveError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams
     // ensure the sprite set is at least large enough
     // to accomodate top dynamic sprite index
     const int top_index = in->ReadInt32();
-    spriteset.enlargeTo(top_index);
+    spriteset.EnlargeTo(top_index);
     for (int i = 0; i < spr_count; ++i)
     {
         int id = in->ReadInt32();

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -632,12 +632,12 @@ HSaveError WriteDynamicSprites(PStream out)
     int top_index = 1;
     for (int i = 1; i < spriteset.elements; ++i)
     {
-        if (game.spriteflags[i] & SPF_DYNAMICALLOC)
+        if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
         {
             count++;
             top_index = i;
             out->WriteInt32(i);
-            out->WriteInt32(game.spriteflags[i]);
+            out->WriteInt32(game.SpriteInfos[i].Flags);
             serialize_bitmap(spriteset[i], out.get());
         }
     }
@@ -656,17 +656,13 @@ HSaveError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams
     // ensure the sprite set is at least large enough
     // to accomodate top dynamic sprite index
     const int top_index = in->ReadInt32();
-    if (!AssertCompatRange(err, top_index, 1, MAX_SPRITES - 1, "sprite top index"))
-        return err;
     spriteset.enlargeTo(top_index);
     for (int i = 0; i < spr_count; ++i)
     {
         int id = in->ReadInt32();
-        if (!AssertCompatRange(err, id, 1, MAX_SPRITES - 1, "sprite index"))
-            return err;
         int flags = in->ReadInt32();
         add_dynamic_sprite(id, read_serialized_bitmap(in.get()));
-        game.spriteflags[id] = flags;
+        game.SpriteInfos[id].Flags = flags;
     }
     return err;
 }

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -92,7 +92,7 @@ int get_adjusted_spriteheight(int spr)
 
 bool is_sprite_alpha(int spr)
 {
-  return ((game.spriteflags[spr] & SPF_ALPHACHANNEL) != 0);
+  return ((game.SpriteInfos[spr].Flags & SPF_ALPHACHANNEL) != 0);
 }
 
 void set_eip_guiobj(int eip)

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -475,7 +475,7 @@ void apply_config(const ConfigTree &cfg)
         // PSP: Don't let the setup determine the cache size as it is always too big.
 #if !defined(PSP_VERSION)
         // the config file specifies cache size in KB, here we convert it to bytes
-        spriteset.maxCacheSize = INIreadint (cfg, "misc", "cachemax", DEFAULTCACHESIZE / 1024) * 1024;
+        spriteset.SetMaxCacheSize(INIreadint (cfg, "misc", "cachemax", DEFAULTCACHESIZE / 1024) * 1024);
 #endif
 
         String repfile = INIreadstring(cfg, "misc", "replay");

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -39,7 +39,6 @@ using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern GameSetup usetup;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern int force_window;
 extern char psp_translation[];

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -74,7 +74,6 @@ extern GameSetupStruct game;
 extern int proper_exit;
 extern char pexbuf[STD_BUFFER_SIZE];
 extern char saveGameDirectory[260];
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern ObjectCache objcache[MAX_INIT_SPR];
 extern ScriptObject scrObj[MAX_INIT_SPR];

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -935,7 +935,7 @@ int engine_init_sprites()
 {
     Debug::Printf(kDbgMsg_Init, "Initialize sprites");
 
-    if (spriteset.initFile ("acsprset.spr")) 
+    if (spriteset.InitFile("acsprset.spr")) 
     {
         platform->FinishedUsingGraphicsMode();
         allegro_exit();
@@ -971,7 +971,7 @@ void engine_init_game_settings()
         // The cursor graphics are assigned to mousecurs[] and so cannot
         // be removed from memory
         if (game.mcurs[ee].pic >= 0)
-            spriteset.precache (game.mcurs[ee].pic);
+            spriteset.Precache(game.mcurs[ee].pic);
 
         // just in case they typed an invalid view number in the editor
         if (game.mcurs[ee].view >= game.numviews)

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -81,7 +81,6 @@ extern int replay_start_this_time;
 extern char noWalkBehindsAtAll;
 extern RoomStatus*croom;
 extern CharacterExtras *charextra;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern int offsetx, offsety;
 extern unsigned int loopcounter,lastcounter;
@@ -435,8 +434,8 @@ void check_keyboard_controls()
                 sprintf(&infobuf[strlen(infobuf)],
                     "[Object %d: (%d,%d) size (%d x %d) on:%d moving:%s animating:%d slot:%d trnsp:%d clkble:%d",
                     ff, objs[ff].x, objs[ff].y,
-                    (spriteset[objs[ff].num] != NULL) ? spritewidth[objs[ff].num] : 0,
-                    (spriteset[objs[ff].num] != NULL) ? spriteheight[objs[ff].num] : 0,
+                    (spriteset[objs[ff].num] != NULL) ? game.SpriteInfos[objs[ff].num].Width : 0,
+                    (spriteset[objs[ff].num] != NULL) ? game.SpriteInfos[objs[ff].num].Height : 0,
                     objs[ff].on,
                     (objs[ff].moving > 0) ? "yes" : "no", objs[ff].cycling,
                     objs[ff].num, objs[ff].transparent,

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -42,7 +42,6 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern SpriteCache spriteset;
 extern RoomStatus troom;    // used for non-saveable rooms, eg. intro
 extern int our_eip;
@@ -87,7 +86,7 @@ void quit_check_dynamic_sprites(QuitReason qreason)
             // game exiting normally -- make sure the dynamic sprites
             // have been deleted
             for (int i = 1; i < spriteset.elements; i++) {
-                if (game.spriteflags[i] & SPF_DYNAMICALLOC)
+                if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
                     debug_script_warn("Dynamic sprite %d was never deleted", i);
             }
     }

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -85,7 +85,7 @@ void quit_check_dynamic_sprites(QuitReason qreason)
         (game.options[OPT_DEBUGMODE] != 0)) {
             // game exiting normally -- make sure the dynamic sprites
             // have been deleted
-            for (int i = 1; i < spriteset.elements; i++) {
+            for (int i = 1; i < spriteset.GetSpriteSlotCount(); i++) {
                 if (game.SpriteInfos[i].Flags & SPF_DYNAMICALLOC)
                     debug_script_warn("Dynamic sprite %d was never deleted", i);
             }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -48,7 +48,6 @@ extern GameState play;
 extern roomstruct thisroom;
 extern RoomObject*objs;
 extern ViewStruct*views;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern int our_eip;
 extern CharacterInfo*playerchar;
 extern CharacterExtras *charextra;
@@ -426,7 +425,7 @@ void update_sierra_speech()
         }
         else
         {
-          view_frame_y = (screenover[face_talking].pic->GetHeight() / 2) - (spriteheight[thisPic] / 2);
+          view_frame_y = (screenover[face_talking].pic->GetHeight() / 2) - (game.SpriteInfos[thisPic].Height / 2);
         }
         screenover[face_talking].pic->Clear(0);
       }
@@ -436,12 +435,12 @@ void update_sierra_speech()
 
       Bitmap *frame_pic = screenover[face_talking].pic;
       const ViewFrame *face_vf = &views[facetalkview].loops[facetalkloop].frames[facetalkframe];
-      bool face_has_alpha = (game.spriteflags[face_vf->pic] & SPF_ALPHACHANNEL) != 0;
+      bool face_has_alpha = (game.SpriteInfos[face_vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
       DrawViewFrame(frame_pic, face_vf, view_frame_x, view_frame_y);
 
       if ((facetalkchar->blinkview > 0) && (facetalkchar->blinktimer < 0)) {
         ViewFrame *blink_vf = &views[facetalkchar->blinkview].loops[facetalkBlinkLoop].frames[facetalkchar->blinkframe];
-        face_has_alpha |= (game.spriteflags[blink_vf->pic] & SPF_ALPHACHANNEL) != 0;
+        face_has_alpha |= (game.SpriteInfos[blink_vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
         // draw the blinking sprite on top
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -104,7 +104,6 @@ extern RoomStatus*croom;
 extern SpriteCache spriteset;
 extern ViewStruct*views;
 extern int game_paused;
-extern int spritewidth[MAX_SPRITES],spriteheight[MAX_SPRITES];
 extern GameSetup usetup;
 extern int inside_script;
 extern ccInstance *gameinst, *roominst;
@@ -467,10 +466,10 @@ int IAGSEngine::IsGamePaused () {
     return game_paused;
 }
 int IAGSEngine::GetSpriteWidth (int32 slot) {
-    return spritewidth[slot];
+    return game.SpriteInfos[slot].Width;
 }
 int IAGSEngine::GetSpriteHeight (int32 slot) {
-    return spriteheight[slot];
+    return game.SpriteInfos[slot].Height;
 }
 void IAGSEngine::GetTextExtent (int32 font, const char *text, int32 *width, int32 *height) {
     if ((font < 0) || (font >= game.numfonts)) {
@@ -584,7 +583,7 @@ void IAGSEngine::DeleteDynamicSprite(int32 slot) {
     free_dynamic_sprite(slot);
 }
 int IAGSEngine::IsSpriteAlphaBlended(int32 slot) {
-    if (game.spriteflags[slot] & SPF_ALPHACHANNEL)
+    if (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL)
         return 1;
     return 0;
 }
@@ -637,10 +636,10 @@ void IAGSEngine::NotifySpriteUpdated(int32 slot) {
 
 void IAGSEngine::SetSpriteAlphaBlended(int32 slot, int32 isAlphaBlended) {
 
-    game.spriteflags[slot] &= ~SPF_ALPHACHANNEL;
+    game.SpriteInfos[slot].Flags &= ~SPF_ALPHACHANNEL;
 
     if (isAlphaBlended)
-        game.spriteflags[slot] |= SPF_ALPHACHANNEL;
+        game.SpriteInfos[slot].Flags |= SPF_ALPHACHANNEL;
 }
 
 void IAGSEngine::QueueGameScriptFunction(const char *name, int32 globalScript, int32 numArgs, long arg1, long arg2) {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -563,7 +563,10 @@ int IAGSEngine::GetFontType(int32 fontNum) {
 }
 int IAGSEngine::CreateDynamicSprite(int32 coldepth, int32 width, int32 height) {
 
-    int gotSlot = spriteset.findFreeSlot();
+    // TODO: why is this implemented right here, should not an existing
+    // script handling implementation be called instead?
+
+    int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
         return 0;
 


### PR DESCRIPTION
This cleans up SpriteCache code and replaces const sized sprite arrays with vector containers.
Also sprite file format was updated a little again to make sprite count a 32-bit integer.

Theoretically this makes sprite numbers unlimited from the engine's perspective (well, limited by INT32_MAX for now). In practice though I kept a limit of the "static" (created at design time) sprites in the Editor. This limit is 30k as before, and may be raised simply by changing one constant in the editor code (or even made an option in the game settings). The dynamic sprites (created at runtime) are now not restricted and may exceed it.

The reason why I still kept some limit to static sprites is one problem which I explain below. I spent a while trying to figure out best way to deal with it, but could not make a decision. This is quite possible that I've had a moment of "obsessive perfectionism" or was missing an obvious solution, so did not want to waste more time and left it as it is for now.

---

The sprite list in AGS has following properties:
1. The list elements contains only brief sprite descriptions, like width, height, address in the data package, extra flags etc. The bitmap is allocated separately and the process of allocation/deletion of bitmap is controlled by sprite cache mechanism (so the main list only stores pointer to bitmap).
2. List may contain quite large number of items (currently 30k max, but in the past users were asking to increase it by 2-3 times at least);
3. the items are addressed by integer key;
4. the key may be customized by the user in the provided limits.
5. at the same time in the most games majority of sprites are probably arranged in big continious sequences with little to no gaps.
6. for most games majority of entries are added into the list only once (at the game load) and never removed; exceptions are games with heavy use of dynamic sprites.

With the random key **p4** the map or even better hash map seems like obvious choice. If the index is limited only by variable capacity one may have e.g. game with two sprites: '1' and '1000000', for which vector/array would have 999998 unused elements.

However, because of **p5** and **p6** hashmap's memory overhead becomes particulary silly; you won't have much benefit from hashmap if the game has 50k sprites with indexes going strictly from 0 to 49999.

Dynamic sprites make hashmap look even worse, because their indexes are assigned automatically in strict order (currently it first fills in the gaps in static sprites, but that's not necessary).

In this situation keeping array/vector but imposing some reasonable upper limit may be a good compromise.



In the past I was also considering more sophisticated solution: a type of container with the interface corresponding to hashmap, which internally stores elements in a list of arrays.
The size of arrays would depend on statistical spread of element indices. The hash would contain a pair of numbers combined: the number of array and the index of element inside array. For example, if the game has sprite 0 - 9999 and then 1000000 - 1009999, such container would create two 10k arrays and have zero memory overhead per element.
Unfortunately, I do not know if such type already exists and how it is called. Maybe there are similar specialized implementations of hashmap.
