### PR TITLE
Tokenised sprite export

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -150,6 +150,12 @@
     <Compile Include="GUI\SplashScreen.Designer.cs">
       <DependentUpon>SplashScreen.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\SpriteExportDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\SpriteExportDialog.Designer.cs">
+      <DependentUpon>SpriteExportDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\TextEntryDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -320,6 +326,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\Progress.resx">
       <DependentUpon>Progress.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\SpriteExportDialog.resx">
+      <DependentUpon>SpriteExportDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Panes\BigPropertySheet.resx">
       <SubType>Designer</SubType>

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
@@ -1,0 +1,241 @@
+﻿namespace AGS.Editor
+{
+    partial class SpriteExportDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBoxExport = new System.Windows.Forms.GroupBox();
+            this.chkSkipValidSpriteSource = new System.Windows.Forms.CheckBox();
+            this.chkRecurse = new System.Windows.Forms.CheckBox();
+            this.radRootFolder = new System.Windows.Forms.RadioButton();
+            this.radThisFolder = new System.Windows.Forms.RadioButton();
+            this.groupBoxSaveAs = new System.Windows.Forms.GroupBox();
+            this.btnBrowse = new System.Windows.Forms.Button();
+            this.txtFolder = new System.Windows.Forms.TextBox();
+            this.txtFilename = new System.Windows.Forms.TextBox();
+            this.lblFolder = new System.Windows.Forms.Label();
+            this.lblFilename = new System.Windows.Forms.Label();
+            this.btnClose = new System.Windows.Forms.Button();
+            this.btnExport = new System.Windows.Forms.Button();
+            this.chkUpdateSpriteSource = new System.Windows.Forms.CheckBox();
+            this.groupBoxExport.SuspendLayout();
+            this.groupBoxSaveAs.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBoxExport
+            // 
+            this.groupBoxExport.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxExport.Controls.Add(this.chkSkipValidSpriteSource);
+            this.groupBoxExport.Controls.Add(this.chkRecurse);
+            this.groupBoxExport.Controls.Add(this.radRootFolder);
+            this.groupBoxExport.Controls.Add(this.radThisFolder);
+            this.groupBoxExport.Location = new System.Drawing.Point(12, 12);
+            this.groupBoxExport.Name = "groupBoxExport";
+            this.groupBoxExport.Size = new System.Drawing.Size(410, 116);
+            this.groupBoxExport.TabIndex = 0;
+            this.groupBoxExport.TabStop = false;
+            this.groupBoxExport.Text = "Export from";
+            // 
+            // chkSkipValidSpriteSource
+            // 
+            this.chkSkipValidSpriteSource.AutoSize = true;
+            this.chkSkipValidSpriteSource.Location = new System.Drawing.Point(7, 92);
+            this.chkSkipValidSpriteSource.Name = "chkSkipValidSpriteSource";
+            this.chkSkipValidSpriteSource.Size = new System.Drawing.Size(192, 17);
+            this.chkSkipValidSpriteSource.TabIndex = 3;
+            this.chkSkipValidSpriteSource.Text = "Skip sprites where source file exists";
+            this.chkSkipValidSpriteSource.UseVisualStyleBackColor = true;
+            // 
+            // chkRecurse
+            // 
+            this.chkRecurse.AutoSize = true;
+            this.chkRecurse.Location = new System.Drawing.Point(7, 68);
+            this.chkRecurse.Name = "chkRecurse";
+            this.chkRecurse.Size = new System.Drawing.Size(115, 17);
+            this.chkRecurse.TabIndex = 2;
+            this.chkRecurse.Text = "Include sub-folders";
+            this.chkRecurse.UseVisualStyleBackColor = true;
+            // 
+            // radRootFolder
+            // 
+            this.radRootFolder.AutoSize = true;
+            this.radRootFolder.Location = new System.Drawing.Point(7, 44);
+            this.radRootFolder.Name = "radRootFolder";
+            this.radRootFolder.Size = new System.Drawing.Size(105, 17);
+            this.radRootFolder.TabIndex = 1;
+            this.radRootFolder.Text = "Root sprite folder";
+            this.radRootFolder.UseVisualStyleBackColor = true;
+            // 
+            // radThisFolder
+            // 
+            this.radThisFolder.AutoSize = true;
+            this.radThisFolder.Checked = true;
+            this.radThisFolder.Location = new System.Drawing.Point(7, 20);
+            this.radThisFolder.Name = "radThisFolder";
+            this.radThisFolder.Size = new System.Drawing.Size(102, 17);
+            this.radThisFolder.TabIndex = 0;
+            this.radThisFolder.TabStop = true;
+            this.radThisFolder.Text = "This sprite folder";
+            this.radThisFolder.UseVisualStyleBackColor = true;
+            // 
+            // groupBoxSaveAs
+            // 
+            this.groupBoxSaveAs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxSaveAs.Controls.Add(this.chkUpdateSpriteSource);
+            this.groupBoxSaveAs.Controls.Add(this.btnBrowse);
+            this.groupBoxSaveAs.Controls.Add(this.txtFolder);
+            this.groupBoxSaveAs.Controls.Add(this.txtFilename);
+            this.groupBoxSaveAs.Controls.Add(this.lblFolder);
+            this.groupBoxSaveAs.Controls.Add(this.lblFilename);
+            this.groupBoxSaveAs.Location = new System.Drawing.Point(12, 134);
+            this.groupBoxSaveAs.Name = "groupBoxSaveAs";
+            this.groupBoxSaveAs.Size = new System.Drawing.Size(410, 136);
+            this.groupBoxSaveAs.TabIndex = 1;
+            this.groupBoxSaveAs.TabStop = false;
+            this.groupBoxSaveAs.Text = "Save As";
+            // 
+            // btnBrowse
+            // 
+            this.btnBrowse.Location = new System.Drawing.Point(63, 74);
+            this.btnBrowse.Name = "btnBrowse";
+            this.btnBrowse.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowse.TabIndex = 4;
+            this.btnBrowse.Text = "Browse";
+            this.btnBrowse.UseVisualStyleBackColor = true;
+            this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
+            // 
+            // txtFolder
+            // 
+            this.txtFolder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFolder.Location = new System.Drawing.Point(63, 47);
+            this.txtFolder.Name = "txtFolder";
+            this.txtFolder.Size = new System.Drawing.Size(341, 20);
+            this.txtFolder.TabIndex = 3;
+            // 
+            // txtFilename
+            // 
+            this.txtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFilename.Location = new System.Drawing.Point(63, 20);
+            this.txtFilename.Name = "txtFilename";
+            this.txtFilename.Size = new System.Drawing.Size(341, 20);
+            this.txtFilename.TabIndex = 2;
+            this.txtFilename.Text = "%Number%";
+            // 
+            // lblFolder
+            // 
+            this.lblFolder.AutoSize = true;
+            this.lblFolder.Location = new System.Drawing.Point(8, 49);
+            this.lblFolder.Name = "lblFolder";
+            this.lblFolder.Size = new System.Drawing.Size(36, 13);
+            this.lblFolder.TabIndex = 1;
+            this.lblFolder.Text = "Folder";
+            // 
+            // lblFilename
+            // 
+            this.lblFilename.AutoSize = true;
+            this.lblFilename.Location = new System.Drawing.Point(7, 22);
+            this.lblFilename.Name = "lblFilename";
+            this.lblFilename.Size = new System.Drawing.Size(49, 13);
+            this.lblFilename.TabIndex = 0;
+            this.lblFilename.Text = "Filename";
+            this.lblFilename.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btnClose
+            // 
+            this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnClose.Location = new System.Drawing.Point(12, 276);
+            this.btnClose.Name = "btnClose";
+            this.btnClose.Size = new System.Drawing.Size(75, 23);
+            this.btnClose.TabIndex = 2;
+            this.btnClose.Text = "Close";
+            this.btnClose.UseVisualStyleBackColor = true;
+            // 
+            // btnExport
+            // 
+            this.btnExport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnExport.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnExport.Location = new System.Drawing.Point(93, 276);
+            this.btnExport.Name = "btnExport";
+            this.btnExport.Size = new System.Drawing.Size(75, 23);
+            this.btnExport.TabIndex = 3;
+            this.btnExport.Text = "Export";
+            this.btnExport.UseVisualStyleBackColor = true;
+            // 
+            // chkUpdateSpriteSource
+            // 
+            this.chkUpdateSpriteSource.AutoSize = true;
+            this.chkUpdateSpriteSource.Location = new System.Drawing.Point(65, 108);
+            this.chkUpdateSpriteSource.Name = "chkUpdateSpriteSource";
+            this.chkUpdateSpriteSource.Size = new System.Drawing.Size(179, 17);
+            this.chkUpdateSpriteSource.TabIndex = 5;
+            this.chkUpdateSpriteSource.Text = "Set exported file as sprite source";
+            this.chkUpdateSpriteSource.UseVisualStyleBackColor = true;
+            // 
+            // SpriteExportDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(434, 311);
+            this.Controls.Add(this.btnExport);
+            this.Controls.Add(this.btnClose);
+            this.Controls.Add(this.groupBoxSaveAs);
+            this.Controls.Add(this.groupBoxExport);
+            this.Name = "SpriteExportDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Sprite export";
+            this.groupBoxExport.ResumeLayout(false);
+            this.groupBoxExport.PerformLayout();
+            this.groupBoxSaveAs.ResumeLayout(false);
+            this.groupBoxSaveAs.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBoxExport;
+        private System.Windows.Forms.CheckBox chkRecurse;
+        private System.Windows.Forms.RadioButton radRootFolder;
+        private System.Windows.Forms.RadioButton radThisFolder;
+        private System.Windows.Forms.GroupBox groupBoxSaveAs;
+        private System.Windows.Forms.TextBox txtFilename;
+        private System.Windows.Forms.Label lblFolder;
+        private System.Windows.Forms.Label lblFilename;
+        private System.Windows.Forms.Button btnBrowse;
+        private System.Windows.Forms.TextBox txtFolder;
+        private System.Windows.Forms.Button btnClose;
+        private System.Windows.Forms.Button btnExport;
+        private System.Windows.Forms.CheckBox chkSkipValidSpriteSource;
+        private System.Windows.Forms.CheckBox chkUpdateSpriteSource;
+    }
+}

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
@@ -124,14 +124,15 @@
             this.groupBoxSaveAs.Controls.Add(this.lblFilename);
             this.groupBoxSaveAs.Location = new System.Drawing.Point(12, 134);
             this.groupBoxSaveAs.Name = "groupBoxSaveAs";
-            this.groupBoxSaveAs.Size = new System.Drawing.Size(410, 107);
+            this.groupBoxSaveAs.Size = new System.Drawing.Size(410, 78);
             this.groupBoxSaveAs.TabIndex = 1;
             this.groupBoxSaveAs.TabStop = false;
             this.groupBoxSaveAs.Text = "Save as";
             // 
             // btnBrowse
             // 
-            this.btnBrowse.Location = new System.Drawing.Point(63, 74);
+            this.btnBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBrowse.Location = new System.Drawing.Point(358, 47);
             this.btnBrowse.Name = "btnBrowse";
             this.btnBrowse.Size = new System.Drawing.Size(46, 21);
             this.btnBrowse.TabIndex = 4;
@@ -146,7 +147,7 @@
             this.txtFolder.ContextMenuStrip = this.contextMenuStripExport;
             this.txtFolder.Location = new System.Drawing.Point(63, 47);
             this.txtFolder.Name = "txtFolder";
-            this.txtFolder.Size = new System.Drawing.Size(341, 20);
+            this.txtFolder.Size = new System.Drawing.Size(290, 20);
             this.txtFolder.TabIndex = 3;
             // 
             // contextMenuStripExport
@@ -238,7 +239,7 @@
             // 
             this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnClose.Location = new System.Drawing.Point(93, 304);
+            this.btnClose.Location = new System.Drawing.Point(93, 272);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(75, 23);
             this.btnClose.TabIndex = 2;
@@ -249,7 +250,7 @@
             // 
             this.btnExport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnExport.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnExport.Location = new System.Drawing.Point(12, 304);
+            this.btnExport.Location = new System.Drawing.Point(12, 272);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 23);
             this.btnExport.TabIndex = 3;
@@ -261,7 +262,7 @@
             this.groupBoxSpriteProperties.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxSpriteProperties.Controls.Add(this.chkUpdateSpriteSource);
-            this.groupBoxSpriteProperties.Location = new System.Drawing.Point(12, 248);
+            this.groupBoxSpriteProperties.Location = new System.Drawing.Point(12, 218);
             this.groupBoxSpriteProperties.Name = "groupBoxSpriteProperties";
             this.groupBoxSpriteProperties.Size = new System.Drawing.Size(409, 44);
             this.groupBoxSpriteProperties.TabIndex = 6;
@@ -272,16 +273,16 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(434, 339);
+            this.ClientSize = new System.Drawing.Size(434, 307);
             this.Controls.Add(this.btnExport);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.groupBoxSaveAs);
             this.Controls.Add(this.groupBoxExport);
             this.Controls.Add(this.groupBoxSpriteProperties);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(4096, 378);
+            this.MaximumSize = new System.Drawing.Size(4096, 346);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(450, 378);
+            this.MinimumSize = new System.Drawing.Size(450, 346);
             this.Name = "SpriteExportDialog";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.groupBoxExport = new System.Windows.Forms.GroupBox();
             this.chkSkipValidSpriteSource = new System.Windows.Forms.CheckBox();
             this.chkRecurse = new System.Windows.Forms.CheckBox();
@@ -36,14 +37,23 @@
             this.groupBoxSaveAs = new System.Windows.Forms.GroupBox();
             this.btnBrowse = new System.Windows.Forms.Button();
             this.txtFolder = new System.Windows.Forms.TextBox();
+            this.contextMenuStripExport = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.menuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItemCut = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.menuItemToken = new System.Windows.Forms.ToolStripMenuItem();
             this.txtFilename = new System.Windows.Forms.TextBox();
             this.lblFolder = new System.Windows.Forms.Label();
             this.lblFilename = new System.Windows.Forms.Label();
+            this.chkUpdateSpriteSource = new System.Windows.Forms.CheckBox();
             this.btnClose = new System.Windows.Forms.Button();
             this.btnExport = new System.Windows.Forms.Button();
-            this.chkUpdateSpriteSource = new System.Windows.Forms.CheckBox();
+            this.groupBoxSpriteProperties = new System.Windows.Forms.GroupBox();
             this.groupBoxExport.SuspendLayout();
             this.groupBoxSaveAs.SuspendLayout();
+            this.contextMenuStripExport.SuspendLayout();
+            this.groupBoxSpriteProperties.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBoxExport
@@ -105,10 +115,8 @@
             // 
             // groupBoxSaveAs
             // 
-            this.groupBoxSaveAs.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.groupBoxSaveAs.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBoxSaveAs.Controls.Add(this.chkUpdateSpriteSource);
             this.groupBoxSaveAs.Controls.Add(this.btnBrowse);
             this.groupBoxSaveAs.Controls.Add(this.txtFolder);
             this.groupBoxSaveAs.Controls.Add(this.txtFilename);
@@ -116,18 +124,18 @@
             this.groupBoxSaveAs.Controls.Add(this.lblFilename);
             this.groupBoxSaveAs.Location = new System.Drawing.Point(12, 134);
             this.groupBoxSaveAs.Name = "groupBoxSaveAs";
-            this.groupBoxSaveAs.Size = new System.Drawing.Size(410, 136);
+            this.groupBoxSaveAs.Size = new System.Drawing.Size(410, 107);
             this.groupBoxSaveAs.TabIndex = 1;
             this.groupBoxSaveAs.TabStop = false;
-            this.groupBoxSaveAs.Text = "Save As";
+            this.groupBoxSaveAs.Text = "Save as";
             // 
             // btnBrowse
             // 
             this.btnBrowse.Location = new System.Drawing.Point(63, 74);
             this.btnBrowse.Name = "btnBrowse";
-            this.btnBrowse.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowse.Size = new System.Drawing.Size(46, 21);
             this.btnBrowse.TabIndex = 4;
-            this.btnBrowse.Text = "Browse";
+            this.btnBrowse.Text = "...";
             this.btnBrowse.UseVisualStyleBackColor = true;
             this.btnBrowse.Click += new System.EventHandler(this.btnBrowse_Click);
             // 
@@ -135,15 +143,62 @@
             // 
             this.txtFolder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFolder.ContextMenuStrip = this.contextMenuStripExport;
             this.txtFolder.Location = new System.Drawing.Point(63, 47);
             this.txtFolder.Name = "txtFolder";
             this.txtFolder.Size = new System.Drawing.Size(341, 20);
             this.txtFolder.TabIndex = 3;
             // 
+            // contextMenuStripExport
+            // 
+            this.contextMenuStripExport.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.menuItemCopy,
+            this.menuItemCut,
+            this.menuItemPaste,
+            this.toolStripSeparator1,
+            this.menuItemToken});
+            this.contextMenuStripExport.Name = "contextMenuStripExport";
+            this.contextMenuStripExport.Size = new System.Drawing.Size(137, 98);
+            this.contextMenuStripExport.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripExport_Opening);
+            // 
+            // menuItemCopy
+            // 
+            this.menuItemCopy.Name = "menuItemCopy";
+            this.menuItemCopy.Size = new System.Drawing.Size(136, 22);
+            this.menuItemCopy.Text = "Copy";
+            this.menuItemCopy.Click += new System.EventHandler(this.menuItemCopy_Click);
+            // 
+            // menuItemCut
+            // 
+            this.menuItemCut.Name = "menuItemCut";
+            this.menuItemCut.Size = new System.Drawing.Size(136, 22);
+            this.menuItemCut.Text = "Cut";
+            this.menuItemCut.Click += new System.EventHandler(this.menuItemCut_Click);
+            // 
+            // menuItemPaste
+            // 
+            this.menuItemPaste.Name = "menuItemPaste";
+            this.menuItemPaste.Size = new System.Drawing.Size(136, 22);
+            this.menuItemPaste.Text = "Paste";
+            this.menuItemPaste.Click += new System.EventHandler(this.menuItemPaste_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(133, 6);
+            // 
+            // menuItemToken
+            // 
+            this.menuItemToken.Name = "menuItemToken";
+            this.menuItemToken.Size = new System.Drawing.Size(136, 22);
+            this.menuItemToken.Text = "Insert token";
+            this.menuItemToken.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.menuItemToken_DropDownItemClicked);
+            // 
             // txtFilename
             // 
             this.txtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFilename.ContextMenuStrip = this.contextMenuStripExport;
             this.txtFilename.Location = new System.Drawing.Point(63, 20);
             this.txtFilename.Name = "txtFilename";
             this.txtFilename.Size = new System.Drawing.Size(341, 20);
@@ -155,25 +210,35 @@
             this.lblFolder.AutoSize = true;
             this.lblFolder.Location = new System.Drawing.Point(8, 49);
             this.lblFolder.Name = "lblFolder";
-            this.lblFolder.Size = new System.Drawing.Size(36, 13);
+            this.lblFolder.Size = new System.Drawing.Size(52, 13);
             this.lblFolder.TabIndex = 1;
-            this.lblFolder.Text = "Folder";
+            this.lblFolder.Text = "Directory:";
             // 
             // lblFilename
             // 
             this.lblFilename.AutoSize = true;
             this.lblFilename.Location = new System.Drawing.Point(7, 22);
             this.lblFilename.Name = "lblFilename";
-            this.lblFilename.Size = new System.Drawing.Size(49, 13);
+            this.lblFilename.Size = new System.Drawing.Size(52, 13);
             this.lblFilename.TabIndex = 0;
-            this.lblFilename.Text = "Filename";
+            this.lblFilename.Text = "Filename:";
             this.lblFilename.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // chkUpdateSpriteSource
+            // 
+            this.chkUpdateSpriteSource.AutoSize = true;
+            this.chkUpdateSpriteSource.Location = new System.Drawing.Point(7, 19);
+            this.chkUpdateSpriteSource.Name = "chkUpdateSpriteSource";
+            this.chkUpdateSpriteSource.Size = new System.Drawing.Size(179, 17);
+            this.chkUpdateSpriteSource.TabIndex = 5;
+            this.chkUpdateSpriteSource.Text = "Set exported file as sprite source";
+            this.chkUpdateSpriteSource.UseVisualStyleBackColor = true;
             // 
             // btnClose
             // 
             this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnClose.Location = new System.Drawing.Point(12, 276);
+            this.btnClose.Location = new System.Drawing.Point(93, 304);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(75, 23);
             this.btnClose.TabIndex = 2;
@@ -184,39 +249,50 @@
             // 
             this.btnExport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnExport.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnExport.Location = new System.Drawing.Point(93, 276);
+            this.btnExport.Location = new System.Drawing.Point(12, 304);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(75, 23);
             this.btnExport.TabIndex = 3;
             this.btnExport.Text = "Export";
             this.btnExport.UseVisualStyleBackColor = true;
             // 
-            // chkUpdateSpriteSource
+            // groupBoxSpriteProperties
             // 
-            this.chkUpdateSpriteSource.AutoSize = true;
-            this.chkUpdateSpriteSource.Location = new System.Drawing.Point(65, 108);
-            this.chkUpdateSpriteSource.Name = "chkUpdateSpriteSource";
-            this.chkUpdateSpriteSource.Size = new System.Drawing.Size(179, 17);
-            this.chkUpdateSpriteSource.TabIndex = 5;
-            this.chkUpdateSpriteSource.Text = "Set exported file as sprite source";
-            this.chkUpdateSpriteSource.UseVisualStyleBackColor = true;
+            this.groupBoxSpriteProperties.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxSpriteProperties.Controls.Add(this.chkUpdateSpriteSource);
+            this.groupBoxSpriteProperties.Location = new System.Drawing.Point(12, 248);
+            this.groupBoxSpriteProperties.Name = "groupBoxSpriteProperties";
+            this.groupBoxSpriteProperties.Size = new System.Drawing.Size(409, 44);
+            this.groupBoxSpriteProperties.TabIndex = 6;
+            this.groupBoxSpriteProperties.TabStop = false;
+            this.groupBoxSpriteProperties.Text = "Sprite properties";
             // 
             // SpriteExportDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(434, 311);
+            this.ClientSize = new System.Drawing.Size(434, 339);
             this.Controls.Add(this.btnExport);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.groupBoxSaveAs);
             this.Controls.Add(this.groupBoxExport);
+            this.Controls.Add(this.groupBoxSpriteProperties);
+            this.MaximizeBox = false;
+            this.MaximumSize = new System.Drawing.Size(4096, 378);
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(450, 378);
             this.Name = "SpriteExportDialog";
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Sprite export";
             this.groupBoxExport.ResumeLayout(false);
             this.groupBoxExport.PerformLayout();
             this.groupBoxSaveAs.ResumeLayout(false);
             this.groupBoxSaveAs.PerformLayout();
+            this.contextMenuStripExport.ResumeLayout(false);
+            this.groupBoxSpriteProperties.ResumeLayout(false);
+            this.groupBoxSpriteProperties.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -237,5 +313,12 @@
         private System.Windows.Forms.Button btnExport;
         private System.Windows.Forms.CheckBox chkSkipValidSpriteSource;
         private System.Windows.Forms.CheckBox chkUpdateSpriteSource;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripExport;
+        private System.Windows.Forms.ToolStripMenuItem menuItemCopy;
+        private System.Windows.Forms.ToolStripMenuItem menuItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem menuItemToken;
+        private System.Windows.Forms.ToolStripMenuItem menuItemCut;
+        private System.Windows.Forms.GroupBox groupBoxSpriteProperties;
     }
 }

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using AGS.Types;
+
+namespace AGS.Editor
+{
+    public partial class SpriteExportDialog : Form
+    {
+        public string ExportPath
+        {
+            get { return Path.Combine(txtFolder.Text, txtFilename.Text); }
+        }
+
+        public bool Recurse
+        {
+            get { return chkRecurse.Checked; }
+        }
+
+        public bool UseRootFolder
+        {
+            get { return radRootFolder.Checked; }
+        }
+
+        public bool SkipValidSpriteSource
+        {
+            get { return chkSkipValidSpriteSource.Checked; }
+        }
+
+        public bool UpdateSpriteSource
+        {
+            get { return chkUpdateSpriteSource.Checked; }
+        }
+
+        public SpriteExportDialog(SpriteFolder folder)
+        {
+            InitializeComponent();
+            radThisFolder.Text = String.Format("This sprite folder ({0})", folder.Name);
+
+            if (folder == Factory.AGSEditor.CurrentGame.RootSpriteFolder)
+            {
+                radRootFolder.Checked = true;
+                radThisFolder.Enabled = false;
+            }
+        }
+
+        private void btnBrowse_Click(object sender, EventArgs e)
+        {
+            string folderPath = Factory.GUIController.ShowSelectFolderOrNoneDialog("Export sprites to folder...", Directory.GetCurrentDirectory());
+
+            if (folderPath != null)
+            {
+                txtFolder.Text = folderPath;
+            }
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -49,6 +50,15 @@ namespace AGS.Editor
                 radRootFolder.Checked = true;
                 radThisFolder.Enabled = false;
             }
+
+            List<ToolStripMenuItem> tokens = new List<ToolStripMenuItem>();
+
+            foreach(PropertyInfo property in typeof(Sprite).GetProperties())
+            {
+                tokens.Add(new ToolStripMenuItem(String.Format("%{0}%", property.Name)));
+            }
+
+            menuItemToken.DropDownItems.AddRange(tokens.ToArray());
         }
 
         private void btnBrowse_Click(object sender, EventArgs e)
@@ -58,6 +68,67 @@ namespace AGS.Editor
             if (folderPath != null)
             {
                 txtFolder.Text = folderPath;
+            }
+        }
+
+        private void contextMenuStripExport_Opening(object sender, CancelEventArgs e)
+        {
+            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+
+            if (textbox != null)
+            {
+                menuItemCopy.Enabled =
+                    menuItemCut.Enabled = textbox.SelectionLength > 0;
+
+                menuItemPaste.Enabled = Clipboard.ContainsText();
+            }
+        }
+
+        private void menuItemCopy_Click(object sender, EventArgs e)
+        {
+            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+
+            if (textbox != null)
+            {
+                textbox.Copy();
+            }
+        }
+
+        private void menuItemCut_Click(object sender, EventArgs e)
+        {
+            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+
+            if (textbox != null)
+            {
+                textbox.Cut();
+            }
+        }
+
+        private void menuItemPaste_Click(object sender, EventArgs e)
+        {
+            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+
+            if (textbox != null)
+            {
+                textbox.Paste();
+            }
+        }
+
+        private void menuItemToken_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
+        {
+            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+
+            if (textbox != null)
+            {
+                int index = textbox.SelectionStart;
+
+                if (textbox.SelectionLength != 0)
+                {
+                    textbox.Text = textbox.Text.Remove(index, textbox.SelectionLength);
+                }
+
+                textbox.Text = textbox.Text.Insert(index, e.ClickedItem.Text);
+                textbox.SelectionStart = index + e.ClickedItem.Text.Length;
             }
         }
     }

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor
 {
     public partial class SpriteExportDialog : Form
     {
+        private TextBox textbox; 
+
         public string ExportPath
         {
             get { return Path.Combine(txtFolder.Text, txtFilename.Text); }
@@ -73,7 +75,9 @@ namespace AGS.Editor
 
         private void contextMenuStripExport_Opening(object sender, CancelEventArgs e)
         {
-            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
+            // track the SourceControl since behaviour varies for sub-menu items
+            // depending on which .NET Framework version is being used
+            textbox = contextMenuStripExport.SourceControl as TextBox;
 
             if (textbox != null)
             {
@@ -86,8 +90,6 @@ namespace AGS.Editor
 
         private void menuItemCopy_Click(object sender, EventArgs e)
         {
-            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
-
             if (textbox != null)
             {
                 textbox.Copy();
@@ -96,8 +98,6 @@ namespace AGS.Editor
 
         private void menuItemCut_Click(object sender, EventArgs e)
         {
-            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
-
             if (textbox != null)
             {
                 textbox.Cut();
@@ -106,8 +106,6 @@ namespace AGS.Editor
 
         private void menuItemPaste_Click(object sender, EventArgs e)
         {
-            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
-
             if (textbox != null)
             {
                 textbox.Paste();
@@ -116,8 +114,6 @@ namespace AGS.Editor
 
         private void menuItemToken_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
-            TextBox textbox = contextMenuStripExport.SourceControl as TextBox;
-
             if (textbox != null)
             {
                 int index = textbox.SelectionStart;

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.resx
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="contextMenuStripExport.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Editor/AGS.Editor/GUI/SpriteExportDialog.resx
+++ b/Editor/AGS.Editor/GUI/SpriteExportDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -635,11 +635,7 @@ namespace AGS.Editor
             }
             else if (item.Name == MENU_ITEM_EXPORT_FOLDER)
             {
-                string exportFolder = Factory.GUIController.ShowSelectFolderOrNoneDialog("Export sprites to folder...", System.IO.Directory.GetCurrentDirectory());
-                if (exportFolder != null)
-                {
-                    ExportAllSpritesInFolder(exportFolder);
-                }
+                ExportAllSprites();
             }
             else if (item.Name == MENU_ITEM_SORT_BY_NUMBER)
             {
@@ -1069,31 +1065,33 @@ namespace AGS.Editor
             bmp.Dispose();
         }
 
-        private void ExportAllSpritesInFolder(string exportToFolder)
+        private void ExportAllSprites()
         {
-            try
+            SpriteExportDialog dialog = new SpriteExportDialog(_currentFolder);
+
+            if (dialog.ShowDialog() == DialogResult.OK)
             {
-                foreach (Sprite sprite in _currentFolder.Sprites)
+                try
                 {
-                    Bitmap bmp = Factory.NativeProxy.GetBitmapForSprite(sprite.Number, sprite.Width, sprite.Height);
-                    if ((sprite.ColorDepth < 32) && (!sprite.AlphaChannel))
+                    if (dialog.UseRootFolder)
                     {
-                        bmp.Save(string.Format("{0}{1}spr{2:00000}.bmp", exportToFolder, Path.DirectorySeparatorChar, sprite.Number), ImageFormat.Bmp);
+                        SpriteTools.ExportSprites(dialog.ExportPath, dialog.Recurse,
+                            dialog.SkipValidSpriteSource, dialog.UpdateSpriteSource);
                     }
                     else
                     {
-                        // export 32-bit images as PNG so no alpha channel is lost
-                        bmp.Save(string.Format("{0}{1}spr{2:00000}.png", exportToFolder, Path.DirectorySeparatorChar, sprite.Number), ImageFormat.Png);
+                        SpriteTools.ExportSprites(_currentFolder, dialog.ExportPath, dialog.Recurse,
+                            dialog.SkipValidSpriteSource, dialog.UpdateSpriteSource);
                     }
-                    bmp.Dispose();
                 }
+                catch (Exception ex)
+                {
+                    String message = String.Format("There was an error during the export. The error message was: '{0}'", ex.Message);
+                    Factory.GUIController.ShowMessage(message, MessageBoxIcon.Warning);
+                }
+            }
 
-                Factory.GUIController.ShowMessage("Sprites exported successfully.", MessageBoxIcon.Information);
-            }
-            catch (Exception ex)
-            {
-                Factory.GUIController.ShowMessage("There was an error exporting the files. The error message was: '" + ex.Message + "'. Please try again", MessageBoxIcon.Warning);
-            }
+            dialog.Dispose();
         }
 
         private void SortAllSpritesInCurrentFolderByNumber()
@@ -1213,7 +1211,7 @@ namespace AGS.Editor
             }
 
             menu.Items.Add(new ToolStripSeparator());
-            menu.Items.Add(new ToolStripMenuItem("Export all sprites in folder...", null, onClick, MENU_ITEM_EXPORT_FOLDER));
+            menu.Items.Add(new ToolStripMenuItem("Export all sprites...", null, onClick, MENU_ITEM_EXPORT_FOLDER));
             menu.Items.Add(new ToolStripMenuItem("Sort sprites by number", null, onClick, MENU_ITEM_SORT_BY_NUMBER));
             menu.Items.Add(new ToolStripSeparator());
             menu.Items.Add(new ToolStripMenuItem("Find sprite by number...", null, onClick, MENU_ITEM_FIND_BY_NUMBER));

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -4,7 +4,9 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using AGS.Types;
 
 namespace AGS.Editor.Utils
@@ -328,6 +330,93 @@ namespace AGS.Editor.Utils
 
             progress.Hide();
             progress.Dispose();
+        }
+
+        private static string ExpandExportPath(object obj, string path)
+        {
+            Type type = obj.GetType();
+            PropertyInfo[] properties = type.GetProperties();
+            Dictionary<string, string> replace = new Dictionary<string, string>();
+
+            foreach (PropertyInfo property in properties)
+            {
+                string token = String.Format("%{0}%", property.Name.ToLower());
+                object value = property.GetValue(obj);
+                replace.Add(token, value != null ? value.ToString() : "");
+            }
+
+            Regex regex = new Regex("%[a-zA-Z0-9]+%");
+
+            return regex.Replace(path, delegate(Match m) {
+                string lookup = m.Value.ToLower();
+
+                if (replace.ContainsKey(lookup))
+                {
+                    return replace[lookup];
+                }
+
+                return m.Value; });
+        }
+
+        public static void ExportSprite(Sprite sprite, string path, bool updateSourcePath)
+        {
+            ImageFormat format = sprite.ColorDepth < 32 && !sprite.AlphaChannel ? ImageFormat.Bmp : ImageFormat.Png;
+            path = String.Format("{0}.{1}", ExpandExportPath(sprite, path), format.ToString().ToLower());
+
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, path);
+            }
+
+            Bitmap bmp = Factory.NativeProxy.GetBitmapForSprite(sprite.Number, sprite.Width, sprite.Height);
+            bmp.Save(path, format);
+            bmp.Dispose();
+
+            if (updateSourcePath)
+            {
+                sprite.SourceFile = Utilities.GetRelativeToProjectPath(path);
+            }
+        }
+
+        public static void ExportSprites(SpriteFolder folder, string path, bool recurse, bool skipValidSourcePath, bool updateSourcePath)
+        {
+            foreach(Sprite sprite in folder.Sprites)
+            {
+                if (skipValidSourcePath)
+                {
+                    string checkPath;
+
+                    if (Path.IsPathRooted(sprite.SourceFile))
+                    {
+                        checkPath = sprite.SourceFile;
+                    }
+                    else
+                    {
+                        checkPath = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, sprite.SourceFile);
+                    }
+
+                    if (File.Exists(checkPath))
+                    {
+                        continue;
+                    }
+                }
+
+                ExportSprite(sprite, path, updateSourcePath);
+            }
+
+            if (recurse)
+            {
+                foreach (SpriteFolder subFolder in folder.SubFolders)
+                {
+                    ExportSprites(subFolder, path, recurse, skipValidSourcePath, updateSourcePath);
+                }
+            }
+        }
+
+        public static void ExportSprites(string path, bool recurse, bool skipValidSourcePath, bool updateSourcePath)
+        {
+            SpriteFolder folder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
+            ExportSprites(folder, path, recurse, skipValidSourcePath, updateSourcePath);
         }
     }
 }


### PR DESCRIPTION
Possible solution to #542, where sprite properties can be used as tokens in the export path. This adds a sprite dialog option, where you can edit the tokens, skip sprites that have an existing source file, and rewrite the source file to use the exported file.

The tokens would probably need to be listed somewhere, but they are just the property names with '%' at either end, case-insensitive. So '%NUMBER%', '%number%', and '%NuMbEr%' would resolve to the sprite number, for example.