### PR TITLE
OSX: minor readme adjustment

### DIFF
--- a/OSX/README.md
+++ b/OSX/README.md
@@ -1,11 +1,6 @@
-# AGS for OSX
+# AGS for macOS (OSX)
 
-Uses a modified Allegro 4 library which sets up an offscreen buffer that the game renders to. And then blits that to texture memory in the OpenGL graphics hardware and finally renders that texture to screen.
-
-Supports Mac OS X 10.7+ (tested through 10.11).
-
-This port was initially done by Edward Rudd for providing Gemini Rue in a Humble Bundle.
-
+This port was initially done by Edward Rudd for providing Gemini Rue in a Humble Bundle when the AGS backend was Allegro 4. Currently, it uses SDL2.
 
 ## Creating Icon Sets
 
@@ -20,40 +15,37 @@ To generate the icon set needed by app bundles, Run, in the project workspace ro
     iconutil -c icns -o OSX/Resources/ags.icns OSX/ags.iconset
 
 This will create a file called `ags.incs` placed in the `Resources/` directory.
-When you build within the cmake build directory, it should pick these files up.
+When you build within the CMake build directory, it should pick these files up.
 
-TIP: Use `touch AGS.app` to force macos to reload the application icon.
+TIP: Use `touch AGS.app` to force macOS to reload the application icon.
 
 
 ## Adding resources for the game
 
-All game resources are taken from `OSX/Resources` . Please feel free to replace the stub files that
-exist there with your own game files, as long as they have the same names.
+After you build your game with the Editor, your own game `.ags` and additional files will be generated in the `Compiled/Data/` of your game project directory.
 
-The default accepted name for the game file to be placed there is `game.ags`, which is generated in the `Compiled/Data/`
-directory of your AGS game project. This name is defined in `Engine/platform/osx/alplmac.mm` file.
+In this port, all game resources are taken from `OSX/Resources`, remove the stub files that exist there and replace them with your game files taken from `Compiled/Data/`.
 
 
 ## Building your game with CMake and Xcode
 
-At the ags project root, use CMake to generate the needed Xcode project.
+At the AGS project root, use CMake to generate the needed Xcode project.
 ```
 mkdir buildXcode
 cd buildXcode
 cmake -G Xcode ..
 ```
 
-Using the flags `-DCMAKE_BUILD_TYPE=Release` or `-DCMAKE_BUILD_TYPE=Debug` to specify the build type don't affect the 
-generated Xcode project. The project will build for debug by default, and to change to release, in Xcode you can go to 
-`Product` -> `Scheme` -> `Edit Scheme...` to change the build type from Debug to Release.
+Using the flags `-DCMAKE_BUILD_TYPE=Release` or `-DCMAKE_BUILD_TYPE=Debug` to specify the build type doesn't affect the generated Xcode project. 
+The project will build for debugging by default, and to change to release, in Xcode you can go to `Product` -> `Scheme` -> `Edit Scheme...` to change the build type from Debug to Release.
 
-The produced binary will be in the `ags/buildXcode/Debug/` directory or `ags/buildXcode/Release/`, depending of the 
-target used. By default the name is `AGS.app`.
+The produced binary will be in the `ags/buildXcode/Debug/` directory or `ags/buildXcode/Release/`, depending on the used target. 
+By default, the name is `AGS.app`.
 
 
 ## Building your game with CMake and make
 
-You can also use CMake and make to build ags. 
+You can also use CMake and make to build AGS. 
 
 ```
 export BUILD_TYPE=Release
@@ -63,14 +55,10 @@ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 make
 ```
 
-This will build the executable `AGS.app` in `the build_Release/` directory. The `AGS.app` has at it's root the directory `Contents`, and inside of it the following:
+This will build the executable `AGS.app` in `the build_Release/` directory. The `AGS.app` has at its root the directory `Contents`, and inside of it the following:
 
 - `Info.plist` , the file that holds the `AGS.app` details and points to `AGS` as the target executable.
 
 - `MacOS/`, contains the `AGS` engine binary used to run your game.
 
-- `Resources/`, the directory where your game and it's resources, including the icon are placed.
-
-
-
-
+- `Resources/`, the directory where your game and its resources, including the icon, are placed.


### PR DESCRIPTION
adjustments to fix #1684

future things for MacOS would be

- uploading the engine binary to CI artefacts
- some way to [build from editor](https://github.com/adventuregamestudio/ags/issues/1333#issuecomment-1042790885)
- updating the xcode projects