### PR TITLE
Provide "on_text_input" callback for handling unicode characters

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -79,7 +79,8 @@
 #define OPT_WALKSPEEDABSOLUTE 47 // if movement speeds are independent of walkable mask resolution
 #define OPT_CLIPGUICONTROLS 48 // clip drawn gui control contents to the control's rectangle
 #define OPT_GAMETEXTENCODING 49 // how the text in the game data should be interpreted
-#define OPT_HIGHESTOPTION   OPT_GAMETEXTENCODING
+#define OPT_KEYHANDLEAPI    50 // key handling mode (old/new)
+#define OPT_HIGHESTOPTION   OPT_KEYHANDLEAPI
 #define OPT_NOMODMUSIC      98
 #define OPT_LIPSYNCTEXT     99
 #define PORTRAIT_LEFT       0

--- a/Common/ac/keycode.h
+++ b/Common/ac/keycode.h
@@ -254,7 +254,9 @@ enum eAGSKeyMod
     eAGSModLCtrl  = 0x0004,
     eAGSModRCtrl  = 0x0008,
     eAGSModLAlt   = 0x0010,
-    eAGSModRAlt   = 0x0020
+    eAGSModRAlt   = 0x0020,
+    eAGSModNum    = 0x0040,
+    eAGSModCaps   = 0x0080,
 };
 
 

--- a/Common/ac/keycode.h
+++ b/Common/ac/keycode.h
@@ -252,8 +252,9 @@ struct KeyInput
 {
     const static size_t UTF8_ARR_SIZE = 5;
 
-    eAGSKeyCode Key = eAGSKeyCodeNone;
-    char        Text[UTF8_ARR_SIZE] = { 0 };
+    eAGSKeyCode Key = eAGSKeyCodeNone; // actual key code
+    int         UChar = 0; // full character value (supports unicode)
+    char        Text[UTF8_ARR_SIZE]{}; // character in a string format
 
     KeyInput() = default;
 };

--- a/Common/ac/keycode.h
+++ b/Common/ac/keycode.h
@@ -246,6 +246,17 @@ enum eAGSKeyCode
     */
 };
 
+// AGS key modifiers
+enum eAGSKeyMod
+{
+    eAGSModLShift = 0x0001,
+    eAGSModRShift = 0x0002,
+    eAGSModLCtrl  = 0x0004,
+    eAGSModRCtrl  = 0x0008,
+    eAGSModLAlt   = 0x0010,
+    eAGSModRAlt   = 0x0020
+};
+
 
 // Combined key code and a textual representation in UTF-8
 struct KeyInput
@@ -253,6 +264,7 @@ struct KeyInput
     const static size_t UTF8_ARR_SIZE = 5;
 
     eAGSKeyCode Key = eAGSKeyCodeNone; // actual key code
+    int         Mod = 0; // key modifiers
     int         UChar = 0; // full character value (supports unicode)
     char        Text[UTF8_ARR_SIZE]{}; // character in a string format
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -98,6 +98,7 @@ namespace AGS.Editor
          *                - Cursor.AnimationDelay
          *                - Room.BackgroundAnimationEnabled
          *                - RuntimeSetup.FullscreenDesktop
+         * 3.6.0.20       - Settings.GameTextEncoding, Settings.UseOldKeyboardHandling;
         */
         public const int    LATEST_XML_VERSION_INDEX = 3060020;
         /*
@@ -925,6 +926,10 @@ namespace AGS.Editor
             if (!_game.Settings.UseOldCustomDialogOptionsAPI)
             {
                 preprocessor.DefineMacro("NEW_DIALOGOPTS_API", "1");
+            }
+            if (!_game.Settings.UseOldKeyboardHandling)
+            {
+                preprocessor.DefineMacro("NEW_KEYINPUT_API", "1");
             }
             // Define Script API level macros
             foreach (ScriptAPIVersion v in Enum.GetValues(typeof(ScriptAPIVersion)))

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -579,6 +579,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_WALKSPEEDABSOLUTE] = (game.Settings.ScaleMovementSpeedWithMaskResolution ? 0 : 1);
             options[NativeConstants.GameOptions.OPT_CLIPGUICONTROLS] = (game.Settings.ClipGUIControls ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_GAMETEXTENCODING] = game.TextEncoding.CodePage;
+            options[NativeConstants.GameOptions.OPT_KEYHANDLEAPI] = (game.Settings.UseOldKeyboardHandling ? 0 : 1);
             options[NativeConstants.GameOptions.OPT_LIPSYNCTEXT] = (game.LipSync.Type == LipSyncType.Text ? 1 : 0);
             for (int i = 0; i < options.Length; ++i) // writing only ints, alignment preserved
             {

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -1861,6 +1861,14 @@ namespace AGS.Editor
             {
                 return false;
             }
+            if ((token.IfNDefOnly == "NEW_KEYINPUT_API") && (!gameSettings.UseOldKeyboardHandling))
+            {
+                return false;
+            }
+            if ((token.IfDefOnly == "NEW_KEYINPUT_API") && (gameSettings.UseOldKeyboardHandling))
+            {
+                return false;
+            }
             if (token.IfNDefOnly != null && token.IfNDefOnly.StartsWith("SCRIPT_API_"))
             {
                 ScriptAPIVersion? v = GetAPIVersionFromString(token.IfNDefOnly.Substring("SCRIPT_API_".Length));

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -362,6 +362,21 @@ enum eKeyCode
   eKeyF12 = 434
 };
 
+#ifdef SCRIPT_API_v360
+enum eKeyMod
+{
+  eKeyModShiftLeft  = 0x0001,
+  eKeyModShiftRight = 0x0002,
+  eKeyModShift      = 0x0003,
+  eKeyModCtrlLeft   = 0x0004,
+  eKeyModCtrlRight  = 0x0008,
+  eKeyModCtrl       = 0x000C,
+  eKeyModAltLeft    = 0x0010,
+  eKeyModAltRight   = 0x0020,
+  eKeyModAlt        = 0x0030
+};
+#endif
+
 #ifdef SCRIPT_API_v3507
 managed struct Point {
 	int x, y;

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -373,7 +373,9 @@ enum eKeyMod
   eKeyModCtrl       = 0x000C,
   eKeyModAltLeft    = 0x0010,
   eKeyModAltRight   = 0x0020,
-  eKeyModAlt        = 0x0030
+  eKeyModAlt        = 0x0030,
+  eKeyModNum        = 0x0040,
+  eKeyModCaps       = 0x0080,
 };
 #endif
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -396,6 +396,8 @@ namespace AGS.Editor
                 { // NOTE: use Encoding.GetEncoding(game.SavedXmlEncodingCodePage) if actual codepage is needed
                     game.Settings.GameTextEncoding = "ANSI";
                 }
+
+                game.Settings.UseOldKeyboardHandling = true;
             }
 
             System.Version editorVersion = new System.Version(AGS.Types.Version.AGS_EDITOR_VERSION);

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -133,6 +133,7 @@ namespace AGS.Editor
             public static readonly int OPT_WALKSPEEDABSOLUTE = (int)Factory.NativeProxy.GetNativeConstant("OPT_WALKSPEEDABSOLUTE");
             public static readonly int OPT_CLIPGUICONTROLS = (int)Factory.NativeProxy.GetNativeConstant("OPT_CLIPGUICONTROLS");
             public static readonly int OPT_GAMETEXTENCODING = (int)Factory.NativeProxy.GetNativeConstant("OPT_GAMETEXTENCODING");
+            public static readonly int OPT_KEYHANDLEAPI = (int)Factory.NativeProxy.GetNativeConstant("OPT_KEYHANDLEAPI");
             public static readonly int OPT_LIPSYNCTEXT = (int)Factory.NativeProxy.GetNativeConstant("OPT_LIPSYNCTEXT");
         }
     }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -825,6 +825,7 @@ namespace AGS
             if (name->Equals("OPT_WALKSPEEDABSOLUTE")) return OPT_WALKSPEEDABSOLUTE;
             if (name->Equals("OPT_CLIPGUICONTROLS")) return OPT_CLIPGUICONTROLS;
             if (name->Equals("OPT_GAMETEXTENCODING")) return OPT_GAMETEXTENCODING;
+            if (name->Equals("OPT_KEYHANDLEAPI")) return OPT_KEYHANDLEAPI;
             if (name->Equals("OPT_LIPSYNCTEXT")) return OPT_LIPSYNCTEXT;
 			if (name->Equals("MAX_PLUGINS")) return MAX_PLUGINS;
             return nullptr;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3085,6 +3085,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
     game->Settings->RenderAtScreenResolution = (RenderAtScreenResolution)thisgame.options[OPT_RENDERATSCREENRES];
     game->Settings->AllowRelativeAssetResolutions = (thisgame.options[OPT_RELATIVEASSETRES] != 0);
     game->Settings->ScaleMovementSpeedWithMaskResolution = (thisgame.options[OPT_WALKSPEEDABSOLUTE] == 0);
+    game->Settings->UseOldKeyboardHandling = (thisgame.options[OPT_KEYHANDLEAPI] == 0);
 
     TextConverter^ tcv = gcnew TextConverter(game->TextEncoding);
 

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -79,6 +79,7 @@ namespace AGS.Types
         private bool _enforceNewStrings = true;
         private bool _enforceNewAudio = true;
         private bool _oldCustomDlgOptsAPI = false;
+        private bool _oldKeyHandling = false;
         private int _playSoundOnScore = -1;
         private CrossfadeSpeed _crossfadeMusic = CrossfadeSpeed.No;
         private int _dialogOptionsGUI = 0;
@@ -757,6 +758,16 @@ namespace AGS.Types
         {
             get { return _oldCustomDlgOptsAPI; }
             set { _oldCustomDlgOptsAPI = value; }
+        }
+
+        [DisplayName("Use old-style keyboard handling")]
+        [Description("Use pre-unicode mode key codes in 'on_key_press' function, where regular keys were merged with Ctrl and Alt modifiers.")]
+        [DefaultValue(false)]
+        [Category("Backwards Compatibility")]
+        public bool UseOldKeyboardHandling
+        {
+            get { return _oldKeyHandling; }
+            set { _oldKeyHandling = value; }
         }
 
         [DisplayName("Left-to-right operator precedence")]

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -914,6 +914,7 @@ bool DialogOptions::Run()
         {
             runDialogOptionKeyPressHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
             runDialogOptionKeyPressHandlerFunc.params[1].SetInt32(AGSKeyToScriptKey(gkey));
+            runDialogOptionKeyPressHandlerFunc.params[2].SetInt32(ki.Mod);
             run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
             runDialogOptionTextInputHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
             runDialogOptionTextInputHandlerFunc.params[1].SetInt32(ki.UChar);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -858,6 +858,7 @@ bool DialogOptions::Run()
     sys_evt_process_pending();
 
     const bool new_custom_render = usingCustomRendering && game.options[OPT_DIALOGOPTIONSAPI] >= 0;
+    const bool old_keyhandle = game.options[OPT_KEYHANDLEAPI] == 0;
 
       if (runGameLoopsInBackground)
       {
@@ -912,13 +913,19 @@ bool DialogOptions::Run()
         }
         else if (new_custom_render)
         {
-            runDialogOptionKeyPressHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
-            runDialogOptionKeyPressHandlerFunc.params[1].SetInt32(AGSKeyToScriptKey(gkey));
-            runDialogOptionKeyPressHandlerFunc.params[2].SetInt32(ki.Mod);
-            run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
-            runDialogOptionTextInputHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
-            runDialogOptionTextInputHandlerFunc.params[1].SetInt32(ki.UChar);
-            run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
+            if (old_keyhandle || (ki.UChar == 0))
+            { // "dialog_options_key_press"
+                runDialogOptionKeyPressHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
+                runDialogOptionKeyPressHandlerFunc.params[1].SetInt32(AGSKeyToScriptKey(gkey));
+                runDialogOptionKeyPressHandlerFunc.params[2].SetInt32(ki.Mod);
+                run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
+            }
+            if (!old_keyhandle && (ki.UChar > 0))
+            { // "dialog_options_text_input"
+                runDialogOptionTextInputHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
+                runDialogOptionTextInputHandlerFunc.params[1].SetInt32(ki.UChar);
+                run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
+            }
         }
         // Allow selection of options by keyboard shortcuts
         else if (game.options[OPT_DIALOGNUMBERED] >= kDlgOptKeysOnly &&

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -915,6 +915,9 @@ bool DialogOptions::Run()
             runDialogOptionKeyPressHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
             runDialogOptionKeyPressHandlerFunc.params[1].SetInt32(AGSKeyToScriptKey(gkey));
             run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
+            runDialogOptionTextInputHandlerFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
+            runDialogOptionTextInputHandlerFunc.params[1].SetInt32(ki.UChar);
+            run_function_on_non_blocking_thread(&runDialogOptionKeyPressHandlerFunc);
         }
         // Allow selection of options by keyboard shortcuts
         else if (game.options[OPT_DIALOGNUMBERED] >= kDlgOptKeysOnly &&

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -154,13 +154,13 @@ void process_event(const EventHappened *evp) {
     RuntimeScriptValue rval_null;
     if (evp->type==EV_TEXTSCRIPT) {
         ccError=0;
-        if (evp->data2 > -1000) {
-            RuntimeScriptValue params[]{ evp->data2 };
+        RuntimeScriptValue params[2]{ evp->data2, evp->data3 };
+        if (evp->data3 > -1000)
+            QueueScriptFunction(kScInstGame, tsnames[evp->data1], 2, params);
+        else if (evp->data2 > -1000)
             QueueScriptFunction(kScInstGame, tsnames[evp->data1], 1, params);
-        }
-        else {
+        else
             QueueScriptFunction(kScInstGame, tsnames[evp->data1]);
-        }
     }
     else if (evp->type==EV_NEWROOM) {
         NewRoom(evp->data1);

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -58,7 +58,7 @@ int evblocknum;
 int inside_processevent=0;
 int eventClaimed = EVENT_NONE;
 
-const char *tsnames[TS_NUM] = { nullptr, REP_EXEC_NAME, "on_key_press", "on_mouse_click" };
+const char *tsnames[TS_NUM] = { nullptr, REP_EXEC_NAME, "on_key_press", "on_mouse_click", "on_text_input" };
 
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed) {

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -37,12 +37,13 @@
 #define EV_FADEIN     3
 #define EV_IFACECLICK 4
 #define EV_NEWROOM    5
-#define TS_REPEAT   1
-#define TS_KEYPRESS 2
-#define TS_MCLICK   3
-#define TS_NUM      4
-#define EVB_HOTSPOT 1
-#define EVB_ROOM    2
+#define TS_REPEAT     1
+#define TS_KEYPRESS   2
+#define TS_MCLICK     3
+#define TS_TEXTINPUT  4
+#define TS_NUM        5
+#define EVB_HOTSPOT   1
+#define EVB_ROOM      2
 
 struct EventHappened {
     int type = 0;

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -57,8 +57,8 @@ void run_on_event (int evtype, RuntimeScriptValue &wparam);
 void run_room_event(int id);
 void run_event_block_inv(int invNum, int event);
 // event list functions
-void setevent(int evtyp,int ev1=0,int ev2=-1000,int ev3=0);
-void force_event(int evtyp,int ev1=0,int ev2=-1000,int ev3=0);
+void setevent(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);
+void force_event(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);
 void process_event(const EventHappened *evp);
 void runevent_now (int evtyp, int ev1, int ev2, int ev3);
 void processallevents();

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -505,6 +505,7 @@ void unload_game_file()
     getDialogOptionUnderCursorFunc.moduleHasFunction.resize(0);
     runDialogOptionMouseClickHandlerFunc.moduleHasFunction.resize(0);
     runDialogOptionKeyPressHandlerFunc.moduleHasFunction.resize(0);
+    runDialogOptionTextInputHandlerFunc.moduleHasFunction.resize(0);
     runDialogOptionRepExecFunc.moduleHasFunction.resize(0);
     numScriptModules = 0;
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -24,6 +24,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "main/engine.h"
 #include "util/string_utils.h"
+#include "util/utf8.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -47,9 +48,10 @@ KeyInput ags_keycode_from_sdl(const SDL_Event &event)
         char ascii[sizeof(SDL_TextInputEvent::text)];
         StrUtil::ConvertUtf8ToAscii(event.text.text, "C", &ascii[0], sizeof(ascii));
         unsigned char textch = ascii[0];
-        strncpy(ki.Text, event.text.text, KeyInput::UTF8_ARR_SIZE);
         if (textch >= 32 && textch <= 255)
             ki.Key = static_cast<eAGSKeyCode>(textch);
+        strncpy(ki.Text, event.text.text, KeyInput::UTF8_ARR_SIZE);
+        Utf8::GetChar(event.text.text, sizeof(SDL_TextInputEvent::text), &ki.UChar);
         return ki;
     }
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -31,7 +31,7 @@ using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 
-eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt);
+eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt, int &ags_mod);
 
 // Converts SDL scan and key codes to the ags keycode
 KeyInput ags_keycode_from_sdl(const SDL_Event &event)
@@ -56,15 +56,27 @@ KeyInput ags_keycode_from_sdl(const SDL_Event &event)
     }
 
     if (event.type == SDL_KEYDOWN)
-        ki.Key = sdl_key_to_ags_key(event.key);
+    {
+        ki.Key = sdl_key_to_ags_key(event.key, ki.Mod);
+    }
     return ki;
 }
 
-eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt)
+eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt, int &ags_mod)
 {
     const SDL_Keysym key = kbevt.keysym;
     const SDL_Keycode sym = key.sym;
     const Uint16 mod = key.mod;
+
+    // First handle the mods, - these are straightforward
+    ags_mod = 0;
+    if (mod & KMOD_LSHIFT) ags_mod |= eAGSModLShift;
+    if (mod & KMOD_RSHIFT) ags_mod |= eAGSModRShift;
+    if (mod & KMOD_LCTRL)  ags_mod |= eAGSModLCtrl;
+    if (mod & KMOD_RCTRL)  ags_mod |= eAGSModRCtrl;
+    if (mod & KMOD_LALT)   ags_mod |= eAGSModLAlt;
+    if (mod & KMOD_RALT)   ags_mod |= eAGSModRAlt;
+
     // Ctrl and Alt combinations realign the letter code to certain offset
     if (sym >= SDLK_a && sym <= SDLK_z)
     {

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -76,6 +76,8 @@ eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt, int &ags_mod, boo
     if (mod & KMOD_RCTRL)  ags_mod |= eAGSModRCtrl;
     if (mod & KMOD_LALT)   ags_mod |= eAGSModLAlt;
     if (mod & KMOD_RALT)   ags_mod |= eAGSModRAlt;
+    if (mod & KMOD_NUM)    ags_mod |= eAGSModNum;
+    if (mod & KMOD_CAPS)   ags_mod |= eAGSModCaps;
 
     // Old mode: Ctrl and Alt combinations realign the letter code to certain offset
     if (old_keyhandle && (sym >= SDLK_a && sym <= SDLK_z))

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -43,7 +43,8 @@ union SDL_Event;
 
 // Converts SDL key data to eAGSKeyCode, which may be also directly used as an ASCII char
 // if it is in proper range, see comments to eAGSKeyCode for details.
-KeyInput ags_keycode_from_sdl(const SDL_Event &event);
+// Optionally works in bacward compatible mode (old_keyhandle)
+KeyInput ags_keycode_from_sdl(const SDL_Event &event, bool old_keyhandle);
 // Converts eAGSKeyCode to SDL key scans (up to 3 values, because this is not a 1:1 match);
 // NOTE: fails at Ctrl+ or Alt+ AGS keys, or any unknown key codes.
 bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3]);

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -405,6 +405,7 @@ void AllocScriptModules()
     getDialogOptionUnderCursorFunc.moduleHasFunction.resize(numScriptModules, true);
     runDialogOptionMouseClickHandlerFunc.moduleHasFunction.resize(numScriptModules, true);
     runDialogOptionKeyPressHandlerFunc.moduleHasFunction.resize(numScriptModules, true);
+    runDialogOptionTextInputHandlerFunc.moduleHasFunction.resize(numScriptModules, true);
     runDialogOptionRepExecFunc.moduleHasFunction.resize(numScriptModules, true);
     for (int i = 0; i < numScriptModules; ++i)
     {

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -548,7 +548,12 @@ static void check_keyboard_controls()
     if (!keywasprocessed) {
         int sckey = AGSKeyToScriptKey(kgn);
         debug_script_log("Running on_key_press keycode %d", sckey);
-        setevent(EV_TEXTSCRIPT,TS_KEYPRESS, sckey);
+        setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey);
+        if (ki.UChar > 0)
+        {
+            debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);
+            setevent(EV_TEXTSCRIPT, TS_TEXTINPUT, ki.UChar);
+        }
     }
 }
 

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -547,8 +547,9 @@ static void check_keyboard_controls()
 
     if (!keywasprocessed) {
         int sckey = AGSKeyToScriptKey(kgn);
-        debug_script_log("Running on_key_press keycode %d", sckey);
-        setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey);
+        int sckeymod = ki.Mod;
+        debug_script_log("Running on_key_press keycode %d, mod %d", sckey, sckeymod);
+        setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey, sckeymod);
         if (ki.UChar > 0)
         {
             debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -288,8 +288,14 @@ int old_key_mod = 0; // for saving previous key mods
 
 // Runs service key controls, returns false if service key combinations were handled
 // and no more processing required, otherwise returns true and provides current keycode and key shifts.
+//
+// * old_keyhandle mode is a backward compatible input handling mode, where
+//   - lone mod keys are not passed further into the engine;
+//   - key + mod combos are merged into one key code for the script callback.
 bool run_service_key_controls(KeyInput &out_key)
 {
+    const bool old_keyhandle = (game.options[OPT_KEYHANDLEAPI] == 0);
+
     bool handled = false;
     const bool key_valid = ags_keyevent_ready();
     const SDL_Event key_evt = key_valid ? ags_get_next_keyevent() : SDL_Event();
@@ -351,11 +357,10 @@ bool run_service_key_controls(KeyInput &out_key)
 
     if (!key_valid)
         return false; // if there was no key press, finish after handling current mod state
-    if (is_only_mod_key || handled)
-        return false; // rest of engine currently does not use pressed mod keys
-                      // change this when it's no longer true (but be mindful about key-skipping!)
+    if (handled || (old_keyhandle && is_only_mod_key))
+        return false; // in backward mode the engine does not react to single mod keys
 
-    KeyInput ki = ags_keycode_from_sdl(key_evt);
+    KeyInput ki = ags_keycode_from_sdl(key_evt, old_keyhandle);
     eAGSKeyCode agskey = ki.Key;
     if (agskey == eAGSKeyCodeNone)
         return false; // should skip this key event
@@ -460,6 +465,7 @@ bool run_service_mb_controls(int &mbut, int &mwheelz)
 // Runs default keyboard handling
 static void check_keyboard_controls()
 {
+    const bool old_keyhandle = game.options[OPT_KEYHANDLEAPI] == 0;
     // First check for service engine's combinations (mouse lock, display mode switch, and so forth)
     KeyInput ki;
     if (!run_service_key_controls(ki)) {
@@ -548,9 +554,12 @@ static void check_keyboard_controls()
     if (!keywasprocessed) {
         int sckey = AGSKeyToScriptKey(kgn);
         int sckeymod = ki.Mod;
-        debug_script_log("Running on_key_press keycode %d, mod %d", sckey, sckeymod);
-        setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey, sckeymod);
-        if (ki.UChar > 0)
+        if (old_keyhandle || (ki.UChar == 0))
+        {
+            debug_script_log("Running on_key_press keycode %d, mod %d", sckey, sckeymod);
+            setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey, sckeymod);
+        }
+        if (!old_keyhandle && (ki.UChar > 0))
         {
             debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);
             setevent(EV_TEXTSCRIPT, TS_TEXTINPUT, ki.UChar);

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -40,9 +40,9 @@ void UpdateGameAudioOnly();
 // Gets current logical game FPS, this is normally a fixed number set in script;
 // in case of "maxed fps" mode this function returns real measured FPS.
 float get_current_fps();
+struct KeyInput;
 // Runs service key controls, returns false if no key was pressed or key input was claimed by the engine,
 // otherwise returns true and provides a keycode.
-struct KeyInput;
 bool run_service_key_controls(KeyInput &kgn);
 // Runs service mouse controls, returns false if mouse input was claimed by the engine,
 // otherwise returns true and provides mouse button code.

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -308,18 +308,20 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
     int32_t startat = -1;
     int k;
     char mangledName[200];
-    sprintf(mangledName, "%s$", funcname);
+    size_t mangled_len = snprintf(mangledName, sizeof(mangledName), "%s$", funcname);
+    int export_args = 0;
 
     for (k = 0; k < instanceof->numexports; k++) {
         char *thisExportName = instanceof->exports[k];
         int match = 0;
 
         // check for a mangled name match
-        if (strncmp(thisExportName, mangledName, strlen(mangledName)) == 0) {
+        if (strncmp(thisExportName, mangledName, mangled_len) == 0) {
             // found, compare the number of parameters
-            char *numParams = thisExportName + strlen(mangledName);
-            if (atoi(numParams) != numargs) {
-                cc_error("wrong number of parameters to exported function '%s' (expected %d, supplied %d)", funcname, atoi(numParams), numargs);
+            export_args = atoi(thisExportName + mangled_len);
+            if (export_args > numargs) {
+                cc_error("wrong number of parameters to exported function '%s' (expected %d, supplied %d)",
+                    funcname, export_args, numargs);
                 return -1;
             }
             match = 1;
@@ -341,6 +343,9 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
         cc_error("function '%s' not found", funcname);
         return -2;
     }
+
+    // Allow to pass less parameters if script callback has less declared args
+    numargs = std::min(numargs, export_args);
 
     //numargs++;                    // account for return address
     flags &= ~INSTF_ABORTED;

--- a/Engine/script/nonblockingscriptfunction.h
+++ b/Engine/script/nonblockingscriptfunction.h
@@ -27,9 +27,7 @@ struct NonBlockingScriptFunction
 {
     const char* functionName;
     int numParameters;
-    //void* param1;
-    //void* param2;
-    RuntimeScriptValue params[2];
+    RuntimeScriptValue params[3];
     bool roomHasFunction;
     bool globalScriptHasFunction;
     std::vector<bool> moduleHasFunction;

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -504,7 +504,7 @@ int RunScriptFunctionAuto(ScriptInstType sc_inst, const char *tsname, size_t par
     // Claimable event is run in all the script modules and room script,
     // before running in the globalscript instance
     if ((strcmp(tsname, tsnames[TS_KEYPRESS]) == 0) || (strcmp(tsname, tsnames[TS_MCLICK]) == 0) ||
-        (strcmp(tsname, "on_event") == 0))
+        (strcmp(tsname, tsnames[TS_TEXTINPUT]) == 0) || (strcmp(tsname, "on_event") == 0))
     {
         return RunClaimableEvent(tsname, param_count, params);
     }

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -74,7 +74,7 @@ NonBlockingScriptFunction getDialogOptionsDimensionsFunc("dialog_options_get_dim
 NonBlockingScriptFunction renderDialogOptionsFunc("dialog_options_render", 1);
 NonBlockingScriptFunction getDialogOptionUnderCursorFunc("dialog_options_get_active", 1);
 NonBlockingScriptFunction runDialogOptionMouseClickHandlerFunc("dialog_options_mouse_click", 2);
-NonBlockingScriptFunction runDialogOptionKeyPressHandlerFunc("dialog_options_key_press", 2);
+NonBlockingScriptFunction runDialogOptionKeyPressHandlerFunc("dialog_options_key_press", 3);
 NonBlockingScriptFunction runDialogOptionTextInputHandlerFunc("dialog_options_text_input", 2);
 NonBlockingScriptFunction runDialogOptionRepExecFunc("dialog_options_repexec", 1);
 

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -75,6 +75,7 @@ NonBlockingScriptFunction renderDialogOptionsFunc("dialog_options_render", 1);
 NonBlockingScriptFunction getDialogOptionUnderCursorFunc("dialog_options_get_active", 1);
 NonBlockingScriptFunction runDialogOptionMouseClickHandlerFunc("dialog_options_mouse_click", 2);
 NonBlockingScriptFunction runDialogOptionKeyPressHandlerFunc("dialog_options_key_press", 2);
+NonBlockingScriptFunction runDialogOptionTextInputHandlerFunc("dialog_options_text_input", 2);
 NonBlockingScriptFunction runDialogOptionRepExecFunc("dialog_options_repexec", 1);
 
 ScriptSystem scsystem;

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -104,6 +104,7 @@ extern NonBlockingScriptFunction renderDialogOptionsFunc;
 extern NonBlockingScriptFunction getDialogOptionUnderCursorFunc;
 extern NonBlockingScriptFunction runDialogOptionMouseClickHandlerFunc;
 extern NonBlockingScriptFunction runDialogOptionKeyPressHandlerFunc;
+extern NonBlockingScriptFunction runDialogOptionTextInputHandlerFunc;
 extern NonBlockingScriptFunction runDialogOptionRepExecFunc;
 
 extern ScriptSystem scsystem;


### PR DESCRIPTION
Resolves #1563.

Existing `on_key_press` callback is not enough for handling keyboard input in unicode mode, and has other limitations even in ascii mode. The keycodes it receives do not represent the actual character typed, but rather key pressed, where textual representation depends on various factors. While this callback is enough for handling key presses, it may complicate coding of custom input fields in the user script.

This pr proposes a new `on_text_input (int chr)` callback, which receives a text character code in the current game mode (ascii or unicode).
Additionally `dialog_options_text_input(int chr)` callback is meant for doing the same in the "custom dialog options render" state (it may be seen inconvenient that we have such separation between 2 game states, but nothing may be improved here without a larger api change).

---

There's still a pending question of whether to change how `on_key_press` is run in case of multi-key input sequences. For example, when using "International English" layout some letters are typed by pressing `~` or `'` and then a letter key, in a sequence. Similar situation may take place in case of e.g. Chinese layouts where user has to press multiple keys in order to create 1 character (at least from what I heard).

While SDL handles each of these key presses, AGS engine does not let the event through until a final letter is formed. This may be changed for unicode mode. Then `on_key_press` will be called for any real key down, while `on_text_input` will be used for text input.