### PR TITLE
DRAFT: Readvalue() optimization

### DIFF
--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -20,7 +20,6 @@
 
 #include <utility>
 #include "core/types.h"
-#include "script/runtimescriptvalue.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
@@ -107,7 +106,6 @@ extern int32_t ccGetObjectHandleFromAddress(const char *address);
 // TODO: not sure if it makes any sense whatsoever to use "const char*"
 // in these functions, might as well change to char* or just void*.
 extern const char *ccGetObjectAddressFromHandle(int32_t handle);
-extern ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, void *&object, ICCDynamicObject *&manager);
 
 extern int ccAddObjectReference(int32_t handle);
 extern int ccReleaseObjectReference(int32_t handle);

--- a/Engine/ac/dynobj/cc_dynamicobject_addr_and_manager.h
+++ b/Engine/ac/dynobj/cc_dynamicobject_addr_and_manager.h
@@ -1,0 +1,11 @@
+#ifndef ADDR_AND_MANAGER_H
+#define ADDR_AND_MANAGER_H
+
+#include "script/runtimescriptvalue.h"
+#include "ac/dynobj/cc_dynamicobject.h"
+
+extern ScriptValueType ccGetObjectAddressAndManagerFromHandle(
+   int32_t handle, void *&object, ICCDynamicObject *&manager);
+
+#endif
+

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -19,6 +19,7 @@
 #include <queue>
 #include <unordered_map>
 
+#include "script/runtimescriptvalue.h"
 #include "ac/dynobj/cc_dynamicobject.h"   // ICCDynamicObject
 
 namespace AGS { namespace Common { class Stream; }}

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -20,6 +20,7 @@
 
 #include "ac/dynobj/scriptdrawingsurface.h"
 #include "ac/characterinfo.h"
+#include "script/runtimescriptvalue.h"
 #include "game/roomstruct.h"
 
 ScriptDrawingSurface* Room_GetDrawingSurfaceForBackground(int backgroundNumber);

--- a/Engine/ac/viewframe.h
+++ b/Engine/ac/viewframe.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__VIEWFRAME_H
 #define __AGS_EE_AC__VIEWFRAME_H
 
+#include "ac/runtime_defines.h"
 #include "ac/view.h"
 #include "ac/dynobj/scriptaudioclip.h"
 #include "ac/dynobj/scriptviewframe.h"

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -37,6 +37,7 @@
 #include "ac/path_helper.h"
 #include "ac/roomstatus.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_dynamicobject_addr_and_manager.h"
 #include "font/fonts.h"
 #include "util/string_compat.h"
 #include "debug/debug_log.h"

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -33,6 +33,7 @@
 #include "ac/dynobj/scriptuserobject.h"
 #include "ac/statobj/agsstaticobject.h"
 #include "ac/statobj/staticarray.h"
+#include "ac/dynobj/cc_dynamicobject_addr_and_manager.h"
 #include "util/memory.h"
 #include "util/string_utils.h" // linux strnicmp definition
 

--- a/Engine/script/runtimescriptvalue.cpp
+++ b/Engine/script/runtimescriptvalue.cpp
@@ -112,56 +112,6 @@ int32_t RuntimeScriptValue::ReadInt32()
     return *((int32_t*)this->GetPtrWithOffset());
 }
 
-// FIXME: find out all certain cases when we are reading a pointer and store it
-// as 32-bit value here. There should be a solution to distinct these cases and
-// store value differently, otherwise it won't work for 64-bit build.
-RuntimeScriptValue RuntimeScriptValue::ReadValue()
-{
-    RuntimeScriptValue rval;
-    switch(this->Type) {
-    case kScValStackPtr:
-    {
-        if (RValue->Type == kScValData)
-        {
-            rval.SetInt32(*(int32_t*)(RValue->GetPtrWithOffset() + this->IValue));
-        }
-        else
-        {
-            rval = *RValue;
-        }
-    }
-    break;
-    case kScValGlobalVar:
-    {
-        if (RValue->Type == kScValData)
-        {
-            rval.SetInt32(Memory::ReadInt32LE(RValue->GetPtrWithOffset() + this->IValue));
-        }
-        else
-        {
-            rval = *RValue;
-        }
-    }
-    break;
-    case kScValStaticObject: case kScValStaticArray:
-    {
-        rval.SetInt32(this->StcMgr->ReadInt32(this->Ptr, this->IValue));
-    }
-    break;
-    case kScValDynamicObject:
-    {
-        rval.SetInt32(this->DynMgr->ReadInt32(this->Ptr, this->IValue));
-    }
-    break;
-    default:
-    {
-        // 64 bit: Memory reads are still 32 bit
-        rval.SetInt32(*(int32_t*)this->GetPtrWithOffset());
-    }
-    }
-    return rval;
-}
-
 bool RuntimeScriptValue::WriteByte(uint8_t val)
 {
     if (this->Type == kScValStackPtr || this->Type == kScValGlobalVar)

--- a/Engine/script/runtimescriptvalue.cpp
+++ b/Engine/script/runtimescriptvalue.cpp
@@ -118,7 +118,8 @@ int32_t RuntimeScriptValue::ReadInt32()
 RuntimeScriptValue RuntimeScriptValue::ReadValue()
 {
     RuntimeScriptValue rval;
-    if (this->Type == kScValStackPtr)
+    switch(this->Type) {
+    case kScValStackPtr:
     {
         if (RValue->Type == kScValData)
         {
@@ -129,7 +130,8 @@ RuntimeScriptValue RuntimeScriptValue::ReadValue()
             rval = *RValue;
         }
     }
-    else if (this->Type == kScValGlobalVar)
+    break;
+    case kScValGlobalVar:
     {
         if (RValue->Type == kScValData)
         {
@@ -140,18 +142,22 @@ RuntimeScriptValue RuntimeScriptValue::ReadValue()
             rval = *RValue;
         }
     }
-    else if (this->Type == kScValStaticObject || this->Type == kScValStaticArray)
+    break;
+    case kScValStaticObject: case kScValStaticArray:
     {
         rval.SetInt32(this->StcMgr->ReadInt32(this->Ptr, this->IValue));
     }
-    else if (this->Type == kScValDynamicObject)
+    break;
+    case kScValDynamicObject:
     {
         rval.SetInt32(this->DynMgr->ReadInt32(this->Ptr, this->IValue));
     }
-    else
+    break;
+    default:
     {
         // 64 bit: Memory reads are still 32 bit
         rval.SetInt32(*(int32_t*)this->GetPtrWithOffset());
+    }
     }
     return rval;
 }


### PR DESCRIPTION
this should speed up Readvalue() which is one of the most used functions during script executions (taking up as much as 3% cpu in my tests). inlining it *should* speed it up.
"should" because it's hard to measure any improvements to script interpreter code with the --fps method which is only adequate to measure gfx performance.