### PR TITLE
removes not used using reference to AGS.Types

### DIFF
--- a/Editor/AGS.CScript.Compiler/ScriptCompiler.cs
+++ b/Editor/AGS.CScript.Compiler/ScriptCompiler.cs
@@ -1,4 +1,3 @@
-using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Text;


### PR DESCRIPTION
I was looking if there was any dependency to AGS.Types in the AGS.CScript.Compiler. Apparently there isn't but I found a spurious AGS.Types mention. This PR removes it.