### PR TITLE
Engine: add clear cache on room change from Android port to config

### DIFF
--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -30,6 +30,7 @@ GameSetup::GameSetup()
     mouse_speed_def = kMouseSpeed_CurrentDisplay;
     RenderAtScreenRes = false;
     Supersampling = 1;
+    clear_cache_on_room_change = false;
 
     Screen.Params.RefreshRate = 0;
     Screen.Params.VSync = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -76,6 +76,7 @@ struct GameSetup {
     MouseSpeedDef mouse_speed_def;
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
+    bool  clear_cache_on_room_change; // compatibility
 
     DisplayModeSetup Screen;
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -924,8 +924,6 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     pl_run_plugin_hooks(AGSE_ENTERROOM, displayed_room);
 }
 
-extern int psp_clear_cache_on_room_change;
-
 // new_room: changes the current room number, and loads the new room from disk
 void new_room(int newnum,CharacterInfo*forchar) {
     EndSkippingUntilCharStops();
@@ -959,7 +957,7 @@ void new_room(int newnum,CharacterInfo*forchar) {
     // change rooms
     unload_old_room();
 
-    if (psp_clear_cache_on_room_change)
+    if (usetup.clear_cache_on_room_change)
     {
         // Delete all cached sprites
         spriteset.DisposeAll();

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -352,6 +352,7 @@ extern int psp_gfx_scaling;
 extern int psp_gfx_super_sampling;
 extern int psp_gfx_smoothing;
 extern int psp_gfx_smooth_sprites;
+extern int psp_clear_cache_on_room_change;
 extern char psp_translation[];
 #if AGS_PLATFORM_OS_ANDROID
 extern int config_mouse_control_mode;
@@ -415,6 +416,7 @@ void override_config_ext(ConfigTree &cfg)
 
     INIwriteint(cfg, "misc", "antialias", psp_gfx_smooth_sprites != 0);
     INIwritestring(cfg, "language", "translation", psp_translation);
+    INIwriteint(cfg, "misc", "clear_cache_on_room_change", psp_clear_cache_on_room_change != 0);
 }
 
 void apply_config(const ConfigTree &cfg)
@@ -455,6 +457,7 @@ void apply_config(const ConfigTree &cfg)
         // This option is backwards (usevox is 0 if no_speech_pack)
         usetup.no_speech_pack = INIreadint(cfg, "sound", "usespeech", 1) == 0;
 
+        usetup.clear_cache_on_room_change = INIreadint(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change);
         usetup.user_data_dir = INIreadstring(cfg, "misc", "user_data_dir");
         usetup.shared_data_dir = INIreadstring(cfg, "misc", "shared_data_dir");
 

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -154,6 +154,7 @@ void main_print_help() {
         "Usage: ags [OPTIONS] [GAMEFILE or DIRECTORY]\n\n"
           //--------------------------------------------------------------------------------|
            "Options:\n"
+           "  --clear-cache-on-room-change Clears sprite cache on every room change\n"
            "  --conf FILEPATH              Specify explicit config file to read on startup\n"
 #if AGS_PLATFORM_OS_WINDOWS
            "  --console-attach             Write output to the parent process's console\n"
@@ -314,6 +315,10 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             strncpy (play.takeover_from, argv[ee + 2], 49);
             play.takeover_from[49] = 0;
             ee += 2;
+        }
+        else if (ags_stricmp(arg, "--clear-cache-on-room-change") == 0)
+        {
+            INIwritestring(cfg, "misc", "clear_cache_on_room_change", "1");
         }
         else if (ags_strnicmp(arg, "--tell", 6) == 0) {
             if (arg[6] == 0)

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -86,6 +86,7 @@ Locations of two latter files differ between running platforms:
   * shared_data_dir = \[string\] - custom path to shared appdata location.
   * antialias = \[0; 1\] - anti-alias scaled sprites.
   * cachemax = \[integer\] - size of the engine's sprite cache, in kilobytes. Default is 131072 (128 MB).
+  * clear_cache_on_room_change = \[0; 1\] - whether to clear sprite cache on every room change.
 * **\[log\]** - log options, allow to setup logging to the chosen OUTPUT with given log groups and verbosity levels.
   * \[outputname\] = GROUP[:LEVEL][,GROUP[:LEVEL]][,...];
   * \[outputname\] = +GROUPLIST[:LEVEL];
@@ -127,6 +128,7 @@ Following OPTIONS are supported when running from command line:
 
 * -? / --help - prints most useful command line arguments and quits.
 * -v / --version - prints engine version and quits.
+* --clear-cache-on-room-change - clears sprite cache on every room change
 * --conf \<FILEPATH\> - specify explicit config file to read on startup.
 * --console-attach - write output to the parent process's console (Windows only).
 * --fps - display fps counter.


### PR DESCRIPTION
**I don't know if we want this or not**

This was a setting that was added to the psp port and to the mobile ports probably due to some memory restriction in these devices back in the day. It's still available in the android.cfg file. If we don't want, then the right PR is the one that removes the psp variable.

We probably need to figure out what goes and what doesn't for #106 and #104