### PR TITLE
Editor: remove transparency color from all sprite previews

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1666,18 +1666,9 @@ namespace AGS.Editor
         }
 
         void IGUIController.DrawSprite(Graphics g, int spriteNumber, int x, int y, int width, int height, bool centreHorizontally)
-		{
-            SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteNumber);
-
-            int spriteWidth = info.Width;
-			int spriteHeight = info.Height;
-            // Draw low-res sprites larger (TODO: find out why, perhaps just for the better looks?)
-            if (info.Resolution == SpriteImportResolution.LowRes)
-            {
-                spriteWidth *= 2;
-                spriteHeight *= 2;
-            }
-			Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(new Sprite(spriteNumber, spriteWidth, spriteHeight), width, height, centreHorizontally, false, SystemColors.Control);
+        {
+            Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(spriteNumber, true);
+            Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, width, height, centreHorizontally, false);
 			g.DrawImage(bmp, x, y);
 			bmp.Dispose();
 		}

--- a/Editor/AGS.Editor/Panes/CursorEditor.cs
+++ b/Editor/AGS.Editor/Panes/CursorEditor.cs
@@ -52,11 +52,15 @@ namespace AGS.Editor
                 IMAGE_SCALE_FACTOR = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
 
                 if (_item.Image > 0)
-				{
-					IntPtr hdc = e.Graphics.GetHdc();
-					Factory.NativeProxy.DrawSprite(hdc, 0, 0, _item.Image);
-					e.Graphics.ReleaseHdc();
-				}
+                {
+                    Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(_item.Image, true);
+
+                    using (Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, sprite.Width * IMAGE_SCALE_FACTOR, sprite.Height * IMAGE_SCALE_FACTOR, false, false))
+                    {
+                        e.Graphics.DrawImage(bmp, 0, 0);
+                    }
+                }
+
                 if ((_item.HotspotX >= 0) && (_item.HotspotY >= 0))
                 {
                     e.Graphics.DrawLine(Pens.LightGreen, (_item.HotspotX - 2) * IMAGE_SCALE_FACTOR, _item.HotspotY * IMAGE_SCALE_FACTOR, (_item.HotspotX + 2) * IMAGE_SCALE_FACTOR, _item.HotspotY * IMAGE_SCALE_FACTOR);

--- a/Editor/AGS.Editor/Panes/InventoryEditor.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.cs
@@ -55,10 +55,13 @@ namespace AGS.Editor
             if (_item != null)
             {
                 IMAGE_SCALE_FACTOR = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
+                Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(_item.CursorImage, true);
 
-                IntPtr hdc = e.Graphics.GetHdc();
-                Factory.NativeProxy.DrawSprite(hdc, 0, 0, _item.CursorImage);
-                e.Graphics.ReleaseHdc();
+                using (Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, sprite.Width * IMAGE_SCALE_FACTOR, sprite.Height * IMAGE_SCALE_FACTOR, false, false))
+                {
+                    e.Graphics.DrawImage(bmp, 0, 0);
+                }
+
                 if ((_item.HotspotX > 0) && (_item.HotspotY > 0))
                 {
                     e.Graphics.DrawLine(Pens.LightGreen, (_item.HotspotX - 2) * IMAGE_SCALE_FACTOR, _item.HotspotY * IMAGE_SCALE_FACTOR, (_item.HotspotX + 2) * IMAGE_SCALE_FACTOR, _item.HotspotY * IMAGE_SCALE_FACTOR);
@@ -92,9 +95,13 @@ namespace AGS.Editor
         {
             if (_item != null)
             {
-                IntPtr hdc = e.Graphics.GetHdc();
-                Factory.NativeProxy.DrawSprite(hdc, 0, 0, _item.Image);
-                e.Graphics.ReleaseHdc();
+                IMAGE_SCALE_FACTOR = Factory.AGSEditor.CurrentGame.GUIScaleFactor;
+                Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(_item.Image, true);
+
+                using (Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, sprite.Width * IMAGE_SCALE_FACTOR, sprite.Height * IMAGE_SCALE_FACTOR, false, false))
+                {
+                    e.Graphics.DrawImage(bmp, 0, 0);
+                }
             }
         }
 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -215,7 +215,6 @@ namespace AGS.Editor
             _spriteImages.Images.Clear();
             _spriteImages.ColorDepth = ColorDepth.Depth16Bit;
             _spriteImages.ImageSize = new Size(64, 64);
-            _spriteImages.TransparentColor = Color.Pink;
             List<ListViewItem> itemsToAdd = new List<ListViewItem>();
 
             Progress progress = new Progress(folder.Sprites.Count, "Refreshing folder...");
@@ -225,7 +224,7 @@ namespace AGS.Editor
             {
                 progress.SetProgressValue(index);
                 Sprite sprite = folder.Sprites[index];
-                Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, 64, 64, false, true, Color.Pink);
+                Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, 64, 64, false, true);
 
                 // we are already indexing from 0 and this ImageList was cleared,
                 // so just adding the image doesn't need a modified index

--- a/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
@@ -127,9 +127,24 @@ namespace AGS.Editor
 
         private void ViewLoopEditor_Paint(object sender, PaintEventArgs e)
         {
-            IntPtr hdc = e.Graphics.GetHdc();
-            Factory.NativeProxy.DrawViewLoop(hdc, _loop, 0, _loopDisplayY, FRAME_DISPLAY_SIZE, _selectedFrame);
-            e.Graphics.ReleaseHdc();
+            for (int i = 0; i < _loop.Frames.Count; i++)
+            {
+                ViewFrame frame = _loop.Frames[i];
+                Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(frame.Image, true);
+
+                using (Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, FRAME_DISPLAY_SIZE, FRAME_DISPLAY_SIZE, false, false))
+                {
+                    if (frame.Flipped)
+                    {
+                        bmp.RotateFlip(RotateFlipType.RotateNoneFlipX);
+                    }
+
+                    Rectangle display = new Rectangle(i * FRAME_DISPLAY_SIZE, _loopDisplayY, FRAME_DISPLAY_SIZE, FRAME_DISPLAY_SIZE);
+                    e.Graphics.DrawImage(bmp, display);
+                    Pen pen = new Pen(i == _selectedFrame ? Color.HotPink : Color.SlateGray);
+                    e.Graphics.DrawRectangle(pen, display);
+                }
+            }
 
 			for (int i = 0; i < _loop.Frames.Count; i++)
 			{

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -103,32 +103,25 @@ namespace AGS.Editor
                 (udFrame.Value < _view.Loops[(int)udLoop.Value].Frames.Count))
             {
                 ViewFrame thisFrame = _view.Loops[(int)udLoop.Value].Frames[(int)udFrame.Value];
-                int spriteNum = thisFrame.Image;
-                SpriteInfo info = Factory.NativeProxy.GetSpriteInfo(spriteNum);
-                int spriteWidth = info.Width;
-                int spriteHeight = info.Height;
-                // Draw low-res sprites larger (TODO: find out why, perhaps just for the better looks?)
-                if (info.Resolution == SpriteImportResolution.LowRes)
-                {
-                    spriteWidth *= 2;
-                    spriteHeight *= 2;
-                }
-                int x = 0, y;
-                y = previewPanel.ClientSize.Height - spriteHeight;
+                Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(thisFrame.Image, true);
+                int x = 0;
+                int y = previewPanel.ClientSize.Height - sprite.Height;
+
                 if (chkCentrePivot.Checked)
                 {
-                    x = previewPanel.ClientSize.Width / 2 - spriteWidth / 2;
+                    x = previewPanel.ClientSize.Width / 2 - sprite.Width / 2;
                 }
-				if ((spriteWidth <= previewPanel.ClientSize.Width) &&
-					(spriteHeight <= previewPanel.ClientSize.Height))
+
+                if ((sprite.Width <= previewPanel.ClientSize.Width) &&
+                    (sprite.Height <= previewPanel.ClientSize.Height))
 				{
 					IntPtr hdc = e.Graphics.GetHdc();
-					Factory.NativeProxy.DrawSprite(hdc, x, y, spriteNum, thisFrame.Flipped);
+                    Factory.NativeProxy.DrawSprite(hdc, x, y, sprite.Number, thisFrame.Flipped);
 					e.Graphics.ReleaseHdc();
 				}
 				else
 				{
-					Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(new Sprite(spriteNum, spriteWidth, spriteHeight), previewPanel.ClientSize.Width, previewPanel.ClientSize.Height, chkCentrePivot.Checked, false, SystemColors.Control);
+                    Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, previewPanel.ClientSize.Width, previewPanel.ClientSize.Height, chkCentrePivot.Checked, false);
 
                     if (thisFrame.Flipped)
                     {

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -104,40 +104,21 @@ namespace AGS.Editor
             {
                 ViewFrame thisFrame = _view.Loops[(int)udLoop.Value].Frames[(int)udFrame.Value];
                 Sprite sprite = Factory.AGSEditor.CurrentGame.RootSpriteFolder.FindSpriteByID(thisFrame.Image, true);
-                int x = 0;
-                int y = previewPanel.ClientSize.Height - sprite.Height;
+                int height = Math.Min(previewPanel.ClientSize.Height, sprite.Height);
+                int width = Math.Min(previewPanel.ClientSize.Width, sprite.Width);
 
-                if (chkCentrePivot.Checked)
+                using (Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, width, height, chkCentrePivot.Checked, false))
                 {
-                    x = previewPanel.ClientSize.Width / 2 - sprite.Width / 2;
-                }
-
-                if ((sprite.Width <= previewPanel.ClientSize.Width) &&
-                    (sprite.Height <= previewPanel.ClientSize.Height))
-				{
-					IntPtr hdc = e.Graphics.GetHdc();
-                    Factory.NativeProxy.DrawSprite(hdc, x, y, sprite.Number, thisFrame.Flipped);
-					e.Graphics.ReleaseHdc();
-				}
-				else
-				{
-                    Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, previewPanel.ClientSize.Width, previewPanel.ClientSize.Height, chkCentrePivot.Checked, false);
+                    int x = chkCentrePivot.Checked ? previewPanel.ClientSize.Width / 2 - bmp.Width / 2 : 0;
+                    int y = previewPanel.ClientSize.Height - bmp.Height;
 
                     if (thisFrame.Flipped)
                     {
-                        Point urCorner = new Point(0, 0);
-                        Point ulCorner = new Point(bmp.Width, 0);
-                        Point llCorner = new Point(bmp.Width, bmp.Height);
-                        Point[] destPara = { ulCorner, urCorner, llCorner };
-                        e.Graphics.DrawImage(bmp, destPara);
-                    }
-                    else
-                    {
-                        e.Graphics.DrawImage(bmp, 1, 1);
+                        bmp.RotateFlip(RotateFlipType.RotateNoneFlipX);
                     }
 
-					bmp.Dispose();
-				}
+                    e.Graphics.DrawImage(bmp, x, y);
+                }
             }
         }
 

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -261,7 +261,7 @@ namespace AGS.Editor
             }
         }
 
-        public static Bitmap GetBitmapForSpriteResizedKeepingAspectRatio(Sprite sprite, int width, int height, bool centreInNewCanvas, bool drawOutline, Color backgroundColour)
+        public static Bitmap GetBitmapForSpriteResizedKeepingAspectRatio(Sprite sprite, int width, int height, bool centreInNewCanvas, bool drawOutline)
         {
             float targetWidthHeightRatio = (float)width / (float)height;
             float spriteWidthHeightRatio = (float)sprite.Width / (float)sprite.Height;
@@ -287,26 +287,42 @@ namespace AGS.Editor
             if (newWidth < 1) newWidth = 1;
             if (newHeight < 1) newHeight = 1;
 
-            Bitmap newBmp = new Bitmap(width, height, PixelFormat.Format32bppRgb);
-            Graphics g = Graphics.FromImage(newBmp);
-            g.Clear(backgroundColour);
-            Bitmap bitmapToDraw = Factory.NativeProxy.GetBitmapForSprite(sprite.Number, newWidth, newHeight);
+            Bitmap newBmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
 
-            int x = 0, y = 0;
-            if (centreInNewCanvas)
+            using (Graphics g = Graphics.FromImage(newBmp))
             {
-                x = width / 2 - bitmapToDraw.Width / 2;
-                y = height - bitmapToDraw.Height;
+                if (sprite.AlphaChannel)
+                {
+                    g.Clear(Color.Transparent);
+                }
+                else
+                {
+                    g.Clear(Color.Magenta);
+                }
+
+                using (Bitmap bitmapToDraw = Factory.NativeProxy.GetBitmapForSprite(sprite.Number, newWidth, newHeight))
+                {
+                    int x = 0, y = 0;
+                    if (centreInNewCanvas)
+                    {
+                        x = width / 2 - bitmapToDraw.Width / 2;
+                        y = height - bitmapToDraw.Height;
+                    }
+
+                    g.DrawImage(bitmapToDraw, x, y, bitmapToDraw.Width, bitmapToDraw.Height);
+
+                    if (drawOutline)
+                    {
+                        g.DrawRectangle(Pens.Brown, x, y, newWidth - 1, newHeight - 1);
+                    }
+                }
             }
 
-            g.DrawImage(bitmapToDraw, x, y, bitmapToDraw.Width, bitmapToDraw.Height);
-
-            if (drawOutline)
+            if (!(sprite.AlphaChannel))
             {
-                g.DrawRectangle(Pens.Brown, x, y, newWidth - 1, newHeight - 1);
+                newBmp.MakeTransparent(Color.Magenta);
             }
 
-            g.Dispose();
             return newBmp;
         }
 


### PR DESCRIPTION
This removes magenta from all sprite previews in the Editor, where the presence of the magenta is meant to indicate transparency. Whether this is correct or not, I'm not sure, as it isn't obivous why some parts of the Editor show it and others don't. I thought submitting as a PR to let people try the build is the best way to describe the change that it provides. The main difference is a slightly slower redraw within the View editor (although it was already slow) since all previews are now going through the same function that provides the previews for the main sprite viewer.

So, anyone's opinion either way would be appreciated...