### PR TITLE
OSX: enable RMB simulation with Ctrl+LMB (in SDL2)

### DIFF
--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -426,18 +426,6 @@ static eAGSMouseButton mgetbutton()
     else if (butis & MouseBitMiddle)
         return kMouseMiddle;
     return kMouseNone;
-
-    // TODO: presumably this was a hack for 1-button Mac mouse;
-    // is this still necessary?
-    // find an elegant way to reimplement this; e.g. allow to configure key->mouse mappings?!
-#define AGS_SIMULATE_RIGHT_CLICK (AGS_PLATFORM_OS_MACOS)
-#if defined (AGS_SIMULATE_RIGHT_CLICK__FIXME)
-        // j Ctrl-left click should be right-click
-        if (ags_iskeypressed(__allegro_KEY_LCONTROL) || ags_iskeypressed(__allegro_KEY_RCONTROL))
-        {
-            toret = RIGHT;
-        }
-#endif
 }
 
 extern eAGSMouseButton pluginSimulatedClick;

--- a/Engine/platform/osx/acplmac.cpp
+++ b/Engine/platform/osx/acplmac.cpp
@@ -18,14 +18,7 @@
 
 // ********* MacOS PLACEHOLDER DRIVER *********
 
-//#include "util/wgt2allg.h"
-//#include "gfx/ali3d.h"
-//#include "ac/runtime_defines.h"
-//#include "main/config.h"
-//#include "plugin/agsplugin.h"
-//#include <libcda.h>
-//#include <pwd.h>
-//#include <sys/stat.h>
+#include <SDL.h>
 #include "platform/base/agsplatformdriver.h"
 #include "util/directory.h"
 #include "ac/common.h"
@@ -40,6 +33,8 @@ static FSLocation commonDataPath;
 
 struct AGSMac : AGSPlatformDriver {
   AGSMac();
+
+  void PreBackendInit() override;
 
   int  CDPlayerCommand(int cmdd, int datt) override;
   void DisplayAlert(const char*, ...) override;
@@ -60,6 +55,13 @@ AGSMac::AGSMac()
   AGSMacInitPaths(libraryApplicationSupport);
   
   commonDataPath = FSLocation(libraryApplicationSupport).Concat("uk.co.adventuregamestudio");
+}
+
+void AGSMac::PreBackendInit()
+{
+  // Simulate right click with Ctrl + LMB
+  // TODO: consider reading this option from user config in the future?
+  SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 }
 
 int AGSMac::CDPlayerCommand(int cmdd, int datt) {


### PR DESCRIPTION
Resolves #1740 using SDL2's `SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK`.