### PR TITLE
CI: speedup MacOS builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -138,20 +138,36 @@ build_macos_task:
     matrix:
       - BUILD_TYPE: debug
       - BUILD_TYPE: release
-    CMAKE_VERSION: 3.20.5
-  install_cmake_script: |
-    url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz"
-    echo "Downloading CMake from $url"
-    curl -fLSs "$url" | bsdtar -f - -xvzC /Applications --strip-components 1
+    CMAKE_VERSION: 3.22.3
+    NINJA_VERSION: 1.10.2
+  macos_dependencies_cache:
+    folder: dep_cache
+    fingerprint_script: echo "$CMAKE_VERSION $NINJA_VERSION"
+    populate_script: |
+      mkdir dep_cache && cd dep_cache && mkdir bin && mkdir app      
+      url="https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-mac.zip"
+      echo "Downloading Ninja from $url"
+      curl -fLSs "$url" --output "ninja-mac.zip" && unzip -d bin ninja-mac.zip && rm ninja-mac.zip
+      url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz"
+      echo "Downloading CMake from $url"
+      curl -fLSs "$url" | bsdtar -f - -xvzC app --strip-components 1
+  install_dependencies_script: |
+    cd dep_cache
+    pushd app && cp -R CMake.app /Applications/CMake.app && popd
+    cd bin && cp ninja /usr/local/bin/ninja
   setup_destdir_script: |
     mkdir destdir
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
-    ln -s destdir/usr/local/bin bin_${xcode}_$BUILD_TYPE
+    ln -s destdir/bin bin_${xcode}_$BUILD_TYPE
   build_script: |
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
     mkdir build_${xcode}_$BUILD_TYPE && cd build_${xcode}_$BUILD_TYPE
-    /Applications/CMake.app/Contents/bin/cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAGS_BUILD_TOOLS=1 -DAGS_TESTS=1 ..
-    make DESTDIR="$(cd ../destdir && pwd)" install
+    /Applications/CMake.app/Contents/bin/cmake -S .. -B . -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+      -DAGS_BUILD_TOOLS=1 \
+      -DAGS_TESTS=1 \
+      -DCMAKE_INSTALL_PREFIX="$(cd ../destdir && pwd)"
+    ninja install
   test_macos_script: |
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
     cd build_${xcode}_$BUILD_TYPE


### PR DESCRIPTION
- use ninja
- cache ninja and cmake

This at least halved the time it takes for the current MacOS builds in my tests.