### PR TITLE
3.5.1: Added System.SaveConfigToFile() and support $CONFIGFILE$ scriptpath

### DIFF
--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -30,7 +30,7 @@ bool CreateDirectory(const String &path)
 
 bool CreateAllDirectories(const String &parent, const String &path)
 {
-    if (!ags_directory_exists(parent.GetCStr()))
+    if (parent.IsEmpty() || !ags_directory_exists(parent.GetCStr()))
         return false;
     if (path.IsEmpty())
         return true;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2101,6 +2101,10 @@ builtin struct System {
   /// Gets/sets whether sprites are rendered at screen resolution or native game resolution.
   import static attribute bool RenderAtScreenResolution;
 #endif
+#ifdef SCRIPT_API_v351
+  /// Saves current runtime settings into configuration file
+  import static void SaveConfigToFile();
+#endif
 };
 
 enum BlockingStyle {

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -196,6 +196,7 @@ const String GameInstallRootToken    = "$INSTALLDIR$";
 const String UserSavedgamesRootToken = "$MYDOCS$";
 const String GameSavedgamesDirToken  = "$SAVEGAMEDIR$";
 const String GameDataDirToken        = "$APPDATADIR$";
+const String UserConfigFileToken     = "$CONFIGFILE$";
 
 void FixupFilename(char *filename)
 {
@@ -312,6 +313,16 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
 {
     rp = ResolvedPath();
 
+    // File tokens (they must be the only thing in script path)
+    if (orig_sc_path.Compare(UserConfigFileToken) == 0)
+    {
+        auto loc = GetGameUserConfigDir();
+        rp.FullPath = Path::ConcatPaths(loc.FullDir, DefaultConfigFileName);
+        rp.BaseDir = loc.BaseDir;
+        return true;
+    }
+
+    // Test absolute paths
     bool is_absolute = !is_relative_filename(orig_sc_path);
     if (is_absolute && !read_only)
     {
@@ -325,6 +336,7 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
         return true;
     }
 
+    // Resolve location tokens
     String sc_path = FixSlashAfterToken(orig_sc_path);
     FSLocation parent_dir;
     String child_path;

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -290,7 +290,9 @@ int RunAGSGame (const char *newgame, unsigned int mode, int data) {
     unload_old_room();
     displayed_room = -10;
 
+#if defined (AGS_AUTO_WRITE_USER_CONFIG)
     save_config_file(); // save current user config in case engine fails to run new game
+#endif // AGS_AUTO_WRITE_USER_CONFIG
     unload_game_file();
 
     // Adjust config (NOTE: normally, RunAGSGame would need a redesign to allow separate config etc per each game)

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -14,20 +14,21 @@
 
 #include "ac/common.h"
 #include "ac/draw.h"
+#include "ac/dynobj/cc_audiochannel.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
+#include "ac/global_debug.h"
 #include "ac/mouse.h"
 #include "ac/string.h"
 #include "ac/system.h"
 #include "ac/dynobj/scriptsystem.h"
 #include "debug/debug_log.h"
+#include "gfx/graphicsdriver.h"
+#include "main/config.h"
+#include "main/graphics_mode.h"
 #include "main/engine.h"
 #include "main/main.h"
-#include "gfx/graphicsdriver.h"
-#include "ac/dynobj/cc_audiochannel.h"
-#include "main/graphics_mode.h"
-#include "ac/global_debug.h"
 #include "media/audio/audio_system.h"
 #include "util/string_compat.h"
 
@@ -394,6 +395,11 @@ RuntimeScriptValue Sc_System_SetRenderAtScreenResolution(const RuntimeScriptValu
     API_SCALL_VOID_PINT(System_SetRenderAtScreenResolution);
 }
 
+RuntimeScriptValue Sc_System_SaveConfigToFile(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID(save_config_file);
+}
+
 
 
 
@@ -427,6 +433,8 @@ void RegisterSystemAPI()
     ccAddExternalStaticFunction("System::set_VSync",                Sc_System_SetVsync);
     ccAddExternalStaticFunction("System::get_Windowed",             Sc_System_GetWindowed);
     ccAddExternalStaticFunction("System::set_Windowed",             Sc_System_SetWindowed);
+
+    ccAddExternalStaticFunction("System::SaveConfigToFile",         Sc_System_SaveConfigToFile);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -610,7 +610,6 @@ void post_config()
 
 void save_config_file()
 {
-#if defined (AGS_WRITE_USER_CONFIG_ON_EXIT)
     ConfigTree cfg;
 
     // Last display mode
@@ -647,5 +646,4 @@ void save_config_file()
     String cfg_file = PreparePathForWriting(GetGameUserConfigDir(), DefaultConfigFileName);
     if (!cfg_file.IsEmpty())
         IniUtil::Merge(cfg_file, cfg);
-#endif // AGS_WRITE_USER_CONFIG_ON_EXIT
 }

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -248,8 +248,10 @@ void quit(const char *quitmsg)
     // about to free plugins)
     String qmsg = quitmsg;
 
+#if defined (AGS_AUTO_WRITE_USER_CONFIG)
     if (qreason & kQuitKind_NormalExit)
         save_config_file();
+#endif // AGS_AUTO_WRITE_USER_CONFIG
 
 	allegro_bitmap_test_release();
 


### PR DESCRIPTION
This complements recent changes to config location setting, which let switch user config location to game directory itself, as well as previous change that disabled engine writing config on exit.

Added `System.SaveConfigToFile()` script function that explicitly saves current runtime settings to user config.
This change may suit game developers who simply want to save those options that may be changed at runtime.

Additionally added $CONFIGFILE$ token supported by File.Open that allows to read/write user config regardless of where it is located not relying on assumptions of engine behavior. This is provided for game developers who want to script more accurate user config reading or writing.