### PR TITLE
Add quotes to the AGS Native copy command (release build)

### DIFF
--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -162,7 +162,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(TargetPath) $(SolutionDir)..\Editor\References</Command>
+      <Command>copy "$(TargetPath)" "$(SolutionDir)..\Editor\References"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This was already changed for the debug build so this puts them back in-sync.

See #477 