### PR TITLE
Removes oldgamestruct.h from Common/CMakeLists.txt

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -35,7 +35,6 @@ target_sources(common
     ac/inventoryiteminfo.h
     ac/mousecursor.cpp
     ac/mousecursor.h
-    ac/oldgamesetupstruct.h
     ac/spritecache.cpp
     ac/spritecache.h
     ac/view.cpp


### PR DESCRIPTION
oldgamestruct.h has been removed from master.