### PR TITLE
Script API: string Set and Dictionary types

### DIFF
--- a/Common/debug/debugmanager.h
+++ b/Common/debug/debugmanager.h
@@ -87,7 +87,7 @@ private:
     // Set of permitted groups' numeric IDs
     std::vector<MessageType> _groupFilter;
     // Set of unresolved groups, which numeric IDs are not yet known
-    typedef stdtr1compat::unordered_map<String, MessageType, HashStrNoCase, StrCmpNoCase> GroupNameToMTMap;
+    typedef stdtr1compat::unordered_map<String, MessageType, HashStrNoCase, StrEqNoCase> GroupNameToMTMap;
     GroupNameToMTMap _unresolvedGroups;
 };
 
@@ -137,8 +137,8 @@ private:
     };
 
     typedef std::vector<DebugGroup> GroupVector;
-    typedef stdtr1compat::unordered_map<String, DebugGroupID, HashStrNoCase, StrCmpNoCase> GroupByStringMap;
-    typedef stdtr1compat::unordered_map<String, OutputSlot, HashStrNoCase, StrCmpNoCase> OutMap;
+    typedef stdtr1compat::unordered_map<String, DebugGroupID, HashStrNoCase, StrEqNoCase> GroupByStringMap;
+    typedef stdtr1compat::unordered_map<String, OutputSlot, HashStrNoCase, StrEqNoCase> OutMap;
 
     void RegisterGroup(const DebugGroup &id);
     void SendMessage(OutputSlot &out, const DebugMessage &msg);

--- a/Common/game/customproperties.h
+++ b/Common/game/customproperties.h
@@ -81,7 +81,7 @@ struct PropertyDesc
 
 // NOTE: AGS has case-insensitive property IDs
 // Schema - a map of property descriptions
-typedef stdtr1compat::unordered_map<String, PropertyDesc, HashStrNoCase, StrCmpNoCase> PropertySchema;
+typedef stdtr1compat::unordered_map<String, PropertyDesc, HashStrNoCase, StrEqNoCase> PropertySchema;
 
 
 namespace Properties

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -64,10 +64,15 @@ public:
     String(char c, size_t count);
     ~String();
 
-    // Get underlying C-string for reading
+    // Get underlying C-string for reading; this method guarantees valid C-string
     inline const char *GetCStr() const
     {
         return _meta ? _meta->CStr : "";
+    }
+    // Get C-string or nullptr
+    inline const char *GetNullableCStr() const
+    {
+        return _meta ? _meta->CStr : nullptr;
     }
     // Get character count
     inline size_t GetLength() const

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -54,6 +54,7 @@ namespace std
 namespace tr1
 {
 #endif
+// std::hash for String object
 template<>
 struct hash<AGS::Common::String> : public unary_function<AGS::Common::String, size_t>
 {
@@ -73,7 +74,12 @@ namespace AGS
 namespace Common
 {
 
-struct StrCmpNoCase : public std::binary_function<String, String, bool>
+//
+// Various comparison functors
+//
+
+// Test case-insensitive String equality
+struct StrEqNoCase : public std::binary_function<String, String, bool>
 {
     bool operator()(const String &s1, const String &s2) const
     {
@@ -81,6 +87,16 @@ struct StrCmpNoCase : public std::binary_function<String, String, bool>
     }
 };
 
+// Case-insensitive String less
+struct StrLessNoCase : public std::binary_function<String, String, bool>
+{
+    bool operator()(const String &s1, const String &s2) const
+    {
+        return s1.CompareNoCase(s2) < 0;
+    }
+};
+
+// Compute case-insensitive hash for a String object
 struct HashStrNoCase : public std::unary_function<String, size_t>
 {
     size_t operator ()(const String &key) const
@@ -91,7 +107,7 @@ struct HashStrNoCase : public std::unary_function<String, size_t>
 
 typedef std::vector<String> StringV;
 typedef stdtr1compat::unordered_map<String, String> StringMap;
-typedef stdtr1compat::unordered_map<String, String, HashStrNoCase, StrCmpNoCase> StringIMap;
+typedef stdtr1compat::unordered_map<String, String, HashStrNoCase, StrEqNoCase> StringIMap;
 
 } // namespace Common
 } // namespace AGS

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -457,6 +457,32 @@ internalstring autoptr builtin managed struct String {
   readonly import attribute int Length;
 };
 
+#ifdef SCRIPT_API_v350
+builtin managed struct Set
+{
+  /// Creates a new empty Set of the given properties.
+  import static Set* Create(bool sorted = false, bool caseSensitive = false); // $AUTOCOMPLETESTATICONLY$
+
+  /// Adds item to the set, fails if such item was already existing.
+  import bool Add(String item);
+  /// Removes all items from the set.
+  import void Clear();
+  /// Tells if given item is in the set.
+  import bool Contains(String item);
+  /// Removes item from the set, fails if there was no such item.
+  import bool Remove(String item);
+
+  /// Gets if this set is case-sensitive.
+  import readonly attribute bool CaseSensitive;
+  /// Gets if this set is sorted in alphabetical order.
+  import readonly attribute bool Sorted;
+  /// Gets the number of items currently in the set.
+  import readonly attribute int ItemCount;
+  /// Creates a dynamic array filled with items in same order as they are stored in the Set.
+  import String[] GetItemsAsArray();
+};
+#endif
+
 builtin managed struct AudioClip;
 
 builtin managed struct ViewFrame {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -458,6 +458,34 @@ internalstring autoptr builtin managed struct String {
 };
 
 #ifdef SCRIPT_API_v350
+builtin managed struct Dictionary
+{
+  /// Creates a new empty Dictionary of the given properties.
+  import static Dictionary* Create(bool sorted = false, bool caseSensitive = false); // $AUTOCOMPLETESTATICONLY$
+
+  /// Removes all items from the dictionary.
+  import void Clear();
+  /// Tells if given key is in the dictionary.
+  import bool Contains(String key);
+  /// Gets value by the key; returns null if such key does not exist.
+  import String Get(String key);
+  /// Removes key/value pair from the dictionary, fails if there was no such key.
+  import bool Remove(String key);
+  /// Assigns a value to the given key, adds this key if it did not exist yet.
+  import bool Set(String key, String value);
+
+  /// Gets if this dictionary is case-sensitive.
+  import readonly attribute bool CaseSensitive;
+  /// Gets if this dictionary is sorted by keys in alphabetical order.
+  import readonly attribute bool Sorted;
+  /// Gets the number of key/value pairs currently in the dictionary.
+  import readonly attribute int ItemCount;
+  /// Creates a dynamic array filled with keys in same order as they are stored in the Dictionary.
+  import String[] GetKeysAsArray();
+  /// Creates a dynamic array filled with values in same order as they are stored in the Dictionary.
+  import String[] GetValuesAsArray();
+};
+
 builtin managed struct Set
 {
   /// Creates a new empty Set of the given properties.

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -66,7 +66,7 @@ void CCDynamicArray::Unserialize(int index, const char *serializedData, int data
     ccRegisterUnserializedObject(index, &newArray[8], this);
 }
 
-int32_t CCDynamicArray::Create(int numElements, int elementSize, bool isManagedType)
+DynObjectRef CCDynamicArray::Create(int numElements, int elementSize, bool isManagedType)
 {
     char *newArray = new char[numElements * elementSize + 8];
     memset(newArray, 0, numElements * elementSize + 8);
@@ -75,7 +75,14 @@ int32_t CCDynamicArray::Create(int numElements, int elementSize, bool isManagedT
     sizePtr[1] = numElements * elementSize;
     if (isManagedType) 
         sizePtr[0] |= ARRAY_MANAGED_TYPE_FLAG;
-    return ccRegisterManagedObject(&newArray[8], this);
+    void *obj_ptr = &newArray[8];
+    int32_t handle = ccRegisterManagedObject(obj_ptr, this);
+    if (handle == 0)
+    {
+        delete[] newArray;
+        return DynObjectRef(0, nullptr);
+    }
+    return DynObjectRef(handle, obj_ptr);
 }
 
 

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -142,3 +142,20 @@ void CCDynamicArray::WriteFloat(const char *address, intptr_t offset, float val)
 }
 
 CCDynamicArray globalDynamicArray;
+
+
+DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char*> items)
+{
+    // NOTE: we need element size of "handle" for array of managed pointers
+    DynObjectRef arr = globalDynamicArray.Create(items.size(), sizeof(int32_t), true);
+    if (!arr.second)
+        return arr;
+    // Create script strings and put handles into array
+    int32_t *slots = static_cast<int32_t*>(arr.second);
+    for (auto s : items)
+    {
+        DynObjectRef str = stringClassImpl->CreateString(s);
+        *(slots++) = str.first;
+    }
+    return arr;
+}

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -11,10 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __CC_DYNAMICARRAY_H
 #define __CC_DYNAMICARRAY_H
 
+#include <vector>
 #include "ac/dynobj/cc_dynamicobject.h"   // ICCDynamicObject
 
 #define CC_DYNAMIC_ARRAY_TYPE_NAME "CCDynamicArray"
@@ -47,5 +47,12 @@ struct CCDynamicArray final : ICCDynamicObject
 };
 
 extern CCDynamicArray globalDynamicArray;
+
+// Helper functions for setting up dynamic arrays.
+namespace DynamicArrayHelpers
+{
+    // Create array of managed strings
+    DynObjectRef CreateStringArray(const std::vector<const char*>);
+};
 
 #endif

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -29,7 +29,8 @@ struct CCDynamicArray final : ICCDynamicObject
     // return number of bytes used
     int Serialize(const char *address, char *buffer, int bufsize) override;
     virtual void Unserialize(int index, const char *serializedData, int dataSize);
-    int32_t Create(int numElements, int elementSize, bool isManagedType);
+    // Create managed array object and return a pointer to the beginning of a buffer
+    DynObjectRef Create(int numElements, int elementSize, bool isManagedType);
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -15,16 +15,19 @@
 // Managed script object interface.
 //
 //=============================================================================
-
 #ifndef __CC_DYNAMICOBJECT_H
 #define __CC_DYNAMICOBJECT_H
 
+#include <utility>
 #include "core/types.h"
 #include "script/runtimescriptvalue.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
+
+// A pair of managed handle and abstract object pointer
+typedef std::pair<int32_t, void*> DynObjectRef;
 
 
 // OBJECT-BASED SCRIPTING RUNTIME FUNCTIONS
@@ -79,7 +82,7 @@ struct ICCObjectReader {
     virtual void Unserialize(int index, const char *objectType, const char *serializedData, int dataSize) = 0;
 };
 struct ICCStringClass {
-    virtual void* CreateString(const char *fromText) = 0;
+    virtual DynObjectRef CreateString(const char *fromText) = 0;
 };
 
 // set the class that will be used for dynamic strings
@@ -101,6 +104,8 @@ extern int   ccUnserializeAllObjects(Common::Stream *in, ICCObjectReader *callba
 extern void  ccAttemptDisposeObject(int32_t handle);
 // translate between object handles and memory addresses
 extern int32_t ccGetObjectHandleFromAddress(const char *address);
+// TODO: not sure if it makes any sense whatsoever to use "const char*"
+// in these functions, might as well change to char* or just void*.
 extern const char *ccGetObjectAddressFromHandle(int32_t handle);
 extern ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&object, ICCDynamicObject *&manager);
 

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -29,6 +29,8 @@ private:
     struct ManagedObject {
         ScriptValueType obj_type;
         int32_t handle;
+        // TODO: this makes no sense having this as "const char*",
+        // void* will be proper (and in all related functions)
         const char *addr;
         ICCDynamicObject *callback;
         int refCount;

--- a/Engine/ac/dynobj/scriptdict.cpp
+++ b/Engine/ac/dynobj/scriptdict.cpp
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "ac/dynobj/scriptdict.h"
+
+int ScriptDictBase::Dispose(const char *address, bool force)
+{
+    Clear();
+    delete this;
+    return 1;
+}
+
+const char *ScriptDictBase::GetType()
+{
+    return "ScriptDict";
+}
+
+int ScriptDictBase::Serialize(const char *address, char *buffer, int bufsize)
+{
+    size_t total_sz = CalcSerializeSize();
+    if (bufsize < 0 || total_sz >(size_t)bufsize)
+    {
+        // buffer not big enough, ask for a bigger one
+        return -((int)total_sz);
+    }
+    StartSerialize(buffer);
+    SerializeContainer();
+    return EndSerialize();
+}
+
+void ScriptDictBase::Unserialize(int index, const char *serializedData, int dataSize)
+{
+    StartUnserialize(serializedData, dataSize);
+    UnserializeContainer(serializedData);
+    ccRegisterUnserializedObject(index, this, this);
+}

--- a/Engine/ac/dynobj/scriptdict.h
+++ b/Engine/ac/dynobj/scriptdict.h
@@ -1,0 +1,185 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Managed script object wrapping std::map<String, String> and
+// unordered_map<String, String>.
+//
+// TODO: support wrapping non-owned container, passed by the reference.
+// TODO: optimize key lookup operations by not creating a String object from
+// const char*. It seems C++14 standard allows to use convertible types as
+// keys. Perhaps there may also be ways to adjust String class and let it
+// wrap non-owned char buffer without any allocations on heap.
+//
+//=============================================================================
+#ifndef __AC_SCRIPTDICT_H
+#define __AC_SCRIPTDICT_H
+
+#include <map>
+#include <unordered_map>
+#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "util/string.h"
+#include "util/string_types.h"
+
+using namespace AGS::Common;
+
+class ScriptDictBase : public AGSCCDynamicObject
+{
+public:
+    int Dispose(const char *address, bool force) override;
+    const char *GetType() override;
+    int Serialize(const char *address, char *buffer, int bufsize) override;
+    void Unserialize(int index, const char *serializedData, int dataSize) override;
+
+    virtual bool IsCaseSensitive() const = 0;
+    virtual bool IsSorted() const = 0;
+
+    virtual void Clear() = 0;
+    virtual bool Contains(const char *key) = 0;
+    virtual const char *Get(const char *key) = 0;
+    virtual bool Remove(const char *key) = 0;
+    virtual bool Set(const char *key, const char *value) = 0;
+    virtual int GetItemCount() = 0;
+    virtual void GetKeys(std::vector<const char*> &buf) const = 0;
+    virtual void GetValues(std::vector<const char*> &buf) const = 0;
+
+private:
+    virtual size_t CalcSerializeSize() = 0;
+    virtual void SerializeContainer() = 0;
+    virtual void UnserializeContainer(const char *serializedData) = 0;
+};
+
+template <typename TDict, bool is_sorted, bool is_casesensitive>
+class ScriptDictImpl final : public ScriptDictBase
+{
+public:
+    typedef typename TDict::const_iterator ConstIterator;
+
+    ScriptDictImpl() = default;
+
+    bool IsCaseSensitive() const override { return is_casesensitive; }
+    bool IsSorted() const override { return is_sorted; }
+
+    void Clear() override
+    {
+        for (auto it = _dic.begin(); it != _dic.end(); ++it)
+            DeleteItem(it);
+        _dic.clear();
+    }
+    bool Contains(const char *key) override { return _dic.count(String(key)) != 0; }
+    const char *Get(const char *key) override
+    {
+        auto it = _dic.find(String(key));
+        if (it == _dic.end()) return nullptr;
+        return it->second.GetNullableCStr();
+    }
+    bool Remove(const char *key) override
+    {
+        auto it = _dic.find(String(key));
+        if (it == _dic.end()) return false;
+        DeleteItem(it);
+        _dic.erase(it);
+        return true;
+    }
+    bool Set(const char *key, const char *value) override
+    {
+        if (!key) return false;
+        size_t key_len = strlen(key);
+        size_t value_len = value ? strlen(value) : 0;
+        return TryAddItem(key, key_len, value, value_len);
+    }
+    int GetItemCount() override { return _dic.size(); }
+    void GetKeys(std::vector<const char*> &buf) const override
+    {
+        for (auto it = _dic.begin(); it != _dic.end(); ++it)
+            buf.push_back(it->first.GetCStr()); // keys cannot be null
+    }
+    void GetValues(std::vector<const char*> &buf) const override
+    {
+        for (auto it = _dic.begin(); it != _dic.end(); ++it)
+            buf.push_back(it->second.GetNullableCStr()); // values may be null
+    }
+
+private:
+    bool TryAddItem(const char *key, size_t key_len, const char *value, size_t value_len)
+    {
+        String elem_key(key, key_len);
+        String elem_value;
+        if (value)
+            elem_value.SetString(value, value_len);
+        _dic[elem_key] = elem_value;
+        return true;
+    }
+    void DeleteItem(ConstIterator it) { /* do nothing */ }
+
+    size_t CalcSerializeSize() override
+    {
+        size_t total_sz = sizeof(int32_t);
+        for (auto it = _dic.begin(); it != _dic.end(); ++it)
+        {
+            total_sz += sizeof(int32_t) + it->first.GetLength();
+            total_sz += sizeof(int32_t) + it->second.GetLength();
+        }
+        return total_sz;
+    }
+
+    void SerializeContainer() override
+    {
+        SerializeInt((int)_dic.size());
+        for (auto it = _dic.begin(); it != _dic.end(); ++it)
+        {
+            SerializeInt((int)it->first.GetLength());
+            memcpy(&serbuffer[bytesSoFar], it->first.GetCStr(), it->first.GetLength());
+            bytesSoFar += it->first.GetLength();
+            if (it->second.GetNullableCStr()) // values may be null
+            {
+                SerializeInt((int)it->second.GetLength());
+                memcpy(&serbuffer[bytesSoFar], it->second.GetCStr(), it->second.GetLength());
+                bytesSoFar += it->second.GetLength();
+            }
+            else
+            {
+                SerializeInt(-1);
+            }
+        }
+    }
+
+    void UnserializeContainer(const char *serializedData)
+    {
+        size_t item_count = (size_t)UnserializeInt();
+        for (size_t i = 0; i < item_count; ++i)
+        {
+            size_t key_len = UnserializeInt();
+            int key_pos = bytesSoFar; bytesSoFar += key_len;
+            size_t value_len = UnserializeInt();
+            if (value_len == (size_t)-1)
+            {
+                TryAddItem(&serializedData[key_pos], key_len, nullptr, 0);
+            }
+            else
+            {
+                int value_pos = bytesSoFar; bytesSoFar += value_len;
+                TryAddItem(&serializedData[key_pos], key_len, &serializedData[value_pos], value_len);
+            }
+        }
+    }
+
+    TDict _dic;
+};
+
+typedef ScriptDictImpl< std::map<String, String>, true, true > ScriptDict;
+typedef ScriptDictImpl< std::map<String, String, StrLessNoCase>, true, false > ScriptDictCI;
+typedef ScriptDictImpl< std::unordered_map<String, String>, false, true > ScriptHashDict;
+typedef ScriptDictImpl< std::unordered_map<String, String, HashStrNoCase, StrEqNoCase>, false, false > ScriptHashDictCI;
+
+#endif // __AC_SCRIPTDICT_H

--- a/Engine/ac/dynobj/scriptset.cpp
+++ b/Engine/ac/dynobj/scriptset.cpp
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "ac/dynobj/scriptset.h"
+
+int ScriptSetBase::Dispose(const char *address, bool force)
+{
+    Clear();
+    delete this;
+    return 1;
+}
+
+const char *ScriptSetBase::GetType()
+{
+    return "ScriptSet";
+}
+
+int ScriptSetBase::Serialize(const char *address, char *buffer, int bufsize)
+{
+    size_t total_sz = CalcSerializeSize();
+    if (bufsize < 0 || total_sz > (size_t)bufsize)
+    {
+        // buffer not big enough, ask for a bigger one
+        return -((int)total_sz);
+    }
+    StartSerialize(buffer);
+    SerializeContainer();
+    return EndSerialize();
+}
+
+void ScriptSetBase::Unserialize(int index, const char *serializedData, int dataSize)
+{
+    StartUnserialize(serializedData, dataSize);
+    UnserializeContainer(serializedData);
+    ccRegisterUnserializedObject(index, this, this);
+}

--- a/Engine/ac/dynobj/scriptset.h
+++ b/Engine/ac/dynobj/scriptset.h
@@ -1,0 +1,143 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Managed script object wrapping std::set<String> and unordered_set<String>.
+//
+// TODO: support wrapping non-owned container, passed by the reference.
+// TODO: optimize key lookup operations by not creating a String object from
+// const char*. It seems C++14 standard allows to use convertible types as
+// keys. Perhaps there may also be ways to adjust String class and let it
+// wrap non-owned char buffer without any allocations on heap.
+//
+//=============================================================================
+#ifndef __AC_SCRIPTSET_H
+#define __AC_SCRIPTSET_H
+
+#include <set>
+#include <unordered_set>
+#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "util/string.h"
+#include "util/string_types.h"
+
+using namespace AGS::Common;
+
+class ScriptSetBase : public AGSCCDynamicObject
+{
+public:
+    int Dispose(const char *address, bool force) override;
+    const char *GetType() override;
+    int Serialize(const char *address, char *buffer, int bufsize) override;
+    void Unserialize(int index, const char *serializedData, int dataSize) override;
+
+    virtual bool IsCaseSensitive() const = 0;
+    virtual bool IsSorted() const = 0;
+
+    virtual bool Add(const char *item) = 0;
+    virtual void Clear() = 0;
+    virtual bool Contains(const char *item) const = 0;
+    virtual bool Remove(const char *item) = 0;
+    virtual int GetItemCount() const = 0;
+    virtual void GetItems(std::vector<const char*> &buf) const = 0;
+
+private:
+    virtual size_t CalcSerializeSize() = 0;
+    virtual void SerializeContainer() = 0;
+    virtual void UnserializeContainer(const char *serializedData) = 0;
+};
+
+template <typename TSet, bool is_sorted, bool is_casesensitive>
+class ScriptSetImpl final : public ScriptSetBase
+{
+public:
+    typedef typename TSet::const_iterator ConstIterator;
+
+    ScriptSetImpl() = default;
+
+    bool IsCaseSensitive() const override { return is_casesensitive; }
+    bool IsSorted() const override { return is_sorted; }
+
+    bool Add(const char *item) override
+    {
+        if (!item) return false;
+        size_t len = strlen(item);
+        return TryAddItem(item, len);
+    }
+    void Clear() override
+    {
+        for (auto it = _set.begin(); it != _set.end(); ++it)
+            DeleteItem(it);
+        _set.clear();
+    }
+    bool Contains(const char *item) const override { return _set.count(String(item)) != 0; }
+    bool Remove(const char *item) override
+    {
+        auto it = _set.find(String(item));
+        if (it == _set.end()) return false;
+        DeleteItem(it);
+        _set.erase(it);
+        return true;
+    }
+    int GetItemCount() const override { return _set.size(); }
+    void GetItems(std::vector<const char*> &buf) const override
+    {
+        for (auto it = _set.begin(); it != _set.end(); ++it)
+            buf.push_back(it->GetCStr());
+    }
+
+private:
+    bool TryAddItem(const char *item, size_t len)
+    {
+        return _set.insert(String(item, len)).second;
+    }
+    void DeleteItem(ConstIterator it) { /* do nothing */ }
+
+    size_t CalcSerializeSize() override
+    {
+        size_t total_sz = sizeof(int32_t);
+        for (auto it = _set.begin(); it != _set.end(); ++it)
+            total_sz += sizeof(int32_t) + it->GetLength();
+        return total_sz;
+    }
+
+    void SerializeContainer() override
+    {
+        SerializeInt((int)_set.size());
+        for (auto it = _set.begin(); it != _set.end(); ++it)
+        {
+            SerializeInt((int)it->GetLength());
+            memcpy(&serbuffer[bytesSoFar], it->GetCStr(), it->GetLength());
+            bytesSoFar += it->GetLength();
+        }
+    }
+
+    void UnserializeContainer(const char *serializedData)
+    {
+        size_t item_count = (size_t)UnserializeInt();
+        for (size_t i = 0; i < item_count; ++i)
+        {
+            size_t len = UnserializeInt();
+            TryAddItem(&serializedData[bytesSoFar], len);
+            bytesSoFar += len;
+        }
+    }
+
+    TSet _set;
+};
+
+typedef ScriptSetImpl< std::set<String>, true, true > ScriptSet;
+typedef ScriptSetImpl< std::set<String, StrLessNoCase>, true, false > ScriptSetCI;
+typedef ScriptSetImpl< std::unordered_set<String>, false, true > ScriptHashSet;
+typedef ScriptSetImpl< std::unordered_set<String, HashStrNoCase, StrEqNoCase>, false, false > ScriptHashSetCI;
+
+#endif // __AC_SCRIPTSET_H

--- a/Engine/ac/dynobj/scriptstring.cpp
+++ b/Engine/ac/dynobj/scriptstring.cpp
@@ -17,8 +17,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-void* ScriptString::CreateString(const char *fromText) {
-    return (void*)CreateNewScriptString(fromText);
+DynObjectRef ScriptString::CreateString(const char *fromText) {
+    return CreateNewScriptStringObj(fromText);
 }
 
 int ScriptString::Dispose(const char *address, bool force) {

--- a/Engine/ac/dynobj/scriptstring.h
+++ b/Engine/ac/dynobj/scriptstring.h
@@ -25,7 +25,7 @@ struct ScriptString final : AGSCCDynamicObject, ICCStringClass {
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, const char *serializedData, int dataSize) override;
 
-    void* CreateString(const char *fromText) override;
+    DynObjectRef CreateString(const char *fromText) override;
 
     ScriptString();
     ScriptString(const char *fromText);

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -1,0 +1,163 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Containers script API.
+//
+//=============================================================================
+#include "ac/dynobj/cc_dynamicarray.h"
+#include "ac/dynobj/cc_dynamicobject.h"
+#include "ac/dynobj/scriptset.h"
+#include "ac/dynobj/scriptstring.h"
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+
+//=============================================================================
+//
+// Set of strings script API.
+//
+//=============================================================================
+
+ScriptSetBase *Set_Create(bool sorted, bool case_sensitive)
+{
+    ScriptSetBase *set;
+    if (sorted)
+    {
+        if (case_sensitive)
+            set = new ScriptSet();
+        else
+            set = new ScriptSetCI();
+    }
+    else
+    {
+        if (case_sensitive)
+            set = new ScriptHashSet();
+        else
+            set = new ScriptHashSetCI();
+    }
+    ccRegisterManagedObject(set, set);
+    return set;
+}
+
+bool Set_Add(ScriptSetBase *set, const char *item)
+{
+    return set->Add(item);
+}
+
+void Set_Clear(ScriptSetBase *set)
+{
+    set->Clear();
+}
+
+bool Set_Contains(ScriptSetBase *set, const char *item)
+{
+    return set->Contains(item);
+}
+
+bool Set_Remove(ScriptSetBase *set, const char *item)
+{
+    return set->Remove(item);
+}
+
+bool Set_GetCaseSensitive(ScriptSetBase *set)
+{
+    return set->IsCaseSensitive();
+}
+
+bool Set_GetSorted(ScriptSetBase *set)
+{
+    return set->IsSorted();
+}
+
+int Set_GetItemCount(ScriptSetBase *set)
+{
+    return set->GetItemCount();
+}
+
+void *Set_GetItemsAsArray(ScriptSetBase *set)
+{
+    std::vector<const char*> items;
+    set->GetItems(items);
+    // NOTE: we need element size of "handle" for array of managed pointers
+    DynObjectRef arr = globalDynamicArray.Create(items.size(), sizeof(int32_t), true);
+    if (!arr.second)
+        return nullptr;
+    // Create script strings and put handles into array
+    int32_t *slots = static_cast<int32_t*>(arr.second);
+    for (auto s : items)
+    {
+        DynObjectRef str = stringClassImpl->CreateString(s);
+        *(slots++) = str.first;
+    }
+    return arr.second;
+}
+
+RuntimeScriptValue Sc_Set_Create(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PBOOL2(ScriptSetBase, Set_Create);
+}
+
+RuntimeScriptValue Sc_Set_Add(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL_POBJ(ScriptSetBase, Set_Add, const char);
+}
+
+RuntimeScriptValue Sc_Set_Clear(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID(ScriptSetBase, Set_Clear);
+}
+
+RuntimeScriptValue Sc_Set_Contains(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL_POBJ(ScriptSetBase, Set_Contains, const char);
+}
+
+RuntimeScriptValue Sc_Set_Remove(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL_POBJ(ScriptSetBase, Set_Remove, const char);
+}
+
+RuntimeScriptValue Sc_Set_GetCaseSensitive(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptSetBase, Set_GetCaseSensitive);
+}
+
+RuntimeScriptValue Sc_Set_GetSorted(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptSetBase, Set_GetSorted);
+}
+
+RuntimeScriptValue Sc_Set_GetItemCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptSetBase, Set_GetItemCount);
+}
+
+RuntimeScriptValue Sc_Set_GetItemAsArray(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptSetBase, void, globalDynamicArray, Set_GetItemsAsArray);
+}
+
+
+
+void RegisterContainerAPI()
+{
+    ccAddExternalStaticFunction("Set::Create", Sc_Set_Create);
+    ccAddExternalObjectFunction("Set::Add", Sc_Set_Add);
+    ccAddExternalObjectFunction("Set::Clear", Sc_Set_Clear);
+    ccAddExternalObjectFunction("Set::Contains", Sc_Set_Contains);
+    ccAddExternalObjectFunction("Set::Remove", Sc_Set_Remove);
+    ccAddExternalObjectFunction("Set::get_CaseSensitive", Sc_Set_GetCaseSensitive);
+    ccAddExternalObjectFunction("Set::get_Sorted", Sc_Set_GetSorted);
+    ccAddExternalObjectFunction("Set::get_ItemCount", Sc_Set_GetItemCount);
+    ccAddExternalObjectFunction("Set::GetItemsAsArray", Sc_Set_GetItemAsArray);
+}

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -214,6 +214,11 @@ int StrContains (const char *s1, const char *s2) {
 //=============================================================================
 
 const char *CreateNewScriptString(const char *fromText, bool reAllocate) {
+    return (const char*)CreateNewScriptStringObj(fromText, reAllocate).second;
+}
+
+DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate)
+{
     ScriptString *str;
     if (reAllocate) {
         str = new ScriptString(fromText);
@@ -222,10 +227,14 @@ const char *CreateNewScriptString(const char *fromText, bool reAllocate) {
         str = new ScriptString();
         str->text = (char*)fromText;
     }
-
-    ccRegisterManagedObject(str->text, str);
-
-    return str->text;
+    void *obj_ptr = str->text;
+    int32_t handle = ccRegisterManagedObject(obj_ptr, str);
+    if (handle == 0)
+    {
+        delete str;
+        return DynObjectRef(0, nullptr);
+    }
+    return DynObjectRef(handle, obj_ptr);
 }
 
 void reverse_text(char *text) {

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -19,6 +19,7 @@
 #define __AGS_EE_AC__STRING_H
 
 #include <stdarg.h>
+#include "ac/dynobj/cc_dynamicobject.h"
 
 // Check that a supplied buffer from a text script function was not null
 #define VALIDATE_STRING(strin) if ((unsigned long)strin <= 4096) quit("!String argument was null: make sure you pass a string, not an int, as a buffer")
@@ -43,6 +44,7 @@ int StrContains (const char *s1, const char *s2);
 //=============================================================================
 
 const char* CreateNewScriptString(const char *fromText, bool reAllocate = true);
+DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate = true);
 void reverse_text(char *text);
 void break_up_text_into_lines(int wii,int fonnt, const char*todis);
 void check_strlen(char*ptt);

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1191,8 +1191,8 @@ int ccInstance::Run(int32_t curpc)
                   cc_error("invalid size for dynamic array; requested: %d, range: 1..1000000", numElements);
                   return -1;
               }
-              int32_t handle = globalDynamicArray.Create(numElements, arg2.IValue, arg3.GetAsBool());
-              reg1.SetDynamicObject((void*)ccGetObjectAddressFromHandle(handle), &globalDynamicArray);
+              DynObjectRef ref = globalDynamicArray.Create(numElements, arg2.IValue, arg3.GetAsBool());
+              reg1.SetDynamicObject(ref.second, &globalDynamicArray);
               break;
           }
       case SCMD_NEWUSEROBJECT:
@@ -1273,7 +1273,7 @@ int ccInstance::Run(int32_t curpc)
           }
           direct_ptr1 = (const char*)reg1.GetDirectPtr();
           reg1.SetDynamicObject(
-              (void*)stringClassImpl->CreateString(direct_ptr1),
+              stringClassImpl->CreateString(direct_ptr1).second,
               &myScriptStringImpl);
           break;
       case SCMD_STRINGSEQUAL:

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -22,6 +22,7 @@ extern void RegisterAudioChannelAPI();
 extern void RegisterAudioClipAPI();
 extern void RegisterButtonAPI();
 extern void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api);
+extern void RegisterContainerAPI();
 extern void RegisterDateTimeAPI();
 extern void RegisterDialogAPI();
 extern void RegisterDialogOptionsRenderingAPI();
@@ -61,6 +62,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterAudioClipAPI();
     RegisterButtonAPI();
     RegisterCharacterAPI(base_api, compat_api);
+    RegisterContainerAPI();
     RegisterDateTimeAPI();
     RegisterDialogAPI();
     RegisterDialogOptionsRenderingAPI();

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -325,6 +325,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue); \
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
 
+#define API_SCALL_OBJAUTO_PBOOL2(RET_CLASS, FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 2); \
+    RET_CLASS* ret_obj = FUNCTION(params[0].GetAsBool(), params[1].GetAsBool()); \
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
+
 #define API_SCALL_OBJAUTO_POBJ(RET_CLASS, FUNCTION, P1CLASS) \
     ASSERT_PARAM_COUNT(FUNCTION, 1); \
     RET_CLASS* ret_obj = FUNCTION((P1CLASS*)params[0].Ptr); \
@@ -478,6 +483,10 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 #define API_OBJCALL_BOOL_PINT(CLASS, METHOD) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
     return RuntimeScriptValue().SetInt32AsBool(METHOD((CLASS*)self, params[0].IValue))
+
+#define API_OBJCALL_BOOL_POBJ(CLASS, METHOD, P1CLASS) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
+    return RuntimeScriptValue().SetInt32AsBool(METHOD((CLASS*)self, (P1CLASS*)params[0].Ptr))
 
 #define API_OBJCALL_BOOL_POBJ_PINT(CLASS, METHOD, P1CLASS) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptuserobject.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptviewframe.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptviewport.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptset.cpp" />
     <ClCompile Include="..\..\Engine\ac\event.cpp" />
     <ClCompile Include="..\..\Engine\ac\file.cpp" />
     <ClCompile Include="..\..\Engine\ac\game.cpp" />
@@ -258,6 +259,7 @@
     <ClCompile Include="..\..\Engine\ac\overlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\parser.cpp" />
     <ClCompile Include="..\..\Engine\ac\properties.cpp" />
+    <ClCompile Include="..\..\Engine\ac\scriptcontainers.cpp" />
     <ClCompile Include="..\..\Engine\ac\sys_events.cpp" />
     <ClCompile Include="..\..\Engine\ac\region.cpp" />
     <ClCompile Include="..\..\Engine\ac\richgamemedia.cpp" />
@@ -518,6 +520,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptoverlay.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptregion.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptstring.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptsystem.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptuserobject.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptcamera.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdatetime.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdialogoptionsrendering.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptdict.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdrawingsurface.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptdynamicsprite.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptfile.cpp" />
@@ -510,6 +511,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdatetime.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdialog.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdialogoptionsrendering.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptdict.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdrawingsurface.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdynamicsprite.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptfile.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1002,6 +1002,12 @@
     <ClCompile Include="..\..\Engine\libsrc\glad\src\glad_wgl.c">
       <Filter>Library Sources\glad</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\scriptcontainers.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptset.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1861,6 +1867,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\media\audio\audio_system.h">
       <Filter>Header Files\media\audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h">
+      <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1008,6 +1008,9 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptset.cpp">
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptdict.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1869,6 +1872,9 @@
       <Filter>Header Files\media\audio</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptset.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptdict.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
AGS script currently does not support templates, generics, or any good ways to reuse algorithms or user classes with multiple types, which is probably a reason we don't have any containers rather than dynamic arrays there.

In this situation it may be still a good idea to give users at least most commonly used type of key/value container which works with strings, because even if suboptimal but it is possible to store almost anything in a string, even invent a reference to other objects.

Also, I've been thinking that it may be viable to replace some of the existing API with Set or Dictionary, extending their use and reducing duplicate functionality at the same time. For example, this could be Custom Properties and Game.DoOnceOnly (see discussion in #701).

The suggested API for Set and Dictionary is this:

<pre>
builtin managed struct Dictionary
{
  /// Creates a new empty Dictionary of the given properties.
  import static Dictionary* Create(bool sorted = false, bool caseSensitive = false);

  /// Removes all items from the dictionary.
  import void Clear();
  /// Tells if given key is in the dictionary.
  import bool Contains(String key);
  /// Gets the value by key; returns null if no such key is in dictionary.
  import String Get(String key);
  /// Removes key/value pair from the dictionary, fails if there was no such key.
  import bool Remove(String key);
  /// Assigns a value to the given key, adds this key if it did not exist yet.
  import void Set(String key, String value);

  /// Gets if this dictionary is case-sensitive.
  import readonly attribute bool CaseSensitive;
  /// Gets if this dictionary is sorted by keys in alphabetical order.
  import readonly attribute bool Sorted;
  /// Gets the number of key/value pairs currently in the dictionary.
  import readonly attribute int ItemCount;
  /// Creates a dynamic array filled with keys in same order as they are stored in the Dictionary.
  import String[] GetKeysAsArray();
  /// Creates a dynamic array filled with values in same order as they are stored in the Dictionary.
  import String[] GetValuesAsArray();
};

builtin managed struct Set
{
  /// Creates a new empty Set of the given properties.
  import static Set* Create(bool sorted = false, bool caseSensitive = false);

  /// Adds item to the set, fails if such item was already existing.
  import bool Add(String item);
  /// Removes all items from the set.
  import void Clear();
  /// Tells if given item is in the set.
  import bool Contains(String item);
  /// Removes item from the set, fails if there was no such item.
  import bool Remove(String item);

  /// Gets if this set is case-sensitive.
  import readonly attribute bool CaseSensitive;
  /// Gets if this set is sorted in alphabetical order.
  import readonly attribute bool Sorted;
  /// Gets the number of items currently in the set.
  import readonly attribute int ItemCount;
  /// Creates a dynamic array filled with items in same order as they are stored in the Set.
  import String[] GetItemsAsArray();
};
</pre>

### Notes:

1. Each of these interfaces may have 4 different implementations behind them: sorted, sorted with case-insensitive key comparison, unsorted and unsorted with case-insensitive comparison. This is to compensate lack of generic types and function pointers in AGS script. Of course it's not absolutely universal, but covers most common use cases in my opinion.
At the same time I am still not certain about necessity to have unsorted variant. In a normal programming language the choice of container is defined by perfomance priorities, but in case of AGS  the script's own overhead may be larger than overhead by imperfect container choice, so benefit may be unnoticable, except when having extra large number of elements.

~2. Set and Dictionary provide access to their item arrays, which may normally be useful for sorted variant. I guess for non-sorted implementation it may make sense only for diagnostic purposes.
In any case the random access goes against set/map purpose and using arbitrary indexes may be very slow. I tried to optimise implementation for the case of sequential access, meant for iterating items in a loop.~

2. Both have methods which return Strings from container in dynamic array (the order matches one of container, i.e. - sorted or random). This is not very optimal for keeping in sync with containers that change often, but a trivial and universal method for starters that will remain useful even after something more optimal for fast iteration is added.

3. There's a certain performance problem with lookup operations. std::set and map demand strictly Key type for lookup, and AGS interpreter only passes "const char*" to the script functions (which is a pain and issue on its own). Therefore I have to allocate a String object for each look up (also when removing or setting value).

I've read that C++14 standard supports using "equivalent" types for lookup and insertion ([see docs](https://en.cppreference.com/w/cpp/container/set/find) and [wikipedia paragraph](https://en.wikipedia.org/wiki/C%2B%2B14#Heterogeneous_lookup_in_associative_containers)), which sounds like what I could use, but we don't officially support that in AGS at the moment (and I've never used that before so still no idea how well that would fit).

I did few quick attempts on a wrapper, but it ends up either by storing an ugly type inside containers, or very unsafe subtype of String, so decided to drop this idea until better times.