### PR TITLE
Tool: agf2dlgasc - generate ags scripts out of Game.agf's dialog scripts

### DIFF
--- a/Common/util/memorystream.cpp
+++ b/Common/util/memorystream.cpp
@@ -1,0 +1,156 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "util/memorystream.h"
+#include <algorithm>
+#include <string.h>
+
+namespace AGS
+{
+namespace Common
+{
+
+MemoryStream::MemoryStream(const std::vector<char> &cbuf, DataEndianess stream_endianess)
+    : DataStream(stream_endianess)
+    , _cbuf(&cbuf.front())
+    , _len(cbuf.size())
+    , _buf(nullptr)
+    , _mode(kStream_Read)
+    , _pos(0)
+{
+}
+
+MemoryStream::MemoryStream(const String &cbuf, DataEndianess stream_endianess)
+    : DataStream(stream_endianess)
+    , _cbuf(cbuf.GetCStr())
+    , _len(cbuf.GetLength())
+    , _buf(nullptr)
+    , _mode(kStream_Read)
+    , _pos(0)
+{
+}
+
+MemoryStream::MemoryStream(std::vector<char> &buf, StreamWorkMode mode, DataEndianess stream_endianess)
+    : DataStream(stream_endianess)
+    , _len(buf.size())
+    , _buf(&buf)
+    , _mode(mode)
+    , _pos(buf.size())
+{
+    _cbuf = (mode == kStream_Read) ? &buf.front() : nullptr;
+}
+
+MemoryStream::~MemoryStream()
+{
+}
+
+void MemoryStream::Close()
+{
+    _cbuf = nullptr;
+    _buf = nullptr;
+    _pos = -1;
+}
+
+bool MemoryStream::Flush()
+{
+    return true;
+}
+
+bool MemoryStream::IsValid() const
+{
+    return _cbuf != nullptr || _buf != nullptr;
+}
+
+bool MemoryStream::EOS() const
+{
+    return _pos >= _len;
+}
+
+soff_t MemoryStream::GetLength() const
+{
+    return _len;
+}
+
+soff_t MemoryStream::GetPosition() const
+{
+    return _pos;
+}
+
+bool MemoryStream::CanRead() const
+{
+    return (_cbuf != nullptr) && (_mode == kStream_Read);
+}
+
+bool MemoryStream::CanWrite() const
+{
+    return (_buf != nullptr) && (_mode == kStream_Write);
+}
+
+bool MemoryStream::CanSeek() const
+{
+    return CanRead(); // TODO: support seeking in writable stream?
+}
+
+size_t MemoryStream::Read(void *buffer, size_t size)
+{
+    if (EOS()) { return 0; }
+    soff_t remain = _len - _pos;
+    assert(remain > 0);
+    size_t read_sz = std::min((size_t)remain, size);
+    memcpy(buffer, _cbuf + _pos, read_sz);
+    _pos += read_sz;
+    return read_sz;
+}
+
+int32_t MemoryStream::ReadByte()
+{
+    if (EOS()) { return -1; }
+    return _cbuf[(size_t)(_pos++)];
+}
+
+size_t MemoryStream::Write(const void *buffer, size_t size)
+{
+    if (!_buf) { return 0; }
+    _buf->resize(_buf->size() + size);
+    memcpy(_buf->data() + _pos, buffer, size);
+    _pos += size;
+    _len += size;
+    return size;
+}
+
+int32_t MemoryStream::WriteByte(uint8_t val)
+{
+    if (!_buf) { return -1; }
+    _buf->push_back(val);
+    _pos++; _len++;
+    return val;
+}
+
+bool MemoryStream::Seek(soff_t offset, StreamSeek origin)
+{
+    if (!CanSeek()) { return false; }
+    switch (origin)
+    {
+    case kSeekBegin:    _pos = 0 + offset; break;
+    case kSeekCurrent:  _pos = _pos + offset; break;
+    case kSeekEnd:      _pos = _len + offset; break;
+    default:
+        return false;
+    }
+    _pos = std::max<soff_t>(0, _pos);
+    _pos = std::min<soff_t>(_len, _pos); // clamp to EOS
+    return true;
+}
+
+} // namespace Common
+} // namespace AGS

--- a/Common/util/memorystream.h
+++ b/Common/util/memorystream.h
@@ -1,0 +1,83 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// MemoryStream does reading and writing over the buffer of chars stored in
+// memory. Currently has rather trivial implementation. Does not own a buffer
+// itself, but works with the provided std::vector reference, which means that
+// the buffer *must* persist until stream is closed.
+// TODO: perhaps accept const char* for reading mode, for compatibility with
+// the older code, and maybe to let also read String objects?
+// TODO: separate StringStream for reading & writing String object?
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__MEMORYSTREAM_H
+#define __AGS_CN_UTIL__MEMORYSTREAM_H
+
+#include <vector>
+#include "util/datastream.h"
+#include "util/string.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+class MemoryStream : public DataStream
+{
+public:
+    // Construct memory stream in the read-only mode over a const std::vector;
+    // vector must persist in memory until the stream is closed.
+    MemoryStream(const std::vector<char> &cbuf, DataEndianess stream_endianess = kLittleEndian);
+    // Construct memory stream in the read-only mode over a const String;
+    // String object must persist in memory until the stream is closed.
+    MemoryStream(const String &cbuf, DataEndianess stream_endianess = kLittleEndian);
+    // Construct memory stream in the chosen mode over a given std::vector;
+    // vector must persist in memory until the stream is closed.
+    MemoryStream(std::vector<char> &buf, StreamWorkMode mode, DataEndianess stream_endianess = kLittleEndian);
+    ~MemoryStream() override;
+
+    void    Close() override;
+    bool    Flush() override;
+
+    // Is stream valid (underlying data initialized properly)
+    bool    IsValid() const override;
+    // Is end of stream
+    bool    EOS() const override;
+    // Total length of stream (if known)
+    soff_t  GetLength() const override;
+    // Current position (if known)
+    soff_t  GetPosition() const override;
+    bool    CanRead() const override;
+    bool    CanWrite() const override;
+    bool    CanSeek() const override;
+
+    size_t  Read(void *buffer, size_t size) override;
+    int32_t ReadByte() override;
+    size_t  Write(const void *buffer, size_t size) override;
+    int32_t WriteByte(uint8_t b) override;
+
+    bool    Seek(soff_t offset, StreamSeek origin) override;
+
+private:
+    const char              *_cbuf;
+    size_t                   _len;
+    std::vector<char>       *_buf;
+    const StreamWorkMode     _mode;
+    soff_t                   _pos;
+};
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__MEMORYSTREAM_H

--- a/Common/util/stream.h
+++ b/Common/util/stream.h
@@ -31,6 +31,14 @@ namespace AGS
 namespace Common
 {
 
+// TODO: merge with FileWorkMode (historical mistake)
+enum StreamWorkMode
+{
+    kStream_Read,
+    kStream_Write
+};
+
+
 class Stream : public IAGSStream
 {
 public:

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <cctype>
 #include "util/math.h"
 #include "util/stream.h"
 #include "util/string.h"
@@ -66,6 +67,18 @@ String::String(char c, size_t count)
 String::~String()
 {
     Free();
+}
+
+bool String::IsNullOrSpace() const
+{
+    if (_len == 0)
+        return true;
+    for (const char *ptr = _cstr; *ptr; ++ptr)
+    {
+        if (!std::isspace(*ptr))
+            return false;
+    }
+    return true;
 }
 
 void String::Read(Stream *in, size_t max_chars, bool stop_at_limit)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -81,6 +81,8 @@ public:
     {
         return _len == 0;
     }
+    // Tells if the string is either empty or has only whitespace characters
+    bool IsNullOrSpace() const;
 
     // Those getters are for tests only, hence if AGS_PLATFORM_DEBUG
 #if AGS_PLATFORM_DEBUG
@@ -148,6 +150,13 @@ public:
     int     CompareRightNoCase(const String &str, size_t count = -1) const
                 { return CompareRightNoCase(str._cstr, count != -1 ? count : str._len); }
     int     CompareRightNoCase(const char *cstr, size_t count = -1) const;
+    // Convenience aliases for Compare functions
+    inline bool Equals(const String &str) const { return Compare(str) == 0; }
+    inline bool Equals(const char *cstr) const { return Compare(cstr) == 0; }
+    inline bool StartsWith(const String &str) const { return CompareLeft(str) == 0; }
+    inline bool StartsWith(const char *cstr) const { return CompareLeft(cstr) == 0; }
+    inline bool EndsWidth(const String &str) const { return CompareRight(str) == 0; }
+    inline bool EndsWidth(const char *cstr) const { return CompareRight(cstr) == 0; }
 
     // These functions search for character or substring inside this string
     // and return the index of the (first) character, or -1 if nothing found.

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -341,6 +341,7 @@
     <ClCompile Include="..\..\Common\util\inifile.cpp" />
     <ClCompile Include="..\..\Common\util\ini_util.cpp" />
     <ClCompile Include="..\..\Common\util\lzw.cpp" />
+    <ClCompile Include="..\..\Common\util\memorystream.cpp" />
     <ClCompile Include="..\..\Common\util\misc.cpp" />
     <ClCompile Include="..\..\Common\util\mutifilelib.cpp" />
     <ClCompile Include="..\..\Common\util\path.cpp" />
@@ -486,6 +487,7 @@
     <ClInclude Include="..\..\Common\util\lzw.h" />
     <ClInclude Include="..\..\Common\util\math.h" />
     <ClInclude Include="..\..\Common\util\memory.h" />
+    <ClInclude Include="..\..\Common\util\memorystream.h" />
     <ClInclude Include="..\..\Common\util\memory_compat.h" />
     <ClInclude Include="..\..\Common\util\misc.h" />
     <ClInclude Include="..\..\Common\util\multifilelib.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -506,6 +506,9 @@
     <ClCompile Include="..\..\Common\game\room_file_base.cpp">
       <Filter>Source Files\game</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\memorystream.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\audiocliptype.h">
@@ -797,6 +800,9 @@
       <Filter>Library Sources\allegro\c</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\util\memory_compat.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\memorystream.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Solutions/Tools.App/afg2dlgasc.vcxproj
+++ b/Solutions/Tools.App/afg2dlgasc.vcxproj
@@ -27,24 +27,37 @@
     <ClCompile Include="..\..\Common\util\stdio_compat.c" />
     <ClCompile Include="..\..\Common\util\stream.cpp" />
     <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\memorystream.cpp" />
     <ClCompile Include="..\..\Common\util\string_compat.c" />
     <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp" />
     <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp" />
-    <ClCompile Include="..\..\Tools\agf2autoash\main.cpp" />
+    <ClCompile Include="..\..\Tools\agf2dlgasc\main.cpp" />
     <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
-    <ClCompile Include="..\..\Tools\data\scriptgen.cpp" />
+    <ClCompile Include="..\..\Tools\data\dialogscriptconv.cpp" />
+    <ClCompile Include="..\..\Tools\data\script_utils.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Common\debug\out.h" />
+    <ClInclude Include="..\..\Common\util\bufferedstream.h" />
+    <ClInclude Include="..\..\Common\util\datastream.h" />
+    <ClInclude Include="..\..\Common\util\file.h" />
+    <ClInclude Include="..\..\Common\util\filestream.h" />
+    <ClInclude Include="..\..\Common\util\stream.h" />
+    <ClInclude Include="..\..\Common\util\string.h" />
+    <ClInclude Include="..\..\Common\util\memorystream.h" />
+    <ClInclude Include="..\..\Common\util\string_utils.h" />
     <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h" />
     <ClInclude Include="..\..\Tools\data\agfreader.h" />
+    <ClInclude Include="..\..\Tools\data\dialogscriptconv.h" />
     <ClInclude Include="..\..\Tools\data\game_utils.h" />
-    <ClInclude Include="..\..\Tools\data\scriptgen.h" />
+    <ClInclude Include="..\..\Tools\data\script_utils.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{1D6C40C4-D623-4889-9670-9B287D2B4F84}</ProjectGuid>
+    <ProjectGuid>{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}</ProjectGuid>
     <RootNamespace>MakeRoomHeader</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <ProjectName>agf2autoash</ProjectName>
+    <ProjectName>agf2dlgasc</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Solutions/Tools.App/afg2dlgasc.vcxproj.filters
+++ b/Solutions/Tools.App/afg2dlgasc.vcxproj.filters
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tinyxml2">
+      <UniqueIdentifier>{46208ff5-d822-4f9b-8208-d51993dbec22}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="agf2dlgasc">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="data">
+      <UniqueIdentifier>{4fd7b344-b56f-488e-b85a-fbcd99b2641a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp">
+      <Filter>tinyxml2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\agf2dlgasc\main.cpp">
+      <Filter>agf2dlgasc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\memorystream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\agfreader.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\dialogscriptconv.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\script_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">
+      <Filter>tinyxml2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\bufferedstream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\datastream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\file.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\filestream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\debug\out.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\stream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\string.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\string_utils.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\memorystream.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\agfreader.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\dialogscriptconv.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\game_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\script_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.App/crm2ash.vcxproj
+++ b/Solutions/Tools.App/crm2ash.vcxproj
@@ -91,11 +91,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\$(ProjectName)</IntDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\$(ProjectName)</IntDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -9,6 +9,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2autoash", "Tools.App\ag
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2glvar", "Tools.App\agf2glvar.vcxproj", "{16D2E9E4-5357-49B8-A446-D99A2F276F89}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2dlgasc", "Tools.App\afg2dlgasc.vcxproj", "{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -41,6 +43,14 @@ Global
 		{16D2E9E4-5357-49B8-A446-D99A2F276F89}.Release|x64.Build.0 = Release|x64
 		{16D2E9E4-5357-49B8-A446-D99A2F276F89}.Release|x86.ActiveCfg = Release|Win32
 		{16D2E9E4-5357-49B8-A446-D99A2F276F89}.Release|x86.Build.0 = Release|Win32
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Debug|x64.ActiveCfg = Debug|x64
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Debug|x64.Build.0 = Debug|x64
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Debug|x86.ActiveCfg = Debug|Win32
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Debug|x86.Build.0 = Debug|Win32
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x64.ActiveCfg = Release|x64
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x64.Build.0 = Release|x64
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x86.ActiveCfg = Release|Win32
+		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/agf2dlgasc/Makefile
+++ b/Tools/agf2dlgasc/Makefile
@@ -1,0 +1,98 @@
+INCDIR = ../../Common ../../Tools ../../libsrc/tinyxml2
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/datastream.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/memorystream.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp \
+	../../Common/util/textstreamreader.cpp
+
+TOOL_OBJS = \
+	../../Tools/data/agfreader.cpp \
+	../../Tools/data/dialogscriptconv.cpp \
+	../../Tools/data/script_utils.cpp
+
+TINYXML2 = \
+	../../libsrc/tinyxml2/tinyxml2.cpp
+
+OBJS := main.cpp \
+	$(COMMON_OBJS) \
+	$(TOOL_OBJS) \
+	$(TINYXML2)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags agf2dlgasc
+
+agf2dlgasc: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags agf2dlgasc
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f agf2dlgasc $(OBJS) $(DEPFILES)
+
+install: agf2dlgasc
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin agf2dlgasc
+
+uninstall:
+	rm -f $(PREFIX)/bin/agf2dlgasc

--- a/Tools/agf2dlgasc/main.cpp
+++ b/Tools/agf2dlgasc/main.cpp
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <vector>
+#include "data/agfreader.h"
+#include "data/dialogscriptconv.h"
+#include "util/file.h"
+#include "util/stream.h"
+#include "util/string_compat.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+namespace AGF = AGS::AGF;
+
+
+const char *HELP_STRING = "Usage: agf2dlgasc <in-game.agf> <out-dialog.asc>\n";
+
+int main(int argc, char *argv[])
+{
+    printf("agf2dlgasc v0.1.0 - AGS game's dialog script generator\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        {
+            printf("%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+    }
+    if (argc < 3)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *src = argv[1];
+    const char *dst = argv[2];
+    printf("Input game AGF: %s\n", src);
+    printf("Output script body: %s\n", dst);
+
+    //-----------------------------------------------------------------------//
+    // Read Game.agf
+    //-----------------------------------------------------------------------//
+    AGF::AGFReader reader;
+    HError err = reader.Open(src);
+    if (!err)
+    {
+        printf("Error: failed to open source AGF:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    GameRef game_obj;
+    AGF::ReadGameRef(game_obj, reader);
+    // We need to query for separate dialog nodes, because ReadGameRef()
+    // does not load dialog scripts; we'll have to do that on our own.
+    AGF::Dialogs p_dialogs;
+    AGF::Dialog p_dialog;
+    std::vector<AGF::DocElem> dlg_elems;
+    p_dialogs.GetAll(reader.GetGameRoot(), dlg_elems);
+
+    //-----------------------------------------------------------------------//
+    // Convert dialog scripts one by one and merge into the single script body
+    //-----------------------------------------------------------------------//
+    // There's a bunch of standard functions that are always prepended to the script
+    String body = DialogScriptDefault;
+    // Now load dialogs one by one, convert and append
+    for (size_t i = 0; i < game_obj.Dialogs.size(); ++i)
+    {
+        const DialogRef &dialog_obj = game_obj.Dialogs[i];
+        AGF::DocElem dialog_el = dlg_elems[i];
+        const String dialog_script = p_dialog.ReadScript(dialog_el);
+
+        DialogScriptConverter conv(dialog_script, game_obj, dialog_obj);
+        String script = conv.Convert();
+
+        body.Append(String::FromFormat("%sDialog %d\"\n", NEW_SCRIPT_MARKER, dialog_obj.ID));
+        if (conv.GetErrors().size() > 0)
+        {
+            printf("%s compilation output:\n", dialog_obj.ScriptName.GetCStr());
+            printf("----------------------------------------\n");
+            for (const auto &e : conv.GetErrors())
+                printf("%s: Line %zu: %s\n", e.Error ? "Error" : "Warning", e.LineNumber, e.Message.GetCStr());
+            printf("----------------------------------------\n");
+            for (const auto &e : conv.GetErrors())
+            {
+                if (e.Error)
+                {
+                    printf("There were conversion errors.\nStop.\n");
+                    return -1;
+                }
+            }
+        }
+        body.Append(script);
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write script body
+    //-----------------------------------------------------------------------//
+    Stream *out = File::CreateFile(dst);
+    if (!out)
+    {
+        printf("Error: failed to open script header for writing.\n");
+        return -1;
+    }
+    out->Write(body.GetCStr(), body.GetLength());
+    delete out;
+    printf("Script body written successfully.\nDone.\n");
+    return 0;
+}

--- a/Tools/data/agfreader.h
+++ b/Tools/data/agfreader.h
@@ -161,6 +161,9 @@ public:
     String ReadType(DocElem elem) override { return "Dialog"; }
     int ReadID(DocElem elem) override { return ReadInt(elem, "ID", -1); }
     String ReadScriptName(DocElem elem) override { return ReadString(elem, "Name"); }
+
+    int ReadOptionCount(DocElem elem);
+    String ReadScript(DocElem elem) { return ReadString(elem, "Script"); }
 };
 
 // Font data parser
@@ -329,6 +332,17 @@ public:
     void GetAll(DocElem root, std::vector<DocElem> &elems) override;
 };
 
+class Game : public EntityParser
+{
+public:
+    String ReadType(DocElem elem) override { return "Game"; }
+    int    ReadID(DocElem elem) override { return -1; }
+    String ReadScriptName(DocElem elem) override { return ""; }
+
+    String ReadSayFunction(DocElem elem) { return ReadString(elem, "DialogScriptSayFunction"); }
+    String ReadNarrateFunction(DocElem elem) { return ReadString(elem, "DialogScriptNarrateFunction"); }
+};
+
 
 //
 // Helper functions
@@ -342,6 +356,8 @@ void ReadAllEntityRefs(std::vector<DataUtil::EntityRef> &ents, EntityListParser 
     EntityParser &parser, DocElem root);
 // Reads global variables defined inside the game project from the given doc root element.
 void ReadGlobalVariables(std::vector<DataUtil::Variable> &vars, DocElem root);
+// Reads game settings from the given doc root element.
+void ReadGameSettings(DataUtil::GameSettings &opt, DocElem root);
 // Reads full game reference data using AGFReader
 void ReadGameRef(DataUtil::GameRef &game, AGFReader &reader);
 

--- a/Tools/data/dialogscriptconv.cpp
+++ b/Tools/data/dialogscriptconv.cpp
@@ -1,0 +1,512 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "data/dialogscriptconv.h"
+#include <cctype>
+#include <regex>
+#include "util/memorystream.h"
+#include "util/string_utils.h"
+#include "util/textstreamreader.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+const char *DialogScriptDefault = "\
+#define DIALOG_NONE      0\n\
+#define DIALOG_RUNNING   1\n\
+#define DIALOG_STOP      2\n\
+#define DIALOG_NEWROOM   100\n\
+#define DIALOG_NEWTOPIC  12000\n\
+\n\
+_tryimport function dialog_request(int);\n\
+int __dlgscript_tempval;\n\
+\n\
+function _run_dialog_request(int parmtr) {\n\
+  game.stop_dialog_at_end = DIALOG_RUNNING;\n\
+  dialog_request(parmtr);\n\
+\n\
+  if (game.stop_dialog_at_end == DIALOG_STOP) {\n\
+    game.stop_dialog_at_end = DIALOG_NONE;\n\
+    return -2;\n\
+  }\n\
+  if (game.stop_dialog_at_end >= DIALOG_NEWTOPIC) {\n\
+    int tval = game.stop_dialog_at_end - DIALOG_NEWTOPIC;\n\
+    game.stop_dialog_at_end = DIALOG_NONE;\n\
+    return tval;\n\
+  }\n\
+  if (game.stop_dialog_at_end >= DIALOG_NEWROOM) {\n\
+    int roomnum = game.stop_dialog_at_end - DIALOG_NEWROOM;\n\
+    game.stop_dialog_at_end = DIALOG_NONE;\n\
+    player.ChangeRoom(roomnum);\n\
+    return -2;\n\
+  }\n\
+  game.stop_dialog_at_end = DIALOG_NONE;\n\
+  return -1;\n\
+}\n\
+";
+
+
+DialogScriptConverter::DialogScriptConverter(const String &dlg_script, const GameRef &game, const DialogRef &dialog)
+    : _dlgScript(dlg_script), _game(game), _dialog(dialog)
+{
+    _scriptName.Format("Dialog %d", _dialog.ID);
+    _sayFnName = _game.Settings.SayFunction;
+    _narrateFnName = _game.Settings.NarrateFunction;
+    // Fixups
+    if (_sayFnName.IsNullOrSpace())
+        _sayFnName = "Say";
+    if (_narrateFnName.IsNullOrSpace())
+        _narrateFnName = "Display";
+}
+
+String DialogScriptConverter::Convert()
+{
+    _errors.clear();
+    _currentlyInsideCodeArea = false;
+    _hadFirstEntryPoint = false;
+    _entryPoints.clear();
+    _lineNumber = 0;
+
+    // TODO: TextStreamReader now deletes stream in dtor, which is a design mistake
+    MemoryStream *mems = new MemoryStream(_dlgScript);
+    TextStreamReader sr(mems);
+
+    String ags_script =
+        String::FromFormat("function _run_dialog%d(int entryPoint) { \n", _dialog.ID);
+
+    String thisLine;
+    for (thisLine = sr.ReadLine(); !thisLine.IsEmpty(); thisLine = sr.ReadLine())
+    {
+        _lineNumber++;
+        String s = ConvertLine(thisLine);
+        if (!s.IsNullOrSpace())
+        {
+            ags_script.Append(s);
+            ags_script.Append("\n");
+        }
+    }
+    if (_currentlyInsideCodeArea)
+    {
+        ags_script.Append("}\n");
+    }
+    ags_script.Append("return RUN_DIALOG_RETURN; }\n"); // end the function
+    return ags_script;
+}
+
+void DialogScriptConverter::CompileError(const String &msg)
+{
+    _errors.push_back(CompileMessage(true, msg, _scriptName, _lineNumber));
+}
+
+void DialogScriptConverter::CompileWarning(const String &msg)
+{
+    _errors.push_back(CompileMessage(false, msg, _scriptName, _lineNumber));
+}
+
+bool DialogScriptConverter::IsRealScriptLine(const String &line)
+{
+    return ((line.GetAt(0) == ' ') || (line.GetAt(0) == '\t')) &&
+        !line.IsNullOrSpace();
+}
+
+String DialogScriptConverter::ConvertLine(const String &line)
+{
+    if (IsRealScriptLine(line))
+    {
+        if (!_currentlyInsideCodeArea)
+        {
+            CompileError("Script commands can only be used in the area between a @ entry point and the closing return/stop statement");
+            return "";
+        }
+        return ConvertRealScript(line);
+    }
+    return ConvertDialogScript(line);
+}
+
+// NOTE: original CJ's comment:
+// We need this hideously complicated function because we don't
+// want to replace it if "this" appears inside a string, hence
+// we can't just use a simple regex
+String DialogScriptConverter::ConvertRealScript(const String &src_line)
+{
+    String line = src_line;
+    size_t at = -1;
+    for (at = line.FindString("this", at + 1); at != -1;
+        at = line.FindString("this", at + 1))
+    {
+        if (std::isalnum(line[at - 1]) ||
+            (line[at - 1] == '_'))
+        {
+            continue;
+        }
+        if ((at < line.GetLength() - 4) &&
+            ((std::isalnum(line[at + 4]) ||
+            (line[at + 4] == '_'))))
+        {
+            continue;
+        }
+        bool insideString = false;
+        for (size_t i = 1; i < at; i++)
+        {
+            if ((line[i] == '"') && (line[i - 1] != '\\'))
+            {
+                insideString = !insideString;
+            }
+        }
+        if (!insideString)
+        { // replace "this" with "dialog[X]"
+            line.ReplaceMid(at, 4, String::FromFormat("dialog[%d]", _dialog.ID).GetCStr());
+        }
+    }
+    return line;
+}
+
+String DialogScriptConverter::ConvertDialogScript(const String &src_line)
+{
+    String line = src_line;
+    // look for comments and cut them off
+    size_t at = line.FindString("//");
+    if (at != -1)
+    {
+        line = line.Mid(0, at);
+    }
+    line.Trim();
+
+    if (line.IsEmpty())
+    {
+        return "";
+    }
+    else if (line.StartsWith("@"))
+    {
+        return ProcessEntryPointTag(line);
+    }
+    else if (!_currentlyInsideCodeArea)
+    {
+        CompileWarning(
+            String::FromFormat("The command '%s' will be ignored since the script for this option has already finished", line.GetCStr()));
+        return "";
+    }
+    else if (line.FindChar(':') != -1)
+    {
+        return ProcessCharacterSpeech(line);
+    }
+    else
+    {
+        String script_line;
+        // the old dialog script compiler allowed semicolons,
+        // so just strip them out
+        line.MakeLower();
+        line.Replace(';', ' ');
+        line.Trim();
+
+        if (line == "return")
+        {
+            script_line = "return RUN_DIALOG_RETURN; }";
+            _currentlyInsideCodeArea = false;
+        }
+        else if (line == "stop")
+        {
+            script_line = "return RUN_DIALOG_STOP_DIALOG; }";
+            _currentlyInsideCodeArea = false;
+        }
+        else if (line.StartsWith("option-off-forever"))
+        {
+            script_line = ProcessOptionOnOff(line, "eOptionOffForever");
+        }
+        else if (line.StartsWith("option-off"))
+        {
+            script_line = ProcessOptionOnOff(line, "eOptionOff");
+        }
+        else if (line.StartsWith("option-on"))
+        {
+            script_line = ProcessOptionOnOff(line, "eOptionOn");
+        }
+        else if (line == "goto-previous")
+        {
+            script_line = "return RUN_DIALOG_GOTO_PREVIOUS; }";
+            _currentlyInsideCodeArea = false;
+        }
+        else if (line.StartsWith("set-speech-view"))
+        {
+            script_line = ProcessCmdSpeechView(line);
+        }
+        else if (line.StartsWith("set-globalint"))
+        {
+            script_line = ProcessCmdSetGlobalInt(line);
+        }
+        else if (line.StartsWith("goto-dialog"))
+        {
+            script_line = ProcessCmdGotoDialog(line);
+            _currentlyInsideCodeArea = false;
+        }
+        else if (line.StartsWith("run-script"))
+        {
+            script_line = ProcessCmdRunScript(line);
+        }
+        else if (line.StartsWith("play-sound"))
+        {
+            script_line = ProcessCmdArgInt(line, "play-sound", "PlaySound(%s);");
+        }
+        else if (line.StartsWith("add-inv"))
+        {
+            script_line = ProcessCmdArgInt(line, "add-inv", "player.AddInventory(inventory[%s]);");
+        }
+        else if (line.StartsWith("lose-inv"))
+        {
+            script_line = ProcessCmdArgInt(line, "lose-inv", "player.LoseInventory(inventory[%s]);");
+        }
+        else if (line.StartsWith("new-room"))
+        {
+            script_line = ProcessCmdArgInt(line, "new-room", "player.ChangeRoom(%s);");
+            script_line.Append(" return RUN_DIALOG_STOP_DIALOG; }");
+            _currentlyInsideCodeArea = false;
+        }
+        else if (line.StartsWith("give-score"))
+        {
+            script_line = ProcessCmdArgInt(line, "give-score", "GiveScore(%s);");
+        }
+        else
+        {
+            CompileError(
+                String::FromFormat("Unknown command: %s. The command may require parameters which you have not supplied.", line.GetCStr()));
+        }
+        return script_line;
+    }
+}
+
+String DialogScriptConverter::ProcessCmdArgInt(const String &line, const char *command, const char *replacement)
+{
+    //Match result = Regex.Match(dlgScriptLine, string.Format(@"^{0}\s*(\d+)$", command), RegexOptions.IgnoreCase);
+    String pattern = String::FromFormat("^%s\\s*(\\d+)$", command);
+    const std::regex regex(pattern.GetCStr(), std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError(String::FromFormat("Invalid/missing parameter for %s", command));
+        return "";
+    }
+    return String::FromFormat(replacement, mr[1].str().c_str());
+}
+
+String DialogScriptConverter::ProcessCmdRunScript(const String &line)
+{
+    //Match result = Regex.Match(dlgScriptCommand, @"^run-script\s*(\d+)$", RegexOptions.IgnoreCase);
+    const std::regex regex("^run-script\\s*(\\d+)$", std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError("run-script must supply dialog request ID");
+        return "";
+    }
+    return String::FromFormat(
+        "__dlgscript_tempval=_run_dialog_request(%s); if(__dlgscript_tempval!=-1) return __dlgscript_tempval;",
+        mr[1].str().c_str());
+}
+
+String DialogScriptConverter::ProcessCmdGotoDialog(const String &line)
+{
+    //Match result = Regex.Match(dlgScriptCommand, @"^goto-dialog\s*(\w+)$", RegexOptions.IgnoreCase);
+    const std::regex regex("^goto-dialog\\s*(\\w+)$", std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError("goto-dialog must supply new dialog name");
+        return "";
+    }
+    
+    String dialog_name = mr[1].str().c_str();
+    int dialogid;
+    if (StrUtil::StringToInt(dialog_name, dialogid, 0) == StrUtil::kNoError)
+    {
+        return String::FromFormat("return %d;}", dialogid);
+    }
+
+    for (const auto &other_dialog : _game.Dialogs)
+    {
+        if (other_dialog.ScriptName.CompareNoCase(dialog_name) == 0)
+        {
+            return String::FromFormat("return %d;}", other_dialog.ID);
+        }
+    }
+
+    CompileError(String::FromFormat("Dialog not found: %s", dialog_name));
+    return "";
+}
+
+String DialogScriptConverter::ProcessCmdSetGlobalInt(const String &line)
+{
+    //Match result = Regex.Match(dlgScriptCommand, @"^set-globalint\s*(\d+),?\s*(\d+)$", RegexOptions.IgnoreCase);
+    const std::regex regex("^set-globalint\\s*(\\d+),?\\s*(\\d+)$", std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError("set-globalint must supply global int number and new value");
+        return "";
+    }
+    return String::FromFormat("SetGlobalInt(%s,%s);", mr[1].str().c_str(), mr[2].str().c_str());
+}
+
+String DialogScriptConverter::ProcessCmdSpeechView(const String &line)
+{
+    //Match result = Regex.Match(dlgScriptCommand, @"^set-speech-view\s*(\w+),?\s*(\d+)$", RegexOptions.IgnoreCase);
+    const std::regex regex("^set-speech-view\\s*(\\w+),?\\s*(\\d+)$", std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError("set-speech-view must supply character name and view number");
+        return "";
+    }
+    String char_name = mr[1].str().c_str();
+    // = result.Groups[2].Captures[0].Value;
+    const auto *character = FindCharacterByScriptName(char_name);
+    if (!character)
+        return "";
+    return String::FromFormat("%s.SpeechView = %s;", character->ScriptName.GetCStr(), mr[2].str().c_str());
+}
+
+String DialogScriptConverter::ProcessOptionOnOff(const String &line, const char *option_state)
+{
+    //Match result = Regex.Match(dlgScriptCommand, @"^option-(on|off(\-forever)?)\s*(\d+)$", RegexOptions.IgnoreCase);
+    const std::regex regex("^option-(on|off(\\-forever)?)\\s*(\\d+)$", std::regex_constants::icase);
+    std::cmatch mr;
+    if (!std::regex_match(line.GetCStr(), mr, regex))
+    {
+        CompileError("option-on/off must supply option number");
+        return "";
+    }
+
+    const char *option_str = mr[3].str().c_str();
+    int option_num;
+    if (StrUtil::StringToInt(option_str, option_num, 0) == StrUtil::kNoError)
+    {
+        if ((option_num < 1) || (option_num > _dialog.OptionCount))
+        {
+            CompileError(String::FromFormat("Dialog does not have an option number %d", option_num));
+            return "";
+        }
+    }
+    else
+    {
+        CompileError(String::FromFormat("Invalid option number: %s", option_str));
+        return "";
+    }
+    return String::FromFormat("dialog[%d].SetOptionState(%d,%s);", _dialog.ID, option_num, option_state);
+}
+
+String DialogScriptConverter::MakeCharacterSpeech(const String &name, const String &say_text)
+{
+    // Note that textToSay does not have to be a literal string, could be a function call for example
+    if (name == "player")
+    {
+        return String::FromFormat("player.%s(%s);", _sayFnName.GetCStr(), say_text.GetCStr());
+    }
+    else if (name == "narrator")
+    {
+        return String::FromFormat("%s(%s);", _narrateFnName.GetCStr(), say_text.GetCStr());
+    }
+    else
+    {
+        const auto *character = FindCharacterByScriptName(name);
+        if (!character)
+            return "";
+        return String::FromFormat("%s.%s(%s);", character->ScriptName.GetCStr(), _sayFnName.GetCStr(), say_text.GetCStr());
+    }
+}
+
+
+String DialogScriptConverter::ProcessCharacterSpeech(const String &line)
+{
+    size_t colon_at = line.FindChar(':');
+    String char_name = line.Mid(0, colon_at);
+    char_name.Trim();
+    char_name.MakeLower();
+    String say_text = line.Mid(colon_at + 1);
+    say_text.Trim();
+    if (say_text.IsEmpty())
+        say_text = "...";
+    else
+        ;// say_text.Replace("\"", "\\\""); // TODO: Replace strings
+    say_text = String::FromFormat("\"%s\"", say_text.GetCStr());
+    return MakeCharacterSpeech(char_name, say_text);
+}
+
+// TODO: move this somewhere else (game utility functions?)
+// Finds character by a *case insensitive* script name
+// (they don't have case sensitivity in dialog scripts)
+const CharacterRef *DialogScriptConverter::FindCharacterByScriptName(const String &name)
+{
+    for (const auto &c : _game.Characters)
+    {
+        if (c.ScriptName.CompareNoCase(name) == 0 ||
+            // also compare to a c-prefixed name
+            (c.ScriptName.GetAt(0) == 'c' && c.ScriptName.CompareMidNoCase(name, 1) == 0))
+        {
+            return &c;
+        }
+    }
+
+    CompileError(String::FromFormat("Unknown character: %s", name.GetCStr()));
+    return nullptr;
+}
+
+String DialogScriptConverter::ProcessEntryPointTag(const String &line)
+{
+    int entryp_id;
+    if (StrUtil::StringToInt(line.Mid(1), entryp_id, 0) == StrUtil::kNoError)
+    {
+    }
+    else if ((line.GetLength() > 1) && (line.GetAt(1) == 'S'))
+    {
+        entryp_id = 0;
+    }
+    else
+    {
+        CompileError(String::FromFormat("Invalid entry point tag: %s", line.GetCStr()));
+        return "";
+    }
+    if (std::find(_entryPoints.begin(), _entryPoints.end(), entryp_id) != _entryPoints.end())
+    {
+        CompileError(String::FromFormat("Entry point already exists in this script: %s", line.GetCStr()));
+        return "";
+    }
+    if ((entryp_id < 0) || (entryp_id > _dialog.OptionCount))
+    {
+        CompileError(String::FromFormat("Dialog has no option number %d", entryp_id));
+        return "";
+    }
+    _entryPoints.push_back(entryp_id);
+
+    String script;
+    if (_currentlyInsideCodeArea)
+    {
+        // the previous clause didn't have a return/stop/etc, so
+        // make it flow into this one
+        script = String::FromFormat("entryPoint = %d; }", entryp_id);
+    }
+    else if (_hadFirstEntryPoint)
+    {
+        script = "else ";
+    }
+
+    script.Append(String::FromFormat("if (entryPoint == %d) {", entryp_id));
+    _hadFirstEntryPoint = true;
+    _currentlyInsideCodeArea = true;
+    return script;
+}
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/dialogscriptconv.h
+++ b/Tools/data/dialogscriptconv.h
@@ -1,0 +1,80 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// DialogScriptConverter converts dialog script dialect into the regular
+// AGS script which can be compiled by the AGS script compiler.
+//
+//=============================================================================
+#ifndef __AGS_TOOL_DATA__DIALOGSCRIPTCONV_H
+#define __AGS_TOOL_DATA__DIALOGSCRIPTCONV_H
+
+#include "util/string.h"
+#include "data/game_utils.h"
+#include "data/script_utils.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+using AGS::Common::String;
+
+extern const char *DialogScriptDefault;
+
+// DialogScriptConverter converts dialog script into the real AGS script
+class DialogScriptConverter
+{
+public:
+    DialogScriptConverter(const String &dlg_script, const GameRef &game, const DialogRef &dialog);
+
+    String Convert();
+    const CompileMessages &GetErrors() const { return _errors; }
+
+private:
+    void CompileError(const String &msg);
+    void CompileWarning(const String &msg);
+    static bool IsRealScriptLine(const String &line);
+    String ConvertLine(const String &line);
+    String ConvertRealScript(const String &line);
+    String ConvertDialogScript(const String &line);
+    String ProcessCmdArgInt(const String &line, const char *command, const char *replacement);
+    String ProcessCmdRunScript(const String &line);
+    String ProcessCmdGotoDialog(const String &line);
+    String ProcessCmdSetGlobalInt(const String &line);
+    String ProcessCmdSpeechView(const String &line);
+    String ProcessOptionOnOff(const String &line, const char *option_state);
+    String MakeCharacterSpeech(const String &name, const String &say_text);
+    String ProcessCharacterSpeech(const String &line);
+    String ProcessEntryPointTag(const String &line);
+    const CharacterRef *FindCharacterByScriptName(const String &name);
+
+
+    CompileMessages _errors;
+    const GameRef &_game;
+    const DialogRef &_dialog;
+    String _scriptName;
+    String _dlgScript;
+
+    String _sayFnName;
+    String _narrateFnName;
+    bool _currentlyInsideCodeArea;
+    bool _hadFirstEntryPoint;
+    std::vector<int> _entryPoints;
+    int _lineNumber;
+};
+
+} // namespace AGF
+} // namespace AGS
+
+#endif // __AGS_TOOL_DATA__DIALOGSCRIPTCONV_H

--- a/Tools/data/game_utils.h
+++ b/Tools/data/game_utils.h
@@ -33,6 +33,15 @@ struct EntityRef
     String ScriptName;
 };
 
+typedef EntityRef CharacterRef;
+
+// DialogRef contains only Dialog data strictly necessary for generating scripts.
+// NOTE: replace with full Dialog struct later if appears necessary
+struct DialogRef : EntityRef
+{
+    int OptionCount = 0;
+};
+
 // GUIRef contains only GUI data strictly necessary for generating scripts.
 // NOTE: replace with full GUI struct later if appears necessary
 struct GUIRef : EntityRef
@@ -48,19 +57,30 @@ struct Variable
     String Value;
 };
 
+// Game settings
+struct GameSettings
+{
+    String SayFunction; // Custom speech function name
+    String NarrateFunction; // Custom narrate function name
+};
+
 // GameRef contains only game data strictly necessary for generating scripts.
 // NOTE: replace with full Game struct later if appears necessary
 struct GameRef
 {
     std::vector<EntityRef> AudioClips;
     std::vector<EntityRef> AudioTypes;
-    std::vector<EntityRef> Characters;
+    std::vector<CharacterRef> Characters;
     std::vector<EntityRef> Cursors;
-    std::vector<EntityRef> Dialogs;
+    std::vector<DialogRef> Dialogs;
     std::vector<EntityRef> Fonts;
     std::vector<GUIRef>    GUI;
     std::vector<EntityRef> Inventory;
     std::vector<EntityRef> Views;
+
+    std::vector<Variable>  GlobalVars;
+
+    GameSettings           Settings;
 };
 
 } // namespace DataUtil

--- a/Tools/data/script_utils.cpp
+++ b/Tools/data/script_utils.cpp
@@ -1,0 +1,24 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "data/script_utils.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+const char *NEW_SCRIPT_MARKER = "\"__NEWSCRIPTSTART_";
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/script_utils.h
+++ b/Tools/data/script_utils.h
@@ -1,0 +1,53 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// This is a number of quickly set up utilities for script handling.
+// Perhaps could be merged and/or shared with AGS Compiler code later.
+//
+//=============================================================================
+#ifndef __AGS_TOOL_DATA__SCRIPTUTIL_H
+#define __AGS_TOOL_DATA__SCRIPTUTIL_H
+
+#include <vector>
+#include "util/string.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+using AGS::Common::String;
+
+// Marker that tells compiler to reset code parsing counters (line number, etc)
+extern const char *NEW_SCRIPT_MARKER;
+
+// A generic compilation message struct, may contain an error or any other
+// type of message (warning, info).
+struct CompileMessage
+{
+    bool   Error;
+    String Message;
+    String ScriptName;
+    size_t LineNumber;
+
+    CompileMessage(bool error, const String &msg, const String &script_name, size_t line)
+        : Error(error), Message(msg), ScriptName(script_name), LineNumber(line) {}
+};
+
+typedef std::vector<CompileMessage> CompileMessages;
+
+} // namespace DataUtil
+} // namespace AGS
+
+#endif // __AGS_TOOL_DATA__SCRIPTUTIL_H

--- a/Tools/data/scriptgen.cpp
+++ b/Tools/data/scriptgen.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "data/scriptgen.h"
+#include <iterator>
 #include <cctype>
 #include "data/room_utils.h"
 
@@ -178,7 +179,9 @@ String MakeGameAutoScriptHeader(const GameRef &game)
     // Cursors
     header.Append(DeclareEntitiesAsEnum(game.Cursors, "CursorMode", "eMode"));
     // Dialogs
-    header.Append(DeclareEntities(game.Dialogs, "Dialog", "dialog"));
+    std::vector<EntityRef> dialogs; // TODO: look for better solution later
+    std::copy(game.Dialogs.begin(), game.Dialogs.end(), std::back_inserter(dialogs));
+    header.Append(DeclareEntities(dialogs, "Dialog", "dialog"));
     // Fonts
     header.Append(DeclareEntitiesAsEnum(game.Fonts, "FontType", "eFont"));
     // GUI


### PR DESCRIPTION
Related to #1008, but does not resolve it (apparently I forgot to create a separate ticket about dialog conversion tool).

agf2dlgasc - stands for "AGF to Dialog ASC" - parses Game.agf (xml) and generates a merged dialog script converting dialog scripts found in the game into standard ags script format.

*Input:* game project (*.agf).
*Output:* generated script body.

Usage: `agf2glvar Game.agf __DialogScripts.asc`

---

For the better context, Dialog Scripts are separate entities in AGS currently, written in their own dialect. Prior to AGS 2.72 they were also processed separately. Today they are converted into regular script and then compiled along with the rest of game scripts.

Here's an article on dialogs: https://github.com/adventuregamestudio/ags-manual/wiki/Settingupthegame#conversations
Scrolling down a bit you will see the syntax explanation.

Conversion is done by replacing special dialog commands with ags script commands, and dialogs themselves are wrapped in regular ags functions with names matching certain convention. This is how it's done in the Editor:
https://github.com/adventuregamestudio/ags/blob/ags3/Editor/AGS.Editor/Utils/DialogScriptConverter.cs

For this standalone tool I practically copied algorithm from DialogScriptConverter.cs. The output from the tool supposed to be nearly identical to the Editor, perhaps with minor identation differences.

---

For now this tool works by reading everything from Game.agf. I had thoughts about maybe making a separate utility for extracting dialog scripts into files, but then decided not to. Because of #1008 our project format may change in a way that I cannot predict right now. So it's perhaps best to keep working with AGF until #1008 will be actually in works and situation becomes more clear.

I did only basic tests so far, but there are numerous dialog commands which have to be all checked. In the end we of course should have automatic tests.
