### PR TITLE
Compiler: remove deprecated lefttoright flag

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -91,7 +91,6 @@ void CompilerOptions::PrintToStdout() const {
     if (Flags.DebugRun) printf("DebugRun; ");
     if (Flags.NoImportOverride) printf("NoImportOverride; ");
     if (Flags.EnforceObjectBasedScript) printf("EnforceObjectBasedScript; ");
-    if (Flags.LeftToRightPrecedence) printf("LeftToRightPrecedence; ");
     if (Flags.EnforceNewStrings) printf("EnforceNewStrings; ");
     if (Flags.EnforceNewAudio) printf("EnforceNewAudio; ");
     if (Flags.UseOldCustomDialogOptionsAPI) printf("UseOldCustomDialogOptionsAPI; ");
@@ -125,10 +124,6 @@ int Compile(const CompilerOptions& comp_opts)
     if (comp_opts.Flags.EnforceObjectBasedScript)
     {
         pp.DefineMacro("STRICT", "1");
-    }
-    if (comp_opts.Flags.LeftToRightPrecedence)
-    {
-        pp.DefineMacro("LRPRECEDENCE", "1");
     }
     if (comp_opts.Flags.EnforceNewStrings)
     {
@@ -177,7 +172,6 @@ int Compile(const CompilerOptions& comp_opts)
     // now deprecated, was used to prevent override imports in the room script
     ccSetOption(SCOPT_NOIMPORTOVERRIDE, comp_opts.Flags.NoImportOverride);
 
-    ccSetOption(SCOPT_LEFTTORIGHT, comp_opts.Flags.LeftToRightPrecedence);
     ccSetOption(SCOPT_OLDSTRINGS, !comp_opts.Flags.EnforceNewStrings);
 
     ccRemoveDefaultHeaders();

--- a/Compiler/compiler.h
+++ b/Compiler/compiler.h
@@ -34,7 +34,6 @@ class CompilerOptions{
         bool DebugRun = false;                // write instructions as they are processed to log file
         bool NoImportOverride = false;        // do not allow an import to be re-declared
         bool EnforceObjectBasedScript = true;
-        bool LeftToRightPrecedence = true;    // left-to-right operator precedence
         bool EnforceNewStrings = true;        // do not allow old-style strings
         bool EnforceNewAudio = true;
         bool UseOldCustomDialogOptionsAPI = false;

--- a/Compiler/main.cpp
+++ b/Compiler/main.cpp
@@ -24,7 +24,6 @@ const char *HELP_STRING = R"EOS(Usage: agscc [options] <INPUT.asc>
 -fdebugrun[=0]               Log instructions as they are processed
 -fnoimportoverride[=0]       Do not allow import to be re-declared
 -fforceobjectbasedscript[=0] Enforce Object based scripting         (default:1)
--flefttoright[=0]            Left-to-right operator precedence      (default:1)
 -fforcenewstrings[=0]        Enforce new strings                    (default:1)
 -fforcenewaudio[=0]          Enforce new audio system               (default:1)
 -foldcustomdialogopt[=0]     Use old custom dialog API
@@ -208,7 +207,7 @@ ParsedOptions parser_to_compiler_opts(const ParseResult& parseResult)
                 continue;
             }
             if(flag_name == "lefttoright") {
-                compilerOptions.Flags.LeftToRightPrecedence = flag_value;
+                printf("Warning: lefttoright flag is deprecated\n");
                 continue;
             }
             if(flag_name == "forcenewstrings") {


### PR DESCRIPTION
fix the failing builds on the CI, I forgot I let the compiler front end building in it.