### PR TITLE
Script API: added Character.IdleAnimationDelay and Cursor.AnimationDelay

### DIFF
--- a/Common/ac/characterinfo.cpp
+++ b/Common/ac/characterinfo.cpp
@@ -11,9 +11,9 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
-#include <string.h>
 #include "ac/characterinfo.h"
+#include <string.h>
+#include "ac/game_version.h"
 #include "util/stream.h"
 
 using AGS::Common::Stream;
@@ -49,7 +49,7 @@ void CharacterInfo::ReadFromFile(Stream *in)
     z = in->ReadInt32();
     walkwait = in->ReadInt32();
     speech_anim_speed = in->ReadInt16();
-    reserved1 = in->ReadInt16();
+    idle_anim_speed = in->ReadInt16();
     blocking_width = in->ReadInt16();
     blocking_height = in->ReadInt16();;
     index_id = in->ReadInt32();
@@ -67,6 +67,9 @@ void CharacterInfo::ReadFromFile(Stream *in)
     in->Read(name, 40);
     in->Read(scrname, MAX_SCRIPT_NAME_LEN);
     on = in->ReadInt8();
+
+    if (loaded_game_file_version < kGameVersion_360_16)
+        idle_anim_speed = animspeed + 5;
 }
 
 void CharacterInfo::WriteToFile(Stream *out)
@@ -99,7 +102,7 @@ void CharacterInfo::WriteToFile(Stream *out)
     out->WriteInt32(z);
     out->WriteInt32(walkwait);
     out->WriteInt16(speech_anim_speed);
-    out->WriteInt16(reserved1);
+    out->WriteInt16(idle_anim_speed);
     out->WriteInt16(blocking_width);
     out->WriteInt16(blocking_height);;
     out->WriteInt32(index_id);

--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -47,8 +47,10 @@ using namespace AGS; // FIXME later
 #define FOLLOW_ALWAYSONTOP  0x7ffe
 
 struct CharacterExtras; // forward declaration
-// remember - if change this struct, also change AGSDEFNS.SH and
-// plugin header file struct
+// IMPORTANT: exposed to script API, and plugin API as AGSCharacter!
+// For older script compatibility the struct also has to maintain its size;
+// do not extend or change existing fields, unless planning breaking compatibility.
+// Use CharacterExtras struct for any extensions.
 struct CharacterInfo {
     int   defview;
     int   talkview;
@@ -71,7 +73,7 @@ struct CharacterInfo {
     short pic_yoffs; // this is fixed in screen coordinates
     int   z;    // z-location, for flying etc
     int   walkwait;
-    short speech_anim_speed, reserved1;  // only 1 reserved left!!
+    short speech_anim_speed, idle_anim_speed;
     short blocking_width, blocking_height;
     int   index_id;  // used for object functions to know the id
     short pic_xoffs; // this is fixed in screen coordinates

--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -144,7 +144,8 @@ enum GameDataVersion
     kGameVersion_350            = 50,
     kGameVersion_360            = 3060000,
     kGameVersion_360_11         = 3060011,
-    kGameVersion_Current        = kGameVersion_360_11
+    kGameVersion_360_16         = 3060016,
+    kGameVersion_Current        = kGameVersion_360_16
 };
 
 // Data format version of the loaded game

--- a/Common/ac/mousecursor.cpp
+++ b/Common/ac/mousecursor.cpp
@@ -17,8 +17,6 @@
 
 using AGS::Common::Stream;
 
-MouseCursor::MouseCursor() { pic = 2054; hotx = 0; hoty = 0; name[0] = 0; flags = 0; view = -1; }
-
 void MouseCursor::ReadFromFile(Stream *in)
 {
     pic = in->ReadInt32();
@@ -39,13 +37,15 @@ void MouseCursor::WriteToFile(Stream *out)
     out->WriteInt8(flags);
 }
 
-void MouseCursor::ReadFromSavegame(Stream *in)
+void MouseCursor::ReadFromSavegame(Stream *in, int cmp_ver)
 {
     pic = in->ReadInt32();
     hotx = in->ReadInt32();
     hoty = in->ReadInt32();
     view = in->ReadInt32();
     flags = in->ReadInt32();
+    if (cmp_ver > 0)
+        animdelay = in->ReadInt32();
 }
 
 void MouseCursor::WriteToSavegame(Stream *out) const
@@ -55,4 +55,5 @@ void MouseCursor::WriteToSavegame(Stream *out) const
     out->WriteInt32(hoty);
     out->WriteInt32(view);
     out->WriteInt32(flags);
+    out->WriteInt32(animdelay);
 }

--- a/Common/ac/mousecursor.h
+++ b/Common/ac/mousecursor.h
@@ -22,18 +22,23 @@ using namespace AGS; // FIXME later
 #define MCF_DISABLED 2
 #define MCF_STANDARD 4
 #define MCF_HOTSPOT  8  // only animate when over hotspot
-// this struct is also in the plugin header file
+// IMPORTANT: exposed to plugin API as AGSCursor!
+// do not change topmost fields, unless planning breaking compatibility.
 struct MouseCursor {
-    int   pic;
-    short hotx, hoty;
-    short view;
-    char  name[10];
-    char  flags;
-    MouseCursor();
+    int   pic = 0;
+    short hotx = 0, hoty = 0;
+    short view = -1;
+    char  name[10]{};
+    char  flags = 0;
+
+    // up to here is a part of plugin API
+    int   animdelay = 5;
+
+    MouseCursor() = default;
 
     void ReadFromFile(Common::Stream *in);
     void WriteToFile(Common::Stream *out);
-    void ReadFromSavegame(Common::Stream *in);
+    void ReadFromSavegame(Common::Stream *in, int cmp_ver);
     void WriteToSavegame(Common::Stream *out) const;
 };
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -823,6 +823,18 @@ HError GameDataExtReader::ReadBlock(int block_id, const String &ext_id,
         }
         return HError::None();
     }
+    else if (ext_id.CompareNoCase("v360_cursors") == 0)
+    {
+        for (int i = 0; i < _ents.Game.numcursors; ++i)
+        {
+            _ents.Game.mcurs[i].animdelay = _in->ReadInt32();
+            // reserved
+            _in->ReadInt32();
+            _in->ReadInt32();
+            _in->ReadInt32();
+        }
+        return HError::None();
+    }
     return new MainGameFileError(kMGFErr_ExtUnknown, String::FromFormat("Type: %s", ext_id.GetCStr()));
 }
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -94,7 +94,7 @@ namespace AGS.Editor
          * --------------------------------------------------------------------
          * 3.6.0          - Settings.CustomDataDir, TTFHeightDefinedBy, TTFMetricsFixup;
          *                - Font.AutoOutlineStyle, AutoOutlineThickness;
-         *                - Character.IdleDelay
+         *                - Character.IdleDelay, Character.IdleAnimationDelay;
          *                - RuntimeSetup.FullscreenDesktop
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060000;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -95,6 +95,7 @@ namespace AGS.Editor
          * 3.6.0          - Settings.CustomDataDir, TTFHeightDefinedBy, TTFMetricsFixup;
          *                - Font.AutoOutlineStyle, AutoOutlineThickness;
          *                - Character.IdleDelay, Character.IdleAnimationDelay;
+         *                - Cursor.AnimationDelay
          *                - RuntimeSetup.FullscreenDesktop
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060000;

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1764,6 +1764,7 @@ namespace AGS.Editor
             // of type WriteExtensionProc that does the actual writing job.
 
             WriteExtension("v360_fonts", WriteExt_360Fonts, writer, game, errors);
+            WriteExtension("v360_cursors", WriteExt_360Cursors, writer, game, errors);
 
             // End of extensions list
             writer.Write((byte)0xff);
@@ -1773,7 +1774,7 @@ namespace AGS.Editor
             return true;
         }
 
-        // 3.6.0: font outline properties
+        // >= 3.6.0: font outline properties
         private static void WriteExt_360Fonts(BinaryWriter writer, Game game, CompileMessages errors)
         {
             // adjustable font outlines
@@ -1783,6 +1784,20 @@ namespace AGS.Editor
                 writer.Write((int)game.Fonts[i].AutoOutlineStyle);
                 // reserved ints
                 writer.Write((int)0);
+                writer.Write((int)0);
+                writer.Write((int)0);
+                writer.Write((int)0);
+            }
+        }
+
+        // >= 3.6.0: extended cursor properties
+        private static void WriteExt_360Cursors(BinaryWriter writer, Game game, CompileMessages errors)
+        {
+            // adjustable font outlines
+            for (int i = 0; i < game.Cursors.Count; ++i)
+            {
+                writer.Write((int)game.Cursors[i].AnimationDelay);
+                // reserved ints
                 writer.Write((int)0);
                 writer.Write((int)0);
                 writer.Write((int)0);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1593,7 +1593,7 @@ namespace AGS.Editor
                 writer.Write(0);                                       // z
                 writer.Write(0);                                       // walkwait
                 writer.Write((short)character.SpeechAnimationDelay);   // speech_anim_speed
-                writer.Write((short)0);                                // reserved1
+                writer.Write((short)character.IdleAnimationDelay);     // idle_anim_speed
                 writer.Write((short)0);                                // blocking_width
                 writer.Write((short)0);                                // blocking_height
                 writer.Write(0);                                       // index_id

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -791,7 +791,7 @@ struct Mouse {
   /// Changes the active hotspot for the specified mouse cursor.
   import static void ChangeModeHotspot(CursorMode, int x, int y);
   /// Changes the view used to animate the specified mouse cursor.
-  import static void ChangeModeView(CursorMode, int view);
+  import static void ChangeModeView(CursorMode, int view, int delay = SCR_NO_VALUE);
   /// Disables the specified cursor mode.
   import static void DisableMode(CursorMode);
   /// Re-enables the specified cursor mode.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2590,6 +2590,10 @@ builtin managed struct Character {
   /// Returns the character at the specified position within this room.
   import static Character* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
 #endif
+#ifdef SCRIPT_API_v360
+  /// Gets/sets the character's idle animation delay.
+  import attribute int  IdleAnimationDelay;
+#endif
 #ifdef STRICT
   /// The character's current X-position.
   import attribute int  x;

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -363,6 +363,11 @@ namespace AGS.Editor
 
             if (xmlVersionIndex < 3060000)
             {
+                foreach (Character c in game.Characters)
+                {
+                    c.IdleAnimationDelay = c.AnimationDelay + 5;
+                }
+
                 game.Settings.TTFHeightDefinedBy = FontHeightDefinition.NominalHeight;
                 game.Settings.TTFMetricsFixup = FontMetricsFixup.SetAscenderToHeight;
                 foreach (Font font in game.Fonts)

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -24,6 +24,7 @@ namespace AGS.Types
         private int _speechView;
         private int _idleView;
         private int _idleDelay = 20;
+        private int _idleAnimationDelay = 4;
         private int _thinkingView;
         private int _blinkingView;
         private int _startingRoom = 0;
@@ -120,6 +121,14 @@ namespace AGS.Types
         {
             get { return _idleDelay; }
             set { _idleDelay = value; }
+        }
+
+        [Description("Delay between changing frames whilst idle animation")]
+        [Category("Appearance")]
+        public int IdleAnimationDelay
+        {
+            get { return _idleAnimationDelay; }
+            set { _idleAnimationDelay = value; }
         }
 
         [Description("The thinking view for the character")]

--- a/Editor/AGS.Types/MouseCursor.cs
+++ b/Editor/AGS.Types/MouseCursor.cs
@@ -9,27 +9,19 @@ namespace AGS.Types
     [DefaultProperty("Image")]
     public class MouseCursor
     {
-        private string _name;
-        private bool _standardMode;
-        private int _id;
-        private int _image;
-        private int _hotspotX, _hotspotY;
-        private int _view;
-        private bool _animate;
-        private bool _animateOnlyOnHotspot;
-        private bool _animateOnlyWhenMoving;
+        private string _name = string.Empty;
+        private bool _standardMode = false;
+        private int _id = 0;
+        private int _image = 0;
+        private int _hotspotX = 0, _hotspotY = 0;
+        private int _view = 0;
+        private bool _animate = false;
+        private bool _animateOnlyOnHotspot = false;
+        private bool _animateOnlyWhenMoving = false;
+        private int _animateDelay = 5;
 
         public MouseCursor()
         {
-            _standardMode = false;
-            _name = string.Empty;
-            _image = 0;
-            _hotspotX = 0;
-            _hotspotY = 0;
-            _view = 0;
-            _animate = false;
-            _animateOnlyOnHotspot = false;
-            _animateOnlyWhenMoving = false;
         }
 
         [Description("The ID number of the cursor")]
@@ -116,6 +108,14 @@ namespace AGS.Types
         {
             get { return _animateOnlyWhenMoving; }
             set { _animateOnlyWhenMoving = value; }
+        }
+
+        [Description("Delay between changing frames whilst animating")]
+        [Category("Appearance")]
+        public int AnimationDelay
+        {
+            get { return _animateDelay; }
+            set { _animateDelay = value; }
         }
 
         [Description("The name of the cursor")]

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1140,6 +1140,8 @@ int Character_GetAnimationSpeed(CharacterInfo *chaa) {
 void Character_SetAnimationSpeed(CharacterInfo *chaa, int newval) {
 
     chaa->animspeed = newval;
+    if (loaded_game_file_version < kGameVersion_360_16)
+        chaa->idle_anim_speed = chaa->animspeed + 5;
 }
 
 int Character_GetBaseline(CharacterInfo *chaa) {
@@ -1512,6 +1514,16 @@ void Character_SetSpeechAnimationDelay(CharacterInfo *chaa, int newDelay)
     }
 
     chaa->speech_anim_speed = newDelay;
+}
+
+int Character_GetIdleAnimationDelay(CharacterInfo *chaa)
+{
+    return chaa->idle_anim_speed;
+}
+
+void Character_SetIdleAnimationDelay(CharacterInfo *chaa, int newDelay)
+{
+    chaa->idle_anim_speed = newDelay;
 }
 
 int Character_GetSpeechView(CharacterInfo *chaa) {
@@ -3668,6 +3680,17 @@ RuntimeScriptValue Sc_Character_SetSpeechAnimationDelay(void *self, const Runtim
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetSpeechAnimationDelay);
 }
 
+RuntimeScriptValue Sc_Character_GetIdleAnimationDelay(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetIdleAnimationDelay);
+}
+
+// void (CharacterInfo *chaa, int newDelay)
+RuntimeScriptValue Sc_Character_SetIdleAnimationDelay(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetIdleAnimationDelay);
+}
+
 // int (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetSpeechColor(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -3907,6 +3930,8 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
 	    ccAddExternalObjectFunction("Character::get_HasExplicitTint",       Sc_Character_GetHasExplicitTint);
 	ccAddExternalObjectFunction("Character::get_ID",                    Sc_Character_GetID);
 	ccAddExternalObjectFunction("Character::get_IdleView",              Sc_Character_GetIdleView);
+    ccAddExternalObjectFunction("Character::get_IdleAnimationDelay",    Sc_Character_GetIdleAnimationDelay);
+    ccAddExternalObjectFunction("Character::set_IdleAnimationDelay",    Sc_Character_SetIdleAnimationDelay);
 	ccAddExternalObjectFunction("Character::geti_InventoryQuantity",    Sc_Character_GetIInventoryQuantity);
 	ccAddExternalObjectFunction("Character::seti_InventoryQuantity",    Sc_Character_SetIInventoryQuantity);
 	ccAddExternalObjectFunction("Character::get_IgnoreLighting",        Sc_Character_GetIgnoreLighting);

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -373,9 +373,9 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
           }
         }
         wait = views[view].loops[loop].frames[frame].speed;
-        // idle anim doesn't have speed stored cos animating==0
+        // idle anim doesn't have speed stored cos animating==0 (TODO: investigate why?)
         if (idleleft < 0)
-          wait += animspeed+5;
+          wait += idle_anim_speed;
         else 
           wait += (animating >> 8) & 0x00ff;
 
@@ -508,10 +508,9 @@ void CharacterInfo::update_character_idle(CharacterExtras *chex, int &doing_noth
         else if (useloop >= maxLoops)
           useloop = 0;
 
-        animate_character(this,useloop,
-          animspeed+5,(idletime == 0) ? 1 : 0, 1);
+        animate_character(this, useloop, idle_anim_speed, (idletime == 0) ? 1 : 0, 1);
 
-        // don't set Animating while the idle anim plays
+        // don't set Animating while the idle anim plays (TODO: investigate why?)
         animating = 0;
       }
     }  // end do idle animation

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2516,7 +2516,7 @@ void construct_game_screen_overlay(bool draw_mouse)
             if (mouse_frame >= views[viewnum].loops[loopnum].numFrames)
                 mouse_frame = 0;
             set_new_cursor_graphic(views[viewnum].loops[loopnum].frames[mouse_frame].pic);
-            mouse_delay = views[viewnum].loops[loopnum].frames[mouse_frame].speed + 5;
+            mouse_delay = views[viewnum].loops[loopnum].frames[mouse_frame].speed + game.mcurs[cur_cursor].animdelay;
             CheckViewFrame(viewnum, loopnum, mouse_frame);
         }
         lastmx = mousex; lastmy = mousey;

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -195,13 +195,15 @@ void ChangeCursorHotspot (int curs, int x, int y) {
         set_mouse_cursor (cur_cursor);
 }
 
-void Mouse_ChangeModeView(int curs, int newview) {
+void Mouse_ChangeModeViewEx(int curs, int newview, int delay) {
     if ((curs < 0) || (curs >= game.numcursors))
         quit("!Mouse.ChangeModeView: invalid mouse cursor");
 
     newview--;
 
     game.mcurs[curs].view = newview;
+    if (delay != SCR_NO_VALUE)
+        game.mcurs[curs].animdelay = delay;
 
     if (newview >= 0)
     {
@@ -210,6 +212,10 @@ void Mouse_ChangeModeView(int curs, int newview) {
 
     if (curs == cur_cursor)
         mouse_delay = 0;  // force update
+}
+
+void Mouse_ChangeModeView(int curs, int newview) {
+    Mouse_ChangeModeViewEx(curs, newview, SCR_NO_VALUE);
 }
 
 void SetNextCursor () {
@@ -461,9 +467,14 @@ RuntimeScriptValue Sc_ChangeCursorHotspot(const RuntimeScriptValue *params, int3
 }
 
 // void (int curs, int newview)
-RuntimeScriptValue Sc_Mouse_ChangeModeView(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Mouse_ChangeModeView_2(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID_PINT2(Mouse_ChangeModeView);
+}
+
+RuntimeScriptValue Sc_Mouse_ChangeModeView(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT3(Mouse_ChangeModeViewEx);
 }
 
 // void (int modd)
@@ -600,7 +611,8 @@ void RegisterMouseAPI()
 {
     ccAddExternalStaticFunction("Mouse::ChangeModeGraphic^2",       Sc_ChangeCursorGraphic);
     ccAddExternalStaticFunction("Mouse::ChangeModeHotspot^3",       Sc_ChangeCursorHotspot);
-    ccAddExternalStaticFunction("Mouse::ChangeModeView^2",          Sc_Mouse_ChangeModeView);
+    ccAddExternalStaticFunction("Mouse::ChangeModeView^2",          Sc_Mouse_ChangeModeView_2);
+    ccAddExternalStaticFunction("Mouse::ChangeModeView^3",          Sc_Mouse_ChangeModeView);
     ccAddExternalStaticFunction("Mouse::Click^1",                   Sc_Mouse_Click);
     ccAddExternalStaticFunction("Mouse::DisableMode^1",             Sc_disable_cursor_mode);
     ccAddExternalStaticFunction("Mouse::EnableMode^1",              Sc_enable_cursor_mode);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -752,7 +752,7 @@ HSaveError ReadMouseCursors(Stream *in, int32_t cmp_ver, const PreservedParams &
         return err;
     for (int i = 0; i < game.numcursors; ++i)
     {
-        game.mcurs[i].ReadFromSavegame(in);
+        game.mcurs[i].ReadFromSavegame(in, cmp_ver);
     }
     return err;
 }
@@ -1190,7 +1190,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Mouse Cursors",
-        0,
+        1,
         0,
         WriteMouseCursors,
         ReadMouseCursors


### PR DESCRIPTION
Resolves #1517.

**1.**
Adds `Character.IdleAnimationDelay` property in the script and editor properties.
The name is complying to previously added SpeechAnimationDelay (also related property is called AnimationDelay internally in the editor, not "speed").

For older games engine assigns this property to (Character.AnimationSpeed + 5) for backward compatibility.

**2.**
Adds `Cursor.AnimationDelay` property in the editor. Added 3rd argument to `Mouse.ChangeModeView` script function, now function is:
`void ChangeModeView(CursorMode, int view, int delay = SCR_NO_VALUE);`
Skipping `delay` argument (or passing SCR_NO_VALUE) will result in keeping previous delay.

For compatibility default delay value in the editor and game data is 5.