### PR TITLE
Mask handling improvements

### DIFF
--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -1812,7 +1812,7 @@ namespace AGS.Editor.Components
                         // if a bright colour, use it, else, draw in red
                         paletteDrawing.Entries[selectedArea] = selectedArea < 15 && selectedArea != 7 && selectedArea != 8
                             ? _agsEditor.CurrentGame.Palette[selectedArea].Colour
-                            : Color.FromArgb(60, 0, 0);
+                            : Color.FromArgb(255, 0, 0);
                     }
                 }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -512,7 +512,21 @@ namespace AGS.Editor
                 {
                     using (Bitmap bmp = _roomController.GetMask(MaskToDraw))
                     {
-                        bmp.Save(fileName, ImageFormat.Bmp);
+                        string extension = System.IO.Path.GetExtension(fileName).ToLower();
+                        ImageFormat format = null;
+                        switch (extension)
+                        {
+                            case ".bmp": format = ImageFormat.Bmp; break;
+                            case ".png": format = ImageFormat.Png; break;
+                        }
+                        if (format != null)
+                        {
+                            bmp.Save(fileName, format);
+                        }
+                        else
+                        {
+                            Factory.GUIController.ShowMessage("Invalid file extension '" + extension + "'. Format not recognised.", System.Windows.Forms.MessageBoxIcon.Warning);
+                        }
                     }
                 }
             }

--- a/Editor/AGS.Types/Constants.cs
+++ b/Editor/AGS.Types/Constants.cs
@@ -10,7 +10,7 @@ namespace AGS.Types
 		public const string AUTOCOMPLETE_ACCEPT_KEYS = "([,.=+-";
         public const string IMAGE_FILE_FILTER = "All supported images (*.bmp; *.gif; *.jpg; *.png; *.tif; *.tiff)|*.bmp;*.gif;*.jpg;*.png;*.tif;*.tiff|Windows bitmap files (*.bmp)|*.bmp|Compuserve Graphics Interchange (*.gif)|*.gif|JPEG (*.jpg)|*.jpg|Portable Network Graphics (*.png)|*.png|Tagged Image File (*.tif; *.tiff)|*.tif;*.tiff";
         public const string FONT_FILE_FILTER = "All supported fonts (font.*; *.ttf; *.wfn)|font.*;*.ttf;*.wfn|TrueType font files (*.ttf)|*.ttf|SCI font files (FONT.*)|font.*|WFN font files (*.wfn)|*.wfn";
-        public const string MASK_IMAGE_FILE_FILTER = "Windows bitmap files (*.bmp)|*.bmp";
+        public const string MASK_IMAGE_FILE_FILTER = "All supported images(*.bmp; *.png)|*.bmp;*.png|Windows bitmap files (*.bmp)|*.bmp|Portable Network Graphics (*.png)|*.png";
         public const string GAME_TEMPLATE_FILE_FILTER = "AGS game template files (*.agt)|*.agt";
         public const string ROOM_TEMPLATE_FILE_FILTER = "AGS room template files (*.art)|*.art";
 	}


### PR DESCRIPTION
- Normalizes palettes also handling partial palettes
- Safer handling of invalid masks
- Added PNG to the formats available for mask export/import
- Restored the original red color for mask brushes

