### PR TITLE
Create all subdirectories when writing a file by script command

### DIFF
--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -9,6 +9,7 @@
 #endif
 #include "util/directory.h"
 #include "util/path.h"
+#include "stdio_compat.h"
 
 namespace AGS
 {
@@ -25,6 +26,29 @@ bool CreateDirectory(const String &path)
         , 0755
 #endif
         ) == 0 || errno == EEXIST;
+}
+
+bool CreateAllDirectories(const String &parent, const String &path)
+{
+    if (!ags_directory_exists(parent.GetCStr()))
+        return false;
+    if (path.IsEmpty())
+        return true;
+    if (!Path::IsSameOrSubDir(parent, path))
+        return false;
+
+    String sub_path = Path::MakeRelativePath(parent, path);
+    String make_path = parent;
+    std::vector<String> dirs = sub_path.Split('/');
+    for (auto dir : dirs)
+    {
+        if (dir.IsEmpty() || dir.Compare(".") == 0) continue;
+        make_path.AppendChar('/');
+        make_path.Append(dir);
+        if (!CreateDirectory(make_path))
+            return false;
+    }
+    return true;
 }
 
 String SetCurrentDirectory(const String &path)

--- a/Common/util/directory.h
+++ b/Common/util/directory.h
@@ -30,6 +30,9 @@ namespace Directory
 {
     // Creates new directory (if it does not exist)
     bool   CreateDirectory(const String &path);
+    // Makes sure all directories in the path are created. Parent path is
+    // not touched, and function must fail if parent path is not accessible.
+    bool   CreateAllDirectories(const String &parent, const String &path);
     // Sets current working directory, returns the resulting path
     String SetCurrentDirectory(const String &path);
     // Gets current working directory

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -67,10 +67,10 @@ String GetDirectoryPath(const String &path)
     size_t slash_at = dir.FindCharReverse('/');
     if (slash_at != -1)
     {
-        dir.ClipMid(slash_at);
+        dir.ClipMid(slash_at + 1);
         return dir;
     }
-    return ".";
+    return "./";
 }
 
 bool IsSameOrSubDir(const String &parent, const String &path)

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -120,6 +120,15 @@ String MakePathNoSlash(const String &path)
     return dir_path;
 }
 
+String MakeTrailingSlash(const String &path)
+{
+    String dir_path = path;
+    FixupPath(dir_path);
+    if (dir_path.GetLast() != '/')
+        dir_path.AppendChar('/');
+    return dir_path;
+}
+
 String MakeAbsolutePath(const String &path)
 {
     if (path.IsEmpty())

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -137,11 +137,26 @@ String MakeAbsolutePath(const String &path)
     //    abs_path = long_path_buffer;
     //}
 #endif
-    char buf[512];
-    canonicalize_filename(buf, abs_path, 512);
+    char buf[MAX_PATH];
+    canonicalize_filename(buf, abs_path, MAX_PATH);
     abs_path = buf;
     FixupPath(abs_path);
     return abs_path;
+}
+
+String MakeRelativePath(const String &base, const String &path)
+{
+    char can_parent[MAX_PATH];
+    char can_path[MAX_PATH];
+    char relative[MAX_PATH];
+    // canonicalize_filename treats "." as "./." (file in working dir)
+    const char *use_parent = base == "." ? "./" : base;
+    const char *use_path = path == "." ? "./" : path;
+    canonicalize_filename(can_parent, use_parent, MAX_PATH);
+    canonicalize_filename(can_path, use_path, MAX_PATH);
+    String rel_path = make_relative_filename(relative, can_parent, can_path, MAX_PATH);
+    FixupPath(rel_path);
+    return rel_path;
 }
 
 String ConcatPaths(const String &parent, const String &child)

--- a/Common/util/path.h
+++ b/Common/util/path.h
@@ -54,6 +54,8 @@ namespace Path
     void    FixupPath(String &path);
     // Fixups path and removes trailing slash
     String  MakePathNoSlash(const String &path);
+    // Fixups path and adds trailing slash if it's missing
+    String  MakeTrailingSlash(const String &path);
     // Converts any path to an absolute path; relative paths are assumed to
     // refer to the current working directory.
     String  MakeAbsolutePath(const String &path);

--- a/Common/util/path.h
+++ b/Common/util/path.h
@@ -54,7 +54,12 @@ namespace Path
     void    FixupPath(String &path);
     // Fixups path and removes trailing slash
     String  MakePathNoSlash(const String &path);
+    // Converts any path to an absolute path; relative paths are assumed to
+    // refer to the current working directory.
     String  MakeAbsolutePath(const String &path);
+    // Tries to create a relative path that would point to 'path' location
+    // if walking out of the 'base'. Returns empty string on failure.
+    String  MakeRelativePath(const String &base, const String &path);
     // Concatenates parent and relative paths
     String  ConcatPaths(const String &parent, const String &child);
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -409,6 +409,24 @@ String String::Section(char separator, size_t first, size_t last,
     return String();
 }
 
+std::vector<String> String::Split(char separator) const
+{
+    std::vector<String> result;
+    if (!_meta || !separator)
+        return result;
+    const char *ptr = _meta->CStr;
+    while (*ptr)
+    {
+        const char *found_cstr = strchr(ptr, separator);
+        if (!found_cstr) break;
+        result.push_back(String(ptr, found_cstr - ptr));
+        ptr = found_cstr + 1;
+    }
+    if (*ptr)
+        result.push_back(String(ptr));
+    return result;
+}
+
 void String::Reserve(size_t max_length)
 {
     if (_meta)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -39,6 +39,7 @@
 #define __AGS_CN_UTIL__STRING_H
 
 #include <stdarg.h>
+#include <vector>
 #include "core/platform.h"
 #include "core/types.h"
 #include "debug/assert.h"
@@ -209,6 +210,7 @@ public:
     // Extract the range of Xth to Yth fields, separated by the given character
     String  Section(char separator, size_t first, size_t last,
                               bool exclude_first_sep = true, bool exclude_last_sep = true) const;
+    std::vector<String> Split(char separator) const;
 
     //-------------------------------------------------------------------------
     // String modification methods

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -274,7 +274,7 @@ int DynamicSprite_SaveToFile(ScriptDynamicSprite *sds, const char* namm)
         filename.Append(".bmp");
 
     ResolvedPath rp;
-    if (!ResolveScriptPath(filename, false, rp))
+    if (!ResolveWritePathAndCreateDirs(filename, rp))
         return 0;
     return spriteset[sds->slot]->SaveToFile(rp.FullPath, palette) ? 1 : 0;
 }

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -273,10 +273,10 @@ int DynamicSprite_SaveToFile(ScriptDynamicSprite *sds, const char* namm)
     if (filename.FindChar('.') == -1)
         filename.Append(".bmp");
 
-    String path, alt_path; // alt_path is unused here, because it's a write op
-    if (!ResolveScriptPath(filename, false, path, alt_path))
+    ResolvedPath rp;
+    if (!ResolveScriptPath(filename, false, rp))
         return 0;
-    return spriteset[sds->slot]->SaveToFile(path, palette) ? 1 : 0;
+    return spriteset[sds->slot]->SaveToFile(rp.FullPath, palette) ? 1 : 0;
 }
 
 ScriptDynamicSprite* DynamicSprite_CreateFromSaveGame(int sgslot, int width, int height) {

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -364,6 +364,18 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
     return true;
 }
 
+bool ResolveWritePathAndCreateDirs(const String &sc_path, ResolvedPath &rp)
+{
+    if (!ResolveScriptPath(sc_path, false, rp))
+        return false;
+    if (!Directory::CreateAllDirectories(rp.BaseDir, Path::GetDirectoryPath(rp.FullPath)))
+    {
+        debug_script_warn("ResolveScriptPath: failed to create all subdirectories: %s", rp.FullPath);
+        return false;
+    }
+    return true;
+}
+
 bool LocateAsset(const AssetPath &path, AssetLocation &loc)
 {
     String assetlib = path.first;

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -370,7 +370,7 @@ bool ResolveWritePathAndCreateDirs(const String &sc_path, ResolvedPath &rp)
         return false;
     if (!Directory::CreateAllDirectories(rp.BaseDir, Path::GetDirectoryPath(rp.FullPath)))
     {
-        debug_script_warn("ResolveScriptPath: failed to create all subdirectories: %s", rp.FullPath);
+        debug_script_warn("ResolveScriptPath: failed to create all subdirectories: %s", rp.FullPath.GetCStr());
         return false;
     }
     return true;

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -60,23 +60,23 @@ String installVoiceDirectory;
 
 int File_Exists(const char *fnmm) {
 
-  String path, alt_path;
-  if (!ResolveScriptPath(fnmm, true, path, alt_path))
+  ResolvedPath rp;
+  if (!ResolveScriptPath(fnmm, true, rp))
     return 0;
 
-  return (File::TestReadFile(path) || File::TestReadFile(alt_path)) ? 1 : 0;
+  return (File::TestReadFile(rp.FullPath) || File::TestReadFile(rp.AltPath)) ? 1 : 0;
 }
 
 int File_Delete(const char *fnmm) {
 
-  String path, alt_path;
-  if (!ResolveScriptPath(fnmm, false, path, alt_path))
+  ResolvedPath rp;
+  if (!ResolveScriptPath(fnmm, false, rp))
     return 0;
 
-  if (::remove(path) == 0)
+  if (::remove(rp.FullPath) == 0)
       return 1;
-  if (errno == ENOENT && !alt_path.IsEmpty() && alt_path.Compare(path) != 0)
-      return ::remove(alt_path) == 0 ? 1 : 0;
+  if (errno == ENOENT && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+      return ::remove(rp.AltPath) == 0 ? 1 : 0;
   return 0;
 }
 
@@ -274,10 +274,9 @@ String MakeAppDataPath()
     return app_data_path;
 }
 
-bool ResolveScriptPath(const String &orig_sc_path, bool read_only, String &path, String &alt_path)
+bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath &rp)
 {
-    path.Empty();
-    alt_path.Empty();
+    rp = ResolvedPath();
 
     bool is_absolute = !is_relative_filename(orig_sc_path);
     if (is_absolute && !read_only)
@@ -286,17 +285,16 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, String &path,
         return false;
     }
 
-    String parent_dir;
-    String child_path;
-
     if (is_absolute)
     {
-        path = orig_sc_path;
+        rp.FullPath = orig_sc_path;
         return true;
     }
 
     String sc_path = FixSlashAfterToken(orig_sc_path);
-    
+    String parent_dir;
+    String child_path;
+    String alt_path;
     if (sc_path.CompareLeft(GameInstallRootToken, GameInstallRootToken.GetLength()) == 0)
     {
         if (!read_only)
@@ -350,17 +348,19 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, String &path,
     if (child_path[0u] == '\\' || child_path[0u] == '/')
         child_path.ClipLeft(1);
 
-    path = String::FromFormat("%s%s", parent_dir.GetCStr(), child_path.GetCStr());
+    String full_path = String::FromFormat("%s%s", parent_dir.GetCStr(), child_path.GetCStr());
     // don't allow write operations for relative paths outside game dir
     if (!read_only)
     {
-        if (!Path::IsSameOrSubDir(parent_dir, path))
+        if (!Path::IsSameOrSubDir(parent_dir, full_path))
         {
             debug_script_warn("Attempt to access file '%s' denied (outside of game directory)", sc_path.GetCStr());
-            path = "";
             return false;
         }
     }
+    rp.BaseDir = parent_dir;
+    rp.FullPath = full_path;
+    rp.AltPath = alt_path;
     return true;
 }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -373,20 +373,22 @@ String get_save_game_path(int slotNum) {
 }
 
 // Convert a path possibly containing path tags into acceptable save path
-String MakeSaveGameDir(const char *newFolder)
+bool MakeSaveGameDir(const String &newFolder, ResolvedPath &rp)
 {
+    rp = ResolvedPath();
     // don't allow absolute paths
     if (!is_relative_filename(newFolder))
-        return "";
+        return false;
 
+    String base_dir;
     String newSaveGameDir = FixSlashAfterToken(newFolder);
 
     if (newSaveGameDir.CompareLeft(UserSavedgamesRootToken, UserSavedgamesRootToken.GetLength()) == 0)
     {
         if (saveGameParent.IsEmpty())
         {
-            newSaveGameDir.ReplaceMid(0, UserSavedgamesRootToken.GetLength(),
-                PathOrCurDir(platform->GetUserSavedgamesDirectory()));
+            base_dir = PathOrCurDir(platform->GetUserSavedgamesDirectory());
+            newSaveGameDir.ReplaceMid(0, UserSavedgamesRootToken.GetLength(), base_dir);
         }
         else
         {
@@ -396,6 +398,7 @@ String MakeSaveGameDir(const char *newFolder)
             if (!newSaveGameDir.IsEmpty())
                 newSaveGameDir.PrependChar('/');
             newSaveGameDir.Prepend(saveGameParent);
+            base_dir = saveGameParent;
         }
     }
     else
@@ -403,18 +406,25 @@ String MakeSaveGameDir(const char *newFolder)
         // Convert the path relative to installation folder into path relative to the
         // safe save path with default name
         if (saveGameParent.IsEmpty())
-            newSaveGameDir.Format("%s/%s/%s", PathOrCurDir(platform->GetUserSavedgamesDirectory()),
-                game.saveGameFolderName, newFolder);
+        {
+            base_dir = PathOrCurDir(platform->GetUserSavedgamesDirectory());
+            newSaveGameDir.Format("%s/%s/%s", base_dir.GetCStr(), game.saveGameFolderName, newFolder.GetCStr());
+        }
         else
-            newSaveGameDir.Format("%s/%s", saveGameParent.GetCStr(), newFolder);
+        {
+            base_dir = saveGameParent;
+            newSaveGameDir.Format("%s/%s", saveGameParent.GetCStr(), newFolder.GetCStr());
+        }
         // For games made in the safe-path-aware versions of AGS, report a warning
         if (game.options[OPT_SAFEFILEPATHS])
         {
             debug_script_warn("Attempt to explicitly set savegame location relative to the game installation directory ('%s') denied;\nPath will be remapped to the user documents directory: '%s'",
-                newFolder, newSaveGameDir.GetCStr());
+                newFolder.GetCStr(), newSaveGameDir.GetCStr());
         }
     }
-    return newSaveGameDir;
+    rp.BaseDir = Path::MakeTrailingSlash(base_dir);
+    rp.FullPath = Path::MakeTrailingSlash(newSaveGameDir);
+    return true;
 }
 
 bool SetCustomSaveParent(const String &path)
@@ -431,15 +441,27 @@ bool SetSaveGameDirectoryPath(const char *newFolder, bool explicit_path)
 {
     if (!newFolder || newFolder[0] == 0)
         newFolder = ".";
-    String newSaveGameDir = explicit_path ? String(newFolder) : MakeSaveGameDir(newFolder);
-    if (newSaveGameDir.IsEmpty())
-        return false;
+    String newSaveGameDir;
+    if (explicit_path)
+    {
+        newSaveGameDir = Path::MakeTrailingSlash(newFolder);
+        if (!Directory::CreateDirectory(newSaveGameDir))
+            return false;
+    }
+    else
+    {
+        ResolvedPath rp;
+        if (!MakeSaveGameDir(newFolder, rp))
+            return false;
+        if (!Directory::CreateAllDirectories(rp.BaseDir, rp.FullPath))
+        {
+            debug_script_warn("SetSaveGameDirectory: failed to create all subdirectories: %s", rp.FullPath.GetCStr());
+            return false;
+        }
+        newSaveGameDir = rp.FullPath;
+    }
 
-    if (!Directory::CreateDirectory(newSaveGameDir))
-        return false;
-    newSaveGameDir.AppendChar('/');
-
-    String newFolderTempFile = String::FromFormat("%s/agstmp.tmp", newSaveGameDir.GetCStr());
+    String newFolderTempFile = String::FromFormat("%s""agstmp.tmp", newSaveGameDir.GetCStr());
     if (!Common::File::TestCreateFile(newFolderTempFile))
         return false;
 

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -30,13 +30,13 @@ extern IGraphicsDriver *gfxDriver;
 
 int LoadImageFile(const char *filename)
 {
-    String path, alt_path;
-    if (!ResolveScriptPath(filename, true, path, alt_path))
+    ResolvedPath rp;
+    if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
-    Bitmap *loadedFile = BitmapHelper::LoadFromFile(path);
-    if (!loadedFile && !alt_path.IsEmpty() && alt_path.Compare(path) != 0)
-        loadedFile = BitmapHelper::LoadFromFile(alt_path);
+    Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
+    if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+        loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
     if (!loadedFile)
         return 0;
 

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -19,6 +19,9 @@
 #include "ac/path_helper.h"
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
+#include "debug/debug_log.h"
+#include "util/directory.h"
+#include "util/path.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
@@ -65,8 +68,16 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
     return 0;
 
   ResolvedPath rp;
-  if (!ResolveScriptPath(fnmm, (open_mode == Common::kFile_Open && work_mode == Common::kFile_Read), rp))
-    return 0;
+  if (open_mode == kFile_Open && work_mode == kFile_Read)
+  {
+    if (!ResolveScriptPath(fnmm, true, rp))
+      return 0;
+  }
+  else
+  {
+    if (!ResolveWritePathAndCreateDirs(fnmm, rp))
+      return 0;
+  }
 
   Stream *s = File::OpenFile(rp.FullPath, open_mode, work_mode);
   if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -43,9 +43,8 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
 {
   int useindx = 0;
 
-  String path, alt_path;
-  if (!ResolveScriptPath(fnmm, (open_mode == Common::kFile_Open && work_mode == Common::kFile_Read),
-      path, alt_path))
+  ResolvedPath rp;
+  if (!ResolveScriptPath(fnmm, (open_mode == Common::kFile_Open && work_mode == Common::kFile_Read), rp))
     return 0;
 
   // find a free file handle to use
@@ -55,9 +54,9 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
       break;
   }
 
-  Stream *s = File::OpenFile(path, open_mode, work_mode);
-  if (!s && !alt_path.IsEmpty() && alt_path.Compare(path) != 0)
-    s = File::OpenFile(alt_path, open_mode, work_mode);
+  Stream *s = File::OpenFile(rp.FullPath, open_mode, work_mode);
+  if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+    s = File::OpenFile(rp.AltPath, open_mode, work_mode);
 
   valid_handles[useindx].stream = s;
   if (valid_handles[useindx].stream == nullptr)

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -67,14 +67,14 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   listbox->Clear();
   guis_need_update = 1;
 
-  String path, alt_path;
-  if (!ResolveScriptPath(filemask, true, path, alt_path))
+  ResolvedPath rp;
+  if (!ResolveScriptPath(filemask, true, rp))
     return;
 
   std::set<String> files;
-  FillDirList(files, path);
-  if (!alt_path.IsEmpty() && alt_path.Compare(path) != 0)
-    FillDirList(files, alt_path);
+  FillDirList(files, rp.FullPath);
+  if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+    FillDirList(files, rp.AltPath);
 
   for (std::set<String>::const_iterator it = files.begin(); it != files.end(); ++it)
   {

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -57,6 +57,11 @@ struct ResolvedPath
 // Returns 'true' on success, and 'false' if either path is impossible to resolve
 // or if the file path is forbidden to be accessed in current situation.
 bool ResolveScriptPath(const String &sc_path, bool read_only, ResolvedPath &rp);
+// Resolves a user file path for writing, and makes sure all the sub-directories are
+// created along the actual path.
+// Returns 'true' on success, and 'false' if either path is impossible to resolve,
+// forbidden for writing, or if failed to create any subdirectories.
+bool ResolveWritePathAndCreateDirs(const String &sc_path, ResolvedPath &rp);
 
 // Sets an optional path to treat like game's installation directory
 void    set_install_dir(const String &path, const String &audio_path, const String &voice_path);

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -43,12 +43,20 @@ String FixSlashAfterToken(const String &path);
 // custom game's directory name.
 // If the path is relative, keeps it unmodified (no extra subdir added).
 String MakeSpecialSubDir(const String &sp_dir);
+
+// ResolvedPath describes an actual location pointed by a user path (e.g. from script)
+struct ResolvedPath
+{
+    String BaseDir; // base directory, one of the special path roots
+    String FullPath;// full path
+    String AltPath; // alternative full path, for backwards compatibility
+};
 // Resolves a file path provided by user (e.g. script) into actual file path,
 // by substituting special keywords with actual platform-specific directory names.
-// Sets a primary and alternate paths; the latter is for backwards compatibility only.
+// Fills in ResolvedPath object on success.
 // Returns 'true' on success, and 'false' if either path is impossible to resolve
 // or if the file path is forbidden to be accessed in current situation.
-bool ResolveScriptPath(const String &sc_path, bool read_only, String &path, String &alt_path);
+bool ResolveScriptPath(const String &sc_path, bool read_only, ResolvedPath &rp);
 
 // Sets an optional path to treat like game's installation directory
 void    set_install_dir(const String &path, const String &audio_path, const String &voice_path);

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -16,6 +16,7 @@
 #if AGS_PLATFORM_DEBUG
 
 #include <string.h>
+#include <vector>
 #include "util/path.h"
 #include "util/string.h"
 #include "debug/assert.h"
@@ -455,6 +456,17 @@ void Test_String()
         assert(strcmp(str10, "") == 0);
         assert(strcmp(str11, "MyNewGame") == 0);
         assert(strcmp(str12, "\\MyNewGame") == 0);
+    }
+
+    // Test Split
+    {
+        String str1 = "C:\\Games\\AGS\\MyNewGame\\";
+        std::vector<String> result = str1.Split('\\');
+        assert(result.size() == 4);
+        assert(strcmp(result[0], "C:") == 0);
+        assert(strcmp(result[1], "Games") == 0);
+        assert(strcmp(result[2], "AGS") == 0);
+        assert(strcmp(result[3], "MyNewGame") == 0);
     }
 }
 


### PR DESCRIPTION
For #697.

This ensures that when the script commands to open a file for writing in a special game location all subdirectories are created beforehand.
Engine ofcourse must test that these subdirectories are nested inside the allowed location.

Affected API:
* File.Open (write only)
* DynamicSprite.SaveToFile
* Game.SetSaveGameDirectory
