### PR TITLE
Script API: implemented Game.IgnoreUserInputForNextTextMs

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2650,6 +2650,10 @@ builtin struct Game {
   /// Gets the number of cameras.
   import static readonly attribute int CameraCount;
 #endif
+#ifdef SCRIPT_API_v351
+  /// Gets/sets the time for which user input is ignored for the new text, after previous one was automatically removed
+  import static attribute int IgnoreUserInputForNextTextMs;
+#endif
 };
 
 builtin struct GameState {

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -954,9 +954,9 @@ bool DialogOptions::Run()
           parserActivated = 1;
       }
 
-      int mouseButtonPressed = ags_mgetbutton();
-
-      if (mouseButtonPressed != NONE)
+      int mouseButtonPressed = NONE;
+      int mouseWheelTurn = 0;
+      if (run_service_mb_controls(mouseButtonPressed, mouseWheelTurn) && mouseButtonPressed >= 0)
       {
         if (mouseison < 0 && !new_custom_render)
         {
@@ -997,7 +997,6 @@ bool DialogOptions::Run()
 
       if (usingCustomRendering)
       {
-        int mouseWheelTurn = ags_check_mouse_wheel();
         if (mouseWheelTurn != 0)
         {
             runDialogOptionMouseClickHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -870,7 +870,7 @@ bool DialogOptions::Run()
       }
 
       int gkey;
-      if (run_service_key_controls(gkey)) {
+      if (run_service_key_controls(gkey) && !play.IsIgnoringInput()) {
         if (parserInput) {
           wantRefresh = true;
           // type into the parser 
@@ -956,7 +956,8 @@ bool DialogOptions::Run()
 
       int mouseButtonPressed = NONE;
       int mouseWheelTurn = 0;
-      if (run_service_mb_controls(mouseButtonPressed, mouseWheelTurn) && mouseButtonPressed >= 0)
+      if (run_service_mb_controls(mouseButtonPressed, mouseWheelTurn) && mouseButtonPressed >= 0 &&
+          !play.IsIgnoringInput())
       {
         if (mouseison < 0 && !new_custom_render)
         {

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -265,18 +265,18 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             render_graphics();
             int mbut, mwheelz;
             if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0) {
-                // If we're allowed, skip with mouse
-                if (skip_setting & SKIP_MOUSECLICK)
+                check_skip_cutscene_mclick(mbut);
+                if (play.fast_forward)
+                    break;
+                if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
                     break;
             }
             int kp;
             if (run_service_key_controls(kp)) {
-                // let them press ESC to skip the cutscene
                 check_skip_cutscene_keypress (kp);
                 if (play.fast_forward)
                     break;
-
-                if (skip_setting & SKIP_KEYPRESS)
+                if ((skip_setting & SKIP_KEYPRESS) && !play.IsIgnoringInput())
                     break;
             }
             

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -246,28 +246,21 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         return screenover[nse].type;
     }
 
+    // Wait for the blocking text to timeout or until skipped by another command
     if (blocking) {
+        // If fast-forwarding, then skip immediately
         if (play.fast_forward) {
             remove_screen_overlay(OVER_TEXTMSG);
             play.messagetime=-1;
             return 0;
         }
 
-        /*    wputblock(xx,yy,screenop,1);
-        remove_screen_overlay(OVER_TEXTMSG);*/
-
         if (!play.mouse_cursor_hidden)
             ags_domouse(DOMOUSE_ENABLE);
-        // play.skip_display has same values as SetSkipSpeech:
-        // 0 = click mouse or key to skip
-        // 1 = key only
-        // 2 = can't skip at all
-        // 3 = only on keypress, no auto timer
-        // 4 = mouse only
         int countdown = GetTextDisplayTime (todis);
         int skip_setting = user_to_internal_skip_speech((SkipSpeechStyle)play.skip_display);
-        while (1) {
-
+        // Loop until skipped
+        while (true) {
             update_audio_system_on_game_loop();
             render_graphics();
 
@@ -296,6 +289,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
             countdown--;
 
+            // Special behavior when coupled with a voice-over
             if (play.speech_has_voice) {
                 // extend life of text if the voice hasn't finished yet
                 if (channel_is_playing(SCHAN_SPEECH) && (play.fast_forward == 0)) {
@@ -305,14 +299,13 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
                 else  // if the voice has finished, remove the speech
                     countdown = 0;
             }
-
+            // Test for the timed auto-skip
             if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
-                play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
+                play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
                 break;
             }
-            // if skipping cutscene, don't get stuck on No Auto Remove
-            // text boxes
+            // if skipping cutscene, don't get stuck on No Auto Remove text boxes
             if ((countdown < 1) && (play.fast_forward))
                 break;
         }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -263,8 +263,8 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         while (true) {
             update_audio_system_on_game_loop();
             render_graphics();
-
-            if (ags_mgetbutton()>NONE) {
+            int mbut, mwheelz;
+            if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0) {
                 // If we're allowed, skip with mouse
                 if (skip_setting & SKIP_MOUSECLICK)
                     break;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -246,6 +246,9 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         return screenover[nse].type;
     }
 
+    // If we've scheduled ignore input since the previous blocking text, then activate it now
+    play.ActivateScheduledIgnoreInput();
+
     // Wait for the blocking text to timeout or until skipped by another command
     if (blocking) {
         // If fast-forwarding, then skip immediately
@@ -303,6 +306,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
             if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
                 play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
+                play.ScheduleIgnoreInput(play.ignore_user_input_at_next_text_ms);
                 break;
             }
             // if skipping cutscene, don't get stuck on No Auto Remove text boxes

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -809,6 +809,16 @@ void Game_SetIgnoreUserInputAfterTextTimeoutMs(int newValueMs)
     play.ignore_user_input_after_text_timeout_ms = newValueMs;
 }
 
+int Game_GetIgnoreUserInputForNextTextMs()
+{
+    return play.ignore_user_input_at_next_text_ms;
+}
+
+void Game_SetIgnoreUserInputForNextTextMs(int newValueMs)
+{
+    play.ignore_user_input_at_next_text_ms = newValueMs;
+}
+
 const char *Game_GetFileName() {
     return CreateNewScriptString(ResPaths.GamePak.Name);
 }
@@ -2258,6 +2268,16 @@ RuntimeScriptValue Sc_Game_GetIgnoreUserInputAfterTextTimeoutMs(const RuntimeScr
     API_SCALL_INT(Game_GetIgnoreUserInputAfterTextTimeoutMs);
 }
 
+RuntimeScriptValue Sc_Game_SetIgnoreUserInputForNextTextMs(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Game_SetIgnoreUserInputForNextTextMs);
+}
+
+RuntimeScriptValue Sc_Game_GetIgnoreUserInputForNextTextMs(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Game_GetIgnoreUserInputForNextTextMs);
+}
+
 // void (int newValueMs)
 RuntimeScriptValue Sc_Game_SetIgnoreUserInputAfterTextTimeoutMs(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2447,6 +2467,8 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::get_GUICount",                           Sc_Game_GetGUICount);
     ccAddExternalStaticFunction("Game::get_IgnoreUserInputAfterTextTimeoutMs",  Sc_Game_GetIgnoreUserInputAfterTextTimeoutMs);
     ccAddExternalStaticFunction("Game::set_IgnoreUserInputAfterTextTimeoutMs",  Sc_Game_SetIgnoreUserInputAfterTextTimeoutMs);
+    ccAddExternalStaticFunction("Game::get_IgnoreUserInputForNextTextMs",       Sc_Game_GetIgnoreUserInputForNextTextMs);
+    ccAddExternalStaticFunction("Game::set_IgnoreUserInputForNextTextMs",       Sc_Game_SetIgnoreUserInputForNextTextMs);
     ccAddExternalStaticFunction("Game::get_InSkippableCutscene",                Sc_Game_GetInSkippableCutscene);
     ccAddExternalStaticFunction("Game::get_InventoryItemCount",                 Sc_Game_GetInventoryItemCount);
     ccAddExternalStaticFunction("Game::get_MinimumTextDisplayTimeMs",           Sc_Game_GetMinimumTextDisplayTimeMs);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1782,14 +1782,28 @@ void start_skipping_cutscene () {
 
 }
 
-void check_skip_cutscene_keypress (int kgn) {
+bool check_skip_cutscene_keypress (int kgn) {
 
     CutsceneSkipStyle skip = get_cutscene_skipstyle();
     if (skip == eSkipSceneAnyKey || skip == eSkipSceneKeyMouse ||
         (kgn == 27 && (skip == eSkipSceneEscOnly || skip == eSkipSceneEscOrRMB)))
     {
         start_skipping_cutscene();
+        return true;
     }
+    return false;
+}
+
+bool check_skip_cutscene_mclick(int mbut)
+{
+    CutsceneSkipStyle skip = get_cutscene_skipstyle();
+    if (skip == eSkipSceneMouse || skip == eSkipSceneKeyMouse ||
+        (mbut == RIGHT && skip == eSkipSceneEscOrRMB))
+    {
+        start_skipping_cutscene();
+        return true;
+    }
+    return false;
 }
 
 // Helper functions used by StartCutscene/EndCutscene, but also

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -158,7 +158,8 @@ long write_screen_shot_for_vista(Common::Stream *out, Common::Bitmap *screenshot
 bool is_in_cutscene();
 CutsceneSkipStyle get_cutscene_skipstyle();
 void start_skipping_cutscene ();
-void check_skip_cutscene_keypress (int kgn);
+bool check_skip_cutscene_keypress(int kgn);
+bool check_skip_cutscene_mclick(int mbut);
 void initialize_skippable_cutscene();
 void stop_fast_forwarding();
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -422,6 +422,22 @@ ScriptCamera *GameState::GetScriptCamera(int index)
     return _scCameraRefs[index].first;
 }
 
+bool GameState::IsIgnoringInput() const
+{
+    return AGS_Clock::now() < _ignoreUserInputUntilTime;
+}
+
+void GameState::SetIgnoreInput(int timeout_ms)
+{
+    if (AGS_Clock::now() + std::chrono::milliseconds(timeout_ms) > _ignoreUserInputUntilTime)
+        _ignoreUserInputUntilTime = AGS_Clock::now() + std::chrono::milliseconds(timeout_ms);
+}
+
+void GameState::ClearIgnoreInput()
+{
+    _ignoreUserInputUntilTime = AGS_Clock::now();
+}
+
 bool GameState::IsBlockingVoiceSpeech() const
 {
     return speech_has_voice && speech_voice_blocking;

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -436,6 +436,24 @@ void GameState::SetIgnoreInput(int timeout_ms)
 void GameState::ClearIgnoreInput()
 {
     _ignoreUserInputUntilTime = AGS_Clock::now();
+    _scheduleIgnoreUserInputUntilTime = AGS_Clock::now();
+}
+
+void GameState::ScheduleIgnoreInput(int timeout_ms)
+{
+    if (AGS_Clock::now() + std::chrono::milliseconds(timeout_ms) > _scheduleIgnoreUserInputUntilTime)
+        _scheduleIgnoreUserInputUntilTime = AGS_Clock::now() + std::chrono::milliseconds(timeout_ms);
+}
+
+void GameState::ActivateScheduledIgnoreInput()
+{
+    if (AGS_Clock::now() < _scheduleIgnoreUserInputUntilTime)
+        _ignoreUserInputUntilTime = _scheduleIgnoreUserInputUntilTime;
+}
+
+void GameState::CancelScheduledIgnoreInput()
+{
+    _scheduleIgnoreUserInputUntilTime = AGS_Clock::now();
 }
 
 bool GameState::IsBlockingVoiceSpeech() const

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -326,7 +326,9 @@ struct GameState {
     //
     // User input management
     //
-    // Tells if game should ignore user input right now
+    // Tells if game should ignore user input right now. Note that some of the parent states
+    // may not ignore it at the same time, such as cutscene state, which may still be skipped
+    // with a key press or a mouse button.
     bool IsIgnoringInput() const;
     // Sets ignore input state, for the given time; if there's one already, chooses max timeout
     void SetIgnoreInput(int timeout_ms);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -217,6 +217,7 @@ struct GameState {
     std::vector<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms;
     int   ignore_user_input_after_text_timeout_ms;
+    int   ignore_user_input_at_next_text_ms;
     int   default_audio_type_volumes[MAX_AUDIO_TYPES];
 
     // Dynamic custom property values for characters and items
@@ -334,6 +335,13 @@ struct GameState {
     void SetIgnoreInput(int timeout_ms);
     // Clears ignore input state
     void ClearIgnoreInput();
+    // Schedules ignore input state, but does not enable it right away.
+    // The state may be activated using ActivateScheduledInput().
+    void ScheduleIgnoreInput(int timeout_ms);
+    // Activates ignore input state if one was scheduled, otherwise does nothing.
+    void ActivateScheduledIgnoreInput();
+    // Cancels scheduled ignore input state, if there's one
+    void CancelScheduledIgnoreInput();
 
     //
     // Voice speech management
@@ -386,6 +394,7 @@ private:
     bool  _roomViewportZOrderChanged;
 
     AGS_Clock::time_point _ignoreUserInputUntilTime;
+    AGS_Clock::time_point _scheduleIgnoreUserInputUntilTime;
 };
 
 // Converts legacy alignment type used in script API

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -217,7 +217,6 @@ struct GameState {
     std::vector<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms;
     int   ignore_user_input_after_text_timeout_ms;
-    AGS_Clock::time_point ignore_user_input_until_time;
     int   default_audio_type_volumes[MAX_AUDIO_TYPES];
 
     // Dynamic custom property values for characters and items
@@ -325,6 +324,16 @@ struct GameState {
     ScriptCamera *GetScriptCamera(int index);
 
     //
+    // User input management
+    //
+    // Tells if game should ignore user input right now
+    bool IsIgnoringInput() const;
+    // Sets ignore input state, for the given time; if there's one already, chooses max timeout
+    void SetIgnoreInput(int timeout_ms);
+    // Clears ignore input state
+    void ClearIgnoreInput();
+
+    //
     // Voice speech management
     //
     // Tells if there's a blocking voice speech playing right now
@@ -373,6 +382,8 @@ private:
     bool  _mainViewportHasChanged;
     // Tells that room viewports need z-order resort
     bool  _roomViewportZOrderChanged;
+
+    AGS_Clock::time_point _ignoreUserInputUntilTime;
 };
 
 // Converts legacy alignment type used in script API

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -370,7 +370,10 @@ bool InventoryScreen::Run()
         if ((isonitem<0) | (isonitem>=numitems) | (isonitem >= top_item + num_visible_items))
             isonitem=-1;
 
-        int mclick = ags_mgetbutton();
+        int mclick, mwheelz;
+        if (!run_service_mb_controls(mclick, mwheelz)) {
+            mclick = NONE;
+        }
         if (mclick == LEFT) {
             if ((mousey<0) | (mousey>windowhit) | (mousex<0) | (mousex>windowwid))
                 return true; // continue inventory screen loop

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -351,12 +351,12 @@ void InventoryScreen::RedrawOverItem(Bitmap *ds, int isonitem)
 
 bool InventoryScreen::Run()
 {
-    if (ags_kbhit() != 0)
+    int kgn;
+    if (run_service_key_controls(kgn) && !play.IsIgnoringInput())
     {
         return false; // end inventory screen loop
     }
 
-        //ags_domouse(DOMOUSE_UPDATE);
         update_audio_system_on_game_loop();
         refresh_gui_screen();
 
@@ -371,9 +371,10 @@ bool InventoryScreen::Run()
             isonitem=-1;
 
         int mclick, mwheelz;
-        if (!run_service_mb_controls(mclick, mwheelz)) {
+        if (!run_service_mb_controls(mclick, mwheelz) || play.IsIgnoringInput()) {
             mclick = NONE;
         }
+
         if (mclick == LEFT) {
             if ((mousey<0) | (mousey>windowhit) | (mousex<0) | (mousex>windowwid))
                 return true; // continue inventory screen loop

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -43,7 +43,7 @@ void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 
 extern int is_complete_overlay;
-extern int is_text_overlay;
+extern int is_text_overlay; // blocking text overlay on screen
 
 extern std::vector<ScreenOverlay> screenover;
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -194,7 +194,7 @@ int ags_getch() {
 void ags_clear_input_buffer()
 {
     while (ags_kbhit()) ags_getch();
-    while (mgetbutton() != NONE);
+    while (ags_mgetbutton() != NONE);
 }
 
 void ags_wait_until_keypress()

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -42,7 +42,7 @@ int mouse_z_was = 0;
 
 int ags_kbhit () {
     int result = keypressed();
-    if ((result) && (AGS_Clock::now() < play.ignore_user_input_until_time))
+    if ((result != 0) && play.IsIgnoringInput())
     {
         // ignoring user input
         ags_getch();
@@ -74,7 +74,7 @@ int ags_mgetbutton() {
         result = mgetbutton();
     }
 
-    if ((result >= 0) && (AGS_Clock::now() < play.ignore_user_input_until_time))
+    if ((result >= 0) && play.IsIgnoringInput())
     {
         // ignoring user input
         result = NONE;

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -41,14 +41,7 @@ extern int misbuttondown(int buno);
 int mouse_z_was = 0;
 
 int ags_kbhit () {
-    int result = keypressed();
-    if ((result != 0) && play.IsIgnoringInput())
-    {
-        // ignoring user input
-        ags_getch();
-        result = 0;
-    }
-    return result;  
+    return keypressed();
 }
 
 int ags_iskeypressed (int keycode) {
@@ -73,13 +66,6 @@ int ags_mgetbutton() {
     else {
         result = mgetbutton();
     }
-
-    if ((result >= 0) && play.IsIgnoringInput())
-    {
-        // ignoring user input
-        result = NONE;
-    }
-
     return result;
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -652,10 +652,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
 
     RestoreViewportsAndCameras(r_data);
 
-    // if savegame contained a global time and not an offset, this will be way off.
-    if ((play.ignore_user_input_until_time - AGS_Clock::now()) > std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms)) {
-        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
-    }
+    play.ClearIgnoreInput(); // don't keep ignored input after save restore
     update_polled_stuff_if_runtime();
 
     pl_run_plugin_hooks(AGSE_POSTRESTOREGAME, 0);

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -175,7 +175,8 @@ int CSCIWaitMessage(CSCIMessage * cscim)
             }
         }
 
-        if (ags_mgetbutton() != NONE) {
+        int mbut, mwheelz;
+        if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0) {
             if (checkcontrols()) {
                 cscim->id = controlid;
                 cscim->code = CM_COMMAND;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -156,7 +156,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         cscim->code = 0;
         smcode = 0;
         int keywas;
-        if (run_service_key_controls(keywas)) {
+        if (run_service_key_controls(keywas) && !play.IsIgnoringInput()) {
             if (keywas == 13) {
                 cscim->id = finddefaultcontrol(CNF_DEFAULT);
                 cscim->code = CM_COMMAND;
@@ -176,7 +176,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         }
 
         int mbut, mwheelz;
-        if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0) {
+        if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && !play.IsIgnoringInput()) {
             if (checkcontrols()) {
                 cscim->id = controlid;
                 cscim->code = CM_COMMAND;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -972,7 +972,7 @@ void engine_init_game_settings()
     play.text_speed=15;
     play.text_min_display_time_ms = 1000;
     play.ignore_user_input_after_text_timeout_ms = 500;
-    play.ignore_user_input_until_time = AGS_Clock::now();
+    play.ClearIgnoreInput();
     play.lipsync_speed = 15;
     play.close_mouth_speech_time = 10;
     play.disable_antialiasing = 0;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -972,6 +972,7 @@ void engine_init_game_settings()
     play.text_speed=15;
     play.text_min_display_time_ms = 1000;
     play.ignore_user_input_after_text_timeout_ms = 500;
+    play.ignore_user_input_at_next_text_ms = 0;
     play.ClearIgnoreInput();
     play.lipsync_speed = 15;
     play.close_mouth_speech_time = 10;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -340,6 +340,9 @@ bool run_service_key_controls(int &kgn)
         }
     }
 
+    if (kbhit_res)
+        play.CancelScheduledIgnoreInput();
+
     if (!kbhit_res || handled)
         return false;
 
@@ -371,6 +374,7 @@ bool run_service_mb_controls(int &mbut, int &mwheelz)
     if (mb == NONE && mz == 0)
         return false;
     lock_mouse_on_click(); // do not claim
+    play.CancelScheduledIgnoreInput();
     mbut = mb;
     mwheelz = mwheelz;
     return true;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -238,9 +238,9 @@ static void check_mouse_controls()
         wasbutdown=0;
     }
 
-    int mbut;
-    int mwheelz;
-    if (run_service_mb_controls(mbut, mwheelz)) {
+    int mbut = NONE;
+    int mwheelz = 0;
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0) {
 
         check_skip_cutscene_mclick(mbut);
 
@@ -376,7 +376,7 @@ bool run_service_mb_controls(int &mbut, int &mwheelz)
     lock_mouse_on_click(); // do not claim
     play.CancelScheduledIgnoreInput();
     mbut = mb;
-    mwheelz = mwheelz;
+    mwheelz = mz;
     return true;
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -242,14 +242,9 @@ static void check_mouse_controls()
     int mwheelz;
     if (run_service_mb_controls(mbut, mwheelz)) {
 
-        CutsceneSkipStyle skip = get_cutscene_skipstyle();
-        if (skip == eSkipSceneMouse || skip == eSkipSceneKeyMouse ||
-            (mbut == RIGHT && skip == eSkipSceneEscOrRMB))
-        {
-            start_skipping_cutscene();
-        }
+        check_skip_cutscene_mclick(mbut);
 
-        if (play.fast_forward) { }
+        if (play.fast_forward || play.IsIgnoringInput()) { /* do nothing if skipping cutscene or input disabled */ }
         else if ((play.wait_counter > 0) && (play.key_skip_wait > 1))
             play.wait_counter = -1;
         else if (is_text_overlay > 0) {
@@ -384,30 +379,20 @@ bool run_service_mb_controls(int &mbut, int &mwheelz)
 // Runs default keyboard handling
 static void check_keyboard_controls()
 {
-    int kgn;
-
     // First check for service engine's combinations (mouse lock, display mode switch, and so forth)
+    int kgn;
     if (!run_service_key_controls(kgn)) {
         return;
     }
-
-    // Now check for in-game controls
-
-    // if (kgn == eAGSKeyCodeF9) { restart_game(); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { Display("numover: %d character movesped: %d, animspd: %d",numscreenover,playerchar->walkspeed,playerchar->animspeed); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { CreateTextOverlay(50,60,170,FONT_SPEECH,14,"This is a test screen overlay which shouldn't disappear"); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { Display("Crashing"); strcpy(NULL, NULL); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { FaceLocation (game.playercharacter, playerchar->x + 1, playerchar->y); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { SetCharacterIdle (game.playercharacter, 5, 0); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { Display("Some for?ign text"); return; }
-    // if (kgn == eAGSKeyCodeCtrlB) { do_conversation(5); return; }
-
-    check_skip_cutscene_keypress (kgn);
-
+    // Then, check cutscene skip
+    check_skip_cutscene_keypress(kgn);
     if (play.fast_forward) { 
         return; 
     }
-
+    if (play.IsIgnoringInput()) {
+        return;
+    }
+    // Now check for in-game controls
     if (pl_run_plugin_hooks(AGSE_KEYPRESS, kgn)) {
         // plugin took the keypress
         debug_script_log("Keypress code %d taken by plugin", kgn);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -238,9 +238,9 @@ static void check_mouse_controls()
         wasbutdown=0;
     }
 
-    int mbut = ags_mgetbutton();
-    if (mbut>NONE) {
-        lock_mouse_on_click();
+    int mbut;
+    int mwheelz;
+    if (run_service_mb_controls(mbut, mwheelz)) {
 
         CutsceneSkipStyle skip = get_cutscene_skipstyle();
         if (skip == eSkipSceneMouse || skip == eSkipSceneKeyMouse ||
@@ -271,12 +271,10 @@ static void check_mouse_controls()
         else setevent(EV_TEXTSCRIPT,TS_MCLICK,mbut+1);
         //    else RunTextScriptIParam(gameinst,"on_mouse_click",aa+1);
     }
-    mbut = ags_check_mouse_wheel();
-    if (mbut !=0)
-        lock_mouse_on_click();
-    if (mbut < 0)
+
+    if (mwheelz < 0)
         setevent (EV_TEXTSCRIPT, TS_MCLICK, 9);
-    else if (mbut > 0)
+    else if (mwheelz > 0)
         setevent (EV_TEXTSCRIPT, TS_MCLICK, 8);
 }
 
@@ -368,6 +366,18 @@ bool run_service_key_controls(int &kgn)
 
     // No service operation triggered? return active keypress and shifts to caller
     kgn = keycode;
+    return true;
+}
+
+bool run_service_mb_controls(int &mbut, int &mwheelz)
+{
+    int mb = ags_mgetbutton();
+    int mz = ags_check_mouse_wheel();
+    if (mb == NONE && mz == 0)
+        return false;
+    lock_mouse_on_click(); // do not claim
+    mbut = mb;
+    mwheelz = mwheelz;
     return true;
 }
 

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -38,8 +38,11 @@ void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBit
 // Gets current logical game FPS, this is normally a fixed number set in script;
 // in case of "maxed fps" mode this function returns real measured FPS.
 float get_current_fps();
-// Runs service key controls, returns false if service key combinations were handled
-// and no more processing required, otherwise returns true and provides current keycode and key shifts.
+// Runs service key controls, returns false if key input was claimed by the engine,
+// otherwise returns true and provides a keycode.
 bool run_service_key_controls(int &kgn);
+// Runs service mouse controls, returns false if mouse input was claimed by the engine,
+// otherwise returns true and provides mouse button code.
+bool run_service_mb_controls(int &mbut, int &mwheelz);
 
 #endif // __AGS_EE_MAIN__GAMERUN_H

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -289,7 +289,7 @@ void update_speech_and_messages()
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
         remove_screen_overlay(OVER_TEXTMSG);
-        play.ignore_user_input_until_time = AGS_Clock::now() + std::chrono::milliseconds(play.ignore_user_input_after_text_timeout_ms);
+        play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
       }
     }
   }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -290,6 +290,7 @@ void update_speech_and_messages()
       {
         remove_screen_overlay(OVER_TEXTMSG);
         play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
+        play.ScheduleIgnoreInput(play.ignore_user_input_at_next_text_ms);
       }
     }
   }

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -69,15 +69,15 @@ Bitmap *fli_target = nullptr;
 int fliTargetWidth, fliTargetHeight;
 int check_if_user_input_should_cancel_video()
 {
-    int key;
+    int key, mbut, mwheelz;
     if (run_service_key_controls(key)) {
         if ((key==27) && (canabort==1))
             return 1;
         if (canabort >= 2)
             return 1;  // skip on any key
     }
-    if (canabort == 3) {  // skip on mouse click
-        if (ags_mgetbutton()!=NONE) return 1;
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && canabort == 3) {
+        return 1; // skip on mouse click
     }
     return 0;
 }

--- a/Engine/platform/windows/media/video/acwavi.cpp
+++ b/Engine/platform/windows/media/video/acwavi.cpp
@@ -391,14 +391,14 @@ int dxmedia_play_video(const char* filename, bool pUseSound, int canskip, int st
 
     RenderToSurface(vscreen);
     //Sleep(0);
-    int key;
+    int key, mbut, mwheelz;
     if (run_service_key_controls(key)) {
       if ((canskip == 1) && (key == 27))
         break;
       if (canskip >= 2)
         break;
     }
-    if ((ags_mgetbutton() >= 0) && (canskip == 3))
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && (canskip == 3))
       break;
   }
 

--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -119,14 +119,14 @@ int dxmedia_play_video_3d(const char* filename, IDirect3DDevice9 *device, bool u
 
     filterState = graph->GetState();
 
-    int key;
+    int key, mbut, mwheelz;
     if (run_service_key_controls(key)) {
       if ((canskip == 1) && (key == 27))
         break;
       if (canskip >= 2)
         break;
     }
-    if ((ags_mgetbutton() >= 0) && (canskip == 3))
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && (canskip == 3))
       break;
 
     //device->Present(NULL, NULL, 0, NULL);

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -409,14 +409,13 @@ void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)
 }
 
 extern void domouse(int);
-extern int  mgetbutton();
 
 void IAGSEngine::PollSystem () {
 
     domouse(DOMOUSE_NOCURSOR);
     update_polled_stuff_if_runtime();
-    int mbut = mgetbutton();
-    if (mbut > NONE)
+    int mbut, mwheelz;
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0)
         pl_run_plugin_hooks (AGSE_MOUSECLICK, mbut);
 
     int kp;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -415,11 +415,10 @@ void IAGSEngine::PollSystem () {
     domouse(DOMOUSE_NOCURSOR);
     update_polled_stuff_if_runtime();
     int mbut, mwheelz;
-    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0)
+    if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && !play.IsIgnoringInput())
         pl_run_plugin_hooks (AGSE_MOUSECLICK, mbut);
-
     int kp;
-    if (run_service_key_controls(kp)) {
+    if (run_service_key_controls(kp) && !play.IsIgnoringInput()) {
         pl_run_plugin_hooks (AGSE_KEYPRESS, kp);
     }
 


### PR DESCRIPTION
By user request, this implements Game.IgnoreUserInputForNextTextMs, as a complement to existing Game.IgnoreUserInputAfterTextMs.

( Definitely, I am aware that these names are ugly :) )

The point of the existing property (Game.IgnoreUserInputAfterTextMs) was to help with misclicks when skipping character speech. When speech is also skipped automatically (by a timer), player may click too late, before realizing that speech was already changed to the next line, or final line ended. In this case player's click would skip next line before player is able to read it, or perform some other action. To counter this, the feature would block user's input for a limited amount of time after auto-skipping the text.

A new user request was to be able to restrict input blocking to only the case when there's next line of text. Because it's impossible to know if there's one at the time when the previous ends, following function is implemented:
* when the text is skipped automatically, it schedules an input block and starts a timeout, but does not disable input just yet.
* if a new line of text will be displayed during this timeout, then the scheduled input block is activated for the remainer of this timeout.
* if user input was already disabled by the first property (Game.IgnoreUserInputAfterTextMs), then the timeout that lasts longer is chosen.

This way a game dev may set up separate timeouts for disabling user input after any text line, and disabling it only if there's a new text line right afterwards.

Additionally, this PR fixes inconsistent handling of few "service" input commands, and cutscene skipping (because input is still handled separately in various game states in the engine code). By the rule, the cutscene should be always skippable, even if player's input is otherwise blocked.


