### PR TITLE
Refactored Bitmap loading non locked bitmaps method as util

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1960,7 +1960,7 @@ namespace AGS.Editor.Components
             _guiController.RefreshPropertyGrid();
         }
 
-        private Bitmap LoadBackground(int i) => LoadNonLockedBitmap(_loadedRoom.GetBackgroundFileName(i));
+        private Bitmap LoadBackground(int i) => BitmapExtensions.LoadNonLockedBitmap(_loadedRoom.GetBackgroundFileName(i));
 
         private void RefreshBackground(int i)
         {
@@ -1980,7 +1980,7 @@ namespace AGS.Editor.Components
             return bitmap;
         }
 
-        private Bitmap LoadMask(RoomAreaMaskType mask) => LoadNonLockedBitmap(_loadedRoom.GetMaskFileName(mask));
+        private Bitmap LoadMask(RoomAreaMaskType mask) => BitmapExtensions.LoadNonLockedBitmap(_loadedRoom.GetMaskFileName(mask));
 
         private void RefreshMask(RoomAreaMaskType mask)
         {
@@ -2029,14 +2029,6 @@ namespace AGS.Editor.Components
             }
 
             return true;
-        }
-
-        private Bitmap LoadNonLockedBitmap(string fileName)
-        {
-            using (MemoryStream ms = new MemoryStream(File.ReadAllBytes(fileName)))
-            {
-                return new Bitmap(ms);
-            }
         }
 
         private void ClearImageCache()

--- a/Editor/AGS.Editor/Utils/BitmapExtensions.cs
+++ b/Editor/AGS.Editor/Utils/BitmapExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -10,6 +11,15 @@ namespace AGS.Editor
 {
     public static class BitmapExtensions
     {
+        /// <summary>
+        /// Loads a <see cref="Bitmap"/> from file that doesn't lock the original file.
+        /// </summary>
+        public static Bitmap LoadNonLockedBitmap(string path)
+        {
+            using (MemoryStream ms = new MemoryStream(File.ReadAllBytes(path)))
+                return new Bitmap(ms);
+        }
+
         /// <summary>
         /// Gets an integer with the color depth of the image.
         /// </summary>


### PR DESCRIPTION
Moving this to the general bitmap util class is more convenient because I want to use this method other places (like in the open sprites project)