### PR TITLE
Be explicit when converting AGS String to char*

### DIFF
--- a/Common/ac/common.cpp
+++ b/Common/ac/common.cpp
@@ -25,5 +25,5 @@ void quitprintf(const char *fmt, ...)
     va_start(ap, fmt);
     String text = String::FromFormatV(fmt, ap);
     va_end(ap);
-    quit(text);
+    quit(text.GetCStr());
 }

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -376,7 +376,7 @@ void GameSetupStruct::read_room_names(Stream *in, GameDataVersion data_ver)
             roomNumbers[bb] = in->ReadInt32();
             pexbuf.Read(in, STD_BUFFER_SIZE);
             roomNames[bb] = new char[pexbuf.GetLength() + 1];
-            strcpy(roomNames[bb], pexbuf);
+            strcpy(roomNames[bb], pexbuf.GetCStr());
         }
     }
     else

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -96,7 +96,7 @@ ScriptAudioClip* GetAudioClipForOldStyleNumber(GameSetupStruct &game, bool is_mu
 
     for (size_t i = 0; i < game.audioClips.size(); ++i)
     {
-        if (clip_name.Compare(game.audioClips[i].scriptName) == 0)
+        if (clip_name.Compare(game.audioClips[i].scriptName.GetCStr()) == 0)
             return &game.audioClips[i];
     }
     return nullptr;

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -68,7 +68,7 @@ AssetManager::~AssetManager()
 
 /* static */ bool AssetManager::IsDataFile(const String &data_file)
 {
-    Stream *in = ci_fopen(data_file, Common::kFile_Open, Common::kFile_Read);
+    Stream *in = ci_fopen(data_file.GetCStr(), Common::kFile_Open, Common::kFile_Read);
     if (in)
     {
         MFLUtil::MFLError err = MFLUtil::TestIsMFL(in, true);
@@ -80,7 +80,7 @@ AssetManager::~AssetManager()
 
 AssetError AssetManager::ReadDataFileTOC(const String &data_file, AssetLibInfo &lib)
 {
-    Stream *in = ci_fopen(data_file, Common::kFile_Open, Common::kFile_Read);
+    Stream *in = ci_fopen(data_file.GetCStr(), Common::kFile_Open, Common::kFile_Read);
     if (in)
     {
         MFLUtil::MFLError err = MFLUtil::ReadHeader(lib, in);
@@ -354,7 +354,7 @@ bool AssetManager::GetAssetFromLib(const String &asset_name, AssetLocation &loc,
     if (!asset)
         return false; // asset not found
 
-    String libfile = cbuf_to_string_and_free( ci_find_file(nullptr, MakeLibraryFileNameForAsset(asset)) );
+    String libfile = cbuf_to_string_and_free( ci_find_file(nullptr, MakeLibraryFileNameForAsset(asset).GetCStr()) );
     if (libfile.IsEmpty())
         return false;
     loc.FileName = libfile;
@@ -365,7 +365,7 @@ bool AssetManager::GetAssetFromLib(const String &asset_name, AssetLocation &loc,
 
 bool AssetManager::GetAssetFromDir(const String &file_name, AssetLocation &loc, FileOpenMode open_mode, FileWorkMode work_mode)
 {
-    String exfile = cbuf_to_string_and_free( ci_find_file(nullptr, file_name) );
+    String exfile = cbuf_to_string_and_free( ci_find_file(nullptr, file_name.GetCStr()) );
     if (exfile.IsEmpty() || !Path::IsFile(exfile))
         return false;
     loc.FileName = exfile;

--- a/Common/game/interactions.cpp
+++ b/Common/game/interactions.cpp
@@ -400,7 +400,7 @@ void InteractionVariable::Read(Stream *in)
 
 void InteractionVariable::Write(Common::Stream *out) const
 {
-    out->Write(Name, INTER_VAR_NAME_LENGTH);
+    out->Write(Name.GetCStr(), INTER_VAR_NAME_LENGTH);
     out->WriteInt8(Type);
     out->WriteInt32(Value);
 }

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -880,7 +880,7 @@ void WriteMainBlock(const RoomStruct *room, Stream *out)
         out->WriteInt8(room->MessageInfos[i].Flags);
     }
     for (size_t i = 0; i < room->MessageCount; ++i)
-        write_string_encrypt(out, room->Messages[i]);
+        write_string_encrypt(out, room->Messages[i].GetCStr());
 
     out->WriteInt16(0); // legacy room animations
 

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -347,7 +347,7 @@ void GUIButton::DrawText(Bitmap *ds, bool draw_disabled)
     color_t text_color = ds->GetCompatibleColor(TextColor);
     if (draw_disabled)
         text_color = ds->GetCompatibleColor(8);
-    GUI::DrawTextAligned(ds, _textToDraw, Font, text_color, frame, TextAlignment);
+    GUI::DrawTextAligned(ds, _textToDraw.GetCStr(), Font, text_color, frame, TextAlignment);
 }
 
 void GUIButton::DrawTextButton(Bitmap *ds, bool draw_disabled)

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -170,7 +170,7 @@ void GUIListBox::Draw(Common::Bitmap *ds)
         int item_index = item + TopItem;
         PrepareTextToDraw(Items[item_index]);
 
-        GUI::DrawTextAlignedHor(ds, _textToDraw, Font, text_color, X + 1 + pixel_size, right_hand_edge, at_y + 1,
+        GUI::DrawTextAlignedHor(ds, _textToDraw.GetCStr(), Font, text_color, X + 1 + pixel_size, right_hand_edge, at_y + 1,
             (FrameAlignment)TextAlignment);
     }
 

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -82,7 +82,7 @@ void GUITextBox::OnKeyPress(int keycode)
 
     Text.AppendChar(keycode);
     // if the new string is too long, remove the new character
-    if (wgettextwidth(Text, Font) > (Width - (6 + get_fixed_pixel_size(5))))
+    if (wgettextwidth(Text.GetCStr(), Font) > (Width - (6 + get_fixed_pixel_size(5))))
         Text.ClipRight(1);
 }
 

--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -21,7 +21,7 @@ namespace Directory
 
 bool CreateDirectory(const String &path)
 {
-    return mkdir(path
+    return mkdir(path.GetCStr()
 #if ! AGS_PLATFORM_OS_WINDOWS
         , 0755
 #endif
@@ -53,7 +53,7 @@ bool CreateAllDirectories(const String &parent, const String &path)
 
 String SetCurrentDirectory(const String &path)
 {
-    chdir(path);
+    chdir(path.GetCStr());
     return GetCurrentDirectory();
 }
 

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -33,7 +33,7 @@ soff_t File::GetFileSize(const String &filename)
 
 bool File::TestReadFile(const String &filename)
 {
-    FILE *test_file = fopen(filename, "rb");
+    FILE *test_file = fopen(filename.GetCStr(), "rb");
     if (test_file)
     {
         fclose(test_file);
@@ -44,7 +44,7 @@ bool File::TestReadFile(const String &filename)
 
 bool File::TestWriteFile(const String &filename)
 {
-    FILE *test_file = fopen(filename, "r+");
+    FILE *test_file = fopen(filename.GetCStr(), "r+");
     if (test_file)
     {
         fclose(test_file);
@@ -55,11 +55,11 @@ bool File::TestWriteFile(const String &filename)
 
 bool File::TestCreateFile(const String &filename)
 {
-    FILE *test_file = fopen(filename, "wb");
+    FILE *test_file = fopen(filename.GetCStr(), "wb");
     if (test_file)
     {
         fclose(test_file);
-        ::remove(filename);
+        ::remove(filename.GetCStr());
         return true;
     }
     return false;
@@ -67,7 +67,7 @@ bool File::TestCreateFile(const String &filename)
 
 bool File::DeleteFile(const String &filename)
 {
-    if (::remove(filename) != 0)
+    if (::remove(filename.GetCStr()) != 0)
     {
         int err;
 #if AGS_PLATFORM_OS_WINDOWS

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -171,7 +171,7 @@ void FileStream::Open(const String &file_name, FileOpenMode open_mode, FileWorkM
     String mode = File::GetCMode(open_mode, work_mode);
     if (mode.IsEmpty())
         throw std::runtime_error("Error determining open mode");
-    _file = fopen(file_name, mode);
+    _file = fopen(file_name.GetCStr(), mode.GetCStr());
     if (_file == nullptr)
         throw std::runtime_error("Error opening file.");
 }

--- a/Common/util/mutifilelib.cpp
+++ b/Common/util/mutifilelib.cpp
@@ -359,7 +359,7 @@ MFLUtil::MFLError MFLUtil::ReadV30(AssetLibInfo &lib, Stream *in, MFLVersion /* 
 
 void MFLUtil::WriteHeader(const AssetLibInfo &lib, MFLVersion lib_version, int lib_index, Stream *out)
 {
-    out->Write(MFLUtil::HeadSig, MFLUtil::HeadSig.GetLength());
+    out->Write(MFLUtil::HeadSig.GetCStr(), MFLUtil::HeadSig.GetLength());
     out->WriteByte(lib_version);
     out->WriteByte(lib_index);   // file number
 
@@ -397,7 +397,7 @@ void MFLUtil::WriteEnder(soff_t lib_offset, MFLVersion lib_index, Stream *out)
         out->WriteInt32((int32_t)lib_offset);
     else
         out->WriteInt64(lib_offset);
-    out->Write(TailSig, TailSig.GetLength());
+    out->Write(TailSig.GetCStr(), TailSig.GetLength());
 }
 
 void MFLUtil::DecryptText(char *text)

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -79,8 +79,8 @@ bool IsSameOrSubDir(const String &parent, const String &path)
     char can_path[MAX_PATH];
     char relative[MAX_PATH];
     // canonicalize_filename treats "." as "./." (file in working dir)
-    const char *use_parent = parent == "." ? "./" : parent;
-    const char *use_path   = path   == "." ? "./" : path;
+    const char *use_parent = parent == "." ? "./" : parent.GetCStr();
+    const char *use_path   = path   == "." ? "./" : path.GetCStr();
     canonicalize_filename(can_parent, use_parent, MAX_PATH);
     canonicalize_filename(can_path, use_path, MAX_PATH);
     const char *pstr = make_relative_filename(relative, can_parent, can_path, MAX_PATH);
@@ -145,7 +145,7 @@ String MakeAbsolutePath(const String &path)
     //}
 #endif
     char buf[MAX_PATH];
-    canonicalize_filename(buf, abs_path, MAX_PATH);
+    canonicalize_filename(buf, abs_path.GetCStr(), MAX_PATH);
     abs_path = buf;
     FixupPath(abs_path);
     return abs_path;

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -75,17 +75,17 @@ void Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat) 
 }
 
 const char* Button_GetText_New(GUIButton *butt) {
-    return CreateNewScriptString(butt->GetText());
+    return CreateNewScriptString(butt->GetText().GetCStr());
 }
 
 void Button_GetText(GUIButton *butt, char *buffer) {
-    strcpy(buffer, butt->GetText());
+    strcpy(buffer, butt->GetText().GetCStr());
 }
 
 void Button_SetText(GUIButton *butt, const char *newtx) {
     newtx = get_translation(newtx);
 
-    if (strcmp(butt->GetText(), newtx)) {
+    if (strcmp(butt->GetText().GetCStr(), newtx)) {
         guis_need_update = 1;
         butt->SetText(newtx);
     }

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -220,9 +220,9 @@ int run_dialog_script(DialogTopic*dtpp, int dialogID, int offse, int optionIndex
             param1 = game.playercharacter;
 
           if (param1 == DCHAR_NARRATOR)
-            Display(get_translation(old_speech_lines[param2]));
+            Display(get_translation(old_speech_lines[param2].GetCStr()));
           else
-            DisplaySpeech(get_translation(old_speech_lines[param2]), param1);
+            DisplaySpeech(get_translation(old_speech_lines[param2].GetCStr()), param1);
 
           said_speech_line = 1;
           break;
@@ -874,9 +874,9 @@ bool DialogOptions::Run()
         if (parserInput) {
           wantRefresh = true;
           // type into the parser 
-          if ((gkey == 361) || ((gkey == ' ') && (strlen(parserInput->Text) == 0))) {
+          if ((gkey == 361) || ((gkey == ' ') && (strlen(parserInput->Text.GetCStr()) == 0))) {
             // write previous contents into textbox (F3 or Space when box is empty)
-            for (unsigned int i = strlen(parserInput->Text); i < strlen(play.lastParserEntry); i++) {
+            for (unsigned int i = strlen(parserInput->Text.GetCStr()); i < strlen(play.lastParserEntry); i++) {
               parserInput->OnKeyPress(play.lastParserEntry[i]);
             }
             //ags_domouse(DOMOUSE_DISABLE);
@@ -1061,8 +1061,8 @@ void DialogOptions::Close()
 
   if (parserActivated) 
   {
-    strcpy (play.lastParserEntry, parserInput->Text);
-    ParseText (parserInput->Text);
+    strcpy (play.lastParserEntry, parserInput->Text.GetCStr());
+    ParseText (parserInput->Text.GetCStr());
     chose = CHOSE_TEXTPARSER;
   }
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -73,10 +73,10 @@ int File_Delete(const char *fnmm) {
   if (!ResolveScriptPath(fnmm, false, rp))
     return 0;
 
-  if (::remove(rp.FullPath) == 0)
+  if (::remove(rp.FullPath.GetCStr()) == 0)
       return 1;
-  if (errno == ENOENT && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-      return ::remove(rp.AltPath) == 0 ? 1 : 0;
+  if (errno == ENOENT && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath.GetCStr()) != 0)
+      return ::remove(rp.AltPath.GetCStr()) == 0 ? 1 : 0;
   return 0;
 }
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -254,7 +254,7 @@ String FixSlashAfterToken(const String &path)
 
 String MakeSpecialSubDir(const String &sp_dir)
 {
-    if (is_relative_filename(sp_dir))
+    if (is_relative_filename(sp_dir.GetCStr()))
         return sp_dir;
     String full_path = sp_dir;
     if (full_path.GetLast() != '/' && full_path.GetLast() != '\\')
@@ -278,7 +278,7 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
 {
     rp = ResolvedPath();
 
-    bool is_absolute = !is_relative_filename(orig_sc_path);
+    bool is_absolute = !is_relative_filename(orig_sc_path.GetCStr());
     if (is_absolute && !read_only)
     {
         debug_script_warn("Attempt to access file '%s' denied (cannot write to absolute path)", orig_sc_path.GetCStr());
@@ -474,13 +474,13 @@ void get_install_dir_path(char* buffer, const char *fileName)
 
 String find_assetlib(const String &filename)
 {
-    String libname = cbuf_to_string_and_free( ci_find_file(ResPaths.DataDir, filename) );
+    String libname = cbuf_to_string_and_free( ci_find_file(ResPaths.DataDir, filename.GetCStr()) );
     if (AssetManager::IsDataFile(libname))
         return libname;
     if (Path::ComparePaths(ResPaths.DataDir, installDirectory) != 0)
     {
       // Hack for running in Debugger
-      libname = cbuf_to_string_and_free( ci_find_file(installDirectory, filename) );
+      libname = cbuf_to_string_and_free( ci_find_file(installDirectory.GetCStr(), filename.GetCStr()) );
       if (AssetManager::IsDataFile(libname))
         return libname;
     }
@@ -561,7 +561,7 @@ ScriptFileHandle *check_valid_file_handle_ptr(Stream *stream_ptr, const char *op
   }
 
   String exmsg = String::FromFormat("!%s: invalid file handle; file not previously opened or has been closed", operation_name);
-  quit(exmsg);
+  quit(exmsg.GetCStr());
   return nullptr;
 }
 
@@ -579,7 +579,7 @@ ScriptFileHandle *check_valid_file_handle_int32(int32_t handle, const char *oper
   }
 
   String exmsg = String::FromFormat("!%s: invalid file handle; file not previously opened or has been closed", operation_name);
-  quit(exmsg);
+  quit(exmsg.GetCStr());
   return nullptr;
 }
 

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -496,7 +496,7 @@ const char* Game_GetSaveSlotDescription(int slnum) {
     String description;
     if (read_savedgame_description(get_save_game_path(slnum), description))
     {
-        return CreateNewScriptString(description);
+        return CreateNewScriptString(description.GetCStr());
     }
     return nullptr;
 }
@@ -1716,10 +1716,10 @@ HSaveError load_game(const String &path, int slotNumber, bool &data_overwritten)
         // [IKM] 2012-11-26: this is a workaround, indeed.
         // Try to find wanted game's executable; if it does not exist,
         // continue loading savedgame in current game, and pray for the best
-        get_install_dir_path(gamefilenamebuf, desc.MainDataFilename);
+        get_install_dir_path(gamefilenamebuf, desc.MainDataFilename.GetCStr());
         if (Common::File::TestReadFile(gamefilenamebuf))
         {
-            RunAGSGame (desc.MainDataFilename, 0, 0);
+            RunAGSGame (desc.MainDataFilename.GetCStr(), 0, 0);
             load_new_game_restore = slotNumber;
             return HSaveError::None();
         }
@@ -1759,9 +1759,9 @@ bool try_restore_save(const Common::String &path, int slot)
         // game data was released or overwritten by the data from save file,
         // this is why we tell engine to shutdown if that happened.
         if (data_overwritten)
-            quitprintf(error);
+            quitprintf(error.GetCStr());
         else
-            Display(error);
+            Display(error.GetCStr());
         return false;
     }
     return true;
@@ -2065,7 +2065,7 @@ void get_message_text (int msnum, char *buffer, char giveErr) {
     }
 
     buffer[0]=0;
-    replace_tokens(get_translation(thisroom.Messages[msnum]), buffer, maxlen);
+    replace_tokens(get_translation(thisroom.Messages[msnum].GetCStr()), buffer, maxlen);
 }
 
 bool unserialize_audio_script_object(int index, const char *objectType, const char *serializedData, int dataSize)

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -34,9 +34,9 @@ int LoadImageFile(const char *filename)
     if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
-    Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
-    if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-        loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
+    Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath.GetCStr());
+    if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath.GetCStr()) != 0)
+        loadedFile = BitmapHelper::LoadFromFile(rp.AltPath.GetCStr());
     if (!loadedFile)
         return 0;
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -122,14 +122,14 @@ void RestoreGameSlot(int slnum) {
 void DeleteSaveSlot (int slnum) {
     String nametouse;
     nametouse = get_save_game_path(slnum);
-    ::remove (nametouse);
+    ::remove (nametouse.GetCStr());
     if ((slnum >= 1) && (slnum <= MAXSAVEGAMES)) {
         String thisname;
         for (int i = MAXSAVEGAMES; i > slnum; i--) {
             thisname = get_save_game_path(i);
             if (Common::File::TestReadFile(thisname)) {
                 // Rename the highest save game to fill in the gap
-                rename (thisname, nametouse);
+                rename (thisname.GetCStr(), nametouse.GetCStr());
                 break;
             }
         }
@@ -158,7 +158,7 @@ int GetSaveSlotDescription(int slnum,char*desbuf) {
     String description;
     if (read_savedgame_description(get_save_game_path(slnum), description))
     {
-        strcpy(desbuf, description);
+        strcpy(desbuf, description.GetCStr());
         return 1;
     }
     sprintf(desbuf,"INVALID SLOT %d", slnum);
@@ -582,7 +582,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
     // on object
     if (loctype == LOCTYPE_OBJ) {
         aa = getloctype_index;
-        strcpy(tempo,get_translation(thisroom.Objects[aa].Name));
+        strcpy(tempo,get_translation(thisroom.Objects[aa].Name.GetCStr()));
         // Compatibility: < 3.1.1 games returned space for nameless object
         // (presumably was a bug, but fixing it affected certain games behavior)
         if (loaded_game_file_version < kGameVersion_311 && tempo[0] == 0) {
@@ -595,7 +595,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
         return;
     }
     onhs = getloctype_index;
-    if (onhs>0) strcpy(tempo,get_translation(thisroom.Hotspots[onhs].Name));
+    if (onhs>0) strcpy(tempo,get_translation(thisroom.Hotspots[onhs].Name.GetCStr()));
     if (play.get_loc_name_last_time != onhs)
         guis_need_update = 1;
     play.get_loc_name_last_time = onhs;

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -45,7 +45,7 @@ int FindGUIID (const char* GUIName) {
     for (int ii = 0; ii < game.numgui; ii++) {
         if (guis[ii].Name.IsEmpty())
             continue;
-        if (strcmp(guis[ii].Name, GUIName) == 0)
+        if (strcmp(guis[ii].Name.GetCStr(), GUIName) == 0)
             return ii;
         if ((guis[ii].Name[0u] == 'g') && (ags_stricmp(guis[ii].Name.GetCStr() + 1, GUIName) == 0))
             return ii;

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -82,7 +82,7 @@ void GetHotspotName(int hotspot, char *buffer) {
     if ((hotspot < 0) || (hotspot >= MAX_ROOM_HOTSPOTS))
         quit("!GetHotspotName: invalid hotspot number");
 
-    strcpy(buffer, get_translation(thisroom.Hotspots[hotspot].Name));
+    strcpy(buffer, get_translation(thisroom.Hotspots[hotspot].Name.GetCStr()));
 }
 
 void RunHotspotInteraction (int hotspothere, int mood) {

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -359,7 +359,7 @@ void GetObjectName(int obj, char *buffer) {
     if (!is_valid_object(obj))
         quit("!GetObjectName: invalid object number");
 
-    strcpy(buffer, get_translation(thisroom.Objects[obj].Name));
+    strcpy(buffer, get_translation(thisroom.Objects[obj].Name.GetCStr()));
 }
 
 void MoveObject(int objj,int xx,int yy,int spp) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -340,7 +340,7 @@ void remove_popup_interface(int ifacenum) {
 void process_interface_click(int ifce, int btn, int mbut) {
     if (btn < 0) {
         // click on GUI background
-        QueueScriptFunction(kScInstGame, guis[ifce].OnClickHandler, 2,
+        QueueScriptFunction(kScInstGame, guis[ifce].OnClickHandler.GetCStr(), 2,
             RuntimeScriptValue().SetDynamicObject(&scrGui[ifce], &ccDynamicGUI),
             RuntimeScriptValue().SetInt32(mbut));
         return;
@@ -366,14 +366,14 @@ void process_interface_click(int ifce, int btn, int mbut) {
         // otherwise, run interface_click
         if ((theObj->GetEventCount() > 0) &&
             (!theObj->EventHandlers[0].IsEmpty()) &&
-            (!gameinst->GetSymbolAddress(theObj->EventHandlers[0]).IsNull())) {
+            (!gameinst->GetSymbolAddress(theObj->EventHandlers[0].GetCStr()).IsNull())) {
                 // control-specific event handler
-                if (strchr(theObj->GetEventArgs(0), ',') != nullptr)
-                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0], 2,
+                if (strchr(theObj->GetEventArgs(0).GetCStr(), ',') != nullptr)
+                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0].GetCStr(), 2,
                         RuntimeScriptValue().SetDynamicObject(theObj, &ccDynamicGUIObject),
                         RuntimeScriptValue().SetInt32(mbut));
                 else
-                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0], 1,
+                    QueueScriptFunction(kScInstGame, theObj->EventHandlers[0].GetCStr(), 1,
                         RuntimeScriptValue().SetDynamicObject(theObj, &ccDynamicGUIObject));
         }
         else

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -68,7 +68,7 @@ void Hotspot_GetName(ScriptHotspot *hss, char *buffer) {
 }
 
 const char* Hotspot_GetName_New(ScriptHotspot *hss) {
-    return CreateNewScriptString(get_translation(thisroom.Hotspots[hss->id].Name));
+    return CreateNewScriptString(get_translation(thisroom.Hotspots[hss->id].Name.GetCStr()));
 }
 
 bool Hotspot_IsInteractionAvailable(ScriptHotspot *hhot, int mood) {

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -24,17 +24,17 @@ extern GameSetupStruct game;
 // ** LABEL FUNCTIONS
 
 const char* Label_GetText_New(GUILabel *labl) {
-    return CreateNewScriptString(labl->GetText());
+    return CreateNewScriptString(labl->GetText().GetCStr());
 }
 
 void Label_GetText(GUILabel *labl, char *buffer) {
-    strcpy(buffer, labl->GetText());
+    strcpy(buffer, labl->GetText().GetCStr());
 }
 
 void Label_SetText(GUILabel *labl, const char *newtx) {
     newtx = get_translation(newtx);
 
-    if (strcmp(labl->GetText(), newtx)) {
+    if (strcmp(labl->GetText().GetCStr(), newtx)) {
         guis_need_update = 1;
         labl->SetText(newtx);
     }

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -55,7 +55,7 @@ void ListBox_Clear(GUIListBox *listbox) {
 void FillDirList(std::set<String> &files, const String &path)
 {
     al_ffblk dfb;
-    int	dun = al_findfirst(path, &dfb, FA_SEARCH);
+    int	dun = al_findfirst(path.GetCStr(), &dfb, FA_SEARCH);
     while (!dun) {
         files.insert(dfb.name);
         dun = al_findnext(&dfb);
@@ -170,7 +170,7 @@ int ListBox_GetItemAtLocation(GUIListBox *listbox, int x, int y) {
 char *ListBox_GetItemText(GUIListBox *listbox, int index, char *buffer) {
   if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBoxGetItemText: invalid item specified");
-  strncpy(buffer, listbox->Items[index],198);
+  strncpy(buffer, listbox->Items[index].GetCStr(), 198);
   buffer[199] = 0;
   return buffer;
 }
@@ -179,14 +179,14 @@ const char* ListBox_GetItems(GUIListBox *listbox, int index) {
   if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBox.Items: invalid index specified");
 
-  return CreateNewScriptString(listbox->Items[index]);
+  return CreateNewScriptString(listbox->Items[index].GetCStr());
 }
 
 void ListBox_SetItemText(GUIListBox *listbox, int index, const char *newtext) {
   if ((index < 0) || (index >= listbox->ItemCount))
     quit("!ListBoxSetItemText: invalid item specified");
 
-  if (strcmp(listbox->Items[index], newtext)) {
+  if (strcmp(listbox->Items[index].GetCStr(), newtext)) {
     listbox->SetItemText(index, newtext);
     guis_need_update = 1;
   }

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -288,7 +288,7 @@ const char* Object_GetName_New(ScriptObject *objj) {
     if (!is_valid_object(objj->id))
         quit("!Object.Name: invalid object number");
 
-    return CreateNewScriptString(get_translation(thisroom.Objects[objj->id].Name));
+    return CreateNewScriptString(get_translation(thisroom.Objects[objj->id].Name.GetCStr()));
 }
 
 bool Object_IsInteractionAvailable(ScriptObject *oobj, int mood) {

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -72,7 +72,7 @@ int find_word_in_dictionary (const char *lookfor) {
         if ((lastletter == 's') || (lastletter == 'S') || (lastletter == '\'')) {
             String singular = lookfor;
             singular.ClipRight(1);
-            return find_word_in_dictionary(singular);
+            return find_word_in_dictionary(singular.GetCStr());
         } 
     }
     return -1;

--- a/Engine/ac/properties.cpp
+++ b/Engine/ac/properties.cpp
@@ -71,7 +71,7 @@ void get_text_property(const StringIMap &st_prop, const StringIMap &rt_prop, con
         return;
 
     String val = get_property_value(st_prop, rt_prop, property, desc.DefaultValue);
-    strcpy(bufer, val);
+    strcpy(bufer, val.GetCStr());
 }
 
 const char* get_text_property_dynamic_string(const StringIMap &st_prop, const StringIMap &rt_prop, const char *property)
@@ -81,7 +81,7 @@ const char* get_text_property_dynamic_string(const StringIMap &st_prop, const St
         return nullptr;
 
     String val = get_property_value(st_prop, rt_prop, property, desc.DefaultValue);
-    return CreateNewScriptString(val);
+    return CreateNewScriptString(val.GetCStr());
 }
 
 bool set_int_property(StringIMap &rt_prop, const char *property, int value)

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -210,7 +210,7 @@ const char* Room_GetMessages(int index) {
     }
     char buffer[STD_BUFFER_SIZE];
     buffer[0]=0;
-    replace_tokens(get_translation(thisroom.Messages[index]), buffer, STD_BUFFER_SIZE);
+    replace_tokens(get_translation(thisroom.Messages[index].GetCStr()), buffer, STD_BUFFER_SIZE);
     return CreateNewScriptString(buffer);
 }
 
@@ -484,7 +484,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     // load the room from disk
     our_eip=200;
     thisroom.GameID = NO_GAME_ID_IN_ROOM_FILE;
-    load_room(room_filename, &thisroom, game.IsLegacyHiRes(), game.SpriteInfos);
+    load_room(room_filename.GetCStr(), &thisroom, game.IsLegacyHiRes(), game.SpriteInfos);
 
     if ((thisroom.GameID != NO_GAME_ID_IN_ROOM_FILE) &&
         (thisroom.GameID != game.uniqueid)) {

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -93,7 +93,7 @@ int System_GetViewportWidth() {
 }
 
 const char *System_GetVersion() {
-    return CreateNewScriptString(EngineVersion.LongString);
+    return CreateNewScriptString(EngineVersion.LongString.GetCStr());
 }
 
 int System_GetHardwareAcceleration() 

--- a/Engine/ac/textbox.cpp
+++ b/Engine/ac/textbox.cpp
@@ -24,15 +24,15 @@ extern GameSetupStruct game;
 // ** TEXT BOX FUNCTIONS
 
 const char* TextBox_GetText_New(GUITextBox *texbox) {
-    return CreateNewScriptString(texbox->Text);
+    return CreateNewScriptString(texbox->Text.GetCStr());
 }
 
 void TextBox_GetText(GUITextBox *texbox, char *buffer) {
-    strcpy(buffer, texbox->Text);
+    strcpy(buffer, texbox->Text.GetCStr());
 }
 
 void TextBox_SetText(GUITextBox *texbox, const char *newtex) {
-    if (strcmp(texbox->Text, newtex)) {
+    if (strcmp(texbox->Text.GetCStr(), newtex)) {
         texbox->Text = newtex;
         guis_need_update = 1;
     }

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -88,11 +88,11 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
         if (quit_on_error)
         {
             parse_error.PrependChar('!');
-            quit(parse_error);
+            quit(parse_error.GetCStr());
         }
         else
         {
-            Debug::Printf(kDbgMsg_Error, parse_error);
+            Debug::Printf(kDbgMsg_Error, parse_error.GetCStr());
             if (!fallback_lang.IsEmpty())
             {
                 Debug::Printf("Fallback to translation: %s", fallback_lang.GetCStr());

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -469,7 +469,7 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
     if (pluginsWantingDebugHooks > 0) {
         // a plugin is handling the debugging
         String scname = GetScriptName(ccinst);
-        pl_run_plugin_debug_hooks(scname, linenum);
+        pl_run_plugin_debug_hooks(scname.GetCStr(), linenum);
         return;
     }
 

--- a/Engine/debug/logfile.cpp
+++ b/Engine/debug/logfile.cpp
@@ -48,10 +48,10 @@ void LogFile::PrintMessage(const DebugMessage &msg)
 
     if (!msg.GroupName.IsEmpty())
     {
-        _file->Write(msg.GroupName, msg.GroupName.GetLength());
+        _file->Write(msg.GroupName.GetCStr(), msg.GroupName.GetLength());
         _file->Write(" : ", 3);
     }
-    _file->Write(msg.Text, msg.Text.GetLength());
+    _file->Write(msg.Text.GetCStr(), msg.Text.GetLength());
     _file->WriteInt8('\n');
     // We should flush after every write to the log; this will make writing
     // bit slower, but will increase the chances that all latest output

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -750,7 +750,7 @@ PStream StartSavegame(const String &filename, const String &user_text, const Bit
     vistaHeader.dwThumbnailSize = 0;
     convert_guid_from_text_to_binary(game.guid, &vistaHeader.guidGameId[0]);
     uconvert(game.gamename, U_ASCII, (char*)&vistaHeader.szGameName[0], U_UNICODE, RM_MAXLENGTH);
-    uconvert(user_text, U_ASCII, (char*)&vistaHeader.szSaveName[0], U_UNICODE, RM_MAXLENGTH);
+    uconvert(user_text.GetCStr(), U_ASCII, (char*)&vistaHeader.szSaveName[0], U_UNICODE, RM_MAXLENGTH);
     vistaHeader.szLevelName[0] = 0;
     vistaHeader.szComments[0] = 0;
     // MS Windows Vista rich media header

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -119,22 +119,22 @@ bool GUIObject::IsClickable() const
 
 void GUILabel::PrepareTextToDraw()
 {
-    replace_macro_tokens(Flags & kGUICtrl_Translated ? String(get_translation(Text)) : Text, _textToDraw);
+    replace_macro_tokens(Flags & kGUICtrl_Translated ? String(get_translation(Text.GetCStr())) : Text, _textToDraw);
 }
 
 size_t GUILabel::SplitLinesForDrawing(SplitLines &lines)
 {
     // Use the engine's word wrap tool, to have hebrew-style writing and other features
-    return break_up_text_into_lines(_textToDraw, lines, Width, Font);
+    return break_up_text_into_lines(_textToDraw.GetCStr(), lines, Width, Font);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, color_t text_color)
 {
-    wouttext_outline(ds, X + 1 + get_fixed_pixel_size(1), Y + 1 + get_fixed_pixel_size(1), Font, text_color, Text);
+    wouttext_outline(ds, X + 1 + get_fixed_pixel_size(1), Y + 1 + get_fixed_pixel_size(1), Font, text_color, Text.GetCStr());
     if (IsGUIEnabled(this))
     {
         // draw a cursor
-        int draw_at_x = wgettextwidth(Text, Font) + X + 3;
+        int draw_at_x = wgettextwidth(Text.GetCStr(), Font) + X + 3;
         int draw_at_y = Y + 1 + getfontheight(Font);
         ds->DrawRect(Rect(draw_at_x, draw_at_y, draw_at_x + get_fixed_pixel_size(5), draw_at_y + (get_fixed_pixel_size(1) - 1)), text_color);
     }
@@ -153,7 +153,7 @@ void GUIListBox::DrawItemsUnfix()
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
     if (Flags & kGUICtrl_Translated)
-        _textToDraw = get_translation(text);
+        _textToDraw = get_translation(text.GetCStr());
     else
         _textToDraw = text;
 }
@@ -161,7 +161,7 @@ void GUIListBox::PrepareTextToDraw(const String &text)
 void GUIButton::PrepareTextToDraw()
 {
     if (Flags & kGUICtrl_Translated)
-        _textToDraw = get_translation(_text);
+        _textToDraw = get_translation(_text.GetCStr());
     else
         _textToDraw = _text;
 }

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -135,7 +135,7 @@ int loadgamedialog()
         else {
           toret = filenumbers[cursel];
           String path = get_save_game_path(toret);
-          strcpy(bufTemp, path);
+          strcpy(bufTemp, path.GetCStr());
           lpTemp = &bufTemp[0];
         }
       } else if (mes.id == ctrlcancel) {
@@ -257,7 +257,7 @@ int savegamedialog()
 
           toret = highestnum + 1;
           String path = get_save_game_path(toret);
-          strcpy(bufTemp, path);
+          strcpy(bufTemp, path.GetCStr());
         } 
         else {
           toret = filenumbers[cursell];
@@ -267,7 +267,7 @@ int savegamedialog()
         if (bufTemp[0] == 0)
         {
           String path = get_save_game_path(toret);
-          strcpy(bufTemp, path);
+          strcpy(bufTemp, path.GetCStr());
         }
 
         lpTemp = &bufTemp[0];

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -94,7 +94,7 @@ int INIreadint(const ConfigTree &cfg, const String &sectn, const String &item, i
     if (!INIreaditem(cfg, sectn, item, str))
         return def_value;
 
-    return atoi(str);
+    return atoi(str.GetCStr());
 }
 
 float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value)
@@ -103,7 +103,7 @@ float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &ite
     if (!INIreaditem(cfg, sectn, item, str))
         return def_value;
 
-    return atof(str);
+    return atof(str.GetCStr());
 }
 
 String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value)
@@ -300,7 +300,7 @@ String find_default_cfg_file(const char *alt_cfg_file)
         strcpy(conffilebuf, alt_cfg_file);
         fix_filename_case(conffilebuf);
         fix_filename_slashes(conffilebuf);
-        INIgetdirec(conffilebuf, DefaultConfigFileName);
+        INIgetdirec(conffilebuf, DefaultConfigFileName.GetCStr());
         filename = conffilebuf;
     }
     return filename;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -187,7 +187,7 @@ bool engine_run_setup(const String &exe_path, ConfigTree &cfg, int &app_res)
             allegro_exit();
             char quotedpath[MAX_PATH];
             snprintf(quotedpath, MAX_PATH, "\"%s\"", exe_path.GetCStr());
-            _spawnl (_P_OVERLAY, exe_path, quotedpath, NULL);
+            _spawnl (_P_OVERLAY, exe_path.GetCStr(), quotedpath, NULL);
     }
 #endif
     return true;
@@ -217,7 +217,7 @@ String find_game_data_in_directory(const String &path)
     String pattern = path;
     pattern.Append("/*");
 
-    if (al_findfirst(pattern, &ff, FA_ALL & ~(FA_DIREC)) != 0)
+    if (al_findfirst(pattern.GetCStr(), &ff, FA_ALL & ~(FA_DIREC)) != 0)
         return "";
     // Select first found data file; files with standart names (*.ags) have
     // higher priority over files with custom names.
@@ -1125,7 +1125,7 @@ void engine_init_game_settings()
 void engine_setup_scsystem_auxiliary()
 {
     // ScriptSystem::aci_version is only 10 chars long
-    strncpy(scsystem.aci_version, EngineVersion.LongString, 10);
+    strncpy(scsystem.aci_version, EngineVersion.LongString.GetCStr(), 10);
     if (usetup.override_script_os >= 0)
     {
         scsystem.os = usetup.override_script_os;
@@ -1218,7 +1218,7 @@ HError define_gamedata_location_checkall(const String &exe_path)
     // Read game data location from the default config file.
     // This is an optional setting that may instruct which game file to use as a primary asset library.
     ConfigTree cfg;
-    String def_cfg_file = find_default_cfg_file(exe_path);
+    String def_cfg_file = find_default_cfg_file(exe_path.GetCStr());
     IniUtil::Read(def_cfg_file, cfg);
     read_game_data_location(cfg);
     if (!usetup.main_data_filename.IsEmpty())
@@ -1293,7 +1293,7 @@ bool engine_init_gamedata(const String &exe_path)
 void engine_read_config(const String &exe_path, ConfigTree &cfg)
 {
     // Read default configuration file
-    String def_cfg_file = find_default_cfg_file(exe_path);
+    String def_cfg_file = find_default_cfg_file(exe_path.GetCStr());
     IniUtil::Read(def_cfg_file, cfg);
 
     // Disabled on Windows because people were afraid that this config could be mistakenly

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -392,7 +392,7 @@ void log_out_driver_modes(const int color_depth)
     }
     else
         out_str.Append("none");
-    Debug::Printf(out_str);
+    Debug::Printf(out_str.GetCStr());
 }
 
 // Create requested graphics driver and try to find and initialize compatible display mode as close to user setup as possible;

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -427,7 +427,7 @@ int ags_entry_point(int argc, char *argv[]) {
 
     if (justDisplayVersion)
     {
-        platform->WriteStdOut(get_engine_string());
+        platform->WriteStdOut(get_engine_string().GetCStr());
         return EXIT_NORMAL;
     }
 
@@ -441,7 +441,7 @@ int ags_entry_point(int argc, char *argv[]) {
         platform->SetGUIMode(true);
 
     init_debug(justTellInfo);
-    Debug::Printf(kDbgMsg_Init, get_engine_string());
+    Debug::Printf(kDbgMsg_Init, get_engine_string().GetCStr());
 
     main_set_gamedir(argc, argv);    
 

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -64,7 +64,7 @@ void quit_tell_editor_debugger(const String &qmsg, QuitReason qreason)
     if (editor_debugging_initialized)
     {
         if (qreason & kQuitKind_GameException)
-            handledErrorInEditor = send_exception_to_editor(qmsg);
+            handledErrorInEditor = send_exception_to_editor(qmsg.GetCStr());
         send_message_to_editor("EXIT");
         editor_debugger->Shutdown();
     }
@@ -288,7 +288,7 @@ void quit(const char *quitmsg)
 
     engine_shutdown_gfxmode();
 
-    quit_message_on_exit(qmsg, alertis, qreason);
+    quit_message_on_exit(qmsg.GetCStr(), alertis, qreason);
 
     quit_release_data();
 

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -305,7 +305,7 @@ SOUNDCLIP *my_load_mod(const AssetPath &asset_name, int repet)
 
     DUH *modPtr = nullptr;
     // determine the file extension
-    const char *lastDot = strrchr(asset_name.second, '.');
+    const char *lastDot = strrchr(asset_name.second.GetCStr(), '.');
     if (lastDot == nullptr)
     {
         dumbfile_close(df);

--- a/Engine/media/audio/soundcache.cpp
+++ b/Engine/media/audio/soundcache.cpp
@@ -110,7 +110,7 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
         if (sound_cache_entries[i].data == nullptr)
             continue;
 
-        if (strcmp(asset_name.second, sound_cache_entries[i].file_name) == 0)
+        if (strcmp(asset_name.second.GetCStr(), sound_cache_entries[i].file_name) == 0)
         {
 #ifdef SOUND_CACHE_DEBUG
             Debug::Printf("..found in slot %d\n", i);
@@ -223,8 +223,8 @@ char* get_cached_sound(const AssetPath &asset_name, bool is_wave, long* size)
 
         if (sound_cache_entries[i].file_name)
             free(sound_cache_entries[i].file_name);
-        sound_cache_entries[i].file_name = (char*)malloc(strlen(asset_name.second) + 1);
-        strcpy(sound_cache_entries[i].file_name, asset_name.second);
+        sound_cache_entries[i].file_name = (char*)malloc(strlen(asset_name.second.GetCStr()) + 1);
+        strcpy(sound_cache_entries[i].file_name, asset_name.second.GetCStr());
         sound_cache_entries[i].reference = 1;
         sound_cache_entries[i].last_used = sound_cache_counter++;
         sound_cache_entries[i].is_wave = is_wave;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -190,7 +190,7 @@ void play_flc_file(int numb,int playflags) {
     PACKFILE *pf = PackfileFromAsset(AssetPath("", flicname));
     if (play_fli_pf(pf, (BITMAP*)fli_buffer->GetAllegroBitmap(), fli_callback)==FLI_ERROR)
 #else
-    if (play_fli(flicname, (BITMAP*)fli_buffer->GetAllegroBitmap(), 0, fli_callback)==FLI_ERROR)
+    if (play_fli(flicname.GetCStr(), (BITMAP*)fli_buffer->GetAllegroBitmap(), 0, fli_callback)==FLI_ERROR)
 #endif
     {
         // This is not a fatal error that should prevent the game from continuing

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -126,7 +126,7 @@ const char *AGSLinux::GetAllUsersDataDirectory()
 const char *AGSLinux::GetUserSavedgamesDirectory()
 {
   DetermineDataDirectories();
-  return UserDataDirectory;
+  return UserDataDirectory.GetCStr();
 }
 
 const char *AGSLinux::GetUserConfigDirectory()
@@ -142,7 +142,7 @@ const char *AGSLinux::GetUserGlobalConfigDirectory()
 const char *AGSLinux::GetAppOutputDirectory()
 {
   DetermineDataDirectories();
-  return UserDataDirectory;
+  return UserDataDirectory.GetCStr();
 }
 
 unsigned long AGSLinux::GetDiskFreeSpaceMB() {

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -674,7 +674,7 @@ void DetermineAppOutputDirectory()
   {
     win32OutputDirectory = win32SavedGamesDirectory;
     win32OutputDirectory.Append("\\.ags");
-    log_to_saves_dir = mkdir(win32OutputDirectory) == 0 || errno == EEXIST;
+    log_to_saves_dir = mkdir(win32OutputDirectory.GetCStr()) == 0 || errno == EEXIST;
   }
 
   if (!log_to_saves_dir)
@@ -707,13 +707,13 @@ const char *AGSWin32::GetUserConfigDirectory()
 const char *AGSWin32::GetUserGlobalConfigDirectory()
 {
   DetermineAppOutputDirectory();
-  return win32OutputDirectory;
+  return win32OutputDirectory.GetCStr();
 }
 
 const char *AGSWin32::GetAppOutputDirectory()
 {
   DetermineAppOutputDirectory();
-  return win32OutputDirectory;
+  return win32OutputDirectory.GetCStr();
 }
 
 const char *AGSWin32::GetIllegalFileChars()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -701,7 +701,7 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   if (hr != D3D_OK)
   {
     if (!previousError.IsEmpty())
-      set_allegro_error(previousError);
+      set_allegro_error(previousError.GetCStr());
     else
       set_allegro_error("Failed to create Direct3D Device: 0x%08X", hr);
     return -1;

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -604,7 +604,7 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
         custom_save_dir = _winCfg.DataDirectory;
     SetCheck(_hCustomSaveDirCheck, has_save_dir);
     char full_save_dir[MAX_PATH] = {0};
-    MakeFullLongPath(custom_save_dir, full_save_dir, MAX_PATH);
+    MakeFullLongPath(custom_save_dir.GetCStr(), full_save_dir, MAX_PATH);
     SetText(_hCustomSaveDir, full_save_dir);
     EnableWindow(_hCustomSaveDir, has_save_dir ? TRUE : FALSE);
     EnableWindow(_hCustomSaveDirBtn, has_save_dir ? TRUE : FALSE);
@@ -618,17 +618,17 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
     if (_winCfg.GameResolution.IsNull())
         _winCfg.GameResolution = ResolutionTypeToSize(_winCfg.GameResType, _winCfg.LetterboxByDesign);
 
-    SetText(_hwnd, _winCfg.Title);
-    SetText(win_get_window(), _winCfg.Title);
+    SetText(_hwnd, _winCfg.Title.GetCStr());
+    SetText(win_get_window(), _winCfg.Title.GetCStr());
     SetText(_hGameResolutionText, String::FromFormat("Native game resolution: %d x %d x %d",
-        _winCfg.GameResolution.Width, _winCfg.GameResolution.Height, _winCfg.GameColourDepth));
+        _winCfg.GameResolution.Width, _winCfg.GameResolution.Height, _winCfg.GameColourDepth).GetCStr());
 
-    SetText(_hVersionText, _winCfg.VersionString);
+    SetText(_hVersionText, _winCfg.VersionString.GetCStr());
 
     InitGfxModes();
 
     for (DriverDescMap::const_iterator it = _drvDescMap.begin(); it != _drvDescMap.end(); ++it)
-        AddString(_hGfxDriverList, it->second->UserName, (DWORD_PTR)it->second->Id.GetCStr());
+        AddString(_hGfxDriverList, it->second->UserName.GetCStr(), (DWORD_PTR)it->second->Id.GetCStr());
     SetCurSelToItemDataStr(_hGfxDriverList, _winCfg.GfxDriverId.GetCStr(), 0);
     OnGfxDriverUpdate();
 
@@ -748,7 +748,7 @@ void WinSetupDialog::OnCustomSaveDirBtn()
     String save_dir = GetText(_hCustomSaveDir);
     if (BrowseForFolder(save_dir))
     {
-        SetText(_hCustomSaveDir, save_dir);
+        SetText(_hCustomSaveDir, save_dir.GetCStr());
     }
 }
 
@@ -906,7 +906,7 @@ void WinSetupDialog::AddScalingString(HWND hlist, int scaling_factor)
         s = String::FromFormat("x%d", scaling_factor);
     else
         s = String::FromFormat("1/%d", -scaling_factor);
-    AddString(hlist, s, (DWORD_PTR)(scaling_factor >= 0 ? scaling_factor + kNumFrameScaleDef : scaling_factor));
+    AddString(hlist, s.GetCStr(), (DWORD_PTR)(scaling_factor >= 0 ? scaling_factor + kNumFrameScaleDef : scaling_factor));
 }
 
 void WinSetupDialog::FillGfxFilterList()
@@ -923,10 +923,10 @@ void WinSetupDialog::FillGfxFilterList()
     {
         const GfxFilterInfo &info = _drvDesc->FilterList[i];
         if (INIreadint(_cfgIn, "disabled", info.Id, 0) == 0)
-            AddString(_hGfxFilterList, info.Name, (DWORD_PTR)info.Id.GetCStr());
+            AddString(_hGfxFilterList, info.Name.GetCStr(), (DWORD_PTR)info.Id.GetCStr());
     }
 
-    SetCurSelToItemDataStr(_hGfxFilterList, _winCfg.GfxFilterId, 0);
+    SetCurSelToItemDataStr(_hGfxFilterList, _winCfg.GfxFilterId.GetCStr(), 0);
     OnGfxFilterUpdate();
 }
 
@@ -957,16 +957,16 @@ void WinSetupDialog::FillGfxModeList()
             continue;
         }
         buf.Format("%d x %d", mode->Width, mode->Height);
-        AddString(_hGfxModeList, buf, (DWORD_PTR)(mode - modes.begin()));
+        AddString(_hGfxModeList, buf.GetCStr(), (DWORD_PTR)(mode - modes.begin()));
     }
 
     int spec_mode_idx = 0;
     if (has_desktop_mode)
         InsertString(_hGfxModeList, String::FromFormat("Desktop resolution (%d x %d)",
-            _desktopSize.Width, _desktopSize.Height), spec_mode_idx++, (DWORD_PTR)kGfxMode_Desktop);
+            _desktopSize.Width, _desktopSize.Height).GetCStr(), spec_mode_idx++, (DWORD_PTR)kGfxMode_Desktop);
     if (has_native_mode)
         InsertString(_hGfxModeList, String::FromFormat("Native game resolution (%d x %d)",
-            _winCfg.GameResolution.Width, _winCfg.GameResolution.Height), spec_mode_idx++, (DWORD_PTR)kGfxMode_GameRes);
+            _winCfg.GameResolution.Width, _winCfg.GameResolution.Height).GetCStr(), spec_mode_idx++, (DWORD_PTR)kGfxMode_GameRes);
 
     SelectNearestGfxMode(_winCfg.ScreenSize);
 }
@@ -979,7 +979,7 @@ void WinSetupDialog::FillLanguageList()
 
     String path_mask = String::FromFormat("%s\\*.tra", _winCfg.DataDirectory.GetCStr());
     WIN32_FIND_DATAA file_data;
-    HANDLE find_handle = FindFirstFile(path_mask, &file_data);
+    HANDLE find_handle = FindFirstFile(path_mask.GetCStr(), &file_data);
     if (find_handle != INVALID_HANDLE_VALUE)
     {
         bool found_sel = false;
@@ -1116,8 +1116,8 @@ void WinSetupDialog::SaveSetup()
         save_dir = GetText(_hCustomSaveDir);
         char full_data_dir[MAX_PATH] = {0};
         char full_save_dir[MAX_PATH] = {0};
-        MakeFullLongPath(_winCfg.DataDirectory, full_data_dir, MAX_PATH);
-        MakeFullLongPath(save_dir, full_save_dir, MAX_PATH);
+        MakeFullLongPath(_winCfg.DataDirectory.GetCStr(), full_data_dir, MAX_PATH);
+        MakeFullLongPath(save_dir.GetCStr(), full_save_dir, MAX_PATH);
         char rel_save_dir[MAX_PATH] = {0};
         if (PathRelativePathTo(rel_save_dir, full_data_dir, FILE_ATTRIBUTE_DIRECTORY, full_save_dir, FILE_ATTRIBUTE_DIRECTORY) &&
             strstr(rel_save_dir, "..") == NULL)
@@ -1230,7 +1230,7 @@ void WinSetupDialog::UpdateMouseSpeedText()
     int slider_pos = GetSliderPos(_hMouseSpeed);
     float mouse_speed = (float)slider_pos / 10.f;
     String text = mouse_speed == 1.f ? "Mouse speed: x 1.0 (Default)" : String::FromFormat("Mouse speed: x %0.1f", mouse_speed);
-    SetText(_hMouseSpeedText, text);
+    SetText(_hMouseSpeedText, text.GetCStr());
 }
 
 //=============================================================================

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -214,11 +214,11 @@ int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int i
     update_polled_mp3();
         if ((strstr(evblockbasename,"character")!=nullptr) || (strstr(evblockbasename,"inventory")!=nullptr)) {
             // Character or Inventory (global script)
-            QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt]);
+            QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt].GetCStr());
         }
         else {
             // Other (room script)
-            QueueScriptFunction(kScInstRoom, nint->ScriptFuncNames[evnt]);
+            QueueScriptFunction(kScInstRoom, nint->ScriptFuncNames[evnt].GetCStr());
         }
         update_polled_mp3();
 
@@ -523,7 +523,7 @@ char* make_ts_func_name(const char*base,int iii,int subd) {
 
 void post_script_cleanup() {
     // should do any post-script stuff here, like go to new room
-    if (ccError) quit(ccErrorString);
+    if (ccError) quit(ccErrorString.GetCStr());
     ExecutingScript copyof = scripts[num_scripts-1];
     if (scripts[num_scripts-1].forked)
         delete scripts[num_scripts-1].inst;
@@ -596,7 +596,7 @@ void post_script_cleanup() {
     for (jj = 0; jj < copyof.numanother; jj++) {
         old_room_number = displayed_room;
         QueuedScript &script = copyof.ScFnQueue[jj];
-        RunScriptFunction(script.Instance, script.FnName, script.ParamCount, script.Param1, script.Param2);
+        RunScriptFunction(script.Instance, script.FnName.GetCStr(), script.ParamCount, script.Param1, script.Param2);
         if (script.Instance == kScInstRoom && script.ParamCount == 1)
         {
             // some bogus hack for "on_call" event handler
@@ -644,11 +644,11 @@ InteractionVariable *get_interaction_variable (int varindx) {
 InteractionVariable *FindGraphicalVariable(const char *varName) {
     int ii;
     for (ii = 0; ii < numGlobalVars; ii++) {
-        if (ags_stricmp (globalvars[ii].Name, varName) == 0)
+        if (ags_stricmp (globalvars[ii].Name.GetCStr(), varName) == 0)
             return &globalvars[ii];
     }
     for (size_t i = 0; i < thisroom.LocalVariables.size(); ++i) {
-        if (ags_stricmp (thisroom.LocalVariables[i].Name, varName) == 0)
+        if (stricmp (thisroom.LocalVariables[i].Name.GetCStr(), varName) == 0)
             return &thisroom.LocalVariables[i];
     }
     return nullptr;

--- a/Engine/util/library_posix.h
+++ b/Engine/util/library_posix.h
@@ -103,7 +103,7 @@ public:
       sprintf(buffer, "%s%s", android_app_directory, "/lib");
       _library = dlopen(BuildPath(buffer, libraryName).GetCStr(), RTLD_LAZY);
 #else
-      _library = dlopen(BuildPath(appDirectory, libraryName).GetCStr(), RTLD_LAZY);
+      _library = dlopen(BuildPath(appDirectory.GetCStr(), libraryName).GetCStr(), RTLD_LAZY);
 #endif
 
       AGS::Common::Debug::Printf("dlopen returned: %s", dlerror());


### PR DESCRIPTION
From past conversations I think we want to be explicit when converting AGS Strings to `const char*`, this PR picks up a previous commit in a different branch where Sonneveld did this, and additionally put the explicit conversion in more places.
