### PR TITLE
AGS3 plugin builtin refactor

### DIFF
--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -46,6 +46,7 @@
 #include "media/audio/sound.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
+#include "plugin/plugin_builtin.h"
 #include "plugin/pluginobjectreader.h"
 #include "script/script.h"
 #include "script/script_runtime.h"

--- a/Engine/plugin/plugin_builtin.h
+++ b/Engine/plugin/plugin_builtin.h
@@ -1,0 +1,41 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Plugin system functions.
+//
+//=============================================================================
+#ifndef __AGS_EE_PLUGIN__PLUGINBUILTIN_H
+#define __AGS_EE_PLUGIN__PLUGINBUILTIN_H
+
+#define PLUGIN_FILENAME_MAX (49)
+
+class IAGSEngine;
+
+using namespace AGS; // FIXME later
+
+//  Initial implementation for apps to register their own inbuilt plugins
+
+struct InbuiltPluginDetails {
+    char      filename[PLUGIN_FILENAME_MAX+1];
+    void      (*engineStartup) (IAGSEngine *);
+    void      (*engineShutdown) ();
+    int       (*onEvent) (int, int);
+    void      (*initGfxHook) (const char *driverName, void *data);
+    int       (*debugHook) (const char * whichscript, int lineNumber, int reserved);
+};
+
+// Register a builtin plugin.
+int pl_register_builtin_plugin(InbuiltPluginDetails const &details);
+
+#endif // __AGS_EE_PLUGIN__PLUGINBUILTIN_H

--- a/Engine/plugin/plugin_engine.h
+++ b/Engine/plugin/plugin_engine.h
@@ -40,19 +40,6 @@ bool pl_is_plugin_loaded(const char *pl_name);
 //returns whether _any_ plugins want a particular event
 bool pl_any_want_hook(int event);
 
-//  Initial implementation for apps to register their own inbuilt plugins
-
-struct InbuiltPluginDetails {
-    char      filename[PLUGIN_FILENAME_MAX+1];
-    void      (*engineStartup) (IAGSEngine *);
-    void      (*engineShutdown) ();
-    int       (*onEvent) (int, int);
-    void      (*initGfxHook) (const char *driverName, void *data);
-    int       (*debugHook) (const char * whichscript, int lineNumber, int reserved);
-};
-
-// Register a builtin plugin.
-int pl_register_builtin_plugin(InbuiltPluginDetails const &details);
 void pl_set_file_handle(long data, AGS::Common::Stream *stream);
 void pl_clear_file_handle();
 

--- a/OSX/xcode/ags/plugin_registration.cpp
+++ b/OSX/xcode/ags/plugin_registration.cpp
@@ -9,6 +9,7 @@
 #include "plugin_registration.hpp"
 
 #include "plugin/agsplugin.h"
+#include "plugin/plugin_builtin.h"
 //#include "example.h"
 
 typedef void (*t_engine_pre_init_callback)(void);


### PR DESCRIPTION
The builtin plugin registration is intended to be used by games that wrap the engine as a library.  The api was originally in ags_plugin.h but was moved to plugin_engine.h which meant it wasn't accessible to apps that only had limited access to the ags headers.

Currently the wadjet eye games use it for their ios games to load builtin plugins.