### PR TITLE
Uniform audio config option which supports string driver ID

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1514,9 +1514,6 @@ namespace AGS.Editor
             bool use_default_midi = _game.DefaultSetup.MidiSound == RuntimeAudioDriver.Default;
             NativeProxy.WritePrivateProfileString("sound", "digiid", use_default_digi ? "-1" : "0", configFilePath);
             NativeProxy.WritePrivateProfileString("sound", "midiid", use_default_midi ? "-1" : "0", configFilePath);
-            // NOTE: the *winindx values are used on Windows for historical reasons; their values are disconnected from the *id
-            NativeProxy.WritePrivateProfileString("sound", "digiwinindx", use_default_digi ? "0" : "2", configFilePath);
-            NativeProxy.WritePrivateProfileString("sound", "midiwinindx", use_default_midi ? "0" : "1", configFilePath);
             NativeProxy.WritePrivateProfileString("sound", "usespeech", _game.DefaultSetup.UseVoicePack ? "1" : "0", configFilePath);
 
             NativeProxy.WritePrivateProfileString("language", "translation", _game.DefaultSetup.Translation, configFilePath);

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -80,7 +80,7 @@ String GetRuntimeInfo()
         runtimeInfo.Append("[Using translation ");
         runtimeInfo.Append(transFileName);
     }
-    if (opts.mod_player == 0)
+    if (usetup.mod_player == 0)
         runtimeInfo.Append("[(mod/xm player discarded)");
 
     return runtimeInfo;

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -106,7 +106,6 @@ const int LegacyRoomVolumeFactor            = 30;
 #define FOR_ANIMATION 1
 #define FOR_SCRIPT    2
 #define FOR_EXITLOOP  3
-#define opts usetup
 #define CHMLSOFFS (MAX_ROOM_OBJECTS+1)    // reserve this many movelists for objects & stuff
 #define MAX_SCREEN_OVERLAYS 20
 #define abort_all_conditions restrict_until

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -325,6 +325,8 @@ extern int psp_gfx_scaling;
 extern int psp_gfx_super_sampling;
 extern int psp_gfx_smoothing;
 extern int psp_gfx_smooth_sprites;
+extern int psp_audio_enabled;
+extern int psp_midi_enabled;
 
 void override_config_ext(ConfigTree &cfg)
 {
@@ -408,6 +410,13 @@ void apply_config(const ConfigTree &cfg)
             idx = MIDI_AUTODETECT;
         usetup.midicard = idx;
 #endif
+        if (!psp_audio_enabled)
+        {
+            usetup.digicard = DIGI_NONE;
+            usetup.midicard = MIDI_NONE;
+        }
+        if (!psp_midi_enabled)
+            usetup.midicard = MIDI_NONE;
         psp_audio_multithreaded = INIreadint(cfg, "sound", "threaded", psp_audio_multithreaded);
 
         // Filter can also be set by command line

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -15,7 +15,7 @@
 //
 // Game configuration
 //
-
+#include <ctype.h> // toupper
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
@@ -204,6 +204,63 @@ int convert_fp_to_scaling(uint32_t scaling)
     return scaling >= kUnit ? (scaling >> kShift) : -kUnit / (int32_t)scaling;
 }
 
+AlIDStr AlIDToChars(int al_id)
+{
+    if (al_id == 0)
+        return AlIDStr{ 'N', 'O', 'N', 'E', 0 };
+    else if (al_id == -1)
+        return AlIDStr{ 'A', 'U', 'T', 'O', 0 };
+    else
+        return AlIDStr{ (al_id >> 24) & 0xFF, (al_id >> 16) & 0xFF, (al_id >> 8) & 0xFF, (al_id) & 0xFF, 0 };
+}
+
+AlIDStr AlIDToChars(const String &s)
+{
+    AlIDStr id_str;
+    size_t i = 0;
+    for (; i < s.GetLength(); ++i)
+        id_str.s[i] = toupper(s[i]);
+    for (; i < 4; ++i)
+        id_str.s[i] = ' ';
+    id_str.s[4] = 0;
+    return id_str;
+}
+
+int StringToAlID(const char *cstr)
+{
+    return (int)(AL_ID(cstr[0u], cstr[1u], cstr[2u], cstr[3u]));
+}
+
+// Parses a config string which may hold plain driver's ID or 4-char ID packed
+// as a 32-bit integer.
+int parse_driverid(const String &id)
+{
+    int asint;
+    if (StrUtil::StringToInt(id, asint, 0) == StrUtil::kNoError)
+        return asint;
+    if (id.GetLength() > 4)
+        return -1; // autodetect
+    if (id.CompareNoCase("AUTO") == 0)
+        return -1; // autodetect
+    if (id.CompareNoCase("NONE") == 0)
+        return 0; // no driver
+    return StringToAlID(AlIDToChars(id).s);
+}
+
+// Reads driver ID from config, where it may be represented as string or number
+int read_driverid(const ConfigTree &cfg, const String &sectn, const String &item, int def_value)
+{
+    String s = INIreadstring(cfg, sectn, item);
+    if (s.IsEmpty())
+        return def_value;
+    return parse_driverid(s);
+}
+
+void write_driverid(ConfigTree &cfg, const String &sectn, const String &item, int value)
+{
+    INIwritestring(cfg, sectn, item, AlIDToChars(value).s);
+}
+
 void graphics_mode_get_defaults(bool windowed, ScreenSizeSetup &scsz_setup, GameFrameSetup &frame_setup)
 {
     scsz_setup.Size = Size();
@@ -258,6 +315,7 @@ void config_defaults()
 #ifdef WINDOWS_VERSION
     usetup.digicard = DIGI_DIRECTAMX(0);
 #endif
+    usetup.midicard = MIDI_AUTODETECT;
 }
 
 void read_game_data_location(const ConfigTree &cfg)
@@ -279,6 +337,33 @@ void read_game_data_location(const ConfigTree &cfg)
 #endif
     }
     usetup.main_data_filename = INIreadstring(cfg, "misc", "datafile", usetup.main_data_filename);
+}
+
+void read_legacy_audio_config(const ConfigTree &cfg)
+{
+#ifdef WINDOWS_VERSION
+    int idx = INIreadint(cfg, "sound", "digiwinindx", -1);
+    if (idx == 0)
+        idx = DIGI_DIRECTAMX(0);
+    else if (idx == 1)
+        idx = DIGI_WAVOUTID(0);
+    else if (idx == 2)
+        idx = DIGI_NONE;
+    else if (idx == 3)
+        idx = DIGI_DIRECTX(0);
+    else
+        idx = DIGI_AUTODETECT;
+    usetup.digicard = idx;
+
+    idx = INIreadint(cfg, "sound", "midiwinindx", -1);
+    if (idx == 1)
+        idx = MIDI_NONE;
+    else if (idx == 2)
+        idx = MIDI_WIN32MAPPER;
+    else
+        idx = MIDI_AUTODETECT;
+    usetup.midicard = idx;
+#endif
 }
 
 void read_legacy_graphics_config(const ConfigTree &cfg, const bool should_read_filter)
@@ -384,39 +469,23 @@ void override_config_ext(ConfigTree &cfg)
 void apply_config(const ConfigTree &cfg)
 {
     {
-#ifndef WINDOWS_VERSION
-        usetup.digicard=INIreadint(cfg, "sound","digiid", DIGI_AUTODETECT);
-        usetup.midicard=INIreadint(cfg, "sound","midiid", MIDI_AUTODETECT);
-#else
-        int idx = INIreadint(cfg, "sound","digiwinindx", -1);
-        if (idx == 0)
-            idx = DIGI_DIRECTAMX(0);
-        else if (idx == 1)
-            idx = DIGI_WAVOUTID(0);
-        else if (idx == 2)
-            idx = DIGI_NONE;
-        else if (idx == 3) 
-            idx = DIGI_DIRECTX(0);
-        else 
-            idx = DIGI_AUTODETECT;
-        usetup.digicard = idx;
-
-        idx = INIreadint(cfg, "sound","midiwinindx", -1);
-        if (idx == 1)
-            idx = MIDI_NONE;
-        else if (idx == 2)
-            idx = MIDI_WIN32MAPPER;
+        // Legacy settings has to be translated into new options;
+        // they must be read first, to let newer options override them, if ones are present
+        read_legacy_audio_config(cfg);
+        if (psp_audio_enabled)
+        {
+            usetup.digicard = read_driverid(cfg, "sound", "digiid", usetup.digicard);
+            if (psp_midi_enabled)
+                usetup.midicard = read_driverid(cfg, "sound", "midiid", usetup.midicard);
+            else
+                usetup.midicard = MIDI_NONE;
+        }
         else
-            idx = MIDI_AUTODETECT;
-        usetup.midicard = idx;
-#endif
-        if (!psp_audio_enabled)
         {
             usetup.digicard = DIGI_NONE;
             usetup.midicard = MIDI_NONE;
         }
-        if (!psp_midi_enabled)
-            usetup.midicard = MIDI_NONE;
+
         psp_audio_multithreaded = INIreadint(cfg, "sound", "threaded", psp_audio_multithreaded);
 
         // Filter can also be set by command line

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -52,6 +52,18 @@ int convert_fp_to_scaling(uint32_t scaling);
 // Fill in setup structs with default settings for the given mode (windowed or fullscreen)
 void graphics_mode_get_defaults(bool windowed, ScreenSizeSetup &scsz_setup, GameFrameSetup &frame_setup);
 
+typedef struct { char s[5]; } AlIDStr;
+// Converts Allegro driver ID type to 4-char string
+AlIDStr AlIDToChars(int al_id);
+AlIDStr AlIDToChars(const String &s);
+// Converts C-string into Allegro's driver ID; string must be at least 4 character long
+int StringToAlID(const char *cstr);
+// Reads driver ID from config, where it may be represented as string or number
+int read_driverid(const ConfigTree &cfg, const String &sectn, const String &item, int def_value);
+// Writes driver ID to config
+void write_driverid(ConfigTree &cfg, const String &sectn, const String &item, int value);
+
+
 bool INIreaditem(const ConfigTree &cfg, const String &sectn, const String &item, String &value);
 int INIreadint(const ConfigTree &cfg, const String &sectn, const String &item, int def_value = 0);
 float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value = 0.f);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -491,7 +491,7 @@ bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 
 void engine_init_audio()
 {
-    if (opts.mod_player)
+    if (usetup.mod_player)
         reserve_voices(NUM_DIGI_VOICES, -1);
     // maybe this line will solve the sound volume? [??? wth is this]
     set_volume_per_voice(1);
@@ -517,11 +517,11 @@ void engine_init_audio()
 
     String err_msg;
     bool sound_res = try_install_sound(usetup.digicard, usetup.midicard, &err_msg);
-    if (!sound_res && opts.mod_player)
+    if (!sound_res && usetup.mod_player)
     {
         Debug::Printf("Resetting to default sound parameters and trying again.");
         reserve_voices(-1, -1); // this resets voice number to defaults
-        opts.mod_player = 0;
+        usetup.mod_player = 0;
         sound_res = try_install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT);
     }
     if (!sound_res)
@@ -777,18 +777,18 @@ void engine_init_modxm_player()
 {
 #ifndef PSP_NO_MOD_PLAYBACK
     if (game.options[OPT_NOMODMUSIC])
-        opts.mod_player = 0;
+        usetup.mod_player = 0;
 
-    if (opts.mod_player) {
+    if (usetup.mod_player) {
         Debug::Printf(kDbgMsg_Init, "Initializing MOD/XM player");
 
         if (init_mod_player(NUM_MOD_DIGI_VOICES) < 0) {
             platform->DisplayAlert("Warning: install_mod: MOD player failed to initialize.");
-            opts.mod_player=0;
+            usetup.mod_player=0;
         }
     }
 #else
-    opts.mod_player = 0;
+    usetup.mod_player = 0;
     Debug::Printf(kDbgMsg_Init, "Compiled without MOD/XM player");
 #endif
 }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -433,39 +433,23 @@ void engine_init_keyboard()
 #endif
 }
 
-typedef char AlIDStr[5];
+typedef struct { char s[5]; } AlIDStr;
 
-void AlIDToChars(int al_id, AlIDStr &id_str)
+AlIDStr AlIDToChars(int al_id)
 {
-    id_str[0] = (al_id >> 24) & 0xFF;
-    id_str[1] = (al_id >> 16) & 0xFF;
-    id_str[2] = (al_id >> 8) & 0xFF;
-    id_str[3] = (al_id) & 0xFF;
-    id_str[4] = 0;
-}
-
-void AlDigiToChars(int digi_id, AlIDStr &id_str)
-{
-    if (digi_id == DIGI_NONE)
-        strcpy(id_str, "None");
-    else if (digi_id == DIGI_AUTODETECT)
-        strcpy(id_str, "Auto");
+    if (al_id == 0)
+        return AlIDStr{ 'N', 'O', 'N', 'E', 0 };
+    else if (al_id == -1)
+        return AlIDStr{ 'A', 'U', 'T', 'O', 0 };
     else
-        AlIDToChars(digi_id, id_str);
-}
-
-void AlMidiToChars(int midi_id, AlIDStr &id_str)
-{
-    if (midi_id == MIDI_NONE)
-        strcpy(id_str, "None");
-    else if (midi_id == MIDI_AUTODETECT)
-        strcpy(id_str, "Auto");
-    else
-        AlIDToChars(midi_id, id_str);
+        return AlIDStr{ (al_id >> 24) & 0xFF, (al_id >> 16) & 0xFF, (al_id >> 8) & 0xFF, (al_id) & 0xFF, 0 };
 }
 
 bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
+    Debug::Printf(kDbgMsg_Init, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
+        AlIDToChars(digi_id).s, digi_id, AlIDToChars(midi_id).s, midi_id);
+
     if (install_sound(digi_id, midi_id, nullptr) == 0)
         return true;
     // Allegro does not let you try digital and MIDI drivers separately,
@@ -489,44 +473,84 @@ bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
     return false;
 }
 
+// Attempts to predict a digital driver Allegro would chose, and get its maximal voices
+std::pair<int, int> autodetect_driver(_DRIVER_INFO *driver_list, int (*detect_audio_driver)(int), const char *type)
+{
+    for (int i = 0; driver_list[i].driver; ++i)
+    {
+        if (driver_list[i].autodetect)
+        {
+            int voices = detect_audio_driver(driver_list[i].id);
+            if (voices == 0)
+                Debug::Printf(kDbgMsg_Warn, "Failed to detect %s driver %s; Error: '%s'.",
+                    type, AlIDToChars(driver_list[i].id).s, get_allegro_error());
+            if (voices > 0)
+                return std::make_pair(driver_list[i].id, voices);
+        }
+    }
+    return std::make_pair(0, 0);
+}
+
+// Decides which audio driver to request from Allegro.
+// Returns a pair of audio card ID and max available voices.
+std::pair<int, int> decide_audiodriver(int try_id, _DRIVER_INFO *driver_list,
+    int(*detect_audio_driver)(int), int &al_drv_id, const char *type)
+{
+    if (try_id == 0) // no driver
+        return std::make_pair(0, 0);
+    al_drv_id = 0; // the driver id will be set by library if one was found
+    if (try_id > 0)
+    {
+        int voices = detect_audio_driver(try_id);
+        if (al_drv_id == try_id && voices > 0) // found and detected
+            return std::make_pair(try_id, voices);
+        if (voices == 0) // found in list but detect failed
+            Debug::Printf(kDbgMsg_Error, "Failed to detect %s driver %s; Error: '%s'.", type, AlIDToChars(try_id).s, get_allegro_error());
+        else // not found at all
+            Debug::Printf(kDbgMsg_Error, "Unknown %s driver: %s, will try to find suitable one.", type, AlIDToChars(try_id).s);
+    }
+    return autodetect_driver(driver_list, detect_audio_driver, type);
+}
+
 void engine_init_audio()
 {
+    Debug::Printf("Initializing sound drivers");
+    int digi_id = usetup.digicard;
+    int midi_id = usetup.midicard;
+    int digi_voices = -1;
+    int midi_voices = -1;
+    // MOD player would need certain minimal number of voices
+    // TODO: find out if this is still relevant?
     if (usetup.mod_player)
-        reserve_voices(NUM_DIGI_VOICES, -1);
+        digi_voices = NUM_DIGI_VOICES;
+
+    Debug::Printf(kDbgMsg_Init, "Sound settings: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
+        AlIDToChars(digi_id).s, digi_id, AlIDToChars(midi_id).s, midi_id);
+
+    // First try if drivers are supported, and switch to autodetect if explicit option failed
+    _DRIVER_INFO *digi_drivers = system_driver->digi_drivers ? system_driver->digi_drivers() : _digi_driver_list;
+    std::pair<int, int> digi_drv = decide_audiodriver(digi_id, digi_drivers, detect_digi_driver, digi_card, "digital");
+    _DRIVER_INFO *midi_drivers = system_driver->midi_drivers ? system_driver->midi_drivers() : _midi_driver_list;
+    std::pair<int, int> midi_drv = decide_audiodriver(midi_id, midi_drivers, detect_midi_driver, midi_card, "MIDI");
+
+    // Now, knowing which drivers we suppose to install, decide on which voices we reserve
+    digi_id = digi_drv.first;
+    midi_id = midi_drv.first;
+    const int max_digi_voices = digi_drv.second;
+    const int max_midi_voices = midi_drv.second;
+    if (digi_voices > max_digi_voices)
+        digi_voices = max_digi_voices;
+    // NOTE: we do not specify number of MIDI voices, so don't have to calculate available here
+
+    reserve_voices(digi_voices, midi_voices);
     // maybe this line will solve the sound volume? [??? wth is this]
     set_volume_per_voice(1);
 
-    Debug::Printf("Initialize sound drivers");
-
-    // TODO: apply those options during config reading instead
-    if (!psp_audio_enabled)
-    {
-        usetup.digicard = DIGI_NONE;
-        usetup.midicard = MIDI_NONE;
-    }
-
-    if (!psp_midi_enabled)
-        usetup.midicard = MIDI_NONE;
-
-    AlIDStr digi_id;
-    AlIDStr midi_id;
-    AlDigiToChars(usetup.digicard, digi_id);
-    AlMidiToChars(usetup.midicard, midi_id);
-    Debug::Printf(kDbgMsg_Init, "Sound settings: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
-        digi_id, usetup.digicard, midi_id, usetup.midicard);
-
     String err_msg;
-    bool sound_res = try_install_sound(usetup.digicard, usetup.midicard, &err_msg);
-    if (!sound_res && usetup.mod_player)
-    {
-        Debug::Printf("Resetting to default sound parameters and trying again.");
-        reserve_voices(-1, -1); // this resets voice number to defaults
-        usetup.mod_player = 0;
-        sound_res = try_install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT);
-    }
+    bool sound_res = try_install_sound(digi_id, midi_id, &err_msg);
     if (!sound_res)
     {
-        Debug::Printf("Everything failed, installing dummy no-sound drivers.");
+        Debug::Printf(kDbgMsg_Error, "Everything failed, disabling sound.");
         reserve_voices(0, 0);
         install_sound(DIGI_NONE, MIDI_NONE, nullptr);
     }
@@ -537,19 +561,17 @@ void engine_init_audio()
     {
         platform->DisplayAlert("Warning: cannot enable %s.\nProblem: %s.\n\nYou may supress this message by disabling %s in the game setup.",
             (digi_failed && midi_failed ? "game audio" : (digi_failed ? "digital audio" : "MIDI audio") ),
-            (err_msg.IsEmpty() ? "No compatible drivers found in the system." : err_msg.GetCStr()),
+            (err_msg.IsEmpty() ? "No compatible drivers found in the system" : err_msg.GetCStr()),
             (digi_failed && midi_failed ? "sound" : (digi_failed ? "digital sound" : "MIDI sound") ));
     }
 
     usetup.digicard = digi_card;
     usetup.midicard = midi_card;
 
-    AlDigiToChars(usetup.digicard, digi_id);
-    AlMidiToChars(usetup.midicard, midi_id);
     Debug::Printf(kDbgMsg_Init, "Installed digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
-        digi_id, usetup.digicard, midi_id, usetup.midicard);
+        AlIDToChars(digi_card).s, digi_card, AlIDToChars(midi_card).s, midi_card);
 
-    if (usetup.digicard == DIGI_NONE)
+    if (digi_card == DIGI_NONE)
     {
         // disable speech and music if no digital sound
         // therefore the MIDI soundtrack will be used if present,
@@ -557,9 +579,15 @@ void engine_init_audio()
         play.want_speech = -2;
         play.separate_music_lib = 0;
     }
+    if (usetup.mod_player && digi_driver->voices < NUM_DIGI_VOICES)
+    {
+        // disable MOD player if there's not enough digital voices
+        // TODO: find out if this is still relevant?
+        usetup.mod_player = 0;
+    }
 
 #ifdef WINDOWS_VERSION
-    if (usetup.digicard == DIGI_DIRECTX(0))
+    if (digi_card == DIGI_DIRECTX(0))
     {
         // DirectX mixer seems to buffer an extra sample itself
         use_extra_sound_offset = 1;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -433,18 +433,6 @@ void engine_init_keyboard()
 #endif
 }
 
-typedef struct { char s[5]; } AlIDStr;
-
-AlIDStr AlIDToChars(int al_id)
-{
-    if (al_id == 0)
-        return AlIDStr{ 'N', 'O', 'N', 'E', 0 };
-    else if (al_id == -1)
-        return AlIDStr{ 'A', 'U', 'T', 'O', 0 };
-    else
-        return AlIDStr{ (al_id >> 24) & 0xFF, (al_id >> 16) & 0xFF, (al_id >> 8) & 0xFF, (al_id) & 0xFF, 0 };
-}
-
 bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
     Debug::Printf(kDbgMsg_Init, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -117,7 +117,7 @@ void quit_shutdown_audio()
     game.options[OPT_CROSSFADEMUSIC] = 0;
     stopmusic();
 #ifndef PSP_NO_MOD_PLAYBACK
-    if (opts.mod_player)
+    if (usetup.mod_player)
         remove_mod_player();
 #endif
 

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -728,7 +728,7 @@ void shutdown_sound()
     stop_all_sound_and_music();
 
 #ifndef PSP_NO_MOD_PLAYBACK
-    if (opts.mod_player)
+    if (usetup.mod_player)
         remove_mod_player();
 #endif
     remove_sound();

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -915,8 +915,7 @@ void AGSWin32::PlayVideo(const char *name, int skip, int flags) {
 
   if (useSound)
   {
-    if (usetup.mod_player)
-      reserve_voices(NUM_DIGI_VOICES, -1);
+    // Restore sound system
     install_sound(usetup.digicard,usetup.midicard,NULL);
     if (usetup.mod_player)
       init_mod_player(NUM_MOD_DIGI_VOICES);

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -915,10 +915,10 @@ void AGSWin32::PlayVideo(const char *name, int skip, int flags) {
 
   if (useSound)
   {
-    if (opts.mod_player)
+    if (usetup.mod_player)
       reserve_voices(NUM_DIGI_VOICES, -1);
     install_sound(usetup.digicard,usetup.midicard,NULL);
-    if (opts.mod_player)
+    if (usetup.mod_player)
       init_mod_player(NUM_MOD_DIGI_VOICES);
   }
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -688,7 +688,8 @@ void IAGSEngine::DisableSound() {
     shutdown_sound();
     usetup.digicard = DIGI_NONE;
     usetup.midicard = MIDI_NONE;
-    install_sound(usetup.digicard,usetup.midicard,nullptr);
+    reserve_voices(0, 0);
+    install_sound(DIGI_NONE, MIDI_NONE, nullptr);
 }
 int IAGSEngine::CanRunScriptFunctionNow() {
     if (inside_script)


### PR DESCRIPTION
After #734.

This lets engine use "digiid" and "midiid" config options on all platforms including Windows and deprecates Windows-only "digiwinindx" and "midiwinindx" options.

These two options are now tried as both number and string, letting user to define audio driver ID as a string for convenience, e.g.:
<pre>
[sound]
digiid=ALSA
midiid=AMID
</pre>
of course you have to know driver names from Allegro for this.

Special names: "auto" for getting default driver and "none" to disable sound.

~**NOTE:** I made these names case-sensitive by oversight but they probably should not be, so I'll fix that.~ should be fixed now

Additionally, I adjusted the initialization step; now it does not try to initialize sound blindly by requesting as much voices as engine likes, but instead queries available driver's capability first and adjusts request accordingly. This should prevent confusing initialization errors when driver reports "unsufficient digital voices", and removes the need to retry installing sound with different voice number settings.