### PR TITLE
Script API: helper functions for Viewport and Camera

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -365,6 +365,12 @@ enum eKeyCode
   eKeyF12 = 434
 };
 
+#ifdef SCRIPT_API_v350
+managed struct Point {
+	int x, y;
+};
+#endif
+
 #define CHARID int  // $AUTOCOMPLETEIGNORE$
 builtin struct ColorType {
   char r,g,b;
@@ -650,12 +656,6 @@ builtin managed struct Game {
   readonly import static attribute int AudioClipCount;
   /// Accesses the audio clips collection.
   readonly import static attribute AudioClip *AudioClips[];
-#endif
-#ifdef SCRIPT_API_v350
-  /// Gets/sets whether the viewport should automatically adjust itself and camera to the new room's background size
-  import static attribute bool AutoSizeViewportOnRoomLoad;
-  /// Gets the room viewport
-  import static readonly attribute Viewport *RoomViewport;
 #endif
 };
 
@@ -2042,6 +2042,7 @@ builtin managed struct AudioClip {
 };
 
 builtin struct System {
+#ifdef SCRIPT_COMPAT_v341
   readonly int  screen_width,screen_height;
   readonly int  color_depth;
   readonly int  os;
@@ -2050,6 +2051,7 @@ builtin struct System {
   readonly int  viewport_width, viewport_height;
 #ifndef STRICT_STRINGS
   readonly char version[10];
+#endif
 #endif
   /// Gets whether Caps Lock is currently on.
   readonly import static attribute bool CapsLock;
@@ -2067,20 +2069,24 @@ builtin struct System {
   readonly import static attribute bool NumLock;
   /// Gets which operating system the game is running on.
   readonly import static attribute eOperatingSystem OperatingSystem;
+#ifdef SCRIPT_COMPAT_v341
   /// Gets the screen height of the current resolution.
   readonly import static attribute int  ScreenHeight;
   /// Gets the screen width of the current resolution.
   readonly import static attribute int  ScreenWidth;
+#endif
   /// Gets whether Scroll Lock is currently on.
   readonly import static attribute bool ScrollLock;
   /// Gets whether the player's system supports gamma adjustment.
   readonly import static attribute bool SupportsGammaControl;
   /// Gets the AGS engine version number.
   readonly import static attribute String Version;
+#ifdef SCRIPT_COMPAT_v341
   /// Gets the height of the visible area in which the game is displayed.
   readonly import static attribute int  ViewportHeight;
   /// Gets the width of the visible area in which the game is displayed.
   readonly import static attribute int  ViewportWidth;
+#endif
   /// Gets/sets the audio output volume, from 0-100.
   import static attribute int  Volume;
   /// Gets/sets whether waiting for the vertical sync is enabled.
@@ -2653,8 +2659,7 @@ builtin struct Speech {
 #endif
 
 #ifdef SCRIPT_API_v350
-builtin managed struct Camera
-{
+builtin managed struct Camera {
   /// Gets/sets the X position of this camera in the room.
   import attribute int X;
   /// Gets/sets the Y position of this camera in the room.
@@ -2666,10 +2671,14 @@ builtin managed struct Camera
 
   /// Gets/sets whether this camera will follow the player character automatically.
   import attribute bool AutoTracking;
+
+  /// Changes camera position in the room and disables automatic tracking of the player character.
+  import void SetAt(int x, int y);
+  /// Changes camera's capture dimensions in room coordinates.
+  import void SetSize(int width, int height);
 };
 
-builtin managed struct Viewport
-{
+builtin managed struct Viewport {
   /// Gets/sets the X position on the screen where this viewport is located.
   import attribute int X;
   /// Gets/sets the Y position on the screen where this viewport is located.
@@ -2680,6 +2689,29 @@ builtin managed struct Viewport
   import attribute int Height;
   /// Gets the room camera displayed in this viewport.
   import readonly attribute Camera *Camera;
+
+  /// Returns the viewport at the specified screen location.
+  import static Viewport *GetAtScreenXY(int x, int y);
+  /// Changes viewport's position on the screen
+  import void SetPosition(int x, int y, int width, int height);
+  /// Returns the point in room corresponding to the given screen coordinates if seen through this viewport.
+  import Point *ScreenToRoomPoint(int scrx, int scry, bool clipViewport = true);
+  /// Returns the point on screen corresponding to the given room coordinates if seen through this viewport.
+  import Point *RoomToScreenPoint(int roomx, int roomy, bool clipViewport = true);
+};
+
+builtin struct Screen {
+  /// Gets the width of the game resolution.
+  import static readonly attribute int Width;
+  /// Gets the height of the game resolution.
+  import static readonly attribute int Height;
+  /// Gets/sets whether the viewport should automatically adjust itself and camera to the new room's background size
+  import static attribute bool AutoSizeViewportOnRoomLoad;
+  /// Gets the primary room viewport
+  import static readonly attribute Viewport *Viewport;
+
+  /// Returns the point in room which is displayed at the given screen coordinates
+  import static Point *ScreenToRoomPoint(int sx, int sy);
 };
 #endif
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2663,10 +2663,6 @@ builtin managed struct Camera
   import attribute int Width;
   /// Gets/sets the camera's capture height in room coordinates.
   import attribute int Height;
-  /// Gets/sets this camera's room horizontal scaling relative to the viewport it is displayed in.
-  import attribute float ScaleX;
-  /// Gets/sets this camera's room vertical scaling relative to the viewport it is displayed in.
-  import attribute float ScaleY;
 
   /// Gets/sets whether this camera will follow the player character automatically.
   import attribute bool AutoTracking;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -423,6 +423,15 @@ AGS_INLINE int divide_down_coordinate(int coord)
         return coord;
 }
 
+AGS_INLINE void divide_down_coordinates(int &x, int &y)
+{
+    if (game.options[OPT_NATIVECOORDINATES] == 0)
+    {
+        x /= current_screen_resolution_multiplier;
+        y /= current_screen_resolution_multiplier;
+    }
+}
+
 AGS_INLINE int divide_down_coordinate_round_up(int coord)
 {
     if (game.options[OPT_NATIVECOORDINATES] == 0)

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -114,12 +114,13 @@ void setpal();
 extern AGS_INLINE int get_fixed_pixel_size(int pixels);
 extern AGS_INLINE int convert_to_low_res(int coord);
 extern AGS_INLINE int convert_back_to_high_res(int coord);
-// coordinate conversion game ---> screen
+// coordinate conversion game,script ---> screen
 extern AGS_INLINE int multiply_up_coordinate(int coord);
 extern AGS_INLINE void multiply_up_coordinates(int *x, int *y);
 extern AGS_INLINE void multiply_up_coordinates_round_up(int *x, int *y);
-// coordinate conversion screen ---> game
+// coordinate conversion screen ---> game,script
 extern AGS_INLINE int divide_down_coordinate(int coord);
+extern AGS_INLINE void divide_down_coordinates(int &x, int &y);
 extern AGS_INLINE int divide_down_coordinate_round_up(int coord);
 
 // Checks if the bitmap needs to be converted and **deletes original** if a new bitmap

--- a/Engine/ac/dynobj/scriptcamera.cpp
+++ b/Engine/ac/dynobj/scriptcamera.cpp
@@ -36,8 +36,6 @@ int ScriptCamera::Serialize(const char *address, char *buffer, int bufsize)
     SerializeInt(cam.Position.Top);
     SerializeInt(cam.Position.GetWidth());
     SerializeInt(cam.Position.GetHeight());
-    SerializeFloat(cam.ScaleX);
-    SerializeFloat(cam.ScaleY);
     return EndSerialize();
 }
 
@@ -50,14 +48,7 @@ void ScriptCamera::Unserialize(int index, const char *serializedData, int dataSi
     int y = UnserializeInt();
     int w = UnserializeInt();
     int h = UnserializeInt();
-    float scalex = UnserializeFloat();
-    float scaley = UnserializeFloat();
-    if (scalex >= 0.f && scaley >= 0.f)
-        play.SetRoomCameraAutoSize(scalex, scaley);
-    else if (w > 0 && h > 0)
-        play.SetRoomCameraSize(Size(w, h));
-    else
-        play.SetRoomCameraAutoSize(1.f, 1.f);
+    play.SetRoomCameraSize(Size(w, h));
     if (flags & kScCamPosLocked)
         play.LockRoomCameraAt(x, y);
     else

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -132,3 +132,13 @@ void ScriptUserObject::WriteFloat(const char *address, intptr_t offset, float va
 {
     *(float*)(_data + offset) = val;
 }
+
+
+// Allocates managed struct containing two ints: X and Y
+ScriptUserObject *ScriptStructHelpers::CreatePoint(int x, int y)
+{
+    ScriptUserObject *suo = ScriptUserObject::CreateManaged(sizeof(int32_t) * 2);
+    suo->WriteInt32((const char*)suo, 0, x);
+    suo->WriteInt32((const char*)suo, sizeof(int32_t), y);
+    return suo;
+}

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -61,4 +61,12 @@ private:
     char    *_data;
 };
 
+
+// Helper functions for setting up custom managed structs based on ScriptUserObject.
+namespace ScriptStructHelpers
+{
+    // Creates a managed Point object, represented as a pair of X and Y coordinates.
+    ScriptUserObject *CreatePoint(int x, int y);
+};
+
 #endif // __AGS_EE_DYNOBJ__SCRIPTUSERSTRUCT_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -59,7 +59,6 @@
 #include "ac/dynobj/all_scriptclasses.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "ac/dynobj/cc_audioclip.h"
-#include "ac/dynobj/scriptviewport.h"
 #include "debug/debug_log.h"
 #include "debug/out.h"
 #include "device/mousew32.h"
@@ -964,24 +963,6 @@ ScriptAudioClip *Game_GetAudioClip(int index)
     if (index < 0 || index >= game.audioClipCount)
         return NULL;
     return &game.audioClips[index];
-}
-
-
-bool Game_GetAutoSizeViewport()
-{
-    return play.IsAutoRoomViewport();
-}
-
-void Game_SetAutoSizeViewport(bool on)
-{
-    play.SetAutoRoomViewport(on);
-}
-
-ScriptViewport* Game_GetRoomViewport()
-{
-    ScriptViewport *viewport = new ScriptViewport();
-    ccRegisterManagedObject(viewport, viewport);
-    return viewport;
 }
 
 //=============================================================================
@@ -2434,21 +2415,6 @@ RuntimeScriptValue Sc_Game_IsPluginLoaded(const RuntimeScriptValue *params, int3
     API_SCALL_BOOL_OBJ(pl_is_plugin_loaded, const char);
 }
 
-RuntimeScriptValue Sc_Game_GetAutoSizeViewport(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_BOOL(Game_GetAutoSizeViewport);
-}
-
-RuntimeScriptValue Sc_Game_SetAutoSizeViewport(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_VOID_PBOOL(Game_SetAutoSizeViewport);
-}
-
-RuntimeScriptValue Sc_Game_GetRoomViewport(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_OBJAUTO(ScriptViewport, Game_GetRoomViewport);
-}
-
 
 void RegisterGameAPI()
 {
@@ -2501,9 +2467,6 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::get_AudioClipCount",                     Sc_Game_GetAudioClipCount);
     ccAddExternalStaticFunction("Game::geti_AudioClips",                        Sc_Game_GetAudioClip);
     ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
-    ccAddExternalStaticFunction("Game::get_AutoSizeViewportOnRoomLoad",         Sc_Game_GetAutoSizeViewport);
-    ccAddExternalStaticFunction("Game::set_AutoSizeViewportOnRoomLoad",         Sc_Game_SetAutoSizeViewport);
-    ccAddExternalStaticFunction("Game::get_RoomViewport",                       Sc_Game_GetRoomViewport);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -195,7 +195,8 @@ void GameState::ReleaseRoomCamera()
 void GameState::UpdateRoomCamera()
 {
     const Rect &camera = _roomCamera.Position;
-    if ((thisroom.width > camera.GetWidth()) || (thisroom.height > camera.GetHeight()))
+    const Size real_room_sz = Size(multiply_up_coordinate(thisroom.width), multiply_up_coordinate(thisroom.height));
+    if ((real_room_sz.Width > camera.GetWidth()) || (real_room_sz.Height > camera.GetHeight()))
     {
         // TODO: split out into Camera Behavior
         if (!play.IsRoomCameraLocked())
@@ -215,9 +216,8 @@ void GameState::SetCameraActualSize(const Size &cam_size)
 {
     // TODO: currently we don't support having camera larger than room background
     // (or rather - looking outside of the room background); look into this later
-    int room_width = multiply_up_coordinate(thisroom.width);
-    int room_height = multiply_up_coordinate(thisroom.height);
-    Size real_size = Size::Clamp(cam_size, Size(1, 1), Size(room_width, room_height));
+    const Size real_room_sz = Size(multiply_up_coordinate(thisroom.width), multiply_up_coordinate(thisroom.height));
+    Size real_size = Size::Clamp(cam_size, Size(1, 1), real_room_sz);
 
     _roomCamera.Position.SetWidth(real_size.Width);
     _roomCamera.Position.SetHeight(real_size.Height);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -17,6 +17,7 @@
 #include "ac/gamestate.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/roomstruct.h"
+#include "ac/dynobj/scriptsystem.h"
 #include "debug/debug_log.h"
 #include "device/mousew32.h"
 #include "game/customproperties.h"
@@ -28,6 +29,7 @@ using namespace AGS::Common;
 extern GameSetupStruct game;
 extern roomstruct thisroom;
 extern CharacterInfo *playerchar;
+extern ScriptSystem scsystem;
 
 GameState::GameState()
 {
@@ -67,6 +69,8 @@ void GameState::SetMainViewport(const Rect &viewport)
 {
     _mainViewport.Position = FixupViewport(viewport, RectWH(game.size));
     Mouse::SetGraphicArea();
+    scsystem.viewport_width = divide_down_coordinate(_mainViewport.Position.GetWidth());
+    scsystem.viewport_height = divide_down_coordinate(_mainViewport.Position.GetHeight());
     _mainViewportHasChanged = true;
     // Update sub-viewports in case main viewport became smaller
     SetUIViewport(_uiViewport.Position);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -109,15 +109,9 @@ void GameState::SetUIViewport(const Rect &viewport)
 
 void GameState::SetRoomViewport(const Rect &viewport)
 {
-    Rect real_view = FixupViewport(viewport, RectWH(_mainViewport.Position.GetSize()));
-    bool pos_changed = viewport.GetLT() != _roomViewport.Position.GetLT();
-    bool size_changed = viewport.GetSize() != _roomViewport.Position.GetSize();
-    _roomViewport.Position = viewport;
-    _roomViewportHasChanged = pos_changed | size_changed;
-    if (size_changed)
-        UpdateCameraSize();
-    else
-        AdjustRoomToViewport();
+    _roomViewport.Position = FixupViewport(viewport, RectWH(_mainViewport.Position.GetSize()));
+    AdjustRoomToViewport();
+    _roomViewportHasChanged = true;
 }
 
 void GameState::UpdateViewports()
@@ -145,16 +139,16 @@ const RoomCamera &GameState::GetRoomCameraObj() const
 
 void GameState::SetRoomCameraSize(const Size &cam_size)
 {
-    _roomCamera.ScaleX = 0.f;
-    _roomCamera.ScaleY = 0.f;
-    SetCameraActualSize(cam_size);
-}
+    // TODO: currently we don't support having camera larger than room background
+    // (or rather - looking outside of the room background); look into this later
+    int room_width = multiply_up_coordinate(thisroom.width);
+    int room_height = multiply_up_coordinate(thisroom.height);
+    Size real_size = Size::Clamp(cam_size, Size(1, 1), Size(room_width, room_height));
 
-void GameState::SetRoomCameraAutoSize(float scalex, float scaley)
-{
-    _roomCamera.ScaleX = scalex;
-    _roomCamera.ScaleY = scaley;
-    UpdateCameraSize();
+    _roomCamera.Position.SetWidth(real_size.Width);
+    _roomCamera.Position.SetHeight(real_size.Height);
+    AdjustRoomToViewport();
+    _cameraHasChanged = true;
 }
 
 void GameState::SetRoomCameraAt(int x, int y)
@@ -209,37 +203,6 @@ void GameState::UpdateRoomCamera()
     else
     {
         SetRoomCameraAt(0, 0);
-    }
-}
-
-void GameState::SetCameraActualSize(const Size &cam_size)
-{
-    // TODO: currently we don't support having camera larger than room background
-    // (or rather - looking outside of the room background); look into this later
-    const Size real_room_sz = Size(multiply_up_coordinate(thisroom.width), multiply_up_coordinate(thisroom.height));
-    Size real_size = Size::Clamp(cam_size, Size(1, 1), real_room_sz);
-
-    _roomCamera.Position.SetWidth(real_size.Width);
-    _roomCamera.Position.SetHeight(real_size.Height);
-    AdjustRoomToViewport();
-    _cameraHasChanged = true;
-}
-
-void GameState::UpdateCameraSize()
-{
-    // TODO: when we support multiple cameras/viewports we should perhaps
-    // call viewport-camera render init for each PAIR rather than camera,
-    // to let displaying same camera in different viewports.
-    if (_roomCamera.ScaleX > 0.f && _roomCamera.ScaleY > 0.f)
-    {
-        // Automatic camera scale
-        int camw = _roomViewport.Position.GetWidth() * (1.f / _roomCamera.ScaleX);
-        int camh = _roomViewport.Position.GetHeight() * (1.f / _roomCamera.ScaleY);
-        SetCameraActualSize(Size(camw, camh));
-    }
-    else
-    {
-        AdjustRoomToViewport();
     }
 }
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -246,8 +246,6 @@ struct GameState {
     const RoomCamera &GetRoomCameraObj() const;
     // Sets explicit room camera's orthographic size
     void SetRoomCameraSize(const Size &cam_size);
-    // Sets automatic room camera resize relative to the viewport it's been used at
-    void SetRoomCameraAutoSize(float scalex = 1.f, float scaley = 1.f);
     // Puts room camera to the new location in the room
     void SetRoomCameraAt(int x, int y);
     // Tells if camera is currently locked at custom position
@@ -306,10 +304,6 @@ private:
     // Tells that the room camera's size has changed since last game update
     bool  _cameraHasChanged;
 
-    // Sets actual camera's size without resetting autoscale flag
-    void SetCameraActualSize(const Size &sz);
-    // Updates camera size after camera or viewport properties change.
-    void UpdateCameraSize();
     // Calculates room-to-viewport coordinate conversion.
     void AdjustRoomToViewport();
 };

--- a/Engine/ac/viewport.cpp
+++ b/Engine/ac/viewport.cpp
@@ -31,7 +31,8 @@
 
 int Camera_GetX(ScriptCamera *)
 {
-    return play.GetRoomCameraObj().Position.Left;
+    int x = play.GetRoomCameraObj().Position.Left;
+    return divide_down_coordinate(x);
 }
 
 void Camera_SetX(ScriptCamera *, int x)
@@ -42,7 +43,8 @@ void Camera_SetX(ScriptCamera *, int x)
 
 int Camera_GetY(ScriptCamera *)
 {
-    return play.GetRoomCameraObj().Position.Top;
+    int y = play.GetRoomCameraObj().Position.Top;
+    return divide_down_coordinate(y);
 }
 
 void Camera_SetY(ScriptCamera *, int y)
@@ -53,21 +55,25 @@ void Camera_SetY(ScriptCamera *, int y)
 
 int Camera_GetWidth(ScriptCamera *)
 {
-    return play.GetRoomCameraObj().Position.GetWidth();
+    int width = play.GetRoomCameraObj().Position.GetWidth();
+    return divide_down_coordinate(width);
 }
 
 void Camera_SetWidth(ScriptCamera *, int width)
 {
+    width = multiply_up_coordinate(width);
     play.SetRoomCameraSize(Size(width, play.GetRoomCamera().GetHeight()));
 }
 
 int Camera_GetHeight(ScriptCamera *)
 {
-    return play.GetRoomCameraObj().Position.GetHeight();
+    int height = play.GetRoomCameraObj().Position.GetHeight();
+    return divide_down_coordinate(height);
 }
 
 void Camera_SetHeight(ScriptCamera *, int height)
 {
+    height = multiply_up_coordinate(height);
     play.SetRoomCameraSize(Size(play.GetRoomCamera().GetWidth(), height));
 }
 
@@ -183,11 +189,13 @@ RuntimeScriptValue Sc_Camera_SetAutoTracking(void *self, const RuntimeScriptValu
 
 int Viewport_GetX(ScriptViewport *view)
 {
-    return play.GetRoomViewport().Left;
+    int x = play.GetRoomViewport().Left;
+    return divide_down_coordinate(x);
 }
 
 void Viewport_SetX(ScriptViewport *, int x)
 {
+    x = multiply_up_coordinate(x);
     Rect view = play.GetRoomViewport();
     view.MoveToX(x);
     play.SetRoomViewport(view);
@@ -195,11 +203,13 @@ void Viewport_SetX(ScriptViewport *, int x)
 
 int Viewport_GetY(ScriptViewport *)
 {
-    return play.GetRoomViewport().Top;
+    int y = play.GetRoomViewport().Top;
+    return divide_down_coordinate(y);
 }
 
 void Viewport_SetY(ScriptViewport *, int y)
 {
+    y = multiply_up_coordinate(y);
     Rect view = play.GetRoomViewport();
     view.MoveToY(y);
     play.SetRoomViewport(view);
@@ -207,11 +217,13 @@ void Viewport_SetY(ScriptViewport *, int y)
 
 int Viewport_GetWidth(ScriptViewport *)
 {
-    return play.GetRoomViewport().GetWidth();
+    int width = play.GetRoomViewport().GetWidth();
+    return divide_down_coordinate(width);
 }
 
 void Viewport_SetWidth(ScriptViewport *, int width)
 {
+    width = multiply_up_coordinate(width);
     Rect view = play.GetRoomViewport();
     view.SetWidth(width);
     play.SetRoomViewport(view);
@@ -219,11 +231,13 @@ void Viewport_SetWidth(ScriptViewport *, int width)
 
 int Viewport_GetHeight(ScriptViewport *)
 {
-    return play.GetRoomViewport().GetHeight();
+    int height = play.GetRoomViewport().GetHeight();
+    return divide_down_coordinate(height);
 }
 
 void Viewport_SetHeight(ScriptViewport *, int height)
 {
+    height = multiply_up_coordinate(height);
     Rect view = play.GetRoomViewport();
     view.SetHeight(height);
     play.SetRoomViewport(view);

--- a/Engine/ac/viewport.cpp
+++ b/Engine/ac/viewport.cpp
@@ -77,26 +77,6 @@ void Camera_SetHeight(ScriptCamera *, int height)
     play.SetRoomCameraSize(Size(play.GetRoomCamera().GetWidth(), height));
 }
 
-float Camera_GetScaleX(ScriptCamera *)
-{
-    return play.GetRoomCameraObj().ScaleX;
-}
-
-void Camera_SetScaleX(ScriptCamera *, float sx)
-{
-    return play.SetRoomCameraAutoSize(sx, play.GetRoomCameraObj().ScaleY);
-}
-
-float Camera_GetScaleY(ScriptCamera *)
-{
-    return play.GetRoomCameraObj().ScaleY;
-}
-
-void Camera_SetScaleY(ScriptCamera *, float sy)
-{
-    return play.SetRoomCameraAutoSize(play.GetRoomCameraObj().ScaleX, sy);
-}
-
 bool Camera_GetAutoTracking(ScriptCamera *)
 {
     return !play.IsRoomCameraLocked();
@@ -148,26 +128,6 @@ RuntimeScriptValue Sc_Camera_GetHeight(void *self, const RuntimeScriptValue *par
 RuntimeScriptValue Sc_Camera_SetHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptCamera, Camera_SetHeight);
-}
-
-RuntimeScriptValue Sc_Camera_GetScaleX(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_FLOAT(ScriptCamera, Camera_GetScaleX);
-}
-
-RuntimeScriptValue Sc_Camera_SetScaleX(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_VOID_PFLOAT(ScriptCamera, Camera_SetScaleX);
-}
-
-RuntimeScriptValue Sc_Camera_GetScaleY(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_FLOAT(ScriptCamera, Camera_GetScaleY);
-}
-
-RuntimeScriptValue Sc_Camera_SetScaleY(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_VOID_PFLOAT(ScriptCamera, Camera_SetScaleY);
 }
 
 RuntimeScriptValue Sc_Camera_GetAutoTracking(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -306,10 +266,6 @@ void RegisterViewportAPI()
     ccAddExternalObjectFunction("Camera::set_Width", Sc_Camera_SetWidth);
     ccAddExternalObjectFunction("Camera::get_Height", Sc_Camera_GetHeight);
     ccAddExternalObjectFunction("Camera::set_Height", Sc_Camera_SetHeight);
-    ccAddExternalObjectFunction("Camera::get_ScaleX", Sc_Camera_GetScaleX);
-    ccAddExternalObjectFunction("Camera::set_ScaleX", Sc_Camera_SetScaleX);
-    ccAddExternalObjectFunction("Camera::get_ScaleY", Sc_Camera_GetScaleY);
-    ccAddExternalObjectFunction("Camera::set_ScaleY", Sc_Camera_SetScaleY);
     ccAddExternalObjectFunction("Camera::get_AutoTracking", Sc_Camera_GetAutoTracking);
     ccAddExternalObjectFunction("Camera::set_AutoTracking", Sc_Camera_SetAutoTracking);
 

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -25,15 +25,13 @@ struct RoomCamera
 {
     // Actual position and orthographic size
     Rect Position;
-    // Automatic scaling used to resize the camera's picture to the viewport
-    float ScaleX;
-    float ScaleY;
     // Locked or following player automatically
     bool Locked;
 };
 
 struct Viewport
 {
+    // Position of the viewport on screen
     Rect Position;
     // TODO: Camera reference (when supporting multiple cameras)
     // Coordinate tranform between camera and viewport

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -138,7 +138,7 @@ void engine_init_resolution_settings(const Size game_size)
     play.SetMainViewport(viewport);
     play.SetUIViewport(viewport);
     play.SetRoomViewport(viewport);
-    play.SetRoomCameraAutoSize();
+    play.SetRoomCameraSize(viewport.GetSize());
 
     Size native_size = game_size;
     if (game.IsHiRes())

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -44,6 +44,7 @@ extern void RegisterOverlayAPI();
 extern void RegisterParserAPI();
 extern void RegisterRegionAPI();
 extern void RegisterRoomAPI();
+extern void RegisterScreenAPI();
 extern void RegisterSliderAPI();
 extern void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api);
 extern void RegisterStringAPI();
@@ -82,6 +83,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterParserAPI();
     RegisterRegionAPI();
     RegisterRoomAPI();
+    RegisterScreenAPI();
     RegisterSliderAPI();
     RegisterSpeechAPI(base_api, compat_api);
     RegisterStringAPI();

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -377,6 +377,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     METHOD((CLASS*)self, params[0].FValue); \
     return RuntimeScriptValue()
 
+#define API_OBJCALL_VOID_PFLOAT2(CLASS, METHOD) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
+    METHOD((CLASS*)self, params[0].FValue, params[1].FValue); \
+    return RuntimeScriptValue()
+
 #define API_OBJCALL_VOID_PBOOL(CLASS, METHOD) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
     METHOD((CLASS*)self, params[0].GetAsBool()); \
@@ -509,6 +514,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 #define API_OBJCALL_OBJAUTO(CLASS, RET_CLASS, METHOD) \
     ASSERT_SELF(METHOD) \
     RET_CLASS* ret_obj = METHOD((CLASS*)self); \
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
+
+#define API_OBJCALL_OBJAUTO_PINT2_PBOOL(CLASS, RET_CLASS, METHOD) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 3) \
+    RET_CLASS* ret_obj = METHOD((CLASS*)self, params[0].IValue, params[1].IValue, params[2].GetAsBool()); \
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
 
 #define API_OBJCALL_OBJAUTO_POBJ(CLASS, RET_CLASS, METHOD, P1CLASS) \


### PR DESCRIPTION
This adds a bunch of script functions to work with Viewport and Camera.

But first of all, I added Screen struct to place static screen-related properties and functions there. At the moment its declaration looks like this:
<pre>
builtin struct Screen {
  /// Gets the width of the game resolution.
  import static readonly attribute int Width;
  /// Gets the height of the game resolution.
  import static readonly attribute int Height;
  /// Gets/sets whether the viewport should automatically adjust itself and camera to the new room's background size
  import static attribute bool AutoSizeViewportOnRoomLoad;
  /// Gets the primary room viewport
  import static readonly attribute Viewport *Viewport;

  /// Returns the point in room which is displayed at the given screen coordinates
  import static Point *ScreenToRoomPoint(int sx, int sy);
};
</pre>

You may notice there's now Point struct in the builtin API. It's declaration is trivial:
<pre>
managed struct Point {
	int x, y;
};
</pre>
So far this is the only managed struct that is intentionally not declared as "builtin", because I thought it would be good to let users also spawn its instances in script.

* Moved RoomViewport and AutoSizeViewportOnRoomLoad properties from Game to Screen struct.
* Deprecated System.ScreenWidth and System.ScreenHeight, as well as System.ViewportWidth and System.ViewportHeight in favor of Screen.Width/Height.

Added following to the Viewport:
<pre>
  /// Returns the viewport at the specified screen location.
  import static Viewport *GetAtScreenXY(int x, int y);
  /// Changes viewport's position on the screen
  import void SetPosition(int x, int y, int width, int height);
  /// Returns the point in room corresponding to the given screen coordinates if seen through this viewport.
  import Point *ScreenToRoomPoint(int scrx, int scry, bool clipViewport = true);
  /// Returns the point on screen corresponding to the given room coordinates if seen through this viewport.
  import Point *RoomToScreenPoint(int roomx, int roomy, bool clipViewport = true);
</pre>

**Removed ScaleX and ScaleY from Camera.**

Added following to the Camera:
<pre>
  /// Changes camera position in the room and disables automatic tracking of the player character.
  import void SetAt(int x, int y);
  /// Changes camera's capture dimensions in room coordinates.
  import void SetSize(int width, int height);
</pre>


**NOTES:**
* Screen.ScreenToRoomPoint returns null if there is no room Viewport under these coordinates. If there will be multiple viewports supported in the future engine simply won't know which to choose if there's none directly there.
* Both Viewport.ScreenToRoomPoint and Viewport.RoomToScreenPoint have clipViewport parameter which tells whether they should return null if the coordinates lie outside of the visible part of the room.