### PR TITLE
New compiler: Fix some bugs in constant handling

### DIFF
--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -567,7 +567,7 @@ TEST_F(Bytecode0, FlowIfThenElse2) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, While) {
+TEST_F(Bytecode0, FlowWhile) {
 
     char *inpl = "\
     char c = 'x';             \n\
@@ -586,7 +586,7 @@ TEST_F(Bytecode0, While) {
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("While", scrip);
+    // WriteOutput("FlowWhile", scrip);
     size_t const codesize = 100;
     EXPECT_EQ(codesize, scrip.codesize);
 
@@ -617,6 +617,95 @@ TEST_F(Bytecode0, While) {
       1,   1,   1,   1,     '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode0, FlowWhileTrue)
+{
+    // Mustn't short-circuit the 'while()' body
+
+    char *inpl = "\n\
+        enum bool { false = 0, true }; \n\
+        int main()          \n\
+        {                   \n\
+            while (true)    \n\
+            {               \n\
+                int i = 5;  \n\
+            }               \n\
+        }                   \n\
+        ";
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("FlowWhileTrue", scrip);
+    size_t const codesize = 16;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            5,   29,    3,    2,    // 7
+       1,    4,   31,  -10,            6,    3,    0,    5,    // 15
+     -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode0, FlowDoWhileFalse)
+{
+    // Don't emit back jump
+
+    char *inpl = "\n\
+        enum bool { false = 0, true }; \n\
+        int main()              \n\
+        {                       \n\
+            do                  \n\
+            {                   \n\
+                int i = 5;      \n\
+                continue;       \n\
+            } while (false);    \n\
+        }                       \n\
+        ";
+    int compileResult = cc_compile(inpl, scrip);
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("FlowDoWhileFalse", scrip);
+    size_t const codesize = 19;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      38,    0,    6,    3,            5,   29,    3,    2,    // 7
+       1,    4,   31,  -10,            2,    1,    4,    6,    // 15
+       3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
 
     int const numimports = 0;
     std::string imports[] = {

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2328,3 +2328,25 @@ TEST_F(Compile1, ReachabilityAndSwitch1)
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     ASSERT_EQ(0, mh.GetMessages().size());
 }
+
+TEST_F(Compile1, IfClauseFloat)
+{
+    // Should complain that the if clause isn't vartype 'int'
+
+    char *inpl = "\
+        managed struct Strct                \n\
+        {                                   \n\
+        };                                  \n\
+                                            \n\
+        float foo()                         \n\
+        {                                   \n\
+            if (foo())                      \n\
+                return 1.0;                 \n\
+            return 0.1;                     \n\
+        }                                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'float'"));
+}


### PR DESCRIPTION
- `while (true)` should not short-circuit the `while` body
```
function game_start()
{
    int i = 5;
    while(true)
    {
        i--;
        if (i <= 0) break;
    }
    if (i ==  5)
        AbortGame("'while' was short-circuited");
}
```

- `do … while (false)` should not have a jump back to the start of the `do`

Can't really test that except by examining the generated code: If there __is__ a jump back to the start of the do, it won't ever be executed because the `do while` condition is `false`.

- `if (expr)` should ensure that type of the condition is `int`
```
float TestFunc()
{
    if (TestFunc()) // ← Should not compile
        return 7.0;
    return 0.0;
}
```