### PR TITLE
Tools: Add missing include for crmpak

### DIFF
--- a/Tools/crmpak/main.cpp
+++ b/Tools/crmpak/main.cpp
@@ -1,3 +1,4 @@
+#include <cerrno>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Fixes the following build issue:
```
g++ -std=c++11 -Werror=delete-non-virtual-dtor  -O2 -g -fsigned-char -fno-strict-aliasing -fwrapv -Wunused-result -Wno-unused-value -Werror=write-strings -Werror=format -Werror=format-security -DNDEBUG -D_FILE_OFFSET_BITS=64 -DRTLD_NEXT  -I../../Common -MD -c -o main.o main.cpp
main.cpp: In function ‘int main(int, char**)’:
main.cpp:137:9: error: ‘errno’ was not declared in this scope
  137 |         errno = 0;
      |         ^~~~~
main.cpp:9:1: note: ‘errno’ is defined in header ‘<cerrno>’; did you forget to ‘#include <cerrno>’?
    8 | #include "util/string_compat.h"
  +++ |+#include <cerrno>
    9 | 
make: *** [Makefile:71: main.o] Error 1
```