### PR TITLE
New compiler: Memory allocation bug when the section changes

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -74,8 +74,6 @@ AGS::ccCompiledScript::ccCompiledScript(bool emit_line_numbers)
     AX_ScopeType = ScT::kGlobal;
     Functions = {};
     ImportIdx = {};
-
-    EmitLineNumbers = emit_line_numbers;
 }
 
 AGS::ccCompiledScript::~ccCompiledScript()

--- a/Compiler/script2/cc_compiledscript.h
+++ b/Compiler/script2/cc_compiledscript.h
@@ -27,10 +27,10 @@ class ccCompiledScript : public ccScript {
     // so that it has at least 'MAX(needed, min_size)' bytes allocated.
     // The chunk is allocated 'malloc' style, so it needs to be 'free'd after use.
     // Returns kERR_InternalError if reallocation fails.
-    ErrorType ResizeMemory(size_t needed, size_t min_size, void *&start, size_t &allocated);
+    ErrorType ResizeMemory(size_t el_size, size_t needed, size_t min_allocated, void *&start, size_t &allocated);
 
-    inline ErrorType ResizeChunk(size_t needed, size_t min_size, void *&start, size_t &allocated)
-        { return allocated >= needed ? kERR_None : ResizeMemory(needed, min_size, start, allocated); }
+    inline ErrorType ResizeChunk(size_t el_size, size_t needed, size_t min_allocated, void *&start, size_t &allocated)
+        { return allocated >= needed ? kERR_None : ResizeMemory(el_size, needed, min_allocated, start, allocated); }
 
 public:
     struct FuncProps
@@ -89,7 +89,7 @@ public:
     int AddExport(std::string const &name, CodeLoc location, size_t num_of_arguments = INT_MAX);
 
     // Start a new section of the code.
-    int StartNewSection(std::string const &name);
+    ErrorType StartNewSection(std::string const &name);
 
     // Write one Bytecode byte    
     void WriteCode(CodeCell cell);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -920,7 +920,7 @@ private:
 
     // If a new section has begun at cursor position pos, tell _scrip to deal with that.
     // Refresh ccCurScriptName
-    void HandleSrcSectionChangeAt(size_t pos);
+    ErrorType HandleSrcSectionChangeAt(size_t pos);
 
     inline void WriteCmd(CodeCell op)
         { _scrip.RefreshLineno(_src.GetLineno()); _scrip.WriteCmd(op); }


### PR DESCRIPTION
This addresses #1219.

In some rare cases, memory allocation for section names went awry. The passage cc_compiledscript.cpp#L236 and following was probably responsible for the bug, it reserves space proportionate to `codesize` (the size of the generated Bytecode) instead of the number of sections. This would fail when very little code is generated for a lot of sections, which possible but rarely the case. So this would explain why the bug only happens rarely. 

I reformulated that passage and the similar passages of that file, introducing some named constants, to make it easy to verify at a glance whether they are set correctly. I rewrote ´ResizeMemory()` to calculate with array elements instead of bytes and renamed some variables to (hopefully) make it clearer what they mean.

cc_compiledscript.cpp#L78 : The assignment `EmitLineNumbers = emit_line_numbers;` is duplicate.