### PR TITLE
3.6.0: Support reading from game assets in script + Editor supports packing custom files

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -179,8 +179,9 @@ void AssetManager::FindAssets(std::vector<String> &assets, const String &wildcar
 
     for (const auto *lib : _activeLibs)
     {
-        auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
-        if (match == lib->Filters.end())
+        if (filter != "*" &&
+            std::find(lib->Filters.begin(), lib->Filters.end(), filter)
+            == lib->Filters.end())
             continue; // filter does not match
 
         bool found = false;
@@ -247,8 +248,9 @@ bool AssetManager::GetAsset(const String &asset_name, const String &filter, bool
 {
     for (const auto *lib : _activeLibs)
     {
-        auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
-        if (match == lib->Filters.end())
+        if (filter != "*" &&
+            std::find(lib->Filters.begin(), lib->Filters.end(), filter)
+            == lib->Filters.end())
             continue; // filter does not match
 
         bool found = false;

--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -13,6 +13,8 @@
 //=============================================================================
 #include "core/assetmanager.h"
 #include <algorithm>
+#include <regex>
+#include "util/directory.h"
 #include "util/multifilelib.h"
 #include "util/path.h"
 #include "util/string_utils.h" // cbuf_to_string_and_free
@@ -166,6 +168,41 @@ String AssetManager::FindAssetFileOnly(const String &asset_name, const String &f
     if (GetAsset(asset_name, filter, true, &loc, Common::kFile_Open, Common::kFile_Read))
         return loc.FileName;
     return "";
+}
+
+void AssetManager::FindAssets(std::vector<String> &assets, const String &wildcard,
+    const String &filter) const
+{
+    String pattern = StrUtil::WildcardToRegex(wildcard);
+    const std::regex regex(pattern.GetCStr(), std::regex_constants::icase);
+    std::cmatch mr;
+
+    for (const auto *lib : _activeLibs)
+    {
+        auto match = std::find(lib->Filters.begin(), lib->Filters.end(), filter);
+        if (match == lib->Filters.end())
+            continue; // filter does not match
+
+        bool found = false;
+        if (IsAssetLibDir(lib))
+        {
+            for (FindFile ff = FindFile::OpenFiles(lib->BaseDir, wildcard);
+                 !ff.AtEnd(); ff.Next())
+                assets.push_back(ff.Current());
+        }
+        else
+        {
+            for (const auto &a : lib->AssetInfos)
+            {
+                if (std::regex_match(a.FileName.GetCStr(), mr, regex))
+                    assets.push_back(a.FileName);
+            }
+        }
+    }
+
+    // Sort and remove duplicates
+    std::sort(assets.begin(), assets.end());
+    assets.erase(std::unique(assets.begin(), assets.end()), assets.end());
 }
 
 AssetError AssetManager::RegisterAssetLib(const String &path, AssetLibEx *&out_lib)

--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -97,6 +97,10 @@ public:
     bool         DoesAssetExist(const String &asset_name, const String &filter = "") const;
     // Finds asset only looking for bare files in directories; returns full path or empty string if failed
     String       FindAssetFileOnly(const String &asset_name, const String &filter = "") const;
+    // Searches in all the registered locations and collects a list of
+    // assets using given wildcard pattern
+    void         FindAssets(std::vector<String> &assets, const String &wildcard,
+                                   const String &filter = "") const;
     // Open asset stream in the given work mode; returns null if asset is not found or cannot be opened
     // This method only searches in libraries that do not have any defined filters
     Stream      *OpenAsset(const String &asset_name, soff_t *asset_size = nullptr,

--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -134,6 +134,19 @@ bool Bitmap::LoadFromFile(const char *filename)
 	return _alBitmap != nullptr;
 }
 
+bool Bitmap::LoadFromFile(PACKFILE *pf)
+{
+    Destroy();
+
+    BITMAP *al_bmp = load_bmp_pf(pf, nullptr);
+    if (al_bmp)
+    {
+        _alBitmap = al_bmp;
+        _isDataOwner = true;
+    }
+    return _alBitmap != nullptr;
+}
+
 bool Bitmap::SaveToFile(const char *filename, const void *palette)
 {
 	return save_bitmap(filename, _alBitmap, (const RGB*)palette) == 0;

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -58,6 +58,7 @@ public:
     bool    LoadFromFile(const String &filename)
             { return LoadFromFile(filename.GetCStr()); }
     bool    LoadFromFile(const char *filename);
+    bool    LoadFromFile(PACKFILE *pf);
     bool    SaveToFile(const String &filename, const void *palette)
             { return SaveToFile(filename.GetCStr(), palette); }
     bool    SaveToFile(const char *filename, const void *palette);

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -79,6 +79,17 @@ Bitmap *LoadFromFile(const char *filename)
 	return bitmap;
 }
 
+Bitmap *LoadFromFile(PACKFILE *pf)
+{
+    Bitmap *bitmap = new Bitmap();
+    if (!bitmap->LoadFromFile(pf))
+    {
+        delete bitmap;
+        bitmap = nullptr;
+    }
+    return bitmap;
+}
+
 Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height)
 {
     int oldw = src->GetWidth(), oldh = src->GetHeight();

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -67,6 +67,7 @@ namespace BitmapHelper
     Bitmap *CreateBitmapCopy(Bitmap *src, int color_depth = 0);
 	Bitmap *LoadFromFile(const char *filename);
     inline Bitmap *LoadFromFile(const String &filename) { return LoadFromFile(filename.GetCStr()); }
+    Bitmap *LoadFromFile(PACKFILE *pf);
 
     // Stretches bitmap to the requested size. The new bitmap will have same
     // colour depth. Returns original bitmap if no changes are necessary. 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -127,6 +127,12 @@ namespace AGS.Editor
         public const string COMPILED_SETUP_FILE_NAME = "winsetup.exe";
 		public const string GAME_EXPLORER_THUMBNAIL_FILE_NAME = "GameExplorer.png";
 
+        public readonly string[] RestrictedGameDirectories = new string[]
+        {
+            OUTPUT_DIRECTORY, DEBUG_OUTPUT_DIRECTORY, AudioClip.AUDIO_CACHE_DIRECTORY,
+            Components.SpeechComponent.SPEECH_DIRECTORY
+        };
+
         private Game _game;
         private string _editorExePath;
         private Script _builtInScriptHeader;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -87,8 +87,14 @@ namespace AGS.Editor
          * 25: 3.5.0.22   - Full editor version saved into XML header, RuntimeSetup.ThreadedAudio.
          * 26:            - Fixed sound references in game properties.
          * 27: 3.5.1      - Settings.AttachDataToExe
+         * --------------------------------------------------------------------
+         * Since 3.6.0 define format value as AGS version represented as NN,NN,NN,NN:
+         * e.g. 3.6.0     is 03,06,00,00 (3060000),
+         *      4.12.3.25 is 04,12,03,25 (4120325), and so on
+         * --------------------------------------------------------------------
+         * 3.6.0          - Settings.
         */
-        public const int    LATEST_XML_VERSION_INDEX = 27;
+        public const int    LATEST_XML_VERSION_INDEX = 3060000;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -33,7 +33,10 @@ namespace AGS.Editor
             }
         }
 
-        private string[] ConstructFileListForDataFile()
+        /// Creates a list of game resources as a list of tuples:
+        /// - first tuple's element is resource's name,
+        /// - second is real file path
+        private Tuple<string, string>[] ConstructFileListForDataFile()
         {
             List<string> files = new List<string>();
             Environment.CurrentDirectory = Factory.AGSEditor.CurrentGame.DirectoryPath;
@@ -59,7 +62,14 @@ namespace AGS.Editor
                 }
             }
             Utilities.AddAllMatchingFiles(files, "*.ogv");
-            return files.ToArray();
+
+            // Regular files are registered under their filenames (w/o dir)
+            var assetList = new List<Tuple<string, string>>();
+            foreach (var f in files)
+            {
+                assetList.Add(new Tuple<string, string>(Path.GetFileName(f), f));
+            }
+            return assetList.ToArray();
         }
 
         private void CreateAudioVOXFile(bool forceRebuild)

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -63,11 +63,23 @@ namespace AGS.Editor
             }
             Utilities.AddAllMatchingFiles(files, "*.ogv");
 
+            List<string> userFiles = new List<string>();
+            string user_dir = Factory.AGSEditor.CurrentGame.Settings.CustomDataDir;
+            if (!string.IsNullOrWhiteSpace(user_dir))
+            {
+                Utilities.AddAllMatchingFiles(userFiles, user_dir, "*", true, SearchOption.AllDirectories);
+            }
+
             // Regular files are registered under their filenames (w/o dir)
             var assetList = new List<Tuple<string, string>>();
             foreach (var f in files)
             {
                 assetList.Add(new Tuple<string, string>(Path.GetFileName(f), f));
+            }
+            // User files are registered under their relative paths
+            foreach (var f in userFiles)
+            {
+                assetList.Add(new Tuple<string, string>(f, f));
             }
             return assetList.ToArray();
         }

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -33,10 +33,12 @@ namespace AGS.Editor
             }
         }
 
+        /// <summary>
         /// Creates a list of game resources as a list of tuples:
         /// - first tuple's element is resource's name,
         /// - second is real file path
-        private Tuple<string, string>[] ConstructFileListForDataFile()
+        /// </summary>
+        private Tuple<string, string>[] ConstructFileListForDataFile(CompileMessages errors)
         {
             List<string> files = new List<string>();
             Environment.CurrentDirectory = Factory.AGSEditor.CurrentGame.DirectoryPath;
@@ -63,20 +65,74 @@ namespace AGS.Editor
             }
             Utilities.AddAllMatchingFiles(files, "*.ogv");
 
-            List<string> userFiles = new List<string>();
-            string user_dir = Factory.AGSEditor.CurrentGame.Settings.CustomDataDir;
-            if (!string.IsNullOrWhiteSpace(user_dir))
-            {
-                Utilities.AddAllMatchingFiles(userFiles, user_dir, "*", true, SearchOption.AllDirectories);
-            }
-
             // Regular files are registered under their filenames (w/o dir)
             var assetList = new List<Tuple<string, string>>();
             foreach (var f in files)
             {
                 assetList.Add(new Tuple<string, string>(Path.GetFileName(f), f));
             }
+
+            var userFiles = ConstructCustomFileListForDataFile(errors);
+            if (userFiles != null) assetList.AddRange(userFiles);
+            return assetList.ToArray();
+        }
+
+        /// <summary>
+        /// Creates a list of custom game resources as a list of tuples:
+        /// - first tuple's element is resource's name,
+        /// - second is real file path
+        /// </summary>
+        private Tuple<string, string>[] ConstructCustomFileListForDataFile(CompileMessages errors)
+        {
+            string userOpt = Factory.AGSEditor.CurrentGame.Settings.CustomDataDir;
+            if (string.IsNullOrEmpty(userOpt)) return null;
+
+            string curDir = Factory.AGSEditor.CurrentGame.DirectoryPath;
+            string[] restrictedDirs = new string[] {
+                Path.Combine(curDir, AGSEditor.OUTPUT_DIRECTORY),
+                Path.Combine(curDir, AGSEditor.DEBUG_OUTPUT_DIRECTORY),
+                Path.Combine(curDir, "AudioCache"),
+                Path.Combine(curDir, "Speech") };
+
+            List<string> userFiles = new List<string>();
+            string[] user_dirs = userOpt.Split(',');
+            Array.Sort(user_dirs);
+            List<string> usedCustomDirs = new List<string>();
+
+            foreach (var dir in user_dirs)
+            {
+                // don't allow absolute paths
+                if (Path.IsPathRooted(dir))
+                {
+                    errors.Add(new CompileWarning(
+                        string.Format("Cannot use absolute path as a custom data source: {0}", dir)));
+                    continue;
+                }
+                // don't allow paths with "." or ".." in them
+                if (Utilities.DoesPathContainDotDirs(dir))
+                {
+                    errors.Add(new CompileWarning(
+                        string.Format("Cannot use path containing '.' or '..' as a custom data source: {0}", dir)));
+                    continue;
+                }
+                // don't allow paths that match or inside restricted folders,
+                // or folders that were already used to make a list of assets
+                string testDir = Path.Combine(curDir, dir);
+                if (Utilities.PathIsSameOrNestedAmong(testDir, restrictedDirs))
+                {
+                    errors.Add(new CompileWarning(
+                        string.Format("Cannot use restricted location as a custom data source: {0}", dir)));
+                    continue;
+                }
+                if (Utilities.PathIsSameOrNestedAmong(testDir, usedCustomDirs.ToArray()))
+                    continue; // don't report, simply skip
+
+                Utilities.AddAllMatchingFiles(userFiles, dir, "*", true, SearchOption.AllDirectories);
+                usedCustomDirs.Add(Path.Combine(curDir, dir));
+            }
+
             // User files are registered under their relative paths
+            var assetList = new List<Tuple<string, string>>();
             foreach (var f in userFiles)
             {
                 assetList.Add(new Tuple<string, string>(f, f));
@@ -125,7 +181,8 @@ namespace AGS.Editor
             {
                 return false;
             }
-            string errorMsg = DataFileWriter.MakeDataFile(ConstructFileListForDataFile(), Factory.AGSEditor.CurrentGame.Settings.SplitResources * 1000000,
+            string errorMsg = DataFileWriter.MakeDataFile(ConstructFileListForDataFile(errors),
+                Factory.AGSEditor.CurrentGame.Settings.SplitResources * 1000000,
                 Factory.AGSEditor.BaseGameFileName, true);
             if (errorMsg != null)
             {

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -88,11 +88,9 @@ namespace AGS.Editor
             if (string.IsNullOrEmpty(userOpt)) return null;
 
             string curDir = Factory.AGSEditor.CurrentGame.DirectoryPath;
-            string[] restrictedDirs = new string[] {
-                Path.Combine(curDir, AGSEditor.OUTPUT_DIRECTORY),
-                Path.Combine(curDir, AGSEditor.DEBUG_OUTPUT_DIRECTORY),
-                Path.Combine(curDir, "AudioCache"),
-                Path.Combine(curDir, "Speech") };
+            string[] restrictedDirs = new string[Factory.AGSEditor.RestrictedGameDirectories.Length];
+            for (int i = 0; i < restrictedDirs.Length; ++i)
+                restrictedDirs[i] = Path.Combine(curDir, Factory.AGSEditor.RestrictedGameDirectories[i]);
 
             List<string> userFiles = new List<string>();
             string[] user_dirs = userOpt.Split(',');

--- a/Editor/AGS.Editor/Components/SpeechComponent.cs
+++ b/Editor/AGS.Editor/Components/SpeechComponent.cs
@@ -13,6 +13,7 @@ namespace AGS.Editor.Components
 {
     class SpeechComponent : BaseComponent
     {
+        public static readonly string SPEECH_DIRECTORY = "Speech";
         private static readonly string PAMELA_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.pam";
         private static readonly string PAPAGAYO_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.dat";
         private static readonly string OGG_VORBIS_FILE_FILTER = "Speech" + Path.DirectorySeparatorChar + "*.ogg";

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -1,6 +1,5 @@
 using AGS.Types;
 using AGS.Editor.Utils;
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,10 +7,8 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.AccessControl;
-using System.Security.Principal;
-using System.Text;
 using System.Windows.Forms;
 
 namespace AGS.Editor
@@ -37,6 +34,9 @@ namespace AGS.Editor
 
         [DllImport("user32.dll", EntryPoint = "DestroyIcon")]
         private static extern bool DestroyIcon(IntPtr hIcon);
+
+        private static char[] PathSeparators = new char[]
+        { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 
         public static string SelectedReligion = "Not a Believer";
 
@@ -178,6 +178,39 @@ namespace AGS.Editor
             }
 
             return sourcePath;
+        }
+
+        /// <summary>
+        /// Tells if the given path equals to or subdirectory of a basepath.
+        /// </summary>
+        public static bool PathsAreSameOrNested(string path, string basepath)
+        {
+            Uri baseUri = new Uri(basepath + Path.DirectorySeparatorChar);
+            Uri pathUri = new Uri(path + Path.DirectorySeparatorChar);
+            return baseUri.IsBaseOf(pathUri);
+        }
+
+        /// <summary>
+        /// Tells if the given path equals to or is a subdirectory of one
+        /// of the given basepaths
+        /// </summary>
+        public static bool PathIsSameOrNestedAmong(string path, string[] basepaths)
+        {
+            foreach (string basepath in basepaths)
+            {
+                if (Utilities.PathsAreSameOrNested(path, basepath))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Tells if the path contains "." or ".." sections.
+        /// </summary>
+        public static bool DoesPathContainDotDirs(string path)
+        {
+            string[] parts = path.Split(PathSeparators);
+            return parts.Contains(".") || parts.Contains("..");
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -123,33 +123,22 @@ namespace AGS.Editor
 
         public static void AddAllMatchingFiles(IList<string> list, string fileMask, bool fullPaths)
         {
-            string currentDirectory = Directory.GetCurrentDirectory();
-            foreach (string fileName in GetDirectoryFileList(currentDirectory, fileMask))
-            {
-                if (fullPaths)
-                {
-                    list.Add(fileName);
-                }
-                else
-                {
-                    list.Add(fileName.Substring(currentDirectory.Length + 1));
-                }
-            }
+            AddAllMatchingFiles(list, Directory.GetCurrentDirectory(), fileMask, fullPaths);
         }
 
         public static void AddAllMatchingFiles(IList<string> list, string parentDir,
-            string fileMask, bool fullPaths, SearchOption searchOption)
+            string fileMask, bool fullPaths, SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            foreach (string fileName in GetDirectoryFileList(parentDir, fileMask, searchOption))
+            var files = GetDirectoryFileList(parentDir, fileMask, searchOption);
+            if (fullPaths)
             {
-                if (fullPaths)
-                {
+                foreach (string fileName in files)
                     list.Add(fileName);
-                }
-                else
-                {
+            }
+            else
+            {
+                foreach (string fileName in files)
                     list.Add(fileName.Substring(parentDir.Length + 1));
-                }
             }
         }
 
@@ -194,14 +183,9 @@ namespace AGS.Editor
         /// Tells if the given path equals to or is a subdirectory of one
         /// of the given basepaths
         /// </summary>
-        public static bool PathIsSameOrNestedAmong(string path, string[] basepaths)
+        public static bool PathIsSameOrNestedAmong(string path, IEnumerable<string> basepaths)
         {
-            foreach (string basepath in basepaths)
-            {
-                if (Utilities.PathsAreSameOrNested(path, basepath))
-                    return true;
-            }
-            return false;
+            return basepaths.Any(basep => Utilities.PathsAreSameOrNested(path, basep));
         }
 
         /// <summary>
@@ -210,7 +194,7 @@ namespace AGS.Editor
         public static bool DoesPathContainDotDirs(string path)
         {
             string[] parts = path.Split(PathSeparators);
-            return parts.Contains(".") || parts.Contains("..");
+            return parts.Any(p => p == "." || p == "..");
         }
 
         /// <summary>

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -137,6 +137,22 @@ namespace AGS.Editor
             }
         }
 
+        public static void AddAllMatchingFiles(IList<string> list, string parentDir,
+            string fileMask, bool fullPaths, SearchOption searchOption)
+        {
+            foreach (string fileName in GetDirectoryFileList(parentDir, fileMask, searchOption))
+            {
+                if (fullPaths)
+                {
+                    list.Add(fileName);
+                }
+                else
+                {
+                    list.Add(fileName.Substring(parentDir.Length + 1));
+                }
+            }
+        }
+
         public static string GetRelativeToProjectPath(string absolutePath)
         {
             if (String.IsNullOrEmpty(absolutePath) ||

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -148,7 +148,14 @@ namespace AGS.Types
                 StringSplitOptions.RemoveEmptyEntries), checkAvailable);
         }
 
-		public void GenerateNewGameID()
+        private static string GetCustomDirsString(string input)
+        {
+            var dirs = input.Split(StringListUIEditor.Separators, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < dirs.Length; i++) dirs[i] = dirs[i].Trim();
+            return string.Join(",", dirs);
+        }
+
+        public void GenerateNewGameID()
 		{
 			_uniqueID = Environment.TickCount;
 			_guid = Guid.NewGuid();
@@ -395,13 +402,13 @@ namespace AGS.Types
             set { _scaleMovementSpeedWithMaskRes = value; }
         }
 
-        [DisplayName("Package custom data folder")]
-        [Description("Contents of this folder and all of its subfolders will be added to the game resources")]
+        [DisplayName("Package custom data folder(s)")]
+        [Description("A comma-separated list of folders; their contents will be added to the game resources")]
         [Category("Compiler")]
         public string CustomDataDir
         {
             get { return _customDataDir; }
-            set { _customDataDir = value; }
+            set { _customDataDir = GetCustomDirsString(value); }
         }
 
         [DisplayName("Split resource files into X MB-sized chunks")]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -49,6 +49,7 @@ namespace AGS.Types
         private bool _autoMoveInWalkMode = true;
         private bool _letterboxMode = false;
         private RenderAtScreenResolution _renderAtScreenRes = RenderAtScreenResolution.UserDefined;
+        private string _customDataDir = null;
         private int _splitResources = 0;
         private bool _attachDataToExe = true;
         private bool _turnBeforeWalking = true;
@@ -392,6 +393,15 @@ namespace AGS.Types
         {
             get { return _scaleMovementSpeedWithMaskRes; }
             set { _scaleMovementSpeedWithMaskRes = value; }
+        }
+
+        [DisplayName("Package custom data folder")]
+        [Description("Contents of this folder and all of its subfolders will be added to the game resources")]
+        [Category("Compiler")]
+        public string CustomDataDir
+        {
+            get { return _customDataDir; }
+            set { _customDataDir = value; }
         }
 
         [DisplayName("Split resource files into X MB-sized chunks")]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -150,8 +150,8 @@ namespace AGS.Types
 
         private static string GetCustomDirsString(string input)
         {
-            var dirs = input.Split(StringListUIEditor.Separators, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < dirs.Length; i++) dirs[i] = dirs[i].Trim();
+            var dirs = input.Split(StringListUIEditor.Separators, StringSplitOptions.RemoveEmptyEntries).
+                Select(d => d.Trim());
             return string.Join(",", dirs);
         }
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -52,7 +52,7 @@ int File_Exists(const char *fnmm) {
     return 0;
 
   if (rp.AssetMgr)
-      return AssetMgr->DoesAssetExist(rp.FullPath);
+      return AssetMgr->DoesAssetExist(rp.FullPath, "*");
 
   return (File::TestReadFile(rp.FullPath) || File::TestReadFile(rp.AltPath)) ? 1 : 0;
 }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -51,6 +51,9 @@ int File_Exists(const char *fnmm) {
   if (!ResolveScriptPath(fnmm, true, rp))
     return 0;
 
+  if (rp.AssetMgr)
+      return AssetMgr->DoesAssetExist(rp.FullPath);
+
   return (File::TestReadFile(rp.FullPath) || File::TestReadFile(rp.AltPath)) ? 1 : 0;
 }
 
@@ -196,6 +199,7 @@ const String GameInstallRootToken    = "$INSTALLDIR$";
 const String UserSavedgamesRootToken = "$MYDOCS$";
 const String GameSavedgamesDirToken  = "$SAVEGAMEDIR$";
 const String GameDataDirToken        = "$APPDATADIR$";
+const String GameAssetToken          = "$DATA$";
 const String UserConfigFileToken     = "$CONFIGFILE$";
 
 void FixupFilename(char *filename)
@@ -295,15 +299,13 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
     }
 
     // Test absolute paths
-    bool is_absolute = !Path::IsRelativePath(orig_sc_path);
-    if (is_absolute && !read_only)
+    if (!Path::IsRelativePath(orig_sc_path))
     {
-        debug_script_warn("Attempt to access file '%s' denied (cannot write to absolute path)", orig_sc_path.GetCStr());
-        return false;
-    }
-
-    if (is_absolute)
-    {
+        if (!read_only)
+        {
+            debug_script_warn("Attempt to access file '%s' denied (cannot write to absolute path)", orig_sc_path.GetCStr());
+            return false;
+        }
         rp = ResolvedPath(orig_sc_path);
         return true;
     }
@@ -312,6 +314,18 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
     // IMPORTANT: for compatibility reasons we support both cases:
     // when token is followed by the path separator and when it is not, in which case it's assumed.
     String sc_path = orig_sc_path;
+    if (sc_path.CompareLeft(GameAssetToken, GameAssetToken.GetLength()) == 0)
+    {
+        if (!read_only)
+        {
+            debug_script_warn("Attempt to access file '%s' denied (cannot write to game assets)", orig_sc_path.GetCStr());
+            return false;
+        }
+        rp.FullPath = sc_path.Mid(GameAssetToken.GetLength() + 1);
+        rp.AssetMgr = true;
+        return true;
+    }
+
     FSLocation parent_dir;
     String child_path;
     String alt_path;

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "ac/global_dynamicsprite.h"
+#include "ac/asset_helper.h"
 #include "ac/draw.h"
 #include "ac/dynamicsprite.h"
 #include "ac/path_helper.h"
@@ -32,12 +33,22 @@ int LoadImageFile(const char *filename)
     if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
-    // TODO: support loading from asset (stream);
-    // use PACKFILE / load_bmp_pf? Or read data and allocate bitmap struct ourselves
+    Bitmap *loadedFile;
+    if (rp.AssetMgr)
+    {
+        size_t asset_size;
+        PACKFILE *pf = PackfileFromAsset(rp.FullPath, asset_size);
+        if (!pf)
+            return 0;
+        loadedFile = BitmapHelper::LoadFromFile(pf);
+    }
+    else
+    {
+        loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
+        if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+            loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
+    }
 
-    Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
-    if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-        loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);
     if (!loadedFile)
         return 0;
 

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -32,6 +32,9 @@ int LoadImageFile(const char *filename)
     if (!ResolveScriptPath(filename, true, rp))
         return 0;
 
+    // TODO: support loading from asset (stream);
+    // use PACKFILE / load_bmp_pf? Or read data and allocate bitmap struct ourselves
+
     Bitmap *loadedFile = BitmapHelper::LoadFromFile(rp.FullPath);
     if (!loadedFile && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
         loadedFile = BitmapHelper::LoadFromFile(rp.AltPath);

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -37,7 +37,7 @@ int LoadImageFile(const char *filename)
     if (rp.AssetMgr)
     {
         size_t asset_size;
-        PACKFILE *pf = PackfileFromAsset(rp.FullPath, asset_size);
+        PACKFILE *pf = PackfileFromAsset(AssetPath(rp.FullPath, "*"), asset_size);
         if (!pf)
             return 0;
         loadedFile = BitmapHelper::LoadFromFile(pf);

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -19,6 +19,7 @@
 #include "ac/path_helper.h"
 #include "ac/runtime_defines.h"
 #include "ac/string.h"
+#include "core/assetmanager.h"
 #include "debug/debug_log.h"
 #include "util/directory.h"
 #include "util/path.h"
@@ -79,9 +80,17 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
       return 0;
   }
 
-  Stream *s = File::OpenFile(rp.FullPath, open_mode, work_mode);
-  if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-    s = File::OpenFile(rp.AltPath, open_mode, work_mode);
+  Stream *s;
+  if (rp.AssetMgr)
+  {
+    s = AssetMgr->OpenAsset(rp.FullPath, nullptr, open_mode, work_mode);
+  }
+  else
+  {
+    s = File::OpenFile(rp.FullPath, open_mode, work_mode);
+    if (!s && !rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+      s = File::OpenFile(rp.AltPath, open_mode, work_mode);
+  }
 
   valid_handles[useindx].stream = s;
   if (valid_handles[useindx].stream == nullptr)

--- a/Engine/ac/global_file.cpp
+++ b/Engine/ac/global_file.cpp
@@ -83,7 +83,7 @@ int32_t FileOpen(const char*fnmm, Common::FileOpenMode open_mode, Common::FileWo
   Stream *s;
   if (rp.AssetMgr)
   {
-    s = AssetMgr->OpenAsset(rp.FullPath, nullptr, open_mode, work_mode);
+    s = AssetMgr->OpenAsset(rp.FullPath, "*", nullptr, open_mode, work_mode);
   }
   else
   {

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -71,7 +71,7 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   std::vector<String> files;
   if (rp.AssetMgr)
   {
-    AssetMgr->FindAssets(files, rp.FullPath);
+    AssetMgr->FindAssets(files, rp.FullPath, "*");
   }
   else
   {

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -11,10 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-#include <algorithm>
-#include <set>
-#include <allegro.h> // find files
 #include "ac/listbox.h"
+#include <algorithm>
+#include <vector>
+#include <allegro.h> // find files
 #include "ac/common.h"
 #include "ac/game.h"
 #include "ac/gamesetupstruct.h"
@@ -22,6 +22,7 @@
 #include "ac/global_game.h"
 #include "ac/path_helper.h"
 #include "ac/string.h"
+#include "core/assetmanager.h"
 #include "gui/guimain.h"
 #include "debug/debug_log.h"
 #include "util/path.h"
@@ -49,12 +50,12 @@ void ListBox_Clear(GUIListBox *listbox) {
   listbox->Clear();
 }
 
-void FillDirList(std::set<String> &files, const String &path)
+void FillDirList(std::vector<String> &files, const String &path)
 {
     al_ffblk dfb;
     int	dun = al_findfirst(path.GetCStr(), &dfb, FA_SEARCH);
     while (!dun) {
-        files.insert(dfb.name);
+        files.push_back(dfb.name);
         dun = al_findnext(&dfb);
     }
     al_findclose(&dfb);
@@ -67,15 +68,23 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   if (!ResolveScriptPath(filemask, true, rp))
     return;
 
-  // TODO: support listing assets from AssetMgr
-
-  std::set<String> files;
-  FillDirList(files, rp.FullPath);
-  if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
-    FillDirList(files, rp.AltPath);
+  std::vector<String> files;
+  if (rp.AssetMgr)
+  {
+    AssetMgr->FindAssets(files, rp.FullPath);
+  }
+  else
+  {
+    FillDirList(files, rp.FullPath);
+    if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)
+      FillDirList(files, rp.AltPath);
+    // Sort and remove duplicates
+    std::sort(files.begin(), files.end());
+    files.erase(std::unique(files.begin(), files.end()), files.end());
+  }
 
   // TODO: method for adding item batch to speed up update
-  for (std::set<String>::const_iterator it = files.begin(); it != files.end(); ++it)
+  for (auto it = files.cbegin(); it != files.cend(); ++it)
   {
     listbox->AddItem(*it);
   }

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -67,6 +67,8 @@ void ListBox_FillDirList(GUIListBox *listbox, const char *filemask) {
   if (!ResolveScriptPath(filemask, true, rp))
     return;
 
+  // TODO: support listing assets from AssetMgr
+
   std::set<String> files;
   FillDirList(files, rp.FullPath);
   if (!rp.AltPath.IsEmpty() && rp.AltPath.Compare(rp.FullPath) != 0)

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -73,6 +73,7 @@ struct ResolvedPath
     FSLocation Loc;  // location (directory)
     String FullPath; // full path, including filename
     String AltPath;  // alternative read-only full path, for backwards compatibility
+    bool   AssetMgr = false; // file is to be accessed through the asset manager
     ResolvedPath() = default;
     ResolvedPath(const String &file, const String &alt = "")
         : FullPath(file), AltPath(alt) {}


### PR DESCRIPTION
Fully resolves #1227.

This PR does two things:
1. Adds support for reading resource files ("assets") in script. This is a backport of #1294 for ags3. I recommend reading 1294's description to understand how this works.
2. In the Editor adds new property to General Settings called "Package custom data folder". If this property is filled, Editor will gather all files from the corresponding subfolder (recursively, including all files in all nested subfolders), and package these files into the game along with all the standard files.

Regarding p2:
* Resources packaged like this are assigned names containing full relative path. For example: `Data/subdir/myfile.dat`. The topmost dir name is also kept - to easily avoid filename conflicts with the rest of the game files.
* To be precise, the path slashes are forced to strictly forward style. This may be important when opening these files in script; although we might adjust engine's behavior to support both ways when opening resources from a package (frankly, I don't remember if it already does that).
* These files may be opened in script using a new filepath token "$DATA$" (as described in #1294), for example:
```
File* f = File.Open("$DATA$/Data/subdir/myfile.dat", eFileRead);
```
* To clarify once more, just in case, $DATA$ token only allows to open files for reading.