### PR TITLE
Linux: switch to printf in launch wrapper

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -173,7 +173,7 @@ scriptdir=$(dirname ""$scriptpath"")
 
 for arg; do
     if [ ""$arg"" = ""--help"" ]; then
-        echo ""Usage: $(basename ""$scriptpath"") [<ags options>]\n""
+        printf ""Usage: %s [<ags options>]\n\n"" ""$(basename ""$scriptpath"")""
         break
     fi
 done

--- a/debian/ags+libraries/startgame
+++ b/debian/ags+libraries/startgame
@@ -4,7 +4,7 @@ scriptdir=$(dirname "$scriptpath")
 
 for arg; do
     if [ "$arg" = "--help" ]; then
-        echo "Usage: $(basename "$scriptpath") [<ags options>]\n"
+        printf "Usage: %s [<ags options>]\n\n" "$(basename "$scriptpath")"
         break
     fi
 done


### PR DESCRIPTION
Not all echo implementations or defaults will expand escape sequences