### PR TITLE
Script: push_version compatible with Python 3 too

### DIFF
--- a/Script/push_version.py
+++ b/Script/push_version.py
@@ -17,7 +17,7 @@ def load_version(path):
     return AgsVersion(version, version_friendly, app_id)
 
 def read_file(path, encoding):
-    print path, encoding
+    print(path, encoding)
 
     with codecs.open(path, "r", encoding=encoding) as f:
         return f.read()


### PR DESCRIPTION
Just adding a parenthesis. Python 2 will still work with it, but python 3 won't error with the parenthesis.