### PR TITLE
New compiler import autoptr bugs

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -387,6 +387,14 @@ std::string const AGS::SymbolTable::GetName(AGS::Symbol symbl) const
         return std::string("(end of input)");
     if (static_cast<size_t>(symbl) >= entries.size())
         return std::string("(invalid symbol)");
+    if (IsAutoptrVartype(symbl))
+    {
+        std::string name = entries[symbl].Name;
+        int const pos_of_last_ch = name.length() - 1;
+        if (pos_of_last_ch >= 0 && ' ' == name[pos_of_last_ch])
+            name.resize(pos_of_last_ch); // cut off trailing ' '
+        return name;
+    }
     return entries[symbl].Name;
 }
 

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -424,6 +424,7 @@ public:
 
     // Structs
     inline bool IsStructVartype(Symbol s) const { return IsVTF(s, VTF::kStruct); }
+    inline bool IsAutoptrVartype(Symbol s) const { return IsVTF(s, VTF::kAutoptr); }
     // Fills compo_list with the symbols of all the strct components. Includes the ancestors' components
     void GetComponentsOfStruct(Symbol strct, std::vector<Symbol> &compo_list) const;
     // Find the description of a component.

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -5881,8 +5881,14 @@ AGS::ErrorType AGS::Parser::ParseVartype(Vartype vartype, TypeQualifierSet tqs, 
         (kKW_NoSymbol != name_of_current_func) ? ScT::kLocal :
         (tqs[TQ::kImport]) ? ScT::kImport : ScT::kGlobal;
 
-    // Only imply a pointer for a managed entity if it isn't imported.
-    if ((ScT::kImport == scope_type && kKW_Dynpointer == _src.PeekNext()) ||
+    // Imply a pointer for managed vartypes. However, do NOT
+    // do this in import statements. (Reason: automatically
+    // generated code does things like "import Object oFoo;" and
+    // then it really does mean "Object", not "Object *".
+    // This can only happen in automatically generated code:
+    // Users are never allowed to define unpointered managed entities.
+    if (kKW_Dynpointer == _src.PeekNext() ||
+        _sym.IsAutoptrVartype(vartype) ||
         (ScT::kImport != scope_type && _sym.IsManagedVartype(vartype)))
     {
         vartype = _sym.VartypeWith(VTT::kDynpointer, vartype);

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -947,3 +947,22 @@ TEST_F(Compile1, EmptySection) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
+
+TEST_F(Compile1, AutoptrDisplay) {
+
+    // Autopointered types should not be shown with trailing ' ' in messages
+    char *inpl = "\
+        internalstring autoptr builtin      \n\
+            managed struct String           \n\
+        {                                   \n\
+        };                                  \n\
+        void main() {                       \n\
+            String s = 17;                  \n\
+        }                                   \n\
+        ";
+
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    ASSERT_EQ(std::string::npos, msg.find("'String '"));
+}

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -966,3 +966,43 @@ TEST_F(Compile1, AutoptrDisplay) {
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     ASSERT_EQ(std::string::npos, msg.find("'String '"));
 }
+
+TEST_F(Compile1, ImportAutoptr1) {
+
+    // Import decls of funcs with autopointered returns must be processed correctly.
+
+    char *inpl = "\
+        internalstring autoptr builtin      \n\
+            managed struct String           \n\
+        {                                   \n\
+        };                                  \n\
+                                            \n\
+        import String foo(int);             \n\
+                                            \n\
+        String foo(int bar)                 \n\
+        {                                   \n\
+            return null;                    \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}
+
+TEST_F(Compile1, ImportAutoptr2) {
+
+    // Import decls of autopointered variables must be processed correctly.
+
+    char *inpl = "\
+        internalstring autoptr builtin      \n\
+            managed struct String           \n\
+        {                                   \n\
+        };                                  \n\
+                                            \n\
+        import String foo;                  \n\
+        String foo;                         \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}


### PR DESCRIPTION
Address the following bugs:
- In `import` statements, `autoptr` entities aren't processed correctly, their pointer isn't implied but should be.
- All `autoptr` types are displayed with a spurious trailing `" "` in messages.

In particular, `String` is affected.

Fix the code so that the bugs go away.