### PR TITLE
Script API: implemented PlayVoiceClip function

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2533,6 +2533,10 @@ builtin managed struct Game {
   /// Accesses the audio clips collection.
   readonly import static attribute AudioClip *AudioClips[];
 #endif
+#ifdef SCRIPT_API_v350
+  /// Play speech voice-over in non-blocking mode, optionally apply music and sound volume reduction
+  import static AudioChannel* PlayVoiceClip(Character*, int cue, bool as_speech = true);
+#endif
 };
 
 builtin struct GameState {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -571,97 +571,6 @@ builtin managed struct Room {
 #endif
 };
 
-builtin managed struct Game {
-  /// Changes the active translation.
-  import static bool   ChangeTranslation(const string newTranslationFileName);
-  /// Returns true the first time this command is called with this token.
-  import static bool   DoOnceOnly(const string token);
-  /// Gets the AGS Colour Number for the specified RGB colour.
-  import static int    GetColorFromRGB(int red, int green, int blue);
-  /// Gets the number of frames in the specified view loop.
-  import static int    GetFrameCountForLoop(int view, int loop);
-  /// Gets the name of whatever is on the screen at (x,y)
-  import static String GetLocationName(int x, int y);
-  /// Gets the number of loops in the specified view.
-  import static int    GetLoopCountForView(int view);
-  /// Returns the current pattern/track number if the current music is MOD or XM.
-  import static int    GetMODPattern();
-  /// Gets whether the "Run next loop after this" setting is checked for the specified loop.
-  import static bool   GetRunNextSettingForLoop(int view, int loop);
-  /// Gets the description of the specified save game slot.
-  import static String GetSaveSlotDescription(int saveSlot);
-  /// Gets the ViewFrame instance for the specified view frame.
-  import static ViewFrame* GetViewFrame(int view, int loop, int frame);
-  /// Prompts the user to type in a string, and returns the text that they type in.
-  import static String InputBox(const string prompt);
-  /// Gets whether any audio (of this type) is currently playing.
-  import static bool   IsAudioPlaying(AudioType audioType=SCR_NO_VALUE);
-  /// Changes the volume drop applied to this audio type when speech is played
-  import static void   SetAudioTypeSpeechVolumeDrop(AudioType, int volumeDrop);
-  /// Changes the default volume of audio clips of the specified type.
-  import static void   SetAudioTypeVolume(AudioType, int volume, ChangeVolumeType);
-  /// Sets the directory where AGS will save and load saved games.
-  import static bool   SetSaveGameDirectory(const string directory);
-  /// Stops all currently playing audio (optionally of the specified type).
-  import static void   StopAudio(AudioType audioType=SCR_NO_VALUE);
-#ifndef STRICT_AUDIO
-  /// Stops all currently playing sound effects.
-  import static void   StopSound(bool includeAmbientSounds=false);   // $AUTOCOMPLETEIGNORE$
-#endif
-  /// Gets the number of characters in the game.
-  readonly import static attribute int CharacterCount;
-  /// Gets the number of dialogs in the game.
-  readonly import static attribute int DialogCount;
-  /// Gets the name of the game EXE file.
-  readonly import static attribute String FileName;
-  /// Gets the number of fonts in the game.
-  readonly import static attribute int FontCount;
-  /// Accesses the legacy Global Messages, from AGS 2.x
-  readonly import static attribute String GlobalMessages[];
-  /// Accesses the global strings collection. This is obsolete.
-  import static attribute String GlobalStrings[];
-  /// Gets the number of GUIs in the game.
-  readonly import static attribute int GUICount;
-  /// Gets/sets the time for which user input is ignored after some text is automatically removed
-  import static attribute int IgnoreUserInputAfterTextTimeoutMs;
-  /// Checks whether the game is currently in the middle of a skippable cutscene.
-  readonly import static attribute bool InSkippableCutscene;
-  /// Gets the number of inventory items in the game.
-  readonly import static attribute int InventoryItemCount;
-  /// Gets/sets the minimum time that a piece of speech text stays on screen (in milliseconds)
-  import static attribute int MinimumTextDisplayTimeMs;
-  /// Gets the number of mouse cursors in the game.
-  readonly import static attribute int MouseCursorCount;
-  /// Gets/sets the game name.
-  import static attribute String Name;
-  /// Gets/sets the normal font used for displaying text.
-  import static attribute FontType NormalFont;
-  /// Checks whether the game is currently skipping over a cutscene.
-  readonly import static attribute bool SkippingCutscene;
-  /// Gets/sets the font used for displaying speech text.
-  import static attribute FontType SpeechFont;
-  /// Gets the height of the specified sprite.
-  readonly import static attribute int SpriteHeight[];
-  /// Gets the width of the specified sprite.
-  readonly import static attribute int SpriteWidth[];
-  /// Gets/sets how fast speech text is removed from the screen.
-  import static attribute int TextReadingSpeed;
-  /// Gets name of the currently active translation.
-  readonly import static attribute String TranslationFilename;
-  /// Gets whether the game is using native co-ordinates.
-  readonly import static attribute bool UseNativeCoordinates;
-  /// Gets the number of views in the game.
-  readonly import static attribute int ViewCount;
-#ifdef SCRIPT_API_v340
-  /// Returns true if the given plugin is currently loaded.
-  import static bool   IsPluginLoaded(const string name);
-  /// Gets the number of audio clips in the game.
-  readonly import static attribute int AudioClipCount;
-  /// Accesses the audio clips collection.
-  readonly import static attribute AudioClip *AudioClips[];
-#endif
-};
-
 builtin managed struct Parser {
   /// Returns the parser dictionary word ID for the specified word
   import static int    FindWordID(const string wordToFind);
@@ -2534,6 +2443,97 @@ builtin managed struct Character {
   char  on;
 #endif
   };
+
+builtin managed struct Game {
+  /// Changes the active translation.
+  import static bool   ChangeTranslation(const string newTranslationFileName);
+  /// Returns true the first time this command is called with this token.
+  import static bool   DoOnceOnly(const string token);
+  /// Gets the AGS Colour Number for the specified RGB colour.
+  import static int    GetColorFromRGB(int red, int green, int blue);
+  /// Gets the number of frames in the specified view loop.
+  import static int    GetFrameCountForLoop(int view, int loop);
+  /// Gets the name of whatever is on the screen at (x,y)
+  import static String GetLocationName(int x, int y);
+  /// Gets the number of loops in the specified view.
+  import static int    GetLoopCountForView(int view);
+  /// Returns the current pattern/track number if the current music is MOD or XM.
+  import static int    GetMODPattern();
+  /// Gets whether the "Run next loop after this" setting is checked for the specified loop.
+  import static bool   GetRunNextSettingForLoop(int view, int loop);
+  /// Gets the description of the specified save game slot.
+  import static String GetSaveSlotDescription(int saveSlot);
+  /// Gets the ViewFrame instance for the specified view frame.
+  import static ViewFrame* GetViewFrame(int view, int loop, int frame);
+  /// Prompts the user to type in a string, and returns the text that they type in.
+  import static String InputBox(const string prompt);
+  /// Gets whether any audio (of this type) is currently playing.
+  import static bool   IsAudioPlaying(AudioType audioType=SCR_NO_VALUE);
+  /// Changes the volume drop applied to this audio type when speech is played
+  import static void   SetAudioTypeSpeechVolumeDrop(AudioType, int volumeDrop);
+  /// Changes the default volume of audio clips of the specified type.
+  import static void   SetAudioTypeVolume(AudioType, int volume, ChangeVolumeType);
+  /// Sets the directory where AGS will save and load saved games.
+  import static bool   SetSaveGameDirectory(const string directory);
+  /// Stops all currently playing audio (optionally of the specified type).
+  import static void   StopAudio(AudioType audioType=SCR_NO_VALUE);
+#ifndef STRICT_AUDIO
+  /// Stops all currently playing sound effects.
+  import static void   StopSound(bool includeAmbientSounds=false);   // $AUTOCOMPLETEIGNORE$
+#endif
+  /// Gets the number of characters in the game.
+  readonly import static attribute int CharacterCount;
+  /// Gets the number of dialogs in the game.
+  readonly import static attribute int DialogCount;
+  /// Gets the name of the game EXE file.
+  readonly import static attribute String FileName;
+  /// Gets the number of fonts in the game.
+  readonly import static attribute int FontCount;
+  /// Accesses the legacy Global Messages, from AGS 2.x
+  readonly import static attribute String GlobalMessages[];
+  /// Accesses the global strings collection. This is obsolete.
+  import static attribute String GlobalStrings[];
+  /// Gets the number of GUIs in the game.
+  readonly import static attribute int GUICount;
+  /// Gets/sets the time for which user input is ignored after some text is automatically removed
+  import static attribute int IgnoreUserInputAfterTextTimeoutMs;
+  /// Checks whether the game is currently in the middle of a skippable cutscene.
+  readonly import static attribute bool InSkippableCutscene;
+  /// Gets the number of inventory items in the game.
+  readonly import static attribute int InventoryItemCount;
+  /// Gets/sets the minimum time that a piece of speech text stays on screen (in milliseconds)
+  import static attribute int MinimumTextDisplayTimeMs;
+  /// Gets the number of mouse cursors in the game.
+  readonly import static attribute int MouseCursorCount;
+  /// Gets/sets the game name.
+  import static attribute String Name;
+  /// Gets/sets the normal font used for displaying text.
+  import static attribute FontType NormalFont;
+  /// Checks whether the game is currently skipping over a cutscene.
+  readonly import static attribute bool SkippingCutscene;
+  /// Gets/sets the font used for displaying speech text.
+  import static attribute FontType SpeechFont;
+  /// Gets the height of the specified sprite.
+  readonly import static attribute int SpriteHeight[];
+  /// Gets the width of the specified sprite.
+  readonly import static attribute int SpriteWidth[];
+  /// Gets/sets how fast speech text is removed from the screen.
+  import static attribute int TextReadingSpeed;
+  /// Gets name of the currently active translation.
+  readonly import static attribute String TranslationFilename;
+  /// Gets whether the game is using native co-ordinates.
+  readonly import static attribute bool UseNativeCoordinates;
+  /// Gets the number of views in the game.
+  readonly import static attribute int ViewCount;
+#ifdef SCRIPT_API_v340
+  /// Returns true if the given plugin is currently loaded.
+  import static bool   IsPluginLoaded(const string name);
+  /// Gets the number of audio clips in the game.
+  readonly import static attribute int AudioClipCount;
+  /// Accesses the audio clips collection.
+  readonly import static attribute AudioClip *AudioClips[];
+#endif
+};
 
 builtin struct GameState {
   int  score;

--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -14,6 +14,7 @@
 
 #include "ac/audiochannel.h"
 #include "ac/gamestate.h"
+#include "ac/global_audio.h"
 #include "ac/dynobj/cc_audioclip.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
@@ -174,7 +175,10 @@ void AudioChannel_SetSpeed(ScriptAudioChannel *channel, int new_speed)
 
 void AudioChannel_Stop(ScriptAudioChannel *channel)
 {
-    stop_or_fade_out_channel(channel->id, -1, nullptr);
+    if (channel->id == SCHAN_SPEECH && play.IsNonBlockingVoiceSpeech())
+        stop_voice_nonblocking();
+    else
+        stop_or_fade_out_channel(channel->id, -1, nullptr);
 }
 
 void AudioChannel_Seek(ScriptAudioChannel *channel, int newPosition)

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2446,6 +2446,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     text_lips_text = texx;
 
     Bitmap *closeupface=nullptr;
+    // TODO: we always call _display_at later which may also start voice-over;
+    // find out if this may be refactored and voice started only in one place.
     if (texx[0]=='&') {
         // auto-speech
         int igr=atoi(&texx[1]);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2448,21 +2448,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     Bitmap *closeupface=nullptr;
     // TODO: we always call _display_at later which may also start voice-over;
     // find out if this may be refactored and voice started only in one place.
-    if (texx[0]=='&') {
-        // auto-speech
-        int igr=atoi(&texx[1]);
-        while ((texx[0]!=' ') & (texx[0]!=0)) texx++;
-        if (texx[0]==' ') texx++;
-        if (igr <= 0)
-            quit("DisplaySpeech: auto-voice symbol '&' not followed by valid integer");
+    try_auto_play_speech(texx, texx, aschar);
 
-        text_lips_text = texx;
-
-        if (play_speech(aschar,igr)) {
-            if (play.want_speech == 2)
-                texx = "  ";  // speech only, no text.
-        }
-    }
     if (game.options[OPT_SPEECHTYPE] == 3)
         remove_screen_overlay(OVER_COMPLETE);
     our_eip=1500;
@@ -2838,7 +2825,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     }
     char_speaking = -1;
     char_thinking = -1;
-    stop_speech();
+    stop_voice_speech();
 }
 
 int get_character_currently_talking() {

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2448,7 +2448,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     Bitmap *closeupface=nullptr;
     // TODO: we always call _display_at later which may also start voice-over;
     // find out if this may be refactored and voice started only in one place.
-    try_auto_play_speech(texx, texx, aschar);
+    try_auto_play_speech(texx, texx, aschar, true);
 
     if (game.options[OPT_SPEECHTYPE] == 3)
         remove_screen_overlay(OVER_COMPLETE);
@@ -2825,7 +2825,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     }
     char_speaking = -1;
     char_thinking = -1;
-    stop_voice_speech();
+    if (play.IsBlockingVoiceSpeech())
+        stop_voice_speech();
 }
 
 int get_character_currently_talking() {

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -264,9 +264,6 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
         ((walking == 0) || ((flags & CHF_MOVENOTWALK) != 0)) &&
         (room == displayed_room)) 
     {
-      // we need to know if there is/was voice-over
-      const bool is_voice = channel_has_clip(SCHAN_SPEECH);
-
       doing_nothing = 0;
       // idle anim doesn't count as doing something
       if (idleleft < 0)
@@ -323,7 +320,7 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
 
         if ((aa == char_speaking) &&
              (play.speech_in_post_state ||
-             ((!is_voice) &&
+             ((!play.speech_has_voice) &&
              (play.close_mouth_speech_time > 0) &&
              (play.messagetime < play.close_mouth_speech_time)))) {
           // finished talking - stop animation

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -267,7 +267,6 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         // 4 = mouse only
         int countdown = GetTextDisplayTime (todis);
         int skip_setting = user_to_internal_skip_speech((SkipSpeechStyle)play.skip_display);
-        auto wasSpeaking = channel_has_clip(SCHAN_SPEECH);
         while (1) {
             /*      if (!play.mouse_cursor_hidden)
             ags_domouse(DOMOUSE_UPDATE);
@@ -294,7 +293,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             PollUntilNextFrame();
             countdown--;
 
-            if (wasSpeaking) {
+            if (play.speech_has_voice) {
                 // extend life of text if the voice hasn't finished yet
                 if (channel_is_playing(SCHAN_SPEECH) && (play.fast_forward == 0)) {
                     if (countdown <= 1)
@@ -344,7 +343,10 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed) {
     int usingfont=FONT_NORMAL;
     if (asspch) usingfont=FONT_SPEECH;
-    int needStopSpeech = 0;
+    // TODO: _display_at may be called from _displayspeech, which can start
+    // and finalize voice speech on its own. Find out if we really need to
+    // keep track of this and not just stop voice regardless.
+    bool need_stop_speech = false;
 
     EndSkippingUntilCharStops();
 
@@ -360,11 +362,11 @@ void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch,
             if (play.want_speech == 2)
                 todis = "  ";
         }
-        needStopSpeech = 1;
+        need_stop_speech = true;
     }
     _display_main(xx,yy,wii,todis,blocking,usingfont,asspch, isThought, allowShrink, overlayPositionFixed);
 
-    if (needStopSpeech)
+    if (need_stop_speech)
         stop_speech();
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -350,7 +350,7 @@ void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch,
 
     EndSkippingUntilCharStops();
 
-    if (try_auto_play_speech(todis, todis, play.narrator_speech))
+    if (try_auto_play_speech(todis, todis, play.narrator_speech, true))
     {// TODO: is there any need for this flag?
         need_stop_speech = true;
     }
@@ -360,7 +360,7 @@ void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch,
         stop_voice_speech();
 }
 
-bool try_auto_play_speech(const char *text, const char *&replace_text, int charid)
+bool try_auto_play_speech(const char *text, const char *&replace_text, int charid, bool blocking)
 {
     const char *src = text;
     if (src[0] != '&')

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -28,7 +28,7 @@ void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch,
 // will assign replacement string, which will be blank string if game is in "voice-only" mode
 // and clip was started, or string cleaned from voice-over tags which is safe to display on screen.
 // Returns whether voice-over clip was started successfully.
-bool try_auto_play_speech(const char *text, const char *&replace_text, int charid);
+bool try_auto_play_speech(const char *text, const char *&replace_text, int charid, bool blocking);
 bool ShouldAntiAliasText();
 // Calculates meaningful length of the displayed text
 int GetTextDisplayLength(const char *text);

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -24,6 +24,11 @@ using AGS::Common::GUIMain;
 
 int  _display_main(int xx,int yy,int wii,const char*todis,int blocking,int usingfont,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
 void _display_at(int xx,int yy,int wii,const char*todis,int blocking,int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
+// Tests the given string for the voice-over tags and plays cue clip for the given character;
+// will assign replacement string, which will be blank string if game is in "voice-only" mode
+// and clip was started, or string cleaned from voice-over tags which is safe to display on screen.
+// Returns whether voice-over clip was started successfully.
+bool try_auto_play_speech(const char *text, const char *&replace_text, int charid);
 bool ShouldAntiAliasText();
 // Calculates meaningful length of the displayed text
 int GetTextDisplayLength(const char *text);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -2324,6 +2324,11 @@ RuntimeScriptValue Sc_Game_IsPluginLoaded(const RuntimeScriptValue *params, int3
     API_SCALL_BOOL_OBJ(pl_is_plugin_loaded, const char);
 }
 
+RuntimeScriptValue Sc_Game_PlayVoiceClip(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ_PINT_PBOOL(ScriptAudioChannel, ccDynamicAudio, PlayVoiceClip, CharacterInfo);
+}
+
 
 void RegisterGameAPI()
 {
@@ -2376,6 +2381,7 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::get_AudioClipCount",                     Sc_Game_GetAudioClipCount);
     ccAddExternalStaticFunction("Game::geti_AudioClips",                        Sc_Game_GetAudioClip);
     ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
+    ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 
@@ -2425,6 +2431,7 @@ void RegisterGameAPI()
     ccAddExternalFunctionForPlugin("Game::get_TranslationFilename",                (void*)Game_GetTranslationFilename);
     ccAddExternalFunctionForPlugin("Game::get_UseNativeCoordinates",               (void*)Game_GetUseNativeCoordinates);
     ccAddExternalFunctionForPlugin("Game::get_ViewCount",                          (void*)Game_GetViewCount);
+    ccAddExternalFunctionForPlugin("Game::PlayVoiceClip",                          (void*)PlayVoiceClip);
 }
 
 void RegisterStaticObjects()

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -466,9 +466,12 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     }
     text_min_display_time_ms = in->ReadInt32();
     ignore_user_input_after_text_timeout_ms = in->ReadInt32();
-    ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(in->ReadInt32());
+    if (svg_ver < kGSSvgVersion_3509)
+        in->ReadInt32(); // ignore_user_input_until_time -- do not apply from savegame
     if (old_save)
         in->ReadArrayOfInt32(default_audio_type_volumes, MAX_AUDIO_TYPES);
+    if (svg_ver >= kGSSvgVersion_3509)
+        speech_has_voice = in->ReadInt32();
 }
 
 void GameState::WriteForSavegame(Common::Stream *out) const
@@ -649,8 +652,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     }
     out->WriteInt32( text_min_display_time_ms);
     out->WriteInt32( ignore_user_input_after_text_timeout_ms);
-    auto ignore_user_input_until_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(ignore_user_input_until_time - AGS_Clock::now());
-    out->WriteInt32( ignore_user_input_until_time_ms.count() );
+    out->WriteInt32( speech_has_voice );
 }
 
 void GameState::ReadQueuedAudioItems_Aligned(Common::Stream *in)

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -44,7 +44,8 @@ enum GameStateSvgVersion
 {
     kGSSvgVersion_OldFormat = -1, // TODO: remove after old save support is dropped
     kGSSvgVersion_Initial   = 0,
-    kGSSvgVersion_350       = 1
+    kGSSvgVersion_350       = 1,
+    kGSSvgVersion_3509      = 2,
 };
 
 // A result of coordinate conversion between screen and the room,
@@ -216,6 +217,10 @@ struct GameState {
     std::vector<AGS::Common::StringIMap> charProps;
     AGS::Common::StringIMap invProps[MAX_INV];
 
+    // Dynamic speech state
+    //
+    // Tells whether there is a voice-over played during current speech
+    bool  speech_has_voice;
     // Tells whether character speech stays on screen not animated for additional time
     bool  speech_in_post_state;
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -221,8 +221,14 @@ struct GameState {
     //
     // Tells whether there is a voice-over played during current speech
     bool  speech_has_voice;
+    // Tells whether the voice was played in blocking mode;
+    // atm blocking speech handles itself, and we only need to finalize
+    // non-blocking voice speech during game update; speech refactor would be
+    // required to get rid of this rule.
+    bool  speech_voice_blocking;
     // Tells whether character speech stays on screen not animated for additional time
     bool  speech_in_post_state;
+
 
     GameState();
     // Free game resources
@@ -287,6 +293,13 @@ struct GameState {
     // usually this depends on how the arguments are created (whether they are in "variadic" or true coords)
     VpPoint ScreenToRoom(int scrx, int scry, bool clip_viewport = true);
     VpPoint ScreenToRoomDivDown(int scrx, int scry, bool clip_viewport = true); // native "variadic" coords variant
+
+    // Tells if there's a blocking voice speech playing right now
+    bool IsBlockingVoiceSpeech() const;
+    // Tells whether we have to finalize voice speech when stopping or reusing the channel
+    bool IsNonBlockingVoiceSpeech() const;
+    // Speech helpers
+    bool ShouldPlayVoiceSpeech() const;
 
     // Serialization
     void ReadQueuedAudioItems_Aligned(Common::Stream *in);

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -1220,12 +1220,6 @@ RuntimeScriptValue Sc_PlaySoundEx(const RuntimeScriptValue *params, int32_t para
     API_SCALL_INT_PINT2(PlaySoundEx);
 }
 
-// void (int who, int which)
-RuntimeScriptValue Sc_scr_play_speech(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_VOID_PINT2(__scr_play_speech);
-}
-
 // void (const char* name, int skip, int flags)
 RuntimeScriptValue Sc_scrPlayVideo(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2480,7 +2474,6 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("PlaySilentMIDI",           Sc_PlaySilentMIDI);
 	ccAddExternalStaticFunction("PlaySound",                Sc_play_sound);
 	ccAddExternalStaticFunction("PlaySoundEx",              Sc_PlaySoundEx);
-	ccAddExternalStaticFunction("PlaySpeech",               Sc_scr_play_speech);
 	ccAddExternalStaticFunction("PlayVideo",                Sc_scrPlayVideo);
 	ccAddExternalStaticFunction("QuitGame",                 Sc_QuitGame);
 	ccAddExternalStaticFunction("Random",                   Sc_Rand);
@@ -2850,7 +2843,6 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("PlaySilentMIDI",           (void*)PlaySilentMIDI);
     ccAddExternalFunctionForPlugin("PlaySound",                (void*)play_sound);
     ccAddExternalFunctionForPlugin("PlaySoundEx",              (void*)PlaySoundEx);
-    ccAddExternalFunctionForPlugin("PlaySpeech",               (void*)__scr_play_speech);
     ccAddExternalFunctionForPlugin("PlayVideo",                (void*)scrPlayVideo);
     ccAddExternalFunctionForPlugin("ProcessClick",             (void*)RoomProcessClick);
     ccAddExternalFunctionForPlugin("QuitGame",                 (void*)QuitGame);

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -458,7 +458,7 @@ void SetSpeechVolume(int newvol) {
 }
 
 void __scr_play_speech(int who, int which) {
-    // *** implement this - needs to call stop_speech as well
+    // *** implement this - needs to call stop_voice_speech as well
     // to reset the volume
     quit("PlaySpeech not yet implemented");
 }
@@ -492,19 +492,12 @@ int IsMusicVoxAvailable () {
     return play.separate_music_lib;
 }
 
-int play_speech(int charid,int sndid) {
-    stop_and_destroy_channel (SCHAN_SPEECH);
-
-    // don't play speech if we're skipping a cutscene
-    if (play.fast_forward)
-        return 0;
-    if ((play.want_speech < 1) || (speech_file.IsEmpty()))
-        return 0;
-
-    SOUNDCLIP *speechmp3;
+// Construct an asset name for the voice-over clip for the given character and cue id
+String get_cue_filename(int charid, int sndid)
+{
     String script_name;
-
-    if (charid >= 0) {
+    if (charid >= 0)
+    {
         // append the first 4 characters of the script name to the filename
         if (game.chars[charid].scrname[0] == 'c')
             script_name.SetString(&game.chars[charid].scrname[1], 4);
@@ -512,28 +505,21 @@ int play_speech(int charid,int sndid) {
             script_name.SetString(game.chars[charid].scrname, 4);
     }
     else
+    {
         script_name = "NARR";
-
-    // append the speech number and create voice file name
-    String voice_file = String::FromFormat("%s%d", script_name.GetCStr(), sndid);
-
-    int ii;  // Compare the base file name to the .pam file name
-    curLipLine = -1;  // See if we have voice lip sync for this line
-    curLipLinePhoneme = -1;
-    for (ii = 0; ii < numLipLines; ii++) {
-        if (stricmp(splipsync[ii].filename, voice_file) == 0) {
-            curLipLine = ii;
-            break;
-        }
     }
-    // if the lip-sync is being used for voice sync, disable
-    // the text-related lipsync
-    if (numLipLines > 0)
-        game.options[OPT_LIPSYNCTEXT] = 0;
+    return String::FromFormat("%s%d", script_name.GetCStr(), sndid);
+}
 
-    String asset_name = voice_file;
+// Play voice-over clip on the common channel;
+// voice_name should be bare clip name without extension
+static bool play_voice_clip_on_channel(const String &voice_name)
+{
+    stop_and_destroy_channel(SCHAN_SPEECH);
+
+    String asset_name = voice_name;
     asset_name.Append(".wav");
-    speechmp3 = my_load_wave(get_voice_over_assetpath(asset_name), play.speech_volume, 0);
+    SOUNDCLIP *speechmp3 = my_load_wave(get_voice_over_assetpath(asset_name), play.speech_volume, 0);
 
     if (speechmp3 == nullptr) {
         asset_name.ReplaceMid(asset_name.GetLength() - 3, 3, "ogg");
@@ -555,26 +541,70 @@ int play_speech(int charid,int sndid) {
     }
 
     if (speechmp3 == nullptr) {
-        debug_script_warn("Speech load failure: '%s'", voice_file.GetCStr());
-        curLipLine = -1;
-        return 0;
+        debug_script_warn("Speech load failure: '%s'", voice_name.GetCStr());
+        return false;
     }
 
     set_clip_to_channel(SCHAN_SPEECH,speechmp3);
-    play.speech_has_voice = true;
-    play.music_vol_was = play.music_master_volume;
+}
 
+// Play voice-over clip and adjust audio volumes;
+// voice_name should be bare clip name without extension
+static bool play_voice_clip_impl(const String &voice_name)
+{
+    if (!play_voice_clip_on_channel(voice_name))
+        return false;
+
+    play.speech_has_voice = true;
+
+    cancel_scheduled_music_update();
+    play.music_vol_was = play.music_master_volume;
     // Negative value means set exactly; positive means drop that amount
     if (play.speech_music_drop < 0)
         play.music_master_volume = -play.speech_music_drop;
     else
         play.music_master_volume -= play.speech_music_drop;
-
-    cancel_scheduled_music_update();
     apply_volume_drop_modifier(true);
     update_music_volume();
-
     update_ambient_sound_vol();
+    return true;
+}
+
+// Stop voice-over clip and schedule audio volume reset
+static void stop_voice_clip_impl()
+{
+    play.music_master_volume = play.music_vol_was;
+    // update the music in a bit (fixes two speeches follow each other
+    // and music going up-then-down)
+    schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
+    stop_and_destroy_channel(SCHAN_SPEECH);
+}
+
+bool play_voice_speech(int charid, int sndid)
+{
+    // don't play speech if we're skipping a cutscene
+    if (play.fast_forward)
+        return false;
+    if ((play.want_speech < 1) || (speech_file.IsEmpty()))
+        return false;
+
+    String voice_file = get_cue_filename(charid, sndid);
+    if (!play_voice_clip_impl(voice_file))
+        return false;
+
+    int ii;  // Compare the base file name to the .pam file name
+    curLipLine = -1;  // See if we have voice lip sync for this line
+    curLipLinePhoneme = -1;
+    for (ii = 0; ii < numLipLines; ii++) {
+        if (stricmp(splipsync[ii].filename, voice_file) == 0) {
+            curLipLine = ii;
+            break;
+        }
+    }
+    // if the lip-sync is being used for voice sync, disable
+    // the text-related lipsync
+    if (numLipLines > 0)
+        game.options[OPT_LIPSYNCTEXT] = 0;
 
     // change Sierra w/bgrnd  to Sierra without background when voice
     // is available (for Tierra)
@@ -582,26 +612,23 @@ int play_speech(int charid,int sndid) {
         game.options[OPT_SPEECHTYPE] = 1;
         play.no_textbg_when_voice = 2;
     }
-
-    return 1;
+    return true;
 }
 
-void stop_speech()
+void stop_voice_speech()
 {
-    if (play.speech_has_voice)
-    {
-        play.music_master_volume = play.music_vol_was;
-        // update the music in a bit (fixes two speeches follow each other
-        // and music going up-then-down)
-        schedule_music_update_at(AGS_Clock::now() + std::chrono::milliseconds(500));
-        stop_and_destroy_channel (SCHAN_SPEECH);
-        curLipLine = -1;
+    if (!play.speech_has_voice)
+        return;
 
-        if (play.no_textbg_when_voice == 2) {
-            // set back to Sierra w/bgrnd
-            play.no_textbg_when_voice = 1;
-            game.options[OPT_SPEECHTYPE] = 2;
-        }
-        play.speech_has_voice = false;
+    stop_voice_clip_impl();
+
+    // Reset lipsync
+    curLipLine = -1;
+    // Set back to Sierra w/bgrnd
+    if (play.no_textbg_when_voice == 2)
+    {
+        play.no_textbg_when_voice = 1;
+        game.options[OPT_SPEECHTYPE] = 2;
     }
+    play.speech_has_voice = false;
 }

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -561,7 +561,7 @@ int play_speech(int charid,int sndid) {
     }
 
     set_clip_to_channel(SCHAN_SPEECH,speechmp3);
-
+    play.speech_has_voice = true;
     play.music_vol_was = play.music_master_volume;
 
     // Negative value means set exactly; positive means drop that amount
@@ -588,9 +588,7 @@ int play_speech(int charid,int sndid) {
 
 void stop_speech()
 {
-    // NOTE: here we should know only if there *was* any voice-over playing
-    // TODO: refactor speech and replace with a state variable to check instead
-    if (channel_has_clip(SCHAN_SPEECH))
+    if (play.speech_has_voice)
     {
         play.music_master_volume = play.music_vol_was;
         // update the music in a bit (fixes two speeches follow each other
@@ -604,5 +602,6 @@ void stop_speech()
             play.no_textbg_when_voice = 1;
             game.options[OPT_SPEECHTYPE] = 2;
         }
+        play.speech_has_voice = false;
     }
 }

--- a/Engine/ac/global_audio.h
+++ b/Engine/ac/global_audio.h
@@ -53,8 +53,9 @@ int     IsVoxAvailable();
 int     IsMusicVoxAvailable ();
 
 //=============================================================================
-
-int     play_speech(int charid,int sndid);
-void    stop_speech();
+// Play voice-over for the active speech and initialize relevant data
+bool    play_voice_speech(int charid, int sndid);
+// Stop voice-over for the active speech and reset relevant data
+void    stop_voice_speech();
 
 #endif // __AGS_EE_AC__GLOBALAUDIO_H

--- a/Engine/ac/global_audio.h
+++ b/Engine/ac/global_audio.h
@@ -46,16 +46,26 @@ void    PlayMP3File (const char *filename);
 void    PlaySilentMIDI (int mnum);
 
 void    SetSpeechVolume(int newvol);
-void    __scr_play_speech(int who, int which);
 void    SetVoiceMode (int newmod);
 int     GetVoiceMode ();
 int     IsVoxAvailable();
 int     IsMusicVoxAvailable ();
 
+struct CharacterInfo;
+struct ScriptAudioChannel;
+// Starts voice-over playback and returns audio channel it is played on;
+// as_speech flag determines whether engine should apply speech-related logic
+// as well, such as temporary volume reduction.
+ScriptAudioChannel *PlayVoiceClip(CharacterInfo *ch, int sndid, bool as_speech);
+
 //=============================================================================
-// Play voice-over for the active speech and initialize relevant data
+// Play voice-over for the active blocking speech and initialize relevant data
 bool    play_voice_speech(int charid, int sndid);
+// Play voice-over clip in non-blocking manner
+bool    play_voice_nonblocking(int charid, int sndid, bool as_speech);
 // Stop voice-over for the active speech and reset relevant data
 void    stop_voice_speech();
+// Stop non-blocking voice-over and revert audio volumes if necessary
+void    stop_voice_nonblocking();
 
 #endif // __AGS_EE_AC__GLOBALAUDIO_H

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -976,8 +976,8 @@ ComponentHandler ComponentHandlers[] =
 {
     {
         "Game State",
-        0,
-        0,
+        kGSSvgVersion_3509,
+        kGSSvgVersion_Initial,
         WriteGameState,
         ReadGameState
     },

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1145,6 +1145,7 @@ void engine_init_game_settings()
     play.speech_display_post_time_ms = 0;
     play.dialog_options_highlight_color = DIALOG_OPTIONS_HIGHLIGHT_COLOR_DEFAULT;
     play.speech_has_voice = false;
+    play.speech_voice_blocking = false;
     play.speech_in_post_state = false;
     play.narrator_speech = game.playercharacter;
     play.crossfading_out_channel = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1144,6 +1144,7 @@ void engine_init_game_settings()
     play.speech_portrait_y = 0;
     play.speech_display_post_time_ms = 0;
     play.dialog_options_highlight_color = DIALOG_OPTIONS_HIGHLIGHT_COLOR_DEFAULT;
+    play.speech_has_voice = false;
     play.speech_in_post_state = false;
     play.narrator_speech = game.playercharacter;
     play.crossfading_out_channel = 0;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -247,20 +247,18 @@ void update_overlay_timers()
 
 void update_speech_and_messages()
 {
-  // we need to know if there is/was voice-over
-  bool is_voice, is_voice_playing;
+  bool is_voice_playing = false;
+  if (play.speech_has_voice)
   {
       AudioChannelsLock lock;
       auto *ch = lock.GetChannel(SCHAN_SPEECH);
-      is_voice = ch != nullptr;
-      is_voice_playing = is_voice && ch->is_playing();
+      is_voice_playing = ch && ch->is_playing();
   }
-
   // determine if speech text should be removed
   if (play.messagetime>=0) {
     play.messagetime--;
     // extend life of text if the voice hasn't finished yet
-    if (is_voice && !play.speech_in_post_state) {
+    if (play.speech_has_voice && !play.speech_in_post_state) {
       if ((is_voice_playing) && (play.fast_forward == 0)) {
         if (play.messagetime <= 1)
           play.messagetime = 1;
@@ -297,16 +295,13 @@ void update_speech_and_messages()
 // update sierra-style speech
 void update_sierra_speech()
 {
-  // we need to know if there is/was voice-over
-  bool is_voice;
-  int voice_pos_ms;
+  int voice_pos_ms = -1;
+  if (play.speech_has_voice)
   {
       AudioChannelsLock lock;
       auto *ch = lock.GetChannel(SCHAN_SPEECH);
-      is_voice = ch != nullptr;
-      voice_pos_ms = is_voice ? ch->get_pos_ms() : -1;
+      voice_pos_ms = ch ? ch->get_pos_ms() : -1;
   }
-
   if ((face_talking >= 0) && (play.fast_forward == 0)) 
   {
     int updatedFrame = 0;
@@ -369,13 +364,13 @@ void update_sierra_speech()
              // if play.close_mouth_speech_time = 0, this means animation should play till
              // the speech ends; but this should not work in voice mode, and also if the
              // speech is in the "post" state
-             (is_voice || play.speech_in_post_state || play.close_mouth_speech_time > 0))
+             (play.speech_has_voice || play.speech_in_post_state || play.close_mouth_speech_time > 0))
       ;
     else {
       // Close mouth at end of sentence: if speech has entered the "post" state,
       // or if this is a text only mode and close_mouth_speech_time is set
       if (play.speech_in_post_state ||
-          (!is_voice &&
+          (!play.speech_has_voice &&
           (play.messagetime < play.close_mouth_speech_time) &&
           (play.close_mouth_speech_time > 0))) {
         facetalkframe = 0;
@@ -392,7 +387,7 @@ void update_sierra_speech()
         // normal non-lip-sync
         facetalkframe++;
         if ((facetalkframe >= views[facetalkview].loops[facetalkloop].numFrames) ||
-            (!is_voice && (play.messagetime < 1) && (play.close_mouth_speech_time > 0))) {
+            (!play.speech_has_voice && (play.messagetime < 1) && (play.close_mouth_speech_time > 0))) {
 
           if ((facetalkframe >= views[facetalkview].loops[facetalkloop].numFrames) &&
               (views[facetalkview].loops[facetalkloop].RunNextLoop())) 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -288,6 +288,8 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
 
 static void audio_update_polled_stuff()
 {
+    ///////////////////////////////////////////////////////////////////////////
+    // Do crossfade
     play.crossfade_step++;
 
     AudioChannelsLock lock;
@@ -330,6 +332,8 @@ static void audio_update_polled_stuff()
         }
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // Do audio queue
     if (play.new_music_queue_size > 0)
     {
         for (int i = 0; i < play.new_music_queue_size; i++)
@@ -349,6 +353,19 @@ static void audio_update_polled_stuff()
                 play_audio_clip_on_channel(channel, clip, itemToPlay.priority, itemToPlay.repeat, 0, itemToPlay.cachedClip);
                 i--;
             }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Do non-blocking voice speech
+    // NOTE: there's only one speech channel, therefore it's either blocking
+    // or non-blocking at any given time. If it's changed, we'd need to keep
+    // record of every channel, or keep a count of active channels.
+    if (play.IsNonBlockingVoiceSpeech())
+    {
+        if (!channel_is_playing(SCHAN_SPEECH))
+        {
+            stop_voice_nonblocking();
         }
     }
 }
@@ -698,6 +715,7 @@ void stop_all_sound_and_music()
 {
     int a;
     stopmusic();
+    stop_voice_nonblocking();
     // make sure it doesn't start crossfading when it comes back
     crossFading = 0;
     // any ambient sound will be aborted
@@ -785,6 +803,9 @@ int crossFading = 0, crossFadeVolumePerStep = 0, crossFadeStep = 0;
 int crossFadeVolumeAtStart = 0;
 SOUNDCLIP *cachedQueuedMusic = nullptr;
 
+//=============================================================================
+// Music update is scheduled when the voice speech stops;
+// we do a small delay before reverting any volume adjustments
 static bool music_update_scheduled = false;
 static auto music_update_at = AGS_Clock::now();
 
@@ -810,6 +831,8 @@ void process_scheduled_music_update() {
     apply_volume_drop_modifier(false);
     update_ambient_sound_vol();
 }
+// end scheduled music update functions
+//=============================================================================
 
 void clear_music_cache() {
 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -432,7 +432,7 @@ ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *cli
     // NOTE: there is a confusing logic in sound clip classes, that they do not use
     // any modifiers when begin playing, therefore we must apply this only after
     // playback was started.
-    if (!play.fast_forward && channel_has_clip(SCHAN_SPEECH))
+    if (!play.fast_forward && play.speech_has_voice)
         apply_volume_drop_to_clip(soundfx);
 
     set_clip_to_channel(channel, soundfx);
@@ -638,7 +638,6 @@ void update_directional_sound_vol()
 void update_ambient_sound_vol ()
 {
     AudioChannelsLock lock;
-    const bool is_voice_playing = lock.GetChannelIfPlaying(SCHAN_SPEECH) != nullptr;
 
     for (int chan = 1; chan < MAX_SOUND_CHANNELS; chan++) {
 
@@ -649,7 +648,7 @@ void update_ambient_sound_vol ()
 
         int sourceVolume = thisSound->vol;
 
-        if (is_voice_playing) {
+        if (play.speech_has_voice) {
             // Negative value means set exactly; positive means drop that amount
             if (play.speech_music_drop < 0)
                 sourceVolume = -play.speech_music_drop;
@@ -891,7 +890,7 @@ void apply_volume_drop_modifier(bool applyModifier)
 // Checks if speech voice-over is currently playing, and reapply volume drop to all other active clips
 void update_volume_drop_if_voiceover()
 {
-    apply_volume_drop_modifier(channel_has_clip(SCHAN_SPEECH));
+    apply_volume_drop_modifier(play.speech_has_voice);
 }
 
 extern volatile char want_exit;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -579,6 +579,11 @@ int IAGSEngine::IsChannelPlaying (int32 channel) {
 }
 void IAGSEngine::PlaySoundChannel (int32 channel, int32 soundType, int32 volume, int32 loop, const char *filename) {
     stop_and_destroy_channel (channel);
+    // Not sure if it's right to let it play on *any* channel, but this is plugin so let it go...
+    // we must correctly stop background voice speech if it takes over speech chan
+    if (channel == SCHAN_SPEECH && play.IsNonBlockingVoiceSpeech())
+        stop_voice_nonblocking();
+
     SOUNDCLIP *newcha = nullptr;
 
     if (((soundType == PSND_MP3STREAM) || (soundType == PSND_OGGSTREAM)) 

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -280,6 +280,10 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     ASSERT_PARAM_COUNT(FUNCTION, 1); \
     return RuntimeScriptValue().SetDynamicObject((void*)(RET_CLASS*)FUNCTION(params[0].IValue), &RET_MGR)
 
+#define API_SCALL_OBJ_POBJ_PINT_PBOOL(RET_CLASS, RET_MGR, FUNCTION, P1CLASS) \
+    ASSERT_PARAM_COUNT(FUNCTION, 3); \
+    return RuntimeScriptValue().SetDynamicObject((void*)(RET_CLASS*)FUNCTION((P1CLASS*)params[0].Ptr, params[1].IValue, params[2].GetAsBool()), &RET_MGR)
+
 #define API_SCALL_OBJ_PINT2(RET_CLASS, RET_MGR, FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 2); \
     return RuntimeScriptValue().SetDynamicObject((void*)(RET_CLASS*)FUNCTION(params[0].IValue, params[1].IValue), &RET_MGR)


### PR DESCRIPTION
**UPDATE**.

This adds a method to play a voice-over clip in a non-blocking manner and without fixed connection to character state or any text displayed on screen. This might come very useful in scripting custom speech, because right now the only way to play a clip from speech.vox in a custom speech style is to call `Character.Say("&NNNN");`, which is a blocking command and makes it harder to handle any background activity.

The new script function is:
<pre>
/// Play speech voice-over in non-blocking mode, optionally apply music and sound volume reduction
import AudioChannel* PlayVoiceClip(Character*, int cue, bool as_speech = true);
</pre>

PlayVoiceClip plays a voice clip in non-blocking manner, clip is chosen by character's ID and cue ID and returns AudioChannel (atm this is always same channel reserved for speech in AGS).
*as_speech* parameter lets user choose whether they'd like to use default volume reduction rule or not (in the latter case they may apply their own). If this is enabled then voice playback lowers volume of all other sound types by the same rules as regular speech, and restores them back afterwards.

The returned AudioChannel pointer lets you stop the voice clip anytime.

**IMPORTANT:** PlayVoiceClip cannot be used during regular blocking voice speech and will fail (return null pointer) if called in this situation (e.g. from repeatedly_execute_always).

**SIDE EFFECTS:**
1) Acquiring speech's AudioChannel will let you stop even normal blocking speech by cutting of its voice playback but only if it was relying on one (that is - had started one in the first place). But I think you could do this prior anyway by getting System.AudioChannels[0].
2) I think it may be possible to run non-blocking voice-over during regular speech that does not have voice-over for some reason (not tested). However, speech will ignore non-blocking voice-over in this case (won't stop it if done displaying or gets skipped).