### PR TITLE
Fix environment checks for building without brew

### DIFF
--- a/OSX/buildlibs/checkenv.sh
+++ b/OSX/buildlibs/checkenv.sh
@@ -1,20 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 
-set -e
-
-if [[ $('xcode-select' --print-path) != "/Applications/Xcode.app/Contents/Developer" ]]; then
-    echo "xcode-select path must be set to \"/Applications/Xcode.app/Contents/Developer\""
-    echo "try \"sudo xcode-select --reset\""
+if [ "$(xcode-select --print-path)" != "/Applications/Xcode.app/Contents/Developer" ]; then
+    echo "xcode-select path must be set to '/Applications/Xcode.app/Contents/Developer'"
+    echo "try 'sudo xcode-select --reset'"
     exit 1
 fi
 
-for bin in curl pkg-config autoconf automake aclocal glibtoolize cmake xcodebuild; do
- path_to_executable=$(which $bin)
- if [ ! -x "$path_to_executable" ] ; then
-    echo "error: require $bin"
-    echo "try \"brew install curl pkg-config autoconf automake libtool\""
-    exit 1
- fi
+for bin in curl pkg-config autoconf automake aclocal libtoolize cmake xcodebuild; do
+    if ! `which -s "$bin"`; then
+        if [ "$bin" = "libtoolize" ] && `which -s "g$bin"`; then
+            continue
+        else
+            echo "error: require $bin"
+            echo "try 'brew install curl pkg-config autoconf automake libtool'"
+            exit 1
+        fi
+    fi
 done
 
 exit 0


### PR DESCRIPTION
- When the pkg check failed the binary name was not printed, because the `which` failure had already aborted the script. This is changed to not exit early (all paths already have an exit code) and just validate the return codes
- I've added a check for 'libtoolize' as well as 'glibtoolize', since installing a packaged build of 'libtool' may give the former rather than the latter. You may encounter this if not using brew as your package manager
- Just a general cleanup. I wasn't sure what the bash + double square brackets were doing, the rest was spacing, or changing quoting/subshell style to remove some escaping requirements. I'll separate these changes out if required though.