### PR TITLE
Plugins: built-in plugins don't need DLL entrypoint

### DIFF
--- a/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
+++ b/Plugins/AGSSpriteFont/AGSSpriteFont/AGSSpriteFont.cpp
@@ -23,7 +23,9 @@
 #endif
 #include <string.h>
 
+#if !defined(BUILTIN_PLUGINS)
 #define THIS_IS_THE_PLUGIN
+#endif
 #include "plugin/agsplugin.h"
 #include "SpriteFontRenderer.h"
 #include "VariableWidthSpriteFont.h"
@@ -69,7 +71,7 @@
 #pragma endregion
 
 
-#if AGS_PLATFORM_OS_WINDOWS
+#if AGS_PLATFORM_OS_WINDOWS && !defined(BUILTIN_PLUGINS)
 // The standard Windows DLL entry point
 
 BOOL APIENTRY DllMain( HANDLE hModule, 

--- a/Plugins/agsblend/AGSBlend.cpp
+++ b/Plugins/agsblend/AGSBlend.cpp
@@ -79,7 +79,7 @@ typedef unsigned char uint8;
 
 #pragma endregion
 
-#if AGS_PLATFORM_OS_WINDOWS
+#if AGS_PLATFORM_OS_WINDOWS && !defined(BUILTIN_PLUGINS)
 // The standard Windows DLL entry point
 
 BOOL APIENTRY DllMain( HANDLE hModule, 

--- a/Plugins/agspalrender/ags_palrender.cpp
+++ b/Plugins/agspalrender/ags_palrender.cpp
@@ -44,7 +44,7 @@
 // The AGS editor will cause this to get called when the editor first
 // starts up, and when it shuts down at the end.
 
-#if AGS_PLATFORM_OS_WINDOWS
+#if AGS_PLATFORM_OS_WINDOWS && !defined(BUILTIN_PLUGINS)
 bool APIENTRY DllMain( HANDLE hModule, 
                        DWORD  ul_reason_for_call, 
                        LPVOID lpReserved) {


### PR DESCRIPTION
When I tried to build with built-in plugins on Windows, I was getting compilation errors, I was able to build fine after the following changes.