### PR TITLE
Fix welcome screen returning the wrong game path

### DIFF
--- a/Editor/AGS.Editor/GUI/WelcomeScreen.cs
+++ b/Editor/AGS.Editor/GUI/WelcomeScreen.cs
@@ -41,10 +41,7 @@ namespace AGS.Editor
 
         public string GetSelectedRecentGamePath()
         {
-            int index = lstRecentGames.SelectedItems[0].Index;
-            RecentGame game = Factory.AGSEditor.Settings.RecentGames[index];
-
-            return game.Path; 
+            return lstRecentGames.SelectedItems[0].SubItems[1].Text;
         }
 
         public WelcomeScreenSelection SelectedOption


### PR DESCRIPTION
I'm not sure what I was doing before, but the game path is already in the control. So rather than resolve the index to a game, just return the path from the control selection.

Fixes #537 
