### PR TITLE
CI: get templates from release-3.5.1 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -254,7 +254,7 @@ editor_packaging_task:
     curl -fLOJ https://github.com/adventuregamestudio/ags-manual/releases/latest/download/ags-help.chm
   get_templates_script: >
     mkdir Windows\Installer\Source\Templates &&
-    curl -fLSs https://github.com/%TEMPLATES_REPOSITORY%/tarball/master |
+    curl -fLSs https://github.com/%TEMPLATES_REPOSITORY%/tarball/release-3.5.1 |
     tar -f - -xvzC Windows\Installer\Source\Templates --strip-components 2
   get_linux_bundle_script: >
     mkdir Windows\Installer\Source\Linux &&


### PR DESCRIPTION
The templates master branch now have 3.6.0 templates, so instead point to release-3.5.1 branch.