### PR TITLE
game data parser: bugfix for versions 2.6-2.7.1

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -324,11 +324,17 @@ HGameFileError GameSetupStruct::read_customprops(Common::Stream *in, GameDataVer
         for (int i = 0; i < numviews; ++i)
             viewNames[i] = String::FromStream(in);
 
-        for (int i = 0; i < numinvitems; ++i)
-            invScriptNames[i] = String::FromStream(in);
+        if (data_ver >= kGameVersion_270)
+        {
+            for (int i = 0; i < numinvitems; ++i)
+                invScriptNames[i] = String::FromStream(in);
 
-        for (int i = 0; i < numdialog; ++i)
-            dialogScriptNames[i] = String::FromStream(in);
+            if (data_ver >= kGameVersion_272)
+            {
+                for (int i = 0; i < numdialog; ++i)
+                    dialogScriptNames[i] = String::FromStream(in);
+            }
+        }
     }
     return HGameFileError::None();
 }


### PR DESCRIPTION
according to analysis of the game data files produced by ags versions
2.6.2, 2.7.0, 2.7.1 and 2.7.2, inventory item names were only added
as of 2.7.0, and dialog script names as of 2.7.2.
the old code used to read past the bounds of the original ac2game.dta
in those versions, effectively reading junk from whatever was stored
behind the data file in the "pack".

closes #1184