### PR TITLE
Sort AudioClip select list using the ScriptName property

### DIFF
--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
+using System.Linq;
 using System.Reflection;
 
 namespace AGS.Types
@@ -33,9 +34,12 @@ namespace AGS.Types
 
             _possibleValues.Clear();
             _possibleValues.Add(-1, "(None)");
-            foreach (AudioClip type in _AudioClips)
+
+            // sort on the script name rather than use the default enumeration order, which
+            // comes from the ordering of items in the audio folder hierarchy (volatile)
+            foreach (AudioClip clip in _AudioClips.OrderBy(a => a.ScriptName))
             {
-                _possibleValues.Add(type.ID, type.ScriptName);
+                _possibleValues.Add(clip.ID, clip.ScriptName);
             }
         }
     }


### PR DESCRIPTION
This is a workflow improvement, for selecting AudioClips in game settings and the ViewFrame editor. If you have more than a trivial amount of AudioClips to select from, it is easier to find them if they are sorted alphabetically.

User quote:
> Is it possible to organize all my sound files in this window?
I will most likely add sound to most of my animations in the View editor
however, it's kind of hard to find my sounds when they are all thrown into one window here... not even sorted by alphabet:sweat_smile:
if not possible ... adding sounds to the game will become a nightmare lol

- Easiest and clearest way to do this was using Linq
- I don't know why the AudioClip was being referred to as 'type', I think that was probably just a mistake, so I've also changed that for clarity