### PR TITLE
Sprite Manager: adds context menu View option.

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -31,9 +31,10 @@ namespace AGS.Editor
             this.splitWindow = new System.Windows.Forms.SplitContainer();
             this.folderList = new System.Windows.Forms.TreeView();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.spriteList = new System.Windows.Forms.ListView();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.button_importNew = new System.Windows.Forms.Button();
             this.sliderPreviewSize = new System.Windows.Forms.TrackBar();
+            this.spriteList = new System.Windows.Forms.ListView();
             ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).BeginInit();
             this.splitWindow.Panel1.SuspendLayout();
             this.splitWindow.Panel2.SuspendLayout();
@@ -103,20 +104,10 @@ namespace AGS.Editor
             this.splitContainer1.SplitterDistance = 48;
             this.splitContainer1.TabIndex = 0;
             // 
-            // spriteList
-            // 
-            this.spriteList.AllowDrop = true;
-            this.spriteList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.spriteList.HideSelection = false;
-            this.spriteList.Location = new System.Drawing.Point(0, 0);
-            this.spriteList.Name = "spriteList";
-            this.spriteList.Size = new System.Drawing.Size(456, 432);
-            this.spriteList.TabIndex = 1;
-            this.spriteList.UseCompatibleStateImageBehavior = false;
-            // 
             // panel1
             // 
             this.panel1.AutoSize = true;
+            this.panel1.Controls.Add(this.button_importNew);
             this.panel1.Controls.Add(this.sliderPreviewSize);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(0, 0);
@@ -125,6 +116,18 @@ namespace AGS.Editor
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(456, 48);
             this.panel1.TabIndex = 0;
+            // 
+            // button_importNew
+            // 
+            this.button_importNew.Dock = System.Windows.Forms.DockStyle.Left;
+            this.button_importNew.Location = new System.Drawing.Point(0, 0);
+            this.button_importNew.MinimumSize = new System.Drawing.Size(128, 45);
+            this.button_importNew.Name = "button_importNew";
+            this.button_importNew.Size = new System.Drawing.Size(128, 48);
+            this.button_importNew.TabIndex = 1;
+            this.button_importNew.Text = "Import new sprite(s) from files..";
+            this.button_importNew.UseVisualStyleBackColor = true;
+            this.button_importNew.Click += new System.EventHandler(this.button_importNew_Click);
             // 
             // sliderPreviewSize
             // 
@@ -138,6 +141,23 @@ namespace AGS.Editor
             this.sliderPreviewSize.TabIndex = 0;
             this.sliderPreviewSize.Value = 1;
             this.sliderPreviewSize.ValueChanged += new System.EventHandler(this.sliderPreviewSize_ValueChanged);
+            // 
+            // spriteList
+            // 
+            this.spriteList.AllowDrop = true;
+            this.spriteList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.spriteList.HideSelection = false;
+            this.spriteList.Location = new System.Drawing.Point(0, 0);
+            this.spriteList.Name = "spriteList";
+            this.spriteList.Size = new System.Drawing.Size(456, 432);
+            this.spriteList.TabIndex = 1;
+            this.spriteList.UseCompatibleStateImageBehavior = false;
+            this.spriteList.ItemActivate += new System.EventHandler(this.spriteList_ItemActivate);
+            this.spriteList.ItemDrag += new System.Windows.Forms.ItemDragEventHandler(this.spriteList_ItemDrag);
+            this.spriteList.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.spriteList_ItemSelectionChanged);
+            this.spriteList.DragDrop += new System.Windows.Forms.DragEventHandler(this.spriteList_DragDrop);
+            this.spriteList.DragOver += new System.Windows.Forms.DragEventHandler(this.spriteList_DragOver);
+            this.spriteList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseUp);
             // 
             // SpriteSelector
             // 
@@ -170,5 +190,6 @@ namespace AGS.Editor
         private System.Windows.Forms.ListView spriteList;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TrackBar sliderPreviewSize;
+        private System.Windows.Forms.Button button_importNew;
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -28,77 +28,137 @@ namespace AGS.Editor
         /// </summary>
         private void InitializeComponent()
         {
-			this.splitWindow = new System.Windows.Forms.SplitContainer();
-			this.folderList = new System.Windows.Forms.TreeView();
-			this.spriteList = new System.Windows.Forms.ListView();
-			this.splitWindow.Panel1.SuspendLayout();
-			this.splitWindow.Panel2.SuspendLayout();
-			this.splitWindow.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// splitWindow
-			// 
-			this.splitWindow.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.splitWindow.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-			this.splitWindow.Location = new System.Drawing.Point(0, 0);
-			this.splitWindow.Name = "splitWindow";
-			// 
-			// splitWindow.Panel1
-			// 
-			this.splitWindow.Panel1.Controls.Add(this.folderList);
-			// 
-			// splitWindow.Panel2
-			// 
-			this.splitWindow.Panel2.Controls.Add(this.spriteList);
-			this.splitWindow.Size = new System.Drawing.Size(640, 484);
-			this.splitWindow.SplitterDistance = 180;
-			this.splitWindow.TabIndex = 0;
-			// 
-			// folderList
-			// 
-			this.folderList.AllowDrop = true;
-			this.folderList.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.folderList.HideSelection = false;
-			this.folderList.LabelEdit = true;
-			this.folderList.Location = new System.Drawing.Point(0, 0);
-			this.folderList.Name = "folderList";
-			this.folderList.Size = new System.Drawing.Size(180, 484);
-			this.folderList.TabIndex = 1;
-			this.folderList.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.folderList_AfterLabelEdit);
-			this.folderList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.folderList_MouseUp);
-			this.folderList.DragDrop += new System.Windows.Forms.DragEventHandler(this.folderList_DragDrop);
-			this.folderList.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.folderList_AfterSelect);
-			this.folderList.DragOver += new System.Windows.Forms.DragEventHandler(this.folderList_DragOver);
-			this.folderList.DragLeave += new System.EventHandler(this.folderList_DragLeave);
-			// 
-			// spriteList
-			// 
-			this.spriteList.AllowDrop = true;
-			this.spriteList.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.spriteList.HideSelection = false;
-			this.spriteList.Location = new System.Drawing.Point(0, 0);
-			this.spriteList.Name = "spriteList";
-			this.spriteList.Size = new System.Drawing.Size(456, 484);
-			this.spriteList.TabIndex = 0;
-			this.spriteList.UseCompatibleStateImageBehavior = false;
-			this.spriteList.ItemActivate += new System.EventHandler(this.spriteList_ItemActivate);
-			this.spriteList.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.spriteList_ItemSelectionChanged);
-			this.spriteList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseUp);
-			this.spriteList.DragDrop += new System.Windows.Forms.DragEventHandler(this.spriteList_DragDrop);
-			this.spriteList.ItemDrag += new System.Windows.Forms.ItemDragEventHandler(this.spriteList_ItemDrag);
-			this.spriteList.DragOver += new System.Windows.Forms.DragEventHandler(this.spriteList_DragOver);
-			// 
-			// SpriteSelector
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.splitWindow);
-			this.Name = "SpriteSelector";
-			this.Size = new System.Drawing.Size(640, 484);
-			this.splitWindow.Panel1.ResumeLayout(false);
-			this.splitWindow.Panel2.ResumeLayout(false);
-			this.splitWindow.ResumeLayout(false);
-			this.ResumeLayout(false);
+            this.splitWindow = new System.Windows.Forms.SplitContainer();
+            this.folderList = new System.Windows.Forms.TreeView();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.spriteList = new System.Windows.Forms.ListView();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.sliderPreviewSize = new System.Windows.Forms.TrackBar();
+            ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).BeginInit();
+            this.splitWindow.Panel1.SuspendLayout();
+            this.splitWindow.Panel2.SuspendLayout();
+            this.splitWindow.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sliderPreviewSize)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // splitWindow
+            // 
+            this.splitWindow.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitWindow.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitWindow.Location = new System.Drawing.Point(0, 0);
+            this.splitWindow.Name = "splitWindow";
+            // 
+            // splitWindow.Panel1
+            // 
+            this.splitWindow.Panel1.Controls.Add(this.folderList);
+            // 
+            // splitWindow.Panel2
+            // 
+            this.splitWindow.Panel2.Controls.Add(this.splitContainer1);
+            this.splitWindow.Size = new System.Drawing.Size(640, 484);
+            this.splitWindow.SplitterDistance = 180;
+            this.splitWindow.TabIndex = 0;
+            // 
+            // folderList
+            // 
+            this.folderList.AllowDrop = true;
+            this.folderList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.folderList.HideSelection = false;
+            this.folderList.LabelEdit = true;
+            this.folderList.Location = new System.Drawing.Point(0, 0);
+            this.folderList.Name = "folderList";
+            this.folderList.Size = new System.Drawing.Size(180, 484);
+            this.folderList.TabIndex = 1;
+            this.folderList.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.folderList_AfterLabelEdit);
+            this.folderList.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.folderList_AfterSelect);
+            this.folderList.DragDrop += new System.Windows.Forms.DragEventHandler(this.folderList_DragDrop);
+            this.folderList.DragOver += new System.Windows.Forms.DragEventHandler(this.folderList_DragOver);
+            this.folderList.DragLeave += new System.EventHandler(this.folderList_DragLeave);
+            this.folderList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.folderList_MouseUp);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.IsSplitterFixed = true;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.panel1);
+            this.splitContainer1.Panel1MinSize = 48;
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.spriteList);
+            this.splitContainer1.Panel2MinSize = 48;
+            this.splitContainer1.Size = new System.Drawing.Size(456, 484);
+            this.splitContainer1.SplitterDistance = 48;
+            this.splitContainer1.TabIndex = 0;
+            // 
+            // spriteList
+            // 
+            this.spriteList.AllowDrop = true;
+            this.spriteList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.spriteList.HideSelection = false;
+            this.spriteList.Location = new System.Drawing.Point(0, 0);
+            this.spriteList.Name = "spriteList";
+            this.spriteList.Size = new System.Drawing.Size(456, 432);
+            this.spriteList.TabIndex = 1;
+            this.spriteList.UseCompatibleStateImageBehavior = false;
+            // 
+            // panel1
+            // 
+            this.panel1.AutoSize = true;
+            this.panel1.Controls.Add(this.sliderPreviewSize);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.MaximumSize = new System.Drawing.Size(0, 48);
+            this.panel1.MinimumSize = new System.Drawing.Size(0, 48);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(456, 48);
+            this.panel1.TabIndex = 0;
+            // 
+            // sliderPreviewSize
+            // 
+            this.sliderPreviewSize.Dock = System.Windows.Forms.DockStyle.Right;
+            this.sliderPreviewSize.LargeChange = 1;
+            this.sliderPreviewSize.Location = new System.Drawing.Point(352, 0);
+            this.sliderPreviewSize.Maximum = 4;
+            this.sliderPreviewSize.Minimum = 1;
+            this.sliderPreviewSize.Name = "sliderPreviewSize";
+            this.sliderPreviewSize.Size = new System.Drawing.Size(104, 48);
+            this.sliderPreviewSize.TabIndex = 0;
+            this.sliderPreviewSize.Value = 1;
+            this.sliderPreviewSize.ValueChanged += new System.EventHandler(this.sliderPreviewSize_ValueChanged);
+            // 
+            // SpriteSelector
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.splitWindow);
+            this.Name = "SpriteSelector";
+            this.Size = new System.Drawing.Size(640, 484);
+            this.splitWindow.Panel1.ResumeLayout(false);
+            this.splitWindow.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).EndInit();
+            this.splitWindow.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sliderPreviewSize)).EndInit();
+            this.ResumeLayout(false);
 
         }
 
@@ -106,6 +166,9 @@ namespace AGS.Editor
 
         private System.Windows.Forms.SplitContainer splitWindow;
         private System.Windows.Forms.TreeView folderList;
+        private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.ListView spriteList;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.TrackBar sliderPreviewSize;
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -32,10 +32,10 @@ namespace AGS.Editor
             this.folderList = new System.Windows.Forms.TreeView();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
             this.button_importNew = new System.Windows.Forms.Button();
             this.sliderPreviewSize = new System.Windows.Forms.TrackBar();
             this.spriteList = new System.Windows.Forms.ListView();
-            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).BeginInit();
             this.splitWindow.Panel1.SuspendLayout();
             this.splitWindow.Panel2.SuspendLayout();
@@ -95,14 +95,12 @@ namespace AGS.Editor
             // splitContainer1.Panel1
             // 
             this.splitContainer1.Panel1.Controls.Add(this.panel1);
-            this.splitContainer1.Panel1MinSize = 48;
             // 
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.spriteList);
-            this.splitContainer1.Panel2MinSize = 48;
             this.splitContainer1.Size = new System.Drawing.Size(456, 484);
-            this.splitContainer1.SplitterDistance = 48;
+            this.splitContainer1.SplitterDistance = 25;
             this.splitContainer1.TabIndex = 0;
             // 
             // panel1
@@ -113,33 +111,45 @@ namespace AGS.Editor
             this.panel1.Controls.Add(this.sliderPreviewSize);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(0, 0);
-            this.panel1.MaximumSize = new System.Drawing.Size(0, 48);
-            this.panel1.MinimumSize = new System.Drawing.Size(0, 48);
+            this.panel1.MaximumSize = new System.Drawing.Size(0, 24);
+            this.panel1.MinimumSize = new System.Drawing.Size(0, 24);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(456, 48);
+            this.panel1.Size = new System.Drawing.Size(456, 24);
             this.panel1.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Right;
+            this.label1.Location = new System.Drawing.Point(239, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(113, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Scale sprite previews: ";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // button_importNew
             // 
             this.button_importNew.Dock = System.Windows.Forms.DockStyle.Left;
             this.button_importNew.Location = new System.Drawing.Point(0, 0);
-            this.button_importNew.MinimumSize = new System.Drawing.Size(128, 45);
+            this.button_importNew.MinimumSize = new System.Drawing.Size(128, 24);
             this.button_importNew.Name = "button_importNew";
-            this.button_importNew.Size = new System.Drawing.Size(128, 48);
+            this.button_importNew.Size = new System.Drawing.Size(186, 24);
             this.button_importNew.TabIndex = 1;
-            this.button_importNew.Text = "Import new sprite(s) from files..";
+            this.button_importNew.Text = "Import new sprite(s) from files...";
             this.button_importNew.UseVisualStyleBackColor = true;
             this.button_importNew.Click += new System.EventHandler(this.button_importNew_Click);
             // 
             // sliderPreviewSize
             // 
+            this.sliderPreviewSize.AutoSize = false;
             this.sliderPreviewSize.Dock = System.Windows.Forms.DockStyle.Right;
             this.sliderPreviewSize.LargeChange = 2;
             this.sliderPreviewSize.Location = new System.Drawing.Point(352, 0);
             this.sliderPreviewSize.Maximum = 8;
             this.sliderPreviewSize.Minimum = 1;
             this.sliderPreviewSize.Name = "sliderPreviewSize";
-            this.sliderPreviewSize.Size = new System.Drawing.Size(104, 48);
+            this.sliderPreviewSize.Size = new System.Drawing.Size(104, 24);
             this.sliderPreviewSize.TabIndex = 0;
             this.sliderPreviewSize.Value = 1;
             this.sliderPreviewSize.ValueChanged += new System.EventHandler(this.sliderPreviewSize_ValueChanged);
@@ -151,7 +161,7 @@ namespace AGS.Editor
             this.spriteList.HideSelection = false;
             this.spriteList.Location = new System.Drawing.Point(0, 0);
             this.spriteList.Name = "spriteList";
-            this.spriteList.Size = new System.Drawing.Size(456, 432);
+            this.spriteList.Size = new System.Drawing.Size(456, 455);
             this.spriteList.TabIndex = 1;
             this.spriteList.UseCompatibleStateImageBehavior = false;
             this.spriteList.ItemActivate += new System.EventHandler(this.spriteList_ItemActivate);
@@ -162,17 +172,6 @@ namespace AGS.Editor
             this.spriteList.DragOver += new System.Windows.Forms.DragEventHandler(this.spriteList_DragOver);
             this.spriteList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseUp);
             this.spriteList.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseWheel);
-            // 
-            // label1
-            // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(242, 18);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(113, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Scale sprite previews: ";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // SpriteSelector
             // 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -35,6 +35,7 @@ namespace AGS.Editor
             this.button_importNew = new System.Windows.Forms.Button();
             this.sliderPreviewSize = new System.Windows.Forms.TrackBar();
             this.spriteList = new System.Windows.Forms.ListView();
+            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).BeginInit();
             this.splitWindow.Panel1.SuspendLayout();
             this.splitWindow.Panel2.SuspendLayout();
@@ -107,6 +108,7 @@ namespace AGS.Editor
             // panel1
             // 
             this.panel1.AutoSize = true;
+            this.panel1.Controls.Add(this.label1);
             this.panel1.Controls.Add(this.button_importNew);
             this.panel1.Controls.Add(this.sliderPreviewSize);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -132,9 +134,9 @@ namespace AGS.Editor
             // sliderPreviewSize
             // 
             this.sliderPreviewSize.Dock = System.Windows.Forms.DockStyle.Right;
-            this.sliderPreviewSize.LargeChange = 1;
+            this.sliderPreviewSize.LargeChange = 2;
             this.sliderPreviewSize.Location = new System.Drawing.Point(352, 0);
-            this.sliderPreviewSize.Maximum = 4;
+            this.sliderPreviewSize.Maximum = 8;
             this.sliderPreviewSize.Minimum = 1;
             this.sliderPreviewSize.Name = "sliderPreviewSize";
             this.sliderPreviewSize.Size = new System.Drawing.Size(104, 48);
@@ -159,6 +161,18 @@ namespace AGS.Editor
             this.spriteList.DragEnter += new System.Windows.Forms.DragEventHandler(this.spriteList_DragEnter);
             this.spriteList.DragOver += new System.Windows.Forms.DragEventHandler(this.spriteList_DragOver);
             this.spriteList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseUp);
+            this.spriteList.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseWheel);
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(242, 18);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(113, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Scale sprite previews: ";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // SpriteSelector
             // 
@@ -192,5 +206,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TrackBar sliderPreviewSize;
         private System.Windows.Forms.Button button_importNew;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -156,6 +156,7 @@ namespace AGS.Editor
             this.spriteList.ItemDrag += new System.Windows.Forms.ItemDragEventHandler(this.spriteList_ItemDrag);
             this.spriteList.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.spriteList_ItemSelectionChanged);
             this.spriteList.DragDrop += new System.Windows.Forms.DragEventHandler(this.spriteList_DragDrop);
+            this.spriteList.DragEnter += new System.Windows.Forms.DragEventHandler(this.spriteList_DragEnter);
             this.spriteList.DragOver += new System.Windows.Forms.DragEventHandler(this.spriteList_DragOver);
             this.spriteList.MouseUp += new System.Windows.Forms.MouseEventHandler(this.spriteList_MouseUp);
             // 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -88,6 +88,7 @@ namespace AGS.Editor
                 _spManagerIcons.Images.Add("OpenFolder", Resources.ResourceManager.GetIcon("openfldr.ico"));
             }
             folderList.ImageList = _spManagerIcons;
+            SetSpritePreviewMultiplier(2); // default value for sprite multiplier
         }
 
         /// <summary>
@@ -203,6 +204,8 @@ namespace AGS.Editor
 
         private void DisplaySpritesForFolder(SpriteFolder folder)
         {
+            if (folder == null) return;
+
             if (OnSelectionChanged != null)
             {
                 // this means the previously selected sprite is un-selected

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -1530,6 +1530,16 @@ namespace AGS.Editor
         {
             SetSpritePreviewMultiplier(sliderPreviewSize.Value);
         }
+
+        private void button_importNew_Click(object sender, EventArgs e)
+        {
+            string[] filenames = Factory.GUIController.ShowOpenFileDialogMultipleFiles("Import new sprites...", Constants.IMAGE_FILE_FILTER);
+
+            if (filenames.Length > 0)
+            {
+                ImportNewSprite(_currentFolder, filenames);
+            }
+        }
     }
 
     internal class SpriteManagerDragDropData

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -231,7 +231,10 @@ namespace AGS.Editor
             {
                 progress.SetProgressValue(index);
                 Sprite sprite = folder.Sprites[index];
-                Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, 64, 64, false, true, Color.Pink);
+
+                int new_size = Math.Min(Math.Max(Math.Max(sprite.Width, sprite.Height), 64), 64* _spriteSizeMultiplier);
+
+                Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, new_size, new_size, false, true, Color.Pink);
 
                 // we are already indexing from 0 and this ImageList was cleared,
                 // so just adding the image doesn't need a modified index

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -221,7 +221,7 @@ namespace AGS.Editor
             spriteList.Clear();
             _spriteImages.Images.Clear();
             _spriteImages.ColorDepth = ColorDepth.Depth16Bit;
-            _spriteImages.ImageSize = new Size(64 * _spriteSizeMultiplier, 64 * _spriteSizeMultiplier);
+            _spriteImages.ImageSize = new Size(32 * _spriteSizeMultiplier, 32 * _spriteSizeMultiplier);
             _spriteImages.TransparentColor = Color.Pink;
             List<ListViewItem> itemsToAdd = new List<ListViewItem>();
 
@@ -233,7 +233,7 @@ namespace AGS.Editor
                 progress.SetProgressValue(index);
                 Sprite sprite = folder.Sprites[index];
 
-                int new_size = Math.Min(Math.Max(Math.Max(sprite.Width, sprite.Height), 64), 64* _spriteSizeMultiplier);
+                int new_size = Math.Min(Math.Max(Math.Max(sprite.Width, sprite.Height), 32), 32 * _spriteSizeMultiplier);
 
                 Bitmap bmp = Utilities.GetBitmapForSpriteResizedKeepingAspectRatio(sprite, new_size, new_size, false, true, Color.Pink);
 
@@ -780,19 +780,19 @@ namespace AGS.Editor
             }
             else if (item.Name == MENU_ITEM_PREVIEW_SIZE_1X)
             {
-                SetSpritePreviewMultiplier(1);
+                SetSpritePreviewMultiplier(2);
             }
             else if (item.Name == MENU_ITEM_PREVIEW_SIZE_2X)
             {
-                SetSpritePreviewMultiplier(2);
+                SetSpritePreviewMultiplier(4);
             }
             else if (item.Name == MENU_ITEM_PREVIEW_SIZE_3X)
             {
-                SetSpritePreviewMultiplier(3);
+                SetSpritePreviewMultiplier(6);
             }
             else if (item.Name == MENU_ITEM_PREVIEW_SIZE_4X)
             {
-                SetSpritePreviewMultiplier(4);
+                SetSpritePreviewMultiplier(8);
             }
         }
 
@@ -1581,6 +1581,29 @@ namespace AGS.Editor
             else
             {
                 e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void spriteList_MouseWheel(object sender, MouseEventArgs e)
+        {
+            if (ModifierKeys.HasFlag(Keys.Control))
+            {
+                int movement = e.Delta;
+                if (movement > 0)
+                {
+                    if (sliderPreviewSize.Value < sliderPreviewSize.Maximum)
+                    {
+                        sliderPreviewSize.Value++;
+                    }
+                }
+                else
+                {
+                    if (sliderPreviewSize.Value > sliderPreviewSize.Minimum)
+                    {
+                        sliderPreviewSize.Value--;
+                    }
+                }
+                SetSpritePreviewMultiplier(sliderPreviewSize.Value);
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -1609,6 +1609,16 @@ namespace AGS.Editor
                 SetSpritePreviewMultiplier(sliderPreviewSize.Value);
             }
         }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == (Keys.Control | Keys.D0))
+            {
+                SetSpritePreviewMultiplier(2);
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
     }
 
     internal class SpriteManagerDragDropData

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -579,6 +579,7 @@ namespace AGS.Editor
         {
             if (_spriteSizeMultiplier != multiplier)
             {
+                sliderPreviewSize.Value = multiplier;
                 _spriteSizeMultiplier = multiplier;
                 RefreshSpriteDisplay();
             }
@@ -1523,6 +1524,11 @@ namespace AGS.Editor
             folderList.BackColor = t.GetColor("sprite-selector/tree/background");
             folderList.ForeColor = t.GetColor("sprite-selector/tree/foreground");
             folderList.LineColor = t.GetColor("sprite-selector/tree/line");
+        }
+
+        private void sliderPreviewSize_ValueChanged(object sender, EventArgs e)
+        {
+            SetSpritePreviewMultiplier(sliderPreviewSize.Value);
         }
     }
 

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -50,6 +50,11 @@ namespace AGS.Editor
         private const string MENU_ITEM_ASSIGN_TO_VIEW = "AssignToView";
         private const string MENU_ITEM_CHANGE_SPRITE_NUMBER = "ChangeSpriteNumber";
 
+        private const string MENU_ITEM_PREVIEW_SIZE_1X = "PreviewSizeSmall";
+        private const string MENU_ITEM_PREVIEW_SIZE_2X = "PreviewSizeMedium";
+        private const string MENU_ITEM_PREVIEW_SIZE_3X = "PreviewSizeLarge";
+        private const string MENU_ITEM_PREVIEW_SIZE_4X = "PreviewSizeExtraLarge";
+
         private static ImageList _spManagerIcons;
         private Dictionary<string, SpriteFolder> _folders;
         private Dictionary<SpriteFolder, TreeNode> _folderNodeMapping;
@@ -63,6 +68,7 @@ namespace AGS.Editor
         private string[] _lastImportedFilenames = null;
         private Timer _timer;
         private TreeNode _dropHighlight;
+        private int _spriteSizeMultiplier = 1;
 
         public SpriteSelector()
         {
@@ -214,7 +220,7 @@ namespace AGS.Editor
             spriteList.Clear();
             _spriteImages.Images.Clear();
             _spriteImages.ColorDepth = ColorDepth.Depth16Bit;
-            _spriteImages.ImageSize = new Size(64, 64);
+            _spriteImages.ImageSize = new Size(64 * _spriteSizeMultiplier, 64 * _spriteSizeMultiplier);
             _spriteImages.TransparentColor = Color.Pink;
             List<ListViewItem> itemsToAdd = new List<ListViewItem>();
 
@@ -569,6 +575,15 @@ namespace AGS.Editor
             return 16;
         }
 
+        private void SetSpritePreviewMultiplier(int multiplier)
+        {
+            if (_spriteSizeMultiplier != multiplier)
+            {
+                _spriteSizeMultiplier = multiplier;
+                RefreshSpriteDisplay();
+            }
+        }
+
         private void SpriteContextMenuEventHandler(object sender, EventArgs e)
         {
             ToolStripMenuItem item = (ToolStripMenuItem)sender;
@@ -757,6 +772,22 @@ namespace AGS.Editor
             else if (item.Name == MENU_ITEM_REPLACE_FROM_SOURCE)
             {
                 ReplaceSpritesFromSource();
+            }
+            else if (item.Name == MENU_ITEM_PREVIEW_SIZE_1X)
+            {
+                SetSpritePreviewMultiplier(1);
+            }
+            else if (item.Name == MENU_ITEM_PREVIEW_SIZE_2X)
+            {
+                SetSpritePreviewMultiplier(2);
+            }
+            else if (item.Name == MENU_ITEM_PREVIEW_SIZE_3X)
+            {
+                SetSpritePreviewMultiplier(3);
+            }
+            else if (item.Name == MENU_ITEM_PREVIEW_SIZE_4X)
+            {
+                SetSpritePreviewMultiplier(4);
             }
         }
 
@@ -1222,6 +1253,16 @@ namespace AGS.Editor
             menu.Items.Add(new ToolStripMenuItem("Sort sprites by number", null, onClick, MENU_ITEM_SORT_BY_NUMBER));
             menu.Items.Add(new ToolStripSeparator());
             menu.Items.Add(new ToolStripMenuItem("Find sprite by number...", null, onClick, MENU_ITEM_FIND_BY_NUMBER));
+
+            ToolStripMenuItem view_menu = new ToolStripMenuItem();
+            view_menu.Text = "View";
+
+            view_menu.DropDownItems.Add(new ToolStripMenuItem("Small icons", null, onClick, MENU_ITEM_PREVIEW_SIZE_1X));
+            view_menu.DropDownItems.Add(new ToolStripMenuItem("Medium icons", null, onClick, MENU_ITEM_PREVIEW_SIZE_2X));
+            view_menu.DropDownItems.Add(new ToolStripMenuItem("Large icons", null, onClick, MENU_ITEM_PREVIEW_SIZE_3X));
+            view_menu.DropDownItems.Add(new ToolStripMenuItem("Extra large icons", null, onClick, MENU_ITEM_PREVIEW_SIZE_4X));
+
+            menu.Items.Add(view_menu);
 
             menu.Show(spriteList, menuPosition);
         }

--- a/Editor/AGS.Editor/Panes/SpriteSelector.resx
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
![sprite_preview_wheel](https://user-images.githubusercontent.com/2244442/95002317-ff995d00-05c1-11eb-9e79-646ad22c4500.gif)

List of Features:

- Allows changing preview sizes for 1x, 2x, 3x, and 4x on right click;
- Slider gives 0.5 steps from 0.5x to 4x;
- Ctrl+Mouse Wheel also modifies the slider;
- Default size is 1x;
- Ctrl+0 resets to default size;
- Added a button for importing new sprite files;
- Image File Drop on Sprite Manager is supported, just click hold the desired image files on Windows Explorer and drag them in the Sprite Manager for import. Fix #922 .

Now I noticed View means something different in AGS and I just stole the naming from Windows Explorer, if a different name is better, please chime in.

