### PR TITLE
New compiler: Fix bug in determining read-only expressions

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3678,7 +3678,7 @@ AGS::ErrorType AGS::Parser::AccessData(bool writing, SrcList &expression, ValueL
     expression.StartRead();
     if (0 == expression.Length())
     {
-        Error("!empty expression");
+        Error("!Empty expression");
         return kERR_InternalError;
     }
     

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3449,13 +3449,6 @@ AGS::ErrorType AGS::Parser::AccessData_Variable(ScopeType scope_type, bool writi
 
 AGS::ErrorType AGS::Parser::AccessData_FirstClause(bool writing, SrcList &expression, ValueLocation &vloc, ScopeType &return_scope_type,Parser::MemoryLocation &mloc, Vartype &vartype, bool &implied_this_dot, bool &static_access)
 {
-    if (expression.Length() < 1)
-    {
-        Error("!Empty first clause");
-        return kERR_InternalError;
-    }
-    expression.StartRead();
-
     implied_this_dot = false;
 
     Symbol const first_sym = expression.PeekNext();
@@ -3682,6 +3675,7 @@ AGS::ErrorType AGS::Parser::AccessData_IsClauseLast(SrcList &expression, bool &i
 // _not_ be called and symlist[0] will be the attribute.
 AGS::ErrorType AGS::Parser::AccessData(bool writing, SrcList &expression, ValueLocation &vloc, ScopeType &scope_type, Vartype &vartype)
 {
+    expression.StartRead();
     if (0 == expression.Length())
     {
         Error("!empty expression");

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -967,6 +967,28 @@ TEST_F(Compile1, AutoptrDisplay) {
     ASSERT_EQ(std::string::npos, msg.find("'String '"));
 }
 
+TEST_F(Compile1, ReadonlyObjectWritableAttribute)
+{
+    // player is readonly, but player.InventoryQuantity[...] can be written to.
+
+    char *inpl = "\
+        builtin managed struct Character                \n\
+        {                                               \n\
+            import attribute int InventoryQuantity[];   \n\
+        };                                              \n\
+                                                        \n\
+        import readonly Character *player;              \n\
+                                                        \n\
+        void main()                                     \n\
+        {                                               \n\
+            player.InventoryQuantity[15] = 0;           \n\
+        }                                               \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}
+
 TEST_F(Compile1, ImportAutoptr1) {
 
     // Import decls of funcs with autopointered returns must be processed correctly.


### PR DESCRIPTION
Typical expression: `player.InventoryQuantity[15] = 0;`
In this expression, player is read-only. But a value may be assigned to the term `player.InventoryQuantity[15]` because the value that `player` points to is _not_ readonly.

The cause of the bug turned out to be in a piece of code that determines whether a sub-expression is the last sub-expression of the expression. This calculation didn't start at the start of the sub-expression, as it should have, but at some random other location. (Also, there was a redundant test on whether the expression is completely empty which I deleted. Also, fixed a typo.)