### PR TITLE
Android: remove deprecated/unused preferences

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -97,24 +97,15 @@ The preferences modifies the `android.cfg` file, either the local or global one.
 
 #### Controls `[controls]`
 
+- **Touch-to-mouse emulation** : Off, One Finger, Two Fingers
+  `mouse_emulation = 0, 1, 2`  
 - **Relative mouse control** : yes or no  
   `mouse_method = 0, 1`  
-- **Dragging with longclick** : yes or no  
-  `mouse_longclick = 0, 1`  
 
 #### Sound `[sound]`
 
 - **Enabled** : yes or no  
   `enabled = 0, 1`  
-- **Use multithreading** : disabled, to be removed  
-  `threaded = 0, 1`  
-  
-#### Midi `[midi]`
-
-- **Enabled** : disabled, to be removed  
-  `enabled = 0, 1`  
-- **Preload patches** : disabled, to be removed  
-  `preload_patches = 0, 1`
 
 #### Video `[video]`
 

--- a/Android/library/runtime/src/main/res/values/strings.xml
+++ b/Android/library/runtime/src/main/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="title_activity_ags_settings">AgsSettingsActivity</string>
 
     <string name="CONFIG_AUDIO_ENABLED">3</string>
-    <string name="CONFIG_AUDIO_THREADED">4</string>
-    <string name="CONFIG_MIDI_ENABLED">6</string>
-    <string name="CONFIG_MIDI_PRELOAD">7</string>
     <string name="CONFIG_VIDEO_FRAMEDROP">8</string>
     <string name="CONFIG_GFX_RENDERER">9</string>
     <string name="CONFIG_GFX_SMOOTHING">10</string>

--- a/Android/library/runtime/src/main/res/xml/preferences.xml
+++ b/Android/library/runtime/src/main/res/xml/preferences.xml
@@ -64,32 +64,6 @@
             android:persistent="false"
             android:shouldDisableView="true"
             android:title="Enabled" />
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_AUDIO_THREADED"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="Reduces stuttering but throws off lipsyncing"
-            android:title="Use multithreading" />
-    </androidx.preference.PreferenceCategory>
-
-    <androidx.preference.PreferenceCategory
-        android:key="preference_key_midi"
-        android:title="Midi">
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_MIDI_ENABLED"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="Needs MIDI patches on the SD card"
-            android:title="Enabled" />
-        <androidx.preference.CheckBoxPreference
-            android:dependency="@string/CONFIG_ENABLED"
-            android:key="@string/CONFIG_MIDI_PRELOAD"
-            android:persistent="false"
-            android:shouldDisableView="true"
-            android:summary="Less delay between MIDI tracks but causes a startup delay"
-            android:title="Preload patches" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory

--- a/Android/misc/android.cfg
+++ b/Android/misc/android.cfg
@@ -3,18 +3,13 @@ config_enabled = 1
 rotation = 0
 translation = default
 [controls]
+mouse_emulation = 1
 mouse_method = 0
-mouse_longclick = 1
 [compatibility]
 clear_cache_on_room_change = 0
 [sound]
-samplerate = 44100
 enabled = 1
-threaded = 1
-cache_size = 10
-[midi]
-enabled = 1
-preload_patches = 0
+cache_size = 64
 [video]
 framedrop = 0
 [graphics]

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -41,24 +41,24 @@ namespace AGS.Editor
             int rotation = (int)setup.Rotation;
 
             NativeProxy.WritePrivateProfileString("misc", "config_enabled", "1", configPath);
+
+            // Misc options
             NativeProxy.WritePrivateProfileString("misc", "rotation", rotation.ToString(), configPath);
             NativeProxy.WritePrivateProfileString("misc", "translation", setup.Translation, configPath);
-
-            NativeProxy.WritePrivateProfileString("controls", "mouse_method", "0", configPath);
-            NativeProxy.WritePrivateProfileString("controls", "mouse_longclick", "1", configPath);
-
             NativeProxy.WritePrivateProfileString("compatibility", "clear_cache_on_room_change", "0", configPath);
 
-            NativeProxy.WritePrivateProfileString("sound", "samplerate", "44100", configPath);
+            // Touch-to-mouse options
+            NativeProxy.WritePrivateProfileString("controls", "mouse_emulation", "1", configPath);
+            NativeProxy.WritePrivateProfileString("controls", "mouse_method", "0", configPath);
+
+            // Sound options
             NativeProxy.WritePrivateProfileString("sound", "enabled", "1", configPath);
-            NativeProxy.WritePrivateProfileString("sound", "threaded", "1", configPath);
             NativeProxy.WritePrivateProfileString("sound", "cache_size", "64", configPath);
 
-            NativeProxy.WritePrivateProfileString("midi", "enabled", "0", configPath);
-            NativeProxy.WritePrivateProfileString("midi", "preload_patches", "0", configPath);
-
+            // Video options
             NativeProxy.WritePrivateProfileString("video", "framedrop", "0", configPath);
 
+            // Graphic options
             if (setup.GraphicsDriver == GraphicsDriver.Software) {
                 NativeProxy.WritePrivateProfileString("graphics", "renderer", "0", configPath);
             } else {
@@ -82,6 +82,7 @@ namespace AGS.Editor
             NativeProxy.WritePrivateProfileString("graphics", "super_sampling", "0", configPath);
             NativeProxy.WritePrivateProfileString("graphics", "smooth_sprites", setup.AAScaledSprites ? "1" : "0", configPath);
 
+            // Debug options
             NativeProxy.WritePrivateProfileString("debug", "show_fps", "0", configPath);
             NativeProxy.WritePrivateProfileString("debug", "logging", "0", configPath);
         }

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -77,12 +77,8 @@ extern "C"
 
 const int CONFIG_IGNORE_ACSETUP = 0;
 const int CONFIG_CLEAR_CACHE = 1;
-const int CONFIG_AUDIO_RATE = 2;
 const int CONFIG_AUDIO_ENABLED = 3;
-const int CONFIG_AUDIO_THREADED = 4;
 const int CONFIG_AUDIO_CACHESIZE = 5;
-const int CONFIG_MIDI_ENABLED = 6;
-const int CONFIG_MIDI_PRELOAD = 7;
 const int CONFIG_VIDEO_FRAMEDROP = 8;
 const int CONFIG_GFX_RENDERER = 9;
 const int CONFIG_GFX_SMOOTHING = 10;
@@ -128,18 +124,10 @@ JNIEXPORT jint JNICALL
       return setup.ignore_acsetup_cfg_file;
     case CONFIG_CLEAR_CACHE:
       return setup.clear_cache_on_room_change;
-    case CONFIG_AUDIO_RATE:
-      return setup.audio_samplerate;
     case CONFIG_AUDIO_ENABLED:
       return setup.audio_enabled;
-    case CONFIG_AUDIO_THREADED:
-      return setup.audio_multithreaded;
     case CONFIG_AUDIO_CACHESIZE:
       return setup.audio_cachesize;
-    case CONFIG_MIDI_ENABLED:
-      return setup.midi_enabled;
-    case CONFIG_MIDI_PRELOAD:
-      return setup.midi_preload_patches;
     case CONFIG_VIDEO_FRAMEDROP:
       return setup.video_framedrop;
     case CONFIG_GFX_RENDERER:
@@ -197,23 +185,11 @@ JNIEXPORT void JNICALL
     case CONFIG_CLEAR_CACHE:
       setup.clear_cache_on_room_change = value;
       break;
-    case CONFIG_AUDIO_RATE:
-      setup.audio_samplerate = value;
-      break;
     case CONFIG_AUDIO_ENABLED:
       setup.audio_enabled = value;
       break;
-    case CONFIG_AUDIO_THREADED:
-      setup.audio_multithreaded = value;
-      break;
     case CONFIG_AUDIO_CACHESIZE:
       setup.audio_cachesize = value;
-      break;
-    case CONFIG_MIDI_ENABLED:
-      setup.midi_enabled = value;
-      break;
-    case CONFIG_MIDI_PRELOAD:
-      setup.midi_preload_patches = value;
       break;
     case CONFIG_VIDEO_FRAMEDROP:
       setup.video_framedrop = value;

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -31,13 +31,8 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
 
     CfgWriteInt(cfg, "compatibility", "clear_cache_on_room_change", setup.clear_cache_on_room_change);
 
-    CfgWriteInt(cfg, "sound", "samplerate", setup.audio_samplerate);
     CfgWriteInt(cfg, "sound", "enabled", setup.audio_enabled);
-    CfgWriteInt(cfg, "sound", "threaded", setup.audio_multithreaded);
     CfgWriteInt(cfg, "sound", "cache_size", setup.audio_cachesize);
-
-    CfgWriteInt(cfg, "midi", "enabled", setup.midi_enabled);
-    CfgWriteInt(cfg, "midi", "preload_patches", setup.midi_preload_patches);
 
     CfgWriteInt(cfg, "video", "framedrop", setup.video_framedrop);
 
@@ -79,13 +74,8 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
 
     setup.clear_cache_on_room_change = CfgReadBoolInt(cfg, "compatibility", "clear_cache_on_room_change", false);
 
-    setup.audio_samplerate = CfgReadInt(cfg, "sound", "samplerate", 0, 44100, 44100);
     setup.audio_enabled = CfgReadBoolInt(cfg, "sound", "enabled", true);
-    setup.audio_multithreaded = CfgReadBoolInt(cfg, "sound", "threaded", true);
     setup.audio_cachesize = CfgReadInt(cfg, "sound", "cache_size", 1, 50, 10);
-
-    setup.midi_enabled = CfgReadBoolInt(cfg, "midi", "enabled", true);
-    setup.midi_preload_patches = CfgReadBoolInt(cfg, "midi", "preload_patches", false);
 
     setup.video_framedrop = CfgReadBoolInt(cfg, "video", "framedrop", true);
 

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -34,28 +34,24 @@ struct MobileSetup
     int mouse_control_mode = 0; // absolute vs relative
 
     // Graphic options
+    int gfx_renderer = 0;
     int gfx_scaling = 0;
     int gfx_smoothing = 0;
+    int gfx_super_sampling = 0;
+    int gfx_smooth_sprites = 0;
 
-    // Audio options from the Allegro library.
-    unsigned int audio_samplerate = 0;
+    // Audio options
     int audio_enabled = 0;
-    int audio_multithreaded = 0;
     int audio_cachesize = 0;
-    int midi_enabled = 0;
-    int midi_preload_patches = 0;
 
     // Video playback options
     int video_framedrop = 0;
 
-    int gfx_renderer = 0;
-    int gfx_super_sampling = 0;
-    int gfx_smooth_sprites = 0;
-
+    // Debug options
     int debug_write_to_logcat = 0;
-
     int show_fps = 0;
 
+    // Misc options
     bool load_latest_savegame = false;
 };
 


### PR DESCRIPTION
This removes following preferences that no longer have implementation in the engine:
* Sound - Use multithreading (cannot be toggled now, depends on compilation flags)
* Sound - samplerate (was not exposed to menu)
* Midi options group
