### PR TITLE
Resolving (most) engine compilation warnings

### DIFF
--- a/Common/ac/dynobj/scriptaudioclip.cpp
+++ b/Common/ac/dynobj/scriptaudioclip.cpp
@@ -22,9 +22,9 @@ void ScriptAudioClip::ReadFromFile(Stream *in)
     id = in->ReadInt32();
     scriptName.ReadCount(in, SCRIPTAUDIOCLIP_SCRIPTNAMELENGTH);
     fileName.ReadCount(in, SCRIPTAUDIOCLIP_FILENAMELENGTH);
-    bundlingType = in->ReadInt8();
-    type = in->ReadInt8();
-    fileType = in->ReadInt8();
+    bundlingType = static_cast<uint8_t>(in->ReadInt8());
+    type = static_cast<uint8_t>(in->ReadInt8());
+    fileType = static_cast<AudioFileType>(in->ReadInt8());
     defaultRepeat = in->ReadInt8();
     defaultPriority = in->ReadInt16();
     defaultVolume = in->ReadInt16();

--- a/Common/ac/dynobj/scriptaudioclip.h
+++ b/Common/ac/dynobj/scriptaudioclip.h
@@ -41,9 +41,9 @@ struct ScriptAudioClip {
     int id = 0;
     Common::String scriptName;
     Common::String fileName;
-    char bundlingType = AUCL_BUNDLE_EXE;
-    char type = 0;
-    char fileType = eAudioFileOGG;
+    uint8_t bundlingType = AUCL_BUNDLE_EXE;
+    uint8_t type = 0;
+    AudioFileType fileType = eAudioFileOGG;
     char defaultRepeat = 0;
     short defaultPriority = 50;
     short defaultVolume = 100;

--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -162,7 +162,7 @@ void GameSetupStruct::WriteInvInfo_Aligned(Stream *out)
     }
 }
 
-HGameFileError GameSetupStruct::read_cursors(Common::Stream *in, GameDataVersion data_ver)
+HGameFileError GameSetupStruct::read_cursors(Common::Stream *in)
 {
     ReadMouseCursors_Aligned(in);
     return HGameFileError::None();
@@ -228,9 +228,9 @@ void GameSetupStruct::WriteMouseCursors_Aligned(Stream *out)
 //-----------------------------------------------------------------------------
 // Reading Part 2
 
-void GameSetupStruct::read_characters(Common::Stream *in, GameDataVersion data_ver)
+void GameSetupStruct::read_characters(Common::Stream *in)
 {
-    chars = new CharacterInfo[numcharacters + 5]; // TODO: why +5, is this really needed?
+    chars = new CharacterInfo[numcharacters];
 
     ReadCharacters_Aligned(in);
 }

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -126,7 +126,7 @@ struct GameSetupStruct: public GameSetupStructBase {
     // Part 1
     void read_savegame_info(Common::Stream *in, GameDataVersion data_ver);
     void read_font_infos(Common::Stream *in, GameDataVersion data_ver);
-    HGameFileError read_cursors(Common::Stream *in, GameDataVersion data_ver);
+    HGameFileError read_cursors(Common::Stream *in);
     void read_interaction_scripts(Common::Stream *in, GameDataVersion data_ver);
     void read_words_dictionary(Common::Stream *in);
 
@@ -136,7 +136,7 @@ struct GameSetupStruct: public GameSetupStructBase {
     void WriteMouseCursors_Aligned(Common::Stream *out);
     //------------------------------
     // Part 2
-    void read_characters(Common::Stream *in, GameDataVersion data_ver);
+    void read_characters(Common::Stream *in);
     void read_lipsync(Common::Stream *in, GameDataVersion data_ver);
     void read_messages(Common::Stream *in, GameDataVersion data_ver);
 

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -262,8 +262,9 @@ Size ResolutionTypeToSize(GameResolutionType resolution, bool letterbox)
         return Size(1024, 768);
     case kGameResolution_1280x720:
         return Size(1280,720);
+    default:
+        return Size();
     }
-    return Size();
 }
 
 const char *GetScriptAPIName(ScriptAPIVersion v)
@@ -280,6 +281,6 @@ const char *GetScriptAPIName(ScriptAPIVersion v)
     case kScriptAPI_v3507: return "v3.5.0-final";
     case kScriptAPI_v351: return "v3.5.1";
     case kScriptAPI_v360: return "v3.6.0";
+    default: return "unknown";
     }
-    return "unknown";
 }

--- a/Common/ac/mousecursor.cpp
+++ b/Common/ac/mousecursor.cpp
@@ -40,10 +40,10 @@ void MouseCursor::WriteToFile(Stream *out)
 void MouseCursor::ReadFromSavegame(Stream *in, int cmp_ver)
 {
     pic = in->ReadInt32();
-    hotx = in->ReadInt32();
-    hoty = in->ReadInt32();
-    view = in->ReadInt32();
-    flags = in->ReadInt32();
+    hotx = static_cast<int16_t>(in->ReadInt32());
+    hoty = static_cast<int16_t>(in->ReadInt32());
+    view = static_cast<int16_t>(in->ReadInt32());
+    flags = static_cast<int8_t>(in->ReadInt32());
     if (cmp_ver > 0)
         animdelay = in->ReadInt32();
 }

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -232,7 +232,7 @@ HError SpriteFile::OpenFile(const String &filename, const String &sprindex_filen
     }
 
     // Failed, index file is invalid; index sprites manually
-    return RebuildSpriteIndex(_stream.get(), topmost, _version, metrics);
+    return RebuildSpriteIndex(_stream.get(), topmost, metrics);
 }
 
 void SpriteFile::Close()
@@ -357,8 +357,7 @@ static inline void ReadSprHeader(SpriteDatHeader &hdr, Stream *in,
     hdr = SpriteDatHeader(bpp, sformat, pal_count, compress, w, h);
 }
 
-HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost,
-    SpriteFileVersion vers, std::vector<Size> &metrics)
+HError SpriteFile::RebuildSpriteIndex(Stream *in, sprkey_t topmost, std::vector<Size> &metrics)
 {
     topmost = std::min(topmost, (sprkey_t)_spriteData.size() - 1);
     for (sprkey_t i = 0; !in->EOS() && (i <= topmost); ++i)

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -48,12 +48,12 @@ typedef ImBufferPtrT<uint8_t*> ImBufferPtr;
 typedef ImBufferPtrT<const uint8_t*> ImBufferCPtr;
 
 
-// Finds the given color's index in the palette, or returns -1 if such color is not there
+// Finds the given color's index in the palette, or returns SIZE_MAX if such color is not there
 static size_t lookup_palette(uint32_t col, uint32_t palette[256], uint32_t ncols)
 {
     for (size_t i = 0; i < ncols; ++i)
         if (palette[i] == col) return i;
-    return -1;
+    return SIZE_MAX;
 }
 
 // Converts a 16/32-bit image into the indexed 8-bit pixel data with palette;
@@ -88,7 +88,7 @@ static bool CreateIndexedBitmap(const Bitmap *image, std::vector<uint8_t> &dst_d
         default: assert(0); return false;
         }
         
-        if (pal_n == -1)
+        if (pal_n == SIZE_MAX)
         {
             if (pal_count == 256) return false;
             pal_n = pal_count;

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -131,8 +131,8 @@ static inline SpriteFormat PaletteFormatForBPP(int bpp)
     case 1: return kSprFmt_PaletteRgb888;
     case 2: return kSprFmt_PaletteRgb565;
     case 4: return kSprFmt_PaletteArgb8888;
+    default: return kSprFmt_Undefined;
     }
-    return kSprFmt_Undefined;
 }
 
 static inline uint8_t GetPaletteBPP(SpriteFormat fmt)
@@ -142,8 +142,8 @@ static inline uint8_t GetPaletteBPP(SpriteFormat fmt)
     case kSprFmt_PaletteRgb888: return 3;
     case kSprFmt_PaletteArgb8888: return 4;
     case kSprFmt_PaletteRgb565: return 2;
+    default: return 0; // means no palette
     }
-    return 0; // means no palette
 }
 
 

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -144,8 +144,7 @@ public:
     bool        LoadSpriteIndexFile(const String &filename, int expectedFileID,
         soff_t spr_initial_offs, sprkey_t topmost, std::vector<Size> &metrics);
     // Rebuilds sprite index from the main sprite file
-    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost, SpriteFileVersion vers,
-        std::vector<Size> &metrics);
+    HError      RebuildSpriteIndex(Stream *in, sprkey_t topmost, std::vector<Size> &metrics);
 
     // Loads an image data and creates a ready bitmap
     HError      LoadSprite(sprkey_t index, Bitmap *&sprite);

--- a/Common/ac/view.cpp
+++ b/Common/ac/view.cpp
@@ -83,7 +83,7 @@ void ViewLoopNew::Dispose()
 
 void ViewLoopNew::WriteToFile_v321(Stream *out)
 {
-    out->WriteInt16(numFrames);
+    out->WriteInt16(static_cast<uint16_t>(numFrames));
     out->WriteInt32(flags);
     WriteFrames_Aligned(out);
 }
@@ -100,7 +100,7 @@ void ViewLoopNew::WriteFrames_Aligned(Stream *out)
 
 void ViewLoopNew::ReadFromFile_v321(Stream *in)
 {
-    Initialize(in->ReadInt16());
+    Initialize(static_cast<uint16_t>(in->ReadInt16()));
     flags = in->ReadInt32();
     ReadFrames_Aligned(in);
 }
@@ -134,7 +134,7 @@ void ViewStruct::Dispose()
 
 void ViewStruct::WriteToFile(Stream *out)
 {
-    out->WriteInt16(numLoops);
+    out->WriteInt16(static_cast<uint16_t>(numLoops));
     for (int i = 0; i < numLoops; i++)
     {
         loops[i].WriteToFile_v321(out);
@@ -143,7 +143,7 @@ void ViewStruct::WriteToFile(Stream *out)
 
 void ViewStruct::ReadFromFile(Stream *in)
 {
-    Initialize(in->ReadInt16());
+    Initialize(static_cast<uint16_t>(in->ReadInt16()));
 
     for (int i = 0; i < numLoops; i++)
     {

--- a/Common/ac/view.h
+++ b/Common/ac/view.h
@@ -40,7 +40,7 @@ struct ViewFrame {
 
 struct ViewLoopNew
 {
-    short numFrames;
+    int   numFrames;
     int   flags;
     std::vector<ViewFrame> frames;
     // NOTE: we still need numFrames for backward compatibility:
@@ -59,7 +59,7 @@ struct ViewLoopNew
 
 struct ViewStruct
 {
-    short numLoops;
+    int numLoops;
     std::vector<ViewLoopNew> loops;
 
     ViewStruct();

--- a/Common/debug/out.h
+++ b/Common/debug/out.h
@@ -106,9 +106,9 @@ enum MessageType
 
 // This enumeration is a list of common hard-coded groups, but more could
 // be added via debugging configuration interface (see 'debug/debug.h').
-enum CommonDebugGroup
+enum CommonDebugGroup : uint32_t
 {
-    kDbgGroup_None = -1,
+    kDbgGroup_None = UINT32_MAX,
     // Main debug group is for reporting general engine status and issues
     kDbgGroup_Main = 0,
     // Game group is for logging game logic state and issues

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -25,7 +25,7 @@ using namespace AGS::Common;
 extern bool ShouldAntiAliasText();
 
 // ***** TTF RENDERER *****
-void TTFFontRenderer::AdjustYCoordinateForFont(int *ycoord, int fontNumber)
+void TTFFontRenderer::AdjustYCoordinateForFont(int *ycoord, int /*fontNumber*/)
 {
   // TTF fonts already have space at the top, so try to remove the gap
   // TODO: adding -1 was here before (check the comment above),
@@ -35,7 +35,7 @@ void TTFFontRenderer::AdjustYCoordinateForFont(int *ycoord, int fontNumber)
   ycoord[0]--;
 }
 
-void TTFFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
+void TTFFontRenderer::EnsureTextValidForFont(char * /*text*/, int /*fontNumber*/)
 {
   // do nothing, TTF can handle all characters
 }
@@ -45,7 +45,7 @@ int TTFFontRenderer::GetTextWidth(const char *text, int fontNumber)
   return alfont_text_length(_fontData[fontNumber].AlFont, text);
 }
 
-int TTFFontRenderer::GetTextHeight(const char *text, int fontNumber)
+int TTFFontRenderer::GetTextHeight(const char * /*text*/, int fontNumber)
 {
   return alfont_get_font_real_height(_fontData[fontNumber].AlFont);
 }
@@ -133,7 +133,7 @@ const char *TTFFontRenderer::GetName(int fontNumber)
   return alfont_get_name(_fontData[fontNumber].AlFont);
 }
 
-void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool aa_mode)
+void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
 {
   if (loaded_game_file_version < kGameVersion_341)
   {

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -25,7 +25,7 @@ public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
   void FreeMemory(int fontNumber) override;
-  bool SupportsExtendedCharacters(int fontNumber) override { return true; }
+  bool SupportsExtendedCharacters(int /*fontNumber*/) override { return true; }
   int GetTextWidth(const char *text, int fontNumber) override;
   int GetTextHeight(const char *text, int fontNumber) override;
   void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override ;

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -29,7 +29,7 @@ static unsigned char GetCharCode(unsigned char wanted_code, const WFNFont* font)
 
 static int RenderChar(Bitmap *ds, const int at_x, const int at_y, const WFNChar &wfn_char, const int scale, const color_t text_color);
 
-void WFNFontRenderer::AdjustYCoordinateForFont(int *ycoord, int fontNumber)
+void WFNFontRenderer::AdjustYCoordinateForFont(int * /*ycoord*/, int /*fontNumber*/)
 {
   // Do nothing
 }
@@ -134,8 +134,8 @@ bool WFNFontRenderer::IsBitmapFont()
     return true;
 }
 
-bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
-    const FontRenderParams *params, FontMetrics *metrics)
+bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
+    const FontRenderParams *params, FontMetrics * /*metrics*/)
 {
   String file_name;
   Stream *ffi = nullptr;

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -36,8 +36,8 @@ public:
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;
-  const char *GetName(int fontNumber) override { return ""; }
-  void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override { /* do nothing */}
+  const char *GetName(int /*fontNumber*/) override { return ""; }
+  void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
 
 private:
   struct FontData

--- a/Common/game/interactions.h
+++ b/Common/game/interactions.h
@@ -52,7 +52,7 @@ namespace AGS
 namespace Common
 {
 
-enum InterValType
+enum InterValType : int8_t
 {
     kInterValLiteralInt = 1,
     kInterValVariable   = 2,

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -786,9 +786,10 @@ protected:
     GameDataVersion _dataVer {};
 };
 
-HError GameDataExtReader::ReadBlock(int block_id, const String &ext_id,
-    soff_t block_len, bool &read_next)
+HError GameDataExtReader::ReadBlock(int /*block_id*/, const String &ext_id,
+    soff_t /*block_len*/, bool &read_next)
 {
+    read_next = true;
     // Add extensions here checking ext_id, which is an up to 16-chars name, for example:
     // if (ext_id.CompareNoCase("GUI_NEWPROPS") == 0)
     // {
@@ -849,7 +850,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
     if (!err)
         return err;
     game.ReadInvInfo_Aligned(in);
-    err = game.read_cursors(in, data_ver);
+    err = game.read_cursors(in);
     if (!err)
         return err;
     game.read_interaction_scripts(in, data_ver);
@@ -877,7 +878,7 @@ HGameFileError ReadGameData(LoadedGameEntities &ents, Stream *in, GameDataVersio
         in->Seek(count * 0x204);
     }
 
-    game.read_characters(in, data_ver);
+    game.read_characters(in);
     game.read_lipsync(in, data_ver);
     game.read_messages(in, data_ver);
 

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -379,8 +379,8 @@ void ReadDialogs(DialogTopic *&dialog,
         // Encrypted text on > 2.60
         while (1)
         {
-            size_t newlen = in->ReadInt32();
-            if (static_cast<int32_t>(newlen) == 0xCAFEBEEF)  // GUI magic
+            size_t newlen = static_cast<uint32_t>(in->ReadInt32());
+            if (newlen == 0xCAFEBEEF)  // GUI magic
             {
                 in->Seek(-4);
                 break;

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -661,7 +661,8 @@ HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, bool g
     // TODO: find out which data versions had these; is it safe to assume this was before kRoomVersion_pre114_3?
     for (size_t i = 0; i < room->MessageCount; ++i)
     {
-        if (!room->Messages[i].IsEmpty() && room->Messages[i].GetLast() == (char)ROOM_MESSAGE_FLAG_DISPLAYNEXT)
+        if (!room->Messages[i].IsEmpty() &&
+            static_cast<uint8_t>(room->Messages[i].GetLast()) == ROOM_MESSAGE_FLAG_DISPLAYNEXT)
         {
             room->Messages[i].ClipRight(1);
             room->MessageInfos[i].Flags |= MSG_DISPLAYNEXT;

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -333,7 +333,7 @@ HError ReadMainBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 }
 
 // Room script sources (original text)
-HError ReadScriptBlock(char *&buf, Stream *in, RoomFileVersion data_ver)
+HError ReadScriptBlock(char *&buf, Stream *in, RoomFileVersion /*data_ver*/)
 {
     size_t len = in->ReadInt32();
     buf = new char[len + 1];
@@ -345,7 +345,7 @@ HError ReadScriptBlock(char *&buf, Stream *in, RoomFileVersion data_ver)
 }
 
 // Compiled room script
-HError ReadCompSc3Block(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
+HError ReadCompSc3Block(RoomStruct *room, Stream *in, RoomFileVersion /*data_ver*/)
 {
     room->CompiledScript.reset(ccScript::CreateFromStream(in));
     if (room->CompiledScript == nullptr)
@@ -413,7 +413,7 @@ HError ReadAnimBgBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 }
 
 // Read custom properties
-HError ReadPropertiesBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
+HError ReadPropertiesBlock(RoomStruct *room, Stream *in, RoomFileVersion /*data_ver*/)
 {
     int prop_ver = in->ReadInt32();
     if (prop_ver != 1)
@@ -507,6 +507,7 @@ private:
     HError ReadBlock(int block_id, const String &ext_id,
         soff_t block_len, bool &read_next) override
     {
+        read_next = true;
         return ReadRoomBlock(_room, _in, (RoomFileBlock)block_id, ext_id, block_len, _dataVer);
     }
 

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -356,10 +356,10 @@ HError ReadCompSc3Block(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 // Room object names
 HError ReadObjNamesBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 {
-    int name_count = in->ReadByte();
+    size_t name_count = static_cast<uint8_t>(in->ReadInt8());
     if (name_count != room->ObjectCount)
         return new RoomFileError(kRoomFileErr_InconsistentData,
-            String::FromFormat("In the object names block, expected name count: %d, got %d", room->ObjectCount, name_count));
+            String::FromFormat("In the object names block, expected name count: %zu, got %zu", room->ObjectCount, name_count));
 
     for (size_t i = 0; i < room->ObjectCount; ++i)
     {
@@ -374,10 +374,10 @@ HError ReadObjNamesBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 // Room object script names
 HError ReadObjScNamesBlock(RoomStruct *room, Stream *in, RoomFileVersion data_ver)
 {
-    int name_count = in->ReadByte();
+    size_t name_count = static_cast<uint8_t>(in->ReadInt8());
     if (name_count != room->ObjectCount)
         return new RoomFileError(kRoomFileErr_InconsistentData,
-            String::FromFormat("In the object script names block, expected name count: %d, got %d", room->ObjectCount, name_count));
+            String::FromFormat("In the object script names block, expected name count: %zu, got %zu", room->ObjectCount, name_count));
 
     for (size_t i = 0; i < room->ObjectCount; ++i)
     {

--- a/Common/game/room_file.h
+++ b/Common/game/room_file.h
@@ -121,7 +121,7 @@ HRoomFileError ReadRoomHeader(RoomDataSource &src);
 // Writes room data header
 void WriteRoomHeader(Stream *out, RoomFileVersion data_ver);
 // Writes a room data ending
-void WriteRoomEnding(Stream *out, RoomFileVersion data_ver);
+void WriteRoomEnding(Stream *out);
 
 // Type of function that writes single room block.
 typedef std::function<void(const RoomStruct *room, Stream *out)> PfnWriteRoomBlock;

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -54,8 +54,8 @@ String GetRoomFileErrorText(RoomFileErrorType err)
         return "Errors encountered when reading custom properties.";
     case kRoomFileErr_BlockNotFound:
         return "Required block was not found.";
+    default: return "Unknown error.";
     }
-    return "Unknown error.";
 }
 
 HRoomFileError OpenRoomFile(const String &filename, RoomDataSource &src)
@@ -103,8 +103,8 @@ String GetRoomBlockName(RoomFileBlock id)
     case kRoomFblk_CompScript3: return "CompScript3";
     case kRoomFblk_Properties: return "Properties";
     case kRoomFblk_ObjectScNames: return "ObjScNames";
+    default: return "unknown";
     }
-    return "unknown";
 }
 
 // Helper for new-style blocks with string id

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -85,7 +85,7 @@ void WriteRoomHeader(Stream *out, RoomFileVersion data_ver)
     out->WriteInt16(static_cast<uint16_t>(data_ver));
 }
 
-void WriteRoomEnding(Stream *out, RoomFileVersion data_ver)
+void WriteRoomEnding(Stream *out)
 {
     out->WriteByte(kRoomFile_EOF);
 }

--- a/Common/game/room_file_base.cpp
+++ b/Common/game/room_file_base.cpp
@@ -82,7 +82,7 @@ HRoomFileError ReadRoomHeader(RoomDataSource &src)
 
 void WriteRoomHeader(Stream *out, RoomFileVersion data_ver)
 {
-    out->WriteInt16(data_ver);
+    out->WriteInt16(static_cast<uint16_t>(data_ver));
 }
 
 void WriteRoomEnding(Stream *out, RoomFileVersion data_ver)

--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -208,8 +208,8 @@ Bitmap *RoomStruct::GetMask(RoomAreaMask mask) const
     case kRoomAreaWalkBehind: return WalkBehindMask.get();
     case kRoomAreaWalkable: return WalkAreaMask.get();
     case kRoomAreaRegion: return RegionMask.get();
+    default: return nullptr;
     }
-    return nullptr;
 }
 
 float RoomStruct::GetMaskScale(RoomAreaMask mask) const
@@ -221,8 +221,8 @@ float RoomStruct::GetMaskScale(RoomAreaMask mask) const
     case kRoomAreaWalkable:
     case kRoomAreaRegion:
         return 1.f / MaskResolution;
+    default: return 0.f;
     }
-    return 0.f;
 }
 
 bool RoomStruct::HasRegionLightLevel(int id) const

--- a/Common/game/tra_file.cpp
+++ b/Common/game/tra_file.cpp
@@ -45,8 +45,8 @@ String GetTraFileErrorText(TraFileErrorType err)
         return "Unknown block type.";
     case kTraFileErr_BlockDataOverlapping:
         return "Block data overlapping.";
+    default: return "Unknown error.";
     }
-    return "Unknown error.";
 }
 
 String GetTraBlockName(TraFileBlock id)
@@ -56,8 +56,8 @@ String GetTraBlockName(TraFileBlock id)
     case kTraFblk_Dict: return "Dictionary";
     case kTraFblk_GameID: return "GameID";
     case kTraFblk_TextOpts: return "TextOpts";
+    default: return "unknown";
     }
-    return "unknown";
 }
 
 HError OpenTraFile(Stream *in)

--- a/Common/game/tra_file.cpp
+++ b/Common/game/tra_file.cpp
@@ -102,7 +102,7 @@ HError ReadTraBlock(Translation &tra, Stream *in, TraFileBlock block, const Stri
         tra.SpeechFont = in->ReadInt32();
         tra.RightToLeft = in->ReadInt32();
         return HError::None();
-    case 0:
+    case kTraFblk_None:
         // continue reading extensions with string ID
         break;
     default:

--- a/Common/game/tra_file.cpp
+++ b/Common/game/tra_file.cpp
@@ -70,7 +70,7 @@ HError OpenTraFile(Stream *in)
     return HError::None();
 }
 
-HError ReadTraBlock(Translation &tra, Stream *in, TraFileBlock block, const String &ext_id, soff_t block_len)
+HError ReadTraBlock(Translation &tra, Stream *in, TraFileBlock block, const String &ext_id, soff_t /*block_len*/)
 {
     switch (block)
     {
@@ -150,6 +150,7 @@ private:
     HError ReadBlock(int block_id, const String &ext_id,
         soff_t block_len, bool &read_next) override
     {
+        read_next = true;
         return ReadTraBlock(_tra, _in, (TraFileBlock)block_id, ext_id, block_len);
     }
 

--- a/Common/game/tra_file.h
+++ b/Common/game/tra_file.h
@@ -40,6 +40,7 @@ enum TraFileErrorType
 
 enum TraFileBlock
 {
+    kTraFblk_None       = 0,
     kTraFblk_Dict       = 1,
     kTraFblk_GameID     = 2,
     kTraFblk_TextOpts   = 3,

--- a/Common/gfx/allegrobitmap.cpp
+++ b/Common/gfx/allegrobitmap.cpp
@@ -163,11 +163,6 @@ bool Bitmap::SaveToFile(const char *filename, const void *palette)
 	return save_bitmap(filename, _alBitmap, (const RGB*)palette) == 0;
 }
 
-void Bitmap::SetMaskColor(color_t color)
-{
-	// not supported? CHECKME
-}
-
 color_t Bitmap::GetCompatibleColor(color_t color)
 {
     color_t compat_color = 0;

--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -139,7 +139,7 @@ public:
         return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : nullptr;
     }
 
-    void    SetMaskColor(color_t color);
+	// Get bitmap's mask color (transparent color)
 	inline color_t GetMaskColor() const
     {
         return bitmap_mask_color(_alBitmap);

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -116,7 +116,7 @@ template <class TPx, size_t BPP_>
 struct PixelTransCpy
 {
     static const size_t BPP = BPP_;
-    inline void operator ()(uint8_t *dst, const uint8_t *src, color_t mask_color, bool use_alpha) const
+    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool use_alpha) const
     {
         if (*(TPx*)src == mask_color)
             *(TPx*)dst = mask_color;
@@ -125,7 +125,7 @@ struct PixelTransCpy
 
 struct PixelNoSkip
 {
-    inline bool operator ()(uint8_t *data, color_t mask_color, bool use_alpha) const
+    inline bool operator ()(uint8_t *data, uint32_t mask_color, bool use_alpha) const
     {
         return false;
     }
@@ -137,7 +137,7 @@ typedef PixelTransCpy<uint16_t, 2> PixelTransCpy16;
 struct PixelTransCpy24
 {
     static const size_t BPP = 3;
-    inline void operator ()(uint8_t *dst, const uint8_t *src, color_t mask_color, bool use_alpha) const
+    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool use_alpha) const
     {
         const uint8_t *mcol_ptr = (const uint8_t*)&mask_color;
         if (src[0] == mcol_ptr[0] && src[1] == mcol_ptr[1] && src[2] == mcol_ptr[2])
@@ -152,7 +152,7 @@ struct PixelTransCpy24
 struct PixelTransCpy32
 {
     static const size_t BPP = 4;
-    inline void operator ()(uint8_t *dst, const uint8_t *src, color_t mask_color, bool use_alpha) const
+    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool use_alpha) const
     {
         if (*(const uint32_t*)src == mask_color)
             *(uint32_t*)dst = mask_color;
@@ -165,14 +165,14 @@ struct PixelTransCpy32
 
 struct PixelTransSkip32
 {
-    inline bool operator ()(uint8_t *data, color_t mask_color, bool use_alpha) const
+    inline bool operator ()(uint8_t *data, uint32_t mask_color, bool use_alpha) const
     {
         return *(uint32_t*)data == mask_color || (use_alpha && data[3] == 0);
     }
 };
 
 template <class FnPxProc, class FnSkip>
-void ApplyMask(uint8_t *dst, const uint8_t *src, size_t pitch, size_t height, FnPxProc proc, FnSkip skip, color_t mask_color, bool dst_has_alpha, bool mask_has_alpha)
+void ApplyMask(uint8_t *dst, const uint8_t *src, size_t pitch, size_t height, FnPxProc proc, FnSkip skip, uint32_t mask_color, bool dst_has_alpha, bool mask_has_alpha)
 {
     for (size_t y = 0; y < height; ++y)
     {

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -112,20 +112,22 @@ Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height)
     return bmp;
 }
 
+// Functor that copies the "mask color" pixels from source to dest
 template <class TPx, size_t BPP_>
 struct PixelTransCpy
 {
     static const size_t BPP = BPP_;
-    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool use_alpha) const
+    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool /*use_alpha*/) const
     {
         if (*(TPx*)src == mask_color)
             *(TPx*)dst = mask_color;
     }
 };
 
+// Functor that tells to never skip a pixel in the mask
 struct PixelNoSkip
 {
-    inline bool operator ()(uint8_t *data, uint32_t mask_color, bool use_alpha) const
+    inline bool operator ()(uint8_t * /*data*/, uint32_t /*mask_color*/, bool /*use_alpha*/) const
     {
         return false;
     }
@@ -134,10 +136,11 @@ struct PixelNoSkip
 typedef PixelTransCpy<uint8_t,  1> PixelTransCpy8;
 typedef PixelTransCpy<uint16_t, 2> PixelTransCpy16;
 
+// Functor that copies the "mask color" pixels from source to dest, 24-bit depth
 struct PixelTransCpy24
 {
     static const size_t BPP = 3;
-    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool use_alpha) const
+    inline void operator ()(uint8_t *dst, const uint8_t *src, uint32_t mask_color, bool /*use_alpha*/) const
     {
         const uint8_t *mcol_ptr = (const uint8_t*)&mask_color;
         if (src[0] == mcol_ptr[0] && src[1] == mcol_ptr[1] && src[2] == mcol_ptr[2])
@@ -149,6 +152,7 @@ struct PixelTransCpy24
     }
 };
 
+// Functor that copies the "mask color" pixels from source to dest, 32-bit depth, with alpha
 struct PixelTransCpy32
 {
     static const size_t BPP = 4;
@@ -163,6 +167,7 @@ struct PixelTransCpy32
     }
 };
 
+// Functor that tells to skip pixels if they match the mask color or have alpha = 0
 struct PixelTransSkip32
 {
     inline bool operator ()(uint8_t *data, uint32_t mask_color, bool use_alpha) const
@@ -171,8 +176,12 @@ struct PixelTransSkip32
     }
 };
 
+// Applies bitmap mask, using 2 functors:
+// - one that tells whether to skip current pixel;
+// - another that copies the color from src to dest
 template <class FnPxProc, class FnSkip>
-void ApplyMask(uint8_t *dst, const uint8_t *src, size_t pitch, size_t height, FnPxProc proc, FnSkip skip, uint32_t mask_color, bool dst_has_alpha, bool mask_has_alpha)
+void ApplyMask(uint8_t *dst, const uint8_t *src, size_t pitch, size_t height,
+    FnPxProc proc, FnSkip skip, uint32_t mask_color, bool dst_has_alpha, bool mask_has_alpha)
 {
     for (size_t y = 0; y < height; ++y)
     {

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -801,8 +801,7 @@ GUILabelMacro FindLabelMacros(const String &text)
                 // Test which macro it is (if any)
                 macro_at++;
                 const size_t macro_len = ptr - macro_at;
-                if (macro_len == -1 || macro_len > 20); // skip zero-length or too long substrings
-                else if (ags_strnicmp(macro_at, "gamename", macro_len) == 0)
+                if (ags_strnicmp(macro_at, "gamename", macro_len) == 0)
                     macro_flags |= kLabelMacro_Gamename;
                 else if (ags_strnicmp(macro_at, "overhotspot", macro_len) == 0)
                     macro_flags |= kLabelMacro_Overhotspot;

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -59,7 +59,7 @@ public:
     virtual bool    IsContentClipped() const { return true; }
     
     // Operations
-    virtual void    Draw(Bitmap *ds) { }
+    virtual void    Draw(Bitmap*) { }
     void            SetClickable(bool on);
     void            SetEnabled(bool on);
     void            SetTranslated(bool on);
@@ -67,7 +67,7 @@ public:
 
     // Events
     // Key pressed for control
-    virtual void    OnKeyPress(const KeyInput &ki) { }
+    virtual void    OnKeyPress(const KeyInput&) { }
     // Mouse button down - return 'True' to lock focus
     virtual bool    OnMouseDown() { return false; }
     // Mouse moves onto control
@@ -75,7 +75,7 @@ public:
     // Mouse moves off control
     virtual void    OnMouseLeave() { }
     // Mouse moves over control - x,y relative to gui
-    virtual void    OnMouseMove(int x, int y) { }
+    virtual void    OnMouseMove(int /*x*/, int /*y*/) { }
     // Mouse button up
     virtual void    OnMouseUp() { }
     // Control was resized

--- a/Common/script/cc_script.cpp
+++ b/Common/script/cc_script.cpp
@@ -315,7 +315,7 @@ bool ccScript::Read(Stream *in)
     sectionOffsets = nullptr;
   }
 
-  if (in->ReadInt32() != ENDFILESIG) {
+  if (static_cast<uint32_t>(in->ReadInt32()) != ENDFILESIG) {
     cc_error("internal error rebuilding script");
     return false;
   }

--- a/Common/util/alignedstream.cpp
+++ b/Common/util/alignedstream.cpp
@@ -221,7 +221,7 @@ size_t AlignedStream::WriteArrayOfInt64(const int64_t *buffer, size_t count)
     return count;
 }
 
-bool AlignedStream::Seek(soff_t offset, StreamSeek origin)
+bool AlignedStream::Seek(soff_t /*offset*/, StreamSeek /*origin*/)
 {
     // TODO: split out Seekable Stream interface
     return false;

--- a/Common/util/cmdlineopts.cpp
+++ b/Common/util/cmdlineopts.cpp
@@ -44,7 +44,7 @@ ParseResult Parse(int argc, const char *const argv[], const std::set<String> &op
         }
     }
 
-    for (int i = 0; i < args.size(); i++)
+    for (size_t i = 0; i < args.size(); i++)
     {
         String arg = args[i];
 

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -326,7 +326,7 @@ std::unique_ptr<Bitmap> load_rle_bitmap8(Stream *in, RGB (*pal)[256])
     return bmp;
 }
 
-void skip_rle_bitmap8(Common::Stream *in)
+void skip_rle_bitmap8(Stream *in)
 {
     int w = in->ReadInt16();
     int h = in->ReadInt16();
@@ -339,7 +339,7 @@ void skip_rle_bitmap8(Common::Stream *in)
 // LZW
 //-----------------------------------------------------------------------------
 
-void lzw_compress(const uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *out)
+void lzw_compress(const uint8_t *data, size_t data_sz, int /*image_bpp*/, Stream *out)
 {
     // LZW algorithm that we use fails on sequence less than 16 bytes.
     if (data_sz < 16)
@@ -351,7 +351,7 @@ void lzw_compress(const uint8_t *data, size_t data_sz, int image_bpp, Common::St
     lzwcompress(&mem_in, out);
 }
 
-void lzw_decompress(uint8_t *data, size_t data_sz, int image_bpp, Common::Stream *in)
+void lzw_decompress(uint8_t *data, size_t data_sz, int /*image_bpp*/, Stream *in)
 {
     // LZW algorithm that we use fails on sequence less than 16 bytes.
     if (data_sz < 16)

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -38,14 +38,14 @@ static void cpackbitl(const uint8_t *line, size_t size, Stream *out)
   size_t cnt = 0;               // bytes encoded
 
   while (cnt < size) {
-    // note that the algorithm below requires signed operations
-    int i = cnt;
+    // IMPORTANT: the algorithm below requires signed operations
+    int i = static_cast<int32_t>(cnt);
     int j = i + 1;
     int jmax = i + 126;
-    if ((size_t)jmax >= size)
+    if (static_cast<uint32_t>(jmax) >= size)
       jmax = size - 1;
 
-    if (i == size - 1) {        //................last byte alone
+    if (static_cast<uint32_t>(i) == size - 1) { //......last byte alone
       out->WriteInt8(0);
       out->WriteInt8(line[i]);
       cnt++;
@@ -75,14 +75,14 @@ static void cpackbitl16(const uint16_t *line, size_t size, Stream *out)
   size_t cnt = 0;               // bytes encoded
 
   while (cnt < size) {
-    // note that the algorithm below requires signed operations
+    // IMPORTANT: the algorithm below requires signed operations
     int i = cnt;
     int j = i + 1;
     int jmax = i + 126;
-    if ((size_t)jmax >= size)
+    if (static_cast<uint32_t>(jmax) >= size)
       jmax = size - 1;
 
-    if (i == size - 1) {        //................last byte alone
+    if (static_cast<uint32_t>(i) == size - 1) { //......last byte alone
       out->WriteInt8(0);
       out->WriteInt16(line[i]);
       cnt++;
@@ -112,14 +112,14 @@ static void cpackbitl32(const uint32_t *line, size_t size, Stream *out)
   size_t cnt = 0;               // bytes encoded
 
   while (cnt < size) {
-    // note that the algorithm below requires signed operations
+    // IMPORTANT: the algorithm below requires signed operations
     int i = cnt;
     int j = i + 1;
     int jmax = i + 126;
-    if ((size_t)jmax >= size)
+    if (static_cast<uint32_t>(jmax) >= size)
       jmax = size - 1;
 
-    if (i == size - 1) {        //................last byte alone
+    if (static_cast<uint32_t>(i) == size - 1) { //......last byte alone
       out->WriteInt8(0);
       out->WriteInt32(line[i]);
       cnt++;

--- a/Common/util/data_ext.cpp
+++ b/Common/util/data_ext.cpp
@@ -133,7 +133,7 @@ void WriteExtBlock(int block, const String &ext_id, PfnWriteExtBlock writer, int
     // Write block's header
     (flags & kDataExt_NumID32) != 0 ?
         out->WriteInt32(block) :
-        out->WriteInt8(block);
+        out->WriteInt8(static_cast<int8_t>(block));
     if (block == 0) // new-style string id
         ext_id.WriteCount(out, 16);
     soff_t sz_at = out->GetPosition();

--- a/Common/util/data_ext.cpp
+++ b/Common/util/data_ext.cpp
@@ -30,8 +30,9 @@ String GetDataExtErrorText(DataExtErrorType err)
         return "Unexpected end of file.";
     case kDataExtErr_BlockDataOverlapping:
         return "Block data overlapping.";
+    default:
+        return "Unknown error.";
     }
-    return "Unknown error.";
 }
 
 HError DataExtParser::OpenBlock()

--- a/Common/util/data_ext.h
+++ b/Common/util/data_ext.h
@@ -92,7 +92,7 @@ public:
     { return String::FromFormat("id:%d", block_id); }
     // Provides a leeway for over-reading (reading past the reported block length):
     // the parser will not error if the mistake is in this range of bytes
-    virtual soff_t GetOverLeeway(int block_id) const { return 0; }
+    virtual soff_t GetOverLeeway(int /*block_id*/) const { return 0; }
 
     // Gets a stream
     inline Stream *GetStream() { return _in; }

--- a/Common/util/directory.cpp
+++ b/Common/util/directory.cpp
@@ -120,7 +120,7 @@ bool GetFilesImpl(const String &dir_path, std::vector<String> &files,
 }
 #else
 bool GetFilesImpl(const String &dir_path, std::vector<String> &files,
-    int attr_dir)
+    uint32_t attr_dir)
 {
     char filename[MAX_PATH_SZ];
     wchar_t wpattern[MAX_PATH_SZ];
@@ -192,8 +192,8 @@ struct FindFile::Internal
 #if AGS_PLATFORM_OS_ANDROID
     std::unique_ptr<AndroidADir> aadir;
 #endif
-    int attrFile = 0;
-    int attrDir = 0;
+    uint32_t attrFile = 0u;
+    uint32_t attrDir = 0u;
 };
 
 
@@ -287,7 +287,7 @@ bool FindFile::Next()
 #if AGS_PLATFORM_OS_WINDOWS
     auto ff = _i->ff;
     auto &fdata = _i->fdata;
-    const int attrDir = _i->attrDir;
+    const uint32_t attrDir = _i->attrDir;
     char filename[MAX_PATH_SZ];
     // We already have an entry opened at this point, so check that first;
     // if it's not valid then continue searching
@@ -305,8 +305,8 @@ bool FindFile::Next()
     }
 #else
     auto dir = _i->dir;
-    const int is_reg = _i->attrFile;
-    const int is_dir = _i->attrDir;
+    const uint32_t is_reg = _i->attrFile;
+    const uint32_t is_dir = _i->attrDir;
     struct dirent *ent;
     struct stat f_stat;
     std::cmatch mr;
@@ -390,7 +390,7 @@ bool FindFileRecursive::Next()
 
 bool FindFileRecursive::PushDir(const String &sub)
 {
-    if (_maxLevel != -1 && _fdirs.size() == _maxLevel)
+    if (_maxLevel != SIZE_MAX && _fdirs.size() == _maxLevel)
         return false; // no more nesting allowed
 
     String path = Path::ConcatPaths(_fullDir, sub);

--- a/Common/util/directory.h
+++ b/Common/util/directory.h
@@ -91,7 +91,7 @@ public:
     ~FindFileRecursive() = default;
 
     static FindFileRecursive Open(const String &path, const String &wildcard = "*",
-                                  size_t max_level = -1);
+                                  size_t max_level = SIZE_MAX);
     // TODO: directory mode, like in FindFile
     bool AtEnd() const { return _ffile.AtEnd(); }
     String Current() const { return _curFile; }
@@ -107,7 +107,8 @@ private:
     std::stack<FindFile> _fdirs;
     FindFile _fdir; // current find dir iterator
     FindFile _ffile; // current find file iterator
-    size_t _maxLevel = -1; // max nesting level, -1 for unrestricted
+    // max nesting level, SIZE_MAX for unrestricted
+    size_t _maxLevel = SIZE_MAX;
     String _fullDir; // full directory path
     String _curDir; // current dir path, relative to the base path
     String _curFile; // current file path with parent dirs

--- a/Common/util/math.h
+++ b/Common/util/math.h
@@ -80,7 +80,8 @@ namespace Math
     template <typename T, typename TBig>
     inline T InRangeOrDef(const TBig &val, const T &def)
     {
-        return (val >= std::numeric_limits<T>::min() && val <= std::numeric_limits<T>::max()) ? val : def;
+        return (val >= std::numeric_limits<T>::min() && val <= std::numeric_limits<T>::max()) ?
+            static_cast<T>(val) : def;
     }
 
     inline float RadiansToDegrees(float rads)

--- a/Common/util/memorystream.cpp
+++ b/Common/util/memorystream.cpp
@@ -46,7 +46,9 @@ void MemoryStream::Close()
 {
     _cbuf = nullptr;
     _buf = nullptr;
-    _pos = -1;
+    _buf_sz = 0;
+    _len = 0;
+    _pos = 0;
 }
 
 bool MemoryStream::Flush()
@@ -92,9 +94,9 @@ bool MemoryStream::CanSeek() const
 size_t MemoryStream::Read(void *buffer, size_t size)
 {
     if (EOS()) { return 0; }
-    soff_t remain = _len - _pos;
-    assert(remain > 0);
-    size_t read_sz = std::min((size_t)remain, size);
+    assert(_len > _pos);
+    size_t remain = _len - _pos;
+    size_t read_sz = std::min(remain, size);
     memcpy(buffer, _cbuf + _pos, read_sz);
     _pos += read_sz;
     return read_sz;
@@ -103,29 +105,30 @@ size_t MemoryStream::Read(void *buffer, size_t size)
 int32_t MemoryStream::ReadByte()
 {
     if (EOS()) { return -1; }
-    return _cbuf[(size_t)(_pos++)];
+    return _cbuf[_pos++];
 }
 
 bool MemoryStream::Seek(soff_t offset, StreamSeek origin)
 {
     if (!CanSeek()) { return false; }
+    soff_t pos = 0;
     switch (origin)
     {
-    case kSeekBegin:    _pos = 0 + offset; break;
-    case kSeekCurrent:  _pos = _pos + offset; break;
-    case kSeekEnd:      _pos = _len + offset; break;
+    case kSeekBegin:    pos = 0 + offset; break;
+    case kSeekCurrent:  pos = _pos + offset; break;
+    case kSeekEnd:      pos = _len + offset; break;
     default:
         return false;
     }
-    _pos = std::max<soff_t>(0, _pos);
-    _pos = std::min<soff_t>(_len, _pos); // clamp to EOS
+    _pos = static_cast<size_t>(std::max<soff_t>(0, pos));
+    _pos = static_cast<size_t>(std::min<soff_t>(_len, pos)); // clamp to EOS
     return true;
 }
 
 size_t MemoryStream::Write(const void *buffer, size_t size)
 {
     if (_pos >= _buf_sz) { return 0; }
-    size = std::min(size, _buf_sz - (size_t)_pos);
+    size = std::min(size, _buf_sz - _pos);
     memcpy(_buf + _pos, buffer, size);
     _pos += size;
     _len += size;

--- a/Common/util/memorystream.h
+++ b/Common/util/memorystream.h
@@ -74,7 +74,7 @@ protected:
     size_t                   _buf_sz; // hard buffer limit
     size_t                   _len; // calculated length of stream
     const StreamWorkMode     _mode;
-    soff_t                   _pos; // current stream pos
+    size_t                   _pos; // current stream pos
 
 private:
     uint8_t                 *_buf;

--- a/Common/util/multifilelib.cpp
+++ b/Common/util/multifilelib.cpp
@@ -37,14 +37,14 @@ namespace MFLUtil
     static const String EncryptionString = "My\x1\xde\x4Jibzle";
 
     MFLError ReadSigsAndVersion(Stream *in, MFLVersion *p_lib_version, soff_t *p_abs_offset);
-    MFLError ReadSingleFileLib(AssetLibInfo &lib, Stream *in, MFLVersion lib_version);
+    MFLError ReadSingleFileLib(AssetLibInfo &lib, Stream *in);
     MFLError ReadMultiFileLib(AssetLibInfo &lib, Stream *in, MFLVersion lib_version);
     MFLError ReadV10(AssetLibInfo &lib, Stream *in, MFLVersion lib_version);
     MFLError ReadV20(AssetLibInfo &lib, Stream *in);
     MFLError ReadV21(AssetLibInfo &lib, Stream *in);
     MFLError ReadV30(AssetLibInfo &lib, Stream *in, MFLVersion lib_version);
 
-    void     WriteV30(const AssetLibInfo &lib, MFLVersion lib_version, Stream *out);
+    void     WriteV30(const AssetLibInfo &lib, Stream *out);
 
     // Encryption / decryption 
     int      GetNextPseudoRand(int &rand_val);
@@ -104,7 +104,7 @@ MFLUtil::MFLError MFLUtil::ReadHeader(AssetLibInfo &lib, Stream *in)
     else
     {
         // read older clib versions (versions 1 to 9)
-        err = ReadSingleFileLib(lib, in, lib_version);
+        err = ReadSingleFileLib(lib, in);
     }
 
     // apply absolute offset for the assets contained in base data file
@@ -185,7 +185,7 @@ MFLUtil::MFLError MFLUtil::ReadSigsAndVersion(Stream *in, MFLVersion *p_lib_vers
     return kMFLNoError;
 }
 
-MFLUtil::MFLError MFLUtil::ReadSingleFileLib(AssetLibInfo &lib, Stream *in, MFLVersion lib_version)
+MFLUtil::MFLError MFLUtil::ReadSingleFileLib(AssetLibInfo &lib, Stream *in)
 {
     char passwmodifier = in->ReadInt8();
     in->ReadInt8(); // unused byte
@@ -382,11 +382,11 @@ void MFLUtil::WriteHeader(const AssetLibInfo &lib, MFLVersion lib_version, int l
     // First datafile in chain: write the table of contents
     if (lib_index == 0)
     {
-        WriteV30(lib, lib_version, out);
+        WriteV30(lib, out);
     }
 }
 
-void MFLUtil::WriteV30(const AssetLibInfo &lib, MFLVersion lib_version, Stream *out)
+void MFLUtil::WriteV30(const AssetLibInfo &lib, Stream *out)
 {
     out->WriteInt32(0); // reserved options
     // filenames for all library parts

--- a/Common/util/multifilelib.cpp
+++ b/Common/util/multifilelib.cpp
@@ -171,7 +171,7 @@ MFLUtil::MFLError MFLUtil::ReadSigsAndVersion(Stream *in, MFLVersion *p_lib_vers
     // if we've reached this point we must be right behind the header signature
 
     // read library header
-    MFLVersion lib_version = (MFLVersion)in->ReadByte();
+    MFLVersion lib_version = static_cast<MFLVersion>(in->ReadInt8());
     if ((lib_version != kMFLVersion_SingleLib) && (lib_version != kMFLVersion_MultiV10) &&
         (lib_version != kMFLVersion_MultiV11) && (lib_version != kMFLVersion_MultiV15) &&
         (lib_version != kMFLVersion_MultiV20) && (lib_version != kMFLVersion_MultiV21) &&
@@ -187,7 +187,7 @@ MFLUtil::MFLError MFLUtil::ReadSigsAndVersion(Stream *in, MFLVersion *p_lib_vers
 
 MFLUtil::MFLError MFLUtil::ReadSingleFileLib(AssetLibInfo &lib, Stream *in, MFLVersion lib_version)
 {
-    int passwmodifier = in->ReadByte();
+    char passwmodifier = in->ReadInt8();
     in->ReadInt8(); // unused byte
     lib.LibFileNames.resize(1); // only one library part
     size_t asset_count = (uint16_t)in->ReadInt16();
@@ -376,8 +376,8 @@ MFLUtil::MFLError MFLUtil::ReadV30(AssetLibInfo &lib, Stream *in, MFLVersion /* 
 void MFLUtil::WriteHeader(const AssetLibInfo &lib, MFLVersion lib_version, int lib_index, Stream *out)
 {
     out->Write(MFLUtil::HeadSig.GetCStr(), MFLUtil::HeadSig.GetLength());
-    out->WriteByte(lib_version);
-    out->WriteByte(lib_index);   // file number
+    out->WriteInt8(static_cast<uint8_t>(lib_version));
+    out->WriteInt8(static_cast<uint8_t>(lib_index));   // file number
 
     // First datafile in chain: write the table of contents
     if (lib_index == 0)
@@ -401,7 +401,7 @@ void MFLUtil::WriteV30(const AssetLibInfo &lib, MFLVersion lib_version, Stream *
     for (const auto &asset : lib.AssetInfos)
     {
         StrUtil::WriteCStr(asset.FileName, out);
-        out->WriteInt8(asset.LibUid);
+        out->WriteInt8(static_cast<uint8_t>(asset.LibUid));
         out->WriteInt64(asset.Offset);
         out->WriteInt64(asset.Size);
     }
@@ -446,13 +446,13 @@ void MFLUtil::ReadEncArray(void *data, size_t size, size_t count, Stream *in, in
     const size_t len = size * count;
     for (size_t i = 0; i < len; ++i)
     {
-        ch[i] -= GetNextPseudoRand(rand_val);
+        ch[i] = static_cast<uint8_t>(ch[i] - GetNextPseudoRand(rand_val));
     }
 }
 
 int8_t MFLUtil::ReadEncInt8(Stream *in, int &rand_val)
 {
-    return in->ReadByte() - GetNextPseudoRand(rand_val);
+    return static_cast<int8_t>(in->ReadInt8() - GetNextPseudoRand(rand_val));
 }
 
 int32_t MFLUtil::ReadEncInt32(Stream *in, int &rand_val)
@@ -470,7 +470,7 @@ void MFLUtil::ReadEncString(char *buffer, size_t max_len, Stream *in, int &rand_
     size_t i = 0;
     while ((i == 0) || (buffer[i - 1] != 0))
     {
-        buffer[i] = in->ReadByte() - GetNextPseudoRand(rand_val);
+        buffer[i] = static_cast<int8_t>(in->ReadInt8() - GetNextPseudoRand(rand_val));
         if (i < max_len - 1)
             i++;
         else

--- a/Common/util/multifilelib.cpp
+++ b/Common/util/multifilelib.cpp
@@ -68,8 +68,9 @@ String MFLUtil::GetMFLErrorText(MFLError err)
         return "Format version not supported.";
     case kMFLErrNoLibBase:
         return "Not the base asset library file.";
+    default:
+        return "Unknown error.";
     }
-    return "Unknown error.";
 }
 
 MFLUtil::MFLError MFLUtil::TestIsMFL(Stream *in, bool test_is_main)

--- a/Common/util/string_compat.c
+++ b/Common/util/string_compat.c
@@ -20,7 +20,7 @@ char *ags_strlwr(char *s)
 {
     char *p = s;
     for (; *p; p++)
-        *p = tolower(*p);
+        *p = (char)tolower(*p);
     return s;
 }
 
@@ -28,7 +28,7 @@ char *ags_strupr(char *s)
 {
     char *p = s;
     for (; *p; p++)
-        *p = toupper(*p);
+        *p = (char)toupper(*p);
     return s;
 }
 

--- a/Common/util/textstreamreader.cpp
+++ b/Common/util/textstreamreader.cpp
@@ -121,8 +121,8 @@ String TextStreamReader::ReadLine()
 
 String TextStreamReader::ReadAll()
 {
-    soff_t len = _stream->GetLength() - _stream->GetPosition();
-    return ReadString(len > SIZE_MAX ? SIZE_MAX : (size_t)len);
+    size_t len = Math::InRangeOrDef<size_t>(_stream->GetLength() - _stream->GetPosition(), SIZE_MAX);
+    return ReadString(len);
 }
 
 } // namespace Common

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3835,7 +3835,7 @@ void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
     Character_Think(chaa, scsf_buffer);
 }
 
-void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
+void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
     ccAddExternalObjectFunction("Character::AddInventory^2",            Sc_Character_AddInventory);
 	ccAddExternalObjectFunction("Character::AddWaypoint^2",             Sc_Character_AddWaypoint);

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -335,7 +335,7 @@ int run_dialog_script(int dialogID, int offse, int optionIndex) {
 }
 
 int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, int numdisp, int mouseison, int areawid,
-    int bullet_wid, int usingfont, DialogTopic*dtop, char*disporder, short*dispyp,
+    int bullet_wid, int usingfont, DialogTopic*dtop, int*disporder, short*dispyp,
     int linespacing, int utextcol, int padding) {
   int ww;
 
@@ -443,10 +443,13 @@ struct DialogOptions
     GUITextBox *parserInput;
     DialogTopic*dtop;
 
-    char disporder[MAXTOPICOPTIONS];
+    // display order of options
+    int disporder[MAXTOPICOPTIONS];
+    // display Y coordinate of options
     short dispyp[MAXTOPICOPTIONS];
-
+    // number of displayed options
     int numdisp;
+    // currently chosen option
     int chose;
 
     Bitmap *tempScrn;

--- a/Engine/ac/draw_software.cpp
+++ b/Engine/ac/draw_software.cpp
@@ -314,23 +314,23 @@ void invalidate_rect_on_surf(int x1, int y1, int x2, int y2, DirtyRects &rects)
         }
         else {
             // didn't fit in an existing span, and there are none spare
-            int nearestDist = 99999, nearestWas = -1, extendLeft;
-            int tleft, tright;
+            int nearestDist = 99999, nearestWas = -1, extendLeft = 0;
             // find the nearest span, and enlarge that to include this rect
             for (s = 0; s < dirtyRow[a].numSpans; s++) {
-                tleft = dirtyRow[a].span[s].x1 - x2;
+                int tleft = dirtyRow[a].span[s].x1 - x2;
                 if ((tleft > 0) && (tleft < nearestDist)) {
                     nearestDist = tleft;
                     nearestWas = s;
                     extendLeft = 1;
                 }
-                tright = x1 - dirtyRow[a].span[s].x2;
+                int tright = x1 - dirtyRow[a].span[s].x2;
                 if ((tright > 0) && (tright < nearestDist)) {
                     nearestDist = tright;
                     nearestWas = s;
                     extendLeft = 0;
                 }
             }
+            assert(nearestWas >= 0);
             if (extendLeft)
                 dirtyRow[a].span[nearestWas].x1 = x1;
             else

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -420,8 +420,8 @@ void DrawingSurface_DrawPixel(ScriptDrawingSurface *sds, int x, int y) {
 int DrawingSurface_GetPixel(ScriptDrawingSurface *sds, int x, int y) {
     sds->PointToGameResolution(&x, &y);
     Bitmap *ds = sds->StartDrawing();
-    unsigned int rawPixel = ds->GetPixel(x, y);
-    unsigned int maskColor = ds->GetMaskColor();
+    int rawPixel = ds->GetPixel(x, y);
+    int maskColor = ds->GetMaskColor();
     int colDepth = ds->GetColorDepth();
 
     if (rawPixel == maskColor)

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -431,14 +431,12 @@ int DrawingSurface_GetPixel(ScriptDrawingSurface *sds, int x, int y) {
     else if (colDepth > 8)
     {
         int r = getr_depth(colDepth, rawPixel);
-        int ds = getg_depth(colDepth, rawPixel);
+        int g = getg_depth(colDepth, rawPixel);
         int b = getb_depth(colDepth, rawPixel);
-
-        rawPixel = Game_GetColorFromRGB(r, ds, b);
+        rawPixel = Game_GetColorFromRGB(r, g, b);
     }
 
     sds->FinishedDrawingReadOnly();
-
     return rawPixel;
 }
 

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -609,7 +609,7 @@ void ScPl_DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, i
     DrawingSurface_DrawString(sds, xx, yy, font, scsf_buffer);
 }
 
-void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
+void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
     ccAddExternalObjectFunction("DrawingSurface::Clear^1",              Sc_DrawingSurface_Clear);
     ccAddExternalObjectFunction("DrawingSurface::CreateCopy^0",         Sc_DrawingSurface_CreateCopy);

--- a/Engine/ac/dynobj/cc_agsdynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.cpp
@@ -20,7 +20,7 @@ using namespace AGS::Common;
 
 // *** The script serialization routines for built-in types
 
-int AGSCCDynamicObject::Dispose(const char *address, bool force) {
+int AGSCCDynamicObject::Dispose(const char* /*address*/, bool /*force*/) {
     // cannot be removed from memory
     return 0;
 }

--- a/Engine/ac/dynobj/cc_audiochannel.cpp
+++ b/Engine/ac/dynobj/cc_audiochannel.cpp
@@ -34,7 +34,7 @@ void CCAudioChannel::Serialize(const char *address, Stream *out) {
     out->WriteInt32(ach->id);
 }
 
-void CCAudioChannel::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCAudioChannel::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int id = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrAudioChannel[id], this);
 }

--- a/Engine/ac/dynobj/cc_audioclip.cpp
+++ b/Engine/ac/dynobj/cc_audioclip.cpp
@@ -34,7 +34,7 @@ void CCAudioClip::Serialize(const char *address, Stream *out) {
     out->WriteInt32(ach->id);
 }
 
-void CCAudioClip::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCAudioClip::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int id = in->ReadInt32();
     ccRegisterUnserializedObject(index, &game.audioClips[id], this);
 }

--- a/Engine/ac/dynobj/cc_character.cpp
+++ b/Engine/ac/dynobj/cc_character.cpp
@@ -32,14 +32,12 @@ size_t CCCharacter::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCCharacter::Serialize(const char *address, Stream *out) {
     CharacterInfo *chaa = (CharacterInfo*)address;
     out->WriteInt32(chaa->index_id);
 }
 
-void CCCharacter::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCCharacter::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &game.chars[num], this);
 }

--- a/Engine/ac/dynobj/cc_dialog.cpp
+++ b/Engine/ac/dynobj/cc_dialog.cpp
@@ -29,14 +29,12 @@ size_t CCDialog::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCDialog::Serialize(const char *address, Stream *out) {
     ScriptDialog *shh = (ScriptDialog*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCDialog::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCDialog::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrDialog[num], this);
 }

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -46,8 +46,6 @@ int CCDynamicArray::Dispose(const char *address, bool force) {
     return 1;
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 int CCDynamicArray::Serialize(const char *address, char *buffer, int bufsize) {
     int *sizeInBytes = &((int*)address)[-1];
     int sizeToWrite = *sizeInBytes + 8;

--- a/Engine/ac/dynobj/cc_gui.cpp
+++ b/Engine/ac/dynobj/cc_gui.cpp
@@ -29,14 +29,12 @@ size_t CCGUI::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCGUI::Serialize(const char *address, Stream *out) {
     ScriptGUI *shh = (ScriptGUI*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCGUI::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCGUI::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrGui[num], this);
 }

--- a/Engine/ac/dynobj/cc_guiobject.cpp
+++ b/Engine/ac/dynobj/cc_guiobject.cpp
@@ -29,15 +29,13 @@ size_t CCGUIObject::CalcSerializeSize()
     return sizeof(int32_t) * 2;
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCGUIObject::Serialize(const char *address, Stream *out) {
     GUIObject *guio = (GUIObject*)address;
     out->WriteInt32(guio->ParentId);
     out->WriteInt32(guio->Id);
 }
 
-void CCGUIObject::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCGUIObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int guinum = in->ReadInt32();
     int objnum = in->ReadInt32();
     ccRegisterUnserializedObject(index, guis[guinum].GetControl(objnum), this);

--- a/Engine/ac/dynobj/cc_hotspot.cpp
+++ b/Engine/ac/dynobj/cc_hotspot.cpp
@@ -31,14 +31,12 @@ size_t CCHotspot::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCHotspot::Serialize(const char *address, Stream *out) {
     ScriptHotspot *shh = (ScriptHotspot*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCHotspot::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCHotspot::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrHotspot[num], this);
 }

--- a/Engine/ac/dynobj/cc_inventory.cpp
+++ b/Engine/ac/dynobj/cc_inventory.cpp
@@ -30,14 +30,12 @@ size_t CCInventory::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCInventory::Serialize(const char *address, Stream *out) {
     ScriptInvItem *shh = (ScriptInvItem*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCInventory::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCInventory::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrInv[num], this);
 }

--- a/Engine/ac/dynobj/cc_object.cpp
+++ b/Engine/ac/dynobj/cc_object.cpp
@@ -31,14 +31,12 @@ size_t CCObject::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCObject::Serialize(const char *address, Stream *out) {
     ScriptObject *shh = (ScriptObject*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCObject::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrObj[num], this);
 }

--- a/Engine/ac/dynobj/cc_region.cpp
+++ b/Engine/ac/dynobj/cc_region.cpp
@@ -31,14 +31,12 @@ size_t CCRegion::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
 void CCRegion::Serialize(const char *address, Stream *out) {
     ScriptRegion *shh = (ScriptRegion*)address;
     out->WriteInt32(shh->id);
 }
 
-void CCRegion::Unserialize(int index, Stream *in, size_t data_sz) {
+void CCRegion::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
     ccRegisterUnserializedObject(index, &scrRegion[num], this);
 }

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -34,14 +34,10 @@ int ManagedObjectPool::Remove(ManagedObject &o, bool force) {
     bool canBeRemovedFromPool = o.callback->Dispose(o.addr, force) != 0;
     if (!(canBeRemovedFromPool || force)) { return 0; }
 
-    auto handle = o.handle;
     available_ids.push(o.handle);
-
     handleByAddress.erase(o.addr);
+    ManagedObjectLog("Line %d Disposed managed object handle=%d", currentline, o.handle);
     o = ManagedObject();
-
-    ManagedObjectLog("Line %d Disposed managed object handle=%d", currentline, handle);
-
     return 1;
 }
 

--- a/Engine/ac/dynobj/scriptcamera.cpp
+++ b/Engine/ac/dynobj/scriptcamera.cpp
@@ -24,7 +24,7 @@ const char *ScriptCamera::GetType()
     return "Camera2";
 }
 
-int ScriptCamera::Dispose(const char *address, bool force)
+int ScriptCamera::Dispose(const char* /*address*/, bool /*force*/)
 {
     // Note that ScriptCamera is a reference to actual Camera object,
     // and this deletes the reference, while camera may remain in GameState.
@@ -37,18 +37,18 @@ size_t ScriptCamera::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-void ScriptCamera::Serialize(const char *address, Stream *out)
+void ScriptCamera::Serialize(const char* /*address*/, Stream *out)
 {
     out->WriteInt32(_id);
 }
 
-void ScriptCamera::Unserialize(int index, Stream *in, size_t data_sz)
+void ScriptCamera::Unserialize(int index, Stream *in, size_t /*data_sz*/)
 {
     _id = in->ReadInt32();
     ccRegisterUnserializedObject(index, this, this);
 }
 
-ScriptCamera *Camera_Unserialize(int handle, Stream *in, size_t data_sz)
+ScriptCamera *Camera_Unserialize(int handle, Stream *in, size_t /*data_sz*/)
 {
     // The way it works now, we must not create a new script object,
     // but acquire one from the GameState, which keeps the first reference.

--- a/Engine/ac/dynobj/scriptdatetime.cpp
+++ b/Engine/ac/dynobj/scriptdatetime.cpp
@@ -16,7 +16,7 @@
 
 using namespace AGS::Common;
 
-int ScriptDateTime::Dispose(const char *address, bool force) {
+int ScriptDateTime::Dispose(const char* /*address*/, bool /*force*/) {
     // always dispose a DateTime
     delete this;
     return 1;
@@ -31,7 +31,7 @@ size_t ScriptDateTime::CalcSerializeSize()
     return sizeof(int32_t) * 7;
 }
 
-void ScriptDateTime::Serialize(const char *address, Stream *out) {
+void ScriptDateTime::Serialize(const char* /*address*/, Stream *out) {
     out->WriteInt32(year);
     out->WriteInt32(month);
     out->WriteInt32(day);
@@ -41,7 +41,7 @@ void ScriptDateTime::Serialize(const char *address, Stream *out) {
     out->WriteInt32(rawUnixTime);
 }
 
-void ScriptDateTime::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptDateTime::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     year = in->ReadInt32();
     month = in->ReadInt32();
     day = in->ReadInt32();

--- a/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
+++ b/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
@@ -26,12 +26,10 @@ size_t ScriptDialogOptionsRendering::CalcSerializeSize()
     return 0;
 }
 
-// serialize the object into BUFFER (which is BUFSIZE bytes)
-// return number of bytes used
-void ScriptDialogOptionsRendering::Serialize(const char *address, Stream *out) {
+void ScriptDialogOptionsRendering::Serialize(const char* /*address*/, Stream* /*out*/) {
 }
 
-void ScriptDialogOptionsRendering::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptDialogOptionsRendering::Unserialize(int index, Stream* /*in*/, size_t /*data_sz*/) {
     ccRegisterUnserializedObject(index, this, this);
 }
 

--- a/Engine/ac/dynobj/scriptdict.cpp
+++ b/Engine/ac/dynobj/scriptdict.cpp
@@ -13,7 +13,7 @@
 //=============================================================================
 #include "ac/dynobj/scriptdict.h"
 
-int ScriptDictBase::Dispose(const char *address, bool force)
+int ScriptDictBase::Dispose(const char* /*address*/, bool /*force*/)
 {
     Clear();
     delete this;
@@ -25,14 +25,14 @@ const char *ScriptDictBase::GetType()
     return "StringDictionary";
 }
 
-void ScriptDictBase::Serialize(const char *address, Stream *out)
+void ScriptDictBase::Serialize(const char* /*address*/, Stream *out)
 {
     out->WriteInt32(IsSorted());
     out->WriteInt32(IsCaseSensitive());
     SerializeContainer(out);
 }
 
-void ScriptDictBase::Unserialize(int index, Stream *in, size_t data_sz)
+void ScriptDictBase::Unserialize(int index, Stream *in, size_t /*data_sz*/)
 {
     // NOTE: we expect sorted/case flags are read by external reader;
     // this is awkward, but I did not find better design solution atm

--- a/Engine/ac/dynobj/scriptdict.h
+++ b/Engine/ac/dynobj/scriptdict.h
@@ -125,7 +125,7 @@ private:
         _dic[key] = value;
         return true;
     }
-    void DeleteItem(ConstIterator it) { /* do nothing */ }
+    void DeleteItem(ConstIterator /*it*/) { /* do nothing */ }
 
     size_t CalcSerializeSize() override
     {

--- a/Engine/ac/dynobj/scriptdrawingsurface.cpp
+++ b/Engine/ac/dynobj/scriptdrawingsurface.cpp
@@ -61,7 +61,7 @@ void ScriptDrawingSurface::FinishedDrawing()
     modified = 1;
 }
 
-int ScriptDrawingSurface::Dispose(const char *address, bool force) {
+int ScriptDrawingSurface::Dispose(const char* /*address*/, bool /*force*/) {
 
     // dispose the drawing surface
     DrawingSurface_Release(this);
@@ -78,7 +78,7 @@ size_t ScriptDrawingSurface::CalcSerializeSize()
     return sizeof(int32_t) * 9;
 }
 
-void ScriptDrawingSurface::Serialize(const char *address, Stream *out) {
+void ScriptDrawingSurface::Serialize(const char* /*address*/, Stream *out) {
     // pack mask type in the last byte of a negative integer
     // note: (-1) is reserved for "unused", for backward compatibility
     if (roomMaskType > 0)
@@ -95,7 +95,7 @@ void ScriptDrawingSurface::Serialize(const char *address, Stream *out) {
     out->WriteInt32(isLinkedBitmapOnly ? 1 : 0);
 }
 
-void ScriptDrawingSurface::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptDrawingSurface::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int room_ds = in->ReadInt32();
     if (room_ds >= 0)
         roomBackgroundNumber = room_ds;

--- a/Engine/ac/dynobj/scriptdynamicsprite.cpp
+++ b/Engine/ac/dynobj/scriptdynamicsprite.cpp
@@ -17,7 +17,7 @@
 
 using namespace AGS::Common;
 
-int ScriptDynamicSprite::Dispose(const char *address, bool force) {
+int ScriptDynamicSprite::Dispose(const char* /*address*/, bool force) {
     // always dispose
     if ((slot) && (!force))
         free_dynamic_sprite(slot);
@@ -35,11 +35,11 @@ size_t ScriptDynamicSprite::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-void ScriptDynamicSprite::Serialize(const char *address, Stream *out) {
+void ScriptDynamicSprite::Serialize(const char* /*address*/, Stream *out) {
     out->WriteInt32(slot);
 }
 
-void ScriptDynamicSprite::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptDynamicSprite::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     slot = in->ReadInt32();
     ccRegisterUnserializedObject(index, this, this);
 }

--- a/Engine/ac/dynobj/scriptfile.cpp
+++ b/Engine/ac/dynobj/scriptfile.cpp
@@ -21,7 +21,7 @@ const Common::FileOpenMode sc_File::fopenModes[] =
 const Common::FileWorkMode sc_File::fworkModes[] = 
     {Common::kFile_Read/*CHECKME, was undefined*/, Common::kFile_Read, Common::kFile_Write, Common::kFile_Write};
 
-int sc_File::Dispose(const char *address, bool force) {
+int sc_File::Dispose(const char* /*address*/, bool /*force*/) {
     Close();
     delete this;
     return 1;
@@ -31,7 +31,7 @@ const char *sc_File::GetType() {
     return "File";
 }
 
-int sc_File::Serialize(const char *address, char *buffer, int bufsize) {
+int sc_File::Serialize(const char* /*address*/, char* /*buffer*/, int /*bufsize*/) {
     // we cannot serialize an open file, so it will get closed
     return 0;
 }
@@ -55,51 +55,51 @@ sc_File::sc_File() {
 }
 
 
-const char* sc_File::GetFieldPtr(const char *address, intptr_t offset)
+const char* sc_File::GetFieldPtr(const char *address, intptr_t /*offset*/)
 {
     return address;
 }
 
-void sc_File::Read(const char *address, intptr_t offset, void *dest, int size)
+void sc_File::Read(const char* /*address*/, intptr_t /*offset*/, void* /*dest*/, int /*size*/)
 {
 }
 
-uint8_t sc_File::ReadInt8(const char *address, intptr_t offset)
-{
-    return 0;
-}
-
-int16_t sc_File::ReadInt16(const char *address, intptr_t offset)
+uint8_t sc_File::ReadInt8(const char* /*address*/, intptr_t /*offset*/)
 {
     return 0;
 }
 
-int32_t sc_File::ReadInt32(const char *address, intptr_t offset)
+int16_t sc_File::ReadInt16(const char* /*address*/, intptr_t /*offset*/)
 {
     return 0;
 }
 
-float sc_File::ReadFloat(const char *address, intptr_t offset)
+int32_t sc_File::ReadInt32(const char* /*address*/, intptr_t /*offset*/)
+{
+    return 0;
+}
+
+float sc_File::ReadFloat(const char* /*address*/, intptr_t /*offset*/)
 {
     return 0.0;
 }
 
-void sc_File::Write(const char *address, intptr_t offset, void *src, int size)
+void sc_File::Write(const char* /*address*/, intptr_t /*offset*/, void* /*src*/, int /*size*/)
 {
 }
 
-void sc_File::WriteInt8(const char *address, intptr_t offset, uint8_t val)
+void sc_File::WriteInt8(const char* /*address*/, intptr_t /*offset*/, uint8_t /*val*/)
 {
 }
 
-void sc_File::WriteInt16(const char *address, intptr_t offset, int16_t val)
+void sc_File::WriteInt16(const char* /*address*/, intptr_t /*offset*/, int16_t /*val*/)
 {
 }
 
-void sc_File::WriteInt32(const char *address, intptr_t offset, int32_t val)
+void sc_File::WriteInt32(const char* /*address*/, intptr_t /*offset*/, int32_t /*val*/)
 {
 }
 
-void sc_File::WriteFloat(const char *address, intptr_t offset, float val)
+void sc_File::WriteFloat(const char* /*address*/, intptr_t /*offset*/, float /*val*/)
 {
 }

--- a/Engine/ac/dynobj/scriptoverlay.cpp
+++ b/Engine/ac/dynobj/scriptoverlay.cpp
@@ -21,7 +21,7 @@
 
 using namespace AGS::Common;
 
-int ScriptOverlay::Dispose(const char *address, bool force) 
+int ScriptOverlay::Dispose(const char* /*address*/, bool force) 
 {
     // since the managed object is being deleted, remove the
     // reference so it doesn't try and dispose something else
@@ -53,14 +53,14 @@ size_t ScriptOverlay::CalcSerializeSize()
     return sizeof(int32_t) * 4;
 }
 
-void ScriptOverlay::Serialize(const char *address, Stream *out) {
+void ScriptOverlay::Serialize(const char* /*address*/, Stream *out) {
     out->WriteInt32(overlayId);
     out->WriteInt32(borderWidth);
     out->WriteInt32(borderHeight);
     out->WriteInt32(isBackgroundSpeech);
 }
 
-void ScriptOverlay::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptOverlay::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     overlayId = in->ReadInt32();
     borderWidth = in->ReadInt32();
     borderHeight = in->ReadInt32();

--- a/Engine/ac/dynobj/scriptset.cpp
+++ b/Engine/ac/dynobj/scriptset.cpp
@@ -14,7 +14,7 @@
 #include "ac/dynobj/scriptset.h"
 #include "util/stream.h"
 
-int ScriptSetBase::Dispose(const char *address, bool force)
+int ScriptSetBase::Dispose(const char* /*address*/, bool /*force*/)
 {
     Clear();
     delete this;
@@ -26,14 +26,14 @@ const char *ScriptSetBase::GetType()
     return "StringSet";
 }
 
-void ScriptSetBase::Serialize(const char *address, Stream *out)
+void ScriptSetBase::Serialize(const char* /*address*/, Stream *out)
 {
     out->WriteInt32(IsSorted());
     out->WriteInt32(IsCaseSensitive());
     SerializeContainer(out);
 }
 
-void ScriptSetBase::Unserialize(int index, Stream *in, size_t data_sz)
+void ScriptSetBase::Unserialize(int index, Stream *in, size_t /*data_sz*/)
 {
     // NOTE: we expect sorted/case flags are read by external reader;
     // this is awkward, but I did not find better design solution atm

--- a/Engine/ac/dynobj/scriptset.h
+++ b/Engine/ac/dynobj/scriptset.h
@@ -105,7 +105,7 @@ private:
     {
         return _set.insert(s).second;
     }
-    void DeleteItem(ConstIterator it) { /* do nothing */ }
+    void DeleteItem(ConstIterator /*it*/) { /* do nothing */ }
 
     size_t CalcSerializeSize() override
     {

--- a/Engine/ac/dynobj/scriptstring.cpp
+++ b/Engine/ac/dynobj/scriptstring.cpp
@@ -24,7 +24,7 @@ DynObjectRef ScriptString::CreateString(const char *fromText) {
     return CreateNewScriptStringObj(fromText);
 }
 
-int ScriptString::Dispose(const char *address, bool force) {
+int ScriptString::Dispose(const char* /*address*/, bool /*force*/) {
     // always dispose
     if (text) {
         free(text);
@@ -43,13 +43,13 @@ size_t ScriptString::CalcSerializeSize()
     return _len + 1 + sizeof(int32_t);
 }
 
-void ScriptString::Serialize(const char *address, Stream *out) {
+void ScriptString::Serialize(const char* /*address*/, Stream *out) {
     const auto *cstr = text ? text : "";
     out->WriteInt32(_len);
     out->Write(cstr, _len + 1);
 }
 
-void ScriptString::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptString::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     _len = in->ReadInt32();
     text = (char*)malloc(_len + 1);
     in->Read(text, _len + 1);

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -60,13 +60,13 @@ void ScriptUserObject::Create(const char *data, Stream *in, size_t size)
     }
 }
 
-int ScriptUserObject::Dispose(const char *address, bool force)
+int ScriptUserObject::Dispose(const char* /*address*/, bool /*force*/)
 {
     delete this;
     return 1;
 }
 
-int ScriptUserObject::Serialize(const char *address, char *buffer, int bufsize)
+int ScriptUserObject::Serialize(const char* /*address*/, char *buffer, int bufsize)
 {
     if (_size > bufsize)
         // buffer not big enough, ask for a bigger one
@@ -82,57 +82,57 @@ void ScriptUserObject::Unserialize(int index, Stream *in, size_t data_sz)
     ccRegisterUnserializedObject(index, this, this);
 }
 
-const char* ScriptUserObject::GetFieldPtr(const char *address, intptr_t offset)
+const char* ScriptUserObject::GetFieldPtr(const char* /*address*/, intptr_t offset)
 {
     return _data + offset;
 }
 
-void ScriptUserObject::Read(const char *address, intptr_t offset, void *dest, int size)
+void ScriptUserObject::Read(const char* /*address*/, intptr_t offset, void *dest, int size)
 {
     memcpy(dest, _data + offset, size);
 }
 
-uint8_t ScriptUserObject::ReadInt8(const char *address, intptr_t offset)
+uint8_t ScriptUserObject::ReadInt8(const char* /*address*/, intptr_t offset)
 {
     return *(uint8_t*)(_data + offset);
 }
 
-int16_t ScriptUserObject::ReadInt16(const char *address, intptr_t offset)
+int16_t ScriptUserObject::ReadInt16(const char* /*address*/, intptr_t offset)
 {
     return *(int16_t*)(_data + offset);
 }
 
-int32_t ScriptUserObject::ReadInt32(const char *address, intptr_t offset)
+int32_t ScriptUserObject::ReadInt32(const char* /*address*/, intptr_t offset)
 {
     return *(int32_t*)(_data + offset);
 }
 
-float ScriptUserObject::ReadFloat(const char *address, intptr_t offset)
+float ScriptUserObject::ReadFloat(const char* /*address*/, intptr_t offset)
 {
     return *(float*)(_data + offset);
 }
 
-void ScriptUserObject::Write(const char *address, intptr_t offset, void *src, int size)
+void ScriptUserObject::Write(const char* /*address*/, intptr_t offset, void *src, int size)
 {
     memcpy((void*)(_data + offset), src, size);
 }
 
-void ScriptUserObject::WriteInt8(const char *address, intptr_t offset, uint8_t val)
+void ScriptUserObject::WriteInt8(const char* /*address*/, intptr_t offset, uint8_t val)
 {
     *(uint8_t*)(_data + offset) = val;
 }
 
-void ScriptUserObject::WriteInt16(const char *address, intptr_t offset, int16_t val)
+void ScriptUserObject::WriteInt16(const char* /*address*/, intptr_t offset, int16_t val)
 {
     *(int16_t*)(_data + offset) = val;
 }
 
-void ScriptUserObject::WriteInt32(const char *address, intptr_t offset, int32_t val)
+void ScriptUserObject::WriteInt32(const char* /*address*/, intptr_t offset, int32_t val)
 {
     *(int32_t*)(_data + offset) = val;
 }
 
-void ScriptUserObject::WriteFloat(const char *address, intptr_t offset, float val)
+void ScriptUserObject::WriteFloat(const char* /*address*/, intptr_t offset, float val)
 {
     *(float*)(_data + offset) = val;
 }

--- a/Engine/ac/dynobj/scriptviewframe.cpp
+++ b/Engine/ac/dynobj/scriptviewframe.cpp
@@ -16,7 +16,7 @@
 
 using namespace AGS::Common;
 
-int ScriptViewFrame::Dispose(const char *address, bool force) {
+int ScriptViewFrame::Dispose(const char* /*address*/, bool /*force*/) {
     // always dispose a ViewFrame
     delete this;
     return 1;
@@ -31,13 +31,13 @@ size_t ScriptViewFrame::CalcSerializeSize()
     return sizeof(int32_t) * 3;
 }
 
-void ScriptViewFrame::Serialize(const char *address, Stream *out) {
+void ScriptViewFrame::Serialize(const char* /*address*/, Stream *out) {
     out->WriteInt32(view);
     out->WriteInt32(loop);
     out->WriteInt32(frame);
 }
 
-void ScriptViewFrame::Unserialize(int index, Stream *in, size_t data_sz) {
+void ScriptViewFrame::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     view = in->ReadInt32();
     loop = in->ReadInt32();
     frame = in->ReadInt32();

--- a/Engine/ac/dynobj/scriptviewport.cpp
+++ b/Engine/ac/dynobj/scriptviewport.cpp
@@ -24,7 +24,7 @@ const char *ScriptViewport::GetType()
     return "Viewport2";
 }
 
-int ScriptViewport::Dispose(const char *address, bool force)
+int ScriptViewport::Dispose(const char* /*address*/, bool /*force*/)
 {
     // Note that ScriptViewport is a reference to actual Viewport object,
     // and this deletes the reference, while viewport may remain in GameState.
@@ -37,18 +37,18 @@ size_t ScriptViewport::CalcSerializeSize()
     return sizeof(int32_t);
 }
 
-void ScriptViewport::Serialize(const char *address, Stream *out)
+void ScriptViewport::Serialize(const char* /*address*/, Stream *out)
 {
     out->WriteInt32(_id);
 }
 
-void ScriptViewport::Unserialize(int index, Stream *in, size_t data_sz)
+void ScriptViewport::Unserialize(int index, Stream *in, size_t /*data_sz*/)
 {
     _id = in->ReadInt32();
     ccRegisterUnserializedObject(index, this, this);
 }
 
-ScriptViewport *Viewport_Unserialize(int handle, Stream *in, size_t data_sz)
+ScriptViewport *Viewport_Unserialize(int handle, Stream *in, size_t /*data_sz*/)
 {
     // The way it works now, we must not create a new script object,
     // but acquire one from the GameState, which keeps the first reference.

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -465,7 +465,7 @@ static int ags_pf_getc(void *userdata)
     return -1;
 }
 
-static int ags_pf_ungetc(int c, void *userdata)
+static int ags_pf_ungetc(int /*c*/, void* /*userdata*/)
 {
     return -1; // we do not want to support this
 }
@@ -482,12 +482,12 @@ static long ags_pf_fread(void *p, long n, void *userdata)
     return -1;
 }
 
-static int ags_pf_putc(int c, void *userdata)
+static int ags_pf_putc(int /*c*/, void* /*userdata*/)
 {
     return -1;  // don't support write
 }
 
-static long ags_pf_fwrite(AL_CONST void *p, long n, void *userdata)
+static long ags_pf_fwrite(AL_CONST void* /*p*/, long /*n*/, void* /*userdata*/)
 {
     return -1; // don't support write
 }

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -139,7 +139,7 @@ void GameState::UpdateViewports()
         }
         _roomViewportZOrderChanged = false;
     }
-    size_t vp_changed = -1;
+    size_t vp_changed = SIZE_MAX;
     for (size_t i = _roomViewportsSorted.size(); i-- > 0;)
     {
         auto vp = _roomViewportsSorted[i];
@@ -150,7 +150,7 @@ void GameState::UpdateViewports()
             vp->ClearChangedFlags();
         }
     }
-    if (vp_changed != -1)
+    if (vp_changed != SIZE_MAX)
         detect_roomviewport_overlaps(vp_changed);
     for (auto cam : _roomCameras)
     {

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -828,12 +828,14 @@ RuntimeScriptValue Sc_GetWalkableAreaAtScreen(const RuntimeScriptValue *params, 
 
 RuntimeScriptValue Sc_GetDrawingSurfaceForWalkableArea(const RuntimeScriptValue *params, int32_t param_count)
 {
+    (void)params; (void)param_count;
     ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkable);
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
 }
 
 RuntimeScriptValue Sc_GetDrawingSurfaceForWalkbehind(const RuntimeScriptValue *params, int32_t param_count)
 {
+    (void)params; (void)param_count;
     ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkBehind);
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
 }

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -410,7 +410,7 @@ void PlayMP3File (const char *filename) {
         debug_script_warn ("PlayMP3File: file '%s' not found or cannot play", filename);
     }
 
-    post_new_music_check(useChan);
+    post_new_music_check();
 
     update_music_volume();
 }

--- a/Engine/ac/global_button.cpp
+++ b/Engine/ac/global_button.cpp
@@ -74,8 +74,6 @@ int GetButtonPic(int guin, int objn, int ptype) {
     else { // pushed pic
         return guil->PushedImage;
     }
-
-    quit("internal error in getbuttonpic");
 }
 
 void SetButtonPic(int guin,int objn,int ptype,int slotn) {

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -400,7 +400,7 @@ void RunCharacterInteraction (int cc, int mood) {
     if (loaded_game_file_version > kGameVersion_272)
     {
         if (passon>=0)
-            run_interaction_script(game.charScripts[cc].get(), passon, 4, (passon == 3));
+            run_interaction_script(game.charScripts[cc].get(), passon, 4);
         run_interaction_script(game.charScripts[cc].get(), 4);  // any click on char
     }
     else 

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -116,7 +116,7 @@ void RunHotspotInteraction (int hotspothere, int mood) {
     if (thisroom.Hotspots[hotspothere].EventHandlers != nullptr)
     {
         if (passon>=0)
-            run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5, (passon == 3));
+            run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5);
         run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), 5);  // any click on hotspot
     }
     else

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -444,7 +444,7 @@ void RunObjectInteraction (int aa, int mood) {
     {
         if (passon>=0) 
         {
-            if (run_interaction_script(thisroom.Objects[aa].EventHandlers.get(), passon, 4, (passon == 3)))
+            if (run_interaction_script(thisroom.Objects[aa].EventHandlers.get(), passon, 4))
                 return;
         }
         run_interaction_script(thisroom.Objects[aa].EventHandlers.get(), 4);  // any click on obj

--- a/Engine/ac/global_string.cpp
+++ b/Engine/ac/global_string.cpp
@@ -23,18 +23,19 @@
 extern size_t MAXSTRLEN;
 
 int StrGetCharAt (const char *strin, int posn) {
-    if ((posn < 0) || (posn >= (int)strlen(strin)))
+    if ((posn < 0) || (static_cast<size_t>(posn) >= strlen(strin)))
         return 0;
     return strin[posn];
 }
 
 void StrSetCharAt (char *strin, int posn, int nchar) {
-    if ((posn < 0) || (posn > (int)strlen(strin)) || (posn >= MAX_MAXSTRLEN))
+    size_t len = strlen(strin);
+    if ((posn < 0) || (static_cast<size_t>(posn) > len) || (posn >= MAX_MAXSTRLEN))
         quit("!StrSetCharAt: tried to write past end of string");
 
-    if (posn == (int)strlen(strin))
-        strin[posn+1] = 0;
-    strin[posn] = nchar;
+    strin[posn] = static_cast<char>(nchar);
+    if (static_cast<size_t>(posn) == len)
+        strin[posn + 1] = 0;
 }
 
 void _sc_strcat(char*s1, const char*s2) {

--- a/Engine/ac/global_string.cpp
+++ b/Engine/ac/global_string.cpp
@@ -43,7 +43,6 @@ void _sc_strcat(char*s1, const char*s2) {
     VALIDATE_STRING (s2);
     check_strlen(s1);
     int mosttocopy=(MAXSTRLEN-strlen(s1))-1;
-    //  int numbf=game.iface[4].numbuttons;
     my_strncpy(&s1[strlen(s1)], s2, mosttocopy);
 }
 
@@ -58,14 +57,6 @@ void _sc_strupper (char *desbuf) {
     check_strlen (desbuf);
     ags_strupr (desbuf);
 }
-
-/*int _sc_strcmp (char *s1, char *s2) {
-return strcmp (get_translation (s1), get_translation(s2));
-}
-
-int _sc_stricmp (char *s1, char *s2) {
-return ags_stricmp (get_translation (s1), get_translation(s2));
-}*/
 
 void _sc_strcpy(char*destt, const char *text) {
     VALIDATE_STRING(destt);

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -338,7 +338,7 @@ void process_interface_click(int ifce, int btn, int mbut) {
     }
 
     int btype = guis[ifce].GetControlType(btn);
-    int rtype=kGUIAction_None,rdata;
+    int rtype=kGUIAction_None,rdata=0;
     if (btype==kGUIButton) {
         GUIButton*gbuto=(GUIButton*)guis[ifce].GetControl(btn);
         rtype=gbuto->ClickAction[kMouseLeft];

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -153,6 +153,7 @@ RuntimeScriptValue Sc_GetHotspotAtScreen(const RuntimeScriptValue *params, int32
 
 RuntimeScriptValue Sc_Hotspot_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
+    (void)params; (void)param_count;
     ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaHotspot);
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
 }

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -149,6 +149,7 @@ RuntimeScriptValue Sc_GetRegionAtScreen(const RuntimeScriptValue *params, int32_
 
 RuntimeScriptValue Sc_Region_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
+    (void)params; (void)param_count;
     ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaRegion);
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -519,7 +519,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     play.bg_anim_delay = play.anim_background_speed;
 
     // Fixup the frame index, in case the new room does not have enough background frames
-    if (play.bg_frame < 0 || play.bg_frame >= thisroom.BgFrameCount)
+    if (play.bg_frame < 0 || static_cast<size_t>(play.bg_frame) >= thisroom.BgFrameCount)
         play.bg_frame = 0;
 
     // do the palette

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -74,7 +74,7 @@ static int line_failed = 0;
 static int lastcx, lastcy;
 
 // TODO: find a way to reimpl this with Bitmap
-static void line_callback(BITMAP *bmpp, int x, int y, int d)
+static void line_callback(BITMAP *bmpp, int x, int y, int /*d*/)
 {
 /*  if ((x>=320) | (y>=200) | (x<0) | (y<0)) line_failed=1;
   else */ if (getpixel(bmpp, x, y) < 1)
@@ -813,8 +813,6 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
     numstages++;
     nearestindx = -1;
 
-    int lastpbs = pathbackstage;
-
 stage_again:
     nearestpos = 0;
     aaa = 1;
@@ -847,7 +845,6 @@ stage_again:
 #ifdef DEBUG_PATHFINDER
      AGS::Common::Debug::Printf("Added: %d, %d pbs:%d",srcx,srcy,pathbackstage);
 #endif
-      lastpbs = pathbackstage;
       pathbackstage = nearestindx;
       goto stage_again;
     }

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -115,21 +115,20 @@ void get_lastcpos(int &lastcx_, int &lastcy_) {
 int find_nearest_walkable_area(Bitmap *tempw, int fromX, int fromY, int toX, int toY, int destX, int destY, int granularity)
 {
   assert(tempw != nullptr);
-
-  int ex, ey, nearest = 99999, thisis, nearx, neary;
   if (fromX < 0) fromX = 0;
   if (fromY < 0) fromY = 0;
   if (toX >= tempw->GetWidth()) toX = tempw->GetWidth() - 1;
   if (toY >= tempw->GetHeight()) toY = tempw->GetHeight() - 1;
 
-  for (ex = fromX; ex < toX; ex += granularity) 
+  int nearest = 99999, nearx = -1, neary = -1;
+  for (int ex = fromX; ex < toX; ex += granularity) 
   {
-    for (ey = fromY; ey < toY; ey += granularity) 
+    for (int ey = fromY; ey < toY; ey += granularity)
     {
-      if (tempw->GetScanLine(ey)[ex] != 232)
+      if (tempw->GetScanLine(ey)[ex] != 232) // CHECKME: what is 232?
         continue;
 
-      thisis = (int)::sqrt((double)((ex - destX) * (ex - destX) + (ey - destY) * (ey - destY)));
+      int thisis = (int)::sqrt((double)((ex - destX) * (ex - destX) + (ey - destY) * (ey - destY)));
       if (thisis < nearest)
       {
         nearest = thisis;

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -315,7 +315,7 @@ RuntimeScriptValue Sc_Speech_GetPortraitOverlay(const RuntimeScriptValue *params
 
 extern RuntimeScriptValue Sc_SetVoiceMode(const RuntimeScriptValue *params, int32_t param_count);
 
-void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion compat_api)
+void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
     ccAddExternalStaticFunction("Speech::get_AnimationStopTimeMargin", Sc_Speech_GetAnimationStopTimeMargin);
     ccAddExternalStaticFunction("Speech::set_AnimationStopTimeMargin", Sc_Speech_SetAnimationStopTimeMargin);

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -116,7 +116,7 @@ Bitmap *remove_alpha_channel(Bitmap *from)
     return to;
 }
 
-void pre_save_sprite(Common::Bitmap *image) {
+void pre_save_sprite(Common::Bitmap* /*image*/) {
     // not used, we don't save
 }
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -150,7 +150,6 @@ eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt, int &ags_mod, boo
 
     default: return eAGSKeyCodeNone;
     }
-    return eAGSKeyCodeNone;
 }
 
 // Converts ags key to SDL key scans (up to 3 values, because this is not a 1:1 match);
@@ -223,7 +222,6 @@ bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3])
 
     default: return false;
     }
-    return false;
 }
 
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -48,7 +48,7 @@ KeyInput ags_keycode_from_sdl(const SDL_Event &event, bool old_keyhandle)
         char ascii[sizeof(SDL_TextInputEvent::text)];
         StrUtil::ConvertUtf8ToAscii(event.text.text, "C", &ascii[0], sizeof(ascii));
         unsigned char textch = ascii[0];
-        if (textch >= 32 && textch <= 255)
+        if (textch >= 32)
             ki.Key = static_cast<eAGSKeyCode>(textch);
         strncpy(ki.Text, event.text.text, KeyInput::UTF8_ARR_SIZE);
         Utf8::GetChar(event.text.text, sizeof(SDL_TextInputEvent::text), &ki.UChar);

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -74,7 +74,7 @@ IAGSEditorDebugger *GetEditorDebugger(const char *instanceToken)
 
 #else   // AGS_PLATFORM_OS_WINDOWS
 
-IAGSEditorDebugger *GetEditorDebugger(const char *instanceToken)
+IAGSEditorDebugger *GetEditorDebugger(const char* /*instanceToken*/)
 {
     return nullptr;
 }
@@ -116,7 +116,7 @@ static MessageType SDL_to_MT[SDL_NUM_LOG_PRIORITIES] = {
     kDbgMsg_None, kDbgMsg_All, kDbgMsg_Debug, kDbgMsg_Info, kDbgMsg_Warn, kDbgMsg_Error, kDbgMsg_Alert
 };
 // Print SDL message through our own log
-void SDL_Log_Output(void *userdata, int category, SDL_LogPriority priority, const char *message) {
+void SDL_Log_Output(void* /*userdata*/, int category, SDL_LogPriority priority, const char *message) {
     char buf[SDL_MAX_LOG_MESSAGE];
     snprintf(buf, SDL_MAX_LOG_MESSAGE, "%s: %s: %s",
         SDL_category[category], SDL_priority[priority], message);
@@ -592,6 +592,8 @@ bool send_exception_to_editor(const char *qmsg)
     {
         platform->Delay(10);
     }
+#else
+    (void)qmsg;
 #endif
     return true;
 }

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -60,7 +60,7 @@ using namespace Common;
 using namespace Engine;
 
 // function is currently implemented in savegame_v321.cpp
-HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data);
+HSaveError restore_save_data_v321(Stream *in, const PreservedParams &pp, RestoredData &r_data);
 
 extern GameSetupStruct game;
 extern AGS::Engine::IGraphicsDriver *gfxDriver;
@@ -694,7 +694,7 @@ HSaveError RestoreGameState(Stream *in, SavegameVersion svg_version)
     if (svg_version >= kSvgVersion_Components)
         err = SavegameComponents::ReadAll(in, svg_version, pp, r_data);
     else
-        err = restore_game_data(in, svg_version, pp, r_data);
+        err = restore_save_data_v321(in, pp, r_data);
     if (!err)
         return err;
     return DoAfterRestore(pp, r_data);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -553,7 +553,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     if (displayed_room >= 0)
     {
         // Fixup the frame index, in case the restored room does not have enough background frames
-        if (play.bg_frame < 0 || play.bg_frame >= thisroom.BgFrameCount)
+        if (play.bg_frame < 0 || static_cast<size_t>(play.bg_frame) >= thisroom.BgFrameCount)
             play.bg_frame = 0;
 
         for (int i = 0; i < MAX_ROOM_BGFRAMES; ++i)
@@ -645,7 +645,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     }
     update_directional_sound_vol();
 
-    adjust_fonts_for_render_mode(game.options[OPT_ANTIALIASFONTS]);
+    adjust_fonts_for_render_mode(game.options[OPT_ANTIALIASFONTS] != 0);
 
     recreate_overlay_ddbs();
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -162,8 +162,9 @@ String GetSavegameErrorText(SavegameErrorType err)
         return "Saved with the engine running at a different colour depth.";
     case kSvgErr_GameObjectInitFailed:
         return "Game object initialization failed after save restoration.";
+    default:
+        return "Unknown error.";
     }
-    return "Unknown error.";
 }
 
 Bitmap *RestoreSaveImage(Stream *in)

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -306,7 +306,7 @@ void ReadViewportState(RestoredData &r_data, Stream *in)
     r_data.Viewports.push_back(view);
 }
 
-HSaveError ReadGameState(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadGameState(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     GameStateSvgVersion svg_ver = (GameStateSvgVersion)cmp_ver;
@@ -420,7 +420,7 @@ HSaveError WriteAudio(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadAudio(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadAudio(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     // Game content assertion
@@ -552,7 +552,7 @@ HSaveError WriteCharacters(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numcharacters, "Characters"))
@@ -582,7 +582,7 @@ HSaveError WriteDialogs(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDialogs(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDialogs(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numdialog, "Dialogs"))
@@ -641,7 +641,7 @@ HSaveError WriteGUI(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadGUI(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadGUI(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     const GuiSvgVersion svg_ver = (GuiSvgVersion)cmp_ver;
@@ -722,7 +722,7 @@ HSaveError WriteInventory(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadInventory(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadInventory(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numinvitems, "Inventory Items"))
@@ -747,7 +747,7 @@ HSaveError WriteMouseCursors(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadMouseCursors(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadMouseCursors(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numcursors, "Mouse Cursors"))
@@ -778,7 +778,7 @@ HSaveError WriteViews(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadViews(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadViews(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     if (!AssertGameContent(err, in->ReadInt32(), game.numviews, "Views"))
@@ -829,7 +829,7 @@ HSaveError WriteDynamicSprites(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDynamicSprites(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDynamicSprites(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     const int spr_count = in->ReadInt32();
@@ -858,7 +858,7 @@ HSaveError WriteOverlays(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     size_t over_count = in->ReadInt32();
     for (size_t i = 0; i < over_count; ++i)
@@ -890,7 +890,7 @@ HSaveError WriteDynamicSurfaces(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadDynamicSurfaces(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadDynamicSurfaces(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     if (!AssertCompatLimit(err, in->ReadInt32(), MAX_DYNAMIC_SURFACES, "Dynamic Surfaces"))
@@ -926,7 +926,7 @@ HSaveError WriteScriptModules(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadScriptModules(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadScriptModules(Stream *in, int32_t /*cmp_ver*/, const PreservedParams &pp, RestoredData &r_data)
 {
     HSaveError err;
     // read the global script data segment
@@ -977,7 +977,7 @@ HSaveError WriteRoomStates(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadRoomStates(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     HSaveError err;
     int roomstat_count = in->ReadInt32();
@@ -1048,7 +1048,7 @@ HSaveError WriteThisRoom(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadThisRoom(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
     HSaveError err;
     displayed_room = in->ReadInt32();
@@ -1106,7 +1106,7 @@ HSaveError WriteManagedPool(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadManagedPool(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadManagedPool(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     if (ccUnserializeAllObjects(in, &ccUnserializer))
     {
@@ -1125,7 +1125,7 @@ HSaveError WritePluginData(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadPluginData(Stream *in, int32_t cmp_ver, const PreservedParams &pp, RestoredData &r_data)
+HSaveError ReadPluginData(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     auto pluginFileHandle = AGSE_RESTOREGAME;
     pl_set_file_handle(pluginFileHandle, in);

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -41,8 +41,8 @@ struct PreservedParams
     bool SpeechVOX;
     bool MusicVOX;
     // Script global data sizes
-    int GlScDataSize;
-    std::vector<int> ScMdDataSize;
+    size_t GlScDataSize;
+    std::vector<size_t> ScMdDataSize;
 
     PreservedParams();
 };

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -63,7 +63,7 @@ extern Bitmap *raw_saved_screen;
 extern RoomStatus troom;
 
 
-static const int32_t MAGICNUMBER = 0xbeefcafe;
+static const uint32_t MAGICNUMBER = 0xbeefcafe;
 
 
 static HSaveError restore_game_head_dynamic_values(Stream *in, RestoredData &r_data)
@@ -94,7 +94,7 @@ static void restore_game_spriteset(Stream *in)
 static HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, RestoredData &r_data)
 {
     // read the global script data segment
-    int gdatasize = in->ReadInt32();
+    size_t gdatasize = (uint32_t)in->ReadInt32();
     if (pp.GlScDataSize != gdatasize)
     {
         return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching size of global script data.");
@@ -103,7 +103,7 @@ static HSaveError restore_game_scripts(Stream *in, const PreservedParams &pp, Re
     r_data.GlobalScript.Data.reset(new char[gdatasize]);
     in->Read(r_data.GlobalScript.Data.get(), gdatasize);
 
-    if (in->ReadInt32() != numScriptModules)
+    if ((uint32_t)in->ReadInt32() != numScriptModules)
     {
         return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of script modules.");
     }
@@ -272,7 +272,7 @@ static HSaveError restore_game_gui(Stream *in, int numGuisWas)
 
 static HSaveError restore_game_audiocliptypes(Stream *in)
 {
-    if (in->ReadInt32() != game.audioClipTypes.size())
+    if ((uint32_t)in->ReadInt32() != game.audioClipTypes.size())
     {
         return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clip Types.");
     }
@@ -414,7 +414,7 @@ static HSaveError restore_game_views(Stream *in)
 
 static HSaveError restore_game_audioclips_and_crossfade(Stream *in, RestoredData &r_data)
 {
-    if (in->ReadInt32() != game.audioClips.size())
+    if ((uint32_t)in->ReadInt32() != game.audioClips.size())
     {
         return new SavegameError(kSvgErr_GameContentAssertion, "Mismatching number of Audio Clips.");
     }
@@ -540,7 +540,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     if (!err)
         return err;
 
-    if (in->ReadInt32() != MAGICNUMBER+1)
+    if (static_cast<uint32_t>(in->ReadInt32()) != (MAGICNUMBER + 1))
     {
         return new SavegameError(kSvgErr_InconsistentFormat, "MAGICNUMBER not found before Audio Clips.");
     }
@@ -553,7 +553,7 @@ HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const Pres
     pl_set_file_handle(pluginFileHandle, in);
     pl_run_plugin_hooks(AGSE_RESTOREGAME, pluginFileHandle);
     pl_clear_file_handle();
-    if (in->ReadInt32() != (unsigned)MAGICNUMBER)
+    if (static_cast<uint32_t>(in->ReadInt32()) != MAGICNUMBER)
         return new SavegameError(kSvgErr_InconsistentPlugin);
 
     // save the new room music vol for later use

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -452,7 +452,7 @@ static HSaveError restore_game_audioclips_and_crossfade(Stream *in, RestoredData
     return HSaveError::None();
 }
 
-HSaveError restore_game_data(Stream *in, SavegameVersion svg_version, const PreservedParams &pp, RestoredData &r_data)
+HSaveError restore_save_data_v321(Stream *in, const PreservedParams &pp, RestoredData &r_data)
 {
     int vv;
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -186,7 +186,7 @@ bool OGLGraphicsDriver::SupportsGammaControl()
   return false;
 }
 
-void OGLGraphicsDriver::SetGamma(int newGamma)
+void OGLGraphicsDriver::SetGamma(int /*newGamma*/)
 {
 }
 
@@ -255,7 +255,6 @@ void OGLGraphicsDriver::InitGlParams(const DisplayMode &mode)
   glClear(GL_COLOR_BUFFER_BIT);
 
 
-  auto interval = mode.Vsync ? 1 : 0;
   bool vsyncEnabled = SDL_GL_SetSwapInterval(mode.Vsync ? 1 : 0) == 0;
   if (mode.Vsync && !vsyncEnabled)
     Debug::Printf(kDbgMsg_Warn, "WARNING: Vertical sync could not be enabled. Setting will be kept at driver default.");
@@ -826,13 +825,13 @@ bool OGLGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
   return !_dstRect.IsEmpty();
 }
 
-int OGLGraphicsDriver::GetDisplayDepthForNativeDepth(int native_color_depth) const
+int OGLGraphicsDriver::GetDisplayDepthForNativeDepth(int /*native_color_depth*/) const
 {
     // TODO: check for device caps to know which depth is supported?
     return 32;
 }
 
-IGfxModeList *OGLGraphicsDriver::GetSupportedModeList(int color_depth)
+IGfxModeList *OGLGraphicsDriver::GetSupportedModeList(int /*color_depth*/)
 {
     std::vector<DisplayMode> modes {};
     sys_get_desktop_modes(modes);
@@ -877,7 +876,7 @@ OGLGraphicsDriver::~OGLGraphicsDriver()
   OGLGraphicsDriver::UnInit();
 }
 
-void OGLGraphicsDriver::ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse)
+void OGLGraphicsDriver::ClearRectangle(int /*x1*/, int /*y1*/, int /*x2*/, int /*y2*/, RGB* /*colorToUse*/)
 {
   // NOTE: this function is practically useless at the moment, because OGL redraws whole game frame each time
 }
@@ -1751,7 +1750,7 @@ void OGLGraphicsDriver::FadeOut(int speed, int targetColourRed, int targetColour
   do_fade(true, speed, targetColourRed, targetColourGreen, targetColourBlue);
 }
 
-void OGLGraphicsDriver::FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue)
+void OGLGraphicsDriver::FadeIn(int speed, PALETTE /*p*/, int targetColourRed, int targetColourGreen, int targetColourBlue)
 {
   do_fade(false, speed, targetColourRed, targetColourGreen, targetColourBlue);
 }

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -217,7 +217,7 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, GlobalFlipType flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    void EnableVsyncBeforeRender(bool enabled) override { }
+    void EnableVsyncBeforeRender(bool /*enabled*/) override { }
     void Vsync() override;
     void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override;
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -178,21 +178,15 @@ struct ShaderProgram
 {
     GLuint Program = 0;
     GLuint Arg[4] {};
-    // GLuint SamplerVar;      // texture ID
-    // GLuint ColorVar;        // primary operation variable
-    // GLuint AuxVar;          // auxiliary variable
 
-    GLuint MVPMatrix = -1;
+    GLuint MVPMatrix = 0;
+    GLuint TextureId = 0;
+    GLuint Alpha = 0;
 
-    GLuint TextureId = -1;
-
-    GLuint Alpha = -1;
-
-    GLuint TintHSV = -1;
-    GLuint TintAmount = -1;
-    GLuint TintLuminance = -1;
-
-    GLuint LightingAmount = -1;
+    GLuint TintHSV = 0;
+    GLuint TintAmount = 0;
+    GLuint TintLuminance = 0;
+    GLuint LightingAmount = 0;
 };
 
 class OGLGfxFilter;

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -77,12 +77,12 @@ bool SDLRendererGraphicsDriver::IsModeSupported(const DisplayMode &mode)
   return true;
 }
 
-int SDLRendererGraphicsDriver::GetDisplayDepthForNativeDepth(int native_color_depth) const
+int SDLRendererGraphicsDriver::GetDisplayDepthForNativeDepth(int /*native_color_depth*/) const
 {
     return 32;
 }
 
-IGfxModeList *SDLRendererGraphicsDriver::GetSupportedModeList(int color_depth)
+IGfxModeList *SDLRendererGraphicsDriver::GetSupportedModeList(int /*color_depth*/)
 {
     std::vector<DisplayMode> modes;
     sys_get_desktop_modes(modes);
@@ -105,7 +105,7 @@ void SDLRendererGraphicsDriver::SetGraphicsFilter(PSDLRenderFilter filter)
   // SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");  // make the scaled rendering look smoother.
 }
 
-void SDLRendererGraphicsDriver::SetTintMethod(TintMethod method) 
+void SDLRendererGraphicsDriver::SetTintMethod(TintMethod /*method*/) 
 {
   // TODO: support new D3D-style tint method
 }
@@ -241,7 +241,7 @@ bool SDLRendererGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
   return !_dstRect.IsEmpty();
 }
 
-void SDLRendererGraphicsDriver::ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse)
+void SDLRendererGraphicsDriver::ClearRectangle(int /*x1*/, int /*y1*/, int /*x2*/, int /*y2*/, RGB* /*colorToUse*/)
 {
   // TODO: but maybe is not necessary, as we use SDL_Renderer with accelerated gfx here?
   // See SDL_RenderDrawRect
@@ -373,7 +373,7 @@ void SDLRendererGraphicsDriver::DrawSprite(int x, int y, IDriverDependantBitmap*
     _spriteBatches[_actSpriteBatch].List.push_back(ALDrawListEntry((ALSoftwareBitmap*)bitmap, x, y));
 }
 
-void SDLRendererGraphicsDriver::SetScreenFade(int red, int green, int blue)
+void SDLRendererGraphicsDriver::SetScreenFade(int /*red*/, int /*green*/, int /*blue*/)
 {
     // TODO: was not necessary atm
     // TODO: checkme later
@@ -615,7 +615,8 @@ bool SDLRendererGraphicsDriver::GetCopyOfScreenIntoBitmap(Bitmap *destination, b
 
 	Author: Matthew Leverton
 **/
-void SDLRendererGraphicsDriver::highcolor_fade_in(Bitmap *vs, void(*draw_callback)(), int offx, int offy, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue)
+void SDLRendererGraphicsDriver::highcolor_fade_in(Bitmap *vs, void(*draw_callback)(),
+    int /*offx*/, int /*offy*/, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue)
 {
    Bitmap *bmp_orig = vs;
    const int col_depth = bmp_orig->GetColorDepth();
@@ -650,7 +651,8 @@ void SDLRendererGraphicsDriver::highcolor_fade_in(Bitmap *vs, void(*draw_callbac
    Present();
 }
 
-void SDLRendererGraphicsDriver::highcolor_fade_out(Bitmap *vs, void(*draw_callback)(), int offx, int offy, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue)
+void SDLRendererGraphicsDriver::highcolor_fade_out(Bitmap *vs, void(*draw_callback)(),
+    int /*offx*/, int /*offy*/, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue)
 {
     Bitmap *bmp_orig = vs;
     const int col_depth = vs->GetColorDepth();

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -49,13 +49,13 @@ public:
     int  GetTransparency() const override { return _transparency; }
     void SetTransparency(int transparency) override { _transparency = transparency; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
-    void SetStretch(int width, int height, bool useResampler = true) override 
+    void SetStretch(int width, int height, bool /*useResampler*/) override 
     {
         _stretchToWidth = width;
         _stretchToHeight = height;
     }
-    void SetLightLevel(int lightLevel) override  { }
-    void SetTint(int red, int green, int blue, int tintSaturation) override { }
+    void SetLightLevel(int /*lightLevel*/) override  { }
+    void SetTint(int /*red*/, int /*green*/, int /*blue*/, int /*tintSaturation*/) override { }
 
     Bitmap *_bmp = nullptr;
     bool _flipped = false;
@@ -179,17 +179,17 @@ public:
     void BoxOutEffect(bool blackingOut, int speed, int delay) override;
     bool SupportsGammaControl() override ;
     void SetGamma(int newGamma) override;
-    void UseSmoothScaling(bool enabled) override { }
-    void EnableVsyncBeforeRender(bool enabled) override { }
+    void UseSmoothScaling(bool /*enabled*/) override { }
+    void EnableVsyncBeforeRender(bool /*enabled*/) override { }
     void Vsync() override;
-    void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override { }
+    void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
     bool RequiresFullRedrawEachFrame() override { return false; }
     bool HasAcceleratedTransform() override { return false; }
     bool UsesMemoryBackBuffer() override { return true; }
     Bitmap *GetMemoryBackBuffer() override;
     void SetMemoryBackBuffer(Bitmap *backBuffer) override;
     Bitmap *GetStageBackBuffer(bool mark_dirty) override;
-    bool GetStageMatrixes(RenderMatrixes &rm) override { return false; /* not supported */ }
+    bool GetStageMatrixes(RenderMatrixes &/*rm*/) override { return false; /* not supported */ }
     ~SDLRendererGraphicsDriver() override;
 
     typedef std::shared_ptr<SDLRendererGfxFilter> PSDLRenderFilter;

--- a/Engine/gfx/blender.cpp
+++ b/Engine/gfx/blender.cpp
@@ -88,7 +88,7 @@ unsigned long _myblender_color32_light(unsigned long x, unsigned long y, unsigne
 }
 
 // Take hue and saturation of blend colour, luminance of image
-unsigned long _myblender_color15(unsigned long x, unsigned long y, unsigned long n)
+unsigned long _myblender_color15(unsigned long x, unsigned long y, unsigned long /*n*/)
 {
     float xh, xs, xv;
     float yh, ys, yv;
@@ -103,7 +103,7 @@ unsigned long _myblender_color15(unsigned long x, unsigned long y, unsigned long
 }
 
 // Take hue and saturation of blend colour, luminance of image
-unsigned long _myblender_color16(unsigned long x, unsigned long y, unsigned long n)
+unsigned long _myblender_color16(unsigned long x, unsigned long y, unsigned long /*n*/)
 {
     float xh, xs, xv;
     float yh, ys, yv;
@@ -118,7 +118,7 @@ unsigned long _myblender_color16(unsigned long x, unsigned long y, unsigned long
 }
 
 // Take hue and saturation of blend colour, luminance of image
-unsigned long _myblender_color32(unsigned long x, unsigned long y, unsigned long n)
+unsigned long _myblender_color32(unsigned long x, unsigned long y, unsigned long /*n*/)
 {
     float xh, xs, xv;
     float yh, ys, yv;
@@ -163,7 +163,7 @@ void set_my_trans_blender(int r, int g, int b, int a)
 
 // plain copy source to destination
 // assign new alpha value as a summ of alphas.
-unsigned long _additive_alpha_copysrc_blender(unsigned long x, unsigned long y, unsigned long n)
+unsigned long _additive_alpha_copysrc_blender(unsigned long x, unsigned long y, unsigned long /*n*/)
 {
     unsigned long newAlpha = ((x & 0xff000000) >> 24) + ((y & 0xff000000) >> 24);
 
@@ -275,7 +275,7 @@ void set_argb2argb_blender(int alpha)
 }
 
 // sets the alpha channel to opaque. used when drawing a non-alpha sprite onto an alpha-sprite
-unsigned long _opaque_alpha_blender(unsigned long x, unsigned long y, unsigned long n)
+unsigned long _opaque_alpha_blender(unsigned long x, unsigned long /*y*/, unsigned long /*n*/)
 {
     return x | 0xff000000;
 }

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -161,7 +161,7 @@ Bitmap *VideoMemoryGraphicsDriver::GetMemoryBackBuffer()
     return nullptr;
 }
 
-void VideoMemoryGraphicsDriver::SetMemoryBackBuffer(Bitmap *backBuffer)
+void VideoMemoryGraphicsDriver::SetMemoryBackBuffer(Bitmap* /*backBuffer*/)
 { // do nothing, video-memory drivers don't use main back buffer, only stage bitmaps they pass to plugins
 }
 

--- a/Engine/gfx/gfxfilter_aad3d.cpp
+++ b/Engine/gfx/gfxfilter_aad3d.cpp
@@ -13,12 +13,12 @@
 //=============================================================================
 
 #include "core/platform.h"
-#include "stdio.h"
-#include "gfx/gfxfilter_aad3d.h"
 
 #if AGS_HAS_DIRECT3D
+
+#include "stdio.h"
+#include "gfx/gfxfilter_aad3d.h"
 #include <d3d9.h>
-#endif
 
 namespace AGS
 {
@@ -36,11 +36,9 @@ const GfxFilterInfo &AAD3DGfxFilter::GetInfo() const
 
 void AAD3DGfxFilter::SetSamplerStateForStandardSprite(void *direct3ddevice9)
 {
-#if AGS_PLATFORM_OS_WINDOWS
     IDirect3DDevice9* d3d9 = ((IDirect3DDevice9*)direct3ddevice9);
     d3d9->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
     d3d9->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
-#endif
 }
 
 bool AAD3DGfxFilter::NeedToColourEdgeLines()
@@ -51,3 +49,5 @@ bool AAD3DGfxFilter::NeedToColourEdgeLines()
 } // namespace D3D
 } // namespace Engine
 } // namespace AGS
+
+#endif // AGS_HAS_DIRECT3D

--- a/Engine/gfx/gfxfilter_aaogl.cpp
+++ b/Engine/gfx/gfxfilter_aaogl.cpp
@@ -48,4 +48,4 @@ const GfxFilterInfo &AAOGLGfxFilter::GetInfo() const
 } // namespace Engine
 } // namespace AGS
 
-#endif // only on Windows, Android and iOS
+#endif // AGS_HAS_OPENGL

--- a/Engine/gfx/gfxfilter_d3d.cpp
+++ b/Engine/gfx/gfxfilter_d3d.cpp
@@ -13,10 +13,11 @@
 //=============================================================================
 
 #include "core/platform.h"
-#include "gfx/gfxfilter_d3d.h"
-#if AGS_PLATFORM_OS_WINDOWS
+
+#if AGS_HAS_DIRECT3D
+
 #include <d3d9.h>
-#endif
+#include "gfx/gfxfilter_d3d.h"
 
 namespace AGS
 {
@@ -34,11 +35,9 @@ const GfxFilterInfo &D3DGfxFilter::GetInfo() const
 
 void D3DGfxFilter::SetSamplerStateForStandardSprite(void *direct3ddevice9)
 {
-#if AGS_PLATFORM_OS_WINDOWS
     IDirect3DDevice9* d3d9 = ((IDirect3DDevice9*)direct3ddevice9);
     d3d9->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
     d3d9->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
-#endif
 }
 
 bool D3DGfxFilter::NeedToColourEdgeLines()
@@ -49,3 +48,5 @@ bool D3DGfxFilter::NeedToColourEdgeLines()
 } // namespace D3D
 } // namespace Engine
 } // namespace AGS
+
+#endif // AGS_HAS_DIRECT3D

--- a/Engine/gfx/gfxfilter_scaling.cpp
+++ b/Engine/gfx/gfxfilter_scaling.cpp
@@ -19,7 +19,7 @@ namespace AGS
 namespace Engine
 {
 
-bool ScalingGfxFilter::Initialize(const int color_depth, String &err_str)
+bool ScalingGfxFilter::Initialize(const int /*color_depth*/, String &/*err_str*/)
 {
     // succeed by default
     return true;

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -15,9 +15,6 @@
 // Implementation from acgui.h and acgui.cpp specific to Engine runtime
 //
 //=============================================================================
-
-// Headers, as they are in acgui.cpp
-#pragma unmanaged
 #include "ac/game_version.h"
 #include "ac/system.h"
 #include "font/fonts.h"
@@ -40,10 +37,6 @@ using namespace AGS::Common;
 extern int eip_guiobj;
 extern void replace_macro_tokens(const char*, String&);
 
-// For engine these are defined in acfonts.cpp
-extern void ensure_text_valid_for_font(char *, int);
-//
-
 extern SpriteCache spriteset; // in ac_runningame
 extern GameSetupStruct game;
 
@@ -65,15 +58,6 @@ bool GUIMain::HasAlphaChannel() const
         // "classic" gui rendering mode historically had non-alpha transparent backgrounds
         // (3.2.0 broke the compatibility, now we restore it)
         loaded_game_file_version >= kGameVersion_320 && game.options[OPT_NEWGUIALPHA] != kGuiAlphaRender_Legacy;
-}
-
-//=============================================================================
-// Engine-specific implementation split out of acgui.h
-//=============================================================================
-
-void check_font(int *fontnum)
-{
-    // do nothing
 }
 
 //=============================================================================

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -44,7 +44,6 @@ IDriverDependantBitmap *dialogDDB;
 
 #undef MAXSAVEGAMES
 #define MAXSAVEGAMES 20
-DisplayProperties dispp;
 char *lpTemp, *lpTemp2;
 char bufTemp[260], buffer2[260];
 int numsaves = 0, toomanygames;

--- a/Engine/gui/guidialogdefines.h
+++ b/Engine/gui/guidialogdefines.h
@@ -84,6 +84,7 @@ namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 
 //  =========  STRUCTS  ========
+#ifdef OBSOLETE
 struct DisplayProperties
 {
     int width;
@@ -91,6 +92,7 @@ struct DisplayProperties
     int colors;
     int textheight;
 };
+#endif // OBSOLETE
 
 struct CSCIMessage
 {

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -96,7 +96,7 @@ int MyPushButton::pressedon(int mx, int my)
     return wasstat;
 }
 
-int MyPushButton::processmessage(int mcode, int wParam, long lParam)
+int MyPushButton::processmessage(int /*mcode*/, int /*wParam*/, long /*lParam*/)
 {
     return -1;                  // doesn't support messages
 }

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -427,7 +427,7 @@ void override_config_ext(ConfigTree &cfg)
 void apply_config(const ConfigTree &cfg)
 {
     {
-        usetup.audio_enabled = INIreadint(cfg, "sound", "enabled", usetup.audio_enabled);
+        usetup.audio_enabled = INIreadint(cfg, "sound", "enabled", usetup.audio_enabled) != 0;
         usetup.audio_driver = INIreadstring(cfg, "sound", "driver");
 
         // Legacy graphics settings has to be translated into new options;
@@ -470,7 +470,7 @@ void apply_config(const ConfigTree &cfg)
         // This option is backwards (usevox is 0 if no_speech_pack)
         usetup.no_speech_pack = INIreadint(cfg, "sound", "usespeech", 1) == 0;
 
-        usetup.clear_cache_on_room_change = INIreadint(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change);
+        usetup.clear_cache_on_room_change = INIreadint(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change) != 0;
         usetup.user_data_dir = INIreadstring(cfg, "misc", "user_data_dir");
         usetup.shared_data_dir = INIreadstring(cfg, "misc", "shared_data_dir");
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -207,6 +207,8 @@ bool engine_run_setup(const ConfigTree &cfg, int &app_res)
             String args = String::FromFormat("\"%s\"", appPath.GetCStr());
             _spawnl(_P_OVERLAY, appPath.GetCStr(), args.GetCStr(), NULL);
     }
+#else
+    (void)cfg;
 #endif
     return true;
 }

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -176,26 +176,6 @@ void engine_pre_gfxmode_driver_cleanup()
     gfxDriver->SetMemoryBackBuffer(nullptr);
 }
 
-// Setup virtual screen
-void engine_post_gfxmode_screen_setup(const DisplayMode &dm, bool recreate_bitmaps)
-{
-    if (recreate_bitmaps)
-    {
-        // TODO: find out if 
-        // - we need to support this case at all;
-        // - if yes then which bitmaps need to be recreated (probably only video bitmaps and textures?)
-    }
-}
-
-void engine_pre_gfxmode_screen_cleanup()
-{
-}
-
-// Release virtual screen
-void engine_pre_gfxsystem_screen_destroy()
-{
-}
-
 // Setup color conversion parameters
 void engine_setup_color_conversions(int coldepth)
 {
@@ -250,7 +230,7 @@ void engine_pre_gfxmode_draw_cleanup()
 }
 
 // Setup mouse control mode and graphic area
-void engine_post_gfxmode_mouse_setup(const DisplayMode &dm, const Size &init_desktop)
+void engine_post_gfxmode_mouse_setup(const Size &init_desktop)
 {
     // Assign mouse control parameters.
     //
@@ -305,8 +285,7 @@ void engine_post_gfxmode_setup(const Size &init_desktop)
     {
         engine_post_gfxmode_draw_setup(dm);
     }
-    engine_post_gfxmode_screen_setup(dm, has_driver_changed);   
-    engine_post_gfxmode_mouse_setup(dm, init_desktop);
+    engine_post_gfxmode_mouse_setup(init_desktop);
 
     video_on_gfxmode_changed();
     invalidate_screen();
@@ -316,14 +295,12 @@ void engine_pre_gfxmode_release()
 {
     engine_pre_gfxmode_mouse_cleanup();
     engine_pre_gfxmode_driver_cleanup();
-    engine_pre_gfxmode_screen_cleanup();
 }
 
 void engine_pre_gfxsystem_shutdown()
 {
     engine_pre_gfxmode_release();
     engine_pre_gfxmode_draw_cleanup();
-    engine_pre_gfxsystem_screen_destroy();
 }
 
 void on_coordinates_scaling_changed()

--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -134,7 +134,7 @@ static inline HError MakeScriptLoadError(const char *name)
 // These are optional, so no error is raised if some of these are not found.
 // For those that do exist, reads them and replaces any scripts of same kind
 // in the already loaded game data.
-HError LoadGameScripts(LoadedGameEntities &ents, GameDataVersion data_ver)
+HError LoadGameScripts(LoadedGameEntities &ents)
 {
     // Global script
     std::unique_ptr<Stream> in(AssetMgr->OpenAsset("GlobalScript.o"));
@@ -209,7 +209,7 @@ HError load_game_file()
     }
     if (!err)
         return err;
-    err = LoadGameScripts(ents, src.DataVersion);
+    err = LoadGameScripts(ents);
     if (!err)
         return err;
     err = (HError)InitGameState(ents, src.DataVersion);

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -370,6 +370,7 @@ bool create_gfx_driver_and_init_mode_any(const String &gfx_driver_id,
     return result;
 }
 
+#ifdef USE_SIMPLE_GFX_INIT
 static bool simple_create_gfx_driver_and_init_mode(const String &gfx_driver_id,
                                             const GraphicResolution &game_res,
                                             const DisplayModeSetup &setup,
@@ -391,6 +392,7 @@ static bool simple_create_gfx_driver_and_init_mode(const String &gfx_driver_id,
 
     return true;
 }
+#endif // USE_SIMPLE_GFX_INIT
 
 
 void display_gfx_mode_error(const Size &game_size, const WindowSetup &ws, const int color_depth,

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -449,13 +449,13 @@ bool graphics_mode_init_any(const GraphicResolution &game_res, const DisplayMode
 
     // Try to create renderer and init gfx mode, choosing one factory at a time
     bool result = false;
-    for (StringV::const_iterator it = ids.begin(); it != ids.end(); ++it)
+    for (const auto &id : ids)
     {
         result =
 #ifdef USE_SIMPLE_GFX_INIT
-            simple_create_gfx_driver_and_init_mode(*it, game_res, setup, color_depth);
+            simple_create_gfx_driver_and_init_mode(id, game_res, setup, color_depth);
 #else
-            create_gfx_driver_and_init_mode_any(*it, game_res, setup, color_depth);
+            create_gfx_driver_and_init_mode_any(id, game_res, setup, color_depth);
 #endif
 
         if (result)

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -212,8 +212,8 @@ Size get_game_frame_from_screen_size(const Size &game_size, const Size screen_si
                 frame_size = ProportionalStretch(screen_size, game_size);
             return frame_size;
         }
+    default: return Size();
     }
-    return Size();
 }
 
 static Size precalc_screen_size(const Size &game_size, const WindowSetup &ws, const FrameScaleDef frame)

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -380,7 +380,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         {
             String logarg = arg + 6;
             size_t split_at = logarg.FindChar('=');
-            if (split_at >= 0)
+            if (split_at != String::NoIndex)
                 cfg["log"][logarg.Left(split_at)] = logarg.Mid(split_at + 1);
             else
                 cfg["log"][logarg] = "";

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -215,8 +215,8 @@ static int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool int
     return channelToUse;
 }
 
-bool is_audiotype_allowed_to_play(AudioFileType type)
-{
+bool is_audiotype_allowed_to_play(AudioFileType /*type*/)
+{ // TODO: this is a remnant of an old audio logic, think this function over
     return usetup.audio_enabled;
 }
 
@@ -995,9 +995,9 @@ void update_music_volume()
     }
 }
 
-// Ensures crossfader is stable after loading (or failing to load)
-// new music
-void post_new_music_check (int newchannel)
+// Ensures crossfader is stable after loading (or failing to load) new music
+// NOTE: part of the legacy audio logic
+void post_new_music_check()
 {
     if ((crossFading > 0) && (AudioChans::GetChannel(crossFading) == nullptr)) {
         crossFading = 0;
@@ -1127,7 +1127,7 @@ static void play_new_music(int mnum, SOUNDCLIP *music)
         AudioChans::DeleteClipOnChannel(useChannel);
     }
 
-    post_new_music_check(useChannel);
+    post_new_music_check();
     update_music_volume();
 }
 

--- a/Engine/media/audio/audio.h
+++ b/Engine/media/audio/audio.h
@@ -99,7 +99,7 @@ void        apply_volume_drop_modifier(bool applyModifier);
 void        update_audio_system_on_game_loop ();
 void        stopmusic();
 void        update_music_volume();
-void        post_new_music_check (int newchannel);
+void        post_new_music_check();
 // Sets up the crossfading for playing the new music track,
 // and returns the channel number to use; the channel is guaranteed to be free
 int         prepare_for_new_music ();

--- a/Engine/media/audio/openalsource.cpp
+++ b/Engine/media/audio/openalsource.cpp
@@ -24,7 +24,7 @@ namespace Engine
 {
 
 // Finds an acceptable OpenAl format representation for the given SDL audio format
-static ALenum OpenAlFormatFromSDLFormat(SDL_AudioFormat fmt, int chans, int freq)
+static ALenum OpenAlFormatFromSDLFormat(SDL_AudioFormat fmt, int chans)
 {
     if (chans == 1) {
         switch (fmt) {
@@ -94,7 +94,7 @@ OpenAlSource::OpenAlSource(SDL_AudioFormat format, int channels, int freq)
     alGenSources(1, &_source);
     dump_al_errors();
     _inputFormat = format;
-    _alFormat = OpenAlFormatFromSDLFormat(format, channels, freq);
+    _alFormat = OpenAlFormatFromSDLFormat(format, channels);
     // FIXME: if failed to find matching format, plan resampler!
     _channels = channels;
     _freq = freq;

--- a/Engine/media/audio/sdldecoder.cpp
+++ b/Engine/media/audio/sdldecoder.cpp
@@ -21,12 +21,12 @@ namespace Engine
 //-----------------------------------------------------------------------------
 // SDLResampler
 //-----------------------------------------------------------------------------
-bool SDLResampler::Setup(SDL_AudioFormat src_fmt, uint8_t src_chans, int src_rate,
-    SDL_AudioFormat dst_fmt, uint8_t dst_chans, int dst_rate)
+bool SDLResampler::Setup(SDL_AudioFormat src_fmt, int src_chans, int src_rate,
+    SDL_AudioFormat dst_fmt, int dst_chans, int dst_rate)
 {
     SDL_zero(_cvt);
-    return SDL_BuildAudioCVT(&_cvt, src_fmt, src_chans, src_rate,
-        dst_fmt, dst_chans, dst_rate) >= 0;
+    return SDL_BuildAudioCVT(&_cvt, src_fmt, static_cast<uint8_t>(src_chans), src_rate,
+        dst_fmt, static_cast<uint8_t>(dst_chans), dst_rate) >= 0;
 }
 
 const void *SDLResampler::Convert(const void *data, size_t sz, size_t &out_sz)

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -76,8 +76,8 @@ struct SDLResampler
 {
 public:
     SDLResampler() = default;
-    SDLResampler(SDL_AudioFormat src_fmt, uint8_t src_chans, int src_rate,
-        SDL_AudioFormat dst_fmt, uint8_t dst_chans, int dst_rate)
+    SDLResampler(SDL_AudioFormat src_fmt, int src_chans, int src_rate,
+        SDL_AudioFormat dst_fmt, int dst_chans, int dst_rate)
     {
         Setup(src_fmt, src_chans, src_rate, dst_fmt, dst_chans, dst_rate);
     }
@@ -85,8 +85,8 @@ public:
     bool HasConversion() const { return _cvt.needed > 0; }
     // Setup a new conversion; returns whether setup has succeeded;
     // note that if no conversion necessary it still considered a success.
-    bool Setup(SDL_AudioFormat src_fmt, uint8_t src_chans, int src_rate,
-        SDL_AudioFormat dst_fmt, uint8_t dst_chans, int dst_rate);
+    bool Setup(SDL_AudioFormat src_fmt, int src_chans, int src_rate,
+        SDL_AudioFormat dst_fmt, int dst_chans, int dst_rate);
     // Converts given sound data, on success returns a read-only pointer to the
     // memory containing resulting data, and fills out_sz with output length value;
     // note that if no conversion is required it does not perform any operation

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -59,7 +59,7 @@ static SOUNDCLIP *my_load_clip(const AssetPath &apath, const char *extension_hin
     if (!s)
         return nullptr;
 
-    const size_t asset_size = s->GetLength();
+    const size_t asset_size = static_cast<size_t>(s->GetLength());
     std::vector<char> data(asset_size);
     s->Read(data.data(), asset_size);
     delete s;

--- a/Engine/media/audio/soundclip.cpp
+++ b/Engine/media/audio/soundclip.cpp
@@ -115,6 +115,8 @@ bool SOUNDCLIP::update()
     case PlaybackState::PlayStatePlaying:
         state = audio_core_slot_play(slot_);
         break;
+    default: /* do nothing */
+        break;
     }
     return is_ready();
 }

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -260,7 +260,7 @@ void FlicPlayer::Restore()
     set_palette_range(fli_palette, 0, 255, 0);
 }
 
-bool FlicPlayer::OpenImpl(const AGS::Common::String &name, int &flags)
+bool FlicPlayer::OpenImpl(const AGS::Common::String &name, int& /*flags*/)
 {
     Stream *in = AssetMgr->OpenAsset(name);
     if (!in)

--- a/Engine/media/video/video.h
+++ b/Engine/media/video/video.h
@@ -88,7 +88,7 @@ public:
 
 protected:
     // Opens the video, implementation-specific; allows to modify flags
-    virtual bool OpenImpl(const String &name, int &flags) { return false; };
+    virtual bool OpenImpl(const String& /*name*/, int& /*flags*/) { return false; };
     // Closes the video, implementation-specific
     virtual void CloseImpl() {};
     // Retrieves next video frame, implementation-specific

--- a/Engine/platform/base/agsplatformdriver.cpp
+++ b/Engine/platform/base/agsplatformdriver.cpp
@@ -48,6 +48,7 @@ void AGSPlatformDriver::PauseApplication() { }
 void AGSPlatformDriver::ResumeApplication() { }
 void AGSPlatformDriver::RegisterGameWithGameExplorer() { }
 void AGSPlatformDriver::UnRegisterGameWithGameExplorer() { }
+void AGSPlatformDriver::ValidateWindowSize(int & /*x*/, int & /*y*/, bool /*borderless*/) const {}
 
 const char* AGSPlatformDriver::GetBackendFailUserHint()
 {
@@ -100,7 +101,7 @@ void AGSPlatformDriver::YieldCPU() {
     //std::this_thread::yield();
 }
 
-SetupReturnValue AGSPlatformDriver::RunSetup(const ConfigTree &cfg_in, ConfigTree &cfg_out)
+SetupReturnValue AGSPlatformDriver::RunSetup(const ConfigTree &/*cfg_in*/, ConfigTree &/*cfg_out*/)
 {
     return kSetup_Cancel;
 }

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -115,7 +115,7 @@ public:
     virtual void RegisterGameWithGameExplorer();
     virtual void UnRegisterGameWithGameExplorer();
     // Adjust window size to ensure it is in the supported limits
-    virtual void ValidateWindowSize(int &x, int &y, bool borderless) const {}
+    virtual void ValidateWindowSize(int &x, int &y, bool borderless) const;
     // Either set window icon using system API directly, or create a SDL_Surface
     // for the SDL backend to set an icon instead.
     virtual SDL_Surface *CreateWindowIcon() { return nullptr; }

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -40,7 +40,7 @@ void sys_main_shutdown() {
     SDL_Quit();
 }
 
-void sys_set_background_mode(bool on) {
+void sys_set_background_mode(bool /*on*/) {
     // TODO: consider if we want any implementation here, and what...
 }
 

--- a/Engine/platform/util/libc.c
+++ b/Engine/platform/util/libc.c
@@ -28,8 +28,7 @@
 
 size_t mbstowcs(wchar_t *wcstr, const char *mbstr, size_t max)
 {
-  int count = 0;
-  
+  size_t count = 0;
   while ((count < max) && (*mbstr != 0))
   {
     *wcstr++ = *mbstr++;
@@ -41,8 +40,7 @@ size_t mbstowcs(wchar_t *wcstr, const char *mbstr, size_t max)
 
 size_t wcstombs(char* mbstr, const wchar_t *wcstr, size_t max)
 {
-  int count = 0;
-
+  size_t count = 0;
   while ((count < max) && (*wcstr != 0))
   {
     *mbstr++ = *wcstr++;

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -105,7 +105,7 @@ struct AGSWin32 : AGSPlatformDriver {
 
 private:
   void add_game_to_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers);
-  void remove_game_from_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers);
+  void remove_game_from_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid);
   void add_tasks_for_game(const char *guidAsText, const char *gameEXE, const char *workingFolder, bool allUsers);
   void get_tasks_directory(char *directoryNameBuffer, const char *guidAsText, bool allUsers);
   void update_game_explorer(bool add);
@@ -305,7 +305,7 @@ void AGSWin32::add_game_to_game_explorer(IGameExplorer* pFwGameExplorer, GUID *g
   SysFreeString(bstrGameDirectory);
 }
 
-void AGSWin32::remove_game_from_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid, const char *guidAsText, bool allUsers)
+void AGSWin32::remove_game_from_game_explorer(IGameExplorer* pFwGameExplorer, GUID *guid)
 {
   HRESULT hr = pFwGameExplorer->RemoveGame(*guid);
   if (FAILED(hr))
@@ -341,7 +341,7 @@ void AGSWin32::update_game_explorer(bool add)
     }
     else
     {
-      remove_game_from_game_explorer(pFwGameExplorer, &guid, game.guid, true);
+      remove_game_from_game_explorer(pFwGameExplorer, &guid);
     }
   }
 
@@ -773,9 +773,7 @@ void AGSWin32::ValidateWindowSize(int &x, int &y, bool borderless) const
     // This is the maximal size that OS can reliably resize the window to (including any frame)
     const Size max_win(GetSystemMetrics(SM_CXMAXTRACK), GetSystemMetrics(SM_CYMAXTRACK));
     // This is the size of window's non-client area (frame, caption, etc)
-    HWND allegro_wnd = (HWND)sys_win_get_window();
     LONG winstyle = borderless ? WS_POPUP : WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX;
-    LONG winstyle_al = GetWindowLong(allegro_wnd, GWL_STYLE);
     SetRectEmpty(&nc_rc);
     AdjustWindowRect(&nc_rc, winstyle, FALSE);
     // Limit the window's full size to the system's window size limit,
@@ -824,7 +822,7 @@ LPDIRECTDRAW2 IAGSEngine::GetDirectDraw2 () {
   quit("!IAGSEngine::GetDirectDraw2() is deprecated and not supported anymore.");
   return nullptr;
 }
-LPDIRECTDRAWSURFACE2 IAGSEngine::GetBitmapSurface (BITMAP *bmp) 
+LPDIRECTDRAWSURFACE2 IAGSEngine::GetBitmapSurface (BITMAP* /*bmp*/) 
 {
   quit("!IAGSEngine::GetBitmapSurface() is deprecated and not supported anymore.");
   return nullptr;

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -2002,4 +2002,4 @@ bool D3DGraphicsFactory::Init()
 } // namespace Engine
 } // namespace AGS
 
-#endif // AGS_PLATFORM_OS_WINDOWS
+#endif // AGS_HAS_DIRECT3D

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -303,7 +303,6 @@ int D3DGraphicsDriver::FirstTimeInit()
     HGLOBAL hGlobal = LoadResource(exeHandle, hRes);
     if (hGlobal)
     {
-      DWORD resourceSize = SizeofResource(exeHandle, hRes);
       DWORD *dataPtr = (DWORD*)LockResource(hGlobal);
       hr = direct3ddevice->CreatePixelShader(dataPtr, &pixelShader);
       if (hr != D3D_OK)
@@ -890,7 +889,7 @@ bool D3DGraphicsDriver::SetRenderFrame(const Rect &dst_rect)
   return !_dstRect.IsEmpty();
 }
 
-int D3DGraphicsDriver::GetDisplayDepthForNativeDepth(int native_color_depth) const
+int D3DGraphicsDriver::GetDisplayDepthForNativeDepth(int /*native_color_depth*/) const
 {
     // TODO: check for device caps to know which depth is supported?
     return 32;
@@ -1796,7 +1795,7 @@ void D3DGraphicsDriver::FadeOut(int speed, int targetColourRed, int targetColour
   do_fade(true, speed, targetColourRed, targetColourGreen, targetColourBlue);
 }
 
-void D3DGraphicsDriver::FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) 
+void D3DGraphicsDriver::FadeIn(int speed, PALETTE /*p*/, int targetColourRed, int targetColourGreen, int targetColourBlue) 
 {
   do_fade(false, speed, targetColourRed, targetColourGreen, targetColourBlue);
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -475,7 +475,8 @@ bool D3DGraphicsDriver::IsModeSupported(const DisplayMode &mode)
       return false;
     }
 
-    if ((d3d_mode.Width == mode.Width) && (d3d_mode.Height == mode.Height))
+    if ((d3d_mode.Width == static_cast<uint32_t>(mode.Width)) &&
+        (d3d_mode.Height == static_cast<uint32_t>(mode.Height)))
     {
       return true;
     }

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -201,9 +201,9 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, GlobalFlipType flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    void EnableVsyncBeforeRender(bool enabled) override { }
+    void EnableVsyncBeforeRender(bool /*enabled*/) override { }
     void Vsync() override;
-    void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override { _renderSprAtScreenRes = enabled; };
+    void RenderSpritesAtScreenResolution(bool enabled, int /*supersampling*/) override { _renderSprAtScreenRes = enabled; };
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void BoxOutEffect(bool blackingOut, int speed, int delay) override;

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -385,7 +385,7 @@ void MakeFullLongPath(const char *path, WCHAR *out_buf, int buf_len)
 //
 //=============================================================================
 
-int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
+int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM /*lParam*/, LPARAM lpData)
 {
     if (uMsg == BFFM_INITIALIZED)
     {
@@ -923,7 +923,7 @@ void WinSetupDialog::ShowAdvancedOptions()
     }
 }
 
-INT_PTR CALLBACK WinSetupDialog::DialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+INT_PTR CALLBACK WinSetupDialog::DialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (uMsg)
     {

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -1238,11 +1238,11 @@ void WinSetupDialog::SelectNearestGfxMode(const WindowSetup &ws)
     // First check two special modes
     if (ws.IsDefaultSize())
     {
-        SetCurSelToItemData(_hGfxModeList, kGfxMode_Desktop);
+        SetCurSelToItemData(_hGfxModeList, static_cast<DWORD_PTR>(kGfxMode_Desktop));
     }
     else if (ws.Size == _winCfg.GameResolution || ws.Scale == 1)
     {
-        SetCurSelToItemData(_hGfxModeList, kGfxMode_GameRes);
+        SetCurSelToItemData(_hGfxModeList, static_cast<DWORD_PTR>(kGfxMode_GameRes));
     }
     else
     {
@@ -1256,7 +1256,7 @@ void WinSetupDialog::SelectNearestGfxMode(const WindowSetup &ws)
             SetCurSelToItemData(_hGfxModeList, index, NULL, kGfxMode_Desktop);
         }
         else
-            SetCurSelToItemData(_hGfxModeList, kGfxMode_Desktop);
+            SetCurSelToItemData(_hGfxModeList, static_cast<DWORD_PTR>(kGfxMode_Desktop));
     }
     OnGfxModeUpdate();
 }

--- a/Engine/plugin/global_plugin.cpp
+++ b/Engine/plugin/global_plugin.cpp
@@ -35,22 +35,22 @@ void PluginSimulateMouseClick(int pluginButtonID) {
 
 #include "script/script_runtime.h"
 
-RuntimeScriptValue Sc_PluginStub_Void(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PluginStub_Void(const RuntimeScriptValue * /*params*/, int32_t /*param_count*/)
 {
     return RuntimeScriptValue((int32_t)0);
 }
 
-RuntimeScriptValue Sc_PluginStub_Int0(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PluginStub_Int0(const RuntimeScriptValue * /*params*/, int32_t /*param_count*/)
 {
     return RuntimeScriptValue().SetInt32(0);
 }
 
-RuntimeScriptValue Sc_PluginStub_IntNeg1(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PluginStub_IntNeg1(const RuntimeScriptValue * /*params*/, int32_t /*param_count*/)
 {
     return RuntimeScriptValue().SetInt32(-1);
 }
 
-RuntimeScriptValue Sc_PluginStub_NullStr(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PluginStub_NullStr(const RuntimeScriptValue * /*params*/, int32_t /*param_count*/)
 {
 	return RuntimeScriptValue().SetStringLiteral(NULL);
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1637,7 +1637,7 @@ bool ccInstance::ResolveScriptImports(const ccScript *scri)
     }
 
     resolved_imports = new uint32_t[numimports];
-    int errors = 0, last_err_idx;
+    size_t errors = 0, last_err_idx = 0;
     for (int import_idx = 0; import_idx < scri->numimports; ++import_idx)
     {
         if (scri->imports[import_idx] == nullptr)
@@ -1779,7 +1779,7 @@ static void cc_error_fixups(const ccScript *scri, size_t pc, const char *fmt, ..
     String displbuf = String::FromFormatV(fmt, ap);
     va_end(ap);
     const char *scname = scri->numSections > 0 ? scri->sectionNames[0] : "?";
-    if (pc == -1)
+    if (pc == SIZE_MAX)
     {
         cc_error("in script %s: %s", scname, displbuf.GetCStr());
     }

--- a/Engine/script/runtimescriptvalue.cpp
+++ b/Engine/script/runtimescriptvalue.cpp
@@ -28,7 +28,7 @@ uint8_t RuntimeScriptValue::ReadByte() const
         }
         else
         {
-            return RValue->IValue; // get RValue as int
+            return static_cast<uint8_t>(RValue->IValue);
         }
     }
     else if (this->Type == kScValStaticObject || this->Type == kScValStaticArray)
@@ -52,7 +52,7 @@ int16_t RuntimeScriptValue::ReadInt16() const
         }
         else
         {
-            return RValue->IValue; // get RValue as int
+            return static_cast<uint16_t>(RValue->IValue);
         }
     }
     else if (this->Type == kScValGlobalVar)
@@ -63,7 +63,7 @@ int16_t RuntimeScriptValue::ReadInt16() const
         }
         else
         {
-            return RValue->IValue; // get RValue as int
+            return static_cast<uint16_t>(RValue->IValue);
         }
     }
     else if (this->Type == kScValStaticObject || this->Type == kScValStaticArray)

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -192,7 +192,7 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
 // (eg. a room change occured)
-int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny, int isInv) {
+int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny) {
 
     if ((nint->ScriptFuncNames[evnt] == nullptr) || (nint->ScriptFuncNames[evnt][0u] == 0)) {
         // no response defined for this event
@@ -742,13 +742,11 @@ int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, in
           PlayFlic(IPARAM1, IPARAM2);
           break;
       case 9:  // Run Dialog
-          { int room_was = play.room_changes;
           RunDialog(IPARAM1);
           // if they changed room within the dialog script,
           // the interaction command list is no longer valid
           if (room_was != play.room_changes)
               return -1;
-          }
           break;
       case 10: // Enable Dialog Option
           SetDialogOption (IPARAM1, IPARAM2, 1);

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -40,7 +40,7 @@ using AGS::Common::InteractionVariable;
 int     run_dialog_request (int parmtr);
 void    run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun);
 int     run_interaction_event (Interaction *nint, int evnt, int chkAny = -1, int isInv = 0);
-int     run_interaction_script(InteractionScripts *nint, int evnt, int chkAny = -1, int isInv = 0);
+int     run_interaction_script(InteractionScripts *nint, int evnt, int chkAny = -1);
 int     create_global_script();
 void    cancel_all_scripts();
 

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -48,12 +48,16 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return ScriptSprintf(buffer, buf_length, format, nullptr, 0, &arg_ptr);
 }
 
-// Helper macros for script functions
+// Helper macros for script functions;
+// asserting for internal mistakes; supressing "unused param" warnings
 #define ASSERT_SELF(METHOD) \
+    (void)params; (void)param_count; \
     assert((self != NULL) && "Object pointer is null in call to API function")
 #define ASSERT_PARAM_COUNT(FUNCTION, X) \
+    (void)params; (void)param_count; \
     assert((params != NULL && param_count >= X) && "Not enough parameters in call to API function")
 #define ASSERT_VARIABLE_VALUE(VARIABLE) \
+    (void)params; (void)param_count; \
     assert((params != NULL && param_count >= 1) && "Not enough parameters to set API property")
 #define ASSERT_OBJ_PARAM_COUNT(METHOD, X) \
     ASSERT_SELF(METHOD); \
@@ -63,6 +67,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 // Get/set variables
 
 #define API_VARGET_INT(VARIABLE) \
+    (void)params; (void)param_count; \
     return RuntimeScriptValue().SetInt32(VARIABLE)
 
 #define API_VARSET_PINT(VARIABLE) \
@@ -112,6 +117,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
 //
 
 #define API_SCALL_VOID(FUNCTION) \
+    (void)params; (void)param_count; \
     FUNCTION(); \
     return RuntimeScriptValue((int32_t)0)
 
@@ -201,6 +207,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return RuntimeScriptValue((int32_t)0)
 
 #define API_SCALL_INT(FUNCTION) \
+    (void)params; (void)param_count; \
     return RuntimeScriptValue().SetInt32(FUNCTION())
 
 #define API_SCALL_INT_PINT(FUNCTION) \
@@ -252,6 +259,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return RuntimeScriptValue().SetInt32(FUNCTION(params[0].IValue, (P1CLASS*)params[1].Ptr))
 
 #define API_SCALL_FLOAT(FUNCTION) \
+    (void)params; (void)param_count; \
     return RuntimeScriptValue().SetFloat(FUNCTION())
 
 #define API_SCALL_FLOAT_PINT(FUNCTION) \
@@ -267,6 +275,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return RuntimeScriptValue().SetFloat(FUNCTION(params[0].FValue, params[1].FValue))
 
 #define API_SCALL_BOOL(FUNCTION) \
+    (void)params; (void)param_count; \
     return RuntimeScriptValue().SetInt32AsBool(FUNCTION())
 
 #define API_SCALL_BOOL_POBJ(FUNCTION, P1CLASS) \
@@ -286,6 +295,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return RuntimeScriptValue().SetInt32AsBool(FUNCTION((P1CLASS*)params[0].Ptr, (P2CLASS*)params[1].Ptr))
 
 #define API_SCALL_OBJ(RET_CLASS, RET_MGR, FUNCTION) \
+    (void)params; (void)param_count; \
     return RuntimeScriptValue().SetDynamicObject((void*)(RET_CLASS*)FUNCTION(), &RET_MGR)
 
 #define API_SCALL_OBJ_PINT(RET_CLASS, RET_MGR, FUNCTION) \
@@ -309,6 +319,7 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return RuntimeScriptValue().SetDynamicObject((void*)(RET_CLASS*)FUNCTION((P1CLASS*)params[0].Ptr), &RET_MGR)
 
 #define API_SCALL_OBJAUTO(RET_CLASS, FUNCTION) \
+    (void)params; (void)param_count; \
     RET_CLASS* ret_obj = FUNCTION(); \
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
 

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -334,6 +334,7 @@
     <ClCompile Include="..\..\Common\script\cc_script.cpp" />
     <ClCompile Include="..\..\Common\util\alignedstream.cpp" />
     <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
+    <ClCompile Include="..\..\Common\util\cmdlineopts.cpp" />
     <ClCompile Include="..\..\Common\util\compress.cpp" />
     <ClCompile Include="..\..\Common\util\datastream.cpp" />
     <ClCompile Include="..\..\Common\util\data_ext.cpp" />
@@ -481,6 +482,7 @@
     <ClInclude Include="..\..\Common\script\script_common.h" />
     <ClInclude Include="..\..\Common\util\alignedstream.h" />
     <ClInclude Include="..\..\Common\util\bbop.h" />
+    <ClInclude Include="..\..\Common\util\cmdlineopts.h" />
     <ClInclude Include="..\..\Common\util\compress.h" />
     <ClInclude Include="..\..\Common\util\datastream.h" />
     <ClInclude Include="..\..\Common\util\data_ext.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -524,6 +524,9 @@
     <ClCompile Include="..\..\Common\ac\spritefile.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\cmdlineopts.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\audiocliptype.h">
@@ -830,6 +833,9 @@
       <Filter>Header Files\ac</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\util\utf8.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\cmdlineopts.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Tools/crmpak/main.cpp
+++ b/Tools/crmpak/main.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
     }
 
     // Finalize the output room
-    WriteRoomEnding(room_out.get(), dataver);
+    WriteRoomEnding(room_out.get());
     room_out.reset();
 
     // If we saved the new room into the memory, now it's the time to overwrite

--- a/libsrc/allegro/include/allegro/gfx.h
+++ b/libsrc/allegro/include/allegro/gfx.h
@@ -59,12 +59,15 @@ struct RGB;
 #define blender_mode_alpha          14
 
 
+typedef AL_METHOD(uintptr_t, _BMP_BANK_SWITCHER, (struct BITMAP *bmp, int lyne));
+typedef AL_METHOD(void, _BMP_UNBANK_SWITCHER, (struct BITMAP *bmp));
+
 
 typedef struct GFX_VTABLE        /* functions for drawing onto bitmaps */
 {
    int color_depth;
    int mask_color;
-   void *unwrite_bank;  /* C function on some machines, asm on i386 */
+   _BMP_UNBANK_SWITCHER unwrite_bank;  /* C function on some machines, asm on i386 */
    AL_METHOD(void, set_clip, (struct BITMAP *bmp));
    AL_METHOD(void, acquire, (struct BITMAP *bmp));
    AL_METHOD(void, release, (struct BITMAP *bmp));
@@ -175,8 +178,8 @@ typedef struct BITMAP            /* a bitmap structure */
    int clip;                     /* flag if clipping is turned on */
    int cl, cr, ct, cb;           /* clip left, right, top and bottom values */
    GFX_VTABLE *vtable;           /* drawing functions */
-   void *write_bank;             /* C func on some machines, asm on i386 */
-   void *read_bank;              /* C func on some machines, asm on i386 */
+   _BMP_BANK_SWITCHER write_bank;/* C func on some machines, asm on i386 */
+   _BMP_BANK_SWITCHER read_bank; /* C func on some machines, asm on i386 */
    void *dat;                    /* the memory we allocated for the bitmap */
    unsigned long id;             /* for identifying sub-bitmaps */
    void *extra;                  /* points to a structure with more info */

--- a/libsrc/allegro/include/allegro/inline/gfx.inl
+++ b/libsrc/allegro/include/allegro/inline/gfx.inl
@@ -125,7 +125,7 @@ AL_INLINE(int, is_same_bitmap, (BITMAP *bmp1, BITMAP *bmp2),
 
 AL_INLINE(int, is_linear_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return TRUE; // only support linear memory bitmaps
 })
@@ -133,7 +133,7 @@ AL_INLINE(int, is_linear_bitmap, (BITMAP *bmp),
 
 AL_INLINE(int, is_planar_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return FALSE; // only support linear memory bitmaps
 })
@@ -141,7 +141,7 @@ AL_INLINE(int, is_planar_bitmap, (BITMAP *bmp),
 
 AL_INLINE(int, is_memory_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return TRUE; // only support linear memory bitmaps
 })
@@ -149,7 +149,7 @@ AL_INLINE(int, is_memory_bitmap, (BITMAP *bmp),
 
 AL_INLINE(int, is_screen_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return FALSE; // only support linear memory bitmaps
 })
@@ -157,7 +157,7 @@ AL_INLINE(int, is_screen_bitmap, (BITMAP *bmp),
 
 AL_INLINE(int, is_video_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return FALSE; // only support linear memory bitmaps
 })
@@ -165,7 +165,7 @@ AL_INLINE(int, is_video_bitmap, (BITMAP *bmp),
 
 AL_INLINE(int, is_system_bitmap, (BITMAP *bmp),
 {
-   ASSERT(bmp);
+   (void)bmp; // unused
 
    return FALSE; // only support linear memory bitmaps
 })

--- a/libsrc/allegro/include/allegro/inline/gfx.inl
+++ b/libsrc/allegro/include/allegro/inline/gfx.inl
@@ -51,28 +51,22 @@ AL_FUNC(void, bmp_unwrite_line, (BITMAP *bmp));
 
 #else
 
-typedef AL_METHOD(uintptr_t, _BMP_BANK_SWITCHER, (BITMAP *bmp, int lyne));
-typedef AL_METHOD(void, _BMP_UNBANK_SWITCHER, (BITMAP *bmp));
-
 
 AL_INLINE(uintptr_t, bmp_write_line, (BITMAP *bmp, int lyne),
 {
-   _BMP_BANK_SWITCHER switcher = (_BMP_BANK_SWITCHER)bmp->write_bank;
-   return switcher(bmp, lyne);
+   return bmp->write_bank(bmp, lyne);
 })
 
 
 AL_INLINE(uintptr_t, bmp_read_line, (BITMAP *bmp, int lyne),
 {
-   _BMP_BANK_SWITCHER switcher = (_BMP_BANK_SWITCHER)bmp->read_bank;
-   return switcher(bmp, lyne);
+   return bmp->read_bank(bmp, lyne);
 })
 
 
 AL_INLINE(void, bmp_unwrite_line, (BITMAP *bmp),
 {
-   _BMP_UNBANK_SWITCHER switcher = (_BMP_UNBANK_SWITCHER)bmp->vtable->unwrite_bank;
-   switcher(bmp);
+   bmp->vtable->unwrite_bank(bmp);
 })
 
 #endif      /* defined ALLEGRO_BCC32 */


### PR DESCRIPTION
Resolves #46 .

In the past couple of months i've been working on resolving compilation warnings. Some of these ended up real bugs and oversights, so this work was definitely not in vain. For the real mistakes and bigger refactors I've been making commits directly into master. This PR addresses too numerous but mostly trivial warnings; i made it to be sure that it builds everywhere, as there are several platform-specific ifdefs in the code which I might have missed.

If necessary i might further split commits into smaller ones, and add more fixes if something interesting is found in CI logs.

For warnings lookup I used:
* MSVS 2015 C++ compiler with /W4 option; I found /Wall to be *way* too verbose with this compiler, reporting obscure warning types which i was not interested in (and even reported lots of warnings for standard headers).
* gcc 5.4.0 with -Wall -Wextra (run using our plain makefile on a Ubuntu vm).

I focused on warnings strictly in the engine code, but decided to fix few annoying ones in the allegro headers, as they are included in lots of places. But did not touch:
* library sources (allegro, alfont, freetype, and so on);
* plugins

Two most common warning types were "unused argument/variable" and type cast issues. The scripting api was perhaps the primary source of "unused argument" because every script function is linked to vm using same uniform function prototype.

I did not aim for 100% removal of warnings; for instance left some typecast and comparison ones for the latter, to look into them more carefully. Some warnings should probably be left as-is for the time being, as they don't cause trouble but indicate a need to rework the code.

Did not count for exact numbers, but judging by gcc output this pr makes the number of warnings go from many hungreds to maybe couple of dozens (counting only engine code, in Common and Engine dirs).
