### PR TITLE
ci_find_file: fix omission to check lstat return value, improve fastpath

### DIFF
--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -122,11 +122,15 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   // in the directory. it's theoretically possible a valid filename
   // could contain "..", but in that case it will just fallback to the
   // slower method later on and succeed.
-  if(directory && filename && !strstr(filename, "..")) {
+  if(filename && !strstr(filename, "..")) {
     char buf[1024];
-    snprintf(buf, sizeof buf, "%s/%s", directory, filename);
-    lstat(buf, &statbuf);
-    if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
+    if(!directory && filename[0] == '/')
+      snprintf(buf, sizeof buf, "%s", filename);
+    else
+      snprintf(buf, sizeof buf, "%s/%s", directory?directory:".", filename);
+
+    if (lstat(buf, &statbuf) == 0 &&
+        (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))) {
       diamond = strdup(buf); goto out;
     }
   }
@@ -173,8 +177,8 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   }
 
   while ((entry = readdir(rough)) != nullptr) {
-    lstat(entry->d_name, &statbuf);
-    if (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
+    if(lstat(entry->d_name, &statbuf) == 0 &&
+       (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
       if (strcasecmp(filename, entry->d_name) == 0) {
 #if AGS_PLATFORM_DEBUG
         fprintf(stderr, "ci_find_file: Looked for %s in rough %s, found diamond %s.\n", filename, directory, entry->d_name);

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -91,7 +91,6 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   struct stat   statbuf;
   struct dirent *entry     = nullptr;
   DIR           *rough     = nullptr;
-  DIR           *prevdir   = nullptr;
   char          *diamond   = nullptr;
   char          *directory = nullptr;
   char          *filename  = nullptr;
@@ -161,19 +160,9 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     filename[match_len] = '\0';
   }
 
-  if ((prevdir = opendir(".")) == nullptr) {
-    fprintf(stderr, "ci_find_file: cannot open current working directory\n");
-    goto out;
-  }
-
-  if (chdir(directory) == -1) {
-    fprintf(stderr, "ci_find_file: cannot change to directory: %s\n", directory);
-    goto out_pd;
-  }
-
   if ((rough = opendir(directory)) == nullptr) {
     fprintf(stderr, "ci_find_file: cannot open directory: %s\n", directory);
-    goto out_pd;
+    goto out;
   }
 
   while ((entry = readdir(rough)) != nullptr) {
@@ -190,10 +179,6 @@ char *ci_find_file(const char *dir_name, const char *file_name)
     }
   }
   closedir(rough);
-
-out_pd:;
-  fchdir(dirfd(prevdir));
-  closedir(prevdir);
 
 out:;
   if(directory) free(directory);

--- a/Common/util/misc.cpp
+++ b/Common/util/misc.cpp
@@ -177,9 +177,9 @@ char *ci_find_file(const char *dir_name, const char *file_name)
   }
 
   while ((entry = readdir(rough)) != nullptr) {
-    if(lstat(entry->d_name, &statbuf) == 0 &&
-       (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode)) {
-      if (strcasecmp(filename, entry->d_name) == 0) {
+    if (strcasecmp(filename, entry->d_name) == 0) {
+      if(lstat(entry->d_name, &statbuf) == 0 &&
+         (S_ISREG(statbuf.st_mode) || S_ISLNK(statbuf.st_mode))) {
 #if AGS_PLATFORM_DEBUG
         fprintf(stderr, "ci_find_file: Looked for %s in rough %s, found diamond %s.\n", filename, directory, entry->d_name);
 #endif // AGS_PLATFORM_DEBUG


### PR DESCRIPTION
if lstat() doesn't return success, it's undefined behaviour to access
the uninitialized memory of the stat buffer.

fast path was improved to kick in in almost 100% of cases, namely:
when directory is null and filename starts with a slash (absolute path)
use the absolute path for lookup, when directory is null and filename
doesn't start with a slash (relative path), use current directory.