### PR TITLE
Editor: send mouse events only to active room layer

### DIFF
--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -43,6 +43,7 @@ namespace AGS.Editor
         protected Room _room;
         protected Panel _panel;        
 		protected ToolTip _tooltip;
+        private bool _isOn = false;
         private int _selectedArea = 1;
 		private int _drawingWithArea;
         private bool _mouseDown = false;
@@ -146,15 +147,11 @@ namespace AGS.Editor
         public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
+        public bool Enabled { get { return _isOn; } }
 
         protected virtual void FilterActivated()
 		{
 		}
-
-        protected bool IsFilterOn()
-        {
-            return Factory.GUIController.ActivePane.ToolbarCommands == _toolbarIcons;
-        }
 
         public void Invalidate() { _panel.Invalidate(); }
 
@@ -169,6 +166,9 @@ namespace AGS.Editor
         /// </summary>
         public virtual void Paint(Graphics graphics, RoomEditorState state)
         {
+            if (!Enabled)
+                return;
+
             int roomPixel = state.RoomSizeToWindow(1);
             int halfRoomPixel = roomPixel / 2;
             if ((_mouseDown) && (_drawMode == AreaDrawMode.Line))
@@ -242,7 +242,7 @@ namespace AGS.Editor
             int x = state.WindowXToRoom(e.X);
             int y = state.WindowYToRoom(e.Y);
 
-            AreaDrawMode drawMode = IsFilterOn() ? _drawMode : AreaDrawMode.Select;
+            AreaDrawMode drawMode = Enabled ? _drawMode : AreaDrawMode.Select;
 
             if (IsLocked(_selectedArea) && drawMode != AreaDrawMode.Select) return false;
 
@@ -306,7 +306,7 @@ namespace AGS.Editor
         public virtual bool MouseUp(MouseEventArgs e, RoomEditorState state)
         {
             _mouseDown = false;
-            AreaDrawMode drawMode = IsFilterOn() ? _drawMode : AreaDrawMode.Select;
+            AreaDrawMode drawMode = Enabled ? _drawMode : AreaDrawMode.Select;
 
             if (IsLocked(_selectedArea) && drawMode != AreaDrawMode.Select) return false;
 
@@ -368,7 +368,7 @@ namespace AGS.Editor
             _currentMouseX = state.WindowXToRoom(x);
             _currentMouseY = state.WindowYToRoom(y);
 
-            AreaDrawMode drawMode = IsFilterOn() ? _drawMode : AreaDrawMode.Select;            
+            AreaDrawMode drawMode = Enabled ? _drawMode : AreaDrawMode.Select;            
 
             if (_mouseDown)
             {
@@ -575,7 +575,8 @@ namespace AGS.Editor
             Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
             
 			FilterActivated();
-            _shouldSetDrawModeOnMouseUp = true;            
+            _shouldSetDrawModeOnMouseUp = true;
+            _isOn = true;
         }
 
         public void FilterOff()
@@ -592,6 +593,7 @@ namespace AGS.Editor
                 Factory.GUIController.ActivePane.ToolbarCommands = null;
             }
             Factory.ToolBarManager.RefreshCurrentPane();
+            _isOn = false;
         }
 
         public void Dispose()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -232,16 +232,6 @@ namespace AGS.Editor
             return _room.MaskResolution;
         }
 
-        public void MouseDownAlways(MouseEventArgs e, RoomEditorState state) 
-        {
-            if (!IsFilterOn())
-            {
-                DeselectArea();
-                _drawingWithArea = 0;
-                _drawMode = AreaDrawMode.Select;
-            }
-        }
-
         public virtual bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
             if (e.Button == MouseButtons.Middle)
@@ -291,9 +281,17 @@ namespace AGS.Editor
             else if (drawMode == AreaDrawMode.Select)
             {
                 int area = Factory.NativeProxy.GetAreaMaskPixel(_room, this.MaskToDraw, x, y);                                
-                if (area != 0 && !IsLocked(area))
+                if (area != 0)
                 {
-                    SelectedArea = area;
+                    if (!IsLocked(area))
+                    {
+                        SelectedArea = area;
+                        SelectedAreaChanged(_selectedArea);
+                    }
+                }
+                else
+                {
+                    DeselectArea();
                     SelectedAreaChanged(_selectedArea);
                 }
             }
@@ -648,6 +646,7 @@ namespace AGS.Editor
         protected void DeselectArea()
         {
             _selectedArea = 0;
+            _drawingWithArea = 0;
         }
 
         protected string GetItemID(int id)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -623,21 +623,9 @@ namespace AGS.Editor
 
         public virtual Cursor GetCursor(int x, int y, RoomEditorState state)
         {
-            if (_drawMode != AreaDrawMode.Select)
-            {
-                return Cursors.Cross;
-            }
-            if (state.CurrentCursor == null)
-            {
-                x = state.WindowXToRoom(x);
-                y = state.WindowYToRoom(y);
-                int area = Factory.NativeProxy.GetAreaMaskPixel(_room, this.MaskToDraw, x, y);
-                if (area != 0 && !IsLocked(area))
-                {
-                    return _selectCursor;
-                }
-            }
-            return null;
+            if (_drawMode == AreaDrawMode.Select)
+                return _selectCursor;
+            return Cursors.Cross;
         }
 
         public bool AllowClicksInterception()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -50,18 +50,14 @@ namespace AGS.Editor
             }
         }
 
-        public void MouseDownAlways(MouseEventArgs e, RoomEditorState state) 
-        {
-            _selectedCharacter = null;
-        }
-
         public bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
             int xClick = state.WindowXToRoom(e.X);
             int yClick = state.WindowYToRoom(e.Y);
             Character character = GetCharacter(xClick, yClick, state);
             if (character != null) SelectCharacter(character, xClick, yClick, state);
-            
+            else _selectedCharacter = null;
+
             if (_selectedCharacter != null)
             {
                 Factory.GUIController.SetPropertyGridObject(_selectedCharacter);

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -23,6 +23,7 @@ namespace AGS.Editor
         private Room _room;
         private Panel _panel;
         RoomSettingsEditor _editor;
+        private bool _isOn = false;
         private Character _selectedCharacter = null;
         private bool _movingCharacterWithMouse = false;
         private int _menuClickX = 0;
@@ -216,10 +217,12 @@ namespace AGS.Editor
 
         public void Paint(Graphics graphics, RoomEditorState state)
         {
+            if (!Enabled || _selectedCharacter == null)
+                return;
+
             Pen pen = new Pen(Color.Goldenrod);
             pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
-
-            if (_selectedCharacter != null)
+            
             {
                 Rectangle rect = GetCharacterRect(_selectedCharacter, state);
                 graphics.DrawRectangle(pen, rect);
@@ -290,11 +293,13 @@ namespace AGS.Editor
         {
             SetPropertyGridList();
             Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            _isOn = true;
         }
 
         public void FilterOff()
         {
             Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            _isOn = false;
         }
 
         public void UpdateCharactersRoom(Character character, int oldRoom)
@@ -372,6 +377,7 @@ namespace AGS.Editor
         public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
+        public bool Enabled { get { return _isOn; } }
 
         public SortedDictionary<string, DesignTimeProperties> DesignItems { get; private set; }
         /// <summary>

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -122,11 +122,6 @@ namespace AGS.Editor
                 DrawDoubleHeightHorizontalLine(graphics, state.RoomYToWindow(_room.BottomEdgeY), scale);
         }
 
-        public void MouseDownAlways(MouseEventArgs e, RoomEditorState state)
-        {
-            _selectedEdge = SelectedEdge.None;
-        }
-
         public bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
             _mouseDown = true;
@@ -137,6 +132,7 @@ namespace AGS.Editor
             else if (IsCursorOnVerticalEdge(x, _room.RightEdgeX, SelectedEdge.Right) && SetSelectedEdge(SelectedEdge.Right)) {}            
             else if (IsCursorOnHorizontalEdge(y, _room.TopEdgeY, SelectedEdge.Top) && SetSelectedEdge(SelectedEdge.Top)) {}
             else if (IsCursorOnHorizontalEdge(y, _room.BottomEdgeY, SelectedEdge.Bottom) && SetSelectedEdge(SelectedEdge.Bottom)) {}                        
+            else _selectedEdge = SelectedEdge.None;
 
             _lastSelectedEdge = _selectedEdge;
             return _selectedEdge != SelectedEdge.None;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -19,6 +19,7 @@ namespace AGS.Editor
         }
 
         private Room _room;
+        private bool _isOn = false;
         private SelectedEdge _selectedEdge = SelectedEdge.None;
         private SelectedEdge _lastSelectedEdge = SelectedEdge.None;
         private Panel _panel;
@@ -55,6 +56,7 @@ namespace AGS.Editor
         public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
+        public bool Enabled { get { return _isOn; } }
 
         public event EventHandler OnItemsChanged { add { } remove { } }
         public event EventHandler<SelectedRoomItemEventArgs> OnSelectedItemChanged;
@@ -166,7 +168,7 @@ namespace AGS.Editor
 
         public void FilterOn()
         {
-
+            _isOn = true;
         }
 
         public void FilterOff()
@@ -175,6 +177,7 @@ namespace AGS.Editor
             {
                 _tooltip.Hide(_panel);
             }
+            _isOn = false;
         }
 
 		public string HelpKeyword

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -15,7 +15,7 @@ namespace AGS.Editor
 		private Panel _panel;
         private Room _room;
 
-		public EmptyEditorFilter(Panel displayPanel, Room room)
+        public EmptyEditorFilter(Panel displayPanel, Room room)
         {
 			_panel = displayPanel;
             _room = room;
@@ -36,6 +36,7 @@ namespace AGS.Editor
         public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
+        public bool Enabled { get { return false; } }
 
         public event EventHandler OnItemsChanged { add { } remove { } }
         public event EventHandler<SelectedRoomItemEventArgs> OnSelectedItemChanged { add { } remove { } }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -70,8 +70,6 @@ namespace AGS.Editor
         {
         }
 
-        public void MouseDownAlways(MouseEventArgs e, RoomEditorState state) { }
-
         public bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
             return false;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -25,9 +25,13 @@ namespace AGS.Editor
         bool SupportVisibleItems { get; }
 
         /// <summary>
-        /// Tells that the design-time properties of the layer or items were modified.
+        /// Gets/sets whether the design-time properties of the layer or items were modified.
         /// </summary>
         bool Modified { get; set; }
+        /// <summary>
+        /// Tells whether filter is currently on (enabled for editing)
+        /// </summary>
+        bool Enabled { get; }
 
         /// <summary>
         /// Gets/sets if this layer is visible.
@@ -42,7 +46,15 @@ namespace AGS.Editor
         /// The dictionary that maps an object ID to its design-time properties.
         /// </summary>
         SortedDictionary<string, DesignTimeProperties> DesignItems { get; }
+        /// <summary>
+        /// Paint filter contents using native C++ functionality.
+        /// </summary>
         void PaintToHDC(IntPtr hDC, RoomEditorState state);
+        /// <summary>
+        /// Paint filter contents using .NET functionality.
+        /// </summary>
+        /// <param name="graphics"></param>
+        /// <param name="state"></param>
         void Paint(Graphics graphics, RoomEditorState state);
         /// <summary>
         /// Notifies mouse down event. Returns whether event is handled by this filter.

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -44,14 +44,28 @@ namespace AGS.Editor
         SortedDictionary<string, DesignTimeProperties> DesignItems { get; }
         void PaintToHDC(IntPtr hDC, RoomEditorState state);
         void Paint(Graphics graphics, RoomEditorState state);
-        void MouseDownAlways(MouseEventArgs e, RoomEditorState state);
+        /// <summary>
+        /// Notifies mouse down event. Returns whether event is handled by this filter.
+        /// </summary>
         bool MouseDown(MouseEventArgs e, RoomEditorState state);
+        /// <summary>
+        /// Notifies mouse up event. Returns whether event is handled by this filter.
+        /// </summary>
         bool MouseUp(MouseEventArgs e, RoomEditorState state);
+        /// <summary>
+        /// Notifies double click event. Returns whether event is handled by this filter.
+        /// </summary>
         bool DoubleClick(RoomEditorState state);
+        /// <summary>
+        /// Notifies mouse move event. Returns whether event is handled by this filter.
+        /// </summary>
         bool MouseMove(int x, int y, RoomEditorState state);
         void FilterOn();
         void FilterOff();
         void CommandClick(string command);
+        /// <summary>
+        /// Notifies key press event. Returns whether event is handled by this filter.
+        /// </summary>
         bool KeyPressed(Keys keyData);
         /// <summary>
         /// Gets a human-readable area name.

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -15,7 +15,7 @@ namespace AGS.Editor
         private const string MENU_ITEM_OBJECT_COORDS = "ObjectCoordinates";
         protected Room _room;
         protected Panel _panel;
-
+        private bool _isOn;
         private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         private RoomObject _selectedObject;
 		private RoomObject _lastSelectedObject;
@@ -49,6 +49,7 @@ namespace AGS.Editor
         public bool Modified { get; set; }
         public bool Visible { get; set; }
         public bool Locked { get; set; }
+        public bool Enabled { get { return _isOn; } }
 
         public SortedDictionary<string, DesignTimeProperties> DesignItems { get; private set; }
         /// <summary>
@@ -133,11 +134,9 @@ namespace AGS.Editor
 
         public virtual void Paint(Graphics graphics, RoomEditorState state)
         {
-            int xPos;
-            int yPos;
-
-            if (_selectedObject == null)
+            if (!Enabled || _selectedObject == null)
                 return;
+
             DesignTimeProperties design = DesignItems[GetItemID(_selectedObject)];
             if (!design.Visible)
                 return;
@@ -145,9 +144,9 @@ namespace AGS.Editor
             int width, height;
             Utilities.GetSizeSpriteWillBeRenderedInGame(_selectedObject.Image, out width, out height);
             width = state.RoomSizeToWindow(width);
-			height = state.RoomSizeToWindow(height);
-			xPos = state.RoomXToWindow(_selectedObject.StartX);
-			yPos = state.RoomYToWindow(_selectedObject.StartY) - height;
+            height = state.RoomSizeToWindow(height);
+            int xPos = state.RoomXToWindow(_selectedObject.StartX);
+            int yPos = state.RoomYToWindow(_selectedObject.StartY) - height;
             Pen pen = new Pen(Color.Goldenrod);
             pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dot;
             graphics.DrawRectangle(pen, xPos, yPos, width, height);
@@ -414,11 +413,13 @@ namespace AGS.Editor
         {
             SetPropertyGridList();
             Factory.GUIController.OnPropertyObjectChanged += _propertyObjectChangedDelegate;
+            _isOn = true;
         }
 
         public void FilterOff()
         {
             Factory.GUIController.OnPropertyObjectChanged -= _propertyObjectChangedDelegate;
+            _isOn = false;
         }
 
         public void Dispose()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -176,11 +176,6 @@ namespace AGS.Editor
             }
         }
 
-        public void MouseDownAlways(MouseEventArgs e, RoomEditorState state)
-        {
-            _selectedObject = null;
-        }
-
         public virtual bool MouseDown(MouseEventArgs e, RoomEditorState state)
         {
             int x = state.WindowXToRoom(e.X);
@@ -202,6 +197,11 @@ namespace AGS.Editor
                     _mouseOffsetY = y - obj.StartY;
                 }
             }
+            else
+            {
+                _selectedObject = null;
+            }
+
             if (_selectedObject == null)
             {                
                 if (e.Button == MouseButtons.Right)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
@@ -33,7 +33,10 @@ namespace AGS.Editor
 
         public override void Paint(Graphics graphics, RoomEditorState state)
 		{
-			int lineYPos = GetCurrentAreaBaselineScreenY(state);
+            if (!Enabled)
+                return;
+
+            int lineYPos = GetCurrentAreaBaselineScreenY(state);
 			Pen pen = (Pen)GetPenForArea(SelectedArea).Clone();
 			pen.DashStyle = System.Drawing.Drawing2D.DashStyle.Dash;
 
@@ -101,7 +104,7 @@ namespace AGS.Editor
                 _draggingBaseline = false;
                 return true;
             }
-            else if (!IsFilterOn()) return base.MouseUp(e, state);
+            else if (!Enabled) return base.MouseUp(e, state);
             else
             {
                 bool handledMouseUp = base.MouseUp(e, state);

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -292,11 +292,11 @@ namespace AGS.Editor
                 int drawOffsX = _state.RoomXToWindow(0);
                 int drawOffsY = _state.RoomYToWindow(0);
                 IRoomEditorFilter maskFilter = GetCurrentMaskFilter();
-				lock (_room)
+                lock (_room)
 				{
 					Factory.NativeProxy.DrawRoomBackground(hdc, _room, drawOffsX, drawOffsY, backgroundNumber, _state.Scale * scaleFactor,
                         maskFilter == null ? RoomAreaMaskType.None : maskFilter.MaskToDraw, 
-                        maskFilter == null ? 0 : maskFilter.SelectedArea, sldTransparency.Value);
+                        (maskFilter == null || !maskFilter.Enabled) ? 0 : maskFilter.SelectedArea, sldTransparency.Value);
 				}
                 foreach (IRoomEditorFilter layer in _layers)
                 {                    

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -755,7 +755,7 @@ namespace AGS.Editor
             {
                 return false;
             }
-            if (_layer != null && _layer.KeyPressed(keyData))
+            if (_layer != null && !IsLocked(_layer) && _layer.KeyPressed(keyData))
             {
                 bufferedPanel1.Invalidate();
                 Factory.GUIController.RefreshPropertyGrid();

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -618,21 +618,7 @@ namespace AGS.Editor
 
         private void SelectCursor(int x, int y, RoomEditorState state)
         {
-            state.CurrentCursor = Cursors.Default;            
-            if (_layer != null) state.CurrentCursor = _layer.GetCursor(x, y, state);
-            else state.CurrentCursor = null;   
-            if (state.CurrentCursor != null)
-            {
-                bufferedPanel1.Cursor = state.CurrentCursor;
-                return;
-            }            
-            for (int layerIndex = _layers.Count - 1; layerIndex >= 0; layerIndex--)
-            {
-                IRoomEditorFilter layer = _layers[layerIndex];
-                if (IsLocked(layer)) continue;
-                Cursor tmpCursor = layer.GetCursor(x, y, state);
-                if (tmpCursor != null) state.CurrentCursor = tmpCursor;
-            }            
+            state.CurrentCursor = _layer != null ? _layer.GetCursor(x, y, state) : Cursors.Default;
             bufferedPanel1.Cursor = state.CurrentCursor ?? Cursors.Default;
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -551,16 +551,8 @@ namespace AGS.Editor
 
         private void bufferedPanel1_MouseDown(object sender, MouseEventArgs e)
         {
-            foreach (IRoomEditorFilter layer in _layers)
-            {
-                if (IsLocked(layer)) continue;
-                layer.MouseDownAlways(e, _state);
-            }
-            foreach (IRoomEditorFilter layer in _layers)
-            {
-                if (IsLocked(layer)) continue;
-                if (layer.MouseDown(e, _state)) break;
-            }
+            if (_layer != null && !IsLocked(_layer))
+                _layer.MouseDown(e, _state);
             _mouseIsDown = true;
 		}
 
@@ -568,11 +560,8 @@ namespace AGS.Editor
         {
             if (_mouseIsDown)
             {
-                foreach (IRoomEditorFilter layer in _layers)
-                {
-                    if (IsLocked(layer)) continue;
-                    if (layer.MouseUp(e, _state)) break;
-                }
+                if (_layer != null && !IsLocked(_layer))
+                    _layer.MouseUp(e, _state);
                 Factory.GUIController.RefreshPropertyGrid();
                 bufferedPanel1.Invalidate();
                 _mouseIsDown = false;
@@ -586,12 +575,9 @@ namespace AGS.Editor
 		}
 
 		private void bufferedPanel1_DoubleClick(object sender, EventArgs e)
-		{            
-            foreach (IRoomEditorFilter layer in _layers)
-            {
-                if (IsLocked(layer)) continue;
-                if (layer.DoubleClick(_state)) break;
-            }
+		{
+            if (_layer != null && !IsLocked(_layer))
+                _layer.DoubleClick(_state);
 			Factory.GUIController.RefreshPropertyGrid();
 			bufferedPanel1.Invalidate();
 		}
@@ -621,15 +607,13 @@ namespace AGS.Editor
             lblMousePos.Text = "Mouse Position: " + xPosText + ", " + yPosText;
 
             SelectCursor(e.X, e.Y, _state);
-            foreach (IRoomEditorFilter layer in _layers)
+            if (_layer != null && !IsLocked(_layer))
             {
-                if (IsLocked(layer)) continue;
-                if (layer.MouseMove(e.X, e.Y, _state))
+                if (_layer.MouseMove(e.X, e.Y, _state))
                 {
-                    bufferedPanel1.Invalidate();                    
-                    break;
+                    bufferedPanel1.Invalidate();
                 }
-            }            
+            }
         }
 
         private void SelectCursor(int x, int y, RoomEditorState state)


### PR DESCRIPTION
Existing behavior of the room editor, where mouse events may be handled by multiple layers at once until one of them claims it, came along with the new navigation bar code. IMO it is not very well thought through for two reasons:
* this mixes "visible" and "interactable" property in one (Visible), which is not necessarily wanted, and contradicts to how layers usually work in editing programs (e.g. paint software).
* event is handled in the order layers are stored internally in the room editor, and this order is arbitrary and hard-coded.

I suggest to disable this behavior for the time being and instead send events only to layers explicitly activated by user.