### PR TITLE
3.5.0: Display character speech relative to nearest viewport

### DIFF
--- a/Common/util/geometry.cpp
+++ b/Common/util/geometry.cpp
@@ -12,6 +12,8 @@
 //
 //=============================================================================
 #include "util/geometry.h"
+#include <algorithm>
+#include <cmath>
 
 //namespace AGS
 //{
@@ -28,6 +30,20 @@ bool IsRectInsideRect(const Rect &place, const Rect &item)
 {
     return item.Left >= place.Left && item.Right <= place.Right &&
         item.Top >= place.Top && item.Bottom <= place.Bottom;
+}
+
+float DistanceBetween(const Rect &r1, const Rect &r2)
+{
+    // https://gamedev.stackexchange.com/a/154040
+    Rect rect_outer(
+        std::min(r1.Left, r2.Left),
+        std::min(r1.Top, r2.Top),
+        std::max(r1.Right, r2.Right),
+        std::max(r1.Bottom, r2.Bottom)
+    );
+    int inner_width = std::max(0, rect_outer.GetWidth() - r1.GetWidth() - r2.GetWidth());
+    int inner_height = std::max(0, rect_outer.GetHeight() - r1.GetHeight() - r2.GetHeight());
+    return std::sqrt(inner_width ^ 2 + inner_height ^ 2);
 }
 
 Size ProportionalStretch(int dest_w, int dest_h, int item_w, int item_h)

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -385,6 +385,8 @@ struct Circle
 bool AreRectsIntersecting(const Rect &r1, const Rect &r2);
 // Tells if the item is completely inside place
 bool IsRectInsideRect(const Rect &place, const Rect &item);
+// Calculates a distance between two axis-aligned rectangles
+float DistanceBetween(const Rect &r1, const Rect &r2);
 
 int AlignInHRange(int x1, int x2, int off_x, int width, FrameAlignment align);
 int AlignInVRange(int y1, int y2, int off_y, int height, FrameAlignment align);

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -23,6 +23,8 @@
 #include "ac/dynobj/scriptobject.h"
 #include "ac/dynobj/scriptinvitem.h"
 #include "ac/dynobj/scriptoverlay.h"
+#include "game/viewport.h"
+#include "util/geometry.h"
 
 // **** CHARACTER: FUNCTIONS ****
 
@@ -193,12 +195,18 @@ int check_click_on_character(int xx,int yy,int mood);
 int is_pos_on_character(int xx,int yy);
 void _DisplaySpeechCore(int chid, const char *displbuf);
 void _DisplayThoughtCore(int chid, const char *displbuf);
-
 void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int isThought);
 int get_character_currently_talking();
 void DisplaySpeech(const char*texx, int aschar);
-
 int update_lip_sync(int talkview, int talkloop, int *talkframeptr);
+
+// Calculates character's bounding box in room coordinates (takes only in-room transform into account)
+// use_frame_0 optionally tells to use frame 0 of current loop instead of current frame.
+Rect GetCharacterRoomBBox(int charid, bool use_frame_0 = false);
+// Find a closest viewport given character is to. Checks viewports in their order in game's array,
+// and returns either first viewport character's bounding box intersects with (or rather with its camera),
+// or the one that is least far away from its camera; calculated as a perpendicular distance between two AABBs.
+PViewport FindNearestViewport(int charid);
 
 extern CharacterInfo*playerchar;
 extern CharacterExtras *charextra;

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -29,7 +29,8 @@ struct CharacterExtras {
     // used in the scripts, therefore overflowing stuff has to go here
     short invorder[MAX_INVORDER];
     short invorder_count;
-    // TODO: implement full AABB and keep updated, so that engine could rely on these cached values all time
+    // TODO: implement full AABB and keep updated, so that engine could rely on these cached values all time;
+    // TODO: consider having both fixed AABB and volatile one that changes with animation frame (unless you change how anims work)
     short width;
     short height;
     short zoom;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1865,6 +1865,7 @@ void prepare_characters_for_drawing() {
         }
         else {
             // draw at original size, so just use the sprite width and height
+            // TODO: store width and height always, that's much simplier to use for reference!
             charextra[aa].width=0;
             charextra[aa].height=0;
             newwidth = game.SpriteInfos[sppic].Width;
@@ -2055,7 +2056,7 @@ void draw_preroom_background()
 // ds and roomcam_surface may be the same bitmap.
 // no_transform flag tells to copy dirty regions on roomcam_surface without any coordinate conversion
 // whatsoever.
-PBitmap draw_room_background(PViewport view, const SpriteTransform &room_trans)
+PBitmap draw_room_background(Viewport *view, const SpriteTransform &room_trans)
 {
     our_eip = 31;
 
@@ -2339,7 +2340,7 @@ static void construct_room_view()
             }
             else
             { // room background is drawn by dirty rects system
-                PBitmap bg_surface = draw_room_background(viewport, room_trans);
+                PBitmap bg_surface = draw_room_background(viewport.get(), room_trans);
                 gfxDriver->BeginSpriteBatch(view_rc, room_trans, Point(), kFlip_None, bg_surface);
             }
         }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -225,12 +225,15 @@ void get_overlay_position(int overlayidx, int *x, int *y) {
         // auto place on character
         int charid = screenover[overlayidx].y;
 
-        tdxp = play.RoomToScreenX((data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth() / 2));
-        if (tdxp < 0) tdxp = 0;
+        auto view = FindNearestViewport(charid);
         const int charpic = views[game.chars[charid].view].loops[game.chars[charid].loop].frames[0].pic;
         const int height = (charextra[charid].height < 1) ? game.SpriteInfos[charpic].Height : charextra[charid].height;
-        tdyp = play.RoomToScreenY(data_to_game_coord(game.chars[charid].get_effective_y()) - height)
-                - get_fixed_pixel_size(5);
+        Point screenpt = view->RoomToScreen(
+            (data_to_game_coord(game.chars[charid].x) - screenover[overlayidx].pic->GetWidth() / 2),
+            data_to_game_coord(game.chars[charid].get_effective_y()) - height).first;
+        tdxp = screenpt.X;
+        if (tdxp < 0) tdxp = 0;
+        tdyp = screenpt.Y - get_fixed_pixel_size(5);
         tdyp -= screenover[overlayidx].pic->GetHeight();
         if (tdyp < 5) tdyp = 5;
 

--- a/Engine/game/viewport.h
+++ b/Engine/game/viewport.h
@@ -147,11 +147,11 @@ public:
     // TODO: provide a Transform object here that does these conversions instead
     // Converts room coordinates to the game screen coordinates through this viewport;
     // if clipping is on, the function will fail for room coordinates outside of camera
-    VpPoint RoomToScreen(int roomx, int roomy, bool clip) const;
+    VpPoint RoomToScreen(int roomx, int roomy, bool clip = false) const;
     // Converts game screen coordinates to the room coordinates through this viewport;
     // if clipping is on, the function will fail for screen coordinates outside of viewport;
     // convert_cam_to_data parameter converts camera "game" coordinates to "data" units (legacy mode)
-    VpPoint ScreenToRoom(int scrx, int scry, bool clip, bool convert_cam_to_data = false) const;
+    VpPoint ScreenToRoom(int scrx, int scry, bool clip = false, bool convert_cam_to_data = false) const;
 
     // Following functions tell if this viewport has changed recently
     inline bool HasChangedPosition() const { return _hasChangedPosition; }


### PR DESCRIPTION
This is not exactly a bugfix but rather unfinished business, it had to be in 3.5.0 new cameras but I forgot to add.

Originally, and still even after addition of new camera system, speech coordinates are set based on where character is located relative to **primary viewport**.

This change makes it find either _first viewport_ in the array this _character is seen in_, or one _which camera is nearest to the character_.

**NOTE:** this pr is based on #1076 code so should be merged after that.

A test game that illustrates the problem and allows to test the solution.
[test_camera_speech.zip](https://github.com/adventuregamestudio/ags/files/4674063/test_camera_speech.zip)
Controls:
* space - make character talk
* 1-4 - turn viewports on and off
* click around to make character walk, and see how speech position changes.

