### PR TITLE
Fixes for Linux launch wrapper (fixes issues with itch.io client)

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -104,11 +104,11 @@ namespace AGS.Editor
             {
                 results +=
 @"
-    ln -f -s ""$SCRIPTPATH/data/lib" + bit + @"/" + soName + @""" """ + soName + @"""";
+    ln -f -s ""$scriptdir/data/lib" + bit + @"/" + soName + @""" """ + soName + @"""";
             }
             results +=
 @"
-    ALLEGRO_MODULES=""$SCRIPTPATH/data/lib" + bit + @""" ""$SCRIPTPATH/data/ags" + bit + @""" ""$@"" ""$SCRIPTPATH/data/""";
+    ALLEGRO_MODULES=""$scriptdir/data/lib" + bit + @""" ""$scriptdir/data/ags" + bit + @""" ""$@"" ""$scriptdir/data/""";
             return results;
         }
 
@@ -163,18 +163,19 @@ namespace AGS.Editor
             string scriptFileName = GetCompiledPath(Factory.AGSEditor.BaseGameFileName.Replace(" ", "")); // strip whitespace from script name
             string scriptText =
 @"#!/bin/sh
-SCRIPTPATH=""$(dirname ""$(readlink -f ""$0"")"")""
+scriptpath=$(readlink -f ""$0"")
+scriptdir=$(dirname ""$scriptpath"")
 
-if test ""x$@"" = ""x--help""
-  then
-    echo ""Usage:"" ""$(basename ""$(readlink -f ""$0"")"")"" ""[<ags options>]""
-    echo """"
-fi
+for arg; do
+    if [ ""$arg"" = ""--help"" ]; then
+        echo ""Usage: $(basename ""$scriptpath"") [<ags options>]\n""
+        break
+    fi
+done
 
-if test $(uname -m) = x86_64
-  then" + GetSymLinkScriptForEachPlugin(true) +
+if [ ""$(uname -m)"" = ""x86_64"" ]; then" + GetSymLinkScriptForEachPlugin(true) +
 @"
-  else" + GetSymLinkScriptForEachPlugin(false) +
+else" + GetSymLinkScriptForEachPlugin(false) +
 @"
 fi
 ";

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -163,11 +163,11 @@ namespace AGS.Editor
             string scriptFileName = GetCompiledPath(Factory.AGSEditor.BaseGameFileName.Replace(" ", "")); // strip whitespace from script name
             string scriptText =
 @"#!/bin/sh
-SCRIPTPATH=""$(dirname ""$(readlink -f $0)"")""
+SCRIPTPATH=""$(dirname ""$(readlink -f ""$0"")"")""
 
-if test ""x$@"" = ""x-h"" -o ""x$@"" = ""x--help""
+if test ""x$@"" = ""x--help""
   then
-    echo ""Usage:"" ""$(basename ""$(readlink -f $0)"")"" ""[<ags options>]""
+    echo ""Usage:"" ""$(basename ""$(readlink -f ""$0"")"")"" ""[<ags options>]""
     echo """"
 fi
 

--- a/debian/ags+libraries/startgame
+++ b/debian/ags+libraries/startgame
@@ -1,15 +1,16 @@
 #!/bin/sh
-SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
+scriptpath=$(readlink -f "$0")
+scriptdir=$(dirname "$scriptpath")
 
-if test "x$@" = "x--help"
-  then
-    echo "Usage:" "$(basename "$(readlink -f "$0")")" "[<ags options>]"
-    echo ""
-fi
+for arg; do
+    if [ "$arg" = "--help" ]; then
+        echo "Usage: $(basename "$scriptpath") [<ags options>]\n"
+        break
+    fi
+done
 
-if test $(uname -m) = x86_64
-  then
-    ALLEGRO_MODULES="$SCRIPTPATH/data/lib64" "$SCRIPTPATH/data/ags64" "$@" "$SCRIPTPATH/data/"
-  else
-    ALLEGRO_MODULES="$SCRIPTPATH/data/lib32" "$SCRIPTPATH/data/ags32" "$@" "$SCRIPTPATH/data/"
+if [ "$(uname -m)" = "x86_64" ]; then
+    ALLEGRO_MODULES="$scriptdir/data/lib64" "$scriptdir/data/ags64" "$@" "$scriptdir/data/"
+else
+    ALLEGRO_MODULES="$scriptdir/data/lib32" "$scriptdir/data/ags32" "$@" "$scriptdir/data/"
 fi

--- a/debian/ags+libraries/startgame
+++ b/debian/ags+libraries/startgame
@@ -1,9 +1,9 @@
 #!/bin/sh
-SCRIPTPATH="$(dirname "$(readlink -f $0)")"
+SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 
-if test "x$@" = "x-h" -o "x$@" = "x--help"
+if test "x$@" = "x--help"
   then
-    echo "Usage:" "$(basename "$(readlink -f $0)")" "[<ags options>]"
+    echo "Usage:" "$(basename "$(readlink -f "$0")")" "[<ags options>]"
     echo ""
 fi
 


### PR DESCRIPTION
- quoted $0 in launch wrapper
This fixes launching the game when there is a space in the path to launch wrapper (the itch.io launch failures are because `readlink -f` could return multiple lines from the sub-shell)

- ~~added exit 1 when printing usage~~
~~For some reason, it was still trying to start the game after printing the instructions~~

- `-h` is not a valid switch
Using this would have printed the usage header but still start the game

- Fix broken if statements and argument checks, when using arguments
   e.g. `./MyGame: 4: test: x--help: unexpected operator`