### PR TITLE
New Compiler (Scanner): Grok  '\\'

### DIFF
--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -466,13 +466,19 @@ AGS::ErrorType AGS::Scanner::EscapedChar2Char(int first_char_after_backslash, st
 
     switch (first_char_after_backslash)
     {
-    default: break;
-    case '\'': converted = '\''; return kERR_None;
-    case '\"': converted = '\"'; return kERR_None;
-    case '?': converted = '\?'; return kERR_None;
+    default:
+        break;
+
+    case '\'': 
+    case '"': 
+    case '?': 
+    case '\\':
+        converted = first_char_after_backslash;
+        return kERR_None;
+
     case 'a': converted = '\a'; return kERR_None;
     case 'b': converted = '\b'; return kERR_None;
-    case 'e': converted = 27; return kERR_None; // escape char
+    case 'e': converted = 27;   return kERR_None; // escape char
     case 'f': converted = '\f'; return kERR_None;
     case 'n': converted = '\n'; return kERR_None;
     case 'r': converted = '\r'; return kERR_None;

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -592,6 +592,24 @@ TEST_F(Scan, BackslashCSym) {
     EXPECT_STREQ(" Is 'Java' \x1bqual to \"Ja\va\" ? ", &(string_collector.strings[value]));
 }
 
+TEST_F(Scan, BackslashBackslash) {
+    
+    // Backslash Backslash in strings or char literals converts to backslash.
+
+    char *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
+    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+
+    ASSERT_LE(0, scanner.GetNextSymstring(symstring, sct, value));
+    ASSERT_LE(0, value);
+    EXPECT_STREQ("'\\\\'", symstring.c_str());
+    EXPECT_EQ('\\', value);
+  
+    ASSERT_LE(0, scanner.GetNextSymstring(symstring, sct, value));
+    ASSERT_LE(0, value);
+    EXPECT_STREQ("\"\\\\a\\\\b\\\\\"", symstring.c_str());
+    EXPECT_STREQ("\\a\\b\\", &(string_collector.strings[value]));
+}
+
 TEST_F(Scan, String1)
 {
     // Should scan advanced escape sequences within string.


### PR DESCRIPTION
This PR addresses #1406.

Convert double-backslash within string and character literals to a single backslash, in 'C' style.
Typical code: 
```
String test = "test\\test";
```
