### PR TITLE
Add ID property to AudioClip

### DIFF
--- a/Common/ac/dynobj/scriptaudioclip.h
+++ b/Common/ac/dynobj/scriptaudioclip.h
@@ -35,7 +35,7 @@ enum AudioFileType {
 #define SCRIPTAUDIOCLIP_SCRIPTNAMELENGTH    30
 #define SCRIPTAUDIOCLIP_FILENAMELENGTH      15
 struct ScriptAudioClip {
-    int id;  // not used by editor, set in engine only
+    int id;
     Common::String scriptName;
     Common::String fileName;
     char bundlingType;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -81,8 +81,9 @@ namespace AGS.Editor
          *                  Real sprite resolution; Individual font scaling; Default room mask resolution
          * 19: 3.5.0.11   - Custom Say and Narrate functions for dialog scripts. GameFileName.
          * 20: 3.5.0.14   - Sprite.ImportAlphaChannel.
+         * 21: 3.5.0.15   - AudioClip ID.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 20;
+        public const int    LATEST_XML_VERSION_INDEX = 21;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -367,11 +367,11 @@ namespace AGS.Editor.Components
                 AudioClip clip = _agsEditor.CurrentGame.FindAudioClipForOldSoundNumber(allAudio, _agsEditor.CurrentGame.Settings.PlaySoundOnScore);
                 if (clip != null)
                 {
-                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = clip.Index;
+                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = clip.ID;
                 }
                 else
                 {
-                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = 0;
+                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = -1;
                 }
             }
         }
@@ -389,11 +389,11 @@ namespace AGS.Editor.Components
                             AudioClip clip = _agsEditor.CurrentGame.FindAudioClipForOldSoundNumber(allAudio, frame.Sound);
                             if (clip != null)
                             {
-                                frame.Sound = clip.Index;
+                                frame.Sound = clip.ID;
                             }
                             else
                             {
-                                frame.Sound = 0;
+                                frame.Sound = -1;
                             }
                         }
                     }
@@ -553,8 +553,6 @@ namespace AGS.Editor.Components
                     Utilities.CopyFileAndSetDestinationWritable(filesToCopy[i].SourceFileName, fileNamesToUpdate[i]);
                 }
             }
-
-            _agsEditor.CurrentGame.UpdateCachedAudioClipList();
         }
 
         private void ProjectTree_OnAfterLabelEdit(string commandID, ProjectTreeItem treeItem)

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -304,6 +304,7 @@ namespace AGS.Editor.Components
             {
                 string newScriptName = EnsureScriptNameIsUnique(Path.GetFileNameWithoutExtension(sourceFileName));
                 AudioClip newClip = new AudioClip(newScriptName, _agsEditor.CurrentGame.GetNextAudioIndex());
+                newClip.ID = _agsEditor.CurrentGame.RootAudioClipFolder.GetAllItemsCount();
                 newClip.SourceFileName = Utilities.GetRelativeToProjectPath(sourceFileName);
                 newClip.FileType = _fileTypeMappings[fileExtension];
                 newClip.FileLastModifiedDate = File.GetLastWriteTimeUtc(sourceFileName);
@@ -651,7 +652,8 @@ namespace AGS.Editor.Components
         protected override ProjectTreeItem CreateTreeItemForItem(AudioClip item)
         {
             string nodeID = GetNodeIDForAudioClip(item);
-            ProjectTreeItem treeItem = (ProjectTreeItem)_guiController.ProjectTree.AddTreeLeaf(this, nodeID, item.ScriptName, GetIconKeyForAudioClip(item));
+            ProjectTreeItem treeItem = (ProjectTreeItem)_guiController.ProjectTree.AddTreeLeaf(this, nodeID,
+                item.ID.ToString() + ": " + item.ScriptName, GetIconKeyForAudioClip(item));
             treeItem.AllowLabelEdit = true;
             treeItem.LabelTextProperty = item.GetType().GetProperty("ScriptName");
             treeItem.LabelTextDescriptionProperty = item.GetType().GetProperty("ScriptName");
@@ -709,8 +711,22 @@ namespace AGS.Editor.Components
 
         protected override void DeleteResourcesUsedByItem(AudioClip item)
         {
-            DeleteResourcesForAudioClip(item);
-            AudioClipTypeConverter.SetAudioClipList(_agsEditor.CurrentGame.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders());                    
+            DeleteAudioClip(item);
+        }
+
+        private void DeleteAudioClip(AudioClip clip)
+        {
+            int removingID = clip.ID;
+            foreach (AudioClip item in _agsEditor.CurrentGame.RootAudioClipFolder.AllItemsFlat)
+            {
+                if (item.ID > removingID)
+                {
+                    item.ID--;
+                }
+            }
+
+            DeleteResourcesForAudioClip(clip);
+            AudioClipTypeConverter.SetAudioClipList(_agsEditor.CurrentGame.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders());
         }
 
         private void DeleteResourcesForAudioClip(AudioClip clipToDelete)

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -865,7 +865,7 @@ namespace AGS.Editor
                             writer.Write((short)frame.Delay);
                             writer.Write((short)0); // struct alignment padding
                             writer.Write(frame.Flipped ? NativeConstants.VFLG_FLIPSPRITE : 0);
-                            writer.Write(frame.Sound > 0 ? game.GetAudioArrayIndexFromAudioClipIndex(frame.Sound) : -1);
+                            writer.Write(frame.Sound);
                             writer.Write(0); // unused reservedForFuture[0]
                             writer.Write(0); // unused reservedForFuture[1]
                         }
@@ -1687,12 +1687,12 @@ namespace AGS.Editor
                 writer.Write((int)game.AudioClipTypes[i - 1].CrossfadeClips); // crossfadeSpeed
                 writer.Write(0);
             }
-            IList<AudioClip> allClips = game.CachedAudioClipListForCompile;
+            IList<AudioClip> allClips = game.AudioClips;
             writer.Write(allClips.Count);
             for (int i = 0; i < allClips.Count; ++i)
             {
                 AudioClip clip = allClips[i];
-                writer.Write(0); // id
+                writer.Write(clip.ID); // id
                 WriteString(SafeTruncate(clip.ScriptName, 29), 30, writer); // scriptName
                 WriteString(SafeTruncate(clip.CacheFileNameWithoutPath, 14), 15, writer); // fileName
                 writer.Write((byte)clip.BundlingType); // bundlingType
@@ -1705,7 +1705,7 @@ namespace AGS.Editor
                 writer.Write(new byte[2]); // struct alignment padding
                 writer.Write(0); // reserved
             }
-            writer.Write(game.GetAudioArrayIndexFromAudioClipIndex(game.Settings.PlaySoundOnScore));
+            writer.Write(game.Settings.PlaySoundOnScore);
             if (game.Settings.DebugMode)
             {
                 writer.Write(game.Rooms.Count);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2048,6 +2048,10 @@ builtin managed struct AudioClip {
   readonly import attribute bool IsAvailable;
   /// Gets the type of audio that this clip contains.
   readonly import attribute AudioType Type;
+#ifdef SCRIPT_API_v350
+  /// Gets the clip's ID number.
+  readonly import attribute int ID;
+#endif
 };
 
 builtin struct System {

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -249,6 +249,17 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 21)
+            {
+                // Assign audio clip ids to match and solidify their current position in AudioClips array.
+                int id = 0;
+                Dictionary<string, string> audioCache = new Dictionary<string, string>();
+                foreach (AudioClip clip in game.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
+                {
+                    clip.ID = id++;
+                }
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -252,11 +252,48 @@ namespace AGS.Editor
             if (xmlVersionIndex < 21)
             {
                 // Assign audio clip ids to match and solidify their current position in AudioClips array.
-                int id = 0;
-                Dictionary<string, string> audioCache = new Dictionary<string, string>();
+                int clipId = 0;
+                Dictionary<int, int> audioIndexToID = new Dictionary<int, int>();
                 foreach (AudioClip clip in game.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
                 {
-                    clip.ID = id++;
+                    clip.ID = clipId++;
+                    audioIndexToID.Add(clip.Index, clip.ID);
+                }
+
+                // Remap old cache indexes to new IDs
+                if (game.Settings.PlaySoundOnScore == 0)
+                {
+                    game.Settings.PlaySoundOnScore = -1;
+                }
+                else
+                {
+                    int id;
+                    if (audioIndexToID.TryGetValue(game.Settings.PlaySoundOnScore, out id))
+                        game.Settings.PlaySoundOnScore = id;
+                    else
+                        game.Settings.PlaySoundOnScore = -1;
+                }
+
+                foreach (Types.View view in game.RootViewFolder.AllItemsFlat)
+                {
+                    foreach (Types.ViewLoop loop in view.Loops)
+                    {
+                        foreach (Types.ViewFrame frame in loop.Frames)
+                        {
+                            if (frame.Sound == 0)
+                            {
+                                frame.Sound = -1;
+                            }
+                            else
+                            {
+                                int id;
+                                if (audioIndexToID.TryGetValue(frame.Sound, out id))
+                                    frame.Sound = id;
+                                else
+                                    frame.Sound = -1;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -181,7 +181,7 @@ namespace AGS.Types
 
         public int CompareTo(AudioClip other)
         {
-            return _typeID.CompareTo(other._typeID);
+            return ID.CompareTo(other.ID);
         }
 
         #endregion

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -11,6 +11,7 @@ namespace AGS.Types
         private const string COMPILED_AUDIO_FILENAME_PREFIX = "au";
         public const string AUDIO_CACHE_DIRECTORY = "AudioCache";
 
+        private int _id;
         private string _sourceFileName;
         private string _scriptName;
         private int _index;
@@ -47,6 +48,15 @@ namespace AGS.Types
             get { return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, _index, Path.GetExtension(_sourceFileName)); }
         }
 
+        [DisplayName("ID")]
+        [Description("The ID number of the clip")]
+        [ReadOnly(true)]
+        public int ID
+        {
+            get { return _id; }
+            set { _id = value; }
+        }
+
         [ReadOnly(true)]
         [Description("The file from which this audio clip was imported")]
         public string SourceFileName
@@ -62,6 +72,7 @@ namespace AGS.Types
             set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
+        // NOTE: this index remains only as a connection to the AudioCache
         [Browsable(false)]
         public int Index
         {

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -60,8 +60,6 @@ namespace AGS.Types
         private LipSync _lipSync;
         private CustomPropertySchema _propertySchema;
         private GlobalVariables _globalVariables;
-        private IList<AudioClip> _cachedAudioClipListForCompile;
-        private Dictionary<int, int> _cachedAudioClipIndexMapping;
 		private string _directoryPath;
 		private bool _roomsAddedOrRemoved = false;
 		private Dictionary<int, object> _deletedViewIDs;
@@ -284,9 +282,9 @@ namespace AGS.Types
             set { _scriptsToCompile = value; }
         }
 
-        public IList<AudioClip> CachedAudioClipListForCompile
+        public IList<AudioClip> AudioClips
         {
-            get { return _cachedAudioClipListForCompile; }
+            get { return _audioClips; }
         }
 
         public GlobalVariables GlobalVariables
@@ -1024,28 +1022,6 @@ namespace AGS.Types
                 }
             }
             return scripts;
-        }
-
-        public void UpdateCachedAudioClipList()
-        {
-            _cachedAudioClipListForCompile = _audioClips.RootFolder.GetAllAudioClipsFromAllSubFolders();
-            _cachedAudioClipIndexMapping = new Dictionary<int, int>();
-            for (int i = 0; i < _cachedAudioClipListForCompile.Count; i++)
-            {
-                _cachedAudioClipIndexMapping.Add(_cachedAudioClipListForCompile[i].Index, i);
-            }
-        }
-
-        public int GetAudioArrayIndexFromAudioClipIndex(int audioClipIndex)
-        {
-            if (audioClipIndex > 0)
-            {
-                if (_cachedAudioClipIndexMapping.ContainsKey(audioClipIndex))
-                {
-                    return _cachedAudioClipIndexMapping[audioClipIndex];
-                }
-            }
-            return -1;
         }
 
         public byte[] GetPaletteAsRawPAL()

--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
@@ -32,10 +32,10 @@ namespace AGS.Types
             }
 
             _possibleValues.Clear();
-            _possibleValues.Add(0, "(None)");
+            _possibleValues.Add(-1, "(None)");
             foreach (AudioClip type in _AudioClips)
             {
-                _possibleValues.Add(type.Index, type.ScriptName);
+                _possibleValues.Add(type.ID, type.ScriptName);
             }
         }
     }

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -1059,6 +1059,7 @@ namespace AGS.Types
             set { _binaryFilesInSourceControl = value; }
         }
 
+        // NOTE: this index only purpose remains to connect clips to audio cache
         [Browsable(false)]
         public int AudioIndexer
         {

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -24,14 +24,19 @@ extern GameSetupStruct game;
 extern ScriptAudioChannel scrAudioChannel[MAX_SOUND_CHANNELS + 1];
 extern CCAudioChannel ccDynamicAudio;
 
+int AudioClip_GetID(ScriptAudioClip *clip)
+{
+    return clip->id;
+}
+
 int AudioClip_GetFileType(ScriptAudioClip *clip)
 {
-    return game.audioClips[clip->id].fileType;
+    return clip->fileType;
 }
 
 int AudioClip_GetType(ScriptAudioClip *clip)
 {
-    return game.audioClips[clip->id].type;
+    return clip->type;
 }
 int AudioClip_GetIsAvailable(ScriptAudioClip *clip)
 {
@@ -78,6 +83,11 @@ ScriptAudioChannel* AudioClip_PlayQueued(ScriptAudioClip *clip, int priority, in
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
+
+RuntimeScriptValue Sc_AudioClip_GetID(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptAudioClip, AudioClip_GetID);
+}
 
 // int | ScriptAudioClip *clip
 RuntimeScriptValue Sc_AudioClip_GetFileType(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -127,6 +137,7 @@ void RegisterAudioClipAPI()
     ccAddExternalObjectFunction("AudioClip::PlayFrom^3",        Sc_AudioClip_PlayFrom);
     ccAddExternalObjectFunction("AudioClip::PlayQueued^2",      Sc_AudioClip_PlayQueued);
     ccAddExternalObjectFunction("AudioClip::Stop^0",            Sc_AudioClip_Stop);
+    ccAddExternalObjectFunction("AudioClip::get_ID",            Sc_AudioClip_GetID);
     ccAddExternalObjectFunction("AudioClip::get_FileType",      Sc_AudioClip_GetFileType);
     ccAddExternalObjectFunction("AudioClip::get_IsAvailable",   Sc_AudioClip_GetIsAvailable);
     ccAddExternalObjectFunction("AudioClip::get_Type",          Sc_AudioClip_GetType);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -141,6 +141,9 @@ void InitAndRegisterAudioObjects()
 
     for (size_t i = 0; i < game.audioClips.size(); ++i)
     {
+        // Note that as of 3.5.0 data format the clip IDs are still restricted
+        // to actual item index in array, so we don't make any difference
+        // between game versions, for now.
         game.audioClips[i].id = i;
         ccRegisterManagedObject(&game.audioClips[i], &ccDynamicAudioClip);
         ccAddExternalDynamicObject(game.audioClips[i].scriptName, &game.audioClips[i], &ccDynamicAudioClip);


### PR DESCRIPTION
For #709.

1) Adds ID property to AudioClip, and exports it to script.
2) Clips are saved in game data strictly in the order of their IDs. Note that since it's impossible to change an ID of a game object right now - that means in order of adding them to game.
3) When importing existing project IDs are assigned to clips in the order corresponding to the one they were written to the game data previously. This is to ensure that if script was relying on their order in Game.AudioClips array it still works.