### PR TITLE
Bugfix: Zero-size variables must not get the stack out of sync

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2258,6 +2258,16 @@ AGS::ErrorType AGS::Parser::ParseExpression_New(SrcList &expression, ValueLocati
             Error("Expected '[' after the integer type '%s'", _sym.GetName(argument_vartype).c_str());
             return kERR_UserError;
         }
+        // Only do this check for new, not for new[]. 
+        if (0 == _sym.GetSize(argument_vartype))
+        {
+            Error(
+                ReferenceMsgSym(
+                    "Struct '%s' doesn't contain any variables, cannot use 'new' with it",
+                    argument_vartype).c_str(),
+                _sym.GetName(argument_vartype).c_str());
+            return kERR_UserError;
+        }
         element_vartype = argument_vartype;
         vartype = _sym.VartypeWith(VTT::kDynpointer, argument_vartype);
     }

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4442,12 +4442,12 @@ AGS::ErrorType AGS::Parser::ParseVardecl_Import(Symbol var_name)
 
 AGS::ErrorType AGS::Parser::ParseVardecl_Global(Symbol var_name, Vartype vartype, void *&initial_val_ptr)
 {
-
     if (kKW_Assign == _src.PeekNext())
     {
         ErrorType retval = ParseVardecl_InitialValAssignment(var_name, initial_val_ptr);
         if (retval < 0) return retval;
     }
+
     SymbolTableEntry &entry = _sym[var_name];
     entry.VariableD->Vartype = vartype;
     size_t const var_size = _sym.GetSize(vartype);
@@ -4470,6 +4470,9 @@ AGS::ErrorType AGS::Parser::ParseVardecl_Local(Symbol var_name, Vartype vartype)
 
     if (kKW_Assign != _src.PeekNext())
     {
+        if (var_size == 0)
+            return kERR_None;
+
         // Initialize the variable with binary zeroes.
         WriteCmd(SCMD_LOADSPOFFS, 0);
         if (is_dyn)
@@ -4530,6 +4533,12 @@ AGS::ErrorType AGS::Parser::ParseVardecl0(Symbol var_name, Vartype vartype, Scop
         ErrorType retval = ParseArray(var_name, vartype);
         if (retval < 0) return retval;
     }
+
+    // Don't warn for builtins or imports, they might have been predefined
+    if (!tqs[TQ::kBuiltin] && ScT::kImport != scope_type && 0 == _sym.GetSize(vartype))
+        Warning(
+            ReferenceMsgSym("Variable '%s' has zero size", vartype).c_str(),
+            _sym.GetName(var_name).c_str());
 
     // Enter the variable into the symbol table
     ErrorType retval = ParseVardecl_Var2SymTable(var_name, vartype, scope_type);

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -1935,42 +1935,40 @@ TEST_F(Bytecode0, Struct05) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct05", scrip);
-    const size_t codesize = 40;
+    size_t const codesize = 33;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,    0,    1,    1,    // 7
-       0,    6,    3,    7,           34,    3,   39,    1,    // 15
-       6,    3,    0,   33,            3,   35,    1,   34,    // 23
-       3,   39,    1,    6,            3,    0,   33,    3,    // 31
-      35,    1,   31,    3,            6,    3,    0,    5,    // 39
-     -999
+      38,    0,    6,    3,            7,   34,    3,   39,    // 7
+       1,    6,    3,    0,           33,    3,   35,    1,    // 15
+      34,    3,   39,    1,            6,    3,    0,   33,    // 23
+       3,   35,    1,   31,            3,    6,    3,    0,    // 31
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 2;
+    size_t const numfixups = 2;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      18,   29,  -999
+      11,   22,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 1;
+    int const numimports = 1;
     std::string imports[] = {
     "StructO::StInt^1",            "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
-
 }
 
 TEST_F(Bytecode0, Struct06) {

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -1859,7 +1859,7 @@ TEST_F(Compile0, AssignPtr2ArrayOfPtr) {
 
     std::string agscode = "\
         managed struct DynamicSprite            \n\
-        {                                       \n\
+         {                                       \n\
             import static DynamicSprite         \n\
                 *Create(int width, int height, bool hasAlphaChannel = false);   \n\
         };                                      \n\


### PR DESCRIPTION
Fix bug: A runtime error occurred whenever a program created a variable of size zero.

Typical code:
```
struct EmptyStruct {
};

function game_start()
{
  EmptyStruct s;
}
```

