### PR TITLE
AGS 3: replace global font scale with individual setting

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -98,7 +98,7 @@ OPT_RENDERATSCREENRES, extended engine caps check, font vertical offset.
 Font custom line spacing.
 
 50 : 3.5.0.8
-Sprites have "real" resolution.
+Sprites have "real" resolution. Individual font scaling.
 
 */
 

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -99,10 +99,15 @@ void GameSetupStruct::Free()
 }
 
 // Assigns font info parameters using flags value read from the game data
-void SetFontInfoFromSerializedFlags(FontInfo &finfo, char flags)
+void SetFontInfoFromSerializedFlags(FontInfo &finfo, uint8_t flags)
 {
-    finfo.Flags = flags & ~FFLG_SIZEMASK;
-    finfo.SizePt = flags &  FFLG_SIZEMASK;
+    finfo.Flags = flags >> 6;
+    finfo.SizePt = flags & FFLG_SIZEMASK;
+    if ((finfo.Flags & FFLG_SIZEMULTIPLIER) != 0)
+    {
+        finfo.SizeMultiplier = finfo.SizePt;
+        finfo.SizePt = 0;
+    }
 }
 
 ScriptAudioClip* GetAudioClipForOldStyleNumber(GameSetupStruct &game, bool is_music, int num)

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -48,6 +48,7 @@ struct OldGameSetupStruct;
 struct GameSetupStruct: public GameSetupStructBase {
     // This array is used only to read data into;
     // font parameters are then put and queried in the fonts module
+    // TODO: split into installation params (used only when reading) and runtime params
     std::vector<FontInfo> fonts;
     InventoryItemInfo invinfo[MAX_INV];
     MouseCursor       mcurs[MAX_CURSOR];

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -44,7 +44,7 @@
 #define OPT_LETTERBOX       13
 #define OPT_FIXEDINVCURSOR  14
 #define OPT_NOLOSEINV       15
-#define OPT_NOSCALEFNT      16
+#define OPT_HIRES_FONTS     16
 #define OPT_SPLITRESOURCES  17
 #define OPT_ROTATECHARS     18
 #define OPT_FADETYPE        19
@@ -91,8 +91,9 @@
 #define FADE_CROSSFADE      4
 #define FADE_LAST           4   // this should equal the last one
 
-//#define FFLG_NOSCALE        1
-#define FFLG_SIZEMASK 0x003f
+//#define FFLG_NOSCALE      0x01 // TODO: is this from legacy format?
+#define FFLG_SIZEMASK 0x3f
+#define FFLG_SIZEMULTIPLIER 0x02  // size data means multiplier
 #define FONT_OUTLINE_NONE -1
 #define FONT_OUTLINE_AUTO -10
 #define MAX_FONT_SIZE 63
@@ -206,7 +207,7 @@ struct SpriteInfo
 struct FontInfo
 {
     // General font's loading and rendering flags
-    unsigned char Flags;
+    uint8_t       Flags;
     // Font size, in points (basically means pixels in AGS)
     int           SizePt;
     // Factor to multiply base font size by

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -209,6 +209,8 @@ struct FontInfo
     unsigned char Flags;
     // Font size, in points (basically means pixels in AGS)
     int           SizePt;
+    // Factor to multiply base font size by
+    int           SizeMultiplier;
     // Outlining font index, or auto-outline flag
     char          Outline;
     // Custom vertical render offset, used mainly for fixing broken fonts

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -39,12 +39,17 @@ public:
 // Font render params, mainly for dealing with various compatibility issues and
 // broken fonts. NOTE: currently left empty as a result of rewrite, but may be
 // used again in the future.
-struct FontRenderParams {};
+struct FontRenderParams
+{
+    // Font's render multiplier
+    int SizeMultiplier = 1;
+};
 
 // NOTE: this extending interface is not yet exposed to plugins
 class IAGSFontRenderer2
 {
 public:
+  virtual bool IsBitmapFont() = 0;
   // Load font, applying extended font rendering parameters
   virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params) = 0;
 };

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -23,8 +23,6 @@
 
 using namespace AGS::Common;
 
-int wtext_multiply = 1;
-
 namespace AGS
 {
 namespace Common
@@ -55,6 +53,7 @@ static WFNFontRenderer wfnRenderer;
 FontInfo::FontInfo()
     : Flags(0)
     , SizePt(0)
+    , SizeMultiplier(1)
     , Outline(FONT_OUTLINE_NONE)
     , YOffset(0)
     , LineSpacing(0)
@@ -95,6 +94,13 @@ IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* ren
   return oldRender;
 }
 
+bool is_bitmap_font(size_t fontNumber)
+{
+    if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
+        return false;
+    return fonts[fontNumber].Renderer2->IsBitmapFont();
+}
+
 bool font_supports_extended_characters(size_t fontNumber)
 {
   if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
@@ -107,6 +113,13 @@ void ensure_text_valid_for_font(char *text, size_t fontnum)
   if (fontnum >= fonts.size() || !fonts[fontnum].Renderer)
     return;
   fonts[fontnum].Renderer->EnsureTextValidForFont(text, fontnum);
+}
+
+int get_font_scaling_mul(size_t fontNumber)
+{
+    if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer)
+        return 0;
+    return fonts[fontNumber].Info.SizeMultiplier;
 }
 
 int wgettextwidth(const char *texx, size_t fontNumber)
@@ -187,15 +200,18 @@ void set_fontinfo(size_t fontNumber, const FontInfo &finfo)
 }
 
 // Loads a font from disk
-bool wloadfont_size(size_t fontNumber, const FontInfo &font_info, const FontRenderParams *params)
+bool wloadfont_size(size_t fontNumber, const FontInfo &font_info)
 {
   fonts.resize(fontNumber + 1);
-  if (ttfRenderer.LoadFromDiskEx(fontNumber, font_info.SizePt, params))
+  FontRenderParams params;
+  params.SizeMultiplier = font_info.SizeMultiplier;
+
+  if (ttfRenderer.LoadFromDiskEx(fontNumber, font_info.SizePt, &params))
   {
     fonts[fontNumber].Renderer  = &ttfRenderer;
     fonts[fontNumber].Renderer2 = &ttfRenderer;
   }
-  else if (wfnRenderer.LoadFromDiskEx(fontNumber, font_info.SizePt, params))
+  else if (wfnRenderer.LoadFromDiskEx(fontNumber, font_info.SizePt, &params))
   {
     fonts[fontNumber].Renderer  = &wfnRenderer;
     fonts[fontNumber].Renderer2 = &wfnRenderer;

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -84,6 +84,11 @@ bool font_first_renderer_loaded()
   return fonts.size() > 0 && fonts[0].Renderer != NULL;
 }
 
+bool is_font_loaded(size_t fontNumber)
+{
+    return fontNumber < fonts.size() && fonts[fontNumber].Renderer != NULL;;
+}
+
 IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* renderer)
 {
   if (fontNumber >= fonts.size())

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -32,6 +32,7 @@ void shutdown_font_renderer();
 void adjust_y_coordinate_for_text(int* ypos, size_t fontnum);
 IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* renderer);
 bool font_first_renderer_loaded();
+bool is_bitmap_font(size_t fontNumber);
 bool font_supports_extended_characters(size_t fontNumber);
 // TODO: with changes to WFN font renderer that implemented safe rendering of
 // strings containing invalid chars (since 3.3.1) this function is not
@@ -40,6 +41,7 @@ bool font_supports_extended_characters(size_t fontNumber);
 // at random times (usually - drawing routines).
 // Need to check whether it is safe to completely remove it.
 void ensure_text_valid_for_font(char *text, size_t fontnum);
+int get_font_scaling_mul(size_t fontNumber);
 int wgettextwidth(const char *texx, size_t fontNumber);
 // Calculates actual height of a line of text
 int wgettextheight(const char *text, size_t fontNumber);
@@ -57,10 +59,8 @@ void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, size_t fontNumber, color_t
 // Assigns FontInfo to the font
 void set_fontinfo(size_t fontNumber, const FontInfo &finfo);
 // Loads a font from disk
-bool wloadfont_size(size_t fontNumber, const FontInfo &font_info, const FontRenderParams *params = NULL);
+bool wloadfont_size(size_t fontNumber, const FontInfo &font_info);
 void wgtprintf(Common::Bitmap *ds, int xxx, int yyy, size_t fontNumber, color_t text_color, char *fmt, ...);
 void wfreefont(size_t fontNumber);
-
-extern int wtext_multiply;
 
 #endif // __AC_FONT_H

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -32,6 +32,7 @@ void shutdown_font_renderer();
 void adjust_y_coordinate_for_text(int* ypos, size_t fontnum);
 IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* renderer);
 bool font_first_renderer_loaded();
+bool is_font_loaded(size_t fontNumber);
 bool is_bitmap_font(size_t fontNumber);
 bool font_supports_extended_characters(size_t fontNumber);
 // TODO: with changes to WFN font renderer that implemented safe rendering of

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -77,6 +77,11 @@ bool TTFFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
   return LoadFromDiskEx(fontNumber, fontSize, NULL);
 }
 
+bool TTFFontRenderer::IsBitmapFont()
+{
+    return false;
+}
+
 bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params)
 {
   String file_name = String::FromFormat("agsfnt%d.ttf", fontNumber);
@@ -113,7 +118,10 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRen
       strcmp(alfont_get_name(alfptr), "LucasFan-Font") == 0)
       set_font_outline(fontNumber, FONT_OUTLINE_AUTO);
 #endif
-
+  if (fontSize == 0)
+      fontSize = 8; // compatibility fix
+  if (params && params->SizeMultiplier > 1)
+      fontSize *= params->SizeMultiplier;
   if (fontSize > 0)
     alfont_set_font_size(alfptr, fontSize);
 

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -33,6 +33,7 @@ public:
   virtual void EnsureTextValidForFont(char *text, int fontNumber);
 
   // IAGSFontRenderer2 implementation
+  virtual bool IsBitmapFont();
   virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params);
 
 private:

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -22,14 +22,12 @@
 
 using namespace AGS::Common;
 
-extern int wtext_multiply;
-
 static unsigned char GetCharCode(unsigned char wanted_code, const WFNFont* font)
 {
     return wanted_code < font->GetCharCount() ? wanted_code : '?';
 }
 
-static int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_char, const color_t text_color);
+static int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_char, const int scale, const color_t text_color);
 
 void WFNFontRenderer::AdjustYCoordinateForFont(int *ycoord, int fontNumber)
 {
@@ -52,6 +50,7 @@ void WFNFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
 int WFNFontRenderer::GetTextWidth(const char *text, int fontNumber)
 {
   const WFNFont* font = _fontData[fontNumber].Font;
+  const FontRenderParams &params = _fontData[fontNumber].Params;
   int text_width = 0;
 
   for (; *text; ++text)
@@ -59,12 +58,13 @@ int WFNFontRenderer::GetTextWidth(const char *text, int fontNumber)
     const WFNChar &wfn_char = font->GetChar(GetCharCode(*text, font));
     text_width += wfn_char.Width;
   }
-  return text_width * wtext_multiply;
+  return text_width * params.SizeMultiplier;
 }
 
 int WFNFontRenderer::GetTextHeight(const char *text, int fontNumber)
 {
   const WFNFont* font = _fontData[fontNumber].Font;
+  const FontRenderParams &params = _fontData[fontNumber].Params;
   int max_height = 0;
 
   for (; *text; ++text) 
@@ -74,7 +74,7 @@ int WFNFontRenderer::GetTextHeight(const char *text, int fontNumber)
     if (height > max_height)
       max_height = height;
   }
-  return max_height * wtext_multiply;
+  return max_height * params.SizeMultiplier;
 }
 
 Bitmap render_wrapper;
@@ -84,15 +84,16 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
   set_our_eip(415);
 
   const WFNFont* font = _fontData[fontNumber].Font;
+  const FontRenderParams &params = _fontData[fontNumber].Params;
   render_wrapper.WrapAllegroBitmap(destination, true);
 
   for (; *text; ++text)
-    x += RenderChar(&render_wrapper, x, y, font->GetChar(GetCharCode(*text, font)), colour);
+    x += RenderChar(&render_wrapper, x, y, font->GetChar(GetCharCode(*text, font)), params.SizeMultiplier, colour);
 
   set_our_eip(oldeip);
 }
 
-int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_char, const color_t text_color)
+int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_char, const int scale, const color_t text_color)
 {
   const int width = wfn_char.Width;
   const int height = wfn_char.Height;
@@ -106,10 +107,10 @@ int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_ch
     for (int w = 0; w < width; ++w)
     {
       if (((actdata[h * bytewid + (w / 8)] & (0x80 >> (w % 8))) != 0)) {
-        if (wtext_multiply > 1)
+        if (scale > 1)
         {
-          ds->FillRect(Rect(x + w, y + h, x + w + (wtext_multiply - 1),
-              y + h + (wtext_multiply - 1)), text_color);
+          ds->FillRect(Rect(x + w, y + h, x + w + (scale - 1),
+              y + h + (scale - 1)), text_color);
         } 
         else
         {
@@ -117,17 +118,22 @@ int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_ch
         }
       }
 
-      x += wtext_multiply - 1;
+      x += scale - 1;
     }
-    y += wtext_multiply - 1;
+    y += scale - 1;
     x = at_x;
   }
-  return width * wtext_multiply;
+  return width * scale;
 }
 
 bool WFNFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
 {
   return LoadFromDiskEx(fontNumber, fontSize, NULL);
+}
+
+bool WFNFontRenderer::IsBitmapFont()
+{
+    return true;
 }
 
 bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params)

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -31,6 +31,7 @@ public:
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber);
   virtual void EnsureTextValidForFont(char *text, int fontNumber);
 
+  virtual bool IsBitmapFont();
   virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params);
 
 private:

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -467,19 +467,22 @@ void ApplySpriteData(GameSetupStruct &game, const LoadedGameEntities &ents, Game
     }
 }
 
-void UpgradeFonts(GameSetupStruct &game)
+void UpgradeFonts(GameSetupStruct &game, GameDataVersion data_ver)
 {
-    for (int i = 0; i < game.numfonts; ++i)
+    if (data_ver < kGameVersion_350)
     {
-        FontInfo &finfo = game.fonts[i];
-        // If the game is hi-res but font is designed for low-res, then scale it up
-        if (game.IsHiRes() && game.options[OPT_NOSCALEFNT] == 0)
+        for (int i = 0; i < game.numfonts; ++i)
         {
-            finfo.SizeMultiplier = 2;
-        }
-        else
-        {
-            finfo.SizeMultiplier = 1;
+            FontInfo &finfo = game.fonts[i];
+            // If the game is hi-res but font is designed for low-res, then scale it up
+            if (game.IsHiRes() && game.options[OPT_HIRES_FONTS] == 0)
+            {
+                finfo.SizeMultiplier = 2;
+            }
+            else
+            {
+                finfo.SizeMultiplier = 1;
+            }
         }
     }
 }
@@ -753,7 +756,7 @@ HGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver
 {
     GameSetupStruct &game = ents.Game;
     ApplySpriteData(game, ents, data_ver);
-    UpgradeFonts(game);
+    UpgradeFonts(game, data_ver);
     UpgradeAudio(game, data_ver);
     AdjustScoreSound(game, data_ver);
     UpgradeCharacters(game, data_ver);

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -467,6 +467,23 @@ void ApplySpriteData(GameSetupStruct &game, const LoadedGameEntities &ents, Game
     }
 }
 
+void UpgradeFonts(GameSetupStruct &game)
+{
+    for (int i = 0; i < game.numfonts; ++i)
+    {
+        FontInfo &finfo = game.fonts[i];
+        // If the game is hi-res but font is designed for low-res, then scale it up
+        if (game.IsHiRes() && game.options[OPT_NOSCALEFNT] == 0)
+        {
+            finfo.SizeMultiplier = 2;
+        }
+        else
+        {
+            finfo.SizeMultiplier = 1;
+        }
+    }
+}
+
 // Convert audio data to the current version
 void UpgradeAudio(GameSetupStruct &game, GameDataVersion data_ver)
 {
@@ -736,6 +753,7 @@ HGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver
 {
     GameSetupStruct &game = ents.Game;
     ApplySpriteData(game, ents, data_ver);
+    UpgradeFonts(game);
     UpgradeAudio(game, data_ver);
     AdjustScoreSound(game, data_ver);
     UpgradeCharacters(game, data_ver);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -76,7 +76,7 @@ namespace AGS.Editor
          *     3.4.3      - Added missing audio properties to DefaultSetup [ forgot to change version index!! ]
          * 16: 3.5.0      - Unlimited fonts (need separate version to prevent crashes in older editors)
          * 17: 3.5.0.4    - Extended sprite source properties
-         * 18: 3.5.0.8    - Real sprite resolution
+         * 18: 3.5.0.8    - Real sprite resolution; Individual font scaling
         */
         public const int    LATEST_XML_VERSION_INDEX = 18;
         /*

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -120,7 +120,8 @@ namespace AGS.Editor.Components
 
         public override void PropertyChanged(string propertyName, object oldValue)
         {
-            AGS.Types.Font itemBeingEdited = ((FontEditor)_guiController.ActivePane.Control).ItemToEdit;
+            FontEditor editor = ((FontEditor)_guiController.ActivePane.Control);
+            AGS.Types.Font itemBeingEdited = editor.ItemToEdit;
 
             if (propertyName == "Name")
             {
@@ -136,6 +137,8 @@ namespace AGS.Editor.Components
             else
             {
                 Factory.NativeProxy.OnFontUpdated(Factory.AGSEditor.CurrentGame, itemBeingEdited.ID);
+                if (propertyName == "SizeMultiplier")
+                    editor.OnFontUpdated();
             }
         }
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -507,7 +507,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_DUPLICATEINV] = (game.Settings.DisplayMultipleInventory ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_STRICTSTRINGS] = (game.Settings.EnforceNewStrings ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_STRICTSCRIPTING] = (game.Settings.EnforceObjectBasedScript ? 1 : 0);
-            options[NativeConstants.GameOptions.OPT_NOSCALEFNT] = (game.Settings.FontsForHiRes ? 1 : 0);
+            options[NativeConstants.GameOptions.OPT_HIRES_FONTS] = 0; // always ignore this setting
             options[NativeConstants.GameOptions.OPT_NEWGUIALPHA] = (int)game.Settings.GUIAlphaStyle;
             options[NativeConstants.GameOptions.OPT_SPRITEALPHA] = (int)game.Settings.SpriteAlphaStyle;
             options[NativeConstants.GameOptions.OPT_HANDLEINVCLICKS] = (game.Settings.HandleInvClicksInScript ? 1 : 0);
@@ -1392,7 +1392,17 @@ namespace AGS.Editor
             WriteString(game.Settings.SaveGameFolderName, NativeConstants.MAX_SG_FOLDER_LEN, writer);
             for (int i = 0; i < game.Fonts.Count; ++i)
             {
-                writer.Write((byte)(game.Fonts[i].PointSize & NativeConstants.FFLG_SIZEMASK));
+                byte flags = 0;
+                if (game.Fonts[i].PointSize == 0)
+                {
+                    flags = (byte)(NativeConstants.FFLG_SIZEMULTIPLIER << 6);
+                    flags |= (byte)(game.Fonts[i].SizeMultiplier & NativeConstants.FFLG_SIZEMASK);
+                }
+                else
+                {
+                    flags = (byte)(game.Fonts[i].PointSize & NativeConstants.FFLG_SIZEMASK);
+                }
+                writer.Write(flags);
             }
             for (int i = 0; i < game.Fonts.Count; ++i)
             {

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -38,6 +38,11 @@ namespace AGS.Editor
             }
         }
 
+        public void OnFontUpdated()
+        {
+            PaintFont();
+        }
+
         protected override string OnGetHelpKeyword()
         {
             return "Fonts";

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -126,8 +126,7 @@ namespace AGS.Editor
             {
                 HandleGameResolutionChange((Size)e.OldValue, Factory.AGSEditor.CurrentGame.Settings.CustomResolution);
             }
-            else if ((e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_SCALE_FONTS) ||
-                     (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_ANTI_ALIAS_FONTS) ||
+            else if ((e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_ANTI_ALIAS_FONTS) ||
                      (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_RENDERATSCREENRES))
             {
                 Factory.Events.OnGameSettingsChanged();

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -195,6 +195,20 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 18)
+            {
+                foreach (Font font in game.Fonts)
+                    font.SizeMultiplier = 1;
+                // Apply font scaling to each individual font settings
+                if (game.IsHighResolution && !game.Settings.FontsForHiRes)
+                {
+                    foreach (Font font in game.Fonts)
+                    {
+                        font.SizeMultiplier = 2;
+                    }
+                }
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -16,6 +16,7 @@ namespace AGS.Editor
         public static readonly int MAX_SG_FOLDER_LEN = (int)Factory.NativeProxy.GetNativeConstant("MAX_SG_FOLDER_LEN");
         public static readonly int MAX_SCRIPT_NAME_LEN = (int)Factory.NativeProxy.GetNativeConstant("MAX_SCRIPT_NAME_LEN");
         public static readonly int FFLG_SIZEMASK = (int)Factory.NativeProxy.GetNativeConstant("FFLG_SIZEMASK");
+        public static readonly int FFLG_SIZEMULTIPLIER = (int)Factory.NativeProxy.GetNativeConstant("FFLG_SIZEMULTIPLIER");
         public static readonly char IFLG_STARTWITH = (char)(int)Factory.NativeProxy.GetNativeConstant("IFLG_STARTWITH");
         public static readonly char MCF_ANIMMOVE = (char)(int)Factory.NativeProxy.GetNativeConstant("MCF_ANIMMOVE");
         public static readonly char MCF_STANDARD = (char)(int)Factory.NativeProxy.GetNativeConstant("MCF_STANDARD");
@@ -100,7 +101,7 @@ namespace AGS.Editor
             public static readonly int OPT_NOWALKMODE = (int)Factory.NativeProxy.GetNativeConstant("OPT_NOWALKMODE");
             public static readonly int OPT_LETTERBOX = (int)Factory.NativeProxy.GetNativeConstant("OPT_LETTERBOX");
             public static readonly int OPT_FIXEDINVCURSOR = (int)Factory.NativeProxy.GetNativeConstant("OPT_FIXEDINVCURSOR");
-            public static readonly int OPT_NOSCALEFNT = (int)Factory.NativeProxy.GetNativeConstant("OPT_NOSCALEFNT");
+            public static readonly int OPT_HIRES_FONTS = (int)Factory.NativeProxy.GetNativeConstant("OPT_HIRES_FONTS");
             public static readonly int OPT_SPLITRESOURCES = (int)Factory.NativeProxy.GetNativeConstant("OPT_SPLITRESOURCES");
             public static readonly int OPT_ROTATECHARS = (int)Factory.NativeProxy.GetNativeConstant("OPT_ROTATECHARS");
             public static readonly int OPT_FADETYPE = (int)Factory.NativeProxy.GetNativeConstant("OPT_FADETYPE");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -647,6 +647,7 @@ namespace AGS
             if (name->Equals("MAX_SG_FOLDER_LEN")) return MAX_SG_FOLDER_LEN;
             if (name->Equals("MAX_SCRIPT_NAME_LEN")) return MAX_SCRIPT_NAME_LEN;
             if (name->Equals("FFLG_SIZEMASK")) return FFLG_SIZEMASK;
+            if (name->Equals("FFLG_SIZEMULTIPLIER")) return FFLG_SIZEMULTIPLIER;
             if (name->Equals("IFLG_STARTWITH")) return IFLG_STARTWITH;
             if (name->Equals("MCF_ANIMMOVE")) return MCF_ANIMMOVE;
             if (name->Equals("MCF_STANDARD")) return MCF_STANDARD;
@@ -725,7 +726,7 @@ namespace AGS
             if (name->Equals("OPT_NOWALKMODE")) return OPT_NOWALKMODE;
             if (name->Equals("OPT_LETTERBOX")) return OPT_LETTERBOX;
             if (name->Equals("OPT_FIXEDINVCURSOR")) return OPT_FIXEDINVCURSOR;
-            if (name->Equals("OPT_NOSCALEFNT")) return OPT_NOSCALEFNT;
+            if (name->Equals("OPT_HIRES_FONTS")) return OPT_HIRES_FONTS;
             if (name->Equals("OPT_SPLITRESOURCES")) return OPT_SPLITRESOURCES;
             if (name->Equals("OPT_ROTATECHARS")) return OPT_ROTATECHARS;
             if (name->Equals("OPT_FADETYPE")) return OPT_FADETYPE;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -931,17 +931,18 @@ void draw_room_background(void *roomvoidptr, int hdc, int x, int y, int bgnum, f
 	
 }
 
+int global_font_scaling;
 void update_font_sizes() {
-  int multiplyWas = wtext_multiply;
+  int multiplyWas = global_font_scaling;
 
   // scale up fonts if necessary
-  wtext_multiply = 1;
+  global_font_scaling = 1;
   if ((thisgame.options[OPT_NOSCALEFNT] == 0) &&
       thisgame.IsHiRes()) {
-    wtext_multiply = 2;
+    global_font_scaling = 2;
   }
 
-  if (multiplyWas != wtext_multiply) {
+  if (multiplyWas != global_font_scaling) {
     // resolution or Scale Up Fonts has changed, reload at new size
     for (int bb=0;bb<thisgame.numfonts;bb++)
       reload_font (bb);
@@ -1438,16 +1439,18 @@ bool reload_font(int curFont)
   wfreefont(curFont);
 
   FontInfo fi = thisgame.fonts[curFont];
-
-  // TODO: for some reason these compat fixes are different in the engine, investigate
   // if the font is designed for 640x400, half it
   if (thisgame.options[OPT_NOSCALEFNT]) {
+    fi.SizeMultiplier = 1;
+    // TODO: for some reason this compat fix is absent in the engine, investigate
     if (!thisgame.IsHiRes())
       fi.SizePt /= 2;
   }
   else if (thisgame.IsHiRes()) {
     // designed for 320x200, double it up
-    fi.SizePt *= 2;
+    fi.SizeMultiplier = 2;
+  } else {
+    fi.SizeMultiplier = 1;
   }
   return wloadfont_size(curFont, fi);
 }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -16,6 +16,7 @@ namespace AGS.Types
         private int _outlineFont;
         private FontOutlineStyle _outlineStyle;
 		private string _sourceFilename = string.Empty;
+        private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
 
@@ -124,6 +125,20 @@ namespace AGS.Types
 			get { return _sourceFilename; }
 			set { _sourceFilename = value; }
 		}
+
+        [Description("Font's size multiplier; primarily for bitmap fonts that don't scale on their own")]
+        [Category("Appearance")]
+        [DefaultValue(1)]
+        public int SizeMultiplier
+        {
+            get { return _sizeMultiplier; }
+            set
+            {
+                if (value < 1)
+                    throw new ArgumentException("ScalingMultiplier must be 1 or greater.");
+                _sizeMultiplier = value;
+            }
+        }
 
         [Description("Vertical offset to render font letters at, in pixels (can be negative)")]
         [Category("Appearance")]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -17,7 +17,7 @@ namespace AGS.Types
         public const string PROPERTY_GAME_NAME = "Game name";
         public const string PROPERTY_COLOUR_DEPTH = "Colour depth";
         public const string PROPERTY_RESOLUTION = "Resolution";
-        public const string PROPERTY_SCALE_FONTS = "Fonts designed for high resolution";
+        public const string PROPERTY_LEGACY_HIRES_FONTS = "Fonts designed for high resolution";
 		public const string PROPERTY_ANTI_ALIAS_FONTS = "Anti-alias TTF fonts";
         public const string PROPERTY_LETTERBOX_MODE = "Enable letterbox mode";
         public const string PROPERTY_BUILD_TARGETS = "Build target platforms";
@@ -789,7 +789,9 @@ namespace AGS.Types
             set { _alwaysDisplayTextAsSpeech = value; }
         }
 
-        [DisplayName(PROPERTY_SCALE_FONTS)]
+        [AGSNoSerialize]
+        [Browsable(false)]
+        [DisplayName(PROPERTY_LEGACY_HIRES_FONTS)]
         [Description("Tells AGS that your fonts are designed for high resolution (higher than 320x240), and therefore not to scale them up in hi-res game")]
         [DefaultValue(false)]
         [Category("Text output")]

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -440,8 +440,8 @@ void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color
     else if (get_font_outline(usingfont) == FONT_OUTLINE_AUTO) {
         int outlineDist = 1;
 
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(usingfont))) {
-            // if it's a scaled up SCI font, move the outline out more
+        if (is_bitmap_font(usingfont) && get_font_scaling_mul(usingfont) > 1) {
+            // if it's a scaled up bitmap font, move the outline out more
             outlineDist = get_fixed_pixel_size(1);
         }
 
@@ -476,8 +476,8 @@ int get_outline_adjustment(int font)
 {
     // automatic outline fonts are 2 pixels taller
     if (get_font_outline(font) == FONT_OUTLINE_AUTO) {
-        // scaled up SCI font, push outline further out
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(font)))
+        // scaled up bitmap font, push outline further out
+        if (is_bitmap_font(font) && get_font_scaling_mul(font) > 1)
             return get_fixed_pixel_size(2);
         // otherwise, just push outline by 1 pixel
         else
@@ -513,7 +513,7 @@ int wgettextwidth_compensate(const char *tex, int font) {
 
     if (get_font_outline(font) == FONT_OUTLINE_AUTO) {
         // scaled up SCI font, push outline further out
-        if ((game.options[OPT_NOSCALEFNT] == 0) && (!font_supports_extended_characters(font)))
+        if (is_bitmap_font(font) && get_font_scaling_mul(font) > 1)
             wdof += get_fixed_pixel_size(2);
         // otherwise, just push outline by 1 pixel
         else

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -29,6 +29,7 @@
 #include "ac/statobj/staticarray.h"
 #include "debug/debug_log.h"
 #include "debug/out.h"
+#include "font/agsfontrenderer.h"
 #include "font/fonts.h"
 #include "game/game_init.h"
 #include "gfx/bitmap.h"
@@ -320,17 +321,7 @@ void LoadFonts()
 {
     for (int i = 0; i < game.numfonts; ++i) 
     {
-        FontInfo finfo = game.fonts[i];
-
-        // Apply compatibility adjustments
-        if (finfo.SizePt == 0)
-            finfo.SizePt = 8;
-
-        // TODO: for some reason these compat fixes are different in the editor, investigate
-        if ((game.options[OPT_NOSCALEFNT] == 0) && game.IsHiRes())
-            finfo.SizePt *= 2;
-
-        if (!wloadfont_size(i, finfo, NULL))
+        if (!wloadfont_size(i, game.fonts[i]))
             quitprintf("Unable to load font %d, no renderer could load a matching file", i);
     }
 }

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -317,7 +317,7 @@ HError InitAndRegisterGameEntities()
     return HError::None();
 }
 
-void LoadFonts()
+void LoadFonts(GameDataVersion data_ver)
 {
     for (int i = 0; i < game.numfonts; ++i) 
     {
@@ -409,7 +409,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     HError err = InitAndRegisterGameEntities();
     if (!err)
         return new GameInitError(kGameInitErr_EntityInitFail, err);
-    LoadFonts();
+    LoadFonts(data_ver);
 
     //
     // 4. Initialize certain runtime variables

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -962,8 +962,6 @@ void engine_init_game_settings()
             palette[ee]=game.defpal[ee];
     }
 
-    if (game.options[OPT_NOSCALEFNT]) wtext_multiply=1;
-
     for (ee = 0; ee < game.numcursors; ee++) 
     {
         // The cursor graphics are assigned to mousecurs[] and so cannot

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -149,14 +149,12 @@ void engine_init_resolution_settings(const Size game_size)
             native_size.Height = game_size.Height / 2;
         }
         current_screen_resolution_multiplier = 2;
-        wtext_multiply = 2;
     }
     else
     {
         native_size.Width = game_size.Width;
         native_size.Height = game_size.Height;
         current_screen_resolution_multiplier = 1;
-        wtext_multiply = 1;
     }
     play.SetNativeSize(native_size);
 


### PR DESCRIPTION
Similar to sprite resolution tag (#651), global font scale setting made all fonts in game scale up x2 if the game is considered high res. This pr replaces that setting with individual size multiplier for each font which may be set regardless of game resolution.

This setting is primarily meant for bitmap fonts, as it's pretty useless for TTF which have their own scaling. But it is applied to latter as well for consistency (simply multiplying the Size parameter).

When importing older game AGS will apply x2 scaling to each font if game was hires and did not have "Fonts are designed for high resolution" setting enabled.