### PR TITLE
New compiler: Recognize the function return type 'const string'

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1669,6 +1669,12 @@ AGS::ErrorType AGS::Parser::ParseFuncdecl_Checks(TypeQualifierSet tqs, Symbol st
         return kERR_UserError;
     }
 
+    if (tqs[TQ::kConst] && kKW_String != return_vartype)
+    {
+        Error("Can only return a 'const' type when it is 'const string'");
+        return kERR_UserError;
+    }
+
     if (PP::kPreAnalyze == _pp &&
         body_follows &&
         _sym.IsFunction(name_of_func) &&
@@ -1746,6 +1752,13 @@ AGS::ErrorType AGS::Parser::ParseFuncdecl(size_t declaration_start, TypeQualifie
 
     retval = ParseFuncdecl_Checks(tqs, struct_of_func, name_of_func, return_vartype, body_follows, no_loop_check);
     if (retval < 0) return retval;
+
+    if (tqs[TQ::kConst])
+    {
+        return_vartype = _sym.VartypeWith(VTT::kConst, return_vartype);
+        tqs[TQ::kConst] = false;
+    }
+
    
     // A forward decl can be written with the
     // "import" keyword (when allowed in the options). This isn't an import
@@ -4343,7 +4356,7 @@ AGS::ErrorType AGS::Parser::ParseVardecl_CheckIllegalCombis(Vartype vartype, Sco
 {
     if (vartype == kKW_String && FlagIsSet(_options, SCOPT_OLDSTRINGS) == 0)
     {
-        Error("Type 'string' is no longer supported; use String instead");
+        Error("Variables of type 'string' aren't supported any longer (use the type 'String' instead)");
         return kERR_UserError;
     }
 

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2143,6 +2143,42 @@ TEST_F(Compile0, StringOldstyle03) {
     EXPECT_NE(std::string::npos, lerr.find("ype mismatch"));
 }
 
+TEST_F(Compile0, ConstOldstringReturn)
+{
+    // A 'const string' should be a valid return
+    // from a 'const string' function.
+
+    char *inpl = "\
+        const string GetLiteral()       \n\
+        {                               \n\
+            return \"string literal\";  \n\
+        }                               \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}
+
+TEST_F(Compile0, ConstOldstringReturn2)
+{
+    // Must not pass a const string return as a
+    // non-const parameter of another function.
+
+    char *inpl = "\
+        import const string GetConstString();   \n\
+        import void UseString(string s);        \n\
+                                                \n\
+        void game_start()                       \n\
+        {                                       \n\
+            UseString(GetConstString());        \n\
+        }                                       \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'const string'"));
+}
+
 TEST_F(Compile0, StructPointerAttribute) {
 
     // It's okay for a managed struct to have a pointer import attribute.


### PR DESCRIPTION
Addresses #1203. The function return type `const string` should be recognized as different from `string`.

Typical code that should be correct:
```
const string GetLiteral() 
{ 
    return "string literal"; 
}         
```

Typical code that should be flagged as incorrect:
```
import const string GetConstString();
import void UseString(string s);

int game_start()
{
    UseString(GetConstString());
}
```