### PR TITLE
Supports wrapping a const buffer for the String class

### DIFF
--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -180,6 +180,10 @@ public:
     // Factory methods
     //-------------------------------------------------------------------------
 
+    // Wraps the given string buffer without owning it, won't count references,
+    // won't delete it at destruction. Can be used with string literals.
+    static String Wrapper(const char *cstr);
+
     static String FromFormat(const char *fcstr, ...);
     static String FromFormatV(const char *fcstr, va_list argptr);
     // Reads stream until null-terminator or EOS
@@ -303,6 +307,9 @@ public:
     // given character
     void    TruncateToSection(char separator, size_t first, size_t last,
                               bool exclude_first_sep = true, bool exclude_last_sep = true);
+    // Wraps the given string buffer without owning it, won't count references,
+    // won't delete it at destruction. Can be used with string literals.
+    void    Wrap(const char *cstr);
 
     //-------------------------------------------------------------------------
     // Operators

--- a/Engine/ac/dynobj/scriptdict.h
+++ b/Engine/ac/dynobj/scriptdict.h
@@ -15,11 +15,11 @@
 // Managed script object wrapping std::map<String, String> and
 // unordered_map<String, String>.
 //
-// TODO: support wrapping non-owned container, passed by the reference.
-// TODO: optimize key lookup operations by not creating a String object from
-// const char*. It seems C++14 standard allows to use convertible types as
-// keys. Perhaps there may also be ways to adjust String class and let it
-// wrap non-owned char buffer without any allocations on heap.
+// TODO: support wrapping non-owned Dictionary, passed by the reference, -
+// that would let expose internal engine's dicts using same interface.
+// TODO: maybe optimize key lookup operations further by not creating a String
+// object from const char*. It seems, C++14 standard allows to use convertible
+// types as keys; need to research what perfomance impact that would make.
 //
 //=============================================================================
 #ifndef __AC_SCRIPTDICT_H
@@ -77,16 +77,16 @@ public:
             DeleteItem(it);
         _dic.clear();
     }
-    bool Contains(const char *key) override { return _dic.count(String(key)) != 0; }
+    bool Contains(const char *key) override { return _dic.count(String::Wrapper(key)) != 0; }
     const char *Get(const char *key) override
     {
-        auto it = _dic.find(String(key));
+        auto it = _dic.find(String::Wrapper(key));
         if (it == _dic.end()) return nullptr;
         return it->second.GetNullableCStr();
     }
     bool Remove(const char *key) override
     {
-        auto it = _dic.find(String(key));
+        auto it = _dic.find(String::Wrapper(key));
         if (it == _dic.end()) return false;
         DeleteItem(it);
         _dic.erase(it);

--- a/Engine/ac/dynobj/scriptset.h
+++ b/Engine/ac/dynobj/scriptset.h
@@ -14,11 +14,11 @@
 //
 // Managed script object wrapping std::set<String> and unordered_set<String>.
 //
-// TODO: support wrapping non-owned container, passed by the reference.
-// TODO: optimize key lookup operations by not creating a String object from
-// const char*. It seems C++14 standard allows to use convertible types as
-// keys. Perhaps there may also be ways to adjust String class and let it
-// wrap non-owned char buffer without any allocations on heap.
+// TODO: support wrapping non-owned Set, passed by the reference, -
+// that would let expose internal engine's sets using same interface.
+// TODO: maybe optimize key lookup operations further by not creating a String
+// object from const char*. It seems, C++14 standard allows to use convertible
+// types as keys; need to research what perfomance impact that would make.
 //
 //=============================================================================
 #ifndef __AC_SCRIPTSET_H
@@ -80,10 +80,10 @@ public:
             DeleteItem(it);
         _set.clear();
     }
-    bool Contains(const char *item) const override { return _set.count(String(item)) != 0; }
+    bool Contains(const char *item) const override { return _set.count(String::Wrapper(item)) != 0; }
     bool Remove(const char *item) override
     {
-        auto it = _set.find(String(item));
+        auto it = _set.find(String::Wrapper(item));
         if (it == _set.end()) return false;
         DeleteItem(it);
         _set.erase(it);

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -47,8 +47,8 @@ void Test_String()
         String s2 = s1;
         String s3 = s1;
         assert(s1.GetRefCount() == 3);
-        assert(s1.GetData() == s2.GetData());
-        assert(s2.GetData() == s3.GetData());
+        assert(s1.GetBuffer() == s2.GetBuffer());
+        assert(s2.GetBuffer() == s3.GetBuffer());
 
         int cap1 = s1.GetCapacity();
         assert(cap1 == s1.GetLength());

--- a/Engine/test/test_string.cpp
+++ b/Engine/test/test_string.cpp
@@ -484,6 +484,20 @@ void Test_String()
         assert(strcmp(result[3], "") == 0);
         assert(strcmp(result[4], "") == 0);
     }
+
+    // Test Wrap
+    {
+        const char *cstr = "This is a string literal";
+        String str1 = String::Wrapper(cstr);
+        String str2 = str1;
+        assert(str1.GetCStr() == cstr);
+        assert(str2.GetCStr() == cstr);
+        assert(str1.GetRefCount() == 0);
+        assert(str2.GetRefCount() == 0);
+        str2.SetAt(0, 'A');
+        assert(str2.GetCStr() != cstr);
+        assert(str2.GetRefCount() == 1);
+    }
 }
 
 #endif // AGS_RUN_TESTS


### PR DESCRIPTION
This pr modifies a String, moving char buffer pointer and length parameter out of the allocated buffer header, and have them as a plain class members. This has two consequences:
* the simple reading operations no longer require extra pointer dereference;
* this allows to reference an external buffer, as an option.
(Note: I used [ScummVM's string as an example too](https://github.com/scummvm/scummvm/blob/master/common/str.h), although it's a bit different)

Latter lets support wrapping an external constant buffer without owning it. Which allows to even wrap string literals. This should be safe, because any writing operation in String class first ensures that owned string buffer exists and has only 1 reference (String::BecomeUnique does that).
Of course, when I say "safe", I assume it is used correctly, as in - this String should not be used after the the original const char buffer cease to exist.

As an addition, I modified script Dictionary and Set implementations to wrap over lookup keys instead of cloning these. This will be a proof of concept for the above changes.
Having to clone lookup keys there was bugging me for a while now. The perfomance gain may be not particulary big, but OTOH the cost for this is negligible, in my opinion, as most of the String class works the same as before, as it does not care where the string pointer is pointing to.

Same wrapping could be later done in other cases where it may be beneficial.