### PR TITLE
Tool: crmpak - compiled room's (re)packer

### DIFF
--- a/Common/game/room_file.h
+++ b/Common/game/room_file.h
@@ -116,6 +116,10 @@ HRoomFileError WriteRoomData(const RoomStruct *room, Stream *out, RoomFileVersio
 // Reads room data header using stream assigned to RoomDataSource;
 // tests and saves its format index if successful
 HRoomFileError ReadRoomHeader(RoomDataSource &src);
+// Writes room data header
+void WriteRoomHeader(Stream *out, RoomFileVersion data_ver);
+// Writes a room data ending
+void WriteRoomEnding(Stream *out, RoomFileVersion data_ver);
 
 // Type of function that writes single room block.
 typedef std::function<void(const RoomStruct *room, Stream *out)> PfnWriteRoomBlock;

--- a/Common/game/room_file.h
+++ b/Common/game/room_file.h
@@ -73,7 +73,9 @@ enum RoomFileBlock
     // Script names of the room objects
     kRoomFblk_ObjectScNames = 9,
     // End of room data tag
-    kRoomFile_EOF = 0xFF
+    kRoomFile_EOF = 0xFF,
+    kRoomFblk_FirstID = kRoomFblk_Main,
+    kRoomFblk_LastID = kRoomFblk_ObjectScNames
 };
 
 String GetRoomFileErrorText(RoomFileErrorType err);

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -80,6 +80,16 @@ HRoomFileError ReadRoomHeader(RoomDataSource &src)
     return HRoomFileError::None();
 }
 
+void WriteRoomHeader(Stream *out, RoomFileVersion data_ver)
+{
+    out->WriteInt16(data_ver);
+}
+
+void WriteRoomEnding(Stream *out, RoomFileVersion data_ver)
+{
+    out->WriteByte(kRoomFile_EOF);
+}
+
 String GetRoomBlockName(RoomFileBlock id)
 {
     switch (id)

--- a/Common/util/data_ext.h
+++ b/Common/util/data_ext.h
@@ -98,6 +98,14 @@ public:
     inline Stream *GetStream() { return _in; }
     // Tells if the end of the block list was reached
     inline bool AtEnd() const { return _blockID < 0; }
+    // Gets parser flags
+    inline int GetFlags() const { return _flags; }
+    // Gets current block ID
+    inline int GetBlockID() const { return _blockID; }
+    inline String GetBlockName() const
+    { return _blockID < 0 ? "" : (_blockID > 0 ? GetOldBlockName(_blockID) : _extID); }
+    // Gets current block length
+    inline soff_t GetBlockLength() const { return _blockLen; }
     // Tries to opens a next standard block from the stream,
     // fills in identifier and length on success
     HError OpenBlock();

--- a/Common/util/data_ext.h
+++ b/Common/util/data_ext.h
@@ -104,6 +104,7 @@ public:
     inline int GetBlockID() const { return _blockID; }
     inline String GetBlockName() const
     { return _blockID < 0 ? "" : (_blockID > 0 ? GetOldBlockName(_blockID) : _extID); }
+    inline soff_t GetBlockOffset() const { return _blockStart; }
     // Gets current block length
     inline soff_t GetBlockLength() const { return _blockLen; }
     // Tries to opens a next standard block from the stream,

--- a/Solutions/Tools.App/crmpak.vcxproj
+++ b/Solutions/Tools.App/crmpak.vcxproj
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp" />
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\data_ext.cpp" />
+    <ClCompile Include="..\..\Common\util\file.cpp" />
+    <ClCompile Include="..\..\Common\util\filestream.cpp" />
+    <ClCompile Include="..\..\Common\util\memorystream.cpp" />
+    <ClCompile Include="..\..\Common\util\path.cpp" />
+    <ClCompile Include="..\..\Common\util\stdio_compat.c" />
+    <ClCompile Include="..\..\Common\util\stream.cpp" />
+    <ClCompile Include="..\..\Common\util\string.cpp" />
+    <ClCompile Include="..\..\Common\util\string_compat.c" />
+    <ClCompile Include="..\..\Common\util\string_utils.cpp" />
+    <ClCompile Include="..\..\Tools\crmpak\main.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{20F0B521-1E8C-4F96-9C35-8CF244CA6947}</ProjectGuid>
+    <RootNamespace>MakeRoomHeader</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>crmpak</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)\.build\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Tools;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Solutions/Tools.App/crmpak.vcxproj.filters
+++ b/Solutions/Tools.App/crmpak.vcxproj.filters
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{eadadb9c-903a-4a50-8db9-a82dbf36b434}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="crmpak">
+      <UniqueIdentifier>{731e5dde-24bd-46ed-ae96-82f7baf41d3d}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Common\util\bufferedstream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\file.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\filestream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\datastream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\stdio_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_compat.c">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\string_utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\game\room_file_base.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\data_ext.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\path.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Tools\crmpak\main.cpp">
+      <Filter>crmpak</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\memorystream.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Solutions/Tools.sln
+++ b/Solutions/Tools.sln
@@ -17,6 +17,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agspak", "Tools.App\agspak.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agsunpak", "Tools.App\agsunpak.vcxproj", "{BED528B1-6BC6-4857-B78D-B70F672D8F23}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "crmpak", "Tools.App\crmpak.vcxproj", "{20F0B521-1E8C-4F96-9C35-8CF244CA6947}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -81,6 +83,14 @@ Global
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x64.Build.0 = Release|x64
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x86.ActiveCfg = Release|Win32
 		{BED528B1-6BC6-4857-B78D-B70F672D8F23}.Release|x86.Build.0 = Release|Win32
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Debug|x64.ActiveCfg = Debug|x64
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Debug|x64.Build.0 = Debug|x64
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Debug|x86.ActiveCfg = Debug|Win32
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Debug|x86.Build.0 = Debug|Win32
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Release|x64.ActiveCfg = Release|x64
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Release|x64.Build.0 = Release|x64
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Release|x86.ActiveCfg = Release|Win32
+		{20F0B521-1E8C-4F96-9C35-8CF244CA6947}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/crmpak/Makefile
+++ b/Tools/crmpak/Makefile
@@ -1,0 +1,90 @@
+INCDIR = ../../Common
+LIBDIR =
+
+CFLAGS := -O2 -g \
+	-fsigned-char -fno-strict-aliasing -fwrapv \
+	-Wunused-result \
+	-Wno-unused-value  \
+	-Werror=write-strings -Werror=format -Werror=format-security \
+	-DNDEBUG \
+	-D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
+	$(CFLAGS)
+
+CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
+
+PREFIX ?= /usr/local
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+CFLAGS   += $(addprefix -I,$(INCDIR))
+CXXFLAGS += $(CFLAGS)
+ASFLAGS  += $(CFLAGS)
+LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
+CFLAGS   += -Werror=implicit-function-declaration
+
+COMMON_OBJS = \
+	../../Common/debug/debugmanager.cpp \
+	../../Common/game/room_file_base.cpp \
+	../../Common/util/bufferedstream.cpp \
+	../../Common/util/data_ext.cpp \
+	../../Common/util/datastream.cpp \
+	../../Common/util/file.cpp \
+	../../Common/util/filestream.cpp \
+	../../Common/util/memorystream.cpp \
+	../../Common/util/path.cpp \
+	../../Common/util/stdio_compat.c \
+	../../Common/util/stream.cpp \
+	../../Common/util/string.cpp \
+	../../Common/util/string_compat.c \
+	../../Common/util/string_utils.cpp
+
+OBJS := main.cpp \
+	$(COMMON_OBJS)
+OBJS := $(OBJS:.cpp=.o)
+OBJS := $(OBJS:.c=.o)
+
+DEPFILES = $(OBJS:.o=.d)
+
+-include config.mak
+
+.PHONY: printflags clean install uninstall rebuild
+
+all: printflags crmpak
+
+crmpak: $(OBJS) 
+	@echo "Linking..."
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+
+debug: CXXFLAGS += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: CFLAGS   += -UNDEBUG -D_DEBUG -Og -g -pg
+debug: LDFLAGS  += -pg
+debug: printflags crmpak
+
+-include $(DEPFILES)
+
+%.o: %.c
+	@echo $@
+	$(CMD_PREFIX) $(CC) $(CFLAGS) -MD -c -o $@ $<
+
+%.o: %.cpp
+	@echo $@
+	$(CMD_PREFIX) $(CXX) $(CXXFLAGS) -MD -c -o $@ $<
+
+printflags:
+	@echo "CFLAGS =" $(CFLAGS) "\n"
+	@echo "CXXFLAGS =" $(CXXFLAGS) "\n"
+	@echo "LDFLAGS =" $(LDFLAGS) "\n"
+	@echo "LIBS =" $(LIBS) "\n"
+
+rebuild: clean all
+
+clean:
+	@echo "Cleaning..."
+	$(CMD_PREFIX) rm -f crmpak $(OBJS) $(DEPFILES)
+
+install: crmpak
+	mkdir -p $(PREFIX)/bin
+	cp -t $(PREFIX)/bin crmpak
+
+uninstall:
+	rm -f $(PREFIX)/bin/crmpak

--- a/Tools/crmpak/main.cpp
+++ b/Tools/crmpak/main.cpp
@@ -1,0 +1,257 @@
+#include <stdio.h>
+#include "game/room_file.h"
+#include "util/data_ext.h"
+#include "util/file.h"
+#include "util/memorystream.h"
+#include "util/string_compat.h"
+
+using namespace AGS::Common;
+
+
+// TODO: move to Common? need to find a good place
+class RoomBlockParser : public DataExtParser
+{
+public:
+    RoomBlockParser(Stream *in, RoomFileVersion data_ver)
+        : DataExtParser(in, kDataExt_NumID8 | ((data_ver < kRoomVersion_350) ? kDataExt_File32 : kDataExt_File64))
+        {}
+    virtual String GetOldBlockName(int block_id) const
+    { return GetRoomBlockName((RoomFileBlock)block_id); }
+};
+
+
+const char *HELP_STRING =
+"Usage: crmpak <in-room.crm> <COMMAND> [<OPTIONS>]\n"
+"Commands:\n"
+"  -d <blockid>           delete: remove a block from the compiled room\n"
+"  -e <blockid> <file>    export: write a block into this file\n"
+"  -i <blockid> <file>    import: add/replace a block with this file contents\n"
+"  -x <blockid> <file>    extract: remove a block and save it in this file\n"
+"Options:\n"
+"  -w <out-room.crm>      for all commands but '-e': write the resulting room\n"
+"                         into a new file; otherwise will modify the input file\n";
+
+int main(int argc, char *argv[])
+{
+    printf("crmpak v0.1.0 - AGS compiled room's (re)packer\n"\
+        "Copyright (c) 2021 AGS Team and contributors\n");
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        {
+            printf("%s\n", HELP_STRING);
+            return 0; // display help and bail out
+        }
+    }
+    // Minimal required args is crmpak <room.crm> <COMMAND> <BLOCKID>
+    if (argc < 4)
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    const char *in_roomfile = argv[1];
+    char command = 0;
+    const char *arg_block = nullptr;
+    const char *arg_blockfile = nullptr;
+    const char *out_roomfile = nullptr;
+    for (int i = 2; i < argc; ++i)
+    {
+        if (argv[i][0] != '-' || strlen(argv[i]) != 2)
+            continue;
+        char arg = argv[2][1];
+        switch (arg)
+        {
+        case 'e': case 'i': case 'x':
+            command = arg;
+            if (argc > i + 2)
+            {
+                arg_block = argv[++i];
+                arg_blockfile = argv[++i];
+            }
+            break;
+        case 'd':
+            command = arg;
+            if (argc > i + 1) arg_block = argv[++i];
+            break;
+        case 'w':
+            if (argc > i + 1) out_roomfile = argv[(i++) + 1];
+            break;
+        }
+    }
+
+    // Test supported commands and number of args
+    if (command == 0)
+    {
+        printf("Error: command not specified\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+    else if (!arg_block || ((command != 'd') && !arg_blockfile))
+    {
+        printf("Error: not enough arguments\n");
+        printf("%s\n", HELP_STRING);
+        return -1;
+    }
+
+    // Parse room block ID
+    char *parse_end = nullptr;
+    errno = 0;
+    const int block_numid = strtol(arg_block, &parse_end, 0);
+    bool is_old_numid = ((errno == 0) && (parse_end == arg_block + strlen(arg_block)));
+    const String block_strid = is_old_numid ? GetRoomBlockName((RoomFileBlock)block_numid) : arg_block;
+
+    // Print working info
+    printf("Room file: %s\n", in_roomfile);
+    printf("Block ID: %s (%d)\n", block_strid.GetCStr(), block_numid);
+    switch (command)
+    {
+    case 'e': case 'x': printf("Output file: %s\n", arg_blockfile); break;
+    case 'i': printf("Input file: %s\n", arg_blockfile); break;
+    case 'd': default: break;
+    }
+    if (out_roomfile && (command != 'e'))
+        printf("Write modified room into: %s\n", out_roomfile);
+
+    //-----------------------------------------------------------------------//
+    // Parse the input room, search for the requested block ID;
+    // save its location in the stream.
+    //-----------------------------------------------------------------------//
+    RoomDataSource datasrc;
+    HError err = OpenRoomFile(in_roomfile, datasrc);
+    if (!err)
+    {
+        printf("Error: failed to open room file for reading:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+
+    RoomBlockParser parser(datasrc.InputStream.get(), datasrc.DataVersion);
+    soff_t block_head = -1;
+    soff_t block_data_at = -1;
+    soff_t block_end = -1;
+    for (block_end = parser.GetStream()->GetPosition(), err = parser.OpenBlock();
+         (block_head < 0) && err && !parser.AtEnd(); err = parser.OpenBlock())
+    {
+        if (parser.GetBlockID() == block_numid || parser.GetBlockName() == block_strid)
+        {
+            block_head = block_end;
+            block_data_at = parser.GetStream()->GetPosition();
+        }
+        parser.SkipBlock();
+        block_end = parser.GetStream()->GetPosition();
+    }
+    // need these later
+    const int dataext_flags = parser.GetFlags();
+    const RoomFileVersion dataver = datasrc.DataVersion;
+        
+    if (!err)
+    {
+        printf("Error: failed to parse the input room:\n");
+        printf("%s\n", err->FullMessage().GetCStr());
+        return -1;
+    }
+    // If no block found for deletion / export - stop
+    if ((block_head < 0) && (command != 'i'))
+    {
+        printf("Requested block not found.\n");
+        return 0;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Export the block data (commands 'e' and 'x')
+    //-----------------------------------------------------------------------//
+    if (command == 'e' || command == 'x')
+    {
+        std::unique_ptr<Stream> block_out(File::CreateFile(arg_blockfile));
+        if (!block_out)
+        {
+            printf("Error: failed to open block file for writing.\n");
+            return -1;
+        }
+        // Note we export only the internal block data, skipping the header
+        datasrc.InputStream->Seek(block_data_at, kSeekBegin);
+        CopyStream(datasrc.InputStream.get(), block_out.get(), block_end - block_data_at);
+    }
+
+    // Export is complete - stop
+    if (command == 'e')
+    {
+        printf("Done.\n");
+        return 0;
+    }
+
+    //-----------------------------------------------------------------------//
+    // Write the new room file (commands 'd', 'i', 'x')
+    //-----------------------------------------------------------------------//
+    // If we are importing, first try opening the input block file
+    std::unique_ptr<Stream> block_in;
+    if (command == 'i')
+    {
+        block_in.reset(File::OpenFileRead(arg_blockfile));
+        if (!block_in)
+        {
+            printf("Error: failed to open block file for reading.\n");
+            return -1;
+        }
+    }
+
+    // Depending on settings we write either directly into the new room file,
+    // or into the temp buffer which we then use to overwrite existing room
+    std::unique_ptr<Stream> room_out;
+    std::vector<char> temp_data;
+    if (out_roomfile)
+    {
+        room_out.reset(File::CreateFile(out_roomfile));
+        if (!room_out)
+        {
+            printf("Error: failed to open room file for writing.\n");
+            return -1;
+        }
+    }
+    else
+    {
+        room_out.reset(new MemoryStream(temp_data, kStream_Write));
+    }
+
+    // Write whole room, except for the block piece (if found)
+    datasrc.InputStream->Seek(0, kSeekBegin);
+    CopyStream(datasrc.InputStream.get(), room_out.get(), block_head);
+    datasrc.InputStream->Seek(block_end, kSeekBegin);
+    CopyStream(datasrc.InputStream.get(), room_out.get(), datasrc.InputStream->GetLength() - block_end);
+    // Finally close the room input
+    datasrc.InputStream.reset();
+    
+    // If we are importing, append the new block
+    if (command == 'i')
+    {
+        WriteExtBlock(block_numid, block_strid,
+            [&block_in](Stream *out) { CopyStream(block_in.get(), out, block_in->GetLength()); },
+            dataext_flags, room_out.get());
+        // TODO: find a better design for this block writing ^
+        // TODO: also maybe modify CopyStream to support reading until input EOS
+        block_in.reset();
+    }
+
+    // Finalize the output room
+    WriteRoomEnding(room_out.get(), dataver);
+    room_out.reset();
+
+    // If we saved the new room into the memory, now it's the time to overwrite
+    // the original room with the accumulated data
+    if (!out_roomfile)
+    {
+        std::unique_ptr<Stream> temp_room(new MemoryStream(temp_data));
+        room_out.reset(File::CreateFile(in_roomfile));
+        if (!room_out)
+        {
+            printf("Error: failed to open room file for writing.\n");
+            return -1;
+        }
+        CopyStream(temp_room.get(), room_out.get(), temp_data.size());
+    }
+    printf("Done.\n");
+    return 0;
+}

--- a/Tools/crmpak/main.cpp
+++ b/Tools/crmpak/main.cpp
@@ -21,6 +21,12 @@ public:
 };
 
 
+static void print_known_blockids()
+{
+    for (int i = kRoomFblk_FirstID; i < kRoomFblk_LastID; ++i)
+        printf("%d:%s\n", i, GetRoomBlockName((RoomFileBlock)i));
+}
+
 HError print_room_blockids(RoomDataSource &datasrc)
 {
     HError err = HError::None();
@@ -36,27 +42,31 @@ HError print_room_blockids(RoomDataSource &datasrc)
 }
 
 
+const char *BIN_STRING = "crmpak v0.1.0 - AGS compiled room's (re)packer\n"
+"Copyright (c) 2021 AGS Team and contributors";
+
 const char *HELP_STRING =
-"Usage: crmpak <in-room.crm> <COMMAND> [<OPTIONS>]\n"
+"Usage: crmpak [OPTIONS] [<in-room.crm> <COMMAND> [<CMD_OPTIONS>]]\n"
+"Options:\n"
+"  --tell-blockids        print a list of the known block ids\n"
 "Commands:\n"
 "  -d <blockid>           delete: remove a block from the compiled room\n"
 "  -e <blockid> <file>    export: write a block into this file\n"
 "  -i <blockid> <file>    import: add/replace a block with this file contents\n"
 "  -l                     list: print id of all blocks found in the room\n"
 "  -x <blockid> <file>    extract: remove a block and save it in this file\n"
-"Options:\n"
+"Command options:\n"
 "  -w <out-room.crm>      for all commands but '-e': write the resulting room\n"
 "                         into a new file; otherwise will modify the input file\n";
 
 int main(int argc, char *argv[])
 {
-    printf("crmpak v0.1.0 - AGS compiled room's (re)packer\n"\
-        "Copyright (c) 2021 AGS Team and contributors\n");
     for (int i = 1; i < argc; ++i)
     {
         const char *arg = argv[i];
-        if (ags_stricmp(arg, "--help") == 0 || ags_stricmp(arg, "/?") == 0 || ags_stricmp(arg, "-?") == 0)
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "/?") == 0 || strcmp(arg, "-?") == 0)
         {
+            printf("%s\n", BIN_STRING);
             printf("%s\n", HELP_STRING);
             return 0; // display help and bail out
         }
@@ -69,6 +79,12 @@ int main(int argc, char *argv[])
     const char *out_roomfile = nullptr;
     for (int i = 2; i < argc; ++i)
     {
+        if (strcmp(argv[i], "--tell-blockids") == 0)
+        {
+            print_known_blockids();
+            return 0;
+        }
+
         if (argv[i][0] != '-' || strlen(argv[i]) != 2)
             continue;
         char arg = argv[2][1];
@@ -94,6 +110,7 @@ int main(int argc, char *argv[])
     }
 
     // Test supported commands and number of args
+    printf("%s\n", BIN_STRING);
     if (command == 0)
     {
         printf("Error: command not specified\n");


### PR DESCRIPTION
After #1330 we may store compiled scripts separate from the room files (*.crm), but then I realized that there will still be rooms with these scripts inside remaining in the ags3 game project. If we, for instance, begin to package scripts separately in the future, there will be redundant script data left inside these rooms.

So here comes the tool that deals with that, but I decided to make it more universal just in case.
(The blocks are searched all the same, so there's no difference)

---

crmpak - imports, exports or deletes chosen blocks from the compiled room file (*.crm).

Usage: `crmpak [OPTIONS] [<in-room.crm> <COMMAND> [<CMD_OPTIONS>]]`

Options:
* `  --tell-blockids` - print a list of the known block ids;
* 
Commands:
* `-d <blockid>` -  delete: remove a block from the compiled room;
* `-e <blockid> <file>` - export: write a block into this file;
* `-i <blockid> <file>` - import/inject: add/replace a block with this file contents;
* `-l` - list: print id of all blocks found in the room;
* `-x <blockid> <file>` - extract: remove a block and save it in this file (export + delete);

Command Options:
* `-w <out-room.crm>` - for all commands but '-e': write the resulting room into a new file; otherwise will modify the input file;

Block IDs may be given both [as numbers](https://github.com/adventuregamestudio/ags/blob/4d8fa9fe6cbe63f6770777f3853e221117c94744/Common/game/room_file.h#L55) or [their string aliases](https://github.com/adventuregamestudio/ags/blob/4d8fa9fe6cbe63f6770777f3853e221117c94744/Common/game/room_file_base.cpp#L83).

**Examples:**

`crmpak room1.crm -x 7 room1.o`
`crmpak room1.crm -x CompScript3 room1.o`

These two commands are equivalent, they extract a compiled script from the `room1.crm`, save it into `room1.o`, and then rewrite the room without it.

`crmpak room1.crm -d CompScript3`

Deletes the script from the room. NOTE: it's interesting that the engine won't complain of its abscence.

`crmpak room1.crm -i CompScript3 newscript.o -w newroom.crm`

Writes a new room as `newroom.crm`; it will have all content from `room1.crm`, but the script will be added/replaced from `newscript.o`.
