### PR TITLE
Editor: allow using property grid to set Preferences

### DIFF
--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -81,14 +81,7 @@ namespace AGS.Editor.Preferences
     {
         protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
         {
-            Dictionary<string, string> colorThemeList = new Dictionary<string, string>();
-
-            foreach (ColorTheme colorTheme in Factory.GUIController.ColorThemes.Themes)
-            {
-                colorThemeList.Add(colorTheme.Name, colorTheme.Name);
-            }
-
-            return colorThemeList;
+            return Factory.GUIController.ColorThemes.Themes.ToDictionary(t => t.Name, t => t.Name);
         }
     }
 
@@ -298,19 +291,17 @@ namespace AGS.Editor.Preferences
             return success;
         }
 
-        private List<PropertyInfo> GetBrowsableProperties()
+        private IEnumerable<PropertyInfo> GetBrowsableProperties()
         {
             return GetType().GetProperties()
-               .Where(f => f.GetCustomAttributes<BrowsableAttribute>().Contains(BrowsableAttribute.Yes))
-               .ToList();
+               .Where(f => f.GetCustomAttributes<BrowsableAttribute>().Contains(BrowsableAttribute.Yes));
         }
 
         public AppSettings CloneAppSettings()
         {
             AppSettings clone = new AppSettings();
-            List<PropertyInfo> props = GetBrowsableProperties();
 
-            foreach (PropertyInfo prop in props)
+            foreach (PropertyInfo prop in GetBrowsableProperties())
             {
                 clone[prop.Name] = this[prop.Name];
             }
@@ -320,9 +311,7 @@ namespace AGS.Editor.Preferences
 
         public void Apply(AppSettings settings)
         {
-            List<PropertyInfo> props = GetBrowsableProperties();
-
-            foreach (PropertyInfo prop in props)
+            foreach (PropertyInfo prop in GetBrowsableProperties())
             {
                 this[prop.Name] = settings[prop.Name];
             }

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -79,12 +79,28 @@ namespace AGS.Editor.Preferences
         const int MAX_RECENT_GAMES = 10;
         const int MAX_RECENT_SEARCHES = 10;
 
+        SettingsLoadedEventHandler eventHandlerLoaded = null;
+        ListChangedEventHandler eventHandlerRecentSearches = null;
+        ListChangedEventHandler eventHandlerRecentGames = null;
+
         public AppSettings()
         {
-            SettingsLoaded += new SettingsLoadedEventHandler(Settings_SettingsLoaded);
-            RecentSearches.ListChanged += new ListChangedEventHandler(Settings_LimitRecentSearches);
-            RecentGames.ListChanged += new ListChangedEventHandler(Settings_LimitRecentGames);
+            eventHandlerLoaded = new SettingsLoadedEventHandler(Settings_SettingsLoaded);
+            eventHandlerRecentSearches = new ListChangedEventHandler(Settings_LimitRecentSearches);
+            eventHandlerRecentGames = new ListChangedEventHandler(Settings_LimitRecentGames);
+
+            SettingsLoaded += eventHandlerLoaded;
+            RecentSearches.ListChanged += eventHandlerRecentSearches;
+            RecentGames.ListChanged += eventHandlerRecentGames;
         }
+
+        ~AppSettings()
+        {
+            SettingsLoaded -= eventHandlerLoaded;
+            RecentSearches.ListChanged -= eventHandlerRecentSearches;
+            RecentGames.ListChanged -= eventHandlerRecentGames;
+        }
+
 
         private void Settings_LimitRecentSearches(object sender, ListChangedEventArgs e)
         {
@@ -242,6 +258,75 @@ namespace AGS.Editor.Preferences
             return success;
         }
 
+        public AppSettings CloneAppSettings()
+        {
+            AppSettings clone = new AppSettings();
+            clone.BackupWarningInterval = BackupWarningInterval;
+            clone.ColorTheme = ColorTheme;
+            clone.DefaultImportPath = DefaultImportPath;
+            clone.DialogOnMultipleTabsClose = DialogOnMultipleTabsClose;
+            clone.IndentUseTabs = IndentUseTabs;
+            clone.KeepHelpOnTop = KeepHelpOnTop;
+            clone.LastBackupWarning = LastBackupWarning;
+            clone.MainWinHeight = MainWinHeight;
+            clone.MainWinMaximize = MainWinMaximize;
+            clone.MainWinWidth = MainWinWidth;
+            clone.MainWinX = MainWinX;
+            clone.MainWinY = MainWinY;
+            clone.MessageBoxOnCompile = MessageBoxOnCompile;
+            clone.MigratedSettings = MigratedSettings;
+            clone.NewGamePath = NewGamePath;
+            clone.PaintProgramPath = PaintProgramPath;
+            clone.RecentGames = RecentGames;
+            clone.RecentSearches = RecentSearches;
+            clone.ReloadScriptOnExternalChange = ReloadScriptOnExternalChange;
+            clone.RemapPalettizedBackgrounds = RemapPalettizedBackgrounds;
+            clone.SendAnonymousStats = SendAnonymousStats;
+            clone.SettingsKey = SettingsKey;
+            clone.ShowViewPreviewByDefault = ShowViewPreviewByDefault;
+            clone.SpriteImportMethod = SpriteImportMethod;
+            clone.StartupPane = StartupPane;
+            clone.StatsLastSent = StatsLastSent;
+            clone.TabSize = TabSize;
+            clone.TestGameWindowStyle = TestGameWindowStyle;
+            clone.UpgradedSettings = UpgradedSettings;
+
+            return clone;
+        }
+
+        public void Apply(AppSettings settings)
+        {
+            BackupWarningInterval = settings.BackupWarningInterval;
+            ColorTheme = settings.ColorTheme;
+            DefaultImportPath = settings.DefaultImportPath;
+            DialogOnMultipleTabsClose = settings.DialogOnMultipleTabsClose;
+            IndentUseTabs = settings.IndentUseTabs;
+            KeepHelpOnTop = settings.KeepHelpOnTop;
+            LastBackupWarning = settings.LastBackupWarning;
+            MainWinHeight = settings.MainWinHeight;
+            MainWinMaximize = settings.MainWinMaximize;
+            MainWinWidth = settings.MainWinWidth;
+            MainWinX = settings.MainWinX;
+            MainWinY = settings.MainWinY;
+            MessageBoxOnCompile = settings.MessageBoxOnCompile;
+            MigratedSettings = settings.MigratedSettings;
+            NewGamePath = settings.NewGamePath;
+            PaintProgramPath = settings.PaintProgramPath;
+            RecentGames = settings.RecentGames;
+            RecentSearches = settings.RecentSearches;
+            ReloadScriptOnExternalChange = settings.ReloadScriptOnExternalChange;
+            RemapPalettizedBackgrounds = settings.RemapPalettizedBackgrounds;
+            SendAnonymousStats = settings.SendAnonymousStats;
+            ShowViewPreviewByDefault = settings.ShowViewPreviewByDefault;
+            SpriteImportMethod = settings.SpriteImportMethod;
+            StartupPane = settings.StartupPane;
+            StatsLastSent = settings.StatsLastSent;
+            TabSize = settings.TabSize;
+            TestGameWindowStyle = settings.TestGameWindowStyle;
+            UpgradedSettings = settings.UpgradedSettings;
+        }
+
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]
         public bool MigratedSettings
@@ -256,6 +341,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]
         public bool UpgradedSettings
@@ -270,6 +356,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Test Game Style")]
+        [Description("Game should run in window or full-screen when you test it. When using F5 game will always run in a window.")]
+        [Category("Test Game")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("UseGameSetup")]
         public TestGameWindowStyle TestGameWindowStyle
@@ -284,6 +373,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Editor Startup Action")]
+        [Description("What editor should do at startup.")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("StartPage")]
         public StartupPane StartupPane
@@ -298,6 +390,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Pop-up messages on Compile")]
+        [Description("In which cases the editor should show pop-up windows when compiling.")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("WarningsAndErrors")]
         public MessageBoxOnCompile MessageBoxOnCompile
@@ -312,6 +407,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Reload Script file modified externally")]
+        [Description("If a script is open for editing and is modified by another program, should it reload?")]
+        [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("Prompt")]
         public ReloadScriptOnExternalChange ReloadScriptOnExternalChange
@@ -326,6 +424,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Default sprite import transparency")]
+        [Description("Sprite transparency import method to use by default.")]
+        [Category("Sprite Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("LeaveAsIs")]
         public SpriteImportMethod SpriteImportMethod
@@ -340,6 +441,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Tab width")]
+        [Description("How many space characters a tab width should be. This setting requires editor restart to be applied.")]
+        [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("2")]
         public int TabSize
@@ -354,6 +458,10 @@ namespace AGS.Editor.Preferences
             }
         }
 
+
+        [DisplayName("Indent Uses Tabs")]
+        [Description("Should editor use tabs instead of spaces when indenting?")]
+        [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]
         public bool IndentUseTabs
@@ -368,6 +476,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Show view preview by default in view editors")]
+        [Description("Wheter view preview is always showing when a view editor is loaded.")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("False")]
         public bool ShowViewPreviewByDefault
@@ -382,6 +493,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Default image editor")]
+        [Description("When you double-click a sprite, what program do you want to use to edit it? This program must support PNG and BMP files.")]
+        [Category("Sprite Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public string PaintProgramPath
@@ -396,6 +510,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("New Game Directory")]
+        [Description("When you create a new game, where do you want it to go?")]
+        [Category("New Game Directory")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public string NewGamePath
@@ -410,6 +527,10 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)] // this is disabled until we can fix the server
+        [DisplayName("Send Anonymous Stats")]
+        [Description("When you create a new game, where do you want it to go?")]
+        [Category("New Game Directory")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("True")]
         public bool SendAnonymousStats
@@ -424,6 +545,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("1601-01-01")]
         public System.DateTime StatsLastSent
@@ -438,6 +560,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("1601-01-01")]
         public System.DateTime LastBackupWarning
@@ -466,6 +589,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Remap palette of room backgrounds")]
+        [Description("Remap paletter of room background into allocated background palette slots (8-bit games only).")]
+        [Category("Import of 8-bit background")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("True")]
         public bool RemapPalettizedBackgrounds
@@ -480,6 +606,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public BindingList<RecentGame> RecentGames
@@ -494,6 +621,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public BindingList<string> RecentSearches
@@ -508,6 +636,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Keep Help window on top")]
+        [Description("Should Help window always be on top of the Editor window when shown?")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("True")]
         public bool KeepHelpOnTop
@@ -522,6 +653,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Ask before closing multiple tabs")]
+        [Description("Prompt dialog on closing multiple tabs.")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("True")]
         public bool DialogOnMultipleTabsClose
@@ -536,6 +670,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Color Theme")]
+        [Description("Select which theme the editor should be using.")]
+        [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public string ColorTheme
@@ -550,6 +687,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [DisplayName("Import Directory")]
+        [Description("When you import files, where do you want to look first?")]
+        [Category("Import Directory")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
         public string DefaultImportPath
@@ -564,6 +704,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("640")]
         public int MainWinWidth
@@ -578,6 +719,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("480")]
         public int MainWinHeight
@@ -592,6 +734,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("0")]
         public int MainWinX
@@ -606,7 +749,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
-
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("0")]
         public int MainWinY
@@ -621,6 +764,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(false)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("True")]
         public bool MainWinMaximize

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -7,6 +7,8 @@ using System.Windows.Forms.Design;
 using System.Drawing.Design;
 using Microsoft.Win32;
 using AGS.Types;
+using System.Reflection;
+using System.Linq;
 
 namespace AGS.Editor.Preferences
 {
@@ -296,72 +298,34 @@ namespace AGS.Editor.Preferences
             return success;
         }
 
+        private List<PropertyInfo> GetBrowsableProperties()
+        {
+            return GetType().GetProperties()
+               .Where(f => f.GetCustomAttributes<BrowsableAttribute>().Contains(BrowsableAttribute.Yes))
+               .ToList();
+        }
+
         public AppSettings CloneAppSettings()
         {
             AppSettings clone = new AppSettings();
-            clone.BackupWarningInterval = BackupWarningInterval;
-            clone.ColorTheme = ColorTheme;
-            clone.DefaultImportPath = DefaultImportPath;
-            clone.DialogOnMultipleTabsClose = DialogOnMultipleTabsClose;
-            clone.IndentUseTabs = IndentUseTabs;
-            clone.KeepHelpOnTop = KeepHelpOnTop;
-            clone.LastBackupWarning = LastBackupWarning;
-            clone.MainWinHeight = MainWinHeight;
-            clone.MainWinMaximize = MainWinMaximize;
-            clone.MainWinWidth = MainWinWidth;
-            clone.MainWinX = MainWinX;
-            clone.MainWinY = MainWinY;
-            clone.MessageBoxOnCompile = MessageBoxOnCompile;
-            clone.MigratedSettings = MigratedSettings;
-            clone.NewGamePath = NewGamePath;
-            clone.PaintProgramPath = PaintProgramPath;
-            clone.RecentGames = RecentGames;
-            clone.RecentSearches = RecentSearches;
-            clone.ReloadScriptOnExternalChange = ReloadScriptOnExternalChange;
-            clone.RemapPalettizedBackgrounds = RemapPalettizedBackgrounds;
-            clone.SendAnonymousStats = SendAnonymousStats;
-            clone.SettingsKey = SettingsKey;
-            clone.ShowViewPreviewByDefault = ShowViewPreviewByDefault;
-            clone.SpriteImportMethod = SpriteImportMethod;
-            clone.StartupPane = StartupPane;
-            clone.StatsLastSent = StatsLastSent;
-            clone.TabSize = TabSize;
-            clone.TestGameWindowStyle = TestGameWindowStyle;
-            clone.UpgradedSettings = UpgradedSettings;
+            List<PropertyInfo> props = GetBrowsableProperties();
+
+            foreach (PropertyInfo prop in props)
+            {
+                clone[prop.Name] = this[prop.Name];
+            }
 
             return clone;
         }
 
         public void Apply(AppSettings settings)
         {
-            BackupWarningInterval = settings.BackupWarningInterval;
-            ColorTheme = settings.ColorTheme;
-            DefaultImportPath = settings.DefaultImportPath;
-            DialogOnMultipleTabsClose = settings.DialogOnMultipleTabsClose;
-            IndentUseTabs = settings.IndentUseTabs;
-            KeepHelpOnTop = settings.KeepHelpOnTop;
-            LastBackupWarning = settings.LastBackupWarning;
-            MainWinHeight = settings.MainWinHeight;
-            MainWinMaximize = settings.MainWinMaximize;
-            MainWinWidth = settings.MainWinWidth;
-            MainWinX = settings.MainWinX;
-            MainWinY = settings.MainWinY;
-            MessageBoxOnCompile = settings.MessageBoxOnCompile;
-            MigratedSettings = settings.MigratedSettings;
-            NewGamePath = settings.NewGamePath;
-            PaintProgramPath = settings.PaintProgramPath;
-            RecentGames = settings.RecentGames;
-            RecentSearches = settings.RecentSearches;
-            ReloadScriptOnExternalChange = settings.ReloadScriptOnExternalChange;
-            RemapPalettizedBackgrounds = settings.RemapPalettizedBackgrounds;
-            SendAnonymousStats = settings.SendAnonymousStats;
-            ShowViewPreviewByDefault = settings.ShowViewPreviewByDefault;
-            SpriteImportMethod = settings.SpriteImportMethod;
-            StartupPane = settings.StartupPane;
-            StatsLastSent = settings.StatsLastSent;
-            TabSize = settings.TabSize;
-            TestGameWindowStyle = settings.TestGameWindowStyle;
-            UpgradedSettings = settings.UpgradedSettings;
+            List<PropertyInfo> props = GetBrowsableProperties();
+
+            foreach (PropertyInfo prop in props)
+            {
+                this[prop.Name] = settings[prop.Name];
+            }
         }
 
         [Browsable(false)]
@@ -394,6 +358,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Test Game Style")]
         [Description("Game should run in window or full-screen when you test it. When using F5 game will always run in a window.")]
         [Category("Test Game")]
@@ -412,6 +377,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Editor Startup Action")]
         [Description("What editor should do at startup.")]
         [Category("Editor Appearance")]
@@ -430,6 +396,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Pop-up messages on Compile")]
         [Description("In which cases the editor should show pop-up windows when compiling.")]
         [Category("Editor Appearance")]
@@ -448,6 +415,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Script file modified externally, should it reload?")]
         [Description("If a script is open for editing and is modified by another program, should it reload?")]
         [Category("Script Editor")]
@@ -466,6 +434,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Default sprite import transparency")]
         [Description("Sprite transparency import method to use by default.")]
         [Category("Sprite Editor")]
@@ -484,6 +453,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Tab width")]
         [Description("How many space characters a tab width should be. This setting requires editor restart to be applied.")]
         [Category("Script Editor")]
@@ -501,7 +471,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
-
+        [Browsable(true)]
         [DisplayName("Indent Uses Tabs")]
         [Description("Should editor use tabs instead of spaces when indenting?")]
         [Category("Script Editor")]
@@ -519,6 +489,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Show view preview by default in view editors")]
         [Description("Wheter view preview is always showing when a view editor is loaded.")]
         [Category("Editor Appearance")]
@@ -536,6 +507,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Default image editor")]
         [Description("When you double-click a sprite, what program do you want to use to edit it? This program must support PNG and BMP files.")]
         [Category("Sprite Editor")]
@@ -554,6 +526,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("New Game Directory")]
         [Description("When you create a new game, where do you want it to go?")]
         [Category("New Game Directory")]
@@ -620,6 +593,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("7")]
         public int BackupWarningInterval
@@ -634,6 +608,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Remap palette of room backgrounds")]
         [Description("Remap paletter of room background into allocated background palette slots (8-bit games only).")]
         [Category("Import of 8-bit background")]
@@ -681,6 +656,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Keep Help window on top")]
         [Description("Should Help window always be on top of the Editor window when shown?")]
         [Category("Editor Appearance")]
@@ -698,6 +674,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Ask before closing multiple tabs")]
         [Description("Prompt dialog on closing multiple tabs.")]
         [Category("Editor Appearance")]
@@ -715,6 +692,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Color Theme")]
         [Description("Select which theme the editor should be using.")]
         [Category("Editor Appearance")]
@@ -733,6 +711,7 @@ namespace AGS.Editor.Preferences
             }
         }
 
+        [Browsable(true)]
         [DisplayName("Import Directory")]
         [Description("When you import files, where do you want to look first?")]
         [Category("Import Directory")]

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -75,6 +75,21 @@ namespace AGS.Editor.Preferences
         Windowed = 2
     }
 
+    public class ColorThemeTypeConverter : BaseListSelectTypeConverter<string, string>
+    {
+        protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
+        {
+            Dictionary<string, string> colorThemeList = new Dictionary<string, string>();
+
+            foreach (ColorTheme colorTheme in Factory.GUIController.ColorThemes.Themes)
+            {
+                colorThemeList.Add(colorTheme.Name, colorTheme.Name);
+            }
+
+            return colorThemeList;
+        }
+    }
+
     public class RecentGame : IEquatable<RecentGame>
     {
         // default constructor is needed to serialize
@@ -705,6 +720,7 @@ namespace AGS.Editor.Preferences
         [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
+        [TypeConverter(typeof(ColorThemeTypeConverter))]
         public string ColorTheme
         {
             get

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
 using System.IO;
+using System.Windows.Forms.Design;
+using System.Drawing.Design;
 using Microsoft.Win32;
 
 namespace AGS.Editor.Preferences
@@ -498,6 +500,7 @@ namespace AGS.Editor.Preferences
         [Category("Sprite Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
+        [EditorAttribute(typeof(FileNameEditor), typeof(UITypeEditor))]
         public string PaintProgramPath
         {
             get
@@ -515,6 +518,7 @@ namespace AGS.Editor.Preferences
         [Category("New Game Directory")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
+        [EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
         public string NewGamePath
         {
             get
@@ -692,6 +696,7 @@ namespace AGS.Editor.Preferences
         [Category("Import Directory")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("")]
+        [EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
         public string DefaultImportPath
         {
             get

--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -6,51 +6,72 @@ using System.IO;
 using System.Windows.Forms.Design;
 using System.Drawing.Design;
 using Microsoft.Win32;
+using AGS.Types;
 
 namespace AGS.Editor.Preferences
 {
     [Flags]
     public enum StartupPane
     {
+        [Description("Show Start Page")]
         StartPage = 0,
+        [Description("Show Game Settings")]
         GeneralSettings = 1,
+        [Description("No panes should open")]
         None = 2
     }
 
     [Flags]
     public enum MessageBoxOnCompile
     {
+        [Description("Always")]
         Always = 0,
+        [Description("When there are warnings or errors")]
         WarningsAndErrors = 1,
+        [Description("When there are errors")]
         OnlyErrors = 2,
+        [Description("Never")]
         Never = 3
     }
 
     [Flags]
     public enum ReloadScriptOnExternalChange
     {
+        [Description("Ask what to do")]
         Prompt = 0,
+        [Description("Always reload the file")]
         Always = 1,
+        [Description("Never reload the file")]
         Never = 2
     }
 
     [Flags]
     public enum SpriteImportMethod
     {
+        [Description("Palette index 0")]
         Pixel0 = 0,
+        [Description("Top -left Pixel")]
         TopLeft = 1,
+        [Description("Bottom-left Pixel")]
         BottomLeft = 2,
+        [Description("Top-right Pixel")]
         TopRight = 3,
+        [Description("Bottom-right Pixel")]
         BottomRight = 4,
+        [Description("Leave as-is")]
         LeaveAsIs = 5,
+        [Description("No transparency")]
         NoTransparency = 6
     }
 
     [Flags]
     public enum TestGameWindowStyle
     {
+        [Description("Use game setup configuration")]
         UseGameSetup = 0,
+        [Description("Always run full-screen")]
         FullScreen = 1,
+        [Description("Always run in a window")]
         Windowed = 2
     }
 
@@ -363,6 +384,7 @@ namespace AGS.Editor.Preferences
         [Category("Test Game")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("UseGameSetup")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public TestGameWindowStyle TestGameWindowStyle
         {
             get
@@ -380,6 +402,7 @@ namespace AGS.Editor.Preferences
         [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("StartPage")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public StartupPane StartupPane
         {
             get
@@ -397,6 +420,7 @@ namespace AGS.Editor.Preferences
         [Category("Editor Appearance")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("WarningsAndErrors")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public MessageBoxOnCompile MessageBoxOnCompile
         {
             get
@@ -409,11 +433,12 @@ namespace AGS.Editor.Preferences
             }
         }
 
-        [DisplayName("Reload Script file modified externally")]
+        [DisplayName("Script file modified externally, should it reload?")]
         [Description("If a script is open for editing and is modified by another program, should it reload?")]
         [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("Prompt")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public ReloadScriptOnExternalChange ReloadScriptOnExternalChange
         {
             get
@@ -431,6 +456,7 @@ namespace AGS.Editor.Preferences
         [Category("Sprite Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("LeaveAsIs")]
+        [TypeConverter(typeof(EnumTypeConverter))]
         public SpriteImportMethod SpriteImportMethod
         {
             get

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.Designer.cs
@@ -30,11 +30,28 @@ namespace AGS.Editor
         {
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
+            this.tabPageLast = new System.Windows.Forms.TabPage();
+            this.propertyGridPreferences = new System.Windows.Forms.PropertyGrid();
+            this.tabPageFirst = new System.Windows.Forms.TabPage();
+            this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.chkRemapBgImport = new System.Windows.Forms.CheckBox();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.cmbSpriteImportTransparency = new System.Windows.Forms.ComboBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.btnSelectPaintProgram = new System.Windows.Forms.Button();
+            this.txtPaintProgram = new System.Windows.Forms.TextBox();
+            this.label11 = new System.Windows.Forms.Label();
+            this.radPaintProgram = new System.Windows.Forms.RadioButton();
+            this.radDefaultPaintProgram = new System.Windows.Forms.RadioButton();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.label4 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.cmbTestGameStyle = new System.Windows.Forms.ComboBox();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.udBackupInterval = new System.Windows.Forms.NumericUpDown();
+            this.label14 = new System.Windows.Forms.Label();
+            this.chkBackupReminders = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.lblReloadScriptOnExternalChange = new System.Windows.Forms.Label();
             this.cmbScriptReloadOnExternalChange = new System.Windows.Forms.ComboBox();
@@ -54,55 +71,50 @@ namespace AGS.Editor
             this.label9 = new System.Windows.Forms.Label();
             this.cmbEditorStartup = new System.Windows.Forms.ComboBox();
             this.label5 = new System.Windows.Forms.Label();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.lnkUsageInfo = new System.Windows.Forms.LinkLabel();
+            this.chkUsageInfo = new System.Windows.Forms.CheckBox();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.btnChooseFolder = new System.Windows.Forms.Button();
             this.txtImportPath = new System.Windows.Forms.TextBox();
             this.label6 = new System.Windows.Forms.Label();
             this.radFolderPath = new System.Windows.Forms.RadioButton();
             this.radGamePath = new System.Windows.Forms.RadioButton();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.cmbSpriteImportTransparency = new System.Windows.Forms.ComboBox();
-            this.label12 = new System.Windows.Forms.Label();
-            this.btnSelectPaintProgram = new System.Windows.Forms.Button();
-            this.txtPaintProgram = new System.Windows.Forms.TextBox();
-            this.label11 = new System.Windows.Forms.Label();
-            this.radPaintProgram = new System.Windows.Forms.RadioButton();
-            this.radDefaultPaintProgram = new System.Windows.Forms.RadioButton();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
             this.btnNewGameChooseFolder = new System.Windows.Forms.Button();
             this.txtNewGamePath = new System.Windows.Forms.TextBox();
             this.label13 = new System.Windows.Forms.Label();
             this.radNewGameSpecificPath = new System.Windows.Forms.RadioButton();
             this.radNewGameMyDocs = new System.Windows.Forms.RadioButton();
-            this.groupBox7 = new System.Windows.Forms.GroupBox();
-            this.lnkUsageInfo = new System.Windows.Forms.LinkLabel();
-            this.chkUsageInfo = new System.Windows.Forms.CheckBox();
-            this.groupBox8 = new System.Windows.Forms.GroupBox();
-            this.udBackupInterval = new System.Windows.Forms.NumericUpDown();
-            this.label14 = new System.Windows.Forms.Label();
-            this.chkBackupReminders = new System.Windows.Forms.CheckBox();
-            this.groupBox9 = new System.Windows.Forms.GroupBox();
-            this.chkRemapBgImport = new System.Windows.Forms.CheckBox();
+            this.tabPageLast.SuspendLayout();
+            this.tabPageFirst.SuspendLayout();
+            this.groupBox9.SuspendLayout();
+            this.groupBox5.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            this.groupBox8.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udBackupInterval)).BeginInit();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udTabWidth)).BeginInit();
             this.groupBox3.SuspendLayout();
-            this.groupBox4.SuspendLayout();
-            this.groupBox5.SuspendLayout();
-            this.groupBox6.SuspendLayout();
             this.groupBox7.SuspendLayout();
-            this.groupBox8.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.udBackupInterval)).BeginInit();
-            this.groupBox9.SuspendLayout();
+            this.tabControl1.SuspendLayout();
+            this.tabPage2.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.groupBox4.SuspendLayout();
+            this.groupBox6.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(12, 529);
+            this.btnOK.Location = new System.Drawing.Point(15, 610);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(98, 27);
+            this.btnOK.Size = new System.Drawing.Size(122, 34);
             this.btnOK.TabIndex = 0;
             this.btnOK.Text = "&OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -112,359 +124,73 @@ namespace AGS.Editor
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(116, 529);
+            this.btnCancel.Location = new System.Drawing.Point(145, 610);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(100, 27);
+            this.btnCancel.Size = new System.Drawing.Size(125, 34);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
-            // groupBox1
+            // tabPageLast
             // 
-            this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.cmbTestGameStyle);
-            this.groupBox1.Location = new System.Drawing.Point(7, 3);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(365, 113);
-            this.groupBox1.TabIndex = 2;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Test game style";
+            this.tabPageLast.Controls.Add(this.propertyGridPreferences);
+            this.tabPageLast.Location = new System.Drawing.Point(4, 26);
+            this.tabPageLast.Name = "tabPageLast";
+            this.tabPageLast.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageLast.Size = new System.Drawing.Size(920, 572);
+            this.tabPageLast.TabIndex = 2;
+            this.tabPageLast.Text = "Advanced";
+            this.tabPageLast.UseVisualStyleBackColor = true;
             // 
-            // label4
+            // propertyGridPreferences
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(12, 52);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(166, 13);
-            this.label4.TabIndex = 3;
-            this.label4.Text = "When running without debugger:";
+            this.propertyGridPreferences.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propertyGridPreferences.Location = new System.Drawing.Point(3, 3);
+            this.propertyGridPreferences.Name = "propertyGridPreferences";
+            this.propertyGridPreferences.Size = new System.Drawing.Size(914, 566);
+            this.propertyGridPreferences.TabIndex = 0;
             // 
-            // label3
+            // tabPageFirst
             // 
-            this.label3.AutoSize = true;
-            this.label3.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(11, 78);
-            this.label3.MaximumSize = new System.Drawing.Size(350, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(344, 26);
-            this.label3.TabIndex = 2;
-            this.label3.Text = "NOTE: When using the F5 (Run) option, the game will always run in a window.";
+            this.tabPageFirst.Controls.Add(this.groupBox9);
+            this.tabPageFirst.Controls.Add(this.groupBox5);
+            this.tabPageFirst.Controls.Add(this.groupBox1);
+            this.tabPageFirst.Controls.Add(this.groupBox8);
+            this.tabPageFirst.Controls.Add(this.groupBox2);
+            this.tabPageFirst.Controls.Add(this.groupBox3);
+            this.tabPageFirst.Controls.Add(this.groupBox7);
+            this.tabPageFirst.Location = new System.Drawing.Point(4, 26);
+            this.tabPageFirst.Name = "tabPageFirst";
+            this.tabPageFirst.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageFirst.Size = new System.Drawing.Size(920, 572);
+            this.tabPageFirst.TabIndex = 0;
+            this.tabPageFirst.Text = "Main Preferences";
+            this.tabPageFirst.UseVisualStyleBackColor = true;
             // 
-            // label1
+            // groupBox9
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(11, 20);
-            this.label1.MaximumSize = new System.Drawing.Size(350, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(334, 26);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Would you like the game to run in a window or full-screen when you test it?";
+            this.groupBox9.Controls.Add(this.chkRemapBgImport);
+            this.groupBox9.Location = new System.Drawing.Point(462, 422);
+            this.groupBox9.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox9.Size = new System.Drawing.Size(451, 65);
+            this.groupBox9.TabIndex = 10;
+            this.groupBox9.TabStop = false;
+            this.groupBox9.Text = "8-bit background import";
             // 
-            // cmbTestGameStyle
+            // chkRemapBgImport
             // 
-            this.cmbTestGameStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbTestGameStyle.FormattingEnabled = true;
-            this.cmbTestGameStyle.Items.AddRange(new object[] {
-            "Use game setup configuration",
-            "Always run full screen",
-            "Always run in a window"});
-            this.cmbTestGameStyle.Location = new System.Drawing.Point(184, 49);
-            this.cmbTestGameStyle.Name = "cmbTestGameStyle";
-            this.cmbTestGameStyle.Size = new System.Drawing.Size(171, 21);
-            this.cmbTestGameStyle.TabIndex = 1;
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.lblReloadScriptOnExternalChange);
-            this.groupBox2.Controls.Add(this.cmbScriptReloadOnExternalChange);
-            this.groupBox2.Controls.Add(this.udTabWidth);
-            this.groupBox2.Controls.Add(this.cmbIndentStyle);
-            this.groupBox2.Controls.Add(this.label10);
-            this.groupBox2.Controls.Add(this.label8);
-            this.groupBox2.Controls.Add(this.label2);
-            this.groupBox2.Location = new System.Drawing.Point(378, 2);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(361, 182);
-            this.groupBox2.TabIndex = 3;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Script editor";
-            // 
-            // lblReloadScriptOnExternalChange
-            // 
-            this.lblReloadScriptOnExternalChange.Location = new System.Drawing.Point(11, 21);
-            this.lblReloadScriptOnExternalChange.Name = "lblReloadScriptOnExternalChange";
-            this.lblReloadScriptOnExternalChange.Size = new System.Drawing.Size(337, 36);
-            this.lblReloadScriptOnExternalChange.TabIndex = 11;
-            this.lblReloadScriptOnExternalChange.Text = "If a script file is open for editing and is modified by another program, how shou" +
-    "ld this be handled?";
-            // 
-            // cmbScriptReloadOnExternalChange
-            // 
-            this.cmbScriptReloadOnExternalChange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbScriptReloadOnExternalChange.FormattingEnabled = true;
-            this.cmbScriptReloadOnExternalChange.Items.AddRange(new object[] {
-            "Always ask what to do",
-            "Always reload the file",
-            "Never reload the file"});
-            this.cmbScriptReloadOnExternalChange.Location = new System.Drawing.Point(12, 57);
-            this.cmbScriptReloadOnExternalChange.Name = "cmbScriptReloadOnExternalChange";
-            this.cmbScriptReloadOnExternalChange.Size = new System.Drawing.Size(178, 21);
-            this.cmbScriptReloadOnExternalChange.TabIndex = 10;
-            // 
-            // udTabWidth
-            // 
-            this.udTabWidth.Location = new System.Drawing.Point(72, 123);
-            this.udTabWidth.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.udTabWidth.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.udTabWidth.Name = "udTabWidth";
-            this.udTabWidth.Size = new System.Drawing.Size(76, 21);
-            this.udTabWidth.TabIndex = 9;
-            this.udTabWidth.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.udTabWidth.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            // 
-            // cmbIndentStyle
-            // 
-            this.cmbIndentStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbIndentStyle.FormattingEnabled = true;
-            this.cmbIndentStyle.Items.AddRange(new object[] {
-            "Use spaces",
-            "Use tabs"});
-            this.cmbIndentStyle.Location = new System.Drawing.Point(72, 149);
-            this.cmbIndentStyle.Name = "cmbIndentStyle";
-            this.cmbIndentStyle.Size = new System.Drawing.Size(178, 21);
-            this.cmbIndentStyle.TabIndex = 8;
-            // 
-            // label10
-            // 
-            this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(9, 152);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(43, 13);
-            this.label10.TabIndex = 7;
-            this.label10.Text = "Indent:";
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(8, 88);
-            this.label8.MaximumSize = new System.Drawing.Size(350, 0);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(339, 26);
-            this.label8.TabIndex = 2;
-            this.label8.Text = "Changing the following settings requires you to restart the editor for them to ta" +
-    "ke effect.";
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(8, 127);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(58, 13);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Tab width:";
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.btnImportColorTheme);
-            this.groupBox3.Controls.Add(this.label7);
-            this.groupBox3.Controls.Add(this.cmbColorTheme);
-            this.groupBox3.Controls.Add(this.chkPromptDialogOnTabsClose);
-            this.groupBox3.Controls.Add(this.chkKeepHelpOnTop);
-            this.groupBox3.Controls.Add(this.chkAlwaysShowViewPreview);
-            this.groupBox3.Controls.Add(this.cmbMessageOnCompile);
-            this.groupBox3.Controls.Add(this.label9);
-            this.groupBox3.Controls.Add(this.cmbEditorStartup);
-            this.groupBox3.Controls.Add(this.label5);
-            this.groupBox3.Location = new System.Drawing.Point(7, 122);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(365, 204);
-            this.groupBox3.TabIndex = 4;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Editor appearance";
-            // 
-            // btnImportColorTheme
-            // 
-            this.btnImportColorTheme.Location = new System.Drawing.Point(152, 97);
-            this.btnImportColorTheme.Name = "btnImportColorTheme";
-            this.btnImportColorTheme.Size = new System.Drawing.Size(203, 23);
-            this.btnImportColorTheme.TabIndex = 12;
-            this.btnImportColorTheme.Text = "Import Color Theme";
-            this.btnImportColorTheme.UseVisualStyleBackColor = true;
-            this.btnImportColorTheme.Click += new System.EventHandler(this.btnImportColorTheme_Click);
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(11, 74);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(71, 13);
-            this.label7.TabIndex = 11;
-            this.label7.Text = "Color Theme:";
-            // 
-            // cmbColorTheme
-            // 
-            this.cmbColorTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbColorTheme.FormattingEnabled = true;
-            this.cmbColorTheme.Location = new System.Drawing.Point(152, 71);
-            this.cmbColorTheme.Name = "cmbColorTheme";
-            this.cmbColorTheme.Size = new System.Drawing.Size(203, 21);
-            this.cmbColorTheme.TabIndex = 10;
-            this.cmbColorTheme.DropDown += new System.EventHandler(this.cmbColorTheme_DropDown);
-            // 
-            // chkPromptDialogOnTabsClose
-            // 
-            this.chkPromptDialogOnTabsClose.AutoSize = true;
-            this.chkPromptDialogOnTabsClose.Location = new System.Drawing.Point(14, 177);
-            this.chkPromptDialogOnTabsClose.Name = "chkPromptDialogOnTabsClose";
-            this.chkPromptDialogOnTabsClose.Size = new System.Drawing.Size(204, 17);
-            this.chkPromptDialogOnTabsClose.TabIndex = 9;
-            this.chkPromptDialogOnTabsClose.Text = "Prompt dialog on closing multiple tabs";
-            this.chkPromptDialogOnTabsClose.UseVisualStyleBackColor = true;
-            // 
-            // chkKeepHelpOnTop
-            // 
-            this.chkKeepHelpOnTop.AutoSize = true;
-            this.chkKeepHelpOnTop.Location = new System.Drawing.Point(14, 154);
-            this.chkKeepHelpOnTop.Name = "chkKeepHelpOnTop";
-            this.chkKeepHelpOnTop.Size = new System.Drawing.Size(230, 17);
-            this.chkKeepHelpOnTop.TabIndex = 8;
-            this.chkKeepHelpOnTop.Text = "Keep Help window on top of editor window";
-            this.chkKeepHelpOnTop.UseVisualStyleBackColor = true;
-            // 
-            // chkAlwaysShowViewPreview
-            // 
-            this.chkAlwaysShowViewPreview.AutoSize = true;
-            this.chkAlwaysShowViewPreview.Location = new System.Drawing.Point(14, 131);
-            this.chkAlwaysShowViewPreview.Name = "chkAlwaysShowViewPreview";
-            this.chkAlwaysShowViewPreview.Size = new System.Drawing.Size(242, 17);
-            this.chkAlwaysShowViewPreview.TabIndex = 7;
-            this.chkAlwaysShowViewPreview.Text = "Show view preview by default in view editors";
-            this.chkAlwaysShowViewPreview.UseVisualStyleBackColor = true;
-            // 
-            // cmbMessageOnCompile
-            // 
-            this.cmbMessageOnCompile.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbMessageOnCompile.FormattingEnabled = true;
-            this.cmbMessageOnCompile.Items.AddRange(new object[] {
-            "Always",
-            "When there are warnings or errors",
-            "When there are errors",
-            "Never"});
-            this.cmbMessageOnCompile.Location = new System.Drawing.Point(152, 46);
-            this.cmbMessageOnCompile.Name = "cmbMessageOnCompile";
-            this.cmbMessageOnCompile.Size = new System.Drawing.Size(203, 21);
-            this.cmbMessageOnCompile.TabIndex = 6;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(12, 49);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(139, 13);
-            this.label9.TabIndex = 5;
-            this.label9.Text = "Popup message on compile:";
-            // 
-            // cmbEditorStartup
-            // 
-            this.cmbEditorStartup.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbEditorStartup.FormattingEnabled = true;
-            this.cmbEditorStartup.Items.AddRange(new object[] {
-            "Show Start Page",
-            "Show Game Settings",
-            "No panes open"});
-            this.cmbEditorStartup.Location = new System.Drawing.Point(152, 20);
-            this.cmbEditorStartup.Name = "cmbEditorStartup";
-            this.cmbEditorStartup.Size = new System.Drawing.Size(203, 21);
-            this.cmbEditorStartup.TabIndex = 2;
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(12, 23);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(135, 13);
-            this.label5.TabIndex = 0;
-            this.label5.Text = "When the editor starts up:";
-            // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.btnChooseFolder);
-            this.groupBox4.Controls.Add(this.txtImportPath);
-            this.groupBox4.Controls.Add(this.label6);
-            this.groupBox4.Controls.Add(this.radFolderPath);
-            this.groupBox4.Controls.Add(this.radGamePath);
-            this.groupBox4.Location = new System.Drawing.Point(378, 424);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(361, 92);
-            this.groupBox4.TabIndex = 5;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Import directory";
-            // 
-            // btnChooseFolder
-            // 
-            this.btnChooseFolder.Location = new System.Drawing.Point(321, 60);
-            this.btnChooseFolder.Name = "btnChooseFolder";
-            this.btnChooseFolder.Size = new System.Drawing.Size(27, 21);
-            this.btnChooseFolder.TabIndex = 4;
-            this.btnChooseFolder.Text = "...";
-            this.btnChooseFolder.UseVisualStyleBackColor = true;
-            this.btnChooseFolder.Click += new System.EventHandler(this.btnChooseFolder_Click);
-            // 
-            // txtImportPath
-            // 
-            this.txtImportPath.Location = new System.Drawing.Point(97, 60);
-            this.txtImportPath.MaxLength = 0;
-            this.txtImportPath.Name = "txtImportPath";
-            this.txtImportPath.Size = new System.Drawing.Size(218, 21);
-            this.txtImportPath.TabIndex = 3;
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(12, 18);
-            this.label6.MaximumSize = new System.Drawing.Size(350, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(273, 13);
-            this.label6.TabIndex = 2;
-            this.label6.Text = "When you import files, where do you want to look first?";
-            // 
-            // radFolderPath
-            // 
-            this.radFolderPath.AutoSize = true;
-            this.radFolderPath.Location = new System.Drawing.Point(14, 62);
-            this.radFolderPath.Name = "radFolderPath";
-            this.radFolderPath.Size = new System.Drawing.Size(77, 17);
-            this.radFolderPath.TabIndex = 1;
-            this.radFolderPath.Text = "Default to:";
-            this.radFolderPath.UseVisualStyleBackColor = true;
-            this.radFolderPath.CheckedChanged += new System.EventHandler(this.radFolderPath_CheckedChanged);
-            // 
-            // radGamePath
-            // 
-            this.radGamePath.AutoSize = true;
-            this.radGamePath.Checked = true;
-            this.radGamePath.Location = new System.Drawing.Point(14, 39);
-            this.radGamePath.Name = "radGamePath";
-            this.radGamePath.Size = new System.Drawing.Size(250, 17);
-            this.radGamePath.TabIndex = 0;
-            this.radGamePath.TabStop = true;
-            this.radGamePath.Text = "Default to the game folder when importing files";
-            this.radGamePath.UseVisualStyleBackColor = true;
-            this.radGamePath.CheckedChanged += new System.EventHandler(this.radGamePath_CheckedChanged);
+            this.chkRemapBgImport.Location = new System.Drawing.Point(18, 20);
+            this.chkRemapBgImport.Margin = new System.Windows.Forms.Padding(4);
+            this.chkRemapBgImport.Name = "chkRemapBgImport";
+            this.chkRemapBgImport.Size = new System.Drawing.Size(433, 38);
+            this.chkRemapBgImport.TabIndex = 8;
+            this.chkRemapBgImport.Text = "Remap palette of room backgrounds into allocated background palette slots (8-bit " +
+    "games only)";
+            this.chkRemapBgImport.UseVisualStyleBackColor = true;
+            this.chkRemapBgImport.CheckedChanged += new System.EventHandler(this.chkRemapBgImport_CheckedChanged);
             // 
             // groupBox5
             // 
@@ -475,9 +201,11 @@ namespace AGS.Editor
             this.groupBox5.Controls.Add(this.label11);
             this.groupBox5.Controls.Add(this.radPaintProgram);
             this.groupBox5.Controls.Add(this.radDefaultPaintProgram);
-            this.groupBox5.Location = new System.Drawing.Point(378, 190);
+            this.groupBox5.Location = new System.Drawing.Point(462, 240);
+            this.groupBox5.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(361, 130);
+            this.groupBox5.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox5.Size = new System.Drawing.Size(451, 174);
             this.groupBox5.TabIndex = 6;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Sprite editor";
@@ -494,25 +222,29 @@ namespace AGS.Editor
             "Bottom-right pixel",
             "Leave as-is",
             "No transparency"});
-            this.cmbSpriteImportTransparency.Location = new System.Drawing.Point(189, 98);
+            this.cmbSpriteImportTransparency.Location = new System.Drawing.Point(236, 139);
+            this.cmbSpriteImportTransparency.Margin = new System.Windows.Forms.Padding(4);
             this.cmbSpriteImportTransparency.Name = "cmbSpriteImportTransparency";
-            this.cmbSpriteImportTransparency.Size = new System.Drawing.Size(159, 21);
+            this.cmbSpriteImportTransparency.Size = new System.Drawing.Size(198, 25);
             this.cmbSpriteImportTransparency.TabIndex = 9;
+            this.cmbSpriteImportTransparency.SelectedIndexChanged += new System.EventHandler(this.cmbSpriteImportTransparency_SelectedIndexChanged);
             // 
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(12, 101);
+            this.label12.Location = new System.Drawing.Point(15, 143);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(176, 13);
+            this.label12.Size = new System.Drawing.Size(222, 17);
             this.label12.TabIndex = 5;
             this.label12.Text = "Default sprite import transparency:";
             // 
             // btnSelectPaintProgram
             // 
-            this.btnSelectPaintProgram.Location = new System.Drawing.Point(321, 72);
+            this.btnSelectPaintProgram.Location = new System.Drawing.Point(401, 107);
+            this.btnSelectPaintProgram.Margin = new System.Windows.Forms.Padding(4);
             this.btnSelectPaintProgram.Name = "btnSelectPaintProgram";
-            this.btnSelectPaintProgram.Size = new System.Drawing.Size(27, 21);
+            this.btnSelectPaintProgram.Size = new System.Drawing.Size(34, 26);
             this.btnSelectPaintProgram.TabIndex = 4;
             this.btnSelectPaintProgram.Text = "...";
             this.btnSelectPaintProgram.UseVisualStyleBackColor = true;
@@ -520,19 +252,21 @@ namespace AGS.Editor
             // 
             // txtPaintProgram
             // 
-            this.txtPaintProgram.Location = new System.Drawing.Point(111, 72);
+            this.txtPaintProgram.Location = new System.Drawing.Point(139, 107);
+            this.txtPaintProgram.Margin = new System.Windows.Forms.Padding(4);
             this.txtPaintProgram.MaxLength = 0;
             this.txtPaintProgram.Name = "txtPaintProgram";
-            this.txtPaintProgram.Size = new System.Drawing.Size(204, 21);
+            this.txtPaintProgram.Size = new System.Drawing.Size(254, 24);
             this.txtPaintProgram.TabIndex = 3;
             // 
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(12, 18);
-            this.label11.MaximumSize = new System.Drawing.Size(350, 0);
+            this.label11.Location = new System.Drawing.Point(15, 22);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label11.MaximumSize = new System.Drawing.Size(438, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(339, 26);
+            this.label11.Size = new System.Drawing.Size(436, 34);
             this.label11.TabIndex = 2;
             this.label11.Text = "When you double-click a sprite, what program do you want to use to edit it? This " +
     "program must support PNG and BMP files.";
@@ -540,9 +274,10 @@ namespace AGS.Editor
             // radPaintProgram
             // 
             this.radPaintProgram.AutoSize = true;
-            this.radPaintProgram.Location = new System.Drawing.Point(14, 74);
+            this.radPaintProgram.Location = new System.Drawing.Point(18, 109);
+            this.radPaintProgram.Margin = new System.Windows.Forms.Padding(4);
             this.radPaintProgram.Name = "radPaintProgram";
-            this.radPaintProgram.Size = new System.Drawing.Size(91, 17);
+            this.radPaintProgram.Size = new System.Drawing.Size(115, 21);
             this.radPaintProgram.TabIndex = 1;
             this.radPaintProgram.Text = "This program:";
             this.radPaintProgram.UseVisualStyleBackColor = true;
@@ -552,129 +287,97 @@ namespace AGS.Editor
             // 
             this.radDefaultPaintProgram.AutoSize = true;
             this.radDefaultPaintProgram.Checked = true;
-            this.radDefaultPaintProgram.Location = new System.Drawing.Point(14, 51);
+            this.radDefaultPaintProgram.Location = new System.Drawing.Point(18, 81);
+            this.radDefaultPaintProgram.Margin = new System.Windows.Forms.Padding(4);
             this.radDefaultPaintProgram.Name = "radDefaultPaintProgram";
-            this.radDefaultPaintProgram.Size = new System.Drawing.Size(271, 17);
+            this.radDefaultPaintProgram.Size = new System.Drawing.Size(341, 21);
             this.radDefaultPaintProgram.TabIndex = 0;
             this.radDefaultPaintProgram.TabStop = true;
             this.radDefaultPaintProgram.Text = "The default paint program registered with Windows";
             this.radDefaultPaintProgram.UseVisualStyleBackColor = true;
             this.radDefaultPaintProgram.CheckedChanged += new System.EventHandler(this.radDefaultPaintProgram_CheckedChanged);
             // 
-            // groupBox6
+            // groupBox1
             // 
-            this.groupBox6.Controls.Add(this.btnNewGameChooseFolder);
-            this.groupBox6.Controls.Add(this.txtNewGamePath);
-            this.groupBox6.Controls.Add(this.label13);
-            this.groupBox6.Controls.Add(this.radNewGameSpecificPath);
-            this.groupBox6.Controls.Add(this.radNewGameMyDocs);
-            this.groupBox6.Location = new System.Drawing.Point(378, 326);
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(361, 92);
-            this.groupBox6.TabIndex = 7;
-            this.groupBox6.TabStop = false;
-            this.groupBox6.Text = "New game directory";
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Controls.Add(this.cmbTestGameStyle);
+            this.groupBox1.Location = new System.Drawing.Point(3, 4);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Size = new System.Drawing.Size(456, 141);
+            this.groupBox1.TabIndex = 2;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Test game style";
             // 
-            // btnNewGameChooseFolder
+            // label4
             // 
-            this.btnNewGameChooseFolder.Location = new System.Drawing.Point(321, 60);
-            this.btnNewGameChooseFolder.Name = "btnNewGameChooseFolder";
-            this.btnNewGameChooseFolder.Size = new System.Drawing.Size(27, 21);
-            this.btnNewGameChooseFolder.TabIndex = 4;
-            this.btnNewGameChooseFolder.Text = "...";
-            this.btnNewGameChooseFolder.UseVisualStyleBackColor = true;
-            this.btnNewGameChooseFolder.Click += new System.EventHandler(this.btnNewGameChooseFolder_Click);
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(15, 65);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(214, 17);
+            this.label4.TabIndex = 3;
+            this.label4.Text = "When running without debugger:";
             // 
-            // txtNewGamePath
+            // label3
             // 
-            this.txtNewGamePath.Location = new System.Drawing.Point(97, 60);
-            this.txtNewGamePath.MaxLength = 0;
-            this.txtNewGamePath.Name = "txtNewGamePath";
-            this.txtNewGamePath.Size = new System.Drawing.Size(218, 21);
-            this.txtNewGamePath.TabIndex = 3;
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(14, 98);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.MaximumSize = new System.Drawing.Size(438, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(431, 34);
+            this.label3.TabIndex = 2;
+            this.label3.Text = "NOTE: When using the F5 (Run) option, the game will always run in a window.";
             // 
-            // label13
+            // label1
             // 
-            this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(12, 18);
-            this.label13.MaximumSize = new System.Drawing.Size(350, 0);
-            this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(293, 13);
-            this.label13.TabIndex = 2;
-            this.label13.Text = "When you create a new game, where do you want it to go?";
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(14, 25);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.MaximumSize = new System.Drawing.Size(438, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(428, 34);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Would you like the game to run in a window or full-screen when you test it?";
             // 
-            // radNewGameSpecificPath
+            // cmbTestGameStyle
             // 
-            this.radNewGameSpecificPath.AutoSize = true;
-            this.radNewGameSpecificPath.Location = new System.Drawing.Point(14, 62);
-            this.radNewGameSpecificPath.Name = "radNewGameSpecificPath";
-            this.radNewGameSpecificPath.Size = new System.Drawing.Size(77, 17);
-            this.radNewGameSpecificPath.TabIndex = 1;
-            this.radNewGameSpecificPath.Text = "Default to:";
-            this.radNewGameSpecificPath.UseVisualStyleBackColor = true;
-            this.radNewGameSpecificPath.CheckedChanged += new System.EventHandler(this.radNewGameSpecificPath_CheckedChanged);
-            // 
-            // radNewGameMyDocs
-            // 
-            this.radNewGameMyDocs.AutoSize = true;
-            this.radNewGameMyDocs.Checked = true;
-            this.radNewGameMyDocs.Location = new System.Drawing.Point(14, 39);
-            this.radNewGameMyDocs.Name = "radNewGameMyDocs";
-            this.radNewGameMyDocs.Size = new System.Drawing.Size(146, 17);
-            this.radNewGameMyDocs.TabIndex = 0;
-            this.radNewGameMyDocs.TabStop = true;
-            this.radNewGameMyDocs.Text = "Default to My Documents";
-            this.radNewGameMyDocs.UseVisualStyleBackColor = true;
-            this.radNewGameMyDocs.CheckedChanged += new System.EventHandler(this.radNewGameMyDocs_CheckedChanged);
-            // 
-            // groupBox7
-            // 
-            this.groupBox7.Controls.Add(this.lnkUsageInfo);
-            this.groupBox7.Controls.Add(this.chkUsageInfo);
-            this.groupBox7.Location = new System.Drawing.Point(7, 448);
-            this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(365, 68);
-            this.groupBox7.TabIndex = 8;
-            this.groupBox7.TabStop = false;
-            this.groupBox7.Text = "Usage statistics";
-            this.groupBox7.Visible = false;
-            // 
-            // lnkUsageInfo
-            // 
-            this.lnkUsageInfo.AutoSize = true;
-            this.lnkUsageInfo.Location = new System.Drawing.Point(12, 42);
-            this.lnkUsageInfo.Name = "lnkUsageInfo";
-            this.lnkUsageInfo.Size = new System.Drawing.Size(197, 13);
-            this.lnkUsageInfo.TabIndex = 9;
-            this.lnkUsageInfo.TabStop = true;
-            this.lnkUsageInfo.Text = "What is this and why should I enable it?";
-            this.lnkUsageInfo.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkUsageInfo_LinkClicked);
-            // 
-            // chkUsageInfo
-            // 
-            this.chkUsageInfo.AutoSize = true;
-            this.chkUsageInfo.Location = new System.Drawing.Point(14, 20);
-            this.chkUsageInfo.Name = "chkUsageInfo";
-            this.chkUsageInfo.Size = new System.Drawing.Size(292, 17);
-            this.chkUsageInfo.TabIndex = 8;
-            this.chkUsageInfo.Text = "Send anonymous usage information to the AGS website";
-            this.chkUsageInfo.UseVisualStyleBackColor = true;
+            this.cmbTestGameStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTestGameStyle.FormattingEnabled = true;
+            this.cmbTestGameStyle.Items.AddRange(new object[] {
+            "Use game setup configuration",
+            "Always run full screen",
+            "Always run in a window"});
+            this.cmbTestGameStyle.Location = new System.Drawing.Point(230, 61);
+            this.cmbTestGameStyle.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbTestGameStyle.Name = "cmbTestGameStyle";
+            this.cmbTestGameStyle.Size = new System.Drawing.Size(213, 25);
+            this.cmbTestGameStyle.TabIndex = 1;
+            this.cmbTestGameStyle.SelectedIndexChanged += new System.EventHandler(this.cmbTestGameStyle_SelectedIndexChanged);
             // 
             // groupBox8
             // 
             this.groupBox8.Controls.Add(this.udBackupInterval);
             this.groupBox8.Controls.Add(this.label14);
             this.groupBox8.Controls.Add(this.chkBackupReminders);
-            this.groupBox8.Location = new System.Drawing.Point(7, 331);
+            this.groupBox8.Location = new System.Drawing.Point(3, 422);
+            this.groupBox8.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(365, 52);
+            this.groupBox8.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox8.Size = new System.Drawing.Size(456, 65);
             this.groupBox8.TabIndex = 9;
             this.groupBox8.TabStop = false;
             this.groupBox8.Text = "Backup reminders";
             // 
             // udBackupInterval
             // 
-            this.udBackupInterval.Location = new System.Drawing.Point(69, 19);
+            this.udBackupInterval.Location = new System.Drawing.Point(86, 24);
+            this.udBackupInterval.Margin = new System.Windows.Forms.Padding(4);
             this.udBackupInterval.Maximum = new decimal(new int[] {
             90,
             0,
@@ -686,7 +389,7 @@ namespace AGS.Editor
             0,
             0});
             this.udBackupInterval.Name = "udBackupInterval";
-            this.udBackupInterval.Size = new System.Drawing.Size(42, 21);
+            this.udBackupInterval.Size = new System.Drawing.Size(52, 24);
             this.udBackupInterval.TabIndex = 10;
             this.udBackupInterval.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.udBackupInterval.Value = new decimal(new int[] {
@@ -694,92 +397,547 @@ namespace AGS.Editor
             0,
             0,
             0});
+            this.udBackupInterval.ValueChanged += new System.EventHandler(this.udBackupInterval_ValueChanged);
             // 
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(117, 21);
-            this.label14.MaximumSize = new System.Drawing.Size(230, 50);
+            this.label14.Location = new System.Drawing.Point(146, 26);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label14.MaximumSize = new System.Drawing.Size(288, 62);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(185, 13);
+            this.label14.Size = new System.Drawing.Size(242, 17);
             this.label14.TabIndex = 9;
             this.label14.Text = "days, remind me to back up my game";
             // 
             // chkBackupReminders
             // 
             this.chkBackupReminders.AutoSize = true;
-            this.chkBackupReminders.Location = new System.Drawing.Point(14, 20);
+            this.chkBackupReminders.Location = new System.Drawing.Point(18, 25);
+            this.chkBackupReminders.Margin = new System.Windows.Forms.Padding(4);
             this.chkBackupReminders.Name = "chkBackupReminders";
-            this.chkBackupReminders.Size = new System.Drawing.Size(54, 17);
+            this.chkBackupReminders.Size = new System.Drawing.Size(66, 21);
             this.chkBackupReminders.TabIndex = 8;
             this.chkBackupReminders.Text = "Every";
             this.chkBackupReminders.UseVisualStyleBackColor = true;
             this.chkBackupReminders.CheckedChanged += new System.EventHandler(this.chkBackupReminders_CheckedChanged);
             // 
-            // groupBox9
+            // groupBox2
             // 
-            this.groupBox9.Controls.Add(this.chkRemapBgImport);
-            this.groupBox9.Location = new System.Drawing.Point(7, 388);
-            this.groupBox9.Name = "groupBox9";
-            this.groupBox9.Size = new System.Drawing.Size(365, 54);
-            this.groupBox9.TabIndex = 10;
-            this.groupBox9.TabStop = false;
-            this.groupBox9.Text = "8-bit background import";
+            this.groupBox2.Controls.Add(this.lblReloadScriptOnExternalChange);
+            this.groupBox2.Controls.Add(this.cmbScriptReloadOnExternalChange);
+            this.groupBox2.Controls.Add(this.udTabWidth);
+            this.groupBox2.Controls.Add(this.cmbIndentStyle);
+            this.groupBox2.Controls.Add(this.label10);
+            this.groupBox2.Controls.Add(this.label8);
+            this.groupBox2.Controls.Add(this.label2);
+            this.groupBox2.Location = new System.Drawing.Point(462, 4);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Size = new System.Drawing.Size(451, 228);
+            this.groupBox2.TabIndex = 3;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Script editor";
             // 
-            // chkRemapBgImport
+            // lblReloadScriptOnExternalChange
             // 
-            this.chkRemapBgImport.Location = new System.Drawing.Point(14, 16);
-            this.chkRemapBgImport.Name = "chkRemapBgImport";
-            this.chkRemapBgImport.Size = new System.Drawing.Size(330, 30);
-            this.chkRemapBgImport.TabIndex = 8;
-            this.chkRemapBgImport.Text = "Remap palette of room backgrounds into allocated background palette slots (8-bit " +
-    "games only)";
-            this.chkRemapBgImport.UseVisualStyleBackColor = true;
+            this.lblReloadScriptOnExternalChange.Location = new System.Drawing.Point(14, 26);
+            this.lblReloadScriptOnExternalChange.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblReloadScriptOnExternalChange.Name = "lblReloadScriptOnExternalChange";
+            this.lblReloadScriptOnExternalChange.Size = new System.Drawing.Size(421, 45);
+            this.lblReloadScriptOnExternalChange.TabIndex = 11;
+            this.lblReloadScriptOnExternalChange.Text = "If a script file is open for editing and is modified by another program, how shou" +
+    "ld this be handled?";
+            // 
+            // cmbScriptReloadOnExternalChange
+            // 
+            this.cmbScriptReloadOnExternalChange.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbScriptReloadOnExternalChange.FormattingEnabled = true;
+            this.cmbScriptReloadOnExternalChange.Items.AddRange(new object[] {
+            "Ask what to do",
+            "Always reload the file",
+            "Never reload the file"});
+            this.cmbScriptReloadOnExternalChange.Location = new System.Drawing.Point(15, 71);
+            this.cmbScriptReloadOnExternalChange.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbScriptReloadOnExternalChange.Name = "cmbScriptReloadOnExternalChange";
+            this.cmbScriptReloadOnExternalChange.Size = new System.Drawing.Size(222, 25);
+            this.cmbScriptReloadOnExternalChange.TabIndex = 10;
+            this.cmbScriptReloadOnExternalChange.SelectedIndexChanged += new System.EventHandler(this.cmbScriptReloadOnExternalChange_SelectedIndexChanged);
+            // 
+            // udTabWidth
+            // 
+            this.udTabWidth.Location = new System.Drawing.Point(90, 154);
+            this.udTabWidth.Margin = new System.Windows.Forms.Padding(4);
+            this.udTabWidth.Maximum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.udTabWidth.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.udTabWidth.Name = "udTabWidth";
+            this.udTabWidth.Size = new System.Drawing.Size(95, 24);
+            this.udTabWidth.TabIndex = 9;
+            this.udTabWidth.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.udTabWidth.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.udTabWidth.ValueChanged += new System.EventHandler(this.udTabWidth_ValueChanged);
+            // 
+            // cmbIndentStyle
+            // 
+            this.cmbIndentStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbIndentStyle.FormattingEnabled = true;
+            this.cmbIndentStyle.Items.AddRange(new object[] {
+            "Use spaces",
+            "Use tabs"});
+            this.cmbIndentStyle.Location = new System.Drawing.Point(90, 186);
+            this.cmbIndentStyle.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbIndentStyle.Name = "cmbIndentStyle";
+            this.cmbIndentStyle.Size = new System.Drawing.Size(222, 25);
+            this.cmbIndentStyle.TabIndex = 8;
+            this.cmbIndentStyle.SelectedIndexChanged += new System.EventHandler(this.cmbIndentStyle_SelectedIndexChanged);
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(11, 190);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(53, 17);
+            this.label10.TabIndex = 7;
+            this.label10.Text = "Indent:";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(10, 110);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label8.MaximumSize = new System.Drawing.Size(438, 0);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(426, 34);
+            this.label8.TabIndex = 2;
+            this.label8.Text = "Changing the following settings requires you to restart the editor for them to ta" +
+    "ke effect.";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(10, 159);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(73, 17);
+            this.label2.TabIndex = 0;
+            this.label2.Text = "Tab width:";
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.btnImportColorTheme);
+            this.groupBox3.Controls.Add(this.label7);
+            this.groupBox3.Controls.Add(this.cmbColorTheme);
+            this.groupBox3.Controls.Add(this.chkPromptDialogOnTabsClose);
+            this.groupBox3.Controls.Add(this.chkKeepHelpOnTop);
+            this.groupBox3.Controls.Add(this.chkAlwaysShowViewPreview);
+            this.groupBox3.Controls.Add(this.cmbMessageOnCompile);
+            this.groupBox3.Controls.Add(this.label9);
+            this.groupBox3.Controls.Add(this.cmbEditorStartup);
+            this.groupBox3.Controls.Add(this.label5);
+            this.groupBox3.Location = new System.Drawing.Point(3, 152);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox3.Size = new System.Drawing.Size(456, 255);
+            this.groupBox3.TabIndex = 4;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Editor appearance";
+            // 
+            // btnImportColorTheme
+            // 
+            this.btnImportColorTheme.Location = new System.Drawing.Point(190, 121);
+            this.btnImportColorTheme.Margin = new System.Windows.Forms.Padding(4);
+            this.btnImportColorTheme.Name = "btnImportColorTheme";
+            this.btnImportColorTheme.Size = new System.Drawing.Size(254, 29);
+            this.btnImportColorTheme.TabIndex = 12;
+            this.btnImportColorTheme.Text = "Import Color Theme";
+            this.btnImportColorTheme.UseVisualStyleBackColor = true;
+            this.btnImportColorTheme.Click += new System.EventHandler(this.btnImportColorTheme_Click);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(14, 92);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(91, 17);
+            this.label7.TabIndex = 11;
+            this.label7.Text = "Color Theme:";
+            // 
+            // cmbColorTheme
+            // 
+            this.cmbColorTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbColorTheme.FormattingEnabled = true;
+            this.cmbColorTheme.Location = new System.Drawing.Point(190, 89);
+            this.cmbColorTheme.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbColorTheme.Name = "cmbColorTheme";
+            this.cmbColorTheme.Size = new System.Drawing.Size(253, 25);
+            this.cmbColorTheme.TabIndex = 10;
+            this.cmbColorTheme.DropDown += new System.EventHandler(this.cmbColorTheme_DropDown);
+            this.cmbColorTheme.SelectedIndexChanged += new System.EventHandler(this.cmbColorTheme_SelectedIndexChanged);
+            // 
+            // chkPromptDialogOnTabsClose
+            // 
+            this.chkPromptDialogOnTabsClose.AutoSize = true;
+            this.chkPromptDialogOnTabsClose.Location = new System.Drawing.Point(18, 221);
+            this.chkPromptDialogOnTabsClose.Margin = new System.Windows.Forms.Padding(4);
+            this.chkPromptDialogOnTabsClose.Name = "chkPromptDialogOnTabsClose";
+            this.chkPromptDialogOnTabsClose.Size = new System.Drawing.Size(260, 21);
+            this.chkPromptDialogOnTabsClose.TabIndex = 9;
+            this.chkPromptDialogOnTabsClose.Text = "Prompt dialog on closing multiple tabs";
+            this.chkPromptDialogOnTabsClose.UseVisualStyleBackColor = true;
+            this.chkPromptDialogOnTabsClose.CheckedChanged += new System.EventHandler(this.chkPromptDialogOnTabsClose_CheckedChanged);
+            // 
+            // chkKeepHelpOnTop
+            // 
+            this.chkKeepHelpOnTop.AutoSize = true;
+            this.chkKeepHelpOnTop.Location = new System.Drawing.Point(18, 192);
+            this.chkKeepHelpOnTop.Margin = new System.Windows.Forms.Padding(4);
+            this.chkKeepHelpOnTop.Name = "chkKeepHelpOnTop";
+            this.chkKeepHelpOnTop.Size = new System.Drawing.Size(290, 21);
+            this.chkKeepHelpOnTop.TabIndex = 8;
+            this.chkKeepHelpOnTop.Text = "Keep Help window on top of editor window";
+            this.chkKeepHelpOnTop.UseVisualStyleBackColor = true;
+            this.chkKeepHelpOnTop.CheckedChanged += new System.EventHandler(this.chkKeepHelpOnTop_CheckedChanged);
+            // 
+            // chkAlwaysShowViewPreview
+            // 
+            this.chkAlwaysShowViewPreview.AutoSize = true;
+            this.chkAlwaysShowViewPreview.Location = new System.Drawing.Point(18, 164);
+            this.chkAlwaysShowViewPreview.Margin = new System.Windows.Forms.Padding(4);
+            this.chkAlwaysShowViewPreview.Name = "chkAlwaysShowViewPreview";
+            this.chkAlwaysShowViewPreview.Size = new System.Drawing.Size(301, 21);
+            this.chkAlwaysShowViewPreview.TabIndex = 7;
+            this.chkAlwaysShowViewPreview.Text = "Show view preview by default in view editors";
+            this.chkAlwaysShowViewPreview.UseVisualStyleBackColor = true;
+            this.chkAlwaysShowViewPreview.CheckedChanged += new System.EventHandler(this.chkAlwaysShowViewPreview_CheckedChanged);
+            // 
+            // cmbMessageOnCompile
+            // 
+            this.cmbMessageOnCompile.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbMessageOnCompile.FormattingEnabled = true;
+            this.cmbMessageOnCompile.Items.AddRange(new object[] {
+            "Always",
+            "When there are warnings or errors",
+            "When there are errors",
+            "Never"});
+            this.cmbMessageOnCompile.Location = new System.Drawing.Point(190, 58);
+            this.cmbMessageOnCompile.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbMessageOnCompile.Name = "cmbMessageOnCompile";
+            this.cmbMessageOnCompile.Size = new System.Drawing.Size(253, 25);
+            this.cmbMessageOnCompile.TabIndex = 6;
+            this.cmbMessageOnCompile.SelectedIndexChanged += new System.EventHandler(this.cmbMessageOnCompile_SelectedIndexChanged);
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(15, 61);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(180, 17);
+            this.label9.TabIndex = 5;
+            this.label9.Text = "Popup message on compile:";
+            // 
+            // cmbEditorStartup
+            // 
+            this.cmbEditorStartup.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbEditorStartup.FormattingEnabled = true;
+            this.cmbEditorStartup.Items.AddRange(new object[] {
+            "Show Start Page",
+            "Show Game Settings",
+            "No panes open"});
+            this.cmbEditorStartup.Location = new System.Drawing.Point(190, 25);
+            this.cmbEditorStartup.Margin = new System.Windows.Forms.Padding(4);
+            this.cmbEditorStartup.Name = "cmbEditorStartup";
+            this.cmbEditorStartup.Size = new System.Drawing.Size(253, 25);
+            this.cmbEditorStartup.TabIndex = 2;
+            this.cmbEditorStartup.SelectedIndexChanged += new System.EventHandler(this.cmbEditorStartup_SelectedIndexChanged);
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(15, 29);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(171, 17);
+            this.label5.TabIndex = 0;
+            this.label5.Text = "When the editor starts up:";
+            // 
+            // groupBox7
+            // 
+            this.groupBox7.Controls.Add(this.lnkUsageInfo);
+            this.groupBox7.Controls.Add(this.chkUsageInfo);
+            this.groupBox7.Location = new System.Drawing.Point(3, 486);
+            this.groupBox7.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox7.Size = new System.Drawing.Size(456, 82);
+            this.groupBox7.TabIndex = 8;
+            this.groupBox7.TabStop = false;
+            this.groupBox7.Text = "Usage statistics";
+            this.groupBox7.Visible = false;
+            // 
+            // lnkUsageInfo
+            // 
+            this.lnkUsageInfo.AutoSize = true;
+            this.lnkUsageInfo.Location = new System.Drawing.Point(15, 52);
+            this.lnkUsageInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lnkUsageInfo.Name = "lnkUsageInfo";
+            this.lnkUsageInfo.Size = new System.Drawing.Size(249, 17);
+            this.lnkUsageInfo.TabIndex = 9;
+            this.lnkUsageInfo.TabStop = true;
+            this.lnkUsageInfo.Text = "What is this and why should I enable it?";
+            this.lnkUsageInfo.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkUsageInfo_LinkClicked);
+            // 
+            // chkUsageInfo
+            // 
+            this.chkUsageInfo.AutoSize = true;
+            this.chkUsageInfo.Location = new System.Drawing.Point(18, 25);
+            this.chkUsageInfo.Margin = new System.Windows.Forms.Padding(4);
+            this.chkUsageInfo.Name = "chkUsageInfo";
+            this.chkUsageInfo.Size = new System.Drawing.Size(370, 21);
+            this.chkUsageInfo.TabIndex = 8;
+            this.chkUsageInfo.Text = "Send anonymous usage information to the AGS website";
+            this.chkUsageInfo.UseVisualStyleBackColor = true;
+            this.chkUsageInfo.CheckedChanged += new System.EventHandler(this.chkUsageInfo_CheckedChanged);
+            // 
+            // tabControl1
+            // 
+            this.tabControl1.Controls.Add(this.tabPageFirst);
+            this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Controls.Add(this.tabPageLast);
+            this.tabControl1.Location = new System.Drawing.Point(6, 0);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(928, 602);
+            this.tabControl1.TabIndex = 11;
+            this.tabControl1.Selected += new System.Windows.Forms.TabControlEventHandler(this.tabControl1_Selected);
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.Controls.Add(this.flowLayoutPanel1);
+            this.tabPage2.Location = new System.Drawing.Point(4, 26);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(920, 572);
+            this.tabPage2.TabIndex = 3;
+            this.tabPage2.Text = "Default Paths";
+            this.tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.groupBox4);
+            this.flowLayoutPanel1.Controls.Add(this.groupBox6);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(914, 566);
+            this.flowLayoutPanel1.TabIndex = 10;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.btnChooseFolder);
+            this.groupBox4.Controls.Add(this.txtImportPath);
+            this.groupBox4.Controls.Add(this.label6);
+            this.groupBox4.Controls.Add(this.radFolderPath);
+            this.groupBox4.Controls.Add(this.radGamePath);
+            this.groupBox4.Location = new System.Drawing.Point(4, 4);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox4.Size = new System.Drawing.Size(904, 115);
+            this.groupBox4.TabIndex = 8;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Import directory";
+            // 
+            // btnChooseFolder
+            // 
+            this.btnChooseFolder.Location = new System.Drawing.Point(401, 75);
+            this.btnChooseFolder.Margin = new System.Windows.Forms.Padding(4);
+            this.btnChooseFolder.Name = "btnChooseFolder";
+            this.btnChooseFolder.Size = new System.Drawing.Size(34, 26);
+            this.btnChooseFolder.TabIndex = 4;
+            this.btnChooseFolder.Text = "...";
+            this.btnChooseFolder.UseVisualStyleBackColor = true;
+            this.btnChooseFolder.Click += new System.EventHandler(this.btnChooseFolder_Click);
+            // 
+            // txtImportPath
+            // 
+            this.txtImportPath.Location = new System.Drawing.Point(121, 75);
+            this.txtImportPath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtImportPath.MaxLength = 0;
+            this.txtImportPath.Name = "txtImportPath";
+            this.txtImportPath.Size = new System.Drawing.Size(272, 24);
+            this.txtImportPath.TabIndex = 3;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label6.Location = new System.Drawing.Point(4, 21);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.MaximumSize = new System.Drawing.Size(800, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(348, 17);
+            this.label6.TabIndex = 2;
+            this.label6.Text = "When you import files, where do you want to look first?";
+            // 
+            // radFolderPath
+            // 
+            this.radFolderPath.AutoSize = true;
+            this.radFolderPath.Location = new System.Drawing.Point(18, 78);
+            this.radFolderPath.Margin = new System.Windows.Forms.Padding(4);
+            this.radFolderPath.Name = "radFolderPath";
+            this.radFolderPath.Size = new System.Drawing.Size(94, 21);
+            this.radFolderPath.TabIndex = 1;
+            this.radFolderPath.Text = "Default to:";
+            this.radFolderPath.UseVisualStyleBackColor = true;
+            this.radFolderPath.CheckedChanged += new System.EventHandler(this.radFolderPath_CheckedChanged);
+            // 
+            // radGamePath
+            // 
+            this.radGamePath.AutoSize = true;
+            this.radGamePath.Checked = true;
+            this.radGamePath.Location = new System.Drawing.Point(18, 49);
+            this.radGamePath.Margin = new System.Windows.Forms.Padding(4);
+            this.radGamePath.Name = "radGamePath";
+            this.radGamePath.Size = new System.Drawing.Size(313, 21);
+            this.radGamePath.TabIndex = 0;
+            this.radGamePath.TabStop = true;
+            this.radGamePath.Text = "Default to the game folder when importing files";
+            this.radGamePath.UseVisualStyleBackColor = true;
+            this.radGamePath.CheckedChanged += new System.EventHandler(this.radGamePath_CheckedChanged);
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.btnNewGameChooseFolder);
+            this.groupBox6.Controls.Add(this.txtNewGamePath);
+            this.groupBox6.Controls.Add(this.label13);
+            this.groupBox6.Controls.Add(this.radNewGameSpecificPath);
+            this.groupBox6.Controls.Add(this.radNewGameMyDocs);
+            this.groupBox6.Location = new System.Drawing.Point(4, 127);
+            this.groupBox6.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox6.Size = new System.Drawing.Size(904, 115);
+            this.groupBox6.TabIndex = 9;
+            this.groupBox6.TabStop = false;
+            this.groupBox6.Text = "New game directory";
+            // 
+            // btnNewGameChooseFolder
+            // 
+            this.btnNewGameChooseFolder.Location = new System.Drawing.Point(401, 75);
+            this.btnNewGameChooseFolder.Margin = new System.Windows.Forms.Padding(4);
+            this.btnNewGameChooseFolder.Name = "btnNewGameChooseFolder";
+            this.btnNewGameChooseFolder.Size = new System.Drawing.Size(34, 26);
+            this.btnNewGameChooseFolder.TabIndex = 4;
+            this.btnNewGameChooseFolder.Text = "...";
+            this.btnNewGameChooseFolder.UseVisualStyleBackColor = true;
+            this.btnNewGameChooseFolder.Click += new System.EventHandler(this.btnNewGameChooseFolder_Click);
+            // 
+            // txtNewGamePath
+            // 
+            this.txtNewGamePath.Location = new System.Drawing.Point(121, 75);
+            this.txtNewGamePath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtNewGamePath.MaxLength = 0;
+            this.txtNewGamePath.Name = "txtNewGamePath";
+            this.txtNewGamePath.Size = new System.Drawing.Size(272, 24);
+            this.txtNewGamePath.TabIndex = 3;
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label13.Location = new System.Drawing.Point(4, 21);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label13.MaximumSize = new System.Drawing.Size(800, 0);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(375, 17);
+            this.label13.TabIndex = 2;
+            this.label13.Text = "When you create a new game, where do you want it to go?";
+            // 
+            // radNewGameSpecificPath
+            // 
+            this.radNewGameSpecificPath.AutoSize = true;
+            this.radNewGameSpecificPath.Location = new System.Drawing.Point(18, 78);
+            this.radNewGameSpecificPath.Margin = new System.Windows.Forms.Padding(4);
+            this.radNewGameSpecificPath.Name = "radNewGameSpecificPath";
+            this.radNewGameSpecificPath.Size = new System.Drawing.Size(94, 21);
+            this.radNewGameSpecificPath.TabIndex = 1;
+            this.radNewGameSpecificPath.Text = "Default to:";
+            this.radNewGameSpecificPath.UseVisualStyleBackColor = true;
+            this.radNewGameSpecificPath.CheckedChanged += new System.EventHandler(this.radNewGameSpecificPath_CheckedChanged);
+            // 
+            // radNewGameMyDocs
+            // 
+            this.radNewGameMyDocs.AutoSize = true;
+            this.radNewGameMyDocs.Checked = true;
+            this.radNewGameMyDocs.Location = new System.Drawing.Point(18, 49);
+            this.radNewGameMyDocs.Margin = new System.Windows.Forms.Padding(4);
+            this.radNewGameMyDocs.Name = "radNewGameMyDocs";
+            this.radNewGameMyDocs.Size = new System.Drawing.Size(186, 21);
+            this.radNewGameMyDocs.TabIndex = 0;
+            this.radNewGameMyDocs.TabStop = true;
+            this.radNewGameMyDocs.Text = "Default to My Documents";
+            this.radNewGameMyDocs.UseVisualStyleBackColor = true;
+            this.radNewGameMyDocs.CheckedChanged += new System.EventHandler(this.radNewGameMyDocs_CheckedChanged);
             // 
             // PreferencesEditor
             // 
             this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(747, 572);
-            this.Controls.Add(this.groupBox9);
-            this.Controls.Add(this.groupBox8);
-            this.Controls.Add(this.groupBox7);
-            this.Controls.Add(this.groupBox6);
-            this.Controls.Add(this.groupBox5);
-            this.Controls.Add(this.groupBox4);
-            this.Controls.Add(this.groupBox3);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
+            this.ClientSize = new System.Drawing.Size(928, 664);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.tabControl1);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "PreferencesEditor";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Preferences";
+            this.tabPageLast.ResumeLayout(false);
+            this.tabPageFirst.ResumeLayout(false);
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udBackupInterval)).EndInit();
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udTabWidth)).EndInit();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox4.PerformLayout();
-            this.groupBox5.ResumeLayout(false);
-            this.groupBox5.PerformLayout();
-            this.groupBox6.ResumeLayout(false);
-            this.groupBox6.PerformLayout();
             this.groupBox7.ResumeLayout(false);
             this.groupBox7.PerformLayout();
-            this.groupBox8.ResumeLayout(false);
-            this.groupBox8.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.udBackupInterval)).EndInit();
-            this.groupBox9.ResumeLayout(false);
+            this.tabControl1.ResumeLayout(false);
+            this.tabPage2.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -788,58 +946,64 @@ namespace AGS.Editor
 
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.TabPage tabPageLast;
+        private System.Windows.Forms.PropertyGrid propertyGridPreferences;
+        private System.Windows.Forms.TabPage tabPageFirst;
+        private System.Windows.Forms.GroupBox groupBox9;
+        private System.Windows.Forms.CheckBox chkRemapBgImport;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.ComboBox cmbSpriteImportTransparency;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Button btnSelectPaintProgram;
+        private System.Windows.Forms.TextBox txtPaintProgram;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.RadioButton radPaintProgram;
+        private System.Windows.Forms.RadioButton radDefaultPaintProgram;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.ComboBox cmbTestGameStyle;
-        private System.Windows.Forms.Label label1;
-		private System.Windows.Forms.GroupBox groupBox2;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label3;
-		private System.Windows.Forms.Label label4;
-		private System.Windows.Forms.GroupBox groupBox3;
-		private System.Windows.Forms.Label label5;
-		private System.Windows.Forms.ComboBox cmbEditorStartup;
-		private System.Windows.Forms.GroupBox groupBox4;
-		private System.Windows.Forms.RadioButton radFolderPath;
-		private System.Windows.Forms.RadioButton radGamePath;
-		private System.Windows.Forms.TextBox txtImportPath;
-		private System.Windows.Forms.Label label6;
-		private System.Windows.Forms.Button btnChooseFolder;
-		private System.Windows.Forms.Label label8;
-		private System.Windows.Forms.ComboBox cmbMessageOnCompile;
-		private System.Windows.Forms.Label label9;
-		private System.Windows.Forms.ComboBox cmbIndentStyle;
-		private System.Windows.Forms.Label label10;
-		private System.Windows.Forms.CheckBox chkAlwaysShowViewPreview;
-		private System.Windows.Forms.NumericUpDown udTabWidth;
-		private System.Windows.Forms.GroupBox groupBox5;
-		private System.Windows.Forms.Button btnSelectPaintProgram;
-		private System.Windows.Forms.TextBox txtPaintProgram;
-		private System.Windows.Forms.Label label11;
-		private System.Windows.Forms.RadioButton radPaintProgram;
-		private System.Windows.Forms.RadioButton radDefaultPaintProgram;
-		private System.Windows.Forms.ComboBox cmbSpriteImportTransparency;
-		private System.Windows.Forms.Label label12;
-		private System.Windows.Forms.GroupBox groupBox6;
-		private System.Windows.Forms.Button btnNewGameChooseFolder;
-		private System.Windows.Forms.TextBox txtNewGamePath;
-		private System.Windows.Forms.Label label13;
-		private System.Windows.Forms.RadioButton radNewGameSpecificPath;
-		private System.Windows.Forms.RadioButton radNewGameMyDocs;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox cmbTestGameStyle;
+        private System.Windows.Forms.GroupBox groupBox8;
+        private System.Windows.Forms.NumericUpDown udBackupInterval;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.CheckBox chkBackupReminders;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.Label lblReloadScriptOnExternalChange;
+        private System.Windows.Forms.ComboBox cmbScriptReloadOnExternalChange;
+        private System.Windows.Forms.NumericUpDown udTabWidth;
+        private System.Windows.Forms.ComboBox cmbIndentStyle;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.Button btnImportColorTheme;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.ComboBox cmbColorTheme;
+        private System.Windows.Forms.CheckBox chkPromptDialogOnTabsClose;
+        private System.Windows.Forms.CheckBox chkKeepHelpOnTop;
+        private System.Windows.Forms.CheckBox chkAlwaysShowViewPreview;
+        private System.Windows.Forms.ComboBox cmbMessageOnCompile;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.ComboBox cmbEditorStartup;
+        private System.Windows.Forms.Label label5;
         private System.Windows.Forms.GroupBox groupBox7;
         private System.Windows.Forms.LinkLabel lnkUsageInfo;
         private System.Windows.Forms.CheckBox chkUsageInfo;
-        private System.Windows.Forms.GroupBox groupBox8;
-        private System.Windows.Forms.CheckBox chkBackupReminders;
-        private System.Windows.Forms.NumericUpDown udBackupInterval;
-        private System.Windows.Forms.Label label14;
-        private System.Windows.Forms.GroupBox groupBox9;
-        private System.Windows.Forms.CheckBox chkRemapBgImport;
-        private System.Windows.Forms.CheckBox chkKeepHelpOnTop;
-        private System.Windows.Forms.CheckBox chkPromptDialogOnTabsClose;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.ComboBox cmbColorTheme;
-        private System.Windows.Forms.Button btnImportColorTheme;
-        private System.Windows.Forms.ComboBox cmbScriptReloadOnExternalChange;
-        private System.Windows.Forms.Label lblReloadScriptOnExternalChange;
+        private System.Windows.Forms.TabControl tabControl1;
+        private System.Windows.Forms.TabPage tabPage2;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.Button btnChooseFolder;
+        private System.Windows.Forms.TextBox txtImportPath;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.RadioButton radFolderPath;
+        private System.Windows.Forms.RadioButton radGamePath;
+        private System.Windows.Forms.GroupBox groupBox6;
+        private System.Windows.Forms.Button btnNewGameChooseFolder;
+        private System.Windows.Forms.TextBox txtNewGamePath;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.RadioButton radNewGameSpecificPath;
+        private System.Windows.Forms.RadioButton radNewGameMyDocs;
     }
 }

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -12,81 +12,64 @@ namespace AGS.Editor
 {
     public partial class PreferencesEditor : Form
     {
+        private AppSettings _settings;
+        public void UpdateControlsForPreferences()
+        {
+            txtImportPath.Text = _settings.DefaultImportPath;
+            radFolderPath.Checked = (_settings.DefaultImportPath != string.Empty);
+            radGamePath.Checked = (_settings.DefaultImportPath == string.Empty);
+            txtImportPath.Enabled = radFolderPath.Checked;
+            btnChooseFolder.Enabled = txtImportPath.Enabled;
+
+            txtNewGamePath.Text = _settings.NewGamePath;
+            radNewGameSpecificPath.Checked = (_settings.NewGamePath != string.Empty);
+            radNewGameMyDocs.Checked = (_settings.NewGamePath == string.Empty);
+            txtNewGamePath.Enabled = radNewGameSpecificPath.Checked;
+            btnNewGameChooseFolder.Enabled = radNewGameSpecificPath.Checked;
+
+            txtPaintProgram.Text = _settings.PaintProgramPath;
+            radPaintProgram.Checked = (_settings.PaintProgramPath != string.Empty);
+            radDefaultPaintProgram.Checked = (_settings.PaintProgramPath == string.Empty);
+            txtPaintProgram.Enabled = radPaintProgram.Checked;
+            btnSelectPaintProgram.Enabled = txtPaintProgram.Enabled;
+
+            udTabWidth.Value = _settings.TabSize;
+            cmbTestGameStyle.SelectedIndex = (int)_settings.TestGameWindowStyle;
+            cmbEditorStartup.SelectedIndex = (int)_settings.StartupPane;
+            cmbMessageOnCompile.SelectedIndex = (int)_settings.MessageBoxOnCompile;
+            cmbIndentStyle.SelectedIndex = _settings.IndentUseTabs ? 1 : 0;
+            chkAlwaysShowViewPreview.Checked = _settings.ShowViewPreviewByDefault;
+            cmbSpriteImportTransparency.SelectedIndex = (int)_settings.SpriteImportMethod;
+            cmbColorTheme.DataSource = Factory.GUIController.ColorThemes.Themes;
+            cmbColorTheme.SelectedIndex = Factory.GUIController.ColorThemes.Themes.ToList().FindIndex(t => t.Name == _settings.ColorTheme);
+            chkUsageInfo.Checked = _settings.SendAnonymousStats;
+            udBackupInterval.Value = (_settings.BackupWarningInterval > 0) ? _settings.BackupWarningInterval : 1;
+            chkBackupReminders.Checked = (_settings.BackupWarningInterval != 0);
+            udBackupInterval.Enabled = chkBackupReminders.Checked;
+            chkRemapBgImport.Checked = _settings.RemapPalettizedBackgrounds;
+            chkKeepHelpOnTop.Checked = _settings.KeepHelpOnTop;
+            chkPromptDialogOnTabsClose.Checked = _settings.DialogOnMultipleTabsClose;
+            cmbScriptReloadOnExternalChange.SelectedIndex = (int)_settings.ReloadScriptOnExternalChange;
+        }
+
         public PreferencesEditor()
         {
             InitializeComponent();
-			// just in case they had it set to something silly in 2.72
-			if (Factory.AGSEditor.Settings.TabSize < udTabWidth.Minimum) Factory.AGSEditor.Settings.TabSize = (int)udTabWidth.Minimum;
-			if (Factory.AGSEditor.Settings.TabSize > udTabWidth.Maximum) Factory.AGSEditor.Settings.TabSize = (int)udTabWidth.Maximum;
 
-            udTabWidth.Value = Factory.AGSEditor.Settings.TabSize;
-            cmbTestGameStyle.SelectedIndex = (int)Factory.AGSEditor.Settings.TestGameWindowStyle;
-			cmbEditorStartup.SelectedIndex = (int)Factory.AGSEditor.Settings.StartupPane;
-			radFolderPath.Checked = (Factory.AGSEditor.Settings.DefaultImportPath != string.Empty);
-			txtImportPath.Text = Factory.AGSEditor.Settings.DefaultImportPath;
-			txtImportPath.Enabled = radFolderPath.Checked;
-			btnChooseFolder.Enabled = txtImportPath.Enabled;
-			radNewGameSpecificPath.Checked = (Factory.AGSEditor.Settings.NewGamePath != string.Empty);
-			txtNewGamePath.Text = Factory.AGSEditor.Settings.NewGamePath;
-			txtNewGamePath.Enabled = radNewGameSpecificPath.Checked;
-			btnNewGameChooseFolder.Enabled = radNewGameSpecificPath.Checked;
-			cmbMessageOnCompile.SelectedIndex = (int)Factory.AGSEditor.Settings.MessageBoxOnCompile;
-			cmbIndentStyle.SelectedIndex = Factory.AGSEditor.Settings.IndentUseTabs ? 1 : 0;
-			chkAlwaysShowViewPreview.Checked = Factory.AGSEditor.Settings.ShowViewPreviewByDefault;
-			txtPaintProgram.Text = Factory.AGSEditor.Settings.PaintProgramPath;
-			radPaintProgram.Checked = (Factory.AGSEditor.Settings.PaintProgramPath != string.Empty);
-			txtPaintProgram.Enabled = radPaintProgram.Checked;
-			btnSelectPaintProgram.Enabled = txtPaintProgram.Enabled;
-			cmbSpriteImportTransparency.SelectedIndex = (int)Factory.AGSEditor.Settings.SpriteImportMethod;
-            cmbColorTheme.DataSource = Factory.GUIController.ColorThemes.Themes;
-            cmbColorTheme.SelectedIndex = Factory.GUIController.ColorThemes.Themes.ToList().FindIndex(t => t.Name == Factory.AGSEditor.Settings.ColorTheme);
-            chkUsageInfo.Checked = Factory.AGSEditor.Settings.SendAnonymousStats;
-            chkBackupReminders.Checked = (Factory.AGSEditor.Settings.BackupWarningInterval != 0);
-            udBackupInterval.Value = (Factory.AGSEditor.Settings.BackupWarningInterval > 0) ? Factory.AGSEditor.Settings.BackupWarningInterval : 1;
-            udBackupInterval.Enabled = chkBackupReminders.Checked;
-            chkRemapBgImport.Checked = Factory.AGSEditor.Settings.RemapPalettizedBackgrounds;
-            chkKeepHelpOnTop.Checked = Factory.AGSEditor.Settings.KeepHelpOnTop;
-            chkPromptDialogOnTabsClose.Checked = Factory.AGSEditor.Settings.DialogOnMultipleTabsClose;
-            cmbScriptReloadOnExternalChange.SelectedIndex = (int)Factory.AGSEditor.Settings.ReloadScriptOnExternalChange;
+            _settings = Factory.AGSEditor.Settings.CloneAppSettings();
+            // just in case they had it set to something silly in 2.72
+            if (_settings.TabSize < udTabWidth.Minimum) _settings.TabSize = (int)udTabWidth.Minimum;
+            if (_settings.TabSize > udTabWidth.Maximum) _settings.TabSize = (int)udTabWidth.Maximum;
+
+            UpdateControlsForPreferences();
+
+            propertyGridPreferences.SelectedObject = _settings;
             Utilities.CheckLabelWidthsOnForm(this);
-		}
+        }
 
         private void btnOK_Click(object sender, EventArgs e)
         {
-			if ((txtImportPath.Text.Length > 0) &&
-				(!System.IO.Directory.Exists(txtImportPath.Text)))
-			{
-				MessageBox.Show("The directory you have selected for import does not exist. Please enter a valid directory.", "Invalid directory", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-				this.DialogResult = DialogResult.None;
-				return;
-			}
-
-			if ((radPaintProgram.Checked) &&
-				(txtPaintProgram.Text.Length > 0) &&
-				(!System.IO.File.Exists(txtPaintProgram.Text)))
-			{
-				MessageBox.Show("The paint program you have selected does not exist. Please select a valid application.", "Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-				this.DialogResult = DialogResult.None;
-				return;
-			}
-
-            Factory.AGSEditor.Settings.TabSize = Convert.ToInt32(udTabWidth.Value);
-            Factory.AGSEditor.Settings.TestGameWindowStyle = (TestGameWindowStyle)cmbTestGameStyle.SelectedIndex;
-			Factory.AGSEditor.Settings.StartupPane = (StartupPane)cmbEditorStartup.SelectedIndex;
-			Factory.AGSEditor.Settings.DefaultImportPath = (radGamePath.Checked ? string.Empty : txtImportPath.Text);
-			Factory.AGSEditor.Settings.MessageBoxOnCompile = (MessageBoxOnCompile)cmbMessageOnCompile.SelectedIndex;
-			Factory.AGSEditor.Settings.IndentUseTabs = (cmbIndentStyle.SelectedIndex == 1);
-			Factory.AGSEditor.Settings.ShowViewPreviewByDefault = chkAlwaysShowViewPreview.Checked;
-			Factory.AGSEditor.Settings.PaintProgramPath = (radDefaultPaintProgram.Checked ? string.Empty : txtPaintProgram.Text);
-			Factory.AGSEditor.Settings.SpriteImportMethod = (SpriteImportMethod)cmbSpriteImportTransparency.SelectedIndex;
-			Factory.AGSEditor.Settings.NewGamePath = (radNewGameMyDocs.Checked ? string.Empty : txtNewGamePath.Text);
-            Factory.AGSEditor.Settings.SendAnonymousStats = chkUsageInfo.Checked;
-            Factory.AGSEditor.Settings.BackupWarningInterval = (chkBackupReminders.Checked ? (int)udBackupInterval.Value : 0);
-            Factory.AGSEditor.Settings.RemapPalettizedBackgrounds = chkRemapBgImport.Checked;
-            Factory.AGSEditor.Settings.KeepHelpOnTop = chkKeepHelpOnTop.Checked;
-            Factory.AGSEditor.Settings.DialogOnMultipleTabsClose = chkPromptDialogOnTabsClose.Checked;
-            Factory.AGSEditor.Settings.ReloadScriptOnExternalChange = (ReloadScriptOnExternalChange)cmbScriptReloadOnExternalChange.SelectedIndex;
-
+            cmbColorTheme.SelectedIndex = Factory.GUIController.ColorThemes.Themes.ToList().FindIndex(t => t.Name == _settings.ColorTheme);
             if ((ColorTheme)cmbColorTheme.SelectedItem != Factory.GUIController.ColorThemes.Current)
             {
                 Factory.GUIController.ShowMessage(
@@ -94,33 +77,68 @@ namespace AGS.Editor
                     MessageBoxIcon.Information);
                 Factory.GUIController.ColorThemes.Current = (ColorTheme)cmbColorTheme.SelectedItem;
             }
+
+            Factory.AGSEditor.Settings.Apply(_settings);
         }
 
 		private void radFolderPath_CheckedChanged(object sender, EventArgs e)
 		{
 			txtImportPath.Enabled = radFolderPath.Checked;
 			btnChooseFolder.Enabled = txtImportPath.Enabled;
-		}
+            _settings.DefaultImportPath = (radGamePath.Checked ? string.Empty : txtImportPath.Text);
+        }
 
 		private void radGamePath_CheckedChanged(object sender, EventArgs e)
 		{
 			txtImportPath.Enabled = radFolderPath.Checked;
 			btnChooseFolder.Enabled = txtImportPath.Enabled;
-		}
+
+            _settings.DefaultImportPath = (radGamePath.Checked ? string.Empty : txtImportPath.Text);
+        }
 
 		private void btnChooseFolder_Click(object sender, EventArgs e)
 		{
-            txtImportPath.Text = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Please select the folder that you wish to import files from.", txtImportPath.Text, false);
-		}
+            string selectedPath = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Please select the folder that you wish to import files from.", txtImportPath.Text, false);
+            if (!string.IsNullOrEmpty(selectedPath))
+            {
+                if (System.IO.Directory.Exists(selectedPath))
+                {
+                    txtImportPath.Text = selectedPath;
+                    _settings.DefaultImportPath = txtImportPath.Text;
+                    return;
+                }
+                else
+                {
+                    MessageBox.Show("The directory you have selected does not exist. Please select a valid path.", "Invalid directory", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+
+            radFolderPath.Checked = !string.IsNullOrEmpty(_settings.DefaultImportPath);
+            radGamePath.Checked = string.IsNullOrEmpty(_settings.DefaultImportPath);
+            txtImportPath.Text = _settings.DefaultImportPath;
+        }
 
 		private void btnSelectPaintProgram_Click(object sender, EventArgs e)
 		{
 			string selectedFile = Factory.GUIController.ShowOpenFileDialog("Select paint program to use", "Executable files (*.exe)|*.exe", false);
-			if (selectedFile != null)
+			if (!string.IsNullOrEmpty(selectedFile))
 			{
-				txtPaintProgram.Text = selectedFile;
-			}
-		}
+                if (System.IO.File.Exists(selectedFile))
+                {
+                    txtPaintProgram.Text = selectedFile;
+                    _settings.PaintProgramPath = txtPaintProgram.Text;
+                    return;
+                }
+                else
+                {
+                    MessageBox.Show("The paint program you have selected does not exist. Please select a valid application.", "Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+            
+            radDefaultPaintProgram.Checked = string.IsNullOrEmpty(_settings.PaintProgramPath);
+            radPaintProgram.Checked = !string.IsNullOrEmpty(_settings.PaintProgramPath);
+            txtPaintProgram.Text = _settings.PaintProgramPath;
+        }
 
 		private void radDefaultPaintProgram_CheckedChanged(object sender, EventArgs e)
 		{
@@ -131,12 +149,31 @@ namespace AGS.Editor
 		{
 			txtPaintProgram.Enabled = radPaintProgram.Checked;
 			btnSelectPaintProgram.Enabled = radPaintProgram.Checked;
-		}
 
-		private void btnNewGameChooseFolder_Click(object sender, EventArgs e)
-		{
-            txtNewGamePath.Text = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Please select the folder that you wish to make a default for your projects.", txtNewGamePath.Text);
-		}
+            _settings.PaintProgramPath = (radDefaultPaintProgram.Checked ? string.Empty : txtPaintProgram.Text);
+        }
+
+        private void btnNewGameChooseFolder_Click(object sender, EventArgs e)
+        {
+            string selectedPath = Factory.GUIController.ShowSelectFolderOrDefaultDialog("Please select the folder that you wish to make a default for your projects.", txtNewGamePath.Text);
+            if (!string.IsNullOrEmpty(selectedPath))
+            {
+                if (System.IO.Directory.Exists(selectedPath))
+                {
+                    txtNewGamePath.Text = selectedPath;
+                    _settings.NewGamePath = txtNewGamePath.Text;
+                    return;
+                }
+                else
+                {
+                    MessageBox.Show("The directory you have selected does not exist. Please select a valid path.", "Invalid directory", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+
+            radNewGameSpecificPath.Checked = !string.IsNullOrEmpty(_settings.NewGamePath);
+            radNewGameMyDocs.Checked = string.IsNullOrEmpty(_settings.NewGamePath);
+            txtNewGamePath.Text = _settings.NewGamePath;
+        }
 
 		private void radNewGameMyDocs_CheckedChanged(object sender, EventArgs e)
 		{
@@ -147,7 +184,9 @@ namespace AGS.Editor
 		{
 			txtNewGamePath.Enabled = radNewGameSpecificPath.Checked;
 			btnNewGameChooseFolder.Enabled = radNewGameSpecificPath.Checked;
-		}
+
+            _settings.NewGamePath = (radNewGameMyDocs.Checked ? string.Empty : txtNewGamePath.Text);
+        }
 
         private void lnkUsageInfo_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
@@ -157,6 +196,7 @@ namespace AGS.Editor
         private void chkBackupReminders_CheckedChanged(object sender, EventArgs e)
         {
             udBackupInterval.Enabled = chkBackupReminders.Checked;
+            _settings.BackupWarningInterval = (chkBackupReminders.Checked ? (int)udBackupInterval.Value : 0);
         }
 
         private void btnImportColorTheme_Click(object sender, EventArgs e)
@@ -175,5 +215,120 @@ namespace AGS.Editor
             cmbColorTheme.DataSource = null;
             cmbColorTheme.DataSource = Factory.GUIController.ColorThemes.Themes;
         }
+        
+        private void udBackupInterval_ValueChanged(object sender, EventArgs e)
+        {
+            if (chkBackupReminders.Checked) {
+                _settings.BackupWarningInterval = (int)udBackupInterval.Value;
+            }
+        }
+
+        private void udTabWidth_ValueChanged(object sender, EventArgs e)
+        {
+            _settings.TabSize = Convert.ToInt32(udTabWidth.Value);
+        }
+
+        private void chkAlwaysShowViewPreview_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.ShowViewPreviewByDefault = chkAlwaysShowViewPreview.Checked;
+        }
+
+
+        private void chkUsageInfo_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.SendAnonymousStats = chkUsageInfo.Checked;
+        }
+
+        private void chkRemapBgImport_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.RemapPalettizedBackgrounds = chkRemapBgImport.Checked;
+        }
+
+        private void chkKeepHelpOnTop_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.KeepHelpOnTop = chkKeepHelpOnTop.Checked;
+        }
+
+        private void chkPromptDialogOnTabsClose_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.DialogOnMultipleTabsClose = chkPromptDialogOnTabsClose.Checked;
+        }
+
+        private void cmbTestGameStyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newIndex = (TestGameWindowStyle)((ComboBox)sender).SelectedIndex;
+            if (_settings.TestGameWindowStyle != newIndex)
+            {
+                _settings.TestGameWindowStyle = newIndex;
+            }
+        }
+
+        private void cmbEditorStartup_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newIndex = (StartupPane)((ComboBox)sender).SelectedIndex;
+            if (_settings.StartupPane != newIndex)
+            {
+                _settings.StartupPane = newIndex;
+            }
+        }
+
+        private void cmbMessageOnCompile_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newIndex = (MessageBoxOnCompile)((ComboBox)sender).SelectedIndex;
+            if (_settings.MessageBoxOnCompile != newIndex)
+            {
+                _settings.MessageBoxOnCompile = newIndex;
+            }
+        }
+
+        private void cmbIndentStyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            bool newIndentStyle = (cmbIndentStyle.SelectedIndex == 1);
+            if (_settings.IndentUseTabs != newIndentStyle)
+            {
+                _settings.IndentUseTabs = newIndentStyle;
+            }
+        }
+        private void cmbSpriteImportTransparency_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newIndex = (SpriteImportMethod)((ComboBox)sender).SelectedIndex;
+            if (_settings.SpriteImportMethod != newIndex)
+            {
+                _settings.SpriteImportMethod = newIndex;
+            }
+
+        }
+
+        private void cmbScriptReloadOnExternalChange_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newIndex = (ReloadScriptOnExternalChange)((ComboBox)sender).SelectedIndex;
+            if(_settings.ReloadScriptOnExternalChange != newIndex)
+            {
+                _settings.ReloadScriptOnExternalChange = newIndex;
+            }
+        }
+
+        private void cmbColorTheme_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            string newColorTheme = ((ColorTheme)cmbColorTheme.SelectedItem).Name;
+            if (_settings.ColorTheme != newColorTheme)
+            {
+                _settings.ColorTheme = newColorTheme;
+            }
+        }
+
+        private void tabControl1_Selected(object sender, TabControlEventArgs e)
+        {
+            TabControl tc = (TabControl)sender;
+            if (tc.SelectedTab != this.tabPageLast)
+            {
+                UpdateControlsForPreferences();
+            }
+            else
+            {
+                this.propertyGridPreferences.Refresh();
+            }
+        }
+
     }
 }

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -310,10 +310,13 @@ namespace AGS.Editor
 
         private void cmbColorTheme_SelectedIndexChanged(object sender, EventArgs e)
         {
-            string newColorTheme = ((ColorTheme)cmbColorTheme.SelectedItem).Name;
-            if (_settings.ColorTheme != newColorTheme)
+            ColorTheme newColorTheme = (ColorTheme)cmbColorTheme.SelectedItem;
+
+            if (newColorTheme == null) return;
+
+            if (_settings.ColorTheme != newColorTheme.Name)
             {
-                _settings.ColorTheme = newColorTheme;
+                _settings.ColorTheme = newColorTheme.Name;
             }
         }
 


### PR DESCRIPTION
![property_grid_preferences](https://user-images.githubusercontent.com/2244442/150656808-b4f6801a-6100-45cb-8c5f-892ceb22c144.gif)

This change modifies the Editor Preferences, it adds a tabbed panel, and allows modifying the settings using a Property Grid. For now all properties available in the Advanced tab are available elsewhere. The idea is that should we need to add a preference, we can add there more easily.

The way it works, is the EditorPreferences has some properties that are hidden using `[Browseable(false)]`, we also copy it when the preferences window is loaded. Any changes modifies this copy. When the user click ok, the values of the properties of this now modified copy is applied to the actual app settings (preferences).

I am not too sure on the names of the tab panels.

Fix #1477 