### PR TITLE
SDL_sound: upgrade to commit icculus/SDL_sound/12983b8acc 

### DIFF
--- a/CMake/FetchSDL_Sound.cmake
+++ b/CMake/FetchSDL_Sound.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     sdlsound_content
-    URL https://github.com/icculus/SDL_sound/archive/ebcf0fe725448f9dbaa7884114e0b96b9c041570.tar.gz
-    URL_HASH MD5=2b8120331f16a5e2ff52fc4d52d70276
+    URL https://github.com/icculus/SDL_sound/archive/12983b8acc8f89a4f0b4c320bdcc601a78824822.tar.gz
+    URL_HASH MD5=f33248b8d63d5e2e79af59ad02cfb248
 )
 
 FetchContent_GetProperties(sdlsound_content)
@@ -10,6 +10,10 @@ if(NOT sdlsound_content)
   set(SDLSOUND_BUILD_SHARED off CACHE BOOL "no shared")
   set(SDLSOUND_BUILD_TEST off CACHE BOOL "no tests")
   set(SDLSOUND_BUILD_STATIC on CACHE BOOL "static")
+
+  # see why we need to manually enable here: https://github.com/icculus/SDL_sound/issues/19#issuecomment-1079263491
+  set(SDLSOUND_DECODER_MIDI on CACHE BOOL "")
+
   message("Including SDL2_sound ...")
   message("SDL2_DIR: ${SDL2_DIR}")
   message("sdl2_content_SOURCE_DIR: ${sdl2_content_SOURCE_DIR}")

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -52,9 +52,9 @@ and SDL2.dll to run.
 ### SDL_Sound
 
 Official page for SDL_Sound library is https://www.icculus.org/SDL_sound/.
-Unfortunately, at the time of writing SDL_Sound did not have an official release for a quite a while, and there are no up-to-date prebuilt binaries on their website. This information will be updated would the situation change.
+Any latest release from the 2.0.X tags should be good.
 
-For now, the only way to get a compatible version is to use their GitHub repository. For the reference, our build server is using revision ebcf0fe725: https://github.com/icculus/SDL_sound/archive/ebcf0fe725448f9dbaa7884114e0b96b9c041570.tar.gz
+For now, people haven't yet packaged the newer releases, so the only way to get a compatible version is to use their GitHub repository. For the reference, our build server is using revision 12983b8acc: https://github.com/icculus/SDL_sound/archive/12983b8acc8f89a4f0b4c320bdcc601a78824822.tar.gz
 
 After you downloaded the source this way or another, use CMake to build MSVS solution from their provided CMakeList.txt, then build a static library using wanted configuration.
 

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -106,7 +106,7 @@ RUN curl -fLsS "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSI
   rm -r /tmp/cmake-$CMAKE_VERSION
 
 # Build and install SDL_sound
-ARG SDL2_SOUND_VERSION=ebcf0fe725448f9dbaa7884114e0b96b9c041570
+ARG SDL2_SOUND_VERSION=12983b8acc8f89a4f0b4c320bdcc601a78824822
 RUN cd /tmp && \
   curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz && \
   tar -xvzf SDL_sound.tar.gz && \
@@ -114,6 +114,6 @@ RUN cd /tmp && \
   cd /tmp/SDL_sound  && \
   mkdir /tmp/SDL_sound/build && \
   cd /tmp/SDL_sound/build && \
-  cmake -DSDL2_DIR=/usr/local/lib/cmake/SDL2 ..  && make -j$(getconf _NPROCESSORS_ONLN) && make install && \
+  cmake -DSDL2_DIR=/usr/local/lib/cmake/SDL2  -DSDLSOUND_DECODER_MIDI=1 ..  && make -j$(getconf _NPROCESSORS_ONLN) && make install && \
   rm /usr/local/lib/libSDL2_sound.*so* && \
   rm -r /tmp/SDL_sound

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -60,13 +60,13 @@ RUN mkdir Lib\SDL2 && \
   echo endif ^(^)  >> "Lib\SDL2\sdl2-config.cmake" && \
   echo string^(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES^) >> "Lib\SDL2\sdl2-config.cmake" 
  
-ARG SDL_SOUND_VERSION=ebcf0fe725448f9dbaa7884114e0b96b9c041570
+ARG SDL_SOUND_VERSION=12983b8acc8f89a4f0b4c320bdcc601a78824822
 RUN mkdir Lib\SDL_sound && \
   echo "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 ^&^& pushd Lib\SDL_sound\build ^&^& msbuild SDL_sound.sln /p:PlatformToolset=v140 /p:Configuration=Release /p:Platform=Win32 /maxcpucount /nologo ^&^& popd > sdlsoundvcbuild.bat && \
-  mkdir Lib\SDL_sound\build  && \	
+  mkdir Lib\SDL_sound\build  && \
   curl -fLSs "https://github.com/icculus/SDL_sound/archive/%SDL_SOUND_VERSION%.tar.gz" | tar -f - -xvzC Lib\SDL_sound --strip-components 1 && \
   set SDL2_DIR=%cd%\Lib\SDL2 && \
-  cmake -DCMAKE_SYSTEM_VERSION=8.1 -S Lib\SDL_sound -B Lib\SDL_sound\build -G "Visual Studio 14 2015" -T"v140" -A"Win32" -DCMAKE_PREFIX_PATH=Lib\SDL2 && \
+  cmake -DCMAKE_SYSTEM_VERSION=8.1 -S Lib\SDL_sound -B Lib\SDL_sound\build -G "Visual Studio 14 2015" -T"v140" -A"Win32" -DCMAKE_PREFIX_PATH=Lib\SDL2  -DSDLSOUND_DECODER_MIDI=1 && \
   sdlsoundvcbuild.bat && \
   copy Lib\SDL_sound\build\Release\SDL2_sound-static.lib Lib\SDL_sound\build\Release\SDL_sound.lib 
 

--- a/debian/README.md
+++ b/debian/README.md
@@ -28,10 +28,10 @@ Other Linux systems use their respective package managers.
 
 SDL_Sound library installation
 ----------------------------------
-At the time of writing SDL_Sound 2.* did not have a proper release and almost no linux distro provides it.
+At the time of writing SDL_Sound 2.* has just been released, but almost no linux distro provides it.
 Until that is resolved, we recommend to download particular revision archive using following url:
 
-    https://github.com/icculus/SDL_sound/archive/ebcf0fe725448f9dbaa7884114e0b96b9c041570.tar.gz
+    https://github.com/icculus/SDL_sound/archive/12983b8acc8f89a4f0b4c320bdcc601a78824822.tar.gz
 
 then build and install using CMake (see instructions in the SDL_Sound's docs).
 


### PR DESCRIPTION
fix #1587

the SDL_sound fixes include:

- 24-bit wav PCM support
- some mp3 sounds were missing a bit of sound at their ends (see https://www.adventuregamestudio.co.uk/forums/index.php?topic=55681.msg636639498#msg636639498)

**Full commit comparison: https://github.com/icculus/SDL_sound/compare/ebcf0fe725448f9dbaa7884114e0b96b9c041570...12983b8acc8f89a4f0b4c320bdcc601a78824822   <<**
