### PR TITLE
Remove $ORIGIN from build script

### DIFF
--- a/debian/make_ags+libraries.sh
+++ b/debian/make_ags+libraries.sh
@@ -60,7 +60,7 @@ debuild -us -uc -d -S
 
 # Build ags binary package in i386 chroot, also use a hook script to copy libraries and licenses
 # from the chroot to a folder that is mounted into the chroot via --bindmounts.
-DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib32" pbuilder-dist jessie i386 build \
+DEB_BUILD_OPTIONS="rpath=lib32" pbuilder-dist jessie i386 build \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \
   --bindmounts "$BASEPATH/ags+libraries" \
@@ -74,7 +74,7 @@ rm -rf $BASEPATH/ags+libraries/ags_* $BASEPATH/ags+libraries/ags-dbg_* $BASEPATH
 
 # Repeat for amd64.
 sed -i -r "5s/.*/BIT=64/" $BASEPATH/debian/ags+libraries/hooks/B00_copy_libs.sh
-DEB_BUILD_OPTIONS="rpath=$ORIGIN/lib64" pbuilder-dist jessie amd64 build \
+DEB_BUILD_OPTIONS="rpath=lib64" pbuilder-dist jessie amd64 build \
   --buildresult $BASEPATH/ags+libraries \
   --hookdir $BASEPATH/debian/ags+libraries/hooks \
   --bindmounts "$BASEPATH/ags+libraries" \


### PR DESCRIPTION
This was being expanded by the shell (so the value is always blank), and what is passed here will end up appending to the 'real' $ORIGIN, separated with a forward slash.

So currently the Debian build option gets set to `/libxx` which results in an actual rpath value of `$ORIGIN//libxx`

After this change the actual rpath value will be `$ORIGIN/libxx` which I think was the intended result