### PR TITLE
Script API: settable Hotspot.Name and Object.Name

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -144,7 +144,8 @@ enum GameDataVersion
     kGameVersion_350            = 50,
     kGameVersion_360            = 3060000,
     kGameVersion_360_11         = 3060011,
-    kGameVersion_Current        = kGameVersion_360_11
+    kGameVersion_360_16         = 3060016,
+    kGameVersion_Current        = kGameVersion_360_16
 };
 
 // Data format version of the loaded game

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -178,13 +178,7 @@ void RoomStruct::InitDefaults()
     MessageCount    = 0;
 
     for (size_t i = 0; i < (size_t)MAX_ROOM_HOTSPOTS; ++i)
-    {
         Hotspots[i] = RoomHotspot();
-        if (i == 0)
-            Hotspots[i].Name = "No hotspot";
-        else
-            Hotspots[i].Name.Format("Hotspot %zu", i);
-    }
     for (size_t i = 0; i < (size_t)MAX_ROOM_OBJECTS; ++i)
         Objects[i] = RoomObjectInfo();
     for (size_t i = 0; i < (size_t)MAX_ROOM_REGIONS; ++i)

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1881,8 +1881,8 @@ builtin managed struct Hotspot {
   import attribute bool Enabled;
   /// Gets the ID of the hotspot.
   readonly import attribute int ID;
-  /// Gets the name of the hotspot.
-  readonly import attribute String Name;
+  /// Gets/sets the name of the hotspot.
+  import attribute String Name;
   /// Gets the X co-ordinate of the walk-to point for this hotspot.
   readonly import attribute int WalkToX;
   /// Gets the Y co-ordinate of the walk-to point for this hotspot.
@@ -2285,8 +2285,8 @@ builtin managed struct Object {
   readonly import attribute int  Loop;
   /// Gets whether the object is currently moving.
   readonly import attribute bool Moving;
-  /// Gets the object's description.
-  readonly import attribute String Name;
+  /// Gets/sets the name of the object.
+  import attribute String Name;
   /// Gets/sets whether other objects and characters can move through this object.
   import attribute bool Solid;
   /// Gets/sets the object's transparency.

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -82,8 +82,6 @@ namespace AGS.Types
             {
                 RoomHotspot hotspot = new RoomHotspot(this);
                 hotspot.ID = i;
-                if (i == 0) hotspot.Description = "No hotspot";
-                else hotspot.Description = "Hotspot " + i;
                 _hotspots.Add(hotspot);
             }
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -15,7 +15,6 @@
 // AGS Character functions
 //
 //=============================================================================
-
 #include "ac/character.h"
 #include "ac/common.h"
 #include "ac/gamesetupstruct.h"
@@ -1404,6 +1403,7 @@ const char* Character_GetName(CharacterInfo *chaa) {
 void Character_SetName(CharacterInfo *chaa, const char *newName) {
     strncpy(chaa->name, newName, 40);
     chaa->name[39] = 0;
+    GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
 int Character_GetNormalView(CharacterInfo *chaa) {

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -611,7 +611,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
     // on object
     if (loctype == LOCTYPE_OBJ) {
         aa = getloctype_index;
-        strcpy(tempo,get_translation(thisroom.Objects[aa].Name.GetCStr()));
+        strcpy(tempo,get_translation(croom->obj[aa].name.GetCStr()));
         // Compatibility: < 3.1.1 games returned space for nameless object
         // (presumably was a bug, but fixing it affected certain games behavior)
         if (loaded_game_file_version < kGameVersion_311 && tempo[0] == 0) {
@@ -624,7 +624,7 @@ void GetLocationName(int xxx,int yyy,char*tempo) {
         return;
     }
     onhs = getloctype_index;
-    if (onhs>0) strcpy(tempo,get_translation(thisroom.Hotspots[onhs].Name.GetCStr()));
+    if (onhs>0) strcpy(tempo,get_translation(croom->hotspot[onhs].Name.GetCStr()));
     if (play.get_loc_name_last_time != onhs)
         GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
     play.get_loc_name_last_time = onhs;

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -40,14 +40,14 @@ extern GameSetupStruct game;
 void DisableHotspot(int hsnum) {
     if ((hsnum<1) | (hsnum>=MAX_ROOM_HOTSPOTS))
         quit("!DisableHotspot: invalid hotspot specified");
-    croom->hotspot_enabled[hsnum]=0;
+    croom->hotspot[hsnum].Enabled = false;
     debug_script_log("Hotspot %d disabled", hsnum);
 }
 
 void EnableHotspot(int hsnum) {
     if ((hsnum<1) | (hsnum>=MAX_ROOM_HOTSPOTS))
         quit("!EnableHotspot: invalid hotspot specified");
-    croom->hotspot_enabled[hsnum]=1;
+    croom->hotspot[hsnum].Enabled = true;
     debug_script_log("Hotspot %d re-enabled", hsnum);
 }
 
@@ -82,7 +82,7 @@ void GetHotspotName(int hotspot, char *buffer) {
     if ((hotspot < 0) || (hotspot >= MAX_ROOM_HOTSPOTS))
         quit("!GetHotspotName: invalid hotspot number");
 
-    strcpy(buffer, get_translation(thisroom.Hotspots[hotspot].Name.GetCStr()));
+    strcpy(buffer, get_translation(croom->hotspot[hotspot].Name.GetCStr()));
 }
 
 void RunHotspotInteraction (int hotspothere, int mood) {

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -395,7 +395,7 @@ void GetObjectName(int obj, char *buffer) {
     if (!is_valid_object(obj))
         quit("!GetObjectName: invalid object number");
 
-    strcpy(buffer, get_translation(thisroom.Objects[obj].Name.GetCStr()));
+    strcpy(buffer, get_translation(croom->obj[obj].name.GetCStr()));
 }
 
 void MoveObject(int objj,int xx,int yy,int spp) {

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -11,8 +11,8 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "ac/dynobj/cc_hotspot.h"
+#include "ac/common.h"
 #include "ac/hotspot.h"
 #include "ac/gamestate.h"
 #include "ac/global_hotspot.h"
@@ -40,7 +40,7 @@ void Hotspot_SetEnabled(ScriptHotspot *hss, int newval) {
 }
 
 int Hotspot_GetEnabled(ScriptHotspot *hss) {
-    return croom->hotspot_enabled[hss->id];
+    return croom->hotspot[hss->id].Enabled ? 1 : 0;
 }
 
 int Hotspot_GetID(ScriptHotspot *hss) {
@@ -68,7 +68,15 @@ void Hotspot_GetName(ScriptHotspot *hss, char *buffer) {
 }
 
 const char* Hotspot_GetName_New(ScriptHotspot *hss) {
-    return CreateNewScriptString(get_translation(thisroom.Hotspots[hss->id].Name.GetCStr()));
+    if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
+        quit("!Hotspot.Name: invalid hotspot number");
+    return CreateNewScriptString(get_translation(croom->hotspot[hss->id].Name.GetCStr()));
+}
+
+void Hotspot_SetName(ScriptHotspot *hss, const char *newName) {
+    if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
+        quit("!Hotspot.Name: invalid hotspot number");
+    croom->hotspot[hss->id].Name = newName;
 }
 
 bool Hotspot_IsInteractionAvailable(ScriptHotspot *hhot, int mood) {
@@ -113,7 +121,7 @@ bool Hotspot_SetTextProperty(ScriptHotspot *hss, const char *property, const cha
 int get_hotspot_at(int xpp,int ypp) {
     int onhs=thisroom.HotspotMask->GetPixel(room_to_mask_coord(xpp), room_to_mask_coord(ypp));
     if (onhs <= 0 || onhs >= MAX_ROOM_HOTSPOTS) return 0;
-    if (croom->hotspot_enabled[onhs]==0) return 0;
+    if (!croom->hotspot[onhs].Enabled) return 0;
     return onhs;
 }
 
@@ -216,6 +224,11 @@ RuntimeScriptValue Sc_Hotspot_GetName_New(void *self, const RuntimeScriptValue *
     API_OBJCALL_OBJ(ScriptHotspot, const char, myScriptStringImpl, Hotspot_GetName_New);
 }
 
+RuntimeScriptValue Sc_Hotspot_SetName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ(ScriptHotspot, Hotspot_SetName, const char);
+}
+
 // int (ScriptHotspot *hss)
 RuntimeScriptValue Sc_Hotspot_GetWalkToX(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -247,6 +260,7 @@ void RegisterHotspotAPI()
     ccAddExternalObjectFunction("Hotspot::set_Enabled",         Sc_Hotspot_SetEnabled);
     ccAddExternalObjectFunction("Hotspot::get_ID",              Sc_Hotspot_GetID);
     ccAddExternalObjectFunction("Hotspot::get_Name",            Sc_Hotspot_GetName_New);
+    ccAddExternalObjectFunction("Hotspot::set_Name",            Sc_Hotspot_SetName);
     ccAddExternalObjectFunction("Hotspot::get_WalkToX",         Sc_Hotspot_GetWalkToX);
     ccAddExternalObjectFunction("Hotspot::get_WalkToY",         Sc_Hotspot_GetWalkToY);
 

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -23,6 +23,7 @@
 #include "ac/string.h"
 #include "game/roomstruct.h"
 #include "gfx/bitmap.h"
+#include "gui/guimain.h"
 #include "script/runtimescriptvalue.h"
 
 using namespace AGS::Common;
@@ -77,6 +78,7 @@ void Hotspot_SetName(ScriptHotspot *hss, const char *newName) {
     if ((hss->id < 0) || (hss->id >= MAX_ROOM_HOTSPOTS))
         quit("!Hotspot.Name: invalid hotspot number");
     croom->hotspot[hss->id].Name = newName;
+    GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
 bool Hotspot_IsInteractionAvailable(ScriptHotspot *hhot, int mood) {

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -288,7 +288,13 @@ const char* Object_GetName_New(ScriptObject *objj) {
     if (!is_valid_object(objj->id))
         quit("!Object.Name: invalid object number");
 
-    return CreateNewScriptString(get_translation(thisroom.Objects[objj->id].Name.GetCStr()));
+    return CreateNewScriptString(get_translation(croom->obj[objj->id].name.GetCStr()));
+}
+
+void Object_SetName(ScriptObject *objj, const char *newName) {
+    if (!is_valid_object(objj->id))
+        quit("!Object.Name: invalid object number");
+    croom->obj[objj->id].name = newName;
 }
 
 bool Object_IsInteractionAvailable(ScriptObject *oobj, int mood) {
@@ -866,6 +872,11 @@ RuntimeScriptValue Sc_Object_GetName_New(void *self, const RuntimeScriptValue *p
     API_OBJCALL_OBJ(ScriptObject, const char, myScriptStringImpl, Object_GetName_New);
 }
 
+RuntimeScriptValue Sc_Object_SetName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_POBJ(ScriptObject, Object_SetName, const char);
+}
+
 RuntimeScriptValue Sc_Object_GetScaling(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptObject, Object_GetScaling);
@@ -994,6 +1005,7 @@ void RegisterObjectAPI()
     ccAddExternalObjectFunction("Object::set_ManualScaling",        Sc_Object_SetManualScaling);
     ccAddExternalObjectFunction("Object::get_Moving",               Sc_Object_GetMoving);
     ccAddExternalObjectFunction("Object::get_Name",                 Sc_Object_GetName_New);
+    ccAddExternalObjectFunction("Object::set_Name",                 Sc_Object_SetName);
     ccAddExternalObjectFunction("Object::get_Scaling",              Sc_Object_GetScaling);
     ccAddExternalObjectFunction("Object::set_Scaling",              Sc_Object_SetScaling);
     ccAddExternalObjectFunction("Object::get_Solid",                Sc_Object_GetSolid);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -29,6 +29,7 @@
 #include "ac/view.h"
 #include "ac/walkablearea.h"
 #include "debug/debug_log.h"
+#include "gui/guimain.h"
 #include "main/game_run.h"
 #include "ac/route_finder.h"
 #include "gfx/graphicsdriver.h"
@@ -295,6 +296,7 @@ void Object_SetName(ScriptObject *objj, const char *newName) {
     if (!is_valid_object(objj->id))
         quit("!Object.Name: invalid object number");
     croom->obj[objj->id].name = newName;
+    GUI::MarkSpecialLabelsForUpdate(kLabelMacro_Overhotspot);
 }
 
 bool Object_IsInteractionAvailable(ScriptObject *oobj, int mood) {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -624,6 +624,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
             croom->obj[cc].last_height = 0;
             croom->obj[cc].blocking_width = 0;
             croom->obj[cc].blocking_height = 0;
+            croom->obj[cc].name = thisroom.Objects[cc].Name;
             if (thisroom.Objects[cc].Baseline>=0)
                 croom->obj[cc].baseline=thisroom.Objects[cc].Baseline;
             if (thisroom.Objects[cc].Sprite > UINT16_MAX)
@@ -642,7 +643,8 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
         croom->objcond[cc]=thisroom.objcond[cc];*/
 
         for (cc=0;cc < MAX_ROOM_HOTSPOTS;cc++) {
-            croom->hotspot_enabled[cc] = 1;
+            croom->hotspot[cc].Enabled = true;
+            croom->hotspot[cc].Name = thisroom.Hotspots[cc].Name;
         }
         for (cc = 0; cc < MAX_ROOM_REGIONS; cc++) {
             croom->region_enabled[cc] = 1;

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -22,6 +22,7 @@
 #include "main/update.h"
 #include "util/math.h"
 #include "util/stream.h"
+#include "util/string_utils.h"
 
 using namespace AGS::Common;
 
@@ -154,7 +155,7 @@ void RoomObject::update_cycle_view_backwards()
       }
 }
 
-void RoomObject::ReadFromFile(Stream *in)
+void RoomObject::ReadFromSavegame(Stream *in, int save_ver)
 {
     x = in->ReadInt32();
     y = in->ReadInt32();
@@ -180,9 +181,13 @@ void RoomObject::ReadFromFile(Stream *in)
     flags = in->ReadInt8();
     blocking_width = in->ReadInt16();
     blocking_height = in->ReadInt16();
+    if (save_ver > 0)
+    {
+        name = StrUtil::ReadString(in);
+    }
 }
 
-void RoomObject::WriteToFile(Stream *out) const
+void RoomObject::WriteToSavegame(Stream *out) const
 {
     out->WriteInt32(x);
     out->WriteInt32(y);
@@ -208,4 +213,5 @@ void RoomObject::WriteToFile(Stream *out) const
     out->WriteInt8(flags);
     out->WriteInt16(blocking_width);
     out->WriteInt16(blocking_height);
+    StrUtil::WriteString(name, out);
 }

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -20,6 +20,7 @@
 
 #include "core/types.h"
 #include "ac/common_defines.h"
+#include "util/string.h"
 
 namespace AGS { namespace Common { class Stream; }}
 using namespace AGS; // FIXME later
@@ -43,7 +44,9 @@ struct RoomObject {
     char  overall_speed;
     char  on;
     char  flags;
+    // Down to here is a part of the plugin API
     short blocking_width, blocking_height;
+    Common::String name;
 
     RoomObject();
 
@@ -58,8 +61,8 @@ struct RoomObject {
 	void update_cycle_view_forwards();
 	void update_cycle_view_backwards();
 
-    void ReadFromFile(Common::Stream *in);
-    void WriteToFile(Common::Stream *out) const;
+    void ReadFromSavegame(Common::Stream *in, int save_ver);
+    void WriteToSavegame(Common::Stream *out) const;
 };
 
 #endif // __AGS_EE_AC__ROOMOBJECT_H

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -11,10 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-//
-//
-//
-//=============================================================================
 #ifndef __AGS_EE_AC__ROOMSTATUS_H
 #define __AGS_EE_AC__ROOMSTATUS_H
 
@@ -27,6 +23,15 @@
 namespace AGS { namespace Common { class Stream; } }
 using AGS::Common::Stream;
 using AGS::Common::Interaction;
+
+struct HotspotState
+{
+    bool Enabled = false;
+    Common::String Name;
+
+    void ReadFromSavegame(Common::Stream *in, int save_ver);
+    void WriteToSavegame(Common::Stream *out) const;
+};
 
 // This struct is saved in the save games - it contains everything about
 // a room that could change
@@ -51,7 +56,7 @@ struct RoomStatus {
     EventBlock objcond[MAX_ROOM_OBJECTS];
     EventBlock misccond;
 #endif
-    char  hotspot_enabled[MAX_ROOM_HOTSPOTS];
+    HotspotState hotspot[MAX_ROOM_HOTSPOTS];
     char  region_enabled[MAX_ROOM_REGIONS];
     short walkbehind_base[MAX_WALK_BEHINDS];
     int   interactionVariableValues[MAX_GLOBAL_VARIABLES];
@@ -64,7 +69,7 @@ struct RoomStatus {
 
     void ReadFromFile_v321(Common::Stream *in);
     void ReadRoomObjects_Aligned(Common::Stream *in);
-    void ReadFromSavegame(Common::Stream *in);
+    void ReadFromSavegame(Common::Stream *in, int save_ver);
     void WriteToSavegame(Common::Stream *out) const;
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -990,7 +990,7 @@ HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, const PreservedParams &pp
             if (!AssertFormatTagStrict(err, in, "RoomState", true))
                 return err;
             RoomStatus *roomstat = getRoomStatus(id);
-            roomstat->ReadFromSavegame(in);
+            roomstat->ReadFromSavegame(in, cmp_ver);
             if (!AssertFormatTagStrict(err, in, "RoomState", false))
                 return err;
         }
@@ -1083,7 +1083,7 @@ HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, const PreservedParams &pp, 
         return err;
     for (int i = 0; i < objmls_count; ++i)
     {
-        err = mls[i].ReadFromFile(in, cmp_ver > 0 ? 1 : 0);
+        err = mls[i].ReadFromFile(in, cmp_ver > 0 ? 1 : 0); // FIXME!!
         if (!err)
             return err;
     }
@@ -1093,7 +1093,7 @@ HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, const PreservedParams &pp, 
 
     // read the current troom state, in case they saved in temporary room
     if (!in->ReadBool())
-        troom.ReadFromSavegame(in);
+        troom.ReadFromSavegame(in, cmp_ver > 1 ? 1 : 0); // FIXME!!
 
     return HSaveError::None();
 }
@@ -1232,14 +1232,14 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Room States",
-        0,
+        1,
         0,
         WriteRoomStates,
         ReadRoomStates
     },
     {
         "Loaded Room State",
-        1,
+        2,
         0,
         WriteThisRoom,
         ReadThisRoom


### PR DESCRIPTION
Resolves #979.

Hotspot and Object.Name property can now be set from script.

Any internal engine's action retrieving an object or hotspot's name should be using current name from the RoomStatus, rather than the default name from the room file.

These properties are now saved when the game is saved.