### PR TITLE
Editor: set default state for audio controls

### DIFF
--- a/Editor/AGS.Editor/Panes/AudioEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.Designer.cs
@@ -64,6 +64,7 @@
             // 
             // btnStop
             // 
+            this.btnStop.Enabled = false;
             this.btnStop.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnStop.Image = ((System.Drawing.Image)(resources.GetObject("btnStop.Image")));
             this.btnStop.Location = new System.Drawing.Point(128, 158);
@@ -85,6 +86,7 @@
             // 
             // btnPause
             // 
+            this.btnPause.Enabled = false;
             this.btnPause.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnPause.Image = ((System.Drawing.Image)(resources.GetObject("btnPause.Image")));
             this.btnPause.Location = new System.Drawing.Point(80, 158);


### PR DESCRIPTION
Disables the pause and stop buttons by default, otherwise the first time that this pane is used you could attempt to pause or stop audio that isn't currently being played.

Fixes #1016