### PR TITLE
Ci release 3.5.1 fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -184,6 +184,7 @@ build_editor_task:
     copy C:\Lib\irrKlang\*.dll Editor\References\ &&
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\8.0\Lib\Win8\um\x86;!LIB!" &&
+    set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&
     msbuild AGS.Editor.Full.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform="Mixed Platforms" /maxcpucount /nologo"
   ags_editor_pdb_artifacts:
     path: Solutions/.build/*/*.pdb

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -135,7 +135,6 @@
       <AdditionalIncludeDirectories>..\..;..\..\Common;..\..\Common\libinclude;..\..\Compiler;..\Native;..\scintilla\include;..\..\Windows\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;_USRDLL;WINDOWS_VERSION;ALLEGRO_STATICLINK;ALLEGRO_NO_FIX_ALIASES;_MERGE_PROXYSTUB;STATIC_BUILD;SCI_LEXER;USE_ALFONT;_BIND_TO_CURRENT_VCLIBS_VERSION=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/ci/android/Dockerfile
+++ b/ci/android/Dockerfile
@@ -68,13 +68,13 @@ RUN curl -fLOJ "https://dl.google.com/android/repository/tools_r${BUILD_TOOLS_AN
   rm tools_r${BUILD_TOOLS_ANT_VERSION}-linux.zip
 
 # Get Ant
-ARG ANT_VERSION=1.10.9
+ARG ANT_VERSION=1.10.11
 RUN curl -fLSs "https://www.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz" | \
   tar -f - -xvzC /opt
 
 # Build libraries
 ARG AGS_ORGANIZATION=adventuregamestudio
-ARG AGS_BRANCH=master
+ARG AGS_BRANCH=release-3.5.1
 RUN cd /tmp && \
   git clone -b "${AGS_BRANCH}" "https://github.com/${AGS_ORGANIZATION}/ags.git" && \
   cd ags/Android/buildlibs && \

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get install curl
 RUN apt-get install \
   build-essential \
   debhelper \
+  autoconf \
+  dh-autoreconf \
   git \
   libaldmb1-dev \
   libogg-dev \
@@ -31,30 +33,36 @@ RUN apt-get install \
 
 # Build newer libogg
 ARG LIBOGG_VERSION=1.3.4
-RUN curl -fLsS "https://downloads.xiph.org/releases/ogg/libogg-$LIBOGG_VERSION.tar.gz" | tar -f - -xvzC /tmp && \
-  cd /tmp/libogg-$LIBOGG_VERSION && \
+RUN curl -fLsS "https://github.com/xiph/ogg/releases/download/v${LIBOGG_VERSION}/libogg-${LIBOGG_VERSION}.tar.xz" --output /tmp/libogg-${LIBOGG_VERSION}.tar.xz && \
+  tar --file=/tmp/libogg-${LIBOGG_VERSION}.tar.xz -xvJC /tmp && \
+  cd /tmp/libogg-${LIBOGG_VERSION} && \
   ./configure --prefix=/opt && \
   make && \
   make install && \
-  rm -r /tmp/libogg-$LIBOGG_VERSION
+  rm -r /tmp/libogg-${LIBOGG_VERSION} && \
+  rm /tmp/libogg-${LIBOGG_VERSION}.tar.xz
 
 # Build newer libvorbis
 ARG LIBVORBIS_VERSION=1.3.7
-RUN curl -fLsS "https://downloads.xiph.org/releases/vorbis/libvorbis-$LIBVORBIS_VERSION.tar.xz" | tar -f - -xvJC /tmp && \
-  cd /tmp/libvorbis-$LIBVORBIS_VERSION && \
+RUN curl -fLsS "https://github.com/xiph/vorbis/releases/download/v${LIBVORBIS_VERSION}/libvorbis-${LIBVORBIS_VERSION}.tar.gz" --output /tmp/libvorbis-${LIBVORBIS_VERSION}.tar.gz && \
+  tar --file=/tmp/libvorbis-${LIBVORBIS_VERSION}.tar.gz -xvzC /tmp && \
+  cd /tmp/libvorbis-${LIBVORBIS_VERSION} && \
   ./configure --disable-examples --disable-oggtest --prefix=/opt && \
   make && \
   make install && \
-  rm -r /tmp/libvorbis-$LIBVORBIS_VERSION
+  rm -r /tmp/libvorbis-${LIBVORBIS_VERSION} && \
+  rm /tmp/libvorbis-${LIBVORBIS_VERSION}.tar.gz 
 
-# Build newer libtheora - note that encoding support is disabled
+# Build newer libtheora - note that encoding support is disabled AND it's directory uses GH repo name instead
 ARG LIBTHEORA_VERSION=1.1.1
-RUN curl -fLsS "https://downloads.xiph.org/releases/theora/libtheora-$LIBTHEORA_VERSION.tar.bz2" | tar -f - -xvjC /tmp && \
-  cd /tmp/libtheora-$LIBTHEORA_VERSION && \
-  ./configure --disable-encode --disable-examples --disable-oggtest --prefix=/opt && \
+RUN curl -fLsS "https://github.com/xiph/theora/archive/refs/tags/v${LIBTHEORA_VERSION}.tar.gz" --output /tmp/libtheora-${LIBTHEORA_VERSION}.tar.gz && \
+  tar --file=/tmp/libtheora-${LIBTHEORA_VERSION}.tar.gz -xvzC /tmp && \
+  cd /tmp/theora-${LIBTHEORA_VERSION} && \
+  ./autogen.sh --disable-encode --disable-examples --disable-oggtest --prefix=/opt && \
   make && \
   make install && \
-  rm -r /tmp/libtheora-$LIBTHEORA_VERSION
+  rm -r /tmp/theora-${LIBTHEORA_VERSION} && \
+  rm /tmp/libtheora-${LIBTHEORA_VERSION}.tar.gz 
 
 # Build and install CMake
 ARG CMAKE_VERSION=3.14.5

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -1,14 +1,8 @@
 # base will already have Chocolatey installed
-FROM cirrusci/windowsservercore:2019
+FROM ericoporto/min-ags-dev-env:1.0.0
 
 # if no temp folder exists by default, create it
 RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
-
-ARG VISUALCPP_BUILD_TOOLS_VERSION=14.0.25420.1
-RUN cinst visualcpp-build-tools --version %VISUALCPP_BUILD_TOOLS_VERSION% -y && \
-  mkdir empty && \
-  robocopy empty %TEMP% /MIR > nul & \
-  rd /s /q empty
 
 # Windows 8.0 SDK (but only install the .NET 4.5 SDK)
 RUN pushd %TEMP% && \
@@ -21,10 +15,8 @@ RUN pushd %TEMP% && \
 
 ARG NUGET_VERSION=5.7.0
 ARG INNO_SETUP_VERSION=6.0.5
-ARG CMAKE_VERSION=3.18.4
 RUN cinst nuget.commandline --version %NUGET_VERSION% -y && \
   cinst innosetup --version %INNO_SETUP_VERSION% -y && \
-  cinst cmake --version %CMAKE_VERSION% --installargs ADD_CMAKE_TO_PATH=System -y && \
   mkdir empty && \
   robocopy empty %TEMP% /MIR > nul & \
   rd /s /q empty
@@ -50,7 +42,7 @@ RUN curl -fLSs http://www.ambiera.at/downloads/irrKlang-32bit-%IRRKLANG_VERSION%
   move %TEMP%\irrKlang-%IRRKLANG_VERSION%\bin\dotnet-4\*.dll Lib\irrKlang\ && \
   rd /s /q %TEMP%\irrKlang-%IRRKLANG_VERSION%
 
-RUN curl -fLSs https://download.microsoft.com/download/3/3/f/33f1af6e-c61b-4f14-a0de-3e9096ed4b3a/dxsdk_aug2007.exe | tar -f - -xvzC %TEMP% && \
+RUN curl -fLSs https://archive.org/download/dxsdk_aug2007/dxsdk_aug2007.exe | tar -f - -xvzC %TEMP% && \
   tar -f %TEMP%\dxsdk_aug2007.exe -xvzC %TEMP% Lib/x86/*.lib && \
   mkdir Lib\DirectX && \
   move %TEMP%\Lib\x86\*.lib Lib\DirectX\ && \


### PR DESCRIPTION
Windows related changes:
- Editor: Native use default Zp alignment (it fails to build the editor in release otherwise)
- CirrusCI: add path to Win SDK or it fails to find `rc.exe` (required to build the Editor)
- Windows Docker: DirectXSDk from MS is not available, use directx sdk from archive.org
- Windows Docker: VS2015 from MS is not availabe, use base image with preinstalled VS2015
If these changes are a problem, we can use the backup Windows Docker image from [here](https://hub.docker.com/repository/docker/ericoporto/ags35x_allegro4) instead.

Additional changes:
- Linux Docker: use XIPH from GitHub for older tls support (Debian Jessie has no newer tls)
- Linux Docker: autoconf necessary for theora build from GitHub sources
- Android Docker: apache ant old version is not available, upgrade it
- Android Docker: use release-3.5.1 branch instead of master

please wait CI finish building to verify these changes are correct.