### PR TITLE
Fix path joins with mixed directory seperators

### DIFF
--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -150,6 +150,19 @@ namespace AGS.Editor
             return Uri.UnescapeDataString(currentProjectUri.MakeRelativeUri(currentPathUri).OriginalString);
         }
 
+        public static string ResolveSourcePath(string sourcePath)
+        {
+            Uri baseUri = new Uri(Factory.AGSEditor.CurrentGame.DirectoryPath + Path.DirectorySeparatorChar);
+            Uri absoluteUri;
+
+            if (Uri.TryCreate(baseUri, sourcePath, out absoluteUri))
+            {
+                sourcePath = absoluteUri.LocalPath;
+            }
+
+            return sourcePath;
+        }
+
         /// <summary>
         /// Wraps Directory.GetFiles in a handler to deal with an exception
         /// erroneously being thrown on Linux network shares if no files match.
@@ -433,15 +446,8 @@ namespace AGS.Editor
         /// <returns></returns>
         public static bool HardlinkOrCopy(string destFileName, string sourceFileName, bool overwrite)
         {
-            if (!Path.IsPathRooted(sourceFileName))
-            {
-                sourceFileName = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, sourceFileName);
-            }
-
-            if (!Path.IsPathRooted(destFileName))
-            {
-                destFileName = Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, destFileName);
-            }
+            sourceFileName = ResolveSourcePath(sourceFileName);
+            destFileName = ResolveSourcePath(destFileName);
 
             if (File.Exists(destFileName))
             {


### PR DESCRIPTION
Relative sources are stored as URIs, so using Path.Combine ends up with a mix of forward and backward slashes in the combined path (technically this valid, but in practice it isn't treated so). This switches to using a URI to do the join and then returning Uri.LocalPath, which should return the combined path with correct directory separators.