### PR TITLE
Editor: fix for autocomplete not selecting proper line

### DIFF
--- a/Editor/scintilla/lexlib/CharacterSet.cxx
+++ b/Editor/scintilla/lexlib/CharacterSet.cxx
@@ -18,10 +18,10 @@ namespace Scintilla {
 int CompareCaseInsensitive(const char *a, const char *b) noexcept {
 	while (*a && *b) {
 		if (*a != *b) {
-			const char upperA = MakeUpperCase(*a);
-			const char upperB = MakeUpperCase(*b);
-			if (upperA != upperB)
-				return upperA - upperB;
+			const char lowerA = MakeLowerCase(*a);
+			const char lowerB = MakeLowerCase(*b);
+			if (lowerA != lowerB)
+				return lowerA - lowerB;
 		}
 		a++;
 		b++;
@@ -33,10 +33,10 @@ int CompareCaseInsensitive(const char *a, const char *b) noexcept {
 int CompareNCaseInsensitive(const char *a, const char *b, size_t len) noexcept {
 	while (*a && *b && len) {
 		if (*a != *b) {
-			const char upperA = MakeUpperCase(*a);
-			const char upperB = MakeUpperCase(*b);
-			if (upperA != upperB)
-				return upperA - upperB;
+			const char lowerA = MakeLowerCase(*a);
+			const char lowerB = MakeLowerCase(*b);
+			if (lowerA != lowerB)
+				return lowerA - lowerB;
 		}
 		a++;
 		b++;


### PR DESCRIPTION
Fixes #1599, at least partially. Would need to check all mentioned cases in that ticket, and ammend with more fixes if necessary.

The root of the "underscore" problem was that Scintilla library used an uncommon "case insensitive comparison" implementation. While many libraries, including .NET, seem to use lowercase values for that, Scintilla converts to uppercase. Uppercase letters have different relational position to "underscore" character. Changing it to use lowercase comparison instead makes it match the Editor's sort.