### PR TITLE
Game file name option in General Settings

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -78,7 +78,7 @@ namespace AGS.Editor
          * 17: 3.5.0.4    - Extended sprite source properties
          * 18: 3.5.0.8    - Disallow relative asset resolutions by default, added flag for compatibility;
          *                  Real sprite resolution; Individual font scaling; Default room mask resolution
-         * 19: 3.5.0.11   - Custom Say and Narrate functions for dialog scripts.
+         * 19: 3.5.0.11   - Custom Say and Narrate functions for dialog scripts. GameFileName.
         */
         public const int    LATEST_XML_VERSION_INDEX = 19;
         /*
@@ -207,7 +207,11 @@ namespace AGS.Editor
 
         public string BaseGameFileName
         {
-            get { return Path.GetFileName(this.GameDirectory); }
+            get
+            {
+                return string.IsNullOrWhiteSpace(_game.Settings.GameFileName) ?
+                    Path.GetFileName(this.GameDirectory) : _game.Settings.GameFileName;
+            }
         }
 
         public Script BuiltInScriptHeader

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
@@ -56,6 +56,10 @@ namespace AGS.Editor
             }
         }
 
+        public virtual void DeleteMainGameData(string name)
+        {
+        }
+
         public virtual bool IsAvailable
         {
             get

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -19,6 +19,12 @@ namespace AGS.Editor
             return new string[] { GetCompiledPath() };
         }
 
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(OutputDirectoryFullPath, name + ".ags");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
         private void DeleteAnyExistingSplitResourceFiles()
         {
             foreach (string fileName in Utilities.GetDirectoryFileList(GetCompiledPath(), Factory.AGSEditor.BaseGameFileName + ".0*"))

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
@@ -34,6 +34,12 @@ namespace AGS.Editor
             return GetCompiledPath(parts);
         }
 
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(Path.Combine(OutputDirectoryFullPath, DEBUG_DIRECTORY), name + ".exe");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
         private object CreateDebugFiles(object parameter)
         {
             Factory.AGSEditor.SetMODMusicFlag();

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -68,6 +68,12 @@ namespace AGS.Editor
             };
         }
 
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(Path.Combine(OutputDirectoryFullPath, LINUX_DATA_DIR), name + ".ags");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
         private bool CheckPluginsHaveSharedLibraries()
         {
             _plugins.Clear();

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -24,6 +24,12 @@ namespace AGS.Editor
             return new string[] { GetCompiledPath() };
         }
 
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(OutputDirectoryFullPath, name + ".exe");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
         public void CopyPlugins(CompileMessages errors)
         {
             try

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -127,9 +127,9 @@ namespace AGS.Editor
 
             if (game != null)
             {
+                game.DirectoryPath = gameDirectory;
                 SetDefaultValuesForNewFeatures(game);
 
-                game.DirectoryPath = gameDirectory;
                 Utilities.EnsureStandardSubFoldersExist();
 
                 RecentGame recentGame = new RecentGame(game.Settings.GameName, gameDirectory);
@@ -221,6 +221,11 @@ namespace AGS.Editor
             {
                 game.Settings.AllowRelativeAssetResolutions = true;
                 game.Settings.DefaultRoomMaskResolution = game.IsHighResolution ? 2 : 1;
+            }
+
+            if (xmlVersionIndex < 19)
+            {
+                game.Settings.GameFileName = AGSEditor.Instance.BaseGameFileName;
             }
 
             game.SetScriptAPIForOldProject();

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -226,6 +226,13 @@ namespace AGS.Editor
             if (xmlVersionIndex < 19)
             {
                 game.Settings.GameFileName = AGSEditor.Instance.BaseGameFileName;
+
+                var buildNames = new Dictionary<string, string>();
+                foreach (IBuildTarget target in BuildTargetsInfo.GetRegisteredBuildTargets())
+                {
+                    buildNames[target.Name] = AGSEditor.Instance.BaseGameFileName;
+                }
+                game.WorkspaceState.SetLastBuildGameFiles(buildNames);
             }
 
             game.SetScriptAPIForOldProject();

--- a/Editor/AGS.Types/Interfaces/IBuildTarget.cs
+++ b/Editor/AGS.Types/Interfaces/IBuildTarget.cs
@@ -43,6 +43,11 @@ namespace AGS.Types
         /// </summary>
         void EnsureStandardSubfoldersExist();
         /// <summary>
+        /// Temporary solution for cleaning old compiled game in
+        /// case game binary name was changed.
+        /// </summary>
+        void DeleteMainGameData(string name);
+        /// <summary>
         /// Attempts to build the target. Compilation errors will
         /// be added to the ERRORS collection. Returns whether or
         /// not the target was successfully built. You should not

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -16,7 +16,7 @@ namespace AGS.Types
     {
         // TODO: reimplement the handling of property value changes in the Editor assembly
         // so that relying on property labels is no longer necessary!
-        public const string PROPERTY_GAME_NAME = "Game name";
+        public const string PROPERTY_GAME_NAME = "Game title";
         public const string PROPERTY_COLOUR_DEPTH = "Colour depth";
         public const string PROPERTY_RESOLUTION = "Resolution";
         public const string PROPERTY_LEGACY_HIRES_FONTS = "Fonts designed for high resolution";
@@ -36,6 +36,7 @@ namespace AGS.Types
 			GenerateNewGameID();
         }
 
+        private string _gameFileName = "";
         private string _gameName = "New game";
         private Size _resolution = new Size(320, 200);
         private GameColorDepth _colorDepth = GameColorDepth.HighColor;
@@ -150,7 +151,16 @@ namespace AGS.Types
 			_guid = Guid.NewGuid();
 		}
 
-		[DisplayName(PROPERTY_GAME_NAME)]
+        [DisplayName("Game file name")]
+        [Description("The game's binary name (the name of the file AGS will create after compiling the game). Leave empty to use project folder's name.")]
+        [Category("(Basic properties)")]
+        public string GameFileName
+        {
+            get { return _gameFileName; }
+            set { _gameFileName = value; }
+        }
+
+        [DisplayName(PROPERTY_GAME_NAME)]
         [Description("The game's name (for display in the title bar)")]
         [Category("(Basic properties)")]
         public string GameName

--- a/Editor/AGS.Types/WorkspaceState.cs
+++ b/Editor/AGS.Types/WorkspaceState.cs
@@ -10,8 +10,9 @@ namespace AGS.Types
 	public class WorkspaceState
 	{
 		private BuildConfiguration _lastBuildConfiguration = AGS.Types.BuildConfiguration.Unknown;
+        private string _lastBuildGameFileName = "";
 
-		public WorkspaceState()
+        public WorkspaceState()
 		{
 		}
 
@@ -23,7 +24,39 @@ namespace AGS.Types
 			set { _lastBuildConfiguration = value; }
 		}
 
-		public void ToXml(XmlTextWriter writer)
+        [Browsable(false)]
+        public string LastBuildGameFileName
+        {
+            get { return _lastBuildGameFileName; }
+            set { _lastBuildGameFileName = value; }
+        }
+
+        // TODO: generic method of serializing key-value list in a string (or other xml element)
+        private static string[] StringListSeparators = new string[] { "," };
+        private static string[] KeyValueSeparators = new string[] { "=" };
+
+        public Dictionary<string, string> GetLastBuildGameFiles()
+        {
+            var dic = new Dictionary<string, string>();
+            string[] files = _lastBuildGameFileName.Split(StringListSeparators, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string item in files)
+            {
+                string[] keyval = item.Split(KeyValueSeparators, StringSplitOptions.None);
+                if (keyval.Length >= 2 && !string.IsNullOrWhiteSpace(keyval[0]))
+                    dic[keyval[0]] = keyval[1];
+            }
+            return dic;
+        }
+
+        public void SetLastBuildGameFiles(IReadOnlyDictionary<string, string> dic)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var item in dic)
+                sb.AppendFormat("{0}={1},", item.Key, item.Value);
+            _lastBuildGameFileName = sb.ToString();
+        }
+
+        public void ToXml(XmlTextWriter writer)
 		{
 			SerializeUtils.SerializeToXML(this, writer);
 		}


### PR DESCRIPTION
For #629.

This adds Game File Name setting that user may change anytime. It may also be left empty to use current project directory's name, as before.

Additionally Editor will now track last binary name used when building each target separately and store these in workspace file (Game.agf.user). Whenever target is rebuilt, if current game file name is different from its last recorded one, editor will try to delete file of old name if it still exists.