### PR TITLE
Updates to script file remapping and path token rule

### DIFF
--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -533,7 +533,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_NATIVECOORDINATES] = (game.Settings.UseLowResCoordinatesInScript ? 0 : 1);
             options[NativeConstants.GameOptions.OPT_WALKONLOOK] = (game.Settings.WalkInLookMode ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_DISABLEOFF] = (int)game.Settings.WhenInterfaceDisabled;
-            options[NativeConstants.GameOptions.OPT_SAFEFILEPATHS] = 1; // always use safe file paths in new games
+            options[NativeConstants.GameOptions.OPT_SAFEFILEPATHS] = 2; // always use safe file paths and require dir token
             options[NativeConstants.GameOptions.OPT_DIALOGOPTIONSAPI] = (game.Settings.UseOldCustomDialogOptionsAPI ? -1 : 1);
             options[NativeConstants.GameOptions.OPT_BASESCRIPTAPI] = (int)game.Settings.ScriptAPIVersionReal;
             options[NativeConstants.GameOptions.OPT_SCRIPTCOMPATLEV] = (int)game.Settings.ScriptCompatLevelReal;

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -323,15 +323,18 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
 
         // For games which were made without having safe paths in mind,
         // provide two paths: a path to the local directory and a path to
-        // AppData directory.
+        // safe writeable directory (aka user path).
         // This is done in case game writes a file by local path, and would
-        // like to read it back later. Since AppData path has higher priority,
-        // game will first check the AppData location and find a previously
+        // like to read it back later. Since user path has higher priority,
+        // game will first check the user location and find a previously
         // written file.
         // If no file was written yet, but game is trying to read a pre-created
         // file in the installation directory, then such file will be found
         // following the 'alt_path'.
-        parent_dir = MakeAppDataPath();
+        if (usetup.remap_installdir_to_shared)
+            parent_dir = MakeAppDataPath();
+        else
+            parent_dir = get_save_game_directory();
         // Set alternate non-remapped "unsafe" path for read-only operations
         if (read_only)
             alt_path = String::FromFormat("%s/%s", get_install_dir().GetCStr(), sc_path.GetCStr());

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -317,10 +317,14 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
         parent_dir = MakeAppDataPath();
         child_path = sc_path.Mid(GameDataDirToken.GetLength());
     }
+    else if(game.options[OPT_SAFEFILEPATHS] > 1)
+    {
+        debug_script_warn("Attempt to access file '%s' denied (path token not specified)", sc_path.GetCStr());
+        return false;
+    }
     else
     {
         child_path = sc_path;
-
         // For games which were made without having safe paths in mind,
         // provide two paths: a path to the local directory and a path to
         // safe writeable directory (aka user path).
@@ -338,14 +342,8 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
         // Set alternate non-remapped "unsafe" path for read-only operations
         if (read_only)
             alt_path = String::FromFormat("%s/%s", get_install_dir().GetCStr(), sc_path.GetCStr());
-
-        // For games made in the safe-path-aware versions of AGS, report a warning
-        // if the unsafe path is used for write operation
-        if (!read_only && game.options[OPT_SAFEFILEPATHS])
-        {
-            debug_script_warn("Attempt to access file '%s' denied (cannot write to game installation directory);\nPath will be remapped to the app data directory: '%s'",
-                sc_path.GetCStr(), parent_dir.GetCStr());
-        }
+        debug_script_warn("Attempt to access file '%s' denied (cannot write to game installation directory);\nPath will be remapped to the app data directory: '%s'",
+            sc_path.GetCStr(), parent_dir.GetCStr());
     }
 
     if (child_path[0u] == '\\' || child_path[0u] == '/')

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -25,6 +25,7 @@ GameSetup::GameSetup()
     enable_antialiasing = false;
     disable_exception_handling = false;
     mouse_auto_lock = false;
+    remap_installdir_to_shared = false;
     override_script_os = -1;
     override_multitasking = -1;
     override_upscale = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -61,6 +61,7 @@ struct GameSetup {
     String install_voice_dir; // optional custom install voice-over dir path
     String user_data_dir; // directory to write savedgames and user files to
     String shared_data_dir; // directory to write shared game files to
+    bool remap_installdir_to_shared; // remap writing in installdir to user or common path
     String translation;
     bool  mouse_auto_lock;
     int   override_script_os;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -600,6 +600,8 @@ void apply_config(const ConfigTree &cfg)
             usetup.override_script_os = eOS_Mac;
         }
         usetup.override_upscale = INIreadint(cfg, "override", "upscale") > 0;
+        if (INIreadstring(cfg, "override", "remap_installdir", "savegamedir").Compare("appdatadir") == 0)
+            usetup.remap_installdir_to_shared = true;
     }
 
     // Apply logging configuration


### PR DESCRIPTION
NOTE: path remapping is only done in backwards-compatibility mode - when running old games where script was opening files for writing in the game directory.

1. Introduced a config option that tells where to remap such file operations:
<pre>
[override]
remap_installdir = appdatadir; remaps to $APPDATADIR$
remap_installdir = savegamedir (or anything invalid); remaps to $SAVEGAMEDIR$
</pre>
Remapping is done to $SAVEGAMEDIR$ by default now.

2. Completely deny using paths without tokens since 3.5.0. In the past I let still use these, and for writing they were remapping to $APPDATADIR$ with a warning, but this behavior was not well understood and causing confusion, so was a mistake on my part.
So, considering this, and that remapping rules are now changing, I see no other good option than to require game developers explicitly point where they want to read and write files every time ($INSTALLDIR$, $SAVEGAMEDIR$ or $APPDATADIR$).