### PR TITLE
New compiler: Comparing String to 'null' yields a runtime error.

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3552,7 +3552,7 @@ AGS::ErrorType AGS::Parser::AccessData_FirstClause(bool writing, SrcList &expres
         // If this unknown symbol can be interpreted as a component of 'this',
         // treat it that way.
         vartype = _sym.GetVartype(kKW_This);
-        if (_sym[vartype].VartypeD->Components.count(first_sym))
+        if (_sym.IsVartype(vartype) && _sym[vartype].VartypeD->Components.count(first_sym))
         {
             vloc = kVL_MAR_pointsto_value;
             WriteCmd(SCMD_REGTOREG, SREG_OP, SREG_MAR);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -546,7 +546,7 @@ private:
 
     // Change the generic opcode to the one that is correct for the vartypes
     // Also check whether the operator can handle the types at all
-    ErrorType GetOpcodeValidForVartype(Vartype vartype1, Vartype vartype2, CodeCell &opcode);
+    ErrorType GetOpcodeValidForVartype(Symbol op_sym, Vartype vartype1, Vartype vartype2, CodeCell &opcode);
 
     // Check for a type mismatch in one direction only
     bool IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_wants_to_be) const;

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2122,18 +2122,18 @@ TEST_F(Bytecode1, CompareStringToNull) {
     int compileResult = cc_compile(input, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    WriteOutput("CompareStringToNull", scrip);
+    // WriteOutput("CompareStringToNull", scrip);
     size_t const codesize = 69;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    2,            0,   48,    3,   29,    // 7
-       3,    6,    3,    0,           30,    4,   66,    4,    // 15
+       3,    6,    3,    0,           30,    4,   16,    4,    // 15
        3,    3,    4,    3,           29,    3,    6,    2,    // 23
        0,   48,    3,   29,            3,    6,    3,    0,    // 31
-      30,    4,   65,    4,            3,    3,    4,    3,    // 39
+      30,    4,   15,    4,            3,    3,    4,    3,    // 39
       29,    3,    6,    3,            0,   29,    3,    6,    // 47
-       2,    0,   48,    3,           30,    4,   66,    4,    // 55
+       2,    0,   48,    3,           30,    4,   16,    4,    // 55
        3,    3,    4,    3,           29,    3,    2,    1,    // 63
       12,    6,    3,    0,            5,  -999
     };
@@ -2161,4 +2161,4 @@ TEST_F(Bytecode1, CompareStringToNull) {
 
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
-   }
+}

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2099,3 +2099,66 @@ TEST_F(Bytecode1, IncrementAttribute) {
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
+
+TEST_F(Bytecode1, CompareStringToNull) {
+
+    // If a String is compared to 'null', the pointer opcodes must be used,
+    // not the String opcodes.
+
+    char inpl[] = "\
+        String S;                           \n\
+        bool func()                         \n\
+        {                                   \n\
+            bool b1 = S != null;            \n\
+            bool b2 = S == null;            \n\
+            bool b3 = null != S;            \n\
+        }                                   \n\
+        ";
+    std::string input = "";
+    input += g_Input_Bool;
+    input += g_Input_String;
+    input += inpl;
+
+    int compileResult = cc_compile(input, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    WriteOutput("CompareStringToNull", scrip);
+    size_t const codesize = 69;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    2,            0,   48,    3,   29,    // 7
+       3,    6,    3,    0,           30,    4,   66,    4,    // 15
+       3,    3,    4,    3,           29,    3,    6,    2,    // 23
+       0,   48,    3,   29,            3,    6,    3,    0,    // 31
+      30,    4,   65,    4,            3,    3,    4,    3,    // 39
+      29,    3,    6,    3,            0,   29,    3,    6,    // 47
+       2,    0,   48,    3,           30,    4,   66,    4,    // 55
+       3,    3,    4,    3,           29,    3,    2,    1,    // 63
+      12,    6,    3,    0,            5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 3;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+       4,   24,   49,  -999
+    };
+    char fixuptypes[] = {
+      1,   1,   1,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+   }

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -135,7 +135,7 @@ TEST_F(Compile1, FloatInt1) {
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("ype mismatch"));
+    EXPECT_NE(std::string::npos, msg.find("'/'"));
 }
 
 TEST_F(Compile1, FloatInt2) {
@@ -169,7 +169,7 @@ TEST_F(Compile1, StringInt1) {
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("ype mismatch"));
+    EXPECT_NE(std::string::npos, msg.find("compare"));
 }
 
 TEST_F(Compile1, ExpressionVoid) {  


### PR DESCRIPTION
Typical code: 
```
String s;
if (s != null)
    Display("Message: %s", s);
```
Cause of bug: The new compiler generated a String comparison opcode. This should have been a regular (non-String) comparison opcode because a String comparison will yield an error unless _both_ operands are non-null Strings. 

Additionally, in the specific local area that I had to fix there were some unspecific error messages. In particular, they talked about “the” operator, which doesn't really help the coder if a complex expression with _many_ operators is involved. I rewrote those messages to name the specific operator.  This entailed getting this information to the place of the error messages. This also entailed slightly changing some googletests that had expected the unspecific error messages before.