### PR TITLE
3.5.0 Android fixes

### DIFF
--- a/Android/library/jni/Android.mk
+++ b/Android/library/jni/Android.mk
@@ -27,7 +27,7 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := pe
-LOCAL_SRC_FILES := ../Android/library/jni/pe_jni.c ../Engine/platform/util/pe.c
+LOCAL_SRC_FILES := ../Android/library/jni/pe_jni.c ../Common/util/stdio_compat.c ../Engine/platform/util/pe.c
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -I$(AGS_COMMON_PATH)
 LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
 LOCAL_LDLIBS    := -lc -llog

--- a/Android/library/jni/Android.mk
+++ b/Android/library/jni/Android.mk
@@ -3,6 +3,7 @@ LOCAL_PATH := $(call my-dir)/../../../Engine
 ADDITIONAL_LIBRARY_PATH := $(call my-dir)/../../nativelibs/$(TARGET_ARCH_ABI)
 AGS_COMMON_PATH := $(call my-dir)/../../../Common
 AGS_ENGINE_PATH := $(call my-dir)/../../../Engine
+AGS_DEFAULT_CXXFLAGS = -std=c++11 -Wno-write-strings -Wno-reserved-user-defined-literal
 
 include $(CLEAR_VARS)
 
@@ -15,7 +16,7 @@ include ../../Engine/Makefile-objs
 LOCAL_MODULE    := agsengine
 LOCAL_SRC_FILES := $(BASE) $(BASE_PLATFORM) $(COMMON) $(COMMON_PLATFORM) $(ALFONT) $(ALMP3) $(ALOGG) $(APEG) $(AASTR) $(AL_MIDI_PATCH)
 LOCAL_CFLAGS    := -g -ffast-math -fsigned-char -Wall -Wfatal-errors -Wno-deprecated-declarations -Wno-psabi -Wno-logical-op-parentheses -Wno-bitwise-op-parentheses -Wno-logical-not-parentheses -Wno-unknown-pragmas -Wno-unknown-warning-option -DAGS_INVERTED_COLOR_ORDER -DALLEGRO_STATICLINK -DANDROID_VERSION -DDISABLE_MPEG_AUDIO -DUSE_TREMOR -I$(ADDITIONAL_LIBRARY_PATH)/include -I$(ADDITIONAL_LIBRARY_PATH)/include/freetype2 -I$(AGS_ENGINE_PATH) -I$(AGS_COMMON_PATH) -I$(AGS_COMMON_PATH)/libinclude
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -std=c++11 -Wno-write-strings -Wno-reserved-user-defined-literal
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lalleg -lfreetype -lvorbisidec -ltheora -logg -laldmb -ldumb -lstdc++ -Wl,-Bdynamic -lc -ldl -lm -lz -llog -lGLESv1_CM -lGLESv2
 LOCAL_LDFLAGS   := -Wl,-L$(ADDITIONAL_LIBRARY_PATH)/lib,--allow-multiple-definition
 LOCAL_ARM_MODE  := arm
@@ -42,7 +43,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := ags_snowrain
 LOCAL_SRC_FILES := ../Plugins/ags_snowrain/ags_snowrain.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH)
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm -llog
 LOCAL_LDFLAGS   :=
 
@@ -55,7 +56,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := agsblend
 LOCAL_SRC_FILES := ../Plugins/agsblend/AGSBlend.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH)
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm -llog
 LOCAL_LDFLAGS   :=
 
@@ -68,7 +69,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := agsflashlight
 LOCAL_SRC_FILES := ../Plugins/AGSflashlight/agsflashlight.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH)
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm -llog
 LOCAL_LDFLAGS   :=
 
@@ -94,7 +95,7 @@ LOCAL_SRC_FILES := ../Plugins/agslua/agslua/agslua/agslua_autogen.cpp \
 ../Plugins/agslua/agslua/agslua/pdep.c \
 ../Plugins/agslua/agslua/agslua/lzio.c
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DTHIS_IS_THE_PLUGIN -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH) -I$(AGS_COMMON_PATH)/../Plugins/agslua/agslua/lualibhelp/include -I$(ADDITIONAL_LIBRARY_PATH)/include
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -llua -Wl,-Bdynamic -lc -lm -llog -lz
 LOCAL_LDFLAGS   := -Wl,-L$(ADDITIONAL_LIBRARY_PATH)/lib
 
@@ -113,7 +114,7 @@ LOCAL_SRC_FILES := ../Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp \
 ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp \
 ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DTHIS_IS_THE_PLUGIN -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH) -I$(ADDITIONAL_LIBRARY_PATH)/include
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm -llog -lz
 LOCAL_LDFLAGS   := -Wl,-L$(ADDITIONAL_LIBRARY_PATH)/lib,--allow-multiple-definition
 
@@ -126,7 +127,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := ags_parallax
 LOCAL_SRC_FILES := ../Plugins/ags_parallax/ags_parallax.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH)
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -Wno-write-strings
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm
 LOCAL_LDFLAGS   :=
 
@@ -139,7 +140,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := agspalrender
 LOCAL_SRC_FILES := ../Plugins/agspalrender/ags_palrender.cpp ../Plugins/agspalrender/raycast.cpp
 LOCAL_CFLAGS    := -O2 -g -ffast-math -fsigned-char -Wall -Wfatal-errors -DLINUX_VERSION -DANDROID_VERSION -I$(AGS_COMMON_PATH)
-LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) -std=c++11 -Wno-write-strings -Wno-reserved-user-defined-literal
+LOCAL_CXXFLAGS  := $(LOCAL_CFLAGS) $(AGS_DEFAULT_CXXFLAGS)
 LOCAL_LDLIBS    := -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -lc -lm
 LOCAL_LDFLAGS   :=
 

--- a/Engine/Makefile-objs
+++ b/Engine/Makefile-objs
@@ -24,7 +24,7 @@ ifdef TARGET_ARCH_ABI
 # For Android: make the path relative to the build directory to search for
 # the files and then strip the path again
 BASE_subdirs_width_prefix := $(addprefix $(LOCAL_PATH)/,$(BASE_subdirs))
-BASE_subdirs_complete := $(addsuffix /*.cpp,$(BASE_subdirs_width_prefix))
+BASE_subdirs_complete := $(addsuffix /*.cpp,$(BASE_subdirs_width_prefix)) $(wildcard $(addsuffix /*.c,$(BASE_subdirs_width_prefix)))
 BASE_full := $(wildcard $(BASE_subdirs_complete))
 BASE := $(subst $(LOCAL_PATH)/,,$(BASE_full))
 else
@@ -48,7 +48,7 @@ ifdef TARGET_ARCH_ABI
 # For Android: make the path relative to the build directory to search for
 # the files and then strip the path again
 COMMON_subdirs_width_prefix := $(addprefix $(LOCAL_PATH)/,$(COMMON_subdirs))
-COMMON_subdirs_complete := $(addsuffix /*.cpp,$(COMMON_subdirs_width_prefix))
+COMMON_subdirs_complete := $(addsuffix /*.cpp,$(COMMON_subdirs_width_prefix)) $(wildcard $(addsuffix /*.c,$(COMMON_subdirs_width_prefix)))
 COMMON_full := $(wildcard $(COMMON_subdirs_complete))
 COMMON := $(subst $(LOCAL_PATH)/,,$(COMMON_full))
 else

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 
-#include <cmath>
+#include <math.h>
 
 #include "ac/display.h"
 #include "ac/common.h"
@@ -404,7 +404,7 @@ int GetTextDisplayLength(const char *text)
 
 int GetTextDisplayTime(const char *text, int canberel) {
     int uselen = 0;
-    auto fpstimer = std::lround(get_current_fps());
+    auto fpstimer = ::lround(get_current_fps());
 
     // if it's background speech, make it stay relative to game speed
     if ((canberel == 1) && (play.bgspeech_game_speed == 1))

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 
-#include <cmath>
+#include <math.h>
 
 #include "core/platform.h"
 #include "ac/audiocliptype.h"
@@ -385,7 +385,7 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
-    return std::lround(get_current_fps()) - play.game_speed_modifier;
+    return ::lround(get_current_fps()) - play.game_speed_modifier;
 }
 
 int SetGameOption (int opt, int setting) {

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -16,7 +16,7 @@
 // Game update procedure
 //
 
-#include <cmath>
+#include <math.h>
 #include "ac/common.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
@@ -272,7 +272,7 @@ void update_speech_and_messages()
     {
         if (!play.speech_in_post_state)
         {
-            play.messagetime = std::lround(play.speech_display_post_time_ms * get_current_fps() / 1000.0f);
+            play.messagetime = ::lround(play.speech_display_post_time_ms * get_current_fps() / 1000.0f);
         }
         play.speech_in_post_state = !play.speech_in_post_state;
     }

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 
-#include <cmath>
+#include <math.h>
 
 #include "core/platform.h"
 #include "util/wgt2allg.h"
@@ -979,7 +979,7 @@ void update_audio_system_on_game_loop ()
                         // we want to crossfade, and we know how far through
                         // the tune we are
                         int takesSteps = calculate_max_volume() / game.options[OPT_CROSSFADEMUSIC];
-                        int takesMs = std::lround(takesSteps * 1000.0f / get_current_fps());
+                        int takesMs = ::lround(takesSteps * 1000.0f / get_current_fps());
                         if (curpos >= muslen - takesMs)
                             play_next_queued();
                     }

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -26,7 +26,7 @@
 #include <sys/stat.h> 
 #include <ctype.h>
 #include <unistd.h>
-#include "util/string_utils.h"
+#include "util/string_compat.h"
 
 
 


### PR DESCRIPTION
Fixing Android build. Most things are trivial, but one I'd like to note is that apparently the older NDK version we suggest building against _does not have std::lround implemented_, even though they support C++11 in general.
Could be related: https://github.com/android-ndk/ndk/issues/82

So I went on to replace all the std::lround in our code to lround from C library.