### PR TITLE
Tools: crm2ash - generates room script header

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -77,6 +77,7 @@ target_sources(common
     game/plugininfo.h
     game/room_file.cpp
     game/room_file.h
+    game/room_file_base.cpp
     game/room_file_deprecated.cpp
     game/room_version.h
     game/roomstruct.cpp

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -41,67 +41,6 @@ namespace AGS
 namespace Common
 {
 
-RoomDataSource::RoomDataSource()
-    : DataVersion(kRoomVersion_Undefined)
-{
-}
-
-String GetRoomFileErrorText(RoomFileErrorType err)
-{
-    switch (err)
-    {
-    case kRoomFileErr_NoError:
-        return "No error.";
-    case kRoomFileErr_FileOpenFailed:
-        return "Room file was not found or could not be opened.";
-    case kRoomFileErr_FormatNotSupported:
-        return "Format version not supported.";
-    case kRoomFileErr_UnexpectedEOF:
-        return "Unexpected end of file.";
-    case kRoomFileErr_UnknownBlockType:
-        return "Unknown block type.";
-    case kRoomFileErr_OldBlockNotSupported:
-        return "Block type is too old and not supported by this version of the engine.";
-    case kRoomFileErr_BlockDataOverlapping:
-        return "Block data overlapping.";
-    case kRoomFileErr_IncompatibleEngine:
-        return "This engine cannot handle requested room content.";
-    case kRoomFileErr_ScriptLoadFailed:
-        return "Script load failed.";
-    case kRoomFileErr_InconsistentData:
-        return "Inconsistent room data, or file is corrupted.";
-    case kRoomFileErr_PropertiesBlockFormat:
-        return "Unknown format of the custom properties block.";
-    case kRoomFileErr_InvalidPropertyValues:
-        return "Errors encountered when reading custom properties.";
-    case kRoomFileErr_BlockNotFound:
-        return "Required block was not found.";
-    }
-    return "Unknown error.";
-}
-
-// Read room data header and check that we support this format
-static HRoomFileError OpenRoomFileBase(Stream *in, RoomDataSource &src)
-{
-    src.DataVersion = (RoomFileVersion)in->ReadInt16();
-    if (src.DataVersion < kRoomVersion_250b || src.DataVersion > kRoomVersion_Current)
-        return new RoomFileError(kRoomFileErr_FormatNotSupported, String::FromFormat("Required format version: %d, supported %d - %d", src.DataVersion, kRoomVersion_250b, kRoomVersion_Current));
-    return HRoomFileError::None();
-}
-
-HRoomFileError OpenRoomFile(const String &filename, RoomDataSource &src)
-{
-    // Cleanup source struct
-    src = RoomDataSource();
-    // Try to open room file
-    Stream *in = File::OpenFileRead(filename);
-    if (in == nullptr)
-        return new RoomFileError(kRoomFileErr_FileOpenFailed, String::FromFormat("Filename: %s.", filename.GetCStr()));
-    src.Filename = filename;
-    src.InputStream.reset(in);
-    return OpenRoomFileBase(in, src);
-}
-
 HRoomFileError OpenRoomFileFromAsset(const String &filename, RoomDataSource &src)
 {
     // Cleanup source struct
@@ -112,49 +51,7 @@ HRoomFileError OpenRoomFileFromAsset(const String &filename, RoomDataSource &src
         return new RoomFileError(kRoomFileErr_FileOpenFailed, String::FromFormat("Filename: %s.", filename.GetCStr()));
     src.Filename = filename;
     src.InputStream.reset(in);
-    return OpenRoomFileBase(in, src);
-}
-
-
-enum RoomFileBlock
-{
-    kRoomFblk_None              = 0,
-    // Main room data
-    kRoomFblk_Main              = 1,
-    // Room script text source (was present in older room formats)
-    kRoomFblk_Script            = 2,
-    // Old versions of compiled script (no longer supported)
-    kRoomFblk_CompScript        = 3,
-    kRoomFblk_CompScript2       = 4,
-    // Names of the room objects
-    kRoomFblk_ObjectNames       = 5,
-    // Secondary room backgrounds
-    kRoomFblk_AnimBg            = 6,
-    // Contemporary compiled script
-    kRoomFblk_CompScript3       = 7,
-    // Custom properties
-    kRoomFblk_Properties        = 8,
-    // Script names of the room objects
-    kRoomFblk_ObjectScNames     = 9,
-    // End of room data tag
-    kRoomFile_EOF               = 0xFF
-};
-
-String GetRoomBlockName(RoomFileBlock id)
-{
-    switch (id)
-    {
-    case kRoomFblk_Main: return "Main";
-    case kRoomFblk_Script: return "TextScript";
-    case kRoomFblk_CompScript: return "CompScript";
-    case kRoomFblk_CompScript2: return "CompScript2";
-    case kRoomFblk_ObjectNames: return "ObjNames";
-    case kRoomFblk_AnimBg: return "AnimBg";
-    case kRoomFblk_CompScript3: return "CompScript3";
-    case kRoomFblk_Properties: return "Properties";
-    case kRoomFblk_ObjectScNames: return "ObjScNames";
-    }
-    return "unknown";
+    return ReadRoomHeader(src);
 }
 
 void ReadRoomObject(RoomObjectInfo &obj, Stream *in)
@@ -587,36 +484,6 @@ HRoomFileError ReadRoomBlock(RoomStruct *room, Stream *in, RoomFileBlock block, 
         String::FromFormat("Type: %s", ext_id.GetCStr()));
 }
 
-
-static HRoomFileError OpenNextBlock(Stream *in, RoomFileVersion data_ver, RoomFileBlock &block_id, String &ext_id, soff_t &block_len)
-{
-    // The block meta format is shared with the main game file extensions
-    //    - 1 byte - an old-style unsigned numeric ID:
-    //               where 0 would indicate following string ID,
-    //               and 0xFF indicates end of extension list.
-    //    - 16 bytes - string ID of an extension (if numeric ID is 0).
-    //    - 4 or 8 bytes - length of extension data, in bytes (size depends on format version).
-    int b = in->ReadByte();
-    if (b < 0)
-        return new RoomFileError(kRoomFileErr_UnexpectedEOF);
-
-    block_id = (RoomFileBlock)b;
-    if (block_id == kRoomFile_EOF)
-        return HRoomFileError::None(); // end of list
-
-    if (block_id > 0)
-    { // old-style block identified by a numeric id
-        ext_id = GetRoomBlockName(block_id);
-        block_len = data_ver < kRoomVersion_350 ? in->ReadInt32() : in->ReadInt64();
-    }
-    else
-    { // new style block identified by a string id
-        ext_id = String::FromStreamCount(in, 16);
-        block_len = in->ReadInt64();
-    }
-    return HRoomFileError::None();
-}
-
 HRoomFileError ReadRoomData(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 {
     room->DataVersion = data_ver;
@@ -631,7 +498,7 @@ HRoomFileError ReadRoomData(RoomStruct *room, Stream *in, RoomFileVersion data_v
         RoomFileBlock block_id;
         String ext_id;
         soff_t block_len;
-        HRoomFileError err = OpenNextBlock(in, data_ver, block_id, ext_id, block_len);
+        HRoomFileError err = OpenNextRoomBlock(in, data_ver, block_id, ext_id, block_len);
         if (!err)
             return err;
         if (ext_id.IsEmpty())
@@ -816,7 +683,7 @@ HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion dat
         RoomFileBlock block_id;
         String ext_id;
         soff_t block_len;
-        HRoomFileError err = OpenNextBlock(in, data_ver, block_id, ext_id, block_len);
+        HRoomFileError err = OpenNextRoomBlock(in, data_ver, block_id, ext_id, block_len);
         if (!err)
             return err;
         if (ext_id.IsEmpty())
@@ -836,43 +703,6 @@ HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion dat
         in->Seek(block_len); // skip block
     };
     return new RoomFileError(kRoomFileErr_BlockNotFound);
-}
-
-
-// Type of function that writes single room block.
-typedef void(*PfnWriteBlock)(const RoomStruct *room, Stream *out);
-// Generic function that saves a block and automatically adds its size into header
-void WriteBlock(const RoomStruct *room, RoomFileBlock block, const String &ext_id, PfnWriteBlock writer, Stream *out)
-{
-    // Write block's header
-    out->WriteByte(block);
-    if (block == kRoomFblk_None) // new-style string id
-        ext_id.WriteCount(out, 16);
-    soff_t sz_at = out->GetPosition();
-    out->WriteInt64(0); // block size placeholder
-    // Call writer to save actual block contents
-    writer(room, out);
-
-    // Now calculate the block's size...
-    soff_t end_at = out->GetPosition();
-    soff_t block_size = (end_at - sz_at) - sizeof(int64_t);
-    // ...return back and write block's size in the placeholder
-    out->Seek(sz_at, Common::kSeekBegin);
-    out->WriteInt64(block_size);
-    // ...and get back to the end of the file
-    out->Seek(0, Common::kSeekEnd);
-}
-
-// Helper for new-style blocks with string id
-void WriteBlock(const RoomStruct *room, const String &ext_id, PfnWriteBlock writer, Stream *out)
-{
-    WriteBlock(room, kRoomFblk_None, ext_id, writer, out);
-}
-
-// Helper for old-style blocks with only numeric id
-void WriteBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteBlock writer, Stream *out)
-{
-    WriteBlock(room, block, String(), writer, out);
 }
 
 void WriteInteractionScripts(const InteractionScripts *interactions, Stream *out)
@@ -1025,21 +855,21 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
     // Header
     out->WriteInt16(data_ver);
     // Main data
-    WriteBlock(room, kRoomFblk_Main, WriteMainBlock, out);
+    WriteRoomBlock(room, kRoomFblk_Main, WriteMainBlock, out);
     // Compiled script
     if (room->CompiledScript)
-        WriteBlock(room, kRoomFblk_CompScript3, WriteCompSc3Block, out);
+        WriteRoomBlock(room, kRoomFblk_CompScript3, WriteCompSc3Block, out);
     // Object names
     if (room->ObjectCount > 0)
     {
-        WriteBlock(room, kRoomFblk_ObjectNames, WriteObjNamesBlock, out);
-        WriteBlock(room, kRoomFblk_ObjectScNames, WriteObjScNamesBlock, out);
+        WriteRoomBlock(room, kRoomFblk_ObjectNames, WriteObjNamesBlock, out);
+        WriteRoomBlock(room, kRoomFblk_ObjectScNames, WriteObjScNamesBlock, out);
     }
     // Secondary background frames
     if (room->BgFrameCount > 1)
-        WriteBlock(room, kRoomFblk_AnimBg, WriteAnimBgBlock, out);
+        WriteRoomBlock(room, kRoomFblk_AnimBg, WriteAnimBgBlock, out);
     // Custom properties
-    WriteBlock(room, kRoomFblk_Properties, WritePropertiesBlock, out);
+    WriteRoomBlock(room, kRoomFblk_Properties, WritePropertiesBlock, out);
 
     // Write end of room file
     out->WriteByte(kRoomFile_EOF);

--- a/Common/game/room_file.h
+++ b/Common/game/room_file.h
@@ -17,10 +17,10 @@
 // options, lists of static game entities and compiled scripts modules.
 //
 //=============================================================================
-
 #ifndef __AGS_CN_GAME_ROOMFILE_H
 #define __AGS_CN_GAME_ROOMFILE_H
 
+#include <functional>
 #include <memory>
 #include <vector>
 #include "game/room_version.h"
@@ -119,6 +119,11 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
 HRoomFileError ReadRoomHeader(RoomDataSource &src);
 // Opens next room block from the stream, fills in its identifier and length on success
 HRoomFileError OpenNextRoomBlock(Stream *in, RoomFileVersion data_ver, RoomFileBlock &block_id, String &ext_id, soff_t &block_len);
+// Type of function that reads single room block and tells whether to continue reading
+typedef std::function<HRoomFileError(Stream *in, RoomFileBlock block_id, const String &ext_id,
+    soff_t block_len, RoomFileVersion data_ver, bool &read_next)> PfnReadRoomBlock;
+// Parses room file, passing each found block into callback; does not read any actual data itself
+HRoomFileError ReadRoomData(PfnReadRoomBlock reader, Stream *in, RoomFileVersion data_ver);
 // Type of function that writes single room block.
 typedef void(*PfnWriteRoomBlock)(const RoomStruct *room, Stream *out);
 // Writes room block with a new-style string id

--- a/Common/game/room_file.h
+++ b/Common/game/room_file.h
@@ -53,7 +53,32 @@ enum RoomFileErrorType
     kRoomFileErr_BlockNotFound
 };
 
+enum RoomFileBlock
+{
+    kRoomFblk_None = 0,
+    // Main room data
+    kRoomFblk_Main = 1,
+    // Room script text source (was present in older room formats)
+    kRoomFblk_Script = 2,
+    // Old versions of compiled script (no longer supported)
+    kRoomFblk_CompScript = 3,
+    kRoomFblk_CompScript2 = 4,
+    // Names of the room objects
+    kRoomFblk_ObjectNames = 5,
+    // Secondary room backgrounds
+    kRoomFblk_AnimBg = 6,
+    // Contemporary compiled script
+    kRoomFblk_CompScript3 = 7,
+    // Custom properties
+    kRoomFblk_Properties = 8,
+    // Script names of the room objects
+    kRoomFblk_ObjectScNames = 9,
+    // End of room data tag
+    kRoomFile_EOF = 0xFF
+};
+
 String GetRoomFileErrorText(RoomFileErrorType err);
+String GetRoomBlockName(RoomFileBlock id);
 
 typedef TypedCodeError<RoomFileErrorType, GetRoomFileErrorText> RoomFileError;
 typedef ErrorHandle<RoomFileError> HRoomFileError;
@@ -73,6 +98,7 @@ struct RoomDataSource
     RoomDataSource();
 };
 
+
 // Opens room data for reading from an arbitrary file
 HRoomFileError OpenRoomFile(const String &filename, RoomDataSource &src);
 // Opens room data for reading from asset of a given name
@@ -85,8 +111,20 @@ HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool g
 // Extracts text script from the room file, if it's available.
 // Historically, text sources were kept inside packed room files before AGS 3.*.
 HRoomFileError ExtractScriptText(String &script, Stream *in, RoomFileVersion data_ver);
-
+// Writes all room data to the stream
 HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersion data_ver);
+
+// Reads room data header using stream assigned to RoomDataSource;
+// tests and saves its format index if successful
+HRoomFileError ReadRoomHeader(RoomDataSource &src);
+// Opens next room block from the stream, fills in its identifier and length on success
+HRoomFileError OpenNextRoomBlock(Stream *in, RoomFileVersion data_ver, RoomFileBlock &block_id, String &ext_id, soff_t &block_len);
+// Type of function that writes single room block.
+typedef void(*PfnWriteRoomBlock)(const RoomStruct *room, Stream *out);
+// Writes room block with a new-style string id
+void WriteRoomBlock(const RoomStruct *room, const String &ext_id, PfnWriteRoomBlock writer, Stream *out);
+// Writes room block with a old-style numeric id
+void WriteRoomBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteRoomBlock writer, Stream *out);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -1,0 +1,164 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "game/room_file.h"
+#include "util/file.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+RoomDataSource::RoomDataSource()
+    : DataVersion(kRoomVersion_Undefined)
+{
+}
+
+String GetRoomFileErrorText(RoomFileErrorType err)
+{
+    switch (err)
+    {
+    case kRoomFileErr_NoError:
+        return "No error.";
+    case kRoomFileErr_FileOpenFailed:
+        return "Room file was not found or could not be opened.";
+    case kRoomFileErr_FormatNotSupported:
+        return "Format version not supported.";
+    case kRoomFileErr_UnexpectedEOF:
+        return "Unexpected end of file.";
+    case kRoomFileErr_UnknownBlockType:
+        return "Unknown block type.";
+    case kRoomFileErr_OldBlockNotSupported:
+        return "Block type is too old and not supported by this version of the engine.";
+    case kRoomFileErr_BlockDataOverlapping:
+        return "Block data overlapping.";
+    case kRoomFileErr_IncompatibleEngine:
+        return "This engine cannot handle requested room content.";
+    case kRoomFileErr_ScriptLoadFailed:
+        return "Script load failed.";
+    case kRoomFileErr_InconsistentData:
+        return "Inconsistent room data, or file is corrupted.";
+    case kRoomFileErr_PropertiesBlockFormat:
+        return "Unknown format of the custom properties block.";
+    case kRoomFileErr_InvalidPropertyValues:
+        return "Errors encountered when reading custom properties.";
+    case kRoomFileErr_BlockNotFound:
+        return "Required block was not found.";
+    }
+    return "Unknown error.";
+}
+
+HRoomFileError OpenRoomFile(const String &filename, RoomDataSource &src)
+{
+    // Cleanup source struct
+    src = RoomDataSource();
+    // Try to open room file
+    Stream *in = File::OpenFileRead(filename);
+    if (in == nullptr)
+        return new RoomFileError(kRoomFileErr_FileOpenFailed, String::FromFormat("Filename: %s.", filename.GetCStr()));
+    src.Filename = filename;
+    src.InputStream.reset(in);
+    return ReadRoomHeader(src);
+}
+
+// Read room data header and check that we support this format
+HRoomFileError ReadRoomHeader(RoomDataSource &src)
+{
+    src.DataVersion = (RoomFileVersion)src.InputStream->ReadInt16();
+    if (src.DataVersion < kRoomVersion_250b || src.DataVersion > kRoomVersion_Current)
+        return new RoomFileError(kRoomFileErr_FormatNotSupported, String::FromFormat("Required format version: %d, supported %d - %d", src.DataVersion, kRoomVersion_250b, kRoomVersion_Current));
+    return HRoomFileError::None();
+}
+
+String GetRoomBlockName(RoomFileBlock id)
+{
+    switch (id)
+    {
+    case kRoomFblk_Main: return "Main";
+    case kRoomFblk_Script: return "TextScript";
+    case kRoomFblk_CompScript: return "CompScript";
+    case kRoomFblk_CompScript2: return "CompScript2";
+    case kRoomFblk_ObjectNames: return "ObjNames";
+    case kRoomFblk_AnimBg: return "AnimBg";
+    case kRoomFblk_CompScript3: return "CompScript3";
+    case kRoomFblk_Properties: return "Properties";
+    case kRoomFblk_ObjectScNames: return "ObjScNames";
+    }
+    return "unknown";
+}
+
+HRoomFileError OpenNextRoomBlock(Stream *in, RoomFileVersion data_ver, RoomFileBlock &block_id, String &ext_id, soff_t &block_len)
+{
+    // The block meta format is shared with the main game file extensions
+    //    - 1 byte - an old-style unsigned numeric ID:
+    //               where 0 would indicate following string ID,
+    //               and 0xFF indicates end of extension list.
+    //    - 16 bytes - string ID of an extension (if numeric ID is 0).
+    //    - 4 or 8 bytes - length of extension data, in bytes (size depends on format version).
+    int b = in->ReadByte();
+    if (b < 0)
+        return new RoomFileError(kRoomFileErr_UnexpectedEOF);
+
+    block_id = (RoomFileBlock)b;
+    if (block_id == kRoomFile_EOF)
+        return HRoomFileError::None(); // end of list
+
+    if (block_id > 0)
+    { // old-style block identified by a numeric id
+        ext_id = GetRoomBlockName(block_id);
+        block_len = data_ver < kRoomVersion_350 ? in->ReadInt32() : in->ReadInt64();
+    }
+    else
+    { // new style block identified by a string id
+        ext_id = String::FromStreamCount(in, 16);
+        block_len = in->ReadInt64();
+    }
+    return HRoomFileError::None();
+}
+
+// Generic function that saves a block and automatically adds its size into header
+static void WriteRoomBlock(const RoomStruct *room, RoomFileBlock block, const String &ext_id, PfnWriteRoomBlock writer, Stream *out)
+{
+    // Write block's header
+    out->WriteByte(block);
+    if (block == kRoomFblk_None) // new-style string id
+        ext_id.WriteCount(out, 16);
+    soff_t sz_at = out->GetPosition();
+    out->WriteInt64(0); // block size placeholder
+                        // Call writer to save actual block contents
+    writer(room, out);
+
+    // Now calculate the block's size...
+    soff_t end_at = out->GetPosition();
+    soff_t block_size = (end_at - sz_at) - sizeof(int64_t);
+    // ...return back and write block's size in the placeholder
+    out->Seek(sz_at, Common::kSeekBegin);
+    out->WriteInt64(block_size);
+    // ...and get back to the end of the file
+    out->Seek(0, Common::kSeekEnd);
+}
+
+// Helper for new-style blocks with string id
+void WriteRoomBlock(const RoomStruct *room, const String &ext_id, PfnWriteRoomBlock writer, Stream *out)
+{
+    WriteRoomBlock(room, kRoomFblk_None, ext_id, writer, out);
+}
+
+// Helper for old-style blocks with only numeric id
+void WriteRoomBlock(const RoomStruct *room, RoomFileBlock block, PfnWriteRoomBlock writer, Stream *out)
+{
+    WriteRoomBlock(room, block, String(), writer, out);
+}
+
+} // namespace Common
+} // namespace AGS

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "game/room_file.h"
+#include "debug/out.h"
 #include "util/file.h"
 
 namespace AGS
@@ -122,6 +123,49 @@ HRoomFileError OpenNextRoomBlock(Stream *in, RoomFileVersion data_ver, RoomFileB
     { // new style block identified by a string id
         ext_id = String::FromStreamCount(in, 16);
         block_len = in->ReadInt64();
+    }
+    return HRoomFileError::None();
+}
+
+HRoomFileError ReadRoomData(PfnReadRoomBlock reader, Stream *in, RoomFileVersion data_ver)
+{
+    // Read list of data blocks. The block meta format is shared with the main game file extensions now.
+    //    - 1 byte - old format block ID, 0xFF indicates end of list.
+    //    - 16 bytes - new string ID of an extension. \0 at the first byte indicates end of list.
+    //    - 4 or 8 bytes - length of extension data, in bytes (depends on format version).
+    while (true)
+    {
+        RoomFileBlock block_id;
+        String ext_id;
+        soff_t block_len;
+        HRoomFileError err = OpenNextRoomBlock(in, data_ver, block_id, ext_id, block_len);
+        if (!err)
+            return err;
+        if (ext_id.IsEmpty())
+            break; // end of list
+
+        soff_t block_end = in->GetPosition() + block_len;
+        bool read_next = true;
+        err = reader(in, block_id, ext_id, block_len, data_ver, read_next);
+        if (!err)
+            return err;
+
+        soff_t cur_pos = in->GetPosition();
+        if (cur_pos > block_end)
+        {
+            return new RoomFileError(kRoomFileErr_BlockDataOverlapping,
+                String::FromFormat("Block: %s, expected to end at offset: %u, finished reading at %u.",
+                    ext_id.GetCStr(), block_end, cur_pos));
+        }
+        else if (cur_pos < block_end)
+        {
+            Debug::Printf(kDbgMsg_Warn, "WARNING: room data blocks nonsequential, block type %s expected to end at %u, finished reading at %u",
+                ext_id.GetCStr(), block_end, cur_pos);
+            in->Seek(block_end, Common::kSeekBegin);
+        }
+
+        if (!read_next)
+            break;
     }
     return HRoomFileError::None();
 }

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -287,6 +287,7 @@
     <ClCompile Include="..\..\Common\game\main_game_file.cpp" />
     <ClCompile Include="..\..\Common\game\roomstruct.cpp" />
     <ClCompile Include="..\..\Common\game\room_file.cpp" />
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp" />
     <ClCompile Include="..\..\Common\game\room_file_deprecated.cpp" />
     <ClCompile Include="..\..\Common\gfx\allegrobitmap.cpp" />
     <ClCompile Include="..\..\Common\gfx\bitmap.cpp" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -503,6 +503,9 @@
     <ClCompile Include="..\..\libsrc\allegro\src\math.c">
       <Filter>Library Sources\allegro</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp">
+      <Filter>Source Files\game</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\audiocliptype.h">

--- a/Solutions/Tools.App/crm2ash.vcxproj
+++ b/Solutions/Tools.App/crm2ash.vcxproj
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp" />
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\Tools\crm2ash\main.cpp" />
+    <ClCompile Include="..\..\Tools\data\room_utils.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Tools\data\room_utils.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}</ProjectGuid>
+    <RootNamespace>MakeRoomHeader</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>crm2ash</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Tools.App/crm2ash.vcxproj.filters
+++ b/Solutions/Tools.App/crm2ash.vcxproj.filters
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="crm2ash">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="data">
+      <UniqueIdentifier>{ebea7864-de2f-48c8-b3d2-51eb82b7a045}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\crm2ash\main.cpp">
+      <Filter>crm2ash</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\room_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Tools\data\room_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "crm2ash", "Tools.App\crm2ash.vcxproj", "{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Debug|x64.ActiveCfg = Debug|x64
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Debug|x64.Build.0 = Debug|x64
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Debug|x86.ActiveCfg = Debug|Win32
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Debug|x86.Build.0 = Debug|Win32
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Release|x64.ActiveCfg = Release|x64
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Release|x64.Build.0 = Release|x64
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Release|x86.ActiveCfg = Release|Win32
+		{1BCFCAFE-B38D-4960-AB33-F76FDA316FB6}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Tools/crm2ash/Makefile
+++ b/Tools/crm2ash/Makefile
@@ -1,0 +1,91 @@
+INCDIR = ../../Common ../../Tools
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/game/room_file_base.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/datastream.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp
+
+TOOL_OBJS = \
+	../../Tools/data/room_utils.cpp
+
+OBJS := main.cpp \
+	$(COMMON_OBJS) \
+	$(TOOL_OBJS)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags crm2ash
+
+crm2ash: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags crm2ash
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f crm2ash $(OBJS) $(DEPFILES)
+
+install: crm2ash
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin crm2ash
+
+uninstall:
+	rm -f $(PREFIX)/bin/crm2ash

--- a/Tools/crm2ash/main.cpp
+++ b/Tools/crm2ash/main.cpp
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include "data/room_utils.h"
+#include "util/file.h"
+#include "util/string_compat.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+
+
+const char *HELP_STRING = "Usage: crm2ash <input-room.crm> <output-room.ash>\n";
+
+int main(int argc, char *argv[])
+{
+    printf("crm2ash v0.1.0 - AGS compiled room's script header generator\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        {
+            printf("%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+    }
+    if (argc < 3)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *src = argv[1];
+    const char *dst = argv[2];
+    printf("Input room file: %s\n", src);
+    printf("Output script header: %s\n", dst);
+
+    //-----------------------------------------------------------------------//
+    // Read room struct
+    //-----------------------------------------------------------------------//
+    RoomDataSource datasrc;
+    auto err = OpenRoomFile(src, datasrc);
+    if (!err)
+    {
+        printf("Error: failed to open room file for reading:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+    
+    RoomScNames data;
+    auto read_cb = [&data](Stream *in, RoomFileBlock block, const String &ext_id,
+        soff_t block_len, RoomFileVersion data_ver, bool &read_next)
+        { return ReadRoomScNames(data, in, block, ext_id, block_len, data_ver); };
+    err = ReadRoomData(read_cb, datasrc.InputStream.get(), datasrc.DataVersion);
+    if (!err)
+    {
+        printf("Error: failed to read room file:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+    datasrc.InputStream.reset();
+
+    //-----------------------------------------------------------------------//
+    // Create script header
+    //-----------------------------------------------------------------------//
+    String header = MakeRoomScriptHeader(data);
+
+    //-----------------------------------------------------------------------//
+    // Write script header
+    //-----------------------------------------------------------------------//
+    Stream *out = File::CreateFile(dst);
+    if (!out)
+    {
+        printf("Error: failed to open script header for writing.\n");
+        return -1;
+    }
+    out->Write(header.GetCStr(), header.GetLength());
+    delete out;
+    printf("Script header written successfully.\nDone.\n");
+    return 0;
+}

--- a/Tools/data/room_utils.cpp
+++ b/Tools/data/room_utils.cpp
@@ -1,0 +1,127 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "data/room_utils.h"
+#include "util/string_utils.h"
+
+#define MIN_ROOM_HOTSPOTS  20
+#define LEGACY_HOTSPOT_NAME_LEN 30
+#define MAX_SCRIPT_NAME_LEN 20
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+HRoomFileError ReadFromMainBlock(RoomScNames &data, Stream *in, RoomFileVersion data_ver, soff_t block_len)
+{
+    soff_t start_pos = in->GetPosition();
+    if (data_ver >= kRoomVersion_208)
+        in->ReadInt32(); // BackgroundBPP
+    size_t wbh_count = in->ReadInt16(); // WalkBehindCount
+                                        // Walk-behinds baselines
+    for (size_t i = 0; i < wbh_count; ++i)
+        in->ReadInt16();
+    size_t hot_count = in->ReadInt32();
+    if (hot_count == 0)
+        hot_count = MIN_ROOM_HOTSPOTS;
+    // Hotspots walk-to points
+    for (size_t i = 0; i < hot_count; ++i)
+    {
+        in->ReadInt16(); // WalkTo.X
+        in->ReadInt16(); // WalkTo.Y
+    }
+    // Hotspots names
+    for (size_t i = 0; i < hot_count; ++i)
+    {
+        if (data_ver >= kRoomVersion_3415)
+            StrUtil::ReadString(in);
+        else if (data_ver >= kRoomVersion_303a)
+            String::FromStream(in);
+        else
+            String::FromStreamCount(in, LEGACY_HOTSPOT_NAME_LEN);
+    }
+    // Hotspot script names
+    if (data_ver >= kRoomVersion_270)
+    {
+        data.HotspotNames.resize(hot_count);
+        for (size_t i = 0; i < hot_count; ++i)
+        {
+            if (data_ver >= kRoomVersion_3415)
+                data.HotspotNames[i] = StrUtil::ReadString(in);
+            else
+                data.HotspotNames[i] = String::FromStreamCount(in, MAX_SCRIPT_NAME_LEN);
+        }
+    }
+    // Skip the rest
+    in->Seek(start_pos + block_len, kSeekBegin);
+    return HRoomFileError::None();
+}
+
+HRoomFileError ReadObjScNamesBlock(RoomScNames &data, Stream *in, RoomFileVersion data_ver)
+{
+    size_t obj_count = in->ReadByte();
+    data.ObjectNames.resize(obj_count);
+    for (size_t i = 0; i < obj_count; ++i)
+    {
+        if (data_ver >= kRoomVersion_3415)
+            data.ObjectNames[i] = StrUtil::ReadString(in);
+        else
+            data.ObjectNames[i].ReadCount(in, MAX_SCRIPT_NAME_LEN);
+    }
+    return HRoomFileError::None();
+}
+
+HRoomFileError ReadRoomScNames(RoomScNames &data, Stream *in, RoomFileBlock block, const String &ext_id,
+    soff_t block_len, RoomFileVersion data_ver)
+{
+    switch (block)
+    {
+    case kRoomFblk_Main:
+        return ReadFromMainBlock(data, in, data_ver, block_len);
+    case kRoomFblk_ObjectScNames:
+        return ReadObjScNamesBlock(data, in, data_ver);
+    default:
+        in->Seek(block_len); // skip block
+        return HRoomFileError::None();
+    }
+}
+
+String MakeRoomScriptHeader(const RoomScNames &data)
+{
+    String header;
+    // Room Object names
+    for (const auto &obj : data.ObjectNames)
+    {
+        if (!obj.IsEmpty())
+        {
+            header.Append("import Object ");
+            header.Append(obj);
+            header.Append(";\n");
+        }
+    }
+    // Hotspot names
+    for (const auto &hot : data.HotspotNames)
+    {
+        if (!hot.IsEmpty())
+        {
+            header.Append("import Hotspot ");
+            header.Append(hot);
+            header.Append(";\n");
+        }
+    }
+    return header;
+}
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/room_utils.h
+++ b/Tools/data/room_utils.h
@@ -1,0 +1,50 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#ifndef __AGS_TOOL_DATA__CRMUTIL_H
+#define __AGS_TOOL_DATA__CRMUTIL_H
+
+#include <vector>
+#include "game/room_file.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+using namespace AGS::Common;
+
+// Script names found in the room data
+struct RoomScNames
+{
+    std::vector<String> ObjectNames;
+    std::vector<String> HotspotNames;
+};
+
+// Following functions parse the binary room file and extract script names
+// Reads only script names from the main room block, ignores other data
+HRoomFileError ReadFromMainBlock(RoomScNames &data, Stream *in, RoomFileVersion data_ver, soff_t block_len);
+// Reads room object script names block
+HRoomFileError ReadObjScNamesBlock(RoomScNames &data, Stream *in, RoomFileVersion data_ver);
+// A room reading callback of type PfnReadRoomBlock, meant to be passed into ReadRoomData();
+// reads only blocks necessary for retrieving script names.
+HRoomFileError ReadRoomScNames(RoomScNames &data, Stream *in, RoomFileBlock block, const String &ext_id,
+    soff_t block_len, RoomFileVersion data_ver);
+
+// Generates room script header out of the room data
+String MakeRoomScriptHeader(const RoomScNames &data);
+
+} // namespace DataUtil
+} // namespace AGS
+
+#endif // __AGS_TOOL_DATA__CRMUTIL_H


### PR DESCRIPTION
Resolves #1147.

This is a proof-of-concept variant of the tool which parses compiled room files (CRM) and generates script header for them.
As it seemed to be the simpliest to make, I decided to try this tool first.

**crm2ash** stands for - CRM to ASH...

*Input:* compiled ags room (*.crm)
*Output:* generated script header with room declarations.

Usage: `crm2ash room.crm room.ash`

It links several utility cpps from the engine's Common folder. ~I hoped to reuse room file reading code too, but it has unnecessary dependencies and may need splitting before it's possible to do without bringing more stuff. So for now just copied necessary bits.~

Builds on Windows and Linux. For MSVS I added a new "Tools" solution. For Linux there's a Makefile. I am not a big expert in writing these, so copied one from ags itself, maybe few things were unnecessary.