### PR TITLE
AGS3 C++ modernisation fixes

### DIFF
--- a/Common/ac/dialogtopic.cpp
+++ b/Common/ac/dialogtopic.cpp
@@ -22,7 +22,7 @@ void DialogTopic::ReadFromFile(Stream *in)
     in->ReadArray(optionnames, 150*sizeof(char), MAXTOPICOPTIONS);
     in->ReadArrayOfInt32(optionflags, MAXTOPICOPTIONS);
     // optionscripts pointer is not used anywhere in the engine
-    optionscripts = NULL;
+    optionscripts = nullptr;
     in->ReadInt32(); // optionscripts 32-bit pointer
     in->ReadArrayOfInt16(entrypoints, MAXTOPICOPTIONS);
     startupentrypoint = in->ReadInt16();

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -24,16 +24,16 @@ using namespace AGS::Common;
 
 GameSetupStruct::GameSetupStruct()
     : filever(0)
-    , intrChar(NULL)
-    , charScripts(NULL)
-    , invScripts(NULL)
+    , intrChar(nullptr)
+    , charScripts(nullptr)
+    , invScripts(nullptr)
     , roomCount(0)
-    , roomNumbers(NULL)
-    , roomNames(NULL)
+    , roomNumbers(nullptr)
+    , roomNames(nullptr)
     , audioClipCount(0)
-    , audioClips(NULL)
+    , audioClips(nullptr)
     , audioClipTypeCount(0)
-    , audioClipTypes(NULL)
+    , audioClipTypes(nullptr)
     , scoreClipID(0)
 {
     memset(invinfo, 0, sizeof(invinfo));
@@ -59,7 +59,7 @@ void GameSetupStruct::Free()
         for (int i = 0; i < numcharacters; ++i)
             delete intrChar[i];
         delete[] intrChar;
-        intrChar = NULL;
+        intrChar = nullptr;
     }
 
     if (charScripts)
@@ -67,7 +67,7 @@ void GameSetupStruct::Free()
         for (int i = 0; i < numcharacters; ++i)
             delete charScripts[i];
         delete[] charScripts;
-        charScripts = NULL;
+        charScripts = nullptr;
     }
     numcharacters = 0;
 
@@ -79,7 +79,7 @@ void GameSetupStruct::Free()
         for (int i = 1; i < numinvitems; i++)
             delete invScripts[i];
         delete invScripts;
-        invScripts = NULL;
+        invScripts = nullptr;
     }
     numinvitems = 0;
 
@@ -90,9 +90,9 @@ void GameSetupStruct::Free()
     roomCount = 0;
 
     delete[] audioClips;
-    audioClips = NULL;
+    audioClips = nullptr;
     delete[] audioClipTypes;
-    audioClipTypes = NULL;
+    audioClipTypes = nullptr;
     audioClipCount = 0;
     audioClipTypeCount = 0;
 
@@ -130,7 +130,7 @@ ScriptAudioClip* GetAudioClipForOldStyleNumber(GameSetupStruct &game, bool is_mu
         if (clip_name.Compare(game.audioClips[i].scriptName) == 0)
             return &game.audioClips[i];
     }
-    return NULL;
+    return nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -228,8 +228,8 @@ void GameSetupStruct::read_interaction_scripts(Common::Stream *in, GameDataVersi
     {
         int bb;
 
-        charScripts = NULL;
-        invScripts = NULL;
+        charScripts = nullptr;
+        invScripts = nullptr;
         intrChar = new Interaction*[numcharacters];
 
         for (bb = 0; bb < numcharacters; bb++) {
@@ -313,7 +313,7 @@ void GameSetupStruct::read_messages(Common::Stream *in, GameDataVersion data_ver
             read_string_decrypt(in, messages[ee], GLOBALMESLENGTH);
     }
     delete [] load_messages;
-    load_messages = NULL;
+    load_messages = nullptr;
 }
 
 void GameSetupStruct::ReadCharacters_Aligned(Stream *in)
@@ -440,7 +440,7 @@ void GameSetupStruct::ReadFromSaveGame_v321(Stream *in, char* gswas, ccScript* c
     ReadInvInfo_Aligned(in);
     ReadMouseCursors_Aligned(in);
 
-    if (invScripts == NULL)
+    if (invScripts == nullptr)
     {
         for (bb = 0; bb < numinvitems; bb++)
             intrInv[bb]->ReadTimesRunFromSavedgame(in);
@@ -501,7 +501,7 @@ void ConvertOldGameStruct (OldGameSetupStruct *ogss, GameSetupStruct *gss) {
         gss->messages[i] = ogss->messages[i];
     gss->dict = ogss->dict;
     gss->globalscript = ogss->globalscript;
-    gss->chars = NULL; //ogss->chars;
+    gss->chars = nullptr; //ogss->chars;
     gss->compiled_script = ogss->compiled_script;
     gss->numcursors = 10;
 }

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -40,11 +40,11 @@ GameSetupStructBase::GameSetupStructBase()
     , numcursors(0)
     , default_lipsync_frame(0)
     , invhotdotsprite(0)
-    , dict(NULL)
-    , globalscript(NULL)
-    , chars(NULL)
-    , compiled_script(NULL)
-    , load_messages(NULL)
+    , dict(nullptr)
+    , globalscript(nullptr)
+    , chars(nullptr)
+    , compiled_script(nullptr)
+    , load_messages(nullptr)
     , load_dictionary(false)
     , load_compiled_script(false)
     , _resolutionType(kGameResolution_Undefined)
@@ -69,18 +69,18 @@ void GameSetupStructBase::Free()
     for (int i = 0; i < MAXGLOBALMES; ++i)
     {
         delete[] messages[i];
-        messages[i] = NULL;
+        messages[i] = nullptr;
     }
     delete[] load_messages;
-    load_messages = NULL;
+    load_messages = nullptr;
     delete dict;
-    dict = NULL;
+    dict = nullptr;
     delete globalscript;
-    globalscript = NULL;
+    globalscript = nullptr;
     delete compiled_script;
-    compiled_script = NULL;
+    compiled_script = nullptr;
     delete[] chars;
-    chars = NULL;
+    chars = nullptr;
 }
 
 void GameSetupStructBase::SetDefaultResolution(GameResolutionType type)

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -57,7 +57,7 @@ SpriteCache::SpriteData::SpriteData()
     : Offset(0)
     , Size(0)
     , Flags(SPRCACHEFLAG_DOESNOTEXIST)
-    , Image(NULL)
+    , Image(nullptr)
 {
 }
 
@@ -133,7 +133,7 @@ void SpriteCache::Reset()
         if (_spriteData[i].Image)
         {
             delete _spriteData[i].Image;
-            _spriteData[i].Image = NULL;
+            _spriteData[i].Image = nullptr;
         }
     }
     _spriteData.clear();
@@ -159,10 +159,10 @@ void SpriteCache::SetSpriteAndLock(sprkey_t index, Bitmap *sprite)
 
 void SpriteCache::RemoveSprite(sprkey_t index, bool freeMemory)
 {
-    if ((_spriteData[index].Image != NULL) && (freeMemory))
+    if ((_spriteData[index].Image != nullptr) && (freeMemory))
         delete _spriteData[index].Image;
 
-    _spriteData[index].Image = NULL;
+    _spriteData[index].Image = nullptr;
     _spriteData[index].Offset = 0;
 }
 
@@ -188,7 +188,7 @@ sprkey_t SpriteCache::AddNewSprite()
     for (size_t i = MIN_SPRITE_INDEX; i < _spriteData.size(); ++i)
     {
         // slot empty
-        if ((_spriteData[i].Image == NULL) && ((_spriteData[i].Flags & SPRCACHEFLAG_DOESNOTEXIST) != 0))
+        if ((_spriteData[i].Image == nullptr) && ((_spriteData[i].Flags & SPRCACHEFLAG_DOESNOTEXIST) != 0))
         {
             _sprInfos[i] = SpriteInfo();
             _spriteData[i] = SpriteData();
@@ -201,14 +201,14 @@ sprkey_t SpriteCache::AddNewSprite()
 
 bool SpriteCache::DoesSpriteExist(sprkey_t index) const
 {
-    return (_spriteData[index].Image != NULL) || // HAS loaded bitmap
+    return (_spriteData[index].Image != nullptr) || // HAS loaded bitmap
         ((_spriteData[index].Flags & SPRCACHEFLAG_DOESNOTEXIST) == 0) || // OR found in the game resources
         ((_spriteData[index].Flags & SPRCACHEFLAG_REMAPPED) != 0); // OR was remapped to another sprite
 }
 
 bool SpriteCache::IsExternalSprite(sprkey_t index) const
 {
-    return (_spriteData[index].Image != NULL) &&  // HAS loaded bitmap
+    return (_spriteData[index].Image != nullptr) &&  // HAS loaded bitmap
         ((_spriteData[index].Flags & SPRCACHEFLAG_DOESNOTEXIST) != 0) && // AND NOT found in game resources
         ((_spriteData[index].Flags & SPRCACHEFLAG_REMAPPED) == 0); // AND was NOT remapped to another sprite
 }
@@ -217,14 +217,14 @@ Bitmap *SpriteCache::operator [] (sprkey_t index)
 {
     // invalid sprite slot
     if (index < 0 || (size_t)index >= _spriteData.size())
-        return NULL;
+        return nullptr;
 
     // Dynamically added sprite, don't put it on the sprite list
     if (IsExternalSprite(index))
         return _spriteData[index].Image;
 
     // if sprite exists in file but is not in mem, load it
-    if ((_spriteData[index].Image == NULL) &&
+    if ((_spriteData[index].Image == nullptr) &&
             (((_spriteData[index].Flags & SPRCACHEFLAG_DOESNOTEXIST) == 0) || ((_spriteData[index].Flags & SPRCACHEFLAG_REMAPPED) != 0)))
         LoadSprite(index);
 
@@ -272,7 +272,7 @@ void SpriteCache::RemoveOldest()
 
     sprkey_t sprnum = _liststart;
 
-    if ((_spriteData[sprnum].Image != NULL) && ((_spriteData[sprnum].Flags & SPRCACHEFLAG_LOCKED) == 0)) {
+    if ((_spriteData[sprnum].Image != nullptr) && ((_spriteData[sprnum].Flags & SPRCACHEFLAG_LOCKED) == 0)) {
         // Free the memory
         if ((_spriteData[sprnum].Flags & SPRCACHEFLAG_DOESNOTEXIST) != 0)
         {
@@ -281,7 +281,7 @@ void SpriteCache::RemoveOldest()
         _cacheSize -= _spriteData[sprnum].Size;
 
         delete _spriteData[sprnum].Image;
-        _spriteData[sprnum].Image = NULL;
+        _spriteData[sprnum].Image = nullptr;
     }
 
     if (_liststart == _listend)
@@ -329,7 +329,7 @@ void SpriteCache::RemoveAll()
             ((_spriteData[i].Flags & SPRCACHEFLAG_DOESNOTEXIST) == 0)) // sprite from game resource
         {
             delete _spriteData[i].Image;
-            _spriteData[i].Image = NULL;
+            _spriteData[i].Image = nullptr;
         }
         _mrulist[i] = 0;
         _mrubacklink[i] = 0;
@@ -344,7 +344,7 @@ void SpriteCache::Precache(sprkey_t index)
 
     soff_t sprSize = 0;
 
-    if (_spriteData[index].Image == NULL)
+    if (_spriteData[index].Image == nullptr)
         sprSize = LoadSprite(index);
     else if ((_spriteData[index].Flags & SPRCACHEFLAG_LOCKED) == 0)
         sprSize = _spriteData[index].Size;
@@ -402,7 +402,7 @@ size_t SpriteCache::LoadSprite(sprkey_t index)
     _sprInfos[index].Height = htt;
 
     _spriteData[index].Image = BitmapHelper::CreateBitmap(wdd, htt, coldep * 8);
-    if (_spriteData[index].Image == NULL)
+    if (_spriteData[index].Image == nullptr)
     {
         // TODO: does it have to remap to sprite 0 here?
         _spriteData[index].Flags |= SPRCACHEFLAG_DOESNOTEXIST;
@@ -507,7 +507,7 @@ void SpriteCache::UnCompressSprite(Bitmap *sprite, Stream *in)
 int SpriteCache::SaveToFile(const char *filnam, bool compressOutput)
 {
     Stream *output = Common::File::CreateFile(filnam);
-    if (output == NULL)
+    if (output == nullptr)
         return -1;
 
     if (compressOutput)
@@ -515,11 +515,11 @@ int SpriteCache::SaveToFile(const char *filnam, bool compressOutput)
         // re-open the file so that it can be seeked
         delete output;
         output = File::OpenFile(filnam, Common::kFile_Open, Common::kFile_ReadWrite); // CHECKME why mode was "r+" here?
-        if (output == NULL)
+        if (output == nullptr)
             return -1;
     }
 
-    int spriteFileIDCheck = (int)time(NULL);
+    int spriteFileIDCheck = (int)time(nullptr);
 
     // sprite file version
     output->WriteInt16(kSprfVersion_Current);
@@ -548,10 +548,10 @@ int SpriteCache::SaveToFile(const char *filnam, bool compressOutput)
         spriteoffs[i] = output->GetPosition();
 
         // if compressing uncompressed sprites, load the sprite into memory
-        if ((_spriteData[i].Image == NULL) && (this->_compressed != compressOutput))
+        if ((_spriteData[i].Image == nullptr) && (this->_compressed != compressOutput))
             (*this)[i];
 
-        if (_spriteData[i].Image != NULL)
+        if (_spriteData[i].Image != nullptr)
         {
             // image in memory -- write it out
             pre_save_sprite(i);
@@ -679,7 +679,7 @@ HError SpriteCache::InitFile(const char *filnam)
     int spriteFileID = 0;
 
     _stream.reset(Common::AssetManager::OpenAsset(filnam));
-    if (_stream == NULL)
+    if (_stream == nullptr)
         return new Error(String::FromFormat("Failed to open spriteset file '%s'.", filnam));
 
     spr_initial_offs = _stream->GetPosition();
@@ -759,7 +759,7 @@ HError SpriteCache::RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost
         if (coldep == 0)
         {
             _spriteData[i].Offset = 0;
-            _spriteData[i].Image = NULL;
+            _spriteData[i].Image = nullptr;
 
             initFile_initNullSpriteParams(i);
 
@@ -775,7 +775,7 @@ HError SpriteCache::RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost
         if ((size_t)i >= _spriteData.size())
             break;
 
-        _spriteData[i].Image = NULL;
+        _spriteData[i].Image = nullptr;
 
         int wdd = in->ReadInt16();
         int htt = in->ReadInt16();
@@ -804,7 +804,7 @@ HError SpriteCache::RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost
 bool SpriteCache::LoadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t topmost)
 {
     Stream *fidx = Common::AssetManager::OpenAsset((char*)spindexfilename);
-    if (fidx == NULL) 
+    if (fidx == nullptr) 
     {
         return false;
     }
@@ -895,7 +895,7 @@ void SpriteCache::DetachFile()
 int SpriteCache::AttachFile(const char *filename)
 {
     _stream.reset(Common::AssetManager::OpenAsset((char *)filename));
-    if (_stream == NULL)
+    if (_stream == nullptr)
         return -1;
     return 0;
 }

--- a/Common/ac/view.cpp
+++ b/Common/ac/view.cpp
@@ -58,7 +58,7 @@ void ViewFrame::WriteToFile(Stream *out)
 ViewLoopNew::ViewLoopNew()
     : numFrames(0)
     , flags(0)
-    , frames(NULL)
+    , frames(nullptr)
 {
 }
 
@@ -76,10 +76,10 @@ void ViewLoopNew::Initialize(int frameCount)
 
 void ViewLoopNew::Dispose()
 {
-    if (frames != NULL)
+    if (frames != nullptr)
     {
         free(frames);
-        frames = NULL;
+        frames = nullptr;
         numFrames = 0;
     }
 }
@@ -124,7 +124,7 @@ void ViewLoopNew::ReadFrames_Aligned(Stream *in)
 
 ViewStruct::ViewStruct()
     : numLoops(0)
-    , loops(NULL)
+    , loops(nullptr)
 {
 }
 

--- a/Common/ac/wordsdictionary.cpp
+++ b/Common/ac/wordsdictionary.cpp
@@ -22,8 +22,8 @@ using AGS::Common::Stream;
 
 WordsDictionary::WordsDictionary()
     : num_words(0)
-    , word(NULL)
-    , wordnum(NULL)
+    , word(nullptr)
+    , wordnum(nullptr)
 {
 }
 
@@ -54,8 +54,8 @@ void WordsDictionary::free_memory()
         delete [] word[0];
         delete [] word;
         delete [] wordnum;
-        word = NULL;
-        wordnum = NULL;
+        word = nullptr;
+        wordnum = nullptr;
         num_words = 0;
     }
 }

--- a/Common/api/stream_api.h
+++ b/Common/api/stream_api.h
@@ -42,7 +42,7 @@ enum StreamSeek
 class IAGSStream
 {
 public:
-    virtual ~IAGSStream(){}
+    virtual ~IAGSStream() = default;
 
     virtual void        Close() = 0;
 

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -31,7 +31,7 @@ AssetLocation::AssetLocation()
 }
 
 
-AssetManager *AssetManager::_theAssetManager = NULL;
+AssetManager *AssetManager::_theAssetManager = nullptr;
 
 /* static */ bool AssetManager::CreateInstance()
 {
@@ -40,13 +40,13 @@ AssetManager *AssetManager::_theAssetManager = NULL;
     delete _theAssetManager;
     _theAssetManager = new AssetManager();
     _theAssetManager->SetSearchPriority(kAssetPriorityDir);
-    return _theAssetManager != NULL; // well, we should return _something_
+    return _theAssetManager != nullptr; // well, we should return _something_
 }
 
 /* static */ void AssetManager::DestroyInstance()
 {
     delete _theAssetManager;
-    _theAssetManager = NULL;
+    _theAssetManager = nullptr;
 }
 
 AssetManager::~AssetManager()
@@ -141,7 +141,7 @@ AssetError AssetManager::ReadDataFileTOC(const String &data_file, AssetLibInfo &
 /* static */ const AssetLibInfo *AssetManager::GetLibraryTOC()
 {
     assert(_theAssetManager != NULL);
-    return _theAssetManager ? &_theAssetManager->_GetLibraryTOC() : NULL;
+    return _theAssetManager ? &_theAssetManager->_GetLibraryTOC() : nullptr;
 }
 
 /* static */ bool AssetManager::GetAssetLocation(const String &asset_name, AssetLocation &loc)
@@ -167,7 +167,7 @@ AssetError AssetManager::ReadDataFileTOC(const String &data_file, AssetLibInfo &
     assert(_theAssetManager != NULL);
     if (!_theAssetManager)
     {
-        return NULL;
+        return nullptr;
     }
     return _theAssetManager->OpenAssetAsStream(asset_name, open_mode, work_mode);
 }
@@ -261,7 +261,7 @@ int AssetManager::_GetAssetCount()
 String AssetManager::_GetAssetFileByIndex(int index)
 {
     if ((index < 0) || ((size_t)index >= _assetLib.AssetInfos.size()))
-        return NULL;
+        return nullptr;
 
     return _assetLib.AssetInfos[index].FileName;
 }
@@ -278,7 +278,7 @@ const AssetLibInfo &AssetManager::_GetLibraryTOC() const
 
 bool AssetManager::_DoesAssetExist(const String &asset_name)
 {
-    return FindAssetByFileName(asset_name) != NULL ||
+    return FindAssetByFileName(asset_name) != nullptr ||
         File::TestReadFile(asset_name);
 }
 
@@ -335,7 +335,7 @@ AssetInfo *AssetManager::FindAssetByFileName(const String &asset_name)
             return &_assetLib.AssetInfos[i];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 String AssetManager::MakeLibraryFileNameForAsset(const AssetInfo *asset)
@@ -353,7 +353,7 @@ bool AssetManager::GetAssetFromLib(const String &asset_name, AssetLocation &loc,
     if (!asset)
         return false; // asset not found
 
-    String libfile = cbuf_to_string_and_free( ci_find_file(NULL, MakeLibraryFileNameForAsset(asset)) );
+    String libfile = cbuf_to_string_and_free( ci_find_file(nullptr, MakeLibraryFileNameForAsset(asset)) );
     if (libfile.IsEmpty())
         return false;
     loc.FileName = libfile;
@@ -364,7 +364,7 @@ bool AssetManager::GetAssetFromLib(const String &asset_name, AssetLocation &loc,
 
 bool AssetManager::GetAssetFromDir(const String &file_name, AssetLocation &loc, FileOpenMode open_mode, FileWorkMode work_mode)
 {
-    String exfile = cbuf_to_string_and_free( ci_find_file(NULL, file_name) );
+    String exfile = cbuf_to_string_and_free( ci_find_file(nullptr, file_name) );
     if (exfile.IsEmpty() || !Path::IsFile(exfile))
         return false;
     loc.FileName = exfile;
@@ -403,7 +403,7 @@ Stream *AssetManager::OpenAssetAsStream(const String &asset_name, FileOpenMode o
         }
         return s;
     }
-    return NULL;
+    return nullptr;
 }
 
 } // namespace Common

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -38,8 +38,8 @@ struct Font
 };
 
 Font::Font()
-    : Renderer(NULL)
-    , Renderer2(NULL)
+    : Renderer(nullptr)
+    , Renderer2(nullptr)
 {}
 
 } // Common
@@ -81,21 +81,21 @@ void adjust_y_coordinate_for_text(int* ypos, size_t fontnum)
 
 bool font_first_renderer_loaded()
 {
-  return fonts.size() > 0 && fonts[0].Renderer != NULL;
+  return fonts.size() > 0 && fonts[0].Renderer != nullptr;
 }
 
 bool is_font_loaded(size_t fontNumber)
 {
-    return fontNumber < fonts.size() && fonts[fontNumber].Renderer != NULL;;
+    return fontNumber < fonts.size() && fonts[fontNumber].Renderer != nullptr;;
 }
 
 IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* renderer)
 {
   if (fontNumber >= fonts.size())
-    return NULL;
+    return nullptr;
   IAGSFontRenderer* oldRender = fonts[fontNumber].Renderer;
   fonts[fontNumber].Renderer = renderer;
-  fonts[fontNumber].Renderer2 = NULL;
+  fonts[fontNumber].Renderer2 = nullptr;
   return oldRender;
 }
 
@@ -192,7 +192,7 @@ void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, size_t fontNumber, color_t
   if (yyy > ds->GetClip().Bottom)
     return;                   // each char is clipped but this speeds it up
 
-  if (fonts[fontNumber].Renderer != NULL)
+  if (fonts[fontNumber].Renderer != nullptr)
   {
     fonts[fontNumber].Renderer->RenderText(texx, fontNumber, (BITMAP*)ds->GetAllegroBitmap(), xxx, yyy, text_color);
   }
@@ -249,8 +249,8 @@ void wfreefont(size_t fontNumber)
   if (fontNumber >= fonts.size())
     return;
 
-  if (fonts[fontNumber].Renderer != NULL)
+  if (fonts[fontNumber].Renderer != nullptr)
     fonts[fontNumber].Renderer->FreeMemory(fontNumber);
 
-  fonts[fontNumber].Renderer = NULL;
+  fonts[fontNumber].Renderer = nullptr;
 }

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -74,7 +74,7 @@ void TTFFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
 
 bool TTFFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
 {
-  return LoadFromDiskEx(fontNumber, fontSize, NULL);
+  return LoadFromDiskEx(fontNumber, fontSize, nullptr);
 }
 
 bool TTFFontRenderer::IsBitmapFont()
@@ -88,7 +88,7 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRen
   Stream *reader = AssetManager::OpenAsset(file_name);
   char *membuffer;
 
-  if (reader == NULL)
+  if (reader == nullptr)
     return false;
 
   long lenof = AssetManager::GetLastAssetSize();
@@ -100,7 +100,7 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRen
   ALFONT_FONT *alfptr = alfont_load_font_from_mem(membuffer, lenof);
   free(membuffer);
 
-  if (alfptr == NULL)
+  if (alfptr == nullptr)
     return false;
 
   // TODO: move this somewhere, should not be right here

--- a/Common/font/wfnfont.cpp
+++ b/Common/font/wfnfont.cpp
@@ -27,7 +27,7 @@ static const size_t  MinCharDataSize     = sizeof(uint16_t) * 2;
 WFNChar::WFNChar()
     : Width(0)
     , Height(0)
-    , Data(NULL)
+    , Data(nullptr)
 {
 }
 

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -128,7 +128,7 @@ int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_ch
 
 bool WFNFontRenderer::LoadFromDisk(int fontNumber, int fontSize)
 {
-  return LoadFromDiskEx(fontNumber, fontSize, NULL);
+  return LoadFromDiskEx(fontNumber, fontSize, nullptr);
 }
 
 bool WFNFontRenderer::IsBitmapFont()
@@ -139,16 +139,16 @@ bool WFNFontRenderer::IsBitmapFont()
 bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params)
 {
   String file_name;
-  Stream *ffi = NULL;
+  Stream *ffi = nullptr;
 
   file_name.Format("agsfnt%d.wfn", fontNumber);
   ffi = AssetManager::OpenAsset(file_name);
-  if (ffi == NULL)
+  if (ffi == nullptr)
   {
     // actual font not found, try font 0 instead
     file_name = "agsfnt0.wfn";
     ffi = AssetManager::OpenAsset(file_name);
-    if (ffi == NULL)
+    if (ffi == nullptr)
       return false;
   }
 

--- a/Common/game/interactions.cpp
+++ b/Common/game/interactions.cpp
@@ -53,7 +53,7 @@ void InteractionValue::Write(Stream *out) const
 
 InteractionCommand::InteractionCommand()
     : Type(0)
-    , Parent(NULL)
+    , Parent(nullptr)
 {
 }
 
@@ -66,7 +66,7 @@ void InteractionCommand::Assign(const InteractionCommand &ic, InteractionCommand
 {
     Type = ic.Type;
     memcpy(Data, ic.Data, sizeof(Data));
-    Children.reset(ic.Children.get() ? new InteractionCommandList(*ic.Children) : NULL);
+    Children.reset(ic.Children.get() ? new InteractionCommandList(*ic.Children) : nullptr);
     Parent = parent;
 }
 
@@ -75,7 +75,7 @@ void InteractionCommand::Reset()
     Type = 0;
     memset(Data, 0, sizeof(Data));
     Children.reset();
-    Parent = NULL;
+    Parent = nullptr;
 }
 
 void InteractionCommand::ReadValues_Aligned(Stream *in)
@@ -120,7 +120,7 @@ InteractionCommand &InteractionCommand::operator = (const InteractionCommand &ic
 {
     Type = ic.Type;
     memcpy(Data, ic.Data, sizeof(Data));
-    Children.reset(ic.Children.get() ? new InteractionCommandList(*ic.Children) : NULL);
+    Children.reset(ic.Children.get() ? new InteractionCommandList(*ic.Children) : nullptr);
     Parent = ic.Parent;
     return *this;
 }
@@ -201,7 +201,7 @@ void InteractionCommandList::Write_v321(Stream *out) const
 
     for (size_t i = 0; i < cmd_count; ++i)
     {
-        if (Cmds[i].Children.get() != NULL)
+        if (Cmds[i].Children.get() != nullptr)
             Cmds[i].Children->Write_v321(out);
     }
 }
@@ -223,7 +223,7 @@ InteractionEvent &InteractionEvent::operator = (const InteractionEvent &ie)
 {
     Type = ie.Type;
     TimesRun = ie.TimesRun;
-    Response.reset(ie.Response.get() ? new InteractionCommandList(*ie.Response) : NULL);
+    Response.reset(ie.Response.get() ? new InteractionCommandList(*ie.Response) : nullptr);
     return *this;
 }
 
@@ -265,7 +265,7 @@ void Interaction::Reset()
 Interaction *Interaction::CreateFromStream(Stream *in)
 {
     if (in->ReadInt32() != kInteractionVersion_Initial)
-        return NULL; // unsupported format
+        return nullptr; // unsupported format
 
     const size_t evt_count = in->ReadInt32();
     if (evt_count > MAX_NEWINTERACTION_EVENTS)
@@ -412,7 +412,7 @@ InteractionScripts *InteractionScripts::CreateFromStream(Stream *in)
     if (evt_count > MAX_NEWINTERACTION_EVENTS)
     {
         quit("Can't deserialize interaction scripts: too many events");
-        return NULL;
+        return nullptr;
     }
 
     InteractionScripts *scripts = new InteractionScripts();

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -186,7 +186,7 @@ HGameFileError ReadDialogScript(PScript &dialog_script, Stream *in, GameDataVers
     if (data_ver > kGameVersion_310) // 3.1.1+ dialog script
     {
         dialog_script.reset(ccScript::CreateFromStream(in));
-        if (dialog_script == NULL)
+        if (dialog_script == nullptr)
             return new MainGameFileError(kMGFErr_CreateDialogScriptFailed, ccErrorString);
     }
     else // 2.x and < 3.1.1 dialog
@@ -205,7 +205,7 @@ HGameFileError ReadScriptModules(std::vector<PScript> &sc_mods, Stream *in, Game
         for (int i = 0; i < count; ++i)
         {
             sc_mods[i].reset(ccScript::CreateFromStream(in));
-            if (sc_mods[i] == NULL)
+            if (sc_mods[i] == nullptr)
                 return new MainGameFileError(kMGFErr_CreateScriptModuleFailed, ccErrorString);
         }
     }
@@ -629,7 +629,7 @@ void SetDefaultGlmsg(GameSetupStruct &game, int msgnum, const char *val)
     // TODO: find out why the index should be lowered by 500
     // (or rather if we may pass correct index right away)
     msgnum -= 500;
-    if (game.messages[msgnum] == NULL)
+    if (game.messages[msgnum] == nullptr)
         game.messages[msgnum] = strdup(val);
 }
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -94,9 +94,7 @@ LoadedGameEntities::LoadedGameEntities(GameSetupStruct &game, DialogTopic *&dial
 {
 }
 
-LoadedGameEntities::~LoadedGameEntities()
-{
-}
+LoadedGameEntities::~LoadedGameEntities() = default;
 
 bool IsMainGameLibrary(const String &filename)
 {

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -84,7 +84,7 @@ HRoomFileError OpenRoomFile(const String &filename, RoomDataSource &src)
     src = RoomDataSource();
     // Try to open room file
     Stream *in = AssetManager::OpenAsset(filename);
-    if (in == NULL)
+    if (in == nullptr)
         return new RoomFileError(kRoomFileErr_FileOpenFailed, String::FromFormat("Filename: %s.", filename.GetCStr()));
     // Read room header
     src.Filename = filename;
@@ -376,7 +376,7 @@ HRoomFileError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_
 
     update_polled_stuff_if_runtime();
     // Primary background
-    Bitmap *mask = NULL;
+    Bitmap *mask = nullptr;
     if (data_ver >= kRoomVersion_pre114_5)
         load_lzw(in, &mask, room->BackgroundBPP, room->Palette);
     else
@@ -394,7 +394,7 @@ HRoomFileError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_
         // an old version - clear the 'shadow' area into a blank regions bmp
         loadcompressed_allegro(in, &mask, room->Palette);
         delete mask;
-        mask = NULL;
+        mask = nullptr;
     }
     room->RegionMask.reset(mask);
     update_polled_stuff_if_runtime();
@@ -425,7 +425,7 @@ HRoomFileError ReadScriptBlock(char *&buf, Stream *in, RoomFileVersion data_ver)
 HRoomFileError ReadCompSc3Block(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 {
     room->CompiledScript.reset(ccScript::CreateFromStream(in));
-    if (room->CompiledScript == NULL)
+    if (room->CompiledScript == nullptr)
         return new RoomFileError(kRoomFileErr_ScriptLoadFailed, ccErrorString);
     return HRoomFileError::None();
 }
@@ -483,7 +483,7 @@ HRoomFileError ReadAnimBgBlock(RoomStruct *room, Stream *in, RoomFileVersion dat
     for (size_t i = 1; i < room->BgFrameCount; ++i)
     {
         update_polled_stuff_if_runtime();
-        Bitmap *frame = NULL;
+        Bitmap *frame = nullptr;
         load_lzw(in, &frame, room->BackgroundBPP, room->BgFrames[i].Palette);
         room->BgFrames[i].Graphic.reset(frame);
     }
@@ -756,7 +756,7 @@ HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion dat
         block = (RoomFileBlock)b;
         if (block == kRoomFblk_Script)
         {
-            char *buf = NULL;
+            char *buf = nullptr;
             HRoomFileError err = ReadScriptBlock(buf, in, data_ver);
             if (err)
             {

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -266,7 +266,7 @@ void FixRoomMasks(RoomStruct *room)
     if (room->MaskResolution <= 0)
         return;
     Bitmap *bkg = room->BgFrames[0].Graphic.get();
-    if (bkg == NULL)
+    if (bkg == nullptr)
         return;
     // TODO: this issue is somewhat complicated. Original code was relying on
     // room->Width and Height properties. But in the engine these are saved

--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -24,27 +24,27 @@ namespace Common
 {
 
 Bitmap::Bitmap()
-    : _alBitmap(NULL)
+    : _alBitmap(nullptr)
     , _isDataOwner(false)
 {
 }
 
 Bitmap::Bitmap(int width, int height, int color_depth)
-    : _alBitmap(NULL)
+    : _alBitmap(nullptr)
     , _isDataOwner(false)
 {
     Create(width, height, color_depth);
 }
 
 Bitmap::Bitmap(Bitmap *src, const Rect &rc)
-    : _alBitmap(NULL)
+    : _alBitmap(nullptr)
     , _isDataOwner(false)
 {
     CreateSubBitmap(src, rc);
 }
 
 Bitmap::Bitmap(BITMAP *al_bmp, bool shared_data)
-    : _alBitmap(NULL)
+    : _alBitmap(nullptr)
     , _isDataOwner(false)
 {
     WrapAllegroBitmap(al_bmp, shared_data);
@@ -71,7 +71,7 @@ bool Bitmap::Create(int width, int height, int color_depth)
         _alBitmap = create_bitmap(width, height);
     }
     _isDataOwner = true;
-    return _alBitmap != NULL;
+    return _alBitmap != nullptr;
 }
 
 bool Bitmap::CreateTransparent(int width, int height, int color_depth)
@@ -89,7 +89,7 @@ bool Bitmap::CreateSubBitmap(Bitmap *src, const Rect &rc)
     Destroy();
     _alBitmap = create_sub_bitmap(src->_alBitmap, rc.Left, rc.Top, rc.GetWidth(), rc.GetHeight());
     _isDataOwner = true;
-    return _alBitmap != NULL;
+    return _alBitmap != nullptr;
 }
 
 bool Bitmap::CreateCopy(Bitmap *src, int color_depth)
@@ -107,7 +107,7 @@ bool Bitmap::WrapAllegroBitmap(BITMAP *al_bmp, bool shared_data)
     Destroy();
     _alBitmap = al_bmp;
     _isDataOwner = !shared_data;
-    return _alBitmap != NULL;
+    return _alBitmap != nullptr;
 }
 
 void Bitmap::Destroy()
@@ -116,7 +116,7 @@ void Bitmap::Destroy()
     {
         destroy_bitmap(_alBitmap);
     }
-    _alBitmap = NULL;
+    _alBitmap = nullptr;
     _isDataOwner = false;
 }
 
@@ -124,13 +124,13 @@ bool Bitmap::LoadFromFile(const char *filename)
 {
     Destroy();
 
-	BITMAP *al_bmp = load_bitmap(filename, NULL);
+	BITMAP *al_bmp = load_bitmap(filename, nullptr);
 	if (al_bmp)
 	{
 		_alBitmap = al_bmp;
         _isDataOwner = true;
 	}
-	return _alBitmap != NULL;
+	return _alBitmap != nullptr;
 }
 
 bool Bitmap::SaveToFile(const char *filename, const void *palette)
@@ -474,7 +474,7 @@ Bitmap *CreateRawBitmapOwner(BITMAP *al_bmp)
 	if (!bitmap->WrapAllegroBitmap(al_bmp, false))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }
@@ -485,7 +485,7 @@ Bitmap *CreateRawBitmapWrapper(BITMAP *al_bmp)
 	if (!bitmap->WrapAllegroBitmap(al_bmp, true))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -134,7 +134,7 @@ public:
     // Get scanline for direct reading
 	inline const unsigned char *GetScanLine(int index) const
     {
-        return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : NULL;
+        return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : nullptr;
     }
 
     void    SetMaskColor(color_t color);
@@ -216,7 +216,7 @@ public:
 	// Gets scanline for directly writing into it
     inline unsigned char *GetScanLineForWriting(int index)
     {
-        return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : NULL;
+        return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : nullptr;
     }
     inline unsigned char *GetDataForWriting()
     {

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -30,7 +30,7 @@ Bitmap *CreateBitmap(int width, int height, int color_depth)
 	if (!bitmap->Create(width, height, color_depth))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }
@@ -41,7 +41,7 @@ Bitmap *CreateTransparentBitmap(int width, int height, int color_depth)
 	if (!bitmap->CreateTransparent(width, height, color_depth))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }
@@ -52,7 +52,7 @@ Bitmap *CreateSubBitmap(Bitmap *src, const Rect &rc)
 	if (!bitmap->CreateSubBitmap(src, rc))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }
@@ -63,7 +63,7 @@ Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth)
 	if (!bitmap->CreateCopy(src, color_depth))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }
@@ -74,7 +74,7 @@ Bitmap *LoadFromFile(const char *filename)
 	if (!bitmap->LoadFromFile(filename))
 	{
 		delete bitmap;
-		bitmap = NULL;
+		bitmap = nullptr;
 	}
 	return bitmap;
 }

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -282,7 +282,7 @@ void GUIButton::DrawImageButton(Bitmap *ds, bool draw_disabled)
     // NOTE: the CLIP flag only clips the image, not the text
     if (IsClippingImage())
         ds->SetClip(Rect(X, Y, X + Width - 1, Y + Height - 1));
-    if (spriteset[CurrentImage] != NULL)
+    if (spriteset[CurrentImage] != nullptr)
         draw_gui_sprite(ds, CurrentImage, X, Y, true);
 
     // Draw active inventory item

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -134,7 +134,7 @@ int GUIMain::GetControlCount() const
 GUIObject *GUIMain::GetControl(int index) const
 {
     if (index < 0 || (size_t)index >= _controls.size())
-        return NULL;
+        return nullptr;
     return _controls[index];
 }
 
@@ -241,7 +241,7 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
 
     SET_EIP(378)
 
-    if (BgImage > 0 && spriteset[BgImage] != NULL)
+    if (BgImage > 0 && spriteset[BgImage] != nullptr)
         draw_gui_sprite(&subbmp, BgImage, 0, 0, false);
 
     SET_EIP(379)

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -44,7 +44,7 @@ class GUIObject
 {
 public:
     GUIObject();
-    virtual ~GUIObject(){}
+    virtual ~GUIObject() = default;
     
     String          GetEventArgs(int event) const;
     int             GetEventCount() const;

--- a/Common/gui/guislider.cpp
+++ b/Common/gui/guislider.cpp
@@ -154,7 +154,7 @@ void GUISlider::Draw(Common::Bitmap *ds)
     {
         // an image for the slider handle
         // TODO: react to sprites initialization/deletion instead!
-        if (spriteset[HandleImage] == NULL)
+        if (spriteset[HandleImage] == nullptr)
             HandleImage = 0;
 
         handle.Left -= get_adjusted_spritewidth(HandleImage) / 2;

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -36,7 +36,7 @@ void freadstring(char **strptr, Stream *in)
         idxx++;
 
     if (ibuffer[0] == 0) {
-        strptr[0] = NULL;
+        strptr[0] = nullptr;
         return;
     }
 
@@ -50,32 +50,32 @@ ccScript *ccScript::CreateFromStream(Stream *in)
     if (!scri->Read(in))
     {
         delete scri;
-        return NULL;
+        return nullptr;
     }
     return scri;
 }
 
 ccScript::ccScript()
 {
-    globaldata          = NULL;
+    globaldata          = nullptr;
     globaldatasize      = 0;
-    code                = NULL;
+    code                = nullptr;
     codesize            = 0;
-    strings             = NULL;
+    strings             = nullptr;
     stringssize         = 0;
-    fixuptypes          = NULL;
-    fixups              = NULL;
+    fixuptypes          = nullptr;
+    fixups              = nullptr;
     numfixups           = 0;
     importsCapacity     = 0;
-    imports             = NULL;
+    imports             = nullptr;
     numimports          = 0;
     exportsCapacity     = 0;
-    exports             = NULL;
-    export_addr         = NULL;
+    exports             = nullptr;
+    export_addr         = nullptr;
     numexports          = 0;
     instances           = 0;
-    sectionNames        = NULL;
-    sectionOffsets      = NULL;
+    sectionNames        = nullptr;
+    sectionOffsets      = nullptr;
     numSections         = 0;
     capacitySections    = 0;
 }
@@ -90,7 +90,7 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        globaldata = NULL;
+        globaldata = nullptr;
     }
 
     codesize = src.codesize;
@@ -101,7 +101,7 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        code = NULL;
+        code = nullptr;
     }
 
     stringssize = src.stringssize;
@@ -112,7 +112,7 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        strings = NULL;
+        strings = nullptr;
     }
 
     numfixups = src.numfixups;
@@ -125,8 +125,8 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        fixups = NULL;
-        fixuptypes = NULL;
+        fixups = nullptr;
+        fixuptypes = nullptr;
     }
 
     importsCapacity = src.numimports;
@@ -139,7 +139,7 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        imports = NULL;
+        imports = nullptr;
     }
 
     exportsCapacity = src.numexports;
@@ -156,8 +156,8 @@ ccScript::ccScript(const ccScript &src)
     }
     else
     {
-        exports = NULL;
-        export_addr = NULL;
+        exports = nullptr;
+        export_addr = nullptr;
     }
 
     capacitySections = src.numSections;
@@ -175,8 +175,8 @@ ccScript::ccScript(const ccScript &src)
     else
     {
         numSections = 0;
-        sectionNames = NULL;
-        sectionOffsets = NULL;
+        sectionNames = nullptr;
+        sectionOffsets = nullptr;
     }
 
     instances = 0;
@@ -248,7 +248,7 @@ bool ccScript::Read(Stream *in)
     in->Read(globaldata, globaldatasize);
   }
   else
-    globaldata = NULL;
+    globaldata = nullptr;
 
   if (codesize > 0) {
     code = (int32_t *)malloc(codesize * sizeof(int32_t));
@@ -259,7 +259,7 @@ bool ccScript::Read(Stream *in)
     in->ReadArrayOfInt32(code, codesize);
   }
   else
-    code = NULL;
+    code = nullptr;
 
   if (stringssize > 0) {
     strings = (char *)malloc(stringssize);
@@ -267,7 +267,7 @@ bool ccScript::Read(Stream *in)
     in->Read(strings, stringssize);
   } 
   else
-    strings = NULL;
+    strings = nullptr;
 
   numfixups = in->ReadInt32();
   if (numfixups > 0) {
@@ -278,8 +278,8 @@ bool ccScript::Read(Stream *in)
     in->ReadArrayOfInt32(fixups, numfixups);
   }
   else {
-    fixups = NULL;
-    fixuptypes = NULL;
+    fixups = nullptr;
+    fixuptypes = nullptr;
   }
 
   numimports = in->ReadInt32();
@@ -309,8 +309,8 @@ bool ccScript::Read(Stream *in)
   else
   {
     numSections = 0;
-    sectionNames = NULL;
-    sectionOffsets = NULL;
+    sectionNames = nullptr;
+    sectionOffsets = nullptr;
   }
 
   if (in->ReadInt32() != ENDFILESIG) {
@@ -322,30 +322,30 @@ bool ccScript::Read(Stream *in)
 
 void ccScript::Free()
 {
-    if (globaldata != NULL)
+    if (globaldata != nullptr)
         free(globaldata);
 
-    if (code != NULL)
+    if (code != nullptr)
         free(code);
 
-    if (strings != NULL)
+    if (strings != nullptr)
         free(strings);
 
-    if (fixups != NULL && numfixups > 0)
+    if (fixups != nullptr && numfixups > 0)
         free(fixups);
 
-    if (fixuptypes != NULL && numfixups > 0)
+    if (fixuptypes != nullptr && numfixups > 0)
         free(fixuptypes);
 
-    globaldata = NULL;
-    code = NULL;
-    strings = NULL;
-    fixups = NULL;
-    fixuptypes = NULL;
+    globaldata = nullptr;
+    code = nullptr;
+    strings = nullptr;
+    fixups = nullptr;
+    fixuptypes = nullptr;
 
     int aa;
     for (aa = 0; aa < numimports; aa++) {
-        if (imports[aa] != NULL)
+        if (imports[aa] != nullptr)
             free(imports[aa]);
     }
 
@@ -355,22 +355,22 @@ void ccScript::Free()
     for (aa = 0; aa < numSections; aa++)
         free(sectionNames[aa]);
 
-    if (sectionNames != NULL)
+    if (sectionNames != nullptr)
     {
         free(sectionNames);
         free(sectionOffsets);
-        sectionNames = NULL;
-        sectionOffsets = NULL;
+        sectionNames = nullptr;
+        sectionOffsets = nullptr;
     }
 
-    if (imports != NULL)
+    if (imports != nullptr)
     {
         free(imports);
         free(exports);
         free(export_addr);
-        imports = NULL;
-        exports = NULL;
-        export_addr = NULL;
+        imports = nullptr;
+        exports = nullptr;
+        export_addr = nullptr;
     }
     numimports = 0;
     numexports = 0;

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -372,7 +372,7 @@ void load_lzw(Stream *in, Bitmap **dst_bmp, int dst_bpp, color *pall) {
   update_polled_stuff_if_runtime();
 
   Bitmap *bmm = BitmapHelper::CreateBitmap((loptr[0] / dst_bpp), loptr[1], dst_bpp * 8);
-  if (bmm == NULL)
+  if (bmm == nullptr)
     quit("!load_room: not enough memory to load room background");
 
   update_polled_stuff_if_runtime();
@@ -416,7 +416,7 @@ void loadcompressed_allegro(Stream *in, Bitmap **bimpp, color *pall) {
   widd = in->ReadInt16();
   hitt = in->ReadInt16();
   Bitmap *bim = BitmapHelper::CreateBitmap(widd, hitt, 8);
-  if (bim == NULL)
+  if (bim == nullptr)
     quit("!load_room: not enough memory to decompress masks");
 
   for (ii = 0; ii < hitt; ii++) {

--- a/Common/util/datastream.cpp
+++ b/Common/util/datastream.cpp
@@ -24,9 +24,7 @@ DataStream::DataStream(DataEndianess stream_endianess)
 {
 }
 
-DataStream::~DataStream()
-{
-}
+DataStream::~DataStream() = default;
 
 int16_t DataStream::ReadInt16()
 {

--- a/Common/util/error.h
+++ b/Common/util/error.h
@@ -96,7 +96,7 @@ template <class T> class ErrorHandle
 public:
     static ErrorHandle<T> None() { return ErrorHandle(); }
 
-    ErrorHandle() {}
+    ErrorHandle() = default;
     ErrorHandle(T *err) : _error(err) {}
     ErrorHandle(std::shared_ptr<T> err) : _error(err) {}
 

--- a/Common/util/error.h
+++ b/Common/util/error.h
@@ -101,7 +101,7 @@ public:
     ErrorHandle(std::shared_ptr<T> err) : _error(err) {}
 
     bool HasError() const { return _error.get() != NULL; }
-    explicit operator bool() const { return _error.get() == NULL; }
+    explicit operator bool() const { return _error.get() == nullptr; }
     operator PError() const { return _error; }
     T *operator ->() const { return _error.operator->(); }
     T &operator *() const { return _error.operator*(); }

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -163,7 +163,7 @@ Stream *File::OpenFile(const String &filename, FileOpenMode open_mode, FileWorkM
     if (!fs->IsValid())
     {
         delete fs;
-        return NULL;
+        return nullptr;
     }
     return fs;
 }

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -22,7 +22,7 @@ namespace Common
 FileStream::FileStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode,
             DataEndianess stream_endianess)
     : DataStream(stream_endianess)
-    , _file(NULL)
+    , _file(nullptr)
     , _openMode(open_mode)
     , _workMode(work_mode)
 {
@@ -45,7 +45,7 @@ void FileStream::Close()
     {
         fclose(_file);
     }
-    _file = NULL;
+    _file = nullptr;
 }
 
 bool FileStream::Flush()
@@ -59,7 +59,7 @@ bool FileStream::Flush()
 
 bool FileStream::IsValid() const
 {
-    return _file != NULL;
+    return _file != nullptr;
 }
 
 bool FileStream::EOS() const

--- a/Common/util/lzw.cpp
+++ b/Common/util/lzw.cpp
@@ -128,7 +128,7 @@ void lzwcompress(Stream *lzw_in, Stream *out)
   char buf[17];
 
   lzbuffer = (char *)malloc(N + F + (N + 1 + N + N + 256) * sizeof(int));       // 28.5 k !
-  if (lzbuffer == NULL) {
+  if (lzbuffer == nullptr) {
     quit("unable to compress: out of memory");
   }
 
@@ -197,7 +197,7 @@ void lzwcompress(Stream *lzw_in, Stream *out)
 }
 
 int expand_to_mem = 0;
-unsigned char *membfptr = NULL;
+unsigned char *membfptr = nullptr;
 void myputc(int ccc, Stream *out)
 {
   if (maxsize > 0) {
@@ -222,7 +222,7 @@ void lzwexpand(Stream *lzw_in, Stream *out)
   putbytes = 0;
 
   lzbuffer = (char *)malloc(N);
-  if (lzbuffer == NULL) {
+  if (lzbuffer == nullptr) {
     quit("compress.cpp: unable to decompress: insufficient memory");
   }
   i = N - F;
@@ -270,6 +270,6 @@ unsigned char *lzwexpand_to_mem(Stream *in)
   unsigned char *membuff = (unsigned char *)malloc(maxsize + 10);
   expand_to_mem = 1;
   membfptr = membuff;
-  lzwexpand(in, NULL);
+  lzwexpand(in, nullptr);
   return membuff;
 }

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -81,17 +81,17 @@ char *ci_find_file(const char *dir_name, const char *file_name)
 char *ci_find_file(const char *dir_name, const char *file_name)
 {
   struct stat   statbuf;
-  struct dirent *entry     = NULL;
-  DIR           *rough     = NULL;
-  DIR           *prevdir   = NULL;
-  char          *diamond   = NULL;
-  char          *directory = NULL;
-  char          *filename  = NULL;
+  struct dirent *entry     = nullptr;
+  DIR           *rough     = nullptr;
+  DIR           *prevdir   = nullptr;
+  char          *diamond   = nullptr;
+  char          *directory = nullptr;
+  char          *filename  = nullptr;
 
-  if (dir_name == NULL && file_name == NULL)
-      return NULL;
+  if (dir_name == nullptr && file_name == nullptr)
+      return nullptr;
 
-  if (dir_name != NULL) {
+  if (dir_name != nullptr) {
     directory = (char *)malloc(strlen(dir_name) + 1);
     strcpy(directory, dir_name);
 
@@ -99,7 +99,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     fix_filename_slashes(directory);
   }
 
-  if (file_name != NULL) {
+  if (file_name != nullptr) {
     filename = (char *)malloc(strlen(file_name) + 1);
     strcpy(filename, file_name);
 
@@ -107,14 +107,14 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     fix_filename_slashes(filename);
   }
 
-  if (directory == NULL) {
-    char  *match    = NULL;
+  if (directory == nullptr) {
+    char  *match    = nullptr;
     int   match_len = 0;
     int   dir_len   = 0;
 
     match = get_filename(filename);
-    if (match == NULL)
-      return NULL;
+    if (match == nullptr)
+      return nullptr;
 
     match_len = strlen(match);
     dir_len   = (match - filename);
@@ -133,22 +133,22 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     filename[match_len] = '\0';
   }
 
-  if ((prevdir = opendir(".")) == NULL) {
+  if ((prevdir = opendir(".")) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open current working directory\n");
-    return NULL;
+    return nullptr;
   }
 
   if (chdir(directory) == -1) {
     fprintf(stderr, "ci_find_file: cannot change to directory: %s\n", directory);
-    return NULL;
+    return nullptr;
   }
   
-  if ((rough = opendir(directory)) == NULL) {
+  if ((rough = opendir(directory)) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open directory: %s\n", directory);
-    return NULL;
+    return nullptr;
   }
 
-  while ((entry = readdir(rough)) != NULL) {
+  while ((entry = readdir(rough)) != nullptr) {
     lstat(entry->d_name, &statbuf);
     if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
       if (strcasecmp(filename, entry->d_name) == 0) {
@@ -180,12 +180,12 @@ Stream *ci_fopen(const char *file_name, FileOpenMode open_mode, FileWorkMode wor
 #if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)
   return File::OpenFile(file_name, open_mode, work_mode);
 #else
-  Stream *fs = NULL;
-  char *fullpath = ci_find_file(NULL, (char*)file_name);
+  Stream *fs = nullptr;
+  char *fullpath = ci_find_file(nullptr, (char*)file_name);
 
   /* If I didn't find a file, this could be writing a new file,
       so use whatever file_name they passed */
-  if (fullpath == NULL) {
+  if (fullpath == nullptr) {
     fs = File::OpenFile(file_name, open_mode, work_mode);
   } else {
     fs = File::OpenFile(fullpath, open_mode, work_mode);

--- a/Common/util/mutifilelib.cpp
+++ b/Common/util/mutifilelib.cpp
@@ -60,7 +60,7 @@ namespace MFLUtil
 MFLUtil::MFLError MFLUtil::TestIsMFL(Stream *in, bool test_is_main)
 {
     MFLVersion lib_version;
-    MFLError err = ReadSigsAndVersion(in, &lib_version, NULL);
+    MFLError err = ReadSigsAndVersion(in, &lib_version, nullptr);
     if (err == kMFLNoError)
     {
         if (lib_version >= kMFLVersion_MultiV10 && test_is_main)

--- a/Common/util/proxystream.cpp
+++ b/Common/util/proxystream.cpp
@@ -36,7 +36,7 @@ void ProxyStream::Close()
     {
         delete _stream;
     }
-    _stream = NULL;
+    _stream = nullptr;
 }
 
 bool ProxyStream::Flush()

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -32,35 +32,35 @@ String::Header::Header()
     : RefCount(0)
     , Capacity(0)
     , Length(0)
-    , CStr(NULL)
+    , CStr(nullptr)
 {
 }
 
 String::String()
-    : _data(NULL)
+    : _data(nullptr)
 {
 }
 
 String::String(const String &str)
-    : _data(NULL)
+    : _data(nullptr)
 {
     *this = str;
 }
 
 String::String(const char *cstr)
-    :_data(NULL)
+    :_data(nullptr)
 {
     *this = cstr;
 }
 
 String::String(const char *cstr, size_t length)
-    : _data(NULL)
+    : _data(nullptr)
 {
     SetString(cstr, length);
 }
 
 String::String(char c, size_t count)
-    : _data(NULL)
+    : _data(nullptr)
 {
     FillString(c, count);
 }
@@ -595,7 +595,7 @@ void String::FormatV(const char *fcstr, va_list argptr)
     fcstr = fcstr ? fcstr : "";
     va_list argptr_cpy;
     va_copy(argptr_cpy, argptr);
-    size_t length = vsnprintf(NULL, 0u, fcstr, argptr);
+    size_t length = vsnprintf(nullptr, 0u, fcstr, argptr);
     ReserveAndShift(false, Math::Surplus(length, GetLength()));
     vsprintf(_meta->CStr, fcstr, argptr_cpy);
     va_end(argptr_cpy);
@@ -614,7 +614,7 @@ void String::Free()
             delete [] _data;
         }
     }
-    _data = NULL;
+    _data = nullptr;
 }
 
 void String::MakeLower()

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -35,7 +35,7 @@ void unescape(char *buffer) {
     else
         offset = buffer;
     // Replace all other occurrences as they're found
-    while((offset = strchr(offset, '[')) != NULL) {
+    while((offset = strchr(offset, '[')) != nullptr) {
         if(offset[-1] != '\\')
             offset[0] = '\n';
         else

--- a/Common/util/textreader.h
+++ b/Common/util/textreader.h
@@ -28,7 +28,7 @@ namespace Common
 class TextReader
 {
 public:
-    virtual ~TextReader(){}
+    virtual ~TextReader() = default;
 
     virtual bool IsValid() const            = 0;
 

--- a/Common/util/textstreamreader.cpp
+++ b/Common/util/textstreamreader.cpp
@@ -44,7 +44,7 @@ const Stream *TextStreamReader::GetStream() const
 
 void TextStreamReader::ReleaseStream()
 {
-    _stream = NULL;
+    _stream = nullptr;
 }
 
 bool TextStreamReader::EOS() const

--- a/Common/util/textstreamwriter.cpp
+++ b/Common/util/textstreamwriter.cpp
@@ -52,7 +52,7 @@ const Stream *TextStreamWriter::GetStream() const
 
 void TextStreamWriter::ReleaseStream()
 {
-    _stream = NULL;
+    _stream = nullptr;
 }
 
 bool TextStreamWriter::EOS() const
@@ -100,7 +100,7 @@ void TextStreamWriter::WriteFormat(const char *fmt, ...)
 
     va_list argptr;
     va_start(argptr, fmt);
-    int need_length = vsnprintf(NULL, 0, fmt, argptr);
+    int need_length = vsnprintf(nullptr, 0, fmt, argptr);
     va_start(argptr, fmt); // Reset argptr
     char *buffer    = new char[need_length + 1];
     vsprintf(buffer, fmt, argptr);

--- a/Common/util/textwriter.h
+++ b/Common/util/textwriter.h
@@ -28,7 +28,7 @@ namespace Common
 class TextWriter
 {
 public:
-    virtual ~TextWriter(){}
+    virtual ~TextWriter() = default;
 
     virtual bool    IsValid() const                         = 0;
 

--- a/Common/util/wgt2allg.cpp
+++ b/Common/util/wgt2allg.cpp
@@ -67,8 +67,8 @@ extern "C"
 
     tempbitm = BitmapHelper::CreateBitmap(twid, thit);
 
-    if (tempbitm == NULL)
-      return NULL;
+    if (tempbitm == nullptr)
+      return nullptr;
 
     tempbitm->Blit(src, x1, y1, 0, 0, tempbitm->GetWidth(), tempbitm->GetHeight());
     return tempbitm;
@@ -81,7 +81,7 @@ extern "C"
     int numspri = 0, vv, hh, wdd, htt;
 
     Stream *in = Common::AssetManager::OpenAsset(filnam);
-    if (in == NULL)
+    if (in == nullptr)
       return -1;
 
     vers = in->ReadInt16();
@@ -101,13 +101,13 @@ extern "C"
     }
 
     for (vv = strt; vv <= eend; vv++)
-      sarray[vv] = NULL;
+      sarray[vv] = nullptr;
 
     for (vv = 0; vv <= numspri; vv++) {
       int coldep = in->ReadInt16();
 
       if (coldep == 0) {
-        sarray[vv] = NULL;
+        sarray[vv] = nullptr;
         if (in->EOS())
           break;
 
@@ -128,7 +128,7 @@ extern "C"
       }
       sarray[vv] = BitmapHelper::CreateBitmap(wdd, htt, coldep * 8);
 
-      if (sarray[vv] == NULL) {
+      if (sarray[vv] == nullptr) {
         delete in;
         return -1;
       }

--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -77,7 +77,7 @@ ScriptAudioClip* AudioChannel_GetPlayingClip(ScriptAudioChannel *channel)
     {
         return (ScriptAudioClip*)ch->sourceClip;
     }
-    return NULL;
+    return nullptr;
 }
 
 int AudioChannel_GetPosition(ScriptAudioChannel *channel)

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -95,7 +95,7 @@ int char_lowest_yp;
 int face_talking=-1,facetalkview=0,facetalkwait=0,facetalkframe=0;
 int facetalkloop=0, facetalkrepeat = 0, facetalkAllowBlink = 1;
 int facetalkBlinkLoop = 0;
-CharacterInfo *facetalkchar = NULL;
+CharacterInfo *facetalkchar = nullptr;
 // Do override default portrait position during QFG4-style speech overlay update
 bool facetalk_qfg4_override_placement_x = false;
 bool facetalk_qfg4_override_placement_y = false;
@@ -103,8 +103,8 @@ bool facetalk_qfg4_override_placement_y = false;
 // lip-sync speech settings
 int loops_per_character, text_lips_offset, char_speaking = -1;
 int char_thinking = -1;
-const char *text_lips_text = NULL;
-SpeechLipSyncLine *splipsync = NULL;
+const char *text_lips_text = nullptr;
+SpeechLipSyncLine *splipsync = nullptr;
 int numLipLines = 0, curLipLine = -1, curLipLinePhoneme = 0;
 
 // **** CHARACTER: FUNCTIONS ****
@@ -112,7 +112,7 @@ int numLipLines = 0, curLipLine = -1, curLipLinePhoneme = 0;
 void Character_AddInventory(CharacterInfo *chaa, ScriptInvItem *invi, int addIndex) {
     int ee;
 
-    if (invi == NULL)
+    if (invi == nullptr)
         quit("!AddInventoryToCharacter: invalid invnetory number");
 
     int inum = invi->id;
@@ -430,7 +430,7 @@ void FaceLocationXY(CharacterInfo *char1, int xx, int yy, int blockingStyle)
 
 void Character_FaceDirection(CharacterInfo *char1, int direction, int blockingStyle)
 {
-    if (char1 == NULL)
+    if (char1 == nullptr)
         quit("!FaceDirection: invalid character specified");
 
     if (direction != SCR_NO_VALUE)
@@ -444,21 +444,21 @@ void Character_FaceDirection(CharacterInfo *char1, int direction, int blockingSt
 
 void Character_FaceLocation(CharacterInfo *char1, int xx, int yy, int blockingStyle)
 {
-    if (char1 == NULL)
+    if (char1 == nullptr)
         quit("!FaceLocation: invalid character specified");
 
     FaceLocationXY(char1, xx, yy, blockingStyle);
 }
 
 void Character_FaceObject(CharacterInfo *char1, ScriptObject *obj, int blockingStyle) {
-    if (obj == NULL) 
+    if (obj == nullptr) 
         quit("!FaceObject: invalid object specified");
 
     FaceLocationXY(char1, objs[obj->id].x, objs[obj->id].y, blockingStyle);
 }
 
 void Character_FaceCharacter(CharacterInfo *char1, CharacterInfo *char2, int blockingStyle) {
-    if (char2 == NULL) 
+    if (char2 == nullptr) 
         quit("!FaceCharacter: invalid character specified");
 
     if (char1->room != char2->room)
@@ -472,11 +472,11 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
     if ((eagerness < 0) || (eagerness > 250))
         quit("!FollowCharacterEx: invalid eagerness: must be 0-250");
 
-    if ((chaa->index_id == game.playercharacter) && (tofollow != NULL) && 
+    if ((chaa->index_id == game.playercharacter) && (tofollow != nullptr) && 
         (tofollow->room != chaa->room))
         quit("!FollowCharacterEx: you cannot tell the player character to follow a character in another room");
 
-    if (tofollow != NULL) {
+    if (tofollow != nullptr) {
         debug_script_log("%s: Start following %s (dist %d, eager %d)", chaa->scrname, tofollow->scrname, distaway, eagerness);
     }
     else {
@@ -490,7 +490,7 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
             chaa->baseline = -1;
     }
 
-    if (tofollow == NULL)
+    if (tofollow == nullptr)
         chaa->following = -1;
     else
         chaa->following = tofollow->index_id;
@@ -512,7 +512,7 @@ void Character_FollowCharacter(CharacterInfo *chaa, CharacterInfo *tofollow, int
 }
 
 int Character_IsCollidingWithChar(CharacterInfo *char1, CharacterInfo *char2) {
-    if (char2 == NULL)
+    if (char2 == nullptr)
         quit("!AreCharactersColliding: invalid char2");
 
     if (char1->room != char2->room) return 0; // not colliding
@@ -531,7 +531,7 @@ int Character_IsCollidingWithChar(CharacterInfo *char1, CharacterInfo *char2) {
 }
 
 int Character_IsCollidingWithObject(CharacterInfo *chin, ScriptObject *objid) {
-    if (objid == NULL)
+    if (objid == nullptr)
         quit("!AreCharObjColliding: invalid object number");
 
     if (chin->room != displayed_room)
@@ -539,13 +539,13 @@ int Character_IsCollidingWithObject(CharacterInfo *chin, ScriptObject *objid) {
     if (objs[objid->id].on != 1)
         return 0;
 
-    Bitmap *checkblk = GetObjectImage(objid->id, NULL);
+    Bitmap *checkblk = GetObjectImage(objid->id, nullptr);
     int objWidth = checkblk->GetWidth();
     int objHeight = checkblk->GetHeight();
     int o1x = objs[objid->id].x;
     int o1y = objs[objid->id].y - game_to_data_coord(objHeight);
 
-    Bitmap *charpic = GetCharacterImage(chin->index_id, NULL);
+    Bitmap *charpic = GetCharacterImage(chin->index_id, nullptr);
 
     int charWidth = charpic->GetWidth();
     int charHeight = charpic->GetHeight();
@@ -696,7 +696,7 @@ void Character_LockViewOffsetEx(CharacterInfo *chap, int vii, int xoffs, int yof
 
 void Character_LoseInventory(CharacterInfo *chap, ScriptInvItem *invi) {
 
-    if (invi == NULL)
+    if (invi == nullptr)
         quit("!LoseInventoryFromCharacter: invalid invnetory number");
 
     int inum = invi->id;
@@ -1102,7 +1102,7 @@ bool Character_SetTextProperty(CharacterInfo *chaa, const char *property, const 
 ScriptInvItem* Character_GetActiveInventory(CharacterInfo *chaa) {
 
     if (chaa->activeinv <= 0)
-        return NULL;
+        return nullptr;
 
     return &scrInv[chaa->activeinv];
 }
@@ -1110,7 +1110,7 @@ ScriptInvItem* Character_GetActiveInventory(CharacterInfo *chaa) {
 void Character_SetActiveInventory(CharacterInfo *chaa, ScriptInvItem* iit) {
     guis_need_update = 1;
 
-    if (iit == NULL) {
+    if (iit == nullptr) {
         chaa->activeinv = -1;
 
         if (chaa->index_id == game.playercharacter) {
@@ -1285,7 +1285,7 @@ int Character_GetIInventoryQuantity(CharacterInfo *chaa, int index) {
 
 int Character_HasInventory(CharacterInfo *chaa, ScriptInvItem *invi)
 {
-    if (invi == NULL)
+    if (invi == nullptr)
         quit("!Character.HasInventory: NULL inventory item supplied");
 
     return (chaa->inv[invi->id] > 0) ? 1 : 0;
@@ -1858,7 +1858,7 @@ int has_hit_another_character(int sourceChar) {
         if (ww == sourceChar) continue;
         if (game.chars[ww].flags & CHF_NOBLOCKING) continue;
 
-        if (is_char_on_another (sourceChar, ww, NULL, NULL)) {
+        if (is_char_on_another (sourceChar, ww, nullptr, nullptr)) {
             // we are now overlapping character 'ww'
             if ((game.chars[ww].walking) && 
                 ((game.chars[ww].flags & CHF_AWAITINGMOVE) == 0))
@@ -2170,7 +2170,7 @@ Bitmap *GetCharacterImage(int charid, int *isFlipped)
 {
     if (!gfxDriver->HasAcceleratedTransform())
     {
-        if (actsps[charid + MAX_ROOM_OBJECTS] != NULL) 
+        if (actsps[charid + MAX_ROOM_OBJECTS] != nullptr) 
         {
             // the actsps image is pre-flipped, so no longer register the image as such
             if (isFlipped)
@@ -2186,7 +2186,7 @@ Bitmap *GetCharacterImage(int charid, int *isFlipped)
 CharacterInfo *GetCharacterAtScreen(int xx, int yy) {
     int hsnum = GetCharIDAtScreen(xx, yy);
     if (hsnum < 0)
-        return NULL;
+        return nullptr;
     return &game.chars[hsnum];
 }
 
@@ -2194,7 +2194,7 @@ CharacterInfo *GetCharacterAtRoom(int x, int y)
 {
     int hsnum = is_pos_on_character(x, y);
     if (hsnum < 0)
-        return NULL;
+        return nullptr;
     return &game.chars[hsnum];
 }
 
@@ -2445,7 +2445,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     text_lips_offset = 0;
     text_lips_text = texx;
 
-    Bitmap *closeupface=NULL;
+    Bitmap *closeupface=nullptr;
     if (texx[0]=='&') {
         // auto-speech
         int igr=atoi(&texx[1]);
@@ -2810,12 +2810,12 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     _display_at(tdxp,tdyp,bwidth,texx,0,textcol, isThought, allowShrink, overlayPositionFixed);
     our_eip=156;
     if ((play.in_conversation > 0) && (game.options[OPT_SPEECHTYPE] == 3))
-        closeupface = NULL;
-    if (closeupface!=NULL)
+        closeupface = nullptr;
+    if (closeupface!=nullptr)
         remove_screen_overlay(ovr_type);
     mark_screen_dirty();
     face_talking = -1;
-    facetalkchar = NULL;
+    facetalkchar = nullptr;
     our_eip=157;
     if (oldview>=0) {
         speakingChar->flags &= ~CHF_FIXVIEW;

--- a/Engine/ac/datetime.cpp
+++ b/Engine/ac/datetime.cpp
@@ -20,7 +20,7 @@
 ScriptDateTime* DateTime_Now_Core() {
     ScriptDateTime *sdt = new ScriptDateTime();
     // TODO: check if it's okay to use larger storage for time() result
-    sdt->rawUnixTime = static_cast<int>(time(NULL));
+    sdt->rawUnixTime = static_cast<int>(time(nullptr));
 
     platform->GetSystemTime(sdt);
 

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -228,12 +228,12 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
           break;
 
         case DCMD_OPTOFF:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           SetDialogOption(dialogID, param1 + 1, 0, true);
           break;
 
         case DCMD_OPTON:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           SetDialogOption(dialogID, param1 + 1, DFLG_ON, true);
           break;
 
@@ -247,29 +247,29 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
           break;
 
         case DCMD_OPTOFFFOREVER:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           SetDialogOption(dialogID, param1 + 1, DFLG_OFFPERM, true);
           break;
 
         case DCMD_RUNTEXTSCRIPT:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           result = run_dialog_request(param1);
           script_running = (result == RUN_DIALOG_STAY);
           break;
 
         case DCMD_GOTODIALOG:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           result = param1;
           script_running = false;
           break;
 
         case DCMD_PLAYSOUND:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           play_sound(param1);
           break;
 
         case DCMD_ADDINV:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           add_inventory(param1);
           break;
 
@@ -279,7 +279,7 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
           break;
 
         case DCMD_NEWROOM:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           NewRoom(param1);
           in_new_room = 1;
           result = RUN_DIALOG_STOP_DIALOG;
@@ -292,7 +292,7 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
           break;
 
         case DCMD_GIVESCORE:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           GiveScore(param1);
           break;
 
@@ -302,7 +302,7 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
           break;
 
         case DCMD_LOSEINV:
-          get_dialog_script_parameters(script, &param1, NULL);
+          get_dialog_script_parameters(script, &param1, nullptr);
           lose_inventory(param1);
           break;
 
@@ -486,10 +486,10 @@ void DialogOptions::Prepare(int _dlgnum, bool _runGameLoopsInBackground)
   linespacing = getfontspacing_outlined(usingfont);
   curswas=cur_cursor;
   bullet_wid = 0;
-  ddb = NULL;
-  subBitmap = NULL;
-  parserInput = NULL;
-  dtop = NULL;
+  ddb = nullptr;
+  subBitmap = nullptr;
+  parserInput = nullptr;
+  dtop = nullptr;
 
   if ((dlgnum < 0) || (dlgnum >= game.numdialog))
     quit("!RunDialog: invalid dialog number specified");
@@ -543,7 +543,7 @@ void DialogOptions::Show()
   if (numdisp<1) quit("!DoDialog: all options have been turned off");
   // Don't display the options if there is only one and the parser
   // is not enabled.
-  if (!((numdisp > 1) || (parserInput != NULL) || (play.show_single_dialog_option)))
+  if (!((numdisp > 1) || (parserInput != nullptr) || (play.show_single_dialog_option)))
   {
       chose = disporder[0];  // only one choice, so select it
       return;
@@ -709,8 +709,8 @@ void DialogOptions::Redraw()
         xspos = (ui_view.GetWidth() - areawid) - get_fixed_pixel_size(10);
 
       // needs to draw the right text window, not the default
-      Bitmap *text_window_ds = NULL;
-      draw_text_window(&text_window_ds, false, &txoffs,&tyoffs,&xspos,&yspos,&areawid,NULL,needheight, game.options[OPT_DIALOGIFACE]);
+      Bitmap *text_window_ds = nullptr;
+      draw_text_window(&text_window_ds, false, &txoffs,&tyoffs,&xspos,&yspos,&areawid,nullptr,needheight, game.options[OPT_DIALOGIFACE]);
       options_surface_has_alpha = guis[game.options[OPT_DIALOGIFACE]].HasAlphaChannel();
       // since draw_text_window incrases the width, restore it
       areawid = savedwid;
@@ -829,15 +829,15 @@ void DialogOptions::Redraw()
       subBitmap->Blit(tempScrn, dirtyx, dirtyy, 0, 0, dirtywidth, dirtyheight);
     }
 
-    if ((ddb != NULL) && 
+    if ((ddb != nullptr) && 
       ((ddb->GetWidth() != dirtywidth) ||
        (ddb->GetHeight() != dirtyheight)))
     {
       gfxDriver->DestroyDDB(ddb);
-      ddb = NULL;
+      ddb = nullptr;
     }
     
-    if (ddb == NULL)
+    if (ddb == nullptr)
       ddb = gfxDriver->CreateDDBFromBitmap(subBitmap, options_surface_has_alpha, false);
     else
       gfxDriver->UpdateDDBFromBitmap(ddb, subBitmap, options_surface_has_alpha);
@@ -942,7 +942,7 @@ bool DialogOptions::Run()
         if ((mouseison<0) | (mouseison>=numdisp)) mouseison=-1;
       }
 
-      if (parserInput != NULL) {
+      if (parserInput != nullptr) {
         int relativeMousey = mousey;
         if (usingCustomRendering)
           relativeMousey -= dirtyy;
@@ -1063,10 +1063,10 @@ void DialogOptions::Close()
 
   if (parserInput) {
     delete parserInput;
-    parserInput = NULL;
+    parserInput = nullptr;
   }
 
-  if (ddb != NULL)
+  if (ddb != nullptr)
     gfxDriver->DestroyDDB(ddb);
   delete subBitmap;
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -523,7 +523,7 @@ int wgettextwidth_compensate(const char *tex, int font) {
 
 void do_corner(Bitmap *ds, int sprn, int x, int y, int offx, int offy) {
     if (sprn<0) return;
-    if (spriteset[sprn] == NULL)
+    if (spriteset[sprn] == nullptr)
     {
         sprn = 0;
     }
@@ -541,7 +541,7 @@ int get_but_pic(GUIMain*guo,int indx)
 
 void draw_button_background(Bitmap *ds, int xx1,int yy1,int xx2,int yy2,GUIMain*iep) {
     color_t draw_color;
-    if (iep==NULL) {  // standard window
+    if (iep==nullptr) {  // standard window
         draw_color = ds->GetCompatibleColor(15);
         ds->FillRect(Rect(xx1,yy1,xx2,yy2), draw_color);
         draw_color = ds->GetCompatibleColor(16);
@@ -668,7 +668,7 @@ void draw_text_window(Bitmap **text_window_ds, bool should_free_ds,
     if (ifnum <= 0) {
         if (ovrheight)
             quit("!Cannot use QFG4 style options without custom text window");
-        draw_button_background(ds, 0,0,ds->GetWidth() - 1,ds->GetHeight() - 1,NULL);
+        draw_button_background(ds, 0,0,ds->GetWidth() - 1,ds->GetHeight() - 1,nullptr);
         if (set_text_color)
             *set_text_color = ds->GetCompatibleColor(16);
         xins[0]=3;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -132,9 +132,9 @@ color palette[256];
 COLOR_MAP maincoltable;
 
 IGraphicsDriver *gfxDriver;
-IDriverDependantBitmap *blankImage = NULL;
-IDriverDependantBitmap *blankSidebarImage = NULL;
-IDriverDependantBitmap *debugConsole = NULL;
+IDriverDependantBitmap *blankImage = nullptr;
+IDriverDependantBitmap *blankSidebarImage = nullptr;
+IDriverDependantBitmap *debugConsole = nullptr;
 
 // actsps is used for temporary storage of the bitamp image
 // of the latest version of the sprite
@@ -148,11 +148,11 @@ CachedActSpsData* actspswbcache;
 
 bool current_background_is_dirty = false;
 
-Bitmap *sub_vscreen = NULL;
+Bitmap *sub_vscreen = nullptr;
 int wasShakingScreen = 0;
 
 // Room background sprite
-IDriverDependantBitmap* roomBackgroundBmp = NULL;
+IDriverDependantBitmap* roomBackgroundBmp = nullptr;
 // Intermediate bitmap for the software drawing method.
 // We use this bitmap in case room camera has scaling enabled, we draw dirty room rects on it,
 // and then pass to software renderer which draws sprite on top and then either blits or stretch-blits
@@ -165,22 +165,22 @@ PBitmap RoomCameraFrame;   // this is either same bitmap reference or sub-bitmap
 std::vector<SpriteListEntry> sprlist;
 std::vector<SpriteListEntry> thingsToDrawList;
 
-Bitmap **guibg = NULL;
-IDriverDependantBitmap **guibgbmp = NULL;
+Bitmap **guibg = nullptr;
+IDriverDependantBitmap **guibgbmp = nullptr;
 
 
-Bitmap *debugConsoleBuffer = NULL;
+Bitmap *debugConsoleBuffer = nullptr;
 
 // whether there are currently remnants of a DisplaySpeech
 bool screen_is_dirty = false;
 
-Bitmap *raw_saved_screen = NULL;
+Bitmap *raw_saved_screen = nullptr;
 Bitmap *dynamicallyCreatedSurfaces[MAX_DYNAMIC_SURFACES];
 
 
 SpriteListEntry::SpriteListEntry()
-    : bmp(NULL)
-    , pic(NULL)
+    : bmp(nullptr)
+    , pic(nullptr)
     , baseline(0), x(0), y(0)
     , transparent(0)
     , takesPriorityIfEqual(false), hasAlphaChannel(false)
@@ -198,7 +198,7 @@ void allegro_bitmap_test_draw()
         test_allegro_bitmap->FillTransparent();
 		test_allegro_bitmap->FillRect(Rect(50,50,150,150), 15);
 
-		if (test_allegro_ddb == NULL) 
+		if (test_allegro_ddb == nullptr) 
         {
             test_allegro_ddb = gfxDriver->CreateDDBFromBitmap(test_allegro_bitmap, false, true);
         }
@@ -535,8 +535,8 @@ void destroy_blank_image()
         gfxDriver->DestroyDDB(blankImage);
     if (blankSidebarImage)
         gfxDriver->DestroyDDB(blankSidebarImage);
-    blankImage = NULL;
-    blankSidebarImage = NULL;
+    blankImage = nullptr;
+    blankSidebarImage = nullptr;
 }
 
 int MakeColor(int color_index)
@@ -581,7 +581,7 @@ void on_mainviewport_changed()
     if (gfxDriver->UsesMemoryBackBuffer())
     {
         const Rect &main_view = play.GetMainViewport();
-        gfxDriver->SetMemoryBackBuffer(NULL); // make it restore original virtual screen
+        gfxDriver->SetMemoryBackBuffer(nullptr); // make it restore original virtual screen
         if (main_view.GetSize() != game.GetGameRes())
         {
             delete sub_vscreen;
@@ -715,11 +715,11 @@ void render_to_screen(int atx, int aty)
     const Rect &viewport = play.GetMainViewport();
     // For software renderer, need to blacken upper part of the game frame when shaking screen moves image down
     if (aty > 0 && wasShakingScreen && gfxDriver->UsesMemoryBackBuffer())
-        gfxDriver->ClearRectangle(viewport.Left, viewport.Top, viewport.GetWidth() - 1, aty, NULL);
+        gfxDriver->ClearRectangle(viewport.Left, viewport.Top, viewport.GetWidth() - 1, aty, nullptr);
     render_black_borders(atx, aty);
 
     if(pl_any_want_hook(AGSE_FINALSCREENDRAW))
-        gfxDriver->DrawSprite(AGSE_FINALSCREENDRAW, 0, NULL);
+        gfxDriver->DrawSprite(AGSE_FINALSCREENDRAW, 0, nullptr);
 
     // only vsync in full screen mode, it makes things worse
     // in a window
@@ -753,8 +753,8 @@ void render_to_screen(int atx, int aty)
 void clear_letterbox_borders()
 {
     const Rect &viewport = play.GetMainViewport();
-    gfxDriver->ClearRectangle(0, 0, game.GetGameRes().Width - 1, viewport.Top - 1, NULL);
-    gfxDriver->ClearRectangle(0, viewport.Bottom + 1, game.GetGameRes().Width - 1, game.GetGameRes().Height - 1, NULL);
+    gfxDriver->ClearRectangle(0, 0, game.GetGameRes().Width - 1, viewport.Top - 1, nullptr);
+    gfxDriver->ClearRectangle(0, viewport.Bottom + 1, game.GetGameRes().Width - 1, game.GetGameRes().Height - 1, nullptr);
 }
 
 // writes the virtual screen to the screen, converting colours if
@@ -843,7 +843,7 @@ void draw_sprite_slot_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int
 
 
 IDriverDependantBitmap* recycle_ddb_bitmap(IDriverDependantBitmap *bimp, Bitmap *source, bool hasAlpha, bool opaque) {
-    if (bimp != NULL) {
+    if (bimp != nullptr) {
         // same colour depth, width and height -> reuse
         if (((bimp->GetColorDepth() + 1) / 8 == source->GetBPP()) && 
             (bimp->GetWidth() == source->GetWidth()) && (bimp->GetHeight() == source->GetHeight()))
@@ -866,7 +866,7 @@ void invalidate_cached_walkbehinds()
 // sort_out_walk_behinds: modifies the supplied sprite by overwriting parts
 // of it with transparent pixels where there are walk-behind areas
 // Returns whether any pixels were updated
-int sort_out_walk_behinds(Bitmap *sprit,int xx,int yy,int basel, Bitmap *copyPixelsFrom = NULL, Bitmap *checkPixelsFrom = NULL, int zoom=100) {
+int sort_out_walk_behinds(Bitmap *sprit,int xx,int yy,int basel, Bitmap *copyPixelsFrom = nullptr, Bitmap *checkPixelsFrom = nullptr, int zoom=100) {
     if (noWalkBehindsAtAll)
         return 0;
 
@@ -886,7 +886,7 @@ int sort_out_walk_behinds(Bitmap *sprit,int xx,int yy,int basel, Bitmap *copyPix
     if (xx < 0)
         ee = 0 - xx;
 
-    if ((checkPixelsFrom != NULL) && (checkPixelsFrom->GetColorDepth() != spcoldep))
+    if ((checkPixelsFrom != nullptr) && (checkPixelsFrom->GetColorDepth() != spcoldep))
         quit("sprite colour depth does not match background colour depth");
 
     for ( ; ee < sprit->GetWidth(); ee++) {
@@ -925,7 +925,7 @@ int sort_out_walk_behinds(Bitmap *sprit,int xx,int yy,int basel, Bitmap *copyPix
             if (tmm<1) continue;
             if (croom->walkbehind_base[tmm] <= basel) continue;
 
-            if (copyPixelsFrom != NULL)
+            if (copyPixelsFrom != nullptr)
             {
                 if (spcoldep <= 8)
                 {
@@ -1021,7 +1021,7 @@ void clear_draw_list() {
 }
 void add_thing_to_draw(IDriverDependantBitmap* bmp, int x, int y, int trans, bool alphaChannel) {
     SpriteListEntry sprite;
-    sprite.pic = NULL;
+    sprite.pic = nullptr;
     sprite.bmp = bmp;
     sprite.x = x;
     sprite.y = y;
@@ -1038,7 +1038,7 @@ void clear_sprite_list() {
 }
 void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, int sprNum, bool isWalkBehind) {
 
-    if (spp == NULL)
+    if (spp == nullptr)
         quit("add_to_sprite_list: attempted to draw NULL sprite");
     // completely invisible, so don't draw it at all
     if (trans == 255)
@@ -1135,7 +1135,7 @@ void draw_sprite_list() {
     {
         for (int ee = 1; ee < MAX_WALK_BEHINDS; ee++)
         {
-            if (walkBehindBitmap[ee] != NULL)
+            if (walkBehindBitmap[ee] != nullptr)
             {
                 // TODO: perhaps do not add camera position here, instead let the renderer do coordinate transform
                 add_to_sprite_list(walkBehindBitmap[ee], walkBehindLeft[ee] - play.GetRoomCamera().Left, walkBehindTop[ee] - play.GetRoomCamera().Top,
@@ -1149,7 +1149,7 @@ void draw_sprite_list() {
     clear_draw_list();
 
     if(pl_any_want_hook(AGSE_PRESCREENDRAW))
-        add_thing_to_draw(NULL, AGSE_PRESCREENDRAW, 0, TRANS_RUN_PLUGIN, false);
+        add_thing_to_draw(nullptr, AGSE_PRESCREENDRAW, 0, TRANS_RUN_PLUGIN, false);
 
     // copy the sorted sprites into the Things To Draw list
     thingsToDrawList.insert(thingsToDrawList.end(), sprlist.begin(), sprlist.end());
@@ -1157,7 +1157,7 @@ void draw_sprite_list() {
 
 // Avoid freeing and reallocating the memory if possible
 Bitmap *recycle_bitmap(Bitmap *bimp, int coldep, int wid, int hit, bool make_transparent) {
-    if (bimp != NULL) {
+    if (bimp != nullptr) {
         // same colour depth, width and height -> reuse
         if ((bimp->GetColorDepth() == coldep) && (bimp->GetWidth() == wid)
                 && (bimp->GetHeight() == hit))
@@ -1426,7 +1426,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
     int useindx = aa;
     bool hardwareAccelerated = !alwaysUseSoftware && gfxDriver->HasAcceleratedTransform();
 
-    if (spriteset[objs[aa].num] == NULL)
+    if (spriteset[objs[aa].num] == nullptr)
         quitprintf("There was an error drawing object %d. Its current sprite, %d, is invalid.", aa, objs[aa].num);
 
     int coldept = spriteset[objs[aa].num]->GetColorDepth();
@@ -1501,9 +1501,9 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
 
     if ((hardwareAccelerated) &&
         (walkBehindMethod != DrawOverCharSprite) &&
-        (objcache[aa].image != NULL) &&
+        (objcache[aa].image != nullptr) &&
         (objcache[aa].sppic == objs[aa].num) &&
-        (actsps[useindx] != NULL))
+        (actsps[useindx] != nullptr))
     {
         // HW acceleration
         objcache[aa].tintamntwas = tint_level;
@@ -1526,7 +1526,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
     }
 
     // If we have the image cached, use it
-    if ((objcache[aa].image != NULL) &&
+    if ((objcache[aa].image != nullptr) &&
         (objcache[aa].sppic == objs[aa].num) &&
         (objcache[aa].tintamntwas == tint_level) &&
         (objcache[aa].tintlightwas == tint_light) &&
@@ -1538,13 +1538,13 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
         (objcache[aa].mirroredWas == isMirrored)) {
             // the image is the same, we can use it cached!
             if ((walkBehindMethod != DrawOverCharSprite) &&
-                (actsps[useindx] != NULL))
+                (actsps[useindx] != nullptr))
                 return 1;
             // Check if the X & Y co-ords are the same, too -- if so, there
             // is scope for further optimisations
             if ((objcache[aa].xwas == objs[aa].x) &&
                 (objcache[aa].ywas == objs[aa].y) &&
-                (actsps[useindx] != NULL) &&
+                (actsps[useindx] != nullptr) &&
                 (walk_behind_baselines_changed == 0))
                 return 1;
             actsps[useindx] = recycle_bitmap(actsps[useindx], coldept, sprwidth, sprheight);
@@ -1568,7 +1568,7 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
     }
 
     // direct read from source bitmap, where possible
-    Bitmap *comeFrom = NULL;
+    Bitmap *comeFrom = nullptr;
     if (!actspsUsed)
         comeFrom = spriteset[objs[aa].num];
 
@@ -1618,7 +1618,7 @@ void prepare_objects_for_drawing() {
         useindx = aa;
         int tehHeight;
 
-        int actspsIntact = construct_object_gfx(aa, NULL, &tehHeight, false);
+        int actspsIntact = construct_object_gfx(aa, nullptr, &tehHeight, false);
 
         // update the cache for next time
         objcache[aa].xwas = objs[aa].x;
@@ -1649,11 +1649,11 @@ void prepare_objects_for_drawing() {
             sort_out_walk_behinds(actsps[useindx],atxp+offsetx,atyp+offsety,usebasel);
         }
 
-        if ((!actspsIntact) || (actspsbmp[useindx] == NULL))
+        if ((!actspsIntact) || (actspsbmp[useindx] == nullptr))
         {
             bool hasAlpha = (game.SpriteInfos[objs[aa].num].Flags & SPF_ALPHACHANNEL) != 0;
 
-            if (actspsbmp[useindx] != NULL)
+            if (actspsbmp[useindx] != nullptr)
                 gfxDriver->DestroyDDB(actspsbmp[useindx]);
             actspsbmp[useindx] = gfxDriver->CreateDDBFromBitmap(actsps[useindx], hasAlpha);
         }
@@ -1918,7 +1918,7 @@ void prepare_characters_for_drawing() {
             if (((light_level != 0) || (tint_amount != 0)) &&
                 (!gfxDriver->HasAcceleratedTransform())) {
                     // apply the lightening or tinting
-                    Bitmap *comeFrom = NULL;
+                    Bitmap *comeFrom = nullptr;
                     // if possible, direct read from the source image
                     if (!actspsUsed)
                         comeFrom = spriteset[sppic];
@@ -1966,7 +1966,7 @@ void prepare_characters_for_drawing() {
             sort_out_walk_behinds(actsps[useindx], bgX, bgY, usebasel);
         }
 
-        if ((!usingCachedImage) || (actspsbmp[useindx] == NULL))
+        if ((!usingCachedImage) || (actspsbmp[useindx] == nullptr))
         {
             bool hasAlpha = (game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) != 0;
 
@@ -2058,7 +2058,7 @@ void draw_room(Bitmap *ds, Bitmap *roomcam_surface, bool no_transform) {
 
     if (gfxDriver->RequiresFullRedrawEachFrame())
     {
-        if (roomBackgroundBmp == NULL) 
+        if (roomBackgroundBmp == nullptr) 
         {
             update_polled_stuff_if_runtime();
             roomBackgroundBmp = gfxDriver->CreateDDBFromBitmap(thisroom.BgFrames[play.bg_frame].Graphic.get(), false, true);
@@ -2119,11 +2119,11 @@ void draw_room(Bitmap *ds, Bitmap *roomcam_surface, bool no_transform) {
 
 void draw_fps()
 {
-    static IDriverDependantBitmap* ddb = NULL;
-    static Bitmap *fpsDisplay = NULL;
+    static IDriverDependantBitmap* ddb = nullptr;
+    static Bitmap *fpsDisplay = nullptr;
 
     const Rect &ui_view = play.GetUIViewport();
-    if (fpsDisplay == NULL)
+    if (fpsDisplay == nullptr)
     {
         fpsDisplay = BitmapHelper::CreateBitmap(ui_view.GetWidth(), (getfontheight_outlined(FONT_SPEECH) + get_fixed_pixel_size(5)), game.GetColorDepth());
         fpsDisplay = ReplaceBitmapWithSupportedFormat(fpsDisplay);
@@ -2167,7 +2167,7 @@ void draw_gui_and_overlays() {
     int gg;
 
     if(pl_any_want_hook(AGSE_PREGUIDRAW))
-        add_thing_to_draw(NULL, AGSE_PREGUIDRAW, 0, TRANS_RUN_PLUGIN, false);
+        add_thing_to_draw(nullptr, AGSE_PREGUIDRAW, 0, TRANS_RUN_PLUGIN, false);
 
     // draw overlays, except text boxes and portraits
     for (gg=0;gg<numscreenover;gg++) {
@@ -2205,7 +2205,7 @@ void draw_gui_and_overlays() {
             for (aa=0;aa<game.numgui;aa++) {
                 if (!guis[aa].IsDisplayed()) continue;
 
-                if (guibg[aa] == NULL)
+                if (guibg[aa] == nullptr)
                     recreate_guibg_image(&guis[aa]);
 
                 eip_guinum = aa;
@@ -2228,7 +2228,7 @@ void draw_gui_and_overlays() {
                     }
                 }
 
-                if (guibgbmp[aa] != NULL) 
+                if (guibgbmp[aa] != nullptr) 
                 {
                     gfxDriver->UpdateDDBFromBitmap(guibgbmp[aa], guibg[aa], isAlpha);
                 }
@@ -2286,17 +2286,17 @@ void put_sprite_list_on_screen(bool in_room)
     {
         thisThing = &thingsToDrawList[i];
 
-        if (thisThing->bmp != NULL) {
+        if (thisThing->bmp != nullptr) {
             // mark the image's region as dirty
             invalidate_sprite(thisThing->x, thisThing->y, thisThing->bmp, in_room);
         }
         else if ((thisThing->transparent != TRANS_RUN_PLUGIN) &&
-            (thisThing->bmp == NULL)) 
+            (thisThing->bmp == nullptr)) 
         {
             quit("Null pointer added to draw list");
         }
 
-        if (thisThing->bmp != NULL)
+        if (thisThing->bmp != nullptr)
         {
             if (thisThing->transparent <= 255)
             {
@@ -2308,7 +2308,7 @@ void put_sprite_list_on_screen(bool in_room)
         else if (thisThing->transparent == TRANS_RUN_PLUGIN) 
         {
             // meta entry to run the plugin hook
-            gfxDriver->DrawSprite(thisThing->x, thisThing->y, NULL);
+            gfxDriver->DrawSprite(thisThing->x, thisThing->y, nullptr);
         }
         else
             quit("Unknown entry in draw list");
@@ -2353,7 +2353,7 @@ void update_screen() {
         return;
 
     if(pl_any_want_hook(AGSE_POSTSCREENDRAW))
-        gfxDriver->DrawSprite(AGSE_POSTSCREENDRAW, 0, NULL);
+        gfxDriver->DrawSprite(AGSE_POSTSCREENDRAW, 0, nullptr);
 
     // update animating mouse cursor
     if (game.mcurs[cur_cursor].view>=0) {
@@ -2393,7 +2393,7 @@ void update_screen() {
         int barheight = getheightoflines(0, DEBUG_CONSOLE_NUMLINES - 1) + 4;
 
         const Rect &viewport = play.GetMainViewport();
-        if (debugConsoleBuffer == NULL)
+        if (debugConsoleBuffer == nullptr)
         {
             debugConsoleBuffer = BitmapHelper::CreateBitmap(viewport.GetWidth(), barheight,game.GetColorDepth());
             debugConsoleBuffer = ReplaceBitmapWithSupportedFormat(debugConsoleBuffer);
@@ -2407,7 +2407,7 @@ void update_screen() {
             ypp += txtspacing;
         }
 
-        if (debugConsole == NULL)
+        if (debugConsole == nullptr)
             debugConsole = gfxDriver->CreateDDBFromBitmap(debugConsoleBuffer, false, true);
         else
             gfxDriver->UpdateDDBFromBitmap(debugConsole, debugConsoleBuffer, false);
@@ -2538,7 +2538,7 @@ void render_graphics(IDriverDependantBitmap *extraBitmap, int extraX, int extraY
     construct_virtual_screen(false);
     our_eip=5;
 
-    if (extraBitmap != NULL) {
+    if (extraBitmap != nullptr) {
         invalidate_sprite(extraX, extraY, extraBitmap, false);
         gfxDriver->DrawSprite(extraX, extraY, extraBitmap);
     }

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -89,7 +89,7 @@ Common::Bitmap *recycle_bitmap(Common::Bitmap *bimp, int coldep, int wid, int hi
 Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *bimp, Common::Bitmap *source, bool hasAlpha = false, bool opaque = false);
 void update_screen();
 // Draw everything 
-void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = NULL, int extraX = 0, int extraY = 0);
+void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
 void construct_virtual_screen(bool fullRedraw) ;
 void add_to_sprite_list(Engine::IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, int sprNum, bool isWalkBehind = false);
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -69,7 +69,7 @@ void DrawingSurface_Release(ScriptDrawingSurface* sds)
         {
             int tt;
             // force a refresh of any cached object or character images
-            if (croom != NULL) 
+            if (croom != nullptr) 
             {
                 for (tt = 0; tt < croom->numobj; tt++) 
                 {
@@ -98,7 +98,7 @@ void DrawingSurface_Release(ScriptDrawingSurface* sds)
     if (sds->dynamicSurfaceNumber >= 0)
     {
         delete dynamicallyCreatedSurfaces[sds->dynamicSurfaceNumber];
-        dynamicallyCreatedSurfaces[sds->dynamicSurfaceNumber] = NULL;
+        dynamicallyCreatedSurfaces[sds->dynamicSurfaceNumber] = nullptr;
         sds->dynamicSurfaceNumber = -1;
     }
     sds->modified = 0;
@@ -131,7 +131,7 @@ ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
 
     for (int i = 0; i < MAX_DYNAMIC_SURFACES; i++)
     {
-        if (dynamicallyCreatedSurfaces[i] == NULL)
+        if (dynamicallyCreatedSurfaces[i] == nullptr)
         {
             dynamicallyCreatedSurfaces[i] = BitmapHelper::CreateBitmapCopy(sourceBitmap);
             ScriptDrawingSurface *newSurface = new ScriptDrawingSurface();
@@ -143,7 +143,7 @@ ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
     }
 
     quit("!DrawingSurface.CreateCopy: too many copied surfaces created");
-    return NULL;
+    return nullptr;
 }
 
 void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev) {
@@ -174,7 +174,7 @@ void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurfa
 
 void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
 {
-    if ((slot < 0) || (spriteset[slot] == NULL))
+    if ((slot < 0) || (spriteset[slot] == nullptr))
         quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
 
     if ((trans < 0) || (trans > 100))

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -286,7 +286,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromSaveGame(int sgslot, int width, int
         ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(slotnum);
         return new_spr;
     }
-    return NULL;
+    return nullptr;
 }
 
 ScriptDynamicSprite* DynamicSprite_CreateFromFile(const char *filename) {
@@ -295,7 +295,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromFile(const char *filename) {
         ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(slotnum);
         return new_spr;
     }
-    return NULL;
+    return nullptr;
 }
 
 ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
@@ -304,7 +304,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
 
     int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
-        return NULL;
+        return nullptr;
 
     const Rect &viewport = play.GetMainViewport();
     if (width <= 0)
@@ -331,15 +331,15 @@ ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preser
 
     int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
-        return NULL;
+        return nullptr;
 
     if (!spriteset.DoesSpriteExist(slot))
         quitprintf("DynamicSprite.CreateFromExistingSprite: sprite %d does not exist", slot);
 
     // create a new sprite as a copy of the existing one
     Bitmap *newPic = BitmapHelper::CreateBitmapCopy(spriteset[slot]);
-    if (newPic == NULL)
-        return NULL;
+    if (newPic == nullptr)
+        return nullptr;
 
     bool hasAlpha = (preserveAlphaChannel) && ((game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
 
@@ -353,7 +353,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface
 {
     int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
-        return NULL;
+        return nullptr;
 
     // use DrawingSurface resolution
     sds->PointToGameResolution(&x, &y);
@@ -367,8 +367,8 @@ ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface
     int colDepth = ds->GetColorDepth();
 
     Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, colDepth);
-    if (newPic == NULL)
-        return NULL;
+    if (newPic == nullptr)
+        return nullptr;
 
     newPic->Blit(ds, x, y, 0, 0, width, height);
 
@@ -385,11 +385,11 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
 
     int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
-        return NULL;
+        return nullptr;
 
     Bitmap *newPic = BitmapHelper::CreateTransparentBitmap(width, height, game.GetColorDepth());
-    if (newPic == NULL)
-        return NULL;
+    if (newPic == nullptr)
+        return nullptr;
 
     if ((alphaChannel) && (game.GetColorDepth() < 32))
         alphaChannel = false;
@@ -427,12 +427,12 @@ ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y
 
     int gotSlot = spriteset.AddNewSprite();
     if (gotSlot <= 0)
-        return NULL;
+        return nullptr;
 
     // create a new sprite as a copy of the existing one
     Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, thisroom.BgFrames[frame].Graphic->GetColorDepth());
-    if (newPic == NULL)
-        return NULL;
+    if (newPic == nullptr)
+        return nullptr;
 
     newPic->Blit(thisroom.BgFrames[frame].Graphic.get(), x1, y1, 0, 0, width, height);
 
@@ -471,7 +471,7 @@ void free_dynamic_sprite (int gotSlot) {
     quitprintf("!DeleteSprite: Attempted to free static sprite %d that was not loaded by the script", gotSlot);
 
   delete spriteset[gotSlot];
-  spriteset.Set(gotSlot, NULL);
+  spriteset.Set(gotSlot, nullptr);
 
   game.SpriteInfos[gotSlot].Flags = 0;
   game.SpriteInfos[gotSlot].Width = 0;
@@ -492,7 +492,7 @@ void free_dynamic_sprite (int gotSlot) {
   }
 
   // force refresh of any object caches using the sprite
-  if (croom != NULL) 
+  if (croom != nullptr) 
   {
     for (tt = 0; tt < croom->numobj; tt++) 
     {

--- a/Engine/ac/dynobj/cc_agsdynamicobject.h
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.h
@@ -19,7 +19,7 @@
 
 struct AGSCCDynamicObject : ICCDynamicObject {
 protected:
-    virtual ~AGSCCDynamicObject(){}
+    virtual ~AGSCCDynamicObject() = default;
 public:
     // default implementation
     int Dispose(const char *address, bool force) override;

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -37,7 +37,7 @@
 
 using namespace AGS::Common;
 
-ICCStringClass *stringClassImpl = NULL;
+ICCStringClass *stringClassImpl = nullptr;
 
 // set the class that will be used for dynamic strings
 void ccSetStringClassImpl(ICCStringClass *theClass) {
@@ -90,7 +90,7 @@ void ccAttemptDisposeObject(int32_t handle) {
 // translate between object handles and memory addresses
 int32_t ccGetObjectHandleFromAddress(const char *address) {
     // set to null
-    if (address == NULL)
+    if (address == nullptr)
         return 0;
 
     int32_t handl = pool.AddressToHandle(address);
@@ -106,15 +106,15 @@ int32_t ccGetObjectHandleFromAddress(const char *address) {
 
 const char *ccGetObjectAddressFromHandle(int32_t handle) {
     if (handle == 0) {
-        return NULL;
+        return nullptr;
     }
     const char *addr = pool.HandleToAddress(handle);
 
     ManagedObjectLog("Line %d ReadPtr: %d to %08X", currentline, handle, addr);
 
-    if (addr == NULL) {
+    if (addr == nullptr) {
         cc_error("Error retrieving pointer: invalid handle %d", handle);
-        return NULL;
+        return nullptr;
     }
     return addr;
 }
@@ -122,8 +122,8 @@ const char *ccGetObjectAddressFromHandle(int32_t handle) {
 ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&object, ICCDynamicObject *&manager)
 {
     if (handle == 0) {
-        object = NULL;
-        manager = NULL;
+        object = nullptr;
+        manager = nullptr;
         return kScValUndefined;
     }
     ScriptValueType obj_type = pool.HandleToAddressAndManager(handle, object, manager);
@@ -144,7 +144,7 @@ int ccReleaseObjectReference(int32_t handle) {
     if (handle == 0)
         return 0;
 
-    if (pool.HandleToAddress(handle) == NULL) {
+    if (pool.HandleToAddress(handle) == nullptr) {
         cc_error("Error releasing pointer: invalid handle %d", handle);
         return -1;
     }

--- a/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
+++ b/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
@@ -40,7 +40,7 @@ void ScriptDialogOptionsRendering::Reset()
     parserTextboxY = 0;
     parserTextboxWidth = 0;
     dialogID = 0;
-    surfaceToRenderTo = NULL;
+    surfaceToRenderTo = nullptr;
     surfaceAccessed = false;
     activeOptionID = -1;
     chosenOptionID = -1;

--- a/Engine/ac/dynobj/scriptdrawingsurface.cpp
+++ b/Engine/ac/dynobj/scriptdrawingsurface.cpp
@@ -39,12 +39,12 @@ Bitmap* ScriptDrawingSurface::GetBitmapSurface()
         return spriteset[dynamicSpriteNumber];
     else if (dynamicSurfaceNumber >= 0)
         return dynamicallyCreatedSurfaces[dynamicSurfaceNumber];
-    else if (linkedBitmapOnly != NULL)
+    else if (linkedBitmapOnly != nullptr)
         return linkedBitmapOnly;
     else
         quit("!DrawingSurface: attempted to use surface after Release was called");
 
-    return NULL;
+    return nullptr;
 }
 
 Bitmap *ScriptDrawingSurface::StartDrawing()
@@ -110,7 +110,7 @@ ScriptDrawingSurface::ScriptDrawingSurface()
     dynamicSpriteNumber = -1;
     dynamicSurfaceNumber = -1;
     isLinkedBitmapOnly = false;
-    linkedBitmapOnly = NULL;
+    linkedBitmapOnly = nullptr;
     currentColour = play.raw_color;
     currentColourScript = 0;
     modified = 0;

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -23,7 +23,7 @@ const char *ScriptUserObject::GetType()
 
 ScriptUserObject::ScriptUserObject()
     : _size(0)
-    , _data(NULL)
+    , _data(nullptr)
 {
 }
 
@@ -35,7 +35,7 @@ ScriptUserObject::~ScriptUserObject()
 /* static */ ScriptUserObject *ScriptUserObject::CreateManaged(size_t size)
 {
     ScriptUserObject *suo = new ScriptUserObject();
-    suo->Create(NULL, size);
+    suo->Create(nullptr, size);
     ccRegisterManagedObject(suo, suo);
     return suo;
 }
@@ -43,7 +43,7 @@ ScriptUserObject::~ScriptUserObject()
 void ScriptUserObject::Create(const char *data, size_t size)
 {
     delete [] _data;
-    _data = NULL;
+    _data = nullptr;
 
     _size = size;
     if (_size > 0)

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -59,7 +59,7 @@ int evblocknum;
 int inside_processevent=0;
 int eventClaimed = EVENT_NONE;
 
-const char*tsnames[4]={NULL, REP_EXEC_NAME, "on_key_press","on_mouse_click"};
+const char*tsnames[4]={nullptr, REP_EXEC_NAME, "on_key_press","on_mouse_click"};
 
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed) {
@@ -105,7 +105,7 @@ void run_on_event (int evtype, RuntimeScriptValue &wparam)
 void run_room_event(int id) {
     evblockbasename="room";
 
-    if (thisroom.EventHandlers != NULL)
+    if (thisroom.EventHandlers != nullptr)
     {
         run_interaction_script(thisroom.EventHandlers.get(), id);
     }
@@ -117,7 +117,7 @@ void run_room_event(int id) {
 
 void run_event_block_inv(int invNum, int event) {
     evblockbasename="inventory%d";
-    if (game.invScripts != NULL)
+    if (game.invScripts != nullptr)
     {
         run_interaction_script(game.invScripts[invNum], event);
     }
@@ -165,14 +165,14 @@ void process_event(EventHappened*evp) {
         NewRoom(evp->data1);
     }
     else if (evp->type==EV_RUNEVBLOCK) {
-        Interaction*evpt=NULL;
-        PInteractionScripts scriptPtr = NULL;
+        Interaction*evpt=nullptr;
+        PInteractionScripts scriptPtr = nullptr;
         const char *oldbasename = evblockbasename;
         int   oldblocknum = evblocknum;
 
         if (evp->data1==EVB_HOTSPOT) {
 
-            if (thisroom.Hotspots[evp->data2].EventHandlers != NULL)
+            if (thisroom.Hotspots[evp->data2].EventHandlers != nullptr)
                 scriptPtr = thisroom.Hotspots[evp->data2].EventHandlers;
             else
                 evpt=&croom->intrHotspot[evp->data2];
@@ -183,7 +183,7 @@ void process_event(EventHappened*evp) {
         }
         else if (evp->data1==EVB_ROOM) {
 
-            if (thisroom.EventHandlers != NULL)
+            if (thisroom.EventHandlers != nullptr)
                 scriptPtr = thisroom.EventHandlers;
             else
                 evpt=&croom->intrRoom;
@@ -197,11 +197,11 @@ void process_event(EventHappened*evp) {
             //Debug::Printf("Running room interaction, event %d", evp->data3);
         }
 
-        if (scriptPtr != NULL)
+        if (scriptPtr != nullptr)
         {
             run_interaction_script(scriptPtr.get(), evp->data3);
         }
-        else if (evpt != NULL)
+        else if (evpt != nullptr)
         {
             run_interaction_event(evpt,evp->data3);
         }
@@ -238,7 +238,7 @@ void process_event(EventHappened*evp) {
             return;
 
         if (((theTransition == FADE_CROSSFADE) || (theTransition == FADE_DISSOLVE)) &&
-            (saved_viewport_bitmap == NULL)) 
+            (saved_viewport_bitmap == nullptr)) 
         {
             // transition type was not crossfade/dissolve when the screen faded out,
             // but it is now when the screen fades in (Eg. a save game was restored
@@ -329,7 +329,7 @@ void process_event(EventHappened*evp) {
             saved_viewport_bitmap->Release();
 
             delete saved_viewport_bitmap;
-            saved_viewport_bitmap = NULL;
+            saved_viewport_bitmap = nullptr;
             set_palette_range(palette, 0, 255, 0);
             gfxDriver->DestroyDDB(ddb);
         }
@@ -366,7 +366,7 @@ void process_event(EventHappened*evp) {
             saved_viewport_bitmap->Release();
 
             delete saved_viewport_bitmap;
-            saved_viewport_bitmap = NULL;
+            saved_viewport_bitmap = nullptr;
             set_palette_range(palette, 0, 255, 0);
             gfxDriver->DestroyDDB(ddb);
         }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -87,7 +87,7 @@ void *sc_OpenFile(const char *fnmm, int mode) {
   sc_File *scf = new sc_File();
   if (scf->OpenFile(fnmm, mode) == 0) {
     delete scf;
-    return 0;
+    return nullptr;
   }
   ccRegisterManagedObject(scf, scf);
   return scf;
@@ -395,7 +395,7 @@ PACKFILE *PackfileFromAsset(const AssetPath &path)
         }
         return pf;
     }
-    return NULL;
+    return nullptr;
 }
 
 DUMBFILE *DUMBfileFromAsset(const AssetPath &path)
@@ -403,7 +403,7 @@ DUMBFILE *DUMBfileFromAsset(const AssetPath &path)
     PACKFILE *pf = PackfileFromAsset(path);
     if (pf)
         return dumbfile_open_packfile(pf);
-    return NULL;
+    return nullptr;
 }
 
 bool DoesAssetExistInLib(const AssetPath &assetname)
@@ -535,7 +535,7 @@ ScriptFileHandle *check_valid_file_handle_ptr(Stream *stream_ptr, const char *op
 
   String exmsg = String::FromFormat("!%s: invalid file handle; file not previously opened or has been closed", operation_name);
   quit(exmsg);
-  return NULL;
+  return nullptr;
 }
 
 ScriptFileHandle *check_valid_file_handle_int32(int32_t handle, const char *operation_name)
@@ -553,13 +553,13 @@ ScriptFileHandle *check_valid_file_handle_int32(int32_t handle, const char *oper
 
   String exmsg = String::FromFormat("!%s: invalid file handle; file not previously opened or has been closed", operation_name);
   quit(exmsg);
-  return NULL;
+  return nullptr;
 }
 
 Stream *get_valid_file_stream_from_handle(int32_t handle, const char *operation_name)
 {
     ScriptFileHandle *sc_handle = check_valid_file_handle_int32(handle, operation_name);
-    return sc_handle ? sc_handle->stream : NULL;
+    return sc_handle ? sc_handle->stream : nullptr;
 }
 
 //=============================================================================

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -136,7 +136,7 @@ GameSetup usetup;
 GameSetupStruct game;
 RoomStatus troom;    // used for non-saveable rooms, eg. intro
 RoomObject*objs;
-RoomStatus*croom=NULL;
+RoomStatus*croom=nullptr;
 RoomStruct thisroom;
 
 volatile int switching_away_from_game = 0;
@@ -173,18 +173,18 @@ ScriptString myScriptStringImpl;
 // system. Noteably we would need an alternate to StaticArray class to track
 // access to their elements.
 ScriptObject scrObj[MAX_ROOM_OBJECTS];
-ScriptGUI    *scrGui = NULL;
+ScriptGUI    *scrGui = nullptr;
 ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
 ScriptRegion scrRegion[MAX_ROOM_REGIONS];
 ScriptInvItem scrInv[MAX_INV];
 ScriptDialog *scrDialog;
 
-ViewStruct*views=NULL;
+ViewStruct*views=nullptr;
 
-CharacterCache *charcache = NULL;
+CharacterCache *charcache = nullptr;
 ObjectCache objcache[MAX_ROOM_OBJECTS];
 
-MoveList *mls = NULL;
+MoveList *mls = nullptr;
 
 //=============================================================================
 
@@ -223,7 +223,7 @@ void Game_StopAudio(int audioType)
         else
         {
             ScriptAudioClip *clip = AudioChannel_GetPlayingClip(&scrAudioChannel[aa]);
-            if ((clip != NULL) && (clip->type == audioType))
+            if ((clip != nullptr) && (clip->type == audioType))
                 stop_or_fade_out_channel(aa);
         }
     }
@@ -242,7 +242,7 @@ int Game_IsAudioPlaying(int audioType)
     for (int aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
     {
         ScriptAudioClip *clip = AudioChannel_GetPlayingClip(&scrAudioChannel[aa]);
-        if (clip != NULL)
+        if (clip != nullptr)
         {
             if ((clip->type == audioType) || (audioType == SCR_NO_VALUE))
             {
@@ -278,7 +278,7 @@ void Game_SetAudioTypeVolume(int audioType, int volume, int changeType)
         for (int aa = 0; aa < MAX_SOUND_CHANNELS; aa++)
         {
             ScriptAudioClip *clip = AudioChannel_GetPlayingClip(&scrAudioChannel[aa]);
-            if ((clip != NULL) && (clip->type == audioType))
+            if ((clip != nullptr) && (clip->type == audioType))
             {
                 auto* ch = lock.GetChannel(aa);
                 if (ch)
@@ -433,7 +433,7 @@ bool SetSaveGameDirectoryPath(const char *newFolder, bool explicit_path)
     char restartGamePath[260];
     sprintf(restartGamePath, "%s""agssave.%d%s", saveGameDirectory, RESTART_POINT_SAVE_GAME_NUMBER, saveGameSuffix.GetCStr());
     Stream *restartGameFile = Common::File::OpenFileRead(restartGamePath);
-    if (restartGameFile != NULL)
+    if (restartGameFile != nullptr)
 	{
         long fileSize = restartGameFile->GetLength();
         char *mbuffer = (char*)malloc(fileSize);
@@ -462,7 +462,7 @@ const char* Game_GetSaveSlotDescription(int slnum) {
     {
         return CreateNewScriptString(description);
     }
-    return NULL;
+    return nullptr;
 }
 
 
@@ -518,7 +518,7 @@ void unload_game_file()
     free(actspswbbmp);
     free(actspswbcache);
 
-    if ((gameinst != NULL) && (gameinst->pc != 0))
+    if ((gameinst != nullptr) && (gameinst->pc != 0))
     {
         quit("Error: unload_game called while script still running");
     }
@@ -526,20 +526,20 @@ void unload_game_file()
     {
         delete gameinstFork;
         delete gameinst;
-        gameinstFork = NULL;
-        gameinst = NULL;
+        gameinstFork = nullptr;
+        gameinst = nullptr;
     }
 
     gamescript.reset();
 
-    if ((dialogScriptsInst != NULL) && (dialogScriptsInst->pc != 0))
+    if ((dialogScriptsInst != nullptr) && (dialogScriptsInst->pc != 0))
     {
         quit("Error: unload_game called while dialog script still running");
     }
-    else if (dialogScriptsInst != NULL)
+    else if (dialogScriptsInst != nullptr)
     {
         delete dialogScriptsInst;
-        dialogScriptsInst = NULL;
+        dialogScriptsInst = nullptr;
     }
 
     dialogScriptsScript.reset();
@@ -564,12 +564,12 @@ void unload_game_file()
     numScriptModules = 0;
 
     free(views);
-    views = NULL;
+    views = nullptr;
 
     free(charcache);
-    charcache = NULL;
+    charcache = nullptr;
 
-    if (splipsync != NULL)
+    if (splipsync != nullptr)
     {
         for (int i = 0; i < numLipLines; ++i)
         {
@@ -577,25 +577,25 @@ void unload_game_file()
             free(splipsync[i].frame);
         }
         free(splipsync);
-        splipsync = NULL;
+        splipsync = nullptr;
         numLipLines = 0;
         curLipLine = -1;
     }
 
     for (int i = 0; i < game.numdialog; ++i)
     {
-        if (dialog[i].optionscripts != NULL)
+        if (dialog[i].optionscripts != nullptr)
             free(dialog[i].optionscripts);
-        dialog[i].optionscripts = NULL;
+        dialog[i].optionscripts = nullptr;
     }
     free(dialog);
-    dialog = NULL;
+    dialog = nullptr;
     delete[] scrDialog;
-    scrDialog = NULL;
+    scrDialog = nullptr;
 
     for (int i = 0; i < game.numgui; ++i) {
         free(guibg[i]);
-        guibg[i] = NULL;
+        guibg[i] = nullptr;
     }
 
     guiScriptObjNames.clear();
@@ -837,7 +837,7 @@ const char* Game_GetLocationName(int x, int y) {
 
 const char* Game_GetGlobalMessages(int index) {
     if ((index < 500) || (index >= MAXGLOBALMES + 500)) {
-        return NULL;
+        return nullptr;
     }
     char buffer[STD_BUFFER_SIZE];
     buffer[0] = 0;
@@ -860,7 +860,7 @@ const char* Game_GetTranslationFilename() {
 
 int Game_ChangeTranslation(const char *newFilename)
 {
-    if ((newFilename == NULL) || (newFilename[0] == 0))
+    if ((newFilename == nullptr) || (newFilename[0] == 0))
     {
         close_translation();
         strcpy(transFileName, "");
@@ -882,7 +882,7 @@ int Game_ChangeTranslation(const char *newFilename)
 ScriptAudioClip *Game_GetAudioClip(int index)
 {
     if (index < 0 || index >= game.audioClipCount)
-        return NULL;
+        return nullptr;
     return &game.audioClips[index];
 }
 
@@ -893,7 +893,7 @@ ScriptAudioClip *Game_GetAudioClip(int index)
 
 
 void serialize_bitmap(const Common::Bitmap *thispic, Stream *out) {
-    if (thispic != NULL) {
+    if (thispic != nullptr) {
         out->WriteInt32(thispic->GetWidth());
         out->WriteInt32(thispic->GetHeight());
         out->WriteInt32(thispic->GetColorDepth());
@@ -952,8 +952,8 @@ Bitmap *read_serialized_bitmap(Stream *in) {
     int pichit = in->ReadInt32();
     int piccoldep = in->ReadInt32();
     thispic = BitmapHelper::CreateBitmap(picwid,pichit,piccoldep);
-    if (thispic == NULL)
-        return NULL;
+    if (thispic == nullptr)
+        return nullptr;
     for (int vv=0; vv < pichit; vv++)
     {
       switch (piccoldep)
@@ -1057,13 +1057,13 @@ void save_game(int slotn, const char*descript) {
     String nametouse;
     nametouse = get_save_game_path(slotn);
 
-    Bitmap *screenShot = NULL;
+    Bitmap *screenShot = nullptr;
 
     // Screenshot
     create_savegame_screenshot(screenShot);
 
     Common::PStream out = StartSavegame(nametouse, descript, screenShot);
-    if (out == NULL)
+    if (out == nullptr)
         quit("save_game: unable to open savegame file for writing");
 
     update_polled_stuff_if_runtime();
@@ -1071,7 +1071,7 @@ void save_game(int slotn, const char*descript) {
     // Actual dynamic game data is saved here
     SaveGameState(out);
 
-    if (screenShot != NULL)
+    if (screenShot != nullptr)
     {
         int screenShotOffset = out->GetPosition() - sizeof(RICH_GAME_MEDIA_HEADER);
         int screenShotSize = write_screen_shot_for_vista(out.get(), screenShot);
@@ -1085,7 +1085,7 @@ void save_game(int slotn, const char*descript) {
         out->WriteInt32(screenShotSize);
     }
 
-    if (screenShot != NULL)
+    if (screenShot != nullptr)
         delete screenShot;
 }
 
@@ -1360,7 +1360,7 @@ void restore_game_dynamic_surfaces(Stream *in, RestoredData &r_data)
     {
         if (in->ReadInt8() == 0)
         {
-            r_data.DynamicSurfaces[i] = NULL;
+            r_data.DynamicSurfaces[i] = nullptr;
         }
         else
         {
@@ -1378,7 +1378,7 @@ void restore_game_displayed_room_status(Stream *in, RestoredData &r_data)
     if (displayed_room >= 0) {
 
         for (bb = 0; bb < MAX_ROOM_BGFRAMES; bb++) {
-            r_data.RoomBkgScene[bb] = NULL;
+            r_data.RoomBkgScene[bb] = nullptr;
             if (play.raw_modified[bb]) {
                 r_data.RoomBkgScene[bb].reset(read_serialized_bitmap(in));
             }
@@ -1396,7 +1396,7 @@ void restore_game_displayed_room_status(Stream *in, RestoredData &r_data)
             in->Read(&troom.tsdata[0],troom.tsdatasize);
         }
         else
-            troom.tsdata = NULL;
+            troom.tsdata = nullptr;
     }
 }
 
@@ -1509,7 +1509,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     // Delete unneeded data
     // TODO: reorganize this (may be solved by optimizing safe format too)
     delete [] game.load_messages;
-    game.load_messages = NULL;
+    game.load_messages = nullptr;
 
     if (game.numdialog!=numdiwas)
     {
@@ -1923,7 +1923,7 @@ void display_switch_in_resume()
 
     // clear the screen if necessary
     if (gfxDriver && gfxDriver->UsesMemoryBackBuffer())
-        gfxDriver->ClearRectangle(0, 0, game.GetGameRes().Width - 1, game.GetGameRes().Height - 1, NULL);
+        gfxDriver->ClearRectangle(0, 0, game.GetGameRes().Width - 1, game.GetGameRes().Height - 1, nullptr);
 
     platform->ResumeApplication();
 }
@@ -1973,7 +1973,7 @@ void replace_tokens(const char*srcmes,char*destm, int maxlen) {
 }
 
 const char *get_global_message (int msnum) {
-    if (game.messages[msnum-500] == NULL)
+    if (game.messages[msnum-500] == nullptr)
         return "";
     return get_translation(game.messages[msnum-500]);
 }
@@ -1985,7 +1985,7 @@ void get_message_text (int msnum, char *buffer, char giveErr) {
 
     if (msnum>=500) {
 
-        if ((msnum >= MAXGLOBALMES + 500) || (game.messages[msnum-500]==NULL)) {
+        if ((msnum >= MAXGLOBALMES + 500) || (game.messages[msnum-500]==nullptr)) {
             if (giveErr)
                 quit("!DisplayGlobalMessage: message does not exist");
             buffer[0] = 0;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -66,8 +66,8 @@ void PlayAmbientSound (int channel, int sndnum, int vol, int x, int y) {
             // in case a normal non-ambient sound was playing, stop it too
             stop_and_destroy_channel(channel);
 
-            SOUNDCLIP *asound = aclip ? load_sound_and_play(aclip, true) : NULL;
-            if (asound == NULL) {
+            SOUNDCLIP *asound = aclip ? load_sound_and_play(aclip, true) : nullptr;
+            if (asound == nullptr) {
                 debug_script_warn ("Cannot load ambient sound %d", sndnum);
                 debug_script_log("FAILED to load ambient sound %d", sndnum);
                 return;
@@ -143,8 +143,8 @@ int PlaySoundEx(int val1, int channel) {
     stop_and_destroy_channel (channel);
     debug_script_log("Playing sound %d on channel %d", val1, channel);
 
-    SOUNDCLIP *soundfx = aclip ? load_sound_and_play(aclip, false) : NULL;
-    if (soundfx == NULL) {
+    SOUNDCLIP *soundfx = aclip ? load_sound_and_play(aclip, false) : nullptr;
+    if (soundfx == nullptr) {
         debug_script_warn("Sound sample load failure: cannot load sound %d", val1);
         debug_script_log("FAILED to load sound %d", val1);
         return -1;
@@ -535,17 +535,17 @@ int play_speech(int charid,int sndid) {
     asset_name.Append(".wav");
     speechmp3 = my_load_wave(get_voice_over_assetpath(asset_name), play.speech_volume, 0);
 
-    if (speechmp3 == NULL) {
+    if (speechmp3 == nullptr) {
         asset_name.ReplaceMid(asset_name.GetLength() - 3, 3, "ogg");
         speechmp3 = my_load_ogg(get_voice_over_assetpath(asset_name), play.speech_volume);
     }
 
-    if (speechmp3 == NULL) {
+    if (speechmp3 == nullptr) {
         asset_name.ReplaceMid(asset_name.GetLength() - 3, 3, "mp3");
         speechmp3 = my_load_mp3(get_voice_over_assetpath(asset_name), play.speech_volume);
     }
 
-    if (speechmp3 != NULL) {
+    if (speechmp3 != nullptr) {
         if (!speechmp3->play()) {
             // not assigned to a channel, so clean up manually.
             speechmp3->destroy();
@@ -554,7 +554,7 @@ int play_speech(int charid,int sndid) {
         }
     }
 
-    if (speechmp3 == NULL) {
+    if (speechmp3 == nullptr) {
         debug_script_warn("Speech load failure: '%s'", voice_file.GetCStr());
         curLipLine = -1;
         return 0;

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -194,7 +194,7 @@ void SetPlayerCharacter(int newchar) {
 void FollowCharacterEx(int who, int tofollow, int distaway, int eagerness) {
     if (!is_valid_character(who))
         quit("!FollowCharacter: Invalid character specified");
-    CharacterInfo *chtofollow = NULL;
+    CharacterInfo *chtofollow = nullptr;
     if (tofollow != -1)
     {
         if (!is_valid_character(tofollow))
@@ -395,7 +395,7 @@ void RunCharacterInteraction (int cc, int mood) {
     else if (mood==MODE_CUSTOM2) passon = 7;
 
     evblockbasename="character%d"; evblocknum=cc;
-    if (game.charScripts != NULL) 
+    if (game.charScripts != nullptr) 
     {
         if (passon>=0)
             run_interaction_script(game.charScripts[cc], passon, 4, (passon == 3));
@@ -453,7 +453,7 @@ int GetCharIDAtScreen(int xx, int yy) {
 
 void SetActiveInventory(int iit) {
 
-    ScriptInvItem *tosend = NULL;
+    ScriptInvItem *tosend = nullptr;
     if ((iit > 0) && (iit < game.numinvitems))
         tosend = &scrInv[iit];
     else if (iit != -1)

--- a/Engine/ac/global_datetime.cpp
+++ b/Engine/ac/global_datetime.cpp
@@ -36,5 +36,5 @@ int sc_GetTime(int whatti) {
 
 int GetRawTime () {
     // TODO: we might need to modify script API to support larger time type
-    return static_cast<int>(time(NULL));
+    return static_cast<int>(time(nullptr));
 }

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -76,7 +76,7 @@ String GetRuntimeInfo()
         runtimeInfo.Append("[AUDIO.VOX enabled");
     if (play.want_speech >= 1)
         runtimeInfo.Append("[SPEECH.VOX enabled");
-    if (transtree != NULL) {
+    if (transtree != nullptr) {
         runtimeInfo.Append("[Using translation ");
         runtimeInfo.Append(transFileName);
     }

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -47,7 +47,7 @@ extern GameSetupStruct game;
 
 // RawSaveScreen: copy the current screen to a backup bitmap
 void RawSaveScreen () {
-    if (raw_saved_screen != NULL)
+    if (raw_saved_screen != nullptr)
         delete raw_saved_screen;
     PBitmap source = thisroom.BgFrames[play.bg_frame].Graphic;
     raw_saved_screen = BitmapHelper::CreateBitmapCopy(source.get());
@@ -56,7 +56,7 @@ void RawSaveScreen () {
 // deliberately don't free the Bitmap *cos they can multiple restore
 // and it gets freed on room exit anyway
 void RawRestoreScreen() {
-    if (raw_saved_screen == NULL) {
+    if (raw_saved_screen == nullptr) {
         debug_script_warn("RawRestoreScreen: unable to restore, since the screen hasn't been saved previously.");
         return;
     }
@@ -67,7 +67,7 @@ void RawRestoreScreen() {
 }
 // Restores the backup bitmap, but tints it to the specified level
 void RawRestoreScreenTinted(int red, int green, int blue, int opacity) {
-    if (raw_saved_screen == NULL) {
+    if (raw_saved_screen == nullptr) {
         debug_script_warn("RawRestoreScreenTinted: unable to restore, since the screen hasn't been saved previously.");
         return;
     }
@@ -169,7 +169,7 @@ void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
 }
 
 void RawDrawImageCore(int xx, int yy, int slot, int alpha) {
-    if ((slot < 0) || (spriteset[slot] == NULL))
+    if ((slot < 0) || (spriteset[slot] == nullptr))
         quit("!RawDrawImage: invalid sprite slot number specified");
     RAW_START();
 
@@ -227,7 +227,7 @@ void RawDrawImageTransparent(int xx, int yy, int slot, int legacy_transparency) 
     update_polled_stuff_if_runtime();  // this operation can be slow so stop music skipping
 }
 void RawDrawImageResized(int xx, int yy, int gotSlot, int width, int height) {
-    if ((gotSlot < 0) || (spriteset[gotSlot] == NULL))
+    if ((gotSlot < 0) || (spriteset[gotSlot] == nullptr))
         quit("!RawDrawImageResized: invalid sprite slot number specified");
     // very small, don't draw it
     if ((width < 1) || (height < 1))

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -51,7 +51,7 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
   // find a free file handle to use
   for (useindx = 0; useindx < num_open_script_files; useindx++) 
   {
-    if (valid_handles[useindx].stream == NULL)
+    if (valid_handles[useindx].stream == nullptr)
       break;
   }
 
@@ -60,7 +60,7 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
     s = File::OpenFile(alt_path, open_mode, work_mode);
 
   valid_handles[useindx].stream = s;
-  if (valid_handles[useindx].stream == NULL)
+  if (valid_handles[useindx].stream == nullptr)
     return 0;
   valid_handles[useindx].handle = useindx + 1; // make handle indexes 1-based
 
@@ -76,7 +76,7 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
 void FileClose(int32_t handle) {
   ScriptFileHandle *sc_handle = check_valid_file_handle_int32(handle,"FileClose");
   delete sc_handle->stream;
-  sc_handle->stream = NULL;
+  sc_handle->stream = nullptr;
   sc_handle->handle = 0;
   }
 void FileWrite(int32_t handle, const char *towrite) {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -740,7 +740,7 @@ int IsKeyPressed (int keycode) {
 int SaveScreenShot(const char*namm) {
     char fileName[MAX_PATH];
 
-    if (strchr(namm,'.') == NULL)
+    if (strchr(namm,'.') == nullptr)
         sprintf(fileName, "%s%s.bmp", saveGameDirectory, namm);
     else
         sprintf(fileName, "%s%s", saveGameDirectory, namm);
@@ -889,7 +889,7 @@ void _sc_AbortGame(const char* text) {
 
 int GetGraphicalVariable (const char *varName) {
     InteractionVariable *theVar = FindGraphicalVariable(varName);
-    if (theVar == NULL) {
+    if (theVar == nullptr) {
         quitprintf("!GetGraphicalVariable: interaction variable '%s' not found", varName);
         return 0;
     }
@@ -898,7 +898,7 @@ int GetGraphicalVariable (const char *varName) {
 
 void SetGraphicalVariable (const char *varName, int p_value) {
     InteractionVariable *theVar = FindGraphicalVariable(varName);
-    if (theVar == NULL) {
+    if (theVar == nullptr) {
         quitprintf("!SetGraphicalVariable: interaction variable '%s' not found", varName);
     }
     else

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -222,7 +222,7 @@ int IsInterfaceEnabled() {
 
 int GetGUIObjectAt (int xx, int yy) {
     GUIObject *toret = GetGUIControlAtLocation(xx, yy);
-    if (toret == NULL)
+    if (toret == nullptr)
         return -1;
 
     return toret->Id;

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -117,7 +117,7 @@ void RunHotspotInteraction (int hotspothere, int mood) {
     evblockbasename="hotspot%d";
     evblocknum=hotspothere;
 
-    if (thisroom.Hotspots[hotspothere].EventHandlers != NULL)
+    if (thisroom.Hotspots[hotspothere].EventHandlers != nullptr)
     {
         if (passon>=0)
             run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5, (passon == 3));

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -250,7 +250,7 @@ void MergeObject(int obn) {
     if (!is_valid_object(obn)) quit("!MergeObject: invalid object specified");
     int theHeight;
 
-    construct_object_gfx(obn, NULL, &theHeight, true);
+    construct_object_gfx(obn, nullptr, &theHeight, true);
 
     //Bitmap *oldabuf = graphics->bmp;
     //abuf = thisroom.BgFrames.Graphic[play.bg_frame];
@@ -402,7 +402,7 @@ void RunObjectInteraction (int aa, int mood) {
     play.usedinv=cdata; }
     evblockbasename="object%d"; evblocknum=aa;
 
-    if (thisroom.Objects[aa].EventHandlers != NULL)
+    if (thisroom.Objects[aa].EventHandlers != nullptr)
     {
         if (passon>=0) 
         {
@@ -500,7 +500,7 @@ Bitmap *GetObjectImage(int obj, int *isFlipped)
 {
     if (!gfxDriver->HasAcceleratedTransform())
     {
-        if (actsps[obj] != NULL) {
+        if (actsps[obj] != nullptr) {
             // the actsps image is pre-flipped, so no longer register the image as such
             if (isFlipped)
                 *isFlipped = 0;

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -157,7 +157,7 @@ void RunRegionInteraction (int regnum, int mood) {
     evblockbasename = "region%d";
     evblocknum = regnum;
 
-    if (thisroom.Regions[regnum].EventHandlers != NULL)
+    if (thisroom.Regions[regnum].EventHandlers != nullptr)
     {
         run_interaction_script(thisroom.Regions[regnum].EventHandlers.get(), mood);
     }

--- a/Engine/ac/global_translation.cpp
+++ b/Engine/ac/global_translation.cpp
@@ -33,7 +33,7 @@ extern TreeMap *transtree;
 extern char transFileName[MAX_PATH];
 
 const char *get_translation (const char *text) {
-    if (text == NULL)
+    if (text == nullptr)
         quit("!Null string supplied to CheckForTranslations");
 
     source_text_length = GetTextDisplayLength(text);
@@ -47,10 +47,10 @@ const char *get_translation (const char *text) {
     }
 #endif
 
-    if (transtree != NULL) {
+    if (transtree != nullptr) {
         // translate the text using the translation file
         char * transl = transtree->findValue (text);
-        if (transl != NULL)
+        if (transl != nullptr)
             return transl;
     }
     // return the original text
@@ -58,7 +58,7 @@ const char *get_translation (const char *text) {
 }
 
 int IsTranslationAvailable () {
-    if (transtree != NULL)
+    if (transtree != nullptr)
         return 1;
     return 0;
 }
@@ -67,18 +67,18 @@ int GetTranslationName (char* buffer) {
     VALIDATE_STRING (buffer);
     const char *copyFrom = transFileName;
 
-    while (strchr(copyFrom, '\\') != NULL)
+    while (strchr(copyFrom, '\\') != nullptr)
     {
         copyFrom = strchr(copyFrom, '\\') + 1;
     }
-    while (strchr(copyFrom, '/') != NULL)
+    while (strchr(copyFrom, '/') != nullptr)
     {
         copyFrom = strchr(copyFrom, '/') + 1;
     }
 
     strcpy (buffer, copyFrom);
     // remove the ".tra" from the end of the filename
-    if (strstr (buffer, ".tra") != NULL)
+    if (strstr (buffer, ".tra") != nullptr)
         strstr (buffer, ".tra")[0] = 0;
 
     return IsTranslationAvailable();

--- a/Engine/ac/global_viewframe.cpp
+++ b/Engine/ac/global_viewframe.cpp
@@ -41,7 +41,7 @@ void SetFrameSound (int vii, int loop, int frame, int sound) {
     else
     {
         ScriptAudioClip* clip = GetAudioClipForOldStyleNumber(game, false, sound);
-        if (clip == NULL)
+        if (clip == nullptr)
             quitprintf("!SetFrameSound: audio clip aSound%d not found", sound);
 
         views[vii].loops[loop].frames[frame].sound = clip->id + (game.IsLegacyAudioSystem() ? 0x10000000 : 0);

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -73,7 +73,7 @@ int eip_guinum, eip_guiobj;
 
 ScriptGUI* GUI_AsTextWindow(ScriptGUI *tehgui)
 { // Internally both GUI and TextWindow are implemented by same class
-    return guis[tehgui->id].IsTextWindow() ? &scrGui[tehgui->id] : NULL;
+    return guis[tehgui->id].IsTextWindow() ? &scrGui[tehgui->id] : nullptr;
 }
 
 int GUI_GetPopupStyle(ScriptGUI *tehgui)
@@ -173,7 +173,7 @@ int GUI_GetID(ScriptGUI *tehgui) {
 
 GUIObject* GUI_GetiControls(ScriptGUI *tehgui, int idx) {
   if ((idx < 0) || (idx >= guis[tehgui->id].GetControlCount()))
-    return NULL;
+    return nullptr;
   return guis[tehgui->id].GetControl(idx);
 }
 
@@ -291,7 +291,7 @@ void GUI_SetTextPadding(ScriptGUI *tehgui, int newpos)
 ScriptGUI *GetGUIAtLocation(int xx, int yy) {
     int guiid = GetGUIAt(xx, yy);
     if (guiid < 0)
-        return NULL;
+        return nullptr;
     return &scrGui[guiid];
 }
 
@@ -366,7 +366,7 @@ void process_interface_click(int ifce, int btn, int mbut) {
             (!theObj->EventHandlers[0].IsEmpty()) &&
             (!gameinst->GetSymbolAddress(theObj->EventHandlers[0]).IsNull())) {
                 // control-specific event handler
-                if (strchr(theObj->GetEventArgs(0), ',') != NULL)
+                if (strchr(theObj->GetEventArgs(0), ',') != nullptr)
                     QueueScriptFunction(kScInstGame, theObj->EventHandlers[0], 2,
                         RuntimeScriptValue().SetDynamicObject(theObj, &ccDynamicGUIObject),
                         RuntimeScriptValue().SetInt32(mbut));
@@ -576,14 +576,14 @@ void recreate_guibg_image(GUIMain *tehgui)
   int ifn = tehgui->ID;
   delete guibg[ifn];
   guibg[ifn] = BitmapHelper::CreateBitmap(tehgui->Width, tehgui->Height, game.GetColorDepth());
-  if (guibg[ifn] == NULL)
+  if (guibg[ifn] == nullptr)
     quit("SetGUISize: internal error: unable to reallocate gui cache");
   guibg[ifn] = ReplaceBitmapWithSupportedFormat(guibg[ifn]);
 
-  if (guibgbmp[ifn] != NULL)
+  if (guibgbmp[ifn] != nullptr)
   {
     gfxDriver->DestroyDDB(guibgbmp[ifn]);
-    guibgbmp[ifn] = NULL;
+    guibgbmp[ifn] = nullptr;
   }
 }
 

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -36,7 +36,7 @@ extern CCGUIObject ccDynamicGUIObject;
 GUIObject *GetGUIControlAtLocation(int xx, int yy) {
     int guinum = GetGUIAt(xx, yy);
     if (guinum == -1)
-        return NULL;
+        return nullptr;
 
     data_to_game_coords(&xx, &yy);
 
@@ -47,7 +47,7 @@ GUIObject *GetGUIControlAtLocation(int xx, int yy) {
     mousex = oldmousex;
     mousey = oldmousey;
     if (toret < 0)
-        return NULL;
+        return nullptr;
 
     return guis[guinum].GetControl(toret);
 }
@@ -108,42 +108,42 @@ ScriptGUI* GUIControl_GetOwningGUI(GUIObject *guio) {
 
 GUIButton* GUIControl_GetAsButton(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIButton)
-    return NULL;
+    return nullptr;
 
   return (GUIButton*)guio;
 }
 
 GUIInvWindow* GUIControl_GetAsInvWindow(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIInvWindow)
-    return NULL;
+    return nullptr;
 
   return (GUIInvWindow*)guio;
 }
 
 GUILabel* GUIControl_GetAsLabel(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUILabel)
-    return NULL;
+    return nullptr;
 
   return (GUILabel*)guio;
 }
 
 GUIListBox* GUIControl_GetAsListBox(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUIListBox)
-    return NULL;
+    return nullptr;
 
   return (GUIListBox*)guio;
 }
 
 GUISlider* GUIControl_GetAsSlider(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUISlider)
-    return NULL;
+    return nullptr;
 
   return (GUISlider*)guio;
 }
 
 GUITextBox* GUIControl_GetAsTextBox(GUIObject *guio) {
   if (guis[guio->ParentId].GetControlType(guio->Id) != kGUITextBox)
-    return NULL;
+    return nullptr;
 
   return (GUITextBox*)guio;
 }

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -58,7 +58,7 @@ int InventoryItem_GetID(ScriptInvItem *scii) {
 ScriptInvItem *GetInvAtLocation(int xx, int yy) {
   int hsnum = GetInvAt(xx, yy);
   if (hsnum <= 0)
-    return NULL;
+    return nullptr;
   return &scrInv[hsnum];
 }
 

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -57,7 +57,7 @@ int in_inv_screen = 0, inv_screen_newroom = -1;
 // *** INV WINDOW FUNCTIONS
 
 void InvWindow_SetCharacterToUse(GUIInvWindow *guii, CharacterInfo *chaa) {
-  if (chaa == NULL)
+  if (chaa == nullptr)
     guii->CharId = -1;
   else
     guii->CharId = chaa->index_id;
@@ -69,7 +69,7 @@ void InvWindow_SetCharacterToUse(GUIInvWindow *guii, CharacterInfo *chaa) {
 
 CharacterInfo* InvWindow_GetCharacterToUse(GUIInvWindow *guii) {
   if (guii->CharId < 0)
-    return NULL;
+    return nullptr;
 
   return &game.chars[guii->CharId];
 }
@@ -135,7 +135,7 @@ void InvWindow_ScrollUp(GUIInvWindow *guii) {
 
 ScriptInvItem* InvWindow_GetItemAtIndex(GUIInvWindow *guii, int index) {
   if ((index < 0) || (index >= charextra[guii->GetCharacterId()].invorder_count))
-    return NULL;
+    return nullptr;
   return &scrInv[charextra[guii->GetCharacterId()].invorder[index]];
 }
 
@@ -221,11 +221,11 @@ void InventoryScreen::Prepare()
 
     // sprites 2041, 2042 and 2043 were hardcoded in the older versions
     // of the engine to be used in the built-in inventory window
-    if (spriteset[2041] == NULL || spriteset[2042] == NULL || spriteset[2043] == NULL)
+    if (spriteset[2041] == nullptr || spriteset[2042] == nullptr || spriteset[2043] == nullptr)
         debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, using sprite 0 instead");
-    btn_look_sprite = spriteset[2041] != NULL ? 2041 : 0;
-    btn_select_sprite = spriteset[2042] != NULL ? 2042 : 0;
-    btn_ok_sprite = spriteset[2043] != NULL ? 2043 : 0;
+    btn_look_sprite = spriteset[2041] != nullptr ? 2041 : 0;
+    btn_select_sprite = spriteset[2042] != nullptr ? 2042 : 0;
+    btn_ok_sprite = spriteset[2043] != nullptr ? 2043 : 0;
 
     break_code = 0;
 }

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -106,7 +106,7 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
     if (numsaves >= MAXSAVEGAMES)
       break;
     // only list games .000 to .099 (to allow higher slots for other perposes)
-    if (strstr(ffb.name,".0")==NULL) {
+    if (strstr(ffb.name,".0")==nullptr) {
       don = al_findnext(&ffb);
       continue;
     }

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -53,9 +53,9 @@ int cur_mode,cur_cursor;
 int mouse_frame=0,mouse_delay=0;
 int lastmx=-1,lastmy=-1;
 char alpha_blend_cursor = 0;
-Bitmap *dotted_mouse_cursor = NULL;
-IDriverDependantBitmap *mouseCursor = NULL;
-Bitmap *blank_mouse_cursor = NULL;
+Bitmap *dotted_mouse_cursor = nullptr;
+IDriverDependantBitmap *mouseCursor = nullptr;
+Bitmap *blank_mouse_cursor = nullptr;
 
 // The Mouse:: functions are static so the script doesn't pass
 // in an object parameter
@@ -110,7 +110,7 @@ void set_mouse_cursor(int newcurs) {
 
     set_new_cursor_graphic(game.mcurs[newcurs].pic);
     delete dotted_mouse_cursor;
-    dotted_mouse_cursor = NULL;
+    dotted_mouse_cursor = nullptr;
 
     if ((newcurs == MODE_USE) && (game.mcurs[newcurs].pic > 0) &&
         ((game.hotdot > 0) || (game.invhotdotsprite > 0)) ) {
@@ -345,7 +345,7 @@ void update_inv_cursor(int invnum) {
 
 void update_cached_mouse_cursor() 
 {
-    if (mouseCursor != NULL)
+    if (mouseCursor != nullptr)
         gfxDriver->DestroyDDB(mouseCursor);
     mouseCursor = gfxDriver->CreateDDBFromBitmap(mousecurs[0], alpha_blend_cursor != 0);
 }
@@ -355,9 +355,9 @@ void set_new_cursor_graphic (int spriteslot) {
 
     // It looks like spriteslot 0 can be used in games with version 2.72 and lower.
     // The NULL check should ensure that the sprite is valid anyway.
-    if (((spriteslot < 1) && (loaded_game_file_version > kGameVersion_272)) || (mousecurs[0] == NULL))
+    if (((spriteslot < 1) && (loaded_game_file_version > kGameVersion_272)) || (mousecurs[0] == nullptr))
     {
-        if (blank_mouse_cursor == NULL)
+        if (blank_mouse_cursor == nullptr)
         {
             blank_mouse_cursor = BitmapHelper::CreateTransparentBitmap(1, 1, game.GetColorDepth());
         }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -58,7 +58,7 @@ int Object_IsCollidingWithObject(ScriptObject *objj, ScriptObject *obj2) {
 ScriptObject *GetObjectAtScreen(int xx, int yy) {
     int hsnum = GetObjectIDAtScreen(xx, yy);
     if (hsnum < 0)
-        return NULL;
+        return nullptr;
     return &scrObj[hsnum];
 }
 
@@ -66,7 +66,7 @@ ScriptObject *GetObjectAtRoom(int x, int y)
 {
     int hsnum = GetObjectIDAtRoom(x, y);
     if (hsnum < 0)
-        return NULL;
+        return nullptr;
     return &scrObj[hsnum];
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -146,11 +146,11 @@ ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colo
 void remove_screen_overlay_index(int cc) {
     int dd;
     delete screenover[cc].pic;
-    screenover[cc].pic=NULL;
+    screenover[cc].pic=nullptr;
 
-    if (screenover[cc].bmp != NULL)
+    if (screenover[cc].bmp != nullptr)
         gfxDriver->DestroyDDB(screenover[cc].bmp);
-    screenover[cc].bmp = NULL;
+    screenover[cc].bmp = nullptr;
 
     if (screenover[cc].type==OVER_COMPLETE) is_complete_overlay--;
     if (screenover[cc].type==OVER_TEXTMSG) is_text_overlay--;
@@ -267,7 +267,7 @@ void recreate_overlay_ddbs()
         if (screenover[i].pic)
             screenover[i].bmp = gfxDriver->CreateDDBFromBitmap(screenover[i].pic, false);
         else
-            screenover[i].bmp = NULL;
+            screenover[i].bmp = nullptr;
     }
 }
 

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -35,12 +35,12 @@ int Parser_FindWordID(const char *wordToFind)
 
 const char* Parser_SaidUnknownWord() {
     if (play.bad_parsed_word[0] == 0)
-        return NULL;
+        return nullptr;
     return CreateNewScriptString(play.bad_parsed_word);
 }
 
 void ParseText (const char*text) {
-    parse_sentence (text, &play.num_parsed_words, play.parsed_words, NULL, 0);
+    parse_sentence (text, &play.num_parsed_words, play.parsed_words, nullptr, 0);
 }
 
 // Said: call with argument for example "get apple"; we then check
@@ -56,7 +56,7 @@ int Said (const char *checkwords) {
 
 int find_word_in_dictionary (const char *lookfor) {
     int j;
-    if (game.dict == NULL)
+    if (game.dict == nullptr)
         return -1;
 
     for (j = 0; j < game.dict->num_words; j++) {
@@ -90,7 +90,7 @@ int FindMatchingMultiWordWord(char *thisword, const char **text) {
     // that match -- if so, use them
     const char *tempptr = *text;
     char tempword[150] = "";
-    if (thisword != NULL)
+    if (thisword != nullptr)
         strcpy(tempword, thisword);
 
     int bestMatchFound = -1, word;
@@ -121,7 +121,7 @@ int FindMatchingMultiWordWord(char *thisword, const char **text) {
     if (word >= 0) {
         // yes, a word like "pick up" was found
         *text = tempptrAtBestMatch;
-        if (thisword != NULL)
+        if (thisword != nullptr)
             strcpy(thisword, tempword);
     }
 
@@ -137,17 +137,17 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
     int  optional_start = 0;
 
     numwords[0] = 0;
-    if (compareto == NULL)
+    if (compareto == nullptr)
         play.bad_parsed_word[0] = 0;
 
     String uniform_text = src_text;
     uniform_text.MakeLower();
     const char *text = uniform_text.GetCStr();
     while (1) {
-        if ((compareto != NULL) && (compareto[comparing] == RESTOFLINE))
+        if ((compareto != nullptr) && (compareto[comparing] == RESTOFLINE))
             return 1;
 
-        if ((text[0] == ']') && (compareto != NULL)) {
+        if ((text[0] == ']') && (compareto != nullptr)) {
             if (!in_optional)
                 quit("!Said: unexpected ']'");
             do_word_now = 1;
@@ -158,7 +158,7 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
             thisword[i] = text[0];
             i++;
         }
-        else if ((text[0] == '[') && (compareto != NULL)) {
+        else if ((text[0] == '[') && (compareto != nullptr)) {
             if (in_optional)
                 quit("!Said: nested optional words");
 

--- a/Engine/ac/properties.cpp
+++ b/Engine/ac/properties.cpp
@@ -78,7 +78,7 @@ const char* get_text_property_dynamic_string(const StringIMap &st_prop, const St
 {
     PropertyDesc desc;
     if (!get_property_desc(desc, property, kPropertyString))
-        return NULL;
+        return nullptr;
 
     String val = get_property_value(st_prop, rt_prop, property, desc.DefaultValue);
     return CreateNewScriptString(val);

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -44,7 +44,7 @@ ScriptRegion *GetRegionAtScreen(int x, int y)
 {
     VpPoint vpt = play.ScreenToRoomDivDown(x, y);
     if (vpt.second < 0)
-        return 0;
+        return nullptr;
     return GetRegionAtRoom(vpt.first.X, vpt.first.Y);
 }
 
@@ -120,9 +120,9 @@ void Region_RunInteraction(ScriptRegion *ssr, int mood) {
 
 void generate_light_table()
 {
-    if (game.color_depth == 1 && color_map == NULL)
+    if (game.color_depth == 1 && color_map == nullptr)
     {
-        create_light_table(&maincoltable, palette, 0, 0, 0, NULL);
+        create_light_table(&maincoltable, palette, 0, 0, 0, nullptr);
         color_map = &maincoltable;
     }
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -200,7 +200,7 @@ bool Room_SetTextProperty(const char *property, const char *value)
 
 const char* Room_GetMessages(int index) {
     if ((index < 0) || ((size_t)index >= thisroom.MessageCount)) {
-        return NULL;
+        return nullptr;
     }
     char buffer[STD_BUFFER_SIZE];
     buffer[0]=0;
@@ -274,19 +274,19 @@ void unload_old_room() {
     cancel_all_scripts();
     numevents = 0;  // cancel any pending room events
 
-    if (roomBackgroundBmp != NULL)
+    if (roomBackgroundBmp != nullptr)
     {
         gfxDriver->DestroyDDB(roomBackgroundBmp);
-        roomBackgroundBmp = NULL;
+        roomBackgroundBmp = nullptr;
     }
 
-    if (croom==NULL) ;
-    else if (roominst!=NULL) {
+    if (croom==nullptr) ;
+    else if (roominst!=nullptr) {
         save_room_data_segment();
         delete roominstFork;
         delete roominst;
-        roominstFork = NULL;
-        roominst=NULL;
+        roominstFork = nullptr;
+        roominst=nullptr;
     }
     else croom->tsdatasize=0;
     memset(&play.walkable_areas_on[0],1,MAX_WALK_AREAS+1);
@@ -295,7 +295,7 @@ void unload_old_room() {
     play.ReleaseRoomCamera();
     remove_screen_overlay(-1);
     delete raw_saved_screen;
-    raw_saved_screen = NULL;
+    raw_saved_screen = nullptr;
     for (ff = 0; ff < MAX_ROOM_BGFRAMES; ff++)
         play.raw_modified[ff] = 0;
     for (size_t i = 0; i < thisroom.LocalVariables.size() && i < MAX_GLOBAL_VARIABLES; ++i)
@@ -305,7 +305,7 @@ void unload_old_room() {
     for (ff = 0; ff < game.numcharacters; ff++) {
         if (charcache[ff].inUse) {
             delete charcache[ff].image;
-            charcache[ff].image = NULL;
+            charcache[ff].image = nullptr;
             charcache[ff].inUse = 0;
         }
         // ensure that any half-moves (eg. with scaled movement) are stopped
@@ -335,25 +335,25 @@ void unload_old_room() {
     // clear the object cache
     for (ff = 0; ff < MAX_ROOM_OBJECTS; ff++) {
         delete objcache[ff].image;
-        objcache[ff].image = NULL;
+        objcache[ff].image = nullptr;
     }
     // clear the actsps buffers to save memory, since the
     // objects/characters involved probably aren't on the
     // new screen. this also ensures all cached data is flushed
     for (ff = 0; ff < MAX_ROOM_OBJECTS + game.numcharacters; ff++) {
         delete actsps[ff];
-        actsps[ff] = NULL;
+        actsps[ff] = nullptr;
 
-        if (actspsbmp[ff] != NULL)
+        if (actspsbmp[ff] != nullptr)
             gfxDriver->DestroyDDB(actspsbmp[ff]);
-        actspsbmp[ff] = NULL;
+        actspsbmp[ff] = nullptr;
 
         delete actspswb[ff];
-        actspswb[ff] = NULL;
+        actspswb[ff] = nullptr;
 
-        if (actspswbbmp[ff] != NULL)
+        if (actspswbbmp[ff] != nullptr)
             gfxDriver->DestroyDDB(actspswbbmp[ff]);
-        actspswbbmp[ff] = NULL;
+        actspswbbmp[ff] = nullptr;
 
         actspswbcache[ff].valid = 0;
     }
@@ -537,7 +537,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     our_eip=205;
     // setup objects
-    if (forchar != NULL) {
+    if (forchar != nullptr) {
         // if not restoring a game, always reset this room
         troom.beenhere=0;  
         troom.FreeScriptData();
@@ -554,7 +554,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         // since we will overwrite the actual NewInteraction structs
         // (cos they have pointers and this might have been loaded from
         // a save game)
-        if (thisroom.EventHandlers == NULL)
+        if (thisroom.EventHandlers == nullptr)
         {// legacy interactions
             thisroom.Interaction->CopyTimesRun(croom->intrRoom);
             for (cc=0;cc < MAX_ROOM_HOTSPOTS;cc++)
@@ -619,7 +619,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     update_polled_stuff_if_runtime();
 
-    if (thisroom.EventHandlers == NULL)
+    if (thisroom.EventHandlers == nullptr)
     {// legacy interactions
         // copy interactions from room file into our temporary struct
         croom->intrRoom = *thisroom.Interaction;
@@ -682,11 +682,11 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             if (palette[ff].b > 63)
                 palette[ff].b = 63;
         }
-        create_rgb_table (&rgb_table, palette, NULL);
+        create_rgb_table (&rgb_table, palette, nullptr);
         rgb_map = &rgb_table;
     }
     our_eip = 211;
-    if (forchar!=NULL) {
+    if (forchar!=nullptr) {
         // if it's not a Restore Game
 
         // if a following character is still waiting to come into the
@@ -714,9 +714,9 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
 
     update_polled_stuff_if_runtime();
 
-    roominst=NULL;
+    roominst=nullptr;
     if (debug_flags & DBG_NOSCRIPT) ;
-    else if (thisroom.CompiledScript!=NULL) {
+    else if (thisroom.CompiledScript!=nullptr) {
         compile_room_script();
         if (croom->tsdatasize>0) {
             if (croom->tsdatasize != roominst->globaldatasize)
@@ -727,7 +727,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     our_eip=207;
     play.entered_edge = -1;
 
-    if ((new_room_x != SCR_NO_VALUE) && (forchar != NULL))
+    if ((new_room_x != SCR_NO_VALUE) && (forchar != nullptr))
     {
         forchar->x = new_room_x;
         forchar->y = new_room_y;
@@ -738,7 +738,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     new_room_x = SCR_NO_VALUE;
 	new_room_loop = SCR_NO_VALUE;
 
-    if ((new_room_pos>0) & (forchar!=NULL)) {
+    if ((new_room_pos>0) & (forchar!=nullptr)) {
         if (new_room_pos>=4000) {
             play.entered_edge = 3;
             forchar->y = thisroom.Edges.Top + get_fixed_pixel_size(1);
@@ -814,7 +814,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         }
         new_room_pos=0;
     }
-    if (forchar!=NULL) {
+    if (forchar!=nullptr) {
         play.entered_at_x=forchar->x;
         play.entered_at_y=forchar->y;
         if (forchar->x >= thisroom.Edges.Right)
@@ -830,7 +830,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         PlayMusicResetQueue(thisroom.Options.StartupMusic);
 
     our_eip=208;
-    if (forchar!=NULL) {
+    if (forchar!=nullptr) {
         if (thisroom.Options.PlayerCharOff==0) { forchar->on=1;
         enable_cursor_mode(0); }
         else {
@@ -846,7 +846,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         else forchar->view=thisroom.Options.PlayerView-1;
         forchar->frame=0;   // make him standing
     }
-    color_map = NULL;
+    color_map = nullptr;
 
     our_eip = 209;
     update_polled_stuff_if_runtime();
@@ -921,11 +921,11 @@ void new_room(int newnum,CharacterInfo*forchar) {
         for (int i = 0; i < game.numgui; i++)
         {
             delete guibg[i];
-            guibg[i] = NULL;
+            guibg[i] = nullptr;
 
             if (guibgbmp[i])
                 gfxDriver->DestroyDDB(guibgbmp[i]);
-            guibgbmp[i] = NULL;
+            guibgbmp[i] = nullptr;
         }
         guis_need_update = 1;
     }
@@ -979,12 +979,12 @@ void compile_room_script() {
 
     roominst = ccInstance::CreateFromScript(thisroom.CompiledScript);
 
-    if ((ccError!=0) || (roominst==NULL)) {
+    if ((ccError!=0) || (roominst==nullptr)) {
         quitprintf("Unable to create local script: %s", ccErrorString.GetCStr());
     }
 
     roominstFork = roominst->Fork();
-    if (roominstFork == NULL)
+    if (roominstFork == nullptr)
         quitprintf("Unable to create forked room instance: %s", ccErrorString.GetCStr());
 
     repExecAlways.roomHasFunction = true;
@@ -1023,8 +1023,8 @@ void on_background_frame_change () {
 
 void croom_ptr_clear()
 {
-    croom = NULL;
-    objs = NULL;
+    croom = nullptr;
+    objs = nullptr;
 }
 
 void convert_move_path_to_room_resolution(MoveList *ml)

--- a/Engine/ac/roomstatus.cpp
+++ b/Engine/ac/roomstatus.cpp
@@ -28,7 +28,7 @@ RoomStatus::RoomStatus()
     numobj = 0;
     memset(&flagstates, 0, sizeof(flagstates));
     tsdatasize = 0;
-    tsdata = NULL;
+    tsdata = nullptr;
     
     memset(&hotspot_enabled, 0, sizeof(hotspot_enabled));
     memset(&region_enabled, 0, sizeof(region_enabled));
@@ -46,7 +46,7 @@ void RoomStatus::FreeScriptData()
 {
     if (tsdata)
         delete [] tsdata;
-    tsdata = NULL;
+    tsdata = nullptr;
     tsdatasize = 0;
 }
 
@@ -208,7 +208,7 @@ RoomStatus* room_statuses[MAX_ROOMS];
 // Replaces all accesses to the roomstats array
 RoomStatus* getRoomStatus(int room)
 {
-    if (room_statuses[room] == NULL)
+    if (room_statuses[room] == nullptr)
     {
         // First access, allocate and initialise the status
         room_statuses[room] = new RoomStatus();
@@ -222,17 +222,17 @@ RoomStatus* getRoomStatus(int room)
 // a room if the status is already initialised.
 bool isRoomStatusValid(int room)
 {
-    return (room_statuses[room] != NULL);
+    return (room_statuses[room] != nullptr);
 }
 
 void resetRoomStatuses()
 {
     for (int i = 0; i < MAX_ROOMS; i++)
     {
-        if (room_statuses[i] != NULL)
+        if (room_statuses[i] != nullptr)
         {
             delete room_statuses[i];
-            room_statuses[i] = NULL;
+            room_statuses[i] = nullptr;
         }
     }
 }

--- a/Engine/ac/route_finder_jps.inl
+++ b/Engine/ac/route_finder_jps.inl
@@ -69,7 +69,7 @@ private:
 		float cost;
 		int index;
 
-		inline Entry() {}
+		inline Entry() = default;
 
 		inline Entry(float ncost, int nindex)
 			: cost(ncost)

--- a/Engine/ac/route_finder_jps.inl
+++ b/Engine/ac/route_finder_jps.inl
@@ -55,7 +55,7 @@ public:
 	NavResult Navigate(int sx, int sy, int ex, int ey, std::vector<int> &opath);
 
 	bool TraceLine(int srcx, int srcy, int targx, int targy, int &lastValidX, int &lastValidY) const;
-	bool TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> *rpath = NULL) const;
+	bool TraceLine(int srcx, int srcy, int targx, int targy, std::vector<int> *rpath = nullptr) const;
 
 	inline void SetMapRow(int y, const unsigned char *row) {map[y] = row;}
 

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -50,7 +50,7 @@ void my_fade_in(PALETTE p, int speed) {
     gfxDriver->FadeIn(speed, p, play.fade_to_red, play.fade_to_green, play.fade_to_blue);
 }
 
-Bitmap *saved_viewport_bitmap = NULL;
+Bitmap *saved_viewport_bitmap = nullptr;
 color old_palette[256];
 void current_fade_out_effect () {
     if (pl_run_plugin_hooks(AGSE_TRANSITIONOUT, 0))
@@ -85,7 +85,7 @@ void current_fade_out_effect () {
 
 IDriverDependantBitmap* prepare_screen_for_transition_in()
 {
-    if (saved_viewport_bitmap == NULL)
+    if (saved_viewport_bitmap == nullptr)
         quit("Crossfade: buffer is null attempting transition");
 
     saved_viewport_bitmap = ReplaceBitmapWithSupportedFormat(saved_viewport_bitmap);
@@ -148,7 +148,7 @@ ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry)
 
     VpPoint vpt = play.ScreenToRoom(scrx, scry);
     if (vpt.second < 0)
-        return NULL;
+        return nullptr;
 
     game_to_data_coords(vpt.first.X, vpt.first.Y);
     return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -20,8 +20,8 @@ using AGS::Common::Stream;
 void ScreenOverlay::ReadFromFile(Stream *in)
 {
     // Skipping bmp and pic pointer values
-    bmp = NULL;
-    pic = NULL;
+    bmp = nullptr;
+    pic = nullptr;
     in->ReadInt32(); // bmp
     hasSerializedBitmap = in->ReadInt32() != 0;
     type = in->ReadInt32();

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -125,13 +125,13 @@ void initialize_sprite (int ee) {
     if ((ee < 0) || (ee > spriteset.GetSpriteSlotCount()))
         quit("initialize_sprite: invalid sprite number");
 
-    if ((spriteset[ee] == NULL) && (ee > 0)) {
+    if ((spriteset[ee] == nullptr) && (ee > 0)) {
         // replace empty sprites with blue cups, to avoid crashes
         spriteset.Set(ee, spriteset[0]);
         game.SpriteInfos[ee].Width = game.SpriteInfos[0].Width;
         game.SpriteInfos[ee].Height = game.SpriteInfos[0].Height;
     }
-    else if (spriteset[ee]==NULL) {
+    else if (spriteset[ee]==nullptr) {
         game.SpriteInfos[ee].Width=0;
         game.SpriteInfos[ee].Height=0;
     }
@@ -154,7 +154,7 @@ void initialize_sprite (int ee) {
 
         if ((newwid != curspr->GetWidth()) || (newhit != curspr->GetHeight())) {
             tmpdbl = BitmapHelper::CreateTransparentBitmap(newwid,newhit,curspr->GetColorDepth());
-            if (tmpdbl == NULL)
+            if (tmpdbl == nullptr)
                 quit("Not enough memory to load sprite graphics");
             tmpdbl->Acquire ();
             curspr->Acquire ();

--- a/Engine/ac/statobj/agsstaticobject.h
+++ b/Engine/ac/statobj/agsstaticobject.h
@@ -21,7 +21,7 @@
 #include "ac/statobj/staticobject.h"
 
 struct AGSStaticObject : public ICCStaticObject {
-    ~AGSStaticObject() override{}
+    ~AGSStaticObject() override = default;
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/statobj/staticarray.cpp
+++ b/Engine/ac/statobj/staticarray.cpp
@@ -5,8 +5,8 @@
 
 void StaticArray::Create(int elem_legacy_size, int elem_real_size, int elem_count)
 {
-    _staticMgr      = NULL;
-    _dynamicMgr     = NULL;
+    _staticMgr      = nullptr;
+    _dynamicMgr     = nullptr;
     _elemLegacySize = elem_legacy_size;
     _elemRealSize   = elem_real_size;
     _elemCount      = elem_count;
@@ -15,7 +15,7 @@ void StaticArray::Create(int elem_legacy_size, int elem_real_size, int elem_coun
 void StaticArray::Create(ICCStaticObject *stcmgr, int elem_legacy_size, int elem_real_size, int elem_count)
 {
     _staticMgr      = stcmgr;
-    _dynamicMgr     = NULL;
+    _dynamicMgr     = nullptr;
     _elemLegacySize = elem_legacy_size;
     _elemRealSize   = elem_real_size;
     _elemCount      = elem_count;
@@ -23,7 +23,7 @@ void StaticArray::Create(ICCStaticObject *stcmgr, int elem_legacy_size, int elem
 
 void StaticArray::Create(ICCDynamicObject *dynmgr, int elem_legacy_size, int elem_real_size, int elem_count)
 {
-    _staticMgr      = NULL;
+    _staticMgr      = nullptr;
     _dynamicMgr     = dynmgr;
     _elemLegacySize = elem_legacy_size;
     _elemRealSize   = elem_real_size;

--- a/Engine/ac/statobj/staticarray.h
+++ b/Engine/ac/statobj/staticarray.h
@@ -24,7 +24,7 @@ struct ICCDynamicObject;
 
 struct StaticArray : public ICCStaticObject {
 public:
-    ~StaticArray() override{}
+    ~StaticArray() override = default;
 
     void Create(int elem_legacy_size, int elem_real_size, int elem_count = -1 /*unknown*/);
     void Create(ICCStaticObject *stcmgr, int elem_legacy_size, int elem_real_size, int elem_count = -1 /*unknown*/);

--- a/Engine/ac/statobj/staticobject.h
+++ b/Engine/ac/statobj/staticobject.h
@@ -23,7 +23,7 @@
 #include "core/types.h"
 
 struct ICCStaticObject {
-    virtual ~ICCStaticObject(){}
+    virtual ~ICCStaticObject() = default;
 
     // Legacy support for reading and writing object values by their relative offset
     virtual const char* GetFieldPtr(const char *address, intptr_t offset)           = 0;

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -33,7 +33,7 @@ extern ScriptString myScriptStringImpl;
 
 int String_IsNullOrEmpty(const char *thisString) 
 {
-    if ((thisString == NULL) || (thisString[0] == 0))
+    if ((thisString == nullptr) || (thisString[0] == 0))
         return 1;
 
     return 0;
@@ -205,7 +205,7 @@ int StrContains (const char *s1, const char *s2) {
     free(tempbuf1);
     free(tempbuf2);
 
-    if (offs == NULL)
+    if (offs == nullptr)
         return -1;
 
     return (offs - tempbuf1);

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -35,14 +35,14 @@ extern GameState play;
 extern char transFileName[MAX_PATH];
 
 
-TreeMap *transtree = NULL;
+TreeMap *transtree = nullptr;
 long lang_offs_start = 0;
 char transFileName[MAX_PATH] = "\0";
 
 void close_translation () {
-    if (transtree != NULL) {
+    if (transtree != nullptr) {
         delete transtree;
-        transtree = NULL;
+        transtree = nullptr;
     }
 }
 
@@ -55,7 +55,7 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
     sprintf(transFileName, "%s.tra", lang.GetCStr());
 
     Stream *language_file = find_open_asset(transFileName);
-    if (language_file == NULL)
+    if (language_file == nullptr)
     {
         Debug::Printf(kDbgMsg_Error, "Cannot open translation: %s", transFileName);
         return false;
@@ -71,7 +71,7 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
         return false;
     }
 
-    if (transtree != NULL)
+    if (transtree != nullptr)
     {
         close_translation();
     }
@@ -169,7 +169,7 @@ bool parse_translation(Stream *language_file, String &parse_error)
         }
     }
 
-    if (transtree->text == NULL)
+    if (transtree->text == nullptr)
     {
         parse_error = "The translation file was empty.";
         return false;

--- a/Engine/ac/tree_map.cpp
+++ b/Engine/ac/tree_map.cpp
@@ -18,56 +18,56 @@
 #include "ac/tree_map.h"
 
 TreeMap::TreeMap() {
-    left = NULL;
-    right = NULL;
-    text = NULL;
-    translation = NULL;
+    left = nullptr;
+    right = nullptr;
+    text = nullptr;
+    translation = nullptr;
 }
 
 char* TreeMap::findValue (const char* key) {
-    if (text == NULL)
-        return NULL;
+    if (text == nullptr)
+        return nullptr;
 
     if (strcmp(key, text) == 0)
         return translation;
     //debug_script_warn("Compare: '%s' with '%s'", key, text);
 
     if (strcmp (key, text) < 0) {
-        if (left == NULL)
-            return NULL;
+        if (left == nullptr)
+            return nullptr;
         return left->findValue (key);
     }
     else {
-        if (right == NULL)
-            return NULL;
+        if (right == nullptr)
+            return nullptr;
         return right->findValue (key);
     }
 }
 
 void TreeMap::addText (const char* ntx, char *trans) {
-    if ((ntx == NULL) || (ntx[0] == 0) ||
-        ((text != NULL) && (strcmp(ntx, text) == 0)))
+    if ((ntx == nullptr) || (ntx[0] == 0) ||
+        ((text != nullptr) && (strcmp(ntx, text) == 0)))
         // don't add if it's an empty string or if it's already here
         return;
 
-    if (text == NULL) {
+    if (text == nullptr) {
         text = (char*)malloc(strlen(ntx)+1);
         translation = (char*)malloc(strlen(trans)+1);
-        if (translation == NULL)
+        if (translation == nullptr)
             quit("load_translation: out of memory");
         strcpy(text, ntx);
         strcpy(translation, trans);
     }
     else if (strcmp(ntx, text) < 0) {
         // Earlier in alphabet, add to left
-        if (left == NULL)
+        if (left == nullptr)
             left = new TreeMap();
 
         left->addText (ntx, trans);
     }
     else if (strcmp(ntx, text) > 0) {
         // Later in alphabet, add to right
-        if (right == NULL)
+        if (right == nullptr)
             right = new TreeMap();
 
         right->addText (ntx, trans);
@@ -87,10 +87,10 @@ void TreeMap::clear() {
         free(text);
     if (translation)
         free(translation);
-    left = NULL;
-    right = NULL;
-    text = NULL;
-    translation = NULL;
+    left = nullptr;
+    right = nullptr;
+    text = nullptr;
+    translation = nullptr;
 }
 
 TreeMap::~TreeMap() {

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -50,7 +50,7 @@ ScriptAudioClip* ViewFrame_GetLinkedAudio(ScriptViewFrame *svf)
 {
   int soundIndex = views[svf->view].loops[svf->loop].frames[svf->frame].sound;
   if (soundIndex < 0)
-    return NULL;
+    return nullptr;
 
   return &game.audioClips[soundIndex];
 }
@@ -58,7 +58,7 @@ ScriptAudioClip* ViewFrame_GetLinkedAudio(ScriptViewFrame *svf)
 void ViewFrame_SetLinkedAudio(ScriptViewFrame *svf, ScriptAudioClip* clip) 
 {
   int newSoundIndex = -1;
-  if (clip != NULL)
+  if (clip != nullptr)
     newSoundIndex = clip->id;
 
   views[svf->view].loops[svf->loop].frames[svf->frame].sound = newSoundIndex;
@@ -79,7 +79,7 @@ void ViewFrame_SetSound(ScriptViewFrame *svf, int newSound)
   {
     // convert sound number to audio clip
     ScriptAudioClip* clip = GetAudioClipForOldStyleNumber(game, false, newSound);
-    if (clip == NULL)
+    if (clip == nullptr)
       quitprintf("!SetFrameSound: audio clip aSound%d not found", newSound);
 
     views[svf->view].loops[svf->loop].frames[svf->frame].sound = clip->id + (game.IsLegacyAudioSystem() ? 0x10000000 : 0);
@@ -118,7 +118,7 @@ void precache_view(int view)
 // the specified frame has just appeared, see if we need
 // to play a sound or whatever
 void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
-    ScriptAudioChannel *channel = NULL;
+    ScriptAudioChannel *channel = nullptr;
     if (game.IsLegacyAudioSystem())
     {
         if (views[view].loops[loop].frames[frame].sound > 0)
@@ -144,7 +144,7 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
             channel = play_audio_clip_by_index(views[view].loops[loop].frames[frame].sound);
         }
     }
-    if (sound_volume != SCR_NO_VALUE && channel != NULL)
+    if (sound_volume != SCR_NO_VALUE && channel != nullptr)
     {
         AudioChannelsLock lock;
         auto* ch = lock.GetChannel(channel->id);

--- a/Engine/ac/viewport.cpp
+++ b/Engine/ac/viewport.cpp
@@ -241,7 +241,7 @@ ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 
     const Rect &view = play.GetRoomViewport();
     if (!view.IsInside(x, y))
-        return NULL;
+        return nullptr;
 
     ScriptViewport *viewport = new ScriptViewport();
     ccRegisterManagedObject(viewport, viewport);
@@ -261,7 +261,7 @@ ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *, int scrx, int scr
 
     VpPoint vpt = play.ScreenToRoom(scrx, scry, clipViewport);
     if (vpt.second < 0)
-        return NULL;
+        return nullptr;
 
     game_to_data_coords(vpt.first.X, vpt.first.Y);
     return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);
@@ -274,7 +274,7 @@ ScriptUserObject *Viewport_RoomToScreenPoint(ScriptViewport *, int roomx, int ro
     const Rect &view = play.GetRoomViewport();
     Point pt = play.RoomToScreen(roomx, roomy);
     if (clipViewport && !view.IsInside(pt.X, pt.Y))
-        return NULL;
+        return nullptr;
 
     game_to_data_coords(pt.X, pt.Y);
     return ScriptStructHelpers::CreatePoint(pt.X, pt.Y);

--- a/Engine/ac/walkablearea.cpp
+++ b/Engine/ac/walkablearea.cpp
@@ -34,7 +34,7 @@ extern int displayed_room;
 extern RoomStatus*croom;
 extern RoomObject*objs;
 
-Bitmap *walkareabackup=NULL, *walkable_areas_temp = NULL;
+Bitmap *walkareabackup=nullptr, *walkable_areas_temp = nullptr;
 
 void redo_walkable_areas() {
 
@@ -164,7 +164,7 @@ Bitmap *prepare_walkable_areas (int sourceChar) {
 
         if (is_char_on_another(sourceChar, ww, &fromx, &cwidth))
             continue;
-        if ((sourceChar >= 0) && (is_char_on_another(ww, sourceChar, NULL, NULL)))
+        if ((sourceChar >= 0) && (is_char_on_another(ww, sourceChar, nullptr, nullptr)))
             continue;
 
         remove_walkable_areas_from_temp(fromx, cwidth, char1->get_blocking_top(), char1->get_blocking_bottom());

--- a/Engine/ac/walkbehind.cpp
+++ b/Engine/ac/walkbehind.cpp
@@ -27,8 +27,8 @@ extern GameState play;
 extern IGraphicsDriver *gfxDriver;
 
 
-char *walkBehindExists = NULL;  // whether a WB area is in this column
-int *walkBehindStartY = NULL, *walkBehindEndY = NULL;
+char *walkBehindExists = nullptr;  // whether a WB area is in this column
+int *walkBehindStartY = nullptr, *walkBehindEndY = nullptr;
 char noWalkBehindsAtAll = 0;
 int walkBehindLeft[MAX_WALK_BEHINDS], walkBehindTop[MAX_WALK_BEHINDS];
 int walkBehindRight[MAX_WALK_BEHINDS], walkBehindBottom[MAX_WALK_BEHINDS];
@@ -67,7 +67,7 @@ void update_walk_behind_images()
 
       update_polled_stuff_if_runtime();
 
-      if (walkBehindBitmap[ee] != NULL)
+      if (walkBehindBitmap[ee] != nullptr)
       {
         gfxDriver->DestroyDDB(walkBehindBitmap[ee]);
       }
@@ -101,10 +101,10 @@ void recache_walk_behinds () {
     walkBehindRight[ee] = 0;
     walkBehindBottom[ee] = 0;
 
-    if (walkBehindBitmap[ee] != NULL)
+    if (walkBehindBitmap[ee] != nullptr)
     {
       gfxDriver->DestroyDDB(walkBehindBitmap[ee]);
-      walkBehindBitmap[ee] = NULL;
+      walkBehindBitmap[ee] = nullptr;
     }
   }
 

--- a/Engine/debug/consoleoutputtarget.cpp
+++ b/Engine/debug/consoleoutputtarget.cpp
@@ -25,9 +25,7 @@ ConsoleOutputTarget::ConsoleOutputTarget()
 {
 }
 
-ConsoleOutputTarget::~ConsoleOutputTarget()
-{
-}
+ConsoleOutputTarget::~ConsoleOutputTarget() = default;
 
 void ConsoleOutputTarget::PrintMessage(const DebugMessage &msg)
 {

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -47,7 +47,7 @@ extern GameSetupStruct game;
 int editor_debugging_enabled = 0;
 int editor_debugging_initialized = 0;
 char editor_debugger_instance_token[100];
-IAGSEditorDebugger *editor_debugger = NULL;
+IAGSEditorDebugger *editor_debugger = nullptr;
 int break_on_next_script_step = 0;
 volatile int game_paused_in_debugger = 0;
 HWND editor_window_handle = 0;
@@ -65,7 +65,7 @@ IAGSEditorDebugger *GetEditorDebugger(const char *instanceToken)
 
 IAGSEditorDebugger *GetEditorDebugger(const char *instanceToken)
 {
-    return NULL;
+    return nullptr;
 }
 
 #endif
@@ -165,7 +165,7 @@ void shutdown_debug()
 
 void debug_set_console(bool enable)
 {
-    if (enable && DebugConsole.get() == NULL)
+    if (enable && DebugConsole.get() == nullptr)
     {
         DebugConsole.reset(new ConsoleOutputTarget());
         PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_Errors);
@@ -174,7 +174,7 @@ void debug_set_console(bool enable)
         if (DebugMsgBuff.get())
             DebugMsgBuff->Send(OutputGameConsoleID);
     }
-    else if (!enable && DebugConsole.get() != NULL)
+    else if (!enable && DebugConsole.get() != nullptr)
     {
         DbgMgr.UnregisterOutput(OutputGameConsoleID);
         DebugConsole.reset();
@@ -186,7 +186,7 @@ void debug_script_print(const String &msg, MessageType mt)
 {
     String script_ref;
     ccInstance *curinst = ccInstance::GetCurrentInstance();
-    if (curinst != NULL) {
+    if (curinst != nullptr) {
         String scriptname;
         if (curinst->instanceof == gamescript)
             scriptname = "G ";
@@ -264,7 +264,7 @@ bool send_message_to_editor(const char *msg, const char *errorMsg)
     sprintf(&messageToSend[strlen(messageToSend)], "  <EngineWindow>%d</EngineWindow> ", (int)win_get_window());
 #endif
     sprintf(&messageToSend[strlen(messageToSend)], "  <ScriptState><![CDATA[%s]]></ScriptState> ", callStack.GetCStr());
-    if (errorMsg != NULL)
+    if (errorMsg != nullptr)
     {
         sprintf(&messageToSend[strlen(messageToSend)], "  <ErrorMessage><![CDATA[%s]]></ErrorMessage> ", errorMsg);
     }
@@ -277,7 +277,7 @@ bool send_message_to_editor(const char *msg, const char *errorMsg)
 
 bool send_message_to_editor(const char *msg) 
 {
-    return send_message_to_editor(msg, NULL);
+    return send_message_to_editor(msg, nullptr);
 }
 
 bool init_editor_debugging() 
@@ -286,10 +286,10 @@ bool init_editor_debugging()
     editor_debugger = GetEditorDebugger(editor_debugger_instance_token);
 #else
     // Editor isn't ported yet
-    editor_debugger = NULL;
+    editor_debugger = nullptr;
 #endif
 
-    if (editor_debugger == NULL)
+    if (editor_debugger == nullptr)
         quit("editor_debugger is NULL but debugger enabled");
 
     if (editor_debugger->Initialize())
@@ -315,7 +315,7 @@ int check_for_messages_from_editor()
     if (editor_debugger->IsMessageAvailable())
     {
         char *msg = editor_debugger->GetNextMessage();
-        if (msg == NULL)
+        if (msg == nullptr)
         {
             return 0;
         }
@@ -461,7 +461,7 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
 
     // no plugin, use built-in debugger
 
-    if (ccinst == NULL) 
+    if (ccinst == nullptr) 
     {
         // come out of script
         return;

--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -61,10 +61,10 @@ bool FileBasedAGSDebugger::IsMessageAvailable()
 char* FileBasedAGSDebugger::GetNextMessage()
 {
     Stream *in = Common::File::OpenFileRead("dbgsend.tmp");
-    if (in == NULL)
+    if (in == nullptr)
     {
         // check again, because the editor might have deleted the file in the meantime
-        return NULL;
+        return nullptr;
     }
     int fileSize = in->GetLength();
     char *msg = (char*)malloc(fileSize + 1);

--- a/Engine/debug/logfile.cpp
+++ b/Engine/debug/logfile.cpp
@@ -70,7 +70,7 @@ bool LogFile::OpenFile(const String &file_path, LogFileOpenMode open_mode, bool 
                            open_mode == kLogFile_OpenAppend ? Common::kFile_Create : Common::kFile_CreateAlways,
                            Common::kFile_Write));
     }
-    return _file.get() != NULL || open_at_first_msg;
+    return _file.get() != nullptr || open_at_first_msg;
 }
 
 void LogFile::CloseFile()

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -328,8 +328,8 @@ void LoadFonts(GameDataVersion data_ver)
 
 void AllocScriptModules()
 {
-    moduleInst.resize(numScriptModules, NULL);
-    moduleInstFork.resize(numScriptModules, NULL);
+    moduleInst.resize(numScriptModules, nullptr);
+    moduleInstFork.resize(numScriptModules, nullptr);
     moduleRepExecAddr.resize(numScriptModules);
     repExecAlways.moduleHasFunction.resize(numScriptModules, true);
     lateRepExecAlways.moduleHasFunction.resize(numScriptModules, true);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -168,7 +168,7 @@ Bitmap *RestoreSaveImage(Stream *in)
 {
     if (in->ReadInt32())
         return read_serialized_bitmap(in);
-    return NULL;
+    return nullptr;
 }
 
 void SkipSaveImage(Stream *in)
@@ -336,7 +336,7 @@ HSaveError OpenSavegame(const String &filename, SavegameSource &src, SavegameDes
 
 HSaveError OpenSavegame(const String &filename, SavegameDescription &desc, SavegameDescElem elems)
 {
-    return OpenSavegameBase(filename, NULL, &desc, elems);
+    return OpenSavegameBase(filename, nullptr, &desc, elems);
 }
 
 // Prepares engine for actual save restore (stops processes, cleans up memory)
@@ -347,7 +347,7 @@ void DoBeforeRestore(PreservedParams &pp)
 
     unload_old_room();
     delete raw_saved_screen;
-    raw_saved_screen = NULL;
+    raw_saved_screen = nullptr;
     remove_screen_overlay(-1);
     is_complete_overlay = 0;
     is_text_overlay = 0;
@@ -368,37 +368,37 @@ void DoBeforeRestore(PreservedParams &pp)
     for (int i = 0; i < game.numgui; ++i)
     {
         delete guibg[i];
-        guibg[i] = NULL;
+        guibg[i] = nullptr;
 
         if (guibgbmp[i])
             gfxDriver->DestroyDDB(guibgbmp[i]);
-        guibgbmp[i] = NULL;
+        guibgbmp[i] = nullptr;
     }
 
     // preserve script data sizes and cleanup scripts
     pp.GlScDataSize = gameinst->globaldatasize;
     delete gameinstFork;
     delete gameinst;
-    gameinstFork = NULL;
-    gameinst = NULL;
+    gameinstFork = nullptr;
+    gameinst = nullptr;
     pp.ScMdDataSize.resize(numScriptModules);
     for (int i = 0; i < numScriptModules; ++i)
     {
         pp.ScMdDataSize[i] = moduleInst[i]->globaldatasize;
         delete moduleInstFork[i];
         delete moduleInst[i];
-        moduleInst[i] = NULL;
+        moduleInst[i] = nullptr;
     }
 
     play.FreeProperties();
 
     delete roominstFork;
     delete roominst;
-    roominstFork = NULL;
-    roominst = NULL;
+    roominstFork = nullptr;
+    roominst = nullptr;
 
     delete dialogScriptsInst;
-    dialogScriptsInst = NULL;
+    dialogScriptsInst = nullptr;
 
     resetRoomStatuses();
     troom.FreeScriptData();
@@ -441,7 +441,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // recache queued clips
     for (int i = 0; i < play.new_music_queue_size; ++i)
     {
-        play.new_music_queue[i].cachedClip = NULL;
+        play.new_music_queue[i].cachedClip = nullptr;
     }
 
     // restore these to the ones retrieved from the save game
@@ -489,7 +489,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
 
     // load the room the game was saved in
     if (displayed_room >= 0)
-        load_new_room(displayed_room, NULL);
+        load_new_room(displayed_room, nullptr);
 
     update_polled_stuff_if_runtime();
 
@@ -571,7 +571,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
             chan_info.Priority, chan_info.Repeat, chan_info.Pos);
 
         auto* ch = lock.GetChannel(i);
-        if (ch != NULL)
+        if (ch != nullptr)
         {
             ch->set_volume_direct(chan_info.VolAsPercent, chan_info.Vol);
             ch->set_speed(chan_info.Speed);
@@ -632,7 +632,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         first_room_initialization();
     }
 
-    if ((play.music_queue_size > 0) && (cachedQueuedMusic == NULL))
+    if ((play.music_queue_size > 0) && (cachedQueuedMusic == nullptr))
     {
         cachedQueuedMusic = load_music_from_disk(play.music_queue[0], 0);
     }
@@ -673,7 +673,7 @@ HSaveError RestoreGameState(PStream in, SavegameVersion svg_version)
 void WriteSaveImage(Stream *out, const Bitmap *screenshot)
 {
     // store the screenshot at the start to make it easily accesible
-    out->WriteInt32((screenshot == NULL) ? 0 : 1);
+    out->WriteInt32((screenshot == nullptr) ? 0 : 1);
 
     if (screenshot)
         serialize_bitmap(screenshot, out);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -271,7 +271,7 @@ HSaveError WriteAudio(PStream out)
     for (int i = 0; i <= MAX_SOUND_CHANNELS; i++)
     {
         auto* ch = lock.GetChannelIfPlaying(i);
-        if ((ch != nullptr) && (ch->sourceClip != NULL))
+        if ((ch != nullptr) && (ch->sourceClip != nullptr))
         {
             out->WriteInt32(((ScriptAudioClip*)ch->sourceClip)->id);
             out->WriteInt32(ch->get_pos());
@@ -703,7 +703,7 @@ HSaveError WriteDynamicSurfaces(PStream out)
     out->WriteInt32(MAX_DYNAMIC_SURFACES);
     for (int i = 0; i < MAX_DYNAMIC_SURFACES; ++i)
     {
-        if (dynamicallyCreatedSurfaces[i] == NULL)
+        if (dynamicallyCreatedSurfaces[i] == nullptr)
         {
             out->WriteInt8(0);
         }
@@ -726,7 +726,7 @@ HSaveError ReadDynamicSurfaces(PStream in, int32_t cmp_ver, const PreservedParam
     for (int i = 0; i < MAX_DYNAMIC_SURFACES; ++i)
     {
         if (in->ReadInt8() == 0)
-            r_data.DynamicSurfaces[i] = NULL;
+            r_data.DynamicSurfaces[i] = nullptr;
         else
             r_data.DynamicSurfaces[i] = read_serialized_bitmap(in.get());
     }
@@ -839,7 +839,7 @@ HSaveError WriteThisRoom(PStream out)
         if (play.raw_modified[i])
             serialize_bitmap(thisroom.BgFrames[i].Graphic.get(), out.get());
     }
-    out->WriteBool(raw_saved_screen != NULL);
+    out->WriteBool(raw_saved_screen != nullptr);
     if (raw_saved_screen)
         serialize_bitmap(raw_saved_screen, out.get());
 
@@ -888,7 +888,7 @@ HSaveError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
         if (play.raw_modified[i])
             r_data.RoomBkgScene[i].reset(read_serialized_bitmap(in.get()));
         else
-            r_data.RoomBkgScene[i] = NULL;
+            r_data.RoomBkgScene[i] = nullptr;
     }
     if (in->ReadBool())
         raw_saved_screen = read_serialized_bitmap(in.get());
@@ -1086,7 +1086,7 @@ ComponentHandler ComponentHandlers[] =
         WritePluginData,
         ReadPluginData
     },
-    { NULL, 0, 0, NULL, NULL } // end of array
+    { nullptr, 0, 0, nullptr, nullptr } // end of array
 };
 
 
@@ -1138,7 +1138,7 @@ HSaveError ReadComponent(PStream in, SvgCmpReadHelper &hlp, ComponentInfo &info)
     info.DataSize = hlp.Version >= kSvgVersion_Cmp_64bit ? in->ReadInt64() : in->ReadInt32();
     info.DataOffset = in->GetPosition();
 
-    const ComponentHandler *handler = NULL;
+    const ComponentHandler *handler = nullptr;
     std::map<String, ComponentHandler>::const_iterator it_hdr = hlp.Handlers.find(info.Name);
     if (it_hdr != hlp.Handlers.end())
         handler = &it_hdr->second;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -128,29 +128,29 @@ GFX_DRIVER gfx_opengl =
    empty_string,
    empty_string,
    "OpenGL",
-   NULL,    // init
-   NULL,   // exit
-   NULL,                        // AL_METHOD(int, scroll, (int x, int y)); 
+   nullptr,    // init
+   nullptr,   // exit
+   nullptr,                        // AL_METHOD(int, scroll, (int x, int y)); 
    ogl_dummy_vsync,   // vsync
-   NULL,  // setpalette
-   NULL,                        // AL_METHOD(int, request_scroll, (int x, int y));
-   NULL,                        // AL_METHOD(int, poll_scroll, (void));
-   NULL,                        // AL_METHOD(void, enable_triple_buffer, (void));
-   NULL,  //create_video_bitmap
-   NULL,  //destroy_video_bitmap
-   NULL,   //show_video_bitmap
-   NULL,
-   NULL,  //gfx_directx_create_system_bitmap,
-   NULL, //gfx_directx_destroy_system_bitmap,
-   NULL, //gfx_directx_set_mouse_sprite,
-   NULL, //gfx_directx_show_mouse,
-   NULL, //gfx_directx_hide_mouse,
-   NULL, //gfx_directx_move_mouse,
-   NULL,                        // AL_METHOD(void, drawing_mode, (void));
-   NULL,                        // AL_METHOD(void, save_video_state, (void*));
-   NULL,                        // AL_METHOD(void, restore_video_state, (void*));
-   NULL,                        // AL_METHOD(void, set_blender_mode, (int mode, int r, int g, int b, int a));
-   NULL,                        // AL_METHOD(int, fetch_mode_list, (void));
+   nullptr,  // setpalette
+   nullptr,                        // AL_METHOD(int, request_scroll, (int x, int y));
+   nullptr,                        // AL_METHOD(int, poll_scroll, (void));
+   nullptr,                        // AL_METHOD(void, enable_triple_buffer, (void));
+   nullptr,  //create_video_bitmap
+   nullptr,  //destroy_video_bitmap
+   nullptr,   //show_video_bitmap
+   nullptr,
+   nullptr,  //gfx_directx_create_system_bitmap,
+   nullptr, //gfx_directx_destroy_system_bitmap,
+   nullptr, //gfx_directx_set_mouse_sprite,
+   nullptr, //gfx_directx_show_mouse,
+   nullptr, //gfx_directx_hide_mouse,
+   nullptr, //gfx_directx_move_mouse,
+   nullptr,                        // AL_METHOD(void, drawing_mode, (void));
+   nullptr,                        // AL_METHOD(void, save_video_state, (void*));
+   nullptr,                        // AL_METHOD(void, restore_video_state, (void*));
+   nullptr,                        // AL_METHOD(void, set_blender_mode, (int mode, int r, int g, int b, int a));
+   nullptr,                        // AL_METHOD(int, fetch_mode_list, (void));
    0, 0,                        // int w, h;
    FALSE,                        // int linear;
    0,                           // long bank_size;
@@ -162,19 +162,19 @@ GFX_DRIVER gfx_opengl =
 
 void OGLBitmap::Dispose()
 {
-    if (_tiles != NULL)
+    if (_tiles != nullptr)
     {
         for (int i = 0; i < _numTiles; i++)
             glDeleteTextures(1, &(_tiles[i].texture));
 
         free(_tiles);
-        _tiles = NULL;
+        _tiles = nullptr;
         _numTiles = 0;
     }
-    if (_vertex != NULL)
+    if (_vertex != nullptr)
     {
         free(_vertex);
-        _vertex = NULL;
+        _vertex = nullptr;
     }
 }
 
@@ -194,7 +194,7 @@ OGLGraphicsDriver::OGLGraphicsDriver()
 #elif defined (LINUX_VERSION)
   device_screen_physical_width  = 0;
   device_screen_physical_height = 0;
-  _glxContext = 0;
+  _glxContext = nullptr;
   _have_window = false;
 #elif defined (ANDROID_VERSION)
   device_screen_physical_width  = android_screen_physical_width;
@@ -210,8 +210,8 @@ OGLGraphicsDriver::OGLGraphicsDriver()
   _tint_red = 0;
   _tint_green = 0;
   _tint_blue = 0;
-  _screenTintLayer = NULL;
-  _screenTintLayerDDB = NULL;
+  _screenTintLayer = nullptr;
+  _screenTintLayerDDB = nullptr;
   _screenTintSprite.skip = true;
   _screenTintSprite.x = 0;
   _screenTintSprite.y = 0;
@@ -662,9 +662,9 @@ void OGLGraphicsDriver::DeleteGlContext()
 #elif defined (LINUX_VERSION)
   if (_glxContext)
   {
-    glXMakeCurrent(_xwin.display, None, NULL);
+    glXMakeCurrent(_xwin.display, None, nullptr);
     glXDestroyContext(_xwin.display, _glxContext);
-    _glxContext = NULL;
+    _glxContext = nullptr;
   }
 #endif
 }
@@ -811,7 +811,7 @@ void OGLGraphicsDriver::CreateShaderProgram(ShaderProgram &prg, const char *name
                                             const char *sampler_var, const char *color_var, const char *aux_var)
 {
   GLint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
-  glShaderSource(fragment_shader, 1, &fragment_shader_src, NULL);
+  glShaderSource(fragment_shader, 1, &fragment_shader_src, nullptr);
   glCompileShader(fragment_shader);
   GLint result;
   glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &result);
@@ -906,7 +906,7 @@ void OGLGraphicsDriver::SetupBackbufferTexture()
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _backTextureSize.Width, _backTextureSize.Height, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _backTextureSize.Width, _backTextureSize.Height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
   glBindTexture(GL_TEXTURE_2D, 0);
 
   glGenFramebuffersEXT(1, &_fbo);
@@ -1046,18 +1046,18 @@ void OGLGraphicsDriver::ReleaseDisplayMode()
   OnModeReleased();
   DeleteBackbufferTexture();
 
-  if (_screenTintLayerDDB != NULL) 
+  if (_screenTintLayerDDB != nullptr) 
   {
     this->DestroyDDB(_screenTintLayerDDB);
-    _screenTintLayerDDB = NULL;
-    _screenTintSprite.bitmap = NULL;
+    _screenTintLayerDDB = nullptr;
+    _screenTintSprite.bitmap = nullptr;
   }
   delete _screenTintLayer;
-  _screenTintLayer = NULL;
+  _screenTintLayer = nullptr;
 
   DestroyAllStageScreens();
 
-  gfx_driver = NULL;
+  gfx_driver = nullptr;
 
   if (platform->ExitFullscreenMode())
     platform->RestoreWindowStyle();
@@ -1354,7 +1354,7 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 
-    if (bmpToDraw->_vertex != NULL)
+    if (bmpToDraw->_vertex != nullptr)
     {
       glTexCoordPointer(2, GL_FLOAT, sizeof(OGLCUSTOMVERTEX), &(bmpToDraw->_vertex[ti * 4].tu));
       glVertexPointer(2, GL_FLOAT, sizeof(OGLCUSTOMVERTEX), &(bmpToDraw->_vertex[ti * 4].position));
@@ -1522,7 +1522,7 @@ void OGLGraphicsDriver::RenderSpriteBatch(const OGLSpriteBatch &batch, GlobalFli
       continue;
 
     const OGLDrawListEntry *sprite = &listToDraw[i];
-    if (listToDraw[i].bitmap == NULL)
+    if (listToDraw[i].bitmap == nullptr)
     {
       if (DoNullSpriteCallback(listToDraw[i].x, listToDraw[i].y))
         stageEntry = OGLDrawListEntry((OGLBitmap*)_stageVirtualScreenDDB);
@@ -1771,7 +1771,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
   OGLTextureTile *tiles = (OGLTextureTile*)malloc(sizeof(OGLTextureTile) * numTiles);
   memset(tiles, 0, sizeof(OGLTextureTile) * numTiles);
 
-  OGLCUSTOMVERTEX *vertices = NULL;
+  OGLCUSTOMVERTEX *vertices = nullptr;
 
   if ((numTiles == 1) &&
       (allocatedWidth == bitmap->GetWidth()) &&
@@ -1812,7 +1812,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
         AdjustSizeToNearestSupportedByCard(&thisAllocatedWidth, &thisAllocatedHeight);
       }
 
-      if (vertices != NULL)
+      if (vertices != nullptr)
       {
         for (int vidx = 0; vidx < 4; vidx++)
         {
@@ -1837,7 +1837,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
       // NOTE: pay attention that the texture format depends on the **display mode**'s format,
       // rather than source bitmap's color depth!
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, thisAllocatedWidth, thisAllocatedHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, thisAllocatedWidth, thisAllocatedHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
     }
   }
 
@@ -1855,7 +1855,7 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   {
     this->_reDrawLastFrame();
   }
-  else if (_drawScreenCallback != NULL)
+  else if (_drawScreenCallback != nullptr)
     _drawScreenCallback();
   
   Bitmap *blackSquare = BitmapHelper::CreateBitmap(16, 16, 32);
@@ -1908,7 +1908,7 @@ void OGLGraphicsDriver::BoxOutEffect(bool blackingOut, int speed, int delay)
   {
     this->_reDrawLastFrame();
   }
-  else if (_drawScreenCallback != NULL)
+  else if (_drawScreenCallback != nullptr)
     _drawScreenCallback();
   
   Bitmap *blackSquare = BitmapHelper::CreateBitmap(16, 16, 32);
@@ -2000,11 +2000,11 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
 }
 
 
-OGLGraphicsFactory *OGLGraphicsFactory::_factory = NULL;
+OGLGraphicsFactory *OGLGraphicsFactory::_factory = nullptr;
 
 OGLGraphicsFactory::~OGLGraphicsFactory()
 {
-    _factory = NULL;
+    _factory = nullptr;
 }
 
 size_t OGLGraphicsFactory::GetFilterCount() const
@@ -2021,7 +2021,7 @@ const GfxFilterInfo *OGLGraphicsFactory::GetFilterInfo(size_t index) const
     case 1:
         return &AAOGLGfxFilter::FilterInfo;
     default:
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -2050,7 +2050,7 @@ OGLGfxFilter *OGLGraphicsFactory::CreateFilter(const String &id)
         return new OGLGfxFilter();
     else if (AAOGLGfxFilter::FilterInfo.Id.CompareNoCase(id) == 0)
         return new AAOGLGfxFilter();
-    return NULL;
+    return nullptr;
 }
 
 } // namespace OGL

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -109,8 +109,8 @@ public:
         _lightLevel = 0;
         _transparency = 0;
         _opaque = opaque;
-        _vertex = NULL;
-        _tiles = NULL;
+        _vertex = nullptr;
+        _tiles = nullptr;
         _numTiles = 0;
     }
 

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -81,15 +81,15 @@ ALSoftwareGraphicsDriver::ALSoftwareGraphicsDriver()
   _tint_green = 0;
   _tint_blue = 0;
   _autoVsync = false;
-  _spareTintingScreen = NULL;
-  _gfxModeList = NULL;
+  _spareTintingScreen = nullptr;
+  _gfxModeList = nullptr;
 #ifdef _WIN32
   dxGammaControl = NULL;
 #endif
-  _allegroScreenWrapper = NULL;
-  _origVirtualScreen = NULL;
-  virtualScreen = NULL;
-  _stageVirtualScreen = NULL;
+  _allegroScreenWrapper = nullptr;
+  _origVirtualScreen = nullptr;
+  virtualScreen = nullptr;
+  _stageVirtualScreen = nullptr;
 
   // Initialize default sprite batch, it will be used when no other batch was activated
   ALSoftwareGraphicsDriver::InitSpriteBatch(0, _spriteBatchDesc[0]);
@@ -111,11 +111,11 @@ bool ALSoftwareGraphicsDriver::IsModeSupported(const DisplayMode &mode)
   {
     return true;
   }
-  if (_gfxModeList == NULL)
+  if (_gfxModeList == nullptr)
   {
     _gfxModeList = get_gfx_mode_list(GetAllegroGfxDriverID(mode.Windowed));
   }
-  if (_gfxModeList != NULL)
+  if (_gfxModeList != nullptr)
   {
     // if a list is available, check if the mode exists. This prevents the screen flicking
     // between loads of unsupported resolutions
@@ -144,13 +144,13 @@ int ALSoftwareGraphicsDriver::GetDisplayDepthForNativeDepth(int native_color_dep
 
 IGfxModeList *ALSoftwareGraphicsDriver::GetSupportedModeList(int color_depth)
 {
-  if (_gfxModeList == NULL)
+  if (_gfxModeList == nullptr)
   {
     _gfxModeList = get_gfx_mode_list(GetAllegroGfxDriverID(false));
   }
-  if (_gfxModeList == NULL)
+  if (_gfxModeList == nullptr)
   {
-    return NULL;
+    return nullptr;
   }
   return new ALSoftwareGfxModeList(_gfxModeList);
 }
@@ -204,8 +204,8 @@ bool ALSoftwareGraphicsDriver::SetDisplayMode(const DisplayMode &mode, volatile 
 
   set_color_depth(mode.ColorDepth);
 
-  if (_initGfxCallback != NULL)
-    _initGfxCallback(NULL);
+  if (_initGfxCallback != nullptr)
+    _initGfxCallback(nullptr);
 
   if (!IsModeSupported(mode) || set_gfx_mode(driver, mode.Width, mode.Height, 0, 0) != 0)
     return false;
@@ -267,9 +267,9 @@ void ALSoftwareGraphicsDriver::DestroyVirtualScreen()
   {
     screen = (BITMAP*)_filter->ShutdownAndReturnRealScreen()->GetAllegroBitmap();
   }
-  _origVirtualScreen = NULL;
-  virtualScreen = NULL;
-  _stageVirtualScreen = NULL;
+  _origVirtualScreen = nullptr;
+  virtualScreen = nullptr;
+  _stageVirtualScreen = nullptr;
 }
 
 void ALSoftwareGraphicsDriver::ReleaseDisplayMode()
@@ -289,7 +289,7 @@ void ALSoftwareGraphicsDriver::ReleaseDisplayMode()
 
   // Note this does not destroy the underlying allegro screen bitmap, only wrapper.
   delete _allegroScreenWrapper;
-  _allegroScreenWrapper = NULL;
+  _allegroScreenWrapper = nullptr;
 }
 
 bool ALSoftwareGraphicsDriver::SetNativeSize(const Size &src_size)
@@ -311,7 +311,7 @@ bool ALSoftwareGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
 void ALSoftwareGraphicsDriver::ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse)
 {
   int color = 0;
-  if (colorToUse != NULL) 
+  if (colorToUse != nullptr) 
     color = makecol_depth(_mode.ColorDepth, colorToUse->r, colorToUse->g, colorToUse->b);
   // TODO: hardware renderers do not scale these coordinates, but software filter does!
   // find out what's the expected behavior and sync them
@@ -328,10 +328,10 @@ void ALSoftwareGraphicsDriver::UnInit()
   OnUnInit();
   ReleaseDisplayMode();
 
-  if (_gfxModeList != NULL)
+  if (_gfxModeList != nullptr)
   {
     destroy_gfx_mode_list(_gfxModeList);
-    _gfxModeList = NULL;
+    _gfxModeList = nullptr;
   }
 }
 
@@ -397,7 +397,7 @@ void ALSoftwareGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDe
     // TODO: correct offsets to have pre-scale (source) and post-scale (dest) offsets!
     int src_w = desc.Viewport.GetWidth() / desc.Transform.ScaleX;
     int src_h = desc.Viewport.GetHeight() / desc.Transform.ScaleY;
-    if (desc.Surface != NULL)
+    if (desc.Surface != nullptr)
     {
         batch.Surface = std::static_pointer_cast<Bitmap>(desc.Surface);
         batch.Opaque = true;
@@ -479,7 +479,7 @@ void ALSoftwareGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, Com
   const std::vector<ALDrawListEntry> &drawlist = batch.List;
   for (size_t i = 0; i < drawlist.size(); i++)
   {
-    if (drawlist[i].bitmap == NULL)
+    if (drawlist[i].bitmap == nullptr)
     {
       if (_nullSpriteCallback)
         _nullSpriteCallback(drawlist[i].x, drawlist[i].y);
@@ -509,7 +509,7 @@ void ALSoftwareGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, Com
         set_alpha_blender();
       else
         // here _transparency is used as alpha (between 1 and 254)
-        set_blender_mode(NULL, NULL, _trans_alpha_blender32, 0, 0, 0, bitmap->_transparency);
+        set_blender_mode(nullptr, nullptr, _trans_alpha_blender32, 0, 0, 0, bitmap->_transparency);
 
       surface->TransBlendBlt(bitmap->_bmp, drawAtX, drawAtY);
     }
@@ -768,14 +768,14 @@ void ALSoftwareGraphicsDriver::BoxOutEffect(bool blackingOut, int speed, int del
       this->Vsync();
       int vcentre = _srcRect.GetHeight() / 2;
       this->ClearRectangle(_srcRect.GetWidth() / 2 - boxwid / 2, vcentre - boxhit / 2,
-          _srcRect.GetWidth() / 2 + boxwid / 2, vcentre + boxhit / 2, NULL);
+          _srcRect.GetWidth() / 2 + boxwid / 2, vcentre + boxhit / 2, nullptr);
     
       if (_pollingCallback)
         _pollingCallback();
 
       platform->Delay(delay);
     }
-    this->ClearRectangle(0, 0, _srcRect.GetWidth() - 1, _srcRect.GetHeight() - 1, NULL);
+    this->ClearRectangle(0, 0, _srcRect.GetWidth() - 1, _srcRect.GetHeight() - 1, nullptr);
   }
   else
   {
@@ -816,11 +816,11 @@ unsigned long _trans_alpha_blender32(unsigned long x, unsigned long y, unsigned 
 }
 
 
-ALSWGraphicsFactory *ALSWGraphicsFactory::_factory = NULL;
+ALSWGraphicsFactory *ALSWGraphicsFactory::_factory = nullptr;
 
 ALSWGraphicsFactory::~ALSWGraphicsFactory()
 {
-    _factory = NULL;
+    _factory = nullptr;
 }
 
 size_t ALSWGraphicsFactory::GetFilterCount() const
@@ -837,7 +837,7 @@ const GfxFilterInfo *ALSWGraphicsFactory::GetFilterInfo(size_t index) const
     case 1:
         return &HqxGfxFilter::FilterInfo;
     default:
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -866,7 +866,7 @@ AllegroGfxFilter *ALSWGraphicsFactory::CreateFilter(const String &id)
         return new AllegroGfxFilter();
     else if (HqxGfxFilter::FilterInfo.Id.CompareNoCase(id) == 0)
         return new HqxGfxFilter();
-    return NULL;
+    return nullptr;
 }
 
 } // namespace ALSW

--- a/Engine/gfx/blender.cpp
+++ b/Engine/gfx/blender.cpp
@@ -250,12 +250,12 @@ unsigned long _argb2rgb_blender(unsigned long src_col, unsigned long dst_col, un
 
 void set_additive_alpha_blender()
 {
-    set_blender_mode(NULL, NULL, _additive_alpha_copysrc_blender, 0, 0, 0, 0);
+    set_blender_mode(nullptr, nullptr, _additive_alpha_copysrc_blender, 0, 0, 0, 0);
 }
 
 void set_argb2argb_blender(int alpha)
 {
-    set_blender_mode(NULL, NULL, _argb2argb_blender, 0, 0, 0, alpha);
+    set_blender_mode(nullptr, nullptr, _argb2argb_blender, 0, 0, 0, alpha);
 }
 
 // sets the alpha channel to opaque. used when drawing a non-alpha sprite onto an alpha-sprite
@@ -266,5 +266,5 @@ unsigned long _opaque_alpha_blender(unsigned long x, unsigned long y, unsigned l
 
 void set_opaque_alpha_blender()
 {
-    set_blender_mode(NULL, NULL, _opaque_alpha_blender, 0, 0, 0, 0);
+    set_blender_mode(nullptr, nullptr, _opaque_alpha_blender, 0, 0, 0, 0);
 }

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -26,7 +26,7 @@ namespace Engine
 class IDriverDependantBitmap
 {
 public:
-  virtual ~IDriverDependantBitmap(){}
+  virtual ~IDriverDependantBitmap() = default;
 
   virtual void SetTransparency(int transparency) = 0;  // 0-255
   virtual void SetFlippedLeftRight(bool isFlipped) = 0;

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -63,8 +63,8 @@ struct BlendModeSetter
 // NOTE: set NULL function pointer to fallback to common image blitting
 static const BlendModeSetter BlendModeSets[kNumBlendModes] =
 {
-    { NULL, NULL, NULL, NULL, NULL }, // kBlendMode_NoAlpha
-    { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, NULL }, // kBlendMode_Alpha
+    { nullptr, nullptr, nullptr, nullptr, nullptr }, // kBlendMode_NoAlpha
+    { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, nullptr }, // kBlendMode_Alpha
     // NOTE: add new modes here
 };
 
@@ -82,7 +82,7 @@ bool SetBlender(BlendMode blend_mode, bool dst_has_alpha, bool src_has_alpha, in
 
     if (blender)
     {
-        set_blender_mode(NULL, NULL, blender, 0, 0, 0, blend_alpha);
+        set_blender_mode(nullptr, nullptr, blender, 0, 0, 0, blend_alpha);
         return true;
     }
     return false;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -27,11 +27,11 @@ namespace Engine
 {
 
 GraphicsDriverBase::GraphicsDriverBase()
-    : _pollingCallback(NULL)
-    , _drawScreenCallback(NULL)
-    , _nullSpriteCallback(NULL)
-    , _initGfxCallback(NULL)
-    , _initSurfaceUpdateCallback(NULL)
+    : _pollingCallback(nullptr)
+    , _drawScreenCallback(nullptr)
+    , _nullSpriteCallback(nullptr)
+    , _initGfxCallback(nullptr)
+    , _initSurfaceUpdateCallback(nullptr)
 {
     // Initialize default sprite batch, it will be used when no other batch was activated
     _actSpriteBatch = 0;
@@ -139,7 +139,7 @@ void GraphicsDriverBase::OnSetFilter()
 
 
 VideoMemoryGraphicsDriver::VideoMemoryGraphicsDriver()
-    : _stageVirtualScreenDDB(NULL)
+    : _stageVirtualScreenDDB(nullptr)
     , _stageScreenDirty(false)
 {
     // Only to have something meaningful as default
@@ -164,7 +164,7 @@ bool VideoMemoryGraphicsDriver::UsesMemoryBackBuffer()
 
 Bitmap *VideoMemoryGraphicsDriver::GetMemoryBackBuffer()
 {
-    return NULL;
+    return nullptr;
 }
 
 void VideoMemoryGraphicsDriver::SetMemoryBackBuffer(Bitmap *backBuffer, int offx, int offy)
@@ -183,7 +183,7 @@ PBitmap VideoMemoryGraphicsDriver::CreateStageScreen(size_t index, const Size &s
         _stageScreens.resize(index + 1);
     if (sz.IsNull())
         _stageScreens[index].reset();
-    else if (_stageScreens[index] == NULL || _stageScreens[index]->GetSize() != sz)
+    else if (_stageScreens[index] == nullptr || _stageScreens[index]->GetSize() != sz)
         _stageScreens[index].reset(new Bitmap(sz.Width, sz.Height, _mode.ColorDepth));
     return _stageScreens[index];
 }
@@ -192,14 +192,14 @@ PBitmap VideoMemoryGraphicsDriver::GetStageScreen(size_t index)
 {
     if (index < _stageScreens.size())
         return _stageScreens[index];
-    return NULL;
+    return nullptr;
 }
 
 void VideoMemoryGraphicsDriver::DestroyAllStageScreens()
 {
     if (_stageVirtualScreenDDB)
         this->DestroyDDB(_stageVirtualScreenDDB);
-    _stageVirtualScreenDDB = NULL;
+    _stageVirtualScreenDDB = nullptr;
 
     for (size_t i = 0; i < _stageScreens.size(); ++i)
         _stageScreens[i].reset();

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -61,7 +61,7 @@ struct SpriteDrawListEntry
     bool skip;
 
     SpriteDrawListEntry()
-        : bitmap(NULL)
+        : bitmap(nullptr)
         , x(0)
         , y(0)
         , skip(false)
@@ -93,7 +93,7 @@ public:
     Rect        GetRenderDestination() const override;
     void        SetNativeRenderOffset(int x, int y) override;
 
-    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, PBitmap surface = NULL) override;
+    void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, PBitmap surface = nullptr) override;
     void        ClearDrawLists() override;
 
     void        SetCallbackForPolling(GFXDRV_CLIENTCALLBACK callback) override { _pollingCallback = callback; }

--- a/Engine/gfx/gfxdriverfactory.cpp
+++ b/Engine/gfx/gfxdriverfactory.cpp
@@ -57,7 +57,7 @@ IGfxDriverFactory *GetGfxDriverFactory(const String id)
     if (id.CompareNoCase("Software") == 0)
         return ALSW::ALSWGraphicsFactory::GetFactory();
     set_allegro_error("No graphics factory with such id: %s", id.GetCStr());
-    return NULL;
+    return nullptr;
 }
 
 } // namespace Engine

--- a/Engine/gfx/gfxdriverfactory.h
+++ b/Engine/gfx/gfxdriverfactory.h
@@ -44,7 +44,7 @@ typedef stdtr1compat::shared_ptr<IGfxFilter> PGfxFilter;
 class IGfxDriverFactory
 {
 public:
-    virtual ~IGfxDriverFactory(){}
+    virtual ~IGfxDriverFactory() = default;
 
     // Shutdown graphics factory and deallocate any resources it owns;
     // graphics factory will be unusable after calling this function.

--- a/Engine/gfx/gfxdriverfactorybase.h
+++ b/Engine/gfx/gfxdriverfactorybase.h
@@ -57,7 +57,7 @@ public:
     void DestroyDriver() override
     {
         delete _driver;
-        _driver = NULL;
+        _driver = nullptr;
     }
 
     PGfxFilter SetFilter(const String &id, String &filter_error) override
@@ -94,7 +94,7 @@ public:
 
 protected:
     GfxDriverFactoryBase()
-        : _driver(NULL)
+        : _driver(nullptr)
     {
     }
 

--- a/Engine/gfx/gfxfilter.h
+++ b/Engine/gfx/gfxfilter.h
@@ -51,7 +51,7 @@ struct GfxFilterInfo
 class IGfxFilter
 {
 public:
-    virtual ~IGfxFilter(){}
+    virtual ~IGfxFilter() = default;
 
     virtual const GfxFilterInfo &GetInfo() const = 0;
 

--- a/Engine/gfx/gfxfilter_allegro.cpp
+++ b/Engine/gfx/gfxfilter_allegro.cpp
@@ -26,10 +26,10 @@ using namespace Common;
 const GfxFilterInfo AllegroGfxFilter::FilterInfo = GfxFilterInfo("StdScale", "Nearest-neighbour");
 
 AllegroGfxFilter::AllegroGfxFilter()
-    : realScreen(NULL)
-    , virtualScreen(NULL)
-    , realScreenSizedBuffer(NULL)
-    , lastBlitFrom(NULL)
+    : realScreen(nullptr)
+    , virtualScreen(nullptr)
+    , realScreenSizedBuffer(nullptr)
+    , lastBlitFrom(nullptr)
     , lastBlitX(0)
     , lastBlitY(0)
 {
@@ -50,7 +50,7 @@ Bitmap* AllegroGfxFilter::InitVirtualScreen(Bitmap *screen, const Size src_size,
     if (src_size == dst_rect.GetSize() && dst_rect.Top == 0 && dst_rect.Left == 0)
     {
         // Speed up software rendering if no scaling is performed
-        realScreenSizedBuffer = NULL;
+        realScreenSizedBuffer = nullptr;
         virtualScreen = realScreen;
     }
     else
@@ -66,10 +66,10 @@ Bitmap *AllegroGfxFilter::ShutdownAndReturnRealScreen()
     if (virtualScreen != realScreen)
         delete virtualScreen;
     delete realScreenSizedBuffer;
-    virtualScreen = NULL;
-    realScreenSizedBuffer = NULL;
+    virtualScreen = nullptr;
+    realScreenSizedBuffer = nullptr;
     Bitmap *real_scr = realScreen;
-    realScreen = NULL;
+    realScreen = nullptr;
     return real_scr;
 }
 

--- a/Engine/gfx/gfxfilter_hqx.cpp
+++ b/Engine/gfx/gfxfilter_hqx.cpp
@@ -28,8 +28,8 @@ using namespace Common;
 const GfxFilterInfo HqxGfxFilter::FilterInfo = GfxFilterInfo("Hqx", "Hqx (High Quality)", 2, 3);
 
 HqxGfxFilter::HqxGfxFilter()
-    : _pfnHqx(NULL)
-    , _hqxScalingBuffer(NULL)
+    : _pfnHqx(nullptr)
+    , _hqxScalingBuffer(nullptr)
 {
 }
 
@@ -74,7 +74,7 @@ Bitmap *HqxGfxFilter::ShutdownAndReturnRealScreen()
 {
     Bitmap *real_screen = AllegroGfxFilter::ShutdownAndReturnRealScreen();
     delete _hqxScalingBuffer;
-    _hqxScalingBuffer = NULL;
+    _hqxScalingBuffer = nullptr;
     return real_screen;
 }
 

--- a/Engine/gfx/gfxmodelist.h
+++ b/Engine/gfx/gfxmodelist.h
@@ -29,7 +29,7 @@ namespace Engine
 class IGfxModeList
 {
 public:
-    virtual ~IGfxModeList(){}
+    virtual ~IGfxModeList() = default;
     virtual int  GetModeCount() const = 0;
     virtual bool GetMode(int index, DisplayMode &mode) const = 0;
 };

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -124,7 +124,7 @@ public:
   // Prepares next sprite batch, a list of sprites with defined viewport and optional
   // global model transformation; all subsequent calls to DrawSprite will be adding
   // sprites to this batch's list.
-  virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, PBitmap surface = NULL) = 0;
+  virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform, PBitmap surface = nullptr) = 0;
   // Adds sprite to the active batch
   virtual void DrawSprite(int x, int y, IDriverDependantBitmap* bitmap) = 0;
   // Clears all sprite batches, resets batch counter
@@ -142,7 +142,7 @@ public:
   // Copies contents of the game screen into bitmap using simple blit or pixel copy.
   // Bitmap must be of supported size and pixel format. If it's not the method will
   // fail and optionally write wanted destination format into 'want_fmt' pointer.
-  virtual bool GetCopyOfScreenIntoBitmap(Common::Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt = NULL) = 0;
+  virtual bool GetCopyOfScreenIntoBitmap(Common::Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt = nullptr) = 0;
   virtual void EnableVsyncBeforeRender(bool enabled) = 0;
   virtual void Vsync() = 0;
   // Enables or disables rendering mode that draws sprite list directly into

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -178,7 +178,7 @@ public:
   virtual bool RequiresFullRedrawEachFrame() = 0;
   virtual bool HasAcceleratedTransform() = 0;
   virtual bool UsesMemoryBackBuffer() = 0;
-  virtual ~IGraphicsDriver() { }
+  virtual ~IGraphicsDriver() = default;
 };
 
 } // namespace Engine

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -142,7 +142,7 @@ void CSCIEraseWindow(int handl)
 int CSCIWaitMessage(CSCIMessage * cscim)
 {
     for (int uu = 0; uu < MAXCONTROLS; uu++) {
-        if (vobjs[uu] != NULL) {
+        if (vobjs[uu] != nullptr) {
             //      ags_domouse(DOMOUSE_DISABLE);
             vobjs[uu]->drawifneeded();
             //      ags_domouse(DOMOUSE_ENABLE);
@@ -206,7 +206,7 @@ int CSCICreateControl(int typeandflags, int xx, int yy, int wii, int hii, const 
     multiply_up(&xx, &yy, &wii, &hii);
     int usec = -1;
     for (int hh = 1; hh < MAXCONTROLS; hh++) {
-        if (vobjs[hh] == NULL) {
+        if (vobjs[hh] == nullptr) {
             usec = hh;
             break;
         }
@@ -242,12 +242,12 @@ int CSCICreateControl(int typeandflags, int xx, int yy, int wii, int hii, const 
 void CSCIDeleteControl(int haa)
 {
     delete vobjs[haa];
-    vobjs[haa] = NULL;
+    vobjs[haa] = nullptr;
 }
 
 int CSCISendControlMessage(int haa, int mess, int wPar, long lPar)
 {
-    if (vobjs[haa] == NULL)
+    if (vobjs[haa] == nullptr)
         return -1;
     return vobjs[haa]->processmessage(mess, wPar, lPar);
 }
@@ -288,7 +288,7 @@ int checkcontrols()
 
     smcode = 0;
     for (int kk = 0; kk < MAXCONTROLS; kk++) {
-        if (vobjs[kk] != NULL) {
+        if (vobjs[kk] != nullptr) {
             if (vobjs[kk]->mouseisinarea(mousex, mousey)) {
                 controlid = kk;
                 return vobjs[kk]->pressedon(mousex, mousey);
@@ -301,7 +301,7 @@ int checkcontrols()
 int finddefaultcontrol(int flagmask)
 {
     for (int ff = 0; ff < MAXCONTROLS; ff++) {
-        if (vobjs[ff] == NULL)
+        if (vobjs[ff] == nullptr)
             continue;
 
         if (vobjs[ff]->wlevel != topwindowhandle)

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -84,9 +84,9 @@ void clear_gui_screen()
 {
     if (dialogDDB)
         gfxDriver->DestroyDDB(dialogDDB);
-    dialogDDB = NULL;
+    dialogDDB = nullptr;
     delete windowBuffer;
-    windowBuffer = NULL;
+    windowBuffer = nullptr;
 }
 
 void refresh_gui_screen()
@@ -109,13 +109,13 @@ int loadgamedialog()
   int ctrlcancel =
     CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 135, 5 + buttonhit, 60, 10,
                       get_global_message(MSG_CANCEL));
-  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 30, 120, 80, NULL);
+  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 30, 120, 80, nullptr);
   int ctrltex1 = CSCICreateControl(CNT_LABEL, 10, 5, 120, 0, get_global_message(MSG_SELECTLOAD));
   CSCISendControlMessage(ctrllist, CLB_CLEAR, 0, 0);
 
   preparesavegamelist(ctrllist);
   CSCIMessage mes;
-  lpTemp = NULL;
+  lpTemp = nullptr;
   int toret = -1;
   while (1) {
     CSCIWaitMessage(&mes);      //printf("mess: %d, id %d ",mes.code,mes.id);
@@ -123,7 +123,7 @@ int loadgamedialog()
       if (mes.id == ctrlok) {
         int cursel = CSCISendControlMessage(ctrllist, CLB_GETCURSEL, 0, 0);
         if ((cursel >= numsaves) | (cursel < 0))
-          lpTemp = NULL;
+          lpTemp = nullptr;
         else {
           toret = filenumbers[cursel];
           String path = get_save_game_path(toret);
@@ -131,7 +131,7 @@ int loadgamedialog()
           lpTemp = &bufTemp[0];
         }
       } else if (mes.id == ctrlcancel) {
-        lpTemp = NULL;
+        lpTemp = nullptr;
       }
 
       break;
@@ -163,7 +163,7 @@ int savegamedialog()
   int ctrlcancel =
     CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 135, 5 + buttonhit, 60, 10,
                       get_global_message(MSG_CANCEL));
-  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 40, 120, 80, NULL);
+  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 40, 120, 80, nullptr);
   int ctrltbox = 0;
 
   CSCISendControlMessage(ctrllist, CLB_CLEAR, 0, 0);    // clear the list box
@@ -173,13 +173,13 @@ int savegamedialog()
     strcpy(labeltext, get_global_message(MSG_MUSTREPLACE));
     labeltop = 2;
   } else
-    ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, NULL);
+    ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, nullptr);
 
   int ctrlok = CSCICreateControl(CNT_PUSHBUTTON | CNF_DEFAULT, 135, 5, 60, 10, okbuttontext);
   int ctrltex1 = CSCICreateControl(CNT_LABEL, 10, labeltop, 120, 0, labeltext);
   CSCIMessage mes;
 
-  lpTemp = NULL;
+  lpTemp = nullptr;
   if (numsaves > 0)
     CSCISendControlMessage(ctrllist, CLB_GETTEXT, 0, (long)&buffer2[0]);
   else
@@ -231,7 +231,7 @@ int savegamedialog()
           bufTemp[0] = 0;
 
           if (cmes.id == btnCancel) {
-            lpTemp = NULL;
+            lpTemp = nullptr;
             break;
           } else
             toret = filenumbers[cursell];
@@ -265,7 +265,7 @@ int savegamedialog()
         lpTemp = &bufTemp[0];
         lpTemp2 = &buffer2[0];
       } else if (mes.id == ctrlcancel) {
-        lpTemp = NULL;
+        lpTemp = nullptr;
       }
       break;
     } else if (mes.code == CM_SELCHANGE) {
@@ -307,7 +307,7 @@ void preparesavegamelist(int ctrllist)
     }
 
     // only list games .000 to .099 (to allow higher slots for other purposes)
-    if (strstr(ffb.name, ".0") == NULL) {
+    if (strstr(ffb.name, ".0") == nullptr) {
       don = al_findnext(&ffb);
       continue;
     }
@@ -368,7 +368,7 @@ void enterstringwindow(const char *prompttext, char *stouse)
   int ctrlcancel = -1;
   if (wantCancel)
     ctrlcancel = CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 135, 20, 60, 10, get_global_message(MSG_CANCEL));
-  int ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, NULL);
+  int ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, nullptr);
   int ctrltex1 = CSCICreateControl(CNT_LABEL, 10, 5, 120, 0, prompttext);
   CSCIMessage mes;
 
@@ -412,7 +412,7 @@ int roomSelectorWindow(int currentRoom, int numRooms, int*roomNumbers, char**roo
   const int labeltop = 5;
 
   int handl = CSCIDrawWindow(boxleft, boxtop, wnd_width, wnd_height);
-  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 40, 220, 100, NULL);
+  int ctrllist = CSCICreateControl(CNT_LISTBOX, 10, 40, 220, 100, nullptr);
   int ctrlcancel =
     CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 80, 145, 60, 10, "Cancel");
 
@@ -431,10 +431,10 @@ int roomSelectorWindow(int currentRoom, int numRooms, int*roomNumbers, char**roo
   int ctrltex1 = CSCICreateControl(CNT_LABEL, 10, labeltop, 180, 0, "Choose which room to go to:");
   CSCIMessage mes;
 
-  lpTemp = NULL;
+  lpTemp = nullptr;
   buffer2[0] = 0;
 
-  int ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, NULL);
+  int ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, nullptr);
   CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);
 
   int toret = -1;
@@ -486,7 +486,7 @@ int myscimessagebox(const char *lpprompt, char *btn1, char *btn2)
     int lbl1 = CSCICreateControl(CNT_LABEL, 10, 5, 150, 0, lpprompt);
     int btflag = CNT_PUSHBUTTON;
 
-    if (btn2 == NULL)
+    if (btn2 == nullptr)
         btflag |= CNF_DEFAULT | CNF_CANCEL;
     else
         btflag |= CNF_DEFAULT;
@@ -494,7 +494,7 @@ int myscimessagebox(const char *lpprompt, char *btn1, char *btn2)
     int btnQuit = CSCICreateControl(btflag, 10, 25, 60, 10, btn1);
     int btnPlay = 0;
 
-    if (btn2 != NULL)
+    if (btn2 != nullptr)
         btnPlay = CSCICreateControl(CNT_PUSHBUTTON | CNF_CANCEL, 85, 25, 60, 10, btn2);
 
     smes.code = 0;

--- a/Engine/gui/mytextbox.cpp
+++ b/Engine/gui/mytextbox.cpp
@@ -31,7 +31,7 @@ MyTextBox::MyTextBox(int xx, int yy, int wii, const char *tee)
     x = xx;
     y = yy;
     wid = wii;
-    if (tee != NULL)
+    if (tee != nullptr)
         strcpy(text, tee);
     else
         text[0] = 0;

--- a/Engine/gui/newcontrol.h
+++ b/Engine/gui/newcontrol.h
@@ -33,7 +33,7 @@ struct NewControl
 
   NewControl(int xx, int yy, int wi, int hi);
   NewControl();
-  virtual ~NewControl(){}
+  virtual ~NewControl() = default;
   int mouseisinarea(int mousex, int mousey);
   void drawifneeded();
   void drawandmouse();

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -62,7 +62,7 @@ void INIgetdirec(char *wasgv, const char *inifil) {
 
     if (u <= 0) {
         // no slashes - either the path is just "f:acwin.exe"
-        if (strchr(wasgv, ':') != NULL)
+        if (strchr(wasgv, ':') != nullptr)
             memcpy(strchr(wasgv, ':') + 1, inifil, strlen(inifil) + 1);
         // or it's just "acwin.exe" (unlikely)
         else
@@ -261,7 +261,7 @@ String find_user_cfg_file()
 
 void config_defaults()
 {
-    usetup.translation = NULL;
+    usetup.translation = nullptr;
 #ifdef WINDOWS_VERSION
     usetup.digicard = DIGI_DIRECTAMX(0);
 #endif

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -96,7 +96,7 @@ extern IDriverDependantBitmap **guibgbmp;
 String music_file;
 String speech_file;
 
-t_engine_pre_init_callback engine_pre_init_callback = 0;
+t_engine_pre_init_callback engine_pre_init_callback = nullptr;
 
 #define ALLEGRO_KEYBOARD_HANDLER
 // KEYBOARD HANDLER
@@ -421,7 +421,7 @@ int engine_check_memory()
     Debug::Printf(kDbgMsg_Init, "Checking memory");
 
     char*memcheck=(char*)malloc(4000000);
-    if (memcheck==NULL) {
+    if (memcheck==nullptr) {
         platform->DisplayAlert("There is not enough memory available to run this game. You need 4 Mb free\n"
             "extended memory to run the game.\n"
             "If you are running from Windows, check the 'DPMI memory' setting on the DOS box\n"
@@ -452,7 +452,7 @@ void engine_init_speech()
                 return;
             }
             Stream *speechsync = AssetManager::OpenAsset("syncdata.dat");
-            if (speechsync != NULL) {
+            if (speechsync != nullptr) {
                 // this game has voice lip sync
                 int lipsync_fmt = speechsync->ReadInt32();
                 if (lipsync_fmt != 4)
@@ -548,9 +548,9 @@ void AlMidiToChars(int midi_id, AlIDStr &id_str)
         AlIDToChars(midi_id, id_str);
 }
 
-bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = NULL)
+bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
-    if (install_sound(digi_id, midi_id, NULL) == 0)
+    if (install_sound(digi_id, midi_id, nullptr) == 0)
         return true;
     // Allegro does not let you try digital and MIDI drivers separately,
     // and does not indicate which driver failed by return value.
@@ -560,13 +560,13 @@ bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = NULL)
     if (midi_id != MIDI_NONE)
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init one of the drivers; Error: '%s'.\nWill try to start without MIDI", get_allegro_error());
-        if (install_sound(digi_id, MIDI_NONE, NULL) == 0)
+        if (install_sound(digi_id, MIDI_NONE, nullptr) == 0)
             return true;
     }
     if (digi_id != DIGI_NONE)
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init one of the drivers; Error: '%s'.\nWill try to start without DIGI", get_allegro_error());
-        if (install_sound(DIGI_NONE, midi_id, NULL) == 0)
+        if (install_sound(DIGI_NONE, midi_id, nullptr) == 0)
             return true;
     }
     Debug::Printf(kDbgMsg_Error, "Failed to init sound drivers. Error: %s", get_allegro_error());
@@ -612,7 +612,7 @@ void engine_init_sound()
     {
         Debug::Printf("Everything failed, installing dummy no-sound drivers.");
         reserve_voices(0, 0);
-        install_sound(DIGI_NONE, MIDI_NONE, NULL);
+        install_sound(DIGI_NONE, MIDI_NONE, nullptr);
     }
     // Only display a warning if they wanted a sound card
     const bool digi_failed = usetup.digicard != DIGI_NONE && digi_card == DIGI_NONE;
@@ -687,7 +687,7 @@ void engine_init_exit_handler()
 
 void engine_init_rand()
 {
-    play.randseed = time(NULL);
+    play.randseed = time(nullptr);
     srand (play.randseed);
 }
 
@@ -883,7 +883,7 @@ void show_preload()
 {
     color temppal[256];
 	Bitmap *splashsc = BitmapHelper::CreateRawBitmapOwner( load_pcx("preload.pcx",temppal) );
-    if (splashsc != NULL)
+    if (splashsc != nullptr)
     {
         Debug::Printf("Displaying preload image");
         if (splashsc->GetColorDepth() == 8)
@@ -938,7 +938,7 @@ void engine_init_game_settings()
     int ee;
 
     for (ee = 0; ee < MAX_ROOM_OBJECTS + game.numcharacters; ee++)
-        actsps[ee] = NULL;
+        actsps[ee] = nullptr;
 
     for (ee=0;ee<256;ee++) {
         if (game.paluses[ee]!=PAL_BACKGROUND)
@@ -964,7 +964,7 @@ void engine_init_game_settings()
         precache_view (playerchar->view);
 
     for (ee = 0; ee < MAX_ROOM_OBJECTS; ee++)
-        objcache[ee].image = NULL;
+        objcache[ee].image = nullptr;
 
     /*  dummygui.guiId = -1;
     dummyguicontrol.guin = -1;
@@ -1009,8 +1009,8 @@ void engine_init_game_settings()
     guibg = (Bitmap **)malloc(sizeof(Bitmap *) * game.numgui);
     guibgbmp = (IDriverDependantBitmap**)malloc(sizeof(IDriverDependantBitmap*) * game.numgui);
     for (ee=0;ee<game.numgui;ee++) {
-        guibg[ee] = NULL;
-        guibgbmp[ee] = NULL;
+        guibg[ee] = nullptr;
+        guibgbmp[ee] = nullptr;
     }
 
     our_eip=-5;
@@ -1253,7 +1253,7 @@ Bitmap *test_allegro_bitmap;
 IDriverDependantBitmap *test_allegro_ddb;
 void allegro_bitmap_test_init()
 {
-	test_allegro_bitmap = NULL;
+	test_allegro_bitmap = nullptr;
 	// Switched the test off for now
 	//test_allegro_bitmap = AllegroBitmap::CreateBitmap(320,200,32);
 }

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -156,10 +156,10 @@ void engine_post_gfxmode_driver_setup()
 // Reset gfx driver callbacks
 void engine_pre_gfxmode_driver_cleanup()
 {
-    gfxDriver->SetCallbackForPolling(NULL);
-    gfxDriver->SetCallbackToDrawScreen(NULL);
-    gfxDriver->SetCallbackForNullSprite(NULL);
-    gfxDriver->SetMemoryBackBuffer(NULL);
+    gfxDriver->SetCallbackForPolling(nullptr);
+    gfxDriver->SetCallbackToDrawScreen(nullptr);
+    gfxDriver->SetCallbackForNullSprite(nullptr);
+    gfxDriver->SetMemoryBackBuffer(nullptr);
 }
 
 // Setup virtual screen
@@ -181,7 +181,7 @@ void engine_pre_gfxmode_screen_cleanup()
 void engine_pre_gfxsystem_screen_destroy()
 {
     delete sub_vscreen;
-    sub_vscreen = NULL;
+    sub_vscreen = nullptr;
 }
 
 // Setup color conversion parameters

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -120,7 +120,7 @@ void PreReadSaveFileInfo(Stream *in, GameDataVersion data_ver)
     game.ReadFromFile(&align_s);
     // Discard game messages we do not need here
     delete [] game.load_messages;
-    game.load_messages = NULL;
+    game.load_messages = nullptr;
     game.read_savegame_info(in, data_ver);
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -425,8 +425,8 @@ void check_keyboard_controls()
                 sprintf(&infobuf[strlen(infobuf)],
                     "[Object %d: (%d,%d) size (%d x %d) on:%d moving:%s animating:%d slot:%d trnsp:%d clkble:%d",
                     ff, objs[ff].x, objs[ff].y,
-                    (spriteset[objs[ff].num] != NULL) ? game.SpriteInfos[objs[ff].num].Width : 0,
-                    (spriteset[objs[ff].num] != NULL) ? game.SpriteInfos[objs[ff].num].Height : 0,
+                    (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Width : 0,
+                    (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Height : 0,
                     objs[ff].on,
                     (objs[ff].moving > 0) ? "yes" : "no", objs[ff].cycling,
                     objs[ff].num, objs[ff].transparent,
@@ -944,7 +944,7 @@ void RunGameUntilAborted()
         GameTick();
 
         if (load_new_game) {
-            RunAGSGame (NULL, load_new_game, 0);
+            RunAGSGame (nullptr, load_new_game, 0);
             load_new_game = 0;
         }
     }

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -28,7 +28,7 @@ void PollUntilNextFrame();
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally
 void RunGameUntilAborted();
 // Update everything game related
-void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = NULL, int extraX = 0, int extraY = 0);
+void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
 
 float get_current_fps();
 // Runs service key controls, returns false if service key combinations were handled

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -70,11 +70,11 @@ void start_game_init_editor_debugging()
 
 void start_game_load_savegame_on_startup()
 {
-    if (loadSaveGameOnStartup != NULL)
+    if (loadSaveGameOnStartup != nullptr)
     {
         int saveGameNumber = 1000;
         const char *sgName = strstr(loadSaveGameOnStartup, "agssave.");
-        if (sgName != NULL)
+        if (sgName != nullptr)
         {
             sscanf(sgName, "agssave.%03d", &saveGameNumber);
         }

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -44,7 +44,7 @@ extern AGSPlatformDriver *platform;
 extern IGraphicsDriver *gfxDriver;
 
 
-IGfxDriverFactory *GfxFactory = NULL;
+IGfxDriverFactory *GfxFactory = nullptr;
 
 // Last saved fullscreen and windowed configs; they are used when switching
 // between between fullscreen and windowed modes at runtime.
@@ -314,9 +314,9 @@ bool try_init_compatible_mode(const DisplayMode &dm, const bool match_device_rat
         if (modes.get())
         {
             if (match_device_ratio)
-                mode_found = find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, &device_size, NULL, dm_compat);
+                mode_found = find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, &device_size, nullptr, dm_compat);
             if (!mode_found)
-                mode_found = find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, NULL, NULL, dm_compat);
+                mode_found = find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, nullptr, nullptr, dm_compat);
         }
         if (!mode_found)
             Debug::Printf("Could not find compatible fullscreen mode. Will try to force-set mode requested by user and fallback to windowed mode if that fails.");
@@ -330,7 +330,7 @@ bool try_init_compatible_mode(const DisplayMode &dm, const bool match_device_rat
         // When initializing windowed mode we could start with any random window size;
         // if that did not work, try to find nearest supported mode, as with fullscreen mode,
         // except refering to max window size as an upper bound
-        if (find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, NULL, &device_size, dm_compat))
+        if (find_nearest_supported_mode(*modes.get(), screen_size, dm.ColorDepth, nullptr, &device_size, dm_compat))
         {
             dm_compat.Vsync = dm.Vsync;
             dm_compat.Windowed = true;
@@ -666,8 +666,8 @@ void graphics_mode_shutdown()
 {
     if (GfxFactory)
         GfxFactory->Shutdown();
-    GfxFactory = NULL;
-    gfxDriver = NULL;
+    GfxFactory = nullptr;
+    gfxDriver = nullptr;
 
     // Tell Allegro that we are no longer in graphics mode
     set_gfx_mode(GFX_TEXT, 0, 0, 0, 0);

--- a/Engine/main/graphics_mode.h
+++ b/Engine/main/graphics_mode.h
@@ -31,7 +31,7 @@ String make_scaling_factor_string(uint32_t scaling);
 namespace AGS { namespace Engine { class IGfxModeList; }}
 bool find_nearest_supported_mode(const AGS::Engine::IGfxModeList &modes, const Size &wanted_size,
                                  const int color_depth, const Size *ratio_reference, const Size *upper_bound,
-                                 AGS::Engine::DisplayMode &dm, int *mode_index = NULL);
+                                 AGS::Engine::DisplayMode &dm, int *mode_index = nullptr);
 
 
 // The game-to-screen transformation

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -63,7 +63,7 @@ LPWSTR *wArgv;
 
 #endif
 
-char **global_argv = NULL;
+char **global_argv = nullptr;
 int    global_argc = 0;
 
 
@@ -87,7 +87,7 @@ bool justDisplayVersion = false;
 bool justRunSetup = false;
 bool justRegisterGame = false;
 bool justUnRegisterGame = false;
-const char *loadSaveGameOnStartup = NULL;
+const char *loadSaveGameOnStartup = nullptr;
 
 #if !defined(MAC_VERSION) && !defined(IOS_VERSION) && !defined(PSP_VERSION) && !defined(ANDROID_VERSION)
 int psp_video_framedrop = 1;
@@ -365,7 +365,7 @@ void main_set_gamedir(int argc,char*argv[])
         // If running data file pointed by command argument, change to that folder
         Directory::SetCurrentDirectory(Path::GetDirectoryPath(GetPathFromCmdArg(datafile_argv)));
     }
-    else if ((loadSaveGameOnStartup != NULL) && (argv[0] != NULL))
+    else if ((loadSaveGameOnStartup != nullptr) && (argv[0] != nullptr))
     {
         // When launched by double-clicking a save game file, the curdir will
         // be the save game folder unless we correct it

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -162,7 +162,7 @@ static void move_track_to_crossfade_channel(int currentChannel, int crossfadeSpe
     play.crossfade_out_volume_per_step = crossfadeSpeed;
 
     play.crossfading_in_channel = fadeInChannel;
-    if (newSound != NULL)
+    if (newSound != nullptr)
     {
         start_fading_in_new_track_if_applicable(fadeInChannel, newSound);
     }
@@ -171,7 +171,7 @@ static void move_track_to_crossfade_channel(int currentChannel, int crossfadeSpe
 void stop_or_fade_out_channel(int fadeOutChannel, int fadeInChannel, ScriptAudioClip *newSound)
 {
     ScriptAudioClip *sourceClip = AudioChannel_GetPlayingClip(&scrAudioChannel[fadeOutChannel]);
-    if ((sourceClip != NULL) && (game.audioClipTypes[sourceClip->type].crossfadeSpeed > 0))
+    if ((sourceClip != nullptr) && (game.audioClipTypes[sourceClip->type].crossfadeSpeed > 0))
     {
         move_track_to_crossfade_channel(fadeOutChannel, game.audioClipTypes[sourceClip->type].crossfadeSpeed, fadeInChannel, newSound);
     }
@@ -245,12 +245,12 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
 {
     if (!is_audiotype_allowed_to_play((AudioFileType)audioClip->fileType))
     {
-        return NULL;
+        return nullptr;
     }
 
     update_clip_default_volume(audioClip);
 
-    SOUNDCLIP *soundClip = NULL;
+    SOUNDCLIP *soundClip = nullptr;
     AssetPath asset_name = get_audio_clip_assetpath(audioClip->bundlingType, audioClip->fileName);
     switch (audioClip->fileType)
     {
@@ -277,7 +277,7 @@ SOUNDCLIP *load_sound_clip(ScriptAudioClip *audioClip, bool repeat)
     default:
         quitprintf("AudioClip.Play: invalid audio file type encountered: %d", audioClip->fileType);
     }
-    if (soundClip != NULL)
+    if (soundClip != nullptr)
     {
         soundClip->set_volume_percent(audioClip->defaultVolume);
         soundClip->sourceClip = audioClip;
@@ -368,7 +368,7 @@ static void queue_audio_clip_to_play(ScriptAudioClip *clip, int priority, int re
     }
 
     SOUNDCLIP *cachedClip = load_sound_clip(clip, (repeat != 0));
-    if (cachedClip != NULL) 
+    if (cachedClip != nullptr) 
     {
         play.new_music_queue[play.new_music_queue_size].audioClipIndex = clip->id;
         play.new_music_queue[play.new_music_queue_size].priority = priority;
@@ -382,18 +382,18 @@ static void queue_audio_clip_to_play(ScriptAudioClip *clip, int priority, int re
 
 ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *clip, int priority, int repeat, int fromOffset, SOUNDCLIP *soundfx)
 {
-    if (soundfx == NULL)
+    if (soundfx == nullptr)
     {
         soundfx = load_sound_clip(clip, (repeat) ? true : false);
     }
-    if (soundfx == NULL)
+    if (soundfx == nullptr)
     {
         debug_script_log("AudioClip.Play: unable to load sound file");
         if (play.crossfading_in_channel == channel)
         {
             play.crossfading_in_channel = 0;
         }
-        return NULL;
+        return nullptr;
     }
     soundfx->priority = priority;
 
@@ -488,7 +488,7 @@ ScriptAudioChannel* play_audio_clip(ScriptAudioClip *clip, int priority, int rep
         else
             debug_script_log("AudioClip.Play: no channels available to interrupt PRI:%d TYPE:%d", priority, clip->type);
 
-        return NULL;
+        return nullptr;
     }
 
     return play_audio_clip_on_channel(channel, clip, priority, repeat, fromOffset);
@@ -499,7 +499,7 @@ ScriptAudioChannel* play_audio_clip_by_index(int audioClipIndex)
     if ((audioClipIndex >= 0) && (audioClipIndex < game.audioClipCount))
         return AudioClip_Play(&game.audioClips[audioClipIndex], SCR_NO_VALUE, SCR_NO_VALUE);
     else 
-        return NULL;
+        return nullptr;
 }
 
 void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings)
@@ -510,10 +510,10 @@ void stop_and_destroy_channel_ex(int chid, bool resetLegacyMusicSettings)
     AudioChannelsLock lock;
     SOUNDCLIP* ch = lock.GetChannel(chid);
 
-    if (ch != NULL) {
+    if (ch != nullptr) {
         ch->destroy();
         delete ch;
-        lock.SetChannel(chid, NULL);
+        lock.SetChannel(chid, nullptr);
         ch = nullptr;
     }
 
@@ -576,12 +576,12 @@ SOUNDCLIP *load_sound_clip_from_old_style_number(bool isMusic, int indexNumber, 
 {
     ScriptAudioClip* audioClip = GetAudioClipForOldStyleNumber(game, isMusic, indexNumber);
 
-    if (audioClip != NULL)
+    if (audioClip != nullptr)
     {
         return load_sound_clip(audioClip, repeat);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 //=============================================================================
@@ -589,7 +589,7 @@ SOUNDCLIP *load_sound_clip_from_old_style_number(bool isMusic, int indexNumber, 
 void force_audiostream_include() {
     // This should never happen, but the call is here to make it
     // link the audiostream libraries
-    stop_audio_stream(NULL);
+    stop_audio_stream(nullptr);
 }
 
 // TODO: double check that ambient sounds array actually needs +1
@@ -784,7 +784,7 @@ int current_music_type = 0;
 // track fading out, no new track)
 int crossFading = 0, crossFadeVolumePerStep = 0, crossFadeStep = 0;
 int crossFadeVolumeAtStart = 0;
-SOUNDCLIP *cachedQueuedMusic = NULL;
+SOUNDCLIP *cachedQueuedMusic = nullptr;
 
 static bool music_update_scheduled = false;
 static auto music_update_at = AGS_Clock::now();
@@ -814,10 +814,10 @@ void process_scheduled_music_update() {
 
 void clear_music_cache() {
 
-    if (cachedQueuedMusic != NULL) {
+    if (cachedQueuedMusic != nullptr) {
         cachedQueuedMusic->destroy();
         delete cachedQueuedMusic;
-        cachedQueuedMusic = NULL;
+        cachedQueuedMusic = nullptr;
     }
 
 }
@@ -846,7 +846,7 @@ void play_next_queued() {
 
         // don't free the memory, as it has been transferred onto the
         // main music channel
-        cachedQueuedMusic = NULL;
+        cachedQueuedMusic = nullptr;
 
         play.music_queue_size--;
         for (int i = 0; i < play.music_queue_size; i++)
@@ -989,7 +989,7 @@ void stopmusic()
         }
     }
     else if ((game.options[OPT_CROSSFADEMUSIC] > 0)
-        && (lock.GetChannelIfPlaying(SCHAN_MUSIC) != NULL)
+        && (lock.GetChannelIfPlaying(SCHAN_MUSIC) != nullptr)
         && (current_music_type != 0)
         && (current_music_type != MUS_MIDI)
         && (current_music_type != MUS_MOD)) {
@@ -1077,7 +1077,7 @@ int prepare_for_new_music ()
     int useChannel = SCHAN_MUSIC;
 
     if ((game.options[OPT_CROSSFADEMUSIC] > 0)
-        && (lock.GetChannelIfPlaying(SCHAN_MUSIC) != NULL)
+        && (lock.GetChannelIfPlaying(SCHAN_MUSIC) != nullptr)
         && (current_music_type != MUS_MIDI)
         && (current_music_type != MUS_MOD)) {
 
@@ -1132,7 +1132,7 @@ SOUNDCLIP *load_music_from_disk(int mnum, bool doRepeat) {
 
     SOUNDCLIP *loaded = load_sound_clip_from_old_style_number(true, mnum, doRepeat);
 
-    if ((loaded == NULL) && (mnum > 0)) 
+    if ((loaded == nullptr) && (mnum > 0)) 
     {
         debug_script_warn("Music %d not found",mnum);
         debug_script_log("FAILED to load music %d", mnum);
@@ -1146,7 +1146,7 @@ static void play_new_music(int mnum, SOUNDCLIP *music)
     if (debug_flags & DBG_NOMUSIC)
         return;
 
-    if ((play.cur_music_number == mnum) && (music == NULL)) {
+    if ((play.cur_music_number == mnum) && (music == nullptr)) {
         debug_script_log("PlayMusic %d but already playing", mnum);
         return;  // don't play the music if it's already playing
     }
@@ -1201,5 +1201,5 @@ static void play_new_music(int mnum, SOUNDCLIP *music)
 
 void newmusic(int mnum)
 {
-    play_new_music(mnum, NULL);
+    play_new_music(mnum, nullptr);
 }

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -69,9 +69,9 @@ void set_clip_to_channel(int chanid, SOUNDCLIP *clip);
 void        calculate_reserved_channel_count();
 void        update_clip_default_volume(ScriptAudioClip *audioClip);
 void        start_fading_in_new_track_if_applicable(int fadeInChannel, ScriptAudioClip *newSound);
-void        stop_or_fade_out_channel(int fadeOutChannel, int fadeInChannel = -1, ScriptAudioClip *newSound = NULL);
+void        stop_or_fade_out_channel(int fadeOutChannel, int fadeInChannel = -1, ScriptAudioClip *newSound = nullptr);
 SOUNDCLIP*  load_sound_clip(ScriptAudioClip *audioClip, bool repeat);
-ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *clip, int priority, int repeat, int fromOffset, SOUNDCLIP *cachedClip = NULL);
+ScriptAudioChannel* play_audio_clip_on_channel(int channel, ScriptAudioClip *clip, int priority, int repeat, int fromOffset, SOUNDCLIP *cachedClip = nullptr);
 void        remove_clips_of_type_from_queue(int audioType);
 void        update_queued_clips_volume(int audioType, int new_vol);
 // Checks if speech voice-over is currently playing, and reapply volume drop to all other active clips

--- a/Engine/media/audio/clip_mydumbmod.cpp
+++ b/Engine/media/audio/clip_mydumbmod.cpp
@@ -22,11 +22,11 @@
 void al_duh_set_loop(AL_DUH_PLAYER *dp, int loop) {
     DUH_SIGRENDERER *sr = al_duh_get_sigrenderer(dp);
     DUMB_IT_SIGRENDERER *itsr = duh_get_it_sigrenderer(sr);
-    if (itsr == NULL)
+    if (itsr == nullptr)
         return;
 
     if (loop)
-        dumb_it_set_loop_callback(itsr, NULL, NULL);
+        dumb_it_set_loop_callback(itsr, nullptr, nullptr);
     else
         dumb_it_set_loop_callback(itsr, dumb_it_callback_terminate, itsr);
 }
@@ -92,7 +92,7 @@ int MYMOD::get_pos()
     // determine the current track number (DUMB calls them 'orders')
     DUH_SIGRENDERER *sr = al_duh_get_sigrenderer(duhPlayer);
     DUMB_IT_SIGRENDERER *itsr = duh_get_it_sigrenderer(sr);
-    if (itsr == NULL)
+    if (itsr == nullptr)
         return -1;
 
     return dumb_it_sr_get_current_order(itsr);
@@ -112,7 +112,7 @@ int MYMOD::get_pos_ms()
 
 int MYMOD::get_length_ms()
 {
-    if (tune == NULL)
+    if (tune == nullptr)
         return 0;
 
     // duh_get_length represents time as 65536ths of a second
@@ -156,8 +156,8 @@ int MYMOD::play() {
 }  
 
 MYMOD::MYMOD() : SOUNDCLIP() {
-    tune = NULL;
-    duhPlayer = NULL;
+    tune = nullptr;
+    duhPlayer = nullptr;
 }
 
 #endif // DUMB_MOD_PLAYER

--- a/Engine/media/audio/clip_mymidi.cpp
+++ b/Engine/media/audio/clip_mymidi.cpp
@@ -44,7 +44,7 @@ void MYMIDI::destroy()
     if (tune) {
         destroy_midi(tune);
     }
-    tune = NULL;
+    tune = nullptr;
 
     state_ = SoundClipStopped;
 }
@@ -106,6 +106,6 @@ int MYMIDI::play() {
 }
 
 MYMIDI::MYMIDI() : SOUNDCLIP() {
-    tune = NULL;
+    tune = nullptr;
     lengthInSeconds = 0;
 }

--- a/Engine/media/audio/clip_mymp3.cpp
+++ b/Engine/media/audio/clip_mymp3.cpp
@@ -35,7 +35,7 @@ void MYMP3::poll()
         tempbuf = (char *)almp3_get_mp3stream_buffer(stream);
     }
 
-    if (tempbuf != NULL) {
+    if (tempbuf != nullptr) {
         int free_val = -1;
         if (chunksize >= in->normal.todo) {
             chunksize = in->normal.todo;
@@ -135,7 +135,7 @@ int MYMP3::get_voice()
     if (!is_playing()) { return -1; }
 	AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     AUDIOSTREAM *ast = almp3_get_audiostream_mp3stream(stream);
-    return (ast != NULL ? ast->voice : -1);
+    return (ast != nullptr ? ast->voice : -1);
 }
 
 int MYMP3::get_sound_type() {
@@ -161,10 +161,10 @@ int MYMP3::play() {
 }
 
 MYMP3::MYMP3() : SOUNDCLIP() {
-    stream = NULL;
-    in = NULL;
+    stream = nullptr;
+    in = nullptr;
     filesize = 0;
-    buffer = NULL;
+    buffer = nullptr;
     chunksize = 0;
 }
 

--- a/Engine/media/audio/clip_myogg.cpp
+++ b/Engine/media/audio/clip_myogg.cpp
@@ -35,7 +35,7 @@ void MYOGG::poll()
     {
         // update the buffer
         char *tempbuf = (char *)alogg_get_oggstream_buffer(stream);
-        if (tempbuf != NULL)
+        if (tempbuf != nullptr)
         {
             int free_val = -1;
             if (chunksize >= in->normal.todo)
@@ -136,7 +136,7 @@ int MYOGG::get_pos_ms()
 
     int end_of_stream = alogg_is_end_of_oggstream(stream);
 
-    if ((str->active == 1) && (last_but_one_but_one > 0) && (str->locked == NULL)) {
+    if ((str->active == 1) && (last_but_one_but_one > 0) && (str->locked == nullptr)) {
         switch (end_of_stream) {
 case 0:
 case 2:
@@ -191,9 +191,9 @@ int MYOGG::play() {
 }
 
 MYOGG::MYOGG() : SOUNDCLIP() {
-    stream = NULL;
-    in = NULL;
-    buffer = NULL;
+    stream = nullptr;
+    in = nullptr;
+    buffer = nullptr;
     chunksize = 0;
     last_but_one_but_one = 0;
     last_but_one = 0;

--- a/Engine/media/audio/clip_mystaticmp3.cpp
+++ b/Engine/media/audio/clip_mystaticmp3.cpp
@@ -122,7 +122,7 @@ int MYSTATICMP3::get_voice()
     if (!is_playing()) { return -1; }
 	AGS::Engine::MutexLock _lockMp3(_mp3_mutex);
     AUDIOSTREAM *ast = almp3_get_audiostream_mp3(tune);
-	return (ast != NULL ? ast->voice : -1);
+	return (ast != nullptr ? ast->voice : -1);
 }
 
 int MYSTATICMP3::get_sound_type() {
@@ -149,8 +149,8 @@ int MYSTATICMP3::play() {
 }
 
 MYSTATICMP3::MYSTATICMP3() : SOUNDCLIP() {
-    tune = NULL;
-    mp3buffer = NULL;
+    tune = nullptr;
+    mp3buffer = nullptr;
 }
 
 #endif // !NO_MP3_PLAYER

--- a/Engine/media/audio/clip_mystaticogg.cpp
+++ b/Engine/media/audio/clip_mystaticogg.cpp
@@ -124,7 +124,7 @@ int MYSTATICOGG::get_pos_ms()
 
     int end_of_stream = alogg_is_end_of_ogg(tune);
 
-    if ((str->active == 1) && (last_but_one_but_one > 0) && (str->locked == NULL)) {
+    if ((str->active == 1) && (last_but_one_but_one > 0) && (str->locked == nullptr)) {
         switch (end_of_stream) {
 case 0:
 case 2:
@@ -195,8 +195,8 @@ int MYSTATICOGG::play() {
 }
 
 MYSTATICOGG::MYSTATICOGG() : SOUNDCLIP() {
-    tune = NULL;
-    mp3buffer = NULL;
+    tune = nullptr;
+    mp3buffer = nullptr;
     mp3buffersize = 0;
     extraOffset = 0;
     last_but_one = 0;

--- a/Engine/media/audio/clip_mywave.cpp
+++ b/Engine/media/audio/clip_mywave.cpp
@@ -81,7 +81,7 @@ int MYWAVE::get_pos_ms()
 
 int MYWAVE::get_length_ms()
 {
-    if (wave == NULL) { return -1; }
+    if (wave == nullptr) { return -1; }
     if (wave->freq < 100)
         return 0;
     return (wave->len / (wave->freq / 100)) * 10;
@@ -98,7 +98,7 @@ int MYWAVE::get_sound_type() {
 }
 
 int MYWAVE::play() {
-    if (wave == NULL) { return 0; }
+    if (wave == nullptr) { return 0; }
 
     voice = play_sample(wave, vol, panning, 1000, repeat);
     if (voice < 0) {
@@ -111,6 +111,6 @@ int MYWAVE::play() {
 }
 
 MYWAVE::MYWAVE() : SOUNDCLIP() {
-    wave = NULL;
+    wave = nullptr;
     voice = -1;
 }

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -69,8 +69,8 @@ SOUNDCLIP *my_load_wave(const AssetPath &asset_name, int voll, int loop)
     long dummy;
     SAMPLE *new_sample = (SAMPLE*)get_cached_sound(asset_name, true, &dummy);
 
-    if (new_sample == NULL)
-        return NULL;
+    if (new_sample == nullptr)
+        return nullptr;
 
     thiswave = new MYWAVE();
     thiswave->wave = new_sample;
@@ -88,13 +88,13 @@ MYMP3 *thistune;
 SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, int voll)
 {
     mp3in = PackfileFromAsset(asset_name);
-    if (mp3in == NULL)
-        return NULL;
+    if (mp3in == nullptr)
+        return nullptr;
 
     char *tmpbuffer = (char *)malloc(MP3CHUNKSIZE);
-    if (tmpbuffer == NULL) {
+    if (tmpbuffer == nullptr) {
         pack_fclose(mp3in);
-        return NULL;
+        return nullptr;
     }
     thistune = new MYMP3();
     thistune->in = mp3in;
@@ -114,11 +114,11 @@ SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, int voll)
         thistune->stream = almp3_create_mp3stream(tmpbuffer, thistune->chunksize, (mp3in->normal.todo < 1));
     }
 
-    if (thistune->stream == NULL) {
+    if (thistune->stream == nullptr) {
         free(tmpbuffer);
         pack_fclose(mp3in);
         delete thistune;
-        return NULL;
+        return nullptr;
     }
 
     return thistune;
@@ -132,17 +132,17 @@ SOUNDCLIP *my_load_static_mp3(const AssetPath &asset_name, int voll, bool loop)
     // Load via soundcache.
     long muslen = 0;
     char* mp3buffer = get_cached_sound(asset_name, false, &muslen);
-    if (mp3buffer == NULL)
-        return NULL;
+    if (mp3buffer == nullptr)
+        return nullptr;
 
     // now, create an MP3 structure for it
     thismp3 = new MYSTATICMP3();
-    if (thismp3 == NULL) {
+    if (thismp3 == nullptr) {
         free(mp3buffer);
-        return NULL;
+        return nullptr;
     }
     thismp3->vol = voll;
-    thismp3->mp3buffer = NULL;
+    thismp3->mp3buffer = nullptr;
     thismp3->repeat = loop;
 
     {
@@ -150,10 +150,10 @@ SOUNDCLIP *my_load_static_mp3(const AssetPath &asset_name, int voll, bool loop)
         thismp3->tune = almp3_create_mp3(mp3buffer, muslen);
     }
 
-    if (thismp3->tune == NULL) {
+    if (thismp3->tune == nullptr) {
         free(mp3buffer);
         delete thismp3;
-        return NULL;
+        return nullptr;
     }
 
     thismp3->mp3buffer = mp3buffer;
@@ -183,8 +183,8 @@ SOUNDCLIP *my_load_static_ogg(const AssetPath &asset_name, int voll, bool loop)
     // Load via soundcache.
     long muslen = 0;
     char* mp3buffer = get_cached_sound(asset_name, false, &muslen);
-    if (mp3buffer == NULL)
-        return NULL;
+    if (mp3buffer == nullptr)
+        return nullptr;
 
     // now, create an OGG structure for it
     thissogg = new MYSTATICOGG();
@@ -195,10 +195,10 @@ SOUNDCLIP *my_load_static_ogg(const AssetPath &asset_name, int voll, bool loop)
 
     thissogg->tune = alogg_create_ogg_from_buffer(mp3buffer, muslen);
 
-    if (thissogg->tune == NULL) {
+    if (thissogg->tune == nullptr) {
         thissogg->destroy();
         delete thissogg;
-        return NULL;
+        return nullptr;
     }
 
     return thissogg;
@@ -208,13 +208,13 @@ MYOGG *thisogg;
 SOUNDCLIP *my_load_ogg(const AssetPath &asset_name, int voll)
 {
     mp3in = PackfileFromAsset(asset_name);
-    if (mp3in == NULL)
-        return NULL;
+    if (mp3in == nullptr)
+        return nullptr;
 
     char *tmpbuffer = (char *)malloc(MP3CHUNKSIZE);
-    if (tmpbuffer == NULL) {
+    if (tmpbuffer == nullptr) {
         pack_fclose(mp3in);
-        return NULL;
+        return nullptr;
     }
 
     thisogg = new MYOGG();
@@ -233,11 +233,11 @@ SOUNDCLIP *my_load_ogg(const AssetPath &asset_name, int voll)
     thisogg->buffer = (char *)tmpbuffer;
     thisogg->stream = alogg_create_oggstream(tmpbuffer, thisogg->chunksize, (mp3in->normal.todo < 1));
 
-    if (thisogg->stream == NULL) {
+    if (thisogg->stream == nullptr) {
         free(tmpbuffer);
         pack_fclose(mp3in);
         delete thisogg;
-        return NULL;
+        return nullptr;
     }
 
     return thisogg;
@@ -254,13 +254,13 @@ SOUNDCLIP *my_load_midi(const AssetPath &asset_name, int repet)
 
     PACKFILE *pf = PackfileFromAsset(asset_name);
     if (!pf)
-        return NULL;
+        return nullptr;
 
     MIDI* midiPtr = load_midi_pf(pf);
     pack_fclose(pf);
 
-    if (midiPtr == NULL)
-        return NULL;
+    if (midiPtr == nullptr)
+        return nullptr;
 
     thismidi = new MYMIDI();
     thismidi->tune = midiPtr;
@@ -298,20 +298,20 @@ void remove_mod_player() {
 //#endif   // JGMOD_MOD_PLAYER
 #elif defined DUMB_MOD_PLAYER
 
-MYMOD *thismod = NULL;
+MYMOD *thismod = nullptr;
 SOUNDCLIP *my_load_mod(const AssetPath &asset_name, int repet)
 {
     DUMBFILE *df = DUMBfileFromAsset(asset_name);
     if (!df)
-        return NULL;
+        return nullptr;
 
-    DUH *modPtr = NULL;
+    DUH *modPtr = nullptr;
     // determine the file extension
     const char *lastDot = strrchr(asset_name.second, '.');
-    if (lastDot == NULL)
+    if (lastDot == nullptr)
     {
         dumbfile_close(df);
-        return NULL;
+        return nullptr;
     }
     // get the first char of the extensin
     int charAfterDot = toupper(lastDot[1]);
@@ -331,8 +331,8 @@ SOUNDCLIP *my_load_mod(const AssetPath &asset_name, int repet)
     }
 
     dumbfile_close(df);
-    if (modPtr == NULL)
-        return NULL;
+    if (modPtr == nullptr)
+        return nullptr;
 
     thismod = new MYMOD();
     thismod->tune = modPtr;

--- a/Engine/media/audio/soundcache.cpp
+++ b/Engine/media/audio/soundcache.cpp
@@ -24,7 +24,7 @@
 
 using namespace Common;
 
-sound_cache_entry_t* sound_cache_entries = NULL;
+sound_cache_entry_t* sound_cache_entries = nullptr;
 unsigned int sound_cache_counter = 0;
 
 AGS::Engine::Mutex _sound_cache_mutex;
@@ -42,9 +42,9 @@ void clear_sound_cache()
             if (sound_cache_entries[i].data)
             {
                 free(sound_cache_entries[i].data);
-                sound_cache_entries[i].data = NULL;
+                sound_cache_entries[i].data = nullptr;
                 free(sound_cache_entries[i].file_name);
-                sound_cache_entries[i].file_name = NULL;
+                sound_cache_entries[i].file_name = nullptr;
                 sound_cache_entries[i].reference = 0;
             }
         }
@@ -106,7 +106,7 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
     int i;
     for (i = 0; i < psp_audio_cachesize; i++)
     {
-        if (sound_cache_entries[i].data == NULL)
+        if (sound_cache_entries[i].data == nullptr)
             continue;
 
         if (strcmp(asset_name.second, sound_cache_entries[i].file_name) == 0)
@@ -123,13 +123,13 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
     }
 
     // Not found
-    PACKFILE *mp3in = NULL;
-    SAMPLE* wave = NULL;
+    PACKFILE *mp3in = nullptr;
+    SAMPLE* wave = nullptr;
 
     if (is_wave)
     {
         PACKFILE *wavin = PackfileFromAsset(asset_name);
-        if (wavin != NULL)
+        if (wavin != nullptr)
         {
             wave = load_wav_pf(wavin);
             pack_fclose(wavin);
@@ -138,16 +138,16 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
     else
     {
         mp3in = PackfileFromAsset(asset_name);
-        if (mp3in == NULL)
+        if (mp3in == nullptr)
         {
-            return NULL;
+            return nullptr;
         }
     }
 
     // Find free slot
     for (i = 0; i < psp_audio_cachesize; i++)
     {
-        if (sound_cache_entries[i].data == NULL)
+        if (sound_cache_entries[i].data == nullptr)
             break;
     }
 
@@ -185,10 +185,10 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
         *size = mp3in->normal.todo;
         newdata = (char *)malloc(*size);
 
-        if (newdata == NULL)
+        if (newdata == nullptr)
         {
             pack_fclose(mp3in);
-            return NULL;
+            return nullptr;
         }
 
         pack_fread(newdata, *size, mp3in);

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -77,6 +77,4 @@ SOUNDCLIP::SOUNDCLIP() {
     directionalVolModifier = 0;
 }
 
-SOUNDCLIP::~SOUNDCLIP()
-{
-}
+SOUNDCLIP::~SOUNDCLIP() = default;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -53,12 +53,12 @@ enum VideoPlaybackType
 VideoPlaybackType video_type = kVideoNone;
 
 // FLIC player start
-Bitmap *fli_buffer = NULL;
+Bitmap *fli_buffer = nullptr;
 short fliwidth,fliheight;
 int canabort=0, stretch_flc = 1;
-Bitmap *hicol_buf=NULL;
-IDriverDependantBitmap *fli_ddb = NULL;
-Bitmap *fli_target = NULL;
+Bitmap *hicol_buf=nullptr;
+IDriverDependantBitmap *fli_ddb = nullptr;
+Bitmap *fli_target = nullptr;
 int fliTargetWidth, fliTargetHeight;
 int check_if_user_input_should_cancel_video()
 {
@@ -158,7 +158,7 @@ void play_flc_file(int numb,int playflags) {
     else if ((fliwidth > view.GetWidth()) || (fliheight >view.GetHeight()))
         stretch_flc = 1;
     fli_buffer=BitmapHelper::CreateBitmap(fliwidth,fliheight,8);
-    if (fli_buffer==NULL) quit("Not enough memory to play animation");
+    if (fli_buffer==nullptr) quit("Not enough memory to play animation");
     fli_buffer->Clear();
 
     if (clearScreenAtStart)
@@ -195,7 +195,7 @@ void play_flc_file(int numb,int playflags) {
 
     video_type = kVideoNone;
     delete fli_buffer;
-    fli_buffer = NULL;
+    fli_buffer = nullptr;
     // NOTE: the screen bitmap could change in the meanwhile, if the display mode has changed
     if (gfxDriver->UsesMemoryBackBuffer())
     {
@@ -207,12 +207,12 @@ void play_flc_file(int numb,int playflags) {
 
     delete fli_target;
     gfxDriver->DestroyDDB(fli_ddb);
-    fli_target = NULL;
-    fli_ddb = NULL;
+    fli_target = nullptr;
+    fli_ddb = nullptr;
 
 
     delete hicol_buf;
-    hicol_buf=NULL;
+    hicol_buf=nullptr;
     //  SetVirtualScreen(screen); wputblock(0,0,backbuffer,0);
     while (ags_mgetbutton()!=NONE) { } // clear any queued mouse events.
     invalidate_screen();
@@ -225,7 +225,7 @@ void play_flc_file(int numb,int playflags) {
 Bitmap gl_TheoraBuffer;
 int theora_playing_callback(BITMAP *theoraBuffer)
 {
-	if (theoraBuffer == NULL)
+	if (theoraBuffer == nullptr)
     {
         // No video, only sound
         return check_if_user_input_should_cancel_video();
@@ -235,7 +235,7 @@ int theora_playing_callback(BITMAP *theoraBuffer)
 
     int drawAtX = 0, drawAtY = 0;
     const Rect &viewport = play.GetMainViewport();
-    if (fli_ddb == NULL)
+    if (fli_ddb == nullptr)
     {
         fli_ddb = gfxDriver->CreateDDBFromBitmap(&gl_TheoraBuffer, false, true);
     }
@@ -283,21 +283,21 @@ int theora_playing_callback(BITMAP *theoraBuffer)
 class ApegStreamReader
 {
 public:
-    ApegStreamReader(const AssetPath path) : _path(path), _pf(NULL) {}
+    ApegStreamReader(const AssetPath path) : _path(path), _pf(nullptr) {}
     ~ApegStreamReader() { Close(); }
 
     bool Open()
     {
         Close(); // PACKFILE cannot be rewinded, sadly
         _pf = PackfileFromAsset(_path);
-        return _pf != NULL;
+        return _pf != nullptr;
     }
 
     void Close()
     {
         if (_pf)
             pack_fclose(_pf);
-        _pf = NULL;
+        _pf = nullptr;
     }
 
     int Read(void *buffer, int bytes)
@@ -338,7 +338,7 @@ void apeg_stream_skip(int bytes, void *ptr)
 APEG_STREAM* get_theora_size(ApegStreamReader &reader, int *width, int *height)
 {
     APEG_STREAM* oggVid = apeg_open_stream_ex(&reader);
-    if (oggVid != NULL)
+    if (oggVid != nullptr)
     {
         apeg_get_video_size(oggVid, width, height);
     }
@@ -422,7 +422,7 @@ void play_theora_video(const char *name, int skip, int flags)
     }
     else
     {
-        fli_ddb = NULL;
+        fli_ddb = nullptr;
     }
 
     update_polled_stuff_if_runtime();
@@ -431,7 +431,7 @@ void play_theora_video(const char *name, int skip, int flags)
         gfxDriver->GetMemoryBackBuffer()->Clear();
 
     video_type = kVideoTheora;
-    if (apeg_play_apeg_stream(oggVid, NULL, 0, theora_playing_callback) == APEG_ERROR)
+    if (apeg_play_apeg_stream(oggVid, nullptr, 0, theora_playing_callback) == APEG_ERROR)
     {
         Display("Error playing theora video '%s'", name);
     }
@@ -441,8 +441,8 @@ void play_theora_video(const char *name, int skip, int flags)
     //destroy_bitmap(fli_buffer);
     delete fli_target;
     gfxDriver->DestroyDDB(fli_ddb);
-    fli_target = NULL;
-    fli_ddb = NULL;
+    fli_target = nullptr;
+    fli_ddb = nullptr;
     invalidate_screen();
 }
 // Theora player end

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -35,8 +35,8 @@ using namespace AGS::Engine;
 #include "libcda.h"
 #endif
 
-AGSPlatformDriver* AGSPlatformDriver::instance = NULL;
-AGSPlatformDriver *platform = NULL;
+AGSPlatformDriver* AGSPlatformDriver::instance = nullptr;
+AGSPlatformDriver *platform = nullptr;
 
 // ******** DEFAULT IMPLEMENTATIONS *******
 

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -183,7 +183,7 @@ void AGSLinux::ShutdownCDPlayer() {
 }
 
 AGSPlatformDriver* AGSPlatformDriver::GetDriver() {
-  if (instance == NULL)
+  if (instance == nullptr)
     instance = new AGSLinux();
   return instance;
 }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -136,11 +136,11 @@ struct EnginePlugin {
     int         savedatasize;
     int         wantHook;
     int         invalidatedRegion;
-    void      (*engineStartup) (IAGSEngine *) = NULL;
-    void      (*engineShutdown) () = NULL;
-    int       (*onEvent) (int, int) = NULL;
-    void      (*initGfxHook) (const char *driverName, void *data) = NULL;
-    int       (*debugHook) (const char * whichscript, int lineNumber, int reserved) = NULL;
+    void      (*engineStartup) (IAGSEngine *) = nullptr;
+    void      (*engineShutdown) () = nullptr;
+    int       (*onEvent) (int, int) = nullptr;
+    void      (*initGfxHook) (const char *driverName, void *data) = nullptr;
+    int       (*debugHook) (const char * whichscript, int lineNumber, int reserved) = nullptr;
     IAGSEngine  eiface;
     bool        builtin;
 
@@ -148,7 +148,7 @@ struct EnginePlugin {
         filename[0] = 0;
         wantHook = 0;
         invalidatedRegion = 0;
-        savedata = NULL;
+        savedata = nullptr;
         savedatasize = 0;
         builtin = false;
         available = false;
@@ -174,8 +174,8 @@ void IAGSEngine::RegisterScriptFunction (const char*name, void*addy) {
 }
 const char* IAGSEngine::GetGraphicsDriverID()
 {
-    if (gfxDriver == NULL)
-        return NULL;
+    if (gfxDriver == nullptr)
+        return nullptr;
 
     return gfxDriver->GetDriverID();
 }
@@ -187,20 +187,20 @@ BITMAP *IAGSEngine::GetScreen ()
         quit("!This plugin requires software graphics driver.");
 
     Bitmap *buffer = gfxDriver->GetMemoryBackBuffer();
-    return buffer ? (BITMAP*)buffer->GetAllegroBitmap() : NULL;
+    return buffer ? (BITMAP*)buffer->GetAllegroBitmap() : nullptr;
 }
 
 BITMAP *IAGSEngine::GetVirtualScreen () 
 {
     Bitmap *stage = gfxDriver->GetStageBackBuffer();
-    return stage ? (BITMAP*)stage->GetAllegroBitmap() : NULL;
+    return stage ? (BITMAP*)stage->GetAllegroBitmap() : nullptr;
 }
 
 void IAGSEngine::RequestEventHook (int32 event) {
     if (event >= AGSE_TOOHIGH) 
         quit("!IAGSEngine::RequestEventHook: invalid event requested");
 
-    if (plugins[this->pluginId].onEvent == NULL)
+    if (plugins[this->pluginId].onEvent == nullptr)
         quit("!IAGSEngine::RequestEventHook: no callback AGS_EngineOnEvent function exported from plugin");
 
     if ((event & AGSE_SCRIPTDEBUG) &&
@@ -225,7 +225,7 @@ void IAGSEngine::UnrequestEventHook(int32 event) {
         (plugins[this->pluginId].wantHook & AGSE_SCRIPTDEBUG)) {
             pluginsWantingDebugHooks--;
             if (pluginsWantingDebugHooks < 1)
-                ccSetDebugHook(NULL);
+                ccSetDebugHook(nullptr);
     }
 
     plugins[this->pluginId].wantHook &= ~event;
@@ -253,11 +253,11 @@ void IAGSEngine::DrawText (int32 x, int32 y, int32 font, int32 color, char *text
 }
 
 void IAGSEngine::GetScreenDimensions (int32 *width, int32 *height, int32 *coldepth) {
-    if (width != NULL)
+    if (width != nullptr)
         width[0] = play.GetMainViewport().GetWidth();
-    if (height != NULL)
+    if (height != nullptr)
         height[0] = play.GetMainViewport().GetHeight();
-    if (coldepth != NULL)
+    if (coldepth != nullptr)
         coldepth[0] = scsystem.coldepth;
 }
 
@@ -305,14 +305,14 @@ BITMAP *IAGSEngine::GetBackgroundScene (int32 index) {
     return (BITMAP*)thisroom.BgFrames[index].Graphic->GetAllegroBitmap();
 }
 void IAGSEngine::GetBitmapDimensions (BITMAP *bmp, int32 *width, int32 *height, int32 *coldepth) {
-    if (bmp == NULL)
+    if (bmp == nullptr)
         return;
 
-    if (width != NULL)
+    if (width != nullptr)
         width[0] = bmp->w;
-    if (height != NULL)
+    if (height != nullptr)
         height[0] = bmp->h;
-    if (coldepth != NULL)
+    if (coldepth != nullptr)
         coldepth[0] = bitmap_color_depth(bmp);
 }
 
@@ -385,7 +385,7 @@ void IAGSEngine::SetVirtualScreen (BITMAP *bmp)
     else
     {
         glVirtualScreenWrap.Destroy();
-        gfxDriver->SetMemoryBackBuffer(NULL);
+        gfxDriver->SetMemoryBackBuffer(nullptr);
     }
 }
 
@@ -510,7 +510,7 @@ BITMAP *IAGSEngine::GetRoomMask (int32 index) {
         return (BITMAP*)thisroom.RegionMask->GetAllegroBitmap();
     else
         quit("!IAGSEngine::GetRoomMask: invalid mask requested");
-    return NULL;
+    return nullptr;
 }
 AGSViewFrame *IAGSEngine::GetViewFrame (int32 view, int32 loop, int32 frame) {
     view--;
@@ -519,7 +519,7 @@ AGSViewFrame *IAGSEngine::GetViewFrame (int32 view, int32 loop, int32 frame) {
     if ((loop < 0) || (loop >= views[view].numLoops))
         quit("!IAGSEngine::GetViewFrame: invalid loop");
     if ((frame < 0) || (frame >= views[view].loops[loop].numFrames))
-        return NULL;
+        return nullptr;
 
     return (AGSViewFrame*)&views[view].loops[loop].frames[frame];
 }
@@ -560,14 +560,14 @@ int IAGSEngine::GetSpriteHeight (int32 slot) {
 }
 void IAGSEngine::GetTextExtent (int32 font, const char *text, int32 *width, int32 *height) {
     if ((font < 0) || (font >= game.numfonts)) {
-        if (width != NULL) width[0] = 0;
-        if (height != NULL) height[0] = 0;
+        if (width != nullptr) width[0] = 0;
+        if (height != nullptr) height[0] = 0;
         return;
     }
 
-    if (width != NULL)
+    if (width != nullptr)
         width[0] = wgettextwidth_compensate (text, font);
-    if (height != NULL)
+    if (height != nullptr)
         height[0] = wgettextheight ((char*)text, font);
 }
 void IAGSEngine::PrintDebugConsole (const char *text) {
@@ -579,7 +579,7 @@ int IAGSEngine::IsChannelPlaying (int32 channel) {
 }
 void IAGSEngine::PlaySoundChannel (int32 channel, int32 soundType, int32 volume, int32 loop, const char *filename) {
     stop_and_destroy_channel (channel);
-    SOUNDCLIP *newcha = NULL;
+    SOUNDCLIP *newcha = nullptr;
 
     if (((soundType == PSND_MP3STREAM) || (soundType == PSND_OGGSTREAM)) 
         && (loop != 0))
@@ -622,7 +622,7 @@ void IAGSEngine::MarkRegionDirty(int32 left, int32 top, int32 right, int32 botto
 }
 AGSMouseCursor * IAGSEngine::GetMouseCursor(int32 cursor) {
     if ((cursor < 0) || (cursor >= game.numcursors))
-        return NULL;
+        return nullptr;
 
     return (AGSMouseCursor*)&game.mcurs[cursor];
 }
@@ -662,7 +662,7 @@ int IAGSEngine::CreateDynamicSprite(int32 coldepth, int32 width, int32 height) {
 
     // resize the sprite to the requested size
     Bitmap *newPic = BitmapHelper::CreateTransparentBitmap(width, height, coldepth);
-    if (newPic == NULL)
+    if (newPic == nullptr)
         return 0;
 
     // add it into the sprite set
@@ -683,7 +683,7 @@ void IAGSEngine::DisableSound() {
     shutdown_sound();
     usetup.digicard = DIGI_NONE;
     usetup.midicard = MIDI_NONE;
-    install_sound(usetup.digicard,usetup.midicard,NULL);
+    install_sound(usetup.digicard,usetup.midicard,nullptr);
 }
 int IAGSEngine::CanRunScriptFunctionNow() {
     if (inside_script)
@@ -710,16 +710,16 @@ void IAGSEngine::NotifySpriteUpdated(int32 slot) {
     for (ff = 0; ff < game.numcharacters; ff++) {
         if ((charcache[ff].inUse) && (charcache[ff].sppic == slot)) {
             delete charcache[ff].image;
-            charcache[ff].image = NULL;
+            charcache[ff].image = nullptr;
             charcache[ff].inUse = 0;
         }
     }
 
     // clear the object cache
     for (ff = 0; ff < MAX_ROOM_OBJECTS; ff++) {
-        if ((objcache[ff].image != NULL) && (objcache[ff].sppic == slot)) {
+        if ((objcache[ff].image != nullptr) && (objcache[ff].sppic == slot)) {
             delete objcache[ff].image;
-            objcache[ff].image = NULL;
+            objcache[ff].image = nullptr;
         }
     }
 }
@@ -754,7 +754,7 @@ void IAGSEngine::AddManagedObjectReader(const char *typeName, IAGSManagedObjectR
     if (numPluginReaders >= MAX_PLUGIN_OBJECT_READERS) 
         quit("Plugin error: IAGSEngine::AddObjectReader: Too many object readers added");
 
-    if ((typeName == NULL) || (typeName[0] == 0))
+    if ((typeName == nullptr) || (typeName[0] == 0))
         quit("Plugin error: IAGSEngine::AddObjectReader: invalid name for type");
 
     for (int ii = 0; ii < numPluginReaders; ii++) {
@@ -858,16 +858,16 @@ IAGSFontRenderer* IAGSEngine::ReplaceFontRenderer(int fontNumber, IAGSFontRender
 
 void pl_stop_plugins() {
     int a;
-    ccSetDebugHook(NULL);
+    ccSetDebugHook(nullptr);
 
     for (a = 0; a < numPlugins; a++) {
         if (plugins[a].available) {
-            if (plugins[a].engineShutdown != NULL)
+            if (plugins[a].engineShutdown != nullptr)
                 plugins[a].engineShutdown();
             plugins[a].wantHook = 0;
             if (plugins[a].savedata) {
                 free(plugins[a].savedata);
-                plugins[a].savedata = NULL;
+                plugins[a].savedata = nullptr;
             }
             if (!plugins[a].builtin) {
               plugins[a].library.Unload();
@@ -912,7 +912,7 @@ int pl_run_plugin_debug_hooks (const char *scriptfile, int linenum) {
 void pl_run_plugin_init_gfx_hooks (const char *driverName, void *data) {
     for (int i = 0; i < numPlugins; i++) 
     {
-        if (plugins[i].initGfxHook != NULL)
+        if (plugins[i].initGfxHook != nullptr)
         {
             plugins[i].initGfxHook(driverName, data);
         }
@@ -1054,13 +1054,13 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
         {
           AGS::Common::Debug::Printf(kDbgMsg_Init, "Plugin '%s' loading succeeded, resolving imports...", apl->filename);
 
-          if (apl->library.GetFunctionAddress("AGS_PluginV2") == NULL) {
+          if (apl->library.GetFunctionAddress("AGS_PluginV2") == nullptr) {
               quitprintf("Plugin '%s' is an old incompatible version.", apl->filename);
           }
           apl->engineStartup = (void(*)(IAGSEngine*))apl->library.GetFunctionAddress("AGS_EngineStartup");
           apl->engineShutdown = (void(*)())apl->library.GetFunctionAddress("AGS_EngineShutdown");
 
-          if (apl->engineStartup == NULL) {
+          if (apl->engineStartup == nullptr) {
               quitprintf("Plugin '%s' is not a valid AGS plugin (no engine startup entry point)", apl->filename);
           }
           apl->onEvent = (int(*)(int,int))apl->library.GetFunctionAddress("AGS_EngineOnEvent");

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -199,7 +199,7 @@ ccInstance *ccInstance::GetCurrentInstance()
 
 ccInstance *ccInstance::CreateFromScript(PScript scri)
 {
-    return CreateEx(scri, NULL);
+    return CreateEx(scri, nullptr);
 }
 
 ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
@@ -209,7 +209,7 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
     if (!cinst->_Create(scri, joined))
     {
         delete cinst;
-        return NULL;
+        return nullptr;
     }
 
     return cinst;
@@ -218,27 +218,27 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
 ccInstance::ccInstance()
 {
     flags               = 0;
-    globaldata          = NULL;
+    globaldata          = nullptr;
     globaldatasize      = 0;
-    code                = NULL;
-    runningInst         = NULL;
+    code                = nullptr;
+    runningInst         = nullptr;
     codesize            = 0;
-    strings             = NULL;
+    strings             = nullptr;
     stringssize         = 0;
-    exports             = NULL;
-    stack               = NULL;
+    exports             = nullptr;
+    stack               = nullptr;
     num_stackentries    = 0;
-    stackdata           = NULL;
+    stackdata           = nullptr;
     stackdatasize       = 0;
-    stackdata_ptr       = NULL;
+    stackdata_ptr       = nullptr;
     pc                  = 0;
     line_number         = 0;
     callStackSize       = 0;
     loadedInstanceId    = 0;
     returnValue         = 0;
     numimports = 0;
-    resolved_imports = NULL;
-    code_fixups         = NULL;
+    resolved_imports = nullptr;
+    code_fixups         = nullptr;
 
     memset(callStackLineNumber, 0, sizeof(callStackLineNumber));
     memset(callStackAddr, 0, sizeof(callStackAddr));
@@ -257,13 +257,13 @@ ccInstance *ccInstance::Fork()
 
 void ccInstance::Abort()
 {
-    if ((this != NULL) && (pc != 0))
+    if ((this != nullptr) && (pc != 0))
         flags |= INSTF_ABORTED;
 }
 
 void ccInstance::AbortAndDestroy()
 {
-    if (this != NULL) {
+    if (this != nullptr) {
         Abort();
         flags |= INSTF_FREE;
     }
@@ -345,7 +345,7 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
     flags &= ~INSTF_ABORTED;
 
     // object pointer needs to start zeroed
-    registers[SREG_OP].SetDynamicObject(0, NULL);
+    registers[SREG_OP].SetDynamicObject(nullptr, nullptr);
 
     ccInstance* currentInstanceWas = current_instance;
     registers[SREG_SP].SetStackPtr( &stack[0] );
@@ -376,7 +376,7 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
     pool.RunGarbageCollectionIfAppropriate();
 
     if (new_line_hook)
-        new_line_hook(NULL, 0);
+        new_line_hook(nullptr, 0);
 
     if (reterr)
         return -6;
@@ -887,7 +887,7 @@ int ccInstance::Run(int32_t curpc)
       case SCMD_MEMWRITEPTR: {
 
           int32_t handle = registers[SREG_MAR].ReadInt32();
-          char *address = NULL;
+          char *address = nullptr;
 
           if (reg1.Type == kScValStaticArray && reg1.StcArr->GetDynamicManager())
           {
@@ -921,7 +921,7 @@ int ccInstance::Run(int32_t curpc)
           break;
                              }
       case SCMD_MEMINITPTR: { 
-          char *address = NULL;
+          char *address = nullptr;
 
           if (reg1.Type == kScValStaticArray && reg1.StcArr->GetDynamicManager())
           {
@@ -967,7 +967,7 @@ int ccInstance::Run(int32_t curpc)
           // CHECKME!! what type of data may reg1 point to?
           pool.disableDisposeForObject = (const char*)registers[SREG_AX].Ptr;
           ccReleaseObjectReference(handle);
-          pool.disableDisposeForObject = NULL;
+          pool.disableDisposeForObject = nullptr;
           registers[SREG_MAR].WriteInt32(0);
           break;
                               }
@@ -1077,7 +1077,7 @@ int ccInstance::Run(int32_t curpc)
               }
               else
               {
-                  int_ret_val = call_function((intptr_t)reg1.Ptr, NULL, num_args_to_func, func_callstack.GetHead() + 1);
+                  int_ret_val = call_function((intptr_t)reg1.Ptr, nullptr, num_args_to_func, func_callstack.GetHead() + 1);
               }
 
               if (GlobalReturnValue.IsValid())
@@ -1267,7 +1267,7 @@ int ccInstance::Run(int32_t curpc)
           }
           break;
       case SCMD_CREATESTRING:
-          if (stringClassImpl == NULL) {
+          if (stringClassImpl == nullptr) {
               cc_error("No string class implementation set, but opcode was used");
               return -1;
           }
@@ -1399,15 +1399,15 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
 {
     int i;
     currentline = -1;
-    if ((scri == NULL) && (joined != NULL))
+    if ((scri == nullptr) && (joined != nullptr))
         scri = joined->instanceof;
 
-    if (scri == NULL) {
+    if (scri == nullptr) {
         cc_error("null pointer passed");
         return false;
     }
 
-    if (joined != NULL) {
+    if (joined != nullptr) {
         // share memory space with an existing instance (ie. this is a thread/fork)
         globalvars = joined->globalvars;
         globaldatasize = joined->globaldatasize;
@@ -1420,7 +1420,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
         // NOTE: globalvars are created in CreateGlobalVars()
         globalvars.reset(new ScVarMap());
         globaldatasize = scri->globaldatasize;
-        globaldata = NULL;
+        globaldata = nullptr;
         if (globaldatasize > 0)
         {
             globaldata = (char *)malloc(globaldatasize);
@@ -1428,7 +1428,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
         }
 
         codesize = scri->codesize;
-        code = NULL;
+        code = nullptr;
         if (codesize > 0)
         {
             code = (intptr_t*)malloc(codesize * sizeof(intptr_t));
@@ -1449,14 +1449,14 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
     num_stackentries = CC_STACK_SIZE;
     stack       = new RuntimeScriptValue[num_stackentries];
     stackdata   = new char[stackdatasize];
-    if (stack == NULL || stackdata == NULL) {
+    if (stack == nullptr || stackdata == nullptr) {
         cc_error("not enough memory to allocate stack");
         return false;
     }
 
     // find a LoadedInstance slot for it
     for (i = 0; i < MAX_LOADED_INSTANCES; i++) {
-        if (loadedInstances[i] == NULL) {
+        if (loadedInstances[i] == nullptr) {
             loadedInstances[i] = this;
             loadedInstanceId = i;
             break;
@@ -1521,7 +1521,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
     instanceof = scri;
     pc = 0;
     flags = 0;
-    if (joined != NULL)
+    if (joined != nullptr)
         flags = INSTF_SHAREDATA;
     scri->instances++;
 
@@ -1539,7 +1539,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
 
 void ccInstance::Free()
 {
-    if (instanceof != NULL) {
+    if (instanceof != nullptr) {
         instanceof->instances--;
         if (instanceof->instances == 0)
         {
@@ -1549,7 +1549,7 @@ void ccInstance::Free()
 
     // remove from the Active Instances list
     if (loadedInstances[loadedInstanceId] == this)
-        loadedInstances[loadedInstanceId] = NULL;
+        loadedInstances[loadedInstanceId] = nullptr;
 
     if ((flags & INSTF_SHAREDATA) == 0)
     {
@@ -1557,24 +1557,24 @@ void ccInstance::Free()
         nullfree(code);
     }
     globalvars.reset();
-    globaldata = NULL;
-    code = NULL;
-    strings = NULL;
+    globaldata = nullptr;
+    code = nullptr;
+    strings = nullptr;
 
     delete [] stack;
     delete [] stackdata;
     delete [] exports;
-    stack = NULL;
-    stackdata = NULL;
-    exports = NULL;
+    stack = nullptr;
+    stackdata = nullptr;
+    exports = nullptr;
 
     if ((flags & INSTF_SHAREDATA) == 0)
     {
         delete [] resolved_imports;
         delete [] code_fixups;
     }
-    resolved_imports = NULL;
-    code_fixups = NULL;
+    resolved_imports = nullptr;
+    code_fixups = nullptr;
 }
 
 bool ccInstance::ResolveScriptImports(PScript scri)
@@ -1592,14 +1592,14 @@ bool ccInstance::ResolveScriptImports(PScript scri)
     numimports = scri->numimports;
     if (numimports == 0)
     {
-        resolved_imports = NULL;
+        resolved_imports = nullptr;
         return false;
     }
     resolved_imports = new int[numimports];
 
     for (int i = 0; i < scri->numimports; ++i) {
         // MACPORT FIX 9/6/5: changed from NULL TO 0
-        if (scri->imports[i] == 0) {
+        if (scri->imports[i] == nullptr) {
             continue;
         }
 
@@ -1703,7 +1703,7 @@ ScriptVariable *ccInstance::FindGlobalVar(int32_t var_addr)
         Debug::Printf(kDbgMsg_Warn, "WARNING: looking up for global variable beyond allocated buffer (%d, %d)", var_addr, globaldatasize);
     }
     ScVarMap::iterator it = globalvars->find(var_addr);
-    return it != globalvars->end() ? &it->second : NULL;
+    return it != globalvars->end() ? &it->second : nullptr;
 }
 
 bool ccInstance::CreateRuntimeCodeFixups(PScript scri)
@@ -1752,7 +1752,7 @@ bool ccInstance::CreateRuntimeCodeFixups(PScript scri)
                 code[fixup] = import_index;
                 // If the call is to another script function next CALLEXT
                 // must be replaced with CALLAS
-                if (import->InstancePtr != NULL && (code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
+                if (import->InstancePtr != nullptr && (code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
                 {
                     code[fixup + 1] = SCMD_CALLAS | (import->InstancePtr->loadedInstanceId << INSTANCE_ID_SHIFT);
                 }

--- a/Engine/script/executingscript.cpp
+++ b/Engine/script/executingscript.cpp
@@ -72,7 +72,7 @@ void ExecutingScript::run_another(const char *namm, ScriptInstType scinst, size_
 }
 
 void ExecutingScript::init() {
-    inst = NULL;
+    inst = nullptr;
     forked = 0;
     numanother = 0;
     numPostScriptActions = 0;

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -56,8 +56,8 @@ public:
     {
         Type        = kScValUndefined;
         IValue      = 0;
-        Ptr         = NULL;
-        MgrPtr      = NULL;
+        Ptr         = nullptr;
+        MgrPtr      = nullptr;
         Size        = 0;
     }
 
@@ -65,8 +65,8 @@ public:
     {
         Type        = kScValInteger;
         IValue      = val;
-        Ptr         = NULL;
-        MgrPtr      = NULL;
+        Ptr         = nullptr;
+        MgrPtr      = nullptr;
         Size        = 4;
     }
 
@@ -111,7 +111,7 @@ public:
     }
     inline bool IsNull() const
     {
-        return Ptr == 0 && IValue == 0;
+        return Ptr == nullptr && IValue == 0;
     }
     
     inline bool GetAsBool() const
@@ -127,8 +127,8 @@ public:
     {
         Type    = kScValUndefined;
         IValue   = 0;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 0;
         return *this;
     }
@@ -136,8 +136,8 @@ public:
     {
         Type    = kScValInteger;
         IValue  = val;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 1;
         return *this;
     }
@@ -145,8 +145,8 @@ public:
     {
         Type    = kScValInteger;
         IValue  = val;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 2;
         return *this;
     }
@@ -154,8 +154,8 @@ public:
     {
         Type    = kScValInteger;
         IValue  = val;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -163,8 +163,8 @@ public:
     {
         Type    = kScValFloat;
         FValue  = val;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -180,8 +180,8 @@ public:
     {
         Type    = kScValPluginArg;
         IValue  = val;
-        Ptr     = NULL;
-        MgrPtr  = NULL;
+        Ptr     = nullptr;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -190,7 +190,7 @@ public:
         Type    = kScValStackPtr;
         IValue  = 0;
         RValue  = stack_entry;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -199,7 +199,7 @@ public:
         Type    = kScValData;
         IValue  = 0;
         Ptr     = data;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = size;
         return *this;
     }
@@ -208,7 +208,7 @@ public:
         Type    = kScValGlobalVar;
         IValue  = 0;
         RValue  = glvar_value;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -218,7 +218,7 @@ public:
         Type    = kScValStringLiteral;
         IValue  = 0;
         Ptr     = const_cast<char *>(str);
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -263,7 +263,7 @@ public:
         Type    = kScValStaticFunction;
         IValue  = 0;
         SPfn    = pfn;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -272,7 +272,7 @@ public:
         Type    = kScValPluginFunction;
         IValue  = 0;
         Ptr     = (char*)pfn;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -281,7 +281,7 @@ public:
         Type    = kScValObjectFunction;
         IValue  = 0;
         ObjPfn  = pfn;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }
@@ -290,7 +290,7 @@ public:
         Type    = kScValCodePtr;
         IValue  = 0;
         Ptr     = ptr;
-        MgrPtr  = NULL;
+        MgrPtr  = nullptr;
         Size    = 4;
         return *this;
     }

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -52,13 +52,13 @@ extern int our_eip;
 extern CharacterInfo*playerchar;
 
 ExecutingScript scripts[MAX_SCRIPT_AT_ONCE];
-ExecutingScript*curscript = NULL;
+ExecutingScript*curscript = nullptr;
 
 PScript gamescript;
 PScript dialogScriptsScript;
-ccInstance *gameinst = NULL, *roominst = NULL;
-ccInstance *dialogScriptsInst = NULL;
-ccInstance *gameinstFork = NULL, *roominstFork = NULL;
+ccInstance *gameinst = nullptr, *roominst = nullptr;
+ccInstance *dialogScriptsInst = nullptr;
+ccInstance *gameinstFork = nullptr, *roominstFork = nullptr;
 
 int num_scripts=0;
 int post_script_cleanup_stack = 0;
@@ -151,13 +151,13 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
 int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 
     if (evnt < 0 || (size_t)evnt >= nint->Events.size() ||
-        (nint->Events[evnt].Response.get() == NULL) || (nint->Events[evnt].Response->Cmds.size() == 0)) {
+        (nint->Events[evnt].Response.get() == nullptr) || (nint->Events[evnt].Response->Cmds.size() == 0)) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
         if (chkAny < 0) ;
         else if ((size_t)chkAny < nint->Events.size() &&
-                (nint->Events[chkAny].Response.get() != NULL) && (nint->Events[chkAny].Response->Cmds.size() > 0))
+                (nint->Events[chkAny].Response.get() != nullptr) && (nint->Events[chkAny].Response->Cmds.size() > 0))
             return 0;
 
         // Otherwise, run unhandled_event
@@ -187,12 +187,12 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 // (eg. a room change occured)
 int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int isInv) {
 
-    if ((nint->ScriptFuncNames[evnt] == NULL) || (nint->ScriptFuncNames[evnt][0u] == 0)) {
+    if ((nint->ScriptFuncNames[evnt] == nullptr) || (nint->ScriptFuncNames[evnt][0u] == 0)) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
         if (chkAny < 0) ;
-        else if ((nint->ScriptFuncNames[chkAny] != NULL) && (nint->ScriptFuncNames[chkAny][0u] != 0))
+        else if ((nint->ScriptFuncNames[chkAny] != nullptr) && (nint->ScriptFuncNames[chkAny][0u] != 0))
             return 0;
 
         // Otherwise, run unhandled_event
@@ -211,7 +211,7 @@ int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int i
     RuntimeScriptValue rval_null;
 
     update_polled_mp3();
-        if ((strstr(evblockbasename,"character")!=0) || (strstr(evblockbasename,"inventory")!=0)) {
+        if ((strstr(evblockbasename,"character")!=nullptr) || (strstr(evblockbasename,"inventory")!=nullptr)) {
             // Character or Inventory (global script)
             QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt]);
         }
@@ -233,27 +233,27 @@ int create_global_script() {
     ccSetOption(SCOPT_AUTOIMPORT, 1);
     for (int kk = 0; kk < numScriptModules; kk++) {
         moduleInst[kk] = ccInstance::CreateFromScript(scriptModules[kk]);
-        if (moduleInst[kk] == NULL)
+        if (moduleInst[kk] == nullptr)
             return -3;
         // create a forked instance for rep_exec_always
         moduleInstFork[kk] = moduleInst[kk]->Fork();
-        if (moduleInstFork[kk] == NULL)
+        if (moduleInstFork[kk] == nullptr)
             return -3;
 
         moduleRepExecAddr[kk] = moduleInst[kk]->GetSymbolAddress(REP_EXEC_NAME);
     }
     gameinst = ccInstance::CreateFromScript(gamescript);
-    if (gameinst == NULL)
+    if (gameinst == nullptr)
         return -3;
     // create a forked instance for rep_exec_always
     gameinstFork = gameinst->Fork();
-    if (gameinstFork == NULL)
+    if (gameinstFork == nullptr)
         return -3;
 
-    if (dialogScriptsScript != NULL)
+    if (dialogScriptsScript != nullptr)
     {
         dialogScriptsInst = ccInstance::CreateFromScript(dialogScriptsScript);
-        if (dialogScriptsInst == NULL)
+        if (dialogScriptsInst == nullptr)
             return -3;
     }
 
@@ -282,7 +282,7 @@ ccInstance *GetScriptInstanceByType(ScriptInstType sc_inst)
         return gameinst;
     else if (sc_inst == kScInstRoom)
         return roominst;
-    return NULL;
+    return nullptr;
 }
 
 void QueueScriptFunction(ScriptInstType sc_inst, const char *fn_name, size_t param_count, const RuntimeScriptValue &p1, const RuntimeScriptValue &p2)
@@ -347,7 +347,7 @@ int PrepareTextScript(ccInstance *sci, const char**tsname)
 {
     ccError = 0;
     // FIXME: try to make it so this function is not called with NULL sci
-    if (sci == NULL) return -1;
+    if (sci == nullptr) return -1;
     if (sci->GetSymbolAddress(tsname[0]).IsNull()) {
         ccErrorString = "no such function in script";
         return -2;
@@ -362,7 +362,7 @@ int PrepareTextScript(ccInstance *sci, const char**tsname)
     // function would have quit earlier (deprecated functionality?)
     if (sci->IsBeingRun()) {
         scripts[num_scripts].inst = sci->Fork();
-        if (scripts[num_scripts].inst == NULL)
+        if (scripts[num_scripts].inst == nullptr)
             quit("unable to fork instance for secondary script");
         scripts[num_scripts].forked = 1;
     }
@@ -443,7 +443,7 @@ int RunTextScript(ccInstance *sci, const char *tsname)
 
         for (int kk = 0; kk < numScriptModules; kk++) {
             if (!moduleRepExecAddr[kk].IsNull())
-                RunScriptFunctionIfExists(moduleInst[kk], tsname, 0, NULL);
+                RunScriptFunctionIfExists(moduleInst[kk], tsname, 0, nullptr);
 
             if ((room_changes_was != play.room_changes) ||
                 (restore_game_count_was != gameHasBeenRestored))
@@ -451,7 +451,7 @@ int RunTextScript(ccInstance *sci, const char *tsname)
         }
     }
 
-    int toret = RunScriptFunctionIfExists(sci, tsname, 0, NULL);
+    int toret = RunScriptFunctionIfExists(sci, tsname, 0, nullptr);
     if ((toret == -18) && (sci == roominst)) {
         // functions in room script must exist
         quitprintf("prepare_script: error %d (%s) trying to run '%s'   (Room %d)", toret, ccErrorString.GetCStr(), tsname, displayed_room);
@@ -528,7 +528,7 @@ void post_script_cleanup() {
     if (num_scripts > 0)
         curscript = &scripts[num_scripts-1];
     else {
-        curscript = NULL;
+        curscript = nullptr;
     }
     //  if (abort_executor) user_disabled_data2=aborted_ip;
 
@@ -640,7 +640,7 @@ InteractionVariable *FindGraphicalVariable(const char *varName) {
         if (stricmp (thisroom.LocalVariables[i].Name, varName) == 0)
             return &thisroom.LocalVariables[i];
     }
-    return NULL;
+    return nullptr;
 }
 
 #define IPARAM1 get_nivalue(nicl, i, 0)
@@ -664,7 +664,7 @@ struct TempEip {
 int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, int*cmdsrun) {
     size_t i;
 
-    if (nicl == NULL)
+    if (nicl == nullptr)
         return -1;
 
     for (i = 0; i < nicl->Cmds.size(); i++) {
@@ -679,7 +679,7 @@ int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, in
               TempEip tempip(4001);
               RuntimeScriptValue rval_null;
               update_polled_mp3();
-                  if ((strstr(evblockbasename,"character")!=0) || (strstr(evblockbasename,"inventory")!=0)) {
+                  if ((strstr(evblockbasename,"character")!=nullptr) || (strstr(evblockbasename,"inventory")!=nullptr)) {
                       // Character or Inventory (global script)
                       const char *torun = make_ts_func_name(evblockbasename,evblocknum,nicl->Cmds[i].Data[0].Value);
                       // we are already inside the mouseclick event of the script, can't nest calls

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -39,13 +39,13 @@ const char *ScriptSprintf(char *buffer, size_t buf_length, const char *format,
 // Sprintf that takes script values as arguments
 inline const char *ScriptSprintf(char *buffer, size_t buf_length, const char *format, const RuntimeScriptValue *args, int32_t argc)
 {
-    return ScriptSprintf(buffer, buf_length, format, args, argc, NULL);
+    return ScriptSprintf(buffer, buf_length, format, args, argc, nullptr);
 }
 // Variadic sprintf (needed, because all arguments are pushed as pointer-sized values). Currently used only when plugin calls
 // exported engine function. Should be removed when this plugin issue is resolved.
 inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *format, va_list &arg_ptr)
 {
-    return ScriptSprintf(buffer, buf_length, format, NULL, 0, &arg_ptr);
+    return ScriptSprintf(buffer, buf_length, format, nullptr, 0, &arg_ptr);
 }
 
 // Helper macros for script functions

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -39,32 +39,32 @@ extern ccInstance *current_instance; // in script/cc_instance
 
 bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *pfn)
 {
-    return simp.add(name, RuntimeScriptValue().SetStaticFunction(pfn), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetStaticFunction(pfn), nullptr) == 0;
 }
 
 bool ccAddExternalPluginFunction(const String &name, void *pfn)
 {
-    return simp.add(name, RuntimeScriptValue().SetPluginFunction(pfn), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetPluginFunction(pfn), nullptr) == 0;
 }
 
 bool ccAddExternalStaticObject(const String &name, void *ptr, ICCStaticObject *manager)
 {
-    return simp.add(name, RuntimeScriptValue().SetStaticObject(ptr, manager), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetStaticObject(ptr, manager), nullptr) == 0;
 }
 
 bool ccAddExternalStaticArray(const String &name, void *ptr, StaticArray *array_mgr)
 {
-    return simp.add(name, RuntimeScriptValue().SetStaticArray(ptr, array_mgr), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetStaticArray(ptr, array_mgr), nullptr) == 0;
 }
 
 bool ccAddExternalDynamicObject(const String &name, void *ptr, ICCDynamicObject *manager)
 {
-    return simp.add(name, RuntimeScriptValue().SetDynamicObject(ptr, manager), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetDynamicObject(ptr, manager), nullptr) == 0;
 }
 
 bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn)
 {
-    return simp.add(name, RuntimeScriptValue().SetObjectFunction(pfn), NULL) == 0;
+    return simp.add(name, RuntimeScriptValue().SetObjectFunction(pfn), nullptr) == 0;
 }
 
 bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst)
@@ -82,13 +82,13 @@ void ccRemoveAllSymbols()
     simp.clear();
 }
 
-ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = {NULL,
-NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 
-NULL, NULL, NULL, NULL, NULL, NULL};
+ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = {nullptr,
+nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 
+nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
 void nullfree(void *data)
 {
-    if (data != NULL)
+    if (data != nullptr)
         free(data);
 }
 
@@ -99,12 +99,12 @@ void *ccGetSymbolAddress(const String &name)
     {
         return import->Value.Ptr;
     }
-    return NULL;
+    return nullptr;
 }
 
 bool ccAddExternalFunctionForPlugin(const String &name, void *pfn)
 {
-    return simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(pfn), NULL) == 0;
+    return simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(pfn), nullptr) == 0;
 }
 
 void *ccGetSymbolAddressForPlugin(const String &name)
@@ -123,10 +123,10 @@ void *ccGetSymbolAddressForPlugin(const String &name)
             return import->Value.Ptr;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
-new_line_hook_type new_line_hook = NULL;
+new_line_hook_type new_line_hook = nullptr;
 
 char ccRunnerCopyright[] = "ScriptExecuter32 v" SCOM_VERSIONSTR " (c) 2001 Chris Jones";
 int maxWhileLoops = 0;
@@ -139,7 +139,7 @@ void ccSetScriptAliveTimer (int numloop) {
 }
 
 void ccNotifyScriptStillAlive () {
-    if (current_instance != NULL)
+    if (current_instance != nullptr)
         current_instance->flags |= INSTF_RUNNING;
 }
 

--- a/Engine/script/systemimports.cpp
+++ b/Engine/script/systemimports.cpp
@@ -28,7 +28,7 @@ int SystemImports::add(const String &name, const RuntimeScriptValue &value, ccIn
 
     if ((ixof = get_index_of(name)) >= 0) {
         // Only allow override if not a script-exported function
-        if (anotherscr == NULL) {
+        if (anotherscr == nullptr) {
             imports[ixof].Value = value;
             imports[ixof].InstancePtr = anotherscr;
         }
@@ -38,7 +38,7 @@ int SystemImports::add(const String &name, const RuntimeScriptValue &value, ccIn
     ixof = imports.size();
     for (size_t i = 0; i < imports.size(); ++i)
     {
-        if (imports[i].Name == NULL)
+        if (imports[i].Name == nullptr)
         {
             ixof = i;
             break;
@@ -59,16 +59,16 @@ void SystemImports::remove(const String &name) {
     if (idx < 0)
         return;
     btree.erase(imports[idx].Name);
-    imports[idx].Name = NULL;
+    imports[idx].Name = nullptr;
     imports[idx].Value.Invalidate();
-    imports[idx].InstancePtr = NULL;
+    imports[idx].InstancePtr = nullptr;
 }
 
 const ScriptImport *SystemImports::getByName(const String &name)
 {
     int o = get_index_of(name);
     if (o < 0)
-        return NULL;
+        return nullptr;
 
     return &imports[o];
 }
@@ -76,7 +76,7 @@ const ScriptImport *SystemImports::getByName(const String &name)
 const ScriptImport *SystemImports::getByIndex(int index)
 {
     if ((size_t)index >= imports.size())
-        return NULL;
+        return nullptr;
 
     return &imports[index];
 }
@@ -116,15 +116,15 @@ void SystemImports::RemoveScriptExports(ccInstance *inst)
 
     for (size_t i = 0; i < imports.size(); ++i)
     {
-        if (imports[i].Name == NULL)
+        if (imports[i].Name == nullptr)
             continue;
 
         if (imports[i].InstancePtr == inst)
         {
             btree.erase(imports[i].Name);
-            imports[i].Name = NULL;
+            imports[i].Name = nullptr;
             imports[i].Value.Invalidate();
-            imports[i].InstancePtr = 0;
+            imports[i].InstancePtr = nullptr;
         }
     }
 }

--- a/Engine/script/systemimports.h
+++ b/Engine/script/systemimports.h
@@ -27,7 +27,7 @@ struct ScriptImport
 {
     ScriptImport()
     {
-        InstancePtr = NULL;
+        InstancePtr = nullptr;
     }
 
     String              Name;           // import's uid

--- a/Engine/util/library.h
+++ b/Engine/util/library.h
@@ -26,13 +26,9 @@ namespace Engine
 class BaseLibrary
 {
 public:
-  BaseLibrary()
-  {
-  };
+  BaseLibrary() = default;
 
-  virtual ~BaseLibrary()
-  {
-  };
+  virtual ~BaseLibrary() = default;
 
   virtual bool Load(AGS::Common::String libraryName) = 0;
 

--- a/Engine/util/library_posix.h
+++ b/Engine/util/library_posix.h
@@ -37,7 +37,7 @@ class PosixLibrary : BaseLibrary
 {
 public:
   PosixLibrary()
-    : _library(NULL)
+    : _library(nullptr)
   {
   };
 
@@ -72,9 +72,9 @@ public:
     Unload();
 
     // Try rpath first
-    _library = dlopen(BuildPath(NULL, libraryName).GetCStr(), RTLD_LAZY);
+    _library = dlopen(BuildPath(nullptr, libraryName).GetCStr(), RTLD_LAZY);
     AGS::Common::Debug::Printf("dlopen returned: %s", dlerror());
-    if (_library != NULL)
+    if (_library != nullptr)
     {
       return true;
     }
@@ -84,7 +84,7 @@ public:
 
     AGS::Common::Debug::Printf("dlopen returned: %s", dlerror());
 
-    if (_library == NULL)
+    if (_library == nullptr)
     {
       // Try the engine directory
 
@@ -99,7 +99,7 @@ public:
       AGS::Common::Debug::Printf("dlopen returned: %s", dlerror());
     }
 
-    return (_library != NULL);
+    return (_library != nullptr);
   }
 
   bool Unload() override
@@ -122,7 +122,7 @@ public:
     }
     else
     {
-      return NULL;
+      return nullptr;
     }
   }
 

--- a/Engine/util/mutex.h
+++ b/Engine/util/mutex.h
@@ -24,13 +24,9 @@ namespace Engine
 class BaseMutex
 {
 public:
-  BaseMutex()
-  {
-  };
+  BaseMutex() = default;
 
-  virtual ~BaseMutex()
-  {
-  };
+  virtual ~BaseMutex() = default;
 
   BaseMutex &operator=(const BaseMutex &) = delete;
   BaseMutex(const BaseMutex &) = delete;

--- a/Engine/util/mutex_lock.h
+++ b/Engine/util/mutex_lock.h
@@ -33,8 +33,8 @@ private:
 public:
 	void Release()
 	{
-		if (_m != NULL) _m->Unlock();
-		_m = NULL;
+		if (_m != nullptr) _m->Unlock();
+		_m = nullptr;
 	}
 
 	void Acquire(BaseMutex &mutex)
@@ -44,11 +44,11 @@ public:
 		_m->Lock();
 	}
 
-	MutexLock() : _m(NULL)
+	MutexLock() : _m(nullptr)
 	{
 	}
 
-	explicit MutexLock(BaseMutex &mutex) : _m(NULL)
+	explicit MutexLock(BaseMutex &mutex) : _m(nullptr)
 	{
 		Acquire(mutex);
 	}

--- a/Engine/util/mutex_std.h
+++ b/Engine/util/mutex_std.h
@@ -26,7 +26,7 @@ class StdMutex : public BaseMutex
 {
   public:
     inline StdMutex() : mutex_() {}
-    inline ~StdMutex() override {}
+    inline ~StdMutex() override = default;
 
     StdMutex &operator=(const StdMutex &) = delete;
     StdMutex(const StdMutex &) = delete;

--- a/Engine/util/thread.h
+++ b/Engine/util/thread.h
@@ -26,8 +26,8 @@ class BaseThread
 public:
   typedef void(* AGSThreadEntry)();
 
-  BaseThread() { };
-  virtual ~BaseThread() { };
+  BaseThread() = default;
+  virtual ~BaseThread() = default;
 
   BaseThread &operator=(const BaseThread &) = delete;
   BaseThread(const BaseThread &) = delete;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -85,9 +85,9 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
 //define engine
 
-IAGSEngine *engine = 0;
-SpriteFontRenderer *fontRenderer = 0;
-VariableWidthSpriteFontRenderer *vWidthRenderer = 0;
+IAGSEngine *engine = nullptr;
+SpriteFontRenderer *fontRenderer = nullptr;
+VariableWidthSpriteFontRenderer *vWidthRenderer = nullptr;
 
                 
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/CharacterEntry.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/CharacterEntry.cpp
@@ -11,6 +11,4 @@ CharacterEntry::CharacterEntry(void)
 }
 
 
-CharacterEntry::~CharacterEntry(void)
-{
-}
+CharacterEntry::~CharacterEntry(void) = default;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFont.cpp
@@ -1,11 +1,7 @@
 #include "SpriteFont.h"
 
 
-SpriteFont::SpriteFont(void)
-{
-}
+SpriteFont::SpriteFont(void) = default;
 
 
-SpriteFont::~SpriteFont(void)
-{
-}
+SpriteFont::~SpriteFont(void) = default;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -11,9 +11,7 @@ SpriteFontRenderer::SpriteFontRenderer(IAGSEngine *engine)
 }
 
 
-SpriteFontRenderer::~SpriteFontRenderer(void)
-{
-}
+SpriteFontRenderer::~SpriteFontRenderer(void) = default;
 
 void SpriteFontRenderer::SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth, int charHeight, int charMin, int charMax, bool use32bit)
 {

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
@@ -9,9 +9,7 @@ VariableWidthFont::VariableWidthFont(void)
 }
 
 
-VariableWidthFont::~VariableWidthFont(void)
-{
-}
+VariableWidthFont::~VariableWidthFont(void) = default;
 
 void VariableWidthFont::SetGlyph(int character, int x, int y, int width, int height)
 {

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -11,9 +11,7 @@ VariableWidthSpriteFontRenderer::VariableWidthSpriteFontRenderer(IAGSEngine *eng
 }
 
 
-VariableWidthSpriteFontRenderer::~VariableWidthSpriteFontRenderer(void)
-{
-}
+VariableWidthSpriteFontRenderer::~VariableWidthSpriteFontRenderer(void) = default;
 
 
 

--- a/Plugins/AGSflashlight/agsflashlight.cpp
+++ b/Plugins/AGSflashlight/agsflashlight.cpp
@@ -75,9 +75,9 @@ int g_FollowCharacterDy = 0;
 int g_FollowCharacterHorz = 0;
 int g_FollowCharacterVert = 0;
 
-AGSCharacter* g_FollowCharacter = NULL;
+AGSCharacter* g_FollowCharacter = nullptr;
 
-BITMAP* g_LightBitmap = NULL;
+BITMAP* g_LightBitmap = nullptr;
 
 
 // This function is from Allegro, split for more performance.
@@ -423,7 +423,7 @@ void CreateLightBitmap()
    {
 	   engine->GetMousePosition(&g_FlashlightX, &g_FlashlightY);
    }
-   else if (g_FollowCharacter != NULL)
+   else if (g_FollowCharacter != nullptr)
    {
      g_FlashlightX = g_FollowCharacter->x + g_FollowCharacterDx;
      g_FlashlightY = g_FollowCharacter->y + g_FollowCharacterDy;

--- a/Plugins/ags_snowrain/ags_snowrain.cpp
+++ b/Plugins/ags_snowrain/ags_snowrain.cpp
@@ -154,9 +154,7 @@ Weather::Weather(bool IsSnow)
 }
 
 
-Weather::~Weather()
-{
-}
+Weather::~Weather() = default;
 
 
 void Weather::Update()

--- a/Plugins/ags_snowrain/ags_snowrain.cpp
+++ b/Plugins/ags_snowrain/ags_snowrain.cpp
@@ -324,7 +324,7 @@ bool Weather::ReinitializeViews()
   int i;
   for (i = 0; i < 5; i++)
   {
-    if (mViews[i].bitmap != NULL)
+    if (mViews[i].bitmap != nullptr)
     {
       if (mViews[i].is_default)
         mViews[i].bitmap = default_bitmap;
@@ -384,7 +384,7 @@ void Weather::Initialize()
     mViews[i].is_default = true;
     mViews[i].view = -1;
     mViews[i].loop = -1;
-    mViews[i].bitmap = NULL;
+    mViews[i].bitmap = nullptr;
   }
   
   SetAmount(0);

--- a/Plugins/agsblend/AGSBlend.cpp
+++ b/Plugins/agsblend/AGSBlend.cpp
@@ -224,7 +224,7 @@ int HighPass(int sprite, int threshold){
     BITMAP* src = engine->GetSpriteGraphic(sprite);
     int srcWidth, srcHeight;
     
-	engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, NULL);
+	engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, nullptr);
 
     unsigned char **srccharbuffer = engine->GetRawBitmapSurface (src);
     unsigned int **srclongbuffer = (unsigned int**)srccharbuffer;
@@ -257,7 +257,7 @@ int Blur (int sprite, int radius) {
     BITMAP* src = engine->GetSpriteGraphic(sprite);
     
     int srcWidth, srcHeight;
-    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, NULL);
+    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, nullptr);
 
     unsigned char **srccharbuffer = engine->GetRawBitmapSurface (src);
     unsigned int **srclongbuffer = (unsigned int**)srccharbuffer;
@@ -432,8 +432,8 @@ int DrawSprite(int destination, int sprite, int x, int y, int DrawMode, int tran
     BITMAP* src = engine->GetSpriteGraphic(sprite);
     BITMAP* dest = engine->GetSpriteGraphic(destination);
         
-    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, NULL);
-    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, NULL);
+    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, nullptr);
+    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, nullptr);
     
     if (x > destWidth || y > destHeight || x + srcWidth < 0 || y + srcHeight < 0) return 1; // offscreen
     
@@ -713,8 +713,8 @@ int DrawAdd(int destination, int sprite, int x, int y, float scale){
     BITMAP* src = engine->GetSpriteGraphic(sprite);
     BITMAP* dest = engine->GetSpriteGraphic(destination);
     
-    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, NULL);
-    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, NULL);
+    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, nullptr);
+    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, nullptr);
     
     if (x > destWidth || y > destHeight) return 1; // offscreen
 
@@ -804,8 +804,8 @@ int DrawAlpha(int destination, int sprite, int x, int y, int trans)
     BITMAP* src = engine->GetSpriteGraphic(sprite);
     BITMAP* dest = engine->GetSpriteGraphic(destination);
     
-    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, NULL);
-    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, NULL);
+    engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, nullptr);
+    engine->GetBitmapDimensions(dest, &destWidth, &destHeight, nullptr);
     
     if (x > destWidth || y > destHeight) return 1; // offscreen
 

--- a/Plugins/agsblend/AGSBlend.cpp
+++ b/Plugins/agsblend/AGSBlend.cpp
@@ -143,7 +143,7 @@ struct Pixel32{
       
       public:
              Pixel32();
-             ~Pixel32() {}
+             ~Pixel32() = default;
 			 int GetColorAsInt();
              int Red;
              int Green;

--- a/Plugins/agspalrender/ags_palrender.cpp
+++ b/Plugins/agspalrender/ags_palrender.cpp
@@ -601,7 +601,7 @@ FLOAT_RETURN_TYPE AGSFastCos (SCRIPT_FLOAT(x))
 void DrawLens (int ox,int oy)
 {
 	int32 sh,sw=0;
-	engine->GetScreenDimensions (&sw,&sh,NULL);
+	engine->GetScreenDimensions (&sw,&sh,nullptr);
 	BITMAP *virtsc = engine->GetVirtualScreen ();
 	if (!virtsc) engine->AbortGame ("DrawLens: Cannot get virtual screen.");
 	BITMAP *lenswrite = engine->CreateBlankBitmap (LensOption.lenswidth,LensOption.lenswidth,8);
@@ -713,7 +713,7 @@ void LensInitialize (int width, int zoom, int lensx,int lensy,int level,int clam
 		if (width < 1) engine->AbortGame ("Invalid lens dimension!");
 		radius = width>>1;
 		lens = new LensDistort [width*width]();
-		engine->GetScreenDimensions (&sw,&sh,NULL);
+		engine->GetScreenDimensions (&sw,&sh,nullptr);
 		int radsq = radius*radius;
 		int zoomsq = zoom * zoom;
 	    for (int y = 0; y < radius; y++) 
@@ -827,7 +827,7 @@ void DrawPlasma (int slot, int palstart, int palend)
 		range = palstart - palend;
 		basecol = palend;
 	}
-	engine->GetBitmapDimensions (plasmaspr,&w,&h,NULL);
+	engine->GetBitmapDimensions (plasmaspr,&w,&h,nullptr);
 	unsigned char **plasmarray = engine->GetRawBitmapSurface (plasmaspr);
 	double frange = range/2.0;
 	int complex = 0;
@@ -894,7 +894,7 @@ void DoFire (int sprite, int masksprite, int palstart,int palend, int strength, 
 		dir=-1;
 	}
 	int divider = 256/range;
-	engine->GetBitmapDimensions (firespr,&w,&h,NULL);
+	engine->GetBitmapDimensions (firespr,&w,&h,nullptr);
 	unsigned char **fire = engine->GetRawBitmapSurface (firespr);
 	unsigned char **color = engine->GetRawBitmapSurface (firecolorspr);
 	int sparky=0;
@@ -1115,7 +1115,7 @@ void InitializeStars (int slot,int maxstars)
 {
         int32 sw,sh=0;
         BITMAP *canvas = engine->GetSpriteGraphic (slot);
-		engine->GetBitmapDimensions (canvas,&sw,&sh,NULL);
+		engine->GetBitmapDimensions (canvas,&sw,&sh,nullptr);
 		Starfield.maxstars = maxstars;
 		Starfield.overscan = 20;
 		stars = new starstype [Starfield.maxstars];
@@ -1291,7 +1291,7 @@ void DrawStars (int slot, int maskslot)
 		if (!canvas) engine->AbortGame ("DrawStars: Can't load sprite slot.");
 		BITMAP *maskcanvas = engine->GetSpriteGraphic (maskslot);
 		if (!maskcanvas) engine->AbortGame ("DrawStars: Can't load mask slot.");
-		engine->GetBitmapDimensions (canvas,&sw,&sh,NULL);
+		engine->GetBitmapDimensions (canvas,&sw,&sh,nullptr);
         unsigned char** screenarray = engine->GetRawBitmapSurface (canvas);
 		unsigned char** maskarray = engine->GetRawBitmapSurface (maskcanvas);
 		for (int i=0;i<Starfield.maxstars;i++)
@@ -1379,7 +1379,7 @@ void DrawStars (int slot, int maskslot)
 							unsigned char** orig = engine->GetRawBitmapSurface (origspr);
 							int32 h1,h2,w1,w2=0;
 							double fw2,fh2;
-							engine->GetBitmapDimensions (origspr,&w1,&h1,NULL);
+							engine->GetBitmapDimensions (origspr,&w1,&h1,nullptr);
 							fh2 = h1 * (scale / 100.0);
 							fw2 = w1 * (scale / 100.0);
 							h2 = static_cast<int>(fh2);
@@ -1595,21 +1595,21 @@ int DrawReflections (int id, int charobj=0)
 {
 	int32 screenw,screenh;
 	int32 bgw,bgh;
-	engine->GetScreenDimensions (&screenw,&screenh,NULL);
+	engine->GetScreenDimensions (&screenw,&screenh,nullptr);
 	BITMAP *bgmask= engine->GetBackgroundScene (1);
-	if (bgmask == NULL) return 1;
+	if (bgmask == nullptr) return 1;
 	//BITMAP *virtsc = engine->GetVirtualScreen();
 	BITMAP *walkbehind = engine->GetRoomMask(MASK_WALKBEHIND);
 	//if (!virtsc) engine->AbortGame ("Can't load virtual screen.");
 	if (!walkbehind) engine->AbortGame ("DrawRelfections: Can't load Walkbehind into memory.");
-	engine->GetBitmapDimensions (walkbehind,&bgw,&bgh,NULL);
+	engine->GetBitmapDimensions (walkbehind,&bgw,&bgh,nullptr);
 	if (!bgmask) engine->AbortGame ("DrawReflections: Can't load reflection mask.");
 	//unsigned char **charbuffer = engine->GetRawBitmapSurface (virtsc);
 	unsigned char **wbarray = engine->GetRawBitmapSurface (walkbehind);
 	unsigned char **maskarray = engine->GetRawBitmapSurface (bgmask);
 	//Initialize stuff
-	BITMAP *charsprite = NULL;
-	BITMAP *charsprite2 = NULL;
+	BITMAP *charsprite = nullptr;
+	BITMAP *charsprite2 = nullptr;
 	AGSCharacter *currchar;
 	AGSObject *currobj;
 	int cox,coy,coz=0;
@@ -1644,7 +1644,7 @@ int DrawReflections (int id, int charobj=0)
 	}
 	bool scaled;
 	int32 w,h;
-	engine->GetBitmapDimensions (charsprite,&w,&h,NULL);
+	engine->GetBitmapDimensions (charsprite,&w,&h,nullptr);
 	if (scale != 100)
 	{
 		unsigned char** orig = engine->GetRawBitmapSurface (charsprite);
@@ -2111,7 +2111,7 @@ int AGS_EngineOnEvent (int event, int data) {
 		if (drawreflections)
 		{
 			int32 sh,sw=0;
-			engine->GetScreenDimensions (&sw,&sh,NULL);
+			engine->GetScreenDimensions (&sw,&sh,nullptr);
 			reflectionmap = new long[sw*sh]();
 			rcolormap = engine->CreateBlankBitmap (sw,sh,8);
 			ralphamap = engine->CreateBlankBitmap (sw,sh,8);

--- a/Plugins/agspalrender/raycast.cpp
+++ b/Plugins/agspalrender/raycast.cpp
@@ -793,7 +793,7 @@ void Raycast_Render (int slot)
 	int32 w=sWidth,h=sHeight;
 	BITMAP *screen = engine->GetSpriteGraphic (slot);
 	if (!screen) engine->AbortGame ("Raycast_Render: No valid sprite to draw on.");
-	engine->GetBitmapDimensions (screen,&w,&h,NULL);
+	engine->GetBitmapDimensions (screen,&w,&h,nullptr);
 	BITMAP *sbBm = engine->GetSpriteGraphic (skybox);
 	if (!sbBm) engine->AbortGame ("Raycast_Render: No valid skybox sprite.");
 	if (skybox > 0)
@@ -1410,7 +1410,7 @@ void Raycast_Render (int slot)
 			else if (sprdeg > 247 && sprdeg < 293) loop = 2;
 			else if (sprdeg > 292 && sprdeg < 337) loop = 4;
 			AGSViewFrame *vf = engine->GetViewFrame (sprite[spriteOrder[i]].view,loop,sprite[spriteOrder[i]].frame);
-			if (vf == NULL) engine->AbortGame ("Raycast_Render: Unable to load viewframe of sprite.");
+			if (vf == nullptr) engine->AbortGame ("Raycast_Render: Unable to load viewframe of sprite.");
 			else
 			{
 				sprite[spriteOrder[i]].texture = vf->pic;


### PR DESCRIPTION
Modernise some of the c++ syntax using clang-tidy. This is only a refactor, it does not change any functionality.

- Replaces all instances of 0 and NULL with `nullptr`. 
- ~in master: Introduces `override` for all overriden methods.~
- Replaces empty `{}` constructors and destructors with `default`
- ~removed for now: Introduces `auto` ONLY for iterators and where the type is already on the right.~

Commands used:

```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
run-clang-tidy-3.8.py -header-filter='.*'  -checks='-*,modernize-use-nullptr' -fix
run-clang-tidy-3.8.py -header-filter='.*'  -checks='-*,modernize-use-override' -fix
run-clang-tidy-3.8.py -header-filter='.*'  -checks='-*,modernize-use-default' -fix
run-clang-tidy-3.8.py -header-filter='.*'  -checks='-*,modernize-use-auto' -fix
```