### PR TITLE
Upgrade to .NET 4.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -195,7 +195,7 @@ build_editor_task:
     set "UseEnv=true" &&
     copy C:\Lib\irrKlang\*.dll Editor\References\ &&
     cd Solutions &&
-    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\8.0\Lib\Win8\um\x86;!LIB!" &&
+    cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
     set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&
     msbuild AGS.Editor.Full.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform="Mixed Platforms" /maxcpucount /nologo"
   ags_editor_pdb_artifacts:

--- a/Editor/AGS.CScript.Compiler/AGS.CScript.Compiler.csproj
+++ b/Editor/AGS.CScript.Compiler/AGS.CScript.Compiler.csproj
@@ -23,7 +23,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Editor/AGS.Controls/AGS.Controls.csproj
+++ b/Editor/AGS.Controls/AGS.Controls.csproj
@@ -35,7 +35,7 @@
     <SccProvider>
     </SccProvider>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -78,7 +78,8 @@
       <HintPath>..\..\Solutions\packages\Magick.NET-Q8-x86.7.10.0\lib\net40\Magick.NET-Q8-x86.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\Solutions\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\Solutions\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -25,7 +25,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Editor/AGS.Editor/packages.config
+++ b/Editor/AGS.Editor/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DockPanelSuite" version="2.6.0.1" targetFramework="net45" />
-  <package id="Magick.NET-Q8-x86" version="7.10.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net40" />
+  <package id="DockPanelSuite" version="2.6.0.1" targetFramework="net46" />
+  <package id="Magick.NET-Q8-x86" version="7.10.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
 </packages>

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{65A387AF-C78C-492B-AB93-E13C6090355D}</ProjectGuid>
     <RootNamespace>AGS.Native</RootNamespace>
     <Keyword>AtlProj</Keyword>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -24,7 +24,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -191,10 +191,11 @@ const
   VCPP_REDIST_MAJOR_VERSION = 14.0;
   VCPP_REDIST_BUILD_VERSION = 24215;
 
-  // .NET Framework 4.5 or newer
-  // in theory this is only needed for OS versions older than Windows 8
-  DOT_NET_45_RELEASE_VERSION = 378389;
-  NEED_DOT_NET_ERROR_MESSAGE = 'AGS needs the Microsoft .NET Framework 4.5 or later to be installed on this computer. Press OK to visit the Microsoft website and download this, then run Setup again.';
+  // .NET Framework 4.6 or newer
+  // in theory this is only needed for OS versions older than Windows 10
+  // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#minimum-version
+  DOT_NET_46_RELEASE_VERSION = 393295;
+  NEED_DOT_NET_ERROR_MESSAGE = 'AGS needs the Microsoft .NET Framework 4.6 or later to be installed on this computer. Press OK to visit the Microsoft website and download this, then run Setup again.';
   DOT_NET_INSTALL_URL = 'https://dotnet.microsoft.com/download/dotnet-framework';
 
 function VCRedistInstalled: Boolean;
@@ -208,7 +209,7 @@ begin
     bld)) AND (bld >= VCPP_REDIST_BUILD_VERSION);
 end;
 
-function DotNet45Installed: Boolean;
+function DotNet46Installed: Boolean;
 var
   version: Cardinal;
 begin
@@ -216,7 +217,7 @@ begin
     HKLM,
     'Software\Microsoft\NET Framework Setup\NDP\v4\Full',
     'Release',
-    version)) AND (version >= DOT_NET_45_RELEASE_VERSION);
+    version)) AND (version >= DOT_NET_46_RELEASE_VERSION);
 end;
 
 function IsWindowsVersionOrNewer(Major, Minor: Integer): Boolean;
@@ -242,7 +243,7 @@ begin
   begin
     MsgBox(PLATFORM_CHECK_ERROR_MESSAGE, mbCriticalError, MB_OK);
   end;
-  if NOT DotNet45Installed then
+  if NOT DotNet46Installed then
   begin
     if NOT WizardSilent then
     begin

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -6,7 +6,7 @@
   * Microsoft Visual Studio 2015 or higher - currently the only supported IDE for making Engine and Editor. The free Community edition is sufficient and is available for download at the Microsoft's site:
     * https://visualstudio.microsoft.com/downloads/
     * https://visualstudio.microsoft.com/vs/older-downloads/
-  * If you are using MSVS 2019 and higher you might need to manually download [Windows 8.1 SDK](https://go.microsoft.com/fwlink/p/?LinkId=323507) from the [SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/).
+  * If you are using MSVS 2019 and higher you might need to manually download [Windows 10 SDK (10.0.10240)](https://go.microsoft.com/fwlink/p/?LinkId=619296) from the [SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/).
 * Specifically for the Engine:
   * SDL 2.0.12 or higher (https://www.libsdl.org/download-2.0.php)
   * SDL_Sound 2.0.* (revision 997e90562b35 or higher) https://hg.icculus.org/icculus/SDL_sound/archive/997e90562b35.tar.gz

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -4,9 +4,9 @@ FROM ericoporto/min-ags-dev-env:1.0.0
 # if no temp folder exists by default, create it
 RUN IF exist %TEMP%\nul ( echo %TEMP% ) ELSE ( mkdir %TEMP% )
 
-# Windows 8.0 SDK (but only install the .NET 4.5 SDK)
+# Windows 10.0.10240 SDK (but only install the .NET 4.6 SDK)
 RUN pushd %TEMP% && \
-  curl -fLO http://download.microsoft.com/download/F/1/3/F1300C9C-A120-4341-90DF-8A52509B23AC/standalonesdk/sdksetup.exe && \
+  curl -fLO https://download.microsoft.com/download/E/1/F/E1F1E61E-F3C6-4420-A916-FB7C47FBC89E/standalonesdk/sdksetup.exe && \
   start /wait sdksetup /ceip off /features OptionID.NetFxSoftwareDevelopmentKit /quiet /norestart && \
   popd && \
   mkdir empty && \


### PR DESCRIPTION
Ref #1446 

We need this for compatibility with Visual Studio 2022 since anything before .NET 4.5.1 is no longer supported

Also need to upgrade the editor test code on the ags4 branch, but I can do that in a separate PR