### PR TITLE
AGS 4: reimplemented native room operations as NativeRoom class

### DIFF
--- a/Common/game/roomstruct.cpp
+++ b/Common/game/roomstruct.cpp
@@ -198,7 +198,19 @@ Bitmap *RoomStruct::GetMask(RoomAreaMask mask) const
     case kRoomAreaWalkBehind: return WalkBehindMask.get();
     case kRoomAreaWalkable: return WalkAreaMask.get();
     case kRoomAreaRegion: return RegionMask.get();
-    default: return nullptr;
+    default: assert(0); return nullptr;
+    }
+}
+
+void RoomStruct::SetMask(RoomAreaMask mask, Bitmap *bmp)
+{
+    switch (mask)
+    {
+    case kRoomAreaHotspot: HotspotMask.reset(bmp); break;
+    case kRoomAreaWalkBehind: WalkBehindMask.reset(bmp); break;
+    case kRoomAreaWalkable: WalkAreaMask.reset(bmp); break;
+    case kRoomAreaRegion: RegionMask.reset(bmp); break;
+    default: assert(0); break;
     }
 }
 

--- a/Common/game/roomstruct.h
+++ b/Common/game/roomstruct.h
@@ -59,7 +59,10 @@ enum RoomAreaMask
     kRoomAreaHotspot,
     kRoomAreaWalkBehind,
     kRoomAreaWalkable,
-    kRoomAreaRegion
+    kRoomAreaRegion,
+
+    kRoomArea_First = kRoomAreaHotspot,
+    kRoomArea_Last  = kRoomAreaRegion
 };
 
 // Room's audio volume modifier
@@ -283,6 +286,9 @@ public:
 
     // Gets bitmap of particular mask layer
     Bitmap *GetMask(RoomAreaMask mask) const;
+    // Sets bitmap for the particular mask layer;
+    // WARNING: takes the ownership of the given bitmap
+    void    SetMask(RoomAreaMask mask, Bitmap *bmp);
     // Gets mask's scale relative to the room's background size
     float   GetMaskScale(RoomAreaMask mask) const;
 

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -264,39 +264,9 @@ namespace AGS.Editor
             }
         }
 
-        public Room LoadRoom(UnloadedRoom roomToLoad, Encoding defEncoding = null)
-        {
-            return _native.LoadRoomFile(roomToLoad, defEncoding);
-        }
-
-        public void SaveRoom(Room roomToSave)
-        {
-            _native.SaveRoomFile(roomToSave);
-        }
-
         public void SaveDefaultRoom(Room roomToSave)
         {
             _native.SaveDefaultRoomFile(roomToSave);
-        }
-
-        public void ImportBackground(Room room, int backgroundNumber, Bitmap bmp, bool useExactPalette, bool sharePalette)
-        {
-            _native.ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
-        }
-
-        public Bitmap GetBitmapForBackground(Room room, int backgroundNumber)
-        {
-            return _native.GetBitmapForBackground(room, backgroundNumber);
-        }
-
-        public void SetAreaMask(Room room, RoomAreaMaskType mask, Bitmap bmp)
-        {
-            _native.SetAreaMask(room, mask, bmp);
-        }
-
-        public Bitmap ExportAreaMask(Room room, RoomAreaMaskType mask)
-        {
-            return _native.ExportAreaMask(room, mask);
         }
 
         public string LoadRoomScript(string roomFileName)

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -855,12 +855,6 @@ namespace AGS.Editor
                 room.Script.SaveToDisk();
                 room.UnloadScript();
             }
-            // Convert all rooms
-            foreach (var room in Factory.AGSEditor.CurrentGame.Rooms)
-            {
-                var loadedRoom = Factory.NativeProxy.LoadRoom((UnloadedRoom)room, oldEnc);
-                Factory.NativeProxy.SaveRoom(loadedRoom);
-            }
             // Save game with a new encoding
             if (Factory.GUIController.InvokeRequired)
             {

--- a/Editor/AGS.Native/NativeDLL.vcxproj
+++ b/Editor/AGS.Native/NativeDLL.vcxproj
@@ -236,12 +236,14 @@
     <ClCompile Include="cstretch.cpp" />
     <ClCompile Include="MSSCCI.cpp" />
     <ClCompile Include="NativeMethods.cpp" />
+    <ClCompile Include="NativeRoom.cpp" />
     <ClCompile Include="ScriptCompiler.cpp" />
     <ClCompile Include="SpriteFileWriter_NET.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="agsnative.h" />
     <ClInclude Include="NativeMethods.h" />
+    <ClInclude Include="NativeRoom.h" />
     <ClInclude Include="NativeUtils.h" />
     <ClInclude Include="Scripting.h" />
     <ClInclude Include="SpriteFileWriter_NET.h" />

--- a/Editor/AGS.Native/NativeDLL.vcxproj.filters
+++ b/Editor/AGS.Native/NativeDLL.vcxproj.filters
@@ -208,6 +208,9 @@
     <ClCompile Include="SpriteFileWriter_NET.cpp">
       <Filter>Header Files</Filter>
     </ClCompile>
+    <ClCompile Include="NativeRoom.cpp">
+      <Filter>Header Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="agsnative.h">
@@ -223,6 +226,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SpriteFileWriter_NET.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="NativeRoom.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -32,8 +32,6 @@ extern bool initialize_native();
 extern void shutdown_native();
 extern AGS::Types::Game^ import_compiled_game_dta(const AGSString &filename);
 extern void free_old_game_data();
-extern AGS::Types::Room^ load_crm_file(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
-extern void save_crm_file(Room ^roomToSave);
 extern void save_default_crm_file(Room ^roomToSave);
 extern AGSString import_sci_font(const AGSString &filename, int fslot);
 extern bool reload_font(int curFont);
@@ -51,7 +49,6 @@ extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitma
 extern int GetSpriteAsHBitmap(int spriteSlot);
 extern Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height);
 extern Bitmap^ getSpriteAsBitmap(int spriteNum);
-extern Bitmap^ getBackgroundAsBitmap(Room ^room, int backgroundNumber);
 extern unsigned char* GetRawSpriteData(int spriteSlot);
 extern int find_free_sprite_slot();
 extern int crop_sprite_edges(int numSprites, int *sprites, bool symmetric);
@@ -63,7 +60,6 @@ extern int GetSpriteColorDepth(int slot);
 extern int GetPaletteAsHPalette();
 extern bool DoesSpriteExist(int slot);
 extern int GetMaxSprites();
-extern int GetCurrentlyLoadedRoomNumber();
 extern int load_template_file(const AGSString &fileName, char **iconDataBuffer, long *iconDataSize, bool isRoomTemplate);
 extern HAGSError extract_template_files(const AGSString &templateFileName);
 extern HAGSError extract_room_template_files(const AGSString &templateFileName, int newRoomNumber);
@@ -77,10 +73,6 @@ extern void GameDirChanged(String ^workingDir);
 extern void GameUpdated(Game ^game, bool forceUpdate);
 extern void GameFontUpdated(Game ^game, int fontNumber, bool forceUpdate);
 extern void UpdateNativeSpritesToGame(Game ^game, List<String^> ^errors);
-extern void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
-extern void FixRoomMasks(Room ^room);
-extern void set_area_mask(void *roomptr, int maskType, Bitmap ^bmp);
-extern Bitmap ^export_area_mask(void *roomptr, int maskType);
 extern System::String ^load_room_script(System::String ^fileName);
 extern bool spritesModified;
 
@@ -349,6 +341,11 @@ namespace AGS
 			}
 		}
 
+        static int GetCurrentlyLoadedRoomNumber()
+        {
+            return 0; // FIXME: not working after moved to open room format
+        }
+
 		Sprite^ NativeMethods::SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel)
 		{
             SetNewSpriteFromBitmap(spriteSlot, bmp, spriteImportMethod, remapColours, useRoomBackgroundColours, alphaChannel);
@@ -490,40 +487,10 @@ namespace AGS
 			return load_sprite_dimensions();
 		}
 
-		AGS::Types::Room^ NativeMethods::LoadRoomFile(UnloadedRoom^ roomToLoad, System::Text::Encoding ^defEncoding)
-		{
-			return load_crm_file(roomToLoad, defEncoding);
-		}
-
-		void NativeMethods::SaveRoomFile(AGS::Types::Room ^roomToSave)
-		{
-			save_crm_file(roomToSave);
-		}
-
         void NativeMethods::SaveDefaultRoomFile(AGS::Types::Room ^roomToSave)
         {
             save_default_crm_file(roomToSave);
         }
-
-		void NativeMethods::ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette)
-		{
-			::ImportBackground(room, backgroundNumber, bmp, useExactPalette, sharePalette);
-		}
-
-		Bitmap^ NativeMethods::GetBitmapForBackground(Room ^room, int backgroundNumber)
-		{
-			return getBackgroundAsBitmap(room, backgroundNumber);
-		}
-
-    void NativeMethods::SetAreaMask(Room^ room, RoomAreaMaskType maskType, Bitmap^ bmp)
-    {
-        set_area_mask((void*)room->_roomStructPtr, (int)maskType, bmp);
-    }
-
-    Bitmap ^NativeMethods::ExportAreaMask(Room ^room, RoomAreaMaskType maskType)
-    {
-        return export_area_mask((void*)room->_roomStructPtr, (int)maskType);
-    }
 
 		String ^NativeMethods::LoadRoomScript(String ^roomFileName) 
 		{

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -67,13 +67,7 @@ namespace Native
 			Dictionary<int,Sprite^>^ LoadAllSpriteDimensions();
 			void LoadNewSpriteFile();
             void ReplaceSpriteFile(String ^srcFileName);
-			Room^ LoadRoomFile(UnloadedRoom ^roomToLoad, System::Text::Encoding ^defEncoding);
-			void SaveRoomFile(Room ^roomToSave);
             void SaveDefaultRoomFile(Room ^roomToSave);
-			void ImportBackground(Room ^room, int backgroundNumber, Bitmap ^bmp, bool useExactPalette, bool sharePalette);
-			Bitmap^ GetBitmapForBackground(Room ^room, int backgroundNumber);
-      void SetAreaMask(Room ^room, RoomAreaMaskType maskType, Bitmap ^bmp);
-      Bitmap ^ExportAreaMask(Room ^room, RoomAreaMaskType maskType);
 			String ^LoadRoomScript(String ^roomFileName);
 			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, CompileMessages ^errors);
 			GameTemplate^ LoadTemplateFile(String ^fileName);

--- a/Editor/AGS.Native/NativeRoom.cpp
+++ b/Editor/AGS.Native/NativeRoom.cpp
@@ -1,0 +1,127 @@
+#include "NativeRoom.h"
+#include "NativeUtils.h"
+#include "game/room_file.h"
+
+using AGSBitmap = AGS::Common::Bitmap;
+using AGSString = AGS::Common::String;
+using RoomStruct = AGS::Common::RoomStruct;
+using AGS::Types::Room;
+using AGS::Types::RoomAreaMaskType;
+using AGS::Types::AGSEditorException;
+using SysBitmap = System::Drawing::Bitmap;
+
+
+AGSBitmap *CreateBlockFromBitmap(SysBitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth);
+extern SysBitmap^ ConvertBlockToBitmap32(AGSBitmap *todraw, int width, int height, bool useAlphaChannel);
+extern SysBitmap^ ConvertBlockToBitmap(AGSBitmap *todraw, bool useAlphaChannel);
+extern void convert_room_from_native(const RoomStruct &rs, AGS::Types::Room ^room, System::Text::Encoding ^defEncoding);
+extern void convert_room_to_native(Room ^room, RoomStruct &rs);
+extern AGSString load_room_file(RoomStruct &rs, const AGSString &filename);
+extern void save_room_file(RoomStruct &rs, const AGSString &path);
+extern void SetNativeRoomBackground(RoomStruct &room, int backgroundNumber,
+    SysBitmap ^bmp, bool useExactPalette, bool sharePalette);
+extern void validate_mask(AGSBitmap *toValidate, const char *name, int maxColour);
+
+
+namespace AGS
+{
+namespace Native
+{
+
+NativeRoom::NativeRoom(AGS::Types::Room ^room)
+{
+    _rs = new RoomStruct();
+    convert_room_to_native(room, *_rs);
+}
+
+NativeRoom::NativeRoom(System::String ^filename, System::Text::Encoding ^defEncoding)
+{
+    _rs = new RoomStruct();
+    AGSString roomFileName = TextHelper::ConvertUTF8(filename);
+    AGSString errorMsg = load_room_file(*_rs, roomFileName);
+    if (!errorMsg.IsEmpty())
+    {
+        delete _rs;
+        throw gcnew AGSEditorException(TextHelper::ConvertUTF8(errorMsg));
+    }
+}
+
+NativeRoom::~NativeRoom()
+{
+    delete _rs;
+}
+
+AGS::Types::Room^ NativeRoom::ConvertToManagedRoom(int roomNumber, System::Text::Encoding ^defEncoding)
+{
+    Room ^room = gcnew Room(roomNumber);
+    convert_room_from_native(*_rs, room, defEncoding);
+    return room;
+}
+
+SysBitmap ^NativeRoom::GetBackground(int bgnum)
+{
+    if (bgnum < 0 || bgnum > MAX_ROOM_BGFRAMES)
+    {
+        throw gcnew AGSEditorException(System::String::Format(
+            "Invalid background number {0}", bgnum));
+    }
+    return ConvertBlockToBitmap32(_rs->BgFrames[bgnum].Graphic.get(), _rs->Width, _rs->Height, false);
+}
+
+SysBitmap ^NativeRoom::GetAreaMask(AGS::Types::RoomAreaMaskType maskType)
+{
+    RoomAreaMask nativeType = (RoomAreaMask)maskType;
+    if (nativeType < kRoomArea_First || nativeType > kRoomArea_Last)
+    {
+        throw gcnew AGSEditorException(System::String::Format("Invalid mask type {0}", (int)nativeType));
+    }
+
+    AGSBitmap *mask = _rs->GetMask(nativeType);
+    SysBitmap^ managedMask = ConvertBlockToBitmap(mask, false);
+    // Palette entry 0 alpha value is hardcoded to 0, probably because it's convenient
+    // for rendering area 0 as invisible? However it creates issues when exporting 8-bit
+    // image with transparency to different image formats (tested with .png). To make things
+    // easier we take the alpha value out.
+    auto palette = managedMask->Palette;
+    palette->Entries[0] = System::Drawing::Color::FromArgb(255, palette->Entries[0]);
+    managedMask->Palette = palette;
+    return managedMask;
+}
+
+void NativeRoom::SetBackground(int bgnum, SysBitmap ^bmp, bool useExactPalette, bool sharePalette)
+{ // NOTE: this operation uses too much from the native code to completely move here 
+    SetNativeRoomBackground(*_rs, bgnum, bmp, useExactPalette, sharePalette);
+}
+
+void NativeRoom::SetAreaMask(AGS::Types::RoomAreaMaskType maskType, SysBitmap ^bmp)
+{
+    RoomAreaMask nativeType = (RoomAreaMask)maskType;
+    if (nativeType < kRoomArea_First || nativeType > kRoomArea_Last)
+    {
+        throw gcnew AGSEditorException(System::String::Format("Invalid mask type {0}", (int)nativeType));
+    }
+
+    // Palette entry 0 alpha value is hardcoded to 0 originally, probably because it's
+    // convenient for rendering area 0 as invisible? This was taken out when converting
+    // the room to open format because it created issues with saving/loading to disk
+    // in certain image formats (.png). Just in case we set the alpha back to 0 when
+    // setting the mask back into crm on the off chance it might be used for something
+    // internally somewhere
+    auto palette = bmp->Palette;
+    palette->Entries[0] = System::Drawing::Color::FromArgb(255, palette->Entries[0]);
+    bmp->Palette = palette;
+
+    RGB pal[256]; // dummy, used as a return value from CreateBlockFromBitmap
+    AGSBitmap* newMask = CreateBlockFromBitmap(bmp, pal, false, false, nullptr);
+    validate_mask(newMask, "imported", (nativeType == kRoomAreaHotspot) ? MAX_ROOM_HOTSPOTS : (MAX_WALK_AREAS + 1));
+    _rs->SetMask(nativeType, newMask);
+}
+
+void NativeRoom::SaveToFile(System::String ^filename)
+{
+    AGSString roomFileName = TextHelper::ConvertUTF8(filename);
+    save_room_file(*_rs, roomFileName);
+}
+
+} // namespace Native
+} // namespace AGS

--- a/Editor/AGS.Native/NativeRoom.h
+++ b/Editor/AGS.Native/NativeRoom.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+#include "game/roomstruct.h"
+
+namespace AGS
+{
+namespace Native
+{
+
+// Wraps a native Room object, provides means for converting into .NET object equivalents
+public ref class NativeRoom
+{
+public:
+    // Constructs native room object from the managed Room
+    NativeRoom(AGS::Types::Room ^room);
+    // Constructs native room object from the file (CRM)
+    NativeRoom(System::String ^filename, System::Text::Encoding ^defEncoding);
+    ~NativeRoom();
+
+    // Generates a managed Room object from the room data;
+    // this does not include backgrounds and masks, they are retrieved using
+    // separate respective methods.
+    AGS::Types::Room^ ConvertToManagedRoom(int roomNumber, System::Text::Encoding ^defEncoding);
+    // Gets respective room background as a .NET Bitmap
+    System::Drawing::Bitmap ^GetBackground(int bgnum);
+    // Gets respective area mask as a .NET Bitmap
+    System::Drawing::Bitmap ^GetAreaMask(AGS::Types::RoomAreaMaskType maskType);
+    // Sets/replaces room background, converting from .NET Bitmap
+    void SetBackground(int bgnum, System::Drawing::Bitmap ^bmp, bool useExactPalette, bool sharePalette);
+    // Sets/replaces area mask, converting from .NET Bitmap
+    void SetAreaMask(AGS::Types::RoomAreaMaskType maskType, System::Drawing::Bitmap ^bmp);
+    // Saves current room object to the file (CRM)
+    void SaveToFile(System::String ^filename);
+
+private:
+    AGS::Common::RoomStruct *_rs = nullptr;
+};
+
+} // namespace Native
+} // namespace AGS

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -59,7 +59,6 @@ namespace AGS.Types
         private readonly List<RoomWalkBehind> _walkBehinds = new List<RoomWalkBehind>();
         private readonly List<RoomRegion> _regions = new List<RoomRegion>();
         private IList<OldInteractionVariable> _oldInteractionVariables = new List<OldInteractionVariable>();
-        public IntPtr _roomStructPtr;
 
         static Room()
         {


### PR DESCRIPTION
NativeRoom class wraps a native RoomStruct object and supports following operations:
* construct from a managed AGS.Types.Room;
* construct by loading from a CRM file (compiled room format);
* convert from native to managed AGS.Types.Room;
* retrieve backgrounds and masks, converting to System.Drawing.Bitmap;
* assign backgrounds and masks, converting from System.Drawing.Bitmap;
* saving native object to CRM file (compiled room format).

Removed `thisroom` global native object, because it's no longer usable anyway. Had to mark couple of places as broken (with FIXME) for the future.

Removed `_roomStructPtr` from the managed Room.

Removed precreating and loading a dummy CRM file when only saving the compiled room.

Removed unnecessary encoding conversion of compiled room files (since they are no longer project files but output artifacts).