### PR TITLE
speech: ensure stopping speech always adjust music volume.

### DIFF
--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -264,9 +264,6 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
         ((walking == 0) || ((flags & CHF_MOVENOTWALK) != 0)) &&
         (room == displayed_room)) 
     {
-      // we need to know if there is/was voice-over
-      const bool is_voice = channel_has_clip(SCHAN_SPEECH);
-
       doing_nothing = 0;
       // idle anim doesn't count as doing something
       if (idleleft < 0)
@@ -321,9 +318,11 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
         else
           frame++;
 
+        // we need to know if there is no speech playing
+        const bool channel_is_speaking = channel_is_playing(SCHAN_SPEECH);
         if ((aa == char_speaking) &&
              (play.speech_in_post_state ||
-             (!is_voice) &&
+             (!channel_is_speaking) &&
              (play.close_mouth_speech_time > 0) &&
              (play.messagetime < play.close_mouth_speech_time))) {
           // finished talking - stop animation

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -532,18 +532,23 @@ int play_speech(int charid,int sndid) {
 void stop_speech() {
     // NOTE: here we should know only if there *was* any voice-over playing
     // TODO: refactor speech and replace with a state variable to check instead
+    
     if (channel_has_clip(SCHAN_SPEECH)) {
+        stop_and_destroy_channel (SCHAN_SPEECH);
+    }
+
+    if (play.music_master_volume != play.music_vol_was) {
         play.music_master_volume = play.music_vol_was;
         // update the music in a bit (fixes two speeches follow each other
         // and music going up-then-down)
         schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
-        stop_and_destroy_channel (SCHAN_SPEECH);
-        curLipLine = -1;
+    }
 
-        if (play.no_textbg_when_voice == 2) {
-            // set back to Sierra w/bgrnd
-            play.no_textbg_when_voice = 1;
-            game.options[OPT_SPEECHTYPE] = 2;
-        }
+    curLipLine = -1;
+
+    if (play.no_textbg_when_voice == 2) {
+        // set back to Sierra w/bgrnd
+        play.no_textbg_when_voice = 1;
+        game.options[OPT_SPEECHTYPE] = 2;
     }
 }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -290,9 +290,6 @@ void update_speech_and_messages()
 
 void update_sierra_speech()
 {
-  // we need to know if there is/was voice-over
-  const bool is_voice = channel_has_clip(SCHAN_SPEECH);
-
 	// update sierra-style speech
   if ((face_talking >= 0) && (play.fast_forward == 0)) 
   {
@@ -326,6 +323,9 @@ void update_sierra_speech()
       }
 
     }
+
+    // we need to know if there is/was voice-over
+    const bool is_voice = channel_has_clip(SCHAN_SPEECH);
 
     if (curLipLine >= 0) {
       // check voice lip sync


### PR DESCRIPTION
- multithreading audio deletes channels when done, we miss speech events.
- check against 'music_was' to see if we need to update it, not if speech playing.
- move 'is_voice' variables closer to where they're used.