### PR TITLE
New compiler: Further refactorings

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -55,7 +55,6 @@ std::map<AGS::TypeQualifier, AGS::Symbol> const &AGS::TypeQualifierSet::TQToSymb
         { TQ::kAttribute,       kKW_Attribute, },
         { TQ::kAutoptr,         kKW_Autoptr, },
         { TQ::kBuiltin,         kKW_Builtin, },
-        { TQ::kConst,           kKW_Const, },
         { TQ::kImport,          kKW_ImportStd, },
         { TQ::kManaged,         kKW_Managed,  },
         { TQ::kProtected,       kKW_Protected,  },

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -9,6 +9,8 @@
 AGS::SymbolTableEntry::~SymbolTableEntry()
 {
     // (note that null pointers may be safely 'delete'd, in contrast to 'free'd)
+    delete this->AttributeD;
+    this->AttributeD = nullptr;
     delete this->ConstantD;
     this->ConstantD = nullptr;
     delete this->ComponentD;
@@ -35,6 +37,7 @@ AGS::SymbolTableEntry &AGS::SymbolTableEntry::operator=(const SymbolTableEntry &
     this->Accessed = orig.Accessed;
 
     // Deep copy semantics.
+    this->AttributeD = (orig.AttributeD) ? new SymbolTableEntry::AttributeDesc{ *(orig.AttributeD) } : nullptr;
     this->ConstantD = (orig.ConstantD) ? new SymbolTableEntry::ConstantDesc{ *(orig.ConstantD) } : nullptr;
     this->DelimeterD = (orig.DelimeterD) ? new SymbolTableEntry::DelimeterDesc{ *(orig.DelimeterD) } : nullptr;
     this->FunctionD = (orig.FunctionD) ? new SymbolTableEntry::FunctionDesc{ *(orig.FunctionD) } : nullptr;
@@ -52,7 +55,6 @@ std::map<AGS::TypeQualifier, AGS::Symbol> const &AGS::TypeQualifierSet::TQToSymb
     // "static" so that we get a singleton that will only be initialized once, at first use
     static std::map<TypeQualifier, Symbol> const tq2sym =
     {
-        { TQ::kAttribute,       kKW_Attribute, },
         { TQ::kAutoptr,         kKW_Autoptr, },
         { TQ::kBuiltin,         kKW_Builtin, },
         { TQ::kImport,          kKW_ImportStd, },
@@ -60,11 +62,32 @@ std::map<AGS::TypeQualifier, AGS::Symbol> const &AGS::TypeQualifierSet::TQToSymb
         { TQ::kProtected,       kKW_Protected,  },
         { TQ::kReadonly,        kKW_Readonly, },
         { TQ::kStatic,          kKW_Static, },
-        { TQ::kStringstruct,    kKW_Internalstring, },
+        { TQ::kInternalstring,  kKW_Internalstring, },
         { TQ::kWriteprotected,  kKW_Writeprotected, },
     };
 
     return tq2sym;
+}
+
+AGS::TypeQualifierSet AGS::TypeQualifierSet::WithoutTypedefQualifiers()
+{
+    TypeQualifierSet ret{ *this };
+    ret[TQ::kAutoptr] =
+        ret[TQ::kBuiltin] =
+        ret[TQ::kInternalstring] =
+        ret[TQ::kManaged] = false;
+    return ret;
+}
+
+AGS::TypeQualifierSet AGS::TypeQualifierSet::WithouttVarFuncDefQualifiers()
+{
+    TypeQualifierSet ret{ *this };
+    ret[TQ::kImport] =
+        ret[TQ::kProtected] =
+        ret[TQ::kReadonly] =
+        ret[TQ::kStatic] =
+        ret[TQ::kWriteprotected] = false;
+    return ret;
 }
 
 void AGS::SymbolTableEntry::Clear()
@@ -74,6 +97,10 @@ void AGS::SymbolTableEntry::Clear()
     Scope = 0u;
     // Don't clear Accessed so when a function is first used and then declared, this doesn't clobber the use.
 
+    delete AttributeD;
+    AttributeD = nullptr;
+    delete ComponentD;
+    ComponentD = nullptr;
     delete ConstantD;
     ConstantD = nullptr;
     delete DelimeterD;
@@ -84,8 +111,6 @@ void AGS::SymbolTableEntry::Clear()
     LiteralD = nullptr;
     delete OperatorD;
     OperatorD = nullptr;
-    delete ComponentD;
-    ComponentD = nullptr;
     delete VariableD;
     VariableD = nullptr;
     delete VartypeD;
@@ -99,12 +124,13 @@ AGS::SymbolTableEntry::SymbolTableEntry(SymbolTableEntry const &orig)
     , Accessed(orig.Accessed)
 {
     // Deep copy semantics.
+    this->AttributeD = (orig.AttributeD) ? new SymbolTableEntry::AttributeDesc{ *(orig.AttributeD) } : nullptr;
+    this->ComponentD = (orig.ComponentD) ? new SymbolTableEntry::ComponentDesc{ *(orig.ComponentD) } : nullptr;
     this->ConstantD = (orig.ConstantD) ? new SymbolTableEntry::ConstantDesc{ *(orig.ConstantD) } : nullptr;
     this->DelimeterD = (orig.DelimeterD) ? new SymbolTableEntry::DelimeterDesc{ *(orig.DelimeterD) } : nullptr;
     this->FunctionD = (orig.FunctionD) ? new SymbolTableEntry::FunctionDesc{ *(orig.FunctionD) } : nullptr;
     this->LiteralD = (orig.LiteralD) ? new SymbolTableEntry::LiteralDesc{ *(orig.LiteralD) } : nullptr;
     this->OperatorD = (orig.OperatorD) ? new SymbolTableEntry::OperatorDesc{ *(orig.OperatorD) } : nullptr;
-    this->ComponentD = (orig.ComponentD) ? new SymbolTableEntry::ComponentDesc{ *(orig.ComponentD) } : nullptr;
     this->VariableD = (orig.VariableD) ? new SymbolTableEntry::VariableDesc{ *(orig.VariableD) } : nullptr;
     this->VartypeD = (orig.VartypeD) ? new SymbolTableEntry::VartypeDesc{ *(orig.VartypeD) } : nullptr;
 }

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -65,7 +65,6 @@ enum class TQ : size_t // Type qualifier
     kAttribute = 0,
     kAutoptr,
     kBuiltin,
-    kConst,
     kImport,
     kManaged,
     kProtected,

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -712,9 +712,8 @@ private:
     // Get the symbol for the get or set function corresponding to the attribute given.
     void ConstructAttributeFuncName(Symbol attribsym, bool is_setter, bool is_indexed, Symbol &func);
 
-    // Call the getter or setter of an attribute
-    // The next symbol read is the attribute (the part after the '.')
-    void AccessData_CallAttributeFunc(bool is_setter, SrcList &expression, Vartype &vartype);
+    // We call the getter or setter of an attribute
+    void AccessData_CallAttributeFunc(bool is_setter, SrcList &expression, Vartype vartype);
 
     // Memory location contains a pointer to another address. Get that address.
     void AccessData_Dereference(ValueLocation &vloc, MemoryLocation &mloc);
@@ -845,8 +844,6 @@ private:
 
     void ParseQualifiers(TypeQualifierSet &tqs);
 
-    void ParseStruct_CheckComponentVartype(Symbol stname, Vartype vartype);
-
     void ParseStruct_FuncDecl(Symbol struct_of_func, Symbol name_of_func, TypeQualifierSet tqs, Vartype vartype);
 
     void ParseStruct_Attribute_ParamList(Symbol struct_of_func, Symbol name_of_func, bool is_setter, bool is_indexed, Vartype vartype);
@@ -857,18 +854,22 @@ private:
     // This corresponds to a getter func and a setter func, declare one of them
     void ParseStruct_Attribute_DeclareFunc(TypeQualifierSet tqs, Symbol strct, Symbol qualified_name, Symbol unqualified_name, bool is_setter, bool is_indexed, Vartype vartype);
 
+    void ParseStruct_Attribute2SymbolTable(TypeQualifierSet const tqs, Vartype const vartype, Symbol const name_of_struct, Symbol const unqualified_attribute, bool const is_indexed);
+
     // We're in a struct declaration. Parse an attribute declaration.
-    void ParseStruct_Attribute(TypeQualifierSet tqs, Symbol stname, Vartype vartype, Symbol vname, bool is_indexed, size_t declaration_start);
+    void ParseStruct_Attribute(TypeQualifierSet tqs, Symbol stname);
 
-    // We're inside a struct decl, processing a member variable or attribute
-    void ParseStruct_VariableOrAttributeDefn(TypeQualifierSet tqs, Vartype curtype, Symbol stname, Symbol vname);
-
+    // We're inside a struct decl, processing a member variable
+    void ParseStruct_VariableDefn(TypeQualifierSet tqs, Vartype curtype, Symbol stname, Symbol vname);
+    
     // We're inside a struct decl, processing a compile-time constant
     void ParseStruct_ConstantDefn(Symbol name_of_struct);
 
     // We have accepted something like 'struct foo extends bar { const int'.
     // We're waiting for the name of the member.
     void ParseStruct_VariableOrFunctionDefn(Symbol name_of_struct, TypeQualifierSet tqs, Vartype vartype);
+
+    void ParseStruct_CheckComponentVartype(Symbol stname, Vartype vartype);
 
     // We've accepted, e.g., 'struct foo {'. Now we're parsing a variable declaration or a function declaration
     void ParseStruct_Vartype(Symbol name_of_struct, TypeQualifierSet tqs);
@@ -917,9 +918,9 @@ private:
 
     void ParseVartype_VarDecl_PreAnalyze(Symbol var_name, ScopeType scope_type);
 
-    void ParseVartype_Attribute(TypeQualifierSet tqs, Vartype vartype, Symbol attribute, ScopeType scope_type);
+    void ParseAttribute(TypeQualifierSet tqs, Symbol name_of_current_func);
 
-    void ParseVartype_VariableOrAttributeDefn(TypeQualifierSet tqs, Vartype vartype, Symbol var_name, ScopeType scope_type);
+    void ParseVartype_VariableDefn(TypeQualifierSet tqs, Vartype vartype, Symbol var_name, ScopeType scope_type);
 
     void ParseVartype_MemberList(TypeQualifierSet tqs, Vartype vartype, ScopeType scope_type, bool no_loop_check, Symbol &struct_of_current_func, Symbol &name_of_current_func);
 

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -544,7 +544,7 @@ private:
 
     // We're at something like 'int foo(', directly before the '('
     // Return in 'body_follows' whether the symbol that follows the corresponding ')' is '{'
-    void ParseFuncdecl_DoesBodyFollow(bool &body_follows);
+    bool ParseFuncdecl_DoesBodyFollow();
 
     // We're in a func decl. Check whether the declaration is valid.
     void ParseFuncdecl_Checks(TypeQualifierSet tqs, Symbol struct_of_func, Symbol name_of_func, Vartype return_vartype, bool body_follows, bool no_loop_check);
@@ -553,7 +553,7 @@ private:
 
     // Parse a function declaration.
     // We're behind the opening '(', and any first extender parameter has already be resolved.
-    void ParseFuncdecl(size_t declaration_start, TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_func, Symbol name_of_func, bool no_loop_check, bool &body_follows);
+    void ParseFuncdecl(TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_func, Symbol name_of_func, bool no_loop_check, bool body_follows);
 
     // Return in 'idx' the index of the operator in the list that binds the least
     // so that either side of it can be evaluated first. '-1' if no operator was found

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -1410,7 +1410,7 @@ TEST_F(Bytecode1, Attributes10) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 
     // WriteOutput("Attributes10", scrip);
-    size_t const codesize = 137;
+    size_t const codesize = 139;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
@@ -1426,12 +1426,12 @@ TEST_F(Bytecode1, Attributes10) {
       45,    2,   39,    1,            6,    3,   22,   33,    // 79
        3,   35,    1,   30,            6,   51,    0,   47,    // 87
        3,    1,    1,    4,            6,    3,    0,    6,    // 95
-       2,    0,   48,    2,           52,   29,    6,   34,    // 103
-       3,   29,    2,    6,            3,    9,   30,    2,    // 111
-      34,    3,   45,    2,           39,    2,    6,    3,    // 119
-      23,   33,    3,   35,            2,   30,    6,   51,    // 127
-       4,   49,    2,    1,            8,    6,    3,    0,    // 135
-       5,  -999
+       2,    0,   48,    2,           52,   64,    3,   29,    // 103
+       6,   34,    3,   29,            2,    6,    3,    9,    // 111
+      30,    2,   34,    3,           45,    2,   39,    2,    // 119
+       6,    3,   23,   33,            3,   35,    2,   30,    // 127
+       6,   51,    4,   49,            2,    1,    8,    6,    // 135
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1440,7 +1440,7 @@ TEST_F(Bytecode1, Attributes10) {
 
     int32_t fixups[] = {
        4,   16,   34,   48,         57,   78,   94,   97,    // 7
-     120,  -999
+     122,  -999
     };
     char fixuptypes[] = {
       1,   4,   1,   4,      1,   4,   3,   1,    // 7

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -676,8 +676,10 @@ TEST_F(Compile0, Protected0) {
 
 TEST_F(Compile0, ParamVoid) {   
 
+    // Can't have a parameter of type 'void'.
+
     char *inpl = "\
-        int Foo(void Bar)                      \n\
+        int Foo(int bar, void bazz)            \n\
         {                                      \n\
             return 1;                          \n\
         }                                      \n\

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -113,13 +113,13 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
     // Note, "_tryimport" isn't legal for struct components.
     // Can only use one of "protected", "writeprotected" and "readonly".
 
-    char *inpl = "                                                          \n\
-        struct BothOrders {                                                 \n\
-            protected import static attribute int something;                \n\
-            attribute static import readonly int another;                   \n\
-            readonly import attribute int MyAttrib;                         \n\
-            import readonly attribute int YourAttrib;                       \n\
-        };\
+    char *inpl = "\
+        struct BothOrders {                                 \n\
+            protected static int something;                 \n\
+            static import readonly attribute int another;   \n\
+            readonly import attribute int MyAttrib;         \n\
+            import readonly attribute int YourAttrib;       \n\
+        };                                                  \n\
         ";
 
     int compileResult = cc_compile(inpl, scrip);
@@ -452,33 +452,7 @@ TEST_F(Compile0, Writeprotected) {
     EXPECT_NE(std::string::npos, err.find("Damage"));
 }
 
-TEST_F(Compile0, Protected1) {   
-
-    // Directly taken from the doc on protected, simplified.
-    // Should fail, no modifying of protected components from the outside.
-
-    char *inpl = "\
-        struct Weapon {                        \n\
-            protected int Damage;              \n\
-        };                                     \n\
-                                               \n\
-        Weapon wp;                             \n\
-                                               \n\
-        void main()                            \n\
-        {                                      \n\
-            wp.Damage = 7;                     \n\
-            return;                            \n\
-        }                                      \n\
-        ";
-    
-    int compileResult = cc_compile(inpl, scrip);
-    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    std::string err = last_seen_cc_error();
-    EXPECT_NE(std::string::npos, err.find("Damage"));
-}
-
-TEST_F(Compile0, Protected2) {
+TEST_F(Compile0, Protected1) {
     
     // Directly taken from the doc on protected, simplified.
     // Should fail, no reading protected components from the outside.
@@ -502,6 +476,31 @@ TEST_F(Compile0, Protected2) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     std::string err = last_seen_cc_error();
     EXPECT_NE(std::string::npos, err.find("Damage"));
+}
+
+TEST_F(Compile0, Protected2) {
+
+    // Is still an attempt to modify a protected component from the outside
+    // ('this.Damage = 7;' or even 'Damage = 7;' would be legal, however.)
+
+    char *inpl = "\
+        struct Weapon {                        \n\
+            protected int Damage;              \n\
+            import int DoDamage();             \n\
+        };                                     \n\
+                                               \n\
+        Weapon wp;                             \n\
+                                               \n\
+        int Weapon::DoDamage()                 \n\
+        {                                      \n\
+            wp.Damage = 7;                     \n\
+        }                                      \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    std::string err = last_seen_cc_error();
+    EXPECT_NE(std::string::npos, err.find("rotected"));
 }
 
 TEST_F(Compile0, Protected3) {
@@ -762,6 +761,8 @@ TEST_F(Compile0, VartypeLocalSeq2) {
 
 TEST_F(Compile0, StructMemberImport) {    
 
+    // Struct variables must not be 'import'
+
     char *inpl = "\
         struct Parent                   \n\
         {                               \n\
@@ -1002,6 +1003,49 @@ TEST_F(Compile0, StructManaged2)
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     std::string err = last_seen_cc_error();
     EXPECT_EQ(std::string::npos, err.find("xception"));
+}
+
+TEST_F(Compile0, StructRecursiveComponent01)
+{
+    // Cannot have a component that has the same type as the struct;
+    // this construct would be infinitively large
+
+    char *inpl = "\
+        struct Foo              \n\
+        {                       \n\
+            Foo magic;          \n\
+        };                      \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    std::string err = last_seen_cc_error();
+    EXPECT_NE(std::string::npos, err.find("include a component"));
+    EXPECT_NE(std::string::npos, err.find("'Foo'"));
+}
+
+TEST_F(Compile0, StructRecursiveComponent02)
+{
+    // Cannot have a component that has the same type as the struct;
+    // this construct would be infinitively large
+
+    char *inpl = "\
+        struct Foo              \n\
+        {                       \n\
+            int magic;          \n\
+        };                      \n\
+        struct Bar extends Foo  \n\
+        {                       \n\
+            Foo vodoo;          \n\
+        };                      \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    std::string err = last_seen_cc_error();
+    EXPECT_NE(std::string::npos, err.find("extends"));
+    EXPECT_NE(std::string::npos, err.find("'Foo'"));
+    EXPECT_NE(std::string::npos, err.find("'Bar'"));
 }
 
 TEST_F(Compile0, Undefined) {   
@@ -1555,7 +1599,7 @@ TEST_F(Compile0, AssignPtr2ArrayOfPtr) {
 
     std::string agscode = "\
         managed struct DynamicSprite            \n\
-         {                                       \n\
+        {                                       \n\
             import static DynamicSprite         \n\
                 *Create(int width, int height, bool hasAlphaChannel = false);   \n\
         };                                      \n\
@@ -1894,6 +1938,48 @@ TEST_F(Compile0, Attributes15) {
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("readonly"));
+}
+
+TEST_F(Compile0, Attributes16) {
+
+    // Import decls of autopointered variables must be processed correctly.
+
+    char *inpl = "\
+        builtin managed struct Object       \n\
+        {                                   \n\
+            import attribute int  Graphic;  \n\
+        } obj;                              \n\
+                                            \n\
+        int foo ()                          \n\
+        {                                   \n\
+            obj.Graphic++;                  \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+}
+
+TEST_F(Compile0, Attributes17)
+{
+
+    // This attribute is type 'float' and assigned an 'int'. This should fail.
+
+    char *inpl = "\
+        builtin managed struct Character            \n\
+        {                                           \n\
+            import attribute float GraphicRotation; \n\
+        };                                          \n\
+        import readonly Character *player;          \n\
+        int foo(void) {                             \n\
+            player.GraphicRotation = 10;            \n\
+        }                                           \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'int'"));
+    EXPECT_NE(std::string::npos, msg.find("'float'"));
 }
 
 TEST_F(Compile0, StructPtrFunc) {

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2258,29 +2258,33 @@ TEST_F(Compile1, CompileTimeConstant4)
 
 TEST_F(Compile1, CompileTimeConstant5)
 {
+    // Cannot define a compile-time constant of type 'short'
+
     char *inpl = "\
         const short S = 42; \n\
         ";
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("'int'"));
+    EXPECT_NE(std::string::npos, msg.find("'short'"));
 
+    // Cannot define a compile-time constant array
     char *inpl2 = "\
         const int C[]; \n\
         ";
     compile_result = cc_compile(inpl2, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("rray"));
+    EXPECT_NE(std::string::npos, msg.find("array"));
 
+    // Misplaced '[]'
     char *inpl3 = "\
         const int[] C; \n\
         ";
     compile_result = cc_compile(inpl3, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("Expected '('"));
+    EXPECT_NE(std::string::npos, msg.find("'['"));
 }
 
 TEST_F(Compile1, CompileTimeConstant6)

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1533,27 +1533,6 @@ TEST_F(Compile1, ZeroMemoryAllocation2)
     EXPECT_NE(std::string::npos, msg.find("'Strct'"));
 }
 
-
-TEST_F(Compile1, AttribInc) {
-
-    // Import decls of autopointered variables must be processed correctly.
-
-    char *inpl = "\
-        builtin managed struct Object       \n\
-        {                                   \n\
-            import attribute int  Graphic;  \n\
-        } obj;                              \n\
-                                            \n\
-        int foo ()                          \n\
-        {                                   \n\
-            obj.Graphic++;                  \n\
-        }                                   \n\
-        ";
-    int compile_result = cc_compile(inpl, scrip);
-    std::string msg = last_seen_cc_error();
-    ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-}
-
 TEST_F(Compile1,ForwardStructManaged)
 {
     // Forward-declared structs must be 'managed', so the
@@ -2318,27 +2297,6 @@ TEST_F(Compile1, StaticThisExtender)
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'static'"));
-}
-
-TEST_F(Compile1, AttributeAssignTypeCheck)
-{
-    // This attribute is type 'float' and assigned an int. This should fail.
-
-    char *inpl = "\
-        builtin managed struct Character            \n\
-        {                                           \n\
-            import attribute float GraphicRotation; \n\
-        };                                          \n\
-        import readonly Character *player;          \n\
-        int foo(void) {                             \n\
-            player.GraphicRotation = 10;            \n\
-        }                                           \n\
-        ";
-    int compile_result = cc_compile(inpl, scrip);
-    std::string msg = last_seen_cc_error();
-    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("'int'"));
-    EXPECT_NE(std::string::npos, msg.find("'float'"));
 }
 
 TEST_F(Compile1, ReachabilityAndSwitch1)


### PR DESCRIPTION
No functional changes.

I'm still indulging in yak shaving to make it easier to implement delegates in the compiler.

1. When I started out, I considered attributes to be a special kind of variable - an attribute variable. It's not, it's a different category of type that needs different information in the symbol table and different code to process. In this way, it is similar to functions and the upcoming delegates that need special treatment, too. The implementation has already drifted this way; now I've streamlined it to make it easier to put delegates alongside.
2. Similarly for `const`: Apart from the type `const string`, the compiler uses `const` as a special category; it keeps track of (integer or float) literals using dedicated fields in the symbol table and it has dedicated compile-time processing for `const`s (for instance, `3 + 4` is converted to `7` at compile-time). This is already implemented, but I've streamlined it to make it easier to put delegates alongside.
3. When a delegate object is called, this looks exactly like a function call. So seeing that delegates will be implemented, I've cleaned up the function calling code beforehand. 