### PR TITLE
Introduced extended FontRenderer plugin API, more fixes for "Clifftop's" SpriteFont

### DIFF
--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -80,7 +80,7 @@ struct FontMetrics
 
 // The strictly internal font renderer interface, not to use in plugin API.
 // Contains methods necessary for built-in font renderers.
-class IAGSFontRendererInternal
+class IAGSFontRendererInternal : public IAGSFontRenderer2
 {
 public:
     // Tells if this is a bitmap font (otherwise it's a vector font)
@@ -88,8 +88,11 @@ public:
     // Load font, applying extended font rendering parameters
     virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
         FontMetrics *metrics) = 0;
+    // Fill FontMetrics struct; note that it may be left cleared if this is not supported
+    virtual void GetFontMetrics(int fontNumber, FontMetrics *metrics) = 0;
     // Perform any necessary adjustments when the AA mode is toggled
     virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
+
 protected:
     IAGSFontRendererInternal() = default;
     ~IAGSFontRendererInternal() = default;

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -17,22 +17,49 @@
 
 struct BITMAP;
 
+// Basic font renderer interface.
 // WARNING: this interface is exposed for plugins and declared for the second time in agsplugin.h
 class IAGSFontRenderer
 {
 public:
-  virtual bool LoadFromDisk(int fontNumber, int fontSize) = 0;
-  virtual void FreeMemory(int fontNumber) = 0;
-  virtual bool SupportsExtendedCharacters(int fontNumber) = 0;
-  virtual int GetTextWidth(const char *text, int fontNumber) = 0;
-  // Get actual height of the given line of text
-  virtual int GetTextHeight(const char *text, int fontNumber) = 0;
-  virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) = 0;
-  virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) = 0;
-  virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
+    virtual bool LoadFromDisk(int fontNumber, int fontSize) = 0;
+    virtual void FreeMemory(int fontNumber) = 0;
+    virtual bool SupportsExtendedCharacters(int fontNumber) = 0;
+    virtual int GetTextWidth(const char *text, int fontNumber) = 0;
+    // Get actual height of the given line of text
+    virtual int GetTextHeight(const char *text, int fontNumber) = 0;
+    virtual void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) = 0;
+    virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) = 0;
+    virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
 protected:
-  IAGSFontRenderer() = default;
-  ~IAGSFontRenderer() = default;
+    IAGSFontRenderer() = default;
+    ~IAGSFontRenderer() = default;
+};
+
+// Extended font renderer interface.
+// WARNING: this interface is exposed for plugins and declared for the second time in agsplugin.h
+class IAGSFontRenderer2 : public IAGSFontRenderer
+{
+public:
+    // Returns engine API version this font renderer complies to.
+    // Must not be lower than 26 (this interface was added at API v26).
+    virtual int GetVersion() = 0;
+    // Returns an arbitrary renderer name; this is for informational
+    // purposes only.
+    virtual const char *GetRendererName() = 0;
+    // Returns given font's name (if available).
+    virtual const char *GetFontName(int fontNumber) = 0;
+    // Returns the given font's height: that is the maximal vertical size
+    // that the font glyphs may occupy.
+    virtual int GetFontHeight(int fontNumber) = 0;
+    // Returns the given font's linespacing;
+    // is allowed to return 0, telling that no specific linespacing
+    // is assigned for this font.
+    virtual int GetLineSpacing(int fontNumber) = 0;
+
+protected:
+    IAGSFontRenderer2() = default;
+    ~IAGSFontRenderer2() = default;
 };
 
 // Font render params, mainly for dealing with various compatibility issues.
@@ -56,18 +83,16 @@ struct FontMetrics
 class IAGSFontRendererInternal
 {
 public:
-  // Tells if this is a bitmap font (otherwise it's a vector font)
-  virtual bool IsBitmapFont() = 0;
-  // Load font, applying extended font rendering parameters
-  virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
-      FontMetrics *metrics) = 0;
-  // Gets font's name; must return an empty string if no name is available
-  virtual const char *GetName(int fontNumber) = 0;
-  // Perform any necessary adjustments when the AA mode is toggled
-  virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
+    // Tells if this is a bitmap font (otherwise it's a vector font)
+    virtual bool IsBitmapFont() = 0;
+    // Load font, applying extended font rendering parameters
+    virtual bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
+        FontMetrics *metrics) = 0;
+    // Perform any necessary adjustments when the AA mode is toggled
+    virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
 protected:
-  IAGSFontRendererInternal() = default;
-  ~IAGSFontRendererInternal() = default;
+    IAGSFontRendererInternal() = default;
+    ~IAGSFontRendererInternal() = default;
 };
 
 #endif // __AC_AGSFONTRENDERER_H

--- a/Common/font/agsfontrenderer.h
+++ b/Common/font/agsfontrenderer.h
@@ -51,8 +51,9 @@ struct FontMetrics
     int CompatHeight = 0; // either formal or real height, depending on compat settings
 };
 
-// NOTE: this extending interface is not yet exposed to plugins
-class IAGSFontRenderer2
+// The strictly internal font renderer interface, not to use in plugin API.
+// Contains methods necessary for built-in font renderers.
+class IAGSFontRendererInternal
 {
 public:
   // Tells if this is a bitmap font (otherwise it's a vector font)
@@ -65,8 +66,8 @@ public:
   // Perform any necessary adjustments when the AA mode is toggled
   virtual void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) = 0;
 protected:
-  IAGSFontRenderer2() = default;
-  ~IAGSFontRenderer2() = default;
+  IAGSFontRendererInternal() = default;
+  ~IAGSFontRendererInternal() = default;
 };
 
 #endif // __AC_AGSFONTRENDERER_H

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -37,7 +37,7 @@ namespace Common
 struct Font
 {
     IAGSFontRenderer   *Renderer = nullptr;
-    IAGSFontRenderer2  *Renderer2 = nullptr;
+    IAGSFontRendererInternal *RendererInt = nullptr;
     FontInfo            Info;
     // Values received from the renderer and saved for the reference
     FontMetrics         Metrics;
@@ -141,16 +141,16 @@ IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* ren
     return nullptr;
   IAGSFontRenderer* oldRender = fonts[fontNumber].Renderer;
   fonts[fontNumber].Renderer = renderer;
-  fonts[fontNumber].Renderer2 = nullptr;
+  fonts[fontNumber].RendererInt = nullptr;
   font_post_init(fontNumber);
   return oldRender;
 }
 
 bool is_bitmap_font(size_t fontNumber)
 {
-    if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer2)
+    if (fontNumber >= fonts.size() || !fonts[fontNumber].RendererInt)
         return false;
-    return fonts[fontNumber].Renderer2->IsBitmapFont();
+    return fonts[fontNumber].RendererInt->IsBitmapFont();
 }
 
 bool font_supports_extended_characters(size_t fontNumber)
@@ -162,9 +162,9 @@ bool font_supports_extended_characters(size_t fontNumber)
 
 const char *get_font_name(size_t fontNumber)
 {
-  if (fontNumber >= fonts.size() || !fonts[fontNumber].Renderer2)
+  if (fontNumber >= fonts.size() || !fonts[fontNumber].RendererInt)
     return "";
-  const char *name = fonts[fontNumber].Renderer2->GetName(fontNumber);
+  const char *name = fonts[fontNumber].RendererInt->GetName(fontNumber);
   return name ? name : "";
 }
 
@@ -475,12 +475,12 @@ bool load_font_size(size_t fontNumber, const FontInfo &font_info)
   if (ttfRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &params, &metrics))
   {
     fonts[fontNumber].Renderer  = &ttfRenderer;
-    fonts[fontNumber].Renderer2 = &ttfRenderer;
+    fonts[fontNumber].RendererInt = &ttfRenderer;
   }
   else if (wfnRenderer.LoadFromDiskEx(fontNumber, font_info.Size, &params, &metrics))
   {
     fonts[fontNumber].Renderer  = &wfnRenderer;
-    fonts[fontNumber].Renderer2 = &wfnRenderer;
+    fonts[fontNumber].RendererInt = &wfnRenderer;
   }
 
   if (!fonts[fontNumber].Renderer)
@@ -538,8 +538,8 @@ void adjust_fonts_for_render_mode(bool aa_mode)
 {
     for (size_t i = 0; i < fonts.size(); ++i)
     {
-        if (fonts[i].Renderer2 != nullptr)
-            fonts[i].Renderer2->AdjustFontForAntiAlias(i, aa_mode);
+        if (fonts[i].RendererInt)
+            fonts[i].RendererInt->AdjustFontForAntiAlias(i, aa_mode);
     }
 }
 

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -24,7 +24,7 @@ namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS;
 
 class IAGSFontRenderer;
-class IAGSFontRenderer2;
+class IAGSFontRendererInternal;
 struct FontInfo;
 struct FontRenderParams;
 

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -24,6 +24,7 @@ namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS;
 
 class IAGSFontRenderer;
+class IAGSFontRenderer2;
 class IAGSFontRendererInternal;
 struct FontInfo;
 struct FontRenderParams;
@@ -32,6 +33,8 @@ void init_font_renderer();
 void shutdown_font_renderer();
 void adjust_y_coordinate_for_text(int* ypos, size_t fontnum);
 IAGSFontRenderer* font_replace_renderer(size_t fontNumber, IAGSFontRenderer* renderer);
+IAGSFontRenderer2* font_replace_renderer(size_t fontNumber, IAGSFontRenderer2* renderer);
+void font_recalc_metrics(size_t fontNumber);
 bool font_first_renderer_loaded();
 bool is_font_loaded(size_t fontNumber);
 bool is_bitmap_font(size_t fontNumber);

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -125,9 +125,14 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
     return true;
 }
 
-const char *TTFFontRenderer::GetName(int fontNumber)
+const char *TTFFontRenderer::GetFontName(int fontNumber)
 {
   return alfont_get_name(_fontData[fontNumber].AlFont);
+}
+
+int TTFFontRenderer::GetFontHeight(int fontNumber)
+{
+  return alfont_get_font_real_height(_fontData[fontNumber].AlFont);
 }
 
 void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)

--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -81,9 +81,8 @@ static int GetAlfontFlags(int load_mode)
   return flags;
 }
 
-// Loads a TTF font of a certain size, optionally fill the FontMetrics struct
-static ALFONT_FONT *LoadTTF(const String &filename, int fontSize,
-    int alfont_flags, FontMetrics *metrics)
+// Loads a TTF font of a certain size
+static ALFONT_FONT *LoadTTF(const String &filename, int fontSize, int alfont_flags)
 {
     std::unique_ptr<Stream> reader(AssetMgr->OpenAsset(filename));
     if (!reader)
@@ -98,12 +97,15 @@ static ALFONT_FONT *LoadTTF(const String &filename, int fontSize,
     if (!alfptr)
         return nullptr;
     alfont_set_font_size_ex(alfptr, fontSize, alfont_flags);
-    if (metrics)
-    {
-        metrics->Height = alfont_get_font_height(alfptr);
-        metrics->RealHeight = alfont_get_font_real_height(alfptr);
-    }
     return alfptr;
+}
+
+// Fill the FontMetrics struct from the given ALFONT
+static void FillMetrics(ALFONT_FONT *alfptr, FontMetrics *metrics)
+{
+    metrics->Height = alfont_get_font_height(alfptr);
+    metrics->RealHeight = alfont_get_font_real_height(alfptr);
+    metrics->CompatHeight = metrics->Height; // just set to default here
 }
 
 bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
@@ -116,12 +118,14 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
         fontSize *= params->SizeMultiplier;
 
     ALFONT_FONT *alfptr = LoadTTF(filename, fontSize,
-        GetAlfontFlags(params->LoadMode), metrics);
+        GetAlfontFlags(params->LoadMode));
     if (!alfptr)
         return false;
 
     _fontData[fontNumber].AlFont = alfptr;
     _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+    if (metrics)
+        FillMetrics(alfptr, metrics);
     return true;
 }
 
@@ -133,6 +137,11 @@ const char *TTFFontRenderer::GetFontName(int fontNumber)
 int TTFFontRenderer::GetFontHeight(int fontNumber)
 {
   return alfont_get_font_real_height(_fontData[fontNumber].AlFont);
+}
+
+void TTFFontRenderer::GetFontMetrics(int fontNumber, FontMetrics *metrics)
+{
+    FillMetrics(_fontData[fontNumber].AlFont, metrics);
 }
 
 void TTFFontRenderer::AdjustFontForAntiAlias(int fontNumber, bool /*aa_mode*/)
@@ -154,18 +163,20 @@ void TTFFontRenderer::FreeMemory(int fontNumber)
 
 bool TTFFontRenderer::MeasureFontOfPointSize(const String &filename, int size_pt, FontMetrics *metrics)
 {
-    ALFONT_FONT *alfptr = LoadTTF(filename, size_pt, ALFONT_FLG_FORCE_RESIZE | ALFONT_FLG_SELECT_NOMINAL_SZ, metrics);
+    ALFONT_FONT *alfptr = LoadTTF(filename, size_pt, ALFONT_FLG_FORCE_RESIZE | ALFONT_FLG_SELECT_NOMINAL_SZ);
     if (!alfptr)
         return false;
+    FillMetrics(alfptr, metrics);
     alfont_destroy_font(alfptr);
     return true;
 }
 
 bool TTFFontRenderer::MeasureFontOfPixelHeight(const String &filename, int pixel_height, FontMetrics *metrics)
 {
-    ALFONT_FONT *alfptr = LoadTTF(filename, pixel_height, ALFONT_FLG_FORCE_RESIZE, metrics);
+    ALFONT_FONT *alfptr = LoadTTF(filename, pixel_height, ALFONT_FLG_FORCE_RESIZE);
     if (!alfptr)
         return false;
+    FillMetrics(alfptr, metrics);
     alfont_destroy_font(alfptr);
     return true;
 }

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -20,7 +20,7 @@
 
 struct ALFONT_FONT;
 
-class TTFFontRenderer : public IAGSFontRenderer, public IAGSFontRenderer2 {
+class TTFFontRenderer : public IAGSFontRenderer, public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -32,7 +32,7 @@ public:
   void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
   void EnsureTextValidForFont(char *text, int fontNumber) override;
 
-  // IAGSFontRenderer2 implementation
+  // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -20,7 +20,7 @@
 
 struct ALFONT_FONT;
 
-class TTFFontRenderer : public IAGSFontRenderer2, public IAGSFontRendererInternal {
+class TTFFontRenderer : public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -43,6 +43,7 @@ public:
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;
+  void GetFontMetrics(int fontNumber, FontMetrics *metrics) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
 
   //

--- a/Common/font/ttffontrenderer.h
+++ b/Common/font/ttffontrenderer.h
@@ -20,7 +20,7 @@
 
 struct ALFONT_FONT;
 
-class TTFFontRenderer : public IAGSFontRenderer, public IAGSFontRendererInternal {
+class TTFFontRenderer : public IAGSFontRenderer2, public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -32,11 +32,17 @@ public:
   void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
   void EnsureTextValidForFont(char *text, int fontNumber) override;
 
+  // IAGSFontRenderer2 implementation
+  int GetVersion() override { return 26; /* first compatible engine API version */ }
+  const char *GetRendererName() override { return "TTFFontRenderer"; }
+  const char *GetFontName(int fontNumber) override;
+  int GetFontHeight(int fontNumber) override;
+  int GetLineSpacing(int fontNumber) override { return 0; /* no specific spacing */ }
+
   // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;
-  const char *GetName(int fontNumber) override;
   void AdjustFontForAntiAlias(int fontNumber, bool aa_mode) override;
 
   //

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -139,7 +139,7 @@ bool WFNFontRenderer::IsBitmapFont()
 }
 
 bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
-    const FontRenderParams *params, FontMetrics * /*metrics*/)
+    const FontRenderParams *params, FontMetrics *metrics)
 {
   String file_name;
   Stream *ffi = nullptr;
@@ -167,6 +167,8 @@ bool WFNFontRenderer::LoadFromDiskEx(int fontNumber, int /*fontSize*/,
   }
   _fontData[fontNumber].Font = font;
   _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+  if (metrics)
+    *metrics = FontMetrics();
   return true;
 }
 

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -20,7 +20,7 @@
 
 class WFNFont;
 
-class WFNFontRenderer : public IAGSFontRenderer2, public IAGSFontRendererInternal {
+class WFNFontRenderer : public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -43,6 +43,7 @@ public:
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;
+  void GetFontMetrics(int fontNumber, FontMetrics *metrics) override { *metrics = FontMetrics(); }
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
 
 private:

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -20,7 +20,7 @@
 
 class WFNFont;
 
-class WFNFontRenderer : public IAGSFontRenderer, public IAGSFontRendererInternal {
+class WFNFontRenderer : public IAGSFontRenderer2, public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -32,11 +32,17 @@ public:
   void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
   void EnsureTextValidForFont(char *text, int fontNumber) override;
 
+  // IAGSFontRenderer2 implementation
+  int GetVersion() override { return 26; /* first compatible engine API version */ }
+  const char *GetRendererName() override { return "WFNFontRenderer"; }
+  const char *GetFontName(int /*fontNumber*/) override { return ""; }
+  int GetFontHeight(int fontNumber) override { return 0; /* TODO? */ }
+  int GetLineSpacing(int fontNumber) override { return 0; /* no specific spacing */ }
+
   // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;
-  const char *GetName(int /*fontNumber*/) override { return ""; }
   void AdjustFontForAntiAlias(int /*fontNumber*/, bool /*aa_mode*/) override { /* do nothing */}
 
 private:

--- a/Common/font/wfnfontrenderer.h
+++ b/Common/font/wfnfontrenderer.h
@@ -20,7 +20,7 @@
 
 class WFNFont;
 
-class WFNFontRenderer : public IAGSFontRenderer, public IAGSFontRenderer2 {
+class WFNFontRenderer : public IAGSFontRenderer, public IAGSFontRendererInternal {
 public:
   // IAGSFontRenderer implementation
   bool LoadFromDisk(int fontNumber, int fontSize) override;
@@ -32,7 +32,7 @@ public:
   void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override;
   void EnsureTextValidForFont(char *text, int fontNumber) override;
 
-  // IAGSFontRenderer2 implementation
+  // IAGSFontRendererInternal implementation
   bool IsBitmapFont() override;
   bool LoadFromDiskEx(int fontNumber, int fontSize, const FontRenderParams *params,
       FontMetrics *metrics) override;

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -814,6 +814,19 @@ IAGSFontRenderer* IAGSEngine::ReplaceFontRenderer(int fontNumber, IAGSFontRender
     return old_render;
 }
 
+IAGSFontRenderer2* IAGSEngine::ReplaceFontRenderer2(int fontNumber, IAGSFontRenderer2 *newRenderer)
+{
+    auto *old_render = font_replace_renderer(fontNumber, newRenderer);
+    GUI::MarkForFontUpdate(fontNumber);
+    return old_render;
+}
+
+void IAGSEngine::NotifyFontUpdated(int fontNumber)
+{
+    font_recalc_metrics(fontNumber);
+    GUI::MarkForFontUpdate(fontNumber);
+}
+
 void IAGSEngine::GetRenderStageDesc(AGSRenderStageDesc* desc)
 {
     if (desc->Version >= 25)

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -299,10 +299,20 @@ public:
   virtual void AdjustYCoordinateForFont(int *ycoord, int fontNumber) = 0;
   virtual void EnsureTextValidForFont(char *text, int fontNumber) = 0;
 protected:
-  IAGSFontRenderer() {};
-  ~IAGSFontRenderer() {};
+  IAGSFontRenderer() = default;
+  ~IAGSFontRenderer() = default;
 };
 
+class IAGSFontRenderer2 : IAGSFontRenderer {
+  virtual int GetVersion() = 0;
+  virtual const char *GetRendererName() = 0;
+  virtual const char *GetFontName(int fontNumber) = 0;
+  virtual int GetFontHeight(int fontNumber) = 0;
+  virtual int GetLineSpacing(int fontNumber) = 0;
+protected:
+  IAGSFontRenderer2() = default;
+  ~IAGSFontRenderer2() = default;
+};
 
 struct AGSRenderMatrixes {
   float WorldMatrix[16];
@@ -580,6 +590,10 @@ public:
   // fills the provided AGSGameInfo struct
   // please note that plugin MUST fill the struct's Version field before passing it into the function!
   AGSIFUNC(void)  GetGameInfo(AGSGameInfo* ginfo);
+  // install a replacement renderer (extended interface) for the specified font number
+  AGSIFUNC(IAGSFontRenderer2*) ReplaceFontRenderer2(int fontNumber, IAGSFontRenderer2* newRenderer);
+  // notify the engine that certain custom font has been updated
+  AGSIFUNC(void)  NotifyFontUpdated(int fontNumber);
 };
 
 #ifdef THIS_IS_THE_PLUGIN

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -99,15 +99,14 @@ void SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth
 {
 	engine->PrintDebugConsole("AGSSpriteFont: SetSpriteFont");
 	fontRenderer->SetSpriteFont(fontNum, sprite, rows, columns, charWidth, charHeight, charMin, charMax, use32bit);
-	engine->ReplaceFontRenderer(fontNum, fontRenderer);
-
+	engine->ReplaceFontRenderer2(fontNum, fontRenderer);
 }
 
 void SetVariableSpriteFont(int fontNum, int sprite)
 {
 	engine->PrintDebugConsole("AGSSpriteFont: SetVariableFont");
 	vWidthRenderer->SetSprite(fontNum, sprite);
-	engine->ReplaceFontRenderer(fontNum, vWidthRenderer);
+	engine->ReplaceFontRenderer2(fontNum, vWidthRenderer);
 }
 
 void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height)

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.cpp
@@ -41,6 +41,8 @@ void SpriteFontRenderer::SetSpriteFont(int fontNum, int sprite, int rows, int co
 	font->CharHeight = charHeight;
 	font->CharWidth = charWidth;
 
+	if (_engine->version >= 26)
+		_engine->NotifyFontUpdated(fontNum);
 }
 
 void SpriteFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
@@ -72,6 +74,12 @@ int SpriteFontRenderer::GetTextWidth(const char *text, int fontNumber)
 }
 
 int SpriteFontRenderer::GetTextHeight(const char *text, int fontNumber)
+{
+	SpriteFont *font = getFontFor(fontNumber);
+	return font->CharHeight;
+}
+
+int SpriteFontRenderer::GetFontHeight(int fontNumber)
 {
 	SpriteFont *font = getFontFor(fontNumber);
 	return font->CharHeight;

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/SpriteFontRenderer.h
@@ -3,11 +3,15 @@
 #include "SpriteFont.h"
 #include <vector>
 class SpriteFontRenderer :
-	public IAGSFontRenderer
+	public IAGSFontRenderer2
 {
 public:
 	SpriteFontRenderer(IAGSEngine *engine);
 	virtual ~SpriteFontRenderer();
+
+	void SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth, int charHeight, int charMin, int charMax, bool use32bit);
+
+	// IAGSFontRenderer implementation
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
 	void FreeMemory(int fontNumber) override;
 	bool SupportsExtendedCharacters(int fontNumber) override;
@@ -16,9 +20,13 @@ public:
 	void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
 	void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override { }
 	void EnsureTextValidForFont(char *text, int fontNumber) override;
-	void SetSpriteFont(int fontNum, int sprite, int rows, int columns, int charWidth, int charHeight, int charMin, int charMax, bool use32bit);
-	
-	
+	// IAGSFontRenderer2 implementation
+	int GetVersion() override { return 26; /* compatible engine API ver */ }
+	const char *GetRendererName() override { return "SpriteFontRenderer"; }
+	const char *GetFontName(int fontNumber) override { return ""; /* not supported */ }
+	int GetFontHeight(int fontNumber);
+	int GetLineSpacing(int fontNumber) { return 0; /* not specified */ }
+
 protected:
 	SpriteFont *getFontFor(int fontNum);
 	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.cpp
@@ -59,12 +59,26 @@ int VariableWidthSpriteFontRenderer::GetTextHeight(const char *text, int fontNum
 	return 0;
 }
 
+int VariableWidthSpriteFontRenderer::GetFontHeight(int fontNumber)
+{
+	VariableWidthFont *font = getFontFor(fontNumber);
+	if (font->characters.size() > 0)
+	{
+		return font->characters.begin()->second.Height + font->LineHeightAdjust;
+	}
+	return 0;
+}
+
+int VariableWidthSpriteFontRenderer::GetLineSpacing(int fontNumber)
+{
+	VariableWidthFont *font = getFontFor(fontNumber);
+	return font->LineSpacingOverride;
+}
+
 void VariableWidthSpriteFontRenderer::SetSpacing(int fontNum, int spacing)
 {
 	VariableWidthFont *font = getFontFor(fontNum);
 	font->Spacing = spacing;
-
-
 }
 
 void VariableWidthSpriteFontRenderer::SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride)
@@ -73,6 +87,9 @@ void VariableWidthSpriteFontRenderer::SetLineHeightAdjust(int fontNum, int lineH
 	font->LineHeightAdjust = lineHeight;
 	font->LineSpacingAdjust = spacingHeight;
 	font->LineSpacingOverride = spacingOverride;
+
+	if (_engine->version >= 26)
+		_engine->NotifyFontUpdated(fontNum);
 }
 
 void VariableWidthSpriteFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
@@ -95,8 +112,13 @@ void VariableWidthSpriteFontRenderer::SetGlyph(int fontNum, int charNum, int x, 
 {
 	VariableWidthFont *font = getFontFor(fontNum);
 	font->SetGlyph(charNum, x, y, width, height);
-}
 
+	// Only notify engine at the first engine glyph,
+	// that should be enough for calculating font height metrics,
+	// and will reduce work load (sadly there's no Begin/EndUpdate functions).
+	if ((_engine->version >= 26) && (font->characters.size() == 1))
+		_engine->NotifyFontUpdated(fontNum);
+}
 
 void VariableWidthSpriteFontRenderer::SetSprite(int fontNum, int spriteNum)
 {

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFont.h
@@ -2,12 +2,20 @@
 #include "plugin/agsplugin.h"
 #include "VariableWidthFont.h"
 #include <vector>
+
 class VariableWidthSpriteFontRenderer :
-	public IAGSFontRenderer
+	public IAGSFontRenderer2
 {
 public:
 	VariableWidthSpriteFontRenderer(IAGSEngine *engine);
 	virtual ~VariableWidthSpriteFontRenderer(void);
+
+	void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);
+	void SetSprite(int fontNum, int spriteNum);
+	void SetSpacing(int fontNum, int spacing);
+	void SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride);
+
+	// IAGSFontRenderer implementation
 	bool LoadFromDisk(int fontNumber, int fontSize) override { return true; }
 	void FreeMemory(int fontNumber) override;
 	bool SupportsExtendedCharacters(int fontNumber) override;
@@ -16,10 +24,12 @@ public:
 	void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
 	void AdjustYCoordinateForFont(int *ycoord, int fontNumber) override { }
 	void EnsureTextValidForFont(char *text, int fontNumber) override;
-	void SetGlyph(int fontNum, int charNum, int x, int y, int width, int height);
-	void SetSprite(int fontNum, int spriteNum);
-	void SetSpacing(int fontNum, int spacing);
-	void SetLineHeightAdjust(int fontNum, int lineHeight, int spacingHeight, int spacingOverride);
+	// IAGSFontRenderer2 implementation
+	int GetVersion() override { return 26; /* compatible engine API ver */ }
+	const char *GetRendererName() override { return "VariableWidthSpriteFontRenderer"; }
+	const char *GetFontName(int fontNumber) override { return ""; /* not supported */ }
+	int GetFontHeight(int fontNumber);
+	int GetLineSpacing(int fontNumber);
 
 protected:
 	IAGSEngine *_engine;
@@ -27,4 +37,3 @@ protected:
 	VariableWidthFont *getFontFor(int fontNum);
 	void Draw(BITMAP *src, BITMAP *dest, int destx, int desty, int srcx, int srcy, int width, int height);
 };
-

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.cpp
@@ -12,30 +12,6 @@ VariableWidthSpriteFontRendererClifftopGames::VariableWidthSpriteFontRendererCli
 
 VariableWidthSpriteFontRendererClifftopGames::~VariableWidthSpriteFontRendererClifftopGames(void) = default;
 
-
-int VariableWidthSpriteFontRendererClifftopGames::GetTextHeight(const char *text, int fontNumber)
-{
-	VariableWidthFont *font = getFontFor(fontNumber);
-	if(strcmp("<LINE_SPACING>", text) == 0)
-		return font->LineSpacingOverride;
-
-	for(int i = 0; i < (int)strlen(text); i++)
-	{
-		if (font->characters.count(text[i]) > 0)
-		{
-			int height = font->characters[text[i]].Height;
-
-			if(strcmp("ZHwypgfjqhkilIK", text) == 0 || strcmp("ZhypjIHQFb", text) == 0 || strcmp("YpyjIHgMNWQ", text) == 0 || strcmp("BigyjTEXT", text) == 0)
-				height += font->LineSpacingAdjust;
-			else
-				height += font->LineHeightAdjust;
-
-			return height;
-		}
-	}
-	return 0;
-}
-
 void VariableWidthSpriteFontRendererClifftopGames::RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour)
 {
 	VariableWidthFont *font = getFontFor(fontNumber);

--- a/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.h
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/VariableWidthSpriteFontClifftopGames.h
@@ -7,7 +7,6 @@ public:
 	VariableWidthSpriteFontRendererClifftopGames(IAGSEngine *engine);
 	~VariableWidthSpriteFontRendererClifftopGames(void) override;
 
-	int GetTextHeight(const char *text, int fontNumber) override;
 	void RenderText(const char *text, int fontNumber, BITMAP *destination, int x, int y, int colour) override;
 
 private:


### PR DESCRIPTION
Fixes #1742

CC: @criezy 

This is an experimental change and related to plugin API, so opening as a draft for now. But it actually fixes all the "Whispers of the machine" font issues.

**The reasoning for changes:**

The old `IAGSFontRenderer` interface unfortunately did not provide proper means to return neither font height nor custom linespacing. Instead it had GetTextHeight(text), which in my honest opinion was a mistake to add, as fonts normally should have a specific height property even if individual characters (glyphs) have varied height.<br>
But anyway, the "Clifftop Games" abused GetTextHeight to also return linespacing depending on which text is passed as an argument, using "secret knowledge" about which lines engine uses for a font height test. This mechanic was doomed to be unreliable and eventually got broken after certain changes in the engine (see #1742 for details).

The proposed solution is to implement an extended FontRenderer interface, that lets to explicitly query for necessary font properties. In addition, engine plugin API needs a function for notifiying if the custom font have changed - because the SpriteFont allows to modify fonts from script in any given moment.

**Proposed changes**

Added `IAGSFontRenderer2` interface that inherits `IAGSFontRenderer` and adds following new members:
Member function | Description
-- | --
int GetVersion () | Returns engine API version this font renderer complies to. Must not be lower than 26 (this interface was added at API v26). If the interface is going to be expanded further in the future, the engine will be able to use this to find out whether it's safe to use newer methods.
const char* GetRendererName () | Returns an arbitrary renderer name; this is for informational purposes only (logging, etc)
const char* GetFontName (int fontNumber) | Returns given font's name (if available); again for informational purposes
int GetFontHeight (int fontNumber) | Returns the given font's height: that is the maximal vertical size that the font glyphs may occupy.
int GetLineSpacing (int fontNumber) | Returns the given font's linespacing; is allowed to return 0, telling that no specific linespacing is assigned for this font.

Added new function to the engine API called `ReplaceFontRenderer2(int fontNumber, IAGSFontRenderer2* newRenderer)`, for setting new font renderer type. The reason why it needs a separate function is mainly that the old interface IAGSFontRenderer does not have any means to find out its version, therefore engine won't be able to find out if it's an extended interface or not. But since IAGSFontRenderer2 includes GetVersion function, it will be possible from now on.

Added new function to the engine API called `NotifyFontUpdated(int fontNumber)`. This may be used by plugins to tell that the custom font has changed, so that engine could react to this (if it has cached font properties or has to redraw stuff, or else).

In **SpriteFont** plugin: all font renderers implement IAGSFontRenderer2. Fixed VariableWidthSpriteFontRendererClifftopGames class to not return text height based on secret argument handling, but instead provide font height and linespacing in corresponding new functions.