### PR TITLE
Fix crash when loading invalid image data

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -504,7 +504,18 @@ namespace AGS.Editor
         private void cmbFilenames_SelectedIndexChanged(object sender, EventArgs e)
         {
             string filename = imageLookup[cmbFilenames.SelectedIndex];
-            image = SpriteTools.LoadFirstImageFromFile(filename);
+
+            try
+            {
+                image = SpriteTools.LoadFirstImageFromFile(filename);
+            }
+            catch (Types.InvalidDataException ex)
+            {
+                // use a placeholder in-case of bad data
+                Factory.GUIController.ShowMessage(ex.Message, MessageBoxIconType.Error);
+                image = SpriteTools.GetPlaceHolder();
+            }
+
             PostImageLoad();
         }
 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -829,9 +829,16 @@ namespace AGS.Editor
 
                     SpriteTools.ReplaceSprite(spr, spr.SourceFile, spr.Frame, spr.AlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spritesheet);
                 }
-                catch (InvalidOperationException ex)
+                catch (Exception ex)
                 {
-                    errors.Add(ex.Message);
+                    if (ex is InvalidOperationException || ex is Types.InvalidDataException)
+                    {
+                        errors.Add(ex.Message);
+                    }
+                    else
+                    {
+                        throw;
+                    }
                 }
             }
 

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -27,7 +27,7 @@ namespace AGS.Editor.Utils
             }
             catch
             {
-                throw new Types.InvalidDataException("Unable to load image data");
+                throw new Types.InvalidDataException($"Unable to load image data from '{fileName}'");
             }
             finally
             {
@@ -52,7 +52,7 @@ namespace AGS.Editor.Utils
 
                 if (decoder.Read(fileName) != GifDecoder.STATUS_OK)
                 {
-                    throw new AGS.Types.InvalidDataException("Unable to load GIF");
+                    throw new Types.InvalidDataException($"Unable to load GIF data from '{fileName}'");
                 }
 
                 for (int i = 0; i < decoder.GetFrameCount(); i ++)

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using AGS.Types;
@@ -18,8 +19,20 @@ namespace AGS.Editor.Utils
             // We have to use this stream code because using "new Bitmap(filename)"
             // keeps the file open until the Bitmap is disposed
             FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-            Bitmap loadedBmp = (Bitmap)Bitmap.FromStream(fileStream);
-            fileStream.Close();
+            Bitmap loadedBmp;
+
+            try
+            {
+                loadedBmp = (Bitmap)Bitmap.FromStream(fileStream);
+            }
+            catch
+            {
+                throw new Types.InvalidDataException("Unable to load image data");
+            }
+            finally
+            {
+                fileStream.Close();
+            }
 
             // Unfortunately the Bitmap.Clone method will crash later due to
             // a .NET bug when it's loaded from a stream. Therefore we need
@@ -432,6 +445,74 @@ namespace AGS.Editor.Utils
         {
             SpriteFolder folder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
             ExportSprites(folder, path, recurse, skipValidSourcePath, updateSourcePath);
+        }
+
+        public static Bitmap GetPlaceHolder(int width = 12, int height = 7)
+        {
+            if (width <= 0 || height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("Cannot generate a zero-sized bitmap");
+            }
+
+            // fine art as a byte array
+            byte[][] cup =
+            {
+                new byte[12] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+                new byte[12] { 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 },
+                new byte[12] { 0x00, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x01, 0x01, 0x01, 0x00 },
+                new byte[12] { 0x00, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x01, 0x00, 0x01, 0x00 },
+                new byte[12] { 0x00, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x01, 0x01, 0x01, 0x00 },
+                new byte[12] { 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00 },
+                new byte[12] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+            };
+
+            Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format8bppIndexed);
+            BitmapData bitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
+            long ptr = bitmapData.Scan0.ToInt64();
+            int y = 0;
+
+            for (int row = 0; row < height; row++)
+            {
+                int x = 0;
+                int span = cup[y].Length;
+
+                while (span == cup[y].Length)
+                {
+                    if (x + span >= width)
+                    {
+                        // align with the right edge of the bitmap
+                        span = width - x;
+                    }
+
+                    Marshal.Copy(cup[y], 0, new IntPtr(ptr), span);
+                    x += span;
+                    ptr += span;
+                }
+
+                // align with bitmap stride
+                ptr += bitmapData.Stride - x;
+
+                // next image row
+                if (y == cup.Length - 1)
+                {
+                    y = 0;
+                }
+                else
+                {
+                    y++;
+                }
+            }
+
+            bitmap.UnlockBits(bitmapData);
+
+            // set colours
+            ColorPalette palette = bitmap.Palette;
+            palette.Entries[0] = Color.FromArgb(0, 0, 0);
+            palette.Entries[1] = Color.FromArgb(85, 85, 255);
+            palette.Entries[2] = Color.FromArgb(0, 0, 170);
+            bitmap.Palette = palette;
+
+            return bitmap;
         }
     }
 }


### PR DESCRIPTION
- Throws exception for non-GIF images that fail to load (GIF images already did this)
- Catch failed image load and insert a place-holder sprite in its place (the normal in-game blue cup).

The cup is coming from a place-holder generating function which returns an 8-bit bitmap of any size (defaults to just a single cup), but will tile and clip it to fit any resolution.

`SpriteTool.GetPlaceHolder()`

![cup_12_7](https://user-images.githubusercontent.com/14958747/51057240-e0cc8900-15dc-11e9-827c-37725d056aee.GIF)

`SpriteTool.GetPlaceHolder(91, 157)`

![cup_91_157](https://user-images.githubusercontent.com/14958747/51057334-330daa00-15dd-11e9-96ce-42544d17f606.GIF)

 Long term idea for this was to eventually remove the reliance on having sprite 0 in a new game template (you can call this function to create sprite 0 if it isn't there), and potentially allow people to actively use it for place-holder graphics (probably needs someone to draw a nicer looking and more subtle cup).