### PR TITLE
Partial Unicode support in the engine (UTF-8 translations)

### DIFF
--- a/Common/ac/keycode.h
+++ b/Common/ac/keycode.h
@@ -19,6 +19,7 @@
 #define __AGS_EE_AC__KEYCODE_H
 
 #include "core/platform.h"
+#include "core/types.h"
 
 #define EXTENDED_KEY_CODE ('\0')
 #define EXTENDED_KEY_CODE_MACOS ('?')
@@ -243,6 +244,18 @@ enum eAGSKeyCode
     case 425: __allegro_KEY_NUMLOCK
     case 426: __allegro_KEY_CAPSLOCK
     */
+};
+
+
+// Combined key code and a textual representation in UTF-8
+struct KeyInput
+{
+    const static size_t UTF8_ARR_SIZE = 5;
+
+    eAGSKeyCode Key = eAGSKeyCodeNone;
+    char        Text[UTF8_ARR_SIZE] = { 0 };
+
+    KeyInput() = default;
 };
 
 

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -205,6 +205,8 @@ void unescape_script_string(const char *cstr, std::vector<char> &out)
         cstr++;
     }
     // Replace all other occurrences as they're found
+    // NOTE: we do not need to decode utf8 here, because
+    // we are only searching for low-code ascii chars.
     const char *off;
     for (off = cstr; *off; ++off)
     {
@@ -241,67 +243,77 @@ size_t split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, siz
     unescape_script_string(todis, lines.LineBuf);
     char *theline = &lines.LineBuf.front();
 
-    size_t i = 0;
-    size_t splitAt;
-    char nextCharWas;
+    char *scan_ptr = theline;
+    char *prev_ptr = theline;
+    char *last_whitespace = nullptr;
     while (1) {
-        splitAt = -1;
+        char *split_at = nullptr;
 
-        if (theline[i] == 0) {
+        if (*scan_ptr == 0) {
             // end of the text, add the last line if necessary
-            if (i > 0) {
+            if (scan_ptr > theline) {
                 lines.Add(theline);
             }
             break;
         }
 
-        // temporarily terminate the line here and test its width
-        nextCharWas = theline[i + 1];
-        theline[i + 1] = 0;
+        if (*scan_ptr == ' ')
+            last_whitespace = scan_ptr;
 
         // force end of line with the \n character
-        if (theline[i] == '\n')
-            splitAt = i;
+        if (*scan_ptr == '\n') {
+            split_at = scan_ptr;
         // otherwise, see if we are too wide
-        else if (wgettextwidth_compensate(theline, fonnt) > wii) {
-            int endline = i;
-            while ((theline[endline] != ' ') && (endline > 0))
-                endline--;
+        } else {
+            // temporarily terminate the line in the *next* char and test its width
+            char *next_ptr = scan_ptr;
+            ugetx(&next_ptr);
+            const int next_chwas = ugetc(next_ptr);
+            *next_ptr = 0;
 
-            // single very wide word, display as much as possible
-            if (endline == 0)
-                endline = i - 1;
+            if (wgettextwidth_compensate(theline, fonnt) > wii) {
+                // line is too wide, order the split
+                if (last_whitespace)
+                    // revert to the last whitespace
+                    split_at = last_whitespace;
+                else
+                    // single very wide word, display as much as possible
+                    split_at = prev_ptr;
+            }
 
-            splitAt = endline;
+            // restore the character that was there before
+            usetc(next_ptr, next_chwas);
         }
 
-        // restore the character that was there before
-        theline[i + 1] = nextCharWas;
-
-        if (splitAt != -1) {
-            if (splitAt == 0 && !((theline[0] == ' ') || (theline[0] == '\n'))) {
+        if (split_at == nullptr) {
+            prev_ptr = scan_ptr;
+            ugetx(&scan_ptr);
+        } else {
+            // check if even one char cannot fit...
+            if (split_at == theline && !((*theline == ' ') || (*theline == '\n'))) {
               // cannot split with current width restriction
               lines.Reset();
               break;
             }
-            // add this line
-            nextCharWas = theline[splitAt];
-            theline[splitAt] = 0;
+            // add this line; do the temporary terminator trick again
+            const int next_chwas = *split_at;
+            *split_at = 0;
             lines.Add(theline);
-            theline[splitAt] = nextCharWas;
+            usetc(split_at, next_chwas);
+            // check if too many lines
             if (lines.Count() >= max_lines) {
                 lines[lines.Count() - 1].Append("...");
                 break;
             }
-            // the next line starts from here
-            theline += splitAt;
+            // the next line starts from the split point
+            theline = split_at;
             // skip the space or new line that caused the line break
-            if ((theline[0] == ' ') || (theline[0] == '\n'))
+            if ((*theline == ' ') || (*theline == '\n'))
                 theline++;
-            i = -1;
+            scan_ptr = theline;
+            prev_ptr = theline;
+            last_whitespace = nullptr;
         }
-
-        i++;
     }
     return lines.Count();
 }

--- a/Common/game/tra_file.h
+++ b/Common/game/tra_file.h
@@ -64,6 +64,7 @@ struct Translation
     int NormalFont = -1; // replacement for normal font, or -1 for default
     int SpeechFont = -1; // replacement for speech font, or -1 for default
     int RightToLeft = -1; // r2l text mode (1, 2), or -1 for default
+    StringMap StrOptions; // to store extended options with string values
 };
 
 

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -25,7 +25,7 @@
 #define GUIDIS_UNCHANGED 4
 #define GUIDIS_GUIOFF  0x80
 
-
+struct KeyInput;
 
 
 namespace AGS
@@ -68,7 +68,7 @@ public:
 
     // Events
     // Key pressed for control
-    virtual void    OnKeyPress(int keycode) { }
+    virtual void    OnKeyPress(const KeyInput &ki) { }
     // Mouse button down - return 'True' to lock focus
     virtual bool    OnMouseDown() { return false; }
     // Mouse moves onto control

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -60,8 +60,9 @@ void GUITextBox::Draw(Bitmap *ds)
     DrawTextBoxContents(ds, text_color);
 }
 
-void GUITextBox::OnKeyPress(int keycode)
+void GUITextBox::OnKeyPress(const KeyInput &ki)
 {
+    eAGSKeyCode keycode = ki.Key;
     // other key, continue
     if ((keycode >= 128) && (!font_supports_extended_characters(Font)))
         return;

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -60,6 +60,22 @@ void GUITextBox::Draw(Bitmap *ds)
     DrawTextBoxContents(ds, text_color);
 }
 
+// TODO: a shared utility function
+static void Backspace(String &text)
+{
+    if (get_uformat() == U_UTF8)
+    {// Find where the last utf8 char begins
+        const char *ptr_end = text.GetCStr() + text.GetLength();
+        const char *ptr = ptr_end - 1;
+        for (; ptr > text.GetCStr() && ((*ptr & 0xC0) == 0x80); --ptr);
+        text.ClipRight(ptr_end - ptr);
+    }
+    else
+    {
+        text.ClipRight(1);
+    }
+}
+
 void GUITextBox::OnKeyPress(const KeyInput &ki)
 {
     eAGSKeyCode keycode = ki.Key;
@@ -71,7 +87,7 @@ void GUITextBox::OnKeyPress(const KeyInput &ki)
     // backspace, remove character
     if (keycode == eAGSKeyCodeBackspace)
     {
-        Text.ClipRight(1);
+        Backspace(Text);
         return;
     }
     // return/enter
@@ -81,10 +97,12 @@ void GUITextBox::OnKeyPress(const KeyInput &ki)
         return;
     }
 
-    Text.AppendChar(keycode);
+    (get_uformat() == U_UTF8) ?
+        Text.Append(ki.Text) :
+        Text.AppendChar(keycode);
     // if the new string is too long, remove the new character
     if (wgettextwidth(Text.GetCStr(), Font) > (Width - (6 + get_fixed_pixel_size(5))))
-        Text.ClipRight(1);
+        Backspace(Text);
 }
 
 void GUITextBox::SetShowBorder(bool on)

--- a/Common/gui/guitextbox.h
+++ b/Common/gui/guitextbox.h
@@ -36,7 +36,7 @@ public:
     void SetShowBorder(bool on);
  
     // Events
-    void OnKeyPress(int keycode) override;
+    void OnKeyPress(const KeyInput &ki) override;
  
     // Serialization
     void ReadFromFile(Stream *in, GuiVersion gui_version) override;

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -811,6 +811,32 @@ void String::Reverse()
     }
 }
 
+void String::ReverseUTF8()
+{
+    if (_len <= 1)
+        return; // nothing to reverse if 1 char or less
+    // TODO: may this be optimized to not alloc new buffer? or dont care
+    char *newstr = new char[_len + 1];
+    for (char *fw = _cstr, *fw2 = _cstr + 1,
+              *bw = _cstr + _len - 1, *bw2 = _cstr + _len;
+        fw <= bw; // FIXME: <= catches odd middle char, optimize?
+        fw = fw2++, bw2 = bw--)
+    {
+        // find end of next character forwards
+        for (; (fw2 < bw) && ((*fw2 & 0xC0) == 0x80); ++fw2);
+        // find beginning of the prev character backwards
+        for (; (bw > fw) && ((*bw & 0xC0) == 0x80); --bw);
+        // put these in opposite sides on the new buffer
+        char *fw_place = newstr + (_cstr + _len - bw2);
+        char *bw_place = newstr + _len - (fw2 - _cstr);
+        memcpy(fw_place, bw, bw2 - bw);
+        if (fw != bw) // FIXME, optimize?
+            memcpy(bw_place, fw, fw2 - fw);
+    }
+    newstr[_len] = 0;
+    SetString(newstr);
+}
+
 void String::SetAt(size_t index, char c)
 {
     if ((index < _len) && c)

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -312,6 +312,10 @@ public:
             { String str = String::Wrapper(cstr); ReplaceMid(from, count, str); }
     // Reverses the string
     void    Reverse();
+    // Reverse the multibyte unicode string
+    // FIXME: name? invent some consistent naming for necessary multibyte funcs,
+    // proper utf8 support where necessary
+    void    ReverseUTF8();
     // Overwrite the Nth character of the string; does not change string's length
     void    SetAt(size_t index, char c);
     // Makes a new string by copying up to N chars from C-string

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -213,5 +213,26 @@ void StrUtil::WriteCStr(const String &s, Stream *out)
     out->Write(s.GetCStr(), s.GetLength() + 1);
 }
 
+void StrUtil::ReadStringMap(StringMap &map, Stream *in)
+{
+    size_t count = in->ReadInt32();
+    for (size_t i = 0; i < count; ++i)
+    {
+        String key = StrUtil::ReadString(in);
+        String value = StrUtil::ReadString(in);
+        map.insert(std::make_pair(key, value));
+    }
+}
+
+void StrUtil::WriteStringMap(const StringMap &map, Stream *out)
+{
+    out->WriteInt32(map.size());
+    for (const auto &kv : map)
+    {
+        StrUtil::WriteString(kv.first, out);
+        StrUtil::WriteString(kv.second, out);
+    }
+}
+
 } // namespace Common
 } // namespace AGS

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -18,7 +18,7 @@
 #ifndef __AGS_CN_UTIL__STRINGUTILS_H
 #define __AGS_CN_UTIL__STRINGUTILS_H
 
-#include "util/string.h"
+#include "util/string_types.h"
 
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
@@ -72,6 +72,10 @@ namespace StrUtil
     void            SkipCStr(Stream *in);
     void            WriteCStr(const char *cstr, Stream *out);
     void            WriteCStr(const String &s, Stream *out);
+
+    // Serialize and unserialize a string map, both keys and values are read using ReadString
+    void            ReadStringMap(StringMap &map, Stream *in);
+    void            WriteStringMap(const StringMap &map, Stream *out);
 }
 } // namespace Common
 } // namespace AGS

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -25,6 +25,7 @@ namespace AGS.Editor.Components
         private const int TRANSLATION_BLOCK_TRANSLATION_DATA = 1;
         private const int TRANSLATION_BLOCK_GAME_ID = 2;
         private const int TRANSLATION_BLOCK_OPTIONS = 3;
+        private const string TRANSLATION_BLOCK_STROPTIONS = "ext_sopts";
         private const int TRANSLATION_BLOCK_END_OF_FILE = -1;
 
 //        private Dictionary<AGS.Types.Font, ContentDocument> _documents;
@@ -131,6 +132,20 @@ namespace AGS.Editor.Components
                 bw.Write(translation.NormalFont ?? -1);
                 bw.Write(translation.SpeechFont ?? -1);
                 bw.Write((translation.RightToLeftText == true) ? 2 : ((translation.RightToLeftText == false) ? 1 : -1));
+
+                bw.Write((int)0); // required for compatibility
+                DataFileWriter.WriteString(TRANSLATION_BLOCK_STROPTIONS, 16, bw);
+                var data_len_pos = bw.BaseStream.Position;
+                bw.Write((long)0); // data length placeholder
+                bw.Write((int)1); // size of key/value table
+                DataFileWriter.FilePutString("encoding", bw);
+                DataFileWriter.FilePutString(translation.TextEncoding, bw);
+                var end_pos = bw.BaseStream.Position;
+                var data_len = end_pos - data_len_pos - 8;
+                bw.Seek((int)data_len_pos, SeekOrigin.Begin);
+                bw.Write(data_len);
+                bw.Seek((int)end_pos, SeekOrigin.Begin);
+
                 bw.Write(TRANSLATION_BLOCK_END_OF_FILE);
                 bw.Write((int)0);
                 bw.Seek((int)offsetOfBlockSize, SeekOrigin.Begin);

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -137,9 +137,11 @@ namespace AGS.Editor.Components
                 DataFileWriter.WriteString(TRANSLATION_BLOCK_STROPTIONS, 16, bw);
                 var data_len_pos = bw.BaseStream.Position;
                 bw.Write((long)0); // data length placeholder
-                bw.Write((int)1); // size of key/value table
+                bw.Write((int)2); // size of key/value table
                 DataFileWriter.FilePutString("encoding", bw);
-                DataFileWriter.FilePutString(translation.TextEncoding, bw);
+                DataFileWriter.FilePutString(translation.EncodingHint, bw);
+                DataFileWriter.FilePutString("gameencoding", bw);
+                DataFileWriter.FilePutString(translation.GameEncodingHint, bw);
                 var end_pos = bw.BaseStream.Position;
                 var data_len = end_pos - data_len_pos - 8;
                 bw.Seek((int)data_len_pos, SeekOrigin.Begin);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -49,7 +49,7 @@ namespace AGS.Editor
         // be exactly 'fixed_length' in size. In such case the larger string
         // gets truncated, and in case of shorter string all the unused bytes
         // are zeroed. No null terminator is appended explicitly though.
-        private static byte[] GetAnsiBytes(string text, int fixed_length)
+        public static byte[] GetAnsiBytes(string text, int fixed_length)
         {
             return GetAnsiBytes(text, fixed_length, fixed_length, 0);
         }
@@ -63,7 +63,7 @@ namespace AGS.Editor
         // If converted string appears larger than array is allowed to accomodate,
         // then it gets truncated; if it is shorter, all the unused bytes are
         // zeroed.
-        private static byte[] GetAnsiBytes(string text, int min_size, int max_size, int reserve_bytes)
+        public static byte[] GetAnsiBytes(string text, int min_size, int max_size, int reserve_bytes)
         {
             // We must convert original Unicode string into ANSI string,
             // because AGS engine currently supports only these.
@@ -228,7 +228,7 @@ namespace AGS.Editor
         /// </summary>
         /// <param name="text"></param>
         /// <param name="writer"></param>
-        static void FilePutString(string text, BinaryWriter writer)
+        public static void FilePutString(string text, BinaryWriter writer)
         {
             if (String.IsNullOrEmpty(text))
                 writer.Write((int)0);
@@ -636,7 +636,7 @@ namespace AGS.Editor
         /// Writes a string to the file as bytes. Length must be provided
         /// and will pad or truncate the text as necessary.
         /// </summary>
-        private static void WriteString(string src, int length, BinaryWriter writer)
+        public static void WriteString(string src, int length, BinaryWriter writer)
         {
             if ((writer == null) || (length <= 0)) return;
             byte[] bytes = GetAnsiBytes(src, length);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -445,11 +445,6 @@ namespace AGS.Editor
             get { return _native.HaveSpritesBeenModified(); }
         }
 
-        public byte[] TransformStringToBytes(string text)
-        {
-            return _native.TransformStringToBytes(text);
-        }
-
         /// <summary>
         /// Allows the Editor to reuse constants from the native code. If a constant required by the Editor
         /// is not also required by the Engine, then it should instead by moved into AGS.Types (AGS.Native

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -627,27 +627,6 @@ namespace AGS
 				throw gcnew AGSEditorException("Unable to extract template files.\n" + ToStr(err->FullMessage()));
 			}
 		}
-				
-		cli::array<unsigned char>^ NativeMethods::TransformStringToBytes(String ^text) 
-		{
-			char* stringPointer = (char*)Marshal::StringToHGlobalAnsi(text).ToPointer();
-			int textLength = text->Length + 1;
-			cli::array<unsigned char>^ toReturn = gcnew cli::array<unsigned char>(textLength + 4);
-			toReturn[0] = textLength % 256;
-			toReturn[1] = textLength / 256;
-			toReturn[2] = 0;
-			toReturn[3] = 0;
-	
-			transform_string(stringPointer);
-
-			{ pin_ptr<unsigned char> nativeBytes = &toReturn[4];
-				memcpy(nativeBytes, stringPointer, textLength);
-			}
-
-			Marshal::FreeHGlobal(IntPtr(stringPointer));
-
-			return toReturn;
-		}
 
 		bool NativeMethods::HaveSpritesBeenModified()
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -93,7 +93,6 @@ namespace AGS
       void UpdateGameExplorerXML(String ^fileToUpdate, cli::array<unsigned char> ^data);
       void UpdateGameExplorerThumbnail(String ^fileToUpdate, cli::array<unsigned char> ^data);
       void UpdateFileVersionInfo(String ^fileToUpdate, cli::array<System::Byte> ^authorNameUnicode, cli::array<System::Byte> ^gameNameUnicode);
-			cli::array<unsigned char>^ TransformStringToBytes(String ^text);
 			bool HaveSpritesBeenModified();
             Object^ GetNativeConstant(String ^name);
 		};

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1167,11 +1167,12 @@ void new_font () {
 
 bool initialize_native()
 {
+    set_uformat(U_ASCII);  // required to stop ALFONT screwing up text
+    install_allegro(SYSTEM_NONE, &errno, atexit);
+
     AssetMgr.reset(new AssetManager());
     AssetMgr->AddLibrary("."); // TODO: this is for search in editor program folder, but maybe don't use implicit cwd?
 
-	set_uformat(U_ASCII);  // required to stop ALFONT screwing up text
-	install_allegro(SYSTEM_NONE, &errno, atexit);
 	//set_gdi_color_format();
 	palette = &thisgame.defpal[0];
 	thisgame.color_depth = 2;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -250,10 +250,6 @@ int GetPaletteAsHPalette() {
   return (int)convert_palette_to_hpalette(palette);
 }
 
-void transform_string(char *text) {
-	encrypt_text(text);
-}
-
 int find_free_sprite_slot() {
   return spriteset.GetFreeIndex();
 }

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -14,6 +14,7 @@ namespace AGS.Types
         private const string NORMAL_FONT_TAG = "//#NormalFont=";
         private const string SPEECH_FONT_TAG = "//#SpeechFont=";
         private const string TEXT_DIRECTION_TAG = "//#TextDirection=";
+        private const string ENCODING_TAG = "//#Encoding=";
         private const string TAG_DEFAULT = "DEFAULT";
         private const string TAG_DIRECTION_LEFT = "LEFT";
         private const string TAG_DIRECTION_RIGHT = "RIGHT";
@@ -24,6 +25,7 @@ namespace AGS.Types
         private int? _normalFont;
         private int? _speechFont;
         private bool? _rightToLeftText;
+        private string _encoding;
         private Dictionary<string, string> _translatedLines;
 
         public Translation(string name)
@@ -33,6 +35,7 @@ namespace AGS.Types
             _normalFont = null;
             _speechFont = null;
             _rightToLeftText = null;
+            _encoding = null;
         }
 
         public string Name
@@ -70,6 +73,11 @@ namespace AGS.Types
         public bool? RightToLeftText
         {
             get { return _rightToLeftText; }
+        }
+
+        public string TextEncoding
+        {
+            get { return _encoding; }
         }
 
         public bool Modified
@@ -110,6 +118,8 @@ namespace AGS.Types
                 sw.WriteLine("//#SpeechFont=" + WriteOptionalInt(_speechFont));
                 sw.WriteLine("// Text direction - DEFAULT, LEFT or RIGHT");
                 sw.WriteLine("//#TextDirection=" + ((_rightToLeftText == true) ? TAG_DIRECTION_RIGHT : ((_rightToLeftText == null) ? TAG_DEFAULT : TAG_DIRECTION_LEFT)));
+                sw.WriteLine("// Text encoding hint");
+                sw.WriteLine("//#Encoding=" + (_encoding ?? "ASCII"));
                 sw.WriteLine("//  ");
                 sw.WriteLine("// ** REMEMBER, WRITE YOUR TRANSLATION IN THE EMPTY LINES, DO");
                 sw.WriteLine("// ** NOT CHANGE THE EXISTING TEXT.");
@@ -177,6 +187,10 @@ namespace AGS.Types
                 {
                     _rightToLeftText = null;
                 }
+            }
+            else if (line.StartsWith(ENCODING_TAG))
+            {
+                _encoding = line.Substring(ENCODING_TAG.Length);
             }
         }
 

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -153,7 +153,8 @@ namespace AGS.Types
                 sw.WriteLine("// Text encoding hint");
                 sw.WriteLine("//#Encoding=" + (_encodingHint ?? "ASCII"));
                 sw.WriteLine("// Source text encoding hint");
-                sw.WriteLine("//#GameEncoding=" + (_gameEncodingHint ?? ""));
+                sw.WriteLine("//#GameEncoding=" +
+                    (string.IsNullOrEmpty(_gameEncodingHint) ? ("." + Encoding.Default.CodePage) : _gameEncodingHint));
                 sw.WriteLine("//  ");
                 sw.WriteLine("// ** REMEMBER, WRITE YOUR TRANSLATION IN THE EMPTY LINES, DO");
                 sw.WriteLine("// ** NOT CHANGE THE EXISTING TEXT.");

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -38,9 +38,8 @@ namespace AGS.Types
             _normalFont = null;
             _speechFont = null;
             _rightToLeftText = null;
-            _encodingHint = null;
-            _gameEncodingHint = null;
-            _encoding = Encoding.Default;
+            _gameEncodingHint = "." + Encoding.Default.CodePage;
+            EncodingHint = "UTF-8";
         }
 
         public string Name

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -15,6 +15,7 @@ namespace AGS.Types
         private const string SPEECH_FONT_TAG = "//#SpeechFont=";
         private const string TEXT_DIRECTION_TAG = "//#TextDirection=";
         private const string ENCODING_TAG = "//#Encoding=";
+        private const string GAMEENCODING_TAG = "//#GameEncoding=";
         private const string TAG_DEFAULT = "DEFAULT";
         private const string TAG_DIRECTION_LEFT = "LEFT";
         private const string TAG_DIRECTION_RIGHT = "RIGHT";
@@ -25,7 +26,8 @@ namespace AGS.Types
         private int? _normalFont;
         private int? _speechFont;
         private bool? _rightToLeftText;
-        private string _encoding;
+        private string _encodingHint;
+        private string _gameEncodingHint;
         private Dictionary<string, string> _translatedLines;
 
         public Translation(string name)
@@ -35,7 +37,7 @@ namespace AGS.Types
             _normalFont = null;
             _speechFont = null;
             _rightToLeftText = null;
-            _encoding = null;
+            _encodingHint = null;
         }
 
         public string Name
@@ -75,9 +77,14 @@ namespace AGS.Types
             get { return _rightToLeftText; }
         }
 
-        public string TextEncoding
+        public string EncodingHint
         {
-            get { return _encoding; }
+            get { return _encodingHint; }
+        }
+
+        public string GameEncodingHint
+        {
+            get { return _gameEncodingHint; }
         }
 
         public bool Modified
@@ -119,7 +126,9 @@ namespace AGS.Types
                 sw.WriteLine("// Text direction - DEFAULT, LEFT or RIGHT");
                 sw.WriteLine("//#TextDirection=" + ((_rightToLeftText == true) ? TAG_DIRECTION_RIGHT : ((_rightToLeftText == null) ? TAG_DEFAULT : TAG_DIRECTION_LEFT)));
                 sw.WriteLine("// Text encoding hint");
-                sw.WriteLine("//#Encoding=" + (_encoding ?? "ASCII"));
+                sw.WriteLine("//#Encoding=" + (_encodingHint ?? "ASCII"));
+                sw.WriteLine("// Source text encoding hint");
+                sw.WriteLine("//#GameEncoding=" + (_gameEncodingHint ?? ""));
                 sw.WriteLine("//  ");
                 sw.WriteLine("// ** REMEMBER, WRITE YOUR TRANSLATION IN THE EMPTY LINES, DO");
                 sw.WriteLine("// ** NOT CHANGE THE EXISTING TEXT.");
@@ -188,9 +197,14 @@ namespace AGS.Types
                     _rightToLeftText = null;
                 }
             }
+            // TODO: make a generic dictionary instead and save any option
             else if (line.StartsWith(ENCODING_TAG))
             {
-                _encoding = line.Substring(ENCODING_TAG.Length);
+                _encodingHint = line.Substring(ENCODING_TAG.Length);
+            }
+            else if (line.StartsWith(GAMEENCODING_TAG))
+            {
+                _gameEncodingHint = line.Substring(GAMEENCODING_TAG.Length);
             }
         }
 

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -875,22 +875,27 @@ bool DialogOptions::Run()
         run_function_on_non_blocking_thread(&runDialogOptionRepExecFunc);
       }
 
-      int gkey;
-      if (run_service_key_controls(gkey) && !play.IsIgnoringInput()) {
+      KeyInput ki;
+      if (run_service_key_controls(ki) && !play.IsIgnoringInput()) {
+        eAGSKeyCode gkey = ki.Key;
         if (parserInput) {
           wantRefresh = true;
           // type into the parser 
+          // TODO: find out what are these key commands, and are these documented?
           if ((gkey == eAGSKeyCodeF3) || ((gkey == eAGSKeyCodeSpace) && (parserInput->Text.GetLength() == 0))) {
             // write previous contents into textbox (F3 or Space when box is empty)
-            for (unsigned int i = parserInput->Text.GetLength(); i < strlen(play.lastParserEntry); i++) {
-              parserInput->OnKeyPress(play.lastParserEntry[i]);
+            size_t last_len = strlen(play.lastParserEntry);
+            KeyInput ki;
+            for (unsigned int i = parserInput->Text.GetLength(); i < last_len; i++) {
+              ki.Key = (eAGSKeyCode)play.lastParserEntry[i];
+              parserInput->OnKeyPress(ki);
             }
             //ags_domouse(DOMOUSE_DISABLE);
             Redraw();
             return true; // continue running loop
           }
           else if ((gkey >= eAGSKeyCodeSpace) || (gkey == eAGSKeyCodeReturn) || (gkey == eAGSKeyCodeBackspace)) {
-            parserInput->OnKeyPress(gkey);
+            parserInput->OnKeyPress(ki);
             if (!parserInput->IsActivated) {
               //ags_domouse(DOMOUSE_DISABLE);
               Redraw();
@@ -908,9 +913,9 @@ bool DialogOptions::Run()
         else if (game.options[OPT_DIALOGNUMBERED] >= kDlgOptKeysOnly &&
                  gkey >= '1' && gkey <= '9')
         {
-          gkey -= '1';
-          if (gkey < numdisp) {
-            chose = disporder[gkey];
+          int numkey = gkey - '1';
+          if (numkey < numdisp) {
+            chose = disporder[numkey];
             return false; // end dialog options running loop
           }
         }

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -884,11 +884,16 @@ bool DialogOptions::Run()
           // TODO: find out what are these key commands, and are these documented?
           if ((gkey == eAGSKeyCodeF3) || ((gkey == eAGSKeyCodeSpace) && (parserInput->Text.GetLength() == 0))) {
             // write previous contents into textbox (F3 or Space when box is empty)
-            size_t last_len = strlen(play.lastParserEntry);
-            KeyInput ki;
-            for (unsigned int i = parserInput->Text.GetLength(); i < last_len; i++) {
-              ki.Key = (eAGSKeyCode)play.lastParserEntry[i];
-              parserInput->OnKeyPress(ki);
+            size_t last_len = ustrlen(play.lastParserEntry);
+            size_t cur_len = ustrlen(parserInput->Text.GetCStr());
+            // [ikm] CHECKME: tbh I don't quite get the logic here (it was like this in original code);
+            // but what we do is copying only the last part of the previous string
+            if (cur_len < last_len)
+            {
+              const char *entry = play.lastParserEntry;
+              // TODO: utility function for advancing N utf-8 chars
+              for (size_t i = 0; i < cur_len; ++i) ugetxc(&entry);
+              parserInput->Text.Append(entry);
             }
             //ags_domouse(DOMOUSE_DISABLE);
             Redraw();

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -283,9 +283,9 @@ int _display_main(int xx, int yy, int wii, const char *text, int disp_type, int 
                 if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
                     break;
             }
-            int kp;
+            KeyInput kp;
             if (run_service_key_controls(kp)) {
-                check_skip_cutscene_keypress (kp);
+                check_skip_cutscene_keypress (kp.Key);
                 if (play.fast_forward)
                     break;
                 if ((skip_setting & SKIP_KEYPRESS) && !play.IsIgnoringInput())

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -356,7 +356,7 @@ bool InventoryScreen::Run()
     // Run() can be called in a loop, so keep events going.
     sys_evt_process_pending();
 
-    int kgn;
+    KeyInput kgn;
     if (run_service_key_controls(kgn) && !play.IsIgnoringInput())
     {
         return false; // end inventory screen loop

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -270,7 +270,9 @@ size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, i
     // write it as normal
     if (game.options[OPT_RIGHTLEFTWRITE])
         for (size_t rr = 0; rr < lines.Count(); rr++) {
-            lines[rr].Reverse();
+            (get_uformat() == U_UTF8) ?
+                lines[rr].ReverseUTF8() :
+                lines[rr].Reverse();
             line_length = wgettextwidth_compensate(lines[rr].GetCStr(), fonnt);
             if (line_length > longestline)
                 longestline = line_length;

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -11,6 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include <algorithm>
 #include <cstdio>
 #include "ac/string.h"
 #include "ac/common.h"
@@ -58,39 +59,51 @@ const char* String_AppendChar(const char *thisString, char extraOne) {
 }
 
 const char* String_ReplaceCharAt(const char *thisString, int index, char newChar) {
-    if ((index < 0) || (index >= (int)strlen(thisString)))
+    size_t len = ustrlen(thisString);
+    if ((index < 0) || ((size_t)index >= len))
         quit("!String.ReplaceCharAt: index outside range of string");
 
-    char *buffer = (char*)malloc(strlen(thisString) + 1);
-    strcpy(buffer, thisString);
-    buffer[index] = newChar;
+    size_t off = uoffset(thisString, index);
+    int uchar = ugetc(thisString + off);
+    size_t remain_sz = strlen(thisString + off);
+    size_t old_sz = ucwidth(uchar);
+    size_t new_sz = sizeof(char); // TODO: support unicode char in API
+    size_t total_sz = off + remain_sz + new_sz - old_sz + 1;
+    char *buffer = (char*)malloc(total_sz);
+    memcpy(buffer, thisString, off);
+    usetc(buffer + off, newChar);
+    memcpy(buffer + off + new_sz, thisString + off + old_sz, remain_sz - old_sz + 1);
     return CreateNewScriptString(buffer, false);
 }
 
 const char* String_Truncate(const char *thisString, int length) {
     if (length < 0)
         quit("!String.Truncate: invalid length");
-
-    if (length >= (int)strlen(thisString))
-    {
+    size_t strlen = ustrlen(thisString);
+    if ((size_t)length >= strlen)
         return thisString;
-    }
 
-    char *buffer = (char*)malloc(length + 1);
-    strncpy(buffer, thisString, length);
-    buffer[length] = 0;
+    size_t sz = uoffset(thisString, length);
+    char *buffer = (char*)malloc(sz + 1);
+    memcpy(buffer, thisString, sz);
+    buffer[sz] = 0;
     return CreateNewScriptString(buffer, false);
 }
 
 const char* String_Substring(const char *thisString, int index, int length) {
     if (length < 0)
         quit("!String.Substring: invalid length");
-    if ((index < 0) || (index > (int)strlen(thisString)))
+    size_t strlen = ustrlen(thisString);
+    if ((index < 0) || ((size_t)index > strlen))
         quit("!String.Substring: invalid index");
+    size_t sublen = std::min((size_t)length, strlen - index);
+    size_t start = uoffset(thisString, index);
+    size_t end = uoffset(thisString + start, sublen) + start;
+    size_t copysz = end - start;
 
-    char *buffer = (char*)malloc(length + 1);
-    strncpy(buffer, &thisString[index], length);
-    buffer[length] = 0;
+    char *buffer = (char*)malloc(copysz + 1);
+    memcpy(buffer, thisString + start, copysz);
+    buffer[copysz] = 0;
     return CreateNewScriptString(buffer, false);
 }
 
@@ -100,7 +113,7 @@ int String_CompareTo(const char *thisString, const char *otherString, bool caseS
         return strcmp(thisString, otherString);
     }
     else {
-        return ags_stricmp(thisString, otherString);
+        return ustricmp(thisString, otherString);
     }
 }
 
@@ -110,75 +123,84 @@ int String_StartsWith(const char *thisString, const char *checkForString, bool c
         return (strncmp(thisString, checkForString, strlen(checkForString)) == 0) ? 1 : 0;
     }
     else {
-        return (ags_strnicmp(thisString, checkForString, strlen(checkForString)) == 0) ? 1 : 0;
+        return (ustrnicmp(thisString, checkForString, ustrlen(checkForString)) == 0) ? 1 : 0;
     }
 }
 
 int String_EndsWith(const char *thisString, const char *checkForString, bool caseSensitive) {
-
-    int checkAtOffset = strlen(thisString) - strlen(checkForString);
-
-    if (checkAtOffset < 0)
-    {
+    // NOTE: we need size in bytes here
+    size_t thislen = strlen(thisString), checklen = strlen(checkForString);
+    if (checklen > thislen)
         return 0;
-    }
 
     if (caseSensitive) 
     {
-        return (strcmp(&thisString[checkAtOffset], checkForString) == 0) ? 1 : 0;
+        return (strcmp(thisString + (thislen - checklen), checkForString) == 0) ? 1 : 0;
     }
     else 
     {
-        return (ags_stricmp(&thisString[checkAtOffset], checkForString) == 0) ? 1 : 0;
+        return (ustricmp(thisString + (thislen - checklen), checkForString) == 0) ? 1 : 0;
     }
 }
 
 const char* String_Replace(const char *thisString, const char *lookForText, const char *replaceWithText, bool caseSensitive)
 {
     char resultBuffer[STD_BUFFER_SIZE] = "";
-    int thisStringLen = (int)strlen(thisString);
-    int outputSize = 0;
-    for (int i = 0; i < thisStringLen; i++)
+    size_t outputSize = 0; // length in bytes
+    if (caseSensitive)
     {
-        bool matchHere = false;
-        if (caseSensitive)
+        size_t lookForLen = strlen(lookForText);
+        size_t replaceLen = strlen(replaceWithText);
+        for (const char *ptr = thisString; *ptr; ++ptr)
         {
-            matchHere = (strncmp(&thisString[i], lookForText, strlen(lookForText)) == 0);
+            if (strncmp(ptr, lookForText, lookForLen) == 0)
+            {
+                memcpy(&resultBuffer[outputSize], replaceWithText, replaceLen);
+                outputSize += replaceLen;
+                ptr += lookForLen - 1;
+            }
+            else
+            {
+                resultBuffer[outputSize] = *ptr;
+                outputSize++;
+            }
         }
-        else
+    }
+    else
+    {
+        size_t lookForLen = ustrlen(lookForText);
+        size_t lookForSz = strlen(lookForText); // length in bytes
+        size_t replaceSz = strlen(replaceWithText); // length in bytes
+        const char *p_cur = thisString;
+        for (int c = ugetxc(&thisString); *p_cur; p_cur = thisString, c = ugetxc(&thisString))
         {
-            matchHere = (ags_strnicmp(&thisString[i], lookForText, strlen(lookForText)) == 0);
-        }
-
-        if (matchHere)
-        {
-            strcpy(&resultBuffer[outputSize], replaceWithText);
-            outputSize += strlen(replaceWithText);
-            i += strlen(lookForText) - 1;
-        }
-        else
-        {
-            resultBuffer[outputSize] = thisString[i];
-            outputSize++;
+            if (ustrnicmp(p_cur, lookForText, lookForLen) == 0)
+            {
+                memcpy(&resultBuffer[outputSize], replaceWithText, replaceSz);
+                outputSize += replaceSz;
+                thisString = p_cur + lookForSz;
+            }
+            else
+            {
+                usetc(&resultBuffer[outputSize], c);
+                outputSize += ucwidth(c);
+            }
         }
     }
 
-    resultBuffer[outputSize] = 0;
-
+    resultBuffer[outputSize] = 0; // terminate
     return CreateNewScriptString(resultBuffer, true);
 }
 
 const char* String_LowerCase(const char *thisString) {
-    char *buffer = (char*)malloc(strlen(thisString) + 1);
-    strcpy(buffer, thisString);
-    ags_strlwr(buffer);
+    char *buffer = ags_strdup(thisString);
+    ustrlwr(buffer);
     return CreateNewScriptString(buffer, false);
 }
 
 const char* String_UpperCase(const char *thisString) {
-    char *buffer = (char*)malloc(strlen(thisString) + 1);
-    strcpy(buffer, thisString);
-    ags_strupr(buffer);
+    char *buffer = ags_strdup(thisString);
+    ustrupr(buffer);
     return CreateNewScriptString(buffer, false);
 }
 
@@ -195,21 +217,25 @@ int StringToInt(const char*stino) {
 int StrContains (const char *s1, const char *s2) {
     VALIDATE_STRING (s1);
     VALIDATE_STRING (s2);
-    char *tempbuf1 = (char*)malloc(strlen(s1) + 1);
-    char *tempbuf2 = (char*)malloc(strlen(s2) + 1);
-    strcpy(tempbuf1, s1);
-    strcpy(tempbuf2, s2);
-    ags_strlwr(tempbuf1);
-    ags_strlwr(tempbuf2);
+    char *tempbuf1 = ags_strdup(s1);
+    char *tempbuf2 = ags_strdup(s2);
+    ustrlwr(tempbuf1);
+    ustrlwr(tempbuf2);
 
-    char *offs = strstr (tempbuf1, tempbuf2);
-    free(tempbuf1);
-    free(tempbuf2);
+    char *offs = ustrstr(tempbuf1, tempbuf2);
 
     if (offs == nullptr)
+    {
+        free(tempbuf1);
+        free(tempbuf2);
         return -1;
+    }
 
-    return (offs - tempbuf1);
+    *offs = 0;
+    int at = ustrlen(tempbuf1);
+    free(tempbuf1);
+    free(tempbuf2);
+    return at;
 }
 
 //=============================================================================
@@ -437,7 +463,7 @@ RuntimeScriptValue Sc_String_GetChars(void *self, const RuntimeScriptValue *para
 RuntimeScriptValue Sc_strlen(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     ASSERT_SELF(strlen);
-    return RuntimeScriptValue().SetInt32(strlen((const char*)self));
+    return RuntimeScriptValue().SetInt32(ustrlen((const char*)self));
 }
 
 //=============================================================================

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -43,7 +43,7 @@ union SDL_Event;
 
 // Converts SDL key data to eAGSKeyCode, which may be also directly used as an ASCII char
 // if it is in proper range, see comments to eAGSKeyCode for details.
-eAGSKeyCode ags_keycode_from_sdl(const SDL_Event &event);
+KeyInput ags_keycode_from_sdl(const SDL_Event &event);
 // Converts eAGSKeyCode to SDL key scans (up to 3 values, because this is not a 1:1 match);
 // NOTE: fails at Ctrl+ or Alt+ AGS keys, or any unknown key codes.
 bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3]);

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -113,7 +113,11 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
         game.options[OPT_RIGHTLEFTWRITE] = 1;
     }
     // Setup a text encoding mode depending on the translation data hint
-    set_uformat(U_ASCII);
+    String encoding = trans.StrOptions["encoding"];
+    if (encoding.CompareNoCase("utf-8") == 0)
+        set_uformat(U_UTF8);
+    else
+        set_uformat(U_ASCII);
 
     Debug::Printf("Translation initialized: %s", trans_filename.GetCStr());
     return true;

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -11,8 +11,9 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include <cstdio>
+#include <locale.h>
+#include <wchar.h>
 #include "ac/asset_helper.h"
 #include "ac/common.h"
 #include "ac/gamesetup.h"
@@ -37,6 +38,25 @@ extern GameState play;
 String trans_name;
 String trans_filename;
 Translation trans;
+
+// TODO: this is a test, later consider using C++ conversion methods
+// that do not change global locale state (but they are more confusing)
+std::vector<wchar_t> wcsbuf; // widechar buffer
+std::vector<char> mbbuf;  // utf8 buffer
+const char *convert_utf8_to_ascii(const char *mbstr, const char *loc_name)
+{
+    // First convert utf-8 string into widestring;
+    size_t len = strlen(mbstr);
+    wcsbuf.resize(len + 1); // the actual length in glyths will be <= len
+    // use uconvert, because libc funcs are locale dependent and complicate things
+    uconvert(mbstr, U_UTF8, (char*)&wcsbuf[0], U_UNICODE, wcsbuf.size() * sizeof(wchar_t));
+    // Then convert widestring to single-byte string using specified locale
+    mbbuf.resize(wcsbuf.size() * 4);
+    setlocale(LC_CTYPE, loc_name);
+    wcstombs(&mbbuf[0], &wcsbuf[0], mbbuf.size());
+    setlocale(LC_CTYPE, "");
+    return &mbbuf[0];
+}
 
 
 void close_translation () {
@@ -118,6 +138,24 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
         set_uformat(U_UTF8);
     else
         set_uformat(U_ASCII);
+
+    // Mixed encoding support: 
+    // original text unfortunately may contain extended ASCII chars (> 127);
+    // if translation is UTF-8 but game is extended ASCII, then the translation
+    // dictionary keys won't match.
+    // With that assumption we must convert dictionary keys into ASCII using
+    // provided locale hint.
+    String key_enc = trans.StrOptions["gameencoding"];
+    if (!key_enc.IsEmpty())
+    {
+        StringMap conv_map;
+        for (const auto &item : trans.Dict)
+        {
+            String key = convert_utf8_to_ascii(item.first.GetCStr(), key_enc.GetCStr());
+            conv_map.insert(std::make_pair(key, item.second));
+        }
+        trans.Dict = conv_map;
+    }
 
     Debug::Printf("Translation initialized: %s", trans_filename.GetCStr());
     return true;

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -43,6 +43,9 @@ void close_translation () {
     trans = Translation();
     trans_name = "";
     trans_filename = "";
+
+    // Return back to default game's encoding
+    set_uformat(U_ASCII);
 }
 
 bool init_translation (const String &lang, const String &fallback_lang, bool quit_on_error) {
@@ -109,6 +112,8 @@ bool init_translation (const String &lang, const String &fallback_lang, bool qui
         play.text_align = kHAlignRight;
         game.options[OPT_RIGHTLEFTWRITE] = 1;
     }
+    // Setup a text encoding mode depending on the translation data hint
+    set_uformat(U_ASCII);
 
     Debug::Printf("Translation initialized: %s", trans_filename.GetCStr());
     return true;

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -155,8 +155,9 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         cscim->id = -1;
         cscim->code = 0;
         smcode = 0;
-        int keywas;
-        if (run_service_key_controls(keywas) && !play.IsIgnoringInput()) {
+        KeyInput ki;
+        if (run_service_key_controls(ki) && !play.IsIgnoringInput()) {
+            int keywas = ki.Key;
             if (keywas == eAGSKeyCodeReturn) {
                 cscim->id = finddefaultcontrol(CNF_DEFAULT);
                 cscim->code = CM_COMMAND;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -123,7 +123,6 @@ bool engine_init_backend()
     }
     
     // Initialize stripped allegro library
-    set_uformat(U_ASCII);
     if (install_allegro(SYSTEM_NONE, &errno, atexit))
     {
         platform->DisplayAlert("Internal error: unable to initialize stripped Allegro 4 library.");
@@ -692,6 +691,9 @@ void engine_init_game_settings()
 {
     our_eip=-7;
     Debug::Printf("Initialize game settings");
+
+    // Setup a text encoding mode depending on the game data hint
+    set_uformat(U_ASCII);
 
     int ee;
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -286,7 +286,7 @@ int old_key_mod = 0; // for saving previous key mods
 
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.
-bool run_service_key_controls(int &out_key)
+bool run_service_key_controls(KeyInput &out_key)
 {
     bool handled = false;
     const bool key_valid = ags_keyevent_ready();
@@ -353,7 +353,8 @@ bool run_service_key_controls(int &out_key)
         return false; // rest of engine currently does not use pressed mod keys
                       // change this when it's no longer true (but be mindful about key-skipping!)
 
-    int agskey = ags_keycode_from_sdl(key_evt);
+    KeyInput ki = ags_keycode_from_sdl(key_evt);
+    eAGSKeyCode agskey = ki.Key;
     if (agskey == eAGSKeyCodeNone)
         return false; // should skip this key event
 
@@ -439,7 +440,7 @@ bool run_service_key_controls(int &out_key)
     }
 
     // No service operation triggered? return active keypress and mods to caller
-    out_key = agskey;
+    out_key = ki;
     return true;
 }
 
@@ -459,10 +460,11 @@ bool run_service_mb_controls(int &mbut, int &mwheelz)
 static void check_keyboard_controls()
 {
     // First check for service engine's combinations (mouse lock, display mode switch, and so forth)
-    int kgn;
-    if (!run_service_key_controls(kgn)) {
+    KeyInput ki;
+    if (!run_service_key_controls(ki)) {
         return;
     }
+    eAGSKeyCode kgn = ki.Key;
     // Then, check cutscene skip
     check_skip_cutscene_keypress(kgn);
     if (play.fast_forward) { 
@@ -530,7 +532,7 @@ static void check_keyboard_controls()
 
                 keywasprocessed = 1;
 
-                guitex->OnKeyPress(kgn);
+                guitex->OnKeyPress(ki);
 
                 if (guitex->IsActivated) {
                     guitex->IsActivated = false;
@@ -541,9 +543,9 @@ static void check_keyboard_controls()
     }
 
     if (!keywasprocessed) {
-        kgn = AGSKeyToScriptKey(kgn);
-        debug_script_log("Running on_key_press keycode %d", kgn);
-        setevent(EV_TEXTSCRIPT,TS_KEYPRESS,kgn);
+        int sckey = AGSKeyToScriptKey(kgn);
+        debug_script_log("Running on_key_press keycode %d", sckey);
+        setevent(EV_TEXTSCRIPT,TS_KEYPRESS, sckey);
     }
 
     // RunTextScriptIParam(gameinst,"on_key_press",kgn);

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -40,7 +40,8 @@ void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBit
 float get_current_fps();
 // Runs service key controls, returns false if no key was pressed or key input was claimed by the engine,
 // otherwise returns true and provides a keycode.
-bool run_service_key_controls(int &kgn);
+struct KeyInput;
+bool run_service_key_controls(KeyInput &kgn);
 // Runs service mouse controls, returns false if mouse input was claimed by the engine,
 // otherwise returns true and provides mouse button code.
 bool run_service_mb_controls(int &mbut, int &mwheelz);

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -136,6 +136,10 @@ AGS::Common::Version SavedgameLowestForwardCompatVersion;
 
 void main_init(int argc, char*argv[])
 {
+    // Init libraries: set text encoding
+    set_uformat(U_UTF8);
+    set_filename_encoding(U_UNICODE);
+
     EngineVersion = Version(ACI_VERSION_STR " " SPECIAL_VERSION);
 #if defined (BUILD_STR)
     EngineVersion.BuildInfo = BUILD_STR;

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -68,9 +68,10 @@ int fliTargetWidth, fliTargetHeight;
 volatile int fli_timer = 0; // TODO: use SDL thread conditions instead?
 int check_if_user_input_should_cancel_video()
 {
-    int key, mbut, mwheelz;
+    KeyInput key;
+    int mbut, mwheelz;
     if (run_service_key_controls(key)) {
-        if ((key==eAGSKeyCodeEscape) && (canabort==1))
+        if ((key.Key==eAGSKeyCodeEscape) && (canabort==1))
             return 1;
         if (canabort >= 2)
             return 1;  // skip on any key

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -413,9 +413,9 @@ void IAGSEngine::PollSystem () {
     int mbut, mwheelz;
     if (run_service_mb_controls(mbut, mwheelz) && mbut >= 0 && !play.IsIgnoringInput())
         pl_run_plugin_hooks (AGSE_MOUSECLICK, mbut);
-    int kp;
+    KeyInput kp;
     if (run_service_key_controls(kp) && !play.IsIgnoringInput()) {
-        pl_run_plugin_hooks (AGSE_KEYPRESS, kp);
+        pl_run_plugin_hooks (AGSE_KEYPRESS, kp.Key);
     }
 
 }

--- a/Tools/data/tra_utils.cpp
+++ b/Tools/data/tra_utils.cpp
@@ -31,6 +31,7 @@ const String NORMAL_FONT_TAG("//#NormalFont=");
 const String SPEECH_FONT_TAG("//#SpeechFont=");
 const String TEXT_DIRECTION_TAG("//#TextDirection=");
 const String ENCODING_TAG("//#Encoding=");
+const String KEYENCODING_TAG("//#KeyEncoding=");
 const char *TAG_DEFAULT = "DEFAULT";
 const char *TAG_DIRECTION_LEFT = "LEFT";
 const char *TAG_DIRECTION_RIGHT = "RIGHT";
@@ -68,9 +69,14 @@ static void ReadSpecialTags(Translation &tra, const String &line)
             tra.RightToLeft = -1;
         }
     }
+    // TODO: make a generic dictionary instead and save any option
     else if (line.StartsWith(ENCODING_TAG))
     {
         tra.StrOptions["encoding"] = line.Mid(ENCODING_TAG.GetLength());
+    }
+    else if (line.StartsWith(KEYENCODING_TAG))
+    {
+        tra.StrOptions["keyencoding"] = line.Mid(KEYENCODING_TAG.GetLength());
     }
 }
 

--- a/Tools/data/tra_utils.cpp
+++ b/Tools/data/tra_utils.cpp
@@ -30,6 +30,7 @@ namespace DataUtil
 const String NORMAL_FONT_TAG("//#NormalFont=");
 const String SPEECH_FONT_TAG("//#SpeechFont=");
 const String TEXT_DIRECTION_TAG("//#TextDirection=");
+const String ENCODING_TAG("//#Encoding=");
 const char *TAG_DEFAULT = "DEFAULT";
 const char *TAG_DIRECTION_LEFT = "LEFT";
 const char *TAG_DIRECTION_RIGHT = "RIGHT";
@@ -66,6 +67,10 @@ static void ReadSpecialTags(Translation &tra, const String &line)
         {
             tra.RightToLeft = -1;
         }
+    }
+    else if (line.StartsWith(ENCODING_TAG))
+    {
+        tra.StrOptions["encoding"] = line.Mid(ENCODING_TAG.GetLength());
     }
 }
 

--- a/libsrc/allegro/include/allegro/unicode.h
+++ b/libsrc/allegro/include/allegro/unicode.h
@@ -107,6 +107,16 @@ AL_PRINTFUNC(int, usprintf, (char *buf, AL_CONST char *format, ...), 2, 3);
 #define ustrncat(dest, src, n)        ustrzncat(dest, INT_MAX, src, n)
 #define uvsprintf(buf, format, args)  uvszprintf(buf, INT_MAX, format, args)
 
+/* UTF-8 support functions
+ */
+AL_FUNC(int, utf8_getc, (AL_CONST char *s));
+AL_FUNC(int, utf8_getx, (char **s));
+AL_FUNC(int, utf8_setc, (char *s, int c));
+AL_FUNC(int, utf8_width, (AL_CONST char *s));
+AL_FUNC(int, utf8_cwidth, (int c));
+AL_FUNC(int, utf8_isok, (int c));
+
+
 #ifdef __cplusplus
    }
 #endif

--- a/libsrc/allegro/src/file.c
+++ b/libsrc/allegro/src/file.c
@@ -89,6 +89,19 @@ static int filename_encoding = U_ASCII;
  ***************************************************/
 
 
+
+/* Use strictly UTF-8 encoding for the file paths
+*/
+#define U_CURRENT U_UTF8
+#define ugetc     utf8_getc
+#define ugetx     utf8_getx
+#define ugetxc    utf8_getx
+#define usetc     utf8_setc
+#define uwidth    utf8_width
+#define ucwidth   utf8_cwidth
+#define uisok     utf8_isok
+
+
 /* fix_filename_case:
  *  Converts filename to upper case.
  */

--- a/libsrc/allegro/src/unicode.c
+++ b/libsrc/allegro/src/unicode.c
@@ -312,7 +312,7 @@ static int unicode_isok(int c)
 /* utf8_getc:
  *  Reads a character from a UTF-8 string.
  */
-static int utf8_getc(AL_CONST char *s)
+/*static*/ int utf8_getc(AL_CONST char *s)
 {
    int c = *((unsigned char *)(s++));
    int n, t;
@@ -342,7 +342,7 @@ static int utf8_getc(AL_CONST char *s)
 /* utf8_getx:
  *  Reads a character from a UTF-8 string, advancing the pointer position.
  */
-static int utf8_getx(char **s)
+/*static*/ int utf8_getx(char **s)
 {
    int c = *((unsigned char *)((*s)++));
    int n, t;
@@ -374,7 +374,7 @@ static int utf8_getx(char **s)
 /* utf8_setc:
  *  Sets a character in a UTF-8 string.
  */
-static int utf8_setc(char *s, int c)
+/*static*/ int utf8_setc(char *s, int c)
 {
    int size, bits, b, i;
 
@@ -414,7 +414,7 @@ static int utf8_setc(char *s, int c)
 /* utf8_width:
  *  Returns the width of a UTF-8 character.
  */
-static int utf8_width(AL_CONST char *s)
+/*static*/ int utf8_width(AL_CONST char *s)
 {
    int c = *((unsigned char *)s);
    int n = 1;
@@ -432,7 +432,7 @@ static int utf8_width(AL_CONST char *s)
 /* utf8_cwidth:
  *  Returns the width of a UTF-8 character.
  */
-static int utf8_cwidth(int c)
+/*static*/ int utf8_cwidth(int c)
 {
    int size, bits, b;
 
@@ -459,7 +459,7 @@ static int utf8_cwidth(int c)
 /* utf8_isok:
  *  Checks whether this character can be encoded in UTF-8 format.
  */
-static int utf8_isok(int c)
+/*static*/ int utf8_isok(int c)
 {
    return TRUE;
 }

--- a/libsrc/allegro/src/unix/ufile.c
+++ b/libsrc/allegro/src/unix/ufile.c
@@ -49,6 +49,18 @@
 #define PREFIX_I "al-unix INFO: "
 
 
+   /* Use strictly UTF-8 encoding for the file paths
+   */
+#define U_CURRENT U_UTF8
+#define ugetc     utf8_getc
+#define ugetx     utf8_getx
+#define ugetxc    utf8_getx
+#define usetc     utf8_setc
+#define uwidth    utf8_width
+#define ucwidth   utf8_cwidth
+#define uisok     utf8_isok
+
+
 /* _al_file_isok:
  *  Helper function to check if it is safe to access a file on a floppy
  *  drive.

--- a/libsrc/allegro/src/win/wfile.c
+++ b/libsrc/allegro/src/win/wfile.c
@@ -30,6 +30,17 @@
 #endif
 
 
+ /* Use strictly UTF-8 encoding for the file paths
+ */
+#define U_CURRENT U_UTF8
+#define ugetc     utf8_getc
+#define ugetx     utf8_getx
+#define ugetxc    utf8_getx
+#define usetc     utf8_setc
+#define uwidth    utf8_width
+#define ucwidth   utf8_cwidth
+#define uisok     utf8_isok
+
 
 /* _al_file_isok:
  *  Helper function to check if it is safe to access a file on a floppy


### PR DESCRIPTION
Addresses #1297
Resolves #662 (or so I hope)

This implements partial unicode (UTF-8, to be precise) support in the engine, with an effort to maintain backwards compatibility at the same time.

Supports loading translations saved as UTF-8 (*without* BOM), with an encoding hint (see below). Unicode in the game data itself (game properties and script) is not yet supported: these would require additional changes to editor, and maybe to game format.

Obviously, for displaying unicode text one would have to provide a proper unicode font (not the hacky ANSI-codepage-compatible fonts that are normally used with AGS).

Also file paths are now strictly UTF-8, which suppose to resolve #662.

---

### Implementation notes

The biggest problem with backward compatibility is that ASCII text in AGS is not a strict ASCII, as engine and editor let game devs to use extended char values (127 - 255) and write texts in corresponding ANSI codepage (of course that requires fonts compatible with that codepage). For this reason we cannot just replace all string functions with utf-8 equivalents so long as we want to load old games.

Current solution utilizes text functions provided by allegro library, because they may switch meaning depending on text format setting. Thus same engine code may work for both ascii and utf-8, with the few exceptions.

When the game is loaded the text format is set to ASCII (current default). When a translation is loaded the engine will check its encoding hint and switch to either ASCII or UTF-8 (ASCII is applied also if no hint is found).

Previously I was thinking about having to switch encoding every time when the engine has to work with filepaths (and then back), but in the end decided to take alternate route. Instead I adjusted allegro library code (which is embedded in the engine now), and made all the file functions always use UTF-8 unconditionally. This is done through macros to reduce changes in code.

---

### Translation

TRS (translation source) now supports two additional options: "Encoding" and "GameEncoding" along with the existing ones in the header. For "Encoding" the only supported value really is "UTF-8", and any other, or no value, is interpreted as "ASCII".

"GameEncoding" is a hint telling how to interpret original game texts. This is only useful if the game itself contains extended ASCII. In this case they have to be converted to match UTF-8 keys from TRA. Having "GameEncoding" hint helps engine to do so.
"GameEncoding" is suppose to be a C locale name, most usually in a form of ".125x", where the number specifies the Windows codepage set on the system when the game data was compiled.

Example of TRS header with Encoding param:
<pre>
// ** Translation settings are below
// ** Leave them as "DEFAULT" to use the game settings
// The normal font to use - DEFAULT or font number
//#NormalFont=3
// The speech font to use - DEFAULT or font number
//#SpeechFont=3
// Text direction - DEFAULT, LEFT or RIGHT
//#TextDirection=DEFAULT
// Text encoding hint
//#Encoding=UTF-8
// Source text encoding hint
//#GameEncoding=.1251
</pre>

Translation compiler is adjusted accordingly to write these values into the TRA file.

---

### Expected behavior

Any existing game or older translation file should still load and display as before.

Editor should update UTF-8 TRS file correctly with new texts, not damaging existing ones.

Engine is capable of starting a game in a directory which path contains unicode characters, on any system.

Loading UTF-8 translation will make following unicode-aware:
* Text display (at least with TTF fonts, but I suspect WFN will work too if it contains glyphs in proper indices);
* String API (also see notes below);
* Text input in the TextBox control.

---

### Script API

Script String class API was changed only in implementation for now, and every "index" or "length" value is interpreted in characters (as opposed to bytes). In my opinion this is what will be commonly expected by users (raw array of chars may be created by other means in script).

Still there are functions that accept or return character as `char` - that is "byte", - I did no changes to these yet.

---

### Potential TODO

* Use Wide-char file/path functions on Windows (get rid of the ugly DOS paths); **EDIT:** *not critical, maybe I will do this separately;*
* BOM detection in TRS files for translation compiler; **EDIT:** *not critical*
* Text parser made unicode-aware; **EDIT:** *there is a larger issue with the parser: its words are not included into translation; that problem should be addressed on its own.*
* String API working with unicode characters (not yet sure if and how this is doable in ags script); **EDIT:** *perhaps better leave for a separate task.*

---

### Potential issues

* There is a group of languages with special rules to gluing characters together, examples are Arabic and Persian, but maybe some more. This is currently not supported. I'm unaware if our current font library (alfont) can do that, but probably not. In any case this is not going to be a part of this PR, and requires additional work.
* If the game contains text with extended ASCII (127 -255) and you load UTF-8 translation, then the original untranslated text containing these extended ascii will not be displayed correctly. The solution now is to provide *any* translation for these lines, even if you just copy the original one.

---

Test game I made for myself:
[test--unicode-source.zip](https://github.com/adventuregamestudio/ags/files/6681700/test--unicode-source.zip)
[test--unicode-game.zip](https://github.com/adventuregamestudio/ags/files/6681701/test--unicode-game.zip)

The game source contains several TRS files which may be copied, filled with different translations and built into TRA.
If you cannot use the Editor, you may also try using stand-alone tool `trac`, which may be built either with a [Makefile](https://github.com/adventuregamestudio/ags/tree/master/Tools/trac) or with Tools.sln [MSVS solution here](https://github.com/adventuregamestudio/ags/blob/master/Solutions/).

In the game itself:
* Space key - starts String API test
* T key - brings up GUI with text box, which fills a list by pressing Enter
* D key - brings up GUI with list box, filled by game directory contents (this is to test dirs with unicode characters)
* S key - plays a sound - this is to test that engine loads up audio file from the other pack/dir, again in case there are unicode characters in directory name, to be certain that nothing is broken there.