### PR TITLE
Script API: replaced "sorted" and "caseSensitive" boolean params with enums

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -415,6 +415,20 @@ enum CharacterDirection {
 };
 #endif
 
+#ifdef SCRIPT_API_v350
+enum StringCompareStyle
+{
+  eCaseInsensitive = 0,
+  eCaseSensitive = 1
+};
+
+enum SortStyle
+{
+  eNonSorted = 0,
+  eSorted = 1
+};
+#endif
+
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
   import static String Format(const string format, ...);    // $AUTOCOMPLETESTATICONLY$
@@ -425,22 +439,22 @@ internalstring autoptr builtin managed struct String {
   /// Returns a new string that has the extra character appended.
   import String  AppendChar(char extraChar);
   /// Compares this string to the other string.
-  import int     CompareTo(const string otherString, bool caseSensitive = false);
+  import int     CompareTo(const string otherString, StringCompareStyle style = eCaseInsensitive);
   import int     Contains(const string needle);   // $AUTOCOMPLETEIGNORE$
   /// Creates a copy of the string.
   import String  Copy();
   /// Checks whether this string ends with the specified text.
-  import bool    EndsWith(const string endsWithText, bool caseSensitive = false);
+  import bool    EndsWith(const string endsWithText, StringCompareStyle style = eCaseInsensitive);
   /// Returns the index of the first occurrence of the needle in this string.
   import int     IndexOf(const string needle);
   /// Returns a lower-cased version of this string.
   import String  LowerCase();
   /// Returns a copy of this string with all occurrences of LookForText replaced with ReplaceWithText
-  import String  Replace(const string lookForText, const string replaceWithText, bool caseSensitive = false);
+  import String  Replace(const string lookForText, const string replaceWithText, StringCompareStyle style = eCaseInsensitive);
   /// Returns a new string, with the specified character changed.
   import String  ReplaceCharAt(int index, char newChar);
   /// Checks whether this string starts with the specified text.
-  import bool    StartsWith(const string startsWithText, bool caseSensitive = false);
+  import bool    StartsWith(const string startsWithText, StringCompareStyle style = eCaseInsensitive);
   /// Returns a portion of the string.
   import String  Substring(int index, int length);
   /// Truncates the string down to the specified length by removing characters from the end.
@@ -461,7 +475,7 @@ internalstring autoptr builtin managed struct String {
 builtin managed struct Dictionary
 {
   /// Creates a new empty Dictionary of the given properties.
-  import static Dictionary* Create(bool sorted = false, bool caseSensitive = false); // $AUTOCOMPLETESTATICONLY$
+  import static Dictionary* Create(SortStyle sortStyle = eNonSorted, StringCompareStyle compareStyle = eCaseInsensitive); // $AUTOCOMPLETESTATICONLY$
 
   /// Removes all items from the dictionary.
   import void Clear();
@@ -489,7 +503,7 @@ builtin managed struct Dictionary
 builtin managed struct Set
 {
   /// Creates a new empty Set of the given properties.
-  import static Set* Create(bool sorted = false, bool caseSensitive = false); // $AUTOCOMPLETESTATICONLY$
+  import static Set* Create(SortStyle sortStyle = eNonSorted, StringCompareStyle compareStyle = eCaseInsensitive); // $AUTOCOMPLETESTATICONLY$
 
   /// Adds item to the set, fails if such item was already existing.
   import bool Add(String item);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -489,9 +489,9 @@ builtin managed struct Dictionary
   import bool Set(String key, String value);
 
   /// Gets if this dictionary is case-sensitive.
-  import readonly attribute bool CaseSensitive;
-  /// Gets if this dictionary is sorted by keys in alphabetical order.
-  import readonly attribute bool Sorted;
+  import readonly attribute StringCompareStyle CompareStyle;
+  /// Gets the method items are arranged in this dictionary.
+  import readonly attribute SortStyle SortStyle;
   /// Gets the number of key/value pairs currently in the dictionary.
   import readonly attribute int ItemCount;
   /// Creates a dynamic array filled with keys in same order as they are stored in the Dictionary.
@@ -515,9 +515,9 @@ builtin managed struct Set
   import bool Remove(String item);
 
   /// Gets if this set is case-sensitive.
-  import readonly attribute bool CaseSensitive;
-  /// Gets if this set is sorted in alphabetical order.
-  import readonly attribute bool Sorted;
+  import readonly attribute StringCompareStyle CompareStyle;
+  /// Gets the method items are arranged in this set.
+  import readonly attribute SortStyle SortStyle;
   /// Gets the number of items currently in the set.
   import readonly attribute int ItemCount;
   /// Creates a dynamic array filled with items in same order as they are stored in the Set.

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -98,14 +98,14 @@ bool Dict_Set(ScriptDictBase *dic, const char *key, const char *value)
     return dic->Set(key, value);
 }
 
-bool Dict_GetCaseSensitive(ScriptDictBase *dic)
+int Dict_GetCompareStyle(ScriptDictBase *dic)
 {
-    return dic->IsCaseSensitive();
+    return dic->IsCaseSensitive() ? 1 : 0;
 }
 
-bool Dict_GetSorted(ScriptDictBase *dic)
+int Dict_GetSortStyle(ScriptDictBase *dic)
 {
-    return dic->IsSorted();
+    return dic->IsSorted() ? 1 : 0;
 }
 
 int Dict_GetItemCount(ScriptDictBase *dic)
@@ -159,14 +159,14 @@ RuntimeScriptValue Sc_Dict_Set(void *self, const RuntimeScriptValue *params, int
     API_OBJCALL_BOOL_POBJ2(ScriptDictBase, Dict_Set, const char, const char);
 }
 
-RuntimeScriptValue Sc_Dict_GetCaseSensitive(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Dict_GetCompareStyle(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_BOOL(ScriptDictBase, Dict_GetCaseSensitive);
+    API_OBJCALL_INT(ScriptDictBase, Dict_GetCompareStyle);
 }
 
-RuntimeScriptValue Sc_Dict_GetSorted(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Dict_GetSortStyle(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_BOOL(ScriptDictBase, Dict_GetSorted);
+    API_OBJCALL_INT(ScriptDictBase, Dict_GetSortStyle);
 }
 
 RuntimeScriptValue Sc_Dict_GetItemCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -250,14 +250,14 @@ bool Set_Remove(ScriptSetBase *set, const char *item)
     return set->Remove(item);
 }
 
-bool Set_GetCaseSensitive(ScriptSetBase *set)
+int Set_GetCompareStyle(ScriptSetBase *set)
 {
-    return set->IsCaseSensitive();
+    return set->IsCaseSensitive() ? 1 : 0;
 }
 
-bool Set_GetSorted(ScriptSetBase *set)
+int Set_GetSortStyle(ScriptSetBase *set)
 {
-    return set->IsSorted();
+    return set->IsSorted() ? 1 : 0;
 }
 
 int Set_GetItemCount(ScriptSetBase *set)
@@ -298,14 +298,14 @@ RuntimeScriptValue Sc_Set_Remove(void *self, const RuntimeScriptValue *params, i
     API_OBJCALL_BOOL_POBJ(ScriptSetBase, Set_Remove, const char);
 }
 
-RuntimeScriptValue Sc_Set_GetCaseSensitive(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Set_GetCompareStyle(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_BOOL(ScriptSetBase, Set_GetCaseSensitive);
+    API_OBJCALL_INT(ScriptSetBase, Set_GetCompareStyle);
 }
 
-RuntimeScriptValue Sc_Set_GetSorted(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Set_GetSortStyle(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_BOOL(ScriptSetBase, Set_GetSorted);
+    API_OBJCALL_INT(ScriptSetBase, Set_GetSortStyle);
 }
 
 RuntimeScriptValue Sc_Set_GetItemCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -328,8 +328,8 @@ void RegisterContainerAPI()
     ccAddExternalObjectFunction("Dictionary::Get", Sc_Dict_Get);
     ccAddExternalObjectFunction("Dictionary::Remove", Sc_Dict_Remove);
     ccAddExternalObjectFunction("Dictionary::Set", Sc_Dict_Set);
-    ccAddExternalObjectFunction("Dictionary::get_CaseSensitive", Sc_Dict_GetCaseSensitive);
-    ccAddExternalObjectFunction("Dictionary::get_Sorted", Sc_Dict_GetSorted);
+    ccAddExternalObjectFunction("Dictionary::get_CompareStyle", Sc_Dict_GetCompareStyle);
+    ccAddExternalObjectFunction("Dictionary::get_SortStyle", Sc_Dict_GetSortStyle);
     ccAddExternalObjectFunction("Dictionary::get_ItemCount", Sc_Dict_GetItemCount);
     ccAddExternalObjectFunction("Dictionary::GetKeysAsArray", Sc_Dict_GetKeysAsArray);
     ccAddExternalObjectFunction("Dictionary::GetValuesAsArray", Sc_Dict_GetValuesAsArray);
@@ -339,8 +339,8 @@ void RegisterContainerAPI()
     ccAddExternalObjectFunction("Set::Clear", Sc_Set_Clear);
     ccAddExternalObjectFunction("Set::Contains", Sc_Set_Contains);
     ccAddExternalObjectFunction("Set::Remove", Sc_Set_Remove);
-    ccAddExternalObjectFunction("Set::get_CaseSensitive", Sc_Set_GetCaseSensitive);
-    ccAddExternalObjectFunction("Set::get_Sorted", Sc_Set_GetSorted);
+    ccAddExternalObjectFunction("Set::get_CompareStyle", Sc_Set_GetCompareStyle);
+    ccAddExternalObjectFunction("Set::get_SortStyle", Sc_Set_GetSortStyle);
     ccAddExternalObjectFunction("Set::get_ItemCount", Sc_Set_GetItemCount);
     ccAddExternalObjectFunction("Set::GetItemsAsArray", Sc_Set_GetItemAsArray);
 }


### PR DESCRIPTION
By user request, this replaces "sorted" and "caseSensitive" booleans in number of functions to corresponding enum types:

<pre>
enum StringCompareStyle
{
  eCaseInsensitive = 0,
  eCaseSensitive = 1
};

enum SortStyle
{
  eNonSorted = 0,
  eSorted = 1
};
</pre>

This applies to some of the String functions as well as newer Dictionary.Create and Set.Create.

The constant values are chosen to match the meaning of boolean parameters, so that the old scripts still compile and work the same way.

---

As a separate commit I also changed two readonly properties in Dicrionary and Set:
* bool CaseSensitive to CompareStyle;
* bool Sorted to SortStyle;

Was not sure about it, so this is done as a separate commit that could be dropped if others think this is not good.

NOTE: Since this is a very new API I believe it's not necessary to keep support for previous property names.