### PR TITLE
Editor: fix outline upgrade was set to 0

### DIFF
--- a/Editor/AGS.Types/Font.cs
+++ b/Editor/AGS.Types/Font.cs
@@ -19,8 +19,8 @@ namespace AGS.Types
         private int _sizeMultiplier = 1;
         private int _verticalOffset;
         private int _lineSpacing;
-        private int _autoOutlineThickness = 0;
-        private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Rounded;
+        private int _autoOutlineThickness = 1;
+        private FontAutoOutlineStyle _autoOutlineStyle = FontAutoOutlineStyle.Squared;
 
         public Font()
         {


### PR DESCRIPTION
If you open and upgrade an older project (before 3.6.X) with the current master, it will not set the internal value for thickness of the font (`_autoOutlineThickness`), and then when you try to open the project after saving you will meet this error:

```
An error occurred whilst trying to load your game. The error was:

Exception has been thrown by the target of an invocation
...
---> System.ArgumentException: AutoOutlineThickness must be 1 or greater.
  at AGS.Types.Font.set_AutoOutlineThickness(Int32 value) in ags\Editor\AGS.Types\Font.cs:line 132
...
```
<details>
<img src="https://user-images.githubusercontent.com/2244442/130708433-f2540d6a-d5dd-49ef-9aa9-f9fd693a86bc.png"></img>

In Game.agf, after upgrade the `AutoOutlineThickness` is 0 as below:

```
 <Font>
        <AutoOutlineStyle>Squared</AutoOutlineStyle>
        <AutoOutlineThickness>0</AutoOutlineThickness>
        <ID>0</ID>
        <LineSpacing>0</LineSpacing>
        <Name>Normal</Name>
        <OutlineFont>0</OutlineFont>
        <OutlineStyle>None</OutlineStyle>
        <PointSize>0</PointSize>
        <SizeMultiplier>1</SizeMultiplier>
        <SourceFilename />
        <VerticalOffset>0</VerticalOffset>
      </Font>
```

After the fix, it's 1.
</details>

I am not sure if this is the right fix, but after applying it, when I upgrade an older project and save, I can load it and don't have the error anymore.

The problem is that as far as I can tell, all fonts need `AutoOutlineThickness` set to at least 1 in project files, even if `OutlineStyle` is set to `None`.