### PR TITLE
Script API: added "frame" parameter to Character.Animate and Object.Animate

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2234,8 +2234,14 @@ builtin managed struct Character {
   import function AddInventory(InventoryItem *item, int addAtIndex=SCR_NO_VALUE);
   /// Manually adds a waypoint to the character's movement path.
   import function AddWaypoint(int x, int y);
+#ifdef SCRIPT_API_v3507
+  /// Animates the character using its current locked view.
+  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
+#endif
+#ifndef SCRIPT_API_v3507
   /// Animates the character using its current locked view.
   import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards);
+#endif
 #ifdef SCRIPT_API_v340
   /// Moves the character to another room. If this is the player character, the game will also switch to that room.
   import function ChangeRoom(int room, int x=SCR_NO_VALUE, int y=SCR_NO_VALUE, CharacterDirection direction=eDirectionNone);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2113,8 +2113,14 @@ enum WalkWhere {
 };
 
 builtin managed struct Object {
+#ifdef SCRIPT_API_v3507
+  /// Animates the object using its current view.
+  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
+#endif
+#ifndef SCRIPT_API_v3507
   /// Animates the object using its current view.
   import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards);
+#endif
   /// Gets the object that is on the screen at the specified co-ordinates.
   import static Object* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
 #ifndef STRICT_STRINGS

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -159,7 +159,7 @@ struct MoveList;
 namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 
-void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride, int direction);
+void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride = 0, int direction = 0, int sframe = 0);
 void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims);
 int  find_looporder_index (int curloop);
 // returns 0 to use diagonal, 1 to not
@@ -179,7 +179,6 @@ void walk_or_move_character(CharacterInfo *chaa, int x, int y, int blocking, int
 int  is_valid_character(int newchar);
 int  wantMoveNow (CharacterInfo *chi, CharacterExtras *chex);
 void setup_player_character(int charid);
-void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride=0, int direction=0);
 void CheckViewFrameForCharacter(CharacterInfo *chi);
 Common::Bitmap *GetCharacterImage(int charid, int *isFlipped);
 CharacterInfo *GetCharacterAtScreen(int xx, int yy);

--- a/Engine/ac/global_object.h
+++ b/Engine/ac/global_object.h
@@ -40,6 +40,7 @@ void SetObjectBaseline (int obn, int basel);
 int  GetObjectBaseline(int obn);
 void AnimateObjectEx(int obn,int loopn,int spdd,int rept, int direction, int blocking);
 void AnimateObject(int obn,int loopn,int spdd,int rept);
+void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking, int sframe);
 void MergeObject(int obn);
 void StopObjectMoving(int objj);
 void ObjectOff(int obn);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -107,7 +107,7 @@ int Object_GetBaseline(ScriptObject *objj) {
     return GetObjectBaseline(objj->id);
 }
 
-void Object_Animate(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction) {
+void Object_AnimateFrom(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction, int sframe) {
     if (direction == FORWARDS)
         direction = 0;
     else if (direction == BACKWARDS)
@@ -122,7 +122,11 @@ void Object_Animate(ScriptObject *objj, int loop, int delay, int repeat, int blo
     else
         quit("!Object.Animate: Invalid BLOCKING parameter");
 
-    AnimateObjectEx(objj->id, loop, delay, repeat, direction, blocking);
+    AnimateObjectImpl(objj->id, loop, delay, repeat, direction, blocking, sframe);
+}
+
+void Object_Animate(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction) {
+    Object_AnimateFrom(objj, loop, delay, repeat, blocking, direction, 0);
 }
 
 void Object_StopAnimating(ScriptObject *objj) {
@@ -544,6 +548,11 @@ RuntimeScriptValue Sc_Object_Animate(void *self, const RuntimeScriptValue *param
     API_OBJCALL_VOID_PINT5(ScriptObject, Object_Animate);
 }
 
+RuntimeScriptValue Sc_Object_AnimateFrom(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT6(ScriptObject, Object_AnimateFrom);
+}
+
 // int (ScriptObject *objj, ScriptObject *obj2)
 RuntimeScriptValue Sc_Object_IsCollidingWithObject(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -890,6 +899,7 @@ RuntimeScriptValue Sc_Object_SetY(void *self, const RuntimeScriptValue *params, 
 void RegisterObjectAPI()
 {
     ccAddExternalObjectFunction("Object::Animate^5",                Sc_Object_Animate);
+    ccAddExternalObjectFunction("Object::Animate^6",                Sc_Object_AnimateFrom);
     ccAddExternalObjectFunction("Object::IsCollidingWithObject^1",  Sc_Object_IsCollidingWithObject);
     ccAddExternalObjectFunction("Object::GetName^1",                Sc_Object_GetName);
     ccAddExternalObjectFunction("Object::GetProperty^1",            Sc_Object_GetProperty);


### PR DESCRIPTION
For #560

Added optional "frame" parameter to Character.Animate and Object.Animate functions that tells which frame to begin animating with.

Trying to comply with existing behavior, reverse animations begin with the *previous frame*, so e.g. if you pass frame 0 they will begin with the last frame instead, if you pass frame 1 they will begin with 0th and so on.

Note: I was also thinking about adding same for Button.Animate, but I noticed that its parameter list does not have several other options, such as Direction and BlockingStyle, so maybe later there should be a separate task of adding them all at once. Besides, buttons are much easier to animate in script on your own.