### PR TITLE
Script API: extended argument list for DrawImage and DrawSurface

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -542,8 +542,15 @@ builtin managed struct DrawingSurface {
   import DrawingSurface* CreateCopy();
   /// Draws a circle onto the surface with its centre at (x,y).
   import void DrawCircle(int x, int y, int radius);
+#ifdef SCRIPT_API_v351
+  /// Draws a sprite onto the surface with its top-left corner at (x,y).
+  import void DrawImage(int x, int y, int spriteSlot, int transparency=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
+						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
+#endif
+#ifndef SCRIPT_API_v351
   /// Draws a sprite onto the surface with its top-left corner at (x,y).
   import void DrawImage(int x, int y, int spriteSlot, int transparency=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE);
+#endif
   /// Draws a straight line between the two points on the surface.
   import void DrawLine(int x1, int y1, int x2, int y2, int thickness=1);
   /// Draws a message from the Room Message Editor, wrapping at the specified width.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -569,8 +569,15 @@ builtin managed struct DrawingSurface {
   /// Draws the text to the surface, wrapping it at the specified width.
   import void DrawStringWrapped(int x, int y, int width, FontType, Alignment, const string text);
 #endif
+#ifdef SCRIPT_API_v351
+  /// Draws the specified surface onto this surface.
+  import void DrawSurface(DrawingSurface *surfaceToDraw, int transparency=0, int x=0, int y=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
+						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
+#endif
+#ifndef SCRIPT_API_v351
   /// Draws the specified surface onto this surface.
   import void DrawSurface(DrawingSurface *surfaceToDraw, int transparency=0);
+#endif
   /// Draws a filled triangle onto the surface.
   import void DrawTriangle(int x1, int y1, int x2, int y2, int x3, int y3);
   /// Gets the colour of a single pixel on the surface.

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -181,58 +181,78 @@ void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurfa
     target->FinishedDrawing();
 }
 
-void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
+void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds, int dst_x, int dst_y, int slot, int trans, int dst_width, int dst_height,
+    int src_x, int src_y, int src_width, int src_height)
 {
     if ((slot < 0) || (spriteset[slot] == nullptr))
         quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
-
     if ((trans < 0) || (trans > 100))
         quit("!DrawingSurface.DrawImage: invalid transparency setting");
-
-    // 100% transparency, don't draw anything
     if (trans == 100)
-        return;
+        return; // fully transparent
+    if (dst_width < 1 || dst_height < 1 || src_width < 1 || src_height < 1)
+        return; // invalid src or dest rectangles
 
-    Bitmap *sourcePic = spriteset[slot];
+    // Setup uninitialized arguments; convert coordinates for legacy script mode
+    Bitmap *ds = sds->GetBitmapSurface();
+    Bitmap *src = spriteset[slot];
+    if (dst_width == SCR_NO_VALUE) { dst_width = src->GetWidth(); }
+    else { sds->SizeToGameResolution(&dst_width); }
+    if (dst_height == SCR_NO_VALUE) { dst_height = src->GetHeight(); }
+    else { sds->SizeToGameResolution(&dst_height); }
+
+    if (src_x == SCR_NO_VALUE) { src_x = 0; }
+    if (src_y == SCR_NO_VALUE) { src_y = 0; }
+    sds->PointToGameResolution(&src_x, &src_y);
+    if (src_width == SCR_NO_VALUE) { src_width = src->GetWidth(); }
+    else { sds->SizeToGameResolution(&src_width); }
+    if (src_height == SCR_NO_VALUE) { src_height = src->GetHeight(); }
+    else { sds->SizeToGameResolution(&src_height); }
+
+    if (dst_x >= ds->GetWidth() || dst_x + dst_width <= 0 || dst_y >= ds->GetHeight() || dst_y + dst_height <= 0 ||
+        src_x >= src->GetWidth() || src_x + src_width <= 0 || src_y >= src->GetHeight() || src_y + src_height <= 0)
+        return; // source or destination rects lie completely off surface
+    // Clamp the source rect to the valid limits to prevent exceptions (ignore dest, bitmap drawing deals with that)
+    Math::ClampLength(src_x, src_width, 0, src->GetWidth());
+    Math::ClampLength(src_y, src_height, 0, src->GetHeight());
+    
+    // TODO: possibly optimize by not making a stretched intermediate bitmap
+    // if simplier blit/draw_sprite could be called (no translucency with alpha channel).
     bool needToFreeBitmap = false;
-
-    if (width != SCR_NO_VALUE)
+    if (dst_width != src->GetWidth() || dst_height != src->GetHeight() ||
+        src_width != src->GetWidth() || src_height != src->GetHeight())
     {
-        // Resize specified
+        // Resize and/or partial copy specified
+        Bitmap *newPic = BitmapHelper::CreateBitmap(dst_width, dst_height, src->GetColorDepth());
+        newPic->StretchBlt(src,
+            RectWH(src_x, src_y, src_width, src_height),
+            RectWH(0, 0, dst_width, dst_height));
 
-        if ((width < 1) || (height < 1))
-            return;
-
-        sds->SizeToGameResolution(&width, &height);
-
-        // resize the sprite to the requested size
-        Bitmap *newPic = BitmapHelper::CreateBitmap(width, height, sourcePic->GetColorDepth());
-
-        newPic->StretchBlt(sourcePic,
-            RectWH(0, 0, game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height),
-            RectWH(0, 0, width, height));
-
-        sourcePic = newPic;
+        src = newPic;
         needToFreeBitmap = true;
         update_polled_stuff_if_runtime();
     }
 
-    Bitmap *ds = sds->StartDrawing();
-    sds->PointToGameResolution(&xx, &yy);
+    ds = sds->StartDrawing();
+    sds->PointToGameResolution(&dst_x, &dst_y);
 
-    if (sourcePic->GetColorDepth() != ds->GetColorDepth()) {
+    if (src->GetColorDepth() != ds->GetColorDepth()) {
         debug_script_warn("RawDrawImage: Sprite %d colour depth %d-bit not same as background depth %d-bit", slot, spriteset[slot]->GetColorDepth(), ds->GetColorDepth());
     }
 
-    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, xx, yy, sourcePic, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0,
+    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0,
         kBlendMode_Alpha, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();
 
     if (needToFreeBitmap)
-        delete sourcePic;
+        delete src;
 }
 
+void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
+{
+    DrawingSurface_DrawImageEx(sds, xx, yy, slot, trans, width, height, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
+}
 
 void DrawingSurface_SetDrawingColor(ScriptDrawingSurface *sds, int newColour) 
 {
@@ -269,18 +289,16 @@ int DrawingSurface_GetUseHighResCoordinates(ScriptDrawingSurface *sds)
 
 int DrawingSurface_GetHeight(ScriptDrawingSurface *sds) 
 {
-    Bitmap *ds = sds->StartDrawing();
+    Bitmap *ds = sds->GetBitmapSurface();
     int height = ds->GetHeight();
-    sds->FinishedDrawingReadOnly();
     sds->SizeToGameResolution(&height);
     return height;
 }
 
 int DrawingSurface_GetWidth(ScriptDrawingSurface *sds) 
 {
-    Bitmap *ds = sds->StartDrawing();
+    Bitmap *ds = sds->GetBitmapSurface();
     int width = ds->GetWidth();
-    sds->FinishedDrawingReadOnly();
     sds->SizeToGameResolution(&width);
     return width;
 }
@@ -483,9 +501,17 @@ RuntimeScriptValue Sc_DrawingSurface_DrawCircle(void *self, const RuntimeScriptV
 }
 
 // void (ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
-RuntimeScriptValue Sc_DrawingSurface_DrawImage(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_DrawingSurface_DrawImage_6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT6(ScriptDrawingSurface, DrawingSurface_DrawImage);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_DrawImage(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 10);
+    DrawingSurface_DrawImageEx((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue,
+        params[6].IValue, params[7].IValue, params[8].IValue, params[9].IValue);
+    return RuntimeScriptValue((int32_t)0);
 }
 
 // void (ScriptDrawingSurface *sds, int fromx, int fromy, int tox, int toy, int thickness)
@@ -609,7 +635,8 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion compa
     ccAddExternalObjectFunction("DrawingSurface::Clear^1",              Sc_DrawingSurface_Clear);
     ccAddExternalObjectFunction("DrawingSurface::CreateCopy^0",         Sc_DrawingSurface_CreateCopy);
     ccAddExternalObjectFunction("DrawingSurface::DrawCircle^3",         Sc_DrawingSurface_DrawCircle);
-    ccAddExternalObjectFunction("DrawingSurface::DrawImage^6",          Sc_DrawingSurface_DrawImage);
+    ccAddExternalObjectFunction("DrawingSurface::DrawImage^6",          Sc_DrawingSurface_DrawImage_6);
+    ccAddExternalObjectFunction("DrawingSurface::DrawImage^10",         Sc_DrawingSurface_DrawImage);
     ccAddExternalObjectFunction("DrawingSurface::DrawLine^5",           Sc_DrawingSurface_DrawLine);
     ccAddExternalObjectFunction("DrawingSurface::DrawMessageWrapped^5", Sc_DrawingSurface_DrawMessageWrapped);
     ccAddExternalObjectFunction("DrawingSurface::DrawPixel^2",          Sc_DrawingSurface_DrawPixel);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -155,47 +155,21 @@ ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
     return nullptr;
 }
 
-void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev) {
-    if ((translev < 0) || (translev > 99))
-        quit("!DrawingSurface.DrawSurface: invalid parameter (transparency must be 0-99)");
-
-    Bitmap *ds = target->StartDrawing();
-    Bitmap *surfaceToDraw = source->GetBitmapSurface();
-
-    if (surfaceToDraw == target->GetBitmapSurface())
-        quit("!DrawingSurface.DrawSurface: cannot draw surface onto itself");
-
-    if (translev == 0) {
-        // just draw it over the top, no transparency
-        ds->Blit(surfaceToDraw, 0, 0, 0, 0, surfaceToDraw->GetWidth(), surfaceToDraw->GetHeight());
-        target->FinishedDrawing();
-        return;
-    }
-
-    if (surfaceToDraw->GetColorDepth() <= 8)
-        quit("!DrawingSurface.DrawSurface: 256-colour surfaces cannot be drawn transparently");
-
-    // Draw it transparently
-    GfxUtil::DrawSpriteWithTransparency(ds, surfaceToDraw, 0, 0,
-        GfxDef::Trans100ToAlpha255(translev));
-    target->FinishedDrawing();
-}
-
-void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds, int dst_x, int dst_y, int slot, int trans, int dst_width, int dst_height,
-    int src_x, int src_y, int src_width, int src_height)
+void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src, int dst_x, int dst_y, int trans, int dst_width, int dst_height,
+    int src_x, int src_y, int src_width, int src_height, int sprite_id, bool src_has_alpha)
 {
-    if ((slot < 0) || (spriteset[slot] == nullptr))
-        quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
+    Bitmap *ds = sds->GetBitmapSurface();
+    if (src == ds)
+        quit("!DrawingSurface.DrawImage: cannot draw onto itself");
     if ((trans < 0) || (trans > 100))
         quit("!DrawingSurface.DrawImage: invalid transparency setting");
+
     if (trans == 100)
         return; // fully transparent
     if (dst_width < 1 || dst_height < 1 || src_width < 1 || src_height < 1)
         return; // invalid src or dest rectangles
 
     // Setup uninitialized arguments; convert coordinates for legacy script mode
-    Bitmap *ds = sds->GetBitmapSurface();
-    Bitmap *src = spriteset[slot];
     if (dst_width == SCR_NO_VALUE) { dst_width = src->GetWidth(); }
     else { sds->SizeToGameResolution(&dst_width); }
     if (dst_height == SCR_NO_VALUE) { dst_height = src->GetHeight(); }
@@ -237,10 +211,13 @@ void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds, int dst_x, int dst_y,
     sds->PointToGameResolution(&dst_x, &dst_y);
 
     if (src->GetColorDepth() != ds->GetColorDepth()) {
-        debug_script_warn("RawDrawImage: Sprite %d colour depth %d-bit not same as background depth %d-bit", slot, spriteset[slot]->GetColorDepth(), ds->GetColorDepth());
+        if (sprite_id >= 0)
+            debug_script_warn("DrawImage: Sprite %d colour depth %d-bit not same as background depth %d-bit", sprite_id, src->GetColorDepth(), ds->GetColorDepth());
+        else
+            debug_script_warn("DrawImage: Source image colour depth %d-bit not same as background depth %d-bit", src->GetColorDepth(), ds->GetColorDepth());
     }
 
-    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0,
+    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, src_has_alpha,
         kBlendMode_Alpha, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();
@@ -249,9 +226,31 @@ void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds, int dst_x, int dst_y,
         delete src;
 }
 
+void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds, int dst_x, int dst_y, int slot, int trans, int dst_width, int dst_height,
+    int src_x, int src_y, int src_width, int src_height)
+{
+    if ((slot < 0) || (spriteset[slot] == nullptr))
+        quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
+    DrawingSurface_DrawImageImpl(sds, spriteset[slot], dst_x, dst_y, trans, dst_width, dst_height,
+        src_x, src_y, src_width, src_height, slot, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
+}
+
 void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
 {
-    DrawingSurface_DrawImageEx(sds, xx, yy, slot, trans, width, height, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
+    DrawingSurface_DrawImageEx(sds, slot, xx, yy, trans, width, height, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
+}
+
+void DrawingSurface_DrawSurfaceEx(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans,
+                                  int dst_x, int dst_y, int dst_width, int dst_height,
+                                  int src_x, int src_y, int src_width, int src_height)
+{
+    DrawingSurface_DrawImageImpl(target, source->GetBitmapSurface(), dst_x, dst_y, trans, dst_width, dst_height,
+        src_x, src_y, src_width, src_height, -1, source->hasAlphaChannel);
+}
+
+void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans)
+{
+    DrawingSurface_DrawSurfaceEx(target, source, trans, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
 }
 
 void DrawingSurface_SetDrawingColor(ScriptDrawingSurface *sds, int newColour) 
@@ -558,9 +557,18 @@ RuntimeScriptValue Sc_DrawingSurface_DrawStringWrapped(void *self, const Runtime
 }
 
 // void (ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev)
-RuntimeScriptValue Sc_DrawingSurface_DrawSurface(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_DrawingSurface_DrawSurface_2(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_POBJ_PINT(ScriptDrawingSurface, DrawingSurface_DrawSurface, ScriptDrawingSurface);
+}
+
+RuntimeScriptValue Sc_DrawingSurface_DrawSurface(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 10);
+    DrawingSurface_DrawSurfaceEx((ScriptDrawingSurface*)self, (ScriptDrawingSurface*)params[0].Ptr,
+        params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue,
+        params[6].IValue, params[7].IValue, params[8].IValue, params[9].IValue);
+    return RuntimeScriptValue((int32_t)0);
 }
 
 // void (ScriptDrawingSurface *sds, int x1, int y1, int x2, int y2, int x3, int y3)
@@ -646,7 +654,8 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion compa
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped_Old);
     else
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped);
-    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^2",        Sc_DrawingSurface_DrawSurface);
+    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^2",        Sc_DrawingSurface_DrawSurface_2);
+    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^10",       Sc_DrawingSurface_DrawSurface);
     ccAddExternalObjectFunction("DrawingSurface::DrawTriangle^6",       Sc_DrawingSurface_DrawTriangle);
     ccAddExternalObjectFunction("DrawingSurface::GetPixel^2",           Sc_DrawingSurface_GetPixel);
     ccAddExternalObjectFunction("DrawingSurface::Release^0",            Sc_DrawingSurface_Release);

--- a/Engine/ac/drawingsurface.h
+++ b/Engine/ac/drawingsurface.h
@@ -24,7 +24,7 @@ void	DrawingSurface_Release(ScriptDrawingSurface* sds);
 // convert actual co-ordinate back to what the script is expecting
 ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds);
 void	DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev);
-void	DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height);
+void	DrawingSurface_DrawImage_FullSrc(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height);
 void	DrawingSurface_SetDrawingColor(ScriptDrawingSurface *sds, int newColour);
 int		DrawingSurface_GetDrawingColor(ScriptDrawingSurface *sds);
 void	DrawingSurface_SetUseHighResCoordinates(ScriptDrawingSurface *sds, int highRes);


### PR DESCRIPTION
1. Extended argument list for DrawImage to allow drawing only part of the source bitmap (part_x, part_y, part_width, part_height).
2. Extended DrawSurface argument list to have all arguments like in DrawImage. Also made both functions share same implementation. DrawSurface function was necessary mostly because some bitmaps in AGS are not accessible with sprite slot number (such as room backgrounds), but in all other aspects this should be same operation.