### PR TITLE
Ensure IsKeyPressed only returns 1 or 0

### DIFF
--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -53,7 +53,7 @@ int ags_kbhit () {
 int ags_iskeypressed (int keycode) {
     if (keycode >= 0 && keycode < __allegro_KEY_MAX)
     {
-        return key[keycode];
+        return key[keycode] != 0;
     }
     return 0;
 }


### PR DESCRIPTION
To fix script compatibility. Because allegro4's `key` array can hold values other than 0 or 1, this breaks scripts as the values are converted to script bool (which is really just an int define)

Fixes https://github.com/adventuregamestudio/ags/issues/1010