### PR TITLE
Prepare 3.4.4 release

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -134,10 +134,4 @@ enum GameDataVersion
 
 extern GameDataVersion loaded_game_file_version;
 
-// Test if the game is made at the times of old audio system
-inline bool is_old_audio_system()
-{
-    return loaded_game_file_version < kGameVersion_320;
-}
-
 #endif // __AGS_CN_AC__GAMEVERSION_H

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -73,7 +73,7 @@ void GameSetupStructBase::ReadFromFile(Stream *in)
     numgui = in->ReadInt32();
     numcursors = in->ReadInt32();
     GameResolutionType resolution_type = (GameResolutionType)in->ReadInt32();
-    if (resolution_type == kGameResolution_Custom && loaded_game_file_version >= kGameVersion_331)
+    if (resolution_type == kGameResolution_Custom && loaded_game_file_version >= kGameVersion_330)
     {
         Size game_size;
         game_size.Width = in->ReadInt32();

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -19,9 +19,11 @@
 #define __AGS_CN_AC__GAMESETUPSTRUCTBASE_H
 
 #include "ac/characterinfo.h"       // OldCharacterInfo, CharacterInfo
+#include "ac/game_version.h"
 #include "ac/wordsdictionary.h"  // WordsDictionary
 #include "ac/gamestructdefines.h"
 #include "script/cc_script.h"           // ccScript
+#include "util/string.h"
 #include "util/wgt2allg.h" // color (allegro RGB)
 
 // Forward declaration
@@ -87,6 +89,17 @@ struct GameSetupStructBase {
         if (default_resolution == kGameResolution_Custom)
             return (size.Width * size.Height) > (320 * 240);
         return ::IsHiRes(default_resolution);
+    }
+
+    // Test if the game is built around old audio system
+    inline bool IsLegacyAudioSystem() const
+    {
+        return loaded_game_file_version < kGameVersion_320;
+    }
+    // Returns the expected filename of a digital audio package
+    inline AGS::Common::String GetAudioVOXName() const
+    {
+        return IsLegacyAudioSystem() ? "music.vox" : "audio.vox";
     }
 
 private:

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -167,4 +167,19 @@ enum RenderAtScreenRes
     kRenderAtScreenRes_Disabled     = 2,
 };
 
+// Method to use when blending two sprites with alpha channel
+enum GameSpriteAlphaRenderingStyle
+{
+    kSpriteAlphaRender_Legacy = 0,
+    kSpriteAlphaRender_Proper
+};
+
+// Method to use when blending two GUI elements with alpha channel
+enum GameGuiAlphaRenderingStyle
+{
+    kGuiAlphaRender_Legacy = 0,
+    kGuiAlphaRender_AdditiveAlpha,
+    kGuiAlphaRender_Proper
+};
+
 #endif // __AGS_CN_AC__GAMESTRUCTDEFINES_H

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -10,6 +10,7 @@ using System.Xml;
 using AGS.CScript.Compiler;
 using AGS.Types;
 using AGS.Types.Interfaces;
+using System.Net;
 
 namespace AGS.Editor
 {
@@ -239,6 +240,9 @@ namespace AGS.Editor
 
         public void DoEditorInitialization()
         {
+            // disable SSL v3 (768 = SecurityProtocolType.Tls11, 3072 = SecurityProtocolType.Tls12)
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | (SecurityProtocolType)768 | (SecurityProtocolType)3072;
+
             _game = new Game();
             _sourceControl = new SourceControlProvider();
             _recentGamesList = new RecentGamesList();

--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -175,7 +175,7 @@ namespace AGS.Editor
         {
             try
             {
-                Bitmap screenShot = CaptureScreenshot();
+                Bitmap screenShot = null; // disable CaptureScreenshot();
                 ExceptionDialog dialog = new ExceptionDialog(ex, screenShot);
                 dialog.ShowDialog();
                 dialog.Dispose();

--- a/Editor/AGS.Types/BaseFolderCollection.cs
+++ b/Editor/AGS.Types/BaseFolderCollection.cs
@@ -70,6 +70,7 @@ namespace AGS.Types
 
         protected virtual string RootNodeName { get { return null; } }
 
+        [Browsable(false)]
         public IEnumerable<TFolderItem> AllItemsFlat
         {
             get

--- a/Editor/scintilla/src/Editor.cxx
+++ b/Editor/scintilla/src/Editor.cxx
@@ -1929,7 +1929,9 @@ LineLayout *Editor::RetrieveLineLayout(int lineNumber) {
 void Editor::LayoutLine(int line, Surface *surface, ViewStyle &vstyle, LineLayout *ll, int width) {
 	if (!ll)
 		return;
-	PLATFORM_ASSERT(line < pdoc->LinesTotal());
+    // CHECKME: disabled this assert because it kept triggering when program is built in Debug configuration
+    // We need to upgrade Scintilla to newer version which may have this and other mistakes fixed
+	//PLATFORM_ASSERT(line < pdoc->LinesTotal());
 	int posLineStart = pdoc->LineStart(line);
 	int posLineEnd = pdoc->LineStart(line + 1);
 	// If the line is very long, limit the treatment to a length that should fit in the viewport

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1394,7 +1394,7 @@ int Character_GetDestinationX(CharacterInfo *chaa) {
 int Character_GetDestinationY(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1] & 0x00ff;
+        return cmls->pos[cmls->numstage - 1] & 0xFFFF;
     }
     else
         return chaa->y;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1259,7 +1259,7 @@ void get_local_tint(int xpp, int ypp, int nolight,
             }
         }
 
-        if ((onRegion > 0) && (onRegion <= MAX_REGIONS)) {
+        if ((onRegion > 0) && (onRegion < MAX_REGIONS)) {
             light_level = thisroom.regionLightLevel[onRegion];
             tint_level = thisroom.regionTintLevel[onRegion];
         }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -867,7 +867,7 @@ void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos
     if (alpha <= 0)
         return;
 
-    if (game.options[OPT_SPRITEALPHA] == kSpriteAlphaRender_Improved)
+    if (game.options[OPT_SPRITEALPHA] == kSpriteAlphaRender_Proper)
     {
         GfxUtil::DrawSpriteBlend(ds, Point(xpos, ypos), image, blend_mode, ds_has_alpha, src_has_alpha, alpha);
     }
@@ -1137,7 +1137,7 @@ void draw_gui_sprite(Bitmap *ds, int pic, int x, int y, bool use_alpha, BlendMod
     const bool ds_has_alpha  = ds->GetColorDepth() == 32;
     const bool src_has_alpha = (game.spriteflags[pic] & SPF_ALPHACHANNEL) != 0;
 
-    if (use_alpha && game.options[OPT_NEWGUIALPHA] == kGuiAlphaRender_Improved)
+    if (use_alpha && game.options[OPT_NEWGUIALPHA] == kGuiAlphaRender_Proper)
     {
         GfxUtil::DrawSpriteBlend(ds, Point(x, y), sprite, blend_mode, ds_has_alpha, src_has_alpha);
     }
@@ -2232,7 +2232,7 @@ void draw_screen_overlay() {
                 {
                     isAlpha = true;
 
-                    if ((game.options[OPT_NEWGUIALPHA] == kGuiAlphaRender_Classic) && (guis[aa].BgImage > 0))
+                    if ((game.options[OPT_NEWGUIALPHA] == kGuiAlphaRender_Legacy) && (guis[aa].BgImage > 0))
                     {
                         // old-style (pre-3.0.2) GUI alpha rendering
                         repair_alpha_channel(guibg[aa], spriteset[guis[aa].BgImage]);

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -276,7 +276,7 @@ int DynamicSprite_SaveToFile(ScriptDynamicSprite *sds, const char* namm)
         filename.Append(".bmp");
 
     String path, alt_path; // alt_path is unused here, because it's a write op
-    if (!ResolveScriptPath(namm, false, path, alt_path))
+    if (!ResolveScriptPath(filename, false, path, alt_path))
         return 0;
     return spriteset[sds->slot]->SaveToFile(path, palette) ? 1 : 0;
 }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -499,7 +499,7 @@ AssetPath get_audio_clip_assetpath(int bundling_type, const String &filename)
     if (bundling_type == AUCL_BUNDLE_EXE)
         return AssetPath(game_file_name, filename);
     else if (bundling_type == AUCL_BUNDLE_VOX)
-        return AssetPath(is_old_audio_system() ? "music.vox" : "audio.vox", filename);
+        return AssetPath(game.GetAudioVOXName(), filename);
     return AssetPath();
 }
 

--- a/Engine/ac/global_viewframe.cpp
+++ b/Engine/ac/global_viewframe.cpp
@@ -44,6 +44,6 @@ void SetFrameSound (int vii, int loop, int frame, int sound) {
         if (clip == NULL)
             quitprintf("!SetFrameSound: audio clip aSound%d not found", sound);
 
-        views[vii].loops[loop].frames[frame].sound = clip->id + (is_old_audio_system() ? 0x10000000 : 0);
+        views[vii].loops[loop].frames[frame].sound = clip->id + (game.IsLegacyAudioSystem() ? 0x10000000 : 0);
     }
 }

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -219,13 +219,17 @@ void InventoryScreen::Prepare()
     in_inv_screen++;
     inv_screen_newroom = -1;
 
-    // sprites 2041, 2042 and 2043 were hardcoded in the older versions
-    // of the engine to be used in the built-in inventory window
+    // Sprites 2041, 2042 and 2043 were hardcoded in the older versions of
+    // the engine to be used in the built-in inventory window.
+    // If they did not exist engine first fell back to sprites 0, 1, 2 instead.
+    // Fun fact: this fallback does not seem to be intentional, and was a
+    // coincidental result of SpriteCache incorrectly remembering "last seeked
+    // sprite" as 2041/2042/2043 while in fact stream was after sprite 0.
     if (spriteset[2041] == NULL || spriteset[2042] == NULL || spriteset[2043] == NULL)
-        debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, using sprite 0 instead");
+        debug_script_warn("InventoryScreen: one or more of the inventory screen graphics (sprites 2041, 2042, 2043) does not exist, fallback to sprites 0, 1, 2 instead");
     btn_look_sprite = spriteset[2041] != NULL ? 2041 : 0;
-    btn_select_sprite = spriteset[2042] != NULL ? 2042 : 0;
-    btn_ok_sprite = spriteset[2043] != NULL ? 2043 : 0;
+    btn_select_sprite = spriteset[2042] != NULL ? 2042 : (spriteset[1] != NULL ? 1 : 0);
+    btn_ok_sprite = spriteset[2043] != NULL ? 2043 : (spriteset[2] != NULL ? 2 : 0);
 
     break_code = 0;
 }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -154,7 +154,9 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
 // draws a view frame, flipped if appropriate
 void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha_blend)
 {
-    if (alpha_blend && (loaded_game_file_version >= kGameVersion_330))
+    // NOTE: DrawViewFrame supports alpha blending only since OPT_SPRITEALPHA;
+    // this is why there's no sense in blending if it's not set (will do no good anyway).
+    if (alpha_blend && game.options[OPT_SPRITEALPHA] == kSpriteAlphaRender_Proper)
     {
         Bitmap *vf_bmp = spriteset[vframe->pic];
         Bitmap *src = vf_bmp;

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -84,7 +84,7 @@ void ViewFrame_SetSound(ScriptViewFrame *svf, int newSound)
     if (clip == NULL)
       quitprintf("!SetFrameSound: audio clip aSound%d not found", newSound);
 
-    views[svf->view].loops[svf->loop].frames[svf->frame].sound = clip->id + (is_old_audio_system() ? 0x10000000 : 0);
+    views[svf->view].loops[svf->loop].frames[svf->frame].sound = clip->id + (game.IsLegacyAudioSystem() ? 0x10000000 : 0);
   }
 }
 
@@ -121,7 +121,7 @@ void precache_view(int view)
 // to play a sound or whatever
 void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
     ScriptAudioChannel *channel = NULL;
-    if (is_old_audio_system())
+    if (game.IsLegacyAudioSystem())
     {
         if (views[view].loops[loop].frames[frame].sound > 0)
         {

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -359,9 +359,6 @@ void Mouse::DisableControl()
 {
     ControlEnabled = false;
     ConfineInCtrlRect = false;
-    SpeedVal = 1.f;
-    SpeedUnit = 1.f;
-    Speed = 1.f;
 }
 
 bool Mouse::IsControlEnabled()
@@ -371,8 +368,6 @@ bool Mouse::IsControlEnabled()
 
 void Mouse::SetSpeedUnit(float f)
 {
-    if (!ControlEnabled)
-        return;
     SpeedUnit = f;
     Speed = SpeedVal / SpeedUnit;
 }
@@ -384,8 +379,6 @@ float Mouse::GetSpeedUnit()
 
 void Mouse::SetSpeed(float speed)
 {
-    if (!ControlEnabled)
-        return;
     SpeedVal = Math::Max(0.f, speed);
     Speed = SpeedUnit * SpeedVal;
 }

--- a/Engine/gfx/blender.h
+++ b/Engine/gfx/blender.h
@@ -19,19 +19,6 @@
 #ifndef __AC_BLENDER_H
 #define __AC_BLENDER_H
 
-enum GameSpriteAlphaRenderingStyle
-{
-    kSpriteAlphaRender_Classic = 0,
-    kSpriteAlphaRender_Improved
-};
-
-enum GameGuiAlphaRenderingStyle
-{
-    kGuiAlphaRender_Classic = 0,
-    kGuiAlphaRender_AdditiveAlpha,
-    kGuiAlphaRender_Improved
-};
-
 //
 // Allegro's standard alpha blenders result in:
 // - src and dst RGB are combined proportionally to src alpha

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -64,7 +64,7 @@ bool GUIMain::HasAlphaChannel() const
         // transparent background have alpha channel only since 3.2.0;
         // "classic" gui rendering mode historically had non-alpha transparent backgrounds
         // (3.2.0 broke the compatibility, now we restore it)
-        loaded_game_file_version >= kGameVersion_320 && game.options[OPT_NEWGUIALPHA] != kGuiAlphaRender_Classic;
+        loaded_game_file_version >= kGameVersion_320 && game.options[OPT_NEWGUIALPHA] != kGuiAlphaRender_Legacy;
 }
 
 //=============================================================================

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -421,8 +421,7 @@ int roomSelectorWindow(int currentRoom, int numRooms, int*roomNumbers, char**roo
   CSCIMessage mes;
 
   lpTemp = NULL;
-  //sprintf(buffer2, "%d", currentRoom);
-  sprintf(buffer2, "");
+  buffer2[0] = 0;
 
   int ctrltbox = CSCICreateControl(CNT_TEXTBOX, boxleft + 10, boxtop + 29, 120, 0, NULL);
   CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);

--- a/Engine/libsrc/allegro-4.2.2-agspatch/midi.c
+++ b/Engine/libsrc/allegro-4.2.2-agspatch/midi.c
@@ -1,5 +1,5 @@
 //
-// Unfortunately, as of now Allegro 4 does not have a variant of MIDI
+// Allegro 4.4.2 and earlier do not have a variant of MIDI
 // constructor that takes PACKFILE stream as parameter. Hence our own
 // version. This should be removed when either Allegro 4 gets patched
 // or we switch to another backend library.
@@ -8,6 +8,9 @@
 //
 
 #include <allegro.h>
+
+#if (ALLEGRO_DATE < 20190303)
+
 #include <allegro/internal/aintern.h>
 
 /* load_midi_pf:
@@ -96,3 +99,5 @@ MIDI *load_midi_pf(PACKFILE *fp)
    destroy_midi(midi);
    return NULL;
 }
+
+#endif // (ALLEGRO_DATE < 20190303)

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -416,14 +416,14 @@ void engine_init_fonts()
     init_font_renderer();
 }
 
-int engine_init_mouse()
+void engine_init_mouse()
 {
     int res = minstalled();
     if (res < 0)
         Debug::Printf(kDbgMsg_Init, "Initializing mouse: failed");
     else
         Debug::Printf(kDbgMsg_Init, "Initializing mouse: number of buttons reported is %d", res);
-	return RETURN_CONTINUE;
+    Mouse::SetSpeed(usetup.mouse_speed);
 }
 
 int engine_check_memory()
@@ -1397,10 +1397,7 @@ int initialize_engine(int argc,char*argv[])
 
     our_eip = -188;
 
-    res = engine_init_mouse();
-	if (res != RETURN_CONTINUE) {
-        return res;
-    }
+    engine_init_mouse();
 
     our_eip = -187;
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -498,27 +498,25 @@ void engine_init_speech()
     }
 }
 
-int engine_init_music()
+void engine_init_digital_audio()
 {
     play.separate_music_lib = 0;
-
-    music_file = "audio.vox";
+    music_file = game.GetAudioVOXName();
     String music_filepath = find_assetlib(music_file);
-    if (!music_filepath.IsEmpty()) {
-
-        Debug::Printf("Initializing audio vox");
-
-        //if (Common::AssetManager::SetDataFile(useloc,"")!=0) {
-        if (Common::AssetManager::SetDataFile(music_filepath)!=Common::kAssetNoError) {
-            platform->DisplayAlert("Unable to initialize music library - check for corruption and that\nit belongs to this game.\n");
-            return EXIT_NORMAL;
+    if (!music_filepath.IsEmpty())
+    {
+        if (AssetManager::SetDataFile(music_filepath) == kAssetNoError)
+        {
+            AssetManager::SetDataFile(game_file_name);
+            Debug::Printf(kDbgMsg_Init, "%s found and initialized.", music_file.GetCStr());
+            play.separate_music_lib = 1;
         }
-        Common::AssetManager::SetDataFile(game_file_name);
-        Debug::Printf(kDbgMsg_Init, "Audio vox found and initialized.");
-        play.separate_music_lib = 1;
+        else
+        {
+            platform->DisplayAlert("Unable to initialize digital audio pack '%s', file could be corrupt or of unsupported format.",
+                music_file.GetCStr());
+        }
     }
-
-    return RETURN_CONTINUE;
 }
 
 void engine_init_keyboard()
@@ -1421,10 +1419,7 @@ int initialize_engine(int argc,char*argv[])
 
     our_eip = -185;
     
-    res = engine_init_music();
-    if (res != RETURN_CONTINUE) {
-        return res;
-    }
+    engine_init_digital_audio();
 
     our_eip = -184;
 

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -408,7 +408,6 @@ void engine_post_gfxmode_mouse_setup(const DisplayMode &dm, const Size &init_des
                 Mouse::SetSpeedUnit(Math::Max((float)cur_desktop.Width / (float)init_desktop.Width,
                                               (float)cur_desktop.Height / (float)init_desktop.Height));
         }
-        Mouse::SetSpeed(usetup.mouse_speed);
     }
     Debug::Printf(kDbgMsg_Init, "Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",
         Mouse::GetSpeedUnit(), Mouse::GetSpeed());

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -486,7 +486,11 @@ bool graphics_mode_init_any(const Size game_size, const ScreenSetup &setup, cons
     // TODO: make factory & driver IDs case-insensitive!
     StringV ids;
     GetGfxDriverFactoryNames(ids);
-    StringV::iterator it = std::find(ids.begin(), ids.end(), setup.DriverID);
+    StringV::iterator it = ids.begin();
+    for (; it != ids.end(); ++it)
+    {
+        if (it->CompareNoCase(setup.DriverID) == 0) break;
+    }
     if (it != ids.end())
         std::rotate(ids.begin(), it, ids.end());
     else

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -468,7 +468,7 @@ int get_old_style_number_for_sound(int sound_number)
 {
     int audio_clip_id = 0;
 
-    if (is_old_audio_system())
+    if (game.IsLegacyAudioSystem())
     {
         // No sound assigned.
         if (sound_number < 1)

--- a/Engine/media/audio/soundcache.cpp
+++ b/Engine/media/audio/soundcache.cpp
@@ -61,7 +61,7 @@ void sound_cache_free(char* buffer, bool is_wave)
     AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    Debug::Printf("sound_cache_free(%d %d)\n", (unsigned int)buffer, (unsigned int)is_wave);
+    Debug::Printf("sound_cache_free(%p %d)\n", buffer, (unsigned int)is_wave);
 #endif
     int i;
     for (i = 0; i < psp_audio_cachesize; i++)
@@ -98,7 +98,7 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
 	AGS::Engine::MutexLock _lock(_sound_cache_mutex);
 
 #ifdef SOUND_CACHE_DEBUG
-    Debug::Printf("get_cached_sound(%s %d)\n", filename, (unsigned int)is_wave);
+    Debug::Printf("get_cached_sound(%s %d)\n", asset_name.first.GetCStr(), (unsigned int)is_wave);
 #endif
 
     *size = 0;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -36,6 +36,10 @@
 #include "media/audio/audio.h"
 #include "util/stream.h"
 
+#if (ALLEGRO_DATE >= 20190303) || defined (WINDOWS_VERSION) || defined (ANDROID_VERSION)
+#define AGS_FLI_FROM_PACK_FILE
+#endif
+
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
@@ -176,7 +180,7 @@ void play_flc_file(int numb,int playflags) {
     // Make only certain versions of the engineuse play_fli_pf from the patched version of Allegro for now.
     // Add more versions as their Allegro lib becomes patched too, or they use newer version of Allegro 4.
     // Ports can still play FLI if separate file is put into game's directory.
-#if defined (WINDOWS_VERSION) || defined (ANDROID_VERSION)
+#if defined (AGS_FLI_FROM_PACK_FILE)
     PACKFILE *pf = PackfileFromAsset(AssetPath("", flicname));
     if (play_fli_pf(pf, (BITMAP*)fli_buffer->GetAllegroBitmap(), fli_callback)==FLI_ERROR)
 #else

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1524,6 +1524,7 @@ IDriverDependantBitmap* D3DGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
 
      if (hr != D3D_OK) 
      {
+        free(tiles);
         char errorMessage[200];
         sprintf(errorMessage, "Direct3DDevice9::CreateVertexBuffer(Length=%d) for texture failed: error code %08X", vertexBufferSize, hr);
         throw Ali3DException(errorMessage);
@@ -1531,6 +1532,7 @@ IDriverDependantBitmap* D3DGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, b
 
      if (ddb->_vertex->Lock(0, 0, (void**)&vertices, D3DLOCK_DISCARD) != D3D_OK)
      {
+       free(tiles);
        throw Ali3DException("Failed to lock vertex buffer");
      }
   }

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -1018,7 +1018,8 @@ void WinSetupDialog::FillScalingList(HWND hlist, GameFrameSetup &frame_setup, bo
 
     const int min_scale = min(_winCfg.GameResolution.Width / _minGameSize.Width, _winCfg.GameResolution.Height / _minGameSize.Height);
     const Size max_size = windowed ? _maxWindowSize : _winCfg.ScreenSize;
-    const int max_scale = min(max_size.Width / _winCfg.GameResolution.Width, max_size.Height / _winCfg.GameResolution.Height);
+    const int max_scale = _winCfg.GameResolution.IsNull() ? 1 :
+        min(max_size.Width / _winCfg.GameResolution.Width, max_size.Height / _winCfg.GameResolution.Height);
     _maxGameScale = max(1, max_scale);
     _minGameScale = -max(1, min_scale);
 


### PR DESCRIPTION
By [former request](https://github.com/adventuregamestudio/ags/issues/785#issuecomment-495952217) (although delayed more than I planned), this prepares a 3.4.4 update, which only contains critical bugfixes and compatibility fixes to be added on top of 3.4.*.

Notable fixes:
* fixed IsMusicVoxAvailable() in old games that had music.vox;
* fixed Character.GetDestinationY not working if coordinate is >255;
* fixed blinking portrait animations in old 32-bit games;
* fixed some very old games (like Ben Jordan 3) not displaying correct gfx on default inventory screen buttons.
* support loading experimental 3.3.0 CR games ("Skumring").
* allow to link to both Allegro 4.4.2 and 4.4.3.