### PR TITLE
fixes Direct3D alt+tab in Full Screen hangs games [DO NOT MERGE WITHOUT VERIFYING]

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -580,7 +580,7 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   d3dpp.SwapEffect = D3DSWAPEFFECT_COPY; //D3DSWAPEFFECT_DISCARD; 
   d3dpp.hDeviceWindow = hwnd;
   d3dpp.Windowed = mode.Windowed;
-  d3dpp.EnableAutoDepthStencil = FALSE;
+  d3dpp.EnableAutoDepthStencil = TRUE;
   d3dpp.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER; // we need this flag to access the backbuffer with lockrect
   d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
   if(mode.Vsync)


### PR DESCRIPTION
I can't reproduce the error reported in the forums here: https://www.adventuregamestudio.co.uk/forums/index.php?topic=58976.msg636635407#msg636635407

BUT with me the ags engine in Direct3D does hangs when it's in FullScreen and I alt+tab - leaving a dead invisible window I have to kill with the task manager.

**warning:** I got here after reading the docs below and noticing that the check in line 532 for `alt+tabbed` wasn't working but I DON'T UNDERSTAND WHY THIS CHANGE FIXES.

below the check that isn't working when in FullScreen for me in the Direct3D driver:
https://github.com/adventuregamestudio/ags/blob/3d0353e36ef55b14fffe3f7515d74adf095415a1/Engine/platform/windows/gfx/ali3dd3d.cpp#L532-L537

https://docs.microsoft.com/en-us/previous-versions/windows/desktop/bb281293(v=vs.85)
https://docs.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-reset