### PR TITLE
[WIP] minor fixes for future Engine in 64-bit windows builds

### DIFF
--- a/Engine/platform/windows/media/video/acwavi3d.cpp
+++ b/Engine/platform/windows/media/video/acwavi3d.cpp
@@ -184,7 +184,7 @@ CVMR9Graph::CVMR9Graph(HWND MediaWindow, IDirect3DDevice9 *device, int NumberOfS
 	}
 
   //m_pD3DDevice = device;
-  m_oldWndProc = GetWindowLong(m_hMediaWindow, GWL_WNDPROC);
+  m_oldWndProc = GetWindowLongPtr(m_hMediaWindow, GWLP_WNDPROC);
 }
 
 // Function name	: CVMR9Graph::~CVMR9Graph
@@ -193,7 +193,7 @@ CVMR9Graph::CVMR9Graph(HWND MediaWindow, IDirect3DDevice9 *device, int NumberOfS
 CVMR9Graph::~CVMR9Graph()
 {
 	ReleaseAllInterfaces();
-  long newProc = GetWindowLong(m_hMediaWindow, GWL_WNDPROC);
+  long newProc = GetWindowLongPtr(m_hMediaWindow, GWLP_WNDPROC);
 }
 
 

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -1240,7 +1240,7 @@ void WinSetupDialog::UpdateMouseSpeedText()
 //=============================================================================
 void SetWinIcon()
 {
-    SetClassLong(win_get_window(),GCL_HICON,
+    SetClassLongPtr(win_get_window(),GCLP_HICON,
         (LONG) LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON))); 
 }
 


### PR DESCRIPTION
Gave a little try at 64 bit Windows builds and picked these. The replacing functions are compatible with both 32-bit and 64-bit builds. 

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlonga
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptra
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclasslonga
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclasslongptra

Note for anyone attempting 64-bit Windows builds: after these, and changing the Directx9 paths to use 64bit, it will build. These other changes are not interesting at this point in time, so I didn't want to add in this PR.