### PR TITLE
Reset game's filename when loading

### DIFF
--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -37,7 +37,7 @@ namespace AGS.Types
 			GenerateNewGameID();
         }
 
-        private string _gameFileName = "";
+        private string _gameFileName = string.Empty;
         private string _gameName = "New game";
         private Size _resolution = new Size(320, 200);
         private GameColorDepth _colorDepth = GameColorDepth.HighColor;

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -1123,6 +1123,7 @@ namespace AGS.Types
             _useLowResCoordinatesInScript = true;
             _audioIndexer = AudioClip.FixedIndexBase;
             _enforceNewAudio = false;
+            _gameFileName = string.Empty;
 
             SerializeUtils.DeserializeFromXML(this, node);
 


### PR DESCRIPTION
This stops a previously loaded game's filename being potentially applied to the next game that is loaded.

Fixes #1024