### PR TITLE
Engine: fix gfx sw driver presented offset twice

### DIFF
--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -548,8 +548,8 @@ void SDLRendererGraphicsDriver::Present(int xoff, int yoff, GraphicFlip flip)
     int yoff_final = _scaling.Y.ScalePt(yoff);
 
     SDL_Rect dst;
-    dst.x = _dstRect.Left + xoff_final;
-    dst.y = _dstRect.Top + yoff_final;
+    dst.x = xoff_final;
+    dst.y = yoff_final;
     dst.w = _dstRect.GetWidth();
     dst.h = _dstRect.GetHeight();
     SDL_RenderCopyEx(_renderer, _screenTex, nullptr, &dst, 0.0, nullptr, sdl_flip);


### PR DESCRIPTION
fix #1799 

Offset is calculated using `ScalePt`, which already includes the destination rectangle offset in it's calculations, so the additional math later is not needed.
