### PR TITLE
Editor: DialogEditor selects line when required

### DIFF
--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -283,7 +283,27 @@ namespace AGS.Editor.Components
             Dialog dialog = GetDialog(evArgs.FileName);
             if (dialog != null)
             {
-                ShowPaneForDialog(dialog).GoToScriptLine(evArgs);
+                DialogEditor dialogEditor = ShowPaneForDialog(dialog);
+
+                // has dialogEditor has already taken the area available?
+                if (dialogEditor.Parent.ClientSize == dialogEditor.Size)
+                {
+                    // the Dialog Editor be already on screen!
+                    dialogEditor.GoToScriptLine(evArgs);
+                } 
+                else
+                {
+                    // GoToScriptLine uses the size of scintilla control to calculate what lines are visibile and scroll accordingly
+                    // since this is not the case, we will advance once the paint events happens, which is after layout adjustment
+                    PaintEventHandler paintEvent = null;
+                    paintEvent = (s, e1) =>
+                    {
+                        dialogEditor.GoToScriptLine(evArgs);
+                        dialogEditor.Paint -= paintEvent;
+                    };
+                    dialogEditor.Paint += paintEvent;
+                    dialogEditor.Invalidate();
+                }
             }         
 		}
 

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -192,6 +192,10 @@ namespace AGS.Editor
                 scintillaEditor.GoToLine(evArgs.ZoomPosition);
             }
             scintillaEditor.Focus();
+            if(evArgs.SelectLine)
+            {
+                scintillaEditor.SelectCurrentLine();
+            }
 
             if (evArgs.IsDebugExecutionPoint)
             {


### PR DESCRIPTION
fixes what was reported by Dave here: https://www.adventuregamestudio.co.uk/forums/index.php?topic=59842.msg636646209#msg636646209

I noticed this was different in Script Editor: https://github.com/adventuregamestudio/ags/blob/874fbbc7a729866dd8fa85c0cf1b0e2c75fce25c/Editor/AGS.Editor/Panes/ScriptEditor.cs#L515-L518

but also, it wasn't respecting what was asked in the `ZoomToFileEventArgs`, since `SelectLine` was true.