### PR TITLE
Editor: disable sending data to ags server

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -138,7 +138,10 @@ namespace AGS.Editor
             _componentController.AddComponent(new SpeechComponent(_guiController, _agsEditor));
             _componentController.AddComponent(new SourceControlComponent(_guiController, _agsEditor));
             _componentController.AddComponent(new WelcomeComponent(_guiController, _agsEditor));
-            _componentController.AddComponent(new StatisticsSenderComponent(_guiController, _agsEditor));
+            //
+            // Disabled until proper server is found to store these stats
+            // _componentController.AddComponent(new StatisticsSenderComponent(_guiController, _agsEditor));
+            //
         }
 
         public void StartGUI(string[] commandLineArguments)

--- a/Editor/AGS.Editor/GUI/ExceptionDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ExceptionDialog.Designer.cs
@@ -28,7 +28,6 @@ namespace AGS.Editor
 		/// </summary>
 		private void InitializeComponent()
 		{
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExceptionDialog));
             this.errorIcon = new System.Windows.Forms.PictureBox();
             this.lblError = new System.Windows.Forms.Label();
             this.txtErrorDetails = new System.Windows.Forms.TextBox();
@@ -53,9 +52,10 @@ namespace AGS.Editor
             this.lblError.Location = new System.Drawing.Point(81, 22);
             this.lblError.MaximumSize = new System.Drawing.Size(400, 0);
             this.lblError.Name = "lblError";
-            this.lblError.Size = new System.Drawing.Size(396, 39);
+            this.lblError.Size = new System.Drawing.Size(396, 26);
             this.lblError.TabIndex = 1;
-            this.lblError.Text = resources.GetString("lblError.Text");
+            this.lblError.Text = "A problem has occurred, and AGS does not know how to deal with it. Please help us" +
+    " to improve AGS by posting error information on the AGS Technical Forum.";
             // 
             // txtErrorDetails
             // 
@@ -86,6 +86,7 @@ namespace AGS.Editor
             this.btnSendErrorReport.TabIndex = 4;
             this.btnSendErrorReport.Text = "Send Error Report";
             this.btnSendErrorReport.UseVisualStyleBackColor = true;
+            this.btnSendErrorReport.Visible = false;
             this.btnSendErrorReport.Click += new System.EventHandler(this.btnSendErrorReport_Click);
             // 
             // lblReportSucceeded
@@ -97,7 +98,7 @@ namespace AGS.Editor
             this.lblReportSucceeded.Size = new System.Drawing.Size(342, 26);
             this.lblReportSucceeded.TabIndex = 5;
             this.lblReportSucceeded.Text = "Your error report has been accepted. If you are experiencing regular errors, plea" +
-                "se post on the AGS Technical Forum for help.";
+    "se post on the AGS Technical Forum for help.";
             this.lblReportSucceeded.Visible = false;
             // 
             // ExceptionDialog

--- a/Editor/AGS.Editor/GUI/ExceptionDialog.resx
+++ b/Editor/AGS.Editor/GUI/ExceptionDialog.resx
@@ -112,12 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="lblError.Text" xml:space="preserve">
-    <value>A problem has occurred, and AGS does not know how to deal with it. Please help us to improve AGS by using the "Send Error Report" button to send this error information to the AGS website for investigation.</value>
-  </data>
 </root>

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -36,6 +36,8 @@ namespace AGS.Editor
             this.label1 = new System.Windows.Forms.Label();
             this.cmbTestGameStyle = new System.Windows.Forms.ComboBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.lblReloadScriptOnExternalChange = new System.Windows.Forms.Label();
+            this.cmbScriptReloadOnExternalChange = new System.Windows.Forms.ComboBox();
             this.udTabWidth = new System.Windows.Forms.NumericUpDown();
             this.cmbIndentStyle = new System.Windows.Forms.ComboBox();
             this.label10 = new System.Windows.Forms.Label();
@@ -81,8 +83,6 @@ namespace AGS.Editor
             this.chkBackupReminders = new System.Windows.Forms.CheckBox();
             this.groupBox9 = new System.Windows.Forms.GroupBox();
             this.chkRemapBgImport = new System.Windows.Forms.CheckBox();
-            this.cmbScriptReloadOnExternalChange = new System.Windows.Forms.ComboBox();
-            this.lblReloadScriptOnExternalChange = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udTabWidth)).BeginInit();
@@ -190,6 +190,28 @@ namespace AGS.Editor
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Script editor";
+            // 
+            // lblReloadScriptOnExternalChange
+            // 
+            this.lblReloadScriptOnExternalChange.Location = new System.Drawing.Point(11, 21);
+            this.lblReloadScriptOnExternalChange.Name = "lblReloadScriptOnExternalChange";
+            this.lblReloadScriptOnExternalChange.Size = new System.Drawing.Size(337, 36);
+            this.lblReloadScriptOnExternalChange.TabIndex = 11;
+            this.lblReloadScriptOnExternalChange.Text = "If a script file is open for editing and is modified by another program, how shou" +
+    "ld this be handled?";
+            // 
+            // cmbScriptReloadOnExternalChange
+            // 
+            this.cmbScriptReloadOnExternalChange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbScriptReloadOnExternalChange.FormattingEnabled = true;
+            this.cmbScriptReloadOnExternalChange.Items.AddRange(new object[] {
+            "Always ask what to do",
+            "Always reload the file",
+            "Never reload the file"});
+            this.cmbScriptReloadOnExternalChange.Location = new System.Drawing.Point(12, 57);
+            this.cmbScriptReloadOnExternalChange.Name = "cmbScriptReloadOnExternalChange";
+            this.cmbScriptReloadOnExternalChange.Size = new System.Drawing.Size(178, 21);
+            this.cmbScriptReloadOnExternalChange.TabIndex = 10;
             // 
             // udTabWidth
             // 
@@ -609,12 +631,13 @@ namespace AGS.Editor
             // 
             this.groupBox7.Controls.Add(this.lnkUsageInfo);
             this.groupBox7.Controls.Add(this.chkUsageInfo);
-            this.groupBox7.Location = new System.Drawing.Point(7, 331);
+            this.groupBox7.Location = new System.Drawing.Point(7, 448);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(365, 68);
             this.groupBox7.TabIndex = 8;
             this.groupBox7.TabStop = false;
             this.groupBox7.Text = "Usage statistics";
+            this.groupBox7.Visible = false;
             // 
             // lnkUsageInfo
             // 
@@ -642,7 +665,7 @@ namespace AGS.Editor
             this.groupBox8.Controls.Add(this.udBackupInterval);
             this.groupBox8.Controls.Add(this.label14);
             this.groupBox8.Controls.Add(this.chkBackupReminders);
-            this.groupBox8.Location = new System.Drawing.Point(7, 405);
+            this.groupBox8.Location = new System.Drawing.Point(7, 331);
             this.groupBox8.Name = "groupBox8";
             this.groupBox8.Size = new System.Drawing.Size(365, 52);
             this.groupBox8.TabIndex = 9;
@@ -696,7 +719,7 @@ namespace AGS.Editor
             // groupBox9
             // 
             this.groupBox9.Controls.Add(this.chkRemapBgImport);
-            this.groupBox9.Location = new System.Drawing.Point(7, 462);
+            this.groupBox9.Location = new System.Drawing.Point(7, 388);
             this.groupBox9.Name = "groupBox9";
             this.groupBox9.Size = new System.Drawing.Size(365, 54);
             this.groupBox9.TabIndex = 10;
@@ -712,28 +735,6 @@ namespace AGS.Editor
             this.chkRemapBgImport.Text = "Remap palette of room backgrounds into allocated background palette slots (8-bit " +
     "games only)";
             this.chkRemapBgImport.UseVisualStyleBackColor = true;
-            // 
-            // cmbScriptReloadOnExternalChange
-            // 
-            this.cmbScriptReloadOnExternalChange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbScriptReloadOnExternalChange.FormattingEnabled = true;
-            this.cmbScriptReloadOnExternalChange.Items.AddRange(new object[] {
-            "Always ask what to do",
-            "Always reload the file",
-            "Never reload the file"});
-            this.cmbScriptReloadOnExternalChange.Location = new System.Drawing.Point(12, 57);
-            this.cmbScriptReloadOnExternalChange.Name = "cmbScriptReloadOnExternalChange";
-            this.cmbScriptReloadOnExternalChange.Size = new System.Drawing.Size(178, 21);
-            this.cmbScriptReloadOnExternalChange.TabIndex = 10;
-            // 
-            // lblReloadScriptOnExternalChange
-            // 
-            this.lblReloadScriptOnExternalChange.Location = new System.Drawing.Point(11, 21);
-            this.lblReloadScriptOnExternalChange.Name = "lblReloadScriptOnExternalChange";
-            this.lblReloadScriptOnExternalChange.Size = new System.Drawing.Size(337, 36);
-            this.lblReloadScriptOnExternalChange.TabIndex = 11;
-            this.lblReloadScriptOnExternalChange.Text = "If a script file is open for editing and is modified by another program, how shou" +
-    "ld this be handled?";
             // 
             // PreferencesEditor
             // 


### PR DESCRIPTION
For #792.

This disables user ability to send crash reports, because it's no longer working and is not particulary useful without proper accessible database (which we don't have anymore).

For now I simply hid the "Send report" button and changed the crash window text, telling user to post on forums instead.