### PR TITLE
Engine: implemented command line options for config and user dir paths

### DIFF
--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -321,6 +321,10 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         //
         // Config overrides
         //
+        else if ((ags_stricmp(arg, "--user-data-dir") == 0) && (argc > ee + 1))
+            cfg["misc"]["user_data_dir"] = argv[++ee];
+        else if ((ags_stricmp(arg, "--shared-data-dir") == 0) && (argc > ee + 1))
+            cfg["misc"]["shared_data_dir"] = argv[++ee];
         else if (ags_stricmp(arg, "--windowed") == 0)
             force_window = 1;
         else if (ags_stricmp(arg, "--fullscreen") == 0)


### PR DESCRIPTION
In response to #961 and #975.

Implemented following:

 --conf - defines explicit and only config file path;
 --user-data-dir - defines user data directory for game files (aka $SAVEGAMEDIR$);
 --shared-data-dir - defines shared data directory for game files (aka $APPDATADIR$);

Example of use:

`ags --conf ./my.cfg --user-data-dir ./saves --shared-data-dir ./appdata`

NOTES:

`--conf` forces engine to ignore all other config files.

`--user-data-dir` and `--shared-data-dir` override corresponding options from config file.

---

The biggest issue I have with `--conf` is that so far it does not have a clear rule in regards to *saving config back*. In other words, must it be considered a read-only special config, or actually "user config" with all the rules applying?
A while ago I've disabled saving config by the engine on exit because it was confusing for number of reasons (see #1156, also related to #975).
But, if we ever enable that, or, for instance, let game developers change and save config from within the game script, what should be the rule in regards to file passed as `--conf`?
I have a concern that if unresolved now then in the long run this may become a cause of more logical conflicts.