### PR TITLE
Add WaitInput in the Script API

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -454,6 +454,16 @@ enum LogLevel
 };
 #endif
 
+#ifdef SCRIPT_API_v360
+enum InputType
+{
+	eInputNone     = 0x00000000,
+	eInputTime     = 0x00010000,
+	eInputKeyboard = 0x00020000,
+	eInputMouse    = 0x00040000,
+	eInputAny      = 0xFFFF0000
+};
+#endif
 
 internalstring autoptr builtin managed struct String {
   /// Creates a formatted string using the supplied parameters.
@@ -1489,6 +1499,8 @@ import int  WaitKey(int waitLoops = -1);
 /// Blocks the script for the specified number of game loops, unless a key is pressed or the mouse is clicked.
 import int  WaitMouseKey(int waitLoops = -1);
 #ifdef SCRIPT_API_v360
+/// Blocks the script for the specified number of game loops, unless a input is issued. Input are flags, and can be combined using bitwise operators.
+import int  WaitInput(InputFlag input_flag, int waitLoops = -1);
 /// Blocks the script for the specified number of game loops, unless the mouse is clicked.
 import int  WaitMouse(int waitLoops = -1);
 /// Cancels current Wait function, regardless of its type, if one was active at the moment.

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -421,12 +421,7 @@ void GameState::SetWaitSkipResult(int how, int data)
 
 int GameState::GetWaitSkipResult() const
 {
-    switch (wait_skipped_by)
-    {
-    case SKIP_KEYPRESS: return wait_skipped_by_data;
-    case SKIP_MOUSECLICK: return -(wait_skipped_by_data + 1); // convert to 1-based code and negate
-    default: return 0;
-    }
+    return wait_skipped_by << 16 | (wait_skipped_by_data & 0x0000FFFF);
 }
 
 bool GameState::IsBlockingVoiceSpeech() const

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2215,6 +2215,12 @@ RuntimeScriptValue Sc_WaitMouseKey(const RuntimeScriptValue *params, int32_t par
     API_SCALL_INT_PINT(WaitMouseKey);
 }
 
+// int (int input_flags, int nloops)
+RuntimeScriptValue Sc_WaitInput(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT_PINT2(WaitInput);
+}
+
 RuntimeScriptValue Sc_SkipWait(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID(SkipWait);
@@ -2670,6 +2676,7 @@ void RegisterGlobalAPI()
 	ccAddExternalStaticFunction("WaitKey",                  Sc_WaitKey);
 	ccAddExternalStaticFunction("WaitMouse",                Sc_WaitMouse);
 	ccAddExternalStaticFunction("WaitMouseKey",             Sc_WaitMouseKey);
+	ccAddExternalStaticFunction("WaitInput",                Sc_WaitInput);
 	ccAddExternalStaticFunction("SkipWait",                 Sc_SkipWait);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
@@ -3039,4 +3046,5 @@ void RegisterGlobalAPI()
     ccAddExternalFunctionForPlugin("Wait",                     (void*)scrWait);
     ccAddExternalFunctionForPlugin("WaitKey",                  (void*)WaitKey);
     ccAddExternalFunctionForPlugin("WaitMouseKey",             (void*)WaitMouseKey);
+    ccAddExternalFunctionForPlugin("WaitInput",                (void*)WaitInput);
 }

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -850,6 +850,10 @@ int WaitMouseKey(int nloops) {
     return WaitImpl(SKIP_KEYPRESS | SKIP_MOUSECLICK | SKIP_AUTOTIMER, nloops);
 }
 
+int WaitInput(int input_flags, int nloops) {
+    return WaitImpl(input_flags >> 16 | SKIP_AUTOTIMER, nloops);
+}
+
 void SkipWait() {
     play.wait_counter = 0;
 }

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -103,6 +103,7 @@ void scrWait(int nloops);
 int WaitKey(int nloops);
 int WaitMouse(int nloops);
 int WaitMouseKey(int nloops);
+int WaitInput(int input_flags, int nloops);
 void SkipWait();
 
 void scStartRecording(int keyToStop);

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -126,10 +126,10 @@ const int LegacyRoomVolumeFactor            = 30;
 #define EVENT_CLAIMED    2
 
 // Internal skip style flags, for speech/display, wait
-#define SKIP_NONE       0
-#define SKIP_AUTOTIMER  1
-#define SKIP_KEYPRESS   2
-#define SKIP_MOUSECLICK 4
+#define SKIP_NONE       0x00
+#define SKIP_AUTOTIMER  0x01
+#define SKIP_KEYPRESS   0x02
+#define SKIP_MOUSECLICK 0x04
 
 #define MANOBJNUM 99
 


### PR DESCRIPTION
we are going to support more input types in the near future (Gamepad/Joystick/Touch Screen), at least for Gamepad we are probably going to need to some way of dealing with blocking actions like Speak that can be skipped. Instead of adding new `WaitGamepadMouseKey` functions, it would be interesting to have a more generic Wait function that could take additional parameters for the which inputs should be accepted when skipping this specific function.

I don't know yet how to make an `fInputAny` that would mean any and if when gamepad is added, I need it to include this in the same any or it's alright to then update the value of `fInputAny` on the script API.