### PR TITLE
Script API: add Game.BlockingTextOverlay and Game.BlockingWaitSkipped

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2812,6 +2812,7 @@ builtin struct GameState {
   
 #ifdef SCRIPT_API_v330
 enum SkipSpeechStyle {
+  eSkipNone         = -1,
   eSkipKeyMouseTime = 0,
   eSkipKeyTime      = 1,
   eSkipTime         = 2,

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2687,6 +2687,10 @@ builtin struct Game {
   /// Gets the number of cameras.
   import static readonly attribute int CameraCount;
 #endif
+#ifdef SCRIPT_API_v351
+  /// Gets the overlay representing displayed blocking text, or null if no such text none is displayed at the moment.
+  import static readonly attribute Overlay* BlockingTextOverlay;
+#endif
 };
 
 builtin struct GameState {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2690,6 +2690,8 @@ builtin struct Game {
 #ifdef SCRIPT_API_v351
   /// Gets the overlay representing displayed blocking text, or null if no such text none is displayed at the moment.
   import static readonly attribute Overlay* BlockingTextOverlay;
+  /// Gets the code which describes how was the last blocking state skipped by a user (or autotimer).
+  import static readonly attribute int BlockingWaitSkipped;
 #endif
 };
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -74,7 +74,6 @@ extern SpriteCache spriteset;
 extern Bitmap *walkable_areas_temp;
 extern IGraphicsDriver *gfxDriver;
 extern Bitmap **actsps;
-extern int is_text_overlay;
 extern int said_speech_line;
 extern int said_text;
 extern int our_eip;
@@ -2370,7 +2369,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     if ((speakingChar->view < 0) || (speakingChar->view >= game.numviews))
         quit("!DisplaySpeech: character has invalid view");
 
-    if (is_text_overlay > 0)
+    if (play.text_overlay_on)
     {
         debug_script_warn("DisplaySpeech: speech was already displayed (nested DisplaySpeech, perhaps room script and global script conflict?)");
         return;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -775,15 +775,10 @@ ScriptOverlay* Character_SayBackground(CharacterInfo *chaa, const char *texx) {
     if (ovri<0)
         quit("!SayBackground internal error: no overlay");
 
-    // Convert the overlay ID to an Overlay object
-    ScriptOverlay *scOver = new ScriptOverlay();
-    scOver->overlayId = ovltype;
+    ScriptOverlay *scOver = add_scriptobj_for_overlay(screenover[ovri]);
     scOver->borderHeight = 0;
     scOver->borderWidth = 0;
     scOver->isBackgroundSpeech = 1;
-    int handl = ccRegisterManagedObject(scOver, scOver);
-    screenover[ovri].associatedOverlayHandle = handl;
-
     return scOver;
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -259,6 +259,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
     if (disp_type == DISPLAYTEXT_MESSAGEBOX) {
         // If fast-forwarding, then skip immediately
         if (play.fast_forward) {
+            play.SetWaitSkipResult(SKIP_AUTOTIMER);
             remove_screen_overlay(OVER_TEXTMSG);
             play.messagetime=-1;
             return 0;
@@ -278,7 +279,10 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
                 if (play.fast_forward)
                     break;
                 if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
+                {
+                    play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
                     break;
+                }
             }
             int kp;
             if (run_service_key_controls(kp)) {
@@ -286,7 +290,10 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
                 if (play.fast_forward)
                     break;
                 if ((skip_setting & SKIP_KEYPRESS) && !play.IsIgnoringInput())
+                {
+                    play.SetWaitSkipResult(SKIP_KEYPRESS, kp);
                     break;
+                }
             }
             
             update_polled_stuff_if_runtime();
@@ -311,6 +318,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
             // Test for the timed auto-skip
             if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
+                play.SetWaitSkipResult(SKIP_AUTOTIMER);
                 play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
                 break;
             }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -106,7 +106,6 @@ extern int displayed_room;
 extern CharacterExtras *charextra;
 extern CharacterInfo*playerchar;
 extern int eip_guinum;
-extern int is_complete_overlay;
 extern int cur_mode,cur_cursor;
 extern int mouse_frame,mouse_delay;
 extern int lastmx,lastmy;
@@ -2387,7 +2386,7 @@ void construct_game_scene(bool full_redraw)
         play.UpdateRoomCameras();
 
     // Stage: room viewports
-    if (play.screen_is_faded_out == 0 && is_complete_overlay == 0)
+    if (play.screen_is_faded_out == 0 && !play.complete_overlay_on)
     {
         if (displayed_room >= 0)
         {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -108,7 +108,6 @@ extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern AnimatingGUIButton animbuts[MAX_ANIMATING_BUTTONS];
 extern int numAnimButs;
 
-extern int is_complete_overlay,is_text_overlay;
 
 #if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
 extern int psp_gfx_renderer;
@@ -1784,7 +1783,7 @@ void start_skipping_cutscene () {
         remove_popup_interface(ifacepopped);
 
     // if a text message is currently displayed, remove it
-    if (is_text_overlay > 0)
+    if (play.text_overlay_on)
         remove_screen_overlay(OVER_TEXTMSG);
 
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -956,6 +956,11 @@ ScriptOverlay* Game_BlockingTextOverlay()
     return blocking_text_scover;
 }
 
+int Game_BlockingWaitSkipped()
+{
+    return play.GetWaitSkipResult();
+}
+
 //=============================================================================
 
 // save game functions
@@ -1790,8 +1795,10 @@ void start_skipping_cutscene () {
 
     // if a text message is currently displayed, remove it
     if (play.text_overlay_on)
+    {
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
         remove_screen_overlay(OVER_TEXTMSG);
-
+    }
 }
 
 bool check_skip_cutscene_keypress (int kgn) {
@@ -2435,6 +2442,11 @@ RuntimeScriptValue Sc_Game_BlockingTextOverlay(const RuntimeScriptValue *params,
     API_SCALL_OBJAUTO(ScriptOverlay, Game_BlockingTextOverlay);
 }
 
+RuntimeScriptValue Sc_Game_BlockingWaitSkipped(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Game_BlockingWaitSkipped);
+}
+
 void RegisterGameAPI()
 {
     ccAddExternalStaticFunction("Game::IsAudioPlaying^1",                       Sc_Game_IsAudioPlaying);
@@ -2489,6 +2501,7 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
     ccAddExternalStaticFunction("Game::SimulateKeyPress",                       Sc_Game_SimulateKeyPress);
     ccAddExternalStaticFunction("Game::get_BlockingTextOverlay",                Sc_Game_BlockingTextOverlay);
+    ccAddExternalStaticFunction("Game::get_BlockingWaitSkipped",                Sc_Game_BlockingWaitSkipped);
 
     ccAddExternalStaticFunction("Game::get_Camera",                             Sc_Game_GetCamera);
     ccAddExternalStaticFunction("Game::get_CameraCount",                        Sc_Game_GetCameraCount);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -950,6 +950,12 @@ void Game_SimulateKeyPress(int key)
     }
 }
 
+extern ScriptOverlay *blocking_text_scover;
+ScriptOverlay* Game_BlockingTextOverlay()
+{
+    return blocking_text_scover;
+}
+
 //=============================================================================
 
 // save game functions
@@ -2424,6 +2430,11 @@ RuntimeScriptValue Sc_Game_SimulateKeyPress(const RuntimeScriptValue *params, in
     API_SCALL_VOID_PINT(Game_SimulateKeyPress);
 }
 
+RuntimeScriptValue Sc_Game_BlockingTextOverlay(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptOverlay, Game_BlockingTextOverlay);
+}
+
 void RegisterGameAPI()
 {
     ccAddExternalStaticFunction("Game::IsAudioPlaying^1",                       Sc_Game_IsAudioPlaying);
@@ -2477,6 +2488,7 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
     ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
     ccAddExternalStaticFunction("Game::SimulateKeyPress",                       Sc_Game_SimulateKeyPress);
+    ccAddExternalStaticFunction("Game::get_BlockingTextOverlay",                Sc_Game_BlockingTextOverlay);
 
     ccAddExternalStaticFunction("Game::get_Camera",                             Sc_Game_GetCamera);
     ccAddExternalStaticFunction("Game::get_CameraCount",                        Sc_Game_GetCameraCount);

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -414,6 +414,23 @@ void GameState::ClearIgnoreInput()
     _ignoreUserInputUntilTime = AGS_Clock::now();
 }
 
+void GameState::SetWaitSkipResult(int how, int data)
+{
+    wait_counter = 0;
+    wait_skipped_by = how;
+    wait_skipped_by_data = data;
+}
+
+int GameState::GetWaitSkipResult() const
+{
+    switch (wait_skipped_by)
+    {
+    case SKIP_KEYPRESS: return wait_skipped_by_data;
+    case SKIP_MOUSECLICK: return -(wait_skipped_by_data + 1); // convert to 1-based code and negate
+    default: return 0;
+    }
+}
+
 bool GameState::IsBlockingVoiceSpeech() const
 {
     return speech_has_voice && speech_voice_blocking;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -235,6 +235,13 @@ struct GameState {
     // Tells whether character speech stays on screen not animated for additional time
     bool  speech_in_post_state;
 
+    // Special overlays
+    //
+    // Is there a QFG4-style dialog overlay on screen
+    bool complete_overlay_on;
+    // Is there a blocking text overlay on screen
+    bool text_overlay_on;
+
     int shake_screen_yoff; // y offset of the shaking screen
 
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -147,8 +147,8 @@ struct GameState {
     int   bg_frame,bg_anim_delay;  // for animating backgrounds
     int   music_vol_was;  // before the volume drop
     short wait_counter;
-    char  wait_skipped_by; // tells how last wait was skipped [not serialized]
-    int   wait_skipped_by_data; // extended data telling how last wait was skipped [not serialized]
+    char  wait_skipped_by; // tells how last blocking wait was skipped [not serialized]
+    int   wait_skipped_by_data; // extended data telling how last blocking wait was skipped [not serialized]
     short mboundx1,mboundx2,mboundy1,mboundy2;
     int   fade_effect;
     int   bg_frame_locked;
@@ -337,6 +337,14 @@ struct GameState {
     void SetIgnoreInput(int timeout_ms);
     // Clears ignore input state
     void ClearIgnoreInput();
+
+    // Set how the last blocking wait was skipped
+    void SetWaitSkipResult(int how, int data = 0);
+    // Returns the code of the latest blocking wait skip method.
+    // * positive value means a key code;
+    // * negative value means a -(mouse code + 1);
+    // * 0 means timeout.
+    int GetWaitSkipResult() const;
 
     //
     // Voice speech management

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -914,7 +914,7 @@ void SetGraphicalVariable (const char *varName, int p_value) {
 int WaitImpl(int skip_type, int nloops)
 {
     play.wait_counter = nloops;
-    play.wait_skipped_by = SKIP_AUTOTIMER; // we set timer flag by default to simplify that case
+    play.wait_skipped_by = SKIP_NONE;
     play.wait_skipped_by_data = 0;
     play.key_skip_wait = skip_type;
 
@@ -925,13 +925,8 @@ int WaitImpl(int skip_type, int nloops)
         // < 3.5.1 return 1 is skipped by user input, otherwise 0
         return (play.wait_skipped_by & (SKIP_KEYPRESS | SKIP_MOUSECLICK) != 0) ? 1 : 0;
     }
-    // >= 3.5.1 return positive keycode, negative mouse button code, or 0 as time-out
-    switch (play.wait_skipped_by)
-    {
-    case SKIP_KEYPRESS: return play.wait_skipped_by_data;
-    case SKIP_MOUSECLICK: return -(play.wait_skipped_by_data + 1); // convert to 1-based code and negate
-    default: return 0;
-    }
+    // >= 3.5.1 return skipping code
+    return play.GetWaitSkipResult();
 }
 
 void scrWait(int nloops) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -590,8 +590,6 @@ void recreate_guibg_image(GUIMain *tehgui)
   }
 }
 
-extern int is_complete_overlay;
-
 int gui_get_interactable(int x,int y)
 {
     if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0))
@@ -613,7 +611,7 @@ int gui_on_mouse_move()
             if (guis[guin].IsInteractableAt(mousex, mousey)) mouse_over_gui=guin;
 
             if (guis[guin].PopupStyle!=kGUIPopupMouseY) continue;
-            if (is_complete_overlay>0) break;  // interfaces disabled
+            if (play.complete_overlay_on) break;  // interfaces disabled
             //    if (play.disabled_user_interface>0) break;
             if (ifacepopped==guin) continue;
             if (!guis[guin].IsVisible()) continue;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -43,7 +43,6 @@ extern IGraphicsDriver *gfxDriver;
 
 
 std::vector<ScreenOverlay> screenover;
-int is_complete_overlay=0,is_text_overlay=0;
 
 void Overlay_Remove(ScriptOverlay *sco) {
     sco->Remove();
@@ -160,8 +159,8 @@ void remove_screen_overlay_index(size_t over_idx)
 {
     ScreenOverlay &over = screenover[over_idx];
     dispose_overlay(over);
-    if (over.type==OVER_COMPLETE) is_complete_overlay--;
-    if (over.type==OVER_TEXTMSG) is_text_overlay--;
+    if (over.type==OVER_COMPLETE) play.complete_overlay_on = false;
+    if (over.type==OVER_TEXTMSG) play.text_overlay_on = false;
     screenover.erase(screenover.begin() + over_idx);
     // if an overlay before the sierra-style speech one is removed,
     // update the index
@@ -196,8 +195,8 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, bool alphaChann
 
 size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel)
 {
-    if (type==OVER_COMPLETE) is_complete_overlay++;
-    if (type==OVER_TEXTMSG) is_text_overlay++;
+    if (type==OVER_COMPLETE) play.complete_overlay_on = true;
+    if (type==OVER_TEXTMSG) play.text_overlay_on = true;
     if (type==OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
         for (int id = OVER_CUSTOM + 1; id < screenover.size() + OVER_CUSTOM + 1; ++id) {

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -43,9 +43,6 @@ size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 
-extern int is_complete_overlay;
-extern int is_text_overlay; // blocking text overlay on screen
 
 extern std::vector<ScreenOverlay> screenover;
-
 #endif // __AGS_EE_AC__OVERLAY_H

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -40,6 +40,8 @@ void remove_screen_overlay(int type);
 void get_overlay_position(const ScreenOverlay &over, int *x, int *y);
 size_t add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
 size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false);
+// Creates and registers a managed script object for existing internal overlay
+ScriptOverlay* add_scriptobj_for_overlay(ScreenOverlay &over);
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -21,6 +21,8 @@ int user_to_internal_skip_speech(SkipSpeechStyle userval)
 {
     switch (userval)
     {
+    case kSkipSpeechNone:
+        return SKIP_NONE;
     case kSkipSpeechKeyMouseTime:
         return SKIP_AUTOTIMER | SKIP_KEYPRESS | SKIP_MOUSECLICK;
     case kSkipSpeechKeyTime:
@@ -37,7 +39,7 @@ int user_to_internal_skip_speech(SkipSpeechStyle userval)
         return SKIP_MOUSECLICK;
     default:
         quit("user_to_internal_skip_speech: unknown userval");
-        return 0;
+        return SKIP_NONE;
     }
 }
 
@@ -75,7 +77,7 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val)
             return kSkipSpeechMouse;
         }
     }
-    return kSkipSpeechUndefined;
+    return kSkipSpeechNone;
 }
 
 //=============================================================================

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -20,7 +20,7 @@
 
 enum SkipSpeechStyle
 {
-    kSkipSpeechUndefined    = -1,
+    kSkipSpeechNone         = -1,
     kSkipSpeechKeyMouseTime =  0,
     kSkipSpeechKeyTime      =  1,
     kSkipSpeechTime         =  2,
@@ -29,7 +29,7 @@ enum SkipSpeechStyle
     kSkipSpeechKey          =  5,
     kSkipSpeechMouse        =  6,
 
-    kSkipSpeechFirst        = kSkipSpeechKeyMouseTime,
+    kSkipSpeechFirst        = kSkipSpeechNone,
     kSkipSpeechLast         = kSkipSpeechMouse
 };
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -349,8 +349,8 @@ void DoBeforeRestore(PreservedParams &pp)
     delete raw_saved_screen;
     raw_saved_screen = nullptr;
     remove_screen_overlay(-1);
-    is_complete_overlay = 0;
-    is_text_overlay = 0;
+    play.complete_overlay_on = false;
+    play.text_overlay_on = false;
 
     // cleanup dynamic sprites
     // NOTE: sprite 0 is a special constant sprite that cannot be dynamic

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1009,6 +1009,7 @@ void engine_init_game_settings()
     play.music_queue_size = 0;
     play.shakesc_length = 0;
     play.wait_counter=0;
+    play.SetWaitSkipResult(SKIP_NONE);
     play.key_skip_wait = SKIP_NONE;
     play.cur_music_number=-1;
     play.music_repeat=1;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1078,6 +1078,8 @@ void engine_init_game_settings()
     play.speech_has_voice = false;
     play.speech_voice_blocking = false;
     play.speech_in_post_state = false;
+    play.complete_overlay_on = false;
+    play.text_overlay_on = false;
     play.narrator_speech = game.playercharacter;
     play.crossfading_out_channel = 0;
     play.speech_textwindow_gui = game.options[OPT_TWCUSTOM];

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -246,13 +246,14 @@ static void check_mouse_controls()
 
         if (play.fast_forward || play.IsIgnoringInput()) { /* do nothing if skipping cutscene or input disabled */ }
         else if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0) {
-            play.wait_counter = 0;
-            play.wait_skipped_by = SKIP_MOUSECLICK;
-            play.wait_skipped_by_data = mbut;
+            play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
         }
         else if (play.text_overlay_on) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
+            {
+                play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
                 remove_screen_overlay(OVER_TEXTMSG);
+            }
         }
         else if (!IsInterfaceEnabled()) ;  // blocking cutscene, ignore mouse
         else if (pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut+1)) {
@@ -416,17 +417,17 @@ static void check_keyboard_controls()
             if ((play.skip_speech_specific_key > 0) &&
                 (kgn != play.skip_speech_specific_key)) { }
             else
+            {
+                play.SetWaitSkipResult(SKIP_KEYPRESS, kgn);
                 remove_screen_overlay(OVER_TEXTMSG);
+            }
         }
 
         return;
     }
 
     if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
-        play.wait_counter = 0;
-        play.wait_skipped_by = SKIP_KEYPRESS;
-        play.wait_skipped_by_data = kgn;
-        debug_script_log("Keypress code %d ignored - in Wait", kgn);
+        play.SetWaitSkipResult(SKIP_KEYPRESS, kgn);
         return;
     }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -64,7 +64,6 @@ extern AnimatingGUIButton animbuts[MAX_ANIMATING_BUTTONS];
 extern int numAnimButs;
 extern int mouse_on_iface;   // mouse cursor is over this interface
 extern int ifacepopped;
-extern int is_text_overlay;
 extern volatile char want_exit, abort_engine;
 extern int proper_exit,our_eip;
 extern int displayed_room, starting_room, in_new_room, new_room_was;
@@ -251,7 +250,7 @@ static void check_mouse_controls()
             play.wait_skipped_by = SKIP_MOUSECLICK;
             play.wait_skipped_by_data = mbut;
         }
-        else if (is_text_overlay > 0) {
+        else if (play.text_overlay_on) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
                 remove_screen_overlay(OVER_TEXTMSG);
         }
@@ -410,7 +409,7 @@ static void check_keyboard_controls()
     }
 
     // skip speech if desired by Speech.SkipStyle
-    if ((is_text_overlay > 0) && (play.cant_skip_speech & SKIP_KEYPRESS)) {
+    if ((play.text_overlay_on) && (play.cant_skip_speech & SKIP_KEYPRESS)) {
         // only allow a key to remove the overlay if the icon bar isn't up
         if (IsGamePaused() == 0) {
             // check if it requires a specific keypress
@@ -491,7 +490,8 @@ static void check_keyboard_controls()
     //     return;
     // }
 
-    if ((kgn == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) && (play.wait_counter < 1) && (is_text_overlay == 0) && (restrict_until == 0)) {
+    if ((kgn == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) && (play.wait_counter < 1) &&
+        (!play.text_overlay_on) && (restrict_until == 0)) {
         // make sure we can't interrupt a Wait()
         // and desync the music to cutscene
         play.debug_mode++;
@@ -878,7 +878,7 @@ static int ShouldStayInWaitMode() {
         if (wkptr[0]<0) retval=0;
     }
     else if (restrict_until==UNTIL_NOOVERLAY) {
-        if (is_text_overlay < 1) retval=0;
+        if (!play.text_overlay_on) retval=0;
     }
     else if (restrict_until==UNTIL_INTIS0) {
         int*wkptr=(int*)user_disabled_data;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -283,10 +283,12 @@ void update_speech_and_messages()
     {
       if (play.fast_forward > 0)
       {
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
         remove_screen_overlay(OVER_TEXTMSG);
       }
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
         remove_screen_overlay(OVER_TEXTMSG);
         play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
       }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -61,7 +61,6 @@ extern int facetalkBlinkLoop;
 extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement_y;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
-extern int is_text_overlay;
 extern IGraphicsDriver *gfxDriver;
 
 int do_movelist_move(short*mlnum,int*xx,int*yy) {
@@ -412,7 +411,7 @@ void update_sierra_speech()
     }
 
     // is_text_overlay might be 0 if it was only just destroyed this loop
-    if ((updatedFrame) && (is_text_overlay > 0)) {
+    if ((updatedFrame) && (play.text_overlay_on)) {
 
       if (updatedFrame & 1)
         CheckViewFrame (facetalkview, facetalkloop, facetalkframe);


### PR DESCRIPTION
Done by user's request, these two properties give game dev little more control over built-in blocking speech in AGS.
These do not require any data format change, and only expose data which already exists internally in the engine.

### Game.BlockingTextOverlay
`readonly attribute Overlay *Game.BlockingTextOverlay` returns special overlay created for the blocking speech, or null if no such text is on screen.

Because of how blocking speech works, this overlay will be only accessible in `repeatedly_execute_always` and `late_repeatedly_execute_always` script callbacks.<br>
But this is a valid overlay in every aspect: you can even change it's coordinates and text.<br>
Calling Remove() function is also legal, and will correctly stop the current blocking speech (the engine was already programmed to rely strictly on overlay's presence).

**IMPORTANT:** in theory, this will return both overlay for blocking Say command and Display command. But the caveat here is that no script callbacks are running during Display in current engine, it's a kind of a "super-blocking" function, but if there will be such function then this property will work for Display as well.

When the speech is removed, script object is detached from actual overlay and invalidated: its Overlay.Valid property will be returning false, and attempt to call any other property or function will result in script error. This is essential to know if you store Overlay pointer in a variable for later use.

For every speech line there's a new overlay generated by the engine. This gives an opportunity to detect the exact game frame when the speech line changed, by comparing previously saved pointer with Game.BlockingTextOverlay's value.


### eSkipNone

`eSkipNone` option added for SkipSpeechStyle. When set, speech may only be skipped by a script command (i.e. - calling Game.BlockingTextOverlay.Remove()).<br>
This complements similar mode added for Wait and cutscenes lately.


### Game.BlockingWaitSkipped
`readonly attribute int Game.BlockingWaitSkipped` returns a code telling how the last blocking wait action was ended. This code is equivalent to the return value of the Wait* functions, introduced previously (#1084). At the moment this property is updated by three sorts of skippable blocking actions: Say*, Display* and Wait*.