### PR TITLE
CMake: fix missing change to script/cc_internal.h

### DIFF
--- a/Compiler/Makefile
+++ b/Compiler/Makefile
@@ -23,8 +23,7 @@ LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
 CFLAGS   += -Werror=implicit-function-declaration
 
 COMMON_OBJS = \
-	../Common/script/cc_error.cpp \
-	../Common/script/cc_options.cpp \
+	../Common/script/cc_common.cpp \
 	../Common/script/cc_script.cpp \
 	../Common/util/bufferedstream.cpp \
 	../Common/util/cmdlineopts.cpp \


### PR DESCRIPTION
Edit: feel free to include this directly in the master branch, adding script/cc_internal.h there is not needed to build but is needed for editing `script/cc_internal.h` in CMake based IDEs.