### PR TITLE
Feature scintilla/script editor: toggle line comments

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -263,6 +263,7 @@ namespace AGS.Editor
             this.scintillaControl1.CharAdded += OnCharAdded;
             this.scintillaControl1.UpdateUI += OnUpdateUI;
             this.scintillaControl1.ModifyAttempt += OnModifyAttemptOnReadOnly;
+            this.scintillaControl1.KeyPress += ScintillaControl1_KeyPress;
             this.scintillaControl1.Insert += ScintillaControl1_Insert;
             this.scintillaControl1.Delete += ScintillaControl1_Delete;
             this.scintillaControl1.MouseUp += ScintillaWrapper_MouseUp;
@@ -1117,6 +1118,17 @@ namespace AGS.Editor
             if (TextModified != null)
             {
                 TextModified(e.Position, e.Text.Length, true);
+            }
+        }
+
+        // prevents keyboard sending non-printable characters to scintilla text buffer
+        private void ScintillaControl1_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (e.KeyChar < 32)
+            {
+                // Prevent control characters from getting inserted
+                e.Handled = true;
+                return;
             }
         }
 

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -23,6 +23,7 @@ namespace AGS.Editor
         private const string PASTE_COMMAND = "ScriptPaste";
         private const string UNDO_COMMAND = "ScriptUndo";
         private const string REDO_COMMAND = "ScriptRedo";
+        private const string TOGGLE_LINE_COMMENT_COMMAND = "ToggleCommentCommand";
         private const string SHOW_AUTOCOMPLETE_COMMAND = "ScriptShowAutoComplete";
         private const string MATCH_BRACE_COMMAND = "MatchBrace";
         private const string TOGGLE_BREAKPOINT_COMMAND = "ToggleBreakpoint";
@@ -108,6 +109,8 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(new MenuCommand(CUT_COMMAND, "Cut", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X, "CutMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(COPY_COMMAND, "Copy", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C, "CopyMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(PASTE_COMMAND, "Paste", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V, "PasteMenuIcon"));
+            _extraMenu.Commands.Add(MenuCommand.Separator);
+            _extraMenu.Commands.Add(new MenuCommand(TOGGLE_LINE_COMMENT_COMMAND, "Toggle Line Comment", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Q));
             _extraMenu.Commands.Add(MenuCommand.Separator);
             _extraMenu.Commands.Add(new MenuCommand(FIND_COMMAND, "Find...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F, "FindMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(FIND_NEXT_COMMAND, "Find next", System.Windows.Forms.Keys.F3, "FindNextMenuIcon"));
@@ -645,6 +648,10 @@ namespace AGS.Editor
                 {
                     scintilla.FindNextOccurrence(_lastSearchText, _lastCaseSensitive, true);
                 }
+            }
+            else if (command == TOGGLE_LINE_COMMENT_COMMAND)
+            {
+                scintilla.ToggleLineComment();
             }
             UpdateToolbarButtonsIfNecessary();
         }


### PR DESCRIPTION
- allow toggling line comments in the script editor with Ctrl+Shift+Q

![toggle_line_comment](https://user-images.githubusercontent.com/2244442/158093561-8492f099-0560-46d5-a091-1799c3612d12.gif)

If it's not something for now I can close this PR for now and later reopen to ags4 at an appropriate time.

When experimenting with this I noticed Ctrl+Shift+letter keys were inserting non-printable characters in the text buffer of the script editor.