### PR TITLE
CMake: debug defines only set per external config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(AGS_NO_MP3_PLAYER "Disable MP3" OFF)
 option(AGS_NO_VIDEO_PLAYER "Disable Video" OFF)
 option(AGS_BUILTIN_PLUGINS "Built in plugins" ON)
 option(AGS_DEBUG_MANAGED_OBJECTS "Managed Objects Log" OFF)
+option(AGS_DEBUG_SPRITECACHE "Sprite Cache Log" OFF)
 set(AGS_BUILD_STR "" CACHE STRING "Engine Build Information")
 
 

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -211,7 +211,13 @@ if(NOT MSVC)
     target_compile_options(common PUBLIC -Werror=undef)
 endif()
 
-target_compile_definitions(common PUBLIC "$<$<CONFIG:DEBUG>:DEBUG_SPRITECACHE>")
+if(AGS_DEBUG_MANAGED_OBJECTS)
+    target_compile_definitions(common PUBLIC "DEBUG_MANAGED_OBJECTS=1")
+endif()
+
+if(AGS_DEBUG_SPRITECACHE)
+    target_compile_definitions(common PUBLIC "DEBUG_SPRITECACHE=1")
+endif()
 
 get_target_property(COMMON_SOURCES common SOURCES)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Source Files" FILES ${COMMON_SOURCES})

--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -11,6 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include "core/platform.h"
 #include "ac/spritecache.h"
 #include "ac/gamestructdefines.h"
 #include "debug/out.h"
@@ -112,7 +113,7 @@ void SpriteCache::SetSprite(sprkey_t index, Bitmap *sprite)
     _spriteData[index].Image = sprite;
     _spriteData[index].Flags = SPRCACHEFLAG_LOCKED; // NOT from asset file
     _spriteData[index].Size = 0;
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "SetSprite: (external) %d", index);
 #endif
 }
@@ -137,7 +138,7 @@ void SpriteCache::SubstituteBitmap(sprkey_t index, Bitmap *sprite)
         return;
     }
     _spriteData[index].Image = sprite;
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "SubstituteBitmap: %d", index);
 #endif
 }
@@ -147,7 +148,7 @@ void SpriteCache::RemoveSprite(sprkey_t index, bool freeMemory)
     if (freeMemory)
         delete _spriteData[index].Image;
     InitNullSpriteParams(index);
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "RemoveSprite: %d", index);
 #endif
 }
@@ -268,7 +269,7 @@ void SpriteCache::DisposeOldest()
         _cacheSize -= _spriteData[sprnum].Size;
         delete _spriteData[*it].Image;
         _spriteData[sprnum].Image = nullptr;
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
         Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "DisposeOldest: disposed %d, size now %d KB", sprnum, _cacheSize / 1024);
 #endif
     }
@@ -315,7 +316,7 @@ void SpriteCache::Precache(sprkey_t index)
     _maxCacheSize += sprSize;
     _lockedSize += sprSize;
     _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Precached %d", index);
 #endif
 }
@@ -368,7 +369,7 @@ size_t SpriteCache::LoadSprite(sprkey_t index)
     _spriteData[index].Size = size;
     _cacheSize += size;
 
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "Loaded %d, size now %zu KB", index, _cacheSize / 1024);
 #endif
 
@@ -383,7 +384,7 @@ void SpriteCache::RemapSpriteToSprite0(sprkey_t index)
     _spriteData[index].Image = nullptr;
     _spriteData[index].Size = _spriteData[0].Size;
     _spriteData[index].Flags |= SPRCACHEFLAG_REMAPPED;
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
     Debug::Printf(kDbgGroup_SprCache, kDbgMsg_Debug, "RemapSpriteToSprite0: %d", index);
 #endif
 }

--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -161,4 +161,12 @@
 
 #define AGS_PLATFORM_IS_XDG_UNIX (AGS_PLATFORM_OS_LINUX || AGS_PLATFORM_OS_FREEBSD)
 
+#if !defined(DEBUG_MANAGED_OBJECTS)
+    #define DEBUG_MANAGED_OBJECTS (0)
+#endif
+
+#if !defined(DEBUG_SPRITECACHE)
+    #define DEBUG_SPRITECACHE (0)
+#endif
+
 #endif // __AC_PLATFORM_H

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -523,10 +523,6 @@ if (AGS_BUILTIN_PLUGINS)
     )
 endif()
 
-target_compile_definitions(engine PRIVATE
-    $<$<BOOL:AGS_DEBUG_MANAGED_OBJECTS>:DEBUG_MANAGED_OBJECTS>
-)
-
 if (AGS_BUILD_STR)
     target_compile_definitions(engine PUBLIC BUILD_STR=\"${AGS_BUILD_STR}\")
 endif()

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -24,10 +24,9 @@
 //
 //=============================================================================
 
-//#define DEBUG_MANAGED_OBJECTS
-
 #include <stdlib.h>
 #include <string.h>
+#include "core/platform.h"
 #include "ac/dynobj/cc_dynamicobject.h"
 #include "ac/dynobj/managedobjectpool.h"
 #include "debug/out.h"

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -19,6 +19,7 @@
 #include <queue>
 #include <unordered_map>
 
+#include "core/platform.h"
 #include "script/runtimescriptvalue.h"
 #include "ac/dynobj/cc_dynamicobject.h"   // ICCDynamicObject
 
@@ -79,7 +80,7 @@ public:
 
 extern ManagedObjectPool pool;
 
-#ifdef DEBUG_MANAGED_OBJECTS
+#if DEBUG_MANAGED_OBJECTS
 #define ManagedObjectLog(...) Debug::Printf(kDbgGroup_ManObj, kDbgMsg_Debug, __VA_ARGS__)
 #else
 #define ManagedObjectLog(...)

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -283,12 +283,12 @@ void apply_debug_config(const ConfigTree &cfg)
           DbgGroupOption(kDbgGroup_SDL, kDbgMsg_Info),
           DbgGroupOption(kDbgGroup_Game, kDbgMsg_Info),
           DbgGroupOption(kDbgGroup_Script, kDbgMsg_All),
-#ifdef DEBUG_SPRITECACHE
+#if DEBUG_SPRITECACHE
           DbgGroupOption(kDbgGroup_SprCache, kDbgMsg_All),
 #else
           DbgGroupOption(kDbgGroup_SprCache, kDbgMsg_Info),
 #endif
-#ifdef DEBUG_MANAGED_OBJECTS
+#if DEBUG_MANAGED_OBJECTS
           DbgGroupOption(kDbgGroup_ManObj, kDbgMsg_All),
 #else
           DbgGroupOption(kDbgGroup_ManObj, kDbgMsg_Info),


### PR DESCRIPTION
We used to set macro DEBUG_SPRITECACHE=1 in Debug builds and DEBUG_SPRITECACHE=0 in Release builds,
and also set DEBUG_MANAGED_OBJECTS=0 or 1 depending on the command line config of AGS_DEBUG_MANAGED_OBJECTS

But in the code, we actually test using `#ifdef` instead of `#if`.

This commit

- only define DEBUG_MANAGED_OBJECTS if AGS_DEBUG_MANAGED_OBJECTS is true
- adds a new command line flag AGS_DEBUG_SPRITECACHE, which will only define DEBUG_SPRITECACHE if true