### PR TITLE
New compiler, fix Bug: Mustn't complain about unreachable code at end of switch case

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -7195,7 +7195,9 @@ AGS::ErrorType AGS::Parser::ParseCommand(Symbol leading_sym, Symbol &struct_of_c
 {
     ErrorType retval;
 
-    if (kKW_CloseBrace != leading_sym)
+    if (kKW_CloseBrace != leading_sym &&
+        kKW_Case != leading_sym &&
+        kKW_Default != leading_sym)
     {
         if (!_nest.DeadEndWarned() && _nest.JumpOutLevel() < _nest.TopLevel())
         {

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -1404,6 +1404,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
     int compileResult = cc_compile(inpl, options, scrip, mh);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
     // Line 6: Can't reach this point.
+    ASSERT_LE(2u, mh.GetMessages().size());
     EXPECT_EQ(6u, mh.GetMessages().at(0).Lineno);
     EXPECT_NE(std::string::npos, mh.GetMessages().at(0).Message.find("reach this"));
     // Line 10: Cases 3 & 4 fall through to case 5; "break;" might be missing

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2012,3 +2012,29 @@ TEST_F(Compile1, AttributeAssignTypeCheck)
     EXPECT_NE(std::string::npos, msg.find("'int'"));
     EXPECT_NE(std::string::npos, msg.find("'float'"));
 }
+
+TEST_F(Compile1, ReachabilityAndSwitch1)
+{
+    // Mustn't complain about unreachable code at the end of a switch case
+
+    char *inpl = "\n\
+        int main()          \n\
+        {                   \n\
+            int i;          \n\
+            switch (i)      \n\
+            {               \n\
+            case 7:         \n\
+                return -5;  \n\
+            case 77:        \n\
+                return -55; \n\
+            default:        \n\
+                return 555; \n\
+            }               \n\
+        }                   \n\
+        ";
+    AGS::MessageHandler mh;
+    int const compile_result = cc_compile(inpl, 0, scrip, mh);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    ASSERT_EQ(0, mh.GetMessages().size());
+}


### PR DESCRIPTION
Typical code:

```
function game_start()
{
    int i = 0;
    switch (i)
    {
    case 7:
        return -5;
    default:
        return 555;
    } 
}
```

Compiler would warn about the first `return` although there's nothing bad about it since a `default:` label follows. There were similarly bad warnings when a `case` label follows.

This PR suppresses those warnings.