### PR TITLE
AGS4: New compiler: Accept LONG_MIN in scanner + parser; don't treat leading '0' as octal

### DIFF
--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -336,6 +336,7 @@ AGS::SymbolTable::SymbolTable()
     MakeEntryLiteral(kKW_Null);
     entries[kKW_Null].LiteralD->Vartype = kKW_Null;
     entries[kKW_Null].LiteralD->Value = 0u;
+    AddKeyword(kKW_OnePastLongMax, "2147483648");
     AddKeyword(kKW_Protected, "protected");
     AddKeyword(kKW_Readonly, "readonly");
     AddKeyword(kKW_Return, "return");
@@ -360,6 +361,12 @@ AGS::SymbolTable::SymbolTable()
         MakeEntryLiteral(one_sym);
         entries[one_sym].LiteralD->Value = 1;
         entries[one_sym].LiteralD->Vartype = kKW_Int;
+    }
+    {
+        Symbol const long_min_sym = Add("-2147483648");
+        MakeEntryLiteral(long_min_sym);
+        entries[long_min_sym].LiteralD->Value = LONG_MIN;
+        entries[long_min_sym].LiteralD->Vartype = kKW_Int;
     }
     {
         Symbol const float_zero_sym = Add("0.0");
@@ -449,7 +456,8 @@ bool AGS::SymbolTable::CanBePartOfAnExpression(Symbol s)
         IsFunction(s) ||
         IsLiteral(s) ||
         (IsOperator(s) && entries.at(s).OperatorD->CanBePartOfAnExpression) ||
-        IsVariable(s);
+        IsVariable(s) ||
+        (s == kKW_OnePastLongMax);
 }
 
 bool AGS::SymbolTable::IsAnyIntegerVartype(Symbol s) const

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -189,6 +189,7 @@ enum Predefined : Symbol
     kKW_New,            // "new"
     kKW_Noloopcheck,    // "noloopcheck"
     kKW_OpenBrace,      // "{"
+    kKW_OnePastLongMax, // "2147483648"
     kKW_Protected,      // "protected"
     kKW_Readonly,       // "readonly"
     kKW_Return,         // "return"

--- a/Compiler/script2/cs_compile_time.cpp
+++ b/Compiler/script2/cs_compile_time.cpp
@@ -88,12 +88,17 @@ void AGS::CTF_IntMinus::Evaluate(Symbol arg1, Symbol arg2, Symbol &result)
     CodeCell const i1 = _sym[arg1].LiteralD->Value;
     CodeCell const i2 = _sym[arg2].LiteralD->Value;
 
+    if (i1 >= 0 && i2 == LONG_MIN)
+        UserError(
+            "Overflow when calculating '%s - %s'",
+            _sym[arg1].Name.c_str(),
+            _sym[arg2].Name.c_str());
     if (((i1 > 0 && i2 < 0) || (i1 < 0 && i2 > 0)) &&
         (std::numeric_limits<CodeCell>::max() - abs(i1) < abs(i2)))
         UserError(
             "Overflow when calculating '%s - %s'",
-            std::to_string(i1).c_str(),
-            std::to_string(i2).c_str());
+            _sym[arg1].Name.c_str(),
+            _sym[arg2].Name.c_str());
 
     CTF_IntToInt::Evaluate(arg1, arg2, result);
 }

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -644,6 +644,10 @@ private:
     // 'expression' is parsed from the beginning. The term must use up 'expression' completely.
     void ParseExpression_PostfixCrement(Symbol op_sym, SrcList &expression, EvaluationResult &eres);
 
+    // Parse literal int with the lowest possible value
+    // This will arrive at the parser as '-' '2147483648'
+    void ParseExpression_LongMin(EvaluationResult &eres);
+
     // If consecutive parentheses surround the expression, strip them.
     void StripOutermostParens(SrcList &expression);
 

--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -241,6 +241,26 @@ void AGS::Scanner::SkipWhitespace()
     }
 }
 
+long long AGS::Scanner::StringToLongLong(std::string const &valstring, bool &conversion_successful) const
+{
+    errno = 0;
+    char *endptr;
+    int base = 0;
+    if (valstring.length() > 1 &&
+        valstring[0] == '0' &&
+        IsDigit(valstring[1]))
+    {
+        // Force interpreting the integer as decimal instead of octal
+        base = 10;
+    }
+    long long retval = std::strtoll(valstring.c_str(), &endptr, base);
+    conversion_successful =
+        (errno == 0 || errno == ERANGE) &&                  // ignore range error here
+        valstring.length() == endptr - valstring.c_str();   // ensure that all chars were used up in the conversion
+
+    return retval;
+}
+
 void AGS::Scanner::ReadInNumberLit(std::string &symstring, ScanType &scan_type, CodeCell &value)
 {
     static std::string const exponent_leadin = "EePp";
@@ -248,48 +268,63 @@ void AGS::Scanner::ReadInNumberLit(std::string &symstring, ScanType &scan_type, 
 
     // Collect all the characters into symstring.
     // Collect those characters that are part of the number proper and have a meaning into valstring
-    // Extend the strings as far as possible so that they still can be interpreted as long or double.
-    // Let std::strtol and std::strtod figure out just what that is.
+    // Extend the strings as far as possible within the constraint that they still can be interpreted as long or double.
+    // Let std::strtoll and std::strtod figure out just what that is.
 
     symstring.push_back(Get());
     std::string valstring = symstring;
-    char *endptr;
 
     while (true)
     {
         int const ch = Get();
         if (!EOFReached() && Failed())
-            UserError("Error whilst reading a number literal (file corrupt?)");
+            UserError(
+                "Error whilst reading the number literal starting with '%s' (file corrupt?)",
+                valstring.c_str());
 
         symstring.push_back(ch);
         if ('\'' == ch)
         {
-            if ((!valstring.empty() && IsDigit(valstring.back()) && IsDigit(Peek())) ||
-                ("0x" == valstring.substr(0, 2) && IsHexDigit(valstring.back()) && IsHexDigit(Peek())))
+            if (!valstring.empty() && IsDigit(valstring.back()) && IsDigit(Peek()))
                 continue;
+
+            if (valstring.length() > 1 &&
+                '0' == valstring[0] &&
+                ('x' == valstring[1] || 'X' == valstring[1]) &&
+                IsHexDigit(valstring.back()) &&
+                IsHexDigit(Peek()))
+                continue; 
         }
         valstring.push_back(ch);
 
-        int const peek = Peek();
-        if ("0x" == valstring && IsHexDigit(peek))
-            continue; // Is neither an int nor a float but will become a number
+        if (2 == valstring.length() &&
+            ("0x" == valstring || "0X" == valstring) &&
+            IsHexDigit(Peek()))
+            continue; // Is neither an int nor a float yet but will become a number in later loop traversals
 
-        if (std::string::npos != exponent_leadin.find(ch) && std::string::npos != exponent_follow.find(peek))
-            continue; // Is neither an int nor a float but will become a number
+        if (std::string::npos != exponent_leadin.find(ch) &&
+            std::string::npos != exponent_follow.find(Peek()))
+            continue; // Is neither an int nor a float yet but will become a number in later loop traversals
 
         if (('-' == ch || '+' == ch) &&
-            IsDigit(peek) &&
+            IsDigit(Peek()) &&
             valstring.length() > 1 &&
             std::string::npos != exponent_leadin.find(valstring[valstring.length() - 2]))
-            continue; // Is neither an int nor a float but will become a number
+            continue; // Is neither an int nor a float yet but will become a number in later loop traversals
 
-        std::strtol(valstring.c_str(), &endptr, 0);
-        bool const can_be_long = (valstring.length() == endptr - valstring.c_str());
-        if (can_be_long)
+        // Test convert to a long long (!) so that -LONG_MIN is still within the range that we must allow.
+        bool can_be_an_integer;
+        StringToLongLong(valstring, can_be_an_integer);
+        if (can_be_an_integer)
             continue;
-        std::strtod(valstring.c_str(), &endptr);
-        bool const can_be_double = (valstring.length() == endptr - valstring.c_str());
-        if (can_be_double)
+
+        errno = 0;
+        char *endptr;
+        std::strtof(valstring.c_str(), &endptr);
+        bool const can_be_a_floating_point =
+            (errno == 0 || errno == ERANGE) &&                  // range errors will be treated below
+            (valstring.length() == endptr - valstring.c_str()); // ensure that all chars are used up in the conversion
+        if (can_be_a_floating_point)
             continue;
 
         // So this last char can't belong to the number
@@ -299,43 +334,73 @@ void AGS::Scanner::ReadInNumberLit(std::string &symstring, ScanType &scan_type, 
         break;
     }
 
-    int const peek = Peek();
-    if ('8' == peek || '9' == peek)
-        UserError("Encountered the illegal digit '%c' in the octal number literal starting with '%s'", peek, symstring.c_str());
+    // We've read in the number completely: Figure out what it is
 
-    if ('f' == peek || 'F' == peek)
-        symstring.push_back(Get());
-
-    errno = 0;
-    long long_value = std::strtoul(valstring.c_str(), &endptr, 0);
-    bool can_be_long = (valstring.length() == endptr - valstring.c_str());
-    if (can_be_long && peek != 'f' && peek != 'F')
+    bool can_be_an_integer;
+    // Convert to a long long (!) so that -LONG_MIN is still within the range that we must allow.
+    long long longlong_value = StringToLongLong(valstring.c_str(), can_be_an_integer);
+    if (can_be_an_integer)
     {
-        if (std::numeric_limits<CodeCell>::max() < long_value || ERANGE == errno)
-            UserError(
-                "Literal integer '%s' is out of bounds (maximum is '%s')",
-                valstring.c_str(),
-                std::to_string(std::numeric_limits<CodeCell>::max()).c_str());
+        if (valstring.length() > 1 && '0' == valstring[0] && IsDigit(valstring[2]))
+            Warning("'%s' is interpreted as a number in decimal notation", symstring.c_str());
+
+        if (longlong_value > LONG_MAX)
+        {
+            if (valstring.length() > 2 &&
+                IsDigit(valstring[0]) &&
+                IsDigit(valstring[1]) &&
+                longlong_value == -static_cast<long long>(LONG_MIN))
+            {
+                // Special case. This is out-of-range for integers,
+                // but might still be allowed when preceded by a _unary_ minus.
+                // Only the parser can decide whether a minus is unary,
+                // so let this through here. A code cell is too small to hold
+                // this value, so return a dedicated scan type for this situation
+                scan_type = kSct_OnePastLongMax;
+                value = 0;
+                return;
+            }
+
+            if (longlong_value >= 0x80000000 &&
+                valstring.length() > 1 &&
+                valstring[0] == '0' &&
+                (valstring[1] == 'x' || valstring[1] == 'X'))
+            {
+                // Large hexadecimal
+                if (longlong_value > 0xFFFFFFFF)
+                    UserError(
+                        "Too many significant hex digits in '%s' (at most 8 significant digits allowed)",
+                        (symstring.length() <= 20? symstring : symstring.substr(0, 20) + "...").c_str());
+                // 'strtoll()' has converted this hexadecimal into a value that
+                // is too large for a long. However, this is still legal and
+                // yields a negative long number.
+                longlong_value = longlong_value - (0xFFFFFFFFLL + 1LL);
+            }
+            else
+            {
+                UserError(
+                    "Literal integer '%s' is out of bounds (maximum is '%d')",
+                    symstring.length() <= 20 ? symstring.c_str() : (symstring.substr(0, 20) + "...").c_str(),
+                    LONG_MAX);
+            }
+        }
 
         scan_type = kSct_IntLiteral;
-        value = long_value;
+        value = static_cast<long>(longlong_value);
         return;
     }
 
     errno = 0;
-    double double_value = std::strtod(valstring.c_str(), &endptr);
-    bool can_be_double = (valstring.length() == endptr - valstring.c_str());
-    if (!can_be_double)
-        UserError("Expected a number literal, found '%s' instead", symstring.c_str());
-
-    if (std::numeric_limits<float>::max() < double_value || ERANGE == errno)
+    float float_value = std::strtof(valstring.c_str(), nullptr);
+    if (ERANGE == errno)
         UserError(
             "Literal float '%s' is out of bounds (maximum is '%.3G')",
-            valstring.c_str(),
+            symstring.c_str(),
             static_cast<double>(std::numeric_limits<float>::max()));
+    if (errno != 0)
+        UserError("Expected a number literal, found '%s' instead", symstring.c_str());   
 
     scan_type = kSct_FloatLiteral;
-    float float_value = static_cast<float>(double_value);
     value = *reinterpret_cast<CodeCell *>(&float_value);
     return;
 }
@@ -645,6 +710,7 @@ void AGS::Scanner::ReadInGTCombi(std::string &symstring)
 void AGS::Scanner::SymstringToSym(std::string const &symstring, ScanType scan_type, CodeCell value, Symbol &symb)
 {
     static Symbol const const_string_vartype = _sym.VartypeWith(VTT::kConst, kKW_String);
+    static const char *const one_past_long_max_string = "2147483648";
 
     symb = _sym.FindOrAdd(symstring);
     if (symb < 0)
@@ -665,6 +731,10 @@ void AGS::Scanner::SymstringToSym(std::string const &symstring, ScanType scan_ty
         _sym[symb].LiteralD = new SymbolTableEntry::LiteralDesc;
         _sym[symb].LiteralD->Vartype = kKW_Int;
         _sym[symb].LiteralD->Value = value;
+        return;
+
+    case Scanner::kSct_OnePastLongMax:  // 1 plus largest signed integer
+        symb = _sym.FindOrAdd(one_past_long_max_string);
         return;
 
     case Scanner::kSct_FloatLiteral:
@@ -797,4 +867,23 @@ void AGS::Scanner::InternalError(char const *descr ...)
     va_end(vlist1);
 
     Error(true, &message[0u]);
+}
+
+void AGS::Scanner::Warning(char const *descr ...)
+{
+    // Convert the parameters into message
+    va_list vlist1, vlist2;
+    va_start(vlist1, descr);
+    va_copy(vlist2, vlist1);
+    size_t const needed_len = vsnprintf(nullptr, 0u, descr, vlist1) + 1u;
+    std::vector<char> message(needed_len);
+    vsprintf(&message[0u], descr, vlist2);
+    va_end(vlist2);
+    va_end(vlist1);
+
+    _msgHandler.AddMessage(
+        MessageHandler::kSV_Warning,
+        _section,
+        _lineno,
+        &message[0u]);
 }

--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -341,7 +341,7 @@ void AGS::Scanner::ReadInNumberLit(std::string &symstring, ScanType &scan_type, 
     long long longlong_value = StringToLongLong(valstring.c_str(), can_be_an_integer);
     if (can_be_an_integer)
     {
-        if (valstring.length() > 1 && '0' == valstring[0] && IsDigit(valstring[2]))
+        if (valstring.length() > 1 && '0' == valstring[0] && IsDigit(valstring[1]))
             Warning("'%s' is interpreted as a number in decimal notation", symstring.c_str());
 
         if (longlong_value > LONG_MAX)

--- a/Compiler/script2/cs_scanner.h
+++ b/Compiler/script2/cs_scanner.h
@@ -25,9 +25,10 @@ public:
     {
         kSct_Unspecified = 0,
         kSct_Identifier,      // Identifier or keyword --- [A-Za-z][A-Za-z_]*
-        kSct_FloatLiteral,    // Numbers containing a "." --- [0-9]+[.][0-9]*
-        kSct_IntLiteral,      // Numbers not containing a "." --- [0-9]+
+        kSct_FloatLiteral,    // Float literal in C++ syntax
+        kSct_IntLiteral,      // Integer literal in C++ syntax
         kSct_NonAlphanum,     // i.e., +, ++, /=; this can be one character or two characters
+        kSct_OnePastLongMax,  // 1 plus largest signed integer
         kSct_SectionChange,   // String literal beginning with magic string
         kSct_StringLiteral,   // Quoted strings --- ["]([\\].[^"]*)*["]
     };
@@ -107,6 +108,9 @@ private:
     // We encountered a section start; process it
     void NewSection(std::string const &section);
 
+    // Convert 'valstring' to a long long (!)
+    long long StringToLongLong(std::string const &valstring, bool &conversion_successful) const;
+
     // Read in either an int literal or a float literal
     // Note: appends to symstring, doesn't clear it first.
     void ReadInNumberLit(std::string &symstring, ScanType &scan_type, CodeCell &value);
@@ -161,6 +165,9 @@ private:
 
     // Abort scanning with an internal error
     void InternalError(char const *desc  ...);
+
+    // Warn, but don't abort.
+    void Warning(char const *desc ...);
 
 protected:
     inline static bool IsDigit(int ch) { return (ch >= '0' && ch <= '9'); }

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -227,7 +227,7 @@ TEST_F(Bytecode0, Float01) {
             return Test1 + Test2 + Test3 +  \n\
                 Test4 + Test5 + Test6 +     \n\
                 Test7 + Test8;              \n\
-            Test1 = 77f;                    \n\
+            Test1 = 77.;                    \n\
         }                                   \n\
         ";
 

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -162,7 +162,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowPositive) {
 
     // Offer some leeway in the error message, but insist that the culprit is named
     std::string res(last_seen_cc_error());
-    EXPECT_NE(std::string::npos, res.find("9999999999999999999999"));
+    EXPECT_NE(std::string::npos, res.find("'99999999999999"));
 }
 
 TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
@@ -175,7 +175,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     // Offer some leeway in the error message, but insist that the culprit is named
     std::string res(last_seen_cc_error());
-    EXPECT_NE(std::string::npos, res.find("9999999999999999999999"));
+    EXPECT_NE(std::string::npos, res.find("'999999999999999"));
 }
 
 TEST_F(Compile0, ParsingIntOverflow) {
@@ -188,7 +188,7 @@ TEST_F(Compile0, ParsingIntOverflow) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     // Offer some leeway in the error message, but insist that the culprit is named
     std::string res(last_seen_cc_error());
-    EXPECT_NE(std::string::npos, res.find("4200000000000000000000"));
+    EXPECT_NE(std::string::npos, res.find("'42000000000000"));
 }
 
 TEST_F(Compile0, ParsingNegIntOverflow) {
@@ -201,7 +201,7 @@ TEST_F(Compile0, ParsingNegIntOverflow) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     // Offer some leeway in the error message, but insist that the culprit is named
     std::string res(last_seen_cc_error());
-    EXPECT_NE(std::string::npos, res.find("4200000000000000000000"));
+    EXPECT_NE(std::string::npos, res.find("'420000000000000"));
 }
 
 TEST_F(Compile0, ParsingHexSuccess) {

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2451,3 +2451,53 @@ TEST_F(Compile1, DisallowStaticVariables)
     EXPECT_NE(std::string::npos, msg.find("tatic "));
 
 }
+
+TEST_F(Compile1, LongMin01) {
+
+    // LONG_MAX + 1 is too large (when there isn't a '-' in front)
+
+    char *inpl = "\
+        int main()                              \n\
+        {                                       \n\
+            int i = 2147483648;                 \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("ut of bounds"));
+}
+
+TEST_F(Compile1, LongMin02) {
+
+    // LONG_MAX + 1 is too large (when there isn't a UNARY '-' in front)
+
+    char *inpl = "\
+        int main()                              \n\
+        {                                       \n\
+            int i = (5 - 2147483648);           \n\
+        }                                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("ut of bounds"));
+}
+
+TEST_F(Compile1, LongMin03) {
+
+    // Can subtract LONG_MIN from LONG_MIN (result is 0)
+
+    char *inpl = "\
+        int main()                                  \n\
+        {                                           \n\
+            int i = (- 2147483648 - -2147483648);   \n\
+        }                                           \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+}

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -402,6 +402,44 @@ TEST_F(Scan, LiteralInt7)
     EXPECT_EQ(123, sym[token].LiteralD->Value);
 }
 
+TEST_F(Scan, LiteralIntLimits)
+{
+    // Should correctly parse INT32_MAX and INT32_MIN
+    const char *inp1 = "-2147483648 2147483647";
+
+    AGS::Scanner scanner(inp1, token_list, string_collector, sym, mh);
+    scanner.Scan();
+    EXPECT_FALSE(mh.HasError());
+    AGS::Symbol const lit_min = token_list[1u]; // 0u is '-'
+
+    // This translates to a symbol that gets special treatment
+    // within expressions in the parser but is NOT recognized
+    // as a literal. I had to treat it this way because 2147483648
+    // is too large for a value for literals. 
+    // ASSERT_TRUE(sym.IsLiteral(lit_min));
+    // EXPECT_EQ(INT32_MIN, sym[lit_min].LiteralD->Value);
+
+    AGS::Symbol const lit_max = token_list[2u];
+    ASSERT_TRUE(sym.IsLiteral(lit_max));
+    EXPECT_EQ(INT32_MAX, sym[lit_max].LiteralD->Value);
+}
+
+TEST_F(Scan, LiteralIntOverflow)
+{
+    // Should detect int32 overflow
+    const char *inp1 = "-2147483649";
+    
+    AGS::Scanner scanner1(inp1, token_list, string_collector, sym, mh);
+    scanner1.Scan();
+    ASSERT_TRUE(mh.HasError());
+
+    // The scanner won't catch this, but the parser will.
+    // const char *inp2 = "2147483648";
+    // AGS::Scanner scanner2(inp2, token_list, string_collector, sym, mh);
+    // scanner2.Scan();
+    // ASSERT_TRUE(mh.HasError());
+}
+
 TEST_F(Scan, LiteralIntHex)
 {
     const char *inp = "0x7FFFFFFF 0xFFFFFFFF";

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -322,7 +322,7 @@ TEST_F(Scan, LiteralInt1)
 TEST_F(Scan, LiteralInt2)
 {
     // Accept LONG_MIN written in decimal (will yield 2 symbols)
-    char *inp = "-2147483648";
+    const char *inp = "-2147483648";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -333,7 +333,7 @@ TEST_F(Scan, LiteralInt2)
 TEST_F(Scan, LiteralInt3)
 {
     // Accept large hexadecimal, treat as negative number (will yield 1 symbol)
-    char *inp = "0XFF000000";
+    const char *inp = "0XFF000000";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -346,7 +346,7 @@ TEST_F(Scan, LiteralInt3)
 TEST_F(Scan, LiteralInt4)
 {
     // Accept LONG_MIN written as hexadecimal (will yield 1 symbol)
-    char *inp = "0x80000000";
+    const char *inp = "0x80000000";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -358,7 +358,7 @@ TEST_F(Scan, LiteralInt4)
 TEST_F(Scan, LiteralInt5)
 {
     // Leading zeroes in hex literal
-    char *inp = "0x000000001234";
+    const char *inp = "0x000000001234";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -370,7 +370,7 @@ TEST_F(Scan, LiteralInt5)
 TEST_F(Scan, LiteralInt6a)
 {
     // Huge hexadecimal, too many significant hex digits
-    char *inp = "0x000123456789";
+    const char *inp = "0x000123456789";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -380,9 +380,9 @@ TEST_F(Scan, LiteralInt6a)
 TEST_F(Scan, LiteralInt6b)
 {
     // Huge decimal 
-    char *inp = "1234567890123456789012345678901234567890123456789012345678901234567890"
-                "1234567890123456789012345678901234567890123456789012345678901234567890"
-                "1234567890123456789012345678901234567890123456789012345678901234567890";
+    const char *inp = "1234567890123456789012345678901234567890123456789012345678901234567890"
+                      "1234567890123456789012345678901234567890123456789012345678901234567890"
+                      "1234567890123456789012345678901234567890123456789012345678901234567890";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -393,7 +393,7 @@ TEST_F(Scan, LiteralInt7)
 {
     // Accept number that begins with '0' but not '0x';
     // interpret such a number in decimal (!) notation
-    char *inp = "0123";
+    const char *inp = "0123";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();


### PR DESCRIPTION
This PR addresses #1711 and #1674.

- Accept '2147483648' in the scanner but balk in the parser unless a unary '-' is in front.
- Accept hexadecimals between '0x80000000' and '0xFFFFFFFF' in the scanner, interpret them as negative integers. (In particular, '0x80000000' is '-2147483648'.)
- Reject hexadecimals beyond '0xFFFFFFFF'.
- Compile-time calculation: The negative of '-2147483648' yields an overflow at compile time.
- Treat integers that start with '0' and no following 'x' as decimal instead of octal.
- Add more googletests for scanner + parser. (I've slightly extended existing tests or moved them into the parser googletests but not reduced them AFAICS.)
- If error messages feature exceptionally long numbers, only show the first 20 digits.