### PR TITLE
3.6.0: implement audio playback speed using resampling

### DIFF
--- a/Engine/media/audio/audio_core.cpp
+++ b/Engine/media/audio/audio_core.cpp
@@ -206,12 +206,12 @@ void audio_core_set_master_volume(float newvol)
 void audio_core_slot_configure(int slot_handle, float volume, float speed, float panning)
 {
     ALuint source_ = g_acore.slots_[slot_handle]->source_;
+    auto &player = g_acore.slots_[slot_handle]->decoder_;
 
     alSourcef(source_, AL_GAIN, volume*0.7f);
     dump_al_errors();
 
-    alSourcef(source_, AL_PITCH, speed);
-    dump_al_errors();
+    player.SetSpeed(speed);
 
     if (panning != 0.0f) {
         // https://github.com/kcat/openal-soft/issues/194

--- a/Engine/media/audio/openaldecoder.h
+++ b/Engine/media/audio/openaldecoder.h
@@ -22,6 +22,7 @@
 #ifndef __AGS_EE_MEDIA__OPENALDECODER_H
 #define __AGS_EE_MEDIA__OPENALDECODER_H
 #include <future>
+#include <deque>
 #include <SDL_sound.h>
 #include "media/audio/audiodefines.h"
 #include "media/audio/openal.h"
@@ -102,8 +103,20 @@ private:
     float onLoadPositionMs = 0.0f;
     bool EOS_ = false;
     float processedBuffersDurationMs_ = 0.0f;
+    float lastPosReport = 0.f; // to fixup reported position, in case speed changes
 
-    static float buffer_duration_ms(ALuint bufferID);
+    // Keeping record of some precalculated buffer properties
+    struct BufferParams
+    {
+        float AlTime = 0.f; // buffer time in internal openal's rate (in seconds)
+        float Speed = 0.f; // associated playback speed
+        float Time = 0.f; // buffer time in the real playback rate (speed-adjusted)
+        BufferParams() = default;
+        BufferParams(float t, float sp) : AlTime(t), Speed(sp), Time(t * sp) {}
+    };
+    // playback speeds related to queued buffers
+    std::deque<BufferParams> bufferRecords;
+
     static ALenum openalFormatFromSample(const SoundSampleUniquePtr &sample);
     void DecoderUnqueueProcessedBuffers();
     void PollBuffers();


### PR DESCRIPTION
Fixes #1503.

It's unclear whether AL_PITCH attribute in OpenAL actually means playback speed or not, the available specification is not clear about this, and in the mojoAL implementation we're using AL_PITCH scales the sample pitch but not the frequency, therefore speed stays the same.

This PR implements playback speed by resampling a portion of sound before we pass it into OpenAL. The result should be equivalent to pre-3.6.0 functionality where the dynamic frequency shift was supported by allegro 4.

So far the only problem I experienced was with calculating playback position, as we no longer may rely only on offset time the OpenAL reports. This is solved by keeping a record of speed and "sped up" time per each queued buffer, and applying these as the buffers are processed.
There's still some mistake which I was not able to track down to the end, which causes the calculated position jump *back* a little when the speed is changed from high to low (or maybe vice versa too, but that's harder to notice). To avoid confusing game scripts would they rely on sound pos, the audio player remembers last reported position and clamps new calculated value to it.

But it's still best to test this more to ensure that the position matches (or is at least close enough to) the original un-sped playback, and that it reaches the full duration in the end.