### PR TITLE
3.6.0: optionally clip GUI control contents

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -77,6 +77,7 @@
 #define OPT_RENDERATSCREENRES 45 // scale sprites at the (final) screen resolution
 #define OPT_RELATIVEASSETRES 46 // relative asset resolution mode (where sprites are resized to match game type)
 #define OPT_WALKSPEEDABSOLUTE 47 // if movement speeds are independent of walkable mask resolution
+#define OPT_CLIPGUICONTROLS 48 // clip drawn gui control contents to the control's rectangle
 #define OPT_HIGHESTOPTION   OPT_WALKSPEEDABSOLUTE
 #define OPT_NOMODMUSIC      98
 #define OPT_LIPSYNCTEXT     99

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -70,9 +70,7 @@
 #define OPT_GLOBALTALKANIMSPD 39
 #define OPT_HIGHESTOPTION_321 39
 #define OPT_SPRITEALPHA     40
-#define OPT_HIGHESTOPTION_330 OPT_SPRITEALPHA
 #define OPT_SAFEFILEPATHS   41
-#define OPT_HIGHESTOPTION_335 OPT_SAFEFILEPATHS
 #define OPT_DIALOGOPTIONSAPI 42 // version of dialog options API (-1 for pre-3.4.0 API)
 #define OPT_BASESCRIPTAPI   43 // version of the Script API (ScriptAPIVersion) used to compile game script
 #define OPT_SCRIPTCOMPATLEV 44 // level of API compatibility (ScriptAPIVersion) used to compile game script

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -308,8 +308,8 @@ void GUIButton::WriteToSavegame(Stream *out) const
 void GUIButton::DrawImageButton(Bitmap *ds, bool draw_disabled)
 {
     // NOTE: the CLIP flag only clips the image, not the text
-    if (IsClippingImage())
-        ds->SetClip(Rect(X, Y, X + Width - 1, Y + Height - 1));
+    if (IsClippingImage() && !GUI::Options.ClipControls)
+        ds->SetClip(RectWH(X, Y, Width, Height));
     if (spriteset[CurrentImage] != nullptr)
         draw_gui_sprite(ds, CurrentImage, X, Y, true);
 
@@ -350,11 +350,13 @@ void GUIButton::DrawImageButton(Bitmap *ds, bool draw_disabled)
             spriteset[CurrentImage]->GetWidth(),
             spriteset[CurrentImage]->GetHeight()));
     }
-    ds->ResetClip();
 
     // Don't print Text of (INV) (INVSHR) (INVNS)
     if (_placeholder == kButtonPlace_None && !_unnamed)
         DrawText(ds, draw_disabled);
+
+    if (IsClippingImage() && !GUI::Options.ClipControls)
+        ds->ResetClip();
 }
 
 void GUIButton::DrawText(Bitmap *ds, bool draw_disabled)

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -97,8 +97,8 @@ void GUIButton::Draw(Bitmap *ds)
     bool draw_disabled = !IsGUIEnabled(this);
 
     // if it's "Unchanged when disabled" or "GUI Off", don't grey out
-    if (gui_disabled_style == GUIDIS_UNCHANGED ||
-        gui_disabled_style == GUIDIS_GUIOFF)
+    if ((GUI::Options.DisabledStyle == kGuiDis_Unchanged) ||
+        (GUI::Options.DisabledStyle == kGuiDis_Off))
     {
         draw_disabled = false;
     }
@@ -106,7 +106,7 @@ void GUIButton::Draw(Bitmap *ds)
     if (CurrentImage <= 0 || draw_disabled)
         CurrentImage = Image;
 
-    if (draw_disabled && gui_disabled_style == GUIDIS_BLACKOUT)
+    if (draw_disabled && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
         // buttons off when disabled - no point carrying on
         return;
 
@@ -343,7 +343,7 @@ void GUIButton::DrawImageButton(Bitmap *ds, bool draw_disabled)
         }
     }
 
-    if ((draw_disabled) && (gui_disabled_style == GUIDIS_GREYOUT))
+    if ((draw_disabled) && (GUI::Options.DisabledStyle == kGuiDis_Greyout))
     {
         // darken the button when disabled
         GUI::DrawDisabledEffect(ds, RectWH(X, Y,

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -200,6 +200,8 @@ enum GuiDisableStyle
 // Global GUI options
 struct GuiOptions
 {
+    // Clip GUI control's contents to the control's rectangle
+    bool ClipControls = true;
     // How the GUI controls are drawn when the interface is disabled
     GuiDisableStyle DisabledStyle = kGuiDis_Unchanged;
     // Whether to graphically outline GUI controls

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -11,14 +11,12 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_GUIDEFINES_H
 #define __AC_GUIDEFINES_H
 
 #define GUIMAGIC          0xcafebeef
 #define MAX_GUIOBJ_EVENTS 10
 #define TEXTWINDOW_PADDING_DEFAULT  3
-//#define MAX_OBJ_EACH_TYPE 251
 
 // TODO: find out more about gui version history
 //=============================================================================
@@ -189,6 +187,23 @@ enum GuiSvgVersion
 {
     kGuiSvgVersion_Initial  = 0,
     kGuiSvgVersion_350      = 1
+};
+
+enum GuiDisableStyle
+{
+    kGuiDis_Greyout   = 0,
+    kGuiDis_Blackout  = 1,
+    kGuiDis_Unchanged = 2,
+    kGuiDis_Off       = 3
+};
+
+// Global GUI options
+struct GuiOptions
+{
+    // How the GUI controls are drawn when the interface is disabled
+    GuiDisableStyle DisabledStyle = kGuiDis_Unchanged;
+    // Whether to graphically outline GUI controls
+    bool OutlineControls = false;
 };
 
 } // namespace Common

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -281,6 +281,8 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
         if (!objToDraw->IsVisible())
             continue;
 
+        if (GUI::Options.ClipControls)
+            subbmp.SetClip(RectWH(objToDraw->X, objToDraw->Y, objToDraw->Width, objToDraw->Height));
         objToDraw->Draw(&subbmp);
 
         int selectedColour = 14;

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -11,7 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
+#include "gui/guimain.h"
 #include <algorithm>
 #include "ac/game_version.h"
 #include "ac/spritecache.h"
@@ -21,7 +21,6 @@
 #include "gui/guiinv.h"
 #include "gui/guilabel.h"
 #include "gui/guilistbox.h"
-#include "gui/guimain.h"
 #include "gui/guislider.h"
 #include "gui/guitextbox.h"
 #include "util/stream.h"
@@ -32,13 +31,15 @@ using namespace AGS::Common;
 
 #define MOVER_MOUSEDOWNLOCKED -4000
 
-int all_buttons_disabled = 0, gui_inv_pic = -1;
-int gui_disabled_style = 0;
+int all_buttons_disabled = -1, gui_inv_pic = -1;
 
 namespace AGS
 {
 namespace Common
 {
+
+GuiOptions GUI::Options;
+
 
 /* static */ String GUIMain::FixupGUIName(const String &name)
 {
@@ -266,7 +267,7 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
 
     SET_EIP(379)
 
-    if (all_buttons_disabled && gui_disabled_style == GUIDIS_BLACKOUT)
+    if ((all_buttons_disabled >= 0) && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
         return; // don't draw GUI controls
 
     for (size_t ctrl_index = 0; ctrl_index < _controls.size(); ++ctrl_index)
@@ -275,7 +276,7 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
 
         GUIObject *objToDraw = _controls[_ctrlDrawOrder[ctrl_index]];
 
-        if (!objToDraw->IsEnabled() && gui_disabled_style == GUIDIS_BLACKOUT)
+        if (!objToDraw->IsEnabled() && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
             continue;
         if (!objToDraw->IsVisible())
             continue;
@@ -286,7 +287,7 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
 
         if (HighlightCtrl == _ctrlDrawOrder[ctrl_index])
         {
-            if (outlineGuiObjects)
+            if (GUI::Options.OutlineControls)
                 selectedColour = 13;
             draw_color = subbmp.GetCompatibleColor(selectedColour);
             DrawBlob(&subbmp, objToDraw->X + objToDraw->Width - get_fixed_pixel_size(1) - 1, objToDraw->Y, draw_color);
@@ -295,7 +296,7 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
             DrawBlob(&subbmp, objToDraw->X + objToDraw->Width - get_fixed_pixel_size(1) - 1, 
                     objToDraw->Y + objToDraw->Height - get_fixed_pixel_size(1) - 1, draw_color);
         }
-        if (outlineGuiObjects)
+        if (GUI::Options.OutlineControls)
         {
             // draw a dotted outline round all objects
             draw_color = subbmp.GetCompatibleColor(selectedColour);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_GUIMAIN_H
 #define __AC_GUIMAIN_H
 
@@ -196,6 +195,7 @@ private:
 namespace GUI
 {
     extern GuiVersion GameGuiVersion;
+    extern GuiOptions Options;
 
     // Draw standart "shading" effect over rectangle
     void DrawDisabledEffect(Bitmap *ds, const Rect &rc);
@@ -232,8 +232,10 @@ namespace GUI
 } // namespace AGS
 
 extern std::vector<Common::GUIMain> guis;
-extern int all_buttons_disabled, gui_inv_pic;
-extern int gui_disabled_style;
+// Tells if all controls are disabled
+// TODO: investigate how this variable works, and if this is at all needed
+extern int all_buttons_disabled;
+extern int gui_inv_pic;
 
 extern int mousex, mousey;
 
@@ -258,7 +260,5 @@ extern void set_our_eip(int eip);
 #define SET_EIP(x) set_our_eip(x);
 extern void set_eip_guiobj(int eip);
 extern int get_eip_guiobj();
-
-extern bool outlineGuiObjects;
 
 #endif // __AC_GUIMAIN_H

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -20,11 +20,6 @@
 #include "gui/guidefines.h"
 #include "util/string.h"
 
-#define GUIDIS_GREYOUT   1
-#define GUIDIS_BLACKOUT  2
-#define GUIDIS_UNCHANGED 4
-#define GUIDIS_GUIOFF  0x80
-
 struct KeyInput;
 
 
@@ -124,6 +119,6 @@ HorAlignment ConvertLegacyGUIAlignment(LegacyGUIAlignment align);
 // Tells if all controls are disabled
 extern int all_buttons_disabled;
 // Tells if the given control is considered enabled, taking global flag into account
-inline bool IsGUIEnabled(AGS::Common::GUIObject *g) { return !all_buttons_disabled && g->IsEnabled(); }
+inline bool IsGUIEnabled(AGS::Common::GUIObject *g) { return (all_buttons_disabled < 0) && g->IsEnabled(); }
 
 #endif // __AC_GUIOBJECT_H

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -573,6 +573,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_RENDERATSCREENRES] = (int)game.Settings.RenderAtScreenResolution;
             options[NativeConstants.GameOptions.OPT_RELATIVEASSETRES] = (game.Settings.AllowRelativeAssetResolutions ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_WALKSPEEDABSOLUTE] = (game.Settings.ScaleMovementSpeedWithMaskResolution ? 0 : 1);
+            options[NativeConstants.GameOptions.OPT_CLIPGUICONTROLS] = (game.Settings.ClipGUIControls ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_LIPSYNCTEXT] = (game.LipSync.Type == LipSyncType.Text ? 1 : 0);
             for (int i = 0; i < options.Length; ++i) // writing only ints, alignment preserved
             {

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -129,6 +129,7 @@ namespace AGS.Editor
             else if ((e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_ALLOWRELATIVEASSETS) ||
                      (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_ANTI_ALIAS_FONTS) ||
                      (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_FONT_HEIGHT_IN_LOGIC) ||
+                     (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_CLIPGUICONTROLS) ||
                      (e.ChangedItem.Label == AGS.Types.Settings.PROPERTY_RENDERATSCREENRES))
             {
                 Factory.Events.OnGameSettingsChanged();

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -377,6 +377,7 @@ namespace AGS.Editor
                     }
                     font.TTFMetricsFixup = FontMetricsFixup.SetAscenderToHeight;
                 }
+                game.Settings.ClipGUIControls = false;
             }
 
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -132,6 +132,7 @@ namespace AGS.Editor
             public static readonly int OPT_RENDERATSCREENRES = (int)Factory.NativeProxy.GetNativeConstant("OPT_RENDERATSCREENRES");
             public static readonly int OPT_RELATIVEASSETRES = (int)Factory.NativeProxy.GetNativeConstant("OPT_RELATIVEASSETRES");
             public static readonly int OPT_WALKSPEEDABSOLUTE = (int)Factory.NativeProxy.GetNativeConstant("OPT_WALKSPEEDABSOLUTE");
+            public static readonly int OPT_CLIPGUICONTROLS = (int)Factory.NativeProxy.GetNativeConstant("OPT_CLIPGUICONTROLS");
             public static readonly int OPT_LIPSYNCTEXT = (int)Factory.NativeProxy.GetNativeConstant("OPT_LIPSYNCTEXT");
         }
     }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -790,6 +790,7 @@ namespace AGS
             if (name->Equals("OPT_RENDERATSCREENRES")) return OPT_RENDERATSCREENRES;
             if (name->Equals("OPT_RELATIVEASSETRES")) return OPT_RELATIVEASSETRES;
             if (name->Equals("OPT_WALKSPEEDABSOLUTE")) return OPT_WALKSPEEDABSOLUTE;
+            if (name->Equals("OPT_CLIPGUICONTROLS")) return OPT_CLIPGUICONTROLS;
             if (name->Equals("OPT_LIPSYNCTEXT")) return OPT_LIPSYNCTEXT;
 			if (name->Equals("MAX_PLUGINS")) return MAX_PLUGINS;
             return nullptr;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -85,7 +85,6 @@ int mousex = 0, mousey = 0;
 int antiAliasFonts = 0;
 int dsc_want_hires = 0;
 bool enable_greyed_out_masks = true;
-bool outlineGuiObjects = false;
 RGB*palette = NULL;
 GameSetupStruct thisgame;
 AGS::Common::SpriteCache spriteset(thisgame.SpriteInfos);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1942,7 +1942,10 @@ void GameUpdated(Game ^game, bool forceUpdate) {
 
   thisgame.options[OPT_RELATIVEASSETRES] = game->Settings->AllowRelativeAssetResolutions;
   thisgame.options[OPT_ANTIALIASFONTS] = game->Settings->AntiAliasFonts;
+  thisgame.options[OPT_CLIPGUICONTROLS] = game->Settings->ClipGUIControls;
   antiAliasFonts = thisgame.options[OPT_ANTIALIASFONTS];
+
+  AGS::Common::GUI::Options.ClipControls = thisgame.options[OPT_CLIPGUICONTROLS] != 0;
 
   BaseColorDepth = thisgame.color_depth * 8;
 

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -25,6 +25,7 @@ namespace AGS.Types
         public const string PROPERTY_LETTERBOX_MODE = "Enable letterbox mode";
         public const string PROPERTY_BUILD_TARGETS = "Build target platforms";
         public const string PROPERTY_RENDERATSCREENRES = "Render sprites at screen resolution";
+        public const string PROPERTY_CLIPGUICONTROLS = "GUI controls clip their contents";
         public const string PROPERTY_DIALOG_SCRIPT_SAYFN = "Custom Say function in dialog scripts";
         public const string PROPERTY_DIALOG_SCRIPT_NARRATEFN = "Custom Narrate function in dialog scripts";
         public const string REGEX_FOUR_PART_VERSION = @"^(\d+)\.(\d+)\.(\d+)\.(\d+)$";
@@ -46,6 +47,7 @@ namespace AGS.Types
         private bool _antiGlideMode = true;
         private bool _walkInLookMode = false;
         private InterfaceDisabledAction _whenInterfaceDisabled = InterfaceDisabledAction.GreyOut;
+        private bool _clipGuiControls = true;
         private bool _pixelPerfect = true;
         private bool _autoMoveInWalkMode = true;
         private bool _letterboxMode = false;
@@ -497,6 +499,17 @@ namespace AGS.Types
         {
             get { return _whenInterfaceDisabled; }
             set { _whenInterfaceDisabled = value; }
+        }
+
+        [DisplayName(PROPERTY_CLIPGUICONTROLS)]
+        [Description("GUI controls will clip their graphical contents, such as text, preventing it from being drawn outside of their rectangle." +
+            "\nNOTE: Button images are clipped using individual button's property.")]
+        [DefaultValue(true)]
+        [Category("Visual")]
+        public bool ClipGUIControls
+        {
+            get { return _clipGuiControls; }
+            set { _clipGuiControls = value; }
         }
 
         [DisplayName("GUI alpha rendering style")]

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2297,8 +2297,8 @@ void draw_gui_and_overlays()
             if (guis[aa].Transparency == 255) continue; // 100% transparent
 
             // Don't draw GUI if "GUIs Turn Off When Disabled"
-            if ((game.options[OPT_DISABLEOFF] == 3) &&
-                (all_buttons_disabled > 0) &&
+            if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) &&
+                (all_buttons_disabled >= 0) &&
                 (guis[aa].PopupStyle != kGUIPopupNoAutoRemove))
                 continue;
 
@@ -2313,8 +2313,8 @@ void draw_gui_and_overlays()
             for (int gg = 0; gg < game.numgui; gg++) {
                 if (!guis[gg].IsDisplayed()) continue; // not on screen
                 // Don't touch GUI if "GUIs Turn Off When Disabled"
-                if ((game.options[OPT_DISABLEOFF] == 3) &&
-                    (all_buttons_disabled > 0) &&
+                if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) &&
+                    (all_buttons_disabled >= 0) &&
                     (guis[gg].PopupStyle != kGUIPopupNoAutoRemove))
                     continue;
                 guis[gg].Poll();

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -76,7 +76,6 @@ extern int load_new_game_restore;
 extern GameSetupStruct game;
 extern std::vector<ViewStruct> views;
 extern RoomStatus*croom;
-extern int gui_disabled_style;
 extern RoomStruct thisroom;
 extern int getloctype_index;
 extern IGraphicsDriver *gfxDriver;
@@ -443,7 +442,7 @@ int SetGameOption (int opt, int setting) {
     if (opt == OPT_DUPLICATEINV)
         update_invorder();
     else if (opt == OPT_DISABLEOFF) {
-        gui_disabled_style = convert_gui_disabled_style(game.options[OPT_DISABLEOFF]);
+        GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);
         // If GUI was disabled at this time then also update it, as visual style could've changed
         if (play.disabled_user_interface > 0) { GUI::MarkAllGUIForUpdate(); }
     } else if (opt == OPT_PORTRAITSIDE) {

--- a/Engine/ac/global_gui.cpp
+++ b/Engine/ac/global_gui.cpp
@@ -202,8 +202,8 @@ void SetGUIBackgroundPic (int guin, int slotn) {
 }
 
 void DisableInterface() {
-  if (play.disabled_user_interface == 0 && // only if was enabled before
-      gui_disabled_style != GUIDIS_UNCHANGED)
+  if ((play.disabled_user_interface == 0) && // only if was enabled before
+      (GUI::Options.DisabledStyle != kGuiDis_Unchanged))
   { // If GUI looks change when disabled, then update them all
     GUI::MarkAllGUIForUpdate();
   }
@@ -216,7 +216,7 @@ void EnableInterface() {
   if (play.disabled_user_interface<1) {
     play.disabled_user_interface=0;
     set_default_cursor();
-    if (gui_disabled_style != GUIDIS_UNCHANGED)
+    if (GUI::Options.DisabledStyle != kGuiDis_Unchanged)
     { // If GUI looks change when disabled, then update them all
         GUI::MarkAllGUIForUpdate();
     }

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -485,32 +485,14 @@ void unexport_gui_controls(int ee)
     }
 }
 
-int convert_gui_disabled_style(int oldStyle) {
-    int toret = GUIDIS_GREYOUT;
-
-    // if GUIs Turn Off is selected, don't grey out buttons for
-    // any Persistent GUIs which remain
-    // set to 0x80 so that it is still non-zero, but has no effect
-    if (oldStyle == 3)
-        toret = GUIDIS_GUIOFF;
-    // GUIs Go Black
-    else if (oldStyle == 1)
-        toret = GUIDIS_BLACKOUT;
-    // GUIs unchanged
-    else if (oldStyle == 2)
-        toret = GUIDIS_UNCHANGED;
-
-    return toret;
-}
-
 void update_gui_disabled_status() {
     // update GUI display status (perhaps we've gone into
     // an interface disabled state)
     int all_buttons_was = all_buttons_disabled;
-    all_buttons_disabled = 0;
+    all_buttons_disabled = -1;
 
     if (!IsInterfaceEnabled()) {
-        all_buttons_disabled = gui_disabled_style;
+        all_buttons_disabled = GUI::Options.DisabledStyle;
     }
 
     if (all_buttons_was != all_buttons_disabled) {
@@ -519,7 +501,7 @@ void update_gui_disabled_status() {
         for (int aa = 0; aa < game.numgui; aa++) {
             guis[aa].OnControlPositionChanged(); // this marks GUI as changed too
         }
-        if (gui_disabled_style != GUIDIS_UNCHANGED) {
+        if (GUI::Options.DisabledStyle != kGuiDis_Unchanged) {
             invalidate_screen();
         }
     }
@@ -527,7 +509,7 @@ void update_gui_disabled_status() {
 
 
 int adjust_x_for_guis (int xx, int yy) {
-    if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0))
+    if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) && (all_buttons_disabled >= 0))
         return xx;
     // If it's covered by a GUI, move it right a bit
     for (int aa=0;aa < game.numgui; aa++) {
@@ -550,7 +532,7 @@ int adjust_x_for_guis (int xx, int yy) {
 }
 
 int adjust_y_for_guis ( int yy) {
-    if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0))
+    if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) && (all_buttons_disabled >= 0))
         return yy;
     // If it's covered by a GUI, move it down a bit
     for (int aa=0;aa < game.numgui; aa++) {
@@ -574,7 +556,7 @@ int adjust_y_for_guis ( int yy) {
 
 int gui_get_interactable(int x,int y)
 {
-    if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0))
+    if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) && (all_buttons_disabled >= 0))
         return -1;
     return GetGUIAt(x, y);
 }
@@ -583,7 +565,7 @@ int gui_on_mouse_move()
 {
     int mouse_over_gui = -1;
     // If all GUIs are off, skip the loop
-    if ((game.options[OPT_DISABLEOFF]==3) && (all_buttons_disabled > 0)) ;
+    if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) && (all_buttons_disabled >= 0)) ;
     else {
         // Scan for mouse-y-pos GUIs, and pop one up if appropriate
         // Also work out the mouse-over GUI while we're at it

--- a/Engine/ac/gui.h
+++ b/Engine/ac/gui.h
@@ -68,7 +68,6 @@ void	replace_macro_tokens(const char *text, AGS::Common::String &fixed_text);
 void	update_gui_zorder();
 void	export_gui_controls(int ee);
 void	unexport_gui_controls(int ee);
-int		convert_gui_disabled_style(int oldStyle);
 void	update_gui_disabled_status();
 int		adjust_x_for_guis (int xx, int yy);
 int		adjust_y_for_guis ( int yy);

--- a/Engine/ac/guiinv.cpp
+++ b/Engine/ac/guiinv.cpp
@@ -23,7 +23,6 @@
 
 
 extern GameSetupStruct game;
-extern int gui_disabled_style;
 extern GameState play;
 extern CharacterExtras *charextra;
 
@@ -44,7 +43,7 @@ int GUIInvWindow::GetCharacterId() const
 void GUIInvWindow::Draw(Bitmap *ds)
 {
     const bool enabled = IsGUIEnabled(this);
-    if (!enabled && (gui_disabled_style == GUIDIS_BLACKOUT))
+    if (!enabled && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
         return;
 
     // backwards compatibility
@@ -81,7 +80,7 @@ void GUIInvWindow::Draw(Bitmap *ds)
     }
 
     if (!enabled &&
-        gui_disabled_style == GUIDIS_GREYOUT && 
+        GUI::Options.DisabledStyle == kGuiDis_Greyout &&
         play.inventory_greys_out == 1)
     {
         // darken the inventory when disabled

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -578,7 +578,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         on_background_frame_change();
     }
 
-    gui_disabled_style = convert_gui_disabled_style(game.options[OPT_DISABLEOFF]);
+    GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);
 
     // restore the queue now that the music is playing
     play.music_queue_size = queuedMusicSize;

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -105,8 +105,6 @@ int get_eip_guiobj()
   return eip_guiobj;
 }
 
-bool outlineGuiObjects = false;
-
 namespace AGS
 {
 namespace Common

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -832,8 +832,9 @@ void engine_init_game_settings()
     play.game_speed_modifier = 0;
     if (debug_flags & DBG_DEBUGMODE)
         play.debug_mode = 1;
-    gui_disabled_style = convert_gui_disabled_style(game.options[OPT_DISABLEOFF]);
     play.shake_screen_yoff = 0;
+
+    GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);
 
     memset(&play.walkable_areas_on[0],1,MAX_WALK_AREAS+1);
     memset(&play.script_timers[0],0,MAX_TIMERS * sizeof(int));

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -835,6 +835,7 @@ void engine_init_game_settings()
     play.shake_screen_yoff = 0;
 
     GUI::Options.DisabledStyle = static_cast<GuiDisableStyle>(game.options[OPT_DISABLEOFF]);
+    GUI::Options.ClipControls = game.options[OPT_CLIPGUICONTROLS] != 0;
 
     memset(&play.walkable_areas_on[0],1,MAX_WALK_AREAS+1);
     memset(&play.script_timers[0],0,MAX_TIMERS * sizeof(int));

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -520,7 +520,7 @@ static void check_keyboard_controls()
     // pressed, but exclude control characters (<32) and
     // extended keys (eg. up/down arrow; 256+)
     if ( (((kgn >= 32) && (kgn <= 255) && (kgn != '[')) || (kgn == eAGSKeyCodeReturn) || (kgn == eAGSKeyCodeBackspace))
-        && !all_buttons_disabled) {
+        && (all_buttons_disabled < 0)) {
         for (int guiIndex = 0; guiIndex < game.numgui; guiIndex++) {
             auto &gui = guis[guiIndex];
 
@@ -906,7 +906,7 @@ static int UpdateWaitMode()
     auto was_disabled_for = user_disabled_for;
 
     set_default_cursor();
-    if (gui_disabled_style != GUIDIS_UNCHANGED)
+    if (GUI::Options.DisabledStyle != kGuiDis_Unchanged)
     { // If GUI looks change when disabled, then update them all
         GUI::MarkAllGUIForUpdate();
     }
@@ -948,7 +948,7 @@ static int GameTick()
 
 static void SetupLoopParameters(int untilwhat,const void* udata) {
     play.disabled_user_interface++;
-    if (gui_disabled_style != GUIDIS_UNCHANGED)
+    if (GUI::Options.DisabledStyle != kGuiDis_Unchanged)
     { // If GUI looks change when disabled, then update them all
         GUI::MarkAllGUIForUpdate();
     }


### PR DESCRIPTION
Historically AGS does not clip GUI controls, which may result in texts drawn outside of the control rectangle. While users may get used to this, it's not correct in my opinion. Also in some cases (like with the list boxes) it may be difficult to work around.

This PR introduces a game setting, which tells whether to clip control content or not. It's enabled by default in the new 3.6.0 projects, but disabled for projects upgraded from before 3.6.0.

My thinking is that control clipping their contents (text, images etc) should be a default. I may imagine a couple of use cases when one may want to have text drawn outside of the button, for instance, but it seems these may be resolved by combining a button and a label, or having a custom sprite on a button. But I am ready to hear more opinions on this.

EDIT:
Theoretically, I may also add a per-control property, merging it with the Button's "Clip Image". Technically this should be trivial, as this is just an internal engine's flag that may already be applied to any control. But in this case I'm more worried that it will make game design complicated, as people will have to specifically remember to toggle this on or off per each thing that needs it.