### PR TITLE
Editor: convert game files when the text format changes

### DIFF
--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -370,6 +370,9 @@ public:
     // Compiled room script
     PScript                 CompiledScript;
 
+    // Various extended options with string values, meta-data etc
+    StringMap               StrOptions;
+
 private:
     // Room's legacy resolution type, defines relation room and game's resolution
     RoomResolutionType      _resolution;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -828,6 +828,13 @@ namespace AGS.Editor
             _game.SavedXmlVersionIndex = versionIndex;
 			_game.SavedXmlVersion = fileVersion;
             _game.SavedXmlEditorVersion = gameSavedWithEditorVersion;
+            try
+            { // Try to retrieve the xml encoding declaration, to be used as a fallback for older projects
+                XmlDeclaration dec = doc.FirstChild as XmlDeclaration;
+                _game.SavedXmlEncodingCodePage = Encoding.GetEncoding(dec.Encoding).CodePage;
+            }
+            catch (Exception) {}
+
 			_game.FromXml(doc.DocumentElement);
 
             Factory.Events.OnGameLoad(doc.DocumentElement);
@@ -1682,6 +1689,7 @@ namespace AGS.Editor
 
 			_game.SavedXmlVersion = LATEST_XML_VERSION;
             _game.SavedXmlVersionIndex = LATEST_XML_VERSION_INDEX;
+            _game.SavedXmlEncodingCodePage = _game.TextEncoding.CodePage;
             _game.ToXml(writer);
 
 			Factory.Events.OnSavingGame(writer);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using AGS.Editor.Preferences;
+using System.Text;
 
 namespace AGS.Editor
 {
@@ -256,9 +256,9 @@ namespace AGS.Editor
             }
         }
 
-        public Room LoadRoom(UnloadedRoom roomToLoad)
+        public Room LoadRoom(UnloadedRoom roomToLoad, Encoding defEncoding = null)
         {
-            return _native.LoadRoomFile(roomToLoad);
+            return _native.LoadRoomFile(roomToLoad, defEncoding);
         }
 
         public void SaveRoom(Room roomToSave)

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -75,9 +75,9 @@ namespace AGS.Editor
             if (oldFormat == newFormat)
                 return;
             if (Factory.GUIController.ShowQuestion("Changing the game text format will make the editor and engine treat all the text in all the game files in accordance to the new setting.\n\n"
-                +"* If this is a completely new project - you won't have any trouble.\n\n* If this is a work in progress, and you were using only basic Latin characters in your game, then the text will remain the same.\n\n"
-                +"* If, on other hand, your game contains extended Latin characters or non-Latin languages, these texts may become wrong and require manual conversion.\n\n"
-                +"NOTE: the Translation files will remain unaffected by this setting.\n\nAre you sure you want to continue?",
+                + "IMPORTANT: the Editor will now convert the game files and scripts to a new format. This may take a while, depending on your game's size.\n\n"
+                + "IMPORTANT: the Translation files will remain unaffected by this setting, as they have their own individual encoding setting.\n\n"
+                + "Are you sure you want to continue?",
                 MessageBoxIcon.Warning) == DialogResult.No)
             {
                 Factory.AGSEditor.CurrentGame.Settings.GameTextEncoding = oldFormat;
@@ -85,6 +85,13 @@ namespace AGS.Editor
             else
             {
                 Factory.Events.OnGameSettingsChanged();
+                BusyDialog.Show("Please wait while we convert game files to the new text format...",
+                    (o) => {
+                        Factory.AGSEditor.Tasks.ConvertAllGameTexts(
+                            Types.Utilities.EncodingFromName(oldFormat),
+                            Types.Utilities.EncodingFromName(newFormat));
+                        return null;
+                    }, null);
             }
         }
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -387,7 +387,15 @@ namespace AGS.Editor
 
             if (xmlVersionIndex < 3060020)
             {
-                game.Settings.GameTextEncoding = "ANSI";
+                if (game.SavedXmlEncodingCodePage.HasValue &&
+                    game.SavedXmlEncodingCodePage.Value == 65001)
+                {
+                    game.Settings.GameTextEncoding = "UTF-8";
+                }
+                else
+                { // NOTE: use Encoding.GetEncoding(game.SavedXmlEncodingCodePage) if actual codepage is needed
+                    game.Settings.GameTextEncoding = "ANSI";
+                }
             }
 
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -29,7 +29,7 @@ extern bool initialize_native();
 extern void shutdown_native();
 extern AGS::Types::Game^ import_compiled_game_dta(const AGSString &filename);
 extern void free_old_game_data();
-extern AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad);
+extern AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
 extern void save_crm_file(Room ^roomToSave);
 extern void save_default_crm_file(Room ^roomToSave);
 extern AGSString import_sci_font(const AGSString &filename, int fslot);
@@ -498,9 +498,9 @@ namespace AGS
 			return load_sprite_dimensions();
 		}
 
-		AGS::Types::Room^ NativeMethods::LoadRoomFile(UnloadedRoom^ roomToLoad)
+		AGS::Types::Room^ NativeMethods::LoadRoomFile(UnloadedRoom^ roomToLoad, System::Text::Encoding ^defEncoding)
 		{
-			return load_crm_file(roomToLoad);
+			return load_crm_file(roomToLoad, defEncoding);
 		}
 
 		void NativeMethods::SaveRoomFile(AGS::Types::Room ^roomToSave)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -66,7 +66,7 @@ namespace AGS
             void OnGameFontUpdated(Game^ game, int fontSlot, bool forceUpdate);
 			Dictionary<int,Sprite^>^ LoadAllSpriteDimensions();
 			void LoadNewSpriteFile();
-			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad);
+			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
 			void SaveRoomFile(Room ^roomToSave);
             void SaveDefaultRoomFile(Room ^roomToSave);
 			void DrawRoomBackground(int hDC, Room ^room, int x, int y, int backgroundNumber, float scaleFactor, RoomAreaMaskType maskType, int selectedArea, int maskTransparency);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3512,10 +3512,10 @@ int GetCurrentlyLoadedRoomNumber()
   return RoomTools->loaded_room_number;
 }
 
-void convert_room_from_native(const RoomStruct &rs, Room ^room)
+void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::Encoding ^defEncoding)
 {
     // Use local converter to account for room encoding (could be imported from another game)
-    TextConverter^ tcv = TextHelper::GetGameTextConverter();
+    TextConverter^ tcv = defEncoding ? gcnew TextConverter(defEncoding) : TextHelper::GetGameTextConverter();
     try
     {
         auto enc_opt = rs.StrOptions.at("textencoding");
@@ -3680,7 +3680,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room)
 	}
 }
 
-AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
+AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding)
 {
     AGSString roomFileName = TextHelper::ConvertUTF8(roomToLoad->FileName);
 
@@ -3693,7 +3693,7 @@ AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad)
     RoomTools->loaded_room_number = roomToLoad->Number;
 
     Room ^room = gcnew Room(roomToLoad->Number);
-    convert_room_from_native(thisroom, room);
+    convert_room_from_native(thisroom, room, defEncoding);
     room->_roomStructPtr = (IntPtr)&thisroom;
 
     room->Description = roomToLoad->Description;
@@ -3829,7 +3829,7 @@ void convert_room_to_native(Room ^room, RoomStruct &rs)
 
     // Prepare script links
     convert_room_interactions_to_native(room, rs);
-    if (room->Script->CompiledData)
+    if (room->Script && room->Script->CompiledData)
 	    rs.CompiledScript = ((AGS::Native::CompiledScript^)room->Script->CompiledData)->Data;
 
     // Encoding hint

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -68,6 +68,7 @@ namespace AGS.Types
 		private string _savedXmlVersion = null;
         private int? _savedXmlVersionIndex = null;
         private string _savedXmlEditorVersion = null;
+        private int? _savedXmlEncodingCP = null;
 
         public Game()
         {
@@ -381,9 +382,16 @@ namespace AGS.Types
             set { _savedXmlVersionIndex = value; }
         }
 
-		/// <summary>
-		/// Full path to the directory where the game is located
-		/// </summary>
+        /// <summary>
+        /// The code page of the Game.agf file that was loaded from disk.
+        /// </summary>
+        public int? SavedXmlEncodingCodePage
+        {
+            get { return _savedXmlEncodingCP; }
+            set { _savedXmlEncodingCP = value; }
+        }
+
+		/// <summary>		/// Full path to the directory where the game is located		/// </summary>
 		public string DirectoryPath
 		{
 			get { return _directoryPath; }

--- a/Editor/AGS.Types/Game.cs
+++ b/Editor/AGS.Types/Game.cs
@@ -114,14 +114,7 @@ namespace AGS.Types
 
         public Encoding TextEncoding
         {
-            get
-            {
-                if (string.Compare(_settings.GameTextEncoding, "ANSI", true) == 0)
-                    return Encoding.Default;
-                else if (string.Compare(_settings.GameTextEncoding, "UTF-8", true) == 0)
-                    return Utilities.UTF8; // UTF-8 w/o BOM
-                return Encoding.GetEncoding(_settings.GameTextEncoding);
-            }
+            get {  return Utilities.EncodingFromName(_settings.GameTextEncoding); }
         }
 
         public bool UnicodeMode

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -182,5 +182,14 @@ namespace AGS.Types
             catch (Exception){ /* just return null in case of any exception */ }
             return v;
         }
+
+        public static Encoding EncodingFromName(string name)
+        {
+            if (string.Compare(name, "ANSI", true) == 0)
+                return Encoding.Default;
+            else if (string.Compare(name, "UTF-8", true) == 0)
+                return Utilities.UTF8; // UTF-8 w/o BOM
+            return Encoding.GetEncoding(name);
+        }
     }
 }


### PR DESCRIPTION
These are the final changes for #1527 (and maybe #1297 in general).

After #1542 is merged you can have a unicode support in the editor, however if you import an older project, and then switch to UTF-8, the text may become corrupted if it uses any characters but common latin.
This pr adds a conversion process run after changing the encoding setting in the editor. The conversion is done simply as:
* load the data using old encoding;
* save the data using new encoding;
repeated with each file.

Files processed are:
* all script files;
* room files;
* main project file (Game.agf).

Translations (TRS files) *are not affected*, as they each have their individual encoding setting.

No big code changes were necessary, as the Editor already converts texts to C# representation in memory using provided Encoding object. So this is mostly calling existing load/save functions in a loop, with some adjustments.

Additional changes:
* save encoding hint to the SCM (exported script module)
* save encoding hint to the room file. For the rooms, added a trivial extension id "ext_sopts", which contains a string key/value map. This extension may be used in the future to store any other optional metadata.

These hints are used by the Editor when importing script modules and rooms.