### PR TITLE
New compiler: Forward struct declaration and actual declaration must match with respect to 'autoptr', 'builtin', and 'managed'

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -770,6 +770,12 @@ private:
 
     ErrorType HandleEndOfFuncBody(Symbol &struct_of_current_func, Symbol &name_of_current_func);
 
+    // Helper for ParseStruct_CheckForwardDecls()
+    ErrorType ParseStruct_GenerateForwardDeclError(Symbol stname, TypeQualifierSet tqs, TypeQualifier tq, VartypeFlag vtf);
+
+    // If there are forward declarations, check that their type qualifiers match 
+    ErrorType ParseStruct_CheckForwardDecls(Symbol stname, TypeQualifierSet tqs);
+
     void ParseStruct_SetTypeInSymboltable(Symbol stname, TypeQualifierSet tqs);
 
     // We have accepted something like "struct foo" and are waiting for "extends"

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1049,10 +1049,10 @@ TEST_F(Compile1, AttribInc) {
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
 
-TEST_F(Compile1, ManagedForwardStruct)
+TEST_F(Compile1,ForwardStructManaged)
 {
-    // If a struct is forward-declared as "managed" then its
-    // actual declaration must be "managed", too.
+    // Forward-declared structs must be 'managed', so the
+    // actual declaration must have the 'managed' keyword
 
     char *inpl = "\
         managed struct Object;              \n\
@@ -1065,4 +1065,60 @@ TEST_F(Compile1, ManagedForwardStruct)
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'managed'"));
+}
+
+TEST_F(Compile1, ForwardStructBuiltin)
+{
+    // Either the forward decl and the actual decl must both be 'builtin'
+    // or both be non-'builtin'.
+
+    char *inpl1 = "\
+        managed struct Object;              \n\
+        managed builtin struct Object       \n\
+        {                                   \n\
+        };                                  \n\
+        ";
+    int compile_result1 = cc_compile(inpl1, scrip);
+    std::string msg1 = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result1 >= 0) ? "Ok" : msg1.c_str());
+    EXPECT_NE(std::string::npos, msg1.find("'builtin'"));
+
+    char *inpl2 = "\
+        builtin managed struct Object;      \n\
+        managed struct Object               \n\
+        {                                   \n\
+        };                                  \n\
+        ";
+    int compile_result2 = cc_compile(inpl2, scrip);
+    std::string msg2 = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
+    EXPECT_NE(std::string::npos, msg2.find("'builtin'"));
+}
+
+TEST_F(Compile1, ForwardStructAutoptr)
+{
+    // Either the forward decl and the actual decl must both be 'autoptr'
+    // or both be non-'autoptr'.
+
+    char *inpl1 = "\
+        managed struct Object;              \n\
+        managed builtin struct Object       \n\
+        {                                   \n\
+        };                                  \n\
+        ";
+    int compile_result1 = cc_compile(inpl1, scrip);
+    std::string msg1 = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result1 >= 0) ? "Ok" : msg1.c_str());
+    EXPECT_NE(std::string::npos, msg1.find("'builtin'"));
+
+    char *inpl2 = "\
+        builtin managed struct Object;      \n\
+        managed struct Object               \n\
+        {                                   \n\
+        };                                  \n\
+        ";
+    int compile_result2 = cc_compile(inpl2, scrip);
+    std::string msg2 = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
+    EXPECT_NE(std::string::npos, msg2.find("'builtin'"));
 }

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1049,3 +1049,20 @@ TEST_F(Compile1, AttribInc) {
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
 
+TEST_F(Compile1, ManagedForwardStruct)
+{
+    // If a struct is forward-declared as "managed" then its
+    // actual declaration must be "managed", too.
+
+    char *inpl = "\
+        managed struct Object;              \n\
+        struct Object                       \n\
+        {                                   \n\
+            import attribute int Graphic;   \n\
+        } obj;                              \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'managed'"));
+}


### PR DESCRIPTION
This PR fixes the bug reported in issue #1195.

If a forward declaration of a struct has any of the qualifiers 'autoptr', 'builtin', or 'managed' then the actual declaration needs them, too. If OTOH the forward declaration doesn't, then the actual declaration may not have them. 