### PR TITLE
3.5.0: have movement speed independent from room mask resolution by default

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -78,7 +78,8 @@
 #define OPT_SCRIPTCOMPATLEV 44 // level of API compatibility (ScriptAPIVersion) used to compile game script
 #define OPT_RENDERATSCREENRES 45 // use the legacy D3D scaling that scales sprites at the (final) screen resolution
 #define OPT_RELATIVEASSETRES 46 // relative asset resolution mode (where sprites are resized to match game type)
-#define OPT_HIGHESTOPTION   OPT_RELATIVEASSETRES
+#define OPT_WALKSPEEDABSOLUTE 47 // if movement speeds are independent of walkable mask resolution
+#define OPT_HIGHESTOPTION   OPT_WALKSPEEDABSOLUTE
 #define OPT_NOMODMUSIC      98
 #define OPT_LIPSYNCTEXT     99
 #define PORTRAIT_LEFT       0

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -82,8 +82,9 @@ namespace AGS.Editor
          * 19: 3.5.0.11   - Custom Say and Narrate functions for dialog scripts. GameFileName.
          * 20: 3.5.0.14   - Sprite.ImportAlphaChannel.
          * 21: 3.5.0.15   - AudioClip ID.
+         * 22: 3.5.0.18   - Settings.ScaleMovementSpeedWithMaskResolution.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 21;
+        public const int    LATEST_XML_VERSION_INDEX = 22;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -539,6 +539,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_SCRIPTCOMPATLEV] = (int)game.Settings.ScriptCompatLevelReal;
             options[NativeConstants.GameOptions.OPT_RENDERATSCREENRES] = (int)game.Settings.RenderAtScreenResolution;
             options[NativeConstants.GameOptions.OPT_RELATIVEASSETRES] = (game.Settings.AllowRelativeAssetResolutions ? 1 : 0);
+            options[NativeConstants.GameOptions.OPT_WALKSPEEDABSOLUTE] = (game.Settings.ScaleMovementSpeedWithMaskResolution ? 0 : 1);
             options[NativeConstants.GameOptions.OPT_LIPSYNCTEXT] = (game.LipSync.Type == LipSyncType.Text ? 1 : 0);
             for (int i = 0; i < options.Length; ++i) // writing only ints, alignment preserved
             {

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -298,6 +298,11 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 22)
+            {
+                game.Settings.ScaleMovementSpeedWithMaskResolution = true;
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -130,6 +130,7 @@ namespace AGS.Editor
             public static readonly int OPT_SCRIPTCOMPATLEV = (int)Factory.NativeProxy.GetNativeConstant("OPT_SCRIPTCOMPATLEV");
             public static readonly int OPT_RENDERATSCREENRES = (int)Factory.NativeProxy.GetNativeConstant("OPT_RENDERATSCREENRES");
             public static readonly int OPT_RELATIVEASSETRES = (int)Factory.NativeProxy.GetNativeConstant("OPT_RELATIVEASSETRES");
+            public static readonly int OPT_WALKSPEEDABSOLUTE = (int)Factory.NativeProxy.GetNativeConstant("OPT_WALKSPEEDABSOLUTE");
             public static readonly int OPT_LIPSYNCTEXT = (int)Factory.NativeProxy.GetNativeConstant("OPT_LIPSYNCTEXT");
         }
     }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -767,6 +767,7 @@ namespace AGS
             if (name->Equals("OPT_SCRIPTCOMPATLEV")) return OPT_SCRIPTCOMPATLEV;
             if (name->Equals("OPT_RENDERATSCREENRES")) return OPT_RENDERATSCREENRES;
             if (name->Equals("OPT_RELATIVEASSETRES")) return OPT_RELATIVEASSETRES;
+            if (name->Equals("OPT_WALKSPEEDABSOLUTE")) return OPT_WALKSPEEDABSOLUTE;
             if (name->Equals("OPT_LIPSYNCTEXT")) return OPT_LIPSYNCTEXT;
 			if (name->Equals("MAX_PLUGINS")) return MAX_PLUGINS;
             return nullptr;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3316,6 +3316,7 @@ Game^ import_compiled_game_dta(const char *fileName)
     game->Settings->SaveGameFolderName = gcnew String(thisgame.gamename);
     game->Settings->RenderAtScreenResolution = (RenderAtScreenResolution)thisgame.options[OPT_RENDERATSCREENRES];
     game->Settings->AllowRelativeAssetResolutions = (thisgame.options[OPT_RELATIVEASSETRES] != 0);
+    game->Settings->ScaleMovementSpeedWithMaskResolution = (thisgame.options[OPT_WALKSPEEDABSOLUTE] == 0);
 
 	game->Settings->InventoryHotspotMarker->DotColor = thisgame.hotdot;
 	game->Settings->InventoryHotspotMarker->CrosshairColor = thisgame.hotdotouter;

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -53,6 +53,7 @@ namespace AGS.Types
         private int _splitResources = 0;
         private bool _turnBeforeWalking = true;
         private bool _turnBeforeFacing = true;
+        private bool _scaleMovementSpeedWithMaskRes = false;
         private bool _mouseWheelEnabled = true;
         private RoomTransitionStyle _roomTransition = RoomTransitionStyle.FadeOutAndIn;
         private bool _saveScreenshots = false;
@@ -362,6 +363,17 @@ namespace AGS.Types
         {
             get { return _turnBeforeWalking; }
             set { _turnBeforeWalking = value; }
+        }
+
+        [DisplayName("Scale movement speed with room's mask resolution")]
+        [Description("Character walking and object movement speeds will scale inversely in proportion to the current room's Mask Resolution, for example having 1:2 mask resolution will multiply speed by 2." +
+            "\nNOTE: this is a backward compatible setting that should not be enabled without real need.")]
+        [Category("Character movement")]
+        [DefaultValue(false)]
+        public bool ScaleMovementSpeedWithMaskResolution
+        {
+            get { return _scaleMovementSpeedWithMaskRes; }
+            set { _scaleMovementSpeedWithMaskRes = value; }
         }
 
         [DisplayName("Split resource files into X MB-sized chunks")]

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1054,6 +1054,15 @@ AGS_INLINE int mask_to_room_coord(int coord)
 
 void convert_move_path_to_room_resolution(MoveList *ml)
 {
+    if ((game.options[OPT_WALKSPEEDABSOLUTE] != 0) && game.GetDataUpscaleMult() > 1)
+    { // Speeds are independent from MaskResolution
+        for (int i = 0; i < ml->numstage; i++)
+        { // ...so they are not multiplied by MaskResolution factor when converted to room coords
+            ml->xpermove[i] = ml->xpermove[i] / game.GetDataUpscaleMult();
+            ml->ypermove[i] = ml->ypermove[i] / game.GetDataUpscaleMult();
+        }
+    }
+
     if (thisroom.MaskResolution == game.GetDataUpscaleMult())
         return;
 
@@ -1067,9 +1076,15 @@ void convert_move_path_to_room_resolution(MoveList *ml)
         uint16_t lowPart = mask_to_room_coord(ml->pos[i] & 0x0000ffff);
         uint16_t highPart = mask_to_room_coord((ml->pos[i] >> 16) & 0x0000ffff);
         ml->pos[i] = ((int)highPart << 16) | (lowPart & 0x0000ffff);
+    }
 
-        ml->xpermove[i] = mask_to_room_coord(ml->xpermove[i]);
-        ml->ypermove[i] = mask_to_room_coord(ml->ypermove[i]);
+    if (game.options[OPT_WALKSPEEDABSOLUTE] == 0)
+    { // Speeds are scaling with MaskResolution
+        for (int i = 0; i < ml->numstage; i++)
+        {
+            ml->xpermove[i] = mask_to_room_coord(ml->xpermove[i]);
+            ml->ypermove[i] = mask_to_room_coord(ml->ypermove[i]);
+        }
     }
 }
 

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -28,7 +28,7 @@ void set_wallscreen(AGS::Common::Bitmap *wallscreen);
 
 int can_see_from(int x1, int y1, int x2, int y2);
 void get_lastcpos(int &lastcx, int &lastcy);
-
+// NOTE: pathfinder implementation mostly needs to know proportion between x and y speed
 void set_route_move_speed(int speed_x, int speed_y);
 
 int find_route(short srcx, short srcy, short xx, short yy, AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);


### PR DESCRIPTION
For #936.

Originally the speed of character's walking & object's moving in room was scaled by the walkable area resolution. For example, if this resolution was 1:2 of the room's background, these speeds ended up multiplied by 2. This caused hi-res games (640x400 and up) having higher actual speeds than low-res games when using same speed values.

This PR introduces a switch which allows to turn speed scaling on and off, but meant for backward compatibility only and is **off** by default.