### PR TITLE
Engine: also include agsshell in ags_shell stub check

### DIFF
--- a/Engine/plugin/global_plugin.cpp
+++ b/Engine/plugin/global_plugin.cpp
@@ -64,9 +64,9 @@ bool RegisterPluginStubs(const char* name)
   bool is_agsgalaxy = (ags_stricmp(name, "agsgalaxy") == 0) || (ags_stricmp(name, "agsgalaxy-unified") == 0) ||
     (ags_stricmp(name, "agsgalaxy-disjoint") == 0);
 
-  if (ags_stricmp(name, "ags_shell") == 0)
+  if (ags_stricmp(name, "ags_shell") == 0 || ags_stricmp(name, "agsshell") == 0)
   {
-    // ags_shell.dll
+    // ags_shell.dll or agsshell.dll
     ccAddExternalStaticFunction("ShellExecute",                 Sc_PluginStub_Void);
     return true;
   }


### PR DESCRIPTION
I did not notice there was already an `ags_shell` plugin check, and GH did not let me reopen the pull request after it closed. Turns out the new one is my own - and is just `agsshell`. It would be good though to support stubs for it.

Old Skies Demo shipped with this plugin.