### PR TITLE
Editor: Fixes for #1138

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1645,6 +1645,7 @@ namespace AGS.Editor.Components
             }
 
             Bitmap newBmp = new Bitmap(bmp);
+            bool hasResolutionChanged = _loadedRoom.Width != newBmp.Width || _loadedRoom.Height != newBmp.Height;
             _loadedRoom.Width = newBmp.Width;
             _loadedRoom.Height = newBmp.Height;
             _loadedRoom.ColorDepth = newBmp.GetColorDepth();
@@ -1674,9 +1675,9 @@ namespace AGS.Editor.Components
             }
 
             // If size or resolution has changed, reset masks
-            if (newBmp.Width != _loadedRoom.Width || newBmp.Height != _loadedRoom.Height)
+            if (hasResolutionChanged)
             {
-                ClearMaskCache();
+                ResetMaskCache();
             }
 
             _loadedRoom.Modified = true;
@@ -2043,6 +2044,21 @@ namespace AGS.Editor.Components
                 {
                     _maskCache[mask]?.Dispose();
                     _maskCache[mask] = null;
+                }
+            }
+        }
+
+        private void ResetMaskCache()
+        {
+            foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))
+            {
+                if (mask == RoomAreaMaskType.None)
+                    continue;
+
+                if (_maskCache.ContainsKey(mask))
+                {
+                    _maskCache[mask]?.Dispose();
+                    _maskCache[mask] = new Bitmap(_loadedRoom.Width / _loadedRoom.MaskResolution, _loadedRoom.Height / _loadedRoom.MaskResolution, PixelFormat.Format8bppIndexed);
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -568,6 +568,7 @@ namespace AGS.Editor
                             {
                                 _roomController.DeleteBackground(1);
                             }
+                            RepopulateBackgroundList(0);
                         }
 
                         // TODO: choose default zoom based on the room size vs window size?


### PR DESCRIPTION
Fixes a logic error on background import not resetting masks, and updates the dropdown menu of the available backgrounds when they are removed after a resolution change.

Closes #1431, #1426