### PR TITLE
Functional open rooms

### DIFF
--- a/Editor/AGS.CScript.Compiler/Preprocessor.cs
+++ b/Editor/AGS.CScript.Compiler/Preprocessor.cs
@@ -40,7 +40,7 @@ namespace AGS.CScript.Compiler
 		public string Preprocess(string script, string scriptName)
 		{
 			StringBuilder output = new StringBuilder(script.Length);
-			output.AppendLine(Constants.NEW_SCRIPT_MARKER + scriptName + "\"");
+			output.AppendLine(Constants.NEW_SCRIPT_MARKER + scriptName.Replace(@"\", @"\\") + "\"");
 			StringReader reader = new StringReader(script);
 			string thisLine;
 			_scriptName = scriptName;

--- a/Editor/AGS.Editor.Tests/ScriptCompiler/PreprocessorTests.cs
+++ b/Editor/AGS.Editor.Tests/ScriptCompiler/PreprocessorTests.cs
@@ -345,5 +345,15 @@ Display(""test"");
             Assert.That(preprocessor.Results.Count, Is.EqualTo(1));
             Assert.That(preprocessor.Results[0].Code, Is.EqualTo(ErrorCode.EndIfWithoutIf));
         }
+
+        [TestCase("room2.asc", "room2.asc")]
+        [TestCase(@"Rooms\2\room2.asc", @"Rooms\\2\\room2.asc")]
+        public void FormatsScriptName(string scriptName, string expected)
+        {
+            IPreprocessor preprocessor = CompilerFactory.CreatePreprocessor(AGS.Types.Version.AGS_EDITOR_VERSION);
+            string res = preprocessor.Preprocess(string.Empty, scriptName);
+            AssertStringEqual(res, $@"""__NEWSCRIPTSTART_{expected}""
+");
+        }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -213,7 +213,7 @@ namespace AGS.Types
             int topEdgeY, int bottomEdgeY, int number, string description)
         {
             string xml = $@"
-            <Room>
+            <Room Version=""{Room.LATEST_XML_VERSION}"">
                 <MaskResolution>{maskResolution}</MaskResolution>
                 <BackgroundCount>{backgroundCount}</BackgroundCount>
                 <GameID>{gameId}</GameID>
@@ -255,6 +255,8 @@ namespace AGS.Types
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(xml);
             _room = new Room(doc.SelectSingleNode("Room"));
+
+            Assert.That(Room.LATEST_XML_VERSION, Is.EqualTo(doc.DocumentElement.Attributes["Version"].Value));
 
             Assert.That(_room.MaskResolution, Is.EqualTo(maskResolution));
             Assert.That(_room.BackgroundCount, Is.EqualTo(backgroundCount));
@@ -316,6 +318,7 @@ namespace AGS.Types
 
             XmlDocument doc = _room.ToXmlDocument();
 
+            Assert.That(doc.DocumentElement.Attributes["Version"].Value, Is.EqualTo(Room.LATEST_XML_VERSION));
             Assert.That(doc.SelectSingleNode("/Room/MaskResolution").InnerText, Is.EqualTo(maskResolution.ToString()));
             Assert.That(doc.SelectSingleNode("/Room/BackgroundCount").InnerText, Is.EqualTo(backgroundCount.ToString()));
             Assert.That(doc.SelectSingleNode("/Room/GameID").InnerText, Is.EqualTo(gameId.ToString()));

--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -170,6 +170,21 @@ namespace AGS.Types
             Assert.That(_room.BottomEdgeY, Is.EqualTo(bottomEdgeY));
         }
 
+        [TestCase(RoomAreaMaskType.Hotspots, Room.MAX_HOTSPOTS)]
+        [TestCase(RoomAreaMaskType.Regions, Room.MAX_REGIONS)]
+        [TestCase(RoomAreaMaskType.WalkableAreas, Room.MAX_WALKABLE_AREAS)]
+        [TestCase(RoomAreaMaskType.WalkBehinds, Room.MAX_WALK_BEHINDS)]
+        public void GetsMaskMaxColor(RoomAreaMaskType mask, int expected)
+        {
+            Assert.That(Room.GetMaskMaxColor(mask), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void GetsMaskMaxColorThrowsExceptionWithIllegalMask()
+        {
+            Assert.Throws<ArgumentException>(() => Room.GetMaskMaxColor(RoomAreaMaskType.None));
+        }
+
         [TestCase(1, RoomAreaMaskType.WalkBehinds, 1.00)]
         [TestCase(2, RoomAreaMaskType.WalkBehinds, 1.00)]
         [TestCase(1, RoomAreaMaskType.Hotspots, 1.00)]

--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -217,7 +217,17 @@ namespace AGS.Types
                 <Properties/>
                 <Number>{number}</Number>
                 <Description xml:space=""preserve"">{description}</Description>
-                <Interactions/>
+                <Interactions>
+                    <Event Index=""0"">room_LeftEdge</Event>
+                    <Event Index=""1"" />
+                    <Event Index=""2"" />
+                    <Event Index=""3"" />
+                    <Event Index=""4"" />
+                    <Event Index=""5"" />
+                    <Event Index=""6"" />
+                    <Event Index=""7"" />
+                    <Event Index=""8"" />
+                </Interactions>
                 <Messages/>
                 <Objects/>
                 <Hotspots/>
@@ -249,6 +259,16 @@ namespace AGS.Types
             Assert.That(_room.Number, Is.EqualTo(number));
             Assert.That(_room.Description, Is.EqualTo(description));
 
+            Assert.That(_room.Interactions.ScriptFunctionNames[0], Is.EqualTo("room_LeftEdge"));
+            Assert.That(_room.Interactions.ScriptFunctionNames[1], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[2], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[3], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[4], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[5], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[6], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[7], Is.Null);
+            Assert.That(_room.Interactions.ScriptFunctionNames[8], Is.Null);
+
             File.Delete("TestScript.asc");
         }
 
@@ -276,6 +296,9 @@ namespace AGS.Types
             _room.BottomEdgeY = bottomEdgeY;
             _room.Number = number;
             _room.Description = description;
+
+            _room.Interactions.ScriptFunctionNames[0] = "room_LeftEdge";
+
             XmlDocument doc = _room.ToXmlDocument();
 
             Assert.That(doc.SelectSingleNode("/Room/MaskResolution").InnerText, Is.EqualTo(maskResolution.ToString()));
@@ -295,6 +318,18 @@ namespace AGS.Types
             Assert.That(doc.SelectSingleNode("/Room/BottomEdgeY").InnerText, Is.EqualTo(bottomEdgeY.ToString()));
             Assert.That(doc.SelectSingleNode("/Room/Number").InnerText, Is.EqualTo(number.ToString()));
             Assert.That(doc.SelectSingleNode("/Room/Description").InnerText, Is.EqualTo(description.ToString()));
+
+            var interactions = doc.SelectSingleNode("/Room/Interactions").SelectNodes("Event");
+            
+            Assert.That(interactions[0].InnerText, Is.EqualTo("room_LeftEdge"));
+            Assert.That(interactions[1].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[2].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[3].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[4].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[5].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[6].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[7].InnerText, Is.EqualTo(""));
+            Assert.That(interactions[8].InnerText, Is.EqualTo(""));
         }
     }
 }

--- a/Editor/AGS.Editor.Tests/Types/RoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/RoomTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.IO;
 using System.Xml;
 
 namespace AGS.Types
@@ -224,6 +225,8 @@ namespace AGS.Types
                 <WalkBehinds/>
                 <Regions/>
             </Room>";
+            Directory.CreateDirectory(Path.Combine("Rooms", $"{number}"));
+            File.WriteAllText(Path.Combine("Rooms", $"{number}", $"room{number}.asc"), "Test placeholder");
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(xml);
             _room = new Room(doc.SelectSingleNode("Room"));
@@ -245,6 +248,8 @@ namespace AGS.Types
             Assert.That(_room.BottomEdgeY, Is.EqualTo(bottomEdgeY));
             Assert.That(_room.Number, Is.EqualTo(number));
             Assert.That(_room.Description, Is.EqualTo(description));
+
+            File.Delete("TestScript.asc");
         }
 
         [TestCase(1, 2, 1174750494, 320, 240, 5, 0, true, false, 1, RoomVolumeAdjustment.Normal, 1, 2, 3, 4, 2, "description1")]

--- a/Editor/AGS.Editor.Tests/Types/UnloadedRoomTests.cs
+++ b/Editor/AGS.Editor.Tests/Types/UnloadedRoomTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.IO;
 using System.Xml;
 
 namespace AGS.Types
@@ -55,7 +56,7 @@ namespace AGS.Types
         public void GetsUserFileName(int number)
         {
             _unloadedRoom.Number = number;
-            Assert.That(_unloadedRoom.UserFileName, Is.EqualTo($"room{number}.crm.user"));
+            Assert.That(_unloadedRoom.UserFileName, Is.EqualTo(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{number}", $"room{number}.crm.user")));
         }
 
         [TestCase(0)]
@@ -64,7 +65,7 @@ namespace AGS.Types
         public void GetsScriptFileName(int number)
         {
             _unloadedRoom.Number = number;
-            Assert.That(_unloadedRoom.ScriptFileName, Is.EqualTo($"room{number}.asc"));
+            Assert.That(_unloadedRoom.ScriptFileName, Is.EqualTo(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{number}", $"room{number}.asc")));
         }
 
         [TestCase("test1file", "test1", false)]

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -850,6 +850,7 @@ namespace AGS.Editor
                 _fileWatcher.Changed += new FileSystemEventHandler(_fileWatcher_Changed);
                 _fileWatcher.NotifyFilter = NotifyFilters.LastWrite;
                 _fileWatcher.EnableRaisingEvents = true;
+                _fileWatcher.IncludeSubdirectories = true;
             }
 
             CloseLockFile();

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -105,6 +105,11 @@ namespace AGS.Editor
          *
         */
         public const int    LATEST_XML_VERSION_INDEX = 3999900;
+        /// <summary>
+        /// XML version index on the release of AGS 4.0.0, this constant be used to determine
+        /// if upgrade of Rooms/Sprites/etc. to new format have been performed.
+        /// </summary>
+        public const int    AGS_4_0_0_XML_VERSION_INDEX = 30;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -109,7 +109,7 @@ namespace AGS.Editor
         /// XML version index on the release of AGS 4.0.0, this constant be used to determine
         /// if upgrade of Rooms/Sprites/etc. to new format have been performed.
         /// </summary>
-        public const int    AGS_4_0_0_XML_VERSION_INDEX = 30;
+        public const int    AGS_4_0_0_XML_VERSION_INDEX = 3999900;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -158,7 +158,6 @@ namespace AGS.Editor
         private IEngineCommunication _engineComms = new NamedPipesEngineCommunication();
         private DebugController _debugger;
 		private bool _applicationStarted = false;
-        private FileSystemWatcher _fileWatcher = null;
         private FileStream _lockFile = null;
 
         private static readonly IDictionary<ScriptAPIVersion, string> _scriptAPIVersionMacros =
@@ -743,13 +742,6 @@ namespace AGS.Editor
 
         public void LoadGameFile(string fileName)
         {
-            if (_fileWatcher != null)
-            {
-                _fileWatcher.EnableRaisingEvents = false;
-                _fileWatcher.Dispose();
-                _fileWatcher = null;
-            }
-
             if (File.Exists(LOCK_FILE_NAME))
             {
                 VerifyGameNotAlreadyOpenInAnotherEditor();
@@ -847,16 +839,6 @@ namespace AGS.Editor
 			{
 				_engineComms.ResetWithCurrentPath();
 			}
-            
-            if (System.Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                // file system watcher only works on NT
-                _fileWatcher = new FileSystemWatcher(newGame.DirectoryPath);
-                _fileWatcher.Changed += new FileSystemEventHandler(_fileWatcher_Changed);
-                _fileWatcher.NotifyFilter = NotifyFilters.LastWrite;
-                _fileWatcher.EnableRaisingEvents = true;
-                _fileWatcher.IncludeSubdirectories = true;
-            }
 
             CloseLockFile();
 
@@ -878,11 +860,6 @@ namespace AGS.Editor
                 _lockFile.Close();
                 _lockFile = null;
             }
-        }
-
-        private void _fileWatcher_Changed(object sender, FileSystemEventArgs e)
-        {
-            Factory.Events.OnFileChangedInGameFolder(e.Name);
         }
 
 		private void DefineMacrosAccordingToGameSettings(IPreprocessor preprocessor)

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -89,6 +89,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
       <HintPath>..\..\Solutions\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
     </Reference>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -362,6 +362,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
+    <Compile Include="Utils\DirectoryInfoExtensions.cs" />
     <Compile Include="Utils\FileWatchHelper.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\Validation.cs" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -362,6 +362,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
+    <Compile Include="Utils\FileWatchHelper.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\Validation.cs" />
     <EmbeddedResource Include="GUI\frmMain.resx">

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -363,7 +363,7 @@
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
     <Compile Include="Utils\DirectoryInfoExtensions.cs" />
-    <Compile Include="Utils\FileWatchHelper.cs" />
+    <Compile Include="Utils\FileWatcher.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\Validation.cs" />
     <EmbeddedResource Include="GUI\frmMain.resx">

--- a/Editor/AGS.Editor/Components/BaseComponentWithScripts.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithScripts.cs
@@ -55,7 +55,7 @@ namespace AGS.Editor.Components
 
         protected void UpdateScriptWindowTitle(ScriptEditor editor)
         {
-            string newTitle = editor.Script.FileName + (editor.IsModified ? " *" : "");
+            string newTitle = editor.Script.FileNameWithoutPath + (editor.IsModified ? " *" : "");
             ContentDocument document = GetDocument(editor);            
             if (document != null && document.Name != newTitle)
             {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1950,11 +1950,17 @@ namespace AGS.Editor.Components
             if (Directory.Exists(UnloadedRoom.ROOM_DIRECTORY))
                 return; // Upgrade already completed
 
+            BusyDialog.Show("Converting rooms from .crm to open format.", new BusyDialog.ProcessingHandler(ConvertAllRoomsFromCrmToOpenFormat), null);
+        }
+
+        private object ConvertAllRoomsFromCrmToOpenFormat(object paramenter)
+        {
             Task.WaitAll(
                 _agsEditor.CurrentGame.Rooms
                 .Cast<UnloadedRoom>()
                 .SelectMany(r => ConvertRoomFromCrmToOpenFormat(r))
                 .ToArray());
+            return null;
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1657,6 +1657,7 @@ namespace AGS.Editor.Components
                 newBmp.Palette = palette;
 
                 newBmp.SetGlobalPaletteFromPalette();
+                // TODO Implement remap_background from AGS.Native
             }
 
             if (background >= _backgroundCache.Count)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -829,7 +829,9 @@ namespace AGS.Editor.Components
                 ((ScriptEditor)_roomScriptEditors[newRoom.Number].Control).UpdateScriptObjectWithLatestTextInWindow();
             }
 
-            _loadedRoom = _nativeProxy.LoadRoom(newRoom);
+            XmlDocument xml = new XmlDocument();
+            xml.LoadXml(File.ReadAllText(newRoom.DataFileName));
+            _loadedRoom = new Room(xml.FirstChild);
             LoadImageCache();
 
             // TODO: group these in some UpdateRoomToNewVersion method

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2094,17 +2094,11 @@ namespace AGS.Editor.Components
                     .Select(i => $"{UnloadedRoom.ROOM_DIRECTORY}Backup-{i}")
                     .First(dir => !Directory.Exists(dir));
 
-                foreach (var room in rooms)
-                {
-                    if (UnloadedRoom.DoRoomDirectoryExist(room.Number))
-                    {
-                        DirectoryInfo backupDir = new DirectoryInfo(Path.Combine(backupRootDir, room.Number.ToString()));
-                        DirectoryInfo di = new DirectoryInfo(room.Directory);
-                        di.CopyAll(backupDir);
-                        // Don't crash the upgrade if a file can't be deleted
-                        di.DeleteWithoutException(recursive: true);
-                    }
-                }
+                DirectoryInfo roomDir = new DirectoryInfo(UnloadedRoom.ROOM_DIRECTORY);
+                DirectoryInfo backupDir = new DirectoryInfo(backupRootDir);
+                roomDir.CopyAll(backupDir);
+                // Don't crash the upgrade if a file can't be deleted
+                roomDir.DeleteWithoutException(recursive: true);
             }
 
             // Now upgrade

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1861,11 +1861,13 @@ namespace AGS.Editor.Components
                 }
             }
 
+            bool imageNotFound = false;
+
             if (!_backgroundCache.Any())
             {
                 _backgroundCache.Add(new Bitmap(_loadedRoom.Width, _loadedRoom.Height));
                 _loadedRoom.BackgroundCount = 1;
-                _loadedRoom.Modified = true;
+                imageNotFound = true;
                 _guiController.ShowMessage(
                     $"Could not to find any background images at \"{_loadedRoom.Directory}\", an empty " +
                     $"default image will be used instead.",
@@ -1890,13 +1892,15 @@ namespace AGS.Editor.Components
                     double scale = _loadedRoom.GetMaskScale(mask);
                     _maskCache[mask] = new Bitmap((int)(_loadedRoom.Width * scale), (int)(_loadedRoom.Height * scale), PixelFormat.Format8bppIndexed);
                     _maskCache[mask].SetPaletteFromGlobalPalette();
-                    _loadedRoom.Modified = true;
+                    imageNotFound = true;
                     _guiController.ShowMessage(
                         $"Could not to find mask at \"{_loadedRoom.GetMaskFileName(mask)}\", an empty " +
                         $"default image will be used instead.",
                         MessageBoxIcon.Warning);
                 }
             }
+
+            _loadedRoom.Modified = imageNotFound;
         }
 
         private XmlNode LoadData(UnloadedRoom room)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1880,7 +1880,12 @@ namespace AGS.Editor.Components
                     $"default image will be used instead.",
                     MessageBoxIcon.Warning);
             }
-
+            else if (_loadedRoom.BackgroundCount != _backgroundCache.Count)
+            {
+                _loadedRoom.BackgroundCount = _backgroundCache.Count;
+                imageNotFound = true;
+            }
+            
             _loadedRoom.ColorDepth = _backgroundCache[0].GetColorDepth();
 
             foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -468,7 +468,6 @@ namespace AGS.Editor.Components
         private void CreateNewRoom(int roomNumber, RoomTemplate template)
         {
             UnloadedRoom newRoom = new UnloadedRoom(roomNumber);
-            Directory.CreateDirectory(newRoom.Directory);
 
             if (!PromptForAndDeleteAnyExistingRoomFile(newRoom.FileName))
             {
@@ -1947,7 +1946,6 @@ namespace AGS.Editor.Components
         private IEnumerable<Task> ConvertRoomFromCrmToOpenFormat(UnloadedRoom unloadedRoom)
         {
             Room room = _nativeProxy.LoadRoom(unloadedRoom);
-            Directory.CreateDirectory(room.Directory);
 
             for (int i = 0; i < room.BackgroundCount; i++)
                 yield return SaveAndDisposeBitmapAsync(_nativeProxy.GetBitmapForBackground(room, i), room.GetBackgroundFileName(i));

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1698,29 +1698,26 @@ namespace AGS.Editor.Components
             {
                 Bitmap mask8bpp = _maskCache[maskType];
                 ColorPalette paletteBackup = mask8bpp.Palette;
+                ColorPalette paletteDrawing = mask8bpp.Palette;
 
                 // Color not selected mask areas to gray
                 if (_grayOutMasks)
                 {
-                    ColorPalette palette = mask8bpp.Palette;
-
                     for (int i = 1; i < 256; i++) // Skip i == 0 because no area should be transparent
                     {
                         const int intensity = 6; // Force the gray scale lighter so that it's easier to see
                         int gray = i < Room.MAX_HOTSPOTS && i > 0 ? ((Room.MAX_HOTSPOTS - i) % 30) * intensity : 0;
-                        palette.Entries[i] = Color.FromArgb(gray, gray, gray);
+                        paletteDrawing.Entries[i] = Color.FromArgb(gray, gray, gray);
                     }
 
                     // Highlight the currently selected area colour
                     if (selectedArea > 0)
                     {
                         // if a bright colour, use it, else, draw in red
-                        palette.Entries[selectedArea] = selectedArea < 15 && selectedArea != 7 && selectedArea != 8
+                        paletteDrawing.Entries[selectedArea] = selectedArea < 15 && selectedArea != 7 && selectedArea != 8
                             ? _agsEditor.CurrentGame.Palette[selectedArea].Colour
                             : Color.FromArgb(60, 0, 0);
                     }
-
-                    mask8bpp.Palette = palette;
                 }
 
                 // Prepare alpha component
@@ -1729,6 +1726,10 @@ namespace AGS.Editor.Components
                 ImageAttributes attributes = new ImageAttributes();
                 attributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 
+                // Force that palette index 0 (No Area) is transparent
+                paletteDrawing.Entries[0] = Color.FromArgb(0, 255, 255, 255);
+
+                mask8bpp.Palette = paletteDrawing;
                 g.DrawImage(mask8bpp, drawingArea, 0, 0, mask8bpp.Width, mask8bpp.Height, GraphicsUnit.Pixel, attributes);
                 mask8bpp.Palette = paletteBackup;
             }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1916,7 +1916,6 @@ namespace AGS.Editor.Components
         private void RefreshData()
         {
             SerializeUtils.DeserializeFromXML(_loadedRoom, LoadData(_loadedRoom));
-            _loadedRoom.Modified = true;
             _guiController.RefreshPropertyGrid();
         }
 
@@ -1926,7 +1925,6 @@ namespace AGS.Editor.Components
         {
             _backgroundCache[i]?.Dispose();
             _backgroundCache[i] = LoadBackground(i);
-            _loadedRoom.Modified = true;
             ((RoomSettingsEditor)_roomSettings.Control).InvalidateDrawingBuffer();
         }
 
@@ -1936,7 +1934,6 @@ namespace AGS.Editor.Components
         {
             _maskCache[mask]?.Dispose();
             _maskCache[mask] = LoadMask(mask);
-            _loadedRoom.Modified = true;
             ((RoomSettingsEditor)_roomSettings.Control).InvalidateDrawingBuffer();
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -987,10 +987,14 @@ namespace AGS.Editor.Components
                 DockData previousDockData = GetPreviousDockData();
                 UnloadCurrentRoomAndGreyOutTree();
 
-				if (!File.Exists(newRoom.FileName))
-				{
-					_guiController.ShowMessage("The file '" + newRoom.FileName + "' was not found. Unable to open this room.", MessageBoxIcon.Warning);
-				}
+                if (!Directory.Exists(newRoom.Directory))
+                {
+                    _guiController.ShowMessage($"The room directory \"{newRoom.Directory}\" could not be found. Unable to open this room.", MessageBoxIcon.Error);
+                }
+                else if (!File.Exists(newRoom.DataFileName))
+                {
+                    _guiController.ShowMessage($"The room data file \"{newRoom.DataFileName} could not be found. Unable to open this room.", MessageBoxIcon.Error);
+                }
 				else
 				{
 					CompileMessages errors = new CompileMessages();

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -70,7 +70,7 @@ namespace AGS.Editor.Components
             _agsEditor.PreSaveGame += new AGSEditor.PreSaveGameHandler(AGSEditor_PreSaveGame);
             _agsEditor.ProcessAllGameTexts += new AGSEditor.ProcessAllGameTextsHandler(AGSEditor_ProcessAllGameTexts);
 			_agsEditor.PreDeleteSprite += new AGSEditor.PreDeleteSpriteHandler(AGSEditor_PreDeleteSprite);
-            Factory.Events.GameLoad += ConvertAllRoomsFromCrmToOpenFormat;
+            Factory.Events.GamePostLoad += ConvertAllRoomsFromCrmToOpenFormat;
             _modifiedChangedHandler = new Room.RoomModifiedChangedHandler(_loadedRoom_RoomModifiedChanged);
             RePopulateTreeView();
         }
@@ -2039,7 +2039,7 @@ namespace AGS.Editor.Components
         /// worthwhile to refactor this hindrance if we're getting a standalone room CLI tool in the future that can
         /// do the same job.
         /// </remarks>
-        private void ConvertAllRoomsFromCrmToOpenFormat(XmlNode root)
+        private void ConvertAllRoomsFromCrmToOpenFormat()
         {
             if (Directory.Exists(UnloadedRoom.ROOM_DIRECTORY))
                 return; // Upgrade already completed

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1707,15 +1707,8 @@ namespace AGS.Editor.Components
                 throw new InvalidOperationException("No room is currently loaded");
             }
 
-            Bitmap bmp = _maskCache[maskType];
-            double scale = _loadedRoom.GetMaskScale(maskType);
-            int xScaled = (int)(x * scale);
-            int yScaled = (int)(y * scale);
-
-            // Colors on mask areas is set from game palette so do a reverse lookup to find the index
-            return xScaled >= 0 && xScaled < bmp.Width && yScaled >= 0 && yScaled < bmp.Height
-                ? _agsEditor.CurrentGame.Palette.FirstOrDefault(p => p.Colour == bmp.GetPixel(xScaled, yScaled))?.Index ?? 0
-                : 0;
+            Bitmap mask = _maskCache[maskType];
+            return mask.GetRawData()[(y * mask.Width) + x];
         }
 
         void IRoomController.DrawRoomBackground(Graphics g, int x, int y, int backgroundNumber, int scaleFactor)

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1934,14 +1934,6 @@ namespace AGS.Editor.Components
         {
             using (Bitmap mask = _nativeProxy.ExportAreaMask(room, type))
             {
-                // Global palette has transparency set on index 0 which is no area, probably to make drawing easier? This transparency is
-                // ignored when saving the file as .bmp, but now when we save to .png for some reason, so we have to remove the transparency
-                // manually.
-                ColorPalette palette = mask.Palette;
-                Color noArea = palette.Entries[0];
-                palette.Entries[0] = Color.FromArgb(noArea.R, noArea.G, noArea.B);
-                mask.Palette = palette;
-
                 mask.Save(room.GetMaskFileName(type), ImageFormat.Png);
             }
         });

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1644,7 +1644,7 @@ namespace AGS.Editor.Components
                 throw new ArgumentNullException(nameof(bmp));
             }
 
-            Bitmap newBmp = (Bitmap)bmp.Clone();
+            Bitmap newBmp = new Bitmap(bmp);
             _loadedRoom.Width = newBmp.Width;
             _loadedRoom.Height = newBmp.Height;
             _loadedRoom.ColorDepth = newBmp.GetColorDepth();

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -819,6 +819,8 @@ namespace AGS.Editor.Components
 
 		private void UnloadCurrentRoom()
 		{
+            _fileWatchers.Enabled = false;
+
 			if (_roomSettings != null)
 			{
 				((RoomSettingsEditor)_roomSettings.Control).SaveRoom -= new RoomSettingsEditor.SaveRoomHandler(RoomEditor_SaveRoom);

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -37,7 +37,7 @@ namespace AGS.Editor.Components
 
         private readonly List<Bitmap> _backgroundCache = new List<Bitmap>(Room.MAX_BACKGROUNDS);
         private readonly Dictionary<RoomAreaMaskType, Bitmap> _maskCache = new Dictionary<RoomAreaMaskType, Bitmap>(Enum.GetValues(typeof(RoomAreaMaskType)).Length);
-        private readonly FileWatchHelpers _fileWatchers = new FileWatchHelpers();
+        private readonly FileWatcherCollection _fileWatchers = new FileWatcherCollection();
 
         public event PreSaveRoomHandler PreSaveRoom;
         private ContentDocument _roomSettings;
@@ -2053,15 +2053,15 @@ namespace AGS.Editor.Components
             }
         }
 
-        private IEnumerable<FileWatchHelper> LoadFileWatchers()
+        private IEnumerable<FileWatcher> LoadFileWatchers()
         {
-            yield return new FileWatchHelper(_loadedRoom.DataFileName, this, RefreshData);
+            yield return new FileWatcher(_loadedRoom.DataFileName, this, RefreshData);
 
             for (int i = 0; i < Room.MAX_BACKGROUNDS; i++)
             {
                 // Have to make a copy otherwise i will be equal to Room.MAX_BACKGROUNDS when loadFile callback is executed
                 int roomNumber = i; 
-                yield return new FileWatchHelper(_loadedRoom.GetBackgroundFileName(roomNumber), this, () => RefreshBackground(roomNumber))
+                yield return new FileWatcher(_loadedRoom.GetBackgroundFileName(roomNumber), this, () => RefreshBackground(roomNumber))
                 {
                     Enabled = roomNumber < _loadedRoom.BackgroundCount
                 };
@@ -2069,7 +2069,7 @@ namespace AGS.Editor.Components
 
             foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)).Cast<RoomAreaMaskType>().Where(m => m != RoomAreaMaskType.None))
             {
-                yield return new FileWatchHelper(_loadedRoom.GetMaskFileName(mask), this, () => RefreshMask(mask));
+                yield return new FileWatcher(_loadedRoom.GetMaskFileName(mask), this, () => RefreshMask(mask));
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -697,7 +697,7 @@ namespace AGS.Editor.Components
                 scriptEditor.Room = _loadedRoom;
             }
             _roomScriptEditors[selectedRoom.Number] = new ContentDocument(scriptEditor,
-                selectedRoom.Script.FileName, this, SCRIPT_ICON);
+                selectedRoom.Script.FileNameWithoutPath, this, SCRIPT_ICON);
             _roomScriptEditors[selectedRoom.Number].ToolbarCommands = scriptEditor.ToolbarIcons;
             _roomScriptEditors[selectedRoom.Number].MainMenu = scriptEditor.ExtraMenu; 
         }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1911,7 +1911,7 @@ namespace AGS.Editor.Components
         private IEnumerable<Task> ConvertRoomFromCrmToOpenFormat(UnloadedRoom unloadedRoom)
         {
             Room room = _nativeProxy.LoadRoom(unloadedRoom);
-            Directory.CreateDirectory(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}"));
+            Directory.CreateDirectory(room.Directory);
 
             for (int i = 0; i < room.BackgroundCount; i++)
                 yield return SaveAndDisposeBitmapAsync(_nativeProxy.GetBitmapForBackground(room, i), room.GetBackgroundFileName(i));
@@ -1921,9 +1921,13 @@ namespace AGS.Editor.Components
             foreach (RoomAreaMaskType type in Enum.GetValues(typeof(RoomAreaMaskType)).Cast<RoomAreaMaskType>().Where(m => m != RoomAreaMaskType.None))
                 yield return SaveAndDisposeBitmapAsync(_nativeProxy.ExportAreaMask(room, type), room.GetMaskFileName(type));
 
-            File.Move($"room{room.Number}.asc", room.ScriptFileName);
-            if (File.Exists(room.UserFileName))
-                File.Move($"room{room.Number}.crm.user", room.UserFileName);
+            string oldScriptFileName = $"room{room.Number}.asc";
+            if (File.Exists(oldScriptFileName))
+                File.Move(oldScriptFileName, room.ScriptFileName);
+
+            string oldUserFileName = $"room{room.Number}.crm.user";
+            if (File.Exists(oldUserFileName))
+                File.Move(oldUserFileName, room.UserFileName);
         }
 
         private Task SaveXmlAsync(XmlDocument document, string filename) => Task.Run(() =>

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1857,7 +1857,7 @@ namespace AGS.Editor.Components
                         _nativeProxy.ImportBackground(
                             _loadedRoom, i, _backgroundCache[i], _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false);
                     else
-                        _nativeProxy.DeleteBackground(_loadedRoom, i);
+                        File.Delete(_loadedRoom.GetBackgroundFileName(i));
                 }
 
                 foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -228,11 +228,6 @@ namespace AGS.Editor.Components
             {
                 filesToDelete.Add(roomToDelete.FileName);
             }
-            else
-            {
-                _guiController.ShowMessage("The room file was not found and could not be deleted.", MessageBoxIcon.Warning);
-            }
-
             if (File.Exists(roomToDelete.ScriptFileName))
             {
                 filesToDelete.Add(roomToDelete.ScriptFileName);
@@ -241,6 +236,22 @@ namespace AGS.Editor.Components
             {
                 filesToDelete.Add(roomToDelete.UserFileName);
             }
+            if (File.Exists(roomToDelete.DataFileName))
+            {
+                filesToDelete.Add(roomToDelete.DataFileName);
+            }
+
+            var backgroundFiles = Enumerable.Range(0, Room.MAX_BACKGROUNDS)
+                .Select(i => roomToDelete.GetBackgroundFileName(i))
+                .Where(f => File.Exists(f));
+            filesToDelete.AddRange(backgroundFiles);
+
+            var maskFiles = Enum.GetValues(typeof(RoomAreaMaskType))
+                .Cast<RoomAreaMaskType>()
+                .Where(m => m != RoomAreaMaskType.None)
+                .Select(m => roomToDelete.GetMaskFileName(m))
+                .Where(f => File.Exists(f));
+            filesToDelete.AddRange(maskFiles);
 
             try
             {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1801,7 +1801,7 @@ namespace AGS.Editor.Components
 
             for (int i = 0; i < _loadedRoom.BackgroundCount; i++)
             {
-                _backgroundCache.Add(_nativeProxy.GetBitmapForBackground(_loadedRoom, i));
+                _backgroundCache.Add(new Bitmap(_loadedRoom.GetBackgroundFileName(i)));
             }
             _loadedRoom.ColorDepth = _backgroundCache[0].GetColorDepth();
 
@@ -1919,7 +1919,7 @@ namespace AGS.Editor.Components
         {
             using (Bitmap background = _nativeProxy.GetBitmapForBackground(room, i))
             {
-                background.Save(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}", $"background{i}.png"), ImageFormat.Png);
+                background.Save(room.GetBackgroundFileName(i), ImageFormat.Png);
             }
         });
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1803,7 +1803,10 @@ namespace AGS.Editor.Components
 
             for (int i = 0; i < _loadedRoom.BackgroundCount; i++)
             {
-                _backgroundCache.Add(new Bitmap(_loadedRoom.GetBackgroundFileName(i)));
+                using (MemoryStream ms = new MemoryStream(File.ReadAllBytes(_loadedRoom.GetBackgroundFileName(i))))
+                {
+                    _backgroundCache.Add(new Bitmap(ms));
+                }
             }
             _loadedRoom.ColorDepth = _backgroundCache[0].GetColorDepth();
 
@@ -1814,7 +1817,10 @@ namespace AGS.Editor.Components
                     continue;
                 }
 
-                _maskCache[mask] = new Bitmap(_loadedRoom.GetMaskFileName(mask));
+                using (MemoryStream ms = new MemoryStream(File.ReadAllBytes(_loadedRoom.GetMaskFileName(mask))))
+                {
+                    _maskCache[mask] = new Bitmap(ms);
+                }
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1814,7 +1814,7 @@ namespace AGS.Editor.Components
                     continue;
                 }
 
-                _maskCache[mask] = _nativeProxy.ExportAreaMask(_loadedRoom, mask);
+                _maskCache[mask] = new Bitmap(_loadedRoom.GetMaskFileName(mask));
             }
         }
 
@@ -1937,7 +1937,7 @@ namespace AGS.Editor.Components
                 palette.Entries[0] = Color.FromArgb(noArea.R, noArea.G, noArea.B);
                 mask.Palette = palette;
 
-                mask.Save(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}", $"{type.ToString().ToLower()}.png"), ImageFormat.Png);
+                mask.Save(room.GetMaskFileName(type), ImageFormat.Png);
             }
         });
         #endregion

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2081,8 +2081,18 @@ namespace AGS.Editor.Components
         /// </remarks>
         private void ConvertAllRoomsFromCrmToOpenFormat()
         {
-            if (Directory.Exists(UnloadedRoom.ROOM_DIRECTORY))
+            if (_agsEditor.CurrentGame.SavedXmlVersionIndex >= AGSEditor.AGS_4_0_0_XML_VERSION_INDEX)
                 return; // Upgrade already completed
+
+            // Room directory might already exist for whatever reason so rename it to a backup location
+            if (Directory.Exists(UnloadedRoom.ROOM_DIRECTORY)) 
+            {
+                string backupDir = Enumerable
+                    .Range(0, int.MaxValue)
+                    .Select(i => $"{UnloadedRoom.ROOM_DIRECTORY}Backup-{i}")
+                    .First(dir => !Directory.Exists(dir));
+                Directory.Move(UnloadedRoom.ROOM_DIRECTORY, backupDir);
+            }
 
             IList<IRoom> rooms = _agsEditor.CurrentGame.Rooms;
             object progressLock = new object();

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -836,7 +836,7 @@ namespace AGS.Editor.Components
                 ((ScriptEditor)_roomScriptEditors[newRoom.Number].Control).UpdateScriptObjectWithLatestTextInWindow();
             }
 
-            _loadedRoom = new Room(LoadData(newRoom));
+            _loadedRoom = new Room(LoadData(newRoom)) { Script = newRoom.Script };
             LoadImageCache();
             _fileWatchers.Clear();
             _fileWatchers.AddRange(LoadFileWatchers());

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1855,7 +1855,6 @@ namespace AGS.Editor.Components
             }
         }
 
-        // TODO Replace with bitmap saving to disk with C# when room is open format
         private void SaveImages()
         {
             lock (_loadedRoom)
@@ -1863,8 +1862,7 @@ namespace AGS.Editor.Components
                 for (int i = 0; i < Room.MAX_BACKGROUNDS; i++)
                 {
                     if (i < _backgroundCache.Count)
-                        _nativeProxy.ImportBackground(
-                            _loadedRoom, i, _backgroundCache[i], _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false);
+                        _backgroundCache[i].Save(_loadedRoom.GetBackgroundFileName(i), ImageFormat.Png);
                     else
                         File.Delete(_loadedRoom.GetBackgroundFileName(i));
                 }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1898,9 +1898,6 @@ namespace AGS.Editor.Components
             if (Directory.Exists(UnloadedRoom.ROOM_DIRECTORY))
                 return; // Upgrade already completed
 
-            Directory.CreateDirectory(UnloadedRoom.ROOM_DIRECTORY);
-            IRoomController roomController = this;
-
             Task.WaitAll(
                 _agsEditor.CurrentGame.Rooms
                 .Cast<UnloadedRoom>()

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1179,8 +1179,8 @@ namespace AGS.Editor.Components
                 }
 
 				oldRoom.Number = numberRequested;
-                XElement newRoomXml = XElement.Load(tempNewRoom.DataFileName);
-                newRoomXml.SetElementValue("Number", numberRequested);
+                XDocument newRoomXml = XDocument.Load(tempNewRoom.DataFileName);
+                newRoomXml.Element("Room").SetElementValue("Number", numberRequested);
                 newRoomXml.Save(tempNewRoom.DataFileName);
 
 				LoadDifferentRoom(oldRoom);

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2101,7 +2101,7 @@ namespace AGS.Editor.Components
         /// worthwhile to refactor this hindrance if we're getting a standalone room CLI tool in the future that can
         /// do the same job.
         /// </remarks>
-        private void ConvertAllRoomsFromCrmToOpenFormat()
+        private async void ConvertAllRoomsFromCrmToOpenFormat()
         {
             if (_agsEditor.CurrentGame.SavedXmlVersionIndex >= AGSEditor.AGS_4_0_0_XML_VERSION_INDEX)
                 return; // Upgrade already completed
@@ -2136,11 +2136,11 @@ namespace AGS.Editor.Components
                     progressForm.SetProgress(progress, $"{progressText} {progress} of {rooms.Count} rooms converted.");
                 };
 
-                Task.WaitAll(
-                    rooms
+                var roomsConvertingTasks = rooms
                     .Cast<UnloadedRoom>()
                     .SelectMany(r => ConvertRoomFromCrmToOpenFormat(r, progressReporter))
-                    .ToArray());
+                    .ToArray();
+                await Task.WhenAll(roomsConvertingTasks);
             }
         }
 

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1873,7 +1873,7 @@ namespace AGS.Editor.Components
                     if (mask == RoomAreaMaskType.None)
                         continue;
 
-                    _nativeProxy.SetAreaMask(_loadedRoom, mask, _maskCache[mask]);
+                    _maskCache[mask].Save(_loadedRoom.GetMaskFileName(mask), ImageFormat.Png);
                 }
             }
         }

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -468,6 +468,8 @@ namespace AGS.Editor.Components
         private void CreateNewRoom(int roomNumber, RoomTemplate template)
         {
             UnloadedRoom newRoom = new UnloadedRoom(roomNumber);
+            Directory.CreateDirectory(newRoom.Directory);
+
             if (!PromptForAndDeleteAnyExistingRoomFile(newRoom.FileName))
             {
                 return;
@@ -488,6 +490,9 @@ namespace AGS.Editor.Components
 				{
 					_nativeProxy.ExtractRoomTemplateFiles(template.FileName, newRoom.Number);
 				}
+
+                Task.WaitAll(ConvertRoomFromCrmToOpenFormat(newRoom).ToArray());
+
                 string newNodeID = AddSingleItem(newRoom);
                 _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
                 _guiController.ProjectTree.SelectNode(this, newNodeID);

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1889,7 +1889,7 @@ namespace AGS.Editor.Components
             Directory.CreateDirectory(UnloadedRoom.ROOM_DIRECTORY);
             IRoomController roomController = this;
 
-            foreach (Room room in _agsEditor.CurrentGame.Rooms.Cast<UnloadedRoom>().Select(r => Factory.NativeProxy.LoadRoom(r)))
+            foreach (Room room in _agsEditor.CurrentGame.Rooms.Cast<UnloadedRoom>().Select(r => _nativeProxy.LoadRoom(r)))
             {
                 Directory.CreateDirectory(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}"));
 
@@ -1917,7 +1917,7 @@ namespace AGS.Editor.Components
 
         private Task UpgradeBackgroundFromCrmToOpenFormatAsync(Room room, int i) => Task.Run(() =>
         {
-            using (Bitmap background = Factory.NativeProxy.GetBitmapForBackground(room, i))
+            using (Bitmap background = _nativeProxy.GetBitmapForBackground(room, i))
             {
                 background.Save(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}", $"background{i}.png"), ImageFormat.Png);
             }
@@ -1925,7 +1925,7 @@ namespace AGS.Editor.Components
 
         private Task UpgradeMaskFromCrmToOpenFormatAsync(Room room, RoomAreaMaskType type) => Task.Run(() =>
         {
-            using (Bitmap mask = Factory.NativeProxy.ExportAreaMask(room, type))
+            using (Bitmap mask = _nativeProxy.ExportAreaMask(room, type))
             {
                 // Global palette has transparency set on index 0 which is no area, probably to make drawing easier? This transparency is
                 // ignored when saving the file as .bmp, but now when we save to .png for some reason, so we have to remove the transparency

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1546,7 +1546,7 @@ namespace AGS.Editor.Components
             }
 
             SaveImages();
-            _nativeProxy.SaveRoom(_loadedRoom);
+            _loadedRoom.ToXmlDocument().Save(_loadedRoom.DataFileName);
             _loadedRoom.Modified = false;
         }
 
@@ -1914,7 +1914,7 @@ namespace AGS.Editor.Components
 
         private Task UpgradeDataFromCrmToOpenFormatAsync(Room room) => Task.Run(() =>
         {
-            room.ToXmlDocument().Save(Path.Combine(UnloadedRoom.ROOM_DIRECTORY, $"{room.Number}", "data.xml"));
+            room.ToXmlDocument().Save(room.DataFileName);
         });
 
         private Task UpgradeBackgroundFromCrmToOpenFormatAsync(Room room, int i) => Task.Run(() =>

--- a/Editor/AGS.Editor/EditorEvents.cs
+++ b/Editor/AGS.Editor/EditorEvents.cs
@@ -27,8 +27,6 @@ namespace AGS.Editor
         public event GetAboutDialogTextHandler GetAboutDialogText;
         public delegate void ShowSpriteManagerHandler(int spriteNumber, ref bool successful);
         public event ShowSpriteManagerHandler ShowSpriteManager;
-        public delegate void FileChangedInGameFolderHandler(string fileName);
-        public event FileChangedInGameFolderHandler FileChangedInGameFolder;
 
         public void OnGameSettingsChanged()
         {
@@ -110,14 +108,6 @@ namespace AGS.Editor
                 ShowSpriteManager(spriteNumber, ref successful);
             }
             return successful;
-        }
-
-        public void OnFileChangedInGameFolder(string fileName)
-        {
-            if (FileChangedInGameFolder != null)
-            {
-                FileChangedInGameFolder(fileName);
-            }
         }
 
         private static EditorEvents _instance;

--- a/Editor/AGS.Editor/GUI/Progress.cs
+++ b/Editor/AGS.Editor/GUI/Progress.cs
@@ -19,9 +19,21 @@ namespace AGS.Editor
             lblTask.Text = text;
         }
 
+        public void SetProgress(int value, string text)
+        {
+            SetProgressValue(value);
+            SetProgressText(text);
+        }
+
         public void SetProgressValue(int value)
         {
             progressBar.Value = Math.Min(value, progressBar.Maximum);
+        }
+
+        public void SetProgressText(string text)
+        {
+            lblTask.Text = text;
+            lblTask.Refresh();
         }
 
         private void Progress_Activated(object sender, EventArgs e)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -276,11 +276,6 @@ namespace AGS.Editor
             _native.ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
         }
 
-        public void DeleteBackground(Room room, int backgroundNumber)
-        {
-            _native.DeleteBackground(room, backgroundNumber);
-        }
-
         public Bitmap GetBitmapForBackground(Room room, int backgroundNumber)
         {
             return _native.GetBitmapForBackground(room, backgroundNumber);

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -217,6 +217,11 @@ namespace AGS.Editor
             _editAddressBar.CurrentNode = node;
             return true;
         }
+
+        /// <summary>
+        /// Invalidate the surface of the drawing control and causes the control to be redrawn
+        /// </summary>
+        public void InvalidateDrawingBuffer() => bufferedPanel1.Invalidate();
         
         private void SelectOldNode(IAddressNode currentNode)
         {

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -58,7 +58,7 @@ namespace AGS.Editor
 
         public ScriptEditor(Script scriptToEdit, AGSEditor agsEditor, Action<Script> showMatchingScript)
         {
-            _fileWatcher = new FileWatchHelper(scriptToEdit.FileName, OnFileChangedExternally);
+            _fileWatcher = new FileWatchHelper(scriptToEdit.FileName, scriptToEdit, OnFileChangedExternally);
             _showMatchingScript = showMatchingScript;
             _agsEditor = agsEditor;
             Init(scriptToEdit);
@@ -420,7 +420,6 @@ namespace AGS.Editor
             {
                 _fileWatcher.Enabled = false;
                 _script.SaveToDisk();
-                _fileWatcher.ChangedAt = _script.LastSavedAt;
                 _fileWatcher.Enabled = true;
 
                 scintilla.SetSavePoint();

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -38,7 +38,7 @@ namespace AGS.Editor
         private const string CONTEXT_MENU_GO_TO_SPRITE = "CtxGoToSprite";
         private const string CONTEXT_MENU_TOGGLE_BREAKPOINT = "CtxToggleBreakpoint";
 
-        private readonly FileWatchHelper _fileWatcher;
+        private readonly FileWatcher _fileWatcher;
         private Script _script;
         private Room _room;
         private int _roomNumber;
@@ -58,7 +58,7 @@ namespace AGS.Editor
 
         public ScriptEditor(Script scriptToEdit, AGSEditor agsEditor, Action<Script> showMatchingScript)
         {
-            _fileWatcher = new FileWatchHelper(scriptToEdit.FileName, scriptToEdit, OnFileChangedExternally);
+            _fileWatcher = new FileWatcher(scriptToEdit.FileName, scriptToEdit, OnFileChangedExternally);
             _showMatchingScript = showMatchingScript;
             _agsEditor = agsEditor;
             Init(scriptToEdit);

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -119,7 +119,7 @@ namespace AGS.Editor
 
             foreach (PaletteEntry global in Factory.AGSEditor.CurrentGame.Palette)
             {
-                palette.Entries[global.Index] = Color.FromArgb(global.Index == 0 ? 0 : 255, global.Colour);
+                palette.Entries[global.Index] = Color.FromArgb(255, global.Colour);
             }
 
             bmp.Palette = palette; // Get Bitmap.Palette is deep copy so we need to set it back

--- a/Editor/AGS.Editor/Utils/DirectoryInfoExtensions.cs
+++ b/Editor/AGS.Editor/Utils/DirectoryInfoExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace AGS.Editor
@@ -50,16 +50,15 @@ namespace AGS.Editor
             if (recursive)
             {
                 foreach (DirectoryInfo di in source.GetDirectories())
-                {
-                    try
-                    {
-                        di.DeleteWithoutException(recursive);
-                        di.Delete(recursive);
-                    }
-                    catch (Exception)
-                    {
-                    }
-                }
+                    di.DeleteWithoutException(recursive);
+            }
+
+            try
+            {
+                source.Delete(recursive);
+            }
+            catch (Exception)
+            {
             }
         }
     }

--- a/Editor/AGS.Editor/Utils/DirectoryInfoExtensions.cs
+++ b/Editor/AGS.Editor/Utils/DirectoryInfoExtensions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+
+namespace AGS.Editor
+{
+    public static class DirectoryInfoExtensions
+    {
+        /// <summary>
+        /// Copies everything from the source directory to the target directory.
+        /// </summary>
+        /// <param name="source">The source directory.</param>
+        /// <param name="target">The target directory.</param>
+        public static void CopyAll(this DirectoryInfo source, DirectoryInfo target)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
+            Directory.CreateDirectory(target.FullName);
+
+            foreach (FileInfo fi in source.GetFiles())
+                fi.CopyTo(Path.Combine(target.FullName, fi.Name), false);
+
+            foreach (DirectoryInfo di in source.GetDirectories())
+            {
+                DirectoryInfo nextDi = target.CreateSubdirectory(di.Name);
+                di.CopyAll(nextDi);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a directory and its contents
+        /// </summary>
+        /// <param name="source">The source directory.</param>
+        /// <param name="recursive">If true delete every file and sub directory.</param>
+        public static void DeleteWithoutException(this DirectoryInfo source, bool recursive = true)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            foreach (FileInfo fi in source.GetFiles())
+            {
+                try
+                {
+                    fi.Delete();
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            if (recursive)
+            {
+                foreach (DirectoryInfo di in source.GetDirectories())
+                {
+                    try
+                    {
+                        di.DeleteWithoutException(recursive);
+                        di.Delete(recursive);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/FileWatchHelper.cs
+++ b/Editor/AGS.Editor/Utils/FileWatchHelper.cs
@@ -1,0 +1,190 @@
+﻿using AGS.Editor.Preferences;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// Helper class to watch a set of related files, like the room files.
+    /// </summary>
+    public class FileWatchHelpers : KeyedCollection<string, FileWatchHelper>, IDisposable
+    {
+        public void Dispose()
+        {
+            foreach (FileWatchHelper item in Items)
+                item.Dispose();
+        }
+
+        public void AddRange(IEnumerable<FileWatchHelper> items)
+        {
+            foreach (FileWatchHelper item in items)
+                Add(item);
+        }
+
+        /// <summary>
+        /// Temporarily disables the file watchers while performing an action, like saving files
+        /// from the AGS editor.
+        /// </summary>
+        public void TemporarilyDisable(Action doWhenDisabled)
+        {
+            Dictionary<string, bool> backup = Items.ToDictionary(i => i.FileName, i => i.Enabled);
+
+            foreach (FileWatchHelper item in Items)
+                item.Enabled = false;
+
+            doWhenDisabled();
+
+            foreach (FileWatchHelper item in Items)
+                item.Enabled = backup[item.FileName];
+        }
+
+        protected override string GetKeyForItem(FileWatchHelper item) => item.FileName;
+
+        protected override void ClearItems()
+        {
+            Dispose();
+            base.ClearItems();
+        }
+
+        protected override void SetItem(int i, FileWatchHelper item)
+        {
+            this[i].Dispose();
+            base.SetItem(i, item);
+        }
+
+        protected override void RemoveItem(int i)
+        {
+            this[i].Dispose();
+            base.RemoveItem(i);
+        }
+    }
+
+    /// <summary>
+    /// Helper utility to watch specific files.
+    /// </summary>
+    public class FileWatchHelper : IDisposable
+    {
+        private delegate void LoadFileOnGUIThread();
+
+        private readonly Action _loadFile;
+        private readonly GUIController _guiController;
+        private readonly IAppSettings _settings;
+        private readonly EditorEvents _events;
+
+        private bool _changed;
+
+        public FileWatchHelper(string fileName, Action loadFile)
+        {
+            FileName = fileName;
+            _loadFile = loadFile;
+
+            _guiController = Factory.GUIController;
+            _guiController.OnMainWindowActivated += OnMainWindowActivated;
+
+            _settings = Factory.AGSEditor.Settings;
+
+            _events = Factory.Events;
+            _events.FileChangedInGameFolder += OnFileChanged;
+        }
+
+        public string FileName { get; }
+        public DateTime ChangedAt { get; set; }
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Use this flag to suppress the file watcher when saving is handled from AGS
+        /// </summary>
+        //public bool SavingInternally { get; set; } = false;
+
+        public void Dispose()
+        {
+            _guiController.OnMainWindowActivated -= OnMainWindowActivated;
+            _events.FileChangedInGameFolder -= OnFileChanged;
+        }
+
+
+        /// <summary>
+        /// If editor window is not the active window we wait to update the UI until
+        /// this event has fired
+        /// </summary>
+        /// <remarks>
+        /// Runs on the UI thread so we can use this to run our code updating UI
+        /// </remarks>
+        private void OnMainWindowActivated(object sender, EventArgs e)
+        {
+            if (_changed)
+            {
+                LoadFile();
+                _changed = false;
+            }
+        }
+
+        /// <summary>
+        /// This is the method used to control file change events triggered by the file watcher.
+        /// </summary>
+        /// <remarks>
+        /// Any actual code updating UI cannot be invoked here, becuse the file watcher and the UI
+        /// fires on different thread which is illegal and will cause crashes, or file streams
+        /// returning empty file reads for some reason. Make sure any code loading data or
+        /// updating UI loads on the GUI thread.
+        /// </remarks>
+        private void OnFileChanged(string fileName)
+        {
+            if (FileName.Equals(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                DateTime now = DateTime.Now;
+
+                if (Enabled)
+                {
+                    if (now.Subtract(ChangedAt).TotalSeconds > 2 &&
+                        !Utilities.IsMonoRunning() &&
+                        Utilities.IsThisApplicationCurrentlyActive())
+                    {
+                        //On Mono can't use the Win API to check if application is in focus.
+                        //Hopefully the prompt will be triggered by its second usage,
+                        //when the main window is activated.
+                        _guiController.Invoke((LoadFileOnGUIThread)LoadFile); // GuiController.Invoke runs on UI thread
+                    }
+                    else
+                    {
+                        _changed = true;
+                    }
+                }
+
+                ChangedAt = now;
+            }
+        }
+
+        private void LoadFile()
+        {
+            if (ShouldLoad())
+            {
+                _loadFile();
+            }
+        }
+
+        private bool ShouldLoad()
+        {
+            switch (_settings.ReloadScriptOnExternalChange)
+            {
+                case ReloadScriptOnExternalChange.Prompt:
+                    string question = $"The file '{FileName}' has been modified externally. Do you want to reload it?";
+                    if (_guiController.ShowQuestion(question, MessageBoxIcon.Question) != DialogResult.Yes)
+                    {
+                        break;
+                    }
+                    return true;
+                case ReloadScriptOnExternalChange.Always:
+                    return true;
+                case ReloadScriptOnExternalChange.Never:
+                default:
+                    break;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/FileWatcher.cs
+++ b/Editor/AGS.Editor/Utils/FileWatcher.cs
@@ -78,6 +78,7 @@ namespace AGS.Editor
         private readonly IAppSettings _settings;
 
         private bool _changed;
+        private bool _changedProcessing;
 
         public FileWatcher(string fileName, ISaveable saveable, Action loadFile)
         {
@@ -127,10 +128,11 @@ namespace AGS.Editor
         /// </remarks>
         private void OnMainWindowActivated(object sender, EventArgs e)
         {
-            if (_changed)
+            if (_changed && !_changedProcessing)
             {
+                _changedProcessing = true;
                 LoadFile();
-                _changed = false;
+                _changed = _changedProcessing = false;
             }
         }
 

--- a/Editor/AGS.Editor/Utils/FileWatcher.cs
+++ b/Editor/AGS.Editor/Utils/FileWatcher.cs
@@ -1,4 +1,4 @@
-﻿using AGS.Editor.Preferences;
+using AGS.Editor.Preferences;
 using AGS.Types.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -157,6 +157,8 @@ namespace AGS.Editor
                 else
                 {
                     _changed = true;
+                    // File changes are made in batches so disable file watcher to avoid spammed Changed events
+                    _fileWatcher.EnableRaisingEvents = false;
                 }
             }
         }
@@ -167,6 +169,8 @@ namespace AGS.Editor
             {
                 _loadFile();
             }
+
+            _fileWatcher.EnableRaisingEvents = true;
         }
 
         private bool ShouldLoad()

--- a/Editor/AGS.Editor/Utils/FileWatcher.cs
+++ b/Editor/AGS.Editor/Utils/FileWatcher.cs
@@ -14,6 +14,18 @@ namespace AGS.Editor
     /// </summary>
     public class FileWatcherCollection : KeyedCollection<string, FileWatcher>, IDisposable
     {
+        /// <summary>
+        /// Sets all <see cref="FileWatcher.Enabled"/> for this collection.
+        /// </summary>
+        public bool Enabled
+        {
+            set
+            {
+                foreach (FileWatcher item in Items)
+                    item.Enabled = value;
+            }
+        }
+
         public void Dispose()
         {
             foreach (FileWatcher item in Items)

--- a/Editor/AGS.Editor/Utils/FileWatcher.cs
+++ b/Editor/AGS.Editor/Utils/FileWatcher.cs
@@ -12,17 +12,17 @@ namespace AGS.Editor
     /// <summary>
     /// Helper class to watch a set of related files, like the room files.
     /// </summary>
-    public class FileWatchHelpers : KeyedCollection<string, FileWatchHelper>, IDisposable
+    public class FileWatcherCollection : KeyedCollection<string, FileWatcher>, IDisposable
     {
         public void Dispose()
         {
-            foreach (FileWatchHelper item in Items)
+            foreach (FileWatcher item in Items)
                 item.Dispose();
         }
 
-        public void AddRange(IEnumerable<FileWatchHelper> items)
+        public void AddRange(IEnumerable<FileWatcher> items)
         {
-            foreach (FileWatchHelper item in items)
+            foreach (FileWatcher item in items)
                 Add(item);
         }
 
@@ -34,16 +34,16 @@ namespace AGS.Editor
         {
             Dictionary<string, bool> backup = Items.ToDictionary(i => i.FileName, i => i.Enabled);
 
-            foreach (FileWatchHelper item in Items)
+            foreach (FileWatcher item in Items)
                 item.Enabled = false;
 
             doWhenDisabled();
 
-            foreach (FileWatchHelper item in Items)
+            foreach (FileWatcher item in Items)
                 item.Enabled = backup[item.FileName];
         }
 
-        protected override string GetKeyForItem(FileWatchHelper item) => item.FileName;
+        protected override string GetKeyForItem(FileWatcher item) => item.FileName;
 
         protected override void ClearItems()
         {
@@ -51,7 +51,7 @@ namespace AGS.Editor
             base.ClearItems();
         }
 
-        protected override void SetItem(int i, FileWatchHelper item)
+        protected override void SetItem(int i, FileWatcher item)
         {
             this[i].Dispose();
             base.SetItem(i, item);
@@ -67,7 +67,7 @@ namespace AGS.Editor
     /// <summary>
     /// Helper utility to watch specific files.
     /// </summary>
-    public class FileWatchHelper : IDisposable
+    public class FileWatcher : IDisposable
     {
         private delegate void LoadFileOnGUIThread();
 
@@ -79,7 +79,7 @@ namespace AGS.Editor
 
         private bool _changed;
 
-        public FileWatchHelper(string fileName, ISaveable saveable, Action loadFile)
+        public FileWatcher(string fileName, ISaveable saveable, Action loadFile)
         {
             AGSEditor agsEditor = Factory.AGSEditor;
 

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -74,7 +74,6 @@ extern void GameUpdated(Game ^game, bool forceUpdate);
 extern void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
 extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
 extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
-extern void DeleteBackground(Room ^room, int backgroundNumber);
 extern void FixRoomMasks(Room ^room);
 extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
@@ -499,11 +498,6 @@ namespace AGS
 		void NativeMethods::ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette)
 		{
 			::ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
-		}
-
-		void NativeMethods::DeleteBackground(Room ^room, int backgroundNumber)
-		{
-			::DeleteBackground(room, backgroundNumber);
 		}
 
 		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -70,7 +70,6 @@ namespace AGS
 			void SaveRoomFile(Room ^roomToSave);
             void SaveDefaultRoomFile(Room ^roomToSave);
 			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
-			void DeleteBackground(Room ^room, int backgroundNumber);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1803,23 +1803,6 @@ Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal,
 	return tempsprite;
 }
 
-void DeleteBackground(Room ^room, int backgroundNumber) 
-{
-	RoomStruct *theRoom = (RoomStruct*)(void*)room->_roomStructPtr;
-
- if (theRoom->BgFrames[backgroundNumber].Graphic)
- {
-     theRoom->BgFrames[backgroundNumber].Graphic.reset();
-     theRoom->BgFrameCount--;
-
-     for (size_t i = backgroundNumber; i < theRoom->BgFrameCount; i++)
-     {
-         theRoom->BgFrames[i] = theRoom->BgFrames[i + 1];
-         theRoom->BgFrames[i].IsPaletteShared = theRoom->BgFrames[i + 1].IsPaletteShared;
-     }
- }
-}
-
 void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap ^bmp, bool useExactPalette, bool sharePalette) 
 {
     RGB oldpale[256];

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1878,6 +1878,16 @@ void ImportBackground(Room ^room, int backgroundNumber, System::Drawing::Bitmap 
 
 void set_area_mask(void* roomptr, int maskType, SysBitmap^ bmp)
 {
+    // Palette entry 0 alpha value is hardcoded to 0 originally, probably because it's
+    // convenient for rendering area 0 as invisible? This was taken out when converting
+    // the room to open format because it created issues with saving/loading to disk
+    // in certain image formats (.png). Just in case we set the alpha back to 0 when
+    // setting the mask back into crm on the off chance it might be used for something
+    // internally somewhere
+    ColorPalette^ palette = bmp->Palette;
+    palette->Entries[0] = Color::FromArgb(255, palette->Entries[0]);
+    bmp->Palette = palette;
+
     RGB oldpale[256];
     RoomStruct* room = (RoomStruct*)roomptr;
     AGSBitmap* oldMask = room->GetMask((RoomAreaMask)maskType);
@@ -1907,7 +1917,17 @@ void set_area_mask(void* roomptr, int maskType, SysBitmap^ bmp)
 SysBitmap ^export_area_mask(void *roomptr, int maskType)
 {
     AGSBitmap *mask = ((RoomStruct*)roomptr)->GetMask((RoomAreaMask)maskType);
-    return ConvertBlockToBitmap(mask, false);
+    SysBitmap^ managedMask = ConvertBlockToBitmap(mask, false);
+
+    // Palette entry 0 alpha value is hardcoded to 0, probably because it's convenient
+    // for rendering area 0 as invisible? However it creates issues when exporting 8-bit
+    // image with transparency to different image formats (tested with .png). To make things
+    // easier we take the alpha value out.
+    ColorPalette^ palette = managedMask->Palette;
+    palette->Entries[0] = Color::FromArgb(255, palette->Entries[0]);
+    managedMask->Palette = palette;
+
+    return managedMask;
 }
 
 void set_rgb_mask_from_alpha_channel(Common::Bitmap *image)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Interfaces\IProjectTreeItem.cs" />
     <Compile Include="Interfaces\IRoom.cs" />
     <Compile Include="Interfaces\IRoomController.cs" />
+    <Compile Include="Interfaces\ISaveable.cs" />
     <Compile Include="Interfaces\IScriptEditorControl.cs" />
     <Compile Include="Interfaces\ISourceControlIntegration.cs" />
     <Compile Include="Interfaces\ISpriteFolder.cs" />

--- a/Editor/AGS.Types/Interfaces/IRoom.cs
+++ b/Editor/AGS.Types/Interfaces/IRoom.cs
@@ -12,6 +12,7 @@ namespace AGS.Types
 		bool StateSaving { get; }
 		string ScriptFileName { get; }
 		Script Script { get; }
+        string Directory { get; }
         string UserFileName { get; }
         void LoadScript();
         void UnloadScript();

--- a/Editor/AGS.Types/Interfaces/IRoom.cs
+++ b/Editor/AGS.Types/Interfaces/IRoom.cs
@@ -13,8 +13,12 @@ namespace AGS.Types
 		string ScriptFileName { get; }
 		Script Script { get; }
         string Directory { get; }
+        string DataFileName { get; }
         string UserFileName { get; }
         void LoadScript();
         void UnloadScript();
-	}
+        string GetBackgroundFileName(int background);
+        string GetMaskFileName(RoomAreaMaskType mask);
+
+    }
 }

--- a/Editor/AGS.Types/Interfaces/ISaveable.cs
+++ b/Editor/AGS.Types/Interfaces/ISaveable.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace AGS.Types.Interfaces
+{
+    public interface ISaveable
+    {
+        bool IsBeingSaved { get; }
+        DateTime LastSavedAt { get; }
+    }
+}

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -25,6 +25,7 @@ namespace AGS.Types
         public const string EVENT_SUFFIX_ROOM_LOAD = "Load";
 
         public const string PROPERTY_NAME_MASKRESOLUTION = "MaskResolution";
+        public const string LATEST_XML_VERSION = "1";
 
         private static InteractionSchema _interactionSchema;
 
@@ -437,7 +438,9 @@ namespace AGS.Types
 
         public override void ToXml(XmlTextWriter writer)
         {
-            SerializeUtils.SerializeToXML(this, writer, false);
+            writer.WriteStartElement(GetType().Name);
+            writer.WriteAttributeString("Version", LATEST_XML_VERSION);
+            SerializeUtils.SerializePropertiesToXML(this, writer);
             Interactions.ToXml(writer);
             SerializeUtils.SerializeToXML(writer, "Messages", Messages);
             SerializeUtils.SerializeToXML(writer, "Objects", Objects);

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -421,7 +421,7 @@ namespace AGS.Types
             if (background < 0 && background >= MAX_BACKGROUNDS)
                 throw new ArgumentException($"Must be positive number, but less than {MAX_BACKGROUNDS}", nameof(background));
 
-            return Path.Combine(ROOM_DIRECTORY, $"{Number}", $"background{background}.png");
+            return Path.Combine(Directory, $"background{background}.png");
         }
 
         public string GetMaskFileName(RoomAreaMaskType mask)
@@ -429,7 +429,7 @@ namespace AGS.Types
             if (mask == RoomAreaMaskType.None)
                 throw new ArgumentException($"Argument cannot be {RoomAreaMaskType.None}, it does not have a file.", nameof(mask));
 
-            return Path.Combine(ROOM_DIRECTORY, $"{Number}", $"{mask.ToString().ToLower()}.png");
+            return Path.Combine(Directory, $"{mask.ToString().ToLower()}.png");
         }
 
         void IChangeNotification.ItemModified()

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -416,22 +416,6 @@ namespace AGS.Types
             }
         }
 
-        public string GetBackgroundFileName(int background)
-        {
-            if (background < 0 && background >= MAX_BACKGROUNDS)
-                throw new ArgumentException($"Must be positive number, but less than {MAX_BACKGROUNDS}", nameof(background));
-
-            return Path.Combine(Directory, $"background{background}.png");
-        }
-
-        public string GetMaskFileName(RoomAreaMaskType mask)
-        {
-            if (mask == RoomAreaMaskType.None)
-                throw new ArgumentException($"Argument cannot be {RoomAreaMaskType.None}, it does not have a file.", nameof(mask));
-
-            return Path.Combine(Directory, $"{mask.ToString().ToLower()}.png");
-        }
-
         void IChangeNotification.ItemModified()
 		{
 			this.Modified = true;

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -423,7 +423,7 @@ namespace AGS.Types
         {
             SerializeUtils.SerializeToXML(this, writer, false);
             Interactions.ToXml(writer);
-            SerializeUtils.SerializeToXML(writer, "RoomMessages", Messages);
+            SerializeUtils.SerializeToXML(writer, "Messages", Messages);
             SerializeUtils.SerializeToXML(writer, "Objects", Objects);
             SerializeUtils.SerializeToXML(writer, "Hotspots", Hotspots);
             SerializeUtils.SerializeToXML(writer, "WalkableAreas", WalkableAreas);

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -121,6 +121,7 @@ namespace AGS.Types
             _regions.AddRange(GetXmlChildren(node, "/Room/Regions", MAX_REGIONS).Select((xml, i) => new RoomRegion(xml) { ID = i }));
         }
 
+        [AGSNoSerialize]
         [Browsable(false)]
         public bool Modified
         {

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -424,6 +424,14 @@ namespace AGS.Types
             return Path.Combine(ROOM_DIRECTORY, $"{Number}", $"background{background}.png");
         }
 
+        public string GetMaskFileName(RoomAreaMaskType mask)
+        {
+            if (mask == RoomAreaMaskType.None)
+                throw new ArgumentException($"Argument cannot be {RoomAreaMaskType.None}, it does not have a file.", nameof(mask));
+
+            return Path.Combine(ROOM_DIRECTORY, $"{Number}", $"{mask.ToString().ToLower()}.png");
+        }
+
         void IChangeNotification.ItemModified()
 		{
 			this.Modified = true;

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -112,6 +112,7 @@ namespace AGS.Types
 
         public Room(XmlNode node) : base(node)
         {
+            LoadScript();
             _messages.AddRange(GetXmlChildren(node, "/Room/Messages", int.MaxValue).Select((xml, i) => new RoomMessage(i, xml)));
             _objects.AddRange(GetXmlChildren(node, "/Room/Objects", MAX_OBJECTS).Select((xml, i) => new RoomObject(this, xml) { ID = i }));
             _hotspots.AddRange(GetXmlChildren(node, "/Room/Hotspots", MAX_HOTSPOTS).Select((xml, i) => new RoomHotspot(this, xml) { ID = i }));

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -112,7 +112,6 @@ namespace AGS.Types
 
         public Room(XmlNode node) : base(node)
         {
-            LoadScript();
             _interactions.FromXml(node);
             _messages.AddRange(GetXmlChildren(node, "/Room/Messages", int.MaxValue).Select((xml, i) => new RoomMessage(i, xml)));
             _objects.AddRange(GetXmlChildren(node, "/Room/Objects", MAX_OBJECTS).Select((xml, i) => new RoomObject(this, xml) { ID = i }));

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -403,6 +403,19 @@ namespace AGS.Types
             get { return _interactions; }
         }
 
+        public static int GetMaskMaxColor(RoomAreaMaskType mask)
+        {
+            switch (mask)
+            {
+                case RoomAreaMaskType.WalkBehinds: return MAX_WALK_BEHINDS;
+                case RoomAreaMaskType.Hotspots: return MAX_HOTSPOTS;
+                case RoomAreaMaskType.WalkableAreas: return MAX_WALKABLE_AREAS;
+                case RoomAreaMaskType.Regions: return MAX_REGIONS;
+                default:
+                    throw new ArgumentException($"Illegal mask type, mask {mask} doesn't have colors");
+            }
+        }
+
         public double GetMaskScale(RoomAreaMaskType mask)
         {
             switch (mask)

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -113,6 +113,7 @@ namespace AGS.Types
         public Room(XmlNode node) : base(node)
         {
             LoadScript();
+            _interactions.FromXml(node);
             _messages.AddRange(GetXmlChildren(node, "/Room/Messages", int.MaxValue).Select((xml, i) => new RoomMessage(i, xml)));
             _objects.AddRange(GetXmlChildren(node, "/Room/Objects", MAX_OBJECTS).Select((xml, i) => new RoomObject(this, xml) { ID = i }));
             _hotspots.AddRange(GetXmlChildren(node, "/Room/Hotspots", MAX_HOTSPOTS).Select((xml, i) => new RoomHotspot(this, xml) { ID = i }));

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -412,6 +413,14 @@ namespace AGS.Types
                 default:
                     throw new ArgumentException($"Illegal mask type, mask {mask} cannot be scaled.");
             }
+        }
+
+        public string GetBackgroundFileName(int background)
+        {
+            if (background < 0 && background >= MAX_BACKGROUNDS)
+                throw new ArgumentException($"Must be positive number, but less than {MAX_BACKGROUNDS}", nameof(background));
+
+            return Path.Combine(ROOM_DIRECTORY, $"{Number}", $"background{background}.png");
         }
 
         void IChangeNotification.ItemModified()

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -223,6 +223,11 @@ namespace AGS.Types
 
         #endregion
 
-        public void ToXml(XmlTextWriter writer) => SerializeUtils.SerializeToXML(this, writer);
+        public void ToXml(XmlTextWriter writer)
+        {
+            SerializeUtils.SerializeToXML(this, writer, false);
+            _interactions.ToXml(writer);
+            writer.WriteEndElement();
+        }
     }
 }

--- a/Editor/AGS.Types/Script.cs
+++ b/Editor/AGS.Types/Script.cs
@@ -79,6 +79,9 @@ namespace AGS.Types
             set { _fileName = value; }
         }
 
+        [Browsable(false)]
+        public string FileNameWithoutPath => Path.GetFileName(FileName);
+
         [Category("Module information")]
         [Description("Friendly name of this script")]
         public string Name

--- a/Editor/AGS.Types/Script.cs
+++ b/Editor/AGS.Types/Script.cs
@@ -10,7 +10,7 @@ using AGS.Types.Interfaces;
 namespace AGS.Types
 {
     [DefaultProperty("Name")]
-    public class Script : IScript, IToXml
+    public class Script : IScript, ISaveable, IToXml
     {
         public const string GLOBAL_SCRIPT_FILE_NAME = "GlobalScript.asc";
         public const string GLOBAL_HEADER_FILE_NAME = "GlobalScript.ash";

--- a/Editor/AGS.Types/SerializeUtils.cs
+++ b/Editor/AGS.Types/SerializeUtils.cs
@@ -339,11 +339,13 @@ namespace AGS.Types
         public static XmlDocument ToXmlDocument(this IToXml toXml)
         {
             XmlDocument res = new XmlDocument();
-            StringWriter rawXml = new StringWriter();
-            XmlTextWriter xmlWriter = new XmlTextWriter(rawXml);
-            toXml.ToXml(xmlWriter);
-            res.LoadXml(rawXml.ToString());
-            xmlWriter.Close();
+            using (StringWriter rawXml = new StringWriter())
+            using (XmlTextWriter xmlWriter = new XmlTextWriter(rawXml))
+            {
+                toXml.ToXml(xmlWriter);
+                res.LoadXml(rawXml.ToString());
+            }
+            res.InsertBefore(res.CreateXmlDeclaration("1.0", Encoding.Default.WebName, standalone: null), res.DocumentElement);
             return res;
         }
     }

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -36,6 +36,7 @@ namespace AGS.Types
         public UnloadedRoom(int roomNumber)
         {
             _number = roomNumber;
+            System.IO.Directory.CreateDirectory(Directory);
         }
 
 		[DisplayName(PROPERTY_NAME_NUMBER)]

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -24,6 +24,12 @@ namespace AGS.Types
         protected string _description;
         protected Script _script = null;
 
+        public static bool DoRoomDirectoryExist(int roomNumber)
+        {
+            string roomDirectory = Path.Combine(ROOM_DIRECTORY, $"{roomNumber}");
+            return System.IO.Directory.Exists(roomDirectory);
+        }
+
 		public static bool DoRoomFilesExist(int roomNumber)
 		{
             string roomDirectory = Path.Combine(ROOM_DIRECTORY, $"{roomNumber}");

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -74,13 +74,13 @@ namespace AGS.Types
         [Description("The filename containing this room data")]
         [Category("Design")]
         [ReadOnly(true)]
-        public string DataFileName => Path.Combine(ROOM_DIRECTORY, $"{Number}", "data.xml");
+        public string DataFileName => Path.Combine(Directory, "data.xml");
 
         [AGSNoSerialize]
         [Browsable(false)]
         public string UserFileName
         {
-            get { return Path.Combine(ROOM_DIRECTORY, $"{Number}", string.Format(ROOM_USER_FILE_NAME_FORMAT, _number)); }
+            get { return Path.Combine(Directory, string.Format(ROOM_USER_FILE_NAME_FORMAT, _number)); }
         }
 
 		[Description("Whether the state of the room is saved when the player leaves the room and comes back")]
@@ -94,8 +94,15 @@ namespace AGS.Types
 		[Browsable(false)]
         public string ScriptFileName
         {
-            get { return Path.Combine(ROOM_DIRECTORY, $"{Number}", string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, _number)); }
+            get { return Path.Combine(Directory, string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, _number)); }
         }
+
+        [AGSNoSerialize]
+        [Description("The directory of the room files")]
+        [Category("Design")]
+        [Browsable(true)]
+        [ReadOnly(true)]
+        public string Directory => Path.Combine(ROOM_DIRECTORY, $"{Number}");
 
         [AGSNoSerialize]
         [Browsable(false)]

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -17,6 +17,7 @@ namespace AGS.Types
 		public const int HIGHEST_ROOM_NUMBER_ALLOWED = 999;
 		public const string PROPERTY_NAME_DESCRIPTION = "Description";
 		public const string PROPERTY_NAME_NUMBER = "Number";
+        public const string ROOM_DIRECTORY = "Rooms";
 
         protected int _number;
         protected string _description;
@@ -73,7 +74,7 @@ namespace AGS.Types
         [Browsable(false)]
         public string UserFileName
         {
-            get { return string.Format(ROOM_USER_FILE_NAME_FORMAT, _number); }
+            get { return Path.Combine(ROOM_DIRECTORY, $"{Number}", string.Format(ROOM_USER_FILE_NAME_FORMAT, _number)); }
         }
 
 		[Description("Whether the state of the room is saved when the player leaves the room and comes back")]
@@ -87,7 +88,7 @@ namespace AGS.Types
 		[Browsable(false)]
         public string ScriptFileName
         {
-            get { return string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, _number); }
+            get { return Path.Combine(ROOM_DIRECTORY, $"{Number}", string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, _number)); }
         }
 
         [AGSNoSerialize]

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -71,6 +71,12 @@ namespace AGS.Types
         }
 
         [AGSNoSerialize]
+        [Description("The filename containing this room data")]
+        [Category("Design")]
+        [ReadOnly(true)]
+        public string DataFileName => Path.Combine(ROOM_DIRECTORY, $"{Number}", "data.xml");
+
+        [AGSNoSerialize]
         [Browsable(false)]
         public string UserFileName
         {

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -12,6 +12,7 @@ namespace AGS.Types
         private const string ROOM_FILE_NAME_FORMAT = "room{0}.crm";
         private const string ROOM_SCRIPT_FILE_NAME_FORMAT = "room{0}.asc";
         private const string ROOM_USER_FILE_NAME_FORMAT = "room{0}.crm.user";
+        private const string ROOM_DATA_FILE_NAME_FORMAT = "data.xml";
 
 		public const int NON_STATE_SAVING_INDEX = 300;
 		public const int HIGHEST_ROOM_NUMBER_ALLOWED = 999;
@@ -25,8 +26,10 @@ namespace AGS.Types
 
 		public static bool DoRoomFilesExist(int roomNumber)
 		{
-			if (File.Exists(string.Format(ROOM_FILE_NAME_FORMAT, roomNumber)) ||
-				File.Exists(string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, roomNumber)))
+            string roomDirectory = Path.Combine(ROOM_DIRECTORY, $"{roomNumber}");
+
+			if (File.Exists(Path.Combine(ROOM_DIRECTORY, ROOM_DATA_FILE_NAME_FORMAT)) ||
+                File.Exists(Path.Combine(roomDirectory, string.Format(ROOM_SCRIPT_FILE_NAME_FORMAT, roomNumber))))
 			{
 				return true;
 			}
@@ -75,7 +78,7 @@ namespace AGS.Types
         [Description("The filename containing this room data")]
         [Category("Design")]
         [ReadOnly(true)]
-        public string DataFileName => Path.Combine(Directory, "data.xml");
+        public string DataFileName => Path.Combine(Directory, ROOM_DATA_FILE_NAME_FORMAT);
 
         [AGSNoSerialize]
         [Browsable(false)]

--- a/Editor/AGS.Types/UnloadedRoom.cs
+++ b/Editor/AGS.Types/UnloadedRoom.cs
@@ -116,6 +116,22 @@ namespace AGS.Types
             set { _script = value; }
         }
 
+        public string GetBackgroundFileName(int background)
+        {
+            if (background < 0 && background >= Room.MAX_BACKGROUNDS)
+                throw new ArgumentException($"Must be positive number, but less than {Room.MAX_BACKGROUNDS}", nameof(background));
+
+            return Path.Combine(Directory, $"background{background}.png");
+        }
+
+        public string GetMaskFileName(RoomAreaMaskType mask)
+        {
+            if (mask == RoomAreaMaskType.None)
+                throw new ArgumentException($"Argument cannot be {RoomAreaMaskType.None}, it does not have a file.", nameof(mask));
+
+            return Path.Combine(Directory, $"{mask.ToString().ToLower()}.png");
+        }
+
         public void LoadScript()
         {
 			if (_script == null)


### PR DESCRIPTION
Reference #469

I still need to cleanup some code and do other improvements, but the most important mechanics are in place so I'm creating a draft PR so people can begin testing.

![image](https://user-images.githubusercontent.com/1510803/118556780-8f140a80-b764-11eb-8180-43e05222807b.png)

- When game is loaded into the editor an upgrade process will trigger. The code is handled from the editor but I imagine it'll be replaced with a CLI tool for processing rooms or something similar in the future. The upgrade process will extract room data and images and save them to disk under a directory `Rooms/{room-number}/`
- Room editor is refactored to read data directly from the new assets in the `Rooms/` directory. .crm files are mostly ignored until compile time.
- .crm files will now be generated from the data found in the `Rooms/` directory when rooms are saved/compiled, so with this PR these files should be safe to .gitignore.
- File watcher code from script editor has been refactored into a utility class with reusable file watching helper code. This means that the script editor file watching should also be tested probably.
- Fixed some minor bugs with room xml serialization
- Removed transparency from mask palette color 0 (eraser area) to not be transparent. It ruined the image when exporting and reimporting masks as .png files. I was never able to figure out exactly what's happening but most software I tested with gets quirky when 8-bit pngs have transparency. A minor rant about my hair pulling experience here https://github.com/adventuregamestudio/ags/issues/1113#issuecomment-794506794

PS: Remember to take backup of your game before upgrading