### PR TITLE
Common: fix incorrect use of delete

### DIFF
--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -91,7 +91,7 @@ String StrUtil::Unescape(const String &s)
     }
     *pb = 0;
     String dst(buf);
-    delete buf;
+    delete [] buf;
     return dst;
 }
 


### PR DESCRIPTION
Fix deletion of a char array (it should use `delete []` instead of `delete`).