### PR TITLE
Implemented basic functionality for --tell command

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -17,8 +17,9 @@
 
 #include "core/platform.h"
 
-#define EXIT_NORMAL 91
-#define EXIT_CRASH  92
+#define EXIT_NORMAL 0
+#define EXIT_ERROR  1
+#define EXIT_CRASH  2
 
 
 #if defined (OBSOLETE)

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -100,7 +100,8 @@ enum MessageType
     // Convenient aliases
     kDbgMsg_Default             = kDbgMsg_Debug,
     kDbgMsgSet_NoDebug          = 0x001D,
-    kDbgMsgSet_Errors           = 0x0019,
+    kDbgMsgSet_Errors           = 0x0018,
+    kDbgMsgSet_InitAndErrors    = 0x0019,
     // Output everything
     kDbgMsgSet_All              = 0xFFFF
 };

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -86,6 +86,26 @@ StrUtil::ConversionError StrUtil::StringToInt(const String &s, int &val, int def
     return StrUtil::kNoError;
 }
 
+String StrUtil::JsonEscape(const char *cstr)
+{
+    String s;
+    for (; *cstr; ++cstr)
+    {
+        switch (*cstr)
+        {
+        case '\b': s.Append("\\b"); break;
+        case '\f': s.Append("\\f"); break;
+        case '\n': s.Append("\\n"); break;
+        case '\r': s.Append("\\r"); break;
+        case '\t': s.Append("\\t"); break;
+        case '"': s.Append("\\\""); break;
+        case '\\': s.Append("\\\\"); break;
+        default: s.AppendChar(*cstr);
+        }
+    }
+    return s;
+}
+
 String StrUtil::ReadString(Stream *in)
 {
     size_t len = in->ReadInt32();

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -55,6 +55,10 @@ namespace StrUtil
     // def_val on failure
     ConversionError StringToInt(const String &s, int &val, int def_val);
 
+    // Creates a new string compliant to JSON key/value format;
+    // assumes that **EVERY** special symbol in the source string must be escaped
+    String          JsonEscape(const char *cstr);
+
     // Serialize and unserialize unterminated string prefixed with 32-bit length;
     // length is presented as 32-bit integer integer
     String          ReadString(Stream *in);

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -97,13 +97,20 @@ const String WarningFileID = "warnfile";
 const String OutputSystemID = "stderr";
 const String OutputGameConsoleID = "console";
 
-void init_debug()
+void init_debug(bool stderr_only)
 {
     // Register outputs
+    if (stderr_only)
+    {
+        PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
+        std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_Errors);
+        AGSPlatformDriver::SetOutputToErr(true);
+        return;
+    }
     DebugMsgBuff.reset(new MessageBuffer());
     DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsgSet_All);
     PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_Errors);
+    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_InitAndErrors);
 }
 
 void apply_debug_config(const ConfigTree &cfg)
@@ -115,13 +122,13 @@ void apply_debug_config(const ConfigTree &cfg)
 #ifdef DEBUG_SPRITECACHE
         file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_InitAndErrors);
 #endif
-        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_InitAndErrors);
 #ifdef DEBUG_MANAGED_OBJECTS
         file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_InitAndErrors);
 #endif
         String logfile_path = platform->GetAppOutputDirectory();
         logfile_path.Append("/ags.log");
@@ -173,7 +180,7 @@ void debug_set_console(bool enable)
     if (enable && DebugConsole.get() == nullptr)
     {
         DebugConsole.reset(new ConsoleOutputTarget());
-        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_Errors);
+        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_InitAndErrors);
         gmcs_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_All);
         gmcs_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_All);
         if (DebugMsgBuff.get())

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -21,7 +21,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "util/ini_util.h"
 
-void init_debug();
+void init_debug(bool stderr_only);
 void apply_debug_config(const AGS::Common::ConfigTree &cfg);
 void shutdown_debug();
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1355,23 +1355,25 @@ bool engine_do_config(const String &exe_path, const ConfigTree &startup_opts)
 extern std::set<String> tellInfoKeys;
 inline static void json_make_block(String &full, const char *name, const char *block, const char *indent = "")
 {
-    if (full.GetLength() > 0 && full.GetLast() == '}')
-        full.AppendChar(',');
-    full.Append(String::FromFormat("%s\"%s\":%s{%s%s}", indent, name, indent, block, indent));
+    if (full.GetLength() > 0 && full.GetLast() != '\n' && full.GetLast() != '{')
+        full.Append(",\n");
+    full.Append(String::FromFormat("%s\"%s\": %s{\n%s\n%s}", indent, name, indent, block, indent));
 }
 
 inline static void json_make_entry(String &full, const char *key, const char *value, const char *indent = "")
 {
-    if (full.GetLength() > 0 && full.GetLast() != '{')
-        full.AppendChar(',');
-    full.Append(String::FromFormat("%s\"%s\":\"%s\"", indent, key, value));
+    if (full.GetLength() > 0 && full.GetLast() != '\n' && full.GetLast() != '{')
+        full.Append(",\n");
+    full.Append(String::FromFormat("%s\"%s\": \"%s\"", indent, key, value));
 }
 
 static void engine_print_info(const String &exe_path)
 {
     const auto &keys = tellInfoKeys;
     const bool all = keys.count("all") > 0;
-    String full = "{";
+    String full = "{\n";
+    const char *tab1 = "\t";
+    const char *tab2 = "\t\t";
     if (all || keys.count("config-meta"))
     {
         String name = StrUtil::JsonEscape(game.gamename);
@@ -1379,12 +1381,14 @@ static void engine_print_info(const String &exe_path)
         String gl_cfg_file = StrUtil::JsonEscape(find_user_global_cfg_file());
         String user_cfg_file = StrUtil::JsonEscape(find_user_cfg_file());
         String s;
-        json_make_entry(s, "gamename", name.GetCStr());
-        json_make_entry(s, "defaultconfig", def_cfg_file.GetCStr());
-        json_make_entry(s, "globalconfig", gl_cfg_file.GetCStr());
-        json_make_entry(s, "userconfig", user_cfg_file.GetCStr());
-        json_make_block(full, "config-meta", s.GetCStr());
+        json_make_entry(s, "gamename", name.GetCStr(), tab2);
+        json_make_entry(s, "defaultconfig", def_cfg_file.GetCStr(), tab2);
+        json_make_entry(s, "globalconfig", gl_cfg_file.GetCStr(), tab2);
+        json_make_entry(s, "userconfig", user_cfg_file.GetCStr(), tab2);
+        json_make_block(full, "config-meta", s.GetCStr(), tab1);
     }
+    if (full.GetLength() > 2)
+        full.AppendChar('\n');
     full.AppendChar('}');
     platform->WriteStdOut("%s", full.GetCStr());
 }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1372,6 +1372,10 @@ static void engine_print_info(const String &exe_path)
     String full = "{\n";
     const char *tab1 = "\t";
     const char *tab2 = "\t\t";
+    {
+        json_make_entry(full, "enginename", get_engine_name(), tab1);
+        json_make_entry(full, "engineversion", get_engine_version(), tab1);
+    }
     if (all || keys.count("config-meta"))
     {
         String name = StrUtil::JsonEscape(game.gamename);
@@ -1612,6 +1616,11 @@ void engine_shutdown_gfxmode()
 
     engine_pre_gfxsystem_shutdown();
     graphics_mode_shutdown();
+}
+
+const char *get_engine_name()
+{
+    return "Adventure Game Studio run-time engine";
 }
 
 const char *get_engine_version() {

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -646,7 +646,6 @@ void engine_pre_init_gfx()
 int engine_load_game_data()
 {
     Debug::Printf("Load game data");
-
     our_eip=-17;
     HError err = load_game_file();
     if (!err)
@@ -654,10 +653,9 @@ int engine_load_game_data()
         proper_exit=1;
         platform->FinishedUsingGraphicsMode();
         display_game_file_error(err);
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
     }
-
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 int engine_check_register_game()
@@ -676,7 +674,7 @@ int engine_check_register_game()
         return EXIT_NORMAL;
     }
 
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 void engine_init_title()
@@ -781,10 +779,10 @@ int engine_check_disk_space()
     if (check_write_access()==0) {
         platform->DisplayAlert("Unable to write in the savegame directory.\n%s", platform->GetDiskWriteAccessTroubleshootingText());
         proper_exit = 1;
-        return EXIT_NORMAL; 
+        return EXIT_ERROR; 
     }
 
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 int engine_check_font_was_loaded()
@@ -793,10 +791,10 @@ int engine_check_font_was_loaded()
     {
         platform->DisplayAlert("No game fonts found. At least one font is required to run the game.");
         proper_exit = 1;
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
     }
 
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 void engine_init_modxm_player()
@@ -866,10 +864,10 @@ int engine_init_sprites()
         platform->DisplayAlert("Could not load sprite set file %s\n%s",
             SpriteCache::DefaultSpriteFileName.GetCStr(),
             err->FullMessage().GetCStr());
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
     }
 
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 void engine_init_game_settings()
@@ -1405,20 +1403,20 @@ int initialize_engine(const ConfigTree &startup_opts)
     //-----------------------------------------------------
     // Install backend
     if (!engine_init_allegro())
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
 
     //-----------------------------------------------------
     // Locate game data and assemble game config
     const String exe_path = global_argv[0];
     if (!engine_init_gamedata(exe_path))
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
     if (justTellInfo)
     {
         engine_print_info(exe_path);
         return EXIT_NORMAL;
     }
     if (!engine_do_config(exe_path, startup_opts))
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
     engine_setup_allegro();
     engine_force_window();
 
@@ -1482,31 +1480,27 @@ int initialize_engine(const ConfigTree &startup_opts)
     our_eip=-19;
 
     int res = engine_load_game_data();
-    if (res != RETURN_CONTINUE) {
+    if (res != 0)
         return res;
-    }
     
     res = engine_check_register_game();
-    if (res != RETURN_CONTINUE) {
+    if (res != 0)
         return res;
-    }
 
     engine_init_title();
 
     our_eip = -189;
 
     res = engine_check_disk_space();
-    if (res != RETURN_CONTINUE) {
+    if (res != 0)
         return res;
-    }
 
     // Make sure that at least one font was loaded in the process of loading
     // the game data.
     // TODO: Fold this check into engine_load_game_data()
     res = engine_check_font_was_loaded();
-    if (res != RETURN_CONTINUE) {
+    if (res != 0)
         return res;
-    }
 
     our_eip = -179;
 
@@ -1516,7 +1510,7 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     // Attempt to initialize graphics mode
     if (!engine_try_set_gfxmode_any(usetup.Screen))
-        return EXIT_NORMAL;
+        return EXIT_ERROR;
 
     SetMultitasking(0);
 
@@ -1527,9 +1521,8 @@ int initialize_engine(const ConfigTree &startup_opts)
     show_preload();
 
     res = engine_init_sprites();
-    if (res != RETURN_CONTINUE) {
+    if (res != 0)
         return res;
-    }
 
     engine_init_game_settings();
 
@@ -1540,7 +1533,7 @@ int initialize_engine(const ConfigTree &startup_opts)
     initialize_start_and_play_game(override_start_room, loadSaveGameOnStartup);
 
     quit("|bye!");
-    return 0;
+    return EXIT_NORMAL;
 }
 
 bool engine_try_set_gfxmode_any(const ScreenSetup &setup)

--- a/Engine/main/engine.h
+++ b/Engine/main/engine.h
@@ -16,6 +16,7 @@
 
 #include "util/ini_util.h"
 
+const char *get_engine_name();
 const char *get_engine_version();
 void        show_preload();
 void        engine_init_game_settings();

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -25,6 +25,7 @@
 #include "core/platform.h"
 #define AGS_PLATFORM_DEFINES_PSP_VARS (AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID)
 
+#include <set>
 #include "ac/common.h"
 #include "ac/gamesetup.h"
 #include "ac/gamestate.h"
@@ -82,6 +83,8 @@ bool justDisplayVersion = false;
 bool justRunSetup = false;
 bool justRegisterGame = false;
 bool justUnRegisterGame = false;
+bool justTellInfo = false;
+std::set<String> tellInfoKeys;
 const char *loadSaveGameOnStartup = nullptr;
 
 #if ! AGS_PLATFORM_DEFINES_PSP_VARS
@@ -275,6 +278,12 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             play.takeover_from[49] = 0;
             ee += 2;
         }
+        else if (ags_strnicmp(arg, "--tell", 6) == 0) {
+            if (arg[6] == 0)
+                tellInfoKeys.insert(String("all"));
+            else if (arg[6] == '-' && arg[7] != 0)
+                tellInfoKeys.insert(String(arg + 7));
+        }
         //
         // Config overrides
         //
@@ -324,6 +333,9 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         // assign standard path for mobile/consoles (defined in their own platform implementation)
         cmdGameDataPath = psp_game_file_name;
     }
+
+    if (tellInfoKeys.size() > 0)
+        justTellInfo = true;
 
     return RETURN_CONTINUE;
 }

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -418,6 +418,8 @@ int ags_entry_point(int argc, char *argv[]) {
         return EXIT_NORMAL;
     }
 
+    if (!justTellInfo)
+        platform->SetGUIMode(true);
     init_debug(justTellInfo);
     Debug::Printf(kDbgMsg_Init, get_engine_string());
 

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -428,7 +428,7 @@ int ags_entry_point(int argc, char *argv[]) {
         return 0;
     }
 
-    init_debug();
+    init_debug(justTellInfo);
     Debug::Printf(kDbgMsg_Init, get_engine_string());
 
     main_set_gamedir(argc, argv);    

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -44,6 +44,7 @@ extern int force_window;
 extern int override_start_room;
 extern bool justRegisterGame;
 extern bool justUnRegisterGame;
+extern bool justTellInfo;
 extern const char *loadSaveGameOnStartup;
 
 extern int psp_video_framedrop;

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -55,6 +55,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
   virtual void WriteStdOut(const char *fmt, ...);
+  virtual void WriteStdErr(const char *fmt, ...);
 };
 
 
@@ -714,6 +715,19 @@ void AGSAndroid::SetGameWindowIcon() {
 void AGSAndroid::WriteStdOut(const char *fmt, ...)
 {
   // TODO: this check should probably be done once when setting up output targets for logging
+  if (psp_debug_write_to_logcat)
+  {
+    va_list args;
+    va_start(args, fmt);
+    __android_log_vprint(ANDROID_LOG_DEBUG, "AGSNative", fmt, args);
+    // NOTE: __android_log_* functions add trailing '\n'
+    va_end(args);
+  }
+}
+
+void AGSAndroid::WriteStdErr(const char *fmt, ...)
+{
+  // TODO: find out if Android needs separate implementation for stderr
   if (psp_debug_write_to_logcat)
   {
     va_list args;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -42,6 +42,7 @@ const auto MaximumDelayBetweenPolling = std::chrono::milliseconds(16);
 
 AGSPlatformDriver* AGSPlatformDriver::instance = nullptr;
 bool AGSPlatformDriver::_logToStdErr = false;
+bool AGSPlatformDriver::_guiMode = false;
 AGSPlatformDriver *platform = nullptr;
 
 // ******** DEFAULT IMPLEMENTATIONS *******

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -41,6 +41,7 @@ using namespace AGS::Engine;
 const auto MaximumDelayBetweenPolling = std::chrono::milliseconds(16);
 
 AGSPlatformDriver* AGSPlatformDriver::instance = nullptr;
+bool AGSPlatformDriver::_logToStdErr = false;
 AGSPlatformDriver *platform = nullptr;
 
 // ******** DEFAULT IMPLEMENTATIONS *******
@@ -94,6 +95,16 @@ void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
     fflush(stdout);
 }
 
+void AGSPlatformDriver::WriteStdErr(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+    fflush(stdout);
+}
+
 void AGSPlatformDriver::YieldCPU() {
     // NOTE: this is called yield, but if we actually yield instead of delay,
     // we get a massive increase in CPU usage.
@@ -136,10 +147,20 @@ void AGSPlatformDriver::UnlockMouse() { }
 //-----------------------------------------------
 void AGSPlatformDriver::PrintMessage(const Common::DebugMessage &msg)
 {
-    if (msg.GroupName.IsEmpty())
-        WriteStdOut("%s", msg.Text.GetCStr());
+    if (_logToStdErr)
+    {
+        if (msg.GroupName.IsEmpty())
+            WriteStdErr("%s", msg.Text.GetCStr());
+        else
+            WriteStdErr("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    }
     else
-        WriteStdOut("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    {
+        if (msg.GroupName.IsEmpty())
+            WriteStdOut("%s", msg.Text.GetCStr());
+        else
+            WriteStdOut("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    }
 }
 
 // ********** CD Player Functions common to Win and Linux ********

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -92,6 +92,9 @@ struct AGSPlatformDriver
     // Formats message and writes to standard platform's output;
     // Always adds trailing '\n' after formatted string
     virtual void WriteStdOut(const char *fmt, ...);
+    // Formats message and writes to platform's error output;
+    // Always adds trailing '\n' after formatted string
+    virtual void WriteStdErr(const char *fmt, ...);
     virtual void YieldCPU();
     // Called when the game window is being switch out from
     virtual void DisplaySwitchOut();
@@ -126,12 +129,22 @@ struct AGSPlatformDriver
     virtual void UnlockMouse();
 
     static AGSPlatformDriver *GetDriver();
+    // Set whether PrintMessage should output to stdout or stderr
+    static void SetOutputToErr(bool on) { _logToStdErr = on; }
 
     //-----------------------------------------------
     // IOutputHandler implementation
     //-----------------------------------------------
     // Writes to the standard platform's output, prepending "AGS: " prefix to the message
     void PrintMessage(const AGS::Common::DebugMessage &msg) override;
+
+protected:
+    // TODO: this is a quick solution for IOutputHandler implementation
+    // logging either to stdout or stderr. Normally there should be
+    // separate implementation, one for each kind of output, but
+    // with both going through PlatformDriver need to figure a better
+    // design first.
+    static bool _logToStdErr;
 
 private:
     static AGSPlatformDriver *instance;

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -131,6 +131,9 @@ struct AGSPlatformDriver
     static AGSPlatformDriver *GetDriver();
     // Set whether PrintMessage should output to stdout or stderr
     static void SetOutputToErr(bool on) { _logToStdErr = on; }
+    // Set whether DisplayAlert is allowed to show modal GUIs on some systems;
+    // it will print to either stdout or stderr otherwise, depending on above flag
+    static void SetGUIMode(bool on) { _guiMode = on; }
 
     //-----------------------------------------------
     // IOutputHandler implementation
@@ -145,6 +148,9 @@ protected:
     // with both going through PlatformDriver need to figure a better
     // design first.
     static bool _logToStdErr;
+    // Defines whether engine is allowed to display important warnings
+    // and errors by showing a message box kind of GUI.
+    static bool _guiMode;
 
 private:
     static AGSPlatformDriver *instance;

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -73,7 +73,10 @@ void AGSLinux::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  printf("%s\n", displbuf);
+  if (_logToStdErr)
+    fprintf(stderr, "%s\n", displbuf);
+  else
+    fprintf(stdout, "%s\n", displbuf);
 }
 
 size_t BuildXDGPath(char *destPath, size_t destSize)

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -78,7 +78,10 @@ void AGSMac::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  printf("%s\n", displbuf);
+  if (_logToStdErr)
+    fprintf(stderr, "%s\n", displbuf);
+  else
+    fprintf(stdout, "%s\n", displbuf);
 }
 
 unsigned long AGSMac::GetDiskFreeSpaceMB() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -830,7 +830,12 @@ void AGSWin32::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  MessageBox(win_get_window(), displbuf, "Adventure Game Studio", MB_OK | MB_ICONEXCLAMATION);
+  if (_guiMode)
+    MessageBox(win_get_window(), displbuf, "Adventure Game Studio", MB_OK | MB_ICONEXCLAMATION);
+  else if (_logToStdErr)
+    AGSWin32::WriteStdErr("%s", displbuf);
+  else
+    AGSWin32::WriteStdOut("%s", displbuf);
 }
 
 int AGSWin32::GetLastSystemError()

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -119,6 +119,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
   virtual void WriteStdOut(const char *fmt, ...);
+  virtual void WriteStdErr(const char *fmt, ...);
   virtual void DisplaySwitchOut();
   virtual void DisplaySwitchIn();
   virtual void PauseApplication();
@@ -977,6 +978,26 @@ void AGSWin32::WriteStdOut(const char *fmt, ...) {
   {
     vprintf(fmt, ap);
     printf("\n");
+  }
+  va_end(ap);
+}
+
+void AGSWin32::WriteStdErr(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  if (_isDebuggerPresent)
+  {
+    // Add "AGS:" prefix when outputting to debugger, to make it clear that this
+    // is a text from the program log
+    char buf[STD_BUFFER_SIZE] = "AGS ERR: ";
+    vsnprintf(buf + 9, STD_BUFFER_SIZE - 9, fmt, ap);
+    OutputDebugString(buf);
+    OutputDebugString("\n");
+  }
+  else
+  {
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
   }
   va_end(ap);
 }


### PR DESCRIPTION
For #520

* Engine detects command line arguments starting with `--tell-`, the suffixes are stored in a set as keys.
* If there was at least one such argument, engine will print out requested info to std out and stop. Because some of this info requires data from the game header, printing is done after game files were found and pre-read.
* Information is printed out in JSON format and may contain multiple key/value pairs and groups of those.

TODO and potential issues:
* **[DONE]** Engine prints some other messages to std out, such as its name and version, game location and version, maybe some warnings and errors. Should these be suppressed to simplify parsing for external process?
* **[DONE]** Need to detect early whether it is required to read game at all, because some of the info may not need that (like, if we need to print only list of supported gfx drivers);
* Need to figure out good names for the keys. I called implemented one "config-meta" because it contains settings that help to find and work with config, but maybe there are better alternatives.
* Implement a minimal necessary set of info keys, as noted in #520.