### PR TITLE
AGS3 audio: introduce audio system headers

### DIFF
--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -17,9 +17,8 @@
 #include "ac/dynobj/cc_audioclip.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "script/runtimescriptvalue.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -16,10 +16,9 @@
 #include "ac/audioclip.h"
 #include "ac/audiochannel.h"
 #include "ac/gamesetupstruct.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "script/runtimescriptvalue.h"
 #include "ac/dynobj/cc_audiochannel.h"
+#include "media/audio/audio_system.h"
 
 extern GameSetupStruct game;
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -59,6 +59,7 @@
 #include "ac/dynobj/cc_inventory.h"
 #include "script/script_runtime.h"
 #include "gfx/gfx_def.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 
@@ -79,7 +80,6 @@ extern int said_speech_line;
 extern int numscreenover;
 extern int said_text;
 extern int our_eip;
-extern int update_music_at;
 extern int cur_mode;
 extern CCCharacter ccDynamicCharacter;
 extern CCInventory ccDynamicInv;

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -15,7 +15,6 @@
 #include "ac/characterinfo.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
-#include "media/audio/audiodefines.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
 #include "ac/gamestate.h"
@@ -26,6 +25,7 @@
 #include "game/roomstruct.h"
 #include "main/maindefines_ex.h"	// RETURN_CONTINUE
 #include "main/update.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 
@@ -35,7 +35,6 @@ extern int displayed_room;
 extern GameState play;
 extern int char_speaking;
 extern RoomStruct thisroom;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern unsigned int loopcounter;
 
 #define Random __Rand

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -43,7 +43,6 @@
 #include "gui/guimain.h"
 #include "gui/guitextbox.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "platform/base/agsplatformdriver.h"
 #include "script/script.h"
 #include "ac/spritecache.h"
@@ -51,6 +50,7 @@
 #include "gfx/gfx_util.h"
 #include "gfx/graphicsdriver.h"
 #include "ac/mouse.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -36,13 +36,12 @@
 #include "gui/guibutton.h"
 #include "gui/guimain.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/spritecache.h"
 #include "gfx/gfx_util.h"
 #include "util/string_utils.h"
 #include "ac/mouse.h"
-#include "media/audio/soundclip.h"
+#include "media/audio/audio_system.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -50,8 +50,6 @@
 #include "debug/debug_log.h"
 #include "font/fonts.h"
 #include "gui/guimain.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
@@ -60,6 +58,7 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/ali3dexception.h"
 #include "gfx/blender.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/dynobj/cc_audiochannel.cpp
+++ b/Engine/ac/dynobj/cc_audiochannel.cpp
@@ -13,8 +13,8 @@
 //=============================================================================
 
 #include "ac/dynobj/cc_audiochannel.h"
-#include "media/audio/audiodefines.h"
 #include "ac/dynobj/scriptaudiochannel.h"
+#include "media/audio/audio_system.h"
 
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
 

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -24,8 +24,6 @@
 #include "ac/roomstatus.h"
 #include "ac/screen.h"
 #include "script/cc_error.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
@@ -33,6 +31,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -72,8 +72,6 @@
 #include "gui/guidialog.h"
 #include "main/graphics_mode.h"
 #include "main/main.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
 #include "script/cc_error.h"
@@ -86,6 +84,7 @@
 #include "util/path.h"
 #include "util/string_utils.h"
 #include "ac/mouse.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -23,6 +23,7 @@
 #include "game/roomstruct.h"
 #include "util/alignedstream.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -65,9 +65,9 @@
 #include "ac/parser.h"
 #include "ac/string.h"
 #include "ac/room.h"
-#include "media/audio/audio.h"
 #include "media/video/video.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 #include "ac/dynobj/scriptstring.h"
 extern ScriptString myScriptStringImpl;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -24,8 +24,7 @@
 #include "debug/debugger.h"
 #include "game/roomstruct.h"
 #include "main/engine.h"
-#include "media/audio/audio.h"
-#include "media/audio/sound.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -47,7 +47,6 @@
 #include "main/game_start.h"
 #include "main/game_run.h"
 #include "main/graphics_mode.h"
-#include "media/audio/audio.h"
 #include "script/script.h"
 #include "script/script_runtime.h"
 #include "ac/spritecache.h"
@@ -56,6 +55,7 @@
 #include "core/assetmanager.h"
 #include "main/game_file.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/global_video.cpp
+++ b/Engine/ac/global_video.cpp
@@ -21,8 +21,8 @@
 #include "ac/path_helper.h"
 #include "debug/agseditordebugger.h"
 #include "debug/debug_log.h"
-#include "media/audio/audio.h"
 #include "media/video/video.h"
+#include "media/audio/audio_system.h"
 
 
 void scrPlayVideo(const char* name, int skip, int flags) {

--- a/Engine/ac/global_viewframe.cpp
+++ b/Engine/ac/global_viewframe.cpp
@@ -17,7 +17,7 @@
 #include "ac/view.h"
 #include "ac/gamesetupstruct.h"
 #include "debug/debug_log.h"
-#include "media/audio/audio.h"
+#include "media/audio/audio_system.h"
 
 extern GameSetupStruct game;
 extern ViewStruct*views;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -28,13 +28,13 @@
 #include "debug/debug_log.h"
 #include "gui/guidialog.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/spritecache.h"
 #include "script/runtimescriptvalue.h"
 #include "ac/dynobj/cc_character.h"
 #include "ac/dynobj/cc_inventory.h"
 #include "util/math.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -14,7 +14,6 @@
 
 #include "util/string_utils.h" //strlwr()
 #include "ac/common.h"
-#include "media/audio/audiodefines.h"
 #include "ac/charactercache.h"
 #include "ac/characterextras.h"
 #include "ac/draw.h"
@@ -51,7 +50,6 @@
 #include "debug/debugger.h"
 #include "debug/out.h"
 #include "game/room_version.h"
-#include "media/audio/audio.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
@@ -67,6 +65,7 @@
 #include "gfx/gfxfilter.h"
 #include "util/math.h"
 #include "ac/dynobj/scriptcamera.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -13,13 +13,11 @@
 //=============================================================================
 
 #include "ac/common.h"
-#include "media/audio/audiodefines.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/keycode.h"
 #include "ac/mouse.h"
 #include "ac/sys_events.h"
-#include "media/audio/soundclip.h"
 #include "device/mousew32.h"
 
 using namespace AGS::Common;
@@ -29,7 +27,6 @@ extern GameSetupStruct game;
 extern GameState play;
 
 extern volatile unsigned long globalTimerCounter;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern int pluginSimulatedClick;
 extern int displayed_room;
 extern char check_dynamic_sprites_at_exit;

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -13,7 +13,6 @@
 //=============================================================================
 
 #include "ac/common.h"
-#include "media/audio/audiodefines.h"
 #include "ac/draw.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
@@ -25,18 +24,17 @@
 #include "debug/debug_log.h"
 #include "main/engine.h"
 #include "main/main.h"
-#include "media/audio/soundclip.h"
 #include "gfx/graphicsdriver.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "main/graphics_mode.h"
 #include "ac/global_debug.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern GameSetup usetup;
 extern GameState play;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
 extern ScriptSystem scsystem;
 extern IGraphicsDriver *gfxDriver;

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -15,14 +15,13 @@
 #include "ac/gamesetupstruct.h"
 #include "ac/viewframe.h"
 #include "debug/debug_log.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "ac/spritecache.h"
 #include "gfx/bitmap.h"
 #include "script/runtimescriptvalue.h"
 #include "ac/dynobj/cc_audioclip.h"
 #include "ac/draw.h"
 #include "ac/game_version.h"
+#include "media/audio/audio_system.h"
 
 using AGS::Common::Bitmap;
 using AGS::Common::Graphics;
@@ -31,7 +30,6 @@ extern GameSetupStruct game;
 extern ViewStruct*views;
 extern SpriteCache spriteset;
 extern CCAudioClip ccDynamicAudioClip;
-extern SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1];
 
 
 int ViewFrame_GetFlipped(ScriptViewFrame *svf) {

--- a/Engine/ac/walkbehind.cpp
+++ b/Engine/ac/walkbehind.cpp
@@ -16,7 +16,6 @@
 #include "ac/common.h"
 #include "ac/common_defines.h"
 #include "ac/gamestate.h"
-#include "media/audio/audio.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -24,8 +24,6 @@
 #include "debug/logfile.h"
 #include "debug/messagebuffer.h"
 #include "main/config.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "plugin/plugin_engine.h"
 #include "script/script.h"
 #include "script/script_common.h"

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -35,13 +35,13 @@
 #include "gfx/bitmap.h"
 #include "gfx/ddb.h"
 #include "gui/guilabel.h"
-#include "media/audio/audio.h"
 #include "plugin/plugin_engine.h"
 #include "script/cc_error.h"
 #include "script/exports.h"
 #include "script/script.h"
 #include "script/script_runtime.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace Common;
 using namespace Engine;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -41,8 +41,6 @@
 #include "game/savegame_components.h"
 #include "game/savegame_internal.h"
 #include "main/main.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
@@ -52,6 +50,7 @@
 #include "util/file.h"
 #include "util/stream.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace Common;
 using namespace Engine;

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -43,13 +43,12 @@
 #include "gui/guimain.h"
 #include "gui/guislider.h"
 #include "gui/guitextbox.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
 #include "script/cc_error.h"
 #include "script/script.h"
 #include "util/filestream.h" // TODO: needed only because plugins expect file handle
+#include "media/audio/audio_system.h"
 
 using namespace Common;
 

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -29,9 +29,9 @@
 #include "gui/guimain.h"
 #include "gui/mycontrols.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
+#include "media/audio/audio_system.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -21,7 +21,6 @@
 #include "gui/guidialog.h"
 #include "gui/guidialoginternaldefs.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "gfx/bitmap.h"
 
 using AGS::Common::Bitmap;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -33,6 +33,7 @@
 #include "util/textstreamreader.h"
 #include "util/path.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -51,7 +51,6 @@
 #include "main/graphics_mode.h"
 #include "main/main.h"
 #include "main/main_allegro.h"
-#include "media/audio/sound.h"
 #include "ac/spritecache.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/ddb.h"
@@ -62,6 +61,7 @@
 #include "util/path.h"
 #include "main/game_file.h"
 #include "debug/out.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -47,11 +47,11 @@
 #include "main/engine.h"
 #include "main/game_run.h"
 #include "main/update.h"
-#include "media/audio/soundclip.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
 #include "script/script.h"
 #include "ac/spritecache.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -33,6 +33,7 @@
 #include "main/game_run.h"
 #include "main/game_start.h"
 #include "script/script.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/main/mainheader.h
+++ b/Engine/main/mainheader.h
@@ -31,8 +31,6 @@
 #include "ac/route_finder.h"
 #include "util/misc.h"
 #include "script/cc_error.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundcache.h"
 
 #if defined (WINDOWS_VERSION)
 #include <process.h>

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -36,6 +36,7 @@
 #include "gfx/bitmap.h"
 #include "core/assetmanager.h"
 #include "plugin/plugin_engine.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -35,7 +35,7 @@
 #include "ac/walkablearea.h"
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
-#include "media/audio/soundclip.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/media/audio/audio_system.h
+++ b/Engine/media/audio/audio_system.h
@@ -1,0 +1,16 @@
+#ifndef __AC_MEDIA_AUDIO_SYSTEM_H
+#define __AC_MEDIA_AUDIO_SYSTEM_H
+
+#include "media/audio/audiodefines.h"
+#include "media/audio/ambientsound.h"
+
+#include "media/audio/audio.h"
+
+#include "media/audio/soundcache.h"
+
+#include "media/audio/soundclip.h"
+#include "media/audio/sound.h"
+
+#include "media/audio/queuedaudioitem.h"
+
+#endif

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -32,8 +32,8 @@
 #include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
 #include "util/stream.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -23,7 +23,7 @@
 //#include "ac/runtime_defines.h"
 //#include "main/config.h"
 //#include "plugin/agsplugin.h"
-//#include "media/audio/audio.h"
+//#include "media/audio/audio_system.h"
 //#include <libcda.h>
 //#include <pwd.h>
 //#include <sys/stat.h>

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -32,13 +32,13 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "main/engine.h"
-#include "media/audio/audio.h"
 #include "platform/base/agsplatformdriver.h"
 #include "platform/windows/setup/winsetup.h"
 #include "plugin/agsplugin.h"
 #include "util/file.h"
 #include "util/stream.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -29,10 +29,12 @@
 #define _D3DTYPES_H_
 #define _STRSAFE_H_INCLUDED_
 typedef float D3DVALUE, *LPD3DVALUE;
+#include "ac/common.h"
 #include "main/game_run.h"
 #include "media/video/VMR9Graph.h"
 #include "platform/base/agsplatformdriver.h"
 //#include <atlbase.h>
+#include "media/audio/audio_system.h"
 
 #define USES_CONVERSION int _convert = 0; _convert; UINT _acp = CP_ACP; _acp; LPCWSTR _lpw = NULL; _lpw; LPCSTR _lpa = NULL; _lpa
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -42,8 +42,6 @@
 #include "gui/guidefines.h"
 #include "main/game_run.h"
 #include "main/engine.h"
-#include "media/audio/audio.h"
-#include "media/audio/sound.h"
 #include "plugin/agsplugin.h"
 #include "plugin/plugin_engine.h"
 #include "plugin/plugin_builtin.h"
@@ -62,6 +60,7 @@
 #include "gfx/gfx_util.h"
 #include "util/memory.h"
 #include "util/filestream.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -38,11 +38,10 @@
 #include "script/cc_options.h"
 #include "debug/debug_log.h"
 #include "main/game_run.h"
-#include "media/audio/audio.h"
-#include "media/audio/soundclip.h"
 #include "media/video/video.h"
 #include "script/script_runtime.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 extern GameSetupStruct game;
 extern GameState play;


### PR DESCRIPTION
Simplify access to the audio system with a single header. Saves guessing which audio header(s) to use.

To be used from non-audio system modules. Not included in other header files.