### PR TITLE
Editor: enforce a rebuild-all when running after upgrading the project

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -100,7 +100,7 @@ namespace AGS.Editor
          * 2: 3.4.0.1    - WorkspaceState section
          * 3: 3.5.0.11
         */
-        public const int LATEST_USER_DATA_XML_VERSION_INDEX = 3;
+        public const int LATEST_USER_DATA_XML_VERSION_INDEX = 4;
         public const string AUDIO_VOX_FILE_NAME = "audio.vox";
 
         private const string USER_DATA_FILE_NAME = GAME_FILE_NAME + USER_DATA_FILE_SUFFIX;
@@ -1235,6 +1235,8 @@ namespace AGS.Editor
 
             Utilities.EnsureStandardSubFoldersExist();
 
+            forceRebuild |= _game.WorkspaceState.RequiresRebuild;
+
             if (PreCompileGame != null)
             {
 				PreCompileGameEventArgs evArgs = new PreCompileGameEventArgs(forceRebuild);
@@ -1269,7 +1271,8 @@ namespace AGS.Editor
 					{
 						CreateCompiledFiles(errors, forceRebuild);
 					}
-				}
+                    _game.WorkspaceState.RequiresRebuild = false;
+                }
 			}
 
             Factory.GUIController.ShowOutputPanel(errors);

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -84,7 +84,8 @@ namespace AGS.Editor
 					Factory.GUIController.ShowMessage("This game was last saved with " +
                         ((game.SavedXmlEditorVersion == null) ? "an older version" : ("version " + game.SavedXmlEditorVersion))
                         + " of AGS. If you save it now, the game will be upgraded and previous versions of AGS will be unable to open it.", MessageBoxIcon.Information);
-				}
+                    game.WorkspaceState.RequiresRebuild = true;
+                }
 
 				return success;
             }

--- a/Editor/AGS.Types/WorkspaceState.cs
+++ b/Editor/AGS.Types/WorkspaceState.cs
@@ -31,6 +31,9 @@ namespace AGS.Types
             set { _lastBuildGameFileName = value; }
         }
 
+        [Browsable(false)]
+        public bool RequiresRebuild { get; set; } = false;
+
         // TODO: generic method of serializing key-value list in a string (or other xml element)
         private static string[] StringListSeparators = new string[] { "," };
         private static string[] KeyValueSeparators = new string[] { "=" };


### PR DESCRIPTION
Long overdue. When upgrading projects, the next run/compile should always do a "rebuild all". This will save us from bogus error reports, and that strange invalid character exception from the new compiler.

Now that I'm writing this I realize  it would be better to serialize this extra value in case the user closed the project without running, although adding parameters to the xml would be annoying if we want to backport this as a simple quality-of-life improvement.