### PR TITLE
AGS 3: deprecated "room resolution" and added MaskResolution property instead

### DIFF
--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -50,7 +50,6 @@ GameSetupStructBase::GameSetupStructBase()
     , _resolutionType(kGameResolution_Undefined)
     , _dataUpscaleMult(1)
     , _screenUpscaleMult(1)
-    , _roomMaskMul(1)
 {
     memset(gamename, 0, sizeof(gamename));
     memset(options, 0, sizeof(options));
@@ -141,7 +140,6 @@ void GameSetupStructBase::OnResolutionSet()
     // The final data-to-game multiplier is always set after actual game resolution (not default one)
     _dataUpscaleMult = _gameResolution.Width / _dataResolution.Width;
     _screenUpscaleMult = _gameResolution.Width / _defGameResolution.Width;
-    _roomMaskMul = IsHiRes() ? HIRES_COORD_MULTIPLIER : 1;
 }
 
 void GameSetupStructBase::ReadFromFile(Stream *in)

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -171,11 +171,6 @@ struct GameSetupStructBase {
     // This also means that mask relation to data resolution is 1:1 if the
     // game uses low-res coordinates in script and 1:2 if high-res.
 
-    // Get constant room mask-->data resolution coordinate multiplier.
-    // Used with all room masks except walk-behinds (which are always 1:1 to room size)
-    // TODO: should this be a property of room instead? Rooms have Resolution setting.
-    inline int GetRoomMaskMul() const { return _roomMaskMul; }
-
     // Test if the game is built around old audio system
     inline bool IsLegacyAudioSystem() const
     {
@@ -213,9 +208,6 @@ private:
     int _dataUpscaleMult;
     // Game default resolution to actual game resolution factor
     int _screenUpscaleMult;
-
-    // Room mask to room data resolution factor
-    int _roomMaskMul;
 };
 
 #endif // __AGS_CN_AC__GAMESETUPSTRUCTBASE_H

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -599,7 +599,15 @@ HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool g
 {
     if (data_ver < kRoomVersion_200_final)
         room->MaskResolution = room->BgFrames[0].Graphic->GetWidth() > 320 ? kRoomHiRes : kRoomLoRes;
-    room->Resolution = room->MaskResolution > 1 ? kRoomHiRes : kRoomLoRes;
+    if (data_ver < kRoomVersion_3508)
+    {
+        // Save legacy resolution if it DOES NOT match game's;
+        // otherwise it gets promoted to "real resolution"
+        if (room->MaskResolution == 1 && game_is_hires)
+            room->SetResolution(kRoomLoRes);
+        else if (room->MaskResolution > 1 && !game_is_hires)
+            room->SetResolution(kRoomHiRes);
+    }
 
     // Old version - copy walkable areas to regions
     if (data_ver < kRoomVersion_255b)

--- a/Common/game/room_version.h
+++ b/Common/game/room_version.h
@@ -45,6 +45,7 @@
 30:  v3.4.0.4 - tint luminance for regions
 31:  v3.4.1.5 - removed room object and hotspot name length limits
 32:  v3.5.0 - 64-bit file offsets
+33:  v3.5.0.8 - deprecated room resolution, added mask resolution
 */
 enum RoomFileVersion
 {
@@ -78,7 +79,8 @@ enum RoomFileVersion
     kRoomVersion_3404 = 30,
     kRoomVersion_3415 = 31,
     kRoomVersion_350 = 32,
-    kRoomVersion_Current = kRoomVersion_350
+    kRoomVersion_3508 = 33,
+    kRoomVersion_Current = kRoomVersion_3508
 };
 
 #endif // __AGS_CN_AC__ROOMVERSION_H

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -15,6 +15,7 @@
 #include "ac/common.h" // update_polled_stuff_if_runtime
 #include "game/room_file.h"
 #include "game/roomstruct.h"
+#include "gfx/bitmap.h"
 
 namespace AGS
 {
@@ -250,6 +251,40 @@ void load_room(const char *filename, RoomStruct *room, bool game_is_hires, const
     }
     if (!err)
         quitprintf("Unable to load the room file '%s'.\n%s.", filename, err->FullMessage().GetCStr());
+}
+
+PBitmap FixBitmap(PBitmap bmp, int width, int height)
+{
+    Bitmap *new_bmp = BitmapHelper::AdjustBitmapSize(bmp.get(), width, height);
+    if (new_bmp != bmp.get())
+        return PBitmap(new_bmp);
+    return bmp;
+}
+
+void FixRoomMasks(RoomStruct *room)
+{
+    if (room->MaskResolution <= 0)
+        return;
+    Bitmap *bkg = room->BgFrames[0].Graphic.get();
+    if (bkg == NULL)
+        return;
+    // TODO: this issue is somewhat complicated. Original code was relying on
+    // room->Width and Height properties. But in the engine these are saved
+    // already converted to data resolution which may be "low-res". Since this
+    // function is shared between engine and editor we do not know if we need
+    // to upscale them.
+    // For now room width/height is always equal to background bitmap.
+    int base_width = bkg->GetWidth();
+    int base_height = bkg->GetHeight();
+    int low_width = base_width / room->MaskResolution;
+    int low_height = base_height / room->MaskResolution;
+
+    // Walk-behinds are always 1:1 of the primary background.
+    // Other masks are 1:x where X is MaskResolution.
+    room->WalkBehindMask = FixBitmap(room->WalkBehindMask, base_width, base_height);
+    room->HotspotMask = FixBitmap(room->HotspotMask, low_width, low_height);
+    room->RegionMask = FixBitmap(room->RegionMask, low_width, low_height);
+    room->WalkAreaMask = FixBitmap(room->WalkAreaMask, low_width, low_height);
 }
 
 } // namespace Common

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -160,7 +160,8 @@ void RoomStruct::InitDefaults()
     DataVersion     = kRoomVersion_Current;
     GameID          = NO_GAME_ID_IN_ROOM_FILE;
 
-    Resolution      = 1;
+    Resolution      = kRoomLoRes;
+    MaskResolution  = 1;
     Width           = 320;
     Height          = 200;
 

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -160,7 +160,7 @@ void RoomStruct::InitDefaults()
     DataVersion     = kRoomVersion_Current;
     GameID          = NO_GAME_ID_IN_ROOM_FILE;
 
-    Resolution      = kRoomLoRes;
+    _resolution     = kRoomRealRes;
     MaskResolution  = 1;
     Width           = 320;
     Height          = 200;
@@ -197,6 +197,11 @@ void RoomStruct::InitDefaults()
     BgAnimSpeed = 5;
 
     memset(Palette, 0, sizeof(Palette));
+}
+
+void RoomStruct::SetResolution(RoomResolutionType type)
+{
+    _resolution = type;
 }
 
 bool RoomStruct::HasRegionLightLevel(int id) const

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -354,7 +354,13 @@ private:
 };
 
 
+// Loads new room data into the given RoomStruct object
 void load_room(const char *filename, RoomStruct *room, bool game_is_hires, const std::vector<SpriteInfo> &sprinfos);
+// Ensures that all existing room masks match room background size and
+// MaskResolution property, resizes mask bitmaps if necessary.
+void FixRoomMasks(RoomStruct *room);
+// Adjusts bitmap size if necessary and returns either new or old bitmap.
+PBitmap FixBitmap(PBitmap bmp, int dst_width, int dst_height);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -238,6 +238,14 @@ struct MessageInfo
 };
 
 
+// Room's legacy resolution type
+enum RoomResolutionType
+{
+    kRoomLoRes = 1, // created for low-resolution game
+    kRoomHiRes = 2 // created for high-resolution game
+};
+
+
 //
 // Description of a single room.
 // This class contains initial room data. Some of it may still be modified
@@ -250,7 +258,7 @@ public:
     ~RoomStruct();
 
     // Gets if room belongs to high resolution
-    inline bool IsHiRes() const { return Resolution == HIRES_COORD_MULTIPLIER; }
+    inline bool IsHiRes() const { return Resolution == kRoomHiRes; }
 
     // Releases room resources
     void            Free();
@@ -284,7 +292,10 @@ public:
 
     // Room's legacy resolution type (1 - lores, 2 - hires);
     // also serves as a hotspot/region mask relation to background
-    int32_t                 Resolution;
+    RoomResolutionType      Resolution;
+    // Room region masks resolution. Defines the relation between room and mask units.
+    // Mask point is calculated as roompt / MaskResolution. Must be >= 1.
+    int32_t                 MaskResolution;
     // Size of the room, in logical coordinates (= pixels)
     int32_t                 Width;
     int32_t                 Height;

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -241,6 +241,7 @@ struct MessageInfo
 // Room's legacy resolution type
 enum RoomResolutionType
 {
+    kRoomRealRes = 0, // room should always be treated as-is
     kRoomLoRes = 1, // created for low-resolution game
     kRoomHiRes = 2 // created for high-resolution game
 };
@@ -257,8 +258,11 @@ public:
     RoomStruct();
     ~RoomStruct();
 
+    // Gets if room should adjust its base size depending on game's resolution
+    inline bool IsRelativeRes() const { return _resolution != kRoomRealRes; }
     // Gets if room belongs to high resolution
-    inline bool IsHiRes() const { return Resolution == kRoomHiRes; }
+    inline bool IsHiRes() const { return _resolution == kRoomHiRes; }
+    inline RoomResolutionType GetResolutionType() const { return _resolution; }
 
     // Releases room resources
     void            Free();
@@ -268,6 +272,8 @@ public:
     void            FreeScripts();
     // Init default room state
     void            InitDefaults();
+    // Set legacy resolution type
+    void            SetResolution(RoomResolutionType type);
 
     // TODO: see later whether it may be more convenient to move these to the Region class instead.
     // Gets if the given region has light level set
@@ -290,9 +296,6 @@ public:
     // the room must have behavior specific to certain version of AGS.
     int32_t                 DataVersion;
 
-    // Room's legacy resolution type (1 - lores, 2 - hires);
-    // also serves as a hotspot/region mask relation to background
-    RoomResolutionType      Resolution;
     // Room region masks resolution. Defines the relation between room and mask units.
     // Mask point is calculated as roompt / MaskResolution. Must be >= 1.
     int32_t                 MaskResolution;
@@ -344,6 +347,10 @@ public:
     PInteractionScripts     EventHandlers;
     // Compiled room script
     PScript                 CompiledScript;
+
+private:
+    // Room's legacy resolution type, defines relation room and game's resolution
+    RoomResolutionType      _resolution;
 };
 
 

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -79,6 +79,15 @@ Bitmap *LoadFromFile(const char *filename)
 	return bitmap;
 }
 
+Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height)
+{
+    int oldw = src->GetWidth(), oldh = src->GetHeight();
+    if ((oldw == width) && (oldh == height))
+        return src;
+    Bitmap *bmp = BitmapHelper::CreateBitmap(width, height, src->GetColorDepth());
+    bmp->StretchBlt(src, RectWH(0, 0, oldw, oldh), RectWH(0, 0, width, height));
+    return bmp;
+}
 
 template <class TPx, size_t BPP_>
 struct PixelTransCpy

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -66,6 +66,9 @@ namespace BitmapHelper
     Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth = 0);
 	Bitmap *LoadFromFile(const char *filename);
 
+    // Stretches bitmap to the requested size. The new bitmap will have same
+    // colour depth. Returns original bitmap if no changes are necessary. 
+    Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height);
     // Copy transparency mask and/or alpha channel from one bitmap into another.
     // Destination and mask bitmaps must be of the same pixel format.
     // Transparency is merged, meaning that fully transparent pixels on

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -76,7 +76,7 @@ namespace AGS.Editor
          *     3.4.3      - Added missing audio properties to DefaultSetup [ forgot to change version index!! ]
          * 16: 3.5.0      - Unlimited fonts (need separate version to prevent crashes in older editors)
          * 17: 3.5.0.4    - Extended sprite source properties
-         * 18: 3.5.0.8    - Real sprite resolution; Individual font scaling
+         * 18: 3.5.0.8    - Real sprite resolution; Individual font scaling; Default room mask resolution
         */
         public const int    LATEST_XML_VERSION_INDEX = 18;
         /*

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -796,9 +796,11 @@ namespace AGS.Editor.Components
                 ((ScriptEditor)_roomScriptEditors[newRoom.Number].Control).UpdateScriptObjectWithLatestTextInWindow();
             }
             _loadedRoom = _nativeProxy.LoadRoom(newRoom);
+            // TODO: group these in some UpdateRoomToNewVersion method
             _loadedRoom.Modified = ImportExport.CreateInteractionScripts(_loadedRoom, errors);
             _loadedRoom.Modified |= HookUpInteractionVariables(_loadedRoom);
             _loadedRoom.Modified |= AddPlayMusicCommandToPlayerEntersRoomScript(_loadedRoom, errors);
+            _loadedRoom.Modified |= ApplyDefaultMaskResolution(_loadedRoom);
 			if (_loadedRoom.Script.Modified)
 			{
 				if (_roomScriptEditors.ContainsKey(_loadedRoom.Number))
@@ -851,6 +853,24 @@ namespace AGS.Editor.Components
             }
 
             return scriptModified;
+        }
+
+        private bool ApplyDefaultMaskResolution(Room room)
+        {
+            // TODO: currently the only way to know if the room was not affected by
+            // game's settings is to test whether it has game's ID. Investigate for
+            // a better way later?
+            if (room.GameID != _agsEditor.CurrentGame.Settings.UniqueID)
+            {
+                int mask = _agsEditor.CurrentGame.Settings.DefaultRoomMaskResolution;
+                if (mask != room.MaskResolution)
+                {
+                    room.MaskResolution = mask;
+                    NativeProxy.Instance.AdjustRoomMaskResolution(room);
+                    return true;
+                }
+            }
+            return false;
         }
 
         private bool HookUpInteractionVariables(Room room)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1036,6 +1036,11 @@ namespace AGS.Editor.Components
 				RenameRoom(_loadedRoom.Number, numberRequested);
 			}
 
+            if ((propertyName == Room.PROPERTY_NAME_MASKRESOLUTION) && (_loadedRoom != null))
+            {
+                AdjustRoomMaskResolution(Convert.ToInt32(oldValue), _loadedRoom.MaskResolution);
+            }
+
             // TODO: wish we could forward event to the CharacterComponent.OnPropertyChanged,
             // but its implementation relies on it being active Pane!
             if ((_guiController.ActivePane.SelectedPropertyGridObject is Character) &&
@@ -1082,6 +1087,19 @@ namespace AGS.Editor.Components
 				RePopulateTreeView();
 			}
 		}
+
+        /// <summary>
+        /// Resize room masks to match current MaskResolution property.
+        /// </summary>
+        private void AdjustRoomMaskResolution(int oldValue, int newValue)
+        {
+            if (newValue > oldValue) // this is a divisor
+            {
+                if (Factory.GUIController.ShowQuestion("The new mask resolution is smaller and this will reduce mask's precision and some pixels may be lost in the process. Do you want to proceed?") != DialogResult.Yes)
+                    return;
+            }
+            _nativeProxy.AdjustRoomMaskResolution(_loadedRoom);
+        }
 
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
         {
@@ -1137,6 +1155,8 @@ namespace AGS.Editor.Components
 
             RePopulateTreeView();
             RoomListTypeConverter.SetRoomList(_agsEditor.CurrentGame.Rooms);
+            // Allow room mask resolutions from 1:1 to 1:4
+            RoomMaskResolutionTypeConverter.SetResolutionRange(1, 4);
         }
 
         private int GetRoomNumberForFileName(string fileName, bool isDebugExecutionPoint)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -272,6 +272,11 @@ namespace AGS.Editor
             return _native.GetBitmapForBackground(room, backgroundNumber);
         }
 
+        public void AdjustRoomMaskResolution(Room room)
+        {
+            _native.AdjustRoomMaskResolution(room);
+        }
+
         public void CreateBuffer(int width, int height)
         {
             _native.CreateBuffer(width, height);

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -221,10 +221,10 @@ namespace AGS.Editor
         // Gets the scale factor for drawing auxiliary stuff on screen.
         // This does not have any relation to screen/room coordinate conversion,
         // only lets to have extra size for some hint lines etc, in hi-res games.
+        // TODO: choose this factor based on game size vs window size relation
         private float GetHintScaleFactor(RoomEditorState state)
         {
-            if (_room.Resolution == RoomResolution.HighRes ||
-                Factory.AGSEditor.CurrentGame.IsHighResolution)
+            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
             {
                 return 2f;
             }
@@ -350,14 +350,7 @@ namespace AGS.Editor
         {
             int tempx = _menuClickX;
             int tempy = _menuClickY;
-
-            if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-             (_room.Resolution == RoomResolution.HighRes))
-            {
-                tempx /= 2;
-                tempy /= 2;
-            }
-
+            RoomEditorState.AdjustCoordsToMatchEngine(_room, ref tempx, ref tempy);
             string textToCopy = tempx.ToString() + ", " + tempy.ToString();
             Utilities.CopyTextToClipboard(textToCopy);
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -162,6 +162,11 @@ namespace AGS.Editor
         {
         }
 
+        /// <summary>
+        /// Draw hint overlay.
+        /// NOTE: this is NOT drawing on actual mask, which is performed when
+        /// user releases mouse button.
+        /// </summary>
         public virtual void Paint(Graphics graphics, RoomEditorState state)
         {
             int roomPixel = state.RoomSizeToWindow(1);
@@ -224,14 +229,7 @@ namespace AGS.Editor
         // TODO: choose this factor based on game size vs window size relation
         private float GetHintScaleFactor(RoomEditorState state)
         {
-            if (Factory.AGSEditor.CurrentGame.IsHighResolution)
-            {
-                return 2f;
-            }
-            else
-            {
-                return 1f;
-            }
+            return _room.MaskResolution;
         }
 
         public void MouseDownAlways(MouseEventArgs e, RoomEditorState state) 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -145,14 +145,7 @@ namespace AGS.Editor
         {
             int tempx = _menuClickX;
             int tempy = _menuClickY;
-
-            if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-                (_room.Resolution == RoomResolution.HighRes))
-            {
-                tempx /= 2;
-                tempy /= 2;
-            }
-
+            RoomEditorState.AdjustCoordsToMatchEngine(_room, ref tempx, ref tempy);
             string textToCopy = tempx.ToString() + ", " + tempy.ToString();
             Utilities.CopyTextToClipboard(textToCopy);
         }
@@ -173,17 +166,7 @@ namespace AGS.Editor
         {
             int tempx = _selectedCharacter.StartX;
             int tempy = _selectedCharacter.StartY;
-
-            //this halves the coordinates of the x and y values 
-            //if you have low res coordinates set in the properties and are in high res
-
-            if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-                (_room.Resolution == RoomResolution.HighRes))
-            {
-                tempx /= 2;
-                tempy /= 2;
-            }
-
+            RoomEditorState.AdjustCoordsToMatchEngine(_room, ref tempx, ref tempy);
             string textToCopy = tempx.ToString() + ", " + tempy.ToString();
             Utilities.CopyTextToClipboard(textToCopy);
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -106,15 +106,8 @@ namespace AGS.Editor
 
 			_menuClickX = state.WindowXToRoom(e.X);
 			_menuClickY = state.WindowYToRoom(e.Y);
-
-            if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-                (_room.Resolution == RoomResolution.HighRes))
-            {
-                _menuClickX /= 2;
-                _menuClickY /= 2;
-            }
-
-			menu.Show(_panel, e.X, e.Y);
+            RoomEditorState.AdjustCoordsToMatchEngine(_room, ref _menuClickX, ref _menuClickY);
+            menu.Show(_panel, e.X, e.Y);
 		}
 
         public bool MouseMove(int x, int y, RoomEditorState state)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -238,14 +238,7 @@ namespace AGS.Editor
         {
             int tempx = _menuClickX;
             int tempy = _menuClickY;
-
-            if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-             (_room.Resolution == RoomResolution.HighRes))
-            {
-                tempx /= 2;
-                tempy /= 2;
-            }
-
+            RoomEditorState.AdjustCoordsToMatchEngine(_room, ref tempx, ref tempy);
             string textToCopy = tempx.ToString() + ", " + tempy.ToString();
             Utilities.CopyTextToClipboard(textToCopy);
         }
@@ -313,14 +306,7 @@ namespace AGS.Editor
             {
                 int tempx = _selectedObject.StartX;
                 int tempy = _selectedObject.StartY;
-
-                if ((Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript) &&
-                	(_room.Resolution == RoomResolution.HighRes))
-                {
-                    tempx = tempx / 2;
-                    tempy = tempy / 2;
-                }
-
+                RoomEditorState.AdjustCoordsToMatchEngine(_room, ref tempx, ref tempy);
                 string textToCopy = tempx.ToString() + ", " + tempy.ToString();
                 Utilities.CopyTextToClipboard(textToCopy);
             }
@@ -407,20 +393,14 @@ namespace AGS.Editor
             return true;            
         }
 
-        private bool IsHighResGameWithLowResScript()
-        {
-            return (Factory.AGSEditor.CurrentGame.IsHighResolution) &&
-                (Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript);
-        }
-
         private int GetArrowMoveStepSize()
         {
-            return IsHighResGameWithLowResScript() ? 2 : 1;
+            return RoomEditorState.IsHighResRoomWithLowResScript(_room) ? 2 : 1;
         }
 
         private int SetObjectCoordinate(int newCoord)
         {
-            if (IsHighResGameWithLowResScript())
+            if (RoomEditorState.IsHighResRoomWithLowResScript(_room))
             {
                 // Round co-ordinate to nearest even number to reflect what
                 // will happen in the engine

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -453,15 +453,9 @@ namespace AGS.Editor
 					{
 						newResolution = _room.Resolution;
 					}
-                    // CHECKME: WTF is this??? How to deal with it?
-					else if (//(bmp.Width > 640) && (bmp.Height > 400) &&
-						(!Factory.AGSEditor.CurrentGame.Settings.LowResolution))
-					{
-						newResolution = RoomResolution.HighRes;
-					}
 					else
 					{
-						newResolution = RoomResolution.LowRes;
+						newResolution = RoomResolution.Real;
 					}
 
 					if ((bmp.Width != _room.Width) || (bmp.Height != _room.Height) ||
@@ -1010,7 +1004,8 @@ namespace AGS.Editor
         internal static bool IsHighResRoomWithLowResScript(Room room)
         {
             return Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript &&
-                room.Resolution == RoomResolution.HighRes;
+                (room.Resolution == RoomResolution.HighRes ||
+                room.Resolution == RoomResolution.Real && Factory.AGSEditor.CurrentGame.IsHighResolution);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -71,11 +71,8 @@ namespace AGS.Editor
             _room = room;
             sldZoomLevel.Maximum = ZOOM_MAX_VALUE / ZOOM_STEP_VALUE;
             sldZoomLevel.Value = 100 / ZOOM_STEP_VALUE;
-            // For low res games, set larger default zoom (x2)
-            int factor = 1;
-            if (_room.Resolution == RoomResolution.LowRes)
-                factor = 2;
-            SetZoomSliderToMultiplier(factor);
+            // TODO: choose default zoom based on the room size vs window size?
+            SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
 
             _layers.Add(new EdgesEditorFilter(bufferedPanel1, _room));
             _characterLayer = new CharactersEditorFilter(bufferedPanel1, _room, Factory.AGSEditor.CurrentGame);
@@ -510,7 +507,8 @@ namespace AGS.Editor
                             }
                         }
 
-                        SetZoomSliderToMultiplier(3 - (int)_room.Resolution);
+                        // TODO: choose default zoom based on the room size vs window size?
+                        SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
 						sldZoomLevel_Scroll(null, null);
 						UpdateScrollableWindowSize();
                     }
@@ -977,7 +975,7 @@ namespace AGS.Editor
         /// <summary>
         /// Scale of the Room image on screen.
         /// </summary>
-        public float Scale
+        internal float Scale
         {
             get { return _scale; }
             set
@@ -997,6 +995,35 @@ namespace AGS.Editor
         {
             _scrollOffsetX = -scrollPt.X;
             _scrollOffsetY = -scrollPt.Y;
+        }
+
+        // Refactor following static methods and/or move elsewhere.
+        // I made them static and put into RoomEditorState because room filters
+        // need to have these methods accessible at random times.
+        // Perhaps filters may acquire this object in constructor instead.
+        // Also, room reference does not have to be passed as an argument like
+        // this either.
+
+        /// <summary>
+        /// Tells if script coordinates have 1:2 resolution in this room.
+        /// </summary>
+        internal static bool IsHighResRoomWithLowResScript(Room room)
+        {
+            return Factory.AGSEditor.CurrentGame.Settings.UseLowResCoordinatesInScript &&
+                room.Resolution == RoomResolution.HighRes;
+        }
+
+        /// <summary>
+        /// Adjusts given coordinates to match resolution that script will
+        /// have in this room when the game is run by the engine.
+        /// </summary>
+        internal static void AdjustCoordsToMatchEngine(Room room, ref int x, ref int y)
+        {
+            if (IsHighResRoomWithLowResScript(room))
+            {
+                x /= 2;
+                y /= 2;
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -217,6 +217,11 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 18)
+            {
+                game.Settings.DefaultRoomMaskResolution = game.IsHighResolution ? 2 : 1;
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -76,6 +76,7 @@ extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
 extern void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
+extern void FixRoomMasks(Room ^room);
 extern void copy_walkable_to_regions(void *roomptr);
 extern int get_mask_pixel(void *roomptr, int maskType, int x, int y);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
@@ -471,6 +472,11 @@ namespace AGS
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
 		}
+
+        void NativeMethods::AdjustRoomMaskResolution(Room ^room)
+        {
+            FixRoomMasks(room);
+        }
 
 		void NativeMethods::DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color)
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -63,6 +63,7 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
+            void AdjustRoomMaskResolution(Room ^room);
 			void DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -701,6 +701,7 @@ float get_scale_for_mask(RoomStruct *roomptr, RoomAreaMask maskType)
     return 0.f;
 }
 
+
 void copy_walkable_to_regions (void *roomptr) {
     RoomStruct *theRoom = (RoomStruct*)roomptr;
 	theRoom->RegionMask->Blit(theRoom->WalkAreaMask.get(), 0, 0, 0, 0, theRoom->RegionMask->GetWidth(), theRoom->RegionMask->GetHeight());
@@ -2642,6 +2643,13 @@ System::Drawing::Bitmap^ getBackgroundAsBitmap(Room ^room, int backgroundNumber)
 
   RoomStruct *roomptr = (RoomStruct*)(void*)room->_roomStructPtr;
   return ConvertBlockToBitmap32(roomptr->BgFrames[backgroundNumber].Graphic.get(), room->Width, room->Height, false);
+}
+
+void FixRoomMasks(Room ^room)
+{
+    RoomStruct *roomptr = (RoomStruct*)(void*)room->_roomStructPtr;
+    roomptr->MaskResolution = room->MaskResolution;
+    AGS::Common::FixRoomMasks(roomptr);
 }
 
 void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette) 

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -181,6 +181,7 @@
     <Compile Include="PropertyGridExtras\CustomPropertiesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />
+    <Compile Include="PropertyGridExtras\RoomMaskResolutionTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\RoomMessagesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\SpriteFileNameEditor.cs" />
     <Compile Include="PropertyGridExtras\SpriteSelectUIEditor.cs" />

--- a/Editor/AGS.Types/Enums/RoomResolution.cs
+++ b/Editor/AGS.Types/Enums/RoomResolution.cs
@@ -7,6 +7,8 @@ namespace AGS.Types
 {
     public enum RoomResolution
     {
+        [Description("Real")]
+        Real = 0,
         [Description("Low (320x240 and below)")]
         LowRes = 1,
         [Description("High (above 320x240)")]

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -539,6 +539,8 @@ namespace AGS.Types
             return null;
         }
 
+        // TODO: remove this after we have proper zoom controls in all editors;
+        // default zoom-in should be relied on the actual image size if on anything
         public int GUIScaleFactor
         {
             get

--- a/Editor/AGS.Types/PropertyGridExtras/RoomMaskResolutionTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/RoomMaskResolutionTypeConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public class RoomMaskResolutionTypeConverter : BaseListSelectTypeConverter<int, string>
+    {
+        private static int _minValue, _maxValue;
+        private static Dictionary<int, string> _possibleValues = new Dictionary<int, string>();
+
+        protected override Dictionary<int, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return _possibleValues;
+        }
+
+        public static void SetResolutionRange(int min, int max)
+        {
+            _minValue = Math.Min(min, max);
+            _maxValue = Math.Max(min, max);
+            _possibleValues.Clear();
+            for (int i = min; i <= max; ++i)
+                _possibleValues.Add(i, String.Format("1:{0}", i));
+        }
+    }
+}

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -35,7 +35,8 @@ namespace AGS.Types
         private bool _showPlayerCharacter = true;
         private int _playerCharacterView;
         private RoomVolumeAdjustment _musicVolumeAdjustment;
-        private RoomResolution _resolution = RoomResolution.LowRes;
+        private RoomResolution _resolution = RoomResolution.Real;
+        private int _maskResolution = 1;
         private int _colorDepth;
         private int _width;
         private int _height;
@@ -131,6 +132,15 @@ namespace AGS.Types
         {
             get { return _resolution; }
             set { _resolution = value; }
+        }
+
+        [Description("What resolution do room region masks have relative to the room size")]
+        [Category("Regions")]
+        [ReadOnly(true)]
+        public int MaskResolution
+        {
+            get { return _maskResolution; }
+            set { _maskResolution = value; }
         }
 
         [Browsable(false)]

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -138,6 +138,7 @@ namespace AGS.Types
 
         [Description("What resolution do room region masks have relative to the room size")]
         [Category("Regions")]
+        [DefaultValue(1)]
         [TypeConverter(typeof(RoomMaskResolutionTypeConverter))]
         public int MaskResolution
         {

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -21,6 +21,8 @@ namespace AGS.Types
 
         public const string EVENT_SUFFIX_ROOM_LOAD = "Load";
 
+        public const string PROPERTY_NAME_MASKRESOLUTION = "MaskResolution";
+
         private static InteractionSchema _interactionSchema;
 
         public delegate void RoomModifiedChangedHandler(bool isModified);
@@ -136,7 +138,7 @@ namespace AGS.Types
 
         [Description("What resolution do room region masks have relative to the room size")]
         [Category("Regions")]
-        [ReadOnly(true)]
+        [TypeConverter(typeof(RoomMaskResolutionTypeConverter))]
         public int MaskResolution
         {
             get { return _maskResolution; }

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -90,8 +90,9 @@ namespace AGS.Types
         private bool _runGameLoopsWhileDialogOptionsDisplayed = false;
         private InventoryHotspotMarker _inventoryHotspotMarker = new InventoryHotspotMarker();
         private bool _useLowResCoordinatesInScript = true;
+        private int _defRoomMaskResolution = 1;
         // Windows game explorer fields
-		private bool _enableGameExplorer = false;
+        private bool _enableGameExplorer = false;
 		private string _description = string.Empty;
 		private DateTime _releaseDate = DateTime.Now;
 		private string _genre = DEFAULT_GENRE;
@@ -847,7 +848,18 @@ namespace AGS.Types
             set { _hasMODMusic = value; }
         }
 
-		[DisplayName("Enable Game Explorer integration")]
+        [DisplayName("Default mask resolution")]
+        [Description("What resolution do room region masks have relative to the room size")]
+        [Category("Rooms")]
+        [DefaultValue(1)]
+        [TypeConverter(typeof(RoomMaskResolutionTypeConverter))]
+        public int DefaultRoomMaskResolution
+        {
+            get { return _defRoomMaskResolution; }
+            set { _defRoomMaskResolution = value; }
+        }
+
+        [DisplayName("Enable Game Explorer integration")]
 		[Description("Whether or not this game can be added to the Vista Game Explorer")]
 		[Category("Windows Game Explorer")]
 		public bool GameExplorerEnabled

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -409,12 +409,12 @@ AGS_INLINE int get_fixed_pixel_size(int pixels)
 
 AGS_INLINE int room_to_mask_coord(int coord)
 {
-    return coord / game.GetRoomMaskMul();
+    return coord / thisroom.MaskResolution;
 }
 
 AGS_INLINE int mask_to_room_coord(int coord)
 {
-    return coord * game.GetRoomMaskMul();
+    return coord * thisroom.MaskResolution;
 }
 
 AGS_INLINE int data_to_game_coord(int coord)

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -110,7 +110,7 @@ void script_debug(int cmdd,int dataa) {
         const Rect &viewport = play.GetRoomViewport();
         const Rect &camera = play.GetRoomCamera();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
-        Rect mask_src = Rect(camera.Left / thisroom.Resolution, camera.Top / thisroom.Resolution, camera.Right / thisroom.Resolution, camera.Bottom / thisroom.Resolution);
+        Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);
 
         IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(view_bmp, false, true);
@@ -168,7 +168,7 @@ void script_debug(int cmdd,int dataa) {
         const Rect &viewport = play.GetRoomViewport();
         const Rect &camera = play.GetRoomCamera();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
-        Rect mask_src = Rect(camera.Left / thisroom.Resolution, camera.Top / thisroom.Resolution, camera.Right / thisroom.Resolution, camera.Bottom / thisroom.Resolution);
+        Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);
 
         IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(view_bmp, false, true);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1032,10 +1032,10 @@ void croom_ptr_clear()
 
 void convert_move_path_to_room_resolution(MoveList *ml)
 { // TODO: refer to room mask own setting here instead
-    if (game.GetRoomMaskMul() == 1)
+    if (thisroom.MaskResolution == 1)
         return;
 
-    const int mul = game.GetRoomMaskMul();
+    const int mul = thisroom.MaskResolution;
     ml->fromx *= mul;
     ml->fromy *= mul;
     ml->lastx *= mul;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -219,20 +219,6 @@ ScriptCamera* Room_GetCamera()
 
 //=============================================================================
 
-// If room mask is too small or too large for this room size,
-// then create a new bitmap and stretch old one to fill in;
-// otherwise return old bitmap.
-PBitmap fix_bitmap_size(PBitmap todubl, int bkg_width, int bkg_height)
-{
-    int oldw=todubl->GetWidth(), oldh=todubl->GetHeight();
-    if ((oldw == bkg_width) && (oldh == bkg_height))
-        return todubl;
-
-    Bitmap *tempb=BitmapHelper::CreateBitmap(bkg_width, bkg_height, todubl->GetColorDepth());
-    tempb->StretchBlt(todubl.get(), RectWH(0,0,oldw,oldh), RectWH(0,0,tempb->GetWidth(),tempb->GetHeight()));
-    return PBitmap(tempb);
-}
-
 // Makes sure that room background and walk-behind mask are matching room size
 // in game resolution coordinates; in other words makes graphics appropriate
 // for display in the game.
@@ -246,11 +232,11 @@ void convert_room_background_to_game_res()
     data_to_game_coords(&bkg_width, &bkg_height);
 
     for (size_t i = 0; i < thisroom.BgFrameCount; ++i)
-        thisroom.BgFrames[i].Graphic = fix_bitmap_size(thisroom.BgFrames[i].Graphic, bkg_width, bkg_height);
+        thisroom.BgFrames[i].Graphic = FixBitmap(thisroom.BgFrames[i].Graphic, bkg_width, bkg_height);
 
-    // fix walk-behinds to match room background
+    // Fix walk-behinds to match room background
     // TODO: would not we need to do similar to each mask if they were 1:1 in hires room?
-    thisroom.WalkBehindMask = fix_bitmap_size(thisroom.WalkBehindMask, bkg_width, bkg_height);
+    thisroom.WalkBehindMask = FixBitmap(thisroom.WalkBehindMask, bkg_width, bkg_height);
 }
 
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -238,6 +238,9 @@ PBitmap fix_bitmap_size(PBitmap todubl, int bkg_width, int bkg_height)
 // for display in the game.
 void convert_room_background_to_game_res()
 {
+    if (!thisroom.IsRelativeRes())
+        return;
+
     int bkg_width = thisroom.Width;
     int bkg_height = thisroom.Height;
     data_to_game_coords(&bkg_width, &bkg_height);


### PR DESCRIPTION
This change is in line with recent #651 and #654.

1. Deprecated room resolution type (high-res/low-res). All rooms are "real resolution" by default, and when loading old rooms their resolution type is promoted to "real resolution" if it matches game's type.
Also, resolution type will be switched to "real" as soon as the user imports new background.
Old types are kept solely for the purpose of importing old projects, but if user wants to continue working with the new editor they will have to adjust their ways accordingly.

2. Added MaskResolution property for the rooms which affects Hotspots, Regions and Walkable Areas (but not Walk-behinds which are always 1:1). This replaces automatic mask resolution dependent on resolution type, which was 1:1 for low-res and 1:2 for high-res. Now you may set up mask resolution to your wanting. 1:1 is default, but if you think it's too much for some of the larger rooms, you may lower its precision down.
Mask resolution may be changed any time, which instantly converts room masks (with a warning in case of precision reduction).

3. Added Default mask resolution property to General Settings (default is also 1:1). This is in case user will want to keep non-standart one for the whole game, and also for backwards compatibility (it is set up to 1:2 for old projects of "hi-res" games).
Note that changing this setting won't modify existing rooms. But it will apply new resolution to any room that is opened in this project for the first time. I used only way I could find at the moment to detect if room is "new": by comparing Game ID (also saved in room file).


**NOTE:** For now I limited resolution choice to 1:1 to 1:4, but that's arbitrary numbers. Previously it was never smaller than 1:2, but I wanted to give additional option just in case, if there will be very big rooms where reducing area resolution could e,g, improve pathfinding; or even if simplify things when drawing a mask.