### PR TITLE
Engine: addresses positioning bug with custom text window GUI

### DIFF
--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -172,6 +172,10 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
     // inform draw_text_window to free the old bitmap
     const bool wantFreeScreenop = true;
 
+    // may later change if usingGUI, needed to avoid changing original coordinates
+    int adjustedXX = xx;
+    int adjustedYY = yy;
+
     if ((strlen (todis) < 1) || (strcmp (todis, "  ") == 0) || (wii == 0)) ;
     // if it's an empty speech line, don't draw anything
     else if (asspch) { //text_color = ds->GetCompatibleColor(12);
@@ -190,7 +194,7 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
         if (drawBackground)
         {
-            draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &ttxleft, &ttxtop, &xx, &yy, &wii, &text_color, 0, usingGui);
+            draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &ttxleft, &ttxtop, &adjustedXX, &adjustedYY, &wii, &text_color, 0, usingGui);
             if (usingGui > 0)
             {
                 alphaChannel = guis[usingGui].HasAlphaChannel();
@@ -241,6 +245,13 @@ int _display_main(int xx,int yy,int wii,const char*text,int blocking,int usingfo
 
     int nse = add_screen_overlay(xx, yy, ovrtype, text_window_ds, alphaChannel);
     // we should not delete text_window_ds here, because it is now owned by Overlay
+
+
+    // uses an internal offset since we prevented draw_text_window_and_bar from changing
+    // the original values
+    screenover[nse]._offsetX = adjustedXX - xx;
+    screenover[nse]._offsetY = adjustedYY - yy;
+
 
     if (blocking>=2) {
         return screenover[nse].type;

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1398,7 +1398,7 @@ void ReadOverlays_Aligned(Stream *in)
     AlignedStream align_s(in, Common::kAligned_Read);
     for (auto &over : screenover)
     {
-        over.ReadFromFile(&align_s);
+        over.ReadFromFile(&align_s, 0);
         align_s.Reset();
     }
 }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -243,8 +243,10 @@ void get_overlay_position(const ScreenOverlay &over, int *x, int *y) {
         }
     }
     else {
-        tdxp = over.x;
-        tdyp = over.y;
+        // Note: the internal offset is only needed when x,y coordinates are specified
+        // and only in the case where the overlay is using a GUI. See issue #1098
+        tdxp = over.x + over._offsetX;
+        tdyp = over.y + over._offsetY;
 
         if (!over.positionRelativeToScreen)
         {

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -17,7 +17,7 @@
 
 using AGS::Common::Stream;
 
-void ScreenOverlay::ReadFromFile(Stream *in)
+void ScreenOverlay::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
     // Skipping bmp and pic pointer values
     // TODO: find out if it's safe to just drop these pointers!! replace with unique_ptr?
@@ -33,6 +33,11 @@ void ScreenOverlay::ReadFromFile(Stream *in)
     associatedOverlayHandle = in->ReadInt32();
     hasAlphaChannel = in->ReadBool();
     positionRelativeToScreen = in->ReadBool();
+    if (cmp_ver >= 1)
+    {
+        _offsetX = in->ReadInt32();
+        _offsetY = in->ReadInt32();
+    }
 }
 
 void ScreenOverlay::WriteToFile(Stream *out) const
@@ -48,4 +53,7 @@ void ScreenOverlay::WriteToFile(Stream *out) const
     out->WriteInt32(associatedOverlayHandle);
     out->WriteBool(hasAlphaChannel);
     out->WriteBool(positionRelativeToScreen);
+    // since cmp_ver = 1
+    out->WriteInt32(_offsetX);
+    out->WriteInt32(_offsetY);
 }

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -18,6 +18,8 @@
 #ifndef __AGS_EE_AC__SCREENOVERLAY_H
 #define __AGS_EE_AC__SCREENOVERLAY_H
 
+#include <stdint.h>
+
 // Forward declaration
 namespace AGS { namespace Common { class Bitmap; class Stream; } }
 namespace AGS { namespace Engine { class IDriverDependantBitmap; }}
@@ -33,8 +35,9 @@ struct ScreenOverlay {
     bool hasAlphaChannel = false;
     bool positionRelativeToScreen = false;
     bool hasSerializedBitmap = false;
+    int _offsetX = 0, _offsetY = 0;
 
-    void ReadFromFile(Common::Stream *in);
+    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -841,7 +841,7 @@ HSaveError ReadOverlays(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
     for (size_t i = 0; i < over_count; ++i)
     {
         ScreenOverlay over;
-        over.ReadFromFile(in.get());
+        over.ReadFromFile(in.get(), cmp_ver);
         if (over.hasSerializedBitmap)
             over.pic = read_serialized_bitmap(in.get());
         screenover.push_back(over);
@@ -1190,7 +1190,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Overlays",
-        0,
+        1,
         0,
         WriteOverlays,
         ReadOverlays


### PR DESCRIPTION
Introduces an internal x,y offset so the original coordinates are not lost due to adjustments for image borders.

Fixes #1098