### PR TITLE
Added testing framework to the AGS Editor

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -178,6 +178,16 @@ build_editor_task:
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\8.0\Lib\Win8\um\x86;!LIB!" &&
     msbuild AGS.Editor.Full.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform="Mixed Platforms" /maxcpucount /nologo"
+  test_script: |
+    curl -fLOJ https://github.com/nunit/nunit-transforms/raw/master/nunit3-junit/nunit3-junit.xslt
+    pushd Solutions\packages\NUnit.ConsoleRunner.3.*
+    set RUNNER="%CD%\tools\nunit3-console.exe"
+    popd
+    cmd /v:on /c "!RUNNER! Editor\AGS.Editor.Tests\bin\%BUILD_CONFIG%\AGS.Editor.Tests.dll --x86 --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
+  test_result_artifacts:
+    path: TestResult-junit.xml
+    type: text/xml
+    format: junit
   ags_editor_pdb_artifacts:
     path: Solutions/.build/*/*.pdb
   ags_native_pdb_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -184,10 +184,11 @@ build_editor_task:
     set RUNNER="%CD%\tools\nunit3-console.exe"
     popd
     cmd /v:on /c "!RUNNER! Editor\AGS.Editor.Tests\bin\%BUILD_CONFIG%\AGS.Editor.Tests.dll --x86 --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
-  test_result_artifacts:
-    path: TestResult-junit.xml
-    type: text/xml
-    format: junit
+  always:
+    test_result_artifacts:
+      path: TestResult-junit.xml
+      type: text/xml
+      format: junit
   ags_editor_pdb_artifacts:
     path: Solutions/.build/*/*.pdb
   ags_native_pdb_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -165,7 +165,9 @@ build_editor_task:
     AGS_DIRECTX_LIB: C:\Lib\DirectX
   nuget_packages_cache:
     folder: Solutions\packages
-    fingerprint_script: type Editor\AGS.Editor\packages.config
+    fingerprint_script:
+      - type Editor\AGS.Editor\packages.config
+      - type Editor\AGS.Editor.Tests\packages.config
     populate_script: nuget restore Solutions\AGS.Editor.Full.sln
   build_script: >
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,7 +183,7 @@ build_editor_task:
     pushd Solutions\packages\NUnit.ConsoleRunner.3.*
     set RUNNER="%CD%\tools\nunit3-console.exe"
     popd
-    cmd /v:on /c "!RUNNER! Editor\AGS.Editor.Tests\bin\%BUILD_CONFIG%\AGS.Editor.Tests.dll --x86 --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
+    cmd /v:on /c "!RUNNER! Editor\AGS.Editor.Tests\bin\%BUILD_CONFIG%\AGS.Editor.Tests.dll --result=TestResult-junit.xml;transform=nunit3-junit.xslt"
   always:
     test_result_artifacts:
       path: TestResult-junit.xml

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -1,9 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\..\Solutions\packages\JunitXml.TestLogger.2.1.15\build\net45\JUnitXml.TestLogger.props" Condition="Exists('..\..\Solutions\packages\JunitXml.TestLogger.2.1.15\build\net45\JUnitXml.TestLogger.props')" />
   <Import Project="..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
+  <Import Project="..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>AGS.Editor</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AGS.Editor\AGSEditor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+</Project>

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\Solutions\packages\JunitXml.TestLogger.2.1.15\build\net45\JUnitXml.TestLogger.props" Condition="Exists('..\..\Solutions\packages\JunitXml.TestLogger.2.1.15\build\net45\JUnitXml.TestLogger.props')" />
   <Import Project="..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
-  <Import Project="..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{057AB7E2-8405-49D2-9E8B-540AC77D692C}</ProjectGuid>
+    <ProjectGuid>{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AGS.Editor</RootNamespace>

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -1,26 +1,95 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
+  <Import Project="..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{057AB7E2-8405-49D2-9E8B-540AC77D692C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AGS.Editor</RootNamespace>
+    <AssemblyName>AGS.Editor.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\AGS.Editor\AGSEditor.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\lib\net45\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
+    </Reference>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\NSubstitute.4.2.1\lib\net45\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Compile Include="ColorThemes\ColorThemesTests.cs" />
+    <Compile Include="ColorThemes\Controls\ComboBoxCustomTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AGS.Editor\AGSEditor.csproj">
+      <Project>{6c0d2bf2-2f34-42ff-8356-79254ccf3131}</Project>
+      <Name>AGSEditor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props'))" />
+    <Error Condition="!Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets'))" />
+    <Error Condition="!Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
+  </Target>
+  <Import Project="..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.targets')" />
+  <Import Project="..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
 </Project>

--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -32,6 +32,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -40,6 +41,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
+++ b/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using AGS.Editor.Preferences;
 using NSubstitute;
 using NUnit.Framework;
@@ -19,6 +20,18 @@ namespace AGS.Editor
         }
 
         [Test]
+        public void CurrentWillDefaultToDefaultTheme()
+        {
+            Assert.That(_themes.Current.Name, Is.EqualTo(ColorThemeStub.DEFAULT.Name));
+        }
+
+        [Test]
+        public void DefaultThemeWillBeAddedToTheThemeCollection()
+        {
+            Assert.That(_themes.Themes.Any(t => t == ColorThemeStub.DEFAULT), Is.True);
+        }
+
+        [Test]
         public void SettingCurrentToNullWillThrowNullReferenceException()
         {
             Assert.Throws<NullReferenceException>(() => _themes.Current = null);
@@ -27,8 +40,6 @@ namespace AGS.Editor
         [Test]
         public void SettingCurrentWillUpdateSettings()
         {
-            _themes.Current = ColorThemeStub.DEFAULT;
-
             Assert.That(_settings.ColorTheme, Is.EqualTo(ColorThemeStub.DEFAULT.Name));
             _settings.Received().Save();
         }

--- a/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
+++ b/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using AGS.Editor.Preferences;
 using NSubstitute;
@@ -9,14 +10,17 @@ namespace AGS.Editor
     [TestFixture]
     public class ColorThemesTests
     {
+        private IAGSEditorDirectories _agsEditorDirs;
         private IAppSettings _settings;
         private IColorThemes _themes;
 
         [SetUp]
         public void SetUp()
         {
+            _agsEditorDirs = Substitute.For<IAGSEditorDirectories>();
+            _agsEditorDirs.LocalAppData.Returns(Directory.GetCurrentDirectory());
             _settings = Substitute.For<IAppSettings>();
-            _themes = new ColorThemes(_settings);
+            _themes = new ColorThemes(_agsEditorDirs, _settings);
         }
 
         [Test]

--- a/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
+++ b/Editor/AGS.Editor.Tests/ColorThemes/ColorThemesTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using AGS.Editor.Preferences;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace AGS.Editor
+{
+    [TestFixture]
+    public class ColorThemesTests
+    {
+        private IAppSettings _settings;
+        private IColorThemes _themes;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settings = Substitute.For<IAppSettings>();
+            _themes = new ColorThemes(_settings);
+        }
+
+        [Test]
+        public void SettingCurrentToNullWillThrowNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => _themes.Current = null);
+        }
+
+        [Test]
+        public void SettingCurrentWillUpdateSettings()
+        {
+            _themes.Current = ColorThemeStub.DEFAULT;
+
+            Assert.That(_settings.ColorTheme, Is.EqualTo(ColorThemeStub.DEFAULT.Name));
+            _settings.Received().Save();
+        }
+    }
+}

--- a/Editor/AGS.Editor.Tests/ColorThemes/Controls/ComboBoxCustomTests.cs
+++ b/Editor/AGS.Editor.Tests/ColorThemes/Controls/ComboBoxCustomTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows.Forms;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace AGS.Editor
+{
+    [TestFixture]
+    public class ComboBoxCustomTests
+    {
+        private IColorThemes _themes;
+        private ComboBox _original;
+        private ComboBoxCustom _customBox;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _themes = Substitute.For<IColorThemes>();
+            _original = new ComboBox();
+            _original.Items.AddRange(new[] { "Test Item" });
+            _customBox = new ComboBoxCustom(_themes, "test-root/", _original);
+        }
+
+        [Test]
+        public void CopiesItemsFromOriginal()
+        {
+            Assert.That(_customBox.Items, Is.EqualTo(_original.Items));
+        }
+    }
+}

--- a/Editor/AGS.Editor.Tests/Properties/AssemblyInfo.cs
+++ b/Editor/AGS.Editor.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("AGS.Editor.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AGS.Editor.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("057ab7e2-8405-49d2-9e8b-540ac77d692c")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Editor/AGS.Editor.Tests/packages.config
+++ b/Editor/AGS.Editor.Tests/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net45" />
   <package id="NSubstitute" version="4.2.1" targetFramework="net45" />
   <package id="NUnit" version="3.12.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
   <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/Editor/AGS.Editor.Tests/packages.config
+++ b/Editor/AGS.Editor.Tests/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
-  <package id="JunitXml.TestLogger" version="2.1.15" targetFramework="net45" />
   <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net45" />
   <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net45" />
   <package id="NSubstitute" version="4.2.1" targetFramework="net45" />

--- a/Editor/AGS.Editor.Tests/packages.config
+++ b/Editor/AGS.Editor.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net45" />
+  <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net45" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net45" />
+  <package id="NUnit" version="3.12.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
+</packages>

--- a/Editor/AGS.Editor.Tests/packages.config
+++ b/Editor/AGS.Editor.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
+  <package id="JunitXml.TestLogger" version="2.1.15" targetFramework="net45" />
   <package id="Microsoft.CodeCoverage" version="16.4.0" targetFramework="net45" />
   <package id="Microsoft.NET.Test.Sdk" version="16.4.0" targetFramework="net45" />
   <package id="NSubstitute" version="4.2.1" targetFramework="net45" />

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -16,7 +16,7 @@ using System.Net;
 
 namespace AGS.Editor
 {
-    public class AGSEditor : ISourceControlIntegration
+    public class AGSEditor : IAGSEditorDirectories, ISourceControlIntegration
     {
         public event GetScriptHeaderListHandler GetScriptHeaderList;
         public event GetScriptModuleListHandler GetScriptModuleList;

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Components\SpriteManagerComponent.cs" />
     <Compile Include="Components\TextParserComponent.cs" />
     <Compile Include="Components\ViewsComponent.cs" />
+    <Compile Include="Entities\IAppSettings.cs" />
     <Compile Include="GUI\AssignToView.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -188,6 +188,7 @@
       <DependentUpon>ViewChooser.cs</DependentUpon>
     </Compile>
     <Compile Include="Hacks.cs" />
+    <Compile Include="IAGSEditorDirectories.cs" />
     <Compile Include="ImportExport.cs" />
     <Compile Include="GUI\NumberEntryDialog.cs">
       <SubType>Form</SubType>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -102,6 +102,7 @@
     </Compile>
     <Compile Include="ColorThemes\Controls\MainMenuColorTable.cs" />
     <Compile Include="ColorThemes\Controls\ToolStripColorTable.cs" />
+    <Compile Include="ColorThemes\IColorThemes.cs" />
     <Compile Include="Components\CharacterIDChangedEventArgs.cs" />
     <Compile Include="Components\CharacterRoomChangedEventArgs.cs" />
     <Compile Include="Components\CharactersComponent.cs" />

--- a/Editor/AGS.Editor/ColorThemes/ColorThemeJson.cs
+++ b/Editor/AGS.Editor/ColorThemes/ColorThemeJson.cs
@@ -46,7 +46,7 @@ namespace AGS.Editor
 
         public override ComboBox GetComboBox(string id, ComboBox original)
         {
-            return DoTransform(id, t => new ComboBoxCustom(this, t.Path, original));
+            return DoTransform(id, t => new ComboBoxCustom(Factory.GUIController.ColorThemes, t.Path, original));
         }
 
         public override Image GetImage(string id, Image original)

--- a/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
+++ b/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
@@ -3,17 +3,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using AGS.Editor.Preferences;
 
 namespace AGS.Editor
 {
     public class ColorThemes : IColorThemes
     {
-        private readonly List<ColorTheme> _themes;
+        private readonly IAppSettings _settings;
+        private readonly List<ColorTheme> _themes = new List<ColorTheme>();
         private ColorTheme _current;
 
-        public ColorThemes()
+        public ColorThemes(IAppSettings settings)
         {
-            _themes = new List<ColorTheme>();
+            _settings = settings;
             Load();
             Init();
         }
@@ -33,8 +35,8 @@ namespace AGS.Editor
                 }
 
                 _current = value;
-                Factory.AGSEditor.Settings.ColorTheme = Current.Name;
-                Factory.AGSEditor.Settings.Save();
+                _settings.ColorTheme = Current.Name;
+                _settings.Save();
             }
         }
 
@@ -54,7 +56,7 @@ namespace AGS.Editor
             _themes.Clear();
             _themes.Add(ColorThemeStub.DEFAULT);
             Directory.GetFiles(DiskDir, "*.json").ToList().ForEach(f => _themes.Add(new ColorThemeJson(Path.GetFileNameWithoutExtension(f), f)));
-            Current = _themes.FirstOrDefault(t => t.Name == Factory.AGSEditor.Settings.ColorTheme) ?? ColorThemeStub.DEFAULT;
+            Current = _themes.FirstOrDefault(t => t.Name == _settings.ColorTheme) ?? ColorThemeStub.DEFAULT;
         }
 
         public void Init()

--- a/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
+++ b/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
@@ -9,12 +9,14 @@ namespace AGS.Editor
 {
     public class ColorThemes : IColorThemes
     {
+        private readonly IAGSEditorDirectories _agsEditorDirs;
         private readonly IAppSettings _settings;
         private readonly List<ColorTheme> _themes = new List<ColorTheme>();
         private ColorTheme _current;
 
-        public ColorThemes(IAppSettings settings)
+        public ColorThemes(IAGSEditorDirectories agsEditorDirs, IAppSettings settings)
         {
+            _agsEditorDirs = agsEditorDirs;
             _settings = settings;
             Load();
             Init();
@@ -44,7 +46,7 @@ namespace AGS.Editor
 
         public bool IsCurrentDefault => Current == ColorThemeStub.DEFAULT;
 
-        private static string DiskDir => Path.Combine(Factory.AGSEditor.LocalAppData, "Themes");
+        private string DiskDir => Path.Combine(_agsEditorDirs.LocalAppData, "Themes");
 
         public void Load()
         {

--- a/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
+++ b/Editor/AGS.Editor/ColorThemes/ColorThemes.cs
@@ -6,7 +6,7 @@ using System.Windows.Forms;
 
 namespace AGS.Editor
 {
-    public class ColorThemes
+    public class ColorThemes : IColorThemes
     {
         private readonly List<ColorTheme> _themes;
         private ColorTheme _current;

--- a/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
+++ b/Editor/AGS.Editor/ColorThemes/Controls/ComboBoxCustom.cs
@@ -4,16 +4,16 @@ using System.Windows.Forms;
 
 namespace AGS.Editor
 {
-    internal class ComboBoxCustom : ComboBox
+    public class ComboBoxCustom : ComboBox
     {
         private const int WM_PAINT = 0x000F;
 
-        private readonly ColorTheme _theme;
+        private readonly IColorThemes _themes;
         private readonly string _root;
 
-        public ComboBoxCustom(ColorTheme theme, string root, ComboBox original)
+        public ComboBoxCustom(IColorThemes themes, string root, ComboBox original)
         {
-            _theme = theme;
+            _themes = themes;
             _root = root;
 
             Dock = original.Dock;
@@ -39,19 +39,19 @@ namespace AGS.Editor
 
             DrawMode = DrawMode.OwnerDrawVariable;
             FlatStyle = FlatStyle.Flat;
-            BackColor = _theme.GetColor(_root + "/background");
-            ForeColor = _theme.GetColor(_root + "/foreground");
+            BackColor = _themes.Current.GetColor(_root + "/background");
+            ForeColor = _themes.Current.GetColor(_root + "/foreground");
 
             DropDown += (s, a) =>
             {
-                BackColor = _theme.GetColor(_root + "/drop-down/background");
-                ForeColor = _theme.GetColor(_root + "/drop-down/foreground");
+                BackColor = _themes.Current.GetColor(_root + "/drop-down/background");
+                ForeColor = _themes.Current.GetColor(_root + "/drop-down/foreground");
             };
 
             DropDownClosed += (s, a) =>
             {
-                BackColor = _theme.GetColor(_root + "/drop-down-closed/background");
-                ForeColor = _theme.GetColor(_root + "/drop-down-closed/foreground");
+                BackColor = _themes.Current.GetColor(_root + "/drop-down-closed/background");
+                ForeColor = _themes.Current.GetColor(_root + "/drop-down-closed/foreground");
             };
 
             DrawItem += (s, a) =>
@@ -62,17 +62,17 @@ namespace AGS.Editor
 
                     if ((a.State & DrawItemState.Selected) == DrawItemState.Selected)
                     {
-                        a.Graphics.FillRectangle(new SolidBrush(_theme.GetColor(_root + "/item-selected/background")),
+                        a.Graphics.FillRectangle(new SolidBrush(_themes.Current.GetColor(_root + "/item-selected/background")),
                             a.Bounds);
                         a.Graphics.DrawString(Items[a.Index].ToString(), Font,
-                            new SolidBrush(_theme.GetColor(_root + "/item-selected/foreground")), a.Bounds);
+                            new SolidBrush(_themes.Current.GetColor(_root + "/item-selected/foreground")), a.Bounds);
                     }
                     else
                     {
                         a.Graphics.FillRectangle(
-                            new SolidBrush(_theme.GetColor(_root + "/item-not-selected/background")), a.Bounds);
+                            new SolidBrush(_themes.Current.GetColor(_root + "/item-not-selected/background")), a.Bounds);
                         a.Graphics.DrawString(Items[a.Index].ToString(), Font,
-                            new SolidBrush(_theme.GetColor(_root + "/item-not-selected/foreground")), a.Bounds);
+                            new SolidBrush(_themes.Current.GetColor(_root + "/item-not-selected/foreground")), a.Bounds);
                     }
 
                     a.DrawFocusRectangle();
@@ -92,20 +92,20 @@ namespace AGS.Editor
                     Rectangle rectButton = new Rectangle(Width - 19, 0, 19, Height);
                     Brush arrow = new SolidBrush(SystemColors.ControlText);
                     graphics.SmoothingMode = SmoothingMode.HighQuality;
-                    ControlPaint.DrawBorder(graphics, rectBorder, _theme.GetColor(_root + "/border/background"),
+                    ControlPaint.DrawBorder(graphics, rectBorder, _themes.Current.GetColor(_root + "/border/background"),
                         ButtonBorderStyle.Solid);
 
                     if (DroppedDown)
                     {
                         graphics.FillRectangle(
-                            new SolidBrush(_theme.GetColor(_root + "/button-dropped-down/background")), rectButton);
-                        arrow = new SolidBrush(_theme.GetColor(_root + "/button-dropped-down/foreground"));
+                            new SolidBrush(_themes.Current.GetColor(_root + "/button-dropped-down/background")), rectButton);
+                        arrow = new SolidBrush(_themes.Current.GetColor(_root + "/button-dropped-down/foreground"));
                     }
                     else
                     {
                         graphics.FillRectangle(
-                            new SolidBrush(_theme.GetColor(_root + "/button-not-dropped-down/background")), rectButton);
-                        arrow = new SolidBrush(_theme.GetColor(_root + "/button-not-dropped-down/background"));
+                            new SolidBrush(_themes.Current.GetColor(_root + "/button-not-dropped-down/background")), rectButton);
+                        arrow = new SolidBrush(_themes.Current.GetColor(_root + "/button-not-dropped-down/background"));
                     }
 
                     GraphicsPath path = new GraphicsPath();

--- a/Editor/AGS.Editor/ColorThemes/IColorThemes.cs
+++ b/Editor/AGS.Editor/ColorThemes/IColorThemes.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AGS.Editor
+{
+    public interface IColorThemes
+    {
+        ColorTheme Current { get; set; }
+
+        bool IsCurrentDefault { get; }
+
+        IEnumerable<ColorTheme> Themes { get; }
+
+        void Apply(Action<ColorTheme> apply);
+
+        void Import(string dir);
+
+        void Init();
+
+        void Load();
+    }
+}

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -74,7 +74,7 @@ namespace AGS.Editor.Preferences
         public string Path { get; set; }
     }
 
-    public sealed class AppSettings : ApplicationSettingsBase
+    public sealed class AppSettings : ApplicationSettingsBase, IAppSettings
     {
         const int MAX_RECENT_GAMES = 10;
         const int MAX_RECENT_SEARCHES = 10;
@@ -143,7 +143,7 @@ namespace AGS.Editor.Preferences
         {
             Dictionary<string, string> regmap = new Dictionary<string, string>()
             {
-            //  [<registry name>] = <setting name>
+                //  [<registry name>] = <setting name>
                 ["ScEdTabWidth"] = "TabSize",
                 ["TestGameStyle"] = "TestGameWindowStyle",
                 ["MessageBoxOnCompileErrors"] = "MessageBoxOnCompile",
@@ -228,7 +228,7 @@ namespace AGS.Editor.Preferences
                 key.Close();
                 int gameCount = Math.Min(gameNames.Count, gamePaths.Count);
 
-                for (int i = 0; i < gameCount; i ++)
+                for (int i = 0; i < gameCount; i++)
                 {
                     if (RecentGames.Count >= MAX_RECENT_GAMES)
                     {

--- a/Editor/AGS.Editor/Entities/IAppSettings.cs
+++ b/Editor/AGS.Editor/Entities/IAppSettings.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace AGS.Editor.Preferences
+{
+    public interface IAppSettings
+    {
+        int BackupWarningInterval { get; set; }
+        string ColorTheme { get; set; }
+        string DefaultImportPath { get; set; }
+        bool DialogOnMultipleTabsClose { get; set; }
+        bool IndentUseTabs { get; set; }
+        bool KeepHelpOnTop { get; set; }
+        DateTime LastBackupWarning { get; set; }
+        int MainWinHeight { get; set; }
+        bool MainWinMaximize { get; set; }
+        int MainWinWidth { get; set; }
+        int MainWinX { get; set; }
+        int MainWinY { get; set; }
+        MessageBoxOnCompile MessageBoxOnCompile { get; set; }
+        bool MigratedSettings { get; set; }
+        string NewGamePath { get; set; }
+        string PaintProgramPath { get; set; }
+        BindingList<RecentGame> RecentGames { get; }
+        BindingList<string> RecentSearches { get; }
+        ReloadScriptOnExternalChange ReloadScriptOnExternalChange { get; set; }
+        bool RemapPalettizedBackgrounds { get; set; }
+        bool SendAnonymousStats { get; set; }
+        bool ShowViewPreviewByDefault { get; set; }
+        SpriteImportMethod SpriteImportMethod { get; set; }
+        StartupPane StartupPane { get; set; }
+        DateTime StatsLastSent { get; set; }
+        int TabSize { get; set; }
+        TestGameWindowStyle TestGameWindowStyle { get; set; }
+        bool UpgradedSettings { get; set; }
+        void Save();
+    }
+}

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -799,7 +799,7 @@ namespace AGS.Editor
             {
                 _agsEditor = agsEditor;
                 _interactiveTasks = new InteractiveTasks(_agsEditor.Tasks);
-                ColorThemes = new ColorThemes();
+                ColorThemes = new ColorThemes(_agsEditor.Settings);
                 _mainForm = new frmMain();
                 SetEditorWindowSize();
                 _treeManager = new ProjectTree(_mainForm.projectPanel.projectTree);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -799,7 +799,7 @@ namespace AGS.Editor
             {
                 _agsEditor = agsEditor;
                 _interactiveTasks = new InteractiveTasks(_agsEditor.Tasks);
-                ColorThemes = new ColorThemes(_agsEditor.Settings);
+                ColorThemes = new ColorThemes(_agsEditor, _agsEditor.Settings);
                 _mainForm = new frmMain();
                 SetEditorWindowSize();
                 _treeManager = new ProjectTree(_mainForm.projectPanel.projectTree);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -136,7 +136,7 @@ namespace AGS.Editor
             get { return _mainForm.Icon; }
         }
 
-        public ColorThemes ColorThemes { get; private set; }
+        public IColorThemes ColorThemes { get; private set; }
 
 		public void ShowMessage(string message, MessageBoxIconType icon)
 		{

--- a/Editor/AGS.Editor/IAGSEditorDirectories.cs
+++ b/Editor/AGS.Editor/IAGSEditorDirectories.cs
@@ -1,0 +1,15 @@
+﻿namespace AGS.Editor
+{
+    /// <summary>
+    /// All important editor directories
+    /// </summary>
+    public interface IAGSEditorDirectories
+    {
+        string BaseGameFileName { get; }
+        string EditorDirectory { get; }
+        string GameDirectory { get; }
+        string LocalAppData { get; }
+        string TemplatesDirectory { get; }
+        string UserTemplatesDirectory { get; }
+    }
+}

--- a/Solutions/AGS.Editor.Full.sln
+++ b/Solutions/AGS.Editor.Full.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
@@ -21,6 +21,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common.Lib", "Common.Lib\Common.Lib.vcxproj", "{463A715C-3EF3-47C7-AC7F-D97660149C49}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Compiler.Lib", "Compiler.Lib\Compiler.Lib.vcxproj", "{7B621FC0-BFD0-40E4-800A-0CD5E5707532}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AGS.Editor.Tests", "..\Editor\AGS.Editor.Tests\AGS.Editor.Tests.csproj", "{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -102,6 +104,18 @@ Global
 		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release|Mixed Platforms.Build.0 = Release_MD|Win32
 		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release|Win32.ActiveCfg = Release|Win32
 		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release|Win32.Build.0 = Release|Win32
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Debug|Win32.Build.0 = Debug|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Win32.ActiveCfg = Release|Any CPU
+		{6D85D3E7-5D23-405F-BEF4-6F09A93ABCCC}.Release|Win32.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -109,6 +123,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{463A715C-3EF3-47C7-AC7F-D97660149C49} = {AD076495-5CEC-4149-B448-0E24AF8B2C2E}
 		{7B621FC0-BFD0-40E4-800A-0CD5E5707532} = {AD076495-5CEC-4149-B448-0E24AF8B2C2E}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DFAAA4EF-B6FB-4B39-A869-CB364E624FC2}
 	EndGlobalSection
 	GlobalSection(TextTemplating) = postSolution
 		TextTemplating = 1

--- a/Solutions/AGS.Editor.NoNative.sln
+++ b/Solutions/AGS.Editor.NoNative.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AGSEditor", "..\Editor\AGS.Editor\AGSEditor.csproj", "{6C0D2BF2-2F34-42FF-8356-79254CCF3131}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AGS.Types", "..\Editor\AGS.Types\AGS.Types.csproj", "{3EBBEDAB-214C-4201-BB5A-5152D56908DD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AGS.Editor.Tests", "..\Editor\AGS.Editor.Tests\AGS.Editor.Tests.csproj", "{D779DF8A-844F-480F-A909-69B0898565E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,9 +35,16 @@ Global
 		{3EBBEDAB-214C-4201-BB5A-5152D56908DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EBBEDAB-214C-4201-BB5A-5152D56908DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EBBEDAB-214C-4201-BB5A-5152D56908DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D779DF8A-844F-480F-A909-69B0898565E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D779DF8A-844F-480F-A909-69B0898565E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D779DF8A-844F-480F-A909-69B0898565E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D779DF8A-844F-480F-A909-69B0898565E5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B052E401-79EF-4345-A6B6-3B3C5DEAF860}
 	EndGlobalSection
 	GlobalSection(TextTemplating) = postSolution
 		TextTemplating = 1


### PR DESCRIPTION
Reference #1035 

In short I
- Added a project for writing tests to the editor. With NUnit and NSubstitute
- I refactored some code to not make use of Singletons because any impure static call makes testing complicated
- Wrote a few tests

My goal here is to make the testing framework available so people can start using it when they write new code, it's not my plan to start adding coverage to already existing code

What I haven't done is added test execution to the CI system, since I'm not familiar with Cirrus CI and have only tried Dockerfiles a little bit, maybe someone else could do that. The easiest way of running the tests from the command line is by using the dotnet CLI, I used the following command `dotnet test AGS.Editor.NoNative.sln --no-build`. The caveat with using dotnet CLI I think is that it works poorly with the AGS.Native project, but I'm assuming that most people will not be writing tests directly to that project

I used the new csproj format for creating a new project, because that's what VS2019 do, I may need someone to test and verify that it opens fine in VS2015, if not I'll have to change the format