### PR TITLE
Remove libfreetype from Linux release packaging

### DIFF
--- a/debian/ags+libraries/hooks/B00_copy_libs.sh
+++ b/debian/ags+libraries/hooks/B00_copy_libs.sh
@@ -20,7 +20,6 @@ BIT=32
     liballeg.so.4.4 \
     libaldmb.so.1 \
     libdumb.so.1 \
-    libfreetype.so.6 \
     libogg.so.0 \
     libtheora.so.0 \
     libvorbis.so.0 \
@@ -35,7 +34,6 @@ BIT=32
 for package in \
   liballegro4.4 \
   libdumb1 \
-  libfreetype6 \
   libogg0 \
   libtheora0 \
   libvorbis0a; do


### PR DESCRIPTION
These files shouldn't be needed any longer, since freetype is now built and included with static linking and any licensing info should be originating from the same source.