### PR TITLE
Editor: fix preferences menu doesn't select current color theme

### DIFF
--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -58,8 +58,9 @@ namespace AGS.Editor
             cmbIndentStyle.SelectedIndex = _settings.IndentUseTabs ? 1 : 0;
             chkAlwaysShowViewPreview.Checked = _settings.ShowViewPreviewByDefault;
             cmbSpriteImportTransparency.SelectedIndex = (int)_settings.SpriteImportMethod;
+            string selected_color_theme = _settings.ColorTheme;
             cmbColorTheme.DataSource = Factory.GUIController.ColorThemes.Themes;
-            cmbColorTheme.SelectedIndex = Factory.GUIController.ColorThemes.Themes.ToList().FindIndex(t => t.Name == _settings.ColorTheme);
+            cmbColorTheme.SelectedIndex = Factory.GUIController.ColorThemes.Themes.ToList().FindIndex(t => t.Name == selected_color_theme);
             chkUsageInfo.Checked = _settings.SendAnonymousStats;
             udBackupInterval.Value = (_settings.BackupWarningInterval > 0) ? _settings.BackupWarningInterval : 1;
             chkBackupReminders.Checked = (_settings.BackupWarningInterval != 0);


### PR DESCRIPTION
I previously made a mistake in the preferences editor, when the DataSource is applied to cmbColorTheme control, the selected index changed event is triggered, but we haven't adjusted the selectedIndex yet to the theme selected, and this changes the theme before the theme can be configured. So whenever you load the Preferences Editor, Default is always the one configured. This fix gets the selected theme into a temporary variable and then readjust it right after. This is the temporary settings property, so any actual settings change is not saved here.