### PR TITLE
Script API: get DrawingSurface for the room masks

### DIFF
--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -205,6 +205,31 @@ void RoomStruct::SetResolution(RoomResolutionType type)
     _resolution = type;
 }
 
+Bitmap *RoomStruct::GetMask(RoomAreaMask mask) const
+{
+    switch (mask)
+    {
+    case kRoomAreaHotspot: return HotspotMask.get();
+    case kRoomAreaWalkBehind: return WalkBehindMask.get();
+    case kRoomAreaWalkable: return WalkAreaMask.get();
+    case kRoomAreaRegion: return RegionMask.get();
+    }
+    return nullptr;
+}
+
+float RoomStruct::GetMaskScale(RoomAreaMask mask) const
+{
+    switch (mask)
+    {
+    case kRoomAreaWalkBehind: return 1.f; // walk-behinds always 1:1 with room size
+    case kRoomAreaHotspot:
+    case kRoomAreaWalkable:
+    case kRoomAreaRegion:
+        return 1.f / MaskResolution;
+    }
+    return 0.f;
+}
+
 bool RoomStruct::HasRegionLightLevel(int id) const
 {
     if (id >= 0 && id < MAX_ROOM_REGIONS)

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -51,6 +51,16 @@ typedef std::shared_ptr<ccScript> PScript;
 // later, when more engine source is put in AGS namespace and
 // refactored.
 
+// Room's area mask type
+enum RoomAreaMask
+{
+    kRoomAreaNone = 0,
+    kRoomAreaHotspot,
+    kRoomAreaWalkBehind,
+    kRoomAreaWalkable,
+    kRoomAreaRegion
+};
+
 // Room's audio volume modifier
 enum RoomVolumeMod
 {
@@ -274,6 +284,11 @@ public:
     void            InitDefaults();
     // Set legacy resolution type
     void            SetResolution(RoomResolutionType type);
+
+    // Gets bitmap of particular mask layer
+    Bitmap *GetMask(RoomAreaMask mask) const;
+    // Gets mask's scale relative to the room's background size
+    float   GetMaskScale(RoomAreaMask mask) const;
 
     // TODO: see later whether it may be more convenient to move these to the Region class instead.
     // Gets if the given region has light level set

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -706,6 +706,12 @@ import int  GetWalkableAreaAtScreen(int screenX, int screenY);
 /// Returns which walkable area is at the specified position within the room.
 import int  GetWalkableAreaAtRoom(int roomX, int roomY);
 #endif
+#ifdef SCRIPT_API_v351
+/// Gets the drawing surface for the 8-bit walkable mask
+import DrawingSurface* GetDrawingSurfaceForWalkableArea();
+/// Gets the drawing surface for the 8-bit walk-behind mask
+import DrawingSurface* GetDrawingSurfaceForWalkbehind();
+#endif
 /// Returns the scaling level at the specified position within the room.
 import int  GetScalingAt (int x, int y);
 #ifdef SCRIPT_COMPAT_v335
@@ -1827,6 +1833,10 @@ builtin managed struct Hotspot {
   /// Returns the hotspot at the specified position within this room.
   import static Hotspot* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
 #endif
+#ifdef SCRIPT_API_v351
+  /// Gets the drawing surface for the 8-bit hotspots mask
+  import static DrawingSurface* GetDrawingSurface();     // $AUTOCOMPLETESTATICONLY$
+#endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
@@ -1858,6 +1868,10 @@ builtin managed struct Region {
 #ifdef SCRIPT_API_v3507
   /// Returns the region at the specified position on the screen.
   import static Region* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#endif
+#ifdef SCRIPT_API_v351
+  /// Gets the drawing surface for the 8-bit regions mask
+  import static DrawingSurface* GetDrawingSurface();  // $AUTOCOMPLETESTATICONLY$
 #endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -26,6 +26,8 @@ namespace AGS.Types
         v350 = 6,
         [Description("3.5.0 Final")]
         v3507 = 7,
+        [Description("3.5.1")]
+        v351 = 8,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -25,6 +25,7 @@
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
 #include "ac/string.h"
+#include "ac/walkbehind.h"
 #include "debug/debug_log.h"
 #include "font/fonts.h"
 #include "gui/guimain.h"
@@ -62,6 +63,14 @@ void DrawingSurface_Release(ScriptDrawingSurface* sds)
         }
 
         sds->roomBackgroundNumber = -1;
+    }
+    if (sds->roomMaskType > kRoomAreaNone)
+    {
+        if (sds->roomMaskType == kRoomAreaWalkBehind)
+        {
+            recache_walk_behinds();
+        }
+        sds->roomMaskType = kRoomAreaNone;
     }
     if (sds->dynamicSpriteNumber >= 0)
     {

--- a/Engine/ac/dynobj/scriptdrawingsurface.h
+++ b/Engine/ac/dynobj/scriptdrawingsurface.h
@@ -16,11 +16,15 @@
 #define __AC_SCRIPTDRAWINGSURFACE_H
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
+#include "game/roomstruct.h"
 
 namespace AGS { namespace Common { class Bitmap; }}
 
 struct ScriptDrawingSurface final : AGSCCDynamicObject {
+    // These numbers and types are used to determine the source of this drawing surface;
+    // only one of them can be valid for this surface.
     int roomBackgroundNumber;
+    RoomAreaMask roomMaskType;
     int dynamicSpriteNumber;
     int dynamicSurfaceNumber;
     bool isLinkedBitmapOnly;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -826,6 +826,18 @@ RuntimeScriptValue Sc_GetWalkableAreaAtScreen(const RuntimeScriptValue *params, 
     API_SCALL_INT_PINT2(GetWalkableAreaAtScreen);
 }
 
+RuntimeScriptValue Sc_GetDrawingSurfaceForWalkableArea(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkable);
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+}
+
+RuntimeScriptValue Sc_GetDrawingSurfaceForWalkbehind(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkBehind);
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+}
+
 // void (int amnt) 
 RuntimeScriptValue Sc_GiveScore(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2407,6 +2419,8 @@ void RegisterGlobalAPI()
     ccAddExternalStaticFunction("GetWalkableAreaAtRoom",    Sc_GetWalkableAreaAtRoom);
 	ccAddExternalStaticFunction("GetWalkableAreaAt",        Sc_GetWalkableAreaAtScreen);
     ccAddExternalStaticFunction("GetWalkableAreaAtScreen",  Sc_GetWalkableAreaAtScreen);
+    ccAddExternalStaticFunction("GetDrawingSurfaceForWalkableArea", Sc_GetDrawingSurfaceForWalkableArea);
+    ccAddExternalStaticFunction("GetDrawingSurfaceForWalkbehind", Sc_GetDrawingSurfaceForWalkbehind);
 	ccAddExternalStaticFunction("GiveScore",                Sc_GiveScore);
 	ccAddExternalStaticFunction("HasPlayerBeenInRoom",      Sc_HasPlayerBeenInRoom);
 	ccAddExternalStaticFunction("HideMouseCursor",          Sc_HideMouseCursor);

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -73,12 +73,8 @@ int GetHotspotPointY (int hotspot) {
 
 int GetHotspotIDAtScreen(int scrx, int scry) {
     VpPoint vpt = play.ScreenToRoomDivDown(scrx, scry);
-    if (vpt.second < 0)
-        return 0;
-    Point pt = vpt.first;
-    if ((pt.X>=thisroom.Width) | (pt.X<0) | (pt.Y<0) | (pt.Y>=thisroom.Height))
-        return 0;
-    return get_hotspot_at(pt.X, pt.Y);
+    if (vpt.second < 0) return 0;
+    return get_hotspot_at(vpt.first.X, vpt.first.Y);
 }
 
 void GetHotspotName(int hotspot, char *buffer) {

--- a/Engine/ac/global_hotspot.h
+++ b/Engine/ac/global_hotspot.h
@@ -22,6 +22,8 @@ void DisableHotspot(int hsnum);
 void EnableHotspot(int hsnum);
 int  GetHotspotPointX (int hotspot);
 int  GetHotspotPointY (int hotspot);
+// Gets hotspot ID at the given screen coordinates;
+// if hotspot is disabled or non-existing, returns 0 (no area)
 int  GetHotspotIDAtScreen(int xxx,int yyy);
 void GetHotspotName(int hotspot, char *buffer);
 void RunHotspotInteraction (int hotspothere, int mood);

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -51,15 +51,8 @@ int GetRegionIDAtRoom(int xxx, int yyy) {
     }
 
     int hsthere = thisroom.RegionMask->GetPixel (xxx, yyy);
-    if (hsthere < 0)
-        hsthere = 0;
-
-    if (hsthere >= MAX_ROOM_REGIONS) {
-        quitprintf("!An invalid pixel was found on the room region mask (colour %d, location: %d, %d)", hsthere, xxx, yyy);
-    }
-
-    if (croom->region_enabled[hsthere] == 0)
-        return 0;
+    if (hsthere <= 0 || hsthere >= MAX_ROOM_REGIONS) return 0;
+    if (croom->region_enabled[hsthere] == 0) return 0;
     return hsthere;
 }
 

--- a/Engine/ac/global_region.h
+++ b/Engine/ac/global_region.h
@@ -18,6 +18,8 @@
 #ifndef __AGS_EE_AC__GLOBALREGION_H
 #define __AGS_EE_AC__GLOBALREGION_H
 
+// Gets region ID at the given room coordinates;
+// if region is disabled or non-existing, returns 0 (no area)
 int  GetRegionIDAtRoom(int xxx, int yyy);
 void SetAreaLightLevel(int area, int brightness);
 void SetRegionTint (int area, int red, int green, int blue, int amount, int luminance = 100);

--- a/Engine/ac/global_walkablearea.cpp
+++ b/Engine/ac/global_walkablearea.cpp
@@ -81,12 +81,10 @@ int GetWalkableAreaAtScreen(int x, int y) {
 }
 
 int GetWalkableAreaAtRoom(int x, int y) {
-  if ((x>=thisroom.Width) | (x<0) | (y<0) | (y>=thisroom.Height))
-    return 0;
-  int result = get_walkable_area_pixel(x, y);
-  if (result <= 0)
-    return 0;
-  return result;
+  int area = get_walkable_area_pixel(x, y);
+  // IMPORTANT: disabled walkable areas are actually erased completely from the mask;
+  // see: RemoveWalkableArea() and RestoreWalkableArea().
+  return area >= 0 && area < (MAX_WALK_AREAS + 1) ? area : 0;
 }
 
 //=============================================================================

--- a/Engine/ac/global_walkablearea.h
+++ b/Engine/ac/global_walkablearea.h
@@ -22,9 +22,11 @@ int   GetScalingAt (int x, int y);
 void  SetAreaScaling(int area, int min, int max);
 void  RemoveWalkableArea(int areanum);
 void  RestoreWalkableArea(int areanum);
-// Gets walkable area at the given room coordinates
+// Gets walkable area at the given room coordinates;
+// if area is disabled or non-existing, returns 0 (no area)
 int   GetWalkableAreaAtRoom(int x, int y);
 // Gets walkable area at the given screen coordinates
+// if area is disabled or non-existing, returns 0 (no area)
 int   GetWalkableAreaAtScreen(int x, int y);
 
 #endif // __AGS_EE_AC__GLOBALWALKABLEAREA_H

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -153,6 +153,12 @@ RuntimeScriptValue Sc_GetHotspotAtScreen(const RuntimeScriptValue *params, int32
     API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, GetHotspotAtScreen);
 }
 
+RuntimeScriptValue Sc_Hotspot_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaHotspot);
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+}
+
 // void (ScriptHotspot *hss, char *buffer)
 RuntimeScriptValue Sc_Hotspot_GetName(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -240,6 +246,7 @@ void RegisterHotspotAPI()
 {
     ccAddExternalStaticFunction("Hotspot::GetAtRoomXY^2",       Sc_GetHotspotAtRoom);
     ccAddExternalStaticFunction("Hotspot::GetAtScreenXY^2",     Sc_GetHotspotAtScreen);
+    ccAddExternalStaticFunction("Hotspot::GetDrawingSurface",   Sc_Hotspot_GetDrawingSurface);
     ccAddExternalObjectFunction("Hotspot::GetName^1",           Sc_Hotspot_GetName);
     ccAddExternalObjectFunction("Hotspot::GetProperty^1",       Sc_Hotspot_GetProperty);
     ccAddExternalObjectFunction("Hotspot::GetPropertyText^2",   Sc_Hotspot_GetPropertyText);

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -56,23 +56,11 @@ int Hotspot_GetWalkToY(ScriptHotspot *hss) {
 }
 
 ScriptHotspot *GetHotspotAtScreen(int xx, int yy) {
-    int hsnum = GetHotspotIDAtScreen(xx, yy);
-    ScriptHotspot *ret_hotspot;
-    if (hsnum <= 0)
-        ret_hotspot = &scrHotspot[0];
-    else
-        ret_hotspot = &scrHotspot[hsnum];
-    return ret_hotspot;
+    return &scrHotspot[GetHotspotIDAtScreen(xx, yy)];
 }
 
 ScriptHotspot *GetHotspotAtRoom(int x, int y) {
-    int hsnum = get_hotspot_at(x, y);
-    ScriptHotspot *ret_hotspot;
-    if (hsnum <= 0)
-        ret_hotspot = &scrHotspot[0];
-    else
-        ret_hotspot = &scrHotspot[hsnum];
-    return ret_hotspot;
+    return &scrHotspot[get_hotspot_at(x, y)];
 }
 
 void Hotspot_GetName(ScriptHotspot *hss, char *buffer) {
@@ -124,7 +112,7 @@ bool Hotspot_SetTextProperty(ScriptHotspot *hss, const char *property, const cha
 
 int get_hotspot_at(int xpp,int ypp) {
     int onhs=thisroom.HotspotMask->GetPixel(room_to_mask_coord(xpp), room_to_mask_coord(ypp));
-    if (onhs<0) return 0;
+    if (onhs <= 0 || onhs >= MAX_ROOM_HOTSPOTS) return 0;
     if (croom->hotspot_enabled[onhs]==0) return 0;
     return onhs;
 }

--- a/Engine/ac/hotspot.h
+++ b/Engine/ac/hotspot.h
@@ -35,7 +35,8 @@ int     Hotspot_GetProperty (ScriptHotspot *hss, const char *property);
 void    Hotspot_GetPropertyText (ScriptHotspot *hss, const char *property, char *bufer);
 const char* Hotspot_GetTextProperty(ScriptHotspot *hss, const char *property);
 
-// Gets hotspot ID at the given room coordinates
+// Gets hotspot ID at the given room coordinates;
+// if hotspot is disabled or non-existing, returns 0 (no area)
 int     get_hotspot_at(int xpp,int ypp);
 
 #endif // __AGS_EE_AC__HOTSPOT_H

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -17,8 +17,10 @@
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
 #include "ac/global_region.h"
+#include "ac/room.h"
 #include "ac/roomstatus.h"
 #include "ac/dynobj/cc_region.h"
+#include "ac/dynobj/scriptdrawingsurface.h"
 #include "game/roomstruct.h"
 #include "script/runtimescriptvalue.h"
 
@@ -148,6 +150,12 @@ RuntimeScriptValue Sc_GetRegionAtScreen(const RuntimeScriptValue *params, int32_
     API_SCALL_OBJ_PINT2(ScriptRegion, ccDynamicRegion, GetRegionAtScreen);
 }
 
+RuntimeScriptValue Sc_Region_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaRegion);
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+}
+
 RuntimeScriptValue Sc_Region_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT5(ScriptRegion, Region_Tint);
@@ -236,6 +244,7 @@ void RegisterRegionAPI()
 {
     ccAddExternalStaticFunction("Region::GetAtRoomXY^2",        Sc_GetRegionAtRoom);
     ccAddExternalStaticFunction("Region::GetAtScreenXY^2",      Sc_GetRegionAtScreen);
+    ccAddExternalStaticFunction("Region::GetDrawingSurface",    Sc_Region_GetDrawingSurface);
     ccAddExternalObjectFunction("Region::Tint^4",               Sc_Region_TintNoLum);
     ccAddExternalObjectFunction("Region::Tint^5",               Sc_Region_Tint);
     ccAddExternalObjectFunction("Region::RunInteraction^1",     Sc_Region_RunInteraction);

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -36,10 +36,7 @@ extern CCRegion ccDynamicRegion;
 
 
 ScriptRegion *GetRegionAtRoom(int xx, int yy) {
-    int hsnum = GetRegionIDAtRoom(xx, yy);
-    if (hsnum < 0)
-        hsnum = 0;
-    return &scrRegion[hsnum];
+    return &scrRegion[GetRegionIDAtRoom(xx, yy)];
 }
 
 ScriptRegion *GetRegionAtScreen(int x, int y)

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -138,6 +138,15 @@ ScriptDrawingSurface* Room_GetDrawingSurfaceForBackground(int backgroundNumber)
     return surface;
 }
 
+ScriptDrawingSurface* Room_GetDrawingSurfaceForMask(RoomAreaMask mask)
+{
+    if (displayed_room < 0)
+        quit("!Room_GetDrawingSurfaceForMask: no room is currently loaded");
+    ScriptDrawingSurface *surface = new ScriptDrawingSurface();
+    surface->roomMaskType = mask;
+    ccRegisterManagedObject(surface, surface);
+    return surface;
+}
 
 int Room_GetObjectCount() {
     return croom->numobj;

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -24,6 +24,7 @@
 #include "game/roomstruct.h"
 
 ScriptDrawingSurface* Room_GetDrawingSurfaceForBackground(int backgroundNumber);
+ScriptDrawingSurface* Room_GetDrawingSurfaceForMask(RoomAreaMask mask);
 int Room_GetObjectCount();
 int Room_GetWidth();
 int Room_GetHeight();


### PR DESCRIPTION
For #480.

This is a minor addition, but may have numerous practical uses.
There's already a DrawingSurface interface, and room areas - walkable areas, hotspots, regions and walk-behinds - are represented as 8-bit bitmap masks, so it's trivial to connect these.

The 4 new script functions allow to get corresponding room mask as a DrawingSurface, and do with it whatever a game developer wants.
Surfaces will be 8-bit, and each color index corresponds to an area ID. Color index = 0 is "no area", or eraser.
There are necessary safety tests in the engine to make sure that indexes beyond supported area limit are simply ignored (treated as "no area").

For example, following script will expand walkable area 1:
<pre>
DrawingSurface* ds = GetDrawingSurfaceForWalkableArea();
ds.DrawingColor = 1; // drawing color = area ID
ds.DrawRectangle(100, 100, 200, 200);
ds.Release();
</pre>

Changes made this way **are not saved between room visit**, which is in line with drawing upon a room background (this was done to prevent save data bloat). If user wants these changes to persist, the usual approach is to save custom data, and use it as an instruction, performing drawing on room load event.