### PR TITLE
Small fixes for building with CMake+MSVC on Windows

### DIFF
--- a/CMake/FetchSDL2.cmake
+++ b/CMake/FetchSDL2.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     sdl2_content
-    URL https://www.libsdl.org/release/SDL2-2.0.12.tar.gz
-    URL_HASH MD5=783b6f2df8ff02b19bb5ce492b99c8ff
+    URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.0.12.tar.gz
+    URL_HASH MD5=7ccff5e151cbca26476f6fcaae3ac46c
 )
 
 FetchContent_GetProperties(sdl2_content)

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -179,6 +179,10 @@ target_sources(common
 
 target_link_libraries(common PUBLIC SDL2::SDL2 Allegro::Allegro AlFont::AlFont AAStr::AAStr)
 
+if (WIN32)
+    target_link_libraries(common PUBLIC shlwapi)
+endif()
+
 # NOTE: You can optionally create case sensitive filesystems on Macos and Windows now.
 if (LINUX)
     target_compile_definitions(common PRIVATE AGS_CASE_SENSITIVE_FILESYSTEM)

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -2445,7 +2445,7 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
   }
 
   int oploc = find_lowest_bonding_operator(symlist,listlen);
-  bool hasNegatedLiteral;
+  bool hasNegatedLiteral = false;
 
   // A literal is being negated on the left
   if ((oploc == 0) && (listlen > 1) && (sym.get_type(symlist[1]) == SYM_LITERALVALUE) &&


### PR DESCRIPTION
Just some small corrections I picked building with CMake on Windows
- link shlwapi when building Common alone 
- hasNegateLiteral is being used without being initialized error pops up when trying to build Compiler Tests with CMake on Windows

Additionally, better always get SDL2 from GitHub on CMake builds, because it has better uptime than the SDL website.