### PR TITLE
Editor: Removed the copy walkable to region button

### DIFF
--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -317,11 +317,6 @@ namespace AGS.Editor
             _native.DrawFillOntoMask(room, mask, x1, y1, color);
         }
 
-        public void CopyWalkableAreaMaskToRegions(Room room)
-        {
-            _native.CopyWalkableMaskToRegions(room);
-        }
-
 		public bool GreyOutNonSelectedMasks
 		{
 			set { _native.SetGreyedOutMasksEnabled(value); }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -15,7 +15,6 @@ namespace AGS.Editor
         protected const string DRAW_FREEHAND_COMMAND = "DrawFreehand";
 		protected const string DRAW_RECTANGLE_COMMAND = "DrawRectangle";
 		protected const string DRAW_FILL_COMMAND = "DrawFill";
-        protected const string COPY_WALKABLE_AREA_MASK_COMMAND = "CopyWalkableMaskToRegions";
         protected const string IMPORT_MASK_COMMAND = "ImportAreaMask";
         protected const string EXPORT_MASK_COMMAND = "ExportAreaMask";
         protected const string UNDO_COMMAND = "UndoAreaDraw";
@@ -84,7 +83,6 @@ namespace AGS.Editor
             _toolbarIcons.Add(new MenuCommand(UNDO_COMMAND, "Undo (Ctrl+Z)", "UndoIcon"));
 			_toolbarIcons.Add(new MenuCommand(IMPORT_MASK_COMMAND, "Import mask from file", "ImportMaskIcon"));
             _toolbarIcons.Add(new MenuCommand(EXPORT_MASK_COMMAND, "Export mask to file", "ExportMaskIcon"));
-            _toolbarIcons.Add(new MenuCommand(COPY_WALKABLE_AREA_MASK_COMMAND, "Copy walkable area mask to regions", "CopyWalkableAreaMaskIcon"));
 			_toolbarIcons.Add(new MenuCommand(GREYED_OUT_MASKS_COMMAND, "Show non-selected masks greyed out", "GreyedOutMasksIcon"));
 			_toolbarIcons[(int)_drawMode].Checked = true;
 			_toolbarIcons[TOOLBAR_INDEX_GREY_OUT_MASKS].Checked = _greyedOutMasks;
@@ -434,15 +432,6 @@ namespace AGS.Editor
                     ExportMaskFromFile(fileName);
                 }
             }
-            else if (command == COPY_WALKABLE_AREA_MASK_COMMAND)
-			{
-				if (Factory.GUIController.ShowQuestion("This will overwrite your Regions mask with a copy of your Walkable Areas mask. Are you sure you want to do this?") == DialogResult.Yes)
-				{
-					Factory.NativeProxy.CopyWalkableAreaMaskToRegions(_room);
-					_room.Modified = true;
-					_panel.Invalidate();
-				}
-			}
 			else if (command == GREYED_OUT_MASKS_COMMAND)
 			{
 				_greyedOutMasks = !_greyedOutMasks;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -79,7 +79,6 @@ extern void draw_filled_rect_onto_mask(void *roomptr, int maskType, int x1, int 
 extern void draw_fill_onto_mask(void *roomptr, int maskType, int x1, int y1, int color);
 extern void AdjustRoomResolution(Room ^room);
 extern void FixRoomMasks(Room ^room);
-extern void copy_walkable_to_regions(void *roomptr);
 extern int get_mask_pixel(void *roomptr, int maskType, int x, int y);
 extern void import_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
@@ -505,10 +504,6 @@ namespace AGS
 			draw_fill_onto_mask((void*)room->_roomStructPtr, (int)maskType, x1, y1, color);
 		}
 
-		void NativeMethods::CopyWalkableMaskToRegions(Room ^room) 
-		{
-			copy_walkable_to_regions((void*)room->_roomStructPtr);
-		}
 
 		int NativeMethods::GetAreaMaskPixel(Room ^room, RoomAreaMaskType maskType, int x, int y)
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -69,7 +69,6 @@ namespace AGS
 			void DrawLineOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFilledRectOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int x2, int y2, int color);
 			void DrawFillOntoMask(Room ^room, RoomAreaMaskType maskType, int x1, int y1, int color);
-			void CopyWalkableMaskToRegions(Room ^room);
 			int  GetAreaMaskPixel(Room ^room, RoomAreaMaskType maskType, int x, int y);
       void ImportAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -669,11 +669,6 @@ float get_scale_for_mask(RoomStruct *roomptr, RoomAreaMask maskType)
 }
 
 
-void copy_walkable_to_regions (void *roomptr) {
-    RoomStruct *theRoom = (RoomStruct*)roomptr;
-	theRoom->RegionMask->Blit(theRoom->WalkAreaMask.get(), 0, 0, 0, 0, theRoom->RegionMask->GetWidth(), theRoom->RegionMask->GetHeight());
-}
-
 int get_mask_pixel(void *roomptr, int maskType, int x, int y)
 {
     Common::Bitmap *mask = get_bitmap_for_mask((RoomStruct*)roomptr, (RoomAreaMask)maskType);


### PR DESCRIPTION
Removed it from the hotbar and all related functionality.

This was oddly specific, it's unlikely that it's used often enough that it warrants a dedicated button. Users who wants to replicate this feature without button can export and import manually.

Related to #1138