### PR TITLE
3.6.0 Editor: fixed sprites never deleted from spritefile

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -480,6 +480,8 @@ int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompr
 
 HError SpriteCache::InitFile(const String &filename, const String &sprindex_filename)
 {
+    Reset();
+
     std::vector<Size> metrics;
     HError err = _file.OpenFile(filename, sprindex_filename, metrics);
     if (!err)
@@ -497,7 +499,6 @@ HError SpriteCache::InitFile(const String &filename, const String &sprindex_file
         {
             // Existing sprite
             _spriteData[i].Flags = SPRCACHEFLAG_ISASSET;
-            _spriteData[i].Image = nullptr;
             get_new_size_for_sprite(i, metrics[i].Width, metrics[i].Height, _sprInfos[i].Width, _sprInfos[i].Height);
         }
         else

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -464,16 +464,16 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index)
 
 int SpriteCache::SaveToFile(const String &filename, int store_flags, SpriteCompression compress, SpriteFileIndex &index)
 {
-    std::vector<Bitmap*> sprites;
-    for (const auto &data : _spriteData)
+    std::vector<std::pair<bool, Bitmap*>> sprites;
+    for (size_t i = 0; i < _spriteData.size(); ++i)
     {
         // NOTE: this is a horrible hack:
         // because Editor expects slightly different RGB order, it swaps colors
         // when loading them (call to initialize_sprite), so here we basically
         // unfix that fix to save the data in a way that engine will expect.
         // TODO: perhaps adjust the editor to NOT need this?!
-        pre_save_sprite(data.Image);
-        sprites.push_back(data.Image);
+        pre_save_sprite(_spriteData[i].Image);
+        sprites.push_back(std::make_pair(DoesSpriteExist(i), _spriteData[i].Image));
     }
     return SaveSpriteFile(filename, sprites, &_file, store_flags, compress, index);
 }

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -155,6 +155,8 @@ SpriteFile::SpriteFile()
 HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filename,
     std::vector<Size> &metrics)
 {
+    Close();
+
     char buff[20];
     soff_t spr_initial_offs = 0;
     int spriteFileID = 0;
@@ -236,6 +238,10 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
 void SpriteFile::Close()
 {
     _stream.reset();
+    _spriteData.clear();
+    _version = kSprfVersion_Undefined;
+    _storeFlags = 0;
+    _compress = kSprCompress_None;
     _curPos = -2;
 }
 

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -508,18 +508,18 @@ void SpriteFile::SeekToSprite(sprkey_t index)
 }
 
 
-// Finds the topmost occupied slot index. Warning: may be slow.
-static sprkey_t FindTopmostSprite(const std::vector<Bitmap*> &sprites)
+// Finds the topmost occupied slot index
+static sprkey_t FindTopmostSprite(const std::vector<std::pair<bool, Bitmap*>> &sprites)
 {
     sprkey_t topmost = -1;
     for (sprkey_t i = 0; i < static_cast<sprkey_t>(sprites.size()); ++i)
-        if (sprites[i])
+        if (sprites[i].first)
             topmost = i;
     return topmost;
 }
 
 int SaveSpriteFile(const String &save_to_file,
-    const std::vector<Bitmap*> &sprites,
+    const std::vector<std::pair<bool, Bitmap*>> &sprites,
     SpriteFile *read_from_file,
     int store_flags, SpriteCompression compress, SpriteFileIndex &index)
 {
@@ -527,9 +527,7 @@ int SaveSpriteFile(const String &save_to_file,
     if (output == nullptr)
         return -1;
 
-    sprkey_t lastslot = read_from_file ? read_from_file->GetTopmostSprite() : 0;
-    lastslot = std::max(lastslot, FindTopmostSprite(sprites));
-
+    sprkey_t lastslot = FindTopmostSprite(sprites);
     SpriteFileWriter writer(std::move(output));
     writer.Begin(store_flags, compress, lastslot);
 
@@ -544,8 +542,13 @@ int SaveSpriteFile(const String &save_to_file,
 
     for (sprkey_t i = 0; i <= lastslot; ++i)
     {
-        Bitmap *image = (size_t)i < sprites.size() ? sprites[i] : nullptr;
+        if (!sprites[i].first)
+        { // empty slot
+            writer.WriteEmptySlot();
+            continue;
+        }
 
+        Bitmap *image = sprites[i].second;
         // if compression setting is different, load the sprite into memory
         // (otherwise we will be able to simply copy bytes from one file to another
         if ((image == nullptr) && diff_compress)

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -40,6 +40,7 @@ class Bitmap;
 // TODO: research old version differences
 enum SpriteFileVersion
 {
+    kSprfVersion_Undefined = 0,
     kSprfVersion_Uncompressed = 4,
     kSprfVersion_Compressed = 5,
     kSprfVersion_Last32bit = 6,
@@ -150,8 +151,6 @@ public:
     HError      LoadSprite(sprkey_t index, Bitmap *&sprite);
     // Loads a raw sprite element data into the buffer, stores header info separately
     HError      LoadRawData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data);
-    HError      LoadSpriteData(sprkey_t index, SpriteDatHeader &hdr, std::vector<uint8_t> &data,
-        std::vector<uint32_t> &palette);
 
 private:
     // Seek stream to sprite

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -215,10 +215,13 @@ private:
 };
 
 
-// Saves all sprites to file; fills in index data for external use
+// Saves all sprites to file; fills in index data for external use.
 // TODO: refactor to be able to save main file and index file separately (separate function for gather data?)
+// Accepts available sprites as pairs of bool and Bitmap pointer, where boolean value
+// tells if sprite exists and Bitmap pointer may be null;
+// If a sprite's bitmap is missing, it will try reading one from the input file stream.
 int SaveSpriteFile(const String &save_to_file,
-    const std::vector<Bitmap*> &sprites, // available sprites (may contain nullptrs)
+    const std::vector<std::pair<bool, Bitmap*>> &sprites,
     SpriteFile *read_from_file, // optional file to read missing sprites from
     int store_flags, SpriteCompression compress, SpriteFileIndex &index);
 // Saves sprite index table in a separate file

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -176,6 +176,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System" />
     <Reference Include="System.Drawing">
       <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1138,7 +1138,6 @@ bool initialize_native()
 	thisgame.numfonts = 0;
 	new_font();
 
-	spriteset.Reset();
 	HAGSError err = spriteset.InitFile(sprsetname, sprindexname);
 	if (!err)
 	  return false;
@@ -1354,7 +1353,6 @@ bool reload_font(int curFont)
 }
 
 HAGSError reset_sprite_file() {
-  spriteset.Reset();
   HAGSError err = spriteset.InitFile(sprsetname, sprindexname);
   if (!err)
     return err;
@@ -1898,7 +1896,6 @@ void SaveNativeSprites(Settings^ gameSettings)
     finally
     {
         // Reset the sprite cache to whichever file was successfully saved
-        spriteset.Reset();
         HAGSError err = spriteset.InitFile(saved_spritefile, saved_indexfile);
         if (!err)
         {


### PR DESCRIPTION
The commit 393ef2c24bbc835d8e7a7229d40f638a6f172304 has introduced a bug, where saving spritefile would unintentionally restore all the sprites that were deleted during the session.

Sprites are not all stored in memory, and when the file is saved, these that were not loaded at the moment would be read from the *previous* version of the file, and copied into new one. Aftter certain changes the code was missing a proper check for non-existing sprites. Because of that all the sprites that were in the previous file but marked for deletion are still carried over.
And because their references are removed from the project, these would be non accessible, and user won't even know about the leftover data, unless they try to import new sprites and notice they cannot assign a presumably "empty" slot to them.

This PR fixes the problem, but also implements a cleanup procedure, where Editor would test for sprite data that does not have a proper reference inside a project, and mark it for deletion. This procedure is run right after the game is loaded.
