### PR TITLE
Platform additions emscripten

### DIFF
--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -5,20 +5,22 @@
 
 // check Android first because sometimes it can get confused with host OS
 #if defined(__ANDROID__) || defined(ANDROID)
-    #define AGS_PLATFORM_OS_WINDOWS (0)
-    #define AGS_PLATFORM_OS_LINUX   (0)
-    #define AGS_PLATFORM_OS_MACOS   (0)
-    #define AGS_PLATFORM_OS_ANDROID (1)
-    #define AGS_PLATFORM_OS_IOS     (0)
-    #define AGS_PLATFORM_OS_PSP     (0)
+    #define AGS_PLATFORM_OS_WINDOWS    (0)
+    #define AGS_PLATFORM_OS_LINUX      (0)
+    #define AGS_PLATFORM_OS_MACOS      (0)
+    #define AGS_PLATFORM_OS_ANDROID    (1)
+    #define AGS_PLATFORM_OS_IOS        (0)
+    #define AGS_PLATFORM_OS_PSP        (0)
+    #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
 #elif defined(_WIN32)
     //define something for Windows (32-bit and 64-bit)
-    #define AGS_PLATFORM_OS_WINDOWS (1)
-    #define AGS_PLATFORM_OS_LINUX   (0)
-    #define AGS_PLATFORM_OS_MACOS   (0)
-    #define AGS_PLATFORM_OS_ANDROID (0)
-    #define AGS_PLATFORM_OS_IOS     (0)
-    #define AGS_PLATFORM_OS_PSP     (0)
+    #define AGS_PLATFORM_OS_WINDOWS    (1)
+    #define AGS_PLATFORM_OS_LINUX      (0)
+    #define AGS_PLATFORM_OS_MACOS      (0)
+    #define AGS_PLATFORM_OS_ANDROID    (0)
+    #define AGS_PLATFORM_OS_IOS        (0)
+    #define AGS_PLATFORM_OS_PSP        (0)
+    #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
 #elif defined(__APPLE__)
     #include "TargetConditionals.h"
     #ifndef TARGET_OS_SIMULATOR
@@ -32,40 +34,51 @@
     #endif
 
     #if TARGET_OS_SIMULATOR || TARGET_IPHONE_SIMULATOR
-        #define AGS_PLATFORM_OS_WINDOWS (0)
-        #define AGS_PLATFORM_OS_LINUX   (0)
-        #define AGS_PLATFORM_OS_MACOS   (0)
-        #define AGS_PLATFORM_OS_ANDROID (0)
-        #define AGS_PLATFORM_OS_IOS     (1)
-        #define AGS_PLATFORM_OS_PSP     (0)
+        #define AGS_PLATFORM_OS_WINDOWS    (0)
+        #define AGS_PLATFORM_OS_LINUX      (0)
+        #define AGS_PLATFORM_OS_MACOS      (0)
+        #define AGS_PLATFORM_OS_ANDROID    (0)
+        #define AGS_PLATFORM_OS_IOS        (1)
+        #define AGS_PLATFORM_OS_PSP        (0)
+        #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
     #elif TARGET_OS_IOS || TARGET_OS_IPHONE
-        #define AGS_PLATFORM_OS_WINDOWS (0)
-        #define AGS_PLATFORM_OS_LINUX   (0)
-        #define AGS_PLATFORM_OS_MACOS   (0)
-        #define AGS_PLATFORM_OS_ANDROID (0)
-        #define AGS_PLATFORM_OS_IOS     (1)
-        #define AGS_PLATFORM_OS_PSP     (0)
+        #define AGS_PLATFORM_OS_WINDOWS    (0)
+        #define AGS_PLATFORM_OS_LINUX      (0)
+        #define AGS_PLATFORM_OS_MACOS      (0)
+        #define AGS_PLATFORM_OS_ANDROID    (0)
+        #define AGS_PLATFORM_OS_IOS        (1)
+        #define AGS_PLATFORM_OS_PSP        (0)
+        #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
     #elif TARGET_OS_OSX || TARGET_OS_MAC
-        #define AGS_PLATFORM_OS_WINDOWS (0)
-        #define AGS_PLATFORM_OS_LINUX   (0)
-        #define AGS_PLATFORM_OS_MACOS   (1)
-        #define AGS_PLATFORM_OS_ANDROID (0)
-        #define AGS_PLATFORM_OS_IOS     (0)
-        #define AGS_PLATFORM_OS_PSP     (0)
+        #define AGS_PLATFORM_OS_WINDOWS    (0)
+        #define AGS_PLATFORM_OS_LINUX      (0)
+        #define AGS_PLATFORM_OS_MACOS      (1)
+        #define AGS_PLATFORM_OS_ANDROID    (0)
+        #define AGS_PLATFORM_OS_IOS        (0)
+        #define AGS_PLATFORM_OS_PSP        (0)
+        #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
     #else
         #error "Unknown Apple platform"
     #endif
 #elif defined(__linux__)
-    #define AGS_PLATFORM_OS_WINDOWS (0)
-    #define AGS_PLATFORM_OS_LINUX   (1)
-    #define AGS_PLATFORM_OS_MACOS   (0)
-    #define AGS_PLATFORM_OS_ANDROID (0)
-    #define AGS_PLATFORM_OS_IOS     (0)
-    #define AGS_PLATFORM_OS_PSP     (0)
+    #define AGS_PLATFORM_OS_WINDOWS    (0)
+    #define AGS_PLATFORM_OS_LINUX      (1)
+    #define AGS_PLATFORM_OS_MACOS      (0)
+    #define AGS_PLATFORM_OS_ANDROID    (0)
+    #define AGS_PLATFORM_OS_IOS        (0)
+    #define AGS_PLATFORM_OS_PSP        (0)
+    #define AGS_PLATFORM_OS_EMSCRIPTEN (0)
+#elif defined(__EMSCRIPTEN__)
+    #define AGS_PLATFORM_OS_WINDOWS    (0)
+    #define AGS_PLATFORM_OS_LINUX      (0)
+    #define AGS_PLATFORM_OS_MACOS      (0)
+    #define AGS_PLATFORM_OS_ANDROID    (0)
+    #define AGS_PLATFORM_OS_IOS        (0)
+    #define AGS_PLATFORM_OS_PSP        (0)
+    #define AGS_PLATFORM_OS_EMSCRIPTEN (1)
 #else
     #error "Unknown platform"
 #endif
-
 
 #if defined(__LP64__)
     // LP64 machine, OS X or Linux
@@ -108,12 +121,16 @@
 #endif
 
 #define AGS_HAS_DIRECT3D (AGS_PLATFORM_OS_WINDOWS)
-#define AGS_HAS_OPENGL (AGS_PLATFORM_OS_WINDOWS || AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_LINUX)
-#define AGS_OPENGL_ES2 (AGS_PLATFORM_OS_ANDROID)
+#define AGS_HAS_OPENGL (AGS_PLATFORM_OS_WINDOWS || AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_LINUX || AGS_PLATFORM_OS_EMSCRIPTEN)
+#define AGS_OPENGL_ES2 (AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_EMSCRIPTEN)
 
 // Only allow searching around for game data on desktop systems;
 // otherwise use explicit argument either from program wrapper, command-line
 // or read from default config.
-#define AGS_SEARCH_FOR_GAME_ON_LAUNCH (AGS_PLATFORM_OS_WINDOWS || AGS_PLATFORM_OS_LINUX || AGS_PLATFORM_OS_MACOS)
+#define AGS_SEARCH_FOR_GAME_ON_LAUNCH (AGS_PLATFORM_OS_WINDOWS || AGS_PLATFORM_OS_LINUX || AGS_PLATFORM_OS_MACOS || AGS_PLATFORM_OS_EMSCRIPTEN)
+
+#if AGS_PLATFORM_OS_EMSCRIPTEN
+#define AGS_NO_VIDEO_PLAYER (1)
+#endif // ! AGS_PLATFORM_OS_EMSCRIPTEN
 
 #endif // __AC_PLATFORM_H

--- a/Engine/util/library.h
+++ b/Engine/util/library.h
@@ -53,7 +53,8 @@ public:
    || AGS_PLATFORM_OS_ANDROID
 #include "library_posix.h"
 
-#elif AGS_PLATFORM_OS_IOS
+#elif AGS_PLATFORM_OS_IOS \
+   || AGS_PLATFORM_OS_EMSCRIPTEN
 #include "library_dummy.h"
 
 #endif

--- a/libsrc/allegro/include/allegro/internal/alconfig.h
+++ b/libsrc/allegro/include/allegro/internal/alconfig.h
@@ -51,6 +51,8 @@
    #endif
 #elif defined(__linux__)
    #define ALLEGRO_UNIX
+#elif defined(__EMSCRIPTEN__)
+   #define ALLEGRO_UNIX
 #endif
 
 


### PR DESCRIPTION
these are platform specific checks that are used in the Emscripten port, I am adding them here in case they are easier to understand than FreeBSD ones to avoid future conflicts.