### PR TITLE
Engine: AnimateCharacter with better error message for invalid loop error

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2125,8 +2125,10 @@ void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noi
         Character_UnlockView(chap);
         chap->idleleft=chap->idletime;
     }
-    if ((loopn < 0) || (loopn >= views[chap->view].numLoops))
-        quit("!AnimateCharacter: invalid loop number specified");
+    if ((loopn < 0) || (loopn >= views[chap->view].numLoops)) {
+        quitprintf("!AnimateCharacter: invalid loop number\n"
+            "(trying to animate '%s' using loop %d. View is currently %d).",chap->name,loopn,chap->view+1);
+    }
     if ((sframe < 0) || (sframe >= views[chap->view].loops[loopn].numFrames))
         quit("!AnimateCharacter: invalid starting frame number specified");
     Character_StopMoving(chap);


### PR DESCRIPTION
AnimateCharacter "invalid loop number specified" didn't inform, either loop number, view or character.

![image](https://user-images.githubusercontent.com/2244442/148607657-13d1ed2a-66a7-43f9-91ba-677d765b09d6.png)

Fix #1482 