### PR TITLE
New compiler: Receive and show compiler warnings in Editor

### DIFF
--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -14,17 +14,12 @@
 
 // A  wrapper around cc_compile(), in order to squeeze the C++ style parameters 
 // through the limited means of Managed C++ (CLR) into the C# Editor.
-ccScript *ccCompileText2(char const *script, char const *scriptName, long const options)
+ccScript *ccCompileText2(std::string const &script, std::string const &scriptName, long const options, MessageHandler &mh)
 {
-    // All warnings and the error (if present) end up here.
-    // TODO: This is what will need to be sqeezed through the interface
-    // into the editor so that the editor can display the warnings, too
-    MessageHandler mh;
-
     ccCompiledScript *compiled_script =
         new ccCompiledScript(FlagIsSet(options, SCOPT_LINENUMBERS));
 
-    compiled_script->StartNewSection(scriptName ? scriptName : "Unnamed script");
+    compiled_script->StartNewSection(scriptName.empty() ? scriptName : "Unnamed script");
     int const error_code = cc_compile(script, options, *compiled_script, mh);
     if (error_code < 0)
     {

--- a/Compiler/script2/cs_compiler.h
+++ b/Compiler/script2/cs_compiler.h
@@ -1,22 +1,22 @@
 /*
-** 'C'-style script compiler
-** Copyright (C) 2000-2001, Chris Jones
-** All Rights Reserved.
-**
-** This is UNPUBLISHED PROPRIETARY SOURCE CODE;
-** the contents of this file may not be disclosed to third parties,
-** copied or duplicated in any form, in whole or in part, without
-** prior express permission from Chris Jones.
-**
+// 'C'-style script compiler
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
 */
 
 #ifndef __CS_COMPILER2_H
 #define __CS_COMPILER2_H
+
 #include "script/cc_script.h"
-// ********* SCRIPT COMPILATION FUNCTIONS **************
+#include "cs_message_handler.h"
 
 // compile the script supplied, returns nullptr on failure
 // cc_error() gets called.
-extern ccScript *ccCompileText2(char const *script, char const *scriptName, long options);
+extern ccScript *ccCompileText2(std::string const &script, std::string const &scriptName, long options, MessageHandler &mh);
 
 #endif // __CS_COMPILER2_H

--- a/Compiler/script2/cs_message_handler.cpp
+++ b/Compiler/script2/cs_message_handler.cpp
@@ -1,5 +1,5 @@
 
-#include "cs_parser_common.h"
+#include "cs_message_handler.h"
 
 AGS::MessageHandler::Entry::Entry(enum Severity sev, std::string const &section, size_t lineno, std::string const &msg)
     : Severity(sev)
@@ -10,10 +10,3 @@ AGS::MessageHandler::Entry::Entry(enum Severity sev, std::string const &section,
 }
 
 AGS::MessageHandler::Entry AGS::MessageHandler::_noError = { AGS::MessageHandler::kSV_Error, "", 0u, "((no error))" };
-
-AGS::MessageHandler::Entry const &AGS::MessageHandler::GetError(void) const
-{
-    if (_entries.empty() || kSV_Error != _entries.back().Severity)
-        return _noError;
-    return _entries.back();
-}

--- a/Compiler/script2/cs_message_handler.h
+++ b/Compiler/script2/cs_message_handler.h
@@ -1,0 +1,49 @@
+#ifndef __CS_MESSAGE_HANDLER_H
+#define __CS_MESSAGE_HANDLER_H
+
+#include <string>
+#include <vector>
+
+namespace AGS
+{
+
+class MessageHandler
+{
+public:
+    enum Severity
+    {
+        kSV_None,
+        kSV_Info,
+        kSV_Warning,
+        kSV_Error,
+    };
+
+    struct Entry
+    {
+        Severity Severity = kSV_Error;
+        std::string Section = "";
+        size_t Lineno = 0u;
+        std::string Message = "";
+
+        Entry() = default;
+        Entry(enum Severity sev, std::string const &section, size_t lineno, std::string const &msg);
+    };
+
+    typedef std::vector<Entry> MessagesType;
+
+private:
+    MessagesType _entries;
+    static Entry _noError;
+
+public:
+    inline void AddMessage(Severity sev, std::string const &sec, size_t line, std::string const &msg)
+        { _entries.emplace_back(sev, sec, line, msg); }
+    inline MessagesType GetMessages() const { return _entries; }
+    inline void Clear() { _entries.clear(); }
+    bool HasError() const { return !_entries.empty() && kSV_Error == _entries.back().Severity; }
+    Entry const &GetError() const { return HasError() ? _entries.back() : _noError; }
+};
+
+} // namespace AGS
+
+#endif

--- a/Compiler/script2/cs_parser_common.h
+++ b/Compiler/script2/cs_parser_common.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "cs_message_handler.h"
+
 namespace AGS
 {
 typedef int Symbol; // A symbol (result of scanner preprocessing)
@@ -38,42 +40,6 @@ enum ErrorType
     kERR_None = 0,
     kERR_UserError = -1,
     kERR_InternalError = -99,
-};
-
-class MessageHandler
-{
-public:
-    enum Severity
-    {
-        kSV_None,
-        kSV_Info,
-        kSV_Warning,
-        kSV_Error,
-    };
-
-    struct Entry
-    {
-        Severity Severity = kSV_Error;
-        std::string Section = "";
-        size_t Lineno = 0u;
-        std::string Message = "";
-
-        Entry() = default;
-        Entry(enum Severity sev, std::string const &section, size_t lineno, std::string const &msg);
-    };
-
-    typedef std::vector<Entry> MessagesType;
-
-private:
-    MessagesType _entries;
-    static Entry _noError;
-
-public:
-    inline void AddMessage(Severity sev, std::string const &sec, size_t line, std::string const &msg)
-        {_entries.emplace_back(sev, sec, line, msg); }
-    inline MessagesType GetMessages() const { return _entries; }
-    inline void Clear() { _entries.clear(); }
-    Entry const &GetError() const;
 };
 
 } // namespace AGS

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -609,7 +609,11 @@ namespace AGS.Editor.Components
             Room room = (Room)parameter;
             _agsEditor.RegenerateScriptHeader(room);
             List<Script> headers = (List<Script>)_agsEditor.GetAllScriptHeaders();
-            _agsEditor.CompileScript(room.Script, headers, null);
+            CompileMessages messages = new CompileMessages();
+            _agsEditor.CompileScript(room.Script, headers, messages);
+            if (messages.HasErrors)
+                throw messages.Errors[0];
+
             ((IRoomController)this).Save();
 
             return null;            

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -286,9 +286,9 @@ namespace AGS.Editor
             return _native.LoadRoomScript(roomFileName);
         }
 
-        public void CompileScript(Script script, string[] preProcessedData, Game game)
+        public void CompileScript(Script script, string[] preProcessedData, Game game, CompileMessages messages)
         {
-            _native.CompileScript(script, preProcessedData, game);
+            _native.CompileScript(script, preProcessedData, game, messages);
         }
 
         public void CreateDataFile(string[] fileList, int splitSize, string baseFileName, bool isGameEXE)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -66,7 +66,7 @@ namespace AGS
       void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
 			String ^LoadRoomScript(String ^roomFileName);
-			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game);
+			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, CompileMessages ^errors);
 			void CreateDataFile(cli::array<String^> ^fileList, long splitSize, String ^baseFileName, bool isGameEXE);
 			void CreateVOXFile(String ^fileName, cli::array<String^> ^fileList);
 			GameTemplate^ LoadTemplateFile(String ^fileName);

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj
@@ -170,7 +170,7 @@
     <ClCompile Include="..\..\Compiler\script2\cs_compiler.cpp" />
     <ClCompile Include="..\..\Compiler\script2\cs_compile_time.cpp" />
     <ClCompile Include="..\..\Compiler\script2\cs_parser.cpp" />
-    <ClCompile Include="..\..\Compiler\script2\cs_parser_common.cpp" />
+    <ClCompile Include="..\..\Compiler\script2\cs_message_handler.cpp" />
     <ClCompile Include="..\..\Compiler\script2\cs_scanner.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -184,6 +184,7 @@
     <ClInclude Include="..\..\Compiler\script2\cc_symboltable.h" />
     <ClInclude Include="..\..\Compiler\script2\cs_compile_time.h" />
     <ClInclude Include="..\..\Compiler\script2\cs_compiler.h" />
+    <ClInclude Include="..\..\Compiler\script2\cs_message_handler.h" />
     <ClInclude Include="..\..\Compiler\script2\cs_parser.h" />
     <ClInclude Include="..\..\Compiler\script2\cs_parser_common.h" />
     <ClInclude Include="..\..\Compiler\script2\cs_scanner.h" />

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj.filters
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj.filters
@@ -13,9 +13,6 @@
     <ClCompile Include="..\..\Common\util\string.cpp">
       <Filter>Source Files\cs</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Compiler\script2\cs_parser_common.cpp">
-      <Filter>Source Files\script</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Compiler\script2\cc_compiledscript.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
@@ -35,6 +32,9 @@
       <Filter>Source Files\script</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Compiler\script2\cs_compile_time.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Compiler\script2\cs_message_handler.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
   </ItemGroup>
@@ -76,6 +76,9 @@
       <Filter>Header Files\script</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Compiler\script2\cs_compile_time.h">
+      <Filter>Header Files\script</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Compiler\script2\cs_message_handler.h">
       <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Please test before integrating
I tried hard to keep all the other behaviour as before, but you never know.
-----
The new compiler has generated warnings under certain circumstances that were invisible because they didn't reach the Editor. Typical example: A header file has:
```
import function Foo(float f = 0);
```
The old compiler treats '0' as a special case and lets this through. The new compiler does likewise but warns that this default value is an integer and so putting `0.0` would be preferable.

This PR makes those compiler warnings show up in the Editor. Warnings don't terminate the compilation run (but errors do, of course.)
As a side effect, this PR improves compilation times a bit.

-----
Specific changes:
New compiler:
- `ccCompileText2()`, add parameter for messages
- Move message handler into dedicated `cc_message_handler.cpp/.h`
- cs_compiler.h, change "THIS IS PROPRIETARY CODE" comment to Artistic License verbiage.

Editor / AGS.Native:
- `CompileScript()` , add parameter for messages; don't throw on compiler error
- `CompileScript()`, call new compiler in a way that gets warnings as well as error (old compiler still works as before)

Editor / AGS.Editor:
- Don't throw on compiler error.
- Aggregate messages in `CompileScripts()` instead of `CompileMessages()`
- RoomsComponent.cs, adapt to new behaviour of `CompileMessages()`