### PR TITLE
Windows: support UTF-8 paths in the engine

### DIFF
--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -20,6 +20,8 @@ namespace AGS
 namespace Common
 {
 
+using namespace Path;
+
 namespace Directory
 {
 
@@ -102,8 +104,8 @@ bool GetFilesImpl(const String &dir_path, std::vector<String> &files,
 bool GetFilesImpl(const String &dir_path, std::vector<String> &files,
     int attr_dir)
 {
-    char pattern[MAX_PATH];
-    snprintf(pattern, MAX_PATH, "%s/%s", dir_path.GetCStr(), "*");
+    char pattern[MAX_PATH_SZ];
+    snprintf(pattern, sizeof(pattern), "%s/%s", dir_path.GetCStr(), "*");
     WIN32_FIND_DATAA findData;
     HANDLE hFind = FindFirstFileA(pattern, &findData);
     if (hFind == INVALID_HANDLE_VALUE)
@@ -197,8 +199,8 @@ FindFile FindFile::Open(const String &path, const String &wildcard, bool do_file
 {
     Internal ffi;
 #if AGS_PLATFORM_OS_WINDOWS
-    char pattern[MAX_PATH];
-    snprintf(pattern, MAX_PATH, "%s/%s", path.GetCStr(), wildcard.GetCStr());
+    char pattern[MAX_PATH_SZ];
+    snprintf(pattern, sizeof(pattern), "%s/%s", path.GetCStr(), wildcard.GetCStr());
     HANDLE hFind = FindFirstFileA(pattern, &ffi.fdata);
     if (hFind == INVALID_HANDLE_VALUE)
         return FindFile(); // return invalid object

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -37,7 +37,7 @@ soff_t File::GetFileSize(const String &filename)
 
 bool File::TestReadFile(const String &filename)
 {
-    FILE *test_file = fopen(filename.GetCStr(), "rb");
+    FILE *test_file = ags_fopen(filename.GetCStr(), "rb");
     if (test_file)
     {
         fclose(test_file);
@@ -48,7 +48,7 @@ bool File::TestReadFile(const String &filename)
 
 bool File::TestWriteFile(const String &filename)
 {
-    FILE *test_file = fopen(filename.GetCStr(), "r+");
+    FILE *test_file = ags_fopen(filename.GetCStr(), "r+");
     if (test_file)
     {
         fclose(test_file);
@@ -59,11 +59,11 @@ bool File::TestWriteFile(const String &filename)
 
 bool File::TestCreateFile(const String &filename)
 {
-    FILE *test_file = fopen(filename.GetCStr(), "wb");
+    FILE *test_file = ags_fopen(filename.GetCStr(), "wb");
     if (test_file)
     {
         fclose(test_file);
-        ::remove(filename.GetCStr());
+        ags_remove(filename.GetCStr());
         return true;
     }
     return false;
@@ -71,7 +71,7 @@ bool File::TestCreateFile(const String &filename)
 
 bool File::DeleteFile(const String &filename)
 {
-    if (::remove(filename.GetCStr()) != 0)
+    if (ags_remove(filename.GetCStr()) != 0)
     {
         int err;
 #if AGS_PLATFORM_OS_WINDOWS
@@ -89,7 +89,7 @@ bool File::DeleteFile(const String &filename)
 
 bool File::RenameFile(const String &old_name, const String &new_name)
 {
-    return ::rename(old_name.GetCStr(), new_name.GetCStr()) == 0;
+    return ags_rename(old_name.GetCStr(), new_name.GetCStr()) == 0;
 }
 
 bool File::GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, FileWorkMode &work_mode)

--- a/Common/util/filestream.cpp
+++ b/Common/util/filestream.cpp
@@ -11,10 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "util/filestream.h"
-
 #include <stdexcept>
+#include "platform/windows/windows.h"
+#include "util/path.h"
 #include "util/stdio_compat.h"
 #include "util/string.h"
 
@@ -181,7 +181,7 @@ void FileStream::Open(const String &file_name, FileOpenMode open_mode, FileWorkM
     String mode = File::GetCMode(open_mode, work_mode);
     if (mode.IsEmpty())
         throw std::runtime_error("Error determining open mode");
-    _file = fopen(file_name.GetCStr(), mode.GetCStr());
+    _file = ags_fopen(file_name.GetCStr(), mode.GetCStr());
     if (_file == nullptr)
         throw std::runtime_error("Error opening file.");
     _ownHandle = true;

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -5,11 +5,6 @@
 #include "util/path.h"
 #include "util/stdio_compat.h"
 
-// TODO: implement proper portable path length
-#ifndef MAX_PATH
-#define MAX_PATH 512
-#endif
-
 namespace AGS
 {
 namespace Common
@@ -199,8 +194,8 @@ String FixupSharedFilename(const String &filename)
 String GetPathInASCII(const String &path)
 {
 #if AGS_PLATFORM_OS_WINDOWS
-    char ascii_buffer[MAX_PATH];
-    if (GetShortPathNameA(path.GetCStr(), ascii_buffer, MAX_PATH) == 0)
+    char ascii_buffer[MAX_PATH_SZ];
+    if (GetShortPathNameA(path.GetCStr(), ascii_buffer, sizeof(ascii_buffer)) == 0)
         return "";
     return ascii_buffer;
 #else
@@ -212,12 +207,12 @@ String GetPathInASCII(const String &path)
 #if AGS_PLATFORM_OS_WINDOWS
 String WidePathNameToAnsi(LPCWSTR pathw)
 {
-    WCHAR short_path[MAX_PATH];
-    char ascii_buffer[MAX_PATH];
+    WCHAR short_path[MAX_PATH_SZ];
+    char ascii_buffer[MAX_PATH_SZ];
     LPCWSTR arg_path = pathw;
-    if (GetShortPathNameW(arg_path, short_path, MAX_PATH) == 0)
+    if (GetShortPathNameW(arg_path, short_path, sizeof(short_path)) == 0)
         return "";
-    WideCharToMultiByte(CP_ACP, 0, short_path, -1, ascii_buffer, MAX_PATH, NULL, NULL);
+    WideCharToMultiByte(CP_ACP, 0, short_path, -1, ascii_buffer, sizeof(ascii_buffer), NULL, NULL);
     return ascii_buffer;
 }
 #endif

--- a/Common/util/path.h
+++ b/Common/util/path.h
@@ -95,10 +95,11 @@ namespace Path
     // could be copied across systems without problems.
     String  FixupSharedFilename(const String &filename);
 
-    // Converts filepath into ASCII variant; returns empty string on failure
-    String  GetPathInASCII(const String &path);
-    // Converts filepath from command line's argument into ASCII variant
-    String  GetCmdLinePathInASCII(const char *arg, int arg_index);
+    // NOTE: these are only required for internal util implementations
+#if AGS_PLATFORM_OS_WINDOWS
+    // Converts system wide-char path into a UTF-8 string
+    String  WidePathToUTF8(const wchar_t *ws);
+#endif
 } // namespace Path
 
 } // namespace Common

--- a/Common/util/path_ex.cpp
+++ b/Common/util/path_ex.cpp
@@ -16,12 +16,6 @@ int ComparePaths(const String &path1, const String &path2)
     String fixed_path1 = MakeAbsolutePath(path1);
     String fixed_path2 = MakeAbsolutePath(path2);
 
-#if AGS_PLATFORM_OS_WINDOWS
-    // On Windows make sure both are represented as short names (at least until we support wide paths)
-    fixed_path1 = GetPathInASCII(fixed_path1);
-    fixed_path2 = GetPathInASCII(fixed_path2);
-#endif
-
     fixed_path1.TrimRight('/');
     fixed_path2.TrimRight('/');
 

--- a/Common/util/path_ex.cpp
+++ b/Common/util/path_ex.cpp
@@ -1,10 +1,6 @@
 #include "util/path.h"
 #include "allegro/file.h"
-
-// TODO: implement proper portable path length
-#ifndef MAX_PATH
-#define MAX_PATH 512
-#endif
+#include "util/stdio_compat.h"
 
 namespace AGS
 {
@@ -40,15 +36,15 @@ int ComparePaths(const String &path1, const String &path2)
 
 bool IsSameOrSubDir(const String &parent, const String &path)
 {
-    char can_parent[MAX_PATH];
-    char can_path[MAX_PATH];
-    char relative[MAX_PATH];
+    char can_parent[MAX_PATH_SZ];
+    char can_path[MAX_PATH_SZ];
+    char relative[MAX_PATH_SZ];
     // canonicalize_filename treats "." as "./." (file in working dir)
     const char *use_parent = parent == "." ? "./" : parent.GetCStr();
     const char *use_path   = path   == "." ? "./" : path.GetCStr();
-    canonicalize_filename(can_parent, use_parent, MAX_PATH);
-    canonicalize_filename(can_path, use_path, MAX_PATH);
-    const char *pstr = make_relative_filename(relative, can_parent, can_path, MAX_PATH);
+    canonicalize_filename(can_parent, use_parent, MAX_PATH_SZ);
+    canonicalize_filename(can_path, use_path, MAX_PATH_SZ);
+    const char *pstr = make_relative_filename(relative, can_parent, can_path, MAX_PATH_SZ);
     if (!pstr)
         return false;
     for (pstr = strstr(pstr, ".."); pstr && *pstr; pstr = strstr(pstr, ".."))
@@ -82,8 +78,8 @@ String MakeAbsolutePath(const String &path)
     //    abs_path = long_path_buffer;
     //}
 #endif
-    char buf[MAX_PATH];
-    canonicalize_filename(buf, abs_path.GetCStr(), MAX_PATH);
+    char buf[MAX_PATH_SZ];
+    canonicalize_filename(buf, abs_path.GetCStr(), MAX_PATH_SZ);
     abs_path = buf;
     FixupPath(abs_path);
     return abs_path;
@@ -91,15 +87,15 @@ String MakeAbsolutePath(const String &path)
 
 String MakeRelativePath(const String &base, const String &path)
 {
-    char can_parent[MAX_PATH];
-    char can_path[MAX_PATH];
-    char relative[MAX_PATH];
+    char can_parent[MAX_PATH_SZ];
+    char can_path[MAX_PATH_SZ];
+    char relative[MAX_PATH_SZ];
     // canonicalize_filename treats "." as "./." (file in working dir)
     const char *use_parent = base == "." ? "./" : base.GetCStr();
     const char *use_path = path == "." ? "./" : path.GetCStr(); // FIXME?
-    canonicalize_filename(can_parent, use_parent, MAX_PATH);
-    canonicalize_filename(can_path, use_path, MAX_PATH);
-    String rel_path = make_relative_filename(relative, can_parent, can_path, MAX_PATH);
+    canonicalize_filename(can_parent, use_parent, MAX_PATH_SZ);
+    canonicalize_filename(can_path, use_path, MAX_PATH_SZ);
+    String rel_path = make_relative_filename(relative, can_parent, can_path, MAX_PATH_SZ);
     FixupPath(rel_path);
     return rel_path;
 }

--- a/Common/util/path_ex.cpp
+++ b/Common/util/path_ex.cpp
@@ -63,15 +63,6 @@ String MakeAbsolutePath(const String &path)
     }
     // canonicalize_filename treats "." as "./." (file in working dir)
     String abs_path = path == "." ? "./" : path;
-#if AGS_PLATFORM_OS_WINDOWS
-    // NOTE: cannot use long path names in the engine, because it does not have unicode strings support
-    //
-    //char long_path_buffer[MAX_PATH];
-    //if (GetLongPathNameA(path, long_path_buffer, MAX_PATH) > 0)
-    //{
-    //    abs_path = long_path_buffer;
-    //}
-#endif
     char buf[MAX_PATH_SZ];
     canonicalize_filename(buf, abs_path.GetCStr(), MAX_PATH_SZ);
     abs_path = buf;

--- a/Common/util/stdio_compat.h
+++ b/Common/util/stdio_compat.h
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AGS_CN_UTIL__STDIOCOMPAT_H
 #define __AGS_CN_UTIL__STDIOCOMPAT_H
 
@@ -19,6 +18,9 @@
 #include <stdint.h>
 
 typedef int64_t file_off_t;
+
+// Size of the buffer enough to accomodate a UTF-8 path
+const size_t MAX_PATH_SZ = 1024;
 
 #ifdef __cplusplus
 extern "C" {

--- a/Common/util/stdio_compat.h
+++ b/Common/util/stdio_compat.h
@@ -20,12 +20,17 @@
 typedef int64_t file_off_t;
 
 // Size of the buffer enough to accomodate a UTF-8 path
-const size_t MAX_PATH_SZ = 1024;
+#ifdef __cplusplus
+const size_t MAX_PATH_SZ = 1024u;
+#else
+#define MAX_PATH_SZ (1024u)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+FILE *ags_fopen(const char *path, const char *mode);
 int	 ags_fseek(FILE * stream, file_off_t offset, int whence);
 file_off_t	 ags_ftell(FILE * stream);
 
@@ -33,6 +38,9 @@ int ags_file_exists(const char *path);
 int ags_directory_exists(const char *path);
 int ags_path_exists(const char *path);
 file_off_t ags_file_size(const char *path);
+
+int ags_remove(const char *path);
+int ags_rename(const char *src, const char *dst);
 
 #ifdef __cplusplus
 }

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -17,7 +17,6 @@
 #include "ac/dynamicsprite.h"
 #include "ac/path_helper.h"
 #include "ac/spritecache.h"
-#include "ac/runtime_defines.h" //MAX_PATH
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -131,10 +131,6 @@ const int LegacyRoomVolumeFactor            = 30;
 
 #define MAX_PLUGIN_OBJECT_READERS 50
 
-#ifndef MAX_PATH
-#define MAX_PATH 260
-#endif
-
 #define TRANS_ALPHA_CHANNEL 20000
 #define TRANS_OPAQUE        20001
 #define TRANS_RUN_PLUGIN    20002

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -208,9 +208,8 @@ bool engine_run_setup(const ConfigTree &cfg, int &app_res)
             // problem on Win9x, so let's restart the process.
             sys_main_shutdown();
             allegro_exit();
-            char quotedpath[MAX_PATH];
-            snprintf(quotedpath, MAX_PATH, "\"%s\"", appPath.GetCStr());
-            _spawnl(_P_OVERLAY, appPath.GetCStr(), quotedpath, NULL);
+            String args = String::FromFormat("\"%s\"", appPath.GetCStr());
+            _spawnl(_P_OVERLAY, appPath.GetCStr(), args.GetCStr(), NULL);
     }
 #endif
     return true;

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -59,10 +59,6 @@ String appPath; // engine exe path
 String appDirectory; // engine dir
 String cmdGameDataPath; // game path received from cmdline
 
-char **global_argv = nullptr;
-int    global_argc = 0;
-
-
 extern GameSetup usetup;
 extern GameState play;
 extern int our_eip;
@@ -149,10 +145,8 @@ void main_init(int argc, char*argv[])
     AssetMgr.reset(new AssetManager());
     main_pre_init();
     main_create_platform_driver();
+    platform->InitCommandArgs(argv, argc);
     platform->MainInitAdjustments();
-
-    global_argv = argv;
-    global_argc = argc;
 }
 
 String get_engine_string()
@@ -383,7 +377,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
 
     if (datafile_argv > 0)
     {
-        cmdGameDataPath = GetPathFromCmdArg(datafile_argv);
+        cmdGameDataPath = platform->GetCommandArg(datafile_argv);
     }
     else
     {
@@ -397,36 +391,10 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
     return 0;
 }
 
-void main_set_gamedir(int argc, char*argv[])
+void main_set_gamedir()
 {
-    appPath = GetPathFromCmdArg(0);
+    appPath = Path::MakeAbsolutePath(platform->GetCommandArg(0));
     appDirectory = Path::GetDirectoryPath(appPath);
-
-    // TODO: remove following when supporting unicode paths
-    {
-        // It looks like Allegro library does not like ANSI (ACP) paths.
-        // When *not* working in U_UNICODE filepath mode, whenever it gets
-        // current directory for its own operations, it "fixes" it by
-        // substituting non-ASCII symbols with '^'.
-        // Here we explicitly set current directory to ASCII path.
-        String cur_dir = Directory::GetCurrentDirectory();
-        String path = Path::GetPathInASCII(cur_dir);
-        if (!path.IsEmpty())
-            Directory::SetCurrentDirectory(Path::MakeAbsolutePath(path));
-        else
-            Debug::Printf(kDbgMsg_Error, "Unable to determine current directory: GetPathInASCII failed.\nArg: %s", cur_dir.GetCStr());
-    }
-}
-
-String GetPathFromCmdArg(int arg_index)
-{
-    if (arg_index < 0 || arg_index >= global_argc)
-        return "";
-    String path = Path::GetCmdLinePathInASCII(global_argv[arg_index], arg_index);
-    if (!path.IsEmpty())
-        return Path::MakeAbsolutePath(path);
-    Debug::Printf(kDbgMsg_Error, "Unable to determine path: GetCmdLinePathInASCII failed.\nCommand line argument %i: %s", arg_index, global_argv[arg_index]);
-    return global_argv[arg_index];
 }
 
 int ags_entry_point(int argc, char *argv[]) { 
@@ -463,7 +431,7 @@ int ags_entry_point(int argc, char *argv[]) {
     init_debug(startup_opts, justTellInfo);
     Debug::Printf(kDbgMsg_Alert, get_engine_string());
 
-    main_set_gamedir(argc, argv);    
+    main_set_gamedir();
 
     // Update shell associations and exit
     if (debug_flags & DBG_REGONLY)

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -30,16 +30,12 @@ extern AGS::Common::Version SavedgameLowestForwardCompatVersion;
 
 //=============================================================================
 
-extern char **global_argv;
-
 // Full path to the engine executable
 extern AGS::Common::String appPath;
 // Engine executable's directory
 extern AGS::Common::String appDirectory;
 // Game path from the startup options (before reading config)
 extern AGS::Common::String cmdGameDataPath;
-
-AGS::Common::String GetPathFromCmdArg(int arg_index);
 
 // Startup flags, set from parameters to engine
 extern int force_window;

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -105,6 +105,17 @@ SetupReturnValue AGSPlatformDriver::RunSetup(const ConfigTree &cfg_in, ConfigTre
     return kSetup_Cancel;
 }
 
+void AGSPlatformDriver::InitCommandArgs(const char *const argv[], size_t argc)
+{
+    _cmdArgs = argv;
+    _cmdArgCount = argc;
+}
+
+String AGSPlatformDriver::GetCommandArg(size_t arg_index)
+{
+    return arg_index < _cmdArgCount ? _cmdArgs[arg_index] : nullptr;
+}
+
 //-----------------------------------------------
 // IOutputHandler implementation
 //-----------------------------------------------

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -106,6 +106,11 @@ public:
     virtual int  CDPlayerCommand(int cmdd, int datt) = 0;
     virtual void ShutdownCDPlayer() = 0;
 
+    // Store command line arguments for the future use; preprocess them if necessary
+    virtual void InitCommandArgs(const char *const argv[], size_t argc);
+    // Returns command line argument in a UTF-8 format
+    virtual Common::String GetCommandArg(size_t arg_index);
+
      // Allows adjusting parameters and other fixes before engine is initialized
     virtual void MainInitAdjustments() { };
 
@@ -136,6 +141,9 @@ protected:
     // Defines whether engine is allowed to display important warnings
     // and errors by showing a message box kind of GUI.
     bool _guiMode = false;
+
+    const char * const *_cmdArgs = nullptr;
+    size_t _cmdArgCount = 0u;
 
 private:
     static AGSPlatformDriver *CreateDriver();

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -98,6 +98,9 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void UnRegisterGameWithGameExplorer();
   virtual void ValidateWindowSize(int &x, int &y, bool borderless) const;
 
+  // Returns command line argument in a UTF-8 format
+  String GetCommandArg(size_t arg_index) override;
+
 private:
   void add_game_to_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers);
   void remove_game_from_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers);
@@ -816,6 +819,21 @@ void AGSWin32::ValidateWindowSize(int &x, int &y, bool borderless) const
     y = Math::Min(y, (int)(max_win.Height - (nc_rc.bottom - nc_rc.top)));
     x = Math::Clamp(x, 1, (int)(wa_rc.right - wa_rc.left));
     y = Math::Clamp(y, 1, (int)(wa_rc.bottom - wa_rc.top));
+}
+
+String AGSWin32::GetCommandArg(size_t arg_index)
+{
+    // On MS Windows the regular cmdargs are represented in ASCII,
+    // therefore we must retrieve widechar variants using WinAPI
+    int wargc;
+    LPWSTR *wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (!wargv)
+        return nullptr;
+    String arg;
+    if (arg_index <= (size_t)wargc)
+        arg = Path::WidePathToUTF8(wargv[arg_index]);
+    LocalFree(wargv);
+    return arg;
 }
 
 AGSPlatformDriver* AGSPlatformDriver::CreateDriver()

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -15,7 +15,6 @@
 #include "core/platform.h"
 
 #if AGS_PLATFORM_OS_WINDOWS
-#define NOMINMAX
 #include <direct.h>
 #include <string.h>
 #include "platform/windows/windows.h"
@@ -35,15 +34,17 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "main/engine.h"
+#include "media/audio/audio_system.h"
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/sys_main.h"
 #include "platform/windows/setup/winsetup.h"
 #include "plugin/agsplugin.h"
+#include "util/directory.h"
 #include "util/file.h"
 #include "util/path.h"
+#include "util/stdio_compat.h"
 #include "util/stream.h"
 #include "util/string_compat.h"
-#include "media/audio/audio_system.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -60,8 +61,8 @@ extern RGB palette[256];
 #define CSIDL_COMMON_APPDATA       0x0023
 #endif
 
-char win32SavedGamesDirectory[MAX_PATH] = "\0";
-char win32AppDataDirectory[MAX_PATH] = "\0";
+String win32SavedGamesDirectory;
+String win32AppDataDirectory;
 String win32OutputDirectory;
 
 const unsigned int win32TimerPeriod = 1;
@@ -489,36 +490,26 @@ bool IsWindowsVistaOrGreater() {
 
 void determine_app_data_folder()
 {
-  if (win32AppDataDirectory[0] != 0) 
+  if (!win32AppDataDirectory.IsEmpty()) 
   {
     // already discovered
     return;
   }
 
-  WCHAR unicodePath[MAX_PATH];
-  WCHAR unicodeShortPath[MAX_PATH];
+  WCHAR unicodePath[MAX_PATH_SZ];
   SHGetSpecialFolderPathW(NULL, unicodePath, CSIDL_COMMON_APPDATA, FALSE);
-  if (GetShortPathNameW(unicodePath, unicodeShortPath, MAX_PATH) == 0)
-  {
-    platform->DisplayAlert("Unable to get App Data dir: GetShortPathNameW failed");
-    return;
-  }
-  WideCharToMultiByte(CP_ACP, 0, unicodeShortPath, -1, win32AppDataDirectory, MAX_PATH, NULL, NULL);
-
-  strcat(win32AppDataDirectory, "\\Adventure Game Studio");
-  mkdir(win32AppDataDirectory);
+  win32AppDataDirectory = Path::WidePathToUTF8(unicodePath);
+  win32AppDataDirectory = Path::ConcatPaths(win32AppDataDirectory, "Adventure Game Studio");
+  Directory::CreateDirectory(win32AppDataDirectory);
 }
 
 void determine_saved_games_folder()
 {
-  if (win32SavedGamesDirectory[0] != 0)
+  if (!win32SavedGamesDirectory.IsEmpty())
   {
     // already discovered
     return;
   }
-
-  WCHAR unicodeSaveGameDir[MAX_PATH] = L"";
-  WCHAR unicodeShortSaveGameDir[MAX_PATH] = L"";
 
   if (IsWindowsVistaOrGreater())
   {
@@ -530,9 +521,7 @@ void determine_saved_games_folder()
       PWSTR path = NULL;
       if (SUCCEEDED(Dynamic_SHGetKnownFolderPath(FOLDERID_SAVEDGAMES, 0, NULL, &path)))
       {
-        if (GetShortPathNameW(path, unicodeShortSaveGameDir, MAX_PATH) > 0) {
-          WideCharToMultiByte(CP_ACP, 0, unicodeShortSaveGameDir, -1, win32SavedGamesDirectory, MAX_PATH, NULL, NULL);
-        }
+        win32SavedGamesDirectory = Path::WidePathToUTF8(path);
         CoTaskMemFree(path);
       }
     }
@@ -541,25 +530,21 @@ void determine_saved_games_folder()
   }
   else
   {
+    WCHAR unicodeSaveGameDir[MAX_PATH_SZ] = L"";
     // Windows XP didn't have a "My Saved Games" folder, so create one under "My Documents"
     SHGetSpecialFolderPathW(NULL, unicodeSaveGameDir, CSIDL_PERSONAL, FALSE);
-    // workaround for case where My Documents path has unicode chars (eg.
-    // with Russian Windows) -- so use Short File Name instead
-    if (GetShortPathNameW(unicodeSaveGameDir, unicodeShortSaveGameDir, MAX_PATH) > 0)
-    {
-      WideCharToMultiByte(CP_ACP, 0, unicodeShortSaveGameDir, -1, win32SavedGamesDirectory, MAX_PATH, NULL, NULL);
-      strcat(win32SavedGamesDirectory, "\\My Saved Games");
-      mkdir(win32SavedGamesDirectory);
-    }
+    win32SavedGamesDirectory = Path::WidePathToUTF8(unicodeSaveGameDir);
+    win32SavedGamesDirectory = Path::ConcatPaths(win32SavedGamesDirectory, "My Saved Games");
+    Directory::CreateDirectory(win32SavedGamesDirectory);
   }
 
   // Fallback to a subdirectory of the app data directory
-  if (win32SavedGamesDirectory[0] == '\0')
+  if (win32SavedGamesDirectory.IsEmpty())
   {
     determine_app_data_folder();
-    strcpy(win32SavedGamesDirectory, win32AppDataDirectory);
-    strcat(win32SavedGamesDirectory, "\\Saved Games");
-    mkdir(win32SavedGamesDirectory);
+    win32SavedGamesDirectory = win32AppDataDirectory;
+    win32SavedGamesDirectory = Path::ConcatPaths(win32SavedGamesDirectory, "Saved Games");
+    Directory::CreateDirectory(win32SavedGamesDirectory);
   }
 }
 
@@ -572,37 +557,37 @@ void DetermineAppOutputDirectory()
 
   determine_saved_games_folder();
   bool log_to_saves_dir = false;
-  if (win32SavedGamesDirectory[0])
+  if (!win32SavedGamesDirectory.IsEmpty())
   {
     win32OutputDirectory = Path::ConcatPaths(win32SavedGamesDirectory, "Adventure Game Studio");
-    log_to_saves_dir = mkdir(win32OutputDirectory.GetCStr()) == 0 || errno == EEXIST;
+    log_to_saves_dir = Directory::CreateDirectory(win32OutputDirectory.GetCStr());
   }
 
   if (!log_to_saves_dir)
   {
-    char theexename[MAX_PATH + 1] = {0};
-    GetModuleFileName(NULL, theexename, MAX_PATH);
-    PathRemoveFileSpec(theexename);
-    win32OutputDirectory = theexename;
+    WCHAR theexename[MAX_PATH_SZ];
+    GetModuleFileNameW(NULL, theexename, MAX_PATH_SZ);
+    PathRemoveFileSpecW(theexename);
+    win32OutputDirectory = Path::WidePathToUTF8(theexename);
   }
 }
 
 const char* AGSWin32::GetAllUsersDataDirectory() 
 {
   determine_app_data_folder();
-  return &win32AppDataDirectory[0];
+  return win32AppDataDirectory.GetCStr();
 }
 
 const char *AGSWin32::GetUserSavedgamesDirectory()
 {
   determine_saved_games_folder();
-  return win32SavedGamesDirectory;
+  return win32SavedGamesDirectory.GetCStr();
 }
 
 const char *AGSWin32::GetUserConfigDirectory()
 {
   determine_saved_games_folder();
-  return win32SavedGamesDirectory;
+  return win32SavedGamesDirectory.GetCStr();
 }
 
 const char *AGSWin32::GetUserGlobalConfigDirectory()

--- a/Engine/platform/windows/debug/namedpipesagsdebugger.cpp
+++ b/Engine/platform/windows/debug/namedpipesagsdebugger.cpp
@@ -11,14 +11,12 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "core/platform.h"
 
 #if AGS_PLATFORM_OS_WINDOWS
-
-#include "platform/windows/debug/namedpipesagsdebugger.h"
-
 #include <stdio.h> // sprintf
+#include "platform/windows/debug/namedpipesagsdebugger.h"
+#include "util/stdio_compat.h"
 
 void NamedPipesAGSDebugger::SendAcknowledgement()
 {
@@ -37,12 +35,15 @@ NamedPipesAGSDebugger::NamedPipesAGSDebugger(const char *instanceToken)
 bool NamedPipesAGSDebugger::Initialize()
 {
     // can't use a single duplex pipe as it was deadlocking
-    char pipeNameBuffer[MAX_PATH];
-    sprintf(pipeNameBuffer, "\\\\.\\pipe\\AGSEditorDebuggerGameToEd%s", _instanceToken);
-    _hPipeSending = CreateFile(pipeNameBuffer, GENERIC_WRITE, 0, NULL, OPEN_EXISTING,0, NULL);
+    char pipeNameBuffer[MAX_PATH_SZ];
+    WCHAR wpipeNameBuf[MAX_PATH_SZ];
+    snprintf(pipeNameBuffer, MAX_PATH_SZ, "\\\\.\\pipe\\AGSEditorDebuggerGameToEd%s", _instanceToken);
+    MultiByteToWideChar(CP_UTF8, 0, pipeNameBuffer, -1, wpipeNameBuf, MAX_PATH_SZ);
+    _hPipeSending = CreateFileW(wpipeNameBuf, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 
-    sprintf(pipeNameBuffer, "\\\\.\\pipe\\AGSEditorDebuggerEdToGame%s", _instanceToken);
-    _hPipeReading = CreateFile(pipeNameBuffer, GENERIC_READ, 0, NULL, OPEN_EXISTING,0, NULL);
+    snprintf(pipeNameBuffer, MAX_PATH_SZ, "\\\\.\\pipe\\AGSEditorDebuggerEdToGame%s", _instanceToken);
+    MultiByteToWideChar(CP_UTF8, 0, pipeNameBuffer, -1, wpipeNameBuf, MAX_PATH_SZ);
+    _hPipeReading = CreateFileW(wpipeNameBuf, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
 
     if ((_hPipeReading == INVALID_HANDLE_VALUE) ||
         (_hPipeSending == INVALID_HANDLE_VALUE))

--- a/Engine/platform/windows/debug/namedpipesagsdebugger.h
+++ b/Engine/platform/windows/debug/namedpipesagsdebugger.h
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_NAMEDPIPESAGSDEBUGGER_H
 #define __AC_NAMEDPIPESAGSDEBUGGER_H
 


### PR DESCRIPTION
After #1321 unix ports should support utf-8 paths naturally, but on Windows standard library functions (as well as WinAPI) accepting `const char*` paths do not handle utf-8, which means we have to use wide-string api for unicode paths.

This pr changes all the file related functions to convert our strings to wide-char paths and use corresponding wide-string api on Windows.

Supposedly, after this change -
* DOS paths (aka "short paths") are no longer used anywhere in the engine;
* Windows engine should correctly interpret unicode paths passed into command line (well, it probably did before, but just to be sure...);
* Hopefully utf-8 paths in config file and winsetup will also work.
