### PR TITLE
Editor: added Help command for pane's tab context menu

### DIFF
--- a/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
+++ b/Editor/AGS.Editor/GUI/TabbedDocumentManager.cs
@@ -478,6 +478,8 @@ namespace AGS.Editor
             {
                 menu.Items.Add(new ToolStripMenuItem("Navigate (In Tree)", null, onClick, MENU_ITEM_NAVIGATE));
             }
+            menu.Items.Add(new ToolStripMenuItem("Help", GUIController.Instance.ImageList.Images["MenuIconDynamicHelp"],
+                new EventHandler(TreeContextMenuOnHelp), Keys.F1));
             document.Control.DockingContainer.TabPageContextMenuStrip = menu;
         }
 
@@ -506,8 +508,14 @@ namespace AGS.Editor
             else if (item.Name == MENU_ITEM_NAVIGATE)
             {
                 Factory.GUIController.ProjectTree.SelectNode(null, document.TreeNodeID);
- 
             }
+        }
+
+        private void TreeContextMenuOnHelp(object sender, EventArgs e)
+        {
+            ToolStripMenuItem item = (ToolStripMenuItem)sender;
+            ContentDocument document = (ContentDocument)item.Owner.Tag;
+            Factory.GUIController.LaunchHelpForKeyword(document.Control.HelpKeyword);
         }
 
         private void btnClose_Click(object sender, EventArgs e)


### PR DESCRIPTION
Just a small suggestion, added "Help" command to the document's tab context menu, in case user does not know about F1, also if there are multiple subpanes with different keywords, this will ensure displaying help for the pane itself:

![panectxhelp](https://user-images.githubusercontent.com/1833754/174446384-b18caa3f-fcb3-4be7-8f74-55c3c2c8eaf4.png)

