### PR TITLE
3.5.0: Allow to change certain game item IDs in Editor

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -143,6 +143,12 @@
     <Compile Include="GUI\CustomPropertySchemaItemEditor.Designer.cs">
       <DependentUpon>CustomPropertySchemaItemEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\NumberEntryWithInfoDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\NumberEntryWithInfoDialog.Designer.cs">
+      <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\Progress.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -328,6 +334,10 @@
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>
       <DependentUpon>frmMain.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\NumberEntryWithInfoDialog.resx">
+      <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\Progress.resx">
       <DependentUpon>Progress.cs</DependentUpon>

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -12,6 +12,7 @@ namespace AGS.Editor.Components
         private const string COMMAND_PROPERTIES = "PropertiesAudioClip";
         private const string COMMAND_RENAME = "RenameAudioClip";
         private const string COMMAND_DELETE = "DeleteAudioClip";
+        private const string COMMAND_CHANGE_ID = "ChangeAudioID";
         private const string SPEECH_NODE_ID = "DummySpeechNode";
         private const string AUDIO_TYPES_FOLDER_NODE_ID = "AudioTypesFolderNode";
         private const string NODE_ID_PREFIX_CLIP_TYPE = "AudioClipType";
@@ -101,6 +102,24 @@ namespace AGS.Editor.Components
                 {
                     DeleteSingleItem(clipToDelete);                    
                 }
+            }
+            else if (controlID == COMMAND_CHANGE_ID)
+            {
+                AudioClip clipClicked = _items[_rightClickedID];
+                int oldNumber = clipClicked.ID;
+                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("AudioClip", oldNumber, 0, _items.Count - 1);
+                if (newNumber < 0)
+                    return;
+                foreach (var obj in _items)
+                {
+                    if (obj.Value.ID == newNumber)
+                    {
+                        obj.Value.ID = oldNumber;
+                        break;
+                    }
+                }
+                clipClicked.ID = newNumber;
+                OnItemIDChanged(clipClicked);
             }
             else if (controlID == SPEECH_NODE_ID)
             {
@@ -584,6 +603,11 @@ namespace AGS.Editor.Components
             return _iconMappings[clip.FileType];
         }
 
+        private void OnItemIDChanged(AudioClip item)
+        {
+            RePopulateTreeView();
+        }
+
         public override void PropertyChanged(string propertyName, object oldValue)
         {
             if (propertyName == "ScriptName")
@@ -634,6 +658,7 @@ namespace AGS.Editor.Components
             }
             else if (!IsFolderNode(controlID))
             {
+                menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change Clip ID", null));
                 menu.Add(new MenuCommand(COMMAND_RENAME, "Rename", null));
                 menu.Add(new MenuCommand(COMMAND_DELETE, "Delete", null));
                 menu.Add(MenuCommand.Separator);

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -14,6 +14,7 @@ namespace AGS.Editor.Components
         private const string COMMAND_NEW_VIEW = "NewView";
         private const string COMMAND_RENAME = "RenameView";
 		private const string COMMAND_DELETE = "DeleteView";
+        private const string COMMAND_CHANGE_ID = "ChangeViewID";
         private const string COMMAND_FIND_ALL_USAGES = "FindAllUsages";
         private const string ICON_KEY = "ViewsIcon";
         
@@ -56,6 +57,25 @@ namespace AGS.Editor.Components
                     }
 				}
 			}
+            else if (controlID == COMMAND_CHANGE_ID)
+            {
+                View viewClicked = _items[_rightClickedID];
+                int oldNumber = viewClicked.ID;
+                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("View", oldNumber, 1, _items.Count);
+                if (newNumber < 0)
+                    return;
+                foreach (var obj in _items)
+                {
+                    if (obj.Value.ID == newNumber)
+                    {
+                        obj.Value.ID = oldNumber;
+                        break;
+                    }
+                }
+                _agsEditor.CurrentGame.GetAndAllocateViewID(newNumber);
+                viewClicked.ID = newNumber;
+                OnItemIDChanged(viewClicked);
+            }
             else if (controlID == COMMAND_FIND_ALL_USAGES)
             {
                 FindAllUsages findAllUsages = new FindAllUsages(null, null, null, _agsEditor);
@@ -162,6 +182,12 @@ namespace AGS.Editor.Components
             }
         }
 
+        private void OnItemIDChanged(View item)
+        {
+            RePopulateTreeView(GetNodeIDForView(item));
+            UpdateOpenWindowTitles();
+        }
+
         public override void PropertyChanged(string propertyName, object oldValue)
         {
             if (propertyName == "Name")
@@ -174,8 +200,7 @@ namespace AGS.Editor.Components
                 }
                 else
                 {
-                    RePopulateTreeView(GetNodeIDForView(itemBeingEdited));
-                    UpdateOpenWindowTitles();
+                    OnItemIDChanged(itemBeingEdited);
                 }
             }
         }
@@ -187,6 +212,7 @@ namespace AGS.Editor.Components
             if ((controlID.StartsWith(ITEM_COMMAND_PREFIX)) &&
                 (!IsFolderNode(controlID)))
             {
+                menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change View ID", null));
                 menu.Add(new MenuCommand(COMMAND_RENAME, "Rename", null));
 				menu.Add(new MenuCommand(COMMAND_DELETE, "Delete", null));
                 View view = _items[_rightClickedID];

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -743,6 +743,14 @@ namespace AGS.Editor
 			}
         }
 
+        public int ShowChangeObjectIDDialog(string objectType, int oldValue, int minValue, int maxValue)
+        {
+            return NumberEntryWithInfoDialog.Show(string.Format("Change {0} ID", objectType),
+                string.Format("Enter the new ID in the box below ({0}-{1}):", minValue, maxValue),
+                "WARNING: Changing the game item's ID is a specialized operation, for advanced users only. It is meant for rearranging item order inside their list. Thus changing IDs works as swapping position of two item.\n\nPlease note that this will affect any script that refers to items by their number rather than script name.",
+                oldValue, minValue, maxValue);
+        }
+
         public void Initialize(AGSEditor agsEditor)
         {
             if (_mainForm == null)

--- a/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.Designer.cs
@@ -1,0 +1,124 @@
+namespace AGS.Editor
+{
+    partial class NumberEntryWithInfoDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnOK = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.lblHeader = new System.Windows.Forms.Label();
+            this.udNumber = new System.Windows.Forms.NumericUpDown();
+            this.lblInfo = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.udNumber)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // btnOK
+            // 
+            this.btnOK.Location = new System.Drawing.Point(20, 83);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(94, 22);
+            this.btnOK.TabIndex = 0;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(120, 83);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(94, 22);
+            this.btnCancel.TabIndex = 1;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // lblHeader
+            // 
+            this.lblHeader.AutoSize = true;
+            this.lblHeader.Location = new System.Drawing.Point(16, 4);
+            this.lblHeader.MaximumSize = new System.Drawing.Size(400, 0);
+            this.lblHeader.Name = "lblHeader";
+            this.lblHeader.Size = new System.Drawing.Size(364, 13);
+            this.lblHeader.TabIndex = 2;
+            this.lblHeader.Text = "jdlk jkf dkjf dkjfkjf dk jfdkjf dkf jdkj fkdj fkdj fdkj fdk jfdkjf dkfjd kfjdf dk" +
+    "fj dkf d";
+            // 
+            // udNumber
+            // 
+            this.udNumber.Location = new System.Drawing.Point(22, 49);
+            this.udNumber.Name = "udNumber";
+            this.udNumber.Size = new System.Drawing.Size(115, 20);
+            this.udNumber.TabIndex = 5;
+            // 
+            // lblInfo
+            // 
+            this.lblInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblInfo.AutoSize = true;
+            this.lblInfo.BackColor = System.Drawing.Color.LightYellow;
+            this.lblInfo.Location = new System.Drawing.Point(16, 123);
+            this.lblInfo.MaximumSize = new System.Drawing.Size(400, 0);
+            this.lblInfo.Name = "lblInfo";
+            this.lblInfo.Size = new System.Drawing.Size(35, 13);
+            this.lblInfo.TabIndex = 6;
+            this.lblInfo.Text = "label1";
+            // 
+            // NumberEntryWithInfoDialog
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(434, 215);
+            this.Controls.Add(this.lblInfo);
+            this.Controls.Add(this.udNumber);
+            this.Controls.Add(this.lblHeader);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOK);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "NumberEntryWithInfoDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "NumberEntryDialog";
+            ((System.ComponentModel.ISupportInitialize)(this.udNumber)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Label lblHeader;
+        private System.Windows.Forms.NumericUpDown udNumber;
+        private System.Windows.Forms.Label lblInfo;
+    }
+}

--- a/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.cs
+++ b/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public partial class NumberEntryWithInfoDialog : Form
+    {
+        private NumberEntryWithInfoDialog(string titleText, string headerText, string infoText,
+            int initialValue, int minValue, int maxValue)
+        {
+            InitializeComponent();
+            this.Text = titleText;
+            lblHeader.Text = headerText;
+            lblInfo.Text = infoText;
+            udNumber.Minimum = minValue;
+            udNumber.Maximum = maxValue;
+            udNumber.Value = initialValue;
+            udNumber.Select();
+            udNumber.Select(0, ((int)udNumber.Value).ToString().Length);
+        }
+
+        public int Number
+        {
+            get { return (int)udNumber.Value; }
+            set { udNumber.Value = value; }
+        }
+
+        public static int Show(string titleBar, string headerText, string infoText,
+            int currentValue, int minValue = Int32.MinValue, int maxValue = Int32.MaxValue)
+        {
+            int result = -1;
+            NumberEntryWithInfoDialog dialog = new NumberEntryWithInfoDialog(titleBar, headerText, infoText,
+                currentValue, minValue, maxValue);
+            if (dialog.ShowDialog() == DialogResult.OK)
+            {
+                result = dialog.Number;
+            }
+            dialog.Dispose();
+            return result;
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+            this.Close();
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.resx
+++ b/Editor/AGS.Editor/GUI/NumberEntryWithInfoDialog.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -453,6 +453,18 @@ namespace AGS.Types
             return FindHighestViewNumber(_views.RootFolder) + 1;
         }
 
+        /// <summary>
+		/// Returns specific View ID and allocates it as in use
+		/// </summary>
+        public int GetAndAllocateViewID(int id)
+        {
+            if (_deletedViewIDs.ContainsKey(id))
+            {
+                _deletedViewIDs.Remove(id);
+            }
+            return id;
+        }
+
         private int FindHighestViewNumber(ViewFolder folder)
         {
             int highest = 0;


### PR DESCRIPTION
This adds context menu command for changing IDs (order in the list) of following game items:

* Audio clips
* Characters
* Dialogs
* GUIs
* Inventory items
* Views

Note that this does not introduce any new data, nor changes file formats, only lets user swap IDs of two game objects. This functionality is purely optional and is mostly meant for advanced users who would like to arrange items in a certain sequence at design time.

The input dialog also displays a warning that explains possible issues following changing order of items.