### PR TITLE
ags3/timing: reimplement timing changes similar to c4907f5d but without counter

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1044,7 +1044,14 @@ bool DialogOptions::Run()
             return true; // continue running loop
         }
       }
-      PollUntilNextFrame();
+
+      update_polled_stuff_if_runtime();
+
+      if (play.fast_forward == 0)
+      {
+          WaitForNextFrame();
+      }
+
       return true; // continue running loop
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -290,7 +290,14 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 if (skip_setting & SKIP_KEYPRESS)
                     break;
             }
-            PollUntilNextFrame();
+            
+            update_polled_stuff_if_runtime();
+
+            if (play.fast_forward == 0)
+            {
+                WaitForNextFrame();
+            }
+
             countdown--;
 
             if (play.speech_has_voice) {

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -282,12 +282,12 @@ void process_event(EventHappened*evp) {
                     boxhit = Math::Clamp(boxhit, 0, viewport.GetHeight());
                     int lxp = viewport.GetWidth() / 2 - boxwid / 2;
                     int lyp = viewport.GetHeight() / 2 - boxhit / 2;
+                    gfxDriver->Vsync();
                     temp_scr->Blit(saved_backbuf, lxp, lyp, lxp, lyp, 
                         boxwid, boxhit);
                     render_to_screen(viewport.Left, viewport.Top);
-                    do {
-                        update_polled_stuff_if_runtime();
-                    } while (waitingForNextTick());
+                    update_polled_mp3();
+                    WaitForNextFrame();
                 }
                 gfxDriver->SetMemoryBackBuffer(saved_backbuf, viewport.Left, viewport.Top);
             }
@@ -315,9 +315,8 @@ void process_event(EventHappened*evp) {
                     gfxDriver->DrawSprite(0, 0, ddb);
                 }
                 render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+                update_polled_stuff_if_runtime();
+                WaitForNextFrame();
                 transparency -= 16;
             }
             saved_viewport_bitmap->Release();
@@ -353,9 +352,8 @@ void process_event(EventHappened*evp) {
                 draw_screen_callback();
                 gfxDriver->DrawSprite(0, 0, ddb);
                 render_to_screen();
-                do {
-                    update_polled_stuff_if_runtime();
-                } while (waitingForNextTick());
+                update_polled_stuff_if_runtime();
+                WaitForNextFrame();
             }
             saved_viewport_bitmap->Release();
 

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -474,7 +474,10 @@ bool InventoryScreen::Run()
             //ags_domouse(DOMOUSE_ENABLE);
         }
         wasonitem=isonitem;
-        PollUntilNextFrame();
+
+        update_polled_stuff_if_runtime();
+
+        WaitForNextFrame();
 
     return true; // continue inventory screen loop
 }

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -27,19 +27,57 @@ namespace {
 
 const auto MAXIMUM_FALL_BEHIND = 3;
 
-auto last_tick_time = AGS_Clock::now();
 auto tick_duration = std::chrono::microseconds(1000000LL/40);
 auto framerate_maxed = false;
 
+auto last_tick_time = AGS_Clock::now();
+auto next_frame_timestamp = AGS_Clock::now();
+
 }
 
-void setTimerFps(int new_fps) {
+std::chrono::microseconds GetFrameDuration()
+{
+    if (framerate_maxed) {
+        return std::chrono::microseconds(0);
+    }
+    return tick_duration;
+}
+
+void setTimerFps(int new_fps) 
+{
     tick_duration = std::chrono::microseconds(1000000LL/new_fps);
-    last_tick_time = AGS_Clock::now();
     framerate_maxed = new_fps >= 1000;
+
+    last_tick_time = AGS_Clock::now();
+    next_frame_timestamp = AGS_Clock::now();
 }
 
-bool waitingForNextTick() {
+void WaitForNextFrame()
+{
+    auto now = AGS_Clock::now();
+    auto frameDuration = GetFrameDuration();
+
+    // early exit if we're trying to maximise framerate
+    if (frameDuration <= std::chrono::milliseconds::zero()) {
+        next_frame_timestamp = now;
+        return;
+    }
+
+    // jump ahead if we're lagging
+    if (next_frame_timestamp < (now - MAXIMUM_FALL_BEHIND*frameDuration)) {
+        next_frame_timestamp = now;
+    }
+
+    auto frame_time_remaining = next_frame_timestamp - now;
+    if (frame_time_remaining > std::chrono::milliseconds::zero()) {
+        std::this_thread::sleep_for(frame_time_remaining);
+    }
+    
+    next_frame_timestamp += frameDuration;
+}
+
+bool waitingForNextTick() 
+{
     auto now = AGS_Clock::now();
 
     if (framerate_maxed) {
@@ -67,11 +105,11 @@ bool waitingForNextTick() {
         return false;
     }
 
-    std::this_thread::sleep_for(next_tick_time - now);
-
     return true;
 }
 
-void skipMissedTicks() {
+void skipMissedTicks() 
+{
     last_tick_time = AGS_Clock::now();
+    next_frame_timestamp = AGS_Clock::now();
 }

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -28,6 +28,8 @@ using AGS_Clock = std::conditional<
         std::chrono::high_resolution_clock, std::chrono::steady_clock
       >::type;
 
+extern void WaitForNextFrame();
+
 extern void setTimerFps(int new_fps);
 extern bool waitingForNextTick();  // store last tick time.
 extern void skipMissedTicks();  // if more than N frames, just skip all, start a fresh.

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1918,11 +1918,9 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_render(flipTypeLastTime, false);
 
-    do {
-      if (_pollingCallback)
-        _pollingCallback();
-    } while (waitingForNextTick());
-
+    if (_pollingCallback)
+      _pollingCallback();
+    WaitForNextFrame();
   }
 
   if (fadingOut)

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -622,12 +622,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_in(Bitmap *vs, int offx, int offy,
        bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
        this->Vsync();
        _filter->RenderScreen(bmp_buff, 0, 0);
-       do
-       {
-         if (_pollingCallback)
-           _pollingCallback();
-       }
-       while (waitingForNextTick());
+       if (_pollingCallback)
+         _pollingCallback();
+       WaitForNextFrame();
    }
    delete bmp_buff;
    if (bmp_orig != vs)
@@ -651,12 +648,9 @@ void ALSoftwareGraphicsDriver::highcolor_fade_out(Bitmap *vs, int offx, int offy
         bmp_buff->TransBlendBlt(bmp_orig, 0, 0);
         this->Vsync();
         _filter->RenderScreen(bmp_buff, 0, 0);
-        do
-        {
-          if (_pollingCallback)
-            _pollingCallback();
-          platform->Delay(1);
-        } while (waitingForNextTick());
+        if (_pollingCallback)
+          _pollingCallback();
+        WaitForNextFrame();
     }
     delete bmp_buff;
 

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -190,9 +190,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         if (cscim->code > 0)
             break;
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        WaitForNextFrame();
     }
 
     return 0;

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -90,9 +90,7 @@ int MyPushButton::pressedon(int mousex, int mousey)
 
         refresh_gui_screen();
 
-        while (waitingForNextTick()) {
-            update_polled_stuff_if_runtime();
-        }
+        WaitForNextFrame();
     }
     wasstat = state;
     state = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -438,6 +438,13 @@ void engine_init_keyboard()
 #endif
 }
 
+void engine_init_timer()
+{
+    Debug::Printf(kDbgMsg_Init, "Install timer");
+
+    skipMissedTicks();
+}
+
 bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
     Debug::Printf(kDbgMsg_Init, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
@@ -1142,10 +1149,7 @@ void engine_setup_scsystem_auxiliary()
 void engine_update_mp3_thread()
 {
     update_mp3_thread();
-    // reduce polling period to encourage more multithreading bugs.
-#if ! AGS_PLATFORM_DEBUG
     platform->Delay(50);
-#endif
 }
 
 void engine_start_multithreaded_audio()
@@ -1403,8 +1407,7 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     our_eip = -197;
 
-    // Original timer was initialised here.
-    skipMissedTicks();
+    engine_init_timer();
 
     our_eip = -198;
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -717,15 +717,6 @@ void set_loop_counter(unsigned int new_counter) {
     fps = std::numeric_limits<float>::quiet_NaN();
 }
 
-void PollUntilNextFrame()
-{
-    if (play.fast_forward) { return; }
-    while (waitingForNextTick()) {
-        // make sure we poll, cos a low framerate (eg 5 fps) could stutter mp3 music
-        update_polled_stuff_if_runtime();
-    }
-}
-
 void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int extraX, int extraY) {
 
     int res;
@@ -801,7 +792,9 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     game_loop_update_fps();
 
-    PollUntilNextFrame();
+    update_polled_stuff_if_runtime();
+
+    WaitForNextFrame();
 }
 
 static void UpdateMouseOverLocation()

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -31,8 +31,6 @@ void GameLoopUntilValueIsNegative(const int *value);
 void GameLoopUntilNotMoving(const short *move);
 void GameLoopUntilNoOverlay();
 
-// Polls audio until the end of current game frame
-void PollUntilNextFrame();
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally
 void RunGameUntilAborted();
 // Update everything game related

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1819,10 +1819,9 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
     d3db->SetTransparency(fadingOut ? a : (255 - a));
     this->_renderAndPresent(flipTypeLastTime, false);
 
-    do {
-      if (_pollingCallback)
-        _pollingCallback();
-    } while (waitingForNextTick());
+    if (_pollingCallback)
+      _pollingCallback();
+    WaitForNextFrame();
   }
 
   if (fadingOut)

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -112,6 +112,8 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
   OAFilterState filterState = State_Running;
   while ((filterState != State_Stopped) && (!want_exit))
   {
+    WaitForNextFrame();
+
     if (!useAVISound)
       update_audio_system_on_game_loop();
 
@@ -128,10 +130,6 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
       break;
 
     //device->Present(NULL, NULL, 0, NULL);
-
-		while (waitingForNextTick()) {
-      update_polled_stuff_if_runtime();
-		}
 	}
 
   graph->StopGraph();


### PR DESCRIPTION
The timing api is essentially the same between `ags3` and `release-3.5.0`, just different implementations now.

This is intended for the next version of AGS (which I think `ags` is now), not 3.5