### PR TITLE
Automatic font outlines

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -137,8 +137,8 @@ enum GameDataVersion
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
     kGameVersion_350            = 50,
-    kGameVersion_350_1          = 51,
-    kGameVersion_Current        = kGameVersion_350_1
+    kGameVersion_351            = 51,
+    kGameVersion_Current        = kGameVersion_351
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -101,6 +101,9 @@ Font custom line spacing.
 Sprites have "real" resolution. Expanded FontInfo data format.
 Option to allow legacy relative asset resolutions.
 
+51 :
+Fonts have adjustable outline
+
 */
 
 enum GameDataVersion
@@ -134,7 +137,8 @@ enum GameDataVersion
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
     kGameVersion_350            = 50,
-    kGameVersion_Current        = kGameVersion_350
+    kGameVersion_350_1          = 51,
+    kGameVersion_Current        = kGameVersion_350_1
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -143,6 +143,12 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             fonts[i].YOffset = in->ReadInt32();
             fonts[i].LineSpacing = Math::Max(0, in->ReadInt32());
             AdjustFontInfoUsingFlags(fonts[i], flags);
+            if (data_ver >= kGameVersion_350_1)
+            {
+                fonts[i].AutoOutlineThickness = in->ReadInt32();
+                fonts[i].AutoOutlineStyle = 
+                    static_cast<FontInfo::AutoOutlineStyleT>(in->ReadInt32());
+            }
         }
     }
 }

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -143,7 +143,7 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             fonts[i].YOffset = in->ReadInt32();
             fonts[i].LineSpacing = Math::Max(0, in->ReadInt32());
             AdjustFontInfoUsingFlags(fonts[i], flags);
-            if (data_ver >= kGameVersion_350_1)
+            if (data_ver >= kGameVersion_351)
             {
                 fonts[i].AutoOutlineThickness = in->ReadInt32();
                 fonts[i].AutoOutlineStyle = 

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -147,7 +147,7 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             {
                 fonts[i].AutoOutlineThickness = in->ReadInt32();
                 fonts[i].AutoOutlineStyle = 
-                    static_cast<FontInfo::AutoOutlineStyleT>(in->ReadInt32());
+                    static_cast<enum FontInfo::AutoOutlineStyle>(in->ReadInt32());
             }
         }
     }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -225,7 +225,7 @@ struct SpriteInfo
 // multiple lines, and similar cases.
 struct FontInfo
 {
-    enum AutoOutlineStyleT : int
+    enum AutoOutlineStyle : int
     {
         kRounded = 0,
         kSquared = 1,
@@ -246,7 +246,7 @@ struct FontInfo
     // When automatic outlining, thickness of the outline (0 = use legacy thickness)
     int           AutoOutlineThickness;
     // When automatic outlining, style of the outline
-    AutoOutlineStyleT AutoOutlineStyle;
+    AutoOutlineStyle AutoOutlineStyle;
 
     FontInfo();
 };

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -225,6 +225,12 @@ struct SpriteInfo
 // multiple lines, and similar cases.
 struct FontInfo
 {
+    enum AutoOutlineStyleT : int
+    {
+        kRounded = 0,
+        kSquared = 1,
+    };
+
     // General font's loading and rendering flags
     uint32_t      Flags;
     // Font size, in points (basically means pixels in AGS)
@@ -237,6 +243,10 @@ struct FontInfo
     int           YOffset;
     // custom line spacing between two lines of text (0 = use font height)
     int           LineSpacing;
+    // When automatic outlining, thickness of the outline (0 = use legacy thickness)
+    int           AutoOutlineThickness;
+    // When automatic outlining, style of the outline
+    AutoOutlineStyleT AutoOutlineStyle;
 
     FontInfo();
 };

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -61,6 +61,8 @@ FontInfo::FontInfo()
     , Outline(FONT_OUTLINE_NONE)
     , YOffset(0)
     , LineSpacing(0)
+    , AutoOutlineStyle(kRounded)
+    , AutoOutlineThickness(0)
 {}
 
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -28,7 +28,6 @@
 #include "util/path.h"
 #include "util/string_compat.h"
 #include "util/string_utils.h"
-#include "font/fonts.h"
 
 namespace AGS
 {
@@ -483,21 +482,6 @@ void UpgradeFonts(GameSetupStruct &game, GameDataVersion data_ver)
             else
             {
                 finfo.SizeMultiplier = 1;
-            }
-        }
-    } 
-    else
-    {
-        for (size_t font = 0; font < game.numfonts; font++)
-        {
-            FontInfo &finfo = game.fonts[font];
-            if (0 == finfo.AutoOutlineThickness)
-            {
-                // Thickness that corresponds to 1 game pixel
-                finfo.AutoOutlineThickness =
-                    (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
-                    get_fixed_pixel_size(1) : 1;
-                finfo.AutoOutlineStyle = FontInfo::kSquared;
             }
         }
     }

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -28,6 +28,7 @@
 #include "util/path.h"
 #include "util/string_compat.h"
 #include "util/string_utils.h"
+#include "font/fonts.h"
 
 namespace AGS
 {
@@ -482,6 +483,21 @@ void UpgradeFonts(GameSetupStruct &game, GameDataVersion data_ver)
             else
             {
                 finfo.SizeMultiplier = 1;
+            }
+        }
+    } 
+    else
+    {
+        for (size_t font = 0; font < game.numfonts; font++)
+        {
+            FontInfo &finfo = game.fonts[font];
+            if (0 == finfo.AutoOutlineThickness)
+            {
+                // Thickness that corresponds to 1 game pixel
+                finfo.AutoOutlineThickness =
+                    (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+                    get_fixed_pixel_size(1) : 1;
+                finfo.AutoOutlineStyle = FontInfo::kSquared;
             }
         }
     }

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1413,6 +1413,8 @@ namespace AGS.Editor
 
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
+				writer.Write(game.Fonts[i].AutoOutlineThickness);
+				writer.Write((int) game.Fonts[i].AutoOutlineStyle);
             }
             int topmostSprite;
             byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -116,6 +116,7 @@
     <Compile Include="EditorFeatures\MenuCommands.cs" />
     <Compile Include="EditorFeatures\MessageBoxIconType.cs" />
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
+    <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />
     <Compile Include="Enums\CustomPropertyAppliesTo.cs" />
     <Compile Include="Enums\CustomPropertyType.cs" />

--- a/Editor/AGS.Types/Enums/FontAutoOutlineStyle.cs
+++ b/Editor/AGS.Types/Enums/FontAutoOutlineStyle.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AGS.Types
+{
+	public enum FontAutoOutlineStyle
+	{
+		Rounded = 0,
+		Squared = 1,
+	}
+}

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -7,8 +7,8 @@ using System.Xml;
 namespace AGS.Types
 {
     [DefaultProperty("OutlineStyle")]
-    public class Font
-    {
+    public class Font : ICustomTypeDescriptor
+	{
         private int _id;
         private string _name;
         private int _pointSize;
@@ -19,14 +19,16 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
+		private int _autoOutlineThickness = 0;
+		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
-            _outlineStyle = FontOutlineStyle.None;
-            _outlineFont = 0;
             _name = string.Empty;
             _pointSize = 0;
-            _fontHeight = 0;
+			_outlineFont = 0;
+			_outlineStyle = FontOutlineStyle.None;
+			_fontHeight = 0;
             _lineSpacing = 0;
         }
 
@@ -101,7 +103,7 @@ namespace AGS.Types
             get { return "Font: " + this.Name; }
         }
 
-        [Description("Font to use as an outline for this one (only if FontOutlineStyle is OutlineFont)")]
+        [Description("Font to use as an outline for this one")]
         [Category("Appearance")]
         public int OutlineFont
         {
@@ -111,11 +113,28 @@ namespace AGS.Types
 
         [Description("Whether this font should be drawn with an outline")]
         [Category("Appearance")]
-        public FontOutlineStyle OutlineStyle
+		[RefreshProperties(RefreshProperties.All)]
+		public FontOutlineStyle OutlineStyle
         {
             get { return _outlineStyle; }
             set { _outlineStyle = value; }
         }
+
+		[Description("Thickness of the automatic outline (0 = default)")]
+		[Category("Appearance")]
+		public int AutoOutlineThickness
+		{
+			get { return _autoOutlineThickness; }
+			set { _autoOutlineThickness = value; }
+		}
+
+		[Description("Style of the automatic outline")]
+		[Category("Appearance")]
+		public FontAutoOutlineStyle AutoOutlineStyle
+		{
+			get { return _autoOutlineStyle; }
+			set { _autoOutlineStyle = value; }
+		}
 
 		[Description("The file path that this font was imported from")]
 		[Category("Design")]
@@ -178,5 +197,84 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
-    }
+		#region ICustomTypeDescriptor Members
+		public AttributeCollection GetAttributes()
+		{
+			return TypeDescriptor.GetAttributes(this, true);
+		}
+
+		public string GetClassName()
+		{
+			return TypeDescriptor.GetClassName(this, true);
+		}
+
+		public string GetComponentName()
+		{
+			return TypeDescriptor.GetComponentName(this, true);
+		}
+
+		public TypeConverter GetConverter()
+		{
+			return TypeDescriptor.GetConverter(this, true);
+		}
+
+		public EventDescriptor GetDefaultEvent()
+		{
+			return TypeDescriptor.GetDefaultEvent(this, true);
+		}
+
+		public PropertyDescriptor GetDefaultProperty()
+		{
+			return TypeDescriptor.GetDefaultProperty(this, true);
+		}
+
+		public object GetEditor(Type editorBaseType)
+		{
+			return TypeDescriptor.GetEditor(this, editorBaseType, true);
+		}
+
+		public EventDescriptorCollection GetEvents()
+		{
+			return TypeDescriptor.GetEvents(this, true);
+		}
+
+		public EventDescriptorCollection GetEvents(Attribute[] attributes)
+		{
+			return TypeDescriptor.GetEvents(this, attributes, true);
+		}
+
+		public PropertyDescriptorCollection GetProperties()
+		{
+			return TypeDescriptor.GetProperties(this, true);
+		}
+
+		public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+		{
+			PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
+			List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
+			foreach (PropertyDescriptor property in properties)
+			{
+				if (property.Name == "AutoOutlineStyle" ||
+					property.Name == "AutoOutlineThickness")
+				{
+					if (_outlineStyle != FontOutlineStyle.Automatic)
+						continue;
+				}
+				else if (property.Name == "OutlineFont")
+				{
+					if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
+						continue;
+				}
+
+				wantedProperties.Add(property);
+			}
+			return new PropertyDescriptorCollection(wantedProperties.ToArray());
+		}
+
+		public object GetPropertyOwner(PropertyDescriptor pd)
+		{
+			return this;
+		}
+		#endregion
+	}
 }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -19,14 +19,14 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-		private int _autoOutlineThickness = 0; 
+		private int _autoOutlineThickness = 0;
 		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
             _name = string.Empty;
             _pointSize = 0;
-			_outlineFont = 0; 
+			_outlineFont = 0;
 			_outlineStyle = FontOutlineStyle.None;
 			_fontHeight = 0;
             _lineSpacing = 0;

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -8,27 +8,27 @@ namespace AGS.Types
 {
     [DefaultProperty("OutlineStyle")]
     public class Font : ICustomTypeDescriptor
-	{
+    {
         private int _id;
         private string _name;
         private int _pointSize;
         private int _fontHeight;
         private int _outlineFont;
         private FontOutlineStyle _outlineStyle;
-		private string _sourceFilename = string.Empty;
+        private string _sourceFilename = string.Empty;
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-		private int _autoOutlineThickness = 0; 
-		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
+        private int _autoOutlineThickness = 0; 
+        private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
             _name = string.Empty;
             _pointSize = 0;
-			_outlineFont = 0; 
-			_outlineStyle = FontOutlineStyle.None;
-			_fontHeight = 0;
+            _outlineFont = 0; 
+            _outlineStyle = FontOutlineStyle.None;
+            _fontHeight = 0;
             _lineSpacing = 0;
         }
 
@@ -75,27 +75,27 @@ namespace AGS.Types
             set { _name = value; }
         }
 
-		[Description("The name with which the script will access this font")]
-		[Category("Design")]
-		public string ScriptID
-		{
-			get
-			{
-				if (Name.Length < 1)
-				{
-					return string.Empty;
-				}
-				string scriptName = "eFont" + Name;
-				for (int i = 0; i < scriptName.Length; i++)
-				{
-					if (!Char.IsLetterOrDigit(scriptName[i]))
-					{
-						scriptName = scriptName.Replace(scriptName[i].ToString(), string.Empty);
-					}
-				}
-				return scriptName;
-			}
-		}
+        [Description("The name with which the script will access this font")]
+        [Category("Design")]
+        public string ScriptID
+        {
+            get
+            {
+                if (Name.Length < 1)
+                {
+                    return string.Empty;
+                }
+                string scriptName = "eFont" + Name;
+                for (int i = 0; i < scriptName.Length; i++)
+                {
+                    if (!Char.IsLetterOrDigit(scriptName[i]))
+                    {
+                        scriptName = scriptName.Replace(scriptName[i].ToString(), string.Empty);
+                    }
+                }
+                return scriptName;
+            }
+        }
 
         [Browsable(false)]
         public string WindowTitle
@@ -113,37 +113,37 @@ namespace AGS.Types
 
         [Description("Whether this font should be drawn with an outline")]
         [Category("Appearance")]
-		[RefreshProperties(RefreshProperties.All)]
-		public FontOutlineStyle OutlineStyle
+        [RefreshProperties(RefreshProperties.All)]
+        public FontOutlineStyle OutlineStyle
         {
             get { return _outlineStyle; }
             set { _outlineStyle = value; }
         }
 
-		[Description("Thickness of the automatic outline (0 = default)")]
-		[Category("Appearance")]
-		public int AutoOutlineThickness
-		{
-			get { return _autoOutlineThickness; }
-			set { _autoOutlineThickness = value; }
-		}
+        [Description("Thickness of the automatic outline (0 = default)")]
+        [Category("Appearance")]
+        public int AutoOutlineThickness
+        {
+            get { return _autoOutlineThickness; }
+            set { _autoOutlineThickness = value; }
+        }
 
-		[Description("Style of the automatic outline")]
-		[Category("Appearance")]
-		public FontAutoOutlineStyle AutoOutlineStyle
-		{
-			get { return _autoOutlineStyle; }
-			set { _autoOutlineStyle = value; }
-		}
+        [Description("Style of the automatic outline")]
+        [Category("Appearance")]
+        public FontAutoOutlineStyle AutoOutlineStyle
+        {
+            get { return _autoOutlineStyle; }
+            set { _autoOutlineStyle = value; }
+        }
 
-		[Description("The file path that this font was imported from")]
-		[Category("Design")]
-		[ReadOnly(true)]
-		public string SourceFilename
-		{
-			get { return _sourceFilename; }
-			set { _sourceFilename = value; }
-		}
+        [Description("The file path that this font was imported from")]
+        [Category("Design")]
+        [ReadOnly(true)]
+        public string SourceFilename
+        {
+            get { return _sourceFilename; }
+            set { _sourceFilename = value; }
+        }
 
         [Description("Font's size multiplier; primarily for bitmap fonts that don't scale on their own")]
         [Category("Appearance")]
@@ -175,17 +175,17 @@ namespace AGS.Types
             set { _lineSpacing = value; }
         }
 
-		[Browsable(false)]
-		public string WFNFileName
-		{
-			get { return "agsfnt" + _id + ".wfn"; }
-		}
+        [Browsable(false)]
+        public string WFNFileName
+        {
+            get { return "agsfnt" + _id + ".wfn"; }
+        }
 
-		[Browsable(false)]
-		public string TTFFileName
-		{
-			get { return "agsfnt" + _id + ".ttf"; }
-		}
+        [Browsable(false)]
+        public string TTFFileName
+        {
+            get { return "agsfnt" + _id + ".ttf"; }
+        }
 
         public Font(XmlNode node)
         {
@@ -197,84 +197,84 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
-		#region ICustomTypeDescriptor Members
-		public AttributeCollection GetAttributes()
-		{
-			return TypeDescriptor.GetAttributes(this, true);
-		}
+        #region ICustomTypeDescriptor Members
+        public AttributeCollection GetAttributes()
+        {
+            return TypeDescriptor.GetAttributes(this, true);
+        }
 
-		public string GetClassName()
-		{
-			return TypeDescriptor.GetClassName(this, true);
-		}
+        public string GetClassName()
+        {
+            return TypeDescriptor.GetClassName(this, true);
+        }
 
-		public string GetComponentName()
-		{
-			return TypeDescriptor.GetComponentName(this, true);
-		}
+        public string GetComponentName()
+        {
+            return TypeDescriptor.GetComponentName(this, true);
+        }
 
-		public TypeConverter GetConverter()
-		{
-			return TypeDescriptor.GetConverter(this, true);
-		}
+        public TypeConverter GetConverter()
+        {
+            return TypeDescriptor.GetConverter(this, true);
+        }
 
-		public EventDescriptor GetDefaultEvent()
-		{
-			return TypeDescriptor.GetDefaultEvent(this, true);
-		}
+        public EventDescriptor GetDefaultEvent()
+        {
+            return TypeDescriptor.GetDefaultEvent(this, true);
+        }
 
-		public PropertyDescriptor GetDefaultProperty()
-		{
-			return TypeDescriptor.GetDefaultProperty(this, true);
-		}
+        public PropertyDescriptor GetDefaultProperty()
+        {
+            return TypeDescriptor.GetDefaultProperty(this, true);
+        }
 
-		public object GetEditor(Type editorBaseType)
-		{
-			return TypeDescriptor.GetEditor(this, editorBaseType, true);
-		}
+        public object GetEditor(Type editorBaseType)
+        {
+            return TypeDescriptor.GetEditor(this, editorBaseType, true);
+        }
 
-		public EventDescriptorCollection GetEvents()
-		{
-			return TypeDescriptor.GetEvents(this, true);
-		}
+        public EventDescriptorCollection GetEvents()
+        {
+            return TypeDescriptor.GetEvents(this, true);
+        }
 
-		public EventDescriptorCollection GetEvents(Attribute[] attributes)
-		{
-			return TypeDescriptor.GetEvents(this, attributes, true);
-		}
+        public EventDescriptorCollection GetEvents(Attribute[] attributes)
+        {
+            return TypeDescriptor.GetEvents(this, attributes, true);
+        }
 
-		public PropertyDescriptorCollection GetProperties()
-		{
-			return TypeDescriptor.GetProperties(this, true);
-		}
+        public PropertyDescriptorCollection GetProperties()
+        {
+            return TypeDescriptor.GetProperties(this, true);
+        }
 
-		public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
-		{
-			PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
-			List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
-			foreach (PropertyDescriptor property in properties)
-			{
-				if (property.Name == "AutoOutlineStyle" ||
-					property.Name == "AutoOutlineThickness")
-				{
-					if (_outlineStyle != FontOutlineStyle.Automatic)
-						continue;
-				}
-				else if (property.Name == "OutlineFont")
-				{
-					if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
-						continue;
-				}
+        public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+        {
+            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
+            List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
+            foreach (PropertyDescriptor property in properties)
+            {
+                if (property.Name == "AutoOutlineStyle" ||
+                    property.Name == "AutoOutlineThickness")
+                {
+                    if (_outlineStyle != FontOutlineStyle.Automatic)
+                        continue;
+                }
+                else if (property.Name == "OutlineFont")
+                {
+                    if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
+                        continue;
+                }
 
-				wantedProperties.Add(property);
-			}
-			return new PropertyDescriptorCollection(wantedProperties.ToArray());
-		}
+                wantedProperties.Add(property);
+            }
+            return new PropertyDescriptorCollection(wantedProperties.ToArray());
+        }
 
-		public object GetPropertyOwner(PropertyDescriptor pd)
-		{
-			return this;
-		}
-		#endregion
-	}
+        public object GetPropertyOwner(PropertyDescriptor pd)
+        {
+            return this;
+        }
+        #endregion
+    }
 }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -8,27 +8,27 @@ namespace AGS.Types
 {
     [DefaultProperty("OutlineStyle")]
     public class Font : ICustomTypeDescriptor
-    {
+	{
         private int _id;
         private string _name;
         private int _pointSize;
         private int _fontHeight;
         private int _outlineFont;
         private FontOutlineStyle _outlineStyle;
-        private string _sourceFilename = string.Empty;
+		private string _sourceFilename = string.Empty;
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-        private int _autoOutlineThickness = 0; 
-        private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
+		private int _autoOutlineThickness = 0; 
+		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
             _name = string.Empty;
             _pointSize = 0;
-            _outlineFont = 0; 
-            _outlineStyle = FontOutlineStyle.None;
-            _fontHeight = 0;
+			_outlineFont = 0; 
+			_outlineStyle = FontOutlineStyle.None;
+			_fontHeight = 0;
             _lineSpacing = 0;
         }
 
@@ -75,27 +75,27 @@ namespace AGS.Types
             set { _name = value; }
         }
 
-        [Description("The name with which the script will access this font")]
-        [Category("Design")]
-        public string ScriptID
-        {
-            get
-            {
-                if (Name.Length < 1)
-                {
-                    return string.Empty;
-                }
-                string scriptName = "eFont" + Name;
-                for (int i = 0; i < scriptName.Length; i++)
-                {
-                    if (!Char.IsLetterOrDigit(scriptName[i]))
-                    {
-                        scriptName = scriptName.Replace(scriptName[i].ToString(), string.Empty);
-                    }
-                }
-                return scriptName;
-            }
-        }
+		[Description("The name with which the script will access this font")]
+		[Category("Design")]
+		public string ScriptID
+		{
+			get
+			{
+				if (Name.Length < 1)
+				{
+					return string.Empty;
+				}
+				string scriptName = "eFont" + Name;
+				for (int i = 0; i < scriptName.Length; i++)
+				{
+					if (!Char.IsLetterOrDigit(scriptName[i]))
+					{
+						scriptName = scriptName.Replace(scriptName[i].ToString(), string.Empty);
+					}
+				}
+				return scriptName;
+			}
+		}
 
         [Browsable(false)]
         public string WindowTitle
@@ -113,37 +113,37 @@ namespace AGS.Types
 
         [Description("Whether this font should be drawn with an outline")]
         [Category("Appearance")]
-        [RefreshProperties(RefreshProperties.All)]
-        public FontOutlineStyle OutlineStyle
+		[RefreshProperties(RefreshProperties.All)]
+		public FontOutlineStyle OutlineStyle
         {
             get { return _outlineStyle; }
             set { _outlineStyle = value; }
         }
 
-        [Description("Thickness of the automatic outline (0 = default)")]
-        [Category("Appearance")]
-        public int AutoOutlineThickness
-        {
-            get { return _autoOutlineThickness; }
-            set { _autoOutlineThickness = value; }
-        }
+		[Description("Thickness of the automatic outline (0 = default)")]
+		[Category("Appearance")]
+		public int AutoOutlineThickness
+		{
+			get { return _autoOutlineThickness; }
+			set { _autoOutlineThickness = value; }
+		}
 
-        [Description("Style of the automatic outline")]
-        [Category("Appearance")]
-        public FontAutoOutlineStyle AutoOutlineStyle
-        {
-            get { return _autoOutlineStyle; }
-            set { _autoOutlineStyle = value; }
-        }
+		[Description("Style of the automatic outline")]
+		[Category("Appearance")]
+		public FontAutoOutlineStyle AutoOutlineStyle
+		{
+			get { return _autoOutlineStyle; }
+			set { _autoOutlineStyle = value; }
+		}
 
-        [Description("The file path that this font was imported from")]
-        [Category("Design")]
-        [ReadOnly(true)]
-        public string SourceFilename
-        {
-            get { return _sourceFilename; }
-            set { _sourceFilename = value; }
-        }
+		[Description("The file path that this font was imported from")]
+		[Category("Design")]
+		[ReadOnly(true)]
+		public string SourceFilename
+		{
+			get { return _sourceFilename; }
+			set { _sourceFilename = value; }
+		}
 
         [Description("Font's size multiplier; primarily for bitmap fonts that don't scale on their own")]
         [Category("Appearance")]
@@ -175,17 +175,17 @@ namespace AGS.Types
             set { _lineSpacing = value; }
         }
 
-        [Browsable(false)]
-        public string WFNFileName
-        {
-            get { return "agsfnt" + _id + ".wfn"; }
-        }
+		[Browsable(false)]
+		public string WFNFileName
+		{
+			get { return "agsfnt" + _id + ".wfn"; }
+		}
 
-        [Browsable(false)]
-        public string TTFFileName
-        {
-            get { return "agsfnt" + _id + ".ttf"; }
-        }
+		[Browsable(false)]
+		public string TTFFileName
+		{
+			get { return "agsfnt" + _id + ".ttf"; }
+		}
 
         public Font(XmlNode node)
         {
@@ -197,84 +197,84 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
-        #region ICustomTypeDescriptor Members
-        public AttributeCollection GetAttributes()
-        {
-            return TypeDescriptor.GetAttributes(this, true);
-        }
+		#region ICustomTypeDescriptor Members
+		public AttributeCollection GetAttributes()
+		{
+			return TypeDescriptor.GetAttributes(this, true);
+		}
 
-        public string GetClassName()
-        {
-            return TypeDescriptor.GetClassName(this, true);
-        }
+		public string GetClassName()
+		{
+			return TypeDescriptor.GetClassName(this, true);
+		}
 
-        public string GetComponentName()
-        {
-            return TypeDescriptor.GetComponentName(this, true);
-        }
+		public string GetComponentName()
+		{
+			return TypeDescriptor.GetComponentName(this, true);
+		}
 
-        public TypeConverter GetConverter()
-        {
-            return TypeDescriptor.GetConverter(this, true);
-        }
+		public TypeConverter GetConverter()
+		{
+			return TypeDescriptor.GetConverter(this, true);
+		}
 
-        public EventDescriptor GetDefaultEvent()
-        {
-            return TypeDescriptor.GetDefaultEvent(this, true);
-        }
+		public EventDescriptor GetDefaultEvent()
+		{
+			return TypeDescriptor.GetDefaultEvent(this, true);
+		}
 
-        public PropertyDescriptor GetDefaultProperty()
-        {
-            return TypeDescriptor.GetDefaultProperty(this, true);
-        }
+		public PropertyDescriptor GetDefaultProperty()
+		{
+			return TypeDescriptor.GetDefaultProperty(this, true);
+		}
 
-        public object GetEditor(Type editorBaseType)
-        {
-            return TypeDescriptor.GetEditor(this, editorBaseType, true);
-        }
+		public object GetEditor(Type editorBaseType)
+		{
+			return TypeDescriptor.GetEditor(this, editorBaseType, true);
+		}
 
-        public EventDescriptorCollection GetEvents()
-        {
-            return TypeDescriptor.GetEvents(this, true);
-        }
+		public EventDescriptorCollection GetEvents()
+		{
+			return TypeDescriptor.GetEvents(this, true);
+		}
 
-        public EventDescriptorCollection GetEvents(Attribute[] attributes)
-        {
-            return TypeDescriptor.GetEvents(this, attributes, true);
-        }
+		public EventDescriptorCollection GetEvents(Attribute[] attributes)
+		{
+			return TypeDescriptor.GetEvents(this, attributes, true);
+		}
 
-        public PropertyDescriptorCollection GetProperties()
-        {
-            return TypeDescriptor.GetProperties(this, true);
-        }
+		public PropertyDescriptorCollection GetProperties()
+		{
+			return TypeDescriptor.GetProperties(this, true);
+		}
 
-        public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
-        {
-            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
-            List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
-            foreach (PropertyDescriptor property in properties)
-            {
-                if (property.Name == "AutoOutlineStyle" ||
-                    property.Name == "AutoOutlineThickness")
-                {
-                    if (_outlineStyle != FontOutlineStyle.Automatic)
-                        continue;
-                }
-                else if (property.Name == "OutlineFont")
-                {
-                    if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
-                        continue;
-                }
+		public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+		{
+			PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
+			List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
+			foreach (PropertyDescriptor property in properties)
+			{
+				if (property.Name == "AutoOutlineStyle" ||
+					property.Name == "AutoOutlineThickness")
+				{
+					if (_outlineStyle != FontOutlineStyle.Automatic)
+						continue;
+				}
+				else if (property.Name == "OutlineFont")
+				{
+					if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
+						continue;
+				}
 
-                wantedProperties.Add(property);
-            }
-            return new PropertyDescriptorCollection(wantedProperties.ToArray());
-        }
+				wantedProperties.Add(property);
+			}
+			return new PropertyDescriptorCollection(wantedProperties.ToArray());
+		}
 
-        public object GetPropertyOwner(PropertyDescriptor pd)
-        {
-            return this;
-        }
-        #endregion
-    }
+		public object GetPropertyOwner(PropertyDescriptor pd)
+		{
+			return this;
+		}
+		#endregion
+	}
 }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -19,14 +19,14 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-		private int _autoOutlineThickness = 0;
+		private int _autoOutlineThickness = 0; 
 		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
             _name = string.Empty;
             _pointSize = 0;
-			_outlineFont = 0;
+			_outlineFont = 0; 
 			_outlineStyle = FontOutlineStyle.None;
 			_fontHeight = 0;
             _lineSpacing = 0;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -479,6 +479,14 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
 
     int thickness = game.fonts.at(font).AutoOutlineThickness;
     auto style = game.fonts.at(font).AutoOutlineStyle;
+    if (0 == thickness)
+    {
+        // Thickness that corresponds to 1 game pixel
+        thickness =
+            (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+            get_fixed_pixel_size(1) : 1;
+        style = FontInfo::kSquared;
+    }
     if (thickness <= 0)
         return; 
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -47,6 +47,8 @@
 #include "ac/timer.h"
 
 using AGS::Common::Bitmap;
+using AGS::Common::BitmapHelper::CreateTransparentBitmap;
+
 namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 extern GameState play;
@@ -446,7 +448,7 @@ bool ShouldAntiAliasText() {
 }
 
 // Make semi-transparent bits much more opaque
-void wouttextxy_AutoOutline_Semitransparent2Opaque(AGS::Common::Bitmap *map)
+void wouttextxy_AutoOutline_Semitransparent2Opaque(Bitmap *map)
 {
     if (map->GetColorDepth() < 32)
         return; // such maps don't feature partial transparency
@@ -471,8 +473,10 @@ void wouttextxy_AutoOutline_Semitransparent2Opaque(AGS::Common::Bitmap *map)
 }
 
 // Draw outline that is calculated from the text font, not derived from an outline font
-void wouttextxy_AutoOutline(AGS::Common::Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
+void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
 {
+    using AGS::Common::kBitmap_Transparency;
+
     int thickness = game.fonts.at(font).AutoOutlineThickness;
     auto style = game.fonts.at(font).AutoOutlineStyle;
     if (0 == thickness)
@@ -488,10 +492,10 @@ void wouttextxy_AutoOutline(AGS::Common::Bitmap *ds, size_t font, int32_t color,
 
     size_t const t_width = wgettextwidth(texx, font);
     size_t const t_height = wgettextheight(texx, font);
-    AGS::Common::Bitmap *outline_stencil =
-        AGS::Common::BitmapHelper::CreateTransparentBitmap(t_width, t_height + 2 * thickness, ds->GetColorDepth());
-    AGS::Common::Bitmap *texx_stencil =
-        AGS::Common::BitmapHelper::CreateTransparentBitmap(t_width, t_height, ds->GetColorDepth());
+    Bitmap *outline_stencil =
+        CreateTransparentBitmap(t_width, t_height + 2 * thickness, ds->GetColorDepth());
+    Bitmap *texx_stencil =
+        CreateTransparentBitmap(t_width, t_height, ds->GetColorDepth());
     if (!outline_stencil || !texx_stencil)
         return;
     wouttextxy(texx_stencil, 0, 0, font, color, texx);
@@ -516,16 +520,16 @@ void wouttextxy_AutoOutline(AGS::Common::Bitmap *ds, size_t font, int32_t color,
             y_diff <= thickness && y_diff * y_diff  <= y_term_limit; 
             y_diff++)
         {
-            outline_stencil->Blit(texx_stencil, 0, thickness - y_diff, AGS::Common::kBitmap_Transparency);
+            outline_stencil->Blit(texx_stencil, 0, thickness - y_diff, kBitmap_Transparency);
             if (y_diff > 0)
-                outline_stencil->Blit(texx_stencil, 0, thickness + y_diff, AGS::Common::kBitmap_Transparency);
+                outline_stencil->Blit(texx_stencil, 0, thickness + y_diff, kBitmap_Transparency);
             largest_y_diff_reached_so_far = y_diff;
         }
 
         // stamp the outline stencil to the left and right of the text
-        ds->Blit(outline_stencil, xxp - x_diff, outline_y, AGS::Common::kBitmap_Transparency);
+        ds->Blit(outline_stencil, xxp - x_diff, outline_y, kBitmap_Transparency);
         if (x_diff > 0)
-            ds->Blit(outline_stencil, xxp + x_diff, outline_y, AGS::Common::kBitmap_Transparency);
+            ds->Blit(outline_stencil, xxp + x_diff, outline_y, kBitmap_Transparency);
     }
  
     delete texx_stencil;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -215,7 +215,6 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             }
             else {
                 text_color = text_window_ds->GetCompatibleColor(asspch);
-                //wouttext_outline(ttxp,ttyp,usingfont,lines[ee]);
                 wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, lines[ee], play.speech_text_align);
             }
         }
@@ -446,39 +445,112 @@ bool ShouldAntiAliasText() {
     return (game.options[OPT_ANTIALIASFONTS] != 0);
 }
 
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx) {
-    
-    color_t outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
-    if (get_font_outline(usingfont) >= 0) {
-        // MACPORT FIX 9/6/5: cast
-        wouttextxy(ds, xxp, yyp, (int)get_font_outline(usingfont), outline_color, texx);
-    }
-    else if (get_font_outline(usingfont) == FONT_OUTLINE_AUTO) {
-        int outlineDist = 1;
+// Make semi-transparent bits much more opaque
+void wouttextxy_AutoOutline_Semitransparent2Opaque(AGS::Common::Bitmap *map)
+{
+    if (map->GetColorDepth() < 32)
+        return; // such maps don't feature partial transparency
+    size_t const width = map->GetWidth();
+    size_t const height = map->GetHeight();
 
-        if (is_bitmap_font(usingfont) && get_font_scaling_mul(usingfont) > 1) {
-            // if it's a scaled up bitmap font, move the outline out more
-            outlineDist = get_fixed_pixel_size(1);
+    for (size_t y = 0; y < height; y++)
+    {
+        int32 *sc_line = reinterpret_cast<int32 *>(map->GetScanLineForWriting(y));
+        for (size_t x = 0; x < width; x++)
+        {
+            int32 &px = sc_line[x];
+            int const transparency = geta(px);
+            if (0 < transparency && transparency < 255)
+                px = makeacol32(
+                    getr32(px), 
+                    getg32(px), 
+                    getb32(px), 
+                    std::min(85 + transparency * 2, 255));
         }
-
-        // move the text over so that it's still within the bounding rect
-        xxp += outlineDist;
-        yyp += outlineDist;
-
-        wouttextxy(ds, xxp - outlineDist, yyp, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp, yyp - outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp - outlineDist, yyp - outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp - outlineDist, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp - outlineDist, usingfont, outline_color, texx);
     }
-
-    wouttextxy(ds, xxp, yyp, usingfont, text_color, texx);
 }
 
-void wouttext_aligned (Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align) {
+// Draw outline that is calculated from the text font, not derived from an outline font
+void wouttextxy_AutoOutline(AGS::Common::Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
+{
+    int thickness = game.fonts.at(font).AutoOutlineThickness;
+    auto style = game.fonts.at(font).AutoOutlineStyle;
+    if (0 == thickness)
+    {
+        // Thickness that corresponds to 1 game pixel
+        thickness =
+            (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+            get_fixed_pixel_size(1) : 1;
+        style = FontInfo::kSquared;
+    }
+    if (thickness <= 0)
+        return; 
+
+    size_t const t_width = wgettextwidth(texx, font);
+    size_t const t_height = wgettextheight(texx, font);
+    AGS::Common::Bitmap *outline_stencil =
+        AGS::Common::BitmapHelper::CreateTransparentBitmap(t_width, t_height + 2 * thickness, ds->GetColorDepth());
+    AGS::Common::Bitmap *texx_stencil =
+        AGS::Common::BitmapHelper::CreateTransparentBitmap(t_width, t_height, ds->GetColorDepth());
+    if (!outline_stencil || !texx_stencil)
+        return;
+    wouttextxy(texx_stencil, 0, 0, font, color, texx);
+    wouttextxy_AutoOutline_Semitransparent2Opaque(texx_stencil);
+    
+    // move start of text so that the outline doesn't drop off the bitmap
+    xxp += thickness;
+    int const outline_y = yyp;
+    yyp += thickness;
+    
+    int largest_y_diff_reached_so_far = -1; 
+    for (int x_diff = thickness; x_diff >= 0; x_diff--)
+    {
+        // Integer arithmetics: In the following, we use terms k*(k + 1) to account for rounding.
+        //     (k + 0.5)^2 == k*k + 2*k*0.5 + 0.5^2 == k*k + k + 0.25 ==approx. k*(k + 1)
+        int y_term_limit = thickness * (thickness + 1);
+        if (FontInfo::kRounded == style)
+            y_term_limit -= x_diff * x_diff;
+
+        // extend the outline stencil to the top and bottom
+        for (int y_diff = largest_y_diff_reached_so_far + 1; 
+            y_diff <= thickness && y_diff * y_diff  <= y_term_limit; 
+            y_diff++)
+        {
+            outline_stencil->Blit(texx_stencil, 0, thickness - y_diff, AGS::Common::kBitmap_Transparency);
+            if (y_diff > 0)
+                outline_stencil->Blit(texx_stencil, 0, thickness + y_diff, AGS::Common::kBitmap_Transparency);
+            largest_y_diff_reached_so_far = y_diff;
+        }
+
+        // stamp the outline stencil to the left and right of the text
+        ds->Blit(outline_stencil, xxp - x_diff, outline_y, AGS::Common::kBitmap_Transparency);
+        if (x_diff > 0)
+            ds->Blit(outline_stencil, xxp + x_diff, outline_y, AGS::Common::kBitmap_Transparency);
+    }
+ 
+    delete texx_stencil;
+    delete outline_stencil;
+}
+
+// Draw an outline if requested, then draw the text on top 
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int font, color_t text_color, const char *texx) 
+{    
+    size_t const text_font = static_cast<size_t>(font);
+    // Draw outline (a backdrop) if requested
+    color_t const outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
+    int const outline_font = get_font_outline(font);
+    if (outline_font >= 0)
+        wouttextxy(ds, xxp, yyp, static_cast<size_t>(outline_font), outline_color, texx);
+    else if (outline_font == FONT_OUTLINE_AUTO)
+        wouttextxy_AutoOutline(ds, text_font, outline_color, texx, xxp, yyp);
+    else
+        ; // no outline
+
+    // Draw text on top
+    wouttextxy(ds, xxp, yyp, text_font, text_color, texx);
+}
+
+void wouttext_aligned(Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align) {
 
     if (align & kMAlignHCenter)
         usexp = usexp + (oriwid / 2) - (wgettextwidth_compensate(text, usingfont) / 2);

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -479,14 +479,6 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
 
     int thickness = game.fonts.at(font).AutoOutlineThickness;
     auto style = game.fonts.at(font).AutoOutlineStyle;
-    if (0 == thickness)
-    {
-        // Thickness that corresponds to 1 game pixel
-        thickness =
-            (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
-            get_fixed_pixel_size(1) : 1;
-        style = FontInfo::kSquared;
-    }
     if (thickness <= 0)
         return; 
 

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -34,6 +34,7 @@ bool ShouldAntiAliasText();
 int GetTextDisplayLength(const char *text);
 // Calculates number of game loops for displaying a text on screen
 int GetTextDisplayTime(const char *text, int canberel = 0);
+// Draw an outline if requested, then draw the text on top 
 void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align);
 // TODO: GUI classes located in Common library do not make use of outlining,


### PR DESCRIPTION
So, let's try that again, this time without spurious commits (see https://github.com/adventuregamestudio/ags/pull/891#issuecomment-522176713).

Have a look: This is proposed code for issue #878 (automatic outlines).
Added two additional fields to fonts:
- `AutoOutlineStyle` (`Rounded`, `Squared`).
- `AutoOutlineThickness` (positive integer, or 0 for default) 
(I couldn't use "1" as the default for `AutoOutlineThickness` because currently, scaled bitmap fonts get an outline that is thicker than 1). 

The fields will only show in the editor if `OutlineStyle==Automatic`.
The field `OutlineFont` will now only show if `OutlineStyle==UseOutlineFont`.

The algo for generating the outline is based on messengerbag's. The text is only rendered _once_ per outline into a local bitmap; from then on, the bitmap is blitted repeatedly. Another local bitmap accumulates the vertical blits. In all, the number of blits is proportional to the thickness of the outline. 

For anti-aliased ttf fonts, a thickness of 2 to 3 seems to work nicely.

What do you think?
