### PR TITLE
Feature joystick

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -64,6 +64,10 @@
 
 #define SCR_NO_VALUE   31998   // $AUTOCOMPLETEIGNORE$
 
+#ifdef SCRIPT_API_v399
+  #define AXIS_DEFAULT_DEADZONE 0.125
+#endif
+
 enum bool {
   false = 0,
   true = 1
@@ -435,7 +439,61 @@ enum InputType
   // 0x0100... is used internally to define Timeout (may be worked around in the future)
   eInputKeyboard = 0x02000000,
   eInputMouse    = 0x04000000,
+#endif
+#ifdef SCRIPT_API_v399
+  eInputGamepad  = 0x08000000,
+#endif
+#ifdef SCRIPT_API_v36026
   eInputAny      = 0xFF000000
+};
+#endif
+
+#ifdef SCRIPT_API_v399
+enum eGamepad_Axis
+{
+    eGamepad_AxisInvalid=0,
+    eGamepad_AxisLeftX,
+    eGamepad_AxisLeftY,
+    eGamepad_AxisRightX,
+    eGamepad_AxisRightY,
+    eGamepad_AxisTriggerLeft,
+    eGamepad_AxisTriggerRight,
+    eGamepad_AxisCount
+};
+
+enum eGamepad_Button
+{
+    eGamepad_ButtonInvalid=0,
+    eGamepad_ButtonA,
+    eGamepad_ButtonB,
+    eGamepad_ButtonX,
+    eGamepad_ButtonY,
+    eGamepad_ButtonBack,
+    eGamepad_ButtonGuide,
+    eGamepad_ButtonStart,
+    eGamepad_ButtonLeftStick,
+    eGamepad_ButtonRightStick,
+    eGamepad_ButtonLeftShoulder,
+    eGamepad_ButtonRightShoulder,
+    eGamepad_ButtonDpadUp,
+    eGamepad_ButtonDpadDown,
+    eGamepad_ButtonDpadLeft,
+    eGamepad_ButtonDpadRight,
+    eGamepad_ButtonCount
+};
+
+enum eJoystick_Hat
+{
+    eJoystick_HatInvalid = -1,
+    eJoystick_HatCentered = 0,
+    eJoystick_HatUp = 0x01,
+    eJoystick_HatRight = 0x02,
+    eJoystick_HatDown = 0x04,
+    eJoystick_HatLeft = 0x08,
+    eJoystick_HatRightUp = 0x03,
+    eJoystick_HatRightDown = 0x06,
+    eJoystick_HatLeftUp = 0x09,
+    eJoystick_HatLeftDown = 0x0C,
 };
 #endif
 
@@ -2471,6 +2529,36 @@ builtin struct Screen {
 };
 #endif
 
+#ifdef SCRIPT_API_v399
+builtin managed struct Joystick {
+  /// get number of connected joysticks.
+  import static readonly attribute int JoystickCount; // $AUTOCOMPLETESTATICONLY$
+  /// get a connected joystick by index or null on invalid index.
+  import static readonly attribute Joystick *Joysticks[]; // $AUTOCOMPLETESTATICONLY$
+  /// gets joystick name
+  import readonly attribute String Name;
+  /// checks if joystick is really connected
+  import readonly attribute bool IsConnected;
+  /// checks if joystick is a valid gamepad
+  import readonly attribute bool IsGamepad;
+  /// checks if a gamepad button is pressed, including dpad.
+  import bool IsGamepadButtonDown(eGamepad_Button button);
+  /// get gamepad axis or trigger, trigger only has positive values.
+  import float GetGamepadAxis(eGamepad_Axis axis, float dead_zone = AXIS_DEFAULT_DEADZONE); 
+  /// get joystick axis or trigger, by index
+  import float GetAxis(int axis, float dead_zone = AXIS_DEFAULT_DEADZONE);
+  /// checks if a joystick button is pressed.
+  import bool IsButtonDown(int button);
+  /// gets the direction a dpad from the joystick is pointing to.
+  import eJoystick_Hat GetHat(int hat);
+  /// get axis count from the joystick
+  import readonly attribute int AxisCount;
+  /// get button count from the joystick
+  import readonly attribute int ButtonCount;
+  /// get hat count from the joystick
+  import readonly attribute int HatCount;
+};
+#endif
 
 
 import readonly Character *player;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -98,6 +98,8 @@ target_sources(engine
     ac/dynobj/scriptdynamicsprite.h
     ac/dynobj/scriptfile.cpp
     ac/dynobj/scriptfile.h
+    ac/dynobj/scriptjoystick.cpp
+    ac/dynobj/scriptjoystick.h
     ac/dynobj/scriptgui.h
     ac/dynobj/scripthotspot.h
     ac/dynobj/scriptinvitem.h
@@ -127,6 +129,8 @@ target_sources(engine
     ac/file.h
     ac/game.cpp
     ac/game.h
+    ac/joystick.cpp
+    ac/joystick.h
     ac/gamesetup.cpp
     ac/gamesetup.h
     ac/gamestate.cpp

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -47,6 +47,7 @@
 #include "ac/mouse.h"
 #include "media/audio/audio_system.h"
 #include "ac/timer.h"
+#include "joystick.h"
 
 using namespace AGS::Common;
 using namespace AGS::Common::BitmapHelper;
@@ -241,6 +242,21 @@ bool display_check_user_input(int skip)
             if (skip & SKIP_MOUSECLICK && !play.IsIgnoringInput())
             {
                 play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
+                return true; // stop display
+            }
+        }
+        else if (type == kInputGamepad)
+        {
+            GamepadInput gbut;
+            if (!run_service_gamepad_controls(gbut) || play.fast_forward)
+                continue;
+            eAGSGamepad_Button gbn = gbut.Button;
+            if (check_skip_cutscene_gamepad(gbn))
+                return true;
+            if (skip & SKIP_GAMEPAD && !play.IsIgnoringInput() &&
+                    is_default_gamepad_skip_button_pressed(gbn))
+            {
+                play.SetWaitSkipResult(SKIP_GAMEPAD, gbn);
                 return true; // stop display
             }
         }

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -26,6 +26,7 @@
 #include "debug/debug_log.h"
 #include "plugin/plugin_engine.h"
 #include "util/memorystream.h"
+#include "scriptjoystick.h"
 
 using namespace AGS::Common;
 
@@ -158,6 +159,12 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     else if (strcmp(objectType, "AudioClip") == 0)
     {
         ccDynamicAudioClip.Unserialize(index, &mems, data_sz);
+    }
+    else if (strcmp(objectType, "Joystick") == 0)
+    {
+        // joysticks cannot be restored properly, any operation will fail
+        auto *scj = new ScriptJoystick();
+        ccRegisterUnserializedObject(index, scj, scj);
     }
     else
     {

--- a/Engine/ac/dynobj/scriptjoystick.cpp
+++ b/Engine/ac/dynobj/scriptjoystick.cpp
@@ -1,0 +1,44 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#include "ac/dynobj/scriptjoystick.h"
+#include "ac/joystick.h"
+#include "util/stream.h"
+#include "dynobj_manager.h"
+
+using namespace AGS::Common;
+
+ScriptJoystick::ScriptJoystick(int id) : _id(id) {}
+
+const char *ScriptJoystick::GetType() {
+    return "Joystick";
+}
+
+int ScriptJoystick::Dispose(void *address, bool force) {
+    delete this;
+    return 1;
+}
+
+size_t ScriptJoystick::CalcSerializeSize(void* /*address*/){
+    return 0;
+}
+
+void ScriptJoystick::Serialize(void *address, AGS::Common::Stream *out) {
+
+}
+
+void ScriptJoystick::Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) {
+    this->Invalidate();
+    ccRegisterUnserializedObject(index, this, this);
+}

--- a/Engine/ac/dynobj/scriptjoystick.h
+++ b/Engine/ac/dynobj/scriptjoystick.h
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+
+#ifndef __AC_SCRIPTJOYSTICK_H
+#define __AC_SCRIPTJOYSTICK_H
+
+#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "SDL_gamecontroller.h"
+
+struct ScriptJoystick final : AGSCCDynamicObject {
+public:
+    ScriptJoystick(int id = -1);
+    // Get gamepad index; negative means the gamepad was deleted
+    int GetID() const { return _id; }
+    void SetID(int id) { _id = id; }
+    // Reset gamepad index to indicate that this reference is no longer valid
+    void Invalidate() { _id = -1; }
+    inline bool IsInvalid() const {return _id == -1; }
+
+    int Dispose(void *address, bool force) override;
+    const char *GetType() override;
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
+
+protected:
+    // Calculate and return required space for serialization, in bytes
+    size_t CalcSerializeSize(void *address) override;
+    // Write object data into the provided stream
+    void Serialize(void *address, AGS::Common::Stream *out) override;
+
+private:
+    int _id = -1;
+};
+
+#endif // __AC_SCRIPTJOYSTICK_H

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1112,6 +1112,17 @@ bool check_skip_cutscene_mclick(int mbut)
     return false;
 }
 
+bool check_skip_cutscene_gamepad(int gbut)
+{
+    CutsceneSkipStyle skip = get_cutscene_skipstyle();
+    if (gbut>0 && skip == eSkipSceneAnyKey)
+    {
+        start_skipping_cutscene();
+        return true;
+    }
+    return false;
+}
+
 // Helper functions used by StartCutscene/EndCutscene, but also
 // by SkipUntilCharacterStops
 void initialize_skippable_cutscene() {

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -154,6 +154,7 @@ CutsceneSkipStyle get_cutscene_skipstyle();
 void start_skipping_cutscene ();
 bool check_skip_cutscene_keypress(int kgn);
 bool check_skip_cutscene_mclick(int mbut);
+bool check_skip_cutscene_gamepad(int gbut);
 void initialize_skippable_cutscene();
 void stop_fast_forwarding();
 

--- a/Engine/ac/joystick.cpp
+++ b/Engine/ac/joystick.cpp
@@ -1,0 +1,450 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include <algorithm>
+#include <vector>
+#include "ac/string.h"
+#include "ac/gamestructdefines.h"
+#include "ac/joystick.h"
+#include "SDL_joystick.h"
+#include "SDL_gamecontroller.h"
+#include "debug/debug_log.h"
+#include "script/script_api.h"
+#include "ac/dynobj/dynobj_manager.h"
+
+// clamps to -1.0 to 1.0, taking into account a dead-zone from 0.0
+float gamepad_clamp_val(float val, float dead_zone)
+{
+    dead_zone = std::max(dead_zone, 0.01f); // ignore negative values, but force minimal deadzone
+
+    if (val < 0.0f) {
+        val = val < -dead_zone ? val : 0.0f;
+    } else {
+        val = val > dead_zone ? val : 0.0f;
+    }
+
+    if (val < -0.99f) return -1.0f;
+    if (val > 0.99f) return 1.0f;
+
+    return val;
+}
+
+float axis_to_float_with_deadzone(int axis_val_int, float dead_zone) {
+    float axis_val = axis_val_int < 0 ? static_cast<float>(axis_val_int) / 32768.0f : static_cast<float>(axis_val_int) / 32767.0f;
+    return gamepad_clamp_val(axis_val, dead_zone);
+}
+
+SDL_GameControllerAxis Gamepad_Axis_AGStoSDL( eAGSGamepad_Axis ags_axis) {
+    switch (ags_axis)
+    {
+        case eAGSGamepad_AxisInvalid: return SDL_CONTROLLER_AXIS_INVALID;
+        case eAGSGamepad_AxisLeftX: return SDL_CONTROLLER_AXIS_LEFTX;
+        case eAGSGamepad_AxisLeftY: return SDL_CONTROLLER_AXIS_LEFTY;
+        case eAGSGamepad_AxisRightX: return SDL_CONTROLLER_AXIS_RIGHTX;
+        case eAGSGamepad_AxisRightY: return SDL_CONTROLLER_AXIS_RIGHTY;
+        case eAGSGamepad_AxisTriggerLeft: return SDL_CONTROLLER_AXIS_TRIGGERLEFT;
+        case eAGSGamepad_AxisTriggerRight: return SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
+    }
+    return SDL_CONTROLLER_AXIS_INVALID;
+}
+
+SDL_GameControllerButton Gamepad_Button_AGStoSDL(eAGSGamepad_Button ags_button) {
+    switch (ags_button)
+    {
+        case eAGSGamepad_ButtonInvalid: return SDL_CONTROLLER_BUTTON_INVALID;
+        case eAGSGamepad_ButtonA: return SDL_CONTROLLER_BUTTON_A;
+        case eAGSGamepad_ButtonB: return SDL_CONTROLLER_BUTTON_B;
+        case eAGSGamepad_ButtonX: return SDL_CONTROLLER_BUTTON_X;
+        case eAGSGamepad_ButtonY: return SDL_CONTROLLER_BUTTON_Y;
+        case eAGSGamepad_ButtonBack: return SDL_CONTROLLER_BUTTON_BACK;
+        case eAGSGamepad_ButtonGuide: return SDL_CONTROLLER_BUTTON_GUIDE;
+        case eAGSGamepad_ButtonStart: return SDL_CONTROLLER_BUTTON_START;
+        case eAGSGamepad_ButtonLeftStick: return  SDL_CONTROLLER_BUTTON_LEFTSTICK;
+        case eAGSGamepad_ButtonRightStick: return  SDL_CONTROLLER_BUTTON_RIGHTSTICK;
+        case eAGSGamepad_ButtonLeftShoulder: return SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+        case eAGSGamepad_ButtonRightShoulder: return SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+        case eAGSGamepad_ButtonDpadUp: return  SDL_CONTROLLER_BUTTON_DPAD_UP;
+        case eAGSGamepad_ButtonDpadDown: return  SDL_CONTROLLER_BUTTON_DPAD_DOWN;
+        case eAGSGamepad_ButtonDpadLeft: return  SDL_CONTROLLER_BUTTON_DPAD_LEFT;
+        case eAGSGamepad_ButtonDpadRight: return  SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
+    }
+    return SDL_CONTROLLER_BUTTON_INVALID;
+}
+
+eAGSJoystick_Hat Joystick_Hat_SDLtoAGS(uint8_t sdl_hat) {
+    switch (sdl_hat)
+    {
+        case SDL_HAT_CENTERED: return eAGSJoystick_HatCentered;
+        case SDL_HAT_UP: return eAGSJoystick_HatUp;
+        case SDL_HAT_RIGHT: return eAGSJoystick_HatRight;
+        case SDL_HAT_DOWN: return eAGSJoystick_HatDown;
+        case SDL_HAT_LEFT: return eAGSJoystick_HatLeft;
+        case SDL_HAT_RIGHTUP: return eAGSJoystick_HatRightUp;
+        case SDL_HAT_RIGHTDOWN: return eAGSJoystick_HatRightDown;
+        case SDL_HAT_LEFTUP: return eAGSJoystick_HatLeftUp;
+        case SDL_HAT_LEFTDOWN: return eAGSJoystick_HatLeftDown;
+    }
+    return eAGSJoystick_HatCentered;
+}
+
+uint8_t Joystick_Hat_AGStoSDL(eAGSJoystick_Hat ags_hat)
+{
+    switch (ags_hat)
+    {
+        case eAGSJoystick_HatCentered: return SDL_HAT_CENTERED;
+        case eAGSJoystick_HatUp: return SDL_HAT_UP;
+        case eAGSJoystick_HatRight: return SDL_HAT_RIGHT;
+        case eAGSJoystick_HatDown: return SDL_HAT_DOWN;
+        case eAGSJoystick_HatLeft: return  SDL_HAT_LEFT;
+        case eAGSJoystick_HatRightUp: return  SDL_HAT_RIGHTUP;
+        case eAGSJoystick_HatRightDown: return SDL_HAT_RIGHTDOWN;
+        case eAGSJoystick_HatLeftUp: return SDL_HAT_LEFTUP;
+        case eAGSJoystick_HatLeftDown: return SDL_HAT_LEFTDOWN;
+    }
+    return SDL_HAT_CENTERED;
+}
+
+eAGSGamepad_Button Gamepad_Button_SDLtoAGS(SDL_GameControllerButton sdl_button) {
+    switch (sdl_button)
+    {
+        case SDL_CONTROLLER_BUTTON_INVALID: return eAGSGamepad_ButtonInvalid;
+        case SDL_CONTROLLER_BUTTON_A: return eAGSGamepad_ButtonA;
+        case SDL_CONTROLLER_BUTTON_B: return eAGSGamepad_ButtonB;
+        case SDL_CONTROLLER_BUTTON_X: return eAGSGamepad_ButtonX;
+        case SDL_CONTROLLER_BUTTON_Y: return eAGSGamepad_ButtonY;
+        case SDL_CONTROLLER_BUTTON_BACK: return eAGSGamepad_ButtonBack;
+        case SDL_CONTROLLER_BUTTON_GUIDE: return eAGSGamepad_ButtonGuide;
+        case SDL_CONTROLLER_BUTTON_START: return eAGSGamepad_ButtonStart;
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK: return eAGSGamepad_ButtonLeftStick;
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return eAGSGamepad_ButtonRightStick;
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return eAGSGamepad_ButtonLeftShoulder;
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return eAGSGamepad_ButtonRightShoulder;
+        case SDL_CONTROLLER_BUTTON_DPAD_UP: return eAGSGamepad_ButtonDpadUp;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return eAGSGamepad_ButtonDpadDown;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return eAGSGamepad_ButtonDpadLeft;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return eAGSGamepad_ButtonDpadRight;
+    }
+    return eAGSGamepad_ButtonInvalid;
+}
+
+struct JoystickImpl {
+    SDL_GameController* sdlGameController = nullptr;
+    SDL_Joystick* sdlJoystick = nullptr;
+    SDL_JoystickID sdlJoystickID = -1;
+    int scriptJoystickHandle;
+};
+
+std::vector<JoystickImpl> _joysticks;
+
+void add_joystick(int device_index)
+{
+    // in case the platform also generates connection events at start, see note in init_joystick()
+    if(_joysticks.size() != device_index) return;
+
+    SDL_GameController* sdl_gamepad = nullptr;
+    SDL_Joystick* sdl_joy = nullptr;
+
+    if (SDL_IsGameController(device_index))
+    {
+        sdl_gamepad = SDL_GameControllerOpen(device_index);
+        sdl_joy = SDL_GameControllerGetJoystick(sdl_gamepad);
+    }
+    else
+    {
+        sdl_joy = SDL_JoystickOpen(device_index);
+    }
+
+    if (!sdl_joy) return;
+
+    SDL_JoystickID sdl_id = SDL_JoystickInstanceID(sdl_joy);
+
+    JoystickImpl joy;
+    joy.sdlJoystick = sdl_joy;
+    joy.sdlGameController = sdl_gamepad;
+    joy.sdlJoystickID = sdl_id;
+    joy.scriptJoystickHandle = -1;
+    _joysticks.push_back(joy);
+}
+
+void remove_joystick(int instance_id)
+{
+    SDL_JoystickID sdl_id = instance_id;
+    auto it = std::find_if(_joysticks.begin(), _joysticks.end(),
+                           [sdl_id](const JoystickImpl& joystick) {
+                               return joystick.sdlJoystickID == sdl_id;
+                           });
+
+    // remove the joystick from list if it was found
+    if (it != _joysticks.end()) {
+        // need to do something with the script reference here!
+        if(it->scriptJoystickHandle != -1) {
+            auto* scriptJoystick = (ScriptJoystick*) ccGetObjectAddressFromHandle(it->scriptJoystickHandle);
+            scriptJoystick->Invalidate();
+            ccReleaseObjectReference(it->scriptJoystickHandle);
+        }
+
+        _joysticks.erase(it);
+    }
+
+    for(int i=0; i<_joysticks.size(); i++)
+    {
+        auto const& joy = _joysticks[i];
+        if(joy.scriptJoystickHandle != -1) {
+            auto* scriptJoystick = (ScriptJoystick*) ccGetObjectAddressFromHandle(joy.scriptJoystickHandle);
+            scriptJoystick->SetID(i);
+        }
+    }
+}
+
+// it looks like on desktop platforms a connection event is always generated and thus this is not needed
+void init_joystick()
+{
+    if(!_joysticks.empty()) return;
+    int joy_count = SDL_NumJoysticks();
+    for(int i=0; i<joy_count; i++) {
+        add_joystick(i);
+    }
+}
+
+void JoystickConnectionEvent(const SDL_JoyDeviceEvent &event)
+{
+    if (event.type == SDL_JOYDEVICEADDED) add_joystick(event.which);
+    else if (event.type == SDL_JOYDEVICEREMOVED) remove_joystick(event.which);
+}
+
+int32_t Joystick_GetJoystickCount()
+{
+    return static_cast<int32_t>(_joysticks.size());
+}
+
+ScriptJoystick* Joystick_GetiJoysticks(int i)
+{
+    if(i<0 || i>=_joysticks.size()) return nullptr;
+
+    if(_joysticks[i].scriptJoystickHandle != -1) {
+        return static_cast<ScriptJoystick *>(ccGetObjectAddressFromHandle(_joysticks[i].scriptJoystickHandle));
+    }
+
+    ScriptJoystick *newJoy = new ScriptJoystick(i);
+    int handle = ccRegisterManagedObject(newJoy, newJoy);
+    // make sure an internal reference is kept
+    ccAddObjectReference(handle);
+    _joysticks[i].scriptJoystickHandle = handle;
+    return newJoy;
+}
+
+int Joystick_IsConnected(ScriptJoystick* joy)
+{
+    if(joy->IsInvalid()) return 0;
+    return SDL_JoystickGetAttached(_joysticks[joy->GetID()].sdlJoystick) ? 1 : 0;
+}
+
+int Joystick_IsGamepad(ScriptJoystick* joy)
+{
+    return _joysticks[joy->GetID()].sdlGameController != nullptr;
+}
+
+const char* Joystick_GetName(ScriptJoystick* joy) {
+    if (joy->IsInvalid()) return nullptr;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    const char* name_str = SDL_JoystickName(joy_impl.sdlJoystick);
+    if (!name_str) return nullptr;
+    return CreateNewScriptString(name_str);
+}
+
+int Joystick_IsGamepadButtonDown(ScriptJoystick* joy, int butt)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    return SDL_GameControllerGetButton(joy_impl.sdlGameController, Gamepad_Button_AGStoSDL(static_cast<eAGSGamepad_Button>(butt)));
+}
+
+float Joystick_GetGamepadAxis(ScriptJoystick* joy, int axis, float dead_zone)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    int axis_val_int = SDL_GameControllerGetAxis(joy_impl.sdlGameController, Gamepad_Axis_AGStoSDL(static_cast<eAGSGamepad_Axis>(axis)));
+    return axis_to_float_with_deadzone(axis_val_int, dead_zone);
+}
+
+float Joystick_GetAxis(ScriptJoystick* joy, int axis, float dead_zone)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    int axis_count = SDL_JoystickNumAxes(joy_impl.sdlJoystick);
+    if (axis < 0 || axis >= axis_count) {
+        debug_script_warn("Warning: joystick's (id %d) axis %d is not in range (0:%d), returned 0",
+                          joy_impl.sdlJoystickID, axis, axis_count);
+        return 0;
+    }
+    int axis_val_int = SDL_JoystickGetAxis(joy_impl.sdlJoystick, axis);
+    return axis_to_float_with_deadzone(axis_val_int, dead_zone);
+
+}
+
+int Joystick_IsButtonDown(ScriptJoystick* joy, int butt)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    int button_count = SDL_JoystickNumButtons(joy_impl.sdlJoystick);
+    if (butt < 0 || butt >= button_count) {
+        debug_script_warn("Warning: joystick's (id %d) button %d is not in range (0:%d), returned false",
+                          joy_impl.sdlJoystickID, butt, button_count);
+        return 0;
+    }
+    return SDL_JoystickGetButton(joy_impl.sdlJoystick, butt);
+}
+
+
+int Joystick_GetHat(ScriptJoystick* joy, int hat)
+{
+    if (joy->IsInvalid()) return eAGSJoystick_Hat::eAGSJoystick_HatCentered;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    int hat_count = SDL_JoystickNumHats(joy_impl.sdlJoystick);
+    if (hat < 0 || hat >= hat_count) {
+        debug_script_warn("Warning: joystick's (id %d) hat %d is not in range (0:%d), returned HatCentered",
+                          joy_impl.sdlJoystickID, hat, hat_count);
+        return eAGSJoystick_Hat::eAGSJoystick_HatCentered;
+    }
+    return SDL_JoystickGetHat(joy_impl.sdlJoystick, Joystick_Hat_AGStoSDL(static_cast<eAGSJoystick_Hat>(hat)));
+}
+
+int Joystick_GetAxisCount(ScriptJoystick* joy)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    return SDL_JoystickNumAxes(joy_impl.sdlJoystick);
+}
+
+int Joystick_GetButtonCount(ScriptJoystick* joy)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    return SDL_JoystickNumButtons(joy_impl.sdlJoystick);
+}
+
+int Joystick_GetHatCount(ScriptJoystick* joy)
+{
+    if (joy->IsInvalid()) return 0;
+    auto const& joy_impl = _joysticks[joy->GetID()];
+    return SDL_JoystickNumHats(joy_impl.sdlJoystick);
+}
+
+//=============================================================================
+//
+// Script API Functions
+//
+//=============================================================================
+
+#include "script/script_api.h"
+#include "script/script_runtime.h"
+#include "ac/dynobj/scriptstring.h"
+
+extern ScriptString myScriptStringImpl;
+
+// int ScriptJoystick::()
+RuntimeScriptValue Sc_Joystick_GetJoystickCount(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Joystick_GetJoystickCount);
+}
+
+// ScriptJoystick* ScriptJoystick::(int index)
+RuntimeScriptValue Sc_Joystick_GetiJoysticks(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJAUTO_PINT(ScriptJoystick, Joystick_GetiJoysticks);
+}
+
+// String* (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_GetName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptJoystick, const char, myScriptStringImpl, Joystick_GetName);
+}
+
+// int (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_IsConnected(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptJoystick, Joystick_IsConnected);
+}
+
+// int (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_IsGamepad(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptJoystick, Joystick_IsGamepad);
+}
+
+// int (ScriptJoystick *joy, int button)
+RuntimeScriptValue Sc_Joystick_IsGamepadButtonDown(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_PINT(ScriptJoystick, Joystick_IsGamepadButtonDown);
+}
+
+// float (ScriptJoystick *joy, int axis)
+RuntimeScriptValue Sc_Joystick_GetGamepadAxis(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT_PINT_PFLOAT(ScriptJoystick, Joystick_GetGamepadAxis);
+}
+
+RuntimeScriptValue Sc_Joystick_GetAxis(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_FLOAT_PINT_PFLOAT(ScriptJoystick, Joystick_GetAxis);
+}
+
+RuntimeScriptValue Sc_Joystick_IsButtonDown(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_PINT(ScriptJoystick, Joystick_IsButtonDown);
+}
+
+//int (ScriptJoystick *joy, int hat)
+RuntimeScriptValue Sc_Joystick_GetHat(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT_PINT(ScriptJoystick, Joystick_GetHat);
+}
+
+// int (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_GetAxisCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptJoystick, Joystick_GetAxisCount);
+}
+
+// int (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_GetButtonCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptJoystick, Joystick_GetButtonCount);
+}
+
+// int (ScriptJoystick *joy)
+RuntimeScriptValue Sc_Joystick_GetHatCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_INT(ScriptJoystick, Joystick_GetHatCount);
+}
+
+void RegisterJoystickAPI()
+{
+    ScFnRegister joystick_api[] = {
+            {"Joystick::get_JoystickCount",     API_FN_PAIR(Joystick_GetJoystickCount)},
+            {"Joystick::geti_Joysticks",         API_FN_PAIR(Joystick_GetiJoysticks)},
+            {"Joystick::get_Name",              API_FN_PAIR(Joystick_GetName)},
+            {"Joystick::get_IsConnected",       API_FN_PAIR(Joystick_IsConnected)},
+            {"Joystick::get_IsGamepad",         API_FN_PAIR(Joystick_IsGamepad)},
+            {"Joystick::IsGamepadButtonDown^1", API_FN_PAIR(Joystick_IsGamepadButtonDown)},
+            {"Joystick::GetGamepadAxis^2",      API_FN_PAIR(Joystick_GetGamepadAxis)},
+            {"Joystick::GetAxis^2",             API_FN_PAIR(Joystick_GetAxis)},
+            {"Joystick::IsButtonDown^1",        API_FN_PAIR(Joystick_IsButtonDown)},
+            {"Joystick::GetHat^1",              API_FN_PAIR(Joystick_GetHat)},
+            {"Joystick::get_AxisCount",         API_FN_PAIR(Joystick_GetAxisCount)},
+            {"Joystick::get_ButtonCount",       API_FN_PAIR(Joystick_GetButtonCount)},
+            {"Joystick::get_HatCount",          API_FN_PAIR(Joystick_GetHatCount)}
+    };
+
+    ccAddExternalFunctions(joystick_api);
+}

--- a/Engine/ac/joystick.cpp
+++ b/Engine/ac/joystick.cpp
@@ -22,6 +22,14 @@
 #include "script/script_api.h"
 #include "ac/dynobj/dynobj_manager.h"
 
+bool is_default_gamepad_skip_button_pressed(eAGSGamepad_Button gbn)
+{
+    return (gbn == eAGSGamepad_ButtonA) ||
+    (gbn == eAGSGamepad_ButtonB) ||
+    (gbn == eAGSGamepad_ButtonX) ||
+    (gbn == eAGSGamepad_ButtonY);
+}
+
 // clamps to -1.0 to 1.0, taking into account a dead-zone from 0.0
 float gamepad_clamp_val(float val, float dead_zone)
 {

--- a/Engine/ac/joystick.h
+++ b/Engine/ac/joystick.h
@@ -80,13 +80,14 @@ enum eAGSGamepad_InputType
 
 struct GamepadInput
 {
-    int gamepad_index = -1;
+    SDL_JoystickID JoystickID = -1;
     eAGSGamepad_Button Button = eAGSGamepad_Button::eAGSGamepad_ButtonInvalid;
     eAGSGamepad_Axis Axis = eAGSGamepad_Axis::eAGSGamepad_AxisInvalid;
     eAGSGamepad_InputType Type = eAGSGamepad_InputType::eAGSGamepad_InputTypeNone;
 };
 
 void JoystickConnectionEvent(const SDL_JoyDeviceEvent &event);
+bool is_default_gamepad_skip_button_pressed(eAGSGamepad_Button gbn);
 void init_joystick();
 
 SDL_GameControllerAxis Gamepad_Axis_AGStoSDL(eAGSGamepad_Axis ags_axis);

--- a/Engine/ac/joystick.h
+++ b/Engine/ac/joystick.h
@@ -1,0 +1,96 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+//
+//
+//=============================================================================
+#ifndef __AGS_EE_AC__JOYSTICK_H
+#define __AGS_EE_AC__JOYSTICK_H
+
+#include "ac/dynobj/scriptjoystick.h"
+#include "SDL_gamecontroller.h"
+#include "SDL_events.h"
+
+enum eAGSJoystick_Hat
+{
+    eAGSJoystick_HatInvalid = -1,
+    eAGSJoystick_HatCentered = 0,
+    eAGSJoystick_HatUp = 0x01,
+    eAGSJoystick_HatRight = 0x02,
+    eAGSJoystick_HatDown = 0x04,
+    eAGSJoystick_HatLeft = 0x08,
+    eAGSJoystick_HatRightUp = 0x03,
+    eAGSJoystick_HatRightDown = 0x06,
+    eAGSJoystick_HatLeftUp = 0x09,
+    eAGSJoystick_HatLeftDown = 0x0C,
+};
+
+enum eAGSGamepad_Axis
+{
+    eAGSGamepad_AxisInvalid,
+    eAGSGamepad_AxisLeftX,
+    eAGSGamepad_AxisLeftY,
+    eAGSGamepad_AxisRightX,
+    eAGSGamepad_AxisRightY,
+    eAGSGamepad_AxisTriggerLeft,
+    eAGSGamepad_AxisTriggerRight,
+    eAGSGamepad_AxisCount
+};
+
+enum eAGSGamepad_Button
+{
+    eAGSGamepad_ButtonInvalid,
+    eAGSGamepad_ButtonA,
+    eAGSGamepad_ButtonB,
+    eAGSGamepad_ButtonX,
+    eAGSGamepad_ButtonY,
+    eAGSGamepad_ButtonBack,
+    eAGSGamepad_ButtonGuide,
+    eAGSGamepad_ButtonStart,
+    eAGSGamepad_ButtonLeftStick,
+    eAGSGamepad_ButtonRightStick,
+    eAGSGamepad_ButtonLeftShoulder,
+    eAGSGamepad_ButtonRightShoulder,
+    eAGSGamepad_ButtonDpadUp,
+    eAGSGamepad_ButtonDpadDown,
+    eAGSGamepad_ButtonDpadLeft,
+    eAGSGamepad_ButtonDpadRight,
+    eAGSGamepad_ButtonCount
+};
+
+enum eAGSGamepad_InputType
+{
+    eAGSGamepad_InputTypeNone,
+    eAGSGamepad_InputTypeAxis,
+    eAGSGamepad_InputTypeButton,
+    eAGSGamepad_InputTypeHat,
+    eAGSGamepad_InputTypeCount,
+};
+
+struct GamepadInput
+{
+    int gamepad_index = -1;
+    eAGSGamepad_Button Button = eAGSGamepad_Button::eAGSGamepad_ButtonInvalid;
+    eAGSGamepad_Axis Axis = eAGSGamepad_Axis::eAGSGamepad_AxisInvalid;
+    eAGSGamepad_InputType Type = eAGSGamepad_InputType::eAGSGamepad_InputTypeNone;
+};
+
+void JoystickConnectionEvent(const SDL_JoyDeviceEvent &event);
+void init_joystick();
+
+SDL_GameControllerAxis Gamepad_Axis_AGStoSDL(eAGSGamepad_Axis ags_axis);
+SDL_GameControllerButton Gamepad_Button_AGStoSDL(eAGSGamepad_Button ags_button);
+eAGSGamepad_Button Gamepad_Button_SDLtoAGS(SDL_GameControllerButton sdl_button);
+
+#endif // __AGS_EE_AC__JOYSTICK_H

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -130,6 +130,7 @@ enum LegacyScriptAlignment
 #define SKIP_AUTOTIMER  0x01
 #define SKIP_KEYPRESS   0x02
 #define SKIP_MOUSECLICK 0x04
+#define SKIP_GAMEPAD    0x08
 // Bit shift for packing skip type into result
 #define SKIP_RESULT_TYPE_SHIFT 24
 // Bit mask for packing skip key/button data into result

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -39,7 +39,7 @@ int user_to_internal_skip_speech(SkipSpeechStyle userval)
     case kSkipSpeechNone:
         return SKIP_NONE;
     case kSkipSpeechKeyMouseTime:
-        return SKIP_AUTOTIMER | SKIP_KEYPRESS | SKIP_MOUSECLICK;
+        return SKIP_AUTOTIMER | SKIP_KEYPRESS | SKIP_MOUSECLICK | SKIP_GAMEPAD; // FIXME: remake this as `kSkipAny`
     case kSkipSpeechKeyTime:
         return SKIP_AUTOTIMER | SKIP_KEYPRESS;
     case kSkipSpeechTime:

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -274,6 +274,8 @@ InputType ags_inputevent_ready()
     case SDL_MOUSEBUTTONDOWN:
     case SDL_MOUSEBUTTONUP:
         return kInputMouse;
+    case SDL_CONTROLLERBUTTONDOWN:
+        return kInputGamepad;
     default:
         return kInputNone;
     }
@@ -927,9 +929,9 @@ void ags_clear_mouse_movement()
 // JOYSTICK INPUT
 // ----------------------------------------------------------------------------
 
-static void on_sdl_joystick_button(const SDL_JoyButtonEvent &event)
+static void on_sdl_joystick_button(const SDL_Event &event)
 {
-
+    g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_joystick_device(const SDL_JoyDeviceEvent &event)
@@ -941,9 +943,9 @@ static void on_sdl_joystick_device(const SDL_JoyDeviceEvent &event)
 // GAMEPAD INPUT
 // ----------------------------------------------------------------------------
 
-static void on_sdl_gamepad_button(const SDL_ControllerButtonEvent &event)
+static void on_sdl_gamepad_button(const SDL_Event &event)
 {
-
+    g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_gamepad_device(const SDL_ControllerDeviceEvent &event)
@@ -1036,14 +1038,14 @@ void sys_evt_process_one(const SDL_Event &event) {
         break;
     // JOYSTICK INPUT
     case SDL_JOYBUTTONDOWN:
-        on_sdl_joystick_button(event.jbutton);
+        on_sdl_joystick_button(event);
         break;
     case SDL_JOYDEVICEADDED:
     case SDL_JOYDEVICEREMOVED:
         on_sdl_joystick_device(event.jdevice);
         break;
     case SDL_CONTROLLERBUTTONDOWN:
-        on_sdl_gamepad_button(event.cbutton);
+        on_sdl_gamepad_button(event);
         break;
     case SDL_CONTROLLERDEVICEADDED:
     case SDL_CONTROLLERDEVICEREMOVED:

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -19,6 +19,7 @@
 #include "core/platform.h"
 #include "ac/common.h"
 #include "ac/gamesetup.h"
+#include "ac/joystick.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/keycode.h"
 #include "ac/mouse.h"
@@ -922,6 +923,33 @@ void ags_clear_mouse_movement()
     mouse_accum_rely = 0;
 }
 
+// ----------------------------------------------------------------------------
+// JOYSTICK INPUT
+// ----------------------------------------------------------------------------
+
+static void on_sdl_joystick_button(const SDL_JoyButtonEvent &event)
+{
+
+}
+
+static void on_sdl_joystick_device(const SDL_JoyDeviceEvent &event)
+{
+    JoystickConnectionEvent(event);
+}
+
+// ----------------------------------------------------------------------------
+// GAMEPAD INPUT
+// ----------------------------------------------------------------------------
+
+static void on_sdl_gamepad_button(const SDL_ControllerButtonEvent &event)
+{
+
+}
+
+static void on_sdl_gamepad_device(const SDL_ControllerDeviceEvent &event)
+{
+
+}
 
 // ----------------------------------------------------------------------------
 // EVENTS
@@ -1005,6 +1033,21 @@ void sys_evt_process_one(const SDL_Event &event) {
         break;
     case SDL_FINGERMOTION:
         on_sdl_touch_motion(event.tfinger);
+        break;
+    // JOYSTICK INPUT
+    case SDL_JOYBUTTONDOWN:
+        on_sdl_joystick_button(event.jbutton);
+        break;
+    case SDL_JOYDEVICEADDED:
+    case SDL_JOYDEVICEREMOVED:
+        on_sdl_joystick_device(event.jdevice);
+        break;
+    case SDL_CONTROLLERBUTTONDOWN:
+        on_sdl_gamepad_button(event.cbutton);
+        break;
+    case SDL_CONTROLLERDEVICEADDED:
+    case SDL_CONTROLLERDEVICEREMOVED:
+        on_sdl_gamepad_device(event.cdevice);
         break;
     default: break;
     }

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -29,6 +29,7 @@ enum InputType
     // 0x01 is skipped for a purpose, because it has special meaning in script
     kInputKeyboard  = 0x02,
     kInputMouse     = 0x04,
+    kInputGamepad   = 0x08,
     kInputAny       = 0xFF
 };
 

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_EE_AC__SYS_EVENTS_H
 #define __AGS_EE_AC__SYS_EVENTS_H
 #include <SDL_keyboard.h>
+#include <SDL_events.h>
 #include "ac/keycode.h"
 
 // Internal AGS device and event type, made as flags

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -76,6 +76,7 @@
 #include "util/error.h"
 #include "util/path.h"
 #include "util/string_utils.h"
+#include "ac/joystick.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -1227,6 +1228,8 @@ int initialize_engine(const ConfigTree &startup_opts)
     engine_init_fonts();
 
     our_eip = -195;
+
+    init_joystick();
 
     engine_init_keyboard();
 

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -18,6 +18,7 @@
 
 namespace AGS { namespace Engine { class IDriverDependantBitmap; }}
 using namespace AGS::Engine; // FIXME later
+struct GamepadInput;
 
 // Loops game frames until certain event takes place (for blocking actions)
 void GameLoopUntilValueIsZero(const char *value);
@@ -50,6 +51,9 @@ bool run_service_key_controls(KeyInput &kgn);
 // Runs service mouse controls, returns false if mouse input was claimed by the engine,
 // otherwise returns true and provides mouse button code.
 bool run_service_mb_controls(eAGSMouseButton &mbut);
+// Runs service gamepad controls, returns false if no button was pressed or if button input was claimed by the engine,
+// otherwise returns true and provides the gamepad input.
+bool run_service_gamepad_controls(GamepadInput &out_key);
 // Polls few things (exit flag and debugger messages)
 // TODO: refactor this
 void update_polled_stuff();

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -39,6 +39,7 @@
 #include "util/stream.h"
 #include "media/audio/audio_system.h"
 #include "media/audio/openal.h"
+#include "ac/joystick.h"
 
 using namespace AGS::Common;
 using namespace AGS::Engine;
@@ -509,6 +510,13 @@ static bool video_check_user_input(VideoSkipType skip)
             eAGSMouseButton mbut;
             if (run_service_mb_controls(mbut) && (skip == VideoSkipKeyOrMouse))
                 return true; // skip on mouse click
+        }
+        else if (type == kInputGamepad)
+        {
+            GamepadInput gbut;
+            if (run_service_gamepad_controls(gbut) && (skip == VideoSkipAnyKey) &&
+                is_default_gamepad_skip_button_pressed(gbut.Button))
+                return true; // skip on ABXY
         }
     }
     return false;

--- a/Engine/script/exports.cpp
+++ b/Engine/script/exports.cpp
@@ -37,6 +37,7 @@ extern void RegisterGUIControlAPI();
 extern void RegisterHotspotAPI();
 extern void RegisterInventoryItemAPI();
 extern void RegisterInventoryWindowAPI();
+extern void RegisterJoystickAPI();
 extern void RegisterLabelAPI();
 extern void RegisterListBoxAPI();
 extern void RegisterMathAPI();
@@ -78,6 +79,7 @@ void setup_script_exports(ScriptAPIVersion base_api, ScriptAPIVersion compat_api
     RegisterHotspotAPI();
     RegisterInventoryItemAPI();
     RegisterInventoryWindowAPI();
+    RegisterJoystickAPI();
     RegisterLabelAPI();
     RegisterListBoxAPI();
     RegisterMathAPI();

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -499,6 +499,10 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     ASSERT_OBJ_PARAM_COUNT(METHOD, 1); \
     return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, params[0].IValue))
 
+#define API_OBJCALL_FLOAT_PINT_PFLOAT(CLASS, METHOD) \
+    ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
+    return RuntimeScriptValue().SetFloat(METHOD((CLASS*)self, params[0].IValue, params[1].FValue))
+
 #define API_OBJCALL_INT_PINT_POBJ(CLASS, METHOD, P1CLASS) \
     ASSERT_OBJ_PARAM_COUNT(METHOD, 2); \
     return RuntimeScriptValue().SetInt32(METHOD((CLASS*)self, params[0].IValue, (P1CLASS*)params[1].Ptr))

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -488,6 +488,7 @@
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptfile.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptgame.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptmouse.cpp" />
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptjoystick.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptoverlay.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptstring.cpp" />
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptsystem.cpp" />
@@ -498,6 +499,7 @@
     <ClCompile Include="..\..\Engine\ac\event.cpp" />
     <ClCompile Include="..\..\Engine\ac\file.cpp" />
     <ClCompile Include="..\..\Engine\ac\game.cpp" />
+    <ClCompile Include="..\..\Engine\ac\joystick.cpp" />
     <ClCompile Include="..\..\Engine\ac\gamesetup.cpp" />
     <ClCompile Include="..\..\Engine\ac\gamestate.cpp" />
     <ClCompile Include="..\..\Engine\ac\global_api.cpp" />
@@ -726,7 +728,8 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdrawingsurface.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptdynamicsprite.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptfile.h" />
-    <ClInclude Include="..\..\Engine\ac\dynobj\scriptgame.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptgame.h" /> 
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptjoystick.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptgui.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scripthotspot.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptinvitem.h" />
@@ -743,6 +746,7 @@
     <ClInclude Include="..\..\Engine\ac\event.h" />
     <ClInclude Include="..\..\Engine\ac\file.h" />
     <ClInclude Include="..\..\Engine\ac\game.h" />
+    <ClInclude Include="..\..\Engine\ac\joystick.h" />
     <ClInclude Include="..\..\Engine\ac\gamesetup.h" />
     <ClInclude Include="..\..\Engine\ac\gamestate.h" />
     <ClInclude Include="..\..\Engine\ac\global_audio.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -207,6 +207,9 @@
     <ClCompile Include="..\..\Engine\ac\game.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\joystick.cpp">
+      <Filter>Source Files\ac</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Engine\ac\gamesetup.cpp">
       <Filter>Source Files\ac</Filter>
     </ClCompile>
@@ -442,6 +445,9 @@
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptfile.cpp">
+      <Filter>Source Files\ac\dynobj</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Engine\ac\dynobj\scriptjoystick.cpp">
       <Filter>Source Files\ac\dynobj</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Engine\ac\dynobj\scriptoverlay.cpp">
@@ -809,6 +815,9 @@
     <ClInclude Include="..\..\Engine\ac\game.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\joystick.h">
+      <Filter>Header Files\ac</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\Engine\ac\gamesetup.h">
       <Filter>Header Files\ac</Filter>
     </ClInclude>
@@ -1056,6 +1065,9 @@
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptfile.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\scriptjoystick.h">
       <Filter>Header Files\ac\dynobj</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Engine\ac\dynobj\scriptgui.h">


### PR DESCRIPTION
fix #1364  | [Forum thread](https://www.adventuregamestudio.co.uk/forums/index.php?topic=59945.0)

Adds a Joystick API with support to SDL Game Controller too (named Gamepad in Script API here).

- Joysticks are managed internally in the engine: you can't open or close connection to joysticks from the script api.
- Missing a better integration with the engine and a way to set the buttons for things like skipping text dialogs with the joystick. 
- Haptics (Rumble) is not added here.
- Navigating default AGS menus with joystick/gamepad is not intended to be supported because it would require a new concept of selection.
- Also I have no idea what to do regarding save files.

## Script API

### Joystick Static Methods

**`Joystick.JoystickCount`**
```AGS Script
static readonly int Joystick.JoystickCount
```
Get the number of connected joysticks. No joysticks should return 0!

---

**`Joystick.Get`**
```AGS Script
static readonly Joystick* Joystick.Joysticks[int index]
```

Get a joystick from it's index in the internal engine list of joysticks.

---

### Joystick Instance Attributes and Methods

**`Joystick.IsConnected`**
```AGS Script
readonly bool Joystick.IsConnected
```
True if joystick is really connected.

---

**`Joystick.Name`**
```AGS Script
readonly String Joystick.Name
```
joystick name.

---


**`Joystick.IsButtonDown`**
```AGS Script
bool Joystick.IsButtonDown(int button)
```
checks if a joystick button is pressed, by index. DPad is usually mapped separately as a hat.

---

**`Joystick.GetAxis`**
```AGS Script
bool Joystick.GetAxis(int axis, optional float deadzone)
```
get a joystick axis or trigger, trigger only has positive values, by axis number. Values varies from -1.0 to 1.0 for axis, and 0.0 to 1.0 for triggers.

---

**`Joystick.GetHat`**
```AGS Script
eJoystick_Hat Joystick.GetHat(int hat)
```
returns hat position as enum.

---

**`Joystick.AxisCount`**
```AGS Script
readonly int Joystick.AxisCount
```
get the raw number of axis in the joystick.

---

**`Joystick.ButtonCount`**
```AGS Script
readonly int Joystick.ButtonCount
```
get the raw number of buttons in the joystick.

---

**`Joystick.HatCount`**
```AGS Script
readonly int Joystick.HatCount
```
get the raw number of hats in the joystick.

---


**`Joystick.IsGamepad`**
```AGS Script
readonly bool Joystick.IsGamepad
```
True if joystick is a valid gamepad connected - this means SDL2 recognized it as a valid GameController and has successfully mapped it's buttons to an Xbox360 gamepad.

---

**`Joystick.IsGamepadButtonDown`**
```AGS Script
bool Joystick.IsGamepadButtonDown(eGamepad_Button button)
```
checks if a gamepad button is pressed, including dpad.

Possible buttons:

- `eGamepad_ButtonA`
- `eGamepad_ButtonB`
- `eGamepad_ButtonX`
- `eGamepad_ButtonY`
- `eGamepad_ButtonBack`
- `eGamepad_ButtonGuide`
- `eGamepad_ButtonStart`
- `eGamepad_ButtonLeftStick`
- `eGamepad_ButtonRightStick`
- `eGamepad_ButtonLeftShoulder`
- `eGamepad_ButtonRightShoulder`
- `eGamepad_ButtonDpadUp`
- `eGamepad_ButtonDpadDown`
- `eGamepad_ButtonDpadLeft`
- `eGamepad_ButtonDpadRight`

---

**`Joystick.GetGamepadAxis`**
```AGS Script
float Joystick.GetGamepadAxis(eGamepad_Axis axis, optional float deadzone)
```
get gamepad axis or trigger, trigger only has positive values. Values varies from -1.0 to 1.0 for axis, and 0.0 to 1.0 for triggers.

You can optionally pass an additional parameter to use as deadzone. If an axis absolute value is smaller than the value of deadzone, it will return 0.0. Default value is AXIS_DEFAULT_DEADZONE, which is for now 0.125, use the name if you need a number.

Possible axis and triggers:

- `eGamepad_AxisLeftX`
- `eGamepad_AxisLeftY`
- `eGamepad_AxisRightX`
- `eGamepad_AxisRightY`
- `eGamepad_AxisTriggerLeft`
- `eGamepad_AxisTriggerRight`

---