### PR TITLE
Editor: custom replacements for Say and Display in dialog scripts

### DIFF
--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1610,7 +1610,9 @@ namespace AGS.Editor
                 {
                     DialogOption option = curDialog.Options[i];
                     int flags = 0;
-                    if (!option.Say) flags |= NativeConstants.DFLG_NOREPEAT;
+                    // NOTE: we always force "no-say" flag, because "say" checkbox is processed when
+                    // the dialog script is converted into regular script now.
+                    flags |= NativeConstants.DFLG_NOREPEAT;
                     if (option.Show) flags |= NativeConstants.DFLG_ON;
                     writer.Write(flags); // optionflags
                 }

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -54,7 +54,7 @@ namespace AGS.Editor
             flowLayoutPanel1.Controls.Remove(btnNewOption);
             foreach (DialogOption option in _dialog.Options)
             {
-                DialogOptionEditor optionEditor = new DialogOptionEditor(option);
+                DialogOptionEditor optionEditor = new DialogOptionEditor(option, DialogOptionChanged);
                 _optionPanes.Add(optionEditor);
                 flowLayoutPanel1.Controls.Add(optionEditor);
             }
@@ -290,7 +290,7 @@ namespace AGS.Editor
                 newOption.Show = true;
             }
             _dialog.Options.Add(newOption);
-            DialogOptionEditor newEditor = new DialogOptionEditor(newOption);
+            DialogOptionEditor newEditor = new DialogOptionEditor(newOption, DialogOptionChanged);
             _optionPanes.Add(newEditor);
             flowLayoutPanel1.Controls.Remove(btnNewOption);
             flowLayoutPanel1.Controls.Remove(btnDeleteOption);
@@ -320,6 +320,11 @@ namespace AGS.Editor
                 _dialog.Script += "@" + newOption.ID + Environment.NewLine + "return" + Environment.NewLine;
                 scintillaEditor.SetText(_dialog.Script);
             }
+        }
+
+        private void DialogOptionChanged(object sender, EventArgs e)
+        {
+            _dialog.ScriptChangedSinceLastConverted = true;
         }
 
         private void LoadColorTheme(ColorTheme t)

--- a/Editor/AGS.Editor/Panes/DialogOptionEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogOptionEditor.cs
@@ -11,15 +11,19 @@ namespace AGS.Editor
 {
     public partial class DialogOptionEditor : UserControl
     {
-        public DialogOptionEditor(DialogOption option)
+        public DialogOptionEditor(DialogOption option, EventHandler onOptionChanged)
         {
             InitializeComponent();
+            if (onOptionChanged != null)
+            {
+                chkSay.CheckedChanged += onOptionChanged;
+                txtOptionText.TextChanged += onOptionChanged;
+            }
             chkSay.DataBindings.Add("Checked", option, "Say", false, DataSourceUpdateMode.OnPropertyChanged);
             chkShow.DataBindings.Add("Checked", option, "Show", false, DataSourceUpdateMode.OnPropertyChanged);
             txtOptionText.DataBindings.Add("Text", option, "Text", false, DataSourceUpdateMode.OnPropertyChanged);
             lblOptionID.Text = option.ID.ToString() + ":";
             txtOptionText.Focus();
         }
-
     }
 }

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -131,6 +131,13 @@ namespace AGS.Editor
             {
                 Factory.Events.OnGameSettingsChanged();
             }
+            else if (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_DIALOG_SCRIPT_SAYFN ||
+                e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_DIALOG_SCRIPT_NARRATEFN)
+            {
+                // Force rebuild all dialog scripts
+                foreach (Dialog d in Factory.AGSEditor.CurrentGame.Dialogs)
+                    d.ScriptChangedSinceLastConverted = true;
+            }
         }
 
         private void LoadColorTheme(ColorTheme t)

--- a/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
+++ b/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
@@ -15,6 +15,8 @@ namespace AGS.Editor
         private bool _hadFirstEntryPoint = false;
         private Dictionary<int, object> _existingEntryPoints = new Dictionary<int, object>();
         private Game _game;
+        private string _sayFnName;
+        private string _narrateFnName;
 
         private static readonly string _DefaultDialogScriptsScript = null;
 
@@ -61,6 +63,12 @@ namespace AGS.Editor
             _currentlyInsideCodeArea = false;
             _hadFirstEntryPoint = false;
             _game = game;
+            _sayFnName = game.Settings.DialogScriptSayFunction;
+            if (string.IsNullOrWhiteSpace(_sayFnName))
+                _sayFnName = "Say";
+            _narrateFnName = game.Settings.DialogScriptNarrateFunction;
+            if (string.IsNullOrWhiteSpace(_narrateFnName))
+                _narrateFnName = "Display";
             _currentDialog = dialog;
             _existingEntryPoints.Clear();
             _currentLineNumber = 0;
@@ -365,16 +373,16 @@ namespace AGS.Editor
             textToSay = textToSay.Replace("\"", "\\\"");
             if (charName == "player")
             {
-                scriptToReturn = string.Format("player.Say(\"{0}\");", textToSay);
+                scriptToReturn = string.Format("player.{0}(\"{1}\");", _sayFnName, textToSay);
             }
             else if (charName == "narrator")
             {
-                scriptToReturn = string.Format("Display(\"{0}\");", textToSay);
+                scriptToReturn = string.Format("{0}(\"{1}\");", _narrateFnName, textToSay);
             }
             else
             {
                 Character character = FindCharacterByScriptName(charName);
-                scriptToReturn = string.Format("{0}.Say(\"{1}\");", character.ScriptName, textToSay);
+                scriptToReturn = string.Format("{0}.{1}(\"{2}\");", character.ScriptName, _sayFnName, textToSay);
             }
             return scriptToReturn;
         }

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -14,6 +14,8 @@ namespace AGS.Types
     [DefaultProperty("DebugMode")]
     public class Settings : ICustomTypeDescriptor
     {
+        // TODO: reimplement the handling of property value changes in the Editor assembly
+        // so that relying on property labels is no longer necessary!
         public const string PROPERTY_GAME_NAME = "Game name";
         public const string PROPERTY_COLOUR_DEPTH = "Colour depth";
         public const string PROPERTY_RESOLUTION = "Resolution";
@@ -22,7 +24,9 @@ namespace AGS.Types
         public const string PROPERTY_LETTERBOX_MODE = "Enable letterbox mode";
         public const string PROPERTY_BUILD_TARGETS = "Build target platforms";
         public const string PROPERTY_RENDERATSCREENRES = "Render sprites at screen resolution";
-		public const string REGEX_FOUR_PART_VERSION = @"^(\d+)\.(\d+)\.(\d+)\.(\d+)$";
+        public const string PROPERTY_DIALOG_SCRIPT_SAYFN = "Custom Say function in dialog scripts";
+        public const string PROPERTY_DIALOG_SCRIPT_NARRATEFN = "Custom Narrate function in dialog scripts";
+        public const string REGEX_FOUR_PART_VERSION = @"^(\d+)\.(\d+)\.(\d+)\.(\d+)$";
 
 		private const string DEFAULT_GENRE = "Adventure";
         private const string DEFAULT_VERSION = "1.0.0.0";
@@ -75,6 +79,8 @@ namespace AGS.Types
         private DialogOptionsNumbering _numberDialogOptions = DialogOptionsNumbering.KeyShortcutsOnly;
         private bool _dialogOptionsBackwards = false;
         private SpeechPortraitSide _speechPortraitSide = SpeechPortraitSide.Left;
+        private string _dialogScriptSayFunction;
+        private string _dialogScriptNarrateFunction;
         private int _textWindowGUI = 0;
         private bool _alwaysDisplayTextAsSpeech = false;
         private bool _fontsAreHiRes = false;
@@ -779,6 +785,26 @@ namespace AGS.Types
         {
             get { return _speechPortraitSide; }
             set { _speechPortraitSide = value; }
+        }
+
+        [DisplayName("Custom Say function in dialog scripts")]
+        [Description("Sets which function name to use in place of character.Say when running dialog scripts. Note that it must be an extension function of a Character class. Leave empty to use default (Character.Say).")]
+        [DefaultValue("")]
+        [Category("Dialog")]
+        public string DialogScriptSayFunction
+        {
+            get { return _dialogScriptSayFunction; }
+            set { _dialogScriptSayFunction = value; }
+        }
+
+        [DisplayName("Custom Narrate function in dialog scripts")]
+        [Description("Sets which function name to use in place of narrator's speech when running dialog scripts. Note that it must be either regular function or a static struct function. Leave empty to use default (Display).")]
+        [DefaultValue("")]
+        [Category("Dialog")]
+        public string DialogScriptNarrateFunction
+        {
+            get { return _dialogScriptNarrateFunction; }
+            set { _dialogScriptNarrateFunction = value; }
         }
 
         [DisplayName("Custom text-window GUI")]


### PR DESCRIPTION
This is perhaps the easiest possible solution for using custom speech functions in dialog scripts.

In AGS 3.* dialog scripts are converted to regular ags script by substituting dialog-specific syntax with script commands, for example:
`CHARNAME: Sais something`
gets converted into:
`cCHARNAME.Say("Sais something");`

Obviously this hard-coded behavior was not compatible with custom speech functions many people do, forcing them to use regular functions in dialog scripts as well, which is often inconvenient.

The proposed change introduces two properties in General Settings: DialogScriptSayFunction and DialogScriptNarrateFunction. The values of these properties are simply substituting previously hard-coded "Say" and "Display" commands during dialog script compilation.

Additionally "Say" checkbox is translated to the `player.SayFunction(dDialog.GetOptionText(n));` in script.
GetOptionText is used in case option text could be altered at runtime at some future point.