### PR TITLE
CI: avoid piping zip to bsdtar (release-3.5.1 branch)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -241,8 +241,8 @@ editor_packaging_task:
     copy %SYSTEMDRIVE%\Redist\vc_redist.x86.exe Windows\Installer\Source\Redist\
   get_editor_script: >
     mkdir Windows\Installer\Source\Editor &&
-    curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_editor/binaries.zip" |
-    tar -f - -xvzC Windows\Installer\Source\Editor --strip-components 3 Solutions/.build/Release
+    curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_editor/binaries.zip" --output "%TEMP%\binaries.zip" &&
+    tar -f "%TEMP%\binaries.zip" -xvzC Windows\Installer\Source\Editor --strip-components 3 Solutions/.build/Release
   get_windows_engine_script: >
     mkdir Windows\Installer\Source\Engine &&
     curl -fLSso Windows\Installer\Source\Engine\acwin.exe
@@ -289,7 +289,9 @@ pdb_packaging_task:
       "build_editor/ags_editor_pdb.zip" \
       "build_editor/ags_native_pdb.zip"
     do
-      curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download" | bsdtar -f - -xvzC /tmp/pdb -s "!.*/Debug/.*!!p" -s "!.*/!!p"
+      curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/$download" --output /tmp/tmp_pdb.zip 
+      bsdtar -f /tmp/tmp_pdb.zip -xvzC /tmp/pdb -s "!.*/Debug/.*!!p" -s "!.*/!!p"
+      rm /tmp/tmp_pdb.zip
     done
   make_pdb_archive_script: |
     version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
@@ -340,7 +342,9 @@ make_release_task:
     baseurl="https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID"
     mkdir -p /tmp/github_release && \
     cd /tmp/github_release && \
-    curl -fLSs "$baseurl/editor_packaging/installer.zip" | bsdtar -f - -xv --strip-components 3 && \
+    curl -fLSs "$baseurl/editor_packaging/installer.zip" -o /tmp/github_release/installer.zip && \
+    bsdtar -f /tmp/github_release/installer.zip -xv --strip-components 3 && \
+    rm /tmp/github_release/installer.zip  && \
     for download in "editor_packaging/archive/$(basename AGS-*.exe .exe).zip" \
       "linux_packaging/binaries/ags_${version}_linux.tar.gz" \
       "pdb_packaging/archive/AGS-${version}-pdb.zip" \


### PR DESCRIPTION
In case we need a new release in this branch, avoiding piping zip files to bsdtar will fix the errors that happen from time to time of missing files in zip files.