### PR TITLE
AGS 4: compile rooms without using global native room object

### DIFF
--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -59,7 +59,10 @@ enum RoomAreaMask
     kRoomAreaHotspot,
     kRoomAreaWalkBehind,
     kRoomAreaWalkable,
-    kRoomAreaRegion
+    kRoomAreaRegion,
+
+    kRoomArea_First = kRoomAreaHotspot,
+    kRoomArea_Last  = kRoomAreaRegion
 };
 
 // Room's audio volume modifier

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2240,30 +2240,10 @@ namespace AGS.Editor.Components
                 throw new InvalidOperationException("No room is currently loaded");
             }
 
-            if (!File.Exists(_loadedRoom.FileName))
-                _nativeProxy.SaveDefaultRoom(_loadedRoom); // create a valid room file
-
-            // Load and forget; We need a valid RoomStruct instance because the Editor Native Proxy code
-            // expects to find it. We can't construct an instance easily directly from C#, but we get can get
-            // one by running the Native Proxy room loader code.
-            if (_loadedRoom._roomStructPtr == default(IntPtr))
-                _loadedRoom._roomStructPtr = _nativeProxy.LoadRoom(_loadedRoom)._roomStructPtr;
-
-            for (int i = 0; i < _loadedRoom.BackgroundCount; i++)
-            {
-                _nativeProxy.ImportBackground(
-                    _loadedRoom, i, _backgroundCache[i], _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false);
-            }
-
-            foreach (RoomAreaMaskType mask in Enum.GetValues(typeof(RoomAreaMaskType)))
-            {
-                if (mask == RoomAreaMaskType.None)
-                    continue;
-
-                _nativeProxy.SetAreaMask(_loadedRoom, mask, _maskCache[mask]);
-            }
-
-            _nativeProxy.SaveRoom(_loadedRoom);
+            var masks = new List<Bitmap>();
+            masks.AddRange(_maskCache.OrderBy(v => v.Key).Select(v => v.Value));
+            _nativeProxy.SaveRoom(_loadedRoom, _backgroundCache,
+                _agsEditor.Settings.RemapPalettizedBackgrounds, sharePalette: false, masks: masks);
         }
         #endregion
     }

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -269,9 +269,10 @@ namespace AGS.Editor
             return _native.LoadRoomFile(roomToLoad, defEncoding);
         }
 
-        public void SaveRoom(Room roomToSave)
+        public void SaveRoom(Room room, IList<Bitmap> backgrounds,
+            bool useExactPalette, bool sharePalette, IList<Bitmap> masks)
         {
-            _native.SaveRoomFile(roomToSave);
+            _native.SaveRoomFile(room, backgrounds, useExactPalette, sharePalette, masks);
         }
 
         public void SaveDefaultRoom(Room roomToSave)
@@ -279,19 +280,9 @@ namespace AGS.Editor
             _native.SaveDefaultRoomFile(roomToSave);
         }
 
-        public void ImportBackground(Room room, int backgroundNumber, Bitmap bmp, bool useExactPalette, bool sharePalette)
-        {
-            _native.ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
-        }
-
         public Bitmap GetBitmapForBackground(Room room, int backgroundNumber)
         {
             return _native.GetBitmapForBackground(room, backgroundNumber);
-        }
-
-        public void SetAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
-        {
-            _native.SetAreaMask(room, mask, bmp);
         }
 
         public Bitmap ExportAreaMask(Room room, RoomAreaMaskType mask)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -855,12 +855,6 @@ namespace AGS.Editor
                 room.Script.SaveToDisk();
                 room.UnloadScript();
             }
-            // Convert all rooms
-            foreach (var room in Factory.AGSEditor.CurrentGame.Rooms)
-            {
-                var loadedRoom = Factory.NativeProxy.LoadRoom((UnloadedRoom)room, oldEnc);
-                Factory.NativeProxy.SaveRoom(loadedRoom);
-            }
             // Save game with a new encoding
             if (Factory.GUIController.InvokeRequired)
             {

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -33,7 +33,8 @@ extern void shutdown_native();
 extern AGS::Types::Game^ import_compiled_game_dta(const AGSString &filename);
 extern void free_old_game_data();
 extern AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
-extern void save_crm_file(Room ^roomToSave);
+extern void save_crm_file(Room ^room, IList<Bitmap^>^ backgrounds,
+    bool useExactPalette, bool sharePalette, IList<Bitmap^>^ masks);
 extern void save_default_crm_file(Room ^roomToSave);
 extern AGSString import_sci_font(const AGSString &filename, int fslot);
 extern bool reload_font(int curFont);
@@ -77,9 +78,7 @@ extern void GameDirChanged(String ^workingDir);
 extern void GameUpdated(Game ^game, bool forceUpdate);
 extern void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
 extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
-extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 extern void FixRoomMasks(Room ^room);
-extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
 extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern System::String ^load_room_script(System::String ^fileName);
 extern bool spritesModified;
@@ -495,9 +494,10 @@ namespace AGS
 			return load_crm_file(roomToLoad, defEncoding);
 		}
 
-		void NativeMethods::SaveRoomFile(AGS::Types::Room ^roomToSave)
+		void NativeMethods::SaveRoomFile(Room ^room, IList<Bitmap^>^ backgrounds,
+            bool useExactPalette, bool sharePalette, IList<Bitmap^>^ masks)
 		{
-			save_crm_file(roomToSave);
+			save_crm_file(room, backgrounds, useExactPalette, sharePalette, masks);
 		}
 
         void NativeMethods::SaveDefaultRoomFile(AGS::Types::Room ^roomToSave)
@@ -505,20 +505,10 @@ namespace AGS
             save_default_crm_file(roomToSave);
         }
 
-		void NativeMethods::ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette)
-		{
-			::ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
-		}
-
 		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)
 		{
 			return getBackgroundAsBitmap(room, backgroundNumber);
 		}
-
-    void NativeMethods::SetAreaMask(Room^ room, RoomAreaMaskType maskType, Bitmap^ bmp)
-    {
-        set_area_mask((void*)room->_roomStructPtr, (int)maskType, bmp);
-    }
 
     Bitmap ^NativeMethods::ExportAreaMask(Room ^room, RoomAreaMaskType maskType)
     {

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -68,11 +68,10 @@ namespace Native
 			void LoadNewSpriteFile();
             void ReplaceSpriteFile(String ^srcFileName);
 			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
-			void SaveRoomFile(Room ^roomToSave);
+			void SaveRoomFile(Room ^room, IList<Bitmap^>^ backgrounds,
+                bool useExactPalette, bool sharePalette, IList<Bitmap^>^ masks);
             void SaveDefaultRoomFile(Room ^roomToSave);
-			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
 			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-      void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
       Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
 			String ^LoadRoomScript(String ^roomFileName);
 			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, CompileMessages ^errors);


### PR DESCRIPTION
Resolves #1629 in the sense that the process of saving CRM file no longer requires a file to exist.

Makes converting and saving room.crm file a single operation that does not require using a global native room object.
All necessary data is passed into NativeProxy.SaveRoom, where it is converted to a temporary room object, which is saved and disposed right after.