### PR TITLE
Script API: changed Object.SetView default loop & frame values to 0

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -162,7 +162,8 @@ enum ScriptAPIVersion
     kScriptAPI_v341 = 5,
     kScriptAPI_v350 = 6,
     kScriptAPI_v3507= 7,
-    kScriptAPI_Current = kScriptAPI_v3507
+    kScriptAPI_v351 = 8,
+    kScriptAPI_Current = kScriptAPI_v351
 };
 
 // Determines whether the graphics renderer should scale sprites at the final

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2143,8 +2143,14 @@ builtin managed struct Object {
   import function RunInteraction(CursorMode);
   /// Instantly moves the object to have its bottom-left at the new co-ordinates.
   import function SetPosition(int x, int y);
+#ifdef SCRIPT_API_v351
+  /// Sets the object to use the specified view, ahead of doing an animation.
+  import function SetView(int view, int loop=0, int frame=0);
+#endif
+#ifndef SCRIPT_API_v351
   /// Sets the object to use the specified view, ahead of doing an animation.
   import function SetView(int view, int loop=-1, int frame=-1);
+#endif
   /// Stops any currently running animation on the object.
   import function StopAnimating();
   /// Stops any currently running move on the object.

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -151,20 +151,9 @@ void SetObjectView(int obn,int vii) {
 void SetObjectFrame(int obn,int viw,int lop,int fra) {
     if (!is_valid_object(obn)) quit("!SetObjectFrame: invalid object number specified");
     viw--;
-    if (viw>=game.numviews) quit("!SetObjectFrame: invalid view number used");
-    if (views[viw].numLoops == 0) quit("!SetObjectFrame: specified view has no loops");
-    if (lop>=views[viw].numLoops) quit("!SetObjectFrame: invalid loop number used");
-    objs[obn].view=viw;
-    if (fra >= 0)
-        objs[obn].frame=fra;
-    if (lop >= 0)
-        objs[obn].loop=lop;
-
-    if (objs[obn].loop >= views[viw].numLoops)
-        objs[obn].loop = 0;
-    if (objs[obn].frame >= views[viw].loops[objs[obn].loop].numFrames)
-        objs[obn].frame = 0;
-
+    if (viw < 0 || viw >= game.numviews) quit("!SetObjectFrame: invalid view number used");
+    if (lop < 0 || lop >= views[viw].numLoops) quit("!SetObjectFrame: invalid loop number used");
+    if (fra < 0 || fra >= views[viw].loops[objs[obn].loop].numFrames) quit("!SetObjectFrame: invalid frame number used");
     // AGS >= 3.2.0 do not let assign an empty loop
     // NOTE: pre-3.2.0 games are converting views from ViewStruct272 struct, always has at least 1 frame
     if (loaded_game_file_version >= kGameVersion_320)
@@ -172,7 +161,9 @@ void SetObjectFrame(int obn,int viw,int lop,int fra) {
         if (views[viw].loops[objs[obn].loop].numFrames == 0) 
             quit("!SetObjectFrame: specified loop has no frames");
     }
-
+    objs[obn].view = viw;
+    objs[obn].loop = lop;
+    objs[obn].frame = fra;
     objs[obn].cycling=0;
     objs[obn].num = views[viw].loops[objs[obn].loop].frames[objs[obn].frame].pic;
     CheckViewFrame(viw, objs[obn].loop, objs[obn].frame);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -26,6 +26,7 @@
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
 #include "ac/system.h"
+#include "ac/view.h"
 #include "ac/walkablearea.h"
 #include "debug/debug_log.h"
 #include "main/game_run.h"
@@ -43,6 +44,7 @@ using namespace AGS::Common;
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern RoomStatus*croom;
 extern RoomObject*objs;
+extern ViewStruct*views;
 extern RoomStruct thisroom;
 extern ObjectCache objcache[MAX_ROOM_OBJECTS];
 extern MoveList *mls;
@@ -85,6 +87,16 @@ void Object_RemoveTint(ScriptObject *objj) {
 }
 
 void Object_SetView(ScriptObject *objj, int view, int loop, int frame) {
+    if (game.options[OPT_BASESCRIPTAPI] < kScriptAPI_v351)
+    { // Previous version of SetView had negative loop and frame mean "use latest values"
+        auto &obj = objs[objj->id];
+        if (loop < 0) loop = obj.loop;
+        if (frame < 0) frame = obj.frame;
+        const int vidx = view - 1;
+        if (vidx < 0 || vidx >= game.numviews) quit("!Object_SetView: invalid view number used");
+        loop = Math::Clamp(loop, 0, (int)views[vidx].numLoops - 1);
+        frame = Math::Clamp(frame, 0, (int)views[vidx].loops[loop].numFrames - 1);
+    }
     SetObjectFrame(objj->id, view, loop, frame);
 }
 


### PR DESCRIPTION
See #940
This may be somewhat controversial, so I'd like to hear more opinions on this.

The original Object.SetView function had a somewhat unexpected behavior: if no explicit values were provided for loop and frame then it kept the last loop and frame object had from the previously set view.
Although documented, but such behavior seem to cause confusion among users who expect it to reset loop and/or frame instead.

This pr changes default values to 0, which resets loop and frame if they are not provided.
Original behavior is kept for games made with previous script API version.