### PR TITLE
PushValueToStack: remove validation code for undefined values

### DIFF
--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1851,16 +1851,6 @@ bool ccInstance::FixupArgument(intptr_t code_value, char fixup_type, RuntimeScri
 
 void ccInstance::PushValueToStack(const RuntimeScriptValue &rval)
 {
-    if (!rval.IsValid())
-    {
-        cc_error("internal error: undefined value pushed to stack");
-        return;
-    }
-    if (registers[SREG_SP].RValue->IsValid())
-    {
-        cc_error("internal error: valid data beyond stack ptr");
-        return;
-    }
     // Write value to the stack tail and advance stack ptr
     registers[SREG_SP].WriteValue(rval);
     registers[SREG_SP].RValue++;


### PR DESCRIPTION
the ags script compiler rarely makes use of the registers "cx" and "dx"
if at all. this means they will contain a scriptvalue of type "undefined"
until first usage.
with the check assuming pushing undefined values to the stack is invalid,
it makes it impossible for a bugfix developer to use those registers
freely, as he needs to push them before usage to store their contents,
and pop the original contents after he is done using them.
if they happen to contain undefined values before the push, the engine
will quit, even though everything happening is perfectly safe:
the registers contained undefined before the push, some valid values
while it's used, and undefined again after the pop.

additionally, push is an operation used very often, and the 2 basically
unnecessary check add quite some overhead to script execution time.
ideally, all virtual cpu operations should be implemented as inline
functions or macros and as short as possible.