### PR TITLE
Tool: agfexport - export miscellaneous data from the game source

### DIFF
--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -522,6 +522,27 @@ void String::AppendChar(char c)
     }
 }
 
+void String::AppendFmt(const char *fcstr, ...)
+{
+    va_list argptr;
+    va_start(argptr, fcstr);
+    AppendFmtv(fcstr, argptr);
+    va_end(argptr);
+}
+
+void String::AppendFmtv(const char *fcstr, va_list argptr)
+{
+    fcstr = fcstr ? fcstr : "";
+    va_list argptr_cpy;
+    va_copy(argptr_cpy, argptr);
+    size_t length = vsnprintf(nullptr, 0u, fcstr, argptr);
+    ReserveAndShift(false, length);
+    vsprintf(_cstr + _len, fcstr, argptr_cpy);
+    va_end(argptr_cpy);
+    _len += length;
+    _cstr[_len] = 0;
+}
+
 void String::ClipLeft(size_t count)
 {
     if ((_len != 0) && (count > 0))

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -260,6 +260,9 @@ public:
     void    Append(const char *cstr, size_t len);
     // Appends a single character
     void    AppendChar(char c);
+    // Appends a formatted string
+    void    AppendFmt(const char *fcstr, ...);
+    void    AppendFmtv(const char *fcstr, va_list argptr);
     // Clip* methods decrease the string, removing defined part
     // Cuts off leftmost N characters
     void    ClipLeft(size_t count);

--- a/Solutions/Tools.App/agfexport.vcxproj
+++ b/Solutions/Tools.App/agfexport.vcxproj
@@ -1,0 +1,157 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\path.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp" />
+    <ClCompile Include="..\..\Tools\agfexport\main.cpp" />
+    <ClCompile Include="..\..\Tools\data\agfreader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h" />
+    <ClInclude Include="..\..\Tools\data\agfreader.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{776E38BA-D6A4-431E-8053-299310D85301}</ProjectGuid>
+    <RootNamespace>MakeRoomHeader</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>agfexport</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Tools;..\..\Common;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Tools;..\..\Common;..\..\libsrc\tinyxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Tools.App/agfexport.vcxproj.filters
+++ b/Solutions/Tools.App/agfexport.vcxproj.filters
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tinyxml2">
+      <UniqueIdentifier>{46208ff5-d822-4f9b-8208-d51993dbec22}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="data">
+      <UniqueIdentifier>{bdb62516-d050-4c05-81b5-4bedb3b8da0b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="agfexport">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libsrc\tinyxml2\tinyxml2.cpp">
+      <Filter>tinyxml2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\data\agfreader.cpp">
+      <Filter>data</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\agfexport\main.cpp">
+      <Filter>agfexport</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\path.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\libsrc\tinyxml2\tinyxml2.h">
+      <Filter>tinyxml2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Tools\data\agfreader.h">
+      <Filter>data</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -17,6 +17,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agspak", "Tools.App\agspak.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agsunpak", "Tools.App\agsunpak.vcxproj", "{BED528B1-6BC6-4857-B78D-B70F672D8F23}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agfexport", "Tools.App\agfexport.vcxproj", "{776E38BA-D6A4-431E-8053-299310D85301}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -81,6 +83,14 @@ Global
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x64.Build.0 = Release|x64
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x86.ActiveCfg = Release|Win32
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x86.Build.0 = Release|Win32
+		{776E38BA-D6A4-431E-8053-299310D85301}.Debug|x64.ActiveCfg = Debug|x64
+		{776E38BA-D6A4-431E-8053-299310D85301}.Debug|x64.Build.0 = Debug|x64
+		{776E38BA-D6A4-431E-8053-299310D85301}.Debug|x86.ActiveCfg = Debug|Win32
+		{776E38BA-D6A4-431E-8053-299310D85301}.Debug|x86.Build.0 = Debug|Win32
+		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x64.ActiveCfg = Release|x64
+		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x64.Build.0 = Release|x64
+		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x86.ActiveCfg = Release|Win32
+		{776E38BA-D6A4-431E-8053-299310D85301}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/agfexport/Makefile
+++ b/Tools/agfexport/Makefile
@@ -1,0 +1,95 @@
+INCDIR = ../../Common ../../Tools ../../libsrc/tinyxml2
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/datastream.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/path.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp
+
+TOOL_OBJS = \
+	../../Tools/data/agfreader.cpp
+
+TINYXML2 = \
+	../../libsrc/tinyxml2/tinyxml2.cpp
+
+OBJS := main.cpp \
+	$(COMMON_OBJS) \
+	$(TOOL_OBJS) \
+	$(TINYXML2)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags agfexport
+
+agfexport: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags agfexport
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f agfexport $(OBJS) $(DEPFILES)
+
+install: agfexport
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin agfexport
+
+uninstall:
+	rm -f $(PREFIX)/bin/agfexport

--- a/Tools/agfexport/main.cpp
+++ b/Tools/agfexport/main.cpp
@@ -1,0 +1,128 @@
+#include <memory>
+#include <stdio.h>
+#include <string.h>
+#include "data/agfreader.h"
+#include "util/file.h"
+#include "util/stream.h"
+
+using namespace AGS::Common;
+using namespace AGS::DataUtil;
+namespace AGF = AGS::AGF;
+
+
+enum Command
+{
+    kCmdNone,
+    kCmdScriptList,
+    kCmdRoomList
+};
+
+struct CommandType
+{
+    const char *Opt;
+    Command     Cmd;
+    int         NumArgs;
+} CommandTypes[] = {
+    { "--script-list"    , kCmdScriptList, 0 },
+    { "--room-list"      , kCmdRoomList, 0 },
+    { nullptr            , kCmdNone, 0 }
+};
+
+const char *HELP_STRING = "Usage: agfexport <input-game.agf> <COMMAND> [<OPTIONS>] <out-file>\n"
+"Commands:\n"
+"  --script-list <file>   exports ordered list of script modules\n"
+"  --room-list <file>     exports list of active rooms\n";
+
+int main(int argc, char *argv[])
+{
+    printf("agfexport v0.1.0 - AGS game's miscellaneous export tool\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "/?") == 0 || strcmp(arg, "-?") == 0)
+        {
+            printf("%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+    }
+    if (argc < 3)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *src = argv[1];
+    const char *command = argv[2];
+    Command cmd_type = kCmdNone;
+    int cmd_arg_num = 0;
+    for (size_t i = 0; CommandTypes[i].Opt; ++i)
+    {
+        if (strcmp(command, CommandTypes[i].Opt) == 0)
+        {
+            cmd_type = CommandTypes[i].Cmd;
+            cmd_arg_num = CommandTypes[i].NumArgs;
+            break;
+        }
+    }
+    if (cmd_type == kCmdNone)
+    {
+        printf("Error: unknown command '%s'\n", command);
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *dst = argv[3 + cmd_arg_num];
+    printf("Input game AGF: %s\n", src);
+    printf("Output file: %s\n", dst);
+
+    //-----------------------------------------------------------------------//
+    // Read Game.agf
+    //-----------------------------------------------------------------------//
+    AGF::AGFReader reader;
+    HError err = reader.Open(src);
+    if (!err)
+    {
+        printf("Error: failed to open source AGF:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Prepare export
+    //-----------------------------------------------------------------------//
+    String exp_data;
+    switch (cmd_type)
+    {
+    case kCmdScriptList:
+        {
+            std::vector<String> scripts;
+            AGF::ReadScriptList(scripts, reader.GetGameRoot());
+            for (const auto &s : scripts)
+                exp_data.AppendFmt("%s\n", s.GetCStr());
+        }
+        break;
+    case kCmdRoomList:
+        {
+            std::vector<std::pair<int, String>> rooms;
+            AGF::ReadRoomList(rooms, reader.GetGameRoot());
+            for (const auto &r : rooms)
+                exp_data.AppendFmt("room%d.crm:%s\n", r.first, r.second.GetCStr());
+        }
+        break;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write script header
+    //-----------------------------------------------------------------------//
+    std::unique_ptr<Stream> out( File::CreateFile(dst) );
+    if (!out)
+    {
+        printf("Error: failed to open an output file for writing.\n");
+        return -1;
+    }
+    out->Write(exp_data.GetCStr(), exp_data.GetLength());
+    printf("Data exported successfully.\nDone.\n");
+    return 0;
+}


### PR DESCRIPTION
agfexport - parses the game project file (*.agf), and exports various stuff depending on command.
This tool is meant to group simple tasks which do not require complex generation of anything, only outputting data for use along with the other tools and processes.

*Input:* game project (*.agf).
*Output:* a text file.

Usage: `agfexport Game.agf <COMMAND> [<OPTIONS>] somefile.txt`
Currently supported commands are:
* `--script-list` - exports ordered list of script modules (in the order of their dependency, or headers inclusion)
* `--room-list` - exports list of active rooms in the form of `roomNNN.crm:DESCRIPTION`.

These provide last remaining information necessary to write a system script that compiles all game scripts from the source without specifying script files by hand.

More could be added later if necessary.

For example of potential extensions, this tool could be exporting dialog scripts and additional info needed for the dialog converter to process them into ags script, then we would be able to replace current *agf2dlgasc* tool with one that does conversion using these files and not reading AGF document directly.