### PR TITLE
Tab switching performance improvements

### DIFF
--- a/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
+++ b/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
@@ -25,10 +25,12 @@ namespace AGS.Editor
             Size = original.Size;
             TabIndex = original.TabIndex;
 
+            BeginUpdate();
             foreach (var i in original.Items)
             {
                 Items.Add(i);
             }
+            EndUpdate();
         }
 
         protected override void OnCreateControl()

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -260,6 +260,7 @@ namespace AGS.Editor
 
         private void UpdateFunctionList()
         {
+            if (!this.ContainsFocus) return; // only update for the active pane to avoid expensive combo Add operations
             List<string> functions = new List<string>();
             foreach (ScriptFunction func in _script.AutoCompleteData.Functions)
             {
@@ -278,13 +279,12 @@ namespace AGS.Editor
                     }
                 }
             }
+            cmbFunctions.BeginUpdate();
             cmbFunctions.Items.Clear();
             cmbFunctions.Items.Add("(general definitions)");
             functions.Sort();
-            foreach (string func in functions)
-            {
-                cmbFunctions.Items.Add(func);
-            }
+            cmbFunctions.Items.AddRange(functions.ToArray());
+            cmbFunctions.EndUpdate();
             SelectFunctionInListForCurrentPosition();
         }
 


### PR DESCRIPTION
On windows 10 the performances of switching between script tabs was horrible compared to windows 7 due to the function list updates to the combobox
I've wrapped the functions combobox changes between BeginUpdate-EndUpdate which halved the impact, then I also made so that only the currently focused script pane performs the update, because the update is triggered at any change of focus anyway so there's little point to update every single combobox from every open script.

~~To improve further I'm also updating the DockPanelSuite to the latest 3.0.6 version which brings back the performances I see on a W7 VM.~~

~~There's just one problem, the newer DockPanelSuite versions use a different api for theming so the theme loading is not working correctly and causes a NullPointerException at some point with the existing VisualStudioDark theme.~~ Moved to another branch
