### PR TITLE
AGS 3: ammendments to custom viewports system

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -74,8 +74,8 @@
 #define OPT_SAFEFILEPATHS   41
 #define OPT_HIGHESTOPTION_335 OPT_SAFEFILEPATHS
 #define OPT_DIALOGOPTIONSAPI 42 // version of dialog options API (-1 for pre-3.4.0 API)
-#define OPT_BASESCRIPTAPI   43 // version of the Script API used to compile game script
-#define OPT_SCRIPTCOMPATLEV 44 // level of API compatibility used to compile game script
+#define OPT_BASESCRIPTAPI   43 // version of the Script API (ScriptAPIVersion) used to compile game script
+#define OPT_SCRIPTCOMPATLEV 44 // level of API compatibility (ScriptAPIVersion) used to compile game script
 #define OPT_RENDERATSCREENRES 45 // use the legacy D3D scaling that scales sprites at the (final) screen resolution
 #define OPT_HIGHESTOPTION   OPT_RENDERATSCREENRES
 #define OPT_NOMODMUSIC      98

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -731,8 +731,16 @@ import void DeleteSaveSlot(int slot);
 import void SetRestartPoint();
 /// Gets what type of thing is in the room at the specified co-ordinates.
 import LocationType GetLocationType(int x, int y);
-/// Returns which walkable area is at the specified position relative to the current viewport.
+#ifdef SCRIPT_COMPAT_v341
+/// Returns which walkable area is at the specified position on screen.
 import int  GetWalkableAreaAt(int screenX, int screenY);
+#endif
+#ifdef SCRIPT_API_v350
+/// Returns which walkable area is at the specified position on screen.
+import int  GetWalkableAreaAtScreen(int screenX, int screenY);
+/// Returns which walkable area is at the specified position within the room.
+import int  GetWalkableAreaAtRoom(int roomX, int roomY);
+#endif
 /// Returns the scaling level at the specified position within the room.
 import int  GetScalingAt (int x, int y);
 #ifndef STRICT_IN_v340
@@ -1843,11 +1851,15 @@ builtin managed struct Hotspot {
   /// Sets a text custom property for this hotspot.
   import bool SetTextProperty(const string property, const string value);
 #endif
+#ifdef SCRIPT_API_v350
+  /// Returns the hotspot at the specified position within this room.
+  import static Hotspot* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
+#endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
 builtin managed struct Region {
-  /// Gets the region at the specified location within this room.
+  /// Returns the region at the specified position within this room.
   import static Region* GetAtRoomXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
   /// Runs the event handler for the specified event for this region.
   import void RunInteraction(int event);
@@ -1871,6 +1883,10 @@ builtin managed struct Region {
   readonly import attribute int  TintSaturation;
   /// Gets the Luminance of this region's colour tint.
   readonly import attribute int  TintLuminance;
+#ifdef SCRIPT_API_v350
+  /// Returns the region at the specified position on the screen.
+  import static Region* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
@@ -2219,6 +2235,10 @@ builtin managed struct Object {
   /// Gets the Luminance of this object's colour tint.
   readonly import attribute int  TintLuminance;
 #endif
+#ifdef SCRIPT_API_v350
+  /// Returns the object at the specified position within this room.
+  import static Object* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
+#endif
 
   int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
@@ -2459,6 +2479,10 @@ builtin managed struct Character {
   readonly import attribute int  TintSaturation;
   /// Gets the Luminance of this character's colour tint.
   readonly import attribute int  TintLuminance;
+#endif
+#ifdef SCRIPT_API_v350
+  /// Returns the character at the specified position within this room.
+  import static Character* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
 #endif
 #ifdef STRICT
   /// The character's current X-position.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -825,7 +825,7 @@ void Character_SetAsPlayer(CharacterInfo *chaa) {
     if (displayed_room != playerchar->room)
         NewRoom(playerchar->room);
     else   // make sure it doesn't run the region interactions
-        play.player_on_region = GetRegionAt (playerchar->x, playerchar->y);
+        play.player_on_region = GetRegionIDAtRoom(playerchar->x, playerchar->y);
 
     if ((playerchar->activeinv >= 0) && (playerchar->inv[playerchar->activeinv] < 1))
         playerchar->activeinv = -1;
@@ -2198,8 +2198,8 @@ Bitmap *GetCharacterImage(int charid, int *isFlipped)
     return spriteset[sppic];
 }
 
-CharacterInfo *GetCharacterAtLocation(int xx, int yy) {
-    int hsnum = GetCharacterAt(xx, yy);
+CharacterInfo *GetCharacterAtScreen(int xx, int yy) {
+    int hsnum = GetCharIDAtScreen(xx, yy);
     if (hsnum < 0)
         return NULL;
     return &game.chars[hsnum];
@@ -3270,9 +3270,9 @@ RuntimeScriptValue Sc_Character_WalkStraight(void *self, const RuntimeScriptValu
 }
 
 // CharacterInfo *(int xx, int yy)
-RuntimeScriptValue Sc_GetCharacterAtLocation(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetCharacterAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(CharacterInfo, ccDynamicCharacter, GetCharacterAtLocation);
+    API_SCALL_OBJ_PINT2(CharacterInfo, ccDynamicCharacter, GetCharacterAtScreen);
 }
 
 // ScriptInvItem* (CharacterInfo *chaa)
@@ -3837,7 +3837,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
 	ccAddExternalObjectFunction("Character::Walk^4",                    Sc_Character_Walk);
 	ccAddExternalObjectFunction("Character::WalkStraight^3",            Sc_Character_WalkStraight);
 
-	ccAddExternalStaticFunction("Character::GetAtScreenXY^2",           Sc_GetCharacterAtLocation);
+	ccAddExternalStaticFunction("Character::GetAtScreenXY^2",           Sc_GetCharacterAtScreen);
 
 	ccAddExternalObjectFunction("Character::get_ActiveInventory",       Sc_Character_GetActiveInventory);
 	ccAddExternalObjectFunction("Character::set_ActiveInventory",       Sc_Character_SetActiveInventory);
@@ -3992,7 +3992,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     ccAddExternalFunctionForPlugin("Character::UnlockView^1",              (void*)Character_UnlockViewEx);
     ccAddExternalFunctionForPlugin("Character::Walk^4",                    (void*)Character_Walk);
     ccAddExternalFunctionForPlugin("Character::WalkStraight^3",            (void*)Character_WalkStraight);
-    ccAddExternalFunctionForPlugin("Character::GetAtScreenXY^2",           (void*)GetCharacterAtLocation);
+    ccAddExternalFunctionForPlugin("Character::GetAtScreenXY^2",           (void*)GetCharacterAtScreen);
     ccAddExternalFunctionForPlugin("Character::get_ActiveInventory",       (void*)Character_GetActiveInventory);
     ccAddExternalFunctionForPlugin("Character::set_ActiveInventory",       (void*)Character_SetActiveInventory);
     ccAddExternalFunctionForPlugin("Character::get_Animating",             (void*)Character_GetAnimating);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2205,6 +2205,14 @@ CharacterInfo *GetCharacterAtScreen(int xx, int yy) {
     return &game.chars[hsnum];
 }
 
+CharacterInfo *GetCharacterAtRoom(int x, int y)
+{
+    int hsnum = is_pos_on_character(x, y);
+    if (hsnum < 0)
+        return NULL;
+    return &game.chars[hsnum];
+}
+
 extern int char_lowest_yp, obj_lowest_yp;
 
 int is_pos_on_character(int xx,int yy) {
@@ -3269,6 +3277,11 @@ RuntimeScriptValue Sc_Character_WalkStraight(void *self, const RuntimeScriptValu
     API_OBJCALL_VOID_PINT3(CharacterInfo, Character_WalkStraight);
 }
 
+RuntimeScriptValue Sc_GetCharacterAtRoom(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT2(CharacterInfo, ccDynamicCharacter, GetCharacterAtRoom);
+}
+
 // CharacterInfo *(int xx, int yy)
 RuntimeScriptValue Sc_GetCharacterAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -3837,6 +3850,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
 	ccAddExternalObjectFunction("Character::Walk^4",                    Sc_Character_Walk);
 	ccAddExternalObjectFunction("Character::WalkStraight^3",            Sc_Character_WalkStraight);
 
+    ccAddExternalStaticFunction("Character::GetAtRoomXY^2",             Sc_GetCharacterAtRoom);
 	ccAddExternalStaticFunction("Character::GetAtScreenXY^2",           Sc_GetCharacterAtScreen);
 
 	ccAddExternalObjectFunction("Character::get_ActiveInventory",       Sc_Character_GetActiveInventory);
@@ -3992,6 +4006,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     ccAddExternalFunctionForPlugin("Character::UnlockView^1",              (void*)Character_UnlockViewEx);
     ccAddExternalFunctionForPlugin("Character::Walk^4",                    (void*)Character_Walk);
     ccAddExternalFunctionForPlugin("Character::WalkStraight^3",            (void*)Character_WalkStraight);
+    ccAddExternalFunctionForPlugin("Character::GetAtRoomXY^2",             (void*)GetCharacterAtRoom);
     ccAddExternalFunctionForPlugin("Character::GetAtScreenXY^2",           (void*)GetCharacterAtScreen);
     ccAddExternalFunctionForPlugin("Character::get_ActiveInventory",       (void*)Character_GetActiveInventory);
     ccAddExternalFunctionForPlugin("Character::set_ActiveInventory",       (void*)Character_SetActiveInventory);

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -182,7 +182,7 @@ void setup_player_character(int charid);
 void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride=0, int direction=0);
 void CheckViewFrameForCharacter(CharacterInfo *chi);
 Common::Bitmap *GetCharacterImage(int charid, int *isFlipped);
-CharacterInfo *GetCharacterAtLocation(int xx, int yy);
+CharacterInfo *GetCharacterAtScreen(int xx, int yy);
 int is_pos_on_character(int xx,int yy);
 void get_char_blocking_rect(int charid, int *x1, int *y1, int *width, int *y2);
 // Check whether the source char has walked onto character ww

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -183,6 +183,7 @@ void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noi
 void CheckViewFrameForCharacter(CharacterInfo *chi);
 Common::Bitmap *GetCharacterImage(int charid, int *isFlipped);
 CharacterInfo *GetCharacterAtScreen(int xx, int yy);
+// Get character ID at the given room coordinates
 int is_pos_on_character(int xx,int yy);
 void get_char_blocking_rect(int charid, int *x1, int *y1, int *width, int *y2);
 // Check whether the source char has walked onto character ww

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -330,9 +330,9 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         if (!overlayPositionFixed)
         {
             screenover[nse].positionRelativeToScreen = false;
-            Point roompt = play.ScreenToRoom(screenover[nse].x, screenover[nse].y);
-            screenover[nse].x = roompt.X;
-            screenover[nse].y = roompt.Y;
+            VpPoint vpt = play.ScreenToRoom(screenover[nse].x, screenover[nse].y, false);
+            screenover[nse].x = vpt.first.X;
+            screenover[nse].y = vpt.first.Y;
         }
 
         GameLoopUntilEvent(UNTIL_NOOVERLAY,0);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1175,16 +1175,16 @@ void get_local_tint(int xpp, int ypp, int nolight,
         if ((play.ground_level_areas_disabled & GLED_EFFECTS) == 0) {
             // check if the player is on a region, to find its
             // light/tint level
-            onRegion = GetRegionAt (xpp, ypp);
+            onRegion = GetRegionIDAtRoom(xpp, ypp);
             if (onRegion == 0) {
                 // when walking, he might just be off a walkable area
-                onRegion = GetRegionAt (xpp - 3, ypp);
+                onRegion = GetRegionIDAtRoom(xpp - 3, ypp);
                 if (onRegion == 0)
-                    onRegion = GetRegionAt (xpp + 3, ypp);
+                    onRegion = GetRegionIDAtRoom(xpp + 3, ypp);
                 if (onRegion == 0)
-                    onRegion = GetRegionAt (xpp, ypp - 3);
+                    onRegion = GetRegionIDAtRoom(xpp, ypp - 3);
                 if (onRegion == 0)
-                    onRegion = GetRegionAt (xpp, ypp + 3);
+                    onRegion = GetRegionIDAtRoom(xpp, ypp + 3);
             }
         }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -200,6 +200,7 @@ char pexbuf[STD_BUFFER_SIZE];
 unsigned int load_new_game = 0;
 int load_new_game_restore = -1;
 
+// TODO: refactor these global vars into function arguments
 int getloctype_index = 0, getloctype_throughgui = 0;
 
 //=============================================================================
@@ -1788,9 +1789,11 @@ int __GetLocationType(int xxx,int yyy, int allowHotspot0) {
 
     const int scrx = xxx;
     const int scry = yyy;
-    Point roompt = play.ScreenToRoomDivDown(xxx, yyy);
-    xxx = roompt.X;
-    yyy = roompt.Y;
+    VpPoint vpt = play.ScreenToRoomDivDown(xxx, yyy);
+    if (vpt.second < 0)
+        return 0;
+    xxx = vpt.first.X;
+    yyy = vpt.first.Y;
     if ((xxx>=thisroom.Width) | (xxx<0) | (yyy<0) | (yyy>=thisroom.Height))
         return 0;
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1798,7 +1798,7 @@ int __GetLocationType(int xxx,int yyy, int allowHotspot0) {
     // foremost visible to the player
     int charat = is_pos_on_character(xxx,yyy);
     int hsat = get_hotspot_at(xxx,yyy);
-    int objat = GetObjectAt(scrx, scry);
+    int objat = GetObjectIDAtScreen(scrx, scry);
 
     multiply_up_coordinates(&xxx, &yyy);
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -215,12 +215,6 @@ Point GameState::RoomToScreen(int roomx, int roomy)
     return _roomViewport.Transform.Scale(Point(roomx - _roomCamera.Position.Left, roomy - _roomCamera.Position.Top));
 }
 
-Point GameState::RoomToScreenDivDown(int roomx, int roomy)
-{
-    return _roomViewport.Transform.Scale(Point(roomx - divide_down_coordinate(_roomCamera.Position.Left),
-        roomy - divide_down_coordinate(_roomCamera.Position.Top)));
-}
-
 int GameState::RoomToScreenX(int roomx)
 {
     return _roomViewport.Transform.X.ScalePt(roomx - _roomCamera.Position.Left);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -225,20 +225,28 @@ int GameState::RoomToScreenY(int roomy)
     return _roomViewport.Transform.Y.ScalePt(roomy - _roomCamera.Position.Top);
 }
 
-Point GameState::ScreenToRoom(int scrx, int scry)
+VpPoint GameState::ScreenToRoom(int scrx, int scry, bool clip_viewport)
 {
-    Point p = _roomViewport.Transform.UnScale(Point(scrx, scry));
+    clip_viewport &= game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v350;
+    Point screen_pt(scrx, scry);
+    if (clip_viewport && !_roomViewport.Position.IsInside(screen_pt))
+        return std::make_pair(Point(), -1);
+    Point p = _roomViewport.Transform.UnScale(screen_pt);
     p.X += _roomCamera.Position.Left;
     p.Y += _roomCamera.Position.Top;
-    return p;
+    return std::make_pair(p, 0);
 }
 
-Point GameState::ScreenToRoomDivDown(int scrx, int scry)
+VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry, bool clip_viewport)
 {
-    Point p = _roomViewport.Transform.UnScale(Point(scrx, scry));
+    clip_viewport &= game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v350;
+    Point screen_pt(scrx, scry);
+    if (clip_viewport && !_roomViewport.Position.IsInside(screen_pt))
+        return std::make_pair(Point(), -1);
+    Point p = _roomViewport.Transform.UnScale(screen_pt);
     p.X += divide_down_coordinate(_roomCamera.Position.Left);
     p.Y += divide_down_coordinate(_roomCamera.Position.Top);
-    return p;
+    return std::make_pair(p, 0);
 }
 
 void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver)

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -37,6 +37,10 @@ enum GameStateSvgVersion
     kGSSvgVersion_350       = 1
 };
 
+// A result of coordinate conversion between screen and the room,
+// tells which viewport was used to pass the "touch" through.
+typedef std::pair<Point, int> VpPoint;
+
 // Adding to this might need to modify AGSDEFNS.SH and AGSPLUGIN.H
 struct GameState {
     int  score;      // player's current score
@@ -260,6 +264,8 @@ struct GameState {
     // Runs camera behavior
     void UpdateRoomCamera();
     // Converts room coordinates to the game screen coordinates through the room viewport
+    // This group of functions always tries to pass a point through the **primary** room viewport
+    // TODO: also support using arbitrary viewport (for multiple viewports).
     Point RoomToScreen(int roomx, int roomy);
     int  RoomToScreenX(int roomx);
     int  RoomToScreenY(int roomy);
@@ -268,8 +274,8 @@ struct GameState {
     // TODO: also support using arbitrary viewport (for multiple viewports)
     // TODO: find out if possible to refactor and get rid of "variadic" variants;
     // usually this depends on how the arguments are created (whether they are in "variadic" or true coords)
-    Point ScreenToRoom(int scrx, int scry);
-    Point ScreenToRoomDivDown(int scrx, int scry); // native "variadic" coords variant
+    VpPoint ScreenToRoom(int scrx, int scry, bool clip_viewport = true);
+    VpPoint ScreenToRoomDivDown(int scrx, int scry, bool clip_viewport = true); // native "variadic" coords variant
 
     // Serialization
     void ReadQueuedAudioItems_Aligned(Common::Stream *in);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -260,13 +260,14 @@ struct GameState {
     // Runs camera behavior
     void UpdateRoomCamera();
     // Converts room coordinates to the game screen coordinates through the room viewport
-    // TODO: find out if possible to refactor and get rid of "variadic" variants;
-    // usually this depends on how the arguments are created (whether they are in "variadic" or true coords)
     Point RoomToScreen(int roomx, int roomy);
-    Point RoomToScreenDivDown(int roomx, int roomy); // native "variadic" coords variant
     int  RoomToScreenX(int roomx);
     int  RoomToScreenY(int roomy);
     // Converts game screen coordinates to the room coordinates through the room viewport
+    // These functions first try to find if there is any viewport at the given coords
+    // TODO: also support using arbitrary viewport (for multiple viewports)
+    // TODO: find out if possible to refactor and get rid of "variadic" variants;
+    // usually this depends on how the arguments are created (whether they are in "variadic" or true coords)
     Point ScreenToRoom(int scrx, int scry);
     Point ScreenToRoomDivDown(int scrx, int scry); // native "variadic" coords variant
 

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -492,9 +492,9 @@ RuntimeScriptValue Sc_GetButtonPic(const RuntimeScriptValue *params, int32_t par
 }
 
 // int  (int xx, int yy)
-RuntimeScriptValue Sc_GetCharacterAt(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetCharIDAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT2(GetCharacterAt);
+    API_SCALL_INT_PINT2(GetCharIDAtScreen);
 }
 
 // int  (int cha, const char *property)
@@ -572,9 +572,9 @@ RuntimeScriptValue Sc_GetGUIObjectAt(const RuntimeScriptValue *params, int32_t p
 }
 
 // int (int xxx,int yyy)
-RuntimeScriptValue Sc_GetHotspotAt(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetHotspotIDAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT2(GetHotspotAt);
+    API_SCALL_INT_PINT2(GetHotspotIDAtScreen);
 }
 
 // void (int hotspot, char *buffer)
@@ -668,9 +668,9 @@ RuntimeScriptValue Sc_GetMP3PosMillis(const RuntimeScriptValue *params, int32_t 
 }
 
 // int (int xx,int yy)
-RuntimeScriptValue Sc_GetObjectAt(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetObjectIDAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT2(GetObjectAt);
+    API_SCALL_INT_PINT2(GetObjectIDAtScreen);
 }
 
 // int (int obn)
@@ -728,9 +728,9 @@ RuntimeScriptValue Sc_GetRawTime(const RuntimeScriptValue *params, int32_t param
 }
 
 // int  (int xxx, int yyy)
-RuntimeScriptValue Sc_GetRegionAt(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetRegionIDAtRoom(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT2(GetRegionAt);
+    API_SCALL_INT_PINT2(GetRegionIDAtRoom);
 }
 
 // void  (const char *property, char *bufer)
@@ -818,7 +818,7 @@ RuntimeScriptValue Sc_GetViewportY(const RuntimeScriptValue *params, int32_t par
 // int (int xxx,int yyy)
 RuntimeScriptValue Sc_GetWalkableAreaAt(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_INT_PINT2(GetWalkableAreaAt);
+    API_SCALL_INT_PINT2(GetWalkableAreaAtScreen);
 }
 
 // void (int amnt) 
@@ -2342,7 +2342,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("FollowCharacterEx",        Sc_FollowCharacterEx);
 	ccAddExternalStaticFunction("GetBackgroundFrame",       Sc_GetBackgroundFrame);
 	ccAddExternalStaticFunction("GetButtonPic",             Sc_GetButtonPic);
-	ccAddExternalStaticFunction("GetCharacterAt",           Sc_GetCharacterAt);
+	ccAddExternalStaticFunction("GetCharacterAt",           Sc_GetCharIDAtScreen);
 	ccAddExternalStaticFunction("GetCharacterProperty",     Sc_GetCharacterProperty);
 	ccAddExternalStaticFunction("GetCharacterPropertyText", Sc_GetCharacterPropertyText);
 	ccAddExternalStaticFunction("GetCurrentMusic",          Sc_GetCurrentMusic);
@@ -2356,7 +2356,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("GetGraphicalVariable",     Sc_GetGraphicalVariable);
 	ccAddExternalStaticFunction("GetGUIAt",                 Sc_GetGUIAt);
 	ccAddExternalStaticFunction("GetGUIObjectAt",           Sc_GetGUIObjectAt);
-	ccAddExternalStaticFunction("GetHotspotAt",             Sc_GetHotspotAt);
+	ccAddExternalStaticFunction("GetHotspotAt",             Sc_GetHotspotIDAtScreen);
 	ccAddExternalStaticFunction("GetHotspotName",           Sc_GetHotspotName);
 	ccAddExternalStaticFunction("GetHotspotPointX",         Sc_GetHotspotPointX);
 	ccAddExternalStaticFunction("GetHotspotPointY",         Sc_GetHotspotPointY);
@@ -2373,7 +2373,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("GetMessageText",           Sc_GetMessageText);
 	ccAddExternalStaticFunction("GetMIDIPosition",          Sc_GetMIDIPosition);
 	ccAddExternalStaticFunction("GetMP3PosMillis",          Sc_GetMP3PosMillis);
-	ccAddExternalStaticFunction("GetObjectAt",              Sc_GetObjectAt);
+	ccAddExternalStaticFunction("GetObjectAt",              Sc_GetObjectIDAtScreen);
 	ccAddExternalStaticFunction("GetObjectBaseline",        Sc_GetObjectBaseline);
 	ccAddExternalStaticFunction("GetObjectGraphic",         Sc_GetObjectGraphic);
 	ccAddExternalStaticFunction("GetObjectName",            Sc_GetObjectName);
@@ -2384,7 +2384,7 @@ void RegisterGlobalAPI()
 	//  ccAddExternalStaticFunction("GetPalette",           Sc_scGetPal);
 	ccAddExternalStaticFunction("GetPlayerCharacter",       Sc_GetPlayerCharacter);
 	ccAddExternalStaticFunction("GetRawTime",               Sc_GetRawTime);
-	ccAddExternalStaticFunction("GetRegionAt",              Sc_GetRegionAt);
+	ccAddExternalStaticFunction("GetRegionAt",              Sc_GetRegionIDAtRoom);
 	ccAddExternalStaticFunction("GetRoomProperty",          Sc_Room_GetProperty);
 	ccAddExternalStaticFunction("GetRoomPropertyText",      Sc_GetRoomPropertyText);
 	ccAddExternalStaticFunction("GetSaveSlotDescription",   Sc_GetSaveSlotDescription);
@@ -2711,7 +2711,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("FollowCharacterEx",        (void*)FollowCharacterEx);
     ccAddExternalFunctionForPlugin("GetBackgroundFrame",       (void*)GetBackgroundFrame);
     ccAddExternalFunctionForPlugin("GetButtonPic",             (void*)GetButtonPic);
-    ccAddExternalFunctionForPlugin("GetCharacterAt",           (void*)GetCharacterAt);
+    ccAddExternalFunctionForPlugin("GetCharacterAt",           (void*)GetCharIDAtScreen);
     ccAddExternalFunctionForPlugin("GetCharacterProperty",     (void*)GetCharacterProperty);
     ccAddExternalFunctionForPlugin("GetCharacterPropertyText", (void*)GetCharacterPropertyText);
     ccAddExternalFunctionForPlugin("GetCurrentMusic",          (void*)GetCurrentMusic);
@@ -2725,7 +2725,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("GetGraphicalVariable",     (void*)GetGraphicalVariable);
     ccAddExternalFunctionForPlugin("GetGUIAt",                 (void*)GetGUIAt);
     ccAddExternalFunctionForPlugin("GetGUIObjectAt",           (void*)GetGUIObjectAt);
-    ccAddExternalFunctionForPlugin("GetHotspotAt",             (void*)GetHotspotAt);
+    ccAddExternalFunctionForPlugin("GetHotspotAt",             (void*)GetHotspotIDAtScreen);
     ccAddExternalFunctionForPlugin("GetHotspotName",           (void*)GetHotspotName);
     ccAddExternalFunctionForPlugin("GetHotspotPointX",         (void*)GetHotspotPointX);
     ccAddExternalFunctionForPlugin("GetHotspotPointY",         (void*)GetHotspotPointY);
@@ -2742,7 +2742,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("GetMessageText",           (void*)GetMessageText);
     ccAddExternalFunctionForPlugin("GetMIDIPosition",          (void*)GetMIDIPosition);
     ccAddExternalFunctionForPlugin("GetMP3PosMillis",          (void*)GetMP3PosMillis);
-    ccAddExternalFunctionForPlugin("GetObjectAt",              (void*)GetObjectAt);
+    ccAddExternalFunctionForPlugin("GetObjectAt",              (void*)GetObjectIDAtScreen);
     ccAddExternalFunctionForPlugin("GetObjectBaseline",        (void*)GetObjectBaseline);
     ccAddExternalFunctionForPlugin("GetObjectGraphic",         (void*)GetObjectGraphic);
     ccAddExternalFunctionForPlugin("GetObjectName",            (void*)GetObjectName);
@@ -2753,7 +2753,7 @@ void RegisterGlobalAPI()
     //  ccAddExternalFunctionForPlugin("GetPalette",           (void*)scGetPal);
     ccAddExternalFunctionForPlugin("GetPlayerCharacter",       (void*)GetPlayerCharacter);
     ccAddExternalFunctionForPlugin("GetRawTime",               (void*)GetRawTime);
-    ccAddExternalFunctionForPlugin("GetRegionAt",              (void*)GetRegionAt);
+    ccAddExternalFunctionForPlugin("GetRegionAt",              (void*)GetRegionIDAtRoom);
     ccAddExternalFunctionForPlugin("GetRoomProperty",          (void*)Room_GetProperty);
     ccAddExternalFunctionForPlugin("GetRoomPropertyText",      (void*)GetRoomPropertyText);
     ccAddExternalFunctionForPlugin("GetSaveSlotDescription",   (void*)GetSaveSlotDescription);
@@ -2767,7 +2767,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("GetTranslationName",       (void*)GetTranslationName);
     ccAddExternalFunctionForPlugin("GetViewportX",             (void*)GetViewportX);
     ccAddExternalFunctionForPlugin("GetViewportY",             (void*)GetViewportY);
-    ccAddExternalFunctionForPlugin("GetWalkableAreaAt",        (void*)GetWalkableAreaAt);
+    ccAddExternalFunctionForPlugin("GetWalkableAreaAt",        (void*)GetWalkableAreaAtScreen);
     ccAddExternalFunctionForPlugin("GiveScore",                (void*)GiveScore);
     ccAddExternalFunctionForPlugin("HasPlayerBeenInRoom",      (void*)HasPlayerBeenInRoom);
     ccAddExternalFunctionForPlugin("HideMouseCursor",          (void*)HideMouseCursor);
@@ -2837,7 +2837,7 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("PlaySoundEx",              (void*)PlaySoundEx);
     ccAddExternalFunctionForPlugin("PlaySpeech",               (void*)__scr_play_speech);
     ccAddExternalFunctionForPlugin("PlayVideo",                (void*)scrPlayVideo);
-    ccAddExternalFunctionForPlugin("ProcessClick",             (void*)ProcessClick);
+    ccAddExternalFunctionForPlugin("ProcessClick",             (void*)RoomProcessClick);
     ccAddExternalFunctionForPlugin("QuitGame",                 (void*)QuitGame);
     ccAddExternalFunctionForPlugin("Random",                   (void*)__Rand);
     ccAddExternalFunctionForPlugin("RawClearScreen",           (void*)RawClear);

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -815,8 +815,13 @@ RuntimeScriptValue Sc_GetViewportY(const RuntimeScriptValue *params, int32_t par
     API_SCALL_INT(GetViewportY);
 }
 
+RuntimeScriptValue Sc_GetWalkableAreaAtRoom(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT2(GetWalkableAreaAtRoom);
+}
+
 // int (int xxx,int yyy)
-RuntimeScriptValue Sc_GetWalkableAreaAt(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetWalkableAreaAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_INT_PINT2(GetWalkableAreaAtScreen);
 }
@@ -2400,7 +2405,9 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("GetTranslationName",       Sc_GetTranslationName);
 	ccAddExternalStaticFunction("GetViewportX",             Sc_GetViewportX);
 	ccAddExternalStaticFunction("GetViewportY",             Sc_GetViewportY);
-	ccAddExternalStaticFunction("GetWalkableAreaAt",        Sc_GetWalkableAreaAt);
+    ccAddExternalStaticFunction("GetWalkableAreaAtRoom",    Sc_GetWalkableAreaAtRoom);
+	ccAddExternalStaticFunction("GetWalkableAreaAt",        Sc_GetWalkableAreaAtScreen);
+    ccAddExternalStaticFunction("GetWalkableAreaAtScreen",  Sc_GetWalkableAreaAtScreen);
 	ccAddExternalStaticFunction("GiveScore",                Sc_GiveScore);
 	ccAddExternalStaticFunction("HasPlayerBeenInRoom",      Sc_HasPlayerBeenInRoom);
 	ccAddExternalStaticFunction("HideMouseCursor",          Sc_HideMouseCursor);
@@ -2767,7 +2774,9 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("GetTranslationName",       (void*)GetTranslationName);
     ccAddExternalFunctionForPlugin("GetViewportX",             (void*)GetViewportX);
     ccAddExternalFunctionForPlugin("GetViewportY",             (void*)GetViewportY);
+    ccAddExternalFunctionForPlugin("GetWalkableAreaAtRoom",    (void*)GetWalkableAreaAtRoom);
     ccAddExternalFunctionForPlugin("GetWalkableAreaAt",        (void*)GetWalkableAreaAtScreen);
+    ccAddExternalFunctionForPlugin("GetWalkableAreaAtScreen",  (void*)GetWalkableAreaAtScreen);
     ccAddExternalFunctionForPlugin("GiveScore",                (void*)GiveScore);
     ccAddExternalFunctionForPlugin("HasPlayerBeenInRoom",      (void*)HasPlayerBeenInRoom);
     ccAddExternalFunctionForPlugin("HideMouseCursor",          (void*)HideMouseCursor);

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -445,8 +445,10 @@ void GetCharacterPropertyText (int item, const char *property, char *bufer) {
 }
 
 int GetCharIDAtScreen(int xx, int yy) {
-    Point roompt = play.ScreenToRoomDivDown(xx, yy);
-    return is_pos_on_character(roompt.X, roompt.Y);
+    VpPoint vpt = play.ScreenToRoomDivDown(xx, yy);
+    if (vpt.second < 0)
+        return -1;
+    return is_pos_on_character(vpt.first.X, vpt.first.Y);
 }
 
 void SetActiveInventory(int iit) {

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -444,7 +444,7 @@ void GetCharacterPropertyText (int item, const char *property, char *bufer) {
     get_text_property (game.charProps[item], play.charProps[item], property, bufer);
 }
 
-int GetCharacterAt (int xx, int yy) {
+int GetCharIDAtScreen(int xx, int yy) {
     Point roompt = play.ScreenToRoomDivDown(xx, yy);
     return is_pos_on_character(roompt.X, roompt.Y);
 }

--- a/Engine/ac/global_character.h
+++ b/Engine/ac/global_character.h
@@ -70,7 +70,7 @@ int  GetPlayerCharacter();
 void GetCharacterPropertyText (int item, const char *property, char *bufer);
 
 int GetCharacterSpeechAnimationDelay(CharacterInfo *cha);
-int GetCharacterAt (int xx, int yy);
+int GetCharIDAtScreen(int xx, int yy);
 
 void SetActiveInventory(int iit);
 void AddInventoryToCharacter(int charid, int inum);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -781,7 +781,7 @@ void SetMultitasking (int mode) {
 
 extern int getloctype_throughgui, getloctype_index;
 
-void ProcessClick(int xx,int yy,int mood) {
+void RoomProcessClick(int xx,int yy,int mood) {
     getloctype_throughgui = 1;
     int loctype = GetLocationType (xx, yy);
     Point roompt = play.ScreenToRoomDivDown(xx, yy);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -548,9 +548,11 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
         return;
     }
     int loctype = GetLocationType (xxx, yyy);
-    Point roompt = play.ScreenToRoomDivDown(xxx, yyy);
-    xxx = roompt.X;
-    yyy = roompt.Y;
+    VpPoint vpt = play.ScreenToRoomDivDown(xxx, yyy);
+    if (vpt.second < 0)
+        return;
+    xxx = vpt.first.X;
+    yyy = vpt.first.Y;
     tempo[0]=0;
     if ((xxx>=thisroom.Width) | (xxx<0) | (yyy<0) | (yyy>=thisroom.Height))
         return;
@@ -784,9 +786,11 @@ extern int getloctype_throughgui, getloctype_index;
 void RoomProcessClick(int xx,int yy,int mood) {
     getloctype_throughgui = 1;
     int loctype = GetLocationType (xx, yy);
-    Point roompt = play.ScreenToRoomDivDown(xx, yy);
-    xx = roompt.X;
-    yy = roompt.Y;
+    VpPoint vpt = play.ScreenToRoomDivDown(xx, yy);
+    if (vpt.second < 0)
+        return;
+    xx = vpt.first.X;
+    yy = vpt.first.Y;
 
     if ((mood==MODE_WALK) && (game.options[OPT_NOWALKMODE]==0)) {
         int hsnum=get_hotspot_at(xx,yy);
@@ -822,9 +826,11 @@ void RoomProcessClick(int xx,int yy,int mood) {
 int IsInteractionAvailable (int xx,int yy,int mood) {
     getloctype_throughgui = 1;
     int loctype = GetLocationType (xx, yy);
-    Point roompt = play.ScreenToRoomDivDown(xx, yy);
-    xx = roompt.X;
-    yy = roompt.Y;
+    VpPoint vpt = play.ScreenToRoomDivDown(xx, yy);
+    if (vpt.second < 0)
+        return 0;
+    xx = vpt.first.X;
+    yy = vpt.first.Y;
 
     // You can always walk places
     if ((mood==MODE_WALK) && (game.options[OPT_NOWALKMODE]==0))

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -65,7 +65,7 @@ int IsKeyPressed (int keycode);
 int SaveScreenShot(const char*namm);
 void SetMultitasking (int mode);
 
-void ProcessClick(int xx,int yy,int mood);
+void RoomProcessClick(int xx,int yy,int mood);
 int IsInteractionAvailable (int xx,int yy,int mood);
 
 void GetMessageText (int msg, char *buffer);

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -71,7 +71,7 @@ int GetHotspotPointY (int hotspot) {
     return thisroom.Hotspots[hotspot].WalkTo.Y;
 }
 
-int GetHotspotAt(int scrx, int scry) {
+int GetHotspotIDAtScreen(int scrx, int scry) {
     Point pt = play.ScreenToRoomDivDown(scrx, scry);
     if ((pt.X>=thisroom.Width) | (pt.X<0) | (pt.Y<0) | (pt.Y>=thisroom.Height))
         return 0;

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -72,7 +72,10 @@ int GetHotspotPointY (int hotspot) {
 }
 
 int GetHotspotIDAtScreen(int scrx, int scry) {
-    Point pt = play.ScreenToRoomDivDown(scrx, scry);
+    VpPoint vpt = play.ScreenToRoomDivDown(scrx, scry);
+    if (vpt.second < 0)
+        return 0;
+    Point pt = vpt.first;
     if ((pt.X>=thisroom.Width) | (pt.X<0) | (pt.Y<0) | (pt.Y>=thisroom.Height))
         return 0;
     return get_hotspot_at(pt.X, pt.Y);

--- a/Engine/ac/global_hotspot.h
+++ b/Engine/ac/global_hotspot.h
@@ -22,7 +22,7 @@ void DisableHotspot(int hsnum);
 void EnableHotspot(int hsnum);
 int  GetHotspotPointX (int hotspot);
 int  GetHotspotPointY (int hotspot);
-int  GetHotspotAt(int xxx,int yyy);
+int  GetHotspotIDAtScreen(int xxx,int yyy);
 void GetHotspotName(int hotspot, char *buffer);
 void RunHotspotInteraction (int hotspothere, int mood);
 

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -58,14 +58,14 @@ extern IGraphicsDriver *gfxDriver;
 // Used for deciding whether a char or obj was closer
 int obj_lowest_yp;
 
-int GetObjectAt(int scrx, int scry)
+int GetObjectIDAtScreen(int scrx, int scry)
 {
     // translate screen co-ordinates to room co-ordinates
     Point roompt = play.ScreenToRoomDivDown(scrx, scry);
-    return GetObjectAtRoom(roompt.X, roompt.Y);
+    return GetObjectIDAtRoom(roompt.X, roompt.Y);
 }
 
-int GetObjectAtRoom(int roomx, int roomy)
+int GetObjectIDAtRoom(int roomx, int roomy)
 {
     int aa,bestshotyp=-1,bestshotwas=-1;
     // Iterate through all objects in the room

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -58,10 +58,16 @@ extern IGraphicsDriver *gfxDriver;
 // Used for deciding whether a char or obj was closer
 int obj_lowest_yp;
 
-int GetObjectAt(int scrx, int scry) {
-    int aa,bestshotyp=-1,bestshotwas=-1;
+int GetObjectAt(int scrx, int scry)
+{
     // translate screen co-ordinates to room co-ordinates
     Point roompt = play.ScreenToRoomDivDown(scrx, scry);
+    return GetObjectAtRoom(roompt.X, roompt.Y);
+}
+
+int GetObjectAtRoom(int roomx, int roomy)
+{
+    int aa,bestshotyp=-1,bestshotwas=-1;
     // Iterate through all objects in the room
     for (aa=0;aa<croom->numobj;aa++) {
         if (objs[aa].on != 1) continue;
@@ -76,7 +82,7 @@ int GetObjectAt(int scrx, int scry) {
 
         Bitmap *theImage = GetObjectImage(aa, &isflipped);
 
-        if (is_pos_in_sprite(roompt.X, roompt.Y, xxx, yyy - spHeight, theImage,
+        if (is_pos_in_sprite(roomx, roomy, xxx, yyy - spHeight, theImage,
             spWidth, spHeight, isflipped) == FALSE)
             continue;
 

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -61,8 +61,10 @@ int obj_lowest_yp;
 int GetObjectIDAtScreen(int scrx, int scry)
 {
     // translate screen co-ordinates to room co-ordinates
-    Point roompt = play.ScreenToRoomDivDown(scrx, scry);
-    return GetObjectIDAtRoom(roompt.X, roompt.Y);
+    VpPoint vpt = play.ScreenToRoomDivDown(scrx, scry);
+    if (vpt.second < 0)
+        return -1;
+    return GetObjectIDAtRoom(vpt.first.X, vpt.first.Y);
 }
 
 int GetObjectIDAtRoom(int roomx, int roomy)

--- a/Engine/ac/global_object.h
+++ b/Engine/ac/global_object.h
@@ -26,7 +26,10 @@ struct _Rect {
     int x1,y1,x2,y2;
 };
 
+// Get object at the given screen coordinates
 int  GetObjectAt(int xx,int yy);
+// Get object at the given room coordinates
+int  GetObjectAtRoom(int roomx, int roomy);
 void SetObjectTint(int obj, int red, int green, int blue, int opacity, int luminance);
 void RemoveObjectTint(int obj);
 void SetObjectView(int obn,int vii);

--- a/Engine/ac/global_object.h
+++ b/Engine/ac/global_object.h
@@ -27,9 +27,9 @@ struct _Rect {
 };
 
 // Get object at the given screen coordinates
-int  GetObjectAt(int xx,int yy);
+int  GetObjectIDAtScreen(int xx,int yy);
 // Get object at the given room coordinates
-int  GetObjectAtRoom(int roomx, int roomy);
+int  GetObjectIDAtRoom(int roomx, int roomy);
 void SetObjectTint(int obj, int red, int green, int blue, int opacity, int luminance);
 void RemoveObjectTint(int obj);
 void SetObjectView(int obn,int vii);

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -30,7 +30,7 @@ extern RoomStatus*croom;
 extern char*evblockbasename;
 extern int evblocknum;
 
-int GetRegionAt (int xxx, int yyy) {
+int GetRegionIDAtRoom(int xxx, int yyy) {
     // if the co-ordinates are off the edge of the screen,
     // correct them to be just within
     // this fixes walk-off-screen problems

--- a/Engine/ac/global_region.h
+++ b/Engine/ac/global_region.h
@@ -18,7 +18,7 @@
 #ifndef __AGS_EE_AC__GLOBALREGION_H
 #define __AGS_EE_AC__GLOBALREGION_H
 
-int  GetRegionAt (int xxx, int yyy);
+int  GetRegionIDAtRoom(int xxx, int yyy);
 void SetAreaLightLevel(int area, int brightness);
 void SetRegionTint (int area, int red, int green, int blue, int amount, int luminance = 100);
 void DisableRegion(int hsnum);

--- a/Engine/ac/global_walkablearea.cpp
+++ b/Engine/ac/global_walkablearea.cpp
@@ -74,7 +74,7 @@ void RestoreWalkableArea(int areanum) {
 }
 
 
-int GetWalkableAreaAt(int x, int y) {
+int GetWalkableAreaAtScreen(int x, int y) {
   Point roompt = play.ScreenToRoomDivDown(x, y);
   if ((roompt.X>=thisroom.Width) | (roompt.X<0) | (roompt.Y<0) | (roompt.Y>=thisroom.Height))
     return 0;

--- a/Engine/ac/global_walkablearea.cpp
+++ b/Engine/ac/global_walkablearea.cpp
@@ -73,15 +73,17 @@ void RestoreWalkableArea(int areanum) {
   debug_script_log("Walkable area %d restored", areanum);
 }
 
-
 int GetWalkableAreaAtScreen(int x, int y) {
   VpPoint vpt = play.ScreenToRoomDivDown(x, y);
   if (vpt.second < 0)
     return 0;
-  Point roompt = vpt.first;
-  if ((roompt.X>=thisroom.Width) | (roompt.X<0) | (roompt.Y<0) | (roompt.Y>=thisroom.Height))
+  return GetWalkableAreaAtRoom(vpt.first.X, vpt.first.Y);
+}
+
+int GetWalkableAreaAtRoom(int x, int y) {
+  if ((x>=thisroom.Width) | (x<0) | (y<0) | (y>=thisroom.Height))
     return 0;
-  int result = get_walkable_area_pixel(roompt.X, roompt.Y);
+  int result = get_walkable_area_pixel(x, y);
   if (result <= 0)
     return 0;
   return result;

--- a/Engine/ac/global_walkablearea.cpp
+++ b/Engine/ac/global_walkablearea.cpp
@@ -75,7 +75,10 @@ void RestoreWalkableArea(int areanum) {
 
 
 int GetWalkableAreaAtScreen(int x, int y) {
-  Point roompt = play.ScreenToRoomDivDown(x, y);
+  VpPoint vpt = play.ScreenToRoomDivDown(x, y);
+  if (vpt.second < 0)
+    return 0;
+  Point roompt = vpt.first;
   if ((roompt.X>=thisroom.Width) | (roompt.X<0) | (roompt.Y<0) | (roompt.Y>=thisroom.Height))
     return 0;
   int result = get_walkable_area_pixel(roompt.X, roompt.Y);

--- a/Engine/ac/global_walkablearea.h
+++ b/Engine/ac/global_walkablearea.h
@@ -22,7 +22,9 @@ int   GetScalingAt (int x, int y);
 void  SetAreaScaling(int area, int min, int max);
 void  RemoveWalkableArea(int areanum);
 void  RestoreWalkableArea(int areanum);
+// Gets walkable area at the given room coordinates
+int   GetWalkableAreaAtRoom(int x, int y);
 // Gets walkable area at the given screen coordinates
-int   GetWalkableAreaAtScreen(int xxx,int yyy);
+int   GetWalkableAreaAtScreen(int x, int y);
 
 #endif // __AGS_EE_AC__GLOBALWALKABLEAREA_H

--- a/Engine/ac/global_walkablearea.h
+++ b/Engine/ac/global_walkablearea.h
@@ -22,6 +22,7 @@ int   GetScalingAt (int x, int y);
 void  SetAreaScaling(int area, int min, int max);
 void  RemoveWalkableArea(int areanum);
 void  RestoreWalkableArea(int areanum);
-int   GetWalkableAreaAt(int xxx,int yyy);
+// Gets walkable area at the given screen coordinates
+int   GetWalkableAreaAtScreen(int xxx,int yyy);
 
 #endif // __AGS_EE_AC__GLOBALWALKABLEAREA_H

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -65,6 +65,16 @@ ScriptHotspot *GetHotspotAtScreen(int xx, int yy) {
     return ret_hotspot;
 }
 
+ScriptHotspot *GetHotspotAtRoom(int x, int y) {
+    int hsnum = get_hotspot_at(x, y);
+    ScriptHotspot *ret_hotspot;
+    if (hsnum <= 0)
+        ret_hotspot = &scrHotspot[0];
+    else
+        ret_hotspot = &scrHotspot[hsnum];
+    return ret_hotspot;
+}
+
 void Hotspot_GetName(ScriptHotspot *hss, char *buffer) {
     GetHotspotName(hss->id, buffer);
 }
@@ -131,6 +141,11 @@ int get_hotspot_at(int xpp,int ypp) {
 #include "ac/dynobj/scriptstring.h"
 
 extern ScriptString myScriptStringImpl;
+
+RuntimeScriptValue Sc_GetHotspotAtRoom(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, GetHotspotAtRoom);
+}
 
 // ScriptHotspot *(int xx, int yy)
 RuntimeScriptValue Sc_GetHotspotAtScreen(const RuntimeScriptValue *params, int32_t param_count)
@@ -223,6 +238,7 @@ RuntimeScriptValue Sc_Hotspot_GetWalkToY(void *self, const RuntimeScriptValue *p
 
 void RegisterHotspotAPI()
 {
+    ccAddExternalStaticFunction("Hotspot::GetAtRoomXY^2",       Sc_GetHotspotAtRoom);
     ccAddExternalStaticFunction("Hotspot::GetAtScreenXY^2",     Sc_GetHotspotAtScreen);
     ccAddExternalObjectFunction("Hotspot::GetName^1",           Sc_Hotspot_GetName);
     ccAddExternalObjectFunction("Hotspot::GetProperty^1",       Sc_Hotspot_GetProperty);
@@ -241,6 +257,7 @@ void RegisterHotspotAPI()
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
+    ccAddExternalFunctionForPlugin("Hotspot::GetAtRoomXY^2",       (void*)GetHotspotAtRoom);
     ccAddExternalFunctionForPlugin("Hotspot::GetAtScreenXY^2",     (void*)GetHotspotAtScreen);
     ccAddExternalFunctionForPlugin("Hotspot::GetName^1",           (void*)Hotspot_GetName);
     ccAddExternalFunctionForPlugin("Hotspot::GetProperty^1",       (void*)Hotspot_GetProperty);

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -55,8 +55,8 @@ int Hotspot_GetWalkToY(ScriptHotspot *hss) {
     return GetHotspotPointY(hss->id);
 }
 
-ScriptHotspot *GetHotspotAtLocation(int xx, int yy) {
-    int hsnum = GetHotspotAt(xx, yy);
+ScriptHotspot *GetHotspotAtScreen(int xx, int yy) {
+    int hsnum = GetHotspotIDAtScreen(xx, yy);
     ScriptHotspot *ret_hotspot;
     if (hsnum <= 0)
         ret_hotspot = &scrHotspot[0];
@@ -133,9 +133,9 @@ int get_hotspot_at(int xpp,int ypp) {
 extern ScriptString myScriptStringImpl;
 
 // ScriptHotspot *(int xx, int yy)
-RuntimeScriptValue Sc_GetHotspotAtLocation(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetHotspotAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, GetHotspotAtLocation);
+    API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, GetHotspotAtScreen);
 }
 
 // void (ScriptHotspot *hss, char *buffer)
@@ -223,7 +223,7 @@ RuntimeScriptValue Sc_Hotspot_GetWalkToY(void *self, const RuntimeScriptValue *p
 
 void RegisterHotspotAPI()
 {
-    ccAddExternalStaticFunction("Hotspot::GetAtScreenXY^2",     Sc_GetHotspotAtLocation);
+    ccAddExternalStaticFunction("Hotspot::GetAtScreenXY^2",     Sc_GetHotspotAtScreen);
     ccAddExternalObjectFunction("Hotspot::GetName^1",           Sc_Hotspot_GetName);
     ccAddExternalObjectFunction("Hotspot::GetProperty^1",       Sc_Hotspot_GetProperty);
     ccAddExternalObjectFunction("Hotspot::GetPropertyText^2",   Sc_Hotspot_GetPropertyText);
@@ -241,7 +241,7 @@ void RegisterHotspotAPI()
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
-    ccAddExternalFunctionForPlugin("Hotspot::GetAtScreenXY^2",     (void*)GetHotspotAtLocation);
+    ccAddExternalFunctionForPlugin("Hotspot::GetAtScreenXY^2",     (void*)GetHotspotAtScreen);
     ccAddExternalFunctionForPlugin("Hotspot::GetName^1",           (void*)Hotspot_GetName);
     ccAddExternalFunctionForPlugin("Hotspot::GetProperty^1",       (void*)Hotspot_GetProperty);
     ccAddExternalFunctionForPlugin("Hotspot::GetPropertyText^2",   (void*)Hotspot_GetPropertyText);

--- a/Engine/ac/hotspot.h
+++ b/Engine/ac/hotspot.h
@@ -35,6 +35,7 @@ int     Hotspot_GetProperty (ScriptHotspot *hss, const char *property);
 void    Hotspot_GetPropertyText (ScriptHotspot *hss, const char *property, char *bufer);
 const char* Hotspot_GetTextProperty(ScriptHotspot *hss, const char *property);
 
+// Gets hotspot ID at the given room coordinates
 int     get_hotspot_at(int xpp,int ypp);
 
 #endif // __AGS_EE_AC__HOTSPOT_H

--- a/Engine/ac/hotspot.h
+++ b/Engine/ac/hotspot.h
@@ -23,7 +23,7 @@
 void    Hotspot_SetEnabled(ScriptHotspot *hss, int newval);
 int     Hotspot_GetEnabled(ScriptHotspot *hss);
 int     Hotspot_GetID(ScriptHotspot *hss);
-ScriptHotspot *GetHotspotAtLocation(int xx, int yy);
+ScriptHotspot *GetHotspotAtScreen(int xx, int yy);
 int     Hotspot_GetWalkToX(ScriptHotspot *hss);;
 int     Hotspot_GetWalkToY(ScriptHotspot *hss);
 void    Hotspot_GetName(ScriptHotspot *hss, char *buffer);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -512,11 +512,10 @@ int is_pos_in_sprite(int xx,int yy,int arx,int ary, Bitmap *sprit, int spww,int 
     return TRUE;
 }
 
-// X and Y co-ordinates must be in 320x200 format (TODO: find out if this comment is still true)
-// X and Y are ROOM coordinates here for some reason, so we have to perform that ugly back-and-forth coordinate conversion
-int check_click_on_object(int xx,int yy,int mood) {
-    Point pt = play.RoomToScreenDivDown(xx, yy);
-    int aa = GetObjectAt(pt.X, pt.Y);
+// X and Y co-ordinates must be in native format (TODO: find out if this comment is still true)
+int check_click_on_object(int roomx, int roomy, int mood)
+{
+    int aa = GetObjectAtRoom(roomx, roomy);
     if (aa < 0) return 0;
     RunObjectInteraction(aa, mood);
     return 1;

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -55,8 +55,8 @@ int Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2) {
     return AreObjectsColliding(objj->id, obj2->id);
 }
 
-ScriptObject *GetObjectAtLocation(int xx, int yy) {
-    int hsnum = GetObjectAt(xx, yy);
+ScriptObject *GetObjectAtScreen(int xx, int yy) {
+    int hsnum = GetObjectIDAtScreen(xx, yy);
     if (hsnum < 0)
         return NULL;
     return &scrObj[hsnum];
@@ -515,7 +515,7 @@ int is_pos_in_sprite(int xx,int yy,int arx,int ary, Bitmap *sprit, int spww,int 
 // X and Y co-ordinates must be in native format (TODO: find out if this comment is still true)
 int check_click_on_object(int roomx, int roomy, int mood)
 {
-    int aa = GetObjectAtRoom(roomx, roomy);
+    int aa = GetObjectIDAtRoom(roomx, roomy);
     if (aa < 0) return 0;
     RunObjectInteraction(aa, mood);
     return 1;
@@ -685,9 +685,9 @@ RuntimeScriptValue Sc_Object_Tint(void *self, const RuntimeScriptValue *params, 
 }
 
 // ScriptObject *(int xx, int yy)
-RuntimeScriptValue Sc_GetObjectAtLocation(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetObjectAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(ScriptObject, ccDynamicObject, GetObjectAtLocation);
+    API_SCALL_OBJ_PINT2(ScriptObject, ccDynamicObject, GetObjectAtScreen);
 }
 
 // int (ScriptObject *objj)
@@ -901,7 +901,7 @@ void RegisterObjectAPI()
     ccAddExternalObjectFunction("Object::Tint^5",                   Sc_Object_Tint);
 
     // static
-    ccAddExternalStaticFunction("Object::GetAtScreenXY^2",          Sc_GetObjectAtLocation);
+    ccAddExternalStaticFunction("Object::GetAtScreenXY^2",          Sc_GetObjectAtScreen);
 
     ccAddExternalObjectFunction("Object::get_Animating",            Sc_Object_GetAnimating);
     ccAddExternalObjectFunction("Object::get_Baseline",             Sc_Object_GetBaseline);
@@ -962,7 +962,7 @@ void RegisterObjectAPI()
     ccAddExternalFunctionForPlugin("Object::StopAnimating^0",          (void*)Object_StopAnimating);
     ccAddExternalFunctionForPlugin("Object::StopMoving^0",             (void*)Object_StopMoving);
     ccAddExternalFunctionForPlugin("Object::Tint^5",                   (void*)Object_Tint);
-    ccAddExternalFunctionForPlugin("Object::GetAtScreenXY^2",          (void*)GetObjectAtLocation);
+    ccAddExternalFunctionForPlugin("Object::GetAtScreenXY^2",          (void*)GetObjectAtScreen);
     ccAddExternalFunctionForPlugin("Object::get_Animating",            (void*)Object_GetAnimating);
     ccAddExternalFunctionForPlugin("Object::get_Baseline",             (void*)Object_GetBaseline);
     ccAddExternalFunctionForPlugin("Object::set_Baseline",             (void*)Object_SetBaseline);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -62,6 +62,14 @@ ScriptObject *GetObjectAtScreen(int xx, int yy) {
     return &scrObj[hsnum];
 }
 
+ScriptObject *GetObjectAtRoom(int x, int y)
+{
+    int hsnum = GetObjectIDAtRoom(x, y);
+    if (hsnum < 0)
+        return NULL;
+    return &scrObj[hsnum];
+}
+
 AGS_INLINE int is_valid_object(int obtest) {
     if ((obtest < 0) || (obtest >= croom->numobj)) return 0;
     return 1;
@@ -684,6 +692,11 @@ RuntimeScriptValue Sc_Object_Tint(void *self, const RuntimeScriptValue *params, 
     API_OBJCALL_VOID_PINT5(ScriptObject, Object_Tint);
 }
 
+RuntimeScriptValue Sc_GetObjectAtRoom(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT2(ScriptObject, ccDynamicObject, GetObjectAtRoom);
+}
+
 // ScriptObject *(int xx, int yy)
 RuntimeScriptValue Sc_GetObjectAtScreen(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -901,6 +914,7 @@ void RegisterObjectAPI()
     ccAddExternalObjectFunction("Object::Tint^5",                   Sc_Object_Tint);
 
     // static
+    ccAddExternalStaticFunction("Object::GetAtRoomXY^2",            Sc_GetObjectAtRoom);
     ccAddExternalStaticFunction("Object::GetAtScreenXY^2",          Sc_GetObjectAtScreen);
 
     ccAddExternalObjectFunction("Object::get_Animating",            Sc_Object_GetAnimating);
@@ -962,6 +976,7 @@ void RegisterObjectAPI()
     ccAddExternalFunctionForPlugin("Object::StopAnimating^0",          (void*)Object_StopAnimating);
     ccAddExternalFunctionForPlugin("Object::StopMoving^0",             (void*)Object_StopMoving);
     ccAddExternalFunctionForPlugin("Object::Tint^5",                   (void*)Object_Tint);
+    ccAddExternalFunctionForPlugin("Object::GetAtRoomXY^2",            (void*)GetObjectAtRoom);
     ccAddExternalFunctionForPlugin("Object::GetAtScreenXY^2",          (void*)GetObjectAtScreen);
     ccAddExternalFunctionForPlugin("Object::get_Animating",            (void*)Object_GetAnimating);
     ccAddExternalFunctionForPlugin("Object::get_Baseline",             (void*)Object_GetBaseline);

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -81,9 +81,9 @@ void    move_object(int objj,int tox,int toy,int spee,int ignwal);
 void    get_object_blocking_rect(int objid, int *x1, int *y1, int *width, int *y2);
 int     isposinbox(int mmx,int mmy,int lf,int tp,int rt,int bt);
 int     is_pos_in_sprite(int xx,int yy,int arx,int ary, Common::Bitmap *sprit, int spww,int sphh, int flipped = 0);
-// X and Y co-ordinates must be in 320x200 format
+// X and Y co-ordinates must be in native format
 // X and Y are ROOM coordinates
-int     check_click_on_object(int xx,int yy,int mood);
+int     check_click_on_object(int roomx, int roomy, int mood);
 
 #endif // __AGS_EE_AC__OBJECT_H
 

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -28,7 +28,7 @@ using namespace AGS; // FIXME later
 
 AGS_INLINE int is_valid_object(int obtest);
 int     Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2);
-ScriptObject *GetObjectAtLocation(int xx, int yy);
+ScriptObject *GetObjectAtScreen(int xx, int yy);
 void    Object_Tint(ScriptObject *objj, int red, int green, int blue, int saturation, int luminance);
 void    Object_RemoveTint(ScriptObject *objj);
 void    Object_SetView(ScriptObject *objj, int view, int loop, int frame);

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -32,8 +32,8 @@ extern color palette[256];
 extern CCRegion ccDynamicRegion;
 
 
-ScriptRegion *GetRegionAtLocation(int xx, int yy) {
-    int hsnum = GetRegionAt(xx, yy);
+ScriptRegion *GetRegionAtRoom(int xx, int yy) {
+    int hsnum = GetRegionIDAtRoom(xx, yy);
     if (hsnum < 0)
         hsnum = 0;
     return &scrRegion[hsnum];
@@ -129,9 +129,9 @@ void generate_light_table()
 #include "script/script_runtime.h"
 
 // ScriptRegion *(int xx, int yy)
-RuntimeScriptValue Sc_GetRegionAtLocation(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_GetRegionAtRoom(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJ_PINT2(ScriptRegion, ccDynamicRegion, GetRegionAtLocation);
+    API_SCALL_OBJ_PINT2(ScriptRegion, ccDynamicRegion, GetRegionAtRoom);
 }
 
 RuntimeScriptValue Sc_Region_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -220,7 +220,7 @@ RuntimeScriptValue Sc_Region_GetTintLuminance(void *self, const RuntimeScriptVal
 
 void RegisterRegionAPI()
 {
-    ccAddExternalStaticFunction("Region::GetAtRoomXY^2",        Sc_GetRegionAtLocation);
+    ccAddExternalStaticFunction("Region::GetAtRoomXY^2",        Sc_GetRegionAtRoom);
     ccAddExternalObjectFunction("Region::Tint^4",               Sc_Region_TintNoLum);
     ccAddExternalObjectFunction("Region::Tint^5",               Sc_Region_Tint);
     ccAddExternalObjectFunction("Region::RunInteraction^1",     Sc_Region_RunInteraction);
@@ -238,7 +238,7 @@ void RegisterRegionAPI()
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
-    ccAddExternalFunctionForPlugin("Region::GetAtRoomXY^2",        (void*)GetRegionAtLocation);
+    ccAddExternalFunctionForPlugin("Region::GetAtRoomXY^2",        (void*)GetRegionAtRoom);
     ccAddExternalFunctionForPlugin("Region::Tint^4",               (void*)Region_TintNoLum);
     ccAddExternalFunctionForPlugin("Region::RunInteraction^1",     (void*)Region_RunInteraction);
     ccAddExternalFunctionForPlugin("Region::get_Enabled",          (void*)Region_GetEnabled);

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -15,6 +15,7 @@
 #include "ac/region.h"
 #include "ac/common_defines.h"
 #include "ac/gamesetupstruct.h"
+#include "ac/gamestate.h"
 #include "ac/global_region.h"
 #include "ac/roomstatus.h"
 #include "ac/dynobj/cc_region.h"
@@ -37,6 +38,14 @@ ScriptRegion *GetRegionAtRoom(int xx, int yy) {
     if (hsnum < 0)
         hsnum = 0;
     return &scrRegion[hsnum];
+}
+
+ScriptRegion *GetRegionAtScreen(int x, int y)
+{
+    VpPoint vpt = play.ScreenToRoomDivDown(x, y);
+    if (vpt.second < 0)
+        return 0;
+    return GetRegionAtRoom(vpt.first.X, vpt.first.Y);
 }
 
 void Region_SetLightLevel(ScriptRegion *ssr, int brightness) {
@@ -134,6 +143,11 @@ RuntimeScriptValue Sc_GetRegionAtRoom(const RuntimeScriptValue *params, int32_t 
     API_SCALL_OBJ_PINT2(ScriptRegion, ccDynamicRegion, GetRegionAtRoom);
 }
 
+RuntimeScriptValue Sc_GetRegionAtScreen(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_PINT2(ScriptRegion, ccDynamicRegion, GetRegionAtScreen);
+}
+
 RuntimeScriptValue Sc_Region_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT5(ScriptRegion, Region_Tint);
@@ -221,6 +235,7 @@ RuntimeScriptValue Sc_Region_GetTintLuminance(void *self, const RuntimeScriptVal
 void RegisterRegionAPI()
 {
     ccAddExternalStaticFunction("Region::GetAtRoomXY^2",        Sc_GetRegionAtRoom);
+    ccAddExternalStaticFunction("Region::GetAtScreenXY^2",      Sc_GetRegionAtScreen);
     ccAddExternalObjectFunction("Region::Tint^4",               Sc_Region_TintNoLum);
     ccAddExternalObjectFunction("Region::Tint^5",               Sc_Region_Tint);
     ccAddExternalObjectFunction("Region::RunInteraction^1",     Sc_Region_RunInteraction);
@@ -239,6 +254,7 @@ void RegisterRegionAPI()
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
     ccAddExternalFunctionForPlugin("Region::GetAtRoomXY^2",        (void*)GetRegionAtRoom);
+    ccAddExternalFunctionForPlugin("Region::GetAtScreenXY^2",      (void*)GetRegionAtScreen);
     ccAddExternalFunctionForPlugin("Region::Tint^4",               (void*)Region_TintNoLum);
     ccAddExternalFunctionForPlugin("Region::RunInteraction^1",     (void*)Region_RunInteraction);
     ccAddExternalFunctionForPlugin("Region::get_Enabled",          (void*)Region_GetEnabled);

--- a/Engine/ac/region.h
+++ b/Engine/ac/region.h
@@ -20,7 +20,7 @@
 
 #include "ac/dynobj/scriptregion.h"
 
-ScriptRegion *GetRegionAtLocation(int xx, int yy);
+ScriptRegion *GetRegionAtRoom(int xx, int yy);
 void    Region_SetLightLevel(ScriptRegion *ssr, int brightness);
 int     Region_GetLightLevel(ScriptRegion *ssr);
 int     Region_GetTintEnabled(ScriptRegion *srr);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1141,9 +1141,9 @@ RuntimeScriptValue Sc_Room_GetWidth(const RuntimeScriptValue *params, int32_t pa
 }
 
 // void (int xx,int yy,int mood)
-RuntimeScriptValue Sc_ProcessClick(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_RoomProcessClick(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_VOID_PINT3(ProcessClick);
+    API_SCALL_VOID_PINT3(RoomProcessClick);
 }
 
 RuntimeScriptValue Sc_Room_GetCamera(const RuntimeScriptValue *params, int32_t param_count)
@@ -1159,8 +1159,8 @@ void RegisterRoomAPI()
     ccAddExternalStaticFunction("Room::GetTextProperty^1",                  Sc_Room_GetTextProperty);
     ccAddExternalStaticFunction("Room::SetProperty^2",                      Sc_Room_SetProperty);
     ccAddExternalStaticFunction("Room::SetTextProperty^2",                  Sc_Room_SetTextProperty);
-    ccAddExternalStaticFunction("Room::ProcessClick^3",                     Sc_ProcessClick);
-    ccAddExternalStaticFunction("ProcessClick",                             Sc_ProcessClick);
+    ccAddExternalStaticFunction("Room::ProcessClick^3",                     Sc_RoomProcessClick);
+    ccAddExternalStaticFunction("ProcessClick",                             Sc_RoomProcessClick);
     ccAddExternalStaticFunction("Room::get_BottomEdge",                     Sc_Room_GetBottomEdge);
     ccAddExternalStaticFunction("Room::get_ColorDepth",                     Sc_Room_GetColorDepth);
     ccAddExternalStaticFunction("Room::get_Height",                         Sc_Room_GetHeight);

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -146,13 +146,12 @@ ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry)
 {
     multiply_up_coordinates(&scrx, &scry);
 
-    const Rect &view = play.GetRoomViewport();
-    if (!view.IsInside(scrx, scry))
+    VpPoint vpt = play.ScreenToRoom(scrx, scry);
+    if (vpt.second < 0)
         return NULL;
-    Point pt = play.ScreenToRoom(scrx, scry);
 
-    divide_down_coordinates(pt.X, pt.Y);
-    return ScriptStructHelpers::CreatePoint(pt.X, pt.Y);
+    divide_down_coordinates(vpt.first.X, vpt.first.Y);
+    return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);
 }
 
 RuntimeScriptValue Sc_Screen_GetScreenHeight(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/viewport.cpp
+++ b/Engine/ac/viewport.cpp
@@ -259,13 +259,12 @@ ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *, int scrx, int scr
 {
     multiply_up_coordinates(&scrx, &scry);
 
-    const Rect &view = play.GetRoomViewport();
-    if (clipViewport && !view.IsInside(scrx, scry))
+    VpPoint vpt = play.ScreenToRoom(scrx, scry, clipViewport);
+    if (vpt.second < 0)
         return NULL;
-    Point pt = play.ScreenToRoom(scrx, scry);
 
-    divide_down_coordinates(pt.X, pt.Y);
-    return ScriptStructHelpers::CreatePoint(pt.X, pt.Y);
+    divide_down_coordinates(vpt.first.X, vpt.first.Y);
+    return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);
 }
 
 ScriptUserObject *Sc_Viewport_RoomToScreenPoint(ScriptViewport *, int roomx, int roomy, bool clipViewport)

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -147,7 +147,7 @@ int game_loop_check_ground_level_interactions()
         setevent(EV_RUNEVBLOCK, EVB_HOTSPOT, hotspotThere, 0);
 
         // check current region
-        int onRegion = GetRegionAt (playerchar->x, playerchar->y);
+        int onRegion = GetRegionIDAtRoom(playerchar->x, playerchar->y);
         int inRoom = displayed_room;
 
         if (onRegion != play.player_on_region) {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -436,11 +436,11 @@ void IAGSEngine::RoomToViewport (int32 *x, int32 *y) {
         *y = scrp.Y;
 }
 void IAGSEngine::ViewportToRoom (int32 *x, int32 *y) {
-    Point scrp = play.ScreenToRoom(x ? divide_down_coordinate(*x) : 0, y ? divide_down_coordinate(*y) : 0);
+    VpPoint vpt = play.ScreenToRoom(x ? divide_down_coordinate(*x) : 0, y ? divide_down_coordinate(*y) : 0, false);
     if (x)
-        *x = scrp.X;
+        *x = vpt.first.X;
     if (y)
-        *y = scrp.Y;
+        *y = vpt.first.Y;
 }
 int IAGSEngine::GetNumObjects () {
     return croom->numobj;

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -380,9 +380,9 @@ public:
   // *** BELOW ARE INTERFACE VERSION 7 AND ABOVE ONLY
   // get the current player character
   AGSIFUNC(int)  GetPlayerCharacter ();
-  // adjust to viewport co-ordinates
+  // adjust to main viewport co-ordinates
   AGSIFUNC(void) RoomToViewport (int32 *x, int32 *y);
-  // adjust from viewport co-ordinates
+  // adjust from main viewport co-ordinates (ignores viewport bounds)
   AGSIFUNC(void) ViewportToRoom (int32 *x, int32 *y);
   // number of objects in current room
   AGSIFUNC(int)  GetNumObjects ();


### PR DESCRIPTION
These are final touches needed for custom viewports script API to work consistently at least.

Historically engine let user supply screen coordinates that lie outside of the game screen (and room viewport). Since there was only single viewport, and coordinate conversion simply subtracted "camera" offset in room, that was not much of a problem (perhaps being only questionable logic).

As we move towards custom viewports, and maybe even multiple viewports, engine can no longer make assumptions on what conversion to do if the coordinates lie outside of any room viewport.

This PR does two things:

1. Every API function that checks for a  room entity (object, character or region) at the given screen coordinates now is restricted by the viewport bounds. If there's no active viewport at them these functions will fail (return "no object found").

Affected functions:
* All of the GetAtScreenXY(x, y)
* IsInteractionAvailable(x, y, mode)
* GetLocationName(x, y)
* GetLocationType(x, y)
* Room.ProcessClick(x, y, mode)

Old behavior is only left for backwards-compatible mode (when the game is compiled using old script API).

2. Makes sure every room entity that has GetAtScreenXY also has GetAtRoomXY (and vice versa).

Following functions are added:
* Character.GetAtRoomXY(x, y)
* Hotspot.GetAtRoomXY(x, y)
* Object.GetAtRoomXY(x, y)
* Region.GetAtScreenXY(x, y)
* GetWalkableAreaAt is renamed to GetWalkableAreaAtScreen, GetWalkableAreaAtRoom is added.

With these functions it is still possible to reach the object in the room from any arbitrary screen coordinates would such need arise, with the condition that you specify actual Viewport "through" which the access is made (so that engine could use correct coordinate conversion). For example:
<pre>
// Gets character through the primary room viewport
Character *GetAtAnyScreenXY(int scrx, int scry)
{
    Point *p = Screen.Viewport.ScreenToRoomPoint(scrx, scry, false); // no viewport clipping
    return Character.GetAtRoomXY(p.x, p.y);
}
</pre>

And ofcourse they allow to test any room coordinate relative to other room object:
<pre>
// Dummy function for testing objects around character
Object *FindObjectsAroundMe(Character this*, int radius, int step)
{
    for (int x = this.x - radius; x < this.x + radius; x += step)
    {
        for (int y = this.y - radius; y < this.y + radius; y += step)
        {
            Object *o = Object.GetAtRoomXY(x, y);
            if (o != null) return o;
        }
    }
    return null;
}
</pre>