### PR TITLE
Disable SSL v3

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -12,6 +12,7 @@ using AGS.Types;
 using AGS.Types.Interfaces;
 using AGS.Editor.Preferences;
 using AGS.Editor.Utils;
+using System.Net;
 
 namespace AGS.Editor
 {
@@ -257,6 +258,9 @@ namespace AGS.Editor
 
         public void DoEditorInitialization()
         {
+            // disable SSL v3
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
             try
             {
                 Directory.CreateDirectory(UserTemplatesDirectory);


### PR DESCRIPTION
Partially fixes #792.

I believe in later .NET versions this is already forced off and it shouldn't be being used anyway. Ideally this should just mandate TLS 1.2 or higher, but I don't think this currently works with the TLS negotiation settings between .NET and the server where data is being sent - I tried it and got an SSL error.