### PR TITLE
Reimplement room mask display as a persistent overlay

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2138,6 +2138,7 @@ void prepare_room_sprites()
     our_eip = 36;
 
     // Debug room overlay
+    update_room_debug();
     if ((debugRoomMask != kRoomAreaNone) && debugRoomMaskDDB)
         add_thing_to_draw(debugRoomMaskDDB, 0, 0);
 }
@@ -2623,6 +2624,16 @@ void debug_draw_room_mask(RoomAreaMask mask)
 
     debugRoomMaskDDB = recycle_ddb_bitmap(debugRoomMaskDDB, mask_bmp, false, true);
     debugRoomMaskDDB->SetTransparency(150);
+}
+
+void update_room_debug()
+{
+    if (debugRoomMask == kRoomAreaWalkable)
+    {
+        Bitmap *mask_bmp = prepare_walkable_areas(-1);
+        debugRoomMaskDDB = recycle_ddb_bitmap(debugRoomMaskDDB, mask_bmp, false, true);
+        debugRoomMaskDDB->SetTransparency(150);
+    }
 }
 
 // Draw everything 

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -103,6 +103,7 @@ void construct_engine_overlay();
 void clear_letterbox_borders();
 
 void debug_draw_room_mask(RoomAreaMask mask);
+void update_room_debug();
 
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
 void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha,

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -11,10 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-//
-//
-//
-//=============================================================================
 #ifndef __AGS_EE_AC__DRAW_H
 #define __AGS_EE_AC__DRAW_H
 
@@ -22,6 +18,7 @@
 #include "core/types.h"
 #include "ac/common_defines.h"
 #include "gfx/gfx_def.h"
+#include "game/roomstruct.h"
 
 namespace AGS
 {
@@ -104,6 +101,8 @@ void construct_game_screen_overlay(bool draw_mouse = true);
 void construct_engine_overlay();
 // Clears black game borders in legacy letterbox mode
 void clear_letterbox_borders();
+
+void debug_draw_room_mask(RoomAreaMask mask);
 
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
 void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha,

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -103,6 +103,7 @@ void construct_engine_overlay();
 void clear_letterbox_borders();
 
 void debug_draw_room_mask(RoomAreaMask mask);
+void debug_draw_movelist(int charnum);
 void update_room_debug();
 
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);

--- a/Engine/ac/walkablearea.cpp
+++ b/Engine/ac/walkablearea.cpp
@@ -136,14 +136,13 @@ int is_point_in_rect(int x, int y, int left, int top, int right, int bottom) {
 Bitmap *prepare_walkable_areas (int sourceChar) {
     // copy the walkable areas to the temp bitmap
     walkable_areas_temp->Blit(thisroom.WalkAreaMask.get(), 0,0,0,0,thisroom.WalkAreaMask->GetWidth(),thisroom.WalkAreaMask->GetHeight());
-    // if the character who's moving doesn't Bitmap *, don't bother checking
+    // if the character who's moving doesn't block, don't bother checking
     if (sourceChar < 0) ;
     else if (game.chars[sourceChar].flags & CHF_NOBLOCKING)
         return walkable_areas_temp;
 
     int ww;
-    // for each character in the current room, make the area under
-    // them unwalkable
+    // for each character in the current room, make the area under them unwalkable
     for (ww = 0; ww < game.numcharacters; ww++) {
         if (game.chars[ww].on != 1) continue;
         if (game.chars[ww].room != displayed_room) continue;
@@ -164,8 +163,7 @@ Bitmap *prepare_walkable_areas (int sourceChar) {
         remove_walkable_areas_from_temp(fromx, cwidth, char1->get_blocking_top(), char1->get_blocking_bottom());
     }
 
-    // check for any blocking objects in the room, and deal with them
-    // as well
+    // check for any blocking objects in the room, and deal with them as well
     for (ww = 0; ww < croom->numobj; ww++) {
         if (objs[ww].on != 1) continue;
         if ((objs[ww].flags & OBJF_SOLID) == 0)


### PR DESCRIPTION
Resolves #724.

1. "Show walkable areas" debug command (`Debug(2, 0)`) is reimplemented from displaying an opaque mask over a freezed game into persistent half-transparent overlay that does not pause the game.
2. `Debug(2, n)` now has a meaningful second parameter which defines a mask type, values are: 0 -none, 1 -hotspot, 2 -walk-behind, 3 -walkable, 4 -regions.
3. `Debug(2, n)` command now works as a on/off toggle, so calling it will same mask type consecutively will turn it on and off.  This also helps with backward compatibility, because old games that have this command in script would not have a way to turn masks off.
4. "Show character walking paths" debug command (`Debug(5, n)`) is similarily reimplemented as a half-transparent overlay, and working in a toggling manner.

**NOTE:** In many old games this command is run on "Ctrl+A"; you may have to run them in debug mode though (`ags game --test`)