### PR TITLE
ci_find_file/unix: add fast-path for file lookup

### DIFF
--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -115,7 +115,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     fix_filename_slashes(filename);
   }
 
-  if(directory && filename) {
+  if(directory && filename && !strstr(filename, "..")) {
     char buf[1024];
     snprintf(buf, sizeof buf, "%s/%s", directory, filename);
     lstat(buf, &statbuf);

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -115,6 +115,15 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     fix_filename_slashes(filename);
   }
 
+  if(directory && filename) {
+    char buf[1024];
+    snprintf(buf, sizeof buf, "%s/%s", directory, filename);
+    lstat(buf, &statbuf);
+    if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
+      diamond = strdup(buf); goto out;
+    }
+  }
+
   if (directory == nullptr) {
     char  *match    = nullptr;
     int   match_len = 0;
@@ -174,6 +183,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   fchdir(dirfd(prevdir));
   closedir(prevdir);
 
+out:;
   free(directory);
   free(filename);
 

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -115,6 +115,13 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     fix_filename_slashes(filename);
   }
 
+  // the ".." check here prevents file system traversal -
+  // since only in this fast-path it's possible a potentially evil
+  // script could try to break out of the directories it's restricted
+  // to, whereas the latter chdir/opendir approach checks file by file
+  // in the directory. it's theoretically possible a valid filename
+  // could contain "..", but in that case it will just fallback to the
+  // slower method later on and succeed.
   if(directory && filename && !strstr(filename, "..")) {
     char buf[1024];
     snprintf(buf, sizeof buf, "%s/%s", directory, filename);

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -164,12 +164,12 @@ char *ci_find_file(const char *dir_name, const char *file_name)
 
   if (chdir(directory) == -1) {
     fprintf(stderr, "ci_find_file: cannot change to directory: %s\n", directory);
-    goto out;
+    goto out_pd;
   }
 
   if ((rough = opendir(directory)) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open directory: %s\n", directory);
-    goto out;
+    goto out_pd;
   }
 
   while ((entry = readdir(rough)) != nullptr) {
@@ -187,6 +187,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   }
   closedir(rough);
 
+out_pd:;
   fchdir(dirfd(prevdir));
   closedir(prevdir);
 

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -85,7 +85,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
 }
 
 #else
-/* Case Insensitive File Find */
+/* Case Sensitive File Find - only used on UNIX platforms */
 char *ci_find_file(const char *dir_name, const char *file_name)
 {
   struct stat   statbuf;
@@ -131,7 +131,7 @@ char *ci_find_file(const char *dir_name, const char *file_name)
 
     match = get_filename(filename);
     if (match == nullptr)
-      return nullptr;
+      goto out;
 
     match_len = strlen(match);
     dir_len   = (match - filename);
@@ -152,17 +152,17 @@ char *ci_find_file(const char *dir_name, const char *file_name)
 
   if ((prevdir = opendir(".")) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open current working directory\n");
-    return nullptr;
+    goto out;
   }
 
   if (chdir(directory) == -1) {
     fprintf(stderr, "ci_find_file: cannot change to directory: %s\n", directory);
-    return nullptr;
+    goto out;
   }
-  
+
   if ((rough = opendir(directory)) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open directory: %s\n", directory);
-    return nullptr;
+    goto out;
   }
 
   while ((entry = readdir(rough)) != nullptr) {
@@ -184,8 +184,8 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   closedir(prevdir);
 
 out:;
-  free(directory);
-  free(filename);
+  if(directory) free(directory);
+  if(filename) free(filename);
 
   return diamond;
 }


### PR DESCRIPTION
this achieves 2 major improvements:

- if the directory and filename are correct, only a single stat
  syscall needs to be done to check whether the file exists.
  no need to open the directory (1 syscall) and check whether
  each one of the entries matches the filename (1 syscall each).
  for perspective, each syscall requires to enter the kernel,
  a full contex switch, and therefore at least 1000 cpu cycles.

- if the filename contains a directory separator to dive into
  a subdir, the existing method fails.
  this allows to use e.g. PlayMP3File("sounds/sound25.ogg")
  successfully.