### PR TITLE
Handle unterminated strings to avoid data corruption

### DIFF
--- a/Compiler/preproc/preprocessor.cpp
+++ b/Compiler/preproc/preprocessor.cpp
@@ -190,6 +190,7 @@ namespace Preprocessor {
                     size_t endOfString = text.FindChar(text[i],i);
                     if (endOfString == NOT_FOUND) //size_t is unsigned but it's alright
                     {
+                        LogError(ErrorCode::UnterminatedString, "Unterminated string");
                         break;
                     }
                     endOfString++;

--- a/Compiler/preproc/preprocessor.h
+++ b/Compiler/preproc/preprocessor.h
@@ -19,6 +19,7 @@ namespace Preprocessor {
         EndIfWithoutIf,
         IfWithoutEndIf,
         InvalidVersionNumber,
+        UnterminatedString
     };
 
     class Preprocessor {

--- a/Editor/AGS.CScript.Compiler/Entities/ErrorCode.cs
+++ b/Editor/AGS.CScript.Compiler/Entities/ErrorCode.cs
@@ -44,6 +44,7 @@ namespace AGS.CScript.Compiler
         VariableDeclarationNotAllowedHere,
         MemberFunctionNotDefined,
         ParentIsNotAStruct,
-        InvalidUseOfStruct
+        InvalidUseOfStruct,
+        UnterminatedString
 	}
 }

--- a/Editor/AGS.CScript.Compiler/Preprocessor.cs
+++ b/Editor/AGS.CScript.Compiler/Preprocessor.cs
@@ -356,6 +356,7 @@ namespace AGS.CScript.Compiler
 						int endOfString = FindIndexOfMatchingCharacter(text, i, text[i]);
 						if (endOfString < 0)
 						{
+							RecordError(ErrorCode.UnterminatedString, "Unterminated string");
 							break;
 						}
 						endOfString++;

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -218,6 +218,11 @@ namespace AGS.Editor.Components
         private void DoTranslationUpdate(IList<Translation> translations)
         {
             _agsEditor.SaveGameFiles();
+            
+            // reload current translations, in case the trs files were modified externally
+            foreach (Translation translation in translations)
+                translation.LoadData();
+
             CompileMessages messages = (CompileMessages)BusyDialog.Show("Please wait while the translation(s) are updated...", new BusyDialog.ProcessingHandler(UpdateTranslationsProcess), translations);
             _guiController.ShowOutputPanel(messages);
             if (!messages.HasErrors)

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -186,7 +186,11 @@ namespace AGS.Editor.Components
         {
             List<Translation> translations = (List<Translation>)translationList;
             TranslationGenerator generator = new TranslationGenerator();
-            CompileMessages errors = generator.CreateTranslationList(_agsEditor.CurrentGame);
+            CompileMessages messages = generator.CreateTranslationList(_agsEditor.CurrentGame);
+
+            if (messages.HasErrors)
+                return messages; // abort for avoiding corrupting translations
+
             foreach (string line in generator.LinesForTranslation)
             {
                 foreach (Translation translation in translations)
@@ -208,15 +212,18 @@ namespace AGS.Editor.Components
                     }
                 }
             }
-            return errors;
+            return messages;
         }
 
         private void DoTranslationUpdate(IList<Translation> translations)
         {
             _agsEditor.SaveGameFiles();
-            CompileMessages errors = (CompileMessages)BusyDialog.Show("Please wait while the translation(s) are updated...", new BusyDialog.ProcessingHandler(UpdateTranslationsProcess), translations);
-            _guiController.ShowOutputPanel(errors);
-            _guiController.ShowMessage("Translation(s) updated.", MessageBoxIcon.Information);
+            CompileMessages messages = (CompileMessages)BusyDialog.Show("Please wait while the translation(s) are updated...", new BusyDialog.ProcessingHandler(UpdateTranslationsProcess), translations);
+            _guiController.ShowOutputPanel(messages);
+            if (!messages.HasErrors)
+                _guiController.ShowMessage("Translation(s) updated.", MessageBoxIcon.Information);
+            else
+                _guiController.ShowMessage("Translation(s) update failed. Check the output window for details.", MessageBoxIcon.Error);
         }
 
         private void UpdateAllTranslationsWithNewDefaultText(Dictionary<string, string> textChanges, CompileMessages errors)

--- a/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
+++ b/Editor/AGS.Editor/TextProcessing/SpeechLinesNumbering.cs
@@ -72,6 +72,18 @@ namespace AGS.Editor
 				game.GlobalMessages[i] = processor.ProcessText(game.GlobalMessages[i], GameTextType.Message, Character.NARRATOR_CHARACTER_ID);
 			}
 
+            if (_errors.HasErrors)
+            {
+                // we're on a different thread here, so Invoke to show the errors
+                if (Factory.GUIController.InvokeRequired)
+                {
+                    Factory.GUIController.Invoke(new Action(() => {
+                        Factory.GUIController.ShowOutputPanel(_errors);
+                    }));
+                };
+                throw new Exception("Errors encountered. Check the output window for details.");
+            }
+
             Factory.AGSEditor.RunProcessAllGameTextsEvent(processor, _errors);
         }
 


### PR DESCRIPTION
The main goal of this PR is to prevent data loss and corruption from dealing with unclosed strings,
- Fixed the preprocessor not reporting unterminated literals
- Abort translation update on error
- Abort auto-numbering speech line on error
- Reload translation froms disk before any update operation to prevent loss of user changes

With these commits all causes of corruption and data loss, when dealing with translations and autonumbering speech, should be covered.
When something fails, the operation is aborted without applying changes.

Might be worth backporting to 3.5.1

fixes #1777,  #1022