### PR TITLE
fixes for agf2dlgasc.exe

### DIFF
--- a/Tools/data/dialogscriptconv.cpp
+++ b/Tools/data/dialogscriptconv.cpp
@@ -389,7 +389,7 @@ String DialogScriptConverter::ProcessOptionOnOff(const String &line, const char 
         return "";
     }
 
-    const char *option_str = mr[3].str().c_str();
+    String option_str = mr[3].str().c_str();
     int option_num;
     if (StrUtil::StringToInt(option_str, option_num, 0) == StrUtil::kNoError)
     {

--- a/Tools/data/dialogscriptconv.cpp
+++ b/Tools/data/dialogscriptconv.cpp
@@ -343,7 +343,7 @@ String DialogScriptConverter::ProcessCmdGotoDialog(const String &line)
         }
     }
 
-    CompileError(String::FromFormat("Dialog not found: %s", dialog_name));
+    CompileError(String::FromFormat("Dialog not found: %s", dialog_name.GetCStr()));
     return "";
 }
 


### PR DESCRIPTION
Hey, I tried to use `agf2dlgasc.exe`, but had an issue with `option-on` and `option-off` not being recognized. Additionally, I adjusted one statement that missed a C string conversion - judging from other calls in the same file.

Also I didn't fix here, but I noticed the option `DialogScriptSayFunction` from the `Game.agf` file is not considered - that one that allows using `Character.MySay()` instead of `Character.Say()`. 