### PR TITLE
AGS 4: new compiler: fixed int32 limit tests

### DIFF
--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -138,13 +138,11 @@ TEST_F(Compile0, ParsingIntSuccess) {
 
 TEST_F(Compile0, ParsingIntLimits) {    
 
-    // Note, 2147483648 will result in an overflow found by the scanner
-
     const char *inpl = "\
-        import int int_limits(int param_min = -2147483647, int param_max = 2147483647); \n\
+        import int int_limits(int param_min = -2147483648, int param_max = 2147483647); \n\
         int int_limits(int param_min, int param_max)    \n\
         {                                               \n\
-            int var_min = - 2147483647;                 \n\
+            int var_min = -2147483648;                  \n\
             int var_max = 2147483647;                   \n\
         }\
         ";
@@ -228,7 +226,7 @@ TEST_F(Compile0, EnumNegative) {
             x,                  \n\
             y,                  \n\
             z,                  \n\
-            intmin=-2147483647, \n\
+            intmin=-2147483648, \n\
             intmax=2147483647   \n\
         };\
         ";
@@ -252,8 +250,7 @@ TEST_F(Compile0, EnumNegative) {
     EXPECT_EQ(sym.Find("-1"), sym.entries.at(sym.Find("y")).ConstantD->ValueSym);
     EXPECT_EQ(sym.Find("0"), sym.entries.at(sym.Find("z")).ConstantD->ValueSym);
 
-    // Note: -2147483648 makes the scanner (!) find an int overflow.
-    EXPECT_EQ(sym.Find("-2147483647"), sym.entries.at(sym.Find("intmin")).ConstantD->ValueSym);
+    EXPECT_EQ(sym.Find("-2147483648"), sym.entries.at(sym.Find("intmin")).ConstantD->ValueSym);
     EXPECT_EQ(sym.Find("2147483647"), sym.entries.at(sym.Find("intmax")).ConstantD->ValueSym);
 }
 
@@ -275,7 +272,7 @@ TEST_F(Compile0, DefaultParametersLargeInts) {
             int data4 = -32000,     \n\
             int  = 32001,           \n\
             int data6 = 2147483647, \n\
-            int data7 = -2147483647 , \n\
+            int data7 = -2147483648 , \n\
             int data8 = -1,         \n\
             int data9 = -2          \n\
             );                      \n\
@@ -307,7 +304,7 @@ TEST_F(Compile0, DefaultParametersLargeInts) {
     EXPECT_EQ(sym.Find("2147483647"), sym.entries.at(funcidx).FunctionD->Parameters[6].Default);
 
     EXPECT_EQ(AGS::kKW_Int, sym.entries.at(funcidx).FunctionD->Parameters[7].Vartype);
-    EXPECT_EQ(sym.Find("-2147483647"), sym.entries.at(funcidx).FunctionD->Parameters[7].Default);
+    EXPECT_EQ(sym.Find("-2147483648"), sym.entries.at(funcidx).FunctionD->Parameters[7].Default);
 
     EXPECT_EQ(AGS::kKW_Int, sym.entries.at(funcidx).FunctionD->Parameters[8].Vartype);
     EXPECT_EQ(sym.Find("-1"), sym.entries.at(funcidx).FunctionD->Parameters[8].Default);

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -204,6 +204,33 @@ TEST_F(Compile0, ParsingNegIntOverflow) {
     EXPECT_NE(std::string::npos, res.find("4200000000000000000000"));
 }
 
+TEST_F(Compile0, ParsingHexSuccess) {
+
+    const char *inpl = "\
+        import  int  importedfunc(int data1 = 0x01, int data2=0x20, int data3=0x400); \n\
+        int testfunc(int x ) { int y = 0xABCDEF; int z = 0xabcdef; } \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+}
+
+TEST_F(Compile0, ParsingHexLimits) {
+    // Try some edge values (convert to INT32_MAX, INT32_MIN and -1)
+    const char *inpl = "\
+        import int int_limits(int param_hex1 = 0x7FFFFFFF, int param_hex2 = 0x80000000, int param_hex3 = 0xFFFFFFFF); \n\
+        int int_limits(int param_hex1, int param_hex2, int param_hex3) \n\
+        {                                               \n\
+            int var_hex1 = 0x7FFFFFFF;                  \n\
+            int var_hex2 = 0x80000000;                  \n\
+            int var_hex3 = 0xFFFFFFFF;                  \n\
+        }\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+}
+
 TEST_F(Compile0, EnumNegative) {
     
     std::vector<AGS::Symbol> tokens;

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -352,6 +352,23 @@ TEST_F(Scan, LiteralIntOverflow)
     ASSERT_TRUE(mh.HasError());
 }
 
+TEST_F(Scan, LiteralIntHex)
+{
+    const char *inp = "0x7FFFFFFF 0xFFFFFFFF";
+
+    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    scanner.Scan();
+    EXPECT_FALSE(mh.HasError());
+
+    AGS::Symbol const lit_hex1 = token_list[0u];
+    ASSERT_TRUE(sym.IsLiteral(lit_hex1));
+    EXPECT_EQ(INT32_MAX, sym[lit_hex1].LiteralD->Value);
+
+    AGS::Symbol const lit_hex2 = token_list[1u];
+    ASSERT_TRUE(sym.IsLiteral(lit_hex2));
+    EXPECT_EQ(-1, sym[lit_hex2].LiteralD->Value);
+}
+
 TEST_F(Scan, LiteralFloat)
 {
     //           0u 1u  2u  3u  4u   5u    6u   7u    8u   9u    10u

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -319,12 +319,36 @@ TEST_F(Scan, LiteralInt1)
     EXPECT_EQ(5, sym[lit05].LiteralD->Value);
 }
 
-TEST_F(Scan, LiteralInt2)
+TEST_F(Scan, LiteralIntLimits)
 {
-    const char *inp = "-2147483648";
+    // Should correctly parse INT32_MAX and INT32_MIN
+    const char *inp1 = "-2147483648 2147483647";
 
-    AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
+    AGS::Scanner scanner(inp1, token_list, string_collector, sym, mh);
     scanner.Scan();
+    EXPECT_FALSE(mh.HasError());
+
+    AGS::Symbol const lit_min = token_list[1u]; // 0u is '-'
+    ASSERT_TRUE(sym.IsLiteral(lit_min));
+    EXPECT_EQ(INT32_MIN, sym[lit_min].LiteralD->Value);
+
+    AGS::Symbol const lit_max = token_list[2u];
+    ASSERT_TRUE(sym.IsLiteral(lit_max));
+    EXPECT_EQ(INT32_MAX, sym[lit_max].LiteralD->Value);
+}
+
+TEST_F(Scan, LiteralIntOverflow)
+{
+    // Should detect int32 overflow
+    const char *inp1 = "-2147483649";
+    const char *inp2 = "2147483648";
+
+    AGS::Scanner scanner1(inp1, token_list, string_collector, sym, mh);
+    scanner1.Scan();
+    ASSERT_TRUE(mh.HasError());
+
+    AGS::Scanner scanner2(inp2, token_list, string_collector, sym, mh);
+    scanner2.Scan();
     ASSERT_TRUE(mh.HasError());
 }
 


### PR DESCRIPTION
There has been some kind of a mistake in the new compiler's Scanner class that resulted in the incorrect parsing and/or testing of int32 negative limit (see #1674). Unfortunately, the tests were adjusted to comply for this incorrect behavior, which is quite a wrong thing to do, in my opinion. A recent commit (53538101712f81359a4b4162e1142bb4f0c875bb) fixed one problem in practice, but introduced new ones, and some tests no longer work.

In order to introduce some clarity to this, I suggest correcting the tests first. Note that "Scan.LiteralIntOverflow" test does not work correctly after (53538101712f81359a4b4162e1142bb4f0c875bb), while "Scan.LiteralIntLimits" won't work if that commit would be reverted.

In addition this adds hexadecimal test for the scanner.