### PR TITLE
Script API: implement Character.AnimationVolume and volume param for Animate()

### DIFF
--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -188,7 +188,8 @@ enum GuiSvgVersion
     kGuiSvgVersion_Initial  = 0,
     kGuiSvgVersion_350,
     kGuiSvgVersion_36020,
-    kGuiSvgVersion_36023
+    kGuiSvgVersion_36023,
+    kGuiSvgVersion_36025
 };
 
 enum GuiDisableStyle

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1680,7 +1680,7 @@ builtin managed struct Label extends GUIControl {
 builtin managed struct Button extends GUIControl {
 #ifdef SCRIPT_API_v360
   /// Animates the button graphic using the specified view loop.
-  import void Animate(int view, int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eNoBlock, Direction=eForwards, int frame=0);
+  import void Animate(int view, int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eNoBlock, Direction=eForwards, int frame=0, int volume=-1);
 #endif
 #ifndef SCRIPT_API_v360
   /// Animates the button graphic using the specified view loop.
@@ -2244,14 +2244,15 @@ builtin struct System {
 };
 
 builtin managed struct Object {
+  /// Animates the object using its current view.
+  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards
 #ifdef SCRIPT_API_v3507
-  /// Animates the object using its current view.
-  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
+    , int frame=0
+#endif  
+#ifdef SCRIPT_API_v360
+    , int volume=-1
 #endif
-#ifndef SCRIPT_API_v3507
-  /// Animates the object using its current view.
-  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards);
-#endif
+  );
   /// Gets the object that is on the screen at the specified co-ordinates.
   import static Object* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
 #ifndef STRICT_STRINGS
@@ -2385,14 +2386,15 @@ builtin managed struct Character {
   import function AddInventory(InventoryItem *item, int addAtIndex=SCR_NO_VALUE);
   /// Manually adds a waypoint to the character's movement path.
   import function AddWaypoint(int x, int y);
+  /// Animates the character using its current locked view.
+  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards
 #ifdef SCRIPT_API_v3507
-  /// Animates the character using its current locked view.
-  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards, int frame=0);
+    , int frame=0
+#endif  
+#ifdef SCRIPT_API_v360
+    , int volume=-1
 #endif
-#ifndef SCRIPT_API_v3507
-  /// Animates the character using its current locked view.
-  import function Animate(int loop, int delay, RepeatStyle=eOnce, BlockingStyle=eBlock, Direction=eForwards);
-#endif
+  );
 #ifdef SCRIPT_API_v340
   /// Moves the character to another room. If this is the player character, the game will also switch to that room.
   import function ChangeRoom(int room, int x=SCR_NO_VALUE, int y=SCR_NO_VALUE, CharacterDirection direction=eDirectionNone);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2624,6 +2624,8 @@ builtin managed struct Character {
   import static Character* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
 #endif
 #ifdef SCRIPT_API_v360
+  /// Gets/sets the volume modifier (0-100) of frame-linked sounds for this character.
+  import attribute int  AnimationVolume;
   /// Gets/sets the character's idle animation delay.
   import attribute int  IdleAnimationDelay;
 #endif

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -178,25 +178,33 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
 
 }
 
-void Character_AnimateFrom(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction, int sframe) {
-
+void Character_AnimateEx(CharacterInfo *chaa, int loop, int delay, int repeat,
+    int blocking, int direction, int sframe, int volume = -1)
+{
     if (direction == FORWARDS)
         direction = 0;
     else if (direction == BACKWARDS)
         direction = 1;
-    else
-        quit("!Character.Animate: Invalid DIRECTION parameter");
+    if (blocking == BLOCKING)
+        blocking = 1;
+    else if (blocking == IN_BACKGROUND)
+        blocking = 0;
 
-    animate_character(chaa, loop, delay, repeat, 0, direction, sframe);
+    if ((repeat < 0) || (repeat > 1))
+        quit("!Character.Animate: invalid repeat value");
+    if ((blocking < 0) || (blocking > 1))
+        quit("!Character.Animate: invalid blocking value");
+    if ((direction < 0) || (direction > 1))
+        quit("!Character.Animate: invalid direction");
 
-    if ((blocking == BLOCKING) || (blocking == 1))
+    animate_character(chaa, loop, delay, repeat, 0, direction, sframe, volume);
+
+    if (blocking != 0)
         GameLoopUntilValueIsZero(&chaa->animating);
-    else if ((blocking != IN_BACKGROUND) && (blocking != 0))
-        quit("!Character.Animate: Invalid BLOCKING parameter");
 }
 
 void Character_Animate(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction) {
-    Character_AnimateFrom(chaa, loop, delay, repeat, blocking, direction, 0);
+    Character_AnimateEx(chaa, loop, delay, repeat, blocking, direction, 0, -1);
 }
 
 void Character_ChangeRoomAutoPosition(CharacterInfo *chaa, int room, int newPos) 
@@ -284,7 +292,7 @@ void Character_ChangeView(CharacterInfo *chap, int vii) {
     debug_script_log("%s: Change view to %d", chap->scrname, vii+1);
     chap->defview = vii;
     chap->view = vii;
-    chap->animating = 0;
+    stop_character_anim(chap);
     chap->frame = 0;
     chap->wait = 0;
     chap->walkwait = 0;
@@ -600,7 +608,7 @@ void Character_LockViewEx(CharacterInfo *chap, int vii, int stopMoving) {
         Character_StopMoving(chap);
     }
     chap->view=vii;
-    chap->animating=0;
+    stop_character_anim(chap);
     FindReasonableLoopForCharacter(chap);
     chap->frame=0;
     chap->wait=0;
@@ -1003,7 +1011,7 @@ void Character_UnlockViewEx(CharacterInfo *chaa, int stopMoving) {
             maxloop = 4;
         FindReasonableLoopForCharacter(chaa);
     }
-    chaa->animating = 0;
+    stop_character_anim(chaa);
     chaa->idleleft = chaa->idletime;
     chaa->pic_xoffs = 0;
     chaa->pic_yoffs = 0;
@@ -1679,7 +1687,7 @@ void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims) {
     }
 
     if ((chin->animating) && (autoWalkAnims))
-        chin->animating = 0;
+        stop_character_anim(chin);
 
     if (chin->idleleft < 0) {
         ReleaseCharacterView(chac);
@@ -2120,13 +2128,15 @@ void setup_player_character(int charid) {
     }
 }
 
-void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride, int direction, int sframe) {
-
+void animate_character(CharacterInfo *chap, int loopn, int sppd, int rept,
+    int noidleoverride, int direction, int sframe, int volume)
+{
     if ((chap->view < 0) || (chap->view > game.numviews)) {
         quitprintf("!AnimateCharacter: you need to set the view number first\n"
             "(trying to animate '%s' using loop %d. View is currently %d).",chap->name,loopn,chap->view+1);
     }
-    debug_script_log("%s: Start anim view %d loop %d, spd %d, repeat %d, frame: %d", chap->scrname, chap->view+1, loopn, sppd, rept, sframe);
+    debug_script_log("%s: Start anim view %d loop %d, spd %d, repeat %d, frame: %d",
+        chap->scrname, chap->view+1, loopn, sppd, rept, sframe);
     if ((chap->idleleft < 0) && (noidleoverride == 0)) {
         // if idle view in progress for the character (and this is not the
         // "start idle animation" animate_character call), stop the idle anim
@@ -2153,30 +2163,43 @@ void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noi
             sframe = views[chap->view].loops[loopn].numFrames - (-sframe);
     }
     chap->frame = sframe;
-
     chap->wait = sppd + views[chap->view].loops[loopn].frames[chap->frame].speed;
+    charextra[chap->index_id].cur_anim_volume = std::min(100, volume);
+
     CheckViewFrameForCharacter(chap);
 }
 
-void CheckViewFrameForCharacter(CharacterInfo *chi) {
+void stop_character_anim(CharacterInfo *chap)
+{ // TODO: may expand with resetting more properties,
+  // but have to be careful to not break logic somewhere
+    chap->animating = 0;
+    charextra[chap->index_id].cur_anim_volume = -1;
+}
 
-    int soundVolume = SCR_NO_VALUE;
-
-    if (chi->flags & CHF_SCALEVOLUME) {
-        // adjust the sound volume using the character's zoom level
+void CheckViewFrameForCharacter(CharacterInfo *chi)
+{
+    int frame_vol = -1;
+    // If there's an explicit animation volume - use that first
+    if (charextra[chi->index_id].cur_anim_volume >= 0)
+    {
+        frame_vol = charextra[chi->index_id].cur_anim_volume;
+    }
+    // Adjust the sound volume using the character's zoom level
+    // NOTE: historically scales only in 0-100 range :/
+    if (chi->flags & CHF_SCALEVOLUME)
+    {
         int zoom_level = charextra[chi->index_id].zoom;
-        if (zoom_level == 0)
+        if (zoom_level <= 0)
             zoom_level = 100;
-
-        soundVolume = zoom_level;
-
-        if (soundVolume < 0)
-            soundVolume = 0;
-        if (soundVolume > 100)
-            soundVolume = 100;
+        else
+            zoom_level = std::min(zoom_level, 100);
+        if (frame_vol < 0)
+            frame_vol = zoom_level;
+        else
+            frame_vol = frame_vol * zoom_level / 100;
     }
 
-    CheckViewFrame(chi->view, chi->loop, chi->frame, soundVolume);
+    CheckViewFrame(chi->view, chi->loop, chi->frame, frame_vol);
 }
 
 Bitmap *GetCharacterImage(int charid, int *isFlipped) 
@@ -2830,7 +2853,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         if (loaded_game_file_version > kGameVersion_272)
             speakingChar->loop = oldloop;
 
-        speakingChar->animating=0;
+        stop_character_anim(speakingChar);
         speakingChar->frame = charFrameWas;
         speakingChar->wait=0;
         speakingChar->idleleft = speakingChar->idletime;
@@ -2982,9 +3005,14 @@ RuntimeScriptValue Sc_Character_Animate(void *self, const RuntimeScriptValue *pa
     API_OBJCALL_VOID_PINT5(CharacterInfo, Character_Animate);
 }
 
-RuntimeScriptValue Sc_Character_AnimateFrom(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Character_Animate6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT6(CharacterInfo, Character_AnimateFrom);
+    API_OBJCALL_VOID_PINT6(CharacterInfo, Character_AnimateEx);
+}
+
+RuntimeScriptValue Sc_Character_Animate7(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT7(CharacterInfo, Character_AnimateEx);
 }
 
 // void | CharacterInfo *chaa, int room, int x, int y
@@ -3836,7 +3864,8 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
     ccAddExternalObjectFunction("Character::AddInventory^2",            Sc_Character_AddInventory);
 	ccAddExternalObjectFunction("Character::AddWaypoint^2",             Sc_Character_AddWaypoint);
 	ccAddExternalObjectFunction("Character::Animate^5",                 Sc_Character_Animate);
-    ccAddExternalObjectFunction("Character::Animate^6",                 Sc_Character_AnimateFrom);
+    ccAddExternalObjectFunction("Character::Animate^6",                 Sc_Character_Animate6);
+    ccAddExternalObjectFunction("Character::Animate^7",                 Sc_Character_Animate7);
 	ccAddExternalObjectFunction("Character::ChangeRoom^3",              Sc_Character_ChangeRoom);
     ccAddExternalObjectFunction("Character::ChangeRoom^4",              Sc_Character_ChangeRoomSetLoop);
 	ccAddExternalObjectFunction("Character::ChangeRoomAutoPosition^2",  Sc_Character_ChangeRoomAutoPosition);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1147,6 +1147,15 @@ void Character_SetAnimationSpeed(CharacterInfo *chaa, int newval) {
         chaa->idle_anim_speed = chaa->animspeed + 5;
 }
 
+int Character_GetAnimationVolume(CharacterInfo *chaa) {
+    return charextra[chaa->index_id].anim_volume;
+}
+
+void Character_SetAnimationVolume(CharacterInfo *chaa, int newval) {
+
+    charextra[chaa->index_id].anim_volume = std::min(newval, 100); // negative means default
+}
+
 int Character_GetBaseline(CharacterInfo *chaa) {
 
     if (chaa->baseline < 1)
@@ -2183,6 +2192,11 @@ void CheckViewFrameForCharacter(CharacterInfo *chi)
     if (charextra[chi->index_id].cur_anim_volume >= 0)
     {
         frame_vol = charextra[chi->index_id].cur_anim_volume;
+    }
+    // Next check the character's animation volume setting
+    else if (charextra[chi->index_id].anim_volume >= 0)
+    {
+        frame_vol = charextra[chi->index_id].anim_volume;
     }
     // Adjust the sound volume using the character's zoom level
     // NOTE: historically scales only in 0-100 range :/
@@ -3376,6 +3390,16 @@ RuntimeScriptValue Sc_Character_SetAnimationSpeed(void *self, const RuntimeScrip
     API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetAnimationSpeed);
 }
 
+RuntimeScriptValue Sc_Character_GetAnimationVolume(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(CharacterInfo, Character_GetAnimationVolume);
+}
+
+RuntimeScriptValue Sc_Character_SetAnimationVolume(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT(CharacterInfo, Character_SetAnimationVolume);
+}
+
 // int (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetBaseline(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -3929,6 +3953,8 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
 	ccAddExternalObjectFunction("Character::get_Animating",             Sc_Character_GetAnimating);
 	ccAddExternalObjectFunction("Character::get_AnimationSpeed",        Sc_Character_GetAnimationSpeed);
 	ccAddExternalObjectFunction("Character::set_AnimationSpeed",        Sc_Character_SetAnimationSpeed);
+    ccAddExternalObjectFunction("Character::get_AnimationVolume",       Sc_Character_GetAnimationVolume);
+    ccAddExternalObjectFunction("Character::set_AnimationVolume",       Sc_Character_SetAnimationVolume);
 	ccAddExternalObjectFunction("Character::get_Baseline",              Sc_Character_GetBaseline);
 	ccAddExternalObjectFunction("Character::set_Baseline",              Sc_Character_SetBaseline);
 	ccAddExternalObjectFunction("Character::get_BlinkInterval",         Sc_Character_GetBlinkInterval);

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -161,7 +161,10 @@ struct MoveList;
 namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
 
-void animate_character(CharacterInfo *chap, int loopn,int sppd,int rept, int noidleoverride = 0, int direction = 0, int sframe = 0);
+void animate_character(CharacterInfo *chap, int loopn,int sppd, int rept,
+    int noidleoverride = 0, int direction = 0, int sframe = 0, int volume = -1);
+// Clears up animation parameters
+void stop_character_anim(CharacterInfo *chap);
 void walk_character(int chac,int tox,int toy,int ignwal, bool autoWalkAnims);
 int  find_looporder_index (int curloop);
 // returns 0 to use diagonal, 1 to not

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -17,7 +17,7 @@
 
 using AGS::Common::Stream;
 
-void CharacterExtras::ReadFromFile(Stream *in)
+void CharacterExtras::ReadFromSavegame(Stream *in, int save_ver)
 {
     in->ReadArrayOfInt16(invorder, MAX_INVORDER);
     invorder_count = in->ReadInt16();
@@ -34,9 +34,16 @@ void CharacterExtras::ReadFromFile(Stream *in)
     process_idle_this_time = in->ReadInt8();
     slow_move_counter = in->ReadInt8();
     animwait = in->ReadInt16();
+    if (save_ver >= 2) // expanded at ver 2
+    {
+        anim_volume = in->ReadInt8();
+        cur_anim_volume = in->ReadInt8();
+        in->ReadInt8(); // reserved to fill int32
+        in->ReadInt8();
+    }
 }
 
-void CharacterExtras::WriteToFile(Stream *out)
+void CharacterExtras::WriteToSavegame(Stream *out)
 {
     out->WriteArrayOfInt16(invorder, MAX_INVORDER);
     out->WriteInt16(invorder_count);
@@ -53,4 +60,8 @@ void CharacterExtras::WriteToFile(Stream *out)
     out->WriteInt8(process_idle_this_time);
     out->WriteInt8(slow_move_counter);
     out->WriteInt16(animwait);
+    out->WriteInt8(anim_volume);
+    out->WriteInt8(cur_anim_volume);
+    out->WriteInt8(0); // reserved to fill int32
+    out->WriteInt8(0);
 }

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -47,8 +47,8 @@ struct CharacterExtras {
     int   anim_volume = -1; // default animation volume (-1 use clip default)
     int   cur_anim_volume = -1; // current animation sound volume (-1 = default)
 
-    void ReadFromFile(Common::Stream *in);
-    void WriteToFile(Common::Stream *out);
+    void ReadFromSavegame(Common::Stream *in, int save_ver);
+    void WriteToSavegame(Common::Stream *out);
 };
 
 #endif // __AGS_EE_AC__CHARACTEREXTRAS_H

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -44,6 +44,7 @@ struct CharacterExtras {
     char  process_idle_this_time = 0;
     char  slow_move_counter = 0;
     short animwait = 0;
+    int   anim_volume = -1; // default animation volume (-1 use clip default)
     int   cur_anim_volume = -1; // current animation sound volume (-1 = default)
 
     void ReadFromFile(Common::Stream *in);

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -44,6 +44,7 @@ struct CharacterExtras {
     char  process_idle_this_time = 0;
     char  slow_move_counter = 0;
     short animwait = 0;
+    int   cur_anim_volume = -1; // current animation sound volume (-1 = default)
 
     void ReadFromFile(Common::Stream *in);
     void WriteToFile(Common::Stream *out);

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -303,18 +303,19 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
         // Normal view animation
         const int oldframe = frame;
 
+        bool done_anim = false;
         if ((aa == char_speaking) &&
             (play.speech_in_post_state ||
             ((!play.speech_has_voice) &&
                 (play.close_mouth_speech_time > 0) &&
                 (play.messagetime < play.close_mouth_speech_time)))) {
             // finished talking - stop animation
-            animating = 0;
+            done_anim = true;
             frame = 0;
         } else {
             if (!CycleViewAnim(view, loop, frame, (animating & CHANIM_BACKWARDS) == 0,
                     (animating & CHANIM_REPEAT) ? ANIM_REPEAT : ANIM_ONCE)) {
-                animating = 0; // finished animating
+                done_anim = true; // finished animating
                 // end of idle anim
                 if (idleleft < 0) {
                     // constant anim, reset (need this cos animating==0)
@@ -338,6 +339,9 @@ int CharacterInfo::update_character_animating(int &aa, int &doing_nothing)
 
         if (frame != oldframe)
           CheckViewFrameForCharacter(this);
+
+        if (done_anim)
+          stop_character_anim(this);
       }
     }
 

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -11,6 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include <algorithm>
 #include "ac/global_object.h"
 #include "ac/common.h"
 #include "ac/object.h"
@@ -221,7 +222,7 @@ int GetObjectBaseline(int obn) {
     return objs[obn].baseline;
 }
 
-void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking, int sframe) {
+void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking, int sframe, int volume) {
     if (obn>=MANOBJNUM) {
         scAnimateCharacter(obn - 100,loopn,spdd,rept);
         return;
@@ -266,7 +267,8 @@ void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, in
     objs[obn].num = Math::InRangeOrDef<uint16_t>(pic, 0);
     if (pic > UINT16_MAX)
         debug_script_warn("Warning: object's (id %d) sprite %d is outside of internal range (%d), reset to 0", obn, pic, UINT16_MAX);
-    CheckViewFrame (objs[obn].view, loopn, objs[obn].frame);
+    objs[obn].anim_volume = std::min(volume, 100); // NOTE: negative volume means use defaults
+    CheckViewFrame(objs[obn].view, loopn, objs[obn].frame, objs[obn].anim_volume);
 
     if (blocking)
         GameLoopUntilValueIsZero(&objs[obn].cycling);

--- a/Engine/ac/global_object.h
+++ b/Engine/ac/global_object.h
@@ -40,7 +40,7 @@ void SetObjectBaseline (int obn, int basel);
 int  GetObjectBaseline(int obn);
 void AnimateObjectEx(int obn,int loopn,int spdd,int rept, int direction, int blocking);
 void AnimateObject(int obn,int loopn,int spdd,int rept);
-void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking, int sframe);
+void AnimateObjectImpl(int obn, int loopn, int spdd, int rept, int direction, int blocking, int sframe, int volume = -1);
 void MergeObject(int obn);
 void StopObjectMoving(int objj);
 void ObjectOff(int obn);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -119,26 +119,29 @@ int Object_GetBaseline(ScriptObject *objj) {
     return GetObjectBaseline(objj->id);
 }
 
-void Object_AnimateFrom(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction, int sframe) {
+void Object_AnimateEx(ScriptObject *objj, int loop, int delay, int repeat,
+    int blocking, int direction, int sframe, int volume = -1) {
     if (direction == FORWARDS)
         direction = 0;
     else if (direction == BACKWARDS)
         direction = 1;
-    else
-        quit("!Object.Animate: Invalid DIRECTION parameter");
-
-    if ((blocking == BLOCKING) || (blocking == 1))
+    if (blocking == BLOCKING)
         blocking = 1;
-    else if ((blocking == IN_BACKGROUND) || (blocking == 0))
+    else if (blocking == IN_BACKGROUND)
         blocking = 0;
-    else
-        quit("!Object.Animate: Invalid BLOCKING parameter");
 
-    AnimateObjectImpl(objj->id, loop, delay, repeat, direction, blocking, sframe);
+    if ((repeat < 0) || (repeat > 1))
+        quit("!Object.Animate: invalid repeat value");
+    if ((blocking < 0) || (blocking > 1))
+        quit("!Object.Animate: invalid blocking value");
+    if ((direction < 0) || (direction > 1))
+        quit("!Object.Animate: invalid direction");
+
+    AnimateObjectImpl(objj->id, loop, delay, repeat, direction, blocking, sframe, volume);
 }
 
 void Object_Animate(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction) {
-    Object_AnimateFrom(objj, loop, delay, repeat, blocking, direction, 0);
+    Object_AnimateEx(objj, loop, delay, repeat, blocking, direction, 0, -1);
 }
 
 void Object_StopAnimating(ScriptObject *objj) {
@@ -673,9 +676,14 @@ RuntimeScriptValue Sc_Object_Animate(void *self, const RuntimeScriptValue *param
     API_OBJCALL_VOID_PINT5(ScriptObject, Object_Animate);
 }
 
-RuntimeScriptValue Sc_Object_AnimateFrom(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Object_Animate6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT6(ScriptObject, Object_AnimateFrom);
+    API_OBJCALL_VOID_PINT6(ScriptObject, Object_AnimateEx);
+}
+
+RuntimeScriptValue Sc_Object_Animate7(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_VOID_PINT7(ScriptObject, Object_AnimateEx);
 }
 
 // int (ScriptObject *objj, ScriptObject *obj2)
@@ -1045,7 +1053,8 @@ RuntimeScriptValue Sc_Object_SetY(void *self, const RuntimeScriptValue *params, 
 void RegisterObjectAPI()
 {
     ccAddExternalObjectFunction("Object::Animate^5",                Sc_Object_Animate);
-    ccAddExternalObjectFunction("Object::Animate^6",                Sc_Object_AnimateFrom);
+    ccAddExternalObjectFunction("Object::Animate^6",                Sc_Object_Animate6);
+    ccAddExternalObjectFunction("Object::Animate^7",                Sc_Object_Animate7);
     ccAddExternalObjectFunction("Object::IsCollidingWithObject^1",  Sc_Object_IsCollidingWithObject);
     ccAddExternalObjectFunction("Object::GetName^1",                Sc_Object_GetName);
     ccAddExternalObjectFunction("Object::GetProperty^1",            Sc_Object_GetProperty);

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -119,9 +119,16 @@ void RoomObject::ReadFromSavegame(Stream *in, int save_ver)
     flags = in->ReadInt8();
     blocking_width = in->ReadInt16();
     blocking_height = in->ReadInt16();
-    if (save_ver > 0)
+    if (save_ver >= 1)
     {
         name = StrUtil::ReadString(in);
+    }
+    if (save_ver >= 2)
+    {
+        anim_volume = in->ReadInt8();
+        in->ReadInt8(); // reserved to fill int32
+        in->ReadInt8();
+        in->ReadInt8();
     }
 }
 
@@ -152,4 +159,8 @@ void RoomObject::WriteToSavegame(Stream *out) const
     out->WriteInt16(blocking_width);
     out->WriteInt16(blocking_height);
     StrUtil::WriteString(name, out);
+    out->WriteInt8(anim_volume);
+    out->WriteInt8(0); // reserved to fill int32
+    out->WriteInt8(0);
+    out->WriteInt8(0);
 }

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -90,7 +90,7 @@ void RoomObject::UpdateCyclingView(int ref_id)
       return;
 
     wait=vfptr->speed+overall_speed;
-    CheckViewFrame (view, loop, frame);
+    CheckViewFrame(view, loop, frame, anim_volume);
 }
 
 void RoomObject::ReadFromSavegame(Stream *in, int save_ver)

--- a/Engine/ac/roomobject.h
+++ b/Engine/ac/roomobject.h
@@ -48,6 +48,7 @@ struct RoomObject {
     char  flags;
     // Down to here is a part of the plugin API
     short blocking_width, blocking_height;
+    int   anim_volume = -1; // current animation volume
     Common::String name;
 
     RoomObject();

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -117,17 +117,18 @@ void precache_view(int view)
     }
 }
 
-// the specified frame has just appeared, see if we need
-// to play a sound or whatever
-void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
+// Handle the new animation frame (play linked sounds, etc)
+void CheckViewFrame(int view, int loop, int frame, int sound_volume)
+{
     ScriptAudioChannel *channel = nullptr;
+    // Play a sound, if one is linked to this frame
     if (game.IsLegacyAudioSystem())
     {
         // sound field contains legacy sound num, so we also need an actual clip index
         const int sound = views[view].loops[loop].frames[frame].sound;
-        int &clip_id = views[view].loops[loop].frames[frame].audioclip;
         if (sound > 0)
         {
+            int &clip_id = views[view].loops[loop].frames[frame].audioclip;
             if (clip_id < 0)
             {
                 ScriptAudioClip* clip = GetAudioClipForOldStyleNumber(game, false, sound);
@@ -141,12 +142,12 @@ void CheckViewFrame (int view, int loop, int frame, int sound_volume) {
     else
     {
         if (views[view].loops[loop].frames[frame].sound >= 0) {
-            // play this sound (eg. footstep)
             channel = play_audio_clip_by_index(views[view].loops[loop].frames[frame].sound);
         }
     }
-    if (sound_volume != SCR_NO_VALUE && channel != nullptr)
+    if (channel && (sound_volume >= 0))
     {
+        sound_volume = std::min(sound_volume, 100);
         auto* ch = AudioChans::GetChannel(channel->id);
         if (ch)
             ch->set_volume100(ch->get_volume100() * sound_volume / 100);

--- a/Engine/ac/viewframe.h
+++ b/Engine/ac/viewframe.h
@@ -40,7 +40,8 @@ int  ViewFrame_GetLoop(ScriptViewFrame *svf);
 int  ViewFrame_GetFrame(ScriptViewFrame *svf);
 
 void precache_view(int view);
-void CheckViewFrame (int view, int loop, int frame, int sound_volume=SCR_NO_VALUE);
+// Handle the new animation frame (play linked sounds, etc)
+void CheckViewFrame(int view, int loop, int frame, int sound_volume =- 1);
 // draws a view frame, flipped if appropriate
 void DrawViewFrame(Common::Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha_blend = false);
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -539,7 +539,7 @@ HSaveError WriteCharacters(Stream *out)
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].WriteToFile(out);
-        charextra[i].WriteToFile(out);
+        charextra[i].WriteToSavegame(out);
         Properties::WriteValues(play.charProps[i], out);
         if (loaded_game_file_version <= kGameVersion_272)
             WriteTimesRun272(*game.intrChar[i], out);
@@ -557,7 +557,7 @@ HSaveError ReadCharacters(Stream *in, int32_t cmp_ver, const PreservedParams& /*
     for (int i = 0; i < game.numcharacters; ++i)
     {
         game.chars[i].ReadFromFile(in);
-        charextra[i].ReadFromFile(in);
+        charextra[i].ReadFromSavegame(in, cmp_ver);
         Properties::ReadValues(play.charProps[i], in);
         if (loaded_game_file_version <= kGameVersion_272)
             ReadTimesRun272(*game.intrChar[i], in);
@@ -634,7 +634,7 @@ HSaveError WriteGUI(Stream *out)
     size_t num_abuts = GetAnimatingButtonCount();
     out->WriteInt32(num_abuts);
     for (size_t i = 0; i < num_abuts; ++i)
-        GetAnimatingButtonByIndex(i)->WriteToFile(out);
+        GetAnimatingButtonByIndex(i)->WriteToSavegame(out);
     return HSaveError::None();
 }
 
@@ -700,7 +700,7 @@ HSaveError ReadGUI(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, R
     for (int i = 0; i < anim_count; ++i)
     {
         AnimatingGUIButton abut;
-        abut.ReadFromFile(in, cmp_ver);
+        abut.ReadFromSavegame(in, cmp_ver);
         AddButtonAnimation(abut);
     }
     return err;
@@ -1167,7 +1167,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Characters",
-        1,
+        2,
         0,
         WriteCharacters,
         ReadCharacters
@@ -1181,7 +1181,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "GUI",
-        kGuiSvgVersion_36023,
+        kGuiSvgVersion_36025,
         kGuiSvgVersion_Initial,
         WriteGUI,
         ReadGUI
@@ -1237,14 +1237,14 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Room States",
-        2,
+        3,
         0,
         WriteRoomStates,
         ReadRoomStates
     },
     {
         "Loaded Room State",
-        2, // should correspond to "Room States"
+        3, // must correspond to "Room States"
         0,
         WriteThisRoom,
         ReadThisRoom

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -210,7 +210,7 @@ static void ReadCharacterExtras_Aligned(Stream *in)
     AlignedStream align_s(in, Common::kAligned_Read);
     for (int i = 0; i < game.numcharacters; ++i)
     {
-        charextra[i].ReadFromFile(&align_s);
+        charextra[i].ReadFromSavegame(&align_s, 0);
         align_s.Reset();
     }
 }
@@ -241,7 +241,7 @@ void ReadAnimatedButtons_Aligned(Stream *in, int num_abuts)
     for (int i = 0; i < num_abuts; ++i)
     {
         AnimatingGUIButton abtn;
-        abtn.ReadFromFile(&align_s, 0);
+        abtn.ReadFromSavegame(&align_s, 0);
         AddButtonAnimation(abtn);
         align_s.Reset();
     }

--- a/Engine/gui/animatingguibutton.cpp
+++ b/Engine/gui/animatingguibutton.cpp
@@ -11,13 +11,13 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "gui/animatingguibutton.h"
+#include "gui/guidefines.h"
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+using namespace AGS::Common;
 
-void AnimatingGUIButton::ReadFromFile(Stream *in, int cmp_ver)
+void AnimatingGUIButton::ReadFromSavegame(Stream *in, int cmp_ver)
 {
     buttonid = in->ReadInt16();
     ongui = in->ReadInt16();
@@ -29,13 +29,21 @@ void AnimatingGUIButton::ReadFromFile(Stream *in, int cmp_ver)
     uint16_t anim_flags = in->ReadInt16(); // was repeat (0,1)
     wait = in->ReadInt16();
 
-    if (cmp_ver < 2) anim_flags &= 0x1; // restrict to repeat only
+    if (cmp_ver < kGuiSvgVersion_36020) anim_flags &= 0x1; // restrict to repeat only
     repeat = anim_flags & 0x1;
     blocking = (anim_flags >> 1) & 0x1;
     direction = (anim_flags >> 2) & 0x1;
+
+    if (cmp_ver >= kGuiSvgVersion_36025)
+    {
+        volume = in->ReadInt8();
+        in->ReadInt8(); // reserved to fill int32
+        in->ReadInt8();
+        in->ReadInt8();
+    }
 }
 
-void AnimatingGUIButton::WriteToFile(Stream *out)
+void AnimatingGUIButton::WriteToSavegame(Stream *out)
 {
     uint16_t anim_flags =
         (repeat & 0x1) |
@@ -51,4 +59,8 @@ void AnimatingGUIButton::WriteToFile(Stream *out)
     out->WriteInt16(speed);
     out->WriteInt16(anim_flags); // was repeat (0,1)
     out->WriteInt16(wait);
+    out->WriteInt8(volume);
+    out->WriteInt8(0); // reserved to fill int32
+    out->WriteInt8(0);
+    out->WriteInt8(0);
 }

--- a/Engine/gui/animatingguibutton.h
+++ b/Engine/gui/animatingguibutton.h
@@ -35,8 +35,8 @@ struct AnimatingGUIButton
     // relative volume of the frame sounds
     int volume = -1;
 
-    void ReadFromFile(Common::Stream *in, int cmp_ver);
-    void WriteToFile(Common::Stream *out);
+    void ReadFromSavegame(Common::Stream *in, int cmp_ver);
+    void WriteToSavegame(Common::Stream *out);
 };
 
 #endif // __AGS_EE_GUI__ANIMATINGGUIBUTTON_H

--- a/Engine/gui/animatingguibutton.h
+++ b/Engine/gui/animatingguibutton.h
@@ -25,12 +25,15 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-struct AnimatingGUIButton {
+struct AnimatingGUIButton
+{
     // index into guibuts array, GUI, button
-    short buttonid, ongui, onguibut;
+    short buttonid = -1, ongui = -1, onguibut = -1;
     // current animation status
-    uint16_t view, loop, frame;
-    short speed, repeat, blocking, direction, wait;
+    uint16_t view = 0, loop = 0, frame = 0;
+    short speed = 0, repeat = 0, blocking = 0, direction = 0, wait = 0;
+    // relative volume of the frame sounds
+    int volume = -1;
 
     void ReadFromFile(Common::Stream *in, int cmp_ver);
     void WriteToFile(Common::Stream *out);

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -417,6 +417,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     METHOD((CLASS*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue, params[6].IValue); \
     return RuntimeScriptValue((int32_t)0)
 
+#define API_OBJCALL_VOID_PINT8(CLASS, METHOD) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 8); \
+    METHOD((CLASS*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue, params[6].IValue, params[7].IValue); \
+    return RuntimeScriptValue((int32_t)0)
+
 #define API_OBJCALL_VOID_PFLOAT(CLASS, METHOD) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
     METHOD((CLASS*)self, params[0].FValue); \


### PR DESCRIPTION
**Problem**

This has been a user complaint for a while that you cannot alter the volume of sounds linked to the view frames (animation). As these sounds are played automatically, with the current audio system it's not always possible to know which channel they will play on, and even if it were possible, it's not possible to catch that moment when the sound starts playing and adjust it immediately.

**Solution**

The proposed solution seem to be the simpliest available without doing much overhaul of the animation and/or audio system.
Instead of trying to modify the animation frames or the clip properties (which are shared resources and may be played simultaneously from different characters or objects), we view the object as a sound emitter and animation as a process of playing the frames with certain parameters. Therefore the idea is to add volume property to the game object and as an optional parameter to the Animate() command.

* Added Character.AnimationVolume property, that determines the *relative* volume of sounds linked to the character's views. The range is 0-100. Set to -1 to ignore this parameter.
* Added an optional "volume" parameter to all three Animate functions (Button.Animate, Character.Animate, Object.Animate). Similarily, it determines the *relative* volume of sounds linked to frames during this particular animation. The range is 0-100. Set to -1 to ignore this parameter.

The reasoning for having AnimationVolume only in Character is that Characters have animations run implicitly (walking, speaking, idle), unlike other types which require explicit Animate call.
Animate's parameter has a priority over AnimationVolume, - this way you may have implicit character's animation volume and still override it with the Animate param when necessary.
On another hand, it is still possible to change Object and Button's volume in the middle of animation by re-calling Animate with different starting frame and volume

Character.ScaleVolume property is still applied over the chosen volume - I was not certain about this, but left this on.

**Example**

```
function repeatedly_execute() {
    player.AnimationVolume = (player.x * 100) / Room.Width;
}
```
^ Above will scale volume of player's animation depending on its X position in the room.