### PR TITLE
AGS 4: Support reading from game assets in script

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -282,10 +282,11 @@ Stream *AssetManager::OpenAsset(const String &asset_name, const String &filter, 
     AssetLocation loc;
     if (GetAsset(asset_name, filter, false, &loc, open_mode, work_mode))
     {
-        Stream *s = File::OpenFile(loc.FileName, open_mode, work_mode);
+        Stream *s = work_mode == kFile_Read ?
+            File::OpenFile(loc.FileName, loc.Offset, loc.Offset + loc.Size) :
+            File::OpenFile(loc.FileName, open_mode, work_mode);
         if (s)
         {
-            s->Seek(loc.Offset, kSeekBegin);
             if (asset_size)
                 *asset_size = loc.Size;
         }

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -189,7 +189,7 @@ void AssetManager::FindAssets(std::vector<String> &assets, const String &wildcar
         if (IsAssetLibDir(lib))
         {
             // TODO: write util function for getting list of files in dir using standard C/C++
-            String path = Path::ConcatPaths(lib->BaseDir, "*.*");
+            String path = Path::ConcatPaths(lib->BaseDir, "*");
             al_ffblk dfb;
             int	dun = al_findfirst(path.GetCStr(), &dfb, -1);
             while (!dun) {

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -180,8 +180,9 @@ void AssetManager::FindAssets(std::vector<String> &assets, const String &wildcar
 
     for (const auto *lib : _activeLibs)
     {
-        auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
-        if (match == lib->Filters.end())
+        if (filter != "*" &&
+            std::find(lib->Filters.begin(), lib->Filters.end(), filter)
+            == lib->Filters.end())
             continue; // filter does not match
 
         bool found = false;
@@ -255,8 +256,9 @@ bool AssetManager::GetAsset(const String &asset_name, const String &filter, bool
 {
     for (const auto *lib : _activeLibs)
     {
-        auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
-        if (match == lib->Filters.end())
+        if (filter != "*" &&
+            std::find(lib->Filters.begin(), lib->Filters.end(), filter)
+            == lib->Filters.end())
             continue; // filter does not match
 
         bool found = false;

--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -97,6 +97,10 @@ public:
     bool         DoesAssetExist(const String &asset_name, const String &filter = "") const;
     // Finds asset only looking for bare files in directories; returns full path or empty string if failed
     String       FindAssetFileOnly(const String &asset_name, const String &filter = "") const;
+    // Searches in all the registered locations and collects a list of
+    // assets using given wildcard pattern
+    void         FindAssets(std::vector<String> &assets, const String &wildcard,
+                                   const String &filter = "") const;
     // Open asset stream in the given work mode; returns null if asset is not found or cannot be opened
     // This method only searches in libraries that do not have any defined filters
     Stream      *OpenAsset(const String &asset_name, soff_t *asset_size = nullptr,

--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -134,6 +134,19 @@ bool Bitmap::LoadFromFile(const char *filename)
 	return _alBitmap != nullptr;
 }
 
+bool Bitmap::LoadFromFile(PACKFILE *pf)
+{
+    Destroy();
+
+    BITMAP *al_bmp = load_bmp_pf(pf, nullptr);
+    if (al_bmp)
+    {
+        _alBitmap = al_bmp;
+        _isDataOwner = true;
+    }
+    return _alBitmap != nullptr;
+}
+
 bool Bitmap::SaveToFile(const char *filename, const void *palette)
 {
 	return save_bitmap(filename, _alBitmap, (const RGB*)palette) == 0;

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -58,6 +58,7 @@ public:
     bool    LoadFromFile(const String &filename)
             { return LoadFromFile(filename.GetCStr()); }
     bool    LoadFromFile(const char *filename);
+    bool    LoadFromFile(PACKFILE *pf);
     bool    SaveToFile(const String &filename, const void *palette)
             { return SaveToFile(filename.GetCStr(), palette); }
     bool    SaveToFile(const char *filename, const void *palette);

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -79,6 +79,17 @@ Bitmap *LoadFromFile(const char *filename)
 	return bitmap;
 }
 
+Bitmap *LoadFromFile(PACKFILE *pf)
+{
+    Bitmap *bitmap = new Bitmap();
+    if (!bitmap->LoadFromFile(pf))
+    {
+        delete bitmap;
+        bitmap = nullptr;
+    }
+    return bitmap;
+}
+
 Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height)
 {
     int oldw = src->GetWidth(), oldh = src->GetHeight();

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -67,6 +67,7 @@ namespace BitmapHelper
     Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth = 0);
 	Bitmap *LoadFromFile(const char *filename);
     inline Bitmap *LoadFromFile(const String &filename) { return LoadFromFile(filename.GetCStr()); }
+    Bitmap *LoadFromFile(PACKFILE *pf);
 
     // Stretches bitmap to the requested size. The new bitmap will have same
     // colour depth. Returns original bitmap if no changes are necessary. 

--- a/Common/util/bufferedstream.cpp
+++ b/Common/util/bufferedstream.cpp
@@ -29,6 +29,7 @@ BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode, 
     if (FileStream::Seek(0, kSeekEnd) == false)
         throw std::runtime_error("Error determining stream end.");
 
+    _start = 0;
     _end = FileStream::GetPosition();
     if (_end == -1)
         throw std::runtime_error("Error determining stream end.");
@@ -120,14 +121,35 @@ bool BufferedStream::Seek(soff_t offset, StreamSeek origin)
     switch(origin)
     {
         case StreamSeek::kSeekCurrent:  want_pos = _position   + offset; break;
-        case StreamSeek::kSeekBegin:    want_pos = 0           + offset; break;
+        case StreamSeek::kSeekBegin:    want_pos = _start      + offset; break;
         case StreamSeek::kSeekEnd:      want_pos = _end        + offset; break;
         break;
     }
 
     // clamp
-    _position = std::min(std::max(want_pos, (soff_t)0), _end);
+    _position = std::min(std::max(want_pos, (soff_t)_start), _end);
     return _position == want_pos;
+}
+
+BufferedSectionStream::BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
+    FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess)
+    : BufferedStream(file_name, open_mode, work_mode, stream_endianess)
+{
+    assert(start_pos <= end_pos);
+    start_pos = std::min(start_pos, end_pos);
+    _start = std::min(start_pos, _end);
+    _end = std::min(end_pos, _end);
+    Seek(0, kSeekBegin);
+}
+
+soff_t BufferedSectionStream::GetPosition() const
+{
+    return BufferedStream::GetPosition() - _start;
+}
+
+soff_t BufferedSectionStream::GetLength() const
+{
+    return _end - _start;
 }
 
 } // namespace Common

--- a/Common/util/bufferedstream.h
+++ b/Common/util/bufferedstream.h
@@ -51,16 +51,28 @@ public:
 
     bool    Seek(soff_t offset, StreamSeek origin) override;
 
-
-private:
-
-    soff_t _bufferPosition;
-    std::vector<char> _buffer;
-
-    soff_t _position;
+protected:
+    soff_t _start;
     soff_t _end;
 
+private:
     void FillBufferFromPosition(soff_t position);
+
+    soff_t _position;
+    soff_t _bufferPosition;
+    std::vector<char> _buffer;
+};
+
+
+// Creates a BufferedStream limited by an arbitrary offset range
+class BufferedSectionStream : public BufferedStream
+{
+public:
+    BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
+        FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
+
+    soff_t  GetPosition() const override;
+    soff_t  GetLength() const override;
 };
 
 } // namespace Common

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -178,5 +178,20 @@ Stream *File::OpenFile(const String &filename, FileOpenMode open_mode, FileWorkM
     return fs;
 }
 
+Stream *File::OpenFile(const String &filename, soff_t start_off, soff_t end_off)
+{
+    try {
+        FileStream *fs = new BufferedSectionStream(filename, start_off, end_off, kFile_Open, kFile_Read);
+        if (fs != nullptr && !fs->IsValid()) {
+            delete fs;
+            return nullptr;
+        }
+        return fs;
+    }
+    catch (std::runtime_error) {
+        return nullptr;
+    }
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/util/file.h
+++ b/Common/util/file.h
@@ -63,7 +63,10 @@ namespace File
     // Gets C-style file mode from FileOpenMode and FileWorkMode
     String      GetCMode(FileOpenMode open_mode, FileWorkMode work_mode);
 
+    // Opens file in the given mode
     Stream      *OpenFile(const String &filename, FileOpenMode open_mode, FileWorkMode work_mode);
+    // Opens file for reading restricted to the arbitrary offset range
+    Stream      *OpenFile(const String &filename, soff_t start_off, soff_t end_off);
     // Convenience helpers
     // Create a totally new file, overwrite existing one
     inline Stream *CreateFile(const String &filename)

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -11,11 +11,12 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include "util/string_utils.h"
 #include <errno.h>
 #include <string.h>
+#include <regex>
 #include "core/platform.h"
 #include "util/math.h"
-#include "util/string_utils.h"
 #include "util/stream.h"
 
 using namespace AGS::Common;
@@ -61,6 +62,19 @@ StrUtil::ConversionError StrUtil::StringToInt(const String &s, int &val, int def
         return StrUtil::kOutOfRange;
     val = (int)lval;
     return StrUtil::kNoError;
+}
+
+String StrUtil::WildcardToRegex(const String &wildcard)
+{
+    // https://stackoverflow.com/questions/40195412/c11-regex-search-for-exact-string-escape
+    // matches any characters that need to be escaped in RegEx
+    std::regex esc{ R"([-[\]{}()*+?.,\^$|#\s])" };
+    std::string sanitized = std::regex_replace(wildcard.GetCStr(), esc, R"(\$&)");
+    // convert (now escaped) wildcard "\\*" and "\\?" into ".*" and "." respectively
+    String pattern(sanitized.c_str());
+    pattern.Replace("\\*", ".*");
+    pattern.Replace("\\?", ".");
+    return pattern;
 }
 
 String StrUtil::ReadString(Stream *in)

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -53,6 +53,9 @@ namespace StrUtil
     // def_val on failure
     ConversionError StringToInt(const String &s, int &val, int def_val);
 
+    // Converts a classic wildcard search pattern into C++11 compatible regex pattern
+    String          WildcardToRegex(const String &wildcard);
+
     // Serialize and unserialize unterminated string prefixed with 32-bit length;
     // length is presented as 32-bit integer integer
     String          ReadString(Stream *in);

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -52,6 +52,9 @@ int File_Exists(const char *fnmm) {
   if (!ResolveScriptPath(fnmm, true, rp))
     return 0;
 
+  if (rp.AssetMgr)
+      return AssetMgr->DoesAssetExist(rp.FullPath);
+
   return (File::TestReadFile(rp.FullPath) || File::TestReadFile(rp.AltPath)) ? 1 : 0;
 }
 
@@ -194,6 +197,7 @@ const String GameInstallRootToken    = "$INSTALLDIR$";
 const String UserSavedgamesRootToken = "$MYDOCS$";
 const String GameSavedgamesDirToken  = "$SAVEGAMEDIR$";
 const String GameDataDirToken        = "$APPDATADIR$";
+const String GameAssetToken          = "$DATA$";
 const String UserConfigFileToken     = "$CONFIGFILE$";
 
 void FixupFilename(char *filename)
@@ -243,7 +247,8 @@ String FixSlashAfterToken(const String &path)
     if (FixSlashAfterToken(fixed_path, GameInstallRootToken,    fixed_path) ||
         FixSlashAfterToken(fixed_path, UserSavedgamesRootToken, fixed_path) ||
         FixSlashAfterToken(fixed_path, GameSavedgamesDirToken,  fixed_path) ||
-        FixSlashAfterToken(fixed_path, GameDataDirToken,        fixed_path))
+        FixSlashAfterToken(fixed_path, GameDataDirToken,        fixed_path) ||
+        FixSlashAfterToken(fixed_path, GameAssetToken,          fixed_path))
         return fixed_path;
     return path;
 }
@@ -321,21 +326,31 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
     }
 
     // Test absolute paths
-    bool is_absolute = !Path::IsRelativePath(orig_sc_path);
-    if (is_absolute && !read_only)
+    if (!Path::IsRelativePath(orig_sc_path))
     {
-        debug_script_warn("Attempt to access file '%s' denied (cannot write to absolute path)", orig_sc_path.GetCStr());
-        return false;
-    }
-
-    if (is_absolute)
-    {
+        if (!read_only)
+        {
+            debug_script_warn("Attempt to access file '%s' denied (cannot write to absolute path)", orig_sc_path.GetCStr());
+            return false;
+        }
         rp.FullPath = orig_sc_path;
         return true;
     }
 
     // Resolve location tokens
     String sc_path = FixSlashAfterToken(orig_sc_path);
+    if (sc_path.CompareLeft(GameAssetToken, GameAssetToken.GetLength()) == 0)
+    {
+        if (!read_only)
+        {
+            debug_script_warn("Attempt to access file '%s' denied (cannot write to game assets)", orig_sc_path.GetCStr());
+            return false;
+        }
+        rp.FullPath = sc_path.Mid(GameAssetToken.GetLength() + 1);
+        rp.AssetMgr = true;
+        return true;
+    }
+
     FSLocation parent_dir;
     String child_path;
     String alt_path;

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -53,7 +53,7 @@ int File_Exists(const char *fnmm) {
     return 0;
 
   if (rp.AssetMgr)
-      return AssetMgr->DoesAssetExist(rp.FullPath);
+      return AssetMgr->DoesAssetExist(rp.FullPath, "*");
 
   return (File::TestReadFile(rp.FullPath) || File::TestReadFile(rp.AltPath)) ? 1 : 0;
 }

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/global_dynamicsprite.h"
+#include "ac/asset_helper.h"
 #include "ac/draw.h"
 #include "ac/dynamicsprite.h"
 #include "ac/path_helper.h"
@@ -32,12 +33,22 @@ int LoadImageFile(const char *filename)
     if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
-    // TODO: support loading from asset (stream);
-    // use PACKFILE / load_bmp_pf? Or read data and allocate bitmap struct ourselves
+    Bitmap *loadedFile;
+    if (rp.AssetMgr)
+    {
+        size_t asset_size;
+        PACKFILE *pf = PackfileFromAsset(rp.FullPath, asset_size);
+        if (!pf)
+            return 0;
+        loadedFile = BitmapHelper::LoadFromFile(pf);
+    }
+    else
+    {
+        loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
+        if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+            loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
+    }
 
-    Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
-    if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-        loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
     if (!loadedFile)
         return 0;
 

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -32,6 +32,9 @@ int LoadImageFile(const char *filename)
     if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
+    // TODO: support loading from asset (stream);
+    // use PACKFILE / load_bmp_pf? Or read data and allocate bitmap struct ourselves
+
     Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
     if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
         loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -37,7 +37,7 @@ int LoadImageFile(const char *filename)
     if (rp.AssetMgr)
     {
         size_t asset_size;
-        PACKFILE *pf = PackfileFromAsset(rp.FullPath, asset_size);
+        PACKFILE *pf = PackfileFromAsset(AssetPath(rp.FullPath, "*"), asset_size);
         if (!pf)
             return 0;
         loadedFile = BitmapHelper::LoadFromFile(pf);

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -19,6 +19,7 @@
 #include "ac/path_helper.h"
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
+#include "core/assetmanager.h"
 #include "debug/debug_log.h"
 #include "util/directory.h"
 #include "util/path.h"
@@ -79,9 +80,17 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
       return 0;
   }
 
-  Stream *s = File::OpenFile(rp.FullPath, open_mode, work_mode);
-  if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-    s = File::OpenFile(rp.AltPath, open_mode, work_mode);
+  Stream *s;
+  if (rp.AssetMgr)
+  {
+    s = AssetMgr->OpenAsset(rp.FullPath, nullptr, open_mode, work_mode);
+  }
+  else
+  {
+    s = File::OpenFile(rp.FullPath, open_mode, work_mode);
+    if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+      s = File::OpenFile(rp.AltPath, open_mode, work_mode);
+  }
 
   valid_handles[useindx].stream = s;
   if (valid_handles[useindx].stream == nullptr)

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -83,7 +83,7 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
   Stream *s;
   if (rp.AssetMgr)
   {
-    s = AssetMgr->OpenAsset(rp.FullPath, nullptr, open_mode, work_mode);
+    s = AssetMgr->OpenAsset(rp.FullPath, "*", nullptr, open_mode, work_mode);
   }
   else
   {

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -71,7 +71,7 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   std::vector<String> files;
   if (rp.AssetMgr)
   {
-    AssetMgr->FindAssets(files, rp.FullPath);
+    AssetMgr->FindAssets(files, rp.FullPath, "*");
   }
   else
   {

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -11,10 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-#include <algorithm>
-#include <set>
-#include <allegro.h> // find files
 #include "ac/listbox.h"
+#include <algorithm>
+#include <vector>
+#include <allegro.h> // find files
 #include "ac/common.h"
 #include "ac/game.h"
 #include "ac/gamesetupstruct.h"
@@ -22,6 +22,7 @@
 #include "ac/global_game.h"
 #include "ac/path_helper.h"
 #include "ac/string.h"
+#include "core/assetmanager.h"
 #include "gui/guimain.h"
 #include "debug/debug_log.h"
 #include "util/path.h"
@@ -49,12 +50,12 @@ void ListBox_Clear(GUIListBox *listbox) {
   listbox->Clear();
 }
 
-void FillDirList(std::set<String> &files, const String &path)
+void FillDirList(std::vector<String> &files, const String &path)
 {
     al_ffblk dfb;
     int	dun = al_findfirst(path.GetCStr(), &dfb, FA_SEARCH);
     while (!dun) {
-        files.insert(dfb.name);
+        files.push_back(dfb.name);
         dun = al_findnext(&dfb);
     }
     al_findclose(&dfb);
@@ -67,15 +68,23 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   if (!ResolveScriptPath(filemask, true, rp))
     return;
 
-  // TODO: support listing assets from AssetMgr
-
-  std::set<String> files;
-  FillDirList(files, rp.FullPath);
-  if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-    FillDirList(files, rp.AltPath);
+  std::vector<String> files;
+  if (rp.AssetMgr)
+  {
+    AssetMgr->FindAssets(files, rp.FullPath);
+  }
+  else
+  {
+    FillDirList(files, rp.FullPath);
+    if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+      FillDirList(files, rp.AltPath);
+    // Sort and remove duplicates
+    std::sort(files.begin(), files.end());
+    files.erase(std::unique(files.begin(), files.end()), files.end());
+  }
 
   // TODO: method for adding item batch to speed up update
-  for (std::set<String>::const_iterator it = files.begin(); it != files.end(); ++it)
+  for (auto it = files.cbegin(); it != files.cend(); ++it)
   {
     listbox->AddItem(*it);
   }

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -67,6 +67,8 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   if (!ResolveScriptPath(filemask, true, rp))
     return;
 
+  // TODO: support listing assets from AssetMgr
+
   std::set<String> files;
   FillDirList(files, rp.FullPath);
   if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -75,6 +75,7 @@ struct ResolvedPath
     String BaseDir;  // base directory, which we assume already exists
     String FullPath; // full path, including filename
     String AltPath;  // alternative full path, for backwards compatibility
+    bool   AssetMgr = false; // file is to be accessed through the asset manager
 };
 // Resolves a file path provided by user (e.g. script) into actual file path,
 // by substituting special keywords with actual platform-specific directory names.


### PR DESCRIPTION
For #1227 (does only engine part of the job).

This supports reading resource files ("assets") in script. Resources are retrieved using engine's own AssetManager, thus the script has access to everything that engine has. This method allows to open files only in read mode.

The opened file stream is modified to restrict reading and seeking to the range of offsets: this ensures that the script won't read past the end of resource even if it's retrieved from the larger file (package).

To specify game resource a new path token is introduced: "$DATA$".

Following script functions support this token:

**File.Open** - opens resource file for reading (if script asks to open for writing it will throw an error and return null pointer, as usual).
Example: `File* f = File.Open("$DATA$/myfile.dat");`

**DynamicSprite.CreateFromFile** - will try to create a sprite from the bitmap in game resources.
Example: `DynamicSprite* dspr = DynamicSprite.CreateFromFile("$DATA$/custom.bmp");`

**ListBox.FillDirList** - will fill list box with all found resource names using wildcard pattern.
Example: `MyListBox.FillDirList("$DATA$/room*.crm");` - this shows a list of all room files in the game.