### PR TITLE
multifilelib: don't allow head sig search to extend past tail offset

### DIFF
--- a/Common/util/mutifilelib.cpp
+++ b/Common/util/mutifilelib.cpp
@@ -132,15 +132,18 @@ MFLUtil::MFLError MFLUtil::ReadSigsAndVersion(Stream *in, MFLVersion *p_lib_vers
         soff_t abs_offset_32 = in->ReadInt32();
 
         // test for header signature again, with 64-bit and 32-bit offsets if necessary
-        if (abs_offset > 0 && abs_offset < (tail_abs_offset - HeadSig.GetLength())) {
+        if (abs_offset > 0 && abs_offset < (tail_abs_offset - HeadSig.GetLength())) 
+        {
             in->Seek(abs_offset, kSeekBegin);
             sig.ReadCount(in, HeadSig.GetLength());
         }
 
         // try again with 32-bit offset
-        if (HeadSig.Compare(sig) != 0) {
+        if (HeadSig.Compare(sig) != 0) 
+        {
             abs_offset = abs_offset_32;
-            if (abs_offset > 0 && abs_offset < (tail_abs_offset - HeadSig.GetLength())) {
+            if (abs_offset > 0 && abs_offset < (tail_abs_offset - HeadSig.GetLength())) 
+            {
                 in->Seek(abs_offset, kSeekBegin);
                 sig.ReadCount(in, HeadSig.GetLength());
             }


### PR DESCRIPTION
This fixes issues on systems where it is an error to read at an offset past end. (reading at end should still give you 0 bytes though)

edit: I didn't add a check to Seek itself since it would require grabbing the file size on load. Plus, we can't always rely on that if we're reading sub-resources (in instances where we pass Streams already repositioned to the right resource).