### PR TITLE
CI: add compiler2 tests in ags4 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -315,11 +315,16 @@ ags_windows_tests_task:
   env:
     BUILD_CONFIG: Release
   get_submodule_script: git submodule update --init Common/libsrc/googletest
-  build_compiler_test_runner_script: >
+  build_legacy_compiler_test_runner_script: >
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
     cd Solutions &&
     msbuild Compiler.Lib.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform=Win32 /maxcpucount /nologo
-  run_compiler_tests_script: Solutions\.test\Release\Compiler.Lib.Test.exe
+  run_legacy_compiler_tests_script: Solutions\.test\Release\Compiler.Lib.Test.exe
+  build_new_compiler_test_runner_script: >
+    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    cd Solutions &&
+    msbuild Compiler2.Lib.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform=Win32 /maxcpucount /nologo
+  run_new_compiler_tests_script: Solutions\.test\Release\Compiler2.Lib.Test.exe
   build_ags_test_runner_script: >
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
     cd Solutions &&

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
@@ -83,7 +83,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Compiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Compiler2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
fix #1217 

- builds and tests new compiler in CI in ags4 branch
- fix small typo in the test vcxproj for the new compiler

**NOTE: there's a test current failing in `cc_parser_test_1.cpp`, under `TEST_F(Compile1, FloatInt2)`**

I could allow failure tolerance if desired (https://cirrus-ci.org/guide/writing-tasks/#failure-toleration) but it would still break flow on the specific task.