### PR TITLE
build system: factor out freetype C/LDFLAGS

### DIFF
--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -1,8 +1,13 @@
+FT_CFLAGS := $(shell pkg-config --cflags freetype2)
+FT_LDFLAGS := $(shell pkg-config --libs freetype2)
+
 INCDIR = ../Engine ../Common ../Common/libinclude ../Plugins
 LIBDIR =
-CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DALLEGRO_NO_COMPATIBILITY -DALLEGRO_NO_FIX_ALIASES -DALLEGRO_NO_FIX_CLASS -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -D_FILE_OFFSET_BITS=64 -DHAVE_FSEEKO -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(shell pkg-config --cflags freetype2) $(CFLAGS)
+CFLAGS := -O2 -g -fsigned-char -Wfatal-errors -DNDEBUG -DALLEGRO_NO_COMPATIBILITY -DALLEGRO_NO_FIX_ALIASES -DALLEGRO_NO_FIX_CLASS -DAGS_RUNTIME_PATCH_ALLEGRO -DAGS_HAS_CD_AUDIO -DAGS_CASE_SENSITIVE_FILESYSTEM -D_FILE_OFFSET_BITS=64 -DHAVE_FSEEKO -DALLEGRO_STATICLINK -DLINUX_VERSION -DDISABLE_MPEG_AUDIO -DBUILTIN_PLUGINS -DRTLD_NEXT $(FT_CFLAGS) $(CFLAGS)
+
 CXXFLAGS := -std=c++11 -fno-rtti -Wno-write-strings $(CXXFLAGS)
 LIBS := -rdynamic -laldmb -ldumb -Wl,-Bdynamic
+LIBS += $(FT_LDFLAGS)
 LIBS += $(shell pkg-config --libs allegro)
 LIBS += $(shell pkg-config --libs x11)
 LIBS += $(shell pkg-config --libs ogg)
@@ -15,7 +20,6 @@ else
   LIBS += $(shell pkg-config --libs vorbis)
 endif
 LIBS += $(shell pkg-config --libs vorbisfile)
-LIBS += $(shell pkg-config --libs freetype2)
 LIBS += -ldl -lpthread -lc -lm -lstdc++
 
 ifeq ($(ALLEGRO_MAGIC_DRV), 1)


### PR DESCRIPTION
this allows to override them from the make command line like

make FT_CFLAGS=-I ../foo FT_LDFLAGS=/tmp/libfreetype.a

or by defining them in config.mak