### PR TITLE
Add sprite property 'ImportAsTile'

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -84,7 +84,7 @@ namespace AGS.Editor
          * 21: 3.5.0.15   - AudioClip ID.
          * 22: 3.5.0.18   - Settings.ScaleMovementSpeedWithMaskResolution.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 23;
+        public const int    LATEST_XML_VERSION_INDEX = 24;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
+++ b/Editor/AGS.Editor/Panes/SpriteImportWindow.cs
@@ -405,7 +405,7 @@ namespace AGS.Editor
             try
             {
                 SpriteTools.ReplaceSprite(replace, image, UseAlphaChannel, RemapToGamePalette,
-                    UseBackgroundSlots, SpriteImportMethod, spritesheet, 0, filename);
+                    UseBackgroundSlots, SpriteImportMethod, filename, 0, spritesheet);
             }
             catch (AGSEditorException ex)
             {
@@ -435,7 +435,7 @@ namespace AGS.Editor
                 {
                     // in the interest of speed, import the existing bitmap if the file has a single frame
                     SpriteTools.ImportNewSprites(folder, image, UseAlphaChannel, RemapToGamePalette,
-                        UseBackgroundSlots, SpriteImportMethod, spritesheet, 0, filename);
+                        UseBackgroundSlots, SpriteImportMethod, filename, 0, spritesheet);
                 }
                 else
                 {

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -791,7 +791,16 @@ namespace AGS.Editor
 
                 try
                 {
-                    SpriteSheet spritesheet = new SpriteSheet(new Point(spr.OffsetX, spr.OffsetY), new Size(spr.ImportWidth, spr.ImportHeight));
+                    SpriteSheet spritesheet;
+
+                    if (spr.ImportAsTile)
+                    {
+                        spritesheet = new SpriteSheet(new Point(spr.OffsetX, spr.OffsetY), new Size(spr.ImportWidth, spr.ImportHeight));
+                    }
+                    else
+                    {
+                        spritesheet = null;
+                    }
 
                     // take the alpha channel preference from the specified import option
                     // (instead of using whether the old sprite has an alpha channel)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -313,6 +313,56 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 24)
+            {
+                // get all known source images and their largest known size
+                // (avoiding System.Drawing / GDI as a dependency to load the project)
+                Dictionary<string, Tuple<int, int>> sourceMaxSize = new Dictionary<string, Tuple<int, int>>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+                {
+                    if (!string.IsNullOrWhiteSpace(sprite.SourceFile))
+                    {
+                        int currentX = sprite.OffsetX + sprite.ImportWidth;
+                        int currentY = sprite.OffsetY + sprite.ImportHeight;
+
+                        if (sourceMaxSize.ContainsKey(sprite.SourceFile))
+                        {
+                            int maxX = sourceMaxSize[sprite.SourceFile].Item1;
+                            int maxY = sourceMaxSize[sprite.SourceFile].Item2;
+                            if (maxX < currentX) maxX = currentX;
+                            if (maxY < currentY) maxY = currentY;
+                            sourceMaxSize[sprite.SourceFile] = Tuple.Create(maxX, maxY);
+                        }
+                        else
+                        {
+                            sourceMaxSize.Add(sprite.SourceFile, Tuple.Create(currentX, currentY));
+                        }
+                    }
+                }
+
+                // Set the tiled image flag for existing imports - the only misdetection would be
+                // a single import from a source image that starts at 0,0, but wasn't for the
+                // entire image
+                foreach (Sprite sprite in game.RootSpriteFolder.GetAllSpritesFromAllSubFolders())
+                {
+                    if (sprite.OffsetX > 0 || sprite.OffsetY > 0)
+                    {
+                        sprite.ImportAsTile = true;
+                    }
+                    else if (sourceMaxSize.ContainsKey(sprite.SourceFile))
+                    {
+                        int maxX = sourceMaxSize[sprite.SourceFile].Item1;
+                        int maxY = sourceMaxSize[sprite.SourceFile].Item2;
+                        sprite.ImportAsTile = sprite.ImportWidth < maxX || sprite.ImportHeight < maxY;
+                    }
+                    else
+                    {
+                        sprite.ImportAsTile = false;
+                    }
+                }
+            }
+
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);
             System.Version projectVersion = game.SavedXmlEditorVersion != null ? Types.Utilities.TryParseVersion(game.SavedXmlEditorVersion) : null;
             if (projectVersion < editorVersion)

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -200,7 +200,7 @@ namespace AGS.Editor.Utils
         }
 
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, string filename = "", int frame = 0, int offsetX = 0, int offsetY = 0)
+            SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
             // ignore alpha channel if not 32 bit ARGB
             bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
@@ -221,17 +221,19 @@ namespace AGS.Editor.Utils
             sprite.RemapToRoomPalette = useRoomBackground;
             sprite.SourceFile = Utilities.GetRelativeToProjectPath(filename);
             sprite.Frame = frame;
-            sprite.OffsetX = offsetX;
-            sprite.OffsetY = offsetY;
-            sprite.ImportWidth = sprite.Width;
-            sprite.ImportHeight = sprite.Height;
+            sprite.OffsetX = selection.Left;
+            sprite.OffsetY = selection.Top;
+            sprite.ImportWidth = selection.Width;
+            sprite.ImportHeight = selection.Height;
             sprite.ImportAlphaChannel = alpha;
         }
 
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, SpriteSheet spritesheet = null, int frame = 0, string filename = "")
+            SpriteImportTransparency transparency, string filename, int frame, SpriteSheet spritesheet)
         {
-            if (spritesheet != null)
+            bool tiled = spritesheet != null;
+
+            if (tiled)
             {
                 Rectangle selection = spritesheet.GetFirstSpriteSelection(new Size(bmp.Width, bmp.Height));
                 
@@ -239,7 +241,7 @@ namespace AGS.Editor.Utils
                 {
                     Bitmap replacement = bmp.Clone(selection, bmp.PixelFormat);
                     ReplaceSprite(sprite, replacement, alpha, remapColours, useRoomBackground, transparency, filename,
-                        frame, selection.Left, selection.Top);
+                        frame, selection, tiled);
                     replacement.Dispose();
                 }
                 else
@@ -250,20 +252,21 @@ namespace AGS.Editor.Utils
             }
             else
             {
-                ReplaceSprite(sprite, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame);
+                Rectangle selection = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                ReplaceSprite(sprite, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame, selection, tiled);
             }
         }
 
         public static void ReplaceSprite(Sprite sprite, string filename, int frame, bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, SpriteSheet spritesheet = null)
+            SpriteImportTransparency transparency, SpriteSheet spritesheet)
         {
             Bitmap bmp = LoadFrameImageFromFile(filename, frame);
-            ReplaceSprite(sprite, bmp, alpha, remapColours, useRoomBackground, transparency, spritesheet, frame, filename);
+            ReplaceSprite(sprite, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame, spritesheet);
             bmp.Dispose();
         }
 
         public static void ImportNewSprite(SpriteFolder folder, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, string filename = "", int frame = 0, int offsetX = 0, int offsetY = 0)
+            SpriteImportTransparency transparency, string filename, int frame, Rectangle selection, bool tile)
         {
             // ignore alpha channel if not 32 bit ARGB
             bool useAlphaChannel = bmp.PixelFormat != PixelFormat.Format32bppArgb ||
@@ -284,31 +287,33 @@ namespace AGS.Editor.Utils
             sprite.RemapToRoomPalette = useRoomBackground;
             sprite.SourceFile = Utilities.GetRelativeToProjectPath(filename);
             sprite.Frame = frame;
-            sprite.OffsetX = offsetX;
-            sprite.OffsetY = offsetY;
-            sprite.ImportWidth = sprite.Width;
-            sprite.ImportHeight = sprite.Height;
+            sprite.OffsetX = selection.Left;
+            sprite.OffsetY = selection.Top;
+            sprite.ImportWidth = selection.Width;
+            sprite.ImportHeight = selection.Height;
             sprite.ImportAlphaChannel = alpha;
 
             folder.Sprites.Add(sprite);
         }
 
         public static void ImportNewSprites(SpriteFolder folder, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
-            SpriteImportTransparency transparency, SpriteSheet spritesheet = null, int frame = 0, string filename = "")
+            SpriteImportTransparency transparency, string filename, int frame, SpriteSheet spritesheet)
         {
-            if (spritesheet != null)
+            bool tiled = spritesheet != null;
+
+            if (tiled)
             {
                 foreach (Rectangle selection in spritesheet.GetSpriteSelections(new Size(bmp.Width, bmp.Height)))
                 {
                     Bitmap import = bmp.Clone(selection, bmp.PixelFormat);
-                    ImportNewSprite(folder, import, alpha, remapColours, useRoomBackground, transparency,
-                        filename, frame, selection.Left, selection.Top);
+                    ImportNewSprite(folder, import, alpha, remapColours, useRoomBackground, transparency, filename, frame, selection, tiled);
                     import.Dispose();
                 }
             }
             else
             {
-                ImportNewSprite(folder, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame);
+                Rectangle selection = new Rectangle(0, 0, bmp.Width, bmp.Height);
+                ImportNewSprite(folder, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame, selection, tiled);
             }
         }
 
@@ -322,7 +327,7 @@ namespace AGS.Editor.Utils
             foreach (Bitmap bmp in LoadSpritesFromFile(filename))
             {
                 progress.SetProgressValue(frame);
-                ImportNewSprites(folder, bmp, alpha, remapColours, useRoomBackground, transparency, spritesheet, frame, filename);
+                ImportNewSprites(folder, bmp, alpha, remapColours, useRoomBackground, transparency, filename, frame, spritesheet);
                 bmp.Dispose();
                 frame ++;
             }

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -226,6 +226,7 @@ namespace AGS.Editor.Utils
             sprite.ImportWidth = selection.Width;
             sprite.ImportHeight = selection.Height;
             sprite.ImportAlphaChannel = alpha;
+            sprite.ImportAsTile = tile;
         }
 
         public static void ReplaceSprite(Sprite sprite, Bitmap bmp, bool alpha, bool remapColours, bool useRoomBackground,
@@ -292,6 +293,7 @@ namespace AGS.Editor.Utils
             sprite.ImportWidth = selection.Width;
             sprite.ImportHeight = selection.Height;
             sprite.ImportAlphaChannel = alpha;
+            sprite.ImportAsTile = tile;
 
             folder.Sprites.Add(sprite);
         }

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -7,7 +7,7 @@ using System.Xml;
 namespace AGS.Types
 {
     [DefaultProperty("Resolution")]
-    public class Sprite : IComparable<Sprite>
+    public class Sprite : ICustomTypeDescriptor, IComparable<Sprite>
     {
         public const string PROPERTY_SPRITE_NUMBER = "Number";
         public const string PROPERTY_RESOLUTION = "Resolution";
@@ -179,6 +179,7 @@ namespace AGS.Types
 
         [Description("Import as a spritesheet tile using the specified size and offsets")]
         [Category("Import")]
+        [RefreshProperties(RefreshProperties.All)]
         public bool ImportAsTile
         {
             get { return _importAsTile; }
@@ -316,6 +317,92 @@ namespace AGS.Types
 
             writer.WriteEndElement();
         }
+
+        #region ICustomTypeDescriptor Members
+
+        public AttributeCollection GetAttributes()
+        {
+            return TypeDescriptor.GetAttributes(this, true);
+        }
+
+        public string GetClassName()
+        {
+            return TypeDescriptor.GetClassName(this, true);
+        }
+
+        public string GetComponentName()
+        {
+            return TypeDescriptor.GetComponentName(this, true);
+        }
+
+        public TypeConverter GetConverter()
+        {
+            return TypeDescriptor.GetConverter(this, true);
+        }
+
+        public EventDescriptor GetDefaultEvent()
+        {
+            return TypeDescriptor.GetDefaultEvent(this, true);
+        }
+
+        public PropertyDescriptor GetDefaultProperty()
+        {
+            return TypeDescriptor.GetDefaultProperty(this, true);
+        }
+
+        public object GetEditor(Type editorBaseType)
+        {
+            return TypeDescriptor.GetEditor(this, editorBaseType, true);
+        }
+
+        public EventDescriptorCollection GetEvents(Attribute[] attributes)
+        {
+            return TypeDescriptor.GetEvents(this, attributes, true);
+        }
+
+        public EventDescriptorCollection GetEvents()
+        {
+            return TypeDescriptor.GetEvents(this, true);
+        }
+
+        public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+        {
+            // if a re-import wouldn't be a spritesheet tile selected from the source
+            // file, don't return the properties that specify the tile size and offsets
+            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
+            List<PropertyDescriptor> wantProperties = new List<PropertyDescriptor>();
+
+            foreach (PropertyDescriptor property in properties)
+            {
+                switch(property.Name)
+                {
+                    case "ImportHeight":
+                    case "ImportWidth":
+                    case "OffsetX":
+                    case "OffsetY":
+                        if (!_importAsTile) break;
+                        goto default;
+                    default:
+                        wantProperties.Add(property);
+                        break;
+                }
+            }
+
+            return new PropertyDescriptorCollection(wantProperties.ToArray());
+        }
+
+        public PropertyDescriptorCollection GetProperties()
+        {
+            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, true);
+            return properties;
+        }
+
+        public object GetPropertyOwner(PropertyDescriptor pd)
+        {
+            return this;
+        }
+
+        #endregion
 
 		#region IComparable<Sprite> Members
 

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -243,6 +243,8 @@ namespace AGS.Types
                 try
                 {
                     _sourceFile = SerializeUtils.GetElementString(sourceNode, "FileName");
+
+                    // added in XML version 17
                     _offsetX = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "OffsetX"));
                     _offsetY = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "OffsetY"));
                     _frame = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "Frame"));
@@ -255,6 +257,17 @@ namespace AGS.Types
                     // pass
                 }
 
+                // added with fixup task in XML version 20
+                try
+                {
+                    _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
+                }
+                catch (InvalidDataException)
+                {
+                    _importAlphaChannel = true;
+                }
+
+                // added with fixup task in XML Version 23
                 try
                 {
                     _importWidth = Convert.ToInt32(SerializeUtils.GetElementString(sourceNode, "ImportWidth"));
@@ -266,6 +279,7 @@ namespace AGS.Types
                     _importHeight = _height;
                 }
 
+                // added with fixup task in XML Version 24
                 try
                 {
                     _importAsTile = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAsTile"));
@@ -273,15 +287,6 @@ namespace AGS.Types
                 catch (InvalidDataException)
                 {
                     _importAsTile = false;
-                }
-
-                try
-                {
-                    _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
-                }
-                catch (InvalidDataException)
-                {
-                    _importAlphaChannel = true;
                 }
             }
         }

--- a/Editor/AGS.Types/Sprite.cs
+++ b/Editor/AGS.Types/Sprite.cs
@@ -29,6 +29,7 @@ namespace AGS.Types
         private bool _remapToGamePalette;
         private bool _remapToRoomPalette;
         private bool _importAlphaChannel;
+        private bool _importAsTile;
 
         public Sprite(int number, int width, int height, int colorDepth, SpriteImportResolution importRes, bool alphaChannel)
         {
@@ -176,6 +177,14 @@ namespace AGS.Types
             set { _importHeight = value; }
         }
 
+        [Description("Import as a spritesheet tile using the specified size and offsets")]
+        [Category("Import")]
+        public bool ImportAsTile
+        {
+            get { return _importAsTile; }
+            set { _importAsTile = value; }
+        }
+
         [Description("The frame number of a multi-frame image within the source file")]
         [Category("Import")]
         public int Frame
@@ -258,6 +267,15 @@ namespace AGS.Types
 
                 try
                 {
+                    _importAsTile = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAsTile"));
+                }
+                catch (InvalidDataException)
+                {
+                    _importAsTile = false;
+                }
+
+                try
+                {
                     _importAlphaChannel = Convert.ToBoolean(SerializeUtils.GetElementString(sourceNode, "ImportAlphaChannel"));
                 }
                 catch (InvalidDataException)
@@ -288,6 +306,7 @@ namespace AGS.Types
             writer.WriteElementString("OffsetY", _offsetY.ToString());
             writer.WriteElementString("ImportHeight", _importHeight.ToString());
             writer.WriteElementString("ImportWidth", _importWidth.ToString());
+            writer.WriteElementString("ImportAsTile", _importAsTile.ToString());
             writer.WriteElementString("Frame", _frame.ToString());
             writer.WriteElementString("RemapToGamePalette", _remapToGamePalette.ToString());
             writer.WriteElementString("RemapToRoomPalette", _remapToRoomPalette.ToString());


### PR DESCRIPTION
This allows you to re-import a sprite of a different size without needing to adjust the tile size, which fixes the issue of re-importing images which are not from a spritesheet and have been resized. There isn't enough information to automatically set the flag automatic for existing projects where there is already tile size information for the sprite, but I think the upgrade mechansim should cover every case except where the tile selection begins at 0,0 and the size is larger than any other tile from the same source.

Secondary changes were:
- internal import functions are modified to be more consistent in terms of the parameters that are passed
- import size and offset values are hidden from the property grid whilst ImportAsTile is set to false

I'm not entirely sure on the name ImportAsTile, but it does mean the optional properties are listed directly below this in the property grid, just based on the alphabetical order.

Any testing would be appreciated, I've been using it and it seems OK, but there might be something I've not clicked.