### PR TITLE
3.6.0: print SDL logs through our own log system

### DIFF
--- a/Common/debug/debugmanager.cpp
+++ b/Common/debug/debugmanager.cpp
@@ -108,6 +108,7 @@ DebugManager::DebugManager()
     RegisterGroup(DebugGroup(DebugGroupID(kDbgGroup_Script, "script"), "Script"));
     RegisterGroup(DebugGroup(DebugGroupID(kDbgGroup_SprCache, "sprcache"), "Sprite cache"));
     RegisterGroup(DebugGroup(DebugGroupID(kDbgGroup_ManObj, "manobj"), "Managed obj"));
+    RegisterGroup(DebugGroup(DebugGroupID(kDbgGroup_SDL, "sdl"), "SDL"));
     _firstFreeGroupID = _groups.size();
     _lastGroupID = _firstFreeGroupID;
 }

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -95,6 +95,8 @@ enum MessageType
     // Debug reason is for arbitrary information about events and current
     // game state.
     kDbgMsg_Debug               ,
+    // Total number of message types (should be last)
+    kNumDbgMsg                  ,
 
 
     // Convenient aliases

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -116,7 +116,9 @@ enum CommonDebugGroup
     // Sprite cache logging
     kDbgGroup_SprCache,
     // Group for debugging managed object state (can slow engine down!)
-    kDbgGroup_ManObj
+    kDbgGroup_ManObj,
+    // SDL backend group
+    kDbgGroup_SDL
 };
 
 // Debug group identifier defining either numeric or string id, or both

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -104,9 +104,14 @@ struct HashStrNoCase : public std::unary_function<String, size_t>
     }
 };
 
+// Alias for vector of Strings
 typedef std::vector<String> StringV;
+// Alias for case-sensitive hash-map of Strings
 typedef std::unordered_map<String, String> StringMap;
+// Alias for case-insensitive hash-map of Strings
 typedef std::unordered_map<String, String, HashStrNoCase, StrEqNoCase> StringIMap;
+// Alias for std::array of C-strings
+template <size_t SIZE> using CstrArr = std::array<const char*, SIZE>;
 
 } // namespace Common
 } // namespace AGS

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 //
-//
+// Various string helpers.
 //
 //=============================================================================
 #ifndef __AGS_CN_UTIL__STRINGUTILS_H
@@ -20,15 +20,13 @@
 
 #include "util/string_types.h"
 
-namespace AGS { namespace Common { class Stream; } }
-using namespace AGS; // FIXME later
-
-//=============================================================================
-
 namespace AGS
 {
 namespace Common
 {
+
+class Stream;
+
 namespace StrUtil
 {
     enum ConversionError
@@ -74,6 +72,30 @@ namespace StrUtil
     // Serialize and unserialize a string map, both keys and values are read using ReadString
     void            ReadStringMap(StringMap &map, Stream *in);
     void            WriteStringMap(const StringMap &map, Stream *out);
+
+
+    // Parses enum value by name, using provided C-string array,
+    // where strings are compared as case-insensitive; returns def_val if failed;
+    template<typename T, std::size_t SIZE>
+    T ParseEnum(const String &option, const CstrArr<SIZE>& arr, const T def_val = static_cast<T>(-1))
+    {
+        for (auto it = arr.cbegin(); it < arr.cend(); ++it)
+            if ((*it && *it[0] != 0) && (option.CompareNoCase(*it) == 0))
+                return static_cast<T>(it - arr.begin());
+        return def_val;
+    }
+    // Parses enum value either as a number, or searching withing the C-string array,
+    // where strings are compared as case-insensitive; returns def_val if failed to do both
+    template<typename T, std::size_t SIZE>
+    T ParseEnumAllowNum(const String &option, const CstrArr<SIZE>& arr, const T def_val = static_cast<T>(-1))
+    {
+        int num = StrUtil::StringToInt(option, -1);
+        if (num >= 0) return static_cast<T>(num);
+        for (auto it = arr.cbegin(); it < arr.cend(); ++it)
+            if ((*it && *it[0] != 0) && (option.CompareNoCase(*it) == 0))
+                return static_cast<T>(it - arr.begin());
+        return def_val;
+    }
 }
 } // namespace Common
 } // namespace AGS

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -260,7 +260,24 @@ void init_debug(const ConfigTree &cfg, bool stderr_only)
 {
     // Setup SDL output
     SDL_LogSetOutputFunction(SDL_Log_Output, nullptr);
-    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_INFO); // TODO: backend log verbosity from config
+    String sdl_log = INIreadstring(cfg, "log", "sdl", "info");
+    int priority;
+    if (StrUtil::StringToInt(sdl_log, priority, 0) == StrUtil::kNoError)
+    {
+        SDL_LogSetAllPriority(static_cast<SDL_LogPriority>(priority));
+    }
+    else
+    {
+        const char *sdl_priority[SDL_NUM_LOG_PRIORITIES] = { "", "verbose", "debug", "info", "warn", "error", "critical" };
+        for (size_t i = 0; i < SDL_NUM_LOG_PRIORITIES; ++i)
+        {
+            if (sdl_log.CompareNoCase(sdl_priority[i]) == 0)
+            {
+                SDL_LogSetAllPriority(static_cast<SDL_LogPriority>(i));
+                break;
+            }
+        }
+    }
 
     // Register outputs
     apply_debug_config(cfg);

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -144,26 +144,16 @@ enum ScreenSizeDefinition
 
 static ScreenSizeDefinition parse_legacy_screendef(const String &option)
 {
-    const char *screen_sz_def_options[kNumScreenDef] = { "explicit", "scaling", "max" };
-    for (int i = 0; i < kNumScreenDef; ++i)
-    {
-        if (option.CompareNoCase(screen_sz_def_options[i]) == 0)
-        {
-            return (ScreenSizeDefinition)i;
-        }
-    }
-    return kScreenDef_Undefined;
+    return StrUtil::ParseEnum<ScreenSizeDefinition>(option,
+        CstrArr<kNumScreenDef>{"explicit", "scaling", "max"}, kScreenDef_Undefined);
 }
 
 FrameScaleDef parse_scaling_option(const String &option, FrameScaleDef def_value)
 {
-    if (option.CompareNoCase("round") == 0 || option.CompareNoCase("max_round") == 0)
-        return kFrame_Round;
-    if (option.CompareNoCase("stretch") == 0)
-        return kFrame_Stretch;
-    if (option.CompareNoCase("proportional") == 0)
-        return kFrame_Proportional;
-    return def_value;
+    // Backward compatible option name from the previous versions
+    if (option.CompareNoCase("max_round") == 0) return kFrame_Round;
+    return StrUtil::ParseEnum<FrameScaleDef>(option,
+        CstrArr<kNumFrameScaleDef>{"round", "stretch", "proportional"}, def_value);
 }
 
 static FrameScaleDef parse_legacy_scaling_option(const String &option, int &scale)
@@ -479,47 +469,19 @@ void apply_config(const ConfigTree &cfg)
         usetup.mouse_speed = INIreadfloat(cfg, "mouse", "speed", 1.f);
         if (usetup.mouse_speed <= 0.f)
             usetup.mouse_speed = 1.f;
-        const char *mouse_ctrl_options[kNumMouseCtrlOptions] = { "never", "fullscreen", "always" };
         String mouse_str = INIreadstring(cfg, "mouse", "control_when", "fullscreen");
-        for (int i = 0; i < kNumMouseCtrlOptions; ++i)
-        {
-            if (mouse_str.CompareNoCase(mouse_ctrl_options[i]) == 0)
-            {
-                usetup.mouse_ctrl_when = (MouseControlWhen)i;
-                break;
-            }
-        }
+        usetup.mouse_ctrl_when = StrUtil::ParseEnum<MouseControlWhen>(
+            mouse_str, CstrArr<kNumMouseCtrlOptions>{ "never", "fullscreen", "always" },
+                usetup.mouse_ctrl_when);
         usetup.mouse_ctrl_enabled = INIreadint(cfg, "mouse", "control_enabled", usetup.mouse_ctrl_enabled) > 0;
-        const char *mouse_speed_options[kNumMouseSpeedDefs] = { "absolute", "current_display" };
         mouse_str = INIreadstring(cfg, "mouse", "speed_def", "current_display");
-        for (int i = 0; i < kNumMouseSpeedDefs; ++i)
-        {
-            if (mouse_str.CompareNoCase(mouse_speed_options[i]) == 0)
-            {
-                usetup.mouse_speed_def = (MouseSpeedDef)i;
-                break;
-            }
-        }
+        usetup.mouse_speed_def = StrUtil::ParseEnum<MouseSpeedDef>(
+            mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
         usetup.override_multitasking = INIreadint(cfg, "override", "multitasking", -1);
         String override_os = INIreadstring(cfg, "override", "os");
-        usetup.override_script_os = -1;
-        if (override_os.CompareNoCase("dos") == 0)
-        {
-            usetup.override_script_os = eOS_DOS;
-        }
-        else if (override_os.CompareNoCase("win") == 0)
-        {
-            usetup.override_script_os = eOS_Win;
-        }
-        else if (override_os.CompareNoCase("linux") == 0)
-        {
-            usetup.override_script_os = eOS_Linux;
-        }
-        else if (override_os.CompareNoCase("mac") == 0)
-        {
-            usetup.override_script_os = eOS_Mac;
-        }
+        usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(
+            override_os, CstrArr<5>{"", "dos", "win", "linux", "mac"}, (eScriptSystemOSID)-1);
         usetup.override_upscale = INIreadint(cfg, "override", "upscale", usetup.override_upscale) > 0;
     }
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -480,8 +480,8 @@ void apply_config(const ConfigTree &cfg)
 
         usetup.override_multitasking = INIreadint(cfg, "override", "multitasking", -1);
         String override_os = INIreadstring(cfg, "override", "os");
-        usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(
-            override_os, CstrArr<5>{"", "dos", "win", "linux", "mac"}, (eScriptSystemOSID)-1);
+        usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(override_os,
+            CstrArr<eNumOS>{"", "dos", "win", "linux", "mac", "android", "ios", "psp", "web", "freebsd"}, eOS_Unknown);
         usetup.override_upscale = INIreadint(cfg, "override", "upscale", usetup.override_upscale) > 0;
     }
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -868,7 +868,7 @@ void engine_setup_scsystem_auxiliary()
 {
     // ScriptSystem::aci_version is only 10 chars long
     strncpy(scsystem.aci_version, EngineVersion.LongString.GetCStr(), 10);
-    if (usetup.override_script_os >= 0)
+    if (usetup.override_script_os > eOS_Unknown)
     {
         scsystem.os = usetup.override_script_os;
     }

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -205,6 +205,10 @@ void main_print_help() {
            "  --nospr                      Don't draw room objects and characters\n"
            "  --noupdate                   Don't run game update\n"
            "  --novideo                    Don't play game videos\n"
+           "  --sdl-log=LEVEL              Setup SDL backend logging level\n"
+           "                               LEVELs are:\n"
+           "                                 verbose (1), debug (2), info (3), warn (4),\n"
+           "                                 error (5), critical (6)\n"
 #if AGS_PLATFORM_OS_WINDOWS
            "  --setup                      Run setup application\n"
 #endif
@@ -358,6 +362,10 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
                 cfg["log"][logarg.Left(split_at)] = logarg.Mid(split_at + 1);
             else
                 cfg["log"][logarg] = "";
+        }
+        else if (ags_strnicmp(arg, "--sdl-log", 9) == 0 && arg[9] == '=')
+        {
+            cfg["log"]["sdl"] = arg + 10;
         }
         else if (ags_stricmp(arg, "--console-attach") == 0) attachToParentConsole = true;
         else if (ags_stricmp(arg, "--no-message-box") == 0) hideMessageBoxes = true;

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -37,7 +37,8 @@ using namespace AGS; // FIXME later
 
 enum eScriptSystemOSID
 {
-    eOS_DOS = 1,
+    eOS_Unknown = 0,
+    eOS_DOS,
     eOS_Win,
     eOS_Linux,
     eOS_Mac,
@@ -45,7 +46,8 @@ enum eScriptSystemOSID
     eOS_iOS,
     eOS_PSP,
     eOS_Web,
-    eOS_FreeBSD
+    eOS_FreeBSD,
+    eNumOS
 };
 
 enum SetupReturnValue

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -27,8 +27,6 @@ using namespace AGS::Engine;
 // ----------------------------------------------------------------------------
 
 int sys_main_init(/*config*/) {
-    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE); // TODO: backend log verbosity from config
-
     // TODO: setup these subsystems in config rather than keep hardcoded?
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) != 0) {
         Debug::Printf(kDbgMsg_Error, "Unable to initialize SDL: %s", SDL_GetError());

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -88,18 +88,20 @@ Locations of two latter files differ between running platforms:
   * cachemax = \[integer\] - size of the engine's sprite cache, in kilobytes. Default is 131072 (128 MB).
 * **\[log\]** - log options, allow to setup logging to the chosen OUTPUT with given log groups and verbosity levels.
   * \[outputname\] = GROUP[:LEVEL][,GROUP[:LEVEL]][,...];
-  * \[outputname\] = +GROUPLIST[:LEVEL];<br>
-    Groups may be defined either by name or by a LIST of one-letter IDs, preceded by '+', e.g. +ABCD:LEVEL. Verbosity may be defined either by name or a numberic ID.
+  * \[outputname\] = +GROUPLIST[:LEVEL];
+    Groups may be defined either by name or by a LIST of one-letter IDs, preceded by '+', e.g. +ABCD:LEVEL. Verbosity may be defined either by name or a numeric ID.
     - OUTPUTs are:
       * stdout, file, console (where \"console\" is internal engine's console);
     - GROUPs are:
-      * all, main (m), game (g), manobj (o), sprcache (c);
+      * all, main (m), game (g), manobj (o), sdl (l), sprcache (c);
     - LEVELs are:
       * all, alert (1), fatal (2), error (3), warn (4), info (5), debug (6);
     - Examples:
       * file=all:warn
       * stdout=+mg:debug
   * file-path = \[string\] - custom path to the log file.
+  * sdl = LEVEL - setup SDL's own logging level, defined either by name or numeric ID:
+    * verbose (1), debug (2), info (3), warn (4), error (5), critical (6).
 * **\[override\]** - special options, overriding game behavior.
   * multitasking = \[0; 1\] - lock the game in the "single-tasking" or "multitasking" mode. In the nutshell, "multitasking" here means that the game will continue running when player switched away from game window; otherwise it will freeze until player switches back.
   * os = \[string\] - trick the game to think that it runs on a particular operating system. This may come handy if the game is scripted to play differently depending on OS. Possible choices are:
@@ -134,7 +136,7 @@ Following OPTIONS are supported when running from command line:
 * --loadsavedgame \<filepath\> - load savegame on startup.
 * --localuserconf - read and write user config in the game's directory rather than using standard system path. Game directory must be writeable.
 * --log-OUTPUT=GROUP[:LEVEL][,GROUP[:LEVEL]][,...];
-* --log-OUTPUT=+GROUPLIST[:LEVEL] - setup logging to the chosen OUTPUT with given log groups and verbosity levels (see explanation above).
+* --log-OUTPUT=+GROUPLIST[:LEVEL] - setup logging to the chosen OUTPUT with given log groups and verbosity levels (see explanation for the related config option).
   * Examples:
     * --log-file=all:warn
     * --log-stdout=+mg:debug
@@ -145,6 +147,7 @@ Following OPTIONS are supported when running from command line:
 * --nospr - don't draw room objects and characters (for test purposes).
 * --noupdate - don't run game update (for test purposes).
 * --novideo - don't play game videos (for test purposes).
+* --sdl-log=LEVEL - setup SDL's own logging level (see explanation for the related config option).
 * --setup - run integrated setup dialog. Currently only supported by Windows version.
 * --shared-data-dir \<DIR\> - set the shared game data directory. Corresponds to "shared_data_dir" config option.
 * --startr \<room_number\> - start game by loading certain room (for test purposes).


### PR DESCRIPTION
Also fixes #1359.

SDL2 log will be printed using our own log system.
Added new log group called `"sdl"` which may be configured same way as any other log groups.

SDL2 has default message priority "info" (`SDL_LOG_PRIORITY_INFO`).
Added separate config option for SDL's priority:
In config: `[log] sdl=<priority>`
In command line: `--sdl-log=<priority>`

Where "priority" may be: `verbose`, `debug`, `info`, `warn`, `error`, `critical`.

This separate option is necessary, because SDL has a different way of setting message level: it sets priority per group; while we set priority per group _per output_.

Examples of use:
* in command line
`--sdl-log=verbose --log-file=sdl:all`
`--sdl-log=info --log-stdout=all:info`
* or config
```
[log]
file=all:all
sdl=warn
```