### PR TITLE
New compiler: Fix: Error on incrementing an attribute

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4180,7 +4180,7 @@ AGS::ErrorType AGS::Parser::ParseAssignment_SAssign(Symbol ass_symbol, SrcList &
         return kERR_None;
     }
 
-    retval = ParseAssignment_Assign(lhs); // moves cursor to end of LHS
+    retval = AccessData_AssignTo(lhs); // moves cursor to end of LHS
     if (retval < 0) return retval; 
     _src.GetNext(); // Eat ++ or --
     return kERR_None;
@@ -5458,7 +5458,16 @@ AGS::ErrorType AGS::Parser::ParseStruct(TypeQualifierSet tqs, Symbol &struct_of_
     }
 
     // Take struct that has just been defined as the vartype of a declaration
-    return ParseVartype(stname, tqs, struct_of_current_func, name_of_current_func);
+    // Take struct that has just been defined as the vartype of a declaration
+    // Those type qualifiers that are used to define the struct type
+    // have been used up, so reset them
+    TypeQualifierSet vardecl_tqs = tqs;
+    vardecl_tqs[TQ::kAutoptr] = false;
+    vardecl_tqs[TQ::kBuiltin] = false;
+    vardecl_tqs[TQ::kManaged] = false;
+    vardecl_tqs[TQ::kStringstruct] = false;
+
+    return ParseVartype(stname, vardecl_tqs, struct_of_current_func, name_of_current_func);
 }
 
 // We've accepted something like "enum foo { bar"; '=' follows

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -5458,7 +5458,6 @@ AGS::ErrorType AGS::Parser::ParseStruct(TypeQualifierSet tqs, Symbol &struct_of_
     }
 
     // Take struct that has just been defined as the vartype of a declaration
-    // Take struct that has just been defined as the vartype of a declaration
     // Those type qualifiers that are used to define the struct type
     // have been used up, so reset them
     TypeQualifierSet vardecl_tqs = tqs;

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2042,3 +2042,60 @@ TEST_F(Bytecode1, ThisExpression1) {
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
+
+TEST_F(Bytecode1, IncrementAttribute) {
+
+    char inpl[] = "\
+        builtin managed struct Object       \n\
+        {                                   \n\
+            import attribute int Graphic;   \n\
+        } obj;                              \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            obj.Graphic++;                  \n\
+        }                                   \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("IncrementAttribute", scrip);
+
+    size_t const codesize = 51;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    2,            0,   48,    2,   52,    // 7
+      29,    6,   45,    2,           39,    0,    6,    3,    // 15
+       0,   33,    3,   30,            6,    1,    3,    1,    // 23
+       6,    2,    0,   48,            2,   52,   29,    6,    // 31
+      34,    3,   45,    2,           39,    1,    6,    3,    // 39
+       1,   33,    3,   35,            1,   30,    6,    6,    // 47
+       3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 4;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+       4,   16,   26,   40,        -999
+    };
+    char fixuptypes[] = {
+      1,   4,   1,   4,     '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 2;
+    std::string imports[] = {
+    "Object::get_Graphic^0",      "Object::set_Graphic^1",       "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1006,3 +1006,24 @@ TEST_F(Compile1, ImportAutoptr2) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
+
+TEST_F(Compile1, AttribInc) {
+
+    // Import decls of autopointered variables must be processed correctly.
+
+    char *inpl = "\
+        builtin managed struct Object       \n\
+        {                                   \n\
+            import attribute int  Graphic;  \n\
+        } obj;                              \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            obj.Graphic++;                  \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}
+


### PR DESCRIPTION
New compiler generated an error when an attribute was incremented or decremented.
Typical code: `oObject.Graphic++;`
This PR fixes the issue.