### PR TITLE
Tools: trac - compiles game translation (TRS -> TRA)

### DIFF
--- a/Common/game/tra_file.h
+++ b/Common/game/tra_file.h
@@ -64,7 +64,7 @@ struct Translation
     // Localization parameters
     int NormalFont = -1; // replacement for normal font, or -1 for default
     int SpeechFont = -1; // replacement for speech font, or -1 for default
-    int RightToLeft = -1; // r2l text mode (0, 1), or -1 for default
+    int RightToLeft = -1; // r2l text mode (1, 2), or -1 for default
 };
 
 
@@ -77,6 +77,13 @@ typedef std::function<HTraFileError(Stream *in, TraFileBlock block_id,
     soff_t block_len, bool &read_next)> PfnReadTraBlock;
 // Parses tra file, passing each found block into callback; does not read any actual data itself
 HTraFileError ReadTraData(PfnReadTraBlock reader, Stream *in);
+
+// Writes all translation data to the stream
+HTraFileError WriteTraData(const Translation &tra, Stream *out);
+// Type of function that writes single room block.
+typedef std::function<HTraFileError(const Translation &tra, Stream *out)> PfnWriteTraBlock;
+// Writes room block with a old-style numeric id
+void WriteTraBlock(const Translation &tra, TraFileBlock block_id, PfnWriteTraBlock writer, Stream *out);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -63,6 +63,45 @@ StrUtil::ConversionError StrUtil::StringToInt(const String &s, int &val, int def
     return StrUtil::kNoError;
 }
 
+String StrUtil::Unescape(const String &s)
+{
+    size_t at = s.FindChar('\\');
+    if (at == -1)
+        return s; // no unescaping necessary, return original string
+    char *buf = new char[s.GetLength()];
+    strncpy(buf, s.GetCStr(), at);
+    char *pb = buf + at;
+    for (const char *ptr = s.GetCStr() + at; *ptr; ++ptr)
+    {
+        if (*ptr != '\\')
+        {
+            *(pb++) = *ptr;
+            continue;
+        }
+
+        char next = *(++ptr);
+        switch (next)
+        {
+        case 'a':  *(pb++) = '\a'; break;
+        case 'b':  *(pb++) = '\b'; break;
+        case 'f':  *(pb++) = '\f'; break;
+        case 'n':  *(pb++) = '\n'; break;
+        case 'r':  *(pb++) = '\r'; break;
+        case 't':  *(pb++) = '\t'; break;
+        case 'v':  *(pb++) = '\v'; break;
+        case '\\': *(pb++) = '\\'; break;
+        case '\'': *(pb++) = '\''; break;
+        case '\"': *(pb++) = '\"'; break;
+        case '\?': *(pb++) = '\?'; break;
+        default: *(pb++) = next; break;
+        }
+    }
+    *pb = 0;
+    String dst(buf);
+    delete buf;
+    return dst;
+}
+
 String StrUtil::ReadString(Stream *in)
 {
     size_t len = in->ReadInt32();
@@ -118,6 +157,13 @@ void StrUtil::WriteString(const String &s, Stream *out)
 void StrUtil::WriteString(const char *cstr, Stream *out)
 {
     size_t len = strlen(cstr);
+    out->WriteInt32(len);
+    if (len > 0)
+        out->Write(cstr, len);
+}
+
+void StrUtil::WriteString(const char *cstr, size_t len, Stream *out)
+{
     out->WriteInt32(len);
     if (len > 0)
         out->Write(cstr, len);

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -53,6 +53,9 @@ namespace StrUtil
     // def_val on failure
     ConversionError StringToInt(const String &s, int &val, int def_val);
 
+    // A simple unescape string implementation, unescapes '\\x' into '\x'.
+    String          Unescape(const String &s);
+
     // Serialize and unserialize unterminated string prefixed with 32-bit length;
     // length is presented as 32-bit integer integer
     String          ReadString(Stream *in);
@@ -62,6 +65,7 @@ namespace StrUtil
     void            SkipString(Stream *in);
     void            WriteString(const String &s, Stream *out);
     void            WriteString(const char *cstr, Stream *out);
+    void            WriteString(const char *cstr, size_t len, Stream *out);
 
     // Serialize and unserialize string as c-string (null-terminated sequence)
     void            ReadCStr(char *buf, Stream *in, size_t buf_limit);

--- a/Solutions/Tools.App/trac.vcxproj
+++ b/Solutions/Tools.App/trac.vcxproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\ac\wordsdictionary.cpp" />
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
+    <ClCompile Include="..\..\Common\game\tra_file.cpp" />
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp" />
+    <ClCompile Include="..\..\Tools\data\tra_utils.cpp" />
+    <ClCompile Include="..\..\Tools\trac\main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Common\game\tra_file.h" />
+    <ClInclude Include="..\..\Common\util\textstreamreader.h" />
+    <ClInclude Include="..\..\Tools\data\tra_utils.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}</ProjectGuid>
+    <RootNamespace>MakeRoomHeader</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>trac</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Tools.App/trac.vcxproj.filters
+++ b/Solutions/Tools.App/trac.vcxproj.filters
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="data">
+      <UniqueIdentifier>{ebea7864-de2f-48c8-b3d2-51eb82b7a045}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="trac">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\tra_utils.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\trac\main.cpp">
+      <Filter>trac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\ac\wordsdictionary.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\tra_file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\Tools\data\tra_utils.h">
+      <Filter>data</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\textstreamreader.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\game\tra_file.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -11,6 +11,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2glvar", "Tools.App\agf2
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agf2dlgasc", "Tools.App\afg2dlgasc.vcxproj", "{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "trac", "Tools.App\trac.vcxproj", "{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -51,6 +53,14 @@ Global
 		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x64.Build.0 = Release|x64
 		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x86.ActiveCfg = Release|Win32
 		{D0CB449B-83AB-43B2-9286-0FAE4C37D73F}.Release|x86.Build.0 = Release|Win32
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Debug|x64.ActiveCfg = Debug|x64
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Debug|x64.Build.0 = Debug|x64
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Debug|x86.ActiveCfg = Debug|Win32
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Debug|x86.Build.0 = Debug|Win32
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Release|x64.ActiveCfg = Release|x64
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Release|x64.Build.0 = Release|x64
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Release|x86.ActiveCfg = Release|Win32
+		{0981C97D-C8AE-43CE-8A4B-3231B6468AE7}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/data/tra_utils.cpp
+++ b/Tools/data/tra_utils.cpp
@@ -1,0 +1,121 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "data/tra_utils.h"
+#include "ac/wordsdictionary.h"
+#include "util/string_utils.h"
+#include "util/textstreamreader.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+//-----------------------------------------------------------------------------
+// TRA - original translation source a in text format
+//-----------------------------------------------------------------------------
+
+const String NORMAL_FONT_TAG("//#NormalFont=");
+const String SPEECH_FONT_TAG("//#SpeechFont=");
+const String TEXT_DIRECTION_TAG("//#TextDirection=");
+const char *TAG_DEFAULT = "DEFAULT";
+const char *TAG_DIRECTION_LEFT = "LEFT";
+const char *TAG_DIRECTION_RIGHT = "RIGHT";
+
+static int ReadOptionalInt(const String &text)
+{
+    if (text == TAG_DEFAULT)
+        return -1;
+    return StrUtil::StringToInt(text, -1);
+}
+
+static void ReadSpecialTags(Translation &tra, const String &line)
+{
+    if (line.StartsWith(NORMAL_FONT_TAG))
+    {
+        tra.NormalFont = ReadOptionalInt(line.Mid(NORMAL_FONT_TAG.GetLength()));
+    }
+    else if (line.StartsWith(SPEECH_FONT_TAG))
+    {
+        tra.SpeechFont = ReadOptionalInt(line.Mid(SPEECH_FONT_TAG.GetLength()));
+    }
+    else if (line.StartsWith(TEXT_DIRECTION_TAG))
+    {
+        String directionText = line.Mid(TEXT_DIRECTION_TAG.GetLength());
+        if (directionText == TAG_DIRECTION_LEFT)
+        {
+            tra.RightToLeft = 1;
+        }
+        else if (directionText == TAG_DIRECTION_RIGHT)
+        {
+            tra.RightToLeft = 2;
+        }
+        else
+        {
+            tra.RightToLeft = -1;
+        }
+    }
+}
+
+HError ReadTRS(Translation &tra, Stream *in)
+{
+    TextStreamReader sr(in);
+
+    String line;
+    for (line = sr.ReadLine(); !sr.EOS(); line = sr.ReadLine())
+    {
+        if (line.StartsWith("//"))
+        {
+            ReadSpecialTags(tra, line);
+            continue;
+        }
+        String src = line;
+        String dst = sr.ReadLine();
+        // TODO: warn about duplicates
+        if (tra.Dict.count(src) == 0)
+        {
+            tra.Dict.insert(std::make_pair(src, dst));
+        }
+    }
+
+    sr.ReleaseStream(); // we do not want to delete it
+    return HError::None();
+}
+
+//-----------------------------------------------------------------------------
+// TRA - compiled translation in a binary format
+//-----------------------------------------------------------------------------
+
+HError WriteTRA(const Translation &tra, Stream *out)
+{
+    // Check if translation object is meaningful
+    if (tra.Dict.size() < 1)
+        return new Error("Translation source appears to be empty");
+    bool has_translation = false;
+    for (const auto &kv : tra.Dict)
+    {
+        has_translation |= !kv.first.IsEmpty() && !kv.second.IsEmpty();
+    }
+    if (!has_translation)
+        return new Error("Translation source did not appear to have any translated lines.");
+
+    // Write translation
+    WriteTraData(tra, out);
+
+    return HError::None();
+}
+
+} // namespace DataUtil
+} // namespace AGS

--- a/Tools/data/tra_utils.h
+++ b/Tools/data/tra_utils.h
@@ -1,0 +1,36 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#ifndef __AGS_TOOL_DATA__CRMUTIL_H
+#define __AGS_TOOL_DATA__CRMUTIL_H
+
+#include "game/tra_file.h"
+
+namespace AGS
+{
+namespace DataUtil
+{
+
+using AGS::Common::HError;
+using AGS::Common::Stream;
+using AGS::Common::String;
+using AGS::Common::Translation;
+
+// Parses a TRS format and fills Translation data
+HError ReadTRS(Translation &tra, Stream *in);
+HError WriteTRA(const Translation &tra, Stream *out);
+
+} // namespace DataUtil
+} // namespace AGS
+
+#endif // __AGS_TOOL_DATA__CRMUTIL_H

--- a/Tools/trac/Makefile
+++ b/Tools/trac/Makefile
@@ -1,0 +1,93 @@
+INCDIR = ../../Common ../../Tools
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/ac/wordsdictionary.cpp \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/game/tra_file.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/datastream.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp \
+	../../Common/util/textstreamreader.cpp
+
+TOOL_OBJS = \
+	../../Tools/data/tra_utils.cpp
+
+OBJS := main.cpp \
+	$(COMMON_OBJS) \
+	$(TOOL_OBJS)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags trac
+
+trac: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags trac
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f trac $(OBJS) $(DEPFILES)
+
+install: trac
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin trac
+
+uninstall:
+	rm -f $(PREFIX)/bin/trac

--- a/Tools/trac/main.cpp
+++ b/Tools/trac/main.cpp
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include "data/tra_utils.h"
+#include "util/file.h"
+#include "util/string_compat.h"
+#include "util/string_utils.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+
+
+const char *HELP_STRING = "Usage: trac <input.tra> <output.trs>\n\t[--gamename <name>][--uniqueid <idnum>]";
+
+int main(int argc, char *argv[])
+{
+    printf("trac v0.1.0 - AGS translation compiler (TRS -> TRA)\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        {
+            printf("%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+    }
+    if (argc < 3)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    String game_name;
+    int game_uid;
+    for (int i = 3; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--gamename") == 0 && (i < argc - 1))
+            game_name = argv[++i];
+        else if (ags_stricmp(arg, "--uniqueid") == 0 && (i < argc - 1))
+            game_uid = StrUtil::StringToInt(argv[++i]);
+    }
+
+    const char *src = argv[1];
+    const char *dst = argv[2];
+    printf("Input room file: %s\n", src);
+    printf("Output script header: %s\n", dst);
+    printf("Game name: %s\n", game_name.GetCStr());
+    printf("Game uniqueid: %d\n", game_uid);
+
+    //-----------------------------------------------------------------------//
+    // Read TRS
+    //-----------------------------------------------------------------------//
+    Stream *in = File::OpenFileRead(src);
+    if (!in)
+    {
+        printf("Error: failed to open source TRS for reading:\n");
+        return -1;
+    }
+    
+    Translation tra;
+    HError err = ReadTRS(tra, in);
+    delete in;
+    if (!err)
+    {
+        printf("Error: failed to read source TRS:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write TRA
+    //-----------------------------------------------------------------------//
+    Stream *out = File::CreateFile(dst);
+    if (!out)
+    {
+        printf("Error: failed to open output TRA for writing.\n");
+        return -1;
+    }
+    tra.GameName = game_name;
+    tra.GameUid = game_uid;
+    err = WriteTRA(tra, out);
+    delete out;
+    if (!err)
+    {
+        printf("Error: failed to compile TRA:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+    printf("Compiled translation written successfully.\nDone.\n");
+    return 0;
+}


### PR DESCRIPTION
Resolves #1299

This tool compiles TRS (translation source file) into TRA (runtime translation file).

**trac** - stands for "TRAnslation Compiler".

*Input:* translation source (`*.trs`) and game identification parameters (name, uniqueid).
*Output:* runtime translation (`*.tra`).

Usage: `trac name.trs name.tra --gamename MyGame --uniqueid 12345`

---

There's a noteable issue that the TRA needs game title and uniqueid field to be set: engine uses these to match translation with the game. Normally editor would get these from the game data, but here I thought that it may be overkill to parse Game.agf for two values. Also, I thought hypothetically that we may add an option to force translation without game check.
These two arguments may be omited, in which case they will be saved as an empty string and 0 respectively.
**EDIT:** one alternative is to support reading these from TRS (there are already few extra options read from there), in which case TRS will be fully independent from the rest of the game data. But this won't work if it comes from older project of course - it will have to be updated in such case. Editor may be adjusted to write this information into TRS on generation.

Another thing, it may not be easy to compare output with the one produced by the editor. The main bulk of data is a dictionary of key/value string pairs and there's no rule to how these should be ordered. Editor currently saves them in the order they are present in .NET implementation of Dictionary class, which is an unordered map. Without using exactly same hashing etc algorithms I don't think it's possible to match the same order, and I don't believe it's essential to do so.

PS. Oh, and the output strings are encrypted by the way. Again, maybe we could support a switch that enables/disables this encryption for the easier debugging (but the engine will have to be aware of that too).