### PR TITLE
CMake: make sure generated SDL_config.h is used

### DIFF
--- a/CMake/FetchSDL2.cmake
+++ b/CMake/FetchSDL2.cmake
@@ -38,6 +38,10 @@ if(NOT sdl2_content_POPULATED)
     endif()
     add_library(SDL2::SDL2main ALIAS SDL2main)
 
+    if(EXISTS "${sdl2_content_BINARY_DIR}/include/SDL_config.h")
+        file(REMOVE "${sdl2_content_BINARY_DIR}/include/SDL_config.h")
+    endif()
+
     if(EXISTS "${sdl2_content_SOURCE_DIR}/android-project")
         file(REMOVE_RECURSE "${sdl2_content_SOURCE_DIR}/android-project")
     endif()


### PR DESCRIPTION
I was playing with Ubuntu 16.04, and noticed that the wrong `SDL_config.h` was being used. This change should ensure the CMake genereated one is used when using CMake.