### PR TITLE
Add basic utf-8 utilities to Common, and fix extended ansi key codes in on_key_press callback

### DIFF
--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -96,6 +96,10 @@ namespace StrUtil
                 return static_cast<T>(it - arr.begin());
         return def_val;
     }
+
+    // Convert utf-8 string to ascii/ansi representation;
+    // writes into out_cstr buffer limited by out_sz bytes; returns bytes written.
+    size_t ConvertUtf8ToAscii(const char *mbstr, const char *loc_name, char *out_cstr, size_t out_sz);
 }
 } // namespace Common
 } // namespace AGS

--- a/Common/util/utf8.h
+++ b/Common/util/utf8.h
@@ -1,0 +1,111 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// UTF-8 utilities.
+// Based on utf8 code from https://c9x.me/git/irc.git/tree/irc.c
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__UTF8_H
+#define __AGS_CN_UTIL__UTF8_H
+
+#include <algorithm>
+#include <cstring>
+#include "core/types.h"
+
+namespace Utf8
+{
+
+typedef int32_t Rune;
+const size_t UtfSz = 4;
+const Rune RuneInvalid = 0xFFFD;
+
+const unsigned char utfbyte[UtfSz + 1] = { 0x80,    0, 0xC0, 0xE0, 0xF0 };
+const unsigned char utfmask[UtfSz + 1] = { 0xC0, 0x80, 0xE0, 0xF0, 0xF8 };
+const Rune utfmin[UtfSz + 1] = { 0,    0,  0x80,  0x800,  0x10000 };
+const Rune utfmax[UtfSz + 1] = { 0x10FFFF, 0x7F, 0x7FF, 0xFFFF, 0x10FFFF };
+
+
+inline size_t Validate(Rune *u, size_t i)
+{
+    if (*u < utfmin[i] || *u > utfmax[i] || (0xD800 <= *u && *u <= 0xDFFF))
+        *u = RuneInvalid;
+    for (i = 1; *u > utfmax[i]; ++i)
+        ;
+    return i;
+}
+
+inline Rune DecodeByte(unsigned char c, size_t *i)
+{
+    for (*i = 0; *i < UtfSz + 1; ++(*i))
+        if ((c & utfmask[*i]) == utfbyte[*i])
+            return c & ~utfmask[*i];
+    return 0;
+}
+
+inline char EncodeByte(Rune u, size_t i)
+{
+    return utfbyte[i] | (u & ~utfmask[i]);
+}
+
+// Read a single utf8 codepoint from the c-string;
+// returns codepoint's size in bytes (may be used to advance string pos)
+inline size_t GetChar(const char *c, size_t clen, Rune *u)
+{
+    size_t i, j, len, type;
+    Rune udecoded;
+    *u = RuneInvalid;
+    if (!clen || !*c)
+        return 0;
+    udecoded = DecodeByte(c[0], &len);
+    if (len < 1 || len > UtfSz)
+        return 1;
+    for (i = 1, j = 1; i < clen && j < len; ++i, ++j) {
+        udecoded = (udecoded << 6) | DecodeByte(c[i], &type);
+        if (type != 0)
+            return j;
+    }
+    if (j < len)
+        return 0;
+    *u = udecoded;
+    Validate(u, len);
+    return len;
+}
+
+// Convert utf8 codepoint to the string representation and write to the buffer
+inline size_t SetChar(Rune u, char *c, size_t clen)
+{
+    size_t len, i;
+    len = Validate(&u, 0);
+    if (len > UtfSz || len > clen)
+        return 0;
+    for (i = len - 1; i != 0; --i) {
+        c[i] = EncodeByte(u, 0);
+        u >>= 6;
+    }
+    c[0] = EncodeByte(u, len);
+    return len;
+}
+
+// Calculates utf8 string length in characters
+inline size_t GetLength(const char *c)
+{
+    size_t len = 0;
+    Rune r;
+    for (size_t chr_sz = 0; (chr_sz = GetChar(c, UtfSz, &r)) > 0; c += chr_sz, ++len);
+    return len;
+}
+
+} // namespace Utf8
+
+#endif // __AGS_CN_UTIL__UTF8_H

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -23,6 +23,7 @@
 #include "device/mousew32.h"
 #include "platform/base/agsplatformdriver.h"
 #include "main/engine.h"
+#include "util/string_utils.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -43,7 +44,9 @@ KeyInput ags_keycode_from_sdl(const SDL_Event &event)
     // systems where single keypress can produce that symbol.
     if (event.type == SDL_TEXTINPUT)
     {
-        unsigned char textch = event.text.text[0];
+        char ascii[sizeof(SDL_TextInputEvent::text)];
+        StrUtil::ConvertUtf8ToAscii(event.text.text, "C", &ascii[0], sizeof(ascii));
+        unsigned char textch = ascii[0];
         strncpy(ki.Text, event.text.text, KeyInput::UTF8_ARR_SIZE);
         if (textch >= 32 && textch <= 255)
             ki.Key = static_cast<eAGSKeyCode>(textch);

--- a/Engine/ac/translation.cpp
+++ b/Engine/ac/translation.cpp
@@ -12,8 +12,6 @@
 //
 //=============================================================================
 #include <cstdio>
-#include <locale.h>
-#include <wchar.h>
 #include "ac/asset_helper.h"
 #include "ac/common.h"
 #include "ac/gamesetup.h"
@@ -23,10 +21,11 @@
 #include "ac/runtime_defines.h"
 #include "ac/translation.h"
 #include "ac/wordsdictionary.h"
+#include "core/assetmanager.h"
 #include "debug/out.h"
 #include "game/tra_file.h"
 #include "util/stream.h"
-#include "core/assetmanager.h"
+#include "util/string_utils.h"
 
 using namespace AGS::Common;
 
@@ -37,25 +36,6 @@ extern GameState play;
 String trans_name;
 String trans_filename;
 Translation trans;
-
-// TODO: this is a test, later consider using C++ conversion methods
-// that do not change global locale state (but they are more confusing)
-std::vector<wchar_t> wcsbuf; // widechar buffer
-std::vector<char> mbbuf;  // utf8 buffer
-const char *convert_utf8_to_ascii(const char *mbstr, const char *loc_name)
-{
-    // First convert utf-8 string into widestring;
-    size_t len = strlen(mbstr);
-    wcsbuf.resize(len + 1); // the actual length in glyths will be <= len
-    // use uconvert, because libc funcs are locale dependent and complicate things
-    uconvert(mbstr, U_UTF8, (char*)&wcsbuf[0], U_UNICODE, wcsbuf.size() * sizeof(wchar_t));
-    // Then convert widestring to single-byte string using specified locale
-    mbbuf.resize(wcsbuf.size() * 4);
-    setlocale(LC_CTYPE, loc_name);
-    wcstombs(&mbbuf[0], &wcsbuf[0], mbbuf.size());
-    setlocale(LC_CTYPE, "");
-    return &mbbuf[0];
-}
 
 
 void close_translation () {
@@ -144,10 +124,12 @@ bool init_translation(const String &lang, const String &fallback_lang)
         if (!key_enc.IsEmpty())
         {
             StringMap conv_map;
+            std::vector<char> ascii; // ascii buffer
             for (const auto &item : trans.Dict)
             {
-                String key = convert_utf8_to_ascii(item.first.GetCStr(), key_enc.GetCStr());
-                conv_map.insert(std::make_pair(key, item.second));
+                ascii.resize(item.first.GetLength()); // ascii len will be <= utf-8 len
+                StrUtil::ConvertUtf8ToAscii(item.first.GetCStr(), key_enc.GetCStr(), &ascii[0], ascii.size());
+                conv_map.insert(std::make_pair(&ascii[0], item.second));
             }
             trans.Dict = conv_map;
         }

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -510,6 +510,7 @@
     <ClInclude Include="..\..\Common\util\textstreamreader.h" />
     <ClInclude Include="..\..\Common\util\textstreamwriter.h" />
     <ClInclude Include="..\..\Common\util\textwriter.h" />
+    <ClInclude Include="..\..\Common\util\utf8.h" />
     <ClInclude Include="..\..\Common\util\version.h" />
     <ClInclude Include="..\..\Common\util\wgt2allg.h" />
     <ClInclude Include="..\..\libsrc\allegro\src\c\cblit.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -829,5 +829,8 @@
     <ClInclude Include="..\..\Common\ac\spritefile.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\utf8.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #1561. (Also may be eventually useful for #1550)

Added some utf-8 utilities (encoding, decoding), based on the code from https://c9x.me/git/irc.git/tree/irc.c with minor adjustments.
Moved previously experimental "convert_utf8_to_ascii" function from translation.cpp to StrUtil module. Don't use allegro4 function uconvert, and use utf-8 utilities instead, to avoid depending on allegro.

Upon SDL_TEXTINPUT convert received text from utf-8 to ascii before assigning to the keycode. This fixes extended ANSI keycodes passed into on_key_press script callback.

NOTE: I had to use custom utf-8 decoding code, because apparently `setlocale` fails at setting "utf-8" on some older Windows systems (prior to Windows 10, judging by documentation, unless some patches are installed). Because of that I could not use standard `mbstowcs` to convert from utf-8 to widechar.