### PR TITLE
prevents NDK_HOME replace if already defined

### DIFF
--- a/Android/buildlibs/makestandalones.sh
+++ b/Android/buildlibs/makestandalones.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Please update NDK_HOME to the path of ndk-bundle in your system
-NDK_HOME=~/Android/Sdk/ndk-bundle
+NDK_HOME="${NDK_HOME:-~/Android/Sdk/ndk-bundle}"
 
 # android-14 is the minimum we can go with current Android SDK
 PLATFORM=android-14


### PR DESCRIPTION
If you follow instruction from README.md under Android, it tells you to define NDK_HOME

https://github.com/adventuregamestudio/ags/blob/master/Android/README.md#native-3rd-party-libraries

>...
>Set NDK_HOME variable, pointing to the location of Android NDK at your system. Change to the /Android/buildlibs directory and run, e.g. assuming the ndk is installed in '/opt/android-ndk-r16b':
>    `$ export NDK_HOME=/opt/android-ndk-r16b`
>    `$ cd <SOURCE>/Android/buildlibs`
>    `$ ./buildall.sh`
>...

But the `Android/buildlibs/makestandalones.sh` will redefine NDK_HOME anyway.

This adds the value as a default value if NDK_HOME is undefined, but keeps any value that is exported previously. [This bash is explained here](https://unix.stackexchange.com/questions/122845/using-a-b-for-variable-assignment-in-scripts/122878).