### PR TITLE
AGS 4: new compiler: replaced char* with const char* where necessary

### DIFF
--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -379,7 +379,7 @@ private:
     bool IsVTF(Symbol s, VartypeFlag flag) const;
 
     // A wrapper, only for usage in the debugger
-    inline Symbol FindCString(char *name) { return Find(name); }
+    inline Symbol FindCString(const char *name) { return Find(name); }
 
 public:
     std::vector<SymbolTableEntry> entries;

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -44,7 +44,7 @@
 TEST_F(Bytecode0, P_r_o_t_o_t_y_p_e) {
     
 
-    char *inpl = "\
+    const const char *inpl = "\
         int Foo(int a)      \n\
         {                   \n\
             return a*a;     \n\
@@ -80,7 +80,7 @@ TEST_F(Bytecode0, UnaryMinus1) {
 
     // Accept a unary minus in front of parens
 
-    char *inpl = "\
+    const const char *inpl = "\
         void Foo()              \n\
         {                       \n\
             int bar = 5;        \n\
@@ -125,7 +125,7 @@ TEST_F(Bytecode0, UnaryMinus2) {
 
     // Unary minus binds more than multiply
 
-    char *inpl = "\
+    const const char *inpl = "\
         int main()                      \n\
         {                               \n\
             int five = 5;               \n\
@@ -171,7 +171,7 @@ TEST_F(Bytecode0, UnaryMinus2) {
 TEST_F(Bytecode0, NotNot) {
 
     // !!a should be interpreted as !(!a)
-    char *inpl = "\
+    const const char *inpl = "\
         int main()                  \n\
         {                           \n\
             int five = 5;           \n\
@@ -341,7 +341,7 @@ TEST_F(Bytecode0, Float02) {
 
 TEST_F(Bytecode0, Float03) { 
 
-    char *inpl = "\
+    const const char *inpl = "\
         float a = 15.0;     \n\
         float Foo()         \n\
         {                   \n\
@@ -391,7 +391,7 @@ TEST_F(Bytecode0, Float03) {
 
 TEST_F(Bytecode0, Float04) {    
 
-    char *inpl = "\
+    const const char *inpl = "\
         float a = 15.0;                             \n\
         float Foo()                                 \n\
         {                                           \n\
@@ -461,7 +461,7 @@ TEST_F(Bytecode0, Float04) {
 
 TEST_F(Bytecode0, FlowIfThenElse1) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     int Foo()               \n\
     {                       \n\
         readonly int vier = 4; \n\
@@ -515,7 +515,7 @@ TEST_F(Bytecode0, FlowIfThenElse1) {
 
 TEST_F(Bytecode0, FlowIfThenElse2) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     int Foo()               \n\
     {                       \n\
         readonly int deux = 2; \n\
@@ -569,7 +569,7 @@ TEST_F(Bytecode0, FlowIfThenElse2) {
 
 TEST_F(Bytecode0, FlowWhile) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     char c = 'x';             \n\
     int Foo(int i, float f)   \n\
     {                         \n\
@@ -635,7 +635,7 @@ TEST_F(Bytecode0, FlowWhileTrue)
 {
     // Mustn't short-circuit the 'while()' body
 
-    char *inpl = "\n\
+    const const char *inpl = "\n\
         enum bool { false = 0, true }; \n\
         int main()          \n\
         {                   \n\
@@ -679,7 +679,7 @@ TEST_F(Bytecode0, FlowDoWhileFalse)
 {
     // Don't emit back jump
 
-    char *inpl = "\n\
+    const const char *inpl = "\n\
         enum bool { false = 0, true }; \n\
         int main()              \n\
         {                       \n\
@@ -722,7 +722,7 @@ TEST_F(Bytecode0, FlowDoWhileFalse)
 
 TEST_F(Bytecode0, FlowDoNCall) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     char c = 'x';             \n\
     int Foo(int i)            \n\
     {                         \n\
@@ -793,7 +793,7 @@ TEST_F(Bytecode0, FlowDoNCall) {
 
 TEST_F(Bytecode0, FlowDoUnbracedIf) {    
 
-    char *inpl = "\
+    const const char *inpl = "\
     void noloopcheck main()   \n\
     {                         \n\
         int sum = 0;          \n\
@@ -845,7 +845,7 @@ TEST_F(Bytecode0, FlowDoUnbracedIf) {
 
 TEST_F(Bytecode0, FlowFor1) {  
 
-    char *inpl = "\
+    const const char *inpl = "\
     int loop;                       \n\
     int Foo(int i, float f)         \n\
     {                               \n\
@@ -910,7 +910,7 @@ TEST_F(Bytecode0, FlowFor1) {
 
 TEST_F(Bytecode0, FlowFor2) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     int Foo(int i, float f)         \n\
     {                               \n\
         int lp, sum;                \n\
@@ -998,7 +998,7 @@ TEST_F(Bytecode0, FlowFor2) {
 
 TEST_F(Bytecode0, FlowFor3) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct           \n\
     {                               \n\
         float Payload[1];           \n\
@@ -1059,7 +1059,7 @@ TEST_F(Bytecode0, FlowFor3) {
 
 TEST_F(Bytecode0, FlowFor4) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     void main()                     \n\
     {                               \n\
         for (int Loop = 0; Loop < 10; Loop++)  \n\
@@ -1106,7 +1106,7 @@ TEST_F(Bytecode0, FlowFor4) {
 
 TEST_F(Bytecode0, FlowFor5) {
 
-    char *inpl = "\
+    const const char *inpl = "\
         int Start()                     \n\
         {                               \n\
             return 1;                   \n\
@@ -1182,7 +1182,7 @@ TEST_F(Bytecode0, FlowFor5) {
 
 TEST_F(Bytecode0, FlowFor6) {
 
-    char *inpl = "\
+    const const char *inpl = "\
         void main()                     \n\
         {                               \n\
             for(int i = Start();        \n\
@@ -1262,7 +1262,7 @@ TEST_F(Bytecode0, FlowFor7) {
     // Initializer and iterator of a for() need not be assignments,
     // they can be func calls.
 
-    char *inpl = "\
+    const const char *inpl = "\
         int i;                          \n\
         void main()                     \n\
         {                               \n\
@@ -1344,7 +1344,7 @@ TEST_F(Bytecode0, FlowContinue1) {
     // they remain valid, and so the offset to start of the local block
     // must not be reduced.
 
-    char *inpl = "\
+    const const char *inpl = "\
         int main()                      \n\
         {                               \n\
             int I;                      \n\
@@ -1404,7 +1404,7 @@ TEST_F(Bytecode0, FlowContinue1) {
 
 TEST_F(Bytecode0, FlowIfDoWhile) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     int Foo(int i, float f)                      \n\
     {                                            \n\
         int five = 5, sum, loop = -2;            \n\
@@ -1472,7 +1472,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
 
     // The "break;" in line 6 is unreachable code
 
-    char *inpl = "\
+    const const char *inpl = "\
     int Foo(int i, float f)         \n\
     {                               \n\
         switch (i * i)              \n\
@@ -1545,7 +1545,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
 TEST_F(Bytecode0, FlowSwitch02) {
 
     // Last switch clause no "break"
-    char *inpl = "\
+    const const char *inpl = "\
         void main()                     \n\
         {                               \n\
             int i = 5;                  \n\
@@ -1593,7 +1593,7 @@ TEST_F(Bytecode0, FlowSwitch02) {
 
 TEST_F(Bytecode0, FlowSwitch03) {
     // Last case clause an empty pair of braces
-    char *inpl = "\
+    const const char *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 0;   \n\
@@ -1642,7 +1642,7 @@ TEST_F(Bytecode0, FlowSwitch04) {
 
     // Last case clause an empty pair of braces
 
-    char *inpl = "\
+    const const char *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 7;   \n\
@@ -1690,7 +1690,7 @@ TEST_F(Bytecode0, FlowSwitch05) {
 
     // No default/case clauses (zany but allowed)
 
-    char *inpl = "\
+    const const char *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 0;   \n\
@@ -1733,7 +1733,7 @@ TEST_F(Bytecode0, FlowSwitch06) {
 
     // 'Default' and 'case 77' fall through, compiler should warn about the latter
 
-    char *inpl = "\
+    const const char *inpl = "\
         int main()              \n\
         {                       \n\
             int test = 7;       \n\
@@ -1794,7 +1794,7 @@ TEST_F(Bytecode0, FlowSwitch07) {
 
     // Expression in switch clause
 
-    char *inpl = "\
+    const const char *inpl = "\
         readonly int two = 2;   \n\
         int main()              \n\
         {                       \n\
@@ -1857,7 +1857,7 @@ TEST_F(Bytecode0, FlowSwitch07) {
 
 TEST_F(Bytecode0, FreeLocalPtr) {   
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct S                  \n\
     {                                 \n\
         int i;                        \n\
@@ -1910,7 +1910,7 @@ TEST_F(Bytecode0, FreeLocalPtr) {
 
 TEST_F(Bytecode0, Struct01) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     	struct Struct                       \n\
 		{                                   \n\
 			float Float;                    \n\
@@ -1990,7 +1990,7 @@ TEST_F(Bytecode0, Struct02) {
     // test arrays; arrays in structs;
     // whether the namespace in structs is independent of the global namespace
 
-    char *inpl = "\
+    const const char *inpl = "\
     struct Struct1                  \n\
     {                               \n\
         int Array[17], Ix;          \n\
@@ -2056,7 +2056,7 @@ TEST_F(Bytecode0, Struct03) {
     // test arrays; arrays in structs;
     // whether the namespace in structs is independent of the global namespace
 
-    char *inpl = "\
+    const const char *inpl = "\
     struct Struct1                  \n\
     {                               \n\
         int Array[17], Ix;          \n\
@@ -2117,7 +2117,7 @@ TEST_F(Bytecode0, Struct03) {
 
 TEST_F(Bytecode0, Struct04) {
 
-    char *inpl = "\
+    const const char *inpl = "\
         managed struct StructI                               \n\
         {                                                    \n\
             int k;                                           \n\
@@ -2180,7 +2180,7 @@ TEST_F(Bytecode0, Struct04) {
 
 TEST_F(Bytecode0, Struct05) {   
 
-    char *inpl = "\
+    const const char *inpl = "\
         struct StructO                                       \n\
         {                                                    \n\
             static import int StInt(int i);                  \n\
@@ -2242,7 +2242,7 @@ TEST_F(Bytecode0, Struct06) {
     // NOTE: S1.Array[3] is null, so S1.Array[3].Payload should dump
     // when executed in real.
 
-    char *inpl = "\
+    const const char *inpl = "\
         managed struct Struct0;                             \n\
                                                             \n\
         struct Struct1                                      \n\
@@ -2299,7 +2299,7 @@ TEST_F(Bytecode0, Struct06) {
 
 TEST_F(Bytecode0, Struct07) {    
 
-    char *inpl = "\
+    const const char *inpl = "\
         struct Struct1                                       \n\
         {                                                    \n\
             int IPayload;                                    \n\
@@ -2362,7 +2362,7 @@ TEST_F(Bytecode0, Struct07) {
 
 TEST_F(Bytecode0, Struct08) {   
 
-    char *inpl = "\
+    const const char *inpl = "\
         struct Struct                                        \n\
         {                                                    \n\
             int k;                                           \n\
@@ -2422,7 +2422,7 @@ TEST_F(Bytecode0, Struct09) {
     // VehicleBase as an extension of Vehicle Cars[5];
     // should generate call of VehicleBase::SetCharacter()
 
-    char *inpl = "\
+    const const char *inpl = "\
         enum CharacterDirection                                     \n\
         {                                                           \n\
             eDirectionUp = 3                                        \n\
@@ -2528,7 +2528,7 @@ TEST_F(Bytecode0, Struct10) {
     // the import variable must be read first so that the fixup can be
     // applied. Only then may the offset be added to it.
 
-    char *inpl = "\
+    const const char *inpl = "\
         import struct Struct                                 \n\
         {                                                    \n\
             int fluff;                                       \n\
@@ -2583,7 +2583,7 @@ TEST_F(Bytecode0, Struct11) {
     // Structs may contain variables that are structs themselves.
     // Since Inner1 is managed, In1 will convert into an Inner1 *.
 
-    char *inpl = "\
+    const const char *inpl = "\
         managed struct Inner1                               \n\
         {                                                   \n\
             short Fluff;                                    \n\
@@ -2657,7 +2657,7 @@ TEST_F(Bytecode0, Struct12) {
 
     // Can have managed components in non-managed struct.
 
-    char *inpl = "\
+    const const char *inpl = "\
         struct NonManaged           \n\
         {                           \n\
             long Dummy;             \n\
@@ -2716,7 +2716,7 @@ TEST_F(Bytecode0, Struct12) {
 
 TEST_F(Bytecode0, StructArray01) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         int Int[10];                     \n\
@@ -2764,7 +2764,7 @@ TEST_F(Bytecode0, StructArray02) {
 
     // Static arrays can be multidimensional
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         int Int1[5, 4];                  \n\
@@ -2815,7 +2815,7 @@ TEST_F(Bytecode0, StructArray02) {
 
 TEST_F(Bytecode0, Func01) {
 
-    char *inpl = "\
+    const const char *inpl = "\
         int Foo()      \n\
     {                  \n\
         return 15;     \n\
@@ -2851,7 +2851,7 @@ TEST_F(Bytecode0, Func01) {
 
 TEST_F(Bytecode0, Func02) {
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -2916,7 +2916,7 @@ TEST_F(Bytecode0, Func02) {
 
 TEST_F(Bytecode0, Func03) {   
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -2981,7 +2981,7 @@ TEST_F(Bytecode0, Func03) {
 
 TEST_F(Bytecode0, Func04) {    
 
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -3054,7 +3054,7 @@ TEST_F(Bytecode0, Func04) {
 
 TEST_F(Bytecode0, Func05) {
     
-    char *inpl = "\
+    const const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -3114,7 +3114,7 @@ TEST_F(Bytecode0, Func05) {
 
 TEST_F(Bytecode0, Func06) {
    
-    char *inpl = "\
+    const const char *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         int Func(int P1, int P2)     \n\
@@ -3172,7 +3172,7 @@ TEST_F(Bytecode0, Func06) {
 
 TEST_F(Bytecode0, Func07) {  
 
-    char *inpl = "\
+    const const char *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         void main()                  \n\
@@ -3227,7 +3227,7 @@ TEST_F(Bytecode0, Func07) {
 
 TEST_F(Bytecode0, Func08) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         void main()                  \n\
         {                            \n\
             int Int1 = Func(4);      \n\
@@ -3282,7 +3282,7 @@ TEST_F(Bytecode0, Func08) {
 
 TEST_F(Bytecode0, Func09) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Func(int f, int = 5); \n\
         import int Func(int, int = 5); \n\
                                      \n\
@@ -3338,7 +3338,7 @@ TEST_F(Bytecode0, Func09) {
 
 TEST_F(Bytecode0, Func10) {
     
-    char *inpl = "\
+    const char *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         int Func(int P1, int P2)     \n\
@@ -3396,7 +3396,7 @@ TEST_F(Bytecode0, Func10) {
 
 TEST_F(Bytecode0, Func11) {   
 
-    char *inpl = "\
+    const char *inpl = "\
     struct Struct                   \n\
     {                               \n\
         float Float;                \n\
@@ -3462,7 +3462,7 @@ TEST_F(Bytecode0, Func12) {
     // Function with float default, or default "0", for float parameter
     // The latter will make the compiler slightly unhappy
 
-    char *inpl = "\
+    const char *inpl = "\
     float Func1(float F = 7.2)          \n\
     {                                   \n\
         return F;                       \n\
@@ -3529,7 +3529,7 @@ TEST_F(Bytecode0, Func13) {
     // Function with default null or 0 for managed parameter
     // The latter will make the compiler slightly unhappy
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct S                    \n\
     {                                   \n\
         float f;                        \n\
@@ -3606,7 +3606,7 @@ TEST_F(Bytecode0, Func14) {
 
     // Strange misalignment due to bad function protocol
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct               \n\
         {                           \n\
             int A[];                \n\
@@ -3688,7 +3688,7 @@ TEST_F(Bytecode0, Func14) {
 
 TEST_F(Bytecode0, Func15) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int a = 15;    \n\
         int Foo( )     \n\
         {              \n\
@@ -3734,7 +3734,7 @@ TEST_F(Bytecode0, Func15) {
 
 TEST_F(Bytecode0, Func16) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int Foo(int a) \n\
         {              \n\
             return a;  \n\
@@ -3770,7 +3770,7 @@ TEST_F(Bytecode0, Func16) {
 
 TEST_F(Bytecode0, Func17) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int Foo()       \n\
         {               \n\
             int a = 15; \n\
@@ -3864,7 +3864,7 @@ TEST_F(Bytecode0, Func18) {
 TEST_F(Bytecode0, Function19) {
 
     // Simple void function
-    char *inpl = "\
+    const char *inpl = "\
         void Foo()          \n\
         {                   \n\
             return;         \n\
@@ -3973,7 +3973,7 @@ TEST_F(Bytecode0, Func20) {
 
 TEST_F(Bytecode0, Export) {
     
-    char *inpl = "\
+    const char *inpl = "\
     struct Struct                   \n\
     {                               \n\
         float Float;                \n\
@@ -4039,7 +4039,7 @@ TEST_F(Bytecode0, Export) {
 
 TEST_F(Bytecode0, ArrayOfPointers1) {
    
-    char *inpl = "\
+    const char *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         float Float;                     \n\
@@ -4105,7 +4105,7 @@ TEST_F(Bytecode0, ArrayOfPointers1) {
 
 TEST_F(Bytecode0, ArrayOfPointers2) {    
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         float Float;                     \n\
@@ -4168,7 +4168,7 @@ TEST_F(Bytecode0, Writeprotected) {
     
     // Directly taken from the doc on writeprotected, simplified.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                         \n\
             short Beauty;                       \n\
             writeprotected int Damage;          \n\
@@ -4230,7 +4230,7 @@ TEST_F(Bytecode0, Protected1) {
 
     // Directly taken from the doc on protected, simplified.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int SetDamage(int damage);  \n\
@@ -4277,7 +4277,7 @@ TEST_F(Bytecode0, Protected1) {
 
 TEST_F(Bytecode0, Static1) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                         \n\
             import static int CalcDamage(       \n\
             int Lifepoints, int Hitpoints = 5); \n\
@@ -4346,7 +4346,7 @@ TEST_F(Bytecode0, Static1) {
 
 TEST_F(Bytecode0, Static2) {
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
         };                                     \n\
                                                \n\
@@ -4407,7 +4407,7 @@ TEST_F(Bytecode0, Protected2) {
     // In a struct func, a variable that can't be found otherwise
     // should be taken to be out of the current struct.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int SetDamage(int damage);  \n\
@@ -4454,7 +4454,7 @@ TEST_F(Bytecode0, Protected2) {
 
 TEST_F(Bytecode0, Import) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Weapon;                     \n\
                                                \n\
         int Func(int damage)                   \n\

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -32,7 +32,7 @@ protected:
 TEST_F(Bytecode1, StringOldstyle01) {
     ccSetOption(SCOPT_OLDSTRINGS, true);
 
-    char *inpl = "\
+    const char *inpl = "\
         int Sentinel1;              \n\
         string GLOBAL;              \n\
         int Sentinel2;              \n\
@@ -86,7 +86,7 @@ TEST_F(Bytecode1, StringOldstyle01) {
 
 TEST_F(Bytecode1, StringOldstyle02) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int sub(const string s) \n\
         {                       \n\
             return;             \n\
@@ -146,7 +146,7 @@ TEST_F(Bytecode1, StringOldstyle02) {
 
 TEST_F(Bytecode1, StringOldstyle03) {
     
-    char *inpl = "\
+    const char *inpl = "\
         int Sentinel1;                  \n\
         string Global;                  \n\
         int Sentinel2;                  \n\
@@ -217,7 +217,7 @@ TEST_F(Bytecode1, StringOldstyle03) {
 
 TEST_F(Bytecode1, StringOldstyle04) {
     
-    char *inpl = "\
+    const char *inpl = "\
         int Sentinel;                   \n\
         string Global;                  \n\
         int main()                      \n\
@@ -280,7 +280,7 @@ TEST_F(Bytecode1, StringOldstyle04) {
 
 TEST_F(Bytecode1, StringOldstyle05) {
     
-    char *inpl = "\
+    const char *inpl = "\
         int main()                  \n\
         {                           \n\
             string S3 = \"Holz-\";  \n\
@@ -585,7 +585,7 @@ TEST_F(Bytecode1, AccessStructAsPointer01) {
     // - the struct is "builtin" as well as "managed".
     // Such structs can be used as a parameter of a function that expects a pointered struct
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Object {                 \n\
         };                                              \n\
         import Object oCleaningCabinetDoor;             \n\
@@ -647,7 +647,7 @@ TEST_F(Bytecode1, AccessStructAsPointer02) {
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Object { };              \n\
         import Object oCleaningCabinetDoor;             \n\
                                                         \n\
@@ -712,7 +712,7 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Object {                 \n\
             readonly int Reserved;                      \n\
         };                                              \n\
@@ -770,7 +770,7 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
 
 TEST_F(Bytecode1, Attributes01) {
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1, };              \n\
         builtin managed struct ViewFrame {              \n\
             readonly import attribute bool Flipped;     \n\
@@ -856,7 +856,7 @@ TEST_F(Bytecode1, Attributes02) {
     // as calling the setter; reading the same as calling the getter.
     // Armor:: functions should be allowed to access _Damage.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Armor {                          \n\
             attribute int Damage;                       \n\
             writeprotected short _Aura;                 \n\
@@ -938,7 +938,7 @@ TEST_F(Bytecode1, Attributes03) {
     // so import decls should be generated for them.
     // The getters and setters should be called as import funcs.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Armor {                          \n\
             attribute int Damage;                       \n\
             writeprotected short _aura;                 \n\
@@ -1001,7 +1001,7 @@ TEST_F(Bytecode1, Attributes04) {
     
     // Attribute func was not called properly
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Character {      \n\
             import attribute int  x;            \n\
         };                                      \n\
@@ -1060,7 +1060,7 @@ TEST_F(Bytecode1, Attributes05) {
     
     // Test static attribute
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool                               \n\
         {                                       \n\
             false = 0,                          \n\
@@ -1123,7 +1123,7 @@ TEST_F(Bytecode1, Attributes06) {
     
     // Indexed static attribute -- must return an int
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Game             \n\
         {                                       \n\
             readonly import static attribute    \n\
@@ -1237,7 +1237,7 @@ TEST_F(Bytecode1, Attributes07) {
 
 TEST_F(Bytecode1, Attributes08) {
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed autoptr struct String           \n\
         {                                               \n\
             char Payload;                               \n\
@@ -1319,7 +1319,7 @@ TEST_F(Bytecode1, Attributes09) {
     // Function call to 'set_Visible()' mustn't go awry
     // After loading 'true' to AX´, must protect AX from being clobbered (push it)
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true };                  \n\
         builtin managed struct GUIControl               \n\
         {                                               \n\
@@ -1538,7 +1538,7 @@ TEST_F(Bytecode1, DynArrayOfPrimitives) {
     
     // Dynamic arrays of primitives are allowed.
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             short PrmArray[] = new short[10];   \n\
@@ -1585,7 +1585,7 @@ TEST_F(Bytecode1, DynArrayOfPrimitives) {
 TEST_F(Bytecode1, ManagedDerefZerocheck) {
     
     // Bytecode ought to check that S isn't initialized yet
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct           \n\
         {                               \n\
             int Int[10];                \n\
@@ -1637,7 +1637,7 @@ TEST_F(Bytecode1, MemInitPtr1) {
     
     // Check that pointer vars are pushed correctly in func calls
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct1          \n\
         {                               \n\
             float Payload1;             \n\
@@ -1715,7 +1715,7 @@ TEST_F(Bytecode1, Ternary1) {
     // Accept a simple ternary expression
     // The 'return' in line 4 isn't reachable
     
-    char *inpl = "\
+    const char *inpl = "\
     int Foo(int i)              \n\
     {                           \n\
         return i > 0 ? 1 : -1;  \n\
@@ -1763,7 +1763,7 @@ TEST_F(Bytecode1, Ternary2) {
     
     // Accept Elvis operator expression
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct Struct       \n\
     {                           \n\
         int Payload;            \n\
@@ -1822,7 +1822,7 @@ TEST_F(Bytecode1, Ternary3) {
     
     // Accept nested expression
 
-    char *inpl = "\
+    const char *inpl = "\
     int main()                  \n\
     {                           \n\
         int t1 = 15;            \n\

--- a/Compiler/test2/cc_bytecode_test_lib.cpp
+++ b/Compiler/test2/cc_bytecode_test_lib.cpp
@@ -300,7 +300,7 @@ void CompareStrings(AGS::ccCompiledScript *scrip, size_t stringssize, char strin
     }
 }
 
-void WriteOutput(char *fname, AGS::ccCompiledScript const &scrip)
+void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip)
 {
     std::string path = WRITE_PATH;
     std::ofstream of;

--- a/Compiler/test2/cc_bytecode_test_lib.h
+++ b/Compiler/test2/cc_bytecode_test_lib.h
@@ -7,7 +7,7 @@
 // Should contain a path to which the tests can write copies of their checking code
 constexpr char *WRITE_PATH = "C:/TEMP/";
 
-extern void WriteOutput(char *fname, AGS::ccCompiledScript const &scrip);
+extern void WriteOutput(const char *fname, AGS::ccCompiledScript const &scrip);
 
 extern void CompareCode(AGS::ccCompiledScript *scrip, size_t codesize, int32_t code[]);
 extern void CompareFixups(AGS::ccCompiledScript *scrip, size_t numfixups, int32_t fixups[], char fixuptypes[]);

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -71,7 +71,7 @@ TEST_F(Compile0, UnknownVartypeAfterReadonly) {
 
     // Must have a known vartype in struct
 
-    char *inpl = "\
+    const char *inpl = "\
         struct MyStruct     \n\
         {                   \n\
           readonly int2 a;  \n\
@@ -90,7 +90,7 @@ TEST_F(Compile0, DynamicArrayReturnValueErrorText) {
 
     // Can't convert DynamicSprite[] to int[]
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct DynamicSprite { };   \n\
                                             \n\
         int[] Func()                        \n\
@@ -112,7 +112,7 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
     // Note, AGS doesn't feature static struct variables.
     // Can only use one of "protected", "writeprotected" and "readonly".
 
-    char *inpl = "\
+    const char *inpl = "\
         struct BothOrders {                                 \n\
             protected static int something();               \n\
             static import readonly attribute int another;   \n\
@@ -127,7 +127,7 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
 
 TEST_F(Compile0, ParsingIntSuccess) {  
 
-    char *inpl = "\
+    const char *inpl = "\
         import  int  importedfunc(int data1 = 1, int data2=2, int data3=3); \n\
         int testfunc(int x ) { int y = 42; } \n\
         ";
@@ -140,7 +140,7 @@ TEST_F(Compile0, ParsingIntLimits) {
 
     // Note, 2147483648 will result in an overflow found by the scanner
 
-    char *inpl = "\
+    const char *inpl = "\
         import int int_limits(int param_min = -2147483647, int param_max = 2147483647); \n\
         int int_limits(int param_min, int param_max)    \n\
         {                                               \n\
@@ -155,7 +155,7 @@ TEST_F(Compile0, ParsingIntLimits) {
 
 TEST_F(Compile0, ParsingIntDefaultOverflowPositive) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         import int importedfunc(int data1 = 9999999999999999999999, int data2=2, int data3=3);    \n\
         ";
 
@@ -169,7 +169,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowPositive) {
 
 TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
 
-    char *inpl = "\
+    const char *inpl = "\
         import  int  importedfunc(int data1 = -9999999999999999999999, int data2=2, int data3=3);   \n\
         ";
 
@@ -182,7 +182,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
 
 TEST_F(Compile0, ParsingIntOverflow) {
     
-    char *inpl = "\
+    const char *inpl = "\
         int testfunc(int x ) { int y = 4200000000000000000000; }    \n\
         ";
 
@@ -195,7 +195,7 @@ TEST_F(Compile0, ParsingIntOverflow) {
 
 TEST_F(Compile0, ParsingNegIntOverflow) {
     
-    char *inpl = "\
+    const char *inpl = "\
         int testfunc(int x ) { int y = -4200000000000000000000; }   \n\
         ";
 
@@ -216,7 +216,7 @@ TEST_F(Compile0, EnumNegative) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    char *inpl = "\
+    const char *inpl = "\
         enum TestMyEnums {      \n\
             cat,                \n\
             dog,                \n\
@@ -267,7 +267,7 @@ TEST_F(Compile0, DefaultParametersLargeInts) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    char *inpl = "\
+    const char *inpl = "\
         import int importedfunc(    \n\
             int data1 = 0,          \n\
             int data2 = 1,          \n\
@@ -326,7 +326,7 @@ TEST_F(Compile0, ImportFunctionReturningDynamicArray) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    char *inpl = "\
+    const char *inpl = "\
         struct A                            \n\
         {                                   \n\
             import static int[] MyFunc();   \n\
@@ -349,7 +349,7 @@ TEST_F(Compile0, DoubleNegatedConstant) {
     
     // Parameter default can be evaluated at compile time
 
-    char *inpl = "\
+    const char *inpl = "\
         import int MyFunction(  \n\
             int data0 = - -69   \n\
             );                  \n\
@@ -361,7 +361,7 @@ TEST_F(Compile0, DoubleNegatedConstant) {
 
 TEST_F(Compile0, SubtractionWithoutSpaces) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int MyFunction()        \n\
         {                       \n\
             int data0 = 2-4;    \n\
@@ -374,7 +374,7 @@ TEST_F(Compile0, SubtractionWithoutSpaces) {
 
 TEST_F(Compile0, NegationLHSOfExpression) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         enum MyEnum         \n\
         {                   \n\
             cat             \n\
@@ -401,7 +401,7 @@ TEST_F(Compile0, NegationLHSOfExpression) {
 
 TEST_F(Compile0, NegationRHSOfExpression) {
 
-    char *inpl = "\
+    const char *inpl = "\
         enum MyEnum\
         {\
             cat\
@@ -431,7 +431,7 @@ TEST_F(Compile0, Writeprotected) {
     // Directly taken from the doc on writeprotected, simplified.
     // Should fail, no modifying of writeprotected components from the outside.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             writeprotected int Damage;         \n\
         };                                     \n\
@@ -456,7 +456,7 @@ TEST_F(Compile0, Protected1) {
     // Directly taken from the doc on protected, simplified.
     // Should fail, no reading protected components from the outside.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
         };                                     \n\
@@ -482,7 +482,7 @@ TEST_F(Compile0, Protected2) {
     // Is still an attempt to modify a protected component from the outside
     // ('this.Damage = 7;' or even 'Damage = 7;' would be legal, however.)
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int DoDamage();             \n\
@@ -506,7 +506,7 @@ TEST_F(Compile0, Protected3) {
 
     // Should succeed; protected is allowed for struct component functions.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -532,7 +532,7 @@ TEST_F(Compile0, Protected4) {
     
     // Should succeed
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -558,7 +558,7 @@ TEST_F(Compile0, Protected5) {
 
     // Should succeed; protected is allowed for extender functions.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -575,7 +575,7 @@ TEST_F(Compile0, Protected5) {
 
 TEST_F(Compile0, Do1Wrong) {    
 
-    char *inpl = "\
+    const char *inpl = "\
     void main()                     \n\
     {                               \n\
         do                          \n\
@@ -595,7 +595,7 @@ TEST_F(Compile0, Do2Wrong) {
 
     // Should balk because the "while" clause is missing.
 
-    char *inpl = "\
+    const char *inpl = "\
     void main()                     \n\
     {                               \n\
         int I;                      \n\
@@ -612,7 +612,7 @@ TEST_F(Compile0, Do2Wrong) {
 
 TEST_F(Compile0, Do3Wrong) {
     
-    char *inpl = "\
+    const char *inpl = "\
     void main()                     \n\
     {                               \n\
         int i;                      \n\
@@ -631,7 +631,7 @@ TEST_F(Compile0, Do3Wrong) {
 
 TEST_F(Compile0, Do4Wrong) {    
 
-    char *inpl = "\
+    const char *inpl = "\
     void main()                     \n\
     {                               \n\
         int i;                      \n\
@@ -652,7 +652,7 @@ TEST_F(Compile0, Protected0) {
 
     // Should fail, no modifying of protected components from the outside.
     
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int DoDamage();             \n\
@@ -676,7 +676,7 @@ TEST_F(Compile0, ParamVoid) {
 
     // Can't have a parameter of type 'void'.
 
-    char *inpl = "\
+    const char *inpl = "\
         int Foo(int bar, void bazz)            \n\
         {                                      \n\
             return 1;                          \n\
@@ -693,7 +693,7 @@ TEST_F(Compile0, LocalGlobalSeq2) {
 
     // Should garner a warning for line 7 because the re-definition hides the func
 
-    char *inpl = "\
+    const char *inpl = "\
         float Func(void) { return 7.7; }    \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -726,7 +726,7 @@ TEST_F(Compile0, VartypeLocalSeq1) {
 
     // Can't redefine a vartype as a local variable
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true, };     \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -744,7 +744,7 @@ TEST_F(Compile0, VartypeLocalSeq2) {
 
     // Can't redefine an enum constant as a local variable
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true };      \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -762,7 +762,7 @@ TEST_F(Compile0, StructMemberImport) {
 
     // Struct variables must not be 'import'
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Parent                   \n\
         {                               \n\
             import int Payload;         \n\
@@ -777,7 +777,7 @@ TEST_F(Compile0, StructMemberImport) {
 
 TEST_F(Compile0, StructExtend1) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Parent                   \n\
         {                               \n\
             int Payload;                \n\
@@ -796,7 +796,7 @@ TEST_F(Compile0, StructExtend1) {
 
 TEST_F(Compile0, StructExtend2) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Grandparent              \n\
         {                               \n\
             int Payload;                \n\
@@ -820,7 +820,7 @@ TEST_F(Compile0, StructExtend2) {
 
 TEST_F(Compile0, StructExtend3) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Parent           \n\
         {                               \n\
             int Wage;                   \n\
@@ -843,7 +843,7 @@ TEST_F(Compile0, StructExtend4) {
 
     // Can't assign Parent * to Child *: Parent doesn't necessarily have all the fields
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Parent           \n\
         {                               \n\
             int Wage;                   \n\
@@ -868,7 +868,7 @@ TEST_F(Compile0, StructStaticFunc) {
 
     // Okay, a struct that is being defined is automatically forward-declared
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct GUI {                          \n\
             import static GUI* GetAtScreenXY(int x, int y);   \n\
         };                                                    \n\
@@ -882,7 +882,7 @@ TEST_F(Compile0, StructForwardDeclare1) {
 
     // GUI is forward-defined, but the definition will show up later so this is okay.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct GUI;     \n\
         GUI *Var;               \n\
         managed struct GUI {    \n\
@@ -897,7 +897,7 @@ TEST_F(Compile0, StructForwardDeclare2) {
 
     // Forward-declared structs must be "managed".
 
-    char *inpl = "\
+    const char *inpl = "\
         struct GUI;     \n\
         ";
 
@@ -911,7 +911,7 @@ TEST_F(Compile0, StructForwardDeclare3) {
 
     // GUI only has a forward definition
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct GUI;     \n\
         GUI *Var;               \n\
         ";
@@ -927,7 +927,7 @@ TEST_F(Compile0, StructForwardDeclareNew) {
     // "new" on a forward-declared struct mustn't work
     // even when the struct is defined after the reference
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Bang;        \n\
         int main()                  \n\
         {                           \n\
@@ -950,7 +950,7 @@ TEST_F(Compile0, StructManaged1a)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Managed1 \n\
         { };                    \n\
         managed struct Managed  \n\
@@ -971,7 +971,7 @@ TEST_F(Compile0, StructManaged1b)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Managed1 \n\
         { };                    \n\
         managed struct Managed  \n\
@@ -991,7 +991,7 @@ TEST_F(Compile0, StructManaged2)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Managed  \n\
         {                       \n\
             int *compo;         \n\
@@ -1009,7 +1009,7 @@ TEST_F(Compile0, StructRecursiveComponent01)
     // Cannot have a component that has the same type as the struct;
     // this construct would be infinitively large
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Foo              \n\
         {                       \n\
             Foo magic;          \n\
@@ -1028,7 +1028,7 @@ TEST_F(Compile0, StructRecursiveComponent02)
     // Cannot have a component that has the same type as the struct;
     // this construct would be infinitively large
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Foo              \n\
         {                       \n\
             int magic;          \n\
@@ -1049,7 +1049,7 @@ TEST_F(Compile0, StructRecursiveComponent02)
 
 TEST_F(Compile0, Undefined) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         Supercalifragilisticexpialidocious! \n\
         ";
 
@@ -1062,7 +1062,7 @@ TEST_F(Compile0, Undefined) {
 
 TEST_F(Compile0, ImportOverride1) {
 
-    char *inpl = "\
+    const char *inpl = "\
     import int Func(int i = 5);     \n\
     int Func(int i)                 \n\
     {                               \n\
@@ -1081,7 +1081,7 @@ TEST_F(Compile0, DynamicNonManaged1) {
 
     // Dynamic array of non-managed struct not allowed
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1102,7 +1102,7 @@ TEST_F(Compile0, DynamicNonManaged2) {
 
     // Dynamic array of non-managed struct not allowed
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1123,7 +1123,7 @@ TEST_F(Compile0, DynamicNonManaged3) {
 
     // Dynamic array of non-managed struct not allowed
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1141,7 +1141,7 @@ TEST_F(Compile0, BuiltinStructMember) {
 
     // Builtin (non-managed) components not allowed 
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin struct Inner                                \n\
         {                                                   \n\
             short Fluff;                                    \n\
@@ -1160,7 +1160,7 @@ TEST_F(Compile0, BuiltinStructMember) {
 
 TEST_F(Compile0, ImportOverride2) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func(int i = 5);    \n\
         int Func(int i)         \n\
         {                       \n\
@@ -1176,7 +1176,7 @@ TEST_F(Compile0, ImportOverride2) {
 
 TEST_F(Compile0, ImportOverride3) {   
 
-    char *inpl = "\
+    const char *inpl = "\
     int Func(int i)                 \n\
     {                               \n\
         return 2 * i;               \n\
@@ -1195,7 +1195,7 @@ TEST_F(Compile0, LocalSeq1) {
 
     // The  { ... } must NOT invalidate Var1 but they MUST invalidate Var2.
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func()                 \n\
         {                           \n\
             int Var1 = 0;           \n\
@@ -1213,7 +1213,7 @@ TEST_F(Compile0, LocalSeq2) {
 
     // The  while() { ... } must NOT invalidate Var1 but MUST invalidate Var2.
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1231,7 +1231,7 @@ TEST_F(Compile0, LocalSeq3) {
     
     // The  do { ... } while() must NOT invalidate Var1 but MUST invalidate Var2.
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1249,7 +1249,7 @@ TEST_F(Compile0, LocalSeq4) {
    
     // The  for() { ... } must NOT invalidate Var1 but MUST invalidate Var2 and Var3.
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1271,7 +1271,7 @@ TEST_F(Compile0, LocalParameterSeq1) {
 
     // Must fail because definitions of I collide
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int I)                \n\
         {                               \n\
             int I;                      \n\
@@ -1288,7 +1288,7 @@ TEST_F(Compile0, LocalParameterSeq2) {
 
     // Fine
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int I)            \n\
         {                           \n\
             { int I; }              \n\
@@ -1301,7 +1301,7 @@ TEST_F(Compile0, LocalParameterSeq2) {
 
 TEST_F(Compile0, LocalGlobalSeq1) {   
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func()                     \n\
         {                               \n\
             short Var = 5;              \n\
@@ -1316,7 +1316,7 @@ TEST_F(Compile0, LocalGlobalSeq1) {
 
 TEST_F(Compile0, Void1) {
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Parser {                             \n\
 	        import static int    FindWordID(const string wordToFind);   \n\
 	        import static void   ParseText(const string text);      \n\
@@ -1335,7 +1335,7 @@ TEST_F(Compile0, Void1) {
 
 TEST_F(Compile0, RetLengthNoMatch) { 
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct GUI {                                \n\
             import void Centre();                                   \n\
             import static GUI* GetAtScreenXY(int x, int y);         \n\
@@ -1352,7 +1352,7 @@ TEST_F(Compile0, RetLengthNoMatch) {
 
 TEST_F(Compile0, ImportVar1) {    
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         int Var;            \n\
@@ -1365,7 +1365,7 @@ TEST_F(Compile0, ImportVar1) {
 
 TEST_F(Compile0, ImportVar2) {
     
-    char *inpl = "\
+    const char *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         int Var;            \n\
@@ -1382,7 +1382,7 @@ TEST_F(Compile0, ImportVar2) {
 
 TEST_F(Compile0, ImportVar3) {
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         short Var;          \n\
@@ -1397,7 +1397,7 @@ TEST_F(Compile0, ImportVar3) {
 
 TEST_F(Compile0, ImportVar4) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int Var;            \n\
         import int Var;     \n\
         ";
@@ -1413,7 +1413,7 @@ TEST_F(Compile0, ImportVar5) {
     // "import int Var" is treated as a forward declaration
     // for the "int Var" that follows, not as an import proper.
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Var;     \n\
         int main()          \n\
         {                   \n\
@@ -1431,7 +1431,7 @@ TEST_F(Compile0, ExtenderFuncDifference) {
     
     // Same func name, should be okay since they extend different structs
 
-    char *inpl = "\
+    const char *inpl = "\
         struct A            \n\
         {                   \n\
             int A_Payload;  \n\
@@ -1459,7 +1459,7 @@ TEST_F(Compile0, StaticFuncCall) {
     
     // Static function call, should work.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct GUI                                  \n\
         {                                                           \n\
             import static void ProcessClick(int x, int y, int z);   \n\
@@ -1480,7 +1480,7 @@ TEST_F(Compile0, Import2GlobalAllocation) {
     // Imported var I becomes a global var; must be allocated only once.
     // This means that J ought to be allocated at 4.
 
-    char *inpl = "\
+    const char *inpl = "\
         import int I;   \n\
         int I;          \n\
         int J;          \n\
@@ -1505,7 +1505,7 @@ TEST_F(Compile0, Import2GlobalAllocation) {
 
 TEST_F(Compile0, LocalImportVar) {
     
-    char *inpl = "\
+    const char *inpl = "\
         import int Var;     \n\
         int Var;            \n\
         export Var;         \n\
@@ -1620,7 +1620,7 @@ TEST_F(Compile0, Attributes01) {
     
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             float get_Flipped;                          \n\
@@ -1638,7 +1638,7 @@ TEST_F(Compile0, Attributes02) {
 
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             import bool get_Flipped(int Holzschuh);     \n\
@@ -1656,7 +1656,7 @@ TEST_F(Compile0, Attributes03) {
 
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             readonly import attribute bool Flipped;     \n\
@@ -1674,7 +1674,7 @@ TEST_F(Compile0, Attributes04) {
 
     // Components may have the same name as vartypes.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Character {  \n\
             readonly import attribute int Room;     \n\
         };                                  \n\
@@ -1697,7 +1697,7 @@ TEST_F(Compile0, Attributes05) {
 
     // Assignment to static attribute should call the setter.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Game {       \n\
             import static attribute int MinimumTextDisplayTimeMs;     \n\
         };                                  \n\
@@ -1716,7 +1716,7 @@ TEST_F(Compile0, Attributes06) {
 
     // Assignment to static indexed attribute
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Dialog {                             \n\
             readonly import attribute int OptionCount;              \n\
         };                                                          \n\
@@ -1742,7 +1742,7 @@ TEST_F(Compile0, Attributes07) {
     // Reading an import static attribute should not trigger
     //  a Not Declared error since it is declared.
 
-    char *inpl = "\
+    const char *inpl = "\
 		enum bool { false = 0, true };                              \n\
 		builtin managed struct Game {                               \n\
 			readonly import static attribute bool Foo;              \n\
@@ -1764,7 +1764,7 @@ TEST_F(Compile0, Attributes08) {
 
     // Accept a readonly attribute and a non-readonly getter
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1786,7 +1786,7 @@ TEST_F(Compile0, Attributes09) {
 
     // Do not accept a static attribute and a non-static getter
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1809,7 +1809,7 @@ TEST_F(Compile0, Attributes10) {
 
     // Call non-indexed attribute with index, is error
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1832,7 +1832,7 @@ TEST_F(Compile0, Attributes11) {
 
     // Call indexed attribute without index, is error
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1854,7 +1854,7 @@ TEST_F(Compile0, Attributes12) {
 
     // No local attributes
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1876,7 +1876,7 @@ TEST_F(Compile0, Attributes13) {
 
     // No attributes defined as 'static'
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1895,7 +1895,7 @@ TEST_F(Compile0, Attributes14) {
 
     // Setting a readonly attribute, is error
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1919,7 +1919,7 @@ TEST_F(Compile0, Attributes15) {
 
     // Setting a readonly attribute, is error
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1943,7 +1943,7 @@ TEST_F(Compile0, Attributes16) {
 
     // Import decls of autopointered variables must be processed correctly.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             import attribute int Graphic;   \n\
@@ -1964,7 +1964,7 @@ TEST_F(Compile0, Attributes17)
 
     // This attribute is type 'float' and assigned an 'int'. This should fail.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Character            \n\
         {                                           \n\
             import attribute float GraphicRotation; \n\
@@ -1986,7 +1986,7 @@ TEST_F(Compile0, StructPtrFunc) {
     // Func is ptr to managed, but it is a function not a variable
     // so ought to be let through.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct MS {     \n\
             MS *Func();         \n\
         };                      \n\
@@ -2005,7 +2005,7 @@ TEST_F(Compile0, StringOldstyle01) {
     // Can't return a local string because it will be already de-allocated when
     // the function returns
 
-    char *inpl = "\
+    const char *inpl = "\
         string MyFunction(int a)    \n\
         {                           \n\
             string x;               \n\
@@ -2025,7 +2025,7 @@ TEST_F(Compile0, StringOldstyle02) {
     
     // If a function expects a non-const string, it mustn't be passed a const string
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(string s)         \n\
         {                           \n\
             Func(\"Holzschuh\");    \n\
@@ -2045,7 +2045,7 @@ TEST_F(Compile0, StringOldstyle03) {
     // A string literal is a constant string, so you should not be able to
     // return it as a string.
 
-    char *inpl = "\
+    const char *inpl = "\
         string Func()                   \n\
         {                               \n\
             return \"Parameter\";       \n\
@@ -2065,7 +2065,7 @@ TEST_F(Compile0, ConstOldstringReturn)
     // A 'const string' should be a valid return
     // from a 'const string' function.
 
-    char *inpl = "\
+    const char *inpl = "\
         const string GetLiteral()       \n\
         {                               \n\
             return \"string literal\";  \n\
@@ -2081,7 +2081,7 @@ TEST_F(Compile0, ConstOldstringReturn2)
     // Must not pass a const string return as a
     // non-const parameter of another function.
 
-    char *inpl = "\
+    const char *inpl = "\
         import const string GetConstString();   \n\
         import void UseString(string s);        \n\
                                                 \n\
@@ -2100,7 +2100,7 @@ TEST_F(Compile0, StructPointerAttribute) {
 
     // It's okay for a managed struct to have a pointer import attribute.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct AudioClip {          \n\
             import void Stop();                     \n\
         };                                          \n\
@@ -2139,7 +2139,7 @@ TEST_F(Compile0, Decl) {
     // Should complain about the "+="
     // Note, there are many more legal possibilites than just "," ";" "=".
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()          \n\
         {                   \n\
             int Sum +=4;    \n\
@@ -2159,7 +2159,7 @@ TEST_F(Compile0, DynamicArrayCompare) {
     // The pointers, not the array components are compared.
     // May have a '*' after a struct defn.
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct               \n\
         {                                   \n\
         } *Arr1[];                          \n\
@@ -2182,7 +2182,7 @@ TEST_F(Compile0, DoubleLocalDecl) {
     // A local definition may hide an outer local definition or a global definition;
     // those will be uncovered when the scope of the local definition ends.
 
-    char *inpl = "\
+    const char *inpl = "\
         float Bang1 = 7.7;                              \n\
         int room_AfterFadeIn()                          \n\
         {                                               \n\
@@ -2205,7 +2205,7 @@ TEST_F(Compile0, NewEnumArray) {
     
     // dynamic array of enum should work
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool                               \n\
         {                                       \n\
             false = 0,                          \n\
@@ -2226,7 +2226,7 @@ TEST_F(Compile0, Readonly01) {
     
     // Declaring a readonly variable with initialization is okay.
 
-    char *inpl = "\
+    const char *inpl = "\
 		int room_RepExec()                  \n\
         {                                   \n\
             readonly int Constant = 835;    \n\
@@ -2241,7 +2241,7 @@ TEST_F(Compile0, Ternary01) {
 
     // case labels accept expressions in AGS, so ternary expressions should work, too.
 
-    char *inpl = "\
+    const char *inpl = "\
         void main()                     \n\
         {                               \n\
             int i = 15;                 \n\
@@ -2263,7 +2263,7 @@ TEST_F(Compile0, Ternary02) {
 
     // Values of ternary must have compatible vartypes
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                      \n\
         {                               \n\
             return 2 < 1 ? 1 : 2.0;     \n\
@@ -2283,7 +2283,7 @@ TEST_F(Compile0, FlowPointerExpressions1) {
     // The parenthesized expression after 'if', 'while', 'do ... while'
     // may evaluate to a pointer 
 
-    char *inpl = "\
+    const char *inpl = "\
         import builtin managed struct Character     \n\
         {                                           \n\
         } *player;                                  \n\
@@ -2307,7 +2307,7 @@ TEST_F(Compile0, FlowPointerExpressions2) {
 
     // The parenthesized expression after 'if' must not be float
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()              \n\
         {                       \n\
             if (1.0)            \n\
@@ -2325,7 +2325,7 @@ TEST_F(Compile0, FlowPointerExpressions3) {
 
     // The parenthesized expression after 'while' must not be float
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()              \n\
         {                       \n\
             while (0.0)         \n\
@@ -2343,7 +2343,7 @@ TEST_F(Compile0, FlowPointerExpressions4) {
 
     // The parenthesized expression after 'do ... while' must not be float
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()              \n\
         {                       \n\
             do                  \n\

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -35,7 +35,7 @@ TEST_F(Compile1, Sections) {
     // "__NEWSCRIPTSTART..." begins a line #0,
     // so the error must be reported on line 3.
 
-    char *inpl = "\
+    const char *inpl = "\
         \"__NEWSCRIPTSTART_globalscript.ash\"   \n\
         int main()                              \n\
         {                                       \n\
@@ -54,7 +54,7 @@ TEST_F(Compile1, Autoptr) {
 
     // String is autoptr so should not print as "String *"
 
-    char *inpl = "\
+    const char *inpl = "\
         managed autoptr builtin struct String   \n\
         {};                                     \n\
         int main()                              \n\
@@ -74,7 +74,7 @@ TEST_F(Compile1, BinaryNot)
 
     // '!' can't be binary
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = 15 ! 2;                   \n\
@@ -91,7 +91,7 @@ TEST_F(Compile1, UnaryDivideBy) {
 
     // '/' can't be unary
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = (/ 2);                    \n\
@@ -108,7 +108,7 @@ TEST_F(Compile1, UnaryPlus) {
 
     // '/' can't be unary
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return +42;                         \n\
@@ -124,7 +124,7 @@ TEST_F(Compile1, FloatInt1) {
 
     // Can't mix float and int
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = 4 / 2.0;                  \n\
@@ -141,7 +141,7 @@ TEST_F(Compile1, FloatInt2) {
 
     // Can't negate float
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = !2.0;                     \n\
@@ -158,7 +158,7 @@ TEST_F(Compile1, StringInt1) {
 
     // Can't mix string and int
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = (\"Holzschuh\" == 2);     \n\
@@ -175,7 +175,7 @@ TEST_F(Compile1, ExpressionVoid) {
 
     // Can't mix void
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -193,7 +193,7 @@ TEST_F(Compile1, ExpressionLoneUnary1) {
 
     // Unary -, nothing following
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -212,7 +212,7 @@ TEST_F(Compile1, ExpressionLoneUnary2) {
 
     // Unary ~, nothing following
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -231,7 +231,7 @@ TEST_F(Compile1, ExpressionBinaryWithoutRHS) {
 
     // Binary %, nothing following
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -248,7 +248,7 @@ TEST_F(Compile1, ExpressionBinaryWithoutRHS) {
 
 TEST_F(Compile1, LocalTypes1)
 {
-    char *inpl = "\
+    const char *inpl = "\
         void Test1()            \n\
         {                       \n\
             struct MyStruct     \n\
@@ -265,7 +265,7 @@ TEST_F(Compile1, LocalTypes1)
 
 TEST_F(Compile1, LocalTypes2)
 {
-    char *inpl = "\
+    const char *inpl = "\
         void Test1()            \n\
         {                       \n\
             enum Foo            \n\
@@ -284,7 +284,7 @@ TEST_F(Compile1, StaticArrayIndex1) {
 
     // Constant array index, is out ouf bounds
 
-    char *inpl = "\
+    const char *inpl = "\
         enum E                          \n\
         {                               \n\
             MinusFive = -5,             \n\
@@ -306,7 +306,7 @@ TEST_F(Compile1, StaticArrayIndex2) {
 
     // Constant array index, is out ouf bounds
 
-    char *inpl = "\
+    const char *inpl = "\
         enum E                          \n\
         {                               \n\
             MinusFive = -5,             \n\
@@ -328,7 +328,7 @@ TEST_F(Compile1, ExpressionArray1) {
 
     // Can't mix void
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -347,7 +347,7 @@ TEST_F(Compile1, FuncTypeClash1) {
 
     // Can't use func here except in a func call
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -368,7 +368,7 @@ TEST_F(Compile1, FloatOutOfBounds) {
 
     // Too small
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -389,7 +389,7 @@ TEST_F(Compile1, DoWhileSemicolon) {
 
     // ';' missing
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             int I = 1;                          \n\
@@ -409,7 +409,7 @@ TEST_F(Compile1, ExtenderExtender1) {
 
     // No extending a struct with a compound function
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct1                      \n\
         {                                   \n\
             void Func();                    \n\
@@ -432,7 +432,7 @@ TEST_F(Compile1, ExtenderExtender2) {
 
     // No extending a struct with a compound function
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct1                      \n\
         {                                   \n\
         };                                  \n\
@@ -452,7 +452,7 @@ TEST_F(Compile1, NonManagedStructParameter) {
 
     // Can't pass a non-managed struct as a function parameter
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct                           \n\
         {                                       \n\
         };                                      \n\
@@ -471,7 +471,7 @@ TEST_F(Compile1, StrangeParameterName) {
 
     // Can't use keyword as parameter name
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int while)                    \n\
         {                                       \n\
         }                                       \n\
@@ -487,7 +487,7 @@ TEST_F(Compile1, DoubleParameterName) {
 
     // Can't use keyword as parameter name
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int PI, float PI)             \n\
         {                                       \n\
         }                                       \n\
@@ -503,7 +503,7 @@ TEST_F(Compile1, FuncParamDefaults1) {
 
     // Either give no defaults or give them all
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int i = 5, float j = 6.0);    \n\
         void Func(int i = 5, float j)           \n\
         {                                       \n\
@@ -520,7 +520,7 @@ TEST_F(Compile1, FuncParamDefaults2) {
 
     // All parameters that follow a default parameter must have a default
 
-    char *inpl = "\
+    const char *inpl = "\
         import void Func(int i = 5, float j);   \n\
         ";
     
@@ -534,7 +534,7 @@ TEST_F(Compile1, FuncParamDefaults3) {
 
     // Can't give a parameter a default here, not a default there
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int i, float j);          \n\
         void Func(int i, float j = 6.0)     \n\
         {                                       \n\
@@ -551,7 +551,7 @@ TEST_F(Compile1, FuncParamDefaults4) {
 
     // Can't give a parameter differing defaults
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(float J = -6.0);              \n\
         void Func(float J = 6.0)                \n\
         {                                       \n\
@@ -568,7 +568,7 @@ TEST_F(Compile1, FuncParamNumber1) {
 
     // Differing number of parameters
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int, float);                  \n\
         void Func(int I, float J, short K)      \n\
         {                                       \n\
@@ -585,7 +585,7 @@ TEST_F(Compile1, FuncParamNumber2) {
 
     // Instantiation has number of parameters than is different from declaration
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Test                                         \n\
         {                                                   \n\
             import void Func(int a, int b, int c, int d);   \n\
@@ -606,7 +606,7 @@ TEST_F(Compile1, FuncVariadicCollision) {
 
     // Variadic / non-variadic
 
-    char *inpl = "\
+    const char *inpl = "\
         void Func(int, float, short, ...);      \n\
         void Func(int I, float J, short K)      \n\
         {                                       \n\
@@ -623,7 +623,7 @@ TEST_F(Compile1, FuncReturnVartypes) {
 
     // Return vartypes
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func(int, float, short);            \n\
         short Func(int I, float J, short K)     \n\
         {                                       \n\
@@ -640,7 +640,7 @@ TEST_F(Compile1, FuncReturnStruct1) {
 
     // Return vartype must be managed when it is a struct
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct {  };                     \n\
         Struct Func()                           \n\
         {                                       \n\
@@ -658,7 +658,7 @@ TEST_F(Compile1, FuncReturnStruct2) {
     // Compiler will imply the '*'
     // but should be slightly unhappy about the missing return statement
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct {  }; \n\
         Struct Func()               \n\
         {                           \n\
@@ -676,7 +676,7 @@ TEST_F(Compile1, FuncReturnStruct3) {
 
     // Compiler should be slightly unhappy about the missing return statement
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct {  };             \n\
         Struct[] Func()                         \n\
         {                                       \n\
@@ -695,7 +695,7 @@ TEST_F(Compile1, FuncReturn1) {
     // Should detect that the 'I' define can't be reached
     // Should not warn about a missing return at end of function body.
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Random(int); \n\
         float Func()            \n\
         {                       \n\
@@ -719,7 +719,7 @@ TEST_F(Compile1, FuncReturn2) {
     // Should detect that the 'I' assignment can't be reached
     // Should warn about a missing return at end of function body.
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Random(int); \n\
         float Func()            \n\
         {                       \n\
@@ -745,7 +745,7 @@ TEST_F(Compile1, FuncDouble) {
 
     // No two equally-named functions with body
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -764,7 +764,7 @@ TEST_F(Compile1, FuncProtected) {
 
     // Protected functions must be part of a struct
 
-    char *inpl = "\
+    const char *inpl = "\
         protected void Func(int I = 6)          \n\
         {                                       \n\
         }                                       \n\
@@ -780,7 +780,7 @@ TEST_F(Compile1, FuncNameClash1) {
 
     // Function name mustn't equal a variable name.
 
-    char *inpl = "\
+    const char *inpl = "\
         int Func;                               \n\
         void Func(int I = 6)                    \n\
         {                                       \n\
@@ -795,7 +795,7 @@ TEST_F(Compile1, FuncNameClash1) {
 
 TEST_F(Compile1, FuncDeclWrong1) {
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -828,7 +828,7 @@ TEST_F(Compile1, FuncDeclWrong1) {
 TEST_F(Compile1, FuncDeclWrong2) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -862,7 +862,7 @@ TEST_F(Compile1, FuncDeclReturnVartype) {
 
     // Should compile.
 
-    char *inpl = "\
+    const char *inpl = "\
     managed struct DynamicSprite                                    \n\
     {                                                               \n\
     };                                                              \n\
@@ -888,7 +888,7 @@ TEST_F(Compile1, FuncHeader1) {
 
     // Can't have a specific array size in func parameters
 
-    char *inpl = "\
+    const char *inpl = "\
         void main(int a[15])                   \n\
         {                                      \n\
              return;                           \n\
@@ -905,7 +905,7 @@ TEST_F(Compile1, FuncHeader2) {
 
     // Default for float parameter, an int value. Should fail
 
-    char *inpl = "\
+    const char *inpl = "\
         void Foo(float Param = 7);              \n\
         {                                      \n\
              return;                           \n\
@@ -921,7 +921,7 @@ TEST_F(Compile1, FuncHeader2) {
 TEST_F(Compile1, FuncHeader3) {
 
     // Integer default for managed parameter. Should fail
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Payload                  \n\
         {                                       \n\
             float foo;                          \n\
@@ -941,7 +941,7 @@ TEST_F(Compile1, FuncHeader3) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault1a) {
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -962,7 +962,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1b) {
 
     // A comma or paren should follow 'Weapon'
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -981,7 +981,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1b) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault1c) {
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -1000,7 +1000,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1c) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault2) {
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -1022,7 +1022,7 @@ TEST_F(Compile1, FuncDoubleExtender) {
 
     // Must not define a function with body twice.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Weapon {                         \n\
             int Damage;                         \n\
         };                                      \n\
@@ -1046,7 +1046,7 @@ TEST_F(Compile1, FuncDoubleExtender) {
 
 TEST_F(Compile1, FuncDoubleNonExtender) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int Foo(int Bar)                       \n\
         {                                      \n\
             return 1;                          \n\
@@ -1067,7 +1067,7 @@ TEST_F(Compile1, FuncUndeclaredStruct1) {
 
     // Should fail, Struct doesn't have Func
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct                       \n\
         {                                           \n\
             int Component;                          \n\
@@ -1088,7 +1088,7 @@ TEST_F(Compile1, FuncUndeclaredStruct2) {
 
     // Should succeed, Struct has Func
 
-    char *inpl = "\
+    const char *inpl = "\
         void Struct::Func(int Param)                \n\
         {                                           \n\
         }                                           \n\
@@ -1107,7 +1107,7 @@ TEST_F(Compile1, TypeEqComponent) {
 
     // A struct component may have the same name as a type.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Room             \n\
         {                                       \n\
         };                                      \n\
@@ -1127,7 +1127,7 @@ TEST_F(Compile1, ExtenderFuncClash) {
 
     // Don't remember the struct of extender functions past their definition (and body, if applicable)
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin struct Maths 							\n\
         { 												\n\
         }; 												\n\
@@ -1144,7 +1144,7 @@ TEST_F(Compile1, MissingSemicolonAfterStruct1) {
 
     // Missing ";" after struct declaration; isn't a var decl either
 
-    char *inpl = "\
+    const char *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1167,7 +1167,7 @@ TEST_F(Compile1, NewBuiltin1) {
 
     // Cannot do "new X;" when X is a builtin type
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct DynamicSprite            \n\
         {                                               \n\
         };                                              \n\
@@ -1195,7 +1195,7 @@ TEST_F(Compile1, NewArrayBuiltin1) {
     // Can do "new X[77];" when X is a builtin type because this will only
     // allocate a dynarray of pointers, not of X chunks
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct DynamicSprite            \n\
         {                                               \n\
         };                                              \n\
@@ -1222,7 +1222,7 @@ TEST_F(Compile1, MissingFunc) {
     // Must either import or define a function with body if you want to call it.
     // Also, check that the section is set correctly.
 
-    char *inpl = "\
+    const char *inpl = "\
 \"__NEWSCRIPTSTART_HauntedHouse\"                       \n\
         int main()                                      \n\
         {                                               \n\
@@ -1243,7 +1243,7 @@ TEST_F(Compile1, FixupMismatch) {
     // Code cells that have an "import" fixup must point to the corresponding imports.
     // (This used to fail in combination with linenumbers turned on)
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct InventoryItem    \n\
         {                                       \n\
             readonly int reserved[2];           \n\
@@ -1292,7 +1292,7 @@ TEST_F(Compile1, ComponentOfNonStruct1) {
     // If a '.' follows something other than a struct then complain about that fact.
     // Do not complain about expecting and not finding a component.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct MyStruct             \n\
         {                           \n\
             int i;                  \n\
@@ -1316,7 +1316,7 @@ TEST_F(Compile1, ComponentOfNonStruct2) {
     // If a '.' follows something other than a struct then complain about that fact.
     // Do not complain about expecting and not finding a component.
 
-    char *inpl = "\
+    const char *inpl = "\
         void Test()     \n\
         {               \n\
             int i;      \n\
@@ -1334,7 +1334,7 @@ TEST_F(Compile1, EmptySection) {
 
     // An empty last section should not result in an endless loop.
 
-    char *inpl = "\
+    const char *inpl = "\
 \"__NEWSCRIPTSTART_FOO\"     \n\
 \"__NEWSCRIPTSTART_BAR\"      \n\
         ";
@@ -1347,7 +1347,7 @@ TEST_F(Compile1, EmptySection) {
 TEST_F(Compile1, AutoptrDisplay) {
 
     // Autopointered types should not be shown with trailing ' ' in messages
-    char *inpl = "\
+    const char *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1367,7 +1367,7 @@ TEST_F(Compile1, ReadonlyObjectWritableAttribute)
 {
     // player is readonly, but player.InventoryQuantity[...] can be written to.
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Character                \n\
         {                                               \n\
             import attribute int InventoryQuantity[];   \n\
@@ -1389,7 +1389,7 @@ TEST_F(Compile1, ImportAutoptr1) {
 
     // Import decls of funcs with autopointered returns must be processed correctly.
 
-    char *inpl = "\
+    const char *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1411,7 +1411,7 @@ TEST_F(Compile1, ImportAutoptr2) {
 
     // Import decls of autopointered variables must be processed correctly.
 
-    char *inpl = "\
+    const char *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1429,7 +1429,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1)
 {
     // It is an error to assign a Dynpointer to a Dynarray variable
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1450,7 +1450,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1a)
 {
     // It is an error to assign a Dynpointer to a Dynarray variable
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1472,7 +1472,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch2)
 {
     // It is an error to assign a Dynarray to a Dynpointer variable
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1496,7 +1496,7 @@ TEST_F(Compile1, ZeroMemoryAllocation1)
     // to allocate. However, it _is_ legal to allocate a dynarray for the
     // struct. (Its elements could be initialized via other means than new.)
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -1516,7 +1516,7 @@ TEST_F(Compile1, ZeroMemoryAllocation2)
     // If a struct type doesn't contain any variables then there are zero
     // bytes to allocate. The Engine really doesn't like allocating 0 bytes
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -1537,7 +1537,7 @@ TEST_F(Compile1,ForwardStructManaged)
     // Forward-declared structs must be 'managed', so the
     // actual declaration must have the 'managed' keyword
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Object;              \n\
         struct Object                       \n\
         {                                   \n\
@@ -1638,7 +1638,7 @@ TEST_F(Compile1, BuiltinForbidden)
 {
     // Function names must not start with '__Builtin_'.
 
-    char *inpl = "\
+    const char *inpl = "\
         void __Builtin_TestFunc()   \n\
         {                           \n\
             return;                 \n\
@@ -1655,7 +1655,7 @@ TEST_F(Compile1, ReadonlyParameters1) {
     // Parameters may be declared "readonly" so that they cannot be
     // assigned to within the function.
 
-    char *inpl = "\
+    const char *inpl = "\
         int foo(readonly int bar)           \n\
         {                                   \n\
             bar++;                          \n\
@@ -1684,7 +1684,7 @@ TEST_F(Compile1, ReadonlyParameters2) {
     // "Readonly" does NOT imply "const".
     // All the assignments in the function should be allowed.
 
-    char *inpl = "\
+    const char *inpl = "\
         int ReadonlyTest2(readonly int ReadOnly)    \n\
         {                                   \n\
             readonly int A = ReadOnly;      \n\
@@ -1703,7 +1703,7 @@ TEST_F(Compile1, BinaryCompileTimeEval1) {
 
     // Checks binary compile time evaluations for integers.
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (4 + 3) / 0;                 \n\
@@ -1742,7 +1742,7 @@ TEST_F(Compile1, BinaryCompileTimeEval1) {
 TEST_F(Compile1, CTEvalIntPlus) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (4 + 3) / 0;                 \n\
@@ -1781,7 +1781,7 @@ TEST_F(Compile1, CTEvalIntPlus) {
 TEST_F(Compile1, CTEvalIntMinus) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (83 - 95) / 0;               \n\
@@ -1820,7 +1820,7 @@ TEST_F(Compile1, CTEvalIntMinus) {
 TEST_F(Compile1, CTEvalIntMultiply) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (33 * -39) / 0;              \n\
@@ -1859,7 +1859,7 @@ TEST_F(Compile1, CTEvalIntMultiply) {
 TEST_F(Compile1, CTEvalIntDivide) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (52 / 8) / 0;                \n\
@@ -1875,7 +1875,7 @@ TEST_F(Compile1, CTEvalIntDivide) {
 TEST_F(Compile1, CTEvalIntModulo) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (95 % 17) / 0;               \n\
@@ -1902,7 +1902,7 @@ TEST_F(Compile1, CTEvalIntModulo) {
 TEST_F(Compile1, CTEvalIntShiftLeft) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (60 << 3) / 0;               \n\
@@ -1966,7 +1966,7 @@ TEST_F(Compile1, CTEvalIntShiftLeft) {
 TEST_F(Compile1, CTEvalIntShiftRight) {
 
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (60 >> 3) / 0;               \n\
@@ -2019,7 +2019,7 @@ TEST_F(Compile1, CTEvalIntComparisons) {
 
     // Will fail as soon as any one of those comparisons go awry
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                          \n\
         {                                   \n\
             return                          \n\
@@ -2052,7 +2052,7 @@ TEST_F(Compile1, CTEvalIntComparisons) {
 
 TEST_F(Compile1, CTEvalBitOps) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                        \n\
         {                                 \n\
             return                        \n\
@@ -2079,7 +2079,7 @@ TEST_F(Compile1, CTEvalBitOps) {
 
 TEST_F(Compile1, CTEvalBitNeg) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                        \n\
         {                                 \n\
             return (~660753869) / 0;      \n\
@@ -2094,7 +2094,7 @@ TEST_F(Compile1, CTEvalBitNeg) {
 
 TEST_F(Compile1, CTEvalLogicalOps) {
 
-    char *inpl = "\
+    const char *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (  100000000 *   (!!7) +     \n\
@@ -2119,7 +2119,7 @@ TEST_F(Compile1, EnumConstantExpressions)
 {
     // Enum values to be evaluated at compile time
 
-    char *inpl = "\
+    const char *inpl = "\
         enum Bytes              \n\
         {                       \n\
             zero = 1 << 0,      \n\
@@ -2141,7 +2141,7 @@ TEST_F(Compile1, IncrementReadonly)
 {
     // No incrementing readonly vars
 
-    char *inpl = "\
+    const char *inpl = "\
         readonly int I;         \n\
                                 \n\
         int main() {            \n\
@@ -2158,7 +2158,7 @@ TEST_F(Compile1, SpuriousExpression)
 {
     // Warn that '77' doesn't have any effect
 
-    char *inpl = "\
+    const char *inpl = "\
         int main() {            \n\
             77;                 \n\
         }                       \n\
@@ -2172,7 +2172,7 @@ TEST_F(Compile1, SpuriousExpression)
 
 TEST_F(Compile1, CompileTimeConstant1)
 {
-    char *inpl = "\
+    const char *inpl = "\
         const int CI = 4711;                    \n\
         const float Euler = 2.718281828459045;  \n\
         const float AroundOne = Euler / Euler;  \n\
@@ -2185,7 +2185,7 @@ TEST_F(Compile1, CompileTimeConstant1)
 
 TEST_F(Compile1, CompileTimeConstant2)
 {
-    char *inpl = "\
+    const char *inpl = "\
         int main() {                            \n\
             while (1)                           \n\
             {                                   \n\
@@ -2201,7 +2201,7 @@ TEST_F(Compile1, CompileTimeConstant2)
 
 TEST_F(Compile1, CompileTimeConstant3)
 {
-    char *inpl = "\
+    const char *inpl = "\
         struct Str                          \n\
         {                                   \n\
             int stuff;                      \n\
@@ -2221,7 +2221,7 @@ TEST_F(Compile1, CompileTimeConstant3)
 
 TEST_F(Compile1, CompileTimeConstant4)
 {
-    char *inpl = "\
+    const char *inpl = "\
         import const int C = 42; \n\
         ";
     int compile_result = cc_compile(inpl, scrip);
@@ -2242,7 +2242,7 @@ TEST_F(Compile1, CompileTimeConstant5)
 {
     // Cannot define a compile-time constant of type 'short'
 
-    char *inpl = "\
+    const char *inpl = "\
         const short S = 42; \n\
         ";
     int compile_result = cc_compile(inpl, scrip);
@@ -2271,7 +2271,7 @@ TEST_F(Compile1, CompileTimeConstant5)
 
 TEST_F(Compile1, CompileTimeConstant6)
 {
-    char *inpl = "\
+    const char *inpl = "\
             const float pi = 3.14;  \n\
         int main() {                \n\
             float pi = 3.141;       \n\
@@ -2289,7 +2289,7 @@ TEST_F(Compile1, StaticThisExtender)
     // This declaration should be written
     //     "import int foo (static Struct);"
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Struct                   \n\
         {                                       \n\
             int Payload;                        \n\
@@ -2306,7 +2306,7 @@ TEST_F(Compile1, ReachabilityAndSwitch1)
 {
     // Mustn't complain about unreachable code at the end of a switch case
 
-    char *inpl = "\n\
+    const char *inpl = "\n\
         int main()          \n\
         {                   \n\
             int i;          \n\
@@ -2332,7 +2332,7 @@ TEST_F(Compile1, IfClauseFloat)
 {
     // Should complain that the if clause isn't vartype 'int'
 
-    char *inpl = "\
+    const char *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -2356,7 +2356,7 @@ TEST_F(Compile1, SideEffectExpression1)
     // the expression has a side effect.
     // Compiler shouldn't warn about an expression without side effects
 
-    char *inpl = "\
+    const char *inpl = "\
         builtin managed struct Character {              \n\
             int Payload;                                \n\
         };                                              \n\
@@ -2380,7 +2380,7 @@ TEST_F(Compile1, SideEffectExpression2)
     // that should have side effects.
     // Compiler should complain about 'SaveTheWorld;'
 
-    char *inpl = "\
+    const char *inpl = "\
         import int SaveTheWorld();      \n\
                                         \n\
         int game_start()                \n\
@@ -2400,7 +2400,7 @@ TEST_F(Compile1, SideEffectExpression3)
     // that should have side effects.
     // Compiler should complain about 'Initialize;' in the 'for' loop
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Initialize();        \n\
                                         \n\
         int game_start()                \n\
@@ -2421,7 +2421,7 @@ TEST_F(Compile1, SideEffectExpression4)
     // that should have side effects.
     // Compiler should complain about 'Increment' in the 'for' loop
 
-    char *inpl = "\
+    const char *inpl = "\
         import int Increment();         \n\
                                         \n\
         int game_start()                \n\
@@ -2439,7 +2439,7 @@ TEST_F(Compile1, DisallowStaticVariables)
 {
     // AGS does not have static variables.
 
-    char *inpl = "\
+    const char *inpl = "\
         struct Struct       \n\
         {                   \n\
             static int Var; \n\

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -106,7 +106,7 @@ TEST_F(Scan, ShortInputString1) {
 
     // String literal isn't ended
 
-    char *Input = "\"Supercalifragilisticexpialidocious";
+    const char *Input = "\"Supercalifragilisticexpialidocious";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -118,7 +118,7 @@ TEST_F(Scan, ShortInputString2) {
 
     // String literal isn't ended
 
-    char *Input = "\"Donaudampfschiffahrtskapitaen\\";
+    const char *Input = "\"Donaudampfschiffahrtskapitaen\\";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -130,7 +130,7 @@ TEST_F(Scan, ShortInputString3) {
 
     // String literal isn't ended
 
-    char *Input = "\"Aldiborontiphoscophornio!\nWhere left you...";
+    const char *Input = "\"Aldiborontiphoscophornio!\nWhere left you...";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -299,7 +299,7 @@ TEST_F(Scan, StringCollect)
 
 TEST_F(Scan, LiteralInt1)
 {
-    char *inp = "15 3 05 ";
+    const char *inp = "15 3 05 ";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -321,7 +321,7 @@ TEST_F(Scan, LiteralInt1)
 
 TEST_F(Scan, LiteralInt2)
 {
-    char *inp = "-2147483648";
+    const char *inp = "-2147483648";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -331,7 +331,7 @@ TEST_F(Scan, LiteralInt2)
 TEST_F(Scan, LiteralFloat)
 {
     //           0u 1u  2u  3u  4u   5u    6u   7u    8u   9u    10u
-    char *inp = "3. 3.0 0.0 0.3 33E5 3e-15 3.E5 3.E-5 .3E5 .3E-5 3.14E+2";
+    const char *inp = "3. 3.0 0.0 0.3 33E5 3e-15 3.E5 3.E-5 .3E5 .3E-5 3.14E+2";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -473,7 +473,7 @@ TEST_F(Scan, BackslashBracketInChar) {
 
     // Character literal '\[' is forbidden ('[' is okay)
 
-    char *Input = "int i = '\\[';";
+    const char *Input = "int i = '\\[';";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     scanner.Scan();
@@ -486,7 +486,7 @@ TEST_F(Scan, BackslashOctal1) {
 
     // "\19" is equivalent to "\1" + "9" because 9 isn't an octal digit
 
-    char *Input = "String s = \"Boom\\19 Box\";";
+    const char *Input = "String s = \"Boom\\19 Box\";";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -506,7 +506,7 @@ TEST_F(Scan, BackslashOctal2) {
     // '/' is just below the lowest digit '0'; "\7/" is equivalent to "\7" + "/"
     // Octal 444 is too large for a character, so this is equivalent to "\44" + "4"
 
-    char *Input = "String s = \"Boom\\7/Box\\444/Borg\";";
+    const char *Input = "String s = \"Boom\\7/Box\\444/Borg\";";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -523,7 +523,7 @@ TEST_F(Scan, BackslashOctal3) {
 
     // '\102' is 66 corresponds to 'B'; '\234' is 156u is -100
 
-    char *Input = "\"b\\102b\" '\\234'";
+    const char *Input = "\"b\\102b\" '\\234'";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
     
@@ -539,7 +539,7 @@ TEST_F(Scan, BackslashHex1) {
 
     // Expect a hex digit after '\x'
 
-    char *Input = "\"Le\\xicon\"";
+    const char *Input = "\"Le\\xicon\"";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -556,7 +556,7 @@ TEST_F(Scan, BackslashHex2) {
     // End hex when 'g' is encountered; that's directly after 'F'
     // End hex after two hex digits
 
-    char *Input = "\"He\\xA/meter \\xC@fe Nicolas C\\xAGE \\xFACE \"";
+    const char *Input = "\"He\\xA/meter \\xC@fe Nicolas C\\xAGE \\xFACE \"";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -571,7 +571,7 @@ TEST_F(Scan, BackslashOctHex) {
     
     // Test all combinations of upper and lower letters and numbers
 
-    char *Input =
+    const char *Input =
         "\" \\x19 \\x2a \\x3A \\xb4 \\xcd \\xeB \\xC5 \\xDf \\xEF \""
         "\" \\31 \\52 \\72 \\264 \\315 \\353 \\305 \\337 \\357 \"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
@@ -589,7 +589,7 @@ TEST_F(Scan, BackslashCSym) {
     
     // Test different symbol characters after '\'
 
-    char *Input = "\" Is \\'Java\\' \\equal to \\\"Ja\\va\\\" \\? \"";
+    const char *Input = "\" Is \\'Java\\' \\equal to \\\"Ja\\va\\\" \\? \"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -602,7 +602,7 @@ TEST_F(Scan, BackslashBackslash) {
     
     // Backslash Backslash in strings or char literals converts to backslash.
 
-    char *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
+    const char *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -634,7 +634,7 @@ TEST_F(Scan, UnknownKeywordAfterReadonly) {
     // Now, semantic struct parsing has been completely relocated into the parser,
     // and thus this sequence should not pose problems.
 
-    char *inpl =   "struct MyStruct \
+    const char *inpl =   "struct MyStruct \
                     {\
                       readonly int2 a; \
                       readonly int2 b; \
@@ -756,7 +756,7 @@ TEST_F(Scan, MatchBraceParen5)
     // The scanner checks that nested (), [], {} match.
     // Opener without closer
 
-    char *Input = "\
+    const char *Input = "\
             struct MyStruct \n\
             {               \n\
                 int i;      \n\
@@ -778,7 +778,7 @@ TEST_F(Scan, MatchBraceParen6)
     // The scanner checks that nested (), [], {} match.
     // Opener without closer
 
-    char *Input = "\
+    const char *Input = "\
             struct MyStruct \n\
             {               \n\
                 int i;      \n\
@@ -817,7 +817,7 @@ TEST_F(Scan, ConsecutiveStringLiterals2)
     // Literals that start with __NEWSCRIPTSTART_ are section start markers
     // and must NOT be concatenated.
 
-    char *input = " \
+    const char *input = " \
         \"__NEWSCRIPTSTART_File1\" \
         \"xyzzy\" \
         \"__NEWSCRIPTSTART_File2\" \


### PR DESCRIPTION
Mostly affecting compiler2 tests.