### PR TITLE
Sprite file supports storing 16/32-bit sprites as indexed images with palette

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -462,7 +462,7 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index)
 #endif
 }
 
-int SpriteCache::SaveToFile(const String &filename, bool compressOutput, SpriteFileIndex &index)
+int SpriteCache::SaveToFile(const String &filename, int store_flags, bool compress, SpriteFileIndex &index)
 {
     std::vector<Bitmap*> sprites;
     for (const auto &data : _spriteData)
@@ -475,7 +475,7 @@ int SpriteCache::SaveToFile(const String &filename, bool compressOutput, SpriteF
         pre_save_sprite(data.Image);
         sprites.push_back(data.Image);
     }
-    return SaveSpriteFile(filename, sprites, &_file, compressOutput, index);
+    return SaveSpriteFile(filename, sprites, &_file, store_flags, compress, index);
 }
 
 HError SpriteCache::InitFile(const String &filename, const String &sprindex_filename)

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -69,10 +69,11 @@ public:
     // Loads sprite reference information and inits sprite stream
     HError      InitFile(const Common::String &filename, const Common::String &sprindex_filename);
     // Saves current cache contents to the file
-    int         SaveToFile(const Common::String &filename, bool compressOutput, SpriteFileIndex &index);
+    int         SaveToFile(const Common::String &filename, int store_flags, bool compress, SpriteFileIndex &index);
     // Closes an active sprite file stream
     void        DetachFile();
 
+    inline int GetStoreFlags() const { return _file.GetStoreFlags(); }
     inline bool IsFileCompressed() const { return _file.IsFileCompressed(); }
 
     // Tells if there is a sprite registered for the given index;

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -126,7 +126,6 @@ private:
     void        DisposeOldest();
 
     // Information required for the sprite streaming
-    // TODO: split into sprite cache and sprite stream data
     struct SpriteData
     {
         size_t          Size; // to track cache size

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -279,11 +279,9 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
     return HError::None();
 }
 
-HError SpriteFile::LoadSpriteData(sprkey_t index, Size &metric, int &bpp,
-    std::vector<uint8_t> &data)
+HError SpriteFile::LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data)
 {
-    metric = Size();
-    bpp = 0;
+    hdr = SpriteDatHeader();
     data.resize(0);
     if (index < 0 || (size_t)index >= _spriteData.size())
         new Error(String::FromFormat("LoadSprite: slot index %d out of bounds (%d - %d).",
@@ -295,17 +293,22 @@ HError SpriteFile::LoadSpriteData(sprkey_t index, Size &metric, int &bpp,
     SeekToSprite(index);
     _curPos = -2; // mark undefined pos
 
-    bpp = _stream->ReadInt16();
+    int bpp = _stream->ReadInt16();
     if (bpp == 0)
     { // empty slot, this is normal
         return HError::None();
     }
     int w = _stream->ReadInt16();
     int h = _stream->ReadInt16();
-    size_t data_size = _compressed ? _stream->ReadInt32() : w * h * bpp;
+    size_t data_size = w * h * bpp;
+    if (_compressed)
+    {
+        data_size = _stream->ReadInt32() + sizeof(int32_t);
+        _stream->Seek(-4);
+    }
     data.resize(data_size);
     _stream->Read(&data[0], data_size);
-    metric = Size(w, h);
+    hdr = SpriteDatHeader(bpp, w, h);
 
     _curPos = index + 1; // mark correct pos
     return HError::None();
@@ -380,15 +383,14 @@ int SaveSpriteFile(const String &save_to_file,
 
         // Not in memory - and same compression option;
         // Directly copy the sprite bytes from the input file to the output
-        Size metric;
-        int bpp;
-        read_from_file->LoadSpriteData(i, metric, bpp, membuf);
-        if (bpp == 0)
-        {
+        SpriteDatHeader hdr;
+        read_from_file->LoadRawData(i, hdr, membuf);
+        if (hdr.BPP == 0)
+        { // empty slot
             writer.WriteEmptySlot();
-            continue; // empty slot
+            continue;
         }
-        writer.WriteSpriteData(&membuf[0], membuf.size(), metric.Width, metric.Height, bpp);
+        writer.WriteRawData(hdr, &membuf[0], membuf.size());
     }
     writer.Finalize();
 
@@ -455,16 +457,44 @@ void SpriteFileWriter::WriteBitmap(Bitmap *image)
     int bpp = image->GetBPP();
     int w = image->GetWidth();
     int h = image->GetHeight();
+    const SpriteDatHeader hdr(bpp, w, h);
     if (_compress)
     {
         MemoryStream mems(_membuf, kStream_Write);
         rle_compress(image, &mems);
-        WriteSpriteData(&_membuf[0], _membuf.size(), w, h, bpp);
+        // write image data as a plain byte array
+        WriteSpriteData(hdr, &_membuf[0], _membuf.size(), 1);
         _membuf.clear();
     }
     else
     {
-        WriteSpriteData(image->GetData(), w * h * bpp, w, h, bpp);
+        WriteSpriteData(hdr, image->GetData(), w * h * bpp, bpp);
+    }
+}
+
+void SpriteFileWriter::WriteSpriteData(const SpriteDatHeader &hdr,
+    const uint8_t *im_data, size_t im_data_sz, int im_bpp)
+{
+    // Add index entry and write resulting data to the stream
+    soff_t sproff = _out->GetPosition();
+    _index.Offsets.push_back(sproff);
+    _index.Widths.push_back(hdr.Width);
+    _index.Heights.push_back(hdr.Height);
+    _out->WriteInt16(hdr.BPP);
+    _out->WriteInt16(hdr.Width);
+    _out->WriteInt16(hdr.Height);
+    // if not compressed, then the data size is supposed to be calculated
+    // from the image metrics
+    if (_compress)
+        _out->WriteInt32(im_data_sz);
+    switch (im_bpp)
+    {
+    case 1: _out->Write(im_data, im_data_sz); break;
+    case 2: _out->WriteArrayOfInt16(reinterpret_cast<const int16_t*>(im_data),
+        im_data_sz / sizeof(int16_t)); break;
+    case 4: _out->WriteArrayOfInt32(reinterpret_cast<const int32_t*>(im_data),
+        im_data_sz / sizeof(int32_t)); break;
+    default: assert(0); break;
     }
 }
 
@@ -478,23 +508,17 @@ void SpriteFileWriter::WriteEmptySlot()
     _index.Heights.push_back(0);
 }
 
-void SpriteFileWriter::WriteSpriteData(const uint8_t *pbuf, size_t len,
-    int w, int h, int bpp)
+void SpriteFileWriter::WriteRawData(const SpriteDatHeader &hdr, const uint8_t *data, size_t data_sz)
 {
     if (!_out) return;
     soff_t sproff = _out->GetPosition();
     _index.Offsets.push_back(sproff);
-    _index.Widths.push_back(w);
-    _index.Heights.push_back(h);
-    _out->WriteInt16(bpp);
-    _out->WriteInt16(w);
-    _out->WriteInt16(h);
-    // if not compressed, then the data size could be calculated from the
-    // image metrics, therefore no need to write one
-    if (_compress)
-        _out->WriteInt32(len);
-    if (len == 0) return; // bad data?
-    _out->Write(pbuf, len); // write data itself
+    _index.Widths.push_back(hdr.Width);
+    _index.Heights.push_back(hdr.Height);
+    _out->WriteInt16(hdr.BPP);
+    _out->WriteInt16(hdr.Width);
+    _out->WriteInt16(hdr.Height);
+    _out->Write(data, data_sz);
 }
 
 void SpriteFileWriter::Finalize()

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -33,6 +33,119 @@ const String SpriteFile::DefaultSpriteFileName = "acsprset.spr";
 const String SpriteFile::DefaultSpriteIndexName = "sprindex.dat";
 
 
+// Image buffer pointer, a helper struct that eases switching
+// between intermediate buffers when loading, saving or converting an image.
+template <typename T> struct ImBufferPtrT
+{
+    T        Buf = nullptr;
+    size_t   Size = 0;
+    int      BPP = 1; // byte per pixel
+
+    ImBufferPtrT() = default;
+    ImBufferPtrT(T buf, size_t sz, int bpp) : Buf(buf), Size(sz), BPP(bpp) {}
+};
+typedef ImBufferPtrT<uint8_t*> ImBufferPtr;
+typedef ImBufferPtrT<const uint8_t*> ImBufferCPtr;
+
+
+// Finds the given color's index in the palette, or returns -1 if such color is not there
+static size_t lookup_palette(uint32_t col, uint32_t palette[256], uint32_t ncols)
+{
+    for (size_t i = 0; i < ncols; ++i)
+        if (palette[i] == col) return i;
+    return -1;
+}
+
+// Converts a 16/32-bit image into the indexed 8-bit pixel data with palette;
+// NOTE: the palette will contain colors in the same format as the source image.
+// only succeeds if the total number of colors used in the image is < 257.
+static bool CreateIndexedBitmap(const Bitmap *image, std::vector<uint8_t> &dst_data,
+    uint32_t palette[256], uint32_t &pal_count)
+{
+    const int src_bpp = image->GetBPP();
+    const size_t src_size = image->GetWidth() * image->GetHeight() * image->GetBPP();
+    const size_t dst_size = image->GetWidth() * image->GetHeight();
+    dst_data.resize(dst_size);
+    const uint8_t *src = image->GetData(), *src_end = src + src_size;
+    uint8_t *dst = &dst_data[0], *dst_end = dst + dst_size;
+    pal_count = 0;
+
+    for (; src < src_end && dst < dst_end; src += src_bpp)
+    {
+        uint32_t col;
+        size_t pal_n;
+        switch (src_bpp)
+        {
+        case 2:
+            col = *((const uint16_t*)src);
+            pal_n = lookup_palette(col, palette, pal_count);
+            break;
+        case 4:
+            col = *((const uint32_t*)src);
+            pal_n = lookup_palette(col, palette, pal_count);
+            break;
+        default: assert(0); break;
+        }
+        
+        if (pal_n == -1)
+        {
+            if (pal_count == 256) return false;
+            pal_n = pal_count;
+            palette[pal_count++] = col;
+        }
+        *(dst++) = (uint8_t)pal_n;
+    }
+    return true;
+}
+
+// Unpacks an indexed image's pixel data into the 16/32-bit image;
+// NOTE: the palette is expected to contain colors in the same format as the destination.
+static void UnpackIndexedBitmap(Bitmap *image, const uint8_t *data, size_t data_size,
+    uint32_t *palette, uint32_t pal_count)
+{
+    assert(pal_count > 0);
+    if (pal_count == 0) return; // meaningless
+    const uint8_t bpp = image->GetBPP();
+    const size_t dst_size = image->GetWidth() * image->GetHeight() * image->GetBPP();
+    uint8_t *dst = image->GetDataForWriting(), *dst_end = dst + dst_size;
+    for (size_t p = 0; (p < data_size) && (dst < dst_end); ++p, dst += bpp)
+    {
+        uint8_t index = data[p];
+        assert(index < pal_count);
+        uint32_t color = (index < pal_count) ? palette[index] : palette[0];
+        switch (bpp)
+        {
+        case 2: *((uint16_t*)dst) = color; break;
+        case 4: *((uint32_t*)dst) = color; break;
+        default: assert(0); break;
+        }
+    }
+}
+
+
+static inline SpriteFormat PaletteFormatForBPP(int bpp)
+{
+    switch (bpp)
+    {
+    case 1: return kSprFmt_PaletteRgb888;
+    case 2: return kSprFmt_PaletteRgb565;
+    case 4: return kSprFmt_PaletteArgb8888;
+    }
+    return kSprFmt_Undefined;
+}
+
+static inline uint8_t GetPaletteBPP(SpriteFormat fmt)
+{
+    switch (fmt)
+    {
+    case kSprFmt_PaletteRgb888: return 3;
+    case kSprFmt_PaletteArgb8888: return 4;
+    case kSprFmt_PaletteRgb565: return 2;
+    }
+    return 0; // means no palette
+}
+
+
 SpriteFile::SpriteFile()
 {
     _compressed = false;
@@ -42,7 +155,6 @@ SpriteFile::SpriteFile()
 HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filename,
     std::vector<Size> &metrics)
 {
-    SpriteFileVersion vers;
     char buff[20];
     soff_t spr_initial_offs = 0;
     int spriteFileID = 0;
@@ -53,14 +165,15 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
 
     spr_initial_offs = _stream->GetPosition();
 
-    vers = (SpriteFileVersion)_stream->ReadInt16();
+    _version = (SpriteFileVersion)_stream->ReadInt16();
     // read the "Sprite File" signature
     _stream->ReadArray(&buff[0], 13, 1);
 
-    if (vers < kSprfVersion_Uncompressed || vers > kSprfVersion_Current)
+    if (_version < kSprfVersion_Uncompressed || _version > kSprfVersion_Current)
     {
         _stream.reset();
-        return new Error(String::FromFormat("Unsupported spriteset format (requested %d, supported %d - %d).", vers, kSprfVersion_Uncompressed, kSprfVersion_Current));
+        return new Error(String::FromFormat("Unsupported spriteset format (requested %d, supported %d - %d).", _version,
+            kSprfVersion_Uncompressed, kSprfVersion_Current));
     }
 
     // unknown version
@@ -71,32 +184,42 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
         return new Error("Uknown spriteset format.");
     }
 
-    if (vers < kSprfVersion_Compressed)
+    _storeFlags = 0;
+    if (_version < kSprfVersion_Compressed)
     {
         _compressed = false;
         // skip the palette
         _stream->Seek(256 * 3); // sizeof(RGB) * 256
     }
-    else if (vers == kSprfVersion_Compressed)
+    else if (_version == kSprfVersion_Compressed)
     {
         _compressed = true;
     }
-    else if (vers >= kSprfVersion_Last32bit)
+    else if (_version >= kSprfVersion_Last32bit)
     {
         _compressed = (_stream->ReadInt8() == 1);
         spriteFileID = _stream->ReadInt32();
     }
 
     sprkey_t topmost;
-    if (vers < kSprfVersion_HighSpriteLimit)
+    if (_version < kSprfVersion_HighSpriteLimit)
         topmost = (uint16_t)_stream->ReadInt16();
     else
         topmost = _stream->ReadInt32();
-    if (vers < kSprfVersion_Uncompressed)
+    if (_version < kSprfVersion_Uncompressed)
         topmost = 200;
 
     _spriteData.resize(topmost + 1);
     metrics.resize(topmost + 1);
+
+    // Version 12+: read global store flags
+    if (_version >= kSprfVersion_StorageFormats)
+    {
+        _storeFlags = _stream->ReadInt8();
+        _stream->ReadInt8(); // reserved
+        _stream->ReadInt8();
+        _stream->ReadInt8();
+    }
 
     // if there is a sprite index file, use it
     if (LoadSpriteIndexFile(sprindex_filename, spriteFileID,
@@ -107,13 +230,18 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
     }
 
     // Failed, index file is invalid; index sprites manually
-    return RebuildSpriteIndex(_stream.get(), topmost, vers, metrics);
+    return RebuildSpriteIndex(_stream.get(), topmost, _version, metrics);
 }
 
 void SpriteFile::Close()
 {
     _stream.reset();
     _curPos = -2;
+}
+
+int SpriteFile::GetStoreFlags() const
+{
+    return _storeFlags;
 }
 
 bool SpriteFile::IsFileCompressed() const
@@ -204,6 +332,24 @@ bool SpriteFile::LoadSpriteIndexFile(const String &filename, int expectedFileID,
     return true;
 }
 
+static inline void ReadSprHeader(SpriteDatHeader &hdr, Stream *in,
+    const SpriteFileVersion ver, int gl_compress)
+{
+    int bpp = in->ReadInt8();
+    SpriteFormat sformat = (SpriteFormat)in->ReadInt8();
+    // note we MUST read first 2 * int8 before skipping rest
+    if (bpp == 0) { hdr = SpriteDatHeader(); return; } // empty slot
+    int compress = gl_compress, pal_count = 0;
+    if (ver >= kSprfVersion_StorageFormats)
+    {
+        pal_count = (uint8_t)in->ReadInt8() + 1; // saved as (count - 1)
+        compress = in->ReadInt8();
+    }
+    int w = in->ReadInt16();
+    int h = in->ReadInt16();
+    hdr = SpriteDatHeader(bpp, sformat, pal_count, compress, w, h);
+}
+
 HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost,
     SpriteFileVersion vers, std::vector<Size> &metrics)
 {
@@ -211,13 +357,13 @@ HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost,
     for (sprkey_t i = 0; !in->EOS() && (i <= topmost); ++i)
     {
         _spriteData[i].Offset = in->GetPosition();
-        int bpp = in->ReadInt16();
-        if (bpp == 0) continue; // empty slot
-        int w = in->ReadInt16();
-        int h = in->ReadInt16();
-        metrics[i].Width = w;
-        metrics[i].Height = h;
-        size_t data_sz = _compressed ? in->ReadInt32() : w * h * bpp;
+        SpriteDatHeader hdr;
+        ReadSprHeader(hdr, _stream.get(), _version, _compressed ? 1 : 0);
+        if (hdr.BPP == 0) return HError::None(); // empty slot, this is normal
+        int pal_bpp = GetPaletteBPP(hdr.SFormat);
+        if (pal_bpp > 0) in->Seek(hdr.PalCount * pal_bpp); // skip palette
+        size_t data_sz = ((_version >= kSprfVersion_StorageFormats) || _compressed) ?
+            (uint32_t)in->ReadInt32() : hdr.Width * hdr.Height * hdr.BPP;
         in->Seek(data_sz); // skip image data
     }
     return HError::None();
@@ -236,42 +382,62 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
     SeekToSprite(index);
     _curPos = -2; // mark undefined pos
 
-    int bpp = _stream->ReadInt16();
-    if (bpp == 0)
-    { // empty slot, this is normal
-        return HError::None();
-    }
-    int w = _stream->ReadInt16();
-    int h = _stream->ReadInt16();
+    SpriteDatHeader hdr;
+    ReadSprHeader(hdr, _stream.get(), _version, _compressed ? 1 : 0);
+    if (hdr.BPP == 0) return HError::None(); // empty slot, this is normal
+    int bpp = hdr.BPP, w = hdr.Width, h = hdr.Height;
     Bitmap *image = BitmapHelper::CreateBitmap(w, h, bpp * 8);
     if (image == nullptr)
     {
         return new Error(String::FromFormat("LoadSprite: failed to allocate bitmap %d (%dx%d%d).",
             index, w, h, bpp * 8));
     }
-
+    ImBufferPtr im_data(image->GetDataForWriting(), w * h * bpp, bpp);
+    // (Optional) Handle storage options, reverse
+    std::vector<uint8_t> indexed_buf;
+    uint32_t palette[256];
+    uint32_t pal_bpp = GetPaletteBPP(hdr.SFormat);
+    if (pal_bpp > 0)
+    { // read palette if format assumes one
+        switch (pal_bpp)
+        {
+        case 2: for (uint32_t i = 0; i < hdr.PalCount; ++i) palette[i] = _stream->ReadInt16(); break;
+        case 4: for (uint32_t i = 0; i < hdr.PalCount; ++i) palette[i] = _stream->ReadInt32(); break;
+        default: assert(0); break;
+        }
+        indexed_buf.resize(w * h);
+        im_data = ImBufferPtr(&indexed_buf[0], indexed_buf.size(), 1);
+    }
+    // (Optional) Decompress the image data into the temp buffer
+    size_t in_data_size = ((_version >= kSprfVersion_StorageFormats) || _compressed) ?
+        (uint32_t)_stream->ReadInt32() : (w * h * bpp);
     if (_compressed)
     {
-        size_t data_size = _stream->ReadInt32();
-        if (data_size == 0)
+        if (in_data_size == 0)
         {
             delete image;
             return new Error(String::FromFormat("LoadSprite: bad compressed data for sprite %d.", index));
         }
-        rle_decompress(image->GetDataForWriting(), w * h * bpp, bpp, _stream.get());
+        rle_decompress(im_data.Buf, im_data.Size, im_data.BPP, _stream.get());
         // TODO: test that not more than data_size was read!
     }
+    // Otherwise (no compression) read directly
     else
     {
-        switch (bpp)
+        switch (im_data.BPP)
         {
-        case 1: _stream->Read(image->GetDataForWriting(), w * h); break;
+        case 1: _stream->Read(im_data.Buf, im_data.Size); break;
         case 2: _stream->ReadArrayOfInt16(
-            reinterpret_cast<int16_t*>(image->GetDataForWriting()), w * h); break;
+            reinterpret_cast<int16_t*>(im_data.Buf), im_data.Size / sizeof(int16_t)); break;
         case 4: _stream->ReadArrayOfInt32(
-            reinterpret_cast<int32_t*>(image->GetDataForWriting()), w * h); break;
-        default: assert(0); break;
+            reinterpret_cast<int32_t*>(im_data.Buf), im_data.Size / sizeof(int32_t)); break;
+        default: assert(0);
         }
+    }
+    // Finally revert storage options
+    if (pal_bpp > 0)
+    {
+        UnpackIndexedBitmap(image, im_data.Buf, im_data.Size, palette, hdr.PalCount);
     }
 
     sprite = image;
@@ -293,22 +459,19 @@ HError SpriteFile::LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector
     SeekToSprite(index);
     _curPos = -2; // mark undefined pos
 
-    int bpp = _stream->ReadInt16();
-    if (bpp == 0)
-    { // empty slot, this is normal
-        return HError::None();
-    }
-    int w = _stream->ReadInt16();
-    int h = _stream->ReadInt16();
-    size_t data_size = w * h * bpp;
-    if (_compressed)
-    {
-        data_size = _stream->ReadInt32() + sizeof(int32_t);
-        _stream->Seek(-4);
-    }
+    ReadSprHeader(hdr, _stream.get(), _version, _compressed ? 1 : 0);
+    if (hdr.BPP == 0) return HError::None(); // empty slot, this is normal
+    size_t data_size = 0;
+    soff_t data_pos = _stream->GetPosition();
+    // Optional palette
+    data_size += hdr.PalCount * GetPaletteBPP(hdr.SFormat);
+    if ((_version >= kSprfVersion_StorageFormats) || _compressed)
+        data_size += (uint32_t)_stream->ReadInt32() + sizeof(uint32_t);
+    else
+        data_size += hdr.Width * hdr.Height * hdr.BPP;
     data.resize(data_size);
+    _stream->Seek(data_pos);
     _stream->Read(&data[0], data_size);
-    hdr = SpriteDatHeader(bpp, w, h);
 
     _curPos = index + 1; // mark correct pos
     return HError::None();
@@ -338,7 +501,7 @@ static sprkey_t FindTopmostSprite(const std::vector<Bitmap*> &sprites)
 int SaveSpriteFile(const String &save_to_file,
     const std::vector<Bitmap*> &sprites,
     SpriteFile *read_from_file,
-    bool compressOutput, SpriteFileIndex &index)
+    int store_flags, bool compress, SpriteFileIndex &index)
 {
     std::unique_ptr<Stream> output(File::CreateFile(save_to_file));
     if (output == nullptr)
@@ -348,13 +511,16 @@ int SaveSpriteFile(const String &save_to_file,
     lastslot = std::max(lastslot, FindTopmostSprite(sprites));
 
     SpriteFileWriter writer(std::move(output));
-    writer.Begin(compressOutput, lastslot);
+    writer.Begin(store_flags, compress, lastslot);
 
     std::unique_ptr<Bitmap> temp_bmp; // for disposing temp sprites
     std::vector<uint8_t> membuf; // for loading raw sprite data
+    std::vector<uint32_t> palette;
 
     const bool diff_compress =
-        read_from_file && read_from_file->IsFileCompressed() != compressOutput;
+        read_from_file &&
+        (read_from_file->IsFileCompressed() != compress ||
+        read_from_file->GetStoreFlags() != store_flags);
 
     for (sprkey_t i = 0; i <= lastslot; ++i)
     {
@@ -424,11 +590,12 @@ int SaveSpriteIndex(const String &filename, const SpriteFileIndex &index)
 }
 
 
-void SpriteFileWriter::Begin(bool compressed, sprkey_t last_slot)
+void SpriteFileWriter::Begin(int store_flags, bool compress, sprkey_t last_slot)
 {
     if (!_out) return;
     _index.SpriteFileIDCheck = (int)time(nullptr);
-    _compress = compressed;
+    _storeFlags = store_flags;
+    _compress = compress;
 
     // sprite file version
     _out->WriteInt16(kSprfVersion_Current);
@@ -441,6 +608,11 @@ void SpriteFileWriter::Begin(bool compressed, sprkey_t last_slot)
     // and write correct one; this is done in Finalize().
     _lastSlotPos = _out->GetPosition();
     _out->WriteInt32(last_slot);
+
+    _out->WriteInt8(_storeFlags);
+    _out->WriteInt8(0); // reserved
+    _out->WriteInt8(0);
+    _out->WriteInt8(0);
 
     if (last_slot >= 0)
     { // allocate buffers to store the indexing info
@@ -457,36 +629,69 @@ void SpriteFileWriter::WriteBitmap(Bitmap *image)
     int bpp = image->GetBPP();
     int w = image->GetWidth();
     int h = image->GetHeight();
-    const SpriteDatHeader hdr(bpp, w, h);
+    ImBufferCPtr im_data(image->GetData(), w * h * bpp, bpp);
+    // (Optional) Handle storage options
+    std::vector<uint8_t> indexed_buf;
+    uint32_t palette[256];
+    uint32_t pal_count = 0;
+    SpriteFormat sformat = kSprFmt_Undefined;
+    int compress = 0;
+    if ((_storeFlags & kSprStore_OptimizeForSize) != 0 && (image->GetBPP() > 1))
+    { // Try to store this sprite as an indexed bitmap
+        if (CreateIndexedBitmap(image, indexed_buf, palette, pal_count) && pal_count > 0)
+        {
+            sformat = PaletteFormatForBPP(image->GetBPP());
+            im_data = ImBufferCPtr(&indexed_buf[0], indexed_buf.size(), 1);
+        }
+    }
+    // (Optional) Compress the image data into the temp buffer
     if (_compress)
     {
+        compress = 1;
         MemoryStream mems(_membuf, kStream_Write);
-        rle_compress(image->GetData(), w * h * bpp, bpp, &mems);
-        // write image data as a plain byte array
-        WriteSpriteData(hdr, &_membuf[0], _membuf.size(), 1);
-        _membuf.clear();
+        rle_compress(im_data.Buf, im_data.Size, im_data.BPP, &mems);
+        // mark to write as a plain byte array
+        im_data = ImBufferCPtr(&_membuf[0], _membuf.size(), 1);
     }
-    else
-    {
-        WriteSpriteData(hdr, image->GetData(), w * h * bpp, bpp);
-    }
+    // Write the final data
+    SpriteDatHeader hdr(bpp, sformat, pal_count, compress, w, h);
+    WriteSpriteData(hdr, im_data.Buf, im_data.Size, im_data.BPP, palette);
+    _membuf.clear();
+}
+
+static inline void WriteSprHeader(const SpriteDatHeader &hdr, Stream *out)
+{
+    out->WriteInt8(hdr.BPP);
+    out->WriteInt8(hdr.SFormat);
+    out->WriteInt8(hdr.PalCount > 0 ? (uint8_t)(hdr.PalCount - 1) : 0);
+    out->WriteInt8(hdr.Compress);
+    out->WriteInt16(hdr.Width);
+    out->WriteInt16(hdr.Height);
 }
 
 void SpriteFileWriter::WriteSpriteData(const SpriteDatHeader &hdr,
-    const uint8_t *im_data, size_t im_data_sz, int im_bpp)
+    const uint8_t *im_data, size_t im_data_sz, int im_bpp,
+    const uint32_t palette[256])
 {
     // Add index entry and write resulting data to the stream
     soff_t sproff = _out->GetPosition();
     _index.Offsets.push_back(sproff);
     _index.Widths.push_back(hdr.Width);
     _index.Heights.push_back(hdr.Height);
-    _out->WriteInt16(hdr.BPP);
-    _out->WriteInt16(hdr.Width);
-    _out->WriteInt16(hdr.Height);
-    // if not compressed, then the data size is supposed to be calculated
-    // from the image metrics
-    if (_compress)
-        _out->WriteInt32(im_data_sz);
+    WriteSprHeader(hdr, _out.get());
+    // write palette, if available
+    int pal_bpp = GetPaletteBPP(hdr.SFormat);
+    if (pal_bpp > 0)
+    {
+        assert(hdr.PalCount > 0);
+        switch (pal_bpp)
+        {
+        case 2: for (uint32_t i = 0; i < hdr.PalCount; ++i) _out->WriteInt16(palette[i]);
+        case 4: for (uint32_t i = 0; i < hdr.PalCount; ++i) _out->WriteInt32(palette[i]);
+        }
+    }
+    // write the image pixel data
+    _out->WriteInt32(im_data_sz);
     switch (im_bpp)
     {
     case 1: _out->Write(im_data, im_data_sz); break;
@@ -515,9 +720,7 @@ void SpriteFileWriter::WriteRawData(const SpriteDatHeader &hdr, const uint8_t *d
     _index.Offsets.push_back(sproff);
     _index.Widths.push_back(hdr.Width);
     _index.Heights.push_back(hdr.Height);
-    _out->WriteInt16(hdr.BPP);
-    _out->WriteInt16(hdr.Width);
-    _out->WriteInt16(hdr.Height);
+    WriteSprHeader(hdr, _out.get());
     _out->Write(data, data_sz);
 }
 

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -71,24 +71,20 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
         return new Error("Uknown spriteset format.");
     }
 
-    if (vers == kSprfVersion_Uncompressed)
+    if (vers < kSprfVersion_Compressed)
     {
-        this->_compressed = false;
+        _compressed = false;
+        // skip the palette
+        _stream->Seek(256 * 3); // sizeof(RGB) * 256
     }
     else if (vers == kSprfVersion_Compressed)
     {
-        this->_compressed = true;
+        _compressed = true;
     }
     else if (vers >= kSprfVersion_Last32bit)
     {
-        this->_compressed = (_stream->ReadInt8() == 1);
+        _compressed = (_stream->ReadInt8() == 1);
         spriteFileID = _stream->ReadInt32();
-    }
-
-    if (vers < kSprfVersion_Compressed)
-    {
-        // skip the palette
-        _stream->Seek(256 * 3); // sizeof(RGB) * 256
     }
 
     sprkey_t topmost;
@@ -211,44 +207,18 @@ bool SpriteFile::LoadSpriteIndexFile(const String &filename, int expectedFileID,
 HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost,
     SpriteFileVersion vers, std::vector<Size> &metrics)
 {
-    for (sprkey_t i = 0; i <= topmost; ++i)
+    topmost = std::min(topmost, (sprkey_t)_spriteData.size() - 1);
+    for (sprkey_t i = 0; !in->EOS() && (i <= topmost); ++i)
     {
         _spriteData[i].Offset = in->GetPosition();
-
-        int coldep = in->ReadInt16();
-
-        if (coldep == 0)
-        {
-            if (in->EOS())
-                break;
-            continue;
-        }
-
-        if (in->EOS())
-            break;
-
-        if ((size_t)i >= _spriteData.size())
-            break;
-
-        int wdd = in->ReadInt16();
-        int htt = in->ReadInt16();
-        metrics[i].Width = wdd;
-        metrics[i].Height = htt;
-
-        size_t spriteDataSize;
-        if (vers == kSprfVersion_Compressed)
-        {
-            spriteDataSize = in->ReadInt32();
-        }
-        else if (vers >= kSprfVersion_Last32bit)
-        {
-            spriteDataSize = this->_compressed ? in->ReadInt32() : wdd * coldep * htt;
-        }
-        else
-        {
-            spriteDataSize = wdd * coldep * htt;
-        }
-        in->Seek(spriteDataSize);
+        int bpp = in->ReadInt16();
+        if (bpp == 0) continue; // empty slot
+        int w = in->ReadInt16();
+        int h = in->ReadInt16();
+        metrics[i].Width = w;
+        metrics[i].Height = h;
+        size_t data_sz = _compressed ? in->ReadInt32() : w * h * bpp;
+        in->Seek(data_sz); // skip image data
     }
     return HError::None();
 }
@@ -266,19 +236,18 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
     SeekToSprite(index);
     _curPos = -2; // mark undefined pos
 
-    int coldep = _stream->ReadInt16();
-    if (coldep == 0)
+    int bpp = _stream->ReadInt16();
+    if (bpp == 0)
     { // empty slot, this is normal
         return HError::None();
     }
-
-    int wdd = _stream->ReadInt16();
-    int htt = _stream->ReadInt16();
-    Bitmap *image = BitmapHelper::CreateBitmap(wdd, htt, coldep * 8);
+    int w = _stream->ReadInt16();
+    int h = _stream->ReadInt16();
+    Bitmap *image = BitmapHelper::CreateBitmap(w, h, bpp * 8);
     if (image == nullptr)
     {
         return new Error(String::FromFormat("LoadSprite: failed to allocate bitmap %d (%dx%d%d).",
-            index, wdd, htt, coldep * 8));
+            index, w, h, bpp * 8));
     }
 
     if (_compressed)
@@ -290,25 +259,21 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
             return new Error(String::FromFormat("LoadSprite: bad compressed data for sprite %d.", index));
         }
         rle_decompress(image, _stream.get());
+        // TODO: test that not more than data_size was read!
     }
     else
     {
-        if (coldep == 1)
+        switch (bpp)
         {
-            for (int h = 0; h < htt; ++h)
-                _stream->ReadArray(&image->GetScanLineForWriting(h)[0], coldep, wdd);
-        }
-        else if (coldep == 2)
-        {
-            for (int h = 0; h < htt; ++h)
-                _stream->ReadArrayOfInt16((int16_t*)&image->GetScanLineForWriting(h)[0], wdd);
-        }
-        else
-        {
-            for (int h = 0; h < htt; ++h)
-                _stream->ReadArrayOfInt32((int32_t*)&image->GetScanLineForWriting(h)[0], wdd);
+        case 1: _stream->Read(image->GetDataForWriting(), w * h); break;
+        case 2: _stream->ReadArrayOfInt16(
+            reinterpret_cast<int16_t*>(image->GetDataForWriting()), w * h); break;
+        case 4: _stream->ReadArrayOfInt32(
+            reinterpret_cast<int32_t*>(image->GetDataForWriting()), w * h); break;
+        default: assert(0); break;
         }
     }
+
     sprite = image;
     _curPos = index + 1; // mark correct pos
     return HError::None();
@@ -319,6 +284,7 @@ HError SpriteFile::LoadSpriteData(sprkey_t index, Size &metric, int &bpp,
 {
     metric = Size();
     bpp = 0;
+    data.resize(0);
     if (index < 0 || (size_t)index >= _spriteData.size())
         new Error(String::FromFormat("LoadSprite: slot index %d out of bounds (%d - %d).",
             index, 0, _spriteData.size() - 1));
@@ -329,27 +295,18 @@ HError SpriteFile::LoadSpriteData(sprkey_t index, Size &metric, int &bpp,
     SeekToSprite(index);
     _curPos = -2; // mark undefined pos
 
-    int coldep = _stream->ReadInt16();
-    if (coldep == 0)
+    bpp = _stream->ReadInt16();
+    if (bpp == 0)
     { // empty slot, this is normal
-        metric = Size();
-        bpp = 0;
-        data.resize(0);
         return HError::None();
     }
-
-    int width = _stream->ReadInt16();
-    int height = _stream->ReadInt16();
-
-    size_t data_size;
-    if (_compressed)
-        data_size = _stream->ReadInt32();
-    else
-        data_size = width * height * coldep;
+    int w = _stream->ReadInt16();
+    int h = _stream->ReadInt16();
+    size_t data_size = _compressed ? _stream->ReadInt32() : w * h * bpp;
     data.resize(data_size);
     _stream->Read(&data[0], data_size);
-    metric = Size(width, height);
-    bpp = coldep;
+    metric = Size(w, h);
+
     _curPos = index + 1; // mark correct pos
     return HError::None();
 }
@@ -456,9 +413,9 @@ int SaveSpriteIndex(const String &filename, const SpriteFileIndex &index)
     out->WriteInt32(index.GetCount());
     if (index.GetCount() > 0)
     {
-        out->WriteArrayOfInt16(&index.Widths.front(), index.Widths.size());
-        out->WriteArrayOfInt16(&index.Heights.front(), index.Heights.size());
-        out->WriteArrayOfInt64(&index.Offsets.front(), index.Offsets.size());
+        out->WriteArrayOfInt16(&index.Widths[0], index.Widths.size());
+        out->WriteArrayOfInt16(&index.Heights[0], index.Heights.size());
+        out->WriteArrayOfInt64(&index.Offsets[0], index.Offsets.size());
     }
     delete out;
     return 0;
@@ -495,7 +452,7 @@ void SpriteFileWriter::Begin(bool compressed, sprkey_t last_slot)
 void SpriteFileWriter::WriteBitmap(Bitmap *image)
 {
     if (!_out) return;
-    int bpp = image->GetColorDepth() / 8;
+    int bpp = image->GetBPP();
     int w = image->GetWidth();
     int h = image->GetHeight();
     if (_compress)

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -258,7 +258,7 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
             delete image;
             return new Error(String::FromFormat("LoadSprite: bad compressed data for sprite %d.", index));
         }
-        rle_decompress(image, _stream.get());
+        rle_decompress(image->GetDataForWriting(), w * h * bpp, bpp, _stream.get());
         // TODO: test that not more than data_size was read!
     }
     else
@@ -461,7 +461,7 @@ void SpriteFileWriter::WriteBitmap(Bitmap *image)
     if (_compress)
     {
         MemoryStream mems(_membuf, kStream_Write);
-        rle_compress(image, &mems);
+        rle_compress(image->GetData(), w * h * bpp, bpp, &mems);
         // write image data as a plain byte array
         WriteSpriteData(hdr, &_membuf[0], _membuf.size(), 1);
         _membuf.clear();

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -45,7 +45,8 @@ enum SpriteFileVersion
     kSprfVersion_Last32bit = 6,
     kSprfVersion_64bit = 10,
     kSprfVersion_HighSpriteLimit = 11,
-    kSprfVersion_Current = kSprfVersion_HighSpriteLimit
+    kSprfVersion_StorageFormats = 12,
+    kSprfVersion_Current = kSprfVersion_StorageFormats
 };
 
 enum SpriteIndexFileVersion
@@ -55,6 +56,26 @@ enum SpriteIndexFileVersion
     kSpridxfVersion_64bit = 10,
     kSpridxfVersion_HighSpriteLimit = 11,
     kSpridxfVersion_Current = kSpridxfVersion_HighSpriteLimit
+};
+
+// Instructions to how the sprites are allowed to be stored
+enum SpriteStorage
+{
+    // When possible convert the sprite into another format for less disk space
+    // e.g. save 16/32-bit images as 8-bit colormaps with palette
+    kSprStore_OptimizeForSize = 0x01
+};
+
+// Format in which the sprite's pixel data is stored
+enum SpriteFormat
+{
+    kSprFmt_Undefined       = 0, // undefined, or keep as-is
+    // Encoded as a 8-bit colormap with palette of 24-bit RGB values
+    kSprFmt_PaletteRgb888   = 32,
+    // Encoded as a 8-bit colormap with palette of 32-bit ARGB values
+    kSprFmt_PaletteArgb8888 = 33,
+    // Encoded as a 8-bit colormap with palette of 16-bit RGB565 values
+    kSprFmt_PaletteRgb565   = 34
 };
 
 typedef int32_t sprkey_t;
@@ -74,13 +95,18 @@ struct SpriteFileIndex
 // Invidual sprite data header (as read from the file)
 struct SpriteDatHeader
 {
-    int BPP = 0; // color depth (bytes per pixel)
-    int Width = 0;
-    int Height = 0;
+    int BPP = 0; // color depth (bytes per pixel); or input format
+    SpriteFormat SFormat = kSprFmt_Undefined; // storage format
+    uint32_t PalCount = 0; // palette length, if applicable to storage format
+    int Compress = 0; // compression type
+    int Width = 0; // sprite's width
+    int Height = 0; // sprite's height
 
     SpriteDatHeader() = default;
-    SpriteDatHeader(int bpp, int w = 0, int h = 0)
-        : BPP(bpp), Width(w), Height(h) {}
+    SpriteDatHeader(int bpp, SpriteFormat sformat = kSprFmt_Undefined,
+        uint32_t pal_count = 0, int compress = 0, int w = 0, int h = 0)
+        : BPP(bpp), SFormat(sformat), PalCount(pal_count),
+          Compress(compress), Width(w), Height(h) {}
 };
 
 
@@ -100,6 +126,7 @@ public:
     // Closes stream; no reading will be possible unless opened again
     void        Close();
 
+    int         GetStoreFlags() const;
     // Tells if bitmaps in the file are compressed
     bool        IsFileCompressed() const;
     // Tells the highest known sprite index
@@ -116,6 +143,8 @@ public:
     HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
     // Loads a raw sprite element data into the buffer, stores header info separately
     HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
+    HError      LoadSpriteData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data,
+        std::vector<uint32_t> &palette);
 
 private:
     // Seek stream to sprite
@@ -132,6 +161,8 @@ private:
     // Array of sprite references
     std::vector<SpriteRef> _spriteData;
     std::unique_ptr<Stream> _stream; // the sprite stream
+    SpriteFileVersion _version = kSprfVersion_Current;
+    int _storeFlags = 0; // storage flags, specify how sprites may be stored
     bool _compressed; // are sprites compressed
     sprkey_t _curPos; // current stream position (sprite slot)
 };
@@ -151,7 +182,7 @@ public:
     const SpriteFileIndex &GetIndex() const { return _index; }
 
     // Initializes new sprite file format
-    void Begin(bool compress, sprkey_t last_slot = -1);
+    void Begin(int store_flags, bool compress, sprkey_t last_slot = -1);
     // Writes a bitmap into file, compressing if necessary
     void WriteBitmap(Bitmap *image);
     // Writes an empty slot marker
@@ -163,9 +194,12 @@ public:
 
 private:
     // Writes prepared image data in a proper file format, following explicit data_bpp rule
-    void WriteSpriteData(const SpriteDatHeader &hdr, const uint8_t *im_data, size_t im_data_sz, int im_bpp);
+    void WriteSpriteData(const SpriteDatHeader &hdr,
+        const uint8_t *im_data, size_t im_data_sz, int im_bpp,
+        const uint32_t palette[256]);
 
     std::unique_ptr<Stream> _out;
+    int _storeFlags = 0;
     bool _compress = false;
     soff_t _lastSlotPos = -1; // last slot save position in file
     // sprite index accumulated on write for reporting back to user
@@ -180,7 +214,7 @@ private:
 int SaveSpriteFile(const String &save_to_file,
     const std::vector<Bitmap*> &sprites, // available sprites (may contain nullptrs)
     SpriteFile *read_from_file, // optional file to read missing sprites from
-    bool compressOutput, SpriteFileIndex &index);
+    int store_flags, bool compress, SpriteFileIndex &index);
 // Saves sprite index table in a separate file
 int SaveSpriteIndex(const String &filename, const SpriteFileIndex &index);
 

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -71,6 +71,18 @@ struct SpriteFileIndex
     inline sprkey_t GetLastSlot() const { return (sprkey_t)GetCount() - 1; }
 };
 
+// Invidual sprite data header (as read from the file)
+struct SpriteDatHeader
+{
+    int BPP = 0; // color depth (bytes per pixel)
+    int Width = 0;
+    int Height = 0;
+
+    SpriteDatHeader() = default;
+    SpriteDatHeader(int bpp, int w = 0, int h = 0)
+        : BPP(bpp), Width(w), Height(h) {}
+};
+
 
 // SpriteFile opens a sprite file for reading, reports general information,
 // and lets read sprites in any order.
@@ -102,8 +114,8 @@ public:
 
     // Loads an image data and creates a ready bitmap
     HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
-    // Loads an image data into the buffer, reports the bitmap metrics and color depth
-    HError      LoadSpriteData(sprkey_t index, Size &metric, int &bpp, std::vector<uint8_t> &data);
+    // Loads a raw sprite element data into the buffer, stores header info separately
+    HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
 
 private:
     // Seek stream to sprite
@@ -144,12 +156,15 @@ public:
     void WriteBitmap(Bitmap *image);
     // Writes an empty slot marker
     void WriteEmptySlot();
-    // Writes a raw sprite data without additional processing
-    void WriteSpriteData(const uint8_t *pbuf, size_t len, int w, int h, int bpp);
+    // Writes a raw sprite data without any additional processing
+    void WriteRawData(const SpriteDatHeader &hdr, const uint8_t *data, size_t data_sz);
     // Finalizes current format; no further writing is possible after this
     void Finalize();
 
 private:
+    // Writes prepared image data in a proper file format, following explicit data_bpp rule
+    void WriteSpriteData(const SpriteDatHeader &hdr, const uint8_t *im_data, size_t im_data_sz, int im_bpp);
+
     std::unique_ptr<Stream> _out;
     bool _compress = false;
     soff_t _lastSlotPos = -1; // last slot save position in file

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -113,7 +113,8 @@ private:
     struct SpriteRef
     {
         soff_t Offset = 0; // data offset
-        size_t Size = 0;   // cache size of element, in bytes
+        size_t RawSize = 0; // file size of element, in bytes
+        // TODO: RawSize is currently unused, due to incompleteness of spriteindex format
     };
 
     // Array of sprite references

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -20,8 +20,8 @@ namespace AGS { namespace Common { class Stream; class Bitmap; } }
 using namespace AGS; // FIXME later
 
 // RLE compression
-void rle_compress(Common::Bitmap*, Common::Stream*);
-void rle_decompress(Common::Bitmap*, Common::Stream*);
+void rle_compress(const uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *out);
+void rle_decompress(uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *in);
 
 // LZW compression
 void save_lzw(Common::Stream *out, const Common::Bitmap *bmpp, const RGB *pall);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -65,7 +65,7 @@ extern HAGSError extract_template_files(const AGSString &templateFileName);
 extern HAGSError extract_room_template_files(const AGSString &templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
 extern void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes);
-extern void SaveGame(bool compressSprites);
+extern void SaveNativeSprites(Settings^ gameSettings);
 extern HAGSError reset_sprite_file();
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
 extern void GameDirChanged(String ^workingDir);
@@ -210,7 +210,7 @@ namespace AGS
 
 		void NativeMethods::SaveGame(Game ^game)
 		{
-			::SaveGame(game->Settings->CompressSprites);
+			::SaveNativeSprites(game->Settings);
 		}
 
 		void NativeMethods::GameSettingsChanged(Game ^game)

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -60,6 +60,7 @@ namespace AGS.Types
         private RoomTransitionStyle _roomTransition = RoomTransitionStyle.FadeOutAndIn;
         private bool _saveScreenshots = false;
         private bool _compressSprites = false;
+        private bool _optimizeSpriteStorage = true;
         private bool _inventoryCursors = true;
         private bool _handleInvInScript = false;
         private bool _displayMultipleInv = false;
@@ -334,6 +335,16 @@ namespace AGS.Types
         {
             get { return _compressSprites; }
             set { _compressSprites = value; }
+        }
+
+        [DisplayName("Enable sprite storage optimization")]
+        [Description("When possible save sprites in game files in a format that requires less storage space. This may reduce the compiled game size on disk, but effect may differ depending on number of colors used in sprites, and other factors.")]
+        [DefaultValue(true)]
+        [Category("Compiler")]
+        public bool OptimizeSpriteStorage
+        {
+            get { return _optimizeSpriteStorage; }
+            set { _optimizeSpriteStorage = value; }
         }
 
         [DisplayName("Save screenshots in save games")]


### PR DESCRIPTION
Resolves #983.

### General information

This permits sprite file to store 16 and 32-bit sprites as indexed images (8-bit) with palette *when possible*. This is a form of a lossless compression, and does not change anything in the game looks.

The idea is that the sprite writer will calculate the number of individual colors within the sprite, and if that number is lower than 257, it will create a palette of these colors and convert the sprite to a 8-bit image using palette. The result of this conversion is then saved into the spritefile.

**IMPORTANT:** this *does not affect* how the loaded sprites are stored in the program memory (whether in the Engine or Editor). Only how they are saved in the compiled spritefile.

On success may reduce eligible 32-bit sprites roughly 4 times (not precisely, as palette also takes space), and 16-bit sprites 2 times.

The effect of this method will vary from game to game. It's ideal for the 32-bit games with simplier graphics and less colors used per sprite. While games with highly detailed graphics will likely get little to no improvement.

**NOTE:** this method is separate from existing compression, and may actually be used in combination with it, decreasing sprite sizes even further.

**Editor**

In the Editor's General Settings this adds "Enable sprite storage optimization" option. It is **ENABLED** by default.
(I decided to give this option more generic name to make it easier, and just in case we'll add something else in the future)

---

### Format changes

**Sprite File's header**

Sprite file's version is increased to 12.
In the file's header 4 more bytes are appended to the end of meta data. First byte contains "sprite storage flags", which is a collection of flags describing which storage methods were allowed when writing this file. This is purely for information, for Editor  or other tools that may want to know this. Other 3 bytes are reserved.

**Sprite format**

Current format looks like this:

bytes | meaning
-- | --
2 | color depth (bytes per pixel)
2 | width
2 | height
4 | _optional_ size of pixel data, in bytes, only written when the sprite is compressed
N | sprite's pixel data, optionally compressed

The new format will look like:

bytes | meaning
-- | --
1 | color depth (bytes per pixel), may be turned into input format enum
1 | storage format (enum)
1 | palette length, if applicable, stored as (entries count - 1) (to let save all 256 elements in a byte), or 0
1 | compression type (used as bool, but may be turned into enum)
2 | width
2 | height
N1 | (optional) palette, entry's size is defined by the storage format (usually = sprite BPP), total size = pal length * entry size
4 | _mandatory_ size of pixel data, in bytes
N2 | sprite's pixel data, optionally compressed and/or converted

First of all, the 2 bytes meant for color depth in the beginning were split into 2 values 1 byte each.
Color depth remains and defines the "input format" (what the sprite is meant to be). It's in byte-per-pixels (1,2,4) but may in theory be turned into an enum, while keeping same values for compatibility.
"Storage format" is an enum, describes how this sprite is stored. Currently supported values are only ones related to converting bitmap into the indexed bitmap with palette:
0 - undefined (keep same);
32 = palette888: may be used for normal 8-bit sprites accompanied by palette, or maybe to pack 24-bit images;
33 = palette8888: used when packing 32-bit ARGB sprites;
34 = palette565: used when packing 16-bit RGB565 sprites;

Palette is only saved if storage format is appropriate. Palette entries are supposed to *have same size and same format* as the original image (for the 32-bit sprite palette entry is 4-bytes ARGB, for 16-bit sprite it's 2-bytes RGB565).

The size of pixel data is now mandatory at all times (previously was only written for compressed sprite files).