### PR TITLE
Don't recreate overlay object in call to Overlay.SetText()

### DIFF
--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -60,7 +60,6 @@ extern SpriteCache spriteset;
 
 int display_message_aschar=0;
 
-
 TopBarSettings topBar;
 struct DisplayVars
 {
@@ -68,74 +67,56 @@ struct DisplayVars
     int fulltxtheight = 0; // total height of all the text
 } disp;
 
-// Pass yy = -1 to find Y co-ord automatically
-// allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
-// pass blocking=2 to create permanent overlay
-ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
-    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer)
+
+// Generates a textual image and returns a disposable bitmap
+Bitmap *create_textual_image(const char *text, int asspch, int isThought,
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
+    bool &alphaChannel)
 {
+    //
+    // Configure the textual image
+    //
+
     const bool use_speech_textwindow = (asspch < 0) && (game.options[OPT_SPEECHTYPE] >= 2);
     const bool use_thought_gui = (isThought) && (game.options[OPT_THOUGHTGUI] > 0);
 
-    bool alphaChannel = false;
-    char todis[STD_BUFFER_SIZE];
-    snprintf(todis, STD_BUFFER_SIZE - 1, "%s", text);
+    alphaChannel = false;
     int usingGui = -1;
     if (use_speech_textwindow)
-	    usingGui = play.speech_textwindow_gui;
+        usingGui = play.speech_textwindow_gui;
     else if (use_thought_gui)
-	    usingGui = game.options[OPT_THOUGHTGUI];
+        usingGui = game.options[OPT_THOUGHTGUI];
 
-    int padding = get_textwindow_padding(usingGui);
-    int paddingScaled = get_fixed_pixel_size(padding);
-    int paddingDoubledScaled = get_fixed_pixel_size(padding * 2); // Just in case screen size does is not neatly divisible by 320x200
+    const int padding = get_textwindow_padding(usingGui);
+    const int paddingScaled = get_fixed_pixel_size(padding);
+    // Just in case screen size does is not neatly divisible by 320x200
+    const int paddingDoubledScaled = get_fixed_pixel_size(padding * 2);
 
+    // Make message copy, because ensure_text_valid_for_font() may modify it
+    char todis[STD_BUFFER_SIZE];
+    snprintf(todis, STD_BUFFER_SIZE - 1, "%s", text);
     ensure_text_valid_for_font(todis, usingfont);
-    break_up_text_into_lines(todis, Lines, wii-2*padding, usingfont);
-    disp.linespacing= get_font_linespacing(usingfont);
+    break_up_text_into_lines(todis, Lines, wii - 2 * padding, usingfont);
+    disp.linespacing = get_font_linespacing(usingfont);
     disp.fulltxtheight = get_text_lines_surf_height(usingfont, Lines.Count());
 
-    // AGS 2.x: If the screen is faded out, fade in again when displaying a message box.
-    if (!asspch && (loaded_game_file_version <= kGameVersion_272))
-        play.screen_is_faded_out = 0;
-
-    // if it's a normal message box and the game was being skipped,
-    // ensure that the screen is up to date before the message box
-    // is drawn on top of it
-    // TODO: is this really necessary anymore?
-    if ((play.skip_until_char_stops >= 0) && (disp_type == DISPLAYTEXT_MESSAGEBOX))
-        render_graphics();
-
-    EndSkippingUntilCharStops();
-
     if (topBar.wantIt) {
-        // ensure that the window is wide enough to display
-        // any top bar text
+        // ensure that the window is wide enough to display any top bar text
         int topBarWid = get_text_width_outlined(topBar.text, topBar.font);
         topBarWid += data_to_game_coord(play.top_bar_borderwidth + 2) * 2;
         if (longestline < topBarWid)
             longestline = topBarWid;
-        // the top bar should behave like DisplaySpeech wrt blocking
-        disp_type = DISPLAYTEXT_SPEECH;
-    }
-
-    if (asspch > 0) {
-        // update the all_buttons_disabled variable in advance
-        // of the adjust_x/y_for_guis calls
-        play.disabled_user_interface++;
-        update_gui_disabled_status();
-        play.disabled_user_interface--;
     }
 
     const Rect &ui_view = play.GetUIViewport();
-    if (xx == OVR_AUTOPLACE) ;
+    if (xx == OVR_AUTOPLACE);
     // centre text in middle of screen
-    else if (yy<0) yy= ui_view.GetHeight()/2-disp.fulltxtheight/2-padding;
+    else if (yy<0) yy = ui_view.GetHeight() / 2 - disp.fulltxtheight / 2 - padding;
     // speech, so it wants to be above the character's head
     else if (asspch > 0) {
-        yy-=disp.fulltxtheight;
-        if (yy < 5) yy=5;
-        yy = adjust_y_for_guis (yy);
+        yy -= disp.fulltxtheight;
+        if (yy < 5) yy = 5;
+        yy = adjust_y_for_guis(yy);
     }
 
     if (longestline < wii - paddingDoubledScaled) {
@@ -151,23 +132,20 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
             xx += (oldWid - wii);
     }
 
-    if (xx<-1) { 
-        xx=(-xx)-wii/2;
+    if (xx<-1) {
+        xx = (-xx) - wii / 2;
         if (xx < 0)
             xx = 0;
 
-        xx = adjust_x_for_guis (xx, yy);
+        xx = adjust_x_for_guis(xx, yy);
 
         if (xx + wii >= ui_view.GetWidth())
             xx = (ui_view.GetWidth() - wii) - 5;
     }
-    else if (xx<0) xx= ui_view.GetWidth()/2-wii/2;
+    else if (xx<0) xx = ui_view.GetWidth() / 2 - wii / 2;
 
-    int extraHeight = paddingDoubledScaled;
+    const int extraHeight = paddingDoubledScaled;
     color_t text_color = MakeColor(15);
-    if (disp_type < DISPLAYTEXT_NORMALOVERLAY)
-        remove_screen_overlay(play.text_overlay_on); // remove any previous blocking texts
-
     const int bmp_width = std::max(2, wii);
     const int bmp_height = std::max(2, disp.fulltxtheight + extraHeight);
     Bitmap *text_window_ds = BitmapHelper::CreateTransparentBitmap(bmp_width, bmp_height, game.GetColorDepth());
@@ -176,13 +154,14 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     const bool wantFreeScreenop = true;
 
     //
-    // Creating displayed graphic
+    // Create the textual image (may also adjust some params in the process)
     //
-    // may later change if usingGUI, needed to avoid changing original coordinates
-    int adjustedXX = xx;
-    int adjustedYY = yy;
 
-    if ((strlen (todis) < 1) || (strcmp (todis, "  ") == 0) || (wii == 0)) ;
+    // may later change if usingGUI, needed to avoid changing original coordinates
+    adjustedXX = xx;
+    adjustedYY = yy;
+
+    if ((strlen(todis) < 1) || (strcmp(todis, "  ") == 0) || (wii == 0));
     // if it's an empty speech line, don't draw anything
     else if (asspch) { //text_color = ds->GetCompatibleColor(12);
         int ttxleft = 0, ttxtop = paddingScaled, oriwid = wii - padding * 2;
@@ -209,13 +188,13 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
         else if ((ShouldAntiAliasText()) && (game.GetColorDepth() >= 24))
             alphaChannel = true;
 
-        for (size_t ee=0;ee<Lines.Count();ee++) {
+        for (size_t ee = 0; ee<Lines.Count(); ee++) {
             //int ttxp=wii/2 - get_text_width_outlined(lines[ee], usingfont)/2;
-            int ttyp=ttxtop+ee*disp.linespacing;
+            int ttyp = ttxtop + ee*disp.linespacing;
             // asspch < 0 means that it's inside a text box so don't
             // centre the text
             if (asspch < 0) {
-                if ((usingGui >= 0) && 
+                if ((usingGui >= 0) &&
                     ((game.options[OPT_SPEECHTYPE] >= 2) || (isThought)))
                     text_color = text_window_ds->GetCompatibleColor(guis[usingGui].FgColor);
                 else
@@ -230,8 +209,8 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
         }
     }
     else {
-        int xoffs,yoffs, oriwid = wii - padding * 2;
-        draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &xoffs,&yoffs,&adjustedXX,&adjustedYY,&wii,&text_color);
+        int xoffs, yoffs, oriwid = wii - padding * 2;
+        draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &xoffs, &yoffs, &adjustedXX, &adjustedYY, &wii, &text_color);
 
         if (game.options[OPT_TWCUSTOM] > 0)
         {
@@ -240,9 +219,65 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
 
         adjust_y_coordinate_for_text(&yoffs, usingfont);
 
-        for (size_t ee=0;ee<Lines.Count();ee++)
-            wouttext_aligned (text_window_ds, xoffs, yoffs + ee * disp.linespacing, oriwid, usingfont, text_color, Lines[ee].GetCStr(), play.text_align);
+        for (size_t ee = 0; ee<Lines.Count(); ee++)
+            wouttext_aligned(text_window_ds, xoffs, yoffs + ee * disp.linespacing, oriwid, usingfont, text_color, Lines[ee].GetCStr(), play.text_align);
     }
+
+    return text_window_ds;
+}
+
+// Pass yy = -1 to find Y co-ord automatically
+// allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
+// pass blocking=2 to create permanent overlay
+ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
+    int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer)
+{
+    //
+    // Prepare for the message display
+    //
+
+    // AGS 2.x: If the screen is faded out, fade in again when displaying a message box.
+    if (!asspch && (loaded_game_file_version <= kGameVersion_272))
+        play.screen_is_faded_out = 0;
+
+    // if it's a normal message box and the game was being skipped,
+    // ensure that the screen is up to date before the message box
+    // is drawn on top of it
+    // TODO: is this really necessary anymore?
+    if ((play.skip_until_char_stops >= 0) && (disp_type == DISPLAYTEXT_MESSAGEBOX))
+        render_graphics();
+
+    // TODO: should this really be called regardless of message type?
+    // _display_main may be called even for custom textual overlays
+    EndSkippingUntilCharStops();
+
+    if (asspch > 0)
+    {
+        // update the all_buttons_disabled variable in advance
+        // of the adjust_x/y_for_guis calls
+        play.disabled_user_interface++;
+        update_gui_disabled_status();
+        play.disabled_user_interface--;
+    }
+
+    if (topBar.wantIt)
+    {
+        // the top bar should behave like DisplaySpeech wrt blocking
+        disp_type = DISPLAYTEXT_SPEECH;
+    }
+
+    // Remove any previous blocking texts if necessary
+    if (disp_type < DISPLAYTEXT_NORMALOVERLAY)
+        remove_screen_overlay(play.text_overlay_on);
+
+    int adjustedXX, adjustedYY;
+    bool alphaChannel;
+    Bitmap *text_window_ds = create_textual_image(text, asspch, isThought,
+        xx, yy, adjustedXX, adjustedYY, wii, usingfont, allowShrink, alphaChannel);
+
+    //
+    // Configure and create an overlay object
+    //
 
     int ovrtype;
     switch (disp_type)
@@ -256,6 +291,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
     // we should not delete text_window_ds here, because it is now owned by Overlay
 
+    // If it's a non-blocking overlay type, then we're done here
     if (disp_type >= DISPLAYTEXT_NORMALOVERLAY) {
         return &screenover[nse];
     }
@@ -263,6 +299,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     //
     // Wait for the blocking text to timeout or until skipped by another command
     //
+
     if (disp_type == DISPLAYTEXT_MESSAGEBOX) {
         // If fast-forwarding, then skip immediately
         if (play.fast_forward) {
@@ -272,7 +309,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
             return nullptr;
         }
 
-        int countdown = GetTextDisplayTime (todis);
+        int countdown = GetTextDisplayTime(text);
         int skip_setting = user_to_internal_skip_speech((SkipSpeechStyle)play.skip_display);
         // Loop until skipped
         while (true) {
@@ -359,6 +396,10 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
 
         GameLoopUntilNoOverlay();
     }
+
+    //
+    // Post-message cleanup
+    //
 
     ags_clear_input_buffer();
     play.messagetime=-1;

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -32,6 +32,10 @@ using AGS::Common::GUIMain;
 // also accepts explicit overlay ID >= OVER_CUSTOM
 
 struct ScreenOverlay;
+// Generates a textual image from the given text and parameters (used by _display_main)
+Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
+    bool &alphaChannel);
 // Creates a textual overlay using the given parameters;
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -32,7 +32,8 @@ using AGS::Common::GUIMain;
 // also accepts explicit overlay ID >= OVER_CUSTOM
 
 struct ScreenOverlay;
-// Generates a textual image from the given text and parameters (used by _display_main)
+// Generates a textual image from the given text and parameters;
+// see _display_main's comment below for parameters description
 Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
     bool &alphaChannel);
@@ -40,6 +41,11 @@ Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
 // pass blocking=2 to create permanent overlay
+// asspch has several meanings, which affect how the message is positioned
+//   == 0 - standard display box
+//   != 0 - text color for a speech or a regular textual overlay, where
+//     < 0 - use text window if applicable
+//     > 0 - suppose it's a classic LA-style speech above character's head
 ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp_type, int usingfont,
     int asspch, int isThought, int allowShrink, bool overlayPositionFixed, bool roomlayer = false);
 void _display_at(int xx, int yy, int wii, const char *text, int disp_type, int asspch, int isThought, int allowShrink, bool overlayPositionFixed);

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -31,8 +31,10 @@ int CreateGraphicOverlay(int x, int y, int slott, int trans) {
 int CreateTextOverlay(int xx, int yy, int wii, int fontid, int text_color, const char* text, int disp_type) {
     int allowShrink = 0;
 
-    if (xx != OVR_AUTOPLACE) {
-        data_to_game_coords(&xx,&yy);
+    if (xx != OVR_AUTOPLACE)
+    {
+        data_to_game_coords(&xx, &yy);
+        // NOTE: this is ugly, but OVR_AUTOPLACE here suggests that width is already in game coords
         wii = data_to_game_coord(wii);
     }
     else  // allow DisplaySpeechBackground to be shrunk

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -48,25 +48,41 @@ void Overlay_Remove(ScriptOverlay *sco) {
     sco->Remove();
 }
 
-void Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int text_color, const char *text) {
-    int ovri=find_overlay_of_type(scover->overlayId);
-    if (ovri<0)
+void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_color, const char *text)
+{
+    int ovri = find_overlay_of_type(scover->overlayId);
+    if (ovri < 0)
         quit("!Overlay.SetText: invalid overlay ID specified");
-    int xx = game_to_data_coord(screenover[ovri].x);
-    int yy = game_to_data_coord(screenover[ovri].y);
+    auto &over = screenover[ovri];
+    const int x = over.x;
+    const int y = over.y;
 
-    // FIXME: a refactor needed!
-    // these calls to RemoveOverlay and CreateOverlay below are potentially dangerous,
-    // because they may allocate new script objects too under certain conditions.
-    // This did not happen because users only had access to custom overlay pointers before,
-    // but now they also may access internal overlays (such as Say text and portrait).
-    const int disp_type = scover->overlayId;
-    RemoveOverlay(scover->overlayId);
+    // TODO: find a nice way to refactor and share these code pieces
+    // from CreateTextOverlay
+    width = data_to_game_coord(width);
+    // allow DisplaySpeechBackground to be shrunk
+    int allow_shrink = (x == OVR_AUTOPLACE) ? 1 : 0;
 
-    int new_ovrid = CreateTextOverlay(xx, yy, wii, fontid, text_color, get_translation(text), disp_type);
-    if (new_ovrid != disp_type)
-        quit("SetTextOverlay internal error: inconsistent type ids");
-    scover->overlayId = new_ovrid;
+    // from Overlay_CreateTextCore
+    if (width < 8) width = play.GetUIViewport().GetWidth() / 2;
+    if (text_color == 0) text_color = 16;
+
+    // Recreate overlay image
+    int dummy_x = x, dummy_y = y, adj_x = x, adj_y = y;
+    bool has_alpha = false;
+    // NOTE: we pass text_color negated to let optionally use textwindow (if applicable)
+    // this is a generic ugliness of _display_main args, need to refactor later.
+    Bitmap *image = create_textual_image(get_translation(text), -text_color, 0, dummy_x, dummy_y, adj_x, adj_y,
+        width, fontid, allow_shrink, has_alpha);
+
+    // Update overlay properties
+    over.SetImage(std::unique_ptr<Bitmap>(image));
+    over.SetAlphaChannel(has_alpha);
+    over.x = x;
+    over.y = y;
+    over.offsetX = adj_x - dummy_x;
+    over.offsetY = adj_y - dummy_y;
+    over.ddb = nullptr; // is generated during first draw pass
 }
 
 int Overlay_GetX(ScriptOverlay *scover) {

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -76,12 +76,8 @@ void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_colo
         width, fontid, allow_shrink, has_alpha);
 
     // Update overlay properties
-    over.SetImage(std::unique_ptr<Bitmap>(image));
+    over.SetImage(std::unique_ptr<Bitmap>(image), adj_x - dummy_x, adj_y - dummy_y);
     over.SetAlphaChannel(has_alpha);
-    over.x = x;
-    over.y = y;
-    over.offsetX = adj_x - dummy_x;
-    over.offsetY = adj_y - dummy_y;
     over.ddb = nullptr; // is generated during first draw pass
 }
 
@@ -413,19 +409,17 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
     ScreenOverlay over;
     if (piccy)
     {
-        over.SetImage(std::unique_ptr<Bitmap>(piccy));
+        over.SetImage(std::unique_ptr<Bitmap>(piccy), pic_offx, pic_offy);
         over.SetAlphaChannel(has_alpha);
     }
     else
     {
-        over.SetSpriteNum(sprnum);
+        over.SetSpriteNum(sprnum, pic_offx, pic_offy);
         over.SetAlphaChannel((game.SpriteInfos[sprnum].Flags & SPF_ALPHACHANNEL) != 0);
     }
     over.ddb = nullptr; // is generated during first draw pass
     over.x=x;
     over.y=y;
-    over.offsetX = pic_offx;
-    over.offsetY = pic_offy;
     // by default draw speech and portraits over GUI, and the rest under GUI
     over.zorder = (roomlayer || type == OVER_TEXTMSG || type == OVER_PICTURE || type == OVER_TEXTSPEECH) ?
         INT_MAX : INT_MIN;

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -25,12 +25,13 @@ Bitmap *ScreenOverlay::GetImage() const
         _pic.get();
 }
 
-void ScreenOverlay::SetImage(std::unique_ptr<Common::Bitmap> pic)
+void ScreenOverlay::SetImage(std::unique_ptr<Common::Bitmap> pic, int offx, int offy)
 {
     _flags &= ~kOver_SpriteReference;
     _pic = std::move(pic);
     _sprnum = -1;
-    offsetX = offsetY = 0;
+    offsetX = offx;
+    offsetY = offy;
     scaleWidth = scaleHeight = 0;
     const auto *img = GetImage();
     if (img)
@@ -41,12 +42,13 @@ void ScreenOverlay::SetImage(std::unique_ptr<Common::Bitmap> pic)
     MarkChanged();
 }
 
-void ScreenOverlay::SetSpriteNum(int sprnum)
+void ScreenOverlay::SetSpriteNum(int sprnum, int offx, int offy)
 {
     _flags |= kOver_SpriteReference;
     _pic.reset();
     _sprnum = sprnum;
-    offsetX = offsetY = 0;
+    offsetX = offx;
+    offsetY = offy;
     scaleWidth = scaleHeight = 0;
     const auto *img = GetImage();
     if (img)

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -69,8 +69,8 @@ struct ScreenOverlay
     Common::Bitmap *GetImage() const;
     // Get sprite reference id, or -1 if none set
     int GetSpriteNum() const { return _sprnum; }
-    void SetImage(std::unique_ptr<Common::Bitmap> pic);
-    void SetSpriteNum(int sprnum);
+    void SetImage(std::unique_ptr<Common::Bitmap> pic, int offx = 0, int offy = 0);
+    void SetSpriteNum(int sprnum, int offx = 0, int offy = 0);
     // Tells if Overlay has graphically changed recently
     bool HasChanged() const { return _hasChanged; }
     // Manually marks GUI as graphically changed

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -864,7 +864,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
         bool has_bitmap;
         over.ReadFromFile(in, has_bitmap, cmp_ver);
         if (has_bitmap)
-            over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)));
+            over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)), over.offsetX, over.offsetY);
         if (over.scaleWidth <= 0 || over.scaleHeight <= 0)
         {
             over.scaleWidth = over.GetImage()->GetWidth();

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -324,7 +324,8 @@ static void restore_game_overlays(Stream *in)
     ReadOverlays_Aligned(in, has_bitmap, num_overs);
     for (size_t i = 0; i < num_overs; ++i) {
         if (has_bitmap[i])
-            screenover[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)));
+            screenover[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)),
+                screenover[i].offsetX, screenover[i].offsetY);
     }
 }
 


### PR DESCRIPTION
This addresses a problem which I found while was fixing #1797 (it was not directly related to 1797 though).

**The problem**

Previously `Overlay.SetText()` was passing into `CreateTextOverlay()` -> `Overlay_CreateTextCore()` -> `_display_main()`.
This effectively removed and recreated an internal overlay object with different image but the same ID.

Also, previously, this method could have been only called for custom overlays in practice. For these the script object was not touched, and kept the correct overlay reference.

The situation has changed when we let user script to access some of the internally created overlays, such as Text and Portrait overlays created by a blocking Say command (`Speech.TextOverlay` and `Speech.PortraitOverlay`). When these overlays are recreated, they also must be completely destroyed, invalidating any existing script references. Hence calling `_display_main()` from `Overlay.SetText()` is no longer acceptable, as it leads to a full overlay recreation, and possible duplication of a script reference with two (or more) separate managed handles (this is almost like, two shared pointers owning same object). An alternative was to invalidate the old script reference, which might greatly surprise a user... and makes no sense from the scripting perspective.

```
function repeatedly_execute_always()
{
    if (Speech.TextOverlay) {
        Overlay* o = Speech.TextOverlay;
        o.SetText(100, eFontNormal, 123456, "a new text");
        // overlay will suddenly disappear here in the latest master,
        // because `o` pointer is detached from internal reference count,
        // and engine will destroy overlay as soon as pointer is lost
    }
}
```

To fix this problem, here we replace a call to `CreateTextOverlay()` with manual recreation of a textual image, and assigning a new image to the same overlay. This **does not change anything from the script's POV**, as SetText method already suggests that the overlay reference remains valid (previously only the internal object was secretly replaced).

With this change Overlay.SetText method should correctly work with overlay pointers copied from Speech.TextOverlay (and maybe even Speech.PortraitOverlay, lol). E.g.:

```
int counter;
function repeatedly_execute_always()
{
    if (IsKeyPressed(eKeySpace)) {
        if (Speech.TextOverlay) {
            Overlay* o = Speech.TextOverlay;
            o.SetText(100, eFontNormal, 123456, "text: %d", counter);
            counter++;
        }
    }
}
```

**Implementation notes**

1. Had to refactor `_display_main()` by picking out a function I called `create_textual_image()`. This function generates a bitmap with text on it and adjusts the position. `_display_main` calls it internally, and then creates overlay and optionally waits for a skipping player input, as usual.
2. `Overlay_SetText()` now does not call `CreateTextOverlay()` anymore, but instead calls `create_textual_image()` directly, skipping the whole chain of functions, and lots of unnecessary code. For this I also had to copy two small pieces from `CreateTextOverlay` and `Overlay_CreateTextCore`, which adjust some parameters, because I could not quickly figure out a good way to share this code; so I'd leave this for future refactor.

Normally I don't like refactoring important functions like `display_main` right before the final version release. Here i tried to keep changes to minimum, and they are mostly moved code (and some lines were auto-styled by VS, but I left that).