### PR TITLE
3.5.0: safety changes for Editor loading and saving sprite file

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -803,16 +803,12 @@ HError SpriteCache::InitFile(const char *filnam)
         return HError::None();
     }
 
-    // failed, delete the index file because it's invalid
-    // TODO: refactor loading process and make it NOT delete file running the game!!
-    ::remove(spindexfilename);
-
+    // Failed, index file is invalid; index sprites manually
     return RebuildSpriteIndex(_stream.get(), topmost, vers);
 }
 
 HError SpriteCache::RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost, SpriteFileVersion vers)
 {
-    // no sprite index file, manually index it
     for (sprkey_t i = 0; i <= topmost; ++i)
     {
         _spriteData[i].Offset = in->GetPosition();

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -165,6 +165,16 @@ void SpriteCache::SetSprite(sprkey_t index, Bitmap *sprite)
 #endif
 }
 
+void SpriteCache::SetEmptySprite(sprkey_t index)
+{
+    if (index < 0 || EnlargeTo(index) != index)
+    {
+        Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Error, "SetEmptySprite: unable to use index %d", index);
+        return;
+    }
+    RemapSpriteToSprite0(index);
+}
+
 void SpriteCache::SubstituteBitmap(sprkey_t index, Common::Bitmap *sprite)
 {
     if (!DoesSpriteExist(index))

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -124,6 +124,8 @@ public:
     void        Reset();
     // Assigns new sprite for the given index; this sprite won't be auto disposed
     void        SetSprite(sprkey_t index, Common::Bitmap *);
+    // Assigns new sprite for the given index, remapping it to sprite 0
+    void        SetEmptySprite(sprkey_t index);
     // Assigns new bitmap for the *registered* sprite without changing its properties
     void        SubstituteBitmap(sprkey_t index, Common::Bitmap *);
     // Sets max cache size in bytes

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -90,6 +90,10 @@ public:
     static const sprkey_t MAX_SPRITE_INDEX = INT32_MAX - 1;
     static const size_t   MAX_SPRITE_SLOTS = INT32_MAX;
 
+    // Standart sprite file and sprite index names
+    static const Common::String DefaultSpriteFileName;
+    static const Common::String DefaultSpriteIndexName;
+
     SpriteCache(std::vector<SpriteInfo> &sprInfos);
     ~SpriteCache();
 
@@ -132,15 +136,16 @@ public:
     void        SetMaxCacheSize(size_t size);
 
     // Loads sprite reference information and inits sprite stream
-    HAGSError   InitFile(const char *filename);
+    HAGSError   InitFile(const char *filename, const char *sprindex_filename);
     // Tells if bitmaps in the file are compressed
     bool        IsFileCompressed() const;
     // Opens file stream
     int         AttachFile(const char *filename);
     // Closes file stream
     void        DetachFile();
-    // Saves all sprites until lastElement (exclusive) to file 
-    int         SaveToFile(const char *filename, bool compressOutput);
+    // Saves all sprites to file
+    // TODO: refactor to be able to save main file and index file separately
+    int         SaveToFile(const char *filename, const char *sprindex_filename, bool compressOutput);
     // Saves sprite index table in a separate file
     int         SaveSpriteIndex(const char *filename, int spriteFileIDCheck, sprkey_t lastslot, sprkey_t numsprits,
         const std::vector<int16_t> &spritewidths, const std::vector<int16_t> &spriteheights, const std::vector<soff_t> &spriteoffs);
@@ -203,7 +208,7 @@ private:
     int _listend;
 
     // Loads sprite index file
-    bool        LoadSpriteIndexFile(int expectedFileID, soff_t spr_initial_offs, sprkey_t topmost);
+    bool        LoadSpriteIndexFile(const char *filename, int expectedFileID, soff_t spr_initial_offs, sprkey_t topmost);
     // Rebuilds sprite index from the main sprite file
     HAGSError   RebuildSpriteIndex(AGS::Common::Stream *in, sprkey_t topmost, SpriteFileVersion vers);
     // Writes compressed sprite to the stream

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -83,6 +83,18 @@ enum SpriteIndexFileVersion
 
 typedef int32_t sprkey_t;
 
+// SpriteFileIndex contains sprite file's table of contents
+struct SpriteFileIndex
+{
+    int SpriteFileIDCheck = 0; // tag matching sprite file and index file
+    sprkey_t LastSlot = -1;
+    sprkey_t SpriteCount = 0;
+    std::vector<int16_t> Widths;
+    std::vector<int16_t> Heights;
+    std::vector<soff_t>  Offsets;
+};
+
+
 class SpriteCache
 {
 public:
@@ -143,12 +155,11 @@ public:
     int         AttachFile(const char *filename);
     // Closes file stream
     void        DetachFile();
-    // Saves all sprites to file
-    // TODO: refactor to be able to save main file and index file separately
-    int         SaveToFile(const char *filename, const char *sprindex_filename, bool compressOutput);
+    // Saves all sprites to file; fills in index data for external use
+    // TODO: refactor to be able to save main file and index file separately (separate function for gather data?)
+    int         SaveToFile(const char *filename, bool compressOutput, SpriteFileIndex &index);
     // Saves sprite index table in a separate file
-    int         SaveSpriteIndex(const char *filename, int spriteFileIDCheck, sprkey_t lastslot, sprkey_t numsprits,
-        const std::vector<int16_t> &spritewidths, const std::vector<int16_t> &spriteheights, const std::vector<soff_t> &spriteoffs);
+    int         SaveSpriteIndex(const char *filename, const SpriteFileIndex &index);
 
     // Loads (if it's not in cache yet) and returns bitmap by the sprite index
     Common::Bitmap *operator[] (sprkey_t index);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1482,8 +1482,8 @@ namespace AGS.Editor
                 result = (bool)BusyDialog.Show("Please wait while your files are saved...", new BusyDialog.ProcessingHandler(SaveGameFilesProcess), null);
             }
             catch (Exception ex)
-            {
-                InteractiveTasks.ReportTaskException("An error occurred whilst trying to save your game.", ex);
+            { // CHECKME: rethrown exception from other thread duplicates original exception as inner one for some reason
+                InteractiveTasks.ReportTaskException("An error occurred whilst trying to save your game.", ex.InnerException);
                 result = false;
             }
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1476,7 +1476,16 @@ namespace AGS.Editor
             Settings.RecentGames.Insert(0, recentGame);
             Settings.Save();
 
-            bool result = (bool)BusyDialog.Show("Please wait while your files are saved...", new BusyDialog.ProcessingHandler(SaveGameFilesProcess), null);
+            bool result;
+            try
+            {
+                result = (bool)BusyDialog.Show("Please wait while your files are saved...", new BusyDialog.ProcessingHandler(SaveGameFilesProcess), null);
+            }
+            catch (Exception ex)
+            {
+                InteractiveTasks.ReportTaskException("An error occurred whilst trying to save your game.", ex);
+                result = false;
+            }
 
 			if (!evArgs.SaveSucceeded)
 			{

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -279,7 +279,22 @@ namespace AGS.Editor
             _builtInScriptHeader = new Script(BUILT_IN_HEADER_FILE_NAME, Resources.ResourceManager.GetResourceAsString("agsdefns.sh"), true);
             AutoComplete.ConstructCache(_builtInScriptHeader);
 
-            Factory.NativeProxy.NewGameLoaded(Factory.AGSEditor.CurrentGame);
+            List<string> errors = new List<string>();
+            Factory.NativeProxy.NewGameLoaded(Factory.AGSEditor.CurrentGame, errors);
+            ReportGameLoad(errors);
+        }
+
+        public void ReportGameLoad(List<string> errors)
+        {
+            if (errors.Count == 1)
+            {
+                Factory.GUIController.ShowMessage(errors[0], MessageBoxIcon.Warning);
+            }
+            else if (errors.Count > 1)
+            {
+                Factory.GUIController.ShowOutputPanel(errors.ToArray(), "SpriteIcon");
+                Factory.GUIController.ShowMessage("Game was loaded, but there were errors", MessageBoxIcon.Warning);
+            }
         }
 
         public void Dispose()
@@ -769,13 +784,13 @@ namespace AGS.Editor
             Factory.Events.OnGameLoad(doc.DocumentElement);
         }
 
-        public void RefreshEditorAfterGameLoad(Game newGame)
+        public void RefreshEditorAfterGameLoad(Game newGame, List<string> errors)
         {
             _game = newGame;
 
             Factory.Events.OnRefreshAllComponentsFromGame();
             Factory.GUIController.GameNameUpdated();
-            Factory.NativeProxy.NewGameLoaded(Factory.AGSEditor.CurrentGame);
+            Factory.NativeProxy.NewGameLoaded(Factory.AGSEditor.CurrentGame, errors);
 
             RegenerateScriptHeader(null);
             

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -26,6 +26,25 @@ namespace AGS.Editor
             _tasks.TestGameFinished += new Tasks.TestGameFinishedHandler(Tasks_TestGameFinished);
         }
 
+        public static void ReportTaskException(string errorMsg, Exception ex)
+        {
+            string messageDetails = string.Empty;
+            if ((!(ex is AGS.Types.InvalidDataException)) &&
+                (!(ex is AGS.Types.AGSEditorException)))
+            {
+                messageDetails = "Error details: " + ex.ToString();
+            }
+            else if (ex is AGS.Types.AGSEditorException && ex.InnerException != null)
+            {
+                messageDetails = "Error details: ";
+                for (Exception ie = ex.InnerException; ie != null; ie = ie.InnerException)
+                    messageDetails += ie.Message + Environment.NewLine + Environment.NewLine;
+            }
+            Factory.GUIController.ShowMessage(errorMsg + " The error was:" + Environment.NewLine + Environment.NewLine + ex.Message +
+                Environment.NewLine + Environment.NewLine + "If you cannot resolve the error, please post on the AGS Technical Forum for assistance." +
+                Environment.NewLine + Environment.NewLine + messageDetails, MessageBoxIcon.Warning);
+        }
+
         public bool BrowseForAndLoadGame()
         {
             bool loadedSuccessfully = false;
@@ -70,13 +89,7 @@ namespace AGS.Editor
             }
             catch (Exception ex)
             {
-                string messageDetails = string.Empty;
-                if ((!(ex is AGS.Types.InvalidDataException)) &&
-                    (!(ex is AGS.Types.AGSEditorException)))
-                {
-                    messageDetails = "\r\n\r\nError details: " + ex.ToString();
-                }
-                Factory.GUIController.ShowMessage("An error occurred whilst trying to load your game. The error was: " + Environment.NewLine + Environment.NewLine + ex.Message + "\r\n\r\nIf you cannot resolve the error, please post on the AGS Technical Forum for assistance." + messageDetails, MessageBoxIcon.Warning);
+                ReportTaskException("An error occurred whilst trying to load your game.", ex);
                 return false;
             }
         }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -57,9 +57,9 @@ namespace AGS.Editor
             _native.Initialize();
         }
 
-        public void NewGameLoaded(Game game)
+        public void NewGameLoaded(Game game, List<string> errors)
         {
-            _native.NewGameLoaded(game);
+            _native.NewGameLoaded(game, errors);
         }
 
         public void GameSettingsChanged(Game game)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Windows.Forms;
 using AGS.Editor.Preferences;
 
 namespace AGS.Editor
@@ -107,6 +108,8 @@ namespace AGS.Editor
                 throw new AGSEditorException("This game cannot be loaded because it is in a folder that has a name longer than 40 characters.");
             }
 
+            List<string> errors = new List<string>();
+
             Directory.SetCurrentDirectory(gameDirectory);
             AddFontIfNotAlreadyThere(0);
             AddFontIfNotAlreadyThere(1);
@@ -141,11 +144,13 @@ namespace AGS.Editor
 
                 Factory.Events.OnGamePostLoad();
 
-                Factory.AGSEditor.RefreshEditorAfterGameLoad(game);
+                Factory.AGSEditor.RefreshEditorAfterGameLoad(game, errors);
                 if (needToSave)
                 {
                     Factory.AGSEditor.SaveGameFiles();
                 }
+
+                Factory.AGSEditor.ReportGameLoad(errors);
                 return true;
             }
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -66,7 +66,7 @@ extern HAGSError reset_sprite_file();
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
 extern void GameUpdated(Game ^game);
 extern void GameFontUpdated(Game ^game, int fontNumber);
-extern void UpdateSpriteFlags(SpriteFolder ^folder) ;
+extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
 extern void draw_room_background(void *roomptr, int hdc, int x, int y, int bgnum, float scaleFactor, int maskType, int selectedArea, int maskTransparency);
 extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 extern void DeleteBackground(Room ^room, int backgroundNumber);
@@ -156,11 +156,11 @@ namespace AGS
 			}
 		}
 
-		void NativeMethods::NewGameLoaded(Game ^game)
+		void NativeMethods::NewGameLoaded(Game ^game, List<String^> ^errors)
 		{
 			this->PaletteColoursUpdated(game);
 			GameUpdated(game);
-			UpdateSpriteFlags(game->RootSpriteFolder);
+			UpdateNativeSpritesToGame(game, errors);
 		}
 
 		void NativeMethods::PaletteColoursUpdated(Game ^game)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -61,7 +61,7 @@ extern int extract_template_files(const char *templateFileName);
 extern int extract_room_template_files(const char *templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
 extern void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes);
-extern void save_game(bool compressSprites);
+extern void SaveGame(bool compressSprites);
 extern HAGSError reset_sprite_file();
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
 extern void GameUpdated(Game ^game);
@@ -180,7 +180,7 @@ namespace AGS
 
 		void NativeMethods::SaveGame(Game ^game)
 		{
-			save_game(game->Settings->CompressSprites);
+			::SaveGame(game->Settings->CompressSprites);
 		}
 
 		void NativeMethods::GameSettingsChanged(Game ^game)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -25,7 +25,7 @@ namespace AGS
 			NativeMethods(String ^version);
 
 			void Initialize();
-			void NewGameLoaded(Game^ game);
+			void NewGameLoaded(Game^ game, List<String^> ^errors);
 			void SaveGame(Game^ game);
 			void GameSettingsChanged(Game^ game);
 			void PaletteColoursUpdated(Game ^game);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2160,14 +2160,23 @@ void PutNewSpritefileIntoProject(const AGSString &temp_spritefile, const AGSStri
     {
         if (IO::File::Exists(sprfilename))
             IO::File::Delete(sprfilename);
-        if (IO::File::Exists(sprindexfilename))
-            IO::File::Delete(sprindexfilename);
         IO::File::Move(gcnew String(temp_spritefile), sprfilename);
-        IO::File::Move(gcnew String(temp_indexfile), sprindexfilename);
     }
     catch (Exception ^e)
     {
         throw gcnew AGSEditorException("Unable to replace the previous sprite file in your project folder.", e);
+    }
+
+    // Sprite index is wanted but optional, so react to exceptions separately
+    try
+    {
+        if (IO::File::Exists(sprindexfilename))
+            IO::File::Delete(sprindexfilename);
+        if (!temp_indexfile.IsEmpty())
+            IO::File::Move(gcnew String(temp_indexfile), sprindexfilename);
+    }
+    catch (Exception ^e)
+    {// TODO: ignore for now, but proper warning output system in needed here
     }
 }
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -34,6 +34,8 @@ extern int Scintilla_LinkLexers();
 #include "core/assetmanager.h"
 #include "NativeUtils.h"
 
+using AGS::Types::AGSEditorException;
+
 using AGS::Common::AlignedStream;
 using AGS::Common::Stream;
 namespace AGSProps = AGS::Common::Properties;
@@ -78,7 +80,8 @@ color*palette = NULL;
 GameSetupStruct thisgame;
 SpriteCache spriteset(thisgame.SpriteInfos);
 GUIMain tempgui;
-const char*sprsetname = "acsprset.spr";
+const char *sprsetname = "acsprset.spr";
+const char *sprindexname = "sprindex.dat";
 const char *old_editor_data_file = "editor.dat";
 const char *new_editor_data_file = "game.agf";
 const char *old_editor_main_game_file = "ac2game.dta";
@@ -563,43 +566,6 @@ int load_template_file(const char *fileName, char **iconDataBuffer, long *iconDa
     }
   }
   return 0;
-}
-
-const char* save_sprites(bool compressSprites) 
-{
-  const char *errorMsg = NULL;
-  char backupname[100];
-  sprintf(backupname, "backup_%s", sprsetname);
-
-  if ((spritesModified) || (compressSprites != spriteset.IsFileCompressed()))
-  {
-    spriteset.DetachFile();
-    if (exists(backupname) && (unlink(backupname) != 0)) {
-      errorMsg = "Unable to overwrite the old backup file. Make sure the backup sprite file is not read-only";
-    }
-    else if (rename(sprsetname, backupname)) {
-      errorMsg = "Unable to create the backup sprite file. Make sure the backup sprite file is not read-only";
-    }
-    else if (spriteset.AttachFile(backupname)) {
-      errorMsg = "An error occurred attaching to the backup sprite file. Check write permissions on your game folder";
-    }
-    else if (spriteset.SaveToFile(sprsetname, compressSprites)) {
-      errorMsg = "Unable to save the sprites. An error occurred writing the sprite file.";
-    }
-
-    // reset the sprite cache
-    spriteset.Reset();
-    HAGSError err = spriteset.InitFile(sprsetname);
-    if (!err)
-    {
-      if (errorMsg == NULL)
-        errorMsg = "Unable to re-initialize sprite file after save.";
-    }
-
-    if (errorMsg == NULL)
-      spritesModified = false;
-  }
-  return errorMsg;
 }
 
 void drawBlockDoubleAt (int hdc, Common::Bitmap *todraw ,int x, int y) {
@@ -1213,7 +1179,7 @@ bool initialize_native()
 	new_font();
 
 	spriteset.Reset();
-	HAGSError err = spriteset.InitFile(sprsetname);
+	HAGSError err = spriteset.InitFile(sprsetname, sprindexname);
 	if (!err)
 	  return false;
 	spriteset.SetMaxCacheSize(100 * 1024 * 1024);  // 100 mb cache // TODO: set this up in preferences?
@@ -1415,7 +1381,7 @@ bool reload_font(int curFont)
 
 HAGSError reset_sprite_file() {
   spriteset.Reset();
-  HAGSError err = spriteset.InitFile(sprsetname);
+  HAGSError err = spriteset.InitFile(sprsetname, sprindexname);
   if (!err)
     return err;
   spriteset.SetMaxCacheSize(100 * 1024 * 1024);  // 100 mb cache // TODO: set in preferences?
@@ -2038,15 +2004,6 @@ void ThrowManagedException(const char *message)
 	throw gcnew AGS::Types::AGSEditorException(gcnew String((const char*)message));
 }
 
-void save_game(bool compressSprites)
-{
-	const char *errorMsg = save_sprites(compressSprites);
-	if (errorMsg != NULL)
-	{
-		throw gcnew AGSEditorException(gcnew String(errorMsg));
-	}
-}
-
 void CreateBuffer(int width, int height)
 {
     auto &drawBuffer = RoomTools->drawBuffer;
@@ -2149,6 +2106,113 @@ void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors)
             "Sprite file (acsprset.spr) contained less sprites than the game project referenced ({0} sprites were missing). This could happen if it was not saved properly last time. Some sprites could be missing actual images. You may try restoring them by reimporting from the source files.",
             missing_count));
     }
+}
+
+// Attempts to save the current spriteset contents into the temporary file
+// provided by the system API. On success assigns saved_filename.
+void SaveTempSpritefile(bool compressSprites, AGSString &saved_spritefile, AGSString &saved_indexfile)
+{
+    // First save new sprite set into the temporary file
+    String ^temp_spritefile = nullptr;
+    String ^temp_indexfile = nullptr;
+    try
+    {
+        temp_spritefile = IO::Path::GetTempFileName();
+        temp_indexfile = IO::Path::GetTempFileName();
+    }
+    catch (Exception ^e)
+    {
+        throw gcnew AGSEditorException("Unable to create a temporary file to save sprites to.", e);
+    }
+
+    AGSString n_temp_spritefile = ConvertStringToNativeString(temp_spritefile);
+    AGSString n_temp_indexfile = ConvertStringToNativeString(temp_indexfile);
+    if (spriteset.SaveToFile(n_temp_spritefile, n_temp_indexfile, compressSprites))
+        throw gcnew AGSEditorException(String::Format("Unable to save the sprites. An error occurred whilst writing the sprite file.{0}Temp path: {1}",
+            Environment::NewLine, temp_spritefile));
+    saved_spritefile = n_temp_spritefile;
+    saved_indexfile = n_temp_indexfile;
+}
+
+// Updates the backup and spritefile, moving it from the temp location.
+void PutNewSpritefileIntoProject(const AGSString &temp_spritefile, const AGSString &temp_indexfile)
+{
+    spriteset.DetachFile();
+    // Now when sprites are safe, move last sprite file to backup file
+    String ^sprfilename = gcnew String(sprsetname);
+    String ^backupname = String::Format("backup_{0}", sprfilename);
+    try
+    {
+        if (IO::File::Exists(backupname))
+            IO::File::Delete(backupname);
+        if (IO::File::Exists(sprfilename))
+            IO::File::Move(sprfilename, backupname);
+    }
+    catch (Exception ^e)
+    {// TODO: ignore for now, but proper warning output system in needed here
+    }
+
+    // And then temp file to its final location
+    String ^sprindexfilename = gcnew String(sprindexname);
+    try
+    {
+        if (IO::File::Exists(sprfilename))
+            IO::File::Delete(sprfilename);
+        if (IO::File::Exists(sprindexfilename))
+            IO::File::Delete(sprindexfilename);
+        IO::File::Move(gcnew String(temp_spritefile), sprfilename);
+        IO::File::Move(gcnew String(temp_indexfile), sprindexfilename);
+    }
+    catch (Exception ^e)
+    {
+        throw gcnew AGSEditorException("Unable to replace the previous sprite file in your project folder.", e);
+    }
+}
+
+void SaveNativeSprites(bool compressSprites)
+{
+    if (!spritesModified && (compressSprites == spriteset.IsFileCompressed()))
+        return;
+
+    AGSString saved_spritefile;
+    AGSString saved_indexfile;
+    SaveTempSpritefile(compressSprites, saved_spritefile, saved_indexfile);
+
+    Exception ^main_exception;
+    try
+    {
+        PutNewSpritefileIntoProject(saved_spritefile, saved_indexfile);
+        saved_spritefile = sprsetname;
+        saved_indexfile = sprindexname;
+    }
+    catch (Exception ^e)
+    {
+        main_exception = e;
+    }
+    finally
+    {
+        // Reset the sprite cache to whichever file was successfully saved
+        spriteset.Reset();
+        HAGSError err = spriteset.InitFile(saved_spritefile, saved_indexfile);
+        if (!err)
+        {
+            throw gcnew AGSEditorException(
+                String::Format("Unable to re-initialize sprite file after save.{0}{1}",
+                    Environment::NewLine, gcnew String(err->FullMessage().GetCStr())), main_exception);
+        }
+        else if (err && main_exception != nullptr)
+        {
+            throw gcnew AGSEditorException(
+                String::Format("Unable to save sprites in your project folder. The sprites were saved to a temporary location:{0}{1}",
+                    Environment::NewLine, gcnew String(saved_spritefile)), main_exception);
+        }
+    }
+    spritesModified = false;
+}
+
+void SaveGame(bool compressSprites)
+{
+    SaveNativeSprites(compressSprites);
 }
 
 void SetGameResolution(Game ^game)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2127,11 +2127,13 @@ void SaveTempSpritefile(bool compressSprites, AGSString &saved_spritefile, AGSSt
 
     AGSString n_temp_spritefile = ConvertStringToNativeString(temp_spritefile);
     AGSString n_temp_indexfile = ConvertStringToNativeString(temp_indexfile);
-    if (spriteset.SaveToFile(n_temp_spritefile, n_temp_indexfile, compressSprites))
+    SpriteFileIndex index;
+    if (spriteset.SaveToFile(n_temp_spritefile, compressSprites, index) != 0)
         throw gcnew AGSEditorException(String::Format("Unable to save the sprites. An error occurred whilst writing the sprite file.{0}Temp path: {1}",
             Environment::NewLine, temp_spritefile));
     saved_spritefile = n_temp_spritefile;
-    saved_indexfile = n_temp_indexfile;
+    if (spriteset.SaveSpriteIndex(n_temp_indexfile, index) == 0)
+        saved_indexfile = n_temp_indexfile;
 }
 
 // Updates the backup and spritefile, moving it from the temp location.

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -275,7 +275,7 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
         quitprintf("!RunAGSGame: error loading new game file:\n%s", err->FullMessage().GetCStr());
 
     spriteset.Reset();
-    err = spriteset.InitFile("acsprset.spr");
+    err = spriteset.InitFile(SpriteCache::DefaultSpriteFileName, SpriteCache::DefaultSpriteIndexName);
     if (!err)
         quitprintf("!RunAGSGame: error loading new sprites:\n%s", err->FullMessage().GetCStr());
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -850,13 +850,14 @@ int engine_init_sprites()
 {
     Debug::Printf(kDbgMsg_Init, "Initialize sprites");
 
-    HError err = spriteset.InitFile("acsprset.spr");
+    HError err = spriteset.InitFile(SpriteCache::DefaultSpriteFileName, SpriteCache::DefaultSpriteIndexName);
     if (!err) 
     {
         platform->FinishedUsingGraphicsMode();
         allegro_exit();
         proper_exit=1;
-        platform->DisplayAlert("Could not load sprite set file ACSPRSET.SPR\n%s",
+        platform->DisplayAlert("Could not load sprite set file %s\n%s",
+            SpriteCache::DefaultSpriteFileName.GetCStr(),
             err->FullMessage().GetCStr());
         return EXIT_NORMAL;
     }


### PR DESCRIPTION
This pr attempts to address two potential problems with sprite file after which user may loose an ability to open project and/or loose some data.

1) The current order of actions, and error handling, when saving sprites is such that new data may get lost if there's a trivial file access error, and editor refuses to save it even if it failed to update a backup for example.
2) If the sprite file did not save correctly, next time you load the project it crashes because number of sprites in the sprite file does not match import references in the project itself.

In this pr problem 1) is resolved by saving new sprite file into temporary location provided by system API first, and replacing one in the project folder only after. Even if something fails at the second step, sprite cache *attaches itself to the temporary file* thus giving user ability to continue work inside Editor, try to resave, fix access problem, or just move temp file by hand to a safer place as a backup (it reports the name of the file too).

For the problem 2) editor creates a dummy sprite slot for every entry missing in the sprite file remapping to sprite 0. This should at least prevent the crashing. Ofcourse user will have to reimport missing sprites from sources eventually.