### PR TITLE
Editor: Faster check for speech file rebuild

### DIFF
--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -302,11 +302,13 @@ namespace AGS.Editor.Components
                     if (fileTimeNow != lastCheckFileTime)
                     {
                         needsRebuild = true;
+                        break;
                     }
                 }
                 else
                 {
                     needsRebuild = true;
+                    break;
                 }
             }
             return needsRebuild;


### PR DESCRIPTION
It'll be a lot faster (relatively) to avoid reading the timestamps for all files, when a previous filename or timestamp check has already set the rebuild flag.