### PR TITLE
Linux: display launch wrapper name without dereferencing

### DIFF
--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -173,7 +173,7 @@ scriptdir=$(dirname ""$scriptpath"")
 
 for arg; do
     if [ ""$arg"" = ""--help"" ]; then
-        printf ""Usage: %s [<ags options>]\n\n"" ""$(basename ""$scriptpath"")""
+        printf ""Usage: %s [<ags options>]\n\n"" ""$(basename ""$0"")""
         break
     fi
 done

--- a/debian/ags+libraries/startgame
+++ b/debian/ags+libraries/startgame
@@ -4,7 +4,7 @@ scriptdir=$(dirname "$scriptpath")
 
 for arg; do
     if [ "$arg" = "--help" ]; then
-        printf "Usage: %s [<ags options>]\n\n" "$(basename "$scriptpath")"
+        printf "Usage: %s [<ags options>]\n\n" "$(basename "$0")"
         break
     fi
 done


### PR DESCRIPTION
Given that the primary reason of having the launch wrapper symlinked would be to provide an interface to one or more launch scripts under an alternate name or path, it would seem logical that when the output provides a name it should be what the user specified.

i.e.

```
$ ./linked_launch --help
Usage: linked_launch [<ags options>]
```