### PR TITLE
adds alleg-sdl2digi.so to Linux build target

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -22,6 +22,7 @@ namespace AGS.Editor
             string[] libs =
             {
                 "alleg-alsadigi.so",
+                "alleg-sdl2digi.so",
                 "alleg-alsamidi.so",
                 "libaldmb.so.1",
                 "liballeg.so.4.4",


### PR DESCRIPTION
`alleg-sdl2digi.so` is currently shipped with the Editor/Linux package but it's not part of the built target of the Editor, so it's missing when building for Linux using the Editor.