### PR TITLE
AGS4: BlendMode remake

### DIFF
--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -69,7 +69,7 @@ void CharacterInfo::ReadFromFile(Stream *in)
     on = in->ReadInt8();
 }
 
-void CharacterInfo::WriteToFile(Stream *out)
+void CharacterInfo::WriteToFile(Stream *out) const
 {
     out->WriteInt32(defview);
     out->WriteInt32(talkview);

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -109,7 +109,7 @@ struct CharacterInfo {
 	void update_character_follower(int &char_index, int &numSheep, int *followingAsSheep, int &doing_nothing);
 
     void ReadFromFile(Common::Stream *in);
-    void WriteToFile(Common::Stream *out);
+    void WriteToFile(Common::Stream *out) const;
 };
 
 

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -103,6 +103,7 @@ Option to allow legacy relative asset resolutions.
 
 60 :
 Fonts have adjustable outline
+BlendModes
 
 */
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -512,12 +512,20 @@ static HGameFileError ReadExtBlock(LoadedGameEntities &ents, Stream *in, const S
         for (size_t i = 0; i < (size_t)ents.Game.numcharacters; ++i)
         {
             ents.CharEx[i].BlendMode = (BlendMode)in->ReadInt32();
+            // Reserved for colour options
+            in->Seek(sizeof(int32_t) * 3); // flags + tint rgbs + light level
+            // Reserved for transform options (see brief list in savegame format)
+            in->Seek(sizeof(int32_t) * 11);
         }
 
         // new gui properties
         for (size_t i = 0; i < guis.size(); ++i)
         {
             guis[i].BlendMode = (BlendMode)in->ReadInt32();
+            // Reserved for colour options
+            in->Seek(sizeof(int32_t) * 3); // flags + tint rgbs + light level
+            // Reserved for transform options (see list in savegame format)
+            in->Seek(sizeof(int32_t) * 11);
         }
 
         return HGameFileError::None();

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -501,12 +501,25 @@ static HGameFileError ReadExtBlock(LoadedGameEntities &ents, Stream *in, const S
     if (ext_id.CompareNoCase("ext_ags399") == 0)
     {
         // adjustable font outlines
-        for (int i = 0; i < ents.Game.numfonts; ++i)
+        for (size_t i = 0; i < (size_t)ents.Game.numfonts; ++i)
         {
             ents.Game.fonts[i].AutoOutlineThickness = in->ReadInt32();
             ents.Game.fonts[i].AutoOutlineStyle =
                 static_cast<enum FontInfo::AutoOutlineStyle>(in->ReadInt32());
         }
+
+        // new character properties
+        for (size_t i = 0; i < (size_t)ents.Game.numcharacters; ++i)
+        {
+            ents.CharEx[i].BlendMode = (BlendMode)in->ReadInt32();
+        }
+
+        // new gui properties
+        for (size_t i = 0; i < guis.size(); ++i)
+        {
+            guis[i].BlendMode = (BlendMode)in->ReadInt32();
+        }
+
         return HGameFileError::None();
     }
     return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));
@@ -581,6 +594,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
     if (data_ver <= kGameVersion_350)
         return HGameFileError::None();
 
+    ents.CharEx.resize(game.numcharacters);
     //-------------------------------------------------------------------------
     // All the extended data, for AGS > 3.5.0.
     //-------------------------------------------------------------------------

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include "ac/game_version.h"
 #include "game/plugininfo.h"
+#include "gfx/gfx_def.h"
 #include "script/cc_script.h"
 #include "util/error.h"
 #include "util/stream.h"
@@ -98,6 +99,15 @@ struct MainGameSource
     MainGameSource();
 };
 
+// Struct contains an extended data loaded for chars.
+// At the runtime it goes into CharacterExtras struct, which is currently
+// not exposed. This may be fixed by future refactoring, such as merging
+// CharacterExtras with CharacterInfo structs.
+struct CharDataEx
+{
+    Common::BlendMode BlendMode = kBlend_Normal;
+};
+
 // LoadedGameEntities is meant for keeping objects loaded from the game file.
 // Because copying/assignment methods are not properly implemented for some
 // of these objects yet, they have to be attached using references to be read
@@ -106,6 +116,7 @@ struct MainGameSource
 struct LoadedGameEntities
 {
     GameSetupStruct        &Game;
+    std::vector<CharDataEx> CharEx;
     DialogTopic           *&Dialogs;
     ViewStruct            *&Views;
     PScript                 GlobalScript;

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -446,6 +446,10 @@ HRoomFileError ReadExt399(RoomStruct *room, Stream *in, RoomFileVersion data_ver
     for (size_t i = 0; i < room->ObjectCount; ++i)
     {
         room->Objects[i].BlendMode = (BlendMode)in->ReadInt32();
+        // Reserved for colour options
+        in->Seek(sizeof(int32_t) * 4); // flags, transparency, tint rbgs, light level
+        // Reserved for transform options (see list in savegame format)
+        in->Seek(sizeof(int32_t) * 11);
     }
 
     return HRoomFileError::None();
@@ -849,6 +853,10 @@ void WriteExt399(const RoomStruct *room, Stream *out)
     for (size_t i = 0; i < room->ObjectCount; i++)
     {
         out->WriteInt32(room->Objects[i].BlendMode);
+        // Reserved for colour options
+        out->WriteByteCount(0, sizeof(int32_t) * 4); // flags, transparency, tint rgbs, light level
+        // Reserved for transform options (see list in savegame format)
+        out->WriteByteCount(0, sizeof(int32_t) * 11);
     }
 }
 

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -439,6 +439,18 @@ HRoomFileError ReadPropertiesBlock(RoomStruct *room, Stream *in, RoomFileVersion
     return HRoomFileError::None();
 }
 
+// Early development version of "ags4"
+HRoomFileError ReadExt399(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
+{
+    // New room object properties
+    for (size_t i = 0; i < room->ObjectCount; ++i)
+    {
+        room->Objects[i].BlendMode = (BlendMode)in->ReadInt32();
+    }
+
+    return HRoomFileError::None();
+}
+
 HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, const String &ext_id,
     soff_t block_len, RoomFileVersion data_ver)
 {
@@ -478,6 +490,13 @@ HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, 
     // {
     //     // read new region properties
     // }
+
+    // Early development version of "ags4"
+    if (ext_id.CompareNoCase("ext_ags399") == 0)
+    {
+        return ReadExt399(room, in, data_ver);
+    }
+
     return new RoomFileError(kRoomFileErr_UnknownBlockType,
         String::FromFormat("Type: %s", ext_id.GetCStr()));
 }
@@ -824,6 +843,15 @@ void WritePropertiesBlock(const RoomStruct *room, Stream *out)
         Properties::WriteValues(room->Objects[i].Properties, out);
 }
 
+void WriteExt399(const RoomStruct *room, Stream *out)
+{
+    // New object properties
+    for (size_t i = 0; i < room->ObjectCount; i++)
+    {
+        out->WriteInt32(room->Objects[i].BlendMode);
+    }
+}
+
 HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersion data_ver)
 {
     if (data_ver < kRoomVersion_Current)
@@ -847,6 +875,9 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
         WriteBlock(room, kRoomFblk_AnimBg, WriteAnimBgBlock, out);
     // Custom properties
     WriteBlock(room, kRoomFblk_Properties, WritePropertiesBlock, out);
+
+    // Early development version of "ags4"
+    WriteBlock(room, "ext_ags399", WriteExt399, out);
 
     // Write end of room file
     out->WriteByte(kRoomFile_EOF);

--- a/Common/game/room_version.h
+++ b/Common/game/room_version.h
@@ -46,6 +46,7 @@
 31:  v3.4.1.5 - removed room object and hotspot name length limits
 32:  v3.5.0 - 64-bit file offsets
 33:  v3.5.0.8 - deprecated room resolution, added mask resolution
+40:  v3.9.9 - room object blend modes
 */
 enum RoomFileVersion
 {
@@ -80,7 +81,8 @@ enum RoomFileVersion
     kRoomVersion_3415 = 31,
     kRoomVersion_350 = 32,
     kRoomVersion_3508 = 33,
-    kRoomVersion_Current = kRoomVersion_3508
+    kRoomVersion_399 = 40,
+    kRoomVersion_Current = kRoomVersion_399
 };
 
 #endif // __AGS_CN_AC__ROOMVERSION_H

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -61,6 +61,7 @@ RoomObjectInfo::RoomObjectInfo()
     , IsOn(false)
     , Baseline(0xFF)
     , Flags(0)
+    , BlendMode(kBlend_Normal)
 {
 }
 

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -40,6 +40,7 @@
 #include <memory>
 #include "ac/common_defines.h"
 #include "game/interactions.h"
+#include "gfx/gfx_def.h"
 #include "util/geometry.h"
 #include "util/string_types.h"
 #include "util/wgt2allg.h" // color (allegro RGB)
@@ -171,6 +172,7 @@ struct RoomObjectInfo
     int32_t         X;
     int32_t         Y;
     int32_t         Sprite;
+    Common::BlendMode BlendMode;
     bool            IsOn;
     // Object's z-order in the room, or -1 (use Y)
     int32_t         Baseline;

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -26,16 +26,16 @@ namespace Common
 // Blend modes for object sprites
 enum BlendMode
 {
-    kBlendMode_Normal,        // alpha-blend src to dest, combining src & dest alphas
-    kBlendMode_Add,
-    kBlendMode_Darken,
-    kBlendMode_Lighten,
-    kBlendMode_Multiply,
-    kBlendMode_Screen,
-    kBlendMode_Burn,
-    kBlendMode_Subtract,
-    kBlendMode_Exclusion,
-    kBlendMode_Dodge,
+    kBlend_Normal,        // alpha-blend src to dest, combining src & dest alphas
+    kBlend_Add,
+    kBlend_Darken,
+    kBlend_Lighten,
+    kBlend_Multiply,
+    kBlend_Screen,
+    kBlend_Burn,
+    kBlend_Subtract,
+    kBlend_Exclusion,
+    kBlend_Dodge,
     kNumBlendModes
 };
 

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -23,11 +23,10 @@ namespace AGS
 namespace Common
 {
 
+// Blend modes for object sprites
 enum BlendMode
 {
-    // free blending (ARGB -> ARGB) modes
-    kBlendMode_NoAlpha        = 0, // ignore alpha channel
-    kBlendMode_Alpha,              // alpha-blend src to dest, combining src & dest alphas
+    kBlendMode_Normal,        // alpha-blend src to dest, combining src & dest alphas
     // NOTE: add new modes here
 
     kNumBlendModes

--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -27,8 +27,15 @@ namespace Common
 enum BlendMode
 {
     kBlendMode_Normal,        // alpha-blend src to dest, combining src & dest alphas
-    // NOTE: add new modes here
-
+    kBlendMode_Add,
+    kBlendMode_Darken,
+    kBlendMode_Lighten,
+    kBlendMode_Multiply,
+    kBlendMode_Screen,
+    kBlendMode_Burn,
+    kBlendMode_Subtract,
+    kBlendMode_Exclusion,
+    kBlendMode_Dodge,
     kNumBlendModes
 };
 

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -45,6 +45,7 @@
 // 3.5.0      (119): Game data contains GUI properties that previously
 //                   could be set only at runtime.
 //
+// 3.9.9      (130): Blend modes.
 //=============================================================================
 
 enum GuiVersion
@@ -72,7 +73,8 @@ enum GuiVersion
     kGuiVersion_331         = 117,
     kGuiVersion_340         = 118,
     kGuiVersion_350         = 119,
-    kGuiVersion_Current     = kGuiVersion_350,
+    kGuiVersion_399         = 130,
+    kGuiVersion_Current     = kGuiVersion_399,
 };
 
 namespace AGS
@@ -174,7 +176,8 @@ enum GUITextBoxFlags
 enum GuiSvgVersion
 {
     kGuiSvgVersion_Initial  = 0,
-    kGuiSvgVersion_350      = 1
+    kGuiSvgVersion_350      = 1,
+    kGuiSvgVersion_399      = 10
 };
 
 } // namespace Common

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -45,6 +45,8 @@ GUIMain::GUIMain()
     InitDefaults();
 }
 
+// TODO: remove and use constructor instead,
+// assign constructor result to object when want to clean it up (gui = GUIMain();)
 void GUIMain::InitDefaults()
 {
     ID            = 0;

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -71,6 +71,8 @@ void GUIMain::InitDefaults()
     MouseWasAt.X  = -1;
     MouseWasAt.Y  = -1;
 
+    BlendMode     = 0;
+
     OnClickHandler.Empty();
 
     _controls.clear();
@@ -626,6 +628,11 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version)
     MouseDownCtrl = in->ReadInt32();
     MouseWasAt.X = in->ReadInt32();
     MouseWasAt.Y = in->ReadInt32();
+
+    if (svg_version >= kGuiSvgVersion_399)
+    {
+        BlendMode = in->ReadInt32();
+    }
 }
 
 void GUIMain::WriteToSavegame(Common::Stream *out) const
@@ -650,6 +657,8 @@ void GUIMain::WriteToSavegame(Common::Stream *out) const
     out->WriteInt32(MouseDownCtrl);
     out->WriteInt32(MouseWasAt.X);
     out->WriteInt32(MouseWasAt.Y);
+    // since version 10 (kGuiSvgVersion_399)
+    out->WriteInt32(BlendMode);
 }
 
 

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -73,7 +73,7 @@ void GUIMain::InitDefaults()
     MouseWasAt.X  = -1;
     MouseWasAt.Y  = -1;
 
-    BlendMode     = 0;
+    BlendMode     = kBlend_Normal;
 
     OnClickHandler.Empty();
 
@@ -633,7 +633,7 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version)
 
     if (svg_version >= kGuiSvgVersion_399)
     {
-        BlendMode = in->ReadInt32();
+        BlendMode = (Common::BlendMode)in->ReadInt32();
     }
 }
 

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -634,6 +634,23 @@ void GUIMain::ReadFromSavegame(Common::Stream *in, GuiSvgVersion svg_version)
     if (svg_version >= kGuiSvgVersion_399)
     {
         BlendMode = (Common::BlendMode)in->ReadInt32();
+
+        // Reserved for colour options
+        in->ReadInt32(); // colour flags
+        in->ReadInt32(); // tint rgb + s
+        in->ReadInt32(); // tint light (or light level)
+        // Reserved for transform options
+        in->ReadInt32(); // sprite transform flags1
+        in->ReadInt32(); // sprite transform flags2
+        in->ReadInt32(); // transform scale x
+        in->ReadInt32(); // transform scale y
+        in->ReadInt32(); // transform skew x
+        in->ReadInt32(); // transform skew y
+        in->ReadInt32(); // transform rotate
+        in->ReadInt32(); // sprite pivot x
+        in->ReadInt32(); // sprite pivot y
+        in->ReadInt32(); // sprite anchor x
+        in->ReadInt32(); // sprite anchor y
     }
 }
 
@@ -661,6 +678,22 @@ void GUIMain::WriteToSavegame(Common::Stream *out) const
     out->WriteInt32(MouseWasAt.Y);
     // since version 10 (kGuiSvgVersion_399)
     out->WriteInt32(BlendMode);
+    // Reserved for colour options
+    out->WriteInt32(0); // colour flags
+    out->WriteInt32(0); // tint rgb + s
+    out->WriteInt32(0); // tint light (or light level)
+    // Reserved for transform options
+    out->WriteInt32(0); // sprite transform flags1
+    out->WriteInt32(0); // sprite transform flags2
+    out->WriteInt32(0); // transform scale x
+    out->WriteInt32(0); // transform scale y
+    out->WriteInt32(0); // transform skew x
+    out->WriteInt32(0); // transform skew y
+    out->WriteInt32(0); // transform rotate
+    out->WriteInt32(0); // sprite pivot x
+    out->WriteInt32(0); // sprite pivot y
+    out->WriteInt32(0); // sprite anchor x
+    out->WriteInt32(0); // sprite anchor y
 }
 
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -218,7 +218,7 @@ extern bool is_sprite_alpha(int spr);
 
 // This function has distinct implementations in Engine and Editor
 extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y, bool use_alpha = true,
-                            Common::BlendMode blend_mode = Common::kBlendMode_Alpha);
+                            Common::BlendMode blend_mode = Common::kBlendMode_Normal);
 
 // Those function have distinct implementations in Engine and Editor
 extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -168,6 +168,8 @@ public:
 
     String  OnClickHandler; // script function name
 
+    int32_t BlendMode;
+
 private:
     int32_t _flags;          // style and behavior flags
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -158,6 +158,7 @@ public:
     GUIPopupStyle PopupStyle; // GUI popup behavior
     int32_t PopupAtMouseY;  // popup when mousey < this
     int32_t Transparency;   // "incorrect" alpha (in legacy 255-range units)
+    Common::BlendMode BlendMode; // render blend mode
     int32_t ZOrder;
 
     int32_t FocusCtrl;      // which control has the focus
@@ -167,8 +168,6 @@ public:
     Point   MouseWasAt;     // last mouse cursor position
 
     String  OnClickHandler; // script function name
-
-    int32_t BlendMode;
 
 private:
     int32_t _flags;          // style and behavior flags
@@ -218,7 +217,7 @@ extern bool is_sprite_alpha(int spr);
 
 // This function has distinct implementations in Engine and Editor
 extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y, bool use_alpha = true,
-                            Common::BlendMode blend_mode = Common::kBlendMode_Normal);
+                            Common::BlendMode blend_mode = Common::kBlend_Normal);
 
 // Those function have distinct implementations in Engine and Editor
 extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1728,10 +1728,22 @@ namespace AGS.Editor
         private static void WriteExt_Ags399(BinaryWriter writer, Game game, CompileMessages errors)
         {
             // adjustable font outlines
-            for (int i = 0; i < game.Fonts.Count; ++i)
+            foreach (var font in game.Fonts)
             {
-                writer.Write(game.Fonts[i].AutoOutlineThickness);
-                writer.Write((int)game.Fonts[i].AutoOutlineStyle);
+                writer.Write(font.AutoOutlineThickness);
+                writer.Write((int)font.AutoOutlineStyle);
+            }
+
+            // new character properties
+            foreach (var ch in game.Characters)
+            {
+                writer.Write((int)ch.BlendMode);
+            }
+
+            // new gui properties
+            foreach (var gui in game.GUIs)
+            {
+                writer.Write((int)gui.BlendMode);
             }
         }
 

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1738,12 +1738,20 @@ namespace AGS.Editor
             foreach (var ch in game.Characters)
             {
                 writer.Write((int)ch.BlendMode);
+                // Reserved for colour options
+                writer.Write(new byte[3 * 4]); // flags + tint rgbs + light level
+                // Reserved for transform options (see brief list in the engine)
+                writer.Write(new byte[11 * 4]);
             }
 
             // new gui properties
             foreach (var gui in game.GUIs)
             {
                 writer.Write((int)gui.BlendMode);
+                // Reserved for colour options
+                writer.Write(new byte[3 * 4]); // flags + tint rgbs + light level
+                // Reserved for transform options (see brief list in the engine)
+                writer.Write(new byte[11 * 4]);
             }
         }
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -919,6 +919,10 @@ builtin managed struct Overlay {
   import attribute int X;
   /// Gets/sets the Y position on the screen where this overlay is displayed.
   import attribute int Y;
+#ifdef SCRIPT_API_v399
+  /// Gets/sets the blending mode of this overlay.
+  import attribute int BlendMode;
+#endif
 };
 
 builtin managed struct DynamicSprite {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -556,6 +556,9 @@ builtin managed struct DrawingSurface {
   /// Draws a sprite onto the surface with its top-left corner at (x,y).
   import void DrawImage(int x, int y, int spriteSlot, int transparency=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
 						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
+  /// Blends a sprite onto the surface with its top-left corner at (x,y).
+  import void BlendImage(int x, int y, int spriteSlot, BlendMode mode, int transparency=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
+						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
 #endif
 #ifndef SCRIPT_API_v399
   /// Draws a sprite onto the surface with its top-left corner at (x,y).
@@ -583,6 +586,9 @@ builtin managed struct DrawingSurface {
   /// Draws the specified surface onto this surface.
   import void DrawSurface(DrawingSurface *surfaceToDraw, int transparency=0, int x=0, int y=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
 						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
+  /// Blends the specified surface onto this surface.
+  import void BlendSurface(DrawingSurface *surfaceToDraw, BlendMode mode, int transparency=0, int x=0, int y=0, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE,
+						int part_x=0, int part_y=0, int part_width=SCR_NO_VALUE, int part_height=SCR_NO_VALUE);
 #endif
 #ifndef SCRIPT_API_v399
   /// Draws the specified surface onto this surface.
@@ -598,8 +604,6 @@ builtin managed struct DrawingSurface {
   import attribute int DrawingColor;
   /// Gets the height of this surface.
   readonly import attribute int Height;
-#ifdef SCRIPT_COMPAT_v341
-#endif
   /// Gets the width of the surface.
   readonly import attribute int Width;
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1784,7 +1784,10 @@ builtin managed struct Object {
   /// Gets/sets the object's current scaling level.
   import attribute int  Scaling;
 #endif
-
+#ifdef SCRIPT_API_v399
+  /// Gets/sets the blending mode for this object.
+  import attribute int  BlendMode;
+#endif
   readonly int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -403,16 +403,16 @@ enum LogLevel
 
 #ifdef SCRIPT_API_v399
 enum BlendMode {
-    eBlendModeNormal = 0,
-    eBlendModeAdd,
-    eBlendModeDarken,
-    eBlendModeLighten,
-    eBlendModeMultiply,
-    eBlendModeScreen,
-    eBlendModeBurn,
-    eBlendModeSubtract,
-    eBlendModeExclusion,
-    eBlendModeDodge
+    eBlendNormal = 0,
+    eBlendAdd,
+    eBlendDarken,
+    eBlendLighten,
+    eBlendMultiply,
+    eBlendScreen,
+    eBlendBurn,
+    eBlendSubtract,
+    eBlendExclusion,
+    eBlendDodge
 };
 #endif
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2008,6 +2008,10 @@ builtin managed struct Character {
   import attribute int  y;
   /// The character's current Z-position.
   import attribute int  z;
+#ifdef SCRIPT_API_v399
+  /// Gets/sets the character's current blend mode.
+  import attribute int  BlendMode;
+#endif
   readonly int reserved_a[28];   // $AUTOCOMPLETEIGNORE$
   readonly short reserved_f[MAX_INV];  // $AUTOCOMPLETEIGNORE$
   readonly int   reserved_e;   // $AUTOCOMPLETEIGNORE$

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -401,6 +401,20 @@ enum LogLevel
 };
 #endif
 
+#ifdef SCRIPT_API_v399
+enum BlendMode {
+    eBlendModeNormal = 0,
+    eBlendModeAdd,
+    eBlendModeDarken,
+    eBlendModeLighten,
+    eBlendModeMultiply,
+    eBlendModeScreen,
+    eBlendModeBurn,
+    eBlendModeSubtract,
+    eBlendModeExclusion,
+    eBlendModeDodge
+};
+#endif
 
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
@@ -921,7 +935,7 @@ builtin managed struct Overlay {
   import attribute int Y;
 #ifdef SCRIPT_API_v399
   /// Gets/sets the blending mode of this overlay.
-  import attribute int BlendMode;
+  import attribute BlendMode BlendMode;
 #endif
 };
 
@@ -1351,7 +1365,7 @@ builtin managed struct GUI {
 #endif
 #ifdef SCRIPT_API_v399
   /// Gets/sets the blending mode for this GUI.
-  import attribute int  BlendMode;
+  import attribute BlendMode BlendMode;
 #endif
 };
 
@@ -1794,7 +1808,7 @@ builtin managed struct Object {
 #endif
 #ifdef SCRIPT_API_v399
   /// Gets/sets the blending mode for this object.
-  import attribute int  BlendMode;
+  import attribute BlendMode BlendMode;
 #endif
   readonly int reserved[2];  // $AUTOCOMPLETEIGNORE$
 };
@@ -2021,7 +2035,7 @@ builtin managed struct Character {
   import attribute int  z;
 #ifdef SCRIPT_API_v399
   /// Gets/sets the character's current blend mode.
-  import attribute int  BlendMode;
+  import attribute BlendMode BlendMode;
 #endif
   readonly int reserved_a[28];   // $AUTOCOMPLETEIGNORE$
   readonly short reserved_f[MAX_INV];  // $AUTOCOMPLETEIGNORE$

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1345,6 +1345,10 @@ builtin managed struct GUI {
   /// Gets/sets the Y co-ordinate at which the GUI will appear when using MouseYPos popup style.
   import attribute int  PopupYPos;
 #endif
+#ifdef SCRIPT_API_v399
+  /// Gets/sets the blending mode for this GUI.
+  import attribute int  BlendMode;
+#endif
 };
 
 #ifdef SCRIPT_API_v350

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3410,6 +3410,7 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
 		RoomObject ^obj = gcnew RoomObject(room);
 		obj->ID = i;
 		obj->Image = thisroom.Objects[i].Sprite;
+        obj->BlendMode = (BlendMode)thisroom.Objects[i].BlendMode;
 		obj->StartX = thisroom.Objects[i].X;
 		obj->StartY = thisroom.Objects[i].Y;
 		obj->Visible = (thisroom.Objects[i].IsOn != 0);
@@ -3549,6 +3550,7 @@ void save_crm_file(Room ^room)
 		thisroom.Objects[i].ScriptName = ConvertStringToNativeString(obj->Name);
 
 		thisroom.Objects[i].Sprite = obj->Image;
+        thisroom.Objects[i].BlendMode = (AGS::Common::BlendMode)obj->BlendMode;
 		thisroom.Objects[i].X = obj->StartX;
 		thisroom.Objects[i].Y = obj->StartY;
 		thisroom.Objects[i].IsOn = obj->Visible;

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -116,6 +116,7 @@
     <Compile Include="EditorFeatures\MenuCommands.cs" />
     <Compile Include="EditorFeatures\MessageBoxIconType.cs" />
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
+    <Compile Include="Enums\BlendMode.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />
     <Compile Include="Enums\CustomPropertyAppliesTo.cs" />

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -130,6 +130,16 @@ namespace AGS.Types
             set { _blinkingView = value; }
         }
 
+        [Description("The blend mode for the character")]
+        [Category("Appearance")]
+        [TypeConverter(typeof(EnumTypeConverter))]
+        [DefaultValue(BlendMode.Normal)]
+        public BlendMode BlendMode
+        {
+            get;
+            set;
+        }
+
         [Description("Room number that the character starts in")]
         [Category("Design")]
         [TypeConverter(typeof(RoomListTypeConverter))]

--- a/Editor/AGS.Types/Enums/BlendMode.cs
+++ b/Editor/AGS.Types/Enums/BlendMode.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public enum BlendMode
+    {
+        Normal = 0,
+        Add,
+        Darken,
+        Lighten,
+        Multiply,
+        Screen,
+        Burn,
+        Subtract,
+        Exclusion,
+        Dodge
+    }
+}

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -82,6 +82,16 @@ namespace AGS.Types
             set { _bgimage = value; }
         }
 
+        [Description("The blend mode for the GUI")]
+        [Category("Appearance")]
+        [TypeConverter(typeof(EnumTypeConverter))]
+        [DefaultValue(BlendMode.Normal)]
+        public BlendMode BlendMode
+        {
+            get;
+            set;
+        }
+
         [Description("The ID number of the GUI")]
         [Category("Design")]
         [ReadOnly(true)]

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -61,6 +61,16 @@ namespace AGS.Types
             set { _image = Math.Max(value, 0); }  // ignore negative values
         }
 
+        [Description("The blend mode for the object")]
+        [Category("Appearance")]
+        [TypeConverter(typeof(EnumTypeConverter))]
+        [DefaultValue(BlendMode.Normal)]
+        public BlendMode BlendMode
+        {
+            get;
+            set;
+        }
+
         [Description("Is the object initially visible?")]
         [Category("Design")]
         public bool Visible

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1564,6 +1564,8 @@ int Character_GetBlendMode(CharacterInfo *chaa) {
 }
 
 void Character_SetBlendMode(CharacterInfo *chaa, int blendMode) {
+    if ((blendMode < 0) || (blendMode >= kNumBlendModes))
+        quitprintf("!SetBlendMode: invalid blend mode %d, supported modes are %d - %d", blendMode, 0, kNumBlendModes - 1);
     charextra[chaa->index_id].blend_mode = (BlendMode)blendMode;
 }
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1564,7 +1564,7 @@ int Character_GetBlendMode(CharacterInfo *chaa) {
 }
 
 void Character_SetBlendMode(CharacterInfo *chaa, int blendMode) {
-    charextra[chaa->index_id].blend_mode = blendMode;
+    charextra[chaa->index_id].blend_mode = (BlendMode)blendMode;
 }
 
 int Character_GetTurnBeforeWalking(CharacterInfo *chaa) {

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1558,6 +1558,15 @@ void Character_SetTransparency(CharacterInfo *chaa, int trans) {
     chaa->transparency = GfxDef::Trans100ToLegacyTrans255(trans);
 }
 
+int Character_GetBlendMode(CharacterInfo *chaa) {
+
+    return charextra[chaa->index_id].blend_mode;
+}
+
+void Character_SetBlendMode(CharacterInfo *chaa, int blendMode) {
+    charextra[chaa->index_id].blend_mode = blendMode;
+}
+
 int Character_GetTurnBeforeWalking(CharacterInfo *chaa) {
 
     if (chaa->flags & CHF_NOTURNING)
@@ -3760,6 +3769,18 @@ RuntimeScriptValue Sc_Character_SetZ(void *self, const RuntimeScriptValue *param
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetZ);
 }
 
+// int (CharacterInfo *chaa)
+RuntimeScriptValue Sc_Character_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetBlendMode);
+}
+
+// void (CharacterInfo *chaa, int blend_mode)
+RuntimeScriptValue Sc_Character_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetBlendMode);
+}
+
 //=============================================================================
 //
 // Exclusive API for Plugins
@@ -3942,6 +3963,8 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     ccAddExternalObjectFunction("Character::get_TintRed",               Sc_Character_GetTintRed);
     ccAddExternalObjectFunction("Character::get_TintSaturation",        Sc_Character_GetTintSaturation);
     ccAddExternalObjectFunction("Character::get_TintLuminance",         Sc_Character_GetTintLuminance);
+    ccAddExternalObjectFunction("Character::get_BlendMode",             Sc_Character_GetBlendMode);
+    ccAddExternalObjectFunction("Character::set_BlendMode",             Sc_Character_SetBlendMode);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -154,6 +154,8 @@ void    Character_SetY(CharacterInfo *chaa, int newval);
 int     Character_GetZ(CharacterInfo *chaa);
 void    Character_SetZ(CharacterInfo *chaa, int newval);
 int     Character_GetSpeakingFrame(CharacterInfo *chaa);
+int     Character_GetBlendMode(CharacterInfo *chaa);
+void    Character_SetBlendMode(CharacterInfo *chaa, int blendMode);
 
 //=============================================================================
 

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -38,6 +38,10 @@ void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
     {
         blend_mode = in->ReadInt32();
     }
+    else
+    {
+        blend_mode = 0;
+    }
 }
 
 void CharacterExtras::WriteToFile(Stream *out)

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -17,7 +17,7 @@
 
 using AGS::Common::Stream;
 
-void CharacterExtras::ReadFromFile(Stream *in)
+void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
     in->ReadArrayOfInt16(invorder, MAX_INVORDER);
     invorder_count = in->ReadInt16();
@@ -34,6 +34,10 @@ void CharacterExtras::ReadFromFile(Stream *in)
     process_idle_this_time = in->ReadInt8();
     slow_move_counter = in->ReadInt8();
     animwait = in->ReadInt16();
+    if (cmp_ver >= 10)
+    {
+        blend_mode = in->ReadInt32();
+    }
 }
 
 void CharacterExtras::WriteToFile(Stream *out)
@@ -53,4 +57,6 @@ void CharacterExtras::WriteToFile(Stream *out)
     out->WriteInt8(process_idle_this_time);
     out->WriteInt8(slow_move_counter);
     out->WriteInt16(animwait);
+    // since version 10
+    out->WriteInt32(blend_mode);
 }

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -37,6 +37,20 @@ void CharacterExtras::ReadFromSavegame(Stream *in, int32_t cmp_ver)
     if (cmp_ver >= 10)
     {
         blend_mode = (BlendMode)in->ReadInt32();
+        // Reserved for colour options
+        in->ReadInt32(); // colour flags
+        // Reserved for transform options
+        in->ReadInt32(); // sprite transform flags1
+        in->ReadInt32(); // sprite transform flags2
+        in->ReadInt32(); // transform scale x
+        in->ReadInt32(); // transform scale y
+        in->ReadInt32(); // transform skew x
+        in->ReadInt32(); // transform skew y
+        in->ReadInt32(); // transform rotate
+        in->ReadInt32(); // sprite pivot x
+        in->ReadInt32(); // sprite pivot y
+        in->ReadInt32(); // sprite anchor x
+        in->ReadInt32(); // sprite anchor y
     }
     else
     {
@@ -63,4 +77,18 @@ void CharacterExtras::WriteToSavegame(Stream *out) const
     out->WriteInt16(animwait);
     // since version 10
     out->WriteInt32(blend_mode);
+    // Reserved for colour options
+    out->WriteInt32(0); // colour flags
+    // Reserved for transform options
+    out->WriteInt32(0); // sprite transform flags1
+    out->WriteInt32(0); // sprite transform flags2
+    out->WriteInt32(0); // transform scale x
+    out->WriteInt32(0); // transform scale y
+    out->WriteInt32(0); // transform skew x
+    out->WriteInt32(0); // transform skew y
+    out->WriteInt32(0); // transform rotate
+    out->WriteInt32(0); // sprite pivot x
+    out->WriteInt32(0); // sprite pivot y
+    out->WriteInt32(0); // sprite anchor x
+    out->WriteInt32(0); // sprite anchor y
 }

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -15,7 +15,7 @@
 #include "ac/characterextras.h"
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+using namespace AGS::Common;
 
 void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
@@ -36,11 +36,11 @@ void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
     animwait = in->ReadInt16();
     if (cmp_ver >= 10)
     {
-        blend_mode = in->ReadInt32();
+        blend_mode = (BlendMode)in->ReadInt32();
     }
     else
     {
-        blend_mode = 0;
+        blend_mode = kBlend_Normal;
     }
 }
 

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -17,7 +17,7 @@
 
 using namespace AGS::Common;
 
-void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
+void CharacterExtras::ReadFromSavegame(Stream *in, int32_t cmp_ver)
 {
     in->ReadArrayOfInt16(invorder, MAX_INVORDER);
     invorder_count = in->ReadInt16();
@@ -44,7 +44,7 @@ void CharacterExtras::ReadFromFile(Stream *in, int32_t cmp_ver)
     }
 }
 
-void CharacterExtras::WriteToFile(Stream *out)
+void CharacterExtras::WriteToSavegame(Stream *out) const
 {
     out->WriteArrayOfInt16(invorder, MAX_INVORDER);
     out->WriteInt16(invorder_count);

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -47,8 +47,8 @@ struct CharacterExtras {
     short animwait;
     Common::BlendMode blend_mode;
 
-    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
-    void WriteToFile(Common::Stream *out);
+    void ReadFromSavegame(Common::Stream *in, int32_t cmp_ver);
+    void WriteToSavegame(Common::Stream *out) const;
 };
 
 #endif // __AGS_EE_AC__CHARACTEREXTRAS_H

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__CHARACTEREXTRAS_H
 #define __AGS_EE_AC__CHARACTEREXTRAS_H
 
+#include "core/types.h"
 #include "ac/runtime_defines.h"
 
 // Forward declaration
@@ -43,8 +44,9 @@ struct CharacterExtras {
     char  process_idle_this_time;
     char  slow_move_counter;
     short animwait;
+    short blend_mode;
 
-    void ReadFromFile(Common::Stream *in);
+    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);
 };
 

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -20,6 +20,7 @@
 
 #include "core/types.h"
 #include "ac/runtime_defines.h"
+#include "gfx/gfx_def.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
@@ -44,7 +45,7 @@ struct CharacterExtras {
     char  process_idle_this_time;
     char  slow_move_counter;
     short animwait;
-    short blend_mode;
+    Common::BlendMode blend_mode;
 
     void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -164,7 +164,7 @@ struct SpriteListEntry
     bool takesPriorityIfEqual = false;
     // Mark for the render stage callback (if >= 0 other fields are ignored)
     int renderStage = -1;
-    int blendMode;
+    BlendMode blendMode = kBlend_Normal;
 };
 
 // Two lists of sprites to push into renderer during next render pass
@@ -770,7 +770,7 @@ static void clear_draw_list()
     thingsToDrawList.clear();
 }
 
-static void add_thing_to_draw(IDriverDependantBitmap* bmp, int x, int y, int trans, int blendMode = 0)
+static void add_thing_to_draw(IDriverDependantBitmap* bmp, int x, int y, int trans, BlendMode blendMode = kBlend_Normal)
 {
     SpriteListEntry sprite;
     sprite.bmp = bmp;
@@ -793,7 +793,8 @@ static void clear_sprite_list()
     sprlist.clear();
 }
 
-void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, bool isWalkBehind, int blendMode = 0)
+void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, bool isWalkBehind,
+    BlendMode blendMode = kBlend_Normal)
 {
     if (spp == nullptr)
         quit("add_to_sprite_list: attempted to draw NULL sprite");

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -164,6 +164,7 @@ struct SpriteListEntry
     bool takesPriorityIfEqual = false;
     // Mark for the render stage callback (if >= 0 other fields are ignored)
     int renderStage = -1;
+    int blendMode;
 };
 
 // Two lists of sprites to push into renderer during next render pass
@@ -791,7 +792,7 @@ static void clear_sprite_list()
     sprlist.clear();
 }
 
-static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, bool isWalkBehind)
+void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, bool isWalkBehind, int blendMode = 0)
 {
     if (spp == nullptr)
         quit("add_to_sprite_list: attempted to draw NULL sprite");
@@ -805,6 +806,7 @@ static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int 
     sprite.x = xx;
     sprite.y = yy;
     sprite.transparent = trans;
+    sprite.blendMode = blendMode;
 
     if (walkBehindMethod == DrawAsSeparateSprite)
         sprite.takesPriorityIfEqual = !isWalkBehind;
@@ -1877,7 +1879,7 @@ void prepare_characters_for_drawing() {
         chin->actx = atxp;
         chin->acty = atyp;
 
-        add_to_sprite_list(actspsbmp[useindx], bgX, bgY, usebasel, chin->transparency, false);
+        add_to_sprite_list(actspsbmp[useindx], bgX, bgY, usebasel, chin->transparency, false, charextra[chin->index_id].blend_mode);
     }
 }
 
@@ -2142,7 +2144,7 @@ void put_sprite_list_on_screen(bool in_room)
             {
                 thisThing->bmp->SetTransparency(thisThing->transparent);
             }
-
+            thisThing->bmp->SetBlendMode(thisThing->blendMode);
             gfxDriver->DrawSprite(thisThing->x, thisThing->y, thisThing->bmp);
         }
         else if (thisThing->renderStage >= 0)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2033,12 +2033,12 @@ void draw_gui_and_overlays()
     // draw overlays, except text boxes and portraits
     for (const auto &over : screenover) {
         // complete overlay draw in non-transparent mode
-        if (over.type == OVER_COMPLETE)
-            add_thing_to_draw(over.bmp, over.x, over.y, 0);
-        else if (over.type != OVER_TEXTMSG && over.type != OVER_PICTURE) {
+        if (over.type == OVER_COMPLETE) {
+            add_thing_to_draw(over.bmp, over.x, over.y, 0, over.blendMode);
+        } else if (over.type != OVER_TEXTMSG && over.type != OVER_PICTURE) {
             int tdxp, tdyp;
             get_overlay_position(over, &tdxp, &tdyp);
-            add_thing_to_draw(over.bmp, tdxp, tdyp, 0);
+            add_thing_to_draw(over.bmp, tdxp, tdyp, 0, over.blendMode);
         }
     }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -770,13 +770,14 @@ static void clear_draw_list()
     thingsToDrawList.clear();
 }
 
-static void add_thing_to_draw(IDriverDependantBitmap* bmp, int x, int y, int trans)
+static void add_thing_to_draw(IDriverDependantBitmap* bmp, int x, int y, int trans, int blendMode = 0)
 {
     SpriteListEntry sprite;
     sprite.bmp = bmp;
     sprite.x = x;
     sprite.y = y;
     sprite.transparent = trans;
+    sprite.blendMode = blendMode;
     thingsToDrawList.push_back(sprite);
 }
 
@@ -2098,7 +2099,7 @@ void draw_gui_and_overlays()
                 (guis[aa].PopupStyle != kGUIPopupNoAutoRemove))
                 continue;
 
-            add_thing_to_draw(guibgbmp[aa], guis[aa].X, guis[aa].Y, guis[aa].Transparency);
+            add_thing_to_draw(guibgbmp[aa], guis[aa].X, guis[aa].Y, guis[aa].Transparency, guis[aa].BlendMode);
 
             // only poll if the interface is enabled (mouseovers should not
             // work while in Wait state)

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1567,7 +1567,7 @@ void prepare_objects_for_drawing() {
                 actspsbmp[useindx]->SetLightLevel(0);
         }
 
-        add_to_sprite_list(actspsbmp[useindx], atxp, atyp, usebasel, objs[aa].transparent, false);
+        add_to_sprite_list(actspsbmp[useindx], atxp, atyp, usebasel, objs[aa].transparent, false, objs[aa].blend_mode);
     }
 }
 

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -109,12 +109,12 @@ void construct_game_screen_overlay(bool draw_mouse = true);
 void construct_engine_overlay();
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
 void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha,
-                               Common::BlendMode blend_mode = Common::kBlendMode_Normal, int alpha = 0xFF);
+                               Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
 void draw_sprite_slot_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot,
-                                    Common::BlendMode blend_mode = Common::kBlendMode_Normal, int alpha = 0xFF);
+                                    Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
 // CLNUP I'd like to put the default parameters to draw_gui_sprite, but the extern from guiman.h prevents it
 void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode);
-//void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true, Common::BlendMode blend_mode = Common::kBlendMode_Alpha);
+//void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true, Common::BlendMode blend_mode = Common::kBlend_Alpha);
 // Render game on screen
 void render_to_screen();
 // Callbacks for the graphics driver

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -109,9 +109,9 @@ void construct_game_screen_overlay(bool draw_mouse = true);
 void construct_engine_overlay();
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
 void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha,
-                               Common::BlendMode blend_mode = Common::kBlendMode_Alpha, int alpha = 0xFF);
+                               Common::BlendMode blend_mode = Common::kBlendMode_Normal, int alpha = 0xFF);
 void draw_sprite_slot_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot,
-                                    Common::BlendMode blend_mode = Common::kBlendMode_Alpha, int alpha = 0xFF);
+                                    Common::BlendMode blend_mode = Common::kBlendMode_Normal, int alpha = 0xFF);
 // CLNUP I'd like to put the default parameters to draw_gui_sprite, but the extern from guiman.h prevents it
 void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode);
 //void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true, Common::BlendMode blend_mode = Common::kBlendMode_Alpha);

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -191,7 +191,7 @@ void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src, int ds
     }
 
     draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, src_has_alpha,
-        kBlendMode_Normal, GfxDef::Trans100ToAlpha255(trans));
+        kBlend_Normal, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();
 

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -191,7 +191,7 @@ void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src, int ds
     }
 
     draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, src_has_alpha,
-        kBlendMode_Alpha, GfxDef::Trans100ToAlpha255(trans));
+        kBlendMode_Normal, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();
 

--- a/Engine/ac/global_drawingsurface.cpp
+++ b/Engine/ac/global_drawingsurface.cpp
@@ -187,7 +187,7 @@ void RawDrawImageCore(int xx, int yy, int slot, int alpha) {
         debug_script_warn("RawDrawImage: Sprite %d colour depth %d-bit not same as background depth %d-bit", slot, spriteset[slot]->GetColorDepth(), RAW_SURFACE()->GetColorDepth());
     }
 
-    draw_sprite_slot_support_alpha(RAW_SURFACE(), false, xx, yy, slot, kBlendMode_Alpha, alpha);
+    draw_sprite_slot_support_alpha(RAW_SURFACE(), false, xx, yy, slot, kBlend_Alpha, alpha);
     invalidate_screen();
     mark_current_background_dirty();
     RAW_END();

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -324,6 +324,8 @@ int GUI_GetBlendMode(ScriptGUI *gui) {
 }
 
 void GUI_SetBlendMode(ScriptGUI *gui, int blendMode) {
+    if ((blendMode < 0) || (blendMode >= kNumBlendModes))
+        quitprintf("!SetBlendMode: invalid blend mode %d, supported modes are %d - %d", blendMode, 0, kNumBlendModes - 1);
     guis[gui->id].BlendMode = (BlendMode)blendMode;
 }
 

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -324,7 +324,7 @@ int GUI_GetBlendMode(ScriptGUI *gui) {
 }
 
 void GUI_SetBlendMode(ScriptGUI *gui, int blendMode) {
-    guis[gui->id].BlendMode = blendMode;
+    guis[gui->id].BlendMode = (BlendMode)blendMode;
 }
 
 //=============================================================================

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -319,6 +319,14 @@ void GUI_ProcessClick(int x, int y, int mbut)
     }
 }
 
+int GUI_GetBlendMode(ScriptGUI *gui) {
+    return guis[gui->id].BlendMode;
+}
+
+void GUI_SetBlendMode(ScriptGUI *gui, int blendMode) {
+    guis[gui->id].BlendMode = blendMode;
+}
+
 //=============================================================================
 
 void remove_popup_interface(int ifacenum) {
@@ -928,6 +936,18 @@ RuntimeScriptValue Sc_GUI_ProcessClick(const RuntimeScriptValue *params, int32_t
     API_SCALL_VOID_PINT3(GUI_ProcessClick);
 }
 
+// int (ScriptGUI *gui)
+RuntimeScriptValue Sc_GUI_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptGUI, GUI_GetBlendMode);
+}
+
+// void (ScriptGUI *gui, int blendMode)
+RuntimeScriptValue Sc_GUI_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptGUI, GUI_SetBlendMode);
+}
+
 void RegisterGUIAPI()
 {
     ccAddExternalObjectFunction("GUI::Centre^0",                Sc_GUI_Centre);
@@ -969,6 +989,8 @@ void RegisterGUIAPI()
     ccAddExternalObjectFunction("GUI::set_Y",                   Sc_GUI_SetY);
     ccAddExternalObjectFunction("GUI::get_ZOrder",              Sc_GUI_GetZOrder);
     ccAddExternalObjectFunction("GUI::set_ZOrder",              Sc_GUI_SetZOrder);
+    ccAddExternalObjectFunction("GUI::get_BlendMode",           Sc_GUI_GetBlendMode);
+    ccAddExternalObjectFunction("GUI::set_BlendMode",           Sc_GUI_SetBlendMode);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -419,6 +419,8 @@ int Object_GetBlendMode(ScriptObject *objj) {
 }
 
 void Object_SetBlendMode(ScriptObject *objj, int blendMode) {
+    if ((blendMode < 0) || (blendMode >= kNumBlendModes))
+        quitprintf("!SetBlendMode: invalid blend mode %d, supported modes are %d - %d", blendMode, 0, kNumBlendModes - 1);
     objs[objj->id].blend_mode = (BlendMode)blendMode;
 }
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -414,6 +414,15 @@ int Object_GetIgnoreWalkbehinds(ScriptObject *chaa) {
     return 0;
 }
 
+int Object_GetBlendMode(ScriptObject *objj) {
+    return objs[objj->id].blend_mode;
+}
+
+void Object_SetBlendMode(ScriptObject *objj, int blendMode) {
+    objs[objj->id].blend_mode = blendMode;
+}
+
+
 void move_object(int objj,int tox,int toy,int spee,int ignwal) {
 
     if (!is_valid_object(objj))
@@ -932,6 +941,17 @@ RuntimeScriptValue Sc_Object_SetY(void *self, const RuntimeScriptValue *params, 
     API_OBJCALL_VOID_PINT(ScriptObject, Object_SetY);
 }
 
+// int (ScriptObject *objj)
+RuntimeScriptValue Sc_Object_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptObject, Object_GetBlendMode);
+}
+
+// void (ScriptObject *objj, int blendMode)
+RuntimeScriptValue Sc_Object_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptObject, Object_SetBlendMode);
+}
 
 
 void RegisterObjectAPI()
@@ -1006,6 +1026,9 @@ void RegisterObjectAPI()
     ccAddExternalObjectFunction("Object::get_TintRed",              Sc_Object_GetTintRed);
     ccAddExternalObjectFunction("Object::get_TintSaturation",       Sc_Object_GetTintSaturation);
     ccAddExternalObjectFunction("Object::get_TintLuminance",        Sc_Object_GetTintLuminance);
+
+    ccAddExternalObjectFunction("Object::get_BlendMode",            Sc_Object_GetBlendMode);
+    ccAddExternalObjectFunction("Object::set_BlendMode",            Sc_Object_SetBlendMode);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -419,7 +419,7 @@ int Object_GetBlendMode(ScriptObject *objj) {
 }
 
 void Object_SetBlendMode(ScriptObject *objj, int blendMode) {
-    objs[objj->id].blend_mode = blendMode;
+    objs[objj->id].blend_mode = (BlendMode)blendMode;
 }
 
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -151,7 +151,7 @@ void Overlay_SetBlendMode(ScriptOverlay *scover, int blendMode) {
     if (ovri < 0)
         quit("!invalid overlay ID specified");
 
-    screenover[ovri].blendMode = blendMode;
+    screenover[ovri].blendMode = (BlendMode)blendMode;
 }
 
 //=============================================================================
@@ -207,7 +207,7 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, bool alphaChann
     return add_screen_overlay(x, y, type, piccy, 0, 0, alphaChannel);
 }
 
-size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel, int blendMode)
+size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel, BlendMode blendMode)
 {
     if (type==OVER_COMPLETE) is_complete_overlay++;
     if (type==OVER_TEXTMSG) is_text_overlay++;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -150,6 +150,8 @@ void Overlay_SetBlendMode(ScriptOverlay *scover, int blendMode) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
+    if ((blendMode < 0) || (blendMode >= kNumBlendModes))
+        quitprintf("!SetBlendMode: invalid blend mode %d, supported modes are %d - %d", blendMode, 0, kNumBlendModes - 1);
 
     screenover[ovri].blendMode = (BlendMode)blendMode;
 }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -138,6 +138,22 @@ ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colo
     return sco;
 }
 
+int Overlay_GetBlendMode(ScriptOverlay *scover) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+
+    return screenover[ovri].blendMode;
+}
+
+void Overlay_SetBlendMode(ScriptOverlay *scover, int blendMode) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+
+    screenover[ovri].blendMode = blendMode;
+}
+
 //=============================================================================
 
 void dispose_overlay(ScreenOverlay &over)
@@ -191,7 +207,7 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, bool alphaChann
     return add_screen_overlay(x, y, type, piccy, 0, 0, alphaChannel);
 }
 
-size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel)
+size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel, int blendMode)
 {
     if (type==OVER_COMPLETE) is_complete_overlay++;
     if (type==OVER_TEXTMSG) is_text_overlay++;
@@ -214,6 +230,7 @@ size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic
     over.associatedOverlayHandle = 0;
     over.hasAlphaChannel = alphaChannel;
     over.positionRelativeToScreen = true;
+    over.blendMode = blendMode;
     screenover.push_back(over);
     return screenover.size() - 1;
 }
@@ -346,6 +363,18 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetY);
 }
 
+// int (ScriptOverlay *scover)
+RuntimeScriptValue Sc_Overlay_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetBlendMode);
+}
+
+// void (ScriptOverlay *scover, int blendMode)
+RuntimeScriptValue Sc_Overlay_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetBlendMode);
+}
+
 //=============================================================================
 //
 // Exclusive API for Plugins
@@ -378,6 +407,8 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::set_X",               Sc_Overlay_SetX);
     ccAddExternalObjectFunction("Overlay::get_Y",               Sc_Overlay_GetY);
     ccAddExternalObjectFunction("Overlay::set_Y",               Sc_Overlay_SetY);
+    ccAddExternalObjectFunction("Overlay::get_BlendMode",       Sc_Overlay_GetBlendMode);
+    ccAddExternalObjectFunction("Overlay::set_BlendMode",       Sc_Overlay_SetBlendMode);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -39,7 +39,7 @@ void remove_screen_overlay(int type);
 // Calculates overlay position in screen coordinates
 void get_overlay_position(const ScreenOverlay &over, int *x, int *y);
 size_t add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
-size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false);
+size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false, int blendMode = 0);
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -39,7 +39,8 @@ void remove_screen_overlay(int type);
 // Calculates overlay position in screen coordinates
 void get_overlay_position(const ScreenOverlay &over, int *x, int *y);
 size_t add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
-size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false, int blendMode = 0);
+size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy,
+    bool alphaChannel = false, Common::BlendMode blendMode = Common::kBlend_Normal);
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -524,8 +524,8 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             croom->obj[cc].blocking_width = 0;
             croom->obj[cc].blocking_height = 0;
             if (thisroom.Objects[cc].Baseline>=0)
-                //        croom->obj[cc].baseoffs=thisroom.Objects.Baseline[cc]-thisroom.Objects[cc].y;
                 croom->obj[cc].baseline=thisroom.Objects[cc].Baseline;
+            croom->obj[cc].blend_mode = thisroom.Objects[cc].BlendMode;
         }
         for (size_t i = 0; i < (size_t)MAX_WALK_BEHINDS; ++i)
             croom->walkbehind_base[i] = thisroom.WalkBehinds[i].Baseline;

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -160,6 +160,10 @@ void RoomObject::ReadFromFile(Stream *in, int32_t cmp_ver)
     {
         blend_mode = in->ReadInt32();
     }
+    else
+    {
+        blend_mode = 0;
+    }
 }
 
 void RoomObject::WriteToFile(Stream *out) const

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -46,6 +46,7 @@ RoomObject::RoomObject()
     on = 0;
     flags = 0;
     blocking_width = blocking_height = 0;
+    blend_mode = 0;
 }
 
 int RoomObject::get_width() {
@@ -149,12 +150,16 @@ void RoomObject::update_cycle_view_backwards()
       }
 }
 
-void RoomObject::ReadFromFile(Stream *in)
+void RoomObject::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
     in->ReadArrayOfInt32(&x, 3);
     in->ReadArrayOfInt16(&tint_r, 15);
     in->ReadArrayOfInt8((int8_t*)&cycling, 4);
     in->ReadArrayOfInt16(&blocking_width, 2);
+    if (cmp_ver >= 10)
+    {
+        blend_mode = in->ReadInt32();
+    }
 }
 
 void RoomObject::WriteToFile(Stream *out) const
@@ -163,4 +168,6 @@ void RoomObject::WriteToFile(Stream *out) const
     out->WriteArrayOfInt16(&tint_r, 15);
     out->WriteArrayOfInt8((int8_t*)&cycling, 4);
     out->WriteArrayOfInt16(&blocking_width, 2);
+    // since version 10
+    out->WriteInt32(blend_mode);
 }

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -22,7 +22,7 @@
 #include "main/update.h"
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+using namespace AGS::Common;
 
 extern ViewStruct*views;
 extern GameState play;
@@ -46,7 +46,7 @@ RoomObject::RoomObject()
     on = 0;
     flags = 0;
     blocking_width = blocking_height = 0;
-    blend_mode = 0;
+    blend_mode = kBlend_Normal;
 }
 
 int RoomObject::get_width() {
@@ -158,11 +158,11 @@ void RoomObject::ReadFromFile(Stream *in, int32_t cmp_ver)
     in->ReadArrayOfInt16(&blocking_width, 2);
     if (cmp_ver >= 10)
     {
-        blend_mode = in->ReadInt32();
+        blend_mode = (BlendMode)in->ReadInt32();
     }
     else
     {
-        blend_mode = 0;
+        blend_mode = kBlend_Normal;
     }
 }
 

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -159,6 +159,20 @@ void RoomObject::ReadFromFile(Stream *in, int32_t cmp_ver)
     if (cmp_ver >= 10)
     {
         blend_mode = (BlendMode)in->ReadInt32();
+        // Reserved for colour options
+        in->ReadInt32(); // colour flags
+        // Reserved for transform options
+        in->ReadInt32(); // sprite transform flags1
+        in->ReadInt32(); // sprite transform flags2
+        in->ReadInt32(); // transform scale x
+        in->ReadInt32(); // transform scale y
+        in->ReadInt32(); // transform skew x
+        in->ReadInt32(); // transform skew y
+        in->ReadInt32(); // transform rotate
+        in->ReadInt32(); // sprite pivot x
+        in->ReadInt32(); // sprite pivot y
+        in->ReadInt32(); // sprite anchor x
+        in->ReadInt32(); // sprite anchor y
     }
     else
     {
@@ -174,4 +188,18 @@ void RoomObject::WriteToFile(Stream *out) const
     out->WriteArrayOfInt16(&blocking_width, 2);
     // since version 10
     out->WriteInt32(blend_mode);
+    // Reserved for colour options
+    out->WriteInt32(0); // colour flags
+    // Reserved for transform options
+    out->WriteInt32(0); // sprite transform flags1
+    out->WriteInt32(0); // sprite transform flags2
+    out->WriteInt32(0); // transform scale x
+    out->WriteInt32(0); // transform scale y
+    out->WriteInt32(0); // transform skew x
+    out->WriteInt32(0); // transform skew y
+    out->WriteInt32(0); // transform rotate
+    out->WriteInt32(0); // sprite pivot x
+    out->WriteInt32(0); // sprite pivot y
+    out->WriteInt32(0); // sprite anchor x
+    out->WriteInt32(0); // sprite anchor y
 }

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__ROOMOBJECT_H
 #define __AGS_EE_AC__ROOMOBJECT_H
 
+#include "core/types.h"
 #include "ac/common_defines.h"
 
 namespace AGS { namespace Common { class Stream; }}
@@ -41,6 +42,7 @@ struct RoomObject {
     char  on;
     char  flags;
     short blocking_width, blocking_height;
+    short blend_mode;
 
     RoomObject();
 
@@ -55,7 +57,7 @@ struct RoomObject {
 	void update_cycle_view_forwards();
 	void update_cycle_view_backwards();
 
-    void ReadFromFile(Common::Stream *in);
+    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;
 };
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -20,11 +20,11 @@
 
 #include "core/types.h"
 #include "ac/common_defines.h"
+#include "gfx/gfx_def.h"
 
 namespace AGS { namespace Common { class Stream; }}
 using namespace AGS; // FIXME later
 
-// IMPORTANT: this struct is restricted by plugin API!
 struct RoomObject {
     int   x,y;
     int   transparent;    // current transparency setting
@@ -42,7 +42,7 @@ struct RoomObject {
     char  on;
     char  flags;
     short blocking_width, blocking_height;
-    short blend_mode;
+    Common::BlendMode blend_mode;
 
     RoomObject();
 

--- a/Engine/ac/roomstatus.cpp
+++ b/Engine/ac/roomstatus.cpp
@@ -64,7 +64,7 @@ void RoomStatus::FreeProperties()
     }
 }
 
-void RoomStatus::ReadFromSavegame(Stream *in)
+void RoomStatus::ReadFromSavegame(Stream *in, int32_t cmp_ver)
 {
     FreeScriptData();
     FreeProperties();
@@ -73,7 +73,7 @@ void RoomStatus::ReadFromSavegame(Stream *in)
     numobj = in->ReadInt32();
     for (int i = 0; i < numobj; ++i)
     {
-        obj[i].ReadFromFile(in);
+        obj[i].ReadFromFile(in, cmp_ver);
         Properties::ReadValues(objProps[i], in);
     }
     for (int i = 0; i < MAX_ROOM_HOTSPOTS; ++i)

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -51,7 +51,7 @@ struct RoomStatus {
     void FreeScriptData();
     void FreeProperties();
 
-    void ReadFromSavegame(Common::Stream *in);
+    void ReadFromSavegame(Common::Stream *in, int32_t cmp_ver);
     void WriteToSavegame(Common::Stream *out) const;
 };
 

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -37,6 +37,10 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
         _offsetX = in->ReadInt32();
         _offsetY = in->ReadInt32();
     }
+    if (cmp_ver >= 10)
+    {
+        blendMode = in->ReadInt32();
+    }
 }
 
 void ScreenOverlay::WriteToFile(Stream *out) const
@@ -54,4 +58,6 @@ void ScreenOverlay::WriteToFile(Stream *out) const
     // since cmp_ver = 1
     out->WriteInt32(_offsetX);
     out->WriteInt32(_offsetY);
+    // since cmp_ver = 10
+    out->WriteInt32(blendMode);
 }

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -40,6 +40,23 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     if (cmp_ver >= 10)
     {
         blendMode = (BlendMode)in->ReadInt32();
+        // Reserved for colour options
+        in->ReadInt32(); // colour flags
+        in->ReadInt32(); // transparency / alpha
+        in->ReadInt32(); // tint rgb + s
+        in->ReadInt32(); // tint light (or light level)
+        // Reserved for transform options
+        in->ReadInt32(); // sprite transform flags1
+        in->ReadInt32(); // sprite transform flags2
+        in->ReadInt32(); // transform scale x
+        in->ReadInt32(); // transform scale y
+        in->ReadInt32(); // transform skew x
+        in->ReadInt32(); // transform skew y
+        in->ReadInt32(); // transform rotate
+        in->ReadInt32(); // sprite pivot x
+        in->ReadInt32(); // sprite pivot y
+        in->ReadInt32(); // sprite anchor x
+        in->ReadInt32(); // sprite anchor y
     }
 }
 
@@ -60,4 +77,20 @@ void ScreenOverlay::WriteToFile(Stream *out) const
     out->WriteInt32(_offsetY);
     // since cmp_ver = 10
     out->WriteInt32(blendMode);
+    // Reserved for colour options
+    out->WriteInt32(0); // colour flags
+    out->WriteInt32(0); // tint rgb + s
+    out->WriteInt32(0); // tint light (or light level)
+    // Reserved for transform options
+    out->WriteInt32(0); // sprite transform flags1
+    out->WriteInt32(0); // sprite transform flags2
+    out->WriteInt32(0); // transform scale x
+    out->WriteInt32(0); // transform scale y
+    out->WriteInt32(0); // transform skew x
+    out->WriteInt32(0); // transform skew y
+    out->WriteInt32(0); // transform rotate
+    out->WriteInt32(0); // sprite pivot x
+    out->WriteInt32(0); // sprite pivot y
+    out->WriteInt32(0); // sprite anchor x
+    out->WriteInt32(0); // sprite anchor y
 }

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -15,7 +15,7 @@
 #include "screenoverlay.h"
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+using namespace AGS::Common;
 
 void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
 {
@@ -39,7 +39,7 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     }
     if (cmp_ver >= 10)
     {
-        blendMode = in->ReadInt32();
+        blendMode = (BlendMode)in->ReadInt32();
     }
 }
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -36,6 +36,7 @@ struct ScreenOverlay {
     int associatedOverlayHandle = 0;
     bool positionRelativeToScreen = false;
     int _offsetX = 0, _offsetY = 0;
+    int blendMode;
 
     void ReadFromFile(Common::Stream *in, bool &has_bitmap, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -36,7 +36,7 @@ struct ScreenOverlay {
     int associatedOverlayHandle = 0;
     bool positionRelativeToScreen = false;
     int _offsetX = 0, _offsetY = 0;
-    int blendMode;
+    int blendMode = 0;
 
     void ReadFromFile(Common::Stream *in, bool &has_bitmap, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -18,7 +18,8 @@
 #ifndef __AGS_EE_AC__SCREENOVERLAY_H
 #define __AGS_EE_AC__SCREENOVERLAY_H
 
-#include <stdint.h>
+#include "core/types.h"
+#include "gfx/gfx_def.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Bitmap; class Stream; } }
@@ -36,7 +37,7 @@ struct ScreenOverlay {
     int associatedOverlayHandle = 0;
     bool positionRelativeToScreen = false;
     int _offsetX = 0, _offsetY = 0;
-    int blendMode = 0;
+    Common::BlendMode blendMode = Common::kBlend_Normal;
 
     void ReadFromFile(Common::Stream *in, bool &has_bitmap, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -147,7 +147,7 @@ void InitAndRegisterAudioObjects()
 }
 
 // Initializes characters and registers them in the script system
-void InitAndRegisterCharacters()
+void InitAndRegisterCharacters(const LoadedGameEntities &ents)
 {
     characterScriptObjNames.resize(game.numcharacters);
     for (int i = 0; i < game.numcharacters; ++i)
@@ -170,6 +170,15 @@ void InitAndRegisterCharacters()
         // export the character's script object
         characterScriptObjNames[i] = game.chars[i].scrname;
         ccAddExternalDynamicObject(characterScriptObjNames[i], &game.chars[i], &ccDynamicCharacter);
+    }
+
+    // extra character properties (because the characters are split into 2 structs now)
+    if (ents.CharEx.size() > 0)
+    {
+        for (int i = 0; i < game.numcharacters; ++i)
+        {
+            charextra[i].blend_mode = ents.CharEx[i].BlendMode;
+        }
     }
 }
 
@@ -307,10 +316,10 @@ void RegisterStaticArrays()
 }
 
 // Initializes various game entities and registers them in the script system
-HError InitAndRegisterGameEntities()
+HError InitAndRegisterGameEntities(const LoadedGameEntities &ents)
 {
     InitAndRegisterAudioObjects();
-    InitAndRegisterCharacters();
+    InitAndRegisterCharacters(ents);
     InitAndRegisterDialogs();
     InitAndRegisterDialogOptions();
     HError err = InitAndRegisterGUI();
@@ -405,7 +414,7 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     actspswbbmp = (IDriverDependantBitmap**)calloc(actSpsCount, sizeof(IDriverDependantBitmap*));
     actspswbcache = (CachedActSpsData*)calloc(actSpsCount, sizeof(CachedActSpsData));
     play.charProps.resize(game.numcharacters);
-    HError err = InitAndRegisterGameEntities();
+    HError err = InitAndRegisterGameEntities(ents);
     if (!err)
         return new GameInitError(kGameInitErr_EntityInitFail, err);
     LoadFonts(data_ver);

--- a/Engine/game/savegame.h
+++ b/Engine/game/savegame.h
@@ -52,7 +52,8 @@ enum SavegameVersion
     kSvgVersion_Cmp_64bit = 10,
     kSvgVersion_350_final = 11,
     kSvgVersion_350_final2= 12,
-    kSvgVersion_Current   = kSvgVersion_350_final2,
+    kSvgVersion_399       = 20,
+    kSvgVersion_Current   = kSvgVersion_399,
     kSvgVersion_LowestSupported = kSvgVersion_Components // change if support dropped
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1077,7 +1077,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "GUI",
-        kGuiSvgVersion_350,
+        kGuiSvgVersion_399,
         kGuiSvgVersion_Initial,
         WriteGUI,
         ReadGUI

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -466,7 +466,7 @@ HSaveError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams &pp
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].ReadFromFile(in.get());
-        charextra[i].ReadFromFile(in.get());
+        charextra[i].ReadFromFile(in.get(), cmp_ver);
         Properties::ReadValues(play.charProps[i], in.get());
         // character movement path cache
         err = mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver > 0 ? 1 : 0);
@@ -1063,7 +1063,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Characters",
-        1,
+        10,
         0,
         WriteCharacters,
         ReadCharacters

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1112,7 +1112,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Overlays",
-        1,
+        10,
         0,
         WriteOverlays,
         ReadOverlays

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -450,7 +450,7 @@ HSaveError WriteCharacters(PStream out)
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].WriteToFile(out.get());
-        charextra[i].WriteToFile(out.get());
+        charextra[i].WriteToSavegame(out.get());
         Properties::WriteValues(play.charProps[i], out.get());
         // character movement path cache
         mls[CHMLSOFFS + i].WriteToFile(out.get());
@@ -466,7 +466,7 @@ HSaveError ReadCharacters(PStream in, int32_t cmp_ver, const PreservedParams &pp
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].ReadFromFile(in.get());
-        charextra[i].ReadFromFile(in.get(), cmp_ver);
+        charextra[i].ReadFromSavegame(in.get(), cmp_ver);
         Properties::ReadValues(play.charProps[i], in.get());
         // character movement path cache
         err = mls[CHMLSOFFS + i].ReadFromFile(in.get(), cmp_ver > 0 ? 1 : 0);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -891,7 +891,7 @@ HSaveError ReadRoomStates(PStream in, int32_t cmp_ver, const PreservedParams &pp
             if (!AssertFormatTagStrict(err, in, "RoomState", true))
                 return err;
             RoomStatus *roomstat = getRoomStatus(id);
-            roomstat->ReadFromSavegame(in.get());
+            roomstat->ReadFromSavegame(in.get(), cmp_ver);
             if (!AssertFormatTagStrict(err, in, "RoomState", false))
                 return err;
         }
@@ -994,7 +994,7 @@ HSaveError ReadThisRoom(PStream in, int32_t cmp_ver, const PreservedParams &pp, 
 
     // read the current troom state, in case they saved in temporary room
     if (!in->ReadBool())
-        troom.ReadFromSavegame(in.get());
+        troom.ReadFromSavegame(in.get(), cmp_ver);
 
     return HSaveError::None();
 }
@@ -1133,7 +1133,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Room States",
-        0,
+        10,
         0,
         WriteRoomStates,
         ReadRoomStates

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -111,6 +111,10 @@ const void (*glSwapIntervalEXT)(int) = NULL;
 // Necessary to update textures from 8-bit bitmaps
 extern RGB palette[256];
 
+#define AGS_OGLBLENDOP(blend_op, src_blend, dest_blend) \
+  glBlendEquation(blend_op); \
+  glBlendFunc(src_blend, dest_blend); \
+
 
 namespace AGS
 {
@@ -1329,7 +1333,56 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
       glVertexPointer(2, GL_FLOAT, sizeof(OGLCUSTOMVERTEX), &defaultVertices[0].position);
     }
 
+    // Blend modes
+    switch (bmpToDraw->_blendMode) {
+        // blend mode is always NORMAL at this point
+        //case kBlendMode_Alpha: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); break; // ALPHA
+        case kBlendMode_Add: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE); break; // ADD (transparency = strength)
+        case kBlendMode_Darken: AGS_OGLBLENDOP(GL_MIN, GL_ONE, GL_ONE); break; // DARKEN
+        case kBlendMode_Lighten: AGS_OGLBLENDOP(GL_MAX, GL_ONE, GL_ONE); break; // LIGHTEN
+        case kBlendMode_Multiply: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ZERO, GL_SRC_COLOR); break; // MULTIPLY
+        case kBlendMode_Screen: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE, GL_ONE_MINUS_SRC_COLOR); break; // SCREEN
+        case kBlendMode_Subtract: AGS_OGLBLENDOP(GL_FUNC_REVERSE_SUBTRACT, GL_SRC_ALPHA, GL_ONE); break; // SUBTRACT (transparency = strength)
+        case kBlendMode_Exclusion: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_COLOR); break; // EXCLUSION
+        // APPROXIMATIONS (need pixel shaders)
+        case kBlendMode_Burn: AGS_OGLBLENDOP(GL_FUNC_SUBTRACT, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR); break; // LINEAR BURN (approximation)
+        case kBlendMode_Dodge: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_DST_COLOR, GL_ONE); break; // fake color dodge (half strength of the real thing)
+    }
+
+    // WORKAROUNDS - BEGIN
+
+    // allow transparency with blending modes
+    // darken/lighten the base sprite so a higher transparency value makes it trasparent
+    if (bmpToDraw->_blendMode > 0) {
+        const float alpha = bmpToDraw->_transparency == 0 ? 1.0 : bmpToDraw->_transparency / 255.0;
+        const float invalpha = 1.0 - alpha;
+        switch (bmpToDraw->_blendMode) {
+        case kBlendMode_Darken:
+        case kBlendMode_Multiply:
+        case kBlendMode_Burn: // burn is imperfect due to blend mode, darker than normal even when trasparent
+            // fade to white
+            glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD);
+            glColor4f(invalpha, invalpha, invalpha, invalpha);
+            break;
+        default:
+            glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+            glColor4f(alpha, alpha, alpha, alpha);
+            break;
+        }
+    }
+
+    // workaround: since the dodge is only half strength we can get a closer approx by drawing it twice
+    if (bmpToDraw->_blendMode == kBlendMode_Dodge)
+    {
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    }
+    // BLENDMODES WORKAROUNDS - END
+
+
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    // Restore default blending mode
+    AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   }
   glUseProgram(0);
 }

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1338,8 +1338,12 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
         // blend mode is always NORMAL at this point
         //case kBlendMode_Alpha: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); break; // ALPHA
         case kBlendMode_Add: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE); break; // ADD (transparency = strength)
+#ifdef GL_MIN
         case kBlendMode_Darken: AGS_OGLBLENDOP(GL_MIN, GL_ONE, GL_ONE); break; // DARKEN
+#endif
+#ifdef GL_MAX
         case kBlendMode_Lighten: AGS_OGLBLENDOP(GL_MAX, GL_ONE, GL_ONE); break; // LIGHTEN
+#endif
         case kBlendMode_Multiply: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ZERO, GL_SRC_COLOR); break; // MULTIPLY
         case kBlendMode_Screen: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE, GL_ONE_MINUS_SRC_COLOR); break; // SCREEN
         case kBlendMode_Subtract: AGS_OGLBLENDOP(GL_FUNC_REVERSE_SUBTRACT, GL_SRC_ALPHA, GL_ONE); break; // SUBTRACT (transparency = strength)

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1336,21 +1336,21 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
     // Blend modes
     switch (bmpToDraw->_blendMode) {
         // blend mode is always NORMAL at this point
-        //case kBlendMode_Alpha: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); break; // ALPHA
-        case kBlendMode_Add: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE); break; // ADD (transparency = strength)
+        //case kBlend_Alpha: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); break; // ALPHA
+        case kBlend_Add: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE); break; // ADD (transparency = strength)
 #ifdef GL_MIN
-        case kBlendMode_Darken: AGS_OGLBLENDOP(GL_MIN, GL_ONE, GL_ONE); break; // DARKEN
+        case kBlend_Darken: AGS_OGLBLENDOP(GL_MIN, GL_ONE, GL_ONE); break; // DARKEN
 #endif
 #ifdef GL_MAX
-        case kBlendMode_Lighten: AGS_OGLBLENDOP(GL_MAX, GL_ONE, GL_ONE); break; // LIGHTEN
+        case kBlend_Lighten: AGS_OGLBLENDOP(GL_MAX, GL_ONE, GL_ONE); break; // LIGHTEN
 #endif
-        case kBlendMode_Multiply: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ZERO, GL_SRC_COLOR); break; // MULTIPLY
-        case kBlendMode_Screen: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE, GL_ONE_MINUS_SRC_COLOR); break; // SCREEN
-        case kBlendMode_Subtract: AGS_OGLBLENDOP(GL_FUNC_REVERSE_SUBTRACT, GL_SRC_ALPHA, GL_ONE); break; // SUBTRACT (transparency = strength)
-        case kBlendMode_Exclusion: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_COLOR); break; // EXCLUSION
+        case kBlend_Multiply: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ZERO, GL_SRC_COLOR); break; // MULTIPLY
+        case kBlend_Screen: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE, GL_ONE_MINUS_SRC_COLOR); break; // SCREEN
+        case kBlend_Subtract: AGS_OGLBLENDOP(GL_FUNC_REVERSE_SUBTRACT, GL_SRC_ALPHA, GL_ONE); break; // SUBTRACT (transparency = strength)
+        case kBlend_Exclusion: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_ONE_MINUS_DST_COLOR, GL_ONE_MINUS_SRC_COLOR); break; // EXCLUSION
         // APPROXIMATIONS (need pixel shaders)
-        case kBlendMode_Burn: AGS_OGLBLENDOP(GL_FUNC_SUBTRACT, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR); break; // LINEAR BURN (approximation)
-        case kBlendMode_Dodge: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_DST_COLOR, GL_ONE); break; // fake color dodge (half strength of the real thing)
+        case kBlend_Burn: AGS_OGLBLENDOP(GL_FUNC_SUBTRACT, GL_DST_COLOR, GL_ONE_MINUS_DST_COLOR); break; // LINEAR BURN (approximation)
+        case kBlend_Dodge: AGS_OGLBLENDOP(GL_FUNC_ADD, GL_DST_COLOR, GL_ONE); break; // fake color dodge (half strength of the real thing)
     }
 
     // WORKAROUNDS - BEGIN
@@ -1361,9 +1361,9 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
         const float alpha = bmpToDraw->_transparency == 0 ? 1.0 : bmpToDraw->_transparency / 255.0;
         const float invalpha = 1.0 - alpha;
         switch (bmpToDraw->_blendMode) {
-        case kBlendMode_Darken:
-        case kBlendMode_Multiply:
-        case kBlendMode_Burn: // burn is imperfect due to blend mode, darker than normal even when trasparent
+        case kBlend_Darken:
+        case kBlend_Multiply:
+        case kBlend_Burn: // burn is imperfect due to blend mode, darker than normal even when trasparent
             // fade to white
             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD);
             glColor4f(invalpha, invalpha, invalpha, invalpha);
@@ -1376,7 +1376,7 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
     }
 
     // workaround: since the dodge is only half strength we can get a closer approx by drawing it twice
-    if (bmpToDraw->_blendMode == kBlendMode_Dodge)
+    if (bmpToDraw->_blendMode == kBlend_Dodge)
     {
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -80,7 +80,7 @@ public:
         _blue = blue;
         _tintSaturation = tintSaturation;
     }
-    void SetBlendMode(int blendMode) override { _blendMode = blendMode; }
+    void SetBlendMode(Common::BlendMode blendMode) override { _blendMode = blendMode; }
 
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
@@ -93,7 +93,7 @@ public:
     OGLCUSTOMVERTEX* _vertex;
     OGLTextureTile *_tiles;
     int _numTiles;
-    int _blendMode;
+    Common::BlendMode _blendMode;
 
     OGLBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -113,7 +113,7 @@ public:
         _vertex = nullptr;
         _tiles = nullptr;
         _numTiles = 0;
-        _blendMode = 0;
+        _blendMode = Common::kBlend_Normal;
     }
 
     int GetWidthToRender() const { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -80,6 +80,7 @@ public:
         _blue = blue;
         _tintSaturation = tintSaturation;
     }
+    void SetBlendMode(int blendMode) override { _blendMode = blendMode; }
 
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
@@ -92,6 +93,7 @@ public:
     OGLCUSTOMVERTEX* _vertex;
     OGLTextureTile *_tiles;
     int _numTiles;
+    int _blendMode;
 
     OGLBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -111,6 +113,7 @@ public:
         _vertex = nullptr;
         _tiles = nullptr;
         _numTiles = 0;
+        _blendMode = 0;
     }
 
     int GetWidthToRender() const { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -525,28 +525,21 @@ void ALSoftwareGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, Com
 
     if (bitmap->_transparency >= 255) {} // fully transparent, do nothing
     else if ((bitmap->_opaque) && (bitmap->_bmp == surface) && (bitmap->_transparency == 0)) {}
-    else if (bitmap->_opaque)
+    else if (bitmap->_opaque && bitmap->_blendMode == 0)
     {
         surface->Blit(bitmap->_bmp, 0, 0, drawAtX, drawAtY, bitmap->_bmp->GetWidth(), bitmap->_bmp->GetHeight());
         // TODO: we need to also support non-masked translucent blend, but...
         // Allegro 4 **does not have such function ready** :( (only masked blends, where it skips magenta pixels);
         // I am leaving this problem for the future, as coincidentally software mode does not need this atm.
     }
-    else if (bitmap->_hasAlpha)
-    {
-      if (bitmap->_transparency == 0) // no global transparency, simple alpha blend
-        set_alpha_blender();
-      else
-        // here _transparency is used as alpha (between 1 and 254)
-        set_blender_mode(nullptr, nullptr, _trans_alpha_blender32, 0, 0, 0, bitmap->_transparency);
-
-      surface->TransBlendBlt(bitmap->_bmp, drawAtX, drawAtY);
-    }
     else
     {
-      // here _transparency is used as alpha (between 1 and 254), but 0 means opaque!
-      GfxUtil::DrawSpriteWithTransparency(surface, bitmap->_bmp, drawAtX, drawAtY,
-          bitmap->_transparency ? bitmap->_transparency : 255);
+        Common::BlendMode al_blender_mode = (Common::BlendMode) bitmap->_blendMode;
+        if (al_blender_mode >= Common::kNumBlendModes || al_blender_mode < kBlendMode_Normal)
+            al_blender_mode = Common::kBlendMode_Normal;
+
+        // here _transparency is used as alpha (between 1 and 254), but 0 means opaque!
+        GfxUtil::DrawSpriteBlend(surface, Point(drawAtX, drawAtY), bitmap->_bmp, al_blender_mode, false, true, bitmap->_transparency ? bitmap->_transparency : 255);
     }
   }
     // NOTE: following is experimental tint code (currently unused)

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -534,12 +534,8 @@ void ALSoftwareGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, Com
     }
     else
     {
-        Common::BlendMode al_blender_mode = (Common::BlendMode) bitmap->_blendMode;
-        if (al_blender_mode >= Common::kNumBlendModes || al_blender_mode < kBlendMode_Normal)
-            al_blender_mode = Common::kBlendMode_Normal;
-
         // here _transparency is used as alpha (between 1 and 254), but 0 means opaque!
-        GfxUtil::DrawSpriteBlend(surface, Point(drawAtX, drawAtY), bitmap->_bmp, al_blender_mode, false, true, bitmap->_transparency ? bitmap->_transparency : 255);
+        GfxUtil::DrawSpriteBlend(surface, Point(drawAtX, drawAtY), bitmap->_bmp, bitmap->_blendMode, false, true, bitmap->_transparency ? bitmap->_transparency : 255);
     }
   }
     // NOTE: following is experimental tint code (currently unused)

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -64,6 +64,7 @@ public:
     int GetColorDepth() override { return _colDepth; }
     void SetLightLevel(int lightLevel) override  { }
     void SetTint(int red, int green, int blue, int tintSaturation) override { }
+    void SetBlendMode(int blendMode) override { _blendMode = blendMode; }
 
     Bitmap *_bmp;
     int _width, _height;
@@ -73,6 +74,7 @@ public:
     bool _opaque; // no mask color
     bool _hasAlpha;
     int _transparency;
+    int _blendMode;
 
     ALSoftwareBitmap(Bitmap *bmp, bool opaque, bool hasAlpha)
     {
@@ -86,6 +88,7 @@ public:
         _transparency = 0;
         _opaque = opaque;
         _hasAlpha = hasAlpha;
+        _blendMode = 0;
     }
 
     int GetWidthToRender() { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -64,7 +64,7 @@ public:
     int GetColorDepth() override { return _colDepth; }
     void SetLightLevel(int lightLevel) override  { }
     void SetTint(int red, int green, int blue, int tintSaturation) override { }
-    void SetBlendMode(int blendMode) override { _blendMode = blendMode; }
+    void SetBlendMode(Common::BlendMode blendMode) override { _blendMode = blendMode; }
 
     Bitmap *_bmp;
     int _width, _height;
@@ -74,7 +74,7 @@ public:
     bool _opaque; // no mask color
     bool _hasAlpha;
     int _transparency;
-    int _blendMode;
+    Common::BlendMode _blendMode;
 
     ALSoftwareBitmap(Bitmap *bmp, bool opaque, bool hasAlpha)
     {
@@ -88,7 +88,7 @@ public:
         _transparency = 0;
         _opaque = opaque;
         _hasAlpha = hasAlpha;
-        _blendMode = 0;
+        _blendMode = Common::kBlend_Normal;
     }
 
     int GetWidthToRender() { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/gfx/blender.cpp
+++ b/Engine/gfx/blender.cpp
@@ -298,3 +298,108 @@ void set_argb2any_blender()
         _blender_alpha15, skiptranspixels_blender_alpha16, _blender_alpha24,
         0, 0, 0, 0xff); // TODO: do we need to support proper 15- and 24-bit here?
 }
+
+// ===============================
+// [AVD] Custom blenders for software BlendMode implementation
+// If we ditch software rendering we can remove this whole section
+
+#include <allegro/internal/aintern.h>
+
+#define BLEND(bpp, r, g, b)   _blender_trans##bpp(makecol##bpp(r, g, b), y, n)
+// some formulas from AGSBlend
+#define _BLENDOP_BURN(B,L) ((B + L < 255) ? 0:(B + L - 255)) // note: burn was called subtract
+#define _BLENDOP_LIGHTEN(B,L) ((L > B) ? L:B)
+#define _BLENDOP_DARKEN(B,L) ((L > B) ? B:L)
+#define _BLENDOP_EXCLUSION(B,L) (B + L - 2 * B * L / 255)
+#define _BLENDOP_SUBTRACT(B,L) (L - B < 0) ? 0:(L - B)
+
+unsigned long _blender_mask_alpha24(unsigned long blender_result, unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long src_alpha = geta32(x);
+    const unsigned long alphainv = 255 - src_alpha;
+    const unsigned long r = (getr24(blender_result)*src_alpha + alphainv*getr24(y)) / 255;
+    const unsigned long g = (getg24(blender_result)*src_alpha + alphainv*getg24(y)) / 255;
+    const unsigned long b = (getb24(blender_result)*src_alpha + alphainv*getb24(y)) / 255;
+    return r | g << 8 | b << 16;
+}
+// alegro's dodge blend was wrong, mine is not perfect either
+unsigned long _my_blender_dodge24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = (getr24(y)*n) / (256 - getr24(x));
+    const unsigned long j = (getg24(y)*n) / (256 - getg24(x));
+    const unsigned long k = (getb24(y)*n) / (256 - getb24(x));
+    return BLEND(24, h>255 ? 255 : h, j>255 ? 255 : j, k>255 ? 255 : k);
+}
+unsigned long _my_blender_burn24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = _BLENDOP_BURN(getr24(x), getr24(y));
+    const unsigned long j = _BLENDOP_BURN(getg24(x), getg24(y));
+    const unsigned long k = _BLENDOP_BURN(getb24(x), getb24(y));
+    return BLEND(24, h, j, k);
+}
+unsigned long _my_blender_lighten24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = _BLENDOP_LIGHTEN(getr24(x), getr24(y));
+    const unsigned long j = _BLENDOP_LIGHTEN(getg24(x), getg24(y));
+    const unsigned long k = _BLENDOP_LIGHTEN(getb24(x), getb24(y));
+    return BLEND(24, h, j, k);
+}
+unsigned long _my_blender_darken24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = _BLENDOP_DARKEN(getr24(x), getr24(y));
+    const unsigned long j = _BLENDOP_DARKEN(getg24(x), getg24(y));
+    const unsigned long k = _BLENDOP_DARKEN(getb24(x), getb24(y));
+    return BLEND(24, h, j, k);
+}
+unsigned long _my_blender_exclusion24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = _BLENDOP_EXCLUSION(getr24(x), getr24(y));
+    const unsigned long j = _BLENDOP_EXCLUSION(getg24(x), getg24(y));
+    const unsigned long k = _BLENDOP_EXCLUSION(getb24(x), getb24(y));
+    return BLEND(24, h, j, k);
+}
+unsigned long _my_blender_subtract24(unsigned long x, unsigned long y, unsigned long n)
+{
+    const unsigned long h = _BLENDOP_SUBTRACT(getr24(x), getr24(y));
+    const unsigned long j = _BLENDOP_SUBTRACT(getg24(x), getg24(y));
+    const unsigned long k = _BLENDOP_SUBTRACT(getb24(x), getb24(y));
+    return BLEND(24, h, j, k);
+}
+
+unsigned long _blender_masked_add32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_blender_add24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_dodge32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_dodge24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_burn32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_burn24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_lighten32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_lighten24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_darken32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_darken24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_exclusion32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_exclusion24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_subtract32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_my_blender_subtract24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_screen32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_blender_screen24(x, y, n), x, y, n);
+}
+unsigned long _blender_masked_multiply32(unsigned long x, unsigned long y, unsigned long n)
+{
+    return _blender_mask_alpha24(_blender_multiply24(x, y, n), x, y, n);
+}
+// ===============================

--- a/Engine/gfx/blender.h
+++ b/Engine/gfx/blender.h
@@ -62,4 +62,27 @@ void set_opaque_alpha_blender();
 // Sets argb2argb for 32-bit mode, and provides appropriate funcs for blending 32-bit onto 15/16/24-bit destination
 void set_argb2any_blender();
 
+// ===============================
+// [AVD] Custom blenders for software BlendMode implementation
+// If we ditch software rendering we can remove this whole section
+// not very pretty but forces the original alpha of "x" to "blender_result"
+unsigned long _blender_mask_alpha24(unsigned long blender_result, unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_dodge24(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_burn24(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_lighten24(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_darken24(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_exclusion24(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _my_blender_subtract24(unsigned long x, unsigned long y, unsigned long n);
+
+unsigned long _blender_masked_add32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_dodge32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_burn32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_lighten32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_darken32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_exclusion32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_subtract32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_screen32(unsigned long x, unsigned long y, unsigned long n);
+unsigned long _blender_masked_multiply32(unsigned long x, unsigned long y, unsigned long n);
+// ===============================
+
 #endif // __AC_BLENDER_H

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -33,6 +33,7 @@ public:
   virtual void SetStretch(int width, int height, bool useResampler = true) = 0;
   virtual void SetLightLevel(int light_level) = 0;   // 0-255
   virtual void SetTint(int red, int green, int blue, int tintSaturation) = 0;  // 0-255
+  virtual void SetBlendMode(int blendMode) = 0;
 
   virtual int GetWidth() = 0;
   virtual int GetHeight() = 0;

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -18,6 +18,8 @@
 #ifndef __AGS_EE_GFX__DDB_H
 #define __AGS_EE_GFX__DDB_H
 
+#include "gfx/gfx_def.h"
+
 namespace AGS
 {
 namespace Engine
@@ -33,7 +35,7 @@ public:
   virtual void SetStretch(int width, int height, bool useResampler = true) = 0;
   virtual void SetLightLevel(int light_level) = 0;   // 0-255
   virtual void SetTint(int red, int green, int blue, int tintSaturation) = 0;  // 0-255
-  virtual void SetBlendMode(int blendMode) = 0;
+  virtual void SetBlendMode(Common::BlendMode blendMode) = 0;
 
   virtual int GetWidth() = 0;
   virtual int GetHeight() = 0;

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -64,7 +64,6 @@ struct BlendModeSetter
 // NOTE: set NULL function pointer to fallback to common image blitting
 static const BlendModeSetter BlendModeSets[kNumBlendModes] =
 {
-    { nullptr, nullptr, nullptr, nullptr, nullptr }, // kBlendMode_NoAlpha
     { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, nullptr }, // kBlendMode_Alpha
     // NOTE: add new modes here
 };

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -15,6 +15,7 @@
 #include "core/platform.h"
 #include "gfx/gfx_util.h"
 #include "gfx/blender.h"
+#include <allegro/internal/aintern.h> // for blenders
 
 // CHECKME: is this hack still relevant?
 #if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
@@ -65,6 +66,15 @@ struct BlendModeSetter
 static const BlendModeSetter BlendModeSets[kNumBlendModes] =
 {
     { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, nullptr }, // kBlendMode_Alpha
+    { nullptr, _blender_masked_add32, _blender_add24, _blender_add24, nullptr }, // kBlendMode_Add
+    { nullptr, _blender_masked_darken32, _my_blender_darken24, _my_blender_darken24, nullptr }, // kBlendMode_Darken
+    { nullptr, _blender_masked_lighten32, _my_blender_lighten24, _my_blender_lighten24, nullptr }, // kBlendMode_Lighten
+    { nullptr, _blender_masked_multiply32, _blender_multiply24, _blender_multiply24, nullptr }, // kBlendMode_Multiply
+    { nullptr, _blender_masked_screen32, _blender_screen24, _blender_screen24, nullptr }, // kBlendMode_Screen
+    { nullptr, _blender_masked_burn32, _my_blender_burn24, _my_blender_burn24, nullptr }, // kBlendMode_Burn
+    { nullptr, _blender_masked_subtract32, _my_blender_subtract24, nullptr }, // kBlendMode_Subtract
+    { nullptr, _blender_masked_exclusion32, _my_blender_exclusion24, _my_blender_exclusion24, nullptr }, // kBlendMode_Exclusion
+    { nullptr, _blender_masked_dodge32, _my_blender_dodge24, _my_blender_dodge24, nullptr }, // kBlendMode_Dodge
     // NOTE: add new modes here
 };
 

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -65,16 +65,16 @@ struct BlendModeSetter
 // NOTE: set NULL function pointer to fallback to common image blitting
 static const BlendModeSetter BlendModeSets[kNumBlendModes] =
 {
-    { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, nullptr }, // kBlendMode_Alpha
-    { nullptr, _blender_masked_add32, _blender_add24, _blender_add24, nullptr }, // kBlendMode_Add
-    { nullptr, _blender_masked_darken32, _my_blender_darken24, _my_blender_darken24, nullptr }, // kBlendMode_Darken
-    { nullptr, _blender_masked_lighten32, _my_blender_lighten24, _my_blender_lighten24, nullptr }, // kBlendMode_Lighten
-    { nullptr, _blender_masked_multiply32, _blender_multiply24, _blender_multiply24, nullptr }, // kBlendMode_Multiply
-    { nullptr, _blender_masked_screen32, _blender_screen24, _blender_screen24, nullptr }, // kBlendMode_Screen
-    { nullptr, _blender_masked_burn32, _my_blender_burn24, _my_blender_burn24, nullptr }, // kBlendMode_Burn
-    { nullptr, _blender_masked_subtract32, _my_blender_subtract24, nullptr }, // kBlendMode_Subtract
-    { nullptr, _blender_masked_exclusion32, _my_blender_exclusion24, _my_blender_exclusion24, nullptr }, // kBlendMode_Exclusion
-    { nullptr, _blender_masked_dodge32, _my_blender_dodge24, _my_blender_dodge24, nullptr }, // kBlendMode_Dodge
+    { _argb2argb_blender, _argb2rgb_blender, _rgb2argb_blender, _opaque_alpha_blender, nullptr }, // kBlend_Alpha
+    { nullptr, _blender_masked_add32, _blender_add24, _blender_add24, nullptr }, // kBlend_Add
+    { nullptr, _blender_masked_darken32, _my_blender_darken24, _my_blender_darken24, nullptr }, // kBlend_Darken
+    { nullptr, _blender_masked_lighten32, _my_blender_lighten24, _my_blender_lighten24, nullptr }, // kBlend_Lighten
+    { nullptr, _blender_masked_multiply32, _blender_multiply24, _blender_multiply24, nullptr }, // kBlend_Multiply
+    { nullptr, _blender_masked_screen32, _blender_screen24, _blender_screen24, nullptr }, // kBlend_Screen
+    { nullptr, _blender_masked_burn32, _my_blender_burn24, _my_blender_burn24, nullptr }, // kBlend_Burn
+    { nullptr, _blender_masked_subtract32, _my_blender_subtract24, nullptr }, // kBlend_Subtract
+    { nullptr, _blender_masked_exclusion32, _my_blender_exclusion24, _my_blender_exclusion24, nullptr }, // kBlend_Exclusion
+    { nullptr, _blender_masked_dodge32, _my_blender_dodge24, _my_blender_dodge24, nullptr }, // kBlend_Dodge
     // NOTE: add new modes here
 };
 

--- a/Engine/gfx/gfx_util.h
+++ b/Engine/gfx/gfx_util.h
@@ -24,6 +24,7 @@
 #ifndef __AGS_EE_GFX__GFXUTIL_H
 #define __AGS_EE_GFX__GFXUTIL_H
 
+#include "ac/common_defines.h"
 #include "gfx/bitmap.h"
 #include "gfx/gfx_def.h"
 

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1324,17 +1324,17 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
     // Blend modes
     switch (bmpToDraw->_blendMode) {
         // blend mode is always NORMAL at this point
-        //case kBlendMode_Alpha: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA); break; // ALPHA
-        case kBlendMode_Add: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // ADD (transparency = strength)
-        case kBlendMode_Darken: AGS_D3DBLENDOP(D3DBLENDOP_MIN, D3DBLEND_ONE, D3DBLEND_ONE); break; // DARKEN
-        case kBlendMode_Lighten: AGS_D3DBLENDOP(D3DBLENDOP_MAX, D3DBLEND_ONE, D3DBLEND_ONE); break; // LIGHTEN
-        case kBlendMode_Multiply: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCCOLOR); break; // MULTIPLY
-        case kBlendMode_Screen: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_INVSRCCOLOR); break; // SCREEN
-        case kBlendMode_Subtract: AGS_D3DBLENDOP(D3DBLENDOP_REVSUBTRACT, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // SUBTRACT (transparency = strength)
-        case kBlendMode_Exclusion: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_INVDESTCOLOR, D3DBLEND_INVSRCCOLOR); break; // EXCLUSION
+        //case kBlend_Alpha: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA); break; // ALPHA
+        case kBlend_Add: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // ADD (transparency = strength)
+        case kBlend_Darken: AGS_D3DBLENDOP(D3DBLENDOP_MIN, D3DBLEND_ONE, D3DBLEND_ONE); break; // DARKEN
+        case kBlend_Lighten: AGS_D3DBLENDOP(D3DBLENDOP_MAX, D3DBLEND_ONE, D3DBLEND_ONE); break; // LIGHTEN
+        case kBlend_Multiply: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCCOLOR); break; // MULTIPLY
+        case kBlend_Screen: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_INVSRCCOLOR); break; // SCREEN
+        case kBlend_Subtract: AGS_D3DBLENDOP(D3DBLENDOP_REVSUBTRACT, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // SUBTRACT (transparency = strength)
+        case kBlend_Exclusion: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_INVDESTCOLOR, D3DBLEND_INVSRCCOLOR); break; // EXCLUSION
         // APPROXIMATIONS (need pixel shaders)
-        case kBlendMode_Burn: AGS_D3DBLENDOP(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
-        case kBlendMode_Dodge: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
+        case kBlend_Burn: AGS_D3DBLENDOP(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
+        case kBlend_Dodge: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
     }
 
     // BLENDMODES WORKAROUNDS - BEGIN
@@ -1345,17 +1345,17 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
         const int alpha = bmpToDraw->_transparency == 0 ? 255 : bmpToDraw->_transparency;
         const int invalpha = 255 - alpha;
         switch (bmpToDraw->_blendMode) {
-        case kBlendMode_Darken:
-        case kBlendMode_Multiply:
-        case kBlendMode_Burn: // FIXME burn is imperfect due to blend mode, darker than normal even when trasparent
+        case kBlend_Darken:
+        case kBlend_Multiply:
+        case kBlend_Burn: // FIXME burn is imperfect due to blend mode, darker than normal even when trasparent
             // fade to white
             direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_ADDSMOOTH);
             direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(invalpha, invalpha, invalpha, invalpha));
             break;
-        case kBlendMode_Lighten:
-        case kBlendMode_Screen:
-        case kBlendMode_Exclusion:
-        case kBlendMode_Dodge:
+        case kBlend_Lighten:
+        case kBlend_Screen:
+        case kBlend_Exclusion:
+        case kBlend_Dodge:
             // fade to black
             direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
             direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(alpha, alpha, alpha, alpha));
@@ -1366,7 +1366,7 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
     }
 
     // workaround: since the dodge is only half strength we can get a closer approx by drawing it twice
-    if (bmpToDraw->_blendMode == kBlendMode_Dodge)
+    if (bmpToDraw->_blendMode == kBlend_Dodge)
     {
         hr = direct3ddevice->DrawPrimitive(D3DPT_TRIANGLESTRIP, ti * 4, 2);
         if (hr != D3D_OK)

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -40,6 +40,11 @@ extern int dxmedia_play_video_3d(const char*filename, IDirect3DDevice9 *device, 
 extern void dxmedia_shutdown_3d();
 #endif
 
+#define AGS_D3DBLENDOP(blend_op, src_blend, dest_blend) \
+  direct3ddevice->SetRenderState(D3DRS_BLENDOP, blend_op); \
+  direct3ddevice->SetRenderState(D3DRS_SRCBLEND, src_blend); \
+  direct3ddevice->SetRenderState(D3DRS_DESTBLEND, dest_blend); \
+
 using namespace AGS::Common;
 
 // Necessary to update textures from 8-bit bitmaps
@@ -1316,12 +1321,69 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
     direct3ddevice->SetTransform(D3DTS_WORLD, &matTransform);
     direct3ddevice->SetTexture(0, bmpToDraw->_tiles[ti].texture);
 
+    // Blend modes
+    switch (bmpToDraw->_blendMode) {
+        // blend mode is always NORMAL at this point
+        //case kBlendMode_Alpha: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA); break; // ALPHA
+        case kBlendMode_Add: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // ADD (transparency = strength)
+        case kBlendMode_Darken: AGS_D3DBLENDOP(D3DBLENDOP_MIN, D3DBLEND_ONE, D3DBLEND_ONE); break; // DARKEN
+        case kBlendMode_Lighten: AGS_D3DBLENDOP(D3DBLENDOP_MAX, D3DBLEND_ONE, D3DBLEND_ONE); break; // LIGHTEN
+        case kBlendMode_Multiply: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ZERO, D3DBLEND_SRCCOLOR); break; // MULTIPLY
+        case kBlendMode_Screen: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_ONE, D3DBLEND_INVSRCCOLOR); break; // SCREEN
+        case kBlendMode_Subtract: AGS_D3DBLENDOP(D3DBLENDOP_REVSUBTRACT, D3DBLEND_SRCALPHA, D3DBLEND_ONE); break; // SUBTRACT (transparency = strength)
+        case kBlendMode_Exclusion: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_INVDESTCOLOR, D3DBLEND_INVSRCCOLOR); break; // EXCLUSION
+        // APPROXIMATIONS (need pixel shaders)
+        case kBlendMode_Burn: AGS_D3DBLENDOP(D3DBLENDOP_SUBTRACT, D3DBLEND_DESTCOLOR, D3DBLEND_INVDESTCOLOR); break; // LINEAR BURN (approximation)
+        case kBlendMode_Dodge: AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_DESTCOLOR, D3DBLEND_ONE); break; // fake color dodge (half strength of the real thing)
+    }
+
+    // BLENDMODES WORKAROUNDS - BEGIN
+
+    // allow transparency with blending modes
+    // darken/lighten the base sprite so a higher transparency value makes it trasparent
+    if (bmpToDraw->_blendMode > 0) {
+        const int alpha = bmpToDraw->_transparency == 0 ? 255 : bmpToDraw->_transparency;
+        const int invalpha = 255 - alpha;
+        switch (bmpToDraw->_blendMode) {
+        case kBlendMode_Darken:
+        case kBlendMode_Multiply:
+        case kBlendMode_Burn: // FIXME burn is imperfect due to blend mode, darker than normal even when trasparent
+            // fade to white
+            direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_ADDSMOOTH);
+            direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(invalpha, invalpha, invalpha, invalpha));
+            break;
+        case kBlendMode_Lighten:
+        case kBlendMode_Screen:
+        case kBlendMode_Exclusion:
+        case kBlendMode_Dodge:
+            // fade to black
+            direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+            direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(alpha, alpha, alpha, alpha));
+            break;
+        }
+        direct3ddevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+        direct3ddevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
+    }
+
+    // workaround: since the dodge is only half strength we can get a closer approx by drawing it twice
+    if (bmpToDraw->_blendMode == kBlendMode_Dodge)
+    {
+        hr = direct3ddevice->DrawPrimitive(D3DPT_TRIANGLESTRIP, ti * 4, 2);
+        if (hr != D3D_OK)
+        {
+            throw Ali3DException("IDirect3DDevice9::DrawPrimitive failed");
+        }
+    }
+    // BLENDMODES WORKAROUNDS - END
+
     hr = direct3ddevice->DrawPrimitive(D3DPT_TRIANGLESTRIP, ti * 4, 2);
     if (hr != D3D_OK) 
     {
       throw Ali3DException("IDirect3DDevice9::DrawPrimitive failed");
     }
 
+    // Restore default blending mode
+    AGS_D3DBLENDOP(D3DBLENDOP_ADD, D3DBLEND_SRCALPHA, D3DBLEND_INVSRCALPHA);
   }
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -73,7 +73,7 @@ public:
         _blue = blue;
         _tintSaturation = tintSaturation;
     }
-    void SetBlendMode(int blendMode) override  { _blendMode = blendMode; }
+    void SetBlendMode(Common::BlendMode blendMode) override  { _blendMode = blendMode; }
 
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
@@ -86,7 +86,7 @@ public:
     IDirect3DVertexBuffer9* _vertex;
     D3DTextureTile *_tiles;
     int _numTiles;
-    int _blendMode;
+    Common::BlendMode _blendMode;
 
     D3DBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -106,7 +106,7 @@ public:
         _vertex = NULL;
         _tiles = NULL;
         _numTiles = 0;
-        _blendMode = 0;
+        _blendMode = Common::kBlend_Normal;
     }
 
     int GetWidthToRender() { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -73,6 +73,7 @@ public:
         _blue = blue;
         _tintSaturation = tintSaturation;
     }
+    void SetBlendMode(int blendMode) override  { _blendMode = blendMode; }
 
     bool _flipped;
     int _stretchToWidth, _stretchToHeight;
@@ -85,6 +86,7 @@ public:
     IDirect3DVertexBuffer9* _vertex;
     D3DTextureTile *_tiles;
     int _numTiles;
+    int _blendMode;
 
     D3DBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -104,6 +106,7 @@ public:
         _vertex = NULL;
         _tiles = NULL;
         _numTiles = 0;
+        _blendMode = 0;
     }
 
     int GetWidthToRender() { return (_stretchToWidth > 0) ? _stretchToWidth : _width; }

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -398,7 +398,7 @@ void IAGSEngine::BlitSpriteTranslucent(int32 x, int32 y, BITMAP *bmp, int32 tran
     if (gfxDriver->UsesMemoryBackBuffer())
         GfxUtil::DrawSpriteWithTransparency(ds, &wrap, x, y, trans);
     else
-        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlendMode_Alpha, true, false, trans);
+        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlendMode_Normal, true, false, trans);
 }
 
 void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -398,7 +398,7 @@ void IAGSEngine::BlitSpriteTranslucent(int32 x, int32 y, BITMAP *bmp, int32 tran
     if (gfxDriver->UsesMemoryBackBuffer())
         GfxUtil::DrawSpriteWithTransparency(ds, &wrap, x, y, trans);
     else
-        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlendMode_Normal, true, false, trans);
+        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlend_Normal, true, false, trans);
 }
 
 void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)


### PR DESCRIPTION
This is mostly a copy of work by @AlanDrake (#1124). As much as I understood he did not have time to fix up his pr, so I picked his commits, did some cleanup, and also added few more things for consistency.

* Implements BlendMode type, which presents number of traditional sprite blend modes: Add, Darken, Lighten, Multiply, Screen, Burn, Subtract, Exclusion, Dodge;
* Added BlendMode property to Character, RoomObject, GUI, Overlay both in script and in the editor (except for Overlays, which cannot be created in editor).
* Implemented DrawingSurface.BlendImage and BlendSurface functions, which work like DrawImage and DrawSurface but accept BlendMode as an extra argument.

Known issues:
* BlendImage does not work if both sprites have alpha channel. This is actually a silly oversight because Alan's code did not provide software blender setup for this variant. There might be a way to make ones (by adjusting present ones?).
* Linear Burn and Dodge are approximations on D3D9/OGL, to work properly they might require writing a shader (In fact, maybe in the end we may switch completely to shaders here).
* (Android) Darken and Lighten don't work because GLES2 lacks GL_MIN/GL_MAX, but maybe GLES3 supports them
(then again, we may switch to shaders later).
* GUIControl seem to be the only remaining drawable object type that does not have BlendMode. This is unfortunately due to how its drawing on parent GUI is currently done in the engine (they are always drawn using simple software paint right to the parent's bitmap). I thought that adding blend operations there will result in suboptimal implementation. So I'd leave this until gui rendering is improved. A workaround for now is to create separate GUI for individual controls, and set their blending mode instead.
* EDIT: Ah, another object which is missing is ... mouse cursor. I am wondering where in API to add such property or function that sets blendmode. For instance, maybe it could be added to a cursor type (where cursor image etc are)? A workaround for now is again to make a gui with blending to work as a cursor.

Other references:
* posted by Alan in his pr: http://blog.onebyonedesign.com/unity/photoshop-blend-modes-for-unity3d/
