### PR TITLE
3.5.0 Editor: Fix audio clip references in property field, revert to using internal fixed index

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -85,8 +85,9 @@ namespace AGS.Editor
          * 22: 3.5.0.18   - Settings.ScaleMovementSpeedWithMaskResolution.
          * 23-24: 3.5.0.20+ - Sprite tile import properties.
          * 25: 3.5.0.22   - Full editor version saved into XML header, RuntimeSetup.ThreadedAudio.
+         * 26:            - Fixed sound references in game properties.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 25;
+        public const int    LATEST_XML_VERSION_INDEX = 26;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -386,11 +386,11 @@ namespace AGS.Editor.Components
                 AudioClip clip = _agsEditor.CurrentGame.FindAudioClipForOldSoundNumber(allAudio, _agsEditor.CurrentGame.Settings.PlaySoundOnScore);
                 if (clip != null)
                 {
-                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = clip.ID;
+                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = clip.Index;
                 }
                 else
                 {
-                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = -1;
+                    _agsEditor.CurrentGame.Settings.PlaySoundOnScore = AudioClip.FixedIndexNoValue;
                 }
             }
         }
@@ -408,11 +408,11 @@ namespace AGS.Editor.Components
                             AudioClip clip = _agsEditor.CurrentGame.FindAudioClipForOldSoundNumber(allAudio, frame.Sound);
                             if (clip != null)
                             {
-                                frame.Sound = clip.ID;
+                                frame.Sound = clip.Index;
                             }
                             else
                             {
-                                frame.Sound = -1;
+                                frame.Sound = AudioClip.FixedIndexNoValue;
                             }
                         }
                     }
@@ -572,6 +572,8 @@ namespace AGS.Editor.Components
                     Utilities.CopyFileAndSetDestinationWritable(filesToCopy[i].SourceFileName, fileNamesToUpdate[i]);
                 }
             }
+
+            _agsEditor.CurrentGame.UpdateAudioClipMap();
         }
 
         private void ProjectTree_OnAfterLabelEdit(string commandID, ProjectTreeItem treeItem)

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -866,7 +866,7 @@ namespace AGS.Editor
                             writer.Write((short)frame.Delay);
                             writer.Write((short)0); // struct alignment padding
                             writer.Write(frame.Flipped ? NativeConstants.VFLG_FLIPSPRITE : 0);
-                            writer.Write(frame.Sound);
+                            writer.Write(game.GetAudioArrayIDFromFixedIndex(frame.Sound));
                             writer.Write(0); // unused reservedForFuture[0]
                             writer.Write(0); // unused reservedForFuture[1]
                         }
@@ -1706,7 +1706,7 @@ namespace AGS.Editor
                 writer.Write(new byte[2]); // struct alignment padding
                 writer.Write(0); // reserved
             }
-            writer.Write(game.Settings.PlaySoundOnScore);
+            writer.Write(game.GetAudioArrayIDFromFixedIndex(game.Settings.PlaySoundOnScore));
             if (game.Settings.DebugMode)
             {
                 writer.Write(game.Rooms.Count);

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -14,7 +14,8 @@ namespace AGS.Types
         private int _id;
         private string _sourceFileName;
         private string _scriptName;
-        private int _index;
+        // FixedID is a clip's UID which never change, even if the list got reordered
+        private int _fixedID;
         private int _typeID;
         private AudioFileBundlingType _bundlingType = AudioFileBundlingType.InGameEXE;
         private AudioClipFileType _fileType;
@@ -26,10 +27,17 @@ namespace AGS.Types
         private AudioClipPriority _actualPriority;
         private bool _actualRepeat;
 
-        public AudioClip(string scriptName, int index)
+        // The value of a "no sound reference"
+        public const int FixedIndexNoValue = 0;
+        // The value of a "first index"
+        public const int FixedIndexBase = 1;
+        // The value of a "no sound" for AudioClip.ID
+        public const int IDNoValue = -1;
+
+        public AudioClip(string scriptName, int fixed_index)
         {
             _scriptName = scriptName;
-            _index = index;
+            _fixedID = fixed_index;
         }
 
         [AGSNoSerialize]
@@ -45,7 +53,7 @@ namespace AGS.Types
         [DisplayName("Cache File Name")]
         public string CacheFileNameWithoutPath
         {
-            get { return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, _index, Path.GetExtension(_sourceFileName)); }
+            get { return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, _fixedID, Path.GetExtension(_sourceFileName)); }
         }
 
         [DisplayName("ID")]
@@ -72,12 +80,13 @@ namespace AGS.Types
             set { _scriptName = Utilities.ValidateScriptName(value); }
         }
 
-        // NOTE: this index remains only as a connection to the AudioCache
+        // This is a "Fixed Index" that is used as a stable reference the clip,
+        // regardless of any clip list rearrangements.
         [Browsable(false)]
         public int Index
         {
-            get { return _index; }
-            set { _index = value; }
+            get { return _fixedID; }
+            set { _fixedID = value; }
         }
 
         [Description("Which type of audio does this clip contain")]

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -60,7 +60,9 @@ namespace AGS.Types
         private LipSync _lipSync;
         private CustomPropertySchema _propertySchema;
         private GlobalVariables _globalVariables;
-		private string _directoryPath;
+        // Maps AudioClip.Index (fixed ID) to AudioClip.ID
+        private Dictionary<int, int> _audioClipIndexMapping;
+        private string _directoryPath;
 		private bool _roomsAddedOrRemoved = false;
 		private Dictionary<int, object> _deletedViewIDs;
 		private string _savedXmlVersion = null;
@@ -1034,6 +1036,31 @@ namespace AGS.Types
                 }
             }
             return scripts;
+        }
+
+        // NOTE: when to update FixedID->ID map is mostly a question of
+        // when and how is it used. As of now it is only called when writing game data, -
+        // that is where we need to know real ordered clip ID. But in universal case
+        // the map will have to be updated whenever a sound is added, deleted
+        // or have its ID changed.
+        public void UpdateAudioClipMap()    
+        {
+            _audioClipIndexMapping = new Dictionary<int, int>();
+            foreach (AudioClip clip in _audioClips)
+            {
+                _audioClipIndexMapping.Add(clip.Index, clip.ID);
+            }
+        }
+
+        public int GetAudioArrayIDFromFixedIndex(int fixedIndex)
+        {
+            int id;
+            if (fixedIndex >= AudioClip.FixedIndexBase &&
+                _audioClipIndexMapping.TryGetValue(fixedIndex, out id))
+            {
+                return id;
+            }
+            return AudioClip.IDNoValue;
         }
 
         public byte[] GetPaletteAsRawPAL()

--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipTypeConverter.cs
@@ -33,13 +33,13 @@ namespace AGS.Types
             }
 
             _possibleValues.Clear();
-            _possibleValues.Add(-1, "(None)");
+            _possibleValues.Add(AudioClip.FixedIndexNoValue, "(None)");
 
             // sort on the script name rather than use the default enumeration order, which
             // comes from the ordering of items in the audio folder hierarchy (volatile)
             foreach (AudioClip clip in _AudioClips.OrderBy(a => a.ScriptName))
             {
-                _possibleValues.Add(clip.ID, clip.ScriptName);
+                _possibleValues.Add(clip.Index, clip.ScriptName);
             }
         }
     }

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -113,7 +113,7 @@ namespace AGS.Types
 		private string _saveGameExtension = string.Empty;
 		private bool _enhancedSaveGames = false;
         private string _saveGamesFolderName = string.Empty;
-        private int _audioIndexer = 0;
+        private int _audioIndexer = AudioClip.FixedIndexBase;
         private string _buildTargets = GetBuildTargetsString(BuildTargetsInfo.GetAvailableBuildTargetNames(), false);
 
         /// <summary>
@@ -673,7 +673,7 @@ namespace AGS.Types
 
         [DisplayName("Play sound when the player gets points")]
         [Description("This sound number will be played whenever the player scores points (0 to disable)")]
-        [DefaultValue(-1)]
+        [DefaultValue(AudioClip.FixedIndexNoValue)]
         [Category("Sound")]
         [TypeConverter(typeof(AudioClipTypeConverter))]
         public int PlaySoundOnScore
@@ -1072,7 +1072,8 @@ namespace AGS.Types
             set { _binaryFilesInSourceControl = value; }
         }
 
-        // NOTE: this index only purpose remains to connect clips to audio cache
+        // This is used to assign "fixed indices" to audio clips, which work as a stable reference the clip,
+        // regardless of any clip list rearrangements.
         [Browsable(false)]
         public int AudioIndexer
         {
@@ -1120,7 +1121,7 @@ namespace AGS.Types
             _runGameLoopsWhileDialogOptionsDisplayed = false;
             _inventoryHotspotMarker = new InventoryHotspotMarker();
             _useLowResCoordinatesInScript = true;
-            _audioIndexer = 0;
+            _audioIndexer = AudioClip.FixedIndexBase;
             _enforceNewAudio = false;
 
             SerializeUtils.DeserializeFromXML(this, node);

--- a/Editor/AGS.Types/ViewFrame.cs
+++ b/Editor/AGS.Types/ViewFrame.cs
@@ -61,7 +61,7 @@ namespace AGS.Types
         [Description("Sound to be played when the frame becomes visible")]
         [Category("Design")]
         [TypeConverter(typeof(AudioClipTypeConverter))]
-        [DefaultValue(-1)]
+        [DefaultValue(AudioClip.FixedIndexNoValue)]
         public int Sound
         {
             get { return _sound; }


### PR DESCRIPTION
This was a big mistake to switch to using AudioClip.ID as a reference to clips in property fields, because currently ID value is volatile and may change if the list of clips was modified in the middle. This commit partially reverts 72a01d64e31a93be900d6e04bd22e812c64608bc and puts fixed index into use again.

This affects ViewFrame's Sound property and GeneralSettings.PlaySoundOnScore.
