### PR TITLE
Script should serialize back empty imports as empty strings.

### DIFF
--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -45,6 +45,15 @@ void freadstring(char **strptr, Stream *in)
     strcpy(strptr[0], ibuffer);
 }
 
+void fwritestring(const char *strptr, Stream *out)
+{
+    if(strptr == nullptr){
+        out->WriteByte(0);
+    } else {
+        out->Write(strptr, strlen(strptr) + 1);
+    }
+}
+
 ccScript *ccScript::CreateFromStream(Stream *in)
 {
     ccScript *scri = new ccScript();
@@ -208,15 +217,15 @@ void ccScript::Write(Stream *out) {
     }
     out->WriteInt32(numimports);
     for (n=0;n<numimports;n++)
-        out->WriteArray(imports[n],strlen(imports[n])+1,1);
+        fwritestring(imports[n], out);
     out->WriteInt32(numexports);
     for (n=0;n<numexports;n++) {
-        out->WriteArray(exports[n],strlen(exports[n])+1,1);
+        fwritestring(exports[n], out);
         out->WriteInt32(export_addr[n]);
     }
     out->WriteInt32(numSections);
     for (n = 0; n < numSections; n++) {
-        out->WriteArray(sectionNames[n], strlen(sectionNames[n]) + 1, 1);
+        fwritestring(sectionNames[n], out);
         out->WriteInt32(sectionOffsets[n]);
     }
     out->WriteInt32(ENDFILESIG);


### PR DESCRIPTION
- When engine resolves script imports, empty string imports are expected to be `nullptr`.
  [`Engine/script/cc_instance.cpp#L1591`](https://github.com/adventuregamestudio/ags/blob/c52217180969576717173777d8ac195dd4347047/Engine/script/cc_instance.cpp#L1591)
- This works because when reading script objects, empty strings (a single `\0` character) are replaced by a `nullptr`.
  [`Common/script/cc_script.cpp#L39`](https://github.com/adventuregamestudio/ags/blob/c52217180969576717173777d8ac195dd4347047/Common/script/cc_script.cpp#L39)
- When writing a script object, we don't treat the `nullptr` case, so if you read a script object, and want to write it back to a file, it breaks on empty strings.
  [`Common/script/cc_script.cpp#L211`](https://github.com/adventuregamestudio/ags/blob/c52217180969576717173777d8ac195dd4347047/Common/script/cc_script.cpp#L211)
- Currently Compiler only produces empty string for each unused import.

The fix proposed here is to simply treat this case of `nullptr` when writing the script object :

```C++
if(imports[n]== nullptr){
    out->WriteArray("\0", 1, 1);
} else {
    out->WriteArray(imports[n], strlen(imports[n]) + 1, 1);
}
```

This should not change nothing currently but is needed for a compiled script that is serialized, and then de-serialized, can be serialized back, which happens when updating the script object of a `room.crm` file. 

If this change is not applied, the original line `out->WriteArray(imports[n], strlen(imports[n]) + 1, 1)` will crash because `imports[n] == nullptr` when `n` leads to an de-serialized empty string.

This or other fix so a ccScript can be written back once read is necessary for the future compiler tools.