### PR TITLE
Editor: letterbox mode moved to compatibility category

### DIFF
--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -474,7 +474,7 @@ namespace AGS.Types
         [DisplayName("Old-style letterbox mode")]
         [Description("Game will run at 320x240 or 640x480 with top and bottom black borders to give a square aspect ratio. Not recommended unless importing an old project.")]
         [DefaultValue(false)]
-        [Category("(Basic properties)")]
+        [Category("Backwards Compatibility")]
         public bool LetterboxMode
         {
             get { return _letterboxMode; }


### PR DESCRIPTION
It looks like the `Old-style letterbox mode` doesn't belong in the `(Basic properties)` category anymore, and may be more well suited to the Backward Compatibility category.

This change moves it.