### PR TITLE
Improve argument print in DumpInstruction

### DIFF
--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1378,24 +1378,29 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
         }
         else
         {
-            switch(op.Args[i].Type) {
+            RuntimeScriptValue arg = op.Args[i];
+            if (arg.Type == kScValStackPtr || arg.Type == kScValGlobalVar)
+            {
+                arg = *arg.RValue;
+            }
+            switch(arg.Type) {
             case kScValInteger:
             case kScValPluginArg:
-                writer.WriteFormat(" %d", op.Args[i].IValue);
+                writer.WriteFormat(" %d", arg.IValue);
                 break;
             case kScValFloat:
-                writer.WriteFormat(" %f", op.Args[i].FValue);
+                writer.WriteFormat(" %f", arg.FValue);
                 break;
             case kScValStringLiteral:
-                writer.WriteFormat(" \"%s\"", op.Args[i].Ptr);
+                writer.WriteFormat(" \"%s\"", arg.Ptr);
                 break;
             case kScValStackPtr:
             case kScValGlobalVar:
-                writer.WriteFormat(" %p", op.Args[i].RValue);
+                writer.WriteFormat(" %p", arg.RValue);
                 break;
             case kScValData:
             case kScValCodePtr:
-                writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+                writer.WriteFormat(" %p", arg.GetPtrWithOffset());
                 break;
             case kScValStaticArray:
             case kScValStaticObject:
@@ -1405,14 +1410,14 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
             case kScValPluginFunction:
             case kScValPluginObject:
             {
-                String name = simp.findName(op.Args[i]);
+                String name = simp.findName(arg);
                 if (!name.IsEmpty())
                 {
                     writer.WriteFormat(" &%s", name.GetCStr());
                 }
                 else
                 {
-                    writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+                    writer.WriteFormat(" %p", arg.GetPtrWithOffset());
                 }
              }
                 break;

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1378,9 +1378,36 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
         }
         else
         {
-            // MACPORT FIX 9/6/5: changed %d to %ld
-            // FIXME: check type and write appropriate values
-            writer.WriteFormat(" %ld", op.Args[i].GetPtrWithOffset());
+            switch(op.Args[i].Type) {
+            case kScValInteger:
+            case kScValPluginArg:
+                writer.WriteFormat(" %d", op.Args[i].IValue);
+                break;
+            case kScValFloat:
+                writer.WriteFormat(" %f", op.Args[i].FValue);
+                break;
+            case kScValStringLiteral:
+                writer.WriteFormat(" \"%s\"", op.Args[i].Ptr);
+                break;
+            case kScValStackPtr:
+            case kScValGlobalVar:
+                writer.WriteFormat(" %p", op.Args[i].RValue);
+                break;
+            case kScValData:
+            case kScValCodePtr:
+            case kScValStaticArray:
+            case kScValStaticObject:
+            case kScValDynamicObject:
+            case kScValStaticFunction:
+            case kScValObjectFunction:
+            case kScValPluginFunction:
+            case kScValPluginObject:
+                writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+                break;
+            case kScValUndefined:
+				writer.WriteString("undefined");
+                break;
+             }
         }
     }
     writer.WriteLineBreak();

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1395,6 +1395,8 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
                 break;
             case kScValData:
             case kScValCodePtr:
+                writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+                break;
             case kScValStaticArray:
             case kScValStaticObject:
             case kScValDynamicObject:
@@ -1402,7 +1404,17 @@ void ccInstance::DumpInstruction(const ScriptOperation &op)
             case kScValObjectFunction:
             case kScValPluginFunction:
             case kScValPluginObject:
-                writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+            {
+                String name = simp.findName(op.Args[i]);
+                if (!name.IsEmpty())
+                {
+                    writer.WriteFormat(" &%s", name.GetCStr());
+                }
+                else
+                {
+                    writer.WriteFormat(" %p", op.Args[i].GetPtrWithOffset());
+                }
+             }
                 break;
             case kScValUndefined:
 				writer.WriteString("undefined");

--- a/Engine/script/systemimports.cpp
+++ b/Engine/script/systemimports.cpp
@@ -107,6 +107,18 @@ int SystemImports::get_index_of(const String &name)
     return -1;
 }
 
+String SystemImports::findName(const RuntimeScriptValue &value)
+{
+    for (size_t i = 0; i < imports.size(); ++i)
+    {
+        if (imports[i].Value == value)
+        {
+            return imports[i].Name;
+        }
+    }
+    return String();
+}
+
 void SystemImports::RemoveScriptExports(ccInstance *inst)
 {
     if (!inst)

--- a/Engine/script/systemimports.h
+++ b/Engine/script/systemimports.h
@@ -51,6 +51,7 @@ public:
     const ScriptImport *getByName(const String &name);
     int  get_index_of(const String &name);
     const ScriptImport *getByIndex(int index);
+    String findName(const RuntimeScriptValue &value);
     void RemoveScriptExports(ccInstance *inst);
     void clear();
 };


### PR DESCRIPTION
To help me debug some issues in ScummVM, I made improvements to the DumpInstruction functions.
I am not sure all the changes are a good idea, so I made them incrementally in three separate commits (so that for example you may decide to merge only the first commit).

Feedback and suggestions, if you think I made some mistakes or something could be improved, are welcome.