### PR TITLE
Perfomance: implement short-term texture cache

### DIFF
--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -87,7 +87,10 @@ void mark_current_background_dirty();
 // Avoid freeing and reallocating the memory if possible
 Common::Bitmap *recycle_bitmap(Common::Bitmap *bimp, int coldep, int wid, int hit, bool make_transparent = false);
 void recycle_bitmap(std::unique_ptr<Common::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent = false);
-Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *ddb, Common::Bitmap *source, bool has_alpha = false, bool opaque = false);
+Engine::IDriverDependantBitmap* recycle_ddb_sprite(Engine::IDriverDependantBitmap *ddb, int sprite_id,
+    Common::Bitmap *source, bool has_alpha = false, bool opaque = false);
+inline Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *ddb, Common::Bitmap *source, bool has_alpha = false, bool opaque = false)
+    { return recycle_ddb_sprite(ddb, UINT32_MAX, source, has_alpha, opaque); }
 // Draw everything 
 void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
 // Construct game scene, scheduling drawing list for the renderer

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1438,6 +1438,8 @@ bool unserialize_audio_script_object(int index, const char *objectType, Stream *
 
 void game_sprite_updated(int sprnum)
 {
+    // update the shared texture (if exists)
+    gfxDriver->UpdateSharedDDB(sprnum, spriteset[sprnum], game.SpriteInfos[sprnum].Flags & SPF_ALPHACHANNEL, false);
     // character and object draw caches
     reset_objcache_for_sprite(sprnum);
     // gui backgrounds
@@ -1474,6 +1476,8 @@ void game_sprite_updated(int sprnum)
 
 void game_sprite_deleted(int sprnum)
 {
+    // clear from texture cache
+    gfxDriver->ClearSharedDDB(sprnum);
     // character and object draw caches
     reset_objcache_for_sprite(sprnum);
     // room object graphics

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1417,7 +1417,7 @@ void OGLGraphicsDriver::DrawSprite(int x, int y, IDriverDependantBitmap* ddb)
     _spriteList.push_back(OGLDrawListEntry((OGLBitmap*)ddb, _actSpriteBatch, x, y));
 }
 
-void OGLGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb)
+void OGLGraphicsDriver::DestroyDDBImpl(IDriverDependantBitmap* ddb)
 {
     // Remove deleted DDB from backups
     for (auto &backup_spr : _backupSpriteList)

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -69,25 +69,19 @@ namespace OGL
 
 using namespace AGS::Common;
 
-void OGLBitmap::Dispose()
+OGLTextureData::~OGLTextureData()
 {
-    if (_tiles != nullptr)
+    if (_tiles)
     {
-        for (int i = 0; i < _numTiles; i++)
+        for (size_t i = 0; i < _numTiles; ++i)
             glDeleteTextures(1, &(_tiles[i].texture));
-
-        free(_tiles);
-        _tiles = nullptr;
-        _numTiles = 0;
+        delete[] _tiles;
     }
-    if (_vertex != nullptr)
+    if (_vertex)
     {
-        free(_vertex);
-        _vertex = nullptr;
+        delete[] _vertex;
     }
 }
-
-
 
 
 OGLGraphicsDriver::OGLGraphicsDriver()
@@ -1047,16 +1041,17 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry,
   int drawAtX = drawListEntry->x;
   int drawAtY = drawListEntry->y;
 
-  for (int ti = 0; ti < bmpToDraw->_numTiles; ti++)
+  const auto *txdata = bmpToDraw->_data.get();
+  for (size_t ti = 0; ti < txdata->_numTiles; ++ti)
   {
-    width = bmpToDraw->_tiles[ti].width * xProportion;
-    height = bmpToDraw->_tiles[ti].height * yProportion;
+    width = txdata->_tiles[ti].width * xProportion;
+    height = txdata->_tiles[ti].height * yProportion;
     float xOffs;
-    float yOffs = bmpToDraw->_tiles[ti].y * yProportion;
+    float yOffs = txdata->_tiles[ti].y * yProportion;
     if (bmpToDraw->_flipped)
-      xOffs = (bmpToDraw->_width - (bmpToDraw->_tiles[ti].x + bmpToDraw->_tiles[ti].width)) * xProportion;
+      xOffs = (bmpToDraw->_width - (txdata->_tiles[ti].x + txdata->_tiles[ti].width)) * xProportion;
     else
-      xOffs = bmpToDraw->_tiles[ti].x * xProportion;
+      xOffs = txdata->_tiles[ti].x * xProportion;
     int thisX = drawAtX + xOffs;
     int thisY = drawAtY + yOffs;
     thisX = (-(_srcRect.GetWidth() / 2)) + thisX;
@@ -1094,7 +1089,7 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry,
     glUniformMatrix4fv(program.MVPMatrix, 1, GL_FALSE, glm::value_ptr(transform));
 
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, bmpToDraw->_tiles[ti].texture);
+    glBindTexture(GL_TEXTURE_2D, txdata->_tiles[ti].texture);
 
     if ((_smoothScaling) && bmpToDraw->_useResampler && (bmpToDraw->_stretchToHeight > 0) &&
         ((bmpToDraw->_stretchToHeight != bmpToDraw->_height) ||
@@ -1115,15 +1110,15 @@ void OGLGraphicsDriver::_renderSprite(const OGLDrawListEntry *drawListEntry,
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 
-    if (bmpToDraw->_vertex != nullptr)
+    if (txdata->_vertex != nullptr)
     {
         glEnableVertexAttribArray(0);
         GLint a_Position = glGetAttribLocation(program.Program, "a_Position");
-        glVertexAttribPointer(a_Position, 2, GL_FLOAT, GL_FALSE, sizeof(OGLCUSTOMVERTEX), &(bmpToDraw->_vertex[ti * 4].position));
+        glVertexAttribPointer(a_Position, 2, GL_FLOAT, GL_FALSE, sizeof(OGLCUSTOMVERTEX), &(txdata->_vertex[ti * 4].position));
 
         glEnableVertexAttribArray(1);
         GLint a_TexCoord = glGetAttribLocation(program.Program, "a_TexCoord");
-        glVertexAttribPointer(a_TexCoord, 2, GL_FLOAT, GL_FALSE, sizeof(OGLCUSTOMVERTEX), &(bmpToDraw->_vertex[ti * 4].tu));
+        glVertexAttribPointer(a_TexCoord, 2, GL_FLOAT, GL_FALSE, sizeof(OGLCUSTOMVERTEX), &(txdata->_vertex[ti * 4].tu));
     }
     else
     {
@@ -1434,7 +1429,7 @@ void OGLGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb)
 }
 
 
-void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, OGLBitmap *target, bool hasAlpha)
+void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, bool opaque, bool hasAlpha)
 {
   int textureHeight = tile->height;
   int textureWidth = tile->width;
@@ -1458,7 +1453,7 @@ void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap
   }
 
   const bool usingLinearFiltering = _filter->UseLinearFiltering();
-  char *origPtr = (char*)malloc(sizeof(int) * tileWidth * tileHeight);
+  char *origPtr = new char[sizeof(int) * tileWidth * tileHeight];
   const int pitch = tileWidth * sizeof(int);
   char *memPtr = origPtr + pitch * tiley + tilex * sizeof(int);
 
@@ -1467,7 +1462,7 @@ void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap
   fixedTile.y = tile->y;
   fixedTile.width = std::min(tile->width, tileWidth);
   fixedTile.height = std::min(tile->height, tileHeight);
-  if (target->_opaque)
+  if (opaque)
     BitmapToVideoMemOpaque(bitmap, hasAlpha, &fixedTile, memPtr, pitch);
   else
     BitmapToVideoMem(bitmap, hasAlpha, &fixedTile, memPtr, pitch, usingLinearFiltering);
@@ -1514,7 +1509,7 @@ void OGLGraphicsDriver::UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap
   glBindTexture(GL_TEXTURE_2D, tile->texture);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, tileWidth, tileHeight, GL_RGBA, GL_UNSIGNED_BYTE, origPtr);
 
-  free(origPtr);
+  delete []origPtr;
 }
 
 void OGLGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha)
@@ -1527,12 +1522,19 @@ void OGLGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpda
     throw Ali3DException("UpdateDDBFromBitmap: mismatched colour depths");
 
   target->_hasAlpha = hasAlpha;
+  UpdateTextureData(target->_data.get(), bitmap, target->_opaque, hasAlpha);
+}
+
+void OGLGraphicsDriver::UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha)
+{
+  const int color_depth = bitmap->GetColorDepth();
   if (color_depth == 8)
       select_palette(palette);
 
-  for (int i = 0; i < target->_numTiles; i++)
+  auto *ogldata = reinterpret_cast<OGLTextureData*>(txdata);
+  for (size_t i = 0; i < ogldata->_numTiles; ++i)
   {
-    UpdateTextureRegion(&target->_tiles[i], bitmap, target, hasAlpha);
+    UpdateTextureRegion(&ogldata->_tiles[i], bitmap, opaque, hasAlpha);
   }
 
   if (color_depth == 8)
@@ -1575,27 +1577,41 @@ void OGLGraphicsDriver::AdjustSizeToNearestSupportedByCard(int *width, int *heig
   *height = allocatedHeight;
 }
 
-
-
 IDriverDependantBitmap* OGLGraphicsDriver::CreateDDB(int width, int height, int color_depth, bool opaque)
+{
+  if (color_depth != GetCompatibleBitmapFormat(color_depth))
+    throw Ali3DException("CreateDDB: bitmap colour depth not supported");
+  OGLBitmap *ddb = new OGLBitmap(width, height, color_depth, opaque);
+  ddb->_data.reset(reinterpret_cast<OGLTextureData*>(CreateTextureData(width, height, opaque)));
+  return ddb;
+}
+
+IDriverDependantBitmap *OGLGraphicsDriver::CreateDDB(std::shared_ptr<TextureData> txdata,
+    int width, int height, int color_depth, bool opaque)
+{
+    auto *ddb = reinterpret_cast<OGLBitmap*>(CreateDDB(width, height, color_depth, opaque));
+    if (ddb)
+        ddb->_data = std::static_pointer_cast<OGLTextureData>(txdata);
+    return ddb;
+}
+
+std::shared_ptr<TextureData> OGLGraphicsDriver::GetTextureData(IDriverDependantBitmap *ddb)
+{
+    return std::static_pointer_cast<TextureData>((reinterpret_cast<OGLBitmap*>(ddb))->_data);
+}
+
+TextureData *OGLGraphicsDriver::CreateTextureData(int width, int height, bool opaque)
 {
   assert(width > 0);
   assert(height > 0);
   int allocatedWidth = width;
   int allocatedHeight = height;
-  // NOTE: original bitmap object is not modified in this function
-  if (color_depth != GetCompatibleBitmapFormat(color_depth))
-    throw Ali3DException("CreateDDB: bitmap colour depth not supported");
-  int colourDepth = color_depth;
-
-  OGLBitmap *ddb = new OGLBitmap(width, height, colourDepth, opaque);
-
   AdjustSizeToNearestSupportedByCard(&allocatedWidth, &allocatedHeight);
   int tilesAcross = 1, tilesDown = 1;
 
+  auto *txdata = new OGLTextureData();
   // Calculate how many textures will be necessary to
   // store this image
-
   int MaxTextureWidth = 512;
   int MaxTextureHeight = 512;
   glGetIntegerv(GL_MAX_TEXTURE_SIZE, &MaxTextureWidth);
@@ -1617,8 +1633,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDB(int width, int height, int 
   AdjustSizeToNearestSupportedByCard(&tileAllocatedWidth, &tileAllocatedHeight);
 
   int numTiles = tilesAcross * tilesDown;
-  OGLTextureTile *tiles = (OGLTextureTile*)malloc(sizeof(OGLTextureTile) * numTiles);
-  memset(tiles, 0, sizeof(OGLTextureTile) * numTiles);
+  OGLTextureTile *tiles = new OGLTextureTile[numTiles];
 
   OGLCUSTOMVERTEX *vertices = nullptr;
 
@@ -1632,9 +1647,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDB(int width, int height, int 
   {
      // The texture is not the same as the bitmap, so create some custom vertices
      // so that only the relevant portion of the texture is rendered
-     int vertexBufferSize = numTiles * 4 * sizeof(OGLCUSTOMVERTEX);
-
-     ddb->_vertex = vertices = (OGLCUSTOMVERTEX*)malloc(vertexBufferSize);
+     txdata->_vertex = vertices = new OGLCUSTOMVERTEX[numTiles * 4];
   }
 
   for (int x = 0; x < tilesAcross; x++)
@@ -1701,9 +1714,9 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateDDB(int width, int height, int 
     }
   }
 
-  ddb->_numTiles = numTiles;
-  ddb->_tiles = tiles;
-  return ddb;
+  txdata->_numTiles = numTiles;
+  txdata->_tiles = tiles;
+  return txdata;
 }
 
 void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue)

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -75,6 +75,8 @@ struct OGLTextureData : TextureData
 class OGLBitmap : public BaseDDB
 {
 public:
+    uint32_t GetRefID() const override { return _data->ID; }
+
     int  GetAlpha() const override { return _alpha; }
     void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
@@ -221,7 +223,7 @@ public:
     // Retrieve shared texture data object from the given DDB
     std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
-    void DestroyDDB(IDriverDependantBitmap* ddb) override;
+    void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
     void RenderToBackBuffer() override;
     void Render() override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -164,6 +164,8 @@ public:
     { // Software renderer does not require a texture cache, because it uses bitmaps directly
         return CreateDDBFromBitmap(bitmap, hasAlpha, opaque);
     }
+    void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool hasAlpha, bool opaque) override { /* do nothing */ }
+    void ClearSharedDDB(uint32_t sprite_id) override { /* do nothing */ }
 
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
     void SetScreenFade(int red, int green, int blue) override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -44,6 +44,8 @@ using AGS::Common::Bitmap;
 class ALSoftwareBitmap : public BaseDDB
 {
 public:
+    uint32_t GetRefID() const override { return UINT32_MAX /* not supported */; }
+
     int  GetAlpha() const override { return _alpha; }
     void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
@@ -156,6 +158,12 @@ public:
     IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
     void DestroyDDB(IDriverDependantBitmap* ddb) override;
+
+    IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id,
+        Common::Bitmap *bitmap, bool hasAlpha, bool opaque) override
+    { // Software renderer does not require a texture cache, because it uses bitmaps directly
+        return CreateDDBFromBitmap(bitmap, hasAlpha, opaque);
+    }
 
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
     void SetScreenFade(int red, int green, int blue) override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -85,15 +85,7 @@ public:
     int GetWidthToRender() { return _stretchToWidth; }
     int GetHeightToRender() { return _stretchToHeight; }
 
-    void Dispose()
-    {
-        // do we want to free the bitmap?
-    }
-
-    ~ALSoftwareBitmap() override
-    {
-        Dispose();
-    }
+    ~ALSoftwareBitmap() override = default;
 };
 
 

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -30,6 +30,9 @@ namespace Engine
 class IDriverDependantBitmap
 {
 public:
+  // Get an arbitrary sprite ID, returns UINT32_MAX if does not have one
+  virtual uint32_t GetRefID() const = 0;
+
   virtual int  GetAlpha() const = 0;
   virtual void SetAlpha(int alpha) = 0;  // 0-255
   virtual void SetFlippedLeftRight(bool isFlipped) = 0;
@@ -43,7 +46,7 @@ public:
 
 protected:
   IDriverDependantBitmap() = default;
-  ~IDriverDependantBitmap() = default;
+  virtual ~IDriverDependantBitmap() = default;
 };
 
 } // namespace Engine

--- a/Engine/gfx/ddb.h
+++ b/Engine/gfx/ddb.h
@@ -12,12 +12,12 @@
 //
 //=============================================================================
 //
-// Driver-dependant bitmap interface
+// Driver-dependant bitmap interface.
 //
-// TODO: split into texture object that has only tex data
-// and object describing a drawing operation, with ref to texture and
-// drawing parameters (modes, shaders, etc).
-// Then we will also be able to share one texture among multiple game entities.
+// This interface describes an individual sprite object. The actual texture
+// data (pixel data) may be shared among multiple DDBs, while DDB define
+// additional settings telling how to present the texture: transform, colorize,
+// and so on.
 //=============================================================================
 #ifndef __AGS_EE_GFX__DDB_H
 #define __AGS_EE_GFX__DDB_H

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -213,6 +213,24 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_
     return CreateDDB(txdata, bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth(), opaque);
 }
 
+void VideoMemoryGraphicsDriver::UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool hasAlpha, bool opaque)
+{
+    const auto found = _txRefs.find(sprite_id);
+    if (found != _txRefs.end())
+    {
+        auto txdata = found->second.Data.lock();
+        if (txdata)
+            UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
+    }
+}
+
+void VideoMemoryGraphicsDriver::ClearSharedDDB(uint32_t sprite_id)
+{
+    const auto found = _txRefs.find(sprite_id);
+    if (found != _txRefs.end())
+        _txRefs.erase(found);
+}
+
 void VideoMemoryGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb)
 {
     uint32_t sprite_id = ddb->GetRefID();

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -190,6 +190,39 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::CreateDDBFromBitmap(Bitmap *b
     return ddb;
 }
 
+IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque)
+{
+    const auto found = _txRefs.find(sprite_id);
+    if (found != _txRefs.end())
+    {
+        const auto &item = found->second;
+        if (!item.Data.expired())
+            return CreateDDB(item.Data.lock(), item.Res.Width, item.Res.Height, item.Res.ColorDepth, opaque);
+    }
+
+    // Create and add a new element
+    std::shared_ptr<TextureData> txdata(CreateTextureData(bitmap->GetWidth(), bitmap->GetHeight(), opaque));
+    txdata->ID = sprite_id;
+    UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
+    // only add into the map when has valid sprite ID
+    if (sprite_id != UINT32_MAX)
+    {
+        _txRefs[sprite_id] = TextureCacheItem(txdata,
+            GraphicResolution(bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth()));
+    }
+    return CreateDDB(txdata, bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth(), opaque);
+}
+
+void VideoMemoryGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb)
+{
+    uint32_t sprite_id = ddb->GetRefID();
+    DestroyDDBImpl(ddb);
+    // Remove shared object from ref list if no more active refs left
+    const auto found = _txRefs.find(sprite_id);
+    if (found != _txRefs.end() && found->second.Data.expired())
+        _txRefs.erase(found);
+}
+
 VideoMemoryGraphicsDriver::StageScreen
     VideoMemoryGraphicsDriver::CreateStageScreen(size_t index, const Size &sz)
 {

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -214,6 +214,10 @@ public:
     IDriverDependantBitmap *CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque = false) override;
     // Get shared texture from cache, or create from bitmap and assign ID
     IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+    // Removes the shared texture reference, will force the texture to recreate next time
+    void ClearSharedDDB(uint32_t sprite_id) override;
+    // Updates shared texture data, but only if it is present in the cache
+    void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool hasAlpha, bool opaque) override;
     void DestroyDDB(IDriverDependantBitmap* ddb) override;
 
 protected:

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -134,6 +134,9 @@ public:
   // Get shared texture from cache, or create from bitmap and assign ID
   virtual IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id,
       Common::Bitmap *bitmap = nullptr, bool hasAlpha = true, bool opaque = false) = 0;
+  virtual void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap = nullptr, bool hasAlpha = true, bool opaque = false) = 0;
+  // Removes the shared texture reference, will force the texture to recreate next time
+  virtual void ClearSharedDDB(uint32_t sprite_id) = 0;
 
   // Prepares next sprite batch, a list of sprites with defined viewport and optional
   // global model transformation; all subsequent calls to DrawSprite will be adding

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -131,6 +131,10 @@ public:
   virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Common::Bitmap *bitmap, bool hasAlpha) = 0;
   virtual void DestroyDDB(IDriverDependantBitmap* bitmap) = 0;
 
+  // Get shared texture from cache, or create from bitmap and assign ID
+  virtual IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id,
+      Common::Bitmap *bitmap = nullptr, bool hasAlpha = true, bool opaque = false) = 0;
+
   // Prepares next sprite batch, a list of sprites with defined viewport and optional
   // global model transformation; all subsequent calls to DrawSprite will be adding
   // sprites to this batch's list.

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1486,7 +1486,7 @@ void D3DGraphicsDriver::DrawSprite(int x, int y, IDriverDependantBitmap* ddb)
     _spriteList.push_back(D3DDrawListEntry((D3DBitmap*)ddb, _actSpriteBatch, x, y));
 }
 
-void D3DGraphicsDriver::DestroyDDB(IDriverDependantBitmap* ddb)
+void D3DGraphicsDriver::DestroyDDBImpl(IDriverDependantBitmap* ddb)
 {
     // Remove deleted DDB from backups
     for (auto &backup_spr : _backupSpriteList)

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -65,6 +65,8 @@ struct D3DTextureData : TextureData
 class D3DBitmap : public BaseDDB
 {
 public:
+    uint32_t GetRefID() const override { return _data->ID; }
+
     int  GetAlpha() const override { return _alpha; }
     void SetAlpha(int alpha) override { _alpha = alpha; }
     void SetFlippedLeftRight(bool isFlipped) override { _flipped = isFlipped; }
@@ -202,7 +204,7 @@ public:
     // Retrieve shared texture data object from the given DDB
     std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
-    void DestroyDDB(IDriverDependantBitmap* ddb) override;
+    void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
     void SetScreenFade(int red, int green, int blue) override;
     void SetScreenTint(int red, int green, int blue) override;


### PR DESCRIPTION
Implements a short-term texture (DDB) cache in the graphics renderer(s).

**Has two purposes:**
* shares same texture data among multiple sprites on screen, somewhat reducing amount of texture recreations and memory requirements in case same sprite is used on a number of objects.
* potentially a foundation for implementing a long-term cache similar to the (bitmap) sprite cache in some future (may be seen as a practical experiment).

**Limits:**
* only short-term caching, the texture data is stored only so long as there's at least 1 object using this sprite.
* does not affect GUI and gui objects: since these may contain generated images, they would require additional changes to use this method. So, currently affects: characters, room objects and overlays.

**Implementation:**
* IDriverDependentBitmap (aka DDB) implementations have the texture data itself split out into a separate object. DDB will use shared_ptr to reference that object. DDB will still represent an individual texture entity on screen, with draw settings (transform, coloring, etc), while the TextureData parent class represents a shareable texture tile.
* Graphics renderer contains a map of TextureData objects, identified by an arbitrary uint32 key (renderer itself does not care what this id means). Engine can use new GetSharedDDB method: it generates a DDB which either wraps an existing texture data or generates a new texture, if one with a given id is not present.
* DestroyDDB now checks if the destroyed texture is a part of the map, and if there are no more active "users", then the data is removed from the cache.

**Testing:**

The best way to test this is to have a large number of objects with same sprite assigned to them, the higher the resolution the easier is to notice the effect. Using overlays is easiest as you may create them in script in thousands now.
Without this cache each object will have its own texture data allocated for it, with this PR there should be only one texture data per sprite number, + minimal amount of memory per object struct and DDB struct (in dozens of int32s).

---

**In regards to the long-term cache.**

I was thinking this over for a while, but came to realization that properly adding it would require bigger changes to the engine code, in several places. Just making one in the renderer might be almost trivial, but that won't be fully efficient and will cause number of issues. I'm not ready to work on that right now, but perhaps will be able to write a task for that for the future.