### PR TITLE
New compiler: Join juxtaposed string literals

### DIFF
--- a/Compiler/script2/cs_scanner.h
+++ b/Compiler/script2/cs_scanner.h
@@ -33,6 +33,7 @@ public:
     };
 
     static std::string const kNewSectionLitPrefix;
+    static size_t const kNewSectionLitPrefixSize;
 
 private:
     // Collect a sequence of opening ("([{") and closing (")]}") symbols; check matching


### PR DESCRIPTION
Make the compiler join string _literals_ (!) that are separated by whitespace, if any. This is an operation that happens at compile time, not at runtime.

The same way it is done in `C` or `C++`.


Typical code:
```
player.Say(
    "The rain it raineth on the just ""And also on the unjust fella; "
    "But chiefly on the just because "     "The unjust hath the just's umbrella.");
```

Generates the same code as
```
player.Say(
    "The rain it raineth on the just And also on the unjust fella; But chiefly on the just because The unjust hath the just's umbrella.");
```