### PR TITLE
New Compiler: Fix bug when assigning a string literal to a String

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4189,7 +4189,7 @@ AGS::ErrorType AGS::Parser::AccessData_AssignTo(ScopeType sct, Vartype vartype, 
         return kERR_None;
     }
 
-    ConvertAXStringToStringObject(rhsvartype, lhsvartype);
+    ConvertAXStringToStringObject(lhsvartype, rhsvartype);
     if (IsVartypeMismatch_Oneway(rhsvartype, lhsvartype))
     {
         Error(

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -514,7 +514,7 @@ private:
     // 'current_vartype' must be the vartype of AX. If it is 'string' and
     // wanted_vartype is 'String', then AX will be converted to 'String'.
     // then convert AX into a String object and set its type accordingly
-    void ConvertAXStringToStringObject(Vartype current_vartype, Vartype &wanted_vartype);
+    void ConvertAXStringToStringObject(Vartype wanted_vartype, Vartype &current_vartype);
 
     static int GetReadCommandForSize(int the_size);
 

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2492,3 +2492,67 @@ TEST_F(Bytecode1, DynarrayLength2) {
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
+
+TEST_F(Bytecode1, StringLiteral2String) {
+
+    char inpl[] = "\
+        internalstring autoptr builtin managed struct String    \n\
+        {};                     \n\
+                                \n\
+        struct StructWithString \n\
+        {                       \n\
+            String Txt;         \n\
+        };                      \n\
+                                \n\
+        int func1()             \n\
+        {                       \n\
+            StructWithString a; \n\
+            a.Txt = \"Cause bug!\"; \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("StringLiteral2String", scrip);
+
+    size_t const codesize = 26;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            0,   29,    3,    6,    // 7
+       3,    0,   51,    4,           64,    3,   47,    3,    // 15
+      51,    4,   49,    2,            1,    4,    6,    3,    // 23
+       0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 1;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+       9,  -999
+    };
+    char fixuptypes[] = {
+      3,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 11;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+
+    char strings[] = {
+    'C',  'a',  'u',  's',          'e',  ' ',  'b',  'u',     // 7
+    'g',  '!',    0,  '\0'
+    };
+    CompareStrings(&scrip, stringssize, strings);
+}


### PR DESCRIPTION
This fix addresses #1312.

When a `string` literal is assigned to a `String`, a `string`-to-`String` conversion should be emitted before the assignment is emitted. Wasn't when compiling the following AGS code:
```
struct Stru {
  String Txt;
};

void game_start()
{
  Stru a;
  a.Txt = "Cause bug!";
}
```

Root cause: Parameters for `ConvertAXStringToStringObject()` were named differently in `parser.h` and `parser.cpp`; because of this confusion, this function was called incorrectly in one place.

This PR fixes the bug and adds a googletest.