### PR TITLE
RLE decompressing: Redefined char as signed char

### DIFF
--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -153,7 +153,7 @@ static int cunpackbitl(uint8_t *line, size_t size, Stream *in)
     if (in->HasErrors())
       break;
 
-    char cx = ix;
+    signed char cx = ix;
     if (cx == -128)
       cx = 0;
 
@@ -191,7 +191,7 @@ static int cunpackbitl16(uint16_t *line, size_t size, Stream *in)
     if (in->HasErrors())
       break;
 
-    char cx = ix;
+    signed char cx = ix;
     if (cx == -128)
       cx = 0;
 
@@ -229,7 +229,7 @@ static int cunpackbitl32(uint32_t *line, size_t size, Stream *in)
     if (in->HasErrors())
       break;
 
-    char cx = ix;
+    signed char cx = ix;
     if (cx == -128)
       cx = 0;
 


### PR DESCRIPTION
Some compilers may default char to unsigned char, which makes the RLE decompression fail.