### PR TITLE
3.5.0: fixed speech Y level above character not scaled by camera

### DIFF
--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -191,6 +191,9 @@ int my_getpixel(Common::Bitmap *blk, int x, int y);
 // X and Y co-ordinates must be in 320x200 format
 int check_click_on_character(int xx,int yy,int mood);
 int is_pos_on_character(int xx,int yy);
+// Returns character's room height (after in-room scaling, but before camera transform);
+// optionally uses frame 0 of the current loop, or refers to actual current frame by default
+int GetCharacterRoomHeight(int chid, bool use_frame_0 = false);
 void _DisplaySpeechCore(int chid, const char *displbuf);
 void _DisplayThoughtCore(int chid, const char *displbuf);
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -15,6 +15,7 @@
 #include "ac/overlay.h"
 #include "ac/common.h"
 #include "ac/view.h"
+#include "ac/character.h"
 #include "ac/characterextras.h"
 #include "ac/draw.h"
 #include "ac/gamesetupstruct.h"
@@ -223,18 +224,14 @@ void get_overlay_position(int overlayidx, int *x, int *y) {
     if (screenover[overlayidx].x == OVR_AUTOPLACE) {
         // auto place on character
         int charid = screenover[overlayidx].y;
-        int charpic = views[game.chars[charid].view].loops[game.chars[charid].loop].frames[0].pic;
 
-        tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[charid].get_effective_y())) - 5;
-        if (charextra[charid].height<1)
-            tdyp -= game.SpriteInfos[charpic].Height;
-        else
-            tdyp -= charextra[charid].height;
-
+        tdxp = play.RoomToScreenX((data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth() / 2));
+        if (tdxp < 0) tdxp = 0;
+        const int height = GetCharacterRoomHeight(charid, true);
+        tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[charid].get_effective_y()) - height)
+                - get_fixed_pixel_size(5);
         tdyp -= screenover[overlayidx].pic->GetHeight();
-        if (tdyp < 5) tdyp=5;
-        tdxp = play.RoomToScreenX((data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth()/2));
-        if (tdxp < 0) tdxp=0;
+        if (tdyp < 5) tdyp = 5;
 
         if ((tdxp + screenover[overlayidx].pic->GetWidth()) >= ui_view.GetWidth())
             tdxp = (ui_view.GetWidth() - screenover[overlayidx].pic->GetWidth()) - 1;


### PR DESCRIPTION
Fixes #1069

A character's height was not included when passing room-screen coordinate conversion.
