### PR TITLE
Updates for room editor controls

### DIFF
--- a/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
+++ b/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
@@ -348,6 +348,9 @@ namespace AddressBarExt.Controls
             else
                 tsButton = new ToolStripButton(node.DisplayName, null, NodeButtonClicked);
 
+            //AGS: match the padding on the dropdown buttons
+            tsButton.Padding = new Padding(1, 0, 1, 0);
+
             //attach the node as the tag
             tsButton.Tag = node;
 
@@ -372,7 +375,12 @@ namespace AddressBarExt.Controls
                 if (node.Children.Length > 0)
                 {
                     //create the drop down button
-                    tsddButton = new ToolStripDropDownButton("");
+                    //tsddButton = new ToolStripDropDownButton("");
+
+                    //AGS: use some text to pickup text layout styling
+                    //and provide a bigger target to click on
+                    tsddButton = new ToolStripDropDownButton("···");
+                    tsddButton.ShowDropDownArrow = false;
 
                     //check if we have any tag data (we cache already built drop down items in the node TAG data.
                     if (node.Tag == null)
@@ -452,13 +460,21 @@ namespace AddressBarExt.Controls
                     tsddButton.DropDown = tsDropDown;
 
                     //set it to ignore text rendering
-                    tsddButton.DisplayStyle = ToolStripItemDisplayStyle.None;
+                    //tsddButton.DisplayStyle = ToolStripItemDisplayStyle.None;
+
+                    //AGS: use text stlying for dropdown menu to match the vertical
+                    //offset of other text inside the ToolStrip overflow
+                    tsddButton.DisplayStyle = ToolStripItemDisplayStyle.Text;
 
                     //align the image
                     tsddButton.ImageAlign = ContentAlignment.TopCenter;
 
                     //giving right margin to avoid drop down hiding itself when accidentally slightly moving the cursor to the button on the right
-                    tsddButton.Margin = new Padding(0, 0, 5, 0);
+                    //tsddButton.Margin = new Padding(0, 0, 5, 0);
+
+                    //AGS: prefer padding over margin to get a bigger click target
+                    //and reduce the amount of unclickable gaps
+                    tsddButton.Padding = new Padding(1, 0, 1, 0);
 
                     //add it to the bar
                     if (position < 0)

--- a/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
+++ b/Editor/AGS.Controls/AdressBarEx/AddressBarExt.cs
@@ -681,9 +681,11 @@ namespace AddressBarExt.Controls
         /// <returns>Boolean indicating </returns>
         private bool TooManyNodes()
         {
-            if (ts_bar.Items.Count == 0) return false;
+            //AGS: Remove overflow handling
+            return false;
+            //if (ts_bar.Items.Count == 0) return false;
             //check if the last item has overflowed
-            return ts_bar.Items[ts_bar.Items.Count - 1].IsOnOverflow;
+            //return ts_bar.Items[ts_bar.Items.Count - 1].IsOnOverflow;
         }
 
         #endregion

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -29,10 +29,13 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.mainFrame = new System.Windows.Forms.GroupBox();
+            this.lblMouse = new System.Windows.Forms.Label();
+            this.sldTransparency = new System.Windows.Forms.TrackBar();
+            this.lblTransparency = new System.Windows.Forms.Label();
             this.lblZoomInfo = new System.Windows.Forms.Label();
             this._editAddressBar = new AddressBarExt.Controls.AddressBarExt();
+            this.sldZoomLevel = new System.Windows.Forms.TrackBar();
             this.chkCharacterOffset = new System.Windows.Forms.CheckBox();
-            this.lblTransparency = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.lblMousePos = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
@@ -42,11 +45,9 @@ namespace AGS.Editor
             this.label1 = new System.Windows.Forms.Label();
             this.cmbBackgrounds = new System.Windows.Forms.ComboBox();
             this.bufferedPanel1 = new AGS.Editor.BufferedPanel();
-            this.sldZoomLevel = new System.Windows.Forms.TrackBar();
-            this.sldTransparency = new System.Windows.Forms.TrackBar();
             this.mainFrame.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
             this.SuspendLayout();
             // 
             // mainFrame
@@ -54,10 +55,13 @@ namespace AGS.Editor
             this.mainFrame.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.mainFrame.Controls.Add(this.lblMouse);
+            this.mainFrame.Controls.Add(this.sldTransparency);
+            this.mainFrame.Controls.Add(this.lblTransparency);
             this.mainFrame.Controls.Add(this.lblZoomInfo);
             this.mainFrame.Controls.Add(this._editAddressBar);
+            this.mainFrame.Controls.Add(this.sldZoomLevel);
             this.mainFrame.Controls.Add(this.chkCharacterOffset);
-            this.mainFrame.Controls.Add(this.lblTransparency);
             this.mainFrame.Controls.Add(this.label3);
             this.mainFrame.Controls.Add(this.lblMousePos);
             this.mainFrame.Controls.Add(this.label2);
@@ -67,19 +71,51 @@ namespace AGS.Editor
             this.mainFrame.Controls.Add(this.label1);
             this.mainFrame.Controls.Add(this.cmbBackgrounds);
             this.mainFrame.Controls.Add(this.bufferedPanel1);
-            this.mainFrame.Controls.Add(this.sldZoomLevel);
-            this.mainFrame.Controls.Add(this.sldTransparency);
-            this.mainFrame.Location = new System.Drawing.Point(3, 3);
+            this.mainFrame.Location = new System.Drawing.Point(2, 3);
             this.mainFrame.Name = "mainFrame";
             this.mainFrame.Size = new System.Drawing.Size(759, 485);
             this.mainFrame.TabIndex = 4;
             this.mainFrame.TabStop = false;
             this.mainFrame.Text = "Room details";
             // 
+            // lblMouse
+            // 
+            this.lblMouse.AutoSize = true;
+            this.lblMouse.Location = new System.Drawing.Point(16, 83);
+            this.lblMouse.Name = "lblMouse";
+            this.lblMouse.Size = new System.Drawing.Size(77, 13);
+            this.lblMouse.TabIndex = 20;
+            this.lblMouse.Text = "Mouse coords:";
+            // 
+            // sldTransparency
+            // 
+            this.sldTransparency.LargeChange = 20;
+            this.sldTransparency.Location = new System.Drawing.Point(558, 50);
+            this.sldTransparency.Margin = new System.Windows.Forms.Padding(1);
+            this.sldTransparency.Maximum = 100;
+            this.sldTransparency.Name = "sldTransparency";
+            this.sldTransparency.Size = new System.Drawing.Size(91, 45);
+            this.sldTransparency.SmallChange = 5;
+            this.sldTransparency.TabIndex = 14;
+            this.sldTransparency.TickFrequency = 20;
+            this.sldTransparency.Value = 70;
+            this.sldTransparency.Visible = false;
+            this.sldTransparency.Scroll += new System.EventHandler(this.sldTransparency_Scroll);
+            // 
+            // lblTransparency
+            // 
+            this.lblTransparency.AutoSize = true;
+            this.lblTransparency.Location = new System.Drawing.Point(523, 53);
+            this.lblTransparency.Name = "lblTransparency";
+            this.lblTransparency.Size = new System.Drawing.Size(38, 13);
+            this.lblTransparency.TabIndex = 15;
+            this.lblTransparency.Text = "Trans:";
+            this.lblTransparency.Visible = false;
+            // 
             // lblZoomInfo
             // 
             this.lblZoomInfo.AutoSize = true;
-            this.lblZoomInfo.Location = new System.Drawing.Point(575, 46);
+            this.lblZoomInfo.Location = new System.Drawing.Point(646, 21);
             this.lblZoomInfo.Name = "lblZoomInfo";
             this.lblZoomInfo.Size = new System.Drawing.Size(36, 13);
             this.lblZoomInfo.TabIndex = 19;
@@ -92,18 +128,30 @@ namespace AGS.Editor
             this._editAddressBar.DropDownBackColor = System.Drawing.Color.Empty;
             this._editAddressBar.DropDownForeColor = System.Drawing.Color.Empty;
             this._editAddressBar.ForeColor = System.Drawing.SystemColors.InfoText;
-            this._editAddressBar.Location = new System.Drawing.Point(93, 40);
-            this._editAddressBar.MinimumSize = new System.Drawing.Size(331, 23);
+            this._editAddressBar.Location = new System.Drawing.Point(98, 48);
+            this._editAddressBar.MinimumSize = new System.Drawing.Size(331, 26);
             this._editAddressBar.Name = "_editAddressBar";
             this._editAddressBar.RootNode = null;
             this._editAddressBar.SelectedStyle = ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline)));
-            this._editAddressBar.Size = new System.Drawing.Size(331, 23);
+            this._editAddressBar.Size = new System.Drawing.Size(419, 26);
             this._editAddressBar.TabIndex = 18;
+            // 
+            // sldZoomLevel
+            // 
+            this.sldZoomLevel.LargeChange = 1;
+            this.sldZoomLevel.Location = new System.Drawing.Point(558, 18);
+            this.sldZoomLevel.Maximum = 6;
+            this.sldZoomLevel.Minimum = 1;
+            this.sldZoomLevel.Name = "sldZoomLevel";
+            this.sldZoomLevel.Size = new System.Drawing.Size(91, 45);
+            this.sldZoomLevel.TabIndex = 12;
+            this.sldZoomLevel.Value = 1;
+            this.sldZoomLevel.Scroll += new System.EventHandler(this.sldZoomLevel_Scroll);
             // 
             // chkCharacterOffset
             // 
             this.chkCharacterOffset.AutoSize = true;
-            this.chkCharacterOffset.Location = new System.Drawing.Point(467, 69);
+            this.chkCharacterOffset.Location = new System.Drawing.Point(308, 82);
             this.chkCharacterOffset.Name = "chkCharacterOffset";
             this.chkCharacterOffset.Size = new System.Drawing.Size(209, 17);
             this.chkCharacterOffset.TabIndex = 17;
@@ -112,20 +160,10 @@ namespace AGS.Editor
             this.chkCharacterOffset.Visible = false;
             this.chkCharacterOffset.CheckedChanged += new System.EventHandler(this.chkCharacterOffset_CheckedChanged);
             // 
-            // lblTransparency
-            // 
-            this.lblTransparency.AutoSize = true;
-            this.lblTransparency.Location = new System.Drawing.Point(622, 46);
-            this.lblTransparency.Name = "lblTransparency";
-            this.lblTransparency.Size = new System.Drawing.Size(38, 13);
-            this.lblTransparency.TabIndex = 15;
-            this.lblTransparency.Text = "Trans:";
-            this.lblTransparency.Visible = false;
-            // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(435, 46);
+            this.label3.Location = new System.Drawing.Point(524, 21);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(37, 13);
             this.label3.TabIndex = 13;
@@ -134,16 +172,16 @@ namespace AGS.Editor
             // lblMousePos
             // 
             this.lblMousePos.AutoSize = true;
-            this.lblMousePos.Location = new System.Drawing.Point(10, 70);
+            this.lblMousePos.Location = new System.Drawing.Point(95, 83);
             this.lblMousePos.Name = "lblMousePos";
-            this.lblMousePos.Size = new System.Drawing.Size(103, 13);
+            this.lblMousePos.Size = new System.Drawing.Size(24, 13);
             this.lblMousePos.TabIndex = 11;
             this.lblMousePos.Text = "?, ?";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 45);
+            this.label2.Location = new System.Drawing.Point(10, 53);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(83, 13);
             this.label2.TabIndex = 10;
@@ -151,7 +189,7 @@ namespace AGS.Editor
             // 
             // btnExport
             // 
-            this.btnExport.Location = new System.Drawing.Point(460, 14);
+            this.btnExport.Location = new System.Drawing.Point(433, 16);
             this.btnExport.Name = "btnExport";
             this.btnExport.Size = new System.Drawing.Size(84, 23);
             this.btnExport.TabIndex = 8;
@@ -161,7 +199,7 @@ namespace AGS.Editor
             // 
             // btnDelete
             // 
-            this.btnDelete.Location = new System.Drawing.Point(370, 14);
+            this.btnDelete.Location = new System.Drawing.Point(343, 16);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(84, 23);
             this.btnDelete.TabIndex = 7;
@@ -171,7 +209,7 @@ namespace AGS.Editor
             // 
             // btnChangeImage
             // 
-            this.btnChangeImage.Location = new System.Drawing.Point(280, 14);
+            this.btnChangeImage.Location = new System.Drawing.Point(253, 16);
             this.btnChangeImage.Name = "btnChangeImage";
             this.btnChangeImage.Size = new System.Drawing.Size(84, 23);
             this.btnChangeImage.TabIndex = 3;
@@ -182,19 +220,19 @@ namespace AGS.Editor
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 19);
+            this.label1.Location = new System.Drawing.Point(25, 21);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(104, 13);
+            this.label1.Size = new System.Drawing.Size(67, 13);
             this.label1.TabIndex = 5;
-            this.label1.Text = "Display Background:";
+            this.label1.Text = "Background:";
             // 
             // cmbBackgrounds
             // 
             this.cmbBackgrounds.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbBackgrounds.FormattingEnabled = true;
-            this.cmbBackgrounds.Location = new System.Drawing.Point(132, 16);
+            this.cmbBackgrounds.Location = new System.Drawing.Point(98, 17);
             this.cmbBackgrounds.Name = "cmbBackgrounds";
-            this.cmbBackgrounds.Size = new System.Drawing.Size(130, 21);
+            this.cmbBackgrounds.Size = new System.Drawing.Size(148, 21);
             this.cmbBackgrounds.TabIndex = 4;
             this.cmbBackgrounds.SelectedIndexChanged += new System.EventHandler(this.cmbBackgrounds_SelectedIndexChanged);
             // 
@@ -205,9 +243,9 @@ namespace AGS.Editor
             | System.Windows.Forms.AnchorStyles.Right)));
             this.bufferedPanel1.AutoScroll = true;
             this.bufferedPanel1.BackColor = System.Drawing.SystemColors.Control;
-            this.bufferedPanel1.Location = new System.Drawing.Point(12, 93);
+            this.bufferedPanel1.Location = new System.Drawing.Point(12, 106);
             this.bufferedPanel1.Name = "bufferedPanel1";
-            this.bufferedPanel1.Size = new System.Drawing.Size(741, 384);
+            this.bufferedPanel1.Size = new System.Drawing.Size(741, 371);
             this.bufferedPanel1.TabIndex = 1;
             this.bufferedPanel1.TabStop = true;
             this.bufferedPanel1.Paint += new System.Windows.Forms.PaintEventHandler(this.bufferedPanel1_Paint);
@@ -215,33 +253,6 @@ namespace AGS.Editor
             this.bufferedPanel1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseDown);
             this.bufferedPanel1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseMove);
             this.bufferedPanel1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.bufferedPanel1_MouseUp);
-            // 
-            // sldZoomLevel
-            // 
-            this.sldZoomLevel.LargeChange = 1;
-            this.sldZoomLevel.Location = new System.Drawing.Point(478, 37);
-            this.sldZoomLevel.Maximum = 6;
-            this.sldZoomLevel.Minimum = 1;
-            this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(91, 42);
-            this.sldZoomLevel.TabIndex = 12;
-            this.sldZoomLevel.Value = 1;
-            this.sldZoomLevel.Scroll += new System.EventHandler(this.sldZoomLevel_Scroll);
-            // 
-            // sldTransparency
-            // 
-            this.sldTransparency.LargeChange = 20;
-            this.sldTransparency.Location = new System.Drawing.Point(664, 37);
-            this.sldTransparency.Margin = new System.Windows.Forms.Padding(1);
-            this.sldTransparency.Maximum = 100;
-            this.sldTransparency.Name = "sldTransparency";
-            this.sldTransparency.Size = new System.Drawing.Size(91, 42);
-            this.sldTransparency.SmallChange = 5;
-            this.sldTransparency.TabIndex = 14;
-            this.sldTransparency.TickFrequency = 20;
-            this.sldTransparency.Value = 70;
-            this.sldTransparency.Visible = false;
-            this.sldTransparency.Scroll += new System.EventHandler(this.sldTransparency_Scroll);
             // 
             // RoomSettingsEditor
             // 
@@ -253,8 +264,8 @@ namespace AGS.Editor
             this.Size = new System.Drawing.Size(768, 491);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -277,5 +288,6 @@ namespace AGS.Editor
         private System.Windows.Forms.CheckBox chkCharacterOffset;
         private AddressBarExt.Controls.AddressBarExt _editAddressBar;
         private System.Windows.Forms.Label lblZoomInfo;
+        private System.Windows.Forms.Label lblMouse;
     }
 }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -32,7 +32,6 @@ namespace AGS.Editor
             this.lblZoomInfo = new System.Windows.Forms.Label();
             this._editAddressBar = new AddressBarExt.Controls.AddressBarExt();
             this.chkCharacterOffset = new System.Windows.Forms.CheckBox();
-            this.coordbox = new System.Windows.Forms.CheckBox();
             this.lblTransparency = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.lblMousePos = new System.Windows.Forms.Label();
@@ -58,7 +57,6 @@ namespace AGS.Editor
             this.mainFrame.Controls.Add(this.lblZoomInfo);
             this.mainFrame.Controls.Add(this._editAddressBar);
             this.mainFrame.Controls.Add(this.chkCharacterOffset);
-            this.mainFrame.Controls.Add(this.coordbox);
             this.mainFrame.Controls.Add(this.lblTransparency);
             this.mainFrame.Controls.Add(this.label3);
             this.mainFrame.Controls.Add(this.lblMousePos);
@@ -113,18 +111,6 @@ namespace AGS.Editor
             this.chkCharacterOffset.UseVisualStyleBackColor = true;
             this.chkCharacterOffset.Visible = false;
             this.chkCharacterOffset.CheckedChanged += new System.EventHandler(this.chkCharacterOffset_CheckedChanged);
-            // 
-            // coordbox
-            // 
-            this.coordbox.AutoSize = true;
-            this.coordbox.Enabled = false;
-            this.coordbox.Location = new System.Drawing.Point(280, 69);
-            this.coordbox.Name = "coordbox";
-            this.coordbox.Size = new System.Drawing.Size(178, 17);
-            this.coordbox.TabIndex = 16;
-            this.coordbox.Text = "Display Coordinates as Low Res";
-            this.coordbox.UseVisualStyleBackColor = true;
-            this.coordbox.Visible = false;
             // 
             // lblTransparency
             // 
@@ -288,7 +274,6 @@ namespace AGS.Editor
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.Label lblTransparency;
 		private System.Windows.Forms.TrackBar sldTransparency;
-        public  System.Windows.Forms.CheckBox coordbox;
         private System.Windows.Forms.CheckBox chkCharacterOffset;
         private AddressBarExt.Controls.AddressBarExt _editAddressBar;
         private System.Windows.Forms.Label lblZoomInfo;

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -138,7 +138,7 @@ namespace AGS.Editor
             this.lblMousePos.Name = "lblMousePos";
             this.lblMousePos.Size = new System.Drawing.Size(103, 13);
             this.lblMousePos.TabIndex = 11;
-            this.lblMousePos.Text = "Mouse Coordinates:";
+            this.lblMousePos.Text = "?, ?";
             // 
             // label2
             // 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -668,7 +668,7 @@ namespace AGS.Editor
             {
                 yPosText = "?";
             }
-            lblMousePos.Text = "Mouse Position: " + xPosText + ", " + yPosText;
+            lblMousePos.Text = $"{xPosText}, {yPosText}";
 
             SelectCursor(e.X, e.Y, _state);
             if (_layer != null && !IsLocked(_layer))

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -37,6 +37,7 @@ namespace AGS.Editor
         private bool _mouseIsDown = false;
         private int _menuClickX;
         private int _menuClickY;
+        private object _startNode; // track breadcrumbs path so that it can be compared when saving
 
         private int ZOOM_STEP_VALUE = 25;
         private int ZOOM_MAX_VALUE = 600;
@@ -61,12 +62,18 @@ namespace AGS.Editor
             {
                 foreach (IRoomEditorFilter layer in _layers)
                     if (layer.Modified) return true;
+
+                if (_startNode != _editAddressBar.CurrentNode.UniqueID)
+                    return true;
+
                 return false;
             }
             set
             { // Kind of ugly, I know...
                 foreach (IRoomEditorFilter layer in _layers)
                     layer.Modified = value;
+
+                _startNode = _editAddressBar.CurrentNode.UniqueID;
             }
         }
 
@@ -101,6 +108,7 @@ namespace AGS.Editor
             
             RefreshLayersTree();
             _editAddressBar.SelectionChange += editAddressBar_SelectionChange;
+            _startNode = _editAddressBar.CurrentNode.UniqueID;
 
             RepopulateBackgroundList(0);
             UpdateScrollableWindowSize();


### PR DESCRIPTION
- Fixes that the current address bar node is not always saved into design time data
- Stop the address bar from implementing its own overflow to prefer the built-in ToolStrip overflow. Indirectly fixes #1054 
- Remove unused checkbox for "Display Coordinates as Low Res"
- Rearrange room editing controls to give more space to the address bar

To maintain vertical alignment of the dropdown buttons within the ToolStrip overflow, it seems to be a requirement that text be present in the item. So to fix this, empty dropdown items with an arrow are now replaced by the literal text "···" and no arrow. This has a side-effect of the buttons becoming wider and easier to click, which I think is an improvement over what is there now.

![updated_address_bar](https://user-images.githubusercontent.com/14958747/82120772-6091d700-9780-11ea-91b7-7c2b496b740c.png)