### PR TITLE
Prevent new compiler from going into an endless loop on encountering a last section that is completely empty

### DIFF
--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -51,6 +51,10 @@ void AGS::Scanner::NewSection(std::string const &section)
 
 AGS::ErrorType AGS::Scanner::GetNextSymstring(std::string &symstring, ScanType &scan_type, CodeCell &value)
 {
+    symstring = "";
+    scan_type = kSct_Unspecified;
+    value = 0;
+
     ErrorType retval = SkipWhitespace();
     if (retval < 0) return kERR_UserError;
     if (EOFReached()) return kERR_None;
@@ -168,6 +172,12 @@ AGS::ErrorType AGS::Scanner::GetNextSymbol(Symbol &symbol)
         ErrorType retval = GetNextSymstring(symstring, scan_type, value);
         if (retval < 0) return retval;
 
+        if (symstring.empty())
+        {
+            symbol = kKW_NoSymbol;
+            return _ocMatcher.EndOfInputCheck();
+        }
+
         if (kSct_SectionChange != scan_type)
             break;
 
@@ -175,12 +185,6 @@ AGS::ErrorType AGS::Scanner::GetNextSymbol(Symbol &symbol)
         if (retval < 0) return retval;
 
         NewSection(symstring);
-    }
-
-    if (symstring.empty())
-    {
-        symbol = kKW_NoSymbol;
-        return _ocMatcher.EndOfInputCheck();
     }
 
     ErrorType retval = SymstringToSym(symstring, scan_type, value, symbol);

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -933,3 +933,17 @@ TEST_F(Compile1, ComponentOfNonStruct2) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'.'"));
 }
+
+TEST_F(Compile1, EmptySection) {
+
+    // An empty last section should not result in an endless loop.
+
+    char *inpl = "\
+\"__NEWSCRIPTSTART_FOO\"     \n\
+\"__NEWSCRIPTSTART_BAR\"      \n\
+        ";
+
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
@@ -63,7 +63,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Compiler_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Compiler2_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
This PR depends on the previous one (fix dependency in solution Compiler2.Lib.sln).

The new compiler ran into an endless loop when encountering a last section that is completely empty. This happens in particular when a room file is completely empty. This PR fixes this.