### PR TITLE
Made calling RunScriptFunction* safer

### DIFF
--- a/Common/script/cc_error.h
+++ b/Common/script/cc_error.h
@@ -20,14 +20,15 @@
 #define __CC_ERROR_H
 
 #include "script/cc_script.h"
+#include "util/string.h"
 
 extern void cc_error(const char *, ...);
 
 // error reporting
 extern int ccError;             // set to non-zero if error occurs
 extern int ccErrorLine;         // line number of the error
-extern char ccErrorString[400]; // description of the error
-extern char ccErrorCallStack[400];
+extern AGS::Common::String ccErrorString; // description of the error
+extern AGS::Common::String ccErrorCallStack; // callstack where error happened
 extern bool ccErrorIsUserError;
 extern const char *ccCurScriptName; // name of currently compiling script
 

--- a/Editor/Native/script_agsnative.cpp
+++ b/Editor/Native/script_agsnative.cpp
@@ -2,17 +2,19 @@
 // Implementation for script specific to AGS.Native library
 //
 
-#include <stdio.h>
-#include "script/cc_error.h"
+#include <utility>
+#include "util/string.h"
+
+using namespace AGS::Common;
 
 extern int currentline; // in script/script_common
 
-void cc_error_at_line(char *buffer, const char *error_msg)
+std::pair<String, String> cc_error_at_line(const char *error_msg)
 {
-    sprintf(ccErrorString, "Error (line %d): %s", currentline, error_msg);
+    return std::make_pair(String::FromFormat("Error (line %d): %s", currentline, error_msg), String());
 }
 
-void cc_error_without_line(char *buffer, const char *error_msg)
+String cc_error_without_line(const char *error_msg)
 {
-    sprintf(ccErrorString, "Error (line unknown): %s", error_msg);
+    return String::FromFormat("Error (line unknown): %s", error_msg);
 }

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -195,7 +195,7 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
   {
     char funcName[100];
     sprintf(funcName, "_run_dialog%d", dialogID);
-    dialogScriptsInst->RunTextScriptIParam(funcName, RuntimeScriptValue().SetInt32(optionIndex));
+    RunTextScriptIParam(dialogScriptsInst, funcName, RuntimeScriptValue().SetInt32(optionIndex));
     result = dialogScriptsInst->returnValue;
   }
   else

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -75,7 +75,7 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
     int toret;
 
     if (includeRoom) {
-        toret = roominst->RunScriptFunctionIfExists(tsname, numParams, params);
+        toret = RunScriptFunctionIfExists(roominst, tsname, numParams, params);
 
         if (eventClaimed == EVENT_CLAIMED) {
             eventClaimed = eventClaimedOldValue;
@@ -85,7 +85,7 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
 
     // run script modules
     for (int kk = 0; kk < numScriptModules; kk++) {
-        toret = moduleInst[kk]->RunScriptFunctionIfExists(tsname, numParams, params);
+        toret = RunScriptFunctionIfExists(moduleInst[kk], tsname, numParams, params);
 
         if (eventClaimed == EVENT_CLAIMED) {
             eventClaimed = eventClaimedOldValue;

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -74,7 +74,7 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
     eventClaimed = EVENT_INPROGRESS;
     int toret;
 
-    if (includeRoom) {
+    if (includeRoom && roominst) {
         toret = RunScriptFunctionIfExists(roominst, tsname, numParams, params);
 
         if (eventClaimed == EVENT_CLAIMED) {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1713,7 +1713,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     if (ccUnserializeAllObjects(in, &ccUnserializer))
     {
         return new SavegameError(kSvgErr_GameObjectInitFailed,
-            String::FromFormat("Managed pool deserialization failed: %s.", ccErrorString));
+            String::FromFormat("Managed pool deserialization failed: %s.", ccErrorString.GetCStr()));
     }
 
     // preserve legacy music type setting

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -54,6 +54,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
+#include "script/cc_error.h"
 #include "script/script.h"
 #include "script/script_runtime.h"
 #include "ac/spritecache.h"
@@ -98,8 +99,6 @@ extern int in_leaves_screen;
 extern CharacterInfo*playerchar;
 extern int starting_room;
 extern unsigned int loopcounter,lastcounter;
-extern int ccError;
-extern char ccErrorString[400];
 extern IDriverDependantBitmap* roomBackgroundBmp;
 extern IGraphicsDriver *gfxDriver;
 extern Bitmap *raw_saved_screen;
@@ -1013,12 +1012,12 @@ void compile_room_script() {
     roominst = ccInstance::CreateFromScript(thisroom.compiled_script);
 
     if ((ccError!=0) || (roominst==NULL)) {
-        quitprintf("Unable to create local script: %s", ccErrorString);
+        quitprintf("Unable to create local script: %s", ccErrorString.GetCStr());
     }
 
     roominstFork = roominst->Fork();
     if (roominstFork == NULL)
-        quitprintf("Unable to create forked room instance: %s", ccErrorString);
+        quitprintf("Unable to create forked room instance: %s", ccErrorString.GetCStr());
 
     repExecAlways.roomHasFunction = true;
     lateRepExecAlways.roomHasFunction = true;

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -220,13 +220,15 @@ void debug_script_log(const char *msg, ...)
 }
 
 
-const char *get_cur_script(int numberOfLinesOfCallStack) {
-    ccInstance::GetCurrentInstance()->GetCallStack(pexbuf, numberOfLinesOfCallStack);
-
-    if (pexbuf[0] == 0)
-        strcpy(pexbuf, ccErrorCallStack);
-
-    return &pexbuf[0];
+String get_cur_script(int numberOfLinesOfCallStack)
+{
+    String callstack;
+    ccInstance *sci = ccInstance::GetCurrentInstance();
+    if (sci)
+        callstack = sci->GetCallStack(numberOfLinesOfCallStack);
+    if (callstack.IsEmpty())
+        callstack = ccErrorCallStack;
+    return callstack;
 }
 
 bool get_script_position(ScriptPosition &script_pos)
@@ -451,8 +453,7 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
 
     if (pluginsWantingDebugHooks > 0) {
         // a plugin is handling the debugging
-        char scname[40];
-        ccinst->GetScriptName(scname);
+        String scname = GetScriptName(ccinst);
         pl_run_plugin_debug_hooks(scname, linenum);
         return;
     }

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -16,6 +16,7 @@
 #define __AC_DEBUGGER_H
 
 #include "debug/agseditordebugger.h"
+#include "util/string.h"
 
 struct ScriptPosition;
 
@@ -28,7 +29,8 @@ extern int break_on_next_script_step;
 int check_for_messages_from_editor();
 bool send_message_to_editor(const char *msg);
 bool send_exception_to_editor(const char *qmsg);
-const char *get_cur_script(int numberOfLinesOfCallStack);
+// Returns current script's location and callstack
+AGS::Common::String get_cur_script(int numberOfLinesOfCallStack);
 bool get_script_position(ScriptPosition &script_pos);
 void check_debug_keys();
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -455,7 +455,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     if (create_global_script())
     {
         return new SavegameError(kSvgErr_GameObjectInitFailed,
-            String::FromFormat("Unable to recreate global script: %s", ccErrorString));
+            String::FromFormat("Unable to recreate global script: %s", ccErrorString.GetCStr()));
     }
 
     // read the global data into the newly created script

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -935,7 +935,7 @@ HSaveError ReadManagedPool(PStream in, int32_t cmp_ver, const PreservedParams &p
     if (ccUnserializeAllObjects(in.get(), &ccUnserializer))
     {
         return new SavegameError(kSvgErr_GameObjectInitFailed,
-            String::FromFormat("Managed pool deserialization failed: %s", ccErrorString));
+            String::FromFormat("Managed pool deserialization failed: %s", ccErrorString.GetCStr()));
     }
     return HSaveError::None();
 }

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -104,9 +104,9 @@ void start_game() {
     our_eip = -42;
 
     for (int kk = 0; kk < numScriptModules; kk++)
-        moduleInst[kk]->RunTextScript("game_start");
+        RunTextScript(moduleInst[kk], "game_start");
 
-    gameinst->RunTextScript("game_start");
+    RunTextScript(gameinst, "game_start");
 
     our_eip = -43;
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -614,7 +614,7 @@ int IAGSEngine::CallGameScriptFunction(const char *name, int32 globalScript, int
     params[0].SetPluginArgument(arg1);
     params[1].SetPluginArgument(arg2);
     params[2].SetPluginArgument(arg3);
-    int toret = toRun->RunScriptFunctionIfExists((char*)name, numArgs, params);
+    int toret = RunScriptFunctionIfExists(toRun, (char*)name, numArgs, params);
     return toret;
 }
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -14,8 +14,6 @@
 
 #include <string.h>
 #include "ac/common.h"
-#include "ac/event.h"
-#include "ac/mouse.h"
 #include "ac/roomstruct.h"
 #include "ac/dynobj/cc_dynamicarray.h"
 #include "ac/dynobj/managedobjectpool.h"
@@ -25,7 +23,6 @@
 #include "debug/debug_log.h"
 #include "debug/out.h"
 #include "script/cc_options.h"
-#include "script/executingscript.h"
 #include "script/script.h"
 #include "script/script_runtime.h"
 #include "script/systemimports.h"
@@ -392,72 +389,6 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
         return -5;
     }
     return ccError;
-}
-
-bool ccInstance::DoRunScriptFuncCantBlock(NonBlockingScriptFunction* funcToRun, bool hasTheFunc) {
-    if (!hasTheFunc)
-        return(false);
-
-    no_blocking_functions++;
-    int result = 0;
-
-    if (funcToRun->numParameters < 3)
-    {
-        result = CallScriptFunction((char*)funcToRun->functionName, funcToRun->numParameters, funcToRun->params);
-    }
-    else
-        quit("DoRunScriptFuncCantBlock called with too many parameters");
-
-    if (result == -2) {
-        // the function doens't exist, so don't try and run it again
-        hasTheFunc = false;
-    }
-    else if ((result != 0) && (result != 100)) {
-        quit_with_script_error(funcToRun->functionName);
-    }
-    else
-    {
-        funcToRun->atLeastOneImplementationExists = true;
-    }
-    // this might be nested, so don't disrupt blocked scripts
-    ccErrorString[0] = 0;
-    ccError = 0;
-    no_blocking_functions--;
-    return(hasTheFunc);
-}
-
-char scfunctionname[MAX_FUNCTION_NAME_LEN+1];
-int ccInstance::PrepareTextScript(const char**tsname) {
-    ccError=0;
-    if (this==NULL) return -1;
-    if (GetSymbolAddress(tsname[0]).IsNull()) {
-        strcpy (ccErrorString, "no such function in script");
-        return -2;
-    }
-    if (pc!=0) {
-        strcpy(ccErrorString,"script is already in execution");
-        return -3;
-    }
-    scripts[num_scripts].init();
-    scripts[num_scripts].inst = this;
-    if (pc != 0) {
-        scripts[num_scripts].inst = Fork();
-        if (scripts[num_scripts].inst == NULL)
-            quit("unable to fork instance for secondary script");
-        scripts[num_scripts].forked = 1;
-    }
-    curscript = &scripts[num_scripts];
-    num_scripts++;
-    if (num_scripts >= MAX_SCRIPT_AT_ONCE)
-        quit("too many nested text script instances created");
-    // in case script_run_another is the function name, take a backup
-    strncpy(scfunctionname,tsname[0],MAX_FUNCTION_NAME_LEN);
-    tsname[0]=&scfunctionname[0];
-    update_script_mouse_coords();
-    inside_script++;
-    //  aborted_ip=0;
-    //  abort_executor=0;
-    return 0;
 }
 
 // Macros to maintain the call stack
@@ -1375,120 +1306,6 @@ int ccInstance::Run(int32_t curpc)
     }
 }
 
-int ccInstance::RunScriptFunctionIfExists(const char*tsname, int numParam, const RuntimeScriptValue *params) {
-    int oldRestoreCount = gameHasBeenRestored;
-    // First, save the current ccError state
-    // This is necessary because we might be attempting
-    // to run Script B, while Script A is still running in the
-    // background.
-    // If CallInstance here has an error, it would otherwise
-    // also abort Script A because ccError is a global variable.
-    int cachedCcError = ccError;
-    ccError = 0;
-
-    int toret = PrepareTextScript(&tsname);
-    if (toret) {
-        ccError = cachedCcError;
-        return -18;
-    }
-
-    // Clear the error message
-    ccErrorString[0] = 0;
-
-    if (numParam < 3)
-    {
-        toret = curscript->inst->CallScriptFunction(tsname,numParam, params);
-    }
-    else
-        quit("Too many parameters to RunScriptFunctionIfExists");
-
-    // 100 is if Aborted (eg. because we are LoadAGSGame'ing)
-    if ((toret != 0) && (toret != -2) && (toret != 100)) {
-        quit_with_script_error(tsname);
-    }
-
-    post_script_cleanup_stack++;
-
-    if (post_script_cleanup_stack > 50)
-        quitprintf("!post_script_cleanup call stack exceeded: possible recursive function call? running %s", tsname);
-
-    post_script_cleanup();
-
-    post_script_cleanup_stack--;
-
-    // restore cached error state
-    ccError = cachedCcError;
-
-    // if the game has been restored, ensure that any further scripts are not run
-    if ((oldRestoreCount != gameHasBeenRestored) && (eventClaimed == EVENT_INPROGRESS))
-        eventClaimed = EVENT_CLAIMED;
-
-    return toret;
-}
-
-int ccInstance::RunTextScript(const char *tsname) {
-    if (strcmp(tsname, REP_EXEC_NAME) == 0) {
-        // run module rep_execs
-        int room_changes_was = play.room_changes;
-        int restore_game_count_was = gameHasBeenRestored;
-
-        for (int kk = 0; kk < numScriptModules; kk++) {
-            if (!moduleRepExecAddr[kk].IsNull())
-                moduleInst[kk]->RunScriptFunctionIfExists(tsname, 0, NULL);
-
-            if ((room_changes_was != play.room_changes) ||
-                (restore_game_count_was != gameHasBeenRestored))
-                return 0;
-        }
-    }
-
-    int toret = RunScriptFunctionIfExists(tsname, 0, NULL);
-    if ((toret == -18) && (this == roominst)) {
-        // functions in room script must exist
-        quitprintf("prepare_script: error %d (%s) trying to run '%s'   (Room %d)",toret,ccErrorString,tsname, displayed_room);
-    }
-    return toret;
-}
-
-int ccInstance::RunTextScriptIParam(const char *tsname, const RuntimeScriptValue &iparam) {
-    if ((strcmp(tsname, "on_key_press") == 0) || (strcmp(tsname, "on_mouse_click") == 0)) {
-        bool eventWasClaimed;
-        int toret = run_claimable_event(tsname, true, 1, &iparam, &eventWasClaimed);
-
-        if (eventWasClaimed)
-            return toret;
-    }
-
-    return RunScriptFunctionIfExists(tsname, 1, &iparam);
-}
-
-int ccInstance::RunTextScript2IParam(const char*tsname, const RuntimeScriptValue &iparam, const RuntimeScriptValue &param2) {
-    RuntimeScriptValue params[2];
-    params[0] = iparam;
-    params[1] = param2;
-
-    if (strcmp(tsname, "on_event") == 0) {
-        bool eventWasClaimed;
-        int toret = run_claimable_event(tsname, true, 2, params, &eventWasClaimed);
-
-        if (eventWasClaimed)
-            return toret;
-    }
-
-    // response to a button click, better update guis
-    if (strnicmp(tsname, "interface_click", 15) == 0)
-        guis_need_update = 1;
-
-    int toret = RunScriptFunctionIfExists(tsname, 2, params);
-
-    // tsname is no longer valid, because RunScriptFunctionIfExists might
-    // have restored a save game and freed the memory. Therefore don't 
-    // attempt any strcmp's here
-    tsname = NULL;
-
-    return toret;
-}
-
 void ccInstance::GetCallStack(char *buffer, int maxLines) {
 
     // FIXME: check ptr prior to function call instead
@@ -1583,6 +1400,11 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
     }
     writer.WriteLineBreak();
     // the writer will delete data stream internally
+}
+
+bool ccInstance::IsBeingRun() const
+{
+    return pc != 0;
 }
 
 bool ccInstance::_Create(PScript scri, ccInstance * joined)

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -155,30 +155,27 @@ public:
 
     ccInstance();
     ~ccInstance();
-    // create a runnable instance of the same script, sharing global memory
+    // Create a runnable instance of the same script, sharing global memory
     ccInstance *Fork();
-    // specifies that when the current function returns to the script, it
+    // Specifies that when the current function returns to the script, it
     // will stop and return from CallInstance
     void    Abort();
-    // aborts instance, then frees the memory later when it is done with
+    // Aborts instance, then frees the memory later when it is done with
     void    AbortAndDestroy();
     
-    // call an exported function in the script (2nd arg is number of params)
+    // Call an exported function in the script
     int     CallScriptFunction(const char *funcname, int32_t num_params, const RuntimeScriptValue *params);
-    bool    DoRunScriptFuncCantBlock(NonBlockingScriptFunction* funcToRun, bool hasTheFunc);
-    int     PrepareTextScript(const char **tsname);
+    // Begin executing script starting from the given bytecode index
     int     Run(int32_t curpc);
-    int     RunScriptFunctionIfExists(const char *tsname, int numParam, const RuntimeScriptValue *params);
-    int     RunTextScript(const char *tsname);
-    int     RunTextScriptIParam(const char *tsname, const RuntimeScriptValue &iparam);
-    int     RunTextScript2IParam(const char *tsname, const RuntimeScriptValue &iparam, const RuntimeScriptValue &param2);
     
     void    GetCallStack(char *buffer, int maxLines);
     void    GetScriptName(char *curScrName);
     void    GetScriptPosition(ScriptPosition &script_pos);
-    // get the address of an exported variable in the script
+    // Get the address of an exported symbol (function or variable) in the script
     RuntimeScriptValue GetSymbolAddress(const char *symname);
     void    DumpInstruction(const ScriptOperation &op);
+    // Tells whether this instance is in the process of executing the byte-code
+    bool    IsBeingRun() const;
 
 protected:
     bool    _Create(PScript scri, ccInstance * joined);

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -168,8 +168,9 @@ public:
     // Begin executing script starting from the given bytecode index
     int     Run(int32_t curpc);
     
-    void    GetCallStack(char *buffer, int maxLines);
-    void    GetScriptName(char *curScrName);
+    // Get the script's execution position and callstack as human-readable text
+    Common::String GetCallStack(int maxLines);
+    // Get the script's execution position
     void    GetScriptPosition(ScriptPosition &script_pos);
     // Get the address of an exported symbol (function or variable) in the script
     RuntimeScriptValue GetSymbolAddress(const char *symname);

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -339,7 +339,7 @@ bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcTo
         funcToRun->atLeastOneImplementationExists = true;
     }
     // this might be nested, so don't disrupt blocked scripts
-    ccErrorString[0] = 0;
+    ccErrorString = "";
     ccError = 0;
     no_blocking_functions--;
     return(hasTheFunc);
@@ -352,11 +352,11 @@ int PrepareTextScript(ccInstance *sci, const char**tsname)
     // FIXME: try to make it so this function is not called with NULL sci
     if (sci == NULL) return -1;
     if (sci->GetSymbolAddress(tsname[0]).IsNull()) {
-        strcpy(ccErrorString, "no such function in script");
+        ccErrorString = "no such function in script";
         return -2;
     }
     if (sci->IsBeingRun()) {
-        strcpy(ccErrorString, "script is already in execution");
+        ccErrorString = "script is already in execution";
         return -3;
     }
     scripts[num_scripts].init();
@@ -402,7 +402,7 @@ int RunScriptFunctionIfExists(ccInstance *sci, const char*tsname, int numParam, 
     }
 
     // Clear the error message
-    ccErrorString[0] = 0;
+    ccErrorString = "";
 
     if (numParam < 3)
     {
@@ -457,7 +457,7 @@ int RunTextScript(ccInstance *sci, const char *tsname)
     int toret = RunScriptFunctionIfExists(sci, tsname, 0, NULL);
     if ((toret == -18) && (sci == roominst)) {
         // functions in room script must exist
-        quitprintf("prepare_script: error %d (%s) trying to run '%s'   (Room %d)", toret, ccErrorString, tsname, displayed_room);
+        quitprintf("prepare_script: error %d (%s) trying to run '%s'   (Room %d)", toret, ccErrorString.GetCStr(), tsname, displayed_room);
     }
     return toret;
 }
@@ -501,6 +501,19 @@ int RunTextScript2IParam(ccInstance *sci, const char*tsname, const RuntimeScript
     tsname = NULL;
 
     return toret;
+}
+
+String GetScriptName(ccInstance *sci)
+{
+    // TODO: have script name a ccScript's member?
+    // TODO: check script modules too?
+    if (!sci)
+        return "Not in a script";
+    else if (sci->instanceof == gamescript)
+        return "Global script";
+    else if (sci->instanceof == thisroom.compiled_script)
+        return String::FromFormat("Room %d script", displayed_room);
+    return "Unknown script";
 }
 
 //=============================================================================
@@ -605,7 +618,7 @@ void post_script_cleanup() {
 
 void quit_with_script_error(const char *functionName)
 {
-    quitprintf("%sError running function '%s':\n%s", (ccErrorIsUserError ? "!" : ""), functionName, ccErrorString);
+    quitprintf("%sError running function '%s':\n%s", (ccErrorIsUserError ? "!" : ""), functionName, ccErrorString.GetCStr());
 }
 
 int get_nivalue (InteractionCommandList *nic, int idx, int parm) {

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -93,7 +93,7 @@ std::vector<String> guiScriptObjNames;
 
 int run_dialog_request (int parmtr) {
     play.stop_dialog_at_end = DIALOG_RUNNING;
-    gameinst->RunTextScriptIParam("dialog_request", RuntimeScriptValue().SetInt32(parmtr));
+    RunTextScriptIParam(gameinst, "dialog_request", RuntimeScriptValue().SetInt32(parmtr));
 
     if (play.stop_dialog_at_end == DIALOG_STOP) {
         play.stop_dialog_at_end = DIALOG_NONE;
@@ -124,18 +124,18 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
     // run modules
     // modules need a forkedinst for this to work
     for (int kk = 0; kk < numScriptModules; kk++) {
-        funcToRun->moduleHasFunction[kk] = moduleInstFork[kk]->DoRunScriptFuncCantBlock(funcToRun, funcToRun->moduleHasFunction[kk]);
+        funcToRun->moduleHasFunction[kk] = DoRunScriptFuncCantBlock(moduleInstFork[kk], funcToRun, funcToRun->moduleHasFunction[kk]);
 
         if (room_changes_was != play.room_changes)
             return;
     }
 
-    funcToRun->globalScriptHasFunction = gameinstFork->DoRunScriptFuncCantBlock(funcToRun, funcToRun->globalScriptHasFunction);
+    funcToRun->globalScriptHasFunction = DoRunScriptFuncCantBlock(gameinstFork, funcToRun, funcToRun->globalScriptHasFunction);
 
     if (room_changes_was != play.room_changes)
         return;
 
-    funcToRun->roomHasFunction = roominstFork->DoRunScriptFuncCantBlock(funcToRun, funcToRun->roomHasFunction);
+    funcToRun->roomHasFunction = DoRunScriptFuncCantBlock(roominstFork, funcToRun, funcToRun->roomHasFunction);
 }
 
 //-----------------------------------------------------------
@@ -300,16 +300,207 @@ void QueueScriptFunction(ScriptInstType sc_inst, const char *fn_name, size_t par
 
 void RunScriptFunction(ScriptInstType sc_inst, const char *fn_name, size_t param_count, const RuntimeScriptValue &p1, const RuntimeScriptValue &p2)
 {
-    ccInstance *inst = GetScriptInstanceByType(sc_inst);
-    if (inst)
+    ccInstance *sci = GetScriptInstanceByType(sc_inst);
+    if (sci)
     {
         if (param_count == 2)
-            inst->RunTextScript2IParam(fn_name, p1, p2);
+            RunTextScript2IParam(sci, fn_name, p1, p2);
         else if (param_count == 1)
-            inst->RunTextScriptIParam(fn_name, p1);
+            RunTextScriptIParam(sci, fn_name, p1);
         else if (param_count == 0)
-            inst->RunTextScript(fn_name);
+            RunTextScript(sci, fn_name);
     }
+}
+
+bool DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc)
+{
+    if (!hasTheFunc)
+        return(false);
+
+    no_blocking_functions++;
+    int result = 0;
+
+    if (funcToRun->numParameters < 3)
+    {
+        result = sci->CallScriptFunction((char*)funcToRun->functionName, funcToRun->numParameters, funcToRun->params);
+    }
+    else
+        quit("DoRunScriptFuncCantBlock called with too many parameters");
+
+    if (result == -2) {
+        // the function doens't exist, so don't try and run it again
+        hasTheFunc = false;
+    }
+    else if ((result != 0) && (result != 100)) {
+        quit_with_script_error(funcToRun->functionName);
+    }
+    else
+    {
+        funcToRun->atLeastOneImplementationExists = true;
+    }
+    // this might be nested, so don't disrupt blocked scripts
+    ccErrorString[0] = 0;
+    ccError = 0;
+    no_blocking_functions--;
+    return(hasTheFunc);
+}
+
+char scfunctionname[MAX_FUNCTION_NAME_LEN + 1];
+int PrepareTextScript(ccInstance *sci, const char**tsname)
+{
+    ccError = 0;
+    // FIXME: try to make it so this function is not called with NULL sci
+    if (sci == NULL) return -1;
+    if (sci->GetSymbolAddress(tsname[0]).IsNull()) {
+        strcpy(ccErrorString, "no such function in script");
+        return -2;
+    }
+    if (sci->IsBeingRun()) {
+        strcpy(ccErrorString, "script is already in execution");
+        return -3;
+    }
+    scripts[num_scripts].init();
+    scripts[num_scripts].inst = sci;
+    // CHECKME: this conditional block will never run, because
+    // function would have quit earlier (deprecated functionality?)
+    if (sci->IsBeingRun()) {
+        scripts[num_scripts].inst = sci->Fork();
+        if (scripts[num_scripts].inst == NULL)
+            quit("unable to fork instance for secondary script");
+        scripts[num_scripts].forked = 1;
+    }
+    curscript = &scripts[num_scripts];
+    num_scripts++;
+    if (num_scripts >= MAX_SCRIPT_AT_ONCE)
+        quit("too many nested text script instances created");
+    // in case script_run_another is the function name, take a backup
+    strncpy(scfunctionname, tsname[0], MAX_FUNCTION_NAME_LEN);
+    tsname[0] = &scfunctionname[0];
+    update_script_mouse_coords();
+    inside_script++;
+    //  aborted_ip=0;
+    //  abort_executor=0;
+    return 0;
+}
+
+int RunScriptFunctionIfExists(ccInstance *sci, const char*tsname, int numParam, const RuntimeScriptValue *params)
+{
+    int oldRestoreCount = gameHasBeenRestored;
+    // First, save the current ccError state
+    // This is necessary because we might be attempting
+    // to run Script B, while Script A is still running in the
+    // background.
+    // If CallInstance here has an error, it would otherwise
+    // also abort Script A because ccError is a global variable.
+    int cachedCcError = ccError;
+    ccError = 0;
+
+    int toret = PrepareTextScript(sci, &tsname);
+    if (toret) {
+        ccError = cachedCcError;
+        return -18;
+    }
+
+    // Clear the error message
+    ccErrorString[0] = 0;
+
+    if (numParam < 3)
+    {
+        toret = curscript->inst->CallScriptFunction(tsname, numParam, params);
+    }
+    else
+        quit("Too many parameters to RunScriptFunctionIfExists");
+
+    // 100 is if Aborted (eg. because we are LoadAGSGame'ing)
+    if ((toret != 0) && (toret != -2) && (toret != 100)) {
+        quit_with_script_error(tsname);
+    }
+
+    post_script_cleanup_stack++;
+
+    if (post_script_cleanup_stack > 50)
+        quitprintf("!post_script_cleanup call stack exceeded: possible recursive function call? running %s", tsname);
+
+    post_script_cleanup();
+
+    post_script_cleanup_stack--;
+
+    // restore cached error state
+    ccError = cachedCcError;
+
+    // if the game has been restored, ensure that any further scripts are not run
+    if ((oldRestoreCount != gameHasBeenRestored) && (eventClaimed == EVENT_INPROGRESS))
+        eventClaimed = EVENT_CLAIMED;
+
+    return toret;
+}
+
+int RunTextScript(ccInstance *sci, const char *tsname)
+{
+    if (strcmp(tsname, REP_EXEC_NAME) == 0) {
+        // run module rep_execs
+        // FIXME: in theory the function may be already called for moduleInst[i],
+        // in which case this should not be executed; need to rearrange the code somehow
+        int room_changes_was = play.room_changes;
+        int restore_game_count_was = gameHasBeenRestored;
+
+        for (int kk = 0; kk < numScriptModules; kk++) {
+            if (!moduleRepExecAddr[kk].IsNull())
+                RunScriptFunctionIfExists(moduleInst[kk], tsname, 0, NULL);
+
+            if ((room_changes_was != play.room_changes) ||
+                (restore_game_count_was != gameHasBeenRestored))
+                return 0;
+        }
+    }
+
+    int toret = RunScriptFunctionIfExists(sci, tsname, 0, NULL);
+    if ((toret == -18) && (sci == roominst)) {
+        // functions in room script must exist
+        quitprintf("prepare_script: error %d (%s) trying to run '%s'   (Room %d)", toret, ccErrorString, tsname, displayed_room);
+    }
+    return toret;
+}
+
+int RunTextScriptIParam(ccInstance *sci, const char *tsname, const RuntimeScriptValue &iparam)
+{
+    if ((strcmp(tsname, "on_key_press") == 0) || (strcmp(tsname, "on_mouse_click") == 0)) {
+        bool eventWasClaimed;
+        int toret = run_claimable_event(tsname, true, 1, &iparam, &eventWasClaimed);
+
+        if (eventWasClaimed)
+            return toret;
+    }
+
+    return RunScriptFunctionIfExists(sci, tsname, 1, &iparam);
+}
+
+int RunTextScript2IParam(ccInstance *sci, const char*tsname, const RuntimeScriptValue &iparam, const RuntimeScriptValue &param2)
+{
+    RuntimeScriptValue params[2];
+    params[0] = iparam;
+    params[1] = param2;
+
+    if (strcmp(tsname, "on_event") == 0) {
+        bool eventWasClaimed;
+        int toret = run_claimable_event(tsname, true, 2, params, &eventWasClaimed);
+
+        if (eventWasClaimed)
+            return toret;
+    }
+
+    // response to a button click, better update guis
+    if (strnicmp(tsname, "interface_click", 15) == 0)
+        guis_need_update = 1;
+
+    int toret = RunScriptFunctionIfExists(sci, tsname, 2, params);
+
+    // tsname is no longer valid, because RunScriptFunctionIfExists might
+    // have restored a save game and freed the memory. Therefore don't 
+    // attempt any strcmp's here
+    tsname = NULL;
+
+    return toret;
 }
 
 //=============================================================================

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -50,6 +50,14 @@ void    QueueScriptFunction(ScriptInstType sc_inst, const char *fn_name, size_t 
 void    RunScriptFunction(ScriptInstType sc_inst, const char *fn_name, size_t param_count = 0,
                           const RuntimeScriptValue &p1 = RuntimeScriptValue(), const RuntimeScriptValue &p2 = RuntimeScriptValue());
 
+int     RunScriptFunctionIfExists(ccInstance *sci, const char *tsname, int numParam, const RuntimeScriptValue *params);
+int     RunTextScript(ccInstance *sci, const char *tsname);
+int     RunTextScriptIParam(ccInstance *sci, const char *tsname, const RuntimeScriptValue &iparam);
+int     RunTextScript2IParam(ccInstance *sci, const char *tsname, const RuntimeScriptValue &iparam, const RuntimeScriptValue &param2);
+
+int     PrepareTextScript(ccInstance *sci, const char **tsname);
+bool    DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc);
+
 //=============================================================================
 
 char*   make_ts_func_name(char*base,int iii,int subd);
@@ -63,7 +71,6 @@ int     run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun
 InteractionVariable *get_interaction_variable (int varindx);
 InteractionVariable *FindGraphicalVariable(const char *varName);
 void    run_unhandled_event (int evnt);
-void    setup_exports(char*expfrom);
 void    can_run_delayed_command();
 
 

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -25,6 +25,7 @@
 #include "script/nonblockingscriptfunction.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "game/interactions.h"
+#include "util/string.h"
 
 using AGS::Common::Interaction;
 using AGS::Common::InteractionCommandList;
@@ -57,6 +58,8 @@ int     RunTextScript2IParam(ccInstance *sci, const char *tsname, const RuntimeS
 
 int     PrepareTextScript(ccInstance *sci, const char **tsname);
 bool    DoRunScriptFuncCantBlock(ccInstance *sci, NonBlockingScriptFunction* funcToRun, bool hasTheFunc);
+
+AGS::Common::String GetScriptName(ccInstance *sci);
 
 //=============================================================================
 

--- a/Engine/script/script_engine.cpp
+++ b/Engine/script/script_engine.cpp
@@ -36,20 +36,22 @@ char *scripteditruntimecopr = "Script Editor v1.2 run-time component. (c) 1998 C
 extern void quit(const char *);
 extern int currentline; // in script/script_common
 
-void cc_error_at_line(char *buffer, const char *error_msg)
+std::pair<String, String> cc_error_at_line(const char *error_msg)
 {
-    if (ccInstance::GetCurrentInstance() == NULL) {
-        sprintf(ccErrorString, "Error (line %d): %s", currentline, error_msg);
+    ccInstance *sci = ccInstance::GetCurrentInstance();
+    if (!sci)
+    {
+        return std::make_pair(String::FromFormat("Error (line %d): %s", currentline, error_msg), String());
     }
-    else {
-        sprintf(ccErrorString, "Error: %s\n", error_msg);
-        ccInstance::GetCurrentInstance()->GetCallStack(ccErrorCallStack, 5);
+    else
+    {
+        return std::make_pair(String::FromFormat("Error: %s\n", error_msg), ccInstance::GetCurrentInstance()->GetCallStack(5));
     }
 }
 
-void cc_error_without_line(char *buffer, const char *error_msg)
+String cc_error_without_line(const char *error_msg)
 {
-    sprintf(ccErrorString, "Runtime error: %s", error_msg);
+    return String::FromFormat("Runtime error: %s", error_msg);
 }
 
 void save_script_configuration(Stream *out)


### PR DESCRIPTION
Presumably fixes #553.

1. Moved several RunScriptFunction* type of functions out from ccInstance class. They were made its members by mistake during refactoring many years ago. In practice they don't access any of its private data and work with global data too.
2. Refactored ccInstance::GetCallStack() and GetScriptName(), removed weird <pre>if (this == NULL)</pre> checks from them. Instead test ccInstance pointer before calling these functions.
3. Replaced few fixed-sized character buffers with dynamic strings to avoid buffer overrun when reporting script information and errors.
4. By @toojays's suggestion, ammended condition in run_claimable_event() and avoid even trying to run a script function in the room script if it was not loaded yet.