### PR TITLE
import error: print all missing imports for current script module

### DIFF
--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1638,7 +1638,7 @@ bool ccInstance::ResolveScriptImports(PScript scri)
     }
 
     resolved_imports = new int[numimports];
-    int errors = 0;
+    int errors = 0, last_err_idx;
     for (int i = 0; i < scri->numimports; ++i) {
         if (scri->imports[i] == nullptr) {
             resolved_imports[i] = -1;
@@ -1647,11 +1647,18 @@ bool ccInstance::ResolveScriptImports(PScript scri)
 
         resolved_imports[i] = simp.get_index_of(scri->imports[i]);
         if (resolved_imports[i] < 0) {
-            AGS::Common::Debug::Printf(kDbgMsg_Info, "unresolved import '%s' in %s", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
+            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
             errors++;
+            last_err_idx = i;
         }
     }
-    if (errors > 0) cc_error("unresolved imports, quitting.");
+
+    if (errors > 0)
+       cc_error("in %s: %d unresolved imports (last: %s)",
+         scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>",
+         errors,
+         scri->imports[last_err_idx]);
+
     return errors == 0;
 }
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1638,6 +1638,7 @@ bool ccInstance::ResolveScriptImports(PScript scri)
     }
 
     resolved_imports = new int[numimports];
+    int errors = 0;
     for (int i = 0; i < scri->numimports; ++i) {
         if (scri->imports[i] == nullptr) {
             resolved_imports[i] = -1;
@@ -1646,11 +1647,12 @@ bool ccInstance::ResolveScriptImports(PScript scri)
 
         resolved_imports[i] = simp.get_index_of(scri->imports[i]);
         if (resolved_imports[i] < 0) {
-            cc_error("unresolved import '%s' in %s", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
-            return false;
+            AGS::Common::Debug::Printf(kDbgMsg_Info, "unresolved import '%s' in %s", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
+            errors++;
         }
     }
-    return true;
+    if (errors > 0) cc_error("unresolved imports, quitting.");
+    return errors == 0;
 }
 
 // TODO: it is possible to deduce global var's size at start with


### PR DESCRIPTION
rather than bailing out after the first.
this helps to evaluate missing script functions much quicker, than
with current approach. it's helpful when e.g. trying to implement
stubs for a proprietary binary plugin.