### PR TITLE
AGS3 Refactor script code loading

### DIFF
--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -31,6 +31,7 @@ struct ccScript
 public:
     char *globaldata;
     int32_t globaldatasize;
+    intptr_t *code;
     int32_t *rawCode;
     int32_t codesize;
     char *strings;
@@ -56,7 +57,7 @@ public:
     static ccScript *CreateFromStream(Common::Stream *in);
 
     ccScript();
-    ccScript(const ccScript &src);
+    ccScript(const ccScript &) = delete;
     virtual ~ccScript(); // there are few derived classes, so dtor should be virtual
 
     // write the script to disk (after compiling)

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -31,7 +31,7 @@ struct ccScript
 public:
     char *globaldata;
     int32_t globaldatasize;
-    intptr_t *code;
+    int32_t *rawCode;
     int32_t codesize;
     char *strings;
     int32_t stringssize;

--- a/Common/util/stream.cpp
+++ b/Common/util/stream.cpp
@@ -19,52 +19,6 @@ namespace AGS
 namespace Common
 {
 
-size_t Stream::ReadArrayOfIntPtr32(intptr_t *buffer, size_t count)
-{
-    if (!CanRead())
-    {
-        return 0;
-    }
-
-    int32_t *buf_ptr = sizeof(int32_t) == sizeof(intptr_t) ?
-        (int32_t*)buffer : new int32_t[count];
-    if (!buf_ptr)
-    {
-        return 0;
-    }
-
-    count = ReadArrayOfInt32(buf_ptr, count);
-
-    if (sizeof(int32_t) != sizeof(intptr_t))
-    {
-        for (size_t i = 0; i < count; ++i)
-        {
-            buffer[i] = buf_ptr[i];
-        }
-        delete [] buf_ptr;
-    }
-    return count;
-}
-
-size_t Stream::WriteArrayOfIntPtr32(const intptr_t *buffer, size_t count)
-{
-    if (!CanWrite())
-    {
-        return 0;
-    }
-
-    size_t elem;
-    for (elem = 0; elem < count && !EOS(); ++elem, ++buffer)
-    {
-        int32_t val = (int32_t)*buffer;
-        if (WriteInt32(val) < sizeof(int32_t))
-        {
-            break;
-        }
-    }
-    return elem;
-}
-
 size_t Stream::WriteByteCount(uint8_t b, size_t count)
 {
     if (!CanWrite())

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -94,14 +94,6 @@ public:
 #endif
     }
 
-    // Helper function for easier compatibility with 64-bit platforms
-    // reads 32-bit values and stores them in intptr_t array
-    size_t ReadArrayOfIntPtr32(intptr_t *buffer, size_t count);
-
-    // Helper function for easier compatibility with 64-bit platforms,
-    // writes intptr_t array elements as 32-bit values
-    size_t WriteArrayOfIntPtr32(const intptr_t *buffer, size_t count);
-
     // Fill the requested number of bytes with particular value
     size_t WriteByteCount(uint8_t b, size_t count);
 };

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1422,11 +1422,15 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
         }
 
         codesize = scri->codesize;
-        code = NULL;
+        code = nullptr;
         if (codesize > 0)
         {
             code = (intptr_t*)malloc(codesize * sizeof(intptr_t));
-            memcpy(code, scri->code, codesize * sizeof(intptr_t));
+            // 64 bit: Read code into 8 byte array, necessary for being able to perform
+            // relocations on the references.
+            for (int i = 0; i < codesize; i++) {
+                code[i] = scri->rawCode[i];
+            }
         }
     }
 

--- a/Engine/test/test_file.cpp
+++ b/Engine/test/test_file.cpp
@@ -131,12 +131,16 @@ void Test_File()
 
     out->WriteInt32(20);
 
-    intptr_t ptr32_array_out[4];
-    ptr32_array_out[0] = 0xABCDABCD;
-    ptr32_array_out[1] = 0xFEDCFEDC;
-    ptr32_array_out[2] = 0xFEEDBEEF;
-    ptr32_array_out[3] = 0xBEEFFEED;
-    out->WriteArrayOfIntPtr32(ptr32_array_out, 4);
+    int32_t int32_array_out[8];
+    int32_array_out[0] = 0xABCDABCD;
+    int32_array_out[1] = 0xFEDCFEDC;
+    int32_array_out[2] = 0xFEEDBEEF;
+    int32_array_out[3] = 0xBEEFFEED;
+    int32_array_out[4] = 0x00000000;
+    int32_array_out[5] = 0x00000001;
+    int32_array_out[6] = 0x7FFFFFFF;
+    int32_array_out[7] = -1;
+    out->WriteArrayOfInt32(int32_array_out, 8);
 
     delete out;
 
@@ -180,8 +184,8 @@ void Test_File()
 
     int32_t int32val    = in->ReadInt32();
 
-    intptr_t ptr32_array_in[4];
-    in->ReadArrayOfIntPtr32(ptr32_array_in, 4);
+    int32_t int32_array_in[8];
+    in->ReadArrayOfInt32(int32_array_in, 8);
 
     delete in;
 
@@ -196,10 +200,27 @@ void Test_File()
     assert(memcmp(&tricky_data_in, &tricky_data_out, sizeof(TTrickyAlignedData)) == 0);
     assert(int32val == 20);
 
-    assert(ptr32_array_in[0] == 0xABCDABCD);
-    assert(ptr32_array_in[1] == 0xFEDCFEDC);
-    assert(ptr32_array_in[2] == 0xFEEDBEEF);
-    assert(ptr32_array_in[3] == 0xBEEFFEED);
+#ifndef AGS_64BIT
+    assert(int32_array_in[0] == 0xABCDABCD);
+    assert(int32_array_in[1] == 0xFEDCFEDC);
+    assert(int32_array_in[2] == 0xFEEDBEEF);
+    assert(int32_array_in[3] == 0xBEEFFEED);
+    assert(int32_array_in[4] == 0x00000000);
+    assert(int32_array_in[5] == 0x00000001);
+    assert(int32_array_in[6] == 0x7fffffff);
+    assert(int32_array_in[7] == -1);
+#else
+    // Because these are saved as signed int, they get sign extended. 
+    // This is fine as we might want negative numbers
+    assert(int32_array_in[0] == 0xFFFFFFFFABCDABCD);
+    assert(int32_array_in[1] == 0xFFFFFFFFFEDCFEDC);
+    assert(int32_array_in[2] == 0xFFFFFFFFFEEDBEEF);
+    assert(int32_array_in[3] == 0xFFFFFFFFBEEFFEED);
+    assert(int32_array_in[4] == 0x00000000);
+    assert(int32_array_in[5] == 0x00000001);
+    assert(int32_array_in[6] == 0x7fffffff);
+    assert(int32_array_in[7] == -1);
+#endif
 
     assert(!File::TestReadFile("test.tmp"));
 }


### PR DESCRIPTION
This removes the use of the `(Read|Write)ArrayOfIntPtr32` and loads code as int32, explicitly mapping to int_ptr when loading into an cc_instance.

This works because we use FIXUPs to replace any use of pointers (which wouldn't work when truncated to 32bit) with new pointers in cc_instance.

In the future, it might be worth editing the Save script method to strip pointers out of the rawCode buffer.