### PR TITLE
Editor: Android build feature

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,30 +149,15 @@ build_android_task:
     greedy: true
   git_submodules_script: git submodule update --init --recursive
   build_debug_library_and_runtime_script: |
-    pushd Android/agsplayer && ./gradlew assembleDebug && popd
+    pushd Android && ./and-build.sh build_debug && popd
   build_release_library_and_runtime_script: |
-    pushd Android/agsplayer && ./gradlew assembleRelease && popd
-    bsdtar -f android-libs-release.zip -acv --strip-components 8 Android/agsplayer/app/build/intermediates/stripped_native_libs/release/out/lib
+    pushd Android && ./and-build.sh build_release && popd
   rename_apks_script: |
-    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
-    pushd Android/agsplayer/app/build/outputs/apk/debug/
-    for apk in $(find -maxdepth 1 -name "*.apk" -type f); do
-      mv -v $apk AGS-${version}-${apk#*-}
-    done
-    popd
-    mv Android/agsplayer/app/build/outputs/apk/debug/*.apk .
-    pushd Android/agsplayer/app/build/outputs/apk/release/
-    for apk in $(find -maxdepth 1 -name "*.apk" -type f); do
-      mv -v $apk AGS-${version}-${apk#*-}
-    done
-    popd
-    mv Android/agsplayer/app/build/outputs/apk/release/*.apk .
+    pushd Android && ./and-build.sh archive_apks && popd
   apks_artifacts:
     path: AGS-*.apk
   create_libs_archive_script: |
-    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
-    bsdtar -f AGS-${version}-android-libs-debug.zip -acv --strip-components 8 Android/agsplayer/app/build/intermediates/stripped_native_libs/debug/out/lib
-    bsdtar -f AGS-${version}-android-libs-release.zip -acv --strip-components 8 Android/agsplayer/app/build/intermediates/stripped_native_libs/release/out/lib
+    pushd Android && ./and-build.sh archive_libs && popd
   libs_artifacts:
     path: AGS-*-android-libs-*.zip
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -238,6 +238,7 @@ windows_packaging_task:
     - build_windows
     - linux_packaging
     - build_emscripten
+    - build_android
   windows_container:
     dockerfile: ci/windows/Dockerfile
     os_version: 2019
@@ -275,6 +276,11 @@ windows_packaging_task:
     call Script\setvar.cmd ACI_VERSION_STR &&
     cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_emscripten/binaries/ags_!ACI_VERSION_STR!_web.tar.gz" |
     tar -f - -xvC Windows\Installer\Source\Web"
+  get_android_bundle_script: >
+    mkdir Windows\Installer\Source\Android &&
+    call Script\setvar.cmd ACI_VERSION_STR &&
+    cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_android/proj/AGS-!ACI_VERSION_STR!-android-proj-release.zip" --output "%TEMP%\Android.zip" &&
+    tar -f "%TEMP%\Android.zip" -xvzC Windows\Installer\Source\Android"
   make_installer_script: >
     powershell Windows\Installer\build.ps1 -IsccPath 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
   installer_artifacts:
@@ -285,6 +291,7 @@ windows_packaging_task:
     move Windows\Installer\Source\Licenses Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Linux Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Web Windows\Installer\Source\Editor\ &&
+    move Windows\Installer\Source\Android Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Templates Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\URLs Windows\Installer\Source\Editor\ &&
     for %%f in (Windows\Installer\Output\*.exe) do

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -148,6 +148,8 @@ build_android_task:
     memory: 8G
     greedy: true
   git_submodules_script: git submodule update --init --recursive
+  build_prepare_script: |
+    pushd Android && ./and-build.sh prepare && popd
   build_debug_library_and_runtime_script: |
     pushd Android && ./and-build.sh build_debug && popd
   build_release_library_and_runtime_script: |
@@ -156,10 +158,10 @@ build_android_task:
     pushd Android && ./and-build.sh archive_apks && popd
   apks_artifacts:
     path: AGS-*.apk
-  create_libs_archive_script: |
-    pushd Android && ./and-build.sh archive_libs && popd
-  libs_artifacts:
-    path: AGS-*-android-libs-*.zip
+  create_proj_archive_script: |
+    pushd Android && ./and-build.sh archive_project && popd
+  proj_artifacts:
+    path: AGS-*-android-proj-*.zip
 
 
 build_emscripten_task:
@@ -389,8 +391,8 @@ make_release_task:
       "build_linux_debian/debian_packages/ags_${version}_amd64.deb" \
       "build_android/apks/AGS-${version}-debug.apk" \
       "build_android/apks/AGS-${version}-release.apk" \
-      "build_android/libs/AGS-${version}-android-libs-debug.zip" \
-      "build_android/libs/AGS-${version}-android-libs-release.zip"
+      "build_android/proj/AGS-${version}-android-proj-debug.zip" \
+      "build_android/proj/AGS-${version}-android-proj-release.zip"
     do
       url="$baseurl/$download"
       echo "Downloading $url"

--- a/Android/agsplayer/app/src/main/AndroidManifest.xml
+++ b/Android/agsplayer/app/src/main/AndroidManifest.xml
@@ -21,6 +21,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".AGSPlayerRuntimeActivity"
+            android:alwaysRetainTaskState="true"
+            android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
+            android:label="@string/app_name"
+            android:launchMode="singleInstance">
+        </activity>
     </application>
 
 </manifest>

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/AGSPlayerRuntimeActivity.java
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/AGSPlayerRuntimeActivity.java
@@ -1,0 +1,90 @@
+package uk.co.adventuregamestudio.agsplayer;
+
+import android.Manifest;
+import android.app.AlertDialog;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.Keep;
+import androidx.core.app.ActivityCompat;
+
+import uk.co.adventuregamestudio.runtime.AGSRuntimeActivity;
+
+public class AGSPlayerRuntimeActivity extends AGSRuntimeActivity {
+    protected final int[] externalStorageRequestDummy = new int[1];
+    public static final int EXTERNAL_STORAGE_REQUEST_CODE = 2;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        if(!hasExternalStoragePermission())
+        {
+            showExternalStoragePermissionMissingDialog();
+        }
+
+        super.onCreate(savedInstanceState);
+    }
+
+
+    public void showExternalStoragePermissionMissingDialog() {
+        AlertDialog dialog = new AlertDialog.Builder(mSingleton)
+                .setTitle("Storage Permission Missing")
+                .setMessage("AGS for Android will not be able to run non-packaged games without storage permission.")
+                .setNeutralButton("Continue", null)
+                .create();
+        dialog.show();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (grantResults.length > 0) {
+            Log.d("AGSRuntimeActivity", "Received a request permission result");
+
+            switch (requestCode) {
+                case EXTERNAL_STORAGE_REQUEST_CODE: {
+                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        Log.d("AGSRuntimeActivity", "Permission granted");
+                    } else {
+                        Log.d("AGSRuntimeActivity", "Did not get permission.");
+                        if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                            showExternalStoragePermissionMissingDialog();
+                        }
+                    }
+
+                    Log.d("AGSRuntimeActivity", "Unlocking AGS thread");
+                    synchronized (externalStorageRequestDummy) {
+                        externalStorageRequestDummy[0] = grantResults[0];
+                        externalStorageRequestDummy.notify();
+                    }
+                    break;
+                }
+                default:
+                    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            }
+        }
+    }
+
+
+    @Keep
+    public boolean hasExternalStoragePermission() {
+        if (ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.READ_EXTERNAL_STORAGE)
+                == PackageManager.PERMISSION_GRANTED) {
+            return true;
+        }
+
+        Log.d("AGSRuntimeActivity", "Requesting permission and locking AGS thread until we have an answer.");
+        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, EXTERNAL_STORAGE_REQUEST_CODE);
+
+        synchronized (externalStorageRequestDummy) {
+            try {
+                externalStorageRequestDummy.wait();
+            } catch (InterruptedException e) {
+                Log.d("AGSRuntimeActivity", "requesting external storage permission", e);
+                return false;
+            }
+        }
+
+        return ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import uk.co.adventuregamestudio.runtime.PreferencesActivity
-import uk.co.adventuregamestudio.runtime.AGSRuntimeActivity
 import uk.co.adventuregamestudio.runtime.CreditsActivity
 import uk.co.adventuregamestudio.runtime.NativeHelper
 import java.io.File
@@ -34,6 +33,7 @@ import java.io.FilenameFilter
 import java.util.*
 import kotlin.collections.ArrayList
 import uk.co.adventuregamestudio.agsplayer.FileUtil
+import uk.co.adventuregamestudio.agsplayer.AGSPlayerRuntimeActivity
 
 
 class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickListener, GameListRecyclerViewAdapter.ItemCreateContextMenuListener {
@@ -224,7 +224,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
 //    }
 
     private fun startGame(filename: String, loadLastSave: Boolean) {
-        val intent = Intent(this, AGSRuntimeActivity::class.java)
+        val intent = Intent(this, AGSPlayerRuntimeActivity::class.java)
         val b = Bundle()
         b.putString("filename", filename)
         b.putString("directory", baseDirectory)

--- a/Android/and-build.sh
+++ b/Android/and-build.sh
@@ -4,6 +4,39 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 TAR_CMD="bsdtar"
 command -v bsdtar >/dev/null 2>&1 || { TAR_CMD="tar" ; }
 
+function prepare_package {
+  echo "Do this only before any build, or after a full clean."
+  echo "doing preparations..."
+  pushd "${SCRIPT_DIR}"
+  [[ -d package_debug ]] && rm -rf package_debug
+  [[ -d package_release ]] && rm -rf package_release
+  mkdir package_debug
+  mkdir package_release
+  cp -r library package_debug/library
+  cp -r misc package_debug/misc
+  cp -r mygame package_debug/mygame
+  cp -r gradle package_debug/gradle
+  
+  cp -r library package_release/library
+  cp -r misc package_release/misc
+  cp -r mygame package_release/mygame
+  cp -r gradle package_release/gradle
+  
+  mkdir package_release/mygame/gradle
+  mkdir package_release/mygame/gradle/wrapper
+  mkdir package_debug/mygame/gradle
+  mkdir package_debug/mygame/gradle/wrapper
+  
+  cp agsplayer/gradle/wrapper/gradle-wrapper.jar package_release/mygame/gradle/wrapper/
+  cp agsplayer/gradle/wrapper/gradle-wrapper.properties package_release/mygame/gradle/wrapper/
+    
+  cp agsplayer/gradle/wrapper/gradle-wrapper.jar package_debug/mygame/gradle/wrapper/
+  cp agsplayer/gradle/wrapper/gradle-wrapper.properties package_debug/mygame/gradle/wrapper/
+  
+  popd
+  echo "done!"
+}
+
 function build_debug_library_and_runtime {
   echo "building debug library and runtime..."
   pushd "${SCRIPT_DIR}"
@@ -40,12 +73,14 @@ function rename_apks {
   echo "done!"
 }
 
-function create_libs_archive {
+function create_proj_archive {
   echo "creating libs archive..."
   pushd "${SCRIPT_DIR}"
   version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' ../Common/core/def_version.h)
-  ${TAR_CMD} -f ../AGS-${version}-android-libs-debug.zip -acv --strip-components 8 agsplayer/app/build/intermediates/stripped_native_libs/debug/out/lib
-  ${TAR_CMD} -f ../AGS-${version}-android-libs-release.zip -acv --strip-components 8 agsplayer/app/build/intermediates/stripped_native_libs/release/out/lib
+  cp -rf agsplayer/app/build/intermediates/stripped_native_libs/debug/out/lib/* package_debug/library/runtime/libs
+  cp -rf agsplayer/app/build/intermediates/stripped_native_libs/release/out/lib/* package_release/library/runtime/libs
+  ${TAR_CMD} -f ../AGS-${version}-android-proj-debug.zip -acv --strip-components 1 package_debug
+  ${TAR_CMD} -f ../AGS-${version}-android-proj-release.zip -acv --strip-components 1 package_release
   popd
   echo "done!"
 }
@@ -56,11 +91,12 @@ function usage
    echo
    echo "Syntax: and-build.sh [options]"
    echo "options:"
-   echo "build_debug"
-   echo "build_release"
-   echo "archive_apks"
-   echo "archive_libs"
-   echo "-h --help  prints this message."
+   echo "  prepare"
+   echo "  build_debug"
+   echo "  build_release"
+   echo "  archive_apks"
+   echo "  archive_project"
+   echo "  -h --help  prints this message."
    echo
 }
 
@@ -70,7 +106,10 @@ if [[ $# -eq 0 ]]; then
 fi
 
 while : ; do
-  case "$1" in 
+  case "$1" in
+    prepare)
+       prepare_package
+       shift 1 ;;
     build_debug)
        build_debug_library_and_runtime
        shift 1 ;;
@@ -79,9 +118,9 @@ while : ; do
        shift 1 ;;
     archive_apks)
        rename_apks
-       shift 1 ;;    
-    archive_libs)
-       create_libs_archive
+       shift 1 ;;
+    archive_project)
+       create_proj_archive
        shift 1 ;;
     -h|--help)
        usage

--- a/Android/and-build.sh
+++ b/Android/and-build.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+TAR_CMD="bsdtar"
+command -v bsdtar >/dev/null 2>&1 || { TAR_CMD="tar" ; }
+
+function build_debug_library_and_runtime {
+  echo "building debug library and runtime..."
+  pushd "${SCRIPT_DIR}"
+  pushd agsplayer && ./gradlew assembleDebug --console=plain && popd
+  popd
+  echo "done!"
+}
+
+function build_release_library_and_runtime {
+  echo "building release library and runtime..."
+  pushd "${SCRIPT_DIR}"
+  pushd agsplayer && ./gradlew assembleRelease --console=plain && popd
+  popd
+  echo "done!"
+}
+
+function rename_apks {
+  echo "renaming apks..."
+  pushd "${SCRIPT_DIR}"
+  version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' ../Common/core/def_version.h)
+  pushd agsplayer/app/build/outputs/apk/debug/
+  for apk in $(find -maxdepth 1 -name "*.apk" -type f); do
+    mv -v $apk AGS-${version}-${apk#*-}
+  done
+  popd
+  mv agsplayer/app/build/outputs/apk/debug/*.apk ..
+  pushd agsplayer/app/build/outputs/apk/release/
+  for apk in $(find -maxdepth 1 -name "*.apk" -type f); do
+    mv -v $apk AGS-${version}-${apk#*-}
+  done
+  popd
+  mv agsplayer/app/build/outputs/apk/release/*.apk ..
+  popd
+  echo "done!"
+}
+
+function create_libs_archive {
+  echo "creating libs archive..."
+  pushd "${SCRIPT_DIR}"
+  version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' ../Common/core/def_version.h)
+  ${TAR_CMD} -f ../AGS-${version}-android-libs-debug.zip -acv --strip-components 8 agsplayer/app/build/intermediates/stripped_native_libs/debug/out/lib
+  ${TAR_CMD} -f ../AGS-${version}-android-libs-release.zip -acv --strip-components 8 agsplayer/app/build/intermediates/stripped_native_libs/release/out/lib
+  popd
+  echo "done!"
+}
+
+function usage
+{
+   echo "android build script."
+   echo
+   echo "Syntax: and-build.sh [options]"
+   echo "options:"
+   echo "build_debug"
+   echo "build_release"
+   echo "archive_apks"
+   echo "archive_libs"
+   echo "-h --help  prints this message."
+   echo
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit
+fi
+
+while : ; do
+  case "$1" in 
+    build_debug)
+       build_debug_library_and_runtime
+       shift 1 ;;
+    build_release)
+       build_release_library_and_runtime
+       shift 1 ;;
+    archive_apks)
+       rename_apks
+       shift 1 ;;    
+    archive_libs)
+       create_libs_archive
+       shift 1 ;;
+    -h|--help)
+       usage
+       break ;;
+    *)
+       break ;;
+  esac
+done

--- a/Android/library/runtime/src/main/AndroidManifest.xml
+++ b/Android/library/runtime/src/main/AndroidManifest.xml
@@ -19,11 +19,9 @@
         android:required="false" /> <!-- External mouse input events -->
     <uses-feature
         android:name="android.hardware.type.pc"
-        android:required="false" /> <!-- Allow writing to external storage -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Allow reading to external storage -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" /> <!-- Allow access to Bluetooth devices -->
-    <uses-permission android:name="android.permission.BLUETOOTH" /> <!-- Allow access to the vibrator -->
-    <uses-permission android:name="android.permission.VIBRATE" />
+        android:required="false" />
+    <uses-permission android:name="android.permission.BLUETOOTH" /> <!-- Allow access to Bluetooth devices -->
+    <uses-permission android:name="android.permission.VIBRATE" /> <!-- Allow access to the vibrator -->
 
     <application
         android:allowBackup="true"

--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
@@ -36,7 +36,6 @@ import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-import androidx.core.app.ActivityCompat;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -54,8 +53,6 @@ public class AGSRuntimeActivity extends SDLActivity {
 
     public static native void nativeSdlShowKeyboard();
 
-    protected final int[] externalStorageRequestDummy = new int[1];
-    public static final int EXTERNAL_STORAGE_REQUEST_CODE = 2;
     private static Boolean handledIntent = false;
 
     @Override
@@ -88,11 +85,6 @@ public class AGSRuntimeActivity extends SDLActivity {
 
         // must be reset or it will use the existing value.
         //gamePath = "";
-
-        if(!hasExternalStoragePermission())
-        {
-            showExternalStoragePermissionMissingDialog();
-        }
 
         // Get filename from "Open with" of another application
         // Get the game filename from the launcher activity
@@ -286,68 +278,6 @@ public class AGSRuntimeActivity extends SDLActivity {
         }
 
         return super.dispatchKeyEvent(ev);
-    }
-
-    public void showExternalStoragePermissionMissingDialog() {
-        AlertDialog dialog = new AlertDialog.Builder(mSingleton)
-                .setTitle("Storage Permission Missing")
-                .setMessage("AGS for Android will not be able to run non-packaged games without storage permission.")
-                .setNeutralButton("Continue", null)
-                .create();
-        dialog.show();
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        if (grantResults.length > 0) {
-            Log.d("AGSRuntimeActivity", "Received a request permission result");
-
-            switch (requestCode) {
-                case EXTERNAL_STORAGE_REQUEST_CODE: {
-                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                        Log.d("AGSRuntimeActivity", "Permission granted");
-                    } else {
-                        Log.d("AGSRuntimeActivity", "Did not get permission.");
-                        if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-                            showExternalStoragePermissionMissingDialog();
-                        }
-                    }
-
-                    Log.d("AGSRuntimeActivity", "Unlocking AGS thread");
-                    synchronized (externalStorageRequestDummy) {
-                        externalStorageRequestDummy[0] = grantResults[0];
-                        externalStorageRequestDummy.notify();
-                    }
-                    break;
-                }
-                default:
-                    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-            }
-        }
-    }
-
-
-    @Keep
-    public boolean hasExternalStoragePermission() {
-        if (ActivityCompat.checkSelfPermission(this,
-                Manifest.permission.READ_EXTERNAL_STORAGE)
-                == PackageManager.PERMISSION_GRANTED) {
-            return true;
-        }
-
-        Log.d("AGSRuntimeActivity", "Requesting permission and locking AGS thread until we have an answer.");
-        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, EXTERNAL_STORAGE_REQUEST_CODE);
-
-        synchronized (externalStorageRequestDummy) {
-            try {
-                externalStorageRequestDummy.wait();
-            } catch (InterruptedException e) {
-                Log.d("AGSRuntimeActivity", "requesting external storage permission", e);
-                return false;
-            }
-        }
-
-        return ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
     }
 
     @Keep

--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
@@ -1,5 +1,6 @@
 package uk.co.adventuregamestudio.runtime;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.ContentUris;
@@ -12,16 +13,28 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Looper;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.util.Log;
 
+import org.libsdl.app.SDL;
 import org.libsdl.app.SDLActivity;
 
 import android.Manifest;
 
 import android.content.Intent;
+import android.view.ContextMenu;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.InputMethodManager;
+
 import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 
@@ -38,6 +51,8 @@ public class AGSRuntimeActivity extends SDLActivity {
     private String _android_base_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
     private String _android_app_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
     private boolean _loadLastSave = false; // Can't be local variable since ags engine reads it. See acpland.cpp.
+
+    public static native void nativeSdlShowKeyboard();
 
     protected final int[] externalStorageRequestDummy = new int[1];
     public static final int EXTERNAL_STORAGE_REQUEST_CODE = 2;
@@ -126,8 +141,152 @@ public class AGSRuntimeActivity extends SDLActivity {
 
 
         super.onCreate(savedInstanceState);
+        View view = getContentView();
+        registerForContextMenu(view);
     }
 
+    // Exit confirmation dialog displayed when hitting the "back" button
+    public void showExitConfirmation()
+    {
+        onPause();
+
+        AlertDialog.Builder ad = new AlertDialog.Builder(this);
+        ad.setMessage("Are you sure you want to quit?");
+
+        ad.setPositiveButton("Yes", (dialog, which) -> {
+            onResume();
+            nativeSendQuit();
+        });
+
+        ad.setOnCancelListener(dialog -> onResume());
+        ad.setNegativeButton("No", (dialog, which) -> onResume());
+
+        ad.show();
+    }
+
+    public void toggleKeyboard()
+    {
+        new android.os.Handler(Looper.getMainLooper()).postDelayed(
+                AGSRuntimeActivity::nativeSdlShowKeyboard,
+                200
+        );
+    }
+
+    public void simulateKeyPress(int key, boolean hold_ctrl){
+
+        new android.os.Handler(Looper.getMainLooper()).postDelayed(
+                () -> {
+                    Activity a = (Activity) getContext();
+                    a.getWindow().getDecorView().getRootView();
+                    BaseInputConnection inputConnection = new BaseInputConnection(a.getWindow().getDecorView().getRootView(),
+                            true);
+                    if(hold_ctrl) inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_CTRL_LEFT));
+                    inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, key));
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ignored) {
+
+                    }
+                    inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, key));
+                    if(hold_ctrl) inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_CTRL_LEFT));
+                },
+                200
+        );
+    }
+
+    public void simulateKeyPress(int key) {
+        simulateKeyPress(key, false);
+    }
+
+    public boolean onInGameMenuItemSelected(MenuItem item)
+    {
+        int id = item.getItemId();
+
+        // This must be if-else instead of switch-case because it is in a library
+        if (id == R.id.key_f1) {
+            simulateKeyPress(KeyEvent.KEYCODE_F1);
+        } else if(id == R.id.key_f2) {
+            simulateKeyPress(KeyEvent.KEYCODE_F2);
+        } else if(id == R.id.key_f3) {
+            simulateKeyPress(KeyEvent.KEYCODE_F3);
+        } else if(id == R.id.key_f4) {
+            simulateKeyPress(KeyEvent.KEYCODE_F4);
+        } else if(id == R.id.key_f5) {
+            simulateKeyPress(KeyEvent.KEYCODE_F5);
+        } else if(id == R.id.key_f6) {
+            simulateKeyPress(KeyEvent.KEYCODE_F6);
+        } else if(id == R.id.key_f7) {
+            simulateKeyPress(KeyEvent.KEYCODE_F7);
+        } else if(id == R.id.key_f8) {
+            simulateKeyPress(KeyEvent.KEYCODE_F8);
+        } else if(id == R.id.key_f9) {
+            simulateKeyPress(KeyEvent.KEYCODE_F9);
+        } else if(id == R.id.key_f10) {
+            simulateKeyPress(KeyEvent.KEYCODE_F10);
+        } else if(id == R.id.key_f11) {
+            simulateKeyPress(KeyEvent.KEYCODE_F11);
+        } else if(id == R.id.key_f12) {
+            simulateKeyPress(KeyEvent.KEYCODE_F12);
+        } else if(id == R.id.key_ctrla) {
+            simulateKeyPress(KeyEvent.KEYCODE_A, true);
+        } else if(id == R.id.key_ctrlq) {
+            simulateKeyPress(KeyEvent.KEYCODE_Q, true);
+        } else if(id == R.id.key_ctrlv) {
+            simulateKeyPress(KeyEvent.KEYCODE_V, true);
+        } else if(id == R.id.key_ctrlx) {
+            simulateKeyPress(KeyEvent.KEYCODE_X, true);
+        } else if(id == R.id.exitgame) {
+            showExitConfirmation();
+        } else if(id == R.id.toggle_keyboard) {
+            toggleKeyboard();
+        } else {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int getInGameMenuID()
+    {
+        return R.menu.default_ingame;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v,
+                                    ContextMenu.ContextMenuInfo menuInfo)
+    {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(getInGameMenuID(), menu);
+    }
+
+    @Override
+    public boolean onContextItemSelected(@NonNull MenuItem item)
+    {
+        if (this.onInGameMenuItemSelected(item)) return true;
+        return super.onOptionsItemSelected(item);
+    }
+
+    public void showInGameMenu()
+    {
+        View view = getContentView();
+        openContextMenu(view);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent ev)
+    {
+        int action = ev.getAction();
+        int key = ev.getKeyCode();
+
+        if(action == KeyEvent.ACTION_DOWN && key == KeyEvent.KEYCODE_BACK)
+        {
+            showInGameMenu();
+            return true;
+        }
+
+        return super.dispatchKeyEvent(ev);
+    }
 
     public void showExternalStoragePermissionMissingDialog() {
         AlertDialog dialog = new AlertDialog.Builder(mSingleton)

--- a/Android/library/runtime/src/main/res/menu/default_ingame.xml
+++ b/Android/library/runtime/src/main/res/menu/default_ingame.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@+id/toggle_keyboard" android:title="Toggle keyboard" android:checkable="false">
+    </item>
+    <item android:id="@+id/keys" android:title="Keys" android:checkable="false">
+        <menu>
+            <item android:id="@+id/key_f1" android:title="F1" android:checkable="false"></item>
+            <item android:id="@+id/key_f2" android:title="F2" android:checkable="false"></item>
+            <item android:id="@+id/key_f3" android:title="F3" android:checkable="false"></item>
+            <item android:id="@+id/key_f4" android:title="F4" android:checkable="false"></item>
+            <item android:id="@+id/key_f5" android:title="F5" android:checkable="false"></item>
+            <item android:id="@+id/key_f6" android:title="F6" android:checkable="false"></item>
+            <item android:id="@+id/key_f7" android:title="F7" android:checkable="false"></item>
+            <item android:id="@+id/key_f8" android:title="F8" android:checkable="false"></item>
+            <item android:id="@+id/key_f9" android:title="F9" android:checkable="false"></item>
+            <item android:id="@+id/key_f10" android:title="F10" android:checkable="false"></item>
+            <item android:id="@+id/key_f11" android:title="F11" android:checkable="false"></item>
+            <item android:id="@+id/key_f12" android:title="F12" android:checkable="false"></item>
+            <item android:id="@+id/key_ctrlq" android:title="Ctrl Q" android:checkable="false"></item>
+            <item android:id="@+id/key_ctrlv" android:title="Ctrl V" android:checkable="false"></item>
+            <item android:id="@+id/key_ctrla" android:title="Ctrl A" android:checkable="false"></item>
+            <item android:id="@+id/key_ctrlx" android:title="Ctrl X" android:checkable="false"></item>
+        </menu>
+    </item>
+    <item android:id="@+id/exitgame" android:title="Exit game" android:checkable="false">
+    </item>
+</menu>

--- a/Android/mygame/README.md
+++ b/Android/mygame/README.md
@@ -110,12 +110,12 @@ To be easier for debugging, keep your game files on `mygame/app/src/main/assets`
 
 ## Testing the app bundle
 
-If you want to make sure that the built `.aab` bundle actually has your game package working, you can use the bundletool, grab it from it's [release page](https://github.com/google/bundletool/releases). Additionally, you will need to install java, [grab it here](https://www.java.com/en/download/).
+If you want to make sure that the built `.aab` bundle actually has your game package working, you can use the bundletool, grab it from it's [release page](https://github.com/google/bundletool/releases).
 
 Now, you will need to set `JAVA_HOME`, `ANDROID_HOME` and make sure java is on your Path to be able to use this tool. Below is an example for configuring via `cmd.exe` on Windows, but adjust it accordingly, attention to java directory that will change on each version.
 
     setx ANDROID_HOME "%USERPROFILE%\AppData\Local\Android\Sdk"
-	setx JAVA_HOME "C:\Program Files\Java\jre1.8.0_301"
+	setx JAVA_HOME "%ProgramFiles%\Android\Android Studio\jre"
 	setx Path "%Path%;%JAVA_HOME%\bin"
 
 With that set, generate APKs with the `--local-testing` flag
@@ -125,6 +125,8 @@ With that set, generate APKs with the `--local-testing` flag
 And after, you can push the generated apks file with package, just connect a device (or turn on the emulator) and run bundletool to sideload the APKs:
 
     java -jar bundletool.jar install-apks --apks=output.apks
+
+_note:_ If you don't have Android Studio installed you will need to install java, [grab it here](https://www.java.com/en/download/), and you need to tell your software where Java is, so use `setx JAVA_HOME "C:\Program Files\Java\jre1.8.0_301"`.
 
 
 ## Androig Configuration

--- a/Android/mygame/app/build.gradle
+++ b/Android/mygame/app/build.gradle
@@ -10,7 +10,7 @@ projectProperties.load(new FileInputStream(projectPropertiesFile))
 
 android {
     compileSdkVersion = 29
-    buildToolsVersion = '29.0.2'
+    buildToolsVersion = '30.0.3'
     def appIdParts = projectProperties['applicationId'].split(/\./)
     def nameCount = appIdParts.size()
     def appIdLastPart = appIdParts[nameCount-1]

--- a/Android/mygame/app/build.gradle
+++ b/Android/mygame/app/build.gradle
@@ -11,12 +11,15 @@ projectProperties.load(new FileInputStream(projectPropertiesFile))
 android {
     compileSdkVersion = 29
     buildToolsVersion = '29.0.2'
-
+    def appIdParts = projectProperties['applicationId'].split(/\./)
+    def nameCount = appIdParts.size()
+    def appIdLastPart = appIdParts[nameCount-1]
 
     assetPacks = [":game"]
 
     defaultConfig {
         applicationId projectProperties['applicationId']
+        archivesBaseName = "app-" + appIdLastPart
         minSdkVersion 19
         targetSdkVersion 29
         versionCode Integer.parseInt(projectProperties.getProperty('versionCode'))

--- a/Android/mygame/app/build.gradle
+++ b/Android/mygame/app/build.gradle
@@ -41,6 +41,11 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/Android/mygame/app/src/main/AndroidManifest.xml
+++ b/Android/mygame/app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.mystudioname.mygamename"
@@ -6,25 +7,10 @@
     <!-- Required to access Google Play Licensing -->
     <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
 
-    <!-- Required to download files from Google Play -->
-    <uses-permission android:name="android.permission.INTERNET" />
-
     <!-- Required to keep CPU alive while downloading files
         (NOT to keep screen awake) -->
     <!-- But also required by the engine to keep the screen awake -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-
-    <!-- Required to poll the state of the network connection
-        and respond to changes -->
-    <uses-permission
-        android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <!-- Required to check whether Wi-Fi is enabled -->
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-
-    <!-- Required to read and write the expansion files on shared storage -->
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name="com.mystudioname.mygamename.App"
@@ -37,7 +23,8 @@
 
         <activity android:configChanges="orientation|keyboardHidden|screenSize"
             tools:replace="android:configChanges"
-            android:name="uk.co.adventuregamestudio.runtime.AGSRuntimeActivity">
+            android:name="uk.co.adventuregamestudio.runtime.AGSRuntimeActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
@@ -45,7 +32,7 @@
 
         <activity
             android:name="com.mystudioname.mygamename.MainActivity"
-            android:label="@string/app_name" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -196,6 +196,7 @@ namespace AGS.Editor
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDebug());
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetLinux());
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetWeb());
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetAndroid());
         }
 
         public Game CurrentGame

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1607,6 +1607,8 @@ namespace AGS.Editor
             bool render_at_screenres = _game.Settings.RenderAtScreenResolution == RenderAtScreenResolution.UserDefined ?
                 _game.DefaultSetup.RenderAtScreenResolution : _game.Settings.RenderAtScreenResolution == RenderAtScreenResolution.True;
             NativeProxy.WritePrivateProfileString("graphics", "render_at_screenres", render_at_screenres ? "1" : "0", configFilePath);
+            int rotation = (int)_game.DefaultSetup.Rotation;
+            NativeProxy.WritePrivateProfileString("graphics", "rotation", rotation.ToString(), configFilePath);
 
             bool use_default_digi = _game.DefaultSetup.DigitalSound == RuntimeAudioDriver.Default;
             bool use_default_midi = _game.DefaultSetup.MidiSound == RuntimeAudioDriver.Default;

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -96,6 +96,7 @@
   <ItemGroup>
     <Compile Include="AGSEditor.cs" />
     <Compile Include="BuildTargets\BuildTargetWeb.cs" />
+    <Compile Include="BuildTargets\BuildTargetAndroid.cs" />
     <Compile Include="ColorThemes\ColorTheme.cs" />
     <Compile Include="ColorThemes\ColorThemes.cs" />
     <Compile Include="ColorThemes\ColorThemeJson.cs" />

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -147,6 +147,12 @@
     <Compile Include="GUI\CustomPropertySchemaItemEditor.Designer.cs">
       <DependentUpon>CustomPropertySchemaItemEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\GenerateAndroidKeystore.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\GenerateAndroidKeystore.Designer.cs">
+      <DependentUpon>GenerateAndroidKeystore.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\ImportTTFDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -347,11 +353,16 @@
     <Compile Include="GUI\ProjectTree.cs" />
     <Compile Include="GUI\ProjectTreeItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\AndroidUtilities.cs" />
+    <Compile Include="Utils\ArgumentBuilder.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\Validation.cs" />
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>
       <DependentUpon>frmMain.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\GenerateAndroidKeystore.resx">
+      <DependentUpon>GenerateAndroidKeystore.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\ImportTTFDialog.resx">
       <DependentUpon>ImportTTFDialog.cs</DependentUpon>

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -1,11 +1,11 @@
-﻿using AGS.Types;
+﻿using AGS.Editor.Preferences;
+using AGS.Types;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
-using AGS.Types;
 
 namespace AGS.Editor
 {
@@ -136,11 +136,11 @@ namespace AGS.Editor
             string fileName = Path.Combine(dest_dir, "local.static.properties");
 
             // this should NOT GET KEYS FROM SETTINGS
-            Settings gameSettings = Factory.AGSEditor.CurrentGame.Settings;
-            string storeFile = EscapeFilenamePathStringAsNeeded(gameSettings.AndroidKeystoreFile);
-            string storePassword = gameSettings.AndroidKeystorePassword;
-            string keyAlias = gameSettings.AndroidKeystoreKeyAlias;
-            string keyPassword = gameSettings.AndroidKeystoreKeyPassword;
+            AppSettings settings = Factory.AGSEditor.Settings;
+            string storeFile = EscapeFilenamePathStringAsNeeded(settings.AndroidKeystoreFile);
+            string storePassword = settings.AndroidKeystorePassword;
+            string keyAlias = settings.AndroidKeystoreKeyAlias;
+            string keyPassword = settings.AndroidKeystoreKeyPassword;
 
             string fileText = "storeFile=" + storeFile + "\n" +
                               "storePassword=" + storePassword + "\n" +

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -31,6 +31,7 @@ namespace AGS.Editor
         public static readonly IList<string> ICON_DIRS = new ReadOnlyCollection<string> (new List<string> {
             "mipmap-hdpi", "mipmap-mdpi", "mipmap-xhdpi", "mipmap-xxhdpi", "mipmap-xxxhdpi",
         });
+        private bool UseGradleDaemon = false;
 
         private void WriteAndroidCfg(string outputDir)
         {
@@ -177,6 +178,8 @@ namespace AGS.Editor
 
         private void StopGradle()
         {
+            if (!UseGradleDaemon) return;
+
             string prjDir = GetAndroidProjectInCompiledDir();
             string gradle_path = Path.Combine(prjDir, "gradlew.bat");
             if (!Directory.Exists(prjDir) || !File.Exists(gradle_path)) return;
@@ -502,6 +505,7 @@ namespace AGS.Editor
         {
             if (!base.Build(errors, forceRebuild)) return false;
 
+            UseGradleDaemon = Factory.AGSEditor.Settings.AndroidBuildGradleDaemon;
             string andProjDir = GetAndroidProjectInCompiledDir();
 
             if(!IsProjectSane(errors))
@@ -571,7 +575,7 @@ namespace AGS.Editor
             GradleTasks gradleTask = GradleTasks.bundleRelease;
             if (buildFormat == AndroidBuildFormat.ApkEmbedded) gradleTask = GradleTasks.assembleRelease;
 
-            if (!AndroidUtilities.RunGradlewTask(gradleTask, andProjDir))
+            if (!AndroidUtilities.RunGradlewTask(gradleTask, andProjDir, use_daemon:UseGradleDaemon))
             {
                 errors.Add(new CompileError("There was an error running gradle to build the Android App."));
                 return false;

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -12,6 +12,60 @@ namespace AGS.Editor
     class BuildTargetAndroid : BuildTargetBase
     {
         public const string ANDROID_DIR = "Android";
+        public const string ANDROID_CFG = "android.cfg";
+
+        private void WriteAndroidCfg(string outputDir)
+        {
+            string configPath = Path.Combine(outputDir, ANDROID_CFG);
+
+            RuntimeSetup setup = Factory.AGSEditor.CurrentGame.DefaultSetup;
+            int rotation = (int)setup.Rotation;
+
+            NativeProxy.WritePrivateProfileString("misc", "config_enabled", "1", configPath);
+            NativeProxy.WritePrivateProfileString("misc", "rotation", rotation.ToString(), configPath);
+            NativeProxy.WritePrivateProfileString("misc", "translation", setup.Translation, configPath);
+
+            NativeProxy.WritePrivateProfileString("controls", "mouse_method", "0", configPath);
+            NativeProxy.WritePrivateProfileString("controls", "mouse_longclick", "1", configPath);
+
+            NativeProxy.WritePrivateProfileString("compatibility", "clear_cache_on_room_change", "0", configPath);
+
+            NativeProxy.WritePrivateProfileString("sound", "samplerate", "44100", configPath);
+            NativeProxy.WritePrivateProfileString("sound", "enabled", "1", configPath);
+            NativeProxy.WritePrivateProfileString("sound", "threaded", "1", configPath);
+            NativeProxy.WritePrivateProfileString("sound", "cache_size", "64", configPath);
+
+            NativeProxy.WritePrivateProfileString("midi", "enabled", "0", configPath);
+            NativeProxy.WritePrivateProfileString("midi", "preload_patches", "0", configPath);
+
+            NativeProxy.WritePrivateProfileString("video", "framedrop", "0", configPath);
+
+            if (setup.GraphicsDriver == GraphicsDriver.Software) {
+                NativeProxy.WritePrivateProfileString("graphics", "renderer", "0", configPath);
+            } else {
+                NativeProxy.WritePrivateProfileString("graphics", "renderer", "1", configPath);
+            }
+
+            if (setup.GraphicsFilter == "StdScale") {
+                NativeProxy.WritePrivateProfileString("graphics", "smoothing", "0", configPath);
+            } else {
+                NativeProxy.WritePrivateProfileString("graphics", "smoothing", "1", configPath);
+            }
+
+            if (setup.FullscreenGameScaling == GameScaling.ProportionalStretch) {
+                NativeProxy.WritePrivateProfileString("graphics", "scaling", "1", configPath);
+            } else if (setup.FullscreenGameScaling == GameScaling.StretchToFit) {
+                NativeProxy.WritePrivateProfileString("graphics", "scaling", "2", configPath);
+            } else {
+                NativeProxy.WritePrivateProfileString("graphics", "scaling", "0", configPath);
+            }
+
+            NativeProxy.WritePrivateProfileString("graphics", "super_sampling", "0", configPath);
+            NativeProxy.WritePrivateProfileString("graphics", "smooth_sprites", setup.AAScaledSprites ? "1" : "0", configPath);
+
+            NativeProxy.WritePrivateProfileString("debug", "show_fps", "0", configPath);
+            NativeProxy.WritePrivateProfileString("debug", "logging", "0", configPath);
+        }
 
         private string EscapeFilenamePathStringAsNeeded(string str)
         {
@@ -340,7 +394,6 @@ namespace AGS.Editor
                 "mygame\\settings.gradle",
                 "mygame\\app\\build.gradle",
                 "mygame\\app\\src\\main\\AndroidManifest.xml",
-                "mygame\\app\\src\\main\\assets\\android.cfg",
                 "mygame\\app\\src\\main\\java\\com\\mystudioname\\mygamename\\App.java",
                 "mygame\\app\\src\\main\\java\\com\\mystudioname\\mygamename\\MainActivity.java",
                 "mygame\\app\\src\\main\\res\\drawable\\download_landscape.png",
@@ -452,6 +505,7 @@ namespace AGS.Editor
 
             // Update config file with current game parameters
             Factory.AGSEditor.WriteConfigFile(assetsDir);
+            WriteAndroidCfg(assetsDir);
 
             foreach (KeyValuePair<string, string> pair in GetRequiredLibraryPaths())
             {

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -123,6 +123,19 @@ namespace AGS.Editor
             RunCommand("/C gradlew.bat --stop", prjDir, false);
         }
 
+        private void InstallSdkToolsIfNeeded()
+        {
+            string androidHome = GetAndroidHome();
+            string javaHome = GetJavaHome();
+            string prjDir = GetProjectDir();
+
+            string packages = "\"build-tools;30.0.3\" \"ndk;21.3.6528147\" \"platforms;android-29\"";
+
+            RunCommand("/C " + "set \"JAVA_HOME=" + javaHome + "\" & " +
+                      "set \"ANDROID_HOME=" + androidHome + "\" & "    +
+                      androidHome + "\\tools\\bin\\sdkmanager " + packages, prjDir, true);
+        }
+
         private string GetProjectDir()
         {
             return GetCompiledPath(ANDROID_DIR, "mygame");
@@ -414,6 +427,8 @@ namespace AGS.Editor
                 return false;
 
             }
+
+            InstallSdkToolsIfNeeded();
 
             AndroidBuildFormat buildFormat = Factory.AGSEditor.CurrentGame.Settings.AndroidBuildFormat;
             string appName = GetFinalAppName();

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using System.Xml;
 
 namespace AGS.Editor
 {
@@ -291,6 +292,33 @@ namespace AGS.Editor
             return outputBuildDir;
         }
         
+        private void WriteProjectXml(string dest_dir)
+        {
+            string fileName = Path.Combine(dest_dir, "app\\src\\main\\res\\values\\project.xml");
+
+            using (TextWriter writer = File.CreateText(fileName))
+            {
+                string gameName = Factory.AGSEditor.CurrentGame.Settings.GameName;
+
+                XmlDocument doc = new XmlDocument();
+                XmlNode docNode = doc.CreateXmlDeclaration("1.0", "UTF-8", null);
+                doc.AppendChild(docNode);
+
+                XmlNode resourcesNode = doc.CreateElement("resources");
+                doc.AppendChild(resourcesNode);
+
+                XmlNode stringNode = doc.CreateElement("string");
+                XmlAttribute stringAttribute = doc.CreateAttribute("name");
+                stringAttribute.Value = "app_name";
+                stringNode.Attributes.Append(stringAttribute);
+                stringNode.InnerText = gameName;
+
+                resourcesNode.AppendChild(stringNode);
+
+                doc.Save(writer);
+            }
+        }
+
         private void WriteProjectProperties(string dest_dir)
         {
             string fileName = Path.Combine(dest_dir, "project.properties");
@@ -451,7 +479,6 @@ namespace AGS.Editor
                 "mygame\\app\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher.png",
                 "mygame\\app\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher_round.png",
                 "mygame\\app\\src\\main\\res\\values\\colors.xml",
-                "mygame\\app\\src\\main\\res\\values\\project.xml",
                 "mygame\\app\\src\\main\\res\\values\\strings.xml",
                 "mygame\\app\\src\\main\\res\\values\\styles.xml",
                 "mygame\\game\\build.gradle",
@@ -563,8 +590,11 @@ namespace AGS.Editor
                 }
             }
 
-            WriteProjectProperties(GetCompiledPath(ANDROID_DIR, "mygame"));
-            WriteLocalStaticProperties(GetCompiledPath(ANDROID_DIR, "mygame"));
+            string dest_dir = GetCompiledPath(ANDROID_DIR, "mygame");
+
+            WriteProjectProperties(dest_dir);
+            WriteLocalStaticProperties(dest_dir);
+            WriteProjectXml(dest_dir);
 
             string gradle_task = "bundleRelease";
             if (buildFormat == AndroidBuildFormat.ApkEmbedded) gradle_task = "assembleRelease";

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -1,0 +1,260 @@
+﻿using AGS.Types;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    class BuildTargetAndroid : BuildTargetBase
+    {
+        public const string ANDROID_DIR = "Android";
+
+        public override IDictionary<string, string> GetRequiredLibraryPaths()
+        {
+            Dictionary<string, string> paths = new Dictionary<string, string>();
+
+            string androidDir = Path.Combine(Factory.AGSEditor.EditorDirectory, ANDROID_DIR);
+
+            List<string> files = new List<string>()
+            {
+                "gradle\\buildCacheSettings.gradle",
+                "library\\runtime\\.gitignore",
+                "library\\runtime\\build.gradle",
+                "library\\runtime\\gradle.properties",
+                "library\\runtime\\gradlew",
+                "library\\runtime\\gradlew.bat",
+                "library\\runtime\\proguard-rules.pro",
+                "library\\runtime\\gradle\\wrapper\\gradle-wrapper.jar",
+                "library\\runtime\\gradle\\wrapper\\gradle-wrapper.properties",
+                "library\\runtime\\libs\\libs_go_here.txt",
+                "library\\runtime\\libs\\arm64-v8a\\libags.so",
+                "library\\runtime\\libs\\arm64-v8a\\libengine.so",
+                "library\\runtime\\libs\\arm64-v8a\\libhidapi.so",
+                "library\\runtime\\libs\\arm64-v8a\\libSDL2.so",
+                "library\\runtime\\libs\\armeabi-v7a\\libags.so",
+                "library\\runtime\\libs\\armeabi-v7a\\libengine.so",
+                "library\\runtime\\libs\\armeabi-v7a\\libhidapi.so",
+                "library\\runtime\\libs\\armeabi-v7a\\libSDL2.so",
+                "library\\runtime\\libs\\x86\\libags.so",
+                "library\\runtime\\libs\\x86\\libengine.so",
+                "library\\runtime\\libs\\x86\\libhidapi.so",
+                "library\\runtime\\libs\\x86\\libSDL2.so",
+                "library\\runtime\\libs\\x86_64\\libags.so",
+                "library\\runtime\\libs\\x86_64\\libengine.so",
+                "library\\runtime\\libs\\x86_64\\libhidapi.so",
+                "library\\runtime\\libs\\x86_64\\libSDL2.so",
+                "library\\runtime\\src\\androidTest\\java\\uk\\co\\adventuregamestudio\\runtime\\ExampleInstrumentedTest.java",
+                "library\\runtime\\src\\main\\AndroidManifest.xml",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\HIDDevice.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\HIDDeviceBLESteamController.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\HIDDeviceManager.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\HIDDeviceUSB.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\SDL.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\SDLActivity.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\SDLAudioManager.java",
+                "library\\runtime\\src\\main\\java\\org\\libsdl\\app\\SDLControllerManager.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\AGSRuntimeActivity.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\AgsSettingsFragment.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\CreditsActivity.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\NativeHelper.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\PreferencesActivity.java",
+                "library\\runtime\\src\\main\\java\\uk\\co\\adventuregamestudio\\runtime\\ReadOnlyINI.java",
+                "library\\runtime\\src\\main\\res\\drawable\\ic_launcher_background.xml",
+                "library\\runtime\\src\\main\\res\\layout\\credits.xml",
+                "library\\runtime\\src\\main\\res\\layout\\loading.xml",
+                "library\\runtime\\src\\main\\res\\layout\\settings_activity.xml",
+                "library\\runtime\\src\\main\\res\\mipmap-hdpi\\ic_launcher.png",
+                "library\\runtime\\src\\main\\res\\mipmap-hdpi\\ic_launcher_round.png",
+                "library\\runtime\\src\\main\\res\\mipmap-mdpi\\ic_launcher.png",
+                "library\\runtime\\src\\main\\res\\mipmap-mdpi\\ic_launcher_round.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xhdpi\\ic_launcher.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xhdpi\\ic_launcher_round.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xxhdpi\\ic_launcher.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xxhdpi\\ic_launcher_round.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher.png",
+                "library\\runtime\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher_round.png",
+                "library\\runtime\\src\\main\\res\\values\\arrays.xml",
+                "library\\runtime\\src\\main\\res\\values\\colors.xml",
+                "library\\runtime\\src\\main\\res\\values\\strings.xml",
+                "library\\runtime\\src\\main\\res\\values\\styles.xml",
+                "library\\runtime\\src\\main\\res\\xml\\preferences.xml",
+                "library\\runtime\\src\\main\\res\\menu\\default_ingame.xml",
+                "library\\runtime\\src\\test\\java\\uk\\co\\adventuregamestudio\\runtime\\ExampleUnitTest.java",
+                "mygame\\.gitignore",
+                "mygame\\build.gradle",
+                "mygame\\gradle.properties",
+                "mygame\\gradlew",
+                "mygame\\gradlew.bat",
+                "mygame\\gradle\\wrapper\\gradle-wrapper.jar",
+                "mygame\\gradle\\wrapper\\gradle-wrapper.properties",
+                "mygame\\settings.gradle",
+                "mygame\\app\\build.gradle",
+                "mygame\\app\\src\\main\\AndroidManifest.xml",
+                "mygame\\app\\src\\main\\assets\\android.cfg",
+                "mygame\\app\\src\\main\\java\\com\\mystudioname\\mygamename\\App.java",
+                "mygame\\app\\src\\main\\java\\com\\mystudioname\\mygamename\\MainActivity.java",
+                "mygame\\app\\src\\main\\res\\drawable\\download_landscape.png",
+                "mygame\\app\\src\\main\\res\\drawable\\download_portrait.png",
+                "mygame\\app\\src\\main\\res\\layout\\downloader_ui.xml",
+                "mygame\\app\\src\\main\\res\\layout-land\\downloader_ui.xml",
+                "mygame\\app\\src\\main\\res\\mipmap-hdpi\\ic_launcher.png",
+                "mygame\\app\\src\\main\\res\\mipmap-hdpi\\ic_launcher_round.png",
+                "mygame\\app\\src\\main\\res\\mipmap-mdpi\\ic_launcher.png",
+                "mygame\\app\\src\\main\\res\\mipmap-mdpi\\ic_launcher_round.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xhdpi\\ic_launcher.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xhdpi\\ic_launcher_round.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xxhdpi\\ic_launcher.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xxhdpi\\ic_launcher_round.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher.png",
+                "mygame\\app\\src\\main\\res\\mipmap-xxxhdpi\\ic_launcher_round.png",
+                "mygame\\app\\src\\main\\res\\values\\colors.xml",
+                "mygame\\app\\src\\main\\res\\values\\project.xml",
+                "mygame\\app\\src\\main\\res\\values\\strings.xml",
+                "mygame\\app\\src\\main\\res\\values\\styles.xml",
+                "mygame\\game\\build.gradle",
+                "mygame\\game\\src\\main\\assets\\.gitkeep",
+                "mygame\\play_licensing_library\\.gitignore",
+                "mygame\\play_licensing_library\\build.gradle",
+                "mygame\\play_licensing_library\\COPYING",
+                "mygame\\play_licensing_library\\src\\main\\AndroidManifest.xml",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\AESObfuscator.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\APKExpansionPolicy.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\DeviceLimiter.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\ILicenseResultListener.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\ILicensingService.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\LicenseChecker.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\LicenseCheckerCallback.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\LicenseValidator.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\NullDeviceLimiter.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\Obfuscator.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\Policy.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\PreferenceObfuscator.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\ResponseData.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\ServerManagedPolicy.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\StrictPolicy.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\ValidationException.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\util\\Base64.java",
+                "mygame\\play_licensing_library\\src\\main\\java\\com\\google\\android\\vending\\licensing\\util\\Base64DecoderException.java"
+            };
+
+            foreach(string file in files)
+            {
+                paths.Add(file, androidDir);
+            }
+            return paths;
+        }
+
+        public override string[] GetPlatformStandardSubfolders()
+        {
+            return new string[] { GetCompiledPath() };
+        }
+
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(Path.Combine(OutputDirectoryFullPath, ANDROID_DIR), name + ".ags");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
+        public override bool Build(CompileMessages errors, bool forceRebuild)
+        {
+            if (!base.Build(errors, forceRebuild)) return false;
+
+            string assets_dir = GetCompiledPath(ANDROID_DIR, "mygame\\app\\src\\main\\assets");
+            string mygame_dir = GetCompiledPath(ANDROID_DIR, "mygame");
+
+            if (!Directory.Exists(assets_dir))
+            {
+                // doesn't exist, let's create it
+                Directory.CreateDirectory(assets_dir);
+            }
+
+            foreach (string fileName in Directory.GetFiles(Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY)))
+            {
+                if ((File.GetAttributes(fileName) & (FileAttributes.Hidden | FileAttributes.System | FileAttributes.Temporary)) != 0)
+                    continue;
+                if ((!fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) &&
+                    (!Path.GetFileName(fileName).Equals("winsetup.exe", StringComparison.OrdinalIgnoreCase)) &&
+                    (!Path.GetFileName(fileName).Equals(AGSEditor.CONFIG_FILE_NAME, StringComparison.OrdinalIgnoreCase)))
+                {
+                    string dest_filename = Path.Combine(assets_dir, Path.GetFileName(fileName));
+                    Utilities.HardlinkOrCopy(dest_filename, fileName, true);
+                }
+            }
+
+
+            // Update config file with current game parameters
+            Factory.AGSEditor.WriteConfigFile(assets_dir);
+
+            foreach (KeyValuePair<string, string> pair in GetRequiredLibraryPaths())
+            {
+                string fileName = pair.Key;
+                string origin_dir = pair.Value;
+
+                string dest_dir = GetCompiledPath(ANDROID_DIR, Path.GetDirectoryName(fileName));
+
+                if(!Directory.Exists(dest_dir))
+                {
+                    // doesn't exist, let's create it
+                    Directory.CreateDirectory(dest_dir);
+                }
+
+                string dest_file = GetCompiledPath(ANDROID_DIR, fileName);
+                string origin_file = Path.Combine(origin_dir, fileName);
+                string destFileName = Utilities.ResolveSourcePath(dest_file);
+                string sourceFileName = Utilities.ResolveSourcePath(origin_file);
+
+                if (fileName.EndsWith(".so")) { 
+                    Utilities.HardlinkOrCopy(dest_file, origin_file, true);
+                } 
+                else
+                {
+                    File.Copy(sourceFileName, destFileName, true);
+                }
+            }
+
+            using (Process proc = new Process
+            {
+                StartInfo =
+                {
+                    UseShellExecute = false,
+                    FileName = "cmd.exe",
+                    Arguments = "/C gradlew.bat assembleRelease & pause",
+                    CreateNoWindow = false,
+                    WorkingDirectory = mygame_dir
+                }
+            })
+            {
+                try
+                {
+                    proc.Start();
+                    proc.WaitForExit();
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "Android";
+            }
+        }
+
+        public override string OutputDirectory
+        {
+            get
+            {
+                return ANDROID_DIR;
+            }
+        }
+    }
+}

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -230,8 +230,8 @@ namespace AGS.Editor
         private string GetFinalAppName()
         {
             Settings gameSettings = Factory.AGSEditor.CurrentGame.Settings;
-            string androidPackageName = gameSettings.AndroidPackageName;
-            string[] nameParts = androidPackageName.Split('.');
+            string applicationId = gameSettings.AndroidApplicationId;
+            string[] nameParts = applicationId.Split('.');
             int lastPart = nameParts.Length - 1;
             if (lastPart < 0) lastPart = 0;
             string ext = ".aab";
@@ -308,7 +308,7 @@ namespace AGS.Editor
             }
 
             Settings gameSettings = Factory.AGSEditor.CurrentGame.Settings;
-            string androidPackageName = gameSettings.AndroidPackageName;
+            string androidPackageName = gameSettings.AndroidApplicationId;
             string androidAppVersionId = gameSettings.AndroidAppVersionCode.ToString();
             string androidAppVersionName = gameSettings.AndroidAppVersionName;
             if (string.IsNullOrEmpty(androidPackageName)) androidPackageName = "com.mystudio.mygame";

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -832,6 +832,24 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
+        [DisplayName("Use gradle daemon")]
+        [Description("Gradle daemon can severily improve building speed, but it may increase ram usage. If you are recurrently building for Android, consider turning it on.")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("false")]
+        [UserScopedSettingAttribute()]
+        public bool AndroidBuildGradleDaemon
+        {
+            get
+            {
+                return (bool)(this["AndroidBuildGradleDaemon"]);
+            }
+            set
+            {
+                this["AndroidBuildGradleDaemon"] = value;
+            }
+        }
+
         [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("640")]

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -720,6 +720,44 @@ namespace AGS.Editor.Preferences
         }
 
         [Browsable(true)]
+        [DisplayName("JAVA_HOME")]
+        [Description("The path to your JRE and JDK directory, usually 'C:\\Program Files\\Android\\Android Studio\\jre'. Leave empty if your JAVA_HOME environment variable is set.")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("")]
+        [UserScopedSettingAttribute()]
+        [EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
+        public string AndroidJavaHome
+        {
+            get
+            {
+                return (string)(this["AndroidJavaHome"]);
+            }
+            set
+            {
+                this["AndroidJavaHome"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("ANDROID_HOME")]
+        [Description("The path to your Android SDK directory, usually 'C:\\Users\\user\\AppData\\Local\\Android\\Sdk'. Leave empty if your ANDROID_HOME environment variable is set.")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("")]
+        [UserScopedSettingAttribute()]
+        [EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
+        public string AndroidHome
+        {
+            get
+            {
+                return (string)(this["AndroidHome"]);
+            }
+            set
+            {
+                this["AndroidHome"] = value;
+            }
+        }
+
+        [Browsable(true)]
         [DisplayName("Keystore File Path")]
         [Description("Your Keystore File (*.jks/*.store).")]
         [Category("Android")]

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -719,6 +719,81 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
+        [DisplayName("Keystore File Path")]
+        [Description("Your Keystore File (*.jks/*.store).")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("")]
+        [UserScopedSettingAttribute()]
+        [EditorAttribute(typeof(FileNameEditor), typeof(UITypeEditor))]
+        public string AndroidKeystoreFile
+        {
+            get 
+            { 
+                return (string)(this["AndroidKeystoreFile"]); 
+            }
+            set 
+            { 
+                this["AndroidKeystoreFile"] = value; 
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Keystore Password")]
+        [Description("Keystore Password. Must be the same as Key Password for most key types.")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("")]
+        [UserScopedSettingAttribute()]
+        [PasswordPropertyText(true)]
+        public string AndroidKeystorePassword
+        {
+            get 
+            { 
+                return (string)(this["AndroidKeystorePassword"]);
+            }
+            set 
+            {
+                this["AndroidKeystorePassword"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Key Alias")]
+        [Description("Keystore Key Alias")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("key0")]
+        [UserScopedSettingAttribute()]
+        public string AndroidKeystoreKeyAlias
+        {
+            get
+            {
+                return (string)(this["AndroidKeystoreKeyAlias"]);
+            }
+            set
+            {
+                this["AndroidKeystoreKeyAlias"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Key Password")]
+        [Description("Keystore Key Password. Must be the same as Keystore Password for most key types.")]
+        [Category("Android")]
+        [DefaultSettingValueAttribute("")]
+        [UserScopedSettingAttribute()]
+        [PasswordPropertyText(true)]
+        public string AndroidKeystoreKeyPassword
+        {
+            get
+            {
+                return (string)(this["AndroidKeystoreKeyPassword"]);
+            }
+            set
+            {
+                this["AndroidKeystoreKeyPassword"] = value;
+            }
+        }
+
         [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("640")]

--- a/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.Designer.cs
+++ b/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.Designer.cs
@@ -1,0 +1,614 @@
+﻿
+namespace AGS.Editor
+{
+    partial class GenerateAndroidKeystore
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GenerateAndroidKeystore));
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.buttonGenerate = new System.Windows.Forms.Button();
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.labelExplanation = new System.Windows.Forms.Label();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.textboxKeystorePassword = new System.Windows.Forms.TextBox();
+            this.textboxKeystorePath = new System.Windows.Forms.TextBox();
+            this.labelKeystore_Path = new System.Windows.Forms.Label();
+            this.labelKeystorePass = new System.Windows.Forms.Label();
+            this.buttonBrowse = new System.Windows.Forms.Button();
+            this.groupBoxKey = new System.Windows.Forms.GroupBox();
+            this.groupBoxCertificate = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.textboxKeystoreCertCN = new System.Windows.Forms.TextBox();
+            this.label17 = new System.Windows.Forms.Label();
+            this.textboxKeystoreCertC = new System.Windows.Forms.TextBox();
+            this.label22 = new System.Windows.Forms.Label();
+            this.label18 = new System.Windows.Forms.Label();
+            this.textboxKeystoreCertOU = new System.Windows.Forms.TextBox();
+            this.textboxKeystoreCertST = new System.Windows.Forms.TextBox();
+            this.label21 = new System.Windows.Forms.Label();
+            this.label19 = new System.Windows.Forms.Label();
+            this.textboxKeystoreCertO = new System.Windows.Forms.TextBox();
+            this.textboxKeystoreCertL = new System.Windows.Forms.TextBox();
+            this.label20 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.textboxKeystoreKeyPassword = new System.Windows.Forms.TextBox();
+            this.labelKeystoreKeyAlias = new System.Windows.Forms.Label();
+            this.label23 = new System.Windows.Forms.Label();
+            this.textboxKeystoreKeyAlias = new System.Windows.Forms.TextBox();
+            this.numericValidityYears = new System.Windows.Forms.NumericUpDown();
+            this.labelKeystoreKeyPass = new System.Windows.Forms.Label();
+            this.richTextBox1 = new System.Windows.Forms.RichTextBox();
+            this.panel1.SuspendLayout();
+            this.flowLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.panel2.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.groupBoxKey.SuspendLayout();
+            this.groupBoxCertificate.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericValidityYears)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Controls.Add(this.flowLayoutPanel2);
+            this.panel1.Controls.Add(this.labelExplanation);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panel1.Location = new System.Drawing.Point(0, 425);
+            this.panel1.MinimumSize = new System.Drawing.Size(0, 60);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(818, 89);
+            this.panel1.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(0, 17);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(634, 17);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "You won\'t be able to change the signing configuration after you submit to Play St" +
+    "ore or other store. ";
+            // 
+            // flowLayoutPanel2
+            // 
+            this.flowLayoutPanel2.AutoSize = true;
+            this.flowLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel2.Controls.Add(this.buttonGenerate);
+            this.flowLayoutPanel2.Controls.Add(this.buttonOK);
+            this.flowLayoutPanel2.Controls.Add(this.buttonCancel);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(0, 56);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(818, 33);
+            this.flowLayoutPanel2.TabIndex = 1;
+            // 
+            // buttonGenerate
+            // 
+            this.buttonGenerate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonGenerate.AutoSize = true;
+            this.buttonGenerate.Location = new System.Drawing.Point(3, 3);
+            this.buttonGenerate.Name = "buttonGenerate";
+            this.buttonGenerate.Size = new System.Drawing.Size(138, 27);
+            this.buttonGenerate.TabIndex = 0;
+            this.buttonGenerate.Text = "Generate Keystore";
+            this.buttonGenerate.UseVisualStyleBackColor = true;
+            this.buttonGenerate.Click += new System.EventHandler(this.buttonGenerate_Click);
+            // 
+            // buttonOK
+            // 
+            this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonOK.AutoSize = true;
+            this.buttonOK.Location = new System.Drawing.Point(147, 3);
+            this.buttonOK.Name = "buttonOK";
+            this.buttonOK.Size = new System.Drawing.Size(75, 27);
+            this.buttonOK.TabIndex = 1;
+            this.buttonOK.Text = "OK";
+            this.buttonOK.UseVisualStyleBackColor = true;
+            this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonCancel.AutoSize = true;
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(228, 3);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 27);
+            this.buttonCancel.TabIndex = 2;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // labelExplanation
+            // 
+            this.labelExplanation.AutoSize = true;
+            this.labelExplanation.Dock = System.Windows.Forms.DockStyle.Top;
+            this.labelExplanation.Location = new System.Drawing.Point(0, 0);
+            this.labelExplanation.Name = "labelExplanation";
+            this.labelExplanation.Size = new System.Drawing.Size(596, 17);
+            this.labelExplanation.TabIndex = 0;
+            this.labelExplanation.Text = "WARNING: Please backup all information!  No certificate information is stored in " +
+    "your project!!!";
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.panel2);
+            this.flowLayoutPanel1.Controls.Add(this.richTextBox1);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(818, 425);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // panel2
+            // 
+            this.panel2.AutoSize = true;
+            this.panel2.Controls.Add(this.tableLayoutPanel2);
+            this.panel2.Controls.Add(this.groupBoxKey);
+            this.panel2.Location = new System.Drawing.Point(3, 3);
+            this.panel2.MinimumSize = new System.Drawing.Size(464, 400);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(464, 404);
+            this.panel2.TabIndex = 5;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.AutoSize = true;
+            this.tableLayoutPanel2.ColumnCount = 3;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 38.09524F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 61.90476F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 47F));
+            this.tableLayoutPanel2.Controls.Add(this.textboxKeystorePassword, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.textboxKeystorePath, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.labelKeystore_Path, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.labelKeystorePass, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.buttonBrowse, 2, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.MinimumSize = new System.Drawing.Size(464, 64);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(464, 64);
+            this.tableLayoutPanel2.TabIndex = 3;
+            // 
+            // textboxKeystorePassword
+            // 
+            this.textboxKeystorePassword.Location = new System.Drawing.Point(161, 35);
+            this.textboxKeystorePassword.MaxLength = 64;
+            this.textboxKeystorePassword.MinimumSize = new System.Drawing.Size(240, 24);
+            this.textboxKeystorePassword.Name = "textboxKeystorePassword";
+            this.textboxKeystorePassword.Size = new System.Drawing.Size(240, 24);
+            this.textboxKeystorePassword.TabIndex = 18;
+            this.textboxKeystorePassword.TextChanged += new System.EventHandler(this.textboxKeystorePassword_TextChanged);
+            this.textboxKeystorePassword.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystorePassword_Validating);
+            // 
+            // textboxKeystorePath
+            // 
+            this.textboxKeystorePath.Location = new System.Drawing.Point(161, 3);
+            this.textboxKeystorePath.MaxLength = 280;
+            this.textboxKeystorePath.MinimumSize = new System.Drawing.Size(240, 24);
+            this.textboxKeystorePath.Name = "textboxKeystorePath";
+            this.textboxKeystorePath.Size = new System.Drawing.Size(240, 24);
+            this.textboxKeystorePath.TabIndex = 17;
+            this.textboxKeystorePath.TextChanged += new System.EventHandler(this.textboxKeystorePath_TextChanged);
+            this.textboxKeystorePath.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystorePath_Validating);
+            // 
+            // labelKeystore_Path
+            // 
+            this.labelKeystore_Path.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelKeystore_Path.AutoSize = true;
+            this.labelKeystore_Path.Location = new System.Drawing.Point(51, 0);
+            this.labelKeystore_Path.Name = "labelKeystore_Path";
+            this.labelKeystore_Path.Size = new System.Drawing.Size(104, 17);
+            this.labelKeystore_Path.TabIndex = 13;
+            this.labelKeystore_Path.Text = "Key store path:";
+            // 
+            // labelKeystorePass
+            // 
+            this.labelKeystorePass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelKeystorePass.AutoSize = true;
+            this.labelKeystorePass.Location = new System.Drawing.Point(82, 32);
+            this.labelKeystorePass.Name = "labelKeystorePass";
+            this.labelKeystorePass.Size = new System.Drawing.Size(73, 17);
+            this.labelKeystorePass.TabIndex = 14;
+            this.labelKeystorePass.Text = "Password:";
+            // 
+            // buttonBrowse
+            // 
+            this.buttonBrowse.Location = new System.Drawing.Point(419, 3);
+            this.buttonBrowse.Name = "buttonBrowse";
+            this.buttonBrowse.Size = new System.Drawing.Size(39, 24);
+            this.buttonBrowse.TabIndex = 19;
+            this.buttonBrowse.Text = "...";
+            this.buttonBrowse.UseVisualStyleBackColor = true;
+            this.buttonBrowse.Click += new System.EventHandler(this.buttonBrowse_Click);
+            // 
+            // groupBoxKey
+            // 
+            this.groupBoxKey.AutoSize = true;
+            this.groupBoxKey.Controls.Add(this.groupBoxCertificate);
+            this.groupBoxKey.Controls.Add(this.tableLayoutPanel1);
+            this.groupBoxKey.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.groupBoxKey.Location = new System.Drawing.Point(0, 64);
+            this.groupBoxKey.MinimumSize = new System.Drawing.Size(436, 340);
+            this.groupBoxKey.Name = "groupBoxKey";
+            this.groupBoxKey.Size = new System.Drawing.Size(464, 340);
+            this.groupBoxKey.TabIndex = 4;
+            this.groupBoxKey.TabStop = false;
+            this.groupBoxKey.Text = "Key";
+            // 
+            // groupBoxCertificate
+            // 
+            this.groupBoxCertificate.AutoSize = true;
+            this.groupBoxCertificate.Controls.Add(this.tableLayoutPanel3);
+            this.groupBoxCertificate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBoxCertificate.Location = new System.Drawing.Point(3, 118);
+            this.groupBoxCertificate.MinimumSize = new System.Drawing.Size(430, 200);
+            this.groupBoxCertificate.Name = "groupBoxCertificate";
+            this.groupBoxCertificate.Size = new System.Drawing.Size(458, 219);
+            this.groupBoxCertificate.TabIndex = 1;
+            this.groupBoxCertificate.TabStop = false;
+            this.groupBoxCertificate.Text = "Certificate";
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.ColumnCount = 2;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 39.62264F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 60.37736F));
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertCN, 1, 0);
+            this.tableLayoutPanel3.Controls.Add(this.label17, 0, 0);
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertC, 1, 5);
+            this.tableLayoutPanel3.Controls.Add(this.label22, 0, 5);
+            this.tableLayoutPanel3.Controls.Add(this.label18, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertOU, 1, 1);
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertST, 1, 4);
+            this.tableLayoutPanel3.Controls.Add(this.label21, 0, 4);
+            this.tableLayoutPanel3.Controls.Add(this.label19, 0, 2);
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertO, 1, 2);
+            this.tableLayoutPanel3.Controls.Add(this.textboxKeystoreCertL, 1, 3);
+            this.tableLayoutPanel3.Controls.Add(this.label20, 0, 3);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 18);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(452, 198);
+            this.tableLayoutPanel3.TabIndex = 0;
+            // 
+            // textboxKeystoreCertCN
+            // 
+            this.textboxKeystoreCertCN.Location = new System.Drawing.Point(182, 3);
+            this.textboxKeystoreCertCN.MaxLength = 48;
+            this.textboxKeystoreCertCN.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertCN.Name = "textboxKeystoreCertCN";
+            this.textboxKeystoreCertCN.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertCN.TabIndex = 1;
+            this.textboxKeystoreCertCN.TextChanged += new System.EventHandler(this.textboxKeystoreCertCN_TextChanged);
+            this.textboxKeystoreCertCN.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertCN_Validating);
+            // 
+            // label17
+            // 
+            this.label17.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(37, 0);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(139, 17);
+            this.label17.TabIndex = 0;
+            this.label17.Text = "First and Last Name:";
+            // 
+            // textboxKeystoreCertC
+            // 
+            this.textboxKeystoreCertC.Location = new System.Drawing.Point(182, 163);
+            this.textboxKeystoreCertC.MaxLength = 2;
+            this.textboxKeystoreCertC.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertC.Name = "textboxKeystoreCertC";
+            this.textboxKeystoreCertC.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertC.TabIndex = 11;
+            this.textboxKeystoreCertC.TextChanged += new System.EventHandler(this.textboxKeystoreCertC_TextChanged);
+            this.textboxKeystoreCertC.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertC_Validating);
+            // 
+            // label22
+            // 
+            this.label22.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label22.AutoSize = true;
+            this.label22.Location = new System.Drawing.Point(46, 160);
+            this.label22.Name = "label22";
+            this.label22.Size = new System.Drawing.Size(130, 17);
+            this.label22.TabIndex = 10;
+            this.label22.Text = "Country Code (XX):";
+            // 
+            // label18
+            // 
+            this.label18.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label18.AutoSize = true;
+            this.label18.Location = new System.Drawing.Point(43, 32);
+            this.label18.Name = "label18";
+            this.label18.Size = new System.Drawing.Size(133, 17);
+            this.label18.TabIndex = 2;
+            this.label18.Text = "Organizational Unit:";
+            // 
+            // textboxKeystoreCertOU
+            // 
+            this.textboxKeystoreCertOU.Location = new System.Drawing.Point(182, 35);
+            this.textboxKeystoreCertOU.MaxLength = 48;
+            this.textboxKeystoreCertOU.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertOU.Name = "textboxKeystoreCertOU";
+            this.textboxKeystoreCertOU.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertOU.TabIndex = 3;
+            this.textboxKeystoreCertOU.TextChanged += new System.EventHandler(this.textboxKeystoreCertOU_TextChanged);
+            this.textboxKeystoreCertOU.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertOU_Validating);
+            // 
+            // textboxKeystoreCertST
+            // 
+            this.textboxKeystoreCertST.Location = new System.Drawing.Point(182, 131);
+            this.textboxKeystoreCertST.MaxLength = 48;
+            this.textboxKeystoreCertST.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertST.Name = "textboxKeystoreCertST";
+            this.textboxKeystoreCertST.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertST.TabIndex = 9;
+            this.textboxKeystoreCertST.TextChanged += new System.EventHandler(this.textboxKeystoreCertST_TextChanged);
+            this.textboxKeystoreCertST.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertST_Validating);
+            // 
+            // label21
+            // 
+            this.label21.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label21.AutoSize = true;
+            this.label21.Location = new System.Drawing.Point(55, 128);
+            this.label21.Name = "label21";
+            this.label21.Size = new System.Drawing.Size(121, 17);
+            this.label21.TabIndex = 8;
+            this.label21.Text = "State or Province:";
+            // 
+            // label19
+            // 
+            this.label19.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label19.AutoSize = true;
+            this.label19.Location = new System.Drawing.Point(83, 64);
+            this.label19.Name = "label19";
+            this.label19.Size = new System.Drawing.Size(93, 17);
+            this.label19.TabIndex = 4;
+            this.label19.Text = "Organization:";
+            // 
+            // textboxKeystoreCertO
+            // 
+            this.textboxKeystoreCertO.Location = new System.Drawing.Point(182, 67);
+            this.textboxKeystoreCertO.MaxLength = 48;
+            this.textboxKeystoreCertO.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertO.Name = "textboxKeystoreCertO";
+            this.textboxKeystoreCertO.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertO.TabIndex = 5;
+            this.textboxKeystoreCertO.TextChanged += new System.EventHandler(this.textboxKeystoreCertO_TextChanged);
+            this.textboxKeystoreCertO.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertO_Validating);
+            // 
+            // textboxKeystoreCertL
+            // 
+            this.textboxKeystoreCertL.Location = new System.Drawing.Point(182, 99);
+            this.textboxKeystoreCertL.MaxLength = 48;
+            this.textboxKeystoreCertL.MinimumSize = new System.Drawing.Size(236, 24);
+            this.textboxKeystoreCertL.Name = "textboxKeystoreCertL";
+            this.textboxKeystoreCertL.Size = new System.Drawing.Size(236, 22);
+            this.textboxKeystoreCertL.TabIndex = 7;
+            this.textboxKeystoreCertL.TextChanged += new System.EventHandler(this.textboxKeystoreCertL_TextChanged);
+            this.textboxKeystoreCertL.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreCertL_Validating);
+            // 
+            // label20
+            // 
+            this.label20.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label20.AutoSize = true;
+            this.label20.Location = new System.Drawing.Point(72, 96);
+            this.label20.Name = "label20";
+            this.label20.Size = new System.Drawing.Size(104, 17);
+            this.label20.TabIndex = 6;
+            this.label20.Text = "City or Locality:";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 38.07107F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 61.92893F));
+            this.tableLayoutPanel1.Controls.Add(this.textboxKeystoreKeyPassword, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelKeystoreKeyAlias, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label23, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.textboxKeystoreKeyAlias, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.numericValidityYears, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.labelKeystoreKeyPass, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 18);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(458, 100);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // textboxKeystoreKeyPassword
+            // 
+            this.textboxKeystoreKeyPassword.Location = new System.Drawing.Point(177, 36);
+            this.textboxKeystoreKeyPassword.MaxLength = 64;
+            this.textboxKeystoreKeyPassword.MinimumSize = new System.Drawing.Size(238, 24);
+            this.textboxKeystoreKeyPassword.Name = "textboxKeystoreKeyPassword";
+            this.textboxKeystoreKeyPassword.Size = new System.Drawing.Size(238, 22);
+            this.textboxKeystoreKeyPassword.TabIndex = 20;
+            this.textboxKeystoreKeyPassword.TextChanged += new System.EventHandler(this.textboxKeystoreKeyPassword_TextChanged);
+            this.textboxKeystoreKeyPassword.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreKeyPassword_Validating);
+            // 
+            // labelKeystoreKeyAlias
+            // 
+            this.labelKeystoreKeyAlias.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelKeystoreKeyAlias.AutoSize = true;
+            this.labelKeystoreKeyAlias.Location = new System.Drawing.Point(101, 0);
+            this.labelKeystoreKeyAlias.Name = "labelKeystoreKeyAlias";
+            this.labelKeystoreKeyAlias.Size = new System.Drawing.Size(70, 17);
+            this.labelKeystoreKeyAlias.TabIndex = 15;
+            this.labelKeystoreKeyAlias.Text = "Key Alias:";
+            // 
+            // label23
+            // 
+            this.label23.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label23.AutoSize = true;
+            this.label23.Location = new System.Drawing.Point(65, 66);
+            this.label23.Name = "label23";
+            this.label23.Size = new System.Drawing.Size(106, 17);
+            this.label23.TabIndex = 12;
+            this.label23.Text = "Validity (years):";
+            // 
+            // textboxKeystoreKeyAlias
+            // 
+            this.textboxKeystoreKeyAlias.Location = new System.Drawing.Point(177, 3);
+            this.textboxKeystoreKeyAlias.MaxLength = 64;
+            this.textboxKeystoreKeyAlias.MinimumSize = new System.Drawing.Size(238, 24);
+            this.textboxKeystoreKeyAlias.Name = "textboxKeystoreKeyAlias";
+            this.textboxKeystoreKeyAlias.Size = new System.Drawing.Size(238, 22);
+            this.textboxKeystoreKeyAlias.TabIndex = 19;
+            this.textboxKeystoreKeyAlias.TextChanged += new System.EventHandler(this.textboxKeystoreKeyAlias_TextChanged);
+            this.textboxKeystoreKeyAlias.Validating += new System.ComponentModel.CancelEventHandler(this.textboxKeystoreKeyAlias_Validating);
+            // 
+            // numericValidityYears
+            // 
+            this.numericValidityYears.Location = new System.Drawing.Point(177, 69);
+            this.numericValidityYears.Name = "numericValidityYears";
+            this.numericValidityYears.Size = new System.Drawing.Size(120, 22);
+            this.numericValidityYears.TabIndex = 3;
+            this.numericValidityYears.Validating += new System.ComponentModel.CancelEventHandler(this.numericValidityYears_Validating);
+            // 
+            // labelKeystoreKeyPass
+            // 
+            this.labelKeystoreKeyPass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelKeystoreKeyPass.AutoSize = true;
+            this.labelKeystoreKeyPass.Location = new System.Drawing.Point(70, 33);
+            this.labelKeystoreKeyPass.Name = "labelKeystoreKeyPass";
+            this.labelKeystoreKeyPass.Size = new System.Drawing.Size(101, 17);
+            this.labelKeystoreKeyPass.TabIndex = 16;
+            this.labelKeystoreKeyPass.Text = "Key Password:";
+            // 
+            // richTextBox1
+            // 
+            this.richTextBox1.CausesValidation = false;
+            this.richTextBox1.DetectUrls = false;
+            this.richTextBox1.Enabled = false;
+            this.richTextBox1.HideSelection = false;
+            this.richTextBox1.Location = new System.Drawing.Point(473, 3);
+            this.richTextBox1.Name = "richTextBox1";
+            this.richTextBox1.ReadOnly = true;
+            this.richTextBox1.Size = new System.Drawing.Size(302, 404);
+            this.richTextBox1.TabIndex = 6;
+            this.richTextBox1.Text = resources.GetString("richTextBox1.Text");
+            // 
+            // GenerateAndroidKeystore
+            // 
+            this.AcceptButton = this.buttonOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(818, 514);
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.Controls.Add(this.panel1);
+            this.MinimizeBox = false;
+            this.Name = "GenerateAndroidKeystore";
+            this.ShowIcon = false;
+            this.Text = "GenerateAndroidKeystore";
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
+            this.flowLayoutPanel2.ResumeLayout(false);
+            this.flowLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.groupBoxKey.ResumeLayout(false);
+            this.groupBoxKey.PerformLayout();
+            this.groupBoxCertificate.ResumeLayout(false);
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericValidityYears)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Label labelExplanation;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.TextBox textboxKeystorePassword;
+        private System.Windows.Forms.TextBox textboxKeystorePath;
+        private System.Windows.Forms.Label labelKeystore_Path;
+        private System.Windows.Forms.Label labelKeystorePass;
+        private System.Windows.Forms.GroupBox groupBoxKey;
+        private System.Windows.Forms.GroupBox groupBoxCertificate;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private System.Windows.Forms.TextBox textboxKeystoreCertCN;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.TextBox textboxKeystoreCertC;
+        private System.Windows.Forms.Label label22;
+        private System.Windows.Forms.Label label18;
+        private System.Windows.Forms.TextBox textboxKeystoreCertOU;
+        private System.Windows.Forms.TextBox textboxKeystoreCertST;
+        private System.Windows.Forms.Label label21;
+        private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.TextBox textboxKeystoreCertO;
+        private System.Windows.Forms.TextBox textboxKeystoreCertL;
+        private System.Windows.Forms.Label label20;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TextBox textboxKeystoreKeyPassword;
+        private System.Windows.Forms.Label labelKeystoreKeyAlias;
+        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.TextBox textboxKeystoreKeyAlias;
+        private System.Windows.Forms.NumericUpDown numericValidityYears;
+        private System.Windows.Forms.Label labelKeystoreKeyPass;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+        private System.Windows.Forms.Button buttonGenerate;
+        private System.Windows.Forms.Button buttonOK;
+        private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.RichTextBox richTextBox1;
+        private System.Windows.Forms.Button buttonBrowse;
+    }
+}

--- a/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.cs
+++ b/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+using System.Reflection;
+using System.Windows.Forms;
+using AGS.Editor.Utils;
+
+namespace AGS.Editor
+{
+    public partial class GenerateAndroidKeystore : Form
+    {
+        private AndroidKeystoreData _ks;
+        private AndroidKeystoreData _lastGeneratedKS;
+
+        private Dictionary<TextBox, PropertyInfo> _TbProp;
+
+        public GenerateAndroidKeystoreResponse Response;
+
+        public GenerateAndroidKeystore()
+        {
+            InitializeComponent();
+            buttonOK.Enabled = false;
+            _ks = new AndroidKeystoreData();
+            _lastGeneratedKS = null;
+            Response = null;
+            _TbProp = new Dictionary<TextBox, PropertyInfo>
+            {
+                {textboxKeystorePath, typeof(AndroidKeystoreData).GetProperty("KeystorePath") },
+                {textboxKeystorePassword, typeof(AndroidKeystoreData).GetProperty("Password") },
+                {textboxKeystoreKeyAlias, typeof(AndroidKeystoreData).GetProperty("KeyAlias") },
+                {textboxKeystoreKeyPassword, typeof(AndroidKeystoreData).GetProperty("KeyPassword") },
+                {textboxKeystoreCertCN, typeof(AndroidKeystoreData).GetProperty("FirstAndLastName") },
+                {textboxKeystoreCertOU, typeof(AndroidKeystoreData).GetProperty("OrganizationalUnit") },
+                {textboxKeystoreCertO, typeof(AndroidKeystoreData).GetProperty("OrganizationName") },
+                {textboxKeystoreCertL, typeof(AndroidKeystoreData).GetProperty("CityOrLocality") },
+                {textboxKeystoreCertST, typeof(AndroidKeystoreData).GetProperty("StateOrProvince") },
+                {textboxKeystoreCertC, typeof(AndroidKeystoreData).GetProperty("CountryCode") }
+            };
+        }
+
+        private void UpdateAndValidate(object sender, bool inChangedEvent = false)
+        {
+            // AndroidKeystoreData Properties already check and only set non-invalid characters
+            // We are going use this to filter unwanted data
+
+            TextBox tb = sender as TextBox;
+            if (tb == null) return;
+
+            if (inChangedEvent && tb.Text.Length > 2)
+            {
+                // we allow typing a space character in this case, because some certificate info may have spaces
+
+                int len = tb.Text.Length;
+                if((tb.Text[len - 1] == ' ') && (tb.Text[len - 2] != ' '))
+                {
+                    return;
+                }
+            }
+
+            string ks_val = (string)_TbProp[tb].GetValue(_ks);
+
+            if (ks_val == tb.Text) return;
+
+            _TbProp[tb].SetValue(_ks, tb.Text);
+
+            // after evaluating and trimming, the property may be still empty
+            ks_val = (string)_TbProp[tb].GetValue(_ks);
+            if (string.IsNullOrEmpty(ks_val)) return;
+
+            // if it's not, then update back
+            tb.Text = ks_val;
+            tb.SelectionStart = tb.Text.Length;
+            tb.SelectionLength = 0;
+        }
+
+        private void UpdateAndValidateAllowSpaces(object sender)
+        {
+            UpdateAndValidate(sender, true);
+        }
+
+        private void numericValidityYears_Validating(object sender, CancelEventArgs e)
+        {
+            if (_ks.ValidityInYears == (int)numericValidityYears.Value) return;
+            numericValidityYears.Value = _ks.ValidityInYears = (int)numericValidityYears.Value;
+        }
+
+        // TextBox Validating Events
+
+        private void textboxKeystorePath_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystorePassword_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreKeyAlias_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreKeyPassword_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+
+        private void textboxKeystoreCertCN_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreCertOU_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreCertO_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreCertL_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreCertST_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        private void textboxKeystoreCertC_Validating(object sender, CancelEventArgs e)
+        {
+            UpdateAndValidate(sender);
+        }
+
+        // TextChanged Events
+
+        private void textboxKeystorePath_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystorePassword_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreKeyAlias_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreKeyPassword_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertCN_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertOU_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertO_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertL_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertST_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void textboxKeystoreCertC_TextChanged(object sender, EventArgs e)
+        {
+            UpdateAndValidateAllowSpaces(sender);
+        }
+
+        private void buttonGenerate_Click(object sender, EventArgs e)
+        {
+            string errors = String.Join("\n", AndroidUtilities.GetKeystoreErrors(_ks));
+
+            if (!string.IsNullOrEmpty(errors))
+            {
+                string intro = "We found errors that have to be fixed before keystore geneation:";
+
+                MessageBox.Show(intro + "\n\n" + errors);
+                return;
+            }
+
+            if(AndroidUtilities.RunGenerateKeystore(_ks))
+            {
+                _lastGeneratedKS = _ks.Copy();
+                buttonOK.Enabled = true;
+            }
+        }
+
+        private void buttonOK_Click(object sender, EventArgs e)
+        {
+            if (_lastGeneratedKS == null) return;
+
+            Response = new GenerateAndroidKeystoreResponse()
+            {
+                Keystore = _lastGeneratedKS.KeystorePath,
+                Password = _lastGeneratedKS.Password,
+                KeyAlias = _lastGeneratedKS.KeyAlias,
+                KeyPassword = _lastGeneratedKS.KeyPassword,
+            };
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void buttonBrowse_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Title = "Set keystore filename for generation";
+                openFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                openFileDialog.Filter = "key store files (*.jks)|*.jks|All files (*.*)|*.*";
+                openFileDialog.RestoreDirectory = true;
+                openFileDialog.CheckFileExists = false;
+
+                if (openFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    textboxKeystorePath.Text = openFileDialog.FileName;
+                }
+            }
+        }
+    }
+
+    public class GenerateAndroidKeystoreResponse
+    {
+        public string Keystore;
+        public string Password;
+        public string KeyAlias;
+        public string KeyPassword;
+    }
+}

--- a/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.resx
+++ b/Editor/AGS.Editor/GUI/GenerateAndroidKeystore.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="richTextBox1.Text" xml:space="preserve">
+    <value>Key store path: Select the location where your keystore should be created. Also, a file name should be added to the end of the location path with the .jks extension.
+Password: Create and confirm a secure password for your keystore.
+
+Alias: Enter an identifying name for your key.
+Password: Create and confirm a secure password for your key. This should be the same as your keystore password.
+Validity (years): Set the length of time in years that your key will be valid. Your key should be valid for at least 25 years, so you can sign app updates with the same key through the lifespan of your app. And at minimum 12 years to be accepted in Play Store.
+
+Certificate: Enter some information about yourself for your certificate. This information is not displayed in your app, but is included in your certificate as part of the APK.</value>
+  </data>
+</root>

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -89,6 +89,37 @@ namespace AGS.Editor
             this.label13 = new System.Windows.Forms.Label();
             this.radNewGameSpecificPath = new System.Windows.Forms.RadioButton();
             this.radNewGameMyDocs = new System.Windows.Forms.RadioButton();
+            this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.groupBoxAndroidJdkPath = new System.Windows.Forms.GroupBox();
+            this.btnAndChooseJavaHomePath = new System.Windows.Forms.Button();
+            this.txtAndJavaHomePath = new System.Windows.Forms.TextBox();
+            this.label16 = new System.Windows.Forms.Label();
+            this.radAndJavaHomePath = new System.Windows.Forms.RadioButton();
+            this.radAndJavaHomeEnv = new System.Windows.Forms.RadioButton();
+            this.groupBoxAndroidSdkPath = new System.Windows.Forms.GroupBox();
+            this.btnAndChooseAndroidHomePath = new System.Windows.Forms.Button();
+            this.txtAndAndroidHomePath = new System.Windows.Forms.TextBox();
+            this.label15 = new System.Windows.Forms.Label();
+            this.radAndAndroidHomePath = new System.Windows.Forms.RadioButton();
+            this.radAndAndroidHomeEnv = new System.Windows.Forms.RadioButton();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelAndKey_File = new System.Windows.Forms.Label();
+            this.textBoxAndKeystoreFile = new System.Windows.Forms.TextBox();
+            this.labelAndKey_Pass = new System.Windows.Forms.Label();
+            this.textBoxAndKeystorePassword = new System.Windows.Forms.TextBox();
+            this.labelAndKey_KeyAlias = new System.Windows.Forms.Label();
+            this.textBoxAndKeystoreKeyAlias = new System.Windows.Forms.TextBox();
+            this.labelAndKey_KeyPass = new System.Windows.Forms.Label();
+            this.textBoxAndKeystoreKeyPassword = new System.Windows.Forms.TextBox();
+            this.checkBoxAndroidShowPassword = new System.Windows.Forms.CheckBox();
+            this.label17 = new System.Windows.Forms.Label();
+            this.buttonAndroidGenerateKeystore = new System.Windows.Forms.Button();
+            this.buttonAndroidChooseKeystore = new System.Windows.Forms.Button();
+            this.groupBoxKeystore = new System.Windows.Forms.GroupBox();
+            this.labelJdkOk = new System.Windows.Forms.Label();
+            this.labelSdkOk = new System.Windows.Forms.Label();
             this.tabPageLast.SuspendLayout();
             this.tabPageFirst.SuspendLayout();
             this.groupBox9.SuspendLayout();
@@ -105,6 +136,15 @@ namespace AGS.Editor
             this.flowLayoutPanel1.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupBox6.SuspendLayout();
+            this.tabPage3.SuspendLayout();
+            this.flowLayoutPanel2.SuspendLayout();
+            this.groupBoxAndroidJdkPath.SuspendLayout();
+            this.groupBoxAndroidSdkPath.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.groupBoxKeystore.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOK
@@ -719,8 +759,10 @@ namespace AGS.Editor
             // 
             this.tabControl1.Controls.Add(this.tabPageFirst);
             this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Controls.Add(this.tabPage3);
             this.tabControl1.Controls.Add(this.tabPageLast);
-            this.tabControl1.Location = new System.Drawing.Point(6, 0);
+            this.tabControl1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(928, 602);
@@ -896,6 +938,377 @@ namespace AGS.Editor
             this.radNewGameMyDocs.UseVisualStyleBackColor = true;
             this.radNewGameMyDocs.CheckedChanged += new System.EventHandler(this.radNewGameMyDocs_CheckedChanged);
             // 
+            // tabPage3
+            // 
+            this.tabPage3.Controls.Add(this.flowLayoutPanel2);
+            this.tabPage3.Location = new System.Drawing.Point(4, 26);
+            this.tabPage3.Name = "tabPage3";
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage3.Size = new System.Drawing.Size(920, 572);
+            this.tabPage3.TabIndex = 4;
+            this.tabPage3.Text = "Android";
+            this.tabPage3.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel2
+            // 
+            this.flowLayoutPanel2.Controls.Add(this.groupBoxAndroidJdkPath);
+            this.flowLayoutPanel2.Controls.Add(this.groupBoxAndroidSdkPath);
+            this.flowLayoutPanel2.Controls.Add(this.splitContainer1);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(914, 566);
+            this.flowLayoutPanel2.TabIndex = 0;
+            // 
+            // groupBoxAndroidJdkPath
+            // 
+            this.groupBoxAndroidJdkPath.Controls.Add(this.labelJdkOk);
+            this.groupBoxAndroidJdkPath.Controls.Add(this.btnAndChooseJavaHomePath);
+            this.groupBoxAndroidJdkPath.Controls.Add(this.txtAndJavaHomePath);
+            this.groupBoxAndroidJdkPath.Controls.Add(this.label16);
+            this.groupBoxAndroidJdkPath.Controls.Add(this.radAndJavaHomePath);
+            this.groupBoxAndroidJdkPath.Controls.Add(this.radAndJavaHomeEnv);
+            this.groupBoxAndroidJdkPath.Location = new System.Drawing.Point(4, 4);
+            this.groupBoxAndroidJdkPath.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBoxAndroidJdkPath.Name = "groupBoxAndroidJdkPath";
+            this.groupBoxAndroidJdkPath.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBoxAndroidJdkPath.Size = new System.Drawing.Size(904, 115);
+            this.groupBoxAndroidJdkPath.TabIndex = 13;
+            this.groupBoxAndroidJdkPath.TabStop = false;
+            this.groupBoxAndroidJdkPath.Text = "JDK Path";
+            // 
+            // btnAndChooseJavaHomePath
+            // 
+            this.btnAndChooseJavaHomePath.Location = new System.Drawing.Point(401, 75);
+            this.btnAndChooseJavaHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.btnAndChooseJavaHomePath.Name = "btnAndChooseJavaHomePath";
+            this.btnAndChooseJavaHomePath.Size = new System.Drawing.Size(34, 26);
+            this.btnAndChooseJavaHomePath.TabIndex = 4;
+            this.btnAndChooseJavaHomePath.Text = "...";
+            this.btnAndChooseJavaHomePath.UseVisualStyleBackColor = true;
+            this.btnAndChooseJavaHomePath.Click += new System.EventHandler(this.btnAndChooseJavaHomePath_Click);
+            // 
+            // txtAndJavaHomePath
+            // 
+            this.txtAndJavaHomePath.Location = new System.Drawing.Point(121, 75);
+            this.txtAndJavaHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtAndJavaHomePath.MaxLength = 0;
+            this.txtAndJavaHomePath.Name = "txtAndJavaHomePath";
+            this.txtAndJavaHomePath.Size = new System.Drawing.Size(272, 24);
+            this.txtAndJavaHomePath.TabIndex = 3;
+            // 
+            // label16
+            // 
+            this.label16.AutoSize = true;
+            this.label16.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label16.Location = new System.Drawing.Point(4, 21);
+            this.label16.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label16.MaximumSize = new System.Drawing.Size(800, 0);
+            this.label16.Name = "label16";
+            this.label16.Size = new System.Drawing.Size(465, 17);
+            this.label16.TabIndex = 2;
+            this.label16.Text = "Where is the JDK installation that should be used by Android build process?";
+            // 
+            // radAndJavaHomePath
+            // 
+            this.radAndJavaHomePath.AutoSize = true;
+            this.radAndJavaHomePath.Location = new System.Drawing.Point(18, 78);
+            this.radAndJavaHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.radAndJavaHomePath.Name = "radAndJavaHomePath";
+            this.radAndJavaHomePath.Size = new System.Drawing.Size(94, 21);
+            this.radAndJavaHomePath.TabIndex = 1;
+            this.radAndJavaHomePath.Text = "Default to:";
+            this.radAndJavaHomePath.UseVisualStyleBackColor = true;
+            this.radAndJavaHomePath.CheckedChanged += new System.EventHandler(this.radAndJavaHomePath_CheckedChanged);
+            // 
+            // radAndJavaHomeEnv
+            // 
+            this.radAndJavaHomeEnv.AutoSize = true;
+            this.radAndJavaHomeEnv.Checked = true;
+            this.radAndJavaHomeEnv.Location = new System.Drawing.Point(18, 49);
+            this.radAndJavaHomeEnv.Margin = new System.Windows.Forms.Padding(4);
+            this.radAndJavaHomeEnv.Name = "radAndJavaHomeEnv";
+            this.radAndJavaHomeEnv.Size = new System.Drawing.Size(300, 21);
+            this.radAndJavaHomeEnv.TabIndex = 0;
+            this.radAndJavaHomeEnv.TabStop = true;
+            this.radAndJavaHomeEnv.Text = "Default to JAVA_HOME environment variable";
+            this.radAndJavaHomeEnv.UseVisualStyleBackColor = true;
+            this.radAndJavaHomeEnv.CheckedChanged += new System.EventHandler(this.radAndJavaHomeEnv_CheckedChanged);
+            // 
+            // groupBoxAndroidSdkPath
+            // 
+            this.groupBoxAndroidSdkPath.Controls.Add(this.labelSdkOk);
+            this.groupBoxAndroidSdkPath.Controls.Add(this.btnAndChooseAndroidHomePath);
+            this.groupBoxAndroidSdkPath.Controls.Add(this.txtAndAndroidHomePath);
+            this.groupBoxAndroidSdkPath.Controls.Add(this.label15);
+            this.groupBoxAndroidSdkPath.Controls.Add(this.radAndAndroidHomePath);
+            this.groupBoxAndroidSdkPath.Controls.Add(this.radAndAndroidHomeEnv);
+            this.groupBoxAndroidSdkPath.Location = new System.Drawing.Point(4, 127);
+            this.groupBoxAndroidSdkPath.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBoxAndroidSdkPath.Name = "groupBoxAndroidSdkPath";
+            this.groupBoxAndroidSdkPath.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBoxAndroidSdkPath.Size = new System.Drawing.Size(904, 115);
+            this.groupBoxAndroidSdkPath.TabIndex = 12;
+            this.groupBoxAndroidSdkPath.TabStop = false;
+            this.groupBoxAndroidSdkPath.Text = "SDK Path";
+            // 
+            // btnAndChooseAndroidHomePath
+            // 
+            this.btnAndChooseAndroidHomePath.Location = new System.Drawing.Point(401, 75);
+            this.btnAndChooseAndroidHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.btnAndChooseAndroidHomePath.Name = "btnAndChooseAndroidHomePath";
+            this.btnAndChooseAndroidHomePath.Size = new System.Drawing.Size(34, 26);
+            this.btnAndChooseAndroidHomePath.TabIndex = 4;
+            this.btnAndChooseAndroidHomePath.Text = "...";
+            this.btnAndChooseAndroidHomePath.UseVisualStyleBackColor = true;
+            this.btnAndChooseAndroidHomePath.Click += new System.EventHandler(this.btnAndChooseAndroidHomePath_Click);
+            // 
+            // txtAndAndroidHomePath
+            // 
+            this.txtAndAndroidHomePath.Location = new System.Drawing.Point(121, 75);
+            this.txtAndAndroidHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtAndAndroidHomePath.MaxLength = 0;
+            this.txtAndAndroidHomePath.Name = "txtAndAndroidHomePath";
+            this.txtAndAndroidHomePath.Size = new System.Drawing.Size(272, 24);
+            this.txtAndAndroidHomePath.TabIndex = 3;
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label15.Location = new System.Drawing.Point(4, 21);
+            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label15.MaximumSize = new System.Drawing.Size(800, 0);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(452, 17);
+            this.label15.TabIndex = 2;
+            this.label15.Text = "Where is the Android SDK that should be used by Android build process?";
+            // 
+            // radAndAndroidHomePath
+            // 
+            this.radAndAndroidHomePath.AutoSize = true;
+            this.radAndAndroidHomePath.Location = new System.Drawing.Point(18, 78);
+            this.radAndAndroidHomePath.Margin = new System.Windows.Forms.Padding(4);
+            this.radAndAndroidHomePath.Name = "radAndAndroidHomePath";
+            this.radAndAndroidHomePath.Size = new System.Drawing.Size(94, 21);
+            this.radAndAndroidHomePath.TabIndex = 1;
+            this.radAndAndroidHomePath.Text = "Default to:";
+            this.radAndAndroidHomePath.UseVisualStyleBackColor = true;
+            this.radAndAndroidHomePath.CheckedChanged += new System.EventHandler(this.radAndAndroidHomePath_CheckedChanged);
+            // 
+            // radAndAndroidHomeEnv
+            // 
+            this.radAndAndroidHomeEnv.AutoSize = true;
+            this.radAndAndroidHomeEnv.Checked = true;
+            this.radAndAndroidHomeEnv.Location = new System.Drawing.Point(18, 49);
+            this.radAndAndroidHomeEnv.Margin = new System.Windows.Forms.Padding(4);
+            this.radAndAndroidHomeEnv.Name = "radAndAndroidHomeEnv";
+            this.radAndAndroidHomeEnv.Size = new System.Drawing.Size(330, 21);
+            this.radAndAndroidHomeEnv.TabIndex = 0;
+            this.radAndAndroidHomeEnv.TabStop = true;
+            this.radAndAndroidHomeEnv.Text = "Default to ANDROID_HOME environment variable";
+            this.radAndAndroidHomeEnv.UseVisualStyleBackColor = true;
+            this.radAndAndroidHomeEnv.CheckedChanged += new System.EventHandler(this.radAndAndroidHomeEnv_CheckedChanged);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.IsSplitterFixed = true;
+            this.splitContainer1.Location = new System.Drawing.Point(3, 249);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.groupBoxKeystore);
+            this.splitContainer1.Size = new System.Drawing.Size(899, 291);
+            this.splitContainer1.SplitterDistance = 460;
+            this.splitContainer1.TabIndex = 0;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 128F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 270F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.checkBoxAndroidShowPassword, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.buttonAndroidGenerateKeystore, 1, 6);
+            this.tableLayoutPanel1.Controls.Add(this.label17, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.buttonAndroidChooseKeystore, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.labelAndKey_File, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxAndKeystoreFile, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.labelAndKey_Pass, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxAndKeystorePassword, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelAndKey_KeyAlias, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxAndKeystoreKeyAlias, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.labelAndKey_KeyPass, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.textBoxAndKeystoreKeyPassword, 1, 3);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 20);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 7;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(454, 268);
+            this.tableLayoutPanel1.TabIndex = 1;
+            // 
+            // labelAndKey_File
+            // 
+            this.labelAndKey_File.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelAndKey_File.AutoSize = true;
+            this.labelAndKey_File.Location = new System.Drawing.Point(94, 0);
+            this.labelAndKey_File.Name = "labelAndKey_File";
+            this.labelAndKey_File.Size = new System.Drawing.Size(31, 17);
+            this.labelAndKey_File.TabIndex = 0;
+            this.labelAndKey_File.Text = "File:";
+            // 
+            // textBoxAndKeystoreFile
+            // 
+            this.textBoxAndKeystoreFile.Location = new System.Drawing.Point(131, 3);
+            this.textBoxAndKeystoreFile.MinimumSize = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreFile.Name = "textBoxAndKeystoreFile";
+            this.textBoxAndKeystoreFile.Size = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreFile.TabIndex = 1;
+            this.textBoxAndKeystoreFile.Validated += new System.EventHandler(this.textBoxAndKeystoreFile_Validated);
+            // 
+            // labelAndKey_Pass
+            // 
+            this.labelAndKey_Pass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelAndKey_Pass.AutoSize = true;
+            this.labelAndKey_Pass.Location = new System.Drawing.Point(54, 32);
+            this.labelAndKey_Pass.Name = "labelAndKey_Pass";
+            this.labelAndKey_Pass.Size = new System.Drawing.Size(71, 17);
+            this.labelAndKey_Pass.TabIndex = 2;
+            this.labelAndKey_Pass.Text = "Password:";
+            // 
+            // textBoxAndKeystorePassword
+            // 
+            this.textBoxAndKeystorePassword.Location = new System.Drawing.Point(131, 35);
+            this.textBoxAndKeystorePassword.MinimumSize = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystorePassword.Name = "textBoxAndKeystorePassword";
+            this.textBoxAndKeystorePassword.Size = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystorePassword.TabIndex = 3;
+            this.textBoxAndKeystorePassword.Validated += new System.EventHandler(this.textBoxAndKeystorePassword_Validated);
+            // 
+            // labelAndKey_KeyAlias
+            // 
+            this.labelAndKey_KeyAlias.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelAndKey_KeyAlias.AutoSize = true;
+            this.labelAndKey_KeyAlias.Location = new System.Drawing.Point(60, 62);
+            this.labelAndKey_KeyAlias.Name = "labelAndKey_KeyAlias";
+            this.labelAndKey_KeyAlias.Size = new System.Drawing.Size(65, 17);
+            this.labelAndKey_KeyAlias.TabIndex = 4;
+            this.labelAndKey_KeyAlias.Text = "Key Alias:";
+            // 
+            // textBoxAndKeystoreKeyAlias
+            // 
+            this.textBoxAndKeystoreKeyAlias.Location = new System.Drawing.Point(131, 65);
+            this.textBoxAndKeystoreKeyAlias.MinimumSize = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreKeyAlias.Name = "textBoxAndKeystoreKeyAlias";
+            this.textBoxAndKeystoreKeyAlias.Size = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreKeyAlias.TabIndex = 5;
+            this.textBoxAndKeystoreKeyAlias.Validated += new System.EventHandler(this.textBoxAndKeystoreKeyAlias_Validated);
+            // 
+            // labelAndKey_KeyPass
+            // 
+            this.labelAndKey_KeyPass.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelAndKey_KeyPass.AutoSize = true;
+            this.labelAndKey_KeyPass.Location = new System.Drawing.Point(27, 92);
+            this.labelAndKey_KeyPass.Name = "labelAndKey_KeyPass";
+            this.labelAndKey_KeyPass.Size = new System.Drawing.Size(98, 17);
+            this.labelAndKey_KeyPass.TabIndex = 6;
+            this.labelAndKey_KeyPass.Text = "Key Password:";
+            // 
+            // textBoxAndKeystoreKeyPassword
+            // 
+            this.textBoxAndKeystoreKeyPassword.Location = new System.Drawing.Point(131, 95);
+            this.textBoxAndKeystoreKeyPassword.MinimumSize = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreKeyPassword.Name = "textBoxAndKeystoreKeyPassword";
+            this.textBoxAndKeystoreKeyPassword.Size = new System.Drawing.Size(260, 24);
+            this.textBoxAndKeystoreKeyPassword.TabIndex = 7;
+            this.textBoxAndKeystoreKeyPassword.Validated += new System.EventHandler(this.textBoxAndKeystoreKeyPassword_Validated);
+            // 
+            // checkBoxAndroidShowPassword
+            // 
+            this.checkBoxAndroidShowPassword.AutoSize = true;
+            this.checkBoxAndroidShowPassword.Location = new System.Drawing.Point(131, 125);
+            this.checkBoxAndroidShowPassword.Name = "checkBoxAndroidShowPassword";
+            this.checkBoxAndroidShowPassword.Size = new System.Drawing.Size(126, 21);
+            this.checkBoxAndroidShowPassword.TabIndex = 0;
+            this.checkBoxAndroidShowPassword.Text = "Show Password";
+            this.checkBoxAndroidShowPassword.UseVisualStyleBackColor = true;
+            this.checkBoxAndroidShowPassword.CheckStateChanged += new System.EventHandler(this.checkBoxAndroidShowPassword_CheckStateChanged);
+            // 
+            // label17
+            // 
+            this.label17.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label17.AutoSize = true;
+            this.label17.Location = new System.Drawing.Point(131, 176);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(249, 34);
+            this.label17.TabIndex = 5;
+            this.label17.Text = "If you don\'t have a Keystore, generate one";
+            // 
+            // buttonAndroidGenerateKeystore
+            // 
+            this.buttonAndroidGenerateKeystore.Location = new System.Drawing.Point(131, 213);
+            this.buttonAndroidGenerateKeystore.MinimumSize = new System.Drawing.Size(180, 26);
+            this.buttonAndroidGenerateKeystore.Name = "buttonAndroidGenerateKeystore";
+            this.buttonAndroidGenerateKeystore.Size = new System.Drawing.Size(180, 26);
+            this.buttonAndroidGenerateKeystore.TabIndex = 4;
+            this.buttonAndroidGenerateKeystore.Text = "Generate Keystore";
+            this.buttonAndroidGenerateKeystore.UseVisualStyleBackColor = true;
+            this.buttonAndroidGenerateKeystore.Click += new System.EventHandler(this.buttonAndroidGenerateKeystore_Click);
+            // 
+            // buttonAndroidChooseKeystore
+            // 
+            this.buttonAndroidChooseKeystore.Location = new System.Drawing.Point(402, 4);
+            this.buttonAndroidChooseKeystore.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonAndroidChooseKeystore.Name = "buttonAndroidChooseKeystore";
+            this.buttonAndroidChooseKeystore.Size = new System.Drawing.Size(34, 24);
+            this.buttonAndroidChooseKeystore.TabIndex = 6;
+            this.buttonAndroidChooseKeystore.Text = "...";
+            this.buttonAndroidChooseKeystore.UseVisualStyleBackColor = true;
+            this.buttonAndroidChooseKeystore.Click += new System.EventHandler(this.buttonAndroidChooseKeystore_Click);
+            // 
+            // groupBoxKeystore
+            // 
+            this.groupBoxKeystore.AutoSize = true;
+            this.groupBoxKeystore.Controls.Add(this.tableLayoutPanel1);
+            this.groupBoxKeystore.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBoxKeystore.Location = new System.Drawing.Point(0, 0);
+            this.groupBoxKeystore.Name = "groupBoxKeystore";
+            this.groupBoxKeystore.Size = new System.Drawing.Size(460, 291);
+            this.groupBoxKeystore.TabIndex = 0;
+            this.groupBoxKeystore.TabStop = false;
+            this.groupBoxKeystore.Text = "Keystore";
+            // 
+            // labelJdkOk
+            // 
+            this.labelJdkOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelJdkOk.AutoSize = true;
+            this.labelJdkOk.Location = new System.Drawing.Point(476, 21);
+            this.labelJdkOk.Name = "labelJdkOk";
+            this.labelJdkOk.Size = new System.Drawing.Size(144, 17);
+            this.labelJdkOk.TabIndex = 5;
+            this.labelJdkOk.Text = "JDK Found On Config!";
+            this.labelJdkOk.Visible = false;
+            // 
+            // labelSdkOk
+            // 
+            this.labelSdkOk.AutoSize = true;
+            this.labelSdkOk.Location = new System.Drawing.Point(474, 21);
+            this.labelSdkOk.Name = "labelSdkOk";
+            this.labelSdkOk.Size = new System.Drawing.Size(146, 17);
+            this.labelSdkOk.TabIndex = 6;
+            this.labelSdkOk.Text = "SDK Found On Config!";
+            this.labelSdkOk.Visible = false;
+            // 
             // PreferencesEditor
             // 
             this.AcceptButton = this.btnOK;
@@ -938,6 +1351,19 @@ namespace AGS.Editor
             this.groupBox4.PerformLayout();
             this.groupBox6.ResumeLayout(false);
             this.groupBox6.PerformLayout();
+            this.tabPage3.ResumeLayout(false);
+            this.flowLayoutPanel2.ResumeLayout(false);
+            this.groupBoxAndroidJdkPath.ResumeLayout(false);
+            this.groupBoxAndroidJdkPath.PerformLayout();
+            this.groupBoxAndroidSdkPath.ResumeLayout(false);
+            this.groupBoxAndroidSdkPath.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.groupBoxKeystore.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -1005,5 +1431,36 @@ namespace AGS.Editor
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.RadioButton radNewGameSpecificPath;
         private System.Windows.Forms.RadioButton radNewGameMyDocs;
+        private System.Windows.Forms.TabPage tabPage3;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+        private System.Windows.Forms.GroupBox groupBoxAndroidJdkPath;
+        private System.Windows.Forms.Button btnAndChooseJavaHomePath;
+        private System.Windows.Forms.TextBox txtAndJavaHomePath;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.RadioButton radAndJavaHomePath;
+        private System.Windows.Forms.RadioButton radAndJavaHomeEnv;
+        private System.Windows.Forms.GroupBox groupBoxAndroidSdkPath;
+        private System.Windows.Forms.Button btnAndChooseAndroidHomePath;
+        private System.Windows.Forms.TextBox txtAndAndroidHomePath;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.RadioButton radAndAndroidHomePath;
+        private System.Windows.Forms.RadioButton radAndAndroidHomeEnv;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label labelAndKey_File;
+        private System.Windows.Forms.TextBox textBoxAndKeystoreFile;
+        private System.Windows.Forms.Label labelAndKey_Pass;
+        private System.Windows.Forms.TextBox textBoxAndKeystorePassword;
+        private System.Windows.Forms.Label labelAndKey_KeyAlias;
+        private System.Windows.Forms.TextBox textBoxAndKeystoreKeyAlias;
+        private System.Windows.Forms.Label labelAndKey_KeyPass;
+        private System.Windows.Forms.TextBox textBoxAndKeystoreKeyPassword;
+        private System.Windows.Forms.CheckBox checkBoxAndroidShowPassword;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.Button buttonAndroidGenerateKeystore;
+        private System.Windows.Forms.Button buttonAndroidChooseKeystore;
+        private System.Windows.Forms.GroupBox groupBoxKeystore;
+        private System.Windows.Forms.Label labelJdkOk;
+        private System.Windows.Forms.Label labelSdkOk;
     }
 }

--- a/Editor/AGS.Editor/Utils/AndroidUtilities.cs
+++ b/Editor/AGS.Editor/Utils/AndroidUtilities.cs
@@ -179,7 +179,7 @@ namespace AGS.Editor.Utils
         {
             string cmd = GetPrefixEnv();
             cmd += "gradlew.bat " + task_str + " & ";
-            cmd += "pause";
+            cmd += "if ERRORLEVEL 1 pause";
 
             return RunInCmdEXE(cmd, working_dir, show_window);
         }

--- a/Editor/AGS.Editor/Utils/AndroidUtilities.cs
+++ b/Editor/AGS.Editor/Utils/AndroidUtilities.cs
@@ -1,0 +1,428 @@
+﻿using AGS.Editor.Preferences;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace AGS.Editor.Utils
+{
+    public enum GradleTasks
+    {
+        bundleRelease,
+        assembleRelease
+    }
+
+    public class AndroidKeystoreCertificateData
+    {
+        protected string _firstAndLastName;
+        protected string _organizationalUnit;
+        protected string _organizationName;
+        protected string _cityOrLocality;
+        protected string _stateOrProvince;
+        protected string _countryCode;
+
+        public string FirstAndLastName
+        {
+            set { _firstAndLastName = FilterCertificateString(value); }
+            get { return _firstAndLastName; }
+        }
+        public string OrganizationalUnit
+        {
+            set { _organizationalUnit = FilterCertificateString(value); }
+            get { return _organizationalUnit; }
+        }
+        public string OrganizationName
+        {
+            set { _organizationName = FilterCertificateString(value); }
+            get { return _organizationName; }
+        }
+        public string CityOrLocality
+        {
+            set { _cityOrLocality = FilterCertificateString(value); }
+            get { return _cityOrLocality; }
+        }
+        public string StateOrProvince
+        {
+            set { _stateOrProvince = FilterCertificateString(value); }
+            get { return _stateOrProvince; }
+        }
+        public string CountryCode
+        {
+            set { _countryCode = FilterCertificateString(value); }
+            get { return _countryCode; }
+        }
+
+        protected static string FilterCertificateString(string st)
+        {
+            return st.Replace("\"", "").Replace("^", "").Replace(",", "").Replace(";", "").Replace("=", "").Replace("%", "").Trim();
+        }
+    }
+
+    public class AndroidKeystoreData : AndroidKeystoreCertificateData
+    {
+        private string _keystorePath;
+        private string _password;
+        private string _keyAlias;
+        private string _keyPassword;
+        private int _validityInYears;
+
+        protected static string FilterString(string st)
+        {
+            st = FilterCertificateString(st);
+            return st.Replace(" ", "").Replace("'", "");
+        }
+
+        public string KeystorePath
+        {
+            set { _keystorePath = FilterCertificateString(value); }
+            get { return _keystorePath; }
+        }
+
+        public string Password
+        {
+            set { _password = FilterString(value); }
+            get { return _password; }
+        }
+
+        public string KeyAlias
+        {
+            set { _keyAlias = FilterString(value); }
+            get { return _keyAlias; }
+        }
+
+        public string KeyPassword
+        {
+            set { _keyPassword = FilterString(value); }
+            get { return _keyPassword; }
+        }
+
+        public int ValidityInYears
+        {
+            set { _validityInYears = value < 0 ? 1 : value; }
+            get { return _validityInYears; }
+        }
+
+        public AndroidKeystoreData Copy()
+        {
+            AndroidKeystoreData ks = new AndroidKeystoreData
+            {
+                _keystorePath = _keystorePath,
+                _password = _password,
+                _keyAlias = _keyAlias,
+                _keyPassword = _keyPassword,
+                _validityInYears = _validityInYears,
+
+                _firstAndLastName = _firstAndLastName,
+                _organizationalUnit = _organizationalUnit,
+                _organizationName = _organizationName,
+                _cityOrLocality = _cityOrLocality,
+                _stateOrProvince = _stateOrProvince,
+                _countryCode = _countryCode
+            };
+
+            return ks;
+        }
+    }
+
+
+    internal class AndroidUtilities
+    {
+
+        private static bool RunCommand(string command, string args, string working_dir, bool show_window = true)
+        {
+            using (Process proc = new Process
+            {
+                StartInfo =
+                {
+                    UseShellExecute = false,
+                    FileName = command,
+                    Arguments = args,
+                    CreateNoWindow = !show_window,
+                    WorkingDirectory = working_dir
+                }
+            })
+            {
+                try
+                {
+                    proc.Start();
+                    proc.WaitForExit();
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        private static bool RunInCmdEXE(string command, string working_dir, bool show_window = true)
+        {
+            return RunCommand(
+                       command: "cmd.exe",
+                       args: "/C " + command,
+                       working_dir: working_dir,
+                       show_window: show_window
+                       );
+        }
+
+        private static string GetPrefixEnv()
+        {
+            string cmd = "";
+            cmd += "set \"JAVA_HOME=" + GetJavaHome() + "\" & ";
+            cmd += "set \"ANDROID_HOME=" + GetAndroidHome() + "\" & ";
+            cmd += "set \"PATH=%JAVA_HOME%\\bin:%PATH%\" & ";
+            return cmd;
+        }
+
+        private static bool RunGradlewTaskByName(string task_str, string working_dir, bool show_window = true)
+        {
+            string cmd = GetPrefixEnv();
+            cmd += "gradlew.bat " + task_str + " & ";
+            cmd += "pause";
+
+            return RunInCmdEXE(cmd, working_dir, show_window);
+        }
+
+        public static bool RunGradlewTask(GradleTasks task, string working_dir, bool show_window = true)
+        {
+            string task_str = task.ToString();
+            return RunGradlewTaskByName(task_str, working_dir, show_window);
+        }
+
+        public static bool RunGradlewStop(string working_dir)
+        {
+            string cmd = GetPrefixEnv();
+            cmd += "gradlew.bat --stop";
+            return RunInCmdEXE(cmd, working_dir, show_window: false);
+        }
+
+        public static bool RunSdkManager(string parameters, string working_dir)
+        {
+            string sdkManager = GetSdkManagerPath();
+
+            string cmd = GetPrefixEnv();
+            cmd += sdkManager + " " + parameters;
+
+            return RunInCmdEXE(cmd, working_dir, show_window: true);
+        }
+
+        private static string GetEnvironmentPreferences(string env_variable_name, string preferences_variable_value)
+        {
+            string variable_process = Environment.GetEnvironmentVariable(env_variable_name, EnvironmentVariableTarget.Process);
+            string variable_user = Environment.GetEnvironmentVariable(env_variable_name, EnvironmentVariableTarget.User);
+            string variable_machine = Environment.GetEnvironmentVariable(env_variable_name, EnvironmentVariableTarget.Machine);
+
+            string[] vars_in_pref_order = new string[] {
+                preferences_variable_value, variable_process, variable_user, variable_machine };
+
+            for (int i = 0; i < vars_in_pref_order.Length; i++)
+            {
+                string variable = vars_in_pref_order[i];
+                if (!string.IsNullOrEmpty(variable) && Directory.Exists(variable))
+                {
+                    return variable;
+                }
+
+            }
+
+            return null;
+        }
+
+        private static string GetJavaHome()
+        {
+            AppSettings settings = Factory.AGSEditor.Settings;
+            return GetEnvironmentPreferences("JAVA_HOME", settings.AndroidJavaHome);
+        }
+
+        private static string GetAndroidHome()
+        {
+            AppSettings settings = Factory.AGSEditor.Settings;
+            return GetEnvironmentPreferences("ANDROID_HOME", settings.AndroidHome);
+        }
+
+        private static string GetSdkManagerPath()
+        {
+            return Path.Combine(GetAndroidHome(), "tools\\bin\\sdkmanager");
+        }
+
+        private static string GetJavacPath()
+        {
+            return Path.Combine(GetJavaHome(), "bin\\javac");
+        }
+
+        private static string GetKeytoolPath()
+        {
+            return Path.Combine(GetJavaHome(), "bin\\keytool");
+        }
+
+        private static bool IsExecutableAvailable(string path)
+        {
+            return (File.Exists(path) || File.Exists(path + ".exe") || File.Exists(path + ".bat"));
+        }
+
+        public static bool IsKeytoolAvailable()
+        {
+            return IsExecutableAvailable(GetKeytoolPath());
+        }
+
+        public static bool IsJdkFound(string dir)
+        {
+            string path = GetEnvironmentPreferences("JAVA_HOME", dir);
+
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) return false;
+
+            return IsExecutableAvailable(Path.Combine(path, "bin\\javac")) && IsExecutableAvailable(Path.Combine(path, "bin\\keytool"));
+        }
+
+        public static bool IsSdkFound(string dir)
+        {
+            string path = GetEnvironmentPreferences("ANDROID_HOME", dir);
+
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) return false;
+
+            return IsExecutableAvailable(Path.Combine(path, "tools\\bin\\sdkmanager"));
+        }
+
+        private static bool IsJavacAvailable()
+        {
+            return IsExecutableAvailable(GetJavacPath());
+        }
+
+        private static bool IsSdkManagerAvailable()
+        {
+            return IsExecutableAvailable(GetSdkManagerPath());
+        }
+
+        private static string FilterString(string st)
+        {
+            return Regex.Replace(st, @"[^\w\d _]", "").Trim();
+        }
+
+        public static string GetKeystoreCertificateInputString(AndroidKeystoreCertificateData data)
+        {
+            string strCN = data.FirstAndLastName;
+            string strOU = data.OrganizationalUnit;
+            string strO = data.OrganizationName;
+            string strL = data.CityOrLocality;
+            string cnST = data.StateOrProvince;
+            string cnC = data.CountryCode;
+
+            string cert = "";
+            if (!string.IsNullOrEmpty(strCN)) cert += "cn=" + strCN + ", ";
+            if (!string.IsNullOrEmpty(strOU)) cert += "ou=" + strOU + ", ";
+            if (!string.IsNullOrEmpty(strO)) cert += "o=" + strO + ", ";
+            if (!string.IsNullOrEmpty(strL)) cert += "l=" + strL + ", ";
+            if (!string.IsNullOrEmpty(cnST)) cert += "st=" + cnST + ", ";
+            if (!string.IsNullOrEmpty(cnC)) cert += "c=" + cnC;
+
+            if (cert.Length > 2) return cert;
+
+            return string.Empty;
+        }
+
+        private static string GetKeystoreGenerationArguments(AndroidKeystoreData d)
+        {
+            string cert = GetKeystoreCertificateInputString(d);
+
+            string days = (d.ValidityInYears * 365).ToString();
+
+            if (string.IsNullOrEmpty(cert)) cert = "cn=" + d.KeyAlias;
+
+            var cmd = new ArgumentsBuilder(spacesBetweenFlagParam: true);
+
+            cmd.AppendFlag("-genkeypair");
+            cmd.AppendFlag("-noprompt");
+
+            cmd.AppendFlagAndParameter("-keyalg", "RSA");
+            cmd.AppendFlagAndParameter("-keysize", "4096");
+
+            cmd.AppendFlagAndParameter("-dname", cert, quoteAlways: true);
+
+            cmd.AppendFlagAndParameter("-alias", d.KeyAlias);
+            cmd.AppendFlagAndParameter("-keypass", d.KeyPassword);
+            cmd.AppendFlagAndParameter("-storepass", d.Password);
+            cmd.AppendFlagAndParameter("-keystore", d.KeystorePath, quoteAlways: true);
+            cmd.AppendFlagAndParameter("-validity", days);
+
+            return cmd.ToString();
+        }
+
+        public static IEnumerable<string> GetKeystoreErrors(AndroidKeystoreData d)
+        {
+            List<string> errors = new List<string>();
+
+            if (string.IsNullOrEmpty(d.KeystorePath)) errors.Add("Key store path can't be empty.");
+            if (!string.IsNullOrEmpty(d.KeystorePath) && Directory.GetParent(d.KeystorePath) == null) errors.Add("Key store path directory doesn't exist!");
+            if (!string.IsNullOrEmpty(d.KeystorePath) && string.IsNullOrEmpty(Path.GetExtension(d.KeystorePath))) errors.Add("Key store path must include desired filename with extension.");
+            if (!string.IsNullOrEmpty(d.KeystorePath) && !Path.IsPathRooted(d.KeystorePath)) errors.Add("Key store path must be absolute.");
+            if (!string.IsNullOrEmpty(d.KeystorePath) && File.Exists(d.KeystorePath)) errors.Add("Key store path must be a new file, it cannot overwrite an existing file.");
+
+            if (string.IsNullOrEmpty(d.Password)) errors.Add("Password can't be empty.");
+            if (string.IsNullOrEmpty(d.KeyPassword)) errors.Add("Key Password can't be empty.");
+            if (d.KeyPassword != d.Password) errors.Add("Passwords don't match.");
+            if (string.IsNullOrEmpty(d.KeyAlias)) errors.Add("Key alias cannot be empty.");
+
+            if (d.ValidityInYears < 1) errors.Add("Validity cannot be lower than 1 year.");
+
+            return errors;
+        }
+
+        public static bool RunGenerateKeystore(AndroidKeystoreData d)
+        {
+            if (!IsKeytoolAvailable()) return false;
+            string keytool = GetKeytoolPath();
+            string args = GetKeystoreGenerationArguments(d);
+            string wdir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            return RunCommand(command: keytool, args: args, working_dir: wdir, show_window: false);
+        }
+
+        public static IEnumerable<string> GetPreferencesErrors()
+        {
+            AppSettings preferences = Factory.AGSEditor.Settings;
+            string javaHome = GetJavaHome();
+            string androidHome = GetAndroidHome();
+
+            List<string> errors = new List<string>();
+
+            if (string.IsNullOrEmpty(javaHome))
+            {
+                errors.Add("JAVA_HOME is not set in Preferences or Environment variables.");
+            }
+            else
+            {
+                if (!Directory.Exists(javaHome) || !IsJavacAvailable())
+                {
+                    errors.Add("JAVA_HOME is not a valid JDK path. Can't find javac.");
+                }
+            }
+
+            if (string.IsNullOrEmpty(androidHome))
+            {
+                errors.Add("ANDROID_HOME is not set in Preferences or Environment variables.");
+            }
+            else
+            {
+                if (!Directory.Exists(androidHome) || !IsSdkManagerAvailable())
+                {
+                    errors.Add("ANDROID_HOME is not a valid SDK path. Can't find sdkmanager.");
+                }
+            }
+
+            if (string.IsNullOrEmpty(preferences.AndroidKeystoreFile))
+            {
+                errors.Add("Keystore File path was not set in Preferences.");
+            }
+            else
+            {
+                if (!File.Exists(preferences.AndroidKeystoreFile))
+                {
+                    errors.Add("Keystore File path is invalid.");
+                }
+            }
+
+            return errors;
+        }
+    }
+}

--- a/Editor/AGS.Editor/Utils/AndroidUtilities.cs
+++ b/Editor/AGS.Editor/Utils/AndroidUtilities.cs
@@ -175,19 +175,21 @@ namespace AGS.Editor.Utils
             return cmd;
         }
 
-        private static bool RunGradlewTaskByName(string task_str, string working_dir, bool show_window = true)
+        private static bool RunGradlewTaskByName(string task_str, string working_dir, bool use_daemon = false, bool show_window = true)
         {
             string cmd = GetPrefixEnv();
-            cmd += "gradlew.bat " + task_str + " & ";
+            cmd += "gradlew.bat ";
+            if (!use_daemon) cmd += "--no-daemon ";
+            cmd += task_str + " & ";
             cmd += "if ERRORLEVEL 1 pause";
 
             return RunInCmdEXE(cmd, working_dir, show_window);
         }
 
-        public static bool RunGradlewTask(GradleTasks task, string working_dir, bool show_window = true)
+        public static bool RunGradlewTask(GradleTasks task, string working_dir, bool use_daemon = false, bool show_window = true)
         {
             string task_str = task.ToString();
-            return RunGradlewTaskByName(task_str, working_dir, show_window);
+            return RunGradlewTaskByName(task_str, working_dir, use_daemon:use_daemon, show_window:show_window);
         }
 
         public static bool RunGradlewStop(string working_dir)

--- a/Editor/AGS.Editor/Utils/ArgumentBuilder.cs
+++ b/Editor/AGS.Editor/Utils/ArgumentBuilder.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AGS.Editor.Utils
+{
+
+    public class ArgumentsBuilder
+    {
+        private bool _spacesBetweenFlagParam = false;
+        private StringBuilder Cmd { get; } = new StringBuilder();
+
+        private readonly Regex NeedQuotes = new Regex(@"^[a-z\\/:0-9\._\-+=]*$", RegexOptions.None);
+
+        private readonly Regex AllowedUnquoted = new Regex(@"[|><\s,;""]+", RegexOptions.IgnoreCase);
+
+        private void AppendAndFixQuotes(string unquotedText, bool quoteAlways = false)
+        {
+            if (string.IsNullOrEmpty(unquotedText))
+                return;
+
+            bool addQuotes = quoteAlways || NeedQuotes.IsMatch(unquotedText) || !AllowedUnquoted.IsMatch(unquotedText);
+
+            if (addQuotes)
+                Cmd.Append('"');
+
+            int literalQuotes = 0;
+            for (int i = 0; i < unquotedText.Length; i++)
+            {
+                if (unquotedText[i] == '"')
+                {
+                    literalQuotes++;
+                }
+            }
+            if (literalQuotes > 0)
+            {
+                unquotedText = unquotedText.Replace("\\\"", "\\\\\"");
+                unquotedText = unquotedText.Replace("\"", "\\\"");
+            }
+
+            Cmd.Append(unquotedText);
+
+            if (addQuotes && unquotedText.EndsWith("\\", StringComparison.Ordinal))
+            {
+                Cmd.Append('\\');
+            }
+
+            if (addQuotes)
+                Cmd.Append('"');
+        }
+
+        public ArgumentsBuilder(bool spacesBetweenFlagParam = false)
+        {
+            _spacesBetweenFlagParam = spacesBetweenFlagParam;
+        }
+
+        public void AppendFlag(string flagName)
+        {
+            if (string.IsNullOrEmpty(flagName))
+                return;
+
+            if (Cmd.Length != 0 && Cmd[Cmd.Length - 1] != ' ')
+            {
+                Cmd.Append(' ');
+            }
+
+            Cmd.Append(flagName);
+        }
+
+        public void AppendFlagAndParameter(string flagName, string parameter, bool quoteAlways = false)
+        {
+            if (string.IsNullOrEmpty(flagName) || string.IsNullOrEmpty(parameter))
+                return;
+
+            AppendFlag(flagName);
+            if (_spacesBetweenFlagParam) Cmd.Append(' ');
+            AppendAndFixQuotes(parameter, quoteAlways);
+        }
+
+        public override string ToString() => Cmd.ToString();
+    }
+}

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -116,6 +116,7 @@
     <Compile Include="EditorFeatures\MenuCommands.cs" />
     <Compile Include="EditorFeatures\MessageBoxIconType.cs" />
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
+    <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />
     <Compile Include="Enums\CustomPropertyAppliesTo.cs" />

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Enums\RoomResolution.cs" />
     <Compile Include="Enums\RoomTransitionStyle.cs" />
     <Compile Include="Enums\RoomVolumeAdjustment.cs" />
+    <Compile Include="Enums\ScreenRotationMode.cs" />
     <Compile Include="Enums\SkipSpeechStyle.cs" />
     <Compile Include="Enums\SourceControlFileStatus.cs" />
     <Compile Include="Enums\SpeechPortraitSide.cs" />

--- a/Editor/AGS.Types/Enums/AndroidBuildFormat.cs
+++ b/Editor/AGS.Types/Enums/AndroidBuildFormat.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace AGS.Types
+{
+    public enum AndroidBuildFormat
+    {
+        [Description("Apk (Embedded Game)")]
+        ApkEmbedded = 0,
+        [Description("AAB (Embedded Game)")]
+        AabEmbedded = 1,
+        [Description("AAB (Game as Asset)")]
+        Aab = 2
+    }
+}

--- a/Editor/AGS.Types/Enums/ScreenRotationMode.cs
+++ b/Editor/AGS.Types/Enums/ScreenRotationMode.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public enum ScreenRotationMode
+    {
+        [Description("Player can freely rotate the screen if possible")]
+        Unlocked = 0,
+        [Description("Lock in Portrait")]
+        Portrait = 1,
+        [Description("Lock in Landscape")]
+        Landscape = 2
+    }
+}

--- a/Editor/AGS.Types/RuntimeSetup.cs
+++ b/Editor/AGS.Types/RuntimeSetup.cs
@@ -57,6 +57,7 @@ namespace AGS.Types
             VSync = false;
             AAScaledSprites = false;
             RenderAtScreenResolution = false;
+            Rotation = ScreenRotationMode.Unlocked;
             DigitalSound = RuntimeAudioDriver.Default;
             MidiSound = RuntimeAudioDriver.Default;
             UseVoicePack = true;
@@ -200,6 +201,16 @@ namespace AGS.Types
         [DefaultValue(false)]
         [Category("Graphics")]
         public bool RenderAtScreenResolution
+        {
+            get;
+            set;
+        }
+
+        [DisplayName("Rotation mode")]
+        [Description("Sets if the player can freely rotate the screen or if it should be locked to a specific orientation.")]
+        [DefaultValue(ScreenRotationMode.Unlocked)]
+        [Category("Graphics")]
+        public ScreenRotationMode Rotation
         {
             get;
             set;

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -127,6 +127,7 @@ namespace AGS.Types
         private string _androidPackageName = "com.mystudio.mygame";
         private int _androidAppVersionCode = 1;
         private string _androidAppVersionName = DEFAULT_VERSION;
+        private AndroidBuildFormat _androidBuildFormat = AndroidBuildFormat.ApkEmbedded;
 
         /// <summary>
         /// Helper function to validate the BuildTargets string. Excludes data file target
@@ -1260,7 +1261,19 @@ namespace AGS.Types
         public string AndroidPackageName
         {
             get { return _androidPackageName; }
-            set { _androidPackageName = value; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException("Package name cannot be empty");
+                }
+                if ((value.Length > 0) && (!Regex.IsMatch(value, @"^([a-zA-Z0-9\.\ ]+)$")))
+                {
+                    throw new ArgumentException("Package name can only contain letters, number and dots.");
+                }
+                value = value.Replace(" ", "");
+                _androidPackageName = value.ToLower().Trim(); 
+            }
         }
 
         [DisplayName(PROPERTY_ANDROID_APP_VERSION_CODE)]
@@ -1282,6 +1295,16 @@ namespace AGS.Types
             get { return _androidAppVersionName; }
             set { _androidAppVersionName = value; }
         }
+
+        [DisplayName("Build Format")]
+        [Description("Use embedded formats when testing locally. Google Play only accepts AAB.")]
+        [DefaultValue("Aab")]
+        [Category("Android")]
+        public AndroidBuildFormat AndroidBuildFormat
+        {
+            get { return _androidBuildFormat; }
+            set { _androidBuildFormat = value; }
+        }        
 
 
         [Obsolete]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -28,6 +28,9 @@ namespace AGS.Types
         public const string PROPERTY_DIALOG_SCRIPT_SAYFN = "Custom Say function in dialog scripts";
         public const string PROPERTY_DIALOG_SCRIPT_NARRATEFN = "Custom Narrate function in dialog scripts";
         public const string REGEX_FOUR_PART_VERSION = @"^(\d+)\.(\d+)\.(\d+)\.(\d+)$";
+        public const string PROPERTY_ANDROID_PACKAGE_NAME = "Android Package Name";
+        public const string PROPERTY_ANDROID_APP_VERSION_CODE = "App Version Code";
+        public const string PROPERTY_ANDROID_APP_VERSION_NAME = "App Version Name";
 
 		private const string DEFAULT_GENRE = "Adventure";
         private const string DEFAULT_VERSION = "1.0.0.0";
@@ -121,6 +124,9 @@ namespace AGS.Types
         private string _saveGamesFolderName = string.Empty;
         private int _audioIndexer = AudioClip.FixedIndexBase;
         private string _buildTargets = GetBuildTargetsString(BuildTargetsInfo.GetAvailableBuildTargetNames(), false);
+        private string _androidPackageName = "com.mystudio.mygame";
+        private int _androidAppVersionCode = 1;
+        private string _androidAppVersionName = DEFAULT_VERSION;
 
         /// <summary>
         /// Helper function to validate the BuildTargets string. Excludes data file target
@@ -1246,6 +1252,37 @@ namespace AGS.Types
             get { return _renderAtScreenRes; }
             set { _renderAtScreenRes = value; }
         }
+
+        [DisplayName(PROPERTY_ANDROID_PACKAGE_NAME)]
+        [Description("The application ID, used in app store. Also called package name, it's usually looks like com.mystudio.mygame, and it's used in store URLs.")]
+        [DefaultValue("com.mystudio.mygame")]
+        [Category("Android")]
+        public string AndroidPackageName
+        {
+            get { return _androidPackageName; }
+            set { _androidPackageName = value; }
+        }
+
+        [DisplayName(PROPERTY_ANDROID_APP_VERSION_CODE)]
+        [Description("The version ID used by Google Play Store and others - positive integer, must be different from the last one uploaded.")]
+        [DefaultValue("1")]
+        [Category("Android")]
+        public int AndroidAppVersionCode
+        {
+            get { return _androidAppVersionCode; }
+            set { _androidAppVersionCode = value; }
+        }
+
+        [DisplayName(PROPERTY_ANDROID_APP_VERSION_NAME)]
+        [Description("The version name visible to users in the stores, this can be anything. Leave empty to use the same version you set in desktop platforms.")]
+        [DefaultValue("")]
+        [Category("Android")]
+        public string AndroidAppVersionName
+        {
+            get { return _androidAppVersionName; }
+            set { _androidAppVersionName = value; }
+        }
+
 
         [Obsolete]
         [Browsable(false)]

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -28,7 +28,7 @@ namespace AGS.Types
         public const string PROPERTY_DIALOG_SCRIPT_SAYFN = "Custom Say function in dialog scripts";
         public const string PROPERTY_DIALOG_SCRIPT_NARRATEFN = "Custom Narrate function in dialog scripts";
         public const string REGEX_FOUR_PART_VERSION = @"^(\d+)\.(\d+)\.(\d+)\.(\d+)$";
-        public const string PROPERTY_ANDROID_PACKAGE_NAME = "Android Package Name";
+        public const string PROPERTY_ANDROID_APPLICATION_ID = "App ID";
         public const string PROPERTY_ANDROID_APP_VERSION_CODE = "App Version Code";
         public const string PROPERTY_ANDROID_APP_VERSION_NAME = "App Version Name";
 
@@ -124,7 +124,7 @@ namespace AGS.Types
         private string _saveGamesFolderName = string.Empty;
         private int _audioIndexer = AudioClip.FixedIndexBase;
         private string _buildTargets = GetBuildTargetsString(BuildTargetsInfo.GetAvailableBuildTargetNames(), false);
-        private string _androidPackageName = "com.mystudio.mygame";
+        private string _androidApplicationId = "com.mystudio.mygame";
         private int _androidAppVersionCode = 1;
         private string _androidAppVersionName = DEFAULT_VERSION;
         private AndroidBuildFormat _androidBuildFormat = AndroidBuildFormat.ApkEmbedded;
@@ -1254,25 +1254,25 @@ namespace AGS.Types
             set { _renderAtScreenRes = value; }
         }
 
-        [DisplayName(PROPERTY_ANDROID_PACKAGE_NAME)]
-        [Description("The application ID, used in app store. Also called package name, it's usually looks like com.mystudio.mygame, and it's used in store URLs.")]
+        [DisplayName(PROPERTY_ANDROID_APPLICATION_ID)]
+        [Description("The application ID, used in app store. Also called package name, it's usually looks like com.mystudio.mygame, and it's used in store URLs. It must have at least two segments (one or more dots), and each segment must start with a letter.")]
         [DefaultValue("com.mystudio.mygame")]
         [Category("Android")]
-        public string AndroidPackageName
+        public string AndroidApplicationId
         {
-            get { return _androidPackageName; }
+            get { return _androidApplicationId; }
             set
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    throw new ArgumentException("Package name cannot be empty");
+                    throw new ArgumentException("Application ID cannot be empty");
                 }
                 if ((value.Length > 0) && (!Regex.IsMatch(value, @"^([a-zA-Z0-9\.\ ]+)$")))
                 {
-                    throw new ArgumentException("Package name can only contain letters, number and dots.");
+                    throw new ArgumentException("Application ID can only contain letters, number and dots.");
                 }
-                value = value.Replace(" ", "");
-                _androidPackageName = value.ToLower().Trim(); 
+                value = value.Replace(" ", "").ToLower().Trim();
+                _androidApplicationId = value; 
             }
         }
 

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -31,6 +31,7 @@ GameSetup::GameSetup()
     RenderAtScreenRes = false;
     Supersampling = 1;
     clear_cache_on_room_change = false;
+    rotation = kScreenRotation_Unlocked;
 
     Screen.Params.RefreshRate = 0;
     Screen.Params.VSync = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -36,6 +36,15 @@ enum MouseSpeedDef
     kNumMouseSpeedDefs
 };
 
+// Screen rotation mode on supported platforms and devices
+enum ScreenRotation
+{
+    kScreenRotation_Unlocked = 0,     // player can freely rotate the screen if possible
+    kScreenRotation_Portrait,         // screen can only be in portrait orientation
+    kScreenRotation_Landscape,        // screen can only be in landscape orientation
+    kNumScreenRotationOptions
+};
+
 using AGS::Common::String;
 
 // TODO: reconsider the purpose of this struct.
@@ -77,6 +86,7 @@ struct GameSetup {
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
     bool  clear_cache_on_room_change; // compatibility
+    ScreenRotation rotation;
 
     DisplayModeSetup Screen;
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -347,6 +347,7 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
 }
 
 // Variables used for mobile port configs
+extern int psp_rotation;
 extern int psp_gfx_renderer;
 extern int psp_gfx_scaling;
 extern int psp_gfx_super_sampling;
@@ -407,6 +408,12 @@ void override_config_ext(ConfigTree &cfg)
     else
         INIwriteint(cfg, "graphics", "supersampling", 0);
 
+    // psp_gfx_rotation - scaling style:
+    //    * 0 - unlocked, let the user rotate as wished.
+    //    * 1 - portrait
+    //    * 2 - landscape
+    INIwriteint(cfg, "graphics", "rotation", psp_rotation);
+
 #if AGS_PLATFORM_OS_ANDROID
     // config_mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls
@@ -451,6 +458,12 @@ void apply_config(const ConfigTree &cfg)
         usetup.Screen.Params.VSync = INIreadint(cfg, "graphics", "vsync") > 0;
         usetup.RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres") > 0;
         usetup.Supersampling = INIreadint(cfg, "graphics", "supersampling", 1);
+
+        usetup.rotation = (ScreenRotation)INIreadint(cfg, "graphics", "rotation", usetup.rotation);
+        String rotation_str = INIreadstring(cfg, "graphics", "rotation", "unlocked");
+        usetup.rotation = StrUtil::ParseEnum<ScreenRotation>(
+                rotation_str, CstrArr<kNumScreenRotationOptions>{ "unlocked", "portrait", "landscape" },
+                usetup.rotation);
 
         usetup.enable_antialiasing = INIreadint(cfg, "misc", "antialias") > 0;
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1291,6 +1291,8 @@ int initialize_engine(const ConfigTree &startup_opts)
 
     engine_init_resolution_settings(game.GetGameRes());
 
+    engine_adjust_for_rotation_settings();
+
     // Attempt to initialize graphics mode
     if (!engine_try_set_gfxmode_any(usetup.Screen))
         return EXIT_ERROR;

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -143,6 +143,22 @@ void engine_init_resolution_settings(const Size game_size)
     engine_setup_system_gamesize();
 }
 
+void engine_adjust_for_rotation_settings()
+{
+    switch (usetup.rotation) {
+        case ScreenRotation::kScreenRotation_Portrait:
+            SDL_SetHint(SDL_HINT_ORIENTATIONS, "Portrait PortraitUpsideDown");
+            break;
+        case ScreenRotation::kScreenRotation_Landscape:
+            SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
+            break;
+        case kScreenRotation_Unlocked:
+            // let the user rotate as wished. No adjustment needed.
+        default:
+            break;
+    }
+}
+
 // Setup gfx driver callbacks and options
 void engine_post_gfxmode_driver_setup()
 {

--- a/Engine/main/engine_setup.h
+++ b/Engine/main/engine_setup.h
@@ -28,5 +28,7 @@ void engine_pre_gfxmode_release();
 void engine_pre_gfxsystem_shutdown();
 // Applies necessary changes after screen<->virtual coordinate transformation has changed
 void on_coordinates_scaling_changed();
+// prepares game screen for rotation setting
+void engine_adjust_for_rotation_settings();
 
 #endif // __AGS_EE_MAIN__ENGINESETUP_H

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -84,6 +84,7 @@ const char *loadSaveGameOnStartup = nullptr;
 int psp_video_framedrop = 1;
 int psp_ignore_acsetup_cfg_file = 0;
 int psp_clear_cache_on_room_change = 0; // clear --sprite cache-- when room is unloaded
+int psp_rotation = 0;
 
 char psp_game_file_name[] = "";
 char psp_translation[] = "default";
@@ -207,6 +208,8 @@ void main_print_help() {
            "  --nospr                      Don't draw room objects and characters\n"
            "  --noupdate                   Don't run game update\n"
            "  --novideo                    Don't play game videos\n"
+           "  --rotation <MODE>            Screen rotation preferences. MODEs are:\n"
+           "                                 unlocked (0), portrait (1), landscape (2)\n"
            "  --sdl-log=LEVEL              Setup SDL backend logging level\n"
            "                               LEVELs are:\n"
            "                                 verbose (1), debug (2), info (3), warn (4),\n"
@@ -369,6 +372,10 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "--nomusic") == 0) debug_flags |= DBG_NOMUSIC;
         else if (ags_stricmp(arg, "--noscript") == 0) debug_flags |= DBG_NOSCRIPT;
         else if (ags_stricmp(arg, "--novideo") == 0) debug_flags |= DBG_NOVIDEO;
+        else if (ags_stricmp(arg, "--rotation") == 0 && (argc > ee + 1))
+        {
+            INIwritestring(cfg, "graphics", "rotation", argv[++ee]);
+        }
         else if (ags_strnicmp(arg, "--log-", 6) == 0 && arg[6] != 0)
         {
             String logarg = arg + 6;

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -611,17 +611,6 @@ void AGSAndroid::MainInit()
     // Read game specific configuration.
     ReadConfiguration((char*) ANDROID_CONFIG_FILENAME, false);
 
-    // Set the screen rotation.
-    if (psp_rotation == 0) {
-      // Auto, let the user rotate as wished.
-    } else if(psp_rotation == 1) {
-      // Portrait
-      SDL_SetHint(SDL_HINT_ORIENTATIONS, "Portrait PortraitUpsideDown");
-    }  else if(psp_rotation == 2) {
-      // Landscape
-        SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
-    }
-
     if (config_mouse_longclick > 0) {
         jmethodID method_id = env->GetMethodID(clazz, "AgsEnableLongclick", "()V");
         env->CallVoidMethod(activity, method_id);

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -446,6 +446,12 @@ void selectLatestSavegame()
   }
 }
 
+JNIEXPORT void JNICALL
+Java_uk_co_adventuregamestudio_runtime_AGSRuntimeActivity_nativeSdlShowKeyboard(JNIEnv* env, jobject object, jobjectArray translations)
+{
+  SDL_StartTextInput();
+}
+
 } // END of Extern "C"
 
 

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -48,6 +48,10 @@ Locations of two latter files differ between running platforms:
   * render_at_screenres = \[0; 1\] - whether the sprites are transformed and rendered in native game's or current display resolution;
   * supersampling = \[integer\] - supersampling multiplier, default is 1, used with render_at_screenres = 0 (currently supported only by OpenGL renderer);
   * vsync = \[0; 1\] - enable or disable vertical sync.
+  * rotation = \[string | integer\] - screen rotation. Possible values are:
+    * unlocked (0) - device can be freely rotated if possible.
+    * portrait (1) - locks the screen in portrait orientation.
+    * landscape (2) - locks the screen in landscape orientation.
 * **\[sound\]** - sound options
   * digiid = \[string; 0; -1\] - digital driver id, '0' or 'none', '-1' or 'auto'. Driver IDs are platform-dependent.
     * For Linux:
@@ -150,6 +154,7 @@ Following OPTIONS are supported when running from command line:
 * --nospr - don't draw room objects and characters (for test purposes).
 * --noupdate - don't run game update (for test purposes).
 * --novideo - don't play game videos (for test purposes).
+* --rotation \<MODE\> - screen rotation preferences. MODEs are:  unlocked (0), portrait (1), landscape (2).
 * --sdl-log=LEVEL - setup SDL's own logging level (see explanation for the related config option).
 * --setup - run integrated setup dialog. Currently only supported by Windows version.
 * --shared-data-dir \<DIR\> - set the shared game data directory. Corresponds to "shared_data_dir" config option.

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -53,6 +53,7 @@ ComponentEngines=Engines
 ComponentEngineDefault=Runtime engine for MS Windows
 ComponentLinuxBuild=Linux build component
 ComponentWebBuild=Web build component
+ComponentAndroidBuild=Android build component
 ; ComponentDemoGame=Demo Game
 InstallOptions=Install options
 InstallVCRedist=Install {#VcRedistName}
@@ -66,6 +67,7 @@ Name: "engine"; Description: "{cm:ComponentEngines}"; Types: full compact custom
 Name: "engine\default"; Description: "{cm:ComponentEngineDefault}"; Types: full compact; Flags: exclusive
 Name: "linux"; Description: "{cm:ComponentLinuxBuild}"; Types: full custom
 Name: "web"; Description: "{cm:ComponentWebBuild}"; Types: full custom
+Name: "android"; Description: "{cm:ComponentAndroidBuild}"; Types: full custom
 ; Name: "demogame"; Description: "{cm:ComponentDemoGame}"; Types: full custom
 
 
@@ -117,6 +119,10 @@ Source: "Source\Linux\licenses\*"; DestDir: "{app}\Linux\licenses"; Flags: ignor
 Source: "Source\Web\ags.wasm"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
 Source: "Source\Web\ags.js"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
 Source: "Source\Web\index.html"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
+; Android build components
+Source: "Source\Android\mygame\*"; DestDir: "{app}\Android\mygame"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: android
+Source: "Source\Android\gradle\*"; DestDir: "{app}\Android\gradle"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: android
+Source: "Source\Android\library\*"; DestDir: "{app}\Android\library"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: android
 ; Demo game
 ; Source: "Source\Demo Game\*"; DestDir: "{code:GetDemoGameDir}"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: demogame
 ; Visual C++ runtime


### PR DESCRIPTION
This PR should be working now. Additional information in the [forum thread](https://www.adventuregamestudio.co.uk/forums/index.php?topic=59772.0).

https://user-images.githubusercontent.com/2244442/150422308-c7d3c43f-6dcd-45c0-ac7c-7a068ccf7b6e.mp4

## Test instructions

1. Load the AGS Editor built from this codebase and on general settings you should see an Android build option
  a. If you see no Android build option, then you are missing the android bundle. 
  b. If you are building from source you need to download the android bundle, it's named as `AGS-3.6.0.16-android-proj-release.zip` and you can get it from the CI artifacts. It's just the single game project, with the libraries put under libs, and it should be placed in a directory named `Android/` in your Editor root folder.
2. Install Android Studio, preferably the last one, and set the following environment variable in your Windows
  a.  `ANDROID_HOME`, set it to where you installed the Android SDK (usually `C:\Users\USERNAME\AppData\Local\Android\Sdk`)
  b. `JAVA_HOME`, set it to the jre in the Android Studio installation (usually in `C:\Program Files\Android\Android Studio\jre`)
3. Reboot, or log out, just make sure that these are properly applied
4. Now load the AGS Editor again and hit build EXE

---

Leaving in draft since this has a lot of things missing, but just get things started here. Here are some things to do:

- [x] figure how to put keystore info in preferences or **people are going to push their key passwords to git** (maybe someone will solve #1477 ?)
- [x] Allow setting where the keystore is through the Editor (in preferences), this is now set in `Compiled\Android\mygame\local.static.properties` 
- [x] Actually apply the package name, this can be done through gradle nowadays (no renaming)
- [x] move the .aab or .apk file after it's built to root of Android dir.
- [x] Set whether to package game inside apk or in asset dir with .aab
- [x] figure a way to pass file filters through Property decorators..
- [x] CI to prepare the package I made above
- [x] Allow configuring ANDROID_HOME and JAVA_HOME through Editor preferences.
- [x] Check with `sdkmanager` that dependencies (android platform sdk and ndk for the versions used) are in place, and if not, ask to install them (not sure if needed, maybe gradle can request them)
- [x] Override back button for keyboard toggle and extra keys (fix #1472)
- [x] Write `android.cfg` file
- [x] Properly write the app name used in Android launcher
- [x] Add Keystore Generation
- [x] APP icons are picked up from `icons/android/` dir at the AGS Project root, which has to contain android mipmap icon dirs with `ic_launcher.png` files.
- [x] automatically close the gradlew log window (but keep it if there's an error)
- [x] do not use gradle daemon by default, but allow turning it on through preference to speed up building

![image](https://user-images.githubusercontent.com/2244442/150614479-bddeda14-28f5-4a0a-b690-a262682938d1.png)

---

## FAQ

**Q:** Can I not install Android Studio?
**A:** I am using the exactly same tools from Android Studio - it requires installing Android Studio. You could theoretically install only Android SDK, Bundle Tool, Java JRE and JDK but then you need to piece everything together and it will take roughly the same storage space, so it's not worth it.

---

Fix #1337 