### PR TITLE
adds mouse pan with middle click on Room panel

### DIFF
--- a/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
+++ b/Editor/AGS.Editor.Tests/AGS.Editor.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\Solutions\packages\Microsoft.NET.Test.Sdk.16.4.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props" Condition="Exists('..\..\Solutions\packages\Microsoft.CodeCoverage.16.4.0\build\netstandard1.0\Microsoft.CodeCoverage.props')" />
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="ColorThemes\ColorThemesTests.cs" />
     <Compile Include="ColorThemes\Controls\ComboBoxCustomTests.cs" />
+    <Compile Include="Panes\FreePanControlTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Editor/AGS.Editor.Tests/Panes/FreePanControlTests.cs
+++ b/Editor/AGS.Editor.Tests/Panes/FreePanControlTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace AGS.Editor
+{
+    [TestFixture]
+    public class FreePanControlTests
+    {
+        private FreePanControlTestableWrapper _pane;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _pane = new FreePanControlTestableWrapper();
+        }
+
+        [Test]
+        public void IsPanningDefaultsToFalse()
+        {
+            Assert.That(_pane.IsPanning, Is.False);
+        }
+
+        [Test]
+        public void IsPanningIsTrueOnMiddleMouseClick()
+        {
+            _pane.OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, 5, 5, 0));
+            Assert.That(_pane.IsPanning, Is.True);
+        }
+
+        [Test]
+        public void PanGrabbedInvokesOnMiddleMouseClick()
+        {
+            bool panGrabbedInvoked = false;
+            _pane.PanGrabbed += (s, e) => panGrabbedInvoked = true;
+            _pane.OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, 5, 5, 0));
+            Assert.That(panGrabbedInvoked, Is.True);
+        }
+
+        [Test]
+        public void IsPanningReturnsToFalseOnPan()
+        {
+            _pane.OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, 5, 5, 0));
+            Assert.That(_pane.IsPanning, Is.True);
+            _pane.OnMouseMove(new MouseEventArgs(MouseButtons.Middle, 1, 4, 4, 0));
+            Assert.That(_pane.IsPanning, Is.True);
+            _pane.OnMouseUp(new MouseEventArgs(MouseButtons.Middle, 1, 3, 3, 0));
+            Assert.That(_pane.IsPanning, Is.False);
+        }
+
+        [Test]
+        public void CursorIsModifiedAndReturned()
+        {
+            _pane.Cursor = Cursors.IBeam;
+            Assert.That(_pane.Cursor, Is.EqualTo(Cursors.IBeam));
+            _pane.OnMouseDown(new MouseEventArgs(MouseButtons.Middle, 1, 5, 5, 0));
+            Assert.That(_pane.Cursor, Is.EqualTo(_pane.PanCursor));
+            _pane.OnMouseUp(new MouseEventArgs(MouseButtons.Middle, 1, 3, 3, 0));
+            Assert.That(_pane.Cursor, Is.EqualTo(Cursors.Default));
+            // this pane always go back to default cursor, if you want to change it to other cursor
+            // use OnPanRelease to change the cursor to the state desired.
+            // this prevents storing a "state" WaitCursor and restoring to it when it's uneeded.
+        }
+
+        private class FreePanControlTestableWrapper : FreePanControl
+        {
+            public new void OnMouseDown(MouseEventArgs e) => base.OnMouseDown(e);
+            public new void OnMouseUp(MouseEventArgs e) => base.OnMouseUp(e);
+            public new void OnMouseMove(MouseEventArgs e) => base.OnMouseMove(e);
+        }
+    }
+}

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -198,6 +198,9 @@
     </Compile>
     <Compile Include="Panes\Room\RoomEditFilters\CharactersEditorFilter.cs" />
     <Compile Include="Panes\Room\RoomEditFilters\DesignTimeProperties.cs" />
+    <Compile Include="Panes\FreePanControl.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Plugins\IAGSEditor.cs" />
     <Compile Include="Plugins\NativePlugin.cs" />
     <Compile Include="Panes\BufferedPanel.cs">

--- a/Editor/AGS.Editor/Panes/FreePanControl.cs
+++ b/Editor/AGS.Editor/Panes/FreePanControl.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public class FreePanControl : BufferedPanel
+    {
+        private const int WS_EX_COMPOSITED = 0x02000000;
+        private int _lastX, _lastY; //used to prevent useless mouse move events
+        private Point _panGrabPoint = Point.Empty;
+        public event EventHandler PanGrabbed;
+        public event EventHandler PanReleased;
+        public bool IsPanning { get; private set; }
+        public Cursor PanCursor { get; private set; } = Cursors.Hand; // We need a better hand cursor, using the "link" hand for now
+
+        // Enabling Composite makes scrolling smoother
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                CreateParams cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_COMPOSITED;
+                return cp;
+            }
+        }
+
+        protected virtual void OnPanGrab(EventArgs e)
+        {
+            PanGrabbed?.Invoke(this, EventArgs.Empty);
+        }
+
+        protected virtual void OnPanRelease(EventArgs e)
+        {
+            PanReleased?.Invoke(this, EventArgs.Empty);
+        }
+
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            // defines the shortcut for click pan Control+Shift+Left Click Hold or
+            // Middle Click Hold without any modifier.
+            if ( (e.Button == MouseButtons.Left   && ModifierKeys == (Keys.Control|Keys.Shift)) ||
+                 (e.Button == MouseButtons.Middle && ModifierKeys == Keys.None) )
+            {
+                OnPanGrab(e);
+                _panGrabPoint = e.Location;
+                Cursor = PanCursor;
+                IsPanning = true;
+            }
+
+            base.OnMouseDown(e);
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            if (_panGrabPoint != Point.Empty)
+            {
+                _panGrabPoint = Point.Empty;
+                Cursor = Cursors.Default;
+                IsPanning = false;
+                OnPanRelease(e);
+            }
+
+            base.OnMouseUp(e);
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            if ((e.X == _lastX) && (e.Y == _lastY))
+            {
+                return;
+            }
+
+            _lastX = e.X;
+            _lastY = e.Y;
+
+            if (_panGrabPoint != Point.Empty)
+            {
+                Point scrollPosition = AutoScrollPosition;
+                scrollPosition.X = _panGrabPoint.X - e.X - scrollPosition.X;
+                scrollPosition.Y = _panGrabPoint.Y - e.Y - scrollPosition.Y;
+                AutoScrollPosition = scrollPosition;
+                Refresh(); // this prevents the room image to look garbled when panning
+                _panGrabPoint = e.Location; // <- without this the pan doesn't work
+            }
+
+            base.OnMouseMove(e);
+        }
+
+    }
+}
+
+

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -44,7 +44,7 @@ namespace AGS.Editor
             this.btnChangeImage = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.cmbBackgrounds = new System.Windows.Forms.ComboBox();
-            this.bufferedPanel1 = new AGS.Editor.BufferedPanel();
+            this.bufferedPanel1 = new AGS.Editor.FreePanControl();
             this.mainFrame.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).BeginInit();
@@ -275,7 +275,7 @@ namespace AGS.Editor
         private System.Windows.Forms.GroupBox mainFrame;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox cmbBackgrounds;
-        private BufferedPanel bufferedPanel1;
+        private FreePanControl bufferedPanel1;
         private System.Windows.Forms.Button btnExport;
         private System.Windows.Forms.Button btnDelete;
         private System.Windows.Forms.Button btnChangeImage;

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -33,7 +33,6 @@ namespace AGS.Editor
         private List<IRoomEditorFilter> _layers = new List<IRoomEditorFilter>();
         private CharactersEditorFilter _characterLayer; // need to store the reference for special processing
         private bool _editorConstructed = false;
-        private int _lastX, _lastY;
         private bool _mouseIsDown = false;
         private int _menuClickX;
         private int _menuClickY;
@@ -605,6 +604,7 @@ namespace AGS.Editor
 
         private void bufferedPanel1_MouseDown(object sender, MouseEventArgs e)
         {
+            if (bufferedPanel1.IsPanning) return;
             if (_layer != null && !IsLocked(_layer))
                 _layer.MouseDown(e, _state);
             _mouseIsDown = true;
@@ -648,14 +648,7 @@ namespace AGS.Editor
 
 		private void bufferedPanel1_MouseMove(object sender, MouseEventArgs e)
         {
-            if ((e.X == _lastX) && (e.Y == _lastY))
-            {
-                return;
-            }
-
-            _lastX = e.X;
-            _lastY = e.Y;            
-
+            if (bufferedPanel1.IsPanning) return;
             int mouseXPos = _state.WindowXToRoom(e.X);
             int mouseYPos = _state.WindowYToRoom(e.Y);
             string xPosText = mouseXPos.ToString();


### PR DESCRIPTION
Creates FreePanControl.cs
- replaces BufferedPanel in Room Editor with FreePanControl
- adds pan with middle mouse click hold to ags editor
- also accepts left click+shift+ctrl 
- adds simple isolated tests for FreePanControl in `AGS.Editor.Tests` to document expected behavior.

**[CirrusCi builds of this PR](https://cirrus-ci.com/github/adventuregamestudio/ags/pull/1089)**
This is a rewrite of #1046
Attempt to solve #613 , [agsforums-57490](https://www.adventuregamestudio.co.uk/forums/index.php?topic=57490.0)