### PR TITLE
Bump Newtonsoft.Json from 10.0.3 to 13.0.1 in /Editor/AGS.Editor

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -77,8 +77,8 @@
     <Reference Include="Magick.NET-Q8-x86, Version=7.10.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=x86">
       <HintPath>..\..\Solutions\packages\Magick.NET-Q8-x86.7.10.0\lib\net40\Magick.NET-Q8-x86.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\Solutions\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\Solutions\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Editor/AGS.Editor/packages.config
+++ b/Editor/AGS.Editor/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="DockPanelSuite" version="2.6.0.1" targetFramework="net46" />
   <package id="Magick.NET-Q8-x86" version="7.10.0" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
do #1701 , but without the error

technically the CVE reported by the bot doesn't matter for us, since AGS isn't being ran in an IIS server, but as far as I can tell there has been no change in Newtonsoft.Json in behavior. We use it for the color theme.