### PR TITLE
AGS3: Make fps display stable and make timing workable when maxed-framerate

### DIFF
--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -54,8 +54,7 @@ extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern volatile int timerloop;
 extern AGSPlatformDriver *platform;
 extern volatile unsigned long globalTimerCounter;
-extern int time_between_timers;
-extern int frames_per_second;
+extern int get_current_fps();
 extern int loops_per_character;
 extern SpriteCache spriteset;
 
@@ -308,7 +307,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
             if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
-                play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms / time_between_timers);
+                play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms * get_current_fps() / 1000);
                 break;
             }
             // if skipping cutscene, don't get stuck on No Auto Remove
@@ -391,7 +390,7 @@ int GetTextDisplayLength(const char *text)
 
 int GetTextDisplayTime(const char *text, int canberel) {
     int uselen = 0;
-    int fpstimer = frames_per_second;
+    int fpstimer = get_current_fps();
 
     // if it's background speech, make it stay relative to game speed
     if ((canberel == 1) && (play.bgspeech_game_speed == 1))

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2130,9 +2130,11 @@ void draw_fps()
     fpsDisplay->ClearTransparent();
     
     char tbuffer[60];
-    sprintf(tbuffer,"FPS: %d",fps);
     color_t text_color = fpsDisplay->GetCompatibleColor(14);
+    if (fps > 0) {
+    sprintf(tbuffer,"FPS: %d",fps);
     wouttext_outline(fpsDisplay, 1, 1, FONT_SPEECH, text_color, tbuffer);
+    }
     sprintf(tbuffer, "Loop %u", loopcounter);
     int textw = wgettextwidth(tbuffer, FONT_SPEECH);
     wouttext_outline(fpsDisplay, ui_view.GetWidth() / 2, 1, FONT_SPEECH, text_color, tbuffer);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -320,9 +320,9 @@ void set_debug_mode(bool on)
     debug_set_console(on);
 }
 
-void set_game_speed(int fps) {
-    frames_per_second = fps;
-    time_between_timers = 1000 / fps;
+void set_game_speed(int _frames_per_second) {
+    frames_per_second = _frames_per_second;
+    time_between_timers = 1000 / _frames_per_second;
     install_int_ex(dj_timer_handler,MSEC_TO_TIMER(time_between_timers));
 }
 
@@ -1102,7 +1102,7 @@ HSaveError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
     int camx = in->ReadInt32();
     int camy = in->ReadInt32();
     play.SetRoomCameraAt(camx, camy);
-    loopcounter = in->ReadInt32();
+    set_loop_counter(in->ReadInt32());
     return HSaveError::None();
 }
 

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -129,7 +129,7 @@ int Game_ChangeTranslation(const char *newFilename);
 //=============================================================================
 
 void set_debug_mode(bool on);
-void set_game_speed(int fps);
+void set_game_speed(int _frames_per_second);
 void setup_for_dialog();
 void restore_after_dialog();
 Common::String get_save_game_path(int slotNum);
@@ -183,6 +183,7 @@ extern int new_room_x, new_room_y, new_room_loop;
 extern int displayed_room;
 extern int frames_per_second;
 extern unsigned int loopcounter;
+extern void set_loop_counter(unsigned int _loopcounter);
 extern Common::String saveGameSuffix;
 extern int game_paused;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -67,7 +67,6 @@ extern int displayed_room;
 extern int game_paused;
 extern SpriteCache spriteset;
 extern int frames_per_second;
-extern int time_between_timers;
 extern char gamefilenamebuf[200];
 extern GameSetup usetup;
 extern unsigned int load_new_game;
@@ -81,6 +80,7 @@ extern int getloctype_index;
 extern char saveGameDirectory[260];
 extern IGraphicsDriver *gfxDriver;
 extern color palette[256];
+extern int get_current_fps();
 
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
 extern int psp_gfx_renderer;
@@ -373,8 +373,8 @@ void SetRestartPoint() {
 
 void SetGameSpeed(int newspd) {
     // if Ctrl+E has been used to max out frame rate, lock it there
-    if ((frames_per_second == 1000) && (display_fps == 2))
-        return;
+    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == 2);
+    if (maxed_framerate) { return; }
 
     newspd += play.game_speed_modifier;
     if (newspd>1000) newspd=1000;
@@ -384,7 +384,7 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
-    return frames_per_second - play.game_speed_modifier;
+    return get_current_fps() - play.game_speed_modifier;
 }
 
 int SetGameOption (int opt, int setting) {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -962,9 +962,7 @@ extern long t1;  // defined in ac_main
 
 void first_room_initialization() {
     starting_room = displayed_room;
-    t1 = time(NULL);
-    lastcounter=0;
-    loopcounter=0;
+    set_loop_counter(0);
     mouse_z_was = mouse_z;
 }
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -240,7 +240,7 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
 
     // Other dynamic values
     r_data.FPS = in->ReadInt32();
-    loopcounter = in->ReadInt32();
+    set_loop_counter(in->ReadInt32());
     ifacepopped = in->ReadInt32();
     game_paused = in->ReadInt32();
     // Mouse cursor state

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -56,15 +56,13 @@ extern int facetalkloop, facetalkrepeat, facetalkAllowBlink;
 extern int facetalkBlinkLoop;
 extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement_y;
 extern volatile unsigned long globalTimerCounter;
-extern int time_between_timers;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern int numscreenover;
 extern int is_text_overlay;
 extern IGraphicsDriver *gfxDriver;
-extern int frames_per_second;
-
+extern int get_current_fps();
 
 int do_movelist_move(short*mlnum,int*xx,int*yy) {
   int need_to_fix_sprite=0;
@@ -269,7 +267,7 @@ void update_speech_and_messages()
     {
         if (!play.speech_in_post_state)
         {
-            play.messagetime = play.speech_display_post_time_ms * frames_per_second / 1000;
+            play.messagetime = play.speech_display_post_time_ms * get_current_fps() / 1000;
         }
         play.speech_in_post_state = !play.speech_in_post_state;
     }
@@ -283,7 +281,7 @@ void update_speech_and_messages()
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
         remove_screen_overlay(OVER_TEXTMSG);
-        play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms / time_between_timers);
+        play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms * get_current_fps() / 1000);
       }
     }
   }

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -802,7 +802,7 @@ void update_volume_drop_if_voiceover()
 }
 
 extern volatile char want_exit;
-extern int frames_per_second;
+extern int get_current_fps();
 
 void update_mp3_thread()
 {
@@ -865,7 +865,7 @@ void update_polled_audio_and_crossfade ()
                     // we want to crossfade, and we know how far through
                     // the tune we are
                     int takesSteps = calculate_max_volume() / game.options[OPT_CROSSFADEMUSIC];
-                    int takesMs = (takesSteps * 1000) / frames_per_second;
+                    int takesMs = takesSteps * 1000 / get_current_fps();
                     if (curpos >= muslen - takesMs)
                         play_next_queued();
                 }


### PR DESCRIPTION
Use a finer time source to calculate fps.

I found some parts of the engine were using the requested framerate instead of the actual framerate. This works fine except when in maxed framerate, which never reaches 1000fps :) This PR fixes that too. (only when in maxed framerate mode, in normal gameplay it uses the requested framerate always)