### PR TITLE
AGS3 Further cmake work

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -9,18 +9,30 @@ The latest version of CMake is recommended and available as source and pre-built
 
 https://cmake.org/download/
 
+Kitware now provide Ubuntu packges:
+
+https://blog.kitware.com/ubuntu-cmake-repository-now-available/
+
 
 ## Example Building on macOS
 
 CMake can create Xcode projects, which allow multi-configs (like Debug, Release, RelWithDebInfo)
 
+Configuring:
+
  - Install XCode and ensure command line tools are installed.
  - Install CMake 3.14 (via homebrew or from the above site)
- - make -C OSX/buildlibs install 
  - mkdir build
  - cd build
  - cmake -GXcode ..
- - cmake --build . --config Debug
+
+Building:
+
+There are multiple options from command line or IDE:
+
+   - cmake --build . --config Debug --parallel
+   - cmake --build . --config Release --parallel
+   - use XCode to open AGS.xcodeproj
 
 
 ## Example Building on Linux
@@ -30,7 +42,7 @@ CMake can create Makefile and Ninja projects. These are single config systems so
  - Install recommended dev packages
  - Install CMake 3.14 (via above site)
  - mkdir build-debug
- - cmake .. -DCMAKE_BUILD_TYPE=Debug ..
+ - cmake .. -DCMAKE_BUILD_TYPE=Debug
  - cmake --build . --parallel
 
 
@@ -38,10 +50,32 @@ CMake can create Makefile and Ninja projects. These are single config systems so
 
 CMake can create Visual Studio projects. Different versions of Visual Studio are supported. It also supports multi-config.
 
+Configuring:
+
  - Install Visual Studio (2015, 2017, 2019 should work)
- - Install DirectX SDK (August 2017)
+ - Install DirectX SDK (August 2007)
  - Install CMake (via above site)
- - Build ogg, vorbis, theora, allegro using /MD. Use directory names of libogg, libvorbis, libtheora
- - Copy include files and libs in Windows/Include and Solutions/.lib (allegro and ogg may have an extra include file in the build dir)
- - cmake -G "Visual Studio 16 2019" -A Win32 ..
- - cmake --build . --parallel --config Debug
+ - cmake -A Win32 ..
+
+Building:
+
+There are multiple options from command line or IDE:
+
+ - cmake --build . --config Debug
+ - cmake --build . --config Release
+ - use Visual Studio to open AGS.sln
+
+
+## Configuration
+
+Cmake can be configured with `ccmake` or `cmake-gui` commands or provide options on the command line:
+
+    cmake -DCMAKE_BUILD_TYPE=Debug
+
+The relevant options include
+
+ AGS_BUILD_STR - optionally append information to version string
+ AGS_BUILTIN_PLUGINS - build and include plugins. Works on linux and macos.
+ AGS_NO_MP3_PLAYER - disable mp3 playing for license reasons.
+ CMAKE_BUILD_TYPE - Debug, Release, RelWithDebInfo and MinSizeRel
+

--- a/CMake/FetchAllegro.cmake
+++ b/CMake/FetchAllegro.cmake
@@ -1,0 +1,13 @@
+FetchContent_Declare(
+  allegro_content
+  GIT_REPOSITORY https://github.com/adventuregamestudio/lib-allegro.git
+  GIT_TAG        allegro-4.4.3.1-agspatch
+  GIT_SHALLOW    yes
+)
+
+FetchContent_GetProperties(allegro_content)
+if(NOT allegro_content_POPULATED)
+  FetchContent_Populate(allegro_content)
+  file(COPY Common/libsrc/allegro4/CMakeLists.txt DESTINATION ${allegro_content_SOURCE_DIR})
+  add_subdirectory(${allegro_content_SOURCE_DIR} ${allegro_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/CMake/FetchOgg.cmake
+++ b/CMake/FetchOgg.cmake
@@ -1,0 +1,13 @@
+FetchContent_Declare(
+  ogg_content
+  GIT_REPOSITORY https://github.com/xiph/ogg.git
+  GIT_TAG        f7dadaaf75634289f7ead64ed1802b627d761ee3
+  GIT_SHALLOW    yes
+)
+
+FetchContent_GetProperties(ogg_content)
+if(NOT ogg_content_POPULATED)
+  FetchContent_Populate(ogg_content)
+  file(COPY Engine/libsrc/ogg/CMakeLists.txt DESTINATION ${ogg_content_SOURCE_DIR})
+  add_subdirectory(${ogg_content_SOURCE_DIR} ${ogg_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/CMake/FetchTheora.cmake
+++ b/CMake/FetchTheora.cmake
@@ -1,0 +1,13 @@
+FetchContent_Declare(
+  theora_content
+  GIT_REPOSITORY https://github.com/xiph/theora.git
+  GIT_TAG        e5d205bfe849f1b41f45b91a0b71a3bdc6cd458f
+  GIT_SHALLOW    yes
+)
+
+FetchContent_GetProperties(theora_content)
+if(NOT theora_content_POPULATED)
+  FetchContent_Populate(theora_content)
+  file(COPY Engine/libsrc/theora/CMakeLists.txt DESTINATION ${theora_content_SOURCE_DIR})
+  add_subdirectory(${theora_content_SOURCE_DIR} ${theora_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/CMake/FetchVorbis.cmake
+++ b/CMake/FetchVorbis.cmake
@@ -1,0 +1,13 @@
+FetchContent_Declare(
+  vorbis_content
+  GIT_REPOSITORY https://github.com/xiph/vorbis.git
+  GIT_TAG        9eadeccdc4247127d91ac70555074239f5ce3529
+  GIT_SHALLOW    yes
+)
+
+FetchContent_GetProperties(vorbis_content)
+if(NOT vorbis_content_POPULATED)
+  FetchContent_Populate(vorbis_content)
+  file(COPY Engine/libsrc/vorbis/CMakeLists.txt DESTINATION ${vorbis_content_SOURCE_DIR})
+  add_subdirectory(${vorbis_content_SOURCE_DIR} ${vorbis_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/CMake/c_flag_overrides.cmake
+++ b/CMake/c_flag_overrides.cmake
@@ -1,0 +1,8 @@
+# For reference https://gitlab.kitware.com/cmake/community/wikis/FAQ#make-override-files
+# Original values are available in cmake repo: Modules/Platform/Windows-MSVC.cmake
+if(MSVC)
+    set(CMAKE_C_FLAGS_DEBUG_INIT          "/MTd /Zi /Ob0 /Od /RTC1")
+    set(CMAKE_C_FLAGS_RELEASE_INIT        "/MT /O2 /Ob2 /DNDEBUG")
+    set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "/MT /Zi /O2 /Ob1 /DNDEBUG")
+    set(CMAKE_C_FLAGS_MINSIZEREL_INIT     "/MT /O1 /Ob1 /DNDEBUG")
+endif()

--- a/CMake/cxx_flag_overrides.cmake
+++ b/CMake/cxx_flag_overrides.cmake
@@ -1,0 +1,8 @@
+# For reference https://gitlab.kitware.com/cmake/community/wikis/FAQ#make-override-files
+# Original values are available in cmake repo: Modules/Platform/Windows-MSVC.cmake
+if(MSVC)
+    set(CMAKE_CXX_FLAGS_DEBUG_INIT          "/MTd /Zi /Ob0 /Od /RTC1")
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT        "/MT /O2 /Ob2 /DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/MT /Zi /O2 /Ob1 /DNDEBUG")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT     "/MT /O1 /Ob1 /DNDEBUG")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,15 @@ set(AGS_BUILD_STR "" CACHE STRING "Engine Build Information")
 include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED on)
 
-# todo use platform id (from generators)
-if(UNIX AND NOT APPLE)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    # WIN32 is set by CMake for any Windows platform
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX TRUE)
-endif()
-
-if(UNIX AND APPLE)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOS TRUE)
-endif()
+else()
+    message(FATAL_ERROR "Unsupported system: ${CMAKE_SYSTEM_NAME}")
+endif ()
 
 if (WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
 	message(FATAL_ERROR "Windows builds only support 32bit for now")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.13..3.14)
 
+set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/CMake/c_flag_overrides.cmake)
+set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX ${CMAKE_CURRENT_SOURCE_DIR}/CMake/cxx_flag_overrides.cmake)
+
 project(AGS
     VERSION 3.5.0.8
     LANGUAGES CXX C)
@@ -22,7 +25,7 @@ if(UNIX AND APPLE)
     set(MACOS TRUE)
 endif()
 
-if (MSVC AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+if (WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
 	message(FATAL_ERROR "Windows builds only support 32bit for now")
 endif()
 
@@ -31,7 +34,11 @@ add_compile_definitions("_FILE_OFFSET_BITS=64")
 add_compile_definitions("$<$<CONFIG:DEBUG>:_DEBUG>")
 add_compile_definitions("$<$<CONFIG:RELEASE>:NDEBUG>")
 
-if(NOT MSVC)
+if(MSVC)
+    add_compile_options(/MP)    # Build with Multiple Processes
+    add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
+    add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
+else()
     add_compile_options(
         -fsigned-char 
         -fno-strict-aliasing 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,14 @@ project(AGS
     VERSION 3.5.0.8
     LANGUAGES CXX C)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/CMake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" OFF)
 set(AGS_BUILD_STR "" CACHE STRING "Engine Build Information")
+
+include(FetchContent)
+set(FETCHCONTENT_UPDATES_DISCONNECTED on)
 
 # todo use platform id (from generators)
 if(UNIX AND NOT APPLE)
@@ -39,6 +42,8 @@ if(NOT MSVC)
 
         -Wendif-labels
         -Wfloat-equal
+        -Wformat
+        -Wformat-security
         -Winit-self
         -Winline
         -Wmissing-noreturn
@@ -61,8 +66,6 @@ if(NOT MSVC)
         -Wno-redundant-decls
 
         -Werror=write-strings
-        -Werror=format
-        -Werror=format-security
         #-Werror=implicit-function-declaration
         #-Werror=unused-result
     )
@@ -87,10 +90,10 @@ elseif (LINUX)
     find_package(X11)
 endif()
 
-find_package(Allegro)
-find_package(Ogg)
-find_package(Vorbis)
-find_package(Theora)
+include(FetchAllegro)
+include(FetchOgg)
+include(FetchVorbis)
+include(FetchTheora)
 
 add_subdirectory(Common/libsrc/aastr-0.1.1      EXCLUDE_FROM_ALL)
 add_subdirectory(Common                         EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ if (WIN32 AND NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
 	message(FATAL_ERROR "Windows builds only support 32bit for now")
 endif()
 
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported OUTPUT ipo_not_supported_reason)
+if(ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+    message(STATUS "Interprocedural optimisation (IPO/LTO) not supported: <${ipo_not_supported_reason}>")
+endif()
+
+
 add_compile_definitions("_FILE_OFFSET_BITS=64")
 
 add_compile_definitions("$<$<CONFIG:DEBUG>:_DEBUG>")

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -179,6 +179,10 @@ else()
     target_compile_definitions(common PUBLIC AGS_LITTLE_ENDIAN)
 endif()
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    target_compile_definitions(common PUBLIC AGS_64BIT)
+endif()
+
 # NOTE: You can optionally create case sensitive filesystems on Macos and Windows now.
 if (LINUX)
     target_compile_definitions(common PRIVATE AGS_CASE_SENSITIVE_FILESYSTEM)

--- a/Common/libsrc/allegro4/CMakeLists.txt
+++ b/Common/libsrc/allegro4/CMakeLists.txt
@@ -1,0 +1,782 @@
+#-----------------------------------------------------------------------------#
+#
+# CMake setup
+#
+
+cmake_minimum_required(VERSION 3.13..3.14)
+
+#-----------------------------------------------------------------------------#
+#
+# Build options
+#
+
+# Set the project name.
+project(allegro
+    LANGUAGES C CXX
+    VERSION 4.4.3
+)
+
+if(WIN32)
+    enable_language(RC OPTIONAL)
+endif(WIN32)
+
+# Search in the `cmake' directory for additional CMake modules.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+
+#-----------------------------------------------------------------------------#
+#
+# Build options
+#
+
+option(MAGIC_MAIN "Enable magic main (Unix)" off)
+
+
+#-----------------------------------------------------------------------------#
+#
+# Unix platform checks
+#
+
+include(CheckIncludeFiles)
+include(CheckFunctionExists)
+include(CheckCSourceCompiles)
+include(CheckCSourceRuns)
+include(FindPkgConfig)
+include(TestBigEndian)
+
+if(UNIX)
+    test_big_endian(ALLEGRO_BIG_ENDIAN)
+    if(NOT ALLEGRO_BIG_ENDIAN)
+        set(ALLEGRO_LITTLE_ENDIAN 1)
+    endif(NOT ALLEGRO_BIG_ENDIAN)
+
+    check_include_files(dirent.h ALLEGRO_HAVE_DIRENT_H)
+    check_include_files(inttypes.h ALLEGRO_HAVE_INTTYPES_H)
+
+    check_include_files(linux/awe_voice.h ALLEGRO_HAVE_LINUX_AWE_VOICE_H)
+    check_include_files(linux/input.h ALLEGRO_HAVE_LINUX_INPUT_H)
+    # On some systems including linux/joystick.h without sys/types.h results
+    # in conflicting definitions of fd_set.
+    check_include_files("sys/types.h;linux/joystick.h" ALLEGRO_HAVE_LINUX_JOYSTICK_H)
+    check_include_files(linux/soundcard.h ALLEGRO_HAVE_LINUX_SOUNDCARD_H)
+    check_include_files(machine/soundcard.h ALLEGRO_HAVE_MACHINE_SOUNDCARD_H)
+    check_include_files(soundcard.h ALLEGRO_HAVE_SOUNDCARD_H)
+    check_include_files(stdint.h ALLEGRO_HAVE_STDINT_H)
+    check_include_files(sys/io.h ALLEGRO_HAVE_SYS_IO_H)
+    check_include_files(sys/stat.h ALLEGRO_HAVE_SYS_STAT_H)
+    check_include_files(sys/time.h ALLEGRO_HAVE_SYS_TIME_H)
+    check_include_files(sys/soundcard.h ALLEGRO_HAVE_SYS_SOUNDCARD_H)
+    check_include_files(sys/utsname.h ALLEGRO_HAVE_SYS_UTSNAME_H)
+
+    check_function_exists(getexecname ALLEGRO_HAVE_GETEXECNAME)
+    check_function_exists(memcmp ALLEGRO_HAVE_MEMCMP)
+    check_function_exists(mkstemp ALLEGRO_HAVE_MKSTEMP)
+    check_function_exists(mmap ALLEGRO_HAVE_MMAP)
+    check_function_exists(mprotect ALLEGRO_HAVE_MPROTECT)
+    check_function_exists(sched_yield ALLEGRO_HAVE_SCHED_YIELD)
+    check_function_exists(stricmp ALLEGRO_HAVE_STRICMP)
+    check_function_exists(strlwr ALLEGRO_HAVE_STRLWR)
+    check_function_exists(strupr ALLEGRO_HAVE_STRUPR)
+    check_function_exists(sysconf ALLEGRO_HAVE_SYSCONF)
+
+    check_c_source_compiles("
+        #include <sys/procfs.h>
+        #include <sys/ioctl.h>
+        int main(void) {
+            struct prpsinfo psinfo;
+            ioctl(0, PIOCPSINFO, &psinfo);
+            return 0;
+        }"
+        ALLEGRO_HAVE_SV_PROCFS_H
+        )
+    check_c_source_compiles("
+        #include <sys/procfs.h>
+        int main(void) {
+            struct prpsinfo psinfo;
+            psinfo.pr_argc = 0;
+            return 0;
+        }"
+        ALLEGRO_HAVE_PROCFS_ARGCV
+        )
+
+    check_c_source_compiles("
+        #include <unistd.h>
+        #include <sys/mman.h>
+        int main(void) {
+            void *x = MAP_FAILED;
+        }"
+        MAP_FAILED_DEFINED)
+    if(NOT MAP_FAILED_DEFINED)
+        set(MAP_FAILED "((void *) -1)")
+    endif()
+
+    check_c_source_runs("
+        static int notsupported = 1;
+        void test_ctor (void) __attribute__((constructor));
+        void test_ctor (void) { notsupported = 0; }
+        int main(void) { return (notsupported); }
+        "
+        ALLEGRO_USE_CONSTRUCTOR)
+
+    find_library(RT_LIBRARY rt)
+    mark_as_advanced(RT_LIBRARY)
+    check_c_source_compiles("
+        #include <time.h>
+        int main(void) {
+            struct timespec new_time_ns;
+            clock_gettime(CLOCK_MONOTONIC, &new_time_ns);
+            return 0;
+        }"
+        ALLEGRO_HAVE_POSIX_MONOTONIC_CLOCK
+        )
+
+    if(MAGIC_MAIN)
+        set(ALLEGRO_WITH_MAGIC_MAIN 1)
+    endif(MAGIC_MAIN)
+
+    # XXX const
+    # XXX inline
+    # XXX size_t
+endif(UNIX)
+
+
+#-----------------------------------------------------------------------------#
+#
+# Main library
+#
+
+add_library(allegro)
+
+target_compile_definitions(allegro PRIVATE ALLEGRO_SRC)
+
+target_compile_definitions (allegro
+    INTERFACE 
+        ALLEGRO_STATICLINK
+        ALLEGRO_NO_COMPATIBILITY 
+        ALLEGRO_NO_FIX_ALIASES 
+        ALLEGRO_NO_FIX_CLASS
+)
+
+# ALLEGRO_SRC_FILES
+target_sources(allegro PRIVATE
+    src/allegro.c
+    src/blit.c
+    src/bmp.c
+    src/clip3d.c
+    src/clip3df.c
+    src/colblend.c
+    src/color.c
+    src/config.c
+    src/datafile.c
+    src/dataregi.c
+    src/digmid.c
+    src/dither.c
+    src/dispsw.c
+    src/drvlist.c
+    src/file.c
+    src/fli.c
+    src/flood.c
+    src/font.c
+    src/fontbios.c
+    src/fontbmp.c
+    src/fontdat.c
+    src/fontgrx.c
+    src/fonttxt.c
+    src/fsel.c
+    src/gfx.c
+    src/glyph.c
+    src/graphics.c
+    src/gsprite.c
+    src/gui.c
+    src/guiproc.c
+    src/inline.c
+    src/joystick.c
+    src/keyboard.c
+    src/lbm.c
+    src/libc.c
+    src/lzss.c
+    src/math.c
+    src/math3d.c
+    src/midi.c
+    src/mixer.c
+    src/modesel.c
+    src/mouse.c
+    src/pcx.c
+    src/poly3d.c
+    src/polygon.c
+    src/quantize.c
+    src/quat.c
+    src/readbmp.c
+    src/readfont.c
+    src/readsmp.c
+    src/rle.c
+    src/rotate.c
+    src/rsfb.c
+    src/scene3d.c
+    src/sound.c
+    src/spline.c
+    src/stream.c
+    src/text.c
+    src/tga.c
+    src/timer.c
+    src/unicode.c
+    src/vtable.c
+    src/vtable15.c
+    src/vtable16.c
+    src/vtable24.c
+    src/vtable32.c
+    src/vtable8.c
+)
+
+# ALLEGRO_SRC_C_FILES
+target_sources(allegro PRIVATE
+    src/c/cblit16.c
+    src/c/cblit24.c
+    src/c/cblit32.c
+    src/c/cblit8.c
+    src/c/ccpu.c
+    src/c/ccsprite.c
+    src/c/cgfx15.c
+    src/c/cgfx16.c
+    src/c/cgfx24.c
+    src/c/cgfx32.c
+    src/c/cgfx8.c
+    src/c/cmisc.c
+    src/c/cscan15.c
+    src/c/cscan16.c
+    src/c/cscan24.c
+    src/c/cscan32.c
+    src/c/cscan8.c
+    src/c/cspr15.c
+    src/c/cspr16.c
+    src/c/cspr24.c
+    src/c/cspr32.c
+    src/c/cspr8.c
+    src/c/cstretch.c
+    src/c/czscan15.c
+    src/c/czscan16.c
+    src/c/czscan24.c
+    src/c/czscan32.c
+    src/c/czscan8.c
+    src/misc/ccolconv.c
+    src/misc/colconv.c
+)
+
+# set(ALLEGRO_INCLUDE_ALLEGRO_FILES
+target_sources(allegro PRIVATE
+    include/allegro/3d.h
+    include/allegro/3dmaths.h
+    include/allegro/alcompat.h
+    include/allegro/alinline.h
+    include/allegro/base.h
+    include/allegro/color.h
+    include/allegro/compiled.h
+    include/allegro/config.h
+    include/allegro/datafile.h
+    include/allegro/debug.h
+    include/allegro/digi.h
+    include/allegro/draw.h
+    include/allegro/file.h
+    include/allegro/fix.h
+    include/allegro/fixed.h
+    include/allegro/fli.h
+    include/allegro/fmaths.h
+    include/allegro/font.h
+    include/allegro/gfx.h
+    include/allegro/graphics.h
+    include/allegro/gui.h
+    include/allegro/joystick.h
+    include/allegro/keyboard.h
+    include/allegro/lzss.h
+    include/allegro/matrix.h
+    include/allegro/midi.h
+    include/allegro/mouse.h
+    include/allegro/palette.h
+    include/allegro/quat.h
+    include/allegro/rle.h
+    include/allegro/sound.h
+    include/allegro/stream.h
+    include/allegro/system.h
+    include/allegro/text.h
+    include/allegro/timer.h
+    include/allegro/unicode.h
+)
+
+# set(ALLEGRO_INCLUDE_ALLEGRO_INLINE_FILES
+target_sources(allegro PRIVATE
+    include/allegro/inline/3dmaths.inl
+    include/allegro/inline/asm.inl
+    include/allegro/inline/color.inl
+    include/allegro/inline/draw.inl
+    include/allegro/inline/fix.inl
+    include/allegro/inline/fmaths.inl
+    include/allegro/inline/gfx.inl
+    include/allegro/inline/matrix.inl
+    include/allegro/inline/rle.inl
+    include/allegro/inline/system.inl
+)
+
+# set(ALLEGRO_INCLUDE_ALLEGRO_INTERNAL_FILES
+target_sources(allegro PRIVATE
+    include/allegro/internal/aintern.h
+    include/allegro/internal/aintvga.h
+    include/allegro/internal/alconfig.h
+)
+
+# set(ALLEGRO_INCLUDE_ALLEGRO_PLATFORM_FILES
+target_sources(allegro PRIVATE
+    include/allegro/platform/aintbeos.h
+    include/allegro/platform/aintdos.h
+    include/allegro/platform/aintlnx.h
+    include/allegro/platform/aintmac.h
+    include/allegro/platform/aintosx.h
+    include/allegro/platform/aintpsp.h
+    include/allegro/platform/aintios.h
+    include/allegro/platform/aintand.h
+    include/allegro/platform/aintqnx.h
+    include/allegro/platform/aintunix.h
+    include/allegro/platform/aintwin.h
+    include/allegro/platform/al386gcc.h
+    include/allegro/platform/al386vc.h
+    include/allegro/platform/al386wat.h
+    include/allegro/platform/albcc32.h
+    include/allegro/platform/albecfg.h
+    include/allegro/platform/albeos.h
+    include/allegro/platform/aldjgpp.h
+    include/allegro/platform/aldmc.h
+    include/allegro/platform/aldos.h
+    include/allegro/platform/almac.h
+    include/allegro/platform/almaccfg.h
+    include/allegro/platform/almngw32.h
+    include/allegro/platform/almsvc.h
+    include/allegro/platform/alosx.h
+    include/allegro/platform/alosxcfg.h
+    # include/allegro/platform/alplatf.h.cmake
+    include/allegro/platform/alpsp.h
+    include/allegro/platform/alpspcfg.h
+    include/allegro/platform/alios.h
+    include/allegro/platform/alioscfg.h
+    include/allegro/platform/aland.h
+    include/allegro/platform/alandcfg.h
+    include/allegro/platform/alqnx.h
+    include/allegro/platform/alqnxcfg.h
+    include/allegro/platform/alucfg.h
+    include/allegro/platform/alunix.h
+    # include/allegro/platform/alunixac.h.cmake
+    # include/allegro/platform/alunixac.hin
+    include/allegro/platform/alwatcom.h
+    include/allegro/platform/alwin.h
+    include/allegro/platform/astdint.h
+    include/allegro/platform/macdef.h
+)
+
+
+#-----------------------------------------------------------------------------#
+#
+# Compiler and platform setup
+#
+
+if(CMAKE_COMPILER_IS_GNUCC)
+    set(COMPILER_GCC 1)
+    set(ALLEGRO_GCC 1)
+endif(CMAKE_COMPILER_IS_GNUCC)
+
+if(MSVC)
+    set(COMPILER_MSVC 1)
+    set(ALLEGRO_MSVC 1)
+endif(MSVC)
+
+if(WIN32)
+    set(ALLEGRO_WINDOWS 1)
+endif()
+
+if(APPLE)
+    set(ALLEGRO_MACOSX 1)
+    set(ALLEGRO_DARWIN 1)
+endif(APPLE)
+
+if(UNIX AND NOT APPLE)
+    set(ALLEGRO_UNIX 1)
+endif()
+
+if(IOS)
+    set(ALLEGRO_IOS 1)
+
+    set(ALLEGRO_IOS_ARCH arm64 CACHE STRING "iOS Architecture")
+    set_property(CACHE ALLEGRO_IOS_ARCH PROPERTY STRINGS arm64 armv7 armv7s i386 x86_64)
+
+    set(ALLEGRO_IOS_SDK iphoneos CACHE STRING "iOS SDK")
+    set_property(CACHE ALLEGRO_IOS_SDK PROPERTY STRINGS iphoneos iphonesimulator)
+
+    execute_process(COMMAND xcrun --sdk ${ALLEGRO_IOS_SDK} --show-sdk-path
+        OUTPUT_VARIABLE SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(IOS_ADDITIONAL_LIBRARY_PATH "$(pwd)/../../../nativelibs/${ALLEGRO_IOS_ARCH}")
+    set(IOS_PLATFORM_INCLUDE "${SDK_PATH}/usr/include")
+    set(IOS_PLATFORM_LIB "${SDK_PATH}/usr/lib")
+
+    target_compile_options(allegro PRIVATE -arch ${ALLEGRO_IOS_ARCH})
+endif(IOS)
+
+if(ANDROID)
+    set(ALLEGRO_ANDROID 1)
+endif(ANDROID)
+
+target_compile_definitions(allegro PUBLIC ALLEGRO_STATICLINK)
+target_compile_definitions(allegro PUBLIC $<$<CONFIG:DEBUG>:DEBUGMODE=1>)
+
+
+#-----------------------------------------------------------------------------#
+
+# Not sure if we want to support disabling these any more.
+set(ALLEGRO_COLOR8 1)
+set(ALLEGRO_COLOR16 1)
+set(ALLEGRO_COLOR24 1)
+set(ALLEGRO_COLOR32 1)
+
+set(ALLEGRO_NO_ASM 1)
+# ALLEGRO_MMX left undefined
+# ALLEGRO_SSE left undefined
+
+
+#-----------------------------------------------------------------------------#
+#
+# Platform drivers
+#
+
+# -- Unix --
+
+option(WANT_OSS "Build OSS support" off)
+option(WANT_ALSA "Build ALSA support" on)
+option(WANT_JACK "Build JACK support" on)
+
+if(ALLEGRO_UNIX) # not MACOSX
+    target_sources(allegro PRIVATE
+        src/unix/alsa9.c
+        src/unix/alsamidi.c
+        src/unix/sdl2digi.c
+        src/unix/arts.c
+        src/unix/sgial.c
+        src/unix/jack.c
+        src/unix/udjgpp.c
+        src/unix/udrvlist.c
+        src/unix/udummy.c
+        src/unix/uesd.c
+        src/unix/ufile.c
+        src/unix/ugfxdrv.c
+        src/unix/ujoydrv.c
+        src/unix/ukeybd.c
+        src/unix/umain.c
+        src/unix/umodules.c
+        src/unix/umouse.c
+        src/unix/uoss.c
+        src/unix/uossmidi.c
+        src/unix/uptimer.c
+        src/unix/usigalrm.c
+        src/unix/usnddrv.c
+        src/unix/ustimer.c
+        src/unix/usystem.c
+        src/unix/uthreads.c
+        src/unix/utimer.c
+        # src/misc/modexsms.c
+
+        # May be used without enabling the entire Linux console port.
+        src/linux/ljoy.c
+    )
+
+    find_package(Threads)
+    if(NOT CMAKE_USE_PTHREADS_INIT)
+        message(FATAL_ERROR "Unix port requires pthreads support.")
+    endif()
+    set(ALLEGRO_HAVE_LIBPTHREAD 1)
+    target_link_libraries(allegro PUBLIC m ${CMAKE_THREAD_LIBS_INIT})
+
+    target_link_libraries(allegro PUBLIC ${CMAKE_DL_LIBS})
+
+    if(ALLEGRO_HAVE_POSIX_MONOTONIC_CLOCK)
+        target_link_libraries(allegro PUBLIC ${RT_LIBRARY})
+    endif(ALLEGRO_HAVE_POSIX_MONOTONIC_CLOCK)
+
+    if(WANT_OSS)
+        include(AllegroFindOSS)
+        if(OSS_FOUND)
+            set(ALLEGRO_WITH_OSSDIGI 1)
+            set(ALLEGRO_WITH_OSSMIDI 1)
+            target_include_directories(allegro PRIVATE ${OSS_INCLUDE_DIR})
+        endif(OSS_FOUND)
+    endif(WANT_OSS)
+
+    if(WANT_ALSA)
+        pkg_check_modules(ALSA alsa)
+        if(ALSA_FOUND)
+            # ALSA 0.5 is beyond obsolete.
+            set(ALLEGRO_ALSA_VERSION 9)
+            set(ALLEGRO_WITH_ALSADIGI 1)
+            set(ALLEGRO_WITH_ALSAMIDI 1)
+            target_include_directories(allegro PRIVATE ${ALSA_INCLUDE_DIRS})
+            target_link_libraries(allegro PUBLIC ${ALSA_LIBRARIES})
+        endif(ALSA_FOUND)
+    endif(WANT_ALSA)
+
+    pkg_check_modules(SDL2 sdl2)
+    if(SDL2_FOUND)
+        set(ALLEGRO_WITH_SDL2DIGI 1)
+        target_include_directories(allegro PRIVATE ${SDL2_INCLUDE_DIRS})
+        target_link_directories(allegro PUBLIC ${SDL2_LIBRARY_DIRS})
+        target_link_libraries(allegro PUBLIC ${SDL2_LIBRARIES})
+    endif(SDL2_FOUND)
+
+    if(WANT_JACK)
+        pkg_check_modules(JACK jack)
+        if(JACK_FOUND)
+            set(ALLEGRO_WITH_JACKDIGI 1)
+            target_include_directories(allegro PRIVATE ${JACK_INCLUDE_DIRS})
+            target_link_libraries(allegro PUBLIC ${JACK_LIBRARIES})
+        endif(JACK_FOUND)
+    endif(WANT_JACK)
+
+endif(ALLEGRO_UNIX)
+
+# -- X11 --
+
+option(WANT_X11 "Want X11 support (Unix)" on)
+
+if(ALLEGRO_UNIX AND WANT_X11)
+    find_package(X11)
+    if(X11_FOUND)
+        set(ALLEGRO_WITH_XWINDOWS 1)
+    endif()
+endif()
+
+if(ALLEGRO_WITH_XWINDOWS)
+    target_include_directories(allegro PRIVATE ${X11_INCLUDE_DIR})
+
+    target_sources(allegro PRIVATE
+        src/x/xgfxdrv.c
+        src/x/xkeyboard.c
+        src/x/xmouse.c
+        src/x/xsystem.c
+        src/x/xtimer.c
+        src/x/xvtable.c
+        src/x/xwin.c
+        src/x/xdga2.c
+        src/x/xdga2s.s
+        src/x/xwins.s
+    )
+
+    target_link_libraries(allegro PUBLIC ${X11_LIBRARIES})
+
+    if(X11_XShm_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_SHM 1)
+        target_link_libraries(allegro PUBLIC ${X11_Xext_LIB})
+    endif()
+
+    if(X11_Xcursor_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XCURSOR 1)
+        target_link_libraries(allegro PUBLIC ${X11_Xcursor_LIB})
+    endif()
+
+    if(X11_Xcursor_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XCURSOR 1)
+        target_link_libraries(allegro PUBLIC ${X11_Xcursor_LIB})
+    endif()
+
+    if(X11_Xpm_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XPM 1)
+        target_link_libraries(allegro PUBLIC ${X11_Xpm_LIB})
+    endif()
+
+    find_library(X11_Xxf86vm_LIB Xxf86vm ${X11_LIB_SEARCH_PATH})
+    mark_as_advanced(X11_Xxf86vm_LIB)
+    if(X11_xf86vmode_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XF86VIDMODE 1)
+        target_link_libraries(allegro PUBLIC ${X11_Xxf86vm_LIB})
+    endif()
+
+    check_library_exists(X11 XOpenIM "${X11_LIB_SEARCH_PATH}" XIM_FOUND)
+    if(XIM_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XIM 1)
+    endif(XIM_FOUND)
+
+    check_library_exists(Xxf86dga XDGAQueryExtension
+        "${X11_LIB_SEARCH_PATH}" XDGA_FOUND)
+    if(XDGA_FOUND)
+        set(ALLEGRO_XWINDOWS_WITH_XF86DGA2 1)
+        target_link_libraries(allegro PUBLIC Xxf86dga ${X11_LIBRARIES})
+    endif()
+endif(ALLEGRO_WITH_XWINDOWS)
+
+# -- Windows --
+
+if(WIN32)
+    target_sources(allegro PRIVATE
+        src/win/asmlock.s
+        src/win/dllver.rc
+        src/win/gdi.c
+        src/win/wddaccel.c
+        src/win/wddbmp.c
+        src/win/wddbmpl.c
+        src/win/wddraw.c
+        src/win/wddfull.c
+        src/win/wddlock.c
+        src/win/wddmode.c
+        src/win/wddovl.c
+        src/win/wddwin.c
+        src/win/wdsinput.c
+        src/win/wdsndmix.c
+        src/win/wdsound.c
+        src/win/wsndwo.c
+        src/win/wdxver.c
+        src/win/wdispsw.c
+        src/win/wfile.c
+        src/win/wgdi.c
+        src/win/wgfxdrv.c
+        src/win/winput.c
+        src/win/wjoydrv.c
+        src/win/wjoydx.c
+        src/win/wjoyhelp.c
+        src/win/wjoyw32.c
+        src/win/wkeybd.c
+        src/win/wmidi.c
+        src/win/wmouse.c
+        src/win/wsnddrv.c
+        src/win/wsystem.c
+        src/win/wthread.c
+        src/win/wtimer.c
+        src/win/wwnd.c
+    )
+
+    find_package(DDraw)
+    find_package(DInput)
+    find_package(DSound)
+    find_package(DXGuid)
+
+    if(NOT DDRAW_FOUND OR NOT DINPUT_FOUND OR NOT DSOUND_FOUND OR NOT DXGUID_FOUND)
+        message(FATAL_ERROR "DirectX required for Windows port. You might need to add DirectX include and lib directories to your INCLUDE and LIB environment variables.")
+    endif()
+
+    # Don't use include directories from DirectX SDK as Windows SDK contains them now.
+    # target_include_directories(allegro PRIVATE
+    #     ${DDRAW_INCLUDE_DIR}
+    #     ${DINPUT_INCLUDE_DIR}
+    #     ${DSOUND_INCLUDE_DIR}
+    #     ${DXGUID_INCLUDE_DIR}
+    # )
+
+    target_link_libraries(allegro PUBLIC
+        kernel32
+        user32
+        gdi32
+        comdlg32
+        ole32
+        ${DINPUT_LIBRARIES}
+        ${DDRAW_LIBRARIES}
+        ${DXGUID_LIBRARIES}
+        winmm
+        ${DSOUND_LIBRARIES}
+    )
+endif(WIN32)
+
+# -- Mac OS X --
+
+if(ALLEGRO_MACOSX)
+
+    target_sources(allegro PRIVATE
+        src/macosx/cadigi.m
+        src/macosx/camidi.m
+        src/macosx/drivers.m
+        src/macosx/hidjoy.m
+        src/macosx/hidman.m
+        src/macosx/keybd.m
+        src/macosx/pcpu.m
+        src/macosx/quartz.m
+        src/macosx/qzmouse.m
+        src/macosx/system.m
+        src/macosx/cocoagl.m
+        src/macosx/cocoashared.m
+        src/unix/ufile.c
+        src/unix/utimer.c
+        src/unix/uptimer.c
+        src/unix/usystem.c
+        src/unix/uthreads.c
+
+        src/macosx/main.m
+    )
+
+    foreach(fw Cocoa IOKit CoreAudio AudioUnit AudioToolbox OpenGL CoreVideo)
+        find_library(${fw}_FRAMEWORK ${fw})
+        mark_as_advanced(${fw}_FRAMEWORK)
+        target_link_libraries(allegro PUBLIC ${${fw}_FRAMEWORK})
+    endforeach(fw)
+
+endif(ALLEGRO_MACOSX)
+
+# -- iOS --
+
+if(IOS)
+    target_include_directories(allegro PRIVATE ${IOS_PLATFORM_INCLUDE})
+    target_include_directories(allegro PRIVATE "${SDK_PATH}/usr/include")
+    target_sources(allegro PRIVATE 
+        src/ios/idrivers.c
+        src/ios/isound.c
+        src/ios/ifile.c
+        src/ios/igfx.c
+        src/ios/ikey.c
+        src/ios/isystem.c
+        src/ios/imouse.c
+        src/ios/itimer.c
+        src/ios/ithreads.c
+        src/misc/colconv.c
+    )
+	link_directories(IOS_PLATFORM_LIB)
+endif(IOS)
+
+# -- Android --
+
+if(ANDROID)
+    target_sources(allegro PRIVATE
+        src/android/adrivers.c
+        src/android/asound.c
+        src/android/afile.c
+        src/android/agfx.c
+        src/android/akey.c
+        src/android/asystem.c
+        src/android/amouse.c
+        src/android/ajni.c
+        src/android/atimer.c
+        src/misc/colconv.c
+    )
+endif(ANDROID)
+
+
+#-----------------------------------------------------------------------------#
+#
+# Generate and install headers
+#
+
+configure_file(
+    include/allegro/platform/alplatf.h.cmake
+    ${CMAKE_BINARY_DIR}/include/allegro/platform/alplatf.h
+    @ONLY
+    )
+
+if(UNIX)
+    configure_file(
+        include/allegro/platform/alunixac.h.cmake
+        ${CMAKE_BINARY_DIR}/include/allegro/platform/alunixac.h
+        )
+endif(UNIX)
+
+target_include_directories(allegro BEFORE PUBLIC ${CMAKE_BINARY_DIR}/include)
+target_include_directories(allegro PUBLIC include)
+
+
+#-----------------------------------------------------------------------------#
+#
+# Alias
+#
+
+add_library(Allegro::Allegro ALIAS allegro)
+
+#-----------------------------------------------------------------------------#
+# vim: set sts=4 sw=4 et:

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -608,6 +608,11 @@ target_sources(ags
 
 target_link_libraries(ags PRIVATE engine)
 
+if (LINUX)
+    # We may override `allegro_icon` and `load_midi_pf` depending on the version
+    target_link_options(ags PRIVATE -Wl,--allow-multiple-definition)
+endif ()
+
 set_target_properties(ags PROPERTIES
     RUNTIME_OUTPUT_NAME ags
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,6 +1,3 @@
-include(CheckLoadMidiPf)
-
-
 # Engine
 # -----------------------------------------------------------------------------
 
@@ -539,10 +536,6 @@ if (AGS_BUILTIN_PLUGINS)
         ../Plugins/agspalrender/raycast.cpp
         ../Plugins/agspalrender/raycast.h
     )
-endif()
-
-if (NOT HAVE_LOAD_MIDI_PF)
-    target_sources(engine PRIVATE libsrc/allegro-4.2.2-agspatch/midi.c)
 endif()
 
 

--- a/Engine/libsrc/apeg-1.2.1/CMakeLists.txt
+++ b/Engine/libsrc/apeg-1.2.1/CMakeLists.txt
@@ -10,19 +10,6 @@ target_include_directories(apeg PUBLIC . )
 target_sources(apeg 
     PRIVATE
     adisplay.c
-    audio/aaudio.c
-    audio/apegcommon.c
-    audio/dct64.c
-    audio/decode_1to1.c
-    audio/decode_2to1.c
-    audio/decode_4to1.c
-    audio/layer1.c
-    audio/layer2.c
-    audio/layer3.c
-    audio/mpg123.c
-    audio/readers.c
-    audio/tabinit.c
-    audio/vbrhead.c
     getbits.c
     getblk.c
     gethdr.c
@@ -32,10 +19,25 @@ target_sources(apeg
     mpeg1dec.c
     ogg.c
     recon.c
+    audio/aaudio.c
+    audio/mpg123.c
+
+    # if MPEG_AUDIO not disabled
+    # audio/apegcommon.c
+    # audio/dct64.c
+    # audio/decode_1to1.c
+    # audio/decode_2to1.c
+    # audio/decode_4to1.c
+    # audio/layer1.c
+    # audio/layer2.c
+    # audio/layer3.c
+    # audio/readers.c
+    # audio/tabinit.c
+    # audio/vbrhead.c
 )
 
 target_compile_definitions(apeg PUBLIC DISABLE_MPEG_AUDIO)
 
-target_link_libraries(apeg PUBLIC Allegro::Allegro Ogg::Ogg Vorbis::Vorbis Vorbis::VorbisFile Theora::Theora)
+target_link_libraries(apeg PUBLIC Allegro::Allegro Ogg::Ogg Vorbis::Vorbis Vorbis::VorbisFile Theora::TheoraDecoder)
 
 add_library(Apeg::Apeg ALIAS apeg)

--- a/Engine/libsrc/ogg/CMakeLists.txt
+++ b/Engine/libsrc/ogg/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.14)
+project(ogg LANGUAGES C)
+
+include(CheckIncludeFiles)
+
+# Configure config_type.h
+check_include_files(inttypes.h INCLUDE_INTTYPES_H)
+check_include_files(stdint.h INCLUDE_STDINT_H)
+check_include_files(sys/types.h INCLUDE_SYS_TYPES_H)
+
+set(SIZE16 int16_t)
+set(USIZE16 uint16_t)
+set(SIZE32 int32_t)
+set(USIZE32 uint32_t)
+set(SIZE64 int64_t)
+set(USIZE64 uint64_t)
+
+configure_file(include/ogg/config_types.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/ogg/config_types.h @ONLY)
+
+
+add_library(ogg)
+
+target_sources(ogg PRIVATE
+    src/bitwise.c
+    src/framing.c
+    ${CMAKE_CURRENT_BINARY_DIR}/include/ogg/config_types.h
+    include/ogg/ogg.h
+    include/ogg/os_types.h
+)
+
+target_include_directories(ogg PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+
+add_library(Ogg::Ogg ALIAS ogg)

--- a/Engine/libsrc/theora/CMakeLists.txt
+++ b/Engine/libsrc/theora/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.14)
+project(theora LANGUAGES C)
+
+add_library(theoradec)
+
+target_include_directories(theoradec PUBLIC include)
+
+target_sources(theoradec PRIVATE
+    include/theora/codec.h
+    include/theora/theora.h
+    include/theora/theoradec.h
+    include/theora/theoraenc.h
+
+    lib/apiwrapper.c
+    lib/bitpack.c
+    lib/dequant.c
+    lib/fragment.c
+    lib/idct.c
+    lib/info.c
+    lib/internal.c
+    lib/state.c
+    lib/quant.c
+
+    lib/decapiwrapper.c
+    lib/decinfo.c
+    lib/decode.c
+    lib/huffdec.c
+)
+
+target_link_libraries(theoradec ogg)
+
+add_library (Theora::TheoraDecoder ALIAS theoradec)

--- a/Engine/libsrc/vorbis/CMakeLists.txt
+++ b/Engine/libsrc/vorbis/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.14)
+project(vorbis LANGUAGES C)
+
+include(CheckIncludeFiles)
+
+add_library(vorbis)
+
+target_include_directories(vorbis
+    PUBLIC include
+    PRIVATE lib
+)
+
+target_sources(vorbis PRIVATE
+    lib/envelope.h
+    lib/lpc.h
+    lib/lsp.h
+    lib/codebook.h
+    lib/misc.h
+    lib/psy.h
+    lib/masking.h
+    lib/os.h
+    lib/mdct.h
+    lib/smallft.h
+    lib/highlevel.h
+    lib/registry.h
+    lib/scales.h
+    lib/window.h
+    lib/lookup.h
+    lib/lookup_data.h
+    lib/codec_internal.h
+    lib/backends.h
+    lib/bitrate.h
+    lib/mdct.c
+    lib/smallft.c
+    lib/block.c
+    lib/envelope.c
+    lib/window.c
+    lib/lsp.c
+    lib/lpc.c
+    lib/analysis.c
+    lib/synthesis.c
+    lib/psy.c
+    lib/info.c
+    lib/floor1.c
+    lib/floor0.c
+    lib/res0.c
+    lib/mapping0.c
+    lib/registry.c
+    lib/codebook.c
+    lib/sharedbook.c
+    lib/lookup.c
+    lib/bitrate.c
+)
+
+target_link_libraries(vorbis ogg)
+
+add_library(Vorbis::Vorbis ALIAS vorbis)
+
+
+
+
+add_library(vorbisfile)
+
+target_sources(vorbisfile PUBLIC
+    lib/vorbisfile.c
+)
+ 
+target_include_directories(vorbisfile
+    PUBLIC include
+    PRIVATE lib
+)
+
+target_link_libraries(vorbisfile ogg vorbis)
+
+add_library(Vorbis::VorbisFile ALIAS vorbisfile)


### PR DESCRIPTION
Demonstrate automatic download and builds of all dependencies. You only need one Solution to build AGS and all its dependencies!

This will be extremely useful for cross-compilation as you should hopefully only need to supply one toolchain file.

Also includes some fixes for Windows to allow static runtime.