### PR TITLE
Common: Make sure old dialog script strings are null terminated

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -326,8 +326,9 @@ void ReadDialogs(DialogTopic *&dialog,
             // Originally in the Editor +20000 bytes more were allocated, with comment:
             //   "add a large buffer because it will get added to if another option is added"
             // which probably refered to this data used by old editor directly to edit dialogs
-            char *buffer = new char[script_text_len];
+            char *buffer = new char[script_text_len + 1];
             in->Read(buffer, script_text_len);
+            buffer[script_text_len] = 0;
             if (data_ver > kGameVersion_260)
                 decrypt_text(buffer);
             old_dialog_src[i] = buffer;


### PR DESCRIPTION
One of the tester for the AGS engine in ScummVM reported a buffer overflow and a crash when trying to save in King of Rock. I checked this and in my case I am getting a buffer overflow when starting the game.

The issue is in `ReadDialogs()`:
```c++
	if (script_text_len > 1) {
		// Originally in the Editor +20000 bytes more were allocated, with comment:
		//   "add a large buffer because it will get added to if another option is added"
		// which probably refered to this data used by old editor directly to edit dialogs
		char *buffer = new char[script_text_len];
		in->Read(buffer, script_text_len);
		if (data_ver > kGameVersion_260)
			decrypt_text(buffer);
		old_dialog_src[i] = buffer;
		delete[] buffer;
	}
```
For this game `data_ver` is equal to `kGameVersion_260`, so `decrypt_text()` does not get called.
When it tries to add the `buffer` to `old_dialog_src`, it ends up in ` String::SetString(const char *cstr, size_t length)` with `length` equal to npos, so very big.
```c++
void String::SetString(const char *cstr, size_t length)
{
    if (cstr)
    {
        length = Math::Min(length, strlen(cstr));
```
And there `strlen(cstr)` returns something random because the string is not null-terminated (so it depends on what is in the memory after that array). Making sure the buffer is null terminated fixes this issue.

I noticed that `read_string_decrypt()` does something similar, so I assume this should be fine also for more recent games (and I have tested a few to make sure they at least start).
