### PR TITLE
Engine: Link in such a way that functions can call all imported (!) functions, no matter the module sequence

### DIFF
--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -945,6 +945,12 @@ void compile_room_script() {
         quitprintf("Unable to create local script: %s", ccErrorString.GetCStr());
     }
 
+    if (!roominst->ResolveScriptImports(roominst->instanceof))
+        quitprintf("Unable to resolve imports in room script");
+
+    if (!roominst->ResolveImportFixups(roominst->instanceof))
+        quitprintf("Unable to resolve import fixups in room script");
+
     roominstFork = roominst->Fork();
     if (roominstFork == nullptr)
         quitprintf("Unable to create forked room instance: %s", ccErrorString.GetCStr());

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1437,7 +1437,6 @@ bool ccInstance::IsBeingRun() const
 
 bool ccInstance::_Create(PScript scri, ccInstance * joined)
 {
-    int i;
     currentline = -1;
     if ((scri == nullptr) && (joined != nullptr))
         scri = joined->instanceof;
@@ -1495,7 +1494,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
     }
 
     // find a LoadedInstance slot for it
-    for (i = 0; i < MAX_LOADED_INSTANCES; i++) {
+    for (int i = 0; i < MAX_LOADED_INSTANCES; i++) {
         if (loadedInstances[i] == nullptr) {
             loadedInstances[i] = this;
             loadedInstanceId = i;
@@ -1514,10 +1513,6 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
     }
     else
     {
-        if (!ResolveScriptImports(scri))
-        {
-            return false;
-        }
         if (!CreateGlobalVars(scri))
         {
             return false;
@@ -1531,7 +1526,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
     exports = new RuntimeScriptValue[scri->numexports];
 
     // find the real address of the exports
-    for (i = 0; i < scri->numexports; i++) {
+    for (int i = 0; i < scri->numexports; i++) {
         int32_t etype = (scri->export_addr[i] >> 24L) & 0x000ff;
         int32_t eaddr = (scri->export_addr[i] & 0x00ffffff);
         if (etype == EXPORT_FUNCTION)
@@ -1567,7 +1562,7 @@ bool ccInstance::_Create(PScript scri, ccInstance * joined)
 
     if ((scri->instances == 1) && (ccGetOption(SCOPT_AUTOIMPORT) != 0)) {
         // import all the exported stuff from this script
-        for (i = 0; i < scri->numexports; i++) {
+        for (int i = 0; i < scri->numexports; i++) {
             if (!ccAddExternalScriptSymbol(scri->exports[i], exports[i], this)) {
                 cc_error("Export table overflow at '%s'", scri->exports[i]);
                 return false;
@@ -1619,44 +1614,47 @@ void ccInstance::Free()
 
 bool ccInstance::ResolveScriptImports(PScript scri)
 {
-    // When the import is referenced in code, it's being addressed
-    // by it's index in the script imports array. That index is
-    // NOT unique and relative to script only.
-    // Script keeps information of used imports as an array of
-    // names.
-    // To allow real-time import use we should put resolved imports
-    // to the array keeping the order of their names in script's
-    // array of names.
+    // Script keeps the information of what imports are used as an array of names.
+    // When an import is referenced in the code, it's addressed by its index in this
+    // array. Different scripts have differing arrays of imports; indexes
+    // into 'imports[]' are NOT unique and relative to the respective script only.
+    // To allow real-time import use, the sequence of imports in 'imports[]'
+    // and 'resolved_imports[]' should not be modified.
 
-    // resolve all imports referenced in the script
     numimports = scri->numimports;
     if (numimports == 0)
     {
+        // [PGB] AFAICS there's nothing wrong with not having any imports, and
+        // it doesn't lead to trouble. However, if it turns out that we do need
+        // to return 'false' here, we should also report why with a 'Debug::Printf()' call.
         resolved_imports = nullptr;
-        return false;
+        return true;
     }
 
     resolved_imports = new int[numimports];
     int errors = 0, last_err_idx;
-    for (int i = 0; i < scri->numimports; ++i) {
-        if (scri->imports[i] == nullptr) {
-            resolved_imports[i] = -1;
+    for (int import_idx = 0; import_idx < scri->numimports; ++import_idx)
+    {
+        if (scri->imports[import_idx] == nullptr)
+        {
+            resolved_imports[import_idx] = -1;
             continue;
         }
 
-        resolved_imports[i] = simp.get_index_of(scri->imports[i]);
-        if (resolved_imports[i] < 0) {
-            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[i], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
+        resolved_imports[import_idx] = simp.get_index_of(scri->imports[import_idx]);
+        if (resolved_imports[import_idx] < 0)
+        {
+            Debug::Printf(kDbgMsg_Error, "unresolved import '%s' in '%s'", scri->imports[import_idx], scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>");
             errors++;
-            last_err_idx = i;
+            last_err_idx = import_idx;
         }
     }
 
     if (errors > 0)
-       cc_error("in %s: %d unresolved imports (last: %s)",
-         scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>",
-         errors,
-         scri->imports[last_err_idx]);
+        cc_error("in %s: %d unresolved imports (last: %s)",
+            scri->numSections > 0 ? scri->sectionNames[0] : "<unknown>",
+            errors,
+            scri->imports[last_err_idx]);
 
     return errors == 0;
 }
@@ -1785,32 +1783,37 @@ bool ccInstance::CreateRuntimeCodeFixups(PScript scri)
         case FIXUP_FUNCTION:
         case FIXUP_STRING:
         case FIXUP_STACK:
-            break; // do nothing yet
         case FIXUP_IMPORT:
-            // we do not need to save import's address now when we have
-            // resolved imports kept so far as instance exists, but we
-            // must fixup the following instruction in certain case
-            {
-                int import_index = resolved_imports[code[fixup]];
-                const ScriptImport *import = simp.getByIndex(import_index);
-                if (!import)
-                {
-                    cc_error("cannot resolve import, key = %d", import_index);
-                    return false;
-                }
-                code[fixup] = import_index;
-                // If the call is to another script function next CALLEXT
-                // must be replaced with CALLAS
-                if (import->InstancePtr != nullptr && (code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
-                {
-                    code[fixup + 1] = SCMD_CALLAS | (import->InstancePtr->loadedInstanceId << INSTANCE_ID_SHIFT);
-                }
-            }
-            break;
+            break; // do nothing yet
+        
         default:
             cc_error("internal fixup index error: %d", scri->fixuptypes[i]);
             return false;
         }
+    }
+    return true;
+}
+
+bool ccInstance::ResolveImportFixups(PScript scri)
+{
+    for (int fixup_idx = 0; fixup_idx < scri->numfixups; ++fixup_idx)
+    {
+        if (scri->fixuptypes[fixup_idx] != FIXUP_IMPORT)
+            continue;
+
+        int32_t const fixup = scri->fixups[fixup_idx];
+        int const import_index = resolved_imports[code[fixup]];
+        ScriptImport const *import = simp.getByIndex(import_index);
+        if (!import)
+        {
+            cc_error("cannot resolve import, key = %d", import_index);
+            return false;
+        }
+        code[fixup] = import_index;
+        // If the call is to another script function next CALLEXT
+        // must be replaced with CALLAS
+        if (import->InstancePtr != nullptr && (code[fixup + 1] & INSTANCE_ID_REMOVEMASK) == SCMD_CALLEXT)
+            code[fixup + 1] = SCMD_CALLAS | (import->InstancePtr->loadedInstanceId << INSTANCE_ID_SHIFT);
     }
     return true;
 }

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -180,12 +180,19 @@ public:
     // Tells whether this instance is in the process of executing the byte-code
     bool    IsBeingRun() const;
 
-protected:
+    // For each import, find the instance that corresponds to it and save it
+    // in resolved_imports[]. Return whether the function is successful
+    bool    ResolveScriptImports(PScript scri);
+
+    // Using resolved_imports[], resolve the IMPORT fixups
+    // Also change CALLEXT op-codes to CALLAS when they pertain to a script instance 
+    bool    ResolveImportFixups(PScript scri);
+
+protected:    
     bool    _Create(PScript scri, ccInstance * joined);
     // free the memory associated with the instance
     void    Free();
 
-    bool    ResolveScriptImports(PScript scri);
     bool    CreateGlobalVars(PScript scri);
     bool    AddGlobalVar(const ScriptVariable &glvar);
     ScriptVariable *FindGlobalVar(int32_t var_addr);


### PR DESCRIPTION
Rationale:
- It makes life easier for coders, they have less reason to juggle the module sequence. 
- This is a **prerequisite** for implementing any sort of a function pointer or callback mechanism. For callbacks, it's kind of the point that we can call a function without knowing anything about it, in particular without having to guarantee that it has been defined in an earlier module. 

AFAICS existing programs don't need to be changed in any way for this PR; they should continue to work without recompiling.
AFAICS neither the new nor the existing compilers need to be changed for this PR.

The effect is achieved by changing the sequence of the linking steps.
- First, create the instances for the scripts.
- Then, resolve references to imports and the 'IMPORT' fixups.
- Then, create the forks.