### PR TITLE
(Test) AGS 4: use standard ColorDialog as a color picker for properties

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -66,6 +66,8 @@ namespace AGS.Editor
 
         private string _timerScriptName;
         private string _timerSearchForText;
+        // Custom color table for the ColorDialog
+        private int[] _customColors = null;
 
         private GUIController()
         {
@@ -835,6 +837,7 @@ namespace AGS.Editor
                 ScriptFunctionUIEditor.CreateScriptFunction = new ScriptFunctionUIEditor.CreateScriptFunctionHandler(ScriptFunctionUIEditor_CreateScriptFunction);
                 RoomMessagesUIEditor.ShowRoomMessagesEditor = new RoomMessagesUIEditor.RoomMessagesEditorType(ShowRoomMessageEditorFromPropertyGrid);
                 CustomResolutionUIEditor.CustomResolutionSetGUI = new CustomResolutionUIEditor.CustomResolutionGUIType(ShowCustomResolutionChooserFromPropertyGrid);
+                ColorUIEditor.ColorGUI = new ColorUIEditor.ColorGUIType(ShowColorDialog);
             }
         }
 
@@ -1364,6 +1367,18 @@ namespace AGS.Editor
         private Size ShowCustomResolutionChooserFromPropertyGrid(Size currentSize)
         {
             return CustomResolutionDialog.Show(currentSize);
+        }
+
+        private Color ShowColorDialog(Color color)
+        {
+            ColorDialog dialog = new ColorDialog();
+            dialog.Color = color;
+            dialog.FullOpen = true;
+            dialog.SolidColorOnly = true;
+            dialog.CustomColors = _customColors;
+            dialog.ShowDialog();
+            _customColors = (int[])dialog.CustomColors.Clone();
+            return dialog.Color;
         }
 
         private void ShowPropertiesEditorFromPropertyGrid(CustomProperties props, object objectThatHasProperties)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Plugins\IAGSEditor.cs" />
     <Compile Include="Plugins\IAGSEditorPlugin.cs" />
     <Compile Include="Plugins\RequiredAGSVersionAttribute.cs" />
+    <Compile Include="PropertyGridExtras\ColorUIEditor.cs" />
     <Compile Include="PropertyGridExtras\CustomPropertiesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -245,6 +245,7 @@ namespace AGS.Types
         [DisplayName("SpeechColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color SpeechColorRGB
         {
             get

--- a/Editor/AGS.Types/GUI.cs
+++ b/Editor/AGS.Types/GUI.cs
@@ -61,6 +61,7 @@ namespace AGS.Types
         [DisplayName("BackgroundColour")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color BackgroundColorRGB
         {
             get

--- a/Editor/AGS.Types/GUIButton.cs
+++ b/Editor/AGS.Types/GUIButton.cs
@@ -101,6 +101,7 @@ namespace AGS.Types
         [DisplayName("TextColour")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color TextColorRGB
         {
             get

--- a/Editor/AGS.Types/GUILabel.cs
+++ b/Editor/AGS.Types/GUILabel.cs
@@ -56,6 +56,7 @@ namespace AGS.Types
         [DisplayName("TextColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color TextColorRGB
         {
             get

--- a/Editor/AGS.Types/GUIListBox.cs
+++ b/Editor/AGS.Types/GUIListBox.cs
@@ -96,6 +96,7 @@ namespace AGS.Types
         [DisplayNameAttribute("TextColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color TextColorRGB
         {
             get
@@ -123,6 +124,7 @@ namespace AGS.Types
         [DisplayName("SelectedTextColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color SelectedTextColorRGB
         {
             get
@@ -150,6 +152,7 @@ namespace AGS.Types
         [DisplayName("SelectedBackgroundColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color SelectedBackgroundColorRGB
         {
             get

--- a/Editor/AGS.Types/GUITextBox.cs
+++ b/Editor/AGS.Types/GUITextBox.cs
@@ -62,6 +62,7 @@ namespace AGS.Types
         [DisplayName("TextColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color TextColorRGB
         {
             get

--- a/Editor/AGS.Types/NormalGUI.cs
+++ b/Editor/AGS.Types/NormalGUI.cs
@@ -183,6 +183,7 @@ namespace AGS.Types
         [DisplayName("BorderColor")]
         [RefreshProperties(RefreshProperties.All)]
         [AGSNoSerialize]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color BorderColorRGB
         {
             get

--- a/Editor/AGS.Types/PaletteEntry.cs
+++ b/Editor/AGS.Types/PaletteEntry.cs
@@ -26,6 +26,7 @@ namespace AGS.Types
         [Description("The colour represented by this palette index")]
         [Category("Appearance")]
         [DisplayName(PROPERTY_COLOR_RGB)]
+        [Editor(typeof(ColorUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
         public Color Colour
         {
             get { return _color; }

--- a/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Design;
+
+namespace AGS.Types
+{
+    public class ColorUIEditor : UITypeEditor
+    {
+        public delegate Color ColorGUIType(Color color);
+        public static ColorGUIType ColorGUI;
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.DropDown;
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            Color color = (Color)value;
+            if (ColorGUI != null)
+            {
+                color = ColorGUI(color);
+            }
+            return color;
+        }
+    }
+}

--- a/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ColorUIEditor.cs
@@ -24,5 +24,19 @@ namespace AGS.Types
             }
             return color;
         }
+
+        public override bool GetPaintValueSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override void PaintValue(PaintValueEventArgs e)
+        {
+            Color color = (Color)e.Value;
+            using (SolidBrush brush = new SolidBrush(color))
+            {
+                e.Graphics.FillRectangle(brush, e.Bounds);
+            }
+        }
     }
 }


### PR DESCRIPTION
This is frankly just a quick experiment, and I don't know if it looks good and convenient to use. It seems working though.

Introduced UITypeEditor wrapper over classic ColorDialog. Set it as an editor for each game property of type Color. This replaces default color picker called by property grid, which is not good for AGS Editor at all.

Caveats:
* ColorDialog is from System.Windows.Forms, if that matters. EDIT: made the UITypeEditor class in AGS.Types to use delegate instead of directly referencing Windows.Forms namespace.
* ColorDialog is modal and appears at the center of the screen, as opposed to default non-modal color picker that was displayed right next to the property.
* I made it save "custom colors" array in a static variable, so it will persist during editor session, but it's not serialized in project files.


PS. On second thought, I myself don't like this variant very much either. It might be better to find a proper color picker control with a RGB circle or similar, which would be compatible with UITypeEditor or already implemented as one.
