### PR TITLE
Android: fix Preferences crashes when no android.cfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(AGS_BUILD_COMPILER "Build compiler" ${AGS_BUILD_TOOLS})
 option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_NO_VIDEO_PLAYER "Disable Video" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" ON)
+option(AGS_DEBUG_MANAGED_OBJECTS "Managed Objects Log" OFF)
 set(AGS_BUILD_STR "" CACHE STRING "Engine Build Information")
 
 
@@ -26,6 +27,7 @@ message(" AGS_BUILD_COMPILER: ${AGS_BUILD_COMPILER}")
 message(" AGS_NO_MP3_PLAYER: ${AGS_NO_MP3_PLAYER}")
 message(" AGS_NO_VIDEO_PLAYER: ${AGS_NO_VIDEO_PLAYER}")
 message(" AGS_BUILTIN_PLUGINS: ${AGS_BUILTIN_PLUGINS}")
+message(" AGS_DEBUG_MANAGED_OBJECTS: ${AGS_DEBUG_MANAGED_OBJECTS}")
 message("----------------------------------------")
 
 # Tools like ninja don't have a pseudo-terminal so compilers assume no coloured output

--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -172,6 +172,8 @@ namespace AGS
         void AAssetStream::Open(const String &asset_name, int asset_mode)
         {
             AAssetManager* aAssetManager = GetAAssetManager();
+            if(aAssetManager == nullptr)
+                throw std::runtime_error("Couldn't get AAssetManager, SDL not initialized yet.");
             _ownHandle = true;
 
             if(!asset_name.IsNullOrSpace() && asset_name[0] == '/') {

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -31,6 +31,8 @@ void InitAndroidFile()
     assert(gAAssetManager == nullptr);
     if (gAAssetManager)
         return; // already initialized
+    if(SDL_WasInit(SDL_INIT_EVERYTHING) == 0)
+        return; // SDL has not been initialized yet
 
     JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
@@ -65,13 +67,13 @@ void ShutdownAndroidFile()
 AAssetManager* GetAAssetManager()
 {
     if (!gAAssetManager) { InitAndroidFile(); }
-    assert(gAAssetManager);
     return gAAssetManager;
 }
 
 bool GetAAssetExists(const String &filename)
 {
     AAssetManager* mgr = GetAAssetManager();
+    if(mgr == nullptr) return false;
     // TODO: find out if it's acceptable to open/close asset to only test its existance;
     // the alternative is to use AAssetManager_openDir and read asset list using AAssetDir_getNextFileName
     AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
@@ -83,6 +85,7 @@ bool GetAAssetExists(const String &filename)
 soff_t GetAAssetSize(const String &filename)
 {
     AAssetManager* mgr = GetAAssetManager();
+    if(mgr == nullptr) return -1;
     AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
     if (!asset) return -1;
     soff_t len = AAsset_getLength64(asset);
@@ -100,6 +103,7 @@ AndroidADir::AndroidADir(AndroidADir &&aadir)
 AndroidADir::AndroidADir(const String &dirname)
 {
     AAssetManager* mgr = GetAAssetManager();
+    if(mgr == nullptr) {_dir = nullptr; return; }
     _dir = AAssetManager_openDir(mgr, dirname.GetCStr());
 }
 

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -530,9 +530,8 @@ if (AGS_BUILTIN_PLUGINS)
     )
 endif()
 
-target_compile_definitions(engine PRIVATE 
-    $<$<CONFIG:DEBUG>:SOUND_CACHE_DEBUG>
-    $<$<CONFIG:DEBUG>:DEBUG_MANAGED_OBJECTS>
+target_compile_definitions(engine PRIVATE
+    $<$<BOOL:AGS_DEBUG_MANAGED_OBJECTS>:DEBUG_MANAGED_OBJECTS>
 )
 
 if (AGS_BUILD_STR)


### PR DESCRIPTION
Crash is caused by unintialized SDL.

fix #1471 