### PR TITLE
New compiler: When an opener isn't closed, complain about that on the line of the opener instead of at EOF

### DIFF
--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -726,24 +726,11 @@ void AGS::Scanner::OpenCloseMatcher::EndOfInputCheck()
 
     struct OpenInfo const oi = _openInfoStack.back();
     size_t const opener_section_id = _scanner._tokenList.GetSectionIdAt(oi.Pos);
-    std::string const &opener_section = _scanner._tokenList.SectionId2Section(opener_section_id);
-    size_t const opener_lineno = _scanner._tokenList.GetLinenoAt(oi.Pos);
+    _scanner._section = _scanner._tokenList.SectionId2Section(opener_section_id);
+    _scanner._lineno = _scanner._tokenList.GetLinenoAt(oi.Pos);
 
-    std::string const &current_section = _scanner._section;
-    size_t const current_lineno = _scanner._lineno;
-
-    std::string error_msg = "The '&opener&' in &section& on line &lineno& has not been closed.";
-    if (opener_section == current_section)
-    {
-        error_msg = "The '&opener&' on line &lineno& has not been closed.";
-        if (opener_lineno == current_lineno)
-            error_msg = "The '&opener&' on this line has not been closed.";
-    }
+    std::string error_msg = "The '&opener&' on this line isn't closed.";
     ReplaceToken(error_msg, "&opener&", _scanner._sym.GetName(oi.Opener));
-    if (std::string::npos != error_msg.find("&lineno&"))
-        ReplaceToken(error_msg, "&lineno&", std::to_string(opener_lineno));
-    if (std::string::npos != error_msg.find("&section&"))
-        ReplaceToken(error_msg, "&section&", opener_section);
     _scanner.UserError(error_msg.c_str());
 }
 

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -768,10 +768,31 @@ TEST_F(Scan, MatchBraceParen5)
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
-    EXPECT_LE(7u, scanner.GetLineno());
+    EXPECT_EQ(6u, scanner.GetLineno());
     std::string errmsg = mh.GetError().Message;
-    EXPECT_NE(std::string::npos, errmsg.find("not been closed"));
-    EXPECT_NE(std::string::npos, errmsg.find("ine 6"));
+    EXPECT_NE(std::string::npos, errmsg.find("isn't closed"));
+}
+
+TEST_F(Scan, MatchBraceParen6)
+{
+    // The scanner checks that nested (), [], {} match.
+    // Opener without closer
+
+    char *Input = "\
+            struct MyStruct \n\
+            {               \n\
+                int i;      \n\
+            void Test()     \n\
+            {               \n\
+                S.          \n\
+            }               \n\
+        ";
+    AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
+    scanner.Scan();
+    ASSERT_TRUE(mh.HasError());
+    EXPECT_EQ(2u, scanner.GetLineno());
+    std::string errmsg = mh.GetError().Message;
+    EXPECT_NE(std::string::npos, errmsg.find("isn't closed"));
 }
 
 TEST_F(Scan, ConsecutiveStringLiterals1)


### PR DESCRIPTION
Previously, when there wasn't any closer for an opened brace, the compiler would move the cursor to the very last line of the input and then complain that the brace higher up at … hasn't been closed. 

That's unnecessarily circuitous. Change things so that the cursor is put on the line where the unopened brace is when the error is reported.

Typical code:
```
function DoubleInt(int x)
{  // ← Complain about the unclosed '{' right here.
    return 2 * x;

function TripleInt(int x)
{
    return 3 * x;
}
```