### PR TITLE
Editor: adjustments for room panning controls

### DIFF
--- a/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
+++ b/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
@@ -367,6 +367,10 @@ namespace AGS.Editor
                 }
                 _flipThroughPanesIndex = 0;
             }
+            else if (_currentPane != null)
+            {
+                return _currentPane.Control.KeyReleased(key);
+            }
             return false;
         }
 

--- a/Editor/AGS.Editor/Panes/FreePanControl.cs
+++ b/Editor/AGS.Editor/Panes/FreePanControl.cs
@@ -106,7 +106,11 @@ namespace AGS.Editor
             base.OnMouseMove(e);
         }
 
+        // Override mouse wheel to avoid automatic scrolling: this is conflicting with scrolling done by separate controls now
+        // TODO: perhaps it would be better to move wheel controls here from RoomSettingsEditor_MouseWheel to make things more consistent,
+        // but looks like that would require more refactoring done over both classes.
+        protected override void OnMouseWheel(MouseEventArgs e)
+        { // do nothing here
+        }
     }
 }
-
-

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -38,8 +38,9 @@ namespace AGS.Editor
         private int _menuClickY;
         private object _startNode; // track breadcrumbs path so that it can be compared when saving
 
-        private int ZOOM_STEP_VALUE = 25;
-        private int ZOOM_MAX_VALUE = 600;
+        private const int ZOOM_STEP_VALUE = 25;
+        private const int ZOOM_MAX_VALUE = 600;
+        private bool _isChangingZoom = false;
         private RoomEditorState _state = new RoomEditorState();
 
         /// <summary>
@@ -91,10 +92,6 @@ namespace AGS.Editor
             InitializeComponent();
             Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _room = room;
-            sldZoomLevel.Maximum = ZOOM_MAX_VALUE / ZOOM_STEP_VALUE;
-            sldZoomLevel.Value = 100 / ZOOM_STEP_VALUE;
-            // TODO: choose default zoom based on the room size vs window size?
-            SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
 
             _emptyLayer = new EmptyEditorFilter(bufferedPanel1, _room);
             _layers.Add(new EdgesEditorFilter(bufferedPanel1, _room));
@@ -118,6 +115,11 @@ namespace AGS.Editor
 
             RepopulateBackgroundList(0);
             UpdateScrollableWindowSize();
+            sldZoomLevel.Maximum = ZOOM_MAX_VALUE / ZOOM_STEP_VALUE;
+            sldZoomLevel.Value = 100 / ZOOM_STEP_VALUE;
+            // TODO: choose default zoom based on the room size vs window size?
+            SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
+
             MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
             bufferedPanel1.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
             sldZoomLevel.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
@@ -278,18 +280,21 @@ namespace AGS.Editor
             // Ctrl + Wheel = zoom
             if (ModifierKeys == Keys.Control)
             {
+                // For zooming with mouse wheel we use current mouse position as anchor
+                // (ofcourse we need to translate it to the panel position)
+                Point anchor = bufferedPanel1.PointToClient(Cursor.Position);
                 if (e.Delta > 0)
                 {
                     if (sldZoomLevel.Value < sldZoomLevel.Maximum)
                     {
-                        sldZoomLevel.Value++;
+                        ChangeZoom(sldZoomLevel.Value + 1, anchor);
                     }
                 }
                 else
                 {
                     if (sldZoomLevel.Value > sldZoomLevel.Minimum)
                     {
-                        sldZoomLevel.Value--;
+                        ChangeZoom(sldZoomLevel.Value - 1, anchor);
                     }
                 }
             }
@@ -303,7 +308,6 @@ namespace AGS.Editor
             {
                 bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) - e.Delta);
             }
-			sldZoomLevel_Scroll(null, null);
             // Ridiculous solution, found on stackoverflow.com
             // TODO: check again later, how reliable this is?!
             HandledMouseEventArgs ee = (HandledMouseEventArgs)e;
@@ -313,7 +317,7 @@ namespace AGS.Editor
         private void SetZoomSliderToMultiplier(int factor)
         {
             sldZoomLevel.Value = (100 * factor) / ZOOM_STEP_VALUE;
-            sldZoomLevel_Scroll(null, null);
+            ChangeZoom(sldZoomLevel.Value, Point.Empty);
         }
 
         private void UpdateScrollableWindowSize()
@@ -344,7 +348,7 @@ namespace AGS.Editor
 
         private void bufferedPanel1_Paint(object sender, PaintEventArgs e)
         {
-            _state.UpdateScroll(bufferedPanel1.AutoScrollPosition);
+            _state.Offset = new Point(-bufferedPanel1.AutoScrollPosition.X, -bufferedPanel1.AutoScrollPosition.Y);
 
             int scaleFactor = 1;
 
@@ -560,8 +564,6 @@ namespace AGS.Editor
 
                         // TODO: choose default zoom based on the room size vs window size?
                         SetZoomSliderToMultiplier(_room.Width <= 320 ? 2 : 1);
-						sldZoomLevel_Scroll(null, null);
-						UpdateScrollableWindowSize();
                     }
                 }
                 catch (Exception ex)
@@ -931,20 +933,52 @@ namespace AGS.Editor
             }
         }
 
+        /// <summary>
+        /// Set new zoom level and updates controls accordingly.
+        /// </summary>
+        /// <param name="zoom">Zoom level in ZOOM_STEP_VALUE percents.</param>
+        /// <param name="anchor">The room point of reference which must retain its position after zoom.
+        /// This point should be given in the ** window ** coordinates though (best to think as a point
+        /// under mouse cursor, or center of the panel).
+        /// </param>
+        private void ChangeZoom(int zoom, Point anchor)
+        {
+            _isChangingZoom = true; // set the flag to prevent controls reupdating themselves infinitely
+
+            float oldScale = _state.Scale;
+            Point oldOffset = _state.Offset;
+
+            // Update scale
+            float newScale = zoom * ZOOM_STEP_VALUE * 0.01f;
+            _state.Scale = newScale;
+            UpdateScrollableWindowSize();
+
+            // Update offset
+            Point newOffset = RoomEditorState.RecalcOffset(bufferedPanel1.ClientSize, oldOffset, oldScale, newScale, anchor);
+            newOffset.X = Math.Min(bufferedPanel1.AutoScrollMinSize.Width, newOffset.X);
+            newOffset.Y = Math.Min(bufferedPanel1.AutoScrollMinSize.Height, newOffset.Y);
+            newOffset.X = Math.Max(0, newOffset.X);
+            newOffset.Y = Math.Max(0, newOffset.Y);
+            _state.Offset = newOffset;
+
+            // Update scroll positions and redraw
+            bufferedPanel1.HorizontalScroll.Value = _state.Offset.X;
+            bufferedPanel1.VerticalScroll.Value = _state.Offset.Y;
+            bufferedPanel1.Invalidate();
+            // Update slider position (in case zoom was set by other controls)
+            sldZoomLevel.Value = zoom;
+            // Update label text
+            lblZoomInfo.Text = String.Format("{0}%", zoom * ZOOM_STEP_VALUE);
+            _isChangingZoom = false;
+        }
+
         private void sldZoomLevel_Scroll(object sender, EventArgs e)
 		{
-            lblZoomInfo.Text = String.Format("{0}%", sldZoomLevel.Value * ZOOM_STEP_VALUE);
-
-            int oldPosX = _state.WindowSizeToRoom(bufferedPanel1.HorizontalScroll.Value);
-            int oldPosY = _state.WindowSizeToRoom(bufferedPanel1.VerticalScroll.Value);
-
-            _state.Scale = sldZoomLevel.Value * ZOOM_STEP_VALUE * 0.01f;
-            UpdateScrollableWindowSize();
-            
-            bufferedPanel1.HorizontalScroll.Value = _state.RoomSizeToWindow(oldPosX);
-            bufferedPanel1.VerticalScroll.Value = _state.RoomSizeToWindow(oldPosY);
-            bufferedPanel1.Invalidate();
-		}
+            if (_isChangingZoom)
+                return;
+            // for the zoom slider we use center of panel as anchor
+            ChangeZoom(sldZoomLevel.Value, new Point(bufferedPanel1.ClientSize.Width / 2, bufferedPanel1.ClientSize.Height / 2));
+        }
 
 		private void sldTransparency_Scroll(object sender, EventArgs e)
 		{
@@ -996,8 +1030,7 @@ namespace AGS.Editor
         // Multiplier, defining convertion between room and editor coords.
         private float _scale;
         // Offsets, in window coordinates.
-        private int _scrollOffsetX;
-        private int _scrollOffsetY;
+        private Point _scrollOffset;
 
         internal Cursor CurrentCursor;
         internal bool DragFromCenter;
@@ -1009,22 +1042,22 @@ namespace AGS.Editor
 
         internal int WindowXToRoom(int x)
         {
-            return (int)((x + _scrollOffsetX) / _scale);
+            return (int)((x + _scrollOffset.X) / _scale);
         }
 
         internal int WindowYToRoom(int y)
         {
-            return (int)((y + _scrollOffsetY) / _scale);
+            return (int)((y + _scrollOffset.Y) / _scale);
         }
 
         internal int RoomXToWindow(int x)
         {
-            return (int)(x * _scale) - _scrollOffsetX;
+            return (int)(x * _scale) - _scrollOffset.X;
         }
 
         internal int RoomYToWindow(int y)
         {
-            return (int)(y * _scale) - _scrollOffsetY;
+            return (int)(y * _scale) - _scrollOffset.Y;
         }
 
         internal int RoomSizeToWindow(int sz)
@@ -1043,23 +1076,42 @@ namespace AGS.Editor
         internal float Scale
         {
             get { return _scale; }
-            set
-            {
-                float oldScale = _scale;
-                _scale = value;
-                _scrollOffsetX = (int)((_scrollOffsetX / oldScale) * _scale);
-                _scrollOffsetY = (int)((_scrollOffsetY / oldScale) * _scale);
-            }
+            set { _scale = value; }
         }
 
         /// <summary>
-        /// Updates offset using current scrollbar position.
+        /// Offset of the Room image on screen.
         /// </summary>
-        /// <param name="scrollPt">Scroll position in window coordinates.</param>
-        internal void UpdateScroll(Point scrollPt)
+        internal Point Offset
         {
-            _scrollOffsetX = -scrollPt.X;
-            _scrollOffsetY = -scrollPt.Y;
+            get { return _scrollOffset; }
+            set { _scrollOffset = value; }
+        }
+
+        /// <summary>
+        /// Recalculates resulting image offsets, depending on the changing zoom and anchor point.
+        /// </summary>
+        // TODO: move this elsewhere, this kind of logic should perhaps take place in a dedicated control.
+        // FreePanControl?
+        /// <param name="windowSize">The size of the control containing the zoomable image.</param>
+        /// <param name="curOffset"></param>
+        /// <param name="oldScale"></param>
+        /// <param name="newScale"></param>
+        /// <param name="anchor">Anchor point in * window * coordinates.</param>
+        /// <returns>Image offset in * window * coordinates</returns>
+        internal static Point RecalcOffset(Size windowSize, Point curOffset, float oldScale, float newScale, Point anchor)
+        {
+            // The idea here is that the anchor point defines the room location that must remain
+            // * under same window location * after the rescaling.
+            // In other words, the distance from window sides to this point must be same with old and new zoom.
+            // Since the anchor is already given to us in window coordinates, its meaning is equal to distance from window's left-top;
+            // this distance will remain the same, what will change is the distance in * room coordinates * (because room scale changes).
+            
+            Point roomAnchor = new Point((int)((anchor.X + curOffset.X) / oldScale), (int)((anchor.Y + curOffset.Y) / oldScale));
+            Point newRoomDist = new Point((int)(anchor.X / newScale), (int)(anchor.Y / newScale));
+            Point newRoomLT = new Point(roomAnchor.X - newRoomDist.X, roomAnchor.Y - newRoomDist.Y);
+            Point newWindowLT = new Point((int)(newRoomLT.X * newScale), (int)(newRoomLT.Y * newScale));
+            return newWindowLT;
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -118,9 +118,10 @@ namespace AGS.Editor
 
             RepopulateBackgroundList(0);
             UpdateScrollableWindowSize();
-			this.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
-			this.bufferedPanel1.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
-            this.sldZoomLevel.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            bufferedPanel1.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            sldZoomLevel.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            cmbBackgrounds.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
             bufferedPanel1.PanButtons = MouseButtons.Middle;
 
             _editorConstructed = true;
@@ -274,21 +275,34 @@ namespace AGS.Editor
                 
         private void RoomSettingsEditor_MouseWheel(object sender, MouseEventArgs e)
 		{
-			int movement = e.Delta;
-			if (movement > 0)
-			{
-				if (sldZoomLevel.Value < sldZoomLevel.Maximum)
-				{
-					sldZoomLevel.Value++;
-				}
-			}
-			else
-			{
-				if (sldZoomLevel.Value > sldZoomLevel.Minimum)
-				{
-					sldZoomLevel.Value--;
-				}
-			}
+            // Ctrl + Wheel = zoom
+            if (ModifierKeys == Keys.Control)
+            {
+                if (e.Delta > 0)
+                {
+                    if (sldZoomLevel.Value < sldZoomLevel.Maximum)
+                    {
+                        sldZoomLevel.Value++;
+                    }
+                }
+                else
+                {
+                    if (sldZoomLevel.Value > sldZoomLevel.Minimum)
+                    {
+                        sldZoomLevel.Value--;
+                    }
+                }
+            }
+            // Shift + Wheel = scroll horizontal
+            else if (ModifierKeys == Keys.Shift)
+            {
+                bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X) - e.Delta, Math.Abs(bufferedPanel1.AutoScrollPosition.Y));
+            }
+            // Wheel without modifiers = scroll vertical
+            else if(ModifierKeys == Keys.None)
+            {
+                bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) - e.Delta);
+            }
 			sldZoomLevel_Scroll(null, null);
             // Ridiculous solution, found on stackoverflow.com
             // TODO: check again later, how reliable this is?!

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -121,6 +121,7 @@ namespace AGS.Editor
 			this.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
 			this.bufferedPanel1.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
             this.sldZoomLevel.MouseWheel += new MouseEventHandler(RoomSettingsEditor_MouseWheel);
+            bufferedPanel1.PanButtons = MouseButtons.Middle;
 
             _editorConstructed = true;
         }
@@ -759,63 +760,65 @@ namespace AGS.Editor
 			return (focused == this.ActiveControl);*/
 		}
 
-		private bool ProcessZoomAndPanKeyPresses(Keys keyData)
-		{
-			if (keyData == Keys.Down)
-			{
-				bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) + 50);
-			}
-			else if (keyData == Keys.Up)
-			{
-				bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) - 50);
-			}
-			else if (keyData == Keys.Right)
-			{
-				bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X) + 50, Math.Abs(bufferedPanel1.AutoScrollPosition.Y));
-			}
-			else if (keyData == Keys.Left)
-			{
-				bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X) - 50, Math.Abs(bufferedPanel1.AutoScrollPosition.Y));
-			}
-			else if (keyData == Keys.Space)
-			{
-				if (sldZoomLevel.Value < sldZoomLevel.Maximum)
-				{
-					sldZoomLevel.Value++;
-				}
-				else
-				{
-					sldZoomLevel.Value = sldZoomLevel.Minimum;
-				}
-				sldZoomLevel_Scroll(null, null);
-			}
-			else
-			{
-				return false;
-			}
-
-			return true;
+		private bool ProcessPanKeyPress(Keys keyData)
+        {
+            switch (keyData)
+            {
+            case Keys.Down:
+	            bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) + 50);
+                return true;
+            case Keys.Up:
+	            bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X), Math.Abs(bufferedPanel1.AutoScrollPosition.Y) - 50);
+                return true;
+            case Keys.Right:
+	            bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X) + 50, Math.Abs(bufferedPanel1.AutoScrollPosition.Y));
+                return true;
+            case Keys.Left:
+	            bufferedPanel1.AutoScrollPosition = new Point(Math.Abs(bufferedPanel1.AutoScrollPosition.X) - 50, Math.Abs(bufferedPanel1.AutoScrollPosition.Y));
+                return true;
+            case Keys.Space:
+                bufferedPanel1.PanButtons |= MouseButtons.Left;
+                return true;
+            }
+			return false;
 		}
+
+        private bool ProcessPanKeyRelease(Keys keyData)
+        {
+            switch (keyData)
+            {
+                case Keys.Space:
+                    bufferedPanel1.PanButtons &= ~MouseButtons.Left;
+                    return true;
+            }
+            return false;
+        }
 
 		protected override bool HandleKeyPress(Keys keyData)
 		{
-			bool returnHandled = true;
-
             if (!DoesThisPanelHaveFocus())
             {
                 return false;
             }
+
             if (_layer != null && !IsLocked(_layer) && _layer.KeyPressed(keyData))
             {
                 bufferedPanel1.Invalidate();
                 Factory.GUIController.RefreshPropertyGrid();
+                return true;
             }
-            else if (!ProcessZoomAndPanKeyPresses(keyData))
-            {
-                returnHandled = false;
-            }			
-			return returnHandled;
+            return ProcessPanKeyPress(keyData);
 		}
+
+        protected override bool HandleKeyRelease(Keys keyData)
+        {
+            if (!DoesThisPanelHaveFocus())
+            {
+                return false;
+            }
+
+            return ProcessPanKeyRelease(keyData);
+        }
 
         private void ShowCoordMenu(MouseEventArgs e)
         {

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -611,7 +611,7 @@ namespace AGS.Editor
                 }
                 if (!handled)
                 {
-                    if (e.Button == MouseButtons.Middle)
+                    if (e.Button == MouseButtons.Right && ModifierKeys == Keys.Shift)
                     {
                         ShowCoordMenu(e);
                     }

--- a/Editor/AGS.Types/EditorFeatures/EditorContentPanel.cs
+++ b/Editor/AGS.Types/EditorFeatures/EditorContentPanel.cs
@@ -60,6 +60,16 @@ namespace AGS.Types
 			return false;
 		}
 
+        public bool KeyReleased(Keys keyData)
+        {
+            if (HandleKeyRelease(keyData))
+            {
+                return true;
+            }
+            OnKeyReleased(keyData);
+            return false;
+        }
+
 		/// <summary>
 		/// Attempts to handle a key press, and returns true if it has done.
 		/// </summary>
@@ -76,10 +86,26 @@ namespace AGS.Types
 		{
 		}
 
-		/// <summary>
-		/// This panel has just become the active one
+        /// <summary>
+		/// Attempts to handle a key release, and returns true if it has done.
 		/// </summary>
-		public void WindowActivated()
+		protected virtual bool HandleKeyRelease(Keys keyData)
+        {
+            return false;
+        }
+
+        /// <summary>
+		/// Process a key release, but cannot mark it as handled.
+		/// </summary>
+		/// <param name="keyData"></param>
+        protected virtual void OnKeyReleased(Keys keyData)
+        {
+        }
+
+        /// <summary>
+        /// This panel has just become the active one
+        /// </summary>
+        public void WindowActivated()
 		{
 			OnWindowActivated();
 		}


### PR DESCRIPTION
For #613, adjust panning & zoom controls as suggested in comments.

* added PanButtons property to FreePanControl and use that instead of hardcoding which buttons to use;
* pass another event (on key up) through from the parent EditorContentPanel class to Room editor pane to be able to react to released keys there;
* changed room panning from Ctrl+Shift+LClick to Space+LClick; Middle mouse button also works.
I did not really know how to better organize this. FreePanControl is not guaranteed to have focus, so it's not possible to catch press and release events there. What I did: made RoomSettingsEditor do that instead, and toggle FreePanControl's PanButtons to allow and disallow Left Click as Space is pressed and released.
If it's bad, I can maybe add methods for passing key pressed/release in FreePanControl, but that seemed a bit ugly.
* Changed room context menu call to Shift+RClick. I also tried to implement suggestion from comments and use middle button "when mouse did not move", but it worked very unreliably. Maybe I did not do something right.
* New controls for scroll/zoom:
    - wheel w/o modifiers: scroll vertically;
    - wheel + Shift: scroll horizontally;
    - wheel + Ctrl: zoom
