### PR TITLE
Add editable sprite properties for import width and height

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -84,7 +84,7 @@ namespace AGS.Editor
          * 21: 3.5.0.15   - AudioClip ID.
          * 22: 3.5.0.18   - Settings.ScaleMovementSpeedWithMaskResolution.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 22;
+        public const int    LATEST_XML_VERSION_INDEX = 23;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -791,17 +791,7 @@ namespace AGS.Editor
 
                 try
                 {
-                    SpriteSheet spritesheet;
-
-                    // if offset would make a selection, use it
-                    if (spr.OffsetX > 0 || spr.OffsetY > 0)
-                    {
-                        spritesheet = new SpriteSheet(new Point(spr.OffsetX, spr.OffsetY), new Size(spr.Width, spr.Height));
-                    }
-                    else
-                    {
-                        spritesheet = null;
-                    }
+                    SpriteSheet spritesheet = new SpriteSheet(new Point(spr.OffsetX, spr.OffsetY), new Size(spr.ImportWidth, spr.ImportHeight));
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -303,6 +303,16 @@ namespace AGS.Editor
                 game.Settings.ScaleMovementSpeedWithMaskResolution = true;
             }
 
+            if (xmlVersionIndex < 23)
+            {
+                // Set the import dimensions based on existing sprite dimensions
+                foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+                {
+                    sprite.ImportWidth = sprite.Width;
+                    sprite.ImportHeight = sprite.Height;
+                }
+            }
+
             game.SetScriptAPIForOldProject();
         }
 

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -223,6 +223,8 @@ namespace AGS.Editor.Utils
             sprite.Frame = frame;
             sprite.OffsetX = offsetX;
             sprite.OffsetY = offsetY;
+            sprite.ImportWidth = sprite.Width;
+            sprite.ImportHeight = sprite.Height;
             sprite.ImportAlphaChannel = alpha;
         }
 
@@ -284,6 +286,8 @@ namespace AGS.Editor.Utils
             sprite.Frame = frame;
             sprite.OffsetX = offsetX;
             sprite.OffsetY = offsetY;
+            sprite.ImportWidth = sprite.Width;
+            sprite.ImportHeight = sprite.Height;
             sprite.ImportAlphaChannel = alpha;
 
             folder.Sprites.Add(sprite);

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -24,6 +24,8 @@ namespace AGS.Types
         private SpriteImportTransparency _tranparentColour = SpriteImportTransparency.LeaveAsIs;
         private int _offsetX;
         private int _offsetY;
+        private int _importWidth;
+        private int _importHeight;
         private bool _remapToGamePalette;
         private bool _remapToRoomPalette;
         private bool _importAlphaChannel;
@@ -158,6 +160,22 @@ namespace AGS.Types
             set { _offsetY = value; }
         }
 
+        [Description("The width of the import")]
+        [Category("Import")]
+        public int ImportWidth
+        {
+            get { return _importWidth; }
+            set { _importWidth = value; }
+        }
+
+        [Description("The height of the import")]
+        [Category("Import")]
+        public int ImportHeight
+        {
+            get { return _importHeight; }
+            set { _importHeight = value; }
+        }
+
         [Description("The frame number of a multi-frame image within the source file")]
         [Category("Import")]
         public int Frame
@@ -229,6 +247,17 @@ namespace AGS.Types
 
                 try
                 {
+                    _importWidth = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "ImportWidth"));
+                    _importHeight = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "ImportHeight"));
+                }
+                catch (InvalidDataException)
+                {
+                    _importWidth = _width;
+                    _importHeight = _height;
+                }
+
+                try
+                {
                     _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
                 }
                 catch (InvalidDataException)
@@ -257,6 +286,8 @@ namespace AGS.Types
             writer.WriteElementString("FileName", _sourceFile);
             writer.WriteElementString("OffsetX", _offsetX.ToString());
             writer.WriteElementString("OffsetY", _offsetY.ToString());
+            writer.WriteElementString("ImportHeight", _importHeight.ToString());
+            writer.WriteElementString("ImportWidth", _importWidth.ToString());
             writer.WriteElementString("Frame", _frame.ToString());
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());
             writer.WriteElementString("RemapToRoomPalette", _remapToRoomPalette.ToString());


### PR DESCRIPTION
Two new properites specify import width and height, and re-importing a sprite now uses these properties. This fixes the case where a re-import of a sprite from offset 0,0 would reload the frame as the entire image, and also lets the user reconfigure the tile size.

Fixes #973