### PR TITLE
Engine: clear D3D9 borders

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -250,6 +250,8 @@ private:
     SpriteBatchDescs _backupBatchDescs;
     D3DSpriteBatches _backupBatches;
 
+    D3DVIEWPORT9 _d3dViewport;
+
     // Called after new mode was successfully initialized
     void OnModeSet(const DisplayMode &mode) override;
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;


### PR DESCRIPTION
ColorFill is used on pBackBuffer to redraw the black background and ensure that steam overlays and shader wrappers won't cause hall of mirror effects.
Related to issue #971.