### PR TITLE
Build tools on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,17 +167,17 @@ build_android_task:
     greedy: true
   git_submodules_script: git submodule update --init --recursive
   build_prepare_script: |
-    pushd Android && ./and-build.sh prepare && popd
+    cd Android && ./and-build.sh prepare
   build_debug_library_and_runtime_script: |
-    pushd Android && ./and-build.sh build_debug && popd
+    cd Android && ./and-build.sh build_debug
   build_release_library_and_runtime_script: |
-    pushd Android && ./and-build.sh build_release && popd
+    cd Android && ./and-build.sh build_release
   rename_apks_script: |
-    pushd Android && ./and-build.sh archive_apks && popd
+    cd Android && ./and-build.sh archive_apks
   apks_artifacts:
     path: AGS-*.apk
   create_proj_archive_script: |
-    pushd Android && ./and-build.sh archive_project && popd
+    cd Android && ./and-build.sh archive_project
   proj_artifacts:
     path: AGS-*-android-proj-*.zip
 
@@ -186,7 +186,7 @@ build_emscripten_task:
   container:
     dockerfile: ci/emscripten/Dockerfile 
   build_emscripten_script: |
-    pushd Emscripten && ./build.sh && popd
+    cd Emscripten && ./build.sh
   package_emscripten_build_script: |
     tmp=/tmp/bundle$$
     version=$(awk -F"[ \"]+" '{ if ($1=="#define" && $2=="ACI_VERSION_STR") { print $3; exit } }' Common/core/def_version.h)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,8 +17,12 @@ build_windows_task:
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
     cd Solutions &&
     msbuild Engine.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform=Win32 /maxcpucount /nologo
+  build_tools_script: >
+    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
+    cd Solutions &&
+    msbuild Tools.sln /p:PlatformToolset=v140 /p:Configuration=%BUILD_CONFIG% /p:Platform=x86 /maxcpucount /nologo
   engine_pdb_artifacts:
-    path: Solutions/.build/*/*.pdb
+    path: Solutions/.build/*/acwin.pdb
   delete_engine_pdb_script: >
     cd Solutions/.build &&
     del /s *.pdb *.map *.ilk *.iobj *.ipdb
@@ -37,18 +41,21 @@ build_linux_cmake_task:
     matrix:
       - BUILD_TYPE: release
       - BUILD_TYPE: debug
+  setup_destdir_script: |
+    mkdir destdir
+    arch=$(dpkg --print-architecture)
+    ln -s destdir/usr/local/bin bin_${BUILD_TYPE}_$arch
   build_script: |
     arch=$(dpkg --print-architecture)
-    filename=${BUILD_TYPE}_$arch
-    mkdir build_$filename && cd build_$filename
-    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAGS_BUILD_COMPILER=1 -DAGS_TESTS=1  .. && make
+    mkdir build_${BUILD_TYPE}_$arch && cd build_${BUILD_TYPE}_$arch
+    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAGS_BUILD_TOOLS=1 -DAGS_TESTS=1 ..
+    make DESTDIR="$(cd ../destdir && pwd)" install
   test_linux_script: |
     arch=$(dpkg --print-architecture)
-    filename=${BUILD_TYPE}_$arch
-    cd build_$filename
+    cd build_${BUILD_TYPE}_$arch
     ctest --output-on-failure
   binaries_artifacts:
-    path: build_*/ags
+    path: bin_*/*
 
 build_linux_debian_task:
   container:
@@ -108,12 +115,18 @@ build_linux_make_task:
       matrix:
         - FROM_DEBIAN: debian:jessie
         - FROM_DEBIAN: i386/debian:jessie
-  build_script: |
+  setup_destdir_script: |
+    mkdir destdir
     arch=$(dpkg --print-architecture)
-    make --directory=Engine
-    mkdir build_$arch && mv Engine/ags build_$arch/
+    ln -s destdir/usr/local/bin bin_$arch
+  build_script: |
+    make PREFIX="$(cd destdir && pwd)/usr/local" --directory=Engine install
+  build_compiler_script: |
+    make PREFIX="$(cd destdir && pwd)/usr/local" --directory=Compiler install
+  build_tools_script: |
+    find Tools -name Makefile -execdir make PREFIX="$(cd destdir && pwd)/usr/local" install \;
   binaries_artifacts:
-    path: build_*/ags
+    path: bin_*/*
 
 build_macos_task:
   only_if: $CIRRUS_RELEASE == ''
@@ -130,16 +143,21 @@ build_macos_task:
     url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz"
     echo "Downloading CMake from $url"
     curl -fLSs "$url" | bsdtar -f - -xvzC /Applications --strip-components 1
+  setup_destdir_script: |
+    mkdir destdir
+    xcode=$(xcodebuild -version | awk '{ print $2; exit }')
+    ln -s destdir/usr/local/bin bin_${xcode}_$BUILD_TYPE
   build_script: |
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
     mkdir build_${xcode}_$BUILD_TYPE && cd build_${xcode}_$BUILD_TYPE
-    /Applications/CMake.app/Contents/bin/cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAGS_TESTS=1 -DAGS_BUILD_COMPILER=1 .. && make
+    /Applications/CMake.app/Contents/bin/cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAGS_BUILD_TOOLS=1 -DAGS_TESTS=1 ..
+    make DESTDIR="$(cd ../destdir && pwd)" install
   test_macos_script: |
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
     cd build_${xcode}_$BUILD_TYPE
     ctest --output-on-failure
   binaries_artifacts:
-    path: build_*/ags
+    path: bin_*/*
 
 build_android_task:
   container:

--- a/Tools/data/dialogscriptconv.cpp
+++ b/Tools/data/dialogscriptconv.cpp
@@ -401,7 +401,7 @@ String DialogScriptConverter::ProcessOptionOnOff(const String &line, const char 
     }
     else
     {
-        CompileError(String::FromFormat("Invalid option number: %s", option_str));
+        CompileError(String::FromFormat("Invalid option number: %s", option_str.GetCStr()));
         return "";
     }
     return String::FromFormat("dialog[%d].SetOptionState(%d,%s);", _dialog.ID, option_num, option_state);

--- a/Tools/data/mfl_utils.h
+++ b/Tools/data/mfl_utils.h
@@ -28,7 +28,6 @@ namespace DataUtil
     using AGS::Common::HError;
     using AGS::Common::Stream;
     using AGS::Common::String;
-    namespace MFLUtil = AGS::Common::MFLUtil;
 
     // Unpacks the library by reading its parts and writing assets into files.
     // lib_dir - tells the directory where the library parts are located;
@@ -46,11 +45,11 @@ namespace DataUtil
     // Writes the library partition into the file lib_filename;
     // recalculates asset offsets and stores in lib as it goes.
     HError WriteLibraryFile(AssetLibInfo &lib, const String &src_dir,
-        const String &lib_filename, MFLUtil::MFLVersion lib_version, int lib_index);
+        const String &lib_filename, AGS::Common::MFLUtil::MFLVersion lib_version, int lib_index);
     // Writes the potentially multi-file library into the dst_dir directory;
     // recalculates asset offsets and stores in lib as it goes.
     HError WriteLibrary(AssetLibInfo &lib, const String &asset_dir,
-        const String &dst_dir, MFLUtil::MFLVersion lib_version);
+        const String &dst_dir, AGS::Common::MFLUtil::MFLVersion lib_version);
 
 } // namespace DataUtil
 } // namespace AGS


### PR DESCRIPTION
- Builds tools binaries on all 3 platforms which are configured to build
- Includes 2 source changes to tools source to account for variations in the compiler being used (as far as I can tell these are errors relating to string data types and the accidental creation of a circular namespace reference)
- Removes some push and pop commands from directory switching because they mislead about how the CI is operating

Note: Tool binaries are not tested and not uploaded as part of a release