### PR TITLE
Remove freespace checks and fix project data saving when writes fail

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -112,8 +112,6 @@ namespace AGS.Editor
         public const string SETUP_PROGRAM_SOURCE_FILE = "setup.dat";
         public const string COMPILED_SETUP_FILE_NAME = "winsetup.exe";
 		public const string GAME_EXPLORER_THUMBNAIL_FILE_NAME = "GameExplorer.png";
-		private const long MINIMUM_BYTES_FREE_TO_SAVE = 15000000;
-		private const long MINIMUM_BYTES_FREE_TO_COMPILE = 50000000;
 
         private Game _game;
         private string _editorExePath;
@@ -1162,11 +1160,6 @@ namespace AGS.Editor
                     errors.Add(new CompileError("Audio file missing for " + clip.ScriptName + ": " + clip.CacheFileName));
                 }
             }
-
-			if (!IsEnoughSpaceFreeOnDisk(MINIMUM_BYTES_FREE_TO_COMPILE))
-			{
-				errors.Add(new CompileError("There is not enough space on the disk."));
-			}
         }
 
 		private void EnsureViewHasAtLeast4LoopsAndAFrameInLeftRightLoops(AGS.Types.View view)
@@ -1213,28 +1206,6 @@ namespace AGS.Editor
 					}
 				}
 			}
-		}
-
-		private bool IsEnoughSpaceFreeOnDisk(long spaceRequired)
-		{
-			string gameRoot = Path.GetPathRoot(_game.DirectoryPath).ToUpper();
-            if (gameRoot.StartsWith(@"\\"))
-            {                
-                // network share, we can't check free space
-                return true;
-            }
-			foreach (DriveInfo drive in DriveInfo.GetDrives())
-			{
-				if (drive.RootDirectory.Name.ToUpper() == gameRoot)
-				{
-					if (drive.AvailableFreeSpace < spaceRequired)
-					{
-						return false;
-					}
-					return true;
-				}
-			}
-			throw new AGSEditorException("Unable to find drive for game path: " + _game.DirectoryPath);
 		}
 
 		public bool NeedsRebuildForDebugMode()
@@ -1460,11 +1431,6 @@ namespace AGS.Editor
             {
                 return false;
             }
-			if (!IsEnoughSpaceFreeOnDisk(MINIMUM_BYTES_FREE_TO_SAVE))
-			{
-				Factory.GUIController.ShowMessage("The disk is full. Please clear some space then try again", MessageBoxIcon.Warning);
-				return false;
-			}
 
             // Make sure the game's name in the Recent list is updated, in
             // case the user has just changed it


### PR DESCRIPTION
Initial changes were to remove freespace checks since:
 - if freespace on a volume is actually low then Windows 10 hassles you about it anyway
 - they are based on artbitrary values which aren't related to the active game project or correct at actual time of writing (so the result may not be relevant)
 - they didn't take into account any form of symlink or redirection done at the filesystem level (so the result may be incorrect if using NTFS junctions)
 - potentially masks an actual problem when saving data and the writes fail (see below)

Once the checks were removed and the disk was full, the project file for the game was truncated when writing and there was crash from native Windows components because the StreamWriter wasn't disposed of. The previous backup logic didn't seem correct either, it deleted what maybe your only copy of the data (the backup) and then potentially failed to write anything valid after that point.

So I've rewritten this to dispose of the StreamWriter, use a temporary file, and also accomodate creation of the backup copy within the same function. As it is now, there is no crash, no truncated data, and if you press save twice and it fails twice you will still have your backup copy to recover from.

I've also switched the exception catching from `UnauthorizedAccessException` to `Exception`, since there are no recovery options at this point and multiple reasons why the write may fail.