### PR TITLE
Automatic font outlines (2)

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -101,6 +101,9 @@ Font custom line spacing.
 Sprites have "real" resolution. Expanded FontInfo data format.
 Option to allow legacy relative asset resolutions.
 
+51 :
+Fonts have adjustable outline
+
 */
 
 enum GameDataVersion
@@ -134,7 +137,8 @@ enum GameDataVersion
     kGameVersion_341            = 48,
     kGameVersion_341_2          = 49,
     kGameVersion_350            = 50,
-    kGameVersion_Current        = kGameVersion_350
+    kGameVersion_351            = 51,
+    kGameVersion_Current        = kGameVersion_351
 };
 
 extern GameDataVersion loaded_game_file_version;

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -143,6 +143,12 @@ void GameSetupStruct::read_font_infos(Common::Stream *in, GameDataVersion data_v
             fonts[i].YOffset = in->ReadInt32();
             fonts[i].LineSpacing = Math::Max(0, in->ReadInt32());
             AdjustFontInfoUsingFlags(fonts[i], flags);
+            if (data_ver >= kGameVersion_351)
+            {
+                fonts[i].AutoOutlineThickness = in->ReadInt32();
+                fonts[i].AutoOutlineStyle = 
+                    static_cast<enum FontInfo::AutoOutlineStyle>(in->ReadInt32());
+            }
         }
     }
 }

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -226,6 +226,12 @@ struct SpriteInfo
 // multiple lines, and similar cases.
 struct FontInfo
 {
+    enum AutoOutlineStyle : int
+    {
+        kRounded = 0,
+        kSquared = 1,
+    };
+
     // General font's loading and rendering flags
     uint32_t      Flags;
     // Font size, in points (basically means pixels in AGS)
@@ -238,6 +244,10 @@ struct FontInfo
     int           YOffset;
     // custom line spacing between two lines of text (0 = use font height)
     int           LineSpacing;
+    // When automatic outlining, thickness of the outline (0 = use legacy thickness)
+    int           AutoOutlineThickness;
+    // When automatic outlining, style of the outline
+    AutoOutlineStyle AutoOutlineStyle;
 
     FontInfo();
 };

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -62,7 +62,7 @@ FontInfo::FontInfo()
     , YOffset(0)
     , LineSpacing(0)
     , AutoOutlineStyle(kRounded)
-    , AutoOutlineThickness(0)
+    , AutoOutlineThickness(1)
 {}
 
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -61,6 +61,8 @@ FontInfo::FontInfo()
     , Outline(FONT_OUTLINE_NONE)
     , YOffset(0)
     , LineSpacing(0)
+    , AutoOutlineStyle(kRounded)
+    , AutoOutlineThickness(0)
 {}
 
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -154,6 +154,13 @@ int get_font_outline(size_t font_number)
     return fonts[font_number].Info.Outline;
 }
 
+int get_font_outline_thickness(size_t font_number)
+{
+    if (font_number >= fonts.size())
+        return 0;
+    return fonts[font_number].Info.AutoOutlineThickness;
+}
+
 void set_font_outline(size_t font_number, int outline_type)
 {
     if (font_number >= fonts.size())

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -44,6 +44,7 @@ bool font_supports_extended_characters(size_t fontNumber);
 // at random times (usually - drawing routines).
 // Need to check whether it is safe to completely remove it.
 void ensure_text_valid_for_font(char *text, size_t fontnum);
+// Get font's scaling multiplier
 int get_font_scaling_mul(size_t fontNumber);
 // Calculate actual width of a line of text
 int wgettextwidth(const char *texx, size_t fontNumber);
@@ -55,7 +56,11 @@ int getfontheight(size_t fontNumber);
 int getfontlinespacing(size_t fontNumber);
 // Get is font is meant to use default line spacing
 bool use_default_linespacing(size_t fontNumber);
+// Get font's outline type
 int  get_font_outline(size_t font_number);
+// Get font's automatic outline thickness (if set)
+int  get_font_outline_thickness(size_t font_number);
+// Set font's outline type
 void set_font_outline(size_t font_number, int outline_type);
 // Outputs a single line of text on the defined position on bitmap, using defined font, color and parameters
 int getfontlinespacing(size_t fontNumber);

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -28,6 +28,7 @@
 #include "util/path.h"
 #include "util/string_compat.h"
 #include "util/string_utils.h"
+#include "font/fonts.h"
 
 namespace AGS
 {
@@ -483,6 +484,21 @@ void UpgradeFonts(GameSetupStruct &game, GameDataVersion data_ver)
             else
             {
                 finfo.SizeMultiplier = 1;
+            }
+        }
+    } 
+    else
+    {
+        for (size_t font = 0; font < game.numfonts; font++)
+        {
+            FontInfo &finfo = game.fonts[font];
+            if (0 == finfo.AutoOutlineThickness)
+            {
+                // Thickness that corresponds to 1 game pixel
+                finfo.AutoOutlineThickness =
+                    (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+                    get_fixed_pixel_size(1) : 1;
+                finfo.AutoOutlineStyle = FontInfo::kSquared;
             }
         }
     }

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -486,20 +486,18 @@ void UpgradeFonts(GameSetupStruct &game, GameDataVersion data_ver)
                 finfo.SizeMultiplier = 1;
             }
         }
-    } 
-    else
+    }
+    if (data_ver < kGameVersion_351)
     {
         for (size_t font = 0; font < game.numfonts; font++)
         {
             FontInfo &finfo = game.fonts[font];
-            if (0 == finfo.AutoOutlineThickness)
-            {
-                // Thickness that corresponds to 1 game pixel
-                finfo.AutoOutlineThickness =
-                    (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
-                    get_fixed_pixel_size(1) : 1;
-                finfo.AutoOutlineStyle = FontInfo::kSquared;
-            }
+            // Thickness that corresponds to 1 game pixel
+            finfo.AutoOutlineThickness =
+                // if it's a scaled up bitmap font, move the outline out more
+                (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+                get_fixed_pixel_size(1) : 1;
+            finfo.AutoOutlineStyle = FontInfo::kSquared;
         }
     }
 }

--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -207,6 +207,11 @@ void Bitmap::Blit(Bitmap *src, int src_x, int src_y, int dst_x, int dst_y, int w
 	}
 }
 
+void Bitmap::MaskedBlit(Bitmap *src, int dst_x, int dst_y)
+{
+    draw_sprite(_alBitmap, src->_alBitmap, dst_x, dst_y);
+}
+
 void Bitmap::StretchBlt(Bitmap *src, const Rect &dst_rc, BitmapMaskOption mask)
 {
 	BITMAP *al_src_bmp = src->_alBitmap;

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -166,7 +166,9 @@ public:
     // Draw other bitmap over current one
     void    Blit(Bitmap *src, int dst_x = 0, int dst_y = 0, BitmapMaskOption mask = kBitmap_Copy);
     void    Blit(Bitmap *src, int src_x, int src_y, int dst_x, int dst_y, int width, int height, BitmapMaskOption mask = kBitmap_Copy);
-    // Copy other bitmap, stretching or shrinking its size to given values
+    // Draw other bitmap in a masked mode (kBitmap_Transparency)
+    void    MaskedBlit(Bitmap *src, int dst_x, int dst_y);
+    // Draw other bitmap, stretching or shrinking its size to given values
     void    StretchBlt(Bitmap *src, const Rect &dst_rc, BitmapMaskOption mask = kBitmap_Copy);
     void    StretchBlt(Bitmap *src, const Rect &src_rc, const Rect &dst_rc, BitmapMaskOption mask = kBitmap_Copy);
     // Antia-aliased stretch-blit

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -86,8 +86,9 @@ namespace AGS.Editor
          * 23-24: 3.5.0.20+ - Sprite tile import properties.
          * 25: 3.5.0.22   - Full editor version saved into XML header, RuntimeSetup.ThreadedAudio.
          * 26:            - Fixed sound references in game properties.
+         * 27: 3.5.1?     - Font outline thickness.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 26;
+        public const int    LATEST_XML_VERSION_INDEX = 27;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1414,6 +1414,8 @@ namespace AGS.Editor
 
                 writer.Write(game.Fonts[i].VerticalOffset);
                 writer.Write(game.Fonts[i].LineSpacing);
+				writer.Write(game.Fonts[i].AutoOutlineThickness);
+				writer.Write((int) game.Fonts[i].AutoOutlineStyle);
             }
             int topmostSprite;
             byte[] spriteFlags = new byte[NativeConstants.MAX_STATIC_SPRITES];

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -354,6 +354,27 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 27)
+            {
+                bool is_legacy_hires = game.IsHighResolution;
+                foreach (Font font in game.Fonts)
+                {
+                    font.AutoOutlineStyle = FontAutoOutlineStyle.Squared;
+                    // For scaled-up bitmap fonts in hi-res game outline is x2
+                    if (is_legacy_hires &&
+                        // NOTE: unfortunately as of now there's no direct way to determine if
+                        // this is a bitmap font or TTF
+                        !File.Exists(font.TTFFileName) && font.SizeMultiplier > 1)
+                    {
+                        font.AutoOutlineThickness = 2;
+                    }
+                    else
+                    {
+                        font.AutoOutlineThickness = 1;
+                    }
+                }
+            }
+
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);
             System.Version projectVersion = game.SavedXmlEditorVersion != null ? Types.Utilities.TryParseVersion(game.SavedXmlEditorVersion) : null;
             if (projectVersion == null || projectVersion < editorVersion)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -116,6 +116,7 @@
     <Compile Include="EditorFeatures\MenuCommands.cs" />
     <Compile Include="EditorFeatures\MessageBoxIconType.cs" />
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
+    <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />
     <Compile Include="Enums\CustomPropertyAppliesTo.cs" />
     <Compile Include="Enums\CustomPropertyType.cs" />

--- a/Editor/AGS.Types/Enums/FontAutoOutlineStyle.cs
+++ b/Editor/AGS.Types/Enums/FontAutoOutlineStyle.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AGS.Types
+{
+	public enum FontAutoOutlineStyle
+	{
+		Rounded = 0,
+		Squared = 1,
+	}
+}

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -120,7 +120,7 @@ namespace AGS.Types
             set { _outlineStyle = value; }
         }
 
-        [Description("Thickness of the automatic outline")]
+        [Description("Thickness of the automatic outline. WARNING: automatic outlines are generated at runtime and large sizes may negatively affect your game performance.")]
         [Category("Appearance")]
         [DefaultValue(1)]
 		public int AutoOutlineThickness

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -7,8 +7,8 @@ using System.Xml;
 namespace AGS.Types
 {
     [DefaultProperty("OutlineStyle")]
-    public class Font
-    {
+    public class Font : ICustomTypeDescriptor
+	{
         private int _id;
         private string _name;
         private int _pointSize;
@@ -19,14 +19,16 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
+		private int _autoOutlineThickness = 0;
+		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
         {
-            _outlineStyle = FontOutlineStyle.None;
-            _outlineFont = 0;
             _name = string.Empty;
             _pointSize = 0;
-            _fontHeight = 0;
+			_outlineFont = 0;
+			_outlineStyle = FontOutlineStyle.None;
+			_fontHeight = 0;
             _lineSpacing = 0;
         }
 
@@ -101,7 +103,7 @@ namespace AGS.Types
             get { return "Font: " + this.Name; }
         }
 
-        [Description("Font to use as an outline for this one (only if FontOutlineStyle is OutlineFont)")]
+        [Description("Font to use as an outline for this one")]
         [Category("Appearance")]
         public int OutlineFont
         {
@@ -111,11 +113,28 @@ namespace AGS.Types
 
         [Description("Whether this font should be drawn with an outline")]
         [Category("Appearance")]
-        public FontOutlineStyle OutlineStyle
+		[RefreshProperties(RefreshProperties.All)]
+		public FontOutlineStyle OutlineStyle
         {
             get { return _outlineStyle; }
             set { _outlineStyle = value; }
         }
+
+		[Description("Thickness of the automatic outline (0 = default)")]
+		[Category("Appearance")]
+		public int AutoOutlineThickness
+		{
+			get { return _autoOutlineThickness; }
+			set { _autoOutlineThickness = value; }
+		}
+
+		[Description("Style of the automatic outline")]
+		[Category("Appearance")]
+		public FontAutoOutlineStyle AutoOutlineStyle
+		{
+			get { return _autoOutlineStyle; }
+			set { _autoOutlineStyle = value; }
+		}
 
 		[Description("The file path that this font was imported from")]
 		[Category("Design")]
@@ -178,5 +197,84 @@ namespace AGS.Types
             SerializeUtils.SerializeToXML(this, writer);
         }
 
-    }
+		#region ICustomTypeDescriptor Members
+		public AttributeCollection GetAttributes()
+		{
+			return TypeDescriptor.GetAttributes(this, true);
+		}
+
+		public string GetClassName()
+		{
+			return TypeDescriptor.GetClassName(this, true);
+		}
+
+		public string GetComponentName()
+		{
+			return TypeDescriptor.GetComponentName(this, true);
+		}
+
+		public TypeConverter GetConverter()
+		{
+			return TypeDescriptor.GetConverter(this, true);
+		}
+
+		public EventDescriptor GetDefaultEvent()
+		{
+			return TypeDescriptor.GetDefaultEvent(this, true);
+		}
+
+		public PropertyDescriptor GetDefaultProperty()
+		{
+			return TypeDescriptor.GetDefaultProperty(this, true);
+		}
+
+		public object GetEditor(Type editorBaseType)
+		{
+			return TypeDescriptor.GetEditor(this, editorBaseType, true);
+		}
+
+		public EventDescriptorCollection GetEvents()
+		{
+			return TypeDescriptor.GetEvents(this, true);
+		}
+
+		public EventDescriptorCollection GetEvents(Attribute[] attributes)
+		{
+			return TypeDescriptor.GetEvents(this, attributes, true);
+		}
+
+		public PropertyDescriptorCollection GetProperties()
+		{
+			return TypeDescriptor.GetProperties(this, true);
+		}
+
+		public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+		{
+			PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(this, attributes, true);
+			List<PropertyDescriptor> wantedProperties = new List<PropertyDescriptor>();
+			foreach (PropertyDescriptor property in properties)
+			{
+				if (property.Name == "AutoOutlineStyle" ||
+					property.Name == "AutoOutlineThickness")
+				{
+					if (_outlineStyle != FontOutlineStyle.Automatic)
+						continue;
+				}
+				else if (property.Name == "OutlineFont")
+				{
+					if (_outlineStyle != FontOutlineStyle.UseOutlineFont)
+						continue;
+				}
+
+				wantedProperties.Add(property);
+			}
+			return new PropertyDescriptorCollection(wantedProperties.ToArray());
+		}
+
+		public object GetPropertyOwner(PropertyDescriptor pd)
+		{
+			return this;
+		}
+		#endregion
+	}
 }

--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -19,7 +19,7 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-		private int _autoOutlineThickness = 0;
+        private int _autoOutlineThickness = 1;
 		private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
 
         public Font()
@@ -120,17 +120,24 @@ namespace AGS.Types
             set { _outlineStyle = value; }
         }
 
-		[Description("Thickness of the automatic outline (0 = default)")]
-		[Category("Appearance")]
+        [Description("Thickness of the automatic outline")]
+        [Category("Appearance")]
+        [DefaultValue(1)]
 		public int AutoOutlineThickness
 		{
 			get { return _autoOutlineThickness; }
-			set { _autoOutlineThickness = value; }
+            set
+            {
+                if (value < 1)
+                    throw new ArgumentException("AutoOutlineThickness must be 1 or greater.");
+                _autoOutlineThickness = value;
+            }
 		}
 
 		[Description("Style of the automatic outline")]
 		[Category("Appearance")]
-		public FontAutoOutlineStyle AutoOutlineStyle
+        [DefaultValue(FontAutoOutlineStyle.Rounded)]
+        public FontAutoOutlineStyle AutoOutlineStyle
 		{
 			get { return _autoOutlineStyle; }
 			set { _autoOutlineStyle = value; }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -477,14 +477,6 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
 
     int thickness = game.fonts.at(font).AutoOutlineThickness;
     auto style = game.fonts.at(font).AutoOutlineStyle;
-    if (0 == thickness)
-    {
-        // Thickness that corresponds to 1 game pixel
-        thickness =
-            (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
-            get_fixed_pixel_size(1) : 1;
-        style = FontInfo::kSquared;
-    }
     if (thickness <= 0)
         return; 
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -35,6 +35,7 @@
 #include "ac/system.h"
 #include "ac/topbarsettings.h"
 #include "debug/debug_log.h"
+#include "gfx/blender.h"
 #include "gui/guibutton.h"
 #include "gui/guimain.h"
 #include "main/game_run.h"
@@ -476,25 +477,40 @@ void wouttextxy_AutoOutline_Semitransparent2Opaque(Bitmap *map)
 // Draw outline that is calculated from the text font, not derived from an outline font
 void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
 {
-    using AGS::Common::kBitmap_Transparency;
-
-    int thickness = game.fonts.at(font).AutoOutlineThickness;
-    auto style = game.fonts.at(font).AutoOutlineStyle;
+    int const thickness = game.fonts.at(font).AutoOutlineThickness;
+    auto const style = game.fonts.at(font).AutoOutlineStyle;
     if (thickness <= 0)
-        return; 
+        return;
+
+    // 16-bit games should use 32-bit stencils to keep anti-aliasing working
+    int const  ds_cd = ds->GetColorDepth();
+    bool const antialias = ds_cd >= 16 && game.options[OPT_ANTIALIASFONTS] != 0 && !is_bitmap_font(font);
+    int const  stencil_cd = antialias ? 32 : ds_cd;
+    if (antialias) // This is to make sure TTFs render proper alpha channel in 16-bit games too
+        color |= makeacol32(0, 0, 0, 0xff);
 
     size_t const t_width = wgettextwidth(texx, font);
     size_t const t_height = wgettextheight(texx, font);
-    Bitmap *outline_stencil =
-        CreateTransparentBitmap(t_width, t_height + 2 * thickness, ds->GetColorDepth());
-    Bitmap *texx_stencil =
-        CreateTransparentBitmap(t_width, t_height, ds->GetColorDepth());
-    if (!outline_stencil || !texx_stencil)
+    Bitmap texx_stencil, outline_stencil;
+    texx_stencil.CreateTransparent(t_width, t_height, stencil_cd);
+    outline_stencil.CreateTransparent(t_width, t_height + 2 * thickness, stencil_cd);
+    if (outline_stencil.IsNull() || texx_stencil.IsNull())
         return;
-    wouttextxy(texx_stencil, 0, 0, font, color, texx);
+    wouttextxy(&texx_stencil, 0, 0, font, color, texx);
 #if defined (AGS_FONTOUTLINE_MOREOPAQUE)
     wouttextxy_AutoOutline_Semitransparent2Opaque(texx_stencil);
 #endif
+
+    void(Bitmap::*pfn_drawstencil)(Bitmap *src, int dst_x, int dst_y);
+    if (antialias)
+    { // NOTE: we must set out blender AFTER wouttextxy, or it will be overidden
+        set_argb2any_blender();
+        pfn_drawstencil = &Bitmap::TransBlendBlt;
+    }
+    else
+    {
+        pfn_drawstencil = &Bitmap::MaskedBlit;
+    }
     
     // move start of text so that the outline doesn't drop off the bitmap
     xxp += thickness;
@@ -515,20 +531,17 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
             y_diff <= thickness && y_diff * y_diff  <= y_term_limit; 
             y_diff++)
         {
-            outline_stencil->Blit(texx_stencil, 0, thickness - y_diff, kBitmap_Transparency);
+            (outline_stencil.*pfn_drawstencil)(&texx_stencil, 0, thickness - y_diff);
             if (y_diff > 0)
-                outline_stencil->Blit(texx_stencil, 0, thickness + y_diff, kBitmap_Transparency);
+                (outline_stencil.*pfn_drawstencil)(&texx_stencil, 0, thickness + y_diff);
             largest_y_diff_reached_so_far = y_diff;
         }
 
         // stamp the outline stencil to the left and right of the text
-        ds->Blit(outline_stencil, xxp - x_diff, outline_y, kBitmap_Transparency);
+        (ds->*pfn_drawstencil)(&outline_stencil, xxp - x_diff, outline_y);
         if (x_diff > 0)
-            ds->Blit(outline_stencil, xxp + x_diff, outline_y, kBitmap_Transparency);
+            (ds->*pfn_drawstencil)(&outline_stencil, xxp + x_diff, outline_y);
     }
- 
-    delete texx_stencil;
-    delete outline_stencil;
 }
 
 // Draw an outline if requested, then draw the text on top 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -445,6 +445,8 @@ bool ShouldAntiAliasText() {
     return (game.options[OPT_ANTIALIASFONTS] != 0);
 }
 
+#if defined (AGS_FONTOUTLINE_MOREOPAQUE)
+// TODO: was suggested by fernewelten, but it's unclear whether is necessary
 // Make semi-transparent bits much more opaque
 void wouttextxy_AutoOutline_Semitransparent2Opaque(Bitmap *map)
 {
@@ -469,6 +471,7 @@ void wouttextxy_AutoOutline_Semitransparent2Opaque(Bitmap *map)
         }
     }
 }
+#endif
 
 // Draw outline that is calculated from the text font, not derived from an outline font
 void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
@@ -489,7 +492,9 @@ void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *
     if (!outline_stencil || !texx_stencil)
         return;
     wouttextxy(texx_stencil, 0, 0, font, color, texx);
+#if defined (AGS_FONTOUTLINE_MOREOPAQUE)
     wouttextxy_AutoOutline_Semitransparent2Opaque(texx_stencil);
+#endif
     
     // move start of text so that the outline doesn't drop off the bitmap
     xxp += thickness;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -47,6 +47,7 @@
 #include "ac/timer.h"
 
 using namespace AGS::Common;
+using namespace AGS::Common::BitmapHelper;
 
 extern GameState play;
 extern GameSetupStruct game;
@@ -214,7 +215,6 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             }
             else {
                 text_color = text_window_ds->GetCompatibleColor(asspch);
-                //wouttext_outline(ttxp,ttyp,usingfont,lines[ee]);
                 wouttext_aligned(text_window_ds, ttxleft, ttyp, wii, usingfont, text_color, Lines[ee], play.speech_text_align);
             }
         }
@@ -445,39 +445,114 @@ bool ShouldAntiAliasText() {
     return (game.options[OPT_ANTIALIASFONTS] != 0);
 }
 
-void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx) {
-    
-    color_t outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
-    if (get_font_outline(usingfont) >= 0) {
-        // MACPORT FIX 9/6/5: cast
-        wouttextxy(ds, xxp, yyp, (int)get_font_outline(usingfont), outline_color, texx);
-    }
-    else if (get_font_outline(usingfont) == FONT_OUTLINE_AUTO) {
-        int outlineDist = 1;
+// Make semi-transparent bits much more opaque
+void wouttextxy_AutoOutline_Semitransparent2Opaque(Bitmap *map)
+{
+    if (map->GetColorDepth() < 32)
+        return; // such maps don't feature partial transparency
+    size_t const width = map->GetWidth();
+    size_t const height = map->GetHeight();
 
-        if (is_bitmap_font(usingfont) && get_font_scaling_mul(usingfont) > 1) {
-            // if it's a scaled up bitmap font, move the outline out more
-            outlineDist = get_fixed_pixel_size(1);
+    for (size_t y = 0; y < height; y++)
+    {
+        int32 *sc_line = reinterpret_cast<int32 *>(map->GetScanLineForWriting(y));
+        for (size_t x = 0; x < width; x++)
+        {
+            int32 &px = sc_line[x];
+            int const transparency = geta(px);
+            if (0 < transparency && transparency < 255)
+                px = makeacol32(
+                    getr32(px), 
+                    getg32(px), 
+                    getb32(px), 
+                    std::min(85 + transparency * 2, 255));
         }
-
-        // move the text over so that it's still within the bounding rect
-        xxp += outlineDist;
-        yyp += outlineDist;
-
-        wouttextxy(ds, xxp - outlineDist, yyp, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp, yyp - outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp - outlineDist, yyp - outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp - outlineDist, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp + outlineDist, usingfont, outline_color, texx);
-        wouttextxy(ds, xxp + outlineDist, yyp - outlineDist, usingfont, outline_color, texx);
     }
-
-    wouttextxy(ds, xxp, yyp, usingfont, text_color, texx);
 }
 
-void wouttext_aligned (Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align) {
+// Draw outline that is calculated from the text font, not derived from an outline font
+void wouttextxy_AutoOutline(Bitmap *ds, size_t font, int32_t color, const char *texx, int &xxp, int &yyp)
+{
+    using AGS::Common::kBitmap_Transparency;
+
+    int thickness = game.fonts.at(font).AutoOutlineThickness;
+    auto style = game.fonts.at(font).AutoOutlineStyle;
+    if (0 == thickness)
+    {
+        // Thickness that corresponds to 1 game pixel
+        thickness =
+            (is_bitmap_font(font) && get_font_scaling_mul(font) > 1) ?
+            get_fixed_pixel_size(1) : 1;
+        style = FontInfo::kSquared;
+    }
+    if (thickness <= 0)
+        return; 
+
+    size_t const t_width = wgettextwidth(texx, font);
+    size_t const t_height = wgettextheight(texx, font);
+    Bitmap *outline_stencil =
+        CreateTransparentBitmap(t_width, t_height + 2 * thickness, ds->GetColorDepth());
+    Bitmap *texx_stencil =
+        CreateTransparentBitmap(t_width, t_height, ds->GetColorDepth());
+    if (!outline_stencil || !texx_stencil)
+        return;
+    wouttextxy(texx_stencil, 0, 0, font, color, texx);
+    wouttextxy_AutoOutline_Semitransparent2Opaque(texx_stencil);
+    
+    // move start of text so that the outline doesn't drop off the bitmap
+    xxp += thickness;
+    int const outline_y = yyp;
+    yyp += thickness;
+    
+    int largest_y_diff_reached_so_far = -1; 
+    for (int x_diff = thickness; x_diff >= 0; x_diff--)
+    {
+        // Integer arithmetics: In the following, we use terms k*(k + 1) to account for rounding.
+        //     (k + 0.5)^2 == k*k + 2*k*0.5 + 0.5^2 == k*k + k + 0.25 ==approx. k*(k + 1)
+        int y_term_limit = thickness * (thickness + 1);
+        if (FontInfo::kRounded == style)
+            y_term_limit -= x_diff * x_diff;
+
+        // extend the outline stencil to the top and bottom
+        for (int y_diff = largest_y_diff_reached_so_far + 1; 
+            y_diff <= thickness && y_diff * y_diff  <= y_term_limit; 
+            y_diff++)
+        {
+            outline_stencil->Blit(texx_stencil, 0, thickness - y_diff, kBitmap_Transparency);
+            if (y_diff > 0)
+                outline_stencil->Blit(texx_stencil, 0, thickness + y_diff, kBitmap_Transparency);
+            largest_y_diff_reached_so_far = y_diff;
+        }
+
+        // stamp the outline stencil to the left and right of the text
+        ds->Blit(outline_stencil, xxp - x_diff, outline_y, kBitmap_Transparency);
+        if (x_diff > 0)
+            ds->Blit(outline_stencil, xxp + x_diff, outline_y, kBitmap_Transparency);
+    }
+ 
+    delete texx_stencil;
+    delete outline_stencil;
+}
+
+// Draw an outline if requested, then draw the text on top 
+void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int font, color_t text_color, const char *texx) 
+{    
+    size_t const text_font = static_cast<size_t>(font);
+    // Draw outline (a backdrop) if requested
+    color_t const outline_color = ds->GetCompatibleColor(play.speech_text_shadow);
+    int const outline_font = get_font_outline(font);
+    if (outline_font >= 0)
+        wouttextxy(ds, xxp, yyp, static_cast<size_t>(outline_font), outline_color, texx);
+    else if (outline_font == FONT_OUTLINE_AUTO)
+        wouttextxy_AutoOutline(ds, text_font, outline_color, texx, xxp, yyp);
+    else
+        ; // no outline
+
+    // Draw text on top
+    wouttextxy(ds, xxp, yyp, text_font, text_color, texx);
+}
+
+void wouttext_aligned(Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align) {
 
     if (align & kMAlignHCenter)
         usexp = usexp + (oriwid / 2) - (wgettextwidth_compensate(text, usingfont) / 2);

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -554,23 +554,18 @@ void wouttext_aligned(Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, 
     wouttext_outline(ds, usexp, yy, usingfont, text_color, (char *)text);
 }
 
-int get_outline_adjustment(int font)
+// Get outline's thickness addition to the font's width or height
+int get_outline_padding(int font)
 {
-    // automatic outline fonts are 2 pixels taller
     if (get_font_outline(font) == FONT_OUTLINE_AUTO) {
-        // scaled up bitmap font, push outline further out
-        if (is_bitmap_font(font) && get_font_scaling_mul(font) > 1)
-            return get_fixed_pixel_size(2);
-        // otherwise, just push outline by 1 pixel
-        else
-            return 2;
+        return get_font_outline_thickness(font) * 2;
     }
     return 0;
 }
 
 int getfontheight_outlined(int font)
 {
-    return getfontheight(font) + get_outline_adjustment(font);
+    return getfontheight(font) + get_outline_padding(font);
 }
 
 int getfontspacing_outlined(int font)
@@ -590,19 +585,9 @@ int getheightoflines(int font, int numlines)
     return getfontspacing_outlined(font) * (numlines - 1) + getfontheight_outlined(font);
 }
 
-int wgettextwidth_compensate(const char *tex, int font) {
-    int wdof = wgettextwidth(tex, font);
-
-    if (get_font_outline(font) == FONT_OUTLINE_AUTO) {
-        // scaled up SCI font, push outline further out
-        if (is_bitmap_font(font) && get_font_scaling_mul(font) > 1)
-            wdof += get_fixed_pixel_size(2);
-        // otherwise, just push outline by 1 pixel
-        else
-            wdof += get_fixed_pixel_size(1);
-    }
-
-    return wdof;
+int wgettextwidth_compensate(const char *tex, int font)
+{
+    return wgettextwidth(tex, font) + get_outline_padding(font);
 }
 
 void do_corner(Bitmap *ds, int sprn, int x, int y, int offx, int offy) {

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -34,6 +34,7 @@ bool ShouldAntiAliasText();
 int GetTextDisplayLength(const char *text);
 // Calculates number of game loops for displaying a text on screen
 int GetTextDisplayTime(const char *text, int canberel = 0);
+// Draw an outline if requested, then draw the text on top 
 void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align);
 // TODO: GUI classes located in Common library do not make use of outlining,

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -39,7 +39,7 @@ void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color
 void wouttext_aligned (Common::Bitmap *ds, int usexp, int yy, int oriwid, int usingfont, color_t text_color, const char *text, HorAlignment align);
 // TODO: GUI classes located in Common library do not make use of outlining,
 // need to find a way to make all code use same functions.
-// Get the maximal height of the given font, with possible outlining in mind
+// Get the maximal height of the given font, with corresponding outlining
 int getfontheight_outlined(int font);
 // Get line spacing for the given font, with possible outlining in mind
 int getfontspacing_outlined(int font);
@@ -47,6 +47,7 @@ int getfontspacing_outlined(int font);
 int getfontlinegap(int font);
 // Gets the total maximal height of the given number of lines printed with the given font
 int getheightoflines(int font, int numlines);
+// Get the maximal width of the given font, with corresponding outlining
 int wgettextwidth_compensate(const char *tex, int font);
 void do_corner(Common::Bitmap *ds, int sprn,int xx1,int yy1,int typx,int typy);
 // Returns the image of a button control on the GUI under given child index

--- a/Engine/gfx/blender.h
+++ b/Engine/gfx/blender.h
@@ -59,5 +59,7 @@ unsigned long _opaque_alpha_blender(unsigned long src_col, unsigned long dst_col
 void set_additive_alpha_blender();
 // Opaque alpha blender plain copies src over, applying opaque alpha value.
 void set_opaque_alpha_blender();
+// Sets argb2argb for 32-bit mode, and provides appropriate funcs for blending 32-bit onto 15/16/24-bit destination
+void set_argb2any_blender();
 
 #endif // __AC_BLENDER_H


### PR DESCRIPTION
This is a remake of @fernewelten's #892 PR. Old one still had several mistakes, but unfortunately I didn't know if and when fernewelten is planning to complete it, so decided to speed things up and fix it on my own.

Following is the original description:

---

_This is proposed code for issue #878 (automatic outlines)._
_Added two additional fields to fonts:_
- _`AutoOutlineStyle` (`Rounded`, `Squared`)._
- _`AutoOutlineThickness` (positive integer, or 0 for default)_ 
_(I couldn't use "1" as the default for `AutoOutlineThickness` because currently, scaled bitmap fonts get an outline that is thicker than 1)._ 

_The fields will only show in the editor if `OutlineStyle==Automatic`._
_The field `OutlineFont` will now only show if `OutlineStyle==UseOutlineFont`._

_The algo for generating the outline is based on messengerbag's. The text is only rendered _once_ per outline into a local bitmap; from then on, the bitmap is blitted repeatedly. Another local bitmap accumulates the vertical blits. In all, the number of blits is proportional to the thickness of the outline._ 

_For anti-aliased ttf fonts, a thickness of 2 to 3 seems to work nicely._

---

This PR consists of two parts: first are original fernewelten's commits (some minor later tweaks are squashed into bigger ones), and second part is my fixes following this list of issues: https://github.com/adventuregamestudio/ags/pull/892#issuecomment-522987666

**UPDATE**
Also, fixed following problem noted in fernewelten's original post:

> I couldn't use "1" as the default for `AutoOutlineThickness` because currently, scaled bitmap fonts get an outline that is thicker than 1

According to my research, this means the font outline is doubled (becomes = 2) under following condition:
* it is a hi-res game (according to legacy resolution rules);
* it is a bitmap font;
* it is a scaled up font (general settings have the deprecated "fonts are made for hi-res games" turned off, or newer format has individual scaling multiplier set to > 1).

It's possible to detect this condition during the format upgrade, in both editor and engine, so this will no longer be a concern.