### PR TITLE
Add alpha channel import preference for Sprites

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -81,7 +81,7 @@ namespace AGS.Editor
          *                  Real sprite resolution; Individual font scaling; Default room mask resolution
          * 19: 3.5.0.11   - Custom Say and Narrate functions for dialog scripts. GameFileName.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 19;
+        public const int    LATEST_XML_VERSION_INDEX = 20;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -181,7 +181,7 @@ namespace AGS.Editor
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
-            UseAlphaChannel = replace.AlphaChannel;
+            UseAlphaChannel = replace.ImportAlphaChannel;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 
@@ -216,7 +216,7 @@ namespace AGS.Editor
             SpriteImportMethod = replace.TransparentColour;
             SelectionOffset = new Point(replace.OffsetX, replace.OffsetY);
             SelectionSize = new Size(replace.Width, replace.Height);
-            UseAlphaChannel = replace.AlphaChannel;
+            UseAlphaChannel = replace.ImportAlphaChannel;
             RemapToGamePalette = replace.RemapToGamePalette;
             UseBackgroundSlots = replace.RemapToRoomPalette;
 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -827,7 +827,9 @@ namespace AGS.Editor
                         spritesheet = null;
                     }
 
-                    SpriteTools.ReplaceSprite(spr, spr.SourceFile, spr.Frame, spr.AlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spritesheet);
+                    // take the alpha channel preference from the specified import option
+                    // (instead of using whether the old sprite has an alpha channel)
+                    SpriteTools.ReplaceSprite(spr, spr.SourceFile, spr.Frame, spr.ImportAlphaChannel, spr.RemapToGamePalette, spr.RemapToRoomPalette, spr.TransparentColour, spritesheet);
                 }
                 catch (Exception ex)
                 {

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -240,6 +240,15 @@ namespace AGS.Editor
                 game.WorkspaceState.SetLastBuildGameFiles(buildNames);
             }
 
+            if (xmlVersionIndex < 20)
+            {
+                // Set the alpha channel requests for re-import based on the presence of an alpha channel
+                foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+                {
+                    sprite.ImportAlphaChannel = sprite.AlphaChannel;
+                }
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -223,6 +223,7 @@ namespace AGS.Editor.Utils
             sprite.Frame = frame;
             sprite.OffsetX = offsetX;
             sprite.OffsetY = offsetY;
+            sprite.ImportAlphaChannel = alpha;
         }
 
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
@@ -283,6 +284,7 @@ namespace AGS.Editor.Utils
             sprite.Frame = frame;
             sprite.OffsetX = offsetX;
             sprite.OffsetY = offsetY;
+            sprite.ImportAlphaChannel = alpha;
 
             folder.Sprites.Add(sprite);
         }

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -26,6 +26,7 @@ namespace AGS.Types
         private int _offsetY;
         private bool _remapToGamePalette;
         private bool _remapToRoomPalette;
+        private bool _importAlphaChannel;
 
         public Sprite(int number, int width, int height, int colorDepth, SpriteImportResolution importRes, bool alphaChannel)
         {
@@ -117,6 +118,14 @@ namespace AGS.Types
 			get { return _sourceFile; }
 			set { _sourceFile = value; }
 		}
+
+        [Description("Import the alpha channel (if one is available)")]
+        [Category("Import")]
+        public bool ImportAlphaChannel
+        {
+            get { return _importAlphaChannel; }
+            set { _importAlphaChannel = value; }
+        }
 
 		[Browsable(false)]
 		public int? ColoursLockedToRoom
@@ -217,6 +226,15 @@ namespace AGS.Types
                 {
                     // pass
                 }
+
+                try
+                {
+                    _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
+                }
+                catch (InvalidDataException)
+                {
+                    _importAlphaChannel = true;
+                }
             }
         }
 
@@ -243,6 +261,7 @@ namespace AGS.Types
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());
             writer.WriteElementString("RemapToRoomPalette", _remapToRoomPalette.ToString());
             writer.WriteElementString("ImportMethod", _tranparentColour.ToString());
+            writer.WriteElementString("ImportAlphaChannel", _importAlphaChannel.ToString());
             writer.WriteEndElement(); // end source
 
             writer.WriteEndElement();


### PR DESCRIPTION
Adds a Sprite property to store the request to use an image's alpha channel. When reloading sprites from source the use of the alpha channel is checked against this property (so if you manually modify the source you can also modify this to suit). When replacing a sprite using the import UI this is used as a the default option for the 'use alpha channel' checkbox.

This should re-add the intended behaviour for bulk sprite reloading that had to be removed in order to fix #772 