### PR TITLE
fixes for multimonitor of AGS on Linux

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -8,6 +8,8 @@ set_target_properties(engine PROPERTIES
     CXX_EXTENSIONS NO
 )
 
+option(AGS_X11_WITH_XINERAMA "Enable X11 Xinerama fixes" ON)
+
 target_include_directories(engine PUBLIC .)
 
 target_sources(engine
@@ -591,6 +593,16 @@ if (WIN32)
     target_link_libraries(engine PUBLIC DirectX::Direct3D9 shlwapi)
 elseif (LINUX)
     target_link_libraries(engine PUBLIC X11::X11)
+
+    if(AGS_X11_WITH_XINERAMA)
+        check_include_file("X11/extensions/Xinerama.h" HAVE_XINERAMA_H)
+        check_library_exists(Xinerama XineramaQueryExtension "" CAN_XINERAMA)
+        if(CAN_XINERAMA AND HAVE_XINERAMA_H)
+            target_compile_definitions(engine PRIVATE AGS_XWINDOWS_WITH_XINERAMA)
+            find_library(XINERAMA_LIB "Xinerama")
+            target_link_libraries(engine PRIVATE "${XINERAMA_LIB}")
+        endif()
+    endif(AGS_X11_WITH_XINERAMA)
 endif()
 
 get_target_property(ENGINE_SOURCES engine SOURCES)

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -91,9 +91,7 @@ DisplayModeSetup::DisplayModeSetup()
 
 Size get_desktop_size()
 {
-    Size sz;
-    get_desktop_resolution(&sz.Width, &sz.Height);
-    return sz;
+    return platform->GetDesktopSize();
 }
 
 Size get_max_display_size(bool windowed)

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -62,6 +62,13 @@ void AGSPlatformDriver::RegisterGameWithGameExplorer() { }
 void AGSPlatformDriver::UnRegisterGameWithGameExplorer() { }
 void AGSPlatformDriver::PlayVideo(const char* name, int skip, int flags) {}
 
+Size AGSPlatformDriver::GetDesktopSize()
+{
+    Size sz;
+    get_desktop_resolution(&sz.Width, &sz.Height);
+    return sz;
+}
+
 const char* AGSPlatformDriver::GetAllegroFailUserHint()
 {
     return "Make sure you have latest version of Allegro 4 libraries installed, and your system is running in graphical mode.";

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -24,6 +24,7 @@
 #include "ac/datetime.h"
 #include "debug/outputhandler.h"
 #include "util/ini_util.h"
+#include "util/geometry.h"
 
 namespace AGS
 {
@@ -83,6 +84,8 @@ struct AGSPlatformDriver
     virtual eScriptSystemOSID GetSystemOSID() = 0;
     virtual void GetSystemTime(ScriptDateTime*);
     virtual void PlayVideo(const char* name, int skip, int flags);
+    // Returns the monitor resolution of where ags window is
+    virtual Size GetDesktopSize();
     virtual void InitialiseAbufAtStartup();
     virtual void PostAllegroInit(bool windowed);
     virtual void PostAllegroExit() = 0;


### PR DESCRIPTION
- adds each monitor current resolution as an extra mode in the listing;
- adds new `Size AGSPlatformDriver::GetDesktopSize()` method;
- adds a logic to try to figure out the right resolution for GetDesktopSize on Linux (X11 desktop);
- if things fail, fallback to base GetDesktopSize implementation, which relies on previously used Allegro;

My desktop only has 1 monitor and 1 videocard, so need someone to test too. 

Possible fix to #258 ;