### PR TITLE
Windows: Add option to disable message boxes

### DIFF
--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -49,6 +49,7 @@ AGSPlatformDriver *platform = nullptr;
 
 void AGSPlatformDriver::AboutToQuitGame() { }
 void AGSPlatformDriver::PostAllegroInit(bool windowed) { }
+void AGSPlatformDriver::AttachToParentConsole() { }
 void AGSPlatformDriver::DisplaySwitchOut() { }
 void AGSPlatformDriver::DisplaySwitchIn() { }
 void AGSPlatformDriver::PauseApplication() { }

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -57,6 +57,7 @@ struct AGSPlatformDriver
     virtual void AboutToQuitGame();
     virtual void Delay(int millis);
     virtual void DisplayAlert(const char*, ...) = 0;
+    virtual void AttachToParentConsole();
     virtual int  GetLastSystemError() { return errno; }
     // Get root directory for storing per-game shared data
     virtual const char *GetAllUsersDataDirectory() { return "."; }


### PR DESCRIPTION
Add the --no-message-box option in Windows for showing messages on stdout instead of
a message box.

This required changing the SubSystem from Windows to Console, and writing a simple
main() function that calls WinMain(). By making the application a "Console" app,
stdout/stderr handlers properly get initialized now.

This also makes the Windows port behavior more consistent with other platforms:

Startup information now gets shown.
The help menu now appears if there's an error.
The --tell parameter works.