### PR TITLE
New compiler: Bug fix: Disallow "this" parameter for static extender function

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1083,6 +1083,11 @@ AGS::ErrorType AGS::Parser::ParseDynArrayMarkerIfPresent(Vartype &vartype)
 // We'll accept something like "this Character *"
 AGS::ErrorType AGS::Parser::ParseFuncdecl_ExtenderPreparations(bool is_static_extender, Symbol &strct, Symbol &unqualified_name, TypeQualifierSet &tqs)
 {
+    if (tqs[TQ::kStatic])
+    {
+        ErrorType retval = Expect(kKW_Static, _src.PeekNext());
+        if (retval < 0) return retval;
+    }
     if (is_static_extender)
         tqs[TQ::kStatic] = true;
 
@@ -6277,6 +6282,7 @@ AGS::ErrorType AGS::Parser::ParseVartype_FuncDecl(TypeQualifierSet tqs, Vartype 
             Error("Can't use extender syntax with a function name that follows '::'");
             return kERR_UserError;
         }
+
         // Rewrite extender function as a component function of the corresponding struct.
         ErrorType retval = ParseFuncdecl_ExtenderPreparations(func_is_static_extender, struct_name, func_name, tqs);
         if (retval < 0) return retval;

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1913,3 +1913,22 @@ TEST_F(Compile1, CompileTimeConstant6)
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("in use"));
 }
+
+TEST_F(Compile1, StaticThisExtender)
+{
+    // A 'static' extender function cannot have a 'this'.
+    // This declaration should be written
+    //     "import int foo (static Struct);"
+
+    char *inpl = "\
+        managed struct Struct                   \n\
+        {                                       \n\
+            int Payload;                        \n\
+        };                                      \n\
+        import static int Foo(this Struct *);   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'static'"));
+}


### PR DESCRIPTION
The new compiler let through:
```import static int Foo(this Bar *);```

Judging from the `static` keyword, the function `Foo()` must be static, but in this case it doesn't have any `this` pointer, which collides with `this Bar *` part. So this declaration is nonsensical.  This PR makes the compiler balk if whenever encounters that kind of code.

(The correct way of declaring a static extender function would be `import int Foo(static Bar);`).