### PR TITLE
Add Android CI build and release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,6 +113,32 @@ build_macos_task:
   binaries_artifacts:
     path: build_*/ags
 
+build_android_task:
+  container:
+    dockerfile: ci/android/Dockerfile
+    docker_arguments:
+      FROM_DEBIAN: debian:buster
+      AGS_BRANCH: release-3.5.0
+  git_submodules_script: git submodule update --init --recursive
+  symlink_nativelibs_script: ln -s /opt/nativelibs Android/nativelibs
+  build_library_script: |
+    export PATH=$PATH:$(echo /opt/android-ndk-*)
+    cd Android/library && ndk-build
+  build_launcher_script: |
+    export ANDROID_HOME=/opt/android-sdk
+    export JAVA_HOME=$(echo /opt/jdk*)
+    export PATH=$PATH:$JAVA_HOME/bin
+    ant=$(echo /opt/apache-ant-*/bin/ant)
+    cd Android/launcher_list && $ant debug && $ant release
+  rename_apks_script: |
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    cd Android/launcher_list/bin
+    for apk in $(find -maxdepth 1 -name "*.apk" -type f); do
+      mv -v $apk ${apk%%-*}-${version}-${apk#*-}
+    done
+  binaries_artifacts:
+    path: Android/launcher_list/bin/AGS-*.apk
+
 build_editor_task:
   windows_container:
     dockerfile: ci/windows/Dockerfile
@@ -238,6 +264,7 @@ editor_packaging_task:
 upload_release_task:
   only_if: $CIRRUS_RELEASE != ''
   depends_on:
+    - build_android
     - build_linux
     - editor_packaging
     - linux_packaging
@@ -261,7 +288,8 @@ upload_release_task:
       "editor_packaging/installer/Windows/Installer/Output/AGS-$version.exe" \
       "editor_packaging/archive/AGS-$version.zip" \
       "build_linux/debian_packages/ags_${version}_i386.deb" \
-      "build_linux/debian_packages/ags_${version}_amd64.deb"
+      "build_linux/debian_packages/ags_${version}_amd64.deb" \
+      "build_android/binaries/Android/launcher_list/bin/AGS-${version}-debug.apk"
     do
       url="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download"
       echo "Downloading $url"

--- a/ci/android/Dockerfile
+++ b/ci/android/Dockerfile
@@ -1,0 +1,83 @@
+ARG FROM_DEBIAN=debian:latest
+FROM $FROM_DEBIAN
+
+# Take default debconf options
+ENV DEBIAN_FRONTEND noninteractive
+
+# Configure apt defaults
+ARG APT_CONF_LOCAL=99local
+RUN mkdir -p /etc/apt/apt.conf.d && \
+  printf 'APT::Get::Assume-Yes "true";\n\
+APT::Get::Install-Recommends "false";\n\
+APT::Get::Install-Suggests "false";\n' > /etc/apt/apt.conf.d/$APT_CONF_LOCAL
+
+# Upgrade existing packages
+RUN apt-get update && apt-get upgrade
+
+# Get packages
+RUN apt-get install \
+  autoconf \
+  bsdtar \
+  build-essential \
+  cmake \
+  curl \
+  git \
+  jq \
+  libncurses5 \
+  libtool \
+  pkg-config \
+  python
+
+# Get Android NDK
+ARG NDK_VERSION=r16b
+RUN curl -fLOJ "https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip" && \
+  bsdtar -f android-ndk-${NDK_VERSION}-linux-x86_64.zip -xvzC /opt && \
+  rm android-ndk-${NDK_VERSION}-linux-x86_64.zip
+
+# Make NDK toolchains
+RUN export NDK_HOME=/opt/android-ndk-${NDK_VERSION} && \
+  for arch in arm mips x86; do \
+    echo Building toolchain for $arch; \
+    $NDK_HOME/build/tools/make_standalone_toolchain.py --arch $arch --api 14 --install-dir $NDK_HOME/platforms/android-14/$arch; \
+  done
+
+# Get Android SDK manager
+ARG SDK_TOOLS_VERSION=4333796
+RUN curl -flOJ "https://dl.google.com/android/repository/sdk-tools-linux-${SDK_TOOLS_VERSION}.zip" && \
+  mkdir /opt/android-sdk && \
+  bsdtar -f sdk-tools-linux-${SDK_TOOLS_VERSION}.zip -xvzC /opt/android-sdk && \
+  rm sdk-tools-linux-${SDK_TOOLS_VERSION}.zip
+
+# Get OpenJDK 8
+ARG OPENJDK_VERSION=openjdk8
+RUN curl -fLSs "$(curl -fLSs "https://api.adoptopenjdk.net/v2/info/releases/${OPENJDK_VERSION}?os=linux&arch=x64&release=latest&openjdk_impl=hotspot&type=jdk" | \
+  jq -r .binaries[0].binary_link)" | tar -f - -xvzC /opt
+
+# Install SDK packages
+ARG BUILD_TOOLS_VERSION=29.0.2
+ARG PLATFORM_VERSION=android-16
+RUN echo y | JAVA_HOME=$(echo /opt/jdk*) /opt/android-sdk/tools/bin/sdkmanager \
+  "build-tools;${BUILD_TOOLS_VERSION}" \
+  "platforms;${PLATFORM_VERSION}" \
+  platform-tools
+
+# Merge Ant support back in
+ARG BUILD_TOOLS_ANT_VERSION=25.2.5
+RUN curl -fLOJ "https://dl.google.com/android/repository/tools_r${BUILD_TOOLS_ANT_VERSION}-linux.zip" && \
+  bsdtar -f tools_r${BUILD_TOOLS_ANT_VERSION}-linux.zip -xvzkC /opt/android-sdk && \
+  rm tools_r${BUILD_TOOLS_ANT_VERSION}-linux.zip
+
+# Get Ant
+ARG ANT_VERSION=1.10.7
+RUN curl -fLSs "https://www.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz" | \
+  tar -f - -xvzC /opt
+
+# Build libraries
+ARG AGS_ORGANIZATION=adventuregamestudio
+ARG AGS_BRANCH=master
+RUN cd /tmp && \
+  git clone -b "${AGS_BRANCH}" "https://github.com/${AGS_ORGANIZATION}/ags.git" && \
+  cd ags/Android/buildlibs && \
+  NDK_HOME=/opt/android-ndk-${NDK_VERSION} ./buildall.sh && \
+  mv ../nativelibs /opt/ && \
+  rm -r /tmp/ags


### PR DESCRIPTION
This adds the missing Android build that I couldn't get to work before.

Container build:
- download NDK version r16b to /opt and build toolchains for Arm, MIPS, and x86
- download SDK tools build to /opt and install required SDK packages using sdkmanager
- merge (no overwrite) SDK tools 25.2.5 over the top to regain Ant support
- download OpenJDK8 (via API query to get the latest LTS release from [AdoptOpenJDK](https://adoptopenjdk.net/)) to /opt
- download Ant to /opt
- build nativelibs and move them to /opt (this is the part that downloads from AWS so this is cached in the container to avoid being repeated, one of the Docker build arguments lets you specify which branch is used for this action)

Note: I still find that merging SDK tools to get Ant support is breaking things like the SDK manager, although it isn't used after this point

Build task:
- update git submodules
- symlink /opt/nativelibs as Android/nativelibs
- run ndk-build for 'library'
- run Ant in debug and release mode for 'launcher_list'
- rename APKs to insert the build version

Release task:
 - upload `AGS-<VERSION>-debug.apk`