### PR TITLE
misleading set outline in fonts.cpp

### DIFF
--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -157,7 +157,7 @@ void set_font_outline(size_t font_number, int outline_type)
 {
     if (font_number >= fonts.size())
         return;
-    fonts[font_number].Info.Outline = FONT_OUTLINE_AUTO;
+    fonts[font_number].Info.Outline = outline_type;
 }
 
 int getfontheight(size_t fontNumber)


### PR DESCRIPTION
was not really setting outline type but only usage of this function is in the LucasFan-Font fix and it uses the value FONT_OUTLINE_AUTO as parameter so this commit doesn't actually change anything other than correctnes.