### PR TITLE
EXPERIMENT: touch to mouse simulation in the engine

### DIFF
--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -28,6 +28,7 @@ GameSetup::GameSetup()
     mouse_ctrl_when = kMouseCtrl_Fullscreen;
     mouse_ctrl_enabled = false;
     mouse_speed_def = kMouseSpeed_CurrentDisplay;
+    touch_emulate_mouse = kTouchMouse_OneFingerDrag;
     RenderAtScreenRes = false;
     Supersampling = 1;
     clear_cache_on_room_change = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -48,10 +48,11 @@ enum TouchMouseEmulation
 {
     // don't emulate mouse
     kTouchMouse_None = 0,
+    // copy default SDL2 behavior:
     // touch down means hold LMB down, no RMB emulation
     kTouchMouse_OneFingerDrag,
     // tap 1,2 fingers means LMB/RMB click;
-    // longpress means stick LMB/RMB down until next tap
+    // double tap + drag 1 finger would drag the cursor with LMB down
     kTouchMouse_TwoFingersTap
 };
 

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -44,6 +44,17 @@ enum ScreenRotation
     kNumScreenRotationOptions
 };
 
+enum TouchMouseEmulation
+{
+    // don't emulate mouse
+    kTouchMouse_None = 0,
+    // touch down means hold LMB down, no RMB emulation
+    kTouchMouse_OneFingerDrag,
+    // tap 1,2 fingers means LMB/RMB click;
+    // longpress means stick LMB/RMB down until next tap
+    kTouchMouse_TwoFingersTap
+};
+
 using AGS::Common::String;
 
 // TODO: reconsider the purpose of this struct in the future.
@@ -79,6 +90,9 @@ struct GameSetup
     MouseControlWhen mouse_ctrl_when;
     bool  mouse_ctrl_enabled;
     MouseSpeedDef mouse_speed_def;
+    // touch-to-mouse emulation mode
+    int   touch_emulate_mouse;
+    //
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
     size_t SpriteCacheSize = 0u;

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -372,6 +372,9 @@ void apply_config(const ConfigTree &cfg)
         usetup.mouse_speed_def = StrUtil::ParseEnum<MouseSpeedDef>(
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
+        // Touch options
+        usetup.touch_emulate_mouse = CfgReadInt(cfg, "touch", "emulate_mouse", 1);
+
         // Various system options
         usetup.multitasking = CfgReadInt(cfg, "misc", "background", 0) != 0;
 

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -30,6 +30,10 @@ int sys_main_init(/*config*/) {
     SDL_version version;
     SDL_GetVersion(&version);
     Debug::Printf(kDbgMsg_Info, "SDL Version: %d.%d.%d", version.major, version.minor, version.patch);
+    // Disable SDL2's own touch-to-mouse emulation:
+    // we are going to use our own in the engine, and only if requested by the user config
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
     // TODO: setup these subsystems in config rather than keep hardcoded?
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) != 0) {
         Debug::Printf(kDbgMsg_Error, "Unable to initialize SDL: %s", SDL_GetError());


### PR DESCRIPTION
WARNING: an experiment, not to be merged.

Naive reimplementation of the SDL2 internal touch to mouse controls made inside the engine.

Disable SDL_HINT_TOUCH_MOUSE_EVENTS to prevent SDL2 use its own touch-to-mouse simulation.
Enable SDL_HINT_MOUSE_TOUCH_EVENTS to let test this on desktop PC, but this works only with left clicks.