### PR TITLE
SDL2 engine: window icons

### DIFF
--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -25,6 +25,8 @@
 #include "debug/outputhandler.h"
 #include "util/ini_util.h"
 
+struct SDL_Surface;
+
 namespace AGS
 {
     namespace Common { class Stream; }
@@ -103,6 +105,9 @@ public:
     virtual void UnRegisterGameWithGameExplorer();
     // Adjust window size to ensure it is in the supported limits
     virtual void ValidateWindowSize(int &x, int &y, bool borderless) const {}
+    // Either set window icon using system API directly, or create a SDL_Surface
+    // for the SDL backend to set an icon instead.
+    virtual SDL_Surface *CreateWindowIcon() { return nullptr; }
 
     virtual int  InitializeCDPlayer() = 0;  // return 0 on success
     virtual int  CDPlayerCommand(int cmdd, int datt) = 0;

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -14,6 +14,7 @@
 #include "platform/base/sys_main.h"
 #include <SDL.h>
 #include <SDL_syswm.h>
+#include "platform/base/agsplatformdriver.h"
 #include "util/geometry.h"
 #include "util/string.h"
 
@@ -149,10 +150,10 @@ void sys_window_set_title(const char *title) {
 
 void sys_window_set_icon() {
     if (window) {
-        // TODO: actually support getting icon from resources and converting into SDL_Surface.
-        //  - on Linux we had platform/linux/icon.xpm
-        //  - on Windows we had standard embedded resource under ID = 101
-        SDL_SetWindowIcon(window, nullptr);
+        SDL_Surface *icon = platform->CreateWindowIcon();
+        if (!icon) return; // no icon
+        SDL_SetWindowIcon(window, icon);
+        SDL_FreeSurface(icon);
     }
 }
 

--- a/Engine/platform/linux/acpllnx.cpp
+++ b/Engine/platform/linux/acpllnx.cpp
@@ -17,7 +17,8 @@
 #if AGS_PLATFORM_OS_LINUX
 
 // *************** LINUX DRIVER ***************
-
+#include <unordered_map>
+#include <SDL.h>
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/agsplatform_xdg_unix.h"
 #include "libsrc/libcda-0.5/libcda.h"
@@ -27,6 +28,7 @@ struct AGSLinux : AGSPlatformXDGUnix {
   eScriptSystemOSID GetSystemOSID() override;
   int  InitializeCDPlayer() override;
   void ShutdownCDPlayer() override;
+  SDL_Surface *CreateWindowIcon() override;
 };
 
 
@@ -44,6 +46,80 @@ int AGSLinux::InitializeCDPlayer() {
 
 void AGSLinux::ShutdownCDPlayer() {
   cd_exit();
+}
+
+struct XpmInfo
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t palsize = 0;
+    uint32_t chpp = 0; // characters per pixel
+    static const int shift_r = 16;
+    static const int shift_g = 8;
+    static const int shift_b = 0;
+    static const int shift_a = 24;
+
+    std::unordered_map<uint32_t, uint32_t> pal;
+    const char **pixels = nullptr;
+} xpminfo;
+
+static bool OpenXpm(const char *xpm[], XpmInfo &xpminfo)
+{
+    sscanf(xpm[0], "%u %u %u %u", &xpminfo.width, &xpminfo.height, &xpminfo.palsize, &xpminfo.chpp);
+    if (xpminfo.width == 0 || xpminfo.height == 0 || xpminfo.palsize == 0 || xpminfo.chpp == 0)
+        return false;
+    xpminfo.pal.reserve(xpminfo.palsize);
+    for (uint32_t col = 1; col < xpminfo.palsize + 1; ++col)
+    {
+        uint32_t colid = 0;
+        for (uint32_t cc = 0; cc < xpminfo.chpp; ++cc)
+            colid |= xpm[col][cc] << (cc * 8);
+        uint32_t colval = 0;
+        const char *p_value = xpm[col] + xpminfo.chpp + 3;
+        if (*p_value == '#')
+        {
+            sscanf(p_value + 1, "%x", &colval);
+            colval |= 0xFF << XpmInfo::shift_a;
+        }
+        xpminfo.pal.insert(std::make_pair(colid, colval));
+    }
+    xpminfo.pixels = &xpm[xpminfo.palsize + 1];
+    return true;
+}
+
+static void XpmToArgb(const XpmInfo &xpminfo, uint8_t *dst_buf, size_t dst_pitch)
+{
+    const uint32_t w = xpminfo.width, h = xpminfo.height, chpp = xpminfo.chpp;
+    const char **pixels = xpminfo.pixels;
+    for (uint32_t y = 0; y < h; ++y)
+    {
+        const char *src = pixels[y];
+        const char *src_end = src + chpp * w;
+        uint32_t *dst = (uint32_t*)(dst_buf + (dst_pitch * y));
+        for (; src < src_end;)
+        {
+            uint32_t colid = 0;
+            for (size_t cc = 0; cc < chpp; ++cc)
+                colid |= (*src++) << (cc * 8);
+            uint32_t colval = xpminfo.pal.at(colid);
+            (*dst++) =
+                (((colval >> XpmInfo::shift_r) & 0xFF) << 16) |
+                (((colval >> XpmInfo::shift_g) & 0xFF) << 8) |
+                (((colval >> XpmInfo::shift_b) & 0xFF) << 0) |
+                (((colval >> XpmInfo::shift_a) & 0xFF) << 24);
+        }
+    }
+}
+
+#include "platform/linux/icon.xpm"
+
+SDL_Surface *AGSLinux::CreateWindowIcon() {
+    XpmInfo xpminfo;
+    if (!OpenXpm(icon_xpm, xpminfo)) return nullptr;
+    SDL_Surface *sdl_icon = SDL_CreateRGBSurfaceWithFormat(
+        0, xpminfo.width, xpminfo.height, 32, SDL_PIXELFORMAT_ARGB8888);
+    XpmToArgb(xpminfo, (uint8_t*)sdl_icon->pixels, sdl_icon->pitch);
+    return sdl_icon;
 }
 
 AGSPlatformDriver* AGSPlatformDriver::CreateDriver()

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -45,6 +45,7 @@
 #include "util/stdio_compat.h"
 #include "util/stream.h"
 #include "util/string_compat.h"
+#include "resource/resource.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -98,6 +99,7 @@ struct AGSWin32 : AGSPlatformDriver {
   virtual void RegisterGameWithGameExplorer();
   virtual void UnRegisterGameWithGameExplorer();
   virtual void ValidateWindowSize(int &x, int &y, bool borderless) const;
+  virtual SDL_Surface *CreateWindowIcon();
 
   // Returns command line argument in a UTF-8 format
   String GetCommandArg(size_t arg_index) override;
@@ -804,6 +806,14 @@ void AGSWin32::ValidateWindowSize(int &x, int &y, bool borderless) const
     y = Math::Min(y, (int)(max_win.Height - (nc_rc.bottom - nc_rc.top)));
     x = Math::Clamp(x, 1, (int)(wa_rc.right - wa_rc.left));
     y = Math::Clamp(y, 1, (int)(wa_rc.bottom - wa_rc.top));
+}
+
+SDL_Surface *AGSWin32::CreateWindowIcon()
+{
+    // Don't mess with SDL surface, and set an icon simply using WinAPI
+    SetClassLongW((HWND)sys_win_get_window(), GCLP_HICON,
+        (LONG)LoadImage(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE));
+    return nullptr;
 }
 
 String AGSWin32::GetCommandArg(size_t arg_index)

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -1235,12 +1235,6 @@ void WinSetupDialog::UpdateMouseSpeedText()
 // Windows setup entry point.
 //
 //=============================================================================
-void SetWinIcon()
-{
-    SetClassLongPtr((HWND)sys_win_get_window(), GCLP_HICON,
-        (LONG_PTR) LoadImage(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE));
-}
-
 SetupReturnValue WinSetup(const ConfigTree &cfg_in, ConfigTree &cfg_out,
                           const String &game_data_dir, const String &version_str)
 {

--- a/Engine/platform/windows/setup/winsetup.h
+++ b/Engine/platform/windows/setup/winsetup.h
@@ -28,7 +28,6 @@ namespace Engine
 
 using namespace Common;
 
-void SetWinIcon();
 SetupReturnValue WinSetup(const ConfigTree &cfg_in, ConfigTree &cfg_out,
                           const String &game_data_dir, const String &version_str);
 


### PR DESCRIPTION
This reimplements game window icons for Windows and Linux in the new engine.

Added `SDL_Surface *CreateWindowIcon()` method to the platform driver, the idea is that it either creates and returns SDL_Surface with an icon, or sets an icon itself and returns null, or just returns null if does not support this. If the return value is not null, then engine passes the SDL_Surface object into `SDL_SetWindowIcon` and disposes it.

---

On Windows this method simply assigns an icon from resources; I figured it's better to make a pair WinAPI calls than bother generating sdl image from a resource.
There was another reason though; at first I tried the hard way for a test's sake: load icon, extract pixels, convert into SDL_Surface format, and so on. But it seemed that SDL2 does something wrong, or I did, or perhaps there are more requirements for this to work, because the icon appeared as if it were downgraded in color depth.

---

On Linux, we were embedding an XPM file previously, which allegro4 loaded using X11 libs. I am unsure whether it's wanted or not that we link x11 to the engine again. If we do, then I think I could copy original allegro4 code that set up an icon ([one may check it out here](https://github.com/liballeg/allegro5/blob/4.4/src/x/xwin.c#L2243)), or use something similar.
For now I went a "hard" way here and wrote a primitive XPM parser that reads its array and writes into RGBA buffer.

The problem here is, that although this worked when I test on Windows, similar code has no result when running on Linux... the icon is simply not set (I see a gray question mark instead on Ubuntu). I'd leave this PR as wip for a little while, and do more tests and debugging at the same time.

**PS.** BTW, maybe this code should rather be in the parent AGSPlatformXDGUnix class, thus shared with FreeBSD? Or, in theory, with manual XPM loading, same icon could be used on any platform, even Windows.