### PR TITLE
Editor: disabled ColorTheme loading in .NET Design Mode

### DIFF
--- a/Editor/AGS.Editor/GUI/CallStackPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CallStackPanel.Designer.cs
@@ -75,6 +75,7 @@ namespace AGS.Editor
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "CallStackPanel";
             this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
+            this.Load += new System.EventHandler(this.CallStackPanel_Load);
             this.ResumeLayout(false);
 
         }

--- a/Editor/AGS.Editor/GUI/CallStackPanel.cs
+++ b/Editor/AGS.Editor/GUI/CallStackPanel.cs
@@ -16,8 +16,7 @@ namespace AGS.Editor
 
         public CallStackPanel()
         {
-            InitializeComponent();            
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            InitializeComponent();
         }
 
 		public void SetImageList(ImageList list)
@@ -105,6 +104,14 @@ namespace AGS.Editor
                 a.Graphics.DrawString(a.Header.Text, lvwResults.Font, new SolidBrush(t.GetColor("call-stack-panel/column-header/foreground")), a.Bounds.X + 5, a.Bounds.Y + a.Bounds.Size.Height / 5);
                 a.Graphics.DrawRectangle(new Pen(new SolidBrush(t.GetColor("call-stack-panel/column-header/border"))), a.Bounds.X - 1, a.Bounds.Y - 1, a.Bounds.Size.Width, a.Bounds.Size.Height);
             };
+        }
+
+        private void CallStackPanel_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/GUI/FindResultsPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/FindResultsPanel.Designer.cs
@@ -82,6 +82,7 @@ namespace AGS.Editor
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FindResultsPanel";
             this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
+            this.Load += new System.EventHandler(this.FindResultsPanel_Load);
             this.ResumeLayout(false);
 
         }

--- a/Editor/AGS.Editor/GUI/FindResultsPanel.cs
+++ b/Editor/AGS.Editor/GUI/FindResultsPanel.cs
@@ -18,8 +18,7 @@ namespace AGS.Editor
 
         public FindResultsPanel()
         {
-            InitializeComponent();            
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            InitializeComponent();
         }
 
 		public void SetImageList(ImageList list)
@@ -129,6 +128,14 @@ namespace AGS.Editor
                 a.Graphics.DrawString(a.Header.Text, lvwResults.Font, new SolidBrush(t.GetColor("find-results-panel/column-header/foreground")), a.Bounds.X + 5, a.Bounds.Y + a.Bounds.Size.Height / 5);
                 a.Graphics.DrawRectangle(new Pen(new SolidBrush(t.GetColor("find-results-panel/column-header/border"))), a.Bounds.X - 1, a.Bounds.Y - 1, a.Bounds.Size.Width, a.Bounds.Size.Height);
             };
+        }
+
+        private void FindResultsPanel_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/GUI/OutputPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.Designer.cs
@@ -55,7 +55,6 @@ namespace AGS.Editor
             this.lvwResults.View = System.Windows.Forms.View.Details;
             this.lvwResults.ItemActivate += new System.EventHandler(this.lvwResults_ItemActivate);
             this.lvwResults.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lvwResults_MouseUp);
-            this.lvwResults.Click += new System.EventHandler(this.lvwResults_Click);
             // 
             // columnHeader1
             // 
@@ -81,6 +80,7 @@ namespace AGS.Editor
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "OutputPanel";
             this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
+            this.Load += new System.EventHandler(this.OutputPanel_Load);
             this.ResumeLayout(false);
 
         }

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -17,8 +17,7 @@ namespace AGS.Editor
 
         public OutputPanel()
         {
-            InitializeComponent();            
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            InitializeComponent();
         }
 
 		public void SetImageList(ImageList list)
@@ -89,11 +88,6 @@ namespace AGS.Editor
 			}
         }
 
-		private void lvwResults_Click(object sender, EventArgs e)
-		{
-
-		}
-
 		private void ContextMenuEventHandler(object sender, EventArgs e)
 		{
 			String result = string.Empty;
@@ -160,6 +154,14 @@ namespace AGS.Editor
                 a.Graphics.DrawString(a.Header.Text, lvwResults.Font, new SolidBrush(t.GetColor("output-panel/column-header/foreground")), a.Bounds.X + 5, a.Bounds.Y + a.Bounds.Size.Height / 5);
                 a.Graphics.DrawRectangle(new Pen(new SolidBrush(t.GetColor("output-panel/column-header/border"))), a.Bounds.X - 1, a.Bounds.Y - 1, a.Bounds.Size.Width, a.Bounds.Size.Height);
             };
+        }
+
+        private void OutputPanel_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
@@ -54,6 +54,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "ProjectPanel";
             this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
+            this.Load += new System.EventHandler(this.ProjectPanel_Load);
             this.ResumeLayout(false);
 
         }

--- a/Editor/AGS.Editor/GUI/ProjectPanel.cs
+++ b/Editor/AGS.Editor/GUI/ProjectPanel.cs
@@ -14,7 +14,6 @@ namespace AGS.Editor
         public ProjectPanel()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         public void LoadColorTheme(ColorTheme t)
@@ -23,6 +22,14 @@ namespace AGS.Editor
             projectTree.BackColor = t.GetColor("project-panel/project-tree/background");
             projectTree.ForeColor = t.GetColor("project-panel/project-tree/foreground");
             projectTree.LineColor = t.GetColor("project-panel/project-tree/line");
+        }
+
+        private void ProjectPanel_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/GUI/PropertiesPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PropertiesPanel.Designer.cs
@@ -63,6 +63,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "PropertiesPanel";
             this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
+            this.Load += new System.EventHandler(this.PropertiesPanel_Load);
             this.VisibleChanged += new System.EventHandler(this.PropertiesPanel_VisibleChanged);
             this.ResumeLayout(false);
 

--- a/Editor/AGS.Editor/GUI/PropertiesPanel.cs
+++ b/Editor/AGS.Editor/GUI/PropertiesPanel.cs
@@ -13,8 +13,7 @@ namespace AGS.Editor
     {
         public PropertiesPanel()
         {
-            InitializeComponent();                          
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            InitializeComponent();
         }
 
         public event PropertyValueChangedEventHandler PropertyValueChanged
@@ -88,6 +87,14 @@ namespace AGS.Editor
             propertiesGrid.CategoryForeColor = t.GetColor("properties-panel/grid/category");
             propertiesGrid.HelpBackColor = t.GetColor("properties-panel/grid/help/background");
             propertiesGrid.HelpForeColor = t.GetColor("properties-panel/grid/help/foreground");
+        }
+
+        private void PropertiesPanel_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -35,7 +35,6 @@ namespace AGS.Editor
         public frmMain()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
 
             _layoutManager = new WindowsLayoutManager(mainContainer, GetStartupPanes());            
             tabbedDocumentContainer1.ActiveDocumentChanged += new TabbedDocumentManager.ActiveDocumentChangeHandler(tabbedDocumentContainer1_ActiveDocumentChanged);
@@ -80,8 +79,12 @@ namespace AGS.Editor
 
 		private void frmMain_Load(object sender, EventArgs e)
 		{
-            LoadLayout();            			
-		}
+            if (!DesignMode)
+            {
+                LoadLayout();
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
+        }
 
         public void RefreshPropertyGridForDocument(ContentDocument document)
         {

--- a/Editor/AGS.Editor/Panes/AudioEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.Designer.cs
@@ -194,6 +194,7 @@
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "AudioEditor";
             this.Size = new System.Drawing.Size(865, 509);
+            this.Load += new System.EventHandler(this.AudioEditor_Load);
             this.grpAudioClip.ResumeLayout(false);
             this.grpAudioClip.PerformLayout();
             this.grpFolder.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/AudioEditor.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.cs
@@ -23,7 +23,6 @@ namespace AGS.Editor
         public AudioEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         protected override string OnGetHelpKeyword()
@@ -230,6 +229,14 @@ namespace AGS.Editor
             btnStop.FlatStyle = (FlatStyle)t.GetInt("audio-editor/btn-stop/flat/style");
             btnStop.FlatAppearance.BorderSize = t.GetInt("audio-editor/btn-stop/flat/border/size");
             btnStop.FlatAppearance.BorderColor = t.GetColor("audio-editor/btn-stop/flat/border/color");
+        }
+
+        private void AudioEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/BigPropertySheet.cs
+++ b/Editor/AGS.Editor/Panes/BigPropertySheet.cs
@@ -7,19 +7,20 @@ namespace AGS.Editor
     {
         private readonly object _propertyObject;
 
-        public BigPropertySheet(object propertyObject)
+        public BigPropertySheet()
         {
             InitializeComponent();
+        }
 
+        public BigPropertySheet(object propertyObject) : this()
+        {
             _propertyObject = propertyObject;
             RefreshData();
         }
 
         public void RefreshData()
         {
-            propertyGrid.SelectedObject = null;
             propertyGrid.SelectedObject = _propertyObject;
         }
-
     }
 }

--- a/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
@@ -90,7 +90,7 @@ namespace AGS.Editor
             this.lblIsPlayer.Size = new System.Drawing.Size(398, 26);
             this.lblIsPlayer.TabIndex = 5;
             this.lblIsPlayer.Text = "This character is OR IS NOT the player; the game will startin this character\'s ro" +
-                "om or something";
+    "om or something";
             // 
             // CharacterEditor
             // 
@@ -100,6 +100,7 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "CharacterEditor";
             this.Size = new System.Drawing.Size(593, 441);
+            this.Load += new System.EventHandler(this.CharacterEditor_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/CharacterEditor.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.cs
@@ -18,7 +18,6 @@ namespace AGS.Editor
         public CharacterEditor(Character characterToEdit)
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _character = characterToEdit;
             _normalFont = lblIsPlayer.Font;
             _boldFont = new System.Drawing.Font(_normalFont.Name, _normalFont.Size, FontStyle.Bold);
@@ -90,6 +89,14 @@ namespace AGS.Editor
             btnMakePlayer.FlatStyle = (FlatStyle)t.GetInt("character-editor/btn-make/flat/style");
             btnMakePlayer.FlatAppearance.BorderSize = t.GetInt("character-editor/btn-make/flat/border/size");
             btnMakePlayer.FlatAppearance.BorderColor = t.GetColor("character-editor/btn-make/flat/border/color");
+        }
+
+        private void CharacterEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/CursorEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/CursorEditor.Designer.cs
@@ -143,6 +143,7 @@ namespace AGS.Editor
             this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "CursorEditor";
             this.Size = new System.Drawing.Size(647, 418);
+            this.Load += new System.EventHandler(this.CursorEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();

--- a/Editor/AGS.Editor/Panes/CursorEditor.cs
+++ b/Editor/AGS.Editor/Panes/CursorEditor.cs
@@ -15,7 +15,6 @@ namespace AGS.Editor
         public CursorEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         public CursorEditor(MouseCursor cursorToEdit) : this()
@@ -152,6 +151,14 @@ namespace AGS.Editor
         {
             UpdatePanelSize();
             imagePanel.Invalidate();
+        }
+
+        private void CursorEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/DefaultSetupPane.cs
+++ b/Editor/AGS.Editor/Panes/DefaultSetupPane.cs
@@ -10,7 +10,7 @@ namespace AGS.Editor
         public DefaultRuntimeSetupPane()
             : base(Factory.AGSEditor.CurrentGame.DefaultSetup)
         {
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            InitializeComponent();
         }
 
         protected override string OnGetHelpKeyword()
@@ -29,6 +29,26 @@ namespace AGS.Editor
             propertyGrid.ViewForeColor = t.GetColor("general-settings/property-grid/view/foreground");
             propertyGrid.HelpBackColor = t.GetColor("general-settings/property-grid/help/background");
             propertyGrid.HelpForeColor = t.GetColor("general-settings/property-grid/help/foreground");
+        }
+
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // DefaultRuntimeSetupPane
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
+            this.Name = "DefaultRuntimeSetupPane";
+            this.Load += new System.EventHandler(this.DefaultRuntimeSetupPane_Load);
+            this.ResumeLayout(false);
+        }
+
+        private void DefaultRuntimeSetupPane_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -32,14 +32,12 @@ namespace AGS.Editor
             _dialog = dialogToEdit;
             _agsEditor = agsEditor;
 
-            Init();
+            InitializeComponent();
+            this.Load += new EventHandler(DialogEditor_Load);
         }
 
-        private void Init()
+        private void DialogEditor_Load(object sender, EventArgs e)
         {
-            InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
-
             _extraMenu.Commands.Add(new MenuCommand(FIND_COMMAND, "Find...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F, "FindMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(FIND_NEXT_COMMAND, "Find next", System.Windows.Forms.Keys.F3, "FindNextMenuIcon"));
             _extraMenu.Commands.Add(new MenuCommand(REPLACE_COMMAND, "Replace...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E));
@@ -71,6 +69,11 @@ namespace AGS.Editor
 
             RegisterEvents();
             scintillaEditor.ActivateTextEditor();
+
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
 
         private void RegisterEvents()

--- a/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.Designer.cs
@@ -40,9 +40,9 @@ namespace AGS.Editor
             // 
             // currentItemGroupBox
             // 
-            this.currentItemGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.currentItemGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.currentItemGroupBox.BackColor = System.Drawing.SystemColors.Control;
             this.currentItemGroupBox.Controls.Add(this.btnImportFont);
             this.currentItemGroupBox.Controls.Add(this.imagePanel);
@@ -66,9 +66,9 @@ namespace AGS.Editor
             // 
             // imagePanel
             // 
-            this.imagePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.imagePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.imagePanel.AutoScroll = true;
             this.imagePanel.Controls.Add(this.pictureBox);
             this.imagePanel.Location = new System.Drawing.Point(13, 80);
@@ -102,6 +102,7 @@ namespace AGS.Editor
             this.Controls.Add(this.currentItemGroupBox);
             this.Name = "FontEditor";
             this.Size = new System.Drawing.Size(534, 493);
+            this.Load += new System.EventHandler(this.FontEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.currentItemGroupBox.PerformLayout();
             this.imagePanel.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/FontEditor.cs
+++ b/Editor/AGS.Editor/Panes/FontEditor.cs
@@ -17,7 +17,6 @@ namespace AGS.Editor
         public FontEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         public FontEditor(AGS.Types.Font selectedFont) : this()
@@ -195,6 +194,14 @@ namespace AGS.Editor
             btnImportFont.FlatStyle = (FlatStyle)t.GetInt("font-editor/btn-import/flat/style");
             btnImportFont.FlatAppearance.BorderSize = t.GetInt("font-editor/btn-import/flat/border/size");
             btnImportFont.FlatAppearance.BorderColor = t.GetColor("font-editor/btn-import/flat/border/color");
+        }
+
+        private void FontEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.Designer.cs
@@ -105,6 +105,7 @@ namespace AGS.Editor
             this.Controls.Add(this.bgPanel);
             this.Name = "GUIEditor";
             this.Size = new System.Drawing.Size(702, 459);
+            this.Load += new System.EventHandler(this.GUIEditor_Load);
             this.ctrlPanel.ResumeLayout(false);
             this.ctrlPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();

--- a/Editor/AGS.Editor/Panes/GUIEditor.cs
+++ b/Editor/AGS.Editor/Panes/GUIEditor.cs
@@ -110,7 +110,6 @@ namespace AGS.Editor
         public GUIEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
         }
 
@@ -1166,6 +1165,14 @@ namespace AGS.Editor
                 return true;
             }
             return false;
+        }
+
+        private void GUIEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
 
         private void bgPanel_MouseDoubleClick(object sender, MouseEventArgs e)

--- a/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
+++ b/Editor/AGS.Editor/Panes/GeneralSettingsPane.cs
@@ -14,9 +14,9 @@ namespace AGS.Editor
         public GeneralSettingsPane()
             : base(Factory.AGSEditor.CurrentGame.Settings)
         {
+            InitializeComponent();
             this.propertyGrid.PropertyValueChanged +=
                 new System.Windows.Forms.PropertyValueChangedEventHandler(this.gameSettings_PropertyValueChanged);
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         protected override string OnGetHelpKeyword()
@@ -152,6 +152,26 @@ namespace AGS.Editor
             propertyGrid.ViewForeColor = t.GetColor("general-settings/property-grid/view/foreground");
             propertyGrid.HelpBackColor = t.GetColor("general-settings/property-grid/help/background");
             propertyGrid.HelpForeColor = t.GetColor("general-settings/property-grid/help/foreground");
+        }
+
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // GeneralSettingsPane
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
+            this.Name = "GeneralSettingsPane";
+            this.Load += new System.EventHandler(this.GeneralSettingsPane_Load);
+            this.ResumeLayout(false);
+        }
+
+        private void GeneralSettingsPane_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/GlobalVariablesEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/GlobalVariablesEditor.Designer.cs
@@ -90,7 +90,7 @@ namespace AGS.Editor
             this.label1.Size = new System.Drawing.Size(433, 26);
             this.label1.TabIndex = 0;
             this.label1.Text = "Global variables allow you to create variables which you can access from all your" +
-                " scripts. Right-click in the list to add, modify and delete variables.";
+    " scripts. Right-click in the list to add, modify and delete variables.";
             // 
             // GlobalVariablesEditor
             // 
@@ -100,6 +100,7 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "GlobalVariablesEditor";
             this.Size = new System.Drawing.Size(531, 519);
+            this.Load += new System.EventHandler(this.GlobalVariablesEditor_Load);
             this.SizeChanged += new System.EventHandler(this.TextParserEditor_SizeChanged);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();

--- a/Editor/AGS.Editor/Panes/GlobalVariablesEditor.cs
+++ b/Editor/AGS.Editor/Panes/GlobalVariablesEditor.cs
@@ -30,7 +30,6 @@ namespace AGS.Editor
         public GlobalVariablesEditor(Game game)
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             lvwWords.ListViewItemSorter = new GlobalVariableComparer();
             _game = game;
             _variables = game.GlobalVariables;
@@ -260,6 +259,14 @@ namespace AGS.Editor
                 a.Graphics.DrawString(a.Header.Text, lvwWords.Font, new SolidBrush(t.GetColor("global-variables-editor/list/column-header/foreground")), a.Bounds.X + 5, a.Bounds.Y + a.Bounds.Size.Height / 5);
                 a.Graphics.DrawRectangle(new Pen(new SolidBrush(t.GetColor("global-variables-editor/list/column-header/border"))), a.Bounds.X - 1, a.Bounds.Y - 1, a.Bounds.Size.Width, a.Bounds.Size.Height);
             };
+        }
+
+        private void GlobalVariablesEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
@@ -222,6 +222,7 @@ namespace AGS.Editor
             this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "InventoryEditor";
             this.Size = new System.Drawing.Size(791, 414);
+            this.Load += new System.EventHandler(this.InventoryEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();

--- a/Editor/AGS.Editor/Panes/InventoryEditor.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.cs
@@ -45,7 +45,6 @@ namespace AGS.Editor
         public InventoryEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             UpdatePanelSizes();
         }
 
@@ -217,6 +216,14 @@ namespace AGS.Editor
         private void pnlInvWindowImage_MouseWheel(object sender, MouseEventArgs e)
         {
             mouseWheelZoom(sender, e);
+        }
+
+        private void InventoryEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/LipSyncEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.Designer.cs
@@ -50,7 +50,7 @@ namespace AGS.Editor
             this.label2.Size = new System.Drawing.Size(367, 26);
             this.label2.TabIndex = 1;
             this.label2.Text = "In the text boxes, type the letters that will cause that frame to be shown. Separ" +
-                "ate multiple letters with slashes, eg.   C/D/G/K";
+    "ate multiple letters with slashes, eg.   C/D/G/K";
             // 
             // LipSyncEditor
             // 
@@ -61,6 +61,7 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "LipSyncEditor";
             this.Size = new System.Drawing.Size(661, 369);
+            this.Load += new System.EventHandler(this.LipSyncEditor_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Editor/AGS.Editor/Panes/LipSyncEditor.cs
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.cs
@@ -49,7 +49,6 @@ namespace AGS.Editor
                 }
             }
             UpdateControlsEnabled();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         public LipSync EditingLipSync
@@ -104,6 +103,14 @@ namespace AGS.Editor
                     textBox.ForeColor = t.GetColor("lip-sync-editor/text-boxes/foreground");
                     textBox.BorderStyle = (BorderStyle)t.GetInt("lip-sync-editor/text-boxes/border-style");
                 }
+            }
+        }
+
+        private void LipSyncEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.Designer.cs
@@ -28,307 +28,308 @@ namespace AGS.Editor
         /// </summary>
         private void InitializeComponent()
         {
-			this.tabControl = new System.Windows.Forms.TabControl();
-			this.palettePage = new System.Windows.Forms.TabPage();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
-			this.label6 = new System.Windows.Forms.Label();
-			this.palettePanel = new AGS.Editor.BufferedPanel();
-			this.lblPaletteIntro = new System.Windows.Forms.Label();
-			this.colourFinderPage = new System.Windows.Forms.TabPage();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.btnColorDialog = new System.Windows.Forms.Button();
-			this.lblFixedColorsWarning = new System.Windows.Forms.Label();
-			this.blockOfColour = new AGS.Editor.BufferedPanel();
-			this.lblBlueVal = new System.Windows.Forms.Label();
-			this.lblGreenVal = new System.Windows.Forms.Label();
-			this.lblRedVal = new System.Windows.Forms.Label();
-			this.label5 = new System.Windows.Forms.Label();
-			this.trackBarBlue = new System.Windows.Forms.TrackBar();
-			this.label4 = new System.Windows.Forms.Label();
-			this.trackBarGreen = new System.Windows.Forms.TrackBar();
-			this.label3 = new System.Windows.Forms.Label();
-			this.trackBarRed = new System.Windows.Forms.TrackBar();
-			this.txtColourNumber = new System.Windows.Forms.TextBox();
-			this.label2 = new System.Windows.Forms.Label();
-			this.label1 = new System.Windows.Forms.Label();
-			this.tabControl.SuspendLayout();
-			this.palettePage.SuspendLayout();
-			this.groupBox2.SuspendLayout();
-			this.colourFinderPage.SuspendLayout();
-			this.groupBox1.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tabControl
-			// 
-			this.tabControl.Controls.Add(this.palettePage);
-			this.tabControl.Controls.Add(this.colourFinderPage);
-			this.tabControl.Location = new System.Drawing.Point(3, 3);
-			this.tabControl.Name = "tabControl";
-			this.tabControl.SelectedIndex = 0;
-			this.tabControl.Size = new System.Drawing.Size(455, 449);
-			this.tabControl.TabIndex = 2;
-			// 
-			// palettePage
-			// 
-			this.palettePage.Controls.Add(this.groupBox2);
-			this.palettePage.Location = new System.Drawing.Point(4, 22);
-			this.palettePage.Name = "palettePage";
-			this.palettePage.Padding = new System.Windows.Forms.Padding(3);
-			this.palettePage.Size = new System.Drawing.Size(447, 423);
-			this.palettePage.TabIndex = 0;
-			this.palettePage.Text = "Palette";
-			this.palettePage.UseVisualStyleBackColor = true;
-			// 
-			// groupBox2
-			// 
-			this.groupBox2.Controls.Add(this.label6);
-			this.groupBox2.Controls.Add(this.palettePanel);
-			this.groupBox2.Controls.Add(this.lblPaletteIntro);
-			this.groupBox2.Location = new System.Drawing.Point(6, 6);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(435, 411);
-			this.groupBox2.TabIndex = 2;
-			this.groupBox2.TabStop = false;
-			this.groupBox2.Text = "Palette";
-			// 
-			// label6
-			// 
-			this.label6.AutoSize = true;
-			this.label6.Location = new System.Drawing.Point(16, 47);
-			this.label6.MaximumSize = new System.Drawing.Size(400, 0);
-			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(397, 26);
-			this.label6.TabIndex = 2;
-			this.label6.Text = "Click in the grid below to select a colour. Control-click to select additional co" +
-				"lours; Shift-click to select a range.  Right click to import/export.";
-			// 
-			// palettePanel
-			// 
-			this.palettePanel.Location = new System.Drawing.Point(19, 85);
-			this.palettePanel.Name = "palettePanel";
-			this.palettePanel.Size = new System.Drawing.Size(364, 320);
-			this.palettePanel.TabIndex = 1;
+            this.tabControl = new System.Windows.Forms.TabControl();
+            this.palettePage = new System.Windows.Forms.TabPage();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.palettePanel = new AGS.Editor.BufferedPanel();
+            this.lblPaletteIntro = new System.Windows.Forms.Label();
+            this.colourFinderPage = new System.Windows.Forms.TabPage();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.btnColorDialog = new System.Windows.Forms.Button();
+            this.lblFixedColorsWarning = new System.Windows.Forms.Label();
+            this.blockOfColour = new AGS.Editor.BufferedPanel();
+            this.lblBlueVal = new System.Windows.Forms.Label();
+            this.lblGreenVal = new System.Windows.Forms.Label();
+            this.lblRedVal = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.trackBarBlue = new System.Windows.Forms.TrackBar();
+            this.label4 = new System.Windows.Forms.Label();
+            this.trackBarGreen = new System.Windows.Forms.TrackBar();
+            this.label3 = new System.Windows.Forms.Label();
+            this.trackBarRed = new System.Windows.Forms.TrackBar();
+            this.txtColourNumber = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.tabControl.SuspendLayout();
+            this.palettePage.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.colourFinderPage.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tabControl
+            // 
+            this.tabControl.Controls.Add(this.palettePage);
+            this.tabControl.Controls.Add(this.colourFinderPage);
+            this.tabControl.Location = new System.Drawing.Point(3, 3);
+            this.tabControl.Name = "tabControl";
+            this.tabControl.SelectedIndex = 0;
+            this.tabControl.Size = new System.Drawing.Size(455, 449);
+            this.tabControl.TabIndex = 2;
+            // 
+            // palettePage
+            // 
+            this.palettePage.Controls.Add(this.groupBox2);
+            this.palettePage.Location = new System.Drawing.Point(4, 22);
+            this.palettePage.Name = "palettePage";
+            this.palettePage.Padding = new System.Windows.Forms.Padding(3);
+            this.palettePage.Size = new System.Drawing.Size(447, 423);
+            this.palettePage.TabIndex = 0;
+            this.palettePage.Text = "Palette";
+            this.palettePage.UseVisualStyleBackColor = true;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.label6);
+            this.groupBox2.Controls.Add(this.palettePanel);
+            this.groupBox2.Controls.Add(this.lblPaletteIntro);
+            this.groupBox2.Location = new System.Drawing.Point(6, 6);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(435, 411);
+            this.groupBox2.TabIndex = 2;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Palette";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(16, 47);
+            this.label6.MaximumSize = new System.Drawing.Size(400, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(397, 26);
+            this.label6.TabIndex = 2;
+            this.label6.Text = "Click in the grid below to select a colour. Control-click to select additional co" +
+    "lours; Shift-click to select a range.  Right click to import/export.";
+            // 
+            // palettePanel
+            // 
+            this.palettePanel.Location = new System.Drawing.Point(19, 85);
+            this.palettePanel.Name = "palettePanel";
+            this.palettePanel.Size = new System.Drawing.Size(364, 320);
+            this.palettePanel.TabIndex = 1;
 			this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
-			this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
-			// 
-			// lblPaletteIntro
-			// 
-			this.lblPaletteIntro.AutoSize = true;
-			this.lblPaletteIntro.Location = new System.Drawing.Point(16, 17);
-			this.lblPaletteIntro.MaximumSize = new System.Drawing.Size(400, 0);
-			this.lblPaletteIntro.Name = "lblPaletteIntro";
+            this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
+            // 
+            // lblPaletteIntro
+            // 
+            this.lblPaletteIntro.AutoSize = true;
+            this.lblPaletteIntro.Location = new System.Drawing.Point(16, 17);
+            this.lblPaletteIntro.MaximumSize = new System.Drawing.Size(400, 0);
+            this.lblPaletteIntro.Name = "lblPaletteIntro";
 			this.lblPaletteIntro.Size = new System.Drawing.Size(394, 26);
-			this.lblPaletteIntro.TabIndex = 0;
-			this.lblPaletteIntro.Text = "This palette information will only be used for drawing any 8-bit graphics that yo" + 
-				"u may have imported.";
-			// 
-			// colourFinderPage
-			// 
-			this.colourFinderPage.Controls.Add(this.groupBox1);
-			this.colourFinderPage.Location = new System.Drawing.Point(4, 22);
-			this.colourFinderPage.Name = "colourFinderPage";
-			this.colourFinderPage.Padding = new System.Windows.Forms.Padding(3);
-			this.colourFinderPage.Size = new System.Drawing.Size(447, 423);
-			this.colourFinderPage.TabIndex = 1;
-			this.colourFinderPage.Text = "Colour Finder";
-			this.colourFinderPage.UseVisualStyleBackColor = true;
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.btnColorDialog);
-			this.groupBox1.Controls.Add(this.lblFixedColorsWarning);
-			this.groupBox1.Controls.Add(this.blockOfColour);
-			this.groupBox1.Controls.Add(this.lblBlueVal);
-			this.groupBox1.Controls.Add(this.lblGreenVal);
-			this.groupBox1.Controls.Add(this.lblRedVal);
-			this.groupBox1.Controls.Add(this.label5);
-			this.groupBox1.Controls.Add(this.trackBarBlue);
-			this.groupBox1.Controls.Add(this.label4);
-			this.groupBox1.Controls.Add(this.trackBarGreen);
-			this.groupBox1.Controls.Add(this.label3);
-			this.groupBox1.Controls.Add(this.trackBarRed);
-			this.groupBox1.Controls.Add(this.txtColourNumber);
-			this.groupBox1.Controls.Add(this.label2);
-			this.groupBox1.Controls.Add(this.label1);
-			this.groupBox1.Location = new System.Drawing.Point(6, 6);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(395, 337);
-			this.groupBox1.TabIndex = 1;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Colour Finder";
-			// 
-			// btnColorDialog
-			// 
-			this.btnColorDialog.Location = new System.Drawing.Point(201, 74);
-			this.btnColorDialog.Name = "btnColorDialog";
-			this.btnColorDialog.Size = new System.Drawing.Size(96, 21);
-			this.btnColorDialog.TabIndex = 14;
-			this.btnColorDialog.Text = "Find Colour...";
-			this.btnColorDialog.UseVisualStyleBackColor = true;
-			this.btnColorDialog.Click += new System.EventHandler(this.btnColorDialog_Click);
-			// 
-			// lblFixedColorsWarning
-			// 
-			this.lblFixedColorsWarning.AutoSize = true;
-			this.lblFixedColorsWarning.Location = new System.Drawing.Point(16, 300);
-			this.lblFixedColorsWarning.MaximumSize = new System.Drawing.Size(350, 0);
-			this.lblFixedColorsWarning.Name = "lblFixedColorsWarning";
-			this.lblFixedColorsWarning.Size = new System.Drawing.Size(331, 26);
-			this.lblFixedColorsWarning.TabIndex = 13;
-			this.lblFixedColorsWarning.Text = "NOTE: Colours 1-31 are locked to reflect special colours in the 8-bit palette. Fo" +
-				"r shades of blue, set the Green slider to 4.";
-			this.lblFixedColorsWarning.Visible = false;
-			// 
-			// blockOfColour
-			// 
-			this.blockOfColour.Location = new System.Drawing.Point(23, 242);
-			this.blockOfColour.Name = "blockOfColour";
-			this.blockOfColour.Size = new System.Drawing.Size(245, 47);
-			this.blockOfColour.TabIndex = 12;
-			this.blockOfColour.Paint += new System.Windows.Forms.PaintEventHandler(this.blockOfColour_Paint);
-			// 
-			// lblBlueVal
-			// 
-			this.lblBlueVal.AutoSize = true;
-			this.lblBlueVal.Location = new System.Drawing.Point(278, 192);
-			this.lblBlueVal.Name = "lblBlueVal";
-			this.lblBlueVal.Size = new System.Drawing.Size(13, 13);
-			this.lblBlueVal.TabIndex = 11;
-			this.lblBlueVal.Text = "0";
-			// 
-			// lblGreenVal
-			// 
-			this.lblGreenVal.AutoSize = true;
-			this.lblGreenVal.Location = new System.Drawing.Point(278, 153);
-			this.lblGreenVal.Name = "lblGreenVal";
-			this.lblGreenVal.Size = new System.Drawing.Size(13, 13);
-			this.lblGreenVal.TabIndex = 10;
-			this.lblGreenVal.Text = "0";
-			// 
-			// lblRedVal
-			// 
-			this.lblRedVal.AutoSize = true;
-			this.lblRedVal.Location = new System.Drawing.Point(278, 115);
-			this.lblRedVal.Name = "lblRedVal";
-			this.lblRedVal.Size = new System.Drawing.Size(13, 13);
-			this.lblRedVal.TabIndex = 9;
-			this.lblRedVal.Text = "0";
-			// 
-			// label5
-			// 
-			this.label5.AutoSize = true;
-			this.label5.Location = new System.Drawing.Point(18, 192);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(31, 13);
-			this.label5.TabIndex = 8;
-			this.label5.Text = "Blue:";
-			// 
-			// trackBarBlue
-			// 
-			this.trackBarBlue.LargeChange = 40;
-			this.trackBarBlue.Location = new System.Drawing.Point(61, 188);
-			this.trackBarBlue.Maximum = 255;
-			this.trackBarBlue.Name = "trackBarBlue";
-			this.trackBarBlue.Size = new System.Drawing.Size(208, 42);
-			this.trackBarBlue.SmallChange = 8;
-			this.trackBarBlue.TabIndex = 7;
-			this.trackBarBlue.TickFrequency = 16;
-			this.trackBarBlue.Scroll += new System.EventHandler(this.trackBarBlue_Scroll);
-			// 
-			// label4
-			// 
-			this.label4.AutoSize = true;
-			this.label4.Location = new System.Drawing.Point(18, 153);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(40, 13);
-			this.label4.TabIndex = 6;
-			this.label4.Text = "Green:";
-			// 
-			// trackBarGreen
-			// 
-			this.trackBarGreen.LargeChange = 40;
-			this.trackBarGreen.Location = new System.Drawing.Point(61, 149);
-			this.trackBarGreen.Maximum = 255;
-			this.trackBarGreen.Name = "trackBarGreen";
-			this.trackBarGreen.Size = new System.Drawing.Size(208, 42);
-			this.trackBarGreen.SmallChange = 8;
-			this.trackBarGreen.TabIndex = 5;
-			this.trackBarGreen.TickFrequency = 16;
-			this.trackBarGreen.Scroll += new System.EventHandler(this.trackBarGreen_Scroll);
-			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(18, 115);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(30, 13);
-			this.label3.TabIndex = 4;
-			this.label3.Text = "Red:";
-			// 
-			// trackBarRed
-			// 
-			this.trackBarRed.LargeChange = 40;
-			this.trackBarRed.Location = new System.Drawing.Point(61, 111);
-			this.trackBarRed.Maximum = 255;
-			this.trackBarRed.Name = "trackBarRed";
-			this.trackBarRed.Size = new System.Drawing.Size(208, 42);
-			this.trackBarRed.SmallChange = 8;
-			this.trackBarRed.TabIndex = 3;
-			this.trackBarRed.TickFrequency = 16;
-			this.trackBarRed.Scroll += new System.EventHandler(this.trackBarRed_Scroll);
-			// 
-			// txtColourNumber
-			// 
-			this.txtColourNumber.Location = new System.Drawing.Point(110, 74);
-			this.txtColourNumber.MaxLength = 5;
-			this.txtColourNumber.Name = "txtColourNumber";
-			this.txtColourNumber.Size = new System.Drawing.Size(85, 21);
-			this.txtColourNumber.TabIndex = 2;
-			this.txtColourNumber.Text = "0";
-			this.txtColourNumber.TextChanged += new System.EventHandler(this.txtColourNumber_TextChanged);
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(16, 77);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(81, 13);
-			this.label2.TabIndex = 1;
-			this.label2.Text = "Colour number:";
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(16, 26);
-			this.label1.MaximumSize = new System.Drawing.Size(350, 0);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(335, 26);
-			this.label1.TabIndex = 0;
-			this.label1.Text = "You can use the controls below to find the AGS Colour Number for a particular col" +
-				"our.";
-			// 
-			// PaletteEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.tabControl);
-			this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.Name = "PaletteEditor";
-			this.Size = new System.Drawing.Size(476, 452);
-			this.tabControl.ResumeLayout(false);
-			this.palettePage.ResumeLayout(false);
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
-			this.colourFinderPage.ResumeLayout(false);
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).EndInit();
-			this.ResumeLayout(false);
+            this.lblPaletteIntro.TabIndex = 0;
+            this.lblPaletteIntro.Text = "This palette information will only be used for drawing any 8-bit graphics that yo" +
+    "u may have imported.";
+            // 
+            // colourFinderPage
+            // 
+            this.colourFinderPage.Controls.Add(this.groupBox1);
+            this.colourFinderPage.Location = new System.Drawing.Point(4, 22);
+            this.colourFinderPage.Name = "colourFinderPage";
+            this.colourFinderPage.Padding = new System.Windows.Forms.Padding(3);
+            this.colourFinderPage.Size = new System.Drawing.Size(447, 423);
+            this.colourFinderPage.TabIndex = 1;
+            this.colourFinderPage.Text = "Colour Finder";
+            this.colourFinderPage.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.btnColorDialog);
+            this.groupBox1.Controls.Add(this.lblFixedColorsWarning);
+            this.groupBox1.Controls.Add(this.blockOfColour);
+            this.groupBox1.Controls.Add(this.lblBlueVal);
+            this.groupBox1.Controls.Add(this.lblGreenVal);
+            this.groupBox1.Controls.Add(this.lblRedVal);
+            this.groupBox1.Controls.Add(this.label5);
+            this.groupBox1.Controls.Add(this.trackBarBlue);
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.trackBarGreen);
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.trackBarRed);
+            this.groupBox1.Controls.Add(this.txtColourNumber);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Location = new System.Drawing.Point(6, 6);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(395, 337);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Colour Finder";
+            // 
+            // btnColorDialog
+            // 
+            this.btnColorDialog.Location = new System.Drawing.Point(201, 74);
+            this.btnColorDialog.Name = "btnColorDialog";
+            this.btnColorDialog.Size = new System.Drawing.Size(96, 21);
+            this.btnColorDialog.TabIndex = 14;
+            this.btnColorDialog.Text = "Find Colour...";
+            this.btnColorDialog.UseVisualStyleBackColor = true;
+            this.btnColorDialog.Click += new System.EventHandler(this.btnColorDialog_Click);
+            // 
+            // lblFixedColorsWarning
+            // 
+            this.lblFixedColorsWarning.AutoSize = true;
+            this.lblFixedColorsWarning.Location = new System.Drawing.Point(16, 300);
+            this.lblFixedColorsWarning.MaximumSize = new System.Drawing.Size(350, 0);
+            this.lblFixedColorsWarning.Name = "lblFixedColorsWarning";
+            this.lblFixedColorsWarning.Size = new System.Drawing.Size(331, 26);
+            this.lblFixedColorsWarning.TabIndex = 13;
+            this.lblFixedColorsWarning.Text = "NOTE: Colours 1-31 are locked to reflect special colours in the 8-bit palette. Fo" +
+    "r shades of blue, set the Green slider to 4.";
+            this.lblFixedColorsWarning.Visible = false;
+            // 
+            // blockOfColour
+            // 
+            this.blockOfColour.Location = new System.Drawing.Point(23, 242);
+            this.blockOfColour.Name = "blockOfColour";
+            this.blockOfColour.Size = new System.Drawing.Size(245, 47);
+            this.blockOfColour.TabIndex = 12;
+            this.blockOfColour.Paint += new System.Windows.Forms.PaintEventHandler(this.blockOfColour_Paint);
+            // 
+            // lblBlueVal
+            // 
+            this.lblBlueVal.AutoSize = true;
+            this.lblBlueVal.Location = new System.Drawing.Point(278, 192);
+            this.lblBlueVal.Name = "lblBlueVal";
+            this.lblBlueVal.Size = new System.Drawing.Size(13, 13);
+            this.lblBlueVal.TabIndex = 11;
+            this.lblBlueVal.Text = "0";
+            // 
+            // lblGreenVal
+            // 
+            this.lblGreenVal.AutoSize = true;
+            this.lblGreenVal.Location = new System.Drawing.Point(278, 153);
+            this.lblGreenVal.Name = "lblGreenVal";
+            this.lblGreenVal.Size = new System.Drawing.Size(13, 13);
+            this.lblGreenVal.TabIndex = 10;
+            this.lblGreenVal.Text = "0";
+            // 
+            // lblRedVal
+            // 
+            this.lblRedVal.AutoSize = true;
+            this.lblRedVal.Location = new System.Drawing.Point(278, 115);
+            this.lblRedVal.Name = "lblRedVal";
+            this.lblRedVal.Size = new System.Drawing.Size(13, 13);
+            this.lblRedVal.TabIndex = 9;
+            this.lblRedVal.Text = "0";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(18, 192);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(31, 13);
+            this.label5.TabIndex = 8;
+            this.label5.Text = "Blue:";
+            // 
+            // trackBarBlue
+            // 
+            this.trackBarBlue.LargeChange = 40;
+            this.trackBarBlue.Location = new System.Drawing.Point(61, 188);
+            this.trackBarBlue.Maximum = 255;
+            this.trackBarBlue.Name = "trackBarBlue";
+            this.trackBarBlue.Size = new System.Drawing.Size(208, 42);
+            this.trackBarBlue.SmallChange = 8;
+            this.trackBarBlue.TabIndex = 7;
+            this.trackBarBlue.TickFrequency = 16;
+            this.trackBarBlue.Scroll += new System.EventHandler(this.trackBarBlue_Scroll);
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(18, 153);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(40, 13);
+            this.label4.TabIndex = 6;
+            this.label4.Text = "Green:";
+            // 
+            // trackBarGreen
+            // 
+            this.trackBarGreen.LargeChange = 40;
+            this.trackBarGreen.Location = new System.Drawing.Point(61, 149);
+            this.trackBarGreen.Maximum = 255;
+            this.trackBarGreen.Name = "trackBarGreen";
+            this.trackBarGreen.Size = new System.Drawing.Size(208, 42);
+            this.trackBarGreen.SmallChange = 8;
+            this.trackBarGreen.TabIndex = 5;
+            this.trackBarGreen.TickFrequency = 16;
+            this.trackBarGreen.Scroll += new System.EventHandler(this.trackBarGreen_Scroll);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(18, 115);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(30, 13);
+            this.label3.TabIndex = 4;
+            this.label3.Text = "Red:";
+            // 
+            // trackBarRed
+            // 
+            this.trackBarRed.LargeChange = 40;
+            this.trackBarRed.Location = new System.Drawing.Point(61, 111);
+            this.trackBarRed.Maximum = 255;
+            this.trackBarRed.Name = "trackBarRed";
+            this.trackBarRed.Size = new System.Drawing.Size(208, 42);
+            this.trackBarRed.SmallChange = 8;
+            this.trackBarRed.TabIndex = 3;
+            this.trackBarRed.TickFrequency = 16;
+            this.trackBarRed.Scroll += new System.EventHandler(this.trackBarRed_Scroll);
+            // 
+            // txtColourNumber
+            // 
+            this.txtColourNumber.Location = new System.Drawing.Point(110, 74);
+            this.txtColourNumber.MaxLength = 5;
+            this.txtColourNumber.Name = "txtColourNumber";
+            this.txtColourNumber.Size = new System.Drawing.Size(85, 21);
+            this.txtColourNumber.TabIndex = 2;
+            this.txtColourNumber.Text = "0";
+            this.txtColourNumber.TextChanged += new System.EventHandler(this.txtColourNumber_TextChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(16, 77);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(81, 13);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Colour number:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(16, 26);
+            this.label1.MaximumSize = new System.Drawing.Size(350, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(335, 26);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "You can use the controls below to find the AGS Colour Number for a particular col" +
+    "our.";
+            // 
+            // PaletteEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tabControl);
+            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Name = "PaletteEditor";
+            this.Size = new System.Drawing.Size(476, 452);
+            this.Load += new System.EventHandler(this.PaletteEditor_Load);
+            this.tabControl.ResumeLayout(false);
+            this.palettePage.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.colourFinderPage.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarBlue)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarGreen)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarRed)).EndInit();
+            this.ResumeLayout(false);
 
         }
 

--- a/Editor/AGS.Editor/Panes/PaletteEditor.cs
+++ b/Editor/AGS.Editor/Panes/PaletteEditor.cs
@@ -25,7 +25,6 @@ namespace AGS.Editor
         public PaletteEditor()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _colourFinder = tabControl.TabPages[1];
             Factory.GUIController.OnPropertyObjectChanged += new GUIController.PropertyObjectChangedHandler(GUIController_OnPropertyObjectChanged);
             _selectedIndexes.Add(0);
@@ -420,6 +419,14 @@ namespace AGS.Editor
                 TabPage tab = tabControl.TabPages[a.Index];
                 a.Graphics.DrawString(tab.Text, tab.Font, new SolidBrush(t.GetColor("palette/draw-item/foreground")), a.Bounds.X, a.Bounds.Y + 5);
             };
+        }
+
+        private void PaletteEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.Designer.cs
@@ -262,6 +262,7 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "RoomSettingsEditor";
             this.Size = new System.Drawing.Size(768, 491);
+            this.Load += new System.EventHandler(this.RoomSettingsEditor_Load);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.sldTransparency)).EndInit();

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -90,7 +90,6 @@ namespace AGS.Editor
             this.SetStyle(ControlStyles.Selectable, true);
 
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _room = room;
             sldZoomLevel.Maximum = ZOOM_MAX_VALUE / ZOOM_STEP_VALUE;
             sldZoomLevel.Value = 100 / ZOOM_STEP_VALUE;
@@ -966,6 +965,14 @@ namespace AGS.Editor
 		private void chkCharacterOffset_CheckedChanged(object sender, EventArgs e)
         {
             _state.DragFromCenter = chkCharacterOffset.Checked;
+        }
+
+        private void RoomSettingsEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
 
         private void LoadColorTheme(ColorTheme t)

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -60,12 +60,16 @@ namespace AGS.Editor
 
         public ScriptEditor(Script scriptToEdit, AGSEditor agsEditor, Action<Script> showMatchingScript)
         {
-            _showMatchingScript = showMatchingScript;
+            InitializeComponent();
+
             _agsEditor = agsEditor;
-            Init(scriptToEdit);
+            _script = scriptToEdit;
+            _showMatchingScript = showMatchingScript;
             _room = null;
             _roomNumber = 0;
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+
+            this.Load += new EventHandler(ScriptEditor_Load);
+            this.Resize += new EventHandler(ScriptEditor_Resize);
         }
 
         private void Clear()
@@ -86,10 +90,8 @@ namespace AGS.Editor
             scintilla.ToggleBreakpoint -= scintilla_ToggleBreakpoint;
         }
 
-        private void Init(Script scriptToEdit)
+        private void ScriptEditor_Load(object sender, EventArgs e)
         {
-            InitializeComponent();
-
             _autocompleteUpdateHandler = new AutoComplete.BackgroundCacheUpdateStatusChangedHandler(AutoComplete_BackgroundCacheUpdateStatusChanged);
             AutoComplete.BackgroundCacheUpdateStatusChanged += _autocompleteUpdateHandler;
             _fileChangedHandler = new EditorEvents.FileChangedInGameFolderHandler(Events_FileChangedInGameFolder);
@@ -122,9 +124,12 @@ namespace AGS.Editor
             _extraMenu.Commands.Add(new MenuCommand(GOTO_LINE_COMMAND, "Go to Line...", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G));
             _extraMenu.Commands.Add(new MenuCommand(SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND, "Switch to Matching Script or Header", System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M));
 
-            this.Resize += new EventHandler(ScriptEditor_Resize);
-            this.Script = scriptToEdit;
             InitScintilla();
+
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
 
         public int FirstVisibleLine { get { return _firstVisibleLine; } }
@@ -166,6 +171,8 @@ namespace AGS.Editor
 
             // Scripts may miss autocomplete cache when they are first opened, so update
             UpdateAutocompleteAndControls(true);
+
+            scintilla.SetText(_script.Text);
         }
 
         public void ActivateWindow()

--- a/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.Designer.cs
@@ -186,6 +186,7 @@ namespace AGS.Editor
             this.Controls.Add(this.splitWindow);
             this.Name = "SpriteSelector";
             this.Size = new System.Drawing.Size(640, 484);
+            this.Load += new System.EventHandler(this.SpriteSelector_Load);
             this.splitWindow.Panel1.ResumeLayout(false);
             this.splitWindow.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitWindow)).EndInit();

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -77,7 +77,6 @@ namespace AGS.Editor
         public SpriteSelector()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _folders = new Dictionary<string, SpriteFolder>(
                 // The TreeNodeCollection uses case-insensitive string comparer
                 StringComparer.Create(System.Globalization.CultureInfo.CurrentCulture, true));
@@ -1658,6 +1657,14 @@ namespace AGS.Editor
             {
                 ImportNewSprite(_currentFolder, possiblyValidFiles);
             }            
+        }
+
+        private void SpriteSelector_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 

--- a/Editor/AGS.Editor/Panes/TextParserEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/TextParserEditor.Designer.cs
@@ -100,6 +100,7 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "TextParserEditor";
             this.Size = new System.Drawing.Size(531, 519);
+            this.Load += new System.EventHandler(this.TextParserEditor_Load);
             this.SizeChanged += new System.EventHandler(this.TextParserEditor_SizeChanged);
             this.mainFrame.ResumeLayout(false);
             this.mainFrame.PerformLayout();

--- a/Editor/AGS.Editor/Panes/TextParserEditor.cs
+++ b/Editor/AGS.Editor/Panes/TextParserEditor.cs
@@ -24,7 +24,6 @@ namespace AGS.Editor
         public TextParserEditor(TextParser parser)
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             lvwWords.ListViewItemSorter = new TextParserWordComparer();
             _parser = parser;
 
@@ -232,6 +231,14 @@ namespace AGS.Editor
                 a.Graphics.DrawString(a.Header.Text, lvwWords.Font, new SolidBrush(t.GetColor("text-parser-editor/list-view/column-header/foreground")), a.Bounds.X + 5, a.Bounds.Y + a.Bounds.Size.Height / 5);
                 a.Graphics.DrawRectangle(new Pen(new SolidBrush(t.GetColor("text-parser-editor/list-view/column-header/border"))), a.Bounds.X - 1, a.Bounds.Y - 1, a.Bounds.Size.Width, a.Bounds.Size.Height);
             };
+        }
+
+        private void TextParserEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -26,7 +26,6 @@ namespace AGS.Editor
 
             InitializeComponent();
 
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _editingView = viewToEdit;
             InitializeControls();
 			viewPreview.DynamicUpdates = true;
@@ -336,7 +335,11 @@ namespace AGS.Editor
 
 		private void ViewEditor_Load(object sender, EventArgs e)
 		{
-		}
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
+        }
 
         private void LoadColorTheme(ColorTheme t)
         {

--- a/Editor/AGS.Editor/Panes/ViewLoopEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewLoopEditor.Designer.cs
@@ -71,6 +71,7 @@ namespace AGS.Editor
             this.Controls.Add(this.lblLoopTitle);
             this.Name = "ViewLoopEditor";
             this.Size = new System.Drawing.Size(728, 116);
+            this.Load += new System.EventHandler(this.ViewLoopEditor_Load);
             this.Paint += new System.Windows.Forms.PaintEventHandler(this.ViewLoopEditor_Paint);
             this.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ViewLoopEditor_MouseDoubleClick);
             this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.ViewLoopEditor_MouseUp);

--- a/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewLoopEditor.cs
@@ -47,7 +47,6 @@ namespace AGS.Editor
         public ViewLoopEditor(ViewLoop loopToEdit, GUIController guiController)
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             _guiController = guiController;
             _selectedFrame = -1;
             _loop = loopToEdit;
@@ -427,6 +426,14 @@ namespace AGS.Editor
             {
                 _zoomLevel = value;
                 UpdateSize();
+            }
+        }
+
+        private void ViewLoopEditor_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
             }
         }
     }

--- a/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
@@ -29,150 +29,151 @@ namespace AGS.Editor
         /// </summary>
         private void InitializeComponent()
         {
-			this.mainGroupBox = new System.Windows.Forms.GroupBox();
-			this.previewPanel = new AGS.Editor.BufferedPanel();
-			this.chkSkipFrame0 = new System.Windows.Forms.CheckBox();
-			this.chkCentrePivot = new System.Windows.Forms.CheckBox();
-			this.chkAnimate = new System.Windows.Forms.CheckBox();
-			this.label3 = new System.Windows.Forms.Label();
-			this.udDelay = new System.Windows.Forms.NumericUpDown();
-			this.label2 = new System.Windows.Forms.Label();
-			this.udFrame = new System.Windows.Forms.NumericUpDown();
-			this.label1 = new System.Windows.Forms.Label();
-			this.udLoop = new System.Windows.Forms.NumericUpDown();
-			this.mainGroupBox.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.udDelay)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.udFrame)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.udLoop)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// mainGroupBox
-			// 
-			this.mainGroupBox.Controls.Add(this.previewPanel);
-			this.mainGroupBox.Controls.Add(this.chkSkipFrame0);
-			this.mainGroupBox.Controls.Add(this.chkCentrePivot);
-			this.mainGroupBox.Controls.Add(this.chkAnimate);
-			this.mainGroupBox.Controls.Add(this.label3);
-			this.mainGroupBox.Controls.Add(this.udDelay);
-			this.mainGroupBox.Controls.Add(this.label2);
-			this.mainGroupBox.Controls.Add(this.udFrame);
-			this.mainGroupBox.Controls.Add(this.label1);
-			this.mainGroupBox.Controls.Add(this.udLoop);
-			this.mainGroupBox.Location = new System.Drawing.Point(4, 2);
-			this.mainGroupBox.Name = "mainGroupBox";
-			this.mainGroupBox.Size = new System.Drawing.Size(264, 321);
-			this.mainGroupBox.TabIndex = 0;
-			this.mainGroupBox.TabStop = false;
-			this.mainGroupBox.Text = "groupBox1";
-			// 
-			// previewPanel
-			// 
-			this.previewPanel.Location = new System.Drawing.Point(12, 131);
-			this.previewPanel.Name = "previewPanel";
-			this.previewPanel.Size = new System.Drawing.Size(240, 179);
-			this.previewPanel.TabIndex = 9;
-			this.previewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.previewPanel_Paint);
-			// 
-			// chkSkipFrame0
-			// 
-			this.chkSkipFrame0.AutoSize = true;
-			this.chkSkipFrame0.Location = new System.Drawing.Point(31, 106);
-			this.chkSkipFrame0.Name = "chkSkipFrame0";
-			this.chkSkipFrame0.Size = new System.Drawing.Size(163, 17);
-			this.chkSkipFrame0.TabIndex = 8;
-			this.chkSkipFrame0.Text = "Skip frame 0 (standing frame)";
-			this.chkSkipFrame0.UseVisualStyleBackColor = true;
-			// 
-			// chkCentrePivot
-			// 
-			this.chkCentrePivot.AutoSize = true;
-			this.chkCentrePivot.Location = new System.Drawing.Point(19, 62);
-			this.chkCentrePivot.Name = "chkCentrePivot";
-			this.chkCentrePivot.Size = new System.Drawing.Size(162, 17);
-			this.chkCentrePivot.TabIndex = 6;
-			this.chkCentrePivot.Text = "Character view (centre pivot)";
-			this.chkCentrePivot.UseVisualStyleBackColor = true;
-			this.chkCentrePivot.CheckedChanged += new System.EventHandler(this.chkCentrePivot_CheckedChanged);
-			// 
-			// chkAnimate
-			// 
-			this.chkAnimate.AutoSize = true;
-			this.chkAnimate.Location = new System.Drawing.Point(19, 83);
-			this.chkAnimate.Name = "chkAnimate";
-			this.chkAnimate.Size = new System.Drawing.Size(64, 17);
-			this.chkAnimate.TabIndex = 7;
-			this.chkAnimate.Text = "Animate";
-			this.chkAnimate.UseVisualStyleBackColor = true;
-			this.chkAnimate.CheckedChanged += new System.EventHandler(this.chkAnimate_CheckedChanged);
-			// 
-			// label3
-			// 
-			this.label3.AutoSize = true;
-			this.label3.Location = new System.Drawing.Point(157, 19);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(37, 13);
-			this.label3.TabIndex = 5;
-			this.label3.Text = "Delay:";
-			// 
-			// udDelay
-			// 
-			this.udDelay.Location = new System.Drawing.Point(160, 35);
-			this.udDelay.Name = "udDelay";
-			this.udDelay.Size = new System.Drawing.Size(53, 20);
-			this.udDelay.TabIndex = 4;
-			this.udDelay.Value = new decimal(new int[] {
+            this.mainGroupBox = new System.Windows.Forms.GroupBox();
+            this.previewPanel = new AGS.Editor.BufferedPanel();
+            this.chkSkipFrame0 = new System.Windows.Forms.CheckBox();
+            this.chkCentrePivot = new System.Windows.Forms.CheckBox();
+            this.chkAnimate = new System.Windows.Forms.CheckBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.udDelay = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
+            this.udFrame = new System.Windows.Forms.NumericUpDown();
+            this.label1 = new System.Windows.Forms.Label();
+            this.udLoop = new System.Windows.Forms.NumericUpDown();
+            this.mainGroupBox.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udDelay)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.udFrame)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.udLoop)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // mainGroupBox
+            // 
+            this.mainGroupBox.Controls.Add(this.previewPanel);
+            this.mainGroupBox.Controls.Add(this.chkSkipFrame0);
+            this.mainGroupBox.Controls.Add(this.chkCentrePivot);
+            this.mainGroupBox.Controls.Add(this.chkAnimate);
+            this.mainGroupBox.Controls.Add(this.label3);
+            this.mainGroupBox.Controls.Add(this.udDelay);
+            this.mainGroupBox.Controls.Add(this.label2);
+            this.mainGroupBox.Controls.Add(this.udFrame);
+            this.mainGroupBox.Controls.Add(this.label1);
+            this.mainGroupBox.Controls.Add(this.udLoop);
+            this.mainGroupBox.Location = new System.Drawing.Point(4, 2);
+            this.mainGroupBox.Name = "mainGroupBox";
+            this.mainGroupBox.Size = new System.Drawing.Size(264, 321);
+            this.mainGroupBox.TabIndex = 0;
+            this.mainGroupBox.TabStop = false;
+            this.mainGroupBox.Text = "groupBox1";
+            // 
+            // previewPanel
+            // 
+            this.previewPanel.Location = new System.Drawing.Point(12, 131);
+            this.previewPanel.Name = "previewPanel";
+            this.previewPanel.Size = new System.Drawing.Size(240, 179);
+            this.previewPanel.TabIndex = 9;
+            this.previewPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.previewPanel_Paint);
+            // 
+            // chkSkipFrame0
+            // 
+            this.chkSkipFrame0.AutoSize = true;
+            this.chkSkipFrame0.Location = new System.Drawing.Point(31, 106);
+            this.chkSkipFrame0.Name = "chkSkipFrame0";
+            this.chkSkipFrame0.Size = new System.Drawing.Size(163, 17);
+            this.chkSkipFrame0.TabIndex = 8;
+            this.chkSkipFrame0.Text = "Skip frame 0 (standing frame)";
+            this.chkSkipFrame0.UseVisualStyleBackColor = true;
+            // 
+            // chkCentrePivot
+            // 
+            this.chkCentrePivot.AutoSize = true;
+            this.chkCentrePivot.Location = new System.Drawing.Point(19, 62);
+            this.chkCentrePivot.Name = "chkCentrePivot";
+            this.chkCentrePivot.Size = new System.Drawing.Size(162, 17);
+            this.chkCentrePivot.TabIndex = 6;
+            this.chkCentrePivot.Text = "Character view (centre pivot)";
+            this.chkCentrePivot.UseVisualStyleBackColor = true;
+            this.chkCentrePivot.CheckedChanged += new System.EventHandler(this.chkCentrePivot_CheckedChanged);
+            // 
+            // chkAnimate
+            // 
+            this.chkAnimate.AutoSize = true;
+            this.chkAnimate.Location = new System.Drawing.Point(19, 83);
+            this.chkAnimate.Name = "chkAnimate";
+            this.chkAnimate.Size = new System.Drawing.Size(64, 17);
+            this.chkAnimate.TabIndex = 7;
+            this.chkAnimate.Text = "Animate";
+            this.chkAnimate.UseVisualStyleBackColor = true;
+            this.chkAnimate.CheckedChanged += new System.EventHandler(this.chkAnimate_CheckedChanged);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(157, 19);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(37, 13);
+            this.label3.TabIndex = 5;
+            this.label3.Text = "Delay:";
+            // 
+            // udDelay
+            // 
+            this.udDelay.Location = new System.Drawing.Point(160, 35);
+            this.udDelay.Name = "udDelay";
+            this.udDelay.Size = new System.Drawing.Size(53, 20);
+            this.udDelay.TabIndex = 4;
+            this.udDelay.Value = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(86, 19);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(39, 13);
-			this.label2.TabIndex = 3;
-			this.label2.Text = "Frame:";
-			// 
-			// udFrame
-			// 
-			this.udFrame.Location = new System.Drawing.Point(89, 35);
-			this.udFrame.Name = "udFrame";
-			this.udFrame.Size = new System.Drawing.Size(53, 20);
-			this.udFrame.TabIndex = 2;
-			this.udFrame.ValueChanged += new System.EventHandler(this.udFrame_ValueChanged);
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(16, 19);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(34, 13);
-			this.label1.TabIndex = 1;
-			this.label1.Text = "Loop:";
-			// 
-			// udLoop
-			// 
-			this.udLoop.Location = new System.Drawing.Point(19, 35);
-			this.udLoop.Name = "udLoop";
-			this.udLoop.Size = new System.Drawing.Size(53, 20);
-			this.udLoop.TabIndex = 0;
-			this.udLoop.ValueChanged += new System.EventHandler(this.udLoop_ValueChanged);
-			// 
-			// ViewPreview
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-			this.Controls.Add(this.mainGroupBox);
-			this.Name = "ViewPreview";
-			this.Size = new System.Drawing.Size(274, 327);
-			this.mainGroupBox.ResumeLayout(false);
-			this.mainGroupBox.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.udDelay)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.udFrame)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.udLoop)).EndInit();
-			this.ResumeLayout(false);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(86, 19);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(39, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Frame:";
+            // 
+            // udFrame
+            // 
+            this.udFrame.Location = new System.Drawing.Point(89, 35);
+            this.udFrame.Name = "udFrame";
+            this.udFrame.Size = new System.Drawing.Size(53, 20);
+            this.udFrame.TabIndex = 2;
+            this.udFrame.ValueChanged += new System.EventHandler(this.udFrame_ValueChanged);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(16, 19);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(34, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Loop:";
+            // 
+            // udLoop
+            // 
+            this.udLoop.Location = new System.Drawing.Point(19, 35);
+            this.udLoop.Name = "udLoop";
+            this.udLoop.Size = new System.Drawing.Size(53, 20);
+            this.udLoop.TabIndex = 0;
+            this.udLoop.ValueChanged += new System.EventHandler(this.udLoop_ValueChanged);
+            // 
+            // ViewPreview
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.mainGroupBox);
+            this.Name = "ViewPreview";
+            this.Size = new System.Drawing.Size(274, 327);
+            this.Load += new System.EventHandler(this.ViewPreview_Load);
+            this.mainGroupBox.ResumeLayout(false);
+            this.mainGroupBox.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.udDelay)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.udFrame)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.udLoop)).EndInit();
+            this.ResumeLayout(false);
 
         }
 

--- a/Editor/AGS.Editor/Panes/ViewPreview.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.cs
@@ -23,7 +23,6 @@ namespace AGS.Editor
         public ViewPreview()
         {
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         public string Title
@@ -240,6 +239,14 @@ namespace AGS.Editor
             udFrame.ForeColor = t.GetColor("view-preview/numeric-frame/foreground");
             udDelay.BackColor = t.GetColor("view-preview/numeric-delay/background");
             udDelay.ForeColor = t.GetColor("view-preview/numeric-delay/foreground");
+        }
+
+        private void ViewPreview_Load(object sender, EventArgs e)
+        {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
         }
     }
 }

--- a/Editor/AGS.Editor/Panes/WelcomePane.cs
+++ b/Editor/AGS.Editor/Panes/WelcomePane.cs
@@ -32,7 +32,6 @@ namespace AGS.Editor
         {
             _guiContoller = guiContoller;
             InitializeComponent();
-            Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
         }
 
         protected override string OnGetHelpKeyword()
@@ -65,6 +64,11 @@ namespace AGS.Editor
 
         private void WelcomePane_Load(object sender, EventArgs e)
         {
+            if (!DesignMode)
+            {
+                Factory.GUIController.ColorThemes.Apply(LoadColorTheme);
+            }
+
             _currentTipIndex = new Random().Next(0, TIPS_OF_THE_DAY.Length);
             ShowTipOfTheDay(_currentTipIndex);
         }


### PR DESCRIPTION
Fixes #1735.

This fixes certain GUI controls and panes not being able to instantiate in the MSVS's editor.

Moved applying Color Theme to Form.Load event handler, as `DesignMode` property is not set before control's constructor finishes.

NOTE: scintilla-based controls (DialogEditor, ScriptEditor) still cannot show up, possibly because they require external dll; i could not figure out how to deal with this yet.