### PR TITLE
Feature: Web (Emscripten) build through the Editor

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,15 +179,17 @@ build_android_task:
 
 build_emscripten_task:
   container:
-    image: ubuntu:focal
-  install_packages_script: |
-    export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y tzdata git pkg-config curl build-essential cmake bash python3 python3-pip
+    dockerfile: ci/emscripten/Dockerfile 
   build_emscripten_script: |
     pushd Emscripten && ./build.sh && popd
   package_emscripten_build_script: |
-    pushd Emscripten && mkdir out && cp my_game.html my_game_files.js out/ && pushd build-release && mv ags.js ags.wasm ags.html ../out && popd && popd
+    tmp=/tmp/bundle$$
+    version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)
+    pushd Emscripten && mkdir -p $tmp && cp my_game.html my_game_files.js $tmp && pushd build-release && mv ags.js ags.wasm ags.html $tmp && popd && popd
+    mv $tmp/my_game.html $tmp/index.html
+    bsdtar -f ags_${version}_web.tar.gz -cvzC $tmp index.html ags.js ags.wasm my_game_files.js
   emscripten_artifacts:
-    path: Emscripten/out/*
+    path: ags_*.tar.gz
 
 build_editor_task:
   windows_container:

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -193,6 +193,7 @@ namespace AGS.Editor
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetWindows());
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetDebug());
             BuildTargetsInfo.RegisterBuildTarget(new BuildTargetLinux());
+            BuildTargetsInfo.RegisterBuildTarget(new BuildTargetWeb());
         }
 
         public Game CurrentGame

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -95,6 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AGSEditor.cs" />
+    <Compile Include="BuildTargets\BuildTargetWeb.cs" />
     <Compile Include="ColorThemes\ColorTheme.cs" />
     <Compile Include="ColorThemes\ColorThemes.cs" />
     <Compile Include="ColorThemes\ColorThemeJson.cs" />

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
@@ -1,0 +1,110 @@
+﻿using AGS.Types;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    class BuildTargetWeb : BuildTargetBase
+    {
+        public const string WEB_DIR = "Web";
+        public const string MY_GAME_FILES_JS = "my_game_files.js";
+
+        public override IDictionary<string, string> GetRequiredLibraryPaths()
+        {
+            Dictionary<string, string> paths = new Dictionary<string, string>();
+
+            string webDir = Path.Combine(Factory.AGSEditor.EditorDirectory, WEB_DIR);
+       
+            paths.Add("ags.js", webDir);
+            paths.Add("ags.wasm", webDir);
+            paths.Add("index.html", webDir);
+            return paths;
+        }
+
+        public override string[] GetPlatformStandardSubfolders()
+        {
+            return new string[] { GetCompiledPath() };
+        }
+
+        public override void DeleteMainGameData(string name)
+        {
+            string filename = Path.Combine(Path.Combine(OutputDirectoryFullPath, WEB_DIR), name + ".ags");
+            Utilities.DeleteFileIfExists(filename);
+        }
+
+        public override bool Build(CompileMessages errors, bool forceRebuild)
+        {
+            if (!base.Build(errors, forceRebuild)) return false;
+            string my_game_files_text = "var gamefiles = [";
+
+            foreach (string fileName in Directory.GetFiles(Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY)))
+            {
+                if ((File.GetAttributes(fileName) & (FileAttributes.Hidden | FileAttributes.System | FileAttributes.Temporary)) != 0)
+                    continue;
+                if ((!fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) &&
+                    (!Path.GetFileName(fileName).Equals("winsetup.exe", StringComparison.OrdinalIgnoreCase)) &&
+                    (!Path.GetFileName(fileName).Equals(AGSEditor.CONFIG_FILE_NAME, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Utilities.HardlinkOrCopy(GetCompiledPath(WEB_DIR, Path.GetFileName(fileName)), fileName, true);
+
+                    my_game_files_text += "'" + Path.GetFileName(fileName) + "', ";
+                }
+            }
+            my_game_files_text += "'" + AGSEditor.CONFIG_FILE_NAME + "'";
+
+            my_game_files_text += "];";
+
+            // Update config file with current game parameters
+            Factory.AGSEditor.WriteConfigFile(GetCompiledPath(WEB_DIR));
+
+            string compiled_web_path = GetCompiledPath(WEB_DIR);
+            string editor_web_prebuilt = Path.Combine(Factory.AGSEditor.EditorDirectory, WEB_DIR);
+
+            foreach (KeyValuePair<string, string> pair in GetRequiredLibraryPaths())
+            {
+                string fileName = pair.Key;
+                string originDir = pair.Value;
+
+                string destFile = GetCompiledPath(WEB_DIR, fileName);
+                string originFile = Path.Combine(originDir, fileName);
+
+                if (fileName.EndsWith(".wasm"))
+                {
+                    Utilities.HardlinkOrCopy(destFile, originFile, true);
+                }
+                else
+                {
+                    string destFileName = Utilities.ResolveSourcePath(destFile);
+                    string sourceFileName = Utilities.ResolveSourcePath(originFile);
+                    File.Copy(sourceFileName, destFileName, true);
+                }
+            }
+
+            FileStream stream = File.Create(GetCompiledPath(WEB_DIR, MY_GAME_FILES_JS));
+            byte[] bytes = Encoding.UTF8.GetBytes(my_game_files_text);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Close();
+
+            return true;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "Web";
+            }
+        }
+
+        public override string OutputDirectory
+        {
+            get
+            {
+                return WEB_DIR;
+            }
+        }
+    }
+}

--- a/Emscripten/build.sh
+++ b/Emscripten/build.sh
@@ -2,19 +2,22 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 pushd "${SCRIPT_DIR}"
-mkdir emscripten
-pushd emscripten
-git clone https://github.com/emscripten-core/emsdk.git
-pushd emsdk
-./emsdk install 3.1.2
-./emsdk activate 3.1.2
-source ./emsdk_env.sh
-popd
-popd
+
+command -v emcc >/dev/null 2>&1 || { echo >&2 "Make sure emsdk is installed and activated!  emcc not found. Aborting."; exit 1; }
+
+BUILD_CMD="ninja"
+command -v ninja >/dev/null 2>&1 || { BUILD_CMD="make" ; }
+
 mkdir build-release
 pushd build-release
-emcmake cmake ../.. -DCMAKE_BUILD_TYPE=Release
-if ! make; then
+
+if [ ${BUILD_CMD} == "ninja" ]; then
+  emcmake cmake -G "Ninja" ../.. -DCMAKE_BUILD_TYPE=Release
+else 
+  emcmake cmake ../.. -DCMAKE_BUILD_TYPE=Release
+fi
+
+if ! ${BUILD_CMD}; then
   exit 1
 fi
 popd

--- a/Emscripten/install_dependencies.sh
+++ b/Emscripten/install_dependencies.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+pushd "${SCRIPT_DIR}"
+
+mkdir emscripten
+pushd emscripten
+git clone https://github.com/emscripten-core/emsdk.git
+pushd emsdk
+./emsdk install 3.1.2
+./emsdk activate 3.1.2
+source ./emsdk_env.sh
+popd
+popd
+
+popd
+
+echo "you can now run build.sh to build ags!"

--- a/ci/emscripten/Dockerfile
+++ b/ci/emscripten/Dockerfile
@@ -1,0 +1,8 @@
+# The current used version of emsdk
+FROM emscripten/emsdk:3.1.2
+
+# Install required tools
+RUN apt-get update && apt-get install -y tzdata libarchive-tools git pkg-config curl build-essential cmake ninja-build bash python3 python3-pip
+
+RUN embuilder.py build --lto libstubs libc libc++ libc++abi sdl2 freetype ogg vorbis
+RUN embuilder.py build libstubs libc libc++ libc++abi sdl2 freetype ogg vorbis


### PR DESCRIPTION
This adds support for generating a web build through the Editor.

You will need to extract the contents of the generated artifact and place in the Editor directory in a folder named `Web/` 

I did additional changes to the CI, which are explained in the commit.

I have not wired yet the installer and release to actually use the artifact. I want to let the Emscripten builds happen a bit more on the CI before adding the dependency on the release process.