### PR TITLE
Script API: AudioClip.PlayOnChannel()

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2087,6 +2087,10 @@ builtin managed struct AudioClip {
   import AudioChannel* PlayFrom(int position, AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);
   /// Plays this audio clip, or queues it if all channels are busy.
   import AudioChannel* PlayQueued(AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);
+#ifdef SCRIPT_API_v360
+  /// Plays this audio clip, explicitly putting it on the particular channel.
+  import AudioChannel* PlayOnChannel(int chan, AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);
+#endif
   /// Stops all currently playing instances of this audio clip.
   import void Stop();
   /// Gets the file type of the sound.

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -58,20 +58,26 @@ void AudioClip_Stop(ScriptAudioClip *clip)
 
 ScriptAudioChannel* AudioClip_Play(ScriptAudioClip *clip, int priority, int repeat)
 {
-    ScriptAudioChannel *sc_ch = play_audio_clip(clip, priority, repeat, 0, false);
-    return sc_ch;
+    return play_audio_clip(clip, priority, repeat, 0, false);
 }
 
 ScriptAudioChannel* AudioClip_PlayFrom(ScriptAudioClip *clip, int position, int priority, int repeat)
 {
-    ScriptAudioChannel *sc_ch = play_audio_clip(clip, priority, repeat, position, false);
-    return sc_ch;
+    return play_audio_clip(clip, priority, repeat, position, false);
 }
 
 ScriptAudioChannel* AudioClip_PlayQueued(ScriptAudioClip *clip, int priority, int repeat)
 {
-    ScriptAudioChannel *sc_ch = play_audio_clip(clip, priority, repeat, 0, true);
-    return sc_ch;
+    return play_audio_clip(clip, priority, repeat, 0, true);
+}
+
+ScriptAudioChannel* AudioClip_PlayOnChannel(ScriptAudioClip *clip, int chan, int priority, int repeat)
+{
+    if (priority == SCR_NO_VALUE)
+        priority = clip->defaultPriority;
+    if (repeat == SCR_NO_VALUE)
+        repeat = clip->defaultRepeat;
+    return play_audio_clip_on_channel(chan, clip, priority, repeat, 0);
 }
 
 //=============================================================================
@@ -131,11 +137,17 @@ RuntimeScriptValue Sc_AudioClip_PlayQueued(void *self, const RuntimeScriptValue 
     API_OBJCALL_OBJ_PINT2(ScriptAudioClip, ScriptAudioChannel, ccDynamicAudio, AudioClip_PlayQueued);
 }
 
+RuntimeScriptValue Sc_AudioClip_PlayOnChannel(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ_PINT3(ScriptAudioClip, ScriptAudioChannel, ccDynamicAudio, AudioClip_PlayOnChannel);
+}
+
 void RegisterAudioClipAPI()
 {
     ccAddExternalObjectFunction("AudioClip::Play^2",            Sc_AudioClip_Play);
     ccAddExternalObjectFunction("AudioClip::PlayFrom^3",        Sc_AudioClip_PlayFrom);
     ccAddExternalObjectFunction("AudioClip::PlayQueued^2",      Sc_AudioClip_PlayQueued);
+    ccAddExternalObjectFunction("AudioClip::PlayOnChannel^3",   Sc_AudioClip_PlayOnChannel);
     ccAddExternalObjectFunction("AudioClip::Stop^0",            Sc_AudioClip_Stop);
     ccAddExternalObjectFunction("AudioClip::get_ID",            Sc_AudioClip_GetID);
     ccAddExternalObjectFunction("AudioClip::get_FileType",      Sc_AudioClip_GetFileType);


### PR DESCRIPTION
This adds AudioClip.PlayOnChannel() function:

`AudioChannel* AudioClip.PlayOnChannel(int chan, AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);`

The purpose of this function is to provide a lower-level control over how the clips are put onto the logical "channel" slots. Normally this distribution is controlled by a number of settings involving audio type reservation and clip priority, but there are circumstances when users want to have their own logic, yet there's no direct way to apply that. With this function it might be possible to script your own audio mixer freely.

The necessary changes for this are minimal, as this script function simply calls an existing internal one that does the necessary thing, circumventing channel calculation.

Notable issues: channel 0 is reserved for voice-over. Technically it may be used, but there's some engine logic that stops any other sound on it, probably because no actual speech is on.