### PR TITLE
Fix compiler float defaults

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -638,13 +638,26 @@ int check_not_eof(ccInternalList &targ) {
   return 0;
 }
 
-int check_for_default_value(ccInternalList &targ, int funcsym, int numparams) {
+// return the float as an int32 (but not actually converted to int)
+int float_to_int_raw(float toconv) {
+    union
+    {
+        float   f;
+        int32_t i32;
+    } conv;
+    conv.f = toconv;
+    return conv.i32;
+}
 
+int check_for_default_value(ccInternalList &targ, int funcsym, int numparams) {
     if (sym.get_type(targ.peeknext()) == SYM_ASSIGN) {
+        const char *vartype = sym.get_name(targ.script[targ.pos - 2]);
         // parameter has default value
         targ.getnext();
         int defValSym = targ.getnext();
         bool negateIt = false;
+        bool isFloat = false;
+        bool isPointer = strchr(vartype, '*') != NULL;
 
         if (sym.get_name(defValSym)[0] == '-') {
             // allow negative default value
@@ -653,10 +666,36 @@ int check_for_default_value(ccInternalList &targ, int funcsym, int numparams) {
         }
 
         int defaultValue;
-
+        if (strchr(sym.get_name(defValSym), '.') != NULL) {
+            float fval = atof(sym.get_name(defValSym));
+            isFloat = true;
+            if (negateIt)
+                fval = -fval;
+            defaultValue = float_to_int_raw(fval);
+        }
         // extract the default value
-        if (accept_literal_or_constant_value(defValSym, defaultValue, negateIt, "Parameter default value must be literal") < 0) {
+        else if (accept_literal_or_constant_value(defValSym, defaultValue, negateIt, "Parameter default value must be literal") < 0) {
             return -1;
+        }
+
+        // check validity of value type to parameter type
+        if (defaultValue != 0) {
+            // 0 as value or pointer is always valid, so we only check the other cases
+
+            if (isPointer) {
+                cc_error("Parameter default pointer value can only be 0");
+                return -1;
+            }
+            if (isFloat ^ (strcmp(vartype, "float") == 0)) {
+                // float values allowed only for type float
+                cc_error("Parameter default value must be %s or 0", vartype);
+                return -1;
+            }
+            if (strcmp(vartype, "String") == 0) {
+                // prevent non-zero integers for type String
+                cc_error("Parameter default value for type String must be 0");
+                return -1;
+            }
         }
 
         sym.entries[funcsym].funcParamDefaultValues[numparams % 100] = defaultValue;
@@ -1046,17 +1085,6 @@ int process_function_declaration(ccInternalList &targ, ccCompiledScript*scrip,
   }
 
   return 0;
-}
-
-// return the float as an int32 (but not actually converted to int)
-int float_to_int_raw(float toconv) {
-    union
-    {
-        float   f;
-        int32_t i32;
-    } conv;
-    conv.f = toconv;
-    return conv.i32;
 }
 
 int isPartOfExpression(ccInternalList *targ, int j) {

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -167,7 +167,7 @@ TEST(Compile, ParsingNegIntDefaultOverflow) {
 TEST(Compile, ParsingIntDefaultFloatMismatch) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         import  int  importedfunc(int data1 = 156.15);\
         ";
 
@@ -180,7 +180,7 @@ TEST(Compile, ParsingIntDefaultFloatMismatch) {
 TEST(Compile, ParsingFloatDefault) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         import  int  importedfunc(float data1 = 0, float data2=12.5, float data3=-35654.156);\
         ";
 
@@ -192,7 +192,7 @@ TEST(Compile, ParsingFloatDefault) {
 TEST(Compile, ParsingFloatDefaultIntMismatch) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         import  int  importedfunc(float data1 = 1);\
         ";
 
@@ -205,7 +205,7 @@ TEST(Compile, ParsingFloatDefaultIntMismatch) {
 TEST(Compile, ParsingStringDefaultNull) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct String { };\
         import  int  importedfunc(String data1 = 0);\
         ";
@@ -218,7 +218,7 @@ TEST(Compile, ParsingStringDefaultNull) {
 TEST(Compile, ParsingStringDefaultInvalid) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct String { };\
         import  int  importedfunc(String data1 = 1);\
         ";
@@ -232,7 +232,7 @@ TEST(Compile, ParsingStringDefaultInvalid) {
 TEST(Compile, ParsingPointerDefaultNull) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Character { };\
         import  int  importedfunc(Character *data1 = 0);\
         ";
@@ -245,7 +245,7 @@ TEST(Compile, ParsingPointerDefaultNull) {
 TEST(Compile, ParsingPointerDefaultInvalid) {
     ccCompiledScript *scrip = newScriptFixture();
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Character { };\
         import  int  importedfunc(Character *data1 = 10);\
         ";

--- a/Compiler/test/cs_parser_test.cpp
+++ b/Compiler/test/cs_parser_test.cpp
@@ -164,6 +164,98 @@ TEST(Compile, ParsingNegIntDefaultOverflow) {
     EXPECT_STREQ("Could not parse integer symbol '-9999999999999999999999' because of overflow.", last_seen_cc_error());
 }
 
+TEST(Compile, ParsingIntDefaultFloatMismatch) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        import  int  importedfunc(int data1 = 156.15);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Parameter default value must be int or 0", last_seen_cc_error());
+}
+
+TEST(Compile, ParsingFloatDefault) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        import  int  importedfunc(float data1 = 0, float data2=12.5, float data3=-35654.156);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(0, compileResult);
+}
+
+TEST(Compile, ParsingFloatDefaultIntMismatch) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        import  int  importedfunc(float data1 = 1);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Parameter default value must be float or 0", last_seen_cc_error());
+}
+
+TEST(Compile, ParsingStringDefaultNull) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct String { };\
+        import  int  importedfunc(String data1 = 0);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(0, compileResult);
+}
+
+TEST(Compile, ParsingStringDefaultInvalid) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct String { };\
+        import  int  importedfunc(String data1 = 1);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Parameter default value for type String must be 0", last_seen_cc_error());
+}
+
+TEST(Compile, ParsingPointerDefaultNull) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct Character { };\
+        import  int  importedfunc(Character *data1 = 0);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(0, compileResult);
+}
+
+TEST(Compile, ParsingPointerDefaultInvalid) {
+    ccCompiledScript *scrip = newScriptFixture();
+
+    char *inpl = "\
+        managed struct Character { };\
+        import  int  importedfunc(Character *data1 = 10);\
+        ";
+
+    clear_error();
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_EQ(-1, compileResult);
+    EXPECT_STREQ("Parameter default pointer value can only be 0", last_seen_cc_error());
+}
+
 TEST(Compile, ParsingIntOverflow) {
     ccCompiledScript *scrip = newScriptFixture();
 


### PR DESCRIPTION
fixes #1642 

Allows for float values to be used and shows errors when trying to use non-zero integers for float, String, or pointer types.
`-` Alan