### PR TITLE
3.6.0: Room Overlays

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1292,6 +1292,8 @@ builtin managed struct Overlay {
   import static Overlay* CreateRoomGraphical(int x, int y, int slot, bool transparent);  // $AUTOCOMPLETESTATICONLY$
   /// Creates an overlay that displays some text inside the room.
   import static Overlay* CreateRoomTextual(int x, int y, int width, FontType, int colour, const string text, ...);  // $AUTOCOMPLETESTATICONLY$
+  /// Gets whether this overlay is located inside the room, as opposed to the screen layer.
+  import readonly attribute bool InRoom;
   /// Gets/sets the width of this overlay. Resizing overlay will scale its image.
   import attribute int Width;
   /// Gets/sets the height of this overlay. Resizing overlay will scale its image.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1288,6 +1288,10 @@ builtin managed struct Overlay {
   /// Gets/sets the Y position on the screen where this overlay is displayed.
   import attribute int Y;
 #ifdef SCRIPT_API_v360
+  /// Creates an overlay that displays a sprite inside the room.
+  import static Overlay* CreateRoomGraphical(int x, int y, int slot, bool transparent);  // $AUTOCOMPLETESTATICONLY$
+  /// Creates an overlay that displays some text inside the room.
+  import static Overlay* CreateRoomTextual(int x, int y, int width, FontType, int colour, const string text, ...);  // $AUTOCOMPLETESTATICONLY$
   /// Gets/sets the width of this overlay. Resizing overlay will scale its image.
   import attribute int Width;
   /// Gets/sets the height of this overlay. Resizing overlay will scale its image.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2728,7 +2728,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             }
             if (game.options[OPT_SPEECHTYPE] == 3)
                 overlay_x = 0;
-            face_talking=add_screen_overlay(overlay_x,ovr_yp,ovr_type,closeupface, closeupface_has_alpha);
+            face_talking=add_screen_overlay(false,overlay_x,ovr_yp,ovr_type,closeupface, closeupface_has_alpha);
             facetalkframe = 0;
             facetalkwait = viptr->loops[0].frames[0].speed + GetCharacterSpeechAnimationDelay(speakingChar);
             facetalkloop = 0;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -343,7 +343,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
 
         if (!overlayPositionFixed)
         {
-            screenover[nse].positionRelativeToScreen = false;
+            screenover[nse].SetRoomRelative(true);
             VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(screenover[nse].x, screenover[nse].y, false);
             screenover[nse].x = vpt.first.X;
             screenover[nse].y = vpt.first.Y;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -71,7 +71,8 @@ struct DisplayVars
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
 // pass blocking=2 to create permanent overlay
-ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont, int asspch, int isThought, int allowShrink, bool overlayPositionFixed)
+ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
+    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer)
 {
     const bool use_speech_textwindow = (asspch < 0) && (game.options[OPT_SPEECHTYPE] >= 2);
     const bool use_thought_gui = (isThought) && (game.options[OPT_THOUGHTGUI] > 0);
@@ -252,7 +253,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     default: ovrtype = disp_type; break; // must be precreated overlay id
     }
 
-    size_t nse = add_screen_overlay(xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
+    size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
     // we should not delete text_window_ds here, because it is now owned by Overlay
 
     if (disp_type >= DISPLAYTEXT_NORMALOVERLAY) {

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -36,7 +36,8 @@ struct ScreenOverlay;
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
 // pass blocking=2 to create permanent overlay
-ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont, int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
+ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
+    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
 void _display_at(int xx, int yy, int wii, const char *text, int disp_type, int asspch, int isThought, int allowShrink, bool overlayPositionFixed);
 // Tests the given string for the voice-over tags and plays cue clip for the given character;
 // will assign replacement string, which will be blank string if game is in "voice-only" mode

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2184,9 +2184,9 @@ void draw_gui_and_overlays()
         {
             // For software mode - prepare transformed bitmap if necessary
             Bitmap *use_bmp = is_software_mode ? 
-                transform_sprite(over.pic, over.hasAlphaChannel, overlaybmp[i], Size(over.scaleWidth, over.scaleHeight)) :
+                transform_sprite(over.pic, over.HasAlphaChannel(), overlaybmp[i], Size(over.scaleWidth, over.scaleHeight)) :
                 over.pic;
-            over.ddb = recycle_ddb_bitmap(over.ddb, use_bmp, over.hasAlphaChannel);
+            over.ddb = recycle_ddb_bitmap(over.ddb, use_bmp, over.HasAlphaChannel());
             over.ClearChanged();
         }
 

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -23,9 +23,8 @@ void RemoveOverlay(int ovrid) {
     remove_screen_overlay(ovrid);
 }
 
-int CreateGraphicOverlay(int x, int y, int slot, int trans)
-{
-    auto *over = Overlay_CreateGraphicCore(x, y, slot, trans != 0);
+int CreateGraphicOverlay(int xx, int yy, int slott, int trans) {
+    auto *over = Overlay_CreateGraphicCore(false, xx, yy, slott, trans);
     return over ? over->type : 0;
 }
 
@@ -39,7 +38,7 @@ int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const
     else  // allow DisplaySpeechBackground to be shrunk
         allowShrink = 1;
 
-    auto *over = Overlay_CreateTextCore(xx, yy, wii, fontid, text_color, text, disp_type, allowShrink);
+    auto *over = Overlay_CreateTextCore(false, xx, yy, wii, fontid, text_color, text, disp_type, allowShrink);
     return over ? over->type : 0;
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -356,8 +356,8 @@ size_t add_screen_overlay(int x, int y, int type, Bitmap *piccy, int pic_offx, i
     over.timeout=0;
     over.bgSpeechForChar = -1;
     over.associatedOverlayHandle = 0;
-    over.hasAlphaChannel = alphaChannel;
-    over.positionRelativeToScreen = true;
+    over.SetAlphaChannel(alphaChannel);
+    over.SetRoomRelative(false);
     // TODO: move these custom settings outside of this function
     if (type == OVER_COMPLETE) play.complete_overlay_on = type;
     else if (type == OVER_TEXTMSG || type == OVER_TEXTSPEECH)
@@ -412,9 +412,9 @@ Point get_overlay_position(const ScreenOverlay &over)
         // and only in the case where the overlay is using a GUI. See issue #1098
         int tdxp = over.x + over.offsetX;
         int tdyp = over.y + over.offsetY;
-        if (over.positionRelativeToScreen)
-            return Point(tdxp, tdyp);
-        return play.RoomToScreen(tdxp, tdyp);
+        if (over.IsRoomRelative())
+            return play.RoomToScreen(tdxp, tdyp);
+        return Point(tdxp, tdyp);
     }
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -96,6 +96,13 @@ void Overlay_SetY(ScriptOverlay *scover, int newy) {
     screenover[ovri].y = data_to_game_coord(newy);
 }
 
+bool Overlay_InRoom(ScriptOverlay *scover) {
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
+        quit("!invalid overlay ID specified");
+    return screenover[ovri].IsRoomLayer();
+}
+
 int Overlay_GetWidth(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
@@ -534,6 +541,11 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetY);
 }
 
+RuntimeScriptValue Sc_Overlay_InRoom(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_BOOL(ScriptOverlay, Overlay_InRoom);
+}
+
 RuntimeScriptValue Sc_Overlay_GetWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptOverlay, Overlay_GetWidth);
@@ -618,6 +630,7 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::set_X",               Sc_Overlay_SetX);
     ccAddExternalObjectFunction("Overlay::get_Y",               Sc_Overlay_GetY);
     ccAddExternalObjectFunction("Overlay::set_Y",               Sc_Overlay_SetY);
+    ccAddExternalObjectFunction("Overlay::get_InRoom",          Sc_Overlay_InRoom);
     ccAddExternalObjectFunction("Overlay::get_Width",           Sc_Overlay_GetWidth);
     ccAddExternalObjectFunction("Overlay::set_Width",           Sc_Overlay_SetWidth);
     ccAddExternalObjectFunction("Overlay::get_Height",          Sc_Overlay_GetHeight);

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -34,16 +34,16 @@ void Overlay_SetY(ScriptOverlay *scover, int newy);
 int  Overlay_GetValid(ScriptOverlay *scover);
 ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent);
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
-ScreenOverlay *Overlay_CreateGraphicCore(int x, int y, int slot, bool transparent);
-ScreenOverlay *Overlay_CreateTextCore(int x, int y, int width, int font, int text_color,
+ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent);
+ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
     const char *text, int disp_type, int allow_shrink);
 
 int  find_overlay_of_type(int type);
 void remove_screen_overlay(int type);
-// Calculates overlay position in screen coordinates
+// Calculates overlay position in its respective layer (screen or room)
 Point get_overlay_position(const ScreenOverlay &over);
-size_t add_screen_overlay(int x,int y,int type,Common::Bitmap *piccy, bool alphaChannel = false);
-size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool alphaChannel = false);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false);
 void remove_screen_overlay_index(size_t over_idx);
 // Creates and registers a managed script object for existing overlay object;
 // optionally adds an internal engine reference to prevent object's disposal

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -28,8 +28,18 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     timeout = in->ReadInt32();
     bgSpeechForChar = in->ReadInt32();
     associatedOverlayHandle = in->ReadInt32();
-    hasAlphaChannel = in->ReadBool();
-    positionRelativeToScreen = in->ReadBool();
+    if (cmp_ver >= 3)
+    {
+        _flags = in->ReadInt16();
+    }
+    else
+    {
+        if (in->ReadBool()) // has alpha
+            _flags |= kOver_AlphaChannel;
+        if (!(in->ReadBool())) // screen relative position
+            _flags |= kOver_PositionAtRoomXY;
+    }
+
     if (cmp_ver >= 1)
     {
         offsetX = in->ReadInt32();
@@ -54,8 +64,7 @@ void ScreenOverlay::WriteToFile(Stream *out) const
     out->WriteInt32(timeout);
     out->WriteInt32(bgSpeechForChar);
     out->WriteInt32(associatedOverlayHandle);
-    out->WriteBool(hasAlphaChannel);
-    out->WriteBool(positionRelativeToScreen);
+    out->WriteInt16(_flags);
     // since cmp_ver = 1
     out->WriteInt32(offsetX);
     out->WriteInt32(offsetY);

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -11,19 +11,17 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #include "screenoverlay.h"
 #include "util/stream.h"
 
 using AGS::Common::Stream;
 
-void ScreenOverlay::ReadFromFile(Stream *in, int32_t cmp_ver)
+void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
 {
     pic = nullptr;
     ddb = nullptr;
-    // Skipping pointers (were saved by old engine)
-    in->ReadInt32(); // ddb
-    hasSerializedBitmap = in->ReadInt32() != 0; // pic
+    in->ReadInt32(); // ddb 32-bit pointer value (nasty legacy format)
+    has_bitmap = in->ReadInt32() != 0;
     type = in->ReadInt32();
     x = in->ReadInt32();
     y = in->ReadInt32();
@@ -48,9 +46,8 @@ void ScreenOverlay::ReadFromFile(Stream *in, int32_t cmp_ver)
 
 void ScreenOverlay::WriteToFile(Stream *out) const
 {
-    // Writing bitmap "pointers" to correspond to full structure writing
-    out->WriteInt32(0); // ddb
-    out->WriteInt32(pic ? 1 : 0); // pic
+    out->WriteInt32(0); // ddb 32-bit pointer value (nasty legacy format)
+    out->WriteInt32(pic ? 1 : 0); // has bitmap
     out->WriteInt32(type);
     out->WriteInt32(x);
     out->WriteInt32(y);

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -28,7 +28,8 @@ using namespace AGS; // FIXME later
 enum OverlayFlags
 {
     kOver_AlphaChannel     = 0x0001,
-    kOver_PositionAtRoomXY = 0x0002, // room-relative position
+    kOver_PositionAtRoomXY = 0x0002, // room-relative position, may be in ui
+    kOver_RoomLayer        = 0x0004, // work in room layer (as opposed to UI)
 };
 
 // Overlay class.
@@ -60,8 +61,14 @@ struct ScreenOverlay
 
     bool HasAlphaChannel() const { return (_flags & kOver_AlphaChannel) != 0; }
     bool IsRoomRelative() const { return (_flags & kOver_PositionAtRoomXY) != 0; }
+    bool IsRoomLayer() const { return (_flags & kOver_RoomLayer) != 0; }
     void SetAlphaChannel(bool on) { on ? _flags |= kOver_AlphaChannel : _flags &= ~kOver_AlphaChannel; }
     void SetRoomRelative(bool on) { on ? _flags |= kOver_PositionAtRoomXY : _flags &= ~kOver_PositionAtRoomXY; }
+    void SetRoomLayer(bool on)
+    {
+        on ? _flags |= (kOver_RoomLayer | kOver_PositionAtRoomXY) :
+             _flags &= ~(kOver_RoomLayer | kOver_PositionAtRoomXY);
+    }
     // Tells if Overlay has graphically changed recently
     bool HasChanged() const { return _hasChanged; }
     // Manually marks GUI as graphically changed

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -12,13 +12,12 @@
 //
 //=============================================================================
 //
-//
+// ScreenOverlay is a simple sprite container with no advanced functions.
 //
 //=============================================================================
 #ifndef __AGS_EE_AC__SCREENOVERLAY_H
 #define __AGS_EE_AC__SCREENOVERLAY_H
 
-#include <stdint.h>
 #include "core/types.h"
 
 // Forward declaration
@@ -52,7 +51,6 @@ struct ScreenOverlay {
     int associatedOverlayHandle = 0; // script obj handle
     int zorder = INT_MIN;
     bool positionRelativeToScreen = false;
-    bool hasSerializedBitmap = false;
     int transparency = 0;
 
     // Tells if Overlay has graphically changed recently
@@ -62,7 +60,7 @@ struct ScreenOverlay {
     // Clears changed flag
     void ClearChanged() { _hasChanged = false; }
 
-    void ReadFromFile(Common::Stream *in, int32_t cmp_ver);
+    void ReadFromFile(Common::Stream *in, bool &has_bitmap, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out) const;
 
 private:

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -25,6 +25,12 @@ namespace AGS { namespace Common { class Bitmap; class Stream; } }
 namespace AGS { namespace Engine { class IDriverDependantBitmap; }}
 using namespace AGS; // FIXME later
 
+enum OverlayFlags
+{
+    kOver_AlphaChannel     = 0x0001,
+    kOver_PositionAtRoomXY = 0x0002, // room-relative position
+};
+
 // Overlay class.
 // TODO: currently overlay creates and stores its own bitmap, even if
 // created using existing sprite. As a side-effect, changing that sprite
@@ -33,12 +39,12 @@ using namespace AGS; // FIXME later
 // instead; but that would mean that overlay will have to receive sprite
 // changes. For backward compatibility there may be a game switch that
 // forces it to make a copy.
-struct ScreenOverlay {
+struct ScreenOverlay
+{
     // Texture
     Engine::IDriverDependantBitmap *ddb = nullptr;
     // Original bitmap
     Common::Bitmap *pic = nullptr;
-    bool hasAlphaChannel = false;
     int type = 0, timeout = 0;
     // Note that x,y are overlay's properties, that define its position in script;
     // but real drawn position is x + offsetX, y + offsetY;
@@ -50,9 +56,12 @@ struct ScreenOverlay {
     int bgSpeechForChar = -1;
     int associatedOverlayHandle = 0; // script obj handle
     int zorder = INT_MIN;
-    bool positionRelativeToScreen = false;
     int transparency = 0;
 
+    bool HasAlphaChannel() const { return (_flags & kOver_AlphaChannel) != 0; }
+    bool IsRoomRelative() const { return (_flags & kOver_PositionAtRoomXY) != 0; }
+    void SetAlphaChannel(bool on) { on ? _flags |= kOver_AlphaChannel : _flags &= ~kOver_AlphaChannel; }
+    void SetRoomRelative(bool on) { on ? _flags |= kOver_PositionAtRoomXY : _flags &= ~kOver_PositionAtRoomXY; }
     // Tells if Overlay has graphically changed recently
     bool HasChanged() const { return _hasChanged; }
     // Manually marks GUI as graphically changed
@@ -64,6 +73,7 @@ struct ScreenOverlay {
     void WriteToFile(Common::Stream *out) const;
 
 private:
+    int _flags = 0; // OverlayFlags
     bool _hasChanged = false;
 };
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -861,8 +861,9 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
     for (size_t i = 0; i < over_count; ++i)
     {
         ScreenOverlay over;
-        over.ReadFromFile(in, cmp_ver);
-        if (over.hasSerializedBitmap)
+        bool has_bitmap;
+        over.ReadFromFile(in, has_bitmap, cmp_ver);
+        if (has_bitmap)
             over.pic = read_serialized_bitmap(in);
         if (over.scaleWidth <= 0 || over.scaleHeight <= 0)
         {

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1217,7 +1217,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Overlays",
-        2,
+        3,
         0,
         WriteOverlays,
         ReadOverlays

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -18,6 +18,7 @@
 // Perhaps the optimal solution would be to have a savegame converter instead.
 //
 //=============================================================================
+#include <vector>
 #include "core/types.h"
 #include "ac/button.h"
 #include "ac/characterextras.h"
@@ -304,12 +305,15 @@ static void restore_game_ambientsounds(Stream *in, RestoredData &r_data)
     }
 }
 
-static void ReadOverlays_Aligned(Stream *in, size_t num_overs)
+static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size_t num_overs)
 {
     AlignedStream align_s(in, Common::kAligned_Read);
+    has_bitmap.resize(num_overs);
     for (size_t i = 0; i < num_overs; ++i)
     {
-        screenover[i].ReadFromFile(&align_s, 0);
+        bool has_bm;
+        screenover[i].ReadFromFile(&align_s, has_bm, 0);
+        has_bitmap[i] = has_bm;
         align_s.Reset();
     }
 }
@@ -318,9 +322,10 @@ static void restore_game_overlays(Stream *in)
 {
     size_t num_overs = in->ReadInt32();
     screenover.resize(num_overs);
-    ReadOverlays_Aligned(in, num_overs);
+    std::vector<bool> has_bitmap;
+    ReadOverlays_Aligned(in, has_bitmap, num_overs);
     for (size_t i = 0; i < num_overs; ++i) {
-        if (screenover[i].hasSerializedBitmap)
+        if (has_bitmap[i])
             screenover[i].pic = read_serialized_bitmap(in);
     }
 }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -449,7 +449,7 @@ void update_sierra_speech()
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }
 
-      screenover[face_talking].hasAlphaChannel = face_has_alpha;
+      screenover[face_talking].SetAlphaChannel(face_has_alpha);
       screenover[face_talking].MarkChanged();
     }  // end if updatedFrame
   }


### PR DESCRIPTION
Resolves #1044.
Resolves #1209.

Implements room overlays, that is Overlays that are drawn in the room "layer", inside the room viewport and sorted among characters, room objects and walk-behinds. This opens large possibilities, as overlays are created at runtime and are unlimited since 3.6.0. They may be used both as a one time visual effects, or to build a custom room object from ground up.

Technically, not a lot of changes were necessary, we just use same overlays with a flag; depending on the flag they are drawn either as a part of room or part of UI layer. For software renderer room overlays are also processed for walk-behind cropping.

In script, I've been in doubts how to organize this, so ended up with two extra factory functions duplicating two existing ones:
```
  /// Creates an overlay that displays a sprite inside the room.
  import static Overlay* CreateRoomGraphical(int x, int y, int slot, bool transparent);
  /// Creates an overlay that displays some text inside the room.
  import static Overlay* CreateRoomTextual(int x, int y, int width, FontType, int colour, const string text, ...);
```

In regards to the sprite sorting, Overlays have ZOrder property since 3.6.0, and it is compared to other room elements baselines.
Overlays are **not** changing their z-order automatically though, so moving them along the Y axis don't affect their sorting order. IMHO that is proper, as overlays are the basic "sprite containers" without specific behavior.
If user wants to have overlay sorted depending on its Y pos, simply doing `over.ZOrder = over.Y;` or `over.ZOrder = roomover.Y + roomover.Height;` in rep-exec is enough.