### PR TITLE
3.5.0: fix viewport/camera restoration by reading data into temp structs and applying later

### DIFF
--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -24,12 +24,14 @@
 #include "device/mousew32.h"
 #include "game/customproperties.h"
 #include "game/roomstruct.h"
+#include "game/savegame_internal.h"
 #include "main/engine.h"
 #include "media/audio/audio_system.h"
 #include "util/alignedstream.h"
 #include "util/string_utils.h"
 
 using namespace AGS::Common;
+using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern RoomStruct thisroom;
@@ -446,7 +448,7 @@ bool GameState::ShouldPlayVoiceSpeech() const
         (play.want_speech >= 1) && (!ResPaths.SpeechPak.Name.IsEmpty());
 }
 
-void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver)
+void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver, RestoredData &r_data)
 {
     const bool old_save = svg_ver < kGSSvgVersion_Initial;
     score = in->ReadInt32();
@@ -570,9 +572,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     {
         short offsets_locked = in->ReadInt16();
         if (offsets_locked != 0)
-            _roomCameras[0]->Lock();
-        else
-            _roomCameras[0]->Release();
+            r_data.Cameras[0].Flags = kSvgCamPosLocked;
     }
     entered_at_x = in->ReadInt32();
     entered_at_y = in->ReadInt32();

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -30,10 +30,15 @@
 #include "ac/timer.h"
 
 // Forward declaration
-namespace AGS { namespace Common {
-    class Bitmap; class Stream;
-    typedef std::shared_ptr<Bitmap> PBitmap;
-} }
+namespace AGS
+{
+    namespace Common
+    {
+        class Bitmap; class Stream;
+        typedef std::shared_ptr<Bitmap> PBitmap;
+    }
+    namespace Engine { struct RestoredData; }
+}
 using namespace AGS; // FIXME later
 struct ScriptViewport;
 struct ScriptCamera;
@@ -337,7 +342,7 @@ struct GameState {
     void ReadQueuedAudioItems_Aligned(Common::Stream *in);
     void ReadCustomProperties_v340(Common::Stream *in);
     void WriteCustomProperties_v340(Common::Stream *out) const;
-    void ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver);
+    void ReadFromSavegame(Common::Stream *in,  GameStateSvgVersion svg_ver, AGS::Engine::RestoredData &r_data);
     void WriteForSavegame(Common::Stream *out) const;
     void FreeProperties();
     void FreeViewportsAndCameras();

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -303,7 +303,7 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
     }
 
     // Game state
-    play.ReadFromSavegame(in.get(), svg_ver);
+    play.ReadFromSavegame(in.get(), svg_ver, r_data);
 
     // Other dynamic values
     r_data.FPS = in->ReadInt32();

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -185,21 +185,6 @@ inline bool AssertGameObjectContent2(HSaveError &err, int new_val, int original_
 }
 
 
-enum GameViewCamFlags
-{
-    kSvgGameAutoRoomView = 0x01
-};
-
-enum CameraSaveFlags
-{
-    kSvgCamPosLocked = 0x01
-};
-
-enum ViewportSaveFlags
-{
-    kSvgViewportVisible = 0x01
-};
-
 void WriteCameraState(const Camera &cam, Stream *out)
 {
     int flags = 0;
@@ -273,40 +258,30 @@ HSaveError WriteGameState(PStream out)
     return HSaveError::None();
 }
 
-void ReadCameraState(/*Camera &cam,*/ RestoredData &r_data, Stream *in)
+void ReadCameraState(RestoredData &r_data, Stream *in)
 {
-    Camera cam;
-    cam.SetID(r_data.Cameras.size());
-    int flags = in->ReadInt32();
-    if ((flags & kSvgCamPosLocked) != 0)
-        cam.Lock();
-    else
-        cam.Release();
-    int left = in->ReadInt32();
-    int top = in->ReadInt32();
-    int width = in->ReadInt32();
-    int height = in->ReadInt32();
-    cam.SetAt(left, top);
-    cam.SetSize(Size(width, height));
+    RestoredData::CameraData cam;
+    cam.ID = r_data.Cameras.size();
+    cam.Flags = in->ReadInt32();
+    cam.Left = in->ReadInt32();
+    cam.Top = in->ReadInt32();
+    cam.Width = in->ReadInt32();
+    cam.Height = in->ReadInt32();
     r_data.Cameras.push_back(cam);
 }
 
-void ReadViewportState(/*Viewport &view,*/ RestoredData &r_data, Stream *in)
+void ReadViewportState(RestoredData &r_data, Stream *in)
 {
-    Viewport view;
-    view.SetID(r_data.Viewports.size());
-    int flags = in->ReadInt32();
-    view.SetVisible((flags & kSvgViewportVisible) != 0);
-    const Rect &rc = view.GetRect();
-    int left = in->ReadInt32();
-    int top = in->ReadInt32();
-    int width = in->ReadInt32();
-    int height = in->ReadInt32();
-    view.SetRect(RectWH(left, top, width, height));
-    view.SetZOrder(in->ReadInt32());
-    int cam_index = in->ReadInt32();
+    RestoredData::ViewportData view;
+    view.ID = r_data.Viewports.size();
+    view.Flags = in->ReadInt32();
+    view.Left = in->ReadInt32();
+    view.Top = in->ReadInt32();
+    view.Width = in->ReadInt32();
+    view.Height = in->ReadInt32();
+    view.ZOrder = in->ReadInt32();
+    view.CamID = in->ReadInt32();
     r_data.Viewports.push_back(view);
-    r_data.ViewCamLinks.push_back(cam_index);
 }
 
 HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
@@ -353,7 +328,8 @@ HSaveError ReadGameState(PStream in, int32_t cmp_ver, const PreservedParams &pp,
         play.SetAutoRoomViewport((viewcam_flags & kSvgGameAutoRoomView) != 0);
         // TODO: we create viewport and camera objects here because they are
         // required for the managed pool deserialization, but read actual
-        // data into temp structs because of issue with load_new_room().
+        // data into temp structs because we need to apply it after active
+        // room is loaded.
         // See comments to RestoredData struct for further details.
         int cam_count = in->ReadInt32();
         for (int i = 0; i < cam_count; ++i)

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -17,8 +17,8 @@
 
 #include <memory>
 #include <vector>
-
 #include "ac/common_defines.h"
+#include "gfx/bitmap.h"
 #include "media/audio/audiodefines.h"
 
 
@@ -26,6 +26,8 @@ namespace AGS
 {
 namespace Engine
 {
+
+using AGS::Common::Bitmap;
 
 typedef std::shared_ptr<Bitmap> PBitmap;
 

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -45,6 +45,21 @@ struct PreservedParams
     PreservedParams();
 };
 
+enum GameViewCamFlags
+{
+    kSvgGameAutoRoomView = 0x01
+};
+
+enum CameraSaveFlags
+{
+    kSvgCamPosLocked = 0x01
+};
+
+enum ViewportSaveFlags
+{
+    kSvgViewportVisible = 0x01
+};
+
 // RestoredData keeps certain temporary data to help with
 // the restoration process
 struct RestoredData
@@ -88,16 +103,30 @@ struct RestoredData
     ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
     // Ambient sounds
     int                     DoAmbient[MAX_SOUND_CHANNELS];
-    // TODO: this is ugly, but we have to keep this data and apply only after
-    // room gets loaded, otherwise it will override restored settings.
-    // Same may refer to few other settings above.
-    // This could be fixed if we split load_new_room() into 2 functions that
-    // load room data with or without applying additional changes. Since code
-    // is pretty complex there this has to be done with careful research.
-    std::vector<Viewport>   Viewports;
-    std::vector<Camera>     Cameras;
-    // Viewport -> camera links
-    std::vector<int>        ViewCamLinks;
+    // Viewport and camera data, has to be preserved and applied only after
+    // room gets loaded, because we must clamp these to room parameters.
+    struct ViewportData
+    {
+        int ID = -1;
+        int Flags = 0;
+        int Left = 0;
+        int Top = 0;
+        int Width = 0;
+        int Height = 0;
+        int ZOrder = 0;
+        int CamID = -1;
+    };
+    struct CameraData
+    {
+        int ID = -1;
+        int Flags = 0;
+        int Left = 0;
+        int Top = 0;
+        int Width = 0;
+        int Height = 0;
+    };
+    std::vector<ViewportData> Viewports;
+    std::vector<CameraData> Cameras;
 
     RestoredData();
 };


### PR DESCRIPTION
This should fix #775 and may also fix #779 (not sure if both games mentioned there have same problem).

Changes:
* When loading a save keep viewport & camera data in a temporary struct and only apply in the end: this allows to clamp camera positions to actual room bounds (and not depend on loading order);
* Make sure load_new_room function only adjusts cameras when called *not* during restoring a save.
(This function is super messy and may benefit from splitting into two or more functions with different purposes, but that's not a task for this PR)