### PR TITLE
removes hqx mention since it's no longer supported

### DIFF
--- a/Editor/AGS.Types/RuntimeSetup.cs
+++ b/Editor/AGS.Types/RuntimeSetup.cs
@@ -33,7 +33,6 @@ namespace AGS.Types
             _gfxFiltersAll = new Dictionary<GraphicsDriver, Dictionary<string, string>>();
             Dictionary<string, string> filters = new Dictionary<string, string>();
             filters["stdscale"] = "Nearest-neighbour";
-            filters["hqx"] = "High quality (Hqx)";
             _gfxFiltersAll.Add(GraphicsDriver.Software, filters);
             filters = new Dictionary<string, string>();
             filters["stdscale"] = "Nearest-neighbour";

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -186,7 +186,7 @@ void main_print_help() {
 #endif
            "  --gfxfilter FILTER [SCALING]\n"
            "                               Request graphics filter. Available options:\n"           
-           "                                 hqx, linear, none, stdscale\n"
+           "                                 linear, none, stdscale\n"
            "                                 (support differs between graphic drivers);\n"
            "                                 scaling is specified by integer number\n"
            "  --help                       Print this help message and stop\n"


### PR DESCRIPTION
we have removed the hqx filter but it's still mentioned, this PR removes it from a possible filter when Software driver is selected.

![image](https://user-images.githubusercontent.com/2244442/119428038-8d0cf700-bce2-11eb-90bf-d4de6d6e6d7d.png)

![image](https://user-images.githubusercontent.com/2244442/119428414-32c06600-bce3-11eb-9fde-dd4eae9bdcb3.png)

