### PR TITLE
Exclude Sliders from the GUI clipping rule + refactor slider drawing

### DIFF
--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -281,8 +281,10 @@ void GUIMain::DrawAt(Bitmap *ds, int x, int y)
         if (!objToDraw->IsVisible())
             continue;
 
-        if (GUI::Options.ClipControls)
+        if (GUI::Options.ClipControls && objToDraw->IsContentClipped())
             subbmp.SetClip(RectWH(objToDraw->X, objToDraw->Y, objToDraw->Width, objToDraw->Height));
+        else
+            subbmp.ResetClip();
         objToDraw->Draw(&subbmp);
 
         int selectedColour = 14;

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -55,6 +55,8 @@ public:
     bool            IsVisible() const;
     // implemented separately in engine and editor
     bool            IsClickable() const;
+    // Compatibility: should the control's graphic be clipped to its x,y,w,h
+    virtual bool    IsContentClipped() const { return true; }
     
     // Operations
     virtual void    Draw(Bitmap *ds) { }

--- a/Common/gui/guislider.cpp
+++ b/Common/gui/guislider.cpp
@@ -38,6 +38,7 @@ GUISlider::GUISlider()
     _scEventCount = 1;
     _scEventNames[0] = "Change";
     _scEventArgs[0] = "GUIControl *control";
+    _handleRange = 0;
 }
 
 bool GUISlider::IsHorizontal() const
@@ -56,55 +57,63 @@ bool GUISlider::IsOverControl(int x, int y, int leeway) const
 
 void GUISlider::Draw(Common::Bitmap *ds)
 {
-    Rect bar;
-    Rect handle;
-    int  thickness;
-
+    // Clamp Value
+    // TODO: this is necessary here because some Slider fields are still public
     if (MinValue >= MaxValue)
         MaxValue = MinValue + 1;
     Value = Math::Clamp(Value, MinValue, MaxValue);
-  
-    // it's a horizontal slider
-    if (IsHorizontal())
+    // Test if sprite is available
+    // TODO: react to sprites initialization/deletion instead!
+    if (spriteset[HandleImage] == nullptr)
+        HandleImage = 0;
+
+    // Depending on slider's orientation, thickness is either Height or Width
+    const int thickness = IsHorizontal() ? Height : Width;
+    // "thick_f" is the factor for calculating relative element positions
+    const int thick_f = thickness / 3; // one third of the control's thickness
+    // Bar thickness
+    const int bar_thick = thick_f * 2 + 2;
+
+    // Calculate handle size
+    Size handle_sz;
+    if (HandleImage > 0) // handle is a sprite
     {
-        thickness = Height / 3;
-        bar.Left = X + 1;
-        bar.Top = Y + Height / 2 - thickness;
-        bar.Right = X + Width - 1;
-        bar.Bottom = Y + Height / 2 + thickness + 1;
-        handle.Left = (int)(((float)(Value - MinValue) / (float)(MaxValue - MinValue)) * (float)(Width - 4) - 2) + bar.Left + 1;
-        handle.Top = bar.Top - (thickness - 1);
-        handle.Right = handle.Left + get_fixed_pixel_size(4);
-        handle.Bottom = bar.Bottom + (thickness - 1);
-        if (HandleImage > 0)
-        {
-            // store the centre of the pic rather than the top
-            handle.Top = bar.Top + (bar.Bottom - bar.Top) / 2 + get_fixed_pixel_size(1);
-            handle.Left += get_fixed_pixel_size(2);
-        }
-        handle.Top += data_to_game_coord(HandleOffset);
-        handle.Bottom += data_to_game_coord(HandleOffset);
+        handle_sz = Size(get_adjusted_spritewidth(HandleImage),
+            get_adjusted_spriteheight(HandleImage));
+    }
+    else // handle is a drawn rectangle
+    {
+        if (IsHorizontal())
+            handle_sz = Size(get_fixed_pixel_size(4) + 1, bar_thick + (thick_f - 1) * 2);
+        else
+            handle_sz = Size(bar_thick + (thick_f - 1) * 2, get_fixed_pixel_size(4) + 1);
+    }
+  
+    // Calculate bar and handle positions
+    Rect bar;
+    Rect handle;
+    int handle_range;
+    if (IsHorizontal()) // horizontal slider
+    {
+        // Value pos is a coordinate corresponding to current slider's value
+        bar = RectWH(X + 1, Y + Height / 2 - thick_f, Width - 1, bar_thick);
+        handle_range = Width - 4;
+        int value_pos = (int)(((float)(Value - MinValue) * (float)handle_range) / (float)(MaxValue - MinValue));
+        handle = RectWH((bar.Left + get_fixed_pixel_size(2)) - (handle_sz.Width / 2) + 1 + value_pos - 2,
+            bar.Top + (bar.GetHeight() - handle_sz.Height) / 2,
+            handle_sz.Width, handle_sz.Height);
+        handle.MoveToY(handle.Top + data_to_game_coord(HandleOffset));
     }
     // vertical slider
     else
     {
-        thickness = Width / 3;
-        bar.Left = X + Width / 2 - thickness;
-        bar.Top = Y + 1;
-        bar.Right = X + Width / 2 + thickness + 1;
-        bar.Bottom = Y + Height - 1;
-        handle.Top = (int)(((float)(MaxValue - Value) / (float)(MaxValue - MinValue)) * (float)(Height - 4) - 2) + bar.Top + 1;
-        handle.Left = bar.Left - (thickness - 1);
-        handle.Bottom = handle.Top + get_fixed_pixel_size(4);
-        handle.Right = bar.Right + (thickness - 1);
-        if (HandleImage > 0)
-        {
-            // store the centre of the pic rather than the left
-            handle.Left = bar.Left + (bar.Right - bar.Left) / 2 + get_fixed_pixel_size(1);
-            handle.Top += get_fixed_pixel_size(2);
-        }
-        handle.Left += data_to_game_coord(HandleOffset);
-        handle.Right += data_to_game_coord(HandleOffset);
+        bar = RectWH(X + Width / 2 - thick_f, Y + 1, bar_thick, Height - 1);
+        handle_range = Height - 4;
+        int value_pos = (int)(((float)(MaxValue - Value) * (float)handle_range) / (float)(MaxValue - MinValue));
+        handle = RectWH(bar.Left + (bar.GetWidth() - handle_sz.Width) / 2,
+            (bar.Top + get_fixed_pixel_size(2)) - (handle_sz.Height / 2) + 1 + value_pos - 2,
+            handle_sz.Width, handle_sz.Height);
+        handle.MoveToX(handle.Left + data_to_game_coord(HandleOffset));
     }
 
     color_t draw_color;
@@ -141,7 +150,7 @@ void GUISlider::Draw(Common::Bitmap *ds)
     {
         // normal grey background
         draw_color = ds->GetCompatibleColor(16);
-        ds->FillRect(Rect(bar.Left + 1, bar.Top + 1, bar.Right - 1, bar.Bottom - 1), draw_color);
+        ds->FillRect(bar, draw_color);
         draw_color = ds->GetCompatibleColor(8);
         ds->DrawLine(Line(bar.Left, bar.Top, bar.Left, bar.Bottom), draw_color);
         ds->DrawLine(Line(bar.Left, bar.Top, bar.Right, bar.Top), draw_color);
@@ -150,24 +159,15 @@ void GUISlider::Draw(Common::Bitmap *ds)
         ds->DrawLine(Line(bar.Left, bar.Bottom, bar.Right, bar.Bottom), draw_color);
     }
 
-    if (HandleImage > 0)
+    if (HandleImage > 0) // handle is a sprite
     {
-        // an image for the slider handle
-        // TODO: react to sprites initialization/deletion instead!
-        if (spriteset[HandleImage] == nullptr)
-            HandleImage = 0;
-
-        handle.Left -= get_adjusted_spritewidth(HandleImage) / 2;
-        handle.Top -= get_adjusted_spriteheight(HandleImage) / 2;
         draw_gui_sprite(ds, HandleImage, handle.Left, handle.Top, true);
-        handle.Right = handle.Left + get_adjusted_spritewidth(HandleImage);
-        handle.Bottom = handle.Top + get_adjusted_spriteheight(HandleImage);
     }
-    else
+    else // handle is a drawn rectangle
     {
         // normal grey tracker handle
         draw_color = ds->GetCompatibleColor(7);
-        ds->FillRect(Rect(handle.Left, handle.Top, handle.Right, handle.Bottom), draw_color);
+        ds->FillRect(handle, draw_color);
         draw_color = ds->GetCompatibleColor(15);
         ds->DrawLine(Line(handle.Left, handle.Top, handle.Right, handle.Top), draw_color);
         ds->DrawLine(Line(handle.Left, handle.Top, handle.Left, handle.Bottom), draw_color);
@@ -177,6 +177,7 @@ void GUISlider::Draw(Common::Bitmap *ds)
     }
 
     _cachedHandle = handle;
+    _handleRange = handle_range;
 }
 
 bool GUISlider::OnMouseDown()
@@ -192,9 +193,9 @@ void GUISlider::OnMouseMove(int x, int y)
         return;
 
     if (IsHorizontal())
-        Value = (int)(((float)((x - X) - 2) / (float)(Width - 4)) * (float)(MaxValue - MinValue)) + MinValue;
+        Value = (int)(((float)((x - X) - 2) * (float)(MaxValue - MinValue)) / (float)_handleRange) + MinValue;
     else
-        Value = (int)(((float)(((Y + Height) - y) - 2) / (float)(Height - 4)) * (float)(MaxValue - MinValue)) + MinValue;
+        Value = (int)(((float)(((Y + Height) - y) - 2) * (float)(MaxValue - MinValue)) / (float)_handleRange) + MinValue;
 
     Value = Math::Clamp(Value, MinValue, MaxValue);
     NotifyParentChanged();

--- a/Common/gui/guislider.h
+++ b/Common/gui/guislider.h
@@ -60,6 +60,8 @@ private:
     // The following variables are not persisted on disk
     // Cached coordinates of slider handle
     Rect    _cachedHandle;
+    // The length of the handle movement range, in pixels
+    int     _handleRange;
 };
 
 } // namespace Common

--- a/Common/gui/guislider.h
+++ b/Common/gui/guislider.h
@@ -28,6 +28,9 @@ class GUISlider : public GUIObject
 public:
     GUISlider();
 
+    // Compatibility: sliders are not clipped as of 3.6.0
+    bool IsContentClipped() const override { return false; }
+
     // Tells if the slider is horizontal (otherwise - vertical)
     bool IsHorizontal() const;
     bool IsOverControl(int x, int y, int leeway) const override;


### PR DESCRIPTION
Fixes #1581 + refactors its drawing function. Latter is not necessary, but I wrote this code as a part of previous pr attempt (#1583), and imho this may be useful, as it reduces code duplication and clarifies certain settings.

The idea is that Sliders are currently too complicated to simply clip them to the rectangle defined by their position properties. As AGS historically did not restrict the sizes of slider handle and background images, clipping it would perhaps require to redesign its default looks and settings.