### PR TITLE
Editor: zoom View's preview frame and Character preview

### DIFF
--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -264,6 +264,22 @@ namespace AGS.Editor
             }
         }
 
+        public Size GetMaxViewFrameSize(View view, out bool hasLowResSprites)
+        {
+            lock (_spriteSetLock)
+            {
+                List<int> sprites = new List<int>();
+                foreach (ViewLoop loop in view.Loops)
+                {
+                    foreach (ViewFrame frame in loop.Frames)
+                    {
+                        sprites.Add(frame.Image);
+                    }
+                }
+                return _native.GetMaxSpriteSize(sprites.ToArray(), out hasLowResSprites);
+            }
+        }
+
         public Room LoadRoom(UnloadedRoom roomToLoad, Encoding defEncoding = null)
         {
             return _native.LoadRoomFile(roomToLoad, defEncoding);

--- a/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
@@ -29,51 +29,70 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.viewPreview2 = new AGS.Editor.ViewPreview();
-            this.viewPreview1 = new AGS.Editor.ViewPreview();
-            this.btnMakePlayer = new System.Windows.Forms.Button();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.lblIsPlayer = new System.Windows.Forms.Label();
+            this.btnMakePlayer = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
+            this.viewPreview1 = new AGS.Editor.ViewPreview();
+            this.viewPreview2 = new AGS.Editor.ViewPreview();
             this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.viewPreview2);
-            this.groupBox1.Controls.Add(this.viewPreview1);
-            this.groupBox1.Controls.Add(this.btnMakePlayer);
-            this.groupBox1.Controls.Add(this.lblIsPlayer);
-            this.groupBox1.Location = new System.Drawing.Point(5, 5);
+            this.groupBox1.Controls.Add(this.splitContainer1);
+            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox1.Location = new System.Drawing.Point(0, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(581, 424);
+            this.groupBox1.Size = new System.Drawing.Size(588, 451);
             this.groupBox1.TabIndex = 5;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Selected character settings";
             // 
-            // viewPreview2
+            // splitContainer1
             // 
-            this.viewPreview2.DynamicUpdates = false;
-            this.viewPreview2.IsCharacterView = false;
-            this.viewPreview2.Location = new System.Drawing.Point(294, 89);
-            this.viewPreview2.Name = "viewPreview2";
-            this.viewPreview2.Size = new System.Drawing.Size(274, 328);
-            this.viewPreview2.TabIndex = 10;
-            this.viewPreview2.Title = "Speech view";
-            this.viewPreview2.ViewToPreview = null;
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.IsSplitterFixed = true;
+            this.splitContainer1.Location = new System.Drawing.Point(3, 17);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
-            // viewPreview1
+            // splitContainer1.Panel1
             // 
-            this.viewPreview1.DynamicUpdates = false;
-            this.viewPreview1.IsCharacterView = false;
-            this.viewPreview1.Location = new System.Drawing.Point(14, 89);
-            this.viewPreview1.Name = "viewPreview1";
-            this.viewPreview1.Size = new System.Drawing.Size(274, 328);
-            this.viewPreview1.TabIndex = 9;
-            this.viewPreview1.Title = "Normal view";
-            this.viewPreview1.ViewToPreview = null;
+            this.splitContainer1.Panel1.Controls.Add(this.sldZoomLevel);
+            this.splitContainer1.Panel1.Controls.Add(this.lblIsPlayer);
+            this.splitContainer1.Panel1.Controls.Add(this.btnMakePlayer);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.AutoScroll = true;
+            this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel1);
+            this.splitContainer1.Size = new System.Drawing.Size(582, 431);
+            this.splitContainer1.SplitterDistance = 80;
+            this.splitContainer1.SplitterWidth = 3;
+            this.splitContainer1.TabIndex = 11;
+            // 
+            // lblIsPlayer
+            // 
+            this.lblIsPlayer.AutoSize = true;
+            this.lblIsPlayer.Location = new System.Drawing.Point(8, 9);
+            this.lblIsPlayer.MaximumSize = new System.Drawing.Size(400, 0);
+            this.lblIsPlayer.Name = "lblIsPlayer";
+            this.lblIsPlayer.Size = new System.Drawing.Size(398, 26);
+            this.lblIsPlayer.TabIndex = 5;
+            this.lblIsPlayer.Text = "This character is OR IS NOT the player; the game will startin this character\'s ro" +
+    "om or something";
             // 
             // btnMakePlayer
             // 
-            this.btnMakePlayer.Location = new System.Drawing.Point(19, 60);
+            this.btnMakePlayer.Location = new System.Drawing.Point(11, 43);
             this.btnMakePlayer.Name = "btnMakePlayer";
             this.btnMakePlayer.Size = new System.Drawing.Size(188, 23);
             this.btnMakePlayer.TabIndex = 6;
@@ -81,16 +100,64 @@ namespace AGS.Editor
             this.btnMakePlayer.UseVisualStyleBackColor = true;
             this.btnMakePlayer.Click += new System.EventHandler(this.btnMakePlayer_Click);
             // 
-            // lblIsPlayer
+            // tableLayoutPanel1
             // 
-            this.lblIsPlayer.AutoSize = true;
-            this.lblIsPlayer.Location = new System.Drawing.Point(16, 26);
-            this.lblIsPlayer.MaximumSize = new System.Drawing.Size(400, 0);
-            this.lblIsPlayer.Name = "lblIsPlayer";
-            this.lblIsPlayer.Size = new System.Drawing.Size(398, 26);
-            this.lblIsPlayer.TabIndex = 5;
-            this.lblIsPlayer.Text = "This character is OR IS NOT the player; the game will startin this character\'s ro" +
-    "om or something";
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.viewPreview2, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.viewPreview1, 0, 0);
+            this.tableLayoutPanel1.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(572, 334);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // sldZoomLevel
+            // 
+            this.sldZoomLevel.Location = new System.Drawing.Point(356, 37);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.sldZoomLevel.Maximum = 800;
+            this.sldZoomLevel.Minimum = 100;
+            this.sldZoomLevel.Name = "sldZoomLevel";
+            this.sldZoomLevel.Size = new System.Drawing.Size(177, 32);
+            this.sldZoomLevel.Step = 25;
+            this.sldZoomLevel.TabIndex = 9;
+            this.sldZoomLevel.Value = 100;
+            this.sldZoomLevel.ZoomScale = 1F;
+            this.sldZoomLevel.ValueChanged += new System.EventHandler(this.sldZoomLevel_ValueChanged);
+            // 
+            // viewPreview1
+            // 
+            this.viewPreview1.AutoResize = false;
+            this.viewPreview1.DynamicUpdates = false;
+            this.viewPreview1.IsCharacterView = false;
+            this.viewPreview1.Location = new System.Drawing.Point(3, 3);
+            this.viewPreview1.MinimumSize = new System.Drawing.Size(280, 320);
+            this.viewPreview1.Name = "viewPreview1";
+            this.viewPreview1.Size = new System.Drawing.Size(280, 328);
+            this.viewPreview1.TabIndex = 9;
+            this.viewPreview1.Title = "Normal view";
+            this.viewPreview1.ViewToPreview = null;
+            this.viewPreview1.ZoomLevel = 1F;
+            // 
+            // viewPreview2
+            // 
+            this.viewPreview2.AutoResize = false;
+            this.viewPreview2.DynamicUpdates = false;
+            this.viewPreview2.IsCharacterView = false;
+            this.viewPreview2.Location = new System.Drawing.Point(289, 3);
+            this.viewPreview2.MinimumSize = new System.Drawing.Size(280, 320);
+            this.viewPreview2.Name = "viewPreview2";
+            this.viewPreview2.Size = new System.Drawing.Size(280, 328);
+            this.viewPreview2.TabIndex = 10;
+            this.viewPreview2.Title = "Speech view";
+            this.viewPreview2.ViewToPreview = null;
+            this.viewPreview2.ZoomLevel = 1F;
             // 
             // CharacterEditor
             // 
@@ -99,10 +166,16 @@ namespace AGS.Editor
             this.Controls.Add(this.groupBox1);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CharacterEditor";
-            this.Size = new System.Drawing.Size(593, 441);
+            this.Size = new System.Drawing.Size(588, 451);
             this.Load += new System.EventHandler(this.CharacterEditor_Load);
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -114,6 +187,8 @@ namespace AGS.Editor
         private System.Windows.Forms.Label lblIsPlayer;
         private ViewPreview viewPreview2;
         private ViewPreview viewPreview1;
-
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private ZoomTrackbar sldZoomLevel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/Editor/AGS.Editor/Panes/CharacterEditor.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.cs
@@ -15,12 +15,21 @@ namespace AGS.Editor
         private System.Drawing.Font _normalFont;
         private System.Drawing.Font _boldFont;
 
-        public CharacterEditor(Character characterToEdit)
+        public CharacterEditor()
         {
             InitializeComponent();
-            _character = characterToEdit;
             _normalFont = lblIsPlayer.Font;
             _boldFont = new System.Drawing.Font(_normalFont.Name, _normalFont.Size, FontStyle.Bold);
+            viewPreview1.AutoResize = true;
+            viewPreview2.AutoResize = true;
+            viewPreview1.ZoomLevel = sldZoomLevel.ZoomScale;
+            viewPreview2.ZoomLevel = sldZoomLevel.ZoomScale;
+        }
+
+        public CharacterEditor(Character characterToEdit) : this()
+        {
+            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            _character = characterToEdit;
             viewPreview1.IsCharacterView = true;
             viewPreview2.IsCharacterView = true;
             UpdateActivateCharacterText();
@@ -97,6 +106,12 @@ namespace AGS.Editor
             {
                 Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             }
+        }
+        
+        private void sldZoomLevel_ValueChanged(object sender, EventArgs e)
+        {
+            viewPreview1.ZoomLevel = sldZoomLevel.ZoomScale;
+            viewPreview2.ZoomLevel = sldZoomLevel.ZoomScale;
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/CharacterEditor.resx
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
@@ -29,27 +29,27 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.currentItemGroupBox = new System.Windows.Forms.GroupBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.panelScrollAreaCursor = new System.Windows.Forms.Panel();
-            this.pnlCursorImage = new System.Windows.Forms.Panel();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
+            this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.panelScrollAreaImage = new System.Windows.Forms.Panel();
             this.pnlInvWindowImage = new System.Windows.Forms.Panel();
-            this.label1 = new System.Windows.Forms.Label();
-            this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.panelScrollAreaCursor = new System.Windows.Forms.Panel();
+            this.pnlCursorImage = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.currentItemGroupBox.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.panelScrollAreaCursor.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.panelScrollAreaImage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.panelScrollAreaImage.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.panelScrollAreaCursor.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // currentItemGroupBox
@@ -59,130 +59,19 @@ namespace AGS.Editor
             this.currentItemGroupBox.Controls.Add(this.splitContainer1);
             this.currentItemGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.currentItemGroupBox.Location = new System.Drawing.Point(0, 0);
-            this.currentItemGroupBox.Margin = new System.Windows.Forms.Padding(4);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
-            this.currentItemGroupBox.Padding = new System.Windows.Forms.Padding(4);
-            this.currentItemGroupBox.Size = new System.Drawing.Size(791, 414);
+            this.currentItemGroupBox.Size = new System.Drawing.Size(633, 331);
             this.currentItemGroupBox.TabIndex = 1;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected inventory item settings";
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.AutoSize = true;
-            this.groupBox2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.groupBox2.Controls.Add(this.panelScrollAreaCursor);
-            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Location = new System.Drawing.Point(354, 4);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
-            this.groupBox2.MinimumSize = new System.Drawing.Size(300, 300);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox2.Size = new System.Drawing.Size(320, 300);
-            this.groupBox2.TabIndex = 7;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Mouse cursor image";
-            // 
-            // panelScrollAreaCursor
-            // 
-            this.panelScrollAreaCursor.AutoScroll = true;
-            this.panelScrollAreaCursor.AutoSize = true;
-            this.panelScrollAreaCursor.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.panelScrollAreaCursor.Controls.Add(this.pnlCursorImage);
-            this.panelScrollAreaCursor.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelScrollAreaCursor.Location = new System.Drawing.Point(4, 21);
-            this.panelScrollAreaCursor.Name = "panelScrollAreaCursor";
-            this.panelScrollAreaCursor.Size = new System.Drawing.Size(312, 275);
-            this.panelScrollAreaCursor.TabIndex = 5;
-            // 
-            // pnlCursorImage
-            // 
-            this.pnlCursorImage.Location = new System.Drawing.Point(4, 4);
-            this.pnlCursorImage.Margin = new System.Windows.Forms.Padding(4);
-            this.pnlCursorImage.Name = "pnlCursorImage";
-            this.pnlCursorImage.Size = new System.Drawing.Size(304, 244);
-            this.pnlCursorImage.TabIndex = 3;
-            this.pnlCursorImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlCursorImage_Paint);
-            this.pnlCursorImage.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pnlCursorImage_MouseDown);
-            this.pnlCursorImage.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.pnlCursorImage_MouseWheel);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 26);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(314, 17);
-            this.label2.TabIndex = 4;
-            this.label2.Text = "Click in the Mouse cursor image to set it\'s hotspot.";
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.AutoSize = true;
-            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.groupBox1.Controls.Add(this.panelScrollAreaImage);
-            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(4, 4);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
-            this.groupBox1.MinimumSize = new System.Drawing.Size(300, 300);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox1.Size = new System.Drawing.Size(342, 300);
-            this.groupBox1.TabIndex = 6;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Image in inventory window";
-            // 
-            // panelScrollAreaImage
-            // 
-            this.panelScrollAreaImage.AutoScroll = true;
-            this.panelScrollAreaImage.AutoSize = true;
-            this.panelScrollAreaImage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.panelScrollAreaImage.Controls.Add(this.pnlInvWindowImage);
-            this.panelScrollAreaImage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelScrollAreaImage.Location = new System.Drawing.Point(4, 21);
-            this.panelScrollAreaImage.Name = "panelScrollAreaImage";
-            this.panelScrollAreaImage.Size = new System.Drawing.Size(334, 275);
-            this.panelScrollAreaImage.TabIndex = 6;
-            // 
-            // pnlInvWindowImage
-            // 
-            this.pnlInvWindowImage.Location = new System.Drawing.Point(4, 4);
-            this.pnlInvWindowImage.Margin = new System.Windows.Forms.Padding(4);
-            this.pnlInvWindowImage.Name = "pnlInvWindowImage";
-            this.pnlInvWindowImage.Size = new System.Drawing.Size(326, 244);
-            this.pnlInvWindowImage.TabIndex = 5;
-            this.pnlInvWindowImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlInvWindowImage_Paint);
-            this.pnlInvWindowImage.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.pnlInvWindowImage_MouseWheel);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 3);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(370, 17);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Use the property grid on the right to change basic settings.";
-            // 
-            // sldZoomLevel
-            // 
-            this.sldZoomLevel.Location = new System.Drawing.Point(394, 3);
-            this.sldZoomLevel.Maximum = 800;
-            this.sldZoomLevel.Minimum = 100;
-            this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(221, 40);
-            this.sldZoomLevel.Step = 25;
-            this.sldZoomLevel.TabIndex = 8;
-            this.sldZoomLevel.Value = 400;
-            this.sldZoomLevel.ZoomScale = 4F;
-            this.sldZoomLevel.ValueChanged += new System.EventHandler(this.zoomSlider_ValueChanged);
             // 
             // splitContainer1
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(4, 21);
+            this.splitContainer1.Location = new System.Drawing.Point(3, 17);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -194,51 +83,157 @@ namespace AGS.Editor
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.flowLayoutPanel1);
-            this.splitContainer1.Size = new System.Drawing.Size(783, 389);
+            this.splitContainer1.Panel2.AutoScroll = true;
+            this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel1);
+            this.splitContainer1.Size = new System.Drawing.Size(627, 311);
             this.splitContainer1.SplitterDistance = 60;
+            this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 9;
             // 
-            // flowLayoutPanel1
+            // label1
             // 
-            this.flowLayoutPanel1.AutoScroll = true;
-            this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flowLayoutPanel1.Controls.Add(this.groupBox1);
-            this.flowLayoutPanel1.Controls.Add(this.groupBox2);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.flowLayoutPanel1.MinimumSize = new System.Drawing.Size(400, 400);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(783, 400);
-            this.flowLayoutPanel1.TabIndex = 8;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 2);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(292, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Use the property grid on the right to change basic settings.";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 21);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(247, 13);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "Click in the Mouse cursor image to set it\'s hotspot.";
+            // 
+            // sldZoomLevel
+            // 
+            this.sldZoomLevel.Location = new System.Drawing.Point(315, 2);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.sldZoomLevel.Maximum = 800;
+            this.sldZoomLevel.Minimum = 100;
+            this.sldZoomLevel.Name = "sldZoomLevel";
+            this.sldZoomLevel.Size = new System.Drawing.Size(177, 32);
+            this.sldZoomLevel.Step = 25;
+            this.sldZoomLevel.TabIndex = 8;
+            this.sldZoomLevel.Value = 400;
+            this.sldZoomLevel.ZoomScale = 4F;
+            this.sldZoomLevel.ValueChanged += new System.EventHandler(this.zoomSlider_ValueChanged);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.AutoSize = true;
+            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox1.Controls.Add(this.panelScrollAreaImage);
+            this.groupBox1.Location = new System.Drawing.Point(3, 3);
+            this.groupBox1.MinimumSize = new System.Drawing.Size(240, 240);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(273, 240);
+            this.groupBox1.TabIndex = 6;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Image in inventory window";
+            // 
+            // panelScrollAreaImage
+            // 
+            this.panelScrollAreaImage.AutoScroll = true;
+            this.panelScrollAreaImage.AutoSize = true;
+            this.panelScrollAreaImage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panelScrollAreaImage.Controls.Add(this.pnlInvWindowImage);
+            this.panelScrollAreaImage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelScrollAreaImage.Location = new System.Drawing.Point(3, 17);
+            this.panelScrollAreaImage.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelScrollAreaImage.Name = "panelScrollAreaImage";
+            this.panelScrollAreaImage.Size = new System.Drawing.Size(267, 220);
+            this.panelScrollAreaImage.TabIndex = 6;
+            // 
+            // pnlInvWindowImage
+            // 
+            this.pnlInvWindowImage.Location = new System.Drawing.Point(3, 3);
+            this.pnlInvWindowImage.Name = "pnlInvWindowImage";
+            this.pnlInvWindowImage.Size = new System.Drawing.Size(261, 195);
+            this.pnlInvWindowImage.TabIndex = 5;
+            this.pnlInvWindowImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlInvWindowImage_Paint);
+            this.pnlInvWindowImage.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.pnlInvWindowImage_MouseWheel);
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.AutoSize = true;
+            this.groupBox2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox2.Controls.Add(this.panelScrollAreaCursor);
+            this.groupBox2.Location = new System.Drawing.Point(282, 3);
+            this.groupBox2.MinimumSize = new System.Drawing.Size(240, 240);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(255, 240);
+            this.groupBox2.TabIndex = 7;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Mouse cursor image";
+            // 
+            // panelScrollAreaCursor
+            // 
+            this.panelScrollAreaCursor.AutoScroll = true;
+            this.panelScrollAreaCursor.AutoSize = true;
+            this.panelScrollAreaCursor.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panelScrollAreaCursor.Controls.Add(this.pnlCursorImage);
+            this.panelScrollAreaCursor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelScrollAreaCursor.Location = new System.Drawing.Point(3, 17);
+            this.panelScrollAreaCursor.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.panelScrollAreaCursor.Name = "panelScrollAreaCursor";
+            this.panelScrollAreaCursor.Size = new System.Drawing.Size(249, 220);
+            this.panelScrollAreaCursor.TabIndex = 5;
+            // 
+            // pnlCursorImage
+            // 
+            this.pnlCursorImage.Location = new System.Drawing.Point(3, 3);
+            this.pnlCursorImage.Name = "pnlCursorImage";
+            this.pnlCursorImage.Size = new System.Drawing.Size(243, 195);
+            this.pnlCursorImage.TabIndex = 3;
+            this.pnlCursorImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlCursorImage_Paint);
+            this.pnlCursorImage.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pnlCursorImage_MouseDown);
+            this.pnlCursorImage.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.pnlCursorImage_MouseWheel);
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.groupBox2, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(6, 3);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(540, 246);
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // InventoryEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.Controls.Add(this.currentItemGroupBox);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "InventoryEditor";
-            this.Size = new System.Drawing.Size(791, 414);
+            this.Size = new System.Drawing.Size(633, 331);
             this.Load += new System.EventHandler(this.InventoryEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.panelScrollAreaCursor.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.panelScrollAreaImage.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
             this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.panelScrollAreaImage.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.panelScrollAreaCursor.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -257,6 +252,6 @@ namespace AGS.Editor
         private System.Windows.Forms.Panel panelScrollAreaCursor;
         private System.Windows.Forms.Panel panelScrollAreaImage;
         private System.Windows.Forms.SplitContainer splitContainer1;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
@@ -201,6 +201,7 @@ namespace AGS.Editor
             // 
             // flowLayoutPanel1
             // 
+            this.flowLayoutPanel1.AutoScroll = true;
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel1.Controls.Add(this.groupBox1);

--- a/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
@@ -32,9 +32,14 @@ namespace AGS.Editor
             this.editorPanel = new System.Windows.Forms.Panel();
             this.btnDeleteLastLoop = new System.Windows.Forms.Button();
             this.btnNewLoop = new System.Windows.Forms.Button();
-            this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.viewPreview = new AGS.Editor.ViewPreview();
+            this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
             this.editorPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             this.SuspendLayout();
             // 
             // chkShowPreview
@@ -42,7 +47,7 @@ namespace AGS.Editor
             this.chkShowPreview.AutoSize = true;
             this.chkShowPreview.Location = new System.Drawing.Point(12, 12);
             this.chkShowPreview.Name = "chkShowPreview";
-            this.chkShowPreview.Size = new System.Drawing.Size(115, 21);
+            this.chkShowPreview.Size = new System.Drawing.Size(93, 17);
             this.chkShowPreview.TabIndex = 2;
             this.chkShowPreview.Text = "Show Preview";
             this.chkShowPreview.UseVisualStyleBackColor = true;
@@ -53,9 +58,10 @@ namespace AGS.Editor
             this.editorPanel.AutoScroll = true;
             this.editorPanel.Controls.Add(this.btnDeleteLastLoop);
             this.editorPanel.Controls.Add(this.btnNewLoop);
-            this.editorPanel.Location = new System.Drawing.Point(293, 35);
+            this.editorPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.editorPanel.Location = new System.Drawing.Point(0, 0);
             this.editorPanel.Name = "editorPanel";
-            this.editorPanel.Size = new System.Drawing.Size(359, 444);
+            this.editorPanel.Size = new System.Drawing.Size(372, 463);
             this.editorPanel.TabIndex = 4;
             // 
             // btnDeleteLastLoop
@@ -78,9 +84,44 @@ namespace AGS.Editor
             this.btnNewLoop.UseVisualStyleBackColor = true;
             this.btnNewLoop.Click += new System.EventHandler(this.btnNewLoop_Click);
             // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.Location = new System.Drawing.Point(12, 35);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.viewPreview);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.editorPanel);
+            this.splitContainer1.Size = new System.Drawing.Size(647, 463);
+            this.splitContainer1.SplitterDistance = 271;
+            this.splitContainer1.TabIndex = 6;
+            // 
+            // viewPreview
+            // 
+            this.viewPreview.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.viewPreview.DynamicUpdates = false;
+            this.viewPreview.IsCharacterView = false;
+            this.viewPreview.Location = new System.Drawing.Point(0, 0);
+            this.viewPreview.Margin = new System.Windows.Forms.Padding(4);
+            this.viewPreview.Name = "viewPreview";
+            this.viewPreview.Size = new System.Drawing.Size(271, 463);
+            this.viewPreview.TabIndex = 3;
+            this.viewPreview.Title = "Preview";
+            this.viewPreview.ViewToPreview = null;
+            this.viewPreview.Visible = false;
+            this.viewPreview.ZoomLevel = 1F;
+            // 
             // sldZoomLevel
             // 
             this.sldZoomLevel.Location = new System.Drawing.Point(172, 3);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.sldZoomLevel.Maximum = 600;
             this.sldZoomLevel.Minimum = 75;
             this.sldZoomLevel.Name = "sldZoomLevel";
@@ -91,33 +132,23 @@ namespace AGS.Editor
             this.sldZoomLevel.ZoomScale = 1F;
             this.sldZoomLevel.ValueChanged += new System.EventHandler(this.sldZoomLevel_ValueChanged);
             // 
-            // viewPreview
-            // 
-            this.viewPreview.DynamicUpdates = false;
-            this.viewPreview.IsCharacterView = false;
-            this.viewPreview.Location = new System.Drawing.Point(12, 35);
-            this.viewPreview.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.viewPreview.Name = "viewPreview";
-            this.viewPreview.Size = new System.Drawing.Size(275, 332);
-            this.viewPreview.TabIndex = 3;
-            this.viewPreview.Title = "Preview";
-            this.viewPreview.ViewToPreview = null;
-            this.viewPreview.Visible = false;
-            // 
             // ViewEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.sldZoomLevel);
-            this.Controls.Add(this.editorPanel);
             this.Controls.Add(this.chkShowPreview);
-            this.Controls.Add(this.viewPreview);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "ViewEditor";
             this.Size = new System.Drawing.Size(674, 514);
             this.Load += new System.EventHandler(this.ViewEditor_Load);
             this.Resize += new System.EventHandler(this.ViewEditor_Resize);
             this.editorPanel.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -131,5 +162,6 @@ namespace AGS.Editor
 		private System.Windows.Forms.Button btnDeleteLastLoop;
 		private System.Windows.Forms.Button btnNewLoop;
 		private AGS.Editor.ZoomTrackbar sldZoomLevel;
+        private System.Windows.Forms.SplitContainer splitContainer1;
     }
 }

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -63,6 +63,7 @@ namespace AGS.Editor
 
         private void sldZoomLevel_ValueChanged(object sender, EventArgs e)
         {
+            viewPreview.ZoomLevel = sldZoomLevel.ZoomScale;
             UpdateLoopVisuals();
         }
 
@@ -305,6 +306,8 @@ namespace AGS.Editor
 
 				editorPanel.Left = viewPreview.Right;
 				viewPreview.ViewToPreview = _editingView;
+
+                viewPreview.ZoomLevel = sldZoomLevel.ZoomScale;
 			}
 			else
 			{
@@ -356,7 +359,5 @@ namespace AGS.Editor
             btnNewLoop.FlatAppearance.BorderSize = t.GetInt("view-editor/btn-new-option/flat/border/size");
             btnNewLoop.FlatAppearance.BorderColor = t.GetColor("view-editor/btn-new-option/flat/border/color");
         }
-
-
     }
 }

--- a/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
@@ -39,11 +39,13 @@ namespace AGS.Editor
             this.udFrame = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.udLoop = new System.Windows.Forms.NumericUpDown();
+            this.panelAutoScroll = new System.Windows.Forms.Panel();
             this.previewPanel = new AGS.Editor.BufferedPanel();
             this.mainGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.udFrame)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.udLoop)).BeginInit();
+            this.panelAutoScroll.SuspendLayout();
             this.SuspendLayout();
             // 
             // mainGroupBox
@@ -51,7 +53,7 @@ namespace AGS.Editor
             this.mainGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.mainGroupBox.Controls.Add(this.previewPanel);
+            this.mainGroupBox.Controls.Add(this.panelAutoScroll);
             this.mainGroupBox.Controls.Add(this.chkSkipFrame0);
             this.mainGroupBox.Controls.Add(this.chkCentrePivot);
             this.mainGroupBox.Controls.Add(this.chkAnimate);
@@ -156,9 +158,21 @@ namespace AGS.Editor
             this.udLoop.TabIndex = 0;
             this.udLoop.ValueChanged += new System.EventHandler(this.udLoop_ValueChanged);
             // 
+            // panelAutoScroll
+            // 
+            this.panelAutoScroll.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelAutoScroll.AutoScroll = true;
+            this.panelAutoScroll.Controls.Add(this.previewPanel);
+            this.panelAutoScroll.Location = new System.Drawing.Point(12, 131);
+            this.panelAutoScroll.Name = "panelAutoScroll";
+            this.panelAutoScroll.Size = new System.Drawing.Size(240, 179);
+            this.panelAutoScroll.TabIndex = 10;
+            // 
             // previewPanel
             // 
-            this.previewPanel.Location = new System.Drawing.Point(12, 131);
+            this.previewPanel.Location = new System.Drawing.Point(0, 0);
             this.previewPanel.Name = "previewPanel";
             this.previewPanel.Size = new System.Drawing.Size(240, 179);
             this.previewPanel.TabIndex = 9;
@@ -177,6 +191,7 @@ namespace AGS.Editor
             ((System.ComponentModel.ISupportInitialize)(this.udDelay)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.udFrame)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.udLoop)).EndInit();
+            this.panelAutoScroll.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -194,5 +209,6 @@ namespace AGS.Editor
         private BufferedPanel previewPanel;
         private System.Windows.Forms.CheckBox chkSkipFrame0;
         private System.Windows.Forms.CheckBox chkCentrePivot;
+        private System.Windows.Forms.Panel panelAutoScroll;
     }
 }

--- a/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
@@ -30,7 +30,6 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.mainGroupBox = new System.Windows.Forms.GroupBox();
-            this.previewPanel = new AGS.Editor.BufferedPanel();
             this.chkSkipFrame0 = new System.Windows.Forms.CheckBox();
             this.chkCentrePivot = new System.Windows.Forms.CheckBox();
             this.chkAnimate = new System.Windows.Forms.CheckBox();
@@ -40,6 +39,7 @@ namespace AGS.Editor
             this.udFrame = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.udLoop = new System.Windows.Forms.NumericUpDown();
+            this.previewPanel = new AGS.Editor.BufferedPanel();
             this.mainGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.udFrame)).BeginInit();
@@ -48,6 +48,9 @@ namespace AGS.Editor
             // 
             // mainGroupBox
             // 
+            this.mainGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.mainGroupBox.Controls.Add(this.previewPanel);
             this.mainGroupBox.Controls.Add(this.chkSkipFrame0);
             this.mainGroupBox.Controls.Add(this.chkCentrePivot);
@@ -59,19 +62,12 @@ namespace AGS.Editor
             this.mainGroupBox.Controls.Add(this.label1);
             this.mainGroupBox.Controls.Add(this.udLoop);
             this.mainGroupBox.Location = new System.Drawing.Point(4, 2);
+            this.mainGroupBox.MinimumSize = new System.Drawing.Size(264, 321);
             this.mainGroupBox.Name = "mainGroupBox";
             this.mainGroupBox.Size = new System.Drawing.Size(264, 321);
             this.mainGroupBox.TabIndex = 0;
             this.mainGroupBox.TabStop = false;
             this.mainGroupBox.Text = "groupBox1";
-            // 
-            // previewPanel
-            // 
-            this.previewPanel.Location = new System.Drawing.Point(12, 131);
-            this.previewPanel.Name = "previewPanel";
-            this.previewPanel.Size = new System.Drawing.Size(240, 179);
-            this.previewPanel.TabIndex = 9;
-            this.previewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.previewPanel_Paint);
             // 
             // chkSkipFrame0
             // 
@@ -159,6 +155,14 @@ namespace AGS.Editor
             this.udLoop.Size = new System.Drawing.Size(53, 20);
             this.udLoop.TabIndex = 0;
             this.udLoop.ValueChanged += new System.EventHandler(this.udLoop_ValueChanged);
+            // 
+            // previewPanel
+            // 
+            this.previewPanel.Location = new System.Drawing.Point(12, 131);
+            this.previewPanel.Name = "previewPanel";
+            this.previewPanel.Size = new System.Drawing.Size(240, 179);
+            this.previewPanel.TabIndex = 9;
+            this.previewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.previewPanel_Paint);
             // 
             // ViewPreview
             // 

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -18,6 +18,7 @@ namespace AGS.Editor
 		private int _thisFrameDelay = 0;
 		private float _zoomLevel = 1.0f;
         private readonly Size _defaultFrameSize; // default picture frame size
+        private bool _autoResize = false;
 
         private const int MILLISECONDS_IN_SECOND = 1000;
         private const int DEFUALT_FRAME_RATE = 40;
@@ -61,6 +62,23 @@ namespace AGS.Editor
             set
             {
                 _zoomLevel = value;
+                UpdateSize();
+            }
+        }
+
+        /// <summary>
+        /// Whether ViewPreview control should automatically resize itself
+        /// whenever preview frame gets too large or small.
+        /// </summary>
+        public bool AutoResize
+        {
+            get
+            {
+                return _autoResize;
+            }
+            set
+            {
+                _autoResize = value;
                 UpdateSize();
             }
         }
@@ -146,6 +164,17 @@ namespace AGS.Editor
                     Math.Max(_defaultFrameSize.Height, viewSize.Height));
             }
             previewPanel.Invalidate();
+
+            if (_autoResize)
+            {
+                // Try to calculate necessary size, knowing the previewPanel's
+                // location relative to client edges, and its new size
+                // (actually use panelAutoScroll as a reference here, as it's
+                // previewPanel's immediate parent).
+                this.ClientSize = new Size(
+                    panelAutoScroll.Left + (this.ClientRectangle.Right - panelAutoScroll.Right) + previewPanel.Width,
+                    panelAutoScroll.Top + (this.ClientRectangle.Bottom - panelAutoScroll.Bottom) + previewPanel.Height);
+            }
         }
 
         private void previewPanel_Paint(object sender, PaintEventArgs e)

--- a/Editor/AGS.Editor/Panes/ViewPreview.resx
+++ b/Editor/AGS.Editor/Panes/ViewPreview.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/Utils/MathExtra.cs
+++ b/Editor/AGS.Editor/Utils/MathExtra.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Drawing;
 
 namespace AGS.Editor
 {
@@ -13,6 +10,12 @@ namespace AGS.Editor
             if (val.CompareTo(min) < 0) return min;
             else if (val.CompareTo(max) > 0) return max;
             else return val;
+        }
+
+        public static Size SafeScale(this Size size, float scale)
+        {
+            return new Size(Math.Max(1, (int)(size.Width * scale)),
+                     Math.Max(1, (int)(size.Height * scale)));
         }
     }
 }

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -411,6 +411,22 @@ namespace AGS.Editor
             return new Size { Width = width, Height = height };
         }
 
+        /// <summary>
+        /// Gets the maximal size at which the given view's frames will be
+        /// rendered in game.
+        /// </summary>
+        public static Size GetSizeViewWillBeRenderedInGame(Types.View view)
+        {
+            bool hasLowResSprites;
+            Size size = Factory.NativeProxy.GetMaxViewFrameSize(view, out hasLowResSprites);
+            if (hasLowResSprites && Factory.AGSEditor.CurrentGame.IsHighResolution)
+            {
+                size.Width *= 2;
+                size.Height *= 2;
+            }
+            return size;
+        }
+
         public static void CheckLabelWidthsOnForm(Control parentControl)
         {
             foreach (Control child in parentControl.Controls)

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -51,6 +51,7 @@ namespace AGS
             Types::SpriteInfo^ GetSpriteInfo(int spriteSlot);
 			int  GetSpriteWidth(int spriteSlot);
 			int  GetSpriteHeight(int spriteSlot);
+            Drawing::Size GetMaxSpriteSize(array<int>^ sprites, [Runtime::InteropServices::Out] bool% hasLowResSprites);
 			bool CropSpriteEdges(System::Collections::Generic::IList<Sprite^>^ sprites, bool symmetric);
 			bool DoesSpriteExist(int spriteNumber);
 			void ChangeSpriteNumber(Sprite^ sprite, int newNumber);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -214,18 +214,16 @@ int GetMaxSprites() {
 }
 
 int GetSpriteWidth(int slot) {
-	return get_sprite(slot)->GetWidth();
+    return thisgame.SpriteInfos[slot].Width;
 }
 
 int GetSpriteHeight(int slot) {
-	return get_sprite(slot)->GetHeight();
+    return thisgame.SpriteInfos[slot].Height;
 }
 
 void GetSpriteInfo(int slot, ::SpriteInfo &info) {
-    // TODO: find out if we may get width/height from SpriteInfos
-    // or it is necessary to go through get_sprite and check bitmaps in cache?
-    info.Width = GetSpriteWidth(slot);
-    info.Height = GetSpriteHeight(slot);
+    info.Width = thisgame.SpriteInfos[slot].Width;
+    info.Height = thisgame.SpriteInfos[slot].Height;
     info.Flags = thisgame.SpriteInfos[slot].Flags;
 }
 


### PR DESCRIPTION
Completes #710.

The View editor's zoom was implemented by #1415, but preview frame was still unscaled.
While working on this I also noticed that the Character preview pane does not have a zoom control, unlike Inventory and Cursor preview panes which recently received a zoom control.

This PR:
1. ViewPreview control now displays a frame inside a panel with automatic scrollbar, which is displayed if the image is larger than the panel. The frame resizes if the (scaled) sprite cannot fit. It keeps the "default" size in memory, and sets it back if the sprite is small enough: this prevents small sprites from being drawn too low at the window bottom.
2. ViewPreview control now has AutoResize property, that tells it to resize itself (whole control) if the image frame is too big or small. AutoResize is *false* by default.
3. On View editor: adds a splitter between preview and the loop editor.
4. On View editor: zoom slider also affects the preview frame.
5. Character pane now has same kind of layout as Inventory Editor panes (preview panels inside a Layout Table). The two ViewPreviews have AutoResize property set to true, so they grow in size if the scaled image is too big to fit.
6. Extra: replaced FlowLayout with TableLayout on Inventory Editor (and use same on Character editor), to force a horizontal layout and scroll (may be argued and adjusted later).
