### PR TITLE
Fixes to increase compatibility with GCC 8

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -27,6 +27,7 @@
 #include "util/alignedstream.h"
 #include "util/path.h"
 #include "util/string_utils.h"
+#include "debug/debug_log.h"
 
 namespace AGS
 {
@@ -403,16 +404,24 @@ void BuildAudioClipArray(const AssetLibInfo &lib, std::vector<ScriptAudioClip> &
             ScriptAudioClip &clip = audioclips.back();
             if (ags_stricmp(temp_name, "music") == 0)
             {
-                sprintf(clip.scriptName, "aMusic%d", temp_number);
-                sprintf(clip.fileName, "music%d.%s", temp_number, temp_extension);
+                int err = snprintf(clip.scriptName, sizeof(clip.scriptName), "aMusic%d", temp_number);
+                if (err >= sizeof(clip.scriptName))
+                    debug_script_warn("Script name length exceeded: %d", err);
+                err = snprintf(clip.fileName, sizeof(clip.fileName), "music%d.%s", temp_number, temp_extension);
+                if (err >= sizeof(clip.fileName))
+                    debug_script_warn("Clip file name length exceeded: %d", err);
                 clip.bundlingType = (ags_stricmp(temp_extension, "mid") == 0) ? AUCL_BUNDLE_EXE : AUCL_BUNDLE_VOX;
                 clip.type = 2;
                 clip.defaultRepeat = 1;
             }
             else if (ags_stricmp(temp_name, "sound") == 0)
             {
-                sprintf(clip.scriptName, "aSound%d", temp_number);
-                sprintf(clip.fileName, "sound%d.%s", temp_number, temp_extension);
+                int err = snprintf(clip.scriptName, sizeof(clip.scriptName), "aSound%d", temp_number);
+                if (err >= sizeof(clip.scriptName))
+                    debug_script_warn("Script name length exceeded: %d", err);
+                err = snprintf(clip.fileName, sizeof(clip.fileName), "sound%d.%s", temp_number, temp_extension);
+                if (err >= sizeof(clip.fileName))
+                    debug_script_warn("Clip file name length exceeded: %d", err);
                 clip.bundlingType = AUCL_BUNDLE_EXE;
                 clip.type = 3;
             }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2101,11 +2101,14 @@ void draw_fps()
 
     char fps_buffer[60];
     // Don't display fps if we don't have enough information (because loop count was just reset)
+    int err;
     if (!std::isnan(fps)) {
-        sprintf(fps_buffer, "FPS: %2.1f / %s", fps, base_buffer);
+        err = snprintf(fps_buffer, sizeof(fps_buffer), "FPS: %2.1f / %s", fps, base_buffer);
     } else {
-        sprintf(fps_buffer, "FPS: --.- / %s", base_buffer);
+        err = snprintf(fps_buffer, sizeof(fps_buffer), "FPS: --.- / %s", base_buffer);
     }
+    if (err >= sizeof(fps_buffer))
+        debug_script_warn("FPS string length exceeded: %d", err);
     wouttext_outline(fpsDisplay, 1, 1, FONT_SPEECH, text_color, fps_buffer);
 
     char loop_buffer[60];

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -440,16 +440,20 @@ bool SetSaveGameDirectoryPath(const char *newFolder, bool explicit_path)
 
     // copy the Restart Game file, if applicable
     char restartGamePath[260];
-    sprintf(restartGamePath, "%s""agssave.%d%s", saveGameDirectory, RESTART_POINT_SAVE_GAME_NUMBER, saveGameSuffix.GetCStr());
+    int err = snprintf(restartGamePath, sizeof(restartGamePath), "%s""agssave.%d%s", saveGameDirectory, RESTART_POINT_SAVE_GAME_NUMBER, saveGameSuffix.GetCStr());
+    if (err >= sizeof(restartGamePath))
+        debug_script_warn("Savegame path length exceeded: %d", err);
     Stream *restartGameFile = Common::File::OpenFileRead(restartGamePath);
     if (restartGameFile != nullptr)
-	{
+    {
         long fileSize = restartGameFile->GetLength();
         char *mbuffer = (char*)malloc(fileSize);
         restartGameFile->Read(mbuffer, fileSize);
         delete restartGameFile;
 
-        sprintf(restartGamePath, "%s""agssave.%d%s", newSaveGameDir.GetCStr(), RESTART_POINT_SAVE_GAME_NUMBER, saveGameSuffix.GetCStr());
+        err = snprintf(restartGamePath, sizeof(restartGamePath), "%s""agssave.%d%s", newSaveGameDir.GetCStr(), RESTART_POINT_SAVE_GAME_NUMBER, saveGameSuffix.GetCStr());
+        if (err >= sizeof(restartGamePath))
+            debug_script_warn("Savegame path length exceeded: %d", err);
         restartGameFile = Common::File::CreateFile(restartGamePath);
         restartGameFile->Write(mbuffer, fileSize);
         delete restartGameFile;
@@ -1012,9 +1016,11 @@ long write_screen_shot_for_vista(Stream *out, Bitmap *screenshot)
 {
     long fileSize = 0;
     char tempFileName[MAX_PATH];
-    sprintf(tempFileName, "%s""_tmpscht.bmp", saveGameDirectory);
+    int err = snprintf(tempFileName, sizeof(tempFileName), "%s""_tmpscht.bmp", saveGameDirectory);
+    if (err >= sizeof(tempFileName))
+        debug_script_warn("Screenshot path length exceeded: %d", err);
 
-	screenshot->SaveToFile(tempFileName, palette);
+    screenshot->SaveToFile(tempFileName, palette);
 
     update_polled_stuff_if_runtime();
 
@@ -1977,12 +1983,12 @@ void replace_tokens(const char*srcmes,char*destm, int maxlen) {
             if (tokentype==1) {
                 if ((inx<1) | (inx>=game.numinvitems))
                     quit("!Display: invalid inv item specified in @IN@");
-                sprintf(tval,"%d",playerchar->inv[inx]);
+                snprintf(tval,sizeof(tval),"%d",playerchar->inv[inx]);
             }
             else {
                 if ((inx<0) | (inx>=MAXGSVALUES))
                     quit("!Display: invalid global int index speicifed in @GI@");
-                sprintf(tval,"%d",GetGlobalInt(inx));
+                snprintf(tval,sizeof(tval),"%d",GetGlobalInt(inx));
             }
             strcpy(destp,tval);
             indxdest+=strlen(tval);

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -742,10 +742,13 @@ int IsKeyPressed (int keycode) {
 int SaveScreenShot(const char*namm) {
     char fileName[MAX_PATH];
 
+    int err;
     if (strchr(namm,'.') == nullptr)
-        sprintf(fileName, "%s%s.bmp", saveGameDirectory, namm);
+        err = snprintf(fileName, sizeof(fileName), "%s%s.bmp", saveGameDirectory, namm);
     else
-        sprintf(fileName, "%s%s", saveGameDirectory, namm);
+        err = snprintf(fileName, sizeof(fileName), "%s%s", saveGameDirectory, namm);
+    if (err >= sizeof(fileName))
+        debug_script_warn("Screenshot path length exceeded: %d", err);
 
     Bitmap *buffer = CopyScreenIntoBitmap(play.GetMainViewport().GetWidth(), play.GetMainViewport().GetHeight());
     if (!buffer->SaveToFile(fileName, palette) != 0)

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -21,6 +21,7 @@
 #include "ac/path_helper.h"
 #include "ac/string.h"
 #include "gui/guimain.h"
+#include "debug/debug_log.h"
 
 using namespace AGS::Common;
 
@@ -98,7 +99,9 @@ int ListBox_FillSaveGameList(GUIListBox *listbox) {
   char buff[200];
 
   char searchPath[260];
-  sprintf(searchPath, "%s""agssave.*", saveGameDirectory);
+  int err = snprintf(searchPath, sizeof(searchPath), "%s""agssave.*", saveGameDirectory);
+  if (err >= sizeof(searchPath))
+    debug_script_warn("Savegame path length exceeded: %d", err);
 
   int don = al_findfirst(searchPath, &ffb, FA_SEARCH);
   while (!don) {

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -23,6 +23,7 @@
 #include <cctype> //isdigit()
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
+#include "debug/debug_log.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -304,7 +305,9 @@ void preparesavegamelist(int ctrllist)
   int bufix = 0;
 
   char searchPath[260];
-  sprintf(searchPath, "%s""agssave.*%s", saveGameDirectory, saveGameSuffix.GetCStr());
+  int err = snprintf(searchPath, sizeof(searchPath), "%s""agssave.*%s", saveGameDirectory, saveGameSuffix.GetCStr());
+  if (err >= sizeof(searchPath))
+    debug_script_warn("Savegame path length exceeded: %d", err);
 
   int don = al_findfirst(searchPath, &ffb, -1);
   while (!don) {

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -748,14 +748,18 @@ int check_write_access() {
 
   // The Save Game Dir is the only place that we should write to
   char tempPath[MAX_PATH];
-  sprintf(tempPath, "%s""tmptest.tmp", saveGameDirectory);
+  int err = snprintf(tempPath, sizeof(tempPath), "%s""tmptest.tmp", saveGameDirectory);
+  if (err >= sizeof(tempPath))
+    debug_script_warn("Savegame path length exceeded: %d", err);
   Stream *temp_s = Common::File::CreateFile(tempPath);
   if (!temp_s)
       // TODO: move this somewhere else (Android platform driver init?)
 #if AGS_PLATFORM_OS_ANDROID
   {
 	  put_backslash(android_base_directory);
-	  sprintf(tempPath, "%s""tmptest.tmp", android_base_directory);
+	  int err = snprintf(tempPath, sizeof(tempPath), "%s""tmptest.tmp", android_base_directory);
+	  if (err >= sizeof(tempPath))
+	    debug_script_warn("Savegame path length exceeded: %d", err);
 	  temp_s = Common::File::CreateFile(tempPath);
 	  if (temp_s == NULL) return 0;
 	  else SetCustomSaveParent(android_base_directory);

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -511,8 +511,12 @@ String GetScriptName(ccInstance *sci)
 
 char bname[MAX_FUNCTION_NAME_LEN+1],bne[MAX_FUNCTION_NAME_LEN+1];
 char* make_ts_func_name(const char*base,int iii,int subd) {
-    snprintf(bname,MAX_FUNCTION_NAME_LEN,base,iii);
-    snprintf(bne,MAX_FUNCTION_NAME_LEN,"%s_%c",bname,subd+'a');
+    int err = snprintf(bname,MAX_FUNCTION_NAME_LEN,base,iii);
+    if (err >= sizeof(bname))
+      debug_script_warn("Function string length exceeded: %d", err);
+    err = snprintf(bne,MAX_FUNCTION_NAME_LEN,"%s_%c",bname,subd+'a');
+    if (err >= sizeof(bne))
+      debug_script_warn("Function string length exceeded: %d", err);
     return &bne[0];
 }
 


### PR DESCRIPTION
GCC 8 is much more picky with sprintf and snprintf and fails compilation when the return value remains unchecked.
```c++
script/script.cpp: In function ‘char* make_ts_func_name(const char*, int, int)’:
script/script.cpp:515:40: error: ‘_’ directive output may be truncated writing 1 byte into a region of size between 0 and 60 [-Werror=format-truncation=]
     snprintf(bne,MAX_FUNCTION_NAME_LEN,"%s_%c",bname,subd+'a');
                                        ^~~~~~~
script/script.cpp:515:13: note: ‘snprintf’ output between 3 and 63 bytes into a destination of size 60
     snprintf(bne,MAX_FUNCTION_NAME_LEN,"%s_%c",bname,subd+'a');
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This used to be a warning only, but with `-Werror`, it causes failure.

Surprisingly, GCC is able to figure out when a static buffer is passed to sprintf - and it range-checks the result automatically. This prompts the aforementioned warning when the return value isn't checked.

I added the necessary checks and replaced sprintf with snprintf. This could cause compatibility issues with Windows, I can change it back to sprintf if requested.