### PR TITLE
Editor: Script Font and Size selection in Preferences

### DIFF
--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -85,6 +85,14 @@ namespace AGS.Editor.Preferences
         }
     }
 
+    public class InstalledFontTypeConverter : BaseListSelectTypeConverter<string, string>
+    {
+        protected override Dictionary<string, string> GetValueList(ITypeDescriptorContext context)
+        {
+            return Factory.GUIController.InstalledFonts;
+        }
+    }
+
     public class RecentGame : IEquatable<RecentGame>
     {
         // default constructor is needed to serialize
@@ -678,6 +686,45 @@ namespace AGS.Editor.Preferences
             set
             {
                 this["DialogOnMultipleTabsClose"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Script Font")]
+        [Description("Font used in the script editor.")]
+        [Category("Script Editor")]
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("Courier New")]
+        [TypeConverter(typeof(InstalledFontTypeConverter))]
+        public string ScriptFont
+        {
+            get
+            {
+                return (string)(this["ScriptFont"]);
+            }
+            set
+            {
+                this["ScriptFont"] = value;
+            }
+        }
+
+
+        [Browsable(true)]
+        [DisplayName("Script Font Size")]
+        [Description("Font used in the script editor.")]
+        [Category("Script Editor")]
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("10")]
+        public int ScriptFontSize
+        {
+            get
+            {
+                return (int)(this["ScriptFontSize"]);
+            }
+            set
+            {
+                if (value < 8) value = 8;
+                this["ScriptFontSize"] = value;
             }
         }
 

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -11,6 +11,8 @@ using AGS.Types;
 using AGS.Types.AutoComplete;
 using AGS.Types.Interfaces;
 using AGS.Editor.Preferences;
+using System.Drawing.Text;
+using System.Linq;
 
 namespace AGS.Editor
 {
@@ -71,6 +73,7 @@ namespace AGS.Editor
 
         private GUIController()
         {
+            InstalledFonts = new InstalledFontCollection().Families.ToDictionary(t => t.Name, t => t.Name);
             _menuItems = new Dictionary<string, IEditorComponent>();
         }
 
@@ -140,7 +143,9 @@ namespace AGS.Editor
 
         public ColorThemes ColorThemes { get; private set; }
 
-		public void ShowMessage(string message, MessageBoxIconType icon)
+        public Dictionary<string, string> InstalledFonts { get; private set; }
+
+        public void ShowMessage(string message, MessageBoxIconType icon)
 		{
 			MessageBoxIcon windowsFormsIcon = MessageBoxIcon.Information;
 			if (icon == MessageBoxIconType.Warning)

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Windows.Forms;
 using AGS.Editor.Preferences;
 using AGS.Editor.Utils;
+using AGS.Types;
 
 namespace AGS.Editor
 {
@@ -28,6 +29,25 @@ namespace AGS.Editor
                 // Hides password using dot list character
                 textBoxAndKeystorePassword.UseSystemPasswordChar = PasswordPropertyTextAttribute.Yes.Password;
                 textBoxAndKeystoreKeyPassword.UseSystemPasswordChar = PasswordPropertyTextAttribute.Yes.Password;
+            }
+        }
+
+        // Make sure panels can have font and styles updated after settings is applied without restarting ags editor
+        private void UpdateFontSettings()
+        {
+            foreach (ContentDocument pane in Factory.GUIController.Panes)
+            {
+                ScriptEditor scriptEditor = pane.Control as ScriptEditor;
+                if (scriptEditor != null)
+                {
+                    ScintillaWrapper scintilla = scriptEditor.ScriptEditorControl as ScintillaWrapper;
+                    if (scintilla != null)
+                    {
+                        scintilla.ScriptFont = _settings.ScriptFont;
+                        scintilla.ScriptFontSize = _settings.ScriptFontSize;
+                        scintilla.UpdateAllStyles();
+                    }
+                }
             }
         }
 
@@ -120,6 +140,7 @@ namespace AGS.Editor
             }
 
             Factory.AGSEditor.Settings.Apply(_settings);
+            UpdateFontSettings();
         }
 
 		private void radFolderPath_CheckedChanged(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -185,6 +185,7 @@ namespace AGS.Editor
             this.scintillaControl1.Styles[Style.CallTip].Font = USER_FRIENDLY_FONT;
             this.scintillaControl1.Styles[Style.CallTip].Size = USER_FRIENDLY_FONT_SIZE;
 
+            if(this.scintillaControl1.Margins[0].Width > 0) EnableLineNumbers();
             UpdateColors();
         }
 

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -38,8 +38,6 @@ namespace AGS.Editor
         private const int INVALID_POSITION = -1;
         private const int AUTOCOMPLETE_MINIMUM_WORD_LENGTH = 3;
         private const int SCAN_BACK_DISTANCE = 50;
-        private const string DEFAULT_FONT = "Courier New";
-        private const int DEFAULT_FONT_SIZE = 10;
         private const string USER_FRIENDLY_FONT = "Tahoma";
         private const int USER_FRIENDLY_FONT_SIZE = 8;
         private const string AUTO_COMPLETE_CANCEL_CHARS = ")}; ";
@@ -103,6 +101,93 @@ namespace AGS.Editor
         private string _fixedTypeForThisKeyword = null;
         private bool _activated = false;
 
+        private string _scriptFont = Factory.AGSEditor.Settings.ScriptFont;
+        private int _scriptFontSize = Factory.AGSEditor.Settings.ScriptFontSize;
+
+        private void UpdateColors()
+        {
+            this.scintillaControl1.Styles[Style.BraceBad].BackColor = Color.FromArgb(255, 0, 0);
+            this.scintillaControl1.Styles[Style.BraceLight].Bold = true;
+            this.scintillaControl1.Styles[Style.BraceLight].BackColor = Color.FromArgb(210, 210, 0);
+
+            this.scintillaControl1.Styles[Style.Cpp.Word].ForeColor = Color.FromArgb(0, 0, 244);
+            this.scintillaControl1.Styles[Style.Cpp.Word2].ForeColor = Color.FromArgb(43, 145, 175);
+            this.scintillaControl1.Styles[Style.Cpp.GlobalClass].ForeColor = Color.FromArgb(43, 145, 175);
+            this.scintillaControl1.Styles[Style.Cpp.Comment].ForeColor = Color.FromArgb(27, 127, 27);
+            this.scintillaControl1.Styles[Style.Cpp.CommentLine].ForeColor = Color.FromArgb(27, 127, 27);
+            this.scintillaControl1.Styles[Style.Cpp.CommentDoc].ForeColor = Color.FromArgb(27, 127, 27);
+            this.scintillaControl1.Styles[Style.Cpp.CommentLineDoc].ForeColor = Color.FromArgb(27, 127, 27);
+            this.scintillaControl1.Styles[Style.Cpp.Number].ForeColor = Color.FromArgb(150, 27, 27);
+            this.scintillaControl1.Styles[Style.Cpp.String].ForeColor = Color.FromArgb(70, 7, 7);
+            this.scintillaControl1.Styles[Style.Cpp.Operator].ForeColor = Color.FromArgb(0, 70, 0);
+            this.scintillaControl1.Styles[Style.Cpp.Preprocessor].BackColor = Color.FromArgb(210, 210, 210);
+
+            this.scintillaControl1.Styles[Style.CallTip].ForeColor = Color.Black;
+            this.scintillaControl1.Styles[Style.CallTip].BackColor = Color.LightGoldenrodYellow;
+
+            // override the selected text colour
+            this.scintillaControl1.SetSelectionForeColor(true, Color.FromArgb(255, 255, 255));
+            this.scintillaControl1.SetSelectionBackColor(true, Color.FromArgb(0, 34, 130));
+
+            this.scintillaControl1.CallTipSetForeHlt(Color.FromArgb(240, 0, 0));
+
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].SetBackColor(Color.FromArgb(255, 100, 100));
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].SetForeColor(Color.White);
+
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].SetBackColor(Color.Red);
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].SetForeColor(Color.Black);
+
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].SetBackColor(Color.Yellow);
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].SetForeColor(Color.White);
+
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].SetBackColor(Color.Yellow);
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].SetForeColor(Color.White);
+
+            Color FoldingForeColor = ColorTranslator.FromHtml("#F3F3F3");
+            Color FoldingBackColor = ColorTranslator.FromHtml("#808080");
+
+            this.scintillaControl1.Markers[Marker.Folder].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.Folder].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderEnd].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderEnd].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderOpen].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderOpen].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderOpenMid].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderOpenMid].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderMidTail].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderMidTail].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderEnd].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderEnd].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderSub].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderSub].SetBackColor(FoldingBackColor);
+            this.scintillaControl1.Markers[Marker.FolderTail].SetForeColor(FoldingForeColor);
+            this.scintillaControl1.Markers[Marker.FolderTail].SetBackColor(FoldingBackColor);
+
+            this.scintillaControl1.Styles[Style.IndentGuide].ForeColor = ColorTranslator.FromHtml("#DDDDDD");
+
+            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+        }
+
+        public void UpdateAllStyles()
+        {
+            scintillaControl1.StyleResetDefault();
+
+            this.scintillaControl1.Styles[Style.Default].Font = _scriptFont;
+            this.scintillaControl1.Styles[Style.Default].Size = _scriptFontSize;
+
+            scintillaControl1.StyleClearAll();
+
+            this.scintillaControl1.Styles[Style.BraceBad].Font = _scriptFont;
+            this.scintillaControl1.Styles[Style.BraceBad].Size = _scriptFontSize;
+            this.scintillaControl1.Styles[Style.BraceLight].Font = _scriptFont;
+            this.scintillaControl1.Styles[Style.BraceLight].Size = _scriptFontSize;
+
+            this.scintillaControl1.Styles[Style.CallTip].Font = USER_FRIENDLY_FONT;
+            this.scintillaControl1.Styles[Style.CallTip].Size = USER_FRIENDLY_FONT_SIZE;
+
+            UpdateColors();
+        }
+
         public ScintillaWrapper()
         {
             // Scintilla is statically linked to our AGS.Native, therefore point to it
@@ -140,40 +225,15 @@ namespace AGS.Editor
             // otherwise lexer will not know about external defines.
             scintillaControl1.SetProperty("lexer.cpp.track.preprocessor", "0");
 
-            scintillaControl1.StyleResetDefault();
+            UpdateAllStyles();
 
-            this.scintillaControl1.Styles[Style.Default].Font = DEFAULT_FONT;
-            this.scintillaControl1.Styles[Style.Default].Size = DEFAULT_FONT_SIZE;
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].Symbol = MarkerSymbol.Background;
+            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].Symbol = MarkerSymbol.Circle;
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].Symbol = MarkerSymbol.Arrow;
+            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].Symbol = MarkerSymbol.Background;
 
-            scintillaControl1.StyleClearAll();
-
-            this.scintillaControl1.Styles[Style.BraceBad].Font = DEFAULT_FONT;
-            this.scintillaControl1.Styles[Style.BraceBad].Size = DEFAULT_FONT_SIZE;
-            this.scintillaControl1.Styles[Style.BraceBad].BackColor = Color.FromArgb(255, 0, 0);
-            this.scintillaControl1.Styles[Style.BraceLight].Font = DEFAULT_FONT;
-            this.scintillaControl1.Styles[Style.BraceLight].Size = DEFAULT_FONT_SIZE;
-            this.scintillaControl1.Styles[Style.BraceLight].Bold = true;
-            this.scintillaControl1.Styles[Style.BraceLight].BackColor = Color.FromArgb(210, 210, 0);
-
-            this.scintillaControl1.Styles[Style.Cpp.Word].ForeColor = Color.FromArgb(0, 0, 244);
-            this.scintillaControl1.Styles[Style.Cpp.Word2].ForeColor = Color.FromArgb(43, 145, 175);
-            this.scintillaControl1.Styles[Style.Cpp.GlobalClass].ForeColor = Color.FromArgb(43, 145, 175);
-            this.scintillaControl1.Styles[Style.Cpp.Comment].ForeColor = Color.FromArgb(27, 127, 27);
-            this.scintillaControl1.Styles[Style.Cpp.CommentLine].ForeColor = Color.FromArgb(27, 127, 27);
-            this.scintillaControl1.Styles[Style.Cpp.CommentDoc].ForeColor = Color.FromArgb(27, 127, 27);
-            this.scintillaControl1.Styles[Style.Cpp.CommentLineDoc].ForeColor = Color.FromArgb(27, 127, 27);
-            this.scintillaControl1.Styles[Style.Cpp.Number].ForeColor = Color.FromArgb(150, 27, 27);
-            this.scintillaControl1.Styles[Style.Cpp.String].ForeColor = Color.FromArgb(70, 7, 7);
-            this.scintillaControl1.Styles[Style.Cpp.Operator].ForeColor = Color.FromArgb(0, 70, 0);
-            this.scintillaControl1.Styles[Style.Cpp.Preprocessor].BackColor = Color.FromArgb(210, 210, 210);
-
-            this.scintillaControl1.Styles[Style.CallTip].Font = USER_FRIENDLY_FONT;
-            this.scintillaControl1.Styles[Style.CallTip].Size = USER_FRIENDLY_FONT_SIZE;
-            this.scintillaControl1.Styles[Style.CallTip].ForeColor = Color.Black;
-            this.scintillaControl1.Styles[Style.CallTip].BackColor = Color.LightGoldenrodYellow;
-
-            this.scintillaControl1.CallTipSetForeHlt(Color.FromArgb(240, 0, 0));
             this.scintillaControl1.CallTipTabSize(0);
+
             this.scintillaControl1.AutoCIgnoreCase = true;
             this.scintillaControl1.AutoCCancelAtStart = false;
             this.scintillaControl1.AutoCAutoHide = false;
@@ -189,31 +249,11 @@ namespace AGS.Editor
             this.scintillaControl1.UseTabs = Factory.AGSEditor.Settings.IndentUseTabs;
             this.scintillaControl1.UsePopup(false);
 
-            // override the selected text colour
-            this.scintillaControl1.SetSelectionForeColor(true, Color.FromArgb(255, 255, 255));
-            this.scintillaControl1.SetSelectionBackColor(true, Color.FromArgb(0, 34, 130));
-
             // remove the default margins
             this.scintillaControl1.Margins[0].Width = 0;
             this.scintillaControl1.Margins[1].Width = 16;
 
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].Symbol = MarkerSymbol.Background;
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].SetBackColor(Color.FromArgb(255, 100, 100));
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT].SetForeColor(Color.White);
-
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].Symbol = MarkerSymbol.Circle;
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].SetBackColor(Color.Red);
-            this.scintillaControl1.Markers[MARKER_TYPE_BREAKPOINT2].SetForeColor(Color.Black);
-
             this.scintillaControl1.Margins[1].Sensitive = true;
-
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].Symbol = MarkerSymbol.Arrow;
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].SetBackColor(Color.Yellow);
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT].SetForeColor(Color.White);
-
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].Symbol = MarkerSymbol.Background;
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].SetBackColor(Color.Yellow);
-            this.scintillaControl1.Markers[MARKER_TYPE_CURRENT_STATEMENT2].SetForeColor(Color.White);
 
             SetModEventMask();
 
@@ -240,33 +280,10 @@ namespace AGS.Editor
             this.scintillaControl1.Markers[Marker.FolderSub].Symbol = MarkerSymbol.VLine;
             this.scintillaControl1.Markers[Marker.FolderTail].Symbol = MarkerSymbol.LCorner;
 
-            Color FoldingForeColor = ColorTranslator.FromHtml("#F3F3F3");
-            Color FoldingBackColor = ColorTranslator.FromHtml("#808080");
-
-            this.scintillaControl1.Markers[Marker.Folder].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.Folder].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderEnd].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderEnd].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderOpen].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderOpen].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderOpenMid].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderOpenMid].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderMidTail].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderMidTail].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderEnd].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderEnd].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderSub].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderSub].SetBackColor(FoldingBackColor);
-            this.scintillaControl1.Markers[Marker.FolderTail].SetForeColor(FoldingForeColor);
-            this.scintillaControl1.Markers[Marker.FolderTail].SetBackColor(FoldingBackColor);
-
             // Indentation guides
             this.scintillaControl1.IndentationGuides = IndentView.LookBoth;
-            this.scintillaControl1.Styles[Style.IndentGuide].ForeColor = ColorTranslator.FromHtml("#DDDDDD");
 
             this.scintillaControl1.ReadOnly = true;
-
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         private void RegisterXPMImage(int type, string xpm)
@@ -1412,8 +1429,8 @@ namespace AGS.Editor
 
                 scintillaControl1.AutoCShow(charsTyped, autoCompleteList);
 
-                scintillaControl1.Styles[Style.Default].Font = DEFAULT_FONT;
-                scintillaControl1.Styles[Style.Default].Size = DEFAULT_FONT_SIZE;
+                scintillaControl1.Styles[Style.Default].Font = _scriptFont;
+                scintillaControl1.Styles[Style.Default].Size = _scriptFontSize;
         }
     }
 
@@ -2244,7 +2261,17 @@ namespace AGS.Editor
             get { return scintillaControl1.Lines.Count; }
         }
 
+        public string ScriptFont
+        {
+            set { _scriptFont = value; }
+            get { return _scriptFont; }
+        }
 
+        public int ScriptFontSize
+        {
+            set { _scriptFontSize = value; }
+            get { return _scriptFontSize; }
+        }
 
         void IScriptEditorControl.ShowLineNumbers()
         {


### PR DESCRIPTION
Allow selecting which font to use for Script Editor in AGS Editor, and also the font size.

If it's decided we don't want this now, it can be closed. But I thought it was really nice to be able to switch the default font and font size. :)

![image](https://user-images.githubusercontent.com/2244442/156946598-9e6b0236-c5c1-4c87-b66b-79a8eab4fb0f.png)