### PR TITLE
Fix number dialog for numbers greater than control default

### DIFF
--- a/Editor/AGS.Editor/GUI/NumberEntryDialog.cs
+++ b/Editor/AGS.Editor/GUI/NumberEntryDialog.cs
@@ -15,9 +15,9 @@ namespace AGS.Editor
             InitializeComponent();
             this.Text = titleText;
             lblHeader.Text = headerText;
-            udNumber.Value = initialValue;
             udNumber.Minimum = minValue;
             udNumber.Maximum = maxValue;
+            udNumber.Value = initialValue;
             udNumber.Select();
             udNumber.Select(0, ((int)udNumber.Value).ToString().Length);
         }


### PR DESCRIPTION
This was crashing for numbers greater than 100, because the value was set before the max value was adjusted.