### PR TITLE
Engine: support scripts as separate assets

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -71,8 +71,6 @@ String GetMainGameFileErrorText(MainGameFileErrorType err)
         return "Failed to deserialize custom properties schema.";
     case kMGFErr_InvalidPropertyValues:
         return "Errors encountered when reading custom properties.";
-    case kMGFErr_NoGlobalScript:
-        return "No global script in game.";
     case kMGFErr_CreateGlobalScriptFailed:
         return "Failed to load global script.";
     case kMGFErr_CreateDialogScriptFailed:
@@ -802,17 +800,18 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
     game.read_interaction_scripts(in, data_ver);
     game.read_words_dictionary(in);
 
-    if (!game.load_compiled_script)
-        return new MainGameFileError(kMGFErr_NoGlobalScript);
-    ents.GlobalScript.reset(ccScript::CreateFromStream(in));
-    if (!ents.GlobalScript)
-        return new MainGameFileError(kMGFErr_CreateGlobalScriptFailed, ccErrorString);
-    err = ReadDialogScript(ents.DialogScript, in, data_ver);
-    if (!err)
-        return err;
-    err = ReadScriptModules(ents.ScriptModules, in, data_ver);
-    if (!err)
-        return err;
+    if (game.load_compiled_script)
+    {
+        ents.GlobalScript.reset(ccScript::CreateFromStream(in));
+        if (!ents.GlobalScript)
+            return new MainGameFileError(kMGFErr_CreateGlobalScriptFailed, ccErrorString);
+        err = ReadDialogScript(ents.DialogScript, in, data_ver);
+        if (!err)
+            return err;
+        err = ReadScriptModules(ents.ScriptModules, in, data_ver);
+        if (!err)
+            return err;
+    }
 
     ReadViews(game, ents.Views, in, data_ver);
 

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -56,7 +56,6 @@ enum MainGameFileErrorType
     kMGFErr_TooManyCursors,
     kMGFErr_InvalidPropertySchema,
     kMGFErr_InvalidPropertyValues,
-    kMGFErr_NoGlobalScript,
     kMGFErr_CreateGlobalScriptFailed,
     kMGFErr_CreateDialogScriptFailed,
     kMGFErr_CreateScriptModuleFailed,

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -448,6 +448,26 @@ static void update_all_viewcams_with_newroom()
     }
 }
 
+// Looks up for the room script available as a separate asset.
+// This is optional, so no error is raised if one is not found.
+// If found however, it will replace room script if one had been loaded
+// from the room file itself.
+HError LoadRoomScript(RoomStruct *room, int newnum)
+{
+    String filename = String::FromFormat("room%d.o", newnum);
+    std::unique_ptr<Stream> in(AssetMgr->OpenAsset(filename));
+    if (in)
+    {
+        PScript script(ccScript::CreateFromStream(in.get()));
+        if (!script)
+            return new Error(String::FromFormat(
+                "Failed to load a script module: %s", filename.GetCStr()),
+                ccErrorString);
+        room->CompiledScript = script;
+    }
+    return HError::None();
+}
+
 // forchar = playerchar on NewRoom, or NULL if restore saved game
 void load_new_room(int newnum, CharacterInfo*forchar) {
 
@@ -486,6 +506,11 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         (thisroom.GameID != game.uniqueid)) {
             quitprintf("!Unable to load '%s'. This room file is assigned to a different game.", room_filename.GetCStr());
     }
+
+    HError err = LoadRoomScript(&thisroom, newnum);
+    if (!err)
+        quitprintf("!Unable to load '%s'. Error: %s", room_filename.GetCStr(),
+            err->FullMessage().GetCStr());
 
     convert_room_coordinates_to_data_res(&thisroom);
 

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -124,6 +124,8 @@ String GetGameInitErrorText(GameInitErrorType err)
         return "Too many plugins for this engine to handle.";
     case kGameInitErr_PluginNameInvalid:
         return "Plugin name is invalid.";
+    case kGameInitErr_NoGlobalScript:
+        return "No global script in game.";
     case kGameInitErr_ScriptLinkFailed:
         return "Script link failed.";
     }
@@ -442,6 +444,8 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     // NOTE: we must do this after plugins, because some plugins may export
     // script symbols too.
     //
+    if (!ents.GlobalScript)
+        return new GameInitError(kGameInitErr_NoGlobalScript);
     gamescript = ents.GlobalScript;
     dialogScriptsScript = ents.DialogScript;
     numScriptModules = ents.ScriptModules.size();

--- a/Engine/game/game_init.h
+++ b/Engine/game/game_init.h
@@ -40,7 +40,8 @@ enum GameInitErrorType
     kGameInitErr_EntityInitFail,
     kGameInitErr_TooManyPlugins,
     kGameInitErr_PluginNameInvalid,
-    kGameInitErr_ScriptLinkFailed
+    kGameInitErr_NoGlobalScript,
+    kGameInitErr_ScriptLinkFailed,
 };
 
 String GetGameInitErrorText(GameInitErrorType err);

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -39,6 +39,7 @@
 #include "gfx/blender.h"
 #include "core/assetmanager.h"
 #include "util/alignedstream.h"
+#include "util/textstreamreader.h"
 #include "ac/gamesetup.h"
 #include "game/main_game_file.h"
 #include "game/game_init.h"
@@ -124,15 +125,75 @@ HError preload_game_data()
     return HError::None();
 }
 
+static inline HError MakeScriptLoadError(const char *name)
+{
+    return new Error(String::FromFormat(
+        "Failed to load a script module: %s", name),
+        ccErrorString);
+}
+
+// Looks up for the game scripts available as separate assets.
+// These are optional, so no error is raised if some of these are not found.
+// For those that do exist, reads them and replaces any scripts of same kind
+// in the already loaded game data.
+HError LoadGameScripts(LoadedGameEntities &ents, GameDataVersion data_ver)
+{
+    // Global script
+    std::unique_ptr<Stream> in(AssetMgr->OpenAsset("GlobalScript.o"));
+    if (in)
+    {
+        PScript script(ccScript::CreateFromStream(in.get()));
+        if (!script)
+            return MakeScriptLoadError("GlobalScript.o");
+        ents.GlobalScript = script;
+    }
+    // Dialog script
+    in.reset(AssetMgr->OpenAsset("DialogScript.o"));
+    if (in)
+    {
+        PScript script(ccScript::CreateFromStream(in.get()));
+        if (!script)
+            return MakeScriptLoadError("DialogScript.o");
+        ents.DialogScript = script;
+    }
+    // Script modules
+    // First load a modules list
+    std::vector<String> modules;
+    in.reset(AssetMgr->OpenAsset("ScriptModules.lst"));
+    if (in)
+    {
+        TextStreamReader reader(in.get());
+        in.release(); // TextStreamReader got it
+        while (!reader.EOS())
+            modules.push_back(reader.ReadLine());
+    }
+    if (modules.size() > ents.ScriptModules.size())
+        ents.ScriptModules.resize(modules.size());
+    // Now run by the list and try loading everything
+    for (size_t i = 0; i < modules.size(); ++i)
+    {
+        in.reset(AssetMgr->OpenAsset(modules[i]));
+        if (in)
+        {
+            PScript script(ccScript::CreateFromStream(in.get()));
+            if (!script)
+                return MakeScriptLoadError(modules[i].GetCStr());
+            ents.ScriptModules[i] = script;
+        }
+    }
+    return HError::None();
+}
+
 HError load_game_file()
 {
     MainGameSource src;
     LoadedGameEntities ents(game, dialog, views);
-    HGameFileError load_err = OpenMainGameFileFromDefaultAsset(src);
-    if (load_err)
+    HError err = (HError)OpenMainGameFileFromDefaultAsset(src);
+    if (err)
     {
-        load_err = ReadGameData(ents, src.InputStream.get(), src.DataVersion);
-        if (load_err)
+        err = (HError)ReadGameData(ents, src.InputStream.get(), src.DataVersion);
+        src.InputStream.reset();
+        if (err)
         {
             // Upscale mode -- for old games that supported it.
             // NOTE: this must be done before UpdateGameData, or resolution-dependant
@@ -145,14 +206,17 @@ HError load_game_file()
                     game.SetGameResolution(kGameResolution_640x480);
             }
 
-            load_err = UpdateGameData(ents, src.DataVersion);
+            err = (HError)UpdateGameData(ents, src.DataVersion);
         }
     }
-    if (!load_err)
-        return (HError)load_err;
-    HGameInitError init_err = InitGameState(ents, src.DataVersion);
-    if (!init_err)
-        return (HError)init_err;
+    if (!err)
+        return err;
+    err = LoadGameScripts(ents, src.DataVersion);
+    if (!err)
+        return err;
+    err = (HError)InitGameState(ents, src.DataVersion);
+    if (!err)
+        return err;
     return HError::None();
 }
 


### PR DESCRIPTION
**Summary**

Support loading scripts as separate asset files. Allow to *not* have scripts inside game28.dta and room.crm.

This does not change any data formats, only reinterprets one existing flag in the main game data (as explained below).

The purpose of this is to simplify the data layout in the game package, and the packaging process itself, as this will require at least 1 step less for game and room compilation (compiled script injection into the respective data blob).

**Details**

This allows engine to support game distribs where scripts are not embedded into the game28.dta and roomN.crm blobs, but are present as separate asset files inside the game package.

First of all, the engine will now treat `game.load_compiled_script` flag as an indication whether the scripts are found inside main game data file or not, and won't immediately raise an error if it's 0 (false).

After the main game data is loaded the engine will look up for script files of hardcoded names for Global and Dialog scripts, and then for the script modules. These are optional. If they are not found no error is raised. If they exist then they will be loaded, replacing any scripts found in the main game data if these were also present.

There are two hardcoded script file names: **"GlobalScript.o"** and **"DialogScript.o"**.

For the rest of the script modules, engine first tries loading an asset called **"ScriptModules.lst"** which is supposed to contain simple textual list of filenames *separated by linebreaks*. These files are then loaded as script modules in the given order.
This is not hardcoded, but the suggested names for these modules is again **"scriptname.o"**.

Regardless, GlobalScript must exist anyway. If it's not found at all (neither in main data blob nor as a separate asset), the error is raised.

Similar change is done for the room scripts. Except room scripts are an optional block in the room format, so there was no need for any flag.

Room script should be called **"roomN.o"** where N is a room's number.


**PS.** Naturally these assets may also be loaded from the disk, as any other game data in AGS.