### PR TITLE
Use more common code for config reading and writing among platforms

### DIFF
--- a/Common/util/ini_util.cpp
+++ b/Common/util/ini_util.cpp
@@ -84,6 +84,13 @@ String CfgReadString(const ConfigTree &cfg, const String &sectn, const String &i
     return str;
 }
 
+void CfgReadString(char *cbuf, size_t buf_sz,
+    const ConfigTree &cfg, const String &sectn, const String &item, const String &def)
+{
+    String str = CfgReadString(cfg, sectn, item, def);
+    snprintf(cbuf, buf_sz, "%s", str.GetCStr());
+}
+
 //-----------------------------------------------------------------------------
 // ConfigWriter
 //-----------------------------------------------------------------------------

--- a/Common/util/ini_util.cpp
+++ b/Common/util/ini_util.cpp
@@ -44,27 +44,43 @@ bool CfgReadItem(const ConfigTree &cfg, const String &sectn, const String &item,
     return false;
 }
 
-int CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int def_value)
+int CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int def)
 {
     String str;
     if (!CfgReadItem(cfg, sectn, item, str))
-        return def_value;
-    return StrUtil::StringToInt(str, def_value);
+        return def;
+    return StrUtil::StringToInt(str, def);
 }
 
-float CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value)
+int CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int min, int max, int def)
 {
-    String str;
-    if (!CfgReadItem(cfg, sectn, item, str))
-        return def_value;
-    return StrUtil::StringToFloat(str, def_value);
+    int val = CfgReadInt(cfg, sectn, item, def);
+    if ((val < min) || (val > max))
+        return def;
+    return val;
 }
 
-String CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value)
+float CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def)
 {
     String str;
     if (!CfgReadItem(cfg, sectn, item, str))
-        return def_value;
+        return def;
+    return StrUtil::StringToFloat(str, def);
+}
+
+float CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float min, float max, float def)
+{
+    float val = CfgReadFloat(cfg, sectn, item, def);
+    if ((val < min) || (val > max))
+        return def;
+    return val;
+}
+
+String CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def)
+{
+    String str;
+    if (!CfgReadItem(cfg, sectn, item, str))
+        return def;
     return str;
 }
 

--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -33,12 +33,18 @@ typedef std::map<String, StringOrderMap> ConfigTree;
 //
 // Helper functions for parsing values in a ConfigTree
 bool    CfgReadItem(const ConfigTree &cfg, const String &sectn, const String &item, String &value);
-int     CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int def_value = 0);
-float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value = 0.f);
-String  CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value = "");
+int     CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int def = 0);
+int     CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int min, int max, int def = 0);
+inline bool CfgReadBoolInt(const ConfigTree &cfg, const String &sectn, const String &item, bool def = false)
+            { return CfgReadInt(cfg, sectn, item, 0, 1, def) != 0; }
+float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def = 0.f);
+float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float min, float max, float def = 0.f);
+String  CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def = "");
 //
 // Helper functions for writing values into a ConfigTree
 void    CfgWriteInt(ConfigTree &cfg, const String &sectn, const String &item, int value);
+inline void CfgWriteBoolInt(ConfigTree &cfg, const String &sectn, const String &item, bool value)
+            { CfgWriteInt(cfg, sectn, item, static_cast<int>(value)); }
 void    CfgWriteFloat(ConfigTree &cfg, const String &sectn, const String &item, float value);
 void    CfgWriteFloat(ConfigTree &cfg, const String &sectn, const String &item, float value, unsigned precision);
 void    CfgWriteString(ConfigTree &cfg, const String &sectn, const String &item, const String &value);

--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -12,8 +12,8 @@
 //
 //=============================================================================
 //
-// Functions for exchanging configuration data between key-value tree and
-// INI file.
+// Functions for working with the config key-value tree and exchanging data
+// between key-value tree and INI file.
 //
 //=============================================================================
 #ifndef __AGS_CN_UTIL__INIUTIL_H
@@ -27,14 +27,26 @@ namespace AGS
 namespace Common
 {
 
+typedef std::map<String, String>         StringOrderMap;
+typedef std::map<String, StringOrderMap> ConfigTree;
+
+//
+// Helper functions for parsing values in a ConfigTree
+bool    CfgReadItem(const ConfigTree &cfg, const String &sectn, const String &item, String &value);
+int     CfgReadInt(const ConfigTree &cfg, const String &sectn, const String &item, int def_value = 0);
+float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value = 0.f);
+String  CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value = "");
+//
+// Helper functions for writing values into a ConfigTree
+void    CfgWriteInt(ConfigTree &cfg, const String &sectn, const String &item, int value);
+void    CfgWriteFloat(ConfigTree &cfg, const String &sectn, const String &item, float value);
+void    CfgWriteFloat(ConfigTree &cfg, const String &sectn, const String &item, float value, unsigned precision);
+void    CfgWriteString(ConfigTree &cfg, const String &sectn, const String &item, const String &value);
+
+
 class IniFile;
 
-typedef std::map<String, String>         StringOrderMap;
-typedef StringOrderMap::const_iterator   StrStrOIter;
-
-typedef std::map<String, StringOrderMap> ConfigTree;
-typedef ConfigTree::const_iterator       ConfigNode;
-
+// Utility functions that exchange data between ConfigTree and INI file.
 namespace IniUtil
 {
     // Copies the contents of an IniFile object to a key-value tree.

--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -40,6 +40,9 @@ inline bool CfgReadBoolInt(const ConfigTree &cfg, const String &sectn, const Str
 float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float def = 0.f);
 float   CfgReadFloat(const ConfigTree &cfg, const String &sectn, const String &item, float min, float max, float def = 0.f);
 String  CfgReadString(const ConfigTree &cfg, const String &sectn, const String &item, const String &def = "");
+// Specialized variant for reading into char buffer, for code compatibility
+void    CfgReadString(char *cbuf, size_t buf_sz,
+    const ConfigTree &cfg, const String &sectn, const String &item, const String &def = "");
 //
 // Helper functions for writing values into a ConfigTree
 void    CfgWriteInt(ConfigTree &cfg, const String &sectn, const String &item, int value);

--- a/Common/util/string_utils.cpp
+++ b/Common/util/string_utils.cpp
@@ -57,6 +57,15 @@ StrUtil::ConversionError StrUtil::StringToInt(const String &s, int &val, int def
     return StrUtil::kNoError;
 }
 
+float StrUtil::StringToFloat(const String &s, float def_val)
+{
+    if (!s.GetCStr())
+        return def_val;
+    char *stop_ptr;
+    int val = strtof(s.GetCStr(), &stop_ptr);
+    return (stop_ptr == s.GetCStr() + s.GetLength()) ? val : def_val;
+}
+
 String StrUtil::Unescape(const String &s)
 {
     size_t at = s.FindChar('\\');

--- a/Common/util/string_utils.h
+++ b/Common/util/string_utils.h
@@ -46,6 +46,9 @@ namespace StrUtil
     // of range; the 'val' variable will be set with resulting integer, or
     // def_val on failure
     ConversionError StringToInt(const String &s, int &val, int def_val);
+    // Tries to convert whole string into float value;
+    // returns def_val on failure
+    float           StringToFloat(const String &s, float def_val = 0.f);
 
     // A simple unescape string implementation, unescapes '\\x' into '\x'.
     String          Unescape(const String &s);

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -479,6 +479,9 @@ target_sources(engine
     platform/windows/win_ex_handling.h
     platform/windows/minidump.cpp
     platform/windows/winapi_exclusive.h
+
+    platform/base/mobile_base.cpp
+    platform/base/mobile_base.h
 )
 
 if(ANDROID)

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -191,7 +191,7 @@ int LoadSaveSlotScreenshot(int slnum, int width, int height) {
     return gotSlot;
 }
 
-void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count)
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count)
 {
     if (max_count == 0)
         return; // duh
@@ -204,7 +204,7 @@ void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count)
     {
         int saveGameSlot = Path::GetFileExtension(ff.Current()).ToInt();
         // only list games .000 to .XXX (to allow higher slots for other perposes)
-        if (saveGameSlot < 0 || saveGameSlot > TOP_LISTEDSAVESLOT)
+        if (saveGameSlot < 0 || saveGameSlot > top_index)
             continue;
         String description;
         GetSaveSlotDescription(saveGameSlot, description);
@@ -212,6 +212,16 @@ void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count)
         if (saves.size() >= max_count)
             break;
     }
+}
+
+int GetLastSaveSlot()
+{
+    std::vector<SaveListItem> saves;
+    FillSaveList(saves, RESTART_POINT_SAVE_GAME_NUMBER - 1);
+    if (saves.size() == 0)
+        return -1;
+    std::sort(saves.rbegin(), saves.rend());
+    return saves[0].Slot;
 }
 
 void SetGlobalInt(int index,int valu) {

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -44,7 +44,9 @@ void RestoreGameSlot(int slnum);
 void DeleteSaveSlot (int slnum);
 int  GetSaveSlotDescription(int slnum,char*desbuf);
 int  LoadSaveSlotScreenshot(int slnum, int width, int height);
-void FillSaveList(std::vector<SaveListItem> &saves, size_t max_count = -1);
+void FillSaveList(std::vector<SaveListItem> &saves, unsigned top_index, size_t max_count = -1);
+// Find the latest save slot, returns the slot index or -1 at failure
+int  GetLastSaveSlot();
 void PauseGame();
 void UnPauseGame();
 int  IsGamePaused();

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -96,7 +96,7 @@ int ListBox_GetSaveGameSlots(GUIListBox *listbox, int index) {
 int ListBox_FillSaveGameList(GUIListBox *listbox) {
   // TODO: find out if limiting to MAXSAVEGAMES is still necessary here
   std::vector<SaveListItem> saves;
-  FillSaveList(saves, MAXSAVEGAMES);
+  FillSaveList(saves, TOP_LISTEDSAVESLOT, MAXSAVEGAMES);
   std::sort(saves.rbegin(), saves.rend());
 
   // fill in the list box

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -191,7 +191,7 @@ void apply_log_config(const ConfigTree &cfg, const String &log_id,
                       bool def_enabled,
                       std::initializer_list<DbgGroupOption> def_opts)
 {
-    String value = INIreadstring(cfg, "log", log_id);
+    String value = CfgReadString(cfg, "log", log_id);
     if (value.IsEmpty() && !def_enabled)
         return;
 
@@ -200,7 +200,7 @@ void apply_log_config(const ConfigTree &cfg, const String &log_id,
     const bool was_created_earlier = dbgout != nullptr;
     if (!dbgout)
     {
-        String path = INIreadstring(cfg, "log", String::FromFormat("%s-path", log_id.GetCStr()));
+        String path = CfgReadString(cfg, "log", String::FromFormat("%s-path", log_id.GetCStr()));
         dbgout = create_log_output(log_id, path);
         if (!dbgout)
             return; // unknown output type
@@ -253,7 +253,7 @@ void init_debug(const ConfigTree &cfg, bool stderr_only)
 {
     // Setup SDL output
     SDL_LogSetOutputFunction(SDL_Log_Output, nullptr);
-    String sdl_log = INIreadstring(cfg, "log", "sdl");
+    String sdl_log = CfgReadString(cfg, "log", "sdl");
     SDL_LogPriority priority = StrUtil::ParseEnumAllowNum<SDL_LogPriority>(sdl_log,
         CstrArr<SDL_NUM_LOG_PRIORITIES>{"", "verbose", "debug", "info", "warn", "error", "critical"}, SDL_LOG_PRIORITY_INFO);
     SDL_LogSetAllPriority(priority);
@@ -276,7 +276,7 @@ void apply_debug_config(const ConfigTree &cfg)
         { DbgGroupOption(kDbgGroup_Main, kDbgMsg_Info),
           DbgGroupOption(kDbgGroup_SDL, kDbgMsg_Info),
         });
-    bool legacy_log_enabled = INIreadint(cfg, "misc", "log", 0) != 0;
+    bool legacy_log_enabled = CfgReadInt(cfg, "misc", "log", 0) != 0;
     apply_log_config(cfg, OutputFileID,
         /* defaults */
         legacy_log_enabled,

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -276,7 +276,7 @@ void apply_debug_config(const ConfigTree &cfg)
         { DbgGroupOption(kDbgGroup_Main, kDbgMsg_Info),
           DbgGroupOption(kDbgGroup_SDL, kDbgMsg_Info),
         });
-    bool legacy_log_enabled = CfgReadInt(cfg, "misc", "log", 0) != 0;
+    bool legacy_log_enabled = CfgReadBoolInt(cfg, "misc", "log", false);
     apply_log_config(cfg, OutputFileID,
         /* defaults */
         legacy_log_enabled,

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -299,7 +299,7 @@ void preparesavegamelist(int ctrllist)
 {
   // TODO: find out if limiting to MAXSAVEGAMES is still necessary here
   std::vector<SaveListItem> saves;
-  FillSaveList(saves, MAXSAVEGAMES);
+  FillSaveList(saves, TOP_LISTEDSAVESLOT, MAXSAVEGAMES);
   std::sort(saves.rbegin(), saves.rend());
 
   // fill in the list box and global savegameindex[] array for backward compatibilty

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -222,7 +222,7 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
         usetup.override_upscale = true; // run low-res game in high-res mode
     }
 
-    usetup.Screen.Windowed = CfgReadInt(cfg, "misc", "windowed") > 0;
+    usetup.Screen.Windowed = CfgReadBoolInt(cfg, "misc", "windowed");
     usetup.Screen.DriverID = CfgReadString(cfg, "misc", "gfxdriver", usetup.Screen.DriverID);
 
     // Window setup: style and size definition, game frame style
@@ -241,8 +241,8 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
             if (!usetup.Screen.Windowed)
             {
                 bool allow_borders = 
-                    (CfgReadInt(cfg, "misc", "sideborders") > 0 || CfgReadInt(cfg, "misc", "forceletterbox") > 0 ||
-                     CfgReadInt(cfg, "misc", "prefer_sideborders") > 0 || CfgReadInt(cfg, "misc", "prefer_letterbox") > 0);
+                    (CfgReadBoolInt(cfg, "misc", "sideborders") || CfgReadBoolInt(cfg, "misc", "forceletterbox") ||
+                     CfgReadBoolInt(cfg, "misc", "prefer_sideborders") || CfgReadBoolInt(cfg, "misc", "prefer_letterbox"));
                 usetup.Screen.FsGameFrame = allow_borders ? kFrame_Proportional : kFrame_Stretch;
             }
         }
@@ -258,7 +258,7 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
         }
 
         // AGS 3.5.* gfx mode with screen definition
-        const bool is_windowed = CfgReadInt(cfg, "graphics", "windowed") != 0;
+        const bool is_windowed = CfgReadBoolInt(cfg, "graphics", "windowed");
         WindowSetup &ws = is_windowed ? usetup.Screen.WinSetup : usetup.Screen.FsSetup;
         const WindowMode wm = is_windowed ? kWnd_Windowed : kWnd_Fullscreen;
         ScreenSizeDefinition scr_def = parse_legacy_screendef(CfgReadString(cfg, "graphics", "screen_def"));
@@ -375,7 +375,7 @@ void override_config_ext(ConfigTree &cfg)
 void apply_config(const ConfigTree &cfg)
 {
     {
-        usetup.audio_enabled = CfgReadInt(cfg, "sound", "enabled", usetup.audio_enabled) != 0;
+        usetup.audio_enabled = CfgReadBoolInt(cfg, "sound", "enabled", usetup.audio_enabled);
         usetup.audio_driver = CfgReadString(cfg, "sound", "driver");
 
         // Legacy graphics settings has to be translated into new options;
@@ -384,7 +384,7 @@ void apply_config(const ConfigTree &cfg)
 
         // Graphics mode
         usetup.Screen.DriverID = CfgReadString(cfg, "graphics", "driver", usetup.Screen.DriverID);
-        usetup.Screen.Windowed = CfgReadInt(cfg, "graphics", "windowed", usetup.Screen.Windowed ? 1 : 0) > 0;
+        usetup.Screen.Windowed = CfgReadBoolInt(cfg, "graphics", "windowed", usetup.Screen.Windowed);
         usetup.Screen.FsSetup =
             parse_window_mode(CfgReadString(cfg, "graphics", "fullscreen", "default"), false, usetup.Screen.FsSetup);
         usetup.Screen.WinSetup =
@@ -402,8 +402,8 @@ void apply_config(const ConfigTree &cfg)
 #endif
 
         usetup.Screen.Params.RefreshRate = CfgReadInt(cfg, "graphics", "refresh");
-        usetup.Screen.Params.VSync = CfgReadInt(cfg, "graphics", "vsync") > 0;
-        usetup.RenderAtScreenRes = CfgReadInt(cfg, "graphics", "render_at_screenres") > 0;
+        usetup.Screen.Params.VSync = CfgReadBoolInt(cfg, "graphics", "vsync");
+        usetup.RenderAtScreenRes = CfgReadBoolInt(cfg, "graphics", "render_at_screenres");
         usetup.Supersampling = CfgReadInt(cfg, "graphics", "supersampling", 1);
         usetup.software_render_driver = CfgReadString(cfg, "graphics", "software_driver");
 
@@ -413,12 +413,12 @@ void apply_config(const ConfigTree &cfg)
                 rotation_str, CstrArr<kNumScreenRotationOptions>{ "unlocked", "portrait", "landscape" },
                 usetup.rotation);
 
-        usetup.enable_antialiasing = CfgReadInt(cfg, "misc", "antialias") > 0;
+        usetup.enable_antialiasing = CfgReadBoolInt(cfg, "misc", "antialias");
 
         // This option is backwards (usevox is 0 if no_speech_pack)
-        usetup.no_speech_pack = CfgReadInt(cfg, "sound", "usespeech", 1) == 0;
+        usetup.no_speech_pack = !CfgReadBoolInt(cfg, "sound", "usespeech", true);
 
-        usetup.clear_cache_on_room_change = CfgReadInt(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change) != 0;
+        usetup.clear_cache_on_room_change = CfgReadBoolInt(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change);
         usetup.user_data_dir = CfgReadString(cfg, "misc", "user_data_dir");
         usetup.shared_data_dir = CfgReadString(cfg, "misc", "shared_data_dir");
 
@@ -428,7 +428,7 @@ void apply_config(const ConfigTree &cfg)
         if (cache_size_kb > 0)
             spriteset.SetMaxCacheSize((size_t)cache_size_kb * 1024);
 
-        usetup.mouse_auto_lock = CfgReadInt(cfg, "mouse", "auto_lock") > 0;
+        usetup.mouse_auto_lock = CfgReadBoolInt(cfg, "mouse", "auto_lock");
 
         usetup.mouse_speed = CfgReadFloat(cfg, "mouse", "speed", 1.f);
         if (usetup.mouse_speed <= 0.f)
@@ -437,7 +437,7 @@ void apply_config(const ConfigTree &cfg)
         usetup.mouse_ctrl_when = StrUtil::ParseEnum<MouseControlWhen>(
             mouse_str, CstrArr<kNumMouseCtrlOptions>{ "never", "fullscreen", "always" },
                 usetup.mouse_ctrl_when);
-        usetup.mouse_ctrl_enabled = CfgReadInt(cfg, "mouse", "control_enabled", usetup.mouse_ctrl_enabled) > 0;
+        usetup.mouse_ctrl_enabled = CfgReadBoolInt(cfg, "mouse", "control_enabled", usetup.mouse_ctrl_enabled);
         mouse_str = CfgReadString(cfg, "mouse", "speed_def", "current_display");
         usetup.mouse_speed_def = StrUtil::ParseEnum<MouseSpeedDef>(
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
@@ -446,7 +446,7 @@ void apply_config(const ConfigTree &cfg)
         String override_os = CfgReadString(cfg, "override", "os");
         usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(override_os,
             CstrArr<eNumOS>{"", "dos", "win", "linux", "mac", "android", "ios", "psp", "web", "freebsd"}, eOS_Unknown);
-        usetup.override_upscale = CfgReadInt(cfg, "override", "upscale", usetup.override_upscale) > 0;
+        usetup.override_upscale = CfgReadBoolInt(cfg, "override", "upscale", usetup.override_upscale);
     }
 
     // Apply logging configuration

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 //
 // Game configuration
 //
@@ -47,57 +46,6 @@ extern GameState play;
 
 // Filename of the default config file, the one found in the game installation
 const String DefaultConfigFileName = "acsetup.cfg";
-
-bool INIreaditem(const ConfigTree &cfg, const String &sectn, const String &item, String &value)
-{
-    ConfigNode sec_it = cfg.find(sectn);
-    if (sec_it != cfg.end())
-    {
-        StrStrOIter item_it = sec_it->second.find(item);
-        if (item_it != sec_it->second.end())
-        {
-            value = item_it->second;
-            return true;
-        }
-    }
-    return false;
-}
-
-int INIreadint(const ConfigTree &cfg, const String &sectn, const String &item, int def_value)
-{
-    String str;
-    if (!INIreaditem(cfg, sectn, item, str))
-        return def_value;
-
-    return atoi(str.GetCStr());
-}
-
-float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value)
-{
-    String str;
-    if (!INIreaditem(cfg, sectn, item, str))
-        return def_value;
-
-    return atof(str.GetCStr());
-}
-
-String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value)
-{
-    String str;
-    if (!INIreaditem(cfg, sectn, item, str))
-        return def_value;
-    return str;
-}
-
-void INIwriteint(ConfigTree &cfg, const String &sectn, const String &item, int value)
-{
-    cfg[sectn][item] = StrUtil::IntToString(value);
-}
-
-void INIwritestring(ConfigTree &cfg, const String &sectn, const String &item, const String &value)
-{
-    cfg[sectn][item] = value;
-}
 
 
 WindowSetup parse_window_mode(const String &option, bool as_windowed, WindowSetup def_value)
@@ -266,20 +214,20 @@ void config_defaults()
 static void read_legacy_graphics_config(const ConfigTree &cfg)
 {
     // Pre-3.* game resolution setup
-    int default_res = INIreadint(cfg, "misc", "defaultres", 0);
-    int screen_res = INIreadint(cfg, "misc", "screenres", 0);
+    int default_res = CfgReadInt(cfg, "misc", "defaultres", 0);
+    int screen_res = CfgReadInt(cfg, "misc", "screenres", 0);
     if ((default_res == kGameResolution_320x200 ||
         default_res == kGameResolution_320x240) && screen_res > 0)
     {
         usetup.override_upscale = true; // run low-res game in high-res mode
     }
 
-    usetup.Screen.Windowed = INIreadint(cfg, "misc", "windowed") > 0;
-    usetup.Screen.DriverID = INIreadstring(cfg, "misc", "gfxdriver", usetup.Screen.DriverID);
+    usetup.Screen.Windowed = CfgReadInt(cfg, "misc", "windowed") > 0;
+    usetup.Screen.DriverID = CfgReadString(cfg, "misc", "gfxdriver", usetup.Screen.DriverID);
 
     // Window setup: style and size definition, game frame style
     {
-        String legacy_filter = INIreadstring(cfg, "misc", "gfxfilter");
+        String legacy_filter = CfgReadString(cfg, "misc", "gfxfilter");
         if (!legacy_filter.IsEmpty())
         {
             // Legacy scaling config is applied only to windowed setting
@@ -293,14 +241,14 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
             if (!usetup.Screen.Windowed)
             {
                 bool allow_borders = 
-                    (INIreadint(cfg, "misc", "sideborders") > 0 || INIreadint(cfg, "misc", "forceletterbox") > 0 ||
-                     INIreadint(cfg, "misc", "prefer_sideborders") > 0 || INIreadint(cfg, "misc", "prefer_letterbox") > 0);
+                    (CfgReadInt(cfg, "misc", "sideborders") > 0 || CfgReadInt(cfg, "misc", "forceletterbox") > 0 ||
+                     CfgReadInt(cfg, "misc", "prefer_sideborders") > 0 || CfgReadInt(cfg, "misc", "prefer_letterbox") > 0);
                 usetup.Screen.FsGameFrame = allow_borders ? kFrame_Proportional : kFrame_Stretch;
             }
         }
 
         // AGS 3.4.0 - 3.4.1-rc uniform scaling option
-        String uniform_frame_scale = INIreadstring(cfg, "graphics", "game_scale");
+        String uniform_frame_scale = CfgReadString(cfg, "graphics", "game_scale");
         if (!uniform_frame_scale.IsEmpty())
         {
             int src_scale = 1;
@@ -310,17 +258,17 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
         }
 
         // AGS 3.5.* gfx mode with screen definition
-        const bool is_windowed = INIreadint(cfg, "graphics", "windowed") != 0;
+        const bool is_windowed = CfgReadInt(cfg, "graphics", "windowed") != 0;
         WindowSetup &ws = is_windowed ? usetup.Screen.WinSetup : usetup.Screen.FsSetup;
         const WindowMode wm = is_windowed ? kWnd_Windowed : kWnd_Fullscreen;
-        ScreenSizeDefinition scr_def = parse_legacy_screendef(INIreadstring(cfg, "graphics", "screen_def"));
+        ScreenSizeDefinition scr_def = parse_legacy_screendef(CfgReadString(cfg, "graphics", "screen_def"));
         switch (scr_def)
         {
         case kScreenDef_Explicit:
             {
                 Size sz(
-                    INIreadint(cfg, "graphics", "screen_width"),
-                    INIreadint(cfg, "graphics", "screen_height"));
+                    CfgReadInt(cfg, "graphics", "screen_width"),
+                    CfgReadInt(cfg, "graphics", "screen_height"));
                 ws = WindowSetup(sz, wm);
             }
             break;
@@ -328,8 +276,8 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
             {
                 int src_scale;
                 is_windowed ?
-                    parse_legacy_scaling_option(INIreadstring(cfg, "graphics", "game_scale_win"), src_scale) :
-                    parse_legacy_scaling_option(INIreadstring(cfg, "graphics", "game_scale_fs"), src_scale);
+                    parse_legacy_scaling_option(CfgReadString(cfg, "graphics", "game_scale_win"), src_scale) :
+                    parse_legacy_scaling_option(CfgReadString(cfg, "graphics", "game_scale_fs"), src_scale);
                 ws = WindowSetup(src_scale, wm);
             }
             break;
@@ -341,7 +289,7 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
         }
     }
 
-    usetup.Screen.Params.RefreshRate = INIreadint(cfg, "misc", "refresh");
+    usetup.Screen.Params.RefreshRate = CfgReadInt(cfg, "misc", "refresh");
 }
 
 // Variables used for mobile port configs
@@ -361,7 +309,7 @@ void override_config_ext(ConfigTree &cfg)
 {
     // Mobile ports always run in fullscreen mode
 #if AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_IOS
-    INIwriteint(cfg, "graphics", "windowed", 0);
+    CfgWriteInt(cfg, "graphics", "windowed", 0);
 #endif
 
     // psp_gfx_renderer - rendering mode
@@ -370,13 +318,13 @@ void override_config_ext(ConfigTree &cfg)
     //    * 2 - hardware, render to texture
     if (psp_gfx_renderer == 0)
     {
-        INIwritestring(cfg, "graphics", "driver", "Software");
-        INIwriteint(cfg, "graphics", "render_at_screenres", 1);
+        CfgWriteString(cfg, "graphics", "driver", "Software");
+        CfgWriteInt(cfg, "graphics", "render_at_screenres", 1);
     }
     else
     {
-        INIwritestring(cfg, "graphics", "driver", "OGL");
-        INIwriteint(cfg, "graphics", "render_at_screenres", psp_gfx_renderer == 1);
+        CfgWriteString(cfg, "graphics", "driver", "OGL");
+        CfgWriteInt(cfg, "graphics", "render_at_screenres", psp_gfx_renderer == 1);
     }
 
     // psp_gfx_scaling - scaling style:
@@ -384,121 +332,121 @@ void override_config_ext(ConfigTree &cfg)
     //    * 1 - stretch and preserve aspect ratio
     //    * 2 - stretch to whole screen
     if (psp_gfx_scaling == 0)
-        INIwritestring(cfg, "graphics", "game_scale_fs", "1");
+        CfgWriteString(cfg, "graphics", "game_scale_fs", "1");
     else if (psp_gfx_scaling == 1)
-        INIwritestring(cfg, "graphics", "game_scale_fs", "proportional");
+        CfgWriteString(cfg, "graphics", "game_scale_fs", "proportional");
     else
-        INIwritestring(cfg, "graphics", "game_scale_fs", "stretch");
+        CfgWriteString(cfg, "graphics", "game_scale_fs", "stretch");
 
     // psp_gfx_smoothing - scaling filter:
     //    * 0 - nearest-neighbour
     //    * 1 - linear
     if (psp_gfx_smoothing == 0)
-        INIwritestring(cfg, "graphics", "filter", "StdScale");
+        CfgWriteString(cfg, "graphics", "filter", "StdScale");
     else
-        INIwritestring(cfg, "graphics", "filter", "Linear");
+        CfgWriteString(cfg, "graphics", "filter", "Linear");
 
     // psp_gfx_super_sampling - enable super sampling
     //    * 0 - x1
     //    * 1 - x2
     if (psp_gfx_renderer == 2)
-        INIwriteint(cfg, "graphics", "supersampling", psp_gfx_super_sampling + 1);
+        CfgWriteInt(cfg, "graphics", "supersampling", psp_gfx_super_sampling + 1);
     else
-        INIwriteint(cfg, "graphics", "supersampling", 0);
+        CfgWriteInt(cfg, "graphics", "supersampling", 0);
 
     // psp_gfx_rotation - scaling style:
     //    * 0 - unlocked, let the user rotate as wished.
     //    * 1 - portrait
     //    * 2 - landscape
-    INIwriteint(cfg, "graphics", "rotation", psp_rotation);
+    CfgWriteInt(cfg, "graphics", "rotation", psp_rotation);
 
 #if AGS_PLATFORM_OS_ANDROID
     // config_mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls
     //    * 0 - direct touch mouse control
-    INIwriteint(cfg, "mouse", "control_enabled", config_mouse_control_mode);
+    CfgWriteInt(cfg, "mouse", "control_enabled", config_mouse_control_mode);
 #endif
 
-    INIwriteint(cfg, "misc", "antialias", psp_gfx_smooth_sprites != 0);
-    INIwritestring(cfg, "language", "translation", psp_translation);
-    INIwriteint(cfg, "misc", "clear_cache_on_room_change", psp_clear_cache_on_room_change != 0);
+    CfgWriteInt(cfg, "misc", "antialias", psp_gfx_smooth_sprites != 0);
+    CfgWriteString(cfg, "language", "translation", psp_translation);
+    CfgWriteInt(cfg, "misc", "clear_cache_on_room_change", psp_clear_cache_on_room_change != 0);
 }
 
 void apply_config(const ConfigTree &cfg)
 {
     {
-        usetup.audio_enabled = INIreadint(cfg, "sound", "enabled", usetup.audio_enabled) != 0;
-        usetup.audio_driver = INIreadstring(cfg, "sound", "driver");
+        usetup.audio_enabled = CfgReadInt(cfg, "sound", "enabled", usetup.audio_enabled) != 0;
+        usetup.audio_driver = CfgReadString(cfg, "sound", "driver");
 
         // Legacy graphics settings has to be translated into new options;
         // they must be read first, to let newer options override them, if ones are present
         read_legacy_graphics_config(cfg);
 
         // Graphics mode
-        usetup.Screen.DriverID = INIreadstring(cfg, "graphics", "driver", usetup.Screen.DriverID);
-        usetup.Screen.Windowed = INIreadint(cfg, "graphics", "windowed", usetup.Screen.Windowed ? 1 : 0) > 0;
+        usetup.Screen.DriverID = CfgReadString(cfg, "graphics", "driver", usetup.Screen.DriverID);
+        usetup.Screen.Windowed = CfgReadInt(cfg, "graphics", "windowed", usetup.Screen.Windowed ? 1 : 0) > 0;
         usetup.Screen.FsSetup =
-            parse_window_mode(INIreadstring(cfg, "graphics", "fullscreen", "default"), false, usetup.Screen.FsSetup);
+            parse_window_mode(CfgReadString(cfg, "graphics", "fullscreen", "default"), false, usetup.Screen.FsSetup);
         usetup.Screen.WinSetup =
-            parse_window_mode(INIreadstring(cfg, "graphics", "window", "default"), true, usetup.Screen.WinSetup);
+            parse_window_mode(CfgReadString(cfg, "graphics", "window", "default"), true, usetup.Screen.WinSetup);
 
         // TODO: move to config overrides (replace values during config load)
 #if AGS_PLATFORM_OS_MACOS
         usetup.Screen.Filter.ID = "none";
 #else
-        usetup.Screen.Filter.ID = INIreadstring(cfg, "graphics", "filter", "StdScale");
+        usetup.Screen.Filter.ID = CfgReadString(cfg, "graphics", "filter", "StdScale");
         usetup.Screen.FsGameFrame =
-            parse_scaling_option(INIreadstring(cfg, "graphics", "game_scale_fs", "proportional"), usetup.Screen.FsGameFrame);
+            parse_scaling_option(CfgReadString(cfg, "graphics", "game_scale_fs", "proportional"), usetup.Screen.FsGameFrame);
         usetup.Screen.WinGameFrame =
-            parse_scaling_option(INIreadstring(cfg, "graphics", "game_scale_win", "round"), usetup.Screen.WinGameFrame);
+            parse_scaling_option(CfgReadString(cfg, "graphics", "game_scale_win", "round"), usetup.Screen.WinGameFrame);
 #endif
 
-        usetup.Screen.Params.RefreshRate = INIreadint(cfg, "graphics", "refresh");
-        usetup.Screen.Params.VSync = INIreadint(cfg, "graphics", "vsync") > 0;
-        usetup.RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres") > 0;
-        usetup.Supersampling = INIreadint(cfg, "graphics", "supersampling", 1);
-        usetup.software_render_driver = INIreadstring(cfg, "graphics", "software_driver");
+        usetup.Screen.Params.RefreshRate = CfgReadInt(cfg, "graphics", "refresh");
+        usetup.Screen.Params.VSync = CfgReadInt(cfg, "graphics", "vsync") > 0;
+        usetup.RenderAtScreenRes = CfgReadInt(cfg, "graphics", "render_at_screenres") > 0;
+        usetup.Supersampling = CfgReadInt(cfg, "graphics", "supersampling", 1);
+        usetup.software_render_driver = CfgReadString(cfg, "graphics", "software_driver");
 
-        usetup.rotation = (ScreenRotation)INIreadint(cfg, "graphics", "rotation", usetup.rotation);
-        String rotation_str = INIreadstring(cfg, "graphics", "rotation", "unlocked");
+        usetup.rotation = (ScreenRotation)CfgReadInt(cfg, "graphics", "rotation", usetup.rotation);
+        String rotation_str = CfgReadString(cfg, "graphics", "rotation", "unlocked");
         usetup.rotation = StrUtil::ParseEnum<ScreenRotation>(
                 rotation_str, CstrArr<kNumScreenRotationOptions>{ "unlocked", "portrait", "landscape" },
                 usetup.rotation);
 
-        usetup.enable_antialiasing = INIreadint(cfg, "misc", "antialias") > 0;
+        usetup.enable_antialiasing = CfgReadInt(cfg, "misc", "antialias") > 0;
 
         // This option is backwards (usevox is 0 if no_speech_pack)
-        usetup.no_speech_pack = INIreadint(cfg, "sound", "usespeech", 1) == 0;
+        usetup.no_speech_pack = CfgReadInt(cfg, "sound", "usespeech", 1) == 0;
 
-        usetup.clear_cache_on_room_change = INIreadint(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change) != 0;
-        usetup.user_data_dir = INIreadstring(cfg, "misc", "user_data_dir");
-        usetup.shared_data_dir = INIreadstring(cfg, "misc", "shared_data_dir");
+        usetup.clear_cache_on_room_change = CfgReadInt(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change) != 0;
+        usetup.user_data_dir = CfgReadString(cfg, "misc", "user_data_dir");
+        usetup.shared_data_dir = CfgReadString(cfg, "misc", "shared_data_dir");
 
-        usetup.translation = INIreadstring(cfg, "language", "translation");
+        usetup.translation = CfgReadString(cfg, "language", "translation");
 
-        int cache_size_kb = INIreadint(cfg, "misc", "cachemax", DEFAULTCACHESIZE_KB);
+        int cache_size_kb = CfgReadInt(cfg, "misc", "cachemax", DEFAULTCACHESIZE_KB);
         if (cache_size_kb > 0)
             spriteset.SetMaxCacheSize((size_t)cache_size_kb * 1024);
 
-        usetup.mouse_auto_lock = INIreadint(cfg, "mouse", "auto_lock") > 0;
+        usetup.mouse_auto_lock = CfgReadInt(cfg, "mouse", "auto_lock") > 0;
 
-        usetup.mouse_speed = INIreadfloat(cfg, "mouse", "speed", 1.f);
+        usetup.mouse_speed = CfgReadFloat(cfg, "mouse", "speed", 1.f);
         if (usetup.mouse_speed <= 0.f)
             usetup.mouse_speed = 1.f;
-        String mouse_str = INIreadstring(cfg, "mouse", "control_when", "fullscreen");
+        String mouse_str = CfgReadString(cfg, "mouse", "control_when", "fullscreen");
         usetup.mouse_ctrl_when = StrUtil::ParseEnum<MouseControlWhen>(
             mouse_str, CstrArr<kNumMouseCtrlOptions>{ "never", "fullscreen", "always" },
                 usetup.mouse_ctrl_when);
-        usetup.mouse_ctrl_enabled = INIreadint(cfg, "mouse", "control_enabled", usetup.mouse_ctrl_enabled) > 0;
-        mouse_str = INIreadstring(cfg, "mouse", "speed_def", "current_display");
+        usetup.mouse_ctrl_enabled = CfgReadInt(cfg, "mouse", "control_enabled", usetup.mouse_ctrl_enabled) > 0;
+        mouse_str = CfgReadString(cfg, "mouse", "speed_def", "current_display");
         usetup.mouse_speed_def = StrUtil::ParseEnum<MouseSpeedDef>(
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
-        usetup.override_multitasking = INIreadint(cfg, "override", "multitasking", -1);
-        String override_os = INIreadstring(cfg, "override", "os");
+        usetup.override_multitasking = CfgReadInt(cfg, "override", "multitasking", -1);
+        String override_os = CfgReadString(cfg, "override", "os");
         usetup.override_script_os = StrUtil::ParseEnum<eScriptSystemOSID>(override_os,
             CstrArr<eNumOS>{"", "dos", "win", "linux", "mac", "android", "ios", "psp", "web", "freebsd"}, eOS_Unknown);
-        usetup.override_upscale = INIreadint(cfg, "override", "upscale", usetup.override_upscale) > 0;
+        usetup.override_upscale = CfgReadInt(cfg, "override", "upscale", usetup.override_upscale) > 0;
     }
 
     // Apply logging configuration

--- a/Engine/main/config.h
+++ b/Engine/main/config.h
@@ -48,14 +48,4 @@ String make_scaling_option(FrameScaleDef scale_def);
 uint32_t convert_scaling_to_fp(int scale_factor);
 int convert_fp_to_scaling(uint32_t scaling);
 
-
-bool INIreaditem(const ConfigTree &cfg, const String &sectn, const String &item, String &value);
-int INIreadint(const ConfigTree &cfg, const String &sectn, const String &item, int def_value = 0);
-float INIreadfloat(const ConfigTree &cfg, const String &sectn, const String &item, float def_value = 0.f);
-String INIreadstring(const ConfigTree &cfg, const String &sectn, const String &item, const String &def_value = "");
-void INIwriteint(ConfigTree &cfg, const String &sectn, const String &item, int value);
-void INIwritestring(ConfigTree &cfg, const String &sectn, const String &item, const String &value);
-void INIwriteint(ConfigTree &cfg, const String &sectn, const String &item, int value);
-
-
 #endif // __AGS_EE_MAIN__CONFIG_H

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -223,7 +223,7 @@ static String find_game_data_in_config(const String &path)
     String def_cfg_file = Path::ConcatPaths(path, DefaultConfigFileName);
     if (IniUtil::Read(def_cfg_file, cfg))
     {
-        String data_file = INIreadstring(cfg, "misc", "datafile");
+        String data_file = CfgReadString(cfg, "misc", "datafile");
         Debug::Printf("Found game config: %s", def_cfg_file.GetCStr());
         Debug::Printf(" Cfg: data file: %s", data_file.GetCStr());
         // Only accept if it's a relative path
@@ -1049,9 +1049,9 @@ void engine_read_config(ConfigTree &cfg)
     // Handle directive to search for the user config inside the custom directory;
     // this option may come either from command line or default/global config.
     if (usetup.user_conf_dir.IsEmpty())
-        usetup.user_conf_dir = INIreadstring(cfg, "misc", "user_conf_dir");
+        usetup.user_conf_dir = CfgReadString(cfg, "misc", "user_conf_dir");
     if (usetup.user_conf_dir.IsEmpty()) // also try deprecated option
-        usetup.user_conf_dir = INIreadint(cfg, "misc", "localuserconf") != 0 ? "." : "";
+        usetup.user_conf_dir = CfgReadInt(cfg, "misc", "localuserconf") != 0 ? "." : "";
     // Test if the file is writeable, if it is then both engine and setup
     // applications may actually use it fully as a user config, otherwise
     // fallback to default behavior.

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1051,7 +1051,7 @@ void engine_read_config(ConfigTree &cfg)
     if (usetup.user_conf_dir.IsEmpty())
         usetup.user_conf_dir = CfgReadString(cfg, "misc", "user_conf_dir");
     if (usetup.user_conf_dir.IsEmpty()) // also try deprecated option
-        usetup.user_conf_dir = CfgReadInt(cfg, "misc", "localuserconf") != 0 ? "." : "";
+        usetup.user_conf_dir = CfgReadBoolInt(cfg, "misc", "localuserconf") ? "." : "";
     // Test if the file is writeable, if it is then both engine and setup
     // applications may actually use it fully as a user config, otherwise
     // fallback to default behavior.

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -99,10 +99,6 @@ extern RGB palette[256];
 extern CharacterExtras *charextra;
 extern CharacterInfo*playerchar;
 
-#if AGS_PLATFORM_OS_ANDROID
-extern "C" void selectLatestSavegame();
-#endif
-
 ResourcePaths ResPaths;
 
 t_engine_pre_init_callback engine_pre_init_callback = nullptr;
@@ -897,9 +893,13 @@ void engine_prepare_to_start_game()
 
     engine_setup_scsystem_auxiliary();
 
-#if AGS_PLATFORM_OS_ANDROID
+#if (AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS)
     if (psp_load_latest_savegame)
-        selectLatestSavegame();
+    {
+        int slot = GetLastSaveSlot();
+        if (slot >= 0)
+            loadSaveGameOnStartup = get_save_game_path(slot);
+    }
 #endif
 }
 
@@ -1327,7 +1327,7 @@ int initialize_engine(const ConfigTree &startup_opts)
 
 	allegro_bitmap_test_init();
 
-    initialize_start_and_play_game(override_start_room, loadSaveGameOnStartup);
+    initialize_start_and_play_game(override_start_room, loadSaveGameOnStartup.GetCStr());
 
     return EXIT_NORMAL;
 }

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -321,7 +321,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         }
         else if (ags_stricmp(arg, "--clear-cache-on-room-change") == 0)
         {
-            INIwritestring(cfg, "misc", "clear_cache_on_room_change", "1");
+            CfgWriteString(cfg, "misc", "clear_cache_on_room_change", "1");
         }
         else if (ags_strnicmp(arg, "--tell", 6) == 0) {
             if (arg[6] == 0)
@@ -342,25 +342,25 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             cfg["graphics"]["windowed"] = "0";
         else if ((ags_stricmp(arg, "--gfxdriver") == 0) && (argc > ee + 1))
         {
-            INIwritestring(cfg, "graphics", "driver", argv[++ee]);
+            CfgWriteString(cfg, "graphics", "driver", argv[++ee]);
         }
         else if ((ags_stricmp(arg, "--gfxfilter") == 0) && (argc > ee + 1))
         {
             // NOTE: we make an assumption here that if user provides scaling factor,
             // this factor means to be applied to windowed mode only.
-            INIwritestring(cfg, "graphics", "filter", argv[++ee]);
+            CfgWriteString(cfg, "graphics", "filter", argv[++ee]);
             if (argc > ee + 1 && argv[ee + 1][0] != '-')
-                INIwritestring(cfg, "graphics", "game_scale_win", argv[++ee]);
+                CfgWriteString(cfg, "graphics", "game_scale_win", argv[++ee]);
             else
-                INIwritestring(cfg, "graphics", "game_scale_win", "max_round");
+                CfgWriteString(cfg, "graphics", "game_scale_win", "max_round");
         }
         else if ((ags_stricmp(arg, "--translation") == 0) && (argc > ee + 1))
         {
-            INIwritestring(cfg, "language", "translation", argv[++ee]);
+            CfgWriteString(cfg, "language", "translation", argv[++ee]);
         }
         else if (ags_stricmp(arg, "--no-translation") == 0)
         {
-            INIwritestring(cfg, "language", "translation", "");
+            CfgWriteString(cfg, "language", "translation", "");
         }
         else if (ags_stricmp(arg, "--fps") == 0) display_fps = kFPS_Forced;
         else if (ags_stricmp(arg, "--test") == 0) debug_flags |= DBG_DEBUGMODE;
@@ -374,7 +374,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "--novideo") == 0) debug_flags |= DBG_NOVIDEO;
         else if (ags_stricmp(arg, "--rotation") == 0 && (argc > ee + 1))
         {
-            INIwritestring(cfg, "graphics", "rotation", argv[++ee]);
+            CfgWriteString(cfg, "graphics", "rotation", argv[++ee]);
         }
         else if (ags_strnicmp(arg, "--log-", 6) == 0 && arg[6] != 0)
         {

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -78,7 +78,7 @@ bool justTellInfo = false;
 bool attachToParentConsole = false;
 bool hideMessageBoxes = false;
 std::set<String> tellInfoKeys;
-const char *loadSaveGameOnStartup = nullptr;
+String loadSaveGameOnStartup;
 
 #if ! AGS_PLATFORM_DEFINES_PSP_VARS
 int psp_video_framedrop = 1;

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -42,7 +42,7 @@ extern int override_start_room;
 extern bool justRegisterGame;
 extern bool justUnRegisterGame;
 extern bool justTellInfo;
-extern const char *loadSaveGameOnStartup;
+extern AGS::Common::String loadSaveGameOnStartup;
 
 extern int psp_video_framedrop;
 extern int psp_ignore_acsetup_cfg_file;

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -66,11 +66,6 @@ String android_save_directory = "";
 char psp_game_file_name[256];
 char* psp_game_file_name_pointer = psp_game_file_name;
 
-bool psp_load_latest_savegame = false;
-extern char saveGameDirectory[260];
-extern const char *loadSaveGameOnStartup;
-char lastSaveGameName[200];
-
 // NOTE: the JVM can't use JNI outside here due to C++ name mangling
 extern "C" 
 {
@@ -324,40 +319,6 @@ JNIEXPORT jint JNICALL
   }
 
   return i;
-}
-
-void selectLatestSavegame()
-{
-  DIR* dir;
-  struct dirent* entry;
-  struct stat statBuffer;
-  char buffer[200];
-  time_t lastTime = 0;
-
-  dir = opendir(saveGameDirectory);
-
-  if (dir)
-  {
-    while ((entry = readdir(dir)) != 0)
-    {
-      if (ags_strnicmp(entry->d_name, "agssave", 7) == 0)
-      {
-        if (ags_stricmp(entry->d_name, "agssave.999") != 0)
-        {
-          strcpy(buffer, saveGameDirectory);
-          strcat(buffer, entry->d_name);
-          stat(buffer, &statBuffer);
-          if (statBuffer.st_mtime > lastTime)
-          {
-            strcpy(lastSaveGameName, buffer);
-            loadSaveGameOnStartup = lastSaveGameName;
-            lastTime = statBuffer.st_mtime;
-          }
-        }
-      }
-    }
-    closedir(dir);
-  }
 }
 
 JNIEXPORT void JNICALL

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "core/platform.h"
 
 #if AGS_PLATFORM_OS_ANDROID
@@ -28,7 +27,7 @@
 #include "platform/base/agsplatformdriver.h"
 #include "ac/runtime_defines.h"
 #include "game/main_game_file.h"
-#include "main/config.h"
+#include "platform/base/mobile_base.h"
 #include "plugin/agsplugin.h"
 #include "util/android_file.h"
 #include "util/path.h"
@@ -38,9 +37,6 @@
 using namespace AGS::Common;
 
 #define ANDROID_CONFIG_FILENAME "android.cfg"
-
-bool ReadConfiguration(const char* filename, bool read_everything);
-void ResetConfiguration();
 
 struct AGSAndroid : AGSPlatformDriver {
 
@@ -63,42 +59,6 @@ struct AGSAndroid : AGSPlatformDriver {
   virtual void WriteStdErr(const char *fmt, ...);
 };
 
-int psp_ignore_acsetup_cfg_file = 1;
-int psp_clear_cache_on_room_change = 0;
-int psp_rotation = 0;
-int psp_config_enabled = 0;
-char psp_translation[100];
-char* psp_translations[100];
-
-// Mouse option
-int config_mouse_control_mode;
-
-// Graphic options
-int psp_gfx_scaling;
-int psp_gfx_smoothing;
-
-// Audio options from the Allegro library.
-unsigned int psp_audio_samplerate = 44100;
-int psp_audio_enabled = 1;
-volatile int psp_audio_multithreaded = 1;
-int psp_audio_cachesize = 10;
-int psp_midi_enabled = 1;
-int psp_midi_preload_patches = 0;
-
-int psp_video_framedrop = 0;
-
-int psp_gfx_renderer = 0;
-int psp_gfx_super_sampling = 0;
-int psp_gfx_smooth_sprites = 0;
-
-int psp_debug_write_to_logcat = 1;
-
-int config_mouse_longclick = 0;
-
-extern int display_fps;
-extern int want_exit;
-extern void PauseGame();
-extern void UnPauseGame();
 
 String android_base_directory = ".";
 String android_app_directory = ".";
@@ -110,8 +70,6 @@ bool psp_load_latest_savegame = false;
 extern char saveGameDirectory[260];
 extern const char *loadSaveGameOnStartup;
 char lastSaveGameName[200];
-
-bool reset_configuration = false;
 
 // NOTE: the JVM can't use JNI outside here due to C++ name mangling
 extern "C" 
@@ -155,51 +113,7 @@ JNIEXPORT jboolean JNICALL
 JNIEXPORT jboolean JNICALL
   Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_writeConfigFile(JNIEnv* env, jobject object)
 {
-  FILE* config = fopen(ANDROID_CONFIG_FILENAME, "wb");
-  if (config)
-  {
-    fprintf(config, "[misc]\n");
-    fprintf(config, "config_enabled = %d\n", psp_config_enabled);
-    fprintf(config, "rotation = %d\n", psp_rotation);
-    fprintf(config, "translation = %s\n", psp_translation);
-
-    fprintf(config, "[controls]\n");
-    fprintf(config, "mouse_method = %d\n", config_mouse_control_mode);
-    fprintf(config, "mouse_longclick = %d\n", config_mouse_longclick);
-	
-    fprintf(config, "[compatibility]\n");
-    fprintf(config, "clear_cache_on_room_change = %d\n", psp_clear_cache_on_room_change);
-
-    fprintf(config, "[sound]\n");
-    fprintf(config, "samplerate = %d\n", psp_audio_samplerate );
-    fprintf(config, "enabled = %d\n", psp_audio_enabled);
-    fprintf(config, "threaded = %d\n", psp_audio_multithreaded);
-    fprintf(config, "cache_size = %d\n", psp_audio_cachesize);
-    
-    fprintf(config, "[midi]\n");
-    fprintf(config, "enabled = %d\n", psp_midi_enabled);
-    fprintf(config, "preload_patches = %d\n", psp_midi_preload_patches);
-
-    fprintf(config, "[video]\n");
-    fprintf(config, "framedrop = %d\n", psp_video_framedrop);
-
-    fprintf(config, "[graphics]\n");
-    fprintf(config, "renderer = %d\n", psp_gfx_renderer);
-    fprintf(config, "smoothing = %d\n", psp_gfx_smoothing);
-    fprintf(config, "scaling = %d\n", psp_gfx_scaling);
-    fprintf(config, "super_sampling = %d\n", psp_gfx_super_sampling);
-    fprintf(config, "smooth_sprites = %d\n", psp_gfx_smooth_sprites);
-
-    fprintf(config, "[debug]\n");
-    fprintf(config, "show_fps = %d\n", (display_fps == 2) ? 1 : 0);
-    fprintf(config, "logging = %d\n", psp_debug_write_to_logcat);
-
-    fclose(config);
-
-    return true;
-  }
-
-  return false;
+  return WriteConfiguration(ANDROID_CONFIG_FILENAME);
 }
 
 
@@ -455,101 +369,6 @@ Java_uk_co_adventuregamestudio_runtime_AGSRuntimeActivity_nativeSdlShowKeyboard(
 } // END of Extern "C"
 
 
-int ReadInteger(int* variable, const ConfigTree &cfg, const char* section, const char* name, int minimum, int maximum, int default_value)
-{
-  if (reset_configuration)
-  {
-    *variable = default_value;
-    return 0;
-  }
-
-  int temp = INIreadint(cfg, section, name);
-
-  if (temp == -1)
-    return 0;
-
-  if ((temp < minimum) || (temp > maximum))
-    temp = default_value;
-
-  *variable = temp;
-
-  return 1;
-}
-
-
-int ReadString(char* variable, const ConfigTree &cfg, const char* section, const char* name, const char* default_value)
-{
-  if (reset_configuration)
-  {
-    strcpy(variable, default_value);
-    return 0;
-  }
-
-  String temp;
-  if (!INIreaditem(cfg, section, name, temp))
-    temp = default_value;
-
-  strcpy(variable, temp.GetCStr());
-
-  return 1;
-}
-
-
-void ResetConfiguration()
-{
-  reset_configuration = true;
-
-  ReadConfiguration(ANDROID_CONFIG_FILENAME, true);
-
-  reset_configuration = false;
-}
-
-
-bool ReadConfiguration(const char* filename, bool read_everything)
-{
-  ConfigTree cfg;
-  if (IniUtil::Read(filename, cfg) || reset_configuration)
-  {
-    ReadString(&psp_translation[0], cfg, "misc", "translation", "default");
-
-    ReadInteger((int*)&psp_config_enabled, cfg, "misc", "config_enabled", 0, 1, 0);
-    if (!psp_config_enabled && !read_everything)
-      return true;
-
-    ReadInteger(&psp_debug_write_to_logcat, cfg, "debug", "logging", 0, 1, 0);
-    ReadInteger(&display_fps, cfg, "debug", "show_fps", 0, 1, 0);
-    if (display_fps == 1)
-      display_fps = 2;
-
-    ReadInteger((int*)&psp_rotation, cfg, "misc", "rotation", 0, 2, 0);
-
-    ReadInteger((int*)&psp_clear_cache_on_room_change, cfg, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
-
-    ReadInteger((int*)&psp_audio_samplerate, cfg, "sound", "samplerate", 0, 44100, 44100);
-    ReadInteger((int*)&psp_audio_enabled, cfg, "sound", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_multithreaded, cfg, "sound", "threaded", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_cachesize, cfg, "sound", "cache_size", 1, 50, 10);
-
-    ReadInteger((int*)&psp_midi_enabled, cfg, "midi", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_midi_preload_patches, cfg, "midi", "preload_patches", 0, 1, 0);
-
-    ReadInteger((int*)&psp_video_framedrop, cfg, "video", "framedrop", 0, 1, 0);
-
-    ReadInteger((int*)&psp_gfx_renderer, cfg, "graphics", "renderer", 0, 2, 0);
-    ReadInteger((int*)&psp_gfx_smoothing, cfg, "graphics", "smoothing", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_scaling, cfg, "graphics", "scaling", 0, 2, 1);
-    ReadInteger((int*)&psp_gfx_super_sampling, cfg, "graphics", "super_sampling", 0, 1, 0);
-    ReadInteger((int*)&psp_gfx_smooth_sprites, cfg, "graphics", "smooth_sprites", 0, 1, 0);
-
-    ReadInteger((int*)&config_mouse_control_mode, cfg, "controls", "mouse_method", 0, 1, 0);
-    ReadInteger((int*)&config_mouse_longclick, cfg, "controls", "mouse_longclick", 0, 1, 1);
-
-    return true;
-  }
-
-  return false;
-}
-
 void AGSAndroid::MainInit()
 {
     // retrieve the JNI environment.
@@ -596,7 +415,7 @@ void AGSAndroid::MainInit()
     ResetConfiguration();
 
     // Read general configuration.
-    ReadConfiguration((char*) ANDROID_CONFIG_FILENAME, true);
+    ReadConfiguration(ANDROID_CONFIG_FILENAME, true);
 
     // Get the games path.
     String path = psp_game_file_name;
@@ -609,7 +428,7 @@ void AGSAndroid::MainInit()
     }
 
     // Read game specific configuration.
-    ReadConfiguration((char*) ANDROID_CONFIG_FILENAME, false);
+    ReadConfiguration(ANDROID_CONFIG_FILENAME, false);
 
     if (config_mouse_longclick > 0) {
         jmethodID method_id = env->GetMethodID(clazz, "AgsEnableLongclick", "()V");

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -55,6 +55,8 @@ int config_mouse_longclick = 0;
 // defined in the engine
 extern int display_fps;
 
+bool psp_load_latest_savegame = false;
+
 
 bool WriteConfiguration(const char *filename)
 {

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -1,0 +1,143 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "core/platform.h"
+
+#if (AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS)
+#include "platform/base/mobile_base.h"
+#include "util/ini_util.h"
+
+using namespace AGS::Common;
+
+// Mobile platform options
+int psp_ignore_acsetup_cfg_file = 1;
+int psp_clear_cache_on_room_change = 0;
+int psp_rotation = 0;
+int psp_config_enabled = 0;
+char psp_translation[100]{};
+char* psp_translations[100]{};
+
+// Mouse option
+int config_mouse_control_mode;
+
+// Graphic options
+int psp_gfx_scaling;
+int psp_gfx_smoothing;
+
+// Audio options from the Allegro library.
+unsigned int psp_audio_samplerate = 44100;
+int psp_audio_enabled = 1;
+int psp_audio_multithreaded = 1;
+int psp_audio_cachesize = 10;
+int psp_midi_enabled = 1;
+int psp_midi_preload_patches = 0;
+
+int psp_video_framedrop = 0;
+
+int psp_gfx_renderer = 0;
+int psp_gfx_super_sampling = 0;
+int psp_gfx_smooth_sprites = 0;
+
+int psp_debug_write_to_logcat = 1;
+
+int config_mouse_longclick = 0;
+
+// defined in the engine
+extern int display_fps;
+
+
+bool WriteConfiguration(const char *filename)
+{
+    ConfigTree cfg;
+    CfgWriteInt(cfg, "misc", "config_enabled", psp_config_enabled);
+    CfgWriteInt(cfg, "misc", "rotation", psp_rotation);
+    CfgWriteString(cfg, "misc", "translation", psp_translation);
+
+    CfgWriteInt(cfg, "controls", "mouse_method", config_mouse_control_mode);
+    CfgWriteInt(cfg, "controls", "mouse_longclick", config_mouse_longclick);
+
+    CfgWriteInt(cfg, "compatibility", "clear_cache_on_room_change", psp_clear_cache_on_room_change);
+
+    CfgWriteInt(cfg, "sound", "samplerate", psp_audio_samplerate);
+    CfgWriteInt(cfg, "sound", "enabled", psp_audio_enabled);
+    CfgWriteInt(cfg, "sound", "threaded", psp_audio_multithreaded);
+    CfgWriteInt(cfg, "sound", "cache_size", psp_audio_cachesize);
+
+    CfgWriteInt(cfg, "midi", "enabled", psp_midi_enabled);
+    CfgWriteInt(cfg, "midi", "preload_patches", psp_midi_preload_patches);
+
+    CfgWriteInt(cfg, "video", "framedrop", psp_video_framedrop);
+
+    CfgWriteInt(cfg, "graphics", "renderer", psp_gfx_renderer);
+    CfgWriteInt(cfg, "graphics", "smoothing", psp_gfx_smoothing);
+    CfgWriteInt(cfg, "graphics", "scaling", psp_gfx_scaling);
+    CfgWriteInt(cfg, "graphics", "super_sampling", psp_gfx_super_sampling);
+    CfgWriteInt(cfg, "graphics", "smooth_sprites", psp_gfx_smooth_sprites);
+
+    CfgWriteInt(cfg, "debug", "show_fps", (display_fps == 2) ? 1 : 0);
+    CfgWriteInt(cfg, "debug", "logging", psp_debug_write_to_logcat);
+
+    return IniUtil::Merge(filename, cfg);
+}
+
+void ResetConfiguration()
+{
+    ReadConfiguration(nullptr, true);
+}
+
+// Reads config from a given file; pass nullptr instead of filename
+// to perform a config reset (all variables will get default values)
+bool ReadConfiguration(const char* filename, bool read_everything)
+{
+    ConfigTree cfg;
+    if (filename && !IniUtil::Read(filename, cfg))
+        return false;
+
+    CfgReadString(&psp_translation[0], sizeof(psp_translation), cfg, "misc", "translation", "default");
+
+    psp_config_enabled = CfgReadBoolInt(cfg, "misc", "config_enabled", false);
+    if (!psp_config_enabled && !read_everything)
+        return true;
+
+    psp_debug_write_to_logcat = CfgReadBoolInt(cfg, "debug", "logging", false);
+    display_fps = CfgReadBoolInt(cfg, "debug", "show_fps", false);
+    if (display_fps == 1)
+        display_fps = 2;
+
+    psp_rotation = CfgReadInt(cfg, "misc", "rotation", 0, 2, 0);
+
+    psp_clear_cache_on_room_change = CfgReadBoolInt(cfg, "compatibility", "clear_cache_on_room_change", false);
+
+    psp_audio_samplerate = CfgReadInt(cfg, "sound", "samplerate", 0, 44100, 44100);
+    psp_audio_enabled = CfgReadBoolInt(cfg, "sound", "enabled", true);
+    psp_audio_multithreaded = CfgReadBoolInt(cfg, "sound", "threaded", true);
+    psp_audio_cachesize = CfgReadInt(cfg, "sound", "cache_size", 1, 50, 10);
+
+    psp_midi_enabled = CfgReadBoolInt(cfg, "midi", "enabled", true);
+    psp_midi_preload_patches = CfgReadBoolInt(cfg, "midi", "preload_patches", false);
+
+    psp_video_framedrop = CfgReadBoolInt(cfg, "video", "framedrop", true);
+
+    psp_gfx_renderer = CfgReadInt(cfg, "graphics", "renderer", 0, 2, 0);
+    psp_gfx_smoothing = CfgReadBoolInt(cfg, "graphics", "smoothing", true);
+    psp_gfx_scaling = CfgReadInt(cfg, "graphics", "scaling", 0, 2, 1);
+    psp_gfx_super_sampling = CfgReadBoolInt(cfg, "graphics", "super_sampling", true);
+    psp_gfx_smooth_sprites = CfgReadBoolInt(cfg, "graphics", "smooth_sprites", true);
+
+    config_mouse_control_mode = CfgReadInt(cfg, "controls", "mouse_method", 0, 1, 0);
+    config_mouse_longclick = CfgReadBoolInt(cfg, "controls", "mouse_longclick", true);
+
+    return true;
+}
+
+#endif

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -58,4 +58,6 @@ extern int config_mouse_longclick;
 
 extern int display_fps;
 
+extern bool psp_load_latest_savegame;
+
 #endif

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -1,0 +1,61 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "core/platform.h"
+
+#if (AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS)
+
+// Writes mobile platform config
+bool WriteConfiguration(const char *filename);
+// Reads mobile platform config
+bool ReadConfiguration(const char *filename, bool read_everything);
+// Reset config variables
+void ResetConfiguration();
+
+
+// Mobile platform options
+extern int psp_ignore_acsetup_cfg_file;
+extern int psp_clear_cache_on_room_change;
+extern int psp_rotation;
+extern int psp_config_enabled;
+extern char psp_translation[100];
+extern char* psp_translations[100];
+
+// Mouse option
+extern int config_mouse_control_mode;
+
+// Graphic options
+extern int psp_gfx_scaling;
+extern int psp_gfx_smoothing;
+
+// Audio options from the Allegro library.
+extern unsigned int psp_audio_samplerate;
+extern int psp_audio_enabled;
+extern int psp_audio_multithreaded;
+extern int psp_audio_cachesize;
+extern int psp_midi_enabled;
+extern int psp_midi_preload_patches;
+
+extern int psp_video_framedrop;
+
+extern int psp_gfx_renderer;
+extern int psp_gfx_super_sampling;
+extern int psp_gfx_smooth_sprites;
+
+extern int psp_debug_write_to_logcat;
+
+extern int config_mouse_longclick;
+
+extern int display_fps;
+
+#endif

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -39,11 +39,6 @@ extern int main(int argc,char*argv[]);
 char psp_game_file_name[256];
 char* psp_game_file_name_pointer = psp_game_file_name;
 
-bool psp_load_latest_savegame = false;
-extern char saveGameDirectory[260];
-extern const char *loadSaveGameOnStartup;
-char lastSaveGameName[200];
-
 const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
 const int CONFIG_AUDIO_RATE = 2;
@@ -297,44 +292,6 @@ int getAvailableTranslations(char* translations)
   return i;
 }
 */
-
-
-
-
-void selectLatestSavegame()
-{
-  DIR* dir;
-  struct dirent* entry;
-  struct stat statBuffer;
-  char buffer[200];
-  time_t lastTime = 0;
-
-  dir = opendir(saveGameDirectory);
-
-  if (dir)
-  {
-    while ((entry = readdir(dir)) != 0)
-    {
-      if (ags_strnicmp(entry->d_name, "agssave", 7) == 0)
-      {
-        if (ags_stricmp(entry->d_name, "agssave.999") != 0)
-        {
-          strcpy(buffer, saveGameDirectory);
-          strcat(buffer, entry->d_name);
-          stat(buffer, &statBuffer);
-          if (statBuffer.st_mtime > lastTime)
-          {
-            strcpy(lastSaveGameName, buffer);
-            loadSaveGameOnStartup = lastSaveGameName;
-            lastTime = statBuffer.st_mtime;
-          }
-        }
-      }
-    }
-    closedir(dir);
-  }
-}
-
 
 extern void ios_show_message_box(char* buffer);
 volatile int ios_wait_for_ui = 0;

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "core/platform.h"
 
 #if AGS_PLATFORM_OS_IOS
@@ -23,6 +22,7 @@
 
 #include <allegro.h>
 #include "platform/base/agsplatformdriver.h"
+#include "platform/base/mobile_base.h"
 #include "ac/runtime_defines.h"
 #include "main/config.h"
 #include "plugin/agsplugin.h"
@@ -34,48 +34,6 @@ using namespace AGS::Common;
 
 extern char* ios_document_directory;
 
-bool ReadConfiguration(char* filename, bool read_everything);
-void ResetConfiguration();
-
-//int psp_return_to_menu = 1;
-int psp_ignore_acsetup_cfg_file = 1;
-int psp_clear_cache_on_room_change = 0;
-int psp_rotation = 0;
-int psp_config_enabled = 0;
-char psp_translation[100];
-char* psp_translations[100];
-
-// Mouse option from Allegro.
-extern int config_mouse_control_mode;
-
-
-// Graphic options from the Allegro library.
-extern int psp_gfx_scaling;
-extern int psp_gfx_smoothing;
-
-
-// Audio options from the Allegro library.
-unsigned int psp_audio_samplerate = 44100;
-int psp_audio_enabled = 1;
-volatile int psp_audio_multithreaded = 1;
-int psp_audio_cachesize = 10;
-int psp_midi_enabled = 1;
-int psp_midi_preload_patches = 0;
-
-int psp_video_framedrop = 0;
-
-int psp_gfx_renderer = 0;
-int psp_gfx_super_sampling = 0;
-int psp_gfx_smooth_sprites = 0;
-
-int psp_debug_write_to_logcat = 0;
-
-int config_mouse_longclick = 0;
-
-extern int display_fps;
-extern int want_exit;
-extern void PauseGame();
-extern void UnPauseGame();
 extern int main(int argc,char*argv[]);
 
 char psp_game_file_name[256];
@@ -85,8 +43,6 @@ bool psp_load_latest_savegame = false;
 extern char saveGameDirectory[260];
 extern const char *loadSaveGameOnStartup;
 char lastSaveGameName[200];
-
-bool reset_configuration = false;
 
 const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
@@ -127,7 +83,7 @@ struct AGSIOS : AGSPlatformDriver {
 
 
 
-bool readConfigFile(char* directory)
+bool readConfigFile(const char* directory)
 {
   chdir(directory);
 
@@ -139,51 +95,7 @@ bool readConfigFile(char* directory)
 
 bool writeConfigFile()
 {
-  FILE* config = fopen(IOS_CONFIG_FILENAME, "wb");
-  if (config)
-  {
-    fprintf(config, "[misc]\n");
-    fprintf(config, "config_enabled = %d\n", psp_config_enabled);
-    fprintf(config, "rotation = %d\n", psp_rotation);
-    fprintf(config, "translation = %s\n", psp_translation);
-
-    fprintf(config, "[controls]\n");
-    fprintf(config, "mouse_method = %d\n", config_mouse_control_mode);
-    fprintf(config, "mouse_longclick = %d\n", config_mouse_longclick);
-	
-    fprintf(config, "[compatibility]\n");
-    fprintf(config, "clear_cache_on_room_change = %d\n", psp_clear_cache_on_room_change);
-
-    fprintf(config, "[sound]\n");
-    fprintf(config, "samplerate = %d\n", psp_audio_samplerate );
-    fprintf(config, "enabled = %d\n", psp_audio_enabled);
-    fprintf(config, "threaded = %d\n", psp_audio_multithreaded);
-    fprintf(config, "cache_size = %d\n", psp_audio_cachesize);
-    
-    fprintf(config, "[midi]\n");
-    fprintf(config, "enabled = %d\n", psp_midi_enabled);
-    fprintf(config, "preload_patches = %d\n", psp_midi_preload_patches);
-
-    fprintf(config, "[video]\n");
-    fprintf(config, "framedrop = %d\n", psp_video_framedrop);
-
-    fprintf(config, "[graphics]\n");
-    fprintf(config, "renderer = %d\n", psp_gfx_renderer);
-    fprintf(config, "smoothing = %d\n", psp_gfx_smoothing);
-    fprintf(config, "scaling = %d\n", psp_gfx_scaling);
-    fprintf(config, "super_sampling = %d\n", psp_gfx_super_sampling);
-    fprintf(config, "smooth_sprites = %d\n", psp_gfx_smooth_sprites);
-
-    fprintf(config, "[debug]\n");
-    fprintf(config, "show_fps = %d\n", (display_fps == 2) ? 1 : 0);
-    fprintf(config, "logging = %d\n", psp_debug_write_to_logcat);
-
-    fclose(config);
-
-    return true;
-  }
-
-  return false;
+  return WriteConfiguration(IOS_CONFIG_FILENAME);
 }
 
 
@@ -339,7 +251,7 @@ void setIntConfigValue(int id, int value)
 }
 
 
-void setStringConfigValue(int id, char* value)
+void setStringConfigValue(int id, const char* value)
 {
   switch (id)
   {
@@ -422,110 +334,6 @@ void selectLatestSavegame()
     closedir(dir);
   }
 }
-
-
-int ReadInteger(int* variable, const ConfigTree &cfg, char* section, char* name, int minimum, int maximum, int default_value)
-{
-  if (reset_configuration)
-  {
-    *variable = default_value;
-    return 0;
-  }
-
-  int temp = INIreadint(cfg, section, name);
-
-  if (temp == -1)
-    return 0;
-
-  if ((temp < minimum) || (temp > maximum))
-    temp = default_value;
-
-  *variable = temp;
-
-  return 1;
-}
-
-
-
-int ReadString(char* variable, const ConfigTree &cfg, char* section, char* name, char* default_value)
-{
-  if (reset_configuration)
-  {
-    strcpy(variable, default_value);
-    return 0;
-  }
-
-  String temp;
-  if (!INIreaditem(cfg, section, name, temp))
-    temp = default_value;
-
-  strcpy(variable, temp);
-
-  return 1;
-}
-
-
-
-void ResetConfiguration()
-{
-  reset_configuration = true;
-
-  ReadConfiguration(IOS_CONFIG_FILENAME, true);
-
-  reset_configuration = false;
-}
-
-
-bool ReadConfiguration(char* filename, bool read_everything)
-{
-  ConfigTree cfg;
-  if (IniUtil::Read(filename, cfg) || reset_configuration)
-  {
-//    ReadInteger((int*)&psp_disable_powersaving, "misc", "disable_power_saving", 0, 1, 1);
-
-//    ReadInteger((int*)&psp_return_to_menu, "misc", "return_to_menu", 0, 1, 1);
-
-    ReadString(&psp_translation[0], cfg, "misc", "translation", "default");
-
-    ReadInteger((int*)&psp_config_enabled, cfg, "misc", "config_enabled", 0, 1, 0);
-    if (!psp_config_enabled && !read_everything)
-      return true;
-
-    ReadInteger(&psp_debug_write_to_logcat, cfg, "debug", "logging", 0, 1, 0);
-    ReadInteger(&display_fps, cfg, "debug", "show_fps", 0, 1, 0);
-    if (display_fps == 1)
-      display_fps = 2;
-
-    ReadInteger((int*)&psp_rotation, cfg, "misc", "rotation", 0, 2, 0);
-
-//    ReadInteger((int*)&psp_ignore_acsetup_cfg_file, "compatibility", "ignore_acsetup_cfg_file", 0, 1, 0);
-    ReadInteger((int*)&psp_clear_cache_on_room_change, cfg, "compatibility", "clear_cache_on_room_change", 0, 1, 0);
-
-    ReadInteger((int*)&psp_audio_samplerate, cfg, "sound", "samplerate", 0, 44100, 44100);
-    ReadInteger((int*)&psp_audio_enabled, cfg, "sound", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_multithreaded, cfg, "sound", "threaded", 0, 1, 1);
-    ReadInteger((int*)&psp_audio_cachesize, cfg, "sound", "cache_size", 1, 50, 10);
-
-    ReadInteger((int*)&psp_midi_enabled, cfg, "midi", "enabled", 0, 1, 1);
-    ReadInteger((int*)&psp_midi_preload_patches, cfg, "midi", "preload_patches", 0, 1, 0);
-
-    ReadInteger((int*)&psp_video_framedrop, cfg, "video", "framedrop", 0, 1, 0);
-
-    ReadInteger((int*)&psp_gfx_renderer, cfg, "graphics", "renderer", 0, 2, 0);
-    ReadInteger((int*)&psp_gfx_smoothing, cfg, "graphics", "smoothing", 0, 1, 1);
-    ReadInteger((int*)&psp_gfx_scaling, cfg, "graphics", "scaling", 0, 2, 1);
-    ReadInteger((int*)&psp_gfx_super_sampling, cfg, "graphics", "super_sampling", 0, 1, 0);
-    ReadInteger((int*)&psp_gfx_smooth_sprites, cfg, "graphics", "smooth_sprites", 0, 1, 0);
-
-    ReadInteger((int*)&config_mouse_control_mode, cfg, "controls", "mouse_method", 0, 1, 0);
-    ReadInteger((int*)&config_mouse_longclick, cfg, "controls", "mouse_longclick", 0, 1, 1);
-
-    return true;
-  }
-
-  return false;
-}
-
 
 
 extern void ios_show_message_box(char* buffer);

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -155,7 +155,7 @@ void WinConfig::Load(const ConfigTree &cfg)
     GameResolution.Width = CfgReadInt(cfg, "gameproperties", "resolution_width", GameResolution.Width);
     GameResolution.Height = CfgReadInt(cfg, "gameproperties", "resolution_height", GameResolution.Height);
     GameColourDepth = CfgReadInt(cfg, "gameproperties", "resolution_bpp", GameColourDepth);
-    LetterboxByDesign = CfgReadInt(cfg, "gameproperties", "legacy_letterbox", 0) != 0;
+    LetterboxByDesign = CfgReadBoolInt(cfg, "gameproperties", "legacy_letterbox", false);
 
     GfxDriverId = CfgReadString(cfg, "graphics", "driver", GfxDriverId);
     GfxFilterId = CfgReadString(cfg, "graphics", "filter", GfxFilterId);
@@ -166,8 +166,8 @@ void WinConfig::Load(const ConfigTree &cfg)
     WinGameFrame = parse_scaling_option(CfgReadString(cfg, "graphics", "game_scale_win"), WinGameFrame);
 
     RefreshRate = CfgReadInt(cfg, "graphics", "refresh", RefreshRate);
-    Windowed = CfgReadInt(cfg, "graphics", "windowed", Windowed ? 1 : 0) != 0;
-    VSync = CfgReadInt(cfg, "graphics", "vsync", VSync ? 1 : 0) != 0;
+    Windowed = CfgReadBoolInt(cfg, "graphics", "windowed", Windowed);
+    VSync = CfgReadBoolInt(cfg, "graphics", "vsync", VSync);
     int locked_render_at_screenres = CfgReadInt(cfg, "gameproperties", "render_at_screenres", -1);
     if (locked_render_at_screenres < 0)
         RenderAtScreenRes = CfgReadInt(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
@@ -176,11 +176,11 @@ void WinConfig::Load(const ConfigTree &cfg)
 
     AntialiasSprites = CfgReadInt(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0) != 0;
 
-    AudioEnabled = CfgReadInt(cfg, "sound", "enabled", AudioEnabled ? 1 : 0) != 0;
+    AudioEnabled = CfgReadBoolInt(cfg, "sound", "enabled", AudioEnabled);
     AudioDriverId = CfgReadString(cfg, "sound", "driver", AudioDriverId);
-    UseVoicePack = CfgReadInt(cfg, "sound", "usespeech", UseVoicePack ? 1 : 0) != 0;
+    UseVoicePack = CfgReadBoolInt(cfg, "sound", "usespeech", UseVoicePack);
 
-    MouseAutoLock = CfgReadInt(cfg, "mouse", "auto_lock", MouseAutoLock ? 1 : 0) != 0;
+    MouseAutoLock = CfgReadBoolInt(cfg, "mouse", "auto_lock", MouseAutoLock);
     MouseSpeed = CfgReadFloat(cfg, "mouse", "speed", 1.f);
     if (MouseSpeed <= 0.f)
         MouseSpeed = 1.f;
@@ -714,11 +714,11 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
     if (!File::TestReadFile("speech.vox"))
         EnableWindow(_hUseVoicePack, FALSE);
 
-    if (CfgReadInt(_cfgIn, "disabled", "speechvox", 0) != 0)
+    if (CfgReadBoolInt(_cfgIn, "disabled", "speechvox"))
         EnableWindow(_hUseVoicePack, FALSE);
-    if (CfgReadInt(_cfgIn, "disabled", "filters", 0) != 0)
+    if (CfgReadBoolInt(_cfgIn, "disabled", "filters"))
         EnableWindow(_hGfxFilterList, FALSE);
-    if (CfgReadInt(_cfgIn, "disabled", "render_at_screenres", 0) != 0 ||
+    if (CfgReadBoolInt(_cfgIn, "disabled", "render_at_screenres") ||
         CfgReadInt(_cfgIn, "gameproperties", "render_at_screenres", -1) >= 0)
         EnableWindow(_hRenderAtScreenRes, FALSE);
 
@@ -1004,7 +1004,7 @@ void WinSetupDialog::FillGfxFilterList()
     for (size_t i = 0; i < _drvDesc->FilterList.size(); ++i)
     {
         const GfxFilterInfo &info = _drvDesc->FilterList[i];
-        if (CfgReadInt(_cfgIn, "disabled", info.Id, 0) == 0)
+        if (CfgReadBoolInt(_cfgIn, "disabled", info.Id))
             AddString(_hGfxFilterList, STR(info.Name), (DWORD_PTR)info.Id.GetCStr());
     }
 

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -145,80 +145,80 @@ void WinConfig::SetDefaults()
 
 void WinConfig::Load(const ConfigTree &cfg)
 {
-    DataDirectory = INIreadstring(cfg, "misc", "datadir", DataDirectory);
-    UserSaveDir = INIreadstring(cfg, "misc", "user_data_dir");
-    AppDataDir = INIreadstring(cfg, "misc", "shared_data_dir");
+    DataDirectory = CfgReadString(cfg, "misc", "datadir", DataDirectory);
+    UserSaveDir = CfgReadString(cfg, "misc", "user_data_dir");
+    AppDataDir = CfgReadString(cfg, "misc", "shared_data_dir");
     // Backward-compatible resolution type
-    GameResType = (GameResolutionType)INIreadint(cfg, "gameproperties", "legacy_resolution", GameResType);
+    GameResType = (GameResolutionType)CfgReadInt(cfg, "gameproperties", "legacy_resolution", GameResType);
     if (GameResType < kGameResolution_Undefined || GameResType >= kNumGameResolutions)
         GameResType = kGameResolution_Undefined;
-    GameResolution.Width = INIreadint(cfg, "gameproperties", "resolution_width", GameResolution.Width);
-    GameResolution.Height = INIreadint(cfg, "gameproperties", "resolution_height", GameResolution.Height);
-    GameColourDepth = INIreadint(cfg, "gameproperties", "resolution_bpp", GameColourDepth);
-    LetterboxByDesign = INIreadint(cfg, "gameproperties", "legacy_letterbox", 0) != 0;
+    GameResolution.Width = CfgReadInt(cfg, "gameproperties", "resolution_width", GameResolution.Width);
+    GameResolution.Height = CfgReadInt(cfg, "gameproperties", "resolution_height", GameResolution.Height);
+    GameColourDepth = CfgReadInt(cfg, "gameproperties", "resolution_bpp", GameColourDepth);
+    LetterboxByDesign = CfgReadInt(cfg, "gameproperties", "legacy_letterbox", 0) != 0;
 
-    GfxDriverId = INIreadstring(cfg, "graphics", "driver", GfxDriverId);
-    GfxFilterId = INIreadstring(cfg, "graphics", "filter", GfxFilterId);
-    FsSetup = parse_window_mode(INIreadstring(cfg, "graphics", "fullscreen", "default"), false);
-    WinSetup = parse_window_mode(INIreadstring(cfg, "graphics", "window", "default"), true);
+    GfxDriverId = CfgReadString(cfg, "graphics", "driver", GfxDriverId);
+    GfxFilterId = CfgReadString(cfg, "graphics", "filter", GfxFilterId);
+    FsSetup = parse_window_mode(CfgReadString(cfg, "graphics", "fullscreen", "default"), false);
+    WinSetup = parse_window_mode(CfgReadString(cfg, "graphics", "window", "default"), true);
 
-    FsGameFrame = parse_scaling_option(INIreadstring(cfg, "graphics", "game_scale_fs"), FsGameFrame);
-    WinGameFrame = parse_scaling_option(INIreadstring(cfg, "graphics", "game_scale_win"), WinGameFrame);
+    FsGameFrame = parse_scaling_option(CfgReadString(cfg, "graphics", "game_scale_fs"), FsGameFrame);
+    WinGameFrame = parse_scaling_option(CfgReadString(cfg, "graphics", "game_scale_win"), WinGameFrame);
 
-    RefreshRate = INIreadint(cfg, "graphics", "refresh", RefreshRate);
-    Windowed = INIreadint(cfg, "graphics", "windowed", Windowed ? 1 : 0) != 0;
-    VSync = INIreadint(cfg, "graphics", "vsync", VSync ? 1 : 0) != 0;
-    int locked_render_at_screenres = INIreadint(cfg, "gameproperties", "render_at_screenres", -1);
+    RefreshRate = CfgReadInt(cfg, "graphics", "refresh", RefreshRate);
+    Windowed = CfgReadInt(cfg, "graphics", "windowed", Windowed ? 1 : 0) != 0;
+    VSync = CfgReadInt(cfg, "graphics", "vsync", VSync ? 1 : 0) != 0;
+    int locked_render_at_screenres = CfgReadInt(cfg, "gameproperties", "render_at_screenres", -1);
     if (locked_render_at_screenres < 0)
-        RenderAtScreenRes = INIreadint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
+        RenderAtScreenRes = CfgReadInt(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0) != 0;
     else
         RenderAtScreenRes = locked_render_at_screenres != 0;
 
-    AntialiasSprites = INIreadint(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0) != 0;
+    AntialiasSprites = CfgReadInt(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0) != 0;
 
-    AudioEnabled = INIreadint(cfg, "sound", "enabled", AudioEnabled ? 1 : 0) != 0;
-    AudioDriverId = INIreadstring(cfg, "sound", "driver", AudioDriverId);
-    UseVoicePack = INIreadint(cfg, "sound", "usespeech", UseVoicePack ? 1 : 0) != 0;
+    AudioEnabled = CfgReadInt(cfg, "sound", "enabled", AudioEnabled ? 1 : 0) != 0;
+    AudioDriverId = CfgReadString(cfg, "sound", "driver", AudioDriverId);
+    UseVoicePack = CfgReadInt(cfg, "sound", "usespeech", UseVoicePack ? 1 : 0) != 0;
 
-    MouseAutoLock = INIreadint(cfg, "mouse", "auto_lock", MouseAutoLock ? 1 : 0) != 0;
-    MouseSpeed = INIreadfloat(cfg, "mouse", "speed", 1.f);
+    MouseAutoLock = CfgReadInt(cfg, "mouse", "auto_lock", MouseAutoLock ? 1 : 0) != 0;
+    MouseSpeed = CfgReadFloat(cfg, "mouse", "speed", 1.f);
     if (MouseSpeed <= 0.f)
         MouseSpeed = 1.f;
 
-    SpriteCacheSize = INIreadint(cfg, "misc", "cachemax", SpriteCacheSize);
-    Language = INIreadstring(cfg, "language", "translation", Language);
-    DefaultLanguageName = INIreadstring(cfg, "language", "default_translation_name", DefaultLanguageName);
+    SpriteCacheSize = CfgReadInt(cfg, "misc", "cachemax", SpriteCacheSize);
+    Language = CfgReadString(cfg, "language", "translation", Language);
+    DefaultLanguageName = CfgReadString(cfg, "language", "default_translation_name", DefaultLanguageName);
 
-    Title = INIreadstring(cfg, "misc", "titletext", Title);
+    Title = CfgReadString(cfg, "misc", "titletext", Title);
 }
 
 void WinConfig::Save(ConfigTree &cfg, const Size &desktop_res)
 {
-    INIwritestring(cfg, "misc", "user_data_dir", UserSaveDir);
-    INIwritestring(cfg, "misc", "shared_data_dir", AppDataDir);
+    CfgWriteString(cfg, "misc", "user_data_dir", UserSaveDir);
+    CfgWriteString(cfg, "misc", "shared_data_dir", AppDataDir);
 
-    INIwritestring(cfg, "graphics", "driver", GfxDriverId);
-    INIwritestring(cfg, "graphics", "filter", GfxFilterId);
-    INIwritestring(cfg, "graphics", "fullscreen", make_window_mode_option(FsSetup, GameResolution, desktop_res));
-    INIwritestring(cfg, "graphics", "window", make_window_mode_option(WinSetup, GameResolution, desktop_res));
-    INIwritestring(cfg, "graphics", "game_scale_fs", make_scaling_option(FsGameFrame));
-    INIwritestring(cfg, "graphics", "game_scale_win", make_scaling_option(WinGameFrame));
-    INIwriteint(cfg, "graphics", "refresh", RefreshRate);
-    INIwriteint(cfg, "graphics", "windowed", Windowed ? 1 : 0);
-    INIwriteint(cfg, "graphics", "vsync", VSync ? 1 : 0);
-    INIwriteint(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0);
+    CfgWriteString(cfg, "graphics", "driver", GfxDriverId);
+    CfgWriteString(cfg, "graphics", "filter", GfxFilterId);
+    CfgWriteString(cfg, "graphics", "fullscreen", make_window_mode_option(FsSetup, GameResolution, desktop_res));
+    CfgWriteString(cfg, "graphics", "window", make_window_mode_option(WinSetup, GameResolution, desktop_res));
+    CfgWriteString(cfg, "graphics", "game_scale_fs", make_scaling_option(FsGameFrame));
+    CfgWriteString(cfg, "graphics", "game_scale_win", make_scaling_option(WinGameFrame));
+    CfgWriteInt(cfg, "graphics", "refresh", RefreshRate);
+    CfgWriteInt(cfg, "graphics", "windowed", Windowed ? 1 : 0);
+    CfgWriteInt(cfg, "graphics", "vsync", VSync ? 1 : 0);
+    CfgWriteInt(cfg, "graphics", "render_at_screenres", RenderAtScreenRes ? 1 : 0);
 
-    INIwriteint(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0);
+    CfgWriteInt(cfg, "misc", "antialias", AntialiasSprites ? 1 : 0);
 
-    INIwriteint(cfg, "sound", "enabled", AudioEnabled ? 1 : 0);
-    INIwritestring(cfg, "sound", "driver", AudioDriverId);
-    INIwriteint(cfg, "sound", "usespeech", UseVoicePack ? 1 : 0);
+    CfgWriteInt(cfg, "sound", "enabled", AudioEnabled ? 1 : 0);
+    CfgWriteString(cfg, "sound", "driver", AudioDriverId);
+    CfgWriteInt(cfg, "sound", "usespeech", UseVoicePack ? 1 : 0);
 
-    INIwriteint(cfg, "mouse", "auto_lock", MouseAutoLock ? 1 : 0);
-    INIwritestring(cfg, "mouse", "speed", String::FromFormat("%0.1f", MouseSpeed));
+    CfgWriteInt(cfg, "mouse", "auto_lock", MouseAutoLock ? 1 : 0);
+    CfgWriteFloat(cfg, "mouse", "speed", MouseSpeed, 1);
 
-    INIwriteint(cfg, "misc", "cachemax", SpriteCacheSize);
-    INIwritestring(cfg, "language", "translation", Language);
+    CfgWriteInt(cfg, "misc", "cachemax", SpriteCacheSize);
+    CfgWriteString(cfg, "language", "translation", Language);
 }
 
 
@@ -714,12 +714,12 @@ INT_PTR WinSetupDialog::OnInitDialog(HWND hwnd)
     if (!File::TestReadFile("speech.vox"))
         EnableWindow(_hUseVoicePack, FALSE);
 
-    if (INIreadint(_cfgIn, "disabled", "speechvox", 0) != 0)
+    if (CfgReadInt(_cfgIn, "disabled", "speechvox", 0) != 0)
         EnableWindow(_hUseVoicePack, FALSE);
-    if (INIreadint(_cfgIn, "disabled", "filters", 0) != 0)
+    if (CfgReadInt(_cfgIn, "disabled", "filters", 0) != 0)
         EnableWindow(_hGfxFilterList, FALSE);
-    if (INIreadint(_cfgIn, "disabled", "render_at_screenres", 0) != 0 ||
-        INIreadint(_cfgIn, "gameproperties", "render_at_screenres", -1) >= 0)
+    if (CfgReadInt(_cfgIn, "disabled", "render_at_screenres", 0) != 0 ||
+        CfgReadInt(_cfgIn, "gameproperties", "render_at_screenres", -1) >= 0)
         EnableWindow(_hRenderAtScreenRes, FALSE);
 
     RECT win_rect, gfx_rect, adv_rect, border;
@@ -1004,7 +1004,7 @@ void WinSetupDialog::FillGfxFilterList()
     for (size_t i = 0; i < _drvDesc->FilterList.size(); ++i)
     {
         const GfxFilterInfo &info = _drvDesc->FilterList[i];
-        if (INIreadint(_cfgIn, "disabled", info.Id, 0) == 0)
+        if (CfgReadInt(_cfgIn, "disabled", info.Id, 0) == 0)
             AddString(_hGfxFilterList, STR(info.Name), (DWORD_PTR)info.Id.GetCStr());
     }
 


### PR DESCRIPTION
Resolves #104.

* Reorganized config reading and writing functions, added read parameters used by other platforms (such as min/max value range).
* Moved common config management from Android and iOS into a file called "mobile_base.cpp". I noticed that both platforms host and read exactly same options, so there's no reason to have duplicate code. Made sure this code uses common cfg read/write functions.
* Reorganized platform-dependent file lists in CMakeList.txt, to have all non-common code under os condition. I am not well versed in cmake yet, so if this is wrong, i may return things back.
* Not related to config, but i noticed that selectLatestSavegame may be replaced by common functions too. If wanted, this could be done as a separate pr.

Potential todo:
* remove unused options (i noticed both Android and iOS were still using deprecated options, some refering Allegro backend). But this will require also adjusting them in corresponding java/objective-c parts.
* there's also getAvailableTranslations function that may be reimplemented using available engine's utilities, but maybe it's too much for this pr.