### PR TITLE
AGS 3.5.0 - macOS colour fix

### DIFF
--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -21,21 +21,31 @@
     #define AGS_PLATFORM_OS_PSP     (0)
 #elif defined(__APPLE__)
     #include "TargetConditionals.h"
-    #if TARGET_OS_SIMULATOR
+    #ifndef TARGET_OS_SIMULATOR
+        #define TARGET_OS_SIMULATOR (0)
+    #endif
+    #ifndef TARGET_OS_IOS
+        #define TARGET_OS_IOS (0)
+    #endif
+    #ifndef TARGET_OS_OSX
+        #define TARGET_OS_OSX (0)
+    #endif
+
+    #if TARGET_OS_SIMULATOR || TARGET_IPHONE_SIMULATOR
         #define AGS_PLATFORM_OS_WINDOWS (0)
         #define AGS_PLATFORM_OS_LINUX   (0)
         #define AGS_PLATFORM_OS_MACOS   (0)
         #define AGS_PLATFORM_OS_ANDROID (0)
         #define AGS_PLATFORM_OS_IOS     (1)
         #define AGS_PLATFORM_OS_PSP     (0)
-    #elif TARGET_OS_IOS
+    #elif TARGET_OS_IOS || TARGET_OS_IPHONE
         #define AGS_PLATFORM_OS_WINDOWS (0)
         #define AGS_PLATFORM_OS_LINUX   (0)
         #define AGS_PLATFORM_OS_MACOS   (0)
         #define AGS_PLATFORM_OS_ANDROID (0)
         #define AGS_PLATFORM_OS_IOS     (1)
         #define AGS_PLATFORM_OS_PSP     (0)
-    #elif TARGET_OS_OSX
+    #elif TARGET_OS_OSX || TARGET_OS_MAC
         #define AGS_PLATFORM_OS_WINDOWS (0)
         #define AGS_PLATFORM_OS_LINUX   (0)
         #define AGS_PLATFORM_OS_MACOS   (1)

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -543,14 +543,6 @@ if (AGS_BUILTIN_PLUGINS)
     )
 endif()
 
-if (LINUX OR MACOS)
-    target_sources(engine 
-        PRIVATE 
-        platform/linux/binreloc.c
-        platform/linux/binreloc.h
-    )
-endif ()
-
 target_compile_definitions(engine PRIVATE 
     $<$<CONFIG:DEBUG>:SOUND_CACHE_DEBUG>
     $<$<CONFIG:DEBUG>:DEBUG_MANAGED_OBJECTS>

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -213,7 +213,7 @@ void engine_setup_color_conversions(int coldepth)
         // when we're using 32-bit colour, it converts hi-color images
         // the wrong way round - so fix that
 
-#if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_MACOS
+#if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
         _rgb_b_shift_16 = 0;
         _rgb_g_shift_16 = 5;
         _rgb_r_shift_16 = 11;


### PR DESCRIPTION
This fixes the colour issues found on macos builds. Also requires the changes made to `allegro-4.4.3.1-agspatch` but cmake should pick that up.

Refer to https://github.com/adventuregamestudio/ags/issues/818 for details

This has been tested in the `ags3` branch but this PR ports those fixes officially to 3.5.0

edit: this also removes a dependency on binreloc that snuck in from the sdl2 branch.  And some small fixes to allow building on a macbook that only has macos 10.10 installed :(