### PR TITLE
Engine: support option for software renderer's output driver

### DIFF
--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -90,6 +90,7 @@ struct GameSetup {
     ScreenRotation rotation;
 
     DisplayModeSetup Screen;
+    String software_render_driver;
 
     GameSetup();
 };

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -457,6 +457,7 @@ void apply_config(const ConfigTree &cfg)
         usetup.Screen.Params.VSync = INIreadint(cfg, "graphics", "vsync") > 0;
         usetup.RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres") > 0;
         usetup.Supersampling = INIreadint(cfg, "graphics", "supersampling", 1);
+        usetup.software_render_driver = INIreadstring(cfg, "graphics", "software_driver");
 
         usetup.rotation = (ScreenRotation)INIreadint(cfg, "graphics", "rotation", usetup.rotation);
         String rotation_str = INIreadstring(cfg, "graphics", "rotation", "unlocked");

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1334,6 +1334,8 @@ bool engine_try_set_gfxmode_any(const DisplayModeSetup &setup)
 {
     engine_shutdown_gfxmode();
 
+    sys_renderer_set_output(usetup.software_render_driver);
+
     const Size init_desktop = get_desktop_size();
     bool res = graphics_mode_init_any(GraphicResolution(game.GetGameRes(), game.color_depth * 8),
         setup, ColorDepthOption(game.GetColorDepth()));

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -80,6 +80,11 @@ void sys_get_desktop_modes(std::vector<AGS::Engine::DisplayMode> &dms) {
     }
 }
 
+void sys_renderer_set_output(const String &name)
+{
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, name.GetCStr());
+}
+
 
 // ----------------------------------------------------------------------------
 // AUDIO UTILS

--- a/Engine/platform/base/sys_main.h
+++ b/Engine/platform/base/sys_main.h
@@ -41,6 +41,9 @@ void sys_set_background_mode(bool on);
 int sys_get_desktop_resolution(int &width, int &height);
 // Queries supported desktop modes.
 void sys_get_desktop_modes(std::vector<AGS::Engine::DisplayMode> &dms);
+// Sets output driver for the backend's renderer
+// TODO: consider make part of the SDLRendererGraphicsDriver later
+void sys_renderer_set_output(const String &name);
 
 // Audio utilities.
 //

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -25,6 +25,8 @@ Locations of two latter files differ between running platforms:
     * D3D9 - Direct3D9 (MS Windows version only);
     * OGL - OpenGL;
     * Software - software renderer.
+  * software_driver = \[string\] - *optional* id of the SDL2 driver to use for the final output in software mode, leave empty for default. IDs are provided by SDL2, not all of these will work on any system:
+    * direct3d, opengl, opengles, opengles2, metal, software.
   * windowed = \[0; 1\] - when enabled, runs game in windowed mode.
   * screen_def = \[string\] - determines how display mode is deduced:
     * explicit - use screen_width and screen_height parameters;


### PR DESCRIPTION
Resolves #1567.

Implemented config option for SDL2's driver selection, this is currently used only for software renderer.

```
[graphics]
software_driver = name
```
where driver's name could be one of: direct3d, opengl, opengles, opengles2, metal, software.
Not all of the drivers are supported on all systems.
Empty name, or missing option means use defaults.

Note that AGS prints SDL's driver name in the log, when using software renderer. This looks like:
> Created SDL Renderer: opengl
