### PR TITLE
Android: support relative speed factor for touch-to-mouse emulation

### DIFF
--- a/Android/library/runtime/src/main/res/values/strings.xml
+++ b/Android/library/runtime/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="CONFIG_DEBUG_LOGCAT">18</string>
     <string name="CONFIG_MOUSE_EMULATION">19</string>
     <string name="CONFIG_MOUSE_METHOD">20</string>
+    <string name="CONFIG_MOUSE_SPEED">21</string>
     <string name="toggle_keyboard">Toggle keyboard</string>
     <string name="exit_game">Exit game</string>
 

--- a/Android/library/runtime/src/main/res/xml/preferences.xml
+++ b/Android/library/runtime/src/main/res/xml/preferences.xml
@@ -53,6 +53,15 @@
             android:shouldDisableView="true"
             android:summary="The mouse gets moved relative to the finger motion"
             android:title="Relative mouse control" />
+        <androidx.preference.SeekBarPreference
+            android:dependency="@string/CONFIG_ENABLED"
+            android:key="@string/CONFIG_MOUSE_SPEED"
+            android:persistent="false"
+            android:shouldDisableView="true"
+            android:defaultValue="10"
+            android:max="30"
+            android:summary="Sensibility, 10 is 1.0"
+            android:title="Mouse speed in relative control" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory

--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -107,6 +107,11 @@ struct Point
     {
         return Point(X + p.X, Y + p.Y);
     }
+
+    inline Point operator -(const Point &p) const
+    {
+        return Point(X - p.X, Y - p.Y);
+    }
 };
 
 struct Line

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -92,6 +92,7 @@ const int CONFIG_TRANSLATION = 17;
 const int CONFIG_DEBUG_LOGCAT = 18;
 const int CONFIG_MOUSE_EMULATION = 19;
 const int CONFIG_MOUSE_METHOD = 20;
+const int CONFIG_MOUSE_SPEED = 21;
 
 JNIEXPORT jboolean JNICALL
   Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_readConfigFile(JNIEnv* env, jobject object, jstring directory)
@@ -152,6 +153,8 @@ JNIEXPORT jint JNICALL
       return setup.mouse_emulation;
     case CONFIG_MOUSE_METHOD:
       return setup.mouse_control_mode;
+    case CONFIG_MOUSE_SPEED:
+      return setup.mouse_speed;
     default:
       return 0;
   }
@@ -226,6 +229,8 @@ JNIEXPORT void JNICALL
       break;
     case CONFIG_MOUSE_METHOD:
       setup.mouse_control_mode = value;
+    case CONFIG_MOUSE_SPEED:
+      setup.mouse_speed = value;
       break;
     default:
       break;

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -28,6 +28,7 @@ bool WriteConfiguration(const MobileSetup &setup, const char *filename)
 
     CfgWriteInt(cfg, "controls", "mouse_emulation", setup.mouse_emulation);
     CfgWriteInt(cfg, "controls", "mouse_method", setup.mouse_control_mode);
+    CfgWriteInt(cfg, "controls", "mouse_speed", setup.mouse_speed);
 
     CfgWriteInt(cfg, "compatibility", "clear_cache_on_room_change", setup.clear_cache_on_room_change);
 
@@ -87,6 +88,7 @@ bool ReadConfiguration(MobileSetup &setup, const char* filename, bool read_every
 
     setup.mouse_emulation = CfgReadInt(cfg, "controls", "mouse_emulation", 0, 2, 1);
     setup.mouse_control_mode = CfgReadInt(cfg, "controls", "mouse_method", 0, 1, 0);
+    setup.mouse_speed = CfgReadInt(cfg, "controls", "mouse_speed", 1, 30, 10);
 
     return true;
 }
@@ -158,6 +160,7 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
     //    * 1 - relative mouse touch controls
     //    * 0 - direct touch mouse control
     CfgWriteInt(cfg, "mouse", "control_enabled", setup.mouse_control_mode);
+    CfgWriteFloat(cfg, "mouse", "speed", (float)std::max(setup.mouse_speed, 1)/10.f);
 
     // translations
     CfgWriteString(cfg, "language", "translation", setup.translation);

--- a/Engine/platform/base/mobile_base.h
+++ b/Engine/platform/base/mobile_base.h
@@ -32,6 +32,7 @@ struct MobileSetup
     // Mouse option
     int mouse_emulation = 1; // off, one finger, two fingers
     int mouse_control_mode = 0; // absolute vs relative
+    int mouse_speed = 10; // speed in relative mode
 
     // Graphic options
     int gfx_renderer = 0;


### PR DESCRIPTION
Resolves #862.

Use the mouse speed config option when generating emulated touch-to-mouse events.

@ericoporto added your commit with the option in AGS Player's preferences.
![image](https://user-images.githubusercontent.com/2244442/191137735-0ccb86a0-c44b-4b46-8fa6-1e0f5b9e4a87.png)