### PR TITLE
New compiler: Allow pointer expressions after 'if', 'while', 'do...while'

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -916,7 +916,10 @@ void AGS::Parser::HandleEndOfDo()
         "Expected the 'while' of a 'do ... while(...)' statement");
     EvaluationResult eres;
     ParseDelimitedExpression(_src, kKW_OpenParenthesis, eres);
-    CheckVartypeMismatch(eres.Vartype, kKW_Int, true, "In 'while' clause");
+    if (!_sym.IsAnyIntegerVartype(eres.Vartype) && !_sym.IsDynVartype(eres.Vartype))
+        UserError(
+            "Expected an integer or dynamic array or dynamic pointer expression after 'while', found type '%s' instead",
+            _sym.GetName(eres.Vartype).c_str());
     Expect(kKW_Semicolon, _src.GetNext());
 
     if (!(eres.kTY_Literal == eres.Type &&
@@ -5902,9 +5905,12 @@ void AGS::Parser::ParseIf()
 {
     EvaluationResult eres;
     ParseDelimitedExpression(_src, kKW_OpenParenthesis, eres);
-    CheckVartypeMismatch(eres.Vartype, kKW_Int, true, "'if' condition");
+    if (!_sym.IsAnyIntegerVartype(eres.Vartype) && !_sym.IsDynVartype(eres.Vartype))
+        UserError(
+            "Expected an integer or dynamic array or dynamic pointer expression after 'if', found type '%s' instead",
+            _sym.GetName(eres.Vartype).c_str());
     EvaluationResultToAx(eres);
-    
+
     _nest.Push(NSType::kIf);
 
     // The code that has just been generated has put the result of the check into AX
@@ -5948,7 +5954,10 @@ void AGS::Parser::ParseWhile()
 
     EvaluationResult eres;
     ParseDelimitedExpression(_src, kKW_OpenParenthesis, eres);
-    CheckVartypeMismatch(eres.Vartype, kKW_Int, true, "'while' clause");
+    if (!_sym.IsAnyIntegerVartype(eres.Vartype) && !_sym.IsDynVartype(eres.Vartype))
+        UserError(
+            "Expected an integer or dynamic array or dynamic pointer expression after 'while', found type '%s' instead",
+            _sym.GetName(eres.Vartype).c_str());
     
     _nest.Push(NSType::kWhile);
 

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -2279,3 +2279,82 @@ TEST_F(Compile0, Ternary02) {
     EXPECT_NE(std::string::npos, res.find("float"));
 }
 
+TEST_F(Compile0, FlowPointerExpressions1) {
+
+    // The parenthesized expression after 'if', 'while', 'do ... while'
+    // may evaluate to a pointer 
+
+    char *inpl = "\
+        import builtin managed struct Character     \n\
+        {                                           \n\
+        } *player;                                  \n\
+        int main()                                  \n\
+        {                                           \n\
+            if (player)                             \n\
+                return;                             \n\
+            while (player)                          \n\
+                return;                             \n\
+            do                                      \n\
+                break;                              \n\
+            while (player);                         \n\
+        }                                           \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+}
+
+TEST_F(Compile0, FlowPointerExpressions2) {
+
+    // The parenthesized expression after 'if' must not be float
+
+    char *inpl = "\
+        int main()              \n\
+        {                       \n\
+            if (1.0)            \n\
+                return;         \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string const msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("float"));
+}
+
+TEST_F(Compile0, FlowPointerExpressions3) {
+
+    // The parenthesized expression after 'while' must not be float
+
+    char *inpl = "\
+        int main()              \n\
+        {                       \n\
+            while (0.0)         \n\
+                return;         \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string const msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("float"));
+}
+
+TEST_F(Compile0, FlowPointerExpressions4) {
+
+    // The parenthesized expression after 'do ... while' must not be float
+
+    char *inpl = "\
+        int main()              \n\
+        {                       \n\
+            do                  \n\
+                break;          \n\
+            while (1.0);        \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string const msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("float"));
+}


### PR DESCRIPTION
The old compiler allows code such as `if (player)` where the expression after `if` is a pointer expression. (In these cases, the expression is compared to `null`.) 

Make the new compiler allow this, too.