### PR TITLE
Room Editor: adds keyboard navigation

### DIFF
--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -990,6 +990,64 @@ namespace AGS.Editor
             cmbBackgrounds.SelectedIndexChanged += cmbBackgrounds_SelectedIndexChanged;
             mainFrame.Controls.Add(cmbBackgrounds);
         }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            int number_down = -1;
+            if (keyData.HasFlag(Keys.Shift) || keyData.HasFlag(Keys.Alt)) return base.ProcessCmdKey(ref msg, keyData);
+
+            if (keyData.HasFlag(Keys.D0)) number_down = 0;
+            if (keyData.HasFlag(Keys.D1)) number_down = 1;
+            if (keyData.HasFlag(Keys.D2)) number_down = 2;
+            if (keyData.HasFlag(Keys.D3)) number_down = 3;
+            if (keyData.HasFlag(Keys.D4)) number_down = 4;
+            if (keyData.HasFlag(Keys.D5)) number_down = 5;
+            if (keyData.HasFlag(Keys.D6)) number_down = 6;
+            if (keyData.HasFlag(Keys.D7)) number_down = 7;
+            if (keyData.HasFlag(Keys.D8)) number_down = 8;
+            if (keyData.HasFlag(Keys.D9)) number_down = 9;
+
+            if (number_down < 0) return base.ProcessCmdKey(ref msg, keyData);
+
+            if(keyData.HasFlag(Keys.Control))
+            {
+                RoomEditNode layerNode = _editAddressBar.RootNode.GetChild(GetLayerItemUniqueID(_layer, null), true) as RoomEditNode;
+                // navigate nodes
+                if (number_down < layerNode.Children.Length)
+                {
+                    _editAddressBar.CurrentNode = layerNode.Children[number_down];
+
+                    RoomEditNode node = _editAddressBar.CurrentNode as RoomEditNode;
+                    if (node == null) { SelectLayer(null); return true; }
+            
+                    while (layerNode != null && layerNode.Layer == null)
+                    {
+                        layerNode = layerNode.Parent as RoomEditNode;
+                    }
+                    if (layerNode == null) { SelectLayer(null); return true; }
+
+                    layerNode.IsVisible = true;
+                    SelectLayer(layerNode.Layer);
+                    layerNode.Layer.SelectItem(node == layerNode ? null : node.RoomItemID);
+                }
+            }
+            else
+            {
+                // navigate layers
+                if (number_down < _layers.Count)
+                {
+                    var layer = _layers[number_down];
+                    IAddressNode node = _editAddressBar.RootNode.GetChild(GetLayerItemUniqueID(layer, null), true);
+                    if (node == null) { SelectLayer(null); return true; }
+                    _editAddressBar.CurrentNode = node;
+                    SelectLayer(_layers[number_down]);
+                    
+                }
+            }
+            return true;
+        }
+
+
     }
 
     // TODO: refactor this to make code shared with the GUI Editor


### PR DESCRIPTION
This is an experimental PR. It's made so it gets build on the CI system and someone can test how it **feels** using it.

It adds Keyboard Navigation to the Room Editor:

- 0-9: Selects a layer (Edge, Character, Object, Hotspot, Walkabables, Walkbehind, Region)
- Ctrl+0-9: Selects a node in the layer (hHotspot0, hHotspot1, ...)

It's similar but not exactly what's suggested on #959 . **Ignore the code** and just use and see if controls make sense or not. 

I think ideally Ctrl+0-9, 0-9 like two keys shortcuts on VS would work better for big complex rooms with a lot of things. But this is more code - storing previous key, a timer to reset stored key, ... - so it felt easier to get feedback in this way.

Other shortcut I wanted to add but could not figure from the code was Ctrl+M to load the Script Editor on the respective room `.asc` file.


---

I have a different version of this using **ONLY ARROW KEYS**: [ericoporto/ags/tree/feature-room-ctrlarrow-nav](https://github.com/ericoporto/ags/tree/feature-room-ctrlarrow-nav) | [Cirrus-CI](https://cirrus-ci.com/task/4808094041505792)

This version uses Ctrl+Arrow Keys to navigate on the Room Tree at any time. You can use Ctrl+Right to go deep in a layer, Ctrl+Left to just select layer head, Ctrl+Down to go to the next element (Hotspot, Walkbehind, ... or Eraser, hHotspot1, ...), ... It is slower to get where you want but it's easier to remember how to navigate, it's like moving a cursor in the tree.