### PR TITLE
3.5.0 Patch: fix "Change ID" does not work correctly + related oversights

### DIFF
--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -119,7 +119,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 clipClicked.ID = newNumber;
-                SwapItemsInFlatList(oldNumber, newNumber);
+                GetFlatList().Swap(oldNumber, newNumber);
                 OnItemIDChanged(clipClicked);
             }
             else if (controlID == SPEECH_NODE_ID)

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -119,6 +119,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 clipClicked.ID = newNumber;
+                SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(clipClicked);
             }
             else if (controlID == SPEECH_NODE_ID)
@@ -672,6 +673,11 @@ namespace AGS.Editor.Components
         protected override AudioClipFolder GetRootFolder()
         {
             return _agsEditor.CurrentGame.RootAudioClipFolder;
+        }
+
+        protected override IList<AudioClip> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.AudioClipFlatList;
         }
 
         protected override ProjectTreeItem CreateTreeItemForItem(AudioClip item)

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -154,17 +154,6 @@ namespace AGS.Editor.Components
             string newNodeID = AddTreeNodeForItem(item);
             return newNodeID;
         }
-
-        // Swaps two items in the flat item list only, keeping their folder location unchanged.
-        protected void SwapItemsInFlatList(int index1, int index2)
-        {
-            if (index1 == index2)
-                return;
-            var list = GetFlatList();
-            ItemType item = list[index1];
-            list[index1] = list[index2];
-            list[index2] = item;
-        }
                        
         protected void CreateSubFolder(string parentNodeID, FolderType parentFolder)
         {

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -14,6 +14,7 @@ namespace AGS.Editor.Components
         where FolderType : BaseFolderCollection<ItemType,FolderType>
     {
         protected abstract FolderType GetRootFolder();
+        protected abstract IList<ItemType> GetFlatList();
         protected abstract ProjectTreeItem CreateTreeItemForItem(ItemType item);
         protected abstract void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu);
         protected abstract void AddExtraCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu);
@@ -152,6 +153,17 @@ namespace AGS.Editor.Components
             _guiController.ProjectTree.StartFromNode(this, _rightClickedID);
             string newNodeID = AddTreeNodeForItem(item);
             return newNodeID;
+        }
+
+        // Swaps two items in the flat item list only, keeping their folder location unchanged.
+        protected void SwapItemsInFlatList(int index1, int index2)
+        {
+            if (index1 == index2)
+                return;
+            var list = GetFlatList();
+            ItemType item = list[index1];
+            list[index1] = list[index2];
+            list[index2] = item;
         }
                        
         protected void CreateSubFolder(string parentNodeID, FolderType parentFolder)

--- a/Editor/AGS.Editor/Components/CharacterIDChangedEventArgs.cs
+++ b/Editor/AGS.Editor/Components/CharacterIDChangedEventArgs.cs
@@ -8,7 +8,13 @@ namespace AGS.Editor
     /// </summary>
     public class CharacterIDChangedEventArgs : EventArgs
     {
+        /// <summary>
+        /// A character whose ID got changed. Character.ID should already be a new ID.
+        /// </summary>
         public Character Character { get; private set; }
+        /// <summary>
+        /// Previous character's ID, for the reference.
+        /// </summary>
         public int OldID { get; private set; }
 
         public CharacterIDChangedEventArgs(Character character, int oldID)

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -108,6 +108,7 @@ namespace AGS.Editor.Components
                 _itemRightClicked.ID = newNumber;
                 SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
+                OnCharacterIDChanged?.Invoke(this, new CharacterIDChangedEventArgs(_itemRightClicked, oldNumber));
             }
             else if ((!controlID.StartsWith(NODE_ID_PREFIX_FOLDER)) &&
                      (controlID != TOP_LEVEL_COMMAND_ID))

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -212,6 +212,15 @@ namespace AGS.Editor.Components
             return menu;
         }
 
+        // Synchronize open character documents with Views
+        public void UpdateCharacterViews()
+        {
+            foreach (ContentDocument doc in _documents.Values)
+            {
+                ((CharacterEditor)doc.Control).UpdateViewPreview();
+            }
+        }
+
         public override void RefreshDataFromGame()
         {
             foreach (ContentDocument doc in _documents.Values)

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -106,7 +106,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
-                SwapItemsInFlatList(oldNumber, newNumber);
+                GetFlatList().Swap(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
                 OnCharacterIDChanged?.Invoke(this, new CharacterIDChangedEventArgs(_itemRightClicked, oldNumber));
             }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -106,6 +106,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
+                SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
             }
             else if ((!controlID.StartsWith(NODE_ID_PREFIX_FOLDER)) &&
@@ -279,6 +280,11 @@ namespace AGS.Editor.Components
         protected override CharacterFolder GetRootFolder()
         {
             return _agsEditor.CurrentGame.RootCharacterFolder;
+        }
+
+        protected override IList<Character> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.CharacterFlatList;
         }
 
         protected override ProjectTreeItem CreateTreeItemForItem(Character item)

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -157,11 +157,12 @@ namespace AGS.Editor.Components
         {
             // Refresh tree, property grid and open windows
             RePopulateTreeView();
-            _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(item));
 
             foreach (ContentDocument doc in _documents.Values)
             {
-                doc.Name = ((CharacterEditor)doc.Control).ItemToEdit.WindowTitle;
+                var docItem = ((CharacterEditor)doc.Control).ItemToEdit;
+                doc.Name = item.WindowTitle;
+                _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(docItem), doc, docItem);
             }
         }
 

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -87,7 +87,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
-                SwapItemsInFlatList(oldNumber, newNumber);
+                GetFlatList().Swap(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
             }
             else if (controlID == COMMAND_FIND_ALL_USAGES)

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -87,6 +87,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
+                SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
             }
             else if (controlID == COMMAND_FIND_ALL_USAGES)
@@ -321,6 +322,11 @@ namespace AGS.Editor.Components
         protected override DialogFolder GetRootFolder()
         {
             return _agsEditor.CurrentGame.RootDialogFolder;
+        }
+
+        protected override IList<Dialog> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.DialogFlatList;
         }
     }
 }

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -132,11 +132,12 @@ namespace AGS.Editor.Components
         {
             // Refresh tree, property grid and open windows
             RePopulateTreeView();
-            _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(item));
 
             foreach (ContentDocument doc in _documents.Values)
             {
-                doc.Name = ((DialogEditor)doc.Control).ItemToEdit.WindowTitle;
+                var docItem = ((DialogEditor)doc.Control).ItemToEdit;
+                doc.Name = item.WindowTitle;
+                _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(docItem), doc, docItem);
             }
 
             // Force re-build of dialog scripts since names/ids have changed

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -135,7 +135,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _guiRightClicked.ID = newNumber;
-                SwapItemsInFlatList(oldNumber, newNumber);
+                GetFlatList().Swap(oldNumber, newNumber);
                 OnItemIDChanged(_guiRightClicked);
             }
             else if ((!controlID.StartsWith(NODE_ID_PREFIX_FOLDER)) &&

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -197,11 +197,12 @@ namespace AGS.Editor.Components
         {
             // Refresh tree, property grid and open windows
             RePopulateTreeView();
-            _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(item));
 
             foreach (ContentDocument doc in _documents.Values)
             {
-                doc.Name = ((GUIEditor)doc.Control).GuiToEdit.WindowTitle;
+                var docItem = ((GUIEditor)doc.Control).GuiToEdit;
+                doc.Name = item.WindowTitle;
+                _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(docItem), doc, docItem);
             }
         }
 

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -135,6 +135,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _guiRightClicked.ID = newNumber;
+                SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(_guiRightClicked);
             }
             else if ((!controlID.StartsWith(NODE_ID_PREFIX_FOLDER)) &&
@@ -334,6 +335,11 @@ namespace AGS.Editor.Components
         protected override GUIFolder GetRootFolder()
         {
             return _agsEditor.CurrentGame.RootGUIFolder;
+        }
+
+        protected override IList<GUI> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.GUIFlatList;
         }
 
     }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -75,6 +75,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
+                SwapItemsInFlatList(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
             }
             else if (controlID == COMMAND_FIND_ALL_USAGES)
@@ -236,6 +237,11 @@ namespace AGS.Editor.Components
         protected override InventoryItemFolder GetRootFolder()
         {
             return _agsEditor.CurrentGame.RootInventoryItemFolder;
+        }
+
+        protected override IList<InventoryItem> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.InventoryFlatList;
         }
     }
 }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -75,7 +75,7 @@ namespace AGS.Editor.Components
                     }
                 }
                 _itemRightClicked.ID = newNumber;
-                SwapItemsInFlatList(oldNumber, newNumber);
+                GetFlatList().Swap(oldNumber, newNumber);
                 OnItemIDChanged(_itemRightClicked);
             }
             else if (controlID == COMMAND_FIND_ALL_USAGES)

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -134,11 +134,12 @@ namespace AGS.Editor.Components
         {
             // Refresh tree, property grid and open windows
             RePopulateTreeView();
-            _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(item));
 
             foreach (ContentDocument doc in _documents.Values)
             {
-                doc.Name = ((InventoryEditor)doc.Control).ItemToEdit.WindowTitle;
+                var docItem = ((InventoryEditor)doc.Control).ItemToEdit;
+                doc.Name = item.WindowTitle;
+                _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(docItem), doc, docItem);
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1571,5 +1571,10 @@ namespace AGS.Editor.Components
         {
             return _agsEditor.CurrentGame.RootRoomFolder;
         }
-	}
+
+        protected override IList<IRoom> GetFlatList()
+        {
+            return null;
+        }
+    }
 }

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -617,5 +617,10 @@ namespace AGS.Editor.Components
         {
             return _agsEditor.CurrentGame.RootScriptFolder;
         }
+
+        protected override IList<ScriptAndHeader> GetFlatList()
+        {
+            return null;
+        }
     }
 }

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -61,7 +61,13 @@ namespace AGS.Editor.Components
             {
                 View viewClicked = _items[_rightClickedID];
                 int oldNumber = viewClicked.ID;
-                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("View", oldNumber, 1, _items.Count);
+                // Note that the views are not sequential, there may be gaps in IDs
+                int maxNumber = 1;
+                foreach (var obj in _items)
+                {
+                    maxNumber = Math.Max(maxNumber, obj.Value.ID);
+                }
+                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("View", oldNumber, 1, maxNumber);
                 if (newNumber < 0)
                     return;
                 foreach (var obj in _items)

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -304,6 +304,11 @@ namespace AGS.Editor.Components
             return _agsEditor.CurrentGame.RootViewFolder;
         }
 
+        protected override IList<View> GetFlatList()
+        {
+            return _agsEditor.CurrentGame.ViewFlatList;
+        }
+
         protected override ProjectTreeItem CreateTreeItemForItem(View item)
         {
             string nodeID = GetNodeIDForView(item);

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using AGS.Types;
@@ -62,12 +63,8 @@ namespace AGS.Editor.Components
                 View viewClicked = _items[_rightClickedID];
                 int oldNumber = viewClicked.ID;
                 // Note that the views are not sequential, there may be gaps in IDs
-                int maxNumber = 1;
-                foreach (var obj in _items)
-                {
-                    maxNumber = Math.Max(maxNumber, obj.Value.ID);
-                }
-                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("View", oldNumber, 1, maxNumber);
+                int newNumber = Factory.GUIController.ShowChangeObjectIDDialog("View", oldNumber, 1,
+                    Math.Max(1, _items.Max(i => i.Value.ID)));
                 if (newNumber < 0)
                     return;
                 foreach (var obj in _items)
@@ -192,11 +189,7 @@ namespace AGS.Editor.Components
         {
             RePopulateTreeView(GetNodeIDForView(item));
             UpdateOpenWindowTitles();
-            Components.CharactersComponent cmp = ComponentController.Instance.FindComponent<Components.CharactersComponent>();
-            if (cmp != null)
-            {
-                cmp.UpdateCharacterViews();
-            }
+            ComponentController.Instance.FindComponent<CharactersComponent>()?.UpdateCharacterViews();
         }
 
         public override void PropertyChanged(string propertyName, object oldValue)

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -192,6 +192,11 @@ namespace AGS.Editor.Components
         {
             RePopulateTreeView(GetNodeIDForView(item));
             UpdateOpenWindowTitles();
+            Components.CharactersComponent cmp = ComponentController.Instance.FindComponent<Components.CharactersComponent>();
+            if (cmp != null)
+            {
+                cmp.UpdateCharacterViews();
+            }
         }
 
         public override void PropertyChanged(string propertyName, object oldValue)

--- a/Editor/AGS.Editor/Panes/CharacterEditor.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.cs
@@ -38,7 +38,7 @@ namespace AGS.Editor
             return "Characters";
         }
         
-        private void UpdateViewPreview()
+        public void UpdateViewPreview()
         {
             viewPreview1.ViewToPreview = Factory.AGSEditor.CurrentGame.FindViewByID(_character.NormalView);
             viewPreview2.ViewToPreview = Factory.AGSEditor.CurrentGame.FindViewByID(_character.SpeechView);

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -499,6 +499,8 @@ namespace AGS.Editor
         {
             UpdateCharacterRef(e.Character, GetItemID(e.OldID));
             OnItemsChanged(this, null);
+            if (Enabled)
+                SetPropertyGridList();
         }
 
         private void OnCharacterRoomChanged(object sender, CharacterRoomChangedEventArgs e)
@@ -531,11 +533,30 @@ namespace AGS.Editor
             if (!RoomItemRefs.ContainsKey(oldID))
                 return;
             string newID = GetItemID(c);
-            RoomItemRefs.Remove(oldID);
-            RoomItemRefs.Add(newID, c);
-            // We must keep DesignTimeProperties!
-            DesignItems.Add(newID, DesignItems[oldID]);
-            DesignItems.Remove(oldID);
+            // If the new key is also present that means we are swapping two items
+            if (RoomItemRefs.ContainsKey(newID))
+            {
+                var char2 = RoomItemRefs[newID];
+                RoomItemRefs.Remove(newID);
+                RoomItemRefs.Remove(oldID);
+                RoomItemRefs.Add(newID, c);
+                RoomItemRefs.Add(oldID, char2);
+                // We must keep DesignTimeProperties!
+                var char1Item = DesignItems[oldID];
+                var char2Item = DesignItems[newID];
+                DesignItems.Remove(newID);
+                DesignItems.Remove(oldID);
+                DesignItems.Add(newID, char1Item);
+                DesignItems.Add(oldID, char2Item);
+            }
+            else
+            {
+                RoomItemRefs.Remove(oldID);
+                RoomItemRefs.Add(newID, c);
+                // We must keep DesignTimeProperties!
+                DesignItems.Add(newID, DesignItems[oldID]);
+                DesignItems.Remove(oldID);
+            }
         }
     }
 }

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -218,15 +218,30 @@ namespace AGS.Types
             get { return _characters.RootFolder; }
         }
 
+        public IList<Character> CharacterFlatList
+        {
+            get { return _characters.FlatList; }
+        }
+
         public DialogFolder RootDialogFolder
         {
             get { return _dialogs.RootFolder; }
+        }
+
+        public IList<Dialog> DialogFlatList
+        {
+            get { return _dialogs.FlatList; }
         }
 
         public ViewFolder RootViewFolder
         {
             get { return _views.RootFolder; }
             set { _views = new ViewFolders(value); }
+        }
+
+        public IList<View> ViewFlatList
+        {
+            get { return _views.FlatList; }
         }
 
         public ScriptFolder RootScriptFolder
@@ -239,9 +254,19 @@ namespace AGS.Types
             get { return _inventoryItems.RootFolder; }
         }
 
+        public IList<InventoryItem> InventoryFlatList
+        {
+            get { return _inventoryItems.FlatList; }
+        }
+
         public GUIFolder RootGUIFolder
         {
             get { return _guis.RootFolder; }
+        }
+
+        public IList<GUI> GUIFlatList
+        {
+            get { return _guis.FlatList; }
         }
 
         public UnloadedRoomFolder RootRoomFolder
@@ -252,6 +277,11 @@ namespace AGS.Types
         public AudioClipFolder RootAudioClipFolder
         {
             get { return _audioClips.RootFolder; }
+        }
+
+        public IList<AudioClip> AudioClipFlatList
+        {
+            get { return _audioClips.FlatList; }
         }
 
         public IList<AudioClipType> AudioClipTypes

--- a/Editor/AGS.Types/HelperTypes/FolderListHybrid.cs
+++ b/Editor/AGS.Types/HelperTypes/FolderListHybrid.cs
@@ -32,6 +32,7 @@ namespace AGS.Types
         }
 
         public TFolder RootFolder { get { return _folder; } }
+        public IList<TFolderItem> FlatList { get { return _items; } }
 
         public void ToXml(XmlTextWriter writer)
         {

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -10,6 +10,16 @@ namespace AGS.Types
 {
     public static class Utilities
     {
+        public static void Swap<T>(this IList<T> list, int index1, int index2)
+        {
+            if (index1 == index2)
+                return;
+
+            var temp = list[index1];
+            list[index1] = list[index2];
+            list[index2] = temp;
+        }
+
         public static T GetDefaultValue<T>(Type type, string propertyName, T defaultValue)
         {
             PropertyInfo property = type.GetProperty(propertyName);


### PR DESCRIPTION
This fixes underlying character etc arrays not updated properly when user changes game object ID. This mistake caused these objects to remain on previous positions, and, for example, retain previous indexes at runtime (until user reopens project in the editor).

Additional fixes:
* fixed value constraints when changing View's ID;
* update character's preview when View's ID is changed;
* fixed property grid was switching to object whose ID you are changing even if it has different active pane;
* at the same time fixed property grid of inactive panel did not have ID updated in the object title for the second object when two IDs swapped (i.e. if you have Char1 and Char2 panes opened, and swap their IDs, then only one of them got their property grid title updated).
* fixed Character Room Filter not updating itself after character's ID was changed (resulted in a wrong character displayed in room).
