### PR TITLE
Script API: implemented GUIControl.Transparency

### DIFF
--- a/Common/gfx/gfx_def.h
+++ b/Common/gfx/gfx_def.h
@@ -35,11 +35,12 @@ enum BlendMode
 
 namespace GfxDef
 {
+    // Converts percentage of transparency into alpha
     inline int Trans100ToAlpha255(int transparency)
     {
         return ((100 - transparency) * 255) / 100;
     }
-
+    // Converts alpha into percentage of transparency
     inline int Alpha255ToTrans100(int alpha)
     {
         return 100 - ((alpha * 100) / 255);
@@ -64,32 +65,32 @@ namespace GfxDef
     // 1 -to- 254 = barely visible -to- mostly visible (as proper alpha)
     inline int Trans100ToLegacyTrans255(int transparency)
     {
-        if (transparency == 0)
+        switch (transparency)
         {
+        case 0:
             return 0; // this means opaque
-        }
-        else if (transparency == 100)
-        {
+        case 100:
             return 255; // this means invisible
+        default:
+            // the rest of the range works as alpha
+            return Trans100ToAlpha250(transparency);
         }
-        // the rest of the range works as alpha
-        return Trans100ToAlpha250(transparency);
     }
 
     // Convert legacy 255-ranged "incorrect" transparency into proper
     // 100-ranged transparency.
     inline int LegacyTrans255ToTrans100(int legacy_transparency)
     {
-        if (legacy_transparency == 0)
+        switch (legacy_transparency)
         {
+        case 0:
             return 0; // this means opaque
-        }
-        else if (legacy_transparency == 255)
-        {
+        case 255:
             return 100; // this means invisible
+        default:
+            // the rest of the range works as alpha
+            return Alpha250ToTrans100(legacy_transparency);
         }
-        // the rest of the range works as alpha
-        return Alpha250ToTrans100(legacy_transparency);
     }
 
     // Convert legacy 100-ranged transparency into proper 255-ranged alpha
@@ -98,16 +99,46 @@ namespace GfxDef
     // 1 - 99 => alpha 1 - 244
     inline int LegacyTrans100ToAlpha255(int legacy_transparency)
     {
-        if (legacy_transparency == 0)
+        switch (legacy_transparency)
         {
+        case 0:
             return 255; // this means opaque
-        }
-        else if (legacy_transparency == 100)
-        {
+        case 100:
             return 0; // this means invisible
+        default:
+            // the rest of the range works as alpha (only 100-ranged)
+            return legacy_transparency * 255 / 100;
         }
-        // the rest of the range works as alpha (only 100-ranged)
-        return legacy_transparency * 255 / 100;
+    }
+
+    // Convert legacy 255-ranged transparency into proper 255-ranged alpha
+    inline int LegacyTrans255ToAlpha255(int legacy_transparency)
+    {
+        switch (legacy_transparency)
+        {
+        case 0:
+            return 255; // this means opaque
+        case 255:
+            return 0; // this means invisible
+        default:
+            // the rest of the range works as alpha
+            return legacy_transparency;
+        }
+    }
+
+    // Convert 255-ranged alpha into legacy 255-ranged transparency
+    inline int Alpha255ToLegacyTrans255(int alpha)
+    {
+        switch (alpha)
+        {
+        case 255:
+            return 0; // this means opaque
+        case 0:
+            return 255; // this means invisible
+        default:
+            // the rest of the range works as alpha
+            return alpha;
+        }
     }
 } // namespace GfxDef
 

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -187,7 +187,8 @@ enum GuiSvgVersion
 {
     kGuiSvgVersion_Initial  = 0,
     kGuiSvgVersion_350,
-    kGuiSvgVersion_36020
+    kGuiSvgVersion_36020,
+    kGuiSvgVersion_36023
 };
 
 enum GuiDisableStyle

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -285,6 +285,7 @@ void GUIMain::DrawWithControls(Bitmap *ds)
     if ((all_buttons_disabled >= 0) && (GUI::Options.DisabledStyle == kGuiDis_Blackout))
         return; // don't draw GUI controls
 
+    Bitmap tempbmp; // in case we need transforms
     for (size_t ctrl_index = 0; ctrl_index < _controls.size(); ++ctrl_index)
     {
         set_eip_guiobj(_ctrlDrawOrder[ctrl_index]);
@@ -296,11 +297,23 @@ void GUIMain::DrawWithControls(Bitmap *ds)
         if (!objToDraw->IsVisible())
             continue;
 
-        if (GUI::Options.ClipControls && objToDraw->IsContentClipped())
-            ds->SetClip(RectWH(objToDraw->X, objToDraw->Y, objToDraw->Width, objToDraw->Height));
+        // Depending on draw properties - draw directly on the gui surface, or use a buffer
+        if (objToDraw->GetTransparency() == 0)
+        {
+            if (GUI::Options.ClipControls && objToDraw->IsContentClipped())
+                ds->SetClip(RectWH(objToDraw->X, objToDraw->Y, objToDraw->Width, objToDraw->Height));
+            else
+                ds->ResetClip();
+            objToDraw->Draw(ds, objToDraw->X, objToDraw->Y);
+        }
         else
-            ds->ResetClip();
-        objToDraw->Draw(ds, objToDraw->X, objToDraw->Y);
+        {
+            const Rect rc = objToDraw->CalcGraphicRect(GUI::Options.ClipControls && objToDraw->IsContentClipped());
+            tempbmp.CreateTransparent(rc.GetWidth(), rc.GetHeight());
+            objToDraw->Draw(&tempbmp, objToDraw->X - rc.Left, objToDraw->Y - rc.Top);
+            draw_gui_sprite(ds, true, objToDraw->X, objToDraw->Y, &tempbmp, objToDraw->HasAlphaChannel(), kBlendMode_Alpha,
+                GfxDef::LegacyTrans255ToAlpha255(objToDraw->GetTransparency()));
+        }
 
         int selectedColour = 14;
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -256,6 +256,9 @@ extern bool is_sprite_alpha(int spr);
 // This function has distinct implementations in Engine and Editor
 extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y, bool use_alpha = true,
                             Common::BlendMode blend_mode = Common::kBlendMode_Alpha);
+extern void draw_gui_sprite(Common::Bitmap *ds, bool use_alpha, int x, int y,
+                            Common::Bitmap *image, bool src_has_alpha,
+                            Common::BlendMode blend_mode, int alpha);
 
 extern AGS_INLINE int game_to_data_coord(int coord);
 extern AGS_INLINE int data_to_game_coord(int coord);

--- a/Common/gui/guiobject.cpp
+++ b/Common/gui/guiobject.cpp
@@ -32,7 +32,8 @@ GUIObject::GUIObject()
     Width       = 0;
     Height      = 0;
     ZOrder      = -1;
-    IsActivated    = false;
+    IsActivated   = false;
+    _transparency = 0;
     _scEventCount = 0;
     _hasChanged = true;
 }
@@ -124,6 +125,15 @@ void GUIObject::SetVisible(bool on)
         Flags &= ~kGUICtrl_Visible;
 }
 
+void GUIObject::SetTransparency(int trans)
+{
+    if (_transparency != trans)
+    {
+        _transparency = trans;
+        NotifyParentChanged(); // for software mode
+    }
+}
+
 // TODO: replace string serialization with StrUtil::ReadString and WriteString
 // methods in the future, to keep this organized.
 void GUIObject::WriteToFile(Stream *out) const
@@ -192,6 +202,13 @@ void GUIObject::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)
     ZOrder = in->ReadInt32();
     // Dynamic state
     IsActivated = in->ReadBool() ? 1 : 0;
+    if (svg_ver >= kGuiSvgVersion_36023)
+    {
+        _transparency = in->ReadInt32();
+        in->ReadInt32(); // reserve 3 ints
+        in->ReadInt32();
+        in->ReadInt32();
+    }
 }
 
 void GUIObject::WriteToSavegame(Stream *out) const
@@ -205,6 +222,10 @@ void GUIObject::WriteToSavegame(Stream *out) const
     out->WriteInt32(ZOrder);
     // Dynamic state
     out->WriteBool(IsActivated != 0);
+    out->WriteInt32(_transparency);
+    out->WriteInt32(0); // reserve 3 ints
+    out->WriteInt32(0);
+    out->WriteInt32(0);
 }
 
 

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -55,6 +55,7 @@ public:
     bool            IsVisible() const;
     // implemented separately in engine and editor
     bool            IsClickable() const;
+    int             GetTransparency() const { return _transparency; }
     // Compatibility: should the control's graphic be clipped to its x,y,w,h
     virtual bool    IsContentClipped() const { return true; }
     // Tells if the object image supports alpha channel
@@ -69,6 +70,7 @@ public:
     void            SetEnabled(bool on);
     void            SetTranslated(bool on);
     void            SetVisible(bool on);
+    void            SetTransparency(int trans);
 
     // Events
     // Key pressed for control
@@ -118,6 +120,7 @@ public:
   
 protected:
     uint32_t Flags;      // generic style and behavior flags
+    int32_t  _transparency; // "incorrect" alpha (in legacy 255-range units)
     bool     _hasChanged;
 
     // TODO: explicit event names & handlers for every event

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1650,6 +1650,10 @@ builtin managed struct GUIControl {
   /// Gets/sets the control's z-order relative to other controls within the same owning GUI.
   import attribute int  ZOrder;
 #endif
+#ifdef SCRIPT_API_v360
+  /// Gets/sets the control's transparency.
+  import attribute int  Transparency;
+#endif
 };
 
 builtin managed struct Label extends GUIControl {

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -583,8 +583,11 @@ void wputblock_stretch(Common::Bitmap *g, int xpt,int ypt,Common::Bitmap *tblock
   else g->StretchBlt(tblock,RectWH(xpt,ypt,nsx,nsy), Common::kBitmap_Transparency);
 }
 
-void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use_alpha, Common::BlendMode blend_mode) {
-  Common::Bitmap *blptr = get_sprite(sprnum);
+// draw_gui_sprite is supported formally, without actual blending and other effects
+// This is one ugly function... a "simplified" alternative of the engine's one;
+// but with extra hacks, due to how sprites are stored while working in editor.
+void draw_gui_sprite_impl(Common::Bitmap *g, int sprnum, Common::Bitmap *blptr, int atxp, int atyp)
+{
   Common::Bitmap *towrite=blptr;
   int needtofree=0, main_color_depth = thisgame.color_depth * 8;
 
@@ -605,7 +608,7 @@ void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use
     }
 
   int nwid=towrite->GetWidth(),nhit=towrite->GetHeight();
-  if (thisgame.AllowRelativeRes() && thisgame.SpriteInfos[sprnum].IsRelativeRes()) {
+  if ((sprnum >= 0) && thisgame.AllowRelativeRes() && thisgame.SpriteInfos[sprnum].IsRelativeRes()) {
     if (thisgame.SpriteInfos[sprnum].IsLegacyHiRes()) {
       if (dsc_want_hires == 0) {
         nwid/=2;
@@ -619,6 +622,17 @@ void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use
   }
   wputblock_stretch(g, atxp,atyp,towrite,nwid,nhit);
   if (needtofree) delete towrite;
+}
+
+void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use_alpha, Common::BlendMode blend_mode)
+{
+    draw_gui_sprite_impl(g, sprnum, get_sprite(sprnum), atxp, atyp);
+}
+
+void draw_gui_sprite(Common::Bitmap *g, bool use_alpha, int atxp, int atyp,
+    Common::Bitmap *blptr, bool src_has_alpha, Common::BlendMode blend_mode, int alpha)
+{
+    draw_gui_sprite_impl(g, -1, blptr, atxp, atyp);
 }
 
 void drawBlock (HDC hdc, Common::Bitmap *todraw, int x, int y) {

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2438,7 +2438,8 @@ void draw_gui_and_overlays()
         gfxDriver->DrawSprite(s.x, s.y, s.ddb);
         if (s.id < 0) continue; // not a group parent (gui)
         // Create a sub-batch
-        gfxDriver->BeginSpriteBatch(RectWH(s.x, s.y, s.ddb->GetWidth(), s.ddb->GetHeight()), SpriteTransform());
+        gfxDriver->BeginSpriteBatch(RectWH(s.x, s.y, s.ddb->GetWidth(), s.ddb->GetHeight()),
+            SpriteTransform(0, 0, 1.f, 1.f, 0.f, s.ddb->GetAlpha()));
         const int draw_index = guiobjbmpref[s.id];
         for (const auto &obj_id : guis[s.id].GetControlsDrawOrder())
         {
@@ -2449,7 +2450,7 @@ void draw_gui_and_overlays()
             auto *obj_ddb = guiobjbmp[draw_index + obj_id];
             assert(obj_ddb); // Test for missing texture, might happen if not marked for update
             if (!obj_ddb) continue;
-            obj_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(guis[s.id].Transparency));
+            obj_ddb->SetAlpha(255);
             gfxDriver->DrawSprite(
                 guiobjoff[draw_index + obj_id].X,
                 guiobjoff[draw_index + obj_id].Y,

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -993,7 +993,7 @@ static void add_to_sprite_list(IDriverDependantBitmap* ddb, int x, int y, int zo
 {
     assert(ddb);
     // completely invisible, so don't draw it at all
-    if (ddb->GetTransparency() == 255)
+    if (ddb->GetAlpha() == 0)
         return;
 
     SpriteListEntry sprite;
@@ -1775,7 +1775,7 @@ void prepare_objects_for_drawing() {
                 actspsbmp[useindx]->SetLightLevel(0);
         }
 
-        actspsbmp[useindx]->SetTransparency(objs[aa].transparent);
+        actspsbmp[useindx]->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(objs[aa].transparent));
         add_to_sprite_list(actspsbmp[useindx], atxp, atyp, usebasel, false);
     }
 }
@@ -2088,7 +2088,7 @@ void prepare_characters_for_drawing() {
         chin->actx = atxp;
         chin->acty = atyp;
 
-        actspsbmp[useindx]->SetTransparency(chin->transparency);
+        actspsbmp[useindx]->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(chin->transparency));
         add_to_sprite_list(actspsbmp[useindx], bgX, bgY, usebasel, false);
     }
 }
@@ -2320,7 +2320,7 @@ void draw_gui_and_overlays()
     for (auto &over : screenover)
     {
         if (over.transparency == 255) continue; // skip fully transparent
-        over.bmp->SetTransparency(over.transparency);
+        over.bmp->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(over.transparency));
         int tdxp, tdyp;
         get_overlay_position(over, &tdxp, &tdyp);
         add_to_sprite_list(over.bmp, tdxp, tdyp, over.zorder, false, -1);
@@ -2401,7 +2401,7 @@ void draw_gui_and_overlays()
             auto *gui_ddb = guibgbmp[aa];
             assert(gui_ddb); // Test for missing texture, might happen if not marked for update
             if (!gui_ddb) continue;
-            gui_ddb->SetTransparency(guis[aa].Transparency);
+            gui_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(guis[aa].Transparency));
             add_to_sprite_list(gui_ddb, guis[aa].X, guis[aa].Y, guis[aa].ZOrder, false, aa);
         }
 
@@ -2449,7 +2449,7 @@ void draw_gui_and_overlays()
             auto *obj_ddb = guiobjbmp[draw_index + obj_id];
             assert(obj_ddb); // Test for missing texture, might happen if not marked for update
             if (!obj_ddb) continue;
-            obj_ddb->SetTransparency(guis[s.id].Transparency);
+            obj_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(guis[s.id].Transparency));
             gfxDriver->DrawSprite(
                 guiobjoff[draw_index + obj_id].X,
                 guiobjoff[draw_index + obj_id].Y,
@@ -2469,7 +2469,7 @@ void put_sprite_list_on_screen(bool in_room)
         assert(t.ddb || (t.renderStage >= 0));
         if (t.ddb)
         {
-            if (t.ddb->GetTransparency() == 255)
+            if (t.ddb->GetAlpha() == 0)
                 continue; // skip completely invisible things
             // mark the image's region as dirty
             invalidate_sprite(t.x, t.y, t.ddb, in_room);
@@ -2760,7 +2760,7 @@ void debug_draw_room_mask(RoomAreaMask mask)
     }
 
     debugRoomMaskDDB = recycle_ddb_bitmap(debugRoomMaskDDB, bmp, false, true);
-    debugRoomMaskDDB->SetTransparency(150);
+    debugRoomMaskDDB->SetAlpha(150);
     debugRoomMaskDDB->SetStretch(thisroom.Width, thisroom.Height);
 }
 
@@ -2783,7 +2783,7 @@ void update_room_debug()
             bmp = debugRoomMaskBmp.get();
         }
         debugRoomMaskDDB = recycle_ddb_bitmap(debugRoomMaskDDB, bmp, false, true);
-        debugRoomMaskDDB->SetTransparency(150);
+        debugRoomMaskDDB->SetAlpha(150);
         debugRoomMaskDDB->SetStretch(thisroom.Width, thisroom.Height);
     }
     if (debugMoveListChar >= 0)
@@ -2812,7 +2812,7 @@ void update_room_debug()
             }
         }
         debugMoveListDDB = recycle_ddb_bitmap(debugMoveListDDB, debugMoveListBmp.get(), false, false);
-        debugMoveListDDB->SetTransparency(150);
+        debugMoveListDDB->SetAlpha(150);
         debugMoveListDDB->SetStretch(thisroom.Width, thisroom.Height);
     }
 }

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2450,7 +2450,7 @@ void draw_gui_and_overlays()
             auto *obj_ddb = guiobjbmp[draw_index + obj_id];
             assert(obj_ddb); // Test for missing texture, might happen if not marked for update
             if (!obj_ddb) continue;
-            obj_ddb->SetAlpha(255);
+            obj_ddb->SetAlpha(GfxDef::LegacyTrans255ToAlpha255(obj->GetTransparency()));
             gfxDriver->DrawSprite(
                 guiobjoff[draw_index + obj_id].X,
                 guiobjoff[draw_index + obj_id].Y,

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -113,6 +113,8 @@ void draw_sprite_slot_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int x
                                     Common::BlendMode blend_mode = Common::kBlendMode_Alpha, int alpha = 0xFF);
 void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode);
 void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true, Common::BlendMode blend_mode = Common::kBlendMode_Alpha);
+void draw_gui_sprite(Common::Bitmap *ds, bool use_alpha, int xpos, int ypos,
+    Common::Bitmap *image, bool src_has_alpha, Common::BlendMode blend_mode = Common::kBlendMode_Alpha, int alpha = 0xFF);
 // Render game on screen
 void render_to_screen();
 // Callbacks for the graphics driver

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -302,20 +302,16 @@ void process_event(const EventHappened *evp) {
                 quit("!Cannot use crossfade screen transition in 256-colour games");
 
             IDriverDependantBitmap *ddb = prepare_screen_for_transition_in();
-
-            int transparency = 254;
-
-            while (transparency > 0) {
+            for (int alpha = 254; alpha > 0; alpha -= 16)
+            {
                 // do the crossfade
-                ddb->SetTransparency(transparency);
+                ddb->SetAlpha(alpha);
                 invalidate_screen();
                 construct_game_scene(true);
                 construct_game_screen_overlay(false);
-
-                if (transparency > 16)
+                // draw old screen on top while alpha > 16
+                if (alpha > 16)
                 {
-                    // on last frame of fade (where transparency < 16), don't
-                    // draw the old screen on top
                     gfxDriver->BeginSpriteBatch(play.GetMainViewport(), SpriteTransform());
                     gfxDriver->DrawSprite(0, 0, ddb);
                     gfxDriver->EndSpriteBatch();
@@ -323,7 +319,6 @@ void process_event(const EventHappened *evp) {
                 render_to_screen();
                 update_polled_stuff_if_runtime();
                 WaitForNextFrame();
-                transparency -= 16;
             }
 
             delete saved_viewport_bitmap;

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -207,6 +207,16 @@ void GUIControl_BringToFront(GUIObject *guio) {
   guis[guio->ParentId].BringControlToFront(guio->Id);
 }
 
+int GUIControl_GetTransparency(GUIObject *guio) {
+    return GfxDef::LegacyTrans255ToTrans100(guio->GetTransparency());
+}
+
+void GUIControl_SetTransparency(GUIObject *guio, int trans) {
+    if ((trans < 0) | (trans > 100))
+        quit("!SetGUITransparency: transparency value must be between 0 and 100");
+    guio->SetTransparency(GfxDef::Trans100ToLegacyTrans255(trans));
+}
+
 //=============================================================================
 //
 // Script API Functions
@@ -389,6 +399,16 @@ RuntimeScriptValue Sc_GUIControl_SetZOrder(void *self, const RuntimeScriptValue 
     API_OBJCALL_VOID_PINT(GUIObject, GUIControl_SetZOrder);
 }
 
+RuntimeScriptValue Sc_GUIControl_GetTransparency(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(GUIObject, GUIControl_GetTransparency);
+}
+
+RuntimeScriptValue Sc_GUIControl_SetTransparency(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(GUIObject, GUIControl_SetTransparency);
+}
+
 
 
 void RegisterGUIControlAPI()
@@ -422,6 +442,8 @@ void RegisterGUIControlAPI()
     ccAddExternalObjectFunction("GUIControl::set_Y",            Sc_GUIControl_SetY);
     ccAddExternalObjectFunction("GUIControl::get_ZOrder",       Sc_GUIControl_GetZOrder);
     ccAddExternalObjectFunction("GUIControl::set_ZOrder",       Sc_GUIControl_SetZOrder);
+    ccAddExternalObjectFunction("GUIControl::get_Transparency", Sc_GUIControl_GetTransparency);
+    ccAddExternalObjectFunction("GUIControl::set_Transparency", Sc_GUIControl_SetTransparency);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -11,9 +11,8 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include <map>
-
+#include "game/savegame_components.h"
 #include "ac/audiocliptype.h"
 #include "ac/button.h"
 #include "ac/character.h"
@@ -35,7 +34,6 @@
 #include "ac/system.h"
 #include "ac/dynobj/cc_serializer.h"
 #include "debug/out.h"
-#include "game/savegame_components.h"
 #include "game/savegame_internal.h"
 #include "gfx/bitmap.h"
 #include "gui/animatingguibutton.h"
@@ -1178,7 +1176,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "GUI",
-        kGuiSvgVersion_36020,
+        kGuiSvgVersion_36023,
         kGuiSvgVersion_Initial,
         WriteGUI,
         ReadGUI

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -21,6 +21,7 @@
 #include "ac/timer.h"
 #include "debug/out.h"
 #include "gfx/ali3dexception.h"
+#include "gfx/gfx_def.h"
 #include "gfx/gfxfilter_ogl.h"
 #include "gfx/gfxfilter_aaogl.h"
 #include "platform/base/agsplatformdriver.h"
@@ -961,11 +962,12 @@ void OGLGraphicsDriver::_reDrawLastFrame()
     RestoreDrawLists();
 }
 
-void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, const glm::mat4 &projection, const glm::mat4 &matGlobal)
+void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry,
+    const glm::mat4 &projection, const glm::mat4 &matGlobal, const SpriteColorTransform &color)
 {
   OGLBitmap *bmpToDraw = drawListEntry->ddb;
 
-  const int alpha = bmpToDraw->_alpha;
+  const int alpha = (color.Alpha * bmpToDraw->_alpha) / 255;
 
   ShaderProgram program;
 
@@ -1300,11 +1302,11 @@ size_t OGLGraphicsDriver::RenderSpriteBatch(const OGLSpriteBatch &batch, size_t 
             if (DoNullSpriteCallback(e.x, e.y))
             {
                 auto stageEntry = OGLDrawListEntry((OGLBitmap*)_stageScreen.DDB, batch.ID, 0, 0);
-                _renderSprite(&stageEntry, projection, batch.Matrix);
+                _renderSprite(&stageEntry, projection, batch.Matrix, batch.Color);
             }
             break;
         default:
-            _renderSprite(&e, projection, batch.Matrix);
+            _renderSprite(&e, projection, batch.Matrix, batch.Color);
             break;
         }
     }
@@ -1372,7 +1374,7 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     // Assign the new spritebatch
     if (_spriteBatches.size() <= index)
         _spriteBatches.resize(index + 1);
-    _spriteBatches[index] = OGLSpriteBatch(index, viewport, model);
+    _spriteBatches[index] = OGLSpriteBatch(index, viewport, model, desc.Transform.Color);
 
     // create stage screen for plugin raw drawing
     int src_w = orig_viewport.GetWidth() / desc.Transform.ScaleX;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -965,8 +965,7 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
 {
   OGLBitmap *bmpToDraw = drawListEntry->ddb;
 
-  if (bmpToDraw->_transparency >= 255)
-    return;
+  const int alpha = bmpToDraw->_alpha;
 
   ShaderProgram program;
 
@@ -1036,14 +1035,8 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry, con
     glUseProgram(_transparencyShader.Program);
   }
 
-
   glUniform1i(program.TextureId, 0);
-
-  float alpha = 1.0f;
-  if (bmpToDraw->_transparency > 0) {
-    alpha = bmpToDraw->_transparency / 255.0f;
-  }
-  glUniform1f(program.Alpha, alpha);
+  glUniform1f(program.Alpha, alpha / 255.0f);
 
   float width = bmpToDraw->GetWidthToRender();
   float height = bmpToDraw->GetHeightToRender();
@@ -1736,7 +1729,7 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
-    d3db->SetTransparency(fadingOut ? a : (255 - a));
+    d3db->SetAlpha(fadingOut ? a : (255 - a));
     this->_render(false);
 
     sys_evt_process_pending();
@@ -1747,7 +1740,7 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
 
   if (fadingOut)
   {
-    d3db->SetTransparency(0);
+    d3db->SetAlpha(255);
     this->_render(false);
   }
 
@@ -1838,7 +1831,7 @@ void OGLGraphicsDriver::SetScreenFade(int red, int green, int blue)
     OGLBitmap *ddb = static_cast<OGLBitmap*>(MakeFx(red, green, blue));
     ddb->SetStretch(_spriteBatches[_actSpriteBatch].Viewport.GetWidth(),
         _spriteBatches[_actSpriteBatch].Viewport.GetHeight(), false);
-    ddb->SetTransparency(0);
+    ddb->SetAlpha(255);
     _spriteList.push_back(OGLDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 
@@ -1848,7 +1841,7 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
     OGLBitmap *ddb = static_cast<OGLBitmap*>(MakeFx(red, green, blue));
     ddb->SetStretch(_spriteBatches[_actSpriteBatch].Viewport.GetWidth(),
         _spriteBatches[_actSpriteBatch].Viewport.GetHeight(), false);
-    ddb->SetTransparency(128);
+    ddb->SetAlpha(128);
     _spriteList.push_back(OGLDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -137,10 +137,12 @@ struct OGLSpriteBatch
     Rect Viewport;
     // Transformation matrix, built from the batch description
     glm::mat4 Matrix;
+    // Batch color transformation
+    SpriteColorTransform Color;
 
     OGLSpriteBatch() = default;
-    OGLSpriteBatch(uint32_t id, const Rect view, const glm::mat4 &matrix)
-        : ID(id), Viewport(view), Matrix(matrix) {}
+    OGLSpriteBatch(uint32_t id, const Rect view, const glm::mat4 &matrix, const SpriteColorTransform &color)
+        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
 };
 typedef std::vector<OGLSpriteBatch>    OGLSpriteBatches;
 
@@ -316,7 +318,8 @@ private:
     void UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha);
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
-    void _renderSprite(const OGLDrawListEntry *entry, const glm::mat4 &projection, const glm::mat4 &matGlobal);
+    void _renderSprite(const OGLDrawListEntry *entry, const glm::mat4 &projection, const glm::mat4 &matGlobal,
+        const SpriteColorTransform &color);
     void SetupViewport();
     // Converts rectangle in top->down coordinates into OpenGL's native bottom->up coordinates
     Rect ConvertTopDownRect(const Rect &top_down_rect, int surface_height);

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -65,10 +65,8 @@ struct OGLTextureTile : public TextureTile
 class OGLBitmap : public BaseDDB
 {
 public:
-    // Transparency is a bit counter-intuitive
-    // 0=not transparent, 255=invisible, 1..254 barely visible .. mostly visible
-    int  GetTransparency() const override { return _transparency; }
-    void SetTransparency(int transparency) override { _transparency = transparency; }
+    int  GetAlpha() const override { return _alpha; }
+    void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
     void SetStretch(int width, int height, bool useResampler = true) override
     {
@@ -97,8 +95,7 @@ public:
     int _red, _green, _blue;
     int _tintSaturation;
     int _lightLevel;
-    bool _hasAlpha;
-    int _transparency;
+    int _alpha;
 
     OGLBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -117,7 +114,7 @@ public:
         _red = _green = _blue = 0;
         _tintSaturation = 0;
         _lightLevel = 0;
-        _transparency = 0;
+        _alpha = 255;
         _opaque = opaque;
     }
 

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -463,8 +463,8 @@ size_t SDLRendererGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, 
     int drawAtX = sprite.x + surf_offx;
     int drawAtY = sprite.y + surf_offy;
 
-    if (bitmap->_transparency >= 255) {} // fully transparent, do nothing
-    else if ((bitmap->_opaque) && (bitmap->_bmp == surface) && (bitmap->_transparency == 0)) {}
+    if (bitmap->_alpha == 0) {} // fully transparent, do nothing
+    else if ((bitmap->_opaque) && (bitmap->_bmp == surface) && (bitmap->_alpha == 255)) {}
     else if (bitmap->_opaque)
     {
         surface->Blit(bitmap->_bmp, 0, 0, drawAtX, drawAtY, bitmap->_bmp->GetWidth(), bitmap->_bmp->GetHeight());
@@ -474,11 +474,10 @@ size_t SDLRendererGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, 
     }
     else if (bitmap->_hasAlpha)
     {
-      if (bitmap->_transparency == 0) // no global transparency, simple alpha blend
+      if (bitmap->_alpha == 255) // no global transparency, simple alpha blend
         set_alpha_blender();
       else
-        // here _transparency is used as alpha (between 1 and 254)
-        set_blender_mode(nullptr, nullptr, _trans_alpha_blender32, 0, 0, 0, bitmap->_transparency);
+        set_blender_mode(nullptr, nullptr, _trans_alpha_blender32, 0, 0, 0, bitmap->_alpha);
 
       surface->TransBlendBlt(bitmap->_bmp, drawAtX, drawAtY);
     }
@@ -486,7 +485,7 @@ size_t SDLRendererGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, 
     {
       // here _transparency is used as alpha (between 1 and 254), but 0 means opaque!
       GfxUtil::DrawSpriteWithTransparency(surface, bitmap->_bmp, drawAtX, drawAtY,
-          bitmap->_transparency ? bitmap->_transparency : 255);
+          bitmap->_alpha);
     }
   }
   return from;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -44,10 +44,8 @@ using AGS::Common::Bitmap;
 class ALSoftwareBitmap : public BaseDDB
 {
 public:
-    // Transparency is a bit counter-intuitive
-    // 0=not transparent, 255=invisible, 1..254 barely visible .. mostly visible
-    int  GetTransparency() const override { return _transparency; }
-    void SetTransparency(int transparency) override { _transparency = transparency; }
+    int  GetAlpha() const override { return _alpha; }
+    void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
     void SetStretch(int width, int height, bool /*useResampler*/) override 
     {
@@ -60,9 +58,7 @@ public:
     Bitmap *_bmp = nullptr;
     bool _flipped = false;
     int _stretchToWidth = 0, _stretchToHeight = 0;
-    bool _opaque = false; // no mask color
-    bool _hasAlpha = false;
-    int _transparency = 0;
+    int _alpha = 255;
 
     ALSoftwareBitmap(int width, int height, int color_depth, bool opaque)
     {

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -30,8 +30,8 @@ namespace Engine
 class IDriverDependantBitmap
 {
 public:
-  virtual int  GetTransparency() const = 0;
-  virtual void SetTransparency(int transparency) = 0;  // 0-255
+  virtual int  GetAlpha() const = 0;
+  virtual void SetAlpha(int alpha) = 0;  // 0-255
   virtual void SetFlippedLeftRight(bool isFlipped) = 0;
   virtual void SetStretch(int width, int height, bool useResampler = true) = 0;
   virtual void SetLightLevel(int light_level) = 0;   // 0-255

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -48,20 +48,28 @@ enum TintMethod
   TintSpecifyMaximum = 1
 };
 
+struct SpriteColorTransform
+{
+    int Alpha = 255; // alpha color value (0 - 255)
+
+    SpriteColorTransform() = default;
+    SpriteColorTransform(int alpha) : Alpha(alpha) {}
+};
+
 // Sprite transformation
 // TODO: combine with stretch parameters in the IDriverDependantBitmap?
 struct SpriteTransform
 {
     // Translate
-    int X, Y;
-    float ScaleX, ScaleY;
-    float Rotate; // angle, in radians
+    int X = 0, Y = 0;
+    float ScaleX = 1.f, ScaleY = 1.f;
+    float Rotate = 0.f; // angle, in radians
+    SpriteColorTransform Color;
 
-    SpriteTransform()
-        : X(0), Y(0), ScaleX(1.f), ScaleY(1.f), Rotate(0.f) {}
-
-    SpriteTransform(int x, int y, float scalex = 1.0f, float scaley = 1.0f, float rotate = 0.0f)
-        : X(x), Y(y), ScaleX(scalex), ScaleY(scaley), Rotate(rotate) {}
+    SpriteTransform() = default;
+    SpriteTransform(int x, int y, float scalex = 1.0f, float scaley = 1.0f, float rotate = 0.0f,
+        SpriteColorTransform color = SpriteColorTransform())
+        : X(x), Y(y), ScaleX(scalex), ScaleY(scaley), Rotate(rotate), Color(color) {}
 };
 
 // Describes 3 render matrixes: world, view and projection

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1078,8 +1078,7 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
   D3DMATRIX matSelfTransform;
   D3DMATRIX matTransform;
 
-  if (bmpToDraw->_transparency >= 255)
-    return;
+  const int alpha = bmpToDraw->_alpha;
 
   if (bmpToDraw->_tintSaturation > 0)
   {
@@ -1098,11 +1097,7 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
     }
 
     vector[3] = (float)bmpToDraw->_tintSaturation / 256.0;
-
-    if (bmpToDraw->_transparency > 0)
-      vector[4] = (float)bmpToDraw->_transparency / 256.0;
-    else
-      vector[4] = 1.0f;
+    vector[4] = (float)alpha / 256.0;
 
     if (bmpToDraw->_lightLevel > 0)
       vector[5] = (float)bmpToDraw->_lightLevel / 256.0;
@@ -1142,17 +1137,12 @@ void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, con
       useTintBlue = useTintRed;
     }
 
-    if (bmpToDraw->_transparency > 0)
-    {
-      useTransparency = bmpToDraw->_transparency;
-    }
-
-    direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(useTintRed, useTintGreen, useTintBlue, useTransparency));
+    direct3ddevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(useTintRed, useTintGreen, useTintBlue, alpha));
     direct3ddevice->SetTextureStageState(0, D3DTSS_COLOROP, textureColorOp);
     direct3ddevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
     direct3ddevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
 
-    if (bmpToDraw->_transparency == 0)
+    if (alpha == 255)
     {
       // No transparency, use texture alpha component
       direct3ddevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
@@ -1782,7 +1772,7 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   speed *= 2;  // harmonise speeds with software driver which is faster
   for (int a = 1; a < 255; a += speed)
   {
-    d3db->SetTransparency(fadingOut ? a : (255 - a));
+    d3db->SetAlpha(fadingOut ? a : (255 - a));
     this->_renderAndPresent(false);
 
     sys_evt_process_pending();
@@ -1793,7 +1783,7 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
 
   if (fadingOut)
   {
-    d3db->SetTransparency(0);
+    d3db->SetAlpha(255);
     this->_renderAndPresent(false);
   }
 
@@ -1885,7 +1875,7 @@ void D3DGraphicsDriver::SetScreenFade(int red, int green, int blue)
     D3DBitmap *ddb = static_cast<D3DBitmap*>(MakeFx(red, green, blue));
     ddb->SetStretch(_spriteBatches[_actSpriteBatch].Viewport.GetWidth(),
         _spriteBatches[_actSpriteBatch].Viewport.GetHeight(), false);
-    ddb->SetTransparency(0);
+    ddb->SetAlpha(255);
     _spriteList.push_back(D3DDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 
@@ -1895,7 +1885,7 @@ void D3DGraphicsDriver::SetScreenTint(int red, int green, int blue)
     D3DBitmap *ddb = static_cast<D3DBitmap*>(MakeFx(red, green, blue));
     ddb->SetStretch(_spriteBatches[_actSpriteBatch].Viewport.GetWidth(),
         _spriteBatches[_actSpriteBatch].Viewport.GetHeight(), false);
-    ddb->SetTransparency(128);
+    ddb->SetAlpha(128);
     _spriteList.push_back(D3DDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -27,6 +27,7 @@
 #include "ac/timer.h"
 #include "debug/out.h"
 #include "gfx/ali3dexception.h"
+#include "gfx/gfx_def.h"
 #include "gfx/gfxfilter_d3d.h"
 #include "gfx/gfxfilter_aad3d.h"
 #include "platform/base/agsplatformdriver.h"
@@ -1071,14 +1072,15 @@ void D3DGraphicsDriver::_reDrawLastFrame()
   RestoreDrawLists();
 }
 
-void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, const D3DMATRIX &matGlobal)
+void D3DGraphicsDriver::_renderSprite(const D3DDrawListEntry *drawListEntry, const D3DMATRIX &matGlobal,
+    const SpriteColorTransform &color)
 {
   HRESULT hr;
   D3DBitmap *bmpToDraw = drawListEntry->ddb;
   D3DMATRIX matSelfTransform;
   D3DMATRIX matTransform;
 
-  const int alpha = bmpToDraw->_alpha;
+  const int alpha = (color.Alpha * bmpToDraw->_alpha) / 255;
 
   if (bmpToDraw->_tintSaturation > 0)
   {
@@ -1386,11 +1388,11 @@ size_t D3DGraphicsDriver::RenderSpriteBatch(const D3DSpriteBatch &batch, size_t 
             if (DoNullSpriteCallback(e.x, (int)direct3ddevice))
             {
                 auto stageEntry = D3DDrawListEntry((D3DBitmap*)_stageScreen.DDB, batch.ID, 0, 0);
-                _renderSprite(&stageEntry, batch.Matrix);
+                _renderSprite(&stageEntry, batch.Matrix, batch.Color);
             }
             break;
         default:
-            _renderSprite(&e, batch.Matrix);
+            _renderSprite(&e, batch.Matrix, batch.Color);
             break;
         }
     }
@@ -1449,7 +1451,7 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     // Assign the new spritebatch
     if (_spriteBatches.size() <= index)
         _spriteBatches.resize(index + 1);
-    _spriteBatches[index] = D3DSpriteBatch(index, viewport, matFinal);
+    _spriteBatches[index] = D3DSpriteBatch(index, viewport, matFinal, desc.Transform.Color);
 
     // create stage screen for plugin raw drawing
     int src_w = viewport.GetWidth() / desc.Transform.ScaleX;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -56,10 +56,8 @@ struct D3DTextureTile : public TextureTile
 class D3DBitmap : public BaseDDB
 {
 public:
-    // Transparency is a bit counter-intuitive
-    // 0=not transparent, 255=invisible, 1..254 barely visible .. mostly visible
-    int  GetTransparency() const override { return _transparency; }
-    void SetTransparency(int transparency) override { _transparency = transparency; }
+    int  GetAlpha() const override { return _alpha; }
+    void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
     void SetStretch(int width, int height, bool useResampler = true) override
     {
@@ -88,8 +86,7 @@ public:
     int _red, _green, _blue;
     int _tintSaturation;
     int _lightLevel;
-    bool _hasAlpha;
-    int _transparency;
+    int _alpha;
 
     D3DBitmap(int width, int height, int colDepth, bool opaque)
     {
@@ -108,7 +105,7 @@ public:
         _red = _green = _blue = 0;
         _tintSaturation = 0;
         _lightLevel = 0;
-        _transparency = 0;
+        _alpha = 255;
         _opaque = opaque;
     }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -166,10 +166,12 @@ struct D3DSpriteBatch
     // Transformation matrix, built from the batch description
     // TODO: investigate possibility of using glm here (might need conversion to D3D matrix format)
     D3DMATRIX Matrix;
+    // Batch color transformation
+    SpriteColorTransform Color;
 
     D3DSpriteBatch() = default;
-    D3DSpriteBatch(uint32_t id, const Rect view, const D3DMATRIX &matrix)
-        : ID(id), Viewport(view), Matrix(matrix) {}
+    D3DSpriteBatch(uint32_t id, const Rect view, const D3DMATRIX &matrix, const SpriteColorTransform &color)
+        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
 };
 typedef std::vector<D3DSpriteBatch>    D3DSpriteBatches;
 
@@ -292,7 +294,7 @@ private:
     void SetScissor(const Rect &clip);
     void RenderSpriteBatches();
     size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from);
-    void _renderSprite(const D3DDrawListEntry *entry, const D3DMATRIX &matGlobal);
+    void _renderSprite(const D3DDrawListEntry *entry, const D3DMATRIX &matGlobal, const SpriteColorTransform &color);
     void _renderFromTexture();
 };
 


### PR DESCRIPTION
As #1393 makes it possible to accelerate gui controls, there's a next step to improve gui perfomance: support GUIControl.Transparency, implemented as a texture's render mode. Before that if one would like to have a translucent button graphic, they would have to either put that button on a standalone GUI, or use raw drawing (DrawImage with transparency arg) which is slower, especially in high-res games.

Adding transparency property itself does not require much changes, as all the logic is there. But since controls are part of the GUI sprite batch, this also means supporting batch's own alpha.