### PR TITLE
Enable Travis-CI builds for the ags3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - debhelper
+    - build-essential
+    - pkg-config 
+    - cmake 
+    - libfreetype6-dev 
+    - libogg-dev 
+    - libtheora-dev 
+    - libvorbis-dev
+    - liballegro4-dev
+    - libaldmb1-dev
+    - fakeroot
+script:
+- fakeroot debian/rules binary
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  file: 
+  - ../ags_3~git-1_amd64.deb
+  - ../ags-dbg_3~git-1_amd64.deb
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ addons:
       - pbuilder
       - ubuntu-dev-tools
 
+cache:
+  directories:
+    - /var/cache/pbuilder
+
 before_script:
   - pbuilder-dist jessie i386 --security-only create
   - pbuilder-dist jessie amd64 --security-only create

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,27 @@
-language: c
-compiler:
-  - gcc
+language: minimal
+
 addons:
   apt:
     packages:
-    - debhelper
-    - build-essential
-    - pkg-config 
-    - cmake 
-    - libfreetype6-dev 
-    - libogg-dev 
-    - libtheora-dev 
-    - libvorbis-dev
-    - liballegro4-dev
-    - libaldmb1-dev
-    - fakeroot
+      - debhelper
+      - debian-archive-keyring
+      - fakeroot
+      - pbuilder
+      - ubuntu-dev-tools
+
+before_script:
+  - pbuilder-dist jessie i386 --security-only create
+  - pbuilder-dist jessie amd64 --security-only create
+
 script:
-- fakeroot debian/rules binary
+  - ./debian/make_ags+libraries.sh
+
 deploy:
   provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
+  file_glob: true
   file: 
-  - ../ags_3~git-1_amd64.deb
-  - ../ags-dbg_3~git-1_amd64.deb
+    - ags+libraries_*.tar.xz
   on:
     tags: true


### PR DESCRIPTION
This file needs to be present in the branch in order to build it. For release purposes it probably needs to use the chroot build script or also run a build in a 32 bit container, and there is the Allegro version to consider, but for the moment just checking that builds occur is a good start.

Edit: the current build error should be covered by #717