### PR TITLE
Script API: SkipCutscene and cutscene that cannot be skipped by user input

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1445,6 +1445,11 @@ import void ClaimEvent();
 import void SetTextWindowGUI (int gui);
 import int  FindGUIID(const string);  // $AUTOCOMPLETEIGNORE$
 
+#ifdef SCRIPT_API_v3507
+/// Skip current cutscene (if one is currently in progress)
+import void SkipCutscene();
+#endif
+
 #ifndef STRICT
 // Obsolete GUI functions
 import void SetInvDimensions(int width, int height);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -186,7 +186,8 @@ enum CutsceneSkipType {
   eSkipAnyKey = 2,
   eSkipMouseClick = 3,
   eSkipAnyKeyOrMouseClick = 4,
-  eSkipESCOrRightButton = 5
+  eSkipESCOrRightButton = 5,
+  eSkipScriptOnly = 6
 };
 
 enum DialogOptionState {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1745,7 +1745,7 @@ void start_skipping_cutscene () {
 
 void check_skip_cutscene_keypress (int kgn) {
 
-    if ((play.in_cutscene > 0) && (play.in_cutscene != 3)) {
+    if ((play.in_cutscene > 0) && (play.in_cutscene != 3) && (play.in_cutscene != 6)) {
         if ((kgn != 27) && ((play.in_cutscene == 1) || (play.in_cutscene == 5)))
             ;
         else

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2015,6 +2015,11 @@ RuntimeScriptValue Sc_ShowMouseCursor(const RuntimeScriptValue *params, int32_t 
     API_SCALL_VOID(ShowMouseCursor);
 }
 
+RuntimeScriptValue Sc_SkipCutscene(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID(SkipCutscene);
+}
+
 // void (int cc)
 RuntimeScriptValue Sc_SkipUntilCharacterStops(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2616,6 +2621,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("ShakeScreen",              Sc_ShakeScreen);
 	ccAddExternalStaticFunction("ShakeScreenBackground",    Sc_ShakeScreenBackground);
 	ccAddExternalStaticFunction("ShowMouseCursor",          Sc_ShowMouseCursor);
+    ccAddExternalStaticFunction("SkipCutscene",             Sc_SkipCutscene);
 	ccAddExternalStaticFunction("SkipUntilCharacterStops",  Sc_SkipUntilCharacterStops);
 	ccAddExternalStaticFunction("StartCutscene",            Sc_StartCutscene);
 	ccAddExternalStaticFunction("StartRecording",           Sc_scStartRecording);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -464,6 +464,7 @@ void EndSkippingUntilCharStops() {
 // 3 = mouse button
 // 4 = mouse button or any key
 // 5 = right click or ESC only
+// 6 = nothing, only skip by script command
 void StartCutscene (int skipwith) {
     static ScriptPosition last_cutscene_script_pos;
 
@@ -472,7 +473,7 @@ void StartCutscene (int skipwith) {
             last_cutscene_script_pos.Section.GetCStr(), last_cutscene_script_pos.Line);
     }
 
-    if ((skipwith < 1) || (skipwith > 5))
+    if ((skipwith < 1) || (skipwith > 6))
         quit("!StartCutscene: invalid argument, must be 1 to 5.");
 
     get_script_position(last_cutscene_script_pos);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -484,6 +484,12 @@ void StartCutscene (int skipwith) {
     initialize_skippable_cutscene();
 }
 
+void SkipCutscene()
+{
+    if (play.in_cutscene > 0)
+        start_skipping_cutscene();
+}
+
 int EndCutscene () {
     if (play.in_cutscene == 0)
         quit("!EndCutscene: not in a cutscene");

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -53,6 +53,8 @@ void EndSkippingUntilCharStops();
 // 5 = right click or ESC only
 void StartCutscene (int skipwith);
 int EndCutscene ();
+// Tell the game to skip current cutscene
+void SkipCutscene();
 
 void sc_inputbox(const char*msg,char*bufr);
 


### PR DESCRIPTION
Implemented eSkipScriptOnly cutscene mode and SkipCutscene() function to let users little more flexibility in scripting cutscenes.