### PR TITLE
AGS3: big refactor to put all audio logic under control of one mutex

### DIFF
--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -39,8 +39,11 @@ int AudioChannel_GetIsPlaying(ScriptAudioChannel *channel)
         return 0;
     }
 
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         return 1;
     }
@@ -49,10 +52,13 @@ int AudioChannel_GetIsPlaying(ScriptAudioChannel *channel)
 
 int AudioChannel_GetPanning(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->panningAsPercentage;
+        return ch->panningAsPercentage;
     }
     return 0;
 }
@@ -62,66 +68,84 @@ void AudioChannel_SetPanning(ScriptAudioChannel *channel, int newPanning)
     if ((newPanning < -100) || (newPanning > 100))
         quitprintf("!AudioChannel.Panning: panning value must be between -100 and 100 (passed=%d)", newPanning);
 
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_panning(((newPanning + 100) * 255) / 200);
-        channels[channel->id]->panningAsPercentage = newPanning;
+        ch->set_panning(((newPanning + 100) * 255) / 200);
+        ch->panningAsPercentage = newPanning;
     }
 }
 
 ScriptAudioClip* AudioChannel_GetPlayingClip(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return (ScriptAudioClip*)channels[channel->id]->sourceClip;
+        return (ScriptAudioClip*)ch->sourceClip;
     }
     return NULL;
 }
 
 int AudioChannel_GetPosition(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         if (play.fast_forward)
             return 999999999;
 
-        return channels[channel->id]->get_pos();
+        return ch->get_pos();
     }
     return 0;
 }
 
 int AudioChannel_GetPositionMs(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         if (play.fast_forward)
             return 999999999;
 
-        return channels[channel->id]->get_pos_ms();
+        return ch->get_pos_ms();
     }
     return 0;
 }
 
 int AudioChannel_GetLengthMs(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_length_ms();
+        return ch->get_length_ms();
     }
     return 0;
 }
 
 int AudioChannel_GetVolume(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_volume();
+        return ch->get_volume();
     }
     return 0;
 }
@@ -131,36 +155,45 @@ int AudioChannel_SetVolume(ScriptAudioChannel *channel, int newVolume)
     if ((newVolume < 0) || (newVolume > 100))
         quitprintf("!AudioChannel.Volume: new value out of range (supplied: %d, range: 0..100)", newVolume);
 
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_volume_percent(newVolume);
+        ch->set_volume_percent(newVolume);
     }
     return 0;
 }
 
 int AudioChannel_GetSpeed(ScriptAudioChannel *channel)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_speed();
+        return ch->get_speed();
     }
     return 0;
 }
 
 void AudioChannel_SetSpeed(ScriptAudioChannel *channel, int new_speed)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_speed(new_speed);
+        ch->set_speed(new_speed);
     }
 }
 
 void AudioChannel_Stop(ScriptAudioChannel *channel)
 {
-    stop_or_fade_out_channel(channel->id, -1, NULL);
+    stop_or_fade_out_channel(channel->id, -1, nullptr);
 }
 
 void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
@@ -168,29 +201,35 @@ void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
     if (newPosition < 0)
         quitprintf("!AudioChannel.Seek: invalid seek position %d", newPosition);
 
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->seek(newPosition);
+        ch->seek(newPosition);
     }
 }
 
 void AudioChannel_SetRoomLocation(ScriptAudioChannel *channel, int xPos, int yPos)
 {
-    if ((channels[channel->id] != NULL) &&
-        (channels[channel->id]->done == 0))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         int maxDist = ((xPos > thisroom.Width / 2) ? xPos : (thisroom.Width - xPos)) - AMBIENCE_FULL_DIST;
-        channels[channel->id]->xSource = (xPos > 0) ? xPos : -1;
-        channels[channel->id]->ySource = yPos;
-        channels[channel->id]->maximumPossibleDistanceAway = maxDist;
+        ch->xSource = (xPos > 0) ? xPos : -1;
+        ch->ySource = yPos;
+        ch->maximumPossibleDistanceAway = maxDist;
         if (xPos > 0)
         {
             update_directional_sound_vol();
         }
         else
         {
-            channels[channel->id]->apply_directional_modifier(0);
+            ch->apply_directional_modifier(0);
         }
     }
 }

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -41,9 +41,11 @@ int AudioClip_GetIsAvailable(ScriptAudioClip *clip)
 
 void AudioClip_Stop(ScriptAudioClip *clip)
 {
+    AudioChannelsLock _lock;
     for (int i = 0; i < MAX_SOUND_CHANNELS; i++)
     {
-        if ((channels[i] != NULL) && (!channels[i]->done) && (channels[i]->sourceClip == clip))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (!ch->done) && (ch->sourceClip == clip))
         {
             AudioChannel_Stop(&scrAudioChannel[i]);
         }

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -26,6 +26,7 @@
 #include "game/roomstruct.h"
 #include "main/maindefines_ex.h"	// RETURN_CONTINUE
 #include "main/update.h"
+#include "media/audio/audio.h"
 
 using namespace AGS::Common;
 
@@ -35,7 +36,6 @@ extern int displayed_room;
 extern GameState play;
 extern int char_speaking;
 extern RoomStruct thisroom;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern unsigned int loopcounter;
 
 #define Random __Rand
@@ -265,7 +265,8 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
         ((walking == 0) || ((flags & CHF_MOVENOTWALK) != 0)) &&
         (room == displayed_room)) 
     {
-      const bool is_voice = channels[SCHAN_SPEECH] != NULL;
+      AudioChannelsLock _lock;
+      const bool is_voice = _lock.GetChannel(SCHAN_SPEECH) != nullptr;
 
       doing_nothing = 0;
       // idle anim doesn't count as doing something

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -296,25 +296,29 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             PollUntilNextFrame();
             countdown--;
 
-            if (channels[SCHAN_SPEECH] != NULL) {
-                // extend life of text if the voice hasn't finished yet
-                if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
-                    if (countdown <= 1)
-                        countdown = 1;
-                }
-                else  // if the voice has finished, remove the speech
-                    countdown = 0;
-            }
-
-            if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
-                play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms / time_between_timers);
-                break;
+                AudioChannelsLock _lock;
+                auto* speech_ch = _lock.GetChannel(SCHAN_SPEECH);
+                if (speech_ch != nullptr) {
+                    // extend life of text if the voice hasn't finished yet
+                    if ((!speech_ch->done) && (play.fast_forward == 0)) {
+                        if (countdown <= 1)
+                            countdown = 1;
+                    }
+                    else  // if the voice has finished, remove the speech
+                        countdown = 0;
+                }
+
+                if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
+                {
+                    play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms / time_between_timers);
+                    break;
+                }
+                // if skipping cutscene, don't get stuck on No Auto Remove
+                // text boxes
+                if ((countdown < 1) && (play.fast_forward))
+                    break;
             }
-            // if skipping cutscene, don't get stuck on No Auto Remove
-            // text boxes
-            if ((countdown < 1) && (play.fast_forward))
-                break;
         }
         if (!play.mouse_cursor_hidden)
             ags_domouse(DOMOUSE_DISABLE);

--- a/Engine/ac/dynobj/cc_audiochannel.cpp
+++ b/Engine/ac/dynobj/cc_audiochannel.cpp
@@ -16,7 +16,7 @@
 #include "media/audio/audiodefines.h"
 #include "ac/dynobj/scriptaudiochannel.h"
 
-extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
+extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS];
 
 const char *CCAudioChannel::GetType() {
     return "AudioChannel";

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -29,7 +29,6 @@ extern GameSetupStruct game;
 extern GameState play;
 
 extern volatile unsigned long globalTimerCounter;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern int pluginSimulatedClick;
 extern int displayed_room;
 extern char check_dynamic_sprites_at_exit;

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -30,13 +30,13 @@
 #include "ac/dynobj/cc_audiochannel.h"
 #include "main/graphics_mode.h"
 #include "ac/global_debug.h"
+#include "media/audio/audio.h"
 
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern GameSetup usetup;
 extern GameState play;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
 extern ScriptSystem scsystem;
 extern IGraphicsDriver *gfxDriver;
@@ -201,9 +201,11 @@ void System_SetVolume(int newvol)
     // if it was previously set low; so restore them
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) 
     {
-        if ((channels[i] != NULL) && (channels[i]->done == 0)) 
+        AudioChannelsLock _lock;
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0)) 
         {
-            channels[i]->adjust_volume();
+            ch->adjust_volume();
         }
     }
 }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -23,6 +23,7 @@
 #include "ac/dynobj/cc_audioclip.h"
 #include "ac/draw.h"
 #include "ac/game_version.h"
+#include "media/audio/audio.h"
 
 using AGS::Common::Bitmap;
 using AGS::Common::Graphics;
@@ -31,7 +32,6 @@ extern GameSetupStruct game;
 extern ViewStruct*views;
 extern SpriteCache spriteset;
 extern CCAudioClip ccDynamicAudioClip;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 
 
 int ViewFrame_GetFlipped(ScriptViewFrame *svf) {
@@ -147,7 +147,11 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
         }
     }
     if (sound_volume != SCR_NO_VALUE && channel != NULL)
-        channels[channel->id]->set_volume_percent(channels[channel->id]->get_volume() * sound_volume / 100);
+    {
+        AudioChannelsLock _lock;
+        auto* ch = _lock.GetChannel(channel->id);
+        ch->set_volume_percent(ch->get_volume() * sound_volume / 100);
+    }
     
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -553,41 +553,50 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     const int cf_out_chan = play.crossfading_out_channel;
     play.crossfading_in_channel = 0;
     play.crossfading_out_channel = 0;
-    // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
-    for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
+    
     {
-        const RestoredData::ChannelInfo &chan_info = r_data.AudioChans[i];
-        if (chan_info.ClipID < 0)
-            continue;
-        if (chan_info.ClipID >= game.audioClipCount)
+        AudioChannelsLock _lock;
+        // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
+        for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
         {
-            return new SavegameError(kSvgErr_GameObjectInitFailed,
-                String::FromFormat("Invalid audio clip index: %d (clip count: %d).", chan_info.ClipID, game.audioClipCount));
-        }
-        play_audio_clip_on_channel(i, &game.audioClips[chan_info.ClipID],
-            chan_info.Priority, chan_info.Repeat, chan_info.Pos);
-        if (channels[i] != NULL)
-        {
-            channels[i]->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
-            channels[i]->set_speed(chan_info.Speed);
-            channels[i]->set_panning(chan_info.Pan);
-            channels[i]->panningAsPercentage = chan_info.PanAsPercent;
-        }
-    }
-    if ((cf_in_chan > 0) && (channels[cf_in_chan] != NULL))
-        play.crossfading_in_channel = cf_in_chan;
-    if ((cf_out_chan > 0) && (channels[cf_out_chan] != NULL))
-        play.crossfading_out_channel = cf_out_chan;
+            const RestoredData::ChannelInfo &chan_info = r_data.AudioChans[i];
+            if (chan_info.ClipID < 0)
+                continue;
+            if (chan_info.ClipID >= game.audioClipCount)
+            {
+                return new SavegameError(kSvgErr_GameObjectInitFailed,
+                    String::FromFormat("Invalid audio clip index: %d (clip count: %d).", chan_info.ClipID, game.audioClipCount));
+            }
+            play_audio_clip_on_channel(i, &game.audioClips[chan_info.ClipID],
+                chan_info.Priority, chan_info.Repeat, chan_info.Pos);
+            
+            auto* ch = _lock.GetChannel(i);
 
-    // If there were synced audio tracks, the time taken to load in the
-    // different channels will have thrown them out of sync, so re-time it
-    // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
-    for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
-    {
-        int pos = r_data.AudioChans[i].Pos;
-        if ((pos > 0) && (channels[i] != NULL) && (channels[i]->done == 0))
+            if (ch != NULL)
+            {
+                ch->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
+                ch->set_speed(chan_info.Speed);
+                ch->set_panning(chan_info.Pan);
+                ch->panningAsPercentage = chan_info.PanAsPercent;
+            }
+        }
+
+        if ((cf_in_chan > 0) && (_lock.GetChannel(cf_in_chan) != nullptr))
+            play.crossfading_in_channel = cf_in_chan;
+        if ((cf_out_chan > 0) && (_lock.GetChannel(cf_out_chan) != nullptr))
+            play.crossfading_out_channel = cf_out_chan;
+
+        // If there were synced audio tracks, the time taken to load in the
+        // different channels will have thrown them out of sync, so re-time it
+        // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
+        for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
         {
-            channels[i]->seek(pos);
+            auto* ch = _lock.GetChannel(i);
+            int pos = r_data.AudioChans[i].Pos;
+            if ((pos > 0) && (ch != nullptr) && (ch->done == 0))
+            {
+                ch->seek(pos);
+            }
         }
     }
 
@@ -630,8 +639,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // test if the playing music was properly loaded
     if (current_music_type > 0)
     {
-        if (crossFading > 0 && !channels[crossFading] ||
-            crossFading <= 0 && !channels[SCHAN_MUSIC])
+        AudioChannelsLock _lock;
+
+        if (crossFading > 0 && !_lock.GetChannel(crossFading) ||
+            crossFading <= 0 && !_lock.GetChannel(SCHAN_MUSIC))
         {
             current_music_type = 0;
         }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -267,19 +267,21 @@ HSaveError WriteAudio(PStream out)
     }
 
     // Audio clips and crossfade
+    AudioChannelsLock _lock;
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++)
     {
-        if ((channels[i] != NULL) && (channels[i]->done == 0) && (channels[i]->sourceClip != NULL))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0) && (ch->sourceClip != NULL))
         {
-            out->WriteInt32(((ScriptAudioClip*)channels[i]->sourceClip)->id);
-            out->WriteInt32(channels[i]->get_pos());
-            out->WriteInt32(channels[i]->priority);
-            out->WriteInt32(channels[i]->repeat ? 1 : 0);
-            out->WriteInt32(channels[i]->vol);
-            out->WriteInt32(channels[i]->panning);
-            out->WriteInt32(channels[i]->volAsPercentage);
-            out->WriteInt32(channels[i]->panningAsPercentage);
-            out->WriteInt32(channels[i]->speed);
+            out->WriteInt32(((ScriptAudioClip*)ch->sourceClip)->id);
+            out->WriteInt32(ch->get_pos());
+            out->WriteInt32(ch->priority);
+            out->WriteInt32(ch->repeat ? 1 : 0);
+            out->WriteInt32(ch->vol);
+            out->WriteInt32(ch->panning);
+            out->WriteInt32(ch->volAsPercentage);
+            out->WriteInt32(ch->panningAsPercentage);
+            out->WriteInt32(ch->speed);
         }
         else
         {

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -86,7 +86,7 @@ struct RestoredData
         int PanAsPercent;
         int Speed;
     };
-    ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
+    ChannelInfo             AudioChans[MAX_SOUND_CHANNELS];
     // Ambient sounds
     int                     DoAmbient[MAX_SOUND_CHANNELS];
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -248,14 +248,15 @@ void update_overlay_timers()
 
 void update_speech_and_messages()
 {
-  const bool is_voice = channels[SCHAN_SPEECH] != NULL;
+  AudioChannelsLock _lock;
+  const bool is_voice = _lock.GetChannel(SCHAN_SPEECH) != nullptr;
 
   // determine if speech text should be removed
   if (play.messagetime>=0) {
     play.messagetime--;
     // extend life of text if the voice hasn't finished yet
     if (is_voice && !play.speech_in_post_state) {
-      if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
+      if ((!_lock.GetChannel(SCHAN_SPEECH)->done) && (play.fast_forward == 0)) {
       //if ((!channels[SCHAN_SPEECH]->done) && (play.fast_forward == 0)) {
         if (play.messagetime <= 1)
           play.messagetime = 1;
@@ -291,7 +292,9 @@ void update_speech_and_messages()
 
 void update_sierra_speech()
 {
-  const bool is_voice = channels[SCHAN_SPEECH] != NULL;
+  AudioChannelsLock _lock;
+  const bool is_voice = _lock.GetChannel(SCHAN_SPEECH) != nullptr;
+
 	// update sierra-style speech
   if ((face_talking >= 0) && (play.fast_forward == 0)) 
   {
@@ -328,7 +331,7 @@ void update_sierra_speech()
 
     if (curLipLine >= 0) {
       // check voice lip sync
-      int spchOffs = channels[SCHAN_SPEECH]->get_pos_ms ();
+      int spchOffs = _lock.GetChannel(SCHAN_SPEECH)->get_pos_ms ();
       if (curLipLinePhoneme >= splipsync[curLipLine].numPhonemes) {
         // the lip-sync has finished, so just stay idle
       }

--- a/Engine/media/audio/ambientsound.cpp
+++ b/Engine/media/audio/ambientsound.cpp
@@ -16,15 +16,17 @@
 #include "media/audio/audiodefines.h"
 #include "media/audio/soundclip.h"
 #include "util/stream.h"
+#include "media/audio/audio.h"
 
 using AGS::Common::Stream;
 
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
-
 bool AmbientSound::IsPlaying () {
+    
     if (channel <= 0)
         return false;
-    return (channels[channel] != NULL) ? true : false;
+
+    AudioChannelsLock _lock;
+    return (_lock.GetChannel(channel) != nullptr) ? true : false;
 }
 
 void AmbientSound::ReadFromFile(Stream *in)

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -15,6 +15,8 @@
 #ifndef __AC_AUDIO_H
 #define __AC_AUDIO_H
 
+#include <array>
+
 #include "media/audio/audiodefines.h"
 #include "ac/dynobj/scriptaudioclip.h"
 #include "ac/dynobj/scriptaudiochannel.h"
@@ -25,15 +27,34 @@
 
 struct SOUNDCLIP;
 
+//controls access to the channels, since that's the main point of synchronization between the streaming thread and the user code
+//this is going to be dependent on the underlying mutexes being recursive
+//yes, we will have more recursive traffic on mutexes than we need
+//however this should mostly be happening only when playing sounds, and possibly when sounds numbering only several
+//the load should not be high
+class AudioChannelsLock : public AGS::Engine::MutexLock
+{
+private:
+    AudioChannelsLock(AudioChannelsLock const &); // non-copyable
+    AudioChannelsLock& operator=(AudioChannelsLock const &); // not copy-assignable
+
+public:
+    static AGS::Engine::Mutex s_mutex;
+    AudioChannelsLock()
+        : MutexLock(s_mutex)
+    {
+    }
+
+    SOUNDCLIP* GetChannel(int index);
+    void SetChannel(int index, SOUNDCLIP* ch);
+};
+
+
 void        calculate_reserved_channel_count();
 void        update_clip_default_volume(ScriptAudioClip *audioClip);
 void        start_fading_in_new_track_if_applicable(int fadeInChannel, ScriptAudioClip *newSound);
-void        move_track_to_crossfade_channel(int currentChannel, int crossfadeSpeed, int fadeInChannel, ScriptAudioClip *newSound);
 void        stop_or_fade_out_channel(int fadeOutChannel, int fadeInChannel = -1, ScriptAudioClip *newSound = NULL);
-int         find_free_audio_channel(ScriptAudioClip *clip, int priority, bool interruptEqualPriority);
 SOUNDCLIP*  load_sound_clip(ScriptAudioClip *audioClip, bool repeat);
-void        audio_update_polled_stuff();
-void        queue_audio_clip_to_play(ScriptAudioClip *clip, int priority, int repeat);
 ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *clip, int priority, int repeat, int fromOffset, SOUNDCLIP *cachedClip = NULL);
 void        remove_clips_of_type_from_queue(int audioType);
 void        update_queued_clips_volume(int audioType, int new_vol);
@@ -63,7 +84,6 @@ bool        is_audiotype_allowed_to_play(AudioFileType type);
 SOUNDCLIP * load_sound_and_play(ScriptAudioClip *aclip, bool repeat);
 void        stop_all_sound_and_music();
 void        shutdown_sound();
-int         play_sound_priority (int val1, int priority);
 int         play_sound(int val1);
 
 //=============================================================================
@@ -86,13 +106,10 @@ int         prepare_for_new_music ();
 // Gets audio clip from legacy music number, which also may contain queue flag
 ScriptAudioClip *get_audio_clip_for_music(int mnum);
 SOUNDCLIP * load_music_from_disk(int mnum, bool doRepeat);
-void        play_new_music(int mnum, SOUNDCLIP *music);
 void        newmusic(int mnum);
 
 extern AGS::Engine::Thread audioThread;
-extern AGS::Engine::Mutex _audio_mutex;
 extern volatile bool _audio_doing_crossfade;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1]; // needed for update_mp3_thread
 extern volatile int psp_audio_multithreaded;
 
 void update_mp3();
@@ -109,6 +126,6 @@ extern int crossFadeVolumeAtStart;
 extern SOUNDCLIP *cachedQueuedMusic;
 
 extern int last_sound_played[MAX_SOUND_CHANNELS + 1];
-extern AmbientSound ambient[MAX_SOUND_CHANNELS + 1];  // + 1 just for safety on array iterations
+extern std::array<AmbientSound,MAX_SOUND_CHANNELS+1> ambient;
 
 #endif // __AC_AUDIO_H

--- a/Engine/media/audio/clip_myogg.cpp
+++ b/Engine/media/audio/clip_myogg.cpp
@@ -20,7 +20,6 @@
 
 #include "platform/base/agsplatformdriver.h"
 
-
 extern "C" {
     extern int alogg_is_end_of_oggstream(ALOGG_OGGSTREAM *ogg);
     extern int alogg_is_end_of_ogg(ALOGG_OGG *ogg);
@@ -30,8 +29,7 @@ extern "C" {
 
 int MYOGG::poll()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
-
+    //must be called AudioChannelsLock
     if (!done && _destroyThis)
     {
       internal_destroy();
@@ -120,15 +118,14 @@ void MYOGG::internal_destroy()
 
 void MYOGG::destroy()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
 
-	_lock.Release();
-
+    //warning: scary for this to be done under a lock
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();
 }

--- a/Engine/media/audio/clip_mystaticogg.cpp
+++ b/Engine/media/audio/clip_mystaticogg.cpp
@@ -31,7 +31,7 @@ extern int use_extra_sound_offset;  // defined in ac.cpp
 
 int MYSTATICOGG::poll()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (tune && !done && _destroyThis)
     {
@@ -96,27 +96,22 @@ void MYSTATICOGG::internal_destroy()
 
 void MYSTATICOGG::destroy()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
 
-	_lock.Release();
-
+    //warning: scary for this to be done under a lock
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();
-
-    // Allow the last poll cycle to finish.
-	_lock.Acquire(_mutex);
 }
 
 void MYSTATICOGG::seek(int pos)
 {
-	AGS::Engine::MutexLock _lock;
-    if (psp_audio_multithreaded)
-		_lock.Acquire(_mutex);
+    //must be called AudioChannelsLock
+
     // we stop and restart it because otherwise the buffer finishes
     // playing first and the seek isn't quite accurate
     alogg_stop_ogg(tune);

--- a/Engine/media/audio/clip_mywave.cpp
+++ b/Engine/media/audio/clip_mywave.cpp
@@ -21,10 +21,9 @@
 
 #include "platform/base/agsplatformdriver.h"
 
-
 int MYWAVE::poll()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (!done && _destroyThis)
     {
@@ -82,14 +81,12 @@ void MYWAVE::internal_destroy()
 
 void MYWAVE::destroy()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
-
-	_lock.Release();
 
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -17,8 +17,6 @@
 #include "media/audio/soundclip.h"
 #include "media/audio/audiointernaldefs.h"
 
-SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1]; // needed for update_mp3_thread
-
 int SOUNDCLIP::play_from(int position) 
 {
     int retVal = play();

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -611,7 +611,8 @@ void IAGSEngine::PlaySoundChannel (int32 channel, int32 soundType, int32 volume,
     else
         quit("!IAGSEngine::PlaySoundChannel: unknown sound type");
 
-    channels[channel] = newcha;
+    AudioChannelsLock _lock;
+    _lock.SetChannel(channel,newcha);
 }
 // Engine interface 12 and above are below
 void IAGSEngine::MarkRegionDirty(int32 left, int32 top, int32 right, int32 bottom) {


### PR DESCRIPTION
alternative to #657

I don't make the threading mandatory, in deference to ivan's wariness that it could potentially affect a/v synchronization of some games. This commit was the conservative, minimum work required to get the synchronization under control.

My approach was to rename `channels` to `_channels` so that it wasn't possible to use them on accident without revising the code at this time to fix the synchronization. Then access to the channels was kept hidden and provided through a specialized synchronization structure (a mutex) 

That way, nobody can forget to lock the channels even in the future.

I've tested this in my game and it seems bulletproof

In this commit I also made _channels a std::array to help me debug it