### PR TITLE
Editor: scintilla automatically highlights braces in current position

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -959,7 +959,7 @@ namespace AGS.Editor
             }
         }
 
-        private Tuple<int, int> GetBraceAndMatchingBracePositions(bool beforeCursor, bool afterCursor)
+        private Tuple<int, int> GetBraceAndMatchingBracePositions()
         {
             if (InsideStringOrComment(false))
                 return Tuple.Create(INVALID_POSITION, INVALID_POSITION);
@@ -969,8 +969,8 @@ namespace AGS.Editor
             int currentPos = scintillaControl1.CurrentPosition;
             int prevChar = scintillaControl1.GetCharAt(currentPos - 1);
             int curChar = scintillaControl1.GetCharAt(currentPos);
-            bool isBraceBefore = beforeCursor && (prevChar == '{' || prevChar == '}' || prevChar == '(' || prevChar == ')');
-            bool isBraceAfter = afterCursor && (curChar == '{' || curChar == '}' || curChar == '(' || curChar == ')');
+            bool isBraceBefore = (prevChar == '{' || prevChar == '}' || prevChar == '(' || prevChar == ')');
+            bool isBraceAfter = (curChar == '{' || curChar == '}' || curChar == '(' || curChar == ')');
             
             if (isBraceBefore)
             {
@@ -985,7 +985,7 @@ namespace AGS.Editor
 
         public void DoIdentationAlignAfterBrace()
         {
-            Tuple<int, int> pos = GetBraceAndMatchingBracePositions(true, true);
+            Tuple<int, int> pos = GetBraceAndMatchingBracePositions();
             int currentPos = pos.Item1;
             int matchPos = pos.Item2;
             if (matchPos >= 0)
@@ -995,9 +995,9 @@ namespace AGS.Editor
             _doAlignIdentation = false;
         }
 
-        private void ShowMatchingBrace(bool beforeCursor, bool afterCursor)
+        public void ShowMatchingBraceIfPossible()
         {
-            Tuple<int, int> pos = GetBraceAndMatchingBracePositions(beforeCursor, afterCursor);
+            Tuple<int, int> pos = GetBraceAndMatchingBracePositions();
             if (pos.Item1 < 0 && pos.Item2 < 0)
                 return; // no braces found under cursor
 
@@ -1020,11 +1020,6 @@ namespace AGS.Editor
             int lineToAlignWith = scintillaControl1.LineFromPosition(posToAlignWith);
             int indentOfPosToAlignWith = scintillaControl1.Lines[lineToAlignWith].Indentation;
             scintillaControl1.Lines[lineToAlign].Indentation = indentOfPosToAlignWith;
-        }
-
-        public void ShowMatchingBraceIfPossible()
-        {
-            ShowMatchingBrace(true, true);
         }
 
         private void OnUpdateUI(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ScriptEditor.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditor.cs
@@ -630,7 +630,7 @@ namespace AGS.Editor
             }
             else if (command == MATCH_BRACE_COMMAND)
             {
-                scintilla.ShowMatchingBrace(true);
+                scintilla.ShowMatchingBraceIfPossible();
             }
             else if (command == SHOW_MATCHING_SCRIPT_OR_HEADER_COMMAND)
             {


### PR DESCRIPTION
I am a bit confused, according to [rongel in the forums](https://www.adventuregamestudio.co.uk/forums/index.php?topic=59842.msg636649791#msg636649791) we had this feature previously. But I just checked and we didn't. I did found some code that is meant to provide some brace highlighting while typing, but it doesn't work for me in the 3.5.1 branch. 

I honestly don't remember this feature, but in case we actually had it, this works and is a small change to merge.