### PR TITLE
Engine: Fix potentially invalid frame during Character turning

### DIFF
--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -149,6 +149,7 @@ int CharacterInfo::update_character_walking(CharacterExtras *chex)
           else break;
         }
         loop = turnlooporder[wantloop];
+        if (frame >= views[view].loops[loop].numFrames) frame = 0; // AVD: make sure the loop always has a valid frame
         walking -= TURNING_AROUND;
         // if still turning, wait for next frame
         if (walking % TURNING_BACKWARDS >= TURNING_AROUND)


### PR DESCRIPTION
`update_character_walking()` was applying a new loop without making sure the current frame was still valid, this could trigger an error with scripting because the combination of view-loop-frame could be invalid at that moment.

Closes #802

With this fix I check if the current frame is available, if not it's reset to 0. This way the safe value is correctly available to the scripting system.
An alternative would be resetting if the number of frames is different from old loop to new loop.