### PR TITLE
3.5.1: Configurable log options

### DIFF
--- a/Common/debug/debugmanager.cpp
+++ b/Common/debug/debugmanager.cpp
@@ -58,6 +58,21 @@ void DebugOutput::SetGroupFilter(DebugGroupID id, MessageType verbosity)
         _unresolvedGroups.insert(std::make_pair(id.SID, verbosity));
 }
 
+void DebugOutput::SetAllGroupFilters(MessageType verbosity)
+{
+    for (auto &group : _groupFilter)
+        group = verbosity;
+    for (auto &group : _unresolvedGroups)
+        group.second = verbosity;
+}
+
+void DebugOutput::ClearGroupFilters()
+{
+    for (auto &gf : _groupFilter)
+        gf = kDbgMsg_None;
+    _unresolvedGroups.clear();
+}
+
 void DebugOutput::ResolveGroupID(DebugGroupID id)
 {
     if (!id.IsValid())

--- a/Common/debug/debugmanager.cpp
+++ b/Common/debug/debugmanager.cpp
@@ -82,7 +82,7 @@ bool DebugOutput::TestGroup(DebugGroupID id,  MessageType mt) const
     DebugGroupID real_id = DbgMgr.GetGroup(id).UID;
     if (real_id.ID == kDbgGroup_None || real_id.ID >= _groupFilter.size())
         return false;
-    return (_groupFilter[real_id.ID] & mt) != 0;
+    return (_groupFilter[real_id.ID] >= mt) != 0;
 }
 
 DebugManager::DebugManager()

--- a/Common/debug/debugmanager.h
+++ b/Common/debug/debugmanager.h
@@ -64,7 +64,7 @@ struct DebugGroup
 class DebugOutput
 {
 public:
-    DebugOutput(const String &id, IOutputHandler *handler, MessageType def_verbosity = kDbgMsgSet_All, bool enabled = true);
+    DebugOutput(const String &id, IOutputHandler *handler, MessageType def_verbosity = kDbgMsg_All, bool enabled = true);
 
     String          GetID() const;
     IOutputHandler *GetHandler() const;
@@ -110,7 +110,7 @@ public:
     DebugGroup RegisterGroup(const String &id, const String &out_name);
     // Registers output delegate for passing debug messages to;
     // if the output with such id already exists, replaces the old one
-    PDebugOutput RegisterOutput(const String &id, IOutputHandler *handler, MessageType def_verbosity = kDbgMsgSet_All, bool enabled = true);
+    PDebugOutput RegisterOutput(const String &id, IOutputHandler *handler, MessageType def_verbosity = kDbgMsg_All, bool enabled = true);
     // Unregisters all groups and all targets
     void UnregisterAll();
     // Unregisters debugging group with the given ID

--- a/Common/debug/debugmanager.h
+++ b/Common/debug/debugmanager.h
@@ -73,6 +73,10 @@ public:
     void            SetEnabled(bool enable);
     // Setup group filter: either allow or disallow a group with the given ID
     void            SetGroupFilter(DebugGroupID id, MessageType verbosity);
+    // Assign same verbosity level to all known groups
+    void            SetAllGroupFilters(MessageType verbosity);
+    // Clear all group filters; this efficiently disables everything
+    void            ClearGroupFilters();
     // Try to resolve group filter unknown IDs
     void            ResolveGroupID(DebugGroupID id);
     // Test if given group id is permitted

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -80,30 +80,27 @@ namespace Common
 enum MessageType
 {
     kDbgMsg_None                = 0,
-    // Initialization messages, notify about certain engine components
-    // being created and important modes initialized.
-    kDbgMsg_Init                = 0x0001,
-    // Debug reason is for arbitrary information about events and current
-    // game state
-    kDbgMsg_Debug               = 0x0002,
-    // Warnings are made when unexpected or non-standart behavior
-    // is detected in program, which is not immediately critical,
-    // but may be a symptom of a bigger problem.
-    kDbgMsg_Warn                = 0x0004,
+    // Fatal errors are ones that make program abort immediately
+    kDbgMsg_Fatal               ,
     // Error messages are about engine not being able to perform requested
     // operation in a situation when that will affect game playability and
     // further execution.
-    kDbgMsg_Error               = 0x0008,
-    // Fatal errors are ones that make program abort immediately
-    kDbgMsg_Fatal               = 0x0010,
+    kDbgMsg_Error               ,
+    // Warnings are made when unexpected or non-standart behavior
+    // is detected in program, which is not immediately critical,
+    // but may be a symptom of a bigger problem.
+    kDbgMsg_Warn                ,
+    // Initialization messages, notify about certain engine components
+    // being created and important modes initialized.
+    kDbgMsg_Init                ,
+    // Debug reason is for arbitrary information about events and current
+    // game state.
+    kDbgMsg_Debug               ,
+
 
     // Convenient aliases
     kDbgMsg_Default             = kDbgMsg_Debug,
-    kDbgMsgSet_NoDebug          = 0x001D,
-    kDbgMsgSet_Errors           = 0x0018,
-    kDbgMsgSet_InitAndErrors    = 0x0019,
-    // Output everything
-    kDbgMsgSet_All              = 0xFFFF
+    kDbgMsg_All                 = kDbgMsg_Debug
 };
 
 // This enumeration is a list of common hard-coded groups, but more could

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -35,18 +35,15 @@
 // distinct them from reports on the internal engine's problems and make
 // verbosity configuration flexible.
 //
-// kDbgMsg_Init - is a type for startup initialization notifications; use them
-// when declaring that certain component got initialized (or not initialized),
-// optionally noting working mode, where applicable. Such messages are intended
-// for core engine components and plugin startup only, not work modes and game
-// states that are normally changing during gameplay.
-//
-// kDbgMsg_Debug - is the most common type of message (if the printing function
+// kDbgMsg_Debug - is the most mundane type of message (if the printing function
 // argument list does not specify message type, it is probably kDbgMsg_Debug).
 // You can use it for almost anything, from noting some process steps to
 // displaying current object state. If certain messages are meant to be printed
 // very often, consider using another distinct debug group so that it may be
 // disabled to reduce log verbosity.
+//
+// kDbgMsg_Info - is a type for important notifications, such as initialization
+// and stopping of engine components.
 //
 // kDbgMsg_Warn - this is suggested for more significant cases, when you find
 // out that something is not right, but is not immediately affecting engine
@@ -80,7 +77,10 @@ namespace Common
 enum MessageType
 {
     kDbgMsg_None                = 0,
-    // Fatal errors are ones that make program abort immediately
+    // Alerts may be informative messages with topmost level of importance,
+    // such as reporting engine startup and shutdown.
+    kDbgMsg_Alert               ,
+    // Fatal errors are ones that make program abort immediately.
     kDbgMsg_Fatal               ,
     // Error messages are about engine not being able to perform requested
     // operation in a situation when that will affect game playability and
@@ -90,9 +90,8 @@ enum MessageType
     // is detected in program, which is not immediately critical,
     // but may be a symptom of a bigger problem.
     kDbgMsg_Warn                ,
-    // Initialization messages, notify about certain engine components
-    // being created and important modes initialized.
-    kDbgMsg_Init                ,
+    // General information messages.
+    kDbgMsg_Info                ,
     // Debug reason is for arbitrary information about events and current
     // game state.
     kDbgMsg_Debug               ,

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -739,7 +739,7 @@ HError ReadGUI(std::vector<GUIMain> &guis, Stream *in, bool is_savegame)
         return new Error("ReadGUI: unknown format or file is corrupt");
 
     GameGuiVersion = (GuiVersion)in->ReadInt32();
-    Debug::Printf(kDbgMsg_Init, "Game GUI version: %d", GameGuiVersion);
+    Debug::Printf(kDbgMsg_Info, "Game GUI version: %d", GameGuiVersion);
     size_t gui_count;
     if (GameGuiVersion < kGuiVersion_214)
     {

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -114,12 +114,12 @@ void init_pathfinder(GameDataVersion game_file_version)
 {
     if (game_file_version >= kGameVersion_350) 
     {
-        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Init, "Initialize path finder library");
+        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Info, "Initialize path finder library");
         route_finder_impl = new AGSRouteFinder();
     } 
     else 
     {
-        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Init, "Initialize legacy path finder library");
+        AGS::Common::Debug::Printf(AGS::Common::MessageType::kDbgMsg_Info, "Initialize legacy path finder library");
         route_finder_impl = new AGSLegacyRouteFinder();
     }
 

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -103,14 +103,14 @@ void init_debug(bool stderr_only)
     if (stderr_only)
     {
         PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-        std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_Errors);
+        std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Error);
         platform->SetOutputToErr(true);
         return;
     }
     DebugMsgBuff.reset(new MessageBuffer());
-    DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsgSet_All);
+    DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsg_All);
     PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_InitAndErrors);
+    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Init);
 }
 
 void apply_debug_config(const ConfigTree &cfg)
@@ -118,17 +118,17 @@ void apply_debug_config(const ConfigTree &cfg)
     if (INIreadint(cfg, "misc", "log", 0) != 0)
     {
         DebugLogFile.reset(new LogFile());
-        PDebugOutput file_out = DbgMgr.RegisterOutput(OutputFileID, DebugLogFile.get(), kDbgMsgSet_All);
+        PDebugOutput file_out = DbgMgr.RegisterOutput(OutputFileID, DebugLogFile.get(), kDbgMsg_All);
 #ifdef DEBUG_SPRITECACHE
-        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_All);
+        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsg_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsgSet_InitAndErrors);
+        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsg_Init);
 #endif
-        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_InitAndErrors);
+        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsg_Init);
 #ifdef DEBUG_MANAGED_OBJECTS
-        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_All);
+        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsg_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsgSet_InitAndErrors);
+        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsg_Init);
 #endif
         String logfile_path = platform->GetAppOutputDirectory();
         logfile_path.Append("/ags.log");
@@ -180,9 +180,9 @@ void debug_set_console(bool enable)
     if (enable && DebugConsole.get() == nullptr)
     {
         DebugConsole.reset(new ConsoleOutputTarget());
-        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsgSet_InitAndErrors);
-        gmcs_out->SetGroupFilter(kDbgGroup_Main, kDbgMsgSet_All);
-        gmcs_out->SetGroupFilter(kDbgGroup_Script, kDbgMsgSet_All);
+        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsg_Init);
+        gmcs_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_All);
+        gmcs_out->SetGroupFilter(kDbgGroup_Script, kDbgMsg_All);
         if (DebugMsgBuff.get())
             DebugMsgBuff->Send(OutputGameConsoleID);
     }

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -110,7 +110,7 @@ void init_debug(bool stderr_only)
     DebugMsgBuff.reset(new MessageBuffer());
     DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsg_All);
     PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Init);
+    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Info);
 }
 
 void apply_debug_config(const ConfigTree &cfg)
@@ -122,13 +122,13 @@ void apply_debug_config(const ConfigTree &cfg)
 #ifdef DEBUG_SPRITECACHE
         file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsg_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsg_Init);
+        file_out->SetGroupFilter(kDbgGroup_SprCache, kDbgMsg_Info);
 #endif
-        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsg_Init);
+        file_out->SetGroupFilter(kDbgGroup_Script, kDbgMsg_Info);
 #ifdef DEBUG_MANAGED_OBJECTS
         file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsg_All);
 #else
-        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsg_Init);
+        file_out->SetGroupFilter(kDbgGroup_ManObj, kDbgMsg_Info);
 #endif
         String logfile_path = platform->GetAppOutputDirectory();
         logfile_path.Append("/ags.log");
@@ -180,7 +180,7 @@ void debug_set_console(bool enable)
     if (enable && DebugConsole.get() == nullptr)
     {
         DebugConsole.reset(new ConsoleOutputTarget());
-        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsg_Init);
+        PDebugOutput gmcs_out = DbgMgr.RegisterOutput(OutputGameConsoleID, DebugConsole.get(), kDbgMsg_Info);
         gmcs_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_All);
         gmcs_out->SetGroupFilter(kDbgGroup_Script, kDbgMsg_All);
         if (DebugMsgBuff.get())

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -95,21 +95,6 @@ const String OutputFileID = "file";
 const String OutputSystemID = "stdout";
 const String OutputGameConsoleID = "console";
 
-void init_debug(bool stderr_only)
-{
-    // Register outputs
-    if (stderr_only)
-    {
-        PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-        std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Error);
-        platform->SetOutputToErr(true);
-        return;
-    }
-    DebugMsgBuff.reset(new MessageBuffer());
-    DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsg_All);
-    PDebugOutput std_out = DbgMgr.RegisterOutput(OutputSystemID, AGSPlatformDriver::GetDriver(), kDbgMsg_None);
-    std_out->SetGroupFilter(kDbgGroup_Main, kDbgMsg_Info);
-}
 
 
 PDebugOutput create_log_output(const String &name, const String &path = "", LogFile::OpenMode open_mode = LogFile::kLogFile_Overwrite)
@@ -232,6 +217,20 @@ void apply_log_config(const ConfigTree &cfg, const String &log_id,
     // Delegate buffered messages to this new output
     if (DebugMsgBuff && !was_created_earlier)
         DebugMsgBuff->Send(log_id);
+}
+
+void init_debug(const ConfigTree &cfg, bool stderr_only)
+{
+    // Register outputs
+    apply_debug_config(cfg);
+    platform->SetOutputToErr(stderr_only);
+
+    if (stderr_only)
+        return;
+
+    // Message buffer to save all messages in case we read different log settings from config file
+    DebugMsgBuff.reset(new MessageBuffer());
+    DbgMgr.RegisterOutput(OutputMsgBufID, DebugMsgBuff.get(), kDbgMsg_All);
 }
 
 void apply_debug_config(const ConfigTree &cfg)

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -18,6 +18,7 @@
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/runtime_defines.h"
+#include "debug/agseditordebugger.h"
 #include "debug/debug_log.h"
 #include "debug/debugger.h"
 #include "debug/debugmanager.h"
@@ -27,13 +28,13 @@
 #include "debug/messagebuffer.h"
 #include "main/config.h"
 #include "media/audio/audio_system.h"
+#include "platform/base/agsplatformdriver.h"
 #include "plugin/plugin_engine.h"
 #include "script/script.h"
 #include "script/script_common.h"
 #include "script/cc_error.h"
+#include "util/string_utils.h"
 #include "util/textstreamwriter.h"
-#include "platform/base/agsplatformdriver.h"
-#include "debug/agseditordebugger.h"
 
 #if AGS_PLATFORM_OS_WINDOWS
 #include <winalleg.h>
@@ -155,6 +156,10 @@ std::vector<String> parse_log_multigroup(const String &group_str)
 
 MessageType get_messagetype_from_string(const String &mt)
 {
+    int mtype;
+    if (StrUtil::StringToInt(mt, mtype, 0) == StrUtil::kNoError)
+        return (MessageType)mtype;
+
     if (mt.CompareNoCase("alert") == 0) return kDbgMsg_Alert;
     else if (mt.CompareNoCase("fatal") == 0) return kDbgMsg_Fatal;
     else if (mt.CompareNoCase("error") == 0) return kDbgMsg_Error;

--- a/Engine/debug/debug_log.h
+++ b/Engine/debug/debug_log.h
@@ -21,7 +21,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "util/ini_util.h"
 
-void init_debug(bool stderr_only);
+void init_debug(const AGS::Common::ConfigTree &cfg, bool stderr_only);
 void apply_debug_config(const AGS::Common::ConfigTree &cfg);
 void shutdown_debug();
 

--- a/Engine/debug/logfile.cpp
+++ b/Engine/debug/logfile.cpp
@@ -26,7 +26,7 @@ namespace Engine
 using namespace Common;
 
 LogFile::LogFile()
-    : _openMode(kLogFile_OpenOverwrite)
+    : _openMode(kLogFile_Overwrite)
 {
 }
 
@@ -59,19 +59,19 @@ void LogFile::PrintMessage(const DebugMessage &msg)
     _file->Flush();
 }
 
-bool LogFile::OpenFile(const String &file_path, LogFileOpenMode open_mode, bool open_at_first_msg)
+bool LogFile::OpenFile(const String &file_path, OpenMode open_mode)
 {
     CloseFile();
 
     _filePath = file_path;
     _openMode = open_mode;
-    if (!open_at_first_msg)
+    if (open_mode != OpenMode::kLogFile_OverwriteAtFirstMessage)
     {
         _file.reset(File::OpenFile(file_path,
-                           open_mode == kLogFile_OpenAppend ? Common::kFile_Create : Common::kFile_CreateAlways,
+                           open_mode == kLogFile_Append ? Common::kFile_Create : Common::kFile_CreateAlways,
                            Common::kFile_Write));
     }
-    return _file.get() != nullptr || open_at_first_msg;
+    return _file.get() != nullptr || open_mode == OpenMode::kLogFile_OverwriteAtFirstMessage;
 }
 
 void LogFile::CloseFile()

--- a/Engine/debug/logfile.h
+++ b/Engine/debug/logfile.h
@@ -42,10 +42,11 @@ using Common::String;
 class LogFile : public AGS::Common::IOutputHandler
 {
 public:
-    enum LogFileOpenMode
+    enum OpenMode
     {
-        kLogFile_OpenOverwrite,
-        kLogFile_OpenAppend
+        kLogFile_Overwrite,
+        kLogFile_OverwriteAtFirstMessage,
+        kLogFile_Append
     };
 
 public:
@@ -61,15 +62,14 @@ public:
     // useful information. Whether this is to be determined here or on
     // high-level side remains a question.
     //
-    bool         OpenFile(const String &file_path, LogFileOpenMode open_mode = kLogFile_OpenOverwrite,
-                          bool open_at_first_msg = false);
+    bool         OpenFile(const String &file_path, OpenMode open_mode = kLogFile_Overwrite);
         // Close file
     void         CloseFile();
 
 private:
         std::unique_ptr<Stream> _file;
         String                _filePath;
-        LogFileOpenMode       _openMode;
+        OpenMode              _openMode;
 };
 
 }   // namespace Engine

--- a/Engine/debug/messagebuffer.cpp
+++ b/Engine/debug/messagebuffer.cpp
@@ -49,7 +49,7 @@ void MessageBuffer::Send(const String &out_id)
     {
         DebugGroup gr = DbgMgr.GetGroup(kDbgGroup_Main);
         DbgMgr.SendMessage(out_id, DebugMessage(String::FromFormat("WARNING: output %s lost exceeding buffer: %u debug messages\n", out_id.GetCStr(), (unsigned)_msgLost),
-            gr.UID.ID, gr.OutputName, kDbgMsgSet_All));
+            gr.UID.ID, gr.OutputName, kDbgMsg_All));
     }
     for (std::vector<DebugMessage>::const_iterator it = _buffer.begin(); it != _buffer.end(); ++it)
     {

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -358,7 +358,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
         // TODO: find a way to either automate this list of strings or make it more visible (shared & easier to find in engine code)
         // TODO: stack-allocated strings, here and in other similar places
         const String scapi_names[kScriptAPI_Current + 1] = {"v3.2.1", "v3.3.0", "v3.3.4", "v3.3.5", "v3.4.0", "v3.4.1", "v3.5.0", "v3.5.0.7"};
-        Debug::Printf(kDbgMsg_Init, "Requested script API: %s (%d), compat level: %s (%d)",
+        Debug::Printf(kDbgMsg_Info, "Requested script API: %s (%d), compat level: %s (%d)",
                     base_api >= 0 && base_api <= kScriptAPI_Current ? scapi_names[base_api].GetCStr() : "unknown", base_api,
                     compat_api >= 0 && compat_api <= kScriptAPI_Current ? scapi_names[compat_api].GetCStr() : "unknown", compat_api);
     }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -336,7 +336,7 @@ void OGLGraphicsDriver::FirstTimeInit()
 #else
   ogl_v_str = (const char*)glGetString(GL_VERSION);
 #endif
-  Debug::Printf(kDbgMsg_Init, "Running OpenGL: %s", ogl_v_str.GetCStr());
+  Debug::Printf(kDbgMsg_Info, "Running OpenGL: %s", ogl_v_str.GetCStr());
 
   // Initialize default sprite batch, it will be used when no other batch was activated
   OGLGraphicsDriver::InitSpriteBatch(0, _spriteBatchDesc[0]);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -108,7 +108,7 @@ t_engine_pre_init_callback engine_pre_init_callback = nullptr;
 
 bool engine_init_allegro()
 {
-    Debug::Printf(kDbgMsg_Init, "Initializing allegro");
+    Debug::Printf(kDbgMsg_Info, "Initializing allegro");
 
     our_eip = -199;
     // Initialize allegro
@@ -141,7 +141,7 @@ void winclosehook() {
 
 void engine_setup_window()
 {
-    Debug::Printf(kDbgMsg_Init, "Setting up window");
+    Debug::Printf(kDbgMsg_Info, "Setting up window");
 
     our_eip = -198;
     set_window_title("Adventure Game Studio");
@@ -165,7 +165,7 @@ bool engine_run_setup(const String &exe_path, ConfigTree &cfg, int &app_res)
                 return false;
             }
 
-            Debug::Printf(kDbgMsg_Init, "Running Setup");
+            Debug::Printf(kDbgMsg_Info, "Running Setup");
 
             ConfigTree cfg_out;
             SetupReturnValue res = platform->RunSetup(cfg, cfg_out);
@@ -309,7 +309,7 @@ bool search_for_game_data_file(String &filename, String &search_path)
         return false;
     }
     filename = Path::MakeAbsolutePath(filename);
-    Debug::Printf(kDbgMsg_Init, "Located game data file: %s", filename.GetCStr());
+    Debug::Printf(kDbgMsg_Info, "Located game data file: %s", filename.GetCStr());
     return true;
 }
 
@@ -328,7 +328,7 @@ bool engine_try_init_gamedata(String gamepak_path)
 
 void engine_init_fonts()
 {
-    Debug::Printf(kDbgMsg_Init, "Initializing TTF renderer");
+    Debug::Printf(kDbgMsg_Info, "Initializing TTF renderer");
 
     init_font_renderer();
 }
@@ -337,9 +337,9 @@ void engine_init_mouse()
 {
     int res = minstalled();
     if (res < 0)
-        Debug::Printf(kDbgMsg_Init, "Initializing mouse: failed");
+        Debug::Printf(kDbgMsg_Info, "Initializing mouse: failed");
     else
-        Debug::Printf(kDbgMsg_Init, "Initializing mouse: number of buttons reported is %d", res);
+        Debug::Printf(kDbgMsg_Info, "Initializing mouse: number of buttons reported is %d", res);
     Mouse::SetSpeed(usetup.mouse_speed);
 }
 
@@ -364,7 +364,7 @@ void engine_locate_speech_pak()
                 int lipsync_fmt = speechsync->ReadInt32();
                 if (lipsync_fmt != 4)
                 {
-                    Debug::Printf(kDbgMsg_Init, "Unknown speech lip sync format (%d).\nLip sync disabled.", lipsync_fmt);
+                    Debug::Printf(kDbgMsg_Info, "Unknown speech lip sync format (%d).\nLip sync disabled.", lipsync_fmt);
                 }
                 else {
                     numLipLines = speechsync->ReadInt32();
@@ -382,13 +382,13 @@ void engine_locate_speech_pak()
                 delete speechsync;
             }
             AssetManager::SetDataFile(ResPaths.GamePak.Path); // switch back to the main data pack
-            Debug::Printf(kDbgMsg_Init, "Voice pack found and initialized.");
+            Debug::Printf(kDbgMsg_Info, "Voice pack found and initialized.");
             play.want_speech=1;
         }
         else if (Path::ComparePaths(ResPaths.DataDir, get_voice_install_dir()) != 0)
         {
             // If we have custom voice directory set, we will enable voice-over even if speech.vox does not exist
-            Debug::Printf(kDbgMsg_Init, "Voice pack was not found, but voice installation directory is defined: enabling voice-over.");
+            Debug::Printf(kDbgMsg_Info, "Voice pack was not found, but voice installation directory is defined: enabling voice-over.");
             play.want_speech=1;
         }
         ResPaths.SpeechPak.Name = speech_file;
@@ -406,7 +406,7 @@ void engine_locate_audio_pak()
         if (AssetManager::SetDataFile(music_filepath) == kAssetNoError)
         {
             AssetManager::SetDataFile(ResPaths.GamePak.Path);
-            Debug::Printf(kDbgMsg_Init, "%s found and initialized.", music_file.GetCStr());
+            Debug::Printf(kDbgMsg_Info, "%s found and initialized.", music_file.GetCStr());
             play.separate_music_lib = 1;
             ResPaths.AudioPak.Name = music_file;
             ResPaths.AudioPak.Path = music_filepath;
@@ -422,7 +422,7 @@ void engine_locate_audio_pak()
 void engine_init_keyboard()
 {
 #ifdef ALLEGRO_KEYBOARD_HANDLER
-    Debug::Printf(kDbgMsg_Init, "Initializing keyboard");
+    Debug::Printf(kDbgMsg_Info, "Initializing keyboard");
 
     install_keyboard();
 #endif
@@ -433,14 +433,14 @@ void engine_init_keyboard()
 
 void engine_init_timer()
 {
-    Debug::Printf(kDbgMsg_Init, "Install timer");
+    Debug::Printf(kDbgMsg_Info, "Install timer");
 
     skipMissedTicks();
 }
 
 bool try_install_sound(int digi_id, int midi_id, String *p_err_msg = nullptr)
 {
-    Debug::Printf(kDbgMsg_Init, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
+    Debug::Printf(kDbgMsg_Info, "Trying to init: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
         AlIDToChars(digi_id).s, digi_id, AlIDToChars(midi_id).s, midi_id);
 
     if (install_sound(digi_id, midi_id, nullptr) == 0)
@@ -516,7 +516,7 @@ void engine_init_audio()
     if (usetup.mod_player)
         digi_voices = NUM_DIGI_VOICES;
 
-    Debug::Printf(kDbgMsg_Init, "Sound settings: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
+    Debug::Printf(kDbgMsg_Info, "Sound settings: digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
         AlIDToChars(digi_id).s, digi_id, AlIDToChars(midi_id).s, midi_id);
 
     // First try if drivers are supported, and switch to autodetect if explicit option failed
@@ -560,7 +560,7 @@ void engine_init_audio()
     usetup.digicard = digi_card;
     usetup.midicard = midi_card;
 
-    Debug::Printf(kDbgMsg_Init, "Installed digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
+    Debug::Printf(kDbgMsg_Info, "Installed digital driver ID: '%s' (0x%x), MIDI driver ID: '%s' (0x%x)",
         AlIDToChars(digi_card).s, digi_card, AlIDToChars(midi_card).s, midi_card);
 
     if (digi_card == DIGI_NONE)
@@ -612,7 +612,7 @@ void atexit_handler() {
 
 void engine_init_exit_handler()
 {
-    Debug::Printf(kDbgMsg_Init, "Install exit handler");
+    Debug::Printf(kDbgMsg_Info, "Install exit handler");
 
     atexit(atexit_handler);
 }
@@ -673,22 +673,22 @@ void engine_init_title()
 {
     our_eip=-91;
     set_window_title(game.gamename);
-    Debug::Printf(kDbgMsg_Init, "Game title: '%s'", game.gamename);
+    Debug::Printf(kDbgMsg_Info, "Game title: '%s'", game.gamename);
 }
 
 void engine_init_directories()
 {
-    Debug::Printf(kDbgMsg_Init, "Data directory: %s", usetup.data_files_dir.GetCStr());
+    Debug::Printf(kDbgMsg_Info, "Data directory: %s", usetup.data_files_dir.GetCStr());
     if (!usetup.install_dir.IsEmpty())
-        Debug::Printf(kDbgMsg_Init, "Optional install directory: %s", usetup.install_dir.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Optional install directory: %s", usetup.install_dir.GetCStr());
     if (!usetup.install_audio_dir.IsEmpty())
-        Debug::Printf(kDbgMsg_Init, "Optional audio directory: %s", usetup.install_audio_dir.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Optional audio directory: %s", usetup.install_audio_dir.GetCStr());
     if (!usetup.install_voice_dir.IsEmpty())
-        Debug::Printf(kDbgMsg_Init, "Optional voice-over directory: %s", usetup.install_voice_dir.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Optional voice-over directory: %s", usetup.install_voice_dir.GetCStr());
     if (!usetup.user_data_dir.IsEmpty())
-        Debug::Printf(kDbgMsg_Init, "User data directory: %s", usetup.user_data_dir.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "User data directory: %s", usetup.user_data_dir.GetCStr());
     if (!usetup.shared_data_dir.IsEmpty())
-        Debug::Printf(kDbgMsg_Init, "Shared data directory: %s", usetup.shared_data_dir.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Shared data directory: %s", usetup.shared_data_dir.GetCStr());
 
     ResPaths.DataDir = usetup.data_files_dir;
     ResPaths.GamePak.Path = usetup.main_data_filepath;
@@ -766,7 +766,7 @@ int check_write_access() {
 
 int engine_check_disk_space()
 {
-    Debug::Printf(kDbgMsg_Init, "Checking for disk space");
+    Debug::Printf(kDbgMsg_Info, "Checking for disk space");
 
     if (check_write_access()==0) {
         platform->DisplayAlert("Unable to write in the savegame directory.\n%s", platform->GetDiskWriteAccessTroubleshootingText());
@@ -796,7 +796,7 @@ void engine_init_modxm_player()
         usetup.mod_player = 0;
 
     if (usetup.mod_player) {
-        Debug::Printf(kDbgMsg_Init, "Initializing MOD/XM player");
+        Debug::Printf(kDbgMsg_Info, "Initializing MOD/XM player");
 
         if (init_mod_player(NUM_MOD_DIGI_VOICES) < 0) {
             platform->DisplayAlert("Warning: install_mod: MOD player failed to initialize.");
@@ -805,7 +805,7 @@ void engine_init_modxm_player()
     }
 #else
     usetup.mod_player = 0;
-    Debug::Printf(kDbgMsg_Init, "Compiled without MOD/XM player");
+    Debug::Printf(kDbgMsg_Info, "Compiled without MOD/XM player");
 #endif
 }
 
@@ -845,7 +845,7 @@ void show_preload()
 
 int engine_init_sprites()
 {
-    Debug::Printf(kDbgMsg_Init, "Initialize sprites");
+    Debug::Printf(kDbgMsg_Info, "Initialize sprites");
 
     HError err = spriteset.InitFile(SpriteCache::DefaultSpriteFileName, SpriteCache::DefaultSpriteIndexName);
     if (!err) 
@@ -1152,17 +1152,17 @@ void engine_start_multithreaded_audio()
   {
     if (!audioThread.CreateAndStart(engine_update_mp3_thread, true))
     {
-      Debug::Printf(kDbgMsg_Init, "Failed to start audio thread, audio will be processed on the main thread");
+      Debug::Printf(kDbgMsg_Info, "Failed to start audio thread, audio will be processed on the main thread");
       psp_audio_multithreaded = 0;
     }
     else
     {
-      Debug::Printf(kDbgMsg_Init, "Audio thread started");
+      Debug::Printf(kDbgMsg_Info, "Audio thread started");
     }
   }
   else
   {
-    Debug::Printf(kDbgMsg_Init, "Audio is processed on the main thread");
+    Debug::Printf(kDbgMsg_Info, "Audio is processed on the main thread");
   }
 }
 
@@ -1271,7 +1271,7 @@ bool define_gamedata_location(const String &exe_path)
 // Find and preload main game data
 bool engine_init_gamedata(const String &exe_path)
 {
-    Debug::Printf(kDbgMsg_Init, "Initializing game data");
+    Debug::Printf(kDbgMsg_Info, "Initializing game data");
     if (!define_gamedata_location(exe_path))
         return false;
     if (!engine_try_init_gamedata(usetup.main_data_filepath))
@@ -1322,7 +1322,7 @@ void engine_read_config(const String &exe_path, ConfigTree &cfg)
 // Gathers settings from all available sources into single ConfigTree
 void engine_prepare_config(ConfigTree &cfg, const String &exe_path, const ConfigTree &startup_opts)
 {
-    Debug::Printf(kDbgMsg_Init, "Setting up game configuration");
+    Debug::Printf(kDbgMsg_Info, "Setting up game configuration");
     // Read configuration files
     engine_read_config(exe_path, cfg);
     // Merge startup options in

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -132,7 +132,7 @@ void engine_init_resolution_settings(const Size game_size)
     Debug::Printf("Initializing resolution settings");
     usetup.textheight = getfontheight_outlined(0) + 1;
 
-    Debug::Printf(kDbgMsg_Init, "Game native resolution: %d x %d (%d bit)%s", game_size.Width, game_size.Height, game.color_depth * 8,
+    Debug::Printf(kDbgMsg_Info, "Game native resolution: %d x %d (%d bit)%s", game_size.Width, game_size.Height, game.color_depth * 8,
         game.IsLegacyLetterbox() ? " letterbox-by-design" : "");
 
     convert_gui_to_game_resolution(loaded_game_file_version);
@@ -291,7 +291,7 @@ void engine_post_gfxmode_mouse_setup(const DisplayMode &dm, const Size &init_des
     }
 
     Mouse_EnableControl(usetup.mouse_ctrl_enabled);
-    Debug::Printf(kDbgMsg_Init, "Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",
+    Debug::Printf(kDbgMsg_Info, "Mouse control: %s, base: %f, speed: %f", Mouse::IsControlEnabled() ? "on" : "off",
         Mouse::GetSpeedUnit(), Mouse::GetSpeed());
 
     on_coordinates_scaling_changed();

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -89,13 +89,13 @@ HGameFileError game_file_first_open(MainGameSource &src)
         err->Code() == kMGFErr_FormatVersionNotSupported)
     {
         // Log data description for debugging
-        Debug::Printf(kDbgMsg_Init, "Opened game data file: %s", src.Filename.GetCStr());
-        Debug::Printf(kDbgMsg_Init, "Game data version: %d", src.DataVersion);
-        Debug::Printf(kDbgMsg_Init, "Compiled with: %s", src.CompiledWith.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Opened game data file: %s", src.Filename.GetCStr());
+        Debug::Printf(kDbgMsg_Info, "Game data version: %d", src.DataVersion);
+        Debug::Printf(kDbgMsg_Info, "Compiled with: %s", src.CompiledWith.GetCStr());
         if (src.Caps.size() > 0)
         {
             String caps_list = get_caps_list(src.Caps);
-            Debug::Printf(kDbgMsg_Init, "Requested engine caps: %s", caps_list.GetCStr());
+            Debug::Printf(kDbgMsg_Info, "Requested engine caps: %s", caps_list.GetCStr());
         }
     }
     // Quit in case of error

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -141,8 +141,8 @@ void initialize_start_and_play_game(int override_start_room, const char *loadSav
         if (override_start_room)
             playerchar->room = override_start_room;
 
-        Debug::Printf(kDbgMsg_Init, "Engine initialization complete");
-        Debug::Printf(kDbgMsg_Init, "Starting game");
+        Debug::Printf(kDbgMsg_Info, "Engine initialization complete");
+        Debug::Printf(kDbgMsg_Info, "Starting game");
 
         start_game_init_editor_debugging();
 

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -482,7 +482,7 @@ bool graphics_mode_init_any(const Size game_size, const ScreenSetup &setup, cons
     const bool ignore_device_ratio = setup.DisplayMode.Windowed || scsz.SizeDef == kScreenDef_Explicit;
     GameFrameSetup gameframe = setup.DisplayMode.Windowed ? setup.WinGameFrame : setup.FsGameFrame;
     const String scale_option = make_scaling_option(gameframe);
-    Debug::Printf(kDbgMsg_Init, "Graphic settings: driver: %s, windowed: %s, screen def: %s, screen size: %d x %d, match device ratio: %s, game scale: %s",
+    Debug::Printf(kDbgMsg_Info, "Graphic settings: driver: %s, windowed: %s, screen def: %s, screen size: %d x %d, match device ratio: %s, game scale: %s",
         setup.DriverID.GetCStr(),
         setup.DisplayMode.Windowed ? "yes" : "no", screen_sz_def_options[scsz.SizeDef],
         scsz.Size.Width, scsz.Size.Height,

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -328,8 +328,15 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "-noscript") == 0) debug_flags |= DBG_NOSCRIPT;
         else if (ags_stricmp(arg, "-novideo") == 0) debug_flags |= DBG_NOVIDEO;
         else if (ags_stricmp(arg, "-dbgscript") == 0) debug_flags |= DBG_DBGSCRIPT;
-        else if (ags_stricmp(arg, "--log") == 0) INIwriteint(cfg, "misc", "log", 1);
-        else if (ags_stricmp(arg, "--no-log") == 0) INIwriteint(cfg, "misc", "log", 0);
+        else if (ags_strnicmp(arg, "--log-", 6) == 0 && arg[6] != 0)
+        {
+            String logarg = arg + 6;
+            size_t split_at = logarg.FindChar('=');
+            if (split_at >= 0)
+                cfg["log"][logarg.Left(split_at)] = logarg.Mid(split_at + 1);
+            else
+                cfg["log"][logarg] = "";
+        }
         else if (ags_stricmp(arg, "--console-attach") == 0) attachToParentConsole = true;
         else if (ags_stricmp(arg, "--no-message-box") == 0) hideMessageBoxes = true;
         //
@@ -440,7 +447,7 @@ int ags_entry_point(int argc, char *argv[]) {
     if (!justTellInfo && !hideMessageBoxes)
         platform->SetGUIMode(true);
 
-    init_debug(justTellInfo);
+    init_debug(startup_opts, justTellInfo);
     Debug::Printf(kDbgMsg_Alert, get_engine_string());
 
     main_set_gamedir(argc, argv);    

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -441,7 +441,7 @@ int ags_entry_point(int argc, char *argv[]) {
         platform->SetGUIMode(true);
 
     init_debug(justTellInfo);
-    Debug::Printf(kDbgMsg_Init, get_engine_string());
+    Debug::Printf(kDbgMsg_Alert, get_engine_string());
 
     main_set_gamedir(argc, argv);    
 

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -175,6 +175,7 @@ extern char return_to_room[150];
 void main_print_help() {
     platform->WriteStdOut(
         "Usage: ags [OPTIONS] [GAMEFILE or DIRECTORY]\n\n"
+          //--------------------------------------------------------------------------------|
            "Options:\n"
 #if AGS_PLATFORM_OS_WINDOWS
            "  --console-attach             Write output to the parent process's console\n"
@@ -187,15 +188,33 @@ void main_print_help() {
 #else
            "                                 ogl, software\n"
 #endif
-           "  --gfxfilter <filter> [<scaling>]\n"
+           "  --gfxfilter FILTER [SCALING]\n"
            "                               Request graphics filter. Available options:\n"           
            "                                 hqx, linear, none, stdscale\n"
            "                                 (support differs between graphic drivers);\n"
            "                                 scaling is specified by integer number\n"
            "  --help                       Print this help message and stop\n"
-           "  --log                        Enable program output to the log file\n"
-           "  --no-log                     Disable program output to the log file,\n"
-           "                                 overriding configuration file setting\n"
+           "  --log-OUTPUT=GROUP[:LEVEL][,GROUP[:LEVEL]][,...]\n"
+           "  --log-OUTPUT=+GROUPLIST[:LEVEL]\n"
+           "                               Setup logging to the chosen OUTPUT with given\n"
+           "                               log groups and verbosity levels. Groups may\n"
+           "                               be also defined by a LIST of one-letter IDs,\n"
+           "                               preceded by '+', e.g. +ABCD:LEVEL. Verbosity may\n"
+           "                               be also defined by a numberic ID.\n"
+           "                               OUTPUTs are\n"
+           "                                 stdout, file, console\n"
+           "                               (where \"console\" is internal engine's console)\n"
+           "                               GROUPs are:\n"
+           "                                 all, main (m), script (s), sprcache (c),\n"
+           "                                 manobj (o)\n"
+           "                               LEVELs are:\n"
+           "                                 all, alert (1), fatal (2), error (3), warn (4),\n"
+           "                                 info (5), debug (6)\n"
+           "                               Examples:\n"
+           "                                 --log-stdout=+msco:debug\n"
+           "                                 --log-file=all:warn\n"
+           "  --log-file-path=PATH         Define custom path for the log file\n"
+          //--------------------------------------------------------------------------------|
 #if AGS_PLATFORM_OS_WINDOWS
            "  --no-message-box             Disable reporting of alerts to message boxes\n"
            "  --setup                      Run setup application\n"
@@ -215,6 +234,7 @@ void main_print_help() {
            "  /dir/path/game/              Launch the game in specified directory\n"
            "  /dir/path/game/penguin.exe   Launch penguin.exe\n"
            "  [nothing]                    Launch the game in the current directory\n"
+          //--------------------------------------------------------------------------------|
     );
 }
 

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -305,7 +305,7 @@ void quit(const char *quitmsg)
 
     proper_exit=1;
 
-    Debug::Printf(kDbgMsg_Init, "***** ENGINE HAS SHUTDOWN");
+    Debug::Printf(kDbgMsg_Alert, "***** ENGINE HAS SHUTDOWN");
 
     shutdown_debug();
 

--- a/Engine/platform/windows/win_ex_handling.cpp
+++ b/Engine/platform/windows/win_ex_handling.cpp
@@ -63,7 +63,7 @@ int initialize_engine_with_exception_handling(
 {
     __try
     {
-        Debug::Printf(kDbgMsg_Init, "Installing exception handler");
+        Debug::Printf(kDbgMsg_Info, "Installing exception handler");
         return initialize_engine(startup_opts);
     }
     __except (CustomExceptionHandler(GetExceptionInformation()))

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -1045,7 +1045,7 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
         String expect_filename = apl->library.GetFilenameForLib(apl->filename);
         if (apl->library.Load(apl->filename))
         {
-          AGS::Common::Debug::Printf(kDbgMsg_Init, "Plugin '%s' loaded as '%s', resolving imports...", apl->filename, expect_filename.GetCStr());
+          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' loaded as '%s', resolving imports...", apl->filename, expect_filename.GetCStr());
 
           if (apl->library.GetFunctionAddress("AGS_PluginV2") == nullptr) {
               quitprintf("Plugin '%s' is an old incompatible version.", apl->filename);
@@ -1062,19 +1062,19 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
         }
         else
         {
-          AGS::Common::Debug::Printf(kDbgMsg_Init, "Plugin '%s' could not be loaded (expected '%s'), trying built-in plugins...",
+          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' could not be loaded (expected '%s'), trying built-in plugins...",
               apl->filename, expect_filename.GetCStr());
           if (pl_use_builtin_plugin(apl))
           {
-            AGS::Common::Debug::Printf(kDbgMsg_Init, "Build-in plugin '%s' found and being used.", apl->filename);
+            AGS::Common::Debug::Printf(kDbgMsg_Info, "Build-in plugin '%s' found and being used.", apl->filename);
           }
           else
           {
             // Plugin loading has failed at this point, try using built-in plugin function stubs
             if (RegisterPluginStubs((const char*)apl->filename))
-              AGS::Common::Debug::Printf(kDbgMsg_Init, "Placeholder functions for the plugin '%s' found.", apl->filename);
+              AGS::Common::Debug::Printf(kDbgMsg_Info, "Placeholder functions for the plugin '%s' found.", apl->filename);
             else
-              AGS::Common::Debug::Printf(kDbgMsg_Init, "No placeholder functions for the plugin '%s' found. The game might fail to load!", apl->filename);
+              AGS::Common::Debug::Printf(kDbgMsg_Info, "No placeholder functions for the plugin '%s' found. The game might fail to load!", apl->filename);
             continue;
           }
         }


### PR DESCRIPTION
This is done as a preliminary step for #640.

**As a preface**, engine logging system in a nutshell works like this:
* each message has a "verbosity level" ranging from "debug" to "fatal error".
* there may be a number of message groups, which allow to separate messages related to a component or engine's function (main, script, spritecache, managed pool);
* there may be a number of outputs (stdout, log file, in-game console); each output has its own filter settings, that define which groups & level of messages to let through.

When a message is sent to logging system it tries each registered output implementation, and if its filter allows, message is being printed.

---


**What this PR does**: it actually allows to configure these filters by user (player).

A new section called "[log]" is introduced to the user config. It may have a number of entries - one for each log output - which define a list of filters for that output. These entries have a common syntax:

`output_id = group1:level, group2:level, etc`

where `output_id` is output's name, and entry value is a list of "group name" : "message level" pairs.

Group names may be full names or short 1-letter IDs. **NOTE:** in the latter case these IDs may be put in groups but must be preceded by '+' symbol (e.g. `+msco` - prints groups `m`,`s`,`c` and `o`).
Message level (verbosity) may be level name, or corresponding number (see below).

Possible outputs at this moment are:
* `stdout` - standard output (system console, etc)
* `file` - regular log file
* `console` - in-game console

Possible log groups:
* `main` (m) - default group for most of messages
* `script` (s) - script API messages
* `sprcache` (c) - verbose sprite cache messages (currently not available unless engine is built with DEBUG_SPRITECACHE)
* `manobj` (o) - managed objects / pool log, very verbose! (currently not available unless engine is built with DEBUG_MANAGED_OBJECTS)

Possible message levels:
* `alert` (1) - most important messages (like engine version info and startup/shutdown notification)
* `fatal` (2) - fatal errors
* `error` (3) - any errors
* `warn` (4) - warnings
* `info` (5) - general notifications
* `debug` (6) - verbose debugging messages
* `all` - all messages (which equals to `debug` level actually)

---

**Examples of config:**

<pre>
[log]
stdout = main:info, script:error
file = main:all, script:all
</pre>
Print only important notifications and script API errors to stdout (system console), print everything from main and script groups into file, and use default settings for in-game console.

