### PR TITLE
Implemented basic functionality for --tell command (take 2, INI version)

### DIFF
--- a/Common/ac/common_defines.h
+++ b/Common/ac/common_defines.h
@@ -17,8 +17,9 @@
 
 #include "core/platform.h"
 
-#define EXIT_NORMAL 91
-#define EXIT_CRASH  92
+#define EXIT_NORMAL 0
+#define EXIT_ERROR  1
+#define EXIT_CRASH  2
 
 
 #if defined (OBSOLETE)

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -61,6 +61,7 @@ struct GameSetupStruct: public GameSetupStructBase {
     // TODO: why we do not use this in the engine instead of
     // loaded_game_file_version?
     int               filever;  // just used by editor
+    Common::String    compiled_with; // version of AGS this data was created by
     char              lipSyncFrameLetters[MAXLIPSYNCFRAMES][50];
     AGS::Common::PropertySchema propSchema;
     std::vector<AGS::Common::StringIMap> charProps;

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -100,7 +100,8 @@ enum MessageType
     // Convenient aliases
     kDbgMsg_Default             = kDbgMsg_Debug,
     kDbgMsgSet_NoDebug          = 0x001D,
-    kDbgMsgSet_Errors           = 0x0019,
+    kDbgMsgSet_Errors           = 0x0018,
+    kDbgMsgSet_InitAndErrors    = 0x0019,
     // Output everything
     kDbgMsgSet_All              = 0xFFFF
 };

--- a/Common/util/ini_util.cpp
+++ b/Common/util/ini_util.cpp
@@ -96,6 +96,23 @@ void IniUtil::Write(const String &file, const ConfigTree &tree)
     writer.ReleaseStream();
 }
 
+void IniUtil::WriteToString(String &s, const ConfigTree &tree)
+{
+    for (ConfigNode it_sec = tree.begin(); it_sec != tree.end(); ++it_sec)
+    {
+        const String &sec_key = it_sec->first;
+        const StringOrderMap &sec_tree = it_sec->second;
+        if (!sec_tree.size())
+            continue; // skip empty sections
+        // write section name
+        if (!sec_key.IsEmpty())
+            s.Append(String::FromFormat("[%s]\n", sec_key.GetCStr()));
+        // write all items
+        for (StrStrOIter keyval = sec_tree.begin(); keyval != sec_tree.end(); ++keyval)
+            s.Append(String::FromFormat("%s = %s\n", keyval->first.GetCStr(), keyval->second.GetCStr()));
+    }
+}
+
 bool IniUtil::Merge(const String &file, const ConfigTree &tree)
 {
     // Read ini content

--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -44,6 +44,10 @@ namespace IniUtil
     // The first level values are treated as a global section items.
     // The sub-nodes beyond 2nd level are ignored completely.
     void Write(const String &file, const ConfigTree &tree);
+    // Serialize given tree to the string in INI text format.
+    // TODO: implement proper memory/string stream compatible with base Stream
+    // class and merge this with Write function.
+    void WriteToString(String &s, const ConfigTree &tree);
     // Parse the contents of given source stream as INI format and merge
     // with values of the given tree while doing only minimal replaces;
     // write the result into destination stream.

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -97,13 +97,20 @@ const String WarningFileID = "warnfile";
 const String OutputSystemID = "stderr";
 const String OutputGameConsoleID = "console";
 
-void init_debug()
+void init_debug(bool stderr_only)
 {
     // Register outputs
+    if (stderr_only)
+    {
+        PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
+        std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_Errors);
+        AGSPlatformDriver::SetOutputToErr(true);
+        return;
+    }
     DebugMsgBuff.reset(new MessageBuffer());
     DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsgSet_All);
     PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_Errors);
+    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_InitAndErrors);
 }
 
 void apply_debug_config(const ConfigTree &cfg)
@@ -115,13 +122,13 @@ void apply_debug_config(const ConfigTree &cfg)
 #ifdef DEBUG_SPRITECACHE
         file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_InitAndErrors);
 #endif
-        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_InitAndErrors);
 #ifdef DEBUG_MANAGED_OBJECTS
         file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_Errors);
+        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_InitAndErrors);
 #endif
         String logfile_path = platform->GetAppOutputDirectory();
         logfile_path.Append("/ags.log");
@@ -173,7 +180,7 @@ void debug_set_console(bool enable)
     if (enable && DebugConsole.get() == nullptr)
     {
         DebugConsole.reset(new ConsoleOutputTarget());
-        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_Errors);
+        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_InitAndErrors);
         gmcs_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_All);
         gmcs_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_All);
         if (DebugMsgBuff.get())

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -21,7 +21,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "util/ini_util.h"
 
-void init_debug();
+void init_debug(bool stderr_only);
 void apply_debug_config(const AGS::Common::ConfigTree &cfg);
 void shutdown_debug();
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -54,6 +54,7 @@
 #include "font/agsfontrenderer.h"
 #include "font/fonts.h"
 #include "gfx/graphicsdriver.h"
+#include "gfx/gfxdriverfactory.h"
 #include "gfx/ddb.h"
 #include "main/config.h"
 #include "main/game_file.h"
@@ -1367,6 +1368,15 @@ static void engine_print_info(const std::set<String> &keys, const String &exe_pa
     {
         data["engine"]["name"] = get_engine_name();
         data["engine"]["version"] = get_engine_version();
+    }
+    if (all || keys.count("graphicdriver") > 0)
+    {
+        StringV drv;
+        AGS::Engine::GetGfxDriverFactoryNames(drv);
+        for (size_t i = 0; i < drv.size(); ++i)
+        {
+            data["graphicdriver"][String::FromFormat("%u", i)] = drv[i];
+        }
     }
     if (all || keys.count("configpath") > 0)
     {

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1357,7 +1357,8 @@ void engine_set_config(const ConfigTree cfg)
 extern std::set<String> tellInfoKeys;
 static bool print_info_needs_game(const std::set<String> &keys)
 {
-    return keys.count("all") > 0 || keys.count("config") > 0 || keys.count("configpath") > 0;
+    return keys.count("all") > 0 || keys.count("config") > 0 || keys.count("configpath") > 0 ||
+        keys.count("data") > 0;
 }
 
 static void engine_print_info(const std::set<String> &keys, const String &exe_path, ConfigTree *user_cfg)
@@ -1383,7 +1384,6 @@ static void engine_print_info(const std::set<String> &keys, const String &exe_pa
         String def_cfg_file = find_default_cfg_file(exe_path);
         String gl_cfg_file = find_user_global_cfg_file();
         String user_cfg_file = find_user_cfg_file();
-        data["config-path"]["gamename"] = game.gamename;
         data["config-path"]["default"] = def_cfg_file;
         data["config-path"]["global"] = gl_cfg_file;
         data["config-path"]["user"] = user_cfg_file;
@@ -1396,6 +1396,13 @@ static void engine_print_info(const std::set<String> &keys, const String &exe_pa
             for (const auto &opt : sectn.second)
                 data[cfg_sectn][opt.first] = opt.second;
         }
+    }
+    if (all || keys.count("data") > 0)
+    {
+        data["data"]["gamename"] = game.gamename;
+        data["data"]["version"] = String::FromFormat("%d", loaded_game_file_version);
+        data["data"]["compiledwith"] = game.compiled_with;
+        data["data"]["basepack"] = usetup.main_data_filepath;
     }
     String full;
     IniUtil::WriteToString(full, data);

--- a/Engine/main/engine.h
+++ b/Engine/main/engine.h
@@ -16,6 +16,7 @@
 
 #include "util/ini_util.h"
 
+const char *get_engine_name();
 const char *get_engine_version();
 void        show_preload();
 void        engine_init_game_settings();

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -130,6 +130,7 @@ HError preload_game_data()
         return (HError)err;
     // Read only the particular data we need for preliminary game analysis
     PreReadSaveFileInfo(src.InputStream.get(), src.DataVersion);
+    game.compiled_with = src.CompiledWith;
     FixupSaveDirectory(game);
     return HError::None();
 }

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -25,6 +25,7 @@
 #include "core/platform.h"
 #define AGS_PLATFORM_DEFINES_PSP_VARS (AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID)
 
+#include <set>
 #include "ac/common.h"
 #include "ac/gamesetup.h"
 #include "ac/gamestate.h"
@@ -82,6 +83,8 @@ bool justDisplayVersion = false;
 bool justRunSetup = false;
 bool justRegisterGame = false;
 bool justUnRegisterGame = false;
+bool justTellInfo = false;
+std::set<String> tellInfoKeys;
 const char *loadSaveGameOnStartup = nullptr;
 
 #if ! AGS_PLATFORM_DEFINES_PSP_VARS
@@ -274,6 +277,12 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             play.takeover_from[49] = 0;
             ee += 2;
         }
+        else if (ags_strnicmp(arg, "--tell", 6) == 0) {
+            if (arg[6] == 0)
+                tellInfoKeys.insert(String("all"));
+            else if (arg[6] == '-' && arg[7] != 0)
+                tellInfoKeys.insert(String(arg + 7));
+        }
         //
         // Config overrides
         //
@@ -323,6 +332,9 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         // assign standard path for mobile/consoles (defined in their own platform implementation)
         cmdGameDataPath = psp_game_file_name;
     }
+
+    if (tellInfoKeys.size() > 0)
+        justTellInfo = true;
 
     return 0;
 }
@@ -407,7 +419,9 @@ int ags_entry_point(int argc, char *argv[]) {
         return EXIT_NORMAL;
     }
 
-    init_debug(false);
+    if (!justTellInfo)
+        platform->SetGUIMode(true);
+    init_debug(justTellInfo);
     Debug::Printf(kDbgMsg_Init, get_engine_string());
 
     main_set_gamedir(argc, argv);    

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -195,6 +195,13 @@ void main_print_help() {
 #if AGS_PLATFORM_OS_WINDOWS
            "  --setup                      Run setup application\n"
 #endif
+           "  --tell                       Print various information concerning engine\n"
+           "                                 and the game; for selected output use:\n"
+           "  --tell-config                Print contents of game config\n"
+           "  --tell-configpath            Print paths to available config files\n"
+           "  --tell-engine                Print engine name and version\n"
+           "  --tell-graphicdriver         Print list of supported graphic drivers\n"
+           "\n"
            "  --version                    Print engine's version and stop\n"
            "  --windowed                   Force display mode to windowed\n"
            "\n"

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -135,7 +135,7 @@ AGS::Common::Version SavedgameLowestBackwardCompatVersion;
 // Lowest engine version, which would accept current savedgames
 AGS::Common::Version SavedgameLowestForwardCompatVersion;
 
-void main_init()
+void main_init(int argc, char*argv[])
 {
     EngineVersion = Version(ACI_VERSION_STR " " SPECIAL_VERSION);
 #if defined (BUILD_STR)
@@ -147,6 +147,9 @@ void main_init()
     Common::AssetManager::CreateInstance();
     main_pre_init();
     main_create_platform_driver();
+
+    global_argv = argv;
+    global_argc = argc;
 }
 
 String get_engine_string()
@@ -159,13 +162,6 @@ String get_engine_string()
 #else
         "ACI version %s\n", EngineVersion.ShortString.GetCStr(), EngineVersion.LongString.GetCStr());
 #endif
-}
-
-int main_preprocess_cmdline(int argc,char*argv[])
-{
-    global_argv = argv;
-    global_argc = argc;
-    return RETURN_CONTINUE;
 }
 
 extern char return_to_roomedit[30];
@@ -218,10 +214,13 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         if (ags_stricmp(arg,"--help") == 0 || ags_stricmp(arg,"/?") == 0 || ags_stricmp(arg,"-?") == 0)
         {
             justDisplayHelp = true;
-            return RETURN_CONTINUE;
+            return 0;
         }
-        if (ags_stricmp(arg,"-v") == 0 || ags_stricmp(arg,"--version") == 0)
+        if (ags_stricmp(arg, "-v") == 0 || ags_stricmp(arg, "--version") == 0)
+        {
             justDisplayVersion = true;
+            return 0;
+        }
         else if (ags_stricmp(arg,"-updatereg") == 0)
             debug_flags |= DBG_REGONLY;
 #if AGS_PLATFORM_DEBUG
@@ -325,7 +324,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         cmdGameDataPath = psp_game_file_name;
     }
 
-    return RETURN_CONTINUE;
+    return 0;
 }
 
 void main_set_gamedir(int argc, char*argv[])
@@ -384,14 +383,7 @@ int ags_entry_point(int argc, char *argv[]) {
 #if AGS_PLATFORM_DEBUG
     Test_DoAllTests();
 #endif
-    
-    int res;
-    main_init();
-    
-    res = main_preprocess_cmdline(argc, argv);
-    if (res != RETURN_CONTINUE) {
-        return res;
-    }
+    main_init(argc, argv);
 
 #if AGS_PLATFORM_OS_WINDOWS
     setup_malloc_handling();
@@ -399,21 +391,20 @@ int ags_entry_point(int argc, char *argv[]) {
     debug_flags=0;
 
     ConfigTree startup_opts;
-    res = main_process_cmdline(startup_opts, argc, argv);
-    if (res != RETURN_CONTINUE) {
+    int res = main_process_cmdline(startup_opts, argc, argv);
+    if (res != 0)
         return res;
-    }
 
     if (justDisplayVersion)
     {
         platform->WriteStdOut(get_engine_string());
-        return 0;
+        return EXIT_NORMAL;
     }
 
     if (justDisplayHelp)
     {
         main_print_help();
-        return 0;
+        return EXIT_NORMAL;
     }
 
     init_debug(false);
@@ -423,7 +414,7 @@ int ags_entry_point(int argc, char *argv[]) {
 
     // Update shell associations and exit
     if (debug_flags & DBG_REGONLY)
-        exit(0);
+        exit(EXIT_NORMAL);
 
 #ifdef USE_CUSTOM_EXCEPTION_HANDLER
     if (usetup.disable_exception_handling)

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -199,6 +199,7 @@ void main_print_help() {
            "                                 and the game; for selected output use:\n"
            "  --tell-config                Print contents of game config\n"
            "  --tell-configpath            Print paths to available config files\n"
+           "  --tell-data                  Print information on game data and its location\n"
            "  --tell-engine                Print engine name and version\n"
            "  --tell-graphicdriver         Print list of supported graphic drivers\n"
            "\n"

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -416,7 +416,7 @@ int ags_entry_point(int argc, char *argv[]) {
         return 0;
     }
 
-    init_debug();
+    init_debug(false);
     Debug::Printf(kDbgMsg_Init, get_engine_string());
 
     main_set_gamedir(argc, argv);    

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -44,6 +44,7 @@ extern int force_window;
 extern int override_start_room;
 extern bool justRegisterGame;
 extern bool justUnRegisterGame;
+extern bool justTellInfo;
 extern const char *loadSaveGameOnStartup;
 
 extern int psp_video_framedrop;

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -55,6 +55,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
   virtual void WriteStdOut(const char *fmt, ...);
+  virtual void WriteStdErr(const char *fmt, ...);
 };
 
 
@@ -714,6 +715,19 @@ void AGSAndroid::SetGameWindowIcon() {
 void AGSAndroid::WriteStdOut(const char *fmt, ...)
 {
   // TODO: this check should probably be done once when setting up output targets for logging
+  if (psp_debug_write_to_logcat)
+  {
+    va_list args;
+    va_start(args, fmt);
+    __android_log_vprint(ANDROID_LOG_DEBUG, "AGSNative", fmt, args);
+    // NOTE: __android_log_* functions add trailing '\n'
+    va_end(args);
+  }
+}
+
+void AGSAndroid::WriteStdErr(const char *fmt, ...)
+{
+  // TODO: find out if Android needs separate implementation for stderr
   if (psp_debug_write_to_logcat)
   {
     va_list args;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -42,6 +42,7 @@ const auto MaximumDelayBetweenPolling = std::chrono::milliseconds(16);
 
 AGSPlatformDriver* AGSPlatformDriver::instance = nullptr;
 bool AGSPlatformDriver::_logToStdErr = false;
+bool AGSPlatformDriver::_guiMode = false;
 AGSPlatformDriver *platform = nullptr;
 
 // ******** DEFAULT IMPLEMENTATIONS *******

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -41,6 +41,7 @@ using namespace AGS::Engine;
 const auto MaximumDelayBetweenPolling = std::chrono::milliseconds(16);
 
 AGSPlatformDriver* AGSPlatformDriver::instance = nullptr;
+bool AGSPlatformDriver::_logToStdErr = false;
 AGSPlatformDriver *platform = nullptr;
 
 // ******** DEFAULT IMPLEMENTATIONS *******
@@ -94,6 +95,16 @@ void AGSPlatformDriver::WriteStdOut(const char *fmt, ...) {
     fflush(stdout);
 }
 
+void AGSPlatformDriver::WriteStdErr(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+    fflush(stdout);
+}
+
 void AGSPlatformDriver::YieldCPU() {
     // NOTE: this is called yield, but if we actually yield instead of delay,
     // we get a massive increase in CPU usage.
@@ -136,10 +147,20 @@ void AGSPlatformDriver::UnlockMouse() { }
 //-----------------------------------------------
 void AGSPlatformDriver::PrintMessage(const Common::DebugMessage &msg)
 {
-    if (msg.GroupName.IsEmpty())
-        WriteStdOut("%s", msg.Text.GetCStr());
+    if (_logToStdErr)
+    {
+        if (msg.GroupName.IsEmpty())
+            WriteStdErr("%s", msg.Text.GetCStr());
+        else
+            WriteStdErr("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    }
     else
-        WriteStdOut("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    {
+        if (msg.GroupName.IsEmpty())
+            WriteStdOut("%s", msg.Text.GetCStr());
+        else
+            WriteStdOut("%s : %s", msg.GroupName.GetCStr(), msg.Text.GetCStr());
+    }
 }
 
 // ********** CD Player Functions common to Win and Linux ********

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -92,6 +92,9 @@ struct AGSPlatformDriver
     // Formats message and writes to standard platform's output;
     // Always adds trailing '\n' after formatted string
     virtual void WriteStdOut(const char *fmt, ...);
+    // Formats message and writes to platform's error output;
+    // Always adds trailing '\n' after formatted string
+    virtual void WriteStdErr(const char *fmt, ...);
     virtual void YieldCPU();
     // Called when the game window is being switch out from
     virtual void DisplaySwitchOut();
@@ -126,12 +129,22 @@ struct AGSPlatformDriver
     virtual void UnlockMouse();
 
     static AGSPlatformDriver *GetDriver();
+    // Set whether PrintMessage should output to stdout or stderr
+    static void SetOutputToErr(bool on) { _logToStdErr = on; }
 
     //-----------------------------------------------
     // IOutputHandler implementation
     //-----------------------------------------------
     // Writes to the standard platform's output, prepending "AGS: " prefix to the message
     void PrintMessage(const AGS::Common::DebugMessage &msg) override;
+
+protected:
+    // TODO: this is a quick solution for IOutputHandler implementation
+    // logging either to stdout or stderr. Normally there should be
+    // separate implementation, one for each kind of output, but
+    // with both going through PlatformDriver need to figure a better
+    // design first.
+    static bool _logToStdErr;
 
 private:
     static AGSPlatformDriver *instance;

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -131,6 +131,9 @@ struct AGSPlatformDriver
     static AGSPlatformDriver *GetDriver();
     // Set whether PrintMessage should output to stdout or stderr
     static void SetOutputToErr(bool on) { _logToStdErr = on; }
+    // Set whether DisplayAlert is allowed to show modal GUIs on some systems;
+    // it will print to either stdout or stderr otherwise, depending on above flag
+    static void SetGUIMode(bool on) { _guiMode = on; }
 
     //-----------------------------------------------
     // IOutputHandler implementation
@@ -145,6 +148,9 @@ protected:
     // with both going through PlatformDriver need to figure a better
     // design first.
     static bool _logToStdErr;
+    // Defines whether engine is allowed to display important warnings
+    // and errors by showing a message box kind of GUI.
+    static bool _guiMode;
 
 private:
     static AGSPlatformDriver *instance;

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -73,7 +73,10 @@ void AGSLinux::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  printf("%s\n", displbuf);
+  if (_logToStdErr)
+    fprintf(stderr, "%s\n", displbuf);
+  else
+    fprintf(stdout, "%s\n", displbuf);
 }
 
 size_t BuildXDGPath(char *destPath, size_t destSize)

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -78,7 +78,10 @@ void AGSMac::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  printf("%s\n", displbuf);
+  if (_logToStdErr)
+    fprintf(stderr, "%s\n", displbuf);
+  else
+    fprintf(stdout, "%s\n", displbuf);
 }
 
 unsigned long AGSMac::GetDiskFreeSpaceMB() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -830,7 +830,12 @@ void AGSWin32::DisplayAlert(const char *text, ...) {
   va_start(ap, text);
   vsprintf(displbuf, text, ap);
   va_end(ap);
-  MessageBox(win_get_window(), displbuf, "Adventure Game Studio", MB_OK | MB_ICONEXCLAMATION);
+  if (_guiMode)
+    MessageBox(win_get_window(), displbuf, "Adventure Game Studio", MB_OK | MB_ICONEXCLAMATION);
+  else if (_logToStdErr)
+    AGSWin32::WriteStdErr("%s", displbuf);
+  else
+    AGSWin32::WriteStdOut("%s", displbuf);
 }
 
 int AGSWin32::GetLastSystemError()

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -119,6 +119,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
   virtual void WriteStdOut(const char *fmt, ...);
+  virtual void WriteStdErr(const char *fmt, ...);
   virtual void DisplaySwitchOut();
   virtual void DisplaySwitchIn();
   virtual void PauseApplication();
@@ -977,6 +978,26 @@ void AGSWin32::WriteStdOut(const char *fmt, ...) {
   {
     vprintf(fmt, ap);
     printf("\n");
+  }
+  va_end(ap);
+}
+
+void AGSWin32::WriteStdErr(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  if (_isDebuggerPresent)
+  {
+    // Add "AGS:" prefix when outputting to debugger, to make it clear that this
+    // is a text from the program log
+    char buf[STD_BUFFER_SIZE] = "AGS ERR: ";
+    vsnprintf(buf + 9, STD_BUFFER_SIZE - 9, fmt, ap);
+    OutputDebugString(buf);
+    OutputDebugString("\n");
+  }
+  else
+  {
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
   }
   va_end(ap);
 }


### PR DESCRIPTION
For #520 (attempt 2)

* Engine detects command line arguments starting with `--tell-`, the suffixes are stored in a set as keys.
* If there was at least one such argument, engine will print out requested info to std out and stop. Because some of this info requires data from the game header, printing is done after game files were found and pre-read.
* Information is printed out in INI format, just like the game config, and may contain multiple sections of key/value pairs.
* This is not very common for INI, but currently the output also has "nested" sections which are indicated by '@' character(s) in their names. This is currently used to group number of sections together and give an extra leeway in avoiding possible naming conflicts in the future. The main reason for this addition was that one of the supported commands is "--tell-config" that prints all the parsed user config, which contains multiple sections on its own.

TODO and potential issues:
* **[DONE]** Engine prints some other messages to std out, such as its name and version, game location and version, maybe some warnings and errors. Should these be suppressed to simplify parsing for external process?
* **[DONE]** Need to detect early whether it is required to read game at all, because some of the info may not need that (like, if we need to print only list of supported gfx drivers);
* **[sort of]** Need to figure out good names for the keys.
* **[DONE]** Implement a minimal necessary set of info keys, as noted in #520.

Currently supported keys:
* --tell or --tell-all: prints everything;
* --tell-config: prints config (must locate game data and parse user config)
* --tell-configpath: prints paths to all 3 configs (default, global and user) and other info necessary to locate these (like game name - to find user data dirs).
* --tell-graphicdrivers: list of supported gfx drivers.