### PR TITLE
Android: fix android keyboard doesn't print characters

### DIFF
--- a/Android/library/runtime/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/Android/library/runtime/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2316,7 +2316,7 @@ class DummyEdit extends View implements View.OnKeyListener {
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         ic = new SDLInputConnection(this, true);
 
-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT;
+        outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
 


### PR DESCRIPTION
fix broken keyboard text input on Android. 

Explained in details here: https://github.com/adventuregamestudio/ags/issues/1756#issuecomment-1242514082 , the right fix would be to implement IME I think, but until SDL figures what to do upstream, I think it's ok to revert to the previous behavior and fix with the other way next time we upgrade SDL2.