### PR TITLE
Editor: feature recreating full spritefile from sources

### DIFF
--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -186,7 +186,9 @@ public:
     // Get the sprite index, accumulated after write
     const SpriteFileIndex &GetIndex() const { return _index; }
 
-    // Initializes new sprite file format
+    // Initializes new sprite file format;
+    // store_flags are SpriteStorage;
+    // optionally hint how many sprites will be written.
     void Begin(int store_flags, SpriteCompression compress, sprkey_t last_slot = -1);
     // Writes a bitmap into file, compressing if necessary
     void WriteBitmap(Bitmap *image);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -986,7 +986,7 @@ namespace AGS.Editor
             return dialogScripts;
         }
 
-        private object CompileScripts(object parameter)
+        private object CompileScripts(IWorkProgress progress, object parameter)
         {
             CompileScriptsParameters parameters = (CompileScriptsParameters)parameter;
             CompileMessages errors = parameters.Errors;
@@ -1069,7 +1069,7 @@ namespace AGS.Editor
             }
         }
 
-        private object CreateCompiledFiles(object parameter)
+        private object CreateCompiledFiles(IWorkProgress progress, object parameter)
         {
             CompileScriptsParameters parameters = (CompileScriptsParameters)parameter;
             CompileMessages errors = parameters.Errors;
@@ -1651,7 +1651,7 @@ namespace AGS.Editor
             }
         }
 
-        private object SaveGameFilesProcess(object parameter)
+        private object SaveGameFilesProcess(IWorkProgress progress, object parameter)
         {
 			WriteConfigFile(Path.Combine(OUTPUT_DIRECTORY, DATA_OUTPUT_DIRECTORY));
 

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
@@ -40,7 +40,7 @@ namespace AGS.Editor
             Utilities.TryDeleteFile(filename);
         }
 
-        private object CreateDebugFiles(object parameter)
+        private object CreateDebugFiles(IWorkProgress progress, object parameter)
         {
             Factory.AGSEditor.SetMODMusicFlag();
             CompileMessages errors = (parameter as CompileMessages);

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -198,7 +198,7 @@ namespace AGS.Editor.Components
 
         private object RecreateSpriteFileProcess(IWorkProgress progress, object parameter)
         {
-            Utils.SpriteTools.WriteSpriteFileFromSources((string)parameter);
+            Utils.SpriteTools.WriteSpriteFileFromSources((string)parameter, progress);
             return null;
         }
 

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -196,7 +196,7 @@ namespace AGS.Editor.Components
             _guiController.SetMenuItemEnabled(this, REMOVE_GLOBAL_MESSAGES_COMMAND, false);
         }
 
-        private object RecreateSpriteFileProcess(object parameter)
+        private object RecreateSpriteFileProcess(IWorkProgress progress, object parameter)
         {
             Utils.SpriteTools.WriteSpriteFileFromSources((string)parameter);
             return null;

--- a/Editor/AGS.Editor/Components/FileCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/FileCommandsComponent.cs
@@ -152,7 +152,7 @@ namespace AGS.Editor.Components
             {
                 if (_guiController.ShowQuestion("This will recreate game's spritefile using sprite source files if they are available. All sprites will be updated from their sources.\n\nNOTE: sprites that don't have source file references, or which source files are missing, - will remain untouched.\n\nAre you sure you want to do this?") == DialogResult.Yes)
                 {
-                    RecreateSpriteFileFromSources();
+                    Tasks.RecreateSpriteFileFromSources();
                 }
             }
             else if (controlID == SHOW_PREFERENCES_COMMAND)
@@ -194,30 +194,6 @@ namespace AGS.Editor.Components
 
             _guiController.ShowMessage(messagesRemoved.ToString() + " Global Messages were removed.", MessageBoxIcon.Information);
             _guiController.SetMenuItemEnabled(this, REMOVE_GLOBAL_MESSAGES_COMMAND, false);
-        }
-
-        private object RecreateSpriteFileProcess(IWorkProgress progress, object parameter)
-        {
-            Utils.SpriteTools.WriteSpriteFileFromSources((string)parameter, progress);
-            return null;
-        }
-
-        private void RecreateSpriteFileFromSources()
-        {
-            string tempFilename;
-            try
-            {
-                tempFilename = Path.GetTempFileName();
-                BusyDialog.Show("Please wait while the sprite file is recreated...", new BusyDialog.ProcessingHandler(RecreateSpriteFileProcess), tempFilename);
-            }
-            catch(Exception e)
-            {
-                _guiController.ShowMessage("The recreation of a sprite file was interrupted by error. NO CHANGES were applied to your game.\n\n" + e.Message, MessageBoxIcon.Error);
-                return;
-            }
-
-            Factory.NativeProxy.ReplaceSpriteFile(tempFilename);
-            File.Delete(tempFilename);
         }
 
         private int CountSprites(SpriteFolder folder)

--- a/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/HelpCommandsComponent.cs
@@ -216,7 +216,7 @@ namespace AGS.Editor.Components
             System.Diagnostics.Process.Start(url);
         }
 
-        private object DownloadUpdateStatusThread(object parameter)
+        private object DownloadUpdateStatusThread(IWorkProgress progress, object parameter)
         {
             using (System.Net.WebClient webClient = new System.Net.WebClient())
             {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -610,7 +610,7 @@ namespace AGS.Editor.Components
             room.GameID = _agsEditor.CurrentGame.Settings.UniqueID;
         }
 
-        private object SaveRoomOnThread(object parameter)
+        private object SaveRoomOnThread(IWorkProgress progress, object parameter)
         {            
             Room room = (Room)parameter;
             _agsEditor.RegenerateScriptHeader(room);

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -170,7 +170,7 @@ namespace AGS.Editor.Components
             }
         }
 
-        private object UpdateTranslationsProcess(object translationList)
+        private object UpdateTranslationsProcess(IWorkProgress progress, object translationList)
         {
             List<Translation> translations = (List<Translation>)translationList;
             TranslationGenerator generator = new TranslationGenerator();
@@ -255,7 +255,7 @@ namespace AGS.Editor.Components
             }
         }
 
-        private object ReplaceGameTextWithTranslationProcess(object translationAsObj)
+        private object ReplaceGameTextWithTranslationProcess(IWorkProgress progress, object translationAsObj)
         {
             Translation translation = (Translation)translationAsObj;
             CompileMessages errors = TextImporter.ReplaceAllGameText(_agsEditor.CurrentGame, translation);

--- a/Editor/AGS.Editor/GUI/ExceptionDialog.cs
+++ b/Editor/AGS.Editor/GUI/ExceptionDialog.cs
@@ -61,7 +61,7 @@ namespace AGS.Editor
             return Convert.ToBase64String(serializedImage);
         }
 
-        private object SendErrorReportThread(object parameter)
+        private object SendErrorReportThread(IWorkProgress progress, object parameter)
         {
             string exceptionText = "AGSVersion: " + AGS.Types.Version.AGS_EDITOR_VERSION +
                 Environment.NewLine + "WinVer: " + Environment.OSVersion.VersionString +

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -1222,7 +1222,7 @@ namespace AGS.Editor
             dialog.Dispose();
         }
 
-        private object AutoNumberSpeechLinesProcess(object parameter)
+        private object AutoNumberSpeechLinesProcess(IWorkProgress progress, object parameter)
         {
             AutoNumberSpeechData data = (AutoNumberSpeechData)parameter;
             bool doNarrator = (data.Options & AutoNumberSpeechOptions.DoNarrator) != 0;
@@ -1231,7 +1231,7 @@ namespace AGS.Editor
             return new SpeechLinesNumbering().NumberSpeechLines(_agsEditor.CurrentGame, doNarrator, combineIdenticalLines, removeNumbering, data.CharacterID);
         }
 
-		private object CreateVoiceActingScriptProcess(object parameter)
+		private object CreateVoiceActingScriptProcess(IWorkProgress progress, object parameter)
 		{
 			string outputFile = (string)parameter;
 			VoiceActorScriptGenerator generator = new VoiceActorScriptGenerator();

--- a/Editor/AGS.Editor/InteractiveTasks.cs
+++ b/Editor/AGS.Editor/InteractiveTasks.cs
@@ -101,7 +101,7 @@ namespace AGS.Editor
             BusyDialog.Show("Please wait while the template is created...", new BusyDialog.ProcessingHandler(CreateTemplateFromCurrentGameProcess), templateFileName);
         }
 
-        private object CreateTemplateFromCurrentGameProcess(object templateFileName)
+        private object CreateTemplateFromCurrentGameProcess(IWorkProgress progress, object templateFileName)
         {
             _tasks.CreateTemplateFromCurrentGame((string)templateFileName);
             return null;

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -85,6 +85,14 @@ namespace AGS.Editor
 			}
         }
 
+        public void ReplaceSpriteFile(string srcFilename)
+        {
+            lock (_spriteSetLock)
+            {
+                _native.ReplaceSpriteFile(srcFilename);
+            }
+        }
+
         public void DrawGUI(IntPtr hdc, int x, int y, GUI gui, int resolutionFactor, float scale, int selectedControl)
         {
             _native.DrawGUI((int)hdc, x, y, gui, resolutionFactor, scale, selectedControl);

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -83,7 +83,7 @@ namespace AGS.Editor
             {
                 Factory.Events.OnGameSettingsChanged();
                 BusyDialog.Show("Please wait while we convert game files to the new text format...",
-                    (o) => {
+                    (IWorkProgress progress, object o) => {
                         Factory.AGSEditor.Tasks.ConvertAllGameTexts(
                             Types.Utilities.EncodingFromName(oldFormat),
                             Types.Utilities.EncodingFromName(newFormat));

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -980,7 +980,7 @@ namespace AGS.Editor
             throw new AGSEditorException("No default application registered to handle file type " + extension);
         }
 
-        private object LaunchImageEditorThread(object parameter)
+        private object LaunchImageEditorThread(IWorkProgress progress, object parameter)
         {
             string fileName = (string)parameter;
             Process imageEditor = new Process();

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -122,7 +122,15 @@ namespace AGS.Editor
             else
             {
                 Factory.AGSEditor.LoadGameFile(gameToLoad);
-                Factory.NativeProxy.LoadNewSpriteFile();
+                try
+                {
+                    Factory.NativeProxy.LoadNewSpriteFile();
+                }
+                catch (Exception e)
+                {
+                    errors.Add(e.Message);
+                    CreateNewSpriteFile();
+                }
                 game = Factory.AGSEditor.CurrentGame;
             }
 
@@ -153,6 +161,14 @@ namespace AGS.Editor
             }
 
             return false;
+        }
+
+        private void CreateNewSpriteFile()
+        {
+            string tempFilename = Path.GetTempFileName();
+            Utils.SpriteTools.WriteDummySpriteFile(tempFilename);
+            Factory.NativeProxy.ReplaceSpriteFile(tempFilename);
+            File.Delete(tempFilename);
         }
 
         private void SetDefaultValuesForNewFeatures(Game game)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -114,6 +114,7 @@ namespace AGS.Editor
             AddFontIfNotAlreadyThere(2);
             Game game = null;
 
+            // Load or import the game itself
             if (gameToLoad.ToLower().EndsWith(".dta"))
             {
                 game = new OldGameImporter().ImportGameFromAGS272(gameToLoad, interactive);
@@ -122,51 +123,88 @@ namespace AGS.Editor
             else
             {
                 Factory.AGSEditor.LoadGameFile(gameToLoad);
-                try
-                {
-                    Factory.NativeProxy.LoadNewSpriteFile();
-                }
-                catch (Exception e)
-                {
-                    errors.Add(e.Message);
-                    CreateNewSpriteFile();
-                }
                 game = Factory.AGSEditor.CurrentGame;
             }
 
-            if (game != null)
+            if (game == null)
+                return false;
+
+            game.DirectoryPath = gameDirectory;
+            SetDefaultValuesForNewFeatures(game);
+            Utilities.EnsureStandardSubFoldersExist();
+
+            // Load the sprite file
+            bool isNewSpriteFile = false;
+            if (!File.Exists(Path.Combine(game.DirectoryPath, AGSEditor.SPRITE_FILE_NAME)))
             {
-                game.DirectoryPath = gameDirectory;
-                SetDefaultValuesForNewFeatures(game);
-
-                Utilities.EnsureStandardSubFoldersExist();
-
-                RecentGame recentGame = new RecentGame(game.Settings.GameName, gameDirectory);
-                if (Factory.AGSEditor.Settings.RecentGames.Contains(recentGame))
+                if (Factory.GUIController.ShowQuestion(string.Format("Spriteset file ({0}) was not found. Would you like to try reimport sprites from their sources? Otherwise, we'll generate an empty spritefile.\nNOTE: you may always try reimporting sprites later using respective menu commands.", AGSEditor.SPRITE_FILE_NAME), MessageBoxIcon.Warning)
+                    == DialogResult.Yes)
                 {
-                    Factory.AGSEditor.Settings.RecentGames.Remove(recentGame);
+                    RecreateSpriteFileFromSources();
                 }
-                Factory.AGSEditor.Settings.RecentGames.Insert(0, recentGame);
-
-                Factory.Events.OnGamePostLoad();
-
-                Factory.AGSEditor.RefreshEditorAfterGameLoad(game, errors);
-                if (needToSave)
+                else
                 {
-                    Factory.AGSEditor.SaveGameFiles();
+                    CreateNewSpriteFile();
+                    isNewSpriteFile = true;
                 }
-
-                Factory.AGSEditor.ReportGameLoad(errors);
-                return true;
             }
 
-            return false;
+            try
+            {
+                Factory.NativeProxy.LoadNewSpriteFile();
+            }
+            catch (Exception e)
+            {
+                errors.Add(e.Message);
+                if (!isNewSpriteFile)
+                    CreateNewSpriteFile();
+            }
+
+            // Process after game load operations
+            RecentGame recentGame = new RecentGame(game.Settings.GameName, gameDirectory);
+            if (Factory.AGSEditor.Settings.RecentGames.Contains(recentGame))
+            {
+                Factory.AGSEditor.Settings.RecentGames.Remove(recentGame);
+            }
+            Factory.AGSEditor.Settings.RecentGames.Insert(0, recentGame);
+
+            Factory.Events.OnGamePostLoad();
+
+            Factory.AGSEditor.RefreshEditorAfterGameLoad(game, errors);
+            if (needToSave)
+            {
+                Factory.AGSEditor.SaveGameFiles();
+            }
+
+            Factory.AGSEditor.ReportGameLoad(errors);
+            return true;
         }
 
-        private void CreateNewSpriteFile()
+        public static void CreateNewSpriteFile()
         {
             string tempFilename = Path.GetTempFileName();
             Utils.SpriteTools.WriteDummySpriteFile(tempFilename);
+            Factory.NativeProxy.ReplaceSpriteFile(tempFilename);
+            File.Delete(tempFilename);
+        }
+
+        public static void RecreateSpriteFileFromSources()
+        {
+            string tempFilename;
+            try
+            {
+                tempFilename = Path.GetTempFileName();
+                BusyDialog.Show("Please wait while the sprite file is recreated...",
+                    new BusyDialog.ProcessingHandler(
+                        (IWorkProgress progress, object o) => { Utils.SpriteTools.WriteSpriteFileFromSources((string)o, progress); return null; }),
+                    tempFilename);
+            }
+            catch (Exception e)
+            {
+                Factory.GUIController.ShowMessage("The recreation of a sprite file was interrupted by error. NO CHANGES were applied to your game.\n\n" + e.Message, MessageBoxIcon.Error);
+                return;
+            }
+
             Factory.NativeProxy.ReplaceSpriteFile(tempFilename);
             File.Delete(tempFilename);
         }

--- a/Editor/AGS.Editor/Utils/OldGameImporter.cs
+++ b/Editor/AGS.Editor/Utils/OldGameImporter.cs
@@ -73,7 +73,7 @@ namespace AGS.Editor
             return backupLocation;
         }
 
-        private object ImportOldGameThread(object parameter)
+        private object ImportOldGameThread(IWorkProgress progress, object parameter)
         {
             ImportGameResult result = new ImportGameResult();
             string gameToLoad = (string)parameter;
@@ -85,7 +85,7 @@ namespace AGS.Editor
             return result;
         }
 
-        private object MakeBackupCopyOfGameFolderThread(object backupLocationAsObject)
+        private object MakeBackupCopyOfGameFolderThread(IWorkProgress progress, object backupLocationAsObject)
         {
             string backupLocation = (string)backupLocationAsObject;
             string sourceDir = Path.GetDirectoryName(backupLocation);

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -567,6 +567,24 @@ namespace AGS.Editor.Utils
         }
 
         /// <summary>
+        /// Writes a dummy sprite file with one 1x1 clear sprite at index 0.
+        /// </summary>
+        public static void WriteDummySpriteFile(string filename)
+        {
+            int storeFlags = 0;
+            if (Factory.AGSEditor.CurrentGame.Settings.OptimizeSpriteStorage)
+                storeFlags |= (int)Native.SpriteFileWriter.StorageFlags.OptimizeForSize;
+            var compressSprites = Factory.AGSEditor.CurrentGame.Settings.CompressSpritesType;
+
+            var writer = new Native.SpriteFileWriter(filename);
+            writer.Begin(storeFlags, compressSprites);
+            var bmp = new Bitmap(1, 1);
+            writer.WriteBitmap(bmp);
+            bmp.Dispose();
+            writer.End();
+        }
+
+        /// <summary>
         /// Writes the sprite file, importing all the existing sprites either from the
         /// their sources, or sprite cache, - whatever is present (in that order).
         /// </summary>

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -588,7 +588,7 @@ namespace AGS.Editor.Utils
         /// Writes the sprite file, importing all the existing sprites either from the
         /// their sources, or sprite cache, - whatever is present (in that order).
         /// </summary>
-        public static void WriteSpriteFileFromSources(string filename)
+        public static void WriteSpriteFileFromSources(string filename, IWorkProgress progress)
         {
             int storeFlags = 0;
             if (Factory.AGSEditor.CurrentGame.Settings.OptimizeSpriteStorage)
@@ -599,9 +599,13 @@ namespace AGS.Editor.Utils
             var sprites = folder.GetAllSpritesFromAllSubFolders();
             var orderedSprites = sprites.OrderBy(sprite => sprite.Number);
 
+            progress.Total = orderedSprites.Count();
+            progress.Current = 0;
+
             var writer = new Native.SpriteFileWriter(filename);
             writer.Begin(storeFlags, compressSprites);
             int spriteIndex = 0;
+            int realSprites = 0;
             foreach (Sprite sprite in orderedSprites)
             {
                 // NOTE: we must add empty slots to fill all the gaps in sprite IDs!
@@ -628,6 +632,7 @@ namespace AGS.Editor.Utils
                     writer.WriteBitmap(bmp);
                     bmp.Dispose();
                 }
+                progress.Current = ++realSprites;
                 spriteIndex++;
             }
             writer.End();

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="MSSCCI.cpp" />
     <ClCompile Include="NativeMethods.cpp" />
     <ClCompile Include="ScriptCompiler.cpp" />
+    <ClCompile Include="SpriteFileWriter_NET.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Native\ac\actiontype.h" />
@@ -250,6 +251,7 @@
     <ClInclude Include="NativeMethods.h" />
     <ClInclude Include="NativeUtils.h" />
     <ClInclude Include="Scripting.h" />
+    <ClInclude Include="SpriteFileWriter_NET.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="NativeDLL.rc" />

--- a/Editor/AGS.Native/NativeDLL.vcxproj.filters
+++ b/Editor/AGS.Native/NativeDLL.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="..\scintilla\win32\ScintillaWin.cxx">
       <Filter>Scintilla\win32</Filter>
     </ClCompile>
+    <ClCompile Include="SpriteFileWriter_NET.cpp">
+      <Filter>Header Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="agsnative.h">
@@ -235,6 +238,9 @@
       <Filter>Header Files\ac</Filter>
     </ClInclude>
     <ClInclude Include="NativeUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SpriteFileWriter_NET.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -68,6 +68,7 @@ extern HAGSError extract_room_template_files(const AGSString &templateFileName, 
 extern void change_sprite_number(int oldNumber, int newNumber);
 extern void update_sprite_resolution(int spriteNum, bool isVarRes, bool isHighRes);
 extern void SaveNativeSprites(Settings^ gameSettings);
+extern void ReplaceSpriteFile(const AGSString &new_spritefile, const AGSString &new_indexfile, bool fallback_tempfiles);
 extern HAGSError reset_sprite_file();
 extern void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette);
 extern void GameDirChanged(String ^workingDir);
@@ -236,6 +237,12 @@ namespace AGS
 				throw gcnew AGSEditorException(gcnew String("Unable to load spriteset from ACSPRSET.SPR.\n") + TextHelper::ConvertUTF8(err->FullMessage()));
 			}
 		}
+
+        void NativeMethods::ReplaceSpriteFile(String ^srcFileName)
+        {
+            AGSString temp_filename = TextHelper::ConvertUTF8(srcFileName);
+            ::ReplaceSpriteFile(temp_filename, "", false);
+        }
 
 		void NativeMethods::SaveGame(Game ^game)
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -66,6 +66,7 @@ namespace AGS
             void OnGameFontUpdated(Game^ game, int fontSlot, bool forceUpdate);
 			Dictionary<int,Sprite^>^ LoadAllSpriteDimensions();
 			void LoadNewSpriteFile();
+            void ReplaceSpriteFile(String ^srcFileName);
 			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
 			void SaveRoomFile(Room ^roomToSave);
             void SaveDefaultRoomFile(Room ^roomToSave);

--- a/Editor/AGS.Native/SpriteFileWriter_NET.cpp
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.cpp
@@ -1,0 +1,68 @@
+#include "SpriteFileWriter_NET.h"
+#include <allegro.h>
+#include "NativeUtils.h"
+#include "gfx/bitmap.h"
+#include "util/file.h"
+
+using AGSBitmap = AGS::Common::Bitmap;
+using AGSString = AGS::Common::String;
+using AGSStream = AGS::Common::Stream;
+
+extern AGSBitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, bool fixColourDepth,
+    bool keepTransparency, int *originalColDepth);
+extern AGSBitmap *CreateNativeBitmap(System::Drawing::Bitmap ^bmp, int spriteImportMethod, bool remapColours,
+    bool useRoomBackgroundColours, bool alphaChannel, int *flags);
+extern void pre_save_sprite(AGSBitmap *image);
+
+namespace AGS
+{
+namespace Native
+{
+
+SpriteFileWriter::SpriteFileWriter(System::String ^filename)
+{
+    AGSString fn = TextHelper::ConvertUTF8(filename);
+    std::unique_ptr<AGSStream> out(AGS::Common::File::CreateFile(fn));
+    _nativeWriter = new AGS::Common::SpriteFileWriter(std::move(out));
+}
+
+SpriteFileWriter::~SpriteFileWriter()
+{
+    delete _nativeWriter;
+}
+
+void SpriteFileWriter::Begin(int store_flags, AGS::Types::SpriteCompression compress)
+{
+    _nativeWriter->Begin(store_flags, (AGS::Common::SpriteCompression)compress);
+}
+
+void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image)
+{
+    RGB imgPalBuf[256];
+    int importedColourDepth;
+    std::unique_ptr<AGSBitmap> native_bmp(CreateBlockFromBitmap(image, imgPalBuf, true, true, &importedColourDepth));
+    pre_save_sprite(native_bmp.get()); // RGB swaps
+    _nativeWriter->WriteBitmap(native_bmp.get());
+}
+
+void SpriteFileWriter::WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::SpriteImportTransparency transparency,
+    bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
+{
+    std::unique_ptr<AGSBitmap> native_bmp(CreateNativeBitmap(image, (int)transparency, remapColours,
+        useRoomBackgroundColours, alphaChannel, nullptr));
+    pre_save_sprite(native_bmp.get()); // RGB swaps
+    _nativeWriter->WriteBitmap(native_bmp.get());
+}
+
+void SpriteFileWriter::WriteEmptySlot()
+{
+    _nativeWriter->WriteEmptySlot();
+}
+
+void SpriteFileWriter::End()
+{
+    _nativeWriter->Finalize();
+}
+
+} // namespace Native
+} // namespace AGS

--- a/Editor/AGS.Native/SpriteFileWriter_NET.h
+++ b/Editor/AGS.Native/SpriteFileWriter_NET.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include "ac/spritefile.h"
+
+namespace AGS
+{
+namespace Native
+{
+
+public ref class SpriteFileWriter
+{
+public:
+    enum class StorageFlags
+    {
+        OptimizeForSize = 0x01
+    };
+
+    SpriteFileWriter(System::String ^filename);
+    ~SpriteFileWriter();
+
+    // Initializes new sprite file with the given settings
+    void Begin(int store_flags, AGS::Types::SpriteCompression compress);
+    // Writes bitmap into the file without any additional convertions
+    void WriteBitmap(System::Drawing::Bitmap ^image);
+    // Converts bitmap according to the sprite's properties, and writes into the file
+    void WriteBitmap(System::Drawing::Bitmap ^image, AGS::Types::SpriteImportTransparency transparency,
+        bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
+    // Writes an empty slot marker
+    void WriteEmptySlot();
+    // Finalizes current format; no further writing is possible after this
+    void End();
+
+private:
+    AGS::Common::SpriteFileWriter *_nativeWriter = nullptr;
+};
+
+} // namespace Native
+} // namespace AGS

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1893,6 +1893,49 @@ void PutNewSpritefileIntoProject(const AGSString &temp_spritefile, const AGSStri
     }
 }
 
+void ReplaceSpriteFile(const AGSString &new_spritefile, const AGSString &new_indexfile, bool fallback_tempfiles)
+{
+    AGSString use_spritefile = sprsetname;
+    AGSString use_indexfile = sprindexname;
+
+    Exception ^main_exception;
+    try
+    {
+        PutNewSpritefileIntoProject(new_spritefile, new_indexfile);
+    }
+    catch (Exception ^e)
+    {
+        main_exception = e;
+        if (fallback_tempfiles)
+        {
+            use_spritefile = new_spritefile;
+            use_indexfile = new_indexfile;
+        }
+    }
+    finally
+    {
+        // Reset the sprite cache to whichever file was successfully saved
+        HAGSError err = spriteset.InitFile(use_spritefile, use_indexfile);
+        if (!err)
+        {
+            throw gcnew AGSEditorException(
+                String::Format("Unable to re-initialize sprite file after save.{0}{1}",
+                    Environment::NewLine, gcnew String(err->FullMessage().GetCStr())), main_exception);
+        }
+        else if (main_exception != nullptr)
+        {
+            if (fallback_tempfiles)
+                throw gcnew AGSEditorException(
+                    String::Format("Unable to save sprites in your project folder. The sprites were saved to a temporary location:{0}{1}",
+                        Environment::NewLine, TextHelper::ConvertUTF8(use_spritefile)), main_exception);
+            else
+                throw gcnew AGSEditorException(
+                    String::Format("Unable to save sprites in your project folder."), main_exception);
+        }
+    }
+    spritesModified = false;
+}
+
 void SaveNativeSprites(Settings^ gameSettings)
 {
     int storeFlags = 0;
@@ -1908,35 +1951,7 @@ void SaveNativeSprites(Settings^ gameSettings)
     AGSString saved_indexfile;
     SaveTempSpritefile(storeFlags, compressSprites, saved_spritefile, saved_indexfile);
 
-    Exception ^main_exception;
-    try
-    {
-        PutNewSpritefileIntoProject(saved_spritefile, saved_indexfile);
-        saved_spritefile = sprsetname;
-        saved_indexfile = sprindexname;
-    }
-    catch (Exception ^e)
-    {
-        main_exception = e;
-    }
-    finally
-    {
-        // Reset the sprite cache to whichever file was successfully saved
-        HAGSError err = spriteset.InitFile(saved_spritefile, saved_indexfile);
-        if (!err)
-        {
-            throw gcnew AGSEditorException(
-                String::Format("Unable to re-initialize sprite file after save.{0}{1}",
-                    Environment::NewLine, gcnew String(err->FullMessage().GetCStr())), main_exception);
-        }
-        else if (err && main_exception != nullptr)
-        {
-            throw gcnew AGSEditorException(
-                String::Format("Unable to save sprites in your project folder. The sprites were saved to a temporary location:{0}{1}",
-                    Environment::NewLine, TextHelper::ConvertUTF8(saved_spritefile)), main_exception);
-        }
-    }
-    spritesModified = false;
+    ReplaceSpriteFile(saved_spritefile, saved_indexfile, true);
 }
 
 void SetGameResolution(Game ^game)


### PR DESCRIPTION
Meant to resolve #1404, but currently is a draft; still need to try this out and figure out the best approach to running the recreation tasks.

Implemented managed `SpriteFileWriter`, which is a C++ CLI wrapper around native SpriteFileWriter, also performing necessary conversions between .NET and native data.

Implemented `SpriteTools.WriteSpriteFileFromSources` method that writes a spritefile to the requested destination by reimporting images from sprite sources, or resorting to getting them from the current spritecache, if available.
If image is not available, then simply writes a dummy bitmap of the known size.
This process gets one sprite at a time, and disposes it after writing, thus the memory use supposed to stay low.
This function uses game's sprite compression settings.

Added a menu command "File -> Recreate Sprite File from sources", that writes a new spritefile using aforementioned method, and replaces game's file with it.

In case a spritefile is missing in the game, Editor no longer refuses to load a game, but instead generates a dummy spritefile with one sprite at index 0 (it is required as placeholder to prevent crashes). This allows user to get into the project, and try reimporting sprites either using "File -> Recreate Sprite File from sources", or commands from the sprite manager.
NOTE: all the sprite properties remain, as they are part of the Game.agf rather than a spritefile. Only images are lost in this situation.
