### PR TITLE
Plugin save/restore uses file handle.

### DIFF
--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -38,14 +38,6 @@ public:
     virtual void    Close();
     virtual bool    Flush();
 
-    // TODO
-    // Temporary solution for cases when the code can't live without
-    // having direct access to FILE pointer
-    inline FILE     *GetHandle() const
-    {
-        return _file;
-    }
-
     // Is stream valid (underlying data initialized properly)
     virtual bool    IsValid() const;
     // Is end of stream

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1601,8 +1601,10 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     if (!err)
         return err;
 
-    // [IKM] Plugins expect FILE pointer! // TODO something with this later
-    pl_run_plugin_hooks(AGSE_RESTOREGAME, (long)((Common::FileStream*)in)->GetHandle());
+    auto pluginFileHandle = AGSE_RESTOREGAME;
+    pl_set_file_handle(pluginFileHandle, dynamic_cast<Common::FileStream *>(in));
+    pl_run_plugin_hooks(AGSE_RESTOREGAME, pluginFileHandle);
+    pl_clear_file_handle();
     if (in->ReadInt32() != (unsigned)MAGICNUMBER)
         return new SavegameError(kSvgErr_InconsistentPlugin);
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -942,15 +942,19 @@ HSaveError ReadManagedPool(PStream in, int32_t cmp_ver, const PreservedParams &p
 
 HSaveError WritePluginData(PStream out)
 {
-    // [IKM] Plugins expect FILE pointer! // TODO something with this later...
-    pl_run_plugin_hooks(AGSE_SAVEGAME, (long)((Common::FileStream*)out.get())->GetHandle());
+    auto pluginFileHandle = AGSE_SAVEGAME;
+    pl_set_file_handle(pluginFileHandle, dynamic_cast<Common::FileStream *>(out.get()));
+    pl_run_plugin_hooks(AGSE_SAVEGAME, pluginFileHandle);
+    pl_clear_file_handle();
     return HSaveError::None();
 }
 
 HSaveError ReadPluginData(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
-    // [IKM] Plugins expect FILE pointer! // TODO something with this later
-    pl_run_plugin_hooks(AGSE_RESTOREGAME, (long)((Common::FileStream*)in.get())->GetHandle());
+    auto pluginFileHandle = AGSE_RESTOREGAME;
+    pl_set_file_handle(pluginFileHandle, dynamic_cast<Common::FileStream *>(in.get()));
+    pl_run_plugin_hooks(AGSE_RESTOREGAME, pluginFileHandle);
+    pl_clear_file_handle();
     return HSaveError::None();
 }
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -61,6 +61,7 @@
 #include "main/graphics_mode.h"
 #include "gfx/gfx_util.h"
 #include "util/memory.h"
+#include "util/filestream.h"
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
@@ -311,14 +312,41 @@ void IAGSEngine::GetBitmapDimensions (BITMAP *bmp, int32 *width, int32 *height, 
     if (coldepth != NULL)
         coldepth[0] = bitmap_color_depth(bmp);
 }
-// [IKM] Interesting, why does AGS need those two functions?
-// Can it be that it was planned to change implementation in the future?
-// TODO: plugin API is currently strictly 32-bit, so this may break on 64-bit systems
-int IAGSEngine::FRead (void *buffer, int32 len, int32 handle) {
-    return fread (buffer, 1, len, Int32ToPtr<FILE>(handle));
+
+// On save/restore, the Engine will provide the plugin with a handle. Because we only ever save to one file at a time,
+// we can reuse the same handle.
+
+static long pl_file_handle = -1;
+static AGS::Common::FileStream *pl_file_stream = nullptr;
+
+void pl_set_file_handle(long data, AGS::Common::FileStream *stream) {
+    pl_file_handle = data;
+    pl_file_stream = stream;
 }
+
+void pl_clear_file_handle() {
+    pl_file_handle = -1;
+    pl_file_stream = nullptr;
+}
+
+int IAGSEngine::FRead (void *buffer, int32 len, int32 handle) {
+    if (handle != pl_file_handle) {
+        quitprintf("IAGSEngine::FRead: invalid file handle: %d", handle);
+    }
+    if (!pl_file_stream) {
+        quit("IAGSEngine::FRead: file stream not set");
+    }
+    return pl_file_stream->Read(buffer, len);
+}
+
 int IAGSEngine::FWrite (void *buffer, int32 len, int32 handle) {
-    return fwrite (buffer, 1, len, Int32ToPtr<FILE>(handle));
+    if (handle != pl_file_handle) {
+        quitprintf("IAGSEngine::FWrite: invalid file handle: %d", handle);
+    }
+    if (!pl_file_stream) {
+        quit("IAGSEngine::FWrite: file stream not set");
+    }
+    return pl_file_stream->Write(buffer, len);
 }
 
 void IAGSEngine::DrawTextWrapped (int32 xx, int32 yy, int32 wid, int32 font, int32 color, const char*text)

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -25,7 +25,7 @@
 #define PLUGIN_FILENAME_MAX (49)
 
 class IAGSEngine;
-namespace AGS { namespace Common { class Stream; }}
+namespace AGS { namespace Common { class FileStream; }}
 using namespace AGS; // FIXME later
 
 void pl_stop_plugins();
@@ -50,5 +50,7 @@ struct InbuiltPluginDetails {
 
 // Register a builtin plugin.
 int pl_register_builtin_plugin(InbuiltPluginDetails const &details);
+void pl_set_file_handle(long data, AGS::Common::FileStream *stream);
+void pl_clear_file_handle();
 
 #endif // __AGS_EE_PLUGIN__PLUGINENGINE_H

--- a/Plugins/AGSflashlight/agsflashlight.cpp
+++ b/Plugins/AGSflashlight/agsflashlight.cpp
@@ -40,7 +40,7 @@ inline void calc_x_n(unsigned long bla) __attribute__((always_inline));
 #endif
 
 const unsigned int Magic = 0xBABE0000;
-const unsigned int Version = 1;
+const unsigned int Version = 2;
 const unsigned int SaveMagic = Magic + Version;
 const float PI = 3.14159265f;
 
@@ -475,96 +475,78 @@ void CreateLightBitmap()
    engine->MarkRegionDirty(0, 0, screen_width, screen_height);
 }
 
+static size_t engineFileRead(void * ptr, size_t size, size_t count, long fileHandle) {
+  auto totalBytes = engine->FRead(ptr, size*count, fileHandle);
+  return totalBytes/size;
+}
 
-void RestoreGame(FILE* file)
+static size_t engineFileWrite(const void *ptr, size_t size, size_t count, long fileHandle) {
+  auto totalBytes = engine->FWrite(const_cast<void *>(ptr), size*count, fileHandle);
+  return totalBytes/size;
+}
+
+void RestoreGame(long file)
 {
-  unsigned int Position = ftell(file);
-  unsigned int DataSize;
-
   unsigned int SaveVersion = 0;
-  fread(&SaveVersion, 4, 1, file);
+  engineFileRead(&SaveVersion, sizeof(SaveVersion), 1, file);
 
-  if (SaveVersion == SaveMagic)
-  {
-    fread(&DataSize, 4, 1, file);
-
-    // Current version
-    fread(&g_RedTint, 4, 1, file);
-    fread(&g_GreenTint, 4, 1, file);
-    fread(&g_BlueTint, 4, 1, file);
-
-    fread(&g_DarknessLightLevel, 4, 1, file);
-    fread(&g_BrightnessLightLevel, 4, 1, file);
-    fread(&g_DarknessSize, 4, 1, file);
-    fread(&g_DarknessDiameter, 4, 1, file);
-    fread(&g_BrightnessSize, 4, 1, file);
-
-    fread(&g_FlashlightX, 4, 1, file);
-    fread(&g_FlashlightY, 4, 1, file);
-
-    fread(&g_FlashlightFollowMouse, 4, 1, file);
-
-    fread(&g_FollowCharacterId, 4, 1, file);
-    fread(&g_FollowCharacterDx, 4, 1, file);
-    fread(&g_FollowCharacterDy, 4, 1, file);
-    fread(&g_FollowCharacterHorz, 4, 1, file);
-    fread(&g_FollowCharacterVert, 4, 1, file);
-    
-    if (g_FollowCharacterId != 0)
-      g_FollowCharacter = engine->GetCharacter(g_FollowCharacterId);
-
-    g_BitmapMustBeUpdated = true;
+  if (SaveVersion != SaveMagic) {
+    engine->AbortGame("agsflashlight: bad save.");
   }
-  else if ((SaveVersion & 0xFFFF0000) == Magic)
-  {
-    // Unsupported version, skip it
-    DataSize = 0;
-    fread(&DataSize, 4, 1, file);
 
-    fseek(file, Position + DataSize - 8, SEEK_SET);
-  }
-  else
-  {
-    // Unknown data, loading might fail but we cannot help it
-    fseek(file, Position, SEEK_SET);
-  }
+  // Current version
+  engineFileRead(&g_RedTint, 4, 1, file);
+  engineFileRead(&g_GreenTint, 4, 1, file);
+  engineFileRead(&g_BlueTint, 4, 1, file);
+
+  engineFileRead(&g_DarknessLightLevel, 4, 1, file);
+  engineFileRead(&g_BrightnessLightLevel, 4, 1, file);
+  engineFileRead(&g_DarknessSize, 4, 1, file);
+  engineFileRead(&g_DarknessDiameter, 4, 1, file);
+  engineFileRead(&g_BrightnessSize, 4, 1, file);
+
+  engineFileRead(&g_FlashlightX, 4, 1, file);
+  engineFileRead(&g_FlashlightY, 4, 1, file);
+
+  engineFileRead(&g_FlashlightFollowMouse, 4, 1, file);
+
+  engineFileRead(&g_FollowCharacterId, 4, 1, file);
+  engineFileRead(&g_FollowCharacterDx, 4, 1, file);
+  engineFileRead(&g_FollowCharacterDy, 4, 1, file);
+  engineFileRead(&g_FollowCharacterHorz, 4, 1, file);
+  engineFileRead(&g_FollowCharacterVert, 4, 1, file);
+  
+  if (g_FollowCharacterId != 0)
+    g_FollowCharacter = engine->GetCharacter(g_FollowCharacterId);
+
+  g_BitmapMustBeUpdated = true;
 }
 
 
-void SaveGame(FILE* file)
+void SaveGame(long file)
 {
-  unsigned int StartPosition = ftell(file);
+  engineFileWrite(&SaveMagic, sizeof(SaveMagic), 1, file);
 
-  fwrite(&SaveMagic, 4, 1, file);
-  fwrite(&StartPosition, 4, 1, file); // Update later with the correct size
+  engineFileWrite(&g_RedTint, 4, 1, file);
+  engineFileWrite(&g_GreenTint, 4, 1, file);
+  engineFileWrite(&g_BlueTint, 4, 1, file);
 
-  fwrite(&g_RedTint, 4, 1, file);
-  fwrite(&g_GreenTint, 4, 1, file);
-  fwrite(&g_BlueTint, 4, 1, file);
+  engineFileWrite(&g_DarknessLightLevel, 4, 1, file);
+  engineFileWrite(&g_BrightnessLightLevel, 4, 1, file);
+  engineFileWrite(&g_DarknessSize, 4, 1, file);
+  engineFileWrite(&g_DarknessDiameter, 4, 1, file);
+  engineFileWrite(&g_BrightnessSize, 4, 1, file);
 
-  fwrite(&g_DarknessLightLevel, 4, 1, file);
-  fwrite(&g_BrightnessLightLevel, 4, 1, file);
-  fwrite(&g_DarknessSize, 4, 1, file);
-  fwrite(&g_DarknessDiameter, 4, 1, file);
-  fwrite(&g_BrightnessSize, 4, 1, file);
+  engineFileWrite(&g_FlashlightX, 4, 1, file);
+  engineFileWrite(&g_FlashlightY, 4, 1, file);
 
-  fwrite(&g_FlashlightX, 4, 1, file);
-  fwrite(&g_FlashlightY, 4, 1, file);
+  engineFileWrite(&g_FlashlightFollowMouse, 4, 1, file);
 
-  fwrite(&g_FlashlightFollowMouse, 4, 1, file);
-
-  fwrite(&g_FollowCharacterId, 4, 1, file);
-  fwrite(&g_FollowCharacterDx, 4, 1, file);
-  fwrite(&g_FollowCharacterDy, 4, 1, file);
-  fwrite(&g_FollowCharacterHorz, 4, 1, file);
-  fwrite(&g_FollowCharacterVert, 4, 1, file);
-
-  unsigned int EndPosition = ftell(file);
-  unsigned int SaveSize = EndPosition - StartPosition;
-  fseek(file, StartPosition + 4, SEEK_SET);
-  fwrite(&SaveSize, 4, 1, file);
-
-  fseek(file, EndPosition, SEEK_SET);
+  engineFileWrite(&g_FollowCharacterId, 4, 1, file);
+  engineFileWrite(&g_FollowCharacterDx, 4, 1, file);
+  engineFileWrite(&g_FollowCharacterDy, 4, 1, file);
+  engineFileWrite(&g_FollowCharacterHorz, 4, 1, file);
+  engineFileWrite(&g_FollowCharacterVert, 4, 1, file);
 }
 
 
@@ -799,11 +781,8 @@ void AGS_EngineStartup(IAGSEngine *lpEngine)
   
   engine->RequestEventHook(AGSE_PREGUIDRAW);
   engine->RequestEventHook(AGSE_PRESCREENDRAW);
-
-#if defined(PSP_VERSION) || defined(ANDROID_VERSION) || defined(IOS_VERSION)
   engine->RequestEventHook(AGSE_SAVEGAME);
   engine->RequestEventHook(AGSE_RESTOREGAME);
-#endif
 }
 
 void AGS_EngineShutdown()
@@ -817,16 +796,14 @@ int AGS_EngineOnEvent(int event, int data)
   {
     Update();
   }
-#if defined(PSP_VERSION) || defined(ANDROID_VERSION) || defined(IOS_VERSION)
   else if (event == AGSE_RESTOREGAME)
   {
-    RestoreGame((FILE*)data);
+    RestoreGame(data);
   }
   else if (event == AGSE_SAVEGAME)
   {
-    SaveGame((FILE*)data);
+    SaveGame(data);
   }
-#endif
   else if (event == AGSE_PRESCREENDRAW)
   {
     // Get screen size once here.
@@ -838,11 +815,8 @@ int AGS_EngineOnEvent(int event, int data)
     {
       engine->UnrequestEventHook(AGSE_PREGUIDRAW);
       engine->UnrequestEventHook(AGSE_PRESCREENDRAW);
-
-#if defined(PSP_VERSION) || defined(ANDROID_VERSION) || defined(IOS_VERSION)
       engine->UnrequestEventHook(AGSE_SAVEGAME);
       engine->UnrequestEventHook(AGSE_RESTOREGAME);
-#endif
     }
   }
 

--- a/Plugins/ags_parallax/ags_parallax.cpp
+++ b/Plugins/ags_parallax/ags_parallax.cpp
@@ -28,10 +28,9 @@ namespace ags_parallax {
 #endif
 
 //#define DEBUG
-//#define ENABLE_SAVING // The original plugin does not save any data!
 
 const unsigned int Magic = 0xCAFE0000;
-const unsigned int Version = 1;
+const unsigned int Version = 2;
 const unsigned int SaveMagic = Magic + Version;
 
 int screen_width = 320;
@@ -63,54 +62,35 @@ void dummy()
   void *tmp = new int;
 }
 
-#if defined(ENABLE_SAVING)
-void RestoreGame(FILE* file)
-{
-  unsigned int Position = ftell(file);
-  unsigned int DataSize;
+static size_t engineFileRead(void * ptr, size_t size, size_t count, long fileHandle) {
+  auto totalBytes = engine->FRead(ptr, size*count, fileHandle);
+  return totalBytes/size;
+}
 
+static size_t engineFileWrite(const void *ptr, size_t size, size_t count, long fileHandle) {
+  auto totalBytes = engine->FWrite(const_cast<void *>(ptr), size*count, fileHandle);
+  return totalBytes/size;
+}
+
+void RestoreGame(long fileHandle)
+{
   unsigned int SaveVersion = 0;
-  fread(&SaveVersion, 4, 1, file);
+  engineFileRead(&SaveVersion, sizeof(SaveVersion), 1, fileHandle);
 
-  if (SaveVersion == SaveMagic)
-  {
-    fread(sprites, sizeof(sprite_t), MAX_SPRITES, file);
-    fread(&enabled, sizeof(bool), 1, file);
+  if (SaveVersion != SaveMagic) {
+    engine->AbortGame("ags_parallax: bad save.");
   }
-  else if ((SaveVersion & 0xFFFF0000) == Magic)
-  {
-    // Unsupported version, skip it
-    DataSize = 0;
-    fread(&DataSize, 4, 1, file);
 
-    fseek(file, Position + DataSize - 8, SEEK_SET);
-  }
-  else
-  {
-    // Unknown data, loading might fail but we cannot help it
-    fseek(file, Position, SEEK_SET);
-  }
+  engineFileRead(sprites, sizeof(sprite_t), MAX_SPRITES, fileHandle);
+  engineFileRead(&enabled, sizeof(bool), 1, fileHandle);
 }
 
-
-void SaveGame(FILE* file)
+void SaveGame(long file)
 {
-  unsigned int StartPosition = ftell(file);
-
-  fwrite(&SaveMagic, 4, 1, file);
-  fwrite(&StartPosition, 4, 1, file); // Update later with the correct size
-
-  fwrite(sprites, sizeof(sprite_t), MAX_SPRITES, file);
-  fwrite(&enabled, sizeof(bool), 1, file);
-
-  unsigned int EndPosition = ftell(file);
-  unsigned int SaveSize = EndPosition - StartPosition;
-  fseek(file, StartPosition + 4, SEEK_SET);
-  fwrite(&SaveSize, 4, 1, file);
-
-  fseek(file, EndPosition, SEEK_SET);
+  engineFileWrite(&SaveMagic, sizeof(SaveMagic), 1, file);
+  engineFileWrite(sprites, sizeof(sprite_t), MAX_SPRITES, file);
+  engineFileWrite(&enabled, sizeof(bool), 1, file);
 }
-#endif
 
 
 void Initialize()
@@ -223,10 +203,8 @@ void AGS_EngineStartup(IAGSEngine *lpEngine)
   engine->RequestEventHook(AGSE_PREGUIDRAW);
   engine->RequestEventHook(AGSE_PRESCREENDRAW);
   engine->RequestEventHook(AGSE_ENTERROOM);
-#if defined(ENABLE_SAVING)
   engine->RequestEventHook(AGSE_SAVEGAME);
   engine->RequestEventHook(AGSE_RESTOREGAME);
-#endif
 
   Initialize();
 }
@@ -256,16 +234,14 @@ int AGS_EngineOnEvent(int event, int data)
     engine->GetScreenDimensions(&screen_width, &screen_height, &screen_color_depth);
     engine->UnrequestEventHook(AGSE_PRESCREENDRAW);
   }
-#if defined(ENABLE_SAVING)
   else if (event == AGSE_RESTOREGAME)
   {
-    RestoreGame((FILE*)data);
+    RestoreGame(data);
   }
   else if (event == AGSE_SAVEGAME)
   {
-    SaveGame((FILE*)data);
+    SaveGame(data);
   }
-#endif
   
   return 0;
 }


### PR DESCRIPTION
Instead of casting a FILE* pointer to an integer, the plugin module will now use an abstract file handle which maps to the currently opened savegame file. 

Plugins are supposed to use the engine->FWrite/FRead functions so this also refactors the inbuilt plugins to use that as well.

Since there's only ever one savegame file open at a time, this reuses the save/restore event code as the file handle.