### PR TITLE
Fixes float locale dependant in #1015

### DIFF
--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -426,6 +426,9 @@ void engine_init_keyboard()
 
     install_keyboard();
 #endif
+#if AGS_PLATFORM_OS_LINUX
+    setlocale(LC_NUMERIC, "C"); // needed in X platform because install keyboard affects locale of printfs
+#endif
 }
 
 void engine_init_timer()


### PR DESCRIPTION
need to not use `LC_ALL`on MacOS