### PR TITLE
Editor: Implement "Go to Definition" for Define and Enum

### DIFF
--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -209,7 +209,7 @@ namespace AGS.Editor
                 {
                     if (state.WordBeforeLast == "enum")
                     {
-                        state.InsideEnumDefinition = new ScriptEnum(state.LastWord, state.InsideIfDefBlock, state.InsideIfNDefBlock);
+                        state.InsideEnumDefinition = new ScriptEnum(state.LastWord, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex);
                     }
                     else if (state.WordBeforeLast == "extends")
                     {
@@ -412,7 +412,7 @@ namespace AGS.Editor
                 if (!string.IsNullOrEmpty(macroName) && (Char.IsLetter(macroName[0])) &&
                     (!DoesCurrentLineHaveToken(script, AUTO_COMPLETE_IGNORE)))
                 {
-                    defines.Add(new ScriptDefine(macroName, state.InsideIfDefBlock, state.InsideIfNDefBlock));
+                    defines.Add(new ScriptDefine(macroName, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex));
                 }
             }
             else if (preProcessorDirective == "undef")

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -285,7 +285,7 @@ namespace AGS.Editor
 				{
 					if (state.InsideEnumDefinition != null)
 					{
-						AddEnumValue(state.InsideEnumDefinition, script, state.LastWord);
+						AddEnumValue(state.InsideEnumDefinition, script, state.LastWord, state);
 
                         if (thisWord == "=")
                         {
@@ -329,7 +329,7 @@ namespace AGS.Editor
                     // add the last value (unless it's an empty enum)
                     if (state.LastWord != "{")
                     {
-                        AddEnumValue(state.InsideEnumDefinition, script, state.LastWord);
+                        AddEnumValue(state.InsideEnumDefinition, script, state.LastWord, state);
                     }
 					enums.Add(state.InsideEnumDefinition);
 					state.InsideEnumDefinition = null;
@@ -455,13 +455,13 @@ namespace AGS.Editor
             state.ClearPreviousWords();
         }
 
-        private static void AddEnumValue(ScriptEnum insideEnumDefinition, FastString script, string lastWord)
+        private static void AddEnumValue(ScriptEnum insideEnumDefinition, FastString script, string lastWord, AutoCompleteParserState state)
         {
             if ((lastWord.Length > 0) && (Char.IsLetter(lastWord[0])))
             {
                 if (!DoesCurrentLineHaveToken(script, AUTO_COMPLETE_IGNORE))
                 {
-                    insideEnumDefinition.EnumValues.Add(lastWord);
+                    insideEnumDefinition.EnumValues.Add(new ScriptEnumValue(lastWord, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex));
                 }
             }
         }

--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -2017,9 +2017,9 @@ namespace AGS.Editor
 
         private void AddEnumValuesToAutocompleteList(List<string> list, ScriptEnum se)
         {
-            foreach (string enumValue in se.EnumValues)
+            foreach (ScriptEnumValue enumValue in se.EnumValues)
             {
-                list.Add(enumValue + "?" + IMAGE_INDEX_ENUM);
+                list.Add(enumValue.Name + "?" + IMAGE_INDEX_ENUM);
             }
         }
 

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -911,6 +911,18 @@ namespace AGS.Editor
                 {
                     found = script.AutoCompleteData.FindStruct(memberName);
                 }
+                if (found == null)
+                {
+                    found = script.AutoCompleteData.FindEnum(memberName);
+                }
+                if (found == null)
+                {
+                    found = script.AutoCompleteData.FindEnumValue(memberName);
+                }
+                if (found == null)
+                {
+                    found = script.AutoCompleteData.FindDefine(memberName);
+                }
             }
 
             return found;

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="EditorFeatures\AutoComplete\ScriptDefine.cs" />
     <Compile Include="EditorFeatures\AutoComplete\ScriptEnum.cs" />
+    <Compile Include="EditorFeatures\AutoComplete\ScriptEnumValue.cs" />
     <Compile Include="EditorFeatures\AutoComplete\ScriptFunction.cs" />
     <Compile Include="EditorFeatures\AutoComplete\ScriptStruct.cs" />
     <Compile Include="EditorFeatures\AutoComplete\ScriptToken.cs" />

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptAutoCompleteData.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptAutoCompleteData.cs
@@ -60,6 +60,44 @@ namespace AGS.Types
 			return null;
 		}
 
+        public ScriptDefine FindDefine(string name)
+        {
+            foreach (ScriptDefine define in _defines)
+            {
+                if (define.Name == name)
+                {
+                    return define;
+                }
+            }
+            return null;
+        }
+
+        public ScriptEnum FindEnum(string name)
+        {
+            foreach (ScriptEnum enm in _enums)
+            {
+                if (enm.Name == name)
+                {
+                    return enm;
+                }
+            }
+            return null;
+        }
+
+        public ScriptEnum FindEnumValue(string name)
+        {
+            foreach (ScriptEnum enm in _enums)
+            {
+                foreach (string valueName in enm.EnumValues) {
+                    if(valueName == name)
+                    {
+                        return enm;
+                    }
+                }
+            }
+            return null;
+        }
+
 		public List<ScriptVariable> Variables
         {
             get { return _variables; }

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptAutoCompleteData.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptAutoCompleteData.cs
@@ -84,14 +84,14 @@ namespace AGS.Types
             return null;
         }
 
-        public ScriptEnum FindEnumValue(string name)
+        public ScriptEnumValue FindEnumValue(string name)
         {
             foreach (ScriptEnum enm in _enums)
             {
-                foreach (string valueName in enm.EnumValues) {
-                    if(valueName == name)
+                foreach (ScriptEnumValue enumValue in enm.EnumValues) {
+                    if(enumValue.Name == name)
                     {
-                        return enm;
+                        return enumValue;
                     }
                 }
             }

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptDefine.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptDefine.cs
@@ -6,11 +6,12 @@ namespace AGS.Types.AutoComplete
 {
     public class ScriptDefine : ScriptToken
     {
-        public ScriptDefine(string name, string ifDefOnly, string ifNDefOnly)
+        public ScriptDefine(string name, string ifDefOnly, string ifNDefOnly, int scriptCharacterIndex)
         {
             Name = name;
             IfDefOnly = ifDefOnly;
             IfNDefOnly = ifNDefOnly;
+            StartsAtCharacterIndex = scriptCharacterIndex;
         }
 
         public string Name;

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnum.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnum.cs
@@ -6,12 +6,13 @@ namespace AGS.Types.AutoComplete
 {
     public class ScriptEnum : ScriptToken
     {
-        public ScriptEnum(string name, string ifDefOnly, string ifNDefOnly)
+        public ScriptEnum(string name, string ifDefOnly, string ifNDefOnly, int scriptCharacterIndex)
         {
             Name = name;
             IfDefOnly = ifDefOnly;
             IfNDefOnly = ifNDefOnly;
             EnumValues = new List<string>();
+            StartsAtCharacterIndex = scriptCharacterIndex;
         }
 
         public string Name;

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnum.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnum.cs
@@ -11,11 +11,11 @@ namespace AGS.Types.AutoComplete
             Name = name;
             IfDefOnly = ifDefOnly;
             IfNDefOnly = ifNDefOnly;
-            EnumValues = new List<string>();
+            EnumValues = new List<ScriptEnumValue>();
             StartsAtCharacterIndex = scriptCharacterIndex;
         }
 
         public string Name;
-        public List<string> EnumValues;
+        public List<ScriptEnumValue> EnumValues;
     }
 }

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnumValue.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnumValue.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AGS.Types.AutoComplete
+{
+    public class ScriptEnumValue : ScriptToken
+    {
+        public ScriptEnumValue(string name, string ifDefOnly, string ifNDefOnly, int scriptCharacterIndex)
+        {
+            Name = name;
+            IfDefOnly = ifDefOnly;
+            IfNDefOnly = ifNDefOnly;
+            StartsAtCharacterIndex = scriptCharacterIndex;
+        }
+
+        public string Name;
+    }
+}


### PR DESCRIPTION
Enabled the "Go to DEFINITION" contextual menu option to work with `#define`s, enum types, and enum values.

Possible improvements:
- ~track enum values to the exact line~ DONE
- throw message for builtin enums, like when trying to go to views/audios script names (unless we plan to show builtin headers in the future)