### PR TITLE
Script API: allow to scale overlays by setting Width & Height

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1292,6 +1292,10 @@ builtin managed struct Overlay {
   import attribute int Width;
   /// Gets/sets the height of this overlay. Resizing overlay will scale its image.
   import attribute int Height;
+  /// Gets the original width of this overlay's graphic.
+  import readonly attribute int GraphicWidth;
+  /// Gets the original height of this overlay's graphic.
+  import readonly attribute int GraphicHeight;
   /// Gets/sets the transparency of this overlay.
   import attribute int Transparency;
   /// Gets/sets the overlay's z-order relative to other overlays and on-screen objects.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1288,10 +1288,10 @@ builtin managed struct Overlay {
   /// Gets/sets the Y position on the screen where this overlay is displayed.
   import attribute int Y;
 #ifdef SCRIPT_API_v360
-  /// Gets the width of this overlay.
-  import readonly attribute int Width;
-  /// Gets the height of this overlay.
-  import readonly attribute int Height;
+  /// Gets/sets the width of this overlay. Resizing overlay will scale its image.
+  import attribute int Width;
+  /// Gets/sets the height of this overlay. Resizing overlay will scale its image.
+  import attribute int Height;
   /// Gets/sets the transparency of this overlay.
   import attribute int Transparency;
   /// Gets/sets the overlay's z-order relative to other overlays and on-screen objects.

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -129,6 +129,8 @@ std::vector<Bitmap*> guiobjbg;
 std::vector<IDriverDependantBitmap*> guiobjbmp;
 std::vector<Point> guiobjoff; // because surface may be larger than logical position
 std::vector<int> guiobjbmpref; // first control texture index of each GUI
+// Overlay's cached transformed bitmap, for software mode
+std::vector<Bitmap*> overlaybmp;
 // For debugging room masks
 RoomAreaMask debugRoomMask = kRoomAreaNone;
 std::unique_ptr<Bitmap> debugRoomMaskBmp;
@@ -947,7 +949,7 @@ void draw_sprite_slot_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int
 IDriverDependantBitmap* recycle_ddb_bitmap(IDriverDependantBitmap *bimp, Bitmap *source, bool hasAlpha, bool opaque) {
     if (bimp != nullptr) {
         // same colour depth, width and height -> reuse
-        if (((bimp->GetColorDepth() + 1) / 8 == source->GetBPP()) && 
+        if ((bimp->GetColorDepth() == source->GetColorDepth()) &&
             (bimp->GetWidth() == source->GetWidth()) && (bimp->GetHeight() == source->GetHeight()))
         {
             gfxDriver->UpdateDDBFromBitmap(bimp, source, hasAlpha);
@@ -2324,14 +2326,33 @@ void draw_gui_and_overlays()
 
     clear_sprite_list();
 
+    const bool is_software_mode = !gfxDriver->HasAcceleratedTransform();
     // Add active overlays to the sprite list
-    for (auto &over : screenover)
+    if (overlaybmp.size() < screenover.size())
+        overlaybmp.resize(screenover.size());
+    for (size_t i = 0; i < screenover.size(); ++i)
     {
+        auto &over = screenover[i];
         if (over.transparency == 255) continue; // skip fully transparent
-        over.bmp->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
+        if (screenover[i].HasChanged())
+        {
+            // For software mode - prepare transformed bitmap if necessary
+            Bitmap *use_bmp = over.pic;
+            if (is_software_mode && (over.pic->GetSize() != Size(over.scaleWidth, over.scaleHeight)))
+            {
+                overlaybmp[i] = recycle_bitmap(overlaybmp[i], over.pic->GetColorDepth(), over.scaleWidth, over.scaleHeight);
+                overlaybmp[i]->StretchBlt(over.pic, RectWH(overlaybmp[i]->GetSize()));
+                use_bmp = overlaybmp[i];
+            }
+            over.ddb = recycle_ddb_bitmap(over.ddb, use_bmp, over.hasAlphaChannel);
+            over.ClearChanged();
+        }
+
+        over.ddb->SetStretch(over.scaleWidth, over.scaleHeight);
+        over.ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
         int tdxp, tdyp;
         get_overlay_position(over, &tdxp, &tdyp);
-        add_to_sprite_list(over.bmp, tdxp, tdyp, over.zorder, false, -1);
+        add_to_sprite_list(over.ddb, tdxp, tdyp, over.zorder, false, -1);
     }
 
     // Add GUIs

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -114,6 +114,20 @@ int Overlay_GetHeight(ScriptOverlay *scover) {
     return game_to_data_coord(screenover[ovri].scaleHeight);
 }
 
+int Overlay_GetGraphicWidth(ScriptOverlay *scover) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+    return game_to_data_coord(screenover[ovri].pic->GetWidth());
+}
+
+int Overlay_GetGraphicHeight(ScriptOverlay *scover) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+    return game_to_data_coord(screenover[ovri].pic->GetHeight());
+}
+
 void Overlay_SetScaledSize(ScreenOverlay &over, int width, int height) {
     data_to_game_coords(&width, &height);
     if (width < 1 || height < 1)
@@ -492,6 +506,16 @@ RuntimeScriptValue Sc_Overlay_SetHeight(void *self, const RuntimeScriptValue *pa
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetHeight);
 }
 
+RuntimeScriptValue Sc_Overlay_GetGraphicWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetGraphicWidth);
+}
+
+RuntimeScriptValue Sc_Overlay_GetGraphicHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptOverlay, Overlay_GetGraphicHeight);
+}
+
 RuntimeScriptValue Sc_Overlay_GetTransparency(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetTransparency);
@@ -548,6 +572,8 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::set_Width",           Sc_Overlay_SetWidth);
     ccAddExternalObjectFunction("Overlay::get_Height",          Sc_Overlay_GetHeight);
     ccAddExternalObjectFunction("Overlay::set_Height",          Sc_Overlay_SetHeight);
+    ccAddExternalObjectFunction("Overlay::get_GraphicWidth",    Sc_Overlay_GetGraphicWidth);
+    ccAddExternalObjectFunction("Overlay::get_GraphicHeight",   Sc_Overlay_GetGraphicHeight);
     ccAddExternalObjectFunction("Overlay::get_Transparency",    Sc_Overlay_GetTransparency);
     ccAddExternalObjectFunction("Overlay::set_Transparency",    Sc_Overlay_SetTransparency);
     ccAddExternalObjectFunction("Overlay::get_ZOrder",          Sc_Overlay_GetZOrder);

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "ac/overlay.h"
 #include "ac/common.h"
 #include "ac/view.h"
@@ -26,6 +25,7 @@
 #include "ac/runtime_defines.h"
 #include "ac/screenoverlay.h"
 #include "ac/string.h"
+#include "debug/debug_log.h"
 #include "gfx/graphicsdriver.h"
 #include "gfx/bitmap.h"
 #include "script/runtimescriptvalue.h"
@@ -104,14 +104,42 @@ int Overlay_GetWidth(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].pic->GetWidth());
+    return game_to_data_coord(screenover[ovri].scaleWidth);
 }
 
 int Overlay_GetHeight(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].pic->GetHeight());
+    return game_to_data_coord(screenover[ovri].scaleHeight);
+}
+
+void Overlay_SetScaledSize(ScreenOverlay &over, int width, int height) {
+    data_to_game_coords(&width, &height);
+    if (width < 1 || height < 1)
+    {
+        debug_script_warn("Overlay.SetSize: invalid dimensions: %d x %d", width, height);
+        return;
+    }
+    if ((width == over.scaleWidth) && (height == over.scaleHeight))
+        return; // no change
+    over.scaleWidth = width;
+    over.scaleHeight = height;
+    over.MarkChanged();
+}
+
+void Overlay_SetWidth(ScriptOverlay *scover, int width) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+    Overlay_SetScaledSize(screenover[ovri], width, game_to_data_coord(screenover[ovri].scaleHeight));
+}
+
+void Overlay_SetHeight(ScriptOverlay *scover, int height) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+    Overlay_SetScaledSize(screenover[ovri], game_to_data_coord(screenover[ovri].scaleWidth), height);
 }
 
 int Overlay_GetValid(ScriptOverlay *scover) {
@@ -213,9 +241,9 @@ static void dispose_overlay(ScreenOverlay &over)
 {
     delete over.pic;
     over.pic = nullptr;
-    if (over.bmp != nullptr)
-        gfxDriver->DestroyDDB(over.bmp);
-    over.bmp = nullptr;
+    if (over.ddb != nullptr)
+        gfxDriver->DestroyDDB(over.ddb);
+    over.ddb = nullptr;
     if (over.associatedOverlayHandle) // dispose script object if there are no more refs
         ccAttemptDisposeObject(over.associatedOverlayHandle);
 }
@@ -283,11 +311,13 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, int pic_offx, i
     }
     ScreenOverlay over;
     over.pic=piccy;
-    over.bmp = gfxDriver->CreateDDBFromBitmap(piccy, alphaChannel);
+    over.ddb = nullptr; // is generated during first draw pass
     over.x=x;
     over.y=y;
     over.offsetX = pic_offx;
     over.offsetY = pic_offy;
+    over.scaleWidth = piccy->GetWidth();
+    over.scaleHeight = piccy->GetHeight();
     // by default draw speech and portraits over GUI, and the rest under GUI
     over.zorder = (type == OVER_TEXTMSG || type == OVER_PICTURE || type == OVER_TEXTSPEECH) ?
         INT_MAX : INT_MIN;
@@ -311,6 +341,7 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, int pic_offx, i
     {
         play.speech_face_scover = create_scriptobj_addref(over);
     }
+    over.MarkChanged();
     screenover.push_back(std::move(over));
     return screenover.size() - 1;
 }
@@ -365,12 +396,10 @@ void recreate_overlay_ddbs()
 {
     for (auto &over : screenover)
     {
-        if (over.bmp)
-            gfxDriver->DestroyDDB(over.bmp);
-        if (over.pic)
-            over.bmp = gfxDriver->CreateDDBFromBitmap(over.pic, false);
-        else
-            over.bmp = nullptr;
+        if (over.ddb)
+            gfxDriver->DestroyDDB(over.ddb);
+        over.ddb = nullptr; // is generated during first draw pass
+        over.MarkChanged();
     }
 }
 
@@ -448,9 +477,19 @@ RuntimeScriptValue Sc_Overlay_GetWidth(void *self, const RuntimeScriptValue *par
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetWidth);
 }
 
+RuntimeScriptValue Sc_Overlay_SetWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetWidth);
+}
+
 RuntimeScriptValue Sc_Overlay_GetHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetHeight);
+}
+
+RuntimeScriptValue Sc_Overlay_SetHeight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetHeight);
 }
 
 RuntimeScriptValue Sc_Overlay_GetTransparency(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -506,7 +545,9 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::get_Y",               Sc_Overlay_GetY);
     ccAddExternalObjectFunction("Overlay::set_Y",               Sc_Overlay_SetY);
     ccAddExternalObjectFunction("Overlay::get_Width",           Sc_Overlay_GetWidth);
+    ccAddExternalObjectFunction("Overlay::set_Width",           Sc_Overlay_SetWidth);
     ccAddExternalObjectFunction("Overlay::get_Height",          Sc_Overlay_GetHeight);
+    ccAddExternalObjectFunction("Overlay::set_Height",          Sc_Overlay_SetHeight);
     ccAddExternalObjectFunction("Overlay::get_Transparency",    Sc_Overlay_GetTransparency);
     ccAddExternalObjectFunction("Overlay::set_Transparency",    Sc_Overlay_SetTransparency);
     ccAddExternalObjectFunction("Overlay::get_ZOrder",          Sc_Overlay_GetZOrder);

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -19,12 +19,11 @@ using AGS::Common::Stream;
 
 void ScreenOverlay::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
-    // Skipping bmp and pic pointer values
-    // TODO: find out if it's safe to just drop these pointers!! replace with unique_ptr?
-    bmp = nullptr;
     pic = nullptr;
-    in->ReadInt32(); // bmp
-    hasSerializedBitmap = in->ReadInt32() != 0;
+    ddb = nullptr;
+    // Skipping pointers (were saved by old engine)
+    in->ReadInt32(); // ddb
+    hasSerializedBitmap = in->ReadInt32() != 0; // pic
     type = in->ReadInt32();
     x = in->ReadInt32();
     y = in->ReadInt32();
@@ -42,15 +41,15 @@ void ScreenOverlay::ReadFromFile(Stream *in, int32_t cmp_ver)
     {
         zorder = in->ReadInt32();
         transparency = in->ReadInt32();
-        in->ReadInt32(); // reserve 2 ints
-        in->ReadInt32();
+        scaleWidth = in->ReadInt32();
+        scaleHeight = in->ReadInt32();
     }
 }
 
 void ScreenOverlay::WriteToFile(Stream *out) const
 {
     // Writing bitmap "pointers" to correspond to full structure writing
-    out->WriteInt32(0); // bmp
+    out->WriteInt32(0); // ddb
     out->WriteInt32(pic ? 1 : 0); // pic
     out->WriteInt32(type);
     out->WriteInt32(x);
@@ -66,6 +65,6 @@ void ScreenOverlay::WriteToFile(Stream *out) const
     // since cmp_ver = 2
     out->WriteInt32(zorder);
     out->WriteInt32(transparency);
-    out->WriteInt32(0); // reserve 2 ints
-    out->WriteInt32(0);
+    out->WriteInt32(scaleWidth);
+    out->WriteInt32(scaleHeight);
 }

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -26,9 +26,18 @@ namespace AGS { namespace Common { class Bitmap; class Stream; } }
 namespace AGS { namespace Engine { class IDriverDependantBitmap; }}
 using namespace AGS; // FIXME later
 
-
+// Overlay class.
+// TODO: currently overlay creates and stores its own bitmap, even if
+// created using existing sprite. As a side-effect, changing that sprite
+// (if it were a dynamic one) will not affect overlay (unlike other objects).
+// For future perfomance optimization it may be desired to store sprite index
+// instead; but that would mean that overlay will have to receive sprite
+// changes. For backward compatibility there may be a game switch that
+// forces it to make a copy.
 struct ScreenOverlay {
-    Engine::IDriverDependantBitmap *bmp = nullptr;
+    // Texture
+    Engine::IDriverDependantBitmap *ddb = nullptr;
+    // Original bitmap
     Common::Bitmap *pic = nullptr;
     bool hasAlphaChannel = false;
     int type = 0, timeout = 0;
@@ -37,6 +46,8 @@ struct ScreenOverlay {
     int x = 0, y = 0;
     // Border/padding offset for the tiled text windows
     int offsetX = 0, offsetY = 0;
+    // Width and height to stretch the texture to
+    int scaleWidth = 0, scaleHeight = 0;
     int bgSpeechForChar = -1;
     int associatedOverlayHandle = 0;
     int zorder = INT_MIN;
@@ -44,8 +55,18 @@ struct ScreenOverlay {
     bool hasSerializedBitmap = false;
     int transparency = 0;
 
+    // Tells if Overlay has graphically changed recently
+    bool HasChanged() const { return _hasChanged; }
+    // Manually marks GUI as graphically changed
+    void MarkChanged() { _hasChanged = true; }
+    // Clears changed flag
+    void ClearChanged() { _hasChanged = false; }
+
     void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;
+
+private:
+    bool _hasChanged = false;
 };
 
 #endif // __AGS_EE_AC__SCREENOVERLAY_H

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -865,6 +865,11 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
         over.ReadFromFile(in, cmp_ver);
         if (over.hasSerializedBitmap)
             over.pic = read_serialized_bitmap(in);
+        if (over.scaleWidth <= 0 || over.scaleHeight <= 0)
+        {
+            over.scaleWidth = over.pic->GetWidth();
+            over.scaleHeight = over.pic->GetHeight();
+        }
         screenover.push_back(over);
     }
     return HSaveError::None();

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -451,7 +451,8 @@ void update_sierra_speech()
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }
 
-      gfxDriver->UpdateDDBFromBitmap(screenover[face_talking].bmp, screenover[face_talking].pic, face_has_alpha);
+      screenover[face_talking].hasAlphaChannel = face_has_alpha;
+      screenover[face_talking].MarkChanged();
     }  // end if updatedFrame
   }
 }


### PR DESCRIPTION
Resolves #1585.

1. Makes `Overlay.Width` and `Height` settable (previously were read-only). Changing them will scale overlay's image.
2. Added readonly `Overlay.GraphicWidth` and `GraphicHeight`, which return original image's size. This is necessary, because overlays may have autogenerated image, which sizes cannot be found using `Game.SpriteWidth/Height`.