### PR TITLE
assetmanager SetSearchPriority never set priority fix

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -84,7 +84,7 @@ AssetManager::AssetManager()
 
 void AssetManager::SetSearchPriority(AssetSearchPriority priority)
 {
-    _libsByPriority.Priority = kAssetPriorityDir;
+    _libsByPriority.Priority = priority;
     std::sort(_activeLibs.begin(), _activeLibs.end(), _libsByPriority);
 }
 


### PR DESCRIPTION
I noticed the priority parameter was never passed. 
`kAssetPriorityLib` is apparently only used when loading a template to fetch an icon and made no difference for me - kept working as it was before.