### PR TITLE
AGS3: Remove obsolete (possibly broken) input recording/playback

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2555,7 +2555,7 @@ builtin struct GameState {
   int  game_speed_modifier;  // $AUTOCOMPLETEIGNORE$
   int  score_sound;
   int  previous_game_data;
-  int  replay_hotkey;
+  readonly int unused__041; // $AUTOCOMPLETEIGNORE$
   int  dialog_options_x;
   int  dialog_options_y;
   int  narrator_speech;

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -50,6 +50,7 @@
 #include "gfx/ddb.h"
 #include "gfx/gfx_util.h"
 #include "gfx/graphicsdriver.h"
+#include "ac/mouse.h"
 
 using namespace AGS::Common;
 
@@ -626,14 +627,14 @@ void DialogOptions::Show()
     
     update_polled_stuff_if_runtime();
     if (!play.mouse_cursor_hidden)
-      domouse(1);
+      ags_domouse(DOMOUSE_ENABLE);
     update_polled_stuff_if_runtime();
 
     Redraw();
     while(Run());
 
     if (!play.mouse_cursor_hidden)
-      domouse(2);
+      ags_domouse(DOMOUSE_DISABLE);
 }
 
 void DialogOptions::Redraw()
@@ -883,14 +884,14 @@ bool DialogOptions::Run()
             for (unsigned int i = strlen(parserInput->Text); i < strlen(play.lastParserEntry); i++) {
               parserInput->OnKeyPress(play.lastParserEntry[i]);
             }
-            //domouse(2);
+            //ags_domouse(DOMOUSE_DISABLE);
             Redraw();
             return true; // continue running loop
           }
           else if ((gkey >= 32) || (gkey == 13) || (gkey == 8)) {
             parserInput->OnKeyPress(gkey);
             if (!parserInput->IsActivated) {
-              //domouse(2);
+              //ags_domouse(DOMOUSE_DISABLE);
               Redraw();
               return true; // continue running loop
             }
@@ -958,7 +959,7 @@ bool DialogOptions::Run()
           parserActivated = 1;
       }
 
-      int mouseButtonPressed = mgetbutton();
+      int mouseButtonPressed = ags_mgetbutton();
 
       if (mouseButtonPressed != NONE)
       {
@@ -1001,7 +1002,7 @@ bool DialogOptions::Run()
 
       if (usingCustomRendering)
       {
-        int mouseWheelTurn = check_mouse_wheel();
+        int mouseWheelTurn = ags_check_mouse_wheel();
         if (mouseWheelTurn != 0)
         {
             runDialogOptionMouseClickHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
@@ -1029,7 +1030,7 @@ bool DialogOptions::Run()
         }
       }
       if (mousewason != mouseison) {
-        //domouse(2);
+        //ags_domouse(DOMOUSE_DISABLE);
         Redraw();
         return true; // continue running loop
       }
@@ -1053,7 +1054,7 @@ bool DialogOptions::Run()
 
 void DialogOptions::Close()
 {
-  clear_input_buffer();
+  ags_clear_input_buffer();
   //leave_real_screen();
   construct_virtual_screen(true);
 

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -861,7 +861,6 @@ bool DialogOptions::Run()
       else
       {
         timerloop = 0;
-        NEXT_ITERATION();
 
         render_graphics(ddb, dirtyx, dirtyy);
       

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -32,7 +32,7 @@
 #include "ac/overlay.h"
 #include "ac/mouse.h"
 #include "ac/parser.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/string.h"
 #include "ac/dynobj/scriptdialogoptionsrendering.h"
 #include "ac/dynobj/scriptdrawingsurface.h"

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -26,7 +26,7 @@
 #include "ac/gui.h"
 #include "ac/mouse.h"
 #include "ac/overlay.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/screenoverlay.h"
 #include "ac/speech.h"
 #include "ac/string.h"

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -269,7 +269,6 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         int skip_setting = user_to_internal_skip_speech((SkipSpeechStyle)play.skip_display);
         while (1) {
             timerloop = 0;
-            NEXT_ITERATION();
             /*      if (!play.mouse_cursor_hidden)
             domouse(0);
             write_screen();*/

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -41,6 +41,8 @@
 #include "ac/spritecache.h"
 #include "gfx/gfx_util.h"
 #include "util/string_utils.h"
+#include "ac/mouse.h"
+#include "media/audio/soundclip.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;
@@ -258,7 +260,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         remove_screen_overlay(OVER_TEXTMSG);*/
 
         if (!play.mouse_cursor_hidden)
-            domouse(1);
+            ags_domouse(DOMOUSE_ENABLE);
         // play.skip_display has same values as SetSkipSpeech:
         // 0 = click mouse or key to skip
         // 1 = key only
@@ -270,13 +272,13 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         while (1) {
             timerloop = 0;
             /*      if (!play.mouse_cursor_hidden)
-            domouse(0);
+            ags_domouse(DOMOUSE_UPDATE);
             write_screen();*/
 
             render_graphics();
 
             update_polled_audio_and_crossfade();
-            if (mgetbutton()>NONE) {
+            if (ags_mgetbutton()>NONE) {
                 // If we're allowed, skip with mouse
                 if (skip_setting & SKIP_MOUSECLICK)
                     break;
@@ -296,7 +298,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
             if (channels[SCHAN_SPEECH] != NULL) {
                 // extend life of text if the voice hasn't finished yet
-                if ((!rec_isSpeechFinished()) && (play.fast_forward == 0)) {
+                if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
                     if (countdown <= 1)
                         countdown = 1;
                 }
@@ -315,7 +317,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 break;
         }
         if (!play.mouse_cursor_hidden)
-            domouse(2);
+            ags_domouse(DOMOUSE_DISABLE);
         remove_screen_overlay(OVER_TEXTMSG);
 
         construct_virtual_screen(true);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2313,7 +2313,7 @@ void update_screen() {
 
     // update animating mouse cursor
     if (game.mcurs[cur_cursor].view>=0) {
-        domouse (DOMOUSE_NOCURSOR);
+        ags_domouse(DOMOUSE_NOCURSOR);
         // only on mousemove, and it's not moving
         if (((game.mcurs[cur_cursor].flags & MCF_ANIMMOVE)!=0) &&
             (mousex==lastmx) && (mousey==lastmy)) ;
@@ -2372,7 +2372,7 @@ void update_screen() {
         invalidate_sprite(0, 0, debugConsole, false);
     }
 
-    domouse(DOMOUSE_NOCURSOR);
+    ags_domouse(DOMOUSE_NOCURSOR);
 
     if (!play.mouse_cursor_hidden)
     {
@@ -2381,11 +2381,11 @@ void update_screen() {
     }
 
     /*
-    domouse(1);
+    ags_domouse(DOMOUSE_ENABLE);
     // if the cursor is hidden, remove it again. However, it needs
     // to go on-off in order to update the stored mouse coordinates
     if (play.mouse_cursor_hidden)
-    domouse(2);*/
+    ags_domouse(DOMOUSE_DISABLE);*/
 
     write_screen();
 
@@ -2399,7 +2399,7 @@ void update_screen() {
     }
 
     //if (!play.mouse_cursor_hidden)
-    //    domouse(2);
+    //    ags_domouse(DOMOUSE_DISABLE);
 
     screen_is_dirty = false;
 }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -33,7 +33,7 @@
 #include "ac/mouse.h"
 #include "ac/objectcache.h"
 #include "ac/overlay.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
 #include "ac/runtime_defines.h"

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -112,7 +112,6 @@ extern int is_complete_overlay;
 extern int cur_mode,cur_cursor;
 extern int mouse_frame,mouse_delay;
 extern int lastmx,lastmy;
-extern int replay_time;
 extern IDriverDependantBitmap *mouseCursor;
 extern int hotx,hoty;
 extern int bg_just_changed;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -85,6 +85,7 @@
 #include "util/filestream.h" // TODO: needed only because plugins expect file handle
 #include "util/path.h"
 #include "util/string_utils.h"
+#include "ac/mouse.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -333,13 +334,13 @@ void setup_for_dialog() {
     cbuttfont = play.normal_font;
     acdialog_font = play.normal_font;
     if (!play.mouse_cursor_hidden)
-        domouse(1);
+        ags_domouse(DOMOUSE_ENABLE);
     oldmouse=cur_cursor; set_mouse_cursor(CURS_ARROW);
 }
 void restore_after_dialog() {
     set_mouse_cursor(oldmouse);
     if (!play.mouse_cursor_hidden)
-        domouse(2);
+        ags_domouse(DOMOUSE_DISABLE);
     construct_virtual_screen(true);
 }
 
@@ -1696,7 +1697,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
     our_eip = oldeip;
 
     // ensure keyboard buffer is clean
-    clear_input_buffer();
+    ags_clear_input_buffer();
     // call "After Restore" event callback
     run_on_event(GE_RESTORE_GAME, RuntimeScriptValue().SetInt32(slotNumber));
     return HSaveError::None();
@@ -1856,7 +1857,7 @@ int __GetLocationType(int xxx,int yyy, int allowHotspot0) {
 void display_switch_out()
 {
     switched_away = true;
-    clear_input_buffer();
+    ags_clear_input_buffer();
     // Always unlock mouse when switching out from the game
     Mouse::UnlockFromWindow();
     platform->DisplaySwitchOut();
@@ -1903,7 +1904,7 @@ void display_switch_in()
             platform->EnterFullscreenMode(mode);
     }
     platform->DisplaySwitchIn();
-    clear_input_buffer();
+    ags_clear_input_buffer();
     // If auto lock option is set, lock mouse to the game window
     if (usetup.mouse_auto_lock && scsystem.windowed)
         Mouse::TryLockToWindow();

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -42,7 +42,7 @@
 #include "ac/objectcache.h"
 #include "ac/overlay.h"
 #include "ac/path_helper.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/region.h"
 #include "ac/richgamemedia.h"
 #include "ac/room.h"

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1226,9 +1226,6 @@ void restore_game_play_ex_data(Stream *in)
 
 void restore_game_play(Stream *in)
 {
-    // preserve the replay settings
-    int playback_was = play.playback, recording_was = play.recording;
-    int gamestep_was = play.gamestep;
     int screenfadedout_was = play.screen_is_faded_out;
     int roomchanges_was = play.room_changes;
     // make sure the pointer is preserved
@@ -1237,9 +1234,6 @@ void restore_game_play(Stream *in)
     ReadGameState_Aligned(in);
 
     play.screen_is_faded_out = screenfadedout_was;
-    play.playback = playback_was;
-    play.recording = recording_was;
-    play.gamestep = gamestep_was;
     play.room_changes = roomchanges_was;
     play.gui_draw_order = gui_draw_order_was;
 
@@ -1702,9 +1696,7 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
     our_eip = oldeip;
 
     // ensure keyboard buffer is clean
-    // use the raw versions rather than the rec_ versions so we don't
-    // interfere with the replay sync
-    while (keypressed()) readkey();
+    clear_input_buffer();
     // call "After Restore" event callback
     run_on_event(GE_RESTORE_GAME, RuntimeScriptValue().SetInt32(slotNumber));
     return HSaveError::None();

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -291,7 +291,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     game_speed_modifier = in->ReadInt32();
     score_sound = in->ReadInt32();
     takeover_data = in->ReadInt32();
-    replay_hotkey = in->ReadInt32();
+    replay_hotkey_unused = in->ReadInt32();
     dialog_options_x = in->ReadInt32();
     dialog_options_y = in->ReadInt32();
     narrator_speech = in->ReadInt32();
@@ -516,7 +516,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32(game_speed_modifier);
     out->WriteInt32(score_sound);
     out->WriteInt32(takeover_data);
-    out->WriteInt32(replay_hotkey);
+    out->WriteInt32(replay_hotkey_unused);         // StartRecording: not supported
     out->WriteInt32(dialog_options_x);
     out->WriteInt32(dialog_options_y);
     out->WriteInt32(narrator_speech);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -77,7 +77,7 @@ struct GameState {
     int  game_speed_modifier;
     int  score_sound;
     int  takeover_data;  // value passed to RunAGSGame in previous game
-    int  replay_hotkey;
+    int  replay_hotkey_unused;  // (UNUSED!) StartRecording: not supported
     int  dialog_options_x;
     int  dialog_options_y;
     int  narrator_speech;
@@ -120,9 +120,6 @@ struct GameState {
     int  dialog_options_highlight_color; // The colour used for highlighted (hovered over) text in dialog options
     int  reserved[GAME_STATE_RESERVED_INTS];  // make sure if a future version adds a var, it doesn't mess anything up
     // ** up to here is referenced in the script "game." object
-    int   recording;   // user is recording their moves
-    int   playback;    // playing back recording
-    short gamestep;    // step number for matching recordings
     long  randseed;    // random seed
     int   player_on_region;    // player's current region
     int   screen_is_faded_out; // the screen is currently black

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -119,7 +119,9 @@ void script_debug(int cmdd,int dataa) {
         delete tempw;
         delete view_bmp;
         gfxDriver->DestroyDDB(ddb);
-        wait_until_keypress();
+        // Wait until key press
+        while (!ags_kbhit());
+        ags_getch();
         invalidate_screen();
     }
     else if (cmdd==3) 
@@ -177,7 +179,9 @@ void script_debug(int cmdd,int dataa) {
         delete tempw;
         delete view_bmp;
         gfxDriver->DestroyDDB(ddb);
-        wait_until_keypress();
+        // Wait until key press
+        while (!ags_kbhit());
+        ags_getch();
     }
     else if (cmdd == 99)
         ccSetOption(SCOPT_DEBUGRUN, dataa);

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -25,7 +25,7 @@
 #include "ac/global_room.h"
 #include "ac/movelist.h"
 #include "ac/properties.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/tree_map.h"
 #include "ac/walkablearea.h"
 #include "gfx/gfxfilter.h"

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -636,31 +636,31 @@ int IsKeyPressed (int keycode) {
         else if (keycode == 407) keycode = KEY_ALT;
         else keycode -= AGS_EXT_KEY_SHIFT;
 
-        if (rec_iskeypressed(keycode))
+        if (ags_iskeypressed(keycode))
             return 1;
         // deal with numeric pad keys having different codes to arrow keys
-        if ((keycode == KEY_LEFT) && (rec_iskeypressed(KEY_4_PAD) != 0))
+        if ((keycode == KEY_LEFT) && (ags_iskeypressed(KEY_4_PAD) != 0))
             return 1;
-        if ((keycode == KEY_RIGHT) && (rec_iskeypressed(KEY_6_PAD) != 0))
+        if ((keycode == KEY_RIGHT) && (ags_iskeypressed(KEY_6_PAD) != 0))
             return 1;
-        if ((keycode == KEY_UP) && (rec_iskeypressed(KEY_8_PAD) != 0))
+        if ((keycode == KEY_UP) && (ags_iskeypressed(KEY_8_PAD) != 0))
             return 1;
-        if ((keycode == KEY_DOWN) && (rec_iskeypressed(KEY_2_PAD) != 0))
+        if ((keycode == KEY_DOWN) && (ags_iskeypressed(KEY_2_PAD) != 0))
             return 1;
         // PgDn/PgUp are equivalent to 3 and 9 on numeric pad
-        if ((keycode == KEY_9_PAD) && (rec_iskeypressed(KEY_PGUP) != 0))
+        if ((keycode == KEY_9_PAD) && (ags_iskeypressed(KEY_PGUP) != 0))
             return 1;
-        if ((keycode == KEY_3_PAD) && (rec_iskeypressed(KEY_PGDN) != 0))
+        if ((keycode == KEY_3_PAD) && (ags_iskeypressed(KEY_PGDN) != 0))
             return 1;
         // Home/End are equivalent to 7 and 1
-        if ((keycode == KEY_7_PAD) && (rec_iskeypressed(KEY_HOME) != 0))
+        if ((keycode == KEY_7_PAD) && (ags_iskeypressed(KEY_HOME) != 0))
             return 1;
-        if ((keycode == KEY_1_PAD) && (rec_iskeypressed(KEY_END) != 0))
+        if ((keycode == KEY_1_PAD) && (ags_iskeypressed(KEY_END) != 0))
             return 1;
         // insert/delete have numpad equivalents
-        if ((keycode == KEY_INSERT) && (rec_iskeypressed(KEY_0_PAD) != 0))
+        if ((keycode == KEY_INSERT) && (ags_iskeypressed(KEY_0_PAD) != 0))
             return 1;
-        if ((keycode == KEY_DEL) && (rec_iskeypressed(KEY_DEL_PAD) != 0))
+        if ((keycode == KEY_DEL) && (ags_iskeypressed(KEY_DEL_PAD) != 0))
             return 1;
 
         return 0;
@@ -678,7 +678,7 @@ int IsKeyPressed (int keycode) {
         keycode = KEY_TAB;
     else if (keycode == 13) {
         // check both the main return key and the numeric pad enter
-        if (rec_iskeypressed(KEY_ENTER))
+        if (ags_iskeypressed(KEY_ENTER))
             return 1;
         keycode = KEY_ENTER_PAD;
     }
@@ -688,19 +688,19 @@ int IsKeyPressed (int keycode) {
         keycode = KEY_ESC;
     else if (keycode == '-') {
         // check both the main - key and the numeric pad
-        if (rec_iskeypressed(KEY_MINUS))
+        if (ags_iskeypressed(KEY_MINUS))
             return 1;
         keycode = KEY_MINUS_PAD;
     }
     else if (keycode == '+') {
         // check both the main + key and the numeric pad
-        if (rec_iskeypressed(KEY_EQUALS))
+        if (ags_iskeypressed(KEY_EQUALS))
             return 1;
         keycode = KEY_PLUS_PAD;
     }
     else if (keycode == '/') {
         // check both the main / key and the numeric pad
-        if (rec_iskeypressed(KEY_SLASH))
+        if (ags_iskeypressed(KEY_SLASH))
             return 1;
         keycode = KEY_SLASH_PAD;
     }
@@ -725,7 +725,7 @@ int IsKeyPressed (int keycode) {
         return 0;
     }
 
-    if (rec_iskeypressed(keycode))
+    if (ags_iskeypressed(keycode))
         return 1;
     return 0;
 #else

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -35,7 +35,7 @@
 #include "ac/mouse.h"
 #include "ac/object.h"
 #include "ac/path_helper.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/room.h"
 #include "ac/roomstatus.h"
 #include "ac/string.h"

--- a/Engine/ac/global_record.cpp
+++ b/Engine/ac/global_record.cpp
@@ -16,5 +16,5 @@
 #include "ac/common.h"
 
 void scStartRecording (int keyToStop) {
-    quit("!StartRecording: not et suppotreD");
+    quit("!StartRecording: not supported");
 }

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -283,7 +283,7 @@ int InventoryScreen::Redraw()
 
     Bitmap *ds = prepare_gui_screen(windowxp, windowyp, windowwid, windowhit, true);
     Draw(ds);
-    //domouse(1);
+    //ags_domouse(DOMOUSE_ENABLE);
     set_mouse_cursor(cmode);
     wasonitem = -1;
     return 0;
@@ -346,14 +346,14 @@ void InventoryScreen::RedrawOverItem(Bitmap *ds, int isonitem)
 
 bool InventoryScreen::Run()
 {
-    if (kbhit() != 0)
+    if (ags_kbhit() != 0)
     {
         return false; // end inventory screen loop
     }
 
         timerloop = 0;
         refresh_gui_screen();
-        //domouse(0);
+        //ags_domouse(DOMOUSE_UPDATE);
         update_polled_audio_and_crossfade();
 
         // NOTE: this is because old code was working with full game screen
@@ -366,7 +366,7 @@ bool InventoryScreen::Run()
         if ((isonitem<0) | (isonitem>=numitems) | (isonitem >= top_item + num_visible_items))
             isonitem=-1;
 
-        int mclick = mgetbutton();
+        int mclick = ags_mgetbutton();
         if (mclick == LEFT) {
             if ((mousey<0) | (mousey>windowhit) | (mousex<0) | (mousex>windowwid))
                 return true; // continue inventory screen loop
@@ -377,7 +377,7 @@ bool InventoryScreen::Run()
                 play.used_inv_on = dii[clickedon].num;
 
                 if (cmode==MODE_LOOK) {
-                    //domouse(2);
+                    //ags_domouse(DOMOUSE_DISABLE);
                     run_event_block_inv(dii[clickedon].num, 0); 
                     // in case the script did anything to the screen, redraw it
                     UpdateGameOnce();
@@ -393,7 +393,7 @@ bool InventoryScreen::Run()
                     int activeinvwas = playerchar->activeinv;
                     playerchar->activeinv = toret;
 
-                    //domouse(2);
+                    //ags_domouse(DOMOUSE_DISABLE);
                     run_event_block_inv(dii[clickedon].num, 3);
 
                     // if the script didn't change it, then put it back
@@ -427,7 +427,7 @@ bool InventoryScreen::Run()
                     if (mousey < buttonyp + get_fixed_pixel_size(2) + ARROWBUTTONWID) {
                         if (top_item > 0) {
                             top_item -= ICONSPERLINE;
-                            //domouse(2);
+                            //ags_domouse(DOMOUSE_DISABLE);
 
                             break_code = Redraw();
                             return break_code == 0;
@@ -435,7 +435,7 @@ bool InventoryScreen::Run()
                     }
                     else if ((mousey < buttonyp + get_fixed_pixel_size(4) + ARROWBUTTONWID*2) && (top_item + num_visible_items < numitems)) {
                         top_item += ICONSPERLINE;
-                        //domouse(2);
+                        //ags_domouse(DOMOUSE_DISABLE);
                         
                         break_code = Redraw();
                         return break_code == 0;
@@ -466,9 +466,9 @@ bool InventoryScreen::Run()
         }
         else if (isonitem!=wasonitem)
         {
-            //domouse(2);
+            //ags_domouse(DOMOUSE_DISABLE);
             RedrawOverItem(get_gui_screen(), isonitem);
-            //domouse(1);
+            //ags_domouse(DOMOUSE_ENABLE);
         }
         wasonitem=isonitem;
         PollUntilNextFrame();
@@ -480,7 +480,7 @@ void InventoryScreen::Close()
 {
     clear_gui_screen();
     set_default_cursor();
-    //domouse(2);
+    //ags_domouse(DOMOUSE_DISABLE);
     construct_virtual_screen(true);
     in_inv_screen--;
 }
@@ -501,7 +501,7 @@ int __actual_invscreen()
         return InvScr.break_code;
     }
 
-    clear_input_buffer();
+    ags_clear_input_buffer();
 
     InvScr.Close();
     return InvScr.toret;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -24,7 +24,7 @@
 #include "ac/global_display.h"
 #include "ac/global_room.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "debug/debug_log.h"
 #include "gui/guidialog.h"
 #include "main/game_run.h"

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -352,7 +352,6 @@ bool InventoryScreen::Run()
     }
 
         timerloop = 0;
-        NEXT_ITERATION();
         refresh_gui_screen();
         //domouse(0);
         update_polled_audio_and_crossfade();

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -34,6 +34,10 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxfilter.h"
 
+#ifdef __AGS_EE_AC__RECORD_H
+#error "Can't include record.h since we're interacting with mouse api directly"
+#endif
+
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
@@ -44,6 +48,9 @@ extern Bitmap *mousecurs[MAXCURSORS];
 extern SpriteCache spriteset;
 extern CharacterInfo*playerchar;
 extern IGraphicsDriver *gfxDriver;
+
+extern void ags_domouse(int str);
+extern int misbuttondown(int buno);
 
 ScriptMouse scmouse;
 int cur_mode,cur_cursor;
@@ -264,7 +271,7 @@ void disable_cursor_mode(int modd) {
 }
 
 void RefreshMouse() {
-    domouse(DOMOUSE_NOCURSOR);
+    ags_domouse(DOMOUSE_NOCURSOR);
     scmouse.x = divide_down_coordinate(mousex);
     scmouse.y = divide_down_coordinate(mousey);
 }

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -34,10 +34,6 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxfilter.h"
 
-#ifdef __AGS_EE_AC__RECORD_H
-#error "Can't include record.h since we're interacting with mouse api directly"
-#endif
-
 using namespace AGS::Common;
 using namespace AGS::Engine;
 

--- a/Engine/ac/mouse.h
+++ b/Engine/ac/mouse.h
@@ -20,6 +20,9 @@
 
 #include "ac/dynobj/scriptmouse.h"
 
+#define DOMOUSE_UPDATE 0
+#define DOMOUSE_ENABLE 1
+#define DOMOUSE_DISABLE 2
 #define DOMOUSE_NOCURSOR 5
 // are these mouse buttons? ;/
 // note: also defined in ac_cscidialog as const ints

--- a/Engine/ac/record.cpp
+++ b/Engine/ac/record.cpp
@@ -12,6 +12,8 @@
 //
 //=============================================================================
 
+// TODO: ags3--remove-record  : move into a different spot. input.cpp ? input_Events?  sys_events?
+
 #include "ac/common.h"
 #include "media/audio/audiodefines.h"
 #include "ac/gamesetupstruct.h"
@@ -34,42 +36,32 @@ extern int pluginSimulatedClick;
 extern int displayed_room;
 extern char check_dynamic_sprites_at_exit;
 
+extern void domouse(int str);
+extern int mgetbutton();
+extern int misbuttondown(int buno);
+
 int mouse_z_was = 0;
 
-int rec_getch () {
-    int result = my_readkey();
-    return result;  
-}
-
-int rec_kbhit () {
+int ags_kbhit () {
     int result = keypressed();
     if ((result) && (globalTimerCounter < play.ignore_user_input_until_time))
     {
         // ignoring user input
-        my_readkey();
+        ags_getch();
         result = 0;
     }
     return result;  
 }
 
-int rec_iskeypressed (int keycode) {
-    int toret = key[keycode];
-    return toret;
+int ags_iskeypressed (int keycode) {
+    return key[keycode];
 }
 
-int rec_isSpeechFinished () {
-    if (!channels[SCHAN_SPEECH]->done) {
-        return 0;
-    }
-    return 1;
+int ags_misbuttondown (int but) {
+    return misbuttondown(but);
 }
 
-int rec_misbuttondown (int but) {
-    int result = misbuttondown (but);
-    return result;
-}
-
-int rec_mgetbutton() {
+int ags_mgetbutton() {
     int result;
 
     if (pluginSimulatedClick > NONE) {
@@ -89,14 +81,15 @@ int rec_mgetbutton() {
     return result;
 }
 
-void rec_domouse (int what) {
+void ags_domouse (int what) {
+    // do mouse is "update the mouse x,y and also the cursor position", unless DOMOUSE_NOCURSOR is set.
     if (what == DOMOUSE_NOCURSOR)
         mgetgraphpos();
     else
         domouse(what);
 }
 
-int check_mouse_wheel () {
+int ags_check_mouse_wheel () {
     int result = 0;
     if ((mouse_z != mouse_z_was) && (game.options[OPT_MOUSEWHEEL] != 0)) {
         if (mouse_z > mouse_z_was)
@@ -108,7 +101,7 @@ int check_mouse_wheel () {
     return result;
 }
 
-int my_readkey() {
+int ags_getch() {
     int gott=readkey();
     int scancode = ((gott >> 8) & 0x00ff);
 
@@ -192,14 +185,8 @@ int my_readkey() {
     return gott;
 }
 
-void clear_input_buffer()
+void ags_clear_input_buffer()
 {
-    while (rec_kbhit()) rec_getch();
+    while (ags_kbhit()) ags_getch();
     while (mgetbutton() != NONE);
-}
-
-void wait_until_keypress()
-{
-    while (!rec_kbhit());
-    rec_getch();
 }

--- a/Engine/ac/record.h
+++ b/Engine/ac/record.h
@@ -18,29 +18,20 @@
 #ifndef __AGS_EE_AC__RECORD_H
 #define __AGS_EE_AC__RECORD_H
 
-// If this is defined for record unit it will cause endless recursion!
-#ifndef IS_RECORD_UNIT
-#undef kbhit
-#define mgetbutton rec_mgetbutton
-#define domouse rec_domouse
-#define misbuttondown rec_misbuttondown
-#define kbhit rec_kbhit
-#define getch rec_getch
-#endif
+#pragma GCC poison kbhit rec_kbhit  rec_mgetbutton rec_domouse  rec_misbuttondown getch rec_getch
+#pragma GCC poison check_mouse_wheel clear_input_buffer wait_until_keypress  rec_isSpeechFinished rec_iskeypressed
+// #pragma GCC poison domouse mgetbutton misbuttondown
 
-int  rec_getch ();
-int  rec_kbhit ();
-int  rec_iskeypressed (int keycode);
-int  rec_isSpeechFinished ();
-int  rec_misbuttondown (int but);
-int  rec_mgetbutton();
-void rec_domouse (int what);
-int  check_mouse_wheel ();
-int  my_readkey();
+int  ags_getch ();
+int  ags_kbhit ();
+int  ags_iskeypressed (int keycode);
+
+int  ags_misbuttondown (int but);
+int  ags_mgetbutton();
+void ags_domouse (int what);
+int  ags_check_mouse_wheel ();
+
 // Clears buffered keypresses and mouse clicks, if any
-void clear_input_buffer();
-// Suspends the game until user keypress
-// TODO: this function should not normally exist; need to rewrite update loop to support different states
-void wait_until_keypress();
+void ags_clear_input_buffer();
 
 #endif // __AGS_EE_AC__RECORD_H

--- a/Engine/ac/record.h
+++ b/Engine/ac/record.h
@@ -18,16 +18,6 @@
 #ifndef __AGS_EE_AC__RECORD_H
 #define __AGS_EE_AC__RECORD_H
 
-#define REC_MOUSECLICK 1
-#define REC_MOUSEMOVE  2
-#define REC_MOUSEDOWN  3
-#define REC_KBHIT      4
-#define REC_GETCH      5
-#define REC_KEYDOWN    6
-#define REC_MOUSEWHEEL 7
-#define REC_SPEECHFINISHED 8
-#define REC_ENDOFFILE  0x6f
-
 // If this is defined for record unit it will cause endless recursion!
 #ifndef IS_RECORD_UNIT
 #undef kbhit
@@ -38,9 +28,6 @@
 #define getch rec_getch
 #endif
 
-void write_record_event (int evnt, int dlen, short *dbuf);
-void disable_replay_playback ();
-void done_playback_event (int size);
 int  rec_getch ();
 int  rec_kbhit ();
 int  rec_iskeypressed (int keycode);
@@ -49,10 +36,6 @@ int  rec_misbuttondown (int but);
 int  rec_mgetbutton();
 void rec_domouse (int what);
 int  check_mouse_wheel ();
-void start_recording();
-void start_replay_record ();
-void stop_recording();
-void start_playback();
 int  my_readkey();
 // Clears buffered keypresses and mouse clicks, if any
 void clear_input_buffer();

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -871,7 +871,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     play.gscript_timer=-1;  // avoid screw-ups with changing screens
     play.player_on_region = 0;
     // trash any input which they might have done while it was loading
-    clear_input_buffer();
+    ags_clear_input_buffer();
     // no fade in, so set the palette immediately in case of 256-col sprites
     if (game.color_depth > 1)
         setpal();

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -33,7 +33,7 @@
 #include "ac/overlay.h"
 #include "ac/properties.h"
 #include "ac/region.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/room.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -130,8 +130,6 @@ const int LegacyRoomVolumeFactor            = 30;
 
 #define MAX_PLUGIN_OBJECT_READERS 50
 
-#define NEXT_ITERATION() play.gamestep++
-
 #ifndef MAX_PATH
 #define MAX_PATH 260
 #endif

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -12,15 +12,13 @@
 //
 //=============================================================================
 
-// TODO: ags3--remove-record  : move into a different spot. input.cpp ? input_Events?  sys_events?
-
 #include "ac/common.h"
 #include "media/audio/audiodefines.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/keycode.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "media/audio/soundclip.h"
 #include "device/mousew32.h"
 

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -15,12 +15,8 @@
 //
 //
 //=============================================================================
-#ifndef __AGS_EE_AC__RECORD_H
-#define __AGS_EE_AC__RECORD_H
-
-#pragma GCC poison kbhit rec_kbhit  rec_mgetbutton rec_domouse  rec_misbuttondown getch rec_getch
-#pragma GCC poison check_mouse_wheel clear_input_buffer wait_until_keypress  rec_isSpeechFinished rec_iskeypressed
-// #pragma GCC poison domouse mgetbutton misbuttondown
+#ifndef __AGS_EE_AC__SYS_EVENTS_H
+#define __AGS_EE_AC__SYS_EVENTS_H
 
 int  ags_getch ();
 int  ags_kbhit ();
@@ -34,4 +30,4 @@ int  ags_check_mouse_wheel ();
 // Clears buffered keypresses and mouse clicks, if any
 void ags_clear_input_buffer();
 
-#endif // __AGS_EE_AC__RECORD_H
+#endif // __AGS_EE_AC__SYS_EVENTS_H

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -46,6 +46,10 @@
 #include "ac/global_game.h" // j for IsKeyPressed
 #endif
 
+#ifdef __AGS_EE_AC__RECORD_H
+#error "Can't include record.h since we're interacting with mouse api directly"
+#endif
+
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
@@ -232,12 +236,7 @@ void mfreemem()
   }
 }
 
-void mnewcursor(char cursno)
-{
-  domouse(2);
-  currentcursor = cursno;
-  domouse(1);
-}
+
 
 
 void mloadwcursor(char *namm)

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -46,10 +46,6 @@
 #include "ac/global_game.h" // j for IsKeyPressed
 #endif
 
-#ifdef __AGS_EE_AC__RECORD_H
-#error "Can't include record.h since we're interacting with mouse api directly"
-#endif
-
 using namespace AGS::Common;
 using namespace AGS::Engine;
 

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -37,13 +37,9 @@ void mgetgraphpos();
 // Sets the area of the game frame (zero-based coordinates) where the mouse cursor is allowed to move;
 // this function was meant to be used to achieve gameplay effect
 void msetcursorlimit(int x1, int y1, int x2, int y2);
-void domouse(int str);
 int ismouseinbox(int lf, int tp, int rt, int bt);
 void mfreemem();
-void mnewcursor(char cursno);
 void mloadwcursor(char *namm);
-int mgetbutton();
-int misbuttondown(int buno);
 void msetgraphpos(int xa, int ya);
 void msethotspot(int xx, int yy);
 int minstalled();

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -105,7 +105,7 @@ int CSCIDrawWindow(int xx, int yy, int wid, int hit)
         quit("Too many windows created.");
 
     windowcount++;
-    //  domouse(2);
+    //  ags_domouse(DOMOUSE_DISABLE);
     xx -= 2;
     yy -= 2;
     wid += 4;
@@ -114,7 +114,7 @@ int CSCIDrawWindow(int xx, int yy, int wid, int hit)
     oswi[drawit].x = xx;
     oswi[drawit].y = yy;
     __my_wbutt(ds, 0, 0, wid - 1, hit - 1);    // wbutt goes outside its area
-    //  domouse(1);
+    //  ags_domouse(DOMOUSE_ENABLE);
     oswi[drawit].oldtop = topwindowhandle;
     topwindowhandle = drawit;
     oswi[drawit].handle = topwindowhandle;
@@ -127,11 +127,11 @@ int CSCIDrawWindow(int xx, int yy, int wid, int hit)
 
 void CSCIEraseWindow(int handl)
 {
-    //  domouse(2);
+    //  ags_domouse(DOMOUSE_DISABLE);
     ignore_bounds--;
     topwindowhandle = oswi[handl].oldtop;
     oswi[handl].handle = -1;
-    //  domouse(1);
+    //  ags_domouse(DOMOUSE_ENABLE);
     windowcount--;
     clear_gui_screen();
 }
@@ -140,9 +140,9 @@ int CSCIWaitMessage(CSCIMessage * cscim)
 {
     for (int uu = 0; uu < MAXCONTROLS; uu++) {
         if (vobjs[uu] != NULL) {
-            //      domouse(2);
+            //      ags_domouse(DOMOUSE_DISABLE);
             vobjs[uu]->drawifneeded();
-            //      domouse(1);
+            //      ags_domouse(DOMOUSE_ENABLE);
         }
     }
 
@@ -175,7 +175,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
             }
         }
 
-        if (rec_mgetbutton() != NONE) {
+        if (ags_mgetbutton() != NONE) {
             if (checkcontrols()) {
                 cscim->id = controlid;
                 cscim->code = CM_COMMAND;
@@ -229,9 +229,9 @@ int CSCICreateControl(int typeandflags, int xx, int yy, int wii, int hii, const 
 
     vobjs[usec]->typeandflags = typeandflags;
     vobjs[usec]->wlevel = topwindowhandle;
-    //  domouse(2);
+    //  ags_domouse(DOMOUSE_DISABLE);
     vobjs[usec]->draw( get_gui_screen() );
-    //  domouse(1);
+    //  ags_domouse(DOMOUSE_ENABLE);
     return usec;
 }
 

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -138,7 +138,6 @@ void CSCIEraseWindow(int handl)
 
 int CSCIWaitMessage(CSCIMessage * cscim)
 {
-    NextIteration();
     for (int uu = 0; uu < MAXCONTROLS; uu++) {
         if (vobjs[uu] != NULL) {
             //      domouse(2);
@@ -151,7 +150,6 @@ int CSCIWaitMessage(CSCIMessage * cscim)
 
     while (1) {
         timerloop = 0;
-        NextIteration();
         refresh_gui_screen();
 
         cscim->id = -1;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -21,7 +21,7 @@
 #include "ac/gui.h"
 #include "ac/keycode.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/runtime_defines.h"
 #include "font/fonts.h"
 #include "gui/cscidialog.h"

--- a/Engine/gui/guidialoginternaldefs.h
+++ b/Engine/gui/guidialoginternaldefs.h
@@ -19,7 +19,6 @@
 #define __AGS_EE_GUI__GUIDIALOGINTERNALDEFS_H
 
 #include "gui/guidialogdefines.h"
-#include "ac/record.h"
 
 #if !defined (WINDOWS_VERSION)
 #define _getcwd getcwd
@@ -30,7 +29,8 @@
 #undef WINAPI
 #endif
 #define WINAPI
-#define mbutrelease(X) (!rec_misbuttondown(X))
+extern int ags_misbuttondown (int but);
+#define mbutrelease(X) (!ags_misbuttondown(X))
 #define TEXT_HT usetup.textheight
 
 #endif // __AGS_EE_GUI__GUIDIALOGINTERNALDEFS_H

--- a/Engine/gui/mylistbox.cpp
+++ b/Engine/gui/mylistbox.cpp
@@ -118,9 +118,9 @@ extern int smcode;
 
     }
 
-//    domouse(2);
+//    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-  //  domouse(1);
+  //  ags_domouse(DOMOUSE_ENABLE);
     smcode = CM_SELCHANGE;
     return 0;
   }

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -79,7 +79,6 @@ int MyPushButton::pressedon(int mousex, int mousey)
     while (mbutrelease(LEFT) == 0) {
         timerloop = 0;
         wasstat = state;
-        NextIteration();
         state = mouseisinarea(mousex, mousey);
         // stop mp3 skipping if button held down
         update_polled_stuff_if_runtime();

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -16,7 +16,6 @@
 #include "util/wgt2allg.h"
 #include "ac/common.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
 #include "font/fonts.h"
 #include "gui/mypushbutton.h"
 #include "gui/guidialog.h"
@@ -83,12 +82,12 @@ int MyPushButton::pressedon(int mousex, int mousey)
         // stop mp3 skipping if button held down
         update_polled_stuff_if_runtime();
         if (wasstat != state) {
-            //        domouse(2);
+            //        ags_domouse(DOMOUSE_DISABLE);
             draw(get_gui_screen());
-            //domouse(1);
+            //ags_domouse(DOMOUSE_ENABLE);
         }
 
-        //      domouse(0);
+        //      ags_domouse(DOMOUSE_UPDATE);
 
         refresh_gui_screen();
 
@@ -96,9 +95,9 @@ int MyPushButton::pressedon(int mousex, int mousey)
     }
     wasstat = state;
     state = 0;
-    //    domouse(2);
+    //    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-    //  domouse(1);
+    //  ags_domouse(DOMOUSE_ENABLE);
     return wasstat;
 }
 

--- a/Engine/gui/newcontrol.cpp
+++ b/Engine/gui/newcontrol.cpp
@@ -54,7 +54,7 @@ void NewControl::drawifneeded()
 }
 void NewControl::drawandmouse()
 {
-    //    domouse(2);
+    //    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-    //  domouse(1);
+    //  ags_domouse(DOMOUSE_ENABLE);
 }

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -42,7 +42,6 @@ extern GameSetup usetup;
 extern SpriteCache spriteset;
 extern int force_window;
 extern char psp_translation[];
-extern char replayfile[MAX_PATH];
 extern GameState play;
 
 // Filename of the default config file, the one found in the game installation
@@ -477,14 +476,6 @@ void apply_config(const ConfigTree &cfg)
         // the config file specifies cache size in KB, here we convert it to bytes
         spriteset.SetMaxCacheSize(INIreadint (cfg, "misc", "cachemax", DEFAULTCACHESIZE / 1024) * 1024);
 #endif
-
-        String repfile = INIreadstring(cfg, "misc", "replay");
-        if (repfile != NULL) {
-            strcpy (replayfile, repfile);
-            play.playback = 1;
-        }
-        else
-            play.playback = 0;
 
         usetup.mouse_auto_lock = INIreadint(cfg, "mouse", "auto_lock") > 0;
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -32,7 +32,7 @@
 #include "ac/lipsync.h"
 #include "ac/objectcache.h"
 #include "ac/path_helper.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/roomstatus.h"
 #include "ac/speech.h"
 #include "ac/translation.h"

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1582,7 +1582,7 @@ bool engine_try_switch_windowed_gfxmode()
             init_desktop = get_desktop_size();
         engine_post_gfxmode_setup(init_desktop);
     }
-    clear_input_buffer();
+    ags_clear_input_buffer();
     return res;
 }
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -82,7 +82,6 @@ extern ViewStruct*views;
 extern int displayed_room;
 extern int eip_guinum;
 extern int eip_guiobj;
-extern const char *replayTempFile;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScriptSystem scsystem;
@@ -437,7 +436,6 @@ int engine_check_memory()
         return EXIT_NORMAL;
     }
     free(memcheck);
-    unlink (replayTempFile);
     return RETURN_CONTINUE;
 }
 
@@ -1136,7 +1134,7 @@ void engine_init_game_settings()
     play.speech_music_drop = 60;
     play.room_changes = 0;
     play.check_interaction_only = 0;
-    play.replay_hotkey = 318;  // Alt+R
+    play.replay_hotkey_unused = -1;  // StartRecording: not supported.
     play.dialog_options_x = 0;
     play.dialog_options_y = 0;
     play.min_dialogoption_width = 0;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -76,7 +76,6 @@ extern GameState play;
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern int cur_mode;
 extern RoomObject*objs;
-extern int replay_start_this_time;
 extern char noWalkBehindsAtAll;
 extern RoomStatus*croom;
 extern CharacterExtras *charextra;
@@ -360,9 +359,6 @@ void check_keyboard_controls()
         return;
     // Now check for in-game controls
     {
-        // in case they press the finish-recording button, make sure we know
-        int was_playing = play.playback;
-        
         //    if (kgn==367) restart_game();
         //    if (kgn==2) Display("numover: %d character movesped: %d, animspd: %d",numscreenover,playerchar->walkspeed,playerchar->animspeed);
         //    if (kgn==2) CreateTextOverlay(50,60,170,FONT_SPEECH,14,"This is a test screen overlay which shouldn't disappear");
@@ -371,16 +367,6 @@ void check_keyboard_controls()
         //if (kgn == 2) SetCharacterIdle (game.playercharacter, 5, 0);
         //if (kgn == 2) Display("Some for?ign text");
         //if (kgn == 2) do_conversation(5);
-
-        if (kgn == play.replay_hotkey) {
-            // start/stop recording
-            if (play.recording)
-                stop_recording();
-            else if ((play.playback) || (was_playing))
-                ;  // do nothing (we got the replay of the stop key)
-            else
-                replay_start_this_time = 1;
-        }
 
         check_skip_cutscene_keypress (kgn);
 
@@ -519,7 +505,6 @@ void check_keyboard_controls()
 // check_controls: checks mouse & keyboard interface
 void check_controls() {
     our_eip = 1007;
-    NEXT_ITERATION();
 
     check_mouse_controls();
     check_keyboard_controls();
@@ -684,14 +669,6 @@ void game_loop_update_loop_counter()
     }
 }
 
-void game_loop_check_replay_record()
-{
-    if (replay_start_this_time) {
-        replay_start_this_time = 0;
-        start_replay_record();
-    }
-}
-
 void game_loop_update_fps()
 {
     if (time(NULL) != t1) {
@@ -778,8 +755,6 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
     game_loop_update_background_animation();
 
     game_loop_update_loop_counter();
-
-    game_loop_check_replay_record();
 
     // Immediately start the next frame if we are skipping a cutscene
     if (play.fast_forward)
@@ -937,11 +912,6 @@ void GameLoopUntilEvent(int untilwhat,long daaa) {
   restrict_until = cached_restrict_until;
   user_disabled_data = cached_user_disabled_data;
   user_disabled_for = cached_user_disabled_for;
-}
-
-// for external modules to call
-void NextIteration() {
-    NEXT_ITERATION();
 }
 
 extern unsigned int load_new_game;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -34,7 +34,7 @@
 #include "ac/keycode.h"
 #include "ac/mouse.h"
 #include "ac/overlay.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/room.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -215,15 +215,15 @@ void check_mouse_controls()
     // check mouse clicks on GUIs
     static int wasbutdown=0,wasongui=0;
 
-    if ((wasbutdown>0) && (misbuttondown(wasbutdown-1))) {
+    if ((wasbutdown>0) && (ags_misbuttondown(wasbutdown-1))) {
         gui_on_mouse_hold(wasongui, wasbutdown);
     }
-    else if ((wasbutdown>0) && (!misbuttondown(wasbutdown-1))) {
+    else if ((wasbutdown>0) && (!ags_misbuttondown(wasbutdown-1))) {
         gui_on_mouse_up(wasongui, wasbutdown);
         wasbutdown=0;
     }
 
-    int mbut =mgetbutton();
+    int mbut = ags_mgetbutton();
     if (mbut>NONE) {
         lock_mouse_on_click();
 
@@ -254,7 +254,7 @@ void check_mouse_controls()
         else setevent(EV_TEXTSCRIPT,TS_MCLICK,mbut+1);
         //    else RunTextScriptIParam(gameinst,"on_mouse_click",aa+1);
     }
-    mbut = check_mouse_wheel();
+    mbut = ags_check_mouse_wheel();
     if (mbut !=0)
         lock_mouse_on_click();
     if (mbut < 0)
@@ -292,7 +292,7 @@ bool run_service_key_controls(int &kgn)
     static int old_key_shifts = 0; // for saving shift modes
 
     bool handled = false;
-    int kbhit_res = kbhit();
+    int kbhit_res = ags_kbhit();
     // First, check shifts
     const int act_shifts = get_active_shifts();
     // If shifts combination have already triggered an action, then do nothing
@@ -333,9 +333,9 @@ bool run_service_key_controls(int &kgn)
     if (!kbhit_res || handled)
         return false;
 
-    int keycode = getch();
+    int keycode = ags_getch();
     if (keycode == 0)
-        keycode = getch() + AGS_EXT_KEY_SHIFT;
+        keycode = ags_getch() + AGS_EXT_KEY_SHIFT;
 
     // LAlt or RAlt + Enter
     // NOTE: for some reason LAlt + Enter produces same code as F9
@@ -749,7 +749,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     our_eip=7;
 
-    //    if (mgetbutton()>NONE) break;
+    //    if (ags_mgetbutton()>NONE) break;
     update_polled_stuff_if_runtime();
 
     game_loop_update_background_animation();

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -23,8 +23,6 @@ using namespace AGS::Engine; // FIXME later
 
 // Loops game frames until certain event takes place (for blocking actions)
 void GameLoopUntilEvent(int untilwhat,long daaa);
-// Increases game frame count; used for recording/replay only
-void NextIteration();
 // Polls audio until the end of current game frame
 void PollUntilNextFrame();
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -23,7 +23,6 @@
 #include "ac/gamestate.h"
 #include "ac/global_game.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
 #include "ac/room.h"
 #include "ac/screen.h"
 #include "debug/debug_log.h"
@@ -48,19 +47,6 @@ extern std::vector<ccInstance *> moduleInst;
 extern int numScriptModules;
 extern CharacterInfo*playerchar;
 extern int convert_16bit_bgr;
-
-
-void start_game_check_replay()
-{
-    Debug::Printf("Checking replay status");
-
-    if (play.recording) {
-        start_recording();
-    }
-    else if (play.playback) {
-        start_playback();
-    }
-}
 
 void start_game_init_editor_debugging()
 {
@@ -148,11 +134,8 @@ void initialize_start_and_play_game(int override_start_room, const char *loadSav
         }
 
         srand (play.randseed);
-        play.gamestep = 0;
         if (override_start_room)
             playerchar->room = override_start_room;
-
-        start_game_check_replay();
 
         Debug::Printf(kDbgMsg_Init, "Engine initialization complete");
         Debug::Printf(kDbgMsg_Init, "Starting game");

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -113,8 +113,6 @@ void main_pre_init()
 {
     our_eip = -999;
     Common::AssetManager::SetSearchPriority(Common::kAssetPriorityDir);
-    play.recording = 0;
-    play.playback = 0;
     play.takeover_data = 0;
 }
 
@@ -227,10 +225,6 @@ int main_process_cmdline(int argc,char*argv[])
             force_window = 1;
         else if (stricmp(argv[ee],"-fullscreen") == 0 || stricmp(argv[ee],"--fullscreen") == 0)
             force_window = 2;
-        else if (stricmp(argv[ee],"-record") == 0)
-            play.recording = 1;
-        else if (stricmp(argv[ee],"-playback") == 0)
-            play.playback = 1;
         else if ((stricmp(argv[ee],"-gfxfilter") == 0 || stricmp(argv[ee],"--gfxfilter") == 0) && (argc > ee + 1))
         {
             // TODO: we make an assumption here that if user provides scaling factor,

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -19,7 +19,6 @@
 #include "ac/cdaudio.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
-#include "ac/record.h"
 #include "ac/roomstatus.h"
 #include "ac/translation.h"
 #include "debug/agseditordebugger.h"
@@ -267,8 +266,6 @@ void quit(const char *quitmsg)
     quit_tell_editor_debugger(qmsg, qreason);
 
     our_eip = 9900;
-
-    stop_recording();
 
     quit_stop_cd();
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -255,7 +255,7 @@ void update_speech_and_messages()
     play.messagetime--;
     // extend life of text if the voice hasn't finished yet
     if (is_voice && !play.speech_in_post_state) {
-      if ((!rec_isSpeechFinished()) && (play.fast_forward == 0)) {
+      if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
       //if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
         if (play.messagetime <= 1)
           play.messagetime = 1;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -25,7 +25,7 @@
 #include "ac/global_character.h"
 #include "ac/lipsync.h"
 #include "ac/overlay.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
 #include "main/mainheader.h"

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -62,7 +62,6 @@ Bitmap *fli_target = NULL;
 int fliTargetWidth, fliTargetHeight;
 int check_if_user_input_should_cancel_video()
 {
-    NEXT_ITERATION();
     int key;
     if (run_service_key_controls(key)) {
         if ((key==27) && (canabort==1))

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -24,7 +24,7 @@
 #include "ac/gamestate.h"
 #include "ac/global_display.h"
 #include "ac/mouse.h"
-#include "ac/record.h"
+#include "ac/sys_events.h"
 #include "ac/runtime_defines.h"
 #include "ac/system.h"
 #include "core/assetmanager.h"

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -70,7 +70,7 @@ int check_if_user_input_should_cancel_video()
             return 1;  // skip on any key
     }
     if (canabort == 3) {  // skip on mouse click
-        if (mgetbutton()!=NONE) return 1;
+        if (ags_mgetbutton()!=NONE) return 1;
     }
     return 0;
 }
@@ -214,7 +214,7 @@ void play_flc_file(int numb,int playflags) {
     delete hicol_buf;
     hicol_buf=NULL;
     //  SetVirtualScreen(screen); wputblock(0,0,backbuffer,0);
-    while (mgetbutton()!=NONE) ;
+    while (ags_mgetbutton()!=NONE) ;
     invalidate_screen();
 }
 

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -41,7 +41,6 @@ using namespace AGS::Engine;
 extern void update_polled_audio_and_crossfade();
 extern void update_polled_stuff_if_runtime();
 extern int rec_mgetbutton();
-extern void NextIteration();
 extern void update_music_volume();
 extern int crossFading, crossFadeStep;
 extern volatile char want_exit;
@@ -384,7 +383,6 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
 
     while (currentlyPaused) ;
 
-    NextIteration();
     RenderToSurface(vscreen);
     //Sleep(0);
     int key;

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -40,7 +40,7 @@ using namespace AGS::Engine;
 
 extern void update_polled_audio_and_crossfade();
 extern void update_polled_stuff_if_runtime();
-extern int rec_mgetbutton();
+extern int ags_mgetbutton();
 extern void update_music_volume();
 extern int crossFading, crossFadeStep;
 extern volatile char want_exit;
@@ -392,7 +392,7 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
       if (canskip >= 2)
         break;
     }
-    if ((rec_mgetbutton() >= 0) && (canskip == 3))
+    if ((ags_mgetbutton() >= 0) && (canskip == 3))
       break;
   }
 

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -68,7 +68,6 @@ extern void update_polled_audio_and_crossfade();
 extern volatile char want_exit;
 extern volatile int timerloop;
 extern char lastError[300];
-extern void NextIteration();
 CVMR9Graph *graph = NULL;
 
 void dxmedia_shutdown_3d()
@@ -118,7 +117,6 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
     if (!useAVISound)
       update_polled_audio_and_crossfade();
 
-    NextIteration();
     filterState = graph->GetState();
 
     int key;

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -63,7 +63,7 @@ inline LPWSTR WINAPI AtlA2WHelper(LPWSTR lpw, LPCSTR lpa, int nChars)
 
 // Interface from main game
 
-extern int rec_mgetbutton();
+extern int ags_mgetbutton();
 extern void update_polled_audio_and_crossfade();
 extern volatile char want_exit;
 extern volatile int timerloop;
@@ -126,7 +126,7 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
       if (canskip >= 2)
         break;
     }
-    if ((rec_mgetbutton() >= 0) && (canskip == 3))
+    if ((ags_mgetbutton() >= 0) && (canskip == 3))
       break;
 
     //device->Present(NULL, NULL, 0, NULL);

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -32,7 +32,6 @@
 #include "ac/objectcache.h"
 #include "ac/parser.h"
 #include "ac/path_helper.h"
-#include "ac/record.h"
 #include "ac/roomstatus.h"
 #include "ac/string.h"
 #include "font/fonts.h"
@@ -60,6 +59,10 @@
 #include "ac/dynobj/scriptstring.h"
 #include "main/graphics_mode.h"
 #include "gfx/gfx_util.h"
+
+#ifdef __AGS_EE_AC__RECORD_H
+#error "Can't include record.h since we're interacting with mouse api directly"
+#endif
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -394,7 +397,6 @@ extern int  mgetbutton();
 
 void IAGSEngine::PollSystem () {
 
-    NEXT_ITERATION();
     domouse(DOMOUSE_NOCURSOR);
     update_polled_stuff_if_runtime();
     int mbut = mgetbutton();

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -60,10 +60,6 @@
 #include "main/graphics_mode.h"
 #include "gfx/gfx_util.h"
 
-#ifdef __AGS_EE_AC__RECORD_H
-#error "Can't include record.h since we're interacting with mouse api directly"
-#endif
-
 using namespace AGS::Common;
 using namespace AGS::Engine;
 

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -259,7 +259,7 @@
     <ClCompile Include="..\..\Engine\ac\parser.cpp" />
     <ClCompile Include="..\..\Engine\ac\path.cpp" />
     <ClCompile Include="..\..\Engine\ac\properties.cpp" />
-    <ClCompile Include="..\..\Engine\ac\record.cpp" />
+    <ClCompile Include="..\..\Engine\ac\sys_events.cpp" />
     <ClCompile Include="..\..\Engine\ac\region.cpp" />
     <ClCompile Include="..\..\Engine\ac\richgamemedia.cpp" />
     <ClCompile Include="..\..\Engine\ac\room.cpp" />
@@ -583,7 +583,7 @@
     <ClInclude Include="..\..\Engine\ac\path.h" />
     <ClInclude Include="..\..\Engine\ac\path_helper.h" />
     <ClInclude Include="..\..\Engine\ac\properties.h" />
-    <ClInclude Include="..\..\Engine\ac\record.h" />
+    <ClInclude Include="..\..\Engine\ac\sys_events.h" />
     <ClInclude Include="..\..\Engine\ac\region.h" />
     <ClInclude Include="..\..\Engine\ac\richgamemedia.h" />
     <ClInclude Include="..\..\Engine\ac\room.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -396,7 +396,7 @@
     <ClCompile Include="..\..\Engine\ac\properties.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Engine\ac\record.cpp">
+    <ClCompile Include="..\..\Engine\ac\sys_events.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\region.cpp">
@@ -1226,7 +1226,7 @@
     <ClInclude Include="..\..\Engine\ac\properties.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Engine\ac\record.h">
+    <ClInclude Include="..\..\Engine\ac\sys_events.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\region.h">


### PR DESCRIPTION
This is a refactoring of some of the keyboard/mouse event code to make it easier to rewrite for SDL2.

This pull request is done in a few stages:
1) remove recording/playback
2) rename rec_* functions to ags_*
3) rename record.{cpp,h} to sys_events (since 'events.cpp' was already taken :) )

I deliberately left the functions in sys_events as I will be using that module as a base to slot in the SDL event handling.

I've only tested by building in Linux, I don't believe I've broken anything for Windows. OSX project files will need updating but I suspect they're already out of date from earlier commits :)