### PR TITLE
D3D: Hack for pixel perfect mode

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -252,6 +252,8 @@ private:
 
     D3DVIEWPORT9 _d3dViewport;
 
+    bool _needStretchRectHack;
+
     // Called after new mode was successfully initialized
     void OnModeSet(const DisplayMode &mode) override;
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
@@ -282,6 +284,8 @@ private:
     void RenderSpriteBatches();
     void RenderSpriteBatch(const D3DSpriteBatch &batch);
     void _renderSprite(const D3DDrawListEntry *entry, const D3DMATRIX &matGlobal);
+
+    void _testStretchRectBug();
 };
 
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -250,6 +250,8 @@ private:
     SpriteBatchDescs _backupBatchDescs;
     D3DSpriteBatches _backupBatches;
 
+    D3DVIEWPORT9 _d3dViewport;
+
     // Called after new mode was successfully initialized
     void OnModeSet(const DisplayMode &mode) override;
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;


### PR DESCRIPTION
The StretchRect upscale makes the last row and column always one single pixel in size.
This workaround stretches the main area, right/bottom edges and bottom-right corner separately in order to avoid the distortion.

This is a hack. It would be better if we found the actual reason for which StretchRect causes this distortion, or render to texture and draw it on the scene.
Until then this will make pixel perfect rendering actually pixel perfect.
