### PR TITLE
AGS4: New compiler: Disallow static variables in `struct`s

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -5032,10 +5032,10 @@ void AGS::Parser::ParseStruct_VariableDefn(TypeQualifierSet tqs, Vartype vartype
     if (PP::kMain != _pp)
         return SkipTo(SymbolList{ kKW_Comma, kKW_Semicolon }, _src);
 
-    if (_sym.IsDynarrayVartype(vartype) ||  // e.g., 'int [] zonk;', disallowed
-        tqs[TQ::kStatic])                   // e.g. 'static int zonk;': No static struct variables in AGS
+    if (_sym.IsDynarrayVartype(vartype)) // e.g., 'int [] zonk;', disallowed
         Expect(kKW_OpenParenthesis, _src.PeekNext());
-
+    if (tqs[TQ::kStatic]) // e.g. 'static int zonk;': No static struct variables in AGS
+        UserError("Static variables are not supported");
     if (tqs[TQ::kImport])
         UserError("Cannot import struct component variables; import the whole struct instead");
     

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -5032,8 +5032,10 @@ void AGS::Parser::ParseStruct_VariableDefn(TypeQualifierSet tqs, Vartype vartype
     if (PP::kMain != _pp)
         return SkipTo(SymbolList{ kKW_Comma, kKW_Semicolon }, _src);
 
-    if (_sym.IsDynarrayVartype(vartype)) // e.g., 'int [] zonk;'
-        UserError("Expected '('");
+    if (_sym.IsDynarrayVartype(vartype) ||  // e.g., 'int [] zonk;', disallowed
+        tqs[TQ::kStatic])                   // e.g. 'static int zonk;': No static struct variables in AGS
+        Expect(kKW_OpenParenthesis, _src.PeekNext());
+
     if (tqs[TQ::kImport])
         UserError("Cannot import struct component variables; import the whole struct instead");
     

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -111,11 +111,12 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
 
     // The order of qualifiers shouldn't matter.
     // Note, "_tryimport" isn't legal for struct components.
+    // Note, AGS doesn't feature static struct variables.
     // Can only use one of "protected", "writeprotected" and "readonly".
 
     char *inpl = "\
         struct BothOrders {                                 \n\
-            protected static int something;                 \n\
+            protected static int something();               \n\
             static import readonly attribute int another;   \n\
             readonly import attribute int MyAttrib;         \n\
             import readonly attribute int YourAttrib;       \n\

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2449,6 +2449,6 @@ TEST_F(Compile1, DisallowStaticVariables)
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("'('"));
+    EXPECT_NE(std::string::npos, msg.find("tatic "));
 
 }

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2435,3 +2435,20 @@ TEST_F(Compile1, SideEffectExpression4)
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : mh.GetError().Message.c_str());
 }
+
+TEST_F(Compile1, DisallowStaticVariables)
+{
+    // AGS does not have static variables.
+
+    char *inpl = "\
+        struct Struct       \n\
+        {                   \n\
+            static int Var; \n\
+        };                  \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'('"));
+
+}


### PR DESCRIPTION
This partially addresses #1590.

Fix bug: AGS doesn't have static variables in `struct`s although there __are__ static functions and static attributes. The new compiler didn't catch this.

Typical code:
```
struct MyStruct {
	static bool foo; // ← Compiler should complain at ';': 
                         //   Only function decls. may start with 'static' and no 'attribute'
}
```