### PR TITLE
Engine: VSync toggle support

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -811,8 +811,7 @@ void render_to_screen()
     // Stage: engine overlay
     construct_engine_overlay();
 
-    // only vsync in full screen mode, it makes things worse in a window
-    gfxDriver->SetVsync((scsystem.vsync > 0) && (!scsystem.windowed));
+    gfxDriver->SetVsync(scsystem.vsync > 0);
 
     bool succeeded = false;
     while (!succeeded && !want_exit && !abort_engine)

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1924,7 +1924,11 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
 
 bool OGLGraphicsDriver::SetVsync(bool enabled)
 {
-    _mode.Vsync = SDL_GL_SetSwapInterval(_mode.Vsync ? 1 : 0) == 0;
+    if (SDL_GL_SetSwapInterval(enabled) == 0)
+    {
+        _mode.Vsync = enabled;
+    }
+
     return _mode.Vsync;
 }
 

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1922,6 +1922,12 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
 }
 
 
+bool OGLGraphicsDriver::SetVsync(bool enabled)
+{
+    _mode.Vsync = SDL_GL_SetSwapInterval(_mode.Vsync ? 1 : 0) == 0;
+    return _mode.Vsync;
+}
+
 OGLGraphicsFactory *OGLGraphicsFactory::_factory = nullptr;
 
 OGLGraphicsFactory::~OGLGraphicsFactory()

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -239,8 +239,8 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    bool DoesSupportVsyncToggle() override { return false; }
-    bool SetVsync(bool /*enabled*/) override { return _mode.Vsync; /* TODO: support toggling */ }
+    bool DoesSupportVsyncToggle() override { return true; }
+    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override;
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -863,10 +863,12 @@ bool SDLRendererGraphicsDriver::SetVsync(bool enabled)
         return _mode.Vsync;
     }
 
+    #if SDL_VERSION_ATLEAST(2, 0, 18)
     if (!SDL_RenderSetVSync(_renderer, enabled)) { // 0 on success
         _mode.Vsync = enabled;
         SetGamma(_gamma); // gamma might be lost after changing vsync mode at fullscreen
     }
+    #endif
 
     return _mode.Vsync;
 }

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -287,6 +287,8 @@ void SDLRendererGraphicsDriver::SetGamma(int newGamma)
     gamma_blue[i] = std::min(((int)_defaultGammaBlue[i] * newGamma) / 100, 0xffff);
   }
 
+  _gamma = newGamma;
+
   SDL_SetWindowGammaRamp(sys_get_window(), gamma_red, gamma_green, gamma_blue);
 }
 
@@ -854,6 +856,20 @@ static unsigned long _trans_alpha_blender32(unsigned long x, unsigned long y, un
    return res | g;
 }
 
+bool SDLRendererGraphicsDriver::SetVsync(bool enabled)
+{
+    // do nothing if already applied, necessary to prevent a reset loop when going fullscreen
+    if (_mode.Vsync == enabled) {
+        return _mode.Vsync;
+    }
+
+    if (!SDL_RenderSetVSync(_renderer, enabled)) { // 0 on success
+        _mode.Vsync = enabled;
+        SetGamma(_gamma); // gamma might be lost after changing vsync mode at fullscreen
+    }
+
+    return _mode.Vsync;
+}
 
 SDLRendererGraphicsFactory *SDLRendererGraphicsFactory::_factory = nullptr;
 

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -196,12 +196,8 @@ public:
     bool SupportsGammaControl() override ;
     void SetGamma(int newGamma) override;
     void UseSmoothScaling(bool /*enabled*/) override { }
-    bool DoesSupportVsyncToggle() override { return false; }
-    bool SetVsync(bool /*enabled*/) override
-    {
-        /* TODO: support toggling; need SDL_RenderSetVSync() from SDL 2.0.18 */
-        return _mode.Vsync;
-    }
+    bool DoesSupportVsyncToggle() override { return true; }
+    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
     bool RequiresFullRedrawEachFrame() override { return false; }
     bool HasAcceleratedTransform() override { return false; }
@@ -223,6 +219,7 @@ private:
     Uint16 _defaultGammaRed[256]{};
     Uint16 _defaultGammaGreen[256]{};
     Uint16 _defaultGammaBlue[256]{};
+    int _gamma = 100;
 
     SDL_RendererFlip _renderFlip = SDL_FLIP_NONE;
     SDL_Renderer *_renderer = nullptr;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -196,7 +196,7 @@ public:
     bool SupportsGammaControl() override ;
     void SetGamma(int newGamma) override;
     void UseSmoothScaling(bool /*enabled*/) override { }
-    bool DoesSupportVsyncToggle() override { return true; }
+    bool DoesSupportVsyncToggle() override { return SDL_VERSION_ATLEAST(2, 0, 18); }
     bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
     bool RequiresFullRedrawEachFrame() override { return false; }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1338,6 +1338,8 @@ bool engine_try_switch_windowed_gfxmode()
     ActiveDisplaySetting setting = graphics_mode_get_last_setting(windowed);
     DisplayMode last_opposite_mode = setting.Dm;
     FrameScaleDef frame = setting.Frame;
+
+    last_opposite_mode.Vsync = usetup.Screen.Params.VSync = old_dm.Vsync; // normalize vsync in case it has been toggled at runtime
     
     // If there are saved parameters for given mode (fullscreen/windowed)
     // then use them, if there are not, get default setup for the new mode.

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1923,6 +1923,31 @@ void D3DGraphicsDriver::SetScreenTint(int red, int green, int blue)
     _spriteList.push_back(D3DDrawListEntry(ddb, _actSpriteBatch, 0, 0));
 }
 
+bool D3DGraphicsDriver::SetVsync(bool enabled) 
+{
+    // do nothing if already applied, necessary to prevent a reset loop when going fullscreen
+    if (_mode.Vsync == enabled) {
+        return _mode.Vsync;
+    }
+    
+    _mode.Vsync = enabled;
+    
+    d3dpp.PresentationInterval = _mode.Vsync ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
+    // D3D requires a Reset() in order to apply a new D3DPRESENT_INTERVAL value
+    HRESULT hr = ResetD3DDevice();
+    if (hr != D3D_OK)
+    {
+        Debug::Printf("D3DGraphicsDriver: Failed to reset D3D device");
+        return _mode.Vsync;
+    }
+    InitializeD3DState();
+    CreateVirtualScreen();
+    direct3ddevice->SetGammaRamp(0, D3DSGR_NO_CALIBRATION, &currentgammaramp);
+    SetupViewport();
+
+    return _mode.Vsync;
+}
+
 
 D3DGraphicsFactory *D3DGraphicsFactory::_factory = NULL;
 Library D3DGraphicsFactory::_library;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -224,8 +224,8 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    bool DoesSupportVsyncToggle() override { return false; }
-    bool SetVsync(bool /*enabled*/) override { return _mode.Vsync; /* TODO: support toggling */ }
+    bool DoesSupportVsyncToggle() override { return true; }
+    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool enabled, int /*supersampling*/) override { _renderSprAtScreenRes = enabled; };
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;


### PR DESCRIPTION
Experiment to support togglable VSync at runtime.

Currently implemented: D3D, OGL, and SW mode.
Software mode require SDL2 >= 2.0.18 (gracefully degrades depending on available version at compile)

## Notes
- D3D requires a reset(), while OGL can be switched directly.
- I removed the outdated restriction about windowed modes not supporting VSync.
- I had to force the current mode's Vsync value to `last_opposite_mode.Vsync` and `usetup.Screen.Params.VSync` so it doesn't get lost while switching from windowed<->fullscreen
- SW and D3D mode appears to keel over whenever reapplying the same vsync value at fullscreen, therefore I added a check to avoid doing so
