### PR TITLE
workaround invalid OpenGL ES2 functions, need a proper fix

### DIFF
--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1172,12 +1172,16 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
         case kBlend_Multiply:
         case kBlend_Burn: // burn is imperfect due to blend mode, darker than normal even when trasparent
             // fade to white
+#if !AGS_OPENGL_ES2 // glTexEnvi and glColor4f are not available on OpenGL ES2, need to rewrite the code here
             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_ADD);
             glColor4f(invalpha, invalpha, invalpha, invalpha);
+#endif // !AGS_OPENGL_ES2
             break;
         default:
+#if !AGS_OPENGL_ES2
             glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
             glColor4f(alpha, alpha, alpha, alpha);
+#endif // !AGS_OPENGL_ES2
             break;
         }
     }


### PR DESCRIPTION
OpenGL ES 2.0 doesn't have neither `glColor4f` or [`glTexEnvi`](https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glTexEnv.xml) used in the code. 

This PR simply guards these with ifdef until a proper code can be figured out, so that the Android port can be built and the CI doesn't fail at packaging the editor. Note that if using the normal blend mode, things will work alright.

I think overall the blend modes could be reimplemented with shaders but this is not trivial since the color to blend need to be in a texture (see https://stackoverflow.com/a/17666532 and https://www.shadertoy.com/view/XdS3RW). Curiously the [gl blend ](https://docs.gl/es2/glBlendFunc)functions ARE available in Open GL ES 2.0, it's just the mentioned functions above that aren't.

