### PR TITLE
New compiler: Fix bug: Prevent assignments pointer ↔ dynamic array or allocation of 0 bytes

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2217,16 +2217,6 @@ AGS::ErrorType AGS::Parser::ParseExpression_CheckArgOfNew(Vartype argument_varty
 
     // Note: While it is an error to use a built-in type with new, it is
     // allowed to use a built-in type with new[].
-
-    if (0 == _sym.GetSize(argument_vartype))
-    {   
-        Error(
-            ReferenceMsgSym(
-                "Struct '%s' doesn't contain any variables, cannot use 'new' with it",
-                argument_vartype).c_str(),
-            _sym.GetName(argument_vartype).c_str());
-        return kERR_UserError;
-    }
     return kERR_None;
 }
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1996,6 +1996,10 @@ bool AGS::Parser::IsVartypeMismatch_Oneway(Vartype vartype_is, Vartype vartype_w
             !_sym.IsDynpointerVartype(vartype_wants_to_be) &&
             !_sym.IsDynarrayVartype(vartype_wants_to_be);
 
+    // Can only assign dynarray pointers to dynarray pointers.
+    if (_sym.IsDynarrayVartype(vartype_is) != _sym.IsDynarrayVartype(vartype_wants_to_be))
+        return true;
+
     // can convert String * to const string
     if (_sym.GetStringStructSym() == _sym.VartypeWithout(VTT::kDynpointer, vartype_is) &&
         kKW_String == _sym.VartypeWithout(VTT::kConst, vartype_wants_to_be))
@@ -2213,6 +2217,16 @@ AGS::ErrorType AGS::Parser::ParseExpression_CheckArgOfNew(Vartype argument_varty
 
     // Note: While it is an error to use a built-in type with new, it is
     // allowed to use a built-in type with new[].
+
+    if (0 == _sym.GetSize(argument_vartype))
+    {   
+        Error(
+            ReferenceMsgSym(
+                "Struct '%s' doesn't contain any variables, cannot use 'new' with it",
+                argument_vartype).c_str(),
+            _sym.GetName(argument_vartype).c_str());
+        return kERR_UserError;
+    }
     return kERR_None;
 }
 

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1096,10 +1096,9 @@ TEST_F(Compile1, DynptrDynarrayMismatch2)
 TEST_F(Compile1, ZeroMemoryAllocation1)
 {
 
-    // If a struct type doesn't contain any variables then there are zero
-    // bytes to allocate. The Engine really doesn't like allocating 0 bytes
-    // Note: It would be possible to allocate a block of 10 dynpointers, but
-    // then none of the dynpointers can be initialized.
+    // If a struct type doesn't contain any variables then there are zero bytes 
+    // to allocate. However, it _is_ legal to allocate a dynarray for the
+    // struct. (Its elements could be initialized via other means than new.)
 
     char *inpl = "\
         managed struct Strct                \n\
@@ -1113,8 +1112,7 @@ TEST_F(Compile1, ZeroMemoryAllocation1)
         ";
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
-    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("'Strct'"));
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
 
 TEST_F(Compile1, ZeroMemoryAllocation2)

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1095,7 +1095,11 @@ TEST_F(Compile1, DynptrDynarrayMismatch2)
 
 TEST_F(Compile1, ZeroMemoryAllocation1)
 {
-    // 
+
+    // If a struct type doesn't contain any variables then there are zero
+    // bytes to allocate. The Engine really doesn't like allocating 0 bytes
+    // Note: It would be possible to allocate a block of 10 dynpointers, but
+    // then none of the dynpointers can be initialized.
 
     char *inpl = "\
         managed struct Strct                \n\
@@ -1115,7 +1119,8 @@ TEST_F(Compile1, ZeroMemoryAllocation1)
 
 TEST_F(Compile1, ZeroMemoryAllocation2)
 {
-    // It is an error to assign a Dynpointer to a Dynarray variable
+    // If a struct type doesn't contain any variables then there are zero
+    // bytes to allocate. The Engine really doesn't like allocating 0 bytes
 
     char *inpl = "\
         managed struct Strct                \n\

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1029,6 +1029,111 @@ TEST_F(Compile1, ImportAutoptr2) {
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
 }
 
+TEST_F(Compile1, DynptrDynarrayMismatch1)
+{
+    // It is an error to assign a Dynpointer to a Dynarray variable
+
+    char *inpl = "\
+        managed struct Strct                \n\
+        {                                   \n\
+            int Payload;                    \n\
+        };                                  \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Strct *o[] = new Strct;         \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("assign"));
+}
+
+TEST_F(Compile1, DynptrDynarrayMismatch1a)
+{
+    // It is an error to assign a Dynpointer to a Dynarray variable
+
+    char *inpl = "\
+        managed struct Strct                \n\
+        {                                   \n\
+            int Payload;                    \n\
+        };                                  \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Strct *o[];                     \n\
+            o= new Strct;                   \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("assign"));
+}
+
+TEST_F(Compile1, DynptrDynarrayMismatch2)
+{
+    // It is an error to assign a Dynarray to a Dynpointer variable
+
+    char *inpl = "\
+        builtin managed struct Object       \n\
+        {                                   \n\
+            int Payload;                    \n\
+        };                                  \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Object *o = new Object[10];     \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("assign"));
+}
+
+TEST_F(Compile1, ZeroMemoryAllocation1)
+{
+    // 
+
+    char *inpl = "\
+        managed struct Strct                \n\
+        {                                   \n\
+        };                                  \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Strct *o[] = new Strct[10];     \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'Strct'"));
+}
+
+TEST_F(Compile1, ZeroMemoryAllocation2)
+{
+    // It is an error to assign a Dynpointer to a Dynarray variable
+
+    char *inpl = "\
+        managed struct Strct                \n\
+        {                                   \n\
+        };                                  \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Strct *o = new Strct;           \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'Strct'"));
+}
+
+
 TEST_F(Compile1, AttribInc) {
 
     // Import decls of autopointered variables must be processed correctly.


### PR DESCRIPTION
1.
The Engine doesn't grok allocating dynamic memory of size zero.
Typical code: 
 ```
managed struct S {}; // doesn't contain any variables (attributes and functions don't count here)

function oCupboard_Anyclick()
{
  S *structvar1 = new S;
  S *structvar2[] = new S[99];
}
```

2.
Cannot  assign dynamic array to a dynamic pointer or vice versa.
Typical code:
```
managed struct T {
    int payload;
};

function oCupboard_Anyclick()
{
    S *structvar3 = new S[99]; // dynamic array assigned to pointer variable
    S *structvar4[] = new S; // dynamic memory assigned to array variable
}
```