### PR TITLE
Revert #685

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -80,6 +80,7 @@ extern int said_speech_line;
 extern int numscreenover;
 extern int said_text;
 extern int our_eip;
+extern int cur_mode;
 extern CCCharacter ccDynamicCharacter;
 extern CCInventory ccDynamicInv;
 
@@ -2401,7 +2402,8 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     play.speech_in_post_state = false;
 
     if (isPause) {
-        postpone_scheduled_music_update_by(std::chrono::milliseconds(play.messagetime * 1000 / frames_per_second));
+        if (update_music_at > 0)
+            update_music_at += play.messagetime;
         GameLoopUntilEvent(UNTIL_INTISNEG,(long)&play.messagetime);
         return;
     }

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -15,6 +15,7 @@
 #include "ac/characterinfo.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
+#include "media/audio/soundclip.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
 #include "ac/gamestate.h"

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -60,6 +60,7 @@ extern ccInstance *dialogScriptsInst;
 extern int in_new_room;
 extern CharacterInfo*playerchar;
 extern SpriteCache spriteset;
+extern volatile int timerloop;
 extern AGSPlatformDriver *platform;
 extern int cur_mode,cur_cursor;
 extern IGraphicsDriver *gfxDriver;
@@ -860,6 +861,7 @@ bool DialogOptions::Run()
       }
       else
       {
+        timerloop = 0;
         update_audio_system_on_game_loop();
         render_graphics(ddb, dirtyx, dirtyy);
       }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -54,6 +54,7 @@ extern GameSetupStruct game;
 extern int longestline;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern AGSPlatformDriver *platform;
+extern float get_current_fps();
 extern int loops_per_character;
 extern SpriteCache spriteset;
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -60,7 +60,6 @@
 #include "gfx/ali3dexception.h"
 #include "gfx/blender.h"
 #include "media/audio/audio_system.h"
-#include "ac/game.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -2129,29 +2128,14 @@ void draw_fps()
         fpsDisplay = ReplaceBitmapWithSupportedFormat(fpsDisplay);
     }
     fpsDisplay->ClearTransparent();
-    
+
+    char tbuffer[60];
     color_t text_color = fpsDisplay->GetCompatibleColor(14);
-
-    char base_buffer[60];
-    if (frames_per_second < 1000) {
-        sprintf(base_buffer, "%d", frames_per_second);
-    } else {
-        sprintf(base_buffer, "unlimited");
-    }
-
-    char fps_buffer[60];
-    // Don't display fps if we don't have enough information (because loop count was just reset)
-    if (!std::isnan(fps)) {
-        sprintf(fps_buffer, "FPS: %2.1f / %s", fps, base_buffer);
-    } else {
-        sprintf(fps_buffer, "FPS: --.- / %s", base_buffer);
-    }
-    wouttext_outline(fpsDisplay, 1, 1, FONT_SPEECH, text_color, fps_buffer);
-
-    char loop_buffer[60];
-    sprintf(loop_buffer, "Loop %u", loopcounter);
-    int textw = wgettextwidth(loop_buffer, FONT_SPEECH);
-    wouttext_outline(fpsDisplay, ui_view.GetWidth() / 2, 1, FONT_SPEECH, text_color, loop_buffer);
+    sprintf(tbuffer, "FPS: %d", fps > 0 ? fps : 0);
+    wouttext_outline(fpsDisplay, 1, 1, FONT_SPEECH, text_color, tbuffer);
+    sprintf(tbuffer, "Loop %u", loopcounter);
+    int textw = wgettextwidth(tbuffer, FONT_SPEECH);
+    wouttext_outline(fpsDisplay, ui_view.GetWidth() / 2, 1, FONT_SPEECH, text_color, tbuffer);
 
     if (ddb)
         gfxDriver->UpdateDDBFromBitmap(ddb, fpsDisplay, false);

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -32,7 +32,6 @@
 #include "gfx/ddb.h"
 #include "gfx/graphicsdriver.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -45,6 +44,7 @@ extern GameState play;
 extern color palette[256];
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
+extern volatile int timerloop;
 extern color old_palette[256];
 
 int in_enters_screen=0,done_es_error = 0;
@@ -282,18 +282,19 @@ void process_event(EventHappened*evp) {
                 int boxwid = get_fixed_pixel_size(16);
                 int boxhit = data_to_game_coord(data_res.Height / 20);
                 while (boxwid < temp_scr->GetWidth()) {
+                    timerloop = 0;
                     boxwid += get_fixed_pixel_size(16);
                     boxhit += data_to_game_coord(data_res.Height / 20);
                     boxwid = Math::Clamp(boxwid, 0, viewport.GetWidth());
                     boxhit = Math::Clamp(boxhit, 0, viewport.GetHeight());
                     int lxp = viewport.GetWidth() / 2 - boxwid / 2;
                     int lyp = viewport.GetHeight() / 2 - boxhit / 2;
-                    temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp, 
+                    gfxDriver->Vsync();
+                    temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp,
                         boxwid, boxhit);
                     render_to_screen(viewport.Left, viewport.Top);
-                    do {
-                        update_polled_stuff_if_runtime();
-                    } while (waitingForNextTick());
+                    update_polled_mp3();
+                        while (timerloop == 0) ;
                 }
                 gfxDriver->SetMemoryBackBuffer(saved_backbuf, viewport.Left, viewport.Top);
             }
@@ -309,6 +310,7 @@ void process_event(EventHappened*evp) {
             int transparency = 254;
 
             while (transparency > 0) {
+                timerloop=0;
                 // do the crossfade
                 ddb->SetTransparency(transparency);
                 invalidate_screen();
@@ -320,10 +322,9 @@ void process_event(EventHappened*evp) {
                     // draw the old screen on top
                     gfxDriver->DrawSprite(0, 0, ddb);
                 }
-                render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+				render_to_screen();
+                update_polled_stuff_if_runtime();
+                while (timerloop == 0) ;
                 transparency -= 16;
             }
             saved_viewport_bitmap->Release();
@@ -341,6 +342,7 @@ void process_event(EventHappened*evp) {
             IDriverDependantBitmap *ddb = prepare_screen_for_transition_in();
 
             for (aa=0;aa<16;aa++) {
+                timerloop=0;
                 // merge the palette while dithering
                 if (game.color_depth == 1) 
                 {
@@ -358,10 +360,9 @@ void process_event(EventHappened*evp) {
                 invalidate_screen();
                 draw_screen_callback();
                 gfxDriver->DrawSprite(0, 0, ddb);
-                render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+				render_to_screen();
+                update_polled_stuff_if_runtime();
+                while (timerloop == 0) ;
             }
             saved_viewport_bitmap->Release();
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -90,6 +90,7 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
+extern int time_between_timers;
 extern int cur_mode,cur_cursor;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
@@ -323,7 +324,8 @@ void set_debug_mode(bool on)
 
 void set_game_speed(int new_fps) {
     frames_per_second = new_fps;
-    setTimerFps(new_fps);
+    time_between_timers = 1000 / new_fps;
+    install_int_ex(dj_timer_handler,MSEC_TO_TIMER(time_between_timers));
 }
 
 extern int cbuttfont;
@@ -1882,7 +1884,7 @@ void display_switch_out_suspend()
     }
     } // -- AudioChannelsLock
 
-    platform->Delay(1000);
+    rest(1000);
 
     // restore the callbacks
     SetMultitasking(0);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -26,6 +26,7 @@
 #include "media/audio/audio_system.h"
 #include "util/alignedstream.h"
 #include "util/string_utils.h"
+#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -28,7 +28,6 @@
 #include "util/geometry.h"
 #include "util/string_types.h"
 #include "util/string.h"
-#include "ac/timer.h"
 
 // Forward declaration
 namespace AGS { namespace Common {
@@ -210,7 +209,7 @@ struct GameState {
     std::vector<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms;
     int   ignore_user_input_after_text_timeout_ms;
-    AGS_Clock::time_point ignore_user_input_until_time;
+    unsigned long ignore_user_input_until_time;
     int   default_audio_type_volumes[MAX_AUDIO_TYPES];
 
     // Dynamic custom property values for characters and items

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -12,8 +12,6 @@
 //
 //=============================================================================
 
-#include <cmath>
-
 #include "ac/audiocliptype.h"
 #include "ac/global_game.h"
 #include "ac/common.h"
@@ -82,7 +80,7 @@ extern int getloctype_index;
 extern char saveGameDirectory[260];
 extern IGraphicsDriver *gfxDriver;
 extern color palette[256];
-extern float get_current_fps();
+extern int get_current_fps();
 
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
 extern int psp_gfx_renderer;
@@ -386,7 +384,7 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
-    return std::lround(get_current_fps()) - play.game_speed_modifier;
+    return get_current_fps() - play.game_speed_modifier;
 }
 
 int SetGameOption (int opt, int setting) {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -82,6 +82,7 @@ extern int getloctype_index;
 extern char saveGameDirectory[260];
 extern IGraphicsDriver *gfxDriver;
 extern color palette[256];
+extern float get_current_fps();
 
 #if defined(IOS_VERSION) || defined(ANDROID_VERSION)
 extern int psp_gfx_renderer;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -35,7 +35,6 @@
 #include "ac/dynobj/cc_inventory.h"
 #include "util/math.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -46,6 +45,7 @@ extern ScriptInvItem scrInv[MAX_INV];
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern SpriteCache spriteset;
 extern int mousex,mousey;
+extern volatile int timerloop;
 extern int evblocknum;
 extern CharacterInfo*playerchar;
 extern AGSPlatformDriver *platform;
@@ -351,6 +351,7 @@ bool InventoryScreen::Run()
         return false; // end inventory screen loop
     }
 
+        timerloop = 0;
         //ags_domouse(DOMOUSE_UPDATE);
         update_audio_system_on_game_loop();
         refresh_gui_screen();

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -19,8 +19,6 @@
 #include "ac/mouse.h"
 #include "ac/sys_events.h"
 #include "device/mousew32.h"
-#include "platform/base/agsplatformdriver.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -41,7 +39,7 @@ int mouse_z_was = 0;
 
 int ags_kbhit () {
     int result = keypressed();
-    if ((result) && (AGS_Clock::now() < play.ignore_user_input_until_time))
+    if ((result) && (globalTimerCounter < play.ignore_user_input_until_time))
     {
         // ignoring user input
         ags_getch();
@@ -69,7 +67,7 @@ int ags_mgetbutton() {
         result = mgetbutton();
     }
 
-    if ((result >= 0) && (AGS_Clock::now() < play.ignore_user_input_until_time))
+    if ((result >= 0) && (globalTimerCounter < play.ignore_user_input_until_time))
     {
         // ignoring user input
         result = NONE;
@@ -190,8 +188,6 @@ void ags_clear_input_buffer()
 
 void ags_wait_until_keypress()
 {
-    while (!ags_kbhit()) {
-        platform->YieldCPU();
-    }
+    while (!ags_kbhit());
     ags_getch();
 }

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -13,10 +13,9 @@
 //=============================================================================
 
 #include <stdio.h>
-#if defined (_DEBUG) && defined (__GNUC__)
 #include <execinfo.h>
 #include <unistd.h>
-#endif
+
 #include "ac/timer.h"
 #include "platform/base/agsplatformdriver.h"
 
@@ -46,7 +45,7 @@ bool waitingForNextTick() {
 
     auto is_lagging = (now - last_tick_time) > (MAXIMUM_FALL_BEHIND*tick_duration);
     if (is_lagging) {
-#if defined (_DEBUG) && defined (__GNUC__)
+#ifdef _DEBUG
         auto missed_ticks = ((now - last_tick_time)/tick_duration);
         printf("Lagging! Missed %lld ticks!\n", (long long)missed_ticks);
         void *array[10];

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -18,18 +18,10 @@
 #ifndef __AGS_EE_AC__TIMER_H
 #define __AGS_EE_AC__TIMER_H
 
-#include <type_traits>
-#include <chrono>
-
-// use high resolution clock only if we know it is monotonic/steady.
-// refer to https://stackoverflow.com/a/38253266/84262
-using AGS_Clock = std::conditional<
-        std::chrono::high_resolution_clock::is_steady,
-        std::chrono::high_resolution_clock, std::chrono::steady_clock
-      >::type;
-
-extern void setTimerFps(int new_fps);
-extern bool waitingForNextTick();  // store last tick time.
-extern void skipMissedTicks();  // if more than N frames, just skip all, start a fresh.
+#if defined(WINDOWS_VERSION)
+void __cdecl dj_timer_handler();
+#else
+extern "C" void dj_timer_handler();
+#endif
 
 #endif // __AGS_EE_AC__TIMER_H

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -31,7 +31,6 @@
 #include "script/script_common.h"
 #include "script/cc_error.h"
 #include "util/textstreamwriter.h"
-#include "platform/base/agsplatformdriver.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -77,8 +76,7 @@ bool disable_log_file = false;
 String debug_line[DEBUG_CONSOLE_NUMLINES];
 int first_debug_line = 0, last_debug_line = 0, display_console = 0;
 
-float fps = std::numeric_limits<float>::quiet_NaN();
-int display_fps=0;
+int fps=0,display_fps=0;
 
 std::unique_ptr<MessageBuffer> DebugMsgBuff;
 std::unique_ptr<LogFile> DebugLogFile;

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -34,7 +34,6 @@ AGS::Common::String get_cur_script(int numberOfLinesOfCallStack);
 bool get_script_position(ScriptPosition &script_pos);
 void check_debug_keys();
 
-extern float fps;
-extern int display_fps;
+extern int fps,display_fps;
 
 #endif // __AC_DEBUGGER_H

--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -17,7 +17,6 @@
 #include "util/stream.h"
 #include "util/textstreamwriter.h"
 #include "util/wgt2allg.h"              // exists()
-#include "platform/base/agsplatformdriver.h"
 
 using AGS::Common::Stream;
 using AGS::Common::TextStreamWriter;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -616,10 +616,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
 
     guis_need_update = 1;
 
-    // if savegame contained a global time and not an offset, this will be way off.
-    if ((play.ignore_user_input_until_time - AGS_Clock::now()) > std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms)) {
-        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
-    }
+    play.ignore_user_input_until_time = 0;
     update_polled_stuff_if_runtime();
 
     pl_run_plugin_hooks(AGSE_POSTRESTOREGAME, 0);

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -23,7 +23,6 @@
 #include "main/main_allegro.h"
 #include "platform/base/agsplatformdriver.h"
 #include "util/math.h"
-#include "ac/timer.h"
 
 #if defined(ANDROID_VERSION)
 
@@ -1876,13 +1875,17 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
+    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_render(flipTypeLastTime, false);
 
-    do {
+    do
+    {
       if (_pollingCallback)
         _pollingCallback();
-    } while (waitingForNextTick());
+      platform->YieldCPU();
+    }
+    while (timerValue == *_loopTimer);
 
   }
 

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -47,9 +47,6 @@ extern "C" DDRAW_SURFACE *gfx_directx_primary_surface;
 extern int dxmedia_play_video (const char*, bool, int, int);
 #endif // WINDOWS_VERSION
 
-#include "ac/timer.h"
-
-
 namespace AGS
 {
 namespace Engine
@@ -634,6 +631,7 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
 
    for (a = 0; a < 256; a+=speed)
    {
+       int timerValue = *_loopTimer;
        bmp_buff->Fill(clearColor);
        set_trans_blender(0,0,0,a);
        bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -643,8 +641,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
        {
          if (_pollingCallback)
            _pollingCallback();
+         platform->Delay(1);
        }
-       while (waitingForNextTick());
+       while (timerValue == *_loopTimer);
    }
    delete bmp_buff;
 
@@ -671,6 +670,7 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
 			
             for (a = 255-speed; a > 0; a-=speed)
             {
+                int timerValue = *_loopTimer;
                 bmp_buff->Fill(clearColor);
                 set_trans_blender(0,0,0,a);
                 bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -680,8 +680,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
                 {
                   if (_pollingCallback)
                     _pollingCallback();
+                  platform->Delay(1);
                 }
-                while (waitingForNextTick());
+                while (timerValue == *_loopTimer);
             }
             delete bmp_buff;
         }

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -27,7 +27,8 @@ namespace Engine
 {
 
 GraphicsDriverBase::GraphicsDriverBase()
-    : _pollingCallback(nullptr)
+    : _loopTimer(nullptr)
+    , _pollingCallback(nullptr)
     , _drawScreenCallback(nullptr)
     , _nullSpriteCallback(nullptr)
     , _initGfxCallback(nullptr)
@@ -89,6 +90,7 @@ void GraphicsDriverBase::ClearDrawLists()
 
 void GraphicsDriverBase::OnInit(volatile int *loopTimer)
 {
+    _loopTimer = loopTimer;
 }
 
 void GraphicsDriverBase::OnUnInit()

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -131,6 +131,7 @@ protected:
     Rect                _filterRect;    // filter scaling destination rect (before final scaling)
     PlaneScaling        _scaling;       // native -> render dest coordinate transformation
     Point               _globalViewOff; // extra offset to every sprite draw on screen with DrawSprite
+    volatile int *      _loopTimer;
 
     // Callbacks
     GFXDRV_CLIENTCALLBACK _pollingCallback;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -32,14 +32,13 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "media/audio/audio_system.h"
-#include "platform/base/agsplatformdriver.h"
-#include "ac/timer.h"
 
 using AGS::Common::Bitmap;
 namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 extern char ignore_bounds; // from mousew32
 extern IGraphicsDriver *gfxDriver;
+extern volatile int timerloop; // ac_timer
 extern GameSetup usetup;
 
 //extern void get_save_game_path(int slotNum, char *buffer);
@@ -152,6 +151,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
     prepare_gui_screen(win_x, win_y, win_width, win_height, true);
 
     while (1) {
+        timerloop = 0;
         update_audio_system_on_game_loop();
         refresh_gui_screen();
 
@@ -193,9 +193,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         if (cscim->code > 0)
             break;
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        while (timerloop == 0) ;
     }
 
     return 0;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -22,10 +22,10 @@
 #include "gui/guidialoginternaldefs.h"
 #include "main/game_run.h"
 #include "gfx/bitmap.h"
-#include "platform/base/agsplatformdriver.h"
-#include "ac/timer.h"
 
 using AGS::Common::Bitmap;
+
+extern volatile int timerloop;
 
 extern int windowbackgroundcolor, pushbuttondarkcolor;
 extern int pushbuttonlightcolor;
@@ -75,7 +75,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 {
     int wasstat;
     while (mbutrelease(LEFT) == 0) {
-
+        timerloop = 0;
         wasstat = state;
         state = mouseisinarea(mousex, mousey);
         // stop mp3 skipping if button held down
@@ -90,9 +90,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 
         refresh_gui_screen();
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        while (timerloop == 0) ;
     }
     wasstat = state;
     state = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -26,6 +26,7 @@
 #include "ac/game.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
+#include "media/audio/soundclip.h"
 #include "ac/global_character.h"
 #include "ac/global_game.h"
 #include "ac/gui.h"
@@ -437,6 +438,12 @@ void engine_init_keyboard()
 
     install_keyboard();
 #endif
+}
+
+void engine_init_timer()
+{
+    Debug::Printf(kDbgMsg_Init, "Install timer");
+    install_timer();
 }
 
 typedef char AlIDStr[5];
@@ -966,7 +973,7 @@ void engine_init_game_settings()
     play.text_speed=15;
     play.text_min_display_time_ms = 1000;
     play.ignore_user_input_after_text_timeout_ms = 500;
-    play.ignore_user_input_until_time = AGS_Clock::now();
+    play.ignore_user_input_until_time = 0;
     play.lipsync_speed = 15;
     play.close_mouth_speech_time = 10;
     play.disable_antialiasing = 0;
@@ -1129,11 +1136,8 @@ void engine_setup_scsystem_auxiliary()
 
 void engine_update_mp3_thread()
 {
-    update_mp3_thread();
-    // reduce polling period to encourage more multithreading bugs.
-#ifndef _DEBUG
-    platform->Delay(50);
-#endif
+  update_mp3_thread();
+  platform->Delay(50);
 }
 
 void engine_start_multithreaded_audio()
@@ -1394,8 +1398,7 @@ int initialize_engine(int argc,char*argv[])
 
     our_eip = -197;
 
-    // Original timer was initialised here.
-    skipMissedTicks();
+    engine_init_timer();
 
     our_eip = -198;
 
@@ -1413,6 +1416,10 @@ int initialize_engine(int argc,char*argv[])
 
     engine_init_pathfinder();
 
+    //engine_pre_init_gfx();
+
+    LOCK_VARIABLE(timerloop);
+    LOCK_FUNCTION(dj_timer_handler);
     set_game_speed(40);
 
     our_eip=-20;

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -30,7 +30,6 @@ void RunGameUntilAborted();
 // Update everything game related
 void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
 
-float get_current_fps();
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.
 bool run_service_key_controls(int &kgn);

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -34,7 +34,6 @@
 #include "main/game_start.h"
 #include "script/script.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -43,6 +42,7 @@ extern int our_eip, displayed_room;
 extern volatile char want_exit, abort_engine;
 extern GameSetupStruct game;
 extern GameState play;
+extern volatile int timerloop;
 extern const char *loadSaveGameOnStartup;
 extern std::vector<ccInstance *> moduleInst;
 extern int numScriptModules;
@@ -56,8 +56,8 @@ void start_game_init_editor_debugging()
         SetMultitasking(1);
         if (init_editor_debugging())
         {
-            auto waitUntil = AGS_Clock::now() + std::chrono::milliseconds(500);
-            while (waitUntil > AGS_Clock::now())
+            timerloop = 0;
+            while (timerloop < 20)
             {
                 // pick up any breakpoints in game_start
                 check_for_messages_from_editor();
@@ -89,9 +89,6 @@ void start_game() {
     newmusic(0);
 
     our_eip = -42;
-
-    // skip ticks to account for initialisation or a restored game.
-    skipMissedTicks();
 
     for (int kk = 0; kk < numScriptModules; kk++)
         RunTextScript(moduleInst[kk], "game_start");

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -42,6 +42,7 @@ using namespace AGS::Engine;
 extern int proper_exit;
 extern AGSPlatformDriver *platform;
 extern IGraphicsDriver *gfxDriver;
+extern volatile int timerloop;
 
 
 IGfxDriverFactory *GfxFactory = nullptr;
@@ -571,7 +572,7 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
     if (dm.RefreshRate >= 50)
         request_refresh_rate(dm.RefreshRate);
 
-    if (!gfxDriver->SetDisplayMode(dm, nullptr))
+    if (!gfxDriver->SetDisplayMode(dm, &timerloop))
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init gfx mode. Error: %s", get_allegro_error());
         return false;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -16,7 +16,6 @@
 // Game update procedure
 //
 
-#include <cmath>
 #include "ac/common.h"
 #include "ac/character.h"
 #include "ac/characterextras.h"
@@ -37,7 +36,6 @@
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -57,6 +55,7 @@ extern int face_talking,facetalkview,facetalkwait,facetalkframe;
 extern int facetalkloop, facetalkrepeat, facetalkAllowBlink;
 extern int facetalkBlinkLoop;
 extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement_y;
+extern volatile unsigned long globalTimerCounter;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
@@ -272,7 +271,7 @@ void update_speech_and_messages()
     {
         if (!play.speech_in_post_state)
         {
-            play.messagetime = std::lround(play.speech_display_post_time_ms * get_current_fps() / 1000.0f);
+            play.messagetime = play.speech_display_post_time_ms * get_current_fps() / 1000;
         }
         play.speech_in_post_state = !play.speech_in_post_state;
     }
@@ -286,7 +285,7 @@ void update_speech_and_messages()
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
         remove_screen_overlay(OVER_TEXTMSG);
-        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
+        play.ignore_user_input_until_time = globalTimerCounter + (play.ignore_user_input_after_text_timeout_ms * get_current_fps() / 1000);
       }
     }
   }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -38,7 +38,6 @@
 #include "gfx/graphicsdriver.h"
 #include "media/audio/audio_system.h"
 #include "ac/timer.h"
-#include "main/game_run.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -64,6 +63,7 @@ extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern int numscreenover;
 extern int is_text_overlay;
 extern IGraphicsDriver *gfxDriver;
+extern int get_current_fps();
 
 int do_movelist_move(short*mlnum,int*xx,int*yy) {
   int need_to_fix_sprite=0;

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -36,7 +36,6 @@
 #include "util/stream.h"
 #include "core/assetmanager.h"
 #include "ac/timer.h"
-#include "main/game_run.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -917,6 +916,7 @@ void update_volume_drop_if_voiceover()
 }
 
 extern volatile char want_exit;
+extern int get_current_fps();
 
 void update_mp3_thread()
 {

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -23,7 +23,6 @@
 #include "util/mutex.h"
 #include "util/mutex_lock.h"
 #include "util/thread.h"
-#include "ac/timer.h"
 
 struct SOUNDCLIP;
 
@@ -136,9 +135,8 @@ extern volatile int psp_audio_multithreaded;
 void update_polled_mp3();
 void update_mp3_thread();
 
-extern void cancel_scheduled_music_update();
-extern void schedule_music_update_at(AGS_Clock::time_point);
-extern void postpone_scheduled_music_update_by(std::chrono::milliseconds);
+extern volatile int mvolcounter;
+extern int update_music_at;
 
 // crossFading is >0 (channel number of new track), or -1 (old
 // track fading out, no new track)

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -214,7 +214,7 @@ void play_flc_file(int numb,int playflags) {
     delete hicol_buf;
     hicol_buf=nullptr;
     //  SetVirtualScreen(screen); wputblock(0,0,backbuffer,0);
-    while (ags_mgetbutton()!=NONE) { } // clear any queued mouse events.
+    while (ags_mgetbutton()!=NONE) ;
     invalidate_screen();
 }
 

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -16,7 +16,6 @@
 //
 //=============================================================================
 
-#include <thread>
 #include "util/wgt2allg.h"
 #include "platform/base/agsplatformdriver.h"
 #include "ac/common.h"
@@ -89,7 +88,7 @@ void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
 }
 
 void AGSPlatformDriver::YieldCPU() {
-    std::this_thread::yield();
+    this->Delay(1);
 }
 
 void AGSPlatformDriver::InitialiseAbufAtStartup()

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -184,22 +184,3 @@ int cd_player_control(int cmdd, int datt) {
 
 #endif // AGS_HAS_CD_AUDIO
 
-void AGSPlatformDriver::Delay(int millis) {
-  auto delayUntil = AGS_Clock::now() + std::chrono::milliseconds(millis);
-
-  for (;;) {
-    if (AGS_Clock::now() >= delayUntil) { break; }
-
-    auto duration = delayUntil - AGS_Clock::now();
-    if (duration > std::chrono::milliseconds(25)) {
-      duration = std::chrono::milliseconds(25);
-    }
-    std::this_thread::sleep_for(duration);
-
-    if (AGS_Clock::now() >= delayUntil) { break; }
-
-    // don't allow it to check for debug messages, since this Delay()
-    // call might be from within a debugger polling loop
-    update_polled_mp3();
-  }
-}

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -55,7 +55,7 @@ struct AGSPlatformDriver
     : public AGS::Common::IOutputHandler
 {
     virtual void AboutToQuitGame();
-    virtual void Delay(int millis);
+    virtual void Delay(int millis) = 0;
     virtual void DisplayAlert(const char*, ...) = 0;
     virtual int  GetLastSystemError() { return errno; }
     // Get root directory for storing per-game shared data

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -139,6 +139,13 @@ const char *AGSLinux::GetAppOutputDirectory()
   return LinuxOutputDirectory;
 }
 
+void AGSLinux::Delay(int millis) {
+  struct timespec ts;
+  ts.tv_sec = 0;
+  ts.tv_nsec = millis * 1000000;
+  nanosleep(&ts, NULL);
+}
+
 unsigned long AGSLinux::GetDiskFreeSpaceMB() {
   // placeholder
   return 100;

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -43,6 +43,7 @@ String LinuxOutputDirectory;
 struct AGSLinux : AGSPlatformDriver {
 
   int  CDPlayerCommand(int cmdd, int datt) override;
+  virtual void Delay(int millis);
   void DisplayAlert(const char*, ...) override;
   const char *GetUserSavedgamesDirectory() override;
   const char *GetUserConfigDirectory() override;

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -23,6 +23,7 @@
 //#include "ac/runtime_defines.h"
 //#include "main/config.h"
 //#include "plugin/agsplugin.h"
+//#include "media/audio/audio_system.h"
 //#include <libcda.h>
 //#include <pwd.h>
 //#include <sys/stat.h>
@@ -102,6 +103,10 @@ void AGSMac::DisplayAlert(const char *text, ...) {
   vsprintf(displbuf, text, ap);
   va_end(ap);
   printf("%s\n", displbuf);
+}
+
+void AGSMac::Delay(int millis) {
+  usleep(millis);
 }
 
 unsigned long AGSMac::GetDiskFreeSpaceMB() {

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -65,6 +65,7 @@ struct AGSMac : AGSPlatformDriver {
   AGSMac();
 
   virtual int  CDPlayerCommand(int cmdd, int datt) override;
+  virtual void Delay(int millis) override;
   virtual void DisplayAlert(const char*, ...) override;
   virtual unsigned long GetDiskFreeSpaceMB() override;
   virtual const char* GetNoMouseErrorString() override;

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -95,6 +95,7 @@ struct AGSWin32 : AGSPlatformDriver {
 
   virtual void AboutToQuitGame();
   virtual int  CDPlayerCommand(int cmdd, int datt);
+  virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
   virtual int  GetLastSystemError();
   virtual const char *GetAllUsersDataDirectory();

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -826,6 +826,21 @@ int AGSWin32::GetLastSystemError()
   return ::GetLastError();
 }
 
+void AGSWin32::Delay(int millis) 
+{
+  while (millis >= 5)
+  {
+    Sleep(5);
+    millis -= 5;
+    // don't allow it to check for debug messages, since this Delay()
+    // call might be from within a debugger polling loop
+    update_polled_mp3();
+  }
+
+  if (millis > 0)
+    Sleep(millis);
+}
+
 unsigned long AGSWin32::GetDiskFreeSpaceMB() {
   DWORD returnMb = 0;
   BOOL fResult;

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1801,13 +1801,18 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
+    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_renderAndPresent(flipTypeLastTime, false);
 
-    do {
+    do
+    {
       if (_pollingCallback)
         _pollingCallback();
-    } while (waitingForNextTick());
+      platform->YieldCPU();
+    }
+    while (timerValue == *_loopTimer);
+
   }
 
   if (fadingOut)

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -18,7 +18,6 @@
 
 #include <allegro.h>
 #include <allegro/platform/aintwin.h>
-#include "ac/timer.h"
 #include "debug/assert.h"
 #include "debug/out.h"
 #include "gfx/ali3dexception.h"

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -31,7 +31,6 @@
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
 #include "main/game_run.h"
-#include "platform/base/agsplatformdriver.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -381,9 +380,7 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
 
   while ((g_bAppactive) && (!want_exit)) {
 
-    while (currentlyPaused) {
-      platform->YieldCPU();
-    }
+    while (currentlyPaused) ;
 
     RenderToSurface(vscreen);
     //Sleep(0);

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -64,6 +64,7 @@ inline LPWSTR WINAPI AtlA2WHelper(LPWSTR lpw, LPCSTR lpa, int nChars)
 extern int ags_mgetbutton();
 extern void update_audio_system_on_game_loop();
 extern volatile char want_exit;
+extern volatile int timerloop;
 extern char lastError[300];
 CVMR9Graph *graph = NULL;
 
@@ -104,10 +105,13 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
     return -1;
   }
 
-
   OAFilterState filterState = State_Running;
   while ((filterState != State_Stopped) && (!want_exit))
   {
+    while (timerloop == 0)
+      platform->Delay(1);
+    timerloop = 0;
+
     if (!useAVISound)
       update_audio_system_on_game_loop();
 
@@ -124,10 +128,6 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
       break;
 
     //device->Present(NULL, NULL, 0, NULL);
-
-		while (waitingForNextTick()) {
-      update_polled_stuff_if_runtime();
-		}
 	}
 
   graph->StopGraph();


### PR DESCRIPTION
since it was decided to revert #685, i went to the effort to actually try to revert it cleanly. since the original commit changed dozens of only loosely related things in over 40 files and 300 lines, it gave a lot of merge conflicts, especially in the audio/voice related code that was heavily refactored since.

i think the only reasonable way to solve the issues with the new code is to go back to a known good version and then **carefully** and selectively apply single, fine-grained changes with a one-change-one-commit strategy; and not by simply hiding some of the new code behind an `#ifdef`, which then causes simply that we have 2 different places to maintain instead of one.