### PR TITLE
New compiler: Minor code cleanup

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -376,9 +376,6 @@ private:
     // Augment the message with a "See ..." indication pointing to the declaration of sym
     std::string const ReferenceMsgSym(std::string const &msg, Symbol symb);
 
-    // Adds the symbol to the list if it isn't there yet.
-    void AddToSymbolList(Symbol symb, SymbolList &list);
-
     std::string const TypeQualifierSet2String(TypeQualifierSet tqs) const;
 
     void SetDynpointerInManagedVartype(Vartype &vartype);
@@ -749,9 +746,6 @@ private:
 
     // We compile something like "var += expression"
     ErrorType ParseAssignment_MAssign(Symbol ass_symbol, SrcList &lhs);
-
-    // "var++" or "var--"
-    ErrorType ParseAssignment_SAssign(Symbol ass_symbol, SrcList &lhs);
 
     ErrorType ParseConstantDefn(TypeQualifierSet tqs, Vartype vartype, Symbol vname);
 


### PR DESCRIPTION
Fix typos in comments and string literals
Take out two functions that aren't actually called any longer.
Add forgotten `return` statements
Delete a comment in front of a function that should be in front of the declaration (and already is there)

No functional changes.