### PR TITLE
fixes hang when alt+tab fullscreen direct3d game

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -579,7 +579,7 @@ int D3DGraphicsDriver::_initDLLCallback(const DisplayMode &mode)
   // THIS MUST BE SWAPEFFECT_COPY FOR PlayVideo TO WORK
   d3dpp.SwapEffect = D3DSWAPEFFECT_COPY; //D3DSWAPEFFECT_DISCARD; 
   d3dpp.hDeviceWindow = hwnd;
-  d3dpp.Windowed = mode.Windowed;
+  d3dpp.Windowed = TRUE;
   d3dpp.EnableAutoDepthStencil = FALSE;
   d3dpp.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER; // we need this flag to access the backbuffer with lockrect
   d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;


### PR DESCRIPTION
Probable fix of #1287 

My hypothesis: We are calling Reset on the direct3D device passing the d3dpp structure, and we are setting the Windowed property in it to false, but we are creating our window using `SDL_WINDOW_FULLSCREEN_DESKTOP`, which creates a "fake" fullscreen with a bordless window, so as far as Direct3D is aware, we have a Window, even in FullScreen.

https://docs.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-reset