### PR TITLE
Engine: Fix finding unused overlay custom ID

### DIFF
--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -288,7 +288,7 @@ size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic
 {
     if (type == OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
-        for (int id = OVER_CUSTOM + 1; id < screenover.size() + OVER_CUSTOM + 1; ++id) {
+        for (int id = OVER_CUSTOM + 1; id <= screenover.size() + OVER_CUSTOM + 1; ++id) {
             if (find_overlay_of_type(id) == -1) { type=id; break; }
         }
     }


### PR DESCRIPTION
This was a regression from cb7ab658a.

The custom IDs are supposed to be `> OVER_CUSTOM`, but since that commit it can be `OVER_CUSTOM` (for example if the `screenover` vector is empty). We need the loop to have one more iteration than the number of overlays to be sure we find an unused one.

This issue caused some overlays to use `OVER_CUSTOM ` as their ID, which can then result in the "SetTextOverlay internal error: inconsistent type ids" as the ID can gets changed in `add_screen_overlay` when it thinks it need to try to find an unused ID again.