### PR TITLE
AGS3: Reform do once

### DIFF
--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -52,7 +52,7 @@ class Stream;
 class String
 {
 public:
-    // Standart constructor: intialize empty string
+    // Standard constructor: intialize empty string
     String();
     // Copy constructor
     String(const String&);

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -208,6 +208,7 @@ void StrUtil::ReadString(char *cstr, Stream *in, size_t buf_limit)
     size_t len = in->ReadInt32();
     if (buf_limit > 0)
         len = Math::Min(len, buf_limit - 1);
+    cstr[len] = 0;
     if (len > 0)
         in->Read(cstr, len);
     else
@@ -218,6 +219,7 @@ void StrUtil::ReadString(char **cstr, Stream *in)
 {
     size_t len = in->ReadInt32();
     *cstr = new char[len + 1];
+    (*cstr)[len] = 0;
     if (len > 0)
         in->Read(*cstr, len);
     else

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -137,11 +137,13 @@ void fputstring(const char *sss, Common::Stream *out)
 
 void fgetstring_limit(char *sss, Common::Stream *in, int bufsize)
 {
+    //TODO: bug. should guarantee buffer is terminated in any event. the way this is used, anyway.
     int b = -1;
     do {
         if (b < bufsize - 1)
             b++;
         sss[b] = in->ReadInt8();
+        //TODO: bug. if reached end of stream prematurely, won't have a null terminator
         if (in->EOS())
             return;
     } while (sss[b] != 0);
@@ -213,6 +215,15 @@ void StrUtil::ReadString(char *cstr, Stream *in, size_t buf_limit)
         in->Read(cstr, len);
     else
         cstr[0] = 0;
+}
+
+void StrUtil::ReadString(String *s, Stream *in)
+{
+    size_t len = in->ReadInt32();
+    s->FillString('\0',len);
+    char* ptr = (char*)s->GetCStr(); //yes, this is bad.
+    if (len > 0)
+        in->Read(ptr, len);
 }
 
 void StrUtil::ReadString(char **cstr, Stream *in)

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -102,6 +102,7 @@ namespace StrUtil
     String          ReadString(Stream *in);
     void            ReadString(char *cstr, Stream *in, size_t buf_limit = 0);
     void            ReadString(char **cstr, Stream *in);
+    void            ReadString(String *s, Stream *in);
     void            SkipString(Stream *in);
     void            WriteString(const String &s, Stream *out);
     void            WriteString(const char *cstr, Stream *out);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -502,16 +502,7 @@ void save_game_dialog() {
 
 void free_do_once_tokens()
 {
-    for (int i = 0; i < play.num_do_once_tokens; i++)
-    {
-        free(play.do_once_tokens[i]);
-    }
-    if (play.do_once_tokens != NULL)
-    {
-        free(play.do_once_tokens);
-        play.do_once_tokens = NULL;
-    }
-    play.num_do_once_tokens = 0;
+    play.do_once_tokens.resize(0);
 }
 
 
@@ -744,17 +735,14 @@ int Game_DoOnceOnly(const char *token)
     if (strlen(token) > 199)
         quit("!Game.DoOnceOnly: token length cannot be more than 200 chars");
 
-    for (int i = 0; i < play.num_do_once_tokens; i++)
+    for (int i = 0; i < (int)play.do_once_tokens.size(); i++)
     {
-        if (strcmp(play.do_once_tokens[i], token) == 0)
+        if (play.do_once_tokens[i] == token)
         {
             return 0;
         }
     }
-    play.do_once_tokens = (char**)realloc(play.do_once_tokens, sizeof(char*) * (play.num_do_once_tokens + 1));
-    play.do_once_tokens[play.num_do_once_tokens] = (char*)malloc(strlen(token) + 1);
-    strcpy(play.do_once_tokens[play.num_do_once_tokens], token);
-    play.num_do_once_tokens++;
+    play.do_once_tokens.push_back(token);
     return 1;
 }
 
@@ -1212,15 +1200,10 @@ void ReadGameState_Aligned(Stream *in)
 
 void restore_game_play_ex_data(Stream *in)
 {
-    if (play.num_do_once_tokens > 0)
+    for (int bb = 0; (int)bb < play.do_once_tokens.size(); bb++)
     {
-        play.do_once_tokens = (char**)malloc(sizeof(char*) * play.num_do_once_tokens);
-        for (int bb = 0; bb < play.num_do_once_tokens; bb++)
-        {
-            fgetstring_limit(rbuffer, in, 200);
-            play.do_once_tokens[bb] = (char*)malloc(strlen(rbuffer) + 1);
-            strcpy(play.do_once_tokens[bb], rbuffer);
-        }
+        fgetstring_limit(rbuffer, in, 200);
+        play.do_once_tokens[bb] = rbuffer;
     }
 
     in->ReadArrayOfInt32(&play.gui_draw_order[0], game.numgui);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -463,10 +463,10 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
         in->ReadInt32(); // gui_draw_order
         in->ReadInt32(); // do_once_tokens;
     }
-    num_do_once_tokens = in->ReadInt32();
+    int num_do_once_tokens = in->ReadInt32();
+    do_once_tokens.resize(num_do_once_tokens);
     if (!old_save)
     {
-        do_once_tokens = new char*[num_do_once_tokens];
         for (int i = 0; i < num_do_once_tokens; ++i)
         {
             StrUtil::ReadString(&do_once_tokens[i], in);
@@ -650,8 +650,8 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32( gamma_adjustment);
     out->WriteInt16(temporarily_turned_off_character);
     out->WriteInt16(inv_backwards_compatibility);
-    out->WriteInt32( num_do_once_tokens);
-    for (int i = 0; i < num_do_once_tokens; ++i)
+    out->WriteInt32(do_once_tokens.size());
+    for (int i = 0; i < (int)do_once_tokens.size(); ++i)
     {
         StrUtil::WriteString(do_once_tokens[i], out);
     }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -16,7 +16,10 @@
 #define __AC_GAMESTATE_H
 
 #include "util/stdtr1compat.h"
+
 #include <memory>
+#include <vector>
+
 #include "ac/characterinfo.h"
 #include "ac/runtime_defines.h"
 #include "game/roomstruct.h"
@@ -24,6 +27,7 @@
 #include "media/audio/queuedaudioitem.h"
 #include "util/geometry.h"
 #include "util/string_types.h"
+#include "util/string.h"
 
 // Forward declaration
 namespace AGS { namespace Common {
@@ -201,8 +205,7 @@ struct GameState {
     short temporarily_turned_off_character;  // Hide Player Charactr ticked
     short inv_backwards_compatibility;
     int  *gui_draw_order;
-    char**do_once_tokens;
-    int   num_do_once_tokens;
+    std::vector<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms;
     int   ignore_user_input_after_text_timeout_ms;
     unsigned long ignore_user_input_until_time;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1092,8 +1092,7 @@ void engine_init_game_settings()
     play.temporarily_turned_off_character = -1;
     play.inv_backwards_compatibility = 0;
     play.gamma_adjustment = 100;
-    play.num_do_once_tokens = 0;
-    play.do_once_tokens = NULL;
+    play.do_once_tokens.resize(0);
     play.music_queue_size = 0;
     play.shakesc_length = 0;
     play.wait_counter=0;


### PR DESCRIPTION
The actual problem here was in StrUtil::ReadString. DoOnce tokens would get deserialized occasionally with garbage at the end of the string. 

While debugging this I was annoyed by the old crustiness of "do once tokens". Then I noticed they mixed new[] and malloc, and that was enough to give me the go-ahead to reform them entirely to be more modern.