### PR TITLE
New compiler: Fix bug: Type-check assignments to an attribute

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -4172,6 +4172,16 @@ AGS::ErrorType AGS::Parser::AccessData_AssignTo(ScopeType sct, Vartype vartype, 
 
     if (ValueLocation::kAttribute == vloc.location)
     {
+        ConvertAXStringToStringObject(lhsvartype, rhsvartype);
+        if (IsVartypeMismatch_Oneway(rhsvartype, _sym.VartypeWithout(VTT::kDynarray, lhsvartype)))
+        {
+            Error(
+                "Cannot assign a type '%s' value to a type '%s' attribute",
+                _sym.GetName(rhsvartype).c_str(),
+                _sym.GetName(lhsvartype).c_str());
+            return kERR_UserError;
+        }
+
         // We need to call the attribute setter
         Symbol attribute = vloc.symbol;
 

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -1220,39 +1220,38 @@ TEST_F(Bytecode1, Attributes07) {
 
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     // WriteOutput("Attributes07", scrip);
-    const size_t codesize = 26;
+    size_t const codesize = 28;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            0,    6,    2,   22,    // 7
-      29,    6,   34,    3,           45,    2,   39,    1,    // 15
-       6,    3,   21,   33,            3,   35,    1,   30,    // 23
-       6,    5,  -999
+      64,    3,   29,    6,           34,    3,   45,    2,    // 15
+      39,    1,    6,    3,           21,   33,    3,   35,    // 23
+       1,   30,    6,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 3;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,    7,   18,  -999
+       4,    7,   20,  -999
     };
     char fixuptypes[] = {
       3,   4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 2;
+    int const numimports = 2;
     std::string imports[] = {
     "Label::set_Text^1",          "lbl",          "[[SENTINEL]]"
     };
-
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 1;
+    size_t const stringssize = 1;
     EXPECT_EQ(stringssize, scrip.stringssize);
 
     char strings[] = {

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1932,3 +1932,24 @@ TEST_F(Compile1, StaticThisExtender)
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'static'"));
 }
+
+TEST_F(Compile1, AttributeAssignTypeCheck)
+{
+    // This attribute is type 'float' and assigned an int. This should fail.
+
+    char *inpl = "\
+        builtin managed struct Character            \n\
+        {                                           \n\
+            import attribute float GraphicRotation; \n\
+        };                                          \n\
+        import readonly Character *player;          \n\
+        int foo(void) {                             \n\
+            player.GraphicRotation = 10;            \n\
+        }                                           \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'int'"));
+    EXPECT_NE(std::string::npos, msg.find("'float'"));
+}


### PR DESCRIPTION
This PR addresses #1399.

Assignments to an attribute must be type-checked, but weren't. Typical code:

```
function room_FirstLoad()
{
    
    player.GraphicRotation = 10;
}
```
Should yield an error because the attribute `player.GraphicRotation` is type `float`. Didn't. Does now.

This fix has uncovered and fixes another bug, too: It ensures that `string` values are converted to `String` before they are assigned to an attribute of type `String`.


