### PR TITLE
Create config.yml for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 1
 jobs:
   build:
     docker:
-      - image: ericoporto/ags-primary:0.0.1
+      - image: ericoporto/ags-primary:0.1.0
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 1
+jobs:
+  build:
+    docker:
+      - image: ericoporto/ags-primary:0.0.1
+
+    steps:
+      - checkout
+
+      - run: fakeroot debian/rules binary

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:stretch
+
+# Make no effort to shrink this image as it is only for local development and
+# we want to be able to exploit layer caching
+
+RUN apt-get -y update
+RUN apt-get -y --no-install-recommends install ssh tar gzip
+RUN apt-get -y --no-install-recommends install curl ca-certificates
+RUN apt-get -y --no-install-recommends install git
+RUN apt-get -y --no-install-recommends install build-essential pkg-config 
+RUN apt-get -y --no-install-recommends install debhelper fakeroot
+RUN apt-get -y --no-install-recommends install libfreetype6-dev 
+RUN apt-get -y --no-install-recommends install libogg-dev libvorbis-dev
+RUN apt-get -y --no-install-recommends install libaldmb1-dev libtheora-dev 
+
+RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
+RUN tar -C /opt -xf cmake-3.13.4-Linux-x86_64.tar.gz
+ENV PATH="/opt/cmake-3.13.4-Linux-x86_64/bin:${PATH}"
+
+RUN mkdir lib-allegro \
+&& cd lib-allegro/ \
+&& curl -O -L https://github.com/liballeg/allegro5/releases/download/4.4.3.1/allegro-4.4.3.1.tar.gz \
+&& tar -C . -xf allegro-4.4.3.1.tar.gz \
+&& cd allegro-4.4.3.1 \
+&& mkdir build-liballegro \
+&& cd build-liballegro \
+&& cmake -D SHARED=off -D WANT_ALLEGROGL=off -D WANT_LOADPNG=off -D WANT_LOGG=off \
+         -D WANT_JPGALLEG=off -D WANT_EXAMPLES=off -D WANT_TOOLS=off \
+         -D WANT_TESTS=off -D WANT_DOCS=off -DCMAKE_BUILD_TYPE=Debug .. \
+&& make && make install && cd ../../../
+
+CMD /bin/bash


### PR DESCRIPTION
As simple as possible `config.yml` for building AGS Engine, on Debian, using [**circleci**](https://circleci.com/), which uses a [docker image](https://cloud.docker.com/repository/docker/ericoporto/ags-primary). Before accepting, this should be pretty similar to the current lost `.travis.yml` in the repo, but it's a different CI system so people can have options and decide which one to pursue. It also won't magically work without configuring things on Github or clicking Circle-CI in the Github Marketplace.

`Dockerfile` is below

```
FROM debian:stretch

# Make no effort to shrink this image as it is only for local development and
# we want to be able to exploit layer caching

RUN apt-get -y update
RUN apt-get -y --no-install-recommends install ssh tar gzip
RUN apt-get -y --no-install-recommends install curl ca-certificates
RUN apt-get -y --no-install-recommends install git
RUN apt-get -y --no-install-recommends install build-essential pkg-config 
RUN apt-get -y --no-install-recommends install debhelper fakeroot
RUN apt-get -y --no-install-recommends install libfreetype6-dev 
RUN apt-get -y --no-install-recommends install libogg-dev libvorbis-dev
RUN apt-get -y --no-install-recommends install libaldmb1-dev libtheora-dev 

RUN curl -O -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
RUN tar -C /opt -xf cmake-3.13.4-Linux-x86_64.tar.gz
ENV PATH="/opt/cmake-3.13.4-Linux-x86_64/bin:${PATH}"

RUN mkdir lib-allegro \
&& cd lib-allegro/ \
&& git clone https://github.com/adventuregamestudio/lib-allegro.git \
&& cd lib-allegro \
&& git checkout allegro-4.4.2-agspatch \
&& sed -i '/INLINE int/c\static INLINE int' /lib-allegro/lib-allegro/addons/jpgalleg/src/decode.c \
&& mkdir build-liballegro \
&& cd build-liballegro \
&& cmake -D SHARED=off -DCMAKE_BUILD_TYPE=Debug .. \
&& make && make install && cd ../../../

CMD /bin/bash
```