### PR TITLE
Keep Travis builds on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: minimal
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ cache:
     - /var/cache/pbuilder
 
 before_script:
-  - pbuilder-dist jessie i386 --security-only create
-  - pbuilder-dist jessie amd64 --security-only create
+  - pbuilder-dist jessie i386 --security-only create --debootstrapopts --no-check-gpg
+  - pbuilder-dist jessie amd64 --security-only create --debootstrapopts --no-check-gpg
 
 script:
   - ./debian/make_ags+libraries.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ addons:
       - pbuilder
       - ubuntu-dev-tools
 
-cache:
-  directories:
-    - /var/cache/pbuilder
-
 before_script:
   - pbuilder-dist jessie i386 --security-only create --debootstrapopts --no-check-gpg
   - pbuilder-dist jessie amd64 --security-only create --debootstrapopts --no-check-gpg


### PR DESCRIPTION
Fixes chroot build on Travis CI.

This might just be a temporary issue, but since this environment won't be used for release purposes I think disabling the check isn't an issue.