### PR TITLE
Script API: implement Overlay.ZOrder

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -942,6 +942,8 @@ builtin managed struct Overlay {
   import attribute BlendMode BlendMode;
   /// Gets/sets the transparency of this overlay.
   import attribute int Transparency;
+  /// Gets/sets the overlay's z-order relative to other overlays and on-screen objects.
+  import attribute int ZOrder;
 #endif
 };
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -158,7 +158,7 @@ struct SpriteListEntry
     IDriverDependantBitmap *bmp = nullptr;
     int transparent = 0;
     int x = 0, y = 0;
-    int baseline = 0;
+    int zorder = 0;
     // Tells if this item should take priority during sort if z1 == z2
     // TODO: this is some compatibility feature - find out if may be omited and done without extra struct?
     bool takesPriorityIfEqual = false;
@@ -793,7 +793,7 @@ static void clear_sprite_list()
     sprlist.clear();
 }
 
-static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int baseline, int trans, bool isWalkBehind,
+static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int zorder, bool isWalkBehind, int trans = 0,
     BlendMode blendMode = kBlend_Normal)
 {
     if (spp == nullptr)
@@ -804,7 +804,7 @@ static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int 
 
     SpriteListEntry sprite;
     sprite.bmp = spp;
-    sprite.baseline = baseline;
+    sprite.zorder = zorder;
     sprite.x = xx;
     sprite.y = yy;
     sprite.transparent = trans;
@@ -821,14 +821,14 @@ static void add_to_sprite_list(IDriverDependantBitmap* spp, int xx, int yy, int 
 // function to sort the sprites into baseline order
 static bool spritelistentry_less(const SpriteListEntry &e1, const SpriteListEntry &e2)
 {
-    if (e1.baseline == e2.baseline)
+    if (e1.zorder == e2.zorder)
     {
         if (e1.takesPriorityIfEqual)
             return false;
         if (e2.takesPriorityIfEqual)
             return true;
     }
-    return e1.baseline < e2.baseline;
+    return e1.zorder < e2.zorder;
 }
 
 // copy the sorted sprites into the Things To Draw list
@@ -993,7 +993,7 @@ void sort_out_char_sprite_walk_behind(int actspsIndex, int xx, int yy, int basel
 
     if (actspswbcache[actspsIndex].isWalkBehindHere)
     {
-        add_to_sprite_list(actspswbbmp[actspsIndex], xx, yy, basel, 0, true);
+        add_to_sprite_list(actspswbbmp[actspsIndex], xx, yy, basel, true);
     }
 }
 
@@ -1551,7 +1551,7 @@ void prepare_objects_for_drawing() {
                 actspsbmp[useindx]->SetLightLevel(0);
         }
 
-        add_to_sprite_list(actspsbmp[useindx], atxp, atyp, usebasel, objs[aa].transparent, false, objs[aa].blend_mode);
+        add_to_sprite_list(actspsbmp[useindx], atxp, atyp, usebasel, false, objs[aa].transparent, objs[aa].blend_mode);
     }
 }
 
@@ -1863,7 +1863,7 @@ void prepare_characters_for_drawing() {
         chin->actx = atxp;
         chin->acty = atyp;
 
-        add_to_sprite_list(actspsbmp[useindx], bgX, bgY, usebasel, chin->transparency, false, charextra[chin->index_id].blend_mode);
+        add_to_sprite_list(actspsbmp[useindx], bgX, bgY, usebasel, false, chin->transparency, charextra[chin->index_id].blend_mode);
     }
 }
 
@@ -1915,7 +1915,7 @@ void prepare_room_sprites()
                     if (walkBehindBitmap[ee] != nullptr)
                     {
                         add_to_sprite_list(walkBehindBitmap[ee], walkBehindLeft[ee], walkBehindTop[ee],
-                            croom->walkbehind_base[ee], 0, true);
+                            croom->walkbehind_base[ee], true);
                     }
                 }
             }
@@ -2029,15 +2029,23 @@ void draw_gui_and_overlays()
     if(pl_any_want_hook(AGSE_PREGUIDRAW))
         add_render_stage(AGSE_PREGUIDRAW);
 
-    // draw overlays, except text boxes and portraits
-    for (const auto &over : screenover) {
+    clear_sprite_list();
+
+    // prepare overlays
+    for (const auto &over : screenover)
+    {
         // complete overlay draw in non-transparent mode
-        if (over.type == OVER_COMPLETE) {
-            add_thing_to_draw(over.bmp, over.x, over.y, over.transparency, over.blendMode);
-        } else if (over.type != OVER_TEXTMSG && over.type != OVER_PICTURE) {
+        if (over.type == OVER_COMPLETE)
+        {
+            add_to_sprite_list(over.bmp, over.x, over.y, INT_MIN, false, over.transparency, over.blendMode);
+        }
+        else
+        {
             int tdxp, tdyp;
             get_overlay_position(over, &tdxp, &tdyp);
-            add_thing_to_draw(over.bmp, tdxp, tdyp, over.transparency, over.blendMode);
+            // draw speech and portraits over GUI and the rest under GUI
+            int zorder = (over.type == OVER_TEXTMSG || over.type == OVER_PICTURE) ? INT_MAX : INT_MIN;
+            add_to_sprite_list(over.bmp, tdxp, tdyp, zorder, false, over.transparency, over.blendMode);
         }
     }
 
@@ -2098,7 +2106,7 @@ void draw_gui_and_overlays()
                 (guis[aa].PopupStyle != kGUIPopupNoAutoRemove))
                 continue;
 
-            add_thing_to_draw(guibgbmp[aa], guis[aa].X, guis[aa].Y, guis[aa].Transparency, guis[aa].BlendMode);
+            add_to_sprite_list(guibgbmp[aa], guis[aa].X, guis[aa].Y, guis[aa].ZOrder, false, guis[aa].Transparency, guis[aa].BlendMode);
 
             // only poll if the interface is enabled (mouseovers should not
             // work while in Wait state)
@@ -2107,16 +2115,8 @@ void draw_gui_and_overlays()
         }
     }
 
-    // draw speech and portraits (so that they appear over GUIs)
-    for (const auto &over : screenover) 
-    {
-        if (over.type == OVER_TEXTMSG || over.type == OVER_PICTURE)
-        {
-            int tdxp, tdyp;
-            get_overlay_position(over, &tdxp, &tdyp);
-            add_thing_to_draw(over.bmp, tdxp, tdyp, over.transparency, over.blendMode);
-        }
-    }
+    // sort and append ui sprites to the global draw things list
+    draw_sprite_list();
 
     our_eip = 1099;
 }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2044,7 +2044,7 @@ void draw_gui_and_overlays()
             int tdxp, tdyp;
             get_overlay_position(over, &tdxp, &tdyp);
             // draw speech and portraits over GUI and the rest under GUI
-            int zorder = (over.type == OVER_TEXTMSG || over.type == OVER_PICTURE) ? INT_MAX : INT_MIN;
+            int zorder = (over.type == OVER_TEXTMSG || over.type == OVER_PICTURE) ? INT_MAX : over.zorder;
             add_to_sprite_list(over.bmp, tdxp, tdyp, zorder, false, over.transparency, over.blendMode);
         }
     }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -174,6 +174,22 @@ void Overlay_SetTransparency(ScriptOverlay *scover, int trans) {
     screenover[ovri].transparency = GfxDef::Trans100ToLegacyTrans255(trans);
 }
 
+int Overlay_GetZOrder(ScriptOverlay *scover) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+
+    return screenover[ovri].zorder;
+}
+
+void Overlay_SetZOrder(ScriptOverlay *scover, int zorder) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+
+    screenover[ovri].zorder = zorder;
+}
+
 //=============================================================================
 
 void dispose_overlay(ScreenOverlay &over)
@@ -383,13 +399,11 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetY);
 }
 
-// int (ScriptOverlay *scover)
 RuntimeScriptValue Sc_Overlay_GetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetBlendMode);
 }
 
-// void (ScriptOverlay *scover, int blendMode)
 RuntimeScriptValue Sc_Overlay_SetBlendMode(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetBlendMode);
@@ -400,10 +414,19 @@ RuntimeScriptValue Sc_Overlay_GetTransparency(void *self, const RuntimeScriptVal
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetTransparency);
 }
 
-// void (ScriptOverlay *scover, int blendMode)
 RuntimeScriptValue Sc_Overlay_SetTransparency(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetTransparency);
+}
+
+RuntimeScriptValue Sc_Overlay_GetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetZOrder);
+}
+
+RuntimeScriptValue Sc_Overlay_SetZOrder(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetZOrder);
 }
 
 //=============================================================================
@@ -442,6 +465,8 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::set_BlendMode",       Sc_Overlay_SetBlendMode);
     ccAddExternalObjectFunction("Overlay::get_Transparency",    Sc_Overlay_GetTransparency);
     ccAddExternalObjectFunction("Overlay::set_Transparency",    Sc_Overlay_SetTransparency);
+    ccAddExternalObjectFunction("Overlay::get_ZOrder",          Sc_Overlay_GetZOrder);
+    ccAddExternalObjectFunction("Overlay::set_ZOrder",          Sc_Overlay_SetZOrder);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -35,6 +35,7 @@ struct ScreenOverlay {
     int type = 0, x = 0, y = 0, timeout = 0;
     int bgSpeechForChar = 0;
     int associatedOverlayHandle = 0;
+    int zorder = INT_MIN;
     bool positionRelativeToScreen = false;
     int _offsetX = 0, _offsetY = 0;
     Common::BlendMode blendMode = Common::kBlend_Normal;


### PR DESCRIPTION
Resolves #1202.

This implements Overlay.ZOrder property in compliance with other similar properties from GUI and GUIControl.

Overlays are now z-sorted along with the GUI on screen.

To keep default and backward compatible behavior, newly created overlays have their zorder set:
* For custom overlays and QF4 speech style overlays: to INT_MIN, so that they are beyond any GUI.
* For the text and portraits overlays: to INT_MAX, so that they are above any GUI.

User may adjust Overlay.ZOrder anytime after their creation, so long as there's an access to overlay object in script.

What to note on potential problems?

It must be kept in mind that overlays are not interactable, therefore mouse always "clicks through" them and activates whatever is behind. Just something to remember or maybe write in the manual, to prevent user confusion.

Some of the special overlays still cannot be referenced in the script, which imo is a separate issue that may be resolved by future changes.

I'd mention two good candidates for improvement here:
* An abiility to get actual Overlay objects of speech. I had a [PR in the past](#1127), but closed it being not very happy with it. I could restore it though, in hopes that overlays become easier to manipulate in the future.
* An ability to set default z-order for these overlays, so that user could set them once per game instead of having to catch overlay creation somehow and override z-order.

Is there anything I'm missing?