### PR TITLE
Common: fixed ReadEncInt32() on big-endian systems

### DIFF
--- a/Common/util/multifilelib.cpp
+++ b/Common/util/multifilelib.cpp
@@ -461,7 +461,7 @@ int32_t MFLUtil::ReadEncInt32(Stream *in, int &rand_val)
     int val;
     ReadEncArray(&val, sizeof(int32_t), 1, in, rand_val);
 #if AGS_PLATFORM_ENDIAN_BIG
-    AGS::Common::BitByteOperations::SwapBytesInt32(val);
+    return AGS::Common::BitByteOperations::SwapBytesInt32(val);
 #endif
     return val;
 }


### PR DESCRIPTION
Hi,

This small fix comes from ScummVM testing on a big-endian system. Games using `MFLUtil::ReadV21()` would try to allocate gigantic amounts of memory, because some values were not read properly.

`MFLUtil::ReadEncInt32()` just didn't use the return value of `SwapBytesInt32()`, and so this value was still represented with the wrong endianness.