### PR TITLE
Installer CI: add Web component to releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -188,7 +188,7 @@ build_emscripten_task:
     pushd Emscripten && mkdir -p $tmp && cp my_game.html my_game_files.js $tmp && pushd build-release && mv ags.js ags.wasm ags.html $tmp && popd && popd
     mv $tmp/my_game.html $tmp/index.html
     bsdtar -f ags_${version}_web.tar.gz -cvzC $tmp index.html ags.js ags.wasm my_game_files.js
-  emscripten_artifacts:
+  binaries_artifacts:
     path: ags_*.tar.gz
 
 build_editor_task:
@@ -250,6 +250,7 @@ windows_packaging_task:
     - build_editor
     - build_windows
     - linux_packaging
+    - build_emscripten
   windows_container:
     dockerfile: ci/windows/Dockerfile
     os_version: 2019
@@ -282,6 +283,11 @@ windows_packaging_task:
     call Script\setvar.cmd ACI_VERSION_STR &&
     cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/linux_packaging/binaries/ags_!ACI_VERSION_STR!_linux.tar.gz" |
     tar -f - -xvC Windows\Installer\Source\Linux --strip-components 1"
+  get_emscripten_bundle_script: >
+    mkdir Windows\Installer\Source\Web &&
+    call Script\setvar.cmd ACI_VERSION_STR &&
+    cmd /v:on /c "curl -fLSs "https://api.cirrus-ci.com/v1/artifact/build/%CIRRUS_BUILD_ID%/build_emscripten/binaries/ags_!ACI_VERSION_STR!_web.tar.gz" |
+    tar -f - -xvC Windows\Installer\Source\Web"
   make_installer_script: >
     powershell Windows\Installer\build.ps1 -IsccPath 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
   installer_artifacts:
@@ -291,6 +297,7 @@ windows_packaging_task:
     move Windows\Installer\Source\Engine\* Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Licenses Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Linux Windows\Installer\Source\Editor\ &&
+    move Windows\Installer\Source\Web Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\Templates Windows\Installer\Source\Editor\ &&
     move Windows\Installer\Source\URLs Windows\Installer\Source\Editor\ &&
     for %%f in (Windows\Installer\Output\*.exe) do
@@ -361,6 +368,7 @@ make_release_task:
     - build_linux_debian
     - windows_packaging
     - linux_packaging
+    - build_emscripten
     - pdb_packaging
   container:
     image: alpine:3.10
@@ -390,6 +398,7 @@ make_release_task:
     for download in "windows_packaging/archive/$(basename AGS-*.exe .exe).zip" \
       "windows_packaging/windevdependenciesvs/WinDevDependenciesVS.zip" \
       "linux_packaging/binaries/ags_${version}_linux.tar.gz" \
+      "build_emscripten/binaries/ags_${version}_web.tar.gz" \
       "pdb_packaging/archive/AGS-${version}-pdb.zip" \
       "build_linux_debian/debian_packages/ags_${version}_i386.deb" \
       "build_linux_debian/debian_packages/ags_${version}_amd64.deb" \

--- a/Windows/Installer/ags.iss
+++ b/Windows/Installer/ags.iss
@@ -52,6 +52,7 @@ ComponentMain=Main files
 ComponentEngines=Engines
 ComponentEngineDefault=Runtime engine for MS Windows
 ComponentLinuxBuild=Linux build component
+ComponentWebBuild=Web build component
 ; ComponentDemoGame=Demo Game
 InstallOptions=Install options
 InstallVCRedist=Install {#VcRedistName}
@@ -64,6 +65,7 @@ Name: "main"; Description: "{cm:ComponentMain}"; Types: full compact custom; Fla
 Name: "engine"; Description: "{cm:ComponentEngines}"; Types: full compact custom; Flags: fixed
 Name: "engine\default"; Description: "{cm:ComponentEngineDefault}"; Types: full compact; Flags: exclusive
 Name: "linux"; Description: "{cm:ComponentLinuxBuild}"; Types: full custom
+Name: "web"; Description: "{cm:ComponentWebBuild}"; Types: full custom
 ; Name: "demogame"; Description: "{cm:ComponentDemoGame}"; Types: full custom
 
 
@@ -111,6 +113,10 @@ Source: "Source\Linux\ags64"; DestDir: "{app}\Linux"; Flags: ignoreversion; Comp
 Source: "Source\Linux\lib32\*"; DestDir: "{app}\Linux\lib32"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: linux
 Source: "Source\Linux\lib64\*"; DestDir: "{app}\Linux\lib64"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: linux
 Source: "Source\Linux\licenses\*"; DestDir: "{app}\Linux\licenses"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: linux
+; Web build components
+Source: "Source\Web\ags.wasm"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
+Source: "Source\Web\ags.js"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
+Source: "Source\Web\index.html"; DestDir: "{app}\Web"; Flags: ignoreversion; Components: web
 ; Demo game
 ; Source: "Source\Demo Game\*"; DestDir: "{code:GetDemoGameDir}"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: demogame
 ; Visual C++ runtime


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2244442/152639492-77fa978c-6164-4f73-ba61-bdedf336cd0e.png)

Adds the web build in releases, in the Editor archive under `Web/`, and as the Web component in the installer.

Edit: just squashed the commits with the adjustment to the review.