### PR TITLE
adds game file name validation in the Genral Settings pane.

### DIFF
--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -159,7 +160,23 @@ namespace AGS.Types
         public string GameFileName
         {
             get { return _gameFileName; }
-            set { _gameFileName = value; }
+            set
+            {
+                // Limit what they can set it to
+                if ((value.Length> 0) && value.Where(c => c > 127).Count() > 0)
+                {
+                    throw new ArgumentException("Game name should use only letters and numbers.");
+                }
+                if ((value.Length > 0) && (value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0))
+                {
+                    throw new ArgumentException("Game name has invalid filename characters");
+                }
+                if (value.Length == 0)
+                {
+                    throw new ArgumentException("Game name can't be empty.");
+                }
+                _gameFileName = value;
+            }
         }
 
         [DisplayName(PROPERTY_GAME_NAME)]


### PR DESCRIPTION
Possible fix for #1090 .
- checks if any characters are beyond 127 value range: fix Morgan's test case 1;
- checks if any characters are GetInvalidFileNameChars: fix Morgan's test case 2 and 3.
- additionally checks length > 0.

If this is accepted I can open a new one on release-3.5.0 branch of the same code.