### PR TITLE
CMake: allow building Tools from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ project(AGS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 option(AGS_TESTS "Build tests" OFF)
-option(AGS_BUILD_COMPILER "Build compiler library" OFF)
+option(AGS_BUILD_TOOLS "Build Tools" OFF)
+option(AGS_BUILD_COMPILER "Build compiler" ${AGS_BUILD_TOOLS})
 option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_NO_VIDEO_PLAYER "Disable Video" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" ON)
@@ -20,6 +21,7 @@ set(AGS_BUILD_STR "" CACHE STRING "Engine Build Information")
 
 message("------ AGS selected CMake options ------")
 message(" AGS_TESTS: ${AGS_TESTS}")
+message(" AGS_BUILD_TOOLS: ${AGS_BUILD_TOOLS}")
 message(" AGS_BUILD_COMPILER: ${AGS_BUILD_COMPILER}")
 message(" AGS_NO_MP3_PLAYER: ${AGS_NO_MP3_PLAYER}")
 message(" AGS_NO_VIDEO_PLAYER: ${AGS_NO_VIDEO_PLAYER}")
@@ -184,6 +186,7 @@ include(FetchVorbis)
 include(FetchTheora)
 
 add_subdirectory(libsrc/glm                     EXCLUDE_FROM_ALL)
+add_subdirectory(libsrc/tinyxml2                EXCLUDE_FROM_ALL)
 
 add_subdirectory(Common/libsrc/aastr-0.1.1      EXCLUDE_FROM_ALL)
 add_subdirectory(Common/libsrc/alfont-2.0.9     EXCLUDE_FROM_ALL)
@@ -201,6 +204,10 @@ add_subdirectory(Engine/libsrc/libcda-0.5       EXCLUDE_FROM_ALL)
 add_subdirectory(Engine)
 if(AGS_BUILD_COMPILER)
     add_subdirectory(Compiler)
+endif()
+
+if(AGS_BUILD_TOOLS)
+    add_subdirectory(Tools)
 endif()
 
 set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ags)

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,0 +1,119 @@
+add_library(libtools)
+
+set_target_properties(libtools PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        C_STANDARD 11
+        C_EXTENSIONS NO
+        )
+
+target_include_directories(libtools PUBLIC .)
+
+# we could link to AGS::Common, but this provides much faster LTO times with Release builds
+target_include_directories(libtools PUBLIC ../Common)
+set(TOOLS_COMMON_SOURCES
+        ../Common/ac/wordsdictionary.cpp
+        ../Common/core/asset.cpp
+        ../Common/debug/debugmanager.cpp
+        ../Common/game/room_file_base.cpp
+        ../Common/game/tra_file.cpp
+        ../Common/util/bufferedstream.cpp
+        ../Common/util/data_ext.cpp
+        ../Common/util/datastream.cpp
+        ../Common/util/directory.cpp
+        ../Common/util/file.cpp
+        ../Common/util/filestream.cpp
+        ../Common/util/memorystream.cpp
+        ../Common/util/multifilelib.cpp
+        ../Common/util/path.cpp
+        ../Common/util/stdio_compat.c
+        ../Common/util/stream.cpp
+        ../Common/util/string.cpp
+        ../Common/util/string_compat.c
+        ../Common/util/string_utils.cpp
+        ../Common/util/textstreamreader.cpp)
+
+target_sources(libtools
+        PRIVATE
+        data/agfreader.cpp
+        data/agfreader.h
+        data/dialogscriptconv.cpp
+        data/dialogscriptconv.h
+        data/game_utils.h
+        data/mfl_utils.cpp
+        data/mfl_utils.h
+        data/room_utils.cpp
+        data/room_utils.h
+        data/script_utils.cpp
+        data/script_utils.h
+        data/scriptgen.cpp
+        data/scriptgen.h
+        data/tra_utils.cpp
+        data/tra_utils.h
+        ${TOOLS_COMMON_SOURCES}
+        )
+
+target_link_libraries(libtools PUBLIC TinyXML2::TinyXML2)
+if (WIN32)
+    target_link_libraries(libtools PUBLIC shlwapi)
+endif()
+
+#----- agf2autoash --------------------------------------------
+add_executable(agf2autoash agf2autoash/main.cpp)
+set_target_properties(agf2autoash PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(agf2autoash PUBLIC libtools)
+
+#----- agf2dlgasc ---------------------------------------------
+add_executable(agf2dlgasc agf2dlgasc/main.cpp)
+set_target_properties(agf2dlgasc PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(agf2dlgasc PUBLIC libtools)
+
+#----- agf2glvar -----------------------------------------------
+add_executable(agf2glvar agf2glvar/main.cpp)
+set_target_properties(agf2glvar PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(agf2glvar PUBLIC libtools)
+
+#----- agspak -------------------------------------------------
+add_executable(agspak agspak/main.cpp)
+set_target_properties(agspak PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(agspak PUBLIC libtools)
+
+#----- agsunpak -----------------------------------------------
+add_executable(agsunpak agsunpak/main.cpp)
+set_target_properties(agsunpak PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(agsunpak PUBLIC libtools)
+
+#----- crm2ash ------------------------------------------------
+add_executable(crm2ash crm2ash/main.cpp)
+set_target_properties(crm2ash PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(crm2ash PUBLIC libtools)
+
+#----- trac ---------------------------------------------------
+add_executable(trac trac/main.cpp)
+set_target_properties(trac PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+target_link_libraries(trac PUBLIC libtools)
+
+# Bundle-like target to build all tools
+add_custom_target(Tools)
+add_dependencies(Tools agf2autoash agf2dlgasc agf2glvar agspak agsunpak crm2ash trac)

--- a/Tools/crm2ash/main.cpp
+++ b/Tools/crm2ash/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     // Read room struct
     //-----------------------------------------------------------------------//
     RoomDataSource datasrc;
-    HError err = OpenRoomFile(src, datasrc);
+    HError err = static_cast<PError>(OpenRoomFile(src, datasrc));
     if (!err)
     {
         printf("Error: failed to open room file for reading:\n");

--- a/Tools/data/scriptgen.cpp
+++ b/Tools/data/scriptgen.cpp
@@ -14,6 +14,7 @@
 #include "data/scriptgen.h"
 #include <iterator>
 #include <cctype>
+#include <cstring>
 #include "data/room_utils.h"
 
 namespace AGS

--- a/libsrc/tinyxml2/CMakeLists.txt
+++ b/libsrc/tinyxml2/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(tinyxml2)
+
+set_target_properties(tinyxml2 PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS NO
+        )
+
+target_include_directories(tinyxml2 PUBLIC . )
+
+target_sources(tinyxml2
+        PRIVATE
+        tinyxml2.cpp
+        tinyxml2.h
+        )
+
+add_library(TinyXML2::TinyXML2 ALIAS tinyxml2)


### PR DESCRIPTION
This add a new toggle to build Tools in CMake - which when on also builds Compiler related stuff.

The toggle is OFF by default, and I am not turning the CI on this yet (we don't have a plan for actually shipping the Tools yet, so no need to turn on now). 

Btw, some Makefiles for tools are broken, `multifilelib.cpp` actually has a typo and is `mutifilelib.cpp` (missing first `l` character), I wasn't sure if I should fix with `git mv` the file name or change the Makefiles to carry the typo.