### PR TITLE
Spritesheet import: inverted mouse selection and fixes

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -334,8 +334,8 @@ namespace AGS.Editor
             // Draw dragging indicator
             if (dragging)
             {
-                numSizeX.Value = position.X / zoomLevel - numOffsetX.Value + 1;
-                numSizeY.Value = position.Y / zoomLevel - numOffsetY.Value + 1;
+                numSizeX.Value = Math.Min(image.Width - numOffsetX.Value, position.X / zoomLevel - numOffsetX.Value + 1);
+                numSizeY.Value = Math.Min(image.Height - numOffsetY.Value, position.Y / zoomLevel - numOffsetY.Value + 1);
 
                 Size snappedSize = new Size((int)numSizeX.Value * zoomLevel, (int)numSizeY.Value * zoomLevel);
                 Point snappedStart = new Point((int)numOffsetX.Value * zoomLevel - previewPanel.HorizontalScroll.Value, (int)numOffsetY.Value * zoomLevel - previewPanel.VerticalScroll.Value);

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -289,13 +289,6 @@ namespace AGS.Editor
             }
 
             previewPanel.Refresh();
-
-            // if not doing a tiled import, update selection width and height
-            if (!chkTiled.Checked)
-            {
-                numSizeX.Value = image.Width;
-                numSizeY.Value = image.Height;
-            }
         }
 
         private void updateCornerColours(Point point, Size size)

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -571,19 +571,21 @@ namespace AGS.Editor
                 mouse.X = mouse.X + previewPanel.HorizontalScroll.Value;
                 mouse.Y = mouse.Y + previewPanel.VerticalScroll.Value;
 
-                if (mouse.X < start.X)
-                {
-                    mouse.X = start.X;
-                }
-
-                if (mouse.Y < start.Y)
-                {
-                    mouse.Y = start.Y;
-                }
-
                 position = mouse;
                 position.X = (position.X / zoomLevel) * zoomLevel;
                 position.Y = (position.Y / zoomLevel) * zoomLevel;
+
+                if (mouse.X < start.X)
+                {
+                    numOffsetX.Value = Math.Max(0, position.X / zoomLevel);
+                    position.X = start.X;
+                }
+
+                if (mouse.Y < start.Y) {
+                    numOffsetY.Value = Math.Max(0, position.Y / zoomLevel);
+                    position.Y = start.Y;
+                }
+
                 previewPanel.Invalidate();
             }
         }

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -300,10 +300,13 @@ namespace AGS.Editor
 
         private void updateCornerColours(Point point, Size size)
         {
-            panelTopLeft.BackColor = image.GetPixel(point.X, point.Y);
-            panelTopRight.BackColor = image.GetPixel(point.X + size.Width - 1, point.Y);
-            panelBottomLeft.BackColor = image.GetPixel(point.X, point.Y + size.Height - 1);
-            panelBottomRight.BackColor = image.GetPixel(point.X + size.Width - 1, point.Y + size.Height - 1);
+            if (size.Width > 0 && size.Height > 0)
+            {
+                panelTopLeft.BackColor = image.GetPixel(point.X, point.Y);
+                panelTopRight.BackColor = image.GetPixel(point.X + size.Width - 1, point.Y);
+                panelBottomLeft.BackColor = image.GetPixel(point.X, point.Y + size.Height - 1);
+                panelBottomRight.BackColor = image.GetPixel(point.X + size.Width - 1, point.Y + size.Height - 1);
+            }
         }
 
         private void zoomSlider_Scroll(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -677,12 +677,14 @@ namespace AGS.Editor
                 if (GetDesktopColourDepth() < 32 &&
                     (bmp.PixelFormat != PixelFormat.Format32bppArgb || bmp.PixelFormat == PixelFormat.Format32bppRgb))
                 {
-                    if (Factory.GUIController.ShowQuestion("Your desktop colour depth is lower than this image. You may lose image detail if you copy this to the clipboard. Do you want to go ahead?") == DialogResult.Yes)
+                    if (Factory.GUIController.ShowQuestion("Your desktop colour depth is lower than this image. You may lose image detail if you copy this to the clipboard. Do you want to go ahead?") != DialogResult.Yes)
                     {
-                        Clipboard.SetImage(bmp);
+                        bmp.Dispose();
+                        return;
                     }
                 }
 
+                Clipboard.SetImage(bmp);
                 bmp.Dispose();
             }
             else if (item.Name == MENU_ITEM_CHANGE_SPRITE_NUMBER)

--- a/Editor/AGS.Editor/Utils/SpriteSheet.cs
+++ b/Editor/AGS.Editor/Utils/SpriteSheet.cs
@@ -88,6 +88,11 @@ namespace AGS.Editor.Utils
                     }
                 }
 
+                if (rect.Width == 0 || rect.Height == 0)
+                {
+                    yield break;
+                }
+
                 yield return rect;
             }
         }


### PR DESCRIPTION
 - Allows selection to invert when dragging, so you can now make a tile selection with the left mouse button from bottom-right right to top-left, as well as top-left to bottom-right. The inversion is inclusive of the first pixel, which feels correct in practice.

![select](https://user-images.githubusercontent.com/14958747/50315627-690eb100-04ab-11e9-9ddf-a5451fb4a214.gif)

- Clamp selection size to image edges. Previously cursor position was still tracked, even after leaving the control.
- Fix crashes where the selection height or width was set to 0.
- Don't updated selection sizes when switching images. Invalid selection sizes are handled, and it is more likely that someone with a spritesheet will want to work from the top-left corner.
- Fix copy sprite to clipboard (regression)