### PR TITLE
audio: simplify clip->destroy behaviour (for post-channel lock branch)

### DIFF
--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -43,11 +43,10 @@ int AudioChannel_GetIsPlaying(ScriptAudioChannel *channel)
 
 int AudioChannel_GetPanning(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         return ch->panningAsPercentage;
     }
@@ -59,11 +58,10 @@ void AudioChannel_SetPanning(ScriptAudioChannel *channel, int newPanning)
     if ((newPanning < -100) || (newPanning > 100))
         quitprintf("!AudioChannel.Panning: panning value must be between -100 and 100 (passed=%d)", newPanning);
 
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         ch->set_panning(((newPanning + 100) * 255) / 200);
         ch->panningAsPercentage = newPanning;
@@ -72,11 +70,10 @@ void AudioChannel_SetPanning(ScriptAudioChannel *channel, int newPanning)
 
 ScriptAudioClip* AudioChannel_GetPlayingClip(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         return (ScriptAudioClip*)ch->sourceClip;
     }
@@ -85,11 +82,10 @@ ScriptAudioClip* AudioChannel_GetPlayingClip(ScriptAudioChannel *channel)
 
 int AudioChannel_GetPosition(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         if (play.fast_forward)
             return 999999999;
@@ -101,11 +97,10 @@ int AudioChannel_GetPosition(ScriptAudioChannel *channel)
 
 int AudioChannel_GetPositionMs(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         if (play.fast_forward)
             return 999999999;
@@ -117,11 +112,10 @@ int AudioChannel_GetPositionMs(ScriptAudioChannel *channel)
 
 int AudioChannel_GetLengthMs(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         return ch->get_length_ms();
     }
@@ -130,11 +124,10 @@ int AudioChannel_GetLengthMs(ScriptAudioChannel *channel)
 
 int AudioChannel_GetVolume(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         return ch->get_volume();
     }
@@ -146,11 +139,10 @@ int AudioChannel_SetVolume(ScriptAudioChannel *channel, int newVolume)
     if ((newVolume < 0) || (newVolume > 100))
         quitprintf("!AudioChannel.Volume: new value out of range (supplied: %d, range: 0..100)", newVolume);
 
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         ch->set_volume_percent(newVolume);
     }
@@ -159,11 +151,10 @@ int AudioChannel_SetVolume(ScriptAudioChannel *channel, int newVolume)
 
 int AudioChannel_GetSpeed(ScriptAudioChannel *channel)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         return ch->get_speed();
     }
@@ -172,11 +163,10 @@ int AudioChannel_GetSpeed(ScriptAudioChannel *channel)
 
 void AudioChannel_SetSpeed(ScriptAudioChannel *channel, int new_speed)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != NULL) &&
-        (ch->done == 0))
+    if (ch)
     {
         ch->set_speed(new_speed);
     }
@@ -192,11 +182,10 @@ void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
     if (newPosition < 0)
         quitprintf("!AudioChannel.Seek: invalid seek position %d", newPosition);
 
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         ch->seek(newPosition);
     }
@@ -204,11 +193,10 @@ void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
 
 void AudioChannel_SetRoomLocation(ScriptAudioChannel *channel, int xPos, int yPos)
 {
-    AudioChannelsLock _lock;
-    auto* ch = _lock.GetChannel(channel->id);
+    AudioChannelsLock lock;
+    auto* ch = lock.GetChannelIfPlaying(channel->id);
 
-    if ((ch != nullptr) &&
-        (ch->done == 0))
+    if (ch)
     {
         int maxDist = ((xPos > thisroom.Width / 2) ? xPos : (thisroom.Width - xPos)) - AMBIENCE_FULL_DIST;
         ch->xSource = (xPos > 0) ? xPos : -1;

--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -43,9 +43,13 @@ int AudioChannel_GetIsPlaying(ScriptAudioChannel *channel)
 
 int AudioChannel_GetPanning(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->panningAsPercentage;
+        return ch->panningAsPercentage;
     }
     return 0;
 }
@@ -55,60 +59,84 @@ void AudioChannel_SetPanning(ScriptAudioChannel *channel, int newPanning)
     if ((newPanning < -100) || (newPanning > 100))
         quitprintf("!AudioChannel.Panning: panning value must be between -100 and 100 (passed=%d)", newPanning);
 
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_panning(((newPanning + 100) * 255) / 200);
-        channels[channel->id]->panningAsPercentage = newPanning;
+        ch->set_panning(((newPanning + 100) * 255) / 200);
+        ch->panningAsPercentage = newPanning;
     }
 }
 
 ScriptAudioClip* AudioChannel_GetPlayingClip(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return (ScriptAudioClip*)channels[channel->id]->sourceClip;
+        return (ScriptAudioClip*)ch->sourceClip;
     }
     return NULL;
 }
 
 int AudioChannel_GetPosition(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         if (play.fast_forward)
             return 999999999;
 
-        return channels[channel->id]->get_pos();
+        return ch->get_pos();
     }
     return 0;
 }
 
 int AudioChannel_GetPositionMs(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         if (play.fast_forward)
             return 999999999;
 
-        return channels[channel->id]->get_pos_ms();
+        return ch->get_pos_ms();
     }
     return 0;
 }
 
 int AudioChannel_GetLengthMs(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_length_ms();
+        return ch->get_length_ms();
     }
     return 0;
 }
 
 int AudioChannel_GetVolume(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_volume();
+        return ch->get_volume();
     }
     return 0;
 }
@@ -118,33 +146,45 @@ int AudioChannel_SetVolume(ScriptAudioChannel *channel, int newVolume)
     if ((newVolume < 0) || (newVolume > 100))
         quitprintf("!AudioChannel.Volume: new value out of range (supplied: %d, range: 0..100)", newVolume);
 
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_volume_percent(newVolume);
+        ch->set_volume_percent(newVolume);
     }
     return 0;
 }
 
 int AudioChannel_GetSpeed(ScriptAudioChannel *channel)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        return channels[channel->id]->get_speed();
+        return ch->get_speed();
     }
     return 0;
 }
 
 void AudioChannel_SetSpeed(ScriptAudioChannel *channel, int new_speed)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != NULL) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->set_speed(new_speed);
+        ch->set_speed(new_speed);
     }
 }
 
 void AudioChannel_Stop(ScriptAudioChannel *channel)
 {
-    stop_or_fade_out_channel(channel->id, -1, NULL);
+    stop_or_fade_out_channel(channel->id, -1, nullptr);
 }
 
 void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
@@ -152,27 +192,35 @@ void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)
     if (newPosition < 0)
         quitprintf("!AudioChannel.Seek: invalid seek position %d", newPosition);
 
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
-        channels[channel->id]->seek(newPosition);
+        ch->seek(newPosition);
     }
 }
 
 void AudioChannel_SetRoomLocation(ScriptAudioChannel *channel, int xPos, int yPos)
 {
-    if (channel_is_playing(channel->id))
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(channel->id);
+
+    if ((ch != nullptr) &&
+        (ch->done == 0))
     {
         int maxDist = ((xPos > thisroom.Width / 2) ? xPos : (thisroom.Width - xPos)) - AMBIENCE_FULL_DIST;
-        channels[channel->id]->xSource = (xPos > 0) ? xPos : -1;
-        channels[channel->id]->ySource = yPos;
-        channels[channel->id]->maximumPossibleDistanceAway = maxDist;
+        ch->xSource = (xPos > 0) ? xPos : -1;
+        ch->ySource = yPos;
+        ch->maximumPossibleDistanceAway = maxDist;
         if (xPos > 0)
         {
             update_directional_sound_vol();
         }
         else
         {
-            channels[channel->id]->apply_directional_modifier(0);
+            ch->apply_directional_modifier(0);
         }
     }
 }

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -40,9 +40,11 @@ int AudioClip_GetIsAvailable(ScriptAudioClip *clip)
 
 void AudioClip_Stop(ScriptAudioClip *clip)
 {
+    AudioChannelsLock _lock;
     for (int i = 0; i < MAX_SOUND_CHANNELS; i++)
     {
-        if (channel_is_playing(i) && (channels[i]->sourceClip == clip))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (!ch->done) && (ch->sourceClip == clip))
         {
             AudioChannel_Stop(&scrAudioChannel[i]);
         }

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -40,11 +40,11 @@ int AudioClip_GetIsAvailable(ScriptAudioClip *clip)
 
 void AudioClip_Stop(ScriptAudioClip *clip)
 {
-    AudioChannelsLock _lock;
+    AudioChannelsLock lock;
     for (int i = 0; i < MAX_SOUND_CHANNELS; i++)
     {
-        auto* ch = _lock.GetChannel(i);
-        if ((ch != nullptr) && (!ch->done) && (ch->sourceClip == clip))
+        auto* ch = lock.GetChannelIfPlaying(i);
+        if ((ch != nullptr) && (ch->sourceClip == clip))
         {
             AudioChannel_Stop(&scrAudioChannel[i]);
         }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -269,18 +269,19 @@ void Game_SetAudioTypeVolume(int audioType, int volume, int changeType)
         quitprintf("!Game.SetAudioTypeVolume: volume %d is not between 0..100", volume);
     if ((audioType < 0) || (audioType >= game.audioClipTypeCount))
         quitprintf("!Game.SetAudioTypeVolume: invalid audio type: %d", audioType);
-    int aa;
 
     Debug::Printf("Game.SetAudioTypeVolume: type: %d, volume: %d, change: %d", audioType, volume, changeType);
     if ((changeType == VOL_CHANGEEXISTING) ||
         (changeType == VOL_BOTH))
     {
-        for (aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
+        AudioChannelsLock _lock;
+        for (int aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
         {
             ScriptAudioClip *clip = AudioChannel_GetPlayingClip(&scrAudioChannel[aa]);
             if ((clip != NULL) && (clip->type == audioType))
             {
-                channels[aa]->set_volume_percent(volume);
+                auto* ch = _lock.GetChannel(aa);
+                ch->set_volume_percent(volume);
             }
         }
     }
@@ -297,8 +298,10 @@ void Game_SetAudioTypeVolume(int audioType, int volume, int changeType)
 }
 
 int Game_GetMODPattern() {
-    if (current_music_type == MUS_MOD && channel_is_playing(SCHAN_MUSIC)) {
-        return channels[SCHAN_MUSIC]->get_pos();
+    AudioChannelsLock _lock;
+    auto* music_ch = _lock.GetChannel(SCHAN_MUSIC);
+    if (current_music_type == MUS_MOD && music_ch) {
+        return music_ch->get_pos();
     }
     return -1;
 }
@@ -1316,14 +1319,12 @@ void restore_game_thisroom(Stream *in, RestoredData &r_data)
 
 void restore_game_ambientsounds(Stream *in, RestoredData &r_data)
 {
-    int bb;
-
     for (int i = 0; i < MAX_SOUND_CHANNELS; ++i)
     {
         ambient[i].ReadFromFile(in);
     }
 
-    for (bb = 1; bb < MAX_SOUND_CHANNELS; bb++) {
+    for (int bb = 1; bb < MAX_SOUND_CHANNELS; bb++) {
         if (ambient[bb].channel == 0)
             r_data.DoAmbient[bb] = 0;
         else {
@@ -1752,14 +1753,19 @@ void stop_fast_forwarding() {
     if (play.end_cutscene_music >= 0)
         newmusic(play.end_cutscene_music);
 
+    {
+    AudioChannelsLock _lock;
+
     // Restore actual volume of sounds
     for (int aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
     {
-        if (channel_is_playing(aa))
+        auto* ch = _lock.GetChannel(aa);
+        if ((ch != nullptr) && (!ch->done))
         {
-            channels[aa]->set_mute(false);
+            ch->set_mute(false);
         }
     }
+    } // -- AudioChannelsLock
 
     update_music_volume();
 }
@@ -1868,12 +1874,16 @@ void display_switch_out_suspend()
     if (set_display_switch_mode(SWITCH_BACKGROUND) == -1)
         set_display_switch_mode(SWITCH_BACKAMNESIA);
 
+    {
     // stop the sound stuttering
+    AudioChannelsLock _lock;
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) {
-        if (channel_is_playing(i)) {
-            channels[i]->pause();
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0)) {
+            ch->pause();
         }
     }
+    } // -- AudioChannelsLock
 
     platform->Delay(1000);
 
@@ -1904,11 +1914,15 @@ void display_switch_in_resume()
 {
     display_switch_in();
 
+    {
+    AudioChannelsLock _lock;
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) {
-        if (channel_is_playing(i)) {
-            channels[i]->resume();
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0)) {
+            ch->resume();
         }
     }
+    } // -- AudioChannelsLock
 
     // clear the screen if necessary
     if (gfxDriver && gfxDriver->UsesMemoryBackBuffer())

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1757,7 +1757,7 @@ void stop_fast_forwarding() {
     AudioChannelsLock lock;
 
     // Restore actual volume of sounds
-    for (int aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
+    for (int aa = 0; aa <= MAX_SOUND_CHANNELS; aa++)
     {
         auto* ch = lock.GetChannelIfPlaying(aa);
         if (ch)

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -58,8 +58,11 @@ void PlayAmbientSound (int channel, int sndnum, int vol, int x, int y) {
     if (aclip && !is_audiotype_allowed_to_play((AudioFileType)aclip->fileType))
         return;
 
+    AudioChannelsLock _lock;
+
     // only play the sound if it's not already playing
-    if ((ambient[channel].channel < 1) || !channel_is_playing(ambient[channel].channel) ||
+    if ((ambient[channel].channel < 1) || (_lock.GetChannel(ambient[channel].channel) == nullptr) ||
+        (_lock.GetChannel(ambient[channel].channel)->done == 1) ||
         (ambient[channel].num != sndnum)) {
 
             StopAmbientSound(channel);
@@ -75,8 +78,8 @@ void PlayAmbientSound (int channel, int sndnum, int vol, int x, int y) {
 
             debug_script_log("Playing ambient sound %d on channel %d", sndnum, channel);
             ambient[channel].channel = channel;
-            channels[channel] = asound;
-            channels[channel]->priority = 15;  // ambient sound higher priority than normal sfx
+            asound->priority = 15;  // ambient sound higher priority than normal sfx
+            _lock.SetChannel(channel, asound);
     }
     // calculate the maximum distance away the player can be, using X
     // only (since X centred is still more-or-less total Y)
@@ -105,9 +108,12 @@ int IsSoundPlaying() {
     if (play.fast_forward)
         return 0;
 
+    AudioChannelsLock _lock;
+
     // find if there's a sound playing
     for (int i = SCHAN_NORMAL; i < MAX_SOUND_CHANNELS; i++) {
-        if (channel_is_playing(i))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0))
             return 1;
     }
 
@@ -126,6 +132,8 @@ int PlaySoundEx(int val1, int channel) {
 
     if ((channel < SCHAN_NORMAL) || (channel >= MAX_SOUND_CHANNELS))
         quit("!PlaySoundEx: invalid channel specified, must be 3-7");
+
+    AudioChannelsLock _lock;
 
     // if an ambient sound is playing on this channel, abort it
     StopAmbientSound(channel);
@@ -149,9 +157,9 @@ int PlaySoundEx(int val1, int channel) {
         return -1;
     }
 
-    channels[channel] = soundfx;
-    channels[channel]->priority = 10;
-    channels[channel]->set_volume (play.sound_volume);
+    soundfx->priority = 10;
+    soundfx->set_volume (play.sound_volume);
+    _lock.SetChannel(channel,soundfx);
     return channel;
 }
 
@@ -193,17 +201,19 @@ int IsMusicPlaying() {
     if ((play.fast_forward) && (play.skip_until_char_stops < 0))
         return 0;
 
+    AudioChannelsLock _lock;
+
     // This only returns positive if there was a music started by old audio API
     if (current_music_type == 0)
         return 0;
 
-    if (!channel_has_clip(SCHAN_MUSIC))
+    if (_lock.GetChannel(SCHAN_MUSIC) == nullptr)
     { // This was probably a hacky fix in case it was not reset by game update; TODO: find out if needed
         current_music_type = 0;
         return 0;
     }
 
-    bool result = channel_is_playing(SCHAN_MUSIC) || (crossFading > 0 && channel_is_playing(crossFading));
+    bool result = (_lock.GetChannel(SCHAN_MUSIC)->done == 0) || (crossFading > 0 && (_lock.GetChannel(crossFading) != nullptr));
     return result ? 1 : 0;
 }
 
@@ -256,18 +266,22 @@ void scr_StopMusic() {
 }
 
 void SeekMODPattern(int patnum) {
-    if (current_music_type == MUS_MOD && channel_is_playing(SCHAN_MUSIC)) {
-        channels[SCHAN_MUSIC]->seek (patnum);
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(SCHAN_MUSIC);
+    if (current_music_type == MUS_MOD && ch) {
+        ch->seek (patnum);
         debug_script_log("Seek MOD/XM to pattern %d", patnum);
     }
 }
 void SeekMP3PosMillis (int posn) {
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(crossFading);
     if (current_music_type) {
         debug_script_log("Seek MP3/OGG to %d ms", posn);
-        if (crossFading > 0 && channel_is_playing(crossFading))
-            channels[crossFading]->seek (posn);
-        else if (channel_is_playing(SCHAN_MUSIC))
-            channels[SCHAN_MUSIC]->seek (posn);
+        if (crossFading && ch)
+            ch->seek (posn);
+        else if (_lock.GetChannel(SCHAN_MUSIC))
+            _lock.GetChannel(SCHAN_MUSIC)->seek (posn);
     }
 }
 
@@ -276,12 +290,15 @@ int GetMP3PosMillis () {
     if (play.fast_forward)
         return 999999;
 
-    if (current_music_type && channel_is_playing(SCHAN_MUSIC)) {
-        int result = channels[SCHAN_MUSIC]->get_pos_ms();
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(SCHAN_MUSIC);
+
+    if (current_music_type && ch) {
+        int result = ch->get_pos_ms();
         if (result >= 0)
             return result;
 
-        return channels[SCHAN_MUSIC]->get_pos ();
+        return ch->get_pos ();
     }
 
     return 0;
@@ -318,13 +335,16 @@ void SetChannelVolume(int chan, int newvol) {
     if ((chan < 0) || (chan >= MAX_SOUND_CHANNELS))
         quit("!SetChannelVolume: invalid channel id");
 
-    if (channel_is_playing(chan)) {
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(chan);
+
+    if ((ch != nullptr) && (ch->done == 0)) {
         if (chan == ambient[chan].channel) {
             ambient[chan].vol = newvol;
             update_ambient_sound_vol();
         }
         else
-            channels[chan]->set_volume (newvol);
+            ch->set_volume (newvol);
     }
 }
 
@@ -354,24 +374,34 @@ void PlayMP3File (const char *filename) {
     int useChan = prepare_for_new_music ();
     bool doLoop = (play.music_repeat > 0);
 
-    if ((channels[useChan] = my_load_static_ogg(asset_name, 150, doLoop)) != NULL) {
-        channels[useChan]->play();
+    AudioChannelsLock _lock;
+    SOUNDCLIP *clip = my_load_static_ogg(asset_name, 150, doLoop);
+    if (clip != nullptr) {
+        clip->play();
+        _lock.SetChannel(useChan, clip);
         current_music_type = MUS_OGG;
         play.cur_music_number = 1000;
         // save the filename (if it's not what we were supplied with)
         if (filename != &play.playmp3file_name[0])
             strcpy (play.playmp3file_name, filename);
     }
-    else if ((channels[useChan] = my_load_static_mp3(asset_name, 150, doLoop)) != NULL) {
-        channels[useChan]->play();
-        current_music_type = MUS_MP3;
-        play.cur_music_number = 1000;
-        // save the filename (if it's not what we were supplied with)
-        if (filename != &play.playmp3file_name[0])
-            strcpy (play.playmp3file_name, filename);
-    }
     else
-        debug_script_warn ("PlayMP3File: file '%s' not found or cannot play", filename);
+    {
+        clip = my_load_static_mp3(asset_name, 150, doLoop);
+        if (clip != nullptr) {
+            clip->play();
+            _lock.SetChannel(useChan, clip);
+            current_music_type = MUS_MP3;
+            play.cur_music_number = 1000;
+            // save the filename (if it's not what we were supplied with)
+            if (filename != &play.playmp3file_name[0])
+                strcpy(play.playmp3file_name, filename);
+        }
+        else {
+            _lock.SetChannel(useChan, nullptr);
+            debug_script_warn ("PlayMP3File: file '%s' not found or cannot play", filename);
+        }
+    }
 
     post_new_music_check(useChan);
 
@@ -386,21 +416,29 @@ void PlaySilentMIDI (int mnum) {
     play.silent_midi = mnum;
     play.silent_midi_channel = SCHAN_SPEECH;
     stop_and_destroy_channel(play.silent_midi_channel);
-    channels[play.silent_midi_channel] = load_sound_clip_from_old_style_number(true, mnum, false);
-    if (channels[play.silent_midi_channel] == NULL)
+
+    AudioChannelsLock _lock;
+
+    _lock.SetChannel(play.silent_midi_channel,load_sound_clip_from_old_style_number(true, mnum, false));
+    
+    auto* ch = _lock.GetChannel(play.silent_midi_channel);
+    if (ch == nullptr)
     {
         quitprintf("!PlaySilentMIDI: failed to load aMusic%d", mnum);
     }
-    channels[play.silent_midi_channel]->play();
-    channels[play.silent_midi_channel]->set_volume_percent(0);
+    ch->play();
+    ch->set_volume_percent(0);
 }
 
 void SetSpeechVolume(int newvol) {
     if ((newvol<0) | (newvol>255))
         quit("!SetSpeechVolume: invalid volume - must be from 0-255");
 
-    if (channel_is_playing(SCHAN_SPEECH))
-        channels[SCHAN_SPEECH]->set_volume (newvol);
+    AudioChannelsLock _lock;
+    auto* ch = _lock.GetChannel(SCHAN_SPEECH);
+
+    if (ch)
+        ch->set_volume (newvol);
 
     play.speech_volume = newvol;
 }
@@ -504,7 +542,10 @@ int play_speech(int charid,int sndid) {
         return 0;
     }
 
-    channels[SCHAN_SPEECH] = speechmp3;
+    AudioChannelsLock _lock;
+
+    _lock.SetChannel(SCHAN_SPEECH,speechmp3);
+
     play.music_vol_was = play.music_master_volume;
 
     // Negative value means set exactly; positive means drop that amount
@@ -529,10 +570,12 @@ int play_speech(int charid,int sndid) {
     return 1;
 }
 
-void stop_speech() {
+void stop_speech()
+{
     // NOTE: here we should know only if there *was* any voice-over playing
     // TODO: refactor speech and replace with a state variable to check instead
-    if (channel_has_clip(SCHAN_SPEECH)) {
+    if (channel_has_clip(SCHAN_SPEECH))
+    {
         play.music_master_volume = play.music_vol_was;
         // update the music in a bit (fixes two speeches follow each other
         // and music going up-then-down)

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -199,9 +199,11 @@ void System_SetVolume(int newvol)
     // if it was previously set low; so restore them
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) 
     {
-        if (channel_is_playing(i)) 
+        AudioChannelsLock _lock;
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0)) 
         {
-            channels[i]->adjust_volume();
+            ch->adjust_volume();
         }
     }
 }

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -197,14 +197,12 @@ void System_SetVolume(int newvol)
 
     // allegro's set_volume can lose the volumes of all the channels
     // if it was previously set low; so restore them
+    AudioChannelsLock lock;
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++) 
     {
-        AudioChannelsLock _lock;
-        auto* ch = _lock.GetChannel(i);
-        if ((ch != nullptr) && (ch->done == 0)) 
-        {
+        auto* ch = lock.GetChannelIfPlaying(i);
+        if (ch)
             ch->adjust_volume();
-        }
     }
 }
 

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -146,9 +146,10 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
     }
     if (sound_volume != SCR_NO_VALUE && channel != NULL)
     {
-        AudioChannelsLock _lock;
-        auto* ch = _lock.GetChannel(channel->id);
-        ch->set_volume_percent(ch->get_volume() * sound_volume / 100);
+        AudioChannelsLock lock;
+        auto* ch = lock.GetChannel(channel->id);
+        if (ch)
+            ch->set_volume_percent(ch->get_volume() * sound_volume / 100);
     }
     
 }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -145,7 +145,11 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
         }
     }
     if (sound_volume != SCR_NO_VALUE && channel != NULL)
-        channels[channel->id]->set_volume_percent(channels[channel->id]->get_volume() * sound_volume / 100);
+    {
+        AudioChannelsLock _lock;
+        auto* ch = _lock.GetChannel(channel->id);
+        ch->set_volume_percent(ch->get_volume() * sound_volume / 100);
+    }
     
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -555,6 +555,9 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     const int cf_out_chan = play.crossfading_out_channel;
     play.crossfading_in_channel = 0;
     play.crossfading_out_channel = 0;
+    
+    {
+    AudioChannelsLock _lock;
     // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
@@ -568,17 +571,19 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         }
         play_audio_clip_on_channel(i, &game.audioClips[chan_info.ClipID],
             chan_info.Priority, chan_info.Repeat, chan_info.Pos);
-        if (channel_is_playing(i))
+
+        auto* ch = _lock.GetChannel(i);
+        if (ch != NULL)
         {
-            channels[i]->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
-            channels[i]->set_speed(chan_info.Speed);
-            channels[i]->set_panning(chan_info.Pan);
-            channels[i]->panningAsPercentage = chan_info.PanAsPercent;
+            ch->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
+            ch->set_speed(chan_info.Speed);
+            ch->set_panning(chan_info.Pan);
+            ch->panningAsPercentage = chan_info.PanAsPercent;
         }
     }
-    if ((cf_in_chan > 0) && channel_is_playing(cf_in_chan))
+    if ((cf_in_chan > 0) && (_lock.GetChannel(cf_in_chan) != nullptr))
         play.crossfading_in_channel = cf_in_chan;
-    if ((cf_out_chan > 0) && channel_is_playing(cf_out_chan))
+    if ((cf_out_chan > 0) && (_lock.GetChannel(cf_out_chan) != nullptr))
         play.crossfading_out_channel = cf_out_chan;
 
     // If there were synced audio tracks, the time taken to load in the
@@ -586,12 +591,14 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
+        auto* ch = _lock.GetChannel(i);
         int pos = r_data.AudioChans[i].Pos;
-        if ((pos > 0) && channel_is_playing(i))
+        if ((pos > 0) && (ch != nullptr) && (ch->done == 0))
         {
-            channels[i]->seek(pos);
+            ch->seek(pos);
         }
     }
+    } // -- AudioChannelsLock
 
     // TODO: investigate loop range
     for (int i = 1; i < MAX_SOUND_CHANNELS; ++i)
@@ -635,8 +642,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // Test if the old-style audio had playing music and it was properly loaded
     if (current_music_type > 0)
     {
-        if ((crossFading > 0 && !channel_is_playing(crossFading)) ||
-            (crossFading <= 0 && !channel_is_playing(SCHAN_MUSIC)))
+        AudioChannelsLock _lock;
+
+        if (crossFading > 0 && !_lock.GetChannel(crossFading) ||
+            crossFading <= 0 && !_lock.GetChannel(SCHAN_MUSIC))
         {
             current_music_type = 0; // playback failed, reset flag
         }

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -557,7 +557,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     play.crossfading_out_channel = 0;
     
     {
-    AudioChannelsLock _lock;
+    AudioChannelsLock lock;
     // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
@@ -572,7 +572,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         play_audio_clip_on_channel(i, &game.audioClips[chan_info.ClipID],
             chan_info.Priority, chan_info.Repeat, chan_info.Pos);
 
-        auto* ch = _lock.GetChannel(i);
+        auto* ch = lock.GetChannel(i);
         if (ch != NULL)
         {
             ch->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
@@ -581,9 +581,9 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
             ch->panningAsPercentage = chan_info.PanAsPercent;
         }
     }
-    if ((cf_in_chan > 0) && (_lock.GetChannel(cf_in_chan) != nullptr))
+    if ((cf_in_chan > 0) && (lock.GetChannel(cf_in_chan) != nullptr))
         play.crossfading_in_channel = cf_in_chan;
-    if ((cf_out_chan > 0) && (_lock.GetChannel(cf_out_chan) != nullptr))
+    if ((cf_out_chan > 0) && (lock.GetChannel(cf_out_chan) != nullptr))
         play.crossfading_out_channel = cf_out_chan;
 
     // If there were synced audio tracks, the time taken to load in the
@@ -591,9 +591,9 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
     {
-        auto* ch = _lock.GetChannel(i);
+        auto* ch = lock.GetChannelIfPlaying(i);
         int pos = r_data.AudioChans[i].Pos;
-        if ((pos > 0) && (ch != nullptr) && (ch->done == 0))
+        if ((pos > 0) && (ch != nullptr))
         {
             ch->seek(pos);
         }
@@ -642,10 +642,10 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // Test if the old-style audio had playing music and it was properly loaded
     if (current_music_type > 0)
     {
-        AudioChannelsLock _lock;
+        AudioChannelsLock lock;
 
-        if (crossFading > 0 && !_lock.GetChannel(crossFading) ||
-            crossFading <= 0 && !_lock.GetChannel(SCHAN_MUSIC))
+        if (crossFading > 0 && !lock.GetChannelIfPlaying(crossFading) ||
+            crossFading <= 0 && !lock.GetChannelIfPlaying(SCHAN_MUSIC))
         {
             current_music_type = 0; // playback failed, reset flag
         }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -281,7 +281,7 @@ HSaveError WriteAudio(PStream out)
             out->WriteInt32(ch->panning);
             out->WriteInt32(ch->volAsPercentage);
             out->WriteInt32(ch->panningAsPercentage);
-            out->WriteInt32(ch->speed);
+            out->WriteInt32(ch->get_speed());
         }
         else
         {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -255,6 +255,8 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
 
 HSaveError WriteAudio(PStream out)
 {
+    AudioChannelsLock _lock;
+
     // Game content assertion
     out->WriteInt32(game.audioClipTypeCount);
     out->WriteInt32(game.audioClipCount);
@@ -268,17 +270,18 @@ HSaveError WriteAudio(PStream out)
     // Audio clips and crossfade
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++)
     {
-        if (channel_is_playing(i) && (channels[i]->sourceClip != NULL))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch != nullptr) && (ch->done == 0) && (ch->sourceClip != NULL))
         {
-            out->WriteInt32(((ScriptAudioClip*)channels[i]->sourceClip)->id);
-            out->WriteInt32(channels[i]->get_pos());
-            out->WriteInt32(channels[i]->priority);
-            out->WriteInt32(channels[i]->repeat ? 1 : 0);
-            out->WriteInt32(channels[i]->vol);
-            out->WriteInt32(channels[i]->panning);
-            out->WriteInt32(channels[i]->volAsPercentage);
-            out->WriteInt32(channels[i]->panningAsPercentage);
-            out->WriteInt32(channels[i]->speed);
+            out->WriteInt32(((ScriptAudioClip*)ch->sourceClip)->id);
+            out->WriteInt32(ch->get_pos());
+            out->WriteInt32(ch->priority);
+            out->WriteInt32(ch->repeat ? 1 : 0);
+            out->WriteInt32(ch->vol);
+            out->WriteInt32(ch->panning);
+            out->WriteInt32(ch->volAsPercentage);
+            out->WriteInt32(ch->panningAsPercentage);
+            out->WriteInt32(ch->speed);
         }
         else
         {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -255,7 +255,7 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
 
 HSaveError WriteAudio(PStream out)
 {
-    AudioChannelsLock _lock;
+    AudioChannelsLock lock;
 
     // Game content assertion
     out->WriteInt32(game.audioClipTypeCount);
@@ -270,8 +270,8 @@ HSaveError WriteAudio(PStream out)
     // Audio clips and crossfade
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++)
     {
-        auto* ch = _lock.GetChannel(i);
-        if ((ch != nullptr) && (ch->done == 0) && (ch->sourceClip != NULL))
+        auto* ch = lock.GetChannelIfPlaying(i);
+        if ((ch != nullptr) && (ch->sourceClip != NULL))
         {
             out->WriteInt32(((ScriptAudioClip*)ch->sourceClip)->id);
             out->WriteInt32(ch->get_pos());

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -250,10 +250,10 @@ void update_speech_and_messages()
   // we need to know if there is/was voice-over
   bool is_voice, is_voice_playing;
   {
-      AudioChannelsLock _lock;
-      auto *ch = _lock.GetChannel(SCHAN_SPEECH);
+      AudioChannelsLock lock;
+      auto *ch = lock.GetChannel(SCHAN_SPEECH);
       is_voice = ch != nullptr;
-      is_voice_playing = is_voice && !ch->done;
+      is_voice_playing = is_voice && ch->is_playing();
   }
 
   // determine if speech text should be removed
@@ -301,8 +301,8 @@ void update_sierra_speech()
   bool is_voice;
   int voice_pos_ms;
   {
-      AudioChannelsLock _lock;
-      auto *ch = _lock.GetChannel(SCHAN_SPEECH);
+      AudioChannelsLock lock;
+      auto *ch = lock.GetChannel(SCHAN_SPEECH);
       is_voice = ch != nullptr;
       voice_pos_ms = is_voice ? ch->get_pos_ms() : -1;
   }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -248,14 +248,20 @@ void update_overlay_timers()
 void update_speech_and_messages()
 {
   // we need to know if there is/was voice-over
-  const bool is_voice = channel_has_clip(SCHAN_SPEECH);
+  bool is_voice, is_voice_playing;
+  {
+      AudioChannelsLock _lock;
+      auto *ch = _lock.GetChannel(SCHAN_SPEECH);
+      is_voice = ch != nullptr;
+      is_voice_playing = is_voice && !ch->done;
+  }
 
   // determine if speech text should be removed
   if (play.messagetime>=0) {
     play.messagetime--;
     // extend life of text if the voice hasn't finished yet
     if (is_voice && !play.speech_in_post_state) {
-      if (channel_is_playing(SCHAN_SPEECH) && (play.fast_forward == 0)) {
+      if ((is_voice_playing) && (play.fast_forward == 0)) {
         if (play.messagetime <= 1)
           play.messagetime = 1;
       }
@@ -288,12 +294,19 @@ void update_speech_and_messages()
   }
 }
 
+// update sierra-style speech
 void update_sierra_speech()
 {
   // we need to know if there is/was voice-over
-  const bool is_voice = channel_has_clip(SCHAN_SPEECH);
+  bool is_voice;
+  int voice_pos_ms;
+  {
+      AudioChannelsLock _lock;
+      auto *ch = _lock.GetChannel(SCHAN_SPEECH);
+      is_voice = ch != nullptr;
+      voice_pos_ms = is_voice ? ch->get_pos_ms() : -1;
+  }
 
-	// update sierra-style speech
   if ((face_talking >= 0) && (play.fast_forward == 0)) 
   {
     int updatedFrame = 0;
@@ -334,9 +347,8 @@ void update_sierra_speech()
       }
       else 
       {
-        const int spchOffs = is_voice ? channels[SCHAN_SPEECH]->get_pos_ms() : -1;
         while ((curLipLinePhoneme < splipsync[curLipLine].numPhonemes) &&
-          ((curLipLinePhoneme < 0) || (spchOffs >= splipsync[curLipLine].endtimeoffs[curLipLinePhoneme])))
+          ((curLipLinePhoneme < 0) || (voice_pos_ms >= splipsync[curLipLine].endtimeoffs[curLipLinePhoneme])))
         {
           curLipLinePhoneme ++;
           if (curLipLinePhoneme >= splipsync[curLipLine].numPhonemes)

--- a/Engine/media/audio/ambientsound.cpp
+++ b/Engine/media/audio/ambientsound.cpp
@@ -13,7 +13,7 @@
 //=============================================================================
 
 #include "media/audio/ambientsound.h"
-#include "media/audio/audiodefines.h"
+#include "media/audio/audio.h"
 #include "media/audio/soundclip.h"
 #include "util/stream.h"
 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -39,8 +39,30 @@
 #include "main/game_run.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
-AGS::Engine::Mutex _audio_mutex;
+//-----------------------
+//sound channel management; all access goes through here, which can't be done without a lock
+
+static std::array<SOUNDCLIP *,MAX_SOUND_CHANNELS+1> _channels;
+AGS::Engine::Mutex AudioChannelsLock::s_mutex;
+
+SOUNDCLIP* AudioChannelsLock::GetChannel(int index)
+{
+    return _channels[index];
+}
+
+void AudioChannelsLock::SetChannel(int index, SOUNDCLIP* ch)
+{
+    // TODO: store clips in smart pointers
+    if (_channels[index] == ch)
+        Debug::Printf(kDbgMsg_Warn, "WARNING: channel %d - same clip assigned", index);
+    else if (_channels[index] != nullptr && ch != nullptr)
+        Debug::Printf(kDbgMsg_Warn, "WARNING: channel %d - clip overwritten", index);
+    _channels[index] = ch;
+}
+//-----------------------
+
 volatile bool _audio_doing_crossfade;
 
 extern GameSetupStruct game;
@@ -91,15 +113,18 @@ void start_fading_in_new_track_if_applicable(int fadeInChannel, ScriptAudioClip 
     }
 }
 
-void move_track_to_crossfade_channel(int currentChannel, int crossfadeSpeed, int fadeInChannel, ScriptAudioClip *newSound)
+static void move_track_to_crossfade_channel(int currentChannel, int crossfadeSpeed, int fadeInChannel, ScriptAudioClip *newSound)
 {
+    AudioChannelsLock _lock;
+
     stop_and_destroy_channel(SPECIAL_CROSSFADE_CHANNEL);
-    channels[SPECIAL_CROSSFADE_CHANNEL] = channels[currentChannel];
-    channels[currentChannel] = NULL;
+
+    _lock.SetChannel(SPECIAL_CROSSFADE_CHANNEL, _lock.GetChannel(currentChannel));
+    _lock.SetChannel(currentChannel, nullptr);
 
     play.crossfading_out_channel = SPECIAL_CROSSFADE_CHANNEL;
     play.crossfade_step = 0;
-    play.crossfade_initial_volume_out = channels[SPECIAL_CROSSFADE_CHANNEL]->get_volume();
+    play.crossfade_initial_volume_out = _lock.GetChannel(SPECIAL_CROSSFADE_CHANNEL)->get_volume();
     play.crossfade_out_volume_per_step = crossfadeSpeed;
 
     play.crossfading_in_channel = fadeInChannel;
@@ -122,9 +147,10 @@ void stop_or_fade_out_channel(int fadeOutChannel, int fadeInChannel, ScriptAudio
     }
 }
 
-
-int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool interruptEqualPriority)
+static int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool interruptEqualPriority)
 {
+    AudioChannelsLock _lock;
+
     int lowestPrioritySoFar = 9999999;
     int lowestPriorityID = -1;
     int channelToUse = -1;
@@ -147,16 +173,17 @@ int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool interruptE
 
     for (int i = startAtChannel; i < endBeforeChannel; i++)
     {
-        if (!channel_is_playing(i))
+        auto* ch = _lock.GetChannel(i);
+        if ((ch == nullptr) || (ch->done))
         {
             channelToUse = i;
             stop_and_destroy_channel(i);
             break;
         }
-        if ((channels[i]->priority < lowestPrioritySoFar) &&
-            (channels[i]->soundType == clip->type))
+        if ((ch->priority < lowestPrioritySoFar) &&
+            (ch->soundType == clip->type))
         {
-            lowestPrioritySoFar = channels[i]->priority;
+            lowestPrioritySoFar = ch->priority;
             lowestPriorityID = i;
         }
     }
@@ -225,9 +252,11 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
     return soundClip;
 }
 
-void audio_update_polled_stuff()
+static void audio_update_polled_stuff()
 {
     play.crossfade_step++;
+
+    AudioChannelsLock _lock;
 
     if ((play.crossfading_out_channel > 0) && !channel_is_playing(play.crossfading_out_channel)) {
         play.crossfading_out_channel = 0;
@@ -235,7 +264,11 @@ void audio_update_polled_stuff()
 
     if (play.crossfading_out_channel > 0)
     {
-        int newVolume = channels[play.crossfading_out_channel]->get_volume() - play.crossfade_out_volume_per_step;
+        auto* ch =  _lock.GetChannel(play.crossfading_out_channel);
+        if (ch == NULL)
+            quitprintf("Crossfade out channel is %d but channel has gone", play.crossfading_out_channel);
+
+        int newVolume = ch->get_volume() - play.crossfade_out_volume_per_step;
         if (newVolume > 0)
         {
             AudioChannel_SetVolume(&scrAudioChannel[play.crossfading_out_channel], newVolume);
@@ -249,7 +282,8 @@ void audio_update_polled_stuff()
 
     if (play.crossfading_in_channel > 0)
     {
-        int newVolume = channels[play.crossfading_in_channel]->get_volume() + play.crossfade_in_volume_per_step;
+        auto* ch =  _lock.GetChannel(play.crossfading_in_channel);
+        int newVolume = ch->get_volume() + play.crossfade_in_volume_per_step;
         if (newVolume > play.crossfade_final_volume_in)
         {
             newVolume = play.crossfade_final_volume_in;
@@ -287,13 +321,13 @@ void audio_update_polled_stuff()
 }
 
 // Applies a volume drop modifier to the clip, in accordance to its audio type
-void apply_volume_drop_to_clip(SOUNDCLIP *clip)
+static void apply_volume_drop_to_clip(SOUNDCLIP *clip)
 {
     int audiotype = ((ScriptAudioClip*)clip->sourceClip)->type;
     clip->apply_volume_modifier(-(game.audioClipTypes[audiotype].volume_reduction_while_speech_playing * 255 / 100));
 }
 
-void queue_audio_clip_to_play(ScriptAudioClip *clip, int priority, int repeat)
+static void queue_audio_clip_to_play(ScriptAudioClip *clip, int priority, int repeat)
 {
     if (play.new_music_queue_size >= MAX_QUEUED_MUSIC) {
         debug_script_log("Too many queued music, cannot add %s", clip->scriptName);
@@ -357,6 +391,8 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
         return NULL;
     }
 
+    AudioChannelsLock _lock;
+
     // Apply volume drop if any speech voice-over is currently playing
     // NOTE: there is a confusing logic in sound clip classes, that they do not use
     // any modifiers when begin playing, therefore we must apply this only after
@@ -364,7 +400,7 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
     if (!play.fast_forward && channel_has_clip(SCHAN_SPEECH))
         apply_volume_drop_to_clip(soundfx);
 
-    channels[channel] = soundfx;
+    _lock.SetChannel(channel, soundfx);
     return &scrAudioChannel[channel];
 }
 
@@ -431,14 +467,18 @@ ScriptAudioChannel* play_audio_clip_by_index(int audioClipIndex)
         return NULL;
 }
 
-void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings) {
+void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings)
+{
     if ((chid < 0) || (chid > MAX_SOUND_CHANNELS))
         quit("!StopChannel: invalid channel ID");
 
-    if (channels[chid] != NULL) {
-        channels[chid]->destroy();
-        delete channels[chid];
-        channels[chid] = NULL;
+    AudioChannelsLock _lock;
+    SOUNDCLIP* ch = _lock.GetChannel(chid);
+
+    if (ch != NULL) {
+        ch->destroy();
+        delete ch;
+        _lock.SetChannel(chid, NULL);
     }
 
     if (play.crossfading_in_channel == chid)
@@ -458,7 +498,7 @@ void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings) {
     }
 }
 
-void stop_and_destroy_channel (int chid) 
+void stop_and_destroy_channel(int chid)
 {
     stop_and_destroy_channel_ex(chid, true);
 }
@@ -516,7 +556,8 @@ void force_audiostream_include() {
     stop_audio_stream(NULL);
 }
 
-AmbientSound ambient[MAX_SOUND_CHANNELS + 1];  // + 1 just for safety on array iterations
+// TODO: double check that ambient sounds array actually needs +1
+std::array<AmbientSound,MAX_SOUND_CHANNELS+1> ambient;
 
 int get_volume_adjusted_for_distance(int volume, int sndX, int sndY, int sndMaxDist)
 {
@@ -541,22 +582,27 @@ int get_volume_adjusted_for_distance(int volume, int sndX, int sndY, int sndMaxD
 
 void update_directional_sound_vol()
 {
-    for (int chan = 1; chan < MAX_SOUND_CHANNELS; chan++) 
+    AudioChannelsLock _lock;
+
+    for (int chnum = 1; chnum < MAX_SOUND_CHANNELS; chnum++) 
     {
-        if (channel_is_playing(chan) &&
-            (channels[chan]->xSource >= 0)) 
+        auto* ch = _lock.GetChannel(chnum);
+        if ((ch != nullptr) && (ch->done == 0) &&
+            (ch->xSource >= 0)) 
         {
-            channels[chan]->apply_directional_modifier(
-                get_volume_adjusted_for_distance(channels[chan]->vol, 
-                channels[chan]->xSource,
-                channels[chan]->ySource,
-                channels[chan]->maximumPossibleDistanceAway) -
-                channels[chan]->vol);
+            ch->apply_directional_modifier(
+                get_volume_adjusted_for_distance(ch->vol, 
+                    ch->xSource,
+                    ch->ySource,
+                    ch->maximumPossibleDistanceAway) -
+                ch->vol);
         }
     }
 }
 
-void update_ambient_sound_vol () {
+void update_ambient_sound_vol ()
+{
+    AudioChannelsLock _lock;
 
     for (int chan = 1; chan < MAX_SOUND_CHANNELS; chan++) {
 
@@ -567,7 +613,7 @@ void update_ambient_sound_vol () {
 
         int sourceVolume = thisSound->vol;
 
-        if (channel_is_playing(SCHAN_SPEECH)) {
+        if ((_lock.GetChannel(SCHAN_SPEECH) != nullptr) && (_lock.GetChannel(SCHAN_SPEECH)->done == 0)) {
             // Negative value means set exactly; positive means drop that amount
             if (play.speech_music_drop < 0)
                 sourceVolume = -play.speech_music_drop;
@@ -592,8 +638,8 @@ void update_ambient_sound_vol () {
             wantvol = get_volume_adjusted_for_distance(ambientvol, thisSound->x, thisSound->y, thisSound->maxdist);
         }
 
-        if (channel_is_playing(thisSound->channel)) {
-            channels[thisSound->channel]->set_volume(wantvol);
+        if (_lock.GetChannel(thisSound->channel)) {
+            _lock.GetChannel(thisSound->channel)->set_volume(wantvol);
         }
     }
 }
@@ -634,23 +680,28 @@ void shutdown_sound()
 
 // the sound will only be played if there is a free channel or
 // it has a priority >= an existing sound to override
-int play_sound_priority (int val1, int priority) {
+static int play_sound_priority (int val1, int priority) {
     int lowest_pri = 9999, lowest_pri_id = -1;
+
+    AudioChannelsLock _lock;
 
     // find a free channel to play it on
     for (int i = SCHAN_NORMAL; i < MAX_SOUND_CHANNELS; i++) {
+        auto* ch = _lock.GetChannel(i);
         if (val1 < 0) {
             // Playing sound -1 means iterate through and stop all sound
-            if (channel_is_playing(i))
+            if ((ch != nullptr) && (ch->done == 0))
                 stop_and_destroy_channel (i);
         }
-        else if (!channel_is_playing(i)) {
+        else if (ch == nullptr || ch->done != 0) {
             if (PlaySoundEx(val1, i) >= 0)
-                channels[i]->priority = priority;
+            { // channel will hold a different clip here
+                _lock.GetChannel(i)->priority = priority;
+            }
             return i;
         }
-        else if (channels[i]->priority < lowest_pri) {
-            lowest_pri = channels[i]->priority;
+        else if (ch->priority < lowest_pri) {
+            lowest_pri = ch->priority;
             lowest_pri_id = i;
         }
 
@@ -662,7 +713,7 @@ int play_sound_priority (int val1, int priority) {
     // to override one
     if (priority >= lowest_pri) {
         if (PlaySoundEx(val1, lowest_pri_id) >= 0) {
-            channels[lowest_pri_id]->priority = priority;
+            _lock.GetChannel(lowest_pri_id)->priority = priority;
             return lowest_pri_id;
         }
     }
@@ -685,8 +736,6 @@ int current_music_type = 0;
 int crossFading = 0, crossFadeVolumePerStep = 0, crossFadeStep = 0;
 int crossFadeVolumeAtStart = 0;
 SOUNDCLIP *cachedQueuedMusic = NULL;
-
-int musicPollIterator; // long name so it doesn't interfere with anything else
 
 static bool music_update_scheduled = false;
 static auto music_update_at = AGS_Clock::now();
@@ -723,6 +772,8 @@ void clear_music_cache() {
     }
 
 }
+
+static void play_new_music(int mnum, SOUNDCLIP *music);
 
 void play_next_queued() {
     // check if there's a queued one to play
@@ -773,14 +824,17 @@ int calculate_max_volume() {
 // add/remove the volume drop to the audio channels while speech is playing
 void apply_volume_drop_modifier(bool applyModifier)
 {
+    AudioChannelsLock _lock;
+
     for (int i = 0; i < MAX_SOUND_CHANNELS; i++) 
     {
-        if (channel_is_playing(i) && channels[i]->sourceClip != NULL)
+        auto* ch = _lock.GetChannel(i);
+        if (ch && ch->done == 0 && ch->sourceClip != nullptr)
         {
             if (applyModifier)
-                apply_volume_drop_to_clip(channels[i]);
+                apply_volume_drop_to_clip(ch);
             else
-                channels[i]->apply_volume_modifier(0); // reset modifier
+                ch->apply_volume_modifier(0); // reset modifier
         }
     }
 }
@@ -795,15 +849,22 @@ extern volatile char want_exit;
 
 void update_mp3_thread()
 {
-	while (switching_away_from_game) { }
-	AGS::Engine::MutexLock _lock(_audio_mutex);
-	for (musicPollIterator = 0; musicPollIterator <= MAX_SOUND_CHANNELS; ++musicPollIterator)
-	{
-		if (channel_is_playing(musicPollIterator))
-			channels[musicPollIterator]->poll();
-	}
+    while(switching_away_from_game) {}
+
+    AudioChannelsLock _lock;
+
+    for(int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
+    {
+        auto* ch = _lock.GetChannel(i);
+        if(!ch) continue;
+        if(ch->done) continue;
+            ch->poll();
+    }
 }
 
+//this is called at various points to give streaming logic a chance to update
+//it seems those calls have been littered around and points where it ameliorated skipping
+//a better solution would be to forcibly thread the streaming logic
 void update_polled_mp3()
 {
 	if (psp_audio_multithreaded) { return; }
@@ -816,7 +877,7 @@ void update_audio_system_on_game_loop ()
 {
 	update_polled_stuff_if_runtime ();
 
-	AGS::Engine::MutexLock _lock(_audio_mutex);
+    AudioChannelsLock _lock;
 
     process_scheduled_music_update();
 
@@ -839,8 +900,8 @@ void update_audio_system_on_game_loop ()
         else if ((game.options[OPT_CROSSFADEMUSIC] > 0) &&
             (play.music_queue_size > 0) && (!crossFading)) {
                 // want to crossfade, and new tune in the queue
-                int curpos = channels[SCHAN_MUSIC]->get_pos_ms();
-                int muslen = channels[SCHAN_MUSIC]->get_length_ms();
+                int curpos = _lock.GetChannel(SCHAN_MUSIC)->get_pos_ms();
+                int muslen = _lock.GetChannel(SCHAN_MUSIC)->get_length_ms();
                 if ((curpos > 0) && (muslen > 0)) {
                     // we want to crossfade, and we know how far through
                     // the tune we are
@@ -856,8 +917,9 @@ void update_audio_system_on_game_loop ()
 
 }
 
-
-void stopmusic() {
+void stopmusic()
+{
+    AudioChannelsLock _lock;
 
     if (crossFading > 0) {
         // stop in the middle of a new track fading in
@@ -876,15 +938,16 @@ void stopmusic() {
         }
     }
     else if ((game.options[OPT_CROSSFADEMUSIC] > 0)
-        && channel_is_playing(SCHAN_MUSIC)
+        && (_lock.GetChannel(SCHAN_MUSIC) != NULL)
+        && (_lock.GetChannel(SCHAN_MUSIC)->done == 0)
         && (current_music_type != 0)
         && (current_music_type != MUS_MIDI)
         && (current_music_type != MUS_MOD)) {
 
-            crossFading = -1;
-            crossFadeStep = 0;
-            crossFadeVolumePerStep = game.options[OPT_CROSSFADEMUSIC];
-            crossFadeVolumeAtStart = calculate_max_volume();
+        crossFading = -1;
+        crossFadeStep = 0;
+        crossFadeVolumePerStep = game.options[OPT_CROSSFADEMUSIC];
+        crossFadeVolumeAtStart = calculate_max_volume();
     }
     else
         stop_and_destroy_channel (SCHAN_MUSIC);
@@ -893,7 +956,9 @@ void stopmusic() {
     current_music_type = 0;
 }
 
-void update_music_volume() {
+void update_music_volume()
+{
+    AudioChannelsLock _lock;
 
     if ((current_music_type) || (crossFading < 0)) 
     {
@@ -918,53 +983,57 @@ void update_music_volume() {
                 newvol = targetVol;
                 stop_and_destroy_channel_ex(SCHAN_MUSIC, false);
                 if (crossFading > 0) {
-                    channels[SCHAN_MUSIC] = channels[crossFading];
-                    channels[crossFading] = nullptr;
+                    _lock.SetChannel(SCHAN_MUSIC,_lock.GetChannel(crossFading));
+                    _lock.SetChannel(crossFading, nullptr);
                 }
                 crossFading = 0;
             }
             else {
                 if (crossFading > 0)
-                    channels[crossFading]->set_volume((curvol > targetVol) ? targetVol : curvol);
+                    _lock.GetChannel(crossFading)->set_volume((curvol > targetVol) ? targetVol : curvol);
 
                 newvol -= curvol;
                 if (newvol < 0)
                     newvol = 0;
             }
         }
-        if (channel_is_playing(SCHAN_MUSIC))
-            channels[SCHAN_MUSIC]->set_volume (newvol);
+        if (_lock.GetChannel(SCHAN_MUSIC))
+            _lock.GetChannel(SCHAN_MUSIC)->set_volume(newvol);
     }
 }
 
 // Ensures crossfader is stable after loading (or failing to load)
 // new music
-void post_new_music_check (int newchannel) {
-    if ((crossFading > 0) && !channel_is_playing(crossFading)) {
+void post_new_music_check (int newchannel)
+{
+    AudioChannelsLock _lock;
+    if ((crossFading > 0) && (_lock.GetChannel(crossFading) == nullptr)) {
         crossFading = 0;
         // Was fading out but then they played invalid music, continue
         // to fade out
-        if (channel_is_playing(SCHAN_MUSIC))
+        if (_lock.GetChannel(SCHAN_MUSIC) != nullptr)
             crossFading = -1;
     }
 
 }
 
-// Sets up the crossfading for playing the new music track,
-// and returns the channel number to use
-int prepare_for_new_music () {
+int prepare_for_new_music ()
+{
+    AudioChannelsLock _lock;
+
     int useChannel = SCHAN_MUSIC;
 
     if ((game.options[OPT_CROSSFADEMUSIC] > 0)
-        && channel_is_playing(SCHAN_MUSIC)
+        && (_lock.GetChannel(SCHAN_MUSIC) != NULL)
+        && (_lock.GetChannel(SCHAN_MUSIC)->done == 0)
         && (current_music_type != MUS_MIDI)
         && (current_music_type != MUS_MOD)) {
 
             if (crossFading > 0) {
                 // It's still crossfading to the previous track
                 stop_and_destroy_channel_ex(SCHAN_MUSIC, false);
-                channels[SCHAN_MUSIC] = channels[crossFading];
-                channels[crossFading] = NULL;
+                _lock.SetChannel(SCHAN_MUSIC,_lock.GetChannel(crossFading));
+                _lock.SetChannel(crossFading,nullptr);
                 crossFading = 0;
                 update_music_volume();
             }
@@ -990,7 +1059,7 @@ int prepare_for_new_music () {
     }
 
     // Just make sure, because it will be overwritten in a sec
-    if (channels[useChannel] != NULL)
+    if (_lock.GetChannel(useChannel) != nullptr)
         stop_and_destroy_channel (useChannel);
 
     return useChannel;
@@ -1021,8 +1090,8 @@ SOUNDCLIP *load_music_from_disk(int mnum, bool doRepeat) {
     return loaded;
 }
 
-
-void play_new_music(int mnum, SOUNDCLIP *music) {
+static void play_new_music(int mnum, SOUNDCLIP *music)
+{
     if (debug_flags & DBG_NOMUSIC)
         return;
 
@@ -1049,28 +1118,31 @@ void play_new_music(int mnum, SOUNDCLIP *music) {
         return;
     }
 
-    useChannel = prepare_for_new_music ();
+    useChannel = prepare_for_new_music();
 
-    play.cur_music_number=mnum;
+    AudioChannelsLock _lock;
+
+    play.cur_music_number = mnum;
     current_music_type = 0;
-    channels[useChannel] = NULL;
+    _lock.SetChannel(useChannel, nullptr);
 
     play.current_music_repeating = play.music_repeat;
     // now that all the previous music is unloaded, load in the new one
 
-    if (music != NULL) {
-        channels[useChannel] = music;
+    if (music != nullptr) {
+        _lock.SetChannel(useChannel, music);
     }
     else {
-        channels[useChannel] = load_music_from_disk(mnum, (play.music_repeat > 0));
+        _lock.SetChannel(useChannel, load_music_from_disk(mnum, (play.music_repeat > 0)));
     }
 
-    if (channels[useChannel] != NULL) {
+    auto* ch = _lock.GetChannel(useChannel);
+    if (ch != nullptr) {
 
-        if (channels[useChannel]->play() == 0)
-            channels[useChannel] = NULL;
+        if (ch->play() == 0)
+            _lock.SetChannel(useChannel, nullptr);
         else
-            current_music_type = channels[useChannel]->get_sound_type();
+            current_music_type = ch->get_sound_type();
     }
 
     post_new_music_check(useChannel);
@@ -1079,6 +1151,7 @@ void play_new_music(int mnum, SOUNDCLIP *music) {
 
 }
 
-void newmusic(int mnum) {
+void newmusic(int mnum)
+{
     play_new_music(mnum, NULL);
 }

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -887,7 +887,7 @@ extern volatile char want_exit;
 
 void update_mp3_thread()
 {
-    while(switching_away_from_game) {}
+	if (switching_away_from_game) { return; }
 
     AudioChannelsLock lock;
 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -215,7 +215,7 @@ static int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool int
             break;
         }
         if ((ch->priority < lowestPrioritySoFar) &&
-            (ch->soundType == clip->type))
+            (ch->sourceClipType == clip->type))
         {
             lowestPrioritySoFar = ch->priority;
             lowestPriorityID = i;
@@ -280,8 +280,8 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
     if (soundClip != NULL)
     {
         soundClip->set_volume_percent(audioClip->defaultVolume);
-        soundClip->soundType = audioClip->type;
         soundClip->sourceClip = audioClip;
+        soundClip->sourceClipType = audioClip->type;
     }
     return soundClip;
 }
@@ -356,7 +356,7 @@ static void audio_update_polled_stuff()
 // Applies a volume drop modifier to the clip, in accordance to its audio type
 static void apply_volume_drop_to_clip(SOUNDCLIP *clip)
 {
-    int audiotype = ((ScriptAudioClip*)clip->sourceClip)->type;
+    int audiotype = clip->sourceClipType;
     clip->apply_volume_modifier(-(game.audioClipTypes[audiotype].volume_reduction_while_speech_playing * 255 / 100));
 }
 
@@ -420,8 +420,12 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
 
     if (soundfx->play_from(fromOffset) == 0)
     {
+        // not assigned to a channel, so clean up manually.
+        soundfx->destroy();
+        delete soundfx;
+        soundfx = nullptr;
         debug_script_log("AudioClip.Play: failed to play sound file");
-        return NULL;
+        return nullptr;
     }
 
     // Apply volume drop if any speech voice-over is currently playing
@@ -510,6 +514,7 @@ void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings)
         ch->destroy();
         delete ch;
         lock.SetChannel(chid, NULL);
+        ch = nullptr;
     }
 
     if (play.crossfading_in_channel == chid)
@@ -678,10 +683,13 @@ void update_ambient_sound_vol ()
 SOUNDCLIP *load_sound_and_play(ScriptAudioClip *aclip, bool repeat)
 {
     SOUNDCLIP *soundfx = load_sound_clip(aclip, repeat);
+    if (!soundfx) { return nullptr; }
 
-    if (soundfx != NULL) {
-        if (soundfx->play() == 0)
-            soundfx = NULL;
+    if (soundfx->play() == 0) {
+        // not assigned to a channel, so clean up manually.
+        soundfx->destroy();
+        delete soundfx;
+        return nullptr;
     }
 
     return soundfx;
@@ -724,10 +732,12 @@ static int play_sound_priority (int val1, int priority) {
             if (ch)
                 stop_and_destroy_channel (i);
         }
-        else if (!ch) {
+        else if (!ch->is_playing()) {
+            // PlaySoundEx will destroy the previous channel value.
             const int usechan = PlaySoundEx(val1, i);
             if (usechan >= 0)
             { // channel will hold a different clip here
+                assert(usechan == playSoundCh);
                 auto *ch = lock.GetChannel(usechan);
                 if (ch)
                     ch->priority = priority;
@@ -748,6 +758,7 @@ static int play_sound_priority (int val1, int priority) {
     if (priority >= lowest_pri) {
         const int usechan = PlaySoundEx(val1, lowest_pri_id);
         if (usechan >= 0) {
+            assert(usechan == lowest_pri_id);
             auto *ch = lock.GetChannel(usechan);
             if (ch)
                 ch->priority = priority;
@@ -1174,9 +1185,13 @@ static void play_new_music(int mnum, SOUNDCLIP *music)
     AudioChannelsLock lock;
     auto* ch = lock.SetChannel(useChannel, new_clip);
     if (ch != nullptr) {
-        if (ch->play() == 0)
+        if (!ch->play()) {
+            // previous behavior was to set channel[] to null on error, so continue to do that here.
+            ch->destroy();
+            delete ch;
+            ch = nullptr;
             lock.SetChannel(useChannel, nullptr);
-        else
+        } else
             current_music_type = ch->get_sound_type();
     }
 

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -45,9 +45,25 @@ public:
     {
     }
 
-    SOUNDCLIP* GetChannel(int index);
-    void SetChannel(int index, SOUNDCLIP* ch);
+    // Gets a clip from the channel
+    SOUNDCLIP *GetChannel(int index);
+    // Gets a clip from the channel but only if it's in playback state
+    SOUNDCLIP *GetChannelIfPlaying(int index);
+    // Assign new clip to the channel
+    SOUNDCLIP *SetChannel(int index, SOUNDCLIP *clip);
+    // Move clip from one channel to another, clearing the first channel
+    SOUNDCLIP *MoveChannel(int to, int from);
 };
+
+//
+// Channel helpers, autolock and perform a simple action on a channel.
+//
+// Tells if channel has got a clip; does not care about its state
+bool channel_has_clip(int chanid);
+// Tells if channel has got a clip and clip is in playback state
+bool channel_is_playing(int chanid);
+// Sets new clip to the channel
+void set_clip_to_channel(int chanid, SOUNDCLIP *clip);
 
 
 void        calculate_reserved_channel_count();

--- a/Engine/media/audio/clip_mydumbmod.h
+++ b/Engine/media/audio/clip_mydumbmod.h
@@ -28,7 +28,7 @@ struct MYMOD : public SOUNDCLIP
     DUH *tune;
     AL_DUH_PLAYER *duhPlayer;
 
-    int poll();
+    void poll();
 
     void set_volume(int newvol);
 
@@ -45,14 +45,9 @@ struct MYMOD : public SOUNDCLIP
     // TODO: find a way to redesign this behavior
     int get_pos();
 
-    // Returns real MOD/XM playing position
-    int get_real_mod_pos();
-
     int get_pos_ms();
 
     int get_length_ms();
-
-    int get_voice();
 
     virtual void pause();
 
@@ -65,7 +60,10 @@ struct MYMOD : public SOUNDCLIP
     MYMOD();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
+    // Returns real MOD/XM playing position
+    int get_real_mod_pos();
 };
 
 #endif // __AC_MYDUMBMOD_H

--- a/Engine/media/audio/clip_mymidi.h
+++ b/Engine/media/audio/clip_mymidi.h
@@ -23,11 +23,7 @@ struct MYMIDI:public SOUNDCLIP
     MIDI *tune;
     int lengthInSeconds;
 
-    // The PSP takes a while to play a midi, therefore poll() can be called
-    // before the music is ready and immediately returns done.
-    volatile bool initializing;
-
-    int poll();
+    void poll();
 
     void set_volume(int newvol);
 
@@ -41,8 +37,6 @@ struct MYMIDI:public SOUNDCLIP
 
     int get_length_ms();
 
-    int get_voice();
-
     virtual void pause();
 
     virtual void resume();
@@ -54,6 +48,7 @@ struct MYMIDI:public SOUNDCLIP
     MYMIDI();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 };
 

--- a/Engine/media/audio/clip_mymp3.h
+++ b/Engine/media/audio/clip_mymp3.h
@@ -28,21 +28,20 @@ struct MYMP3:public SOUNDCLIP
     char *buffer;
     int chunksize;
 
-    int poll();
+    void poll();
     void set_volume(int newvol);
     void set_speed(int new_speed);
-    void internal_destroy();
     void destroy();
     void seek(int pos);
     int get_pos();
     int get_pos_ms();
     int get_length_ms();
-    int get_voice();
     int get_sound_type();
     int play();
     MYMP3();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 private:
     void adjust_stream();

--- a/Engine/media/audio/clip_myogg.cpp
+++ b/Engine/media/audio/clip_myogg.cpp
@@ -20,7 +20,6 @@
 
 #include "platform/base/agsplatformdriver.h"
 
-
 extern "C" {
     extern int alogg_is_end_of_oggstream(ALOGG_OGGSTREAM *ogg);
     extern int alogg_is_end_of_ogg(ALOGG_OGG *ogg);
@@ -30,8 +29,7 @@ extern "C" {
 
 int MYOGG::poll()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
-
+    // TODO: must be called AudioChannelsLock
     if (!done && _destroyThis)
     {
       internal_destroy();
@@ -120,15 +118,14 @@ void MYOGG::internal_destroy()
 
 void MYOGG::destroy()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    // TODO: must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
 
-	_lock.Release();
-
+    // TODO: warning: scary for this to be done under a lock
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();
 }

--- a/Engine/media/audio/clip_myogg.h
+++ b/Engine/media/audio/clip_myogg.h
@@ -29,12 +29,10 @@ struct MYOGG:public SOUNDCLIP
     int last_but_one;
     int last_ms_offs;
 
-    int poll();
+    void poll();
 
     void set_volume(int newvol);
     void set_speed(int new_speed);
-
-    void internal_destroy();
 
     void destroy();
 
@@ -46,8 +44,6 @@ struct MYOGG:public SOUNDCLIP
 
     int get_length_ms();
 
-    int get_voice();
-
     int get_sound_type();
 
     int play();
@@ -55,6 +51,7 @@ struct MYOGG:public SOUNDCLIP
     MYOGG();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 private:
     void adjust_stream();

--- a/Engine/media/audio/clip_mystaticmp3.cpp
+++ b/Engine/media/audio/clip_mystaticmp3.cpp
@@ -29,49 +29,31 @@ extern int our_eip;
 // of the mp3 functions and unlocked afterwards.
 AGS::Engine::Mutex _mp3_mutex;
 
-int MYSTATICMP3::poll()
+void MYSTATICMP3::poll()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
-
-    if (tune && !done && _destroyThis)
-    {
-      internal_destroy();
-      _destroyThis = false;
-    }
+    if (state_ != SoundClipPlaying) { return; }
 
     int oldeip = our_eip;
     our_eip = 5997;
-    
-    if ((tune == NULL) || (!ready))
-        ;
-    else 
-    {
-      AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-      int result = almp3_poll_mp3(tune);
-	  _lockMp3.Release();
 
-      if (result == ALMP3_POLL_PLAYJUSTFINISHED)
-      {
+    AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+    int result = almp3_poll_mp3(tune);
+
+    if (result == ALMP3_POLL_PLAYJUSTFINISHED)
+    {
         if (!repeat)
         {
-            done = 1;
-            if (psp_audio_multithreaded)
-                internal_destroy();
+            state_ = SoundClipStopped;
         }
-      }
     }
     our_eip = oldeip;
-
-    return done;
 }
 
 void MYSTATICMP3::adjust_stream()
 {
-    if (tune)
-    {
-        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-        almp3_adjust_mp3(tune, get_final_volume(), panning, speed, repeat);
-    }
+    if (!is_playing()) { return; }
+    AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+    almp3_adjust_mp3(tune, get_final_volume(), panning, speed, repeat);
 }
 
 void MYSTATICMP3::adjust_volume()
@@ -91,50 +73,33 @@ void MYSTATICMP3::set_speed(int new_speed)
     adjust_stream();
 }
 
-void MYSTATICMP3::internal_destroy()
-{
-  if (tune != NULL) {
-      AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-      almp3_stop_mp3(tune);
-      almp3_destroy_mp3(tune);
-	  _lockMp3.Release();
-      tune = NULL;
-  }
-  if (mp3buffer != NULL) {
-      sound_cache_free(mp3buffer, false);
-      mp3buffer = NULL;
-  }
-
-  _destroyThis = false;
-  done = 1;
-}
-
 void MYSTATICMP3::destroy()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    if (tune) {
+        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+        almp3_stop_mp3(tune);
+        almp3_destroy_mp3(tune);
+    }
+    tune = nullptr;
 
-    if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
-      _destroyThis = true;
-    else
-      internal_destroy();
+    if (mp3buffer) {
+        sound_cache_free(mp3buffer, false);
+    }
+    mp3buffer = nullptr;
 
-	_lock.Release();
-
-    while (!done)
-      AGSPlatformDriver::GetDriver()->YieldCPU();
-
-    // Allow the last poll cycle to finish.
-	_lock.Acquire(_mutex);
+    state_ = SoundClipStopped;
 }
 
 void MYSTATICMP3::seek(int pos)
 {
+    if (!is_playing()) { return; }
     AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     almp3_seek_abs_msecs_mp3(tune, pos);
 }
 
 int MYSTATICMP3::get_pos()
 {
+    if (!is_playing()) { return -1; }
     AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     return almp3_get_pos_msecs_mp3(tune);
 }
@@ -147,12 +112,14 @@ int MYSTATICMP3::get_pos_ms()
 
 int MYSTATICMP3::get_length_ms()
 {
+    if (tune == nullptr) { return -1; }
     AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     return almp3_get_length_msecs_mp3(tune);
 }
 
 int MYSTATICMP3::get_voice()
 {
+    if (!is_playing()) { return -1; }
 	AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     AUDIOSTREAM *ast = almp3_get_audiostream_mp3(tune);
 	return (ast != NULL ? ast->voice : -1);
@@ -163,20 +130,21 @@ int MYSTATICMP3::get_sound_type() {
 }
 
 int MYSTATICMP3::play() {
-    AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-    int result = almp3_play_ex_mp3(tune, 16384, vol, panning, 1000, repeat);
-	_lockMp3.Release();
+    if (tune == nullptr) { return 0; }
 
-    if (result != ALMP3_OK) {
-        destroy();
-        delete this;
-        return 0;
+    {
+        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+        int result = almp3_play_ex_mp3(tune, 16384, vol, panning, 1000, repeat);
+        if (result != ALMP3_OK) {
+            return 0;
+        }
     }
+
+    state_ = SoundClipPlaying;
 
     if (!psp_audio_multithreaded)
       poll();
 
-    _playing = true;
     return 1;
 }
 

--- a/Engine/media/audio/clip_mystaticmp3.h
+++ b/Engine/media/audio/clip_mystaticmp3.h
@@ -26,12 +26,10 @@ struct MYSTATICMP3:public SOUNDCLIP
     ALMP3_MP3 *tune;
     char *mp3buffer;
 
-    int poll();
+    void poll();
 
     void set_volume(int newvol);
     void set_speed(int new_speed);
-
-    void internal_destroy();
 
     void destroy();
 
@@ -43,8 +41,6 @@ struct MYSTATICMP3:public SOUNDCLIP
 
     int get_length_ms();
 
-    int get_voice();
-
     int get_sound_type();
 
     int play();
@@ -52,6 +48,7 @@ struct MYSTATICMP3:public SOUNDCLIP
     MYSTATICMP3();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 private:
     void adjust_stream();

--- a/Engine/media/audio/clip_mystaticogg.cpp
+++ b/Engine/media/audio/clip_mystaticogg.cpp
@@ -31,7 +31,7 @@ extern int use_extra_sound_offset;  // defined in ac.cpp
 
 int MYSTATICOGG::poll()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    // TODO: must be called AudioChannelsLock
 
     if (tune && !done && _destroyThis)
     {
@@ -96,27 +96,22 @@ void MYSTATICOGG::internal_destroy()
 
 void MYSTATICOGG::destroy()
 {
-	AGS::Engine::MutexLock _lock(_mutex);
+    //must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
 
-	_lock.Release();
-
+    // TODO: warning: scary for this to be done under a lock
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();
-
-    // Allow the last poll cycle to finish.
-	_lock.Acquire(_mutex);
 }
 
 void MYSTATICOGG::seek(int pos)
 {
-	AGS::Engine::MutexLock _lock;
-    if (psp_audio_multithreaded)
-		_lock.Acquire(_mutex);
+    // TODO: must be called AudioChannelsLock
+
     // we stop and restart it because otherwise the buffer finishes
     // playing first and the seek isn't quite accurate
     alogg_stop_ogg(tune);

--- a/Engine/media/audio/clip_mystaticogg.h
+++ b/Engine/media/audio/clip_mystaticogg.h
@@ -30,12 +30,10 @@ struct MYSTATICOGG:public SOUNDCLIP
     int last_but_one;
     int last_ms_offs;
 
-    int poll();
+    void poll();
 
     void set_volume(int newvol);
     void set_speed(int new_speed);
-
-    void internal_destroy();
 
     void destroy();
 
@@ -47,8 +45,6 @@ struct MYSTATICOGG:public SOUNDCLIP
 
     int get_length_ms();
 
-    int get_voice();
-
     int get_sound_type();
 
     virtual int play_from(int position);
@@ -58,6 +54,7 @@ struct MYSTATICOGG:public SOUNDCLIP
     MYSTATICOGG();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 private:
     void adjust_stream();

--- a/Engine/media/audio/clip_mywave.cpp
+++ b/Engine/media/audio/clip_mywave.cpp
@@ -21,10 +21,9 @@
 
 #include "platform/base/agsplatformdriver.h"
 
-
 int MYWAVE::poll()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
+    // TODO: must be called AudioChannelsLock
 
     if (!done && _destroyThis)
     {
@@ -82,15 +81,14 @@ void MYWAVE::internal_destroy()
 
 void MYWAVE::destroy()
 {
-    AGS::Engine::MutexLock _lock(_mutex);
+    // TODO: must be called AudioChannelsLock
 
     if (psp_audio_multithreaded && _playing && !_audio_doing_crossfade)
       _destroyThis = true;
     else
       internal_destroy();
 
-	_lock.Release();
-
+    // TODO: warning: scary for this to be done under a lock
     while (!done)
       AGSPlatformDriver::GetDriver()->YieldCPU();
 }

--- a/Engine/media/audio/clip_mywave.h
+++ b/Engine/media/audio/clip_mywave.h
@@ -22,13 +22,10 @@ struct MYWAVE:public SOUNDCLIP
 {
     SAMPLE *wave;
     int voice;
-    int firstTime;
 
-    int poll();
+    void poll();
 
     void set_volume(int new_speed);
-
-    void internal_destroy();
 
     void destroy();
 
@@ -39,8 +36,6 @@ struct MYWAVE:public SOUNDCLIP
 
     int get_length_ms();
 
-    int get_voice();
-
     int get_sound_type();
 
     int play();
@@ -48,6 +43,7 @@ struct MYWAVE:public SOUNDCLIP
     MYWAVE();
 
 protected:
+    int get_voice();
     virtual void adjust_volume();
 };
 

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -75,7 +75,6 @@ SOUNDCLIP *my_load_wave(const AssetPath &asset_name, int voll, int loop)
     thiswave = new MYWAVE();
     thiswave->wave = new_sample;
     thiswave->vol = voll;
-    thiswave->firstTime = 1;
     thiswave->repeat = (loop != 0);
 
     return thiswave;
@@ -101,7 +100,6 @@ SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, int voll)
     thistune->in = mp3in;
     thistune->chunksize = MP3CHUNKSIZE;
     thistune->filesize = mp3in->todo;
-    thistune->done = 0;
     thistune->vol = voll;
 
     if (thistune->chunksize > mp3in->todo)
@@ -111,9 +109,10 @@ SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, int voll)
 
     thistune->buffer = (char *)tmpbuffer;
 
-    AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-    thistune->stream = almp3_create_mp3stream(tmpbuffer, thistune->chunksize, (mp3in->todo < 1));
-	_lockMp3.Release();
+    {
+        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+        thistune->stream = almp3_create_mp3stream(tmpbuffer, thistune->chunksize, (mp3in->todo < 1));
+    }
 
     if (thistune->stream == NULL) {
         free(tmpbuffer);
@@ -146,11 +145,10 @@ SOUNDCLIP *my_load_static_mp3(const AssetPath &asset_name, int voll, bool loop)
     thismp3->mp3buffer = NULL;
     thismp3->repeat = loop;
 
-    AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
-    thismp3->tune = almp3_create_mp3(mp3buffer, muslen);
-	_lockMp3.Release();
-    thismp3->done = 0;
-    thismp3->ready = true;
+    {
+        AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
+        thismp3->tune = almp3_create_mp3(mp3buffer, muslen);
+    }
 
     if (thismp3->tune == NULL) {
         free(mp3buffer);
@@ -192,12 +190,10 @@ SOUNDCLIP *my_load_static_ogg(const AssetPath &asset_name, int voll, bool loop)
     thissogg = new MYSTATICOGG();
     thissogg->vol = voll;
     thissogg->repeat = loop;
-    thissogg->done = 0;
     thissogg->mp3buffer = mp3buffer;
     thissogg->mp3buffersize = muslen;
 
     thissogg->tune = alogg_create_ogg_from_buffer(mp3buffer, muslen);
-    thissogg->ready = true;
 
     if (thissogg->tune == NULL) {
         thissogg->destroy();
@@ -225,7 +221,6 @@ SOUNDCLIP *my_load_ogg(const AssetPath &asset_name, int voll)
     thisogg->in = mp3in;
     thisogg->vol = voll;
     thisogg->chunksize = MP3CHUNKSIZE;
-    thisogg->done = 0;
     thisogg->last_but_one = 0;
     thisogg->last_ms_offs = 0;
     thisogg->last_but_one_but_one = 0;
@@ -268,10 +263,8 @@ SOUNDCLIP *my_load_midi(const AssetPath &asset_name, int repet)
         return NULL;
 
     thismidi = new MYMIDI();
-    thismidi->done = 0;
     thismidi->tune = midiPtr;
     thismidi->repeat = (repet != 0);
-    thismidi->initializing = true;
 
     return thismidi;
 }
@@ -288,7 +281,6 @@ SOUNDCLIP *my_load_mod(const char *filname, int repet)
         return NULL;
 
     thismod = new MYMOD();
-    thismod->done = 0;
     thismod->tune = modPtr;
     thismod->repeat = (repet != 0);
 
@@ -343,7 +335,6 @@ SOUNDCLIP *my_load_mod(const AssetPath &asset_name, int repet)
         return NULL;
 
     thismod = new MYMOD();
-    thismod->done = 0;
     thismod->tune = modPtr;
     thismod->vol = 255;
     thismod->repeat = (repet != 0);

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -29,6 +29,8 @@ int SOUNDCLIP::play_from(int position)
 }
 
 void SOUNDCLIP::set_panning(int newPanning) {
+    if (!is_playing()) { return; }
+    
     int voice = get_voice();
     if (voice >= 0) {
         voice_set_pan(voice, newPanning);
@@ -37,29 +39,33 @@ void SOUNDCLIP::set_panning(int newPanning) {
 }
 
 void SOUNDCLIP::pause() {
+    if (state_ != SoundClipPlaying) { return; }
+
     int voice = get_voice();
     if (voice >= 0) {
         voice_stop(voice);
-        paused = 1;
+        state_ = SoundClipPaused;
     }
 }
+
 void SOUNDCLIP::resume() {
+    if (state_ != SoundClipPaused) { return; }
+
     int voice = get_voice();
-    if (voice >= 0)
+    if (voice >= 0) {
         voice_start(voice);
-    paused = 0;
+        state_ = SoundClipPlaying;
+    }
 }
 
 SOUNDCLIP::SOUNDCLIP() {
-    ready = false;
-    done = 0;
-    paused = 0;
+    state_ = SoundClipInitial;
     priority = 50;
     panning = 128;
     panningAsPercentage = 0;
     speed = 1000;
-    soundType = -1;
-    sourceClip = NULL;
+    sourceClipType = 0;
+    sourceClip = nullptr;
     vol = 0;
     volAsPercentage = 0;
     volModifier = 0;
@@ -69,8 +75,6 @@ SOUNDCLIP::SOUNDCLIP() {
     ySource = -1;
     maximumPossibleDistanceAway = 0;
     directionalVolModifier = 0;
-    _destroyThis = false;
-    _playing = false;
 }
 
 SOUNDCLIP::~SOUNDCLIP()

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -13,6 +13,7 @@
 //=============================================================================
 
 #include "util/wgt2allg.h"
+#include "media/audio/audio.h"
 #include "media/audio/audiodefines.h"
 #include "media/audio/soundclip.h"
 #include "media/audio/audiointernaldefs.h"
@@ -74,13 +75,4 @@ SOUNDCLIP::SOUNDCLIP() {
 
 SOUNDCLIP::~SOUNDCLIP()
 {
-}
-
-bool channel_has_clip(int chanid) {
-    return channels[chanid] != nullptr;
-}
-
-bool channel_is_playing(int chanid) {
-    auto ch = channels[chanid];
-    return ch != nullptr && ch->done == 0;
 }

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -17,8 +17,6 @@
 #include "media/audio/soundclip.h"
 #include "media/audio/audiointernaldefs.h"
 
-SOUNDCLIP *channels[MAX_SOUND_CHANNELS+1]; // needed for update_mp3_thread
-
 int SOUNDCLIP::play_from(int position) 
 {
     int retVal = play();

--- a/Engine/media/audio/soundclip.h
+++ b/Engine/media/audio/soundclip.h
@@ -80,6 +80,8 @@ struct SOUNDCLIP
     virtual void pause();
     virtual void resume();
 
+    inline bool is_playing() const { return done == 0; }
+
     inline int get_speed() const
     {
         return speed;
@@ -162,10 +164,5 @@ protected:
         return final_vol >= 0 ? final_vol : 0;
     }
 };
-
-// Tells if channel has got a clip; does not care about its state
-extern bool channel_has_clip(int chanid);
-// Tells if channel has got a clip and clip is in playback state
-extern bool channel_is_playing(int chanid);
 
 #endif // __AC_SOUNDCLIP_H

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -613,8 +613,7 @@ void IAGSEngine::PlaySoundChannel (int32 channel, int32 soundType, int32 volume,
     else
         quit("!IAGSEngine::PlaySoundChannel: unknown sound type");
 
-    AudioChannelsLock _lock;
-    _lock.SetChannel(channel,newcha);
+    set_clip_to_channel(channel, newcha);
 }
 // Engine interface 12 and above are below
 void IAGSEngine::MarkRegionDirty(int32 left, int32 top, int32 right, int32 bottom) {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -613,7 +613,8 @@ void IAGSEngine::PlaySoundChannel (int32 channel, int32 soundType, int32 volume,
     else
         quit("!IAGSEngine::PlaySoundChannel: unknown sound type");
 
-    channels[channel] = newcha;
+    AudioChannelsLock _lock;
+    _lock.SetChannel(channel,newcha);
 }
 // Engine interface 12 and above are below
 void IAGSEngine::MarkRegionDirty(int32 left, int32 top, int32 right, int32 bottom) {

--- a/Engine/util/mutex_std.h
+++ b/Engine/util/mutex_std.h
@@ -12,47 +12,35 @@
 //
 //=============================================================================
 
-#ifndef __AGS_EE_UTIL__MUTEX_H
-#define __AGS_EE_UTIL__MUTEX_H
+#ifndef __AGS_EE_UTIL__MUTEX_STD_H
+#define __AGS_EE_UTIL__MUTEX_STD_H
+
+#include <mutex>
 
 namespace AGS
 {
 namespace Engine
 {
 
-
-class BaseMutex
+class StdMutex : public BaseMutex
 {
-public:
-  BaseMutex()
-  {
-  };
+  public:
+    inline StdMutex() : mutex_() {}
+    inline ~StdMutex() {}
 
-  virtual ~BaseMutex()
-  {
-  };
+    StdMutex &operator=(const StdMutex &) = delete;
+    StdMutex(const StdMutex &) = delete;
 
-  BaseMutex &operator=(const BaseMutex &) = delete;
-  BaseMutex(const BaseMutex &) = delete;
+    inline void Lock() { mutex_.lock(); }
+    inline void Unlock() { mutex_.unlock(); }
 
-  virtual void Lock() = 0;
-
-  virtual void Unlock() = 0;
+  private:
+    std::recursive_mutex mutex_;
 };
 
+typedef StdMutex Mutex;
 
 } // namespace Engine
 } // namespace AGS
 
-
-
-#if defined(PSP_VERSION)
-#include "mutex_psp.h"
-#elif defined(WII_VERSION)
-#include "mutex_wii.h"
-#else
-#include "mutex_std.h"
-#endif
-
-
-#endif // __AGS_EE_UTIL__MUTEX_H
+#endif // __AGS_EE_UTIL__MUTEX_STD_H

--- a/Engine/util/thread.h
+++ b/Engine/util/thread.h
@@ -26,13 +26,11 @@ class BaseThread
 public:
   typedef void(* AGSThreadEntry)();
 
-  BaseThread()
-  {
-  };
+  BaseThread() { };
+  virtual ~BaseThread() { };
 
-  virtual ~BaseThread()
-  {
-  };
+  BaseThread &operator=(const BaseThread &) = delete;
+  BaseThread(const BaseThread &) = delete;
 
   virtual bool Create(AGSThreadEntry entryPoint, bool looping) = 0;
   virtual bool Start() = 0;
@@ -40,38 +38,21 @@ public:
 
   inline bool CreateAndStart(AGSThreadEntry entryPoint, bool looping)
   {
-    if (Create(entryPoint, looping))
-    {
-      if (Start())
-      {
-        return true;
-      }
-    }
-
-    return false;
+    if (!Create(entryPoint, looping)) { return false; }
+    return Start();
   }
 };
-
 
 } // namespace Engine
 } // namespace AGS
 
 
-#if defined(WINDOWS_VERSION)
-#include "thread_windows.h"
-
-#elif defined(PSP_VERSION)
+#if defined(PSP_VERSION)
 #include "thread_psp.h"
-
 #elif defined(WII_VERSION)
 #include "thread_wii.h"
-
-#elif defined(LINUX_VERSION) \
-   || defined(MAC_VERSION) \
-   || defined(IOS_VERSION) \
-   || defined(ANDROID_VERSION)
-#include "thread_pthread.h"
-
+#else
+#include "thread_std.h"
 #endif
 
 

--- a/Engine/util/thread_std.h
+++ b/Engine/util/thread_std.h
@@ -1,0 +1,96 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#ifndef __AGS_EE_PLATFORM__THREAD_STD_H
+#define __AGS_EE_PLATFORM__THREAD_STD_H
+
+#include <thread>
+
+namespace AGS
+{
+namespace Engine
+{
+
+class StdThread : public BaseThread
+{
+public:
+  StdThread() : thread_(), entry_(nullptr), looping_(false)
+  {
+  }
+
+  ~StdThread()
+  {
+    Stop();
+  }
+
+  StdThread &operator=(const StdThread &) = delete;
+  StdThread(const StdThread &) = delete;
+
+  virtual bool Create(AGSThreadEntry entryPoint, bool looping)
+  {
+    if (!entryPoint) { return false; }
+
+    entry_ = entryPoint;
+    looping_ = looping;
+    return true;
+  }
+
+  virtual bool Start()
+  {
+    if (thread_.joinable()) { return true; }
+    if (!entry_) { return false; }
+
+    try {
+      thread_ = std::thread(thread_start_, this);
+    } catch (std::system_error) {
+      return false;
+    }
+    return thread_.joinable();
+  }
+
+  bool Stop()
+  {
+    if (!thread_.joinable()) { return true; }
+
+    looping_ = false; // signal thread to stop
+    thread_.join();
+    return true;
+  }
+
+private:
+  std::thread thread_;
+  AGSThreadEntry entry_;
+  bool looping_;
+
+  static void thread_start_(StdThread *self)
+  {
+    auto entry = self->entry_;
+    for (;;)
+    {
+      entry();
+      if (!self->looping_)
+      {
+        break;
+      }
+      std::this_thread::yield();
+    }
+  }
+};
+
+typedef StdThread Thread;
+
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_PLATFORM__THREAD_STD_H

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -675,6 +675,7 @@
     <ClInclude Include="..\..\Engine\media\audio\audio.h" />
     <ClInclude Include="..\..\Engine\media\audio\audiodefines.h" />
     <ClInclude Include="..\..\Engine\media\audio\audiointernaldefs.h" />
+    <ClInclude Include="..\..\Engine\media\audio\audio_system.h" />
     <ClInclude Include="..\..\Engine\media\audio\clip_mydumbmod.h" />
     <ClInclude Include="..\..\Engine\media\audio\clip_myjgmod.h" />
     <ClInclude Include="..\..\Engine\media\audio\clip_mymidi.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1859,6 +1859,9 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptcamera.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\media\audio\audio_system.h">
+      <Filter>Header Files\media\audio</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="..\..\Engine\resource\DefaultGDF.gdf.xml">


### PR DESCRIPTION
This fixes behaviour where channels were deleted after poll. Now they are only deleted when replaced. This hopefully fixes all issues where speech channels need to hang around when complete.

Previously 'poll would destroy if 'done' && 'multithreaded'. 'play' would destroy/delete on error. This lead to some issues where clips were assigned to channel and played, but then not checked if they succeeded, leading to pointers to freed memory.

Destroy/delete of clips is now up to the main thread. Soundclips will not attempt to delete themselves or destroy during poll. Code calling 'play' will clean up clip if it is not assigned to a channel (where it would get destroyed upon replacement).

Warning: this will break audio multithreading until channel locks are in. A lot of this was work arounds for incorrect locking behaviour, and possibly for not having recursive locks.