### PR TITLE
Dockerfile changes to fix Windows CI builds

### DIFF
--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -1,38 +1,48 @@
 # base will already have Chocolatey installed
 FROM cirrusci/windowsservercore:2019
 
-# no temp folder exists by default
-RUN mkdir %TEMP%
+# if no temp folder exists by default, create it
+RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
 
 ARG VISUALCPP_BUILD_TOOLS_VERSION=14.0.25420.1
-RUN cinst visualcpp-build-tools --version %VISUALCPP_BUILD_TOOLS_VERSION% -y
+RUN cinst visualcpp-build-tools --version %VISUALCPP_BUILD_TOOLS_VERSION% -y && \
+  mkdir empty && \
+  robocopy empty %TEMP% /MIR > nul & \
+  rd /s /q empty
 
 # Windows 8.0 SDK (but only install the .NET 4.5 SDK)
-RUN cd %TEMP% && \
+RUN pushd %TEMP% && \
   curl -fLO http://download.microsoft.com/download/F/1/3/F1300C9C-A120-4341-90DF-8A52509B23AC/standalonesdk/sdksetup.exe && \
-  start /wait sdksetup /ceip off /features OptionID.NetFxSoftwareDevelopmentKit /quiet /norestart
+  start /wait sdksetup /ceip off /features OptionID.NetFxSoftwareDevelopmentKit /quiet /norestart && \
+  popd && \
+  mkdir empty && \
+  robocopy empty %TEMP% /MIR > nul & \
+  rd /s /q empty
 
 ARG NUGET_VERSION=5.7.0
-RUN cinst nuget.commandline --version %NUGET_VERSION% -y
-
 ARG INNO_SETUP_VERSION=6.0.5
-RUN cinst innosetup --version %INNO_SETUP_VERSION% -y
-
 ARG CMAKE_VERSION=3.18.4
-RUN cinst cmake --version %CMAKE_VERSION% --installargs ADD_CMAKE_TO_PATH=System -y
+RUN cinst nuget.commandline --version %NUGET_VERSION% -y && \
+  cinst innosetup --version %INNO_SETUP_VERSION% -y && \
+  cinst cmake --version %CMAKE_VERSION% --installargs ADD_CMAKE_TO_PATH=System -y && \
+  mkdir empty && \
+  robocopy empty %TEMP% /MIR > nul & \
+  rd /s /q empty
 
 RUN pushd %TEMP% && \
-  git clone https://github.com/Microsoft/vcpkg.git && \
-  pushd vcpkg && \
-  if not exist vcpkg.exe call bootstrap-vcpkg.bat && \
-  vcpkg install libogg:x86-windows-static libtheora:x86-windows-static libvorbis:x86-windows-static && \
+  mkdir Lib\Xiph && \
+  pushd Lib\Xiph && \
+  nuget install ericoporto.xiph-for-ags -Version 2020.12.12.1 && \
   popd && \
   popd && \
   mkdir Lib\Xiph && \
-  copy %TEMP%\vcpkg\installed\x86-windows-static\lib\ogg.lib Lib\Xiph\libogg_static.lib && \
-  copy %TEMP%\vcpkg\installed\x86-windows-static\lib\theora.lib Lib\Xiph\libtheora_static.lib && \
-  copy %TEMP%\vcpkg\installed\x86-windows-static\lib\vorbis.lib Lib\Xiph\libvorbis_static.lib && \
-  copy %TEMP%\vcpkg\installed\x86-windows-static\lib\vorbisfile.lib Lib\Xiph\libvorbisfile_static.lib
+  pushd Lib\Xiph && \
+  copy %TEMP%\Lib\Xiph\ericoporto.xiph-for-ags.2020.12.12.1\native\lib\libogg_static.lib libogg_static.lib && \
+  copy %TEMP%\Lib\Xiph\ericoporto.xiph-for-ags.2020.12.12.1\native\lib\libtheora_static.lib libtheora_static.lib && \
+  copy %TEMP%\Lib\Xiph\ericoporto.xiph-for-ags.2020.12.12.1\native\lib\libvorbis_static.lib libvorbis_static.lib && \
+  copy %TEMP%\Lib\Xiph\ericoporto.xiph-for-ags.2020.12.12.1\native\lib\libvorbisfile_static.lib libvorbisfile_static.lib && \
+  popd && \
+  rd /s /q %TEMP%\Lib
 
 ARG IRRKLANG_VERSION=1.6.0
 RUN curl -fLSs http://www.ambiera.at/downloads/irrKlang-32bit-%IRRKLANG_VERSION%.zip | tar -f - -xvzC %TEMP% irrKlang-%IRRKLANG_VERSION%/bin/dotnet-4/*.dll && \
@@ -63,8 +73,3 @@ RUN for %a in (%ALLEGRO_RELEASES%) do \
   curl -fLOJ https://github.com/%ALLEGRO_REPO%/releases/download/%a/alleg-static-mt.lib & \
   curl -fLOJ https://github.com/%ALLEGRO_REPO%/releases/download/%a/alleg-static.lib & \
   popd
-
-# delete all temp Files
-RUN mkdir empty && \
-  robocopy empty %TEMP% /MIR > nul & \
-  rd /s /q empty


### PR DESCRIPTION
- some RUN commands reduced in rearrange to minimize layers (reduce docker size)
- no vcpkg bootstrapping, pulls prebuilt xiph libraries from nuget
  (vcpkg was not building with current VS tooling in this image)
- docker image size lowered a bit and is now 11GB

Same as #1150 but applied to master