### PR TITLE
Editor: remember last selected item in the room

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -483,6 +483,29 @@ namespace AGS.Editor
             }
         }
 
+        /// <summary>
+        /// Sets property list for the given ContentDocument, and displays it in the
+        /// property grid if the given document is an active pane
+        /// (otherwise just assign them to the given document).
+        /// Optionally provides default object: that object will be selected if
+        /// previously selected object is no longer available in the new list.
+        /// </summary>
+        public void SetPropertyGridObjectList(Dictionary<string, object> propertyObjects, ContentDocument doc, object defObject)
+        {
+            if (_mainForm.ActivePane == doc)
+            {
+                _mainForm.ActivePane.PropertyGridObjectList = propertyObjects;
+                _mainForm.RefreshPropertyGridForDocument(_mainForm.ActivePane);
+            }
+            else
+            {
+                object selObject = doc.SelectedPropertyGridObject;
+                doc.PropertyGridObjectList = propertyObjects;
+                if (!propertyObjects.ContainsValue(selObject))
+                    doc.SelectedPropertyGridObject = defObject;
+            }
+        }
+
         public object GetPropertyGridObject()
         {
             if (_mainForm.ActivePane == null) return null;
@@ -496,6 +519,25 @@ namespace AGS.Editor
                 _mainForm.ActivePane.SelectedPropertyGridObject = objectToSetPropertiesOn;
                 _mainForm.ActivePane.SelectedPropertyGridObjects = null;
                 _mainForm.RefreshPropertyGridForDocument(_mainForm.ActivePane);
+            }
+        }
+
+        /// <summary>
+        /// Set selected property object for the given ContentDocument, and displays it in the
+        /// property grid if the given document is an active pane
+        /// (otherwise just assign them to the given document).
+        /// </summary>
+        public void SetPropertyGridObject(object objectToSetPropertiesOn, ContentDocument doc)
+        {
+            if (_mainForm.ActivePane == doc)
+            {
+                _mainForm.ActivePane.SelectedPropertyGridObject = objectToSetPropertiesOn;
+                _mainForm.ActivePane.SelectedPropertyGridObjects = null;
+                _mainForm.RefreshPropertyGridForDocument(_mainForm.ActivePane);
+            }
+            else
+            {
+                doc.SelectedPropertyGridObject = objectToSetPropertiesOn;
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -39,8 +39,9 @@ namespace AGS.Editor
 
         private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         protected Room _room;
-        protected Panel _panel;        
-		protected ToolTip _tooltip;
+        protected Panel _panel;
+        RoomSettingsEditor _editor;
+        protected ToolTip _tooltip;
         private bool _isOn = false;
         private int _selectedArea = 1;
 		private int _drawingWithArea;
@@ -56,7 +57,7 @@ namespace AGS.Editor
         private static Cursor _selectCursor;
 		private static bool _greyedOutMasks = true;
 
-        public BaseAreasEditorFilter(Panel displayPanel, Room room)
+        public BaseAreasEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
         {
             if (!_registeredIcons)
             {
@@ -91,6 +92,7 @@ namespace AGS.Editor
 
             _room = room;
             _panel = displayPanel;
+            _editor = editor;
             _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
             UpdateUndoButtonEnabledState();
             RoomItemRefs = new SortedDictionary<string, int>();
@@ -590,7 +592,7 @@ namespace AGS.Editor
                 SelectedAreaChanged(area);                
                 return;  
             }
-            Factory.GUIController.SetPropertyGridObject(_room);            
+            SetPropertyGridObject(_room);
         }
 
         public virtual Cursor GetCursor(int x, int y, RoomEditorState state)
@@ -646,9 +648,19 @@ namespace AGS.Editor
         /// </summary>
         /// <returns></returns>
         protected abstract SortedDictionary<string, int> InitItemRefs();
-        protected abstract void SetPropertyGridList();
+        protected abstract Dictionary<string, object> GetPropertyGridList();
         protected abstract void SelectedAreaChanged(int areaNumber);
         protected abstract void GUIController_OnPropertyObjectChanged(object newPropertyObject);
+
+        protected void SetPropertyGridList()
+        {
+            Factory.GUIController.SetPropertyGridObjectList(GetPropertyGridList(), _editor.ContentDocument, _room);
+        }
+
+        protected void SetPropertyGridObject(object obj)
+        {
+            Factory.GUIController.SetPropertyGridObject(obj, _editor.ContentDocument);
+        }
 
         private void InitGameEntities()
         {

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -295,33 +295,18 @@ namespace AGS.Editor
 
         private void SetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
-            foreach (var item in RoomItemRefs)
-            {
-                defaultPropertyObjectList.Add(item.Value.PropertyGridTitle, item.Value);
-            }
-
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
-        }
-
-        // Refreshes property grid list explicitly for this room editor's content document;
-        // this is done to work around regular update system which assumes editor to be
-        // an active pane, which is not necessarily the case (this could be background operation).
-        // NOTE: this is done exclusively for Character Filter, because it's the only one
-        // that shares objects with other panes (Character Editor pane).
-        private void SetPropertyGridListExplicit()
-        {
-            object selObject = _editor.ContentDocument.SelectedPropertyGridObject;
             Dictionary<string, object> list = new Dictionary<string, object>();
             list.Add(_room.PropertyGridTitle, _room);
             foreach (var item in RoomItemRefs)
             {
                 list.Add(item.Value.PropertyGridTitle, item.Value);
             }
-            _editor.ContentDocument.PropertyGridObjectList = list;
-            if (!list.ContainsValue(selObject))
-                _editor.ContentDocument.SelectedPropertyGridObject = _room;
+            Factory.GUIController.SetPropertyGridObjectList(list, _editor.ContentDocument, _room);
+        }
+
+        protected void SetPropertyGridObject(object obj)
+        {
+            Factory.GUIController.SetPropertyGridObject(obj, _editor.ContentDocument);
         }
 
         private void GUIController_OnPropertyObjectChanged(object newPropertyObject)
@@ -460,13 +445,13 @@ namespace AGS.Editor
                 if (RoomItemRefs.TryGetValue(id, out character))
                 {
                     _selectedCharacter = character;
-                    Factory.GUIController.SetPropertyGridObject(character);                    
+                    SetPropertyGridObject(character);                    
                     return;
                 }
             }
 
             _selectedCharacter = null;
-            Factory.GUIController.SetPropertyGridObject(_room);            
+            SetPropertyGridObject(_room);
         }
 
         public Cursor GetCursor(int x, int y, RoomEditorState state)
@@ -515,7 +500,7 @@ namespace AGS.Editor
             OnItemsChanged(this, null);
             Invalidate();
             if (Enabled)
-                SetPropertyGridListExplicit();
+                SetPropertyGridList();
         }
 
         private void AddCharacterRef(Character c)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -10,7 +10,8 @@ namespace AGS.Editor
 {
     public class HotspotsEditorFilter : BaseAreasEditorFilter
     {
-        public HotspotsEditorFilter(Panel displayPanel, Room room) : base(displayPanel, room)
+        public HotspotsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
+            : base(displayPanel, editor, room)
         {
         }
 
@@ -29,7 +30,7 @@ namespace AGS.Editor
 
         protected override void SelectedAreaChanged(int areaNumber)
         {
-            Factory.GUIController.SetPropertyGridObject(_room.Hotspots[areaNumber]);
+            SetPropertyGridObject(_room.Hotspots[areaNumber]);
         }
 
         public override void Paint(Graphics graphics, RoomEditorState state)
@@ -64,16 +65,15 @@ namespace AGS.Editor
             return items;
         }
 
-        protected override void SetPropertyGridList()
+        protected override Dictionary<string, object> GetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
+            var list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
             foreach (RoomHotspot hotspot in _room.Hotspots)
             {
-                defaultPropertyObjectList.Add(hotspot.PropertyGridTitle, hotspot);
+                list.Add(hotspot.PropertyGridTitle, hotspot);
             }
-
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+            return list;
         }
 
         protected override void GUIController_OnPropertyObjectChanged(object newPropertyObject)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -14,6 +14,7 @@ namespace AGS.Editor
         private const string MENU_ITEM_OBJECT_COORDS = "ObjectCoordinates";
         protected Room _room;
         protected Panel _panel;
+        protected RoomSettingsEditor _editor;
         private bool _isOn;
         private GUIController.PropertyObjectChangedHandler _propertyObjectChangedDelegate;
         private RoomObject _selectedObject;
@@ -25,10 +26,11 @@ namespace AGS.Editor
         private int _menuClickX, _menuClickY;
         private List<RoomObject> _objectBaselines = new List<RoomObject>();
 
-        public ObjectsEditorFilter(Panel displayPanel, Room room)
+        public ObjectsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
         {
             _room = room;
             _panel = displayPanel;
+            _editor = editor;
             _selectedObject = null;
             _propertyObjectChangedDelegate = new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
             RoomItemRefs = new SortedDictionary<string, RoomObject>();
@@ -435,13 +437,13 @@ namespace AGS.Editor
                 if (RoomItemRefs.TryGetValue(id, out obj))
                 {
                     _selectedObject = obj;
-                    Factory.GUIController.SetPropertyGridObject(obj);                    
+                    SetPropertyGridObject(obj);                    
                     return;
                 }
             }
 
             _selectedObject = null;
-            Factory.GUIController.SetPropertyGridObject(_room);            
+            SetPropertyGridObject(_room);            
         }
 
         public Cursor GetCursor(int x, int y, RoomEditorState state)
@@ -469,14 +471,18 @@ namespace AGS.Editor
 
         private void SetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
+            Dictionary<string, object> list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
             foreach (RoomObject obj in _room.Objects)
             {
-                defaultPropertyObjectList.Add(obj.PropertyGridTitle, obj);
+                list.Add(obj.PropertyGridTitle, obj);
             }
+            Factory.GUIController.SetPropertyGridObjectList(list, _editor.ContentDocument, _room);
+        }
 
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+        protected void SetPropertyGridObject(object obj)
+        {
+            Factory.GUIController.SetPropertyGridObject(obj, _editor.ContentDocument);
         }
 
         private void GUIController_OnPropertyObjectChanged(object newPropertyObject)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
@@ -10,8 +10,8 @@ namespace AGS.Editor
 {
     public class RegionsEditorFilter : BaseAreasEditorFilter
     {
-        public RegionsEditorFilter(Panel displayPanel, Room room)
-            : base(displayPanel, room)
+        public RegionsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
+            : base(displayPanel, editor, room)
         {
         }
 
@@ -30,7 +30,7 @@ namespace AGS.Editor
 
         protected override void SelectedAreaChanged(int areaNumber)
         {
-            Factory.GUIController.SetPropertyGridObject(_room.Regions[areaNumber]);
+            SetPropertyGridObject(_room.Regions[areaNumber]);
         }
 
         protected override string GetItemName(int id)
@@ -48,16 +48,15 @@ namespace AGS.Editor
             return items;
         }
 
-        protected override void SetPropertyGridList()
+        protected override Dictionary<string, object> GetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
+            var list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
             foreach (RoomRegion area in _room.Regions)
             {
-                defaultPropertyObjectList.Add(area.PropertyGridTitle, area);
+                list.Add(area.PropertyGridTitle, area);
             }
-
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+            return list;
         }
 
         protected override void GUIController_OnPropertyObjectChanged(object newPropertyObject)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
@@ -13,8 +13,8 @@ namespace AGS.Editor
 		private bool _draggingBaseline = false;
 		private bool _shownTooltip = false;
 
-        public WalkBehindsEditorFilter(Panel displayPanel, Room room)
-            : base(displayPanel, room)
+        public WalkBehindsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
+            : base(displayPanel, editor, room)
         {
         }
 
@@ -133,7 +133,7 @@ namespace AGS.Editor
 
         protected override void SelectedAreaChanged(int areaNumber)
         {
-            Factory.GUIController.SetPropertyGridObject(_room.WalkBehinds[areaNumber]);
+            SetPropertyGridObject(_room.WalkBehinds[areaNumber]);
         }
 
         protected override string GetItemName(int id)
@@ -151,16 +151,15 @@ namespace AGS.Editor
             return items;
         }
 
-        protected override void SetPropertyGridList()
+        protected override Dictionary<string, object> GetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
+            var list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
             foreach (RoomWalkBehind area in _room.WalkBehinds)
             {
-                defaultPropertyObjectList.Add(area.PropertyGridTitle, area);
+                list.Add(area.PropertyGridTitle, area);
             }
-
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+            return list;
         }
 
         protected override void GUIController_OnPropertyObjectChanged(object newPropertyObject)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
@@ -10,8 +10,8 @@ namespace AGS.Editor
 {
     public class WalkableAreasEditorFilter : BaseAreasEditorFilter
     {
-        public WalkableAreasEditorFilter(Panel displayPanel, Room room)
-            : base(displayPanel, room)
+        public WalkableAreasEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
+            : base(displayPanel, editor, room)
         {
         }
 
@@ -30,7 +30,7 @@ namespace AGS.Editor
 
         protected override void SelectedAreaChanged(int areaNumber)
         {
-            Factory.GUIController.SetPropertyGridObject(_room.WalkableAreas[areaNumber]);
+            SetPropertyGridObject(_room.WalkableAreas[areaNumber]);
         }
 
         protected override string GetItemName(int id)
@@ -48,16 +48,15 @@ namespace AGS.Editor
             return items;
         }
 
-		protected override void SetPropertyGridList()
+        protected override Dictionary<string, object> GetPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
+            var list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
             foreach (RoomWalkableArea area in _room.WalkableAreas)
             {
-                defaultPropertyObjectList.Add(area.PropertyGridTitle, area);
+                list.Add(area.PropertyGridTitle, area);
             }
-
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+            return list;
         }
 
         protected override void GUIController_OnPropertyObjectChanged(object newPropertyObject)

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -82,11 +82,11 @@ namespace AGS.Editor
             _layers.Add(new EdgesEditorFilter(bufferedPanel1, _room));
             _characterLayer = new CharactersEditorFilter(bufferedPanel1, this, _room, Factory.AGSEditor.CurrentGame);
             _layers.Add(_characterLayer);
-            _layers.Add(new ObjectsEditorFilter(bufferedPanel1, _room));
-            _layers.Add(new HotspotsEditorFilter(bufferedPanel1, _room));
-            _layers.Add(new WalkableAreasEditorFilter(bufferedPanel1, _room));
-            _layers.Add(new WalkBehindsEditorFilter(bufferedPanel1, _room));
-            _layers.Add(new RegionsEditorFilter(bufferedPanel1, _room));
+            _layers.Add(new ObjectsEditorFilter(bufferedPanel1, this, _room));
+            _layers.Add(new HotspotsEditorFilter(bufferedPanel1, this, _room));
+            _layers.Add(new WalkableAreasEditorFilter(bufferedPanel1, this, _room));
+            _layers.Add(new WalkBehindsEditorFilter(bufferedPanel1, this, _room));
+            _layers.Add(new RegionsEditorFilter(bufferedPanel1, this, _room));
 
             foreach (IRoomEditorFilter layer in _layers)
             {
@@ -641,7 +641,7 @@ namespace AGS.Editor
         {
             if (_layersRoot.UniqueID.Equals(e.OUniqueID))
             {
-                Factory.GUIController.SetPropertyGridObject(_room);
+                SetPropertyGridObject(_room);
                 SelectLayer(null);
                 return;
             }
@@ -675,7 +675,7 @@ namespace AGS.Editor
             _layer = layer ?? _emptyLayer;
 
             SetDefaultPropertyGridList();
-            Factory.GUIController.SetPropertyGridObject(_room);
+            SetPropertyGridObject(_room);
             lblTransparency.Visible = _layer.ShowTransparencySlider;
             sldTransparency.Visible = _layer.ShowTransparencySlider;
             chkCharacterOffset.Visible = _layer is CharactersEditorFilter;
@@ -689,9 +689,25 @@ namespace AGS.Editor
 		
         private void SetDefaultPropertyGridList()
         {
-            Dictionary<string, object> defaultPropertyObjectList = new Dictionary<string, object>();
-            defaultPropertyObjectList.Add(_room.PropertyGridTitle, _room);
-            Factory.GUIController.SetPropertyGridObjectList(defaultPropertyObjectList);
+            Dictionary<string, object> list = new Dictionary<string, object>();
+            list.Add(_room.PropertyGridTitle, _room);
+            if (Factory.GUIController.ActivePane == this.ContentDocument)
+            {
+                Factory.GUIController.SetPropertyGridObjectList(list);
+            }
+            else
+            {
+                this.ContentDocument.PropertyGridObjectList = list;
+                this.ContentDocument.SelectedPropertyGridObject = _room;
+            }
+        }
+
+        private void SetPropertyGridObject(object obj)
+        {
+            if (Factory.GUIController.ActivePane == this.ContentDocument)
+                Factory.GUIController.SetPropertyGridObject(obj);
+            else
+                this.ContentDocument.SelectedPropertyGridObject = obj;
         }
 
 		protected override string OnGetHelpKeyword()


### PR DESCRIPTION
By user request, this complements room editor saving the "design state" of a room by adding last selected item.

This is a trivial change from data saving perspective, but required additional modifications in the room editor to allow selecting item in "background mode" , that is - while the room pane is not active, because this will be the case when room just getting loaded.

For this I had to write function ~(per each room layer, unfortunately, because of how things are currently abstracted, or rather not abstracted enough)~ that checks whether room editor is an active pane or not. If it is, it then proceeds by a usual route and calls Factory.GUIController.SetPropertyGrid* method which will both update current property list and display one in the grid. If room editor is at the background then it will just assign new property list to the document; that list will be displayed in the grid as soon as room editor receives focus.

Note that I also removed a previos fix made by #619, because new function seem to counter same bug in its own way.