### PR TITLE
Editor is resaving unmodified scripts

### DIFF
--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -308,7 +308,13 @@ namespace AGS.Editor.Components
             _lastActivated = scriptEditor;
             ContentDocument document = _editors[chosenItem];
             document.TreeNodeID = GetNodeID(chosenItem);
+            // Note: a chain of calls from AddOrShowPane() ends up calling UpdateScriptObjectWithLatestTextInWindow()
+            // which reassigns the Text property with the side-effect of setting the script as Modified = true
+            // which in turn can trigger "externally changed" notices during compilation due to resaving unmodified scripts.
+            // We'll workaround that issue by restoring the previous Modified state
+            bool wasScriptModified = chosenItem.Modified;
             _guiController.AddOrShowPane(document);
+            chosenItem.Modified = wasScriptModified; 
             if (activateEditor)
             {
             // Hideous hack -- we need to allow the current message to


### PR DESCRIPTION
I was investigating the issue of bogus externally modified scripts in ags4 branch, and I have found that when opening a script, the script Modified status is not applied correctly.

https://github.com/adventuregamestudio/ags/blob/087b9cd99f89f9cd43c54aa5dd753b7c0fcc5afe/Editor/AGS.Editor/Panes/ScriptEditor.cs#L473-L477

`Text` assignment has a side effect of marking the script `Modified` property as true.

On master branch this doesn't do much beside resaving the file for no reason, but on ags4, where open scripts are being watched for changes, it will complain about externally modified files during compilation.
This is because in this case the script is being saved by AGSEditor.cs, who doesn't even have acces to the filewatcher instances from ScriptEditor.cs, nor should it need to since opened scripts are supposed to be saved before getting there.

Not sure if applying this fix straight to ags4 or upstream to master.