### PR TITLE
Editor: allow to import TTF by searching for a point size matching pixel height

### DIFF
--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -84,43 +84,48 @@ static int GetAlfontFlags(int load_mode)
   return flags;
 }
 
+// Loads a TTF font of a certain size, optionally fill the FontMetrics struct
+static ALFONT_FONT *LoadTTF(const String &filename, int fontSize,
+    int alfont_flags, FontMetrics *metrics)
+{
+    std::unique_ptr<Stream> reader(AssetMgr->OpenAsset(filename));
+    if (!reader)
+        return nullptr;
+
+    const size_t lenof = reader->GetLength();
+    std::vector<char> buf; buf.resize(lenof);
+    reader->Read(&buf.front(), lenof);
+    reader.reset();
+
+    ALFONT_FONT *alfptr = alfont_load_font_from_mem(&buf.front(), lenof);
+    if (!alfptr)
+        return nullptr;
+    alfont_set_font_size_ex(alfptr, fontSize, alfont_flags);
+    if (metrics)
+    {
+        metrics->Height = alfont_get_font_height(alfptr);
+        metrics->RealHeight = alfont_get_font_real_height(alfptr);
+    }
+    return alfptr;
+}
+
 bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
     const FontRenderParams *params, FontMetrics *metrics)
 {
-  String file_name = String::FromFormat("agsfnt%d.ttf", fontNumber);
-  Stream *reader = AssetMgr->OpenAsset(file_name);
-  char *membuffer;
+    String filename = String::FromFormat("agsfnt%d.ttf", fontNumber);
+    if (fontSize <= 0)
+        fontSize = 8; // compatibility fix
+    if (params && params->SizeMultiplier > 1)
+        fontSize *= params->SizeMultiplier;
 
-  if (reader == nullptr)
-    return false;
+    ALFONT_FONT *alfptr = LoadTTF(filename, fontSize,
+        GetAlfontFlags(params->LoadMode), metrics);
+    if (!alfptr)
+        return false;
 
-  const size_t lenof = reader->GetLength();
-  membuffer = (char *)malloc(lenof);
-  reader->ReadArray(membuffer, lenof, 1);
-  delete reader;
-
-  ALFONT_FONT *alfptr = alfont_load_font_from_mem(membuffer, lenof);
-  free(membuffer);
-
-  if (alfptr == nullptr)
-    return false;
-
-  if (fontSize <= 0)
-      fontSize = 8; // compatibility fix
-  if (params && params->SizeMultiplier > 1)
-      fontSize *= params->SizeMultiplier;
-  
-  alfont_set_font_size_ex(alfptr, fontSize, GetAlfontFlags(params->LoadMode));
-
-  _fontData[fontNumber].AlFont = alfptr;
-  _fontData[fontNumber].Params = params ? *params : FontRenderParams();
-
-  if (metrics)
-  {
-      metrics->Height = alfont_get_font_height(alfptr);
-      metrics->RealHeight = alfont_get_font_real_height(alfptr);
-  }
-  return true;
+    _fontData[fontNumber].AlFont = alfptr;
+    _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+    return true;
 }
 
 const char *TTFFontRenderer::GetName(int fontNumber)
@@ -143,4 +148,22 @@ void TTFFontRenderer::FreeMemory(int fontNumber)
 {
   alfont_destroy_font(_fontData[fontNumber].AlFont);
   _fontData.erase(fontNumber);
+}
+
+bool TTFFontRenderer::MeasureFontOfPointSize(const String &filename, int size_pt, FontMetrics *metrics)
+{
+    ALFONT_FONT *alfptr = LoadTTF(filename, size_pt, ALFONT_FLG_FORCE_RESIZE | ALFONT_FLG_SELECT_NOMINAL_SZ, metrics);
+    if (!alfptr)
+        return false;
+    alfont_destroy_font(alfptr);
+    return true;
+}
+
+bool TTFFontRenderer::MeasureFontOfPixelHeight(const String &filename, int pixel_height, FontMetrics *metrics)
+{
+    ALFONT_FONT *alfptr = LoadTTF(filename, pixel_height, ALFONT_FLG_FORCE_RESIZE, metrics);
+    if (!alfptr)
+        return false;
+    alfont_destroy_font(alfptr);
+    return true;
 }

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -11,12 +11,12 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_TTFFONTRENDERER_H
 #define __AC_TTFFONTRENDERER_H
 
 #include <map>
 #include "font/agsfontrenderer.h"
+#include "util/string.h"
 
 struct ALFONT_FONT;
 
@@ -38,6 +38,15 @@ public:
       FontMetrics *metrics) override;
   const char *GetName(int fontNumber) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
+
+  //
+  // Utility functions
+  //
+  // Try load the TTF font using provided point size, and report its metrics
+  static bool MeasureFontOfPointSize(const AGS::Common::String &filename, int size_pt, FontMetrics *metrics);
+  // Try load the TTF font, find the point size which results in pixel height
+  // as close to the requested as possible; report its metrics
+  static bool MeasureFontOfPixelHeight(const AGS::Common::String &filename, int pixel_height, FontMetrics *metrics);
 
 private:
     struct FontData

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -143,6 +143,12 @@
     <Compile Include="GUI\CustomPropertySchemaItemEditor.Designer.cs">
       <DependentUpon>CustomPropertySchemaItemEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\ImportTTFDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\ImportTTFDialog.Designer.cs">
+      <DependentUpon>ImportTTFDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\NumberEntryWithInfoDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -335,6 +341,9 @@
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>
       <DependentUpon>frmMain.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\ImportTTFDialog.resx">
+      <DependentUpon>ImportTTFDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\NumberEntryWithInfoDialog.resx">
       <DependentUpon>NumberEntryWithInfoDialog.cs</DependentUpon>

--- a/Editor/AGS.Editor/GUI/ImportTTFDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ImportTTFDialog.Designer.cs
@@ -1,0 +1,145 @@
+﻿namespace AGS.Editor
+{
+    partial class ImportTTFDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.udSize = new System.Windows.Forms.NumericUpDown();
+            this.lblHeader = new System.Windows.Forms.Label();
+            this.rbPointSize = new System.Windows.Forms.RadioButton();
+            this.rbRealPixelHeight = new System.Windows.Forms.RadioButton();
+            this.panel1 = new System.Windows.Forms.Panel();
+            ((System.ComponentModel.ISupportInitialize)(this.udSize)).BeginInit();
+            this.panel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(186, 131);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(94, 22);
+            this.btnCancel.TabIndex = 5;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOK.Location = new System.Drawing.Point(86, 131);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(94, 22);
+            this.btnOK.TabIndex = 4;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            // 
+            // udSize
+            // 
+            this.udSize.Location = new System.Drawing.Point(22, 56);
+            this.udSize.Name = "udSize";
+            this.udSize.Size = new System.Drawing.Size(115, 20);
+            this.udSize.TabIndex = 3;
+            // 
+            // lblHeader
+            // 
+            this.lblHeader.Location = new System.Drawing.Point(12, 9);
+            this.lblHeader.Name = "lblHeader";
+            this.lblHeader.Size = new System.Drawing.Size(268, 20);
+            this.lblHeader.TabIndex = 0;
+            this.lblHeader.Text = "Select the font size to import this TTF font at:";
+            // 
+            // rbPointSize
+            // 
+            this.rbPointSize.AutoSize = true;
+            this.rbPointSize.Checked = true;
+            this.rbPointSize.Location = new System.Drawing.Point(3, 3);
+            this.rbPointSize.Name = "rbPointSize";
+            this.rbPointSize.Size = new System.Drawing.Size(100, 17);
+            this.rbPointSize.TabIndex = 1;
+            this.rbPointSize.TabStop = true;
+            this.rbPointSize.Text = "Font\'s point size";
+            this.rbPointSize.UseVisualStyleBackColor = true;
+            // 
+            // rbRealPixelHeight
+            // 
+            this.rbRealPixelHeight.AutoSize = true;
+            this.rbRealPixelHeight.Location = new System.Drawing.Point(3, 27);
+            this.rbRealPixelHeight.Name = "rbRealPixelHeight";
+            this.rbRealPixelHeight.Size = new System.Drawing.Size(189, 17);
+            this.rbRealPixelHeight.TabIndex = 2;
+            this.rbRealPixelHeight.Text = "Find closest size to this pixel height";
+            this.rbRealPixelHeight.UseVisualStyleBackColor = true;
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.rbPointSize);
+            this.panel1.Controls.Add(this.rbRealPixelHeight);
+            this.panel1.Controls.Add(this.udSize);
+            this.panel1.Location = new System.Drawing.Point(12, 32);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(268, 93);
+            this.panel1.TabIndex = 6;
+            // 
+            // ImportTTFDialog
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(292, 165);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.lblHeader);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnOK);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ImportTTFDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Import TTF font";
+            ((System.ComponentModel.ISupportInitialize)(this.udSize)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnOK;
+        private System.Windows.Forms.NumericUpDown udSize;
+        private System.Windows.Forms.Label lblHeader;
+        private System.Windows.Forms.RadioButton rbPointSize;
+        private System.Windows.Forms.RadioButton rbRealPixelHeight;
+        private System.Windows.Forms.Panel panel1;
+    }
+}

--- a/Editor/AGS.Editor/GUI/ImportTTFDialog.cs
+++ b/Editor/AGS.Editor/GUI/ImportTTFDialog.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    public partial class ImportTTFDialog : Form
+    {
+        public enum FontSizeMeaning
+        {
+            PointSize,
+            RealPixelHeight
+        }
+
+        public ImportTTFDialog(FontSizeMeaning sizeType, int sizeValue, int maxSize)
+        {
+            InitializeComponent();
+            rbPointSize.Checked = sizeType == FontSizeMeaning.PointSize;
+            rbRealPixelHeight.Checked = sizeType == FontSizeMeaning.RealPixelHeight;
+            udSize.Value = sizeValue;
+            udSize.Minimum = 1;
+            udSize.Maximum = maxSize;
+            ActiveControl = udSize;
+        }
+
+        public FontSizeMeaning SizeType
+        {
+            get
+            {
+                return rbPointSize.Checked ?
+                  FontSizeMeaning.PointSize : FontSizeMeaning.RealPixelHeight;
+            }
+        }
+
+        public int SizeValue
+        {
+            get { return (int)udSize.Value; }
+        }
+
+        public static bool Show(out FontSizeMeaning sizeType, out int sizeValue, int currentSize, int maxSize)
+        {
+            ImportTTFDialog dialog = new ImportTTFDialog(FontSizeMeaning.PointSize, currentSize, maxSize);
+            bool result = dialog.ShowDialog() == DialogResult.OK;
+            sizeType = dialog.SizeType;
+            sizeValue = dialog.SizeValue;
+            return result;
+        }
+    }
+}

--- a/Editor/AGS.Editor/GUI/ImportTTFDialog.resx
+++ b/Editor/AGS.Editor/GUI/ImportTTFDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -205,6 +205,15 @@ namespace AGS.Editor
             _native.ReloadFont(fontSlot);
         }
 
+        /// <summary>
+        /// Measures the TTF font from the given file, and tries to find a point size corresponding
+        /// to the closest pixel height match, returns the found point size, or 0 in case of error.
+        /// </summary>
+        public int FindTTFSizeForHeight(string fileName, int size)
+        {
+            return _native.FindTTFSizeForHeight(fileName, size);
+        }
+
         public void OnFontUpdated(Game game, int fontSlot, bool forceUpdate)
         {
             _native.OnGameFontUpdated(game, fontSlot, forceUpdate);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -9,12 +9,15 @@ see the license.txt for details.
 */
 #include "agsnative.h"
 #define WIN32_LEAN_AND_MEAN
+#define BITMAP WINDOWS_BITMAP
 #include <windows.h>
+#undef BITMAP;
 #include <stdlib.h>
 #include "NativeMethods.h"
 #include "NativeUtils.h"
 #include "ac/game_version.h"
 #include "font/fonts.h"
+#include "font/ttffontrenderer.h"
 #include "game/plugininfo.h"
 #include "util/error.h"
 #include "util/multifilelib.h"
@@ -270,6 +273,17 @@ namespace AGS
       {
         throw gcnew AGSEditorException(String::Format("Unable to load font {0}. No supported font renderer was able to load the font.", fontSlot));
       }
+    }
+
+    int NativeMethods::FindTTFSizeForHeight(String ^fileName, int pixelHeight)
+    {
+        AGSString filename = ConvertStringToNativeString(fileName);
+        FontMetrics metrics;
+        if (!TTFFontRenderer::MeasureFontOfPixelHeight(filename, pixelHeight, &metrics))
+        {
+            throw gcnew AGSEditorException(String::Format("Unable to load font {0}. Not a TTF font, or there an error occured while loading it.", fileName));
+        }
+        return metrics.Height;
     }
 
     void NativeMethods::OnGameFontUpdated(Game^ game, int fontSlot, bool forceUpdate)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -55,6 +55,9 @@ namespace AGS
 			Game^ ImportOldGameFile(String^ fileName);
 			void ImportSCIFont(String ^fileName, int fontSlot);
             void ReloadFont(int fontSlot);
+            // Measures the TTF font from the given file, and tries to find a point size corresponding
+            // to the closest pixel height match, returns the found point size, or 0 in case of error.
+            int FindTTFSizeForHeight(String ^fileName, int size);
             void OnGameFontUpdated(Game^ game, int fontSlot, bool forceUpdate);
 			Dictionary<int,Sprite^>^ LoadAllSpriteDimensions();
 			void LoadNewSpriteFile();


### PR DESCRIPTION
For #1441.

As per @fernewelten 's suggestion, this gives user a choice when importing a TTF font in the project:
a) provide an explicit point size value;
b) provide a pixel height and ask to find the point size that results in the closest match to that height.

New dialog looks like this:
![importttfdialog](https://user-images.githubusercontent.com/1833754/141702514-ec7883b7-cc9c-4191-b981-8f2ef786d7d6.png)


