### PR TITLE
3.6.0: don't store script object pointers in the game objects

### DIFF
--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -262,9 +262,8 @@ PViewport GameState::CreateRoomViewport()
     PViewport viewport(new Viewport());
     viewport->SetID(index);
     viewport->SetRect(_mainViewport.GetRect());
-    ScriptViewport *scv = new ScriptViewport(index);
     _roomViewports.push_back(viewport);
-    _scViewportRefs.push_back(std::make_pair(scv, 0));
+    _scViewportHandles.push_back(0);
     _roomViewportsSorted.push_back(viewport);
     _roomViewportZOrderChanged = true;
     on_roomviewport_created(index);
@@ -275,18 +274,18 @@ ScriptViewport *GameState::RegisterRoomViewport(int index, int32_t handle)
 {
     if (index < 0 || (size_t)index >= _roomViewports.size())
         return nullptr;
-    auto &scobj = _scViewportRefs[index];
+    auto scview = new ScriptViewport(index);
     if (handle == 0)
     {
-        handle = ccRegisterManagedObject(scobj.first, scobj.first);
+        handle = ccRegisterManagedObject(scview, scview);
         ccAddObjectReference(handle); // one reference for the GameState
     }
     else
     {
-        ccRegisterUnserializedObject(handle, scobj.first, scobj.first);
+        ccRegisterUnserializedObject(handle, scview, scview);
     }
-    scobj.second = handle;
-    return scobj.first;
+    _scViewportHandles[index] = handle; // save handle for us
+    return scview;
 }
 
 void GameState::DeleteRoomViewport(int index)
@@ -294,18 +293,23 @@ void GameState::DeleteRoomViewport(int index)
     // NOTE: viewport 0 can not be deleted
     if (index <= 0 || (size_t)index >= _roomViewports.size())
         return;
-    auto scobj = _scViewportRefs[index];
-    scobj.first->Invalidate();
-    ccReleaseObjectReference(scobj.second);
+    auto handle = _scViewportHandles[index];
+    auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
+    if (scobj)
+        scobj->Invalidate();
+    ccReleaseObjectReference(handle);
     auto cam = _roomViewports[index]->GetCamera();
     if (cam)
         cam->UnlinkFromViewport(index);
     _roomViewports.erase(_roomViewports.begin() + index);
-    _scViewportRefs.erase(_scViewportRefs.begin() + index);
+    _scViewportHandles.erase(_scViewportHandles.begin() + index);
     for (size_t i = index; i < _roomViewports.size(); ++i)
     {
         _roomViewports[i]->SetID(i);
-        _scViewportRefs[i].first->SetID(i);
+        handle = _scViewportHandles[index];
+        auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
+        if (scobj)
+            scobj->SetID(i);
     }
     for (size_t i = 0; i < _roomViewportsSorted.size(); ++i)
     {
@@ -331,7 +335,7 @@ PCamera GameState::CreateRoomCamera()
     camera->SetAt(0, 0);
     camera->SetSize(_mainViewport.GetRect().GetSize());
     ScriptCamera *scam = new ScriptCamera(index);
-    _scCameraRefs.push_back(std::make_pair(scam, 0));
+    _scCameraHandles.push_back(0);
     _roomCameras.push_back(camera);
     return camera;
 }
@@ -340,18 +344,18 @@ ScriptCamera *GameState::RegisterRoomCamera(int index, int32_t handle)
 {
     if (index < 0 || (size_t)index >= _roomCameras.size())
         return nullptr;
-    auto &scobj = _scCameraRefs[index];
+    auto sccamera = new ScriptCamera(index);
     if (handle == 0)
     {
-        handle = ccRegisterManagedObject(scobj.first, scobj.first);
+        handle = ccRegisterManagedObject(sccamera, sccamera);
         ccAddObjectReference(handle); // one reference for the GameState
     }
     else
     {
-        ccRegisterUnserializedObject(handle, scobj.first, scobj.first);
+        ccRegisterUnserializedObject(handle, sccamera, sccamera);
     }
-    scobj.second = handle;
-    return scobj.first;
+    _scCameraHandles[index] = handle;
+    return sccamera;
 }
 
 void GameState::DeleteRoomCamera(int index)
@@ -359,9 +363,11 @@ void GameState::DeleteRoomCamera(int index)
     // NOTE: camera 0 can not be deleted
     if (index <= 0 || (size_t)index >= _roomCameras.size())
         return;
-    auto scobj = _scCameraRefs[index];
-    scobj.first->Invalidate();
-    ccReleaseObjectReference(scobj.second);
+    auto handle = _scCameraHandles[index];
+    auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
+    if (scobj)
+        scobj->Invalidate();
+    ccReleaseObjectReference(handle);
     for (auto& viewref : _roomCameras[index]->GetLinkedViewports())
     {
         auto view = viewref.lock();
@@ -369,11 +375,14 @@ void GameState::DeleteRoomCamera(int index)
             view->LinkCamera(nullptr);
     }
     _roomCameras.erase(_roomCameras.begin() + index);
-    _scCameraRefs.erase(_scCameraRefs.begin() + index);
+    _scCameraHandles.erase(_scCameraHandles.begin() + index);
     for (size_t i = index; i < _roomCameras.size(); ++i)
     {
         _roomCameras[i]->SetID(i);
-        _scCameraRefs[i].first->SetID(i);
+        handle = _scCameraHandles[index];
+        auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
+        if (scobj)
+            scobj->SetID(i);
     }
 }
 
@@ -385,15 +394,15 @@ int GameState::GetRoomCameraCount() const
 ScriptViewport *GameState::GetScriptViewport(int index)
 {
     if (index < 0 || (size_t)index >= _roomViewports.size())
-        return NULL;
-    return _scViewportRefs[index].first;
+        return nullptr;
+    return (ScriptViewport*)ccGetObjectAddressFromHandle(_scViewportHandles[index]);
 }
 
 ScriptCamera *GameState::GetScriptCamera(int index)
 {
     if (index < 0 || (size_t)index >= _roomCameras.size())
-        return NULL;
-    return _scCameraRefs[index].first;
+        return nullptr;
+    return (ScriptCamera*)ccGetObjectAddressFromHandle(_scCameraHandles[index]);
 }
 
 bool GameState::IsIgnoringInput() const
@@ -879,19 +888,23 @@ void GameState::FreeViewportsAndCameras()
 {
     _roomViewports.clear();
     _roomViewportsSorted.clear();
-    for (auto &scobj : _scViewportRefs)
+    for (auto handle : _scViewportHandles)
     {
-        scobj.first->Invalidate();
-        ccReleaseObjectReference(scobj.second);
+        auto scview = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
+        if (scview)
+            scview->Invalidate();
+        ccReleaseObjectReference(handle);
     }
-    _scViewportRefs.clear();
+    _scViewportHandles.clear();
     _roomCameras.clear();
-    for (auto &scobj : _scCameraRefs)
+    for (auto handle : _scCameraHandles)
     {
-        scobj.first->Invalidate();
-        ccReleaseObjectReference(scobj.second);
+        auto sccam = (ScriptCamera*)ccGetObjectAddressFromHandle(handle);
+        if (sccam)
+            sccam->Invalidate();
+        ccReleaseObjectReference(handle);
     }
-    _scCameraRefs.clear();
+    _scCameraHandles.clear();
 }
 
 void GameState::ReadCustomProperties_v340(Common::Stream *in)

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -40,8 +40,8 @@ extern ScriptSystem scsystem;
 
 GameState::GameState()
 {
-    speech_text_scover = nullptr;
-    speech_face_scover = nullptr;
+    speech_text_schandle = 0;
+    speech_face_schandle = 0;
     _isAutoRoomViewport = true;
     _mainViewportHasChanged = false;
 }
@@ -296,8 +296,10 @@ void GameState::DeleteRoomViewport(int index)
     auto handle = _scViewportHandles[index];
     auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
     if (scobj)
+    {
         scobj->Invalidate();
-    ccReleaseObjectReference(handle);
+        ccReleaseObjectReference(handle);
+    }
     auto cam = _roomViewports[index]->GetCamera();
     if (cam)
         cam->UnlinkFromViewport(index);
@@ -366,8 +368,10 @@ void GameState::DeleteRoomCamera(int index)
     auto handle = _scCameraHandles[index];
     auto scobj = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
     if (scobj)
+    {
         scobj->Invalidate();
-    ccReleaseObjectReference(handle);
+        ccReleaseObjectReference(handle);
+    }
     for (auto& viewref : _roomCameras[index]->GetLinkedViewports())
     {
         auto view = viewref.lock();
@@ -892,8 +896,10 @@ void GameState::FreeViewportsAndCameras()
     {
         auto scview = (ScriptViewport*)ccGetObjectAddressFromHandle(handle);
         if (scview)
+        {
             scview->Invalidate();
-        ccReleaseObjectReference(handle);
+            ccReleaseObjectReference(handle);
+        }
     }
     _scViewportHandles.clear();
     _roomCameras.clear();
@@ -901,8 +907,10 @@ void GameState::FreeViewportsAndCameras()
     {
         auto sccam = (ScriptCamera*)ccGetObjectAddressFromHandle(handle);
         if (sccam)
+        {
             sccam->Invalidate();
-        ccReleaseObjectReference(handle);
+            ccReleaseObjectReference(handle);
+        }
     }
     _scCameraHandles.clear();
 }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -393,11 +393,10 @@ private:
     std::vector<PViewport> _roomViewportsSorted;
     // Cameras defines the position of a "looking eye" inside the room.
     std::vector<PCamera> _roomCameras;
-    // Script viewports and cameras are references to real data export to
-    // user script. They became invalidated as the actual object gets
-    // destroyed, but are kept in memory to prevent script errors.
-    std::vector<std::pair<ScriptViewport*, int32_t>> _scViewportRefs;
-    std::vector<std::pair<ScriptCamera*, int32_t>> _scCameraRefs;
+    // We keep handles to the script refs to viewports and cameras, so that we
+    // could address them and invalidate as the actual object gets destroyed.
+    std::vector<int32_t> _scViewportHandles;
+    std::vector<int32_t> _scCameraHandles;
 
     // Tells that the main viewport's position has changed since last game update
     bool  _mainViewportHasChanged;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -243,12 +243,12 @@ struct GameState {
     int  complete_overlay_on;
     // Is there a blocking text overlay on screen (contains overlay ID)
     int  text_overlay_on;
-    // Script overlay objects, because we must return same pointers
+    // Script overlay handles, because we must return same script objects
     // whenever user script queries for them.
-    // Blocking speech overlay managed object, for accessing in scripts
-    ScriptOverlay *speech_text_scover;
-    // Speech portrait overlay managed object
-    ScriptOverlay *speech_face_scover;
+    // Blocking speech overlay managed handle
+    int  speech_text_schandle;
+    // Speech portrait overlay managed handle
+    int  speech_face_schandle;
 
     int shake_screen_yoff; // y offset of the shaking screen
 

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -163,6 +163,7 @@ String get_voice_assetpath()
 #include "ac/gamestate.h"
 #include "ac/global_audio.h"
 #include "ac/global_display.h"
+#include "ac/dynobj/cc_dynamicobject.h"
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
@@ -172,12 +173,12 @@ extern GameState play;
 
 ScriptOverlay* Speech_GetTextOverlay()
 {
-    return play.speech_text_scover;
+    return (ScriptOverlay*)ccGetObjectAddressFromHandle(play.speech_text_schandle);
 }
 
 ScriptOverlay* Speech_GetPortraitOverlay()
 {
-    return play.speech_face_scover;
+    return (ScriptOverlay*)ccGetObjectAddressFromHandle(play.speech_face_schandle);
 }
 
 RuntimeScriptValue Sc_Speech_GetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)


### PR DESCRIPTION
Presumably fixes #1678

This is a purely internal change. Engine currently keeps pointers to some types of script managed objects (which are merely wrappers over real object IDs) for easier internal use, but it is not really safe, as these objects may be forcedly disposed when deleting script data. Therefore this is not correct.

Affected object types are: Viewport, Camera and Overlay.

This change replaces the direct pointers to script objects with managed handles. Whenever engine needs to access these there's one extra step now, which safely retrieves a script object by handle and tests for result. But this operation is fast, and occurances are relatively rare, so should not be a problem.