### PR TITLE
3.6.0: Initialize SDL audio using env variables, don't SDL_AudioInit

### DIFF
--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -99,22 +99,34 @@ void sys_renderer_set_output(const String &name)
 
 bool sys_audio_init(const String &driver_name)
 {
+    // IMPORTANT: we must use a combination of SDL_setenv and SDL_InitSubSystem
+    // here, and NOT use SDL_AudioInit, because SDL_AudioInit does not increment
+    // subsystem's reference count. Which in turn may cause problems down the
+    // way when initializing any additional SDL-based audio lib or plugin;
+    // at the very least - the mojoAl (OpenAL's implementation we're using).
     bool res = false;
+    // If user config contained a driver request, then apply one for a try
     if (!driver_name.IsEmpty())
+        SDL_setenv("SDL_AUDIODRIVER", driver_name.GetCStr(), 1);
+    const char *env_drv = SDL_getenv("SDL_AUDIODRIVER");
+    Debug::Printf("Requested audio driver: %s", env_drv ? env_drv : "default");
+    res = SDL_InitSubSystem(SDL_INIT_AUDIO) == 0;
+    // If there have been an explicit request that failed, then try to force
+    // SDL to go through a list of supported drivers and see if that succeeds.
+    if (!res && env_drv)
     {
-        res = SDL_AudioInit(driver_name.GetCStr()) == 0;
-        if (!res)
-            Debug::Printf(kDbgMsg_Error, "Failed to initialize audio driver %s; error: %s",
-                driver_name.GetCStr(), SDL_GetError());
-    }
-    if (!res)
-    {
+        Debug::Printf(kDbgMsg_Error, "Failed to initialize requested audio driver '%s'; error: %s",
+            env_drv, SDL_GetError());
+        Debug::Printf("Attempt to initialize any audio driver from the known list");
+        SDL_setenv("SDL_AUDIODRIVER", "", 1);
         res = SDL_InitSubSystem(SDL_INIT_AUDIO) == 0;
-        if (!res)
-            Debug::Printf(kDbgMsg_Error, "Failed to initialize audio backend: %s", SDL_GetError());
     }
+
     if (res)
         Debug::Printf(kDbgMsg_Info, "Audio driver: %s", SDL_GetCurrentAudioDriver());
+    else
+        Debug::Printf(kDbgMsg_Error, "Failed to initialize any audio driver; error: %s",
+            SDL_GetError());
     return res;
 }
 


### PR DESCRIPTION
Fixes #1692.

CC: @ericoporto 

Following the discussion in #1692, we must use a combination of SDL_setenv(SDL_AUDIODRIVER) and SDL_InitSubSystem here, and *not* use SDL_AudioInit, because SDL_AudioInit does not increment subsystem's reference count. Which in turn may cause problems down the way when initializing any additional SDL-based audio lib or plugin; at the very least - the mojoAl (OpenAL's implementation we're using).

If we specifically requested a driver name, and that failed, we fallback to automatic drivers list by resetting environment variable SDL_AUDIODRIVER and calling SDL_InitSubSystem(SDL_INIT_AUDIO) again. That forces SDL to try every available driver in an order.

**IMPORTANT:** For the second step, the point is to make SDL_getenv to return NULL, so that SDL_AudioInit would iterate the default drivers list. It has to be NULL, not a empty string (at least according to the SDL2 source code).
Now, I found it's impossible to pass NULL to SDL_setenv, SDL refuses to apply that, therefore I pass empty string when trying to reset its value. This nevertheless worked on Windows, but I'm unsure if this is not a system-specific behavior. Must test if this works on Linux too. If not, then there's still a workaround: use SDL_GetNumAudioDrivers / SDL_GetAudioDriver(index) to iterate through the default driver list and try each one manually.
