### PR TITLE
AGS3 revisit `_rgb_[argb]_shift_\d+`

### DIFF
--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -185,6 +185,19 @@ void engine_pre_gfxsystem_screen_destroy()
 // Setup color conversion parameters
 void engine_setup_color_conversions(int coldepth)
 {
+    // Most cards do 5-6-5 RGB, which is the format the files are saved in
+    // Some do 5-6-5 BGR, or 6-5-5 RGB, in which case convert the gfx
+    if ((coldepth == 16) && ((_rgb_b_shift_16 != 0) || (_rgb_r_shift_16 != 11)))
+    {
+        convert_16bit_bgr = 1;
+        if (_rgb_r_shift_16 == 10) {
+            // some very old graphics cards lie about being 16-bit when they
+            // are in fact 15-bit ... get around this
+            _places_r = 3;
+            _places_g = 3;
+        }
+    }
+
     // default shifts for how we store the sprite data
     _rgb_a_shift_32 = 24;
     _rgb_r_shift_32 = 16;
@@ -202,22 +215,6 @@ void engine_setup_color_conversions(int coldepth)
     _rgb_r_shift_15 = 10;
     _rgb_g_shift_15 = 5;
     _rgb_b_shift_15 = 0;
-
-// disabled as the defaults above mean this never triggers
-#if 0
-    // Most cards do 5-6-5 RGB, which is the format the files are saved in
-    // Some do 5-6-5 BGR, or  6-5-5 RGB, in which case convert the gfx
-    if ((coldepth == 16) && ((_rgb_b_shift_16 != 0) || (_rgb_r_shift_16 != 11)))
-    {
-        convert_16bit_bgr = 1;
-        if (_rgb_r_shift_16 == 10) {
-            // some very old graphics cards lie about being 16-bit when they
-            // are in fact 15-bit ... get around this
-            _places_r = 3;
-            _places_g = 3;
-        }
-    }
-#endif
 
     if (coldepth > 16)
     {

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -185,17 +185,26 @@ void engine_pre_gfxsystem_screen_destroy()
 // Setup color conversion parameters
 void engine_setup_color_conversions(int coldepth)
 {
-    // default shifts for how we store the sprite data1
+    // default shifts for how we store the sprite data
+    _rgb_a_shift_32 = 24;
     _rgb_r_shift_32 = 16;
     _rgb_g_shift_32 = 8;
     _rgb_b_shift_32 = 0;
+
+    _rgb_r_shift_24 = 16;
+    _rgb_g_shift_24 = 8;
+    _rgb_b_shift_24 = 0;
+
     _rgb_r_shift_16 = 11;
     _rgb_g_shift_16 = 5;
     _rgb_b_shift_16 = 0;
+
     _rgb_r_shift_15 = 10;
     _rgb_g_shift_15 = 5;
     _rgb_b_shift_15 = 0;
 
+// disabled as the defaults above mean this never triggers
+#if 0
     // Most cards do 5-6-5 RGB, which is the format the files are saved in
     // Some do 5-6-5 BGR, or  6-5-5 RGB, in which case convert the gfx
     if ((coldepth == 16) && ((_rgb_b_shift_16 != 0) || (_rgb_r_shift_16 != 11)))
@@ -208,6 +217,8 @@ void engine_setup_color_conversions(int coldepth)
             _places_g = 3;
         }
     }
+#endif
+
     if (coldepth > 16)
     {
         // when we're using 32-bit colour, it converts hi-color images

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -216,29 +216,32 @@ void engine_setup_color_conversions(int coldepth)
     _rgb_g_shift_15 = 5;
     _rgb_b_shift_15 = 0;
 
-    if (coldepth > 16)
-    {
-        // when we're using 32-bit colour, it converts hi-color images
-        // the wrong way round - so fix that
+    switch(coldepth) {
+        case 8:
+        case 15:
+            // !WINDOWS is essentially what we had before. I'm not sure if this is meant to include Linux.
+            #if !AGS_PLATFORM_OS_WINDOWS
+            // when we're using 32-bit colour, it converts hi-color images
+            // the wrong way round - so fix that
+            _rgb_r_shift_32 = 0;
+            _rgb_g_shift_32 = 8;
+            _rgb_b_shift_32 = 16;
+            #endif
+            break;
 
-#if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
-        _rgb_r_shift_32 = 0;
-        _rgb_g_shift_32 = 8;
-        _rgb_b_shift_32 = 16;
-#endif
-    }
-    else if (coldepth == 16)
-    {
-    }
-    else if (coldepth < 16)
-    {
-        // ensure that any 32-bit graphics displayed are converted
-        // properly to the current depth
-#if !AGS_PLATFORM_OS_WINDOWS
-        _rgb_r_shift_32 = 0;
-        _rgb_g_shift_32 = 8;
-        _rgb_b_shift_32 = 16;
-#endif
+        case 16:
+            break;
+
+        case 24:
+        case 32:
+            #if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
+            // when we're using 32-bit colour, it converts hi-color images
+            // the wrong way round - so fix that
+            _rgb_r_shift_32 = 0;
+            _rgb_g_shift_32 = 8;
+            _rgb_b_shift_32 = 16;
+            #endif
+            break;
     }
 
     set_color_conversion(COLORCONV_MOST | COLORCONV_EXPAND_256);

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -225,13 +225,13 @@ void engine_setup_color_conversions(int coldepth)
         // the wrong way round - so fix that
 
 #if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
-        _rgb_b_shift_16 = 0;
-        _rgb_g_shift_16 = 5;
         _rgb_r_shift_16 = 11;
+        _rgb_g_shift_16 = 5;
+        _rgb_b_shift_16 = 0;
 
-        _rgb_b_shift_15 = 0;
-        _rgb_g_shift_15 = 5;
         _rgb_r_shift_15 = 10;
+        _rgb_g_shift_15 = 5;
+        _rgb_b_shift_15 = 0;
 
         _rgb_r_shift_32 = 0;
         _rgb_g_shift_32 = 8;
@@ -263,9 +263,9 @@ void engine_setup_color_conversions(int coldepth)
         _rgb_g_shift_32 = 8;
         _rgb_b_shift_32 = 16;
 
-        _rgb_b_shift_15 = 0;
-        _rgb_g_shift_15 = 5;
         _rgb_r_shift_15 = 10;
+        _rgb_g_shift_15 = 5;
+        _rgb_b_shift_15 = 0;
 #endif
     }
 

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -225,47 +225,22 @@ void engine_setup_color_conversions(int coldepth)
         // the wrong way round - so fix that
 
 #if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
-        _rgb_r_shift_16 = 11;
-        _rgb_g_shift_16 = 5;
-        _rgb_b_shift_16 = 0;
-
-        _rgb_r_shift_15 = 10;
-        _rgb_g_shift_15 = 5;
-        _rgb_b_shift_15 = 0;
-
         _rgb_r_shift_32 = 0;
         _rgb_g_shift_32 = 8;
         _rgb_b_shift_32 = 16;
-#else
-        _rgb_r_shift_16 = 11;
-        _rgb_g_shift_16 = 5;
-        _rgb_b_shift_16 = 0;
 #endif
     }
     else if (coldepth == 16)
     {
-        // ensure that any 32-bit graphics displayed are converted
-        // properly to the current depth
-        _rgb_r_shift_32 = 16;
-        _rgb_g_shift_32 = 8;
-        _rgb_b_shift_32 = 0;
     }
     else if (coldepth < 16)
     {
         // ensure that any 32-bit graphics displayed are converted
         // properly to the current depth
-#if AGS_PLATFORM_OS_WINDOWS
-        _rgb_r_shift_32 = 16;
-        _rgb_g_shift_32 = 8;
-        _rgb_b_shift_32 = 0;
-#else
+#if !AGS_PLATFORM_OS_WINDOWS
         _rgb_r_shift_32 = 0;
         _rgb_g_shift_32 = 8;
         _rgb_b_shift_32 = 16;
-
-        _rgb_r_shift_15 = 10;
-        _rgb_g_shift_15 = 5;
-        _rgb_b_shift_15 = 0;
 #endif
     }
 


### PR DESCRIPTION
This is just a refactor to make it clearer what we're doing when we're resetting the shift variables. 

The `convert_16bit_bgr` check wasn't actually useful because we were checking shift variables _after_ we'd already set them. So I moved it to the top.

Other than that it should have the exact same behaviour as before.

The order of setting variables was sometimes `r,g,b`, sometimes `b,g,r`, which made it hard to visually scan and has probably led to issues.

I think OpenGL ES is the only reason we need to set these shifts differently now.  We could set the texture format to `GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV`, which is equivalent to direct3d's `D3DFMT_A8R8G8B8` format but unfortunately OpenGL ES doesn't support that pixel format.

I'm posting as a draft request because I wanted people to have a look and tell me what I'm missing in regards to simplifying that final switch statement.  Why do we change shifts if ! Windows, did we mean Ios and Android?

Should we just have the standard pixel formats here and require the graphics drivers to do conversion if needed?