### PR TITLE
Windows: Add option to disable message boxes

### DIFF
--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -106,6 +106,11 @@ int psp_gfx_super_sampling = 1;
 int psp_gfx_smooth_sprites = 0;
 #endif
 
+#if AGS_PLATFORM_OS_WINDOWS
+bool enableMessageBox = true;
+#endif
+
+
 
 void main_pre_init()
 {
@@ -192,6 +197,7 @@ void main_print_help() {
            "  --no-log                     Disable program output to the log file,\n"
            "                                 overriding configuration file setting\n"
 #if AGS_PLATFORM_OS_WINDOWS
+           "  --no-message-box             Write alerts to stdout instead of showing a message box\n"
            "  --setup                      Run setup application\n"
 #endif
            "  --tell                       Print various information concerning engine\n"
@@ -328,6 +334,12 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         // Special case: data file location
         //
         else if (arg[0]!='-') datafile_argv=ee;
+
+#if AGS_PLATFORM_OS_WINDOWS
+        // Windows-specific option to disable message boxes.
+        else if (ags_stricmp(arg, "--no-message-box") == 0) enableMessageBox = false;
+#endif
+
     }
 
     if (datafile_argv > 0)
@@ -427,7 +439,12 @@ int ags_entry_point(int argc, char *argv[]) {
     }
 
     if (!justTellInfo)
+#if AGS_PLATFORM_OS_WINDOWS
+        platform->SetGUIMode(enableMessageBox);
+#else
         platform->SetGUIMode(true);
+#endif
+
     init_debug(justTellInfo);
     Debug::Printf(kDbgMsg_Init, get_engine_string());
 

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -1104,5 +1104,13 @@ LPDIRECTINPUTDEVICE IAGSEngine::GetDirectInputMouse() {
   return mouse_dinput_device;
 }
 
+#undef main
+// Implement a dummy main() method that just calls WinMain so that we can create a console
+// that we can write to.
+int main()
+{
+    return WinMain(GetModuleHandle(NULL), NULL, GetCommandLineA(), SW_SHOWNORMAL);
+}
+
 
 #endif

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -155,7 +155,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
@@ -184,7 +184,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
@@ -213,7 +213,7 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding />
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -247,7 +247,7 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>
       </EnableCOMDATFolding>
@@ -282,7 +282,7 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCD;msvcrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding />
       <RandomizedBaseAddress>false</RandomizedBaseAddress>


### PR DESCRIPTION
Add the --no-message-box option in Windows for showing messages on stdout instead of
a message box.

This required changing the SubSystem from Windows to Console, and writing a simple
main() function that calls WinMain(). By making the application a "Console" app,
stdout/stderr handlers properly get initialized now.

This also makes the Windows port behavior more consistent with other platforms:
- Startup information now gets shown.
- The help menu now appears if there's an error.
- The --tell parameter works.