### PR TITLE
AGS 3: support for multiple cameras and viewports

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -622,6 +622,15 @@ builtin managed struct Room {
 #ifdef SCRIPT_API_v3507
   /// Gets the room camera
   import static readonly attribute Camera *Camera;
+
+  /// Gets the Camera by index.
+  import static readonly attribute Camera *Cameras[];
+  /// Gets the number of cameras.
+  import static readonly attribute int CameraCount;
+  /// Creates a new Camera.
+  import static Camera *CreateCamera();
+  /// Removes an existing camera; primary camera will never be removed
+  import static void RemoveCamera(int id);
 #endif
 };
 
@@ -2777,8 +2786,8 @@ builtin managed struct Viewport {
   import attribute int Width;
   /// Gets/sets the viewport's height in screen coordinates.
   import attribute int Height;
-  /// Gets the room camera displayed in this viewport.
-  import readonly attribute Camera *Camera;
+  /// Gets/sets the room camera displayed in this viewport.
+  import attribute Camera *Camera;
 
   /// Returns the viewport at the specified screen location.
   import static Viewport *GetAtScreenXY(int x, int y);
@@ -2795,12 +2804,21 @@ builtin struct Screen {
   import static readonly attribute int Width;
   /// Gets the height of the game resolution.
   import static readonly attribute int Height;
-  /// Gets/sets whether the viewport should automatically adjust itself and camera to the new room's background size
+  /// Gets/sets whether the viewport should automatically adjust itself and camera to the new room's background size.
   import static attribute bool AutoSizeViewportOnRoomLoad;
-  /// Gets the primary room viewport
+  /// Gets the primary room viewport.
   import static readonly attribute Viewport *Viewport;
 
-  /// Returns the point in room which is displayed at the given screen coordinates
+  /// Gets a Viewport by index.
+  import static readonly attribute Viewport *Viewports[];
+  /// Gets the number of viewports.
+  import static readonly attribute int ViewportCount;
+  /// Creates a new Viewport.
+  import static Viewport *CreateViewport();
+  /// Removes an existing viewport; primary viewport will never be removed
+  import static void RemoveViewport(int id);
+
+  /// Returns the point in room which is displayed at the given screen coordinates.
   import static Point *ScreenToRoomPoint(int sx, int sy);
   /// Returns the point on screen corresponding to the given room coordinates relative to the main viewport.
   import static Point *RoomToScreenPoint(int rx, int ry);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2788,6 +2788,8 @@ builtin managed struct Viewport {
   import attribute int Height;
   /// Gets/sets the room camera displayed in this viewport.
   import attribute Camera *Camera;
+  /// Gets/sets whether the viewport is drawn on screen.
+  import attribute bool Visible;
 
   /// Returns the viewport at the specified screen location.
   import static Viewport *GetAtScreenXY(int x, int y);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2790,6 +2790,8 @@ builtin managed struct Viewport {
   import attribute Camera *Camera;
   /// Gets/sets whether the viewport is drawn on screen.
   import attribute bool Visible;
+  /// Gets/sets the Viewport's z-order relative to other viewports.
+  import attribute int ZOrder;
 
   /// Returns the viewport at the specified screen location.
   import static Viewport *GetAtScreenXY(int x, int y);

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -328,7 +328,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         if (!overlayPositionFixed)
         {
             screenover[nse].positionRelativeToScreen = false;
-            VpPoint vpt = play.ScreenToRoom(screenover[nse].x, screenover[nse].y, false);
+            VpPoint vpt = play.ScreenToRoom(screenover[nse].x, screenover[nse].y, 0, false);
             screenover[nse].x = vpt.first.X;
             screenover[nse].y = vpt.first.Y;
         }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -542,7 +542,7 @@ void init_draw_method()
 void dispose_draw_method()
 {
     dispose_room_drawdata();
-    destroy_invalid_regions();
+    dispose_invalid_regions(false);
     destroy_blank_image();
 }
 
@@ -550,6 +550,7 @@ void dispose_room_drawdata()
 {
     RoomCameraBuffer.clear();
     RoomCameraFrame.clear();
+    dispose_invalid_regions(true);
 }
 
 void on_mainviewport_changed()
@@ -611,7 +612,7 @@ void sync_roomview(PViewport view)
             int room_width = data_to_game_coord(thisroom.Width);
             int room_height = data_to_game_coord(thisroom.Height);
             Size alloc_sz = Size::Clamp(cam_sz * 2, Size(1, 1), Size(room_width, room_height));
-            camera_buffer.reset(new Bitmap(alloc_sz.Width, alloc_sz.Height));
+            camera_buffer.reset(new Bitmap(alloc_sz.Width, alloc_sz.Height, thisroom.BackgroundBPP * 8));
         }
 
         if (!camera_frame || camera_frame->GetSize() != cam_sz)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2400,6 +2400,8 @@ static void construct_room_view()
     for (int i = 0; i < play.GetRoomViewportCount(); ++i)
     {
         auto viewport = play.GetRoomViewportObj(i);
+        if (!viewport->IsVisible())
+            continue;
         auto camera = viewport->GetCamera();
         if (!camera)
             continue;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -535,8 +535,8 @@ void init_draw_method()
     }
 
     on_mainviewport_changed();
-    on_roomviewport_changed();
-    on_camera_size_changed();
+    on_roomviewport_changed(0);
+    on_camera_size_changed(0);
 }
 
 void dispose_draw_method()
@@ -577,9 +577,9 @@ void on_mainviewport_changed()
 // Syncs room viewport and camera in case anything has changed
 void sync_roomview()
 {
-    const Size &cam_sz = play.GetRoomCamera().GetSize();
-    const Size &view_sz = play.GetRoomViewport().GetSize();
-    init_invalid_regions(0, cam_sz, play.GetRoomViewport());
+    const Size &cam_sz = play.GetRoomCamera(0)->GetRect().GetSize();
+    const Size &view_sz = play.GetRoomViewport(0).GetSize();
+    init_invalid_regions(0, cam_sz, play.GetRoomViewport(0));
     if (cam_sz == view_sz)
     { // note we keep the buffer allocated in case it will become useful later
         RoomCameraFrame.reset();
@@ -602,7 +602,7 @@ void sync_roomview()
     }
 }
 
-void on_roomviewport_changed()
+void on_roomviewport_changed(int index)
 {
     if (!gfxDriver->RequiresFullRedrawEachFrame())
     {
@@ -614,7 +614,7 @@ void on_roomviewport_changed()
     }
 }
 
-void on_camera_size_changed()
+void on_camera_size_changed(int index)
 {
     if (!gfxDriver->RequiresFullRedrawEachFrame())
     {
@@ -2030,9 +2030,9 @@ PBitmap draw_room_background(const SpriteTransform &room_trans)
     // TODO: dont use static vars!!
     static int offsetxWas = -100, offsetyWas = -100;
 
-    const Rect &camera = play.GetRoomCamera();
-    const int offsetx = camera.Left;
-    const int offsety = camera.Top;
+    auto camera = play.GetRoomCamera(0);
+    const int offsetx = camera->GetRect().Left;
+    const int offsety = camera->GetRect().Top;
 
     if ((offsetx != offsetxWas) || (offsety != offsetyWas)) {
         invalidate_screen();
@@ -2401,8 +2401,8 @@ static void construct_room_view()
     // reset the Baselines Changed flag now that we've drawn stuff
     walk_behind_baselines_changed = 0;
 
-    const Rect &room_viewport = play.GetRoomViewportAbs();
-    const Rect &camera = play.GetRoomCamera();
+    const Rect &room_viewport = play.GetRoomViewportAbs(0);
+    const Rect &camera = play.GetRoomCamera(0)->GetRect();
     SpriteTransform room_trans(-camera.Left, -camera.Top,
         (float)room_viewport.GetWidth() / (float)camera.GetWidth(),
         (float)room_viewport.GetHeight() / (float)camera.GetHeight(),
@@ -2450,7 +2450,7 @@ void construct_virtual_screen(bool fullRedraw)
     // TODO: move to game update! don't call update during rendering pass!
     // IMPORTANT: keep the order same because sometimes script may depend on it
     if (displayed_room >= 0)
-        play.UpdateRoomCamera();
+        play.UpdateRoomCameras();
 
     // Stage 1: room viewports
     if (displayed_room >= 0 && play.screen_is_faded_out == 0 && is_complete_overlay == 0)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -621,6 +621,13 @@ void sync_roomview(PViewport view)
     }
 }
 
+void init_room_drawdata()
+{
+    // Make sure all frame buffers are created for software drawing
+    for (int i = 0; i < play.GetRoomViewportCount(); ++i)
+        sync_roomview(play.GetRoomViewportObj(i));
+}
+
 void on_roomviewport_changed(int index)
 {
     if (!gfxDriver->RequiresFullRedrawEachFrame())

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2417,13 +2417,13 @@ static void construct_room_view()
 
     for (int i = 0; i < play.GetRoomViewportCount(); ++i)
     {
-        auto viewport = play.GetRoomViewportObj(i);
+        auto viewport = play.GetRoomViewportZOrdered(i);
         if (!viewport->IsVisible())
             continue;
         auto camera = viewport->GetCamera();
         if (!camera)
             continue;
-        const Rect &view_rc = play.GetRoomViewportAbs(i);
+        const Rect &view_rc = play.GetRoomViewportAbs(viewport->GetID());
         const Rect &cam_rc = camera->GetRect();
         SpriteTransform room_trans(-cam_rc.Left, -cam_rc.Top,
             (float)view_rc.GetWidth() / (float)cam_rc.GetWidth(),

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -68,9 +68,9 @@ void dispose_room_drawdata();
 // Updates drawing settings depending on main viewport's size and position on screen
 void on_mainviewport_changed();
 // Updates drawing settings if room viewport's position or size has changed
-void on_roomviewport_changed();
+void on_roomviewport_changed(int index);
 // Updates drawing settings if room camera's size has changed
-void on_camera_size_changed();
+void on_camera_size_changed(int index);
 
 // whether there are currently remnants of a DisplaySpeech
 void mark_screen_dirty();

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -78,6 +78,8 @@ bool is_screen_dirty();
 
 // marks whole screen as needing a redraw
 void invalidate_screen();
+// marks all the camera frame as needing a redraw
+void invalidate_camera_frame(int index);
 // marks certain rectangle on screen as needing a redraw
 // in_room flag tells how to interpret the coordinates: as in-room coords or screen viewport coordinates.
 void invalidate_rect(int x1, int y1, int x2, int y2, bool in_room);

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -110,7 +110,6 @@ void draw_screen_callback();
 void write_screen();
 void GfxDriverOnInitCallback(void *data);
 bool GfxDriverNullSpriteCallback(int x, int y);
-void destroy_invalid_regions();
 void putpixel_compensate (Common::Bitmap *g, int xx,int yy, int col);
 // create the actsps[aa] image with the object drawn correctly
 // returns 1 if nothing at all has changed and actsps is still

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -61,6 +61,8 @@ int MakeColor(int color_index);
 
 // Initializes drawing methods and optimisation
 void init_draw_method();
+// Initializes drawing resources upon entering new room
+void init_room_drawdata();
 // Disposes resources related to the current drawing methods
 void dispose_draw_method();
 // Disposes any temporary resources on leaving current room

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -90,6 +90,7 @@ Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitma
 void update_screen();
 // Draw everything 
 void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
+// Construct game scene, scheduling drawing list for the renderer
 void construct_virtual_screen(bool fullRedraw) ;
 void add_to_sprite_list(Engine::IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, int sprNum, bool isWalkBehind = false);
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);

--- a/Engine/ac/draw_software.cpp
+++ b/Engine/ac/draw_software.cpp
@@ -172,13 +172,13 @@ DirtyRects BlackRects;
 std::vector<DirtyRects> RoomCamRects;
 // Saved room camera offsets to know if we must invalidate whole surface.
 // TODO: if we support rotation then we also need to compare full transform!
-typedef std::pair<int, int> SavedCamPosition;
-std::vector<SavedCamPosition> RoomCamPositions;
+std::vector<std::pair<int, int>> RoomCamPositions;
 
 
-void destroy_invalid_regions()
+void dispose_invalid_regions(bool /* room_only */)
 {
     RoomCamRects.clear();
+    RoomCamPositions.clear();
 }
 
 void init_invalid_regions(int view_index, const Size &surf_size, const Rect &viewport)

--- a/Engine/ac/draw_software.cpp
+++ b/Engine/ac/draw_software.cpp
@@ -168,13 +168,17 @@ void DirtyRects::Reset()
 // these are used when the room viewport does not cover whole screen,
 // so that we know when to paint black after mouse cursor and gui.
 DirtyRects BlackRects;
-// TODO: support for multiple cameras (multiple DirtyRects objects)
 // Dirty rects object for the single room camera
-DirtyRects RoomCamRects;
+std::vector<DirtyRects> RoomCamRects;
+// Saved room camera offsets to know if we must invalidate whole surface.
+// TODO: if we support rotation then we also need to compare full transform!
+typedef std::pair<int, int> SavedCamPosition;
+std::vector<SavedCamPosition> RoomCamPositions;
+
 
 void destroy_invalid_regions()
 {
-    RoomCamRects.Destroy();
+    RoomCamRects.clear();
 }
 
 void init_invalid_regions(int view_index, const Size &surf_size, const Rect &viewport)
@@ -185,8 +189,13 @@ void init_invalid_regions(int view_index, const Size &surf_size, const Rect &vie
     }
     else
     {
-        // TODO: multiple room viewport support
-        RoomCamRects.Init(surf_size, viewport);
+        if (RoomCamRects.size() <= view_index)
+        {
+            RoomCamRects.resize(view_index + 1);
+            RoomCamPositions.resize(view_index + 1);
+        }
+        RoomCamRects[view_index].Init(surf_size, viewport);
+        RoomCamPositions[view_index] = std::make_pair(-1000, -1000);
     }
 }
 
@@ -195,19 +204,38 @@ void set_invalidrects_cameraoffs(int view_index, int x, int y)
     if (view_index < 0)
     {
         BlackRects.SetSurfaceOffsets(x, y);
+        return;
     }
     else
     {
-        RoomCamRects.SetSurfaceOffsets(x, y);
+        RoomCamRects[view_index].SetSurfaceOffsets(x, y);
+    }
+
+    int &posxwas = RoomCamPositions[view_index].first;
+    int &posywas = RoomCamPositions[view_index].second;
+    if ((x != posxwas) || (y != posywas))
+    {
+        invalidate_all_camera_rects(view_index);
+        posxwas = x;
+        posywas = y;
     }
 }
 
 void invalidate_all_rects()
 {
-    // mark the whole screen dirty
-    if (!IsRectInsideRect(RoomCamRects.Viewport, BlackRects.Viewport))
-        BlackRects.NumDirtyRegions = WHOLESCREENDIRTY;
-    RoomCamRects.NumDirtyRegions = WHOLESCREENDIRTY;
+    for (auto &rects : RoomCamRects)
+    {
+        if (!IsRectInsideRect(rects.Viewport, BlackRects.Viewport))
+            BlackRects.NumDirtyRegions = WHOLESCREENDIRTY;
+        rects.NumDirtyRegions = WHOLESCREENDIRTY;
+    }
+}
+
+void invalidate_all_camera_rects(int view_index)
+{
+    if (view_index < 0)
+        return;
+    RoomCamRects[view_index].NumDirtyRegions = WHOLESCREENDIRTY;
 }
 
 void invalidate_rect_on_surf(int x1, int y1, int x2, int y2, DirtyRects &rects)
@@ -295,31 +323,34 @@ void invalidate_rect_on_surf(int x1, int y1, int x2, int y2, DirtyRects &rects)
     //}
 }
 
-void invalidate_rect_ds(int x1, int y1, int x2, int y2, bool in_room)
+void invalidate_rect_ds(DirtyRects &rects, int x1, int y1, int x2, int y2, bool in_room)
 {
-    if (!RoomCamRects.IsInit())
-        return;
-    // TODO: support for multiple cameras (just do the similar thing in a loop, switching DirtyRects object)
     if (!in_room)
     {
         // TODO: for most opimisation (esp. with multiple viewports) should perhaps
         // split/cut parts of the original rectangle which overlap room viewport(s).
         Rect r(x1, y1, x2, y2);
         // If overlay is NOT completely over the room, then invalidate black rect
-        if (!IsRectInsideRect(RoomCamRects.Viewport, r))
+        if (!IsRectInsideRect(rects.Viewport, r))
             invalidate_rect_on_surf(x1, y1, x2, y2, BlackRects);
         // If overlay is NOT intersecting room viewport at all, then stop
-        if (!AreRectsIntersecting(RoomCamRects.Viewport, r))
+        if (!AreRectsIntersecting(rects.Viewport, r))
             return;
 
         // Transform from screen to room coordinates through the known viewport
-        x1 = RoomCamRects.Screen2DirtySurf.X.ScalePt(x1);
-        x2 = RoomCamRects.Screen2DirtySurf.X.ScalePt(x2);
-        y1 = RoomCamRects.Screen2DirtySurf.Y.ScalePt(y1);
-        y2 = RoomCamRects.Screen2DirtySurf.Y.ScalePt(y2);
+        x1 = rects.Screen2DirtySurf.X.ScalePt(x1);
+        x2 = rects.Screen2DirtySurf.X.ScalePt(x2);
+        y1 = rects.Screen2DirtySurf.Y.ScalePt(y1);
+        y2 = rects.Screen2DirtySurf.Y.ScalePt(y2);
     }
 
-    invalidate_rect_on_surf(x1, y1, x2, y2, RoomCamRects);
+    invalidate_rect_on_surf(x1, y1, x2, y2, rects);
+}
+
+void invalidate_rect_ds(int x1, int y1, int x2, int y2, bool in_room)
+{
+    for (auto &rects : RoomCamRects)
+        invalidate_rect_ds(rects, x1, y1, x2, y2, in_room);
 }
 
 // Note that this function is denied to perform any kind of scaling or other transformation
@@ -431,11 +462,11 @@ void update_black_invreg_and_reset(Bitmap *ds)
     BlackRects.Reset();
 }
 
-void update_room_invreg_and_reset(int /*view_index*/, Bitmap *ds, Bitmap *src, bool no_transform)
+void update_room_invreg_and_reset(int view_index, Bitmap *ds, Bitmap *src, bool no_transform)
 {
-    if (!RoomCamRects.IsInit())
+    if (view_index < 0 || RoomCamRects.size() == 0)
         return;
     
-    update_invalid_region(ds, src, RoomCamRects, no_transform);
-    RoomCamRects.Reset();
+    update_invalid_region(ds, src, RoomCamRects[view_index], no_transform);
+    RoomCamRects[view_index].Reset();
 }

--- a/Engine/ac/draw_software.h
+++ b/Engine/ac/draw_software.h
@@ -28,7 +28,10 @@
 void init_invalid_regions(int view_index, const Size &surf_size, const Rect &viewport);
 // Update the coordinate transformation for the particular dirty rects object
 void set_invalidrects_cameraoffs(int view_index, int x, int y);
+// Mark the whole screen dirty
 void invalidate_all_rects();
+// Mark the whole camera surface dirty
+void invalidate_all_camera_rects(int view_index);
 void invalidate_rect_ds(int x1, int y1, int x2, int y2, bool in_room);
 // Paints the black screen background in the regions marked as dirty
 void update_black_invreg_and_reset(AGS::Common::Bitmap *ds);

--- a/Engine/ac/draw_software.h
+++ b/Engine/ac/draw_software.h
@@ -26,6 +26,8 @@
 // Inits dirty rects array for the given room camera/viewport pair
 // View_index indicates the room viewport (>= 0) or the main viewport (-1)
 void init_invalid_regions(int view_index, const Size &surf_size, const Rect &viewport);
+// Disposes dirty rects arrays
+void dispose_invalid_regions(bool room_only);
 // Update the coordinate transformation for the particular dirty rects object
 void set_invalidrects_cameraoffs(int view_index, int x, int y);
 // Mark the whole screen dirty

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -77,8 +77,6 @@ void ccSerializeAllObjects(Stream *out) {
 
 // un-serialise all objects (will remove all currently registered ones)
 int ccUnserializeAllObjects(Stream *in, ICCObjectReader *callback) {
-    // un-register all existing objects, ready for the un-serialization
-    ccUnregisterAllObjects();
     return pool.ReadFromDisk(in, callback);
 }
 

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -16,9 +16,11 @@
 #include "ac/dynobj/cc_serializer.h"
 #include "ac/dynobj/all_dynamicclasses.h"
 #include "ac/dynobj/all_scriptclasses.h"
+#include "ac/dynobj/scriptcamera.h"
 #include "ac/dynobj/scriptcontainers.h"
 #include "ac/dynobj/scriptfile.h"
 #include "ac/dynobj/scriptuserobject.h"
+#include "ac/dynobj/scriptviewport.h"
 #include "ac/game.h"
 #include "debug/debug_log.h"
 
@@ -114,6 +116,14 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     else if (strcmp(objectType, "StringSet") == 0)
     {
         Set_Unserialize(index, serializedData, dataSize);
+    }
+    else if (strcmp(objectType, "Viewport2") == 0)
+    {
+        Viewport_Unserialize(index, serializedData, dataSize);
+    }
+    else if (strcmp(objectType, "Camera2") == 0)
+    {
+        Camera_Unserialize(index, serializedData, dataSize);
     }
     else if (strcmp(objectType, "UserObject") == 0) {
         ScriptUserObject *suo = new ScriptUserObject();

--- a/Engine/ac/dynobj/scriptcamera.cpp
+++ b/Engine/ac/dynobj/scriptcamera.cpp
@@ -15,6 +15,8 @@
 #include "ac/dynobj/scriptcamera.h"
 #include "ac/gamestate.h"
 
+ScriptCamera::ScriptCamera(int id) : _id(id) {}
+
 const char *ScriptCamera::GetType()
 {
     return "Camera2";
@@ -23,13 +25,13 @@ const char *ScriptCamera::GetType()
 int ScriptCamera::Serialize(const char *address, char *buffer, int bufsize)
 {
     StartSerialize(buffer);
-    SerializeInt(0); // ID
+    SerializeInt(_id);
     return EndSerialize();
 }
 
 void ScriptCamera::Unserialize(int index, const char *serializedData, int dataSize)
 {
     StartUnserialize(serializedData, dataSize);
-    UnserializeInt(); // ID, reserved for the future
+    _id = UnserializeInt();
     ccRegisterUnserializedObject(index, this, this);
 }

--- a/Engine/ac/dynobj/scriptcamera.cpp
+++ b/Engine/ac/dynobj/scriptcamera.cpp
@@ -22,6 +22,14 @@ const char *ScriptCamera::GetType()
     return "Camera2";
 }
 
+int ScriptCamera::Dispose(const char *address, bool force)
+{
+    // Note that ScriptCamera is a reference to actual Camera object,
+    // and this deletes the reference, while camera may remain in GameState.
+    delete this;
+    return 1;
+}
+
 int ScriptCamera::Serialize(const char *address, char *buffer, int bufsize)
 {
     StartSerialize(buffer);

--- a/Engine/ac/dynobj/scriptcamera.h
+++ b/Engine/ac/dynobj/scriptcamera.h
@@ -17,19 +17,25 @@
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
-// ScriptCamera manages room Camera struct in script.
+// ScriptCamera keeps a reference to actual room Camera in script.
 struct ScriptCamera final : AGSCCDynamicObject
 {
 public:
     ScriptCamera(int id);
 
+    // Get camera index; negative means the camera was deleted
     int GetID() const { return _id; }
+    void SetID(int id) { _id = id; }
+    // Reset camera index to indicate that this reference is no longer valid
+    void Invalidate() { _id = -1; }
+
     const char *GetType() override;
+    int Dispose(const char *address, bool force) override;
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, const char *serializedData, int dataSize) override;
 
 private:
-    int _id = 0;
+    int _id = -1; // index of camera in the game state array
 };
 
 #endif // __AC_SCRIPTCAMERA_H

--- a/Engine/ac/dynobj/scriptcamera.h
+++ b/Engine/ac/dynobj/scriptcamera.h
@@ -18,13 +18,18 @@
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
 // ScriptCamera manages room Camera struct in script.
-// Currently it has no members and actual data is stored in "GameState" struct.
-// Also in practice there is only single room camera at the moment.
 struct ScriptCamera final : AGSCCDynamicObject
 {
+public:
+    ScriptCamera(int id);
+
+    int GetID() const { return _id; }
     const char *GetType() override;
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, const char *serializedData, int dataSize) override;
+
+private:
+    int _id = 0;
 };
 
 #endif // __AC_SCRIPTCAMERA_H

--- a/Engine/ac/dynobj/scriptcamera.h
+++ b/Engine/ac/dynobj/scriptcamera.h
@@ -38,4 +38,7 @@ private:
     int _id = -1; // index of camera in the game state array
 };
 
+// Unserialize camera from the memory stream
+ScriptCamera *Camera_Unserialize(int handle, const char *serializedData, int dataSize);
+
 #endif // __AC_SCRIPTCAMERA_H

--- a/Engine/ac/dynobj/scriptviewport.cpp
+++ b/Engine/ac/dynobj/scriptviewport.cpp
@@ -22,6 +22,14 @@ const char *ScriptViewport::GetType()
     return "Viewport2";
 }
 
+int ScriptViewport::Dispose(const char *address, bool force)
+{
+    // Note that ScriptViewport is a reference to actual Viewport object,
+    // and this deletes the reference, while viewport may remain in GameState.
+    delete this;
+    return 1;
+}
+
 int ScriptViewport::Serialize(const char *address, char *buffer, int bufsize)
 {
     StartSerialize(buffer);

--- a/Engine/ac/dynobj/scriptviewport.cpp
+++ b/Engine/ac/dynobj/scriptviewport.cpp
@@ -15,6 +15,8 @@
 #include "ac/dynobj/scriptviewport.h"
 #include "ac/gamestate.h"
 
+ScriptViewport::ScriptViewport(int id) : _id(id) {}
+
 const char *ScriptViewport::GetType()
 {
     return "Viewport2";
@@ -23,13 +25,13 @@ const char *ScriptViewport::GetType()
 int ScriptViewport::Serialize(const char *address, char *buffer, int bufsize)
 {
     StartSerialize(buffer);
-    SerializeInt(0); // ID
+    SerializeInt(_id);
     return EndSerialize();
 }
 
 void ScriptViewport::Unserialize(int index, const char *serializedData, int dataSize)
 {
     StartUnserialize(serializedData, dataSize);
-    UnserializeInt(); // ID, reserved for the future
+    _id = UnserializeInt();
     ccRegisterUnserializedObject(index, this, this);
 }

--- a/Engine/ac/dynobj/scriptviewport.h
+++ b/Engine/ac/dynobj/scriptviewport.h
@@ -17,19 +17,24 @@
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
-// ScriptViewport manages room Viewport struct in script.
+// ScriptViewport keeps a reference to actual room Viewport in script.
 struct ScriptViewport final : AGSCCDynamicObject
 {
 public:
     ScriptViewport(int id);
-
+    // Get viewport index; negative means the viewport was deleted
     int GetID() const { return _id; }
+    void SetID(int id) { _id = id; }
+    // Reset viewport index to indicate that this reference is no longer valid
+    void Invalidate() { _id = -1; }
+
     const char *GetType() override;
+    int Dispose(const char *address, bool force) override;
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, const char *serializedData, int dataSize) override;
 
 private:
-    int _id = 0;
+    int _id = -1; // index of viewport in the game state array
 };
 
 #endif // __AC_SCRIPTVIEWPORT_H

--- a/Engine/ac/dynobj/scriptviewport.h
+++ b/Engine/ac/dynobj/scriptviewport.h
@@ -18,13 +18,18 @@
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
 // ScriptViewport manages room Viewport struct in script.
-// Currently it has no members and actual data is stored in "GameState" struct.
-// Also in practice there is only single room viewport at the moment.
 struct ScriptViewport final : AGSCCDynamicObject
 {
+public:
+    ScriptViewport(int id);
+
+    int GetID() const { return _id; }
     const char *GetType() override;
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, const char *serializedData, int dataSize) override;
+
+private:
+    int _id = 0;
 };
 
 #endif // __AC_SCRIPTVIEWPORT_H

--- a/Engine/ac/dynobj/scriptviewport.h
+++ b/Engine/ac/dynobj/scriptviewport.h
@@ -37,4 +37,7 @@ private:
     int _id = -1; // index of viewport in the game state array
 };
 
+// Unserialize viewport from the memory stream
+ScriptViewport *Viewport_Unserialize(int handle, const char *serializedData, int dataSize);
+
 #endif // __AC_SCRIPTVIEWPORT_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1095,7 +1095,7 @@ HSaveError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
     r_data.CursorID = in->ReadInt32();
     int camx = in->ReadInt32();
     int camy = in->ReadInt32();
-    play.SetRoomCameraAt(camx, camy);
+    play.GetRoomCamera(0)->SetAt(camx, camy);
     set_loop_counter(in->ReadInt32());
     return HSaveError::None();
 }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -106,7 +106,7 @@ PViewport GameState::GetRoomViewportObj(int index) const
 PViewport GameState::GetRoomViewportAt(int x, int y) const
 {
     for (auto vp : _roomViewports)
-        if (vp->GetRect().IsInside(x, y))
+        if (vp->IsVisible() && vp->GetRect().IsInside(x, y))
             return vp;
     return nullptr;
 }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -38,8 +38,12 @@ GameState::GameState()
 {
     _isAutoRoomViewport = true;
     _mainViewportHasChanged = false;
-    _roomViewportHasChanged = false;
-    _cameraHasChanged = false;
+
+    // Precreate primary viewport and camera
+    _roomViewports.push_back(PViewport(new Viewport()));
+    _roomCameras.push_back(PCamera(new Camera()));
+    _roomViewports[0]->LinkCamera(_roomCameras[0]);
+    _roomCameras[0]->LinkToViewport(_roomViewports[0]);
 }
 
 void GameState::Free()
@@ -66,186 +70,192 @@ Rect FixupViewport(const Rect &viewport, const Rect &parent)
 
 void GameState::SetMainViewport(const Rect &viewport)
 {
-    _mainViewport.Position = FixupViewport(viewport, RectWH(game.GetGameRes()));
+    _mainViewport.SetRect(FixupViewport(viewport, RectWH(game.GetGameRes())));
     Mouse::SetGraphicArea();
-    scsystem.viewport_width = game_to_data_coord(_mainViewport.Position.GetWidth());
-    scsystem.viewport_height = game_to_data_coord(_mainViewport.Position.GetHeight());
+    scsystem.viewport_width = game_to_data_coord(_mainViewport.GetRect().GetWidth());
+    scsystem.viewport_height = game_to_data_coord(_mainViewport.GetRect().GetHeight());
     _mainViewportHasChanged = true;
     // Update sub-viewports in case main viewport became smaller
-    SetUIViewport(_uiViewport.Position);
-    SetRoomViewport(_roomViewport.Position);
+    SetUIViewport(_uiViewport.GetRect());
+    for (size_t i = 0; i < _roomViewports.size(); ++i)
+        SetRoomViewport(i, _roomViewports[i]->GetRect());
 }
 
 const Rect &GameState::GetMainViewport() const
 {
-    return _mainViewport.Position;
+    return _mainViewport.GetRect();
 }
 
 const Rect &GameState::GetUIViewport() const
 {
-    return _uiViewport.Position;
+    return _uiViewport.GetRect();
 }
 
-const Rect &GameState::GetRoomViewport() const
+const Rect &GameState::GetRoomViewport(int index) const
 {
-    return _roomViewport.Position;
+    return _roomViewports[index]->GetRect();
+}
+
+PViewport GameState::GetRoomViewportObj(int index) const
+{
+    return _roomViewports[index];
+}
+
+PViewport GameState::GetRoomViewportAt(int x, int y) const
+{
+    for (auto vp : _roomViewports)
+        if (vp->GetRect().IsInside(x, y))
+            return vp;
+    return nullptr;
 }
 
 Rect GameState::GetUIViewportAbs() const
 {
-    return Rect::MoveBy(_uiViewport.Position, _mainViewport.Position.Left, _mainViewport.Position.Top);
+    return Rect::MoveBy(_uiViewport.GetRect(), _mainViewport.GetRect().Left, _mainViewport.GetRect().Top);
 }
 
-Rect GameState::GetRoomViewportAbs() const
+Rect GameState::GetRoomViewportAbs(int index) const
 {
-    return Rect::MoveBy(_roomViewport.Position, _mainViewport.Position.Left, _mainViewport.Position.Top);
+    return Rect::MoveBy(_roomViewports[index]->GetRect(), _mainViewport.GetRect().Left, _mainViewport.GetRect().Top);
 }
 
 void GameState::SetUIViewport(const Rect &viewport)
 {
-    _uiViewport.Position = FixupViewport(viewport, RectWH(_mainViewport.Position.GetSize()));
+    _uiViewport.SetRect(FixupViewport(viewport, RectWH(_mainViewport.GetRect().GetSize())));
 }
 
-void GameState::SetRoomViewport(const Rect &viewport)
+void GameState::SetRoomViewport(int index, const Rect &viewport)
 {
-    _roomViewport.Position = FixupViewport(viewport, RectWH(_mainViewport.Position.GetSize()));
-    AdjustRoomToViewport();
-    _roomViewportHasChanged = true;
+    _roomViewports[index]->SetRect(FixupViewport(viewport, RectWH(_mainViewport.GetRect().GetSize())));
 }
 
 void GameState::UpdateViewports()
 {
     if (_mainViewportHasChanged)
+    {
         on_mainviewport_changed();
-    if (_roomViewportHasChanged)
-        on_roomviewport_changed();
-    if (_cameraHasChanged)
-        on_camera_size_changed();
-    _mainViewportHasChanged = false;
-    _roomViewportHasChanged = false;
-    _cameraHasChanged = false;
+        _mainViewportHasChanged = false;
+    }
+    for (auto vp : _roomViewports)
+    {
+        if (vp->HasChanged())
+        {
+            on_roomviewport_changed(vp->GetID());
+            vp->ClearChangedFlag();
+        }
+    }
+    for (auto cam : _roomCameras)
+    {
+        if (cam->HasChanged())
+        {
+            on_camera_size_changed(cam->GetID());
+            cam->ClearChangedFlag();
+        }
+    }
 }
 
-const Rect &GameState::GetRoomCamera() const
+PCamera GameState::GetRoomCamera(int index) const
 {
-    return _roomCamera.Position;
+    return _roomCameras[index];
 }
 
-const RoomCamera &GameState::GetRoomCameraObj() const
+void GameState::UpdateRoomCameras()
 {
-    return _roomCamera;
+    for (size_t i = 0; i < _roomCameras.size(); ++i)
+        UpdateRoomCamera(i);
 }
 
-void GameState::SetRoomCameraSize(const Size &cam_size)
+void GameState::UpdateRoomCamera(int index)
 {
-    // TODO: currently we don't support having camera larger than room background
-    // (or rather - looking outside of the room background); look into this later
+    auto cam = _roomCameras[index];
+    const Rect &rc = cam->GetRect();
     const Size real_room_sz = Size(data_to_game_coord(thisroom.Width), data_to_game_coord(thisroom.Height));
-    Size real_size = Size::Clamp(cam_size, Size(1, 1), real_room_sz);
-
-    _roomCamera.Position.SetWidth(real_size.Width);
-    _roomCamera.Position.SetHeight(real_size.Height);
-    AdjustRoomToViewport();
-    _cameraHasChanged = true;
-}
-
-void GameState::SetRoomCameraAt(int x, int y)
-{
-    int cw = _roomCamera.Position.GetWidth();
-    int ch = _roomCamera.Position.GetHeight();
-    int room_width = data_to_game_coord(thisroom.Width);
-    int room_height = data_to_game_coord(thisroom.Height);
-    x = Math::Clamp(x, 0, room_width - cw);
-    y = Math::Clamp(y, 0, room_height - ch);
-    _roomCamera.Position.MoveTo(Point(x, y));
-}
-
-bool GameState::IsRoomCameraLocked() const
-{
-    return _roomCamera.Locked;
-}
-
-void GameState::LockRoomCamera()
-{
-    debug_script_log("Room camera locked");
-    _roomCamera.Locked = true;
-}
-
-void GameState::LockRoomCameraAt(int x, int y)
-{
-    debug_script_log("Room camera locked to %d,%d", x, y);
-    SetRoomCameraAt(x, y);
-    _roomCamera.Locked = true;
-}
-
-void GameState::ReleaseRoomCamera()
-{
-    _roomCamera.Locked = false;
-    debug_script_log("Room camera released back to engine control");
-}
-
-void GameState::UpdateRoomCamera()
-{
-    const Rect &camera = _roomCamera.Position;
-    const Size real_room_sz = Size(data_to_game_coord(thisroom.Width), data_to_game_coord(thisroom.Height));
-    if ((real_room_sz.Width > camera.GetWidth()) || (real_room_sz.Height > camera.GetHeight()))
+    if ((real_room_sz.Width > rc.GetWidth()) || (real_room_sz.Height > rc.GetHeight()))
     {
         // TODO: split out into Camera Behavior
-        if (!play.IsRoomCameraLocked())
+        if (!cam->IsLocked())
         {
-            int x = data_to_game_coord(playerchar->x) - camera.GetWidth() / 2;
-            int y = data_to_game_coord(playerchar->y) - camera.GetHeight() / 2;
-            SetRoomCameraAt(x, y);
+            int x = data_to_game_coord(playerchar->x) - rc.GetWidth() / 2;
+            int y = data_to_game_coord(playerchar->y) - rc.GetHeight() / 2;
+            cam->SetAt(x, y);
         }
     }
     else
     {
-        SetRoomCameraAt(0, 0);
+        cam->SetAt(0, 0);
     }
-}
-
-void GameState::AdjustRoomToViewport()
-{
-    _roomViewport.Transform.Init(_roomCamera.Position.GetSize(), _roomViewport.Position);
 }
 
 Point GameState::RoomToScreen(int roomx, int roomy)
 {
-    return _roomViewport.Transform.Scale(Point(roomx - _roomCamera.Position.Left, roomy - _roomCamera.Position.Top));
+    return _roomViewports[0]->GetTransform().Scale(Point(roomx - _roomCameras[0]->GetRect().Left, roomy - _roomCameras[0]->GetRect().Top));
 }
 
 int GameState::RoomToScreenX(int roomx)
 {
-    return _roomViewport.Transform.X.ScalePt(roomx - _roomCamera.Position.Left);
+    return _roomViewports[0]->GetTransform().X.ScalePt(roomx - _roomCameras[0]->GetRect().Left);
 }
 
 int GameState::RoomToScreenY(int roomy)
 {
-    return _roomViewport.Transform.Y.ScalePt(roomy - _roomCamera.Position.Top);
+    return _roomViewports[0]->GetTransform().Y.ScalePt(roomy - _roomCameras[0]->GetRect().Top);
 }
 
-VpPoint GameState::ScreenToRoom(int scrx, int scry, bool clip_viewport)
+VpPoint GameState::ScreenToRoomImpl(int scrx, int scry, int view_index, bool clip_viewport, bool convert_cam_to_data)
 {
     clip_viewport &= game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v3507;
     Point screen_pt(scrx, scry);
-    if (clip_viewport && !_roomViewport.Position.IsInside(screen_pt))
-        return std::make_pair(Point(), -1);
-    Point p = _roomViewport.Transform.UnScale(screen_pt);
-    p.X += _roomCamera.Position.Left;
-    p.Y += _roomCamera.Position.Top;
+    PViewport view;
+    if (view_index < 0)
+    {
+        view = GetRoomViewportAt(scrx, scry);
+        if (!view)
+            return std::make_pair(Point(), -1);
+    }
+    else
+    {
+        view = _roomViewports[view_index];
+        if (clip_viewport && !view->GetRect().IsInside(screen_pt))
+            return std::make_pair(Point(), -1);
+    }
+    
+    Point p = view->GetTransform().UnScale(screen_pt);
+    auto cam = view->GetCamera();
+    if (convert_cam_to_data)
+    {
+        p.X += game_to_data_coord(cam->GetRect().Left);
+        p.Y += game_to_data_coord(cam->GetRect().Top);
+    }
+    else
+    {
+        p.X += cam->GetRect().Left;
+        p.Y += cam->GetRect().Top;
+    }
     return std::make_pair(p, 0);
 }
 
-VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry, bool clip_viewport)
+VpPoint GameState::ScreenToRoom(int scrx, int scry)
 {
-    clip_viewport &= game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v3507;
-    Point screen_pt(scrx, scry);
-    if (clip_viewport && !_roomViewport.Position.IsInside(screen_pt))
-        return std::make_pair(Point(), -1);
-    Point p = _roomViewport.Transform.UnScale(screen_pt);
-    p.X += game_to_data_coord(_roomCamera.Position.Left);
-    p.Y += game_to_data_coord(_roomCamera.Position.Top);
-    return std::make_pair(p, 0);
+    return ScreenToRoomImpl(scrx, scry, -1, true, false);
+}
+
+VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry)
+{
+    return ScreenToRoomImpl(scrx, scry, -1, true, true);
+}
+
+VpPoint GameState::ScreenToRoom(int scrx, int scry, int view_index, bool clip_viewport)
+{
+    if ((size_t)view_index >= _roomViewports.size())
+        return VpPoint(Point(), -1);
+    return ScreenToRoomImpl(scrx, scry, view_index, clip_viewport, false);
+}
+
+VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry, int view_index, bool clip_viewport)
+{
+    if ((size_t)view_index >= _roomViewports.size())
+        return VpPoint(Point(), -1);
+    return ScreenToRoomImpl(scrx, scry, view_index, clip_viewport, true);
 }
 
 bool GameState::IsBlockingVoiceSpeech() const
@@ -386,9 +396,9 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     screen_flipped = in->ReadInt16();
     short offsets_locked = in->ReadInt16();
     if (offsets_locked != 0)
-        LockRoomCamera();
+        _roomCameras[0]->Lock();
     else
-        ReleaseRoomCamera();
+        _roomCameras[0]->Release();
     entered_at_x = in->ReadInt32();
     entered_at_y = in->ReadInt32();
     entered_edge = in->ReadInt32();
@@ -600,7 +610,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32( digital_master_volume);
     out->Write(walkable_areas_on, MAX_WALK_AREAS+1);
     out->WriteInt16( screen_flipped);
-    out->WriteInt16( IsRoomCameraLocked() ? 1 : 0 );
+    out->WriteInt16( _roomCameras[0]->IsLocked() ? 1 : 0 );
     out->WriteInt32( entered_at_x);
     out->WriteInt32( entered_at_y);
     out->WriteInt32( entered_edge);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -36,6 +36,8 @@ namespace AGS { namespace Common {
     typedef stdtr1compat::shared_ptr<Bitmap> PBitmap;
 } }
 using namespace AGS; // FIXME later
+struct ScriptViewport;
+struct ScriptCamera;
 
 #define GAME_STATE_RESERVED_INTS 5
 
@@ -288,6 +290,28 @@ struct GameState {
     VpPoint ScreenToRoom(int scrx, int scry, int view_index, bool clip_viewport);
     VpPoint ScreenToRoomDivDown(int scrx, int scry, int view_index, bool clip_viewport); // native "variadic" coords variant
 
+    // Creates new room viewport
+    PViewport CreateRoomViewport();
+    // Deletes existing room viewport
+    void DeleteRoomViewport(int index);
+    // Get number of room viewports
+    int GetRoomViewportCount() const;
+    // Creates new room camera
+    PCamera CreateRoomCamera();
+    // Deletes existing room camera
+    void DeleteRoomCamera(int index);
+    // Get number of room cameras
+    int GetRoomCameraCount() const;
+    // Gets script viewport reference; does NOT increment refcount
+    // because script interpreter does this when acquiring managed pointer.
+    ScriptViewport *GetScriptViewport(int index);
+    // Gets script camera reference; does NOT increment refcount
+    // because script interpreter does this when acquiring managed pointer.
+    ScriptCamera *GetScriptCamera(int index);
+
+    //
+    // Voice speech management
+    //
     // Tells if there's a blocking voice speech playing right now
     bool IsBlockingVoiceSpeech() const;
     // Tells whether we have to finalize voice speech when stopping or reusing the channel
@@ -295,7 +319,9 @@ struct GameState {
     // Speech helpers
     bool ShouldPlayVoiceSpeech() const;
 
+    //
     // Serialization
+    //
     void ReadQueuedAudioItems_Aligned(Common::Stream *in);
     void ReadCustomProperties_v340(Common::Stream *in);
     void WriteCustomProperties_v340(Common::Stream *out) const;
@@ -319,6 +345,11 @@ private:
     std::vector<PViewport> _roomViewports;
     // Cameras defines the position of a "looking eye" inside the room.
     std::vector<PCamera> _roomCameras;
+    // Script viewports and cameras are references to real data export to
+    // user script. They became invalidated as the actual object gets
+    // destroyed, but are kept in memory to prevent script errors.
+    std::vector<std::pair<ScriptViewport*, int32_t>> _scViewportRefs;
+    std::vector<std::pair<ScriptCamera*, int32_t>> _scCameraRefs;
 
     // Tells that the main viewport's position has changed since last game update
     bool  _mainViewportHasChanged;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -48,6 +48,7 @@ enum GameStateSvgVersion
     kGSSvgVersion_Initial   = 0,
     kGSSvgVersion_350       = 1,
     kGSSvgVersion_3509      = 2,
+    kGSSvgVersion_3510      = 3,
 };
 
 // A result of coordinate conversion between screen and the room,
@@ -298,12 +299,16 @@ struct GameState {
 
     // Creates new room viewport
     PViewport CreateRoomViewport();
+    // Register camera in the managed system; optionally links to existing handle
+    ScriptViewport *RegisterRoomViewport(int index, int32_t handle = 0);
     // Deletes existing room viewport
     void DeleteRoomViewport(int index);
     // Get number of room viewports
     int GetRoomViewportCount() const;
     // Creates new room camera
     PCamera CreateRoomCamera();
+    // Register camera in the managed system; optionally links to existing handle
+    ScriptCamera *RegisterRoomCamera(int index, int32_t handle = 0);
     // Deletes existing room camera
     void DeleteRoomCamera(int index);
     // Get number of room cameras
@@ -334,6 +339,7 @@ struct GameState {
     void ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver);
     void WriteForSavegame(Common::Stream *out) const;
     void FreeProperties();
+    void FreeViewportsAndCameras();
 
 private:
     VpPoint ScreenToRoomImpl(int scrx, int scry, int view_index, bool clip_viewport, bool convert_cam_to_data);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -249,8 +249,10 @@ struct GameState {
     const Rect &GetUIViewport() const;
     // Returns Room viewport position, which works as a "window" into the room
     const Rect &GetRoomViewport(int index) const;
-    // Returns Room viewport object by index
+    // Returns Room viewport object by it's main index
     PViewport  GetRoomViewportObj(int index) const;
+    // Returns Room viewport object by index in z-order
+    PViewport  GetRoomViewportZOrdered(int index) const;
     // Finds room viewport at the given screen coordinates; returns nullptr if non found
     PViewport  GetRoomViewportAt(int x, int y) const;
     // Returns UI viewport position in absolute coordinates (with main viewport offset)
@@ -266,8 +268,12 @@ struct GameState {
     void SetUIViewport(const Rect &viewport);
     // Room viewport defines location of a room view inside the main viewport.
     void SetRoomViewport(int index, const Rect &viewport);
-    // Applies all the pending changes to viewports and cameras
+    // Applies all the pending changes to viewports and cameras;
+    // NOTE: this function may be slow, thus recommended to be called only once
+    // and during the main game update.
     void UpdateViewports();
+    // Notifies game state that viewports need z-order resorting upon next update.
+    void InvalidateViewportZOrder();
     // Returns room camera object chosen by index
     PCamera GetRoomCamera(int index) const;
     // Runs cameras behaviors
@@ -343,6 +349,8 @@ private:
     // Room viewports define place on screen where the room camera's
     // contents are drawn.
     std::vector<PViewport> _roomViewports;
+    // Vector of viewports sorted in z-order.
+    std::vector<PViewport> _roomViewportsSorted;
     // Cameras defines the position of a "looking eye" inside the room.
     std::vector<PCamera> _roomCameras;
     // Script viewports and cameras are references to real data export to
@@ -353,6 +361,8 @@ private:
 
     // Tells that the main viewport's position has changed since last game update
     bool  _mainViewportHasChanged;
+    // Tells that room viewports need z-order resort
+    bool  _roomViewportZOrderChanged;
 };
 
 // Converts legacy alignment type used in script API

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -107,8 +107,8 @@ void script_debug(int cmdd,int dataa) {
         // TODO: support multiple viewports?!
         Bitmap *tempw=BitmapHelper::CreateBitmap(thisroom.WalkAreaMask->GetWidth(),thisroom.WalkAreaMask->GetHeight());
         tempw->Blit(prepare_walkable_areas(-1),0,0,0,0,tempw->GetWidth(),tempw->GetHeight());
-        const Rect &viewport = play.GetRoomViewport();
-        const Rect &camera = play.GetRoomCamera();
+        const Rect &viewport = play.GetRoomViewport(0);
+        const Rect &camera = play.GetRoomCamera(0)->GetRect();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
         Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);
@@ -165,8 +165,8 @@ void script_debug(int cmdd,int dataa) {
             tempw->DrawLine(Line(srcx, srcy, targetx, targety), MakeColor(i+1));
         }
 
-        const Rect &viewport = play.GetRoomViewport();
-        const Rect &camera = play.GetRoomCamera();
+        const Rect &viewport = play.GetRoomViewport(0);
+        const Rect &camera = play.GetRoomCamera(0)->GetRect();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
         Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -105,10 +105,12 @@ void script_debug(int cmdd,int dataa) {
     else if (cmdd==2) 
     {  // show walkable areas from here
         // TODO: support multiple viewports?!
+        const int viewport_index = 0;
+        const int camera_index = 0;
         Bitmap *tempw=BitmapHelper::CreateBitmap(thisroom.WalkAreaMask->GetWidth(),thisroom.WalkAreaMask->GetHeight());
         tempw->Blit(prepare_walkable_areas(-1),0,0,0,0,tempw->GetWidth(),tempw->GetHeight());
-        const Rect &viewport = play.GetRoomViewport(0);
-        const Rect &camera = play.GetRoomCamera(0)->GetRect();
+        const Rect &viewport = play.GetRoomViewport(viewport_index);
+        const Rect &camera = play.GetRoomCamera(camera_index)->GetRect();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
         Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);
@@ -165,8 +167,11 @@ void script_debug(int cmdd,int dataa) {
             tempw->DrawLine(Line(srcx, srcy, targetx, targety), MakeColor(i+1));
         }
 
-        const Rect &viewport = play.GetRoomViewport(0);
-        const Rect &camera = play.GetRoomCamera(0)->GetRect();
+        // TODO: support multiple viewports?!
+        const int viewport_index = 0;
+        const int camera_index = 0;
+        const Rect &viewport = play.GetRoomViewport(viewport_index);
+        const Rect &camera = play.GetRoomCamera(camera_index)->GetRect();
         Bitmap *view_bmp = BitmapHelper::CreateBitmap(viewport.GetWidth(), viewport.GetHeight());
         Rect mask_src = Rect(camera.Left / thisroom.MaskResolution, camera.Top / thisroom.MaskResolution, camera.Right / thisroom.MaskResolution, camera.Bottom / thisroom.MaskResolution);
         view_bmp->StretchBlt(tempw, mask_src, RectWH(0, 0, viewport.GetWidth(), viewport.GetHeight()), Common::kBitmap_Transparency);

--- a/Engine/ac/global_screen.cpp
+++ b/Engine/ac/global_screen.cpp
@@ -40,8 +40,6 @@ extern color palette[256];
 extern unsigned int loopcounter;
 extern int wasShakingScreen;
 
-int screen_reset = 0;
-
 void FlipScreen(int amount) {
     if ((amount<0) | (amount>3)) quit("!FlipScreen: invalid argument (0-3)");
     play.screen_flipped=amount;

--- a/Engine/ac/global_viewport.cpp
+++ b/Engine/ac/global_viewport.cpp
@@ -19,14 +19,14 @@
 void SetViewport(int offsx, int offsy) {
     offsx = data_to_game_coord(offsx);
     offsy = data_to_game_coord(offsy);
-    play.LockRoomCameraAt(offsx, offsy);
+    play.GetRoomCamera(0)->LockAt(offsx, offsy);
 }
 void ReleaseViewport() {
-    play.ReleaseRoomCamera();
+    play.GetRoomCamera(0)->Release();
 }
 int GetViewportX () {
-    return game_to_data_coord(play.GetRoomCamera().Left);
+    return game_to_data_coord(play.GetRoomCamera(0)->GetRect().Left);
 }
 int GetViewportY () {
-    return game_to_data_coord(play.GetRoomCamera().Top);
+    return game_to_data_coord(play.GetRoomCamera(0)->GetRect().Top);
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -477,6 +477,10 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     int cc;
     done_es_error = 0;
     play.room_changes ++;
+    // TODO: find out why do we need to temporarily lower color depth to 8-bit.
+    // Or do we? There's a serious usability problem in this: if any bitmap is
+    // created meanwhile it will have this color depth by default, which may
+    // lead to unexpected errors.
     set_color_depth(8);
     displayed_room=newnum;
 
@@ -542,8 +546,6 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         update_letterbox_mode();
     if (play.IsAutoRoomViewport())
         adjust_viewport_to_room();
-    update_all_viewcams_with_newroom();
-    init_room_drawdata();
 
     SetMouseBounds(0, 0, 0, 0);
 
@@ -570,6 +572,9 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     convert_room_background_to_game_res();
     recache_walk_behinds();
     update_polled_stuff_if_runtime();
+
+    update_all_viewcams_with_newroom();
+    init_room_drawdata();
 
     our_eip=205;
     // setup objects

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -228,7 +228,7 @@ ScriptCamera* Room_CreateCamera()
     auto cam = play.CreateRoomCamera();
     if (!cam)
         return NULL;
-    return play.GetScriptCamera(cam->GetID());
+    return play.RegisterRoomCamera(cam->GetID());
 }
 
 void Room_RemoveCamera(int index)

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -456,6 +456,18 @@ static void adjust_viewport_to_room()
     play.GetRoomCamera(0)->SetSize(new_room_view.GetSize());
 }
 
+// Run through all viewports and cameras to make sure they can work in new room's bounds
+static void update_all_viewcams_with_newroom()
+{
+    for (int i = 0; i < play.GetRoomCameraCount(); ++i)
+    {
+        auto cam = play.GetRoomCamera(i);
+        const Rect old_pos = cam->GetRect();
+        cam->SetSize(old_pos.GetSize());
+        cam->SetAt(old_pos.Left, old_pos.Top);
+    }
+}
+
 // forchar = playerchar on NewRoom, or NULL if restore saved game
 void load_new_room(int newnum, CharacterInfo*forchar) {
 
@@ -530,6 +542,8 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         update_letterbox_mode();
     if (play.IsAutoRoomViewport())
         adjust_viewport_to_room();
+    update_all_viewcams_with_newroom();
+    init_room_drawdata();
 
     SetMouseBounds(0, 0, 0, 0);
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -213,6 +213,29 @@ ScriptCamera* Room_GetCamera()
     return play.GetScriptCamera(0);
 }
 
+int Room_GetCameraCount()
+{
+    return play.GetRoomCameraCount();
+}
+
+ScriptCamera* Room_GetAnyCamera(int index)
+{
+    return play.GetScriptCamera(index);
+}
+
+ScriptCamera* Room_CreateCamera()
+{
+    auto cam = play.CreateRoomCamera();
+    if (!cam)
+        return NULL;
+    return play.GetScriptCamera(cam->GetID());
+}
+
+void Room_RemoveCamera(int index)
+{
+    play.DeleteRoomCamera(index);
+}
+
 
 //=============================================================================
 
@@ -1159,6 +1182,26 @@ RuntimeScriptValue Sc_Room_GetCamera(const RuntimeScriptValue *params, int32_t p
     API_SCALL_OBJAUTO(ScriptCamera, Room_GetCamera);
 }
 
+RuntimeScriptValue Sc_Room_GetCameraCount(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Room_GetCameraCount);
+}
+
+RuntimeScriptValue Sc_Room_GetAnyCamera(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PINT(ScriptCamera, Room_GetAnyCamera);
+}
+
+RuntimeScriptValue Sc_Room_CreateCamera(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptCamera, Room_CreateCamera);
+}
+
+RuntimeScriptValue Sc_Room_RemoveCamera(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(ScriptCamera, Room_RemoveCamera);
+}
+
 
 void RegisterRoomAPI()
 {
@@ -1180,6 +1223,10 @@ void RegisterRoomAPI()
     ccAddExternalStaticFunction("Room::get_TopEdge",                        Sc_Room_GetTopEdge);
     ccAddExternalStaticFunction("Room::get_Width",                          Sc_Room_GetWidth);
     ccAddExternalStaticFunction("Room::get_Camera",                         Sc_Room_GetCamera);
+    ccAddExternalStaticFunction("Room::get_CameraCount",                    Sc_Room_GetCameraCount);
+    ccAddExternalStaticFunction("Room::geti_Cameras",                       Sc_Room_GetAnyCamera);
+    ccAddExternalStaticFunction("Room::CreateCamera",                       Sc_Room_CreateCamera);
+    ccAddExternalStaticFunction("Room::RemoveCamera",                       Sc_Room_RemoveCamera);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -210,9 +210,7 @@ const char* Room_GetMessages(int index) {
 
 ScriptCamera* Room_GetCamera()
 {
-    ScriptCamera *camera = new ScriptCamera(0);
-    ccRegisterManagedObject(camera, camera);
-    return camera;
+    return play.GetScriptCamera(0);
 }
 
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1199,7 +1199,7 @@ RuntimeScriptValue Sc_Room_CreateCamera(const RuntimeScriptValue *params, int32_
 
 RuntimeScriptValue Sc_Room_RemoveCamera(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_VOID_PINT(ScriptCamera, Room_RemoveCamera);
+    API_SCALL_VOID_PINT(Room_RemoveCamera);
 }
 
 

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -137,9 +137,7 @@ void Screen_SetAutoSizeViewport(bool on)
 
 ScriptViewport* Screen_GetViewport()
 {
-    ScriptViewport *viewport = new ScriptViewport(0);
-    ccRegisterManagedObject(viewport, viewport);
-    return viewport;
+    return play.GetScriptViewport(0);
 }
 
 ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry)

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -137,7 +137,7 @@ void Screen_SetAutoSizeViewport(bool on)
 
 ScriptViewport* Screen_GetViewport()
 {
-    ScriptViewport *viewport = new ScriptViewport();
+    ScriptViewport *viewport = new ScriptViewport(0);
     ccRegisterManagedObject(viewport, viewport);
     return viewport;
 }

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -140,6 +140,29 @@ ScriptViewport* Screen_GetViewport()
     return play.GetScriptViewport(0);
 }
 
+int Screen_GetViewportCount()
+{
+    return play.GetRoomViewportCount();
+}
+
+ScriptViewport* Screen_GetAnyViewport(int index)
+{
+    return play.GetScriptViewport(index);
+}
+
+ScriptViewport* Screen_CreateViewport()
+{
+    auto view = play.CreateRoomViewport();
+    if (!view)
+        return NULL;
+    return play.GetScriptViewport(view->GetID());
+}
+
+void Screen_RemoveViewport(int index)
+{
+    play.DeleteRoomViewport(index);
+}
+
 ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry)
 {
     data_to_game_coords(&scrx, &scry);
@@ -185,6 +208,26 @@ RuntimeScriptValue Sc_Screen_GetViewport(const RuntimeScriptValue *params, int32
     API_SCALL_OBJAUTO(ScriptViewport, Screen_GetViewport);
 }
 
+RuntimeScriptValue Sc_Screen_GetViewportCount(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Screen_GetViewportCount);
+}
+
+RuntimeScriptValue Sc_Screen_GetAnyViewport(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PINT(ScriptViewport, Screen_GetAnyViewport);
+}
+
+RuntimeScriptValue Sc_Screen_CreateViewport(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptViewport, Screen_CreateViewport);
+}
+
+RuntimeScriptValue Sc_Screen_RemoveViewport(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Screen_RemoveViewport);
+}
+
 RuntimeScriptValue Sc_Screen_ScreenToRoomPoint(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_PINT2(ScriptUserObject, Screen_ScreenToRoomPoint);
@@ -202,6 +245,10 @@ void RegisterScreenAPI()
     ccAddExternalStaticFunction("Screen::get_AutoSizeViewportOnRoomLoad", Sc_Screen_GetAutoSizeViewport);
     ccAddExternalStaticFunction("Screen::set_AutoSizeViewportOnRoomLoad", Sc_Screen_SetAutoSizeViewport);
     ccAddExternalStaticFunction("Screen::get_Viewport", Sc_Screen_GetViewport);
+    ccAddExternalStaticFunction("Screen::get_ViewportCount", Sc_Screen_GetViewportCount);
+    ccAddExternalStaticFunction("Screen::geti_Viewports", Sc_Screen_GetAnyViewport);
+    ccAddExternalStaticFunction("Screen::CreateViewport", Sc_Screen_CreateViewport);
+    ccAddExternalStaticFunction("Screen::RemoveViewport", Sc_Screen_RemoveViewport);
     ccAddExternalStaticFunction("Screen::ScreenToRoomPoint", Sc_Screen_ScreenToRoomPoint);
     ccAddExternalStaticFunction("Screen::RoomToScreenPoint", Sc_Screen_RoomToScreenPoint);
 }

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -155,7 +155,7 @@ ScriptViewport* Screen_CreateViewport()
     auto view = play.CreateRoomViewport();
     if (!view)
         return NULL;
-    return play.GetScriptViewport(view->GetID());
+    return play.RegisterRoomViewport(view->GetID());
 }
 
 void Screen_RemoveViewport(int index)

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -268,6 +268,21 @@ void Viewport_SetVisible(ScriptViewport *scv, bool on)
         view->SetVisible(on);
 }
 
+int Viewport_GetZOrder(ScriptViewport *scv)
+{
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    if (view != nullptr)
+        return view->GetZOrder();
+    return 0;
+}
+
+void Viewport_SetZOrder(ScriptViewport *scv, int zorder)
+{
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    if (view != nullptr)
+        view->SetZOrder(zorder);
+}
+
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 {
     data_to_game_coords(&x, &y);
@@ -369,6 +384,16 @@ RuntimeScriptValue Sc_Viewport_SetVisible(void *self, const RuntimeScriptValue *
     API_OBJCALL_VOID_PBOOL(ScriptViewport, Viewport_SetVisible);
 }
 
+RuntimeScriptValue Sc_Viewport_GetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptViewport, Viewport_GetZOrder);
+}
+
+RuntimeScriptValue Sc_Viewport_SetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptViewport, Viewport_SetZOrder);
+}
+
 RuntimeScriptValue Sc_Viewport_GetAtScreenXY(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_PINT2(ScriptViewport, Viewport_GetAtScreenXY);
@@ -418,6 +443,8 @@ void RegisterViewportAPI()
     ccAddExternalObjectFunction("Viewport::set_Camera", Sc_Viewport_SetCamera);
     ccAddExternalObjectFunction("Viewport::get_Visible", Sc_Viewport_GetVisible);
     ccAddExternalObjectFunction("Viewport::set_Visible", Sc_Viewport_SetVisible);
+    ccAddExternalObjectFunction("Viewport::get_ZOrder", Sc_Viewport_GetZOrder);
+    ccAddExternalObjectFunction("Viewport::set_ZOrder", Sc_Viewport_SetZOrder);
     ccAddExternalObjectFunction("Viewport::GetAtScreenXY", Sc_Viewport_GetAtScreenXY);
     ccAddExternalObjectFunction("Viewport::SetPosition", Sc_Viewport_SetPosition);
     ccAddExternalObjectFunction("Viewport::ScreenToRoomPoint", Sc_Viewport_ScreenToRoomPoint);

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -242,6 +242,17 @@ ScriptCamera* Viewport_GetCamera(ScriptViewport *scv)
     return play.GetScriptCamera(cam->GetID());
 }
 
+void Viewport_SetCamera(ScriptViewport *scv, ScriptCamera *scam)
+{
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    auto cam = play.GetRoomCamera(scam->GetID());
+    if (view != nullptr && cam != nullptr)
+    {
+        view->LinkCamera(cam);
+        cam->LinkToViewport(view);
+    }
+}
+
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 {
     data_to_game_coords(&x, &y);
@@ -328,6 +339,11 @@ RuntimeScriptValue Sc_Viewport_GetCamera(void *self, const RuntimeScriptValue *p
     API_OBJCALL_OBJAUTO(ScriptViewport, ScriptCamera, Viewport_GetCamera);
 }
 
+RuntimeScriptValue Sc_Viewport_SetCamera(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ(ScriptViewport, Viewport_SetCamera, ScriptCamera);
+}
+
 RuntimeScriptValue Sc_Viewport_GetAtScreenXY(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_PINT2(ScriptViewport, Viewport_GetAtScreenXY);
@@ -374,6 +390,7 @@ void RegisterViewportAPI()
     ccAddExternalObjectFunction("Viewport::get_Height", Sc_Viewport_GetHeight);
     ccAddExternalObjectFunction("Viewport::set_Height", Sc_Viewport_SetHeight);
     ccAddExternalObjectFunction("Viewport::get_Camera", Sc_Viewport_GetCamera);
+    ccAddExternalObjectFunction("Viewport::set_Camera", Sc_Viewport_SetCamera);
     ccAddExternalObjectFunction("Viewport::GetAtScreenXY", Sc_Viewport_GetAtScreenXY);
     ccAddExternalObjectFunction("Viewport::SetPosition", Sc_Viewport_SetPosition);
     ccAddExternalObjectFunction("Viewport::ScreenToRoomPoint", Sc_Viewport_ScreenToRoomPoint);

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -253,6 +253,21 @@ void Viewport_SetCamera(ScriptViewport *scv, ScriptCamera *scam)
     }
 }
 
+bool Viewport_GetVisible(ScriptViewport *scv)
+{
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    if (view != nullptr)
+        return view->IsVisible();
+    return false;
+}
+
+void Viewport_SetVisible(ScriptViewport *scv, bool on)
+{
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    if (view != nullptr)
+        view->SetVisible(on);
+}
+
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 {
     data_to_game_coords(&x, &y);
@@ -344,6 +359,16 @@ RuntimeScriptValue Sc_Viewport_SetCamera(void *self, const RuntimeScriptValue *p
     API_OBJCALL_VOID_POBJ(ScriptViewport, Viewport_SetCamera, ScriptCamera);
 }
 
+RuntimeScriptValue Sc_Viewport_GetVisible(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptViewport, Viewport_GetVisible);
+}
+
+RuntimeScriptValue Sc_Viewport_SetVisible(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PBOOL(ScriptViewport, Viewport_SetVisible);
+}
+
 RuntimeScriptValue Sc_Viewport_GetAtScreenXY(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJAUTO_PINT2(ScriptViewport, Viewport_GetAtScreenXY);
@@ -391,6 +416,8 @@ void RegisterViewportAPI()
     ccAddExternalObjectFunction("Viewport::set_Height", Sc_Viewport_SetHeight);
     ccAddExternalObjectFunction("Viewport::get_Camera", Sc_Viewport_GetCamera);
     ccAddExternalObjectFunction("Viewport::set_Camera", Sc_Viewport_SetCamera);
+    ccAddExternalObjectFunction("Viewport::get_Visible", Sc_Viewport_GetVisible);
+    ccAddExternalObjectFunction("Viewport::set_Visible", Sc_Viewport_SetVisible);
     ccAddExternalObjectFunction("Viewport::GetAtScreenXY", Sc_Viewport_GetAtScreenXY);
     ccAddExternalObjectFunction("Viewport::SetPosition", Sc_Viewport_SetPosition);
     ccAddExternalObjectFunction("Viewport::ScreenToRoomPoint", Sc_Viewport_ScreenToRoomPoint);

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -236,9 +236,10 @@ void Viewport_SetHeight(ScriptViewport *scv, int height)
 ScriptCamera* Viewport_GetCamera(ScriptViewport *scv)
 {
     auto view = play.GetRoomViewportObj(scv->GetID());
-    ScriptCamera *camera = new ScriptCamera(view->GetCamera()->GetID());
-    ccRegisterManagedObject(camera, camera);
-    return camera;
+    auto cam = view->GetCamera();
+    if (!cam)
+        return nullptr;
+    return play.GetScriptCamera(cam->GetID());
 }
 
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
@@ -247,9 +248,7 @@ ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
     PViewport view = play.GetRoomViewportAt(x, y);
     if (!view)
         return nullptr;
-    ScriptViewport *viewport = new ScriptViewport(view->GetID());
-    ccRegisterManagedObject(viewport, viewport);
-    return viewport;
+    return play.GetScriptViewport(view->GetID());
 }
 
 void Viewport_SetPosition(ScriptViewport *scv, int x, int y, int width, int height)

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -32,77 +32,82 @@ using namespace AGS::Common;
 //
 //=============================================================================
 
-int Camera_GetX(ScriptCamera *)
+int Camera_GetX(ScriptCamera *scam)
 {
-    int x = play.GetRoomCameraObj().Position.Left;
+    int x = play.GetRoomCamera(scam->GetID())->GetRect().Left;
     return game_to_data_coord(x);
 }
 
-void Camera_SetX(ScriptCamera *, int x)
+void Camera_SetX(ScriptCamera *scam, int x)
 {
     x = data_to_game_coord(x);
-    play.LockRoomCameraAt(x, play.GetRoomCameraObj().Position.Top);
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->LockAt(x, cam->GetRect().Top);
 }
 
-int Camera_GetY(ScriptCamera *)
+int Camera_GetY(ScriptCamera *scam)
 {
-    int y = play.GetRoomCameraObj().Position.Top;
+    int y = play.GetRoomCamera(scam->GetID())->GetRect().Top;
     return game_to_data_coord(y);
 }
 
-void Camera_SetY(ScriptCamera *, int y)
+void Camera_SetY(ScriptCamera *scam, int y)
 {
     y = data_to_game_coord(y);
-    play.LockRoomCameraAt(play.GetRoomCameraObj().Position.Left, y);
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->LockAt(cam->GetRect().Left, y);
 }
 
-int Camera_GetWidth(ScriptCamera *)
+int Camera_GetWidth(ScriptCamera *scam)
 {
-    int width = play.GetRoomCameraObj().Position.GetWidth();
+    int width = play.GetRoomCamera(scam->GetID())->GetRect().GetWidth();
     return game_to_data_coord(width);
 }
 
-void Camera_SetWidth(ScriptCamera *, int width)
+void Camera_SetWidth(ScriptCamera *scam, int width)
 {
     width = data_to_game_coord(width);
-    play.SetRoomCameraSize(Size(width, play.GetRoomCamera().GetHeight()));
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetSize(Size(width, cam->GetRect().GetHeight()));
 }
 
-int Camera_GetHeight(ScriptCamera *)
+int Camera_GetHeight(ScriptCamera *scam)
 {
-    int height = play.GetRoomCameraObj().Position.GetHeight();
+    int height = play.GetRoomCamera(scam->GetID())->GetRect().GetHeight();
     return game_to_data_coord(height);
 }
 
-void Camera_SetHeight(ScriptCamera *, int height)
+void Camera_SetHeight(ScriptCamera *scam, int height)
 {
     height = data_to_game_coord(height);
-    play.SetRoomCameraSize(Size(play.GetRoomCamera().GetWidth(), height));
+    auto cam = play.GetRoomCamera(scam->GetID());
+    cam->SetSize(Size(cam->GetRect().GetWidth(), height));
 }
 
-bool Camera_GetAutoTracking(ScriptCamera *)
+bool Camera_GetAutoTracking(ScriptCamera *scam)
 {
-    return !play.IsRoomCameraLocked();
+    return !play.GetRoomCamera(scam->GetID())->IsLocked();
 }
 
-void Camera_SetAutoTracking(ScriptCamera *, bool on)
+void Camera_SetAutoTracking(ScriptCamera *scam, bool on)
 {
+    auto cam = play.GetRoomCamera(scam->GetID());
     if (on)
-        play.ReleaseRoomCamera(); 
+        cam->Release();
     else
-        play.LockRoomCamera();
+        cam->Lock();
 }
 
-void Camera_SetAt(ScriptCamera *, int x, int y)
+void Camera_SetAt(ScriptCamera *scam, int x, int y)
 {
     data_to_game_coords(&x, &y);
-    play.LockRoomCameraAt(x, y);
+    play.GetRoomCamera(scam->GetID())->LockAt(x, y);
 }
 
-void Camera_SetSize(ScriptCamera *, int width, int height)
+void Camera_SetSize(ScriptCamera *scam, int width, int height)
 {
     data_to_game_coords(&width, &height);
-    play.SetRoomCameraSize(Size(width, height));
+    play.GetRoomCamera(scam->GetID())->SetSize(Size(width, height));
 }
 
 RuntimeScriptValue Sc_Camera_GetX(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -172,65 +177,66 @@ RuntimeScriptValue Sc_Camera_SetSize(void *self, const RuntimeScriptValue *param
 //
 //=============================================================================
 
-int Viewport_GetX(ScriptViewport *view)
+int Viewport_GetX(ScriptViewport *scv)
 {
-    int x = play.GetRoomViewport().Left;
+    int x = play.GetRoomViewport(scv->GetID()).Left;
     return game_to_data_coord(x);
 }
 
-void Viewport_SetX(ScriptViewport *, int x)
+void Viewport_SetX(ScriptViewport *scv, int x)
 {
     x = data_to_game_coord(x);
-    Rect view = play.GetRoomViewport();
+    Rect view = play.GetRoomViewport(scv->GetID());
     view.MoveToX(x);
-    play.SetRoomViewport(view);
+    play.SetRoomViewport(scv->GetID(), view);
 }
 
-int Viewport_GetY(ScriptViewport *)
+int Viewport_GetY(ScriptViewport *scv)
 {
-    int y = play.GetRoomViewport().Top;
+    int y = play.GetRoomViewport(scv->GetID()).Top;
     return game_to_data_coord(y);
 }
 
-void Viewport_SetY(ScriptViewport *, int y)
+void Viewport_SetY(ScriptViewport *scv, int y)
 {
     y = data_to_game_coord(y);
-    Rect view = play.GetRoomViewport();
+    Rect view = play.GetRoomViewport(scv->GetID());
     view.MoveToY(y);
-    play.SetRoomViewport(view);
+    play.SetRoomViewport(scv->GetID(), view);
 }
 
-int Viewport_GetWidth(ScriptViewport *)
+int Viewport_GetWidth(ScriptViewport *scv)
 {
-    int width = play.GetRoomViewport().GetWidth();
+    int width = play.GetRoomViewport(scv->GetID()).GetWidth();
     return game_to_data_coord(width);
 }
 
-void Viewport_SetWidth(ScriptViewport *, int width)
+void Viewport_SetWidth(ScriptViewport *scv, int width)
 {
     width = data_to_game_coord(width);
-    Rect view = play.GetRoomViewport();
+    Rect view = play.GetRoomViewport(scv->GetID());
     view.SetWidth(width);
-    play.SetRoomViewport(view);
+    play.SetRoomViewport(scv->GetID(), view);
 }
 
-int Viewport_GetHeight(ScriptViewport *)
+int Viewport_GetHeight(ScriptViewport *scv)
 {
-    int height = play.GetRoomViewport().GetHeight();
+    int height = play.GetRoomViewport(scv->GetID()).GetHeight();
     return game_to_data_coord(height);
 }
 
-void Viewport_SetHeight(ScriptViewport *, int height)
+void Viewport_SetHeight(ScriptViewport *scv, int height)
 {
     height = data_to_game_coord(height);
-    Rect view = play.GetRoomViewport();
+    Rect view = play.GetRoomViewport(scv->GetID());
     view.SetHeight(height);
-    play.SetRoomViewport(view);
+    play.SetRoomViewport(scv->GetID(), view);
 }
 
-ScriptCamera* Viewport_GetCamera(ScriptViewport *)
+ScriptCamera* Viewport_GetCamera(ScriptViewport *scv)
 {
-    ScriptCamera *camera = new ScriptCamera();
+    auto view = play.GetRoomViewportObj(scv->GetID());
+    ScriptCamera *camera = new ScriptCamera(view->GetCamera()->GetID());
     ccRegisterManagedObject(camera, camera);
     return camera;
 }
@@ -238,28 +244,26 @@ ScriptCamera* Viewport_GetCamera(ScriptViewport *)
 ScriptViewport* Viewport_GetAtScreenXY(int x, int y)
 {
     data_to_game_coords(&x, &y);
-
-    const Rect &view = play.GetRoomViewport();
-    if (!view.IsInside(x, y))
+    PViewport view = play.GetRoomViewportAt(x, y);
+    if (!view)
         return nullptr;
-
-    ScriptViewport *viewport = new ScriptViewport();
+    ScriptViewport *viewport = new ScriptViewport(view->GetID());
     ccRegisterManagedObject(viewport, viewport);
     return viewport;
 }
 
-void Viewport_SetPosition(ScriptViewport *, int x, int y, int width, int height)
+void Viewport_SetPosition(ScriptViewport *scv, int x, int y, int width, int height)
 {
     data_to_game_coords(&x, &y);
     data_to_game_coords(&width, &height);
-    play.SetRoomViewport(RectWH(x, y, width, height));
+    play.SetRoomViewport(scv->GetID(), RectWH(x, y, width, height));
 }
 
-ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *, int scrx, int scry, bool clipViewport)
+ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *scv, int scrx, int scry, bool clipViewport)
 {
     data_to_game_coords(&scrx, &scry);
 
-    VpPoint vpt = play.ScreenToRoom(scrx, scry, clipViewport);
+    VpPoint vpt = play.ScreenToRoom(scrx, scry, scv->GetID(), clipViewport);
     if (vpt.second < 0)
         return nullptr;
 
@@ -267,11 +271,11 @@ ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *, int scrx, int scr
     return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);
 }
 
-ScriptUserObject *Viewport_RoomToScreenPoint(ScriptViewport *, int roomx, int roomy, bool clipViewport)
+ScriptUserObject *Viewport_RoomToScreenPoint(ScriptViewport *scv, int roomx, int roomy, bool clipViewport)
 {
     data_to_game_coords(&roomx, &roomy);
 
-    const Rect &view = play.GetRoomViewport();
+    const Rect &view = play.GetRoomViewport(scv->GetID());
     Point pt = play.RoomToScreen(roomx, roomy);
     if (clipViewport && !view.IsInside(pt.X, pt.Y))
         return nullptr;

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -309,6 +309,10 @@ HError InitAndRegisterGameEntities()
     InitAndRegisterRegions();
     InitAndRegisterRoomObjects();
 
+    // Primary viewport and camera
+    play.RegisterRoomViewport(0);
+    play.RegisterRoomCamera(0);
+
     RegisterStaticArrays();
 
     setup_player_character(game.playercharacter);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -392,6 +392,7 @@ void DoBeforeRestore(PreservedParams &pp)
     }
 
     play.FreeProperties();
+    play.FreeViewportsAndCameras();
 
     delete roominstFork;
     delete roominst;
@@ -407,11 +408,13 @@ void DoBeforeRestore(PreservedParams &pp)
     free_do_once_tokens();
 
     // unregister gui controls from API exports
-    // TODO: find out why are we doing this here? perhaps remove if we do full managed pool reset in DoBeforeRestore
+    // TODO: find out why are we doing this here? is this really necessary?
     for (int i = 0; i < game.numgui; ++i)
     {
         unexport_gui_controls(i);
     }
+    // Clear the managed object pool
+    ccUnregisterAllObjects();
 
     // NOTE: channels are array of MAX_SOUND_CHANNELS+1 size
     for (int i = 0; i <= MAX_SOUND_CHANNELS; ++i)
@@ -420,6 +423,29 @@ void DoBeforeRestore(PreservedParams &pp)
     }
 
     clear_music_cache();
+}
+
+void RestoreViewportCameraLinks(const RestoredData &r_data)
+{
+    for (size_t i = 0; i < r_data.ViewCamLinks.size(); ++i)
+    {
+        int cam_index = r_data.ViewCamLinks[i];
+        if (cam_index < 0) continue;
+        auto view = play.GetRoomViewportObj(i);
+        auto cam = play.GetRoomCamera(cam_index);
+        view->LinkCamera(cam);
+        cam->LinkToViewport(view);
+    }
+    play.InvalidateViewportZOrder();
+}
+
+void RestoreViewportsAndCameras(const RestoredData &r_data)
+{
+    for (size_t i = 0; i < r_data.Cameras.size(); ++i)
+        *play.GetRoomCamera(i) = r_data.Cameras[i];
+    for (size_t i = 0; i < r_data.Viewports.size(); ++i)
+        *play.GetRoomViewportObj(i) = r_data.Viewports[i];
+    RestoreViewportCameraLinks(r_data);
 }
 
 // Final processing after successfully restoring from save
@@ -615,6 +641,8 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     recreate_overlay_ddbs();
 
     guis_need_update = 1;
+
+    RestoreViewportsAndCameras(r_data);
 
     // if savegame contained a global time and not an offset, this will be way off.
     if ((play.ignore_user_input_until_time - AGS_Clock::now()) > std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms)) {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -212,8 +212,8 @@ HSaveError WriteGameState(PStream out)
     out->WriteInt32(cur_cursor);
     out->WriteInt32(mouse_on_iface);
     // Viewport
-    out->WriteInt32(play.GetRoomCamera().Left);
-    out->WriteInt32(play.GetRoomCamera().Top);
+    out->WriteInt32(play.GetRoomCamera(0)->GetRect().Left);
+    out->WriteInt32(play.GetRoomCamera(0)->GetRect().Top);
     return HSaveError::None();
 }
 
@@ -249,7 +249,7 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
     // Viewport state
     int camx = in->ReadInt32();
     int camy = in->ReadInt32();
-    play.SetRoomCameraAt(camx, camy);
+    play.GetRoomCamera(0)->SetAt(camx, camy);
     return err;
 }
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -184,6 +184,51 @@ inline bool AssertGameObjectContent2(HSaveError &err, int new_val, int original_
 }
 
 
+enum GameViewCamFlags
+{
+    kSvgGameAutoRoomView = 0x01
+};
+
+enum CameraSaveFlags
+{
+    kSvgCamPosLocked = 0x01
+};
+
+enum ViewportSaveFlags
+{
+    kSvgViewportVisible = 0x01
+};
+
+void WriteCameraState(const Camera &cam, Stream *out)
+{
+    int flags = 0;
+    if (cam.IsLocked()) flags |= kSvgCamPosLocked;
+    out->WriteInt32(flags);
+    const Rect &rc = cam.GetRect();
+    out->WriteInt32(rc.Left);
+    out->WriteInt32(rc.Top);
+    out->WriteInt32(rc.GetWidth());
+    out->WriteInt32(rc.GetHeight());
+}
+
+void WriteViewportState(const Viewport &view, Stream *out)
+{
+    int flags = 0;
+    if (view.IsVisible()) flags |= kSvgViewportVisible;
+    out->WriteInt32(flags);
+    const Rect &rc = view.GetRect();
+    out->WriteInt32(rc.Left);
+    out->WriteInt32(rc.Top);
+    out->WriteInt32(rc.GetWidth());
+    out->WriteInt32(rc.GetHeight());
+    out->WriteInt32(view.GetZOrder());
+    auto cam = view.GetCamera();
+    if (cam)
+        out->WriteInt32(cam->GetID());
+    else
+        out->WriteInt32(-1);
+}
+
 HSaveError WriteGameState(PStream out)
 {
     // Game base
@@ -211,15 +256,62 @@ HSaveError WriteGameState(PStream out)
     out->WriteInt32(cur_mode);
     out->WriteInt32(cur_cursor);
     out->WriteInt32(mouse_on_iface);
-    // Viewport
-    out->WriteInt32(play.GetRoomCamera(0)->GetRect().Left);
-    out->WriteInt32(play.GetRoomCamera(0)->GetRect().Top);
+
+    // Viewports and cameras
+    int viewcam_flags = 0;
+    if (play.IsAutoRoomViewport())
+        viewcam_flags |= kSvgGameAutoRoomView;
+    out->WriteInt32(viewcam_flags);
+    out->WriteInt32(play.GetRoomCameraCount());
+    for (int i = 0; i < play.GetRoomCameraCount(); ++i)
+        WriteCameraState(*play.GetRoomCamera(i), out.get());
+    out->WriteInt32(play.GetRoomViewportCount());
+    for (int i = 0; i < play.GetRoomViewportCount(); ++i)
+        WriteViewportState(*play.GetRoomViewportObj(i), out.get());
+
     return HSaveError::None();
+}
+
+void ReadCameraState(/*Camera &cam,*/ RestoredData &r_data, Stream *in)
+{
+    Camera cam;
+    cam.SetID(r_data.Cameras.size());
+    int flags = in->ReadInt32();
+    if ((flags & kSvgCamPosLocked) != 0)
+        cam.Lock();
+    else
+        cam.Release();
+    int left = in->ReadInt32();
+    int top = in->ReadInt32();
+    int width = in->ReadInt32();
+    int height = in->ReadInt32();
+    cam.SetAt(left, top);
+    cam.SetSize(Size(width, height));
+    r_data.Cameras.push_back(cam);
+}
+
+void ReadViewportState(/*Viewport &view,*/ RestoredData &r_data, Stream *in)
+{
+    Viewport view;
+    view.SetID(r_data.Viewports.size());
+    int flags = in->ReadInt32();
+    view.SetVisible((flags & kSvgViewportVisible) != 0);
+    const Rect &rc = view.GetRect();
+    int left = in->ReadInt32();
+    int top = in->ReadInt32();
+    int width = in->ReadInt32();
+    int height = in->ReadInt32();
+    view.SetRect(RectWH(left, top, width, height));
+    view.SetZOrder(in->ReadInt32());
+    int cam_index = in->ReadInt32();
+    r_data.Viewports.push_back(view);
+    r_data.ViewCamLinks.push_back(cam_index);
 }
 
 HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
 {
     HSaveError err;
+    GameStateSvgVersion svg_ver = (GameStateSvgVersion)cmp_ver;
     // Game base
     game.ReadFromSavegame(in);
     // Game palette
@@ -235,7 +327,7 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
     }
 
     // Game state
-    play.ReadFromSavegame(in.get(), (GameStateSvgVersion)cmp_ver);
+    play.ReadFromSavegame(in.get(), svg_ver);
 
     // Other dynamic values
     r_data.FPS = in->ReadInt32();
@@ -246,10 +338,35 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
     r_data.CursorMode = in->ReadInt32();
     r_data.CursorID = in->ReadInt32();
     mouse_on_iface = in->ReadInt32();
-    // Viewport state
-    int camx = in->ReadInt32();
-    int camy = in->ReadInt32();
-    play.GetRoomCamera(0)->SetAt(camx, camy);
+
+    // Viewports and cameras
+    if (svg_ver < kGSSvgVersion_3510)
+    {
+        int camx = in->ReadInt32();
+        int camy = in->ReadInt32();
+        play.GetRoomCamera(0)->SetAt(camx, camy);
+    }
+    else
+    {
+        int viewcam_flags = in->ReadInt32();
+        play.SetAutoRoomViewport((viewcam_flags & kSvgGameAutoRoomView) != 0);
+        // TODO: we create viewport and camera objects here because they are
+        // required for the managed pool deserialization, but read actual
+        // data into temp structs because of issue with load_new_room().
+        // See comments to RestoredData struct for further details.
+        int cam_count = in->ReadInt32();
+        for (int i = 0; i < cam_count; ++i)
+        {
+            play.CreateRoomCamera();
+            ReadCameraState(r_data, in.get());
+        }
+        int view_count = in->ReadInt32();
+        for (int i = 0; i < view_count; ++i)
+        {
+            play.CreateRoomViewport();
+            ReadViewportState(r_data, in.get());
+        }
+    }
     return err;
 }
 
@@ -976,7 +1093,7 @@ ComponentHandler ComponentHandlers[] =
 {
     {
         "Game State",
-        kGSSvgVersion_3509,
+        kGSSvgVersion_3510,
         kGSSvgVersion_Initial,
         WriteGameState,
         ReadGameState

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -89,6 +89,16 @@ struct RestoredData
     ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
     // Ambient sounds
     int                     DoAmbient[MAX_SOUND_CHANNELS];
+    // TODO: this is ugly, but we have to keep this data and apply only after
+    // room gets loaded, otherwise it will override restored settings.
+    // Same may refer to few other settings above.
+    // This could be fixed if we split load_new_room() into 2 functions that
+    // load room data with or without applying additional changes. Since code
+    // is pretty complex there this has to be done with careful research.
+    std::vector<Viewport>   Viewports;
+    std::vector<Camera>     Cameras;
+    // Viewport -> camera links
+    std::vector<int>        ViewCamLinks;
 
     RestoredData();
 };

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/draw.h"
+#include "ac/gamestate.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
 #include "game/viewport.h"
@@ -140,6 +141,13 @@ void Viewport::SetVisible(bool on)
 {
     _visible = on;
     _hasChanged = true;
+}
+
+void Viewport::SetZOrder(int zorder)
+{
+    _zorder = zorder;
+    _hasChanged = true;
+    play.InvalidateViewportZOrder();
 }
 
 void Viewport::AdjustTransformation()

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -1,0 +1,150 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "ac/draw.h"
+#include "debug/debug_log.h"
+#include "game/roomstruct.h"
+#include "game/viewport.h"
+
+using namespace AGS::Common;
+
+extern RoomStruct thisroom;
+
+void Camera::SetID(int id)
+{
+    _id = id;
+}
+
+// Returns Room camera position and size inside the room (in room coordinates)
+const Rect &Camera::GetRect() const
+{
+    return _position;
+}
+
+// Sets explicit room camera's orthographic size
+void Camera::SetSize(const Size &cam_size)
+{
+    // TODO: currently we don't support having camera larger than room background
+    // (or rather - looking outside of the room background); look into this later
+    const Size real_room_sz = Size(data_to_game_coord(thisroom.Width), data_to_game_coord(thisroom.Height));
+    Size real_size = Size::Clamp(cam_size, Size(1, 1), real_room_sz);
+
+    _position.SetWidth(real_size.Width);
+    _position.SetHeight(real_size.Height);
+    for (auto vp = _viewportRefs.begin(); vp != _viewportRefs.end(); ++vp)
+    {
+        auto locked_vp = vp->lock();
+        if (locked_vp)
+            locked_vp->AdjustTransformation();
+    }
+    _hasChanged = true;
+}
+
+// Puts room camera to the new location in the room
+void Camera::SetAt(int x, int y)
+{
+    int cw = _position.GetWidth();
+    int ch = _position.GetHeight();
+    int room_width = data_to_game_coord(thisroom.Width);
+    int room_height = data_to_game_coord(thisroom.Height);
+    x = Math::Clamp(x, 0, room_width - cw);
+    y = Math::Clamp(y, 0, room_height - ch);
+    _position.MoveTo(Point(x, y));
+}
+
+// Tells if camera is currently locked at custom position
+bool Camera::IsLocked() const
+{
+    return _locked;
+}
+
+// Locks room camera at its current position
+void Camera::Lock()
+{
+    debug_script_log("Room camera locked");
+    _locked = true;
+}
+
+// Similar to SetAt, but also locks camera preventing it from following player character
+void Camera::LockAt(int x, int y)
+{
+    debug_script_log("Room camera locked to %d,%d", x, y);
+    SetAt(x, y);
+    _locked = true;
+}
+
+// Releases camera lock, letting it follow player character
+void Camera::Release()
+{
+    _locked = false;
+    debug_script_log("Room camera released back to engine control");
+}
+
+// Link this camera to a new viewport; this does not unlink any linked ones
+void Camera::LinkToViewport(ViewportRef viewport)
+{
+    auto new_locked = viewport.lock();
+    if (!new_locked)
+        return;
+    for (auto vp = _viewportRefs.begin(); vp != _viewportRefs.end(); ++vp)
+    {
+        auto old_locked = vp->lock();
+        if (old_locked->GetID() == new_locked->GetID())
+            return;
+    }
+    _viewportRefs.push_back(viewport);
+}
+
+// Unlinks this camera from a given viewport; does nothing if link did not exist
+void Camera::UnlinkFromViewport(int id)
+{
+    for (auto vp = _viewportRefs.begin(); vp != _viewportRefs.end(); ++vp)
+    {
+        auto locked = vp->lock();
+        if (locked && locked->GetID() == id)
+        {
+            _viewportRefs.erase(vp);
+            return;
+        }
+    }
+}
+
+void Viewport::SetID(int id)
+{
+    _id = id;
+}
+
+void Viewport::SetRect(const Rect &rc)
+{
+    _position = rc;
+    AdjustTransformation();
+    _hasChanged = true;
+}
+
+void Viewport::AdjustTransformation()
+{
+    auto locked_cam = _camera.lock();
+    if (locked_cam)
+        _transform.Init(locked_cam->GetRect().GetSize(), _position);
+}
+
+PCamera Viewport::GetCamera() const
+{
+    return _camera.lock();
+}
+
+void Viewport::LinkCamera(PCamera cam)
+{
+    _camera = cam;
+    AdjustTransformation();
+}

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -131,6 +131,12 @@ void Viewport::SetRect(const Rect &rc)
     _hasChanged = true;
 }
 
+void Viewport::SetVisible(bool on)
+{
+    _visible = on;
+    _hasChanged = true;
+}
+
 void Viewport::AdjustTransformation()
 {
     auto locked_cam = _camera.lock();

--- a/Engine/game/viewport.cpp
+++ b/Engine/game/viewport.cpp
@@ -119,6 +119,11 @@ void Camera::UnlinkFromViewport(int id)
     }
 }
 
+const std::vector<ViewportRef> &Camera::GetLinkedViewports() const
+{
+    return _viewportRefs;
+}
+
 void Viewport::SetID(int id)
 {
     _id = id;

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -110,8 +110,14 @@ public:
     // Set viewport's position on screen
     void SetRect(const Rect &rc);
 
+    // Tells whether viewport content is rendered on screen
+    bool IsVisible() const { return _visible; }
+    // Changes viewport visibility
+    void SetVisible(bool on);
+
     // Calculates room-to-viewport coordinate conversion.
     void AdjustTransformation();
+    // Returns linked camera
     PCamera GetCamera() const;
     // Links new camera to this viewport, overriding existing link;
     // pass nullptr to leave viewport without a camera link
@@ -133,6 +139,7 @@ private:
     AGS::Engine::PlaneScaling _transform;
     // Linked camera reference
     CameraRef _camera;
+    bool _visible = true;
     // Flag that tells whether this viewport has changed recently
     bool _hasChanged = false;;
 };

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -74,6 +74,8 @@ public:
     void LinkToViewport(ViewportRef viewport);
     // Unlinks this camera from a given viewport; does nothing if link did not exist
     void UnlinkFromViewport(int id);
+    // Get the array of linked viewport references
+    const std::vector<ViewportRef> &GetLinkedViewports() const;
 
     // Tells if this camera has changed recently
     inline bool HasChanged() const { return _hasChanged; }

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -18,25 +18,123 @@
 #ifndef __AGS_EE_AC__VIEWPORT_H
 #define __AGS_EE_AC__VIEWPORT_H
 
+#include <memory>
+#include <vector>
 #include "util/geometry.h"
 #include "util/scaling.h"
 
-struct RoomCamera
+class Camera;
+class Viewport;
+
+typedef std::shared_ptr<Camera> PCamera;
+typedef std::shared_ptr<Viewport> PViewport;
+typedef std::weak_ptr<Camera> CameraRef;
+typedef std::weak_ptr<Viewport> ViewportRef;
+
+// TODO: move to utility header
+// From https://stackoverflow.com/questions/45507041/how-to-check-if-weak-ptr-is-empty-non-assigned
+// Tests that weak_ptr is empty (was not initialized with valid reference)
+template <typename T>
+bool is_uninitialized(std::weak_ptr<T> const& weak) {
+    using wt = std::weak_ptr<T>;
+    return !weak.owner_before(wt{}) && !wt{}.owner_before(weak);
+}
+
+
+// Camera defines a "looking eye" inside the room, its position and size.
+// It does not render anywhere on its own, instead it is linked to a viewport
+// and latter draws what that camera sees.
+// One camera may be linked to multiple viewports.
+// Camera does not move on its own, this is performed by separate behavior
+// algorithm. But it provides "lock" property that tells if its position is
+// currently owned by user script.
+class Camera
 {
+public:
+    // Gets camera ID (serves as an index)
+    inline int GetID() const { return _id; }
+    // Sets new camera ID
+    void SetID(int id);
+    // Returns Room camera position and size inside the room (in room coordinates)
+    const Rect &GetRect() const;
+    // Sets explicit room camera's orthographic size
+    void SetSize(const Size &cam_size);
+    // Puts room camera to the new location in the room
+    void SetAt(int x, int y);
+    // Tells if camera is currently locked at custom position
+    bool IsLocked() const;
+    // Locks room camera at its current position
+    void Lock();
+    // Similar to SetAt, but also locks camera preventing it from following player character
+    void LockAt(int x, int y);
+    // Releases camera lock, letting it follow player character
+    void Release();
+
+    // Link this camera to a new viewport; this does not unlink any linked ones
+    void LinkToViewport(ViewportRef viewport);
+    // Unlinks this camera from a given viewport; does nothing if link did not exist
+    void UnlinkFromViewport(int id);
+
+    // Tells if this camera has changed recently
+    inline bool HasChanged() const { return _hasChanged; }
+    // Clears the changed flag
+    inline void ClearChangedFlag() { _hasChanged = false; }
+
+private:
+    int _id = -1;
     // Actual position and orthographic size
-    Rect Position;
+    Rect _position;
     // Locked or following player automatically
-    bool Locked;
+    bool _locked = false;
+    // Linked viewport refs, used to notify viewports of camera changes
+    std::vector<ViewportRef> _viewportRefs;
+    // Flag that tells whether this camera has changed recently
+    bool _hasChanged = false;;
 };
 
-struct Viewport
+
+// Viewport class defines a rectangular area on game screen where the contents
+// of a Camera are rendered.
+// Viewport may have one linked camera at a time.
+class Viewport
 {
+public:
+    // Gets viewport ID (serves as an index)
+    inline int GetID() const { return _id; }
+    // Sets new viewport ID
+    void SetID(int id);
+    // Returns viewport's position on screen
+    inline const Rect &GetRect() const { return _position; }
+    // Returns viewport's room-to-screen transformation
+    inline const AGS::Engine::PlaneScaling &GetTransform() const { return _transform; }
+    // Set viewport's position on screen
+    void SetRect(const Rect &rc);
+
+    // Calculates room-to-viewport coordinate conversion.
+    void AdjustTransformation();
+    PCamera GetCamera() const;
+    // Links new camera to this viewport, overriding existing link;
+    // pass nullptr to leave viewport without a camera link
+    void LinkCamera(PCamera cam);
+
+    // Tells if this viewport has changed recently
+    inline bool HasChanged() const { return _hasChanged; }
+    // Clears the changed flag
+    inline void ClearChangedFlag() { _hasChanged = false; }
+
+private:
+    int _id = -1;
     // Position of the viewport on screen
-    Rect Position;
+    Rect _position;
     // TODO: Camera reference (when supporting multiple cameras)
     // Coordinate tranform between camera and viewport
-    // TODO: need to add rotate conversion to let script API support that
-    AGS::Engine::PlaneScaling Transform;
+    // TODO: need to add rotate conversion to let script API support that;
+    // (maybe use full 3D matrix for that)
+    AGS::Engine::PlaneScaling _transform;
+    // Linked camera reference
+    CameraRef _camera;
+    // Flag that tells whether this viewport has changed recently
+    bool _hasChanged = false;;
 };
 
 #endif // __AGS_EE_AC__VIEWPORT_H

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -116,6 +116,10 @@ public:
     bool IsVisible() const { return _visible; }
     // Changes viewport visibility
     void SetVisible(bool on);
+    // Gets the order viewport is displayed on screen
+    int GetZOrder() const { return _zorder; }
+    // Sets the viewport's z-order on screen
+    void SetZOrder(int zorder);
 
     // Calculates room-to-viewport coordinate conversion.
     void AdjustTransformation();
@@ -142,6 +146,7 @@ private:
     // Linked camera reference
     CameraRef _camera;
     bool _visible = true;
+    int _zorder = 0;
     // Flag that tells whether this viewport has changed recently
     bool _hasChanged = false;;
 };

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -998,7 +998,7 @@ void engine_init_game_settings()
     play.music_master_volume=100 + LegacyMusicMasterVolumeAdjustment;
     play.digital_master_volume = 100;
     play.screen_flipped=0;
-    play.ReleaseRoomCamera();
+    play.GetRoomCamera(0)->Release();
     play.cant_skip_speech = user_to_internal_skip_speech((SkipSpeechStyle)game.options[OPT_NOSKIPTEXT]);
     play.sound_volume = 255;
     play.speech_volume = 255;

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -131,8 +131,8 @@ void engine_init_resolution_settings(const Size game_size)
     Rect viewport = RectWH(game_size);
     play.SetMainViewport(viewport);
     play.SetUIViewport(viewport);
-    play.SetRoomViewport(viewport);
-    play.SetRoomCameraSize(viewport.GetSize());
+    play.SetRoomViewport(0, viewport);
+    play.GetRoomCamera(0)->SetSize(viewport.GetSize());
 
     usetup.textheight = getfontheight_outlined(0) + 1;
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -602,7 +602,6 @@ static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBit
 {
     if (!play.fast_forward) {
         int mwasatx=mousex,mwasaty=mousey;
-        const Rect &camera = play.GetRoomCamera();
 
         // React to changes to viewports and cameras (possibly from script) just before the render
         play.UpdateViewports();
@@ -612,10 +611,14 @@ static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBit
 
         // Check Mouse Moves Over Hotspot event
         // TODO: do not use static variables!
+        // TODO: if we support rotation then we also need to compare full transform!
         static int offsetxWas = -100, offsetyWas = -100;
+        auto cam = play.GetRoomCamera(0);
+        int offsetx = cam->GetRect().Left;
+        int offsety = cam->GetRect().Top;
 
         if (((mwasatx!=mousex) || (mwasaty!=mousey) ||
-            (offsetxWas != camera.Left) || (offsetyWas != camera.Top)) &&
+            (offsetxWas != offsetx) || (offsetyWas != offsety)) &&
             (displayed_room >= 0)) 
         {
             // mouse moves over hotspot
@@ -626,8 +629,8 @@ static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBit
             }
         }
 
-        offsetxWas = camera.Left;
-        offsetyWas = camera.Top;
+        offsetxWas = offsetx;
+        offsetyWas = offsety;
     }
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -610,16 +610,23 @@ static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBit
         render_graphics(extraBitmap, extraX, extraY);
 
         // Check Mouse Moves Over Hotspot event
+        // TODO: move this out of render related function? find out why we remember mwasatx and mwasaty before render
         // TODO: do not use static variables!
         // TODO: if we support rotation then we also need to compare full transform!
-        static int offsetxWas = -100, offsetyWas = -100;
-        auto cam = play.GetRoomCamera(0);
+        if (displayed_room < 0)
+            return;
+        auto view = play.GetRoomViewportAt(mousex, mousey);
+        auto cam = view ? view->GetCamera() : nullptr;
+        if (cam)
+        {
+        // NOTE: all cameras are in same room right now, so their positions are in same coordinate system;
+        // therefore we may use this as an indication that mouse is over different camera too.
+        static int offsetxWas = -1000, offsetyWas = -1000;
         int offsetx = cam->GetRect().Left;
         int offsety = cam->GetRect().Top;
 
         if (((mwasatx!=mousex) || (mwasaty!=mousey) ||
-            (offsetxWas != offsetx) || (offsetyWas != offsety)) &&
-            (displayed_room >= 0)) 
+            (offsetxWas != offsetx) || (offsetyWas != offsety))) 
         {
             // mouse moves over hotspot
             if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT) {
@@ -631,6 +638,7 @@ static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBit
 
         offsetxWas = offsetx;
         offsetyWas = offsety;
+        } // camera found under mouse
     }
 }
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -469,7 +469,10 @@ void IAGSEngine::RoomToViewport (int32 *x, int32 *y) {
         *y = scrp.Y;
 }
 void IAGSEngine::ViewportToRoom (int32 *x, int32 *y) {
-    VpPoint vpt = play.ScreenToRoom(x ? game_to_data_coord(*x) : 0, y ? game_to_data_coord(*y) : 0, false);
+    // NOTE: This is an old function that did not account for custom/multiple viewports
+    // and does not expect to fail, therefore we always use primary viewport here.
+    // (Not sure if it's good though)
+    VpPoint vpt = play.ScreenToRoom(x ? game_to_data_coord(*x) : 0, y ? game_to_data_coord(*y) : 0, 0, false);
     if (x)
         *x = vpt.first.X;
     if (y)

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -283,7 +283,7 @@
     <ClCompile Include="..\..\Engine\ac\translation.cpp" />
     <ClCompile Include="..\..\Engine\ac\tree_map.cpp" />
     <ClCompile Include="..\..\Engine\ac\viewframe.cpp" />
-    <ClCompile Include="..\..\Engine\ac\viewport.cpp" />
+    <ClCompile Include="..\..\Engine\ac\viewport_script.cpp" />
     <ClCompile Include="..\..\Engine\ac\walkablearea.cpp" />
     <ClCompile Include="..\..\Engine\ac\walkbehind.cpp" />
     <ClCompile Include="..\..\Engine\debug\consoleoutputtarget.cpp" />
@@ -296,6 +296,7 @@
     <ClCompile Include="..\..\Engine\game\game_init.cpp" />
     <ClCompile Include="..\..\Engine\game\savegame.cpp" />
     <ClCompile Include="..\..\Engine\game\savegame_components.cpp" />
+    <ClCompile Include="..\..\Engine\game\viewport.cpp" />
     <ClCompile Include="..\..\Engine\gfx\ali3dogl.cpp" />
     <ClCompile Include="..\..\Engine\gfx\ali3dsw.cpp" />
     <ClCompile Include="..\..\Engine\gfx\blender.cpp" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -993,14 +993,17 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptcamera.cpp">
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Engine\ac\viewport.cpp">
-      <Filter>Source Files\ac</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Engine\libsrc\glad\src\glad.c">
       <Filter>Library Sources\glad</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\libsrc\glad\src\glad_wgl.c">
       <Filter>Library Sources\glad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\game\viewport.cpp">
+      <Filter>Source Files\game</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\viewport_script.cpp">
+      <Filter>Source Files\ac</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\scriptcontainers.cpp">
       <Filter>Source Files\ac</Filter>


### PR DESCRIPTION
This implements support for multiple room Cameras and Viewports.

User is allowed to create any number of Viewports on screen and Cameras in room, or remove them as necessary. There's one "primary" Viewport and "primary" Camera under index 0 that can never be removed (they are also created automatically). Latter also ensures full backwards support for games that do not have this new functionality.

Following was added to script API:

<pre>
builtin struct Room {
  <...>
  /// Gets the Camera by index.
  import static readonly attribute Camera *Cameras[];
  /// Gets the number of cameras.
  import static readonly attribute int CameraCount;
  /// Creates a new Camera.
  import static Camera *CreateCamera();
  /// Removes an existing camera; primary camera will never be removed
  import static void RemoveCamera(int id);
};

builtin managed struct Viewport {
  <...>
  /// Gets/sets the room camera displayed in this viewport.
  import attribute Camera *Camera;
  /// Gets/sets whether the viewport is drawn on screen.
  import attribute bool Visible;
};

builtin struct Screen {
  <...>
  /// Gets a Viewport by index.
  import static readonly attribute Viewport *Viewports[];
  /// Gets the number of viewports.
  import static readonly attribute int ViewportCount;
  /// Creates a new Viewport.
  import static Viewport *CreateViewport();
  /// Removes an existing viewport; primary viewport will never be removed
  import static void RemoveViewport(int id);
};
</pre>

### Missing functionality (TODO)

~1. Support Z-order for Viewports in case they overlap;~
2. Add Clickable property to Viewport?
~3. Write viewport and camera data to game saves.~

### Conceptual problem

Although technically everything works, but there are certain things about viewport and camera behavior that were not thought through beforehand. I am considering opening a separate discussion about that (and it may be decided and changed later too). But in short, the big questions are:

* What does Viewport and Cameras belong to, Game or Room? Viewport may belong to game (screen), while Camera to the room for example, or both belong to game or room.
* Should Cameras save their state and restore it as the room loads and unloads? Should viewports?

Imho it's better to assume hypothetically that multiple rooms may be loaded and displayed at the same time (because that's a future possibility too). Of course this does not have to happen soon, but it's better to devise a proper concept now.

### Demonstration

Demo game: https://www.dropbox.com/s/zp0e4cidkate0rc/test--multiviewport.zip?dl=0

<details>
  <summary>Examples of use and proof of concept:</summary>

  Cutscene with two cameras following 2 characters as they walk around the large room
  ![](https://i.imgur.com/w8ShCLx.gif)

  One camera with regular zoom follows character, another camera displays larger piece of room.
  Note that you can interact with the room clicking on either.
  ![](https://i.imgur.com/1bMv6sI.gif)
</details>