### PR TITLE
SDL_sound has moved to github (fix CI failing)

### DIFF
--- a/CMake/FetchSDL_Sound.cmake
+++ b/CMake/FetchSDL_Sound.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     sdlsound_content
-    URL https://hg.icculus.org/icculus/SDL_sound/archive/4b78007f035f.tar.gz
-    URL_HASH MD5=ff2448f5a789ae2a07636c243d8f8780
+    URL https://github.com/icculus/SDL_sound/archive/574e3174e311d21cc879f2a5bf26735c52bf1cf2.tar.gz
+    URL_HASH MD5=e4c5da22f5e9edbb74608c2ddded493e
 )
 
 FetchContent_GetProperties(sdlsound_content)

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -106,9 +106,9 @@ RUN curl -fLsS "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSI
   rm -r /tmp/cmake-$CMAKE_VERSION
 
 # Build and install SDL_sound
-ARG SDL2_SOUND_VERSION=4b78007f035f
+ARG SDL2_SOUND_VERSION=574e3174e311d21cc879f2a5bf26735c52bf1cf2
 RUN cd /tmp && \
-  curl -fLsS "https://hg.icculus.org/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz && \
+  curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz && \
   tar -xvzf SDL_sound.tar.gz && \
   mv SDL_sound-$SDL2_SOUND_VERSION SDL_sound &&  \
   cd /tmp/SDL_sound  && \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -60,11 +60,11 @@ RUN mkdir Lib\SDL2 && \
   echo endif ^(^)  >> "Lib\SDL2\sdl2-config.cmake" && \
   echo string^(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES^) >> "Lib\SDL2\sdl2-config.cmake" 
  
-ARG SDL_SOUND_VERSION=4b78007f035f 
+ARG SDL_SOUND_VERSION=574e3174e311d21cc879f2a5bf26735c52bf1cf2
 RUN mkdir Lib\SDL_sound && \
   echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 ^&^& pushd Lib\SDL_sound\build ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild.bat && \
   mkdir Lib\SDL_sound\build  && \	
-  curl -fLSs "https://hg.icculus.org/icculus/SDL_sound/archive/%SDL_SOUND_VERSION%.tar.gz" | tar -f - -xvzC Lib\SDL_sound --strip-components 1 && \
+  curl -fLSs "https://github.com/icculus/SDL_sound/archive/%SDL_SOUND_VERSION%.tar.gz" | tar -f - -xvzC Lib\SDL_sound --strip-components 1 && \
   set SDL2_DIR=%cd%\Lib\SDL2 && \
   cmake -DCMAKE_SYSTEM_VERSION=8.1 -S Lib\SDL_sound -B Lib\SDL_sound\build -G "Visual Studio 14 2015" -T"v140" -A"Win32" -DCMAKE_PREFIX_PATH=Lib\SDL2 && \
   sdlsoundvcbuild.bat && \


### PR DESCRIPTION
- SDL_sound is not on icculus mercurial website

icculus switched SDL_sound off from mercurial and is now pushing to his GitHub, so we can't fetch from the old place anymore. Link to new home:

https://github.com/icculus/SDL_sound

PR changes Docker/CMake to fetch from the new place. 

Since previous commit number was now invalid with the system change (hg->git), I took the opportunity to update to the newer version, but there's no significant change/improvements to the formats we use more often.