### PR TITLE
Support graphical Overlays not cloning the assigned sprite

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1274,7 +1274,11 @@ builtin managed struct InventoryItem {
 
 builtin managed struct Overlay {
   /// Creates an overlay that displays a sprite.
-  import static Overlay* CreateGraphical(int x, int y, int slot, bool transparent);  // $AUTOCOMPLETESTATICONLY$
+  import static Overlay* CreateGraphical(int x, int y, int slot, bool transparent = true
+#ifdef SCRIPT_API_v360
+	, bool clone = false
+#endif
+  );  // $AUTOCOMPLETESTATICONLY$
   /// Creates an overlay that displays some text.
   import static Overlay* CreateTextual(int x, int y, int width, FontType, int colour, const string text, ...);  // $AUTOCOMPLETESTATICONLY$
   /// Changes the text on the overlay.
@@ -1289,7 +1293,7 @@ builtin managed struct Overlay {
   import attribute int Y;
 #ifdef SCRIPT_API_v360
   /// Creates an overlay that displays a sprite inside the room.
-  import static Overlay* CreateRoomGraphical(int x, int y, int slot, bool transparent);  // $AUTOCOMPLETESTATICONLY$
+  import static Overlay* CreateRoomGraphical(int x, int y, int slot, bool transparent = true, bool clone = false);  // $AUTOCOMPLETESTATICONLY$
   /// Creates an overlay that displays some text inside the room.
   import static Overlay* CreateRoomTextual(int x, int y, int width, FontType, int colour, const string text, ...);  // $AUTOCOMPLETESTATICONLY$
   /// Gets whether this overlay is located inside the room, as opposed to the screen layer.

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2461,15 +2461,15 @@ static void construct_overlays()
         {
             // For software mode - prepare transformed bitmap if necessary
             Bitmap *use_bmp = is_software_mode ?
-                transform_sprite(over.pic, over.HasAlphaChannel(), overlaybmp[i], Size(over.scaleWidth, over.scaleHeight)) :
-                over.pic;
+                transform_sprite(over.GetImage(), over.HasAlphaChannel(), overlaybmp[i], Size(over.scaleWidth, over.scaleHeight)) :
+                over.GetImage();
 
             if ((walkBehindMethod == DrawOverCharSprite) && over.IsRoomLayer())
             {
                 if (use_bmp != overlaybmp[i].get())
                 {
-                    recycle_bitmap(overlaybmp[i], over.pic->GetColorDepth(), over.pic->GetWidth(), over.pic->GetHeight(), true);
-                    overlaybmp[i]->Blit(over.pic);
+                    recycle_bitmap(overlaybmp[i], use_bmp->GetColorDepth(), use_bmp->GetWidth(), use_bmp->GetHeight(), true);
+                    overlaybmp[i]->Blit(use_bmp);
                 }
                 Point pos = get_overlay_position(over);
                 walkbehinds_cropout(overlaybmp[i].get(), pos.X, pos.Y, over.zorder);

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1464,6 +1464,12 @@ void game_sprite_updated(int sprnum)
             guislider[i].MarkChanged();
         }
     }
+    // overlays
+    for (auto &over : screenover)
+    {
+        if (over.GetSpriteNum() == sprnum)
+            over.MarkChanged();
+    }
 }
 
 void game_sprite_deleted(int sprnum)
@@ -1525,6 +1531,12 @@ void game_sprite_deleted(int sprnum)
                     views[v].loops[l].frames[f].pic = 0;
             }
         }
+    }
+    // overlays
+    for (auto &over : screenover)
+    {
+        if (over.GetSpriteNum() == sprnum)
+            over.SetSpriteNum(0);
     }
 }
 

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -23,8 +23,8 @@ void RemoveOverlay(int ovrid) {
     remove_screen_overlay(ovrid);
 }
 
-int CreateGraphicOverlay(int xx, int yy, int slott, int trans) {
-    auto *over = Overlay_CreateGraphicCore(false, xx, yy, slott, trans);
+int CreateGraphicOverlay(int x, int y, int slott, int trans) {
+    auto *over = Overlay_CreateGraphicCore(false, x, y, slott, trans != 0, true); // always clone
     return over ? over->type : 0;
 }
 

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -121,14 +121,14 @@ int Overlay_GetGraphicWidth(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].pic->GetWidth());
+    return game_to_data_coord(screenover[ovri].GetImage()->GetWidth());
 }
 
 int Overlay_GetGraphicHeight(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].pic->GetHeight());
+    return game_to_data_coord(screenover[ovri].GetImage()->GetHeight());
 }
 
 void Overlay_SetScaledSize(ScreenOverlay &over, int width, int height) {
@@ -174,11 +174,20 @@ int Overlay_GetValid(ScriptOverlay *scover) {
 ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent)
 {
     data_to_game_coords(&x, &y);
-    Bitmap *screeno = BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height, game.GetColorDepth());
-    screeno->Blit(spriteset[slot], 0, 0, transparent ? kBitmap_Transparency : kBitmap_Copy);
-    size_t nse = add_screen_overlay(room_layer, x, y, OVER_CUSTOM, screeno,
-        (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
-    return nse < SIZE_MAX ? &screenover[nse] : nullptr;
+    size_t overid;
+    // We clone only dynamic sprites, because it makes no sense to clone normal ones
+    if ((game.SpriteInfos[slot].Flags & SPF_DYNAMICALLOC) != 0)
+    {
+        Bitmap *screeno = BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height, game.GetColorDepth());
+        screeno->Blit(spriteset[slot], 0, 0, transparent ? kBitmap_Transparency : kBitmap_Copy);
+        overid = add_screen_overlay(room_layer, x, y, OVER_CUSTOM, screeno,
+            (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
+    }
+    else
+    {
+        overid = add_screen_overlay(room_layer, x, y, OVER_CUSTOM, slot);
+    }
+    return overid < SIZE_MAX ? &screenover[overid] : nullptr;
 }
 
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
@@ -282,8 +291,7 @@ static void invalidate_and_subref(ScreenOverlay &over, ScriptOverlay **scover)
 // Frees overlay resources and tell to dispose script object if there are no refs left
 static void dispose_overlay(ScreenOverlay &over)
 {
-    delete over.pic;
-    over.pic = nullptr;
+    over.SetImage(nullptr);
     if (over.ddb != nullptr)
         gfxDriver->DestroyDDB(over.ddb);
     over.ddb = nullptr;
@@ -346,12 +354,8 @@ int find_overlay_of_type(int type)
     return -1;
 }
 
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, bool alphaChannel)
-{
-    return add_screen_overlay(roomlayer, x, y, type, piccy, 0, 0, alphaChannel);
-}
-
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel)
+size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum, Bitmap *piccy,
+    int pic_offx, int pic_offy, bool has_alpha)
 {
     if (type == OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
@@ -360,14 +364,23 @@ size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy,
         }
     }
     ScreenOverlay over;
-    over.pic=piccy;
+    if (piccy)
+    {
+        over.SetImage(std::unique_ptr<Bitmap>(piccy));
+        over.SetAlphaChannel(has_alpha);
+    }
+    else
+    {
+        over.SetSpriteNum(sprnum);
+        over.SetAlphaChannel((game.SpriteInfos[sprnum].Flags & SPF_ALPHACHANNEL) != 0);
+    }
     over.ddb = nullptr; // is generated during first draw pass
     over.x=x;
     over.y=y;
     over.offsetX = pic_offx;
     over.offsetY = pic_offy;
-    over.scaleWidth = piccy->GetWidth();
-    over.scaleHeight = piccy->GetHeight();
+    over.scaleWidth = over.GetImage()->GetWidth();
+    over.scaleHeight = over.GetImage()->GetHeight();
     // by default draw speech and portraits over GUI, and the rest under GUI
     over.zorder = (roomlayer || type == OVER_TEXTMSG || type == OVER_PICTURE || type == OVER_TEXTSPEECH) ?
         INT_MAX : INT_MIN;
@@ -375,7 +388,6 @@ size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy,
     over.timeout=0;
     over.bgSpeechForChar = -1;
     over.associatedOverlayHandle = 0;
-    over.SetAlphaChannel(alphaChannel);
     over.SetRoomLayer(roomlayer);
     // TODO: move these custom settings outside of this function
     if (type == OVER_COMPLETE) play.complete_overlay_on = type;
@@ -396,7 +408,20 @@ size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy,
     return screenover.size() - 1;
 }
 
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum)
+{
+    return add_screen_overlay_impl(roomlayer, x, y, type, sprnum, nullptr, 0, 0, false);
+}
 
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Bitmap *piccy, bool has_alpha)
+{
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, piccy, 0, 0, has_alpha);
+}
+
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha)
+{
+    return add_screen_overlay_impl(roomlayer, x, y, type, -1, piccy, pic_offx, pic_offy, has_alpha);
+}
 
 Point get_overlay_position(const ScreenOverlay &over)
 {
@@ -417,16 +442,17 @@ Point get_overlay_position(const ScreenOverlay &over)
         Point screenpt = view->RoomToScreen(
             data_to_game_coord(game.chars[charid].x),
             data_to_game_coord(game.chars[charid].get_effective_y()) - height).first;
-        int tdxp = std::max(0, screenpt.X - over.pic->GetWidth() / 2);
+        Bitmap *pic = over.GetImage();
+        int tdxp = std::max(0, screenpt.X - pic->GetWidth() / 2);
         int tdyp = screenpt.Y - get_fixed_pixel_size(5);
-        tdyp -= over.pic->GetHeight();
+        tdyp -= pic->GetHeight();
         tdyp = std::max(5, tdyp);
 
-        if ((tdxp + over.pic->GetWidth()) >= ui_view.GetWidth())
-            tdxp = (ui_view.GetWidth() - over.pic->GetWidth()) - 1;
+        if ((tdxp + pic->GetWidth()) >= ui_view.GetWidth())
+            tdxp = (ui_view.GetWidth() - pic->GetWidth()) - 1;
         if (game.chars[charid].room != displayed_room) {
-            tdxp = ui_view.GetWidth()/2 - over.pic->GetWidth()/2;
-            tdyp = ui_view.GetHeight()/2 - over.pic->GetHeight()/2;
+            tdxp = ui_view.GetWidth()/2 - pic->GetWidth()/2;
+            tdyp = ui_view.GetHeight()/2 - pic->GetHeight()/2;
         }
         return Point(tdxp, tdyp);
     }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -171,12 +171,12 @@ int Overlay_GetValid(ScriptOverlay *scover) {
     return 1;
 }
 
-ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent)
+ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent, bool clone)
 {
     data_to_game_coords(&x, &y);
     size_t overid;
     // We clone only dynamic sprites, because it makes no sense to clone normal ones
-    if ((game.SpriteInfos[slot].Flags & SPF_DYNAMICALLOC) != 0)
+    if (clone && ((game.SpriteInfos[slot].Flags & SPF_DYNAMICALLOC) != 0))
     {
         Bitmap *screeno = BitmapHelper::CreateTransparentBitmap(game.SpriteInfos[slot].Width, game.SpriteInfos[slot].Height, game.GetColorDepth());
         screeno->Blit(spriteset[slot], 0, 0, transparent ? kBitmap_Transparency : kBitmap_Copy);
@@ -199,15 +199,15 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     return _display_main(x, y, width, text, disp_type, font, -text_color, 0, allow_shrink, false);
 }
 
-ScriptOverlay* Overlay_CreateGraphicalEx(bool room_layer, int x, int y, int slot, int transparent)
+ScriptOverlay* Overlay_CreateGraphicalEx(bool room_layer, int x, int y, int slot, int transparent, bool clone)
 {
-    auto *over = Overlay_CreateGraphicCore(room_layer, x, y, slot, transparent != 0);
+    auto *over = Overlay_CreateGraphicCore(room_layer, x, y, slot, transparent != 0, clone);
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 
 ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent)
 {
-    auto *over = Overlay_CreateGraphicCore(false, x, y, slot, transparent != 0);
+    auto *over = Overlay_CreateGraphicCore(false, x, y, slot, transparent != 0, true); // always clone
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 
@@ -494,15 +494,23 @@ RuntimeScriptValue Sc_Overlay_CreateGraphical(const RuntimeScriptValue *params, 
 {
     ASSERT_PARAM_COUNT(FUNCTION, 4);
     ScriptOverlay *overlay = Overlay_CreateGraphicalEx(false, params[0].IValue, params[1].IValue, params[2].IValue,
-        params[3].IValue);
+        params[3].IValue, true); // always clone image
+    return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
+}
+
+RuntimeScriptValue Sc_Overlay_CreateGraphicalRef(const RuntimeScriptValue *params, int32_t param_count)
+{
+    ASSERT_PARAM_COUNT(FUNCTION, 5);
+    ScriptOverlay *overlay = Overlay_CreateGraphicalEx(false, params[0].IValue, params[1].IValue, params[2].IValue,
+        params[3].IValue, params[4].GetAsBool());
     return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
 }
 
 RuntimeScriptValue Sc_Overlay_CreateRoomGraphical(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_PARAM_COUNT(FUNCTION, 4);
+    ASSERT_PARAM_COUNT(FUNCTION, 5);
     ScriptOverlay *overlay = Overlay_CreateGraphicalEx(true, params[0].IValue, params[1].IValue, params[2].IValue,
-        params[3].IValue);
+        params[3].IValue, params[4].GetAsBool());
     return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
 }
 
@@ -646,8 +654,9 @@ void ScPl_Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, c
 void RegisterOverlayAPI()
 {
     ccAddExternalStaticFunction("Overlay::CreateGraphical^4",   Sc_Overlay_CreateGraphical);
+    ccAddExternalStaticFunction("Overlay::CreateGraphical^5",   Sc_Overlay_CreateGraphicalRef);
     ccAddExternalStaticFunction("Overlay::CreateTextual^106",   Sc_Overlay_CreateTextual);
-    ccAddExternalStaticFunction("Overlay::CreateRoomGraphical^4", Sc_Overlay_CreateRoomGraphical);
+    ccAddExternalStaticFunction("Overlay::CreateRoomGraphical^5", Sc_Overlay_CreateRoomGraphical);
     ccAddExternalStaticFunction("Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual);
     ccAddExternalObjectFunction("Overlay::SetText^104",         Sc_Overlay_SetText);
     ccAddExternalObjectFunction("Overlay::Remove^0",            Sc_Overlay_Remove);

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -34,7 +34,7 @@ void Overlay_SetY(ScriptOverlay *scover, int newy);
 int  Overlay_GetValid(ScriptOverlay *scover);
 ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent);
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
-ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent);
+ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent, bool clone);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
     const char *text, int disp_type, int allow_shrink);
 

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -42,8 +42,9 @@ int  find_overlay_of_type(int type);
 void remove_screen_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)
 Point get_overlay_position(const ScreenOverlay &over);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool alphaChannel = false);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool alphaChannel = false);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool has_alpha);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha);
 void remove_screen_overlay_index(size_t over_idx);
 // Creates and registers a managed script object for existing overlay object;
 // optionally adds an internal engine reference to prevent object's disposal

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -11,17 +11,40 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-#include "screenoverlay.h"
+#include "ac/screenoverlay.h"
+#include "ac/spritecache.h"
+#include "gfx/bitmap.h"
 #include "util/stream.h"
 
-using AGS::Common::Stream;
+using namespace AGS::Common;
+
+Bitmap *ScreenOverlay::GetImage() const
+{
+    return IsSpriteReference() ?
+        spriteset[_sprnum] :
+        _pic.get();
+}
+
+void ScreenOverlay::SetImage(std::unique_ptr<Common::Bitmap> pic)
+{
+    _flags &= ~kOver_SpriteReference;
+    _pic = std::move(pic);
+    _sprnum = -1;
+}
+
+void ScreenOverlay::SetSpriteNum(int sprnum)
+{
+    _flags |= kOver_SpriteReference;
+    _pic.reset();
+    _sprnum = sprnum;
+}
 
 void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
 {
-    pic = nullptr;
+    _pic.reset();
     ddb = nullptr;
     in->ReadInt32(); // ddb 32-bit pointer value (nasty legacy format)
-    has_bitmap = in->ReadInt32() != 0;
+    int pic = in->ReadInt32();
     type = in->ReadInt32();
     x = in->ReadInt32();
     y = in->ReadInt32();
@@ -52,12 +75,26 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
         scaleWidth = in->ReadInt32();
         scaleHeight = in->ReadInt32();
     }
+
+    if (_flags & kOver_SpriteReference)
+    {
+        _sprnum = pic;
+        has_bitmap = false;
+    }
+    else
+    {
+        _sprnum = -1;
+        has_bitmap = pic != 0;
+    }
 }
 
 void ScreenOverlay::WriteToFile(Stream *out) const
 {
     out->WriteInt32(0); // ddb 32-bit pointer value (nasty legacy format)
-    out->WriteInt32(pic ? 1 : 0); // has bitmap
+    if (_flags & kOver_SpriteReference)
+        out->WriteInt32(_sprnum); // sprite reference
+    else
+        out->WriteInt32(_pic ? 1 : 0); // has bitmap
     out->WriteInt32(type);
     out->WriteInt32(x);
     out->WriteInt32(y);

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -850,7 +850,8 @@ HSaveError WriteOverlays(Stream *out)
     for (const auto &over : screenover)
     {
         over.WriteToFile(out);
-        serialize_bitmap(over.pic, out);
+        if (!over.IsSpriteReference())
+            serialize_bitmap(over.GetImage(), out);
     }
     return HSaveError::None();
 }
@@ -864,13 +865,13 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
         bool has_bitmap;
         over.ReadFromFile(in, has_bitmap, cmp_ver);
         if (has_bitmap)
-            over.pic = read_serialized_bitmap(in);
+            over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)));
         if (over.scaleWidth <= 0 || over.scaleHeight <= 0)
         {
-            over.scaleWidth = over.pic->GetWidth();
-            over.scaleHeight = over.pic->GetHeight();
+            over.scaleWidth = over.GetImage()->GetWidth();
+            over.scaleHeight = over.GetImage()->GetHeight();
         }
-        screenover.push_back(over);
+        screenover.push_back(std::move(over));
     }
     return HSaveError::None();
 }

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -326,7 +326,7 @@ static void restore_game_overlays(Stream *in)
     ReadOverlays_Aligned(in, has_bitmap, num_overs);
     for (size_t i = 0; i < num_overs; ++i) {
         if (has_bitmap[i])
-            screenover[i].pic = read_serialized_bitmap(in);
+            screenover[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)));
     }
 }
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -417,6 +417,7 @@ void update_sierra_speech()
       int view_frame_x = 0;
       int view_frame_y = 0;
 
+      Bitmap *frame_pic = screenover[face_talking].GetImage();
       if (game.options[OPT_SPEECHTYPE] == 3) {
         // QFG4-style fullscreen dialog
         if (facetalk_qfg4_override_placement_x)
@@ -429,15 +430,14 @@ void update_sierra_speech()
         }
         else
         {
-          view_frame_y = (screenover[face_talking].pic->GetHeight() / 2) - (game.SpriteInfos[thisPic].Height / 2);
+          view_frame_y = (frame_pic->GetHeight() / 2) - (game.SpriteInfos[thisPic].Height / 2);
         }
-        screenover[face_talking].pic->Clear(0);
+        frame_pic->Clear(0);
       }
       else {
-        screenover[face_talking].pic->ClearTransparent();
+        frame_pic->ClearTransparent();
       }
 
-      Bitmap *frame_pic = screenover[face_talking].pic;
       const ViewFrame *face_vf = &views[facetalkview].loops[facetalkloop].frames[facetalkframe];
       bool face_has_alpha = (game.SpriteInfos[face_vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
       DrawViewFrame(frame_pic, face_vf, view_frame_x, view_frame_y);


### PR DESCRIPTION
I think this is the last addition to Overlays, complementing new features added in the last version.
There's a historical issue that Overlays make a full copy of a sprite when created, instead of saving a sprite number like all other objects do. While overlay total number was limited (to 20 afaik) this could be tolerated, but as this restriction is now removed, and overlays may be created in any numbers, this issue becomes quite noteable. It increases the memory usage, often unnecessarily, which becomes silly if a large number of overlays are created using same sprites.

This change adds support for storing a sprite's number in overlays instead of making a bitmap copy, when possible. By default it does so if overlay is assigned a "normal" sprite from the game's resources, as regular sprites cannot be edited or deleted.

To also cover the dynamic sprites, an extra `clone` parameter is added to Overlay.CreateGraphical which tells whether to clone the sprite for overlay's use, or use one from sprite set by the number as all other objects do.
* the default value of `clone` is false, to avoid unnecessary copying when users don't realize it's happening.
* old games will keep using old variant of this function, which translates into `clone = true`.
* regardless of the `clone` parameter, the engine internally still does not clone if the assigned sprite is a regular (non dynamic) one, because there's no point of doing that.

I believe that in the future this parameter may be removed, as well as image cloning itself. In my opinion this should not be an object's feature, but a part of the sprite management.

How to test this: create a large number of overlays using same sprite. In previous version the memory usage should increase roughly by (memory size of sprite x number of overlays). In this branch it should increase by (1 memory size of sprite + negligible amount for overlay structs).