### PR TITLE
Restore support for sound streaming if file is big enough + sound cache for small sounds

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -441,6 +441,8 @@ target_sources(engine
     util/library.h
     util/library_dummy.h
     util/library_posix.h
+    util/sdl2_util.h
+    util/sdl2_util.cpp
 
     platform/windows/acplwin.cpp
     platform/windows/debug/namedpipesagsdebugger.cpp

--- a/Engine/Makefile-objs
+++ b/Engine/Makefile-objs
@@ -17,7 +17,8 @@ platform/base \
 plugin \
 resource \
 script \
-setup
+setup \
+util
 
 ifdef TARGET_ARCH_ABI
 # For Android: make the path relative to the build directory to search for

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -87,6 +87,8 @@ struct GameSetup {
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
     size_t SpriteCacheSize = 0u;
+    size_t SoundLoadAtOnceSize = 1024u * 1024;
+    size_t SoundCacheSize = 0u;
     bool  clear_cache_on_room_change; // for low-end devices: clear resource caches on room change
     bool  load_latest_save; // load latest saved game on launch
     ScreenRotation rotation;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -943,8 +943,9 @@ void new_room(int newnum,CharacterInfo*forchar) {
 
     if (usetup.clear_cache_on_room_change)
     {
-        // Delete all cached sprites
+        // Delete all cached resources
         spriteset.DisposeAll();
+        soundcache_clear();
         GUI::MarkAllGUIForUpdate();
     }
 

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -351,9 +351,15 @@ void apply_config(const ConfigTree &cfg)
 
         usetup.translation = CfgReadString(cfg, "language", "translation");
 
-        int cache_size_kb = CfgReadInt(cfg, "misc", "cachemax", DEFAULTCACHESIZE_KB);
-        if (cache_size_kb > 0)
-            usetup.SpriteCacheSize = cache_size_kb * 1024;
+        int size_kb = CfgReadInt(cfg, "misc", "cachemax", DEFAULTCACHESIZE_KB);
+        if (size_kb > 0)
+            usetup.SpriteCacheSize = size_kb * 1024;
+        size_kb = CfgReadInt(cfg, "sound", "cache_size", DEFAULT_SOUNDCACHESIZE_KB);
+        if (size_kb > 0)
+            usetup.SoundCacheSize = size_kb * 1024;
+        size_kb = CfgReadInt(cfg, "sound", "stream_threshold", DEFAULT_SOUNDLOADATONCE_KB);
+        if (size_kb > 0)
+            usetup.SoundLoadAtOnceSize = size_kb * 1024;
 
         usetup.mouse_auto_lock = CfgReadBoolInt(cfg, "mouse", "auto_lock");
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -58,6 +58,7 @@
 #include "gfx/graphicsdriver.h"
 #include "gfx/gfxdriverfactory.h"
 #include "gfx/ddb.h"
+#include "media/audio/sound.h"
 #include "main/config.h"
 #include "main/game_file.h"
 #include "main/game_start.h"
@@ -393,7 +394,11 @@ void engine_init_audio()
         usetup.audio_enabled = res;
     }
     
-    if (!usetup.audio_enabled)
+    if (usetup.audio_enabled)
+    {
+        soundcache_set_rules(usetup.SoundLoadAtOnceSize, usetup.SoundCacheSize);
+    }
+    else
     {
         // all audio is disabled
         play.voice_avail = false;

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -666,6 +666,7 @@ void shutdown_sound()
 {
     stop_all_sound_and_music(); // game logic
     audio_core_shutdown(); // audio core system
+    soundcache_clear(); // clear cached data
     sys_audio_shutdown(); // backend
     usetup.audio_enabled = false;
 }

--- a/Engine/media/audio/audio_core.cpp
+++ b/Engine/media/audio/audio_core.cpp
@@ -316,7 +316,7 @@ static int audio_core_slot_init(std::unique_ptr<SDLDecoder> decoder)
     return handle;
 }
 
-int audio_core_slot_init(const std::vector<uint8_t> &data, const String &extension_hint, bool repeat)
+int audio_core_slot_init(std::shared_ptr<std::vector<uint8_t>> &data, const String &extension_hint, bool repeat)
 {
     auto decoder = std::make_unique<SDLDecoder>(data, extension_hint, repeat);
     if (!decoder->Open())

--- a/Engine/media/audio/audio_core.h
+++ b/Engine/media/audio/audio_core.h
@@ -17,6 +17,7 @@
 //=============================================================================
 #ifndef __AGS_EE_MEDIA__AUDIOCORE_H
 #define __AGS_EE_MEDIA__AUDIOCORE_H
+#include <memory>
 #include <vector>
 #include "media/audio/audiodefines.h"
 #include "util/string.h"
@@ -32,9 +33,9 @@ void audio_core_shutdown();
 //
 // Initializes playback on a free playback slot (reuses spare one or allocates new if there's none).
 // Data array must contain full wave data to play.
-// TODO: this method requires having full sound in memory;
-// should we add a streaming method later? is this of any priority for regular builds?
-int  audio_core_slot_init(const std::vector<uint8_t> &data, const AGS::Common::String &extension_hint, bool repeat);
+int audio_core_slot_init(const std::vector<uint8_t> &data, const AGS::Common::String &extension_hint, bool repeat);
+// Initializes playback streaming
+int audio_core_slot_init(std::unique_ptr<AGS::Common::Stream> in, const AGS::Common::String &extension_hint, bool repeat);
 // Start playback on a slot
 PlaybackState audio_core_slot_play(int slot_handle);
 // Pause playback on a slot, resume with 'audio_core_slot_play'

--- a/Engine/media/audio/audio_core.h
+++ b/Engine/media/audio/audio_core.h
@@ -33,7 +33,7 @@ void audio_core_shutdown();
 //
 // Initializes playback on a free playback slot (reuses spare one or allocates new if there's none).
 // Data array must contain full wave data to play.
-int audio_core_slot_init(const std::vector<uint8_t> &data, const AGS::Common::String &extension_hint, bool repeat);
+int audio_core_slot_init(std::shared_ptr<std::vector<uint8_t>> &data, const AGS::Common::String &extension_hint, bool repeat);
 // Initializes playback streaming
 int audio_core_slot_init(std::unique_ptr<AGS::Common::Stream> in, const AGS::Common::String &extension_hint, bool repeat);
 // Start playback on a slot

--- a/Engine/media/audio/sdldecoder.cpp
+++ b/Engine/media/audio/sdldecoder.cpp
@@ -57,9 +57,9 @@ const void *SDLResampler::Convert(const void *data, size_t sz, size_t &out_sz)
 //-----------------------------------------------------------------------------
 const auto SampleDefaultBufferSize = 64 * 1024;
 
-SDLDecoder::SDLDecoder(const std::vector<uint8_t> &data,
+SDLDecoder::SDLDecoder(std::shared_ptr<std::vector<uint8_t>> &data,
     const AGS::Common::String &ext_hint, bool repeat)
-    : _sampleData(std::move(data))
+    : _sampleData(data)
     , _sampleExt(ext_hint)
     , _repeat(repeat)
 {
@@ -101,12 +101,12 @@ bool SDLDecoder::Open(float pos_ms)
     else
     {
         sample = SoundSampleUniquePtr(Sound_NewSampleFromMem(
-            (uint8_t*)_sampleData.data(), _sampleData.size(), _sampleExt.GetCStr(), nullptr, SampleDefaultBufferSize));
+            _sampleData->data(), _sampleData->size(), _sampleExt.GetCStr(), nullptr, SampleDefaultBufferSize));
     }
     if (!sample)
     {
         _rwops = nullptr; // rwops was closed by the Sound_NewSample
-        _sampleData.clear();
+        _sampleData = nullptr;
         return false;
     }
 
@@ -124,7 +124,7 @@ void SDLDecoder::Close()
 {
     _sample.reset();
     _rwops = nullptr; // rwops was closed by the Sound_NewSample
-    _sampleData.clear();
+    _sampleData = nullptr;
 }
 
 float SDLDecoder::Seek(float pos_ms)

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 #include <SDL_sound.h>
+#include "util/stream.h"
 #include "util/string.h"
 #ifdef AUDIO_CORE_DEBUG
 #include "debug/out.h"
@@ -34,6 +35,7 @@ namespace AGS
 namespace Engine
 {
 
+using AGS::Common::Stream;
 using AGS::Common::String;
 
 // RAII wrapper over SDL_Sound sample
@@ -107,6 +109,8 @@ class SDLDecoder
 public:
     // Initializes decoder with a complete sound data loaded to memory
     SDLDecoder(const std::vector<uint8_t> &data, const String &ext_hint, bool repeat);
+    // Initializes decoder with an input stream
+    SDLDecoder(const std::unique_ptr<Stream> in, const String &ext_hint, bool repeat);
     SDLDecoder(SDLDecoder&& dec);
     ~SDLDecoder() = default;
 
@@ -135,6 +139,7 @@ public:
     SoundBuffer GetData();
 
 private:
+    SDL_RWops *_rwops = nullptr;
     std::vector<uint8_t> _sampleData{};
     String _sampleExt = "";
     SoundSampleUniquePtr _sample = nullptr;

--- a/Engine/media/audio/sdldecoder.h
+++ b/Engine/media/audio/sdldecoder.h
@@ -108,7 +108,7 @@ class SDLDecoder
 {
 public:
     // Initializes decoder with a complete sound data loaded to memory
-    SDLDecoder(const std::vector<uint8_t> &data, const String &ext_hint, bool repeat);
+    SDLDecoder(std::shared_ptr<std::vector<uint8_t>> &data, const String &ext_hint, bool repeat);
     // Initializes decoder with an input stream
     SDLDecoder(const std::unique_ptr<Stream> in, const String &ext_hint, bool repeat);
     SDLDecoder(SDLDecoder&& dec);
@@ -140,7 +140,7 @@ public:
 
 private:
     SDL_RWops *_rwops = nullptr;
-    std::vector<uint8_t> _sampleData{};
+    std::shared_ptr<std::vector<uint8_t>> _sampleData{};
     String _sampleExt = "";
     SoundSampleUniquePtr _sample = nullptr;
     uint32_t _durationMs = 0u;

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -13,11 +13,14 @@
 //=============================================================================
 #include "media/audio/sound.h"
 #include <cmath>
+#include <list>
+#include <unordered_map>
 #include "core/assetmanager.h"
 #include "media/audio/audio_core.h"
 #include "media/audio/audiodefines.h"
 #include "util/path.h"
 #include "util/stream.h"
+#include "util/string_types.h"
 
 using namespace AGS::Common;
 
@@ -53,31 +56,152 @@ static int GuessSoundTypeFromExt(const String &extension)
     return 0;
 }
 
+// Sound cache, stores most recent used sounds, tracks use history with MRU list.
+// TODO: refactor into the resource cache class, share with the sprite cache.
+class SoundCache
+{
+public:
+    typedef std::shared_ptr<std::vector<uint8_t>> DataRef;
+
+    void SetMaxCacheSize(size_t size)
+    {
+        _maxSize = size;
+        FreeMem(0); // makes sure it does not exceed max size
+    }
+
+    DataRef Get(const String &name)
+    {
+        const auto found = _map.find(name);
+        if (found == _map.end())
+            return DataRef();
+        // Move to the beginning of the MRU list
+        _mru.splice(_mru.begin(), _mru, found->second.MruIt);
+        return found->second.Data;
+    }
+
+    // Add particular item into the cache, remove oldest items if cache size is exceeded
+    void Put(const String &name, DataRef &ref)
+    {
+        assert(ref);
+        if (!ref)
+            return; // safety precaution
+        if (Get(name))
+            return; // already in cache
+        if (_maxSize == 0)
+            return; // cache is disabled
+        // Clear up space before adding
+        if (_cacheSize + ref->size() > _maxSize)
+            FreeMem(ref->size());
+        SoundEntry entry(name, ref);
+        entry.MruIt = _mru.insert(_mru.begin(), name);
+        _map[name] = std::move(entry);
+        _cacheSize += ref->size();
+    }
+
+    // Clear the cache, dispose all resources
+    void Clear()
+    {
+        _map.clear();
+        _mru.clear();
+        _cacheSize = 0u;
+    }
+
+private:
+    // Delete the oldest (least recently used) item in cache
+    void DisposeOldest()
+    {
+        assert(_mru.size() > 0);
+        if (_mru.size() == 0) return;
+        auto it = std::prev(_mru.end());
+        const auto id = *it;
+        _cacheSize -= _map[id].Data->size();
+        _map.erase(id);
+        // Remove from the mru list
+        _mru.erase(it);
+    }
+    // Keep disposing oldest elements until cache has at least the given free space
+    void FreeMem(size_t space)
+    {
+        while ((_mru.size() > 0) && (_cacheSize >= (_maxSize - space)))
+        {
+            DisposeOldest();
+        }
+    }
+
+    struct SoundEntry
+    {
+        String Name;
+        DataRef Data;
+        // MRU list reference
+        std::list<String>::const_iterator MruIt;
+        SoundEntry() = default;
+        SoundEntry(const String &name, DataRef &data)
+            : Name(name), Data(data) {}
+    };
+
+    size_t _cacheSize = 0u;
+    size_t _maxSize = 0u;
+    std::unordered_map<String, SoundEntry, HashStrNoCase> _map;
+    // MRU list: the way to track which items were used recently.
+    // When clearing up space for new items, cache first deletes the items
+    // that were last time used long ago.
+    std::list<String> _mru;
+};
+
+
 // Maximal sound asset size which is allowed to be loaded at once;
 // anything larger will be streamed
 // TODO: make configureable?
 static const size_t MaxLoadAtOnce = 1024u * 1024;
+static SoundCache SndCache;
+
+void soundcache_set_size(size_t size)
+{
+    SndCache.SetMaxCacheSize(size);
+}
+
+void soundcache_clear()
+{
+    SndCache.Clear();
+}
 
 static SOUNDCLIP *my_load_clip(const AssetPath &apath, const char *extension_hint, bool loop)
 {
-    std::unique_ptr<Stream> s(AssetMgr->OpenAsset(apath));
-    if (!s)
-        return nullptr;
+    size_t asset_size;
+    std::unique_ptr<Stream> s_in;
+    auto sounddata = SndCache.Get(apath.Name);
+    if (sounddata)
+    {
+        asset_size = sounddata->size();
+    }
+    else
+    {
+        s_in.reset(AssetMgr->OpenAsset(apath));
+        if (!s_in)
+            return nullptr;
+        asset_size = static_cast<size_t>(s_in->GetLength());
+    }
 
     const auto asset_ext = AGS::Common::Path::GetFileExtension(apath.Name);
     const auto ext_hint = asset_ext.IsEmpty() ? String(extension_hint) : asset_ext;
 
     int slot{};
-    const size_t asset_size = static_cast<size_t>(s->GetLength());
-    if (asset_size > MaxLoadAtOnce)
+    // If sound data was cached, or asset's size is small enough to load at once,
+    // then load/use it and update the cache if necessary
+    if (sounddata || asset_size <= MaxLoadAtOnce)
     {
-        slot = audio_core_slot_init(std::move(s), ext_hint, loop);
+        if (!sounddata)
+        {
+            sounddata.reset(new std::vector<uint8_t>(asset_size));
+            s_in->Read(sounddata->data(), asset_size);
+            SndCache.Put(apath.Name, sounddata);
+        }
+        slot = audio_core_slot_init(sounddata, ext_hint, loop);
     }
+    // Otherwise, if asset's size is too large, start streaming
     else
     {
-        std::vector<uint8_t> data(asset_size);
-        s->Read(data.data(), asset_size);
-        slot = audio_core_slot_init(data, ext_hint, loop);
+        slot = audio_core_slot_init(std::move(s_in), ext_hint, loop);
     }
 
     if (slot < 0) { return nullptr; }

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -140,7 +140,7 @@ private:
     };
 
     size_t _cacheSize = 0u;
-    size_t _maxSize = 0u;
+    size_t _maxSize = DEFAULT_SOUNDCACHESIZE_KB;
     std::unordered_map<String, SoundEntry, HashStrNoCase> _map;
     // MRU list: the way to track which items were used recently.
     // When clearing up space for new items, cache first deletes the items
@@ -152,12 +152,13 @@ private:
 // Maximal sound asset size which is allowed to be loaded at once;
 // anything larger will be streamed
 // TODO: make configureable?
-static const size_t MaxLoadAtOnce = 1024u * 1024;
+static size_t MaxLoadAtOnce = DEFAULT_SOUNDLOADATONCE_KB;
 static SoundCache SndCache;
 
-void soundcache_set_size(size_t size)
+void soundcache_set_rules(size_t max_loadatonce, size_t max_cachesize)
 {
-    SndCache.SetMaxCacheSize(size);
+    MaxLoadAtOnce = max_loadatonce;
+    SndCache.SetMaxCacheSize(max_cachesize);
 }
 
 void soundcache_clear()

--- a/Engine/media/audio/sound.h
+++ b/Engine/media/audio/sound.h
@@ -15,14 +15,21 @@
 // SOUNDCLIP factory methods.
 //
 //=============================================================================
-
 #ifndef __AC_SOUND_H
 #define __AC_SOUND_H
 
 #include "ac/asset_helper.h"
 #include "media/audio/soundclip.h"
 
-void soundcache_set_size(size_t size);
+// Threshold in bytes for loading sounds immediately, in KB
+const size_t DEFAULT_SOUNDLOADATONCE_KB = 1024u;
+// Sound cache limit, in KB
+const size_t DEFAULT_SOUNDCACHESIZE_KB = 1024u * 32; // 32 MB
+
+// Sets sound loading and caching rules:
+// * max_loadatonce - threshold in bytes for loading sounds immediately, vs streaming
+// * max_cachesize - sound cache limit, in bytes
+void soundcache_set_rules(size_t max_loadatonce, size_t max_cachesize);
 void soundcache_clear();
 SOUNDCLIP *my_load_wave(const AssetPath &asset_name, bool loop);
 SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, bool loop);

--- a/Engine/media/audio/sound.h
+++ b/Engine/media/audio/sound.h
@@ -22,6 +22,8 @@
 #include "ac/asset_helper.h"
 #include "media/audio/soundclip.h"
 
+void soundcache_set_size(size_t size);
+void soundcache_clear();
 SOUNDCLIP *my_load_wave(const AssetPath &asset_name, bool loop);
 SOUNDCLIP *my_load_mp3(const AssetPath &asset_name, bool loop);
 SOUNDCLIP *my_load_ogg(const AssetPath &asset_name, bool loop);

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -157,6 +157,7 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
 
     // sound
     CfgWriteInt(cfg, "sound", "enabled", setup.audio_enabled);
+    CfgWriteInt(cfg, "sound", "cache_size", setup.audio_cachesize);
 
     // mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls

--- a/Engine/util/sdl2_util.cpp
+++ b/Engine/util/sdl2_util.cpp
@@ -1,0 +1,88 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "util/sdl2_util.h"
+#include "debug/assert.h"
+
+using namespace AGS::Common;
+
+namespace AGS
+{
+namespace Engine
+{
+namespace SDL2Util
+{
+
+static const Uint32 RWopsType = 0xF0001000;
+
+/* These functions should not be used except from pointers in an SDL_RWops */
+static Sint64 rwops_size(SDL_RWops *context)
+{
+    return static_cast<Stream*>(context->hidden.unknown.data1)->GetLength();
+}
+
+static StreamSeek RWopsSeekToAGS(int whence)
+{
+    switch (whence)
+    {
+    case RW_SEEK_SET: return kSeekBegin;
+    case RW_SEEK_CUR: return kSeekCurrent;
+    case RW_SEEK_END: return kSeekEnd;
+    default: assert(false); return kSeekBegin;
+    }
+}
+
+static Sint64 rwops_seek(SDL_RWops *context, Sint64 offset, int whence)
+{
+    static_cast<Stream*>(context->hidden.unknown.data1)->Seek(offset, RWopsSeekToAGS(whence));
+    return static_cast<Stream*>(context->hidden.unknown.data1)->GetPosition();
+}
+
+static size_t rwops_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
+{
+    return (static_cast<Stream*>(context->hidden.unknown.data1)->Read(ptr, size * maxnum) / size);
+}
+
+static size_t rwops_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
+{
+    return (static_cast<Stream*>(context->hidden.unknown.data1)->Write(ptr, size * num) / size);
+}
+
+static int rwops_close(SDL_RWops *context)
+{
+    if (context->type != RWopsType) {
+        return SDL_SetError("Wrong kind of SDL_RWops for rwops_close(): got %u, expected %u", context->type, RWopsType);
+    }
+
+    delete static_cast<Stream*>(context->hidden.unknown.data1);
+    SDL_FreeRW(context);
+    return 0;
+}
+
+SDL_RWops *OpenRWops(std::unique_ptr<Stream> ags_stream)
+{
+    SDL_RWops *c = SDL_AllocRW();
+    if (!c) return nullptr;
+    c->size = rwops_size;
+    c->seek = rwops_seek;
+    c->read = rwops_read;
+    c->write = rwops_write;
+    c->close = rwops_close;
+    c->type = RWopsType;
+    c->hidden.unknown.data1 = ags_stream.release();
+    return c;
+}
+
+} // namespace SDL2Util
+} // namespace Engine
+} // namespace AGS

--- a/Engine/util/sdl2_util.h
+++ b/Engine/util/sdl2_util.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Custom SDL2 utilities, wrappers, reimplementations etc.
+//
+//=============================================================================
+#ifndef __AGS_EE_UTIL__SDL2UTIL_H
+#define __AGS_EE_UTIL__SDL2UTIL_H
+
+#include <memory>
+#include <SDL.h>
+#include "util/stream.h"
+
+namespace AGS
+{
+namespace Engine
+{
+namespace SDL2Util
+{
+    // Opens a custom SDL2 RWOps implementation that embeds AGS stream
+    SDL_RWops *OpenRWops(std::unique_ptr<Common::Stream> ags_stream);
+} // namespace SDL2Util
+} // namespace Engine
+} // namespace AGS
+
+#endif // __AGS_EE_UTIL__RWOPSUTIL_H

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -61,6 +61,8 @@ Locations of two latter files differ between running platforms:
       * pulseaudio, alsa, arts, esd, jack, pipewire, disk, dsp, dummy
     * For Windows:
       * wasapi, directsound, winmm, disk, dummy
+  * cache_size = \[integer\] - size of the engine's sound cache, in kilobytes. Default is 32768 (32 MB).
+  * stream_threshold = \[integer\] - max size of the sound clip that engine is allowed to load in memory at once, as opposed to continuously streaming one. In the current implementation this also defines the max size of a clip that may be put into the sound cache. Default is 1024 (1 MB).
   * usespeech = \[0; 1\] - enable or disable in-game speech (voice-overs).
 * **\[mouse\]** - mouse options
   * auto_lock = \[0; 1\] - enables mouse autolock in window: mouse cursor locks inside the window whenever it receives input focus.

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -480,6 +480,7 @@
     <ClInclude Include="..\..\Common\script\cc_internal.h" />
     <ClInclude Include="..\..\Common\util\alignedstream.h" />
     <ClInclude Include="..\..\Common\util\bbop.h" />
+    <ClInclude Include="..\..\Common\util\bufferedstream.h" />
     <ClInclude Include="..\..\Common\util\cmdlineopts.h" />
     <ClInclude Include="..\..\Common\util\compress.h" />
     <ClInclude Include="..\..\Common\util\datastream.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -832,5 +832,8 @@
     <ClInclude Include="..\..\Common\script\cc_common.h">
       <Filter>Header Files\script</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\bufferedstream.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -447,6 +447,7 @@
     <ClCompile Include="..\..\Engine\script\script_api.cpp" />
     <ClCompile Include="..\..\Engine\script\script_runtime.cpp" />
     <ClCompile Include="..\..\Engine\script\systemimports.cpp" />
+    <ClCompile Include="..\..\Engine\util\sdl2_util.cpp" />
     <ClCompile Include="..\..\libsrc\mojoAL\mojoal.c" />
   </ItemGroup>
   <ItemGroup>
@@ -721,6 +722,7 @@
     <ClInclude Include="..\..\Engine\test\test_all.h" />
     <ClInclude Include="..\..\Engine\util\library.h" />
     <ClInclude Include="..\..\Engine\util\library_windows.h" />
+    <ClInclude Include="..\..\Engine\util\sdl2_util.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\al.h" />
     <ClInclude Include="..\..\libsrc\mojoAL\AL\alc.h" />
   </ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -163,6 +163,9 @@
     <Filter Include="Library Sources\MojoAL\AL">
       <UniqueIdentifier>{c683eef3-2c8f-4b45-af32-2423f41102ad}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\util">
+      <UniqueIdentifier>{fa93d5a4-ee74-4229-a79c-3a7f3be1e634}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Engine\ac\audiochannel.cpp">
@@ -809,6 +812,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Engine\media\audio\openalsource.cpp">
       <Filter>Source Files\media\audio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\util\sdl2_util.cpp">
+      <Filter>Source Files\util</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1630,6 +1636,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\media\audio\openalsource.h">
       <Filter>Header Files\media\audio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\util\sdl2_util.h">
+      <Filter>Header Files\util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
After we changed to SDL2 and the new audio code, every sound clip is loaded into the memory at once now. The old code allowed to stream sound clips under some condition. In addition it had a sound cache for most frequently used sounds. This pr reimplements streaming within the new audio code, which is done if the sound asset is large enough, and a sound cache, this time coded in similarity with sprite cache (i believe in that in the future it might be possible to pick out shared code into a more universal resource cache class).

1. Engine decides whether to stream sound data from file, or load all at once, based on an asset size threshold.
2. For streaming, it passes opened ags stream into audio core, where the stream is wrapped into custom rwops for SDL sound. The reason why this is necessary is that assets are read from the package, and have to be limited by certain offsets. Unless i missed something, default rwops cannot do the same thing, which may result in the incorrect detection of the sound size.
3. Sound cache only stores sounds loaded at once; so only those smaller than the threshold setting. NOTE: in theory it's possible to code streaming into the shared cached buffer, but I decided to leave this for later (such streaming would also require remembering how much of the sound data has been read, and probably have a mutex, as same buffer may be read and written two from main and audio threads).
4. Added config options for "sound cache size" and "stream threshold". The latter may be renamed if the current name seem difficult to understand.