### PR TITLE
AGS 4 Editor: Fixes importing room template and existing room

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -416,6 +416,7 @@ namespace AGS.Editor.Components
                 }
 
                 UnloadedRoom newRoom = new UnloadedRoom(newRoomNumber);
+                Task.WaitAll(ConvertRoomFromCrmToOpenFormat(newRoom, null).ToArray());
                 AddSingleItem(newRoom);                
 				_agsEditor.CurrentGame.FilesAddedOrRemoved = true;
 
@@ -514,7 +515,7 @@ namespace AGS.Editor.Components
 				}
 
 
-                Task.WaitAll(ConvertRoomFromCrmToOpenFormat(newRoom, null, true).ToArray());
+                Task.WaitAll(ConvertRoomFromCrmToOpenFormat(newRoom, null, template.FileName == null).ToArray());
 
                 string newNodeID = AddSingleItem(newRoom);
                 _agsEditor.CurrentGame.FilesAddedOrRemoved = true;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -376,7 +376,7 @@ HAGSError extract_room_template_files(const AGSString &templateFileName, int new
     }
     char outputName[MAX_PATH];
     AGSString extension = AGSPath::GetFileExtension(thisFile);
-    sprintf(outputName, "room%d%s", newRoomNumber, extension.GetCStr());
+    sprintf(outputName, "room%d.%s", newRoomNumber, extension.GetCStr());
     Stream *wrout = AGSFile::CreateFile(outputName);
     if (!wrout) 
     {


### PR DESCRIPTION
One problem was that the open format conversion function expects files with extension, while the room template unpacking saves them as "room3asc" and similar. 

The other issue with importing an existing room was that the conversion was not happening.

I tested game template, room templates, adding existing room, and creating a blank room. I hope I covered all the cases with this last fix.