### PR TITLE
AGS 3: deprecate sprite resolution tag

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -97,6 +97,9 @@ OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 49 : 3.4.1.2
 Font custom line spacing.
 
+50 : 3.5.0.8
+Sprites have "real" resolution.
+
 */
 
 enum GameDataVersion
@@ -129,7 +132,8 @@ enum GameDataVersion
     kGameVersion_340_4          = 47,
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
-    kGameVersion_Current        = kGameVersion_341_2
+    kGameVersion_350            = 50,
+    kGameVersion_Current        = kGameVersion_350
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -170,12 +170,13 @@ enum RenderAtScreenRes
 
 
 // Sprite flags
-#define SPF_640x400         0x01  // sized for high native resolution
-#define SPF_HICOLOR         0x02  // is 16-bit
-#define SPF_DYNAMICALLOC    0x04  // created by runtime script
-#define SPF_TRUECOLOR       0x08  // is 32-bit
-#define SPF_ALPHACHANNEL    0x10  // has alpha-channel
-#define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
+#define SPF_HIRES           0x0001  // sized for high native resolution (legacy option)
+#define SPF_HICOLOR         0x0002  // is 16-bit
+#define SPF_DYNAMICALLOC    0x0004  // created by runtime script
+#define SPF_TRUECOLOR       0x0008  // is 32-bit
+#define SPF_ALPHACHANNEL    0x0010  // has alpha-channel
+#define SPF_HADALPHACHANNEL 0x0080  // the saved sprite on disk has one
+#define SPF_VAR_RESOLUTION  0x0100  // variable resolution (use SPF_HIRES)
 
 // General information about sprite (properties, size)
 struct SpriteInfo
@@ -185,6 +186,16 @@ struct SpriteInfo
     int      Height;
 
     SpriteInfo();
+
+    //
+    // Legacy game support
+    //
+    // Gets if sprite should adjust its base size depending on game's resolution
+    inline bool IsVarRes() const { return (Flags & SPF_VAR_RESOLUTION) != 0; }
+    // Gets if sprite belongs to high resolution (should be downscaled in low-res games)
+    inline bool IsHiRes() const { return IsVarRes() && (Flags & SPF_HIRES) != 0; }
+    // Gets if sprite belongs to low resolution (should be upscaled in hi-res games)
+    inline bool IsLowRes() const { return IsVarRes() && (Flags & SPF_HIRES) == 0; }
 };
 
 // Various font parameters, defining and extending font rendering behavior.

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -76,8 +76,9 @@ namespace AGS.Editor
          *     3.4.3      - Added missing audio properties to DefaultSetup [ forgot to change version index!! ]
          * 16: 3.5.0      - Unlimited fonts (need separate version to prevent crashes in older editors)
          * 17: 3.5.0.4    - Extended sprite source properties
+         * 18: 3.5.0.8    - Real sprite resolution
         */
-        public const int    LATEST_XML_VERSION_INDEX = 17;
+        public const int    LATEST_XML_VERSION_INDEX = 18;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -88,6 +88,8 @@ namespace AGS.Editor
         {
             Game game = Factory.AGSEditor.CurrentGame;
 
+            // TODO: this may be noticably slow especially for sprites. Display some kind of
+            // progress window to notify user.
             // Convert absolute paths to relative paths. This is an automatic fixup from when the
             // editor stored absolute paths only
             foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -609,7 +609,8 @@ namespace AGS.Editor
             {
                 mostTopmost = Math.Max(sprite.Number, mostTopmost);
                 flags[sprite.Number] = 0;
-                if (sprite.Resolution == SpriteImportResolution.HighRes) flags[sprite.Number] |= NativeConstants.SPF_640x400;
+                if (sprite.Resolution != SpriteImportResolution.Real) flags[sprite.Number] |= NativeConstants.SPF_VAR_RESOLUTION;
+                if (sprite.Resolution == SpriteImportResolution.HighRes) flags[sprite.Number] |= NativeConstants.SPF_HIRES;
                 if (sprite.AlphaChannel) flags[sprite.Number] |= NativeConstants.SPF_ALPHACHANNEL;
             }
             foreach (SpriteFolder subfolder in folder.SubFolders)

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1601,10 +1601,18 @@ namespace AGS.Editor
             }
         }
 
-		void IGUIController.DrawSprite(Graphics g, int spriteNumber, int x, int y, int width, int height, bool centreHorizontally)
+        void IGUIController.DrawSprite(Graphics g, int spriteNumber, int x, int y, int width, int height, bool centreHorizontally)
 		{
-			int spriteWidth = Factory.NativeProxy.GetRelativeSpriteWidth(spriteNumber) * 2;
-			int spriteHeight = Factory.NativeProxy.GetRelativeSpriteHeight(spriteNumber) * 2;
+            SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteNumber);
+
+            int spriteWidth = info.Width;
+			int spriteHeight = info.Height;
+            // Draw low-res sprites larger (TODO: find out why, perhaps just for the better looks?)
+            if (info.Resolution == SpriteImportResolution.LowRes)
+            {
+                spriteWidth *= 2;
+                spriteHeight *= 2;
+            }
 			Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(new Sprite(spriteNumber, spriteWidth, spriteHeight), width, height, centreHorizontally, false, SystemColors.Control);
 			g.DrawImage(bmp, x, y);
 			bmp.Dispose();

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -218,45 +218,28 @@ namespace AGS.Editor
 			}
         }
 
-        /// <summary>
-        /// Returns the multiplier necessary to display this sprite
-        /// at the "standard" size. (ie. 1 if 640x400 sprite, 2 if 320x200)
-        /// </summary>
-        public int GetSpriteResolutionMultiplier(int spriteSlot)
-        {
-            return _native.GetSpriteResolutionMultiplier(spriteSlot);
-        }
-
-        public int GetActualSpriteWidth(int spriteSlot)
+        public SpriteInfo GetSpriteInfo(int spriteSlot)
         {
             lock (_spriteSetLock)
             {
-                return _native.GetActualSpriteWidth(spriteSlot);
+                return _native.GetSpriteInfo(spriteSlot);
             }
         }
 
-        public int GetActualSpriteHeight(int spriteSlot)
+        public int GetSpriteWidth(int spriteSlot)
         {
             lock (_spriteSetLock)
             {
-                return _native.GetActualSpriteHeight(spriteSlot);
+                return _native.GetSpriteWidth(spriteSlot);
             }
         }
 
-        public int GetRelativeSpriteWidth(int spriteSlot)
+        public int GetSpriteHeight(int spriteSlot)
         {
-			lock (_spriteSetLock)
-			{
-				return _native.GetRelativeSpriteWidth(spriteSlot);
-			}
-        }
-
-        public int GetRelativeSpriteHeight(int spriteSlot)
-        {
-			lock (_spriteSetLock)
-			{
-				return _native.GetRelativeSpriteHeight(spriteSlot);
-			}
+            lock (_spriteSetLock)
+            {
+                return _native.GetSpriteHeight(spriteSlot);
+            }
         }
 
         public Room LoadRoom(UnloadedRoom roomToLoad)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -112,9 +112,9 @@ namespace AGS.Editor
                 ViewFrame thisFrame = view.Loops[0].Frames[0];
                 spriteNum = thisFrame.Image;
             }
-
-            int width = GetSpriteWidthForGameResolution(spriteNum);
-            int height = GetSpriteHeightForGameResolution(spriteNum);
+            
+            int width, height;
+            Utilities.GetSizeSpriteWillBeRenderedInGame(spriteNum, out width, out height);
 
             return ((x >= character.StartX - (width / 2)) && (x < character.StartX + (width / 2)) &&
                 (y >= character.StartY - height) && (y < character.StartY));          
@@ -233,36 +233,6 @@ namespace AGS.Editor
             }
         }
 
-        private int GetSpriteHeightForGameResolution(int spriteSlot)
-        {
-            int height;
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
-            {
-                height = Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot) *
-                         Factory.NativeProxy.GetActualSpriteHeight(spriteSlot);
-            }
-            else
-            {
-                height = Factory.NativeProxy.GetRelativeSpriteHeight(spriteSlot);
-            }
-            return height;
-        }
-
-        private int GetSpriteWidthForGameResolution(int spriteSlot)
-        {
-            int width;
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
-            {
-                width = Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot) *
-                        Factory.NativeProxy.GetActualSpriteWidth(spriteSlot);
-            }
-            else
-            {
-                width = Factory.NativeProxy.GetRelativeSpriteWidth(spriteSlot);
-            }
-            return width;
-        }
-
         public void Paint(Graphics graphics, RoomEditorState state)
         {
             Pen pen = new Pen(Color.Goldenrod);
@@ -305,8 +275,10 @@ namespace AGS.Editor
                 }
                 int xPos = state.RoomXToWindow(character.StartX);
                 int yPos = state.RoomYToWindow(character.StartY);
-                int spriteWidth = state.RoomSizeToWindow(GetSpriteWidthForGameResolution(spriteNum));
-                int spriteHeight = state.RoomSizeToWindow(GetSpriteHeightForGameResolution(spriteNum));
+                int spriteWidth, spriteHeight;
+                Utilities.GetSizeSpriteWillBeRenderedInGame(spriteNum, out spriteWidth, out spriteHeight);
+                spriteWidth = state.RoomSizeToWindow(spriteWidth);
+                spriteHeight = state.RoomSizeToWindow(spriteHeight);
 
                 Factory.NativeProxy.DrawSpriteToBuffer(spriteNum, xPos - spriteWidth / 2, yPos - spriteHeight, state.Scale);
             }
@@ -326,8 +298,10 @@ namespace AGS.Editor
             int spriteNum = 0;
             if (view.Loops[0].Frames.Count > 0)
                 spriteNum = _game.FindViewByID(character.NormalView).Loops[0].Frames[0].Image;
-            int spriteWidth = state.RoomSizeToWindow(GetSpriteWidthForGameResolution(spriteNum));
-            int spriteHeight = state.RoomSizeToWindow(GetSpriteHeightForGameResolution(spriteNum));
+            int spriteWidth, spriteHeight;
+            Utilities.GetSizeSpriteWillBeRenderedInGame(spriteNum, out spriteWidth, out spriteHeight);
+            spriteWidth = state.RoomSizeToWindow(spriteWidth);
+            spriteHeight = state.RoomSizeToWindow(spriteHeight);
             return new Rectangle(xPos - spriteWidth / 2, yPos - spriteHeight, spriteWidth, spriteHeight);
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -123,41 +123,12 @@ namespace AGS.Editor
             foreach (RoomObject obj in _objectBaselines)
             {
                 if (!DesignItems[GetItemID(obj)].Visible) continue;
-                int height = GetSpriteHeightForGameResolution(obj.Image);
+                int width, height;
+                Utilities.GetSizeSpriteWillBeRenderedInGame(obj.Image, out width, out height);
                 int ypos = state.RoomYToWindow(obj.StartY - height);
 				Factory.NativeProxy.DrawSpriteToBuffer(obj.Image, state.RoomXToWindow(obj.StartX), ypos, state.Scale);
             }
             
-        }
-
-        private int GetSpriteHeightForGameResolution(int spriteSlot)
-        {
-            int height;
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
-            {
-                height = Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot) *
-                         Factory.NativeProxy.GetActualSpriteHeight(spriteSlot);
-            }
-            else
-            {
-                height = Factory.NativeProxy.GetRelativeSpriteHeight(spriteSlot);
-            }
-            return height;
-        }
-
-        private int GetSpriteWidthForGameResolution(int spriteSlot)
-        {
-            int width;
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
-            {
-                width = Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot) *
-                         Factory.NativeProxy.GetActualSpriteWidth(spriteSlot);
-            }
-            else
-            {
-                width = Factory.NativeProxy.GetRelativeSpriteWidth(spriteSlot);
-            }
-            return width;
         }
 
         public virtual void Paint(Graphics graphics, RoomEditorState state)
@@ -171,8 +142,10 @@ namespace AGS.Editor
             if (!design.Visible)
                 return;
 
-            int width = state.RoomSizeToWindow(GetSpriteWidthForGameResolution(_selectedObject.Image));
-			int height = state.RoomSizeToWindow(GetSpriteHeightForGameResolution(_selectedObject.Image));
+            int width, height;
+            Utilities.GetSizeSpriteWillBeRenderedInGame(_selectedObject.Image, out width, out height);
+            width = state.RoomSizeToWindow(width);
+			height = state.RoomSizeToWindow(height);
 			xPos = state.RoomXToWindow(_selectedObject.StartX);
 			yPos = state.RoomYToWindow(_selectedObject.StartY) - height;
             Pen pen = new Pen(Color.Goldenrod);
@@ -254,9 +227,9 @@ namespace AGS.Editor
         }
 
         private bool HitTest(RoomObject obj, int x, int y)
-        { 
-            int width = GetSpriteWidthForGameResolution(obj.Image);
-            int height = GetSpriteHeightForGameResolution(obj.Image);
+        {
+            int width, height;
+            Utilities.GetSizeSpriteWillBeRenderedInGame(obj.Image, out width, out height);
             return ((x >= obj.StartX) && (x < obj.StartX + width) &&
                 (y >= obj.StartY - height) && (y < obj.StartY));
         }

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -104,8 +104,15 @@ namespace AGS.Editor
             {
                 ViewFrame thisFrame = _view.Loops[(int)udLoop.Value].Frames[(int)udFrame.Value];
                 int spriteNum = thisFrame.Image;
-                int spriteWidth = Factory.NativeProxy.GetRelativeSpriteWidth(spriteNum) * 2;
-                int spriteHeight = Factory.NativeProxy.GetRelativeSpriteHeight(spriteNum) * 2;
+                SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteNum);
+                int spriteWidth = info.Width;
+                int spriteHeight = info.Height;
+                // Draw low-res sprites larger (TODO: find out why, perhaps just for the better looks?)
+                if (info.Resolution == SpriteImportResolution.LowRes)
+                {
+                    spriteWidth *= 2;
+                    spriteHeight *= 2;
+                }
                 int x = 0, y;
                 y = previewPanel.ClientSize.Height - spriteHeight;
                 if (chkCentrePivot.Checked)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -154,6 +154,9 @@ namespace AGS.Editor
 
         private void SetDefaultValuesForNewFeatures(Game game)
         {
+            // TODO: this may be noticably if upgrading lots of items. Display some kind of
+            // progress window to notify user.
+
             int xmlVersionIndex = 0;
             if (game.SavedXmlVersionIndex.HasValue)
             {
@@ -181,6 +184,15 @@ namespace AGS.Editor
             if (xmlVersionIndex < 15)
             {
                 game.DefaultSetup.SetDefaults();
+            }
+
+            if (xmlVersionIndex < 18)
+            {
+                // Promote sprites to "real" resolution when possible (ideally almost always)
+                foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+                {
+                    sprite.Resolution = Utilities.FixupSpriteResolution(sprite.Resolution);
+                }
             }
 
             game.SetScriptAPIForOldProject();

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -44,7 +44,8 @@ namespace AGS.Editor
         public static readonly int GAME_RESOLUTION_CUSTOM = (int)Factory.NativeProxy.GetNativeConstant("GAME_RESOLUTION_CUSTOM");
         public static readonly int CHUNKSIZE = (int)Factory.NativeProxy.GetNativeConstant("CHUNKSIZE");
         public static readonly string SPRSET_NAME = (string)Factory.NativeProxy.GetNativeConstant("SPRSET_NAME");
-        public static readonly byte SPF_640x400 = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_640x400");
+        public static readonly byte SPF_VAR_RESOLUTION = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_VAR_RESOLUTION");
+        public static readonly byte SPF_HIRES = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_HIRES");
         public static readonly byte SPF_ALPHACHANNEL = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_ALPHACHANNEL");
         public static readonly byte[] PASSWORD_ENC_STRING = (byte[])Factory.NativeProxy.GetNativeConstant("PASSWORD_ENC_STRING");
         public static readonly int LOOPFLAG_RUNNEXTLOOP = (int)Factory.NativeProxy.GetNativeConstant("LOOPFLAG_RUNNEXTLOOP");

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -311,6 +311,23 @@ namespace AGS.Editor
         }
 
         /// <summary>
+        /// Tests if its possible to "promote" sprite's resolution to "Real"
+        /// if it is matching current game resolution type.
+        /// </summary>
+        public static SpriteImportResolution FixupSpriteResolution(SpriteImportResolution res)
+        {
+            if (res == SpriteImportResolution.Real ||
+                Factory.AGSEditor.CurrentGame.IsHighResolution &&
+                res == SpriteImportResolution.HighRes ||
+                !Factory.AGSEditor.CurrentGame.IsHighResolution &&
+                res == SpriteImportResolution.LowRes)
+            {
+                return SpriteImportResolution.Real;
+            }
+            return res;
+        }
+
+        /// <summary>
         /// Gets the size at which the sprite will be rendered in the game.
         /// This will be the sprite size, but doubled if it is a 320-res sprite
         /// in a 640-res game.
@@ -320,15 +337,18 @@ namespace AGS.Editor
             SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteSlot);
             width = info.Width;
             height = info.Height;
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.LowRes)
+            if (info.Resolution != SpriteImportResolution.Real)
             {
-                width *= 2;
-                height *= 2;
-            }
-            else if (!Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.HighRes)
-            {
-                width /= 2;
-                height /= 2;
+                if (Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.LowRes)
+                {
+                    width *= 2;
+                    height *= 2;
+                }
+                else if (!Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.HighRes)
+                {
+                    width /= 2;
+                    height /= 2;
+                }
             }
         }
 

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -317,13 +317,18 @@ namespace AGS.Editor
         /// </summary>
         public static void GetSizeSpriteWillBeRenderedInGame(int spriteSlot, out int width, out int height)
         {
-            width = Factory.NativeProxy.GetActualSpriteWidth(spriteSlot);
-            height = Factory.NativeProxy.GetActualSpriteHeight(spriteSlot);
-
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
+            SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteSlot);
+            width = info.Width;
+            height = info.Height;
+            if (Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.LowRes)
             {
-                width *= Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot);
-                height *= Factory.NativeProxy.GetSpriteResolutionMultiplier(spriteSlot);
+                width *= 2;
+                height *= 2;
+            }
+            else if (!Factory.AGSEditor.CurrentGame.IsHighResolution && info.Resolution == SpriteImportResolution.HighRes)
+            {
+                width /= 2;
+                height /= 2;
             }
         }
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -60,7 +60,7 @@ extern int load_template_file(const char *fileName, char **iconDataBuffer, long 
 extern int extract_template_files(const char *templateFileName);
 extern int extract_room_template_files(const char *templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
-extern void update_sprite_resolution(int spriteNum, bool isHighRes);
+extern void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes);
 extern void save_game(bool compressSprites);
 extern HAGSError reset_sprite_file();
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
@@ -254,7 +254,7 @@ namespace AGS
             ::SpriteInfo info;
             ::GetSpriteInfo(spriteSlot, info);
             return gcnew AGS::Types::SpriteInfo(info.Width, info.Height,
-                (info.Flags & SPF_640x400) ? SpriteImportResolution::HighRes : SpriteImportResolution::LowRes);
+                info.IsVarRes() ? (info.IsHiRes() ? SpriteImportResolution::HighRes : SpriteImportResolution::LowRes) : SpriteImportResolution::Real);
         }
 
 		int NativeMethods::GetSpriteWidth(int spriteSlot) 
@@ -281,7 +281,7 @@ namespace AGS
 		{
 			for each (Sprite^ sprite in sprites)
 			{
-				update_sprite_resolution(sprite->Number, sprite->Resolution == SpriteImportResolution::HighRes);
+				update_sprite_resolution(sprite->Number, sprite->Resolution != SpriteImportResolution::Real, sprite->Resolution == SpriteImportResolution::HighRes);
 			}
 		}
 
@@ -675,7 +675,8 @@ namespace AGS
             if (name->Equals("GAME_RESOLUTION_CUSTOM")) return (int)kGameResolution_Custom;
             if (name->Equals("CHUNKSIZE")) return CHUNKSIZE;
             if (name->Equals("SPRSET_NAME")) return gcnew String(sprsetname);
-            if (name->Equals("SPF_640x400")) return SPF_640x400;
+            if (name->Equals("SPF_VAR_RESOLUTION")) return SPF_VAR_RESOLUTION;
+            if (name->Equals("SPF_HIRES")) return SPF_HIRES;
             if (name->Equals("SPF_ALPHACHANNEL")) return SPF_ALPHACHANNEL;
             if (name->Equals("PASSWORD_ENC_STRING"))
             {

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -48,10 +48,9 @@ extern unsigned char* GetRawSpriteData(int spriteSlot);
 extern int find_free_sprite_slot();
 extern int crop_sprite_edges(int numSprites, int *sprites, bool symmetric);
 extern void deleteSprite(int sprslot);
+extern void GetSpriteInfo(int slot, ::SpriteInfo &info);
 extern int GetSpriteWidth(int slot);
 extern int GetSpriteHeight(int slot);
-extern int GetRelativeSpriteWidth(int slot);
-extern int GetRelativeSpriteHeight(int slot);
 extern int GetSpriteColorDepth(int slot);
 extern int GetPaletteAsHPalette();
 extern bool DoesSpriteExist(int slot);
@@ -64,7 +63,6 @@ extern void change_sprite_number(int oldNumber, int newNumber);
 extern void update_sprite_resolution(int spriteNum, bool isHighRes);
 extern void save_game(bool compressSprites);
 extern HAGSError reset_sprite_file();
-extern int GetSpriteResolutionMultiplier(int slot);
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
 extern void GameUpdated(Game ^game);
 extern void GameFontUpdated(Game ^game, int fontNumber);
@@ -251,31 +249,22 @@ namespace AGS
         GameFontUpdated(game, fontSlot);
     }
 
-		// Gets sprite height in 320x200-res co-ordinates
-		int NativeMethods::GetRelativeSpriteHeight(int spriteSlot) 
-		{
-			return ::GetRelativeSpriteHeight(spriteSlot);
-		}
+        AGS::Types::SpriteInfo^ NativeMethods::GetSpriteInfo(int spriteSlot)
+        {
+            ::SpriteInfo info;
+            ::GetSpriteInfo(spriteSlot, info);
+            return gcnew AGS::Types::SpriteInfo(info.Width, info.Height,
+                (info.Flags & SPF_640x400) ? SpriteImportResolution::HighRes : SpriteImportResolution::LowRes);
+        }
 
-		// Gets sprite width in 320x200-res co-ordinates
-		int NativeMethods::GetRelativeSpriteWidth(int spriteSlot) 
-		{
-			return ::GetRelativeSpriteWidth(spriteSlot);
-		}
-
-		int NativeMethods::GetActualSpriteWidth(int spriteSlot) 
+		int NativeMethods::GetSpriteWidth(int spriteSlot) 
 		{
 			return ::GetSpriteWidth(spriteSlot);
 		}
 
-		int NativeMethods::GetActualSpriteHeight(int spriteSlot) 
+		int NativeMethods::GetSpriteHeight(int spriteSlot) 
 		{
 			return ::GetSpriteHeight(spriteSlot);
-		}
-
-		int NativeMethods::GetSpriteResolutionMultiplier(int spriteSlot)
-		{
-			return ::GetSpriteResolutionMultiplier(spriteSlot);
 		}
 
 		void NativeMethods::ChangeSpriteNumber(Sprite^ sprite, int newNumber)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -43,11 +43,9 @@ namespace AGS
       Bitmap^ GetBitmapForSpritePreserveColDepth(int spriteSlot);
 			void DeleteSprite(int spriteSlot);
 			int  GetFreeSpriteSlot();
-			int  GetRelativeSpriteWidth(int spriteSlot);
-			int  GetRelativeSpriteHeight(int spriteSlot);
-			int  GetActualSpriteWidth(int spriteSlot);
-			int  GetActualSpriteHeight(int spriteSlot);
-			int  GetSpriteResolutionMultiplier(int spriteSlot);
+            Types::SpriteInfo^ GetSpriteInfo(int spriteSlot);
+			int  GetSpriteWidth(int spriteSlot);
+			int  GetSpriteHeight(int spriteSlot);
 			bool CropSpriteEdges(System::Collections::Generic::IList<Sprite^>^ sprites, bool symmetric);
 			bool DoesSpriteExist(int spriteNumber);
 			void ChangeSpriteNumber(Sprite^ sprite, int newNumber);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -213,17 +213,12 @@ int GetSpriteHeight(int slot) {
 	return get_sprite(slot)->GetHeight();
 }
 
-int GetRelativeSpriteWidth(int slot) {
-	return GetSpriteWidth(slot) / ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 2 : 1);
-}
-
-int GetRelativeSpriteHeight(int slot) {
-	return GetSpriteHeight(slot) / ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 2 : 1);
-}
-
-int GetSpriteResolutionMultiplier(int slot)
-{
-	return ((thisgame.SpriteInfos[slot].Flags & SPF_640x400) ? 1 : 2);
+void GetSpriteInfo(int slot, ::SpriteInfo &info) {
+    // TODO: find out if we may get width/height from SpriteInfos
+    // or it is necessary to go through get_sprite and check bitmaps in cache?
+    info.Width = GetSpriteWidth(slot);
+    info.Height = GetSpriteHeight(slot);
+    info.Flags = thisgame.SpriteInfos[slot].Flags;
 }
 
 unsigned char* GetRawSpriteData(int spriteSlot) {

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -154,6 +154,7 @@
     <Compile Include="GlobalVariable.cs" />
     <Compile Include="GlobalVariables.cs" />
     <Compile Include="GUIControlGroup.cs" />
+    <Compile Include="HelperTypes\SpriteInfo.cs" />
     <Compile Include="Interfaces\IRePopulatableComponent.cs" />
     <Compile Include="Interfaces\ILoadedRoom.cs" />
     <Compile Include="InteractionSchema.cs" />

--- a/Editor/AGS.Types/Enums/SpriteImportResolution.cs
+++ b/Editor/AGS.Types/Enums/SpriteImportResolution.cs
@@ -4,9 +4,11 @@ namespace AGS.Types
 {
     public enum SpriteImportResolution
     {
+        [Description("Real")]
+        Real = -1,
         [Description("Low (320x240 and below)")]
         LowRes = 0,
         [Description("High (above 320x240)")]
-        HighRes = 1
+        HighRes = 1,
     }
 }

--- a/Editor/AGS.Types/HelperTypes/SpriteInfo.cs
+++ b/Editor/AGS.Types/HelperTypes/SpriteInfo.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace AGS.Types
+{
+    /// <summary>
+    /// Struct for passing basic information about a sprite.
+    /// </summary>
+    public class SpriteInfo
+    {
+        public int Width;
+        public int Height;
+        public SpriteImportResolution Resolution;
+
+        public SpriteInfo(int width, int height, SpriteImportResolution res)
+        {
+            Width = width;
+            Height = height;
+            Resolution = res;
+        }
+    };
+}

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -42,7 +42,7 @@ namespace AGS.Types
 		/// around and use this as an entity.
 		/// </summary>
 		public Sprite(int number, int width, int height)
-			: this(number, width, height, 0, SpriteImportResolution.LowRes, false)
+			: this(number, width, height, 0, SpriteImportResolution.Real, false)
 		{
 		}
 

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -35,24 +35,33 @@ extern color palette[256];
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
 
-void get_new_size_for_sprite (int ee, int ww, int hh, int &newwid, int &newhit) {
-    newwid = ww * current_screen_resolution_multiplier;
-    newhit = hh * current_screen_resolution_multiplier;
-    if (game.SpriteInfos[ee].Flags & SPF_640x400) 
+void get_new_size_for_sprite (int ee, int ww, int hh, int &newwid, int &newhit)
+{
+    const SpriteInfo &spinfo = game.SpriteInfos[ee];
+    if (!spinfo.IsVarRes())
     {
-        if (current_screen_resolution_multiplier == 2) {
+        newwid = ww;
+        newhit = hh;
+        return;
+    }
+
+    if (spinfo.IsHiRes())
+    {
+        if (current_screen_resolution_multiplier == 2)
+        {
             newwid = ww;
             newhit = hh;
         }
-        else {
-            newwid=(ww/2) * current_screen_resolution_multiplier;
-            newhit=(hh/2) * current_screen_resolution_multiplier;
-            // just make sure - could crash if wid or hit is 0
-            if (newwid < 1)
-                newwid = 1;
-            if (newhit < 1)
-                newhit = 1;
+        else
+        {
+            newwid = Math::Min(1, (ww / 2) * current_screen_resolution_multiplier);
+            newhit = Math::Min(1, (hh / 2) * current_screen_resolution_multiplier);
         }
+    }
+    else
+    {
+        newwid = ww * current_screen_resolution_multiplier;
+        newhit = hh * current_screen_resolution_multiplier;
     }
 }
 


### PR DESCRIPTION
A brief explanation, in AGS the game may be thought as being "low resolution" and "high resolution".
This exists since the times when it did not support any arbitrary game size, and historically 320x240 was the last "low resolution" and 640x400 was the first "high resolution".

Some assets, like sprites in this case, were letting developer to tag them as either "lowres" or "highres", and if this tag did not match the game's then such sprite would be scaled up or down twice in game respectively. I believe these were mostly meant to reuse same sprites in different games, but now with arbitrary game sizes the border between "lowres" and "highres" games became very vague.

This PR deprecates "Low/high resolution" sprite flags and introduces "Real resolution" type to replace them as the new default. This means that sprite is always visually same regardless of the game's native resolution.

Upon loading old games or importing older exported assets AGS "promotes" sprite resolution: if its tag matches the game type then it is changed to "Real". Usually that should promote all or nearly all sprites in game.

This should be an intermediate step between old ags and ags4 where this setting is completely removed (I think).