### PR TITLE
Editor: Welcome pane adjust Upgrading To for 3.6 version

### DIFF
--- a/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.Designer.cs
@@ -149,7 +149,7 @@ namespace AGS.Editor
             this.lblUpgradingInfo.Name = "lblUpgradingInfo";
             this.lblUpgradingInfo.Size = new System.Drawing.Size(298, 28);
             this.lblUpgradingInfo.TabIndex = 2;
-            this.lblUpgradingInfo.Text = "With AGS 3.5 you can have multiple game cameras!";
+            this.lblUpgradingInfo.Text = "With AGS 3.6 you can build your game for Web!";
             // 
             // lnkUpgrading
             // 
@@ -173,7 +173,7 @@ namespace AGS.Editor
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(154, 14);
             this.label5.TabIndex = 0;
-            this.label5.Text = "What\'s new in AGS 3.5?";
+            this.label5.Text = "What\'s new in AGS 3.6?";
             // 
             // pnlTipOfTheDay
             // 

--- a/Editor/AGS.Editor/Panes/WelcomePane.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.cs
@@ -47,7 +47,7 @@ namespace AGS.Editor
 
         private void lnkUpgrading_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            _guiContoller.LaunchHelpForKeyword("Upgrading to AGS 3.5");
+            _guiContoller.LaunchHelpForKeyword("Upgrading to AGS 3.6");
         }
 
         private void WelcomePane_Resize(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/WelcomePane.resx
+++ b/Editor/AGS.Editor/Panes/WelcomePane.resx
@@ -118,18 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="lblUpgradingInfo3.Text" xml:space="preserve">
-    <value>Some of the new features in AGS 3.5 include:
-* A new Viewport and Camera system that lets you scale and translate your player's view of a room
-* An updated room editor with multilayer editing modes
-* Rooms can now be smaller than the game's resolution
-* An improved sprite importer allows source image reloading from spritesheets
-* Support for packed sprite files which are larger than 2GB in size
-* New script types Dictionary and Set
-* Updated game templates
+    <value>Some of the new features in AGS 3.6 include:
+* Engine backend now uses SDL2
+* Unicode support
+* New game package options
+* Multiple speech voxes
+* New sprite compression options
+* Multiplatform support extended
+* New Room Overlays and Overlays properties
+* Room objects limit increased
 * And loads more!
 </value>
   </data>
   <data name="lnkUpgrading.Text" xml:space="preserve">
-    <value>If you've come from a much older version of AGS (especially from AGS 2.72 and earlier) be sure to read "Upgrading to ..." articles in the manual. "Upgrading to AGS 3.5" page gives insight into most important changes in current version.</value>
+    <value>If you've come from a much older version of AGS (especially from AGS 2.72 and earlier) be sure to read "Upgrading to ..." articles in the manual. "Upgrading to AGS 3.6" page gives insight into most important changes in current version.</value>
   </data>
 </root>


### PR DESCRIPTION
Adjusts the Welcome pane for AGS 3.6! :)

When I was looking for where the Welcome pane was, I found a version list which I don't know if it should be updated or not, here:
https://github.com/adventuregamestudio/ags/blob/1c51caf1e8ddd33cff2aa2e6dd2eb55abe562786/Editor/AGS.Types/Game.cs#L1176