### PR TITLE
Editor: explicitly update room document's property list on character add/removal

### DIFF
--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -75,7 +75,7 @@ namespace AGS.Editor
             SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
 
             _layers.Add(new EdgesEditorFilter(bufferedPanel1, _room));
-            _characterLayer = new CharactersEditorFilter(bufferedPanel1, _room, Factory.AGSEditor.CurrentGame);
+            _characterLayer = new CharactersEditorFilter(bufferedPanel1, this, _room, Factory.AGSEditor.CurrentGame);
             _layers.Add(_characterLayer);
             _layers.Add(new ObjectsEditorFilter(bufferedPanel1, _room));
             _layers.Add(new HotspotsEditorFilter(bufferedPanel1, _room));

--- a/Editor/AGS.Types/EditorFeatures/ContentDocument.cs
+++ b/Editor/AGS.Types/EditorFeatures/ContentDocument.cs
@@ -44,6 +44,7 @@ namespace AGS.Types
             IEditorComponent owner, string iconKey)
 		{
 			_control = control;
+            _control.ContentDocument = this;
 			_name = name;
 			_owner = owner;
             _iconKey = iconKey;

--- a/Editor/AGS.Types/EditorFeatures/EditorContentPanel.cs
+++ b/Editor/AGS.Types/EditorFeatures/EditorContentPanel.cs
@@ -7,7 +7,8 @@ namespace AGS.Types
 {
 	public class EditorContentPanel : UserControl, IDisposable, IDockingContent
 	{
-        IDockingContainer _dockingContainer;        
+        IDockingContainer _dockingContainer;
+        ContentDocument _contentDocument;
 
         public EditorContentPanel()
 			: base()
@@ -18,6 +19,12 @@ namespace AGS.Types
         {
             get { return _dockingContainer; }
             set { _dockingContainer = value; }
+        }
+
+        public ContentDocument ContentDocument
+        {
+            get { return _contentDocument; }
+            set { _contentDocument = value; }
         }
 
         public void CommandClick(string command)


### PR DESCRIPTION
For #624.

There's a lot to say about how editor handles property grid, for a quick recap see sequential comments to this thread: https://github.com/adventuregamestudio/ags/pull/619#issuecomment-464797516

In short the editor's event system was built with the assumption that only 1 working pane will be open at same time and that this pane will have exclusive ownership on objects it edits. As development progressed which ceased being true, especially after AGS 3.2.2 where docking UI was added and since when you may have several working panes at the same time. And this conflicts with how property grid gets updated, which presumes that it needs to collect objects and properties from the *active pane*, while some actions may have effect on other panes at the background.

Anyhow, this PR contains a rather dirty hack where Characters Filter explicitly tells Room Editor to update its own property list, around the default callback that would instead do this in the active pane.

This solves the bug that occurs when you have character filter active in the room editor, then switch to character editor and change StartingRoom, adding or removing that char to/from the edited room. In such case the room's property list does not get updated and upon switching to room editor user will see wrong list of characters in the property grid.


**NOTE:** The alternative to this seem to be forced property list update (recollecting objects, etc) whenever user changes active pane (on focus). May this be a better solution? After all, property grid only reflects the active pane. Don't know how easy that would be to add such update into current system yet.