### PR TITLE
Engine: rewrote MoveList to avoid using packed shorts for coords

### DIFF
--- a/Common/util/alignedstream.cpp
+++ b/Common/util/alignedstream.cpp
@@ -154,6 +154,14 @@ size_t AlignedStream::ReadArrayOfInt64(int64_t *buffer, size_t count)
     return count;
 }
 
+size_t AlignedStream::ReadArrayOfFloat32(float *buffer, size_t count)
+{
+    ReadPadding(sizeof(float));
+    count = _stream->ReadArrayOfFloat32(buffer, count);
+    _block += count * sizeof(float);
+    return count;
+}
+
 size_t AlignedStream::Write(const void *buffer, size_t size)
 {
     WritePadding(sizeof(int8_t));
@@ -243,6 +251,14 @@ size_t AlignedStream::WriteArrayOfInt64(const int64_t *buffer, size_t count)
     WritePadding(sizeof(int64_t));
     count = _stream->WriteArrayOfInt64(buffer, count);
     _block += count * sizeof(int64_t);
+    return count;
+}
+
+size_t AlignedStream::WriteArrayOfFloat32(const float *buffer, size_t count)
+{
+    WritePadding(sizeof(float));
+    count = _stream->WriteArrayOfFloat32(buffer, count);
+    _block += count * sizeof(float);
     return count;
 }
 

--- a/Common/util/alignedstream.h
+++ b/Common/util/alignedstream.h
@@ -75,6 +75,7 @@ public:
     size_t  ReadArrayOfInt16(int16_t *buffer, size_t count) override;
     size_t  ReadArrayOfInt32(int32_t *buffer, size_t count) override;
     size_t  ReadArrayOfInt64(int64_t *buffer, size_t count) override;
+    size_t  ReadArrayOfFloat32(float *buffer, size_t count) override;
 
     size_t  Write(const void *buffer, size_t size) override;
     int32_t WriteByte(uint8_t b) override;
@@ -87,6 +88,7 @@ public:
     size_t  WriteArrayOfInt16(const int16_t *buffer, size_t count) override;
     size_t  WriteArrayOfInt32(const int32_t *buffer, size_t count) override;
     size_t  WriteArrayOfInt64(const int64_t *buffer, size_t count) override;
+    size_t  WriteArrayOfFloat32(const float *buffer, size_t count) override;
 
     bool    Seek(soff_t offset, StreamSeek origin) override;
 

--- a/Common/util/datastream.cpp
+++ b/Common/util/datastream.cpp
@@ -123,6 +123,16 @@ size_t DataStream::ReadAndConvertArrayOfInt64(int64_t *buffer, size_t count)
     return count;
 }
 
+size_t DataStream::ReadAndConvertArrayOfFloat32(float *buffer, size_t count)
+{
+    count = ReadArray(buffer, sizeof(float), count);
+    for (size_t i = 0; i < count; ++i, ++buffer)
+    {
+        *buffer = BBOp::SwapBytesFloat(*buffer);
+    }
+    return count;
+}
+
 size_t DataStream::WriteAndConvertArrayOfInt16(const int16_t *buffer, size_t count)
 {
     size_t elem;
@@ -161,6 +171,21 @@ size_t DataStream::WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t cou
         int64_t val = *buffer;
         ConvertInt64(val);
         if (Write(&val, sizeof(int64_t)) < sizeof(int64_t))
+        {
+            break;
+        }
+    }
+    return elem;
+}
+
+size_t DataStream::WriteAndConvertArrayOfFloat32(const float *buffer, size_t count)
+{
+    size_t elem;
+    for (elem = 0; elem < count && !EOS(); ++elem, ++buffer)
+    {
+        float val = *buffer;
+        ConvertFloat32(val);
+        if (Write(&val, sizeof(float)) < sizeof(float))
         {
             break;
         }

--- a/Common/util/datastream.h
+++ b/Common/util/datastream.h
@@ -70,6 +70,12 @@ public:
             ReadAndConvertArrayOfInt64(buffer, count) : ReadArray(buffer, sizeof(int64_t), count);
     }
 
+    size_t ReadArrayOfFloat32(float *buffer, size_t count) override
+    {
+        return MustSwapBytes() ?
+            ReadAndConvertArrayOfFloat32(buffer, count) : ReadArray(buffer, sizeof(float), count);
+    }
+
     size_t  WriteInt8(int8_t val) override;
     size_t  WriteInt16(int16_t val) override;
     size_t  WriteInt32(int32_t val) override;
@@ -99,6 +105,12 @@ public:
             WriteAndConvertArrayOfInt64(buffer, count) : WriteArray(buffer, sizeof(int64_t), count);
     }
 
+    size_t WriteArrayOfFloat32(const float *buffer, size_t count) override
+    {
+        return MustSwapBytes() ?
+            WriteAndConvertArrayOfFloat32(buffer, count) : WriteArray(buffer, sizeof(float), count);
+    }
+
 protected:
     DataEndianess _streamEndianess;
 
@@ -107,9 +119,11 @@ protected:
     size_t  ReadAndConvertArrayOfInt16(int16_t *buffer, size_t count);
     size_t  ReadAndConvertArrayOfInt32(int32_t *buffer, size_t count);
     size_t  ReadAndConvertArrayOfInt64(int64_t *buffer, size_t count);
+    size_t  ReadAndConvertArrayOfFloat32(float *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt16(const int16_t *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt32(const int32_t *buffer, size_t count);
     size_t  WriteAndConvertArrayOfInt64(const int64_t *buffer, size_t count);
+    size_t  WriteAndConvertArrayOfFloat32(const float *buffer, size_t count);
 
     inline bool MustSwapBytes()
     {

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -118,6 +118,11 @@ struct Point
     {
         return Point(X - p.X, Y - p.Y);
     }
+
+    inline bool Equals(const int x, const int y) const
+    {
+        return X == x && Y == y;
+    }
 };
 
 struct Line

--- a/Common/util/iagsstream.h
+++ b/Common/util/iagsstream.h
@@ -79,6 +79,7 @@ public:
     virtual size_t      ReadArrayOfInt16(int16_t *buffer, size_t count) = 0;
     virtual size_t      ReadArrayOfInt32(int32_t *buffer, size_t count) = 0;
     virtual size_t      ReadArrayOfInt64(int64_t *buffer, size_t count) = 0;
+    virtual size_t      ReadArrayOfFloat32(float *buffer, size_t count) = 0;
 
     // Convenience methods for writing values of particular size
     virtual size_t      WriteInt8(int8_t val) = 0;;
@@ -92,6 +93,7 @@ public:
     virtual size_t      WriteArrayOfInt16(const int16_t *buffer, size_t count) = 0;
     virtual size_t      WriteArrayOfInt32(const int32_t *buffer, size_t count) = 0;
     virtual size_t      WriteArrayOfInt64(const int64_t *buffer, size_t count) = 0;
+    virtual size_t      WriteArrayOfFloat32(const float *buffer, size_t count) = 0;
 
     virtual bool        Seek(soff_t offset, StreamSeek origin = kSeekCurrent) = 0;
 };

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1022,7 +1022,7 @@ void Character_WalkStraight(CharacterInfo *chaa, int xx, int yy, int blocking) {
     Character_StopMoving(chaa);
     int movetox = xx, movetoy = yy;
 
-    set_wallscreen(prepare_walkable_areas(chaa->index_id));
+    set_walkablearea(prepare_walkable_areas(chaa->index_id));
 
     // TODO: hide these conversions, maybe make can_see_from() function do them internally in and out?
     int fromX = room_to_mask_coord(chaa->x);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1812,8 +1812,8 @@ void start_character_turning (CharacterInfo *chinf, int useloop, int no_diagonal
 }
 
 void fix_player_sprite(MoveList*cmls,CharacterInfo*chinf) {
-    const fixed xpmove = cmls->xpermove[cmls->onstage];
-    const fixed ypmove = cmls->ypermove[cmls->onstage];
+    const float xpmove = cmls->xpermove[cmls->onstage];
+    const float ypmove = cmls->ypermove[cmls->onstage];
 
     // if not moving, do nothing
     if ((xpmove == 0) && (ypmove == 0))

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -168,7 +168,7 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
         return;
     }
 
-    cmls->pos[cmls->numstage] = (x << 16) + y;
+    cmls->pos[cmls->numstage] = { x, y };
     // They're already walking there anyway
     if (cmls->pos[cmls->numstage] == cmls->pos[cmls->numstage - 1])
         return;
@@ -1353,7 +1353,7 @@ int Character_GetMoving(CharacterInfo *chaa) {
 int Character_GetDestinationX(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1] >> 16;
+        return cmls->pos[cmls->numstage - 1].X;
     }
     else
         return chaa->x;
@@ -1362,7 +1362,7 @@ int Character_GetDestinationX(CharacterInfo *chaa) {
 int Character_GetDestinationY(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1] & 0xFFFF;
+        return cmls->pos[cmls->numstage - 1].Y;
     }
     else
         return chaa->y;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1873,7 +1873,7 @@ int has_hit_another_character(int sourceChar) {
 int doNextCharMoveStep (CharacterInfo *chi, int &char_index, CharacterExtras *chex) {
     int ntf=0, xwas = chi->x, ywas = chi->y;
 
-    if (do_movelist_move(&chi->walking,&chi->x,&chi->y) == 2) 
+    if (do_movelist_move(chi->walking, chi->x, chi->y) == 2) 
     {
         if ((chi->flags & CHF_MOVENOTWALK) == 0)
             fix_player_sprite(&mls[chi->walking], chi);

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2887,10 +2887,10 @@ void update_room_debug()
                 mlsnum %= TURNING_AROUND;
             const MoveList &cmls = mls[mlsnum];
             for (int i = 0; i < cmls.numstage - 1; i++) {
-                short srcx = short((cmls.pos[i] >> 16) & 0x00ffff);
-                short srcy = short(cmls.pos[i] & 0x00ffff);
-                short targetx = short((cmls.pos[i + 1] >> 16) & 0x00ffff);
-                short targety = short(cmls.pos[i + 1] & 0x00ffff);
+                int srcx = cmls.pos[i].X;
+                int srcy = cmls.pos[i].Y;
+                int targetx = cmls.pos[i + 1].X;
+                int targety = cmls.pos[i + 1].Y;
                 debugMoveListObj.Bmp->DrawLine(Line(srcx / mult, srcy / mult, targetx / mult, targety / mult),
                     MakeColor(i + 1));
             }

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -56,6 +56,7 @@ enum GameStateSvgVersion
     kGSSvgVersion_350       = 1,
     kGSSvgVersion_350_9     = 2,
     kGSSvgVersion_350_10    = 3,
+    kGSSvgVersion_399       = 4,
 };
 
 

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -48,8 +48,8 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
         pos[i].X = in->ReadInt32();
         pos[i].Y = in->ReadInt32();
     }
-    in->ReadArrayOfInt32(xpermove, numstage);
-    in->ReadArrayOfInt32(ypermove, numstage);
+    in->ReadArrayOfFloat32(xpermove, numstage);
+    in->ReadArrayOfFloat32(ypermove, numstage);
     return HSaveError::None();
 }
 
@@ -70,6 +70,6 @@ void MoveList::WriteToFile(Stream *out)
         out->WriteInt32(pos[i].X);
         out->WriteInt32(pos[i].Y);
     }
-    out->WriteArrayOfInt32(xpermove, numstage);
-    out->WriteArrayOfInt32(ypermove, numstage);
+    out->WriteArrayOfFloat32(xpermove, numstage);
+    out->WriteArrayOfFloat32(ypermove, numstage);
 }

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -21,11 +21,6 @@ using namespace AGS::Engine;
 
 HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
-    if (cmp_ver < 1)
-    {
-        return new SavegameError(kSvgErr_IncompatibleEngine, "Outdated movelist format.");
-    }
-
     numstage = in->ReadInt32();
     // TODO: reimplement MoveList stages as vector to avoid these limits
     if (numstage > MAXNEEDSTAGES)
@@ -53,7 +48,7 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     return HSaveError::None();
 }
 
-void MoveList::WriteToFile(Stream *out)
+void MoveList::WriteToFile(Stream *out) const
 {
     out->WriteInt32(numstage);
     out->WriteInt32(fromx);

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -19,28 +19,11 @@
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
-void MoveList::ReadFromFile_Legacy(Stream *in)
-{
-    in->ReadArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
-    numstage = in->ReadInt32();
-    in->ReadArrayOfInt32(xpermove, MAXNEEDSTAGES_LEGACY);
-    in->ReadArrayOfInt32(ypermove, MAXNEEDSTAGES_LEGACY);
-    fromx = in->ReadInt32();
-    fromy = in->ReadInt32();
-    onstage = in->ReadInt32();
-    onpart = in->ReadInt32();
-    lastx = in->ReadInt32();
-    lasty = in->ReadInt32();
-    doneflag = in->ReadInt8();
-    direct = in->ReadInt8();
-}
-
 HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
     if (cmp_ver < 1)
     {
-        ReadFromFile_Legacy(in);
-        return HSaveError::None();
+        return new SavegameError(kSvgErr_IncompatibleEngine, "Outdated movelist format.");
     }
 
     numstage = in->ReadInt32();
@@ -60,7 +43,11 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 
-    in->ReadArrayOfInt32(pos, numstage);
+    for (int i = 0; i < numstage; ++i)
+    {
+        pos[i].X = in->ReadInt32();
+        pos[i].Y = in->ReadInt32();
+    }
     in->ReadArrayOfInt32(xpermove, numstage);
     in->ReadArrayOfInt32(ypermove, numstage);
     return HSaveError::None();
@@ -78,7 +65,11 @@ void MoveList::WriteToFile(Stream *out)
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
 
-    out->WriteArrayOfInt32(pos, numstage);
+    for (int i = 0; i < numstage; ++i)
+    {
+        out->WriteInt32(pos[i].X);
+        out->WriteInt32(pos[i].Y);
+    }
     out->WriteArrayOfInt32(xpermove, numstage);
     out->WriteArrayOfInt32(ypermove, numstage);
 }

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -13,7 +13,6 @@
 //=============================================================================
 #ifndef __AC_MOVE_H
 #define __AC_MOVE_H
-#include <allegro.h> // fixed math
 #include "game/savegame.h"
 #include "util/geometry.h"
 
@@ -22,12 +21,11 @@ namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
 #define MAXNEEDSTAGES 256
-#define MAXNEEDSTAGES_LEGACY 40
 
 struct MoveList {
     Point pos[MAXNEEDSTAGES]{};
     int   numstage = 0;
-    fixed xpermove[MAXNEEDSTAGES]{}, ypermove[MAXNEEDSTAGES]{};
+    float xpermove[MAXNEEDSTAGES]{}, ypermove[MAXNEEDSTAGES]{};
     int   fromx = 0, fromy = 0;
     int   onstage = 0, onpart = 0;
     int   lastx = 0, lasty = 0;
@@ -36,9 +34,6 @@ struct MoveList {
 
     AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);
-
-private:
-    void ReadFromFile_Legacy(Common::Stream *in);
 };
 
 #endif // __AC_MOVE_H

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -15,6 +15,7 @@
 #define __AC_MOVE_H
 #include <allegro.h> // fixed math
 #include "game/savegame.h"
+#include "util/geometry.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
@@ -24,7 +25,7 @@ using namespace AGS; // FIXME later
 #define MAXNEEDSTAGES_LEGACY 40
 
 struct MoveList {
-    int   pos[MAXNEEDSTAGES]{};
+    Point pos[MAXNEEDSTAGES]{};
     int   numstage = 0;
     fixed xpermove[MAXNEEDSTAGES]{}, ypermove[MAXNEEDSTAGES]{};
     int   fromx = 0, fromy = 0;

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -33,7 +33,7 @@ struct MoveList {
     char  direct = 0;  // MoveCharDirect was used or not
 
     AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
-    void WriteToFile(Common::Stream *out);
+    void WriteToFile(Common::Stream *out) const;
 };
 
 #endif // __AC_MOVE_H

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -22,6 +22,13 @@ using namespace AGS; // FIXME later
 
 #define MAXNEEDSTAGES 256
 
+enum MoveListDoneFlags
+{
+    kMoveListDone_X = 0x01,
+    kMoveListDone_Y = 0x02,
+    kMoveListDone_XY = kMoveListDone_X | kMoveListDone_Y
+};
+
 struct MoveList {
     Point pos[MAXNEEDSTAGES]{};
     int   numstage = 0;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -953,9 +953,8 @@ void convert_move_path_to_room_resolution(MoveList *ml)
 
     for (int i = 0; i < ml->numstage; i++)
     {
-        uint16_t lowPart = mask_to_room_coord(ml->pos[i] & 0x0000ffff);
-        uint16_t highPart = mask_to_room_coord((ml->pos[i] >> 16) & 0x0000ffff);
-        ml->pos[i] = ((int)highPart << 16) | (lowPart & 0x0000ffff);
+        ml->pos[i].X = mask_to_room_coord(ml->pos[i].X);
+        ml->pos[i].Y = mask_to_room_coord(ml->pos[i].Y);
     }
 
     if (game.options[OPT_WALKSPEEDABSOLUTE] == 0)

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -77,8 +77,8 @@ void RoomObject::UpdateCyclingView(int ref_id)
 {
 	if (on != 1) return;
     if (moving>0) {
-      do_movelist_move(&moving,&x,&y);
-      }
+      do_movelist_move(moving, x, y);
+    }
     if (cycling==0) return;
     if (view == RoomObject::NoView) return;
     if (wait>0) { wait--; return; }

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -26,7 +26,7 @@ public:
 
     virtual void init_pathfinder() = 0;
     virtual void shutdown_pathfinder() = 0;
-    virtual void set_wallscreen(Bitmap *wallscreen) = 0;
+    virtual void set_walkablearea(Bitmap *walkablearea) = 0;
     virtual int can_see_from(int x1, int y1, int x2, int y2) = 0;
     virtual void get_lastcpos(int &lastcx, int &lastcy) = 0;
     virtual void set_route_move_speed(int speed_x, int speed_y) = 0;
@@ -45,9 +45,9 @@ public:
     { 
         AGS::Engine::RouteFinder::shutdown_pathfinder(); 
     }
-    void set_wallscreen(Bitmap *wallscreen) override
+    void set_walkablearea(Bitmap *walkablearea) override
     { 
-        AGS::Engine::RouteFinder::set_wallscreen(wallscreen);
+        AGS::Engine::RouteFinder::set_walkablearea(walkablearea);
     }
     int can_see_from(int x1, int y1, int x2, int y2) override
     { 
@@ -82,9 +82,9 @@ public:
     { 
         AGS::Engine::RouteFinderLegacy::shutdown_pathfinder(); 
     }
-    void set_wallscreen(Bitmap *wallscreen) override
+    void set_walkablearea(Bitmap *walkablearea) override
     { 
-        AGS::Engine::RouteFinderLegacy::set_wallscreen(wallscreen); 
+        AGS::Engine::RouteFinderLegacy::set_walkablearea(walkablearea); 
     }
     int can_see_from(int x1, int y1, int x2, int y2) override
     { 
@@ -132,9 +132,9 @@ void shutdown_pathfinder()
         route_finder_impl->shutdown_pathfinder();
 }
 
-void set_wallscreen(Bitmap *wallscreen)
+void set_walkablearea(Bitmap *walkablearea)
 {
-    route_finder_impl->set_wallscreen(wallscreen);
+    route_finder_impl->set_walkablearea(walkablearea);
 }
 
 int can_see_from(int x1, int y1, int x2, int y2)

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -24,7 +24,7 @@ struct MoveList;
 void init_pathfinder(GameDataVersion game_file_version);
 void shutdown_pathfinder();
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+void set_walkablearea(AGS::Common::Bitmap *walkablearea);
 
 int can_see_from(int x1, int y1, int x2, int y2);
 void get_lastcpos(int &lastcx, int &lastcy);

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -43,7 +43,7 @@ namespace RouteFinder {
 static const int MAXNAVPOINTS = MAXNEEDSTAGES;
 static Point navpoints[MAXNAVPOINTS];
 static int num_navpoints;
-static fixed move_speed_x, move_speed_y;
+static float move_speed_x, move_speed_y;
 static Navigation nav;
 static Bitmap *wallscreen;
 static int lastcx, lastcy;
@@ -121,17 +121,17 @@ void set_route_move_speed(int speed_x, int speed_y)
 {
   // negative move speeds like -2 get converted to 1/2
   if (speed_x < 0) {
-    move_speed_x = itofix(1) / (-speed_x);
+    move_speed_x = 1.0 / (-speed_x);
   }
   else {
-    move_speed_x = itofix(speed_x);
+    move_speed_x = speed_x;
   }
 
   if (speed_y < 0) {
-    move_speed_y = itofix(1) / (-speed_y);
+    move_speed_y = 1.0 / (-speed_y);
   }
   else {
-    move_speed_y = itofix(speed_y);
+    move_speed_y = speed_y;
   }
 }
 
@@ -170,10 +170,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  fixed xdist = itofix(abs(ourx - destx));
-  fixed ydist = itofix(abs(oury - desty));
+  float xdist = abs(ourx - destx);
+  float ydist = abs(oury - desty);
 
-  fixed useMoveSpeed;
+  float useMoveSpeed;
 
   if (move_speed_x == move_speed_y) {
     useMoveSpeed = move_speed_x;
@@ -181,27 +181,28 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
   else {
     // different X and Y move speeds
     // the X proportion of the movement is (x / (x + y))
-    fixed xproportion = fixdiv(xdist, (xdist + ydist));
+    float xproportion = xdist / (xdist + ydist);
 
+    // TODO: Investigate why the following comments are the opposite of what's being done
     if (move_speed_x > move_speed_y) {
       // speed = y + ((1 - xproportion) * (x - y))
-      useMoveSpeed = move_speed_y + fixmul(xproportion, move_speed_x - move_speed_y);
+      useMoveSpeed = move_speed_y + (xproportion * (move_speed_x - move_speed_y));
     }
     else {
       // speed = x + (xproportion * (y - x))
-      useMoveSpeed = move_speed_x + fixmul(itofix(1) - xproportion, move_speed_y - move_speed_x);
+      useMoveSpeed = move_speed_x + ((1 - xproportion) * (move_speed_y - move_speed_x));
     }
   }
 
-  fixed angl = fixatan(fixdiv(ydist, xdist));
+  float angl = atan(ydist / xdist);
 
   // now, since new opp=hyp*sin, work out the Y step size
   //fixed newymove = useMoveSpeed * fsin(angl);
-  fixed newymove = fixmul(useMoveSpeed, fixsin(angl));
+  float newymove = useMoveSpeed * sin(angl);
 
   // since adj=hyp*cos, work out X step size
   //fixed newxmove = useMoveSpeed * fcos(angl);
-  fixed newxmove = fixmul(useMoveSpeed, fixcos(angl));
+  float newxmove = useMoveSpeed * cos(angl);
 
   if (destx < ourx)
     newxmove = -newxmove;

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -39,10 +39,9 @@ namespace AGS {
 namespace Engine {
 namespace RouteFinder {
 
-#define MAKE_INTCOORD(x,y) (((unsigned short)x << 16) | ((unsigned short)y))
 
 static const int MAXNAVPOINTS = MAXNEEDSTAGES;
-static int navpoints[MAXNAVPOINTS];
+static Point navpoints[MAXNAVPOINTS];
 static int num_navpoints;
 static fixed move_speed_x, move_speed_y;
 static Navigation nav;
@@ -112,7 +111,7 @@ static int find_route_jps(int fromx, int fromy, int destx, int desty)
     int x, y;
     nav.UnpackSquare(cpath[i], x, y);
 
-    navpoints[num_navpoints++] = MAKE_INTCOORD(x, y);
+    navpoints[num_navpoints++] = { x, y };
   }
 
   return 1;
@@ -147,10 +146,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  short ourx = (mlsp->pos[aaa] >> 16) & 0x000ffff;
-  short oury = (mlsp->pos[aaa] & 0x000ffff);
-  short destx = ((mlsp->pos[aaa + 1] >> 16) & 0x000ffff);
-  short desty = (mlsp->pos[aaa + 1] & 0x000ffff);
+  int ourx = mlsp->pos[aaa].X;
+  int oury = mlsp->pos[aaa].Y;
+  int destx = mlsp->pos[aaa + 1].X;
+  int desty = mlsp->pos[aaa + 1].Y;
 
   // Special case for vertical and horizontal movements
   if (ourx == destx) {
@@ -225,8 +224,8 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   if (ignore_walls || can_see_from(srcx, srcy, xx, yy))
   {
     num_navpoints = 2;
-    navpoints[0] = MAKE_INTCOORD(srcx, srcy);
-    navpoints[1] = MAKE_INTCOORD(xx, yy);
+    navpoints[0] = { srcx, srcy };
+    navpoints[1] = { xx, yy };
   } else {
     if ((nocross == 0) && (wallscreen->GetPixel(xx, yy) == 0))
       return 0; // clicked on a wall
@@ -249,7 +248,7 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
 
   int mlist = movlst;
   mls[mlist].numstage = num_navpoints;
-  memcpy(&mls[mlist].pos[0], &navpoints[0], sizeof(int) * num_navpoints);
+  memcpy(&mls[mlist].pos[0], &navpoints[0], sizeof(Point) * num_navpoints);
 #ifdef DEBUG_PATHFINDER
   AGS::Common::Debug::Printf("stages: %d\n",num_navpoints);
 #endif

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -28,7 +28,7 @@ namespace RouteFinder {
 void init_pathfinder();
 void shutdown_pathfinder();
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+void set_walkablearea(AGS::Common::Bitmap *walkablearea);
 
 int can_see_from(int x1, int y1, int x2, int y2);
 void get_lastcpos(int &lastcx, int &lastcy);

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -52,8 +52,8 @@ static int *pathbacky = nullptr;
 static int waspossible = 1;
 static int suggestx;
 static int suggesty;
-static fixed move_speed_x;
-static fixed move_speed_y;
+static float move_speed_x;
+static float move_speed_y;
 
 void init_pathfinder()
 {
@@ -642,17 +642,17 @@ void set_route_move_speed(int speed_x, int speed_y)
 {
   // negative move speeds like -2 get converted to 1/2
   if (speed_x < 0) {
-    move_speed_x = itofix(1) / (-speed_x);
+    move_speed_x = 1.0 / (-speed_x);
   }
   else {
-    move_speed_x = itofix(speed_x);
+    move_speed_x = speed_x;
   }
 
   if (speed_y < 0) {
-    move_speed_y = itofix(1) / (-speed_y);
+    move_speed_y = 1.0 / (-speed_y);
   }
   else {
-    move_speed_y = itofix(speed_y);
+    move_speed_y = speed_y;
   }
 }
 
@@ -692,10 +692,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  fixed xdist = itofix(abs(ourx - destx));
-  fixed ydist = itofix(abs(oury - desty));
+  float xdist = abs(ourx - destx);
+  float ydist = abs(oury - desty);
 
-  fixed useMoveSpeed;
+  float useMoveSpeed;
 
   if (move_speed_x == move_speed_y) {
     useMoveSpeed = move_speed_x;
@@ -703,27 +703,28 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
   else {
     // different X and Y move speeds
     // the X proportion of the movement is (x / (x + y))
-    fixed xproportion = fixdiv(xdist, (xdist + ydist));
+    float xproportion = (xdist / (xdist + ydist));
 
+    // TODO: Investigate why the following comments are the opposite of what's being done
     if (move_speed_x > move_speed_y) {
       // speed = y + ((1 - xproportion) * (x - y))
-      useMoveSpeed = move_speed_y + fixmul(xproportion, move_speed_x - move_speed_y);
+      useMoveSpeed = move_speed_y + (xproportion * (move_speed_x - move_speed_y));
     }
     else {
       // speed = x + (xproportion * (y - x))
-      useMoveSpeed = move_speed_x + fixmul(itofix(1) - xproportion, move_speed_y - move_speed_x);
+      useMoveSpeed = move_speed_x + ((1 - xproportion) * (move_speed_y - move_speed_x));
     }
   }
 
-  fixed angl = fixatan(fixdiv(ydist, xdist));
+  float angl = atan(ydist / xdist);
 
   // now, since new opp=hyp*sin, work out the Y step size
   //fixed newymove = useMoveSpeed * fsin(angl);
-  fixed newymove = fixmul(useMoveSpeed, fixsin(angl));
+  float newymove = (useMoveSpeed * sin(angl));
 
   // since adj=hyp*cos, work out X step size
   //fixed newxmove = useMoveSpeed * fcos(angl);
-  fixed newxmove = fixmul(useMoveSpeed, fixcos(angl));
+  float newxmove = (useMoveSpeed * cos(angl));
 
   if (destx < ourx)
     newxmove = -newxmove;

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -656,8 +656,7 @@ void set_route_move_speed(int speed_x, int speed_y)
   }
 }
 
-// Calculates the X and Y per game loop, for this stage of the
-// movelist
+// Calculates the X and Y per game loop, for this stage of the movelist
 void calculate_move_stage(MoveList * mlsp, int aaa)
 {
   assert(mlsp != nullptr);
@@ -669,10 +668,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  short ourx = (mlsp->pos[aaa] >> 16) & 0x000ffff;
-  short oury = (mlsp->pos[aaa] & 0x000ffff);
-  short destx = ((mlsp->pos[aaa + 1] >> 16) & 0x000ffff);
-  short desty = (mlsp->pos[aaa + 1] & 0x000ffff);
+  int ourx = mlsp->pos[aaa].X;
+  int oury = mlsp->pos[aaa].Y;
+  int destx = mlsp->pos[aaa + 1].X;
+  int desty = mlsp->pos[aaa + 1].Y;
 
   // Special case for vertical and horizontal movements
   if (ourx == destx) {
@@ -742,7 +741,6 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
 }
 
 
-#define MAKE_INTCOORD(x,y) (((unsigned short)x << 16) | ((unsigned short)y))
 
 int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int movlst, int nocross, int ignore_walls)
 {
@@ -801,14 +799,16 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   }
 
   if (pathbackstage >= 0) {
-    int nearestpos = 0, nearestindx;
-    int reallyneed[MAXNEEDSTAGES], numstages = 0;
-    reallyneed[numstages] = MAKE_INTCOORD(srcx,srcy);
+    Point nearestpos = { 0, 0 };
+    int nearestindx;
+    Point reallyneed[MAXNEEDSTAGES];
+    int numstages = 0;
+    reallyneed[numstages] = { srcx,srcy };
     numstages++;
     nearestindx = -1;
 
 stage_again:
-    nearestpos = 0;
+    nearestpos = {0, 0};
     aaa = 1;
     // find the furthest point that can be seen from this stage
     for (aaa = pathbackstage - 1; aaa >= 0; aaa--) {
@@ -816,26 +816,26 @@ stage_again:
       AGS::Common::Debug::Printf("stage %2d: %2d,%2d\n",aaa,pathbackx[aaa],pathbacky[aaa]);
 #endif
       if (can_see_from(srcx, srcy, pathbackx[aaa], pathbacky[aaa])) {
-        nearestpos = MAKE_INTCOORD(pathbackx[aaa], pathbacky[aaa]);
+        nearestpos = { pathbackx[aaa], pathbacky[aaa] };
         nearestindx = aaa;
       }
     }
 
-    if ((nearestpos == 0) && (can_see_from(srcx, srcy, xx, yy) == 0) &&
+    if ( nearestpos.Equals(0,0) && (can_see_from(srcx, srcy, xx, yy) == 0) &&
         (srcx >= 0) && (srcy >= 0) && (srcx < wallscreen->GetWidth()) && (srcy < wallscreen->GetHeight()) && (pathbackstage > 0)) {
       // If we couldn't see anything, we're stuck in a corner so advance
       // to the next square anyway (but only if they're on the screen)
       nearestindx = pathbackstage - 1;
-      nearestpos = MAKE_INTCOORD(pathbackx[nearestindx], pathbacky[nearestindx]);
+      nearestpos = { pathbackx[nearestindx], pathbacky[nearestindx] };
     }
 
-    if (nearestpos > 0) {
+    if ( (nearestpos.X + nearestpos.Y) > 0) {
       reallyneed[numstages] = nearestpos;
       numstages++;
       if (numstages >= MAXNEEDSTAGES - 1)
         quit("too many stages for auto-walk");
-      srcx = (nearestpos >> 16) & 0x000ffff;
-      srcy = nearestpos & 0x000ffff;
+      srcx = nearestpos.X;
+      srcy = nearestpos.Y;
 #ifdef DEBUG_PATHFINDER
      AGS::Common::Debug::Printf("Added: %d, %d pbs:%d",srcx,srcy,pathbackstage);
 #endif
@@ -844,13 +844,13 @@ stage_again:
     }
 
     if (finalpartx >= 0) {
-      reallyneed[numstages] = MAKE_INTCOORD(finalpartx, finalparty);
+      reallyneed[numstages] = { finalpartx, finalparty };
       numstages++;
     }
 
     // Make sure the end co-ord is in there
-    if (reallyneed[numstages - 1] != MAKE_INTCOORD(xx, yy)) {
-      reallyneed[numstages] = MAKE_INTCOORD(xx, yy);
+    if ( !reallyneed[numstages - 1].Equals(xx, yy) ) {
+      reallyneed[numstages] = { xx, yy };
       numstages++;
     }
 
@@ -862,7 +862,7 @@ stage_again:
 #endif
     int mlist = movlst;
     mls[mlist].numstage = numstages;
-    memcpy(&mls[mlist].pos[0], &reallyneed[0], sizeof(int) * numstages);
+    memcpy(&mls[mlist].pos[0], &reallyneed[0], sizeof(Point) * numstages);
 #ifdef DEBUG_PATHFINDER
     AGS::Common::Debug::Printf("stages: %d\n",numstages);
 #endif

--- a/Engine/ac/route_finder_impl_legacy.h
+++ b/Engine/ac/route_finder_impl_legacy.h
@@ -26,7 +26,7 @@ namespace RouteFinderLegacy {
 void init_pathfinder();
 void shutdown_pathfinder();
 
-void set_wallscreen(AGS::Common::Bitmap *wallscreen);
+void set_walkablearea(AGS::Common::Bitmap *walkablearea);
 
 int can_see_from(int x1, int y1, int x2, int y2);
 void get_lastcpos(int &lastcx, int &lastcy);

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -66,8 +66,8 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
   MoveList*cmls; cmls=&mls[mlnum[0]];
   fixed xpermove=cmls->xpermove[cmls->onstage],ypermove=cmls->ypermove[cmls->onstage];
 
-  short targetx=short((cmls->pos[cmls->onstage+1] >> 16) & 0x00ffff);
-  short targety=short(cmls->pos[cmls->onstage+1] & 0x00ffff);
+  int targetx = cmls->pos[cmls->onstage+1].X;
+  int targety = cmls->pos[cmls->onstage+1].Y;
   int xps=xx[0],yps=yy[0];
   if (cmls->doneflag & 1) {
     // if the X-movement has finished, and the Y-per-move is < 1, finish
@@ -150,11 +150,8 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
 
   if ((cmls->doneflag & 0x03)==3) {
     // this stage is done, go on to the next stage
-    // signed shorts to ensure that numbers like -20 do not become 65515
-    cmls->fromx=(signed short)((cmls->pos[cmls->onstage+1] >> 16) & 0x000ffff);
-    cmls->fromy=(signed short)(cmls->pos[cmls->onstage+1] & 0x000ffff);
-    if ((cmls->fromx > 65000) || (cmls->fromy > 65000))
-      quit("do_movelist: int to short rounding error");
+    cmls->fromx=cmls->pos[cmls->onstage+1].X;
+    cmls->fromy=cmls->pos[cmls->onstage+1].Y;
 
     cmls->onstage++; cmls->onpart=-1; cmls->doneflag&=0xf0;
     cmls->lastx=-1;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -65,17 +65,19 @@ bool movelist_float_equals(float a, float b) {
   return fabs(a - b) < 0.0001;
 }
 
-int do_movelist_move(short*mlnum,int*xx,int*yy) {
+// Receives and modifies movelist_id and entity coordinates
+// Returns whether to there's a need to update the sprite due to a change in direction
+int do_movelist_move(short &movelist_id, int &xx, int &yy) {
+  // TODO: make sense of contradicting comments
   int need_to_fix_sprite=0;
-  if (mlnum[0]<1) quit("movelist_move: attempted to move on a non-exist movelist");
-  MoveList*cmls; cmls=&mls[mlnum[0]];
+  if (movelist_id<1) quit("movelist_move: attempted to move on a non-existent movelist");
+  MoveList* cmls = &mls[movelist_id];
   float xpermove=cmls->xpermove[cmls->onstage],ypermove=cmls->ypermove[cmls->onstage];
-  const float delta = 0.0001; // not sure what kind of precision we need in this context
 
   int targetx = cmls->pos[cmls->onstage+1].X;
   int targety = cmls->pos[cmls->onstage+1].Y;
-  int xps=xx[0],yps=yy[0];
-  if (cmls->doneflag & 1) {
+  int xps=xx, yps=yy; // the new position that will be assigned to xx and yy
+  if (cmls->doneflag & kMoveListDone_X) {
     // if the X-movement has finished, and the Y-per-move is < 1, finish
     // This can cause jump at the end, but without it the character will
     // walk on the spot for a while if the Y-per-move is for example 0.2
@@ -104,7 +106,7 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
   }
   else xps=cmls->fromx+(int)(xpermove*(float)cmls->onpart);
 
-  if (cmls->doneflag & 2) {
+  if (cmls->doneflag & kMoveListDone_Y) {
     // Y-movement has finished
 
     int adjAmnt = 3;
@@ -127,12 +129,13 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
 /*    int xpmm=(xpermove >> 16) & 0x0000ffff;
 //    if ((xpmm==0) | (xpmm==0xffff)) cmls->doneflag|=1;
     if (xpmm==0) cmls->doneflag|=1;*/
-    }
+  }
   else yps=cmls->fromy+(int)(ypermove*(float)cmls->onpart);
+
   // check if finished horizontal movement
   if (((xpermove > 0) && (xps >= targetx)) ||
       ((xpermove < 0) && (xps <= targetx))) {
-    cmls->doneflag|=1;
+    cmls->doneflag |= kMoveListDone_X;
     xps = targetx;
     // if the Y is almost there too, finish it
     // this is new in v2.40
@@ -141,39 +144,44 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
       yps = targety;*/
   }
   else if (xpermove == 0)
-    cmls->doneflag|=1;
+    cmls->doneflag |= kMoveListDone_X;
+
   // check if finished vertical movement
   if ((ypermove > 0) & (yps>=targety)) {
-    cmls->doneflag|=2;
+    cmls->doneflag |= kMoveListDone_Y;
     yps = targety;
   }
   else if ((ypermove < 0) & (yps<=targety)) {
-    cmls->doneflag|=2;
+    cmls->doneflag |= kMoveListDone_Y;
     yps = targety;
   }
   else if (ypermove == 0)
-    cmls->doneflag|=2;
+    cmls->doneflag |= kMoveListDone_Y;
 
-  if ((cmls->doneflag & 0x03)==3) {
+  if ((cmls->doneflag & kMoveListDone_XY) == kMoveListDone_XY) {
     // this stage is done, go on to the next stage
     cmls->fromx=cmls->pos[cmls->onstage+1].X;
     cmls->fromy=cmls->pos[cmls->onstage+1].Y;
 
-    cmls->onstage++; cmls->onpart=-1; cmls->doneflag&=0xf0;
-    cmls->lastx=-1;
+    cmls->onstage++;
+    cmls->onpart = -1;
+    cmls->doneflag = 0; // this used to clear only the lower 4 bits, but no upper bit was ever assigned in the first place
+    cmls->lastx = -1;
     if (cmls->onstage < cmls->numstage) {
-      xps=cmls->fromx; yps=cmls->fromy; }
-    if (cmls->onstage>=cmls->numstage-1) {  // last stage is just dest pos
-      cmls->numstage=0;
-      mlnum[0]=0;
-      need_to_fix_sprite=1;
-      }
-    else need_to_fix_sprite=2;
+      xps=cmls->fromx; yps=cmls->fromy;
     }
-  cmls->onpart++;
-  xx[0]=xps; yy[0]=yps;
-  return need_to_fix_sprite;
+    if (cmls->onstage>=cmls->numstage-1) {  // last stage is just dest pos
+      cmls->numstage = 0;
+      movelist_id = 0; // movelist 0 means "not moving/walking"
+      need_to_fix_sprite = 1; // WARNING: value 1 is not used anywhere, could be a mistake
+    }
+    else need_to_fix_sprite = 2; // used to request a sprite direction update
   }
+  cmls->onpart++;
+  xx = xps;
+  yy = yps;
+  return need_to_fix_sprite;
+}
 
 
 void update_script_timers()

--- a/Engine/main/update.h
+++ b/Engine/main/update.h
@@ -18,7 +18,7 @@
 #ifndef __AGS_EE_MAIN__UPDATE_H
 #define __AGS_EE_MAIN__UPDATE_H
 
-int do_movelist_move(short*mlnum,int*xx,int*yy);
+int do_movelist_move(short &mlnum, int &xx, int &yy);
 void update_stuff();
 
 #endif // __AGS_EE_MAIN__UPDATE_H

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -778,8 +778,8 @@ int IAGSEngine::GetMovementPathLastWaypoint(int32 pathId) {
 }
 
 void IAGSEngine::GetMovementPathWaypointLocation(int32 pathId, int32 waypoint, int32 *x, int32 *y) {
-    *x = (mls[pathId % TURNING_AROUND].pos[waypoint] >> 16) & 0x0000ffff;
-    *y = (mls[pathId % TURNING_AROUND].pos[waypoint] & 0x0000ffff);
+    *x = mls[pathId % TURNING_AROUND].pos[waypoint].X;
+    *y = mls[pathId % TURNING_AROUND].pos[waypoint].Y;
 }
 
 void IAGSEngine::GetMovementPathWaypointSpeed(int32 pathId, int32 waypoint, int32 *xSpeed, int32 *ySpeed) {


### PR DESCRIPTION
I wanted to make this part more readable.
Not sure to what extent I should drag this PR but I really want to rename some stuff because last time I looked at this code I had a bad time.

Also, those `fixed` variables are some legacy from DOS era, aren't they? I could convert them to floats maybe.

Things to note:
- there are `memcpy`s in route_finder_impl.cpp and route_finder_impl_legacy.cpp
- `class Navigation` is still packing shorts into int, will look at it later
- I found a comment about implementing the movelist as a `vector`, could be the next step