### PR TITLE
Engine: Add required '#include <cstdio>' for gcc 10 (ags3--sdl2)

### DIFF
--- a/Engine/debug/filebasedagsdebugger.cpp
+++ b/Engine/debug/filebasedagsdebugger.cpp
@@ -11,6 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include <cstdio>
 #include <string.h>
 #include "debug/filebasedagsdebugger.h"
 #include "util/file.h"


### PR DESCRIPTION
The PR #1111  was merged on Master but not on `ags3--sdl2` branch or not on all files - not sure.

I did a cherry-pick of it and the line in this PR is the missing change for `ags3--sdl2` branch. Below are the other lines, which are already in.

https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Common/font/fonts.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Common/game/main_game_file.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/global_debug.h#L21
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/global_display.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/gui.cpp#L14
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/parser.cpp#L16
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/string.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/ac/translation.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/gui/guidialog.cpp#L15
https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/script/cc_instance.cpp#L15

I couldn't find `cstdio` on [ags3--sdl2/Engine/debug/filebasedagsdebugger.cpp](https://github.com/adventuregamestudio/ags/blob/ags3--sdl2/Engine/debug/filebasedagsdebugger.cpp), so this PR adds to it. In this file, it's needed for `::remove` method.

Perhaps @morganwillcock  knows more.