### PR TITLE
Engine: allow to quit from max framerate mode (2)

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2508,7 +2508,7 @@ void construct_engine_overlay()
         invalidate_sprite(0, 0, debugConsole, false);
     }
 
-    if (display_fps)
+    if (display_fps != kFPS_Hide)
         draw_fps(viewport);
 }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2106,7 +2106,7 @@ void draw_fps(const Rect &viewport)
     color_t text_color = fpsDisplay->GetCompatibleColor(14);
 
     char base_buffer[20];
-    if (frames_per_second < 1000) {
+    if (!isTimerFpsMaxed()) {
         sprintf(base_buffer, "%d", frames_per_second);
     } else {
         sprintf(base_buffer, "unlimited");

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -327,7 +327,8 @@ void set_debug_mode(bool on)
 
 void set_game_speed(int new_fps) {
     frames_per_second = new_fps;
-    setTimerFps(new_fps);
+    if (!isTimerFpsMaxed()) // if in maxed mode, don't update timer for now
+        setTimerFps(new_fps);
 }
 
 extern int cbuttfont;

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -183,7 +183,7 @@ extern int in_new_room;
 extern int new_room_pos;
 extern int new_room_x, new_room_y, new_room_loop;
 extern int displayed_room;
-extern int frames_per_second;
+extern int frames_per_second; // fixed game fps, set by script
 extern unsigned int loopcounter;
 extern void set_loop_counter(unsigned int new_counter);
 extern int game_paused;

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -145,8 +145,8 @@ void script_debug(int cmdd,int dataa) {
             NewRoom(goToRoom);
     }
     else if (cmdd == 4) {
-        if (display_fps != 2)
-            display_fps = dataa;
+        if (display_fps != kFPS_Forced)
+            display_fps = (FPSDisplayMode)dataa;
     }
     else if (cmdd == 5) {
         if (dataa == 0) dataa = game.playercharacter;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -374,7 +374,7 @@ void SetRestartPoint() {
 
 void SetGameSpeed(int newspd) {
     // if Ctrl+E has been used to max out frame rate, lock it there
-    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == 2);
+    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == kFPS_Forced);
     if (maxed_framerate) { return; }
 
     newspd += play.game_speed_modifier;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -69,7 +69,6 @@ extern ExecutingScript*curscript;
 extern int displayed_room;
 extern int game_paused;
 extern SpriteCache spriteset;
-extern int frames_per_second;
 extern char gamefilenamebuf[200];
 extern GameSetup usetup;
 extern unsigned int load_new_game;
@@ -373,10 +372,6 @@ void SetRestartPoint() {
 
 
 void SetGameSpeed(int newspd) {
-    // if Ctrl+E has been used to max out frame rate, lock it there
-    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == kFPS_Forced);
-    if (maxed_framerate) { return; }
-
     newspd += play.game_speed_modifier;
     if (newspd>1000) newspd=1000;
     if (newspd<10) newspd=10;

--- a/Engine/ac/timer.cpp
+++ b/Engine/ac/timer.cpp
@@ -52,6 +52,11 @@ void setTimerFps(int new_fps)
     next_frame_timestamp = AGS_Clock::now();
 }
 
+bool isTimerFpsMaxed()
+{
+    return framerate_maxed;
+}
+
 void WaitForNextFrame()
 {
     auto now = AGS_Clock::now();

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -30,7 +30,10 @@ using AGS_Clock = std::conditional<
 
 extern void WaitForNextFrame();
 
+// Sets real FPS to the given number of frames per second; pass 1000+ for maxed FPS mode
 extern void setTimerFps(int new_fps);
+// Tells whether maxed FPS mode is currently set
+extern bool isTimerFpsMaxed();
 extern bool waitingForNextTick();  // store last tick time.
 extern void skipMissedTicks();  // if more than N frames, just skip all, start a fresh.
 

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -83,7 +83,7 @@ String debug_line[DEBUG_CONSOLE_NUMLINES];
 int first_debug_line = 0, last_debug_line = 0, display_console = 0;
 
 float fps = std::numeric_limits<float>::quiet_NaN();
-int display_fps=0;
+FPSDisplayMode display_fps = kFPS_Hide;
 
 std::unique_ptr<MessageBuffer> DebugMsgBuff;
 std::unique_ptr<LogFile> DebugLogFile;

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -46,8 +46,15 @@ void check_debug_keys();
 #define DBG_REGONLY   0x200
 #define DBG_NOVIDEO   0x400
 
+enum FPSDisplayMode
+{
+    kFPS_Hide = 0,    // hid by the script/user command
+    kFPS_Display = 1, // shown by the script/user command
+    kFPS_Forced = 2   // forced shown by the engine arg
+};
+
 extern float fps;
-extern int display_fps;
+extern FPSDisplayMode display_fps;
 extern int debug_flags;
 
 #endif // __AC_DEBUGGER_H

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -432,7 +432,7 @@ static void check_keyboard_controls()
 
     if ((kgn == eAGSKeyCodeCtrlE) && (display_fps == kFPS_Forced)) {
         // if --fps paramter is used, Ctrl+E will max out frame rate
-        setTimerFps(1000);
+        setTimerFps( isTimerFpsMaxed() ? frames_per_second : 1000 );
         return;
     }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -430,10 +430,9 @@ static void check_keyboard_controls()
         return;
     }
 
-    if ((kgn == eAGSKeyCodeCtrlE) && (display_fps == 2)) {
+    if ((kgn == eAGSKeyCodeCtrlE) && (display_fps == kFPS_Forced)) {
         // if --fps paramter is used, Ctrl+E will max out frame rate
         SetGameSpeed(1000);
-        display_fps = 2;
         return;
     }
 
@@ -736,7 +735,7 @@ static void game_loop_update_fps()
 
 float get_current_fps() {
     // if wanted frames_per_second is >= 1000, that means we have maxed out framerate so return the frame rate we're seeing instead
-    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == 2);
+    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == kFPS_Forced);
     // fps must be greater that 0 or some timings will take forever.
     if (maxed_framerate && fps > 0.0f) {
         return fps;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -432,7 +432,7 @@ static void check_keyboard_controls()
 
     if ((kgn == eAGSKeyCodeCtrlE) && (display_fps == kFPS_Forced)) {
         // if --fps paramter is used, Ctrl+E will max out frame rate
-        SetGameSpeed(1000);
+        setTimerFps(1000);
         return;
     }
 
@@ -734,10 +734,9 @@ static void game_loop_update_fps()
 }
 
 float get_current_fps() {
-    // if wanted frames_per_second is >= 1000, that means we have maxed out framerate so return the frame rate we're seeing instead
-    auto maxed_framerate = (frames_per_second >= 1000) && (display_fps == kFPS_Forced);
+    // if we have maxed out framerate then return the frame rate we're seeing instead
     // fps must be greater that 0 or some timings will take forever.
-    if (maxed_framerate && fps > 0.0f) {
+    if (isTimerFpsMaxed() && fps > 0.0f) {
         return fps;
     }
     return frames_per_second;

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -35,7 +35,8 @@ void GameLoopUntilNoOverlay();
 void RunGameUntilAborted();
 // Update everything game related
 void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
-// Gets current wanted game FPS, this is usually a fixed number set in script
+// Gets current logical game FPS, this is normally a fixed number set in script;
+// in case of "maxed fps" mode this function returns real measured FPS.
 float get_current_fps();
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -35,7 +35,7 @@ void GameLoopUntilNoOverlay();
 void RunGameUntilAborted();
 // Update everything game related
 void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
-
+// Gets current wanted game FPS, this is usually a fixed number set in script
 float get_current_fps();
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -311,7 +311,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             else
                 INIwritestring(cfg, "graphics", "game_scale_win", "max_round");
         }
-        else if (ags_stricmp(arg, "--fps") == 0) display_fps = 2;
+        else if (ags_stricmp(arg, "--fps") == 0) display_fps = kFPS_Forced;
         else if (ags_stricmp(arg, "--test") == 0) debug_flags |= DBG_DEBUGMODE;
         else if (ags_stricmp(arg, "-noiface") == 0) debug_flags |= DBG_NOIFACE;
         else if (ags_stricmp(arg, "-nosprdisp") == 0) debug_flags |= DBG_NODRAWSPRITES;


### PR DESCRIPTION
Remake of #873.

* No longer store special "maxed" value in "frames_per_second" variable, because it's a game property that may be changed anytime by a script.
* Allow to toggle "maxed fps" mode on and off with the same key combo (Ctrl+E); note: as before, works only if you run game with `--fps`. When turning off should return to the latest fps value set by game script.
* Added enum defining fps display mode (no need to wonder what "display_fps == 2" means).