### PR TITLE
Script API: implemented Object.ManualScaling and Object.Scaling

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2173,8 +2173,10 @@ builtin managed struct Object {
   import attribute int  Graphic;
   /// Gets the object's ID number.
   readonly import attribute int ID;
+#ifdef SCRIPT_COMPAT_v3507
   /// Gets/sets whether the object ignores walkable area scaling.
   import attribute bool IgnoreScaling;
+#endif
 #ifdef SCRIPT_COMPAT_v340
   /// Gets/sets whether the object ignores walk-behind areas.
   import attribute bool IgnoreWalkbehinds;
@@ -2228,6 +2230,12 @@ builtin managed struct Object {
 #ifdef SCRIPT_API_v3507
   /// Returns the object at the specified position within this room.
   import static Object* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
+#endif
+#ifdef SCRIPT_API_v351
+  /// Gets/sets whether the object uses manually specified scaling instead of using walkable area scaling.
+  import attribute bool ManualScaling;
+  /// Gets/sets the object's current scaling level.
+  import attribute int  Scaling;
 #endif
 
   int reserved[2];  // $AUTOCOMPLETEIGNORE$

--- a/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
+++ b/Editor/AGS.Types/Enums/ScriptAPIVersion.cs
@@ -26,6 +26,8 @@ namespace AGS.Types
         v350 = 6,
         [Description("3.5.0 Final")]
         v3507 = 7,
+        [Description("3.5.1")]
+        v351 = 8,
         // Highest constant is used for automatic upgrade to new API when
         // the game is loaded in the newer version of the Editor
         [Description("Latest version")]

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1445,23 +1445,24 @@ int construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool alwaysU
     int zoom_level = 100;
 
     // calculate the zoom level
-    if (objs[aa].flags & OBJF_USEROOMSCALING) {
+    if ((objs[aa].flags & OBJF_USEROOMSCALING) == 0)
+    {
+        zoom_level = objs[aa].zoom;
+    }
+    else
+    {
         int onarea = get_walkable_area_at_location(objs[aa].x, objs[aa].y);
-
         if ((onarea <= 0) && (thisroom.WalkAreas[0].ScalingFar == 0)) {
             // just off the edge of an area -- use the scaling we had
             // while on the area
-            zoom_level = objs[aa].last_zoom;
+            zoom_level = objs[aa].zoom;
         }
         else
             zoom_level = get_area_scaling(onarea, objs[aa].x, objs[aa].y);
-
-        if (zoom_level != 100)
-            scale_sprite_size(objs[aa].num, zoom_level, &sprwidth, &sprheight);
-
     }
-    // save the zoom level for next time
-    objs[aa].last_zoom = zoom_level;
+    if (zoom_level != 100)
+        scale_sprite_size(objs[aa].num, zoom_level, &sprwidth, &sprheight);
+    objs[aa].zoom = zoom_level;
 
     // save width/height into parameters if requested
     if (drawnWidth)
@@ -1642,7 +1643,7 @@ void prepare_objects_for_drawing() {
         }
         else if (walkBehindMethod == DrawAsSeparateCharSprite) 
         {
-            sort_out_char_sprite_walk_behind(useindx, atxp, atyp, usebasel, objs[aa].last_zoom, objs[aa].last_width, objs[aa].last_height);
+            sort_out_char_sprite_walk_behind(useindx, atxp, atyp, usebasel, objs[aa].zoom, objs[aa].last_width, objs[aa].last_height);
         }
         else if ((!actspsIntact) && (walkBehindMethod == DrawOverCharSprite))
         {
@@ -1771,10 +1772,12 @@ void prepare_characters_for_drawing() {
         onarea = get_walkable_area_at_character (aa);
         our_eip = 332;
 
+        // calculate the zoom level
         if (chin->flags & CHF_MANUALSCALING)  // character ignores scaling
             zoom_level = charextra[aa].zoom;
         else if ((onarea <= 0) && (thisroom.WalkAreas[0].ScalingFar == 0)) {
             zoom_level = charextra[aa].zoom;
+            // NOTE: room objects don't have this fix
             if (zoom_level == 0)
                 zoom_level = 100;
         }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -587,7 +587,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             croom->obj[cc].moving=-1;
             croom->obj[cc].flags = thisroom.Objects[cc].Flags;
             croom->obj[cc].baseline=-1;
-            croom->obj[cc].last_zoom = 100;
+            croom->obj[cc].zoom = 100;
             croom->obj[cc].last_width = 0;
             croom->obj[cc].last_height = 0;
             croom->obj[cc].blocking_width = 0;

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -35,7 +35,7 @@ RoomObject::RoomObject()
     tint_r = tint_g = 0;
     tint_b = tint_level = 0;
     tint_light = 0;
-    last_zoom = 0;
+    zoom = 0;
     last_width = last_height = 0;
     num = 0;
     baseline = 0;

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -23,15 +23,14 @@
 namespace AGS { namespace Common { class Stream; }}
 using namespace AGS; // FIXME later
 
-// This struct is only used in save games and by plugins
-// [IKM] Not really.... used in update loop
+// IMPORTANT: this struct is restricted by plugin API!
 struct RoomObject {
     int   x,y;
     int   transparent;    // current transparency setting
     short tint_r, tint_g;   // specific object tint
     short tint_b, tint_level;
     short tint_light;
-    short last_zoom;      // zoom level last time
+    short zoom;           // zoom level, either manual or from the current area
     short last_width, last_height;   // width/height last time drawn
     short num;            // sprite slot number
     short baseline;       // <=0 to use Y co-ordinate; >0 for specific baseline


### PR DESCRIPTION
For #954, and for consistency with Character class, this implements Object.ManualScaling and Object.Scaling, and deprecates Object.IgnoreRoomScaling.

No internal data was changed (room object already has got a suitable variable for storing current scale).

Unlike current Character's scaling, Object's don't have an arbitrary limit and instead limits value to 1 -> INT16_MAX percents range ((object's scale variable is int16), or, speaking multipliers, - from x0.01 to x327.67;

For backward compatibility, using old IgnoreRoomScaling property will reset scaling to 100% (also, for consistency with character).