### PR TITLE
Fix autocomplete crash

### DIFF
--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -173,7 +173,7 @@ namespace AGS.Editor
 
                     if (scriptAtComment.StartsWith("///"))
                     {
-                        FastString commentText = scriptAtComment.Substring(3, (scriptAtComment.Length - script.Length) - 4);
+                        FastString commentText = scriptAtComment.Substring(3, (scriptAtComment.Length - script.Length) - 3);
                         state.PreviousComment = commentText.ToString().Trim();
                     }
                     continue;


### PR DESCRIPTION
This was returning one character too many. For the autocomplete header descriptions it included a carriage return (but not the adjacent line feed) which was then immediately stripped, or where there were no following characters the Editor would crash.

In the absence of tests, probably best if a couple of other people can verify that this looks correct.

Fixes #981