### PR TITLE
Allow using OpenGL on MacOS

### DIFF
--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -142,7 +142,8 @@
                         AGS_PLATFORM_OS_IOS        || \
                         AGS_PLATFORM_OS_LINUX      || \
                         AGS_PLATFORM_OS_EMSCRIPTEN || \
-                        AGS_PLATFORM_OS_FREEBSD)
+                        AGS_PLATFORM_OS_FREEBSD    || \
+                        AGS_PLATFORM_OS_MACOS)
 #define AGS_OPENGL_ES2 (AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_EMSCRIPTEN)
 
 // Only allow searching around for game data on desktop systems;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -208,7 +208,7 @@ void OGLGraphicsDriver::SetTintMethod(TintMethod method)
   _legacyPixelShader = (method == TintReColourise);
 }
 
-void OGLGraphicsDriver::FirstTimeInit()
+bool OGLGraphicsDriver::FirstTimeInit()
 {
   String ogl_v_str;
 #ifdef GLAPI
@@ -222,12 +222,15 @@ void OGLGraphicsDriver::FirstTimeInit()
   OGLGraphicsDriver::InitSpriteBatch(0, _spriteBatchDesc[0]);
 
   TestRenderToTexture();
-  CreateShaders();
+  _shaders_created = CreateShaders();
   _firstTimeInit = true;
+  return _shaders_created;
 }
 
 bool OGLGraphicsDriver::InitGlScreen(const DisplayMode &mode)
 {
+  if(!_shaders_created) return false;
+
   SDL_Window* window = sys_get_window();
   if (window == nullptr || (SDL_GetWindowFlags(window) & SDL_WINDOW_OPENGL) == 0)
   {
@@ -395,15 +398,15 @@ void OGLGraphicsDriver::TestSupersampling()
 
 
 
-void CreateTransparencyShader(ShaderProgram &prg);
-void CreateTintShader(ShaderProgram &prg);
-void CreateLightShader(ShaderProgram &prg);
-void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *vertex_shader_src, const char *fragment_shader_src);
+bool CreateTransparencyShader(ShaderProgram &prg);
+bool CreateTintShader(ShaderProgram &prg);
+bool CreateLightShader(ShaderProgram &prg);
+bool CreateShaderProgram(ShaderProgram &prg, const char *name, const char *vertex_shader_src, const char *fragment_shader_src);
 void DeleteShaderProgram(ShaderProgram &prg);
 void OutputShaderError(GLuint obj_id, const String &obj_name, bool is_shader);
 
 
-void OGLGraphicsDriver::CreateShaders()
+bool OGLGraphicsDriver::CreateShaders()
 {
 #if AGS_OPENGL_ES2
   if (!GLAD_GL_ES_VERSION_2_0) {
@@ -411,11 +414,13 @@ void OGLGraphicsDriver::CreateShaders()
   if (!GLAD_GL_VERSION_2_0) {
 #endif
     Debug::Printf(kDbgMsg_Error, "ERROR: Shaders require a minimum of OpenGL 2.0 support.");
-    return;
+    return false;
   }
-  CreateTransparencyShader(_transparencyShader);
-  CreateTintShader(_tintShader);
-  CreateLightShader(_lightShader);
+  bool shaders_created = true;
+  shaders_created &= CreateTransparencyShader(_transparencyShader);
+  shaders_created &= CreateTintShader(_tintShader);
+  shaders_created &= CreateLightShader(_lightShader);
+  return shaders_created;
 }
 
 
@@ -556,41 +561,47 @@ void main()
 )EOS";
 
 
-void CreateTransparencyShader(ShaderProgram &prg)
+bool CreateTransparencyShader(ShaderProgram &prg)
 {
-  CreateShaderProgram(prg, "Transparency", default_vertex_shader_src, transparency_fragment_shader_src);
-
-  prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
-  prg.TextureId = glGetUniformLocation(prg.Program, "textID");
-  prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+  if(CreateShaderProgram(prg, "Transparency", default_vertex_shader_src, transparency_fragment_shader_src)) {
+      prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
+      prg.TextureId = glGetUniformLocation(prg.Program, "textID");
+      prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+      return true;
+  }
+  return false;
 }
 
 
-void CreateTintShader(ShaderProgram &prg)
+bool CreateTintShader(ShaderProgram &prg)
 {
-  CreateShaderProgram(prg, "Tinting", default_vertex_shader_src, tint_fragment_shader_src);
-
-  prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
-  prg.TextureId = glGetUniformLocation(prg.Program, "textID");
-  prg.TintHSV = glGetUniformLocation(prg.Program, "tintHSV");
-  prg.TintAmount = glGetUniformLocation(prg.Program, "tintAmount");
-  prg.TintLuminance = glGetUniformLocation(prg.Program, "tintLuminance");
-  prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+  if(CreateShaderProgram(prg, "Tinting", default_vertex_shader_src, tint_fragment_shader_src)) {
+      prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
+      prg.TextureId = glGetUniformLocation(prg.Program, "textID");
+      prg.TintHSV = glGetUniformLocation(prg.Program, "tintHSV");
+      prg.TintAmount = glGetUniformLocation(prg.Program, "tintAmount");
+      prg.TintLuminance = glGetUniformLocation(prg.Program, "tintLuminance");
+      prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+      return true;
+  }
+  return false;
 }
 
-void CreateLightShader(ShaderProgram &prg)
+bool CreateLightShader(ShaderProgram &prg)
 {
-  CreateShaderProgram(prg, "Lighting", default_vertex_shader_src, light_fragment_shader_src);
-
-  prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
-  prg.TextureId = glGetUniformLocation(prg.Program, "textID");
-  prg.LightingAmount = glGetUniformLocation(prg.Program, "light");
-  prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+  if(CreateShaderProgram(prg, "Lighting", default_vertex_shader_src, light_fragment_shader_src)) {
+      prg.MVPMatrix = glGetUniformLocation(prg.Program, "uMVPMatrix");
+      prg.TextureId = glGetUniformLocation(prg.Program, "textID");
+      prg.LightingAmount = glGetUniformLocation(prg.Program, "light");
+      prg.Alpha = glGetUniformLocation(prg.Program, "alpha");
+      return true;
+  }
+  return false;
 }
 
 
 
-void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *vertex_shader_src, const char *fragment_shader_src)
+bool CreateShaderProgram(ShaderProgram &prg, const char *name, const char *vertex_shader_src, const char *fragment_shader_src)
 {
   GLint result;
 
@@ -601,7 +612,7 @@ void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *verte
   if (result == GL_FALSE)
   {
     OutputShaderError(vertex_shader, String::FromFormat("%s program's vertex shader", name), true);
-    return;
+    return false;
   }
 
   GLint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
@@ -612,7 +623,7 @@ void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *verte
   {
     OutputShaderError(fragment_shader, String::FromFormat("%s program's fragment shader", name), true);
     glDeleteShader(fragment_shader); //not sure yet if this goes here
-    return;
+    return false;
   }
 
   GLuint program = glCreateProgram();
@@ -625,7 +636,7 @@ void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *verte
     OutputShaderError(program, String::FromFormat("%s program", name), false);
     glDeleteProgram(program); //not sure yet if this goes here
     glDeleteShader(fragment_shader); //not sure yet if this goes here
-    return;
+    return false;
   }
 
   glDetachShader(program, vertex_shader);
@@ -636,6 +647,7 @@ void CreateShaderProgram(ShaderProgram &prg, const char *name, const char *verte
 
   prg.Program = program;
   Debug::Printf("OGL: %s shader program created successfully", name);
+  return true;
 }
 
 void DeleteShaderProgram(ShaderProgram &prg)
@@ -757,7 +769,7 @@ bool OGLGraphicsDriver::SetDisplayMode(const DisplayMode &mode)
     if (!InitGlScreen(mode))
       return false;
     if (!_firstTimeInit)
-      FirstTimeInit();
+      if(!FirstTimeInit()) return false;
     InitGlParams(mode);
   }
   catch (Ali3DException exception)

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -255,6 +255,7 @@ private:
     bool _smoothScaling;
     bool _legacyPixelShader;
 
+    bool _shaders_created {};
     ShaderProgram _tintShader;
     ShaderProgram _lightShader;
     ShaderProgram _transparencyShader;
@@ -291,7 +292,7 @@ private:
     void ResetAllBatches() override;
 
     // Sets up GL objects not related to particular display mode
-    void FirstTimeInit();
+    bool FirstTimeInit();
     // Initializes Gl rendering context
     bool InitGlScreen(const DisplayMode &mode);
     bool CreateWindowAndGlContext(const DisplayMode &mode);
@@ -304,7 +305,7 @@ private:
     // Test if supersampling should be allowed with the current setup
     void TestSupersampling();
     // Create shader programs for sprite tinting and changing light level
-    void CreateShaders();
+    bool CreateShaders();
     // Configure backbuffer texture, that is used in render-to-texture mode
     void SetupBackbufferTexture();
     void DeleteBackbufferTexture();


### PR DESCRIPTION
- modify OGL Renderer to fail when shader creation fails so Software renderer is used instead.

I moved things around to account for shader failing to compile, which should not be a problem - it should not fail on real hardware but I do have a MacOS VM that doesn't have good OpenGL support and it does. 

I am not sure if the code changes are acceptable, it's mostly changing function signatures to pass the error forward. Please verify.