### PR TITLE
Allow using OpenGL on MacOS (fail and use Software if it can't)

### DIFF
--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -142,7 +142,8 @@
                         AGS_PLATFORM_OS_IOS        || \
                         AGS_PLATFORM_OS_LINUX      || \
                         AGS_PLATFORM_OS_EMSCRIPTEN || \
-                        AGS_PLATFORM_OS_FREEBSD)
+                        AGS_PLATFORM_OS_FREEBSD    || \
+                        AGS_PLATFORM_OS_MACOS)
 #define AGS_OPENGL_ES2 (AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_EMSCRIPTEN)
 
 // Only allow searching around for game data on desktop systems;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -426,9 +426,13 @@ bool OGLGraphicsDriver::CreateShaders()
 
 
 
-static const auto default_vertex_shader_src = R"EOS(
-#version 100
-
+static const auto default_vertex_shader_src =  ""
+#if AGS_OPENGL_ES2
+"#version 100 \n"
+#else
+"#version 120 \n"
+#endif
+R"EOS(
 uniform mat4 uMVPMatrix;
 
 attribute vec2 a_Position;
@@ -445,11 +449,14 @@ void main() {
 )EOS";
 
 
-static const auto transparency_fragment_shader_src = R"EOS(
-#version 100
-
-precision mediump float;
-
+static const auto transparency_fragment_shader_src = ""
+#if AGS_OPENGL_ES2
+"#version 100 \n"
+"precision mediump float; \n"
+#else
+"#version 120 \n"
+#endif
+R"EOS(
 uniform sampler2D textID;
 uniform float alpha;
 
@@ -475,11 +482,14 @@ void main()
 // tintHSV - tint color in HSV,
 // tintAmnTrsLum - tint parameters: amount, translucence (alpha), luminance.
 
-static const auto tint_fragment_shader_src = R"EOS(
-#version 100
-
-precision mediump float;
-
+static const auto tint_fragment_shader_src = ""
+#if AGS_OPENGL_ES2
+"#version 100 \n"
+"precision mediump float; \n"
+#else
+"#version 120 \n"
+#endif
+R"EOS(
 uniform sampler2D textID;
 uniform vec3 tintHSV;
 uniform float tintAmount;
@@ -537,11 +547,14 @@ void main()
 // light - light level,
 // alpha - color alpha value.
 
-static const auto light_fragment_shader_src = R"EOS(
-#version 100
-
-precision mediump float;
-
+static const auto light_fragment_shader_src = ""
+#if AGS_OPENGL_ES2
+"#version 100 \n"
+"precision mediump float; \n"
+#else
+"#version 120 \n"
+#endif
+R"EOS(
 uniform sampler2D textID;
 uniform float light;
 uniform float alpha;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -291,7 +291,7 @@ private:
     void ResetAllBatches() override;
 
     // Sets up GL objects not related to particular display mode
-    void FirstTimeInit();
+    bool FirstTimeInit();
     // Initializes Gl rendering context
     bool InitGlScreen(const DisplayMode &mode);
     bool CreateWindowAndGlContext(const DisplayMode &mode);
@@ -304,7 +304,7 @@ private:
     // Test if supersampling should be allowed with the current setup
     void TestSupersampling();
     // Create shader programs for sprite tinting and changing light level
-    void CreateShaders();
+    bool CreateShaders();
     // Configure backbuffer texture, that is used in render-to-texture mode
     void SetupBackbufferTexture();
     void DeleteBackbufferTexture();


### PR DESCRIPTION
- modify OGL Renderer to fail when shader creation fails so Software renderer is used instead.
- modify shader version to be compatible (https://en.wikipedia.org/wiki/OpenGL_Shading_Language)
  - MacOS has at least 2.1 (version 120), but not OpenGL ES2 (version 100)

exactly the same as #1353 