### PR TITLE
Use native CreateHardLink

### DIFF
--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -19,6 +19,9 @@ namespace AGS.Editor
     {
         private const int ERROR_NO_MORE_FILES = 18;
 
+        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern bool CreateHardLink(string lpFileName, string lpExistingFileName, IntPtr lpSecurityAttributes);
+
         [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Winapi)]
         internal static extern IntPtr GetFocus();
 
@@ -438,66 +441,32 @@ namespace AGS.Editor
         /// <returns></returns>
         public static bool HardlinkOrCopy(string destFileName, string sourceFileName, bool overwrite)
         {
-            bool res = CreateHardLink(destFileName, sourceFileName, overwrite);
-            if (!res)
-                File.Copy(sourceFileName, destFileName, overwrite);
-            return res;
-        }
+            if (!Path.IsPathRooted(sourceFileName))
+            {
+                sourceFileName = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, sourceFileName);
+            }
 
-        /// <summary>
-        /// Creates hardlink using operating system utilities.
-        /// </summary>
-        /// <param name="destFileName">Destination file path, name of the created hardlink</param>
-        /// <param name="sourceFileName">Source file path, what hardlink to</param>
-        /// <param name="overwrite">Whether overwrite existing hardlink or not</param>
-        /// <returns></returns>
-        public static bool CreateHardLink(string destFileName, string sourceFileName, bool overwrite)
-        {
+            if (!Path.IsPathRooted(destFileName))
+            {
+                destFileName = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, destFileName);
+            }
+
             if (File.Exists(destFileName))
             {
-                if (overwrite) File.Delete(destFileName);
-                else return false;
+                if (!overwrite)
+                {
+                    return false;
+                }
+
+                File.Delete(destFileName);
             }
-            char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
-            if (Path.GetFileName(destFileName).IndexOfAny(invalidFileNameChars) != -1)
+
+            if (IsMonoRunning() || !CreateHardLink(destFileName, sourceFileName, IntPtr.Zero))
             {
-                throw new ArgumentException("Cannot create hard link! Invalid destination file name. (" + destFileName + ")");
+                File.Copy(sourceFileName, destFileName, overwrite);
             }
-            if (Path.GetFileName(sourceFileName).IndexOfAny(invalidFileNameChars) != -1)
-            {
-                throw new ArgumentException("Cannot create hard link! Invalid source file name. (" + sourceFileName + ")");
-            }
-            if (!File.Exists(sourceFileName))
-            {
-                throw new FileNotFoundException("Cannot create hard link! Source file does not exist. (" + sourceFileName + ")");
-            }
-            ProcessStartInfo si = new ProcessStartInfo("cmd.exe");
-            si.RedirectStandardInput = false;
-            si.RedirectStandardOutput = false;
-            si.RedirectStandardError = false;
-            si.UseShellExecute = false;
-            si.Arguments = string.Format("/c mklink /h \"{0}\" \"{1}\"", destFileName, sourceFileName);
-            si.CreateNoWindow = true;
-            si.WindowStyle = ProcessWindowStyle.Hidden;
-            if ((!IsWindowsVistaOrHigher()) && (IsWindowsXPOrHigher())) // running Windows XP
-            {
-                si.Arguments = string.Format("/c fsutil hardlink create \"{0}\" \"{1}\"", destFileName, sourceFileName);
-            }
-            if (IsMonoRunning())
-            {
-                si.FileName = "ln";
-                si.Arguments = string.Format("\"{0}\" \"{1}\"", sourceFileName, destFileName);
-            }
-            Process process = Process.Start(si);
-            bool result = (process != null);
-            if (result)
-            {
-                process.EnableRaisingEvents = true;
-                process.WaitForExit();
-                result = process.ExitCode == 0;
-                process.Close();
-            }
-            return result;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
This stops spawning a shell when trying to create a hardlink, which seems to help with Windows Explorer locking the files when writing data to the game file (at least, I can't recreate the problem with this change applied). This also removes the potential of cmd.exe hanging the build process, if the command processor has been disabled (it will prompt to press a key, but the window would be hidden).

For Mono, just default to copying the file, for the moment.