### PR TITLE
Create .travis.yml for building AGS Engine on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - debhelper
+    - build-essential
+    - pkg-config 
+    - cmake 
+    - libfreetype6-dev 
+    - libogg-dev 
+    - libtheora-dev 
+    - libvorbis-dev
+    - liballegro4-dev
+    - libaldmb1-dev
+    - fakeroot
+script:
+- fakeroot debian/rules binary
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  file: 
+  - ../ags_3~git-1_amd64.deb
+  - ../ags-dbg_3~git-1_amd64.deb
+  on:
+    tags: true


### PR DESCRIPTION
This builds AGS on Linux following the instructions here:

https://github.com/adventuregamestudio/ags/tree/master/debian#building-a-debianubuntu-package-of-ags

Deployed results are upload to Github Releases when a new Release is created.

Requires an user that has TravisCI configured with read and write permissions to this repo and environment variable GITHUB_TOKEN configured for Releases to work.

Build Logs from the PR repo can be seen [on Travis here](https://travis-ci.com/mythsuntold/ags).

It's probably smart to install Allegro [from here](https://github.com/liballeg/allegro5/releases/tag/4.4.3) instead of getting from apt repository - but I didn't do that here.