### PR TITLE
Implement --tell-gameproperties instead of putting game info in --tell-config

### DIFF
--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1440,16 +1440,15 @@ static void engine_print_info(const std::set<String> &keys, ConfigTree *user_cfg
     {
         data["filepath"]["exe"] = appPath;
         data["filepath"]["cwd"] = Directory::GetCurrentDirectory();
-        data["filepath"]["startup"] = usetup.startup_dir;
-        data["filepath"]["datadir"] = ResPaths.DataDir;
+        data["filepath"]["datadir"] = Path::MakePathNoSlash(ResPaths.DataDir);
         if (!ResPaths.DataDir2.IsEmpty())
         {
-            data["filepath"]["datadir2"] = ResPaths.DataDir2;
-            data["filepath"]["audiodir2"] = ResPaths.AudioDir2;
-            data["filepath"]["voicedir2"] = ResPaths.VoiceDir2;
+            data["filepath"]["datadir2"] = Path::MakePathNoSlash(ResPaths.DataDir2);
+            data["filepath"]["audiodir2"] = Path::MakePathNoSlash(ResPaths.AudioDir2);
+            data["filepath"]["voicedir2"] = Path::MakePathNoSlash(ResPaths.VoiceDir2);
         }
-        data["filepath"]["savegamedir"] = GetGameUserDataDir().FullDir;
-        data["filepath"]["appdatadir"] = GetGameAppDataDir().FullDir;
+        data["filepath"]["savegamedir"] = Path::MakePathNoSlash(GetGameUserDataDir().FullDir);
+        data["filepath"]["appdatadir"] = Path::MakePathNoSlash(GetGameAppDataDir().FullDir);
     }
     String full;
     IniUtil::WriteToString(full, data);

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -151,9 +151,26 @@ void engine_setup_window()
     platform->SetGameWindowIcon();
 }
 
+// Fills map with game settings, to e.g. let setup application(s)
+// display correct properties to the user
+static void fill_game_properties(StringOrderMap &map)
+{
+    map["title"] = game.gamename;
+    map["guid"] = game.guid;
+    map["legacy_uniqueid"] = StrUtil::IntToString(game.uniqueid);
+    map["legacy_resolution"] = StrUtil::IntToString(game.GetResolutionType());
+    map["legacy_letterbox"] = StrUtil::IntToString(game.options[OPT_LETTERBOX]);;
+    map["resolution_width"] = StrUtil::IntToString(game.GetDefaultRes().Width);
+    map["resolution_height"] = StrUtil::IntToString(game.GetDefaultRes().Height);
+    map["resolution_bpp"] = StrUtil::IntToString(game.GetColorDepth());
+    map["render_at_screenres"] = StrUtil::IntToString(
+        game.options[OPT_RENDERATSCREENRES] == kRenderAtScreenRes_UserDefined ? -1 :
+        (game.options[OPT_RENDERATSCREENRES] == kRenderAtScreenRes_Enabled ? 1 : 0));
+}
+
 // Starts up setup application, if capable.
 // Returns TRUE if should continue running the game, otherwise FALSE.
-bool engine_run_setup(ConfigTree &cfg, int &app_res)
+bool engine_run_setup(const ConfigTree &cfg, int &app_res)
 {
     app_res = EXIT_NORMAL;
 #if AGS_PLATFORM_OS_WINDOWS
@@ -167,8 +184,10 @@ bool engine_run_setup(ConfigTree &cfg, int &app_res)
 
             Debug::Printf(kDbgMsg_Info, "Running Setup");
 
+            ConfigTree cfg_with_meta = cfg;
+            fill_game_properties(cfg_with_meta["gameproperties"]);
             ConfigTree cfg_out;
-            SetupReturnValue res = platform->RunSetup(cfg, cfg_out);
+            SetupReturnValue res = platform->RunSetup(cfg_with_meta, cfg_out);
             if (res != kSetup_Cancel)
             {
                 if (!IniUtil::Merge(cfg_file, cfg_out))
@@ -1350,20 +1369,6 @@ void engine_prepare_config(ConfigTree &cfg, const ConfigTree &startup_opts)
     for (const auto &sectn : startup_opts)
         for (const auto &opt : sectn.second)
             cfg[sectn.first][opt.first] = opt.second;
-
-    // Add "meta" config settings to let setup application(s)
-    // display correct properties to the user
-    INIwriteint(cfg, "misc", "defaultres", game.GetResolutionType());
-    INIwriteint(cfg, "misc", "letterbox", game.options[OPT_LETTERBOX]);
-    INIwriteint(cfg, "misc", "game_width", game.GetDefaultRes().Width);
-    INIwriteint(cfg, "misc", "game_height", game.GetDefaultRes().Height);
-    INIwriteint(cfg, "misc", "gamecolordepth", game.color_depth * 8);
-    if (game.options[OPT_RENDERATSCREENRES] != kRenderAtScreenRes_UserDefined)
-    {
-        // force enabled/disabled
-        INIwriteint(cfg, "graphics", "render_at_screenres", game.options[OPT_RENDERATSCREENRES] == kRenderAtScreenRes_Enabled);
-        INIwriteint(cfg, "disabled", "render_at_screenres", 1);
-    }
 }
 
 // Applies configuration to the running game
@@ -1381,7 +1386,7 @@ extern std::set<String> tellInfoKeys;
 static bool print_info_needs_game(const std::set<String> &keys)
 {
     return keys.count("all") > 0 || keys.count("config") > 0 || keys.count("configpath") > 0 ||
-        keys.count("data") > 0 || keys.count("filepath") > 0;
+        keys.count("data") > 0 || keys.count("filepath") > 0 || keys.count("gameproperties") > 0;
 }
 
 static void engine_print_info(const std::set<String> &keys, ConfigTree *user_cfg)
@@ -1423,9 +1428,13 @@ static void engine_print_info(const std::set<String> &keys, ConfigTree *user_cfg
     if (all || keys.count("data") > 0)
     {
         data["data"]["gamename"] = game.gamename;
-        data["data"]["version"] = String::FromFormat("%d", loaded_game_file_version);
+        data["data"]["version"] = StrUtil::IntToString(loaded_game_file_version);
         data["data"]["compiledwith"] = game.compiled_with;
         data["data"]["basepack"] = ResPaths.GamePak.Path;
+    }
+    if (all || keys.count("gameproperties") > 0)
+    {
+        fill_game_properties(data["gameproperties"]);
     }
     if (all || keys.count("filepath") > 0)
     {

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -225,6 +225,7 @@ void main_print_help() {
            "  --tell-config                Print contents of merged game config\n"
            "  --tell-configpath            Print paths to available config files\n"
            "  --tell-data                  Print information on game data and its location\n"
+           "  --tell-gameproperties        Print information on game general settings\n"
            "  --tell-engine                Print engine name and version\n"
            "  --tell-filepath              Print all filepaths engine uses for the game\n"
            "  --tell-graphicdriver         Print list of supported graphic drivers\n"

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -152,13 +152,13 @@ void WinConfig::Load(const ConfigTree &cfg)
     DataDirectory = INIreadstring(cfg, "misc", "datadir", DataDirectory);
     UserSaveDir = INIreadstring(cfg, "misc", "user_data_dir");
     // Backward-compatible resolution type
-    GameResType = (GameResolutionType)INIreadint(cfg, "misc", "defaultres", GameResType);
+    GameResType = (GameResolutionType)INIreadint(cfg, "gameproperties", "legacy_resolution", GameResType);
     if (GameResType < kGameResolution_Undefined || GameResType >= kNumGameResolutions)
         GameResType = kGameResolution_Undefined;
-    GameResolution.Width = INIreadint(cfg, "misc", "game_width", GameResolution.Width);
-    GameResolution.Height = INIreadint(cfg, "misc", "game_height", GameResolution.Height);
-    GameColourDepth = INIreadint(cfg, "misc", "gamecolordepth", GameColourDepth);
-    LetterboxByDesign = INIreadint(cfg, "misc", "letterbox", 0) != 0;
+    GameResolution.Width = INIreadint(cfg, "gameproperties", "resolution_width", GameResolution.Width);
+    GameResolution.Height = INIreadint(cfg, "gameproperties", "resolution_height", GameResolution.Height);
+    GameColourDepth = INIreadint(cfg, "gameproperties", "resolution_bpp", GameColourDepth);
+    LetterboxByDesign = INIreadint(cfg, "gameproperties", "legacy_letterbox", 0) != 0;
 
     GfxDriverId = INIreadstring(cfg, "graphics", "driver", GfxDriverId);
     GfxFilterId = INIreadstring(cfg, "graphics", "filter", GfxFilterId);
@@ -171,7 +171,11 @@ void WinConfig::Load(const ConfigTree &cfg)
     RefreshRate = INIreadint(cfg, "graphics", "refresh", RefreshRate);
     Windowed = INIreadint(cfg, "graphics", "windowed", Windowed ? 1 : 0) != 0;
     VSync = INIreadint(cfg, "graphics", "vsync", VSync ? 1 : 0) != 0;
-    RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
+    int locked_render_at_screenres = INIreadint(cfg, "gameproperties", "render_at_screenres", -1);
+    if (locked_render_at_screenres < 0)
+        RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
+    else
+        RenderAtScreenRes = locked_render_at_screenres != 0;
 
     AntialiasSprites = INIreadint(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0) != 0;
 
@@ -685,7 +689,8 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
         EnableWindow(_hUseVoicePack, FALSE);
     if (INIreadint(_cfgIn, "disabled", "filters", 0) != 0)
         EnableWindow(_hGfxFilterList, FALSE);
-    if (INIreadint(_cfgIn, "disabled", "render_at_screenres", 0) != 0)
+    if (INIreadint(_cfgIn, "disabled", "render_at_screenres", 0) != 0 ||
+        INIreadint(_cfgIn, "gameproperties", "render_at_screenres", -1) >= 0)
         EnableWindow(_hRenderAtScreenRes, FALSE);
 
     RECT win_rect, gfx_rect, adv_rect, border;


### PR DESCRIPTION
Resolves #1154

Moved "meta" settings from "--tell-config" to "--tell-gameproperties", improved value naming, added couple of more things.

Embedded winsetup receives a merged config map with "--tell-gameproperties" contents.
These were not really a true part of user config, thus supporting old names is not necessary.

All values printed by "--tell-gameproperties" go in "gameproperties" section, and are following:

* title - game title;
* guid - game guid;
* legacy_uniqueid - random generated 32-bit integer, that worked as UID in old games (may be ignored if guid is present);
* legacy_resolution - deprecated resolution type (integer), should be "8" for all new games;
* legacy_letterbox - bool, whether "letterbox by design" setting is on (considered obsolete);
* resolution_width - native resolution width;
* resolution_height - native resolution height;
* resolution_bpp - native resolution bits per pixel (8, 16, 32);
* render_at_screenres - have 3 values:
    -1 - determined by user config;
    0 (false) - locked at disabled
    1 (true) - locked at enabled
