### PR TITLE
New compiler: Fix bug: Error() called with bad parameter. Also fix dependency in Compiler2.Lib.Test

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2321,7 +2321,7 @@ AGS::ErrorType AGS::Parser::ParseExpression_PrefixNegate(Symbol op_sym, SrcList 
         Error(
             "Expected an integer expression after '%s' but found type %s",
             _sym.GetName(op_sym).c_str(),
-            _sym.GetName(vartype));
+            _sym.GetName(vartype).c_str());
         return kERR_UserError;
     }
 

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
@@ -83,7 +83,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Compiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Compiler2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\.lib\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
This addresses a bug that surfaced in #1314. 

The compiler test library throws an SEH exception for the googletest "Compile1/FloatInt2"; but only when compiled in "Release" build, not when compiled in "Debug" build.

Root cause is that the function `Error()`, a `printf()` lookalike, is called in one place with a `std::string` parameter instead of a `C` string parameter. 

Also, the solution `Compiler2.Lib.Test` has an additional dependency on `Compiler.Lib` for the `Release` build. That should read `Compiler2.Lib`.