### PR TITLE
Fix room saving where object sprite was changed by double clicking

### DIFF
--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -349,9 +349,10 @@ namespace AGS.Editor
 			if (_lastSelectedObject != null)
 			{
 				Sprite chosenSprite = SpriteChooser.ShowSpriteChooser(_lastSelectedObject.Image);
-				if (chosenSprite != null)
+				if (chosenSprite != null && chosenSprite.Number != _lastSelectedObject.Image)
 				{
 					_lastSelectedObject.Image = chosenSprite.Number;
+					_room.Modified = true;
 				}
                 return true;
 			}


### PR DESCRIPTION
When only the sprite for a room object was changed, and the sprite was chosen by double clicking the room object, room changes were not saved. This marks the room as modified, if a sprite was chosen by double-clicking the object and it wasn't the same sprite that the object was using already.