### PR TITLE
Timing: use c++ std timers instead of maintaining own timer thread.

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -80,7 +80,6 @@ extern int said_speech_line;
 extern int numscreenover;
 extern int said_text;
 extern int our_eip;
-extern int cur_mode;
 extern CCCharacter ccDynamicCharacter;
 extern CCInventory ccDynamicInv;
 
@@ -2402,8 +2401,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     play.speech_in_post_state = false;
 
     if (isPause) {
-        if (update_music_at > 0)
-            update_music_at += play.messagetime;
+        postpone_scheduled_music_update_by(std::chrono::milliseconds(play.messagetime * 1000 / frames_per_second));
         GameLoopUntilEvent(UNTIL_INTISNEG,(long)&play.messagetime);
         return;
     }

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -15,7 +15,6 @@
 #include "ac/characterinfo.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
-#include "media/audio/soundclip.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
 #include "ac/gamestate.h"

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -60,7 +60,6 @@ extern ccInstance *dialogScriptsInst;
 extern int in_new_room;
 extern CharacterInfo*playerchar;
 extern SpriteCache spriteset;
-extern volatile int timerloop;
 extern AGSPlatformDriver *platform;
 extern int cur_mode,cur_cursor;
 extern IGraphicsDriver *gfxDriver;
@@ -861,7 +860,6 @@ bool DialogOptions::Run()
       }
       else
       {
-        timerloop = 0;
         update_audio_system_on_game_loop();
         render_graphics(ddb, dirtyx, dirtyy);
       }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -59,6 +59,7 @@
 #include "gfx/ali3dexception.h"
 #include "gfx/blender.h"
 #include "media/audio/audio_system.h"
+#include "ac/game.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -2130,7 +2131,12 @@ void draw_fps()
     
     char tbuffer[60];
     color_t text_color = fpsDisplay->GetCompatibleColor(14);
-    sprintf(tbuffer, "FPS: %d", fps > 0 ? fps : 0);
+    // Don't display fps if we don't have enough information (because loop count was just reset)
+    if (!std::isnan(fps)) {
+        sprintf(tbuffer, "FPS: %2.1f / %d", fps, frames_per_second);
+    } else {
+        sprintf(tbuffer, "FPS: --.- / %d", frames_per_second);
+    }
     wouttext_outline(fpsDisplay, 1, 1, FONT_SPEECH, text_color, tbuffer);
     sprintf(tbuffer, "Loop %u", loopcounter);
     int textw = wgettextwidth(tbuffer, FONT_SPEECH);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -90,7 +90,6 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
-extern int time_between_timers;
 extern int cur_mode,cur_cursor;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
@@ -321,8 +320,7 @@ void set_debug_mode(bool on)
 
 void set_game_speed(int new_fps) {
     frames_per_second = new_fps;
-    time_between_timers = 1000 / new_fps;
-    install_int_ex(dj_timer_handler,MSEC_TO_TIMER(time_between_timers));
+    setTimerFps(new_fps);
 }
 
 extern int cbuttfont;
@@ -1877,7 +1875,7 @@ void display_switch_out_suspend()
         }
     }
 
-    rest(1000);
+    platform->Delay(1000);
 
     // restore the callbacks
     SetMultitasking(0);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -24,6 +24,7 @@
 #include "util/alignedstream.h"
 #include "util/string_utils.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -465,7 +466,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     }
     text_min_display_time_ms = in->ReadInt32();
     ignore_user_input_after_text_timeout_ms = in->ReadInt32();
-    ignore_user_input_until_time = in->ReadInt32();
+    ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(in->ReadInt32());
     if (old_save)
         in->ReadArrayOfInt32(default_audio_type_volumes, MAX_AUDIO_TYPES);
 }
@@ -648,7 +649,8 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     }
     out->WriteInt32( text_min_display_time_ms);
     out->WriteInt32( ignore_user_input_after_text_timeout_ms);
-    out->WriteInt32( ignore_user_input_until_time);
+    auto ignore_user_input_until_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(ignore_user_input_until_time - AGS_Clock::now());
+    out->WriteInt32( ignore_user_input_until_time_ms.count() );
 }
 
 void GameState::ReadQueuedAudioItems_Aligned(Common::Stream *in)

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -28,6 +28,7 @@
 #include "util/geometry.h"
 #include "util/string_types.h"
 #include "util/string.h"
+#include "ac/timer.h"
 
 // Forward declaration
 namespace AGS { namespace Common {
@@ -208,7 +209,7 @@ struct GameState {
     std::vector<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms;
     int   ignore_user_input_after_text_timeout_ms;
-    unsigned long ignore_user_input_until_time;
+    AGS_Clock::time_point ignore_user_input_until_time;
     int   default_audio_type_volumes[MAX_AUDIO_TYPES];
 
     // Dynamic custom property values for characters and items

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -25,6 +25,7 @@
 #include "game/roomstruct.h"
 #include "main/engine.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -505,10 +506,9 @@ int play_speech(int charid,int sndid) {
     else
         play.music_master_volume -= play.speech_music_drop;
 
+    cancel_scheduled_music_update();
     apply_volume_drop_modifier(true);
     update_music_volume();
-    update_music_at = 0;
-    mvolcounter = 0;
 
     update_ambient_sound_vol();
 
@@ -527,8 +527,7 @@ void stop_speech() {
         play.music_master_volume = play.music_vol_was;
         // update the music in a bit (fixes two speeches follow each other
         // and music going up-then-down)
-        update_music_at = 20;
-        mvolcounter = 1;
+        schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
         stop_and_destroy_channel (SCHAN_SPEECH);
         curLipLine = -1;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -12,6 +12,8 @@
 //
 //=============================================================================
 
+#include <cmath>
+
 #include "ac/audiocliptype.h"
 #include "ac/global_game.h"
 #include "ac/common.h"
@@ -80,7 +82,7 @@ extern int getloctype_index;
 extern char saveGameDirectory[260];
 extern IGraphicsDriver *gfxDriver;
 extern color palette[256];
-extern int get_current_fps();
+extern float get_current_fps();
 
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
 extern int psp_gfx_renderer;
@@ -384,7 +386,7 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
-    return get_current_fps() - play.game_speed_modifier;
+    return std::lround(get_current_fps()) - play.game_speed_modifier;
 }
 
 int SetGameOption (int opt, int setting) {

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -35,6 +35,7 @@
 #include "ac/dynobj/cc_inventory.h"
 #include "util/math.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -45,7 +46,6 @@ extern ScriptInvItem scrInv[MAX_INV];
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern SpriteCache spriteset;
 extern int mousex,mousey;
-extern volatile int timerloop;
 extern int evblocknum;
 extern CharacterInfo*playerchar;
 extern AGSPlatformDriver *platform;
@@ -351,7 +351,6 @@ bool InventoryScreen::Run()
         return false; // end inventory screen loop
     }
 
-        timerloop = 0;
         //ags_domouse(DOMOUSE_UPDATE);
         update_audio_system_on_game_loop();
         refresh_gui_screen();

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -19,6 +19,8 @@
 #include "ac/mouse.h"
 #include "ac/sys_events.h"
 #include "device/mousew32.h"
+#include "platform/base/agsplatformdriver.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -39,7 +41,7 @@ int mouse_z_was = 0;
 
 int ags_kbhit () {
     int result = keypressed();
-    if ((result) && (globalTimerCounter < play.ignore_user_input_until_time))
+    if ((result) && (AGS_Clock::now() < play.ignore_user_input_until_time))
     {
         // ignoring user input
         ags_getch();
@@ -67,7 +69,7 @@ int ags_mgetbutton() {
         result = mgetbutton();
     }
 
-    if ((result >= 0) && (globalTimerCounter < play.ignore_user_input_until_time))
+    if ((result >= 0) && (AGS_Clock::now() < play.ignore_user_input_until_time))
     {
         // ignoring user input
         result = NONE;
@@ -188,6 +190,8 @@ void ags_clear_input_buffer()
 
 void ags_wait_until_keypress()
 {
-    while (!ags_kbhit());
+    while (!ags_kbhit()) {
+        platform->YieldCPU();
+    }
     ags_getch();
 }

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -12,24 +12,61 @@
 //
 //=============================================================================
 
+#include <stdio.h>
+#include <execinfo.h>
+#include <unistd.h>
+
 #include "ac/timer.h"
-#include "util/wgt2allg.h" // END_OF_FUNCTION macro
+#include "platform/base/agsplatformdriver.h"
 
-extern volatile int mvolcounter;
+namespace {
 
-unsigned int loopcounter=0,lastcounter=0;
-volatile unsigned long globalTimerCounter = 0;
+const auto MAXIMUM_FALL_BEHIND = 3;
 
-volatile int timerloop=0;
-int time_between_timers=25;  // in milliseconds
-// our timer, used to keep game running at same speed on all systems
-#if defined(WINDOWS_VERSION)
-void __cdecl dj_timer_handler() {
-#else
-extern "C" void dj_timer_handler() {
-#endif
-    timerloop++;
-    globalTimerCounter++;
-    if (mvolcounter > 0) mvolcounter++;
+auto last_tick_time = AGS_Clock::now();
+auto tick_duration = std::chrono::milliseconds(1000/40);
+auto framerate_maxed = false;
+
 }
-END_OF_FUNCTION(dj_timer_handler);
+
+void setTimerFps(int new_fps) {
+    tick_duration = std::chrono::milliseconds(1000/new_fps);
+    last_tick_time = AGS_Clock::now();
+    framerate_maxed = new_fps >= 1000;
+}
+
+bool waitingForNextTick() {
+    auto now = AGS_Clock::now();
+
+    if (framerate_maxed) {
+        last_tick_time = now;
+        return false;
+    }
+
+    auto is_lagging = (now - last_tick_time) > (MAXIMUM_FALL_BEHIND*tick_duration);
+    if (is_lagging) {
+#ifdef _DEBUG
+        auto missed_ticks = ((now - last_tick_time)/tick_duration);
+        printf("Lagging! Missed %lld ticks!\n", missed_ticks);
+        void *array[10];
+        auto size = backtrace(array, 10);
+        backtrace_symbols_fd(array, size, STDOUT_FILENO);
+        printf("\n");
+#endif
+        last_tick_time = now;
+        return false;
+    }
+
+    auto next_tick_time = last_tick_time + tick_duration;
+    if (next_tick_time <= now) {
+        last_tick_time = next_tick_time;
+        return false;
+    }
+
+    platform->YieldCPU();
+    return true;
+}
+
+void skipMissedTicks() {
+    last_tick_time = AGS_Clock::now();
+}

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -18,10 +18,18 @@
 #ifndef __AGS_EE_AC__TIMER_H
 #define __AGS_EE_AC__TIMER_H
 
-#if defined(WINDOWS_VERSION)
-void __cdecl dj_timer_handler();
-#else
-extern "C" void dj_timer_handler();
-#endif
+#include <type_traits>
+#include <chrono>
+
+// use high resolution clock only if we know it is monotonic/steady.
+// refer to https://stackoverflow.com/a/38253266/84262
+using AGS_Clock = std::conditional<
+        std::chrono::high_resolution_clock::is_steady,
+        std::chrono::high_resolution_clock, std::chrono::steady_clock
+      >::type;
+
+extern void setTimerFps(int new_fps);
+extern bool waitingForNextTick();  // store last tick time.
+extern void skipMissedTicks();  // if more than N frames, just skip all, start a fresh.
 
 #endif // __AGS_EE_AC__TIMER_H

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -30,6 +30,7 @@
 #include "script/script_common.h"
 #include "script/cc_error.h"
 #include "util/textstreamwriter.h"
+#include "platform/base/agsplatformdriver.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -75,7 +76,8 @@ bool disable_log_file = false;
 String debug_line[DEBUG_CONSOLE_NUMLINES];
 int first_debug_line = 0, last_debug_line = 0, display_console = 0;
 
-int fps=0,display_fps=0;
+float fps=NAN;
+int display_fps=0;
 
 std::unique_ptr<MessageBuffer> DebugMsgBuff;
 std::unique_ptr<LogFile> DebugLogFile;

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -34,6 +34,7 @@ AGS::Common::String get_cur_script(int numberOfLinesOfCallStack);
 bool get_script_position(ScriptPosition &script_pos);
 void check_debug_keys();
 
-extern int fps,display_fps;
+extern float fps;
+extern int display_fps;
 
 #endif // __AC_DEBUGGER_H

--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -17,6 +17,7 @@
 #include "util/stream.h"
 #include "util/textstreamwriter.h"
 #include "util/wgt2allg.h"              // exists()
+#include "platform/base/agsplatformdriver.h"
 
 using AGS::Common::Stream;
 using AGS::Common::TextStreamWriter;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -51,6 +51,7 @@
 #include "util/stream.h"
 #include "util/string_utils.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace Common;
 using namespace Engine;
@@ -609,7 +610,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
 
     guis_need_update = 1;
 
-    play.ignore_user_input_until_time = 0;
+    // if savegame contained a global time and not an offset, this will be way off.
+    if ((play.ignore_user_input_until_time - AGS_Clock::now()) > std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms)) {
+        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
+    }
     update_polled_stuff_if_runtime();
 
     pl_run_plugin_hooks(AGSE_POSTRESTOREGAME, 0);

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -23,6 +23,7 @@
 #include "main/main_allegro.h"
 #include "platform/base/agsplatformdriver.h"
 #include "util/math.h"
+#include "ac/timer.h"
 
 #if defined(ANDROID_VERSION)
 
@@ -1865,17 +1866,13 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
-    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_render(flipTypeLastTime, false);
 
-    do
-    {
+    do {
       if (_pollingCallback)
         _pollingCallback();
-      platform->YieldCPU();
-    }
-    while (timerValue == *_loopTimer);
+    } while (waitingForNextTick());
 
   }
 

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -47,6 +47,9 @@ extern "C" DDRAW_SURFACE *gfx_directx_primary_surface;
 extern int dxmedia_play_video (const char*, bool, int, int);
 #endif // WINDOWS_VERSION
 
+#include "ac/timer.h"
+
+
 namespace AGS
 {
 namespace Engine
@@ -631,7 +634,6 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
 
    for (a = 0; a < 256; a+=speed)
    {
-       int timerValue = *_loopTimer;
        bmp_buff->Fill(clearColor);
        set_trans_blender(0,0,0,a);
        bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -641,9 +643,8 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
        {
          if (_pollingCallback)
            _pollingCallback();
-         platform->Delay(1);
        }
-       while (timerValue == *_loopTimer);
+       while (waitingForNextTick());
    }
    delete bmp_buff;
 
@@ -670,7 +671,6 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
 			
             for (a = 255-speed; a > 0; a-=speed)
             {
-                int timerValue = *_loopTimer;
                 bmp_buff->Fill(clearColor);
                 set_trans_blender(0,0,0,a);
                 bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -680,9 +680,8 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
                 {
                   if (_pollingCallback)
                     _pollingCallback();
-                  platform->Delay(1);
                 }
-                while (timerValue == *_loopTimer);
+                while (waitingForNextTick());
             }
             delete bmp_buff;
         }

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -27,8 +27,7 @@ namespace Engine
 {
 
 GraphicsDriverBase::GraphicsDriverBase()
-    : _loopTimer(NULL)
-    , _pollingCallback(NULL)
+    : _pollingCallback(NULL)
     , _drawScreenCallback(NULL)
     , _nullSpriteCallback(NULL)
     , _initGfxCallback(NULL)
@@ -90,7 +89,6 @@ void GraphicsDriverBase::ClearDrawLists()
 
 void GraphicsDriverBase::OnInit(volatile int *loopTimer)
 {
-    _loopTimer = loopTimer;
 }
 
 void GraphicsDriverBase::OnUnInit()

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -131,7 +131,6 @@ protected:
     Rect                _filterRect;    // filter scaling destination rect (before final scaling)
     PlaneScaling        _scaling;       // native -> render dest coordinate transformation
     Point               _globalViewOff; // extra offset to every sprite draw on screen with DrawSprite
-    volatile int *      _loopTimer;
 
     // Callbacks
     GFXDRV_CLIENTCALLBACK _pollingCallback;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -32,13 +32,14 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "media/audio/audio_system.h"
+#include "platform/base/agsplatformdriver.h"
+#include "ac/timer.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 extern char ignore_bounds; // from mousew32
 extern IGraphicsDriver *gfxDriver;
-extern volatile int timerloop; // ac_timer
 extern GameSetup usetup;
 
 //extern void get_save_game_path(int slotNum, char *buffer);
@@ -151,7 +152,6 @@ int CSCIWaitMessage(CSCIMessage * cscim)
     prepare_gui_screen(win_x, win_y, win_width, win_height, true);
 
     while (1) {
-        timerloop = 0;
         update_audio_system_on_game_loop();
         refresh_gui_screen();
 
@@ -193,7 +193,9 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         if (cscim->code > 0)
             break;
 
-        while (timerloop == 0) ;
+        while (waitingForNextTick()) {
+            update_polled_stuff_if_runtime();
+        }
     }
 
     return 0;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -22,10 +22,10 @@
 #include "gui/guidialoginternaldefs.h"
 #include "main/game_run.h"
 #include "gfx/bitmap.h"
+#include "platform/base/agsplatformdriver.h"
+#include "ac/timer.h"
 
 using AGS::Common::Bitmap;
-
-extern volatile int timerloop;
 
 extern int windowbackgroundcolor, pushbuttondarkcolor;
 extern int pushbuttonlightcolor;
@@ -75,7 +75,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 {
     int wasstat;
     while (mbutrelease(LEFT) == 0) {
-        timerloop = 0;
+
         wasstat = state;
         state = mouseisinarea(mousex, mousey);
         // stop mp3 skipping if button held down
@@ -90,7 +90,9 @@ int MyPushButton::pressedon(int mousex, int mousey)
 
         refresh_gui_screen();
 
-        while (timerloop == 0) ;
+        while (waitingForNextTick()) {
+            update_polled_stuff_if_runtime();
+        }
     }
     wasstat = state;
     state = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -524,12 +524,6 @@ void engine_init_keyboard()
 #endif
 }
 
-void engine_init_timer()
-{
-    Debug::Printf(kDbgMsg_Init, "Install timer");
-    install_timer();
-}
-
 typedef char AlIDStr[5];
 
 void AlIDToChars(int al_id, AlIDStr &id_str)
@@ -1060,7 +1054,7 @@ void engine_init_game_settings()
     play.text_speed=15;
     play.text_min_display_time_ms = 1000;
     play.ignore_user_input_after_text_timeout_ms = 500;
-    play.ignore_user_input_until_time = 0;
+    play.ignore_user_input_until_time = AGS_Clock::now();
     play.lipsync_speed = 15;
     play.close_mouth_speech_time = 10;
     play.disable_antialiasing = 0;
@@ -1221,8 +1215,11 @@ void engine_setup_scsystem_auxiliary()
 
 void engine_update_mp3_thread()
 {
-  update_mp3_thread();
-  platform->Delay(50);
+    update_mp3_thread();
+    // reduce polling period to encourage more multithreading bugs.
+#ifndef _DEBUG
+    platform->Delay(50);
+#endif
 }
 
 void engine_start_multithreaded_audio()
@@ -1416,7 +1413,8 @@ int initialize_engine(int argc,char*argv[])
 
     our_eip = -183;
 
-    engine_init_timer();
+    // Original timer was initialised here.
+    skipMissedTicks();
 
     our_eip = -182;
 
@@ -1439,8 +1437,6 @@ int initialize_engine(int argc,char*argv[])
 
     //engine_pre_init_gfx();
 
-    LOCK_VARIABLE(timerloop);
-    LOCK_FUNCTION(dj_timer_handler);
     set_game_speed(40);
 
     our_eip=-20;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -53,6 +53,8 @@
 #include "script/script.h"
 #include "ac/spritecache.h"
 #include "media/audio/audio_system.h"
+#include "platform/base/agsplatformdriver.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -82,19 +84,20 @@ extern RoomStatus*croom;
 extern CharacterExtras *charextra;
 extern SpriteCache spriteset;
 extern unsigned int loopcounter,lastcounter;
-extern volatile int timerloop;
 extern int cur_mode,cur_cursor;
 
 // Checks if user interface should remain disabled for now
 int ShouldStayInWaitMode();
 
 int numEventsAtStartOfFunction;
-auto t1 = std::chrono::steady_clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
+auto t1 = AGS_Clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
 
 long user_disabled_for=0,user_disabled_data=0,user_disabled_data2=0;
 int user_disabled_data3=0;
 
 int restrict_until=0;
+
+unsigned int loopcounter=0,lastcounter=0;
 
 void ProperExit()
 {
@@ -615,12 +618,6 @@ void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBitmap, in
 
         offsetxWas = camera.Left;
         offsetyWas = camera.Top;
-
-#ifdef MAC_VERSION
-        // take a breather after the heavy work
-        // cuts down on CPU usage and reduces the fan noise
-        rest(2);
-#endif
     }
 }
 
@@ -674,42 +671,40 @@ void game_loop_update_loop_counter()
 
 void game_loop_update_fps()
 {
-    auto t2 = std::chrono::steady_clock::now();
+    auto t2 = AGS_Clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
     auto frames = loopcounter - lastcounter;
 
     if (duration >= std::chrono::milliseconds(1000) && frames > 0) {
-        fps = frames * 1000 / duration.count();
+        fps = 1000.0f * frames / duration.count();
         t1 = t2;
         lastcounter = loopcounter;
     }
 }
 
-int get_current_fps() {
+float get_current_fps() {
     // if wanted frames_per_second is >= 1000, that means we have maxed out framerate so return the frame rate we're seeing instead
     auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == 2);
-
-    auto result = frames_per_second;
-    if (maxed_framerate && fps > 0) {
-        result = fps;
+    // fps must be greater that 0 or some timings will take forever.
+    if (maxed_framerate && fps > 0.0f) {
+        return fps;
     }
-    return result;
+    return frames_per_second;
 }
 
 void set_loop_counter(unsigned int new_counter) {
     loopcounter = new_counter;
-    t1 = std::chrono::steady_clock::now();
+    t1 = AGS_Clock::now();
     lastcounter = loopcounter;
-    fps = 0;
+    fps = NAN;
 }
 
 void PollUntilNextFrame()
 {
-    // make sure we poll, cos a low framerate (eg 5 fps) could stutter
-    // mp3 music
-    while (timerloop == 0 && play.fast_forward == 0) {
+    if (play.fast_forward) { return; }
+    while (waitingForNextTick()) {
+        // make sure we poll, cos a low framerate (eg 5 fps) could stutter mp3 music
         update_polled_stuff_if_runtime();
-        platform->YieldCPU();
     }
 }
 
@@ -727,7 +722,6 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     ccNotifyScriptStillAlive ();
     our_eip=1;
-    timerloop=0;
 
     game_loop_check_problems_at_start();
 
@@ -932,7 +926,7 @@ void GameLoopUntilEvent(int untilwhat,long daaa) {
   int cached_user_disabled_for = user_disabled_for;
 
   SetupLoopParameters(untilwhat,daaa,0);
-  while (GameTick()==0) ;
+  while (GameTick()==0);
 
   restrict_until = cached_restrict_until;
   user_disabled_data = cached_user_disabled_data;
@@ -942,6 +936,9 @@ void GameLoopUntilEvent(int untilwhat,long daaa) {
 extern unsigned int load_new_game;
 void RunGameUntilAborted()
 {
+    // skip ticks to account for time spent starting game.
+    skipMissedTicks();
+
     while (!abort_engine) {
         GameTick();
 

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -34,6 +34,7 @@
 #include "main/game_start.h"
 #include "script/script.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -42,7 +43,6 @@ extern int our_eip, displayed_room;
 extern volatile char want_exit, abort_engine;
 extern GameSetupStruct game;
 extern GameState play;
-extern volatile int timerloop;
 extern const char *loadSaveGameOnStartup;
 extern std::vector<ccInstance *> moduleInst;
 extern int numScriptModules;
@@ -56,8 +56,8 @@ void start_game_init_editor_debugging()
         SetMultitasking(1);
         if (init_editor_debugging())
         {
-            timerloop = 0;
-            while (timerloop < 20)
+            auto waitUntil = AGS_Clock::now() + std::chrono::milliseconds(500);
+            while (waitUntil > AGS_Clock::now())
             {
                 // pick up any breakpoints in game_start
                 check_for_messages_from_editor();
@@ -89,6 +89,9 @@ void start_game() {
     newmusic(0);
 
     our_eip = -42;
+
+    // skip ticks to account for initialisation or a restored game.
+    skipMissedTicks();
 
     for (int kk = 0; kk < numScriptModules; kk++)
         RunTextScript(moduleInst[kk], "game_start");

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -42,7 +42,6 @@ using namespace AGS::Engine;
 extern int proper_exit;
 extern AGSPlatformDriver *platform;
 extern IGraphicsDriver *gfxDriver;
-extern volatile int timerloop;
 
 
 IGfxDriverFactory *GfxFactory = NULL;
@@ -572,7 +571,7 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
     if (dm.RefreshRate >= 50)
         request_refresh_rate(dm.RefreshRate);
 
-    if (!gfxDriver->SetDisplayMode(dm, &timerloop))
+    if (!gfxDriver->SetDisplayMode(dm, nullptr))
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init gfx mode. Error: %s", get_allegro_error());
         return false;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -16,6 +16,7 @@
 // Game update procedure
 //
 
+#include <cmath>
 #include "ac/common.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
@@ -36,6 +37,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
 #include "media/audio/audio_system.h"
+#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -55,7 +57,6 @@ extern int face_talking,facetalkview,facetalkwait,facetalkframe;
 extern int facetalkloop, facetalkrepeat, facetalkAllowBlink;
 extern int facetalkBlinkLoop;
 extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement_y;
-extern volatile unsigned long globalTimerCounter;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
@@ -267,7 +268,7 @@ void update_speech_and_messages()
     {
         if (!play.speech_in_post_state)
         {
-            play.messagetime = play.speech_display_post_time_ms * get_current_fps() / 1000;
+            play.messagetime = std::lround(play.speech_display_post_time_ms * get_current_fps() / 1000.0f);
         }
         play.speech_in_post_state = !play.speech_in_post_state;
     }
@@ -281,7 +282,7 @@ void update_speech_and_messages()
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
         remove_screen_overlay(OVER_TEXTMSG);
-        play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms * get_current_fps() / 1000);
+        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
       }
     }
   }

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -22,6 +22,7 @@
 #include "util/mutex.h"
 #include "util/mutex_lock.h"
 #include "util/thread.h"
+#include "ac/timer.h"
 
 struct SOUNDCLIP;
 
@@ -97,8 +98,9 @@ extern volatile int psp_audio_multithreaded;
 void update_polled_mp3();
 void update_mp3_thread();
 
-extern volatile int mvolcounter;
-extern int update_music_at;
+extern void cancel_scheduled_music_update();
+extern void schedule_music_update_at(AGS_Clock::time_point);
+extern void postpone_scheduled_music_update_by(std::chrono::milliseconds);
 
 // crossFading is >0 (channel number of new track), or -1 (old
 // track fading out, no new track)

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -214,7 +214,7 @@ void play_flc_file(int numb,int playflags) {
     delete hicol_buf;
     hicol_buf=NULL;
     //  SetVirtualScreen(screen); wputblock(0,0,backbuffer,0);
-    while (ags_mgetbutton()!=NONE) ;
+    while (ags_mgetbutton()!=NONE) { } // clear any queued mouse events.
     invalidate_screen();
 }
 

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -16,6 +16,7 @@
 //
 //=============================================================================
 
+#include <thread>
 #include "util/wgt2allg.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/common.h"
@@ -86,7 +87,7 @@ void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
 }
 
 void AGSPlatformDriver::YieldCPU() {
-    this->Delay(1);
+    std::this_thread::yield();
 }
 
 void AGSPlatformDriver::InitialiseAbufAtStartup()

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -18,6 +18,7 @@
 
 // ********* LINUX PLACEHOLDER DRIVER *********
 
+#include <thread>
 #include <stdio.h>
 #include <allegro.h>
 #include <xalleg.h>
@@ -30,6 +31,8 @@
 
 #include <pwd.h>
 #include <sys/stat.h>
+#include "ac/timer.h"
+#include "media/audio/audio_system.h"
 
 using AGS::Common::String;
 
@@ -141,10 +144,23 @@ const char *AGSLinux::GetAppOutputDirectory()
 }
 
 void AGSLinux::Delay(int millis) {
-  struct timespec ts;
-  ts.tv_sec = 0;
-  ts.tv_nsec = millis * 1000000;
-  nanosleep(&ts, NULL);
+  auto delayUntil = AGS_Clock::now() + std::chrono::milliseconds(millis);
+
+  for (;;) {
+    if (AGS_Clock::now() < delayUntil) { break; }
+    
+    auto duration = delayUntil - AGS_Clock::now();
+    if (duration > std::chrono::milliseconds(25)) {
+      duration = std::chrono::milliseconds(25);
+    }
+    std::this_thread::sleep_for(duration);
+
+    if (AGS_Clock::now() < delayUntil) { break; }
+
+    // don't allow it to check for debug messages, since this Delay()
+    // call might be from within a debugger polling loop
+    update_polled_mp3();
+  }
 }
 
 unsigned long AGSLinux::GetDiskFreeSpaceMB() {

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1781,18 +1781,13 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
-    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_renderAndPresent(flipTypeLastTime, false);
 
-    do
-    {
+    do {
       if (_pollingCallback)
         _pollingCallback();
-      platform->YieldCPU();
-    }
-    while (timerValue == *_loopTimer);
-
+    } while (waitingForNextTick());
   }
 
   if (fadingOut)

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -31,6 +31,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
 #include "main/game_run.h"
+#include "platform/base/agsplatformdriver.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -380,7 +381,9 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
 
   while ((g_bAppactive) && (!want_exit)) {
 
-    while (currentlyPaused) ;
+    while (currentlyPaused) {
+      platform->YieldCPU();
+    }
 
     RenderToSurface(vscreen);
     //Sleep(0);

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -64,7 +64,6 @@ inline LPWSTR WINAPI AtlA2WHelper(LPWSTR lpw, LPCSTR lpa, int nChars)
 extern int ags_mgetbutton();
 extern void update_audio_system_on_game_loop();
 extern volatile char want_exit;
-extern volatile int timerloop;
 extern char lastError[300];
 CVMR9Graph *graph = NULL;
 
@@ -105,13 +104,10 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
     return -1;
   }
 
+
   OAFilterState filterState = State_Running;
   while ((filterState != State_Stopped) && (!want_exit))
   {
-    while (timerloop == 0)
-      platform->Delay(1);
-    timerloop = 0;
-
     if (!useAVISound)
       update_audio_system_on_game_loop();
 
@@ -128,6 +124,10 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
       break;
 
     //device->Present(NULL, NULL, 0, NULL);
+
+		while (waitingForNextTick()) {
+      update_polled_stuff_if_runtime();
+		}
 	}
 
   graph->StopGraph();


### PR DESCRIPTION
- removes timer thread
- use waitingForTicks and skipMissedTicks for managing loop delays
- absolute time for scheduled music update
- absolute time for ignore_user_input (and correct save/restore behaviour)
- common implementation for platform delay