### PR TITLE
adds ctrl and shift keys on agsdefns.sh

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -324,6 +324,12 @@ enum eKeyCode
   eKeyPageDown = 381,
   eKeyInsert = 382,
   eKeyDelete = 383,
+#ifdef SCRIPT_API_v399
+  eKeyShiftLeft = 403, 
+  eKeyShiftRight = 404, 
+  eKeyCtrlLeft = 405, 
+  eKeyCtrlRight = 406,
+#endif
   eKeyF11 = 433,
   eKeyF12 = 434
 };


### PR DESCRIPTION
Adds Ctrl and Shift keys as below in the standard script header:
```
  eKeyShiftLeft = 403, 
  eKeyShiftRight = 404, 
  eKeyCtrlLeft = 405, 
  eKeyCtrlRight = 406,
```
---

[keyTest.zip](https://github.com/adventuregamestudio/ags/files/6525167/keyTest.zip) | [keyTest_ags_proj.zip](https://github.com/adventuregamestudio/ags/files/6525169/keyTest_ags_proj.zip)

![scroll_text_keys](https://user-images.githubusercontent.com/2244442/119201316-05ff1b00-ba65-11eb-8fe9-181f10429b4a.gif)

Above is a game that can be used to test and verify the key presses in AGS and it's project file (I used my own GUI toolkit because I wanted scrollbars).

I used it to verify that the key numbers were correct. Also I chose to go left to right with the less specific to the most specific - so `eKeyCtrlLeft` instead of ~~`eKeyLeftCtrl`~~ because it would feel weird.

Warning: the above game is using 3.5.0.30, so it still has allegro key handling. Using **SDL2 build of AGS** instead don't have the spurious keys, see **below**:

![scroll_text_keys_sdl](https://user-images.githubusercontent.com/2244442/119201636-b1a86b00-ba65-11eb-9edd-3a8bee603ff9.gif)
