### PR TITLE
Editor: fix space at first character hangs editor

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -1424,8 +1424,8 @@ namespace AGS.Editor
                 // potential enum autocomplete
                 bool atLeastOneEquals = false;
                 checkAtPos--;
-                while ((this.scintillaControl1.GetCharAt(checkAtPos) == ' ') ||
-                       (this.scintillaControl1.GetCharAt(checkAtPos) == '='))
+                while (checkAtPos > 0 && ((this.scintillaControl1.GetCharAt(checkAtPos) == ' ') ||
+                       (this.scintillaControl1.GetCharAt(checkAtPos) == '=')))
                 {
                     if (this.scintillaControl1.GetCharAt(checkAtPos) == '=')
                     {


### PR DESCRIPTION
- GetCharAt is clamped to above 0 values, after checkAtPos is negative it will be at char 0 forever in this while loop and hang the editor

This fixes a hang existent in current Script Editor when the first character is a space `' '` character. Regression after the new ScintillaNet.