### PR TITLE
Editor: Add some validation tools and validate game filename

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -331,6 +331,7 @@
     <Compile Include="GUI\ProjectTree.cs" />
     <Compile Include="GUI\ProjectTreeItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\Validation.cs" />
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>
       <DependentUpon>frmMain.cs</DependentUpon>

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
+using AGS.Editor.Utils;
 using AGS.Types;
 using WeifenLuo.WinFormsUI.Docking;
 
@@ -523,7 +524,7 @@ namespace AGS.Editor.Components
                 return;
             }
 
-            if (!Utilities.DoesFileNameContainOnlyValidCharacters(renamedScript.FileName))
+            if (!Validation.FilenameIsValid(renamedScript.FileName))
             {
                 _guiController.ShowMessage("The file name '" + renamedScript.FileName + "' contains some invalid characters. You cannot use some characters like : and / in script file names.", MessageBoxIcon.Warning);
                 renamedScript.FileName = oldScriptName;

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -223,21 +223,6 @@ namespace AGS.Editor
             File.SetAttributes(destFileName, FileAttributes.Archive);
         }
 
-        public static bool DoesFileNameContainOnlyValidCharacters(string fileName)
-        {
-            foreach (char c in fileName)
-            {
-                foreach (char invalidChar in Path.GetInvalidFileNameChars())
-                {
-                    if (invalidChar == c)
-                    {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        }
-
         public static void CopyFont(int fromSlot, int toSlot)
         {
             if (fromSlot == toSlot)

--- a/Editor/AGS.Editor/Utils/Validation.cs
+++ b/Editor/AGS.Editor/Utils/Validation.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AGS.Editor.Utils
+{
+    public class Validation
+    {
+        public static bool FilenameIsValid(string filename)
+        {
+            return !(filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0);
+        }
+
+        public static bool PathIsAvailable(string path)
+        {
+            if (File.Exists(path))
+                return false;
+
+            if (Directory.Exists(path))
+                return false;
+
+            return true;
+        }
+
+        public static bool PathIsAbsoluteDriveLetter(string path)
+        {
+            return Regex.IsMatch(path, @"^[a-zA-Z]:\\");
+        }
+
+        public static bool PathIsAbsolute(string path)
+        {
+            bool rooted = false;
+
+            try
+            {
+                rooted = Path.IsPathRooted(path);
+            }
+            catch (ArgumentException)
+            {
+                // pass
+            }
+
+            return rooted;
+        }
+
+        public static bool PathIsValid(string path)
+        {
+            return !(path.IndexOfAny(Path.GetInvalidPathChars()) >= 0);
+        }
+
+        public static bool StringIsAsciiCharactersOnly(string fileName)
+        {
+            return !fileName.Any(c => c > 127);
+        }
+    }
+}

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -159,7 +160,25 @@ namespace AGS.Types
         public string GameFileName
         {
             get { return _gameFileName; }
-            set { _gameFileName = value; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException("Game file name cannot be empty");
+                }
+
+                if (value.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                {
+                    throw new ArgumentException("Game file name contains invalid characters");
+                }
+
+                if (value.Any(c => c > 127))
+                {
+                    throw new ArgumentException("Game file name should only contain letters and numbers");
+                }
+
+                _gameFileName = value;
+            }
         }
 
         [DisplayName(PROPERTY_GAME_NAME)]


### PR DESCRIPTION
Fixes #1090 (although since the error handling for the settings panel is in AGS.Types some logic is duplicated)

Adds a struct and support functions for passing error and warning information. Messages are just strings and immutable in transit, the idea being that a single front-end validation may invoke and aggregate messages from delegated validation functions. The resulting message should be suitable to show underneath an input field which incorporates dynamic checks.

For alternative/legacy use of the same validation functions, the same struct can still be used (built in messages don't have to be used).

``` c#
// ValidationResult evalulates as a boolean

if (Project.CanBeProjectDirectory(path))
{
  // everything is fine
}
else
{
  // handle the problem
}
```

There is a message formatting function built into the struct so that if all you have for error handling is a message box the formatting logic doesn't need to be re-implemented where the validation functions are called.

``` c#
// Show error messages with a context string prepended

var vr = Project.CanBeProjectDirectory(path)

if (!vr)
{
    ShowMessage(vr.Message("Project directory"))
    return false;
}
```

You can also just access messages directly. This is the only way to access warning messages, since a warning does not invalidate.

``` c#
// Get message strings directly

var vr = Project.CanBeProjectDirectory(path)

if (vr.HasErrors)
{
    foreach (string error in vr.Errors)
    {
        BuildErrorState(error)
    }
}

if (vr.HasWarnings)
{
    foreach (string warning in vr.Warnings)
    {
        ConfirmThisIsWhatYouMeantToDo(warning)
    }
}
```
