### PR TITLE
Fix wrong object dependency in solution Compiler2.Lib.sln

### DIFF
--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
@@ -63,7 +63,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Compiler_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Compiler2_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Solution contains Compiler2.Lib.Test; this project wrongly references `Compiler_d.lib` as additional input dependency for the linker. The correct value would be `Compiler2_d.lib`. Otherwise, googletests won't compile.