### PR TITLE
Android: reimplement touch-to-mouse controls in the engine

### DIFF
--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AGSRuntimeActivity.java
@@ -279,9 +279,4 @@ public class AGSRuntimeActivity extends SDLActivity {
         return super.dispatchKeyEvent(ev);
     }
 
-    @Keep
-    protected  void AgsEnableLongclick() {
-
-    }
-
 }

--- a/Android/library/runtime/src/main/res/values/arrays.xml
+++ b/Android/library/runtime/src/main/res/values/arrays.xml
@@ -13,6 +13,18 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="mouse_emulation">
+        <item>Off</item>
+        <item>One Finger (touch means button down)</item>
+        <item>Two Finger (tap to click)</item>
+    </string-array>
+
+    <string-array name="mouse_emulation_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
 
     <string-array name="game_language">
         <item>Default</item>

--- a/Android/library/runtime/src/main/res/values/strings.xml
+++ b/Android/library/runtime/src/main/res/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="CONFIG_GFX_SMOOTH_SPRITES">16</string>
     <string name="CONFIG_TRANSLATION">17</string>
     <string name="CONFIG_DEBUG_LOGCAT">18</string>
-    <string name="CONFIG_MOUSE_METHOD">19</string>
-    <string name="CONFIG_MOUSE_LONGCLICK">20</string>
+    <string name="CONFIG_MOUSE_EMULATION">19</string>
+    <string name="CONFIG_MOUSE_METHOD">20</string>
     <string name="toggle_keyboard">Toggle keyboard</string>
     <string name="exit_game">Exit game</string>
 

--- a/Android/library/runtime/src/main/res/xml/preferences.xml
+++ b/Android/library/runtime/src/main/res/xml/preferences.xml
@@ -36,6 +36,16 @@
     <androidx.preference.PreferenceCategory
         android:key="preference_key_controls"
         android:title="Controls">
+        <androidx.preference.ListPreference
+            android:dependency="@string/CONFIG_ENABLED"
+            android:dialogTitle="Touch-to-mouse emulation scheme"
+            android:entries="@array/mouse_emulation"
+            android:entryValues="@array/mouse_emulation_values"
+            android:key="@string/CONFIG_MOUSE_EMULATION"
+            android:persistent="false"
+            android:shouldDisableView="true"
+            android:summary="A control scheme for emulating mouse actions with touch screen"
+            android:title="Touch-to-mouse emulation" />
         <androidx.preference.CheckBoxPreference
             android:dependency="@string/CONFIG_ENABLED"
             android:key="@string/CONFIG_MOUSE_METHOD"
@@ -43,14 +53,6 @@
             android:shouldDisableView="true"
             android:summary="The mouse gets moved relative to the finger motion"
             android:title="Relative mouse control" />
-
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_MOUSE_LONGCLICK"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="A longclick keeps the left mouse button pressed"
-            android:title="Dragging with longclick" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -18,6 +18,7 @@
 #ifndef __AGS_CN_UTIL__GEOMETRY_H
 #define __AGS_CN_UTIL__GEOMETRY_H
 
+#include <cmath>
 #include "util/math.h"
 
 namespace AGSMath = AGS::Common::Math;
@@ -386,6 +387,12 @@ struct Circle
 
 };
 
+
+// Calculates a distance between two points
+inline float DistanceBetween(const Point &p1, const Point &p2)
+{
+    return std::sqrt(((p2.X - p1.X) ^ 2) + ((p2.Y - p1.Y) ^ 2));
+}
 
 // Tells if two rectangles intersect (overlap) at least partially
 bool AreRectsIntersecting(const Rect &r1, const Rect &r2);

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -391,7 +391,7 @@ struct Circle
 // Calculates a distance between two points
 inline float DistanceBetween(const Point &p1, const Point &p2)
 {
-    return std::sqrt(((p2.X - p1.X) ^ 2) + ((p2.Y - p1.Y) ^ 2));
+    return static_cast<float>(std::sqrt(((p2.X - p1.X) ^ 2) + ((p2.Y - p1.Y) ^ 2)));
 }
 
 // Tells if two rectangles intersect (overlap) at least partially

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -28,6 +28,7 @@ GameSetup::GameSetup()
     mouse_ctrl_when = kMouseCtrl_Fullscreen;
     mouse_ctrl_enabled = false;
     mouse_speed_def = kMouseSpeed_CurrentDisplay;
+    touch_emulate_mouse = kTouchMouse_OneFingerDrag;
     RenderAtScreenRes = false;
     Supersampling = 1;
     clear_cache_on_room_change = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -48,10 +48,11 @@ enum TouchMouseEmulation
 {
     // don't emulate mouse
     kTouchMouse_None = 0,
+    // copy default SDL2 behavior:
     // touch down means hold LMB down, no RMB emulation
     kTouchMouse_OneFingerDrag,
     // tap 1,2 fingers means LMB/RMB click;
-    // longpress means stick LMB/RMB down until next tap
+    // double tap + drag 1 finger would drag the cursor with LMB down
     kTouchMouse_TwoFingersTap
 };
 

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -44,6 +44,17 @@ enum ScreenRotation
     kNumScreenRotationOptions
 };
 
+enum TouchMouseEmulation
+{
+    // don't emulate mouse
+    kTouchMouse_None = 0,
+    // touch down means hold LMB down, no RMB emulation
+    kTouchMouse_OneFingerDrag,
+    // tap 1,2 fingers means LMB/RMB click;
+    // longpress means stick LMB/RMB down until next tap
+    kTouchMouse_TwoFingersTap
+};
+
 using AGS::Common::String;
 
 // TODO: reconsider the purpose of this struct in the future.
@@ -79,6 +90,9 @@ struct GameSetup
     MouseControlWhen mouse_ctrl_when;
     bool  mouse_ctrl_enabled;
     MouseSpeedDef mouse_speed_def;
+    // touch-to-mouse emulation mode
+    int   touch_emulate_mouse;
+    //
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;
     size_t SpriteCacheSize = 0u;

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -70,8 +70,6 @@ void mgetgraphpos()
 {
     // TODO: review and possibly rewrite whole thing;
     // research what disable_mgetgraphpos does, and is this still necessary?
-    // disable or update mouse speed control to sdl
-    // (does sdl support mouse cursor speed? is it even necessary anymore?);
 
     // TODO: [sonneveld] find out where mgetgraphpos is needed, are events polled before that?
     sys_evt_process_pending();
@@ -97,8 +95,10 @@ void mgetgraphpos()
         // Use relative mouse movement; speed factor should already be applied by SDL in this mode
         int rel_x, rel_y;
         ags_mouse_get_relxy(rel_x, rel_y);
+        Point old_pos = Point(real_mouse_x, real_mouse_y);
         real_mouse_x = Math::Clamp(real_mouse_x + rel_x, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
         real_mouse_y = Math::Clamp(real_mouse_y + rel_y, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
+        Debug::Printf("mouse control: real was %d,%d; rel = %d,%d; result = %d,%d", old_pos.X, old_pos.Y, rel_x, rel_y, real_mouse_x, real_mouse_y);
     }
     else
     {
@@ -208,7 +208,8 @@ void Mouse::SetMovementControl(bool on)
         SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE, "1.0");
 #else
     ControlEnabled = false;
-    Debug::Printf(kDbgMsg_Warn, "WARNING: SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE not supported, mouse control can't be enabled");
+    if (on)
+        Debug::Printf(kDbgMsg_Warn, "WARNING: SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE not supported, mouse control can't be enabled");
 #endif
     ags_clear_mouse_movement();
 }

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -95,10 +95,8 @@ void mgetgraphpos()
         // Use relative mouse movement; speed factor should already be applied by SDL in this mode
         int rel_x, rel_y;
         ags_mouse_get_relxy(rel_x, rel_y);
-        Point old_pos = Point(real_mouse_x, real_mouse_y);
         real_mouse_x = Math::Clamp(real_mouse_x + rel_x, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
         real_mouse_y = Math::Clamp(real_mouse_y + rel_y, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
-        Debug::Printf("mouse control: real was %d,%d; rel = %d,%d; result = %d,%d", old_pos.X, old_pos.Y, rel_x, rel_y, real_mouse_x, real_mouse_y);
     }
     else
     {

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -372,6 +372,9 @@ void apply_config(const ConfigTree &cfg)
         usetup.mouse_speed_def = StrUtil::ParseEnum<MouseSpeedDef>(
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
+        // Touch options
+        usetup.touch_emulate_mouse = CfgReadInt(cfg, "touch", "emulate_mouse", 1);
+
         // Various system options
         usetup.multitasking = CfgReadInt(cfg, "misc", "background", 0) != 0;
 

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -94,8 +94,8 @@ const int CONFIG_DEBUG_FPS = 15;
 const int CONFIG_GFX_SMOOTH_SPRITES = 16;
 const int CONFIG_TRANSLATION = 17;
 const int CONFIG_DEBUG_LOGCAT = 18;
-const int CONFIG_MOUSE_METHOD = 19;
-const int CONFIG_MOUSE_LONGCLICK = 20;
+const int CONFIG_MOUSE_EMULATION = 19;
+const int CONFIG_MOUSE_METHOD = 20;
 
 JNIEXPORT jboolean JNICALL
   Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_readConfigFile(JNIEnv* env, jobject object, jstring directory)
@@ -160,10 +160,10 @@ JNIEXPORT jint JNICALL
       return setup.show_fps;
     case CONFIG_DEBUG_LOGCAT:
       return setup.debug_write_to_logcat;
+    case CONFIG_MOUSE_EMULATION:
+      return setup.mouse_emulation;
     case CONFIG_MOUSE_METHOD:
       return setup.mouse_control_mode;
-    case CONFIG_MOUSE_LONGCLICK:
-      return setup.mouse_longclick;
     default:
       return 0;
   }
@@ -245,11 +245,11 @@ JNIEXPORT void JNICALL
     case CONFIG_DEBUG_LOGCAT:
       setup.debug_write_to_logcat = value;
       break;
+    case CONFIG_MOUSE_EMULATION:
+      setup.mouse_emulation = value;
+      break;
     case CONFIG_MOUSE_METHOD:
       setup.mouse_control_mode = value;
-      break;
-    case CONFIG_MOUSE_LONGCLICK:
-      setup.mouse_longclick = value;
       break;
     default:
       break;
@@ -379,11 +379,6 @@ void AGSAndroid::MainInit()
 
     // Read game specific configuration.
     ::ReadConfiguration(setup, ANDROID_CONFIG_FILENAME, false);
-
-    if (setup.mouse_longclick > 0) {
-        jmethodID method_id = env->GetMethodID(clazz, "AgsEnableLongclick", "()V");
-        env->CallVoidMethod(activity, method_id);
-    }
 
     setup.load_latest_savegame = loadLastSave;
 

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -26,8 +26,8 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
     CfgWriteInt(cfg, "misc", "rotation", setup.rotation);
     CfgWriteString(cfg, "misc", "translation", setup.translation);
 
+    CfgWriteInt(cfg, "controls", "mouse_emulation", setup.mouse_emulation);
     CfgWriteInt(cfg, "controls", "mouse_method", setup.mouse_control_mode);
-    CfgWriteInt(cfg, "controls", "mouse_longclick", setup.mouse_longclick);
 
     CfgWriteInt(cfg, "compatibility", "clear_cache_on_room_change", setup.clear_cache_on_room_change);
 
@@ -95,8 +95,8 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
     setup.gfx_super_sampling = CfgReadBoolInt(cfg, "graphics", "super_sampling", true);
     setup.gfx_smooth_sprites = CfgReadBoolInt(cfg, "graphics", "smooth_sprites", true);
 
+    setup.mouse_emulation = CfgReadInt(cfg, "controls", "mouse_emulation", 0, 2, 1);
     setup.mouse_control_mode = CfgReadInt(cfg, "controls", "mouse_method", 0, 1, 0);
-    setup.mouse_longclick = CfgReadBoolInt(cfg, "controls", "mouse_longclick", true);
 
     return true;
 }
@@ -159,6 +159,11 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
     CfgWriteInt(cfg, "sound", "enabled", setup.audio_enabled);
     CfgWriteInt(cfg, "sound", "cache_size", setup.audio_cachesize);
 
+    // touch-to-mouse emulation mode
+    //    * 0 - off
+    //    * 1 - one finger (holding, dragging)
+    //    * 2 - two fingers (tapping)
+    CfgWriteInt(cfg, "touch", "emulate_mouse", setup.mouse_emulation);
     // mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls
     //    * 0 - direct touch mouse control

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -30,7 +30,8 @@ struct MobileSetup
     AGS::Common::String translation;
 
     // Mouse option
-    int mouse_control_mode = 0;
+    int mouse_emulation = 1; // off, one finger, two fingers
+    int mouse_control_mode = 0; // absolute vs relative
 
     // Graphic options
     int gfx_scaling = 0;
@@ -52,8 +53,6 @@ struct MobileSetup
     int gfx_smooth_sprites = 0;
 
     int debug_write_to_logcat = 0;
-
-    int mouse_longclick = 0;
 
     int show_fps = 0;
 

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -30,6 +30,10 @@ int sys_main_init(/*config*/) {
     SDL_version version;
     SDL_GetVersion(&version);
     Debug::Printf(kDbgMsg_Info, "SDL Version: %d.%d.%d", version.major, version.minor, version.patch);
+    // Disable SDL2's own touch-to-mouse emulation:
+    // we are going to use our own in the engine, and only if requested by the user config
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
     // TODO: setup these subsystems in config rather than keep hardcoded?
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) != 0) {
         Debug::Printf(kDbgMsg_Error, "Unable to initialize SDL: %s", SDL_GetError());


### PR DESCRIPTION
This reimplements touch-to-mouse controls inside the engine, similar to the control scheme of 3.5.1 (before moving to SDL2 and new Android port), with minor differences. Touch-to-mouse emulates mouse buttons and motion, letting players to control AGS games with Android port. The 3.6.0 currently uses default SDL2 emulation, which only supports LMB, but that's not enough for games which require RMB too.

Mouse emulation is enabled using a config setting ("[touch]", "emulate_mouse"). This parameter may have several values, acting as a choice between the control schemes. Right now it supports 2 schemes: a default SDL2-like scheme and reimplementation of an old AGS scheme (see below). The touch-to-mouse may also be disabled completely. In theory, it may be disabled also by the game's own setting, which is useful, for example, if AGS will have a proper touch API in the future version (see #1538).

The SDL2's internal touch-to-mouse is disabled using hints (SDL_HINT_TOUCH_MOUSE_EVENTS and SDL_HINT_MOUSE_TOUCH_EVENTS).

Control schemes:

**1. SDL2-style. LMB drag only.**

* Only the first finger (id = 0) is tracked, others are ignored;
* Touch up and down events directly correspond to mouse up and down events; so you put finger down to press mouse button, and release a finger to release a mouse button.
* Touch motion directly corresponds to the mouse motion.

Pros: simple;
Cons: no RMB emulation, cannot move cursor without holding a button down (for example: to scan around the room without issuing any commands).

This style is more or less suitable for one-click game control scheme, and especially games with drag-n-drop controls.

**2. Classic AGS-style.**

* One finger tap is LMB (mouse click issued when you *release* the finger);
* Two finger tap is RMB; you may hold 1st finger and keep tapping 2nd finger to keep "clicking" RMB, - this may be used for instance to cycle verbs in Sierra-style games.
* Dragging a finger means mouse movement, but without a button down.
* Double tap + drag: means mouse movement with LMB down. This means you have to quickly tap once and then press finger again to start a drag. This is implemented after another user's suggestion in the old ticket #275, also mentioned in #1716. The original method to start a drag was long-click, but I had concerns that it's not obvious when the dragging starts. With double tap it's more explicit, in my opinion.

**Potential TODO:**
* Add control scheme selection to the AGS Player's preferences and save to android.cfg.
* Tidy code by gathering variables into structs.
