### PR TITLE
New compiler: Flag `=` in function call parameters

### DIFF
--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -791,7 +791,7 @@ private:
     // call the attribute function corresponding to LHS.
     void AccessData_AssignTo(SrcList &expression, EvaluationResult eres);
 
-    void SkipToEndOfExpression();
+    void SkipToEndOfExpression(SrcList &src);
 
     // We are parsing the left hand side of a '+=' or similar statement.
     void ParseAssignment_ReadLHSForModification(SrcList &lhs, EvaluationResult &eres);

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2501,3 +2501,22 @@ TEST_F(Compile1, LongMin03) {
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 }
+
+TEST_F(Compile1, AssignmentInParameterList1)
+{
+    // An expression cannot contain an assignment symbol '='.
+    // Each parameter must comprise an expression, no trailing symbols
+
+    const char *inpl = "\
+        int test(int x)     \n\
+        {                   \n\
+            int i = 0;      \n\
+            test(i = 99);   \n\
+        }                   \n\
+        ";
+    int compile_result = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
+    EXPECT_NE(std::string::npos, msg.find("'\='"));
+}
+


### PR DESCRIPTION
This PR addresses #1775.

When a function is called, each parameter must be an expression; it cannot be an assignment. Flag `=` in function call parameters.

Typical code: 
```
function game_start()
{
    int foo;
    Debug(4, foo = 7); // <-- Compiler should balk here
}
``` 

(Also fix an inconsistency in function `ParseExpression()` that I found when fixing this bug: This function is called with a parameter `src` but had ignored this parameter and used the field `_src` instead, which was wrong.)