### PR TITLE
In Global Variables pane gather list of types from script header

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -388,6 +388,7 @@
     <EmbeddedResource Include="Resources\AGSFNT1.WFN" />
     <EmbeddedResource Include="Resources\AGSFNT2.WFN" />
     <Compile Include="Resources\ResourceManager.cs" />
+    <Compile Include="TextProcessing\APITypeDef.cs" />
     <Compile Include="Utils\AlternateStreams.cs" />
     <Compile Include="Utils\SourceControlProvider.cs" />
     <Compile Include="GUI\TabbedDocumentManager.cs">

--- a/Editor/AGS.Editor/GUI/GlobalVariableDialog.cs
+++ b/Editor/AGS.Editor/GUI/GlobalVariableDialog.cs
@@ -17,12 +17,12 @@ namespace AGS.Editor
         private GlobalVariable _variable;
         private Game _game;
 
-        public GlobalVariableDialog(GlobalVariable variable, Game game)
+        public GlobalVariableDialog(GlobalVariable variable, Game game, IEnumerable<APITypeDef> apiTypes)
         {
             InitializeComponent();
             _variable = variable;
             _game = game;
-            PopulateTypeList();
+            PopulateTypeList(apiTypes);
             txtName.Text = variable.Name ?? string.Empty;
             txtDefaultValue.Text = variable.DefaultValue ?? string.Empty;
 
@@ -38,25 +38,30 @@ namespace AGS.Editor
             Utilities.CheckLabelWidthsOnForm(this);
         }
 
-        private void PopulateTypeList()
+        private void PopulateTypeList(IEnumerable<APITypeDef> apiTypes)
         {
             cmbType.Items.Clear();
             cmbType.Items.Add(new GlobalVariableType("int", @"^\-?[0-9]+$"));
             cmbType.Items.Add(new GlobalVariableType("String", @"^.*$"));
             cmbType.Items.Add(new GlobalVariableType("float", @"^\-?[0-9]+(\.[0-9]+)?$"));
             cmbType.Items.Add(new GlobalVariableType("bool", @"^true$|^false$"));
-            cmbType.Items.Add(new GlobalVariableType("GUI*", null));
-            cmbType.Items.Add(new GlobalVariableType("AudioChannel*", null));
-            cmbType.Items.Add(new GlobalVariableType("Character*", null));
-            cmbType.Items.Add(new GlobalVariableType("DynamicSprite*", null));
-            cmbType.Items.Add(new GlobalVariableType("Overlay*", null));
-            cmbType.Items.Add(new GlobalVariableType("ViewFrame*", null));
+            if (apiTypes != null)
+            {
+                foreach (var def in apiTypes)
+                {
+                    if (!def.Managed || def.String) continue;
+                    if (def.Autoptr)
+                        cmbType.Items.Add(new GlobalVariableType(def.Name, null));
+                    else
+                        cmbType.Items.Add(new GlobalVariableType(string.Format("{0}*", def.Name), null));
+                }
+            }
             cmbType.SelectedIndex = 0;
         }
 
-        public static DialogResult Show(GlobalVariable variable, Game game)
+        public static DialogResult Show(GlobalVariable variable, Game game, IEnumerable<APITypeDef> apiTypes)
         {
-            GlobalVariableDialog dialog = new GlobalVariableDialog(variable, game);
+            GlobalVariableDialog dialog = new GlobalVariableDialog(variable, game, apiTypes);
             DialogResult result = dialog.ShowDialog();
             dialog.Dispose();
             return result;
@@ -129,6 +134,5 @@ namespace AGS.Editor
                 return TypeName;
             }
         }
-
     }
 }

--- a/Editor/AGS.Editor/Panes/GlobalVariablesEditor.cs
+++ b/Editor/AGS.Editor/Panes/GlobalVariablesEditor.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Data;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace AGS.Editor
@@ -24,6 +25,7 @@ namespace AGS.Editor
 
         private GlobalVariables _variables;
         private Game _game;
+        private SortedSet<APITypeDef> _apiTypes = new SortedSet<APITypeDef>();
 
         public GlobalVariablesEditor(Game game)
         {
@@ -39,6 +41,12 @@ namespace AGS.Editor
                 lvwWords.Items.Add(CreateListItemFromVariable(variable));
             }
             lvwWords.Sort();
+
+            try
+            {
+                PopulateScriptTypeList();
+            }
+            catch (Exception) { }
         }
 
         public void SelectGlobalVariable(string variableName)
@@ -66,7 +74,27 @@ namespace AGS.Editor
                 UpdateListItemFromVariableObject(lvwWords.SelectedItems[0]);
             }
         }
-        
+
+        private void PopulateScriptTypeList()
+        {
+            _apiTypes.Clear();
+            string api = Resources.ResourceManager.GetResourceAsString("agsdefns.sh");
+            var regex = new Regex(@"\b(?:(internalstring|autoptr|builtin|managed)\s+)+struct\s+(\w+)", RegexOptions.Compiled);
+            for (Match m = regex.Match(api); m.Success; m = m.NextMatch())
+            {
+                bool is_string = false;
+                bool is_managed = false;
+                bool is_autoptr = false;
+                foreach (Capture c in m.Groups[1].Captures)
+                {
+                    is_string |= c.Value == "internalstring";
+                    is_managed |= c.Value == "managed";
+                    is_autoptr |= c.Value == "autoptr";
+                }
+                _apiTypes.Add(new APITypeDef(m.Groups[2].Captures[0].Value, is_autoptr, is_managed, is_string));
+            }
+        }
+
         private ListViewItem CreateListItemFromVariable(GlobalVariable variable)
         {
             ListViewItem newItem = new ListViewItem(new string[] { variable.Name, variable.Type, variable.DefaultValue });
@@ -116,7 +144,7 @@ namespace AGS.Editor
             else if (item.Name == MENU_ITEM_ADD_WORD)
             {
                 GlobalVariable variable = new GlobalVariable();
-                if (GlobalVariableDialog.Show(variable, _game) == DialogResult.OK)
+                if (GlobalVariableDialog.Show(variable, _game, _apiTypes) == DialogResult.OK)
                 {
                     AddNewVariableToList(variable);
                 }
@@ -135,7 +163,7 @@ namespace AGS.Editor
         private void EditSelectedVariable(GlobalVariable variable)
         {
             string nameWas = variable.Name;
-            if (GlobalVariableDialog.Show(variable, _game) == DialogResult.OK)
+            if (GlobalVariableDialog.Show(variable, _game, _apiTypes) == DialogResult.OK)
             {
                 if (variable.Name != nameWas)
                 {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -587,7 +587,7 @@ builtin managed struct Camera;
 builtin managed struct Viewport;
 #endif
 
-builtin managed struct Room {
+builtin struct Room {
   /// Gets a custom text property associated with this room.
   import static String GetTextProperty(const string property);
   /// Gets a drawing surface that allows you to manipulate the room background.
@@ -624,7 +624,7 @@ builtin managed struct Room {
 #endif
 };
 
-builtin managed struct Parser {
+builtin struct Parser {
   /// Returns the parser dictionary word ID for the specified word
   import static int    FindWordID(const string wordToFind);
   /// Stores the supplied user text for later use with Said
@@ -2505,7 +2505,7 @@ builtin managed struct Character {
 #endif
   };
 
-builtin managed struct Game {
+builtin struct Game {
   /// Changes the active translation.
   import static bool   ChangeTranslation(const string newTranslationFileName);
   /// Returns true the first time this command is called with this token.

--- a/Editor/AGS.Editor/TextProcessing/APITypeDef.cs
+++ b/Editor/AGS.Editor/TextProcessing/APITypeDef.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// Describes script API struct type.
+    /// </summary>
+    public class APITypeDef : IComparable<APITypeDef>
+    {
+        public string Name;
+        public bool Autoptr;
+        public bool Managed;
+        public bool String;
+
+        public APITypeDef(string name, bool autoptr, bool managed, bool is_string)
+        {
+            Name = name;
+            Autoptr = autoptr;
+            Managed = managed;
+            String = is_string;
+        }
+
+        public int CompareTo(APITypeDef other)
+        {
+            return Name.CompareTo(other.Name);
+        }
+    }
+}


### PR DESCRIPTION
For #909.

Removes hard-coded types from the variable dialog (which were not updated in ages anyway) and instead use precreated list of types gathered by parsing script API header with regex.