### PR TITLE
Engine: fix agsblend plugin stub missing DrawSprite

### DIFF
--- a/Engine/plugin/global_plugin.cpp
+++ b/Engine/plugin/global_plugin.cpp
@@ -125,6 +125,7 @@ bool RegisterPluginStubs(const char* name)
     ccAddExternalStaticFunction("Blur",                         Sc_PluginStub_Int0);
     ccAddExternalStaticFunction("HighPass",                     Sc_PluginStub_Int0);
     ccAddExternalStaticFunction("DrawAdd",                      Sc_PluginStub_Int0);
+    ccAddExternalStaticFunction("DrawSprite",                   Sc_PluginStub_Int0);
     return true;
   }
   else if (ags_stricmp(name, "agsflashlight") == 0)


### PR DESCRIPTION
AGS Blend plugin functions are listed in it's source code.

https://github.com/adventuregamestudio/ags/blob/c30138ddcbdb658dde7d513303e57efcc1ee4463/Plugins/agsblend/AGSBlend.cpp#L886-L892

DrawSprite stub was missing, this is why things have always crashed when I forgot to turn built-in plugins on!

[link to my comment about this ages ago](https://github.com/adventuregamestudio/ags/issues/1148#issuecomment-765043268)