### PR TITLE
Disable crash report screenshots

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -177,7 +177,7 @@ namespace AGS.Editor
         {
             try
             {
-                Bitmap screenShot = CaptureScreenshot();
+                Bitmap screenShot = null; // disable CaptureScreenshot();
                 ExceptionDialog dialog = new ExceptionDialog(ex, screenShot);
                 dialog.ShowDialog();
                 dialog.Dispose();


### PR DESCRIPTION
This prevents the crash reporter from sending screenshots. I think this commit should also be applied to all previous release branches. I'll look at other problems with the crash reporter separately.