### PR TITLE
adds install target to cmake for ags on Linux

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -602,6 +602,9 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/.. PREFIX "Source Files" FILES ${E
 # -----------------------------------------------------------------------------
 
 add_executable(ags)
+if (LINUX)
+    install(TARGETS ags RUNTIME DESTINATION bin)
+endif ()
 
 set_target_properties(ags PROPERTIES
     CXX_STANDARD 11


### PR DESCRIPTION
- installs ags on `/usr/local/bin/` on Linux systems by using `sudo make install` on the makefile that was generated by cmake. 
- you can override the directory by passing a different install prefix when generating the makefile, like `-DCMAKE_INSTALL_PREFIX=/home/user/.local/` and the binary `ags` will go inside a directory named `bin/` in that prefix.

Having a install target would greatly simplify building ags snap package.