### PR TITLE
New compiler: Fix bug: Dump when an assignment follows a function symbol

### DIFF
--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -455,22 +455,29 @@ public:
     // Functions
     inline size_t NumOfFuncParams(Symbol func) const
         { return IsFunction(func) ? entries.at(func).FunctionD->Parameters.size() - 1 : 0; }
-    inline bool IsVariadicFunc(Symbol func) const { return entries.at(func).FunctionD->IsVariadic; }
+    inline bool IsVariadicFunc(Symbol func) const
+        { return IsFunction(func) && entries.at(func).FunctionD->IsVariadic; }
     inline AGS::Vartype FuncReturnVartype(Symbol func) const
-        { return entries.at(func).FunctionD->Parameters[0u].Vartype; }
+        { return IsFunction(func) ? entries.at(func).FunctionD->Parameters[0u].Vartype : kKW_NoSymbol; }
 
     // Variables
-    inline bool IsImport(Symbol s) const { TypeQualifierSet const &TQ = entries.at(s).VariableD->TypeQualifiers; return TQ[TQ::kImport]; }
+    inline bool IsImport(Symbol s) const
+        { return IsVariable(s) ? entries.at(s).VariableD->TypeQualifiers[TQ::kImport] : false; }
     inline bool IsParameter(Symbol s) const { return kParameterScope == entries.at(s).Scope; };
     // The vartype of the variable, i.e. "int" or "Dynarray *"
-    inline AGS::Vartype GetVartype(Symbol s) const { return IsVariable(s) && entries.at(s).VariableD->Vartype; }
-    inline bool IsAttribute(Symbol s) const { return IsVariable(s) && entries.at(s).VariableD->TypeQualifiers[TQ::kAttribute]; }
+    inline AGS::Vartype GetVartype(Symbol s) const
+        { return IsVariable(s) ? entries.at(s).VariableD->Vartype : kKW_NoSymbol; }
+    inline bool IsAttribute(Symbol s) const
+        { return IsVariable(s) && entries.at(s).VariableD->TypeQualifiers[TQ::kAttribute]; }
     ScopeType GetScopeType(Symbol s) const;
 
     // Operators
-    inline int BinaryOpPrio(Symbol s) const { return entries.at(s).OperatorD->BinaryPrio; }
-    inline int UnaryOpPrio(Symbol s) const { return entries.at(s).OperatorD->UnaryPrio; }
-    inline CodeCell OperatorOpcode(Symbol s) const { return entries.at(s).OperatorD->Opcode; }
+    inline int BinaryOpPrio(Symbol s) const
+        { return IsOperator(s) ? entries.at(s).OperatorD->BinaryPrio : 0; }
+    inline int UnaryOpPrio(Symbol s) const
+        { return IsOperator(s) ? entries.at(s).OperatorD->UnaryPrio : 0; }
+    inline CodeCell OperatorOpcode(Symbol s) const
+        { return IsOperator(s) ? entries.at(s).OperatorD->Opcode : 0; }
 
     // Strings
     bool IsAnyStringVartype(Symbol s) const;

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -463,7 +463,7 @@ public:
     inline bool IsImport(Symbol s) const { TypeQualifierSet const &TQ = entries.at(s).VariableD->TypeQualifiers; return TQ[TQ::kImport]; }
     inline bool IsParameter(Symbol s) const { return kParameterScope == entries.at(s).Scope; };
     // The vartype of the variable, i.e. "int" or "Dynarray *"
-    inline AGS::Vartype GetVartype(Symbol s) const { return entries.at(s).VariableD->Vartype; }
+    inline AGS::Vartype GetVartype(Symbol s) const { return IsVariable(s) && entries.at(s).VariableD->Vartype; }
     inline bool IsAttribute(Symbol s) const { return IsVariable(s) && entries.at(s).VariableD->TypeQualifiers[TQ::kAttribute]; }
     ScopeType GetScopeType(Symbol s) const;
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3830,11 +3830,16 @@ bool AGS::Parser::AccessData_MayAccessClobberAX(SrcList &expression)
     if (1u == expression_length)
         return !_sym.IsVariable(first_sym);
 
-    Vartype outer_vartype = _sym.IsVartype(first_sym) ? first_sym : _sym.GetVartype(first_sym);
+    Vartype outer_vartype =
+        _sym.IsVartype(first_sym) ? first_sym :
+        _sym.IsVariable(first_sym) ? _sym.GetVartype(first_sym) :
+        kKW_NoSymbol;
     for (size_t dot_idx = 1; dot_idx < expression.Length() - 2; dot_idx += 2)
     {
         if (kKW_Dot != expression[dot_idx])
             return true;
+        if (!_sym.IsVartype(outer_vartype))
+            return false; // This is an error, but we'll find out about that later
         Symbol const unqualified_component = expression[dot_idx + 1];
         auto const &outer_components = _sym[outer_vartype].VartypeD->Components;
         if (0 == outer_components.count(unqualified_component))

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1264,3 +1264,31 @@ TEST_F(Compile1, ForwardStructAutoptr)
     ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
     EXPECT_NE(std::string::npos, msg2.find("'builtin'"));
 }
+
+TEST_F(Compile1, FuncThenAssign)
+{
+    // A function symbol in front of an assignment
+    // The compiler should complain about a missing '('  
+
+    char *inpl2 = "\
+        import int GetTextHeight                    \n\
+            (const string text, int, int width);    \n\
+                                                    \n\
+        builtin managed struct Character            \n\
+        {                                           \n\
+            readonly import attribute int Baseline; \n\
+        };                                          \n\
+                                                    \n\
+        import readonly Character *player;          \n\
+                                                    \n\
+        int game_start()                            \n\
+        {                                           \n\
+            GetTextHeight                           \n\
+            player.Baseline = 1;                    \n\
+        }                                           \n\
+        ";
+    int compile_result2 = cc_compile(inpl2, scrip);
+    std::string msg2 = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
+    EXPECT_NE(std::string::npos, msg2.find("'('"));
+}


### PR DESCRIPTION
This fix addresses #1237.

Typical code that this fix addresses:
```
function game_start()
{
    GetTextHeight
    player.Baseline = 1;
}
```

(`GetTextHeight` is a function, so a `(` should follow. It doesn't; the compiler couldn't handle that.)

I'm taking this as an opportunity to add more null pointer guards in the vicinity to make the code more robust.

