### PR TITLE
Script API: expanded Button.Animate() to feature all common params + some refactor

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -11,11 +11,11 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_CHARACTERINFO_H
 #define __AC_CHARACTERINFO_H
 
 #include <vector>
+#include "core/types.h"
 #include "ac/common_defines.h" // constants
 
 namespace AGS { namespace Common { class Stream; } }
@@ -79,7 +79,7 @@ struct CharacterInfo {
     int   index_id;  // used for object functions to know the id
     short pic_xoffs; // this is fixed in screen coordinates
     short walkwaitcounter;
-    short loop, frame;
+    uint16_t loop, frame;
     short walking, animating;
     short walkspeed, animspeed;
     short inv[MAX_INV];

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -131,7 +131,4 @@ private:
 extern std::vector<AGS::Common::GUIButton> guibuts;
 extern int numguibuts;
 
-int UpdateAnimatingButton(int bu);
-void StopButtonAnimation(int idxn);
-
 #endif // __AC_GUIBUTTON_H

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -186,7 +186,8 @@ enum GUITextBoxFlags
 enum GuiSvgVersion
 {
     kGuiSvgVersion_Initial  = 0,
-    kGuiSvgVersion_350      = 1
+    kGuiSvgVersion_350,
+    kGuiSvgVersion_36020
 };
 
 enum GuiDisableStyle

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1579,6 +1579,19 @@ enum GUIPopupStyle {
 };
 #endif
 
+enum BlockingStyle {
+  eBlock = 919,
+  eNoBlock = 920
+};
+enum Direction {
+  eForwards = 1062,
+  eBackwards = 1063
+};
+enum WalkWhere {
+  eAnywhere = 304,
+  eWalkableAreas = 305
+};
+
 // forward-declare these so that they can be returned by GUIControl class
 builtin managed struct GUI;
 builtin managed struct Label;
@@ -1657,8 +1670,14 @@ builtin managed struct Label extends GUIControl {
 };
 
 builtin managed struct Button extends GUIControl {
+#ifdef SCRIPT_API_v360
+  /// Animates the button graphic using the specified view loop.
+  import void Animate(int view, int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
+#endif
+#ifndef SCRIPT_API_v360
   /// Animates the button graphic using the specified view loop.
   import void Animate(int view, int loop, int delay, RepeatStyle);
+#endif
 #ifndef STRICT_STRINGS
   import void GetText(string buffer);
   import void SetText(const string text);
@@ -2214,19 +2233,6 @@ builtin struct System {
   /// Prints message
   import static void Log(LogLevel level, const string format, ...);    // $AUTOCOMPLETESTATICONLY$
 #endif
-};
-
-enum BlockingStyle {
-  eBlock = 919,
-  eNoBlock = 920
-};
-enum Direction {
-  eForwards = 1062,
-  eBackwards = 1063
-};
-enum WalkWhere {
-  eAnywhere = 304,
-  eWalkableAreas = 305
 };
 
 builtin managed struct Object {

--- a/Engine/ac/button.h
+++ b/Engine/ac/button.h
@@ -37,7 +37,8 @@ void		Button_SetPushedGraphic(GUIButton *guil, int slotn);
 int			Button_GetTextColor(GUIButton *butt);
 void		Button_SetTextColor(GUIButton *butt, int newcol);
 
-int			UpdateAnimatingButton(int bu);
+// Update button's animation, returns whether the animation continues
+bool        UpdateAnimatingButton(int bu);
 size_t      GetAnimatingButtonCount();
 AnimatingGUIButton *GetAnimatingButtonByIndex(int idxn);
 void        AddButtonAnimation(const AnimatingGUIButton &abtn);

--- a/Engine/ac/button.h
+++ b/Engine/ac/button.h
@@ -42,6 +42,7 @@ size_t      GetAnimatingButtonCount();
 AnimatingGUIButton *GetAnimatingButtonByIndex(int idxn);
 void        AddButtonAnimation(const AnimatingGUIButton &abtn);
 void		StopButtonAnimation(int idxn);
+int         FindButtonAnimation(int guin, int objn);
 void		FindAndRemoveButtonAnimation(int guin, int objn);
 void        RemoveAllButtonAnimations();
 

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -84,6 +84,10 @@ int     is_pos_in_sprite(int xx,int yy,int arx,int ary, Common::Bitmap *sprit, i
 // X and Y co-ordinates must be in native format
 // X and Y are ROOM coordinates
 int     check_click_on_object(int roomx, int roomy, int mood);
+// General view animation algorithm: find next loop and frame, depending on anim settings;
+// loop and frame values are passed by reference and will be updated;
+// returns whether the animation should continue.
+bool    CycleViewAnim(int view, uint16_t &loop, uint16_t &frame, bool forwards, int repeat);
 
 #endif // __AGS_EE_AC__OBJECT_H
 

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -58,8 +58,6 @@ struct RoomObject {
     inline bool has_explicit_tint()  const { return (flags & OBJF_HASTINT) != 0; }
 
 	void UpdateCyclingView(int ref_id);
-	void update_cycle_view_forwards();
-	void update_cycle_view_backwards();
 
     void ReadFromSavegame(Common::Stream *in, int save_ver);
     void WriteToSavegame(Common::Stream *out) const;

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -109,7 +109,6 @@ const int LegacyRoomVolumeFactor            = 30;
 #define FOR_SCRIPT    2
 #define FOR_EXITLOOP  3
 #define CHMLSOFFS (MAX_ROOM_OBJECTS+1)    // reserve this many movelists for objects & stuff
-#define abort_all_conditions restrict_until
 #define MAX_SCRIPT_AT_ONCE 10
 #define EVENT_NONE       0
 #define EVENT_INPROGRESS 1

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -81,8 +81,11 @@ const int LegacyRoomVolumeFactor            = 30;
 #define CHANIM_REPEAT    2
 #define CHANIM_BACKWARDS 4
 #define ANIM_BACKWARDS 10
+// Animates once and stops at the *last* frame
 #define ANIM_ONCE      1
+// Animates infinitely until stopped by command
 #define ANIM_REPEAT    2
+// Animates once and stops, resetting to the very first frame
 #define ANIM_ONCERESET 3
 #define FONT_STATUSBAR  0
 #define FONT_NORMAL     play.normal_font

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -703,7 +703,7 @@ HSaveError ReadGUI(Stream *in, int32_t cmp_ver, const PreservedParams &pp, Resto
     for (int i = 0; i < anim_count; ++i)
     {
         AnimatingGUIButton abut;
-        abut.ReadFromFile(in);
+        abut.ReadFromFile(in, cmp_ver);
         AddButtonAnimation(abut);
     }
     return err;
@@ -1178,7 +1178,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "GUI",
-        kGuiSvgVersion_350,
+        kGuiSvgVersion_36020,
         kGuiSvgVersion_Initial,
         WriteGUI,
         ReadGUI

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -246,7 +246,7 @@ void ReadAnimatedButtons_Aligned(Stream *in, int num_abuts)
     for (int i = 0; i < num_abuts; ++i)
     {
         AnimatingGUIButton abtn;
-        abtn.ReadFromFile(&align_s);
+        abtn.ReadFromFile(&align_s, 0);
         AddButtonAnimation(abtn);
         align_s.Reset();
     }

--- a/Engine/gui/animatingguibutton.cpp
+++ b/Engine/gui/animatingguibutton.cpp
@@ -17,7 +17,7 @@
 
 using AGS::Common::Stream;
 
-void AnimatingGUIButton::ReadFromFile(Stream *in)
+void AnimatingGUIButton::ReadFromFile(Stream *in, int cmp_ver)
 {
     buttonid = in->ReadInt16();
     ongui = in->ReadInt16();
@@ -26,12 +26,22 @@ void AnimatingGUIButton::ReadFromFile(Stream *in)
     loop = in->ReadInt16();
     frame = in->ReadInt16();
     speed = in->ReadInt16();
-    repeat = in->ReadInt16();
+    uint16_t anim_flags = in->ReadInt16(); // was repeat (0,1)
     wait = in->ReadInt16();
+
+    if (cmp_ver < 2) anim_flags &= 0x1; // restrict to repeat only
+    repeat = anim_flags & 0x1;
+    blocking = (anim_flags >> 1) & 0x1;
+    direction = (anim_flags >> 2) & 0x1;
 }
 
 void AnimatingGUIButton::WriteToFile(Stream *out)
 {
+    uint16_t anim_flags =
+        (repeat & 0x1) |
+        (blocking & 0x1) << 1 |
+        (direction & 0x1) << 2;
+
     out->WriteInt16(buttonid);
     out->WriteInt16(ongui);
     out->WriteInt16(onguibut);
@@ -39,6 +49,6 @@ void AnimatingGUIButton::WriteToFile(Stream *out)
     out->WriteInt16(loop);
     out->WriteInt16(frame);
     out->WriteInt16(speed);
-    out->WriteInt16(repeat);
+    out->WriteInt16(anim_flags); // was repeat (0,1)
     out->WriteInt16(wait);
 }

--- a/Engine/gui/animatingguibutton.h
+++ b/Engine/gui/animatingguibutton.h
@@ -12,12 +12,13 @@
 //
 //=============================================================================
 //
-//
+// Description of a button animation; stored separately from the GUI button.
 //
 //=============================================================================
 #ifndef __AGS_EE_GUI__ANIMATINGGUIBUTTON_H
 #define __AGS_EE_GUI__ANIMATINGGUIBUTTON_H
 
+#include "core/types.h"
 #include "ac/runtime_defines.h"
 
 // Forward declaration
@@ -28,7 +29,7 @@ struct AnimatingGUIButton {
     // index into guibuts array, GUI, button
     short buttonid, ongui, onguibut;
     // current animation status
-    short view, loop, frame;
+    uint16_t view, loop, frame;
     short speed, repeat, blocking, direction, wait;
 
     void ReadFromFile(Common::Stream *in, int cmp_ver);

--- a/Engine/gui/animatingguibutton.h
+++ b/Engine/gui/animatingguibutton.h
@@ -31,7 +31,7 @@ struct AnimatingGUIButton {
     short view, loop, frame;
     short speed, repeat, blocking, direction, wait;
 
-    void ReadFromFile(Common::Stream *in);
+    void ReadFromFile(Common::Stream *in, int cmp_ver);
     void WriteToFile(Common::Stream *out);
 };
 

--- a/Engine/gui/animatingguibutton.h
+++ b/Engine/gui/animatingguibutton.h
@@ -29,7 +29,7 @@ struct AnimatingGUIButton {
     short buttonid, ongui, onguibut;
     // current animation status
     short view, loop, frame;
-    short speed, repeat, wait;
+    short speed, repeat, blocking, direction, wait;
 
     void ReadFromFile(Common::Stream *in);
     void WriteToFile(Common::Stream *out);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -652,10 +652,10 @@ static void game_loop_update_animated_buttons()
     // this bit isn't in update_stuff because it always needs to
     // happen, even when the game is paused
     for (size_t i = 0; i < GetAnimatingButtonCount(); ++i) {
-        if (UpdateAnimatingButton(i)) {
+        if (!UpdateAnimatingButton(i)) {
             StopButtonAnimation(i);
             i--;
-        } 
+        }
     }
 }
 

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -30,6 +30,7 @@ void GameLoopUntilValueIsNegative(const short *value);
 void GameLoopUntilValueIsNegative(const int *value);
 void GameLoopUntilNotMoving(const short *move);
 void GameLoopUntilNoOverlay();
+void GameLoopUntilButAnimEnd(int guin, int objn);
 
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally
 void RunGameUntilAborted();

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -401,6 +401,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     METHOD((CLASS*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue); \
     return RuntimeScriptValue((int32_t)0)
 
+#define API_OBJCALL_VOID_PINT7(CLASS, METHOD) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 7); \
+    METHOD((CLASS*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue, params[6].IValue); \
+    return RuntimeScriptValue((int32_t)0)
+
 #define API_OBJCALL_VOID_PFLOAT(CLASS, METHOD) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
     METHOD((CLASS*)self, params[0].FValue); \


### PR DESCRIPTION
This was mentioned on forums recently, and made me realize I missed Buttons when expanding Character and Object animation with "starting frame".

Added all parameters available for Character and Object's Animate function:
* blocking;
* direction;
* starting frame

So it looks like
```
import void Button.Animate(int view, int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
```

NOTE: same as with Character and Object's starting frame, the reverse animation starts with *frame - 1*, hence passing `frame = 0` will begin reverse animation with the last frame.

Refactored the animation handling (frame, loop increment/decrement) algorithm, use common code among Character, Object and Button.