### PR TITLE
Editor: Add Call Tip font preferences and additional scintilla modification

### DIFF
--- a/Editor/AGS.Editor/Entities/EditorPreferences.cs
+++ b/Editor/AGS.Editor/Entities/EditorPreferences.cs
@@ -691,7 +691,7 @@ namespace AGS.Editor.Preferences
 
         [Browsable(true)]
         [DisplayName("Script Font")]
-        [Description("Font used in the script editor.")]
+        [Description("Font used in the script editor (default: Courier New).")]
         [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("Courier New")]
@@ -708,10 +708,9 @@ namespace AGS.Editor.Preferences
             }
         }
 
-
         [Browsable(true)]
         [DisplayName("Script Font Size")]
-        [Description("Font used in the script editor.")]
+        [Description("Size of the font used in the script editor (default: 10).")]
         [Category("Script Editor")]
         [UserScopedSettingAttribute()]
         [DefaultSettingValueAttribute("10")]
@@ -725,6 +724,44 @@ namespace AGS.Editor.Preferences
             {
                 if (value < 8) value = 8;
                 this["ScriptFontSize"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Script Tip Font")]
+        [Description("Font used in description tips in the script editor (default: Tahoma).")]
+        [Category("Script Editor")]
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("Tahoma")]
+        [TypeConverter(typeof(InstalledFontTypeConverter))]
+        public string ScriptTipFont
+        {
+            get
+            {
+                return (string)(this["ScriptTipFont"]);
+            }
+            set
+            {
+                this["ScriptTipFont"] = value;
+            }
+        }
+
+        [Browsable(true)]
+        [DisplayName("Script Tip Font Size")]
+        [Description("Size of the font used in description tips in the script editor. Script editor line height uses biggest height accross fonts. (default: 8).")]
+        [Category("Script Editor")]
+        [UserScopedSettingAttribute()]
+        [DefaultSettingValueAttribute("8")]
+        public int ScriptTipFontSize
+        {
+            get
+            {
+                return (int)(this["ScriptTipFontSize"]);
+            }
+            set
+            {
+                if (value < 6) value = 6;
+                this["ScriptTipFontSize"] = value;
             }
         }
 

--- a/Editor/AGS.Editor/GUI/PreferencesEditor.cs
+++ b/Editor/AGS.Editor/GUI/PreferencesEditor.cs
@@ -45,6 +45,8 @@ namespace AGS.Editor
                     {
                         scintilla.ScriptFont = _settings.ScriptFont;
                         scintilla.ScriptFontSize = _settings.ScriptFontSize;
+                        scintilla.CallTipFont = _settings.ScriptTipFont;
+                        scintilla.CallTipFontSize = _settings.ScriptTipFontSize;
                         scintilla.UpdateAllStyles();
                     }
                 }

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -1425,15 +1425,9 @@ namespace AGS.Editor
             }
             if (autoCompleteList.Length > 0)
             {
-                scintillaControl1.Styles[Style.Default].Font = USER_FRIENDLY_FONT;
-                scintillaControl1.Styles[Style.Default].Size = USER_FRIENDLY_FONT_SIZE;
-
                 scintillaControl1.AutoCShow(charsTyped, autoCompleteList);
-
-                scintillaControl1.Styles[Style.Default].Font = _scriptFont;
-                scintillaControl1.Styles[Style.Default].Size = _scriptFontSize;
+            }
         }
-    }
 
         private bool CheckForAndShowEnumAutocomplete(int checkAtPos)
         {

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -38,8 +38,6 @@ namespace AGS.Editor
         private const int INVALID_POSITION = -1;
         private const int AUTOCOMPLETE_MINIMUM_WORD_LENGTH = 3;
         private const int SCAN_BACK_DISTANCE = 50;
-        private const string USER_FRIENDLY_FONT = "Tahoma";
-        private const int USER_FRIENDLY_FONT_SIZE = 8;
         private const string AUTO_COMPLETE_CANCEL_CHARS = ")}; ";
         private const int IMAGE_INDEX_PROPERTY = 1;
         private const int IMAGE_INDEX_METHOD = 2;
@@ -103,6 +101,8 @@ namespace AGS.Editor
 
         private string _scriptFont = Factory.AGSEditor.Settings.ScriptFont;
         private int _scriptFontSize = Factory.AGSEditor.Settings.ScriptFontSize;
+        private string _calltipFont = Factory.AGSEditor.Settings.ScriptTipFont;
+        private int _calltipFontSize = Factory.AGSEditor.Settings.ScriptTipFontSize;
 
         private void UpdateColors()
         {
@@ -182,8 +182,8 @@ namespace AGS.Editor
             this.scintillaControl1.Styles[Style.BraceLight].Font = _scriptFont;
             this.scintillaControl1.Styles[Style.BraceLight].Size = _scriptFontSize;
 
-            this.scintillaControl1.Styles[Style.CallTip].Font = USER_FRIENDLY_FONT;
-            this.scintillaControl1.Styles[Style.CallTip].Size = USER_FRIENDLY_FONT_SIZE;
+            this.scintillaControl1.Styles[Style.CallTip].Font = _calltipFont;
+            this.scintillaControl1.Styles[Style.CallTip].Size = _calltipFontSize;
 
             if(this.scintillaControl1.Margins[0].Width > 0) EnableLineNumbers();
             UpdateColors();
@@ -2266,6 +2266,18 @@ namespace AGS.Editor
         {
             set { _scriptFontSize = value; }
             get { return _scriptFontSize; }
+        }
+
+        public string CallTipFont
+        {
+            set { _calltipFont = value; }
+            get { return _calltipFont; }
+        }
+
+        public int CallTipFontSize
+        {
+            set { _calltipFontSize = value; }
+            get { return _calltipFontSize; }
         }
 
         void IScriptEditorControl.ShowLineNumbers()


### PR DESCRIPTION
- makes Scintilla use same font style for AutoComplete as the one used for Script
- adds a preference entry for call tip font and font size

---

After #1557 it appears to be a good idea to include a way to modify the tooltip font used in the editor.

Also there's an issue with AutoComplete when font height is changed mentioned here: https://github.com/adventuregamestudio/ags/pull/1557#issuecomment-1061644287

[Scintilla Docs](https://www.scintilla.org/ScintillaDoc.html) also mentions the following

> All lines of text in Scintilla are the same height, and this height is calculated from the largest font in any current style.

