### PR TITLE
Refactored room editor to use graphics from C# instead of AGS.Native

### DIFF
--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 
 namespace AGS.Types
 {
@@ -165,6 +166,26 @@ namespace AGS.Types
         {
             _room.BottomEdgeY = bottomEdgeY;
             Assert.That(_room.BottomEdgeY, Is.EqualTo(bottomEdgeY));
+        }
+
+        [TestCase(1, RoomAreaMaskType.WalkBehinds, 1.00)]
+        [TestCase(2, RoomAreaMaskType.WalkBehinds, 1.00)]
+        [TestCase(1, RoomAreaMaskType.Hotspots, 1.00)]
+        [TestCase(2, RoomAreaMaskType.Hotspots, 0.50)]
+        [TestCase(3, RoomAreaMaskType.Hotspots, 0.33)]
+        [TestCase(4, RoomAreaMaskType.Hotspots, 0.25)]
+        [TestCase(1, RoomAreaMaskType.WalkableAreas, 1.00)]
+        [TestCase(1, RoomAreaMaskType.Regions, 1.00)]
+        public void GetsMaskScale(int maskResolution, RoomAreaMaskType mask, double expected)
+        {
+            _room.MaskResolution = maskResolution;
+            Assert.That(_room.GetMaskScale(mask), Is.EqualTo(expected).Within(0.009));
+        }
+
+        [Test]
+        public void GetsMaskScaleThrowsExceptionWithIllegalMask()
+        {
+            Assert.Throws<ArgumentException>(() => _room.GetMaskScale(RoomAreaMaskType.None));
         }
     }
 }

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -397,6 +397,7 @@
     <Compile Include="Resources\ResourceManager.cs" />
     <Compile Include="TextProcessing\APITypeDef.cs" />
     <Compile Include="Utils\AlternateStreams.cs" />
+    <Compile Include="Utils\BitmapExtensions.cs" />
     <Compile Include="Utils\SourceControlProvider.cs" />
     <Compile Include="GUI\TabbedDocumentManager.cs">
     </Compile>

--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
@@ -197,6 +198,12 @@ namespace AGS.Editor
         private void GUIController_OnEditorShutdown()
         {
             _componentController.ShutdownComponents();
+
+            foreach (IDisposable component in _componentController.Components.OfType<IDisposable>())
+            {
+                component.Dispose();
+            }
+
             _nativeProxy.Dispose();
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -601,7 +601,8 @@ namespace AGS.Editor.Components
             Room room = (Room)parameter;
             _agsEditor.RegenerateScriptHeader(room);
             List<Script> headers = (List<Script>)_agsEditor.GetAllScriptHeaders();
-            _agsEditor.CompileScript(room.Script, headers, null);
+            _agsEditor.CompileScript(room.Script, headers, null, true);
+            ((IRoomController)this).Save();
 
             return null;            
         }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1669,6 +1669,7 @@ namespace AGS.Editor.Components
             if (maskType != RoomAreaMaskType.None)
             {
                 Bitmap mask8bpp = _maskCache[maskType];
+                ColorPalette paletteBackup = mask8bpp.Palette;
 
                 // Color not selected mask areas to gray
                 if (_grayOutMasks)
@@ -1700,6 +1701,7 @@ namespace AGS.Editor.Components
                 attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 
                 g.DrawImage(mask8bpp, drawingArea, 0, 0, mask8bpp.Width, mask8bpp.Height, GraphicsUnit.Pixel, attributes);
+                mask8bpp.Palette = paletteBackup;
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1524,6 +1524,21 @@ namespace AGS.Editor.Components
             _loadedRoom.Modified = true;
         }
 
+        void IRoomController.DeleteBackground(int background)
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            // TODO Replace with bitmap deleting from disk with C# when room is open format
+            lock (_loadedRoom)
+            {
+                _nativeProxy.DeleteBackground(_loadedRoom, background);
+            }
+            _loadedRoom.Modified = true;
+        }
+
         Bitmap IRoomController.GetMask(RoomAreaMaskType mask)
         {
             if (_loadedRoom == null)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -609,7 +609,7 @@ namespace AGS.Editor.Components
             Room room = (Room)parameter;
             _agsEditor.RegenerateScriptHeader(room);
             List<Script> headers = (List<Script>)_agsEditor.GetAllScriptHeaders();
-            _agsEditor.CompileScript(room.Script, headers, null, true);
+            _agsEditor.CompileScript(room.Script, headers, null);
             ((IRoomController)this).Save();
 
             return null;            

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1604,6 +1604,20 @@ namespace AGS.Editor.Components
 			g.ReleaseHdc(hdc);
 		}
 
+        void IRoomController.CopyWalkableAreaMaskToRegions()
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            using (Bitmap bmp = ((IRoomController)this).GetMask(RoomAreaMaskType.WalkableAreas))
+            {
+                ((IRoomController)this).SetMask(RoomAreaMaskType.Regions, bmp);
+            }
+            _loadedRoom.Modified = true;
+        }
+
 		bool IRoomController.GreyOutNonSelectedMasks
 		{
 			set { _nativeProxy.GreyOutNonSelectedMasks = value; }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1720,12 +1720,12 @@ namespace AGS.Editor.Components
             {
                 if (maskType == RoomAreaMaskType.None) continue;
 
-                Bitmap mask = _maskCache[maskType];
-                Bitmap scaled = maskType == RoomAreaMaskType.WalkBehinds
-                    ? mask.Scale(baseWidth, baseHeight) // Walk-behinds are always 1:1 of the primary background
-                    : mask.Scale(scaledWidth, scaledHeight); // Other masks are 1:x where X is MaskResolution
-                mask.Dispose();
-                _maskCache[maskType] = scaled;
+                using (Bitmap mask = _maskCache[maskType])
+                {
+                    _maskCache[maskType] = maskType == RoomAreaMaskType.WalkBehinds
+                        ? mask.ScaleIndexed(baseWidth, baseHeight) // Walk-behinds are always 1:1 of the primary background
+                        : mask.ScaleIndexed(scaledWidth, scaledHeight); // Other masks are 1:x where X is MaskResolution
+                }
             }
 
             _loadedRoom.Modified = true;

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1540,6 +1540,10 @@ namespace AGS.Editor.Components
             {
                 throw new InvalidOperationException("No room is currently loaded");
             }
+            if (bmp == null)
+            {
+                throw new ArgumentNullException(nameof(bmp));
+            }
 
             _loadedRoom.Width = bmp.Width;
             _loadedRoom.Height = bmp.Height;
@@ -1596,6 +1600,10 @@ namespace AGS.Editor.Components
             if (_loadedRoom == null)
             {
                 throw new InvalidOperationException("No room is currently loaded");
+            }
+            if (bmp == null)
+            {
+                throw new ArgumentNullException(nameof(bmp));
             }
 
             // TODO Replace with bitmap saving to disk with C# when room is open format

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1655,20 +1655,6 @@ namespace AGS.Editor.Components
             }
         }
 
-        void IRoomController.CopyWalkableAreaMaskToRegions()
-        {
-            if (_loadedRoom == null)
-            {
-                throw new InvalidOperationException("No room is currently loaded");
-            }
-
-            using (Bitmap bmp = ((IRoomController)this).GetMask(RoomAreaMaskType.WalkableAreas))
-            {
-                ((IRoomController)this).SetMask(RoomAreaMaskType.Regions, bmp);
-            }
-            _loadedRoom.Modified = true;
-        }
-
         void IRoomController.AdjustMaskResolution()
         {
             if (_loadedRoom == null)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1676,7 +1676,7 @@ namespace AGS.Editor.Components
                 {
                     ColorPalette palette = mask8bpp.Palette;
 
-                    for (int i = 0; i < 256; i++)
+                    for (int i = 1; i < 256; i++) // Skip i == 0 because no area should be transparent
                     {
                         int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * 2 : 0;
                         palette.Entries[i] = Color.FromArgb(gray, gray, gray);

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1641,17 +1641,18 @@ namespace AGS.Editor.Components
                     mask8bpp.Palette = palette;
                 }
 
-                using (Bitmap mask32bpp = new Bitmap(mask8bpp)) // We need to support transparency
-                {
-                    mask32bpp.SetAlpha(100 - maskTransparency + 155);
+                // Prepare alpha component
+                float alpha = (100 - maskTransparency + 155) / 255f;
+                ColorMatrix colorMatrix = new ColorMatrix { Matrix33 = alpha };
+                ImageAttributes attributes = new ImageAttributes();
+                attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 
-                    // x and y is already scaled from outside the method call
-                    Rectangle drawingArea = new Rectangle(
-                        x, y, (int)(background.Width * scaleFactor), (int)(background.Height * scaleFactor));
+                // x and y is already scaled from outside the method call
+                Rectangle drawingArea = new Rectangle(
+                    x, y, (int)(background.Width * scaleFactor), (int)(background.Height * scaleFactor));
 
-                    g.DrawImage(background, drawingArea);
-                    g.DrawImage(mask32bpp, drawingArea);
-                }
+                g.DrawImage(background, drawingArea);
+                g.DrawImage(mask8bpp, drawingArea, 0, 0, mask8bpp.Width, mask8bpp.Height, GraphicsUnit.Pixel, attributes);
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1509,6 +1509,21 @@ namespace AGS.Editor.Components
             return _nativeProxy.GetBitmapForBackground(_loadedRoom, background);
         }
 
+        void IRoomController.SetBackground(int background, Bitmap bmp)
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            _loadedRoom.Width = bmp.Width;
+            _loadedRoom.Height = bmp.Height;
+            // TODO Replace with bitmap saving to disk with C# when room is open format
+            _nativeProxy.ImportBackground(
+                _loadedRoom, background, bmp, _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false);
+            _loadedRoom.Modified = true;
+        }
+
         Bitmap IRoomController.GetMask(RoomAreaMaskType mask)
         {
             if (_loadedRoom == null)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1508,6 +1508,17 @@ namespace AGS.Editor.Components
             return _nativeProxy.GetBitmapForBackground(_loadedRoom, background);
         }
 
+        Bitmap IRoomController.GetMask(RoomAreaMaskType mask)
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            // TODO Replace with bitmap loading from disk with C# when room is open format
+            return _nativeProxy.ExportAreaMask(_loadedRoom, mask);
+        }
+
         int IRoomController.GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y)
 		{
 			if (_loadedRoom == null)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1616,43 +1616,47 @@ namespace AGS.Editor.Components
             }
 
             using (Bitmap background = ((IRoomController)this).GetBackground(backgroundNumber))
-            using (Bitmap mask8bpp = ((IRoomController)this).GetMask(maskType))
             {
-                // Color not selected mask areas to gray
-                if (_grayOutMasks)
-                {
-                    ColorPalette palette = mask8bpp.Palette;
-
-                    for (int i = 0; i < 256; i++)
-                    {
-                        int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * 2 : 0;
-                        palette.Entries[i] = Color.FromArgb(gray, gray, gray);
-                    }
-
-                    // Highlight the currently selected area colour
-                    if (selectedArea > 0)
-                    {
-                        // if a bright colour, use it, else, draw in red
-                        palette.Entries[selectedArea] = selectedArea < 15 && selectedArea != 7 && selectedArea != 8
-                            ? _agsEditor.CurrentGame.Palette[selectedArea].Colour
-                            : Color.FromArgb(60, 0, 0);
-                    }
-
-                    mask8bpp.Palette = palette;
-                }
-
-                // Prepare alpha component
-                float alpha = (100 - maskTransparency + 155) / 255f;
-                ColorMatrix colorMatrix = new ColorMatrix { Matrix33 = alpha };
-                ImageAttributes attributes = new ImageAttributes();
-                attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
-
                 // x and y is already scaled from outside the method call
                 Rectangle drawingArea = new Rectangle(
                     x, y, (int)(background.Width * scaleFactor), (int)(background.Height * scaleFactor));
 
                 g.DrawImage(background, drawingArea);
-                g.DrawImage(mask8bpp, drawingArea, 0, 0, mask8bpp.Width, mask8bpp.Height, GraphicsUnit.Pixel, attributes);
+
+                if (maskType != RoomAreaMaskType.None)
+                using (Bitmap mask8bpp = ((IRoomController)this).GetMask(maskType))
+                {
+                    // Color not selected mask areas to gray
+                    if (_grayOutMasks)
+                    {
+                        ColorPalette palette = mask8bpp.Palette;
+
+                        for (int i = 0; i < 256; i++)
+                        {
+                            int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * 2 : 0;
+                            palette.Entries[i] = Color.FromArgb(gray, gray, gray);
+                        }
+
+                        // Highlight the currently selected area colour
+                        if (selectedArea > 0)
+                        {
+                            // if a bright colour, use it, else, draw in red
+                            palette.Entries[selectedArea] = selectedArea < 15 && selectedArea != 7 && selectedArea != 8
+                                ? _agsEditor.CurrentGame.Palette[selectedArea].Colour
+                                : Color.FromArgb(60, 0, 0);
+                        }
+
+                        mask8bpp.Palette = palette;
+                    }
+
+                    // Prepare alpha component
+                    float alpha = (100 - maskTransparency + 155) / 255f;
+                    ColorMatrix colorMatrix = new ColorMatrix { Matrix33 = alpha };
+                    ImageAttributes attributes = new ImageAttributes();
+                    attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
+
+                    g.DrawImage(mask8bpp, drawingArea, 0, 0, mask8bpp.Width, mask8bpp.Height, GraphicsUnit.Pixel, attributes);
+                }
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -601,8 +601,6 @@ namespace AGS.Editor.Components
             List<Script> headers = (List<Script>)_agsEditor.GetAllScriptHeaders();
             _agsEditor.CompileScript(room.Script, headers, null);
 
-            _nativeProxy.SaveRoom(room);
-            room.Modified = false;
             return null;            
         }
 
@@ -1497,6 +1495,17 @@ namespace AGS.Editor.Components
 			}
 			return LoadDifferentRoom((UnloadedRoom)roomToLoad);
 		}
+
+        void IRoomController.Save()
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            _nativeProxy.SaveRoom(_loadedRoom);
+            _loadedRoom.Modified = false;
+        }
 
         Bitmap IRoomController.GetBackground(int background)
         {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1550,6 +1550,18 @@ namespace AGS.Editor.Components
             return _nativeProxy.ExportAreaMask(_loadedRoom, mask);
         }
 
+        void IRoomController.SetMask(RoomAreaMaskType mask, Bitmap bmp)
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            // TODO Replace with bitmap saving to disk with C# when room is open format
+            _nativeProxy.SetAreaMask(_loadedRoom, mask, bmp);
+            _loadedRoom.Modified = true;
+        }
+
         int IRoomController.GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y)
         {
             if (_loadedRoom == null)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -990,7 +990,7 @@ namespace AGS.Editor.Components
         {
             string paneTitle = "Room " + _loadedRoom.Number + (_loadedRoom.Modified ? " *" : "");
 
-            RoomSettingsEditor editor = new RoomSettingsEditor(_loadedRoom);
+            RoomSettingsEditor editor = new RoomSettingsEditor(_loadedRoom, this);
             _roomSettings = new ContentDocument(editor,
                 paneTitle, this, ROOM_ICON_LOADED, ConstructPropertyObjectList(_loadedRoom));
             if (previousDockData != null && previousDockData.DockState != DockingState.Document)
@@ -1497,7 +1497,18 @@ namespace AGS.Editor.Components
 			return LoadDifferentRoom((UnloadedRoom)roomToLoad);
 		}
 
-		int IRoomController.GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y)
+        Bitmap IRoomController.GetBackground(int background)
+        {
+            if (_loadedRoom == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            // TODO Replace with bitmap loading from disk with C# when room is open format
+            return _nativeProxy.GetBitmapForBackground(_loadedRoom, background);
+        }
+
+        int IRoomController.GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y)
 		{
 			if (_loadedRoom == null)
 			{

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1639,15 +1639,15 @@ namespace AGS.Editor.Components
 
         void IRoomController.DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor)
 		{
-			((IRoomController)this).DrawRoomBackground(g, x, y, backgroundNumber, (double)scaleFactor, RoomAreaMaskType.None, 0, 0);
+			((IRoomController)this).DrawRoomBackground(g, new Point(x, y), backgroundNumber, (double)scaleFactor, RoomAreaMaskType.None, 0, 0);
 		}
 
 		void IRoomController.DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea)
 		{
-            ((IRoomController)this).DrawRoomBackground(g, x, y, backgroundNumber, (double)scaleFactor, maskType, maskTransparency, selectedArea);
+            ((IRoomController)this).DrawRoomBackground(g, new Point(x, y), backgroundNumber, (double)scaleFactor, maskType, maskTransparency, selectedArea);
         }
 
-        void IRoomController.DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea)
+        void IRoomController.DrawRoomBackground(Graphics g, Point point, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea)
         {
             if (_loadedRoom == null)
             {
@@ -1662,7 +1662,7 @@ namespace AGS.Editor.Components
 
             // x and y is already scaled from outside the method call
             Rectangle drawingArea = new Rectangle(
-                x, y, (int)(background.Width * scaleFactor), (int)(background.Height * scaleFactor));
+                point.X, point.Y, (int)(background.Width * scaleFactor), (int)(background.Height * scaleFactor));
 
             g.DrawImage(background, drawingArea);
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -813,7 +813,7 @@ namespace AGS.Editor.Components
             _loadedRoom.Modified = ImportExport.CreateInteractionScripts(_loadedRoom, errors);
             _loadedRoom.Modified |= HookUpInteractionVariables(_loadedRoom);
             _loadedRoom.Modified |= AddPlayMusicCommandToPlayerEntersRoomScript(_loadedRoom, errors);
-            _loadedRoom.Modified |= ApplyDefaultMaskResolution(_loadedRoom);
+            _loadedRoom.Modified |= ApplyDefaultMaskResolution();
 			if (_loadedRoom.Script.Modified)
 			{
 				if (_roomScriptEditors.ContainsKey(_loadedRoom.Number))
@@ -868,18 +868,17 @@ namespace AGS.Editor.Components
             return scriptModified;
         }
 
-        private bool ApplyDefaultMaskResolution(Room room)
+        private bool ApplyDefaultMaskResolution()
         {
             // TODO: currently the only way to know if the room was not affected by
             // game's settings is to test whether it has game's ID. Investigate for
             // a better way later?
-            if (room.GameID != _agsEditor.CurrentGame.Settings.UniqueID)
+            if (_loadedRoom.GameID != _agsEditor.CurrentGame.Settings.UniqueID)
             {
                 int mask = _agsEditor.CurrentGame.Settings.DefaultRoomMaskResolution;
-                if (mask != room.MaskResolution)
+                if (mask != _loadedRoom.MaskResolution)
                 {
-                    room.MaskResolution = mask;
-                    ((IRoomController)this).AdjustMaskResolution();
+                    ((IRoomController)this).AdjustMaskResolution(mask);
                     return true;
                 }
             }
@@ -1131,7 +1130,7 @@ namespace AGS.Editor.Components
                 if (Factory.GUIController.ShowQuestion("The new mask resolution is smaller and this will reduce mask's precision and some pixels may be lost in the process. Do you want to proceed?") != DialogResult.Yes)
                     return;
             }
-            ((IRoomController)this).AdjustMaskResolution();
+            ((IRoomController)this).AdjustMaskResolution(newValue);
         }
 
         protected override void AddNewItemCommandsToFolderContextMenu(string controlID, IList<MenuCommand> menu)
@@ -1705,13 +1704,14 @@ namespace AGS.Editor.Components
             }
         }
 
-        void IRoomController.AdjustMaskResolution()
+        void IRoomController.AdjustMaskResolution(int maskResolution)
         {
             if (_loadedRoom == null)
             {
                 throw new InvalidOperationException("No room is currently loaded");
             }
 
+            _loadedRoom.MaskResolution = maskResolution;
             Bitmap bg = _backgroundCache[0];
             int baseWidth = bg.Width;
             int baseHeight = bg.Height;

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1677,7 +1677,8 @@ namespace AGS.Editor.Components
 
                     for (int i = 1; i < 256; i++) // Skip i == 0 because no area should be transparent
                     {
-                        int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * 2 : 0;
+                        const int intensity = 6; // Force the gray scale lighter so that it's easier to see
+                        int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * intensity : 0;
                         palette.Entries[i] = Color.FromArgb(gray, gray, gray);
                     }
 

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -292,11 +292,6 @@ namespace AGS.Editor
             _native.DrawSpriteToBuffer(spriteNum, x, y, scale);
         }
 
-        public void DrawLineOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int x2, int y2, int color)
-        {
-            _native.DrawLineOntoMask(room, mask, x1, y1, x2, y2, color);
-        }
-
 		public void DrawFilledRectOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int x2, int y2, int color)
 		{
 			_native.DrawFilledRectOntoMask(room, mask, x1, y1, x2, y2, color);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -292,11 +292,6 @@ namespace AGS.Editor
             _native.DrawSpriteToBuffer(spriteNum, x, y, scale);
         }
 
-		public void DrawFilledRectOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int x2, int y2, int color)
-		{
-			_native.DrawFilledRectOntoMask(room, mask, x1, y1, x2, y2, color);
-		}
-
         public void DrawFillOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int color)
         {
             _native.DrawFillOntoMask(room, mask, x1, y1, color);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using AGS.Editor.Preferences;
 
 namespace AGS.Editor
 {
@@ -257,11 +256,6 @@ namespace AGS.Editor
             _native.SaveRoomFile(roomToSave);
         }
 
-        public void DrawRoomBackground(IntPtr hDC, Room room, int x, int y, int backgroundNumber, float scaleFactor, RoomAreaMaskType maskType, int selectedArea, int maskTransparency)
-        {
-            _native.DrawRoomBackground((int)hDC, room, x, y, backgroundNumber, scaleFactor, maskType, selectedArea, maskTransparency);
-        }
-
         public void ImportBackground(Room room, int backgroundNumber, Bitmap bmp, bool useExactPalette, bool sharePalette)
         {
             _native.ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
@@ -276,26 +270,6 @@ namespace AGS.Editor
         {
             return _native.GetBitmapForBackground(room, backgroundNumber);
         }
-
-        public void CreateBuffer(int width, int height)
-        {
-            _native.CreateBuffer(width, height);
-        }
-
-        public void RenderBufferToHDC(IntPtr hDC)
-        {
-            _native.RenderBufferToHDC((int)hDC);
-        }
-
-        public void DrawSpriteToBuffer(int spriteNum, int x, int y, float scale)
-        {
-            _native.DrawSpriteToBuffer(spriteNum, x, y, scale);
-        }
-
-		public bool GreyOutNonSelectedMasks
-		{
-			set { _native.SetGreyedOutMasksEnabled(value); }
-		}
 
         public void ImportAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
         {

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -322,17 +322,6 @@ namespace AGS.Editor
 			set { _native.SetGreyedOutMasksEnabled(value); }
 		}
 
-        public int GetAreaMaskPixel(Room room, RoomAreaMaskType mask, int x, int y)
-        {
-            int pixel = _native.GetAreaMaskPixel(room, mask, x, y);
-            // if it lies outside the bitmap, just return 0
-            if (pixel < 0)
-            {
-                pixel = 0;
-            }
-            return pixel;
-        }
-
         public void CreateUndoBuffer(Room room, RoomAreaMaskType mask)
         {
             _native.CreateUndoBuffer(room, mask);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -297,26 +297,6 @@ namespace AGS.Editor
 			set { _native.SetGreyedOutMasksEnabled(value); }
 		}
 
-        public void CreateUndoBuffer(Room room, RoomAreaMaskType mask)
-        {
-            _native.CreateUndoBuffer(room, mask);
-        }
-
-        public bool DoesUndoBufferExist()
-        {
-            return _native.DoesUndoBufferExist();
-        }
-
-        public void ClearUndoBuffer()
-        {
-            _native.ClearUndoBuffer();
-        }
-
-        public void RestoreFromUndoBuffer(Room room, RoomAreaMaskType mask)
-        {
-            _native.RestoreFromUndoBuffer(room, mask);
-        }
-
         public void ImportAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
         {
             _native.ImportAreaMask(room, mask, bmp);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -271,11 +271,6 @@ namespace AGS.Editor
             return _native.GetBitmapForBackground(room, backgroundNumber);
         }
 
-        public void ImportAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
-        {
-            _native.ImportAreaMask(room, mask, bmp);
-        }
-
         public void SetAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
         {
             _native.SetAreaMask(room, mask, bmp);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -277,11 +277,6 @@ namespace AGS.Editor
             return _native.GetBitmapForBackground(room, backgroundNumber);
         }
 
-        public void AdjustRoomMaskResolution(Room room)
-        {
-            _native.AdjustRoomMaskResolution(room);
-        }
-
         public void CreateBuffer(int width, int height)
         {
             _native.CreateBuffer(width, height);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -312,11 +312,6 @@ namespace AGS.Editor
             _native.DrawFillOntoMask(room, mask, x1, y1, color);
         }
 
-        public void CopyWalkableAreaMaskToRegions(Room room)
-        {
-            _native.CopyWalkableMaskToRegions(room);
-        }
-
 		public bool GreyOutNonSelectedMasks
 		{
 			set { _native.SetGreyedOutMasksEnabled(value); }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -347,6 +347,11 @@ namespace AGS.Editor
             _native.ImportAreaMask(room, mask, bmp);
         }
 
+        public void SetAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
+        {
+            _native.SetAreaMask(room, mask, bmp);
+        }
+
         public Bitmap ExportAreaMask(Room room, RoomAreaMaskType mask)
         {
             return _native.ExportAreaMask(room, mask);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -292,11 +292,6 @@ namespace AGS.Editor
             _native.DrawSpriteToBuffer(spriteNum, x, y, scale);
         }
 
-        public void DrawFillOntoMask(Room room, RoomAreaMaskType mask, int x1, int y1, int color)
-        {
-            _native.DrawFillOntoMask(room, mask, x1, y1, color);
-        }
-
 		public bool GreyOutNonSelectedMasks
 		{
 			set { _native.SetGreyedOutMasksEnabled(value); }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -698,13 +698,12 @@ namespace AGS.Editor
         {
             Point p1 = new Point(_mouseDownX, _mouseDownY);
             Point p2 = new Point(_currentMouseX, _currentMouseY);
-            Color color = Factory.AGSEditor.CurrentGame.Palette[_drawingWithArea].Colour;
             double scale = _room.GetMaskScale(MaskToDraw);
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
-            using (Bitmap drawn = mask.FillRectangle(p1, p2, color, scale))
             {
-                _roomController.SetMask(MaskToDraw, drawn);
+                mask.FillIndexedRectangle(_drawingWithArea, p1, p2, scale);
+                _roomController.SetMask(MaskToDraw, mask);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -715,9 +715,9 @@ namespace AGS.Editor
             double scale = _room.GetMaskScale(MaskToDraw);
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
-            using (Bitmap drawn = mask.FillArea(point, _drawingWithArea, scale))
             {
-                _roomController.SetMask(MaskToDraw, drawn);
+                mask.FillIndexedArea(_drawingWithArea, point, scale);
+                _roomController.SetMask(MaskToDraw, mask);
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -317,7 +317,7 @@ namespace AGS.Editor
             else if (drawMode == AreaDrawMode.Rectangle)
             {
                 Factory.NativeProxy.CreateUndoBuffer(_room, this.MaskToDraw);
-                Factory.NativeProxy.DrawFilledRectOntoMask(_room, this.MaskToDraw, _mouseDownX, _mouseDownY, _currentMouseX, _currentMouseY, _drawingWithArea);
+                DrawFilledRectangleOntoMask();
                 _panel.Invalidate();
                 UpdateUndoButtonEnabledState();
             }
@@ -659,6 +659,20 @@ namespace AGS.Editor
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
             using (Bitmap drawn = mask.DrawLine(start, finish, color, scale))
+            {
+                _roomController.SetMask(MaskToDraw, drawn);
+            }
+        }
+
+        private void DrawFilledRectangleOntoMask()
+        {
+            Point p1 = new Point(_mouseDownX, _mouseDownY);
+            Point p2 = new Point(_currentMouseX, _currentMouseY);
+            Color color = Factory.AGSEditor.CurrentGame.Palette[_drawingWithArea].Colour;
+            double scale = _room.GetMaskScale(MaskToDraw);
+
+            using (Bitmap mask = _roomController.GetMask(MaskToDraw))
+            using (Bitmap drawn = mask.FillRectangle(p1, p2, color, scale))
             {
                 _roomController.SetMask(MaskToDraw, drawn);
             }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -310,7 +310,7 @@ namespace AGS.Editor
             if (drawMode == AreaDrawMode.Line)
             {
                 Factory.NativeProxy.CreateUndoBuffer(_room, this.MaskToDraw);
-                Factory.NativeProxy.DrawLineOntoMask(_room, this.MaskToDraw, _mouseDownX, _mouseDownY, _currentMouseX, _currentMouseY, _drawingWithArea);
+                DrawLineOntoMask();
                 _panel.Invalidate();
                 UpdateUndoButtonEnabledState();
             }
@@ -341,7 +341,7 @@ namespace AGS.Editor
             {
                 if (drawMode == AreaDrawMode.Freehand)
                 {
-					Factory.NativeProxy.DrawLineOntoMask(_room, this.MaskToDraw, _mouseDownX, _mouseDownY, _currentMouseX, _currentMouseY, _drawingWithArea);
+                    DrawLineOntoMask();
                     _mouseDownX = _currentMouseX;
                     _mouseDownY = _currentMouseY;
                     UpdateUndoButtonEnabledState();
@@ -648,6 +648,20 @@ namespace AGS.Editor
             DesignItems.Clear();
             foreach (var item in RoomItemRefs)
                 DesignItems.Add(item.Key, new DesignTimeProperties());
+        }
+
+        private void DrawLineOntoMask()
+        {
+            Point start = new Point(_mouseDownX, _mouseDownY);
+            Point finish = new Point(_currentMouseX, _currentMouseY);
+            Color color = Factory.AGSEditor.CurrentGame.Palette[_drawingWithArea].Colour;
+            double scale = _room.GetMaskScale(MaskToDraw);
+
+            using (Bitmap mask = _roomController.GetMask(MaskToDraw))
+            using (Bitmap drawn = mask.DrawLine(start, finish, color, scale))
+            {
+                _roomController.SetMask(MaskToDraw, drawn);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -423,7 +423,6 @@ namespace AGS.Editor
 			{
                 _roomController.SetMask(MaskToDraw, UndoBufferMask);
                 UndoBufferMask = null;
-                _room.Modified = true;
 				_panel.Invalidate();
 				UpdateUndoButtonEnabledState();
 			}

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -436,8 +436,7 @@ namespace AGS.Editor
 			{
 				if (Factory.GUIController.ShowQuestion("This will overwrite your Regions mask with a copy of your Walkable Areas mask. Are you sure you want to do this?") == DialogResult.Yes)
 				{
-					Factory.NativeProxy.CopyWalkableAreaMaskToRegions(_room);
-					_room.Modified = true;
+                    _roomController.CopyWalkableAreaMaskToRegions();
 					_panel.Invalidate();
 				}
 			}

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -272,7 +272,7 @@ namespace AGS.Editor
             else if (drawMode == AreaDrawMode.Fill)
             {
                 Factory.NativeProxy.CreateUndoBuffer(_room, this.MaskToDraw);
-                Factory.NativeProxy.DrawFillOntoMask(_room, this.MaskToDraw, x, y, _drawingWithArea);
+                FillAreaOntoMask(x, y);
                 _room.Modified = true;
                 UpdateUndoButtonEnabledState();
             }
@@ -673,6 +673,19 @@ namespace AGS.Editor
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
             using (Bitmap drawn = mask.FillRectangle(p1, p2, color, scale))
+            {
+                _roomController.SetMask(MaskToDraw, drawn);
+            }
+        }
+
+        private void FillAreaOntoMask(int x, int y)
+        {
+            Point point = new Point(x, y);
+            Color color = Factory.AGSEditor.CurrentGame.Palette[_drawingWithArea].Colour;
+            double scale = _room.GetMaskScale(MaskToDraw);
+
+            using (Bitmap mask = _roomController.GetMask(MaskToDraw))
+            using (Bitmap drawn = mask.FillArea(point, _drawingWithArea, scale))
             {
                 _roomController.SetMask(MaskToDraw, drawn);
             }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -167,10 +167,6 @@ namespace AGS.Editor
 
         public void Invalidate() { _panel.Invalidate(); }
 
-        public void PaintToHDC(IntPtr hDC, RoomEditorState state)
-        {
-        }
-
         /// <summary>
         /// Draw hint overlay.
         /// NOTE: this is NOT drawing on actual mask, which is performed when
@@ -455,7 +451,7 @@ namespace AGS.Editor
 			{
 				_greyedOutMasks = !_greyedOutMasks;
 				_toolbarIcons[TOOLBAR_INDEX_GREY_OUT_MASKS].Checked = _greyedOutMasks;
-				Factory.NativeProxy.GreyOutNonSelectedMasks = _greyedOutMasks;
+                _roomController.GreyOutNonSelectedMasks = _greyedOutMasks;
 				_panel.Invalidate();
 			}
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -443,7 +443,7 @@ namespace AGS.Editor
 			{
 				if (Factory.GUIController.ShowQuestion("This will overwrite your Regions mask with a copy of your Walkable Areas mask. Are you sure you want to do this?") == DialogResult.Yes)
 				{
-                    _roomController.CopyWalkableAreaMaskToRegions();
+                    CopyWalkableAreaMaskToRegions();
 					_panel.Invalidate();
 				}
 			}
@@ -666,6 +666,20 @@ namespace AGS.Editor
             DesignItems.Clear();
             foreach (var item in RoomItemRefs)
                 DesignItems.Add(item.Key, new DesignTimeProperties());
+        }
+
+        private void CopyWalkableAreaMaskToRegions()
+        {
+            if (_room == null)
+            {
+                throw new InvalidOperationException("No room is currently loaded");
+            }
+
+            using (Bitmap bmp = _roomController.GetMask(RoomAreaMaskType.WalkableAreas))
+            {
+                _roomController.SetMask(RoomAreaMaskType.Regions, bmp);
+            }
+            _room.Modified = true;
         }
 
         private void DrawLineOntoMask()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -483,7 +483,7 @@ namespace AGS.Editor
                     // allow them to import a double-size or half-size mask, adjust it as appropriate
                     if (UndoBufferMask.Size != bmp.Size)
                     {
-                        using (Bitmap scaled = bmp.Scale(bmp.Width, bmp.Height))
+                        using (Bitmap scaled = bmp.ScaleIndexed(bmp.Width, bmp.Height))
                         {
                             _roomController.SetMask(MaskToDraw, scaled);
                         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -685,13 +685,12 @@ namespace AGS.Editor
         {
             Point start = new Point(_mouseDownX, _mouseDownY);
             Point finish = new Point(_currentMouseX, _currentMouseY);
-            Color color = Factory.AGSEditor.CurrentGame.Palette[_drawingWithArea].Colour;
             double scale = _room.GetMaskScale(MaskToDraw);
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
-            using (Bitmap drawn = mask.DrawLine(start, finish, color, scale))
             {
-                _roomController.SetMask(MaskToDraw, drawn);
+                mask.DrawIndexedLine(_drawingWithArea, start, finish, scale);
+                _roomController.SetMask(MaskToDraw, mask);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -278,7 +278,7 @@ namespace AGS.Editor
             }
             else if (drawMode == AreaDrawMode.Select)
             {
-                int area = Factory.NativeProxy.GetAreaMaskPixel(_room, this.MaskToDraw, x, y);                                
+                int area = _roomController.GetAreaMaskPixel(MaskToDraw, x, y);
                 if (area != 0)
                 {
                     SelectedArea = area;

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -689,7 +689,8 @@ namespace AGS.Editor
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
             {
-                mask.DrawIndexedLine(_drawingWithArea, start, finish, scale);
+                using (IndexedGraphics g = IndexedGraphics.FromBitmap(mask))
+                    g.DrawLine(_drawingWithArea, start, finish, scale);
                 _roomController.SetMask(MaskToDraw, mask);
             }
         }
@@ -702,7 +703,8 @@ namespace AGS.Editor
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
             {
-                mask.FillIndexedRectangle(_drawingWithArea, p1, p2, scale);
+                using (IndexedGraphics g = IndexedGraphics.FromBitmap(mask))
+                    g.FillRectangle(_drawingWithArea, p1, p2, scale);
                 _roomController.SetMask(MaskToDraw, mask);
             }
         }
@@ -715,7 +717,8 @@ namespace AGS.Editor
 
             using (Bitmap mask = _roomController.GetMask(MaskToDraw))
             {
-                mask.FillIndexedArea(_drawingWithArea, point, scale);
+                using (IndexedGraphics g = IndexedGraphics.FromBitmap(mask))
+                    g.FillArea(_drawingWithArea, point, scale);
                 _roomController.SetMask(MaskToDraw, mask);
             }
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -107,10 +107,6 @@ namespace AGS.Editor
 
         public void Invalidate() { _panel.Invalidate(); }
 
-        public void PaintToHDC(IntPtr hDC, RoomEditorState state)
-        {
-        }
-
 		public bool KeyPressed(Keys key)
 		{
             switch (key)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -60,10 +60,6 @@ namespace AGS.Editor
 
         public void Invalidate() { _panel.Invalidate(); }
 
-        public void PaintToHDC(IntPtr hDC, RoomEditorState state)
-        {
-        }
-
         public void Paint(Graphics graphics, RoomEditorState state)
         {
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/HotspotsEditorFilter.cs
@@ -10,8 +10,8 @@ namespace AGS.Editor
 {
     public class HotspotsEditorFilter : BaseAreasEditorFilter
     {
-        public HotspotsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
-            : base(displayPanel, editor, room)
+        public HotspotsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room, IRoomController roomController)
+            : base(displayPanel, editor, room, roomController)
         {
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -47,10 +47,6 @@ namespace AGS.Editor
         /// </summary>
         SortedDictionary<string, DesignTimeProperties> DesignItems { get; }
         /// <summary>
-        /// Paint filter contents using native C++ functionality.
-        /// </summary>
-        void PaintToHDC(IntPtr hDC, RoomEditorState state);
-        /// <summary>
         /// Paint filter contents using .NET functionality.
         /// </summary>
         /// <param name="graphics"></param>

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/RegionsEditorFilter.cs
@@ -10,8 +10,8 @@ namespace AGS.Editor
 {
     public class RegionsEditorFilter : BaseAreasEditorFilter
     {
-        public RegionsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
-            : base(displayPanel, editor, room)
+        public RegionsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room, IRoomController roomController)
+            : base(displayPanel, editor, room, roomController)
         {
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkBehindsEditorFilter.cs
@@ -13,8 +13,8 @@ namespace AGS.Editor
 		private bool _draggingBaseline = false;
 		private bool _shownTooltip = false;
 
-        public WalkBehindsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
-            : base(displayPanel, editor, room)
+        public WalkBehindsEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room, IRoomController roomController)
+            : base(displayPanel, editor, room, roomController)
         {
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/WalkableAreasEditorFilter.cs
@@ -10,8 +10,8 @@ namespace AGS.Editor
 {
     public class WalkableAreasEditorFilter : BaseAreasEditorFilter
     {
-        public WalkableAreasEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room)
-            : base(displayPanel, editor, room)
+        public WalkableAreasEditorFilter(Panel displayPanel, RoomSettingsEditor editor, Room room, IRoomController roomController)
+            : base(displayPanel, editor, room, roomController)
         {
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -370,15 +370,13 @@ namespace AGS.Editor
 
                 // Adjust co-ordinates using original scale factor so that it lines
                 // up with objects, etc
-                int drawOffsX = _state.RoomXToWindow(0);
-                int drawOffsY = _state.RoomYToWindow(0);
+                Point drawOffs = new Point(_state.RoomXToWindow(0), _state.RoomYToWindow(0));
                 IRoomEditorFilter maskFilter = GetCurrentMaskFilter();
                 lock (_room)
                 {
                     _roomController.DrawRoomBackground(
                         e.Graphics,
-                        drawOffsX,
-                        drawOffsY,
+                        drawOffs,
                         backgroundNumber,
                         _state.Scale,
                         maskFilter?.MaskToDraw ?? RoomAreaMaskType.None,

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -12,6 +12,7 @@ using AGS.Editor.Panes.Room;
 using AddressBarExt;
 using AddressBarExt.Controls;
 using System.Linq;
+using System.Drawing.Drawing2D;
 
 namespace AGS.Editor
 {
@@ -362,7 +363,8 @@ namespace AGS.Editor
             {
                 e.Graphics.SetClip(new Rectangle(0, 0, bufferedPanel1.ClientSize.Width + SystemInformation.VerticalScrollBarWidth, bufferedPanel1.ClientSize.Height + SystemInformation.HorizontalScrollBarHeight));
                 e.Graphics.Clear(Color.LightGray);
-
+                e.Graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+                e.Graphics.SmoothingMode = SmoothingMode.None;
                 e.Graphics.SetClip(new Rectangle(0, 0, _state.RoomSizeToWindow(_room.Width), _state.RoomSizeToWindow(_room.Height)));
 
                 // Adjust co-ordinates using original scale factor so that it lines

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -365,6 +365,7 @@ namespace AGS.Editor
                 e.Graphics.Clear(Color.LightGray);
                 e.Graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
                 e.Graphics.SmoothingMode = SmoothingMode.None;
+                e.Graphics.PixelOffsetMode = PixelOffsetMode.Half;
                 e.Graphics.SetClip(new Rectangle(0, 0, _state.RoomSizeToWindow(_room.Width), _state.RoomSizeToWindow(_room.Height)));
 
                 // Adjust co-ordinates using original scale factor so that it lines

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -559,10 +559,7 @@ namespace AGS.Editor
                     }
                     if (doImport)
                     {
-                        _room.Width = bmp.Width;
-                        _room.Height = bmp.Height;
-                        Factory.NativeProxy.ImportBackground(_room, bgIndex, bmp, !Factory.AGSEditor.Settings.RemapPalettizedBackgrounds, false);
-                        _room.Modified = true;
+                        _roomController.SetBackground(bgIndex, bmp);
 
                         if (deleteExtraFrames)
                         {

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -565,7 +565,7 @@ namespace AGS.Editor
                         {
                             while (_room.BackgroundCount > 1)
                             {
-                                Factory.NativeProxy.DeleteBackground(_room, 1);
+                                _roomController.DeleteBackground(1);
                             }
                         }
 
@@ -595,12 +595,8 @@ namespace AGS.Editor
         {
             if (Factory.GUIController.ShowQuestion("Are you sure you want to delete this background?") == DialogResult.Yes)
             {
-				lock (_room)
-				{
-					Factory.NativeProxy.DeleteBackground(_room, cmbBackgrounds.SelectedIndex);
-					RepopulateBackgroundList(0);
-				}
-                _room.Modified = true;
+                _roomController.DeleteBackground(cmbBackgrounds.SelectedIndex);
+                RepopulateBackgroundList(0);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -104,10 +104,10 @@ namespace AGS.Editor
             _characterLayer = new CharactersEditorFilter(bufferedPanel1, this, _room, Factory.AGSEditor.CurrentGame);
             _layers.Add(_characterLayer);
             _layers.Add(new ObjectsEditorFilter(bufferedPanel1, this, _room));
-            _layers.Add(new HotspotsEditorFilter(bufferedPanel1, this, _room));
-            _layers.Add(new WalkableAreasEditorFilter(bufferedPanel1, this, _room));
-            _layers.Add(new WalkBehindsEditorFilter(bufferedPanel1, this, _room));
-            _layers.Add(new RegionsEditorFilter(bufferedPanel1, this, _room));
+            _layers.Add(new HotspotsEditorFilter(bufferedPanel1, this, _room, _roomController));
+            _layers.Add(new WalkableAreasEditorFilter(bufferedPanel1, this, _room, _roomController));
+            _layers.Add(new WalkBehindsEditorFilter(bufferedPanel1, this, _room, _roomController));
+            _layers.Add(new RegionsEditorFilter(bufferedPanel1, this, _room, _roomController));
 
             foreach (IRoomEditorFilter layer in _layers)
             {

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -360,6 +360,9 @@ namespace AGS.Editor
             int backgroundNumber = cmbBackgrounds.SelectedIndex;
             if (backgroundNumber < _room.BackgroundCount)
             {
+                e.Graphics.SetClip(new Rectangle(0, 0, bufferedPanel1.ClientSize.Width + SystemInformation.VerticalScrollBarWidth, bufferedPanel1.ClientSize.Height + SystemInformation.HorizontalScrollBarHeight));
+                e.Graphics.Clear(Color.LightGray);
+
                 e.Graphics.SetClip(new Rectangle(0, 0, _state.RoomSizeToWindow(_room.Width), _state.RoomSizeToWindow(_room.Height)));
 
                 // Adjust co-ordinates using original scale factor so that it lines
@@ -374,19 +377,11 @@ namespace AGS.Editor
                         drawOffsX,
                         drawOffsY,
                         backgroundNumber,
-                        (int)_state.Scale,
-                        maskFilter == null ? RoomAreaMaskType.None : maskFilter.MaskToDraw,
+                        _state.Scale,
+                        maskFilter?.MaskToDraw ?? RoomAreaMaskType.None,
                         sldTransparency.Value,
                         maskFilter == null || !maskFilter.Enabled ? 0 : maskFilter.SelectedArea);
                 }
-
-                IntPtr hdc = e.Graphics.GetHdc();
-                foreach (IRoomEditorFilter layer in _layers.Where(l => IsVisible(l)))
-                {
-                    layer.PaintToHDC(hdc, _state);
-                }
-                Factory.NativeProxy.RenderBufferToHDC(hdc);
-                e.Graphics.ReleaseHdc(hdc);
 
                 foreach (IRoomEditorFilter layer in _layers.Where(l => IsVisible(l)))
                 {

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -190,28 +190,6 @@ namespace AGS.Editor
         }
 
         /// <summary>
-        /// Sets alpha for every pixel of the bitmap. Will do nothing if indexed image.
-        /// </summary>
-        /// <param name="bmp">The bitmap to alter the alpha values of.</param>
-        /// <param name="alpha">The alhpa value to put on the image.</param>
-        public static void SetAlpha(this Bitmap bmp, int alpha)
-        {
-            if (bmp.PixelFormat == PixelFormat.Format8bppIndexed)
-            {
-                return;
-            }
-
-            for (int y = 0; y < bmp.Height; y++)
-            {
-                for (int x = 0; x < bmp.Width; x++)
-                {
-                    Color pixel = bmp.GetPixel(x, y);
-                    bmp.SetPixel(x, y, Color.FromArgb(alpha, pixel.R, pixel.G, pixel.B));
-                }
-            }
-        }
-
-        /// <summary>
         /// Checks if the x and y coordinate is within the image.
         /// </summary>
         /// <param name="position">The position to check against.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -220,7 +220,7 @@ namespace AGS.Editor
                 {
                     int i = (position.Y * size.Width) + position.X;
 
-                    if (image[i] == initial)
+                    if (image[i] == initial && image[i] != replacement)
                     {
                         image[i] = replacement;
 

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -1,0 +1,131 @@
+﻿using AGS.Types;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+namespace AGS.Editor
+{
+    public static class BitmapExtensions
+    {
+        /// <summary>
+        /// Gives a scaled deep copy of the input image.
+        /// </summary>
+        /// <param name="bmp">The image to copy and scale.</param>
+        /// <param name="width">Scale the image to this width.</param>
+        /// <param name="height">Scale the image to this height.</param>
+        /// <returns>A scaled deep copy of the input image.</returns>
+        public static Bitmap Scale(this Bitmap bmp, int width, int height) => bmp.Mutate(width, height, g =>
+        {
+            g.DrawImage(bmp, 0, 0, width, height);
+        });
+
+        /// <summary>
+        /// Makes a deep copy of the bitmap that we can perform drawing operations on, and preserve the pixel format.
+        /// </summary>
+        /// <param name="bmp">The bitmap to deep copy.</param>
+        /// <param name="mutate">The drawable <see cref="Graphics"/> in a lambda.</param>
+        /// <returns>A deep copy of the bitmap with the executed drawing operations.</returns>
+        public static Bitmap Mutate(this Bitmap bmp, Action<Graphics> mutate) => bmp.Mutate(bmp.Width, bmp.Height, mutate);
+
+        /// <summary>
+        /// Makes a deep copy of the bitmap that we can perform drawing operations on, and preserve the pixel format.
+        /// </summary>
+        /// <param name="bmp">The bitmap to deep copy.</param>
+        /// <param name="width">The width of the resulting bitmap.</param>
+        /// <param name="height">The height of the resulting bitmap.</param>
+        /// <param name="mutate">The drawable <see cref="Graphics"/> in a lambda.</param>
+        /// <returns>A deep copy of the bitmap with the executed drawing operations.</returns>
+        public static Bitmap Mutate(this Bitmap bmp, int width, int height, Action<Graphics> mutate)
+        {
+            if (width <= 0) throw new ArgumentException("Scale factor must be greater than 0.", nameof(width));
+            if (height <= 0) throw new ArgumentException("Scale factor must be greater than 0.", nameof(height));
+
+            // Drawing operations is not supported on 8-bit images so we have to create a default 32-bit image buffer for drawing
+            using (Bitmap drawBuffer = new Bitmap(width, height))
+            {
+                using (Graphics graphics = Graphics.FromImage(drawBuffer))
+                {
+                    graphics.CompositingMode = CompositingMode.SourceCopy;
+                    graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+                    mutate(graphics);
+                }
+
+                Bitmap result = new Bitmap(width, height, bmp.PixelFormat);
+
+                // Make sure we use the correct palette for indexed images
+                if (bmp.PixelFormat == PixelFormat.Format8bppIndexed)
+                {
+                    result.SetPaletteFromGlobalPalette();
+                    drawBuffer.Palette = result.Palette;
+                }
+
+                // Write drawing buffer to the result image and retain the pixel format.
+                result.SetRawData(drawBuffer.GetRawData(bmp.PixelFormat), bmp.PixelFormat);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets the raw data from the bitmap as a byte array.
+        /// </summary>
+        /// <param name="bmp">The image to get the raw data from.</param>
+        /// <returns>The raw data as a byte array.</returns>
+        public static byte[] GetRawData(this Bitmap bmp) => bmp.GetRawData(bmp.PixelFormat);
+
+        /// <summary>
+        /// Gets the raw data from the bitmap as a byte array.
+        /// </summary>
+        /// <param name="bmp">The image to get the raw data from.</param>
+        /// <param name="pixelFormat">The pixel format to read the raw data as.</param>
+        /// <returns>The raw data as a byte array.</returns>
+        public static byte[] GetRawData(this Bitmap bmp, PixelFormat pixelFormat)
+        {
+            BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, pixelFormat);
+            int pixelCount = Math.Abs(data.Stride) * data.Height;
+            byte[] bitmapRawData = new byte[pixelCount];
+            Marshal.Copy(data.Scan0, bitmapRawData, 0, pixelCount);
+            bmp.UnlockBits(data);
+
+            return bitmapRawData;
+        }
+
+        /// <summary>
+        /// Sets the raw data from the byte array to the bitmap.
+        /// </summary>
+        /// <param name="bmp">The bitmap to set the raw data to.</param>
+        /// <param name="rawData">The raw data to set into the bitmap.</param>
+        /// <param name="pixelFormat">The pixel format to read the raw data as.</param>
+        public static void SetRawData(this Bitmap bmp, byte[] rawData, PixelFormat pixelFormat)
+        {
+            BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.WriteOnly, pixelFormat);
+            int pixelCount = Math.Abs(data.Stride) * data.Height;
+            Marshal.Copy(rawData, 0, data.Scan0, pixelCount);
+            bmp.UnlockBits(data);
+        }
+
+        /// <summary>
+        /// Sets the raw data from the byte array to the bitmap.
+        /// </summary>
+        /// <param name="bmp">The bitmap to set the raw data to.</param>
+        /// <param name="rawData">The raw data to set into the bitmap.</param>
+        public static void SetRawData(this Bitmap bmp, byte[] rawData) => bmp.SetRawData(rawData, bmp.PixelFormat);
+
+        /// <summary>
+        /// Sets the current game's global palette to a bitmap.
+        /// </summary>
+        /// <param name="bmp">The bitmap to set to global palette to.</param>
+        public static void SetPaletteFromGlobalPalette(this Bitmap bmp)
+        {
+            ColorPalette palette = bmp.Palette;
+
+            foreach (PaletteEntry global in Factory.AGSEditor.CurrentGame.Palette)
+            {
+                palette.Entries[global.Index] = global.Colour;
+            }
+
+            bmp.Palette = palette; // Get Bitmap.Palette is deep copy so we need to set it back
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -190,6 +190,28 @@ namespace AGS.Editor
         }
 
         /// <summary>
+        /// Sets alpha for every pixel of the bitmap. Will do nothing if indexed image.
+        /// </summary>
+        /// <param name="bmp">The bitmap to alter the alpha values of.</param>
+        /// <param name="alpha">The alhpa value to put on the image.</param>
+        public static void SetAlpha(this Bitmap bmp, int alpha)
+        {
+            if (bmp.PixelFormat == PixelFormat.Format8bppIndexed)
+            {
+                return;
+            }
+
+            for (int y = 0; y < bmp.Height; y++)
+            {
+                for (int x = 0; x < bmp.Width; x++)
+                {
+                    Color pixel = bmp.GetPixel(x, y);
+                    bmp.SetPixel(x, y, Color.FromArgb(alpha, pixel.R, pixel.G, pixel.B));
+                }
+            }
+        }
+
+        /// <summary>
         /// Checks if the x and y coordinate is within the image.
         /// </summary>
         /// <param name="position">The position to check against.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -206,6 +206,16 @@ namespace AGS.Editor
         }
 
         /// <summary>
+        /// Check if <see cref="Bitmap"/> is indexed image.
+        /// </summary>
+        /// <param name="bmp">Check if this argument is indexed image.</param>
+        /// <returns>A bool indicating if this image is indexed.</returns>
+        public static bool IsIndexed(this Bitmap bmp) =>
+            bmp.PixelFormat == PixelFormat.Format1bppIndexed ||
+            bmp.PixelFormat == PixelFormat.Format4bppIndexed ||
+            bmp.PixelFormat == PixelFormat.Format8bppIndexed;
+
+        /// <summary>
         /// Checks if the x and y coordinate is within the image.
         /// </summary>
         /// <param name="position">The position to check against.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -180,6 +180,15 @@ namespace AGS.Editor
         /// <param name="rawData">The raw data to set into the bitmap.</param>
         public static void SetRawData(this Bitmap bmp, byte[] rawData) => bmp.SetRawData(rawData, bmp.PixelFormat);
 
+        public static void SetGlobalPaletteFromPalette(this Bitmap bmp)
+        {
+            PaletteEntry[] palettes = Factory.AGSEditor.CurrentGame.Palette;
+            foreach (PaletteEntry global in palettes.Where(p => p.ColourType == PaletteColourType.Background))
+            {
+                palettes[global.Index].Colour = bmp.Palette.Entries[global.Index];
+            }
+        }
+
         /// <summary>
         /// Sets the current game's global palette to a bitmap.
         /// </summary>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -40,6 +40,27 @@ namespace AGS.Editor
         });
 
         /// <summary>
+        /// Gives back a deep copy of the bitmap with a filled rectangle.
+        /// </summary>
+        /// <param name="bmp">The bitmap we to copy and draw on.</param>
+        /// <param name="p1">The starting point of the rectangle.</param>
+        /// <param name="p2">The end point of the rectangle.</param>
+        /// <param name="color">The color of the rectangle.</param>
+        /// <param name="scale">Adjust coordinates for the input scale.</param>
+        /// <returns></returns>
+        public static Bitmap FillRectangle(this Bitmap bmp, Point p1, Point p2, Color color, double scale = 1.0) => bmp.Mutate(g =>
+        {
+            Point origin = new Point(p1.X < p2.X ? p1.X : p2.X, p1.Y < p2.Y ? p1.Y : p2.Y);
+            Point originScaled = new Point((int)(origin.X * scale), (int)(origin.Y * scale));
+
+            Size size = new Size(Math.Abs(p1.X - p2.X), Math.Abs(p1.Y - p2.Y));
+            Size sizeScaled = new Size((int)(size.Width * scale), (int)(size.Height * scale));
+
+            g.DrawImage(bmp, 0, 0);
+            g.FillRectangle(new SolidBrush(color), new Rectangle(originScaled, sizeScaled));
+        });
+
+        /// <summary>
         /// Makes a deep copy of the bitmap that we can perform drawing operations on, and preserve the pixel format.
         /// </summary>
         /// <param name="bmp">The bitmap to deep copy.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -95,16 +95,12 @@ namespace AGS.Editor
         /// <param name="position">The position we want to fill from.</param>
         /// <param name="color">The color to use for the filling.</param>
         /// <returns>A new bitmap with the area filled.</returns>
-        public static Bitmap FillArea(this Bitmap bmp, Point position, int color, double scale)
+        public static void FillIndexedArea(this Bitmap bmp, int color, Point position, double scale)
         {
-            Bitmap result = new Bitmap(bmp.Width, bmp.Height, bmp.PixelFormat);
             Point positionScaled = new Point((int)(position.X * scale), (int)(position.Y * scale));
-
             byte[] rawData = bmp.GetRawData(bmp.PixelFormat);
             FloodFillImage(rawData, positionScaled, bmp.Size, rawData[(positionScaled.Y * bmp.Width) + positionScaled.X], (byte)color);
-            result.SetRawData(rawData, bmp.PixelFormat);
-
-            return result;
+            bmp.SetRawData(rawData, bmp.PixelFormat);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -1,4 +1,4 @@
-﻿using AGS.Types;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -199,7 +199,7 @@ namespace AGS.Editor
 
             foreach (PaletteEntry global in Factory.AGSEditor.CurrentGame.Palette)
             {
-                palette.Entries[global.Index] = global.Colour;
+                palette.Entries[global.Index] = Color.FromArgb(global.Index == 0 ? 0 : 255, global.Colour);
             }
 
             bmp.Palette = palette; // Get Bitmap.Palette is deep copy so we need to set it back

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -22,6 +22,24 @@ namespace AGS.Editor
         });
 
         /// <summary>
+        /// Gives back a deep copy of the bitmap with a drawn line.
+        /// </summary>
+        /// <param name="bmp">The bitmap we want to copy and draw on.</param>
+        /// <param name="p1">The starting point for the line.</param>
+        /// <param name="p2">The end point for the line.</param>
+        /// <param name="color">The color of the line.</param>
+        /// <param name="scale">Adjust coordinates for the input scale.</param>
+        /// <returns>A new bitmap with a line drawn on it.</returns>
+        public static Bitmap DrawLine(this Bitmap bmp, Point p1, Point p2, Color color, double scale = 1.0) => bmp.Mutate(g =>
+        {
+            p1 = new Point((int)(p1.X * scale), (int)(p1.Y * scale));
+            p2 = new Point((int)(p2.X * scale), (int)(p2.Y * scale));
+
+            g.DrawImage(bmp, 0, 0);
+            g.DrawLine(new Pen(color), p1, p2);
+        });
+
+        /// <summary>
         /// Makes a deep copy of the bitmap that we can perform drawing operations on, and preserve the pixel format.
         /// </summary>
         /// <param name="bmp">The bitmap to deep copy.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -12,6 +12,13 @@ namespace AGS.Editor
     public static class BitmapExtensions
     {
         /// <summary>
+        /// Gets an integer with the color depth of the image.
+        /// </summary>
+        /// <param name="bmp">The image to get the color depth from.</param>
+        /// <returns>An integer with the color depth.</returns>
+        public static int GetColorDepth(this Bitmap bmp) => Image.GetPixelFormatSize(bmp.PixelFormat);
+
+        /// <summary>
         /// Gives a scaled deep copy of the input image.
         /// </summary>
         /// <param name="bmp">The image to copy and scale.</param>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -96,7 +96,7 @@ namespace AGS.Editor
             if (!bmp.IsIndexed())
                 throw new ArgumentException($"{nameof(bmp)} must be a indexed bitmap.");
 
-            Point origin = new Point(p1.X < p2.X ? p1.X : p2.X, p1.Y < p2.Y ? p1.Y : p2.Y);
+            Point origin = new Point(Math.Min(p1.X, p2.X), Math.Min(p1.Y, p2.Y));
             Point originScaled = new Point((int)(origin.X * scale), (int)(origin.Y * scale));
 
             Size size = new Size(Math.Abs(p1.X - p2.X), Math.Abs(p1.Y - p2.Y));
@@ -278,8 +278,8 @@ namespace AGS.Editor
 
         private static IEnumerable<Point> CalculatRecanglePixels(Point origin, Size size)
         {
-            for (int y = origin.Y; y < origin.Y + size.Height; y++)
-                for (int x = origin.X; x < origin.X + size.Width; x++)
+            for (int y = origin.Y; y <= origin.Y + size.Height; y++)
+                for (int x = origin.X; x <= origin.X + size.Width; x++)
                     yield return new Point(x, y);
         }
 

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -255,7 +255,7 @@ namespace AGS.Editor
                 delta.Y = -delta.Y;
             }
 
-            int difference = 2 * (delta.Y - delta.X);
+            int difference = (2 * delta.Y) - delta.X;
 
             for (Point p = p0; p.X <= p1.X; p.X++)
             {
@@ -282,7 +282,7 @@ namespace AGS.Editor
                 delta.X = -delta.X;
             }
 
-            int difference = 2 * (delta.X - delta.Y);
+            int difference = (2 * delta.X) - delta.Y;
 
             for (Point p = p0; p.Y <= p1.Y; p.Y++)
             {

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -105,10 +105,10 @@ namespace AGS.Editor
 
             byte[] rawImage = bmp.GetRawData();
             byte colorAsByte = (byte)color;
+            IEnumerable<Point> pixels = CalculatRecanglePixels(originScaled, sizeScaled);
 
-            for (int y = originScaled.Y; y < originScaled.Y + sizeScaled.Height; y++)
-                for (int x = originScaled.X; x < originScaled.X + sizeScaled.Width; x++)
-                    rawImage[(paddedWidth * y) + x] = colorAsByte;
+            foreach (int i in pixels.Where(p => bmp.Intersects(p)).Select(p => (paddedWidth * p.Y) + p.X))
+                rawImage[i] = colorAsByte;
 
             bmp.SetRawData(rawImage);
         }
@@ -271,6 +271,13 @@ namespace AGS.Editor
                 else
                     difference += 2 * delta.X;
             }
+        }
+
+        private static IEnumerable<Point> CalculatRecanglePixels(Point origin, Size size)
+        {
+            for (int y = origin.Y; y < origin.Y + size.Height; y++)
+                for (int x = origin.X; x < origin.X + size.Width; x++)
+                    yield return new Point(x, y);
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -123,6 +123,9 @@ namespace AGS.Editor
         /// <returns>A new bitmap with the area filled.</returns>
         public static void FillIndexedArea(this Bitmap bmp, int color, Point position, double scale)
         {
+            if (!bmp.IsIndexed())
+                throw new ArgumentException($"{nameof(bmp)} must be a indexed bitmap.");
+
             Point positionScaled = new Point((int)(position.X * scale), (int)(position.Y * scale));
             byte[] rawData = bmp.GetRawData(bmp.PixelFormat);
             FloodFillImage(rawData, positionScaled, bmp.Size, rawData[(positionScaled.Y * bmp.Width) + positionScaled.X], (byte)color);

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -261,7 +261,7 @@ namespace AGS.Editor
             {
                 yield return p;
 
-                if (difference > 0)
+                if (difference >= 0)
                 {
                     p.Y += yIncrement;
                     difference += 2 * (delta.Y - delta.X);
@@ -288,7 +288,7 @@ namespace AGS.Editor
             {
                 yield return p;
 
-                if (difference > 0)
+                if (difference >= 0)
                 {
                     p.X += xIncrement;
                     difference += 2 * (delta.X - delta.Y);

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -257,7 +257,7 @@ namespace AGS.Editor
 
             int difference = 2 * (delta.Y - delta.X);
 
-            for (Point p = p0; p.X < p1.X; p.X++)
+            for (Point p = p0; p.X <= p1.X; p.X++)
             {
                 yield return p;
 
@@ -284,7 +284,7 @@ namespace AGS.Editor
 
             int difference = 2 * (delta.X - delta.Y);
 
-            for (Point p = p0; p.Y < p1.Y; p.Y++)
+            for (Point p = p0; p.Y <= p1.Y; p.Y++)
             {
                 yield return p;
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -79,7 +79,6 @@ extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int 
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void FixRoomMasks(Room ^room);
 extern void copy_walkable_to_regions(void *roomptr);
-extern int get_mask_pixel(void *roomptr, int maskType, int x, int y);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern void create_undo_buffer(void *roomptr, int maskType) ;
@@ -500,11 +499,6 @@ namespace AGS
 		void NativeMethods::CopyWalkableMaskToRegions(Room ^room) 
 		{
 			copy_walkable_to_regions((void*)room->_roomStructPtr);
-		}
-
-		int NativeMethods::GetAreaMaskPixel(Room ^room, RoomAreaMaskType maskType, int x, int y)
-		{
-			return get_mask_pixel((void*)room->_roomStructPtr, (int)maskType, x, y);
 		}
 
     void NativeMethods::ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -68,19 +68,14 @@ extern void GameDirChanged(String ^workingDir);
 extern void GameUpdated(Game ^game, bool forceUpdate);
 extern void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
 extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
-extern void draw_room_background(void *roomptr, int hdc, int x, int y, int bgnum, float scaleFactor, int maskType, int selectedArea, int maskTransparency);
 extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 extern void DeleteBackground(Room ^room, int backgroundNumber);
-extern void CreateBuffer(int width, int height);
-extern void RenderBufferToHDC(int hdc);
-extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
 extern void FixRoomMasks(Room ^room);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern System::String ^load_room_script(System::String ^fileName);
 extern void transform_string(char *text);
-extern bool enable_greyed_out_masks;
 extern bool spritesModified;
 
 AGSString editorVersionNumber;
@@ -434,26 +429,6 @@ namespace AGS
 			save_crm_file(roomToSave);
 		}
 
-		void NativeMethods::CreateBuffer(int width, int height) 
-		{
-			::CreateBuffer(width, height);
-		}
-
-		void NativeMethods::DrawSpriteToBuffer(int sprNum, int x, int y, float scale) 
-		{
-			::DrawSpriteToBuffer(sprNum, x, y, scale);
-		}
-
-		void NativeMethods::RenderBufferToHDC(int hDC) 
-		{
-			::RenderBufferToHDC(hDC);
-		}
-
-		void NativeMethods::DrawRoomBackground(int hDC, Room ^room, int x, int y, int backgroundNumber, float scaleFactor, RoomAreaMaskType maskType, int selectedArea, int maskTransparency)
-		{
-			draw_room_background((void*)room->_roomStructPtr, hDC, x, y, backgroundNumber, scaleFactor, (int)maskType, selectedArea, maskTransparency);
-		}
-
 		void NativeMethods::ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette)
 		{
 			::ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
@@ -482,11 +457,6 @@ namespace AGS
     Bitmap ^NativeMethods::ExportAreaMask(Room ^room, RoomAreaMaskType maskType)
     {
         return export_area_mask((void*)room->_roomStructPtr, (int)maskType);
-    }
-
-    void NativeMethods::SetGreyedOutMasksEnabled(bool enabled)
-    {
-      enable_greyed_out_masks = enabled;
     }
 
 		String ^NativeMethods::LoadRoomScript(String ^roomFileName) 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -476,11 +476,6 @@ namespace AGS
 			return getBackgroundAsBitmap(room, backgroundNumber);
 		}
 
-        void NativeMethods::AdjustRoomMaskResolution(Room ^room)
-        {
-            FixRoomMasks(room);
-        }
-
 		void NativeMethods::DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color)
 		{
 			draw_line_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, x2, y2, color);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -80,6 +80,7 @@ extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int
 extern void FixRoomMasks(Room ^room);
 extern void copy_walkable_to_regions(void *roomptr);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
+extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern void create_undo_buffer(void *roomptr, int maskType) ;
 extern bool does_undo_buffer_exist();
@@ -504,6 +505,11 @@ namespace AGS
     void NativeMethods::ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp)
     {
       import_area_mask((void*)room->_roomStructPtr, (int)maskType, bmp);
+    }
+
+    void NativeMethods::SetAreaMask(Room^ room, RoomAreaMaskType maskType, Bitmap^ bmp)
+    {
+        set_area_mask((void*)room->_roomStructPtr, (int)maskType, bmp);
     }
 
     Bitmap ^NativeMethods::ExportAreaMask(Room ^room, RoomAreaMaskType maskType)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -78,10 +78,6 @@ extern void FixRoomMasks(Room ^room);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
-extern void create_undo_buffer(void *roomptr, int maskType) ;
-extern bool does_undo_buffer_exist();
-extern void clear_undo_buffer() ;
-extern void restore_from_undo_buffer(void *roomptr, int maskType);
 extern System::String ^load_room_script(System::String ^fileName);
 extern void transform_string(char *text);
 extern bool enable_greyed_out_masks;
@@ -487,26 +483,6 @@ namespace AGS
     {
         return export_area_mask((void*)room->_roomStructPtr, (int)maskType);
     }
-
-    void NativeMethods::CreateUndoBuffer(Room ^room, RoomAreaMaskType maskType)
-		{
-			create_undo_buffer((void*)room->_roomStructPtr, (int)maskType);
-		}
-
-    bool NativeMethods::DoesUndoBufferExist()
-		{
-			return does_undo_buffer_exist();
-		}
-
-    void NativeMethods::ClearUndoBuffer()
-		{
-			clear_undo_buffer();
-		}
-
-    void NativeMethods::RestoreFromUndoBuffer(Room ^room, RoomAreaMaskType maskType)
-		{
-			restore_from_undo_buffer((void*)room->_roomStructPtr, (int)maskType);
-		}
 
     void NativeMethods::SetGreyedOutMasksEnabled(bool enabled)
     {

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -78,7 +78,6 @@ extern void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int
 extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void FixRoomMasks(Room ^room);
-extern void copy_walkable_to_regions(void *roomptr);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
@@ -495,11 +494,6 @@ namespace AGS
 		void NativeMethods::DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color)
 		{
 			draw_fill_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, color);
-		}
-
-		void NativeMethods::CopyWalkableMaskToRegions(Room ^room) 
-		{
-			copy_walkable_to_regions((void*)room->_roomStructPtr);
 		}
 
     void NativeMethods::ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -74,7 +74,6 @@ extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void CreateBuffer(int width, int height);
 extern void RenderBufferToHDC(int hdc);
 extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
-extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void FixRoomMasks(Room ^room);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
@@ -473,11 +472,6 @@ namespace AGS
 		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
-		}
-
-		void NativeMethods::DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color)
-		{
-			draw_filled_rect_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, x2, y2, color);
 		}
 
 		void NativeMethods::DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -74,7 +74,6 @@ extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void CreateBuffer(int width, int height);
 extern void RenderBufferToHDC(int hdc);
 extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
-extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void FixRoomMasks(Room ^room);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
@@ -472,11 +471,6 @@ namespace AGS
 		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
-		}
-
-		void NativeMethods::DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color)
-		{
-			draw_fill_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, color);
 		}
 
     void NativeMethods::ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp)

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -71,7 +71,6 @@ extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
 extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void FixRoomMasks(Room ^room);
-extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern System::String ^load_room_script(System::String ^fileName);
@@ -443,11 +442,6 @@ namespace AGS
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
 		}
-
-    void NativeMethods::ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp)
-    {
-      import_area_mask((void*)room->_roomStructPtr, (int)maskType, bmp);
-    }
 
     void NativeMethods::SetAreaMask(Room^ room, RoomAreaMaskType maskType, Bitmap^ bmp)
     {

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -74,7 +74,6 @@ extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void CreateBuffer(int width, int height);
 extern void RenderBufferToHDC(int hdc);
 extern void DrawSpriteToBuffer(int sprNum, int x, int y, float scale);
-extern void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color);
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void FixRoomMasks(Room ^room);
@@ -474,11 +473,6 @@ namespace AGS
 		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
-		}
-
-		void NativeMethods::DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color)
-		{
-			draw_line_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, x2, y2, color);
 		}
 
 		void NativeMethods::DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -64,7 +64,6 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -64,7 +64,6 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -60,17 +60,12 @@ namespace AGS
 			void LoadNewSpriteFile();
 			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad);
 			void SaveRoomFile(Room ^roomToSave);
-			void DrawRoomBackground(int hDC, Room ^room, int x, int y, int backgroundNumber, float scaleFactor, RoomAreaMaskType maskType, int selectedArea, int maskTransparency);
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
-      void SetGreyedOutMasksEnabled(bool enabled);
-			void CreateBuffer(int width, int height) ;
-			void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) ;
-			void RenderBufferToHDC(int hDC) ;
 			String ^LoadRoomScript(String ^roomFileName);
 			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game);
 			void CreateDataFile(cli::array<String^> ^fileList, long splitSize, String ^baseFileName, bool isGameEXE);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -64,7 +64,6 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-			void DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -70,6 +70,7 @@ namespace AGS
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
 			void CopyWalkableMaskToRegions(Room ^room);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
+      void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
       void CreateUndoBuffer(Room ^room, RoomAreaMaskType maskType);
       bool DoesUndoBufferExist();

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -68,7 +68,6 @@ namespace AGS
 			void DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
-			void CopyWalkableMaskToRegions(Room ^room);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -67,10 +67,6 @@ namespace AGS
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
-      void CreateUndoBuffer(Room ^room, RoomAreaMaskType maskType);
-      bool DoesUndoBufferExist();
-      void ClearUndoBuffer();
-      void RestoreFromUndoBuffer(Room ^room, RoomAreaMaskType maskType);
       void SetGreyedOutMasksEnabled(bool enabled);
 			void CreateBuffer(int width, int height) ;
 			void DrawSpriteToBuffer(int sprNum, int x, int y, float scale) ;

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -64,7 +64,6 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-            void AdjustRoomMaskResolution(Room ^room);
 			void DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -69,7 +69,6 @@ namespace AGS
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
 			void CopyWalkableMaskToRegions(Room ^room);
-			int  GetAreaMaskPixel(Room ^room, RoomAreaMaskType maskType, int x, int y);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
       void CreateUndoBuffer(Room ^room, RoomAreaMaskType maskType);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -63,7 +63,6 @@ namespace AGS
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-      void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
 			String ^LoadRoomScript(String ^roomFileName);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -596,13 +596,6 @@ void drawBlock (HDC hdc, Common::Bitmap *todraw, int x, int y) {
   blit_to_hdc (todraw->GetAllegroBitmap(), hdc, 0,0,x,y,todraw->GetWidth(),todraw->GetHeight());
 }
 
-void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color)
-{
-	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-    float scale = ((RoomStruct*)roomptr)->GetMaskScale((RoomAreaMask)maskType);
-    mask->FillRect(Rect(x1 * scale, y1 * scale, x2 * scale, y2 * scale), color);
-}
-
 void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color)
 {
 	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -596,11 +596,6 @@ void drawBlock (HDC hdc, Common::Bitmap *todraw, int x, int y) {
   blit_to_hdc (todraw->GetAllegroBitmap(), hdc, 0,0,x,y,todraw->GetWidth(),todraw->GetHeight());
 }
 
-void copy_walkable_to_regions (void *roomptr) {
-	RoomStruct *theRoom = (RoomStruct*)roomptr;
-	theRoom->RegionMask->Blit(theRoom->WalkAreaMask.get(), 0, 0, 0, 0, theRoom->RegionMask->GetWidth(), theRoom->RegionMask->GetHeight());
-}
-
 void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color)
 {
 	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -596,13 +596,6 @@ void drawBlock (HDC hdc, Common::Bitmap *todraw, int x, int y) {
   blit_to_hdc (todraw->GetAllegroBitmap(), hdc, 0,0,x,y,todraw->GetWidth(),todraw->GetHeight());
 }
 
-void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color)
-{
-	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-    float scale = ((RoomStruct*)roomptr)->GetMaskScale((RoomAreaMask)maskType);
-    mask->FloodFill(x1 * scale, y1 * scale, color);
-}
-
 void create_undo_buffer(void *roomptr, int maskType) 
 {
 	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -103,7 +103,6 @@ int BaseColorDepth = 0;
 
 struct NativeRoomTools
 {
-    bool roomModified = false;
     int loaded_room_number = -1;
     std::unique_ptr<AGSBitmap> drawBuffer;
     std::unique_ptr<AGSBitmap> roomBkgBuffer;
@@ -1433,7 +1432,6 @@ void validate_mask(Common::Bitmap *toValidate, const char *name, int maxColour) 
        "entry 0 corresponds to No Area, palette index 1 corresponds to area 1, and "
        "so forth.", name);
 	MessageBox(NULL, errorBuf, "Mask Error", MB_OK);
-    RoomTools->roomModified = true;
   }
 }
 
@@ -1483,8 +1481,6 @@ const char* load_room_file(const char*rtlo) {
   if ((thisroom.BgFrames[0].Graphic->GetColorDepth () > 8) &&
       (thisgame.color_depth == 1))
     MessageBox(NULL,"WARNING: This room is hi-color, but your game is currently 256-colour. You will not be able to use this room in this game. Also, the room background will not look right in the editor.", "Colour depth warning", MB_OK);
-
-  RoomTools->roomModified = false;
 
   validate_mask(thisroom.HotspotMask.get(), "hotspot", MAX_ROOM_HOTSPOTS);
   validate_mask(thisroom.WalkBehindMask.get(), "walk-behind", MAX_WALK_AREAS + 1);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -601,13 +601,6 @@ void copy_walkable_to_regions (void *roomptr) {
 	theRoom->RegionMask->Blit(theRoom->WalkAreaMask.get(), 0, 0, 0, 0, theRoom->RegionMask->GetWidth(), theRoom->RegionMask->GetHeight());
 }
 
-int get_mask_pixel(void *roomptr, int maskType, int x, int y)
-{
-    Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-    float scale = ((RoomStruct*)roomptr)->GetMaskScale((RoomAreaMask)maskType);
-	return mask->GetPixel(x * scale, y * scale);
-}
-
 void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color)
 {
 	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -596,13 +596,6 @@ void drawBlock (HDC hdc, Common::Bitmap *todraw, int x, int y) {
   blit_to_hdc (todraw->GetAllegroBitmap(), hdc, 0,0,x,y,todraw->GetWidth(),todraw->GetHeight());
 }
 
-void draw_line_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color)
-{
-	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-    float scale = ((RoomStruct*)roomptr)->GetMaskScale((RoomAreaMask)maskType);
-	mask->DrawLine(Line(x1 * scale, y1 * scale, x2 * scale, y2 * scale), color);
-}
-
 void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int y1, int x2, int y2, int color)
 {
 	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2448,6 +2448,32 @@ void import_area_mask(void *roomptr, int maskType, System::Drawing::Bitmap ^bmp)
 	validate_mask(mask, "imported", (maskType == kRoomAreaHotspot) ? MAX_ROOM_HOTSPOTS : (MAX_WALK_AREAS + 1));
 }
 
+void set_area_mask(void* roomptr, int maskType, SysBitmap^ bmp)
+{
+    color oldpale[256];
+    RoomStruct* room = (RoomStruct*)roomptr;
+    AGSBitmap* oldMask = room->GetMask((RoomAreaMask)maskType);
+    AGSBitmap* newMask = CreateBlockFromBitmap(bmp, oldpale, false, false, NULL);
+
+    switch (maskType)
+    {
+    case kRoomAreaHotspot:
+        room->HotspotMask = PBitmap(newMask);
+        break;
+    case kRoomAreaRegion:
+        room->RegionMask = PBitmap(newMask);
+        break;
+    case kRoomAreaWalkable:
+        room->WalkAreaMask = PBitmap(newMask);
+        break;
+    case kRoomAreaWalkBehind:
+        room->WalkBehindMask = PBitmap(newMask);
+        break;
+    default:
+        return;
+    }
+}
+
 SysBitmap ^export_area_mask(void *roomptr, int maskType)
 {
     AGSBitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2069,8 +2069,7 @@ void DeleteBackground(Room ^room, int backgroundNumber)
  {
      theRoom->BgFrames[backgroundNumber].Graphic.reset();
      theRoom->BgFrameCount--;
-	
-	room->BackgroundCount--;
+
      for (size_t i = backgroundNumber; i < theRoom->BgFrameCount; i++)
      {
          theRoom->BgFrames[i] = theRoom->BgFrames[i + 1];
@@ -2133,9 +2132,6 @@ void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap 
         theRoom->WalkBehindMask->Clear();
         theRoom->RegionMask->Clear();
 	}
-
-	room->BackgroundCount = theRoom->BgFrameCount;
-	room->ColorDepth = theRoom->BgFrames[0].Graphic->GetColorDepth();
 }
 
 void set_area_mask(void* roomptr, int maskType, SysBitmap^ bmp)

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2082,7 +2082,7 @@ void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap 
 	RoomStruct *theRoom = (RoomStruct*)(void*)room->_roomStructPtr;
 	theRoom->Width = room->Width;
 	theRoom->Height = room->Height;
-    theRoom->MaskResolution = theRoom->MaskResolution;
+    theRoom->MaskResolution = room->MaskResolution;
 
 	if (newbg->GetColorDepth() == 8) 
 	{

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2134,32 +2134,14 @@ void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap 
 	room->ColorDepth = theRoom->BgFrames[0].Graphic->GetColorDepth();
 }
 
-void import_area_mask(void *roomptr, int maskType, System::Drawing::Bitmap ^bmp)
-{
-	color oldpale[256];
-	Common::Bitmap *importedImage = CreateBlockFromBitmap(bmp, oldpale, false, false, NULL);
-	Common::Bitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-
-	if (mask->GetWidth() != importedImage->GetWidth())
-	{
-		// allow them to import a double-size or half-size mask, adjust it as appropriate
-		Cstretch_blit(importedImage, mask, 0, 0, importedImage->GetWidth(), importedImage->GetHeight(), 0, 0, mask->GetWidth(), mask->GetHeight());
-	}
-	else
-	{
-		mask->Blit(importedImage, 0, 0, 0, 0, importedImage->GetWidth(), importedImage->GetHeight());
-	}
-	delete importedImage;
-
-	validate_mask(mask, "imported", (maskType == kRoomAreaHotspot) ? MAX_ROOM_HOTSPOTS : (MAX_WALK_AREAS + 1));
-}
-
 void set_area_mask(void* roomptr, int maskType, SysBitmap^ bmp)
 {
     color oldpale[256];
     RoomStruct* room = (RoomStruct*)roomptr;
     AGSBitmap* oldMask = room->GetMask((RoomAreaMask)maskType);
     AGSBitmap* newMask = CreateBlockFromBitmap(bmp, oldpale, false, false, NULL);
+    if (maskType != kRoomAreaNone)
+        validate_mask(newMask, "imported", (maskType == kRoomAreaHotspot) ? MAX_ROOM_HOTSPOTS : (MAX_WALK_AREAS + 1));
 
     switch (maskType)
     {

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2064,15 +2064,19 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, color *imgpa
 void DeleteBackground(Room ^room, int backgroundNumber) 
 {
 	RoomStruct *theRoom = (RoomStruct*)(void*)room->_roomStructPtr;
-    theRoom->BgFrames[backgroundNumber].Graphic.reset();
+
+ if (theRoom->BgFrames[backgroundNumber].Graphic)
+ {
+     theRoom->BgFrames[backgroundNumber].Graphic.reset();
+     theRoom->BgFrameCount--;
 	
-	theRoom->BgFrameCount--;
 	room->BackgroundCount--;
-	for (size_t i = backgroundNumber; i < theRoom->BgFrameCount; i++) 
-	{
-		theRoom->BgFrames[i] = theRoom->BgFrames[i + 1];
-		theRoom->BgFrames[i].IsPaletteShared = theRoom->BgFrames[i + 1].IsPaletteShared;
-	}
+     for (size_t i = backgroundNumber; i < theRoom->BgFrameCount; i++)
+     {
+         theRoom->BgFrames[i] = theRoom->BgFrames[i + 1];
+         theRoom->BgFrames[i].IsPaletteShared = theRoom->BgFrames[i + 1].IsPaletteShared;
+     }
+ }
 }
 
 void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap ^bmp, bool useExactPalette, bool sharePalette) 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2678,13 +2678,6 @@ System::Drawing::Bitmap^ getBackgroundAsBitmap(Room ^room, int backgroundNumber)
   return ConvertBlockToBitmap32(roomptr->BgFrames[backgroundNumber].Graphic.get(), room->Width, room->Height, false);
 }
 
-void FixRoomMasks(Room ^room)
-{
-    RoomStruct *roomptr = (RoomStruct*)(void*)room->_roomStructPtr;
-    roomptr->MaskResolution = room->MaskResolution;
-    AGS::Common::FixRoomMasks(roomptr);
-}
-
 void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette) 
 {  
 	for each (PaletteEntry ^colour in newPalette) 

--- a/Editor/AGS.Types/Enums/PaletteColourType.cs
+++ b/Editor/AGS.Types/Enums/PaletteColourType.cs
@@ -7,7 +7,7 @@ namespace AGS.Types
     public enum PaletteColourType
     {
         Gamewide = 0,
-        //Locked = 1,
+        Locked = 1,
         Background = 2
     }
 }

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -28,6 +28,12 @@ namespace AGS.Types
         /// <returns>A <see cref="Bitmap"/> instance with the selected background. Returns null if background doesn't exist.</returns>
         Bitmap GetBackground(int background);
         /// <summary>
+        /// Sets the loaded room's background frame.
+        /// </summary>
+        /// <param name="background">The background index to set.</param>
+        /// <param name="bmp">The image to use for the frame.</param>
+        void SetBackground(int background, Bitmap bmp);
+        /// <summary>
         /// Gets the loaded room specified mask as a <see cref="Bitmap"/> instance.
         /// </summary>
         /// <param name="mask">The mask type to get.</param>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -22,7 +22,7 @@ namespace AGS.Types
 		/// </summary>
 		bool LoadRoom(IRoom roomToLoad);
         /// <summary>
-        /// Saves the loaded room to disk.
+        /// Saves the loaded room to disk. Room data, background images, and mask images.
         /// </summary>
         void Save();
         /// <summary>
@@ -32,13 +32,15 @@ namespace AGS.Types
         /// <returns>A <see cref="Bitmap"/> instance with the selected background. Returns null if background doesn't exist.</returns>
         Bitmap GetBackground(int background);
         /// <summary>
-        /// Sets the loaded room's background frame.
+        /// Sets the loaded room's background frame. This change is not permanent until
+        /// <see cref="IRoomController.Save"/> is invoked.
         /// </summary>
         /// <param name="background">The background index to set.</param>
         /// <param name="bmp">The image to use for the frame.</param>
         void SetBackground(int background, Bitmap bmp);
         /// <summary>
-        /// Deletes the loaded room's background frame.
+        /// Deletes the loaded room's background frame. This change is not permanent until
+        /// <see cref="IRoomController.Save"/> is invoked.
         /// </summary>
         /// <param name="background">The background index to delete.</param>
         void DeleteBackground(int background);
@@ -49,7 +51,8 @@ namespace AGS.Types
         /// <returns>A <see cref="Bitmap"/> instance with the selected mask type.Return null if none is selected.</returns>
         Bitmap GetMask(RoomAreaMaskType mask);
         /// <summary>
-        /// Sets the loaded room specified mask.
+        /// Sets the loaded room specified mask. This change is not permanent until <see cref="IRoomController.Save"/>
+        /// is invoked.
         /// </summary>
         /// <param name="mask">The mask type to set.</param>
         /// <param name="bmp">The mask to set.</param>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -21,11 +21,17 @@ namespace AGS.Types
 		/// RequiredAGSVersion: 3.0.1.35
 		/// </summary>
 		bool LoadRoom(IRoom roomToLoad);
-		/// <summary>
-		/// Gets the area number on the specified room mask at (x,y)
-		/// RequiredAGSVersion: 3.0.1.35
-		/// </summary>
-		int  GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y);
+        /// <summary>
+        /// Gets the loaded room backround as a <see cref="Bitmap"/> instance.
+        /// </summary>
+        /// <param name="background">The background index to get.</param>
+        /// <returns>A <see cref="Bitmap"/> instance with the selected background. Returns null if background doesn't exist.</returns>
+        Bitmap GetBackground(int background);
+        /// <summary>
+        /// Gets the area number on the specified room mask at (x,y)
+        /// RequiredAGSVersion: 3.0.1.35
+        /// </summary>
+        int  GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y);
 		/// <summary>
 		/// Draws the room background to the specified graphics context.
 		/// RequiredAGSVersion: 3.0.1.35

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -22,6 +22,10 @@ namespace AGS.Types
 		/// </summary>
 		bool LoadRoom(IRoom roomToLoad);
         /// <summary>
+        /// Saves the loaded room to disk.
+        /// </summary>
+        void Save();
+        /// <summary>
         /// Gets the loaded room backround as a <see cref="Bitmap"/> instance.
         /// </summary>
         /// <param name="background">The background index to get.</param>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -66,10 +66,14 @@ namespace AGS.Types
 		/// RequiredAGSVersion: 3.0.1.35
 		/// </summary>
 		void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
-		/// <summary>
-		/// Sets whether or not to grey out non-selected masks when drawing the background.
-		/// </summary>
-		bool GreyOutNonSelectedMasks { set; }
+        /// <summary>
+        /// Copies the walkable area into regions mask.
+        /// </summary>
+        void CopyWalkableAreaMaskToRegions();
+        /// <summary>
+        /// Sets whether or not to grey out non-selected masks when drawing the background.
+        /// </summary>
+        bool GreyOutNonSelectedMasks { set; }
         /// <summary>
         /// Occurs when a room is about to be saved to disk. You can add a new CompileError
         /// to the errors collection if you want to prevent the save going ahead.

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -45,6 +45,12 @@ namespace AGS.Types
         /// <returns>A <see cref="Bitmap"/> instance with the selected mask type.Return null if none is selected.</returns>
         Bitmap GetMask(RoomAreaMaskType mask);
         /// <summary>
+        /// Sets the loaded room specified mask.
+        /// </summary>
+        /// <param name="mask">The mask type to set.</param>
+        /// <param name="bmp">The mask to set.</param>
+        void SetMask(RoomAreaMaskType mask, Bitmap bmp);
+        /// <summary>
         /// Gets the area number on the specified room mask at (x,y)
         /// RequiredAGSVersion: 3.0.1.35
         /// </summary>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -34,6 +34,11 @@ namespace AGS.Types
         /// <param name="bmp">The image to use for the frame.</param>
         void SetBackground(int background, Bitmap bmp);
         /// <summary>
+        /// Deletes the loaded room's background frame.
+        /// </summary>
+        /// <param name="background">The background index to delete.</param>
+        void DeleteBackground(int background);
+        /// <summary>
         /// Gets the loaded room specified mask as a <see cref="Bitmap"/> instance.
         /// </summary>
         /// <param name="mask">The mask type to get.</param>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -78,10 +78,6 @@ namespace AGS.Types
         /// </summary>
         void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
         /// <summary>
-        /// Copies the walkable area into regions mask.
-        /// </summary>
-        void CopyWalkableAreaMaskToRegions();
-        /// <summary>
         /// Scales all the room's masks according to the <see cref="Room.MaskResolution"/>,
         /// execept for the <see cref="RoomAreaMaskType.WalkBehinds"/> which retains the
         /// resolution of the background image. If the <see cref="Room.MaskResolution"/>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -71,6 +71,13 @@ namespace AGS.Types
         /// </summary>
         void CopyWalkableAreaMaskToRegions();
         /// <summary>
+        /// Scales all the room's masks according to the <see cref="Room.MaskResolution"/>,
+        /// execept for the <see cref="RoomAreaMaskType.WalkBehinds"/> which retains the
+        /// resolution of the background image. If the <see cref="Room.MaskResolution"/>
+        /// has a resolution of 2 it will halve the masks in both dimensions.
+        /// </summary>
+        void AdjustMaskResolution();
+        /// <summary>
         /// Sets whether or not to grey out non-selected masks when drawing the background.
         /// </summary>
         bool GreyOutNonSelectedMasks { set; }

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -28,6 +28,12 @@ namespace AGS.Types
         /// <returns>A <see cref="Bitmap"/> instance with the selected background. Returns null if background doesn't exist.</returns>
         Bitmap GetBackground(int background);
         /// <summary>
+        /// Gets the loaded room specified mask as a <see cref="Bitmap"/> instance.
+        /// </summary>
+        /// <param name="mask">The mask type to get.</param>
+        /// <returns>A <see cref="Bitmap"/> instance with the selected mask type.Return null if none is selected.</returns>
+        Bitmap GetMask(RoomAreaMaskType mask);
+        /// <summary>
         /// Gets the area number on the specified room mask at (x,y)
         /// RequiredAGSVersion: 3.0.1.35
         /// </summary>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -59,17 +59,24 @@ namespace AGS.Types
         /// RequiredAGSVersion: 3.0.1.35
         /// </summary>
         int  GetAreaMaskPixel(RoomAreaMaskType maskType, int x, int y);
-		/// <summary>
-		/// Draws the room background to the specified graphics context.
-		/// RequiredAGSVersion: 3.0.1.35
-		/// </summary>
-		void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor);
+        /// <summary>
+        /// Draws the room background to the specified graphics context.
+        /// RequiredAGSVersion: 3.0.1.35
+        /// </summary>
+        [Obsolete("The method is deprecated because it takes integer for scale which is inaccurate. Use overload with double for scale instead.")]
+        void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor);
 		/// <summary>
 		/// Draws the room background to the specified graphics context,
 		/// and overlays one of the room masks onto it.
 		/// RequiredAGSVersion: 3.0.1.35
 		/// </summary>
+        [Obsolete("The method is deprecated because it takes integer for scale which is inaccurate. Use overload with double for scale instead.")]
 		void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
+        /// <summary>
+        /// Draws the room background to the specified graphics context,
+        /// and overlays one of the room masks onto it.
+        /// </summary>
+        void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
         /// <summary>
         /// Copies the walkable area into regions mask.
         /// </summary>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -81,12 +81,13 @@ namespace AGS.Types
         /// </summary>
         void DrawRoomBackground(Graphics g, Point point, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
         /// <summary>
-        /// Scales all the room's masks according to the <see cref="Room.MaskResolution"/>,
-        /// execept for the <see cref="RoomAreaMaskType.WalkBehinds"/> which retains the
+        /// Sets the mask resolution and scales all the room's masks according to the
+        /// <see cref="Room.MaskResolution"/>, execept for the
+        /// <see cref="RoomAreaMaskType.WalkBehinds"/> which retains the
         /// resolution of the background image. If the <see cref="Room.MaskResolution"/>
         /// has a resolution of 2 it will halve the masks in both dimensions.
         /// </summary>
-        void AdjustMaskResolution();
+        void AdjustMaskResolution(int maskResolution);
         /// <summary>
         /// Sets whether or not to grey out non-selected masks when drawing the background.
         /// </summary>

--- a/Editor/AGS.Types/Interfaces/IRoomController.cs
+++ b/Editor/AGS.Types/Interfaces/IRoomController.cs
@@ -79,7 +79,7 @@ namespace AGS.Types
         /// Draws the room background to the specified graphics context,
         /// and overlays one of the room masks onto it.
         /// </summary>
-        void DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
+        void DrawRoomBackground(Graphics g, Point point, int backgroundNumber, double scaleFactor, RoomAreaMaskType maskType, int maskTransparency, int selectedArea);
         /// <summary>
         /// Scales all the room's masks according to the <see cref="Room.MaskResolution"/>,
         /// execept for the <see cref="RoomAreaMaskType.WalkBehinds"/> which retains the

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -379,7 +379,22 @@ namespace AGS.Types
             get { return _interactions; }
         }
 
-		void IChangeNotification.ItemModified()
+        public double GetMaskScale(RoomAreaMaskType mask)
+        {
+            switch (mask)
+            {
+                case RoomAreaMaskType.WalkBehinds:
+                    return 1.0; // walk-behinds always 1:1 with room size
+                case RoomAreaMaskType.Hotspots:
+                case RoomAreaMaskType.WalkableAreas:
+                case RoomAreaMaskType.Regions:
+                    return 1.0 / MaskResolution;
+                default:
+                    return 0.0;
+            }
+        }
+
+        void IChangeNotification.ItemModified()
 		{
 			this.Modified = true;
 		}

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -390,7 +390,7 @@ namespace AGS.Types
                 case RoomAreaMaskType.Regions:
                     return 1.0 / MaskResolution;
                 default:
-                    return 0.0;
+                    throw new ArgumentException($"Illegal mask type, mask {mask} cannot be scaled.");
             }
         }
 


### PR DESCRIPTION
Related to #469 

In short I have
1. Centralized certain room operations used by the room editor to the `IRoomController`, instead of globally used native invocations from `NativeProxy`. This is affects the public API for editor plugin developers.
2. Wrote a small framework as `System.Drawing.Bitmap` extensions for drawing images. I shopped around for potential third party frameworks but drawing on 8-bit indexed images is generally not supported.
3. Replaced a lot of `NativeProxy` invocations related to `IRoomController` with C# code. There's still some room code that uses `NativeProxy`, primarily related to loading/saving data from .crm files. This will be replaced in a future pull request.
4. Deleted dead AGS.Native code related to rooms.