### PR TITLE
AGS 3: ensure to check special key combos prior to in-game keys

### DIFF
--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -296,7 +296,7 @@ static int get_active_shifts()
 
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.
-bool run_service_key_controls(int &kgn)
+bool run_service_key_controls(int &key_out)
 {
     // check keypresses
     static int old_key_shifts = 0; // for saving shift modes
@@ -359,8 +359,75 @@ bool run_service_key_controls(int &kgn)
         return false;
     }
 
+    // debug console
+    if ((keycode == '`') && (play.debug_mode > 0)) {
+        display_console = !display_console;
+        return false;
+    }
+
+    if ((keycode == eAGSKeyCodeCtrlE) && (display_fps == kFPS_Forced)) {
+        // if --fps paramter is used, Ctrl+E will max out frame rate
+        setTimerFps(isTimerFpsMaxed() ? frames_per_second : 1000);
+        return false;
+    }
+
+    if ((keycode == eAGSKeyCodeCtrlD) && (play.debug_mode > 0)) {
+        // ctrl+D - show info
+        char infobuf[900];
+        int ff;
+        // MACPORT FIX 9/6/5: added last %s
+        sprintf(infobuf, "In room %d %s[Player at %d, %d (view %d, loop %d, frame %d)%s%s%s",
+            displayed_room, (noWalkBehindsAtAll ? "(has no walk-behinds)" : ""), playerchar->x, playerchar->y,
+            playerchar->view + 1, playerchar->loop, playerchar->frame,
+            (IsGamePaused() == 0) ? "" : "[Game paused.",
+            (play.ground_level_areas_disabled == 0) ? "" : "[Ground areas disabled.",
+            (IsInterfaceEnabled() == 0) ? "[Game in Wait state" : "");
+        for (ff = 0; ff<croom->numobj; ff++) {
+            if (ff >= 8) break; // buffer not big enough for more than 7
+            sprintf(&infobuf[strlen(infobuf)],
+                "[Object %d: (%d,%d) size (%d x %d) on:%d moving:%s animating:%d slot:%d trnsp:%d clkble:%d",
+                ff, objs[ff].x, objs[ff].y,
+                (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Width : 0,
+                (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Height : 0,
+                objs[ff].on,
+                (objs[ff].moving > 0) ? "yes" : "no", objs[ff].cycling,
+                objs[ff].num, objs[ff].transparent,
+                ((objs[ff].flags & OBJF_NOINTERACT) != 0) ? 0 : 1);
+        }
+        Display(infobuf);
+        int chd = game.playercharacter;
+        char bigbuffer[STD_BUFFER_SIZE] = "CHARACTERS IN THIS ROOM:[";
+        for (ff = 0; ff < game.numcharacters; ff++) {
+            if (game.chars[ff].room != displayed_room) continue;
+            if (strlen(bigbuffer) > 430) {
+                strcat(bigbuffer, "and more...");
+                Display(bigbuffer);
+                strcpy(bigbuffer, "CHARACTERS IN THIS ROOM (cont'd):[");
+            }
+            chd = ff;
+            sprintf(&bigbuffer[strlen(bigbuffer)],
+                "%s (view/loop/frm:%d,%d,%d  x/y/z:%d,%d,%d  idleview:%d,time:%d,left:%d walk:%d anim:%d follow:%d flags:%X wait:%d zoom:%d)[",
+                game.chars[chd].scrname, game.chars[chd].view + 1, game.chars[chd].loop, game.chars[chd].frame,
+                game.chars[chd].x, game.chars[chd].y, game.chars[chd].z,
+                game.chars[chd].idleview, game.chars[chd].idletime, game.chars[chd].idleleft,
+                game.chars[chd].walking, game.chars[chd].animating, game.chars[chd].following,
+                game.chars[chd].flags, game.chars[chd].wait, charextra[chd].zoom);
+        }
+        Display(bigbuffer);
+        return false;
+    }
+
+    if ((keycode == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) && (play.wait_counter < 1) && (is_text_overlay == 0) && (restrict_until == 0)) {
+        // make sure we can't interrupt a Wait()
+        // and desync the music to cutscene
+        play.debug_mode++;
+        script_debug(1, 0);
+        play.debug_mode--;
+        return false;
+    }
+
     // No service operation triggered? return active keypress and shifts to caller
-    kgn = keycode;
+    key_out = keycode;
     return true;
 }
 
@@ -399,12 +466,6 @@ static void check_keyboard_controls()
         return;
     }
 
-    // debug console
-    if ((kgn == '`') && (play.debug_mode > 0)) {
-        display_console = !display_console;
-        return;
-    }
-
     // skip speech if desired by Speech.SkipStyle
     if ((is_text_overlay > 0) && (play.cant_skip_speech & SKIP_KEYPRESS)) {
         // only allow a key to remove the overlay if the icon bar isn't up
@@ -422,76 +483,6 @@ static void check_keyboard_controls()
     if ((play.wait_counter > 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
         play.wait_counter = -1;
         debug_script_log("Keypress code %d ignored - in Wait", kgn);
-        return;
-    }
-
-    if ((kgn == eAGSKeyCodeCtrlE) && (display_fps == kFPS_Forced)) {
-        // if --fps paramter is used, Ctrl+E will max out frame rate
-        setTimerFps( isTimerFpsMaxed() ? frames_per_second : 1000 );
-        return;
-    }
-
-    if ((kgn == eAGSKeyCodeCtrlD) && (play.debug_mode > 0)) {
-        // ctrl+D - show info
-        char infobuf[900];
-        int ff;
-        // MACPORT FIX 9/6/5: added last %s
-        sprintf(infobuf,"In room %d %s[Player at %d, %d (view %d, loop %d, frame %d)%s%s%s",
-            displayed_room, (noWalkBehindsAtAll ? "(has no walk-behinds)" : ""), playerchar->x,playerchar->y,
-            playerchar->view + 1, playerchar->loop,playerchar->frame,
-            (IsGamePaused() == 0) ? "" : "[Game paused.",
-            (play.ground_level_areas_disabled == 0) ? "" : "[Ground areas disabled.",
-            (IsInterfaceEnabled() == 0) ? "[Game in Wait state" : "");
-        for (ff=0;ff<croom->numobj;ff++) {
-            if (ff >= 8) break; // buffer not big enough for more than 7
-            sprintf(&infobuf[strlen(infobuf)],
-                "[Object %d: (%d,%d) size (%d x %d) on:%d moving:%s animating:%d slot:%d trnsp:%d clkble:%d",
-                ff, objs[ff].x, objs[ff].y,
-                (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Width : 0,
-                (spriteset[objs[ff].num] != nullptr) ? game.SpriteInfos[objs[ff].num].Height : 0,
-                objs[ff].on,
-                (objs[ff].moving > 0) ? "yes" : "no", objs[ff].cycling,
-                objs[ff].num, objs[ff].transparent,
-                ((objs[ff].flags & OBJF_NOINTERACT) != 0) ? 0 : 1 );
-        }
-        Display(infobuf);
-        int chd = game.playercharacter;
-        char bigbuffer[STD_BUFFER_SIZE] = "CHARACTERS IN THIS ROOM:[";
-        for (ff = 0; ff < game.numcharacters; ff++) {
-            if (game.chars[ff].room != displayed_room) continue;
-            if (strlen(bigbuffer) > 430) {
-                strcat(bigbuffer, "and more...");
-                Display(bigbuffer);
-                strcpy(bigbuffer, "CHARACTERS IN THIS ROOM (cont'd):[");
-            }
-            chd = ff;
-            sprintf(&bigbuffer[strlen(bigbuffer)], 
-                "%s (view/loop/frm:%d,%d,%d  x/y/z:%d,%d,%d  idleview:%d,time:%d,left:%d walk:%d anim:%d follow:%d flags:%X wait:%d zoom:%d)[",
-                game.chars[chd].scrname, game.chars[chd].view+1, game.chars[chd].loop, game.chars[chd].frame,
-                game.chars[chd].x, game.chars[chd].y, game.chars[chd].z,
-                game.chars[chd].idleview, game.chars[chd].idletime, game.chars[chd].idleleft,
-                game.chars[chd].walking, game.chars[chd].animating, game.chars[chd].following,
-                game.chars[chd].flags, game.chars[chd].wait, charextra[chd].zoom);
-        }
-        Display(bigbuffer);
-
-        return;
-    }
-
-    // if (kgn == key_ctrl_u) {
-    //     play.debug_mode++;
-    //     script_debug(5,0);
-    //     play.debug_mode--;
-    //     return;
-    // }
-
-    if ((kgn == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) && (play.wait_counter < 1) && (is_text_overlay == 0) && (restrict_until == 0)) {
-        // make sure we can't interrupt a Wait()
-        // and desync the music to cutscene
-        play.debug_mode++;
-        script_debug (1,0);
-        play.debug_mode--;
-
         return;
     }
 


### PR DESCRIPTION
Fixes #1176.

These are key combinations that are not part of the game itself, therefore they should be given a priority and checked regardless of current game state.