### PR TITLE
Use BufferedStream for writing files + added stream tests

### DIFF
--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -133,7 +133,11 @@
 
 // Certain methods or classes may be meant for the code testing purposes only
 #if !defined(AGS_PLATFORM_TEST)
-    #define AGS_PLATFORM_TEST (AGS_PLATFORM_DEBUG)
+    #define AGS_PLATFORM_TEST (0)
+#endif
+// This option surrounds the test code which requires write disk access
+#if !defined(AGS_PLATFORM_TEST_FILE_IO)
+    #define AGS_PLATFORM_TEST_FILE_IO (AGS_PLATFORM_TEST)
 #endif
 
 #define AGS_HAS_DIRECT3D (AGS_PLATFORM_OS_WINDOWS)

--- a/Common/test/stream_test.cpp
+++ b/Common/test/stream_test.cpp
@@ -197,7 +197,18 @@ TEST(Stream, VectorStream) {
 
 static const char *DummyFile = "dummy.dat";
 
-TEST(Stream, BufferedStreamRead) {
+class FileBasedTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        File::DeleteFile(DummyFile);
+    }
+
+    void TearDown() override {
+        File::DeleteFile(DummyFile);
+    }
+};
+
+TEST_F(FileBasedTest, BufferedStreamRead) {
     //-------------------------------------------------------------------------
     // Write data into the temp file
     FileStream out(DummyFile, kFile_CreateAlways, kFile_Write);
@@ -264,7 +275,7 @@ TEST(Stream, BufferedStreamRead) {
     File::DeleteFile(DummyFile);
 }
 
-TEST(Stream, BufferedStreamWrite) {
+TEST_F(FileBasedTest, BufferedStreamWrite) {
     //-------------------------------------------------------------------------
     // Write data into the temp file
     // fill in to ensure buffered stream reach buffer size
@@ -320,7 +331,7 @@ TEST(Stream, BufferedStreamWrite) {
     File::DeleteFile(DummyFile);
 }
 
-TEST(Stream, BufferedSectionStream) {
+TEST_F(FileBasedTest, BufferedSectionStream) {
     //-------------------------------------------------------------------------
     // Write data into the temp file
     FileStream out(DummyFile, kFile_CreateAlways, kFile_Write);

--- a/Common/test/stream_test.cpp
+++ b/Common/test/stream_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include "gtest/gtest.h"
 #include "util/alignedstream.h"
+#include "util/bufferedstream.h"
 #include "util/memorystream.h"
 #include "util/string_utils.h"
 
@@ -112,6 +113,7 @@ TEST(Stream, MemoryStream) {
     ASSERT_EQ(in2.ReadInt32(), 11);
     ASSERT_EQ(in2.GetPosition(), sizeof(int32_t) * 4 * 3 + fill_len * 2);
     ASSERT_TRUE(in2.EOS());
+    in2.Close();
 }
 
 TEST(Stream, MemoryStream2) {
@@ -149,6 +151,7 @@ TEST(Stream, MemoryStream2) {
     ASSERT_EQ(in.ReadInt32(), 222);
     ASSERT_EQ(in.GetPosition(), sizeof(int32_t) * 5 + fill_len);
     ASSERT_TRUE(in.EOS());
+    in.Close();
 }
 
 TEST(Stream, VectorStream) {
@@ -187,7 +190,137 @@ TEST(Stream, VectorStream) {
     ASSERT_EQ(in.ReadInt32(), 222);
     ASSERT_EQ(in.GetPosition(), sizeof(int32_t) * 5 + fill_len);
     ASSERT_TRUE(in.EOS());
+    in.Close();
 }
+
+#if (AGS_PLATFORM_TEST_FILE_IO)
+
+static const char *DummyFile = "dummy.dat";
+
+TEST(Stream, BufferedStreamRead) {
+    //-------------------------------------------------------------------------
+    // Write data into the temp file
+    FileStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    out.WriteInt32(0);
+    out.WriteInt32(1);
+    out.WriteInt32(2);
+    out.WriteInt32(3);
+    // fill in to ensure buffered stream reach buffer size
+    out.WriteByteCount(0, BufferedStream::BufferSize);
+    out.WriteInt32(4);
+    out.WriteInt32(5);
+    out.WriteInt32(6);
+    out.WriteInt32(7);
+    out.WriteByteCount(0, BufferedStream::BufferSize);
+    out.WriteInt32(8);
+    out.WriteInt32(9);
+    out.WriteInt32(10);
+    out.WriteInt32(11);
+    const soff_t file_len = out.GetLength();
+    out.Close();
+
+    //-------------------------------------------------------------------------
+    // Read data back
+    BufferedStream in(DummyFile, kFile_Open, kFile_Read);
+    ASSERT_TRUE(in.CanRead());
+    ASSERT_EQ(in.GetLength(), file_len);
+    ASSERT_EQ(in.ReadInt32(), 0);
+    ASSERT_EQ(in.ReadInt32(), 1);
+    ASSERT_EQ(in.ReadInt32(), 2);
+    ASSERT_EQ(in.ReadInt32(), 3);
+    for (size_t i = 0; i < BufferedStream::BufferSize / 4; ++i)
+        in.ReadInt32(); // skip
+    ASSERT_EQ(in.ReadInt32(), 4);
+    ASSERT_EQ(in.ReadInt32(), 5);
+    ASSERT_EQ(in.ReadInt32(), 6);
+    ASSERT_EQ(in.ReadInt32(), 7);
+    for (size_t i = 0; i < BufferedStream::BufferSize / 4; ++i)
+        in.ReadInt32(); // skip
+    ASSERT_EQ(in.ReadInt32(), 8);
+    ASSERT_EQ(in.ReadInt32(), 9);
+    ASSERT_EQ(in.ReadInt32(), 10);
+    ASSERT_EQ(in.ReadInt32(), 11);
+    ASSERT_EQ(in.GetPosition(), file_len);
+    ASSERT_TRUE(in.EOS());
+    in.Close();
+
+    // Test seeks
+    BufferedStream in2(DummyFile, kFile_Open, kFile_Read);
+    ASSERT_TRUE(in2.CanRead());
+    ASSERT_TRUE(in2.CanSeek());
+    ASSERT_EQ(in2.GetLength(), file_len);
+    in2.Seek(4 * sizeof(int32_t) + BufferedStream::BufferSize, kSeekBegin);
+    ASSERT_EQ(in2.ReadInt32(), 4);
+    in2.Seek(2 * sizeof(int32_t), kSeekBegin);
+    ASSERT_EQ(in2.ReadInt32(), 2);
+    in2.Seek(8 * sizeof(int32_t) + BufferedStream::BufferSize * 2, kSeekBegin);
+    ASSERT_EQ(in2.ReadInt32(), 8);
+    in2.Seek(2 * sizeof(int32_t), kSeekCurrent);
+    ASSERT_EQ(in2.ReadInt32(), 11);
+    ASSERT_EQ(in2.GetPosition(), file_len);
+    ASSERT_TRUE(in2.EOS());
+    in2.Close();
+
+    File::DeleteFile(DummyFile);
+}
+
+TEST(Stream, BufferedStreamWrite) {
+    //-------------------------------------------------------------------------
+    // Write data into the temp file
+    // fill in to ensure buffered stream reach buffer size
+    size_t fill_len = BufferedStream::BufferSize;
+    //-------------------------------------------------------------------------
+    // Write data
+    const soff_t file_len = sizeof(int32_t) * 9 + fill_len + fill_len / 2;
+    BufferedStream out(DummyFile, kFile_CreateAlways, kFile_Write);
+    ASSERT_TRUE(out.CanWrite());
+    ASSERT_TRUE(out.CanSeek());
+    out.WriteInt32(0);
+    out.WriteInt32(1);
+    out.WriteInt32(2);
+    auto write_back_pos = out.GetPosition();
+    out.WriteInt32(3);
+    out.WriteByteCount(0, fill_len);
+    out.Seek(write_back_pos, kSeekBegin);
+    out.WriteInt32(111);
+    out.Seek(0, kSeekEnd);
+    out.WriteInt32(4);
+    out.WriteInt32(5);
+    out.WriteInt32(6);
+    write_back_pos = out.GetPosition();
+    out.WriteInt32(7);
+    out.WriteByteCount(0, fill_len / 2);
+    out.Seek(write_back_pos, kSeekBegin);
+    out.WriteInt32(222);
+    out.Seek(0, kSeekEnd);
+    out.WriteInt32(333);
+    ASSERT_EQ(out.GetPosition(), file_len);
+    ASSERT_EQ(out.GetLength(), file_len);
+    out.Close();
+    //-------------------------------------------------------------------------
+    // Read data back
+    FileStream in(DummyFile, kFile_Open, kFile_Read);
+    ASSERT_TRUE(in.CanRead());
+    ASSERT_TRUE(in.CanSeek());
+    ASSERT_EQ(in.GetLength(), file_len);
+    ASSERT_EQ(in.ReadInt32(), 0);
+    ASSERT_EQ(in.ReadInt32(), 1);
+    ASSERT_EQ(in.ReadInt32(), 2);
+    ASSERT_EQ(in.ReadInt32(), 111);
+    in.Seek(fill_len, kSeekCurrent);
+    ASSERT_EQ(in.ReadInt32(), 4);
+    ASSERT_EQ(in.ReadInt32(), 5);
+    ASSERT_EQ(in.ReadInt32(), 6);
+    ASSERT_EQ(in.ReadInt32(), 222);
+    in.Seek(fill_len / 2, kSeekCurrent);
+    ASSERT_EQ(in.ReadInt32(), 333);
+    ASSERT_EQ(in.GetPosition(), file_len);
+    in.Close();
+
+    File::DeleteFile(DummyFile);
+}
+
+#endif // AGS_PLATFORM_TEST_FILE_IO
 
 
 //-------------------------------------------------------------------------

--- a/Common/util/bufferedstream.cpp
+++ b/Common/util/bufferedstream.cpp
@@ -23,10 +23,14 @@ namespace AGS
 namespace Common
 {
 
-BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess)
-        : FileStream(file_name, open_mode, work_mode, stream_endianess), _buffer(BufferStreamSize), _bufferPosition(0), _position(0)
+//-----------------------------------------------------------------------------
+// BufferedStream
+//-----------------------------------------------------------------------------
+
+BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode,
+        FileWorkMode work_mode, DataEndianess stream_endianess)
+    : FileStream(file_name, open_mode, work_mode, stream_endianess)
 {
-    _end = -1;
     if (FileStream::Seek(0, kSeekEnd))
     {
         _start = 0;
@@ -39,16 +43,14 @@ BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode, 
         FileStream::Close();
         throw std::runtime_error("Error determining stream end.");
     }
-
-    _buffer.resize(0);
 }
 
 void BufferedStream::FillBufferFromPosition(soff_t position)
 {
     FileStream::Seek(position, kSeekBegin);
 
-    _buffer.resize(BufferStreamSize);
-    auto sz = FileStream::Read(_buffer.data(), BufferStreamSize);
+    _buffer.resize(BufferSize);
+    auto sz = FileStream::Read(_buffer.data(), BufferSize);
     _buffer.resize(sz);
 
     _bufferPosition = position;
@@ -133,8 +135,12 @@ bool BufferedStream::Seek(soff_t offset, StreamSeek origin)
     return _position == want_pos;
 }
 
+//-----------------------------------------------------------------------------
+// BufferedSectionStream
+//-----------------------------------------------------------------------------
+
 BufferedSectionStream::BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
-    FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess)
+        FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess)
     : BufferedStream(file_name, open_mode, work_mode, stream_endianess)
 {
     assert(start_pos <= end_pos);

--- a/Common/util/bufferedstream.cpp
+++ b/Common/util/bufferedstream.cpp
@@ -45,15 +45,30 @@ BufferedStream::BufferedStream(const String &file_name, FileOpenMode open_mode,
     }
 }
 
+BufferedStream::~BufferedStream()
+{
+    Close();
+}
+
 void BufferedStream::FillBufferFromPosition(soff_t position)
 {
     FileStream::Seek(position, kSeekBegin);
-
     _buffer.resize(BufferSize);
     auto sz = FileStream::Read(_buffer.data(), BufferSize);
     _buffer.resize(sz);
-
     _bufferPosition = position;
+}
+
+void BufferedStream::FlushBuffer(soff_t position)
+{
+    size_t sz = _buffer.size() > 0 ? FileStream::Write(_buffer.data(), _buffer.size()) : 0u;
+    _buffer.clear(); // will start from the clean buffer next time
+    _bufferPosition += sz;
+    if (position != _bufferPosition)
+    {
+        FileStream::Seek(position, kSeekBegin);
+        _bufferPosition = position;
+    }
 }
 
 bool BufferedStream::EOS() const
@@ -61,37 +76,56 @@ bool BufferedStream::EOS() const
     return _position == _end;
 }
 
-soff_t BufferedStream::GetPosition() const
+soff_t BufferedStream::GetLength() const
 {
-    return _position;
+    return _end - _start;
 }
 
-size_t BufferedStream::Read(void *toBuffer, size_t toSize)
+soff_t BufferedStream::GetPosition() const
 {
-    auto to = static_cast<char *>(toBuffer);
+    return _position - _start;
+}
 
-    while(toSize > 0)
+void BufferedStream::Close()
+{
+    if (GetWorkMode() == kFile_Write)
+        FlushBuffer(_position);
+    FileStream::Close();
+}
+
+bool BufferedStream::Flush()
+{
+    if (GetWorkMode() == kFile_Write)
+        FlushBuffer(_position);
+    return FileStream::Flush();
+}
+
+size_t BufferedStream::Read(void *buffer, size_t size)
+{
+    auto to = static_cast<uint8_t*>(buffer);
+
+    while(size > 0)
     {
         if (_position < _bufferPosition || _position >= _bufferPosition + _buffer.size())
         {
             FillBufferFromPosition(_position);
         }
         if (_buffer.empty()) { break; } // reached EOS
-        assert(_position >= _bufferPosition && _position < _bufferPosition + _buffer.size());  // sanity check only, should be checked by above.
+        assert(_position >= _bufferPosition && _position < _bufferPosition + _buffer.size());
 
         soff_t bufferOffset = _position - _bufferPosition;
         assert(bufferOffset >= 0);
         size_t bytesLeft = _buffer.size() - (size_t)bufferOffset;
-        size_t chunkSize = std::min<size_t>(bytesLeft, toSize);
+        size_t chunkSize = std::min<size_t>(bytesLeft, size);
 
-        std::memcpy(to, _buffer.data()+bufferOffset, chunkSize);
+        std::memcpy(to, _buffer.data() + bufferOffset, chunkSize);
 
         to += chunkSize;
         _position += chunkSize;
-        toSize -= chunkSize;
+        size -= chunkSize;
     }
 
-    return to - (char*)toBuffer;
+    return to - static_cast<uint8_t*>(buffer);
 }
 
 int32_t BufferedStream::ReadByte()
@@ -103,13 +137,26 @@ int32_t BufferedStream::ReadByte()
 }
 
 size_t BufferedStream::Write(const void *buffer, size_t size)
-{ 
-    FileStream::Seek(_position, kSeekBegin);
-    auto sz = FileStream::Write(buffer, size);
-    if (_position == _end)
-        _end += sz;
-    _position += sz;
-    return sz;
+{
+    const uint8_t *from = static_cast<const uint8_t*>(buffer);
+    while (size > 0)
+    {
+        if (_position < _bufferPosition || _position >= _bufferPosition + BufferSize)
+        {
+            FlushBuffer(_position);
+        }
+        size_t pos_in_buff = static_cast<size_t>(_position - _bufferPosition);
+        size_t chunk_sz = std::min(size, BufferSize - pos_in_buff);
+        if (_buffer.size() < pos_in_buff + chunk_sz)
+            _buffer.resize(pos_in_buff + chunk_sz);
+        memcpy(_buffer.data() + pos_in_buff, from, chunk_sz);
+        _position += chunk_sz;
+        from += chunk_sz;
+        size -= chunk_sz;
+    }
+
+    _end = std::max(_end, _position);
+    return from - static_cast<const uint8_t*>(buffer);
 }
 
 int32_t BufferedStream::WriteByte(uint8_t val)
@@ -150,15 +197,6 @@ BufferedSectionStream::BufferedSectionStream(const String &file_name, soff_t sta
     Seek(0, kSeekBegin);
 }
 
-soff_t BufferedSectionStream::GetPosition() const
-{
-    return BufferedStream::GetPosition() - _start;
-}
-
-soff_t BufferedSectionStream::GetLength() const
-{
-    return _end - _start;
-}
 
 } // namespace Common
 } // namespace AGS

--- a/Common/util/bufferedstream.h
+++ b/Common/util/bufferedstream.h
@@ -44,9 +44,17 @@ public:
     // It is recommended to use File::OpenFile to safely construct this object.
     BufferedStream(const String &file_name, FileOpenMode open_mode,
         FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
+    ~BufferedStream();
 
-    bool    EOS() const override; ///< Is end of stream
-    soff_t  GetPosition() const override; ///< Current position (if known)
+    // Is end of stream
+    bool    EOS() const override;
+    // Total length of stream (if known)
+    soff_t  GetLength() const override;
+    // Current position (if known)
+    soff_t  GetPosition() const override;
+
+    void    Close() override;
+    bool    Flush() override;
 
     size_t  Read(void *buffer, size_t size) override;
     int32_t ReadByte() override;
@@ -56,14 +64,17 @@ public:
     bool    Seek(soff_t offset, StreamSeek origin) override;
 
 protected:
-    soff_t _start = 0;
-    soff_t _end = -1;
+    soff_t _start = 0; // valid section starting offset
+    soff_t _end = -1; // valid section ending offset
 
 private:
+    // Reads a chunk of file into the buffer, starting from the given offset
     void FillBufferFromPosition(soff_t position);
+    // Writes a buffer into the file, and reposition to the new offset
+    void FlushBuffer(soff_t position);
 
-    soff_t _position = 0;
-    soff_t _bufferPosition = 0;
+    soff_t _position = 0; // absolute read/write offset
+    soff_t _bufferPosition = 0; // buffer's location relative to file
     std::vector<uint8_t> _buffer;
 };
 
@@ -74,9 +85,6 @@ class BufferedSectionStream : public BufferedStream
 public:
     BufferedSectionStream(const String &file_name, soff_t start_pos, soff_t end_pos,
         FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
-
-    soff_t  GetPosition() const override;
-    soff_t  GetLength() const override;
 };
 
 } // namespace Common

--- a/Common/util/bufferedstream.h
+++ b/Common/util/bufferedstream.h
@@ -12,7 +12,12 @@
 //
 //=============================================================================
 //
+// BufferedStream represents a buffered file stream; uses memory buffer
+// during read and write operations to limit number reads and writes on disk
+// and thus improve i/o perfomance.
 //
+// BufferedSectionStream is a subclass stream that limits reading by an
+// arbitrary offset range.
 //
 //=============================================================================
 #ifndef __AGS_CN_UTIL__BUFFEREDSTREAM_H
@@ -27,19 +32,18 @@ namespace AGS
 namespace Common
 {
 
-// Needs tuning depending on the platform.
-const auto BufferStreamSize = 8*1024;
-
 class BufferedStream : public FileStream
 {
 public:
-    // Represents an open _buffered_ file object
+    // Needs tuning depending on the platform.
+    static const size_t BufferSize = 1024u * 8;
     // The constructor may raise std::runtime_error if 
     // - there is an issue opening the file (does not exist, locked, permissions, etc)
     // - the open mode could not be determined
     // - could not determine the length of the stream
     // It is recommended to use File::OpenFile to safely construct this object.
-    BufferedStream(const String &file_name, FileOpenMode open_mode, FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
+    BufferedStream(const String &file_name, FileOpenMode open_mode,
+        FileWorkMode work_mode, DataEndianess stream_endianess = kLittleEndian);
 
     bool    EOS() const override; ///< Is end of stream
     soff_t  GetPosition() const override; ///< Current position (if known)
@@ -52,15 +56,15 @@ public:
     bool    Seek(soff_t offset, StreamSeek origin) override;
 
 protected:
-    soff_t _start;
-    soff_t _end;
+    soff_t _start = 0;
+    soff_t _end = -1;
 
 private:
     void FillBufferFromPosition(soff_t position);
 
-    soff_t _position;
-    soff_t _bufferPosition;
-    std::vector<char> _buffer;
+    soff_t _position = 0;
+    soff_t _bufferPosition = 0;
+    std::vector<uint8_t> _buffer;
 };
 
 

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -352,7 +352,7 @@ Stream *File::OpenFileCI(const String &file_name, FileOpenMode open_mode, FileWo
 Stream *File::OpenFile(const String &filename, soff_t start_off, soff_t end_off)
 {
     try {
-        FileStream *fs = new BufferedSectionStream(filename, start_off, end_off, kFile_Open, kFile_Read);
+        Stream *fs = new BufferedSectionStream(filename, start_off, end_off, kFile_Open, kFile_Read);
         if (fs != nullptr && !fs->IsValid()) {
             delete fs;
             return nullptr;

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -206,10 +206,7 @@ Stream *File::OpenFile(const String &filename, FileOpenMode open_mode, FileWorkM
 {
     Stream *fs = nullptr;
     try {
-        if (work_mode == kFile_Read) // NOTE: BufferedStream does not work correctly in the write mode
-            fs = new BufferedStream(filename, open_mode, work_mode);
-        else
-            fs = new FileStream(filename, open_mode, work_mode);
+        fs = new BufferedStream(filename, open_mode, work_mode);
         if (fs != nullptr && !fs->IsValid()) {
             delete fs;
             fs = nullptr;

--- a/Common/util/filestream.h
+++ b/Common/util/filestream.h
@@ -48,6 +48,8 @@ public:
         { return new FileStream(file, false, work_mode, stream_end); }
     ~FileStream() override;
 
+    FileWorkMode GetWorkMode() const { return _workMode; }
+
     bool    HasErrors() const override;
     void    Close() override;
     bool    Flush() override;

--- a/Common/util/memorystream.cpp
+++ b/Common/util/memorystream.cpp
@@ -25,21 +25,30 @@ MemoryStream::MemoryStream(const uint8_t *cbuf, size_t buf_sz, DataEndianess str
     , _cbuf(cbuf)
     , _buf_sz(buf_sz)
     , _len(buf_sz)
-    , _buf(nullptr)
     , _mode(kStream_Read)
     , _pos(0)
+    , _buf(nullptr)
 {
 }
 
 MemoryStream::MemoryStream(uint8_t *buf, size_t buf_sz, StreamWorkMode mode, DataEndianess stream_endianess)
     : DataStream(stream_endianess)
-    , _buf(buf)
+    , _cbuf(nullptr)
     , _buf_sz(buf_sz)
     , _len(0)
-    , _cbuf(nullptr)
     , _mode(mode)
     , _pos(0)
+    , _buf(nullptr)
 {
+    if (mode == kStream_Read)
+    {
+        _cbuf = buf;
+        _len = buf_sz;
+    }
+    else
+    {
+        _buf = buf;
+    }
 }
 
 void MemoryStream::Close()
@@ -88,7 +97,7 @@ bool MemoryStream::CanWrite() const
 
 bool MemoryStream::CanSeek() const
 {
-    return CanRead(); // TODO: support seeking in writable stream?
+    return true;
 }
 
 size_t MemoryStream::Read(void *buffer, size_t size)
@@ -127,19 +136,22 @@ bool MemoryStream::Seek(soff_t offset, StreamSeek origin)
 
 size_t MemoryStream::Write(const void *buffer, size_t size)
 {
-    if (_pos >= _buf_sz) { return 0; }
+    if (!_buf || (_pos >= _buf_sz)) { return 0; }
     size = std::min(size, _buf_sz - _pos);
     memcpy(_buf + _pos, buffer, size);
     _pos += size;
-    _len += size;
+    // will increase len if writing after eos, otherwise = overwrite at pos
+    _len = std::max(_len, _pos);
     return size;
 }
 
 int32_t MemoryStream::WriteByte(uint8_t val)
 {
-    if (_pos >= _buf_sz) { return -1; }
+    if (!_buf || (_pos >= _buf_sz)) { return -1; }
     *(_buf + _pos) = val;
-    _pos++; _len++;
+    _pos++;
+    // will increase len if writing after eos, otherwise = overwrite at pos
+    _len = std::max(_len, _pos);
     return val;
 }
 
@@ -151,7 +163,8 @@ VectorStream::VectorStream(const std::vector<uint8_t> &cbuf, DataEndianess strea
 }
 
 VectorStream::VectorStream(std::vector<uint8_t> &buf, StreamWorkMode mode, DataEndianess stream_endianess)
-    : MemoryStream((mode == kStream_Read) ? &buf.front() : nullptr, buf.size(), mode, stream_endianess)
+    : MemoryStream(((mode == kStream_Read) && (buf.size() > 0)) ? &buf.front() : nullptr,
+        buf.size(), mode, stream_endianess)
     , _vec(&buf)
 {
 }
@@ -162,19 +175,40 @@ void VectorStream::Close()
     MemoryStream::Close();
 }
 
+bool VectorStream::CanRead() const
+{
+    return _mode == kStream_Read;
+}
+
+bool VectorStream::CanWrite() const
+{
+    return _mode == kStream_Write;
+}
+
 size_t VectorStream::Write(const void *buffer, size_t size)
 {
-    _vec->resize(_vec->size() + size);
+    if (_pos + size > _len)
+    {
+        _vec->resize(_pos + size);
+        _len = _pos + size;
+    }
     memcpy(_vec->data() + _pos, buffer, size);
     _pos += size;
-    _len += size;
     return size;
 }
 
 int32_t VectorStream::WriteByte(uint8_t val)
 {
-    _vec->push_back(val);
-    _pos++; _len++;
+    if (_pos == _len)
+    {
+        _vec->push_back(val);
+        _len++;
+    }
+    else
+    {
+        (*_vec)[_pos] = val;
+    }
+    _pos++;
     return val;
 }
 

--- a/Common/util/memorystream.h
+++ b/Common/util/memorystream.h
@@ -70,14 +70,14 @@ public:
     bool    Seek(soff_t offset, StreamSeek origin) override;
 
 protected:
-    const uint8_t           *_cbuf;
-    size_t                   _buf_sz; // hard buffer limit
-    size_t                   _len; // calculated length of stream
+    const uint8_t           *_cbuf = nullptr; // readonly buffer ptr
+    size_t                   _buf_sz = 0u; // hard buffer limit
+    size_t                   _len = 0u; // calculated length of stream
     const StreamWorkMode     _mode;
-    size_t                   _pos; // current stream pos
+    size_t                   _pos = 0u; // current stream pos
 
 private:
-    uint8_t                 *_buf;
+    uint8_t                 *_buf = nullptr; // writeable buffer ptr
 };
 
 
@@ -94,11 +94,14 @@ public:
 
     void    Close() override;
 
+    bool    CanRead() const override;
+    bool    CanWrite() const override;
+
     size_t  Write(const void *buffer, size_t size) override;
     int32_t WriteByte(uint8_t b) override;
 
 private:
-    std::vector<uint8_t> *_vec; // writeable vector (may be null)
+    std::vector<uint8_t> *_vec = nullptr; // writeable vector (may be null)
 };
 
 } // namespace Common


### PR DESCRIPTION
BufferedStream has been excluded for writing operations for a while, because there were some problems with it. This PR fixes writing ops within BufferedStream, and adds a number of autotests for streams. Tests are cruicial, as mistakes in writing may lead to greater problems (e.g. damage user files).

Speed tests show that writing with BufferedStream is about 50% faster than with the FileStream (tested by writing long byte-by-byte sequences).

There's an annoying issue of BufferedStream being derived from FileStream rather than let choose what to work on, this is a problem with current streams hierarchy; meanwhile memory-backed FILE functions such as `fmemopen` and `open_memstream`, as these are not in standard C. For simplicity the tests now write and read the file, but just in case I added a new compiler flag AGS_PLATFORM_TEST_FILE_IO that lets to skip the parts of code if you build for running from a read-only location (tbh not sure how useful that would be).