### PR TITLE
Disable DRI3 in Linux launch wrapper

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -173,6 +173,10 @@ for arg; do
     fi
 done
 
+## Old versions of Mesa can hang when using DRI3
+## https://bugs.freedesktop.org/show_bug.cgi?id=106404
+export LIBGL_DRI3_DISABLE=true
+
 if [ ""$(uname -m)"" = ""x86_64"" ]; then" + GetSymLinkScriptForEachPlugin(true) +
 @"
 else" + GetSymLinkScriptForEachPlugin(false) +

--- a/debian/ags+libraries/startgame
+++ b/debian/ags+libraries/startgame
@@ -9,6 +9,10 @@ for arg; do
     fi
 done
 
+## Old versions of Mesa can hang when using DRI3
+## https://bugs.freedesktop.org/show_bug.cgi?id=106404
+export LIBGL_DRI3_DISABLE=true
+
 if [ "$(uname -m)" = "x86_64" ]; then
     ALLEGRO_MODULES="$scriptdir/data/lib64" "$scriptdir/data/ags64" "$@" "$scriptdir/data/"
 else


### PR DESCRIPTION
This is set based on the conversation in #510, to follow the merge of the OpenGL changes. The fork is off the master and has a visible merge commit, so I wasn't sure whether someone was just going to cherry pick the existing commits; I didn't want the script change to be forgotten.

Feel free to close if equivalent changes make into the merging branch.