### PR TITLE
import error: print original filename if possible

### DIFF
--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1602,7 +1602,7 @@ bool ccInstance::ResolveScriptImports(PScript scri)
 
         resolved_imports[i] = simp.get_index_of(scri->imports[i]);
         if (resolved_imports[i] < 0) {
-            cc_error("unresolved import '%s'", scri->imports[i]);
+            cc_error("unresolved import '%s' in %s", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
             return false;
         }
     }


### PR DESCRIPTION
in games with lots of scripts, this help to narrow down the exact
origin.