### PR TITLE
Implement AGSSpriteFont plugin for Clifftop Games

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -507,10 +507,14 @@ if (AGS_BUILTIN_PLUGINS)
         ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFont.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
         ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
+        ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp
+        ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
         ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
         ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+        ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
+        ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/color.cpp
         ../Plugins/AGSSpriteFont/AGSSpriteFont/color.h
 

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -500,6 +500,7 @@ if (AGS_BUILTIN_PLUGINS)
         ../Plugins/ags_snowrain/ags_snowrain.h
 
         ../Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+        ../Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/CharacterEntry.cpp
         ../Plugins/AGSSpriteFont/AGSSpriteFont/CharacterEntry.h
         ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFont.cpp

--- a/Engine/Makefile-objs
+++ b/Engine/Makefile-objs
@@ -55,7 +55,7 @@ else
 COMMON := $(wildcard $(addsuffix /*.cpp,$(COMMON_subdirs))) $(wildcard $(addsuffix /*.c,$(COMMON_subdirs)))
 endif
 
-PLUGINS = ../Plugins/AGSflashlight/agsflashlight.cpp ../Plugins/agsblend/AGSBlend.cpp ../Plugins/ags_snowrain/ags_snowrain.cpp ../Plugins/ags_parallax/ags_parallax.cpp ../Plugins/agspalrender/ags_palrender.cpp ../Plugins/agspalrender/raycast.cpp
+PLUGINS = ../Plugins/AGSflashlight/agsflashlight.cpp ../Plugins/agsblend/AGSBlend.cpp ../Plugins/ags_snowrain/ags_snowrain.cpp ../Plugins/ags_parallax/ags_parallax.cpp ../Plugins/agspalrender/ags_palrender.cpp ../Plugins/agspalrender/raycast.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/CharacterEntry.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/color.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFont.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp ../Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
 
 ALFONT = ../Common/libsrc/alfont-2.0.9/alfont.c
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -79,6 +79,7 @@ using namespace AGS::Engine;
 #include "../Plugins/ags_snowrain/ags_snowrain.h"
 #include "../Plugins/ags_parallax/ags_parallax.h"
 #include "../Plugins/agspalrender/agspalrender.h"
+#include "../Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.h"
 #if AGS_PLATFORM_OS_IOS
 #include "../Plugins/agstouch/agstouch.h"
 #endif // AGS_PLATFORM_OS_IOS
@@ -945,6 +946,15 @@ bool pl_use_builtin_plugin(EnginePlugin* apl)
         apl->onEvent = agspalrender::AGS_EngineOnEvent;
         apl->debugHook = agspalrender::AGS_EngineDebugHook;
         apl->initGfxHook = agspalrender::AGS_EngineInitGfx;
+        apl->available = true;
+        apl->builtin = true;
+        return true;
+    }
+    else if (apl->filename.CompareNoCase("agsspritefont") == 0)
+    {
+        apl->engineStartup = agsspritefont::AGS_EngineStartup;
+        apl->engineShutdown = agsspritefont::AGS_EngineShutdown;
+        apl->onEvent = agsspritefont::AGS_EngineOnEvent;
         apl->available = true;
         apl->builtin = true;
         return true;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -106,7 +106,7 @@ extern ScriptString myScriptStringImpl;
 // **************** PLUGIN IMPLEMENTATION ****************
 
 
-const int PLUGIN_API_VERSION = 25;
+const int PLUGIN_API_VERSION = 26;
 struct EnginePlugin {
     AGS::Common::String  filename;
     AGS::Engine::Library library;
@@ -821,6 +821,15 @@ void IAGSEngine::GetRenderStageDesc(AGSRenderStageDesc* desc)
     }
 }
 
+void IAGSEngine::GetGameInfo(AGSGameInfo* ginfo)
+{
+    if (ginfo->Version >= 26)
+    {
+        snprintf(ginfo->GameName, sizeof(ginfo->GameName), "%s", game.gamename);
+        snprintf(ginfo->guid, sizeof(ginfo->guid), "%s", game.guid);
+        ginfo->uniqueid = game.uniqueid;
+    }
+}
 
 // *********** General plugin implementation **********
 

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -317,6 +317,18 @@ struct AGSRenderStageDesc {
   AGSRenderMatrixes Matrixes;
 };
 
+// Game info
+struct AGSGameInfo {
+  // Which version of the plugin interface the struct corresponds to;
+  // this field must be filled by a plugin before passing the struct into the engine!
+  int Version;
+  // Game name
+  char GameName[50];
+  // guid
+  char guid[40];
+  // Random key identifying the game
+  int uniqueid;
+};
 
 // The plugin-to-engine interface
 class IAGSEngine {
@@ -561,6 +573,11 @@ public:
   // fills the provided AGSRenderStageDesc struct with current render stage description;
   // please note that plugin MUST fill the struct's Version field before passing it into the function!
   AGSIFUNC(void)  GetRenderStageDesc(AGSRenderStageDesc* desc);
+
+  // *** BELOW ARE INTERFACE VERSION 26 AND ABOVE ONLY
+  // fills the provided AGSGameInfo struct
+  // please note that plugin MUST fill the struct's Version field before passing it into the function!
+  AGSIFUNC(void)  GetGameInfo(AGSGameInfo* ginfo);
 };
 
 #ifdef THIS_IS_THE_PLUGIN

--- a/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
+++ b/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
@@ -747,6 +747,11 @@
 		52F5D8611DA1219D006F8F4B /* inventoryiteminfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F5D8601DA1219D006F8F4B /* inventoryiteminfo.cpp */; };
 		52F5D8641DA121CC006F8F4B /* version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F5D8621DA121CC006F8F4B /* version.cpp */; };
 		52F5D8651DA121CC006F8F4B /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F5D8631DA121CC006F8F4B /* version.h */; };
+		A3A4659D2866966D00AE0372 /* SpriteFontRendererClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */; };
+		A3A4659E2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */; };
+		A3A4659F2866966D00AE0372 /* AGSSpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */; };
+		A3A465A02866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */; };
+		A3A465A12866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1494,6 +1499,11 @@
 		52F5D8601DA1219D006F8F4B /* inventoryiteminfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inventoryiteminfo.cpp; sourceTree = "<group>"; };
 		52F5D8621DA121CC006F8F4B /* version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = version.cpp; sourceTree = "<group>"; };
 		52F5D8631DA121CC006F8F4B /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRendererClifftopGames.h; sourceTree = "<group>"; };
+		A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFontClifftopGames.h; sourceTree = "<group>"; };
+		A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSSpriteFont.h; sourceTree = "<group>"; };
+		A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRendererClifftopGames.cpp; sourceTree = "<group>"; };
+		A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFontClifftopGames.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1640,6 +1650,11 @@
 		521C54941D1E572B00BD619E /* AGSSpriteFont */ = {
 			isa = PBXGroup;
 			children = (
+				A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */,
+				A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */,
+				A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */,
+				A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */,
+				A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */,
 				521C54951D1E572B00BD619E /* AGSSpriteFont.cpp */,
 				521C54971D1E572B00BD619E /* CharacterEntry.cpp */,
 				521C54981D1E572B00BD619E /* CharacterEntry.h */,
@@ -2204,7 +2219,6 @@
 				526F25001D3B5CC300EF4E1F /* sprite.cpp */,
 				526F25011D3B5CC300EF4E1F /* sprite.h */,
 				526F25021D3B5CC300EF4E1F /* spritecache_engine.cpp */,
-				526F25031D3B5CC300EF4E1F /* spritelistentry.h */,
 				526F25041D3B5CC300EF4E1F /* statobj */,
 				526F250A1D3B5CC300EF4E1F /* string.cpp */,
 				526F250B1D3B5CC300EF4E1F /* string.h */,
@@ -2828,6 +2842,7 @@
 				526F22F41D3B5C4900EF4E1F /* almp3.h in Headers */,
 				526F22A01D3B5C4900EF4E1F /* audiocliptype.h in Headers */,
 				526F26C81D3B5CC300EF4E1F /* cc_gui.h in Headers */,
+				A3A4659E2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h in Headers */,
 				526F23D21D3B5C4900EF4E1F /* file.h in Headers */,
 				526F22C81D3B5C4900EF4E1F /* assert.h in Headers */,
 				526F23C11D3B5C4900EF4E1F /* cc_options.h in Headers */,
@@ -2844,6 +2859,7 @@
 				526F26FE1D3B5CC300EF4E1F /* global_audio.h in Headers */,
 				526F23E11D3B5C4900EF4E1F /* multifilelib.h in Headers */,
 				526F26F31D3B5CC300EF4E1F /* event.h in Headers */,
+				A3A4659F2866966D00AE0372 /* AGSSpriteFont.h in Headers */,
 				526F27D11D3B5CC300EF4E1F /* animatingguibutton.h in Headers */,
 				526F28781D3B5CC300EF4E1F /* audio.h in Headers */,
 				526F28881D3B5CC300EF4E1F /* clip_mystaticogg.h in Headers */,
@@ -2995,9 +3011,9 @@
 				526F26B21D3B5CC300EF4E1F /* draw.h in Headers */,
 				526F22A31D3B5C4900EF4E1F /* common.h in Headers */,
 				526F288A1D3B5CC300EF4E1F /* clip_mywave.h in Headers */,
-				526F27861D3B5CC300EF4E1F /* spritelistentry.h in Headers */,
 				526F286C1D3B5CC300EF4E1F /* maindefines_ex.h in Headers */,
 				526F22E01D3B5C4900EF4E1F /* guidefines.h in Headers */,
+				A3A4659D2866966D00AE0372 /* SpriteFontRendererClifftopGames.h in Headers */,
 				521C54D31D1E572B00BD619E /* agsblend.h in Headers */,
 				526F22F31D3B5C4900EF4E1F /* alfontdll.h in Headers */,
 				526F27821D3B5CC300EF4E1F /* speech.h in Headers */,
@@ -3192,6 +3208,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 521C3BE01D1E545100BD619E;
@@ -3293,6 +3310,7 @@
 				526F27BD1D3B5CC300EF4E1F /* gfxdriverfactory.cpp in Sources */,
 				526F281C1D3B5CC300EF4E1F /* ogg.c in Sources */,
 				526F27DA1D3B5CC300EF4E1F /* mylabel.cpp in Sources */,
+				A3A465A02866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */,
 				526F273A1D3B5CC300EF4E1F /* global_translation.cpp in Sources */,
 				526F27921D3B5CC300EF4E1F /* timer.cpp in Sources */,
 				526F270D1D3B5CC300EF4E1F /* global_dynamicsprite.cpp in Sources */,
@@ -3415,6 +3433,7 @@
 				526F27301D3B5CC300EF4E1F /* global_screen.cpp in Sources */,
 				526F23CB1D3B5C4900EF4E1F /* compress.cpp in Sources */,
 				526F26E11D3B5CC300EF4E1F /* scriptfile.cpp in Sources */,
+				A3A465A12866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */,
 				526F22D71D3B5C4900EF4E1F /* interactions.cpp in Sources */,
 				526F27AC1D3B5CC300EF4E1F /* mousew32.cpp in Sources */,
 				526F27D41D3B5CC300EF4E1F /* gui_engine.cpp in Sources */,

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -119,6 +119,14 @@ void SetSpacing(int fontNum, int spacing)
 	engine->PrintDebugConsole("AGSSpriteFont: SetSpacing");
 	vWidthRenderer->SetSpacing(fontNum, spacing);
 }
+
+void SetLineHeightAdjust(int /*fontNum*/, int /*lineHeight*/, int /*spacingHeight*/, int /*spacingOverride*/)
+{
+	engine->PrintDebugConsole("AGSSpriteFont: SetLineHeightAdjust");
+	// TODO This function was added in the Clifftop version of the plugin
+//	vWidthRenderer->SetLineHeightAdjust(fontNum, lineHeight, spacingHeight, spacingOverride);
+}
+
 //==============================================================================
 
 #if AGS_PLATFORM_OS_WINDOWS && !defined(BUILTIN_PLUGINS)
@@ -131,6 +139,7 @@ const char *ourScriptHeader =
   "import void SetVariableSpriteFont(int fontNum, int sprite);\r\n"
   "import void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);\r\n"
   "import void SetSpacing(int fontNum, int spacing);\r\n"
+  "import void SetLineHeightAdjust(int, int, int, int);\r\n"
   ;
 
 //------------------------------------------------------------------------------
@@ -229,6 +238,7 @@ void AGS_EngineStartup(IAGSEngine *lpEngine)
 	REGISTER(SetVariableSpriteFont)
 	REGISTER(SetGlyph)
 	REGISTER(SetSpacing)
+	REGISTER(SetLineHeightAdjust)
 }
 
 //------------------------------------------------------------------------------

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -21,7 +21,7 @@
 #include <windows.h>
 #include <WinBase.h>
 #endif
-#include <ctype.h>
+#include <string.h>
 
 #define THIS_IS_THE_PLUGIN
 #include "plugin/agsplugin.h"
@@ -224,18 +224,6 @@ void AGS_EditorLoadGame(char *buffer, int bufsize)            //*** optional ***
 namespace agsspritefont {
 #endif
 
-bool IsEqualCaseInsensitive(char const *a, char const *b)
-{
-	for (; *a && *b; a++, b++)
-	{
-		if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
-			return false;
-	}
-	if (*a || *b)
-		return false;
-	return true;
-}
-
 void AGS_EngineStartup(IAGSEngine *lpEngine)
 {
 	engine = lpEngine;
@@ -251,8 +239,11 @@ void AGS_EngineStartup(IAGSEngine *lpEngine)
 		AGSGameInfo gameInfo;
 		gameInfo.Version = 26;
 		lpEngine->GetGameInfo(&gameInfo);
-		useClifftopGamesRenderers = IsEqualCaseInsensitive(gameInfo.GameName, "kathy rain") ||
-			IsEqualCaseInsensitive(gameInfo.GameName, "whispers of a machine");
+		// GUID:
+		// Kathy Rain: {d6795d1c-3cfe-49ec-90a1-85c313bfccaf}
+		// Whispers of a Machine: {5833654f-6f0d-40d9-99e2-65c101c8544a}
+		useClifftopGamesRenderers = strcmp("{d6795d1c-3cfe-49ec-90a1-85c313bfccaf}", gameInfo.guid) == 0 ||
+			strcmp("{5833654f-6f0d-40d9-99e2-65c101c8544a}", gameInfo.guid) == 0;
 	}
 	if (useClifftopGamesRenderers)
 	{

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -26,6 +26,8 @@
 #include "plugin/agsplugin.h"
 #include "SpriteFontRenderer.h"
 #include "VariableWidthSpriteFont.h"
+#include "SpriteFontRendererClifftopGames.h"
+#include "VariableWidthSpriteFontClifftopGames.h"
 
 
 #define DEFAULT_RGB_R_SHIFT_32  16
@@ -225,10 +227,18 @@ namespace agsspritefont {
 void AGS_EngineStartup(IAGSEngine *lpEngine)
 {
 	engine = lpEngine;
+	// TODO: find a way de know which renderers to instantiate
+#if 1
 	engine->PrintDebugConsole("AGSSpriteFont: Init fixed width renderer");
 	fontRenderer = new SpriteFontRenderer(engine);
 	engine->PrintDebugConsole("AGSSpriteFont: Init vari width renderer");
 	vWidthRenderer = new VariableWidthSpriteFontRenderer(engine);
+#else
+	engine->PrintDebugConsole("AGSSpriteFont: Init fixed width renderer");
+	fontRenderer = new SpriteFontRendererClifftopGames(engine);
+	engine->PrintDebugConsole("AGSSpriteFont: Init vari width renderer");
+	vWidthRenderer = new VariableWidthSpriteFontRendererClifftopGames(engine);
+#endif
 	// Make sure it's got the version with the features we need
 	if (engine->version < MIN_ENGINE_VERSION)
 		engine->AbortGame("Plugin needs engine version " STRINGIFY(MIN_ENGINE_VERSION) " or newer.");

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -120,11 +120,10 @@ void SetSpacing(int fontNum, int spacing)
 	vWidthRenderer->SetSpacing(fontNum, spacing);
 }
 
-void SetLineHeightAdjust(int /*fontNum*/, int /*lineHeight*/, int /*spacingHeight*/, int /*spacingOverride*/)
+void SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride)
 {
 	engine->PrintDebugConsole("AGSSpriteFont: SetLineHeightAdjust");
-	// TODO This function was added in the Clifftop version of the plugin
-//	vWidthRenderer->SetLineHeightAdjust(fontNum, lineHeight, spacingHeight, spacingOverride);
+	vWidthRenderer->SetLineHeightAdjust(fontNum, lineHeight, spacingHeight, spacingOverride);
 }
 
 //==============================================================================

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -248,6 +248,8 @@ void AGS_EngineShutdown()
 	// Called by the game engine just before it exits.
 	// This gives you a chance to free any memory and do any cleanup
 	// that you need to do before the engine shuts down.
+	delete fontRenderer;
+	delete vWidthRenderer;
 }
 
 //------------------------------------------------------------------------------

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -219,7 +219,9 @@ void AGS_EditorLoadGame(char *buffer, int bufsize)            //*** optional ***
 #define STRINGIFY(s) STRINGIFY_X(s)
 #define STRINGIFY_X(s) #s
 
-
+#if defined(BUILTIN_PLUGINS)
+namespace agsspritefont {
+#endif
 
 void AGS_EngineStartup(IAGSEngine *lpEngine)
 {
@@ -303,3 +305,7 @@ void AGS_EngineInitGfx(const char *driverID, void *data)      //*** optional ***
 }
 */
 //..............................................................................
+
+#if defined(BUILTIN_PLUGINS)
+}
+#endif

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.h
@@ -1,0 +1,13 @@
+#ifndef AGS_SPRITE_FONT_H
+#define AGS_SPRITE_FONT_H
+
+#include "plugin/agsplugin.h"
+
+namespace agsspritefont
+{
+  void AGS_EngineStartup(IAGSEngine *lpEngine);
+  void AGS_EngineShutdown();
+  int AGS_EngineOnEvent(int event, int data);
+}
+
+#endif

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.vcxproj
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.vcxproj
@@ -84,8 +84,10 @@
     <ClInclude Include="color.h" />
     <ClInclude Include="SpriteFont.h" />
     <ClInclude Include="SpriteFontRenderer.h" />
+    <ClInclude Include="SpriteFontRendererClifftopGames.h" />
     <ClInclude Include="VariableWidthFont.h" />
     <ClInclude Include="VariableWidthSpriteFont.h" />
+    <ClInclude Include="VariableWidthSpriteFontClifftopGames.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AGSSpriteFont.cpp" />
@@ -93,8 +95,10 @@
     <ClCompile Include="color.cpp" />
     <ClCompile Include="SpriteFont.cpp" />
     <ClCompile Include="SpriteFontRenderer.cpp" />
+    <ClCompile Include="SpriteFontRendererClifftopGames.cpp" />
     <ClCompile Include="VariableWidthFont.cpp" />
     <ClCompile Include="VariableWidthSpriteFont.cpp" />
+    <ClCompile Include="VariableWidthSpriteFontClifftopGames.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -144,64 +144,56 @@ void SpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, i
 	int startx = MAX(0, (-1 * destx));
 	int starty = MAX(0, (-1 * desty));
 
-	
 	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col;
 
 	for(int x = startx; x < width; x ++)
 	{
-		
+
 		for(int y = starty; y <  height; y ++)
 		{
 			int srcyy = y + srcy;
 			int srcxx = x + srcx;
 			int destyy = y + desty;
 			int destxx = x + destx;
-				if (destColDepth == 8)
-				{
-					if (srccharbuffer[srcyy][srcxx] != transColor) destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
-				}
-				else if (destColDepth == 16)
-				{
-					if (srcshortbuffer[srcyy][srcxx] != transColor) destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
-				}
-				else if (destColDepth == 32)
-				{
-					//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
-					
-					srca =  (geta32(srclongbuffer[srcyy][srcxx]));
-            
-					if (srca != 0) {
-						   
-						srcr =  getr32(srclongbuffer[srcyy][srcxx]);  
-						srcg =  getg32(srclongbuffer[srcyy][srcxx]);
-						srcb =  getb32(srclongbuffer[srcyy][srcxx]);
-    
-						destr =  getr32(destlongbuffer[destyy][destxx]);
-						destg =  getg32(destlongbuffer[destyy][destxx]);
-						destb =  getb32(destlongbuffer[destyy][destxx]);
-						desta =  geta32(destlongbuffer[destyy][destxx]);
-                
+			if (destColDepth == 8)
+			{
+				if (srccharbuffer[srcyy][srcxx] != transColor) destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 16)
+			{
+				if (srcshortbuffer[srcyy][srcxx] != transColor) destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 32)
+			{
+				//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
 
-						finalr = srcr;
-						finalg = srcg;
-						finalb = srcb;   
-              
-                                                               
-						finala = 255-(255-srca)*(255-desta)/255;                                              
-						finalr = srca*finalr/finala + desta*destr*(255-srca)/finala/255;
-						finalg = srca*finalg/finala + desta*destg*(255-srca)/finala/255;
-						finalb = srca*finalb/finala + desta*destb*(255-srca)/finala/255;
-						col = makeacol32(finalr, finalg, finalb, finala);
-						destlongbuffer[destyy][destxx] = col;
-					}
+				srca =  (geta32(srclongbuffer[srcyy][srcxx]));
 
+				if (srca != 0) {
+					srcr =  getr32(srclongbuffer[srcyy][srcxx]);
+					srcg =  getg32(srclongbuffer[srcyy][srcxx]);
+					srcb =  getb32(srclongbuffer[srcyy][srcxx]);
+
+					destr =  getr32(destlongbuffer[destyy][destxx]);
+					destg =  getg32(destlongbuffer[destyy][destxx]);
+					destb =  getb32(destlongbuffer[destyy][destxx]);
+					desta =  geta32(destlongbuffer[destyy][destxx]);
+
+					finalr = srcr;
+					finalg = srcg;
+					finalb = srcb;
+
+					finala = 255-(255-srca)*(255-desta)/255;
+					finalr = srca*finalr/finala + desta*destr*(255-srca)/finala/255;
+					finalg = srca*finalg/finala + desta*destg*(255-srca)/finala/255;
+					finalb = srca*finalb/finala + desta*destb*(255-srca)/finala/255;
+					col = makeacol32(finalr, finalg, finalb, finala);
+					destlongbuffer[destyy][destxx] = col;
 				}
+			}
 		}
 	}
-	
+
 	_engine->ReleaseBitmapSurface(src);
 	_engine->ReleaseBitmapSurface(dest);
-
-	
-
 }

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -13,6 +13,21 @@ SpriteFontRenderer::SpriteFontRenderer(IAGSEngine *engine)
 
 SpriteFontRenderer::~SpriteFontRenderer(void) = default;
 
+
+void SpriteFontRenderer::FreeMemory(int fontNum)
+{
+	for(auto it = _fonts.begin(); it != _fonts.end() ; ++it)
+	{
+		SpriteFont *font = *it;
+		if (font->FontReplaced == fontNum)
+		{
+			_fonts.erase(it);
+			delete font;
+			return;
+		}
+	}
+}
+
 void SpriteFontRenderer::SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth, int charHeight, int charMin, int charMax, bool use32bit)
 {
 	SpriteFont *font = getFontFor(fontNum);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -1,6 +1,7 @@
 #include "SpriteFontRenderer.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include "color.h"
 
 
@@ -120,15 +121,15 @@ void SpriteFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *de
 void SpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height)
 {
 
-	int srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
+	int32 srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
 
 	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
-	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
-    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+	uint16_t **srcshortbuffer = (uint16_t**)srccharbuffer; //16bit;
+	uint32_t **srclongbuffer = (uint32_t**)srccharbuffer; //32bit
 
 	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
-	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
-    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+	uint16_t **destshortbuffer = (uint16_t**)destcharbuffer; //16bit;
+	uint32_t **destlongbuffer = (uint32_t**)destcharbuffer; //32bit
 
 	int transColor = _engine->GetBitmapTransparentColor(src);
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -45,7 +45,7 @@ void SpriteFontRenderer::SetSpriteFont(int fontNum, int sprite, int rows, int co
 void SpriteFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
 {
 	SpriteFont *font = getFontFor(fontNumber);
-	for(int i = 0; i < strlen(text); i++)
+	for(size_t i = 0; i < strlen(text); i++)
 	{
 		if(text[i] < font->MinChar || text[i] > font->MaxChar) 
 		{
@@ -79,7 +79,7 @@ int SpriteFontRenderer::GetTextHeight(const char *text, int fontNumber)
 SpriteFont *SpriteFontRenderer::getFontFor(int fontNum)
 {
 	SpriteFont *font;
-	for (int i = 0; i < _fonts.size(); i ++)
+	for (size_t i = 0; i < _fonts.size(); i ++)
 	{
 		font = _fonts.at(i);
 		if (font->FontReplaced == fontNum) return font;
@@ -101,7 +101,7 @@ void SpriteFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *de
 	
 	//_engine->SetVirtualScreen(destination);
 	
-	for(int i = 0; i < strlen(text); i++)
+	for(size_t i = 0; i < strlen(text); i++)
 	{
 		char c = text[i];
 		c -= font->MinChar;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -97,7 +97,7 @@ void SpriteFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *de
 {
 	
 	SpriteFont *font = getFontFor(fontNumber);
-	BITMAP *vScreen = _engine->GetVirtualScreen();
+	//BITMAP *vScreen = _engine->GetVirtualScreen();
 	
 	//_engine->SetVirtualScreen(destination);
 	

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
@@ -7,7 +7,7 @@ class SpriteFontRenderer :
 {
 public:
 	SpriteFontRenderer(IAGSEngine *engine);
-	~SpriteFontRenderer(void);
+	virtual ~SpriteFontRenderer();
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
 	void FreeMemory(int fontNumber) override { }
 	bool SupportsExtendedCharacters(int fontNumber) override;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
@@ -19,7 +19,7 @@ public:
 	void SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth, int charHeight, int charMin, int charMax, bool use32bit);
 	
 	
-private:
+protected:
 	SpriteFont *getFontFor(int fontNum);
 	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);
 	std::vector<SpriteFont * > _fonts;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
@@ -9,7 +9,7 @@ public:
 	SpriteFontRenderer(IAGSEngine *engine);
 	virtual ~SpriteFontRenderer();
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
-	void FreeMemory(int fontNumber) override { }
+	void FreeMemory(int fontNumber) override;
 	bool SupportsExtendedCharacters(int fontNumber) override;
 	int GetTextWidth(const char *text, int fontNumber) override;
 	int GetTextHeight(const char *text, int fontNumber) override;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp
@@ -1,0 +1,124 @@
+#include "SpriteFontRendererClifftopGames.h"
+#include <stdio.h>
+#include <string.h>
+#include "color.h"
+
+
+SpriteFontRendererClifftopGames::SpriteFontRendererClifftopGames(IAGSEngine *engine)
+	: SpriteFontRenderer(engine)
+{
+}
+
+SpriteFontRendererClifftopGames::~SpriteFontRendererClifftopGames(void) = default;
+
+bool SpriteFontRendererClifftopGames::SupportsExtendedCharacters(int fontNumber)
+{
+	return true;
+}
+
+void SpriteFontRendererClifftopGames::RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour)
+{
+	SpriteFont *font = getFontFor(fontNumber);
+	//BITMAP *vScreen = _engine->GetVirtualScreen();
+
+	//_engine->SetVirtualScreen(destination);
+
+	for (int i = 0; i < (int)strlen(text); i++)
+	{
+		char c = text[i];
+		c -= font->MinChar;
+		int row = c / font->Columns;
+		int column = c % font->Columns;
+		BITMAP *src = _engine->GetSpriteGraphic(font->SpriteNumber);
+		Draw(src, destination, x + (i * font->CharWidth), y, column * font->CharWidth, row * font->CharHeight, font->CharWidth, font->CharHeight, colour);
+	}
+
+	//_engine->SetVirtualScreen(vScreen);
+}
+
+void SpriteFontRendererClifftopGames::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour)
+{
+	int srcWidth = 0, srcHeight = 0, destWidth = 0, destHeight = 0, srcColDepth = 0, destColDepth = 0;
+
+	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
+	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
+    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+
+	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
+	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
+    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+
+	int transColor = _engine->GetBitmapTransparentColor(src);
+
+	_engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, &srcColDepth);
+	_engine->GetBitmapDimensions(dest, &destWidth, &destHeight, &destColDepth);
+
+	if (srcy + height > srcHeight || srcx + width > srcWidth || srcx < 0 || srcy < 0) return;
+
+	if (width + destx > destWidth) width = destWidth - destx;
+	if (height + desty > destHeight) height = destHeight - desty;
+
+	int startx = MAX(0, (-1 * destx));
+	int starty = MAX(0, (-1 * desty));
+
+	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col, col_r, col_g, col_b;
+	col_r = getr32(colour);
+	col_g = getg32(colour);
+	col_b = getb32(colour);
+
+	for(int x = startx; x < width; x ++)
+	{
+
+		for(int y = starty; y <  height; y ++)
+		{
+			int srcyy = y + srcy;
+			int srcxx = x + srcx;
+			int destyy = y + desty;
+			int destxx = x + destx;
+			if (destColDepth == 8)
+			{
+				if (srccharbuffer[srcyy][srcxx] != transColor)
+					destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 16)
+			{
+				if (srcshortbuffer[srcyy][srcxx] != transColor)
+					destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 32)
+			{
+				//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
+
+				srca =  (geta32(srclongbuffer[srcyy][srcxx]));
+
+				if (srca != 0) {
+					srcr =  getr32(srclongbuffer[srcyy][srcxx]);
+					srcg =  getg32(srclongbuffer[srcyy][srcxx]);
+					srcb =  getb32(srclongbuffer[srcyy][srcxx]);
+
+					destr =  getr32(destlongbuffer[destyy][destxx]);
+					destg =  getg32(destlongbuffer[destyy][destxx]);
+					destb =  getb32(destlongbuffer[destyy][destxx]);
+					desta =  geta32(destlongbuffer[destyy][destxx]);
+
+					// The original source code from Clifftop Games has the code below, but since it is useless it is commented out
+					/*
+					finalr = (col_r * srcr) / 255;
+					finalg = (col_g * srcg) / 255;
+					finalb = (col_b * srcb) / 255;
+						*/
+
+					finala = 255-(255-srca)*(255-desta)/255;
+					finalr = srca*col_r/finala + desta*destr*(255-srca)/finala/255;
+					finalg = srca*col_g/finala + desta*destg*(255-srca)/finala/255;
+					finalb = srca*col_b/finala + desta*destb*(255-srca)/finala/255;
+					col = makeacol32(finalr, finalg, finalb, finala);
+					destlongbuffer[destyy][destxx] = col;
+				}
+			}
+		}
+	}
+
+	_engine->ReleaseBitmapSurface(src);
+	_engine->ReleaseBitmapSurface(dest);
+}

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.cpp
@@ -1,6 +1,7 @@
 #include "SpriteFontRendererClifftopGames.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include "color.h"
 
 
@@ -38,15 +39,15 @@ void SpriteFontRendererClifftopGames::RenderText(const char *text, int fontNumbe
 
 void SpriteFontRendererClifftopGames::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour)
 {
-	int srcWidth = 0, srcHeight = 0, destWidth = 0, destHeight = 0, srcColDepth = 0, destColDepth = 0;
+	int32 srcWidth = 0, srcHeight = 0, destWidth = 0, destHeight = 0, srcColDepth = 0, destColDepth = 0;
 
 	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
-	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
-    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+	uint16_t **srcshortbuffer = (uint16_t**)srccharbuffer; //16bit;
+	uint32_t **srclongbuffer = (uint32_t**)srccharbuffer; //32bit
 
 	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
-	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
-    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+	uint16_t **destshortbuffer = (uint16_t**)destcharbuffer; //16bit;
+    uint32_t **destlongbuffer = (uint32_t**)destcharbuffer; //32bit
 
 	int transColor = _engine->GetBitmapTransparentColor(src);
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRendererClifftopGames.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "SpriteFontRenderer.h"
+class SpriteFontRendererClifftopGames : public SpriteFontRenderer
+{
+public:
+	SpriteFontRendererClifftopGames(IAGSEngine *engine);
+	~SpriteFontRendererClifftopGames(void) override;
+
+	bool SupportsExtendedCharacters(int fontNumber) override;
+	void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
+
+private:
+	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour);
+};
+

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.cpp
@@ -6,6 +6,9 @@ VariableWidthFont::VariableWidthFont(void)
 	Spacing = 0;
 	FontReplaced = 0;
 	SpriteNumber = 0;
+	LineHeightAdjust = 0;
+	LineSpacingAdjust = 0;
+	LineSpacingOverride = 0;
 }
 
 
@@ -19,3 +22,10 @@ void VariableWidthFont::SetGlyph(int character, int x, int y, int width, int hei
 	characters[character].Height = height;
 	characters[character].Character = character;
 }
+
+void VariableWidthFont::SetLineHeightAdjust(int lineHeight, int spacingHeight, int spacingOverride)
+{
+	LineHeightAdjust = lineHeight;
+	LineSpacingAdjust = spacingHeight;
+	LineSpacingOverride = spacingOverride;
+  }

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthFont.h
@@ -8,9 +8,13 @@ public:
 	VariableWidthFont(void);
 	~VariableWidthFont(void);
 	void SetGlyph(int character, int x, int y, int width, int height);
+	void SetLineHeightAdjust(int lineHeight, int spacingHeight, int spacingOverride);
 	int SpriteNumber;
 	int FontReplaced;
 	int Spacing;
+	int LineHeightAdjust;
+	int LineSpacingAdjust;
+	int LineSpacingOverride;
 	std::map<char, CharacterEntry> characters;
 
 private:

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -152,7 +152,7 @@ void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx,
 
 	_engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, &srcColDepth);
 	_engine->GetBitmapDimensions(dest, &destWidth, &destHeight, &destColDepth);
-	
+
 	if (srcy + height > srcHeight || srcx + width > srcWidth || srcx < 0 || srcy < 0) return;
 
 	if (width + destx > destWidth) width = destWidth - destx;
@@ -161,65 +161,57 @@ void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx,
 	int startx = MAX(0, (-1 * destx));
 	int starty = MAX(0, (-1 * desty));
 
-	
 	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col;
 
 	for(int x = startx; x < width; x ++)
 	{
-		
+
 		for(int y = starty; y <  height; y ++)
 		{
 			int srcyy = y + srcy;
 			int srcxx = x + srcx;
 			int destyy = y + desty;
 			int destxx = x + destx;
-				if (destColDepth == 8)
-				{
-					if (srccharbuffer[srcyy][srcxx] != transColor) destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
-				}
-				else if (destColDepth == 16)
-				{
-					if (srcshortbuffer[srcyy][srcxx] != transColor) destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
-				}
-				else if (destColDepth == 32)
-				{
-					//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
-					
-					srca =  (geta32(srclongbuffer[srcyy][srcxx]));
-            
-					if (srca != 0) {
-						   
-						srcr =  getr32(srclongbuffer[srcyy][srcxx]);  
-						srcg =  getg32(srclongbuffer[srcyy][srcxx]);
-						srcb =  getb32(srclongbuffer[srcyy][srcxx]);
-    
-						destr =  getr32(destlongbuffer[destyy][destxx]);
-						destg =  getg32(destlongbuffer[destyy][destxx]);
-						destb =  getb32(destlongbuffer[destyy][destxx]);
-						desta =  geta32(destlongbuffer[destyy][destxx]);
-                
+			if (destColDepth == 8)
+			{
+				if (srccharbuffer[srcyy][srcxx] != transColor) destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 16)
+			{
+				if (srcshortbuffer[srcyy][srcxx] != transColor) destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 32)
+			{
+				//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
 
-						finalr = srcr;
-						finalg = srcg;
-						finalb = srcb;   
-              
-                                                               
-						finala = 255-(255-srca)*(255-desta)/255;                                              
-						finalr = srca*finalr/finala + desta*destr*(255-srca)/finala/255;
-						finalg = srca*finalg/finala + desta*destg*(255-srca)/finala/255;
-						finalb = srca*finalb/finala + desta*destb*(255-srca)/finala/255;
-						col = makeacol32(finalr, finalg, finalb, finala);
-						destlongbuffer[destyy][destxx] = col;
-					}
+				srca =  (geta32(srclongbuffer[srcyy][srcxx]));
 
+				if (srca != 0) {
+					srcr =  getr32(srclongbuffer[srcyy][srcxx]);
+					srcg =  getg32(srclongbuffer[srcyy][srcxx]);
+					srcb =  getb32(srclongbuffer[srcyy][srcxx]);
+
+					destr =  getr32(destlongbuffer[destyy][destxx]);
+					destg =  getg32(destlongbuffer[destyy][destxx]);
+					destb =  getb32(destlongbuffer[destyy][destxx]);
+					desta =  geta32(destlongbuffer[destyy][destxx]);
+
+					finalr = srcr;
+					finalg = srcg;
+					finalb = srcb;
+
+					finala = 255-(255-srca)*(255-desta)/255;
+					finalr = srca*finalr/finala + desta*destr*(255-srca)/finala/255;
+					finalg = srca*finalg/finala + desta*destg*(255-srca)/finala/255;
+					finalb = srca*finalb/finala + desta*destb*(255-srca)/finala/255;
+					col = makeacol32(finalr, finalg, finalb, finala);
+					destlongbuffer[destyy][destxx] = col;
 				}
+			}
 		}
 	}
 	
 	_engine->ReleaseBitmapSurface(src);
 	_engine->ReleaseBitmapSurface(dest);
-
-	
-
 }
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -34,7 +34,7 @@ int VariableWidthSpriteFontRenderer::GetTextWidth(const char *text, int fontNumb
 {
 	int total = 0;
 	VariableWidthFont *font = getFontFor(fontNumber);
-	for(int i = 0; i < strlen(text); i++)
+	for(size_t i = 0; i < strlen(text); i++)
 	{
 		if (font->characters.count(text[i]) > 0)
 		{
@@ -48,7 +48,7 @@ int VariableWidthSpriteFontRenderer::GetTextWidth(const char *text, int fontNumb
 int VariableWidthSpriteFontRenderer::GetTextHeight(const char *text, int fontNumber)
 {
 	VariableWidthFont *font = getFontFor(fontNumber);
-	for(int i = 0; i < strlen(text); i++)
+	for(size_t i = 0; i < strlen(text); i++)
 	{
 		if (font->characters.count(text[i]) > 0)
 		{
@@ -79,7 +79,7 @@ void VariableWidthSpriteFontRenderer::EnsureTextValidForFont(char *text, int fon
 	VariableWidthFont *font = getFontFor(fontNumber);
 	std::string s(text);
 	
-	for(int i = s.length() - 1; i >= 0 ; i--)
+	for(int i = (int)s.length() - 1; i >= 0 ; i--)
 	{
 		if (font->characters.count(s[i]) == 0)
 		{
@@ -105,7 +105,7 @@ void VariableWidthSpriteFontRenderer::SetSprite(int fontNum, int spriteNum)
 
 VariableWidthFont *VariableWidthSpriteFontRenderer::getFontFor(int fontNum){
 	VariableWidthFont *font;
-	for (int i = 0; i < _fonts.size(); i ++)
+	for (size_t i = 0; i < _fonts.size(); i ++)
 	{
 		font = _fonts.at(i);
 		if (font->FontReplaced == fontNum) return font;
@@ -121,7 +121,7 @@ void VariableWidthSpriteFontRenderer::RenderText(const char *text, int fontNumbe
 {
 	VariableWidthFont *font = getFontFor(fontNumber);
 	int totalWidth = 0;
-	for(int i = 0; i < strlen(text); i++)
+	for(size_t i = 0; i < strlen(text); i++)
 	{
 		char c = text[i];
 				

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -1,6 +1,7 @@
 #include "VariableWidthSpriteFont.h"
 #include <string>
 #include <string.h>
+#include <stdint.h>
 #include "color.h"
 
 
@@ -137,15 +138,15 @@ void VariableWidthSpriteFontRenderer::RenderText(const char *text, int fontNumbe
 void VariableWidthSpriteFontRenderer::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height)
 {
 
-	int srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
+	int32 srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
 
 	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
-	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
-    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+	uint16_t **srcshortbuffer = (uint16_t**)srccharbuffer; //16bit;
+	uint32_t **srclongbuffer = (uint32_t**)srccharbuffer; //32bit
 
 	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
-	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
-    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+	uint16_t**destshortbuffer = (uint16_t**)destcharbuffer; //16bit;
+	uint32_t **destlongbuffer = (uint32_t**)destcharbuffer; //32bit
 
 	int transColor = _engine->GetBitmapTransparentColor(src);
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -14,7 +14,19 @@ VariableWidthSpriteFontRenderer::VariableWidthSpriteFontRenderer(IAGSEngine *eng
 VariableWidthSpriteFontRenderer::~VariableWidthSpriteFontRenderer(void) = default;
 
 
-
+void VariableWidthSpriteFontRenderer::FreeMemory(int fontNum)
+{
+	for(auto it = _fonts.begin(); it != _fonts.end() ; ++it)
+	{
+		VariableWidthFont *font = *it;
+		if (font->FontReplaced == fontNum)
+		{
+			_fonts.erase(it);
+			delete font;
+			return;
+		}
+	}
+}
 
 bool VariableWidthSpriteFontRenderer::SupportsExtendedCharacters(int fontNumber) { return false; }
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -54,6 +54,14 @@ void VariableWidthSpriteFontRenderer::SetSpacing(int fontNum, int spacing)
 
 }
 
+void VariableWidthSpriteFontRenderer::SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride)
+{
+	VariableWidthFont *font = getFontFor(fontNum);
+	font->LineHeightAdjust = lineHeight;
+	font->LineSpacingAdjust = spacingHeight;
+	font->LineSpacingOverride = spacingOverride;
+}
+
 void VariableWidthSpriteFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
 {
 	VariableWidthFont *font = getFontFor(fontNumber);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -7,7 +7,7 @@ class VariableWidthSpriteFontRenderer :
 {
 public:
 	VariableWidthSpriteFontRenderer(IAGSEngine *engine);
-	~VariableWidthSpriteFontRenderer(void);
+	virtual ~VariableWidthSpriteFontRenderer(void);
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
 	void FreeMemory(int fontNumber) override { }
 	bool SupportsExtendedCharacters(int fontNumber) override;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -9,7 +9,7 @@ public:
 	VariableWidthSpriteFontRenderer(IAGSEngine *engine);
 	virtual ~VariableWidthSpriteFontRenderer(void);
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
-	void FreeMemory(int fontNumber) override { }
+	void FreeMemory(int fontNumber) override;
 	bool SupportsExtendedCharacters(int fontNumber) override;
 	int GetTextWidth(const char *text, int fontNumber) override;
 	int GetTextHeight(const char *text, int fontNumber) override;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -19,6 +19,7 @@ public:
 	void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);
 	void SetSprite(int fontNum, int spriteNum);
 	void SetSpacing(int fontNum, int spacing);
+	void SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride);
 
 private:
 	IAGSEngine *_engine;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -21,7 +21,7 @@ public:
 	void SetSpacing(int fontNum, int spacing);
 	void SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride);
 
-private:
+protected:
 	IAGSEngine *_engine;
 	std::vector<VariableWidthFont * > _fonts;
 	VariableWidthFont *getFontFor(int fontNum);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
@@ -105,13 +105,13 @@ void VariableWidthSpriteFontRendererClifftopGames::Draw(BITMAP *src, BITMAP *des
 				//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
 					
 				srca =  (geta32(srclongbuffer[srcyy][srcxx]));
-            
+
 				if (srca != 0) {
 
 					srcr =  getr32(srclongbuffer[srcyy][srcxx]);
 					srcg =  getg32(srclongbuffer[srcyy][srcxx]);
 					srcb =  getb32(srclongbuffer[srcyy][srcxx]);
-    
+
 					destr =  getr32(destlongbuffer[destyy][destxx]);
 					destg =  getg32(destlongbuffer[destyy][destxx]);
 					destb =  getb32(destlongbuffer[destyy][destxx]);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
@@ -1,0 +1,137 @@
+#include "VariableWidthSpriteFontClifftopGames.h"
+#include <string>
+#include <string.h>
+#include "color.h"
+
+
+VariableWidthSpriteFontRendererClifftopGames::VariableWidthSpriteFontRendererClifftopGames(IAGSEngine *engine)
+	: VariableWidthSpriteFontRenderer(engine)
+{
+}
+
+VariableWidthSpriteFontRendererClifftopGames::~VariableWidthSpriteFontRendererClifftopGames(void) = default;
+
+
+int VariableWidthSpriteFontRendererClifftopGames::GetTextHeight(const char *text, int fontNumber)
+{
+	VariableWidthFont *font = getFontFor(fontNumber);
+	if(strcmp("<LINE_SPACING>", text) == 0)
+		return font->LineSpacingOverride;
+
+	for(int i = 0; i < (int)strlen(text); i++)
+	{
+		if (font->characters.count(text[i]) > 0)
+		{
+			int height = font->characters[text[i]].Height;
+
+			if(strcmp("ZHwypgfjqhkilIK", text) == 0 || strcmp("ZhypjIHQFb", text) == 0 || strcmp("YpyjIHgMNWQ", text) == 0 || strcmp("BigyjTEXT", text) == 0)
+				height += font->LineSpacingAdjust;
+			else
+				height += font->LineHeightAdjust;
+
+			return height;
+		}
+	}
+	return 0;
+}
+
+void VariableWidthSpriteFontRendererClifftopGames::RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour)
+{
+	VariableWidthFont *font = getFontFor(fontNumber);
+	int totalWidth = 0;
+	for(int i = 0; i < strlen(text); i++)
+	{
+		char c = text[i];
+
+		BITMAP *src = _engine->GetSpriteGraphic(font->SpriteNumber);
+		Draw(src, destination, x + totalWidth, y, font->characters[c].X, font->characters[c].Y, font->characters[c].Width, font->characters[c].Height, colour);
+		totalWidth += font->characters[c].Width;
+		if (text[i] != ' ') totalWidth += font->Spacing;
+	}
+}
+
+
+void VariableWidthSpriteFontRendererClifftopGames::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour)
+{
+	int srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
+
+	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
+	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
+    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+
+	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
+	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
+    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+
+	int transColor = _engine->GetBitmapTransparentColor(src);
+
+	_engine->GetBitmapDimensions(src, &srcWidth, &srcHeight, &srcColDepth);
+	_engine->GetBitmapDimensions(dest, &destWidth, &destHeight, &destColDepth);
+
+	if (srcy + height > srcHeight || srcx + width > srcWidth || srcx < 0 || srcy < 0) return;
+
+	if (width + destx > destWidth) width = destWidth - destx;
+	if (height + desty > destHeight) height = destHeight - desty;
+
+	int startx = MAX(0, (-1 * destx));
+	int starty = MAX(0, (-1 * desty));
+
+	int srca, srcr, srcg, srcb, desta, destr, destg, destb, finalr, finalg, finalb, finala, col, col_r, col_g, col_b;
+	col_r = getr32(colour);
+	col_g = getg32(colour);
+	col_b = getb32(colour);
+
+	for(int x = startx; x < width; x ++)
+	{
+		for(int y = starty; y <  height; y ++)
+		{
+			int srcyy = y + srcy;
+			int srcxx = x + srcx;
+			int destyy = y + desty;
+			int destxx = x + destx;
+			if (destColDepth == 8)
+			{
+				if (srccharbuffer[srcyy][srcxx] != transColor)
+					destcharbuffer[destyy][destxx] = srccharbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 16)
+			{
+				if (srcshortbuffer[srcyy][srcxx] != transColor)
+					destshortbuffer[destyy][destxx] = srcshortbuffer[srcyy][srcxx];
+			}
+			else if (destColDepth == 32)
+			{
+				//if (srclongbuffer[srcyy][srcxx] != transColor) destlongbuffer[destyy][destxx] = srclongbuffer[srcyy][srcxx];
+					
+				srca =  (geta32(srclongbuffer[srcyy][srcxx]));
+            
+				if (srca != 0) {
+
+					srcr =  getr32(srclongbuffer[srcyy][srcxx]);
+					srcg =  getg32(srclongbuffer[srcyy][srcxx]);
+					srcb =  getb32(srclongbuffer[srcyy][srcxx]);
+    
+					destr =  getr32(destlongbuffer[destyy][destxx]);
+					destg =  getg32(destlongbuffer[destyy][destxx]);
+					destb =  getb32(destlongbuffer[destyy][destxx]);
+					desta =  geta32(destlongbuffer[destyy][destxx]);
+
+					finalr = (col_r * srcr) / 255;
+					finalg = (col_g * srcg) / 255;
+					finalb = (col_b * srcb) / 255;
+
+					finala = 255-(255-srca)*(255-desta)/255;
+					finalr = srca*finalr/finala + desta*destr*(255-srca)/finala/255;
+					finalg = srca*finalg/finala + desta*destg*(255-srca)/finala/255;
+					finalb = srca*finalb/finala + desta*destb*(255-srca)/finala/255;
+					col = makeacol32(finalr, finalg, finalb, finala);
+					destlongbuffer[destyy][destxx] = col;
+				}
+			}
+		}
+	}
+
+	_engine->ReleaseBitmapSurface(src);
+	_engine->ReleaseBitmapSurface(dest);
+}
+

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
@@ -1,6 +1,7 @@
 #include "VariableWidthSpriteFontClifftopGames.h"
 #include <string>
 #include <string.h>
+#include <stdint.h>
 #include "color.h"
 
 
@@ -53,15 +54,15 @@ void VariableWidthSpriteFontRendererClifftopGames::RenderText(const char *text, 
 
 void VariableWidthSpriteFontRendererClifftopGames::Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour)
 {
-	int srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
+	int32 srcWidth, srcHeight, destWidth, destHeight, srcColDepth, destColDepth;
 
 	unsigned char **srccharbuffer = _engine->GetRawBitmapSurface (src); //8bit
-	unsigned short **srcshortbuffer = (unsigned short**)srccharbuffer; //16bit;
-    unsigned int **srclongbuffer = (unsigned int**)srccharbuffer; //32bit
+	uint16_t **srcshortbuffer = (uint16_t**)srccharbuffer; //16bit;
+	uint32_t **srclongbuffer = (uint32_t**)srccharbuffer; //32bit
 
 	unsigned char **destcharbuffer = _engine->GetRawBitmapSurface (dest); //8bit
-	unsigned short **destshortbuffer = (unsigned short**)destcharbuffer; //16bit;
-    unsigned int **destlongbuffer = (unsigned int**)destcharbuffer; //32bit
+	uint16_t **destshortbuffer = (uint16_t**)destcharbuffer; //16bit;
+	uint32_t **destlongbuffer = (uint32_t**)destcharbuffer; //32bit
 
 	int transColor = _engine->GetBitmapTransparentColor(src);
 

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "VariableWidthSpriteFont.h"
+
+class VariableWidthSpriteFontRendererClifftopGames : public VariableWidthSpriteFontRenderer
+{
+public:
+	VariableWidthSpriteFontRendererClifftopGames(IAGSEngine *engine);
+	~VariableWidthSpriteFontRendererClifftopGames(void) override;
+
+	int GetTextHeight(const char *text, int fontNumber) override;
+	void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
+
+private:
+	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height, int colour);
+};
+

--- a/Plugins/AGSSpriteFont/Makefile-objs
+++ b/Plugins/AGSSpriteFont/Makefile-objs
@@ -3,5 +3,7 @@ AGSSpriteFont/CharacterEntry.o \
 AGSSpriteFont/color.o \
 AGSSpriteFont/SpriteFont.o \
 AGSSpriteFont/SpriteFontRenderer.o \
+AGSSpriteFont/SpriteFontRendererClifftopGames.o \
 AGSSpriteFont/VariableWidthFont.o \
-AGSSpriteFont/VariableWidthSpriteFont.o
+AGSSpriteFont/VariableWidthSpriteFont.o \
+AGSSpriteFont/VariableWidthSpriteFontClifftopGames.o

--- a/iOS/xcode/ags/ags.xcodeproj/project.pbxproj
+++ b/iOS/xcode/ags/ags.xcodeproj/project.pbxproj
@@ -378,6 +378,8 @@
 		60BC89A8155E969700807358 /* iTunesArtwork in Resources */ = {isa = PBXBuildFile; fileRef = 60BC89A7155E969700807358 /* iTunesArtwork */; };
 		60CE9D9C155272CD00A52D5A /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 60CE9D9B155272CD00A52D5A /* libfreetype.a */; };
 		60F49A4A155131E500A07887 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60F49A49155131E500A07887 /* AudioToolbox.framework */; };
+		A3A465962866964700AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A465922866964700AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */; };
+		A3A465972866964700AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A465932866964700AE0372 /* SpriteFontRendererClifftopGames.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1132,6 +1134,11 @@
 		60CE9D9B155272CD00A52D5A /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = ../../nativelibs/fat/lib/libfreetype.a; sourceTree = SOURCE_ROOT; };
 		60F49A49155131E500A07887 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		8D1107310486CEB800E47090 /* ags-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ags-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		A3A465912866964700AE0372 /* AGSSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSSpriteFont.h; sourceTree = "<group>"; };
+		A3A465922866964700AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFontClifftopGames.cpp; sourceTree = "<group>"; };
+		A3A465932866964700AE0372 /* SpriteFontRendererClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRendererClifftopGames.cpp; sourceTree = "<group>"; };
+		A3A465942866964700AE0372 /* VariableWidthSpriteFontClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFontClifftopGames.h; sourceTree = "<group>"; };
+		A3A465952866964700AE0372 /* SpriteFontRendererClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRendererClifftopGames.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2352,6 +2359,11 @@
 		60898CCC160779DA009E152F /* AGSSpriteFont */ = {
 			isa = PBXGroup;
 			children = (
+				A3A465912866964700AE0372 /* AGSSpriteFont.h */,
+				A3A465932866964700AE0372 /* SpriteFontRendererClifftopGames.cpp */,
+				A3A465952866964700AE0372 /* SpriteFontRendererClifftopGames.h */,
+				A3A465922866964700AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */,
+				A3A465942866964700AE0372 /* VariableWidthSpriteFontClifftopGames.h */,
 				60898CCD160779DA009E152F /* AGSSpriteFont.cpp */,
 				60898CD0160779DA009E152F /* CharacterEntry.cpp */,
 				60898CD1160779DA009E152F /* CharacterEntry.h */,
@@ -2597,6 +2609,7 @@
 				526F1FC91D3B513400EF4E1F /* datetime.cpp in Sources */,
 				526F1FDF1D3B513400EF4E1F /* managedobjectpool.cpp in Sources */,
 				526F204B1D3B513400EF4E1F /* gfxdriverbase.cpp in Sources */,
+				A3A465972866964700AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */,
 				526F20051D3B513400EF4E1F /* global_record.cpp in Sources */,
 				526F206A1D3B513400EF4E1F /* common.c in Sources */,
 				526F20461D3B513400EF4E1F /* ali3dogl.cpp in Sources */,
@@ -2793,6 +2806,7 @@
 				60898D82160779DB009E152F /* SpriteFontRenderer.cpp in Sources */,
 				526F20EA1D3B513400EF4E1F /* agsplatformdriver.cpp in Sources */,
 				526F20471D3B513400EF4E1F /* ali3dsw.cpp in Sources */,
+				A3A465962866964700AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */,
 				526F207B1D3B513400EF4E1F /* aaudio.c in Sources */,
 				60898D84160779DB009E152F /* VariableWidthFont.cpp in Sources */,
 				526F1FD91D3B513400EF4E1F /* cc_guiobject.cpp in Sources */,


### PR DESCRIPTION
This pull request does mainly two things:
* Register the AGSSpriteFont plugin (since currently it is not used and stub functions are used instead).
* Implement the variant of the plugin used for Clifftop Games (Kathy Rain and Whispers of a Machine).

It also fixes some issues with the AGSSpriteFont plugin, such as memory leaks.

I am aware of PR #834, but I used a different approach in the implementation here: I added two new font renderer classes that derive from the unmodified ones of the original plugin and implement the modified functions only. The advantage of this approach is that we can either instantiate the base renderers or the modified ones depending on the game. However that is something I did not actually know how to do (see f89a2f5ff14c111efd7ed52a57ad309cf491f7cb) so any guidance on that point would be welcome.

This is the same approach I used previously in ScummVM to implement the Clifftop Games variant of the plugin and most of the changes in this pull request is borrowed from my previous work. Sadly the approach we used in ScummVM to select the renderers is probably not applicable here since it relies on the game detection system specific to ScummVM.

Another impact of this design decision is that I had to make the `IAGSFontRenderer` destructor virtual so that the destruction of the renderers in the plugin works properly.

I updated the Visual Studio and Xcode files, but this was not tested and I don't know if this is correct.
The changes were only tested on macOS using cmake.

And finally here is a comparison with Kathy Rain:

Current AGS code:
![image](https://user-images.githubusercontent.com/552105/175752656-02af10f4-f981-4e37-9a1c-29dd44168d93.png)


With the changes from this pull request:
![image](https://user-images.githubusercontent.com/552105/175752660-6b7163fe-b94e-4bff-a136-15f0ea1da20b.png)

