### PR TITLE
AGS 4: extended meta format for main game data

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -492,7 +492,12 @@ HGameFileError ReadSpriteFlags(LoadedGameEntities &ents, Stream *in, GameDataVer
 
 static HGameFileError ReadExtBlock(LoadedGameEntities &ents, Stream *in, const String &ext_id, soff_t block_len, GameDataVersion data_ver)
 {
-    return HGameFileError::None();
+    // Add extensions here checking ext_id, which is an up to 16-chars name, for example:
+    // if (ext_id.CompareNoCase("GUI_NEWPROPS") == 0)
+    // {
+    //     // read new gui properties
+    // }
+    return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));
 }
 
 HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersion data_ver)

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -62,7 +62,10 @@ enum MainGameFileErrorType
     kMGFErr_CreateScriptModuleFailed,
     kMGFErr_GameEntityFailed,
     kMGFErr_PluginDataFmtNotSupported,
-    kMGFErr_PluginDataSizeTooLarge
+    kMGFErr_PluginDataSizeTooLarge,
+    kMGFErr_ExtUnexpectedEOF,
+    kMGFErr_ExtUnknown,
+    kMGFErr_ExtBlockDataOverlapping
 };
 
 String GetMainGameFileErrorText(MainGameFileErrorType err);

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -122,6 +122,23 @@ enum RoomFileBlock
     kRoomFile_EOF               = 0xFF
 };
 
+String GetRoomBlockName(RoomFileBlock id)
+{
+    switch (id)
+    {
+    case kRoomFblk_Main: return "Main";
+    case kRoomFblk_Script: return "TextScript";
+    case kRoomFblk_CompScript: return "CompScript";
+    case kRoomFblk_CompScript2: return "CompScript2";
+    case kRoomFblk_ObjectNames: return "ObjNames";
+    case kRoomFblk_AnimBg: return "AnimBg";
+    case kRoomFblk_CompScript3: return "CompScript3";
+    case kRoomFblk_Properties: return "Properties";
+    case kRoomFblk_ObjectScNames: return "ObjScNames";
+    }
+    return "unknown";
+}
+
 void ReadRoomObject(RoomObjectInfo &obj, Stream *in)
 {
     obj.Sprite = in->ReadInt16();
@@ -422,11 +439,9 @@ HRoomFileError ReadPropertiesBlock(RoomStruct *room, Stream *in, RoomFileVersion
     return HRoomFileError::None();
 }
 
-HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, RoomFileVersion data_ver)
+HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const String &ext_id,
+    soff_t block_len, RoomFileVersion data_ver)
 {
-    soff_t block_len = data_ver < kRoomVersion_350 ? in->ReadInt32() : in->ReadInt64();
-    soff_t block_end = in->GetPosition() + block_len;
-
     HRoomFileError err;
     switch (block)
     {
@@ -459,46 +474,77 @@ HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, 
         return new RoomFileError(kRoomFileErr_UnknownBlockType,
             String::FromFormat("Type: %d, known range: %d - %d.", block, kRoomFblk_Main, kRoomFblk_ObjectScNames));
     }
+    return err;
+}
 
-    if (!err)
-        return err;
 
-    soff_t cur_pos = in->GetPosition();
-    if (cur_pos > block_end)
-    {
-        return new RoomFileError(kRoomFileErr_BlockDataOverlapping,
-            String::FromFormat("Type: %d, expected to end at offset: %u, finished reading at %u.", block, block_end, cur_pos));
+static HRoomFileError OpenNextBlock(Stream *in, RoomFileVersion data_ver, RoomFileBlock &block_id, String &ext_id, soff_t &block_len)
+{
+    // The block meta format is shared with the main game file extensions
+    //    - 1 byte - an old-style unsigned numeric ID:
+    //               where 0 would indicate following string ID,
+    //               and 0xFF indicates end of extension list.
+    //    - 16 bytes - string ID of an extension (if numeric ID is 0).
+    //    - 4 or 8 bytes - length of extension data, in bytes (size depends on format version).
+    int b = in->ReadByte();
+    if (b < 0)
+        return new RoomFileError(kRoomFileErr_UnexpectedEOF);
+    if (b == 0xFF)
+        return HRoomFileError::None(); // end of list
+    if (b > 0)
+    { // old-style block identified by a numeric id
+        block_id = (RoomFileBlock)b;
+        ext_id = GetRoomBlockName(block_id);
+        block_len = data_ver < kRoomVersion_350 ? in->ReadInt32() : in->ReadInt64();
     }
-    else if (cur_pos < block_end)
-    {
-        Debug::Printf(kDbgMsg_Warn, "WARNING: room data blocks nonsequential, block type %d expected to end at %u, finished reading at %u",
-            block, block_end, cur_pos);
-        in->Seek(block_end, Common::kSeekBegin);
+    else
+    { // new style block identified by a string id
+        block_id = kRoomFblk_None; // not important
+        ext_id = String::FromStreamCount(in, 16);
+        block_len = in->ReadInt64();
     }
     return HRoomFileError::None();
 }
-
 
 HRoomFileError ReadRoomData(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 {
     room->DataVersion = data_ver;
 
-    RoomFileBlock block;
-    do
+    // Read list of data blocks. The block meta format is shared with the main game file extensions now.
+    //    - 1 byte - old format block ID, 0xFF indicates end of list.
+    //    - 16 bytes - new string ID of an extension. \0 at the first byte indicates end of list.
+    //    - 4 or 8 bytes - length of extension data, in bytes (depends on format version).
+    while (true)
     {
         update_polled_stuff_if_runtime();
-        int b = in->ReadByte();
-        if (b < 0)
-            return new RoomFileError(kRoomFileErr_UnexpectedEOF);
-        block = (RoomFileBlock)b;
-        if (block != kRoomFile_EOF)
+        RoomFileBlock block_id;
+        String ext_id;
+        soff_t block_len;
+        HRoomFileError err = OpenNextBlock(in, data_ver, block_id, ext_id, block_len);
+        if (!err)
+            return err;
+        if (ext_id.IsEmpty())
+            break; // end of list
+
+        soff_t block_end = in->GetPosition() + block_len;
+        err = ReadRoomBlock(room, in, block_id, ext_id, block_len, data_ver);
+        if (!err)
+            return err;
+
+        soff_t cur_pos = in->GetPosition();
+        if (cur_pos > block_end)
         {
-            HRoomFileError err = ReadRoomBlock(room, in, block, data_ver);
-            if (!err)
-                return err;
+            return new RoomFileError(kRoomFileErr_BlockDataOverlapping,
+                String::FromFormat("Block: %s, expected to end at offset: %u, finished reading at %u.",
+                    ext_id.GetCStr(), block_end, cur_pos));
+        }
+        else if (cur_pos < block_end)
+        {
+            Debug::Printf(kDbgMsg_Warn, "WARNING: room data blocks nonsequential, block type %s expected to end at %u, finished reading at %u",
+                ext_id.GetCStr(), block_end, cur_pos);
+            in->Seek(block_end, Common::kSeekBegin);
         }
     }
-    while (block != kRoomFile_EOF);
     return HRoomFileError::None();
 }
 
@@ -558,11 +604,12 @@ HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion dat
     RoomFileBlock block;
     do
     {
-        int b = in->ReadByte();
-        if (b < 0)
-            return new RoomFileError(kRoomFileErr_UnexpectedEOF);
-        block = (RoomFileBlock)b;
-        soff_t block_len = data_ver < kRoomVersion_350 ? in->ReadInt32() : in->ReadInt64();
+        RoomFileBlock block_id;
+        String ext_id;
+        soff_t block_len;
+        HRoomFileError err = OpenNextBlock(in, data_ver, block_id, ext_id, block_len);
+        if (!err)
+            return err;
         if (block == kRoomFblk_Script)
         {
             char *buf = nullptr;

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -442,39 +442,44 @@ HRoomFileError ReadPropertiesBlock(RoomStruct *room, Stream *in, RoomFileVersion
 HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const String &ext_id,
     soff_t block_len, RoomFileVersion data_ver)
 {
-    HRoomFileError err;
+    //
+    // First check classic block types, identified with a numeric id
+    //
     switch (block)
     {
     case kRoomFblk_Main:
-        err = ReadMainBlock(room, in, data_ver);
-        break;
+        return ReadMainBlock(room, in, data_ver);
     case kRoomFblk_Script:
         in->Seek(block_len); // no longer read source script text into RoomStruct
-        break;
+        return HRoomFileError::None();
     case kRoomFblk_CompScript3:
-        err = ReadCompSc3Block(room, in, data_ver);
-        break;
+        return ReadCompSc3Block(room, in, data_ver);
     case kRoomFblk_ObjectNames:
-        err = ReadObjNamesBlock(room, in, data_ver);
-        break;
+        return ReadObjNamesBlock(room, in, data_ver);
     case kRoomFblk_ObjectScNames:
-        err = ReadObjScNamesBlock(room, in, data_ver);
-        break;
+        return ReadObjScNamesBlock(room, in, data_ver);
     case kRoomFblk_AnimBg:
-        err = ReadAnimBgBlock(room, in, data_ver);
-        break;
+        return ReadAnimBgBlock(room, in, data_ver);
     case kRoomFblk_Properties:
-        err = ReadPropertiesBlock(room, in, data_ver);
-        break;
+        return ReadPropertiesBlock(room, in, data_ver);
     case kRoomFblk_CompScript:
     case kRoomFblk_CompScript2:
         return new RoomFileError(kRoomFileErr_OldBlockNotSupported,
             String::FromFormat("Type: %d.", block));
+    case kRoomFblk_None:
+        break; // continue to string ids
     default:
         return new RoomFileError(kRoomFileErr_UnknownBlockType,
             String::FromFormat("Type: %d, known range: %d - %d.", block, kRoomFblk_Main, kRoomFblk_ObjectScNames));
     }
-    return err;
+
+    // Add extensions here checking ext_id, which is an up to 16-chars name, for example:
+    // if (ext_id.CompareNoCase("REGION_NEWPROPS") == 0)
+    // {
+    //     // read new region properties
+    // }
+    return new RoomFileError(kRoomFileErr_UnknownBlockType,
+        String::FromFormat("Type: %s", ext_id.GetCStr()));
 }
 
 
@@ -631,10 +636,12 @@ HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion dat
 // Type of function that writes single room block.
 typedef void(*PfnWriteBlock)(const RoomStruct *room, Stream *out);
 // Generic function that saves a block and automatically adds its size into header
-void WriteBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteBlock writer, Stream *out)
+void WriteBlock(const RoomStruct *room, RoomFileBlock block, const String &ext_id, PfnWriteBlock writer, Stream *out)
 {
     // Write block's header
     out->WriteByte(block);
+    if (block == kRoomFblk_None) // new-style string id
+        ext_id.WriteCount(out, 16);
     soff_t sz_at = out->GetPosition();
     out->WriteInt64(0); // block size placeholder
     // Call writer to save actual block contents
@@ -648,6 +655,18 @@ void WriteBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteBlock write
     out->WriteInt64(block_size);
     // ...and get back to the end of the file
     out->Seek(0, Common::kSeekEnd);
+}
+
+// Helper for new-style blocks with string id
+void WriteBlock(const RoomStruct *room, const String &ext_id, PfnWriteBlock writer, Stream *out)
+{
+    WriteBlock(room, kRoomFblk_None, ext_id, writer, out);
+}
+
+// Helper for old-style blocks with only numeric id
+void WriteBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteBlock writer, Stream *out)
+{
+    WriteBlock(room, block, String(), writer, out);
 }
 
 void WriteInteractionScripts(const InteractionScripts *interactions, Stream *out)


### PR DESCRIPTION
Resolves #828 (hopefully).

The idea is to enforce the rule that any new change or addition to the main game data should be appended as an extension to the end of the current format. So far we were just adding these changes in the midst of existing format randomly, which complicates format parsing for external tools, and imho just generally a bad thing for long term maintenance.

A support is added for reading and writing a list of "blocks" appended after the "classic" format. _The blocks meta format is shared with the one from room files_, trying to keep things consistent if possible. The only addition is the replacement of 1-byte numeric ID with a 16-chars long string ID. I am thinking of doing same ID change for room format, again for consistency and convenience.

The proposal is to keep this way of adding new data while we keep current "raw" binary format and until we implement something better (like compressed text format, or one of these contemporary serialization libs -- just giving random examples here without any implication).

---

Extension format description.

Each block starts with the following header:
- 1 byte - an old-style unsigned numeric ID:
    where 0 would indicate following string ID,
    and 0xFF indicates end of extension list.
- 16 bytes - string ID of an extension. An empty string (with \0 in the first byte) indicates end of extensions.
- 8 bytes - length of extension data, in bytes.

Then goes regular data.
Hence the total blocks size is (1 + 16 + 8 + data length) bytes.

After the block is read the stream position supposed to be at (start + 25 + length of data), where "start" is a first byte of the block header. If it's further - the function returns with error. If it's not far enough - the function logs a warning and skips remaining bytes.

Extensions are read until meeting empty ID string, which indicates end of extension list.
If end of file is found earlier that is considered an error.

