### PR TITLE
Engine: fixed directional audio data not being saved

### DIFF
--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -642,6 +642,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         if (r_data.DoAmbient[i])
             PlayAmbientSound(i, r_data.DoAmbient[i], ambient[i].vol, ambient[i].x, ambient[i].y);
     }
+    update_directional_sound_vol();
 
     for (int i = 0; i < game.numgui; ++i)
     {

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -612,6 +612,9 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
             ch->set_speed(chan_info.Speed);
             ch->set_panning(chan_info.Pan);
             ch->panningAsPercentage = chan_info.PanAsPercent;
+            ch->xSource = chan_info.XSource;
+            ch->ySource = chan_info.YSource;
+            ch->maximumPossibleDistanceAway = chan_info.MaxDist;
         }
     }
     if ((cf_in_chan > 0) && (lock.GetChannel(cf_in_chan) != nullptr))

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -51,7 +51,8 @@ enum SavegameVersion
     kSvgVersion_Components= 9,
     kSvgVersion_Cmp_64bit = 10,
     kSvgVersion_350_final = 11,
-    kSvgVersion_Current   = kSvgVersion_350_final,
+    kSvgVersion_350_final2= 12,
+    kSvgVersion_Current   = kSvgVersion_350_final2,
     kSvgVersion_LowestSupported = kSvgVersion_321 // change if support dropped
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -399,6 +399,10 @@ HSaveError WriteAudio(PStream out)
             out->WriteInt32(ch->volAsPercentage);
             out->WriteInt32(ch->panningAsPercentage);
             out->WriteInt32(ch->get_speed());
+            // since version 1
+            out->WriteInt32(ch->xSource);
+            out->WriteInt32(ch->ySource);
+            out->WriteInt32(ch->maximumPossibleDistanceAway);
         }
         else
         {
@@ -455,6 +459,12 @@ HSaveError ReadAudio(PStream in, int32_t cmp_ver, const PreservedParams &pp, Res
             chan_info.PanAsPercent = in->ReadInt32();
             chan_info.Speed = 1000;
             chan_info.Speed = in->ReadInt32();
+            if (cmp_ver >= 1)
+            {
+                chan_info.XSource = in->ReadInt32();
+                chan_info.YSource = in->ReadInt32();
+                chan_info.MaxDist = in->ReadInt32();
+            }
         }
     }
     crossFading = in->ReadInt32();
@@ -1136,7 +1146,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Audio",
-        0,
+        1,
         0,
         WriteAudio,
         ReadAudio

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -101,6 +101,10 @@ struct RestoredData
         int Pan = 0;
         int PanAsPercent = 0;
         int Speed = 0;
+        // since version 1
+        int XSource = -1;
+        int YSource = -1;
+        int MaxDist = 0;
     };
     ChannelInfo             AudioChans[MAX_SOUND_CHANNELS + 1];
     // Ambient sounds


### PR DESCRIPTION
The new audio API was not saving all the necessary properties to restore directional audio (the one from channel.SetRoomLocation)