### PR TITLE
Android: fix access level for extended classes

### DIFF
--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
@@ -46,10 +46,10 @@ import java.io.FileNotFoundException;
  * status bar and navigation/system bar) with user interaction.
  */
 public class AGSRuntimeActivity extends SDLActivity {
-    private String _game_file_name = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
-    private String _android_base_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
-    private String _android_app_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
-    private boolean _loadLastSave = false; // Can't be local variable since ags engine reads it. See acpland.cpp.
+    protected String _game_file_name = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
+    protected String _android_base_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
+    protected String _android_app_directory = ""; // Can't be local variable since ags engine reads it. See acpland.cpp.
+    protected boolean _loadLastSave = false; // Can't be local variable since ags engine reads it. See acpland.cpp.
 
     public static native void nativeSdlShowKeyboard();
 
@@ -281,7 +281,7 @@ public class AGSRuntimeActivity extends SDLActivity {
     }
 
     @Keep
-    private  void AgsEnableLongclick() {
+    protected  void AgsEnableLongclick() {
 
     }
 


### PR DESCRIPTION
these methods and properties are accessed from the Native parts in acpland, but we extend `AGSRuntimeActivity` as `AGSPlayerRuntimeActivity` for the AGS Player app, so these need to be protected instead of private to be accessible.

For some reason this behavior is only affecting native in old versions of Android (!)

fix #1712