### PR TITLE
Tidy Library classes

### DIFF
--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -29,7 +29,6 @@
 #include "gfx/gfxfilter_aad3d.h"
 #include "platform/base/agsplatformdriver.h"
 #include "platform/base/sys_main.h"
-#include "util/library.h"
 
 using namespace AGS::Common;
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -1015,10 +1015,9 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
             apl->filename = "ags_snowrain";
         }
 
-        String expect_filename = apl->library.GetFilenameForLib(apl->filename);
         if (apl->library.Load(apl->filename))
         {
-          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' loaded as '%s', resolving imports...", apl->filename.GetCStr(), expect_filename.GetCStr());
+          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' loaded from '%s', resolving imports...", apl->filename.GetCStr(), apl->library.GetFilePath().GetCStr());
 
           if (apl->library.GetFunctionAddress("AGS_PluginV2") == nullptr) {
               quitprintf("Plugin '%s' is an old incompatible version.", apl->filename.GetCStr());
@@ -1035,6 +1034,7 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
         }
         else
         {
+          String expect_filename = apl->library.GetFilenameForLib(apl->filename);
           AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' could not be loaded (expected '%s'), trying built-in plugins...",
               apl->filename.GetCStr(), expect_filename.GetCStr());
           if (pl_use_builtin_plugin(apl))

--- a/Engine/util/library.h
+++ b/Engine/util/library.h
@@ -11,7 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AGS_EE_UTIL__LIBRARY_H
 #define __AGS_EE_UTIL__LIBRARY_H
 
@@ -23,23 +22,27 @@ namespace AGS
 namespace Engine
 {
 
+using AGS::Common::String;
 
 class BaseLibrary
 {
 public:
-  BaseLibrary() = default;
+    BaseLibrary() = default;
+    virtual ~BaseLibrary() = default;
 
-  virtual ~BaseLibrary() = default;
+    String GetName() const { return _name; }
+    String GetFilePath() const { return _path; }
 
-  virtual AGS::Common::String GetFilenameForLib(AGS::Common::String libraryName) = 0;
+    virtual String GetFilenameForLib(const String &libname) = 0;
+    virtual bool Load(const String &libname) = 0;
+    virtual void Unload() = 0;
+    virtual bool IsLoaded() const = 0;
+    virtual void *GetFunctionAddress(const String &fn_name) = 0;
 
-  virtual bool Load(AGS::Common::String libraryName) = 0;
-
-  virtual bool Unload() = 0;
-
-  virtual void *GetFunctionAddress(AGS::Common::String functionName) = 0;
+protected:
+    String _name;
+    String _path;
 };
-
 
 } // namespace Engine
 } // namespace AGS
@@ -54,8 +57,7 @@ public:
    || AGS_PLATFORM_OS_FREEBSD
 #include "library_posix.h"
 
-#elif AGS_PLATFORM_OS_IOS \
-   || AGS_PLATFORM_OS_EMSCRIPTEN
+#else
 #include "library_dummy.h"
 
 #endif

--- a/Engine/util/library_dummy.h
+++ b/Engine/util/library_dummy.h
@@ -11,52 +11,44 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AGS_EE_UTIL__LIBRARY_DUMMY_H
 #define __AGS_EE_UTIL__LIBRARY_DUMMY_H
-
 
 namespace AGS
 {
 namespace Engine
 {
 
+using AGS::Common::String;
 
-class DummyLibrary : BaseLibrary
+class DummyLibrary : public BaseLibrary
 {
 public:
-  DummyLibrary()
-  {
-  };
+    DummyLibrary() = default;
+    ~DummyLibrary() override { /* do nothing */ };
 
-  ~DummyLibrary() override
-  {
-  };
+    String GetFilenameForLib(const String &libname) override
+    {
+        return ""; // not supported
+    }
 
-  AGS::Common::String GetFilenameForLib(AGS::Common::String libraryName) override
-  {
-      return libraryName;
-  }
+    bool Load(const String &libname) override
+    {
+        return false; // always fail
+    }
 
-  bool Load(AGS::Common::String libraryName) override
-  {
-    return false;
-  }
+    void Unload() override { /* do nothing */ }
 
-  bool Unload() override
-  {
-    return true;
-  }
+    bool IsLoaded() const override { return false; /* always fail */ }
 
-  void *GetFunctionAddress(AGS::Common::String functionName) override
-  {
-    return NULL;
-  }
+    void *GetFunctionAddress(const String &fn_name) override
+    {
+        return nullptr; // not supported
+    }
 };
 
 
 typedef DummyLibrary Library;
-
 
 
 } // namespace Engine

--- a/Engine/util/library_windows.h
+++ b/Engine/util/library_windows.h
@@ -17,6 +17,7 @@
 #include "debug/out.h"
 #include "platform/windows/winapi_exclusive.h"
 #include "util/path.h"
+#include "util/stdio_compat.h"
 #include "util/string.h"
 
 // Because this class may be exposed to generic code in sake of inlining,
@@ -27,7 +28,7 @@ extern "C" {
 
     WINBASEAPI BOOL WINAPI FreeLibrary(HMODULE hLibModule);
     WINBASEAPI FARPROC WINAPI GetProcAddress(HMODULE hModule, LPCSTR lpProcName);
-    WINBASEAPI HMODULE WINAPI LoadLibraryA(LPCSTR lpLibFileName);
+    WINBASEAPI HMODULE WINAPI LoadLibraryW(LPCWSTR lpLibFileName);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -96,7 +97,9 @@ private:
     {
         path = GetFilenameForLib(libname);
         AGS::Common::Debug::Printf("Built library path: %s", path.GetCStr());
-        return LoadLibraryA(path.GetCStr());
+        WCHAR wpath[MAX_PATH_SZ];
+        MultiByteToWideChar(CP_UTF8, 0, path.GetCStr(), -1, wpath, MAX_PATH_SZ);
+        return LoadLibraryW(wpath);
     }
 
     HMODULE _library = NULL;

--- a/Engine/util/library_windows.h
+++ b/Engine/util/library_windows.h
@@ -16,6 +16,7 @@
 
 #include "debug/out.h"
 #include "platform/windows/winapi_exclusive.h"
+#include "util/path.h"
 #include "util/string.h"
 
 // Because this class may be exposed to generic code in sake of inlining,
@@ -38,77 +39,74 @@ namespace AGS
 namespace Engine
 {
 
+using AGS::Common::String;
 
-class WindowsLibrary : BaseLibrary
+class WindowsLibrary : public BaseLibrary
 {
 public:
-  WindowsLibrary()
-    : _library(NULL)
-  {
-  };
-
-  virtual ~WindowsLibrary()
-  {
-    Unload();
-  };
-
-  AGS::Common::String BuildFilename(AGS::Common::String libraryName)
-  {
-    return String::FromFormat("%s.dll", libraryName.GetCStr());
-  }
-
-  AGS::Common::String BuildPath(AGS::Common::String libraryName)
-  {
-    AGS::Common::String platformLibraryName = BuildFilename(libraryName);
-
-    AGS::Common::Debug::Printf("Built library path: %s", platformLibraryName.GetCStr());
-
-    return platformLibraryName;
-  }
-
-  AGS::Common::String GetFilenameForLib(AGS::Common::String libraryName) override
-  {
-    return BuildFilename(libraryName);
-  }
-
-  bool Load(AGS::Common::String libraryName)
-  {
-    Unload();
-
-    _library = LoadLibraryA(BuildPath(libraryName).GetCStr());
-
-    return (_library != NULL);
-  }
-
-  bool Unload()
-  {
-    if (_library)
+    WindowsLibrary() = default;
+    ~WindowsLibrary() override
     {
-      return (FreeLibrary(_library) != 0);
-    }
-    else
-    {
-      return true;
-    }
-  }
+        Unload();
+    };
 
-  void *GetFunctionAddress(AGS::Common::String functionName)
-  {
-    return GetProcAddress(_library, functionName.GetCStr());
-  }
+    String GetFilenameForLib(const String &libname) override
+    {
+        return String::FromFormat("%s.dll", libname.GetCStr());
+    }
+
+    bool Load(const String &libname) override
+    {
+        Unload();
+        String path;
+        HMODULE lib = TryLoad(libname, path);
+        if (lib == NULL)
+            return false;
+        _library = lib;
+        _name = libname;
+        _path = path;
+        return true;
+    }
+
+    void Unload() override
+    {
+        if (_library)
+        {
+            FreeLibrary(_library);
+            _library = NULL;
+            _name = "";
+            _path = "";
+        }
+    }
+
+    virtual bool IsLoaded() const override
+    {
+        return _library != NULL;
+    }
+
+    void *GetFunctionAddress(const String &fn_name) override
+    {
+        if (!_library)
+            return nullptr;
+        return GetProcAddress(_library, fn_name.GetCStr());
+    }
 
 private:
-  HMODULE _library;
+    HMODULE TryLoad(const String &libname, String &path)
+    {
+        path = GetFilenameForLib(libname);
+        AGS::Common::Debug::Printf("Built library path: %s", path.GetCStr());
+        return LoadLibraryA(path.GetCStr());
+    }
+
+    HMODULE _library = NULL;
 };
 
 
 typedef WindowsLibrary Library;
 
 
-
 } // namespace Engine
 } // namespace AGS
-
-
 
 #endif // __AGS_EE_UTIL__LIBRARY_WINDOWS_H


### PR DESCRIPTION
This is not related to any open issue; but when debugging one problem recently I realized that Library class does not save library's name etc. So I decided to add this information, and tidy the code along.

* No significant functional changes.
* Tidy code and apply the preferred code style.
* Hid class members that should not be public.
* Fixed implementation that did not have safe checks when disposing.
* Save name and path in the Library class.
* Added GetName(), GetFilePath() and IsLoaded() members.

In addition use wide-char winapi function in the WindowsLibrary (because we are supposed to support utf-8 paths now).

TODO: need to be tested on Linux and Android.