### PR TITLE
AGS3 audio: remove last_sound_played and soundclip->restart()

### DIFF
--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -139,22 +139,9 @@ int PlaySoundEx(int val1, int channel) {
     if (play.fast_forward)
         return -1;
 
-    // that sound is already in memory, play it
-    if (!psp_audio_multithreaded)
-    {
-        if ((last_sound_played[channel] == val1) && (channels[channel] != NULL)) {
-            debug_script_log("Playing sound %d on channel %d; cached", val1, channel);
-            channels[channel]->restart();
-            channels[channel]->set_volume (play.sound_volume);
-            return channel;
-        }
-    }
-
     // free the old sound
     stop_and_destroy_channel (channel);
     debug_script_log("Playing sound %d on channel %d", val1, channel);
-
-    last_sound_played[channel] = val1;
 
     SOUNDCLIP *soundfx = aclip ? load_sound_and_play(aclip, false) : NULL;
     if (soundfx == NULL) {

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1188,9 +1188,6 @@ void engine_init_game_settings()
     for (ee = 0; ee < MAXGLOBALSTRINGS; ee++)
         play.globalstrings[ee][0] = 0;
 
-    for (ee = 0; ee < MAX_SOUND_CHANNELS; ee++)
-        last_sound_played[ee] = -1;
-
     if (!usetup.translation.IsEmpty())
         init_translation (usetup.translation, "", true);
 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -360,7 +360,6 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
     if (!play.fast_forward && channels[SCHAN_SPEECH])
         apply_volume_drop_to_clip(soundfx);
 
-    last_sound_played[channel] = -1;
     channels[channel] = soundfx;
     return &scrAudioChannel[channel];
 }
@@ -505,8 +504,6 @@ SOUNDCLIP *load_sound_clip_from_old_style_number(bool isMusic, int indexNumber, 
 }
 
 //=============================================================================
-
-int last_sound_played[MAX_SOUND_CHANNELS + 1];
 
 void force_audiostream_include() {
     // This should never happen, but the call is here to make it

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -108,7 +108,6 @@ extern int crossFadeVolumeAtStart;
 
 extern SOUNDCLIP *cachedQueuedMusic;
 
-extern int last_sound_played[MAX_SOUND_CHANNELS + 1];
 extern AmbientSound ambient[MAX_SOUND_CHANNELS + 1];  // + 1 just for safety on array iterations
 
 #endif // __AC_AUDIO_H

--- a/Engine/media/audio/clip_mydumbmod.cpp
+++ b/Engine/media/audio/clip_mydumbmod.cpp
@@ -120,15 +120,6 @@ int MYMOD::get_length_ms()
     return (duh_get_length(tune) * 10) / 655;
 }
 
-void MYMOD::restart()
-{
-    if (tune != NULL) {
-        al_stop_duh(duhPlayer);
-        done = 0;
-        duhPlayer = al_start_duh(tune, 2, 0, 1.0, 8192, 22050);
-    }
-}
-
 int MYMOD::get_voice()
 {
     // MOD uses so many different voices it's not practical to keep track

--- a/Engine/media/audio/clip_mydumbmod.h
+++ b/Engine/media/audio/clip_mydumbmod.h
@@ -52,8 +52,6 @@ struct MYMOD : public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     virtual void pause();

--- a/Engine/media/audio/clip_myjgmod.cpp
+++ b/Engine/media/audio/clip_myjgmod.cpp
@@ -67,15 +67,6 @@ int MYMOD::get_length_ms()
     return 0;
 }
 
-void MYMOD::restart()
-{
-    if (tune != NULL) {
-        stop_mod();
-        done = 0;
-        play_mod(tune, 0);
-    }
-}
-
 int MYMOD::get_voice()
 {
     // MOD uses so many different voices it's not practical to keep track

--- a/Engine/media/audio/clip_myjgmod.h
+++ b/Engine/media/audio/clip_myjgmod.h
@@ -37,8 +37,6 @@ struct MYMOD:public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     int get_sound_type();

--- a/Engine/media/audio/clip_mymidi.cpp
+++ b/Engine/media/audio/clip_mymidi.cpp
@@ -69,15 +69,6 @@ int MYMIDI::get_length_ms()
     return lengthInSeconds * 1000;
 }
 
-void MYMIDI::restart()
-{
-    if (tune != NULL) {
-        stop_midi();
-        done = 0;
-        play_midi(tune, 0);
-    }
-}
-
 int MYMIDI::get_voice()
 {
     // voice is N/A for midi

--- a/Engine/media/audio/clip_mymidi.h
+++ b/Engine/media/audio/clip_mymidi.h
@@ -41,8 +41,6 @@ struct MYMIDI:public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     virtual void pause();

--- a/Engine/media/audio/clip_mymp3.cpp
+++ b/Engine/media/audio/clip_mymp3.cpp
@@ -166,21 +166,6 @@ int MYMP3::get_length_ms()
     return almp3_get_length_msecs_mp3stream(stream, filesize);
 }
 
-void MYMP3::restart()
-{
-    if (stream != NULL) {
-        // need to reset file pointer for this to work
-		AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-        almp3_play_mp3stream(stream, MP3CHUNKSIZE, vol, panning);
-		_lockMp3.Release();
-        done = 0;
-        paused = 0;
-
-        if (!psp_audio_multithreaded)
-          poll();
-    }
-}
-
 int MYMP3::get_voice()
 {
 	AGS::Engine::MutexLock _lockMp3(_mp3_mutex);

--- a/Engine/media/audio/clip_mymp3.h
+++ b/Engine/media/audio/clip_mymp3.h
@@ -37,7 +37,6 @@ struct MYMP3:public SOUNDCLIP
     int get_pos();
     int get_pos_ms();
     int get_length_ms();
-    void restart();
     int get_voice();
     int get_sound_type();
     int play();

--- a/Engine/media/audio/clip_myogg.cpp
+++ b/Engine/media/audio/clip_myogg.cpp
@@ -192,20 +192,6 @@ int MYOGG::get_length_ms()
     return 0;
 }
 
-void MYOGG::restart()
-{
-    if (stream != NULL) {
-        // need to reset file pointer for this to work
-        quit("Attempted to restart OGG not currently supported");
-        alogg_play_oggstream(stream, MP3CHUNKSIZE, vol, panning);
-        done = 0;
-        paused = 0;
-        
-        if (!psp_audio_multithreaded)
-          poll();
-    }
-}
-
 int MYOGG::get_voice()
 {
     AUDIOSTREAM *ast = alogg_get_audiostream_oggstream(stream);

--- a/Engine/media/audio/clip_myogg.h
+++ b/Engine/media/audio/clip_myogg.h
@@ -46,8 +46,6 @@ struct MYOGG:public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     int get_sound_type();

--- a/Engine/media/audio/clip_mystaticmp3.cpp
+++ b/Engine/media/audio/clip_mystaticmp3.cpp
@@ -151,21 +151,6 @@ int MYSTATICMP3::get_length_ms()
     return almp3_get_length_msecs_mp3(tune);
 }
 
-void MYSTATICMP3::restart()
-{
-    if (tune != NULL) {
-        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-        almp3_stop_mp3(tune);
-        almp3_rewind_mp3(tune);
-        almp3_play_mp3(tune, 16384, vol, panning);
-		_lockMp3.Release();
-        done = 0;
-
-        if (!psp_audio_multithreaded)
-          poll();
-    }
-}
-
 int MYSTATICMP3::get_voice()
 {
 	AGS::Engine::MutexLock _lockMp3(_mp3_mutex);

--- a/Engine/media/audio/clip_mystaticmp3.h
+++ b/Engine/media/audio/clip_mystaticmp3.h
@@ -42,7 +42,6 @@ struct MYSTATICMP3:public SOUNDCLIP
     int get_pos_ms();
 
     int get_length_ms();
-    void restart();
 
     int get_voice();
 

--- a/Engine/media/audio/clip_mystaticogg.cpp
+++ b/Engine/media/audio/clip_mystaticogg.cpp
@@ -177,22 +177,6 @@ int MYSTATICOGG::get_length_ms()
     return alogg_get_length_msecs_ogg(tune);
 }
 
-void MYSTATICOGG::restart()
-{
-    if (tune != NULL) {
-        alogg_stop_ogg(tune);
-        alogg_rewind_ogg(tune);
-        alogg_play_ogg(tune, 16384, vol, panning);
-        last_ms_offs = 0;
-        last_but_one = 0;
-        last_but_one_but_one = 0;
-        done = 0;
-
-        if (!psp_audio_multithreaded)
-          poll();
-    }
-}
-
 int MYSTATICOGG::get_voice()
 {
     AUDIOSTREAM *ast = alogg_get_audiostream_ogg(tune);

--- a/Engine/media/audio/clip_mystaticogg.h
+++ b/Engine/media/audio/clip_mystaticogg.h
@@ -47,8 +47,6 @@ struct MYSTATICOGG:public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     int get_sound_type();

--- a/Engine/media/audio/clip_mywave.cpp
+++ b/Engine/media/audio/clip_mywave.cpp
@@ -123,16 +123,6 @@ int MYWAVE::get_length_ms()
     return (wave->len / (wave->freq / 100)) * 10;
 }
 
-void MYWAVE::restart()
-{
-    if (wave != NULL) {
-        done = 0;
-        paused = 0;
-        stop_sample(wave);
-        voice = play_sample(wave, vol, panning, 1000, 0);
-    }
-}
-
 int MYWAVE::get_voice()
 {
     return voice;

--- a/Engine/media/audio/clip_mywave.h
+++ b/Engine/media/audio/clip_mywave.h
@@ -39,8 +39,6 @@ struct MYWAVE:public SOUNDCLIP
 
     int get_length_ms();
 
-    void restart();
-
     int get_voice();
 
     int get_sound_type();

--- a/Engine/media/audio/soundclip.h
+++ b/Engine/media/audio/soundclip.h
@@ -64,7 +64,6 @@ struct SOUNDCLIP
     // apply volume directly to playback; volume is given in units of 255
     // NOTE: this completely ignores volAsPercentage and muted property
     virtual void set_volume(int) = 0;
-    virtual void restart() = 0;
     virtual void seek(int) = 0;
     virtual int get_pos() = 0;    // return 0 to indicate seek not supported
     virtual int get_pos_ms() = 0; // this must always return valid value if poss


### PR DESCRIPTION
Since we have the sound cache, we probably don't need this caching method for sounds.

This removes last_sound_played and restart() as restart was only used for this caching behaviour. It means one less thing to reimplement when moving to a different sound system.

It was disabled for multi-threading audio, presumably because we delete soundclips after they have played.