### PR TITLE
Engine: Fix positioning with custom text window GUI

### DIFF
--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -228,7 +228,7 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
     }
     else {
         int xoffs,yoffs, oriwid = wii - padding * 2;
-        draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &xoffs,&yoffs,&xx,&yy,&wii,&text_color);
+        draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &xoffs,&yoffs,&adjustedXX,&adjustedYY,&wii,&text_color);
 
         if (game.options[OPT_TWCUSTOM] > 0)
         {


### PR DESCRIPTION
This was a regression introduced with commit 41d156ef63 (from pull request #1104). Only one of the two calls to draw_text_window_and_bar in _display_main were changed to pass the local adjustedXX and adjustedYY variables. Games using the other unmodified call (when `asspch` is 0) have their text boxes shifted to the bottom and right as a result.

For example in Order of the Thorne: The King's Challenge, we get
![image](https://user-images.githubusercontent.com/552105/111071694-3f4c6500-84cf-11eb-9b6a-dfbeeb571d6d.png)

And with the fix in this pull request we get
![image](https://user-images.githubusercontent.com/552105/111071705-4ffcdb00-84cf-11eb-8492-a6e32d9fd440.png)

The Blackwell Converge is another game impacted:

Current master:
![image](https://user-images.githubusercontent.com/552105/111071727-6f940380-84cf-11eb-896d-5c00161d1de0.png)

With the fix in this pull request:
![image](https://user-images.githubusercontent.com/552105/111071740-7d498900-84cf-11eb-8877-b14e2f23f0d2.png)
