### PR TITLE
Removed arbitrary limits in the text wrapping

### DIFF
--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -188,14 +188,12 @@ bool use_default_linespacing(size_t fontNumber)
     return fonts[fontNumber].Info.LineSpacing == 0;
 }
 
-char lines[MAXLINE][200];
-int  numlines;
-
 // Project-dependent implementation
 extern int wgettextwidth_compensate(const char *tex, int font);
 
+namespace AGS { namespace Common { SplitLines Lines; } }
 // Break up the text into lines
-void split_lines(const char *todis, int wii, int fonnt) {
+void split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
     // v2.56.636: rewrote this function because the old version
     // was crap and buggy
     int i = 0;
@@ -209,14 +207,15 @@ void split_lines(const char *todis, int wii, int fonnt) {
     theline = textCopyBuffer;
     unescape(theline);
 
+    lines.Reset();
+
     while (1) {
         splitAt = -1;
 
         if (theline[i] == 0) {
             // end of the text, add the last line if necessary
             if (i > 0) {
-                strcpy(lines[numlines], theline);
-                numlines++;
+                lines.Add(theline);
             }
             break;
         }
@@ -248,11 +247,10 @@ void split_lines(const char *todis, int wii, int fonnt) {
             // add this line
             nextCharWas = theline[splitAt];
             theline[splitAt] = 0;
-            strcpy(lines[numlines], theline);
-            numlines++;
+            lines.Add(theline);
             theline[splitAt] = nextCharWas;
-            if (numlines >= MAXLINE) {
-                strcat(lines[numlines - 1], "...");
+            if (lines.Count() >= max_lines) {
+                lines[lines.Count() - 1].Append("...");
                 break;
             }
             // the next line starts from here

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -227,6 +227,15 @@ void unescape_script_string(const char *cstr, std::vector<char> &out)
 
 // Break up the text into lines
 void split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
+    // NOTE: following hack accomodates for the legacy math mistake in split_lines.
+    // It's hard to tell how cruicial it is for the game looks, so research may be needed.
+    // TODO: IMHO this should rely not on game format, but script API level, because it
+    // defines necessary adjustments to game scripts. If you want to fix this, find a way to
+    // pass this flag here all the way from game.options[OPT_BASESCRIPTAPI] (or game format).
+    //
+    // if (game.options[OPT_BASESCRIPTAPI] < $Your current version$)
+    wii -= 1;
+
     lines.Reset();
     unescape_script_string(todis, lines.LineBuf);
     char *theline = &lines.LineBuf.front();
@@ -253,7 +262,7 @@ void split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_
         if (theline[i] == '\n')
             splitAt = i;
         // otherwise, see if we are too wide
-        else if (wgettextwidth_compensate(theline, fonnt) >= wii) {
+        else if (wgettextwidth_compensate(theline, fonnt) > wii) {
             int endline = i;
             while ((theline[endline] != ' ') && (endline > 0))
                 endline--;

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -87,6 +87,9 @@ public:
         _pool[_count++].SetString(cstr);
     }
 
+    // An auxiliary line processing buffer
+    std::vector<char> LineBuf;
+
 private:
     std::vector<Common::String> _pool;
     size_t _count; // actual number of lines in use

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -15,7 +15,9 @@
 #ifndef __AC_FONT_H
 #define __AC_FONT_H
 
+#include <vector>
 #include "core/types.h"
+#include "util/string.h"
 
 // TODO: we need to make some kind of TextManager class of this module
 
@@ -57,8 +59,6 @@ int  get_font_outline(size_t font_number);
 void set_font_outline(size_t font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters
 int getfontlinespacing(size_t fontNumber);
-// Break up the text into lines restricted by the given width
-void split_lines(const char *texx, int width, int fontNumber);
 // Print text on a surface using a given font
 void wouttextxy(Common::Bitmap *ds, int xxx, int yyy, size_t fontNumber, color_t text_color, const char *texx);
 // Assigns FontInfo to the font
@@ -67,5 +67,34 @@ void set_fontinfo(size_t fontNumber, const FontInfo &finfo);
 bool wloadfont_size(size_t fontNumber, const FontInfo &font_info);
 void wgtprintf(Common::Bitmap *ds, int xxx, int yyy, size_t fontNumber, color_t text_color, char *fmt, ...);
 void wfreefont(size_t fontNumber);
+
+// SplitLines class represents a list of lines and is meant to reduce
+// subsequent memory (de)allocations if used often during game loops
+// and drawing. For that reason it is not equivalent to std::vector,
+// but keeps constructed String buffers intact for most time.
+// TODO: implement proper strings pool.
+class SplitLines
+{
+public:
+    inline size_t Count() const { return _count; }
+    inline const Common::String &operator[](size_t i) const { return _pool[i]; }
+    inline Common::String &operator[](size_t i) { return _pool[i]; }
+    inline void Clear() { _pool.clear(); _count = 0; }
+    inline void Reset() { _count = 0; }
+    inline void Add(const char *cstr)
+    {
+        if (_pool.size() == _count) _pool.resize(_count + 1);
+        _pool[_count++].SetString(cstr);
+    }
+
+private:
+    std::vector<Common::String> _pool;
+    size_t _count; // actual number of lines in use
+};
+
+// Break up the text into lines restricted by the given width
+void split_lines(const char *texx, SplitLines &lines, int width, int fontNumber, size_t max_lines = -1);
+
+namespace AGS { namespace Common { extern SplitLines Lines; } }
 
 #endif // __AC_FONT_H

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -20,8 +20,6 @@
 #define TEXTWINDOW_PADDING_DEFAULT  3
 //#define MAX_OBJ_EACH_TYPE 251
 
-#define MAXLINE 50
-
 // TODO: find out more about gui version history
 //=============================================================================
 // GUI Version history

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -50,17 +50,18 @@ void GUILabel::Draw(Common::Bitmap *ds)
     // TODO: need to find a way to cache text prior to drawing;
     // but that will require to update all gui controls when translation is changed in game
     PrepareTextToDraw();
-    const int line_count = SplitLinesForDrawing();
+    SplitLinesForDrawing(Lines);
 
     color_t text_color = ds->GetCompatibleColor(TextColor);
     const int linespacing = getfontlinespacing(Font) + 1;
     // < 2.72 labels did not limit vertical size of text
     const bool limit_by_label_frame = loaded_game_file_version >= kGameVersion_272;
-    for (int i = 0, at_y = Y;
-        i < line_count && (!limit_by_label_frame || at_y <= Y + Height);
+    int at_y = Y;
+    for (size_t i = 0;
+        i < Lines.Count() && (!limit_by_label_frame || at_y <= Y + Height);
         ++i, at_y += linespacing)
     {
-        GUI::DrawTextAlignedHor(ds, lines[i], Font, text_color, X, X + Width - 1, at_y,
+        GUI::DrawTextAlignedHor(ds, Lines[i], Font, text_color, X, X + Width - 1, at_y,
             (FrameAlignment)TextAlignment);
     }
 }

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -19,6 +19,8 @@
 #include "gui/guiobject.h"
 #include "util/string.h"
 
+class SplitLines;
+
 namespace AGS
 {
 namespace Common
@@ -50,7 +52,7 @@ public:
 
 private:
     void PrepareTextToDraw();
-    int  SplitLinesForDrawing();
+    void SplitLinesForDrawing(SplitLines &lines);
 
     // prepared text buffer/cache
     String _textToDraw;

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -210,8 +210,6 @@ namespace GUI
 extern std::vector<Common::GUIMain> guis;
 extern int all_buttons_disabled, gui_inv_pic;
 extern int gui_disabled_style;
-extern char lines[MAXLINE][200];
-extern int  numlines;
 
 extern int mousex, mousey;
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -704,6 +704,17 @@ void String::ReplaceMid(size_t from, size_t count, const char *cstr)
     _meta->Length += length - count;
 }
 
+void String::Reverse()
+{
+    if (!_meta || GetLength() <= 1)
+        return;
+    for (char *fw = _meta->CStr, *bw = _meta->CStr + _meta->Length - 1;
+        *fw; ++fw, --bw)
+    {
+        std::swap(*fw, *bw);
+    }
+}
+
 void String::SetAt(size_t index, char c)
 {
     if (_meta && index < GetLength() && c)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -274,6 +274,8 @@ public:
     // Replaces particular substring with another substring; new substring
     // may have different length
     void    ReplaceMid(size_t from, size_t count, const char *cstr);
+    // Reverses the string
+    void    Reverse();
     // Overwrite the Nth character of the string; does not change string's length
     void    SetAt(size_t index, char c);
     // Makes a new string by copying up to N chars from C-string

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -20,29 +20,6 @@
 
 using namespace AGS::Common;
 
-// Turn [ into \n and turn \[ into [
-void unescape(char *buffer) {
-    char *offset;
-    // Handle the special case of the first char
-    if(buffer[0] == '[')
-    {
-        buffer[0] = '\n';
-        offset = buffer + 1;
-    }
-    else
-        offset = buffer;
-    // Replace all other occurrences as they're found
-    while((offset = strchr(offset, '[')) != nullptr) {
-        if(offset[-1] != '\\')
-            offset[0] = '\n';
-        else
-            memmove(offset - 1, offset, strlen(offset) + 1);
-        offset++;
-    }
-}
-
-//=============================================================================
-
 String cbuf_to_string_and_free(char *char_buf)
 {
     String s = char_buf;

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -23,8 +23,6 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-void unescape(char *buffer);
-
 //=============================================================================
 
 // Converts char* to string and frees original malloc-ed array;

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -83,11 +83,9 @@ void GUILabel::PrepareTextToDraw()
     _textToDraw = Text;
 }
 
-int GUILabel::SplitLinesForDrawing()
+void GUILabel::SplitLinesForDrawing(SplitLines &lines)
 {
-    numlines = 0;
-    split_lines(_textToDraw, Width, Font);
-    return numlines;
+    split_lines(_textToDraw, lines, Width, Font);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -357,13 +357,12 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
       else text_color = ds->GetCompatibleColor(utextcol);
     }
 
-    break_up_text_into_lines(areawid-(2*padding+2+bullet_wid),usingfont,get_translation(dtop->optionnames[disporder[ww]]));
+    break_up_text_into_lines(get_translation(dtop->optionnames[disporder[ww]]), Lines, areawid-(2*padding+2+bullet_wid), usingfont);
     dispyp[ww]=curyp;
     if (game.dialog_bullet > 0)
     {
         draw_gui_sprite_v330(ds, game.dialog_bullet, dlgxp, curyp, ds_has_alpha);
     }
-    int cc;
     if (game.options[OPT_DIALOGNUMBERED] == kDlgOptNumbering) {
       char tempbfr[20];
       int actualpicwid = 0;
@@ -373,8 +372,8 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
       sprintf (tempbfr, "%d.", ww + 1);
       wouttext_outline (ds, dlgxp + actualpicwid, curyp, usingfont, text_color, tempbfr);
     }
-    for (cc=0;cc<numlines;cc++) {
-      wouttext_outline(ds, dlgxp+((cc==0) ? 0 : 9)+bullet_wid, curyp, usingfont, text_color, lines[cc]);
+    for (size_t cc=0;cc<Lines.Count();cc++) {
+      wouttext_outline(ds, dlgxp+((cc==0) ? 0 : 9)+bullet_wid, curyp, usingfont, text_color, Lines[cc]);
       curyp+=linespacing;
     }
     if (ww < numdisp-1)
@@ -388,8 +387,8 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
 #define GET_OPTIONS_HEIGHT {\
   needheight = 0;\
   for (int i = 0; i < numdisp; ++i) {\
-    break_up_text_into_lines(areawid-(2*padding+2+bullet_wid),usingfont,get_translation(dtop->optionnames[disporder[i]]));\
-    needheight += getheightoflines(usingfont, numlines) + data_to_game_coord(game.options[OPT_DIALOGGAP]);\
+    break_up_text_into_lines(get_translation(dtop->optionnames[disporder[i]]), Lines, areawid-(2*padding+2+bullet_wid), usingfont);\
+    needheight += getheightoflines(usingfont, Lines.Count()) + data_to_game_coord(game.options[OPT_DIALOGGAP]);\
   }\
   if (parserInput) needheight += parserInput->Height + data_to_game_coord(game.options[OPT_DIALOGGAP]);\
  }
@@ -687,7 +686,7 @@ void DialogOptions::Redraw()
       int biggest = 0;
       padding = guis[game.options[OPT_DIALOGIFACE]].Padding;
       for (int i = 0; i < numdisp; ++i) {
-        break_up_text_into_lines(areawid-((2*padding+2)+bullet_wid),usingfont,get_translation(dtop->optionnames[disporder[i]]));
+        break_up_text_into_lines(get_translation(dtop->optionnames[disporder[i]]), Lines, areawid-((2*padding+2)+bullet_wid), usingfont);
         if (longestline > biggest)
           biggest = longestline;
       }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -46,8 +46,7 @@
 #include "media/audio/audio_system.h"
 #include "ac/timer.h"
 
-using AGS::Common::Bitmap;
-namespace BitmapHelper = AGS::Common::BitmapHelper;
+using namespace AGS::Common;
 
 extern GameState play;
 extern GameSetupStruct game;
@@ -91,10 +90,10 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
     int paddingDoubledScaled = get_fixed_pixel_size(padding * 2); // Just in case screen size does is not neatly divisible by 320x200
 
     ensure_text_valid_for_font(todis, usingfont);
-    break_up_text_into_lines(wii-2*padding,usingfont,todis);
+    break_up_text_into_lines(todis, Lines, wii-2*padding, usingfont);
     disp.lineheight = getfontheight_outlined(usingfont);
     disp.linespacing= getfontspacing_outlined(usingfont);
-    disp.fulltxtheight = getheightoflines(usingfont, numlines);
+    disp.fulltxtheight = getheightoflines(usingfont, Lines.Count());
 
     // AGS 2.x: If the screen is faded out, fade in again when displaying a message box.
     if (!asspch && (loaded_game_file_version <= kGameVersion_272))
@@ -163,7 +162,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
     }
     else if (xx<0) xx= ui_view.GetWidth()/2-wii/2;
 
-    int ee, extraHeight = paddingDoubledScaled;
+    int extraHeight = paddingDoubledScaled;
     color_t text_color = MakeColor(15);
     if (blocking < 2)
         remove_screen_overlay(OVER_TEXTMSG);
@@ -200,7 +199,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         else if ((ShouldAntiAliasText()) && (game.GetColorDepth() >= 24))
             alphaChannel = true;
 
-        for (ee=0;ee<numlines;ee++) {
+        for (size_t ee=0;ee<Lines.Count();ee++) {
             //int ttxp=wii/2 - wgettextwidth_compensate(lines[ee], usingfont)/2;
             int ttyp=ttxtop+ee*disp.linespacing;
             // asspch < 0 means that it's inside a text box so don't
@@ -212,12 +211,12 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 else
                     text_color = text_window_ds->GetCompatibleColor(-asspch);
 
-                wouttext_aligned(text_window_ds, ttxleft, ttyp, oriwid, usingfont, text_color, lines[ee], play.text_align);
+                wouttext_aligned(text_window_ds, ttxleft, ttyp, oriwid, usingfont, text_color, Lines[ee], play.text_align);
             }
             else {
                 text_color = text_window_ds->GetCompatibleColor(asspch);
                 //wouttext_outline(ttxp,ttyp,usingfont,lines[ee]);
-                wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, lines[ee], play.speech_text_align);
+                wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, Lines[ee], play.speech_text_align);
             }
         }
     }
@@ -233,8 +232,8 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
         adjust_y_coordinate_for_text(&yoffs, usingfont);
 
-        for (ee=0;ee<numlines;ee++)
-            wouttext_aligned (text_window_ds, xoffs, yoffs + ee * disp.linespacing, oriwid, usingfont, text_color, lines[ee], play.text_align);
+        for (size_t ee=0;ee<Lines.Count();ee++)
+            wouttext_aligned (text_window_ds, xoffs, yoffs + ee * disp.linespacing, oriwid, usingfont, text_color, Lines[ee], play.text_align);
     }
 
     int ovrtype = OVER_TEXTMSG;

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -346,25 +346,25 @@ void DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy,
     sds->PointToGameResolution(&xx, &yy);
     sds->SizeToGameResolution(&wid);
 
-    break_up_text_into_lines(wid, font, (char*)msg);
+    break_up_text_into_lines(msg, Lines, wid, font);
 
     Bitmap *ds = sds->StartDrawing();
     color_t text_color = sds->currentColour;
 
-    for (int i = 0; i < numlines; i++)
+    for (size_t i = 0; i < Lines.Count(); i++)
     {
         int drawAtX = xx;
 
         if (alignment & kMAlignHCenter)
         {
-            drawAtX = xx + ((wid / 2) - wgettextwidth(lines[i], font) / 2);
+            drawAtX = xx + ((wid / 2) - wgettextwidth(Lines[i], font) / 2);
         }
         else if (alignment & kMAlignRight)
         {
-            drawAtX = (xx + wid) - wgettextwidth(lines[i], font);
+            drawAtX = (xx + wid) - wgettextwidth(Lines[i], font);
         }
 
-        wouttext_outline(ds, drawAtX, yy + linespacing*i, font, text_color, lines[i]);
+        wouttext_outline(ds, drawAtX, yy + linespacing*i, font, text_color, Lines[i]);
     }
 
     sds->FinishedDrawing();

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -35,8 +35,6 @@ using namespace AGS::Engine;
 extern Bitmap *raw_saved_screen;
 extern RoomStruct thisroom;
 extern GameState play;
-extern char lines[MAXLINE][200];
-extern int  numlines;
 extern SpriteCache spriteset;
 extern GameSetupStruct game;
 
@@ -157,12 +155,12 @@ void RawPrintMessageWrapped (int xx, int yy, int wid, int font, int msgm) {
     // it's probably too late but check anyway
     if (strlen(displbuf) > 2899)
         quit("!RawPrintMessageWrapped: message too long");
-    break_up_text_into_lines (wid, font, displbuf);
+    break_up_text_into_lines(displbuf, Lines, wid, font);
 
     RAW_START();
     color_t text_color = play.raw_color;
-    for (int i = 0; i < numlines; i++)
-        wouttext_outline(RAW_SURFACE(), xx, yy + linespacing*i, font, text_color, lines[i]);
+    for (size_t i = 0; i < Lines.Count(); i++)
+        wouttext_outline(RAW_SURFACE(), xx, yy + linespacing*i, font, text_color, Lines[i]);
     invalidate_screen();
     mark_current_background_dirty();
     RAW_END();

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -23,6 +23,7 @@
 #include "ac/mouse.h"
 #include "ac/string.h"
 #include "debug/debug_log.h"
+#include "font/fonts.h"
 #include "gui/guimain.h"
 #include "script/runtimescriptvalue.h"
 #include "util/string_compat.h"
@@ -176,9 +177,8 @@ int GetTextHeight(const char *text, int fontnum, int width) {
   if ((fontnum < 0) || (fontnum >= game.numfonts))
     quit("!GetTextHeight: invalid font number.");
 
-  break_up_text_into_lines(data_to_game_coord(width), fontnum, text);
-
-  return game_to_data_coord(getheightoflines(fontnum, numlines));
+  break_up_text_into_lines(text, Lines, data_to_game_coord(width), fontnum);
+  return game_to_data_coord(getheightoflines(fontnum, Lines.Count()));
 }
 
 int GetFontHeight(int fontnum)

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -25,8 +25,6 @@
 #include "script/runtimescriptvalue.h"
 #include "util/string_compat.h"
 
-extern char lines[MAXLINE][200];
-extern int  numlines;
 extern GameSetupStruct game;
 extern GameState play;
 extern int longestline;
@@ -238,21 +236,7 @@ DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate)
     return DynObjectRef(handle, obj_ptr);
 }
 
-void reverse_text(char *text) {
-    int length = strlen(text);
-    int index = length / 2;
-    int xedni;
-    char swap;
-    while(index > 0) {
-        xedni = length - index;
-        index--;
-        swap = text[xedni];
-        text[xedni] = text[index];
-        text[index] = swap;
-    }
-}
-
-void break_up_text_into_lines(int wii,int fonnt, const char*todis) {
+int break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
     if (fonnt == -1)
         fonnt = play.normal_font;
 
@@ -261,33 +245,33 @@ void break_up_text_into_lines(int wii,int fonnt, const char*todis) {
         while ((todis[0]!=' ') & (todis[0]!=0)) todis++;
         if (todis[0]==' ') todis++;
     }
-    numlines=0;
+    lines.Reset();
     longestline=0;
 
     // Don't attempt to display anything if the width is tiny
     if (wii < 3)
-        return;
+        return 0;
 
-    int rr;
     int line_length;
 
-    split_lines(todis, wii, fonnt);
+    split_lines(todis, lines, wii, fonnt, max_lines);
 
     // Right-to-left just means reverse the text then
     // write it as normal
     if (game.options[OPT_RIGHTLEFTWRITE])
-        for (rr = 0; rr < numlines; rr++) {
-            reverse_text(lines[rr]);
+        for (size_t rr = 0; rr < lines.Count(); rr++) {
+            lines[rr].Reverse();
             line_length = wgettextwidth_compensate(lines[rr], fonnt);
             if (line_length > longestline)
                 longestline = line_length;
         }
     else
-        for (rr = 0; rr < numlines; rr++) {
+        for (size_t rr = 0; rr < lines.Count(); rr++) {
             line_length = wgettextwidth_compensate(lines[rr], fonnt);
             if (line_length > longestline)
                 longestline = line_length;
         }
+    return lines.Count();
 }
 
 int MAXSTRLEN = MAX_MAXSTRLEN;

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -45,8 +45,8 @@ int StrContains (const char *s1, const char *s2);
 
 const char* CreateNewScriptString(const char *fromText, bool reAllocate = true);
 DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate = true);
-void reverse_text(char *text);
-void break_up_text_into_lines(int wii,int fonnt, const char*todis);
+class SplitLines;
+int break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1);
 void check_strlen(char*ptt);
 void my_strncpy(char *dest, const char *src, int len);
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -122,12 +122,10 @@ void GUILabel::PrepareTextToDraw()
     replace_macro_tokens(Flags & kGUICtrl_Translated ? String(get_translation(Text)) : Text, _textToDraw);
 }
 
-int GUILabel::SplitLinesForDrawing()
+void GUILabel::SplitLinesForDrawing(SplitLines &lines)
 {
-    // Use the engine's word wrap tool, to have hebrew-style writing
-    // and other features
-    break_up_text_into_lines(Width, Font, _textToDraw);
-    return numlines;
+    // Use the engine's word wrap tool, to have hebrew-style writing and other features
+    break_up_text_into_lines(_textToDraw, lines, Width, Font);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)

--- a/Engine/gui/mylabel.cpp
+++ b/Engine/gui/mylabel.cpp
@@ -21,12 +21,9 @@
 #include "gui/mylabel.h"
 #include "gui/guidialoginternaldefs.h"
 
-using Common::Bitmap;
+using namespace Common;
 
 extern GameSetup usetup;
-// ac_guimain
-extern int numlines;
-extern char lines[MAXLINE][200];
 
 extern int acdialog_font;
 
@@ -46,9 +43,9 @@ void MyLabel::draw(Bitmap *ds)
     char *teptr = &text[0];
     color_t text_color = ds->GetCompatibleColor(0);
 
-    break_up_text_into_lines(wid, acdialog_font, teptr);
-    for (int ee = 0; ee < numlines; ee++) {
-        wouttext_outline(ds, x, cyp, acdialog_font, text_color, lines[ee]);
+    break_up_text_into_lines(teptr, Lines, wid, acdialog_font);
+    for (size_t ee = 0; ee < Lines.Count(); ee++) {
+        wouttext_outline(ds, x, cyp, acdialog_font, text_color, Lines[ee]);
         cyp += TEXT_HT;
     }
 }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -97,8 +97,6 @@ extern ccInstance *gameinst, *roominst;
 extern CharacterCache *charcache;
 extern ObjectCache objcache[MAX_ROOM_OBJECTS];
 extern MoveList *mls;
-extern int numlines;
-extern char lines[MAXLINE][200];
 extern color palette[256];
 extern PluginObjectReader pluginReaders[MAX_PLUGIN_OBJECT_READERS];
 extern int numPluginReaders;
@@ -342,15 +340,15 @@ void IAGSEngine::DrawTextWrapped (int32 xx, int32 yy, int32 wid, int32 font, int
     // TODO: use generic function from the engine instead of having copy&pasted code here
     int linespacing = getfontspacing_outlined(font);
 
-    break_up_text_into_lines (wid, font, (char*)text);
+    break_up_text_into_lines(text, Lines, wid, font);
 
     Bitmap *ds = gfxDriver->GetStageBackBuffer();
     if (!ds)
         return;
     color_t text_color = ds->GetCompatibleColor(color);
     data_to_game_coords((int*)&xx, (int*)&yy); // stupid! quick tweak
-    for (int i = 0; i < numlines; i++)
-        draw_and_invalidate_text(ds, xx, yy + linespacing*i, font, text_color, lines[i]);
+    for (size_t i = 0; i < Lines.Count(); i++)
+        draw_and_invalidate_text(ds, xx, yy + linespacing*i, font, text_color, Lines[i]);
 }
 
 Bitmap glVirtualScreenWrap;


### PR DESCRIPTION
For #707 (although I did not touch splitting code itself much)

Text line wrapping in the engine is performed using split_lines() function, which is used in many locations from GUI elements to DrawStringWrapped script command.

This function was using fixed-sized arrays, which limited both total number of lines and width of such lines.

Current pr removes these limits and makes it use resizing buffers instead.

**Note 1**, I was concerned about this function being called way too often than it's actually may be necessary (which is a separate issue), so, instead of just using plain std::vector<String>, quickly set up a sort of a string pool which prevents from erasing vector elements (dynamic Strings) therefore reducing allocation/deallocation of those strings in game loops. I am not very happy with this and believe we'd need to implement proper string pool class later.
I also use vector<char> as a simple writeable buffer when constructing those lines, because frankly our String class is not very efficient for large amount of small updates (it may be worth to have a separate object for string building, and turn original class into readonly string, but that's again a separate issue).

**Note 2**, split_lines contains a very old error which makes it treat width as having 1 pixel less. IIRC this bug was the topic of my first ever post on AGS forums years ago.... anyway, CJ told me back then that he kept this error for backwards compatibility. I think it's possible to make a switch instead and fix it in later versions. Idk if it's too late for the 3.5.0 or not. In any case we'd have to somehow pass a flag into this function, because it should depend on game property (data format or API version).