### PR TITLE
Script API: remade Overlay.InRoom to Overlay.Layer, ObjectLayer enum

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -377,6 +377,12 @@ enum eKeyMod
   eKeyModNum        = 0x0040,
   eKeyModCaps       = 0x0080,
 };
+
+enum ObjectLayer
+{
+  eLayerRoom,
+  eLayerUI
+};
 #endif
 
 #ifdef SCRIPT_API_v3507
@@ -1293,7 +1299,7 @@ builtin managed struct Overlay {
   /// Creates an overlay that displays some text inside the room.
   import static Overlay* CreateRoomTextual(int x, int y, int width, FontType, int colour, const string text, ...);  // $AUTOCOMPLETESTATICONLY$
   /// Gets whether this overlay is located inside the room, as opposed to the screen layer.
-  import readonly attribute bool InRoom;
+  import readonly attribute ObjectLayer Layer;
   /// Gets/sets the width of this overlay. Resizing overlay will scale its image.
   import attribute int Width;
   /// Gets/sets the height of this overlay. Resizing overlay will scale its image.

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -96,11 +96,11 @@ void Overlay_SetY(ScriptOverlay *scover, int newy) {
     screenover[ovri].y = data_to_game_coord(newy);
 }
 
-bool Overlay_InRoom(ScriptOverlay *scover) {
+bool Overlay_GetLayer(ScriptOverlay *scover) {
     int ovri = find_overlay_of_type(scover->overlayId);
     if (ovri < 0)
         quit("!invalid overlay ID specified");
-    return screenover[ovri].IsRoomLayer();
+    return screenover[ovri].IsRoomLayer() ? eLayerRoom : eLayerUI;
 }
 
 int Overlay_GetWidth(ScriptOverlay *scover) {
@@ -541,9 +541,9 @@ RuntimeScriptValue Sc_Overlay_SetY(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(ScriptOverlay, Overlay_SetY);
 }
 
-RuntimeScriptValue Sc_Overlay_InRoom(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Overlay_GetLayer(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_BOOL(ScriptOverlay, Overlay_InRoom);
+    API_OBJCALL_BOOL(ScriptOverlay, Overlay_GetLayer);
 }
 
 RuntimeScriptValue Sc_Overlay_GetWidth(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -630,7 +630,7 @@ void RegisterOverlayAPI()
     ccAddExternalObjectFunction("Overlay::set_X",               Sc_Overlay_SetX);
     ccAddExternalObjectFunction("Overlay::get_Y",               Sc_Overlay_GetY);
     ccAddExternalObjectFunction("Overlay::set_Y",               Sc_Overlay_SetY);
-    ccAddExternalObjectFunction("Overlay::get_InRoom",          Sc_Overlay_InRoom);
+    ccAddExternalObjectFunction("Overlay::get_Layer",           Sc_Overlay_GetLayer);
     ccAddExternalObjectFunction("Overlay::get_Width",           Sc_Overlay_GetWidth);
     ccAddExternalObjectFunction("Overlay::set_Width",           Sc_Overlay_SetWidth);
     ccAddExternalObjectFunction("Overlay::get_Height",          Sc_Overlay_GetHeight);

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -149,4 +149,11 @@ const int LegacyRoomVolumeFactor            = 30;
 
 #define RETURN_CONTINUE 1
 
+// Defines the coordinate space the game object belongs to
+enum ObjectLayer
+{
+    eLayerRoom,
+    eLayerUI
+};
+
 #endif // __AC_RUNTIMEDEFINES_H


### PR DESCRIPTION
In script added ObjectLayer enum:
```
enum ObjectLayer
{
  eLayerRoom,
  eLayerUI
};
```

Remade recently added `bool Overlay.InRoom` to `ObjectLayer Overlay.Layer` property.


EDIT: There's also an option to use this layer as a parameter to CreateGraphical/CreateTextual instead of adding new functions, but this may make using them annoying. Also in case of CreateTextual it's difficult to add new parameters, as it's a variadic function with text formatting, so parameters cannot be added to the end of the argument list. If I add one, then all existing scripts with CreateTextual will have to be fixed.