### PR TITLE
Fixes for Debian/Ubuntu build script and packaging

### DIFF
--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -11,7 +11,7 @@ set -e
 
 # Preliminaries for running this script:
 # This script is intended for use on Debian or Ubuntu
-# Install ubuntu-dev-scripts and pbuilder:
+# Install ubuntu-dev-tools and pbuilder:
 
 # sudo apt-get install ubuntu-dev-tools pbuilder
 

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -11,14 +11,14 @@ set -e
 
 # Preliminaries for running this script:
 # This script is intended for use on Debian or Ubuntu
-# Install ubuntu-dev-scripts and cowbuilder:
+# Install ubuntu-dev-scripts and pbuilder:
 
-# sudo apt-get install ubuntu-dev-tools cowbuilder
+# sudo apt-get install ubuntu-dev-tools pbuilder
 
 # Create the (chroot) environments that will be used for building ags:
 
-# cowbuilder-dist jessie i386 create
-# cowbuilder-dist jessie amd64 create
+# pbuilder-dist jessie i386 create
+# pbuilder-dist jessie amd64 create
 
 # The only other thing you should take care of is that your ags
 # source tree is git clean. That means: check 'git status', commit any
@@ -27,8 +27,8 @@ set -e
 # The chroots can later be updated, which becomes necessary if
 # this script fails because some Debian package cannot be downloaded:
 
-# cowbuilder-dist jessie i386 update
-# cowbuilder-dist jessie amd64 update
+# pbuilder-dist jessie i386 update
+# pbuilder-dist jessie amd64 update
 
 BASEPATH=$(dirname $(dirname $(readlink -f $0)))
 
@@ -60,7 +60,7 @@ debuild -us -uc -S
 
 # Build ags binary package in i386 chroot, also use a hook script to copy libraries and licenses
 # from the chroot to a folder that is mounted into the chroot via --bindmounts.
-DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib32" cowbuilder-dist jessie i386 build \
+DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib32" pbuilder-dist jessie i386 build \
   $BASEPATH/../ags_$VERSION.dsc \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \
@@ -74,7 +74,7 @@ rm -rf $BASEPATH/ags+libraries/ags_* $BASEPATH/ags+libraries/ags-dbg_* $BASEPATH
 
 # Repeat for amd64.
 sed -i -r "5s/.*/BIT=64/" $BASEPATH/debian/ags+libraries/hooks/B00_copy_libs.sh
-DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib64" cowbuilder-dist jessie amd64 build \
+DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib64" pbuilder-dist jessie amd64 build \
   $BASEPATH/../ags_$VERSION.dsc \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -17,8 +17,8 @@ set -e
 
 # Create the (chroot) environments that will be used for building ags:
 
-# pbuilder-dist jessie i386 create
-# pbuilder-dist jessie amd64 create
+# pbuilder-dist jessie i386 --security-only create
+# pbuilder-dist jessie amd64 --security-only create
 
 # The only other thing you should take care of is that your ags
 # source tree is git clean. That means: check 'git status', commit any
@@ -27,8 +27,8 @@ set -e
 # The chroots can later be updated, which becomes necessary if
 # this script fails because some Debian package cannot be downloaded:
 
-# pbuilder-dist jessie i386 update
-# pbuilder-dist jessie amd64 update
+# pbuilder-dist jessie i386 --security-only update
+# pbuilder-dist jessie amd64 --security-only update
 
 BASEPATH=$(dirname $(dirname $(readlink -f $0)))
 

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -11,9 +11,9 @@ set -e
 
 # Preliminaries for running this script:
 # This script is intended for use on Debian or Ubuntu
-# Install ubuntu-dev-tools and pbuilder:
+# Install ubuntu-dev-tools and pbuilder, Ubuntu also needs debhelper:
 
-# sudo apt-get install ubuntu-dev-tools pbuilder
+# sudo apt-get install ubuntu-dev-tools pbuilder debhelper
 
 # Create the (chroot) environments that will be used for building ags:
 

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -56,7 +56,7 @@ CHANGELOG_VERSION=$(head -1 debian/changelog | sed 's/.*(\(.*\)).*/\1/')
 VERSION=$(grep '#define ACI_VERSION_STR' Common/core/def_version.h | sed 's/.*"\(.*\)".*/\1/')
 sed -i -- "s/$CHANGELOG_VERSION/$VERSION/" debian/changelog
 debian/rules get-orig-source
-debuild -us -uc -S
+debuild -us -uc -d -S
 
 # Build ags binary package in i386 chroot, also use a hook script to copy libraries and licenses
 # from the chroot to a folder that is mounted into the chroot via --bindmounts.

--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -61,10 +61,10 @@ debuild -us -uc -S
 # Build ags binary package in i386 chroot, also use a hook script to copy libraries and licenses
 # from the chroot to a folder that is mounted into the chroot via --bindmounts.
 DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib32" pbuilder-dist jessie i386 build \
-  $BASEPATH/../ags_$VERSION.dsc \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \
-  --bindmounts "$BASEPATH/ags+libraries"
+  --bindmounts "$BASEPATH/ags+libraries" \
+  $BASEPATH/../ags_$VERSION.dsc
 
 # Get the ags binary out of the binary Debian package and clean up.
 cd $BASEPATH/ags+libraries
@@ -75,10 +75,10 @@ rm -rf $BASEPATH/ags+libraries/ags_* $BASEPATH/ags+libraries/ags-dbg_* $BASEPATH
 # Repeat for amd64.
 sed -i -r "5s/.*/BIT=64/" $BASEPATH/debian/ags+libraries/hooks/B00_copy_libs.sh
 DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib64" pbuilder-dist jessie amd64 build \
-  $BASEPATH/../ags_$VERSION.dsc \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \
-  --bindmounts "$BASEPATH/ags+libraries"
+  --bindmounts "$BASEPATH/ags+libraries" \
+  $BASEPATH/../ags_$VERSION.dsc
 
 cd $BASEPATH/ags+libraries
 ar p $BASEPATH/ags+libraries/ags_${VERSION}_amd64.deb data.tar.xz | unxz | tar x

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@ ifneq (,$(filter rpath=%,$(DEB_BUILD_OPTIONS)))
 endif
 
 %:
-	dh $@ --parallel
+	dh $@ --parallel --buildsystem makefile
 
 override_dh_auto_clean:
 	$(MAKE) clean


### PR DESCRIPTION
* Switch from cowbuilder to pbuilder
* Fix for Debian mirror changes - these are permanent changes so the existing bootstrap for chroots would always fail
* Remove unneccesary package requirements on the host running the chroots
* Ubuntu doesn't have `dh` after installing the documented packages, so I've also added a note that Ubuntu will need to install 'debhelper'
* Ignore CMake in Debian packaging by explicitly specifying the build system - dh_auto_configure was autodetecting CMake files, and then the package would fail to build

The main change is switching from cowbuilder to pbuilder, which shouldn't be functionally different, but will work in more places. I don't think anything here is relying on using cowbuilder, and cowbuilder is more likely to have problems based on trying to hardlink across filesystem boundaries.

I've checked that the build script works on:
* Debian 8
* Debian 9
* Ubuntu 14.04
* Ubuntu 16.04
* Ubuntu 18.04

...just using the base OS install and the packages listed in the script file.