### PR TITLE
adds existing Engine, Common and Compiler tests to CMake

### DIFF
--- a/CMake/FetchGoogleTest.cmake
+++ b/CMake/FetchGoogleTest.cmake
@@ -1,0 +1,13 @@
+FetchContent_Declare(
+    googletest_content
+    URL https://github.com/google/googletest/archive/4ec4cd23f486bf70efcc5d2caa40f24368f752e3.tar.gz
+    URL_HASH MD5=b907483a9045a2edda15ee7d2a68aaa5
+)
+
+FetchContent_GetProperties(googletest_content)
+if(NOT googletest_content_POPULATED)
+    FetchContent_Populate(googletest_content)
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    add_subdirectory(${googletest_content_SOURCE_DIR} ${googletest_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(AGS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 option(AGS_TESTS "Build tests" OFF)
+option(AGS_BUILD_COMPILER "Build compiler library" OFF)
 option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_NO_VIDEO_PLAYER "Disable Video" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" ON)
@@ -191,5 +192,8 @@ endif()
 add_subdirectory(Engine/libsrc/libcda-0.5       EXCLUDE_FROM_ALL)
 
 add_subdirectory(Engine)
+if(AGS_BUILD_COMPILER)
+    add_subdirectory(Compiler)
+endif()
 
 set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(AGS
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
+option(AGS_TESTS "Build tests" OFF)
 option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_NO_VIDEO_PLAYER "Disable Video" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" ON)
@@ -158,6 +159,11 @@ endif()
 
 find_package(PkgConfig)
 find_package(Threads)
+
+if(AGS_TESTS)
+    include(FetchGoogleTest)
+    enable_testing()
+endif()
 
 include(FetchSDL2)
 include(FetchSDL_Sound)

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -201,3 +201,25 @@ get_target_property(COMMON_SOURCES common SOURCES)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Source Files" FILES ${COMMON_SOURCES})
 
 add_library(AGS::Common ALIAS common)
+
+if(AGS_TESTS)
+    add_executable(
+        common_test
+        test/gfxdef_test.cpp
+        test/inifile_test.cpp
+        test/math_test.cpp
+        test/memory_test.cpp
+        test/path_test.cpp
+        test/stream_test.cpp
+        test/string_test.cpp
+        test/version_test.cpp
+    )
+    target_link_libraries(
+        common_test
+        common
+        gtest_main
+    )
+
+    include(GoogleTest)
+    gtest_discover_tests(common_test)
+endif()

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -139,6 +139,9 @@ target_sources(common
     util/lzw.h
     util/math.h
     util/memory.h
+    util/memory_compat.h
+    util/memorystream.cpp
+    util/memorystream.h
     util/misc.cpp
     util/misc.h
     util/multifilelib.h

--- a/Compiler/CMakeLists.txt
+++ b/Compiler/CMakeLists.txt
@@ -1,0 +1,61 @@
+add_library(compiler)
+
+set_target_properties(compiler PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        C_STANDARD 11
+        C_EXTENSIONS NO
+        )
+
+target_include_directories(compiler PUBLIC .)
+
+target_sources(compiler
+        PRIVATE
+        fmem.cpp
+        fmem.h
+        script/cc_compiledscript.cpp
+        script/cc_compiledscript.h
+        script/cc_internallist.cpp
+        script/cc_internallist.h
+        script/cc_macrotable.cpp
+        script/cc_macrotable.h
+        script/cc_symboltable.cpp
+        script/cc_symboltable.h
+        script/cc_symboldef.h
+        script/cc_treemap.cpp
+        script/cc_treemap.h
+        script/cc_variablesymlist.h
+        script/cs_compiler.cpp
+        script/cs_compiler.h
+        script/cs_parser.cpp
+        script/cs_parser.h
+        script/cs_parser_common.cpp
+        script/cs_parser_common.h
+        script/cs_prepro.cpp
+        script/cs_prepro.h
+        )
+
+target_link_libraries(compiler PUBLIC AGS::Common)
+
+get_target_property(COMMON_SOURCES compiler SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Source Files" FILES ${COMMON_SOURCES})
+
+add_library(AGS::Compiler ALIAS compiler)
+
+if(AGS_TESTS)
+    add_executable(
+            compiler_test
+            test/cc_internallist_test.cpp
+            test/cc_symboltable_test.cpp
+            test/cc_treemap_test.cpp
+            test/cc_symboltable_test.cpp
+    )
+    target_link_libraries(
+            compiler_test
+            compiler
+            gtest_main
+    )
+
+    include(GoogleTest)
+    gtest_discover_tests(compiler_test)
+endif()

--- a/Compiler/fmem.cpp
+++ b/Compiler/fmem.cpp
@@ -10,14 +10,13 @@
 #pragma unmanaged
 #endif
 
-#include <stdio.h>
-#include <Stdarg.h>
-#include <io.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdarg>
+#include <cstring>
+#include <cstdlib>
 #include "fmem.h"
 
-char*fmemcopyr="FMEM v1.00 (c) 2000 Chris Jones";
+const char*fmemcopyr="FMEM v1.00 (c) 2000 Chris Jones";
 #define FMEM_MAGIC 0xcddebeef
 
 FMEM*tempy;

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -57,7 +57,7 @@ struct symbolTable {
     int  add(const char*);   // adds new symbol, returns -1 if already exists
 
     // TODO: why is there "friendly name" and "name", and what's the difference?
-    std::string symbolTable::get_friendly_name(int idx);  // inclue ptr
+    std::string get_friendly_name(int idx);  // inclue ptr
     const char *get_name(int idx); // gets symbol name of index
 
     int  get_type(int ii);
@@ -71,7 +71,7 @@ private:
     std::vector<char *> symbolTreeNames;
 
     int  add_operator(const char*, int priority, int vcpucmd); // adds new operator
-    std::string symbolTable::get_name_string(int idx);
+    std::string get_name_string(int idx);
 };
 
 

--- a/Compiler/script/cc_treemap.cpp
+++ b/Compiler/script/cc_treemap.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 
+#include <cstring>
 #include "cc_treemap.h"
 
 int ccTreeMap::findValue(const char *key) {

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -649,6 +649,22 @@ if (WIN32)
     )
 endif()
 
+# Test
+# -----------------------------------------------------------------------------
+if(AGS_TESTS)
+    add_executable(
+        engine_test
+        test/scsprintf_test.cpp
+    )
+    target_link_libraries(
+        engine_test
+        engine
+        gtest_main
+    )
+
+    include(GoogleTest)
+    gtest_discover_tests(engine_test)
+endif()
 
 # macOS App Bundle
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I am adding the option to build existing tests with CMake and run them with CTest.

I am adding tests because I will need them to test my preprocessor in the other PR. :)

I followed google docs on here: https://google.github.io/googletest/quickstart-cmake.html

![Screenshot from 2021-07-01 19-51-40](https://user-images.githubusercontent.com/2244442/124197854-d43a9480-daa5-11eb-80fc-0515a06324a7.png)

Tests are off by default, I didn't want to deal with CI just yet. 

Edit: btw we could update the submodule to the current commit (https://github.com/google/googletest/commit/4ec4cd23f486bf70efcc5d2caa40f24368f752e3), I just don't know how exactly to PR this (the submodule change). It needs a small fix to vcxproj files because now googletest has been moved to a directory named googletest. I am skipping the submodule by simply fetching if the test option is on in CMake.