### PR TITLE
3.5.0: fix Sprite Cache after faulty refactor

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -183,7 +183,7 @@ sprkey_t SpriteCache::EnlargeTo(sprkey_t topmost)
     return topmost;
 }
 
-sprkey_t SpriteCache::AddNewSprite()
+sprkey_t SpriteCache::GetFreeIndex()
 {
     for (size_t i = MIN_SPRITE_INDEX; i < _spriteData.size(); ++i)
     {
@@ -277,8 +277,7 @@ Bitmap *SpriteCache::operator [] (sprkey_t index)
     return _spriteData[index].Image;
 }
 
-// Remove the oldest cache element
-void SpriteCache::RemoveOldest()
+void SpriteCache::DisposeOldest()
 {
     if (_liststart < 0)
         return;
@@ -292,7 +291,7 @@ void SpriteCache::RemoveOldest()
         // if such is met here there's something wrong with the internal cache logic!
         if (!_spriteData[sprnum].IsAssetSprite())
         {
-            quitprintf("SpriteCache::RemoveOldest: attempted to remove sprite %d that was added externally or does not exist", sprnum);
+            quitprintf("SpriteCache::DisposeOldest: attempted to remove sprite %d that was added externally or does not exist", sprnum);
         }
         _cacheSize -= _spriteData[sprnum].Size;
 
@@ -326,7 +325,7 @@ void SpriteCache::RemoveOldest()
             // let's just reset the cache
             Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: CACHE INCONSISTENT: RESETTING\n\tAt size %d (of %d), start %d end %d  fwdlink=%d",
                         _cacheSize, _maxCacheSize, oldstart, _listend, _liststart);
-            RemoveAll();
+            DisposeAll();
         }
     }
 
@@ -335,7 +334,7 @@ void SpriteCache::RemoveOldest()
 #endif
 }
 
-void SpriteCache::RemoveAll()
+void SpriteCache::DisposeAll()
 {
     _liststart = -1;
     _listend = -1;
@@ -388,12 +387,12 @@ size_t SpriteCache::LoadSprite(sprkey_t index)
 
     while (_cacheSize > _maxCacheSize)
     {
-        RemoveOldest();
+        DisposeOldest();
         hh++;
         if (hh > 1000)
         {
             Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "RUNTIME CACHE ERROR: STUCK IN FREE_UP_MEM; RESETTING CACHE");
-            RemoveAll();
+            DisposeAll();
         }
     }
 
@@ -777,7 +776,7 @@ HError SpriteCache::RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost
             _spriteData[i].Offset = 0;
             _spriteData[i].Image = nullptr;
 
-            initFile_initNullSpriteParams(i);
+            InitNullSpriteParams(i);
 
             if (in->EOS())
                 break;
@@ -892,7 +891,7 @@ bool SpriteCache::LoadSpriteIndexFile(int expectedFileID, soff_t spr_initial_off
         }
         else if (i > 0)
         {
-            initFile_initNullSpriteParams(i);
+            InitNullSpriteParams(i);
         }
     }
 

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -503,7 +503,9 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index)
     _sprInfos[index].Flags = _sprInfos[0].Flags;
     _sprInfos[index].Width = _sprInfos[0].Width;
     _sprInfos[index].Height = _sprInfos[0].Height;
+    _spriteData[index].Image = nullptr;
     _spriteData[index].Offset = _spriteData[0].Offset;
+    _spriteData[index].Size = _spriteData[0].Size;
     _spriteData[index].Flags |= SPRCACHEFLAG_REMAPPED;
 #ifdef DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "RemapSpriteToSprite0: %d", index);

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -160,6 +160,9 @@ void SpriteCache::SetSprite(sprkey_t index, Bitmap *sprite)
     _spriteData[index].Flags = SPRCACHEFLAG_LOCKED; // NOT from asset file
     _spriteData[index].Offset = 0;
     _spriteData[index].Size = 0;
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "SetSprite: (external) %d", index);
+#endif
 }
 
 void SpriteCache::SubstituteBitmap(sprkey_t index, Common::Bitmap *sprite)
@@ -170,6 +173,9 @@ void SpriteCache::SubstituteBitmap(sprkey_t index, Common::Bitmap *sprite)
         return;
     }
     _spriteData[index].Image = sprite;
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "SubstituteBitmap: %d", index);
+#endif
 }
 
 void SpriteCache::RemoveSprite(sprkey_t index, bool freeMemory)
@@ -177,6 +183,9 @@ void SpriteCache::RemoveSprite(sprkey_t index, bool freeMemory)
     if (freeMemory)
         delete _spriteData[index].Image;
     InitNullSpriteParams(index);
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "RemoveSprite: %d", index);
+#endif
 }
 
 sprkey_t SpriteCache::EnlargeTo(sprkey_t topmost)
@@ -341,7 +350,7 @@ void SpriteCache::DisposeOldest()
     }
 
 #ifdef DEBUG_SPRITECACHE
-    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Removed %d, size now %d KB", sprnum, _cacheSize / 1024);
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "DisposeOldest: disposed %d, size now %d KB", sprnum, _cacheSize / 1024);
 #endif
 }
 
@@ -483,7 +492,7 @@ size_t SpriteCache::LoadSprite(sprkey_t index)
     _cacheSize += size;
 
 #ifdef DEBUG_SPRITECACHE
-    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %lld, size now %u KB", index, _cacheSize / 1024);
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %d, size now %u KB", index, _cacheSize / 1024);
 #endif
 
     return size;
@@ -496,6 +505,9 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index)
     _sprInfos[index].Height = _sprInfos[0].Height;
     _spriteData[index].Offset = _spriteData[0].Offset;
     _spriteData[index].Flags |= SPRCACHEFLAG_REMAPPED;
+#ifdef DEBUG_SPRITECACHE
+    Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "RemapSpriteToSprite0: %d", index);
+#endif
 }
 
 const char *spriteFileSig = " Sprite File ";

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -101,8 +101,6 @@ public:
     sprkey_t    EnlargeTo(sprkey_t topmost);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
     sprkey_t    GetFreeIndex();
-    // Assigns bitmap to the given slot and locks it to prevent release from cache
-    void        SetSpriteAndLock(sprkey_t index, Common::Bitmap *);
     // Returns current size of the cache, in bytes
     size_t      GetCacheSize() const;
     // Gets the total size of the locked sprites, in bytes
@@ -115,6 +113,8 @@ public:
     sprkey_t    FindTopmostSprite() const;
     // Loads sprite and and locks in memory (so it cannot get removed implicitly)
     void        Precache(sprkey_t index);
+    // Remap the given index to the sprite 0
+    void        RemapSpriteToSprite0(sprkey_t index);
     // Unregisters sprite from the bank and optionally deletes bitmap
     void        RemoveSprite(sprkey_t index, bool freeMemory);
     // Deletes all loaded (non-locked, non-external) images from the cache;
@@ -122,8 +122,10 @@ public:
     void        DisposeAll();
     // Deletes all data and resets cache to the clear state
     void        Reset();
-    // Assigns new bitmap for the given sprite index
-    void        Set(sprkey_t index, Common::Bitmap *);
+    // Assigns new sprite for the given index; this sprite won't be auto disposed
+    void        SetSprite(sprkey_t index, Common::Bitmap *);
+    // Assigns new bitmap for the *registered* sprite without changing its properties
+    void        SubstituteBitmap(sprkey_t index, Common::Bitmap *);
     // Sets max cache size in bytes
     void        SetMaxCacheSize(size_t size);
 

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -46,12 +46,12 @@ typedef AGS::Common::HError HAGSError;
 
 struct SpriteInfo;
 
-// Tells that the sprite does not exist in the game resources.
-#define SPRCACHEFLAG_DOESNOTEXIST   0x01
-// Locked sprites are ones that should not be freed when clearing cache space.
-#define SPRCACHEFLAG_LOCKED         0x02
+// Tells that the sprite is found in the game resources.
+#define SPRCACHEFLAG_ISASSET        0x01
 // Tells that the sprite index was remapped to another existing sprite.
-#define SPRCACHEFLAG_REMAPPED       0x04
+#define SPRCACHEFLAG_REMAPPED       0x02
+// Locked sprites are ones that should not be freed when out of cache space.
+#define SPRCACHEFLAG_LOCKED         0x04
 
 // Max size of the sprite cache, in bytes
 #if AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_IOS
@@ -93,10 +93,9 @@ public:
     SpriteCache(std::vector<SpriteInfo> &sprInfos);
     ~SpriteCache();
 
-    // Tells if there is a sprite registered for the given index
+    // Tells if there is a sprite registered for the given index;
+    // this includes sprites that were explicitly assigned but failed to init and were remapped
     bool        DoesSpriteExist(sprkey_t index) const;
-    // Tells if sprite was added externally, not loaded from game resources
-    bool        IsExternalSprite(sprkey_t index) const;
     // Makes sure sprite cache has registered slots for all sprites up to the given exclusive limit
     sprkey_t    EnlargeTo(sprkey_t newsize);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
@@ -159,6 +158,15 @@ private:
         // TODO: investigate if we may safely use unique_ptr here
         // (some of these bitmaps may be assigned from outside of the cache)
         Common::Bitmap *Image; // actual bitmap
+
+        // Tells if there actually is a registered sprite in this slot
+        bool DoesSpriteExist() const;
+        // Tells if there's a game resource corresponding to this slot
+        bool IsAssetSprite() const;
+        // Tells if sprite was added externally, not loaded from game resources
+        bool IsExternalSprite() const;
+        // Tells if sprite is locked and should not be disposed by cache logic
+        bool IsLocked() const;
 
         SpriteData();
         ~SpriteData();

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -100,7 +100,7 @@ public:
     // returns requested index on success, or -1 on failure.
     sprkey_t    EnlargeTo(sprkey_t topmost);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
-    sprkey_t    AddNewSprite();
+    sprkey_t    GetFreeIndex();
     // Assigns bitmap to the given slot and locks it to prevent release from cache
     void        SetSpriteAndLock(sprkey_t index, Common::Bitmap *);
     // Returns current size of the cache, in bytes
@@ -117,8 +117,9 @@ public:
     void        Precache(sprkey_t index);
     // Unregisters sprite from the bank and optionally deletes bitmap
     void        RemoveSprite(sprkey_t index, bool freeMemory);
-    // Removes all loaded images from the cache
-    void        RemoveAll();
+    // Deletes all loaded (non-locked, non-external) images from the cache;
+    // this keeps all the auxiliary sprite information intact
+    void        DisposeAll();
     // Deletes all data and resets cache to the clear state
     void        Reset();
     // Assigns new bitmap for the given sprite index
@@ -145,9 +146,12 @@ public:
 
 private:
     void        Init();
+    // Load sprite from game resource
     size_t      LoadSprite(sprkey_t index);
+    // Seek stream to sprite
     void        SeekToSprite(sprkey_t index);
-    void        RemoveOldest();
+    // Delete the oldest image in cache
+    void        DisposeOldest();
 
     // Information required for the sprite streaming
     // TODO: split into sprite cache and sprite stream data
@@ -203,7 +207,8 @@ private:
     // Uncompresses sprite from stream into the given bitmap
     void        UnCompressSprite(Common::Bitmap *sprite, Common::Stream *in);
 
-    void initFile_initNullSpriteParams(sprkey_t index);
+    // Initialize the empty sprite slot
+    void        InitNullSpriteParams(sprkey_t index);
 };
 
 extern SpriteCache spriteset;

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -96,8 +96,9 @@ public:
     // Tells if there is a sprite registered for the given index;
     // this includes sprites that were explicitly assigned but failed to init and were remapped
     bool        DoesSpriteExist(sprkey_t index) const;
-    // Makes sure sprite cache has registered slots for all sprites up to the given exclusive limit
-    sprkey_t    EnlargeTo(sprkey_t newsize);
+    // Makes sure sprite cache has allocated slots for all sprites up to the given inclusive limit;
+    // returns requested index on success, or -1 on failure.
+    sprkey_t    EnlargeTo(sprkey_t topmost);
     // Finds a free slot index, if all slots are occupied enlarges sprite bank; returns index
     sprkey_t    AddNewSprite();
     // Assigns bitmap to the given slot and locks it to prevent release from cache

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -447,7 +447,7 @@ void BuildAudioClipArray(const AssetLibInfo &lib, std::vector<ScriptAudioClip> &
 void ApplySpriteData(GameSetupStruct &game, const LoadedGameEntities &ents, GameDataVersion data_ver)
 {
     // Apply sprite flags read from original format (sequential array)
-    spriteset.EnlargeTo(ents.SpriteCount);
+    spriteset.EnlargeTo(ents.SpriteCount - 1);
     for (size_t i = 0; i < ents.SpriteCount; ++i)
     {
         game.SpriteInfos[i].Flags = ents.SpriteFlags[i];

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -179,7 +179,7 @@ Common::Bitmap *get_sprite (int spnr) {
 void SetNewSprite(int slot, Common::Bitmap *sprit) {
   delete spriteset[slot];
 
-  spriteset.SetSpriteAndLock(slot, sprit);
+  spriteset.SetSprite(slot, sprit);
   spritesModified = true;
 }
 
@@ -257,7 +257,7 @@ void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes)
 
 void change_sprite_number(int oldNumber, int newNumber) {
 
-  spriteset.SetSpriteAndLock(newNumber, spriteset[oldNumber]);
+  spriteset.SetSprite(newNumber, spriteset[oldNumber]);
   spriteset.RemoveSprite(oldNumber, false);
 
   thisgame.SpriteInfos[newNumber].Flags = thisgame.SpriteInfos[oldNumber].Flags;
@@ -358,7 +358,7 @@ int crop_sprite_edges(int numSprites, int *sprites, bool symmetric) {
     newsprit->Blit(sprit, left, top, 0, 0, newWidth, newHeight);
     delete sprit;
 
-    spriteset.SetSpriteAndLock(sprites[aa], newsprit);
+    spriteset.SetSprite(sprites[aa], newsprit);
   }
 
   spritesModified = true;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -241,7 +241,7 @@ void transform_string(char *text) {
 }
 
 int find_free_sprite_slot() {
-  return spriteset.AddNewSprite();
+  return spriteset.GetFreeIndex();
 }
 
 void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes)

--- a/Editor/Native/sprcache_agsnative.cpp
+++ b/Editor/Native/sprcache_agsnative.cpp
@@ -23,7 +23,7 @@ void get_new_size_for_sprite(int ee, int ww, int hh, int &newwid, int &newhit)
   newhit = hh;
 }
 
-void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
+void SpriteCache::InitNullSpriteParams(sprkey_t index)
 {
     // no sprite ... blank it out
     _sprInfos[index] = SpriteInfo();

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -301,7 +301,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
 
     // TODO: refactor and merge with create_savegame_screenshot()
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
 
@@ -328,7 +328,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
 
 ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preserveAlphaChannel) {
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
 
@@ -350,7 +350,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preser
 
 ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface *sds, int x, int y, int width, int height) 
 {
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
 
@@ -382,7 +382,7 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
 {
     data_to_game_coords(&width, &height);
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
 
@@ -424,7 +424,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y
     data_to_game_coords(&x1, &y1);
     data_to_game_coords(&width, &height);
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
 

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -445,7 +445,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y
 
 void add_dynamic_sprite(int gotSlot, Bitmap *redin, bool hasAlpha) {
 
-  spriteset.Set(gotSlot, redin);
+  spriteset.SetSprite(gotSlot, redin);
 
   game.SpriteInfos[gotSlot].Flags = SPF_DYNAMICALLOC;
 
@@ -469,8 +469,7 @@ void free_dynamic_sprite (int gotSlot) {
   if ((game.SpriteInfos[gotSlot].Flags & SPF_DYNAMICALLOC) == 0)
     quitprintf("!DeleteSprite: Attempted to free static sprite %d that was not loaded by the script", gotSlot);
 
-  delete spriteset[gotSlot];
-  spriteset.Set(gotSlot, nullptr);
+  spriteset.RemoveSprite(gotSlot, true);
 
   game.SpriteInfos[gotSlot].Flags = 0;
   game.SpriteInfos[gotSlot].Width = 0;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1154,7 +1154,7 @@ void restore_game_spriteset(Stream *in)
 {
     // ensure the sprite set is at least as large as it was
     // when the game was saved
-    spriteset.EnlargeTo(in->ReadInt32());
+    spriteset.EnlargeTo(in->ReadInt32() - 1); // they saved top_index + 1
     // get serialized dynamic sprites
     int sprnum = in->ReadInt32();
     while (sprnum) {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1665,7 +1665,7 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot)
 
     if (desc.UserImage.get())
     {
-        int slot = spriteset.AddNewSprite();
+        int slot = spriteset.GetFreeIndex();
         if (slot > 0)
         {
             // add it into the sprite set

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -40,7 +40,7 @@ int LoadImageFile(const char *filename)
     if (!loadedFile)
         return 0;
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return 0;
 

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -219,13 +219,17 @@ void InventoryScreen::Prepare()
     in_inv_screen++;
     inv_screen_newroom = -1;
 
-    // sprites 2041, 2042 and 2043 were hardcoded in the older versions
-    // of the engine to be used in the built-in inventory window
+    // Sprites 2041, 2042 and 2043 were hardcoded in the older versions of
+    // the engine to be used in the built-in inventory window.
+    // If they did not exist engine first fell back to sprites 0, 1, 2 instead.
+    // Fun fact: this fallback does not seem to be intentional, and was a
+    // coincidental result of SpriteCache incorrectly remembering "last seeked
+    // sprite" as 2041/2042/2043 while in fact stream was after sprite 0.
     if (spriteset[2041] == nullptr || spriteset[2042] == nullptr || spriteset[2043] == nullptr)
-        debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, using sprite 0 instead");
+        debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, fallback to sprites 0, 1, 2 instead");
     btn_look_sprite = spriteset[2041] != nullptr ? 2041 : 0;
-    btn_select_sprite = spriteset[2042] != nullptr ? 2042 : 0;
-    btn_ok_sprite = spriteset[2043] != nullptr ? 2043 : 0;
+    btn_select_sprite = spriteset[2042] != nullptr ? 2042 : (spriteset[1] != nullptr ? 1 : 0);
+    btn_ok_sprite = spriteset[2043] != nullptr ? 2043 : (spriteset[2] != nullptr ? 2 : 0);
 
     break_code = 0;
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -926,7 +926,7 @@ void new_room(int newnum,CharacterInfo*forchar) {
     if (psp_clear_cache_on_room_change)
     {
         // Delete all cached sprites
-        spriteset.RemoveAll();
+        spriteset.DisposeAll();
 
         // Delete all gui background images
         for (int i = 0; i < game.numgui; i++)

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -127,9 +127,7 @@ void initialize_sprite (int ee) {
 
     if ((spriteset[ee] == nullptr) && (ee > 0)) {
         // replace empty sprites with blue cups, to avoid crashes
-        spriteset.Set(ee, spriteset[0]);
-        game.SpriteInfos[ee].Width = game.SpriteInfos[0].Width;
-        game.SpriteInfos[ee].Height = game.SpriteInfos[0].Height;
+        spriteset.RemapSpriteToSprite0(ee);
     }
     else if (spriteset[ee]==nullptr) {
         game.SpriteInfos[ee].Width=0;
@@ -162,13 +160,13 @@ void initialize_sprite (int ee) {
             curspr->Release ();
             tmpdbl->Release ();
             delete curspr;
-            spriteset.Set(ee, tmpdbl);
+            spriteset.SubstituteBitmap(ee, tmpdbl);
         }
 
         game.SpriteInfos[ee].Width=spriteset[ee]->GetWidth();
         game.SpriteInfos[ee].Height=spriteset[ee]->GetHeight();
 
-        spriteset.Set(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
+        spriteset.SubstituteBitmap(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
 
         if (game.GetColorDepth() < 32) {
             game.SpriteInfos[ee].Flags &= ~SPF_ALPHACHANNEL;

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -37,5 +37,5 @@ void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
     _sprInfos[index].Width = _sprInfos[0].Width;
     _sprInfos[index].Height = _sprInfos[0].Height;
     _spriteData[index].Offset = _spriteData[0].Offset;
-    _spriteData[index].Flags = SPRCACHEFLAG_DOESNOTEXIST | SPRCACHEFLAG_REMAPPED;
+    _spriteData[index].Flags = SPRCACHEFLAG_REMAPPED;
 }

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -36,6 +36,7 @@ void SpriteCache::InitNullSpriteParams(sprkey_t index)
     // make it a blue cup, to avoid crashes
     _sprInfos[index].Width = _sprInfos[0].Width;
     _sprInfos[index].Height = _sprInfos[0].Height;
+    _spriteData[index].Image = nullptr;
     _spriteData[index].Offset = _spriteData[0].Offset;
     _spriteData[index].Flags = SPRCACHEFLAG_REMAPPED;
 }

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -31,7 +31,7 @@
 // Engine-specific implementation split out of sprcache.cpp
 //=============================================================================
 
-void SpriteCache::initFile_initNullSpriteParams(sprkey_t index)
+void SpriteCache::InitNullSpriteParams(sprkey_t index)
 {
     // make it a blue cup, to avoid crashes
     _sprInfos[index].Width = _sprInfos[0].Width;

--- a/Engine/ac/spritecache_engine.cpp
+++ b/Engine/ac/spritecache_engine.cpp
@@ -38,5 +38,6 @@ void SpriteCache::InitNullSpriteParams(sprkey_t index)
     _sprInfos[index].Height = _sprInfos[0].Height;
     _spriteData[index].Image = nullptr;
     _spriteData[index].Offset = _spriteData[0].Offset;
+    _spriteData[index].Size = _spriteData[0].Size;
     _spriteData[index].Flags = SPRCACHEFLAG_REMAPPED;
 }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -812,7 +812,7 @@ HSaveError ReadDynamicSprites(PStream in, int32_t cmp_ver, const PreservedParams
     // ensure the sprite set is at least large enough
     // to accomodate top dynamic sprite index
     const int top_index = in->ReadInt32();
-    spriteset.EnlargeTo(top_index + 1);
+    spriteset.EnlargeTo(top_index);
     for (int i = 0; i < spr_count; ++i)
     {
         int id = in->ReadInt32();

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -646,7 +646,7 @@ int IAGSEngine::CreateDynamicSprite(int32 coldepth, int32 width, int32 height) {
     // TODO: why is this implemented right here, should not an existing
     // script handling implementation be called instead?
 
-    int gotSlot = spriteset.AddNewSprite();
+    int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return 0;
 


### PR DESCRIPTION
Fixes #773

This is to fix broken SpriteCache logic after commit 238a983 and clarify some things in the class.

This all started when I planned to refactor the class but stopped at some point and decided to push one commit which seemed to be pretty simple, yet broke certain logic inside the cache.

To elaborate a bit, there were certain inconsistencies in how sprites are described internally when dynamic sprites are added to the cache at runtime, but old program logic luckily ignored them. With commit 238a983 I wanted to introduce stricter rules in how sprite state is defined and that revealed this old problem. Also I missed couple of cases when a flag should be (re)set but was not.

In the end dynamic sprites got assigned to the MRU (most-recent-use) list along with the cached data, and then engine tried to delete them to free some space, which caused logic error.