### PR TITLE
Room serialization

### DIFF
--- a/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomHotspotTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Drawing;
+using System.IO;
+using System.Xml;
 using AGS.Types;
 using NSubstitute;
 using NUnit.Framework;
@@ -90,6 +92,42 @@ namespace AGS.Types
             _changeNotification.DidNotReceive();
             ((IChangeNotification)_roomHotspot).ItemModified();
             _changeNotification.Received();
+        }
+
+        [TestCase("Hotspot 1", "hHotspot1", 0, 0)]
+        [TestCase("Hotspot 2", "hHotspot2", 5, 5)]
+        public void DeserializesFromXml(string description, string name, int walkToX, int walkToY)
+        {
+            string xml = $@"
+            <RoomHotspot>
+              <Description xml:space=""preserve"">{description}</Description>
+              <Name>{name}</Name>
+              <WalkToPoint>{walkToX},{walkToY}</WalkToPoint>
+              <Properties />
+              <Interactions />
+            </RoomHotspot>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomHotspot = new RoomHotspot(_changeNotification, doc.SelectSingleNode("RoomHotspot"));
+
+            Assert.That(_roomHotspot.Description, Is.EqualTo(description));
+            Assert.That(_roomHotspot.Name, Is.EqualTo(name));
+            Assert.That(_roomHotspot.WalkToPoint.X, Is.EqualTo(walkToX));
+            Assert.That(_roomHotspot.WalkToPoint.Y, Is.EqualTo(walkToY));
+        }
+
+        [TestCase("Hotspot 1", "hHotspot1", 0, 0)]
+        [TestCase("Hotspot 2", "hHotspot2", 5, 5)]
+        public void SerializeToXml(string description, string name, int walkToX, int walkToY)
+        {
+            _roomHotspot.Description = description;
+            _roomHotspot.Name = name;
+            _roomHotspot.WalkToPoint = new Point(walkToX, walkToY);
+            XmlDocument doc = _roomHotspot.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomHotspot/Description").InnerText, Is.EqualTo(description));
+            Assert.That(doc.SelectSingleNode("/RoomHotspot/Name").InnerText, Is.EqualTo(name));
+            Assert.That(doc.SelectSingleNode("/RoomHotspot/WalkToPoint").InnerText, Is.EqualTo($"{walkToX},{walkToY}"));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomMessageTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomMessageTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -79,6 +80,48 @@ namespace AGS.Types
         {
             _roomMessage.AutoRemoveAfterTime = autoRemoveAfterTime;
             Assert.That(_roomMessage.AutoRemoveAfterTime, Is.EqualTo(autoRemoveAfterTime));
+        }
+
+        [TestCase(4, "Test room message.", false, 1, true, false)]
+        [TestCase(10, "Another test room message.", true, 5, false, true)]
+        public void DeserializesFromXml(int id, string text, bool showAsSpeech, int characterId, bool displayNextMessageAfter, bool autoRemoveAfterTime)
+        {
+            string xml = $@"
+            <RoomMessage>
+                <Text xml:space=""preserve"">{text}</Text>
+                <ShowAsSpeech>{showAsSpeech}</ShowAsSpeech>
+                <CharacterID>{characterId}</CharacterID>
+                <DisplayNextMessageAfter>{displayNextMessageAfter}</DisplayNextMessageAfter>
+                <AutoRemoveAfterTime>{autoRemoveAfterTime}</AutoRemoveAfterTime>
+            </RoomMessage>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomMessage = new RoomMessage(id, doc.SelectSingleNode("RoomMessage"));
+
+            Assert.That(_roomMessage.ID, Is.EqualTo(id));
+            Assert.That(_roomMessage.Text, Is.EqualTo(text));
+            Assert.That(_roomMessage.ShowAsSpeech, Is.EqualTo(showAsSpeech));
+            Assert.That(_roomMessage.CharacterID, Is.EqualTo(characterId));
+            Assert.That(_roomMessage.DisplayNextMessageAfter, Is.EqualTo(displayNextMessageAfter));
+            Assert.That(_roomMessage.AutoRemoveAfterTime, Is.EqualTo(autoRemoveAfterTime));
+        }
+
+        [TestCase("Test room message.", false, 1, true, false)]
+        [TestCase("Another test room message.", true, 5, false, true)]
+        public void SerializesToXml(string text, bool showAsSpeech, int characterId, bool displayNextMessageAfter, bool autoRemoveAfterTime)
+        {
+            _roomMessage.Text = text;
+            _roomMessage.ShowAsSpeech = showAsSpeech;
+            _roomMessage.CharacterID = characterId;
+            _roomMessage.DisplayNextMessageAfter = displayNextMessageAfter;
+            _roomMessage.AutoRemoveAfterTime = autoRemoveAfterTime;
+            XmlDocument doc = _roomMessage.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomMessage/Text").InnerText, Is.EqualTo(text));
+            Assert.That(doc.SelectSingleNode("/RoomMessage/ShowAsSpeech").InnerText, Is.EqualTo(showAsSpeech.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomMessage/CharacterID").InnerText, Is.EqualTo(characterId.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomMessage/DisplayNextMessageAfter").InnerText, Is.EqualTo(displayNextMessageAfter.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomMessage/AutoRemoveAfterTime").InnerText, Is.EqualTo(autoRemoveAfterTime.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using NUnit.Framework;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -146,6 +147,69 @@ namespace AGS.Types
             _changeNotification.DidNotReceive();
             ((IChangeNotification)_roomObject).ItemModified();
             _changeNotification.Received();
+        }
+
+        [TestCase(230, false, -1, false, 200, 100, "description1", "name1", false, false)]
+        [TestCase(220, true, 0, true, 190, 90, "description2", "name2", true, true)]
+        public void DeserializesFromXml(int image, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        {
+            string xml = $@"
+            <RoomObject>
+                <Image>{image}</Image>
+                <Visible>{visible}</Visible>
+                <Baseline>{baseline}</Baseline>
+                <Clickable>{clickable}</Clickable>
+                <StartX>{startX}</StartX>
+                <StartY>{startY}</StartY>
+                <Description>{description}</Description>
+                <Name>{name}</Name>
+                <UseRoomAreaScaling>{useRoomAreaScaling}</UseRoomAreaScaling>
+                <UseRoomAreaLighting>{useRoomAreaLighting}</UseRoomAreaLighting>
+                <Properties />
+                <Interactions/>
+            </RoomObject>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomObject = new RoomObject(_changeNotification, doc.SelectSingleNode("RoomObject"));
+
+            Assert.That(_roomObject.Image, Is.EqualTo(image));
+            Assert.That(_roomObject.Visible, Is.EqualTo(visible));
+            Assert.That(_roomObject.Baseline, Is.EqualTo(baseline));
+            Assert.That(_roomObject.Clickable, Is.EqualTo(clickable));
+            Assert.That(_roomObject.StartX, Is.EqualTo(startX));
+            Assert.That(_roomObject.StartY, Is.EqualTo(startY));
+            Assert.That(_roomObject.Description, Is.EqualTo(description));
+            Assert.That(_roomObject.Name, Is.EqualTo(name));
+            Assert.That(_roomObject.UseRoomAreaScaling, Is.EqualTo(useRoomAreaScaling));
+            Assert.That(_roomObject.UseRoomAreaLighting, Is.EqualTo(useRoomAreaLighting));
+        }
+
+        [TestCase(230, false, -1, false, 200, 100, "description1", "name1", false, false)]
+        [TestCase(220, true, 0, true, 190, 90, "description2", "name2", true, true)]
+        public void SerializesToXml(int image, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        {
+            _roomObject.Image = image;
+            _roomObject.Visible = visible;
+            _roomObject.Baseline = baseline;
+            _roomObject.Clickable = clickable;
+            _roomObject.StartX = startX;
+            _roomObject.StartY = startY;
+            _roomObject.Description = description;
+            _roomObject.Name = name;
+            _roomObject.UseRoomAreaScaling = useRoomAreaScaling;
+            _roomObject.UseRoomAreaLighting = useRoomAreaLighting;
+            XmlDocument doc = _roomObject.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomObject/Image").InnerText, Is.EqualTo(image.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/Visible").InnerText, Is.EqualTo(visible.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/Baseline").InnerText, Is.EqualTo(baseline.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/Clickable").InnerText, Is.EqualTo(clickable.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/StartX").InnerText, Is.EqualTo(startX.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/StartY").InnerText, Is.EqualTo(startY.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/Description").InnerText, Is.EqualTo(description.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/Name").InnerText, Is.EqualTo(name.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/UseRoomAreaScaling").InnerText, Is.EqualTo(useRoomAreaScaling.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/UseRoomAreaLighting").InnerText, Is.EqualTo(useRoomAreaLighting.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomObjectTests.cs
@@ -149,13 +149,14 @@ namespace AGS.Types
             _changeNotification.Received();
         }
 
-        [TestCase(230, false, -1, false, 200, 100, "description1", "name1", false, false)]
-        [TestCase(220, true, 0, true, 190, 90, "description2", "name2", true, true)]
-        public void DeserializesFromXml(int image, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        [TestCase(230, BlendMode.Normal, false, -1, false, 200, 100, "description1", "name1", false, false)]
+        [TestCase(220, BlendMode.Add, true, 0, true, 190, 90, "description2", "name2", true, true)]
+        public void DeserializesFromXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
         {
             string xml = $@"
             <RoomObject>
                 <Image>{image}</Image>
+                <BlendMode>{blendMode}</BlendMode>
                 <Visible>{visible}</Visible>
                 <Baseline>{baseline}</Baseline>
                 <Clickable>{clickable}</Clickable>
@@ -173,6 +174,7 @@ namespace AGS.Types
             _roomObject = new RoomObject(_changeNotification, doc.SelectSingleNode("RoomObject"));
 
             Assert.That(_roomObject.Image, Is.EqualTo(image));
+            Assert.That(_roomObject.BlendMode, Is.EqualTo(blendMode));
             Assert.That(_roomObject.Visible, Is.EqualTo(visible));
             Assert.That(_roomObject.Baseline, Is.EqualTo(baseline));
             Assert.That(_roomObject.Clickable, Is.EqualTo(clickable));
@@ -184,11 +186,12 @@ namespace AGS.Types
             Assert.That(_roomObject.UseRoomAreaLighting, Is.EqualTo(useRoomAreaLighting));
         }
 
-        [TestCase(230, false, -1, false, 200, 100, "description1", "name1", false, false)]
-        [TestCase(220, true, 0, true, 190, 90, "description2", "name2", true, true)]
-        public void SerializesToXml(int image, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
+        [TestCase(230, BlendMode.Normal, false, -1, false, 200, 100, "description1", "name1", false, false)]
+        [TestCase(220, BlendMode.Add, true, 0, true, 190, 90, "description2", "name2", true, true)]
+        public void SerializesToXml(int image, BlendMode blendMode, bool visible, int baseline, bool clickable, int startX, int startY, string description, string name, bool useRoomAreaScaling, bool useRoomAreaLighting)
         {
             _roomObject.Image = image;
+            _roomObject.BlendMode = blendMode;
             _roomObject.Visible = visible;
             _roomObject.Baseline = baseline;
             _roomObject.Clickable = clickable;
@@ -201,6 +204,7 @@ namespace AGS.Types
             XmlDocument doc = _roomObject.ToXmlDocument();
 
             Assert.That(doc.SelectSingleNode("/RoomObject/Image").InnerText, Is.EqualTo(image.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomObject/BlendMode").InnerText, Is.EqualTo(blendMode.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/Visible").InnerText, Is.EqualTo(visible.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/Baseline").InnerText, Is.EqualTo(baseline.ToString()));
             Assert.That(doc.SelectSingleNode("/RoomObject/Clickable").InnerText, Is.EqualTo(clickable.ToString()));

--- a/Editor/AGS.Editor.Tests/Types/RoomRegionTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomRegionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Xml;
 using NUnit.Framework;
 
 namespace AGS.Types
@@ -97,6 +98,56 @@ namespace AGS.Types
         {
             _roomRegion.ID = id;
             Assert.That(_roomRegion.PropertyGridTitle, Is.EqualTo($"Region ID {id}"));
+        }
+
+        [TestCase(false, 100, 30, 40, 50, 60, 70)]
+        [TestCase(true, 90, 40, 50, 60, 70, 80)]
+        public void DeserializesFromXml(bool useColourTint, int lightLevel, int redTint, int greenTint, int blueTint, int tintSaturation, int tintLuminance)
+        {
+            string xml = $@"
+            <RoomRegion>
+                <UseColourTint>{useColourTint}</UseColourTint>
+                <LightLevel>{lightLevel}</LightLevel>
+                <RedTint>{redTint}</RedTint>
+                <GreenTint>{greenTint}</GreenTint>
+                <BlueTint>{blueTint}</BlueTint>
+                <TintSaturation>{tintSaturation}</TintSaturation>
+                <TintLuminance>{tintLuminance}</TintLuminance>
+                <Interactions/>
+            </RoomRegion>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomRegion = new RoomRegion(doc.SelectSingleNode("RoomRegion"));
+
+            Assert.That(_roomRegion.UseColourTint, Is.EqualTo(useColourTint));
+            Assert.That(_roomRegion.LightLevel, Is.EqualTo(lightLevel));
+            Assert.That(_roomRegion.RedTint, Is.EqualTo(redTint));
+            Assert.That(_roomRegion.GreenTint, Is.EqualTo(greenTint));
+            Assert.That(_roomRegion.BlueTint, Is.EqualTo(blueTint));
+            Assert.That(_roomRegion.TintSaturation, Is.EqualTo(tintSaturation));
+            Assert.That(_roomRegion.TintLuminance, Is.EqualTo(tintLuminance));
+        }
+
+        [TestCase(false, 100, 30, 40, 50, 60, 70)]
+        [TestCase(true, 90, 40, 50, 60, 70, 80)]
+        public void SerializesToXml(bool useColourTint, int lightLevel, int redTint, int greenTint, int blueTint, int tintSaturation, int tintLuminance)
+        {
+            _roomRegion.UseColourTint = useColourTint;
+            _roomRegion.LightLevel = lightLevel;
+            _roomRegion.RedTint = redTint;
+            _roomRegion.GreenTint = greenTint;
+            _roomRegion.BlueTint = blueTint;
+            _roomRegion.TintSaturation = tintSaturation;
+            _roomRegion.TintLuminance = tintLuminance;
+            XmlDocument doc = _roomRegion.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomRegion/UseColourTint").InnerText, Is.EqualTo(useColourTint.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/LightLevel").InnerText, Is.EqualTo(lightLevel.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/RedTint").InnerText, Is.EqualTo(redTint.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/GreenTint").InnerText, Is.EqualTo(greenTint.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/BlueTint").InnerText, Is.EqualTo(blueTint.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/TintSaturation").InnerText, Is.EqualTo(tintSaturation.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomRegion/TintLuminance").InnerText, Is.EqualTo(tintLuminance.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -186,6 +187,109 @@ namespace AGS.Types
         public void GetsMaskScaleThrowsExceptionWithIllegalMask()
         {
             Assert.Throws<ArgumentException>(() => _room.GetMaskScale(RoomAreaMaskType.None));
+        }
+
+        [TestCase(1, 2, 1174750494, 320, 240, 5, 0, true, false, 1, RoomVolumeAdjustment.Normal, 1, 2, 3, 4, 2, "description1")]
+        [TestCase(2, 1, 1174750495, 640, 480, 4, 1, false, true, 0, RoomVolumeAdjustment.Loud, 2, 3, 4, 5, 3, "description2")]
+        public void DeserializesFromXml(int maskResolution, int backgroundCount, int gameId, int width, int height,
+            int backgroundAnimationDelay, int playMusicOnRoomLoad, bool saveLoadEnabled, bool showPlayerCharacter,
+            int playerCharacterView, RoomVolumeAdjustment musicVolumeAdjustment, int leftEdgeX, int rightEdgeX,
+            int topEdgeY, int bottomEdgeY, int number, string description)
+        {
+            string xml = $@"
+            <Room>
+                <MaskResolution>{maskResolution}</MaskResolution>
+                <BackgroundCount>{backgroundCount}</BackgroundCount>
+                <GameID>{gameId}</GameID>
+                <Width>{width}</Width>
+                <Height>{height}</Height>
+                <BackgroundAnimationDelay>{backgroundAnimationDelay}</BackgroundAnimationDelay>
+                <PlayMusicOnRoomLoad>{playMusicOnRoomLoad}</PlayMusicOnRoomLoad>
+                <SaveLoadEnabled>{saveLoadEnabled}</SaveLoadEnabled>
+                <ShowPlayerCharacter>{showPlayerCharacter}</ShowPlayerCharacter>
+                <PlayerCharacterView>{playerCharacterView}</PlayerCharacterView>
+                <MusicVolumeAdjustment>{musicVolumeAdjustment}</MusicVolumeAdjustment>
+                <LeftEdgeX>{leftEdgeX}</LeftEdgeX>
+                <RightEdgeX>{rightEdgeX}</RightEdgeX>
+                <TopEdgeY>{topEdgeY}</TopEdgeY>
+                <BottomEdgeY>{bottomEdgeY}</BottomEdgeY>
+                <Properties/>
+                <Number>{number}</Number>
+                <Description xml:space=""preserve"">{description}</Description>
+                <Interactions/>
+                <Messages/>
+                <Objects/>
+                <Hotspots/>
+                <WalkableAreas/>
+                <WalkBehinds/>
+                <Regions/>
+            </Room>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _room = new Room(doc.SelectSingleNode("Room"));
+
+            Assert.That(_room.MaskResolution, Is.EqualTo(maskResolution));
+            Assert.That(_room.BackgroundCount, Is.EqualTo(backgroundCount));
+            Assert.That(_room.GameID, Is.EqualTo(gameId));
+            Assert.That(_room.Width, Is.EqualTo(width));
+            Assert.That(_room.Height, Is.EqualTo(height));
+            Assert.That(_room.BackgroundAnimationDelay, Is.EqualTo(backgroundAnimationDelay));
+            Assert.That(_room.PlayMusicOnRoomLoad, Is.EqualTo(playMusicOnRoomLoad));
+            Assert.That(_room.SaveLoadEnabled, Is.EqualTo(saveLoadEnabled));
+            Assert.That(_room.ShowPlayerCharacter, Is.EqualTo(showPlayerCharacter));
+            Assert.That(_room.PlayerCharacterView, Is.EqualTo(playerCharacterView));
+            Assert.That(_room.MusicVolumeAdjustment, Is.EqualTo(musicVolumeAdjustment));
+            Assert.That(_room.LeftEdgeX, Is.EqualTo(leftEdgeX));
+            Assert.That(_room.RightEdgeX, Is.EqualTo(rightEdgeX));
+            Assert.That(_room.TopEdgeY, Is.EqualTo(topEdgeY));
+            Assert.That(_room.BottomEdgeY, Is.EqualTo(bottomEdgeY));
+            Assert.That(_room.Number, Is.EqualTo(number));
+            Assert.That(_room.Description, Is.EqualTo(description));
+        }
+
+        [TestCase(1, 2, 1174750494, 320, 240, 5, 0, true, false, 1, RoomVolumeAdjustment.Normal, 1, 2, 3, 4, 2, "description1")]
+        [TestCase(2, 1, 1174750495, 640, 480, 4, 1, false, true, 0, RoomVolumeAdjustment.Loud, 2, 3, 4, 5, 3, "description2")]
+        public void SerializesToXml(int maskResolution, int backgroundCount, int gameId, int width, int height,
+            int backgroundAnimationDelay, int playMusicOnRoomLoad, bool saveLoadEnabled, bool showPlayerCharacter,
+            int playerCharacterView, RoomVolumeAdjustment musicVolumeAdjustment, int leftEdgeX, int rightEdgeX,
+            int topEdgeY, int bottomEdgeY, int number, string description)
+        {
+            _room.MaskResolution = maskResolution;
+            _room.BackgroundCount = backgroundCount;
+            _room.GameID = gameId;
+            _room.Width = width;
+            _room.Height = height;
+            _room.BackgroundAnimationDelay = backgroundAnimationDelay;
+            _room.PlayMusicOnRoomLoad = playMusicOnRoomLoad;
+            _room.SaveLoadEnabled = saveLoadEnabled;
+            _room.ShowPlayerCharacter = showPlayerCharacter;
+            _room.PlayerCharacterView = playerCharacterView;
+            _room.MusicVolumeAdjustment = musicVolumeAdjustment;
+            _room.LeftEdgeX = leftEdgeX;
+            _room.RightEdgeX = rightEdgeX;
+            _room.TopEdgeY = topEdgeY;
+            _room.BottomEdgeY = bottomEdgeY;
+            _room.Number = number;
+            _room.Description = description;
+            XmlDocument doc = _room.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/Room/MaskResolution").InnerText, Is.EqualTo(maskResolution.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/BackgroundCount").InnerText, Is.EqualTo(backgroundCount.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/GameID").InnerText, Is.EqualTo(gameId.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/Width").InnerText, Is.EqualTo(width.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/Height").InnerText, Is.EqualTo(height.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/BackgroundAnimationDelay").InnerText, Is.EqualTo(backgroundAnimationDelay.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/PlayMusicOnRoomLoad").InnerText, Is.EqualTo(playMusicOnRoomLoad.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/SaveLoadEnabled").InnerText, Is.EqualTo(saveLoadEnabled.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/ShowPlayerCharacter").InnerText, Is.EqualTo(showPlayerCharacter.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/PlayerCharacterView").InnerText, Is.EqualTo(playerCharacterView.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/MusicVolumeAdjustment").InnerText, Is.EqualTo(musicVolumeAdjustment.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/LeftEdgeX").InnerText, Is.EqualTo(leftEdgeX.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/RightEdgeX").InnerText, Is.EqualTo(rightEdgeX.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/TopEdgeY").InnerText, Is.EqualTo(topEdgeY.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/BottomEdgeY").InnerText, Is.EqualTo(bottomEdgeY.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/Number").InnerText, Is.EqualTo(number.ToString()));
+            Assert.That(doc.SelectSingleNode("/Room/Description").InnerText, Is.EqualTo(description.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomWalkBehindTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomWalkBehindTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -39,6 +40,31 @@ namespace AGS.Types
         {
             _roomWalkBehind.ID = id;
             Assert.That(_roomWalkBehind.PropertyGridTitle, Is.EqualTo($"Walk-behind area ID {id}"));
+        }
+
+        [TestCase(230)]
+        [TestCase(250)]
+        public void DeserializesFromXml(int baseline)
+        {
+            string xml = $@"
+            <RoomWalkBehind>
+                <Baseline>{baseline}</Baseline>
+            </RoomWalkBehind>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomWalkBehind = new RoomWalkBehind(doc.SelectSingleNode("RoomWalkBehind"));
+
+            Assert.That(_roomWalkBehind.Baseline, Is.EqualTo(baseline));
+        }
+
+        [TestCase(230)]
+        [TestCase(250)]
+        public void SerializesToXml(int baseline)
+        {
+            _roomWalkBehind.Baseline = baseline;
+            XmlDocument doc = _roomWalkBehind.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomWalkBehind/Baseline").InnerText, Is.EqualTo(baseline.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomWalkableAreaTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomWalkableAreaTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -73,6 +74,47 @@ namespace AGS.Types
         {
             _roomWalkAbleArea.ID = id;
             Assert.That(_roomWalkAbleArea.PropertyGridTitle, Is.EqualTo($"Walkable area ID {id}"));
+        }
+
+        [TestCase(5, false, 50, 60, 70)]
+        [TestCase(3, true, 40, 50, 60)]
+        public void DeserializesFromXml(int areaSpecificView, bool userContinousScaling, int scalingLevel, int minScalingLevel, int maxScalingLevel)
+        {
+            string xml = $@"
+            <RoomWalkableArea>
+                <AreaSpecificView>{areaSpecificView}</AreaSpecificView>
+                <UseContinuousScaling>{userContinousScaling}</UseContinuousScaling>
+                <ScalingLevel>{scalingLevel}</ScalingLevel>
+                <MinScalingLevel>{minScalingLevel}</MinScalingLevel>
+                <MaxScalingLevel>{maxScalingLevel}</MaxScalingLevel>
+            </RoomWalkableArea>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _roomWalkAbleArea = new RoomWalkableArea(doc.SelectSingleNode("RoomWalkableArea"));
+
+            Assert.That(_roomWalkAbleArea.AreaSpecificView, Is.EqualTo(areaSpecificView));
+            Assert.That(_roomWalkAbleArea.UseContinuousScaling, Is.EqualTo(userContinousScaling));
+            Assert.That(_roomWalkAbleArea.ScalingLevel, Is.EqualTo(scalingLevel));
+            Assert.That(_roomWalkAbleArea.MinScalingLevel, Is.EqualTo(minScalingLevel));
+            Assert.That(_roomWalkAbleArea.MaxScalingLevel, Is.EqualTo(maxScalingLevel));
+        }
+
+        [TestCase(5, false, 50, 60, 70)]
+        [TestCase(3, true, 40, 50, 60)]
+        public void SerializesToXml(int areaSpecificView, bool userContinousScaling, int scalingLevel, int minScalingLevel, int maxScalingLevel)
+        {
+            _roomWalkAbleArea.AreaSpecificView = areaSpecificView;
+            _roomWalkAbleArea.UseContinuousScaling = userContinousScaling;
+            _roomWalkAbleArea.ScalingLevel = scalingLevel;
+            _roomWalkAbleArea.MinScalingLevel = minScalingLevel;
+            _roomWalkAbleArea.MaxScalingLevel = maxScalingLevel;
+            XmlDocument doc = _roomWalkAbleArea.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/RoomWalkableArea/AreaSpecificView").InnerText, Is.EqualTo(areaSpecificView.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomWalkableArea/UseContinuousScaling").InnerText, Is.EqualTo(userContinousScaling.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomWalkableArea/ScalingLevel").InnerText, Is.EqualTo(scalingLevel.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomWalkableArea/MinScalingLevel").InnerText, Is.EqualTo(minScalingLevel.ToString()));
+            Assert.That(doc.SelectSingleNode("/RoomWalkableArea/MaxScalingLevel").InnerText, Is.EqualTo(maxScalingLevel.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/UnloadedRoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/UnloadedRoomTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Xml;
 
 namespace AGS.Types
 {
@@ -81,6 +82,35 @@ namespace AGS.Types
             _unloadedRoom.Script = new Script("dummy", "dummy", false);
             _unloadedRoom.Script = null;
             Assert.That(_unloadedRoom.Script, Is.Null);
+        }
+
+        [TestCase(1, "description1")]
+        [TestCase(2, "description2")]
+        public void DeserializesFromXml(int number, string description)
+        {
+            string xml = $@"
+            <UnloadedRoom>
+                <Number>{number}</Number>
+                <Description xml:space=""preserve"">{description}</Description>
+            </UnloadedRoom>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            _unloadedRoom = new UnloadedRoom(doc.SelectSingleNode("UnloadedRoom"));
+
+            Assert.That(_unloadedRoom.Number, Is.EqualTo(number));
+            Assert.That(_unloadedRoom.Description, Is.EqualTo(description));
+        }
+
+        [TestCase(1, "description1")]
+        [TestCase(2, "description2")]
+        public void SerializesToXml(int number, string description)
+        {
+            _unloadedRoom.Number = number;
+            _unloadedRoom.Description = description;
+            XmlDocument doc = _unloadedRoom.ToXmlDocument();
+
+            Assert.That(doc.SelectSingleNode("/UnloadedRoom/Number").InnerText, Is.EqualTo(number.ToString()));
+            Assert.That(doc.SelectSingleNode("/UnloadedRoom/Description").InnerText, Is.EqualTo(description.ToString()));
         }
     }
 }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1776,6 +1776,7 @@ namespace AGS.Editor.Components
             {
                 _backgroundCache.Add(_nativeProxy.GetBitmapForBackground(_loadedRoom, i));
             }
+            _loadedRoom.ColorDepth = _backgroundCache[0].GetColorDepth();
 
             foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))
             {

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -181,6 +181,7 @@
       <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Native\acfonts_agsnative.cpp" />

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
     [PropertyTab(typeof(PropertyTabInteractions), PropertyTabScope.Component)]
     [DefaultProperty("Description")]
-    public class RoomHotspot : IChangeNotification
+    public class RoomHotspot : IChangeNotification, IToXml
 	{
 		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
 
@@ -36,6 +37,13 @@ namespace AGS.Types
 			_notifyOfModification = changeNotifier;
 		}
 
+        public RoomHotspot(IChangeNotification changeNotifier, XmlNode node) : this(changeNotifier)
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+            Interactions.FromXml(node);
+        }
+
+        [AGSNoSerialize]
         [Description("The ID number of the hotspot")]
         [Category("Design")]
         [ReadOnly(true)]
@@ -86,7 +94,7 @@ namespace AGS.Types
             protected set { _properties = value; }
         }
 
-        [AGSNoSerialize()]
+        [AGSSerializeClass()]
         [Browsable(false)]
         public Interactions Interactions
         {
@@ -97,5 +105,12 @@ namespace AGS.Types
 		{
 			_notifyOfModification.ItemModified();
 		}
-	}
+
+        public void ToXml(XmlTextWriter writer)
+        {
+            SerializeUtils.SerializeToXML(this, writer, false);
+            Interactions.ToXml(writer);
+            writer.WriteEndElement();
+        }
+    }
 }

--- a/Editor/AGS.Types/RoomMessage.cs
+++ b/Editor/AGS.Types/RoomMessage.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
-    public class RoomMessage
+    public class RoomMessage : IToXml
     {
         private int _id;
         private string _text = string.Empty;
@@ -18,6 +19,12 @@ namespace AGS.Types
             _id = id;
         }
 
+        public RoomMessage(int id, XmlNode node) : this(id)
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+        }
+
+        [AGSNoSerialize]
         public int ID
         {
             get { return _id; }
@@ -57,5 +64,7 @@ namespace AGS.Types
             get { return _autoRemoveAfterTime; }
             set { _autoRemoveAfterTime = value; }
         }
+
+        public void ToXml(XmlTextWriter writer) => SerializeUtils.SerializeToXML(this, writer);
     }
 }

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -2,12 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
     [PropertyTab(typeof(PropertyTabInteractions), PropertyTabScope.Component)]
     [DefaultProperty("Image")]
-	public class RoomObject : IComparable<RoomObject>, IChangeNotification, ICustomTypeDescriptor
+	public class RoomObject : IComparable<RoomObject>, IChangeNotification, ICustomTypeDescriptor, IToXml
     {
 		public const string PROPERTY_NAME_SCRIPT_NAME = "Name";
 
@@ -42,6 +43,12 @@ namespace AGS.Types
 		{
 			_notifyOfModification = changeNotifier;
 		}
+
+        public RoomObject(IChangeNotification changeNotifier, XmlNode node) : this(changeNotifier)
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+            Interactions.FromXml(node);
+        }
 
         [Description("The ID number of the object")]
         [Category("Design")]
@@ -285,6 +292,13 @@ namespace AGS.Types
 			return this;
 		}
 
-		#endregion
-	}
+        #endregion
+
+        public void ToXml(XmlTextWriter writer)
+        {
+            SerializeUtils.SerializeToXML(this, writer, false);
+            _interactions.ToXml(writer);
+            writer.WriteEndElement();
+        }
+    }
 }

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -50,6 +50,7 @@ namespace AGS.Types
             Interactions.FromXml(node);
         }
 
+        [AGSNoSerialize]
         [Description("The ID number of the object")]
         [Category("Design")]
         [ReadOnly(true)]

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
     [PropertyTab(typeof(PropertyTabInteractions), PropertyTabScope.Component)]
     [DefaultProperty("LightLevel")]
-    public class RoomRegion : ICustomTypeDescriptor
+    public class RoomRegion : ICustomTypeDescriptor, IToXml
     {
         private static InteractionSchema _interactionSchema;
 
@@ -31,6 +32,17 @@ namespace AGS.Types
                 new string[] { "Standing", "WalksOnto", "WalksOff" });
         }
 
+        public RoomRegion()
+        {
+        }
+
+        public RoomRegion(XmlNode node) : this()
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+            Interactions.FromXml(node);
+        }
+
+        [AGSNoSerialize]
         [Description("The ID number of the region")]
         [Category("Design")]
         [ReadOnly(true)]
@@ -112,7 +124,7 @@ namespace AGS.Types
             get { return "Region ID " + _id; }
         }
 
-        [AGSNoSerialize()]
+        [AGSSerializeClass]
         [Browsable(false)]
         public Interactions Interactions
         {
@@ -211,5 +223,6 @@ namespace AGS.Types
 
         #endregion
 
+        public void ToXml(XmlTextWriter writer) => SerializeUtils.SerializeToXML(this, writer);
     }
 }

--- a/Editor/AGS.Types/RoomWalkBehind.cs
+++ b/Editor/AGS.Types/RoomWalkBehind.cs
@@ -3,14 +3,24 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
     [DefaultProperty("Baseline")]
-    public class RoomWalkBehind
+    public class RoomWalkBehind : IToXml
     {
         private int _id;
         private int _baseline;
+
+        public RoomWalkBehind()
+        {
+        }
+
+        public RoomWalkBehind(XmlNode node) : this()
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+        }
 
         [Description("The ID number of the walk-behind area")]
         [Category("Design")]
@@ -35,5 +45,6 @@ namespace AGS.Types
             get { return "Walk-behind area ID " + _id; }
         }
 
+        public void ToXml(XmlTextWriter writer) => SerializeUtils.SerializeToXML(this, writer);
     }
 }

--- a/Editor/AGS.Types/RoomWalkBehind.cs
+++ b/Editor/AGS.Types/RoomWalkBehind.cs
@@ -22,6 +22,7 @@ namespace AGS.Types
             SerializeUtils.DeserializeFromXML(this, node);
         }
 
+        [AGSNoSerialize]
         [Description("The ID number of the walk-behind area")]
         [Category("Design")]
         [ReadOnly(true)]

--- a/Editor/AGS.Types/RoomWalkableArea.cs
+++ b/Editor/AGS.Types/RoomWalkableArea.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Text;
+using System.Xml;
 
 namespace AGS.Types
 {
     [DefaultProperty("ScalingLevel")]
-    public class RoomWalkableArea : ICustomTypeDescriptor
+    public class RoomWalkableArea : ICustomTypeDescriptor, IToXml
     {
         private int _id;
         private int _areaSpecificView;
@@ -16,6 +17,16 @@ namespace AGS.Types
         private int _scalingLevelMin = 100;
         private int _scalingLevelMax = 100;
 
+        public RoomWalkableArea()
+        {
+        }
+
+        public RoomWalkableArea(XmlNode node) : this()
+        {
+            SerializeUtils.DeserializeFromXML(this, node);
+        }
+
+        [AGSNoSerialize]
         [Description("The ID number of the walkable area")]
         [Category("Design")]
         [ReadOnly(true)]
@@ -165,5 +176,6 @@ namespace AGS.Types
 
         #endregion
 
+        public void ToXml(XmlTextWriter writer) => SerializeUtils.SerializeToXML(this, writer);
     }
 }

--- a/Editor/AGS.Types/SerializeUtils.cs
+++ b/Editor/AGS.Types/SerializeUtils.cs
@@ -78,6 +78,23 @@ namespace AGS.Types
         }
 
         /// <summary>
+        /// Serializes enumerable to xml. 
+        /// </summary>
+        /// <typeparam name="T">The type in the collection. Must implement the <see cref="IToXml"/> interface.</typeparam>
+        /// <param name="writer">The xml writer to add the xml to.</param>
+        /// <param name="name">The name of the xml tag that the collection will we wrapped in.</param>
+        /// <param name="collection">The collection to serialize</param>
+        public static void SerializeToXML<T>(XmlTextWriter writer, string name, IEnumerable<T> collection) where T : IToXml
+        {
+            writer.WriteStartElement(name);
+            foreach (var element in collection)
+            {
+                element.ToXml(writer);
+            }
+            writer.WriteEndElement();
+        }
+
+        /// <summary>
         /// Serializes properties of the object into the current node.
         /// </summary>
         /// <param name="obj"></param>

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -117,7 +117,7 @@ namespace AGS.Types
             SerializeUtils.DeserializeFromXML(this, node);
         }
 
-        public void ToXml(XmlTextWriter writer)
+        public virtual void ToXml(XmlTextWriter writer)
         {
             SerializeUtils.SerializeToXML(this, writer);
         }


### PR DESCRIPTION
Related to #469 

Room entities was lacking serialization handling so I added it, with test cases as proof of concept since no actual uses this yet. They will be used in the next PR related to converting the rooms to open format, but this was big enough change I felt it warranted an isolated PR.

The QA I did here was to make sure that the serialization and deserialization handled all the properties that being read/written in `load_crm_file(...)` and `save_crm_file(...)` from `agsnative.cpp`, and I wrote tests that handles these properties from xml. Anything left out can probably be added in the next PR.

I realize there's an ongoing discussion about using yaml instead, but we already have lots of convenient code for handling xml and I feel like adding yaml and handling it for ags should be a separate issue that maybe covers more than the room format. For now I use xml, we always change it later.