### PR TITLE
Engine: Add required '#include <cstdio>' for gcc 10

### DIFF
--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include <vector>
 #include <alfont.h>
 #include "ac/common.h" // set_our_eip

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "ac/audiocliptype.h"
 #include "ac/dialogtopic.h"
 #include "ac/gamesetupstruct.h"

--- a/Engine/ac/global_debug.h
+++ b/Engine/ac/global_debug.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__GLOBALDEBUG_H
 #define __AGS_EE_AC__GLOBALDEBUG_H
 
+#include <cstdio>
 #include "util/string.h"
 
 AGS::Common::String GetRuntimeInfo();

--- a/Engine/ac/global_display.cpp
+++ b/Engine/ac/global_display.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include <stdarg.h>
 #include "ac/common.h"
 #include "ac/character.h"

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "ac/gui.h"
 #include "ac/common.h"
 #include "ac/draw.h"

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -13,6 +13,7 @@
 //=============================================================================
 
 #include <cctype> //isalnum()
+#include <cstdio>
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "ac/string.h"
 #include "ac/common.h"
 #include "ac/display.h"

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "ac/asset_helper.h"
 #include "ac/common.h"
 #include "ac/gamesetup.h"

--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "debug/filebasedagsdebugger.h"
 #include "ac/file.h"                    // filelength()
 #include "util/stream.h"

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include "gui/guidialog.h"
 
 #include "ac/common.h"

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstdio>
 #include <string.h>
 #include "ac/common.h"
 #include "ac/dynobj/cc_dynamicarray.h"


### PR DESCRIPTION
Fixes #1080

I'm not 100% sure this is correct, but I've tested it on gcc 10 and it now builds. Hopefully the CI checks confirm that the changes were correct and I haven't broken anything.