### PR TITLE
Tools: fix error on g++ 9, %lld is long long int, but soff_t is long int

### DIFF
--- a/Tools/crmpak/main.cpp
+++ b/Tools/crmpak/main.cpp
@@ -1,5 +1,6 @@
-#include <inttypes.h>
-#include <stdio.h>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
 #include "game/room_file.h"
 #include "util/data_ext.h"
 #include "util/file.h"

--- a/Tools/data/mfl_utils.cpp
+++ b/Tools/data/mfl_utils.cpp
@@ -63,8 +63,8 @@ HError UnpackLibrary(const AssetLibInfo &lib, const String &lib_dir, const Strin
             if (wrote == asset.Size)
                 printf("+ %s\n", asset.FileName.GetCStr());
             else
-                printf("Error: file was not written correctly: %s\n Expected: %lld, wrote: %lld bytes\n",
-                    asset.FileName.GetCStr(), asset.Size, wrote);
+                printf("Error: file was not written correctly: %s\n Expected: %jd, wrote: %jd bytes\n",
+                    asset.FileName.GetCStr(), static_cast<intmax_t>(asset.Size), static_cast<intmax_t>(wrote));
         }
     }
     return HError::None();


### PR DESCRIPTION
Currently when building agspak with g++ 9 on Ubuntu 20.04 I get the error below, when using `make` at agspak directory. 

```
../../Tools/data/mfl_utils.cpp:66:82: error: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘soff_t’ {aka ‘long int’} [-Werror=format=]
   66 |                 printf("Error: file was not written correctly: %s\n Expected: %lld, wrote: %lld bytes\n",
      |                                                                               ~~~^
      |                                                                                  |
      |                                                                                  long long int
      |                                                                               %ld
   67 |                     asset.FileName.GetCStr(), asset.Size, wrote);
      |                                               ~~~~~~~~~~
      |                                                     |
      |                                                     soff_t {aka long int}
../../Tools/data/mfl_utils.cpp:66:95: error: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘soff_t’ {aka ‘long int’} [-Werror=format=]
   66 |                 printf("Error: file was not written correctly: %s\n Expected: %lld, wrote: %lld bytes\n",
      |                                                                                            ~~~^
      |                                                                                               |
      |                                                                                               long long int
      |                                                                                            %ld
   67 |                     asset.FileName.GetCStr(), asset.Size, wrote);
      |                                                           ~~~~~
      |                                                           |
      |                                                           soff_t {aka long int}
```

- I also uncovered a problem with crmpak in gcc9 and 10, so adding the fix in the following commit. 