### PR TITLE
make Object.SetPosition on a moving object non-fatal

### DIFF
--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -342,7 +342,7 @@ void SetObjectPosition(int objj, int tox, int toy) {
         quit("!SetObjectPosition: invalid object number");
 
     if (objs[objj].moving > 0)
-        quit("!Object.SetPosition: cannot set position while object is moving");
+        return;
 
     objs[objj].x = tox;
     objs[objj].y = toy;


### PR DESCRIPTION
fixes "Trilby: Art of Theft" crashing when the level selection is moved
rapidly with the cursor keys.
closes #512