### PR TITLE
android dockerfile: bump ant to oldest version still available

### DIFF
--- a/ci/android/Dockerfile
+++ b/ci/android/Dockerfile
@@ -68,7 +68,7 @@ RUN curl -fLOJ "https://dl.google.com/android/repository/tools_r${BUILD_TOOLS_AN
   rm tools_r${BUILD_TOOLS_ANT_VERSION}-linux.zip
 
 # Get Ant
-ARG ANT_VERSION=1.10.7
+ARG ANT_VERSION=1.10.9
 RUN curl -fLSs "https://www.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz" | \
   tar -f - -xvzC /opt
 


### PR DESCRIPTION
ant 1.10.7 was removed from apache server.
if this PR results in a successful build, the now used ant version 1.10.9
should be archived ASAP and made available from another URL via a mirror.

addressing #1187