### PR TITLE
Split and update CI tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,8 @@ build_windows_task:
   binaries_artifacts:
     path: Solutions/.build/*/*
 
-build_linux_task:
+build_linux_cmake_task:
+  only_if: $CIRRUS_RELEASE == ''
   container:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
@@ -34,69 +35,78 @@ build_linux_task:
         - FROM_DEBIAN: i386/debian:jessie
   env:
     matrix:
-      - BUILD_SYSTEM: cmake
-        BUILD_TYPE: release
-      - BUILD_SYSTEM: cmake
-        BUILD_TYPE: debug
-      - BUILD_SYSTEM: debian
-        RPATH_PREFIX: lib
-      - BUILD_SYSTEM: debian
-      - BUILD_SYSTEM: make
+      - BUILD_TYPE: release
+      - BUILD_TYPE: debug
   build_script: |
     arch=$(dpkg --print-architecture)
-    case $BUILD_SYSTEM in
-      cmake)
-        filename=${BUILD_TYPE}_$arch
-        mkdir build_$filename && cd build_$filename
-        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. && make
-        ;;
-      debian)
-        version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
-        sed -i -s "s/ags \(.*\)(.*)/ags \($version\)\1/" debian/changelog
-        case $arch in
-          amd64)
-            bit=64
-            ;;
-          i386)
-            bit=32
-            ;;
-          *)
-            echo "Unknown architecture"
-            exit 1
-            ;;
-        esac
-        if [ -n "$RPATH_PREFIX" ]; then
-          DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" fakeroot debian/rules binary
-          sed -E "/^BI(NDMOUNT|T)=/d" debian/ags+libraries/hooks/B00_copy_libs.sh | BIT=$bit BINDMOUNT=$(pwd) sh
-          ar -p ../ags_${version}_$arch.deb data.tar.xz | unxz | tar -f - -xvC data --transform "s/.*ags/ags$bit/" ./usr/bin/ags
-          cd data && tar -cvzf ../data_$arch.tar.gz *
-        else
-          fakeroot debian/rules binary
-          mv ../ags_${version}_$arch.deb .
-        fi
-        ;;
-      make)
-        make --directory=Engine
-        mkdir build_$arch && mv Engine/ags build_$arch/
-        ;;
-      *)
-        echo "Invalid build system"
-        exit 1
-        ;;
-    esac
+    filename=${BUILD_TYPE}_$arch
+    mkdir build_$filename && cd build_$filename
+    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. && make
   binaries_artifacts:
     path: build_*/ags
+
+build_linux_debian_task:
+  container:
+    dockerfile: ci/linux/Dockerfile
+    docker_arguments:
+      matrix:
+        - FROM_DEBIAN: debian:jessie
+        - FROM_DEBIAN: i386/debian:jessie
+  env:
+    matrix:
+      - RPATH_PREFIX: lib
+      - RPATH_PREFIX:
+  build_script: |
+    arch=$(dpkg --print-architecture)
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    sed -i -s "s/ags \(.*\)(.*)/ags \($version\)\1/" debian/changelog
+    if [ -n "$RPATH_PREFIX" ]; then
+      case $arch in
+        amd64)
+          bit=64
+          ;;
+        i386)
+          bit=32
+          ;;
+        *)
+          echo "Unknown architecture"
+          exit 1
+          ;;
+      esac
+      DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" fakeroot debian/rules binary
+      sed -E "/^BI(NDMOUNT|T)=/d" debian/ags+libraries/hooks/B00_copy_libs.sh | BIT=$bit BINDMOUNT=$(pwd) sh
+      ar -p ../ags_${version}_$arch.deb data.tar.xz | unxz | tar -f - -xvC data --transform "s/.*ags/ags$bit/" ./usr/bin/ags
+      cd data && tar -cvzf ../data_$arch.tar.gz *
+    else
+      fakeroot debian/rules binary
+      mv ../ags_${version}_$arch.deb .
+    fi
   debian_packages_artifacts:
-    path: ags*.deb
-  debian_files_artifacts:
+    path: ags_*.deb
+  data_files_artifacts:
     path: data_*.tar.gz
+
+build_linux_make_task:
+  only_if: $CIRRUS_RELEASE == ''
+  container:
+    dockerfile: ci/linux/Dockerfile
+    docker_arguments:
+      matrix:
+        - FROM_DEBIAN: debian:jessie
+        - FROM_DEBIAN: i386/debian:jessie
+  build_script: |
+    arch=$(dpkg --print-architecture)
+    make --directory=Engine
+    mkdir build_$arch && mv Engine/ags build_$arch/
+  binaries_artifacts:
+    path: build_*/ags
 
 build_macos_task:
   only_if: $CIRRUS_RELEASE == ''
   osx_instance:
     matrix:
-      - image: mojave-xcode-10.2
-      - image: high-sierra-xcode-9.4.1
+      - image: mojave-xcode-10.2   # newest minor release of previous version
+      - image: mojave-xcode        # alias to latest xcode (11.x)
   env:
     matrix:
       - BUILD_TYPE: debug
@@ -174,42 +184,34 @@ build_editor_task:
 
 linux_packaging_task:
   depends_on:
-    - build_linux
-  freebsd_instance:
-    image: freebsd-12-0-release-amd64
+    - build_linux_debian
+  container:
+    image: alpine:3.10
   env:
     ALLEGRO_RELEASE: v4.4.3.1-agspatch-2
+  install_packages_script: apk add --no-cache curl libarchive-tools
   package_script: |
     tmp=/tmp/bundle$$
     mkdir -p $tmp/data
-    for arch in i386 amd64
-    do
-      case $arch in
-        amd64)
-          bit=64
-          ;;
-        i386)
-          bit=32
-          ;;
-      esac
-      echo Downloading files for $arch
-      url="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/build_linux/debian_files/data_$arch.tar.gz"
-      curl -fLsS "$url" | tar -f - -xvzC $tmp/data
-      echo Downloading Allegro $ALLEGRO_RELEASE $arch
-      mkdir $tmp/allegro_${ALLEGRO_RELEASE}_$arch
-      url="https://github.com/adventuregamestudio/lib-allegro/releases/download/$ALLEGRO_RELEASE/lib-allegro_release_$arch.tar.gz"
-      curl -fLsS "$url" | tar -f - -xvzC $tmp/allegro_${ALLEGRO_RELEASE}_$arch --strip-components 1 -s '|pkgconfig/.*||' lib
-      find $tmp/allegro_${ALLEGRO_RELEASE}_$arch \( -name "alleg-*" -or -name "liballeg.so.?.?" \) \
-        -exec cp -v "{}" $tmp/data/lib$bit/ \;
-      echo alleg-sdl2digi.so >> $tmp/data/lib$bit/modules.lst
+    for archbit in i386-32 amd64-64; do
+      echo Downloading files for ${archbit%-*}
+      url="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/build_linux_debian/data_files/data_${archbit%-*}.tar.gz"
+      curl -fLsS "$url" | bsdtar -f - -xvzC $tmp/data
+      echo Downloading Allegro $ALLEGRO_RELEASE ${archbit%-*}
+      mkdir $tmp/allegro_${ALLEGRO_RELEASE}_${archbit%-*}
+      url="https://github.com/adventuregamestudio/lib-allegro/releases/download/$ALLEGRO_RELEASE/lib-allegro_release_${archbit%-*}.tar.gz"
+      curl -fLsS "$url" | bsdtar -f - -xvzC $tmp/allegro_${ALLEGRO_RELEASE}_${archbit%-*} --strip-components 1 -s '|pkgconfig/.*||' lib
+      find $tmp/allegro_${ALLEGRO_RELEASE}_${archbit%-*} \( -name "alleg-*" -or -name "liballeg.so.?.?" \) \
+        -exec cp -v "{}" $tmp/data/lib${archbit#*-}/ \;
+      echo alleg-sdl2digi.so >> $tmp/data/lib${archbit#*-}/modules.lst
     done
     cp -v debian/copyright $tmp/data/licenses/ags-copyright
     cp -v debian/ags+libraries/startgame $tmp/
     awk 'BEGIN { RS="" } !/make_ags/ { if (NR>1) print RS; print }' debian/ags+libraries/README > $tmp/README
     version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
-    tar -f ags_linux_$version.tar.gz -cvzC $tmp data startgame README
+    bsdtar -f ags_${version}_linux.tar.gz -cvzC $tmp data startgame README
   binaries_artifacts:
-    path: ags_linux_*.tar.gz
+    path: ags_*.tar.gz
 
 editor_packaging_task:
   depends_on:
@@ -243,7 +245,7 @@ editor_packaging_task:
   get_linux_bundle_script: >
     mkdir Windows\Installer\Source\Linux &&
     call Script\setvar.cmd ACI_VERSION_STR &&
-    cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/linux_packaging/binaries/ags_linux_!ACI_VERSION_STR!.tar.gz" |
+    cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/linux_packaging/binaries/ags_!ACI_VERSION_STR!_linux.tar.gz" |
     tar -f - -xvC Windows\Installer\Source\Linux --strip-components 1"
   make_installer_script: >
     powershell Windows\Installer\build.ps1 -IsccPath 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
@@ -261,47 +263,78 @@ editor_packaging_task:
   archive_artifacts:
     path: AGS-*.zip
 
-upload_release_task:
-  only_if: $CIRRUS_RELEASE != ''
+pdb_packaging_task:
   depends_on:
-    - build_android
-    - build_linux
-    - editor_packaging
-    - linux_packaging
-  freebsd_instance:
-    image: freebsd-12-0-release-amd64
-  env:
-    GITHUB_TOKEN: ENCRYPTED[f94b2c269006d530d3e6f5f2be0962ba3eeb0d5f43630ad8172b9ef9c405611e54ae5a2b6efc7c53db68176168f0c83d]
-  download_script: |
-    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
-    mkdir pdb && \
-    mkdir github_release && \
+    - build_editor
+    - build_windows
+  container:
+    image: alpine:3.10
+  install_packages_script: apk add --no-cache curl libarchive-tools
+  download_pdb_files_script: |
+    mkdir /tmp/pdb &&
     for download in "build_windows/engine_pdb.zip" \
       "build_editor/ags_editor_pdb.zip" \
       "build_editor/ags_native_pdb.zip"
     do
-      curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download" | tar -f - -xvzC pdb -s "!.*/Debug/.*!!p" -s "!.*/!!p"
-    done && \
-    tar -f github_release/AGS-${version}-pdb.zip -acv --strip-components 1 pdb && \
-    cd github_release && \
-    for download in "linux_packaging/binaries/ags_linux_$version.tar.gz" \
-      "editor_packaging/installer/Windows/Installer/Output/AGS-$version.exe" \
+      curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download" | bsdtar -f - -xvzC /tmp/pdb -s "!.*/Debug/.*!!p" -s "!.*/!!p"
+    done
+  make_pdb_archive_script: |
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    bsdtar -f AGS-${version}-pdb.zip -acv --strip-components 3 /tmp/pdb
+  archive_artifacts:
+    path: AGS-*-pdb.zip
+
+make_release_task:
+  depends_on:
+    - build_android
+    - build_linux_debian
+    - editor_packaging
+    - linux_packaging
+    - pdb_packaging
+  container:
+    image: alpine:3.10
+  env:
+    GITHUB_TOKEN: ENCRYPTED[f94b2c269006d530d3e6f5f2be0962ba3eeb0d5f43630ad8172b9ef9c405611e54ae5a2b6efc7c53db68176168f0c83d]
+  install_packages_script: apk add --no-cache curl git libarchive-tools outils-sha256
+  git_submodules_script: git submodule update --init --recursive
+  create_source_archives_script: |
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    mkdir -p /tmp/github_release && \
+    for ext in tar.bz2 tar.gz tar.xz zip; do
+      echo Writing $ext archive...
+      bsdtar -f /tmp/github_release/ags_${version}_source.$ext \
+        -acs "!\./\(.*\)!ags_${version}_source/\1!" \
+        --exclude ".git*" \
+        --exclude .cirrus.yml \
+        .;
+    done
+  download_release_files_script: |
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    baseurl="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID"
+    mkdir -p /tmp/github_release && \
+    cd /tmp/github_release && \
+    for download in "linux_packaging/binaries/ags_${version}_linux.tar.gz" \
       "editor_packaging/archive/AGS-$version.zip" \
+      "pdb_packaging/archive/AGS-${version}-pdb.zip" \
       "build_linux/debian_packages/ags_${version}_i386.deb" \
       "build_linux/debian_packages/ags_${version}_amd64.deb" \
       "build_android/binaries/Android/launcher_list/bin/AGS-${version}-debug.apk"
     do
-      url="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download"
+      url="$baseurl/$download"
       echo "Downloading $url"
       curl -fLOJ "$url"
-    done
-  checksums_script: |
-    cd github_release && \
-    sha256 -r * | sed -E "s/[[:blank:]]+/  /" > /tmp/checksums.sha256 && \
+    done && \
+    curl -fLSs "$baseurl/editor_packaging/installer.zip" | bsdtar -f - -xv --strip-components 3
+  create_checksums_script: >
+    cd /tmp/github_release &&
+    sha256 -r * | sed -E "s/[[:blank:]]+/  /" | tee /tmp/checksums.sha256 &&
     mv /tmp/checksums.sha256 .
-  release_script: |
-    for fpath in $(find github_release -type f)
-    do
+  upload_release_script: |
+    if [ -z "$CIRRUS_RELEASE" ]; then
+      echo "This is not a release."
+      exit 0
+    fi
+    for fpath in $(find /tmp/github_release -type f); do
       echo "Uploading $fpath"
       curl -X POST \
         --data-binary @$fpath \


### PR DESCRIPTION
The only functional difference is the addition of source archives to the release process, and that the release process is more visible. When releasing, a lot less tasks should run and it should be more apparent where artifacts are coming from.

Adds source releases for #800

Edit: forgot to mention [here](https://github.com/morganwillcock/ags/releases/tag/v3.5.0.17-test-1) is an example release