### PR TITLE
Compiler: fixed accessing non-static members of static members

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -1347,6 +1347,7 @@ long extract_variable_name(int fsym, ccInternalList*targ,long*slist, int *funcAt
         reallywant = fsym;
       }
       else {
+        mustBeStaticMember = 0;
         reallywant = sym.entries[fsym].vartype;
         if (reallywant < 1) {
           cc_error("structure required on left side of '.'");

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -496,3 +496,46 @@ TEST(Compile, AccessMembersInSequence) {
     ASSERT_EQ(0, compileResult);
 }
 
+TEST(Compile, AccessNonStaticMemberOfAType) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct A {\
+            import attribute int x;\
+        };\
+        \
+        builtin struct B {\
+            import readonly attribute A *a;\
+        };\
+        \
+        void Func() {\
+            int a = B.a.x;\
+        }";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("must have an instance of the struct to access a non-static member", last_seen_cc_error());
+}
+
+TEST(Compile, AccessNonStaticMemberOfAStaticMember) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct A {\
+            import attribute int x;\
+        };\
+        \
+        builtin struct B {\
+            import static readonly attribute A *a;\
+        };\
+        \
+        void Func() {\
+            int a = B.a.x;\
+        }";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    printf("Error: %s\n", last_seen_cc_error());
+    ASSERT_EQ(0, compileResult);
+}


### PR DESCRIPTION
Fixes #242.

Now, I spent a day poking around the compiler (and fixing few other minor issues in the process) but ended up with 1-line fix... which may be a correct thing, but it bothers me by how simple it is.

May there be other relevant test cases for this in addition to one I added?

**PS.** To elaborate a bit, this function I modified, **extract_variable_name()**, it seems that what it does is gathering a list of symbols accessed in a chain (i.e. "x.y.z.a"). The problem was that when the first member is a type, it set up a flag saying that the next member must be static, but did not reset it when next member was a static member which could have non-static members on its own naturally.
So my fix resets the flag in that case, allowing the function to continue parsing this chain.

**PPS.** Right, I forgot to tell, I tested this in game with the following real script:
<pre>
function TestStatics(int z)
{
  int a = Screen.Viewport.X;
  Display("%d", a);
  Screen.Viewport.X += z;
}

function on_key_press(eKeyCode keycode) 
{
    TestStatics(1);
}
</pre>