### PR TITLE
3.5.1 hotfix: don't precreate common engine/game directories

### DIFF
--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -38,7 +38,8 @@ bool CreateAllDirectories(const String &parent, const String &path)
         return false;
 
     String fixup_parent = Path::MakeTrailingSlash(parent);
-    String sub_path = Path::MakeRelativePath(fixup_parent, path);
+    String fixup_child = Path::MakeTrailingSlash(path);
+    String sub_path = Path::MakeRelativePath(fixup_parent, fixup_child);
     String make_path = parent;
     std::vector<String> dirs = Path::Split(sub_path);
     for (const String &dir : dirs)

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -150,8 +150,6 @@ MoveList *mls = nullptr;
 //=============================================================================
 
 String saveGameDirectory = "./";
-// Custom save game parent directory
-String saveGameParent;
 
 String saveGameSuffix;
 
@@ -337,50 +335,26 @@ String get_save_game_path(int slotNum)
 // a dir of a new name. While we let this work, we also try to keep these
 // inside same parent location, would that be a common system directory,
 // or a custom one set by a player in config.
-static bool MakeSaveGameDir(const String &newFolder, FSLocation &fsdir)
+static bool MakeSaveGameDir(const String &new_dir, FSLocation &fsdir)
 {
     fsdir = FSLocation();
     // don't allow absolute paths
-    if (!is_relative_filename(newFolder))
+    if (!is_relative_filename(new_dir))
         return false;
 
-    String newSaveGameDir = FixSlashAfterToken(newFolder);
+    String fixed_newdir = FixSlashAfterToken(new_dir);
+    if (fixed_newdir.CompareLeft(UserSavedgamesRootToken, UserSavedgamesRootToken.GetLength()) == 0)
+    {
+        fixed_newdir.ClipLeft(UserSavedgamesRootToken.GetLength());
+    }
+    else if (game.options[OPT_SAFEFILEPATHS] > 0)
+    { // For games made in the safe-path-aware versions of AGS, report a warning
+        debug_script_warn("Attempt to explicitly set savegame location relative to the game installation directory ('%s') denied;\nPath will be remapped to the user documents directory: '%s'",
+            fixed_newdir.GetCStr(), fsdir.FullDir.GetCStr());
+    }
 
-    if (newSaveGameDir.CompareLeft(UserSavedgamesRootToken, UserSavedgamesRootToken.GetLength()) == 0)
-    {
-        if (saveGameParent.IsEmpty())
-        { // Set this up inside a standard AGS save dir
-            fsdir = PathFromInstallDir(platform->GetUserSavedgamesDirectory());
-            fsdir = fsdir.Concat(newSaveGameDir.Mid(UserSavedgamesRootToken.GetLength()));
-        }
-        else
-        {
-            // If there is a custom save parent directory, then replace
-            // not only root token, but also first subdirectory
-            newSaveGameDir.ClipSection('/', 0, 1); // TODO: Path helper function for this?
-            fsdir = FSLocation(saveGameParent).Concat(newSaveGameDir);
-        }
-    }
-    else
-    {
-        // Convert the path relative to installation folder into path relative to the
-        // safe save path with default name
-        if (saveGameParent.IsEmpty())
-        { // Set this up inside a standard AGS save dir
-            fsdir = PathFromInstallDir(platform->GetUserSavedgamesDirectory());
-            fsdir = fsdir.Concat(Path::ConcatPaths(game.saveGameFolderName, newFolder));
-        }
-        else
-        {
-            fsdir = FSLocation(saveGameParent).Concat(newFolder);
-        }
-        // For games made in the safe-path-aware versions of AGS, report a warning
-        if (game.options[OPT_SAFEFILEPATHS])
-        {
-            debug_script_warn("Attempt to explicitly set savegame location relative to the game installation directory ('%s') denied;\nPath will be remapped to the user documents directory: '%s'",
-                newFolder.GetCStr(), fsdir.FullDir.GetCStr());
-        }
-    }
+    // Resolve the new dir relative to the user data parent dir
+    fsdir = GetGameUserDataDir().Concat(fixed_newdir);
     return true;
 }
 
@@ -420,10 +394,6 @@ static bool SetSaveGameDirectory(const FSLocation &fsdir)
 
 void SetDefaultSaveDirectory()
 {
-    // If user set a custom save dir, also keep it as a "save root", in case
-    // the game script uses Game.SetSaveGameDirectory().
-    if (!usetup.user_data_dir.IsEmpty())
-        saveGameParent = usetup.user_data_dir;
     // Request a default save location, and assign it as a save dir
     FSLocation fsdir = GetGameUserDataDir();
     SetSaveGameDirectory(fsdir);

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -75,12 +75,9 @@ int Game_GetMODPattern();
 //=============================================================================
 int Game_GetDialogCount();
 
-// Defines a custom save parent directory, which will replace $MYDOCS$/GameName
-// when a new save directory is set from the script
-bool SetCustomSaveParent(const Common::String &path);
-// If explicit_path flag is false, the actual path will be constructed
-// as a relative to system's user saves directory
-bool SetSaveGameDirectoryPath(const char *newFolder, bool explicit_path = false);
+// Sets a default save directory, based on platform driver settings and user config
+void SetDefaultSaveDirectory();
+// Sets a new save directory within the save parent; copies "restart" slot if available
 int Game_SetSaveGameDirectory(const char *newFolder);
 const char* Game_GetSaveSlotDescription(int slnum);
 

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -22,7 +22,7 @@
 #ifndef __AGS_EE_AC__PATHHELPER_H
 #define __AGS_EE_AC__PATHHELPER_H
 
-#include "util/string.h"
+#include "util/path.h"
 
 using AGS::Common::String;
 
@@ -35,9 +35,6 @@ extern const String DefaultConfigFileName;
 // Subsitutes illegal characters with '_'. This function uses illegal chars array
 // specific to current platform.
 void FixupFilename(char *filename);
-// Tests the input path, if it's an absolute path then returns it unchanged;
-// if it's a relative path then resolves it into absolute, using install dir as a base.
-String PathFromInstallDir(const String &path);
 // Checks if there is a slash after special token in the beginning of the
 // file path, and adds one if it is missing. If no token is found, string is
 // returned unchanged.
@@ -54,7 +51,18 @@ struct FSLocation
     FSLocation() = default;
     FSLocation(const String &base) : BaseDir(base), FullDir(base) {}
     FSLocation(const String &base, const String &full) : BaseDir(base), FullDir(full) {}
+    inline bool IsValid() const { return !FullDir.IsEmpty(); }
+    // Concats the given path to the existing full dir
+    inline FSLocation Concat(const String &path) const
+        { return FSLocation(BaseDir, AGS::Common::Path::ConcatPaths(FullDir, path)); }
+    // Sets full path as a relative to the existing base dir
+    inline FSLocation Rebase(const String &path) const
+        { return FSLocation(BaseDir, AGS::Common::Path::ConcatPaths(BaseDir, path)); }
 };
+// Tests the input path, if it's an absolute path then returns it unchanged;
+// if it's a relative path then resolves it into absolute, using install dir as a base.
+String PathFromInstallDir(const String &path);
+FSLocation PathFromInstallDir(const FSLocation &fsloc);
 // Makes sure that given system location is available, makes directories if have to (and if it's allowed to)
 // Returns full file path on success, empty string on failure.
 String PreparePathForWriting(const FSLocation& fsloc, const String &filename);
@@ -87,5 +95,7 @@ bool ResolveScriptPath(const String &sc_path, bool read_only, ResolvedPath &rp);
 // Returns 'true' on success, and 'false' if either path is impossible to resolve,
 // forbidden for writing, or if failed to create any subdirectories.
 bool ResolveWritePathAndCreateDirs(const String &sc_path, ResolvedPath &rp);
+// Creates all necessary subdirectories inside the safe parent location.
+bool CreateFSDirs(const FSLocation &fs);
 
 #endif // __AGS_EE_AC__PATHHELPER_H

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -108,7 +108,13 @@ PDebugOutput create_log_output(const String &name, const String &path = "", LogF
     else if (name.CompareNoCase(OutputFileID) == 0)
     {
         DebugLogFile.reset(new LogFile());
-        String logfile_path = !path.IsEmpty() ? path : Path::ConcatPaths(platform->GetAppOutputDirectory(), "ags.log");
+        String logfile_path = path;
+        if (logfile_path.IsEmpty())
+        {
+            FSLocation fs = platform->GetAppOutputDirectory();
+            CreateFSDirs(fs);
+            logfile_path = Path::ConcatPaths(fs.FullDir, "ags.log");
+        }
         if (!DebugLogFile->OpenFile(logfile_path, open_mode))
             return nullptr;
         Debug::Printf(kDbgMsg_Info, "Logging to %s", logfile_path.GetCStr());

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -670,22 +670,8 @@ void engine_init_user_directories()
     if (!usetup.shared_data_dir.IsEmpty())
         Debug::Printf(kDbgMsg_Info, "Shared data directory: %s", usetup.shared_data_dir.GetCStr());
 
-    // if end-user specified custom save path, use it
-    bool res = false;
-    if (!usetup.user_data_dir.IsEmpty())
-    {
-        res = SetCustomSaveParent(usetup.user_data_dir);
-        if (!res)
-        {
-            Debug::Printf(kDbgMsg_Warn, "WARNING: custom user save path failed, using default system paths");
-            res = false;
-        }
-    }
-    // if there is no custom path, or if custom path failed, use default system path
-    if (!res)
-    {
-        SetSaveGameDirectoryPath(Path::ConcatPaths(UserSavedgamesRootToken, game.saveGameFolderName));
-    }
+    // Initialize default save directory early, for we'll need it to set restart point
+    SetDefaultSaveDirectory();
 }
 
 #if AGS_PLATFORM_OS_ANDROID

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -674,10 +674,6 @@ void engine_init_user_directories()
     SetDefaultSaveDirectory();
 }
 
-#if AGS_PLATFORM_OS_ANDROID
-extern char android_base_directory[256];
-#endif // AGS_PLATFORM_OS_ANDROID
-
 // TODO: remake/remove this nonsense
 int check_write_access() {
 
@@ -691,21 +687,7 @@ int check_write_access() {
   String tempPath = String::FromFormat("%s""tmptest.tmp", svg_dir.GetCStr());
   Stream *temp_s = Common::File::CreateFile(tempPath);
   if (!temp_s)
-      // TODO: The fallback should be done on all platforms, and there's
-      // already similar procedure found in SetSaveGameDirectoryPath.
-      // If Android has extra dirs to fallback to, they should be provided
-      // by platform driver's method, not right here!
-#if AGS_PLATFORM_OS_ANDROID
-  {
-	  put_backslash(android_base_directory);
-      tempPath.Format("%s""tmptest.tmp", android_base_directory);
-	  temp_s = Common::File::CreateFile(tempPath);
-	  if (temp_s == NULL) return 0;
-	  else SetCustomSaveParent(android_base_directory);
-  }
-#else
     return 0;
-#endif // AGS_PLATFORM_OS_ANDROID
 
   our_eip = -1896;
 

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -46,7 +46,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual int  CDPlayerCommand(int cmdd, int datt);
   virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
-  virtual const char *GetAppOutputDirectory();
+  virtual FSLocation GetAppOutputDirectory();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
   virtual bool IsBackendResponsibleForMouseScaling() { return true; }
@@ -768,9 +768,9 @@ void AGSAndroid::ShutdownCDPlayer() {
   //cd_exit();
 }
 
-const char *AGSAndroid::GetAppOutputDirectory()
+FSLocation AGSAndroid::GetAppOutputDirectory()
 {
-  return android_base_directory;
+  return FSLocation(android_base_directory);
 }
 
 AGSPlatformDriver* AGSPlatformDriver::GetDriver() {

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -49,6 +49,7 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void DisplayAlert(const char*, ...);
   virtual FSLocation GetAllUsersDataDirectory();
   virtual FSLocation GetUserSavedgamesDirectory();
+  virtual FSLocation GetUserGlobalConfigDirectory();
   virtual FSLocation GetAppOutputDirectory();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
@@ -793,6 +794,11 @@ FSLocation AGSAndroid::GetUserSavedgamesDirectory()
   if (android_save_directory.IsEmpty())
     MakeGameSaveDirectory();
   return FSLocation(android_save_directory);
+}
+
+FSLocation AGSAndroid::GetUserGlobalConfigDirectory()
+{
+  return FSLocation(android_base_directory);
 }
 
 FSLocation AGSAndroid::GetAppOutputDirectory()

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include "util/string_compat.h"
+#include "util/file.h"
 
 
 
@@ -46,6 +47,8 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual int  CDPlayerCommand(int cmdd, int datt);
   virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
+  virtual FSLocation GetAllUsersDataDirectory();
+  virtual FSLocation GetUserSavedgamesDirectory();
   virtual FSLocation GetAppOutputDirectory();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
@@ -101,8 +104,9 @@ extern void PauseGame();
 extern void UnPauseGame();
 extern int main(int argc,char*argv[]);
 
-char android_base_directory[256];
-char android_app_directory[256];
+String android_base_directory;
+String android_app_directory;
+String android_save_directory;
 char psp_game_file_name[256];
 char* psp_game_file_name_pointer = psp_game_file_name;
 
@@ -492,12 +496,12 @@ JNIEXPORT jboolean JNICALL
   // Get the base directory (usually "/sdcard/ags").
   const char* cdirectory = java_environment->GetStringUTFChars(directory, NULL);
   chdir(cdirectory);
-  strcpy(android_base_directory, cdirectory);
+  android_base_directory = cdirectory;
   java_environment->ReleaseStringUTFChars(directory, cdirectory);
 
   // Get the app directory (something like "/data/data/com.bigbluecup.android.launcher")
   const char* cappDirectory = java_environment->GetStringUTFChars(appDirectory, NULL);
-  strcpy(android_app_directory, cappDirectory);
+  android_app_directory = cappDirectory;
   java_environment->ReleaseStringUTFChars(appDirectory, cappDirectory);
 
   // Reset configuration.
@@ -766,6 +770,29 @@ void AGSAndroid::WriteStdErr(const char *fmt, ...)
 
 void AGSAndroid::ShutdownCDPlayer() {
   //cd_exit();
+}
+
+static void MakeGameSaveDirectory()
+{
+  // Test the app dir for write access, if failed then switch to "base dir"
+  if (File::TestCreateFile("./tmptest.tmp"))
+    android_save_directory = ".";
+  else
+    android_save_directory = android_base_directory;
+}
+
+FSLocation AGSAndroid::GetAllUsersDataDirectory()
+{
+  if (android_save_directory.IsEmpty())
+    MakeGameSaveDirectory();
+  return FSLocation(android_save_directory);
+}
+
+FSLocation AGSAndroid::GetUserSavedgamesDirectory()
+{
+  if (android_save_directory.IsEmpty())
+    MakeGameSaveDirectory();
+  return FSLocation(android_save_directory);
 }
 
 FSLocation AGSAndroid::GetAppOutputDirectory()

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -15,13 +15,13 @@
 // AGS Cross-Platform Header
 //
 //=============================================================================
-
 #ifndef __AGS_EE_PLATFORM__AGSPLATFORMDRIVER_H
 #define __AGS_EE_PLATFORM__AGSPLATFORMDRIVER_H
 
 #include <errno.h>
 #include <vector>
 #include "ac/datetime.h"
+#include "ac/path_helper.h"
 #include "debug/outputhandler.h"
 #include "util/ini_util.h"
 
@@ -60,15 +60,15 @@ struct AGSPlatformDriver
     virtual void AttachToParentConsole();
     virtual int  GetLastSystemError() { return errno; }
     // Get root directory for storing per-game shared data
-    virtual const char *GetAllUsersDataDirectory() { return "."; }
+    virtual FSLocation GetAllUsersDataDirectory() { return FSLocation("."); }
     // Get root directory for storing per-game saved games
-    virtual const char *GetUserSavedgamesDirectory() { return "."; }
+    virtual FSLocation GetUserSavedgamesDirectory() { return FSLocation("."); }
     // Get root directory for storing per-game user configuration files
-    virtual const char *GetUserConfigDirectory() { return "."; }
+    virtual FSLocation GetUserConfigDirectory() { return FSLocation("."); }
     // Get directory for storing all-games user configuration files
-    virtual const char *GetUserGlobalConfigDirectory()  { return "."; }
+    virtual FSLocation GetUserGlobalConfigDirectory()  { return FSLocation("."); }
     // Get default directory for program output (logs)
-    virtual const char *GetAppOutputDirectory() { return "."; }
+    virtual FSLocation GetAppOutputDirectory() { return FSLocation("."); }
     // Returns array of characters illegal to use in file names
     virtual const char *GetIllegalFileChars() { return "\\/"; }
     virtual const char *GetDiskWriteAccessTroubleshootingText();

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -117,7 +117,7 @@ struct AGSIOS : AGSPlatformDriver {
   virtual int  CDPlayerCommand(int cmdd, int datt);
   virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
-  virtual const char *GetAppOutputDirectory();
+  virtual FSLocation GetAppOutputDirectory();
   virtual unsigned long GetDiskFreeSpaceMB();
   virtual const char* GetNoMouseErrorString();
   virtual bool IsBackendResponsibleForMouseScaling() { return true; }
@@ -630,9 +630,9 @@ void AGSIOS::ShutdownCDPlayer() {
   //cd_exit();
 }
 
-const char *AGSIOS::GetAppOutputDirectory()
+FSLocation AGSIOS::GetAppOutputDirectory()
 {
-  return ios_document_directory;
+  return FSLocation(ios_document_directory);
 }
 
 AGSPlatformDriver* AGSPlatformDriver::GetDriver() {

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -36,7 +36,7 @@ void AGSMacGetBundleDir(char gamepath[PATH_MAX]);
 //bool PlayMovie(char const *name, int skipType);
 
 static char libraryApplicationSupport[PATH_MAX];
-static char commonDataPath[PATH_MAX];
+static FSLocation commonDataPath;
 
 struct AGSMac : AGSPlatformDriver {
   AGSMac();
@@ -51,10 +51,10 @@ struct AGSMac : AGSPlatformDriver {
   virtual void SetGameWindowIcon() override;
   virtual void ShutdownCDPlayer() override;
     
-  virtual const char *GetUserSavedgamesDirectory() override;
-  virtual const char *GetAllUsersDataDirectory() override;
-  virtual const char *GetUserConfigDirectory() override;
-  virtual const char *GetAppOutputDirectory() override;
+  virtual FSLocation GetUserSavedgamesDirectory() override;
+  virtual FSLocation GetAllUsersDataDirectory() override;
+  virtual FSLocation GetUserConfigDirectory() override;
+  virtual FSLocation GetAppOutputDirectory() override;
   virtual const char *GetIllegalFileChars() override;
 };
 
@@ -62,8 +62,7 @@ AGSMac::AGSMac()
 {
   AGSMacInitPaths(libraryApplicationSupport);
   
-  snprintf(commonDataPath, PATH_MAX, "%s/uk.co.adventuregamestudio", libraryApplicationSupport);
-  AGS::Common::Directory::CreateDirectory(commonDataPath);
+  commonDataPath = FSLocation(libraryApplicationSupport).Concat("uk.co.adventuregamestudio");
 }
 
 int AGSMac::CDPlayerCommand(int cmdd, int datt) {
@@ -113,22 +112,22 @@ void AGSMac::ShutdownCDPlayer() {
   //cd_exit();
 }
 
-const char* AGSMac::GetAllUsersDataDirectory()
+FSLocation AGSMac::GetAllUsersDataDirectory()
 {
   return commonDataPath;
 }
 
-const char *AGSMac::GetUserSavedgamesDirectory()
+FSLocation AGSMac::GetUserSavedgamesDirectory()
 {
-  return libraryApplicationSupport;
+  return FSLocation(libraryApplicationSupport);
 }
 
-const char *AGSMac::GetUserConfigDirectory()
+FSLocation AGSMac::GetUserConfigDirectory()
 {
-  return libraryApplicationSupport;
+  return FSLocation(libraryApplicationSupport);
 }
 
-const char *AGSMac::GetAppOutputDirectory()
+FSLocation AGSMac::GetAppOutputDirectory()
 {
   return commonDataPath;
 }


### PR DESCRIPTION
Fixes #1459.

Opened the PR mostly to ensure it builds for all platforms and to provide a test build from the build server.
I will be testing this myself too, as there's a number of scenarios to check.

The problem was that platform drivers in AGS were unconditionally creating directories for game saves etc files at the standard paths. This changes them to not precreate any dirs, but only return the paths, letting engine create directories only if necessary. Thus not only standard dirs will not be created if user (player) provided their own in config, but they are not be created unless engine actually writes something. This complements the previous changes to the 3.5.1 engine.

For technical details, the paths are stored as a pair of "base dir"/"full dir", where "base dir" is considered not engine's business and not touched, only the part after "base dir" will be created when necessary.