### PR TITLE
Tidy up mobile config once more and get rid of psp_* variables

### DIFF
--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -33,6 +33,7 @@ GameSetup::GameSetup()
     clear_cache_on_room_change = false;
     load_latest_save = false;
     rotation = kScreenRotation_Unlocked;
+    show_fps = false;
 
     Screen.Params.RefreshRate = 0;
     Screen.Params.VSync = false;

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -31,6 +31,7 @@ GameSetup::GameSetup()
     RenderAtScreenRes = false;
     Supersampling = 1;
     clear_cache_on_room_change = false;
+    load_latest_save = false;
     rotation = kScreenRotation_Unlocked;
 
     Screen.Params.RefreshRate = 0;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -89,6 +89,7 @@ struct GameSetup {
     bool  clear_cache_on_room_change; // for low-end devices: clear resource caches on room change
     bool  load_latest_save; // load latest saved game on launch
     ScreenRotation rotation;
+    bool  show_fps;
 
     DisplayModeSetup Screen;
     String software_render_driver;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -86,7 +86,8 @@ struct GameSetup {
     MouseSpeedDef mouse_speed_def;
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
-    bool  clear_cache_on_room_change; // compatibility
+    bool  clear_cache_on_room_change; // for low-end devices: clear resource caches on room change
+    bool  load_latest_save; // load latest saved game on launch
     ScreenRotation rotation;
 
     DisplayModeSetup Screen;

--- a/Engine/gfx/gfx_util.cpp
+++ b/Engine/gfx/gfx_util.cpp
@@ -16,11 +16,6 @@
 #include "gfx/gfx_util.h"
 #include "gfx/blender.h"
 
-// CHECKME: is this hack still relevant?
-#if AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID
-extern int psp_gfx_renderer;
-#endif
-
 namespace AGS
 {
 namespace Engine

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -347,6 +347,7 @@ void apply_config(const ConfigTree &cfg)
         usetup.load_latest_save = CfgReadBoolInt(cfg, "misc", "load_latest_save", usetup.load_latest_save);
         usetup.user_data_dir = CfgReadString(cfg, "misc", "user_data_dir");
         usetup.shared_data_dir = CfgReadString(cfg, "misc", "shared_data_dir");
+        usetup.show_fps = CfgReadBoolInt(cfg, "misc", "show_fps");
 
         usetup.translation = CfgReadString(cfg, "language", "translation");
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -292,84 +292,9 @@ static void read_legacy_graphics_config(const ConfigTree &cfg)
     usetup.Screen.Params.RefreshRate = CfgReadInt(cfg, "misc", "refresh");
 }
 
-// Variables used for mobile port configs
-extern int psp_rotation;
-extern int psp_gfx_renderer;
-extern int psp_gfx_scaling;
-extern int psp_gfx_super_sampling;
-extern int psp_gfx_smoothing;
-extern int psp_gfx_smooth_sprites;
-extern int psp_clear_cache_on_room_change;
-extern char psp_translation[];
-#if AGS_PLATFORM_OS_ANDROID
-extern int config_mouse_control_mode;
-#endif
-
 void override_config_ext(ConfigTree &cfg)
 {
-    // Mobile ports always run in fullscreen mode
-#if AGS_PLATFORM_OS_ANDROID || AGS_PLATFORM_OS_IOS
-    CfgWriteInt(cfg, "graphics", "windowed", 0);
-#endif
-
-    // psp_gfx_renderer - rendering mode
-    //    * 0 - software renderer
-    //    * 1 - hardware, render to screen
-    //    * 2 - hardware, render to texture
-    if (psp_gfx_renderer == 0)
-    {
-        CfgWriteString(cfg, "graphics", "driver", "Software");
-        CfgWriteInt(cfg, "graphics", "render_at_screenres", 1);
-    }
-    else
-    {
-        CfgWriteString(cfg, "graphics", "driver", "OGL");
-        CfgWriteInt(cfg, "graphics", "render_at_screenres", psp_gfx_renderer == 1);
-    }
-
-    // psp_gfx_scaling - scaling style:
-    //    * 0 - no scaling
-    //    * 1 - stretch and preserve aspect ratio
-    //    * 2 - stretch to whole screen
-    if (psp_gfx_scaling == 0)
-        CfgWriteString(cfg, "graphics", "game_scale_fs", "1");
-    else if (psp_gfx_scaling == 1)
-        CfgWriteString(cfg, "graphics", "game_scale_fs", "proportional");
-    else
-        CfgWriteString(cfg, "graphics", "game_scale_fs", "stretch");
-
-    // psp_gfx_smoothing - scaling filter:
-    //    * 0 - nearest-neighbour
-    //    * 1 - linear
-    if (psp_gfx_smoothing == 0)
-        CfgWriteString(cfg, "graphics", "filter", "StdScale");
-    else
-        CfgWriteString(cfg, "graphics", "filter", "Linear");
-
-    // psp_gfx_super_sampling - enable super sampling
-    //    * 0 - x1
-    //    * 1 - x2
-    if (psp_gfx_renderer == 2)
-        CfgWriteInt(cfg, "graphics", "supersampling", psp_gfx_super_sampling + 1);
-    else
-        CfgWriteInt(cfg, "graphics", "supersampling", 0);
-
-    // psp_gfx_rotation - scaling style:
-    //    * 0 - unlocked, let the user rotate as wished.
-    //    * 1 - portrait
-    //    * 2 - landscape
-    CfgWriteInt(cfg, "graphics", "rotation", psp_rotation);
-
-#if AGS_PLATFORM_OS_ANDROID
-    // config_mouse_control_mode - enable relative mouse mode
-    //    * 1 - relative mouse touch controls
-    //    * 0 - direct touch mouse control
-    CfgWriteInt(cfg, "mouse", "control_enabled", config_mouse_control_mode);
-#endif
-
-    CfgWriteInt(cfg, "misc", "antialias", psp_gfx_smooth_sprites != 0);
-    CfgWriteString(cfg, "language", "translation", psp_translation);
-    CfgWriteInt(cfg, "misc", "clear_cache_on_room_change", psp_clear_cache_on_room_change != 0);
+    platform->ReadConfiguration(cfg);
 }
 
 void apply_config(const ConfigTree &cfg)
@@ -419,6 +344,7 @@ void apply_config(const ConfigTree &cfg)
         usetup.no_speech_pack = !CfgReadBoolInt(cfg, "sound", "usespeech", true);
 
         usetup.clear_cache_on_room_change = CfgReadBoolInt(cfg, "misc", "clear_cache_on_room_change", usetup.clear_cache_on_room_change);
+        usetup.load_latest_save = CfgReadBoolInt(cfg, "misc", "load_latest_save", usetup.load_latest_save);
         usetup.user_data_dir = CfgReadString(cfg, "misc", "user_data_dir");
         usetup.shared_data_dir = CfgReadString(cfg, "misc", "shared_data_dir");
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -404,6 +404,8 @@ void engine_init_audio()
 
 void engine_init_debug()
 {
+    if (usetup.show_fps)
+        display_fps = kFPS_Forced;
     if ((debug_flags & (~DBG_DEBUGMODE)) >0) {
         platform->DisplayAlert("Engine debugging enabled.\n"
             "\nNOTE: You have selected to enable one or more engine debugging options.\n"

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -872,14 +872,12 @@ void engine_prepare_to_start_game()
 
     engine_setup_scsystem_auxiliary();
 
-#if (AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS)
-    if (psp_load_latest_savegame)
+    if (usetup.load_latest_save)
     {
         int slot = GetLastSaveSlot();
         if (slot >= 0)
             loadSaveGameOnStartup = get_save_game_path(slot);
     }
-#endif
 }
 
 // TODO: move to test unit
@@ -1054,11 +1052,9 @@ void engine_read_config(ConfigTree &cfg)
         Path::ComparePaths(user_cfg_file, user_global_cfg_file) != 0)
         IniUtil::Read(user_cfg_file, cfg);
 
-    // Apply overriding options from mobile port settings
+    // Apply overriding options from platform settings
     // TODO: normally, those should be instead stored in the same config file in a uniform way
-    // NOTE: the variable is historically called "ignore" but we use it in "override" meaning here
-    if (psp_ignore_acsetup_cfg_file)
-        override_config_ext(cfg);
+    override_config_ext(cfg);
 }
 
 // Gathers settings from all available sources into single ConfigTree

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -13,17 +13,10 @@
 //=============================================================================
 
 //
-// Entry point of the application here.
-//
-//
-// For Windows main() function is really called _mangled_main and is called
-// not by system, but from insides of allegro library.
-// (See allegro\platform\alwin.h)
-// What about other platforms?
+// Entry point of the application.
 //
 
 #include "core/platform.h"
-#define AGS_PLATFORM_DEFINES_PSP_VARS (AGS_PLATFORM_OS_IOS || AGS_PLATFORM_OS_ANDROID)
 #include <set>
 #include <allegro.h> // allegro_exit
 #include "ac/common.h"
@@ -77,22 +70,6 @@ bool attachToParentConsole = false;
 bool hideMessageBoxes = false;
 std::set<String> tellInfoKeys;
 String loadSaveGameOnStartup;
-
-#if ! AGS_PLATFORM_DEFINES_PSP_VARS
-int psp_video_framedrop = 1;
-int psp_ignore_acsetup_cfg_file = 0;
-int psp_clear_cache_on_room_change = 0; // clear --sprite cache-- when room is unloaded
-int psp_rotation = 0;
-
-char psp_game_file_name[] = "";
-char psp_translation[] = "default";
-
-int psp_gfx_renderer = 0;
-int psp_gfx_scaling = 1;
-int psp_gfx_smoothing = 0;
-int psp_gfx_super_sampling = 1;
-int psp_gfx_smooth_sprites = 0;
-#endif
 
 // this needs to be updated if the "play" struct changes
 #define SVG_VERSION_BWCOMPAT_MAJOR      3
@@ -390,11 +367,6 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
     if (datafile_argv > 0)
     {
         cmdGameDataPath = platform->GetCommandArg(datafile_argv);
-    }
-    else
-    {
-        // assign standard path for mobile/consoles (defined in their own platform implementation)
-        cmdGameDataPath = psp_game_file_name;
     }
 
     if (tellInfoKeys.size() > 0)

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -287,9 +287,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             ee += 2;
         }
         else if (ags_stricmp(arg, "--clear-cache-on-room-change") == 0)
-        {
-            CfgWriteString(cfg, "misc", "clear_cache_on_room_change", "1");
-        }
+            cfg["misc"]["clear_cache_on_room_change"] = "1";
         else if (ags_strnicmp(arg, "--tell", 6) == 0) {
             if (arg[6] == 0)
                 tellInfoKeys.insert(String("all"));
@@ -308,27 +306,21 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "--fullscreen") == 0)
             cfg["graphics"]["windowed"] = "0";
         else if ((ags_stricmp(arg, "--gfxdriver") == 0) && (argc > ee + 1))
-        {
-            CfgWriteString(cfg, "graphics", "driver", argv[++ee]);
-        }
+            cfg["graphics"]["driver"] = argv[++ee];
         else if ((ags_stricmp(arg, "--gfxfilter") == 0) && (argc > ee + 1))
         {
             // NOTE: we make an assumption here that if user provides scaling factor,
             // this factor means to be applied to windowed mode only.
-            CfgWriteString(cfg, "graphics", "filter", argv[++ee]);
+            cfg["graphics"]["filter"] = argv[++ee];
             if (argc > ee + 1 && argv[ee + 1][0] != '-')
-                CfgWriteString(cfg, "graphics", "game_scale_win", argv[++ee]);
+                cfg["graphics"]["game_scale_win"] = argv[++ee];
             else
-                CfgWriteString(cfg, "graphics", "game_scale_win", "max_round");
+                cfg["graphics"]["game_scale_win"] = "max_round";
         }
         else if ((ags_stricmp(arg, "--translation") == 0) && (argc > ee + 1))
-        {
-            CfgWriteString(cfg, "language", "translation", argv[++ee]);
-        }
+            cfg["language"]["translation"] = argv[++ee];
         else if (ags_stricmp(arg, "--no-translation") == 0)
-        {
-            CfgWriteString(cfg, "language", "translation", "");
-        }
+            cfg["language"]["translation"] = "";
         else if (ags_stricmp(arg, "--fps") == 0) display_fps = kFPS_Forced;
         else if (ags_stricmp(arg, "--test") == 0) debug_flags |= DBG_DEBUGMODE;
         else if (ags_stricmp(arg, "--noiface") == 0) debug_flags |= DBG_NOIFACE;
@@ -340,9 +332,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         else if (ags_stricmp(arg, "--noscript") == 0) debug_flags |= DBG_NOSCRIPT;
         else if (ags_stricmp(arg, "--novideo") == 0) debug_flags |= DBG_NOVIDEO;
         else if (ags_stricmp(arg, "--rotation") == 0 && (argc > ee + 1))
-        {
-            CfgWriteString(cfg, "graphics", "rotation", argv[++ee]);
-        }
+            cfg["graphics"]["rotation"] = argv[++ee];
         else if (ags_strnicmp(arg, "--log-", 6) == 0 && arg[6] != 0)
         {
             String logarg = arg + 6;

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -321,7 +321,8 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
             cfg["language"]["translation"] = argv[++ee];
         else if (ags_stricmp(arg, "--no-translation") == 0)
             cfg["language"]["translation"] = "";
-        else if (ags_stricmp(arg, "--fps") == 0) display_fps = kFPS_Forced;
+        else if (ags_stricmp(arg, "--fps") == 0)
+            cfg["misc"]["show_fps"] = "1";
         else if (ags_stricmp(arg, "--test") == 0) debug_flags |= DBG_DEBUGMODE;
         else if (ags_stricmp(arg, "--noiface") == 0) debug_flags |= DBG_NOIFACE;
         else if (ags_stricmp(arg, "--nosprdisp") == 0) debug_flags |= DBG_NODRAWSPRITES;

--- a/Engine/main/main.h
+++ b/Engine/main/main.h
@@ -42,13 +42,6 @@ extern int override_start_room;
 extern bool justTellInfo;
 extern AGS::Common::String loadSaveGameOnStartup;
 
-extern int psp_video_framedrop;
-extern int psp_ignore_acsetup_cfg_file;
-extern bool psp_load_latest_savegame;
-extern int psp_clear_cache_on_room_change; // clear --sprite cache-- when room is unloaded
-extern char psp_game_file_name[];
-extern char psp_translation[];
-
 void main_print_help();
 
 int ags_entry_point(int argc, char *argv[]);

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -46,7 +46,6 @@ using namespace AGS::Engine;
 
 extern GameSetupStruct game;
 extern IGraphicsDriver *gfxDriver;
-extern int psp_video_framedrop;
 
 
 //-----------------------------------------------------------------------------

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -157,7 +157,7 @@ JNIEXPORT jint JNICALL
     case CONFIG_ENABLED:
       return setup.config_enabled;
     case CONFIG_DEBUG_FPS:
-      return (setup.display_fps == 2) ? 1 : 0;
+      return setup.show_fps;
     case CONFIG_DEBUG_LOGCAT:
       return setup.debug_write_to_logcat;
     case CONFIG_MOUSE_METHOD:
@@ -240,7 +240,7 @@ JNIEXPORT void JNICALL
       setup.config_enabled = value;
       break;
     case CONFIG_DEBUG_FPS:
-      setup.display_fps = (value == 1) ? 2 : 0;
+      setup.show_fps = value;
       break;
     case CONFIG_DEBUG_LOGCAT:
       setup.debug_write_to_logcat = value;

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -81,6 +81,8 @@ public:
     virtual int  GetLastSystemError() { return errno; }
     // platform specific data file
     virtual const char * GetGameDataFile() {return nullptr; }
+    // Optionally fill in config tree from the platform-specific config source
+    virtual void ReadConfiguration(Common::ConfigTree &cfg) { };
     // Get root directory for storing per-game shared data
     virtual FSLocation GetAllUsersDataDirectory() { return FSLocation("."); }
     // Get root directory for storing per-game saved games

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -47,7 +47,7 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
     CfgWriteInt(cfg, "graphics", "super_sampling", setup.gfx_super_sampling);
     CfgWriteInt(cfg, "graphics", "smooth_sprites", setup.gfx_smooth_sprites);
 
-    CfgWriteInt(cfg, "debug", "show_fps", (setup.display_fps == 2) ? 1 : 0);
+    CfgWriteInt(cfg, "debug", "show_fps", setup.show_fps);
     CfgWriteInt(cfg, "debug", "logging", setup.debug_write_to_logcat);
 
     return IniUtil::Merge(filename, cfg);
@@ -73,9 +73,7 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
         return true;
 
     setup.debug_write_to_logcat = CfgReadBoolInt(cfg, "debug", "logging", false);
-    setup.display_fps = CfgReadBoolInt(cfg, "debug", "show_fps", false);
-    if (setup.display_fps == 1)
-        setup.display_fps = 2;
+    setup.show_fps = CfgReadBoolInt(cfg, "debug", "show_fps", false);
 
     setup.rotation = CfgReadInt(cfg, "misc", "rotation", 0, 2, 0);
 
@@ -172,6 +170,7 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
     CfgWriteInt(cfg, "misc", "antialias", setup.gfx_smooth_sprites != 0);
     CfgWriteInt(cfg, "misc", "clear_cache_on_room_change", setup.clear_cache_on_room_change != 0);
     CfgWriteInt(cfg, "misc", "load_latest_save", setup.load_latest_savegame != 0);
+    CfgWriteInt(cfg, "misc", "show_fps", setup.show_fps);
 }
 
 #endif

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -55,7 +55,7 @@ struct MobileSetup
 
     int mouse_longclick = 0;
 
-    int display_fps = 0;
+    int show_fps = 0;
 
     bool load_latest_savegame = false;
 };

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -15,49 +15,58 @@
 
 #if (AGS_PLATFORM_OS_ANDROID) || (AGS_PLATFORM_OS_IOS)
 
-// Writes mobile platform config
-bool WriteConfiguration(const char *filename);
-// Reads mobile platform config
-bool ReadConfiguration(const char *filename, bool read_everything);
-// Reset config variables
-void ResetConfiguration();
-
+#include "util/ini_util.h"
 
 // Mobile platform options
-extern int psp_ignore_acsetup_cfg_file;
-extern int psp_clear_cache_on_room_change;
-extern int psp_rotation;
-extern int psp_config_enabled;
-extern char psp_translation[100];
-extern char* psp_translations[100];
+struct MobileSetup
+{
+    AGS::Common::String game_file_name;
 
-// Mouse option
-extern int config_mouse_control_mode;
+    // Mobile platform options
+    int ignore_acsetup_cfg_file = 0;
+    int clear_cache_on_room_change = 0;
+    int rotation = 0;
+    int config_enabled = 0;
+    AGS::Common::String translation;
 
-// Graphic options
-extern int psp_gfx_scaling;
-extern int psp_gfx_smoothing;
+    // Mouse option
+    int mouse_control_mode = 0;
 
-// Audio options from the Allegro library.
-extern unsigned int psp_audio_samplerate;
-extern int psp_audio_enabled;
-extern int psp_audio_multithreaded;
-extern int psp_audio_cachesize;
-extern int psp_midi_enabled;
-extern int psp_midi_preload_patches;
+    // Graphic options
+    int gfx_scaling = 0;
+    int gfx_smoothing = 0;
 
-extern int psp_video_framedrop;
+    // Audio options from the Allegro library.
+    unsigned int audio_samplerate = 0;
+    int audio_enabled = 0;
+    int audio_multithreaded = 0;
+    int audio_cachesize = 0;
+    int midi_enabled = 0;
+    int midi_preload_patches = 0;
 
-extern int psp_gfx_renderer;
-extern int psp_gfx_super_sampling;
-extern int psp_gfx_smooth_sprites;
+    // Video playback options
+    int video_framedrop = 0;
 
-extern int psp_debug_write_to_logcat;
+    int gfx_renderer = 0;
+    int gfx_super_sampling = 0;
+    int gfx_smooth_sprites = 0;
 
-extern int config_mouse_longclick;
+    int debug_write_to_logcat = 0;
 
-extern int display_fps;
+    int mouse_longclick = 0;
 
-extern bool psp_load_latest_savegame;
+    int display_fps = 0;
+
+    bool load_latest_savegame = false;
+};
+
+// Writes mobile platform config
+bool WriteConfiguration(const MobileSetup &setup, const char *filename);
+// Reads mobile platform config
+bool ReadConfiguration(MobileSetup &setup, const char *filename, bool read_everything);
+// Reset config variables
+void ResetConfiguration(MobileSetup &setup);
+// Copy mobile options to the config tree meant for the engine
+void ApplyEngineConfiguration(const MobileSetup &setup, AGS::Common::ConfigTree &cfg);
 
 #endif

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -136,7 +136,7 @@ int readIntConfigValue(int id)
     case CONFIG_ENABLED:
       return setup.config_enabled;
     case CONFIG_DEBUG_FPS:
-      return (setup.display_fps == 2) ? 1 : 0;
+      return setup.show_fps;
     case CONFIG_DEBUG_LOGCAT:
       return setup.debug_write_to_logcat;
     case CONFIG_MOUSE_METHOD:
@@ -216,7 +216,7 @@ void setIntConfigValue(int id, int value)
       setup.config_enabled = value;
       break;
     case CONFIG_DEBUG_FPS:
-      setup.display_fps = (value == 1) ? 2 : 0;
+      setup.show_fps = value;
       break;
     case CONFIG_DEBUG_LOGCAT:
       setup.debug_write_to_logcat = value;

--- a/Engine/platform/ios/acplios.cpp
+++ b/Engine/platform/ios/acplios.cpp
@@ -36,9 +36,6 @@ extern char* ios_document_directory;
 
 extern int main(int argc,char*argv[]);
 
-char psp_game_file_name[256];
-char* psp_game_file_name_pointer = psp_game_file_name;
-
 const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
 const int CONFIG_AUDIO_RATE = 2;
@@ -64,7 +61,8 @@ const int CONFIG_MOUSE_LONGCLICK = 20;
 
 
 struct AGSIOS : AGSPlatformDriver {
-
+  virtual const char *GetGameDataFile();
+  virtual void ReadConfiguration(ConfigTree &cfg);
   virtual int  CDPlayerCommand(int cmdd, int datt);
   virtual void Delay(int millis);
   virtual void DisplayAlert(const char*, ...);
@@ -74,171 +72,160 @@ struct AGSIOS : AGSPlatformDriver {
   virtual int  InitializeCDPlayer();
   virtual void SetGameWindowIcon();
   virtual void ShutdownCDPlayer();
+
+  static MobileSetup &GetMobileSetup() { return _msetup; }
+
+private:
+  static MobileSetup _msetup; // static for the use from global callbacks
 };
 
+MobileSetup AGSIOS::_msetup;
 
 
 bool readConfigFile(const char* directory)
 {
   chdir(directory);
 
-  ResetConfiguration();
+  ResetConfiguration(AGSIOS::GetMobileSetup());
 
-  return ReadConfiguration(IOS_CONFIG_FILENAME, true);
+  return ReadConfiguration(AGSIOS::GetMobileSetup(), IOS_CONFIG_FILENAME, true);
 }
 
 
 bool writeConfigFile()
 {
-  return WriteConfiguration(IOS_CONFIG_FILENAME);
+  return WriteConfiguration(AGSIOS::GetMobileSetup(), IOS_CONFIG_FILENAME);
 }
 
 
 int readIntConfigValue(int id)
 {
+  const auto &setup = AGSIOS::GetMobileSetup();
   switch (id)
   {
     case CONFIG_IGNORE_ACSETUP:
-      return psp_ignore_acsetup_cfg_file;
-      break;
+      return setup.ignore_acsetup_cfg_file;
     case CONFIG_CLEAR_CACHE:
-      return psp_clear_cache_on_room_change;
-      break;
+      return setup.clear_cache_on_room_change;
     case CONFIG_AUDIO_RATE:
-      return psp_audio_samplerate;
-      break;
+      return setup.audio_samplerate;
     case CONFIG_AUDIO_ENABLED:
-      return psp_audio_enabled;
-      break;
+      return setup.audio_enabled;
     case CONFIG_AUDIO_THREADED:
-      return psp_audio_multithreaded;
-      break;
+      return setup.audio_multithreaded;
     case CONFIG_AUDIO_CACHESIZE:
-      return psp_audio_cachesize;
-      break;
+      return setup.audio_cachesize;
     case CONFIG_MIDI_ENABLED:
-      return psp_midi_enabled;
-      break;
+      return setup.midi_enabled;
     case CONFIG_MIDI_PRELOAD:
-      return psp_midi_preload_patches;
-      break;
+      return setup.midi_preload_patches;
     case CONFIG_VIDEO_FRAMEDROP:
-      return psp_video_framedrop;
-      break;
+      return setup.video_framedrop;
     case CONFIG_GFX_RENDERER:
-      return psp_gfx_renderer;
-      break;
+      return setup.gfx_renderer;
     case CONFIG_GFX_SMOOTHING:
-      return psp_gfx_smoothing;
-      break;
+      return setup.gfx_smoothing;
     case CONFIG_GFX_SCALING:
-      return psp_gfx_scaling;
-      break;
+      return setup.gfx_scaling;
     case CONFIG_GFX_SS:
-      return psp_gfx_super_sampling;
-      break;
+      return setup.gfx_super_sampling;
     case CONFIG_GFX_SMOOTH_SPRITES:
-      return psp_gfx_smooth_sprites;
-      break;
+      return setup.gfx_smooth_sprites;
     case CONFIG_ROTATION:
-      return psp_rotation;
-      break;
+      return setup.rotation;
     case CONFIG_ENABLED:
-      return psp_config_enabled;
-      break;
+      return setup.config_enabled;
     case CONFIG_DEBUG_FPS:
-      return (display_fps == 2) ? 1 : 0;
-      break;
+      return (setup.display_fps == 2) ? 1 : 0;
     case CONFIG_DEBUG_LOGCAT:
-      return psp_debug_write_to_logcat;
-      break;
+      return setup.debug_write_to_logcat;
     case CONFIG_MOUSE_METHOD:
-      return config_mouse_control_mode;
-      break;
+      return setup.mouse_control_mode;
     case CONFIG_MOUSE_LONGCLICK:
-      return config_mouse_longclick;
-      break;
+      return setup.mouse_longclick;
     default:
       return 0;
-      break;
   }
 }
 
 
-char* readStringConfigValue(int id)
+const char* readStringConfigValue(int id)
 {
+  const auto &setup = AGSIOS::GetMobileSetup();
   switch (id)
   {
     case CONFIG_TRANSLATION:
-      return &psp_translation[0];
-      break;
+      return setup.translation.GetCStr();
+    default:
+      return nullptr;
   }
 }
 
 
 void setIntConfigValue(int id, int value)
 {
+  auto &setup = AGSIOS::GetMobileSetup();
   switch (id)
   {
     case CONFIG_IGNORE_ACSETUP:
-      psp_ignore_acsetup_cfg_file = value;
+      setup.ignore_acsetup_cfg_file = value;
       break;
     case CONFIG_CLEAR_CACHE:
-      psp_clear_cache_on_room_change = value;
+      setup.clear_cache_on_room_change = value;
       break;
     case CONFIG_AUDIO_RATE:
-      psp_audio_samplerate = value;
+      setup.audio_samplerate = value;
       break;
     case CONFIG_AUDIO_ENABLED:
-      psp_audio_enabled = value;
+      setup.audio_enabled = value;
       break;
     case CONFIG_AUDIO_THREADED:
-      psp_audio_multithreaded = value;
+      setup.audio_multithreaded = value;
       break;
     case CONFIG_AUDIO_CACHESIZE:
-      psp_audio_cachesize = value;
+      setup.audio_cachesize = value;
       break;
     case CONFIG_MIDI_ENABLED:
-      psp_midi_enabled = value;
+      setup.midi_enabled = value;
       break;
     case CONFIG_MIDI_PRELOAD:
-      psp_midi_preload_patches = value;
+      setup.midi_preload_patches = value;
       break;
     case CONFIG_VIDEO_FRAMEDROP:
-      psp_video_framedrop = value;
+      setup.video_framedrop = value;
       break;
     case CONFIG_GFX_RENDERER:
-      psp_gfx_renderer = value;
+      setup.gfx_renderer = value;
       break;
     case CONFIG_GFX_SMOOTHING:
-      psp_gfx_smoothing = value;
+      setup.gfx_smoothing = value;
       break;
     case CONFIG_GFX_SCALING:
-      psp_gfx_scaling = value;
+      setup.gfx_scaling = value;
       break;
     case CONFIG_GFX_SS:
-      psp_gfx_super_sampling = value;
+      setup.gfx_super_sampling = value;
       break;
     case CONFIG_GFX_SMOOTH_SPRITES:
-      psp_gfx_smooth_sprites = value;
+      setup.gfx_smooth_sprites = value;
       break;
     case CONFIG_ROTATION:
-      psp_rotation = value;
+      setup.rotation = value;
       break;
     case CONFIG_ENABLED:
-      psp_config_enabled = value;
+      setup.config_enabled = value;
       break;
     case CONFIG_DEBUG_FPS:
-      display_fps = (value == 1) ? 2 : 0;
+      setup.display_fps = (value == 1) ? 2 : 0;
       break;
     case CONFIG_DEBUG_LOGCAT:
-      psp_debug_write_to_logcat = value;
+      setup.debug_write_to_logcat = value;
       break;
     case CONFIG_MOUSE_METHOD:
-      config_mouse_control_mode = value;
+      setup.mouse_control_mode = value;
       break;
     case CONFIG_MOUSE_LONGCLICK:
-      config_mouse_longclick = value;
+      setup.mouse_longclick = value;
       break;
     default:
       break;
@@ -248,10 +235,11 @@ void setIntConfigValue(int id, int value)
 
 void setStringConfigValue(int id, const char* value)
 {
+  auto &setup = AGSIOS::GetMobileSetup();
   switch (id)
   {
     case CONFIG_TRANSLATION:
-      strcpy(psp_translation, value);
+      setup.translation = value;
       break;
     default:
       break;
@@ -279,8 +267,6 @@ int getAvailableTranslations(char* translations)
         {
           memset(buffer, 0, 200);
           strncpy(buffer, entry->d_name, length - 4);
-          psp_translations[i] = (char*)malloc(strlen(buffer) + 1);
-          strcpy(psp_translations[i], buffer);
           env->SetObjectArrayElement(translations, i, env->NewStringUTF(&buffer[0]));
           i++;
         }
@@ -299,20 +285,21 @@ volatile int ios_wait_for_ui = 0;
 
 void startEngine(char* filename, char* directory, int loadLastSave)
 {
-  strcpy(psp_game_file_name, filename);
+  auto &setup = AGSIOS::GetMobileSetup();
+  setup.game_file_name = filename;
 
   // Get the base directory (usually "/sdcard/ags").
   chdir(directory);
 
   // Reset configuration.
-  ResetConfiguration();
+  ResetConfiguration(setup);
 
   // Read general configuration.
-  ReadConfiguration(IOS_CONFIG_FILENAME, true);
+  ReadConfiguration(setup, IOS_CONFIG_FILENAME, true);
 
   // Get the games path.
   char path[256];
-  strcpy(path, psp_game_file_name);
+  strcpy(path, setup.game_file_name.GetCStr());
   int lastindex = strlen(path) - 1;
   while (path[lastindex] != '/')
   {
@@ -326,10 +313,10 @@ void startEngine(char* filename, char* directory, int loadLastSave)
   // Read game specific configuration.
   ReadConfiguration(IOS_CONFIG_FILENAME, false);
 
-  psp_load_latest_savegame = loadLastSave;
+  setup.load_latest_savegame = loadLastSave;
 
   // Start the engine main function.
-  main(1, &psp_game_file_name_pointer);
+  main(0, nullptr);
   
   // Explicitly quit here, otherwise the app will hang forever.
   exit(0);
@@ -337,12 +324,19 @@ void startEngine(char* filename, char* directory, int loadLastSave)
 
 
 
+const char *AGSIOS::GetGameDataFile()
+{
+  return _msetup.game_file_name.GetCStr();
+}
+
+void AGSIOS::ReadConfiguration(Common::ConfigTree &cfg)
+{
+  ApplyEngineConfiguration(_msetup, cfg);
+}
 
 int AGSIOS::CDPlayerCommand(int cmdd, int datt) {
   return 0;//cd_player_control(cmdd, datt);
 }
-
-
 
 void AGSIOS::DisplayAlert(const char *text, ...) {
   char displbuf[2000];


### PR DESCRIPTION
Resolves #106.

* Gathered mobile platform config options into MobileSetup struct.
* Removed all psp_* variables from the core engine code.
* Instead the engine receives port's special config using platform->ReadConfiguration().
* Mobile ports pass respective parts of the MobileSetup into the engine's own config.
* Added "load_latest_save" to the engine config.

More options could be transferred later (i noticed that some may still make sense but are not part of engine's config anymore).