### PR TITLE
Fix include guard for agspalrender.h

### DIFF
--- a/Plugins/agspalrender/agspalrender.h
+++ b/Plugins/agspalrender/agspalrender.h
@@ -1,5 +1,5 @@
-#ifndef AGS_TOUCH_H
-#define AGS_TOUCH_H
+#ifndef AGS_PAL_RENDER_H
+#define AGS_PAL_RENDER_H
 
 #include "plugin/agsplugin.h"
 


### PR DESCRIPTION
A simple and hopefully self explanatory change.
The code was obviously copied from the agstouch plugin 😉 