### PR TITLE
AGS4 / New compiler: Attributes with extender syntax

### DIFF
--- a/Compiler/script2/cc_compiledscript.h
+++ b/Compiler/script2/cc_compiledscript.h
@@ -137,6 +137,7 @@ public:
     void Restore();
 
     inline bool IsEmpty() const { return _scrip.codesize <= static_cast<int>(_rememberedCodeLocation); }
+    inline CodeLoc CodeLocation() const { return _rememberedCodeLocation; }
 };
 
 // A storage for parameters of forward jumps. When at some later time,

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -3582,6 +3582,16 @@ AGS::ErrorType AGS::Parser::AccessData_CallAttributeFunc(bool is_setter, SrcList
         return kERR_UserError;
     }
 
+    if (is_setter && _sym[name_of_attribute].VariableD->TypeQualifiers[TQ::kReadonly])
+    {
+        Error(
+            ReferenceMsgSym(
+                "Can't assign a value to readonly attribute '%s'",
+                name_of_attribute).c_str(),
+            _sym[name_of_attribute].Name.c_str());
+        return kERR_UserError;
+    }
+
     // Get the appropriate access function (as a symbol)
     Symbol unqualified_func_name = kKW_NoSymbol;
     ErrorType retval = ConstructAttributeFuncName(unqualified_component, is_setter, attrib_is_indexed, unqualified_func_name);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -129,8 +129,6 @@ private:
     // - or AX, i.e., the value to modify is in m(AX) (kVL_AX_is_value)
     // - attributes must be modified by calling their setter function (kVL_Attribute)
     //      In this case the qualified attribute is in 'symbol'
-
-
     struct ValueLocation
     {
         enum
@@ -344,9 +342,7 @@ private:
         // Track that the previous content of register 'reg' is invalid (has been clobbered)
         // Only consider SREG_AX .. SREG_DX and SREG_MAR
         inline void SetRegister(size_t reg, size_t codesize = INT_MAX)
-        {
-            _register[reg] = std::min<size_t>(codesize, _scrip.codesize);
-        }
+            { _register[reg] = std::min<size_t>(codesize, _scrip.codesize); }
 
         // Track that the previous content of all registers is invalid (e.g., after a call)
         // Only consider SREG_AX .. SREG_DX and SREG_MAR

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -812,7 +812,7 @@ private:
     // Checks whether an old definition exists that may be stashed; stashes it if possible
     ErrorType ParseVardecl_CheckAndStashOldDefn(Symbol var_name);
 
-    ErrorType ParseVardecl(Symbol var_name, Vartype vartype, ScopeType scope_type, TypeQualifierSet tqs);
+    ErrorType ParseVardecl(TypeQualifierSet tqs, Vartype vartype, Symbol var_name, ScopeType scope_type);
 
     ErrorType ParseFuncBodyStart(Symbol struct_of_func, Symbol name_of_func);
 
@@ -844,9 +844,9 @@ private:
     ErrorType ParseStruct_Attribute_DeclareFunc(TypeQualifierSet tqs, Symbol strct, Symbol qualified_name, Symbol unqualified_name, bool is_setter, bool is_indexed, Vartype vartype);
 
     // We're in a struct declaration. Parse an attribute declaration.
-    ErrorType ParseStruct_Attribute(TypeQualifierSet tqs, Symbol stname, Symbol vname, Vartype vartype);
+    ErrorType ParseStruct_Attribute(TypeQualifierSet tqs, Symbol stname, Vartype vartype, Symbol vname, bool is_indexed, size_t declaration_start);
 
-    // We're inside a struct decl, processing a member variable
+    // We're inside a struct decl, processing a member variable or attribute
     ErrorType ParseStruct_VariableOrAttributeDefn(TypeQualifierSet tqs, Vartype curtype, Symbol stname, Symbol vname);
 
     // We're inside a struct decl, processing a compile-time constant
@@ -896,7 +896,9 @@ private:
 
     ErrorType ParseVartype_VarDecl_PreAnalyze(Symbol var_name, ScopeType scope_type);
 
-    ErrorType ParseVartype_VarDecl(Symbol var_name, ScopeType scope_type, TypeQualifierSet tqs, Vartype vartype);
+    ErrorType ParseVartype_Attribute(TypeQualifierSet tqs, Vartype vartype, Symbol attribute, ScopeType scope_type);
+
+    ErrorType ParseVartype_VariableOrAttributeDefn(TypeQualifierSet tqs, Vartype vartype, Symbol var_name, ScopeType scope_type);
 
     // We accepted a variable type such as "int", so what follows is a variable, compile-time constant, or function declaration
     ErrorType ParseVartype(Vartype vartype, TypeQualifierSet tqs, Symbol &name_of_current_func, Symbol &struct_of_current_func);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -447,21 +447,19 @@ private:
 
     // We're at the end of a block and releasing a standard array of dynpointers.
     // MAR points to the array start. Release each array element (dynpointer).
-    ErrorType FreeDynpointersOfStdArrayOfDynpointer(size_t num_of_elements, bool &clobbers_ax);
+    ErrorType FreeDynpointersOfStdArrayOfDynpointer(size_t num_of_elements);
 
     // We're at the end of a block and releasing all the dynpointers in a struct.
     // MAR already points to the start of the struct.
-    void FreeDynpointersOfStruct(Vartype struct_vtype, bool &clobbers_ax);
+    void FreeDynpointersOfStruct(Vartype struct_vtype);
 
     // We're at the end of a block and we're releasing a standard array of struct.
     // MAR points to the start of the array. Release all the pointers in the array.
-    void FreeDynpointersOfStdArrayOfStruct(Vartype element_vtype, size_t num_of_elements, bool &clobbers_ax);
+    void FreeDynpointersOfStdArrayOfStruct(Vartype element_vtype, size_t num_of_elements);
 
     // We're at the end of a block and releasing a standard array. MAR points to the start.
     // Release the pointers that the array contains.
-    void FreeDynpointersOfStdArray(Symbol the_array, bool &clobbers_ax);
-
-    ErrorType FreeDynpointersOfLocals0(size_t from_level, bool &clobbers_ax, bool &clobbers_mar);
+    void FreeDynpointersOfStdArray(Symbol the_array);
 
     // Free the pointers of any locals in level from_level or higher
     ErrorType FreeDynpointersOfLocals(size_t from_level);

--- a/Compiler/script2/cs_parser_common.h
+++ b/Compiler/script2/cs_parser_common.h
@@ -11,6 +11,7 @@ namespace AGS
 {
 typedef int Symbol; // A symbol (result of scanner preprocessing)
 typedef std::vector<Symbol> SymbolList;
+typedef std::vector<size_t> RegisterList;
 typedef long FlagSet; // Collection of bits that are set and reset
 typedef int Vartype; // e.g., "int"
 typedef int32_t CodeCell; // A Bytecode cell (content) or an opcode

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -1412,14 +1412,14 @@ TEST_F(Bytecode0, FlowSwitch01) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(1).Message.find("break"));
 
     // WriteOutput("FlowSwitch01", scrip);
-    size_t const codesize = 158;
+    size_t const codesize = 142;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,   51,    8,            7,    3,   29,    3,    // 7
       51,   12,    7,    3,           30,    4,    9,    4,    // 15
        3,    3,    4,    3,            3,    3,    4,   31,    // 23
-      79,    6,    3,   10,            5,   31,  123,    6,    // 31
+      79,    6,    3,   10,            5,   31,  107,    6,    // 31
        3,    2,   29,    3,           51,   12,    7,    3,    // 39
       30,    4,    9,    3,            4,    8,    3,   51,    // 47
        8,    7,    3,    5,            6,    3,    0,   51,    // 55
@@ -1428,14 +1428,12 @@ TEST_F(Bytecode0, FlowSwitch01) {
        3,    3,    4,    3,           29,    3,    6,    3,    // 79
        4,   30,    4,   12,            4,    3,    3,    4,    // 87
        3,   29,    3,   51,           12,    7,    3,   30,    // 95
-       4,   11,    3,    4,            8,    3,   31,   50,    // 103
-      29,    4,    6,    3,            2,   30,    4,   15,    // 111
-       3,    4,   70,  -91,           29,    4,    6,    3,    // 119
-       3,   30,    4,   15,            3,    4,   70,  -76,    // 127
-      29,    4,    6,    3,            4,   30,    4,   15,    // 135
-       3,    4,   70,  -88,           29,    4,    6,    3,    // 143
-       5,   30,    4,   15,            3,    4,   70,  -93,    // 151
-      31, -123,    6,    3,            0,    5,  -999
+       4,   11,    3,    4,            8,    3,   31,   34,    // 103
+       6,    3,    2,   15,            3,    4,   70,  -87,    // 111
+       6,    3,    3,   15,            3,    4,   70,  -68,    // 119
+       6,    3,    4,   15,            3,    4,   70,  -76,    // 127
+       6,    3,    5,   15,            3,    4,   70,  -77,    // 135
+      31, -107,    6,    3,            0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1474,17 +1472,17 @@ TEST_F(Bytecode0, FlowSwitch02) {
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    WriteOutput("FlowSwitch02", scrip);
-    size_t const codesize = 45;
+    // WriteOutput("FlowSwitch02", scrip);
+    size_t const codesize = 41;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            5,   29,    3,   51,    // 7
        4,    7,    3,    3,            3,    4,   31,   11,    // 15
-      31,   23,    6,    3,            0,   51,    4,    8,    // 23
-       3,   31,   14,   29,            4,    6,    3,    5,    // 31
-      30,    4,   15,    3,            4,   70,  -21,   31,    // 39
-     -25,    2,    1,    4,            5,  -999
+      31,   19,    6,    3,            0,   51,    4,    8,    // 23
+       3,   31,   10,    6,            3,    5,   15,    3,    // 31
+       4,   70,  -17,   31,          -21,    2,    1,    4,    // 39
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1523,16 +1521,15 @@ TEST_F(Bytecode0, FlowSwitch03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch03", scrip);
-
-    size_t const codesize = 37;
+    size_t const codesize = 33;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            0,   29,    3,   51,    // 7
        4,    7,    3,    3,            3,    4,   31,    2,    // 15
-      31,   12,   29,    4,            6,    3,    0,   30,    // 23
-       4,   15,    3,    4,           70,  -14,    2,    1,    // 31
-       4,    6,    3,    0,            5,  -999
+      31,    8,    6,    3,            0,   15,    3,    4,    // 23
+      70,  -10,    2,    1,            4,    6,    3,    0,    // 31
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1672,20 +1669,19 @@ TEST_F(Bytecode0, FlowSwitch06) {
     EXPECT_EQ(11u, mh.GetMessages().at(0u).Lineno);
 
     // WriteOutput("FlowSwitch06", scrip);
-    size_t const codesize = 77;
+    size_t const codesize = 65;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            7,   29,    3,   51,    // 7
        4,    7,    3,    3,            3,    4,   31,   16,    // 15
        6,    3,    6,   51,            4,    8,    3,    6,    // 23
-       3,    5,   51,    4,            8,    3,   31,   38,    // 31
-      29,    4,    6,    3,            7,   30,    4,   15,    // 39
-       3,    4,   70,  -21,           29,    4,    6,    3,    // 47
-      77,   30,    4,   15,            3,    4,   70,  -33,    // 55
-      29,    4,    6,    3,          777,   30,    4,   15,    // 63
-       3,    4,   70,  -38,           31,  -54,    2,    1,    // 71
-       4,    6,    3,    0,            5,  -999
+       3,    5,   51,    4,            8,    3,   31,   26,    // 31
+       6,    3,    7,   15,            3,    4,   70,  -17,    // 39
+       6,    3,   77,   15,            3,    4,   70,  -25,    // 47
+       6,    3,  777,   15,            3,    4,   70,  -26,    // 55
+      31,  -42,    2,    1,            4,    6,    3,    0,    // 63
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1705,7 +1701,31 @@ TEST_F(Bytecode0, FlowSwitch06) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
+TEST_F(Bytecode0, FlowSwitch07) {
 
+    // Expression in switch clause
+
+    char *inpl = "\
+        readonly int two = 2;   \n\
+        int main()              \n\
+        {                       \n\
+            switch (7)          \n\
+            {                   \n\
+            case two + 3:       \n\
+                return 7;       \n\
+            case main():        \n\
+                return 11;      \n\
+            case (two):         \n\
+                break;          \n\
+            }                   \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("FlowSwitch07", scrip);
+}
 
 TEST_F(Bytecode0, FreeLocalPtr) {   
 
@@ -1790,26 +1810,26 @@ TEST_F(Bytecode0, Struct01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct01", scrip);
-    size_t const codesize = 127;
+    size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,   51,    0,           49,    1,    1,    4,    // 7
        6,    3,    0,    3,            6,    2,   52,    8,    // 15
        3,    6,    3,    5,           72,    3,    4,    0,    // 23
-      51,    4,   47,    3,            6,    3,   77,   29,    // 31
-       3,   51,    8,   48,            2,   52,    1,    2,    // 39
-      12,   30,    3,    8,            3,   51,    4,   48,    // 47
-       3,   29,    3,   51,            4,   50,    3,   51,    // 55
-       8,   49,   51,    4,           48,    3,   69,   30,    // 63
-       4,    2,    1,    4,            5,   38,   69,    6,    // 71
-       3,    0,   29,    3,           51,    4,   29,    2,    // 79
-       6,    3,   -1,   29,            3,   51,    8,    7,    // 87
-       2,   45,    2,    6,            3,    0,   23,    3,    // 95
-       2,    1,    4,   30,            2,   51,    0,   47,    // 103
-       3,    1,    1,    4,           51,    4,   48,    2,    // 111
-      52,    1,    2,   12,            7,    3,   29,    3,    // 119
-      51,    8,   49,    2,            1,   12,    5,  -999
+      51,    4,   47,    3,            6,    3,   77,   51,    // 31
+       4,   48,    2,   52,            1,    2,   12,    8,    // 39
+       3,   51,    4,   48,            3,   29,    3,   51,    // 47
+       4,   50,    3,   51,            8,   49,   51,    4,    // 55
+      48,    3,   69,   30,            4,    2,    1,    4,    // 63
+       5,   38,   65,    6,            3,    0,   29,    3,    // 71
+      51,    4,   29,    2,            6,    3,   -1,   29,    // 79
+       3,   51,    8,    7,            2,   45,    2,    6,    // 87
+       3,    0,   23,    3,            2,    1,    4,   30,    // 95
+       2,   51,    0,   47,            3,    1,    1,    4,    // 103
+      51,    4,   48,    2,           52,    1,    2,   12,    // 111
+       7,    3,   29,    3,           51,    8,   49,    2,    // 119
+       1,   12,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1817,7 +1837,7 @@ TEST_F(Bytecode0, Struct01) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      93,  -999
+      89,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -1864,21 +1884,20 @@ TEST_F(Bytecode0, Struct02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct02", scrip);
-    size_t const codesize = 83;
+    size_t const codesize = 79;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            5,    6,    2,   68,    // 7
-       8,    3,    6,    3,            3,   29,    3,    6,    // 15
-       2,   80,   30,    3,            8,    3,    6,    3,    // 23
-      42,   29,    3,    6,            2,    0,   29,    2,    // 31
-       6,    2,   80,    7,            3,   30,    2,   46,    // 39
-       3,   17,   32,    3,            4,   11,    2,    3,    // 47
-      30,    3,    8,    3,            6,    3,   19,   29,    // 55
-       3,    6,    2,    0,           29,    2,    6,    2,    // 63
-      68,    7,    3,   30,            2,   46,    3,   17,    // 71
-      32,    3,    4,   11,            2,    3,   30,    3,    // 79
-       8,    3,    5,  -999
+       8,    3,    6,    3,            3,    6,    2,   80,    // 15
+       8,    3,    6,    3,           42,   29,    3,    6,    // 23
+       2,    0,   29,    2,            6,    2,   80,    7,    // 31
+       3,   30,    2,   46,            3,   17,   32,    3,    // 39
+       4,   11,    2,    3,           30,    3,    8,    3,    // 47
+       6,    3,   19,   29,            3,    6,    2,    0,    // 55
+      29,    2,    6,    2,           68,    7,    3,   30,    // 63
+       2,   46,    3,   17,           32,    3,    4,   11,    // 71
+       2,    3,   30,    3,            8,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1886,7 +1905,7 @@ TEST_F(Bytecode0, Struct02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   17,   29,   34,         59,   64,  -999
+       7,   15,   25,   30,         55,   60,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,   1,  '\0'
@@ -1931,21 +1950,20 @@ TEST_F(Bytecode0, Struct03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct03", scrip);
-    size_t const codesize = 83;
+    size_t const codesize = 79;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            5,    6,    2,   68,    // 7
-       8,    3,    6,    3,            3,   29,    3,    6,    // 15
-       2,   80,   30,    3,            8,    3,    6,    3,    // 23
-      42,   29,    3,    6,            2,    0,   29,    2,    // 31
-       6,    2,   80,    7,            3,   30,    2,   46,    // 39
-       3,   17,   32,    3,            4,   11,    2,    3,    // 47
-      30,    3,    8,    3,            6,    3,   19,   29,    // 55
-       3,    6,    2,    0,           29,    2,    6,    2,    // 63
-      68,    7,    3,   30,            2,   46,    3,   17,    // 71
-      32,    3,    4,   11,            2,    3,   30,    3,    // 79
-       8,    3,    5,  -999
+       8,    3,    6,    3,            3,    6,    2,   80,    // 15
+       8,    3,    6,    3,           42,   29,    3,    6,    // 23
+       2,    0,   29,    2,            6,    2,   80,    7,    // 31
+       3,   30,    2,   46,            3,   17,   32,    3,    // 39
+       4,   11,    2,    3,           30,    3,    8,    3,    // 47
+       6,    3,   19,   29,            3,    6,    2,    0,    // 55
+      29,    2,    6,    2,           68,    7,    3,   30,    // 63
+       2,   46,    3,   17,           32,    3,    4,   11,    // 71
+       2,    3,   30,    3,            8,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1953,7 +1971,7 @@ TEST_F(Bytecode0, Struct03) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   17,   29,   34,         59,   64,  -999
+       7,   15,   25,   30,         55,   60,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,   1,  '\0'
@@ -2001,7 +2019,7 @@ TEST_F(Bytecode0, Struct04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct04", scrip);
-    size_t const codesize = 100;
+    size_t const codesize = 92;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -2009,14 +2027,13 @@ TEST_F(Bytecode0, Struct04) {
       16,   73,    3,    4,           51,   16,   47,    3,    // 15
        6,    3, 12345,   51,           16,   48,    2,   52,    // 23
        8,    3,   51,    0,           63,   48,    1,    1,    // 31
-      48,   73,    3,    4,           29,    3,   51,   20,    // 39
-      30,    3,   47,    3,           51,   64,   49,    1,    // 47
-       2,    4,   49,    1,            2,    4,   49,    1,    // 55
-       2,    4,   49,   51,           48,    6,    3,    3,    // 63
-      29,    2,   29,    3,           49,    1,    2,    4,    // 71
-      49,    1,    2,    4,           49,    1,    2,    4,    // 79
-      49,   30,    3,   30,            2,    1,    2,   16,    // 87
-       2,    3,    1,   70,          -29,    2,    1,   64,    // 95
+      48,   73,    3,    4,           51,   16,   47,    3,    // 39
+      51,   64,   49,    1,            2,    4,   49,    1,    // 47
+       2,    4,   49,    1,            2,    4,   49,   51,    // 55
+      48,    6,    3,    3,           29,    2,   49,    1,    // 63
+       2,    4,   49,    1,            2,    4,   49,    1,    // 71
+       2,    4,   49,   30,            2,    1,    2,   16,    // 79
+       2,    3,    1,   70,          -25,    2,    1,   64,    // 87
        6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
@@ -2127,17 +2144,16 @@ TEST_F(Bytecode0, Struct06) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct06", scrip);
-    size_t const codesize = 48;
+    size_t const codesize = 44;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,            0,   29,    3,    6,    // 7
        3,    5,   72,    3,            4,    1,   51,    4,    // 15
-      47,    3,    6,    3,           77,   29,    3,   51,    // 23
-       8,   48,    2,   52,            1,    2,   12,   48,    // 31
-       2,   52,   30,    3,            8,    3,   51,    4,    // 39
-      49,    2,    1,    4,            6,    3,    0,    5,    // 47
-     -999
+      47,    3,    6,    3,           77,   51,    4,   48,    // 23
+       2,   52,    1,    2,           12,   48,    2,   52,    // 31
+       8,    3,   51,    4,           49,    2,    1,    4,    // 39
+       6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2182,19 +2198,17 @@ TEST_F(Bytecode0, Struct07) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct07", scrip);
-    size_t const codesize = 67;
+    size_t const codesize = 55;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       2,    8,   30,    3,            8,    3,    6,    3,    // 15
-      65,   29,    3,    6,            2,   12,   30,    3,    // 23
-      26,    3,    6,    2,           12,   24,    3,   29,    // 31
-       3,    6,    3,   65,           30,    4,   12,    4,    // 39
-       3,    3,    4,    3,           29,    3,    6,    2,    // 47
-      13,   30,    3,   26,            3,    6,    2,   12,    // 55
-      24,    3,    2,    3,            1,   26,    3,    6,    // 63
-       3,    0,    5,  -999
+      38,    0,    6,    3,            0,    6,    2,    8,    // 7
+       8,    3,    6,    3,           65,    6,    2,   12,    // 15
+      26,    3,    6,    2,           12,   24,    3,   29,    // 23
+       3,    6,    3,   65,           30,    4,   12,    4,    // 31
+       3,    3,    4,    3,            6,    2,   13,   26,    // 39
+       3,    6,    2,   12,           24,    3,    2,    3,    // 47
+       1,   26,    3,    6,            3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2202,7 +2216,7 @@ TEST_F(Bytecode0, Struct07) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,   21,   28,   48,         55,  -999
+       7,   15,   20,   38,         43,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,  '\0'
@@ -2540,16 +2554,16 @@ TEST_F(Bytecode0, Struct12) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct12", scrip);
-    size_t const codesize = 44;
+    size_t const codesize = 40;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,           10,   72,    3,    4,    // 7
        0,    6,    2,    4,           47,    3,    6,    3,    // 15
-       7,   29,    3,    6,            2,    4,   48,    2,    // 23
-      52,    1,    2,   12,           30,    3,    8,    3,    // 31
-       6,    2,    4,   48,            2,   52,    1,    2,    // 39
-      12,    7,    3,    5,          -999
+       7,    6,    2,    4,           48,    2,   52,    1,    // 23
+       2,   12,    8,    3,            6,    2,    4,   48,    // 31
+       2,   52,    1,    2,           12,    7,    3,    5,    // 39
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2557,7 +2571,7 @@ TEST_F(Bytecode0, Struct12) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      11,   21,   34,  -999
+      11,   19,   30,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,  '\0'
@@ -2595,31 +2609,31 @@ TEST_F(Bytecode0, StructArray01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StructArray01", scrip);
-    const size_t codesize = 39;
+    size_t const codesize = 35;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,   73,    3,           40,   51,    0,   47,    // 7
-       3,    1,    1,    4,            6,    3,    1,   29,    // 15
-       3,   51,    8,   48,            2,   52,    1,    2,    // 23
-      16,   30,    3,    8,            3,   51,    4,   49,    // 31
-       2,    1,    4,    6,            3,    0,    5,  -999
+       3,    1,    1,    4,            6,    3,    1,   51,    // 15
+       4,   48,    2,   52,            1,    2,   16,    8,    // 23
+       3,   51,    4,   49,            2,    1,    4,    6,    // 31
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -2646,34 +2660,33 @@ TEST_F(Bytecode0, StructArray02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StructArray02", scrip);
-    const size_t codesize = 63;
+    size_t const codesize = 55;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,   73,    3,          104,   51,    0,   47,    // 7
-       3,    1,    1,    4,            6,    3,    1,   29,    // 15
-       3,   51,    8,   48,            2,   52,    1,    2,    // 23
-      72,   30,    3,    8,            3,   51,    4,   48,    // 31
-       2,   52,    1,    2,           72,    7,    3,   29,    // 39
-       3,   51,    8,   48,            2,   52,    1,    2,    // 47
-     100,   30,    3,    8,            3,   51,    4,   49,    // 55
+       3,    1,    1,    4,            6,    3,    1,   51,    // 15
+       4,   48,    2,   52,            1,    2,   72,    8,    // 23
+       3,   51,    4,   48,            2,   52,    1,    2,    // 31
+      72,    7,    3,   51,            4,   48,    2,   52,    // 39
+       1,    2,  100,    8,            3,   51,    4,   49,    // 47
        2,    1,    4,    6,            3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -3502,7 +3515,7 @@ TEST_F(Bytecode0, Func14) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func14", scrip);
-    const size_t codesize = 139;
+    size_t const codesize = 135;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -3510,44 +3523,43 @@ TEST_F(Bytecode0, Func14) {
        0,    3,    6,    2,           52,   47,    3,    6,    // 15
        3,    1,   72,    3,            4,    0,    3,    6,    // 23
        2,   52,    1,    2,            4,   47,    3,    6,    // 31
-       3,  123,   29,    3,            3,    6,    2,   52,    // 39
-       1,    2,    4,   48,            2,   52,   30,    3,    // 47
-       8,    3,   29,    6,            3,    6,    2,   52,    // 55
-       1,    2,    4,   48,            2,   52,    7,    3,    // 63
-      29,    3,    3,    6,            2,   52,   48,    2,    // 71
-      52,    7,    3,   29,            3,    6,    3,   88,    // 79
-      23,    3,    2,    1,            8,   30,    6,    5,    // 87
-      38,   88,    5,   38,           91,   51,    0,   63,    // 95
-       8,    1,    1,    8,           51,    8,   29,    2,    // 103
-       6,    3,    7,   29,            3,   51,    8,    7,    // 111
-       2,   45,    2,    6,            3,    0,   23,    3,    // 119
-       2,    1,    4,   30,            2,   51,    8,   49,    // 127
-       1,    2,    4,   49,            2,    1,    8,    6,    // 135
-       3,    0,    5,  -999
+       3,  123,    3,    6,            2,   52,    1,    2,    // 39
+       4,   48,    2,   52,            8,    3,   29,    6,    // 47
+       3,    6,    2,   52,            1,    2,    4,   48,    // 55
+       2,   52,    7,    3,           29,    3,    3,    6,    // 63
+       2,   52,   48,    2,           52,    7,    3,   29,    // 71
+       3,    6,    3,   84,           23,    3,    2,    1,    // 79
+       8,   30,    6,    5,           38,   84,    5,   38,    // 87
+      87,   51,    0,   63,            8,    1,    1,    8,    // 95
+      51,    8,   29,    2,            6,    3,    7,   29,    // 103
+       3,   51,    8,    7,            2,   45,    2,    6,    // 111
+       3,    0,   23,    3,            2,    1,    4,   30,    // 119
+       2,   51,    8,   49,            1,    2,    4,   49,    // 127
+       2,    1,    8,    6,            3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 2;
+    size_t const numfixups = 2;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      79,  117,  -999
+      75,  113,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -3993,7 +4005,7 @@ TEST_F(Bytecode0, ArrayOfPointers2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("ArrayOfPointers2", scrip);
-    size_t const codesize = 121;
+    size_t const codesize = 113;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -4006,12 +4018,11 @@ TEST_F(Bytecode0, ArrayOfPointers2) {
       46,    3,   50,   32,            3,    4,   11,    2,    // 55
        3,   30,    3,   47,            3,   51,    4,    7,    // 63
        3,    1,    3,    1,            8,    3,   31,  -58,    // 71
-       2,    1,    4,    6,            3, 1074580685,   29,    3,    // 79
-      51,  184,   48,    2,           52,   30,    3,    8,    // 87
-       3,    6,    3,    0,           29,    3,   51,  188,    // 95
-      30,    3,   47,    3,           51,  200,    6,    3,    // 103
-      50,   49,    1,    2,            4,    2,    3,    1,    // 111
-      70,   -9,    2,    1,          200,    6,    3,    0,    // 119
+       2,    1,    4,    6,            3, 1074580685,   51,  180,    // 79
+      48,    2,   52,    8,            3,    6,    3,    0,    // 87
+      51,  184,   47,    3,           51,  200,    6,    3,    // 95
+      50,   49,    1,    2,            4,    2,    3,    1,    // 103
+      70,   -9,    2,    1,          200,    6,    3,    0,    // 111
        5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -4274,8 +4285,6 @@ TEST_F(Bytecode0, Protected2) {
 
     // In a struct func, a variable that can't be found otherwise
     // should be taken to be out of the current struct.
-    // (Note that this will currently compile to slightly more
-    // inefficient code than "this.Damage = damage")
 
     char *inpl = "\
         struct Weapon {                        \n\
@@ -4296,13 +4305,13 @@ TEST_F(Bytecode0, Protected2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Protected2", scrip);
-    size_t const codesize = 20;
+    size_t const codesize = 16;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-       3,    6,    2,   52,           30,    3,    8,    3,    // 15
-       6,    3,    0,    5,          -999
+      38,    0,   51,    8,            7,    3,    3,    6,    // 7
+       2,   52,    8,    3,            6,    3,    0,    5,    // 15
+     -999
     };
     CompareCode(&scrip, codesize, code);
 

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -1725,6 +1725,45 @@ TEST_F(Bytecode0, FlowSwitch07) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch07", scrip);
+    size_t const codesize = 75;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            7,    3,    3,    4,    // 7
+      31,   10,    6,    3,            7,    5,    6,    3,    // 15
+      11,    5,   31,   51,           29,    4,    6,    2,    // 23
+       0,    7,    3,   29,            3,    6,    3,    3,    // 31
+      30,    4,   11,    4,            3,    3,    4,    3,    // 39
+      30,    4,   15,    3,            4,   70,  -37,   29,    // 47
+       4,    6,    3,    0,           23,    3,   30,    4,    // 55
+      15,    3,    4,   70,          -47,    6,    2,    0,    // 63
+       7,    3,   15,    3,            4,   70,  -53,    6,    // 71
+       3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 3;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      24,   51,   63,  -999
+    };
+    char fixuptypes[] = {
+      1,   2,   1,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode0, FreeLocalPtr) {   

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -886,7 +886,7 @@ TEST_F(Bytecode1, Attributes02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Attributes02", scrip);
-    size_t const codesize = 123;
+    size_t const codesize = 119;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -895,17 +895,16 @@ TEST_F(Bytecode1, Attributes02) {
        4,   48,    2,   52,           29,    6,   29,    3,    // 23
       45,    2,    6,    3,           72,   23,    3,    2,    // 31
        1,    4,   30,    6,           51,    4,   48,    2,    // 39
-      52,   29,    6,   45,            2,    6,    3,  111,    // 47
+      52,   29,    6,   45,            2,    6,    3,  107,    // 47
       23,    3,   30,    6,           29,    3,    6,    3,    // 55
       10,   30,    4,   17,            4,    3,    3,    4,    // 63
        3,   51,    4,   49,            2,    1,    4,    5,    // 71
       38,   72,   51,    8,            7,    3,   29,    3,    // 79
        6,    3,    0,   30,            4,   19,    4,    3,    // 87
-       3,    4,    3,   28,           17,   51,    8,    7,    // 95
-       3,   29,    3,    3,            6,    2,   52,    1,    // 103
-       2,    2,   30,    3,            8,    3,    5,   38,    // 111
-     111,    3,    6,    2,           52,    1,    2,    2,    // 119
-       7,    3,    5,  -999
+       3,    4,    3,   28,           13,   51,    8,    7,    // 95
+       3,    3,    6,    2,           52,    1,    2,    2,    // 103
+       8,    3,    5,   38,          107,    3,    6,    2,    // 111
+      52,    1,    2,    2,            7,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1270,7 +1269,7 @@ TEST_F(Bytecode1, Attributes08) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
     // WriteOutput("Attributes08", scrip);
-    size_t const codesize = 109;
+    size_t const codesize = 105;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -1282,12 +1281,12 @@ TEST_F(Bytecode1, Attributes08) {
       29,    3,   45,    2,            6,    3,   12,   23,    // 47
        3,    2,    1,    4,           30,    6,   51,    0,    // 55
       47,    3,    1,    1,            4,   51,    4,   48,    // 63
-       3,   29,    3,   51,           12,   48,    2,   52,    // 71
-      30,    3,   29,    6,           29,    3,   29,    2,    // 79
-       6,    3,    8,   30,            2,   29,    3,   45,    // 87
-       2,    6,    3,    0,           23,    3,    2,    1,    // 95
-       8,   30,    6,   51,            8,   49,   51,    4,    // 103
-      49,    2,    1,    8,            5,  -999
+       3,   51,    8,   48,            2,   52,   29,    6,    // 71
+      29,    3,   29,    2,            6,    3,    8,   30,    // 79
+       2,   29,    3,   45,            2,    6,    3,    0,    // 87
+      23,    3,    2,    1,            8,   30,    6,   51,    // 95
+       8,   49,   51,    4,           49,    2,    1,    8,    // 103
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1295,7 +1294,7 @@ TEST_F(Bytecode1, Attributes08) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      46,   91,  -999
+      46,   87,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -1343,6 +1342,42 @@ TEST_F(Bytecode1, Attributes09) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
     // WriteOutput("Attributes09", scrip);
+    size_t const codesize = 41;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            1,   29,    3,   39,    // 7
+       0,    6,    3,    2,           33,    3,    3,    3,    // 15
+       2,   52,   30,    3,           29,    6,   34,    3,    // 23
+      45,    2,   39,    1,            6,    3,    1,   33,    // 31
+       3,   35,    1,   30,            6,    6,    3,    0,    // 39
+       5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 2;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      11,   30,  -999
+    };
+    char fixuptypes[] = {
+      4,   4,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 2;
+    std::string imports[] = {
+    "GUIControl::set_Visible^1",  "TwoClickHandler::get_ActionLabel^0",        // 2
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode1, DynArrayOfPrimitives) {
@@ -1362,35 +1397,34 @@ TEST_F(Bytecode1, DynArrayOfPrimitives) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("DynArrayOfPrimitives", scrip);
-    const size_t codesize = 67;
+    size_t const codesize = 59;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
       38,    0,    6,    3,           10,   72,    3,    2,    // 7
        0,   51,    0,   47,            3,    1,    1,    4,    // 15
-       6,    3,    0,   29,            3,   51,    8,   48,    // 23
-       2,   52,    1,    2,           14,   30,    3,   27,    // 31
-       3,   51,    4,   48,            2,   52,    1,    2,    // 39
-      14,   25,    3,   29,            3,   51,    8,   48,    // 47
-       2,   52,    1,    2,            6,   30,    3,   27,    // 55
-       3,   51,    4,   49,            2,    1,    4,    6,    // 63
+       6,    3,    0,   51,            4,   48,    2,   52,    // 23
+       1,    2,   14,   27,            3,   51,    4,   48,    // 31
+       2,   52,    1,    2,           14,   25,    3,   51,    // 39
+       4,   48,    2,   52,            1,    2,    6,   27,    // 47
+       3,   51,    4,   49,            2,    1,    4,    6,    // 55
        3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1411,38 +1445,37 @@ TEST_F(Bytecode1, ManagedDerefZerocheck) {
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     // WriteOutput("ManagedDerefZerocheck", scrip);
-    const size_t codesize = 24;
+    size_t const codesize = 20;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            1,   29,    3,    6,    // 7
-       2,    0,   48,    2,           52,    1,    2,   16,    // 15
-      30,    3,    8,    3,            6,    3,    0,    5,    // 23
-     -999
+      38,    0,    6,    3,            1,    6,    2,    0,    // 7
+      48,    2,   52,    1,            2,   16,    8,    3,    // 15
+       6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 1;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,  -999
+       7,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1989,7 +2022,7 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StructWOldstyleString2", scrip);
-    const size_t codesize = 168;
+    size_t const codesize = 164;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -2004,21 +2037,20 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
        2,    7,    1,    3,            7,    3,   70,  -26,    // 71
        1,    5,    1,    3,            5,    2,    6,    3,    // 79
        0,    8,    3,   51,            8,   48,    2,   52,    // 87
-       1,    2,    2,    3,            2,    3,   29,    3,    // 95
-      51,    8,   48,    2,           52,    1,    2,    8,    // 103
-      48,    2,   52,    1,            2,    2,   30,    3,    // 111
-       3,    3,    5,    3,            2,    4,    6,    7,    // 119
-     199,    3,    4,    2,            7,    3,    3,    5,    // 127
-       2,    8,    3,   28,           25,    1,    4,    1,    // 135
-       1,    5,    1,    2,            7,    1,    3,    7,    // 143
-       3,   70,  -26,    1,            5,    1,    3,    5,    // 151
-       2,    6,    3,    0,            8,    3,   51,    8,    // 159
-      49,   51,    4,   49,            2,    1,    8,    5,    // 167
-     -999
+       1,    2,    2,    3,            2,    3,   51,    4,    // 95
+      48,    2,   52,    1,            2,    8,   48,    2,    // 103
+      52,    1,    2,    2,            3,    3,    5,    3,    // 111
+       2,    4,    6,    7,          199,    3,    4,    2,    // 119
+       7,    3,    3,    5,            2,    8,    3,   28,    // 127
+      25,    1,    4,    1,            1,    5,    1,    2,    // 135
+       7,    1,    3,    7,            3,   70,  -26,    1,    // 143
+       5,    1,    3,    5,            2,    6,    3,    0,    // 151
+       8,    3,   51,    8,           49,   51,    4,   49,    // 159
+       2,    1,    8,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 1;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
@@ -2029,16 +2061,16 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 7;
+    size_t const stringssize = 7;
     EXPECT_EQ(stringssize, scrip.stringssize);
 
     char strings[] = {

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -1315,6 +1315,36 @@ TEST_F(Bytecode1, Attributes08) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
+TEST_F(Bytecode1, Attributes09) {
+
+    // Function call to 'set_Visible()' mustn't go awry
+    // After loading 'true' to AX´, must protect AX from being clobbered (push it)
+
+    char *inpl = "\
+        enum bool { false = 0, true };                  \n\
+        builtin managed struct GUIControl               \n\
+        {                                               \n\
+            import attribute bool Visible;              \n\
+        };                                              \n\
+        builtin managed struct Label extends GUIControl \n\
+        { };                                            \n\
+        struct TwoClickHandler                          \n\
+        {                                               \n\
+            import static attribute Label *ActionLabel; \n\
+        };                                              \n\
+                                                        \n\
+        int room_RepExec()                              \n\
+        {                                               \n\
+            TwoClickHandler.ActionLabel.Visible = true; \n\
+        }                                               \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    // WriteOutput("Attributes09", scrip);
+}
+
 TEST_F(Bytecode1, DynArrayOfPrimitives) {
     
     // Dynamic arrays of primitives are allowed.

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -1380,7 +1380,7 @@ TEST_F(Bytecode1, Attributes09) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode1, Attributes09) {
+TEST_F(Bytecode1, Attributes10) {
 
     // Accept extender attributes
 
@@ -1409,8 +1409,8 @@ TEST_F(Bytecode1, Attributes09) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 
-    // WriteOutput("Attributes09", scrip);
-    size_t const codesize = 141;
+    // WriteOutput("Attributes10", scrip);
+    size_t const codesize = 137;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -1425,13 +1425,13 @@ TEST_F(Bytecode1, Attributes09) {
        2,    6,    3,    3,           30,    2,   34,    3,    // 71
       45,    2,   39,    1,            6,    3,   22,   33,    // 79
        3,   35,    1,   30,            6,   51,    0,   47,    // 87
-       3,    1,    1,    4,            6,    3,    0,   29,    // 95
-       3,    6,    2,    0,           48,    2,   52,   30,    // 103
-       3,   29,    6,   34,            3,   29,    2,    6,    // 111
-       3,    9,   30,    2,           34,    3,   45,    2,    // 119
-      39,    2,    6,    3,           23,   33,    3,   35,    // 127
-       2,   30,    6,   51,            4,   49,    2,    1,    // 135
-       8,    6,    3,    0,            5,  -999
+       3,    1,    1,    4,            6,    3,    0,    6,    // 95
+       2,    0,   48,    2,           52,   29,    6,   34,    // 103
+       3,   29,    2,    6,            3,    9,   30,    2,    // 111
+      34,    3,   45,    2,           39,    2,    6,    3,    // 119
+      23,   33,    3,   35,            2,   30,    6,   51,    // 127
+       4,   49,    2,    1,            8,    6,    3,    0,    // 135
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1439,8 +1439,8 @@ TEST_F(Bytecode1, Attributes09) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   16,   34,   48,         57,   78,   94,   99,    // 7
-     124,  -999
+       4,   16,   34,   48,         57,   78,   94,   97,    // 7
+     120,  -999
     };
     char fixuptypes[] = {
       1,   4,   1,   4,      1,   4,   3,   1,    // 7
@@ -1468,7 +1468,7 @@ TEST_F(Bytecode1, Attributes09) {
     CompareStrings(&scrip, stringssize, strings);
 }
 
-TEST_F(Bytecode1, Attributes10) {
+TEST_F(Bytecode1, Attributes11) {
 
     // Accept static extender attributes
 
@@ -1493,8 +1493,8 @@ TEST_F(Bytecode1, Attributes10) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 
-    // WriteOutput("Attributes10", scrip);
-    size_t const codesize = 72;
+    // WriteOutput("Attributes11", scrip);
+    size_t const codesize = 68;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -1503,11 +1503,10 @@ TEST_F(Bytecode1, Attributes10) {
       39,    1,    6,    3,            1,   33,    3,   35,    // 23
        1,    6,    3,    3,           34,    3,   39,    1,    // 31
        6,    3,    2,   33,            3,   35,    1,   29,    // 39
-       3,   51,    4,    7,            3,   29,    3,   30,    // 47
-       3,   34,    3,    6,            3,   33,   34,    3,    // 55
-      39,    2,    6,    3,            3,   33,    3,   35,    // 63
-       2,    2,    1,    8,            6,    3,    0,    5,    // 71
-     -999
+       3,   51,    4,    7,            3,   34,    3,    6,    // 47
+       3,   33,   34,    3,           39,    2,    6,    3,    // 55
+       3,   33,    3,   35,            2,    2,    1,    8,    // 63
+       6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1515,7 +1514,7 @@ TEST_F(Bytecode1, Attributes10) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       6,   20,   34,   60,        -999
+       6,   20,   34,   56,        -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,     '\0'

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2070,6 +2070,92 @@ TEST_F(Compile0, Attributes09) {
     EXPECT_NE(std::string::npos, msg.find("static"));
 }
 
+TEST_F(Compile0, Attributes10) {
+
+    // Call non-indexed attribute with index, is error
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+        } cam;                                  \n\
+        import readonly attribute int Att (this Cam);   \n\
+        int game_start()                        \n\
+        {                                       \n\
+            return cam.Att[9];                  \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("non-indexed"));
+}
+
+
+TEST_F(Compile0, Attributes11) {
+
+    // Call indexed attribute without index, is error
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+        } cam;                                  \n\
+        import readonly attribute int Att[] (this Cam); \n\
+        int game_start()                        \n\
+        {                                       \n\
+            return cam.Att;                     \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find(" indexed"));
+}
+
+TEST_F(Compile0, Attributes12) {
+
+    // No local attributes
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+        } cam;                                  \n\
+                                                \n\
+        int game_start()                        \n\
+        {                                       \n\
+            readonly attribute int Att[] (this Cam); \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("function body"));
+}
+
+TEST_F(Compile0, Attributes13) {
+
+    // No attributes defined as 'static'
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+        } cam;                                  \n\
+                                                \n\
+        static readonly attribute int Att[] (this Cam); \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("static attribute"));
+}
+
 TEST_F(Compile0, StructPtrFunc) {
 
     // Func is ptr to managed, but it is a function not a variable

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2156,6 +2156,54 @@ TEST_F(Compile0, Attributes13) {
     EXPECT_NE(std::string::npos, msg.find("static attribute"));
 }
 
+TEST_F(Compile0, Attributes14) {
+
+    // Setting a readonly attribute, is error
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+            readonly attribute int Focus;       \n\
+        } cam;                                  \n\
+                                                \n\
+        int game_start()                        \n\
+        {                                       \n\
+            cam.Focus = 9;                      \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("readonly"));
+}
+
+
+TEST_F(Compile0, Attributes15) {
+
+    // Setting a readonly attribute, is error
+
+    char *inpl = "\
+        managed struct Cam                      \n\
+        {                                       \n\
+            int payload;                        \n\
+        } cam;                                  \n\
+                                                \n\
+        readonly attribute int Focus (this Cam *);  \n\
+                                                \n\
+        int game_start()                        \n\
+        {                                       \n\
+            cam.Focus = 9;                      \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("readonly"));
+}
+
 TEST_F(Compile0, StructPtrFunc) {
 
     // Func is ptr to managed, but it is a function not a variable


### PR DESCRIPTION
This PR adds attributes with extender syntax to the language. So it is possible to add, e.g., a `Weight` attribute to a `Character` even though the struct `Character` has been pre-defined.  This would result in the functions `Character::get_Weight()` and `Character::set_Weight()` to be declared, and the coder must then provide code for these functions, too, probably again using the extender syntax.
Extender attributes can be `readonly`, in this case the setter function isn't declared. 

Declare the attribute, in a header file:
```
attribute int Weight(this Character *);
```

Define the functions, in a code file:
```
#define WEIGHTPROP "Weight"
int get_Weight(this Character *)
{
    return this.GetProperty(WEIGHTPROP);
}
void set_Weight(this Character *, int weight)
{
    this.SetProperty(WEIGHTPROP, weight);
}
```

Use the attribute, e.g., in an event:
```
function hBench_Interact()
{
    if (player.Weight > 100)
        player.Say("I'd rather not sit on this frail bench; I'd break it!");
}
```

There are static attributes, too:
```
attribute int Foo(static Character);
…
if (Character.Foo > 10) return;
```

Indexed attributes:
```
attribute int Weapon[](this Character *);
attribute int Bar[](static Character);
```