### PR TITLE
Includes SDL2.dll on the editor package

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -239,6 +239,7 @@ editor_packaging_task:
     os_version: 2019
   env:
     TEMPLATES_REPOSITORY: adventuregamestudio/ags-templates
+    AGS_SDL_LIB: C:\Lib\SDL2\lib\x86
   get_vcredist_script: >
     mkdir Windows\Installer\Source\Redist &&
     copy %SYSTEMDRIVE%\Redist\vc_redist.x86.exe Windows\Installer\Source\Redist\
@@ -250,6 +251,8 @@ editor_packaging_task:
     mkdir Windows\Installer\Source\Engine &&
     curl -fLSso Windows\Installer\Source\Engine\acwin.exe
     "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_windows/binaries/Solutions/.build/Release/acwin.exe"
+  get_sdl2_dll_script: >
+    copy %AGS_SDL_LIB%\SDL2.dll Windows\Installer\Source\Engine
   get_manual_script: >
     mkdir Windows\Installer\Source\Docs &&
     cd Windows\Installer\Source\Docs &&

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -80,6 +80,7 @@ Name: "{app}\Templates";
 [Files]
 ; Engine files
 Source: "Source\Engine\acwin.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: engine\default
+Source: "Source\Engine\SDL2.dll"; DestDir: "{app}"; Flags: ignoreversion; Components: engine\default
 ; Editor files
 Source: "Source\Editor\AGSEditor.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 Source: "Source\Editor\acsprset.spr"; DestDir: "{app}"; Flags: ignoreversion; Components: main


### PR DESCRIPTION
- Cirrus CI: place SDL2.dll in Installer/Source/Engine
- Editor Installer: add SDL2.dll

If we decide to static link SDL2 on Windows in the future, we can revert this commit. 

This makes both the Editor installer and the archive include the SDL2.dll. 

Edit: there's also the possibility to just squish the SDL2.dll to the exe when making the single exe game, at least I think that works in Windows.