### PR TITLE
timing: Refactor timing so all wait loops are done from the one function.

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1046,7 +1046,13 @@ bool DialogOptions::Run()
             return true; // continue running loop
         }
       }
-      PollUntilNextFrame();
+
+      update_polled_stuff_if_runtime();
+
+      if (play.fast_forward == 0)
+      {
+          WaitForNextFrame();
+      }
       return true; // continue running loop
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -292,7 +292,14 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 if (skip_setting & SKIP_KEYPRESS)
                     break;
             }
-            PollUntilNextFrame();
+
+            update_polled_stuff_if_runtime();
+
+            if (play.fast_forward == 0)
+            {
+                WaitForNextFrame();
+            }
+
             countdown--;
 
             if (play.speech_has_voice) {

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -291,8 +291,10 @@ void process_event(EventHappened*evp) {
                     temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp,
                         boxwid, boxhit);
                     render_to_screen(viewport.Left, viewport.Top);
+
                     update_polled_mp3();
-                        while (timerloop == 0) ;
+
+                    WaitForNextFrame();
                 }
                 gfxDriver->SetMemoryBackBuffer(saved_backbuf, viewport.Left, viewport.Top);
             }
@@ -321,8 +323,11 @@ void process_event(EventHappened*evp) {
                     gfxDriver->DrawSprite(0, 0, ddb);
                 }
 				render_to_screen();
+
                 update_polled_stuff_if_runtime();
-                while (timerloop == 0) ;
+
+                WaitForNextFrame();
+
                 transparency -= 16;
             }
             saved_viewport_bitmap->Release();
@@ -359,8 +364,10 @@ void process_event(EventHappened*evp) {
                 draw_screen_callback();
                 gfxDriver->DrawSprite(0, 0, ddb);
 				render_to_screen();
+
                 update_polled_stuff_if_runtime();
-                while (timerloop == 0) ;
+
+                WaitForNextFrame();
             }
             saved_viewport_bitmap->Release();
 

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -475,7 +475,10 @@ bool InventoryScreen::Run()
             //ags_domouse(DOMOUSE_ENABLE);
         }
         wasonitem=isonitem;
-        PollUntilNextFrame();
+
+        update_polled_stuff_if_runtime();
+
+        WaitForNextFrame();
 
     return true; // continue inventory screen loop
 }

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -37,7 +37,13 @@ extern "C" void dj_timer_handler() {
 }
 END_OF_FUNCTION(dj_timer_handler);
 
-
+void WaitForNextFrame()
+{
+    while (timerloop == 0) 
+    { 
+        platform->YieldCPU(); 
+    }
+}
 
 namespace {
 

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -34,6 +34,8 @@ using AGS_Clock = std::conditional<
         std::chrono::high_resolution_clock, std::chrono::steady_clock
       >::type;
 
+extern void WaitForNextFrame();
+
 extern void setTimerFps(int new_fps);
 extern bool waitingForNextTick();  // store last tick time.
 extern void skipMissedTicks();  // if more than N frames, just skip all, start a fresh.

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -192,7 +192,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         if (cscim->code > 0)
             break;
 
-        while (timerloop == 0) ;
+        WaitForNextFrame();
     }
 
     return 0;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -92,7 +92,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 
         refresh_gui_screen();
 
-        while (timerloop == 0) ;
+        WaitForNextFrame();
     }
     wasstat = state;
     state = 0;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -718,16 +718,6 @@ void set_loop_counter(unsigned int new_counter) {
     fps = std::numeric_limits<float>::quiet_NaN();
 }
 
-void PollUntilNextFrame()
-{
-    // make sure we poll, cos a low framerate (eg 5 fps) could stutter
-    // mp3 music
-    while (timerloop == 0 && play.fast_forward == 0) {
-        update_polled_stuff_if_runtime();
-        platform->YieldCPU();
-    }
-}
-
 void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int extraX, int extraY) {
 
     int res;
@@ -804,7 +794,9 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     game_loop_update_fps();
 
-    PollUntilNextFrame();
+    update_polled_stuff_if_runtime();
+
+    WaitForNextFrame();
 }
 
 static void UpdateMouseOverLocation()

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -31,8 +31,6 @@ void GameLoopUntilValueIsNegative(const int *value);
 void GameLoopUntilNotMoving(const short *move);
 void GameLoopUntilNoOverlay();
 
-// Polls audio until the end of current game frame
-void PollUntilNextFrame();
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally
 void RunGameUntilAborted();
 // Update everything game related

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -112,8 +112,7 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
   OAFilterState filterState = State_Running;
   while ((filterState != State_Stopped) && (!want_exit))
   {
-    while (timerloop == 0)
-      platform->Delay(1);
+    WaitForNextFrame();
     timerloop = 0;
 
     if (!useAVISound)


### PR DESCRIPTION
Refactor timing so all wait loops are done from the one function.

This reverts an earlier change made in 6db4421 that introduced PollUntilNextFrame that was useful but mixed in the concerns of fast forward and polling. Pulling that out that allowed us to use the one wait loop function.