### PR TITLE
CI: adjust to allow running with less resources

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,8 +144,9 @@ build_macos_task:
 build_android_task:
   container:
     dockerfile: ci/android/Dockerfile
-    cpu: 6
-    memory: 6G
+    cpu: 4
+    memory: 8G
+    greedy: true
   git_submodules_script: git submodule update --init --recursive
   build_debug_library_and_runtime_script: |
     pushd Android/agsplayer && ./gradlew assembleDebug && popd


### PR DESCRIPTION
switched the Android task to allow using less CPU, but I am turning greedy on, which means it can use more CPUs if available - but it requires RAM available too, so switching RAM requirement up.

Greedy tasks are explained here:
https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4

This should make the task run and when there are resources on the GKE, running faster. This should unstuck the task - didn't get answers from support yet, but my guess is it's not finding any runner for 6CPU task on GKE.

Note: this task is demmanding because we build ags for 4 architectures, and we do it twice, once for Debug and once for Release. Our other tasks usually do only 1 arch and only 1 build type.

(push forced to fix the commit message.)

![image](https://user-images.githubusercontent.com/2244442/127750995-bd737255-9bc7-4e81-b9fb-addbd780aa88.png)

This PR asked 4 CPUs but got 13 during some parts, just as an example of greedy usage.