### PR TITLE
New compiler: Disallow function names without following '(' in statements

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -728,7 +728,7 @@ private:
     void AccessData_Dereference(EvaluationResult &eres);
 
     // Process one index in a sequence of array indexes
-    void AccessData_ProcessCurrentArrayIndex(size_t idx, size_t dim, size_t factor, bool is_dynarray, SrcList &expression);
+    void AccessData_ProcessCurrentArrayIndex(size_t idx, size_t dim, size_t factor, bool is_dynarray, SrcList &expression, EvaluationResult &eres);
 
     // We're processing some struct component or global or local variable.
     // If a sequence of array indexes follows, parse it and shorten symlist accordingly


### PR DESCRIPTION
In general, this shouldn't be allowed in any locations where an expression is purely evaluated for its side effects. 

Typical code:
```
function room_AfterFadeIn()
{
    player.Say; // ← Compiler should complain about missing '('.
}
```

I'm taking this as an opportunity to fix another, related bug: An expression that contains a bracketed sub-expression has side effects when the sub-expression has side effects. Typical examples `object[++i]` or `arr[calculate_index()]`: these expressions have side effects. The compiler hadn't gotten this correct.