### PR TITLE
Script API: add access to blocking speech overlays and latest skip reason

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2292,6 +2292,8 @@ builtin struct Speech {
 #ifdef SCRIPT_API_v399
   /// Gets the overlay representing displayed blocking text, or null if no such text none is displayed at the moment.
   import static readonly attribute Overlay* TextOverlay;
+  /// Gets the overlay representing displayed portrait, or null if it is not displayed at the moment.
+  import static readonly attribute Overlay* PortraitOverlay;
 #endif
 };
 

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2157,6 +2157,10 @@ builtin struct Game {
   /// Gets the number of cameras.
   import static readonly attribute int CameraCount;
 #endif
+#ifdef SCRIPT_API_v399
+  /// Gets the code which describes how was the last blocking state skipped by a user (or autotimer).
+  import static readonly attribute int BlockingWaitSkipped;
+#endif
 };
 
 builtin struct GameState {

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2289,6 +2289,10 @@ builtin struct Speech {
   import static attribute bool            UseGlobalSpeechAnimationDelay;
   /// Gets/sets whether voice and/or text are used in the game.
   import static attribute eVoiceMode      VoiceMode;
+#ifdef SCRIPT_API_v399
+  /// Gets the overlay representing displayed blocking text, or null if no such text none is displayed at the moment.
+  import static readonly attribute Overlay* TextOverlay;
+#endif
 };
 
 #ifdef SCRIPT_API_v3507

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2253,6 +2253,7 @@ builtin struct GameState {
   };
   
 enum SkipSpeechStyle {
+  eSkipNone         = -1,
   eSkipKeyMouseTime = 0,
   eSkipKeyTime      = 1,
   eSkipTime         = 2,

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -74,7 +74,6 @@ extern SpriteCache spriteset;
 extern Bitmap *walkable_areas_temp;
 extern IGraphicsDriver *gfxDriver;
 extern Bitmap **actsps;
-extern int is_text_overlay;
 extern int said_speech_line;
 extern int said_text;
 extern int our_eip;
@@ -2354,7 +2353,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     if ((speakingChar->view < 0) || (speakingChar->view >= game.numviews))
         quit("!DisplaySpeech: character has invalid view");
 
-    if (is_text_overlay > 0)
+    if (play.text_overlay_on > 0)
     {
         debug_script_warn("DisplaySpeech: speech was already displayed (nested DisplaySpeech, perhaps room script and global script conflict?)");
         return;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -759,15 +759,10 @@ ScriptOverlay* Character_SayBackground(CharacterInfo *chaa, const char *texx) {
     if (ovri<0)
         quit("!SayBackground internal error: no overlay");
 
-    // Convert the overlay ID to an Overlay object
-    ScriptOverlay *scOver = new ScriptOverlay();
-    scOver->overlayId = ovltype;
+    ScriptOverlay *scOver = create_scriptobj_for_overlay(screenover[ovri]);
     scOver->borderHeight = 0;
     scOver->borderWidth = 0;
     scOver->isBackgroundSpeech = 1;
-    int handl = ccRegisterManagedObject(scOver, scOver);
-    screenover[ovri].associatedOverlayHandle = handl;
-
     return scOver;
 }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -261,6 +261,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
         // If fast-forwarding, then skip immediately
         if (play.fast_forward) {
             remove_screen_overlay(OVER_TEXTMSG);
+            play.SetWaitSkipResult(SKIP_AUTOTIMER);
             play.messagetime=-1;
             return 0;
         }
@@ -279,7 +280,10 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
                 if (play.fast_forward)
                     break;
                 if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
+                {
+                    play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
                     break;
+                }
             }
             int kp;
             if (run_service_key_controls(kp)) {
@@ -287,7 +291,10 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
                 if (play.fast_forward)
                     break;
                 if ((skip_setting & SKIP_KEYPRESS) && !play.IsIgnoringInput())
+                {
+                    play.SetWaitSkipResult(SKIP_KEYPRESS, kp);
                     break;
+                }
             }
             
             update_polled_stuff_if_runtime();
@@ -312,6 +319,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
             // Test for the timed auto-skip
             if ((countdown < 1) && (skip_setting & SKIP_AUTOTIMER))
             {
+                play.SetWaitSkipResult(SKIP_AUTOTIMER);
                 play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
                 break;
             }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -162,7 +162,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
     int extraHeight = paddingDoubledScaled;
     color_t text_color = MakeColor(15);
     if (disp_type < DISPLAYTEXT_NORMALOVERLAY)
-        remove_screen_overlay(OVER_TEXTMSG); // remove any previous blocking texts
+        remove_screen_overlay(play.text_overlay_on); // remove any previous blocking texts
 
     Bitmap *text_window_ds = BitmapHelper::CreateTransparentBitmap((wii > 0) ? wii : 2, disp.fulltxtheight + extraHeight, game.GetColorDepth());
 
@@ -238,9 +238,14 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
             wouttext_aligned (text_window_ds, xoffs, yoffs + ee * disp.linespacing, oriwid, usingfont, text_color, Lines[ee], play.text_align);
     }
 
-    int ovrtype = OVER_TEXTMSG;
-    if (disp_type == DISPLAYTEXT_NORMALOVERLAY) ovrtype=OVER_CUSTOM;
-    else if (disp_type >= OVER_CUSTOM) ovrtype = disp_type;
+    int ovrtype;
+    switch (disp_type)
+    {
+    case DISPLAYTEXT_SPEECH: ovrtype = OVER_TEXTSPEECH; break;
+    case DISPLAYTEXT_MESSAGEBOX: ovrtype = OVER_TEXTMSG; break;
+    case DISPLAYTEXT_NORMALOVERLAY: ovrtype = OVER_CUSTOM; break;
+    default: ovrtype = disp_type; break; // must be precreated overlay id
+    }
 
     int nse = add_screen_overlay(xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
     // we should not delete text_window_ds here, because it is now owned by Overlay
@@ -319,7 +324,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
         remove_screen_overlay(OVER_TEXTMSG);
         invalidate_screen();
     }
-    else {
+    else { /* DISPLAYTEXT_SPEECH */
         // if the speech does not time out, but we are skipping a cutscene,
         // allow it to time out
         if ((play.messagetime < 0) && (play.fast_forward))

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -23,8 +23,11 @@
 using AGS::Common::GUIMain;
 
 // options for 'disp_type' parameter
+// blocking speech
 #define DISPLAYTEXT_SPEECH        0
+// super-blocking message box
 #define DISPLAYTEXT_MESSAGEBOX    1
+// regular non-blocking overlay
 #define DISPLAYTEXT_NORMALOVERLAY 2
 // also accepts explicit overlay ID >= OVER_CUSTOM
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -105,7 +105,6 @@ extern int displayed_room;
 extern CharacterExtras *charextra;
 extern CharacterInfo*playerchar;
 extern int eip_guinum;
-extern int is_complete_overlay;
 extern int cur_mode,cur_cursor;
 extern int mouse_frame,mouse_delay;
 extern int lastmx,lastmy;
@@ -2044,7 +2043,7 @@ void draw_gui_and_overlays()
             int tdxp, tdyp;
             get_overlay_position(over, &tdxp, &tdyp);
             // draw speech and portraits over GUI and the rest under GUI
-            int zorder = (over.type == OVER_TEXTMSG || over.type == OVER_PICTURE) ? INT_MAX : over.zorder;
+            int zorder = (over.type == OVER_TEXTMSG || over.type == OVER_TEXTSPEECH || over.type == OVER_PICTURE) ? INT_MAX : over.zorder;
             add_to_sprite_list(over.bmp, tdxp, tdyp, zorder, false, over.transparency, over.blendMode);
         }
     }
@@ -2262,7 +2261,7 @@ void construct_game_scene(bool full_redraw)
         play.UpdateRoomCameras();
 
     // Stage: room viewports
-    if (play.screen_is_faded_out == 0 && is_complete_overlay == 0)
+    if (play.screen_is_faded_out == 0 && play.complete_overlay_on == 0)
     {
         if (displayed_room >= 0)
         {

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -893,6 +893,11 @@ void Game_SimulateKeyPress(int key)
     }
 }
 
+int Game_BlockingWaitSkipped()
+{
+    return play.GetWaitSkipResult();
+}
+
 //=============================================================================
 
 // save game functions
@@ -1249,8 +1254,10 @@ void start_skipping_cutscene () {
 
     // if a text message is currently displayed, remove it
     if (play.text_overlay_on > 0)
+    {
         remove_screen_overlay(play.text_overlay_on);
-
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
+    }
 }
 
 bool check_skip_cutscene_keypress (int kgn) {
@@ -1983,6 +1990,11 @@ RuntimeScriptValue Sc_Game_SimulateKeyPress(const RuntimeScriptValue *params, in
     API_SCALL_VOID_PINT(Game_SimulateKeyPress);
 }
 
+RuntimeScriptValue Sc_Game_BlockingWaitSkipped(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Game_BlockingWaitSkipped);
+}
+
 void RegisterGameAPI()
 {
     ccAddExternalStaticFunction("Game::IsAudioPlaying^1",                       Sc_Game_IsAudioPlaying);
@@ -2035,6 +2047,7 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
     ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
     ccAddExternalStaticFunction("Game::SimulateKeyPress",                       Sc_Game_SimulateKeyPress);
+    ccAddExternalStaticFunction("Game::get_BlockingWaitSkipped",                Sc_Game_BlockingWaitSkipped);
 
     ccAddExternalStaticFunction("Game::get_Camera",                             Sc_Game_GetCamera);
     ccAddExternalStaticFunction("Game::get_CameraCount",                        Sc_Game_GetCameraCount);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1248,8 +1248,8 @@ void start_skipping_cutscene () {
         remove_popup_interface(ifacepopped);
 
     // if a text message is currently displayed, remove it
-    if (is_text_overlay > 0)
-        remove_screen_overlay(OVER_TEXTMSG);
+    if (play.text_overlay_on > 0)
+        remove_screen_overlay(play.text_overlay_on);
 
 }
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -405,6 +405,23 @@ void GameState::ClearIgnoreInput()
     _ignoreUserInputUntilTime = AGS_Clock::now();
 }
 
+void GameState::SetWaitSkipResult(int how, int data)
+{
+    wait_counter = 0;
+    wait_skipped_by = how;
+    wait_skipped_by_data = data;
+}
+
+int GameState::GetWaitSkipResult() const
+{
+    switch (wait_skipped_by)
+    {
+    case SKIP_KEYPRESS: return wait_skipped_by_data;
+    case SKIP_MOUSECLICK: return -(wait_skipped_by_data + 1); // convert to 1-based code and negate
+    default: return 0;
+    }
+}
+
 bool GameState::IsBlockingVoiceSpeech() const
 {
     return speech_has_voice && speech_voice_blocking;

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -40,6 +40,7 @@ extern ScriptSystem scsystem;
 
 GameState::GameState()
 {
+    speech_text_scover = nullptr;
     _isAutoRoomViewport = true;
     _mainViewportHasChanged = false;
 }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -41,6 +41,7 @@ extern ScriptSystem scsystem;
 GameState::GameState()
 {
     speech_text_scover = nullptr;
+    speech_face_scover = nullptr;
     _isAutoRoomViewport = true;
     _mainViewportHasChanged = false;
 }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -42,6 +42,7 @@ namespace AGS
 using namespace AGS; // FIXME later
 struct ScriptViewport;
 struct ScriptCamera;
+struct ScriptOverlay;
 
 #define GAME_STATE_RESERVED_INTS 5
 
@@ -238,6 +239,8 @@ struct GameState {
     int  complete_overlay_on;
     // Is there a blocking text overlay on screen (contains overlay ID)
     int  text_overlay_on;
+    // Blocking speech overlay managed object, for accessing in scripts
+    ScriptOverlay *speech_text_scover;
 
     int shake_screen_yoff; // y offset of the shaking screen
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -241,6 +241,8 @@ struct GameState {
     int  text_overlay_on;
     // Blocking speech overlay managed object, for accessing in scripts
     ScriptOverlay *speech_text_scover;
+    // Speech portrait overlay managed object
+    ScriptOverlay *speech_face_scover;
 
     int shake_screen_yoff; // y offset of the shaking screen
 

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -145,8 +145,8 @@ struct GameState {
     int   bg_frame,bg_anim_delay;  // for animating backgrounds
     int   music_vol_was;  // before the volume drop
     short wait_counter;
-    char  wait_skipped_by; // tells how last wait was skipped [not serialized]
-    int   wait_skipped_by_data; // extended data telling how last wait was skipped [not serialized]
+    char  wait_skipped_by; // tells how last blocking wait was skipped [not serialized]
+    int   wait_skipped_by_data; // extended data telling how last blocking wait was skipped [not serialized]
     short mboundx1,mboundx2,mboundy1,mboundy2;
     int   fade_effect;
     int   bg_frame_locked;
@@ -336,6 +336,14 @@ struct GameState {
     void SetIgnoreInput(int timeout_ms);
     // Clears ignore input state
     void ClearIgnoreInput();
+
+    // Set how the last blocking wait was skipped
+    void SetWaitSkipResult(int how, int data = 0);
+    // Returns the code of the latest blocking wait skip method.
+    // * positive value means a key code;
+    // * negative value means a -(mouse code + 1);
+    // * 0 means timeout.
+    int GetWaitSkipResult() const;
 
     //
     // Voice speech management

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -232,6 +232,13 @@ struct GameState {
     // Tells whether character speech stays on screen not animated for additional time
     bool  speech_in_post_state;
 
+    // Special overlays
+    //
+    // Is there a QFG4-style dialog overlay on screen (contains overlay ID)
+    int  complete_overlay_on;
+    // Is there a blocking text overlay on screen (contains overlay ID)
+    int  text_overlay_on;
+
     int shake_screen_yoff; // y offset of the shaking screen
 
 

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -925,7 +925,7 @@ void _sc_AbortGame(const char* text) {
 int WaitImpl(int skip_type, int nloops)
 {
     play.wait_counter = nloops;
-    play.wait_skipped_by = SKIP_AUTOTIMER; // we set timer flag by default to simplify that case
+    play.wait_skipped_by = SKIP_NONE;
     play.wait_skipped_by_data = 0;
     play.key_skip_wait = skip_type;
 
@@ -937,12 +937,7 @@ int WaitImpl(int skip_type, int nloops)
         return (play.wait_skipped_by & (SKIP_KEYPRESS | SKIP_MOUSECLICK) != 0) ? 1 : 0;
     }
     // > 3.5.0 return positive keycode, negative mouse button code, or 0 as time-out
-    switch (play.wait_skipped_by)
-    {
-    case SKIP_KEYPRESS: return play.wait_skipped_by_data;
-    case SKIP_MOUSECLICK: return -(play.wait_skipped_by_data + 1); // convert to 1-based code and negate
-    default: return 0;
-    }
+    return play.GetWaitSkipResult();
 }
 
 void scrWait(int nloops) {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -594,8 +594,6 @@ void recreate_guibg_image(GUIMain *tehgui)
   }
 }
 
-extern int is_complete_overlay;
-
 int gui_get_interactable(int x,int y)
 {
     if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0))
@@ -617,7 +615,7 @@ int gui_on_mouse_move()
             if (guis[guin].IsInteractableAt(mousex, mousey)) mouse_over_gui=guin;
 
             if (guis[guin].PopupStyle!=kGUIPopupMouseY) continue;
-            if (is_complete_overlay>0) break;  // interfaces disabled
+            if (play.complete_overlay_on > 0) break;  // interfaces disabled
             //    if (play.disabled_user_interface>0) break;
             if (ifacepopped==guin) continue;
             if (!guis[guin].IsVisible()) continue;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -43,7 +43,6 @@ extern IGraphicsDriver *gfxDriver;
 
 
 std::vector<ScreenOverlay> screenover;
-int is_complete_overlay=0,is_text_overlay=0;
 
 void Overlay_Remove(ScriptOverlay *sco) {
     sco->Remove();
@@ -209,8 +208,8 @@ void remove_screen_overlay_index(size_t over_idx)
 {
     ScreenOverlay &over = screenover[over_idx];
     dispose_overlay(over);
-    if (over.type==OVER_COMPLETE) is_complete_overlay--;
-    if (over.type==OVER_TEXTMSG) is_text_overlay--;
+    if (over.type == play.complete_overlay_on) play.complete_overlay_on = 0;
+    if (over.type == play.text_overlay_on) play.text_overlay_on = 0;
     screenover.erase(screenover.begin() + over_idx);
     // if an overlay before the sierra-style speech one is removed,
     // update the index
@@ -245,9 +244,9 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, bool alphaChann
 
 size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel, BlendMode blendMode)
 {
-    if (type==OVER_COMPLETE) is_complete_overlay++;
-    if (type==OVER_TEXTMSG) is_text_overlay++;
-    if (type==OVER_CUSTOM) {
+    if (type == OVER_COMPLETE) play.complete_overlay_on = type;
+    if (type == OVER_TEXTMSG || type == OVER_TEXTSPEECH) play.text_overlay_on = type;
+    if (type == OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
         for (int id = OVER_CUSTOM + 1; id < screenover.size() + OVER_CUSTOM + 1; ++id) {
             if (find_overlay_of_type(id) == -1) { type=id; break; }

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -44,9 +44,6 @@ size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 
-extern int is_complete_overlay;
-extern int is_text_overlay; // blocking text overlay on screen
 
 extern std::vector<ScreenOverlay> screenover;
-
 #endif // __AGS_EE_AC__OVERLAY_H

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -41,6 +41,8 @@ void get_overlay_position(const ScreenOverlay &over, int *x, int *y);
 size_t add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
 size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy,
     bool alphaChannel = false, Common::BlendMode blendMode = Common::kBlend_Normal);
+// Creates and registers a managed script object for existing overlay object
+ScriptOverlay* create_scriptobj_for_overlay(ScreenOverlay &over);
 void remove_screen_overlay_index(size_t over_idx);
 void recreate_overlay_ddbs();
 

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -101,6 +101,7 @@ const int LegacyRoomVolumeFactor            = 30;
 #define OVER_TEXTMSG  1
 #define OVER_COMPLETE 2
 #define OVER_PICTURE  3
+#define OVER_TEXTSPEECH 4
 #define OVER_CUSTOM   100
 #define OVR_AUTOPLACE 30000
 #define FOR_ANIMATION 1

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -22,6 +22,8 @@ int user_to_internal_skip_speech(SkipSpeechStyle userval)
 {
     switch (userval)
     {
+    case kSkipSpeechNone:
+        return SKIP_NONE;
     case kSkipSpeechKeyMouseTime:
         return SKIP_AUTOTIMER | SKIP_KEYPRESS | SKIP_MOUSECLICK;
     case kSkipSpeechKeyTime:
@@ -38,7 +40,7 @@ int user_to_internal_skip_speech(SkipSpeechStyle userval)
         return SKIP_MOUSECLICK;
     default:
         quit("user_to_internal_skip_speech: unknown userval");
-        return 0;
+        return SKIP_NONE;
     }
 }
 
@@ -76,7 +78,7 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val)
             return kSkipSpeechMouse;
         }
     }
-    return kSkipSpeechUndefined;
+    return kSkipSpeechNone;
 }
 
 //=============================================================================

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -101,6 +101,11 @@ ScriptOverlay* Speech_GetTextOverlay()
     return play.speech_text_scover;
 }
 
+ScriptOverlay* Speech_GetPortraitOverlay()
+{
+    return play.speech_face_scover;
+}
+
 RuntimeScriptValue Sc_Speech_GetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_VARGET_INT(play.close_mouth_speech_time);
@@ -229,6 +234,11 @@ RuntimeScriptValue Sc_Speech_GetTextOverlay(const RuntimeScriptValue *params, in
     API_SCALL_OBJAUTO(ScriptOverlay, Speech_GetTextOverlay);
 }
 
+RuntimeScriptValue Sc_Speech_GetPortraitOverlay(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptOverlay, Speech_GetPortraitOverlay);
+}
+
 extern RuntimeScriptValue Sc_SetVoiceMode(const RuntimeScriptValue *params, int32_t param_count);
 
 void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
@@ -241,6 +251,7 @@ void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
     ccAddExternalStaticFunction("Speech::set_DisplayPostTimeMs",      Sc_Speech_SetDisplayPostTimeMs);
 	ccAddExternalStaticFunction("Speech::get_GlobalSpeechAnimationDelay", Sc_Speech_GetGlobalSpeechAnimationDelay);
 	ccAddExternalStaticFunction("Speech::set_GlobalSpeechAnimationDelay", Sc_Speech_SetGlobalSpeechAnimationDelay);
+    ccAddExternalStaticFunction("Speech::get_PortraitOverlay",        Sc_Speech_GetPortraitOverlay);
     ccAddExternalStaticFunction("Speech::get_PortraitXOffset",        Sc_Speech_GetPortraitXOffset);
     ccAddExternalStaticFunction("Speech::set_PortraitXOffset",        Sc_Speech_SetPortraitXOffset);
     ccAddExternalStaticFunction("Speech::get_PortraitY",              Sc_Speech_GetPortraitY);

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -15,6 +15,7 @@
 #include "ac/common.h"
 #include "ac/runtime_defines.h"
 #include "ac/speech.h"
+#include "ac/dynobj/scriptoverlay.h"
 #include "debug/debug_log.h"
 
 int user_to_internal_skip_speech(SkipSpeechStyle userval)
@@ -94,6 +95,11 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val)
 
 extern GameSetupStruct game;
 extern GameState play;
+
+ScriptOverlay* Speech_GetTextOverlay()
+{
+    return play.speech_text_scover;
+}
 
 RuntimeScriptValue Sc_Speech_GetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -218,6 +224,11 @@ RuntimeScriptValue Sc_Speech_GetVoiceMode(const RuntimeScriptValue *params, int3
     API_SCALL_INT(GetVoiceMode);
 }
 
+RuntimeScriptValue Sc_Speech_GetTextOverlay(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO(ScriptOverlay, Speech_GetTextOverlay);
+}
+
 extern RuntimeScriptValue Sc_SetVoiceMode(const RuntimeScriptValue *params, int32_t param_count);
 
 void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
@@ -245,6 +256,7 @@ void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
         ccAddExternalStaticFunction("Speech::set_TextAlignment",      Sc_Speech_SetTextAlignment_Old);
     else
         ccAddExternalStaticFunction("Speech::set_TextAlignment",      Sc_Speech_SetTextAlignment);
+    ccAddExternalStaticFunction("Speech::get_TextOverlay",            Sc_Speech_GetTextOverlay);
 	ccAddExternalStaticFunction("Speech::get_UseGlobalSpeechAnimationDelay", Sc_Speech_GetUseGlobalSpeechAnimationDelay);
 	ccAddExternalStaticFunction("Speech::set_UseGlobalSpeechAnimationDelay", Sc_Speech_SetUseGlobalSpeechAnimationDelay);
     ccAddExternalStaticFunction("Speech::get_VoiceMode",              Sc_Speech_GetVoiceMode);

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -20,7 +20,7 @@
 
 enum SkipSpeechStyle
 {
-    kSkipSpeechUndefined    = -1,
+    kSkipSpeechNone         = -1,
     kSkipSpeechKeyMouseTime =  0,
     kSkipSpeechKeyTime      =  1,
     kSkipSpeechTime         =  2,
@@ -29,7 +29,7 @@ enum SkipSpeechStyle
     kSkipSpeechKey          =  5,
     kSkipSpeechMouse        =  6,
 
-    kSkipSpeechFirst        = kSkipSpeechKeyMouseTime,
+    kSkipSpeechFirst        = kSkipSpeechNone,
     kSkipSpeechLast         = kSkipSpeechMouse
 };
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -293,8 +293,8 @@ void DoBeforeRestore(PreservedParams &pp)
     delete raw_saved_screen;
     raw_saved_screen = nullptr;
     remove_screen_overlay(-1);
-    is_complete_overlay = 0;
-    is_text_overlay = 0;
+    play.complete_overlay_on = 0;
+    play.text_overlay_on = 0;
 
     // cleanup dynamic sprites
     // NOTE: sprite 0 is a special constant sprite that cannot be dynamic

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -993,6 +993,7 @@ void engine_init_game_settings()
     play.music_queue_size = 0;
     play.shakesc_length = 0;
     play.wait_counter=0;
+    play.SetWaitSkipResult(SKIP_NONE);
     play.key_skip_wait = SKIP_NONE;
     play.cur_music_number=-1;
     play.music_repeat=1;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1062,6 +1062,8 @@ void engine_init_game_settings()
     play.speech_has_voice = false;
     play.speech_voice_blocking = false;
     play.speech_in_post_state = false;
+    play.complete_overlay_on = 0;
+    play.text_overlay_on = 0;
     play.narrator_speech = game.playercharacter;
     play.crossfading_out_channel = 0;
     play.speech_textwindow_gui = game.options[OPT_TWCUSTOM];

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -246,13 +246,14 @@ static void check_mouse_controls()
 
         if (play.fast_forward || play.IsIgnoringInput()) { /* do nothing if skipping cutscene or input disabled */ }
         else if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_MOUSECLICK) != 0) {
-            play.wait_counter = 0;
-            play.wait_skipped_by = SKIP_MOUSECLICK;
-            play.wait_skipped_by_data = mbut;
+            play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
         }
         else if (play.text_overlay_on > 0) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
+            {
                 remove_screen_overlay(play.text_overlay_on);
+                play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
+            }
         }
         else if (!IsInterfaceEnabled()) ;  // blocking cutscene, ignore mouse
         else if (pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut+1)) {
@@ -478,17 +479,17 @@ static void check_keyboard_controls()
             if ((play.skip_speech_specific_key > 0) &&
                 (kgn != play.skip_speech_specific_key)) { }
             else
+            {
                 remove_screen_overlay(play.text_overlay_on);
+                play.SetWaitSkipResult(SKIP_KEYPRESS, kgn);
+            }
         }
 
         return;
     }
 
     if ((play.wait_counter != 0) && (play.key_skip_wait & SKIP_KEYPRESS) != 0) {
-        play.wait_counter = 0;
-        play.wait_skipped_by = SKIP_KEYPRESS;
-        play.wait_skipped_by_data = kgn;
-        debug_script_log("Keypress code %d ignored - in Wait", kgn);
+        play.SetWaitSkipResult(SKIP_KEYPRESS, kgn);
         return;
     }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -65,7 +65,6 @@ extern AnimatingGUIButton animbuts[MAX_ANIMATING_BUTTONS];
 extern int numAnimButs;
 extern int mouse_on_iface;   // mouse cursor is over this interface
 extern int ifacepopped;
-extern int is_text_overlay;
 extern volatile char want_exit, abort_engine;
 extern int proper_exit,our_eip;
 extern int displayed_room, starting_room, in_new_room, new_room_was;
@@ -251,9 +250,9 @@ static void check_mouse_controls()
             play.wait_skipped_by = SKIP_MOUSECLICK;
             play.wait_skipped_by_data = mbut;
         }
-        else if (is_text_overlay > 0) {
+        else if (play.text_overlay_on > 0) {
             if (play.cant_skip_speech & SKIP_MOUSECLICK)
-                remove_screen_overlay(OVER_TEXTMSG);
+                remove_screen_overlay(play.text_overlay_on);
         }
         else if (!IsInterfaceEnabled()) ;  // blocking cutscene, ignore mouse
         else if (pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut+1)) {
@@ -421,7 +420,8 @@ bool run_service_key_controls(int &key_out)
         return false;
     }
 
-    if ((keycode == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) && (play.wait_counter < 1) && (is_text_overlay == 0) && (restrict_until == 0)) {
+    if ((keycode == eAGSKeyCodeAltV) && (key[KEY_LCONTROL] || key[KEY_RCONTROL]) &&
+        (play.wait_counter < 1) && (play.text_overlay_on == 0) && (restrict_until == 0)) {
         // make sure we can't interrupt a Wait()
         // and desync the music to cutscene
         play.debug_mode++;
@@ -471,14 +471,14 @@ static void check_keyboard_controls()
     }
 
     // skip speech if desired by Speech.SkipStyle
-    if ((is_text_overlay > 0) && (play.cant_skip_speech & SKIP_KEYPRESS)) {
+    if ((play.text_overlay_on > 0) && (play.cant_skip_speech & SKIP_KEYPRESS)) {
         // only allow a key to remove the overlay if the icon bar isn't up
         if (IsGamePaused() == 0) {
             // check if it requires a specific keypress
             if ((play.skip_speech_specific_key > 0) &&
                 (kgn != play.skip_speech_specific_key)) { }
             else
-                remove_screen_overlay(OVER_TEXTMSG);
+                remove_screen_overlay(play.text_overlay_on);
         }
 
         return;
@@ -869,7 +869,7 @@ static int ShouldStayInWaitMode() {
         if (wkptr[0]<0) retval=0;
     }
     else if (restrict_until==UNTIL_NOOVERLAY) {
-        if (is_text_overlay < 1) retval=0;
+        if (play.text_overlay_on == 0) retval=0;
     }
     else if (restrict_until==UNTIL_INTIS0) {
         int*wkptr=(int*)user_disabled_data;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -61,7 +61,6 @@ extern int facetalkBlinkLoop;
 extern bool facetalk_qfg4_override_placement_x, facetalk_qfg4_override_placement_y;
 extern SpeechLipSyncLine *splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
-extern int is_text_overlay;
 extern IGraphicsDriver *gfxDriver;
 
 int do_movelist_move(short*mlnum,int*xx,int*yy) {
@@ -284,11 +283,11 @@ void update_speech_and_messages()
     {
       if (play.fast_forward > 0)
       {
-        remove_screen_overlay(OVER_TEXTMSG);
+        remove_screen_overlay(play.text_overlay_on);
       }
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
-        remove_screen_overlay(OVER_TEXTMSG);
+        remove_screen_overlay(play.text_overlay_on);
         play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
       }
     }
@@ -412,7 +411,7 @@ void update_sierra_speech()
     }
 
     // is_text_overlay might be 0 if it was only just destroyed this loop
-    if ((updatedFrame) && (is_text_overlay > 0)) {
+    if ((updatedFrame) && (play.text_overlay_on > 0)) {
 
       if (updatedFrame & 1)
         CheckViewFrame (facetalkview, facetalkloop, facetalkframe);

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -284,10 +284,12 @@ void update_speech_and_messages()
       if (play.fast_forward > 0)
       {
         remove_screen_overlay(play.text_overlay_on);
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
       }
       else if (play.cant_skip_speech & SKIP_AUTOTIMER)
       {
         remove_screen_overlay(play.text_overlay_on);
+        play.SetWaitSkipResult(SKIP_AUTOTIMER);
         play.SetIgnoreInput(play.ignore_user_input_after_text_timeout_ms);
       }
     }


### PR DESCRIPTION
This is a slightly different remake of #1127.

This PR exposes couple of overlays that were already internal objects but could not be accessed from script in any way, plus adds couple of complementary things.

### Speech.TextOverlay and Speech.PortraitOverlay
`readonly attribute Overlay *Speech.TextOverlay` returns special overlay created for the blocking speech, or null if no such text is on screen.
`readonly attribute Overlay *Game.PortraitOverlay` returns special overlay created for the speech portrait, or null if no such portrait is on screen.

Because of how blocking speech works, these overlays will be only available in `repeatedly_execute_always` and `late_repeatedly_execute_always` script callbacks.
But these are valid overlays in every other aspect: you can use its properties, read or change position, for example.
Calling Remove() function is also legal, and will correctly stop the current blocking speech (the engine was already programmed to rely strictly on overlay's presence).

When the speech is removed, script object is detached from actual overlay and invalidated: its Overlay.Valid property will be returning false, and attempt to call any other property or function will result in script error. This is essential to know if you store Overlay pointer in a variable for later use.

**On practical use**

To clarify, at the moment there's may not much uses of changing their properties per se, but that may be rather a limitation of overlay struct.<br>
The most significant is simply the capability to read these overlay pointers and thus *detect their presence*. Or store them in a variable and later compare with previously saved pointers and thus *detect when the speech changes*. For every speech line there's a new overlay generated by the engine. In practice this gives user an ability to know when speech appeared, changed to next line, or ended - something that was previously not possible without writing wrapper functions over Say command.
Not going to say if this is better or more convenient compared to having your custom Say functions, but I believe this is still a reasonable thing to have, as these are existing game objects. Exposing them will give an opportunity to add some quick handling of built-in speech without writing fully custom speech system.

As noted above, this also adds a completely new method of skipping built-in speech: by calling its overlay's Remove() function.

Which brings us to...

### eSkipNone

`eSkipNone` option added for SkipSpeechStyle. When set, speech may only be skipped by a script command (i.e. - calling Speech.TextOverlay.Remove()).<br>
This complements similar mode added for Wait and cutscenes (see #1084).

### Game.BlockingWaitSkipped

`readonly attribute int Game.BlockingWaitSkipped` returns a code telling how the last blocking wait action was ended. This code is equivalent to the return value of the Wait* functions, introduced previously (#1084). At the moment this property is updated by three sorts of skippable blocking actions: Say*, Display* and Wait*.

The purpose of such property is to be able to write a generic code for detecting last skip reason - without wrapping over every blocking Say etc call. One could e.g. check that in late_repeatedly_execute_always to see if anything was skipped in game last frame.