### PR TITLE
3.5.0: fix several oversights in new camera system

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2487,10 +2487,6 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         // run the "else" clause which  does text in the middle of
         // the screen.
         our_eip=1501;
-        if (tdxp < 0)
-            tdxp = play.RoomToScreenX(data_to_game_coord(speakingChar->x));
-        if (tdxp < 2)
-            tdxp=2;
 
         if (speakingChar->walking)
             StopMoving(aschar);
@@ -2515,24 +2511,25 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
         our_eip=1504;
 
-        if (tdyp < 0) 
+        // Calculate speech position based on character's position on screen
+        if (tdxp < 0)
+            tdxp = play.RoomToScreenX(data_to_game_coord(speakingChar->x));
+        if (tdxp < 2)
+            tdxp = 2;
+        tdxp = -tdxp;  // tell it to centre it ([ikm] not sure what's going on here... wrong comment?)
+
+        if (tdyp < 0)
         {
             int sppic = views[speakingChar->view].loops[speakingChar->loop].frames[0].pic;
-            tdyp = play.RoomToScreenY(data_to_game_coord(speakingChar->get_effective_y())) - get_fixed_pixel_size(5);
-            if (charextra[aschar].height < 1)
-                tdyp -= game.SpriteInfos[sppic].Height;
-            else
-                tdyp -= charextra[aschar].height;
-            // if it's a thought, lift it a bit further up
-            if (isThought)  
+            int height = (charextra[aschar].height < 1) ? game.SpriteInfos[sppic].Height : height = charextra[aschar].height;
+            tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[aschar].get_effective_y()) - height)
+                    - get_fixed_pixel_size(5);
+            if (isThought) // if it's a thought, lift it a bit further up
                 tdyp -= get_fixed_pixel_size(10);
         }
-
-        our_eip=1505;
         if (tdyp < 5)
-            tdyp=5;
+            tdyp = 5;
 
-        tdxp=-tdxp;  // tell it to centre it
         our_eip=152;
 
         if ((useview >= 0) && (game.options[OPT_SPEECHTYPE] > 0)) {

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -29,6 +29,7 @@ struct CharacterExtras {
     // used in the scripts, therefore overflowing stuff has to go here
     short invorder[MAX_INVORDER];
     short invorder_count;
+    // TODO: implement full AABB and keep updated, so that engine could rely on these cached values all time
     short width;
     short height;
     short zoom;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -332,7 +332,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
         if (!overlayPositionFixed)
         {
             screenover[nse].positionRelativeToScreen = false;
-            VpPoint vpt = play.ScreenToRoom(screenover[nse].x, screenover[nse].y, 0, false);
+            VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(screenover[nse].x, screenover[nse].y, false);
             screenover[nse].x = vpt.first.X;
             screenover[nse].y = vpt.first.Y;
         }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -199,22 +199,21 @@ void GameState::UpdateRoomCamera(int index)
 
 Point GameState::RoomToScreen(int roomx, int roomy)
 {
-    return _roomViewports[0]->GetTransform().Scale(Point(roomx - _roomCameras[0]->GetRect().Left, roomy - _roomCameras[0]->GetRect().Top));
+    return _roomViewports[0]->RoomToScreen(roomx, roomy, false).first;
 }
 
 int GameState::RoomToScreenX(int roomx)
 {
-    return _roomViewports[0]->GetTransform().X.ScalePt(roomx - _roomCameras[0]->GetRect().Left);
+    return _roomViewports[0]->RoomToScreen(roomx, 0, false).first.X;
 }
 
 int GameState::RoomToScreenY(int roomy)
 {
-    return _roomViewports[0]->GetTransform().Y.ScalePt(roomy - _roomCameras[0]->GetRect().Top);
+    return _roomViewports[0]->RoomToScreen(0, roomy, false).first.Y;
 }
 
 VpPoint GameState::ScreenToRoomImpl(int scrx, int scry, int view_index, bool clip_viewport, bool convert_cam_to_data)
 {
-    Point screen_pt(scrx, scry);
     PViewport view;
     if (view_index < 0)
     {
@@ -225,26 +224,8 @@ VpPoint GameState::ScreenToRoomImpl(int scrx, int scry, int view_index, bool cli
     else
     {
         view = _roomViewports[view_index];
-        if (clip_viewport && !view->GetRect().IsInside(screen_pt))
-            return std::make_pair(Point(), -1);
     }
-    
-    auto cam = view->GetCamera();
-    if (!cam)
-        return std::make_pair(Point(), -1);
-
-    Point p = view->GetTransform().UnScale(screen_pt);
-    if (convert_cam_to_data)
-    {
-        p.X += game_to_data_coord(cam->GetRect().Left);
-        p.Y += game_to_data_coord(cam->GetRect().Top);
-    }
-    else
-    {
-        p.X += cam->GetRect().Left;
-        p.Y += cam->GetRect().Top;
-    }
-    return std::make_pair(p, 0);
+    return view->ScreenToRoom(scrx, scry, clip_viewport, convert_cam_to_data);
 }
 
 VpPoint GameState::ScreenToRoom(int scrx, int scry)
@@ -259,20 +240,6 @@ VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry)
     if (game.options[OPT_BASESCRIPTAPI] >= kScriptAPI_v3507)
         return ScreenToRoomImpl(scrx, scry, -1, true, true);
     return ScreenToRoomImpl(scrx, scry, 0, false, true);
-}
-
-VpPoint GameState::ScreenToRoom(int scrx, int scry, int view_index, bool clip_viewport)
-{
-    if ((size_t)view_index >= _roomViewports.size())
-        return VpPoint(Point(), -1);
-    return ScreenToRoomImpl(scrx, scry, view_index, clip_viewport, false);
-}
-
-VpPoint GameState::ScreenToRoomDivDown(int scrx, int scry, int view_index, bool clip_viewport)
-{
-    if ((size_t)view_index >= _roomViewports.size())
-        return VpPoint(Point(), -1);
-    return ScreenToRoomImpl(scrx, scry, view_index, clip_viewport, true);
 }
 
 void GameState::CreatePrimaryViewportAndCamera()

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -55,9 +55,7 @@ enum GameStateSvgVersion
     kGSSvgVersion_3510      = 3,
 };
 
-// A result of coordinate conversion between screen and the room,
-// tells which viewport was used to pass the "touch" through.
-typedef std::pair<Point, int> VpPoint;
+
 
 // Adding to this might need to modify AGSDEFNS.SH and AGSPLUGIN.H
 struct GameState {
@@ -288,16 +286,12 @@ struct GameState {
     int  RoomToScreenX(int roomx);
     int  RoomToScreenY(int roomy);
     // Converts game screen coordinates to the room coordinates through the room viewport
-    // First pair of functions try to find if there is any viewport at the given coords and result
+    // This pair of functions tries to find if there is any viewport at the given coords and results
     // in failure if there is none.
     // TODO: find out if possible to refactor and get rid of "variadic" variants;
     // usually this depends on how the arguments are created (whether they are in "variadic" or true coords)
     VpPoint ScreenToRoom(int scrx, int scry);
     VpPoint ScreenToRoomDivDown(int scrx, int scry); // native "variadic" coords variant
-    // Following pair of function check for the particular viewport only, and optonally "clip"
-    // coordinates with its bounds, which means that they would fail if coordinates lie outside.
-    VpPoint ScreenToRoom(int scrx, int scry, int view_index, bool clip_viewport);
-    VpPoint ScreenToRoomDivDown(int scrx, int scry, int view_index, bool clip_viewport); // native "variadic" coords variant
 
     // Makes sure primary viewport and camera are created and linked together
     void CreatePrimaryViewportAndCamera();

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -15,6 +15,7 @@
 #include "ac/overlay.h"
 #include "ac/common.h"
 #include "ac/view.h"
+#include "ac/character.h"
 #include "ac/characterextras.h"
 #include "ac/draw.h"
 #include "ac/gamesetupstruct.h"
@@ -223,18 +224,15 @@ void get_overlay_position(int overlayidx, int *x, int *y) {
     if (screenover[overlayidx].x == OVR_AUTOPLACE) {
         // auto place on character
         int charid = screenover[overlayidx].y;
-        int charpic = views[game.chars[charid].view].loops[game.chars[charid].loop].frames[0].pic;
 
-        tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[charid].get_effective_y())) - 5;
-        if (charextra[charid].height<1)
-            tdyp -= game.SpriteInfos[charpic].Height;
-        else
-            tdyp -= charextra[charid].height;
-
+        tdxp = play.RoomToScreenX((data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth() / 2));
+        if (tdxp < 0) tdxp = 0;
+        const int charpic = views[game.chars[charid].view].loops[game.chars[charid].loop].frames[0].pic;
+        const int height = (charextra[charid].height < 1) ? game.SpriteInfos[charpic].Height : charextra[charid].height;
+        tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[charid].get_effective_y()) - height)
+                - get_fixed_pixel_size(5);
         tdyp -= screenover[overlayidx].pic->GetHeight();
-        if (tdyp < 5) tdyp=5;
-        tdxp = play.RoomToScreenX((data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth()/2));
-        if (tdxp < 0) tdxp=0;
+        if (tdyp < 5) tdyp = 5;
 
         if ((tdxp + screenover[overlayidx].pic->GetWidth()) >= ui_view.GetWidth())
             tdxp = (ui_view.GetWidth() - screenover[overlayidx].pic->GetWidth()) - 1;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -282,7 +282,6 @@ void unload_old_room() {
     memset(&play.walkable_areas_on[0],1,MAX_WALK_AREAS+1);
     play.bg_frame=0;
     play.bg_frame_locked=0;
-    play.GetRoomCamera(0)->Release();
     remove_screen_overlay(-1);
     delete raw_saved_screen;
     raw_saved_screen = nullptr;
@@ -421,10 +420,15 @@ static void adjust_viewport_to_room()
     const Rect main_view = play.GetMainViewport();
     Rect new_room_view = RectWH(Size::Clamp(real_room_sz, Size(1, 1), main_view.GetSize()));
 
-    play.GetRoomViewport(0)->SetRect(new_room_view);
-    auto cam = play.GetRoomCamera(0);
-    cam->SetSize(new_room_view.GetSize());
-    cam->SetAt(0, 0);
+    auto view = play.GetRoomViewport(0);
+    view->SetRect(new_room_view);
+    auto cam = view->GetCamera();
+    if (cam)
+    {
+        cam->SetSize(new_room_view.GetSize());
+        cam->SetAt(0, 0);
+        cam->Release();
+    }
 }
 
 // Run through all viewports and cameras to make sure they can work in new room's bounds

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -365,7 +365,7 @@ ScriptUserObject *Viewport_ScreenToRoomPoint(ScriptViewport *scv, int scrx, int 
     if (scv->GetID() < 0) { debug_script_warn("Viewport.ScreenToRoomPoint: trying to use deleted viewport"); return nullptr; }
     data_to_game_coords(&scrx, &scry);
 
-    VpPoint vpt = play.ScreenToRoom(scrx, scry, scv->GetID(), clipViewport);
+    VpPoint vpt = play.GetRoomViewport(scv->GetID())->ScreenToRoom(scrx, scry, clipViewport);
     if (vpt.second < 0)
         return nullptr;
 

--- a/Engine/ac/viewport_script.cpp
+++ b/Engine/ac/viewport_script.cpp
@@ -299,12 +299,22 @@ ScriptCamera* Viewport_GetCamera(ScriptViewport *scv)
 void Viewport_SetCamera(ScriptViewport *scv, ScriptCamera *scam)
 {
     if (scv->GetID() < 0) { debug_script_warn("Viewport.Camera: trying to use deleted viewport"); return; }
+    if (scam != nullptr && scam->GetID() < 0) { debug_script_warn("Viewport.Camera: trying to link deleted camera"); return; }
     auto view = play.GetRoomViewport(scv->GetID());
-    auto cam = play.GetRoomCamera(scam->GetID());
-    if (view != nullptr && cam != nullptr)
+    // unlink previous camera
+    auto cam = view->GetCamera();
+    if (cam)
+        cam->UnlinkFromViewport(view->GetID());
+    // link new one
+    if (scam != nullptr)
     {
+        cam = play.GetRoomCamera(scam->GetID());
         view->LinkCamera(cam);
         cam->LinkToViewport(view);
+    }
+    else
+    {
+        view->LinkCamera(nullptr);
     }
 }
 

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -101,6 +101,11 @@ private:
 };
 
 
+// A result of coordinate conversion between screen and the room,
+// tells which viewport was used to pass the "touch" through.
+typedef std::pair<Point, int> VpPoint;
+
+
 // Viewport class defines a rectangular area on game screen where the contents
 // of a Camera are rendered.
 // Viewport may have one linked camera at a time.
@@ -139,6 +144,15 @@ public:
     // pass nullptr to leave viewport without a camera link
     void LinkCamera(PCamera cam);
 
+    // TODO: provide a Transform object here that does these conversions instead
+    // Converts room coordinates to the game screen coordinates through this viewport;
+    // if clipping is on, the function will fail for room coordinates outside of camera
+    VpPoint RoomToScreen(int roomx, int roomy, bool clip) const;
+    // Converts game screen coordinates to the room coordinates through this viewport;
+    // if clipping is on, the function will fail for screen coordinates outside of viewport;
+    // convert_cam_to_data parameter converts camera "game" coordinates to "data" units (legacy mode)
+    VpPoint ScreenToRoom(int scrx, int scry, bool clip, bool convert_cam_to_data = false) const;
+
     // Following functions tell if this viewport has changed recently
     inline bool HasChangedPosition() const { return _hasChangedPosition; }
     inline bool HasChangedSize() const { return _hasChangedSize; }
@@ -153,6 +167,9 @@ public:
     }
 
 private:
+    // Parameterized implementation of screen-to-room coordinate conversion
+    VpPoint ScreenToRoomImpl(int scrx, int scry, bool clip, bool convert_cam_to_data);
+
     int _id = -1;
     // Position of the viewport on screen
     Rect _position;


### PR DESCRIPTION
Fixes #1069

1. Fixed crash in case `viewport.Camera = null;` in script. Now actually handle having viewport.Camera unset.
2. Moved coordinate transformation into Viewport class to make code in places simplier, which also fixes couple of bugs:
  * RoomToScreen/ScreenToRoom functions that had hardcoded conversion through camera 0, while primary viewport may have different linked camera;
  *  GameState::ScreenToRoomImpl() was not properly returning viewport index.
3. Fixed Screen.AutoSizeViewportOnRoomLoad was adjusting camera 0, now adjusts whatever camera is linked to primary viewport instead.
4. (#1069) Fixed character speech displaying in wrong Y position if camera was zoomed in or out. (A character's height was not included when passing room-screen coordinate conversion.)

