### PR TITLE
Fix default transparency preference for sprite import

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -131,7 +131,7 @@ namespace AGS.Editor
         {
             InitializeComponent();
 
-            // take some defailts from Editor prederences
+            // take some defaults from Editor preferences
             SpriteImportMethod = (SpriteImportTransparency)Factory.AGSEditor.Settings.SpriteImportMethod;
 
             // import, not replace
@@ -158,7 +158,7 @@ namespace AGS.Editor
         {
             InitializeComponent();
 
-            // take some defailts from Editor prederences
+            // take some defaults from Editor preferences
             SpriteImportMethod = (SpriteImportTransparency)Factory.AGSEditor.Settings.SpriteImportMethod;
 
             // import, not replace

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -100,7 +100,7 @@ namespace AGS.Editor
 
             set
             {
-                switch(SpriteImportMethod)
+                switch(value)
                 {
                     case SpriteImportTransparency.PaletteIndex0:
                         radTransColourIndex0.Checked = true;


### PR DESCRIPTION
The selected preference was never set in the import window because it mistakenly used its own default value. Also, some typo fixes.

Fixes #925

