### PR TITLE
Ags3.5  timing use counter only

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -60,6 +60,7 @@ extern ccInstance *dialogScriptsInst;
 extern int in_new_room;
 extern CharacterInfo*playerchar;
 extern SpriteCache spriteset;
+extern volatile int timerloop;
 extern AGSPlatformDriver *platform;
 extern int cur_mode,cur_cursor;
 extern IGraphicsDriver *gfxDriver;
@@ -860,6 +861,7 @@ bool DialogOptions::Run()
       }
       else
       {
+        timerloop = 0;
         update_audio_system_on_game_loop();
         render_graphics(ddb, dirtyx, dirtyy);
       }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -56,6 +56,7 @@ extern ScreenOverlay screenover[MAX_SCREEN_OVERLAYS];
 extern AGSPlatformDriver *platform;
 extern int loops_per_character;
 extern SpriteCache spriteset;
+extern volatile int timerloop;
 
 int display_message_aschar=0;
 
@@ -268,6 +269,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         int countdown = GetTextDisplayTime (todis);
         int skip_setting = user_to_internal_skip_speech((SkipSpeechStyle)play.skip_display);
         while (1) {
+            timerloop = 0;
             /*      if (!play.mouse_cursor_hidden)
             ags_domouse(DOMOUSE_UPDATE);
             write_screen();*/

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -46,6 +46,7 @@ extern color palette[256];
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
 extern color old_palette[256];
+extern volatile int timerloop;
 
 int in_enters_screen=0,done_es_error = 0;
 int in_leaves_screen = -1;
@@ -279,18 +280,19 @@ void process_event(EventHappened*evp) {
                 int boxwid = get_fixed_pixel_size(16);
                 int boxhit = data_to_game_coord(data_res.Height / 20);
                 while (boxwid < temp_scr->GetWidth()) {
+                    timerloop = 0;
                     boxwid += get_fixed_pixel_size(16);
                     boxhit += data_to_game_coord(data_res.Height / 20);
                     boxwid = Math::Clamp(boxwid, 0, viewport.GetWidth());
                     boxhit = Math::Clamp(boxhit, 0, viewport.GetHeight());
                     int lxp = viewport.GetWidth() / 2 - boxwid / 2;
                     int lyp = viewport.GetHeight() / 2 - boxhit / 2;
-                    temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp, 
+                    gfxDriver->Vsync();
+                    temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp,
                         boxwid, boxhit);
                     render_to_screen(viewport.Left, viewport.Top);
-                    do {
-                        update_polled_stuff_if_runtime();
-                    } while (waitingForNextTick());
+                    update_polled_mp3();
+                        while (timerloop == 0) ;
                 }
                 gfxDriver->SetMemoryBackBuffer(saved_backbuf, viewport.Left, viewport.Top);
             }
@@ -306,6 +308,7 @@ void process_event(EventHappened*evp) {
             int transparency = 254;
 
             while (transparency > 0) {
+                timerloop=0;
                 // do the crossfade
                 ddb->SetTransparency(transparency);
                 invalidate_screen();
@@ -317,10 +320,9 @@ void process_event(EventHappened*evp) {
                     // draw the old screen on top
                     gfxDriver->DrawSprite(0, 0, ddb);
                 }
-                render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+				render_to_screen();
+                update_polled_stuff_if_runtime();
+                while (timerloop == 0) ;
                 transparency -= 16;
             }
             saved_viewport_bitmap->Release();
@@ -338,6 +340,7 @@ void process_event(EventHappened*evp) {
             IDriverDependantBitmap *ddb = prepare_screen_for_transition_in();
 
             for (aa=0;aa<16;aa++) {
+                timerloop=0;
                 // merge the palette while dithering
                 if (game.color_depth == 1) 
                 {
@@ -355,10 +358,9 @@ void process_event(EventHappened*evp) {
                 invalidate_screen();
                 draw_screen_callback();
                 gfxDriver->DrawSprite(0, 0, ddb);
-                render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+				render_to_screen();
+                update_polled_stuff_if_runtime();
+                while (timerloop == 0) ;
             }
             saved_viewport_bitmap->Release();
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -92,6 +92,7 @@ using namespace AGS::Common;
 using namespace AGS::Engine;
 
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
+extern int time_between_timers;
 extern int cur_mode,cur_cursor;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
@@ -325,7 +326,9 @@ void set_debug_mode(bool on)
 
 void set_game_speed(int new_fps) {
     frames_per_second = new_fps;
-    setTimerFps(new_fps);
+    time_between_timers = 1000 / new_fps;
+
+    install_int_ex(dj_timer_handler,MSEC_TO_TIMER(time_between_timers));
 }
 
 extern int cbuttfont;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -35,7 +35,6 @@
 #include "ac/dynobj/cc_inventory.h"
 #include "util/math.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
 
 using namespace AGS::Common;
 
@@ -46,6 +45,7 @@ extern ScriptInvItem scrInv[MAX_INV];
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern SpriteCache spriteset;
 extern int mousex,mousey;
+extern volatile int timerloop;
 extern int evblocknum;
 extern CharacterInfo*playerchar;
 extern AGSPlatformDriver *platform;
@@ -355,6 +355,7 @@ bool InventoryScreen::Run()
         return false; // end inventory screen loop
     }
 
+        timerloop = 0;
         //ags_domouse(DOMOUSE_UPDATE);
         update_audio_system_on_game_loop();
         refresh_gui_screen();

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -29,7 +29,6 @@ using namespace AGS::Engine;
 extern GameSetupStruct game;
 extern GameState play;
 
-extern volatile unsigned long globalTimerCounter;
 extern int pluginSimulatedClick;
 extern int displayed_room;
 extern char check_dynamic_sprites_at_exit;

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -14,14 +14,30 @@
 
 #include "ac/timer.h"
 
+#include <thread>
 #include "core/platform.h"
-
 #if AGS_PLATFORM_DEBUG && defined (__GNUC__)
 #include <stdio.h>
 #include <execinfo.h>
 #include <unistd.h>
 #endif
 #include "platform/base/agsplatformdriver.h"
+#include "util/wgt2allg.h" // END_OF_FUNCTION macro
+
+volatile int timerloop=0;
+int time_between_timers=25;  // in milliseconds
+
+// our timer, used to keep game running at same speed on all systems
+#if defined(WINDOWS_VERSION)
+void __cdecl dj_timer_handler() {
+#else
+extern "C" void dj_timer_handler() {
+#endif
+    timerloop++;
+}
+END_OF_FUNCTION(dj_timer_handler);
+
+
 
 namespace {
 

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -18,6 +18,12 @@
 #ifndef __AGS_EE_AC__TIMER_H
 #define __AGS_EE_AC__TIMER_H
 
+#if defined(WINDOWS_VERSION)
+void __cdecl dj_timer_handler();
+#else
+extern "C" void dj_timer_handler();
+#endif
+
 #include <type_traits>
 #include <chrono>
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1915,14 +1915,17 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
+    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_render(flipTypeLastTime, false);
 
-    do {
+    do
+    {
       if (_pollingCallback)
         _pollingCallback();
-    } while (waitingForNextTick());
-
+      platform->YieldCPU();
+    }
+    while (timerValue == *_loopTimer);
   }
 
   if (fadingOut)

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -629,6 +629,7 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
 
    for (a = 0; a < 256; a+=speed)
    {
+       int timerValue = *_loopTimer;
        bmp_buff->Fill(clearColor);
        set_trans_blender(0,0,0,a);
        bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -638,8 +639,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *currentVirtScreen, int 
        {
          if (_pollingCallback)
            _pollingCallback();
+         platform->Delay(1);
        }
-       while (waitingForNextTick());
+       while (timerValue == *_loopTimer);
    }
    delete bmp_buff;
 
@@ -666,6 +668,7 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
 			
             for (a = 255-speed; a > 0; a-=speed)
             {
+                int timerValue = *_loopTimer;
                 bmp_buff->Fill(clearColor);
                 set_trans_blender(0,0,0,a);
                 bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
@@ -675,8 +678,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(int speed, int targetColourRed
                 {
                   if (_pollingCallback)
                     _pollingCallback();
+                  platform->Delay(1);
                 }
-                while (waitingForNextTick());
+                while (timerValue == *_loopTimer);
             }
             delete bmp_buff;
         }

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -27,7 +27,8 @@ namespace Engine
 {
 
 GraphicsDriverBase::GraphicsDriverBase()
-    : _pollingCallback(nullptr)
+    : _loopTimer(NULL)
+    , _pollingCallback(nullptr)
     , _drawScreenCallback(nullptr)
     , _nullSpriteCallback(nullptr)
     , _initGfxCallback(nullptr)
@@ -89,6 +90,7 @@ void GraphicsDriverBase::ClearDrawLists()
 
 void GraphicsDriverBase::OnInit(volatile int *loopTimer)
 {
+    _loopTimer = loopTimer;
 }
 
 void GraphicsDriverBase::OnUnInit()

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -131,6 +131,7 @@ protected:
     Rect                _filterRect;    // filter scaling destination rect (before final scaling)
     PlaneScaling        _scaling;       // native -> render dest coordinate transformation
     Point               _globalViewOff; // extra offset to every sprite draw on screen with DrawSprite
+    volatile int *      _loopTimer;
 
     // Callbacks
     GFXDRV_CLIENTCALLBACK _pollingCallback;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -40,6 +40,7 @@ namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 extern char ignore_bounds; // from mousew32
 extern IGraphicsDriver *gfxDriver;
+extern volatile int timerloop; // ac_timer
 extern GameSetup usetup;
 
 
@@ -149,6 +150,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
     prepare_gui_screen(win_x, win_y, win_width, win_height, true);
 
     while (1) {
+        timerloop = 0;
         update_audio_system_on_game_loop();
         refresh_gui_screen();
 
@@ -190,9 +192,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         if (cscim->code > 0)
             break;
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        while (timerloop == 0) ;
     }
 
     return 0;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -27,6 +27,8 @@
 
 using AGS::Common::Bitmap;
 
+extern volatile int timerloop;
+
 extern int windowbackgroundcolor, pushbuttondarkcolor;
 extern int pushbuttonlightcolor;
 extern int cbuttfont;
@@ -75,7 +77,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 {
     int wasstat;
     while (mbutrelease(LEFT) == 0) {
-
+        timerloop = 0;
         wasstat = state;
         state = mouseisinarea(mousex, mousey);
         // stop mp3 skipping if button held down
@@ -90,9 +92,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 
         refresh_gui_screen();
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        while (timerloop == 0) ;
     }
     wasstat = state;
     state = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -437,6 +437,12 @@ void engine_init_keyboard()
 #endif
 }
 
+void engine_init_timer()
+{
+    Debug::Printf(kDbgMsg_Init, "Install timer");
+    install_timer();
+}
+
 bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
     Debug::Printf(kDbgMsg_Init, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
@@ -1140,10 +1146,7 @@ void engine_setup_scsystem_auxiliary()
 void engine_update_mp3_thread()
 {
     update_mp3_thread();
-    // reduce polling period to encourage more multithreading bugs.
-#if ! AGS_PLATFORM_DEBUG
     platform->Delay(50);
-#endif
 }
 
 void engine_start_multithreaded_audio()
@@ -1401,8 +1404,7 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     our_eip = -197;
 
-    // Original timer was initialised here.
-    skipMissedTicks();
+    engine_init_timer();
 
     our_eip = -198;
 
@@ -1420,6 +1422,8 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     engine_init_pathfinder();
 
+    LOCK_VARIABLE(timerloop);
+    LOCK_FUNCTION(dj_timer_handler);
     set_game_speed(40);
 
     our_eip=-20;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -85,6 +85,7 @@ extern RoomStatus*croom;
 extern CharacterExtras *charextra;
 extern SpriteCache spriteset;
 extern int cur_mode,cur_cursor;
+extern volatile int timerloop;
 
 // Checks if user interface should remain disabled for now
 static int ShouldStayInWaitMode();
@@ -719,10 +720,11 @@ void set_loop_counter(unsigned int new_counter) {
 
 void PollUntilNextFrame()
 {
-    if (play.fast_forward) { return; }
-    while (waitingForNextTick()) {
-        // make sure we poll, cos a low framerate (eg 5 fps) could stutter mp3 music
+    // make sure we poll, cos a low framerate (eg 5 fps) could stutter
+    // mp3 music
+    while (timerloop == 0 && play.fast_forward == 0) {
         update_polled_stuff_if_runtime();
+        platform->YieldCPU();
     }
 }
 
@@ -740,6 +742,7 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     ccNotifyScriptStillAlive ();
     our_eip=1;
+    timerloop=0;
 
     game_loop_check_problems_at_start();
 

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -43,6 +43,7 @@ using namespace AGS::Engine;
 extern int proper_exit;
 extern AGSPlatformDriver *platform;
 extern IGraphicsDriver *gfxDriver;
+extern volatile int timerloop;
 
 
 IGfxDriverFactory *GfxFactory = nullptr;
@@ -576,7 +577,7 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
     if (dm.RefreshRate >= 50)
         request_refresh_rate(dm.RefreshRate);
 
-    if (!gfxDriver->SetDisplayMode(dm, nullptr))
+    if (!gfxDriver->SetDisplayMode(dm, &timerloop))
     {
         Debug::Printf(kDbgMsg_Error, "Failed to init gfx mode. Error: %s", get_allegro_error());
         return false;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -90,7 +90,10 @@ void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
 }
 
 void AGSPlatformDriver::YieldCPU() {
-    std::this_thread::yield();
+    // NOTE: this is called yield, but if we actually yield instead of delay,
+    // we get a massive increase in CPU usage.
+    this->Delay(1);
+    //std::this_thread::yield();
 }
 
 void AGSPlatformDriver::InitialiseAbufAtStartup()

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -190,18 +190,20 @@ int cd_player_control(int cmdd, int datt) {
 #endif // AGS_HAS_CD_AUDIO
 
 void AGSPlatformDriver::Delay(int millis) {
-  auto delayUntil = AGS_Clock::now() + std::chrono::milliseconds(millis);
+  auto now = AGS_Clock::now();
+  auto delayUntil = now + std::chrono::milliseconds(millis);
 
   for (;;) {
-    if (AGS_Clock::now() >= delayUntil) { break; }
+    if (now >= delayUntil) { break; }
 
-    auto duration = delayUntil - AGS_Clock::now();
-    if (duration > std::chrono::milliseconds(25)) {
-      duration = std::chrono::milliseconds(25);
+    auto duration = delayUntil - now;
+    if (duration > std::chrono::milliseconds(16)) {
+      duration = std::chrono::milliseconds(16);
     }
     std::this_thread::sleep_for(duration);
+    now = AGS_Clock::now(); // update now
 
-    if (AGS_Clock::now() >= delayUntil) { break; }
+    if (now >= delayUntil) { break; }
 
     // don't allow it to check for debug messages, since this Delay()
     // call might be from within a debugger polling loop

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -700,9 +700,10 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   d3dpp.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER; // we need this flag to access the backbuffer with lockrect
   d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
   if(mode.Vsync)
-    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_DEFAULT;
+    d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
   else
     d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
   /* If full screen, specify the refresh rate */
   if ((d3dpp.Windowed == FALSE) && (mode.RefreshRate > 0))
     d3dpp.FullScreen_RefreshRateInHz = mode.RefreshRate;

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1816,13 +1816,16 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
+    int timerValue = *_loopTimer;
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_renderAndPresent(flipTypeLastTime, false);
-
-    do {
+    do
+    {
       if (_pollingCallback)
         _pollingCallback();
-    } while (waitingForNextTick());
+      platform->YieldCPU();
+    }
+    while (timerValue == *_loopTimer);
   }
 
   if (fadingOut)

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -68,6 +68,7 @@ inline LPWSTR WINAPI AtlA2WHelper(LPWSTR lpw, LPCSTR lpa, int nChars)
 extern int ags_mgetbutton();
 extern void update_audio_system_on_game_loop();
 extern volatile char want_exit;
+extern volatile int timerloop;
 extern char lastError[300];
 CVMR9Graph *graph = NULL;
 
@@ -108,10 +109,13 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
     return -1;
   }
 
-
   OAFilterState filterState = State_Running;
   while ((filterState != State_Stopped) && (!want_exit))
   {
+    while (timerloop == 0)
+      platform->Delay(1);
+    timerloop = 0;
+
     if (!useAVISound)
       update_audio_system_on_game_loop();
 
@@ -128,10 +132,6 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
       break;
 
     //device->Present(NULL, NULL, 0, NULL);
-
-		while (waitingForNextTick()) {
-      update_polled_stuff_if_runtime();
-		}
 	}
 
   graph->StopGraph();


### PR DESCRIPTION
This introduces the same changes as https://github.com/adventuregamestudio/ags/pull/795 but without the option of switching back to the new implementation (making comparisons harder).

When merging the 3.5.0 release branch into ags3, please be aware to ignore changeset 5424b49