### PR TITLE
Engine: let D3D9 decide refresh rate on its own

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -682,8 +682,10 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
     d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
 
   /* If full screen, specify the refresh rate */
-  if ((d3dpp.Windowed == FALSE) && (mode.RefreshRate > 0))
-    d3dpp.FullScreen_RefreshRateInHz = mode.RefreshRate;
+  // TODO find a way to avoid the wrong refreshrate to be set on mode.RefreshRate
+  // for now it's best to let it set automatically, so we prevent alt tab delays due to mismatching refreshrates
+  //if ((d3dpp.Windowed == FALSE) && (mode.RefreshRate > 0))
+  //  d3dpp.FullScreen_RefreshRateInHz = mode.RefreshRate;
 
   if (_initGfxCallback != NULL)
     _initGfxCallback(&d3dpp);


### PR DESCRIPTION
GetMode() may return the wrong refresh rate in the case the monitor is not at 60hz, moreover the config refresh setting never makes it far enough to be used.
Leaving it as D3DPRESENT_RATE_DEFAULT will ensure switching from windowed to fullscreen is quick and reliable, as long as it's the same resolution.