### PR TITLE
Engine: audio core init may throw

### DIFF
--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -383,7 +383,12 @@ void engine_init_audio()
     if (usetup.audio_backend != 0)
     {
         Debug::Printf("Initializing audio");
-        audio_core_init(); // audio core system
+        try {
+            audio_core_init(); // audio core system
+        } catch(std::runtime_error) {
+            Debug::Printf("Failed to initialize audio, disabling.");
+            usetup.audio_backend = 0;
+        }
     }
     our_eip = -181;
 


### PR DESCRIPTION
when running `audio_core_init()`, it may throw if **no audio device is available**. 

I discovered it today when I had my headphones disconnected from my computer and no speakers since I had just moved the desk. In this case, AGS from our master doesn't start. Verified in Windows 10.

Previous allegro based AGS show a windows message saying it couldn't initialize audio, and then proceed with the game. I thought a debug message is fine - if it isn't, I can add a **`platform->DisplayAlert()`**.

https://github.com/adventuregamestudio/ags/blob/master/Engine/media/audio/audio_core.cpp#L78-L82

This PR simply catches the thrown errors and disables the audio backend.