### PR TITLE
Android: fix can't open vox packages in single game launcher

### DIFF
--- a/Common/util/aasset_stream.cpp
+++ b/Common/util/aasset_stream.cpp
@@ -20,6 +20,7 @@
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include "util/android_file.h"
+#include "util/path.h"
 #include "util/string.h"
 
 namespace AGS
@@ -176,15 +177,9 @@ namespace AGS
                 throw std::runtime_error("Couldn't get AAssetManager, SDL not initialized yet.");
             _ownHandle = true;
 
-            if(!asset_name.IsNullOrSpace() && asset_name[0] == '/') {
-                String aname = asset_name;
-                aname.ClipLeft(1);
-                _aAsset = AAssetManager_open(aAssetManager, aname.GetCStr(), asset_mode);
-            }
-            else
-            {
-                _aAsset = AAssetManager_open(aAssetManager, asset_name.GetCStr(), asset_mode);
-            }
+            String a_asset_name = Path::GetPathInForeignAsset(asset_name);
+
+            _aAsset = AAssetManager_open(aAssetManager, a_asset_name.GetCStr(), asset_mode);
 
             if (_aAsset == nullptr)
                 throw std::runtime_error("Error opening file.");

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -17,6 +17,7 @@
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
 #include <SDL.h>
+#include "util/path.h"
 
 namespace AGS
 {
@@ -74,9 +75,10 @@ bool GetAAssetExists(const String &filename)
 {
     AAssetManager* mgr = GetAAssetManager();
     if(mgr == nullptr) return false;
+    String a_filename = Path::GetPathInForeignAsset(filename);
     // TODO: find out if it's acceptable to open/close asset to only test its existance;
     // the alternative is to use AAssetManager_openDir and read asset list using AAssetDir_getNextFileName
-    AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
+    AAsset *asset = AAssetManager_open(mgr, a_filename.GetCStr(), AASSET_MODE_UNKNOWN);
     if (!asset) return false;
     AAsset_close(asset);
     return true;
@@ -86,7 +88,8 @@ soff_t GetAAssetSize(const String &filename)
 {
     AAssetManager* mgr = GetAAssetManager();
     if(mgr == nullptr) return -1;
-    AAsset *asset = AAssetManager_open(mgr, filename.GetCStr(), AASSET_MODE_UNKNOWN);
+    String a_filename = Path::GetPathInForeignAsset(filename);
+    AAsset *asset = AAssetManager_open(mgr, a_filename.GetCStr(), AASSET_MODE_UNKNOWN);
     if (!asset) return -1;
     soff_t len = AAsset_getLength64(asset);
     AAsset_close(asset);

--- a/Common/util/path.cpp
+++ b/Common/util/path.cpp
@@ -173,6 +173,24 @@ String FixupSharedFilename(const String &filename)
     return fixed_name;
 }
 
+#if AGS_PLATFORM_OS_ANDROID
+    String GetPathInForeignAsset(const String &filename)
+    {
+        if(filename.IsEmpty()) return filename;
+
+        if(filename[0] == '/')
+        {
+            return filename.Mid(1);
+        }
+        else if(filename[0] == '.' && filename[1] == '/')
+        {
+            return filename.Mid(2);
+        }
+
+        return filename;
+    }
+#endif
+
 #if AGS_PLATFORM_OS_WINDOWS
 String WidePathToUTF8(const wchar_t *ws)
 {

--- a/Common/util/path.h
+++ b/Common/util/path.h
@@ -88,6 +88,11 @@ namespace Path
     // could be copied across systems without problems.
     String  FixupSharedFilename(const String &filename);
 
+#if AGS_PLATFORM_OS_ANDROID
+    // gets a path stripped of directory roots
+    String GetPathInForeignAsset(const String &filename);
+#endif
+
     // NOTE: these are only required for internal util implementations
 #if AGS_PLATFORM_OS_WINDOWS
     // Converts system wide-char path into a UTF-8 string


### PR DESCRIPTION
android asset manager can't find files when they are preceded by `/` or `./` inside it's packaged asset.

fix #1577 

I placed the path stuff in the path utilities but if you think it's better to be in the android file then I can move too. I have a feeling that there must be some other proprietary ROM format that would have some similar need but I don't know any at the time.

I also named the function that simplifies the path as `GetPathInForeignAsset` to illustrate that the asset in question is not an AGS asset but a ROM type of information that another system also calls as "asset".