### PR TITLE
Support multiple Speech VOXes for game translations

### DIFF
--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -83,7 +83,8 @@ public:
 
     // Add library location to the list of asset locations
     AssetError   AddLibrary(const String &path, const AssetLibInfo **lib = nullptr);
-    // Add library location, specifying comma-separated list of filters
+    // Add library location, specifying comma-separated list of filters;
+    // if library was already added before, this method will overwrite the filters only
     AssetError   AddLibrary(const String &path, const String &filters, const AssetLibInfo **lib = nullptr);
     // Remove library location from the list of asset locations
     void         RemoveLibrary(const String &path);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -346,6 +346,12 @@ namespace AGS.Editor
             return success;
         }
 
+        /// <summary>
+        /// Builds a AGS pack file, using the list of assets and parameters.
+        /// Returns null on success and an error message on error.
+        /// Assets come in tuples, where the first string is the name this asset
+        /// is registered by, and the second is the actual filepath.
+        /// </summary>
         public static string MakeDataFile(Tuple<string, string>[] assets, int splitSize, string baseFileName, bool makeFileNameAssumptions)
         {
             Environment.CurrentDirectory = Factory.AGSEditor.CurrentGame.DirectoryPath;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2635,7 +2635,7 @@ builtin managed struct Character {
 
 builtin struct Game {
   /// Changes the active translation.
-  import static bool   ChangeTranslation(const string newTranslationFileName);
+  import static bool   ChangeTranslation(const string newName);
   /// Returns true the first time this command is called with this token.
   import static bool   DoOnceOnly(const string token);
   /// Gets the AGS Colour Number for the specified RGB colour.
@@ -2737,8 +2737,12 @@ builtin struct Game {
   import static readonly attribute int CameraCount;
 #endif
 #ifdef SCRIPT_API_v360
+  /// Changes the active translation.
+  import static bool   ChangeSpeechVox(const string newName);
   /// Gets the code which describes how was the last blocking state skipped by a user (or autotimer).
   import static readonly attribute int BlockingWaitSkipped;
+  /// Gets name of the currently active translation.
+  readonly import static attribute String SpeechVoxFilename;
 #endif
 };
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -395,7 +395,7 @@ bool try_auto_play_speech(const char *text, const char *&replace_text, int chari
     if (play_voice_speech(charid, sndid))
     {
         // if Voice Only, then blank out the text
-        if (play.want_speech == 2)
+        if (play.speech_mode == kSpeech_VoiceOnly)
             replace_text = "  ";
         return true;
     }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -844,6 +844,23 @@ int Game_ChangeTranslation(const char *newFilename)
     return 1;
 }
 
+const char* Game_GetSpeechVoxFilename()
+{
+    return CreateNewScriptString(get_voicepak_name());
+}
+
+bool Game_ChangeSpeechVox(const char *newFilename)
+{
+    if (!init_voicepak(newFilename))
+    {
+        // if failed (and was not default)- fallback to default
+        if (strlen(newFilename) > 0)
+            init_voicepak();
+        return false;
+    }
+    return true;
+}
+
 ScriptAudioClip *Game_GetAudioClip(int index)
 {
     if (index < 0 || (size_t)index >= game.audioClips.size())
@@ -1666,6 +1683,11 @@ RuntimeScriptValue Sc_Game_ChangeTranslation(const RuntimeScriptValue *params, i
     API_SCALL_INT_POBJ(Game_ChangeTranslation, const char);
 }
 
+RuntimeScriptValue Sc_Game_ChangeSpeechVox(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_BOOL_POBJ(Game_ChangeSpeechVox, const char);
+}
+
 // int (const char *token)
 RuntimeScriptValue Sc_Game_DoOnceOnly(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1900,6 +1922,11 @@ RuntimeScriptValue Sc_Game_GetTranslationFilename(const RuntimeScriptValue *para
     API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetTranslationFilename);
 }
 
+RuntimeScriptValue Sc_Game_GetSpeechVoxFilename(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ(const char, myScriptStringImpl, Game_GetSpeechVoxFilename);
+}
+
 // int ()
 RuntimeScriptValue Sc_Game_GetUseNativeCoordinates(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1924,7 +1951,7 @@ RuntimeScriptValue Sc_Game_GetAudioClip(const RuntimeScriptValue *params, int32_
 
 RuntimeScriptValue Sc_Game_IsPluginLoaded(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_BOOL_OBJ(pl_is_plugin_loaded, const char);
+    API_SCALL_BOOL_POBJ(pl_is_plugin_loaded, const char);
 }
 
 RuntimeScriptValue Sc_Game_PlayVoiceClip(const RuntimeScriptValue *params, int32_t param_count)
@@ -2008,9 +2035,11 @@ void RegisterGameAPI()
     ccAddExternalStaticFunction("Game::get_AudioClipCount",                     Sc_Game_GetAudioClipCount);
     ccAddExternalStaticFunction("Game::geti_AudioClips",                        Sc_Game_GetAudioClip);
     ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
+    ccAddExternalStaticFunction("Game::ChangeSpeechVox",                        Sc_Game_ChangeSpeechVox);
     ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
     ccAddExternalStaticFunction("Game::SimulateKeyPress",                       Sc_Game_SimulateKeyPress);
     ccAddExternalStaticFunction("Game::get_BlockingWaitSkipped",                Sc_Game_BlockingWaitSkipped);
+    ccAddExternalStaticFunction("Game::get_SpeechVoxFilename",                  Sc_Game_GetSpeechVoxFilename);
 
     ccAddExternalStaticFunction("Game::get_Camera",                             Sc_Game_GetCamera);
     ccAddExternalStaticFunction("Game::get_CameraCount",                        Sc_Game_GetCameraCount);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -125,6 +125,8 @@ int Game_GetNormalFont();
 
 const char* Game_GetTranslationFilename();
 int Game_ChangeTranslation(const char *newFilename);
+const char* Game_GetSpeechVoxFilename();
+bool Game_ChangeSpeechVox(const char *newFilename);
 
 //=============================================================================
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -442,7 +442,7 @@ bool GameState::IsNonBlockingVoiceSpeech() const
 bool GameState::ShouldPlayVoiceSpeech() const
 {
     return !play.fast_forward &&
-        (play.speech_mode != kSpeech_TextOnly) && (!ResPaths.SpeechPak.Name.IsEmpty());
+        (play.speech_mode != kSpeech_TextOnly) && (play.voice_avail);
 }
 
 void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver, RestoredData &r_data)

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -442,7 +442,7 @@ bool GameState::IsNonBlockingVoiceSpeech() const
 bool GameState::ShouldPlayVoiceSpeech() const
 {
     return !play.fast_forward &&
-        (play.want_speech >= 1) && (!ResPaths.SpeechPak.Name.IsEmpty());
+        (play.speech_mode != kSpeech_TextOnly) && (!ResPaths.SpeechPak.Name.IsEmpty());
 }
 
 void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver, RestoredData &r_data)
@@ -574,7 +574,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     entered_at_x = in->ReadInt32();
     entered_at_y = in->ReadInt32();
     entered_edge = in->ReadInt32();
-    want_speech = in->ReadInt32();
+    speech_mode = (SpeechMode)in->ReadInt32();
     cant_skip_speech = in->ReadInt32();
     in->ReadArrayOfInt32(script_timers, MAX_TIMERS);
     sound_volume = in->ReadInt32();
@@ -583,7 +583,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameStateSvgVersion svg_ver
     speech_font = in->ReadInt32();
     key_skip_wait = in->ReadInt8();
     swap_portrait_lastchar = in->ReadInt32();
-    separate_music_lib = in->ReadInt32();
+    separate_music_lib = in->ReadInt32() != 0;
     in_conversation = in->ReadInt32();
     screen_tint = in->ReadInt32();
     num_parsed_words = in->ReadInt32();
@@ -785,7 +785,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32( entered_at_x);
     out->WriteInt32( entered_at_y);
     out->WriteInt32( entered_edge);
-    out->WriteInt32( want_speech);
+    out->WriteInt32( speech_mode);
     out->WriteInt32( cant_skip_speech);
     out->WriteArrayOfInt32(script_timers, MAX_TIMERS);
     out->WriteInt32( sound_volume);
@@ -794,7 +794,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32( speech_font);
     out->WriteInt8( key_skip_wait);
     out->WriteInt32( swap_portrait_lastchar);
-    out->WriteInt32( separate_music_lib);
+    out->WriteInt32( separate_music_lib ? 1 : 0);
     out->WriteInt32( in_conversation);
     out->WriteInt32( screen_tint);
     out->WriteInt32( num_parsed_words);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -11,23 +11,21 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_GAMESTATE_H
 #define __AC_GAMESTATE_H
 
-
 #include <memory>
 #include <vector>
-
 #include "ac/characterinfo.h"
 #include "ac/runtime_defines.h"
+#include "ac/speech.h"
+#include "ac/timer.h"
 #include "game/roomstruct.h"
 #include "game/viewport.h"
 #include "media/audio/queuedaudioitem.h"
 #include "util/geometry.h"
 #include "util/string_types.h"
 #include "util/string.h"
-#include "ac/timer.h"
 
 // Forward declaration
 namespace AGS
@@ -160,7 +158,8 @@ struct GameState {
     char  walkable_areas_on[MAX_WALK_AREAS+1];
     short screen_flipped;
     int   entered_at_x,entered_at_y, entered_edge;
-    int   want_speech;
+    bool  voice_avail; // whether voice-over is available
+    SpeechMode speech_mode; // speech mode (text, voice, or both)
     int   cant_skip_speech;
     int   script_timers[MAX_TIMERS];
     int   sound_volume,speech_volume;
@@ -168,7 +167,7 @@ struct GameState {
     char  key_skip_wait;
     int   swap_portrait_lastchar;
     int   swap_portrait_lastlastchar;
-    int   separate_music_lib;
+    bool  separate_music_lib;
     int   in_conversation;
     int   screen_tint;
     int   num_parsed_words;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -482,6 +482,7 @@ ScriptAudioChannel *PlayVoiceClip(CharacterInfo *ch, int sndid, bool as_speech)
 // Construct an asset name for the voice-over clip for the given character and cue id
 String get_cue_filename(int charid, int sndid)
 {
+    String asset_path = get_voice_assetpath();
     String script_name;
     if (charid >= 0)
     {
@@ -495,7 +496,7 @@ String get_cue_filename(int charid, int sndid)
     {
         script_name = "NARR";
     }
-    return String::FromFormat("%s%d", script_name.GetCStr(), sndid);
+    return String::FromFormat("%s%s%d", asset_path.GetCStr(), script_name.GetCStr(), sndid);
 }
 
 // Play voice-over clip on the common channel;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -450,33 +450,24 @@ void SetSpeechVolume(int newvol) {
     play.speech_volume = newvol;
 }
 
-// 0 = text only
-// 1 = voice & text
-// 2 = voice only
-void SetVoiceMode (int newmod) {
-    if ((newmod < 0) | (newmod > 2))
-        quit("!SetVoiceMode: invalid mode number (must be 0,1,2)");
-    // If speech is turned off, store the mode anyway in case the
-    // user adds the VOX file later
-    if (play.want_speech < 0)
-        play.want_speech = (-newmod) - 1;
-    else
-        play.want_speech = newmod;
+void SetVoiceMode(int newmod)
+{
+    if ((newmod < kSpeech_First) | (newmod > kSpeech_Last))
+        quitprintf("!SetVoiceMode: invalid mode number %d", newmod);
+    play.speech_mode = (SpeechMode)newmod;
 }
 
 int GetVoiceMode()
 {
-    return play.want_speech >= 0 ? play.want_speech : -(play.want_speech + 1);
+    return (int)play.speech_mode;
 }
 
 int IsVoxAvailable() {
-    if (play.want_speech < 0)
-        return 0;
-    return 1;
+    return play.voice_avail ? 1 : 0;
 }
 
 int IsMusicVoxAvailable () {
-    return play.separate_music_lib;
+    return play.separate_music_lib ? 1 : 0;
 }
 
 extern ScriptAudioChannel scrAudioChannel[MAX_GAME_CHANNELS];

--- a/Engine/ac/global_audio.h
+++ b/Engine/ac/global_audio.h
@@ -11,12 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-//
-//
-//
-//=============================================================================
 #ifndef __AGS_EE_AC__GLOBALAUDIO_H
 #define __AGS_EE_AC__GLOBALAUDIO_H
+
+#include "speech.h"
 
 void    StopAmbientSound (int channel);
 void    PlayAmbientSound (int channel, int sndnum, int vol, int x, int y);
@@ -46,8 +44,8 @@ void    PlayMP3File (const char *filename);
 void    PlaySilentMIDI (int mnum);
 
 void    SetSpeechVolume(int newvol);
-void    SetVoiceMode (int newmod);
-int     GetVoiceMode ();
+void    SetVoiceMode(int newmod);
+int     GetVoiceMode();
 int     IsVoxAvailable();
 int     IsMusicVoxAvailable ();
 

--- a/Engine/ac/global_debug.cpp
+++ b/Engine/ac/global_debug.cpp
@@ -73,7 +73,7 @@ String GetRuntimeInfo()
         spriteset.GetCacheSize() / 1024, spriteset.GetMaxCacheSize() / 1024, spriteset.GetLockedSize() / 1024);
     if (play.separate_music_lib)
         runtimeInfo.Append("[AUDIO.VOX enabled");
-    if (play.want_speech >= 1)
+    if (play.voice_avail)
         runtimeInfo.Append("[SPEECH.VOX enabled");
     if (get_translation_tree().size() > 0) {
         runtimeInfo.Append("[Using translation ");

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -11,12 +11,22 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
+#include "ac/speech.h"
+#include "ac/asset_helper.h"
 #include "ac/common.h"
 #include "ac/runtime_defines.h"
-#include "ac/speech.h"
 #include "ac/dynobj/scriptoverlay.h"
+#include "ac/gamesetup.h"
+#include "ac/gamestate.h"
+#include "core/assetmanager.h"
 #include "debug/debug_log.h"
+#include "main/engine.h"
+#include "util/path.h"
+
+using namespace AGS::Common;
+
+
+static String VoiceAssetPath;
 
 int user_to_internal_skip_speech(SkipSpeechStyle userval)
 {
@@ -79,6 +89,59 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val)
         }
     }
     return kSkipSpeechNone;
+}
+
+bool init_voicepak(const String &name)
+{
+    if (usetup.no_speech_pack) return false; // voice-over disabled
+
+    play.voice_avail = false;
+    String speech_file = name.IsEmpty() ? "speech.vox" : String::FromFormat("sp_%s.vox", name.GetCStr());
+    if (ResPaths.SpeechPak.Name.CompareNoCase(speech_file) == 0)
+        return true; // same pak already assigned
+
+    // First remove existing voice packs
+    AssetMgr->RemoveLibrary(ResPaths.SpeechPak.Path);
+    AssetMgr->RemoveLibrary(ResPaths.VoiceDirSub);
+
+    // Now check for the new packs and add if they exist
+    String speech_filepath = find_assetlib(speech_file);
+    if (!speech_filepath.IsEmpty())
+    {
+        Debug::Printf(kDbgMsg_Info, "Voice pack found: %s", speech_file.GetCStr());
+        play.voice_avail = true;
+    }
+    else
+    {
+        Debug::Printf(kDbgMsg_Error, "Unable to init voice pack '%s', file not found or of unknown format.",
+            speech_file.GetCStr());
+    }
+
+    String speech_subdir = "";
+    if (!ResPaths.VoiceDir2.IsEmpty() && Path::ComparePaths(ResPaths.DataDir, ResPaths.VoiceDir2) != 0)
+    {
+        // If we have custom voice directory set, we will enable voice-over even if speech.vox does not exist
+        speech_subdir = name.IsEmpty() ? ResPaths.VoiceDir2 : Path::ConcatPaths(ResPaths.VoiceDir2, name);
+        if (File::IsDirectory(speech_subdir))
+        {
+            Debug::Printf(kDbgMsg_Info, "Optional voice directory is defined: %s", speech_subdir.GetCStr());
+            play.voice_avail = true;
+        }
+    }
+
+    // Save new resource locations and register asset libraries
+    VoiceAssetPath = name.IsEmpty() ? "" : String::FromFormat("%s/", name.GetCStr());
+    ResPaths.SpeechPak.Name = speech_file;
+    ResPaths.SpeechPak.Path = speech_filepath;
+    ResPaths.VoiceDirSub = speech_subdir;
+    AssetMgr->AddLibrary(ResPaths.VoiceDirSub, "voice");
+    AssetMgr->AddLibrary(ResPaths.SpeechPak.Path, "voice");
+    return play.voice_avail;
+}
+
+String get_voice_assetpath()
+{
+    return VoiceAssetPath;
 }
 
 //=============================================================================

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -25,8 +25,11 @@
 
 using namespace AGS::Common;
 
-
+// identifier (username) of the voice pak
+static String VoicePakName;
+// parent part to use when making voice asset names
 static String VoiceAssetPath;
+
 
 int user_to_internal_skip_speech(SkipSpeechStyle userval)
 {
@@ -130,6 +133,7 @@ bool init_voicepak(const String &name)
     }
 
     // Save new resource locations and register asset libraries
+    VoicePakName = name;
     VoiceAssetPath = name.IsEmpty() ? "" : String::FromFormat("%s/", name.GetCStr());
     ResPaths.SpeechPak.Name = speech_file;
     ResPaths.SpeechPak.Path = speech_filepath;
@@ -137,6 +141,11 @@ bool init_voicepak(const String &name)
     AssetMgr->AddLibrary(ResPaths.VoiceDirSub, "voice");
     AssetMgr->AddLibrary(ResPaths.SpeechPak.Path, "voice");
     return play.voice_avail;
+}
+
+String get_voicepak_name()
+{
+    return VoicePakName;
 }
 
 String get_voice_assetpath()

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -11,10 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-//
-//
-//
-//=============================================================================
 #ifndef __AGS_EE_AC__SPEECH_H
 #define __AGS_EE_AC__SPEECH_H
 
@@ -31,6 +27,16 @@ enum SkipSpeechStyle
 
     kSkipSpeechFirst        = kSkipSpeechNone,
     kSkipSpeechLast         = kSkipSpeechMouse
+};
+
+enum SpeechMode
+{
+    kSpeech_TextOnly        = 0,
+    kSpeech_VoiceText       = 1,
+    kSpeech_VoiceOnly       = 2,
+
+    kSpeech_First           = kSpeech_TextOnly,
+    kSpeech_Last            = kSpeech_VoiceOnly
 };
 
 int user_to_internal_skip_speech(SkipSpeechStyle userval);

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -46,6 +46,8 @@ SkipSpeechStyle internal_skip_speech_to_user(int internal_val);
 // Locates and initializes a voice pack of the given *name*, tells if successful;
 // pass empty string for default voice pack.
 bool init_voicepak(const AGS::Common::String &name = "");
+// Gets voice pack's ID name, that is a filename without "sp_" prefix and no extension.
+AGS::Common::String get_voicepak_name();
 // Gets an asset's parent path for voice-over clips and data files
 AGS::Common::String get_voice_assetpath();
 

--- a/Engine/ac/speech.h
+++ b/Engine/ac/speech.h
@@ -14,6 +14,8 @@
 #ifndef __AGS_EE_AC__SPEECH_H
 #define __AGS_EE_AC__SPEECH_H
 
+#include "util/string.h"
+
 enum SkipSpeechStyle
 {
     kSkipSpeechNone         = -1,
@@ -41,5 +43,10 @@ enum SpeechMode
 
 int user_to_internal_skip_speech(SkipSpeechStyle userval);
 SkipSpeechStyle internal_skip_speech_to_user(int internal_val);
+// Locates and initializes a voice pack of the given *name*, tells if successful;
+// pass empty string for default voice pack.
+bool init_voicepak(const AGS::Common::String &name = "");
+// Gets an asset's parent path for voice-over clips and data files
+AGS::Common::String get_voice_assetpath();
 
 #endif // __AGS_EE_AC__SPEECH_H

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -351,7 +351,7 @@ HSaveError OpenSavegame(const String &filename, SavegameDescription &desc, Saveg
 // Prepares engine for actual save restore (stops processes, cleans up memory)
 void DoBeforeRestore(PreservedParams &pp)
 {
-    pp.SpeechVOX = play.want_speech;
+    pp.SpeechVOX = play.voice_avail;
     pp.MusicVOX = play.separate_music_lib;
 
     unload_old_room();
@@ -465,13 +465,8 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         play.dialog_options_highlight_color = DIALOG_OPTIONS_HIGHLIGHT_COLOR_DEFAULT;
 
     // Preserve whether the music vox is available
+    play.voice_avail = pp.SpeechVOX;
     play.separate_music_lib = pp.MusicVOX;
-    // If they had the vox when they saved it, but they don't now
-    if ((pp.SpeechVOX < 0) && (play.want_speech >= 0))
-        play.want_speech = (-play.want_speech) - 1;
-    // If they didn't have the vox before, but now they do
-    else if ((pp.SpeechVOX >= 0) && (play.want_speech < 0))
-        play.want_speech = (-play.want_speech) - 1;
 
     // Restore debug flags
     if (debug_flags & DBG_DEBUGMODE)

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -38,8 +38,8 @@ typedef std::shared_ptr<Bitmap> PBitmap;
 struct PreservedParams
 {
     // Whether speech and audio packages available
-    int SpeechVOX;
-    int MusicVOX;
+    bool SpeechVOX;
+    bool MusicVOX;
     // Script global data sizes
     int GlScDataSize;
     std::vector<int> ScMdDataSize;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -312,7 +312,7 @@ void engine_init_mouse()
 
 void engine_locate_speech_pak()
 {
-    play.want_speech=-2;
+    play.voice_avail = false;
 
     if (!usetup.no_speech_pack) {
         String speech_file = "speech.vox";
@@ -324,13 +324,13 @@ void engine_locate_speech_pak()
                 return;
             }
             Debug::Printf(kDbgMsg_Info, "Voice pack found and initialized.");
-            play.want_speech=1;
+            play.voice_avail = true;
         }
         else if (Path::ComparePaths(ResPaths.DataDir, ResPaths.VoiceDir2) != 0)
         {
             // If we have custom voice directory set, we will enable voice-over even if speech.vox does not exist
             Debug::Printf(kDbgMsg_Info, "Voice pack was not found, but explicit voice directory is defined: enabling voice-over.");
-            play.want_speech=1;
+            play.voice_avail = true;
         }
         ResPaths.SpeechPak.Name = speech_file;
         ResPaths.SpeechPak.Path = speech_filepath;
@@ -339,7 +339,7 @@ void engine_locate_speech_pak()
 
 void engine_locate_audio_pak()
 {
-    play.separate_music_lib = 0;
+    play.separate_music_lib = false;
     String music_file = game.GetAudioVOXName();
     String music_filepath = find_assetlib(music_file);
     if (!music_filepath.IsEmpty())
@@ -347,7 +347,7 @@ void engine_locate_audio_pak()
         if (AssetMgr->AddLibrary(music_filepath) == kAssetNoError)
         {
             Debug::Printf(kDbgMsg_Info, "%s found and initialized.", music_file.GetCStr());
-            play.separate_music_lib = 1;
+            play.separate_music_lib = true;
             ResPaths.AudioPak.Name = music_file;
             ResPaths.AudioPak.Path = music_filepath;
         }
@@ -412,9 +412,8 @@ void engine_init_audio()
     if (usetup.audio_backend == 0)
     {
         // all audio is disabled
-        // and the voice mode should not go to Voice Only
-        play.want_speech = -2;
-        play.separate_music_lib = 0;
+        play.voice_avail = false;
+        play.separate_music_lib = false;
     }
 }
 
@@ -803,6 +802,7 @@ void engine_init_game_settings()
     play.music_master_volume=100 + LegacyMusicMasterVolumeAdjustment;
     play.digital_master_volume = 100;
     play.screen_flipped=0;
+    play.speech_mode = kSpeech_VoiceText;
     play.cant_skip_speech = user_to_internal_skip_speech((SkipSpeechStyle)game.options[OPT_NOSKIPTEXT]);
     play.sound_volume = 255;
     play.speech_volume = 255;

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -312,29 +312,7 @@ void engine_init_mouse()
 
 void engine_locate_speech_pak()
 {
-    play.voice_avail = false;
-
-    if (!usetup.no_speech_pack) {
-        String speech_file = "speech.vox";
-        String speech_filepath = find_assetlib(speech_file);
-        if (!speech_filepath.IsEmpty()) {
-            Debug::Printf("Initializing speech vox");
-            if (AssetMgr->AddLibrary(speech_filepath) != Common::kAssetNoError) {
-                platform->DisplayAlert("Unable to read voice pack, file could be corrupted or of unknown format.\nSpeech voice-over will be disabled.");
-                return;
-            }
-            Debug::Printf(kDbgMsg_Info, "Voice pack found and initialized.");
-            play.voice_avail = true;
-        }
-        else if (Path::ComparePaths(ResPaths.DataDir, ResPaths.VoiceDir2) != 0)
-        {
-            // If we have custom voice directory set, we will enable voice-over even if speech.vox does not exist
-            Debug::Printf(kDbgMsg_Info, "Voice pack was not found, but explicit voice directory is defined: enabling voice-over.");
-            play.voice_avail = true;
-        }
-        ResPaths.SpeechPak.Name = speech_file;
-        ResPaths.SpeechPak.Path = speech_filepath;
-    }
+    init_voicepak("");
 }
 
 void engine_locate_audio_pak()

--- a/Engine/main/engine.h
+++ b/Engine/main/engine.h
@@ -55,7 +55,8 @@ struct ResourcePaths
     // This is bit ugly, but remain so until more flexible configuration is designed
     String       DataDir2;   // optional data directory
     String       AudioDir2;  // optional audio directory
-    String       VoiceDir2;  // optional voice-over directory
+    String       VoiceDir2;  // optional voice-over directory (base)
+    String       VoiceDirSub;// full voice-over directory with optional sub-dir
 };
 extern ResourcePaths ResPaths;
 

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -269,7 +269,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 #define API_SCALL_BOOL(FUNCTION) \
     return RuntimeScriptValue().SetInt32AsBool(FUNCTION())
 
-#define API_SCALL_BOOL_OBJ(FUNCTION, P1CLASS) \
+#define API_SCALL_BOOL_POBJ(FUNCTION, P1CLASS) \
     ASSERT_PARAM_COUNT(FUNCTION, 1); \
     return RuntimeScriptValue().SetInt32AsBool(FUNCTION((P1CLASS*)params[0].Ptr))
 


### PR DESCRIPTION
Resolves #686 (except the part with expanded clip names, which I think may be moved to a separate ticket).

This adds a support for game having multiple voice-over packages, and being able to switch between them at runtime. The primary goal is to let game developers have the game translated with voice-overs in various languages.

Implementation details follow.

---

### Engine

Engine supports loading a different speech vox at runtime.

By default engine loads a `speech.vox`, if one exists.

When ordered to change to an alternate vox of a name "[name]", engine will look for a vox called `sp_[name].vox`. If this vox is found then it will be loaded. If not, engine falls back to the default `speech.vox`.

The assets in alternate voxes must have names `[name]/filename.ext` where `[name]` is the same "tag name" of a vox, as noted above. This naming rule goal is to mimic the disk structure, where default vox files are in the root and all alternate ones are inside subdirectories. This allows to also read these assets from disk if necessary without any extra hacks to path search. This also in a way corresponds to how the custom user files are named (see #1227, #1372).

Everything else works as usual, regardless of which vox is loaded.

---

### Script API

Implemented 2 new API items:

`bool Game.ChangeSpeechVox(const string name);` - changes the speech vox to the vox of the given name (the actual filename will be `sp_name.vox`, as explained above. An empty string may be passed to switch to the default speech.vox.
`readonly String Game.SpeechVoxFilename;` - gets the "name" of the currently loaded vox (without "sp_" prefix and no extension), an empty string for a default speech.vox.

---

### Editor

Editor now packs alternate speech voxes, by scanning the top-level directories inside the "Speech" folder. For each top-level subdirectory It creates a `sp_[name].vox` where `[name]` is the lowercase subdir name.

For example, if you have this in your game project:
* Speech
  * Francais
  * MyLang

The editor will create following voxes:
- speech.vox (with top-level files from the root "Speech" folder);
- sp_francais.vox (with top-level files from "Speech/Francais");
- sp_mylang.vox (with top-level files from "Speech/MyLang");

The assets in the *alternate* voxes will be called according to the aforementioned naming rules, that is `[dirname]/filename.ext`.
