### PR TITLE
adds a command line front end to the script compiler 

### DIFF
--- a/Compiler/CMakeLists.txt
+++ b/Compiler/CMakeLists.txt
@@ -42,6 +42,16 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Source Files" FILES ${COMM
 
 add_library(AGS::Compiler ALIAS compiler)
 
+add_executable(agscc main.cpp)
+set_target_properties(agscc PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        C_STANDARD 11
+        C_EXTENSIONS NO
+        )
+
+target_link_libraries(agscc PUBLIC AGS::Compiler)
+
 if(AGS_TESTS)
     add_executable(
             compiler_test

--- a/Compiler/main.cpp
+++ b/Compiler/main.cpp
@@ -1,0 +1,151 @@
+#include "script/cs_compiler.h"
+#include "script/cc_options.h"
+#include "script/cc_error.h"
+#include "util/filestream.h"
+#include "util/file.h"
+#include "util/textstreamreader.h"
+#include "util/string_compat.h"
+
+using namespace AGS::Common;
+
+/* needs this or linker fails */
+extern int currentline; // in script/script_common
+
+std::pair<String, String> cc_error_at_line(const char* error_msg)
+{
+    return std::make_pair(String::FromFormat("Error (line %d): %s", currentline, error_msg), String());
+}
+
+String cc_error_without_line(const char* error_msg)
+{
+    return String::FromFormat("Error (line unknown): %s", error_msg);
+}
+
+
+const char *HELP_STRING = "Usage: agscc <input.asc> <output.o> [OPTION...] \n"
+"-H, --Headers HEADER  Header Files in order\n"
+"-r, --roomscript      Use if is a room script\n"
+"-h, --help            Print usage\n";
+
+int main(int argc, char* argv[])
+{
+    bool isRoomScript = false;
+    int h_i_start = 0;
+    int h_i_end = 0;
+    printf("agscc v0.1.0 - A command line compiler for preprocessed ags scripts\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        {
+            printf("\n%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+        if (ags_stricmp(arg, "--roomscript") == 0 || ags_stricmp(arg, "-r") == 0)
+        {
+            isRoomScript = true;
+        }
+
+        if (ags_stricmp(arg, "--Headers") == 0 || ags_stricmp(arg, "-H") == 0)
+        {
+            h_i_start = i;
+        }
+        else if(h_i_start != 0)
+        {
+            h_i_end = i;
+        }
+    }
+    if (argc < 3)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *src = argv[1];
+    const char *dst = argv[2];
+    printf("Input script file: %s\n", src);
+    printf("Output script obj: %s\n", dst);
+
+    std::vector<String> headers;
+    if (h_i_start != 0 && h_i_end > h_i_start)
+    {
+        for(int i=h_i_start+1; i<=h_i_end; i++) {
+            headers.emplace_back(argv[i]);
+        }
+    }
+
+    //-----------------------------------------------------------------------//
+    // Configure compiler
+    //-----------------------------------------------------------------------//
+    ccSetSoftwareVersion("version"); // need to set the version here somehow
+
+    ccSetOption(SCOPT_EXPORTALL, 1);
+    ccSetOption(SCOPT_LINENUMBERS, 1);
+    // Don't allow them to override imports in the room script
+    ccSetOption(SCOPT_NOIMPORTOVERRIDE, isRoomScript);
+
+    ccSetOption(SCOPT_LEFTTORIGHT, 1 /*LeftToRightPrecedence*/);
+    ccSetOption(SCOPT_OLDSTRINGS, 0 /*EnforceNewStrings*/);
+
+    ccRemoveDefaultHeaders();
+
+    //-----------------------------------------------------------------------//
+    // Read input files
+    //-----------------------------------------------------------------------//
+    std::vector<String> heads;
+    for(const auto& header: headers)
+    {
+        Stream *in = File::OpenFileRead(header);
+        if (!in)
+        {
+            printf("Error: failed to open header for reading: %s\n", header.GetCStr());
+            return -1;
+        }
+        TextStreamReader sr(in);
+        heads.push_back(sr.ReadAll());
+        in->Close();
+
+        ccAddDefaultHeader((char*) heads.back().GetCStr(), (char*) header.GetCStr());
+    }
+
+    String script_input;
+    if(src)
+    {
+        Stream *in = File::OpenFileRead(src);
+        if (!in)
+        {
+            printf("Error: failed to open script for reading: %s\n", src);
+            return -1;
+        }
+        TextStreamReader sr(in);
+        script_input = sr.ReadAll();
+        in->Close();
+    }
+
+    //-----------------------------------------------------------------------//
+    // Compiler script
+    //-----------------------------------------------------------------------//
+    ccScript* script = ccCompileText(script_input.GetCStr(), src);
+    if ((script == nullptr) || (ccError != 0))
+    {
+        printf("Error: compile failed at %s, line %d : %s\n", ccCurScriptName, ccErrorLine, ccErrorString.GetCStr());
+        return -1;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write script object
+    //-----------------------------------------------------------------------//
+    Stream *out = File::CreateFile(dst);
+    if (!out || !(out->CanWrite()))
+    {
+        printf("Error: failed to open for writing: %s\n", dst);
+        return -1;
+    }
+    script->Write(out);
+    out->Close();
+
+    return 0;
+}

--- a/Solutions/Compiler.App.sln
+++ b/Solutions/Compiler.App.sln
@@ -1,0 +1,44 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Compiler.App", "Compiler.App\Compiler.App.vcxproj", "{328E0769-7941-4093-8BF9-0E138955F44C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532} = {7B621FC0-BFD0-40E4-800A-0CD5E5707532}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Compiler.Lib", "Compiler.Lib\Compiler.Lib.vcxproj", "{7B621FC0-BFD0-40E4-800A-0CD5E5707532}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_MD|Win32 = Debug_MD|Win32
+		Debug|Win32 = Debug|Win32
+		Release_MD|Win32 = Release_MD|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Debug_MD|Win32.ActiveCfg = Debug_MD|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Debug_MD|Win32.Build.0 = Debug_MD|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Debug|Win32.Build.0 = Debug|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Release_MD|Win32.ActiveCfg = Release_MD|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Release_MD|Win32.Build.0 = Release_MD|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Release|Win32.ActiveCfg = Release|Win32
+		{328E0769-7941-4093-8BF9-0E138955F44C}.Release|Win32.Build.0 = Release|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Debug_MD|Win32.ActiveCfg = Debug_MD|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Debug_MD|Win32.Build.0 = Debug_MD|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Debug|Win32.Build.0 = Debug|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release_MD|Win32.ActiveCfg = Release_MD|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release_MD|Win32.Build.0 = Release_MD|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release|Win32.ActiveCfg = Release|Win32
+		{7B621FC0-BFD0-40E4-800A-0CD5E5707532}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0F916763-DDE3-433C-8C59-2DCFB92A046A}
+	EndGlobalSection
+EndGlobal

--- a/Solutions/Compiler.App/Compiler.App.vcxproj
+++ b/Solutions/Compiler.App/Compiler.App.vcxproj
@@ -1,0 +1,213 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_MD|Win32">
+      <Configuration>Debug_MD</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_MD|Win32">
+      <Configuration>Release_MD</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{328E0769-7941-4093-8BF9-0E138955F44C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CompilerApp</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>14.0.25431.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>Compiler_d</TargetName>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>Compiler</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <TargetName>Compiler_md</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>Compiler_md_d</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Compiler;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WINDOWS_VERSION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Compiler_d.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Compiler;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;WINDOWS_VERSION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Compiler.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Compiler;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;WINDOWS_VERSION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Compiler_md.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Compiler;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;WINDOWS_VERSION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>Compiler_md_d.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Compiler\main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Compiler.App/Compiler.App.vcxproj.filters
+++ b/Solutions/Compiler.App/Compiler.App.vcxproj.filters
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common Source Files">
+      <UniqueIdentifier>{62ea3546-eb7a-4eee-a4f7-965f60a3e19e}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Compiler\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\textstreamreader.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adding a command line front end for the script compiler. Named `agscc`, currently this is the output of `agscc --help`:

```
agscc v0.1.0 - A command line compiler for preprocessed ags scripts
Copyright (c) 2021 AGS Team and contributors

Usage: agscc <input.asc> <output.o> [OPTION...]
-H, --Headers HEADER  Header Files in order
-r, --roomscript      Use if is a room script
-h, --help            Print usage
```

If I modify the code I will update usage above. Only for Windows (for now), builds using a Solution and vcxproj, they are placed on the `Solutions` directory.

There are probably many errors, and I didn't write with any expectation of merging, I think at minimum having something to play can help writing an issue for what a script compiler should have - and also how to organize the files. :)

I was looking the original compiler files and could not figure how to get the editor from the following line:

https://github.com/adventuregamestudio/ags/blob/daf70322bf8677534d31570b7253a94ea16d5758/Editor/AGS.Native/ScriptCompiler.cpp#L71

(for testing I used a hacky tool I made to patch crm room files with the script obj output)

---

List of flags in the compiler today (here because they need to be in the interface)

https://github.com/adventuregamestudio/ags/blob/daf70322bf8677534d31570b7253a94ea16d5758/Common/script/cc_options.h#L22-L29

@rofl0r gave following suggestions for the name of the flags which we could use: 
```
 exportall (1/0) - export all functions automatically
 showwarnings (1/0) - printf warnings to console
 linenumbers (1/0) - include line numbers in compiled code
 autoimport (1/0) - when creating instance, export funcs to other scripts
 debugrun (1/0) - write instructions as they are processed to log file
 noimportoverride (1/0) - do not allow an import to be re-declared
 lefttoright (1/0) - left-to-right operator precedance
 oldstrings (1/0) - allow old-style strings
```

Note though that `noimportoverride` doesn't exists anymore in the editor so we should remove it.

Funnily in general settings not all compiler options are in the compiler area: https://adventuregamestudio.github.io/ags-manual/Settingupthegame.html#general-settings

#### adding preprocessor

There are certain conveniences gained by adding preprocessor support, we may need that here too. On the interface this means setting preprocessor macros. Here are two options on this from @rofl0r's list:

```
-D macro[=val] : define preprocessor macro
-E : run preprocessor only (create file with .i extension)
```

Though note that in this case a preprocessor has to be written.

---

I also have been thinking about passing individual headers through command line and am not sure this is the best way to go, I imagine any medium game would have like 60 different parameters for headers alone.
<details>

```
private void DefineMacrosAccordingToGameSettings(IPreprocessor preprocessor)
		{
			preprocessor.DefineMacro("AGS_NEW_STRINGS", "1");
			preprocessor.DefineMacro("AGS_SUPPORTS_IFVER", "1");
			if (_game.Settings.DebugMode)
			{
				preprocessor.DefineMacro("DEBUG", "1");
			}
			if (_game.Settings.EnforceObjectBasedScript)
			{
				preprocessor.DefineMacro("STRICT", "1");
			}
			if (_game.Settings.LeftToRightPrecedence)
			{
				preprocessor.DefineMacro("LRPRECEDENCE", "1");
			}
			if (_game.Settings.EnforceNewStrings)
			{
				preprocessor.DefineMacro("STRICT_STRINGS", "1");
			}
            if (_game.Settings.EnforceNewAudio)
            {
                preprocessor.DefineMacro("STRICT_AUDIO", "1");
            }
            if (!_game.Settings.UseOldCustomDialogOptionsAPI)
            {
                preprocessor.DefineMacro("NEW_DIALOGOPTS_API", "1");
            }
            // Define Script API level macros
            foreach (ScriptAPIVersion v in Enum.GetValues(typeof(ScriptAPIVersion)))
            {
                if (v == ScriptAPIVersion.Highest)
                    continue; // skip Highest constant
                if (v > _game.Settings.ScriptAPIVersionReal)
                    continue;
                preprocessor.DefineMacro(_scriptAPIVersionMacros[v], "1");
            }
            foreach (ScriptAPIVersion v in Enum.GetValues(typeof(ScriptAPIVersion)))
            {
                if (v == ScriptAPIVersion.Highest)
                    continue; // skip Highest constant
                if (v < _game.Settings.ScriptCompatLevelReal)
                    continue;
                preprocessor.DefineMacro(_scriptCompatLevelMacros[v], "1");
            }
        }
```

</details>