### PR TITLE
Linux: package newest versions of Xiph libraries

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,16 @@ build_linux_debian_task:
       DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" fakeroot debian/rules binary
       sed -E "/^BI(NDMOUNT|T)=/d" debian/ags+libraries/hooks/B00_copy_libs.sh | BIT=$bit BINDMOUNT=$(pwd) sh
       ar -p ../ags_${version}_$arch.deb data.tar.xz | unxz | tar -f - -xvC data --transform "s/.*ags/ags$bit/" ./usr/bin/ags
-      cd data && tar -cvzf ../data_$arch.tar.gz *
+      cd data && \
+      (cd lib$bit && find . \
+        \( \
+        -name "libogg.so.*" -o \
+        -name "libtheora.so.*" -o \
+        -name "libvorbisfile.so.*" -o \
+        -name "libvorbis.so.*" \
+        \) \
+        -exec cp -L -v "/opt/lib/{}" "{}" \;) && \
+      tar -cvzf ../data_$arch.tar.gz *
     else
       fakeroot debian/rules binary
       mv ../ags_${version}_$arch.deb .

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -29,6 +29,33 @@ RUN apt-get install \
   libvorbis-dev \
   pkg-config
 
+# Build newer libogg
+ARG LIBOGG_VERSION=1.3.4
+RUN curl -fLsS "https://downloads.xiph.org/releases/ogg/libogg-$LIBOGG_VERSION.tar.gz" | tar -f - -xvzC /tmp && \
+  cd /tmp/libogg-$LIBOGG_VERSION && \
+  ./configure --prefix=/opt && \
+  make && \
+  make install && \
+  rm -r /tmp/libogg-$LIBOGG_VERSION
+
+# Build newer libvorbis
+ARG LIBVORBIS_VERSION=1.3.7
+RUN curl -fLsS "https://downloads.xiph.org/releases/vorbis/libvorbis-$LIBVORBIS_VERSION.tar.xz" | tar -f - -xvJC /tmp && \
+  cd /tmp/libvorbis-$LIBVORBIS_VERSION && \
+  ./configure --disable-examples --disable-oggtest --prefix=/opt && \
+  make && \
+  make install && \
+  rm -r /tmp/libvorbis-$LIBVORBIS_VERSION
+
+# Build newer libtheora - note that encoding support is disabled
+ARG LIBTHEORA_VERSION=1.1.1
+RUN curl -fLsS "https://downloads.xiph.org/releases/theora/libtheora-$LIBTHEORA_VERSION.tar.bz2" | tar -f - -xvjC /tmp && \
+  cd /tmp/libtheora-$LIBTHEORA_VERSION && \
+  ./configure --disable-encode --disable-examples --disable-oggtest --prefix=/opt && \
+  make && \
+  make install && \
+  rm -r /tmp/libtheora-$LIBTHEORA_VERSION
+
 # Build and install CMake
 ARG CMAKE_VERSION=3.14.5
 RUN curl -fLsS "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" | tar -f - -xvzC /tmp && \


### PR DESCRIPTION
Adds build of libogg, libtheora, and libvorbis into the Linux build Docker container, with installation into /opt. Installing here means that the existing Debian hook script still gives the same result, but newer versions are available to be copied into the archive which is distributed as the Linux version of the engine.

The CI task which builds intermediate archives for each architecture will now look to replace the named Xiph libraries, if present. i.e. lib64/libvorbis.so.0 will be replaced by dereferencing /opt/lib/libvorbis.so.0 when lib64/libvorbis.so.0 exists

This should be seen as a short term change to work around issues found within older Debian libraries, ideally final archive archive contents need to be verified to be in the correct state but this needs further improvements to the build system.