### PR TITLE
Android: expand file-related implementations based on AAssetManager

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -117,6 +117,8 @@ target_sources(common
     script/script_common.h
     util/aasset_stream.cpp
     util/aasset_stream.h
+    util/android_file.cpp
+    util/android_file.h
     util/alignedstream.cpp
     util/alignedstream.h
     util/bbop.h

--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -11,40 +11,21 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "core/platform.h"
-
 #if AGS_PLATFORM_OS_ANDROID
-
-#include <algorithm>
 #include "util/aasset_stream.h"
+#include <algorithm>
+#include <stdexcept>
 #include <jni.h>
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
-#include <stdexcept>
+#include "util/android_file.h"
 #include "util/string.h"
-#include "SDL2/SDL.h"
 
 namespace AGS
 {
     namespace Common
     {
-
-        AAssetManager* GetAssetManagerFromEnv()
-        {
-            JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
-
-            jobject activity =  (jobject)SDL_AndroidGetActivity();
-
-            jclass activity_class = env->GetObjectClass(activity);
-
-            jmethodID activity_class_getAssets = env->GetMethodID(activity_class, "getAssets", "()Landroid/content/res/AssetManager;");
-            jobject asset_manager = env->CallObjectMethod(activity, activity_class_getAssets); // activity.getAssets();
-            jobject global_asset_manager = env->NewGlobalRef(asset_manager);
-
-            return AAssetManager_fromJava(env, global_asset_manager);
-        }
-
         AAssetStream::AAssetStream(const String &asset_name, int asset_mode, DataEndianess stream_endianess)
                 : DataStream(stream_endianess)
                 , _aAsset(nullptr)
@@ -190,7 +171,7 @@ namespace AGS
 
         void AAssetStream::Open(const String &asset_name, int asset_mode)
         {
-            AAssetManager* aAssetManager = GetAssetManagerFromEnv();
+            AAssetManager* aAssetManager = GetAAssetManager();
             _ownHandle = true;
 
             if(!asset_name.IsNullOrSpace() && asset_name[0] == '/') {

--- a/Common/util/aasset_stream.h
+++ b/Common/util/aasset_stream.h
@@ -95,8 +95,6 @@ namespace AGS
             AAsset                *_aAsset = nullptr;
         };
 
-        AAssetManager* GetAssetManagerFromEnv();
-
     } // namespace Common
 } // namespace AGS
 

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -69,6 +69,27 @@ AAssetManager* GetAAssetManager()
     return gAAssetManager;
 }
 
+bool GetAAssetExists(const String &filename)
+{
+    AAssetManager* mgr = GetAAssetManager();
+    // TODO: find out if it's acceptable to open/close asset to only test its existance;
+    // the alternative is to use AAssetManager_openDir and read asset list using AAssetDir_getNextFileName
+    AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
+    if (!asset) return false;
+    AAsset_close(asset);
+    return true;
+}
+
+soff_t GetAAssetSize(const String &filename)
+{
+    AAssetManager* mgr = GetAAssetManager();
+    AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
+    if (!asset) return -1;
+    soff_t len = AAsset_getLength64(asset);
+    AAsset_close(asset);
+    return len;
+}
+
 } // namespace Common
 } // namespace AGS
 #endif // AGS_PLATFORM_OS_ANDROID

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -1,0 +1,74 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "util/android_file.h"
+#if AGS_PLATFORM_OS_ANDROID
+#include <jni.h>
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+#include <SDL.h>
+
+namespace AGS
+{
+namespace Common
+{
+
+static jobject gAAssetManagerRef { nullptr };
+static AAssetManager *gAAssetManager { nullptr };
+
+void InitAndroidFile()
+{
+    assert(gAAssetManager == nullptr);
+    if (gAAssetManager)
+        return; // already initialized
+
+    JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
+
+    jobject activity = (jobject)SDL_AndroidGetActivity();
+
+    jclass activity_class = env->GetObjectClass(activity);
+
+    jmethodID activity_class_getAssets = env->GetMethodID(activity_class, "getAssets", "()Landroid/content/res/AssetManager;");
+    jobject asset_manager = env->CallObjectMethod(activity, activity_class_getAssets); // activity.getAssets();
+    gAAssetManagerRef = env->NewGlobalRef(asset_manager);
+    if (!gAAssetManagerRef)
+        return; // error
+    gAAssetManager = AAssetManager_fromJava(env, gAAssetManagerRef);
+    if (!gAAssetManager)
+    {
+        env->DeleteGlobalRef(gAAssetManagerRef);
+        gAAssetManagerRef = nullptr;
+    }
+}
+
+void ShutdownAndroidFile()
+{
+    if (gAAssetManager)
+    {
+        JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
+        env->DeleteGlobalRef(gAAssetManagerRef);
+        gAAssetManagerRef = nullptr;
+        gAAssetManager = nullptr;
+    }
+}
+
+AAssetManager* GetAAssetManager()
+{
+    if (!gAAssetManager) { InitAndroidFile(); }
+    assert(gAAssetManager);
+    return gAAssetManager;
+}
+
+} // namespace Common
+} // namespace AGS
+#endif // AGS_PLATFORM_OS_ANDROID

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -90,6 +90,44 @@ soff_t GetAAssetSize(const String &filename)
     return len;
 }
 
+
+AndroidADir::AndroidADir(AndroidADir &&aadir)
+{
+    _dir = aadir._dir;
+    aadir._dir = nullptr;
+}
+
+AndroidADir::AndroidADir(const String &dirname)
+{
+    AAssetManager* mgr = GetAAssetManager();
+    _dir = AAssetManager_openDir(mgr, dirname.GetCStr());
+}
+
+AndroidADir::~AndroidADir()
+{
+    if (_dir)
+        AAssetDir_close(_dir);
+}
+
+String AndroidADir::Next()
+{
+    if (_dir)
+        return AAssetDir_getNextFileName(_dir);
+}
+
+String AndroidADir::Next(const std::regex &pattern)
+{
+    if (!_dir) return "";
+    const char *filename = nullptr;
+    std::cmatch mr;
+    while ((filename = AAssetDir_getNextFileName(_dir)) != nullptr)
+    {
+        if (std::regex_match(filename, mr, pattern))
+            return filename;
+    }
+    return "";
+}
+
 } // namespace Common
 } // namespace AGS
 #endif // AGS_PLATFORM_OS_ANDROID

--- a/Common/util/android_file.h
+++ b/Common/util/android_file.h
@@ -1,0 +1,41 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+//  Android-specific implementation of some of the File routines;
+//  mainly purposed to work with the NDK AAssetManager object.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__ANDROID_FILE_H
+#define __AGS_CN_UTIL__ANDROID_FILE_H
+
+#include "core/platform.h"
+#if AGS_PLATFORM_OS_ANDROID
+
+struct AAssetManager;
+
+namespace AGS
+{
+namespace Common
+{
+
+void           InitAndroidFile();
+void           ShutdownAndroidFile();
+AAssetManager *GetAAssetManager();
+
+} // namespace Common
+} // namespace AGS
+
+#endif // AGS_PLATFORM_OS_ANDROID
+
+#endif // __AGS_CN_UTIL__ANDROID_FILE_H

--- a/Common/util/android_file.h
+++ b/Common/util/android_file.h
@@ -21,10 +21,13 @@
 
 #include "core/platform.h"
 #if AGS_PLATFORM_OS_ANDROID
+#include <regex>
 #include "core/types.h"
 #include "util/string.h"
 
 struct AAssetManager;
+struct AAssetDir;
+struct AAsset;
 
 namespace AGS
 {
@@ -38,6 +41,25 @@ AAssetManager *GetAAssetManager();
 bool           GetAAssetExists(const String &filename);
 // Gets the Android Asset's size, returns -1 if such asset was not found
 soff_t         GetAAssetSize(const String &filename);
+
+// AndroidDir wraps Android Asset directory and ensures its disposal
+class AndroidADir
+{
+public:
+    AndroidADir(AndroidADir &&aadir);
+    AndroidADir(const String &dirname);
+    ~AndroidADir();
+
+    // Iterate to the next asset, returns asset's name or empty string
+    // if not more assets are found in this directory
+    String Next();
+    // Iterates through assets until matching the name pattern;
+    // returns asset's name or empty string if no matching asset found
+    String Next(const std::regex &pattern);
+
+private:
+    AAssetDir *_dir {nullptr};
+};
 
 } // namespace Common
 } // namespace AGS

--- a/Common/util/android_file.h
+++ b/Common/util/android_file.h
@@ -21,6 +21,8 @@
 
 #include "core/platform.h"
 #if AGS_PLATFORM_OS_ANDROID
+#include "core/types.h"
+#include "util/string.h"
 
 struct AAssetManager;
 
@@ -32,6 +34,10 @@ namespace Common
 void           InitAndroidFile();
 void           ShutdownAndroidFile();
 AAssetManager *GetAAssetManager();
+// Tells if the Android Asset of the given name exists
+bool           GetAAssetExists(const String &filename);
+// Gets the Android Asset's size, returns -1 if such asset was not found
+soff_t         GetAAssetSize(const String &filename);
 
 } // namespace Common
 } // namespace AGS

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -15,26 +15,24 @@
 #include "core/platform.h"
 
 #if AGS_PLATFORM_OS_ANDROID
-
+#include <ctype.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <sys/stat.h> 
+#include <unistd.h>
+#include <SDL.h>
 #include <allegro.h>
+#include <jni.h>
+#include <android/log.h>
+#include <android/asset_manager_jni.h>
 #include "platform/base/agsplatformdriver.h"
 #include "ac/runtime_defines.h"
 #include "game/main_game_file.h"
 #include "main/config.h"
 #include "plugin/agsplugin.h"
-#include <stdio.h>
-#include <dirent.h>
-#include <sys/stat.h> 
-#include <ctype.h>
-#include <unistd.h>
-#include "util/string_compat.h"
-#include "SDL.h"
+#include "util/android_file.h"
 #include "util/path.h"
-
-#include <jni.h>
-#include <android/log.h>
-#include <android/asset_manager_jni.h>
-#include "util/aasset_stream.h"
+#include "util/string_compat.h"
 
 using namespace AGS::Common;
 
@@ -707,7 +705,7 @@ bool IsValidAgsGame(const String& filename)
 
 const char * AGSAndroid::GetGameDataFile()
 {
-  AAssetManager* assetManager = GetAssetManagerFromEnv();
+  AAssetManager* assetManager = GetAAssetManager();
   AAssetDir* aAssetDir = AAssetManager_openDir(assetManager,"");
 
   psp_game_file_name[0] = '\0';
@@ -771,6 +769,7 @@ int AGSAndroid::InitializeCDPlayer() {
 }
 
 void AGSAndroid::PostBackendExit() {
+  ShutdownAndroidFile();
   //java_environment->DeleteGlobalRef(java_class);
 }
 


### PR DESCRIPTION
This adds more Android-specific implementations of the file system functions based on Android's AAssetManager; which is a kind of virtual filesystem from the engine's perspective.
This PR covers testing that file (aasset) exists, and searching for files (aassets) inside the pseudo-directory of an android package.
Android port will first search in the real filesystem as usual, then - using AAssetManager.
This hopefully fixes the problem of engine ignoring game data packed as individual AAssets in APK (translation files, etc).

* Better handling of our engine's AAssetManager reference: query it once, keep same ref, then dispose upon engine shutdown.
* AAsset variants of File::IsFile() and File::GetFileSize() functions.
* FindFile class's implementation that also searches through AAssets.