### PR TITLE
Editor: adjust help entries for some panes

### DIFF
--- a/Editor/AGS.Editor/Panes/AudioEditor.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.cs
@@ -26,6 +26,11 @@ namespace AGS.Editor
             Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
+        protected override string OnGetHelpKeyword()
+        {
+            return "Music and sound";
+        }
+
         public object SelectedItem
         {
             get { return _selectedItem; }

--- a/Editor/AGS.Editor/Panes/CharacterEditor.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.cs
@@ -35,7 +35,7 @@ namespace AGS.Editor
 
         protected override string OnGetHelpKeyword()
         {
-            return "Characters";
+            return "Character Editor";
         }
         
         public void UpdateViewPreview()

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -137,7 +137,7 @@ namespace AGS.Editor
 
         protected override string OnGetHelpKeyword()
         {
-            return "GUI";
+            return "Editing GUIs";
         }
 
         protected override void OnPropertyChanged(string propertyName, object oldValue)

--- a/Editor/AGS.Editor/Panes/InventoryEditor.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.cs
@@ -56,7 +56,7 @@ namespace AGS.Editor
 
         protected override string OnGetHelpKeyword()
         {
-            return "Inventory";
+            return "Inventory Items Editor";
         }
 
         public InventoryItem ItemToEdit

--- a/Editor/AGS.Editor/Panes/SpriteManager.cs
+++ b/Editor/AGS.Editor/Panes/SpriteManager.cs
@@ -28,7 +28,7 @@ namespace AGS.Editor
 
         protected override string OnGetHelpKeyword()
         {
-            return "Importing your own sprite graphics";
+            return "Sprite Manager";
         }
 
 		protected override void OnWindowActivated()

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -37,7 +37,7 @@ namespace AGS.Editor
 
         protected override string OnGetHelpKeyword()
         {
-            return "Views";
+            return "View Editor";
         }
 
         void UpdateLoopVisuals()


### PR DESCRIPTION
- Character, GUI, and View editors and the Sprite manager are adjusted.

Part of #1181 

Things not fixed here:

- I noticed the below are missing specific pages in the manual. They are mentioned on Setting up the game:
  - CursorEditor
  - FontEditor
  - GeneralSettings
- RoomSettingsPane -> Help keyword is attached to a layer, but there are no layer specific entries on the manual