### PR TITLE
Upgrade SDL to 2.24.1

### DIFF
--- a/CMake/FetchSDL2.cmake
+++ b/CMake/FetchSDL2.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     sdl2_content
-    URL https://github.com/libsdl-org/SDL/archive/b6661c016bba98cdeb7bea1ffa67aa0794dc2942.tar.gz
-    URL_HASH MD5=239819387031eb78e8283d738e2d540f
+    URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.24.1.tar.gz
+    URL_HASH MD5=7c8999f150237df50b9d5ca158a40c56
 )
 
 FetchContent_GetProperties(sdl2_content)

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -86,7 +86,7 @@ RUN curl -fLsS "https://github.com/xiph/vorbis/releases/download/v${LIBVORBIS_VE
   rm /tmp/libvorbis-${LIBVORBIS_VERSION}.tar.gz 
 
 # Build and install SDL2
-ARG SDL2_VERSION=2.24.0
+ARG SDL2_VERSION=2.24.1
 RUN curl -fLsS "https://github.com/libsdl-org/SDL/archive/refs/tags/release-${SDL2_VERSION}.tar.gz" | tar -f - -xvzC /tmp && \
   cd /tmp/SDL-release-${SDL2_VERSION} && \
   ./configure --enable-shared --enable-loadso --enable-pulseaudio-shared --enable-sndio-shared --enable-x11-shared --enable-oss=no --enable-libsamplerate-shared --enable-video-wayland=no --enable-directfb-shared && \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir Redist && \
   cd Redist && \
   curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe
 
-ARG SDL_VERSION=2.24.0
+ARG SDL_VERSION=2.24.1
 RUN mkdir Lib\SDL2 && \
   curl -fLOJ "https://github.com/libsdl-org/SDL/releases/download/release-%SDL_VERSION%/SDL2-devel-%SDL_VERSION%-VC.zip" && \
   tar -f SDL2-devel-%SDL_VERSION%-VC.zip -xvzC Lib\SDL2\ --strip-components 1  && \


### PR DESCRIPTION
to harmonize the builds, make sure Android, Windows, Linux and MacOS are using the same [SDL 2.24.1](https://github.com/libsdl-org/SDL/releases/tag/release-2.24.1), avoiding depending on a specific commit. I tested the Android build to make sure it's alright, Windows too. This SDL is based on [release-2.24.x branch](https://github.com/libsdl-org/SDL/commits/release-2.24.x).

better wait the CI to finish just before merging just in case.