### PR TITLE
changes for android arm64 build

### DIFF
--- a/Android/buildlibs/arm64-v8a/allegro.sh
+++ b/Android/buildlibs/arm64-v8a/allegro.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=allegro-4.4.2
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/allegro-4.4.2.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+# Platform independent patch
+patch -p0 < ../../../patches/liballegro-4.4.2.patch
+
+cmake . -G "Unix Makefiles" \
+	-DWANT_TESTS=off \
+	-DWANT_EXAMPLES=off \
+	-DWANT_TOOLS=off \
+	-DWANT_LOGG=off \
+	-DWANT_ALLEGROGL=off \
+	-DSHARED=off \
+	-DCMAKE_C_FLAGS="$NDK_CFLAGS -fsigned-char" \
+	-DCMAKE_CXX_FLAGS="-fno-rtti -fno-exceptions" \
+	-DCMAKE_LD_FLAGS="$NDK_LDFLAGS" \
+	-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-android-gcc.cmake \
+	-DCMAKE_INSTALL_PREFIX=$NDK_ADDITIONAL_LIBRARY_PATH
+
+make 
+make install
+
+popd
+
+rm -rf $SRC_DIR
+

--- a/Android/buildlibs/arm64-v8a/dumb.sh
+++ b/Android/buildlibs/arm64-v8a/dumb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=dumb-0.9.3
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/dumb-0.9.3.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+patch -p1 < ../../../patches/libdumb-0.9.3.patch
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/arm64-v8a/freetype.sh
+++ b/Android/buildlibs/arm64-v8a/freetype.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=freetype-2.4.12
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/freetype-2.4.12.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -std=gnu99 -fsigned-char" 
+export LDFLAGS="$NDK_LDFLAGS"
+
+./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --without-zlib --disable-shared
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/arm64-v8a/lua.sh
+++ b/Android/buildlibs/arm64-v8a/lua.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=lua-5.1.5
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/lua-5.1.5.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+# Apply platform patch
+patch -p0 < ../../../patches/liblua.patch
+
+export CC=${NDK_HOST_NAME}-gcc
+export MYCFLAGS="$NDK_CFLAGS -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include"
+export MYLDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+make generic 
+make install INSTALL_TOP=$NDK_ADDITIONAL_LIBRARY_PATH
+
+popd 
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/arm64-v8a/ndkenv
+++ b/Android/buildlibs/arm64-v8a/ndkenv
@@ -1,0 +1,18 @@
+get_abs_path() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
+
+export NDK_PLATFORM_ROOT=$NDK_STANDALONE/arm64
+export NDK_PLATFORM_NAME=arm64-v8a
+export NDK_HOST_NAME=aarch64-linux-android
+export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
+export PATH=$NDK_PLATFORM_ROOT/bin:$PATH
+export PKG_CONFIG_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/lib/pkgconfig
+export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
+
+export NDK_CFLAGS=" -D__ANDROID_API__=\$API"
+export CC=$NDK_PLATFORM_ROOT/bin/${NDK_HOST_NAME}-clang
+export CXX=$NDK_PLATFORM_ROOT/bin/${NDK_HOST_NAME}-clang++ 

--- a/Android/buildlibs/arm64-v8a/ogg.sh
+++ b/Android/buildlibs/arm64-v8a/ogg.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libogg-1.3.2
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -fsigned-char "
+export LDFLAGS="$NDK_LDFLAGS"
+
+./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared
+
+make
+make install
+
+popd 
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/arm64-v8a/theora.sh
+++ b/Android/buildlibs/arm64-v8a/theora.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libtheora-20150828-gfbb2758
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libtheora-20150828-gfbb2758.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include"
+export LDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+pushd $SRC_DIR
+
+# disable asflag-probe as it guess wrong arm arch
+./autogen.sh --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-examples --disable-asflag-probe --disable-encode --disable-shared --disable-oggtest --disable-vorbistest
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/arm64-v8a/tremor.sh
+++ b/Android/buildlibs/arm64-v8a/tremor.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libtremor-20150108-r19427
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libtremor-20150108-r19427.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+# use -marm to override -mthumb in ndkenv
+export CFLAGS="$NDK_CFLAGS -marm -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include -DLITTLE_ENDIAN -DBYTE_ORDER=LITTLE_ENDIAN"
+export LDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+./autogen.sh --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/buildall.sh
+++ b/Android/buildlibs/buildall.sh
@@ -7,18 +7,18 @@ pushd ../../libsrc
 popd
 
 # android-14 is the minimum we can go with current Android SDK
-PLATFORM=android-14
+PLATFORM=android-21
 
 # standalone toolchains cannot share same directory
 export NDK_STANDALONE=$NDK_HOME/platforms/$PLATFORM
 
-for arch in armeabi armeabi-v7a x86 mips
+for arch in arm64-v8a armeabi armeabi-v7a x86 x86_64 mips 
 do
 	rm -rf ../nativelibs/$arch
 	mkdir -p ../nativelibs/$arch
 	pushd $arch
 	chmod +x *.sh
-	./lua.sh	
+#	./lua.sh	
 	./ogg.sh	
 	./tremor.sh  # ("vorbis") requires ogg
 	./theora.sh  # requires ogg, "vorbis"

--- a/Android/buildlibs/makestandalones.sh
+++ b/Android/buildlibs/makestandalones.sh
@@ -12,14 +12,14 @@ if [[ -z "$NDK_HOME" ]]; then
 fi
 
 # android-14 is the minimum we can go with current Android SDK
-PLATFORM=android-14
+PLATFORM=android-21
 
 # standalone toolchains cannot share same directory
 export NDK_STANDALONE=$NDK_HOME/platforms/$PLATFORM
 
 # if you don't pass force, the directory is not rewritten
 # verbose is needed to see why making the toolchain fails
-for arch in arm x86 mips
+for arch in arm arm64 x86 x86_64 mips
 do
     INSTALL_DIR=$NDK_STANDALONE/$arch
     mkdir -p $INSTALL_DIR

--- a/Android/buildlibs/x86_64/allegro.sh
+++ b/Android/buildlibs/x86_64/allegro.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=allegro-4.4.2
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/allegro-4.4.2.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+# Platform independent patch
+patch -p0 < ../../../patches/liballegro-4.4.2.patch
+
+cmake . -G "Unix Makefiles" \
+	-DWANT_TESTS=off \
+	-DWANT_EXAMPLES=off \
+	-DWANT_TOOLS=off \
+	-DWANT_LOGG=off \
+	-DWANT_ALLEGROGL=off \
+	-DSHARED=off \
+	-DCMAKE_C_FLAGS="$NDK_CFLAGS -fsigned-char" \
+	-DCMAKE_CXX_FLAGS="-fno-rtti -fno-exceptions" \
+	-DCMAKE_LD_FLAGS="$NDK_LDFLAGS" \
+	-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-android-gcc.cmake \
+	-DCMAKE_INSTALL_PREFIX=$NDK_ADDITIONAL_LIBRARY_PATH
+
+make 
+make install
+
+popd
+
+rm -rf $SRC_DIR
+

--- a/Android/buildlibs/x86_64/dumb.sh
+++ b/Android/buildlibs/x86_64/dumb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=dumb-0.9.3
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/dumb-0.9.3.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+patch -p1 < ../../../patches/libdumb-0.9.3.patch
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/x86_64/freetype.sh
+++ b/Android/buildlibs/x86_64/freetype.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=freetype-2.4.12
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/freetype-2.4.12.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -std=gnu99 -fsigned-char" 
+export LDFLAGS="$NDK_LDFLAGS"
+
+./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --without-zlib --disable-shared
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/x86_64/lua.sh
+++ b/Android/buildlibs/x86_64/lua.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=lua-5.1.5
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/lua-5.1.5.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+# Apply platform patch
+patch -p0 < ../../../patches/liblua.patch
+
+export CC=${NDK_HOST_NAME}-gcc
+export MYCFLAGS="$NDK_CFLAGS -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include"
+export MYLDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+make generic 
+make install INSTALL_TOP=$NDK_ADDITIONAL_LIBRARY_PATH
+
+popd 
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/x86_64/ndkenv
+++ b/Android/buildlibs/x86_64/ndkenv
@@ -1,0 +1,18 @@
+get_abs_path() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+unset DEVROOT SDKROOT CFLAGS CC LD CPP CXX AR AS NM CXXCPP RANLIB LDFLAGS CPPFLAGS CXXFLAGS
+
+export NDK_PLATFORM_ROOT=$NDK_STANDALONE/x86_64
+export NDK_PLATFORM_NAME=x86_64
+export NDK_HOST_NAME=x86_64-linux-android
+export NDK_ADDITIONAL_LIBRARY_PATH=$(get_abs_path "../../nativelibs/$NDK_PLATFORM_NAME")
+export PATH=$NDK_PLATFORM_ROOT/bin:$PATH
+export PKG_CONFIG_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/lib/pkgconfig
+export ACLOCAL_PATH=$NDK_ADDITIONAL_LIBRARY_PATH/share/aclocal
+
+export NDK_CFLAGS=" -D__ANDROID_API__=\$API"
+export CC=$NDK_PLATFORM_ROOT/bin/${NDK_HOST_NAME}-gcc
+export CXX=$NDK_PLATFORM_ROOT/bin/${NDK_HOST_NAME}-g++ 

--- a/Android/buildlibs/x86_64/ogg.sh
+++ b/Android/buildlibs/x86_64/ogg.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libogg-1.3.2
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libogg-1.3.2.tar.gz --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -fsigned-char "
+export LDFLAGS="$NDK_LDFLAGS"
+
+./configure --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared
+
+make
+make install
+
+popd 
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/x86_64/theora.sh
+++ b/Android/buildlibs/x86_64/theora.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libtheora-20150828-gfbb2758
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libtheora-20150828-gfbb2758.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include"
+export LDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+pushd $SRC_DIR
+
+# disable asflag-probe as it guess wrong arm arch
+./autogen.sh --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-examples --disable-asflag-probe --disable-encode --disable-shared --disable-oggtest --disable-vorbistest
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/buildlibs/x86_64/tremor.sh
+++ b/Android/buildlibs/x86_64/tremor.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+source ./ndkenv
+
+SRC_DIR=libtremor-20150108-r19427
+rm -rf $SRC_DIR
+mkdir $SRC_DIR
+tar xf ../../../libsrc/libtremor-20150108-r19427.tar.bz2 --strip-components=1 -C $SRC_DIR
+
+pushd $SRC_DIR
+
+export CFLAGS="$NDK_CFLAGS -fsigned-char -I$NDK_ADDITIONAL_LIBRARY_PATH/include -DLITTLE_ENDIAN -DBYTE_ORDER=LITTLE_ENDIAN"
+export LDFLAGS="$NDK_LDFLAGS -Wl,-L$NDK_ADDITIONAL_LIBRARY_PATH/lib"
+
+./autogen.sh --host=$NDK_HOST_NAME --prefix=$NDK_ADDITIONAL_LIBRARY_PATH --disable-shared
+
+make
+make install
+
+popd
+
+rm -rf $SRC_DIR

--- a/Android/library/jni/Application.mk
+++ b/Android/library/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_PROJECT_PATH := $(call my-dir)/..
-APP_MODULES      := agsengine pe ags_snowrain agsblend agsflashlight agslua agsspritefont ags_parallax agspalrender
+APP_MODULES      := agsengine pe ags_snowrain agsblend agsflashlight agsspritefont ags_parallax agspalrender
 APP_STL          := gnustl_static
 APP_OPTIM        := release
 APP_GNUSTL_FORCE_CPP_FEATURES := exceptions
 #NDK_TOOLCHAIN_VERSION := 4.4.3
-APP_ABI          := armeabi armeabi-v7a x86 mips
+APP_ABI          := arm64-v8a armeabi armeabi-v7a x86 x86_64 mips 

--- a/ci/android/Dockerfile
+++ b/ci/android/Dockerfile
@@ -36,9 +36,9 @@ RUN curl -fLOJ "https://dl.google.com/android/repository/android-ndk-${NDK_VERSI
 
 # Make NDK toolchains
 RUN export NDK_HOME=/opt/android-ndk-${NDK_VERSION} && \
-  for arch in arm mips x86; do \
+  for arch in arm arm64 x86 x86_64 mips; do \
     echo Building toolchain for $arch; \
-    $NDK_HOME/build/tools/make_standalone_toolchain.py --arch $arch --api 14 --install-dir $NDK_HOME/platforms/android-14/$arch; \
+    $NDK_HOME/build/tools/make_standalone_toolchain.py --arch $arch --api 21 --install-dir $NDK_HOME/platforms/android-14/$arch; \
   done
 
 # Get Android SDK manager


### PR DESCRIPTION
Please do not merge without testing this.

As stated on #600 , Google Play doesn't accept app builds that don't contain 64-bit Arm binaries. This PR adds Arm64 builds.