### PR TITLE
Added an error msg if NDK_HOME is undefined.

### DIFF
--- a/Android/buildlibs/makestandalones.sh
+++ b/Android/buildlibs/makestandalones.sh
@@ -4,8 +4,12 @@
 
 set -e
 
-# Please update NDK_HOME to the path of ndk-bundle in your system
-NDK_HOME=~/Android/Sdk/ndk-bundle
+# Please provide NDK_HOME is set to the path of ndk-bundle in your system
+if [[ -z "$NDK_HOME" ]]; then
+    echo "Please provide NDK_HOME is set to the path of ndk-bundle" 1>&2
+    echo "eg: export NDK_HOME=~/Android/Sdk/ndk-bundle/android-ndk-r16b" 1>&2
+    exit 1
+fi
 
 # android-14 is the minimum we can go with current Android SDK
 PLATFORM=android-14


### PR DESCRIPTION
If you follow instruction from README.md under Android, it tells you to define NDK_HOME

https://github.com/adventuregamestudio/ags/blob/master/Android/README.md#native-3rd-party-libraries

>...
>Set NDK_HOME variable, pointing to the location of Android NDK at your system. Change to the /Android/buildlibs directory and run, e.g. assuming the ndk is installed in '/opt/android-ndk-r16b':
>    `$ export NDK_HOME=/opt/android-ndk-r16b`
>    `$ cd <SOURCE>/Android/buildlibs`
>    `$ ./buildall.sh`
>...

This PR reinforces this by throwing an error message if you don't set NDK_HOME, following #604 .