### PR TITLE
Script API: expand Wait functions set for more versatility

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1397,6 +1397,10 @@ import void UnPauseGame();
 import void Wait(int waitLoops);
 /// Blocks the script for the specified number of game loops, unless a key is pressed.
 import int  WaitKey(int waitLoops);
+#ifdef SCRIPT_API_v351
+/// Blocks the script for the specified number of game loops, unless the mouse is clicked.
+import int  WaitMouse(int waitLoops);
+#endif
 /// Blocks the script for the specified number of game loops, unless a key is pressed or the mouse is clicked.
 import int  WaitMouseKey(int waitLoops);
 /// Checks whether the specified key is currently held down.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1396,13 +1396,13 @@ import void UnPauseGame();
 /// Blocks the script for the specified number of game loops.
 import void Wait(int waitLoops);
 /// Blocks the script for the specified number of game loops, unless a key is pressed.
-import int  WaitKey(int waitLoops);
+import int  WaitKey(int waitLoops = -1);
 #ifdef SCRIPT_API_v351
 /// Blocks the script for the specified number of game loops, unless the mouse is clicked.
-import int  WaitMouse(int waitLoops);
+import int  WaitMouse(int waitLoops = -1);
 #endif
 /// Blocks the script for the specified number of game loops, unless a key is pressed or the mouse is clicked.
-import int  WaitMouseKey(int waitLoops);
+import int  WaitMouseKey(int waitLoops = -1);
 /// Checks whether the specified key is currently held down.
 import bool IsKeyPressed(eKeyCode);
 import void SetGlobalInt(int globalInt, int value);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1397,12 +1397,14 @@ import void UnPauseGame();
 import void Wait(int waitLoops);
 /// Blocks the script for the specified number of game loops, unless a key is pressed.
 import int  WaitKey(int waitLoops = -1);
+/// Blocks the script for the specified number of game loops, unless a key is pressed or the mouse is clicked.
+import int  WaitMouseKey(int waitLoops = -1);
 #ifdef SCRIPT_API_v351
 /// Blocks the script for the specified number of game loops, unless the mouse is clicked.
 import int  WaitMouse(int waitLoops = -1);
+/// Cancels current Wait function, regardless of its type, if one was active at the moment.
+import void SkipWait();
 #endif
-/// Blocks the script for the specified number of game loops, unless a key is pressed or the mouse is clicked.
-import int  WaitMouseKey(int waitLoops = -1);
 /// Checks whether the specified key is currently held down.
 import bool IsKeyPressed(eKeyCode);
 import void SetGlobalInt(int globalInt, int value);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -147,6 +147,8 @@ struct GameState {
     int   bg_frame,bg_anim_delay;  // for animating backgrounds
     int   music_vol_was;  // before the volume drop
     short wait_counter;
+    char  wait_skipped_by; // tells how last wait was skipped [not serialized]
+    int   wait_skipped_by_data; // extended data telling how last wait was skipped [not serialized]
     short mboundx1,mboundx2,mboundy1,mboundy2;
     int   fade_effect;
     int   bg_frame_locked;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2202,6 +2202,11 @@ RuntimeScriptValue Sc_WaitKey(const RuntimeScriptValue *params, int32_t param_co
     API_SCALL_INT_PINT(WaitKey);
 }
 
+RuntimeScriptValue Sc_WaitMouse(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT(WaitMouse);
+}
+
 // int (int nloops)
 RuntimeScriptValue Sc_WaitMouseKey(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -2656,6 +2661,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("UpdatePalette",            Sc_UpdatePalette);
 	ccAddExternalStaticFunction("Wait",                     Sc_scrWait);
 	ccAddExternalStaticFunction("WaitKey",                  Sc_WaitKey);
+	ccAddExternalStaticFunction("WaitMouse",                Sc_WaitMouse);
 	ccAddExternalStaticFunction("WaitMouseKey",             Sc_WaitMouseKey);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2213,6 +2213,11 @@ RuntimeScriptValue Sc_WaitMouseKey(const RuntimeScriptValue *params, int32_t par
     API_SCALL_INT_PINT(WaitMouseKey);
 }
 
+RuntimeScriptValue Sc_SkipWait(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID(SkipWait);
+}
+
 //=============================================================================
 //
 // Exclusive API for Plugins
@@ -2663,6 +2668,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("WaitKey",                  Sc_WaitKey);
 	ccAddExternalStaticFunction("WaitMouse",                Sc_WaitMouse);
 	ccAddExternalStaticFunction("WaitMouseKey",             Sc_WaitMouseKey);
+	ccAddExternalStaticFunction("SkipWait",                 Sc_SkipWait);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -911,40 +911,29 @@ void SetGraphicalVariable (const char *varName, int p_value) {
         theVar->Value = p_value;
 }
 
-void scrWait(int nloops) {
+int WaitImpl(int skip_type, int nloops)
+{
     if ((nloops < 1) && (loaded_game_file_version >= kGameVersion_262)) // 2.62+
         quit("!Wait: must wait at least 1 loop");
 
     play.wait_counter = nloops;
-    play.key_skip_wait = 0;
+    play.key_skip_wait = skip_type;
 
     GameLoopUntilValueIsZeroOrLess(&play.wait_counter);
+
+    if (play.wait_counter < 0)
+        return 1;
+    return 0;
+}
+
+void scrWait(int nloops) {
+    WaitImpl(SKIP_AUTOTIMER, nloops);
 }
 
 int WaitKey(int nloops) {
-    if ((nloops < 1) && (loaded_game_file_version >= kGameVersion_262)) // 2.62+
-        quit("!WaitKey: must wait at least 1 loop");
-
-    play.wait_counter = nloops;
-    play.key_skip_wait = 1;
-
-    GameLoopUntilValueIsZeroOrLess(&play.wait_counter);
-
-    if (play.wait_counter < 0)
-        return 1;
-    return 0;
+    return WaitImpl(SKIP_KEYPRESS | SKIP_AUTOTIMER, nloops);
 }
 
 int WaitMouseKey(int nloops) {
-    if ((nloops < 1) && (loaded_game_file_version >= kGameVersion_262)) // 2.62+
-        quit("!WaitMouseKey: must wait at least 1 loop");
-
-    play.wait_counter = nloops;
-    play.key_skip_wait = 3;
-
-    GameLoopUntilValueIsZeroOrLess(&play.wait_counter);
-
-    if (play.wait_counter < 0)
-        return 1;
-    return 0;
+    return WaitImpl(SKIP_KEYPRESS | SKIP_MOUSECLICK | SKIP_AUTOTIMER, nloops);
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -913,15 +913,12 @@ void SetGraphicalVariable (const char *varName, int p_value) {
 
 int WaitImpl(int skip_type, int nloops)
 {
-    if ((nloops < 1) && (loaded_game_file_version >= kGameVersion_262)) // 2.62+
-        quit("!Wait: must wait at least 1 loop");
-
     play.wait_counter = nloops;
     play.wait_skipped_by = SKIP_AUTOTIMER; // we set timer flag by default to simplify that case
     play.wait_skipped_by_data = 0;
     play.key_skip_wait = skip_type;
 
-    GameLoopUntilValueIsZeroOrLess(&play.wait_counter);
+    GameLoopUntilValueIsZero(&play.wait_counter);
 
     if (game.options[OPT_BASESCRIPTAPI] < kScriptAPI_v351)
     {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -934,6 +934,10 @@ int WaitKey(int nloops) {
     return WaitImpl(SKIP_KEYPRESS | SKIP_AUTOTIMER, nloops);
 }
 
+int WaitMouse(int nloops) {
+    return WaitImpl(SKIP_MOUSECLICK | SKIP_AUTOTIMER, nloops);
+}
+
 int WaitMouseKey(int nloops) {
     return WaitImpl(SKIP_KEYPRESS | SKIP_MOUSECLICK | SKIP_AUTOTIMER, nloops);
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -929,7 +929,7 @@ int WaitImpl(int skip_type, int nloops)
     switch (play.wait_skipped_by)
     {
     case SKIP_KEYPRESS: return play.wait_skipped_by_data;
-    case SKIP_MOUSECLICK: return -play.wait_skipped_by_data;
+    case SKIP_MOUSECLICK: return -(play.wait_skipped_by_data + 1); // convert to 1-based code and negate
     default: return 0;
     }
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -949,3 +949,7 @@ int WaitMouse(int nloops) {
 int WaitMouseKey(int nloops) {
     return WaitImpl(SKIP_KEYPRESS | SKIP_MOUSECLICK | SKIP_AUTOTIMER, nloops);
 }
+
+void SkipWait() {
+    play.wait_counter = 0;
+}

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -83,5 +83,6 @@ void scrWait(int nloops);
 int WaitKey(int nloops);
 int WaitMouse(int nloops);
 int WaitMouseKey(int nloops);
+void SkipWait();
 
 #endif // __AGS_EE_AC__GLOBALGAME_H

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -81,6 +81,7 @@ int GetGraphicalVariable (const char *varName);
 void SetGraphicalVariable (const char *varName, int p_value);
 void scrWait(int nloops);
 int WaitKey(int nloops);
+int WaitMouse(int nloops);
 int WaitMouseKey(int nloops);
 
 #endif // __AGS_EE_AC__GLOBALGAME_H

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -113,6 +113,8 @@ const int LegacyRoomVolumeFactor            = 30;
 #define EVENT_INPROGRESS 1
 #define EVENT_CLAIMED    2
 
+// Internal skip style flags, for speech/display, wait
+#define SKIP_NONE       0
 #define SKIP_AUTOTIMER  1
 #define SKIP_KEYPRESS   2
 #define SKIP_MOUSECLICK 4

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1006,7 +1006,7 @@ void engine_init_game_settings()
     play.music_queue_size = 0;
     play.shakesc_length = 0;
     play.wait_counter=0;
-    play.key_skip_wait = 0;
+    play.key_skip_wait = SKIP_NONE;
     play.cur_music_number=-1;
     play.music_repeat=1;
     play.music_master_volume=100 + LegacyMusicMasterVolumeAdjustment;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -93,9 +93,6 @@ static int ShouldStayInWaitMode();
 static int numEventsAtStartOfFunction;
 static auto t1 = AGS_Clock::now();  // timer for FPS // ... 't1'... how very appropriate.. :)
 
-static int user_disabled_for = 0;
-static const void *user_disabled_data = nullptr;
-
 #define UNTIL_ANIMEND   1
 #define UNTIL_MOVEEND   2
 #define UNTIL_CHARIS0   3
@@ -105,7 +102,11 @@ static const void *user_disabled_data = nullptr;
 #define UNTIL_SHORTIS0  7
 #define UNTIL_INTISNEG  8
 
+// Following 3 parameters instruct the engine to run game loops until
+// certain condition is not fullfilled.
 static int restrict_until=0;
+static int user_disabled_for = 0;
+static const void *user_disabled_data = nullptr;
 
 unsigned int loopcounter=0;
 static unsigned int lastcounter=0;
@@ -250,7 +251,7 @@ static void check_mouse_controls()
         }
 
         if (play.fast_forward) { }
-        else if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0) {
+        else if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0) {
             play.wait_counter = 0;
             play.wait_skipped_by = SKIP_MOUSECLICK;
             play.wait_skipped_by_data = mbut;
@@ -427,7 +428,7 @@ static void check_keyboard_controls()
         return;
     }
 
-    if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
+    if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
         play.wait_counter = 0;
         play.wait_skipped_by = SKIP_KEYPRESS;
         play.wait_skipped_by_data = kgn;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -250,8 +250,11 @@ static void check_mouse_controls()
         }
 
         if (play.fast_forward) { }
-        else if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0)
-            play.wait_counter = -1;
+        else if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0) {
+            play.wait_counter = 0;
+            play.wait_skipped_by = SKIP_MOUSECLICK;
+            play.wait_skipped_by_data = mbut;
+        }
         else if (is_text_overlay > 0) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
                 remove_screen_overlay(OVER_TEXTMSG);
@@ -425,7 +428,9 @@ static void check_keyboard_controls()
     }
 
     if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
-        play.wait_counter = -1;
+        play.wait_counter = 0;
+        play.wait_skipped_by = SKIP_KEYPRESS;
+        play.wait_skipped_by_data = kgn;
         debug_script_log("Keypress code %d ignored - in Wait", kgn);
         return;
     }

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -250,7 +250,7 @@ static void check_mouse_controls()
         }
 
         if (play.fast_forward) { }
-        else if ((play.wait_counter > 0) && (play.key_skip_wait > 1))
+        else if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0)
             play.wait_counter = -1;
         else if (is_text_overlay > 0) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
@@ -424,7 +424,7 @@ static void check_keyboard_controls()
         return;
     }
 
-    if ((play.wait_counter > 0) && (play.key_skip_wait > 0)) {
+    if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
         play.wait_counter = -1;
         debug_script_log("Keypress code %d ignored - in Wait", kgn);
         return;


### PR DESCRIPTION
Resolves #647

* Added WaitMouse(timeout) to complement existing functions (WaitKey, WaitMouseKey).
* All Wait functions return a more precise reason they were skipped:
  - `0` = ended by timeout;
  - `> 0` = keycode
  - `< 0` = negated mouse button code minus one (because of how mouse codes start with 0). In order to get mouse code do this: `MouseButton btn = -(result + 1);`
* All Wait* functions (*including* Wait) may have infinite timeout if negative argument is passed; in all functions except Wait() timeout argument is now optional with default value -1.
* Added SkipWait() function that immediately cancels any active Wait*.

NOTE: SkipWait will be only useful if called from `repeatedly_execute_always` or `late_repeatedly_execute_always`.