### PR TITLE
3.5.0 patch: on Linux: fixed OpenGL window did not set to proper size after GL init

### DIFF
--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -470,18 +470,20 @@ bool OGLGraphicsDriver::InitGlScreen(const DisplayMode &mode)
       }
 
       XSetWMNormalHints(_xwin.display, _xwin.wm_window, hints);
+      XFree(hints);
     }
 
-    XFree(hints);
+    // Resize managed window
+    XResizeWindow(_xwin.display, _xwin.wm_window, mode.Width, mode.Height);
   }
-
-  // Set the window we are actually drawing into to the desired size.
-  XResizeWindow(_xwin.display, _xwin.window, mode.Width, mode.Height);
 
   // Make Allegro aware of the new window size, otherwise the mouse cursor
   // movement may be erratic.
   _xwin.window_width = mode.Width;
   _xwin.window_height = mode.Height;
+
+  // Set the window we are actually drawing into to the desired size.
+  XResizeWindow(_xwin.display, _xwin.window, mode.Width, mode.Height);
 
   {
     // Ask the window manager to add (or remove) the "fullscreen" property on


### PR DESCRIPTION
Resolves #1145.

This supposedly fixes XWindow not updated to the wanted size immediately after GL init. I don't know how often (and to how many users) this happens, it happened to me on Ubuntu virtual machine, and also several users reported this happening with our prebuilt binaries (meaning they also used Ubuntu/Debian).

The window parameters seem to be set correctly, because it would stretch automatically as soon as user drags it around. So probably the problem was that it did not update right after new params are set.

To be honest, I have close to zero knowledge of how XWindows work, and this fix was more a result of experimentation. It would be great if someone can give it a test. I'll try to make users who reported this to test this too.