### PR TITLE
3.5.1 Editor: implemented Settings.AttachDataToExe

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -86,8 +86,9 @@ namespace AGS.Editor
          * 23-24: 3.5.0.20+ - Sprite tile import properties.
          * 25: 3.5.0.22   - Full editor version saved into XML header, RuntimeSetup.ThreadedAudio.
          * 26:            - Fixed sound references in game properties.
+         * 27: 3.5.1      - Settings.AttachDataToExe
         */
-        public const int    LATEST_XML_VERSION_INDEX = 26;
+        public const int    LATEST_XML_VERSION_INDEX = 27;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
@@ -68,8 +68,10 @@ namespace AGS.Editor
                     return false;
                 }
                 string compiledEXE = targetWin.GetCompiledPath(exeFileName);
+                string compiledDat = targetWin.GetCompiledPath(baseGameFileName + ".ags");
                 string sourceEXE = Path.Combine(Factory.AGSEditor.EditorDirectory, AGSEditor.ENGINE_EXE_FILE_NAME);
                 Utilities.DeleteFileIfExists(compiledEXE);
+                Utilities.DeleteFileIfExists(compiledDat);
                 File.Copy(sourceEXE, exeFileName, true);
                 BusyDialog.Show("Please wait while we prepare to run the game...", new BusyDialog.ProcessingHandler(CreateDebugFiles), errors);
                 if (errors.HasErrors)

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -205,11 +205,25 @@ namespace AGS.Editor
             UpdateWindowsEXE(newExeName, errors);
             CreateCompiledSetupProgram();
             Environment.CurrentDirectory = Factory.AGSEditor.CurrentGame.DirectoryPath;
-            string mainGameData = Path.Combine(compiledDataDir, baseGameFileName + ".ags");
-            if (File.Exists(mainGameData))
-                AttachDataToEXE(mainGameData, newExeName);
+            string mainGameDataName = baseGameFileName + ".ags";
+            string mainGameDataSrc = Path.Combine(compiledDataDir, mainGameDataName);
+            string mainGameDataDst = GetCompiledPath(mainGameDataName);
+            if (File.Exists(mainGameDataSrc))
+            {
+                if (Factory.AGSEditor.CurrentGame.Settings.AttachDataToExe)
+                {
+                    AttachDataToEXE(mainGameDataSrc, newExeName);
+                    File.Delete(mainGameDataDst);
+                }
+                else
+                {
+                    Utilities.HardlinkOrCopy(GetCompiledPath(mainGameDataName), mainGameDataSrc, true);
+                }
+            }
             else
-                errors.Add(new CompileError(String.Format("Unable to locate main game data file at '{0}'", mainGameData)));
+            {
+                errors.Add(new CompileError(String.Format("Unable to locate main game data file at '{0}'", mainGameDataSrc)));
+            }
             CopyAuxiliaryGameFiles(compiledDataDir, true);
             // Update config file with current game parameters
             Factory.AGSEditor.WriteConfigFile(GetCompiledPath());

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -98,6 +98,7 @@ namespace AGS.Types
         }
 
         [Description("How this file is compiled when you build the game EXE")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public AudioFileBundlingType BundlingType
         {
             get { return _bundlingType; }

--- a/Editor/AGS.Types/AudioClipFolder.cs
+++ b/Editor/AGS.Types/AudioClipFolder.cs
@@ -59,6 +59,7 @@ namespace AGS.Types
         }
 
         [Description("New audio clips imported into this folder will have this bundling type by default")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public AudioFileBundlingType DefaultBundlingType
         {
             get { return _bundlingType; }

--- a/Editor/AGS.Types/Enums/AudioFileBundlingType.cs
+++ b/Editor/AGS.Types/Enums/AudioFileBundlingType.cs
@@ -4,7 +4,7 @@ namespace AGS.Types
 {
     public enum AudioFileBundlingType
     {
-        [Description("In Game EXE")]
+        [Description("In Main Game Data")]
         InGameEXE = 1,
         [Description("In Audio VOX")]
         InSeparateVOX = 2

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -50,6 +50,7 @@ namespace AGS.Types
         private bool _letterboxMode = false;
         private RenderAtScreenResolution _renderAtScreenRes = RenderAtScreenResolution.UserDefined;
         private int _splitResources = 0;
+        private bool _attachDataToExe = true;
         private bool _turnBeforeWalking = true;
         private bool _turnBeforeFacing = true;
         private bool _scaleMovementSpeedWithMaskRes = false;
@@ -401,6 +402,16 @@ namespace AGS.Types
         {
             get { return _splitResources; }
             set { _splitResources = value; }
+        }
+
+        [DisplayName("Attach game data to exe (Windows only)")]
+        [Description("Main game data will be attached to game exe. Otherwise it will be in a separate file called GAMENAME.ags")]
+        [DefaultValue(true)]
+        [Category("Compiler")]
+        public bool AttachDataToExe
+        {
+            get { return _attachDataToExe; }
+            set { _attachDataToExe = value; }
         }
 
         [DisplayName("Old-style letterbox mode")]


### PR DESCRIPTION
This implements new option in General Settings called "Attach game data to exe" which currently works only when building Windows version of the game, where traditionally data was appended to engine executable.

It's "true" by default, but may be disabled, in which case GAMENAME.ags file will be copied to Compiled/Windows folder, similar to how Linux build is deployed.

The reasoning behind this is to optionally let users have same sort of distribution for Windows as made for other systems. This might also improve situation with antiviruses which seem to not like ags games reading executable file all the time.

Also changed displayed name of audio bundling properties from "In Game EXE" to "In Main Game Data" (this was not correct since we added build for Linux support).

PS. Maybe it is better to make it "false" by default and only keep "true" when importing older projects?
I'm in doubts about this, because users may have long used to all data be in exe, so mistakes will be inevitable.