### PR TITLE
Editor: fixed "Select area" tool issues

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1738,7 +1738,15 @@ namespace AGS.Editor.Components
                 throw new InvalidOperationException("No room is currently loaded");
             }
 
+            // adjust coordinates to mask resolution
+            double scale = _loadedRoom.GetMaskScale(maskType);
+            x = (int)(x * scale);
+            y = (int)(y * scale);
+
             Bitmap mask = _maskCache[maskType];
+
+            if (x < 0 || y < 0 || x > mask.Width || y > mask.Height) return 0;
+
             return mask.GetRawData()[(y * mask.Width) + x];
         }
 


### PR DESCRIPTION
Corrected missing adjustment for mask resolution and handled out of bounds coordinates.

Closes #1625 

Is it fine like this or should the x/y traslation be moved elsewhere?