### PR TITLE
New compiler: `.Length` pseudo-attribute for dynamic arrays

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -583,6 +583,10 @@ private:
     // We are processing a function call. General the actual function call
     void AccessData_GenerateFunctionCall(Symbol name_of_func, size_t num_args, bool func_is_import);
 
+    // Generate the function call for the function that returns the number of elements
+    // of a dynarray.
+    void AccessData_GenerateDynarrayLengthFuncCall(MemoryLocation &mloc, ValueLocation &vloc, ScopeType &scope_type, Vartype &vartype);
+
     // We are processing a function call.
     // Get the parameters of the call and push them onto the stack.
     // Return the number of the parameters pushed
@@ -653,7 +657,7 @@ private:
     // The next symbol read is the attribute (the part after the '.')
     ErrorType AccessData_CallAttributeFunc(bool is_setter, SrcList &expression, Vartype &vartype);
 
-    // Location contains a pointer to another address. Get that address.
+    // Memory location contains a pointer to another address. Get that address.
     ErrorType AccessData_Dereference(ValueLocation &vloc, MemoryLocation &mloc);
 
     ErrorType AccessData_ProcessArrayIndexConstant(size_t idx, Symbol index_symbol, bool negate, size_t num_array_elements, size_t element_size, MemoryLocation &mloc);

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2162,3 +2162,111 @@ TEST_F(Bytecode1, CompareStringToNull) {
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
+
+TEST_F(Bytecode1, DynarrayLength1) {
+
+    char inpl[] = "\
+        managed struct Struct               \n\
+        {                                   \n\
+            int Payload;                    \n\
+        } Dynarray[];                       \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            Dynarray = new Struct[5];       \n\
+            return Dynarray.Length;         \n\
+        }                                   \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("DynarrayLength1", scrip);
+
+    size_t const codesize = 37;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            5,   72,    3,    4,    // 7
+       1,    6,    2,    0,           47,    3,    6,    2,    // 15
+       0,   48,    2,   52,           34,    2,   39,    1,    // 23
+       6,    3,    0,   33,            3,   35,    1,   31,    // 31
+       3,    6,    3,    0,            5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 3;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      11,   16,   26,  -999
+    };
+    char fixuptypes[] = {
+      1,   1,   4,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 1;
+    std::string imports[] = {
+    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode1, DynarrayLength2) {
+
+    char inpl[] = "\
+        int foo ()                          \n\
+        {                                   \n\
+            int Dynarray[] = new int[7];    \n\
+            int len = Dynarray.Length;      \n\
+        }                                   \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("DynarrayLength2", scrip);
+
+    size_t const codesize = 44;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            7,   72,    3,    4,    // 7
+       0,   51,    0,   47,            3,    1,    1,    4,    // 15
+      51,    4,   48,    2,           52,   34,    2,   39,    // 23
+       1,    6,    3,    0,           33,    3,   35,    1,    // 31
+      29,    3,   51,    8,           49,    2,    1,    8,    // 39
+       6,    3,    0,    5,          -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 1;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      27,  -999
+    };
+    char fixuptypes[] = {
+      4,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 1;
+    std::string imports[] = {
+    "__Builtin_DynamicArrayLength^1",             "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1292,3 +1292,19 @@ TEST_F(Compile1, FuncThenAssign)
     ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
     EXPECT_NE(std::string::npos, msg2.find("'('"));
 }
+
+TEST_F(Compile1, BuiltinForbidden)
+{
+    // Function names must not start with '__Builtin_'.
+
+    char *inpl = "\
+        void __Builtin_TestFunc()   \n\
+        {                           \n\
+            return;                 \n\
+        }                           \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("__Builtin_"));
+}

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -159,3 +159,28 @@ DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char
     }
     return arr;
 }
+
+
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+
+int32_t DynamicArray_Length(void *untyped_dynarray)
+{
+    // A dynamic array is preceded by two int32_t values.
+    // The first one contains the number of elements, maybe with a flag added to it.
+    // So that's the one we need.
+    size_t const k_offset_to_num_elements = -2u;
+    auto typed_dynarray = static_cast<int32_t *>(untyped_dynarray);
+    return typed_dynarray[k_offset_to_num_elements] & ~ARRAY_MANAGED_TYPE_FLAG;
+}
+
+RuntimeScriptValue Sc_DynamicArray_Length(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_POBJ(DynamicArray_Length, void);
+}
+
+void RegisterDynamicArrayAPI()
+{
+    ccAddExternalStaticFunction("__Builtin_DynamicArrayLength^1", Sc_DynamicArray_Length);
+}
+

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -27,6 +27,7 @@ extern void RegisterDateTimeAPI();
 extern void RegisterDialogAPI();
 extern void RegisterDialogOptionsRenderingAPI();
 extern void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api);
+extern void RegisterDynamicArrayAPI();
 extern void RegisterDynamicSpriteAPI();
 extern void RegisterFileAPI();
 extern void RegisterGameAPI();
@@ -67,6 +68,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterDialogAPI();
     RegisterDialogOptionsRenderingAPI();
     RegisterDrawingSurfaceAPI(base_api, compat_api);
+    RegisterDynamicArrayAPI();
     RegisterDynamicSpriteAPI();
     RegisterFileAPI();
     RegisterGameAPI();


### PR DESCRIPTION
This PR adresses #637.

It adds the `Length` attribute for dynamic arrays which will return the length of any dynamic array at runtime. 
Specifically, if `DA` is a dynamic array, then:
- `DA.Length` will return the the total number of all the fields.
- ~~`DA.Length[0]` will return the number of dimensions, which is always `1` because currently our dynamic arrays only have 1 dimension~~
- ~~`DA.Length[i]` for a positive value of `i`  will return the size of the `i`th dimension (where the first dimension is number 1, not number 0).~~ ~~So currently, `DA.Length[1]` will yield the same as `Da.Length`.~~   ~~If there isn't such a dimension, in particular for a negative `i`, you'll get a runtime out-of-bounds error.~~

~~Currently, our dynamic arrays don't support multiple dimensions, but this may change some day. In the meantime, we don't need to tell anybody about the bracketed parameter if we don't want to. :-)~~

This PR uses an idea of @ivan-mogilko and adds an Engine function to provide the core functionality. This function is only imported and called from the compiler when needed. 

The Engine is new territory for me, so:
**please check the Engine code for whether I've adhered to any conventions that may be in place, whether anything is missing or wrong, whether the code blends in tidily, etc.**

I've currently only done this for dynamic arrays. This is probably the most important use case because you can pass a dynamic array to a function and then, within that function, the code will probably want to know how large that dynamic array is. ~~I intend to implement the `Length` attribute for static arrays, too, for consistency, but make another PR for it.~~
