### PR TITLE
CI: upgrade MacOS versions from deprecated Mojave

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,8 +119,8 @@ build_macos_task:
   only_if: $CIRRUS_RELEASE == ''
   osx_instance:
     matrix:
-      - image: mojave-xcode-10.2   # newest minor release of previous version
-      - image: mojave-xcode        # alias to latest xcode (11.x)
+      - image: monterey-xcode-13.2 # newest minor release of previous version
+      - image: big-sur-xcode-12.3  # oldest xcode image available in cirrus
   env:
     matrix:
       - BUILD_TYPE: debug


### PR DESCRIPTION
This is very minor, it won't change performance or anything, on our CI, but currently according to Cirrus docs available MacOS images are Monterrey and Big Sur - they are listed in the docs below. 

https://cirrus-ci.org/guide/macOS/

Our Mojave is being automatically updated to Catalina, but Catalina images are deprecated (according to the docs), this becomes two builds of the same thing (same Catalina image).

This is not related to this weekend MacOS slow builds - I asked Cirrus about it, but haven't been updated on it yet.