### PR TITLE
MacOS: update xcode project

### DIFF
--- a/Common/libinclude/ogg/config_types.h.in
+++ b/Common/libinclude/ogg/config_types.h.in
@@ -7,5 +7,6 @@ typedef @USIZE16@ ogg_uint16_t;
 typedef @SIZE32@ ogg_int32_t;
 typedef @USIZE32@ ogg_uint32_t;
 typedef @SIZE64@ ogg_int64_t;
+typedef @USIZE64@ ogg_uint64_t;
 
 #endif

--- a/Common/libinclude/ogg/ogg.h
+++ b/Common/libinclude/ogg/ogg.h
@@ -5,13 +5,12 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2002             *
+ * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2007             *
  * by the Xiph.Org Foundation http://www.xiph.org/                  *
  *                                                                  *
  ********************************************************************
 
  function: toplevel libogg include
- last mod: $Id: ogg.h 7188 2004-07-20 07:26:04Z xiphmont $
 
  ********************************************************************/
 #ifndef _OGG_H
@@ -21,7 +20,13 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <ogg/os_types.h>
+
+typedef struct {
+  void *iov_base;
+  size_t iov_len;
+} ogg_iovec_t;
 
 typedef struct {
   long endbyte;
@@ -53,8 +58,8 @@ typedef struct {
 
   int     *lacing_vals;      /* The values that will go to the segment table */
   ogg_int64_t *granule_vals; /* granulepos values for headers. Not compact
-				this way, but it is simple coupled to the
-				lacing fifo */
+                                this way, but it is simple coupled to the
+                                lacing fifo */
   long    lacing_storage;
   long    lacing_fill;
   long    lacing_packet;
@@ -69,10 +74,10 @@ typedef struct {
                              of a logical bitstream */
   long    serialno;
   long    pageno;
-  ogg_int64_t  packetno;      /* sequence number for decode; the framing
+  ogg_int64_t  packetno;  /* sequence number for decode; the framing
                              knows where there's a hole in the data,
                              but we need coupling so that the codec
-                             (which is in a seperate abstraction
+                             (which is in a separate abstraction
                              layer) also knows about the gap */
   ogg_int64_t   granulepos;
 
@@ -88,12 +93,12 @@ typedef struct {
   long  e_o_s;
 
   ogg_int64_t  granulepos;
-  
+
   ogg_int64_t  packetno;     /* sequence number for decode; the framing
-				knows where there's a hole in the data,
-				but we need coupling so that the codec
-				(which is in a seperate abstraction
-				layer) also knows about the gap */
+                                knows where there's a hole in the data,
+                                but we need coupling so that the codec
+                                (which is in a separate abstraction
+                                layer) also knows about the gap */
 } ogg_packet;
 
 typedef struct {
@@ -110,6 +115,7 @@ typedef struct {
 /* Ogg BITSTREAM PRIMITIVES: bitstream ************************/
 
 extern void  oggpack_writeinit(oggpack_buffer *b);
+extern int   oggpack_writecheck(oggpack_buffer *b);
 extern void  oggpack_writetrunc(oggpack_buffer *b,long bits);
 extern void  oggpack_writealign(oggpack_buffer *b);
 extern void  oggpack_writecopy(oggpack_buffer *b,void *source,long bits);
@@ -128,6 +134,7 @@ extern long  oggpack_bits(oggpack_buffer *b);
 extern unsigned char *oggpack_get_buffer(oggpack_buffer *b);
 
 extern void  oggpackB_writeinit(oggpack_buffer *b);
+extern int   oggpackB_writecheck(oggpack_buffer *b);
 extern void  oggpackB_writetrunc(oggpack_buffer *b,long bits);
 extern void  oggpackB_writealign(oggpack_buffer *b);
 extern void  oggpackB_writecopy(oggpack_buffer *b,void *source,long bits);
@@ -148,15 +155,20 @@ extern unsigned char *oggpackB_get_buffer(oggpack_buffer *b);
 /* Ogg BITSTREAM PRIMITIVES: encoding **************************/
 
 extern int      ogg_stream_packetin(ogg_stream_state *os, ogg_packet *op);
+extern int      ogg_stream_iovecin(ogg_stream_state *os, ogg_iovec_t *iov,
+                                   int count, long e_o_s, ogg_int64_t granulepos);
 extern int      ogg_stream_pageout(ogg_stream_state *os, ogg_page *og);
+extern int      ogg_stream_pageout_fill(ogg_stream_state *os, ogg_page *og, int nfill);
 extern int      ogg_stream_flush(ogg_stream_state *os, ogg_page *og);
+extern int      ogg_stream_flush_fill(ogg_stream_state *os, ogg_page *og, int nfill);
 
 /* Ogg BITSTREAM PRIMITIVES: decoding **************************/
 
 extern int      ogg_sync_init(ogg_sync_state *oy);
 extern int      ogg_sync_clear(ogg_sync_state *oy);
 extern int      ogg_sync_reset(ogg_sync_state *oy);
-extern int	ogg_sync_destroy(ogg_sync_state *oy);
+extern int      ogg_sync_destroy(ogg_sync_state *oy);
+extern int      ogg_sync_check(ogg_sync_state *oy);
 
 extern char    *ogg_sync_buffer(ogg_sync_state *oy, long size);
 extern int      ogg_sync_wrote(ogg_sync_state *oy, long bytes);
@@ -173,18 +185,19 @@ extern int      ogg_stream_clear(ogg_stream_state *os);
 extern int      ogg_stream_reset(ogg_stream_state *os);
 extern int      ogg_stream_reset_serialno(ogg_stream_state *os,int serialno);
 extern int      ogg_stream_destroy(ogg_stream_state *os);
+extern int      ogg_stream_check(ogg_stream_state *os);
 extern int      ogg_stream_eos(ogg_stream_state *os);
 
 extern void     ogg_page_checksum_set(ogg_page *og);
 
-extern int      ogg_page_version(ogg_page *og);
-extern int      ogg_page_continued(ogg_page *og);
-extern int      ogg_page_bos(ogg_page *og);
-extern int      ogg_page_eos(ogg_page *og);
-extern ogg_int64_t  ogg_page_granulepos(ogg_page *og);
-extern int      ogg_page_serialno(ogg_page *og);
-extern long     ogg_page_pageno(ogg_page *og);
-extern int      ogg_page_packets(ogg_page *og);
+extern int      ogg_page_version(const ogg_page *og);
+extern int      ogg_page_continued(const ogg_page *og);
+extern int      ogg_page_bos(const ogg_page *og);
+extern int      ogg_page_eos(const ogg_page *og);
+extern ogg_int64_t  ogg_page_granulepos(const ogg_page *og);
+extern int      ogg_page_serialno(const ogg_page *og);
+extern long     ogg_page_pageno(const ogg_page *og);
+extern int      ogg_page_packets(const ogg_page *og);
 
 extern void     ogg_packet_clear(ogg_packet *op);
 
@@ -194,9 +207,3 @@ extern void     ogg_packet_clear(ogg_packet *op);
 #endif
 
 #endif  /* _OGG_H */
-
-
-
-
-
-

--- a/Common/libinclude/ogg/os_types.h
+++ b/Common/libinclude/ogg/os_types.h
@@ -10,8 +10,7 @@
  *                                                                  *
  ********************************************************************
 
- function: #ifdef jail to whip a few platforms into the UNIX ideal.
- last mod: $Id: os_types.h 7524 2004-08-11 04:20:36Z conrad $
+ function: Define a consistent set of types on each platform.
 
  ********************************************************************/
 #ifndef _OS_TYPES_H
@@ -24,47 +23,52 @@
 #define _ogg_realloc realloc
 #define _ogg_free    free
 
-#if defined(_WIN32) 
+#if defined(_WIN32)
 
 #  if defined(__CYGWIN__)
-#    include <_G_config.h>
-     typedef _G_int64_t ogg_int64_t;
-     typedef _G_int32_t ogg_int32_t;
-     typedef _G_uint32_t ogg_uint32_t;
-     typedef _G_int16_t ogg_int16_t;
-     typedef _G_uint16_t ogg_uint16_t;
+#    include <stdint.h>
+     typedef int16_t ogg_int16_t;
+     typedef uint16_t ogg_uint16_t;
+     typedef int32_t ogg_int32_t;
+     typedef uint32_t ogg_uint32_t;
+     typedef int64_t ogg_int64_t;
+     typedef uint64_t ogg_uint64_t;
 #  elif defined(__MINGW32__)
-     typedef short ogg_int16_t;                                                                             
-     typedef unsigned short ogg_uint16_t;                                                                   
-     typedef int ogg_int32_t;                                                                               
-     typedef unsigned int ogg_uint32_t;                                                                     
-     typedef long long ogg_int64_t;                                                                         
-     typedef unsigned long long ogg_uint64_t;  
+#    include <sys/types.h>
+     typedef short ogg_int16_t;
+     typedef unsigned short ogg_uint16_t;
+     typedef int ogg_int32_t;
+     typedef unsigned int ogg_uint32_t;
+     typedef long long ogg_int64_t;
+     typedef unsigned long long ogg_uint64_t;
 #  elif defined(__MWERKS__)
      typedef long long ogg_int64_t;
+     typedef unsigned long long ogg_uint64_t;
      typedef int ogg_int32_t;
      typedef unsigned int ogg_uint32_t;
      typedef short ogg_int16_t;
      typedef unsigned short ogg_uint16_t;
 #  else
-     /* MSVC/Borland */
-     typedef __int64 ogg_int64_t;
-     typedef __int32 ogg_int32_t;
-     typedef unsigned __int32 ogg_uint32_t;
-     typedef __int16 ogg_int16_t;
-     typedef unsigned __int16 ogg_uint16_t;
+#    if defined(_MSC_VER) && (_MSC_VER >= 1800) /* MSVC 2013 and newer */
+#      include <stdint.h>
+       typedef int16_t ogg_int16_t;
+       typedef uint16_t ogg_uint16_t;
+       typedef int32_t ogg_int32_t;
+       typedef uint32_t ogg_uint32_t;
+       typedef int64_t ogg_int64_t;
+       typedef uint64_t ogg_uint64_t;
+#    else
+       /* MSVC/Borland */
+       typedef __int64 ogg_int64_t;
+       typedef __int32 ogg_int32_t;
+       typedef unsigned __int32 ogg_uint32_t;
+       typedef unsigned __int64 ogg_uint64_t;
+       typedef __int16 ogg_int16_t;
+       typedef unsigned __int16 ogg_uint16_t;
+#    endif
 #  endif
 
-#elif defined(__MACOS__)
-
-#  include <sys/types.h>
-   typedef SInt16 ogg_int16_t;
-   typedef UInt16 ogg_uint16_t;
-   typedef SInt32 ogg_int32_t;
-   typedef UInt32 ogg_uint32_t;
-   typedef SInt64 ogg_int64_t;
-
-#elif defined(__MACOSX__) /* MacOS X Framework build */
+#elif (defined(__APPLE__) && defined(__MACH__)) /* MacOS X Framework build */
 
 #  include <sys/types.h>
    typedef int16_t ogg_int16_t;
@@ -72,16 +76,29 @@
    typedef int32_t ogg_int32_t;
    typedef u_int32_t ogg_uint32_t;
    typedef int64_t ogg_int64_t;
+   typedef u_int64_t ogg_uint64_t;
+
+#elif defined(__HAIKU__)
+
+  /* Haiku */
+#  include <sys/types.h>
+   typedef short ogg_int16_t;
+   typedef unsigned short ogg_uint16_t;
+   typedef int ogg_int32_t;
+   typedef unsigned int ogg_uint32_t;
+   typedef long long ogg_int64_t;
+   typedef unsigned long long ogg_uint64_t;
 
 #elif defined(__BEOS__)
 
    /* Be */
 #  include <inttypes.h>
    typedef int16_t ogg_int16_t;
-   typedef u_int16_t ogg_uint16_t;
+   typedef uint16_t ogg_uint16_t;
    typedef int32_t ogg_int32_t;
-   typedef u_int32_t ogg_uint32_t;
+   typedef uint32_t ogg_uint32_t;
    typedef int64_t ogg_int64_t;
+   typedef uint64_t ogg_uint64_t;
 
 #elif defined (__EMX__)
 
@@ -91,6 +108,8 @@
    typedef int ogg_int32_t;
    typedef unsigned int ogg_uint32_t;
    typedef long long ogg_int64_t;
+   typedef unsigned long long ogg_uint64_t;
+
 
 #elif defined (DJGPP)
 
@@ -99,11 +118,13 @@
    typedef int ogg_int32_t;
    typedef unsigned int ogg_uint32_t;
    typedef long long ogg_int64_t;
+   typedef unsigned long long ogg_uint64_t;
 
 #elif defined(R5900)
 
    /* PS2 EE */
    typedef long ogg_int64_t;
+   typedef unsigned long ogg_uint64_t;
    typedef int ogg_int32_t;
    typedef unsigned ogg_uint32_t;
    typedef short ogg_int16_t;
@@ -116,10 +137,20 @@
    typedef signed int ogg_int32_t;
    typedef unsigned int ogg_uint32_t;
    typedef long long int ogg_int64_t;
+   typedef unsigned long long int ogg_uint64_t;
+
+#elif defined(__TMS320C6X__)
+
+   /* TI C64x compiler */
+   typedef signed short ogg_int16_t;
+   typedef unsigned short ogg_uint16_t;
+   typedef signed int ogg_int32_t;
+   typedef unsigned int ogg_uint32_t;
+   typedef long long int ogg_int64_t;
+   typedef unsigned long long int ogg_uint64_t;
 
 #else
 
-#  include <sys/types.h>
 #  include <ogg/config_types.h>
 
 #endif

--- a/Common/libinclude/theora/codec.h
+++ b/Common/libinclude/theora/codec.h
@@ -540,7 +540,7 @@ extern void th_comment_init(th_comment *_tc);
  * \param _tc      The #th_comment struct to add the comment to.
  * \param _comment Must be a null-terminated UTF-8 string containing the
  *                  comment in "TAG=the value" form.*/
-extern void th_comment_add(th_comment *_tc, char *_comment);
+extern void th_comment_add(th_comment *_tc, const char *_comment);
 /**Add a comment to an initialized #th_comment structure.
  * \note Neither th_comment_add() nor th_comment_add_tag() support
  *  comments containing null values, although the bitstream format does
@@ -551,7 +551,7 @@ extern void th_comment_add(th_comment *_tc, char *_comment);
  * \param _tag A null-terminated string containing the tag  associated with
  *              the comment.
  * \param _val The corresponding value as a null-terminated string.*/
-extern void th_comment_add_tag(th_comment *_tc,char *_tag,char *_val);
+extern void th_comment_add_tag(th_comment *_tc,const char *_tag,const char *_val);
 /**Look up a comment value by its tag.
  * \param _tc    An initialized #th_comment structure.
  * \param _tag   The tag to look up.
@@ -567,7 +567,7 @@ extern void th_comment_add_tag(th_comment *_tc,char *_tag,char *_val);
  *         It should not be modified or freed by the application, and
  *          modifications to the structure may invalidate the pointer.
  * \retval NULL If no matching tag is found.*/
-extern char *th_comment_query(th_comment *_tc,char *_tag,int _count);
+extern char *th_comment_query(th_comment *_tc,const char *_tag,int _count);
 /**Look up the number of instances of a tag.
  * Call this first when querying for a specific tag and then iterate over the
  *  number of instances with separate calls to th_comment_query() to
@@ -575,7 +575,7 @@ extern char *th_comment_query(th_comment *_tc,char *_tag,int _count);
  * \param _tc    An initialized #th_comment structure.
  * \param _tag   The tag to look up.
  * \return The number on instances of this particular tag.*/
-extern int th_comment_query_count(th_comment *_tc,char *_tag);
+extern int th_comment_query_count(th_comment *_tc,const char *_tag);
 /**Clears a #th_comment structure.
  * This should be called on a #th_comment structure after it is no longer
  *  needed.

--- a/Common/libinclude/vorbis/codec.h
+++ b/Common/libinclude/vorbis/codec.h
@@ -166,11 +166,11 @@ extern void     vorbis_info_init(vorbis_info *vi);
 extern void     vorbis_info_clear(vorbis_info *vi);
 extern int      vorbis_info_blocksize(vorbis_info *vi,int zo);
 extern void     vorbis_comment_init(vorbis_comment *vc);
-extern void     vorbis_comment_add(vorbis_comment *vc, char *comment);
+extern void     vorbis_comment_add(vorbis_comment *vc, const char *comment);
 extern void     vorbis_comment_add_tag(vorbis_comment *vc,
-				       char *tag, char *contents);
-extern char    *vorbis_comment_query(vorbis_comment *vc, char *tag, int count);
-extern int      vorbis_comment_query_count(vorbis_comment *vc, char *tag);
+				       const char *tag, const char *contents);
+extern char    *vorbis_comment_query(vorbis_comment *vc, const char *tag, int count);
+extern int      vorbis_comment_query_count(vorbis_comment *vc, const char *tag);
 extern void     vorbis_comment_clear(vorbis_comment *vc);
 
 extern int      vorbis_block_init(vorbis_dsp_state *v, vorbis_block *vb);

--- a/Common/libsrc/freetype-2.1.3/src/gzip/ftgzip.c
+++ b/Common/libsrc/freetype-2.1.3/src/gzip/ftgzip.c
@@ -59,6 +59,14 @@
 
 #endif /* !SYSTEM_ZLIB */
 
+#if (defined(__APPLE__) && defined(__MACH__))
+int z_verbose = 0;
+
+void z_error(/* should be const */char* message)
+{
+    // do nothing
+}
+#endif
 
 /***************************************************************************/
 /***************************************************************************/

--- a/Engine/Makefile-defs.osx
+++ b/Engine/Makefile-defs.osx
@@ -1,8 +1,10 @@
 USE_BUILT_IN_LIBSRC = 1
 USE_MIDI_PATCH = 0
 
-INCDIR = ../Engine ../Common ../Common/libinclude ../Plugins ../OSX/include ../OSX/include/freetype2 ../Engine/libsrc/glad/include ../libsrc/glm 
-LIBDIR = ../OSX/lib
+include Makefile-defs.freetype
+
+INCDIR = ../Engine ../Common ../Common/libinclude ../Common/libsrc/alfont-2.0.9 ../Engine/libsrc/apeg-1.2.1/ ../libsrc/mojoAL ../Plugins ../Engine/libsrc/glad/include ../libsrc/glm $(ALLEGRO_SRCDIR)/include
+LIBDIR =
 
 CFLAGS := -O2 -g \
     -fsigned-char -fno-strict-aliasing -fwrapv \
@@ -13,7 +15,7 @@ CFLAGS := -O2 -g \
     -DALLEGRO_STATICLINK \
     -DMAC_VERSION -DBUILTIN_PLUGINS -DHAVE_FSEEKO -DDISABLE_MPEG_AUDIO \
     -D_FILE_OFFSET_BITS=64 -DRTLD_NEXT \
-    $(CFLAGS)
+    $(FT_CFLAGS) $(CFLAGS)
 ifdef BUILD_STR
   CFLAGS += -DBUILD_STR=\"$(BUILD_STR)\"
 endif
@@ -29,13 +31,27 @@ LIBS := -framework Cocoa \
     -framework AudioToolbox \
     -framework CoreVideo\
     -framework IOKit \
-    -lz -ldl -lpthread -lm -lc -lstdc++ -lbz2 \
-    -lalleg -ltheora -logg -lvorbis -lvorbisfile -lfreetype -logg
+    -lz -ldl -lpthread -lm -lc -lstdc++ -lbz2
 
-ifneq ($(USE_BUILT_IN_LIBSRC), 1)
-ALDUMB :=
-LIBS += -laldmb -ldumb
+LIBS += $(FT_LDFLAGS)
+LIBS += $(shell pkg-config --libs ogg)
+LIBS += $(shell pkg-config --libs theora)
+
+ifeq ($(USE_TREMOR), 1)
+LIBS += -lvorbisidec
+CFLAGS += -DUSE_TREMOR
+else
+LIBS += $(shell pkg-config --libs vorbis)
 endif
+LIBS += $(shell pkg-config --libs vorbisfile)
+
+SDL2_CFLAGS = $(shell sdl2-config --cflags)
+SDL2_LIBS = $(shell sdl2-config --libs)
+
+CFLAGS += $(SDL2_CFLAGS)
+LIBS += $(SDL2_LIBS) -lSDL2_sound
+
+LIBS += -ldl -lpthread -lm
 
 PREFIX ?= /usr/local
 CC ?= gcc

--- a/Engine/plugin/plugin_builtin.h
+++ b/Engine/plugin/plugin_builtin.h
@@ -22,12 +22,13 @@
 
 class IAGSEngine;
 
+namespace AGS { namespace Common { class String; }}
 using namespace AGS; // FIXME later
 
 //  Initial implementation for apps to register their own inbuilt plugins
 
 struct InbuiltPluginDetails {
-    String    filename;
+    AGS::Common::String    filename;
     void      (*engineStartup) (IAGSEngine *);
     void      (*engineShutdown) ();
     int       (*onEvent) (int, int);

--- a/OSX/README.md
+++ b/OSX/README.md
@@ -77,3 +77,37 @@ It needs some manual steps to be used.
 - Download xiph [vorbis](https://github.com/xiph/vorbis/archive/84c023699cdf023a32fa4ded32019f194afcdad0.tar.gz) source code, and place in `ags/libsrc/vorbis`
 
 After this, load the `OSX/xcode/ags.xcworkspace` file in Xcode, it will enable building AGSKit, which is a self contained framework like build of AGS Engine, and the `ags` app target, which you can customize with your own game, using the `Resources/` directory, in the same way the CMake build works.
+
+
+## Using the Makefile
+
+You should prefer using the CMake or Xcode project, as the Makefile build is not intended porting your own game, but for running AGS locally. 
+
+You will need to install the necessary xiph libraries (theora, ogg and vorbis):
+
+    brew install theora
+    brew install libogg
+    brew install libvorbis
+    
+Additionally, you also need SDL2
+
+    brew install sdl2
+    
+Make sure you have at least SDL 2.24.1 installed, if you have problems updating sdl2 with brew from a previous version, you can force it using `brew link --overwrite sdl2`.
+
+The SDL_sound available in brew is not really well updated and it's a bit different from what's in the repository, using a different timidity and libmodplug. It's best to build it and install from source. You will need CMake for this.
+
+    SDL2_SOUND_VERSION=8d96d4cc0e1df35835a222ee51a7c32f273ec63e
+    cd /tmp
+    curl -fLsS "https://github.com/icculus/SDL_sound/archive/$SDL2_SOUND_VERSION.tar.gz" --output SDL_sound.tar.gz
+    tar -xvzf SDL_sound.tar.gz
+    mv SDL_sound-$SDL2_SOUND_VERSION SDL_sound
+    cd /tmp/SDL_sound
+    mkdir /tmp/SDL_sound/build
+    cd /tmp/SDL_sound/build
+    cmake -DSDL2_DIR=/usr/local/lib/cmake/SDL2 -DSDL_SOUND  -DSDLSOUND_DECODER_MIDI=1 ..  
+    make && make install
+
+Now you can go to the `Engine/` directory the cloned ags repository, and build it.
+
+    make

--- a/OSX/README.md
+++ b/OSX/README.md
@@ -62,3 +62,18 @@ This will build the executable `AGS.app` in `the build_Release/` directory. The 
 - `MacOS/`, contains the `AGS` engine binary used to run your game.
 
 - `Resources/`, the directory where your game and its resources, including the icon, are placed.
+
+
+## Using the Xcode project
+
+The Xcode project isn't updated often, so you should prefer the CMake generated project. 
+
+It needs some manual steps to be used.
+
+- Download the [SDL2 Framework](https://github.com/libsdl-org/SDL/releases/download/release-2.24.1/SDL2-2.24.1.dmg) from the SDL2 releases, and place it in `ags/OSX/Xcode/AGSKit` directory
+- Download [SDL_sound](https://github.com/icculus/SDL_sound/archive/8d96d4cc0e1df35835a222ee51a7c32f273ec63e.zip) source code and place it in `ags/libsrc/SDL_sound`
+- Download xiph [theora](https://github.com/xiph/theora/archive/7180717276af1ebc7da15c83162d6c5d6203aabf.tar.gz) source code, and place it in `ags/libsrc/theora`
+- Download xiph [ogg](https://github.com/xiph/ogg/archive/refs/tags/v1.3.5.tar.gz		) source code, and place in `ags/libsrc/ogg`
+- Download xiph [vorbis](https://github.com/xiph/vorbis/archive/84c023699cdf023a32fa4ded32019f194afcdad0.tar.gz) source code, and place in `ags/libsrc/vorbis`
+
+After this, load the `OSX/xcode/ags.xcworkspace` file in Xcode, it will enable building AGSKit, which is a self contained framework like build of AGS Engine, and the `ags` app target, which you can customize with your own game, using the `Resources/` directory, in the same way the CMake build works.

--- a/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
+++ b/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
@@ -7,6 +7,374 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2052299628E8EAE700589E91 /* spritefile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2052299228E8EAE500589E91 /* spritefile.h */; };
+		2052299728E8EAE700589E91 /* keycode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2052299328E8EAE600589E91 /* keycode.cpp */; };
+		2052299828E8EAE700589E91 /* spritefile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2052299428E8EAE600589E91 /* spritefile.cpp */; };
+		2052299928E8EAE700589E91 /* keycode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2052299528E8EAE600589E91 /* keycode.h */; };
+		2052299B28E8EB5600589E91 /* platform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2052299A28E8EB5600589E91 /* platform.h */; };
+		2052299F28E8EBA900589E91 /* debugmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2052299C28E8EBA900589E91 /* debugmanager.cpp */; };
+		205229A028E8EBA900589E91 /* debugmanager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2052299D28E8EBA900589E91 /* debugmanager.h */; };
+		205229A128E8EBA900589E91 /* outputhandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2052299E28E8EBA900589E91 /* outputhandler.h */; };
+		205229AB28E8EBE500589E91 /* room_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 205229A228E8EBE300589E91 /* room_file.cpp */; };
+		205229AC28E8EBE500589E91 /* room_file.h in Headers */ = {isa = PBXBuildFile; fileRef = 205229A328E8EBE300589E91 /* room_file.h */; };
+		205229AD28E8EBE500589E91 /* tra_file.h in Headers */ = {isa = PBXBuildFile; fileRef = 205229A428E8EBE300589E91 /* tra_file.h */; };
+		205229AE28E8EBE500589E91 /* room_file_deprecated.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 205229A528E8EBE400589E91 /* room_file_deprecated.cpp */; };
+		205229AF28E8EBE500589E91 /* room_file_base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 205229A628E8EBE400589E91 /* room_file_base.cpp */; };
+		205229B028E8EBE500589E91 /* roomstruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 205229A728E8EBE400589E91 /* roomstruct.h */; };
+		205229B128E8EBE500589E91 /* room_version.h in Headers */ = {isa = PBXBuildFile; fileRef = 205229A828E8EBE400589E91 /* room_version.h */; };
+		205229B228E8EBE500589E91 /* tra_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 205229A928E8EBE500589E91 /* tra_file.cpp */; };
+		205229B328E8EBE500589E91 /* roomstruct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 205229AA28E8EBE500589E91 /* roomstruct.cpp */; };
+		205229BD28E8ECE200589E91 /* alfont.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229BB28E8ECE200589E91 /* alfont.c */; };
+		205229BE28E8ECE200589E91 /* alfont.h in Headers */ = {isa = PBXBuildFile; fileRef = 205229BC28E8ECE200589E91 /* alfont.h */; };
+		205229CE28E8EDE100589E91 /* ftbdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C328E8EDD600589E91 /* ftbdf.c */; };
+		205229CF28E8EDE100589E91 /* ftbase.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C428E8EDD600589E91 /* ftbase.c */; };
+		205229D028E8EDE100589E91 /* ftdebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C528E8EDD600589E91 /* ftdebug.c */; };
+		205229D128E8EDE100589E91 /* ftglyph.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C628E8EDD600589E91 /* ftglyph.c */; };
+		205229D228E8EDE100589E91 /* ftinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C728E8EDD600589E91 /* ftinit.c */; };
+		205229D328E8EDE100589E91 /* ftbbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C828E8EDD600589E91 /* ftbbox.c */; };
+		205229D428E8EDE100589E91 /* ftpfr.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229C928E8EDD700589E91 /* ftpfr.c */; };
+		205229D528E8EDE100589E91 /* fttype1.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229CA28E8EDD700589E91 /* fttype1.c */; };
+		205229D628E8EDE100589E91 /* ftmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229CB28E8EDD700589E91 /* ftmm.c */; };
+		205229D728E8EDE100589E91 /* ftxf86.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229CC28E8EDD700589E91 /* ftxf86.c */; };
+		205229DA28E8EE3000589E91 /* ftsystem.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229D928E8EE3000589E91 /* ftsystem.c */; };
+		205229DC28E8EE5300589E91 /* autohint.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229DB28E8EE5300589E91 /* autohint.c */; };
+		205229DE28E8EE6700589E91 /* bdf.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229DD28E8EE6700589E91 /* bdf.c */; };
+		205229E028E8EE7F00589E91 /* ftcache.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229DF28E8EE7F00589E91 /* ftcache.c */; };
+		205229E228E8EE9B00589E91 /* cff.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229E128E8EE9B00589E91 /* cff.c */; };
+		205229E428E8EEAF00589E91 /* type1cid.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229E328E8EEAF00589E91 /* type1cid.c */; };
+		205229E628E8EED300589E91 /* ftgzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229E528E8EED300589E91 /* ftgzip.c */; };
+		205229E828E8EEEA00589E91 /* pcf.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229E728E8EEEA00589E91 /* pcf.c */; };
+		205229EA28E8F23000589E91 /* pfr.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229E928E8F23000589E91 /* pfr.c */; };
+		205229EE28E8F25B00589E91 /* psaux.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229ED28E8F25A00589E91 /* psaux.c */; };
+		205229F028E8F27800589E91 /* pshinter.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229EF28E8F27800589E91 /* pshinter.c */; };
+		205229F228E8F29900589E91 /* psmodule.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229F128E8F29900589E91 /* psmodule.c */; };
+		205229F428E8F2B700589E91 /* raster.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229F328E8F2B700589E91 /* raster.c */; };
+		205229F628E8F2CF00589E91 /* sfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229F528E8F2CF00589E91 /* sfnt.c */; };
+		205229F828E8F2E200589E91 /* smooth.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229F728E8F2E200589E91 /* smooth.c */; };
+		205229FA28E8F51A00589E91 /* truetype.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229F928E8F51A00589E91 /* truetype.c */; };
+		205229FC28E8F53100589E91 /* type1.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229FB28E8F53000589E91 /* type1.c */; };
+		205229FE28E8F53E00589E91 /* type42.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229FD28E8F53E00589E91 /* type42.c */; };
+		20522A0028E8F54E00589E91 /* winfnt.c in Sources */ = {isa = PBXBuildFile; fileRef = 205229FF28E8F54E00589E91 /* winfnt.c */; };
+		20522A0528E8F7FE00589E91 /* cc_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0228E8F7FD00589E91 /* cc_common.h */; };
+		20522A0628E8F7FE00589E91 /* cc_common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A0328E8F7FD00589E91 /* cc_common.cpp */; };
+		20522A0728E8F7FE00589E91 /* cc_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0428E8F7FD00589E91 /* cc_internal.h */; };
+		20522A1D28E8F81C00589E91 /* stdio_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = 20522A0828E8F81700589E91 /* stdio_compat.c */; };
+		20522A1E28E8F81C00589E91 /* stdio_compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0928E8F81700589E91 /* stdio_compat.h */; };
+		20522A1F28E8F81C00589E91 /* memorystream.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0A28E8F81800589E91 /* memorystream.h */; };
+		20522A2028E8F81C00589E91 /* data_ext.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0B28E8F81800589E91 /* data_ext.h */; };
+		20522A2128E8F81C00589E91 /* memory_compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0C28E8F81800589E91 /* memory_compat.h */; };
+		20522A2228E8F81C00589E91 /* error.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A0D28E8F81800589E91 /* error.h */; };
+		20522A2328E8F81C00589E91 /* cmdlineopts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A0E28E8F81900589E91 /* cmdlineopts.cpp */; };
+		20522A2428E8F81C00589E91 /* android_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A0F28E8F81900589E91 /* android_file.cpp */; };
+		20522A2528E8F81C00589E91 /* bufferedstream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1028E8F81900589E91 /* bufferedstream.cpp */; };
+		20522A2628E8F81C00589E91 /* aasset_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1128E8F81900589E91 /* aasset_stream.cpp */; };
+		20522A2728E8F81C00589E91 /* memorystream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1228E8F81A00589E91 /* memorystream.cpp */; };
+		20522A2828E8F81C00589E91 /* string_compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1328E8F81A00589E91 /* string_compat.h */; };
+		20522A2928E8F81C00589E91 /* string_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1428E8F81A00589E91 /* string_compat.c */; };
+		20522A2A28E8F81C00589E91 /* utf8.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1528E8F81A00589E91 /* utf8.h */; };
+		20522A2B28E8F81C00589E91 /* scaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1628E8F81A00589E91 /* scaling.h */; };
+		20522A2C28E8F81C00589E91 /* path_ex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1728E8F81B00589E91 /* path_ex.cpp */; };
+		20522A2D28E8F81C00589E91 /* data_ext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A1828E8F81B00589E91 /* data_ext.cpp */; };
+		20522A2E28E8F81C00589E91 /* cmdlineopts.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1928E8F81B00589E91 /* cmdlineopts.h */; };
+		20522A2F28E8F81C00589E91 /* android_file.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1A28E8F81B00589E91 /* android_file.h */; };
+		20522A3028E8F81C00589E91 /* bufferedstream.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1B28E8F81B00589E91 /* bufferedstream.h */; };
+		20522A3128E8F81C00589E91 /* aasset_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A1C28E8F81C00589E91 /* aasset_stream.h */; };
+		20522A3C28E8F86400589E91 /* scriptviewport.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3228E8F86200589E91 /* scriptviewport.h */; };
+		20522A3D28E8F86400589E91 /* scriptcamera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A3328E8F86200589E91 /* scriptcamera.cpp */; };
+		20522A3E28E8F86400589E91 /* cc_dynamicobject_addr_and_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3428E8F86200589E91 /* cc_dynamicobject_addr_and_manager.h */; };
+		20522A3F28E8F86400589E91 /* scriptcamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3528E8F86200589E91 /* scriptcamera.h */; };
+		20522A4028E8F86400589E91 /* scriptcontainers.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3628E8F86200589E91 /* scriptcontainers.h */; };
+		20522A4128E8F86400589E91 /* scriptdict.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3728E8F86300589E91 /* scriptdict.h */; };
+		20522A4228E8F86400589E91 /* scriptset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A3828E8F86300589E91 /* scriptset.cpp */; };
+		20522A4328E8F86400589E91 /* scriptset.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A3928E8F86300589E91 /* scriptset.h */; };
+		20522A4428E8F86400589E91 /* scriptviewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A3A28E8F86300589E91 /* scriptviewport.cpp */; };
+		20522A4528E8F86400589E91 /* scriptdict.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A3B28E8F86400589E91 /* scriptdict.cpp */; };
+		20522A4928E8F8AA00589E91 /* draw_software.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A4628E8F8A900589E91 /* draw_software.h */; };
+		20522A4A28E8F8AA00589E91 /* draw_software.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A4728E8F8A900589E91 /* draw_software.cpp */; };
+		20522A4B28E8F8AA00589E91 /* asset_helper.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A4828E8F8AA00589E91 /* asset_helper.h */; };
+		20522A5328E8F8CB00589E91 /* route_finder_impl_legacy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A4C28E8F8CA00589E91 /* route_finder_impl_legacy.cpp */; };
+		20522A5428E8F8CB00589E91 /* route_finder_impl_legacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A4D28E8F8CA00589E91 /* route_finder_impl_legacy.h */; };
+		20522A5528E8F8CB00589E91 /* path_helper.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A4E28E8F8CA00589E91 /* path_helper.h */; };
+		20522A5628E8F8CB00589E91 /* route_finder_jps.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20522A4F28E8F8CA00589E91 /* route_finder_jps.inl */; };
+		20522A5728E8F8CB00589E91 /* route_finder_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A5028E8F8CA00589E91 /* route_finder_impl.h */; };
+		20522A5828E8F8CB00589E91 /* scriptcontainers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A5128E8F8CA00589E91 /* scriptcontainers.cpp */; };
+		20522A5928E8F8CB00589E91 /* route_finder_impl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A5228E8F8CB00589E91 /* route_finder_impl.cpp */; };
+		20522A5D28E8F8DD00589E91 /* viewport_script.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A5A28E8F8DD00589E91 /* viewport_script.cpp */; };
+		20522A5E28E8F8DD00589E91 /* sys_events.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A5B28E8F8DD00589E91 /* sys_events.h */; };
+		20522A5F28E8F8DD00589E91 /* sys_events.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A5C28E8F8DD00589E91 /* sys_events.cpp */; };
+		20522A6228E8F8FD00589E91 /* messagebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A6028E8F8FC00589E91 /* messagebuffer.h */; };
+		20522A6328E8F8FD00589E91 /* messagebuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A6128E8F8FC00589E91 /* messagebuffer.cpp */; };
+		20522A6928E8F92100589E91 /* viewport.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A6428E8F92000589E91 /* viewport.h */; };
+		20522A6A28E8F92100589E91 /* savegame_components.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A6528E8F92000589E91 /* savegame_components.h */; };
+		20522A6B28E8F92100589E91 /* savegame_components.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A6628E8F92000589E91 /* savegame_components.cpp */; };
+		20522A6C28E8F92100589E91 /* viewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A6728E8F92000589E91 /* viewport.cpp */; };
+		20522A6D28E8F92100589E91 /* savegame_v321.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A6828E8F92100589E91 /* savegame_v321.cpp */; };
+		20522A7328E8F94100589E91 /* gfxfilter_aaogl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A6E28E8F94000589E91 /* gfxfilter_aaogl.cpp */; };
+		20522A7428E8F94100589E91 /* gfxfilter_aaogl.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A6F28E8F94000589E91 /* gfxfilter_aaogl.h */; };
+		20522A7528E8F94100589E91 /* gfxfilter_sdl_renderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A7028E8F94000589E91 /* gfxfilter_sdl_renderer.h */; };
+		20522A7628E8F94100589E91 /* ogl_headers.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A7128E8F94100589E91 /* ogl_headers.h */; };
+		20522A7728E8F94100589E91 /* gfxfilter_sdl_renderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A7228E8F94100589E91 /* gfxfilter_sdl_renderer.cpp */; };
+		20522A8228E8F98400589E91 /* khrplatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A7C28E8F98400589E91 /* khrplatform.h */; };
+		20522A8328E8F98400589E91 /* glad.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A7E28E8F98400589E91 /* glad.h */; };
+		20522A8428E8F98400589E91 /* glad.c in Sources */ = {isa = PBXBuildFile; fileRef = 20522A8028E8F98400589E91 /* glad.c */; };
+		20522A8628E8F9D600589E91 /* main_sdl2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A8528E8F9D600589E91 /* main_sdl2.cpp */; };
+		20522A8928E8FD2B00589E91 /* sdl2_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A8728E8FD2B00589E91 /* sdl2_util.h */; };
+		20522A8A28E8FD2B00589E91 /* sdl2_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A8828E8FD2B00589E91 /* sdl2_util.cpp */; };
+		20522A9028E8FD6000589E91 /* plugin_engine.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A8E28E8FD6000589E91 /* plugin_engine.h */; };
+		20522A9328E8FD7700589E91 /* sys_main.h in Headers */ = {isa = PBXBuildFile; fileRef = 20522A9128E8FD7600589E91 /* sys_main.h */; };
+		20522A9428E8FD7700589E91 /* sys_main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20522A9228E8FD7700589E91 /* sys_main.cpp */; };
+		20C76AB528F34A1900772CFC /* include in Resources */ = {isa = PBXBuildFile; fileRef = 205229C128E8ED4400589E91 /* include */; };
+		20E67D6428F1BDE000B95C00 /* gfx.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0A28F1BDDF00B95C00 /* gfx.c */; };
+		20E67D6528F1BDE000B95C00 /* unicode.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0B28F1BDDF00B95C00 /* unicode.c */; };
+		20E67D6628F1BDE000B95C00 /* blit.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0C28F1BDDF00B95C00 /* blit.c */; };
+		20E67D6728F1BDE000B95C00 /* math.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0D28F1BDDF00B95C00 /* math.c */; };
+		20E67D6828F1BDE000B95C00 /* pcx.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0E28F1BDDF00B95C00 /* pcx.c */; };
+		20E67D6928F1BDE000B95C00 /* fli.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0F28F1BDDF00B95C00 /* fli.c */; };
+		20E67D6A28F1BDE000B95C00 /* rotate.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1028F1BDDF00B95C00 /* rotate.c */; };
+		20E67D6B28F1BDE000B95C00 /* flood.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1128F1BDDF00B95C00 /* flood.c */; };
+		20E67D6C28F1BDE000B95C00 /* vtable32.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1228F1BDDF00B95C00 /* vtable32.c */; };
+		20E67D6F28F1BDE000B95C00 /* graphics.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1628F1BDDF00B95C00 /* graphics.c */; };
+		20E67D7028F1BDE000B95C00 /* vtable.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1728F1BDDF00B95C00 /* vtable.c */; };
+		20E67D7128F1BDE000B95C00 /* libc.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1828F1BDDF00B95C00 /* libc.c */; };
+		20E67D7228F1BDE000B95C00 /* polygon.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1928F1BDDF00B95C00 /* polygon.c */; };
+		20E67D7328F1BDE000B95C00 /* vtable16.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1A28F1BDDF00B95C00 /* vtable16.c */; };
+		20E67D7428F1BDE000B95C00 /* ufile.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1C28F1BDDF00B95C00 /* ufile.c */; };
+		20E67D7528F1BDE000B95C00 /* quantize.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1D28F1BDDF00B95C00 /* quantize.c */; };
+		20E67D7628F1BDE000B95C00 /* colblend.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1E28F1BDDF00B95C00 /* colblend.c */; };
+		20E67D7728F1BDE000B95C00 /* dither.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1F28F1BDDF00B95C00 /* dither.c */; };
+		20E67D7828F1BDE000B95C00 /* dataregi.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2028F1BDDF00B95C00 /* dataregi.c */; };
+		20E67D7928F1BDE000B95C00 /* allegro.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2128F1BDDF00B95C00 /* allegro.c */; };
+		20E67D7A28F1BDE000B95C00 /* vtable15.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2228F1BDDF00B95C00 /* vtable15.c */; };
+		20E67D7B28F1BDE000B95C00 /* readbmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2328F1BDDF00B95C00 /* readbmp.c */; };
+		20E67D7C28F1BDE000B95C00 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2428F1BDDF00B95C00 /* file.c */; };
+		20E67D7D28F1BDE000B95C00 /* bmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2528F1BDDF00B95C00 /* bmp.c */; };
+		20E67D7E28F1BDE000B95C00 /* vtable8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2628F1BDDF00B95C00 /* vtable8.c */; };
+		20E67D7F28F1BDE000B95C00 /* cblit.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D2828F1BDDF00B95C00 /* cblit.h */; };
+		20E67D8028F1BDE000B95C00 /* cspr8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2928F1BDDF00B95C00 /* cspr8.c */; };
+		20E67D8128F1BDE000B95C00 /* cspr16.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2A28F1BDDF00B95C00 /* cspr16.c */; };
+		20E67D8228F1BDE000B95C00 /* cblit16.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2B28F1BDDF00B95C00 /* cblit16.c */; };
+		20E67D8328F1BDE000B95C00 /* cspr24.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2C28F1BDDF00B95C00 /* cspr24.c */; };
+		20E67D8428F1BDE000B95C00 /* cgfx8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2D28F1BDDF00B95C00 /* cgfx8.c */; };
+		20E67D8528F1BDE000B95C00 /* cblit24.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2E28F1BDDF00B95C00 /* cblit24.c */; };
+		20E67D8628F1BDE000B95C00 /* cdefs32.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D2F28F1BDDF00B95C00 /* cdefs32.h */; };
+		20E67D8728F1BDE000B95C00 /* cspr15.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3028F1BDDF00B95C00 /* cspr15.c */; };
+		20E67D8828F1BDE000B95C00 /* cmisc.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3128F1BDDF00B95C00 /* cmisc.c */; };
+		20E67D8928F1BDE000B95C00 /* cgfx32.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3228F1BDDF00B95C00 /* cgfx32.c */; };
+		20E67D8A28F1BDE000B95C00 /* cgfx.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3328F1BDDF00B95C00 /* cgfx.h */; };
+		20E67D8B28F1BDE000B95C00 /* cdefs16.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3428F1BDDF00B95C00 /* cdefs16.h */; };
+		20E67D8C28F1BDE000B95C00 /* cgfx16.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3528F1BDDF00B95C00 /* cgfx16.c */; };
+		20E67D8D28F1BDE000B95C00 /* cstretch.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3628F1BDDF00B95C00 /* cstretch.c */; };
+		20E67D8E28F1BDE000B95C00 /* cdefs24.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3728F1BDDF00B95C00 /* cdefs24.h */; };
+		20E67D8F28F1BDE000B95C00 /* cgfx24.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3828F1BDDF00B95C00 /* cgfx24.c */; };
+		20E67D9028F1BDE000B95C00 /* cspr.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3928F1BDDF00B95C00 /* cspr.h */; };
+		20E67D9128F1BDE000B95C00 /* cspr32.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3A28F1BDDF00B95C00 /* cspr32.c */; };
+		20E67D9228F1BDE000B95C00 /* cblit8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3B28F1BDDF00B95C00 /* cblit8.c */; };
+		20E67D9328F1BDE000B95C00 /* cdefs15.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3C28F1BDDF00B95C00 /* cdefs15.h */; };
+		20E67D9428F1BDE000B95C00 /* cdefs8.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D3D28F1BDDF00B95C00 /* cdefs8.h */; };
+		20E67D9528F1BDE000B95C00 /* cblit32.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3E28F1BDDF00B95C00 /* cblit32.c */; };
+		20E67D9628F1BDE000B95C00 /* cgfx15.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D3F28F1BDDF00B95C00 /* cgfx15.c */; };
+		20E67D9728F1BDE000B95C00 /* vtable24.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D4028F1BDDF00B95C00 /* vtable24.c */; };
+		20E67D9828F1BDE000B95C00 /* inline.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D4128F1BDDF00B95C00 /* inline.c */; };
+		20E67D9928F1BDE000B95C00 /* color.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D4228F1BDDF00B95C00 /* color.c */; };
+		20E67D9B28F1BDE000B95C00 /* allegro.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4528F1BDE000B95C00 /* allegro.h */; };
+		20E67D9C28F1BDE000B95C00 /* datafile.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4728F1BDE000B95C00 /* datafile.h */; };
+		20E67D9D28F1BDE000B95C00 /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4828F1BDE000B95C00 /* debug.h */; };
+		20E67D9E28F1BDE000B95C00 /* fixed.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4928F1BDE000B95C00 /* fixed.h */; };
+		20E67D9F28F1BDE000B95C00 /* file.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4A28F1BDE000B95C00 /* file.h */; };
+		20E67DA028F1BDE000B95C00 /* astdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4C28F1BDE000B95C00 /* astdint.h */; };
+		20E67DA328F1BDE000B95C00 /* alosxcfg.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4F28F1BDE000B95C00 /* alosxcfg.h */; };
+		20E67DA628F1BDE000B95C00 /* aintern.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5328F1BDE000B95C00 /* aintern.h */; };
+		20E67DA728F1BDE000B95C00 /* alconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5428F1BDE000B95C00 /* alconfig.h */; };
+		20E67DA828F1BDE000B95C00 /* color.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5528F1BDE000B95C00 /* color.h */; };
+		20E67DA928F1BDE000B95C00 /* draw.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20E67D5728F1BDE000B95C00 /* draw.inl */; };
+		20E67DAA28F1BDE000B95C00 /* gfx.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20E67D5828F1BDE000B95C00 /* gfx.inl */; };
+		20E67DAB28F1BDE000B95C00 /* fmaths.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20E67D5928F1BDE000B95C00 /* fmaths.inl */; };
+		20E67DAC28F1BDE000B95C00 /* color.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20E67D5A28F1BDE000B95C00 /* color.inl */; };
+		20E67DAD28F1BDE000B95C00 /* fix.inl in Resources */ = {isa = PBXBuildFile; fileRef = 20E67D5B28F1BDE000B95C00 /* fix.inl */; };
+		20E67DAE28F1BDE000B95C00 /* fmaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5C28F1BDE000B95C00 /* fmaths.h */; };
+		20E67DAF28F1BDE000B95C00 /* unicode.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5D28F1BDE000B95C00 /* unicode.h */; };
+		20E67DB028F1BDE000B95C00 /* palette.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5E28F1BDE000B95C00 /* palette.h */; };
+		20E67DB128F1BDE000B95C00 /* gfx.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D5F28F1BDE000B95C00 /* gfx.h */; };
+		20E67DB228F1BDE000B95C00 /* fli.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D6028F1BDE000B95C00 /* fli.h */; };
+		20E67DB328F1BDE000B95C00 /* system.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D6128F1BDE000B95C00 /* system.h */; };
+		20E67DB428F1BDE000B95C00 /* draw.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D6228F1BDE000B95C00 /* draw.h */; };
+		20E67DB528F1BDE000B95C00 /* base.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D6328F1BDE000B95C00 /* base.h */; };
+		20E6810528F1BE5D00B95C00 /* al.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810228F1BE5C00B95C00 /* al.h */; };
+		20E6810628F1BE5D00B95C00 /* alc.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810328F1BE5C00B95C00 /* alc.h */; };
+		20E6810728F1BE5D00B95C00 /* mojoal.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6810428F1BE5D00B95C00 /* mojoal.c */; };
+		20E6810B28F1C7D000B95C00 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6810A28F1C7D000B95C00 /* SDL2.framework */; };
+		20E6811428F1C98400B95C00 /* apeg.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810C28F1C98200B95C00 /* apeg.h */; };
+		20E6811528F1C98400B95C00 /* l2tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810D28F1C98200B95C00 /* l2tables.h */; };
+		20E6811628F1C98400B95C00 /* getblk.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810E28F1C98200B95C00 /* getblk.h */; };
+		20E6811728F1C98400B95C00 /* mpg123.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6810F28F1C98300B95C00 /* mpg123.h */; };
+		20E6811828F1C98400B95C00 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6811028F1C98300B95C00 /* common.h */; };
+		20E6811928F1C98400B95C00 /* mpeg1dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6811128F1C98300B95C00 /* mpeg1dec.h */; };
+		20E6811A28F1C98400B95C00 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6811228F1C98300B95C00 /* huffman.h */; };
+		20E6811B28F1C98400B95C00 /* getbits.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6811328F1C98300B95C00 /* getbits.h */; };
+		20E681F328F1D2A800B95C00 /* SDL_sound_coreaudio.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681E528F1D2A100B95C00 /* SDL_sound_coreaudio.c */; };
+		20E681F428F1D2A800B95C00 /* SDL_sound_modplug.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681E628F1D2A200B95C00 /* SDL_sound_modplug.c */; };
+		20E681F528F1D2A800B95C00 /* SDL_sound_aiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681E728F1D2A200B95C00 /* SDL_sound_aiff.c */; };
+		20E681F628F1D2A800B95C00 /* SDL_sound_mp3.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681E828F1D2A200B95C00 /* SDL_sound_mp3.c */; };
+		20E681F728F1D2A800B95C00 /* SDL_sound_voc.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681E928F1D2A200B95C00 /* SDL_sound_voc.c */; };
+		20E681F828F1D2A800B95C00 /* SDL_sound_flac.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681EA28F1D2A200B95C00 /* SDL_sound_flac.c */; };
+		20E681F928F1D2A800B95C00 /* SDL_sound_midi.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681EB28F1D2A200B95C00 /* SDL_sound_midi.c */; };
+		20E681FA28F1D2A800B95C00 /* SDL_sound_au.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681EC28F1D2A200B95C00 /* SDL_sound_au.c */; };
+		20E681FC28F1D2A800B95C00 /* SDL_sound_raw.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681EE28F1D2A300B95C00 /* SDL_sound_raw.c */; };
+		20E681FD28F1D2A800B95C00 /* SDL_sound_vorbis.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681EF28F1D2A700B95C00 /* SDL_sound_vorbis.c */; };
+		20E681FE28F1D2A800B95C00 /* SDL_sound_wav.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681F028F1D2A700B95C00 /* SDL_sound_wav.c */; };
+		20E681FF28F1D2A800B95C00 /* SDL_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681F128F1D2A800B95C00 /* SDL_sound.c */; };
+		20E6820028F1D2A800B95C00 /* SDL_sound_shn.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E681F228F1D2A800B95C00 /* SDL_sound_shn.c */; };
+		20E6822328F1D2B400B95C00 /* load_okt.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820228F1D2B300B95C00 /* load_okt.c */; };
+		20E6822428F1D2B400B95C00 /* sndfile.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820328F1D2B300B95C00 /* sndfile.c */; };
+		20E6822528F1D2B400B95C00 /* load_amf.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820428F1D2B300B95C00 /* load_amf.c */; };
+		20E6822628F1D2B400B95C00 /* modplug.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6820528F1D2B300B95C00 /* modplug.h */; };
+		20E6822728F1D2B400B95C00 /* load_mtm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820628F1D2B300B95C00 /* load_mtm.c */; };
+		20E6822828F1D2B400B95C00 /* load_ult.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820728F1D2B300B95C00 /* load_ult.c */; };
+		20E6822928F1D2B400B95C00 /* load_far.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820828F1D2B300B95C00 /* load_far.c */; };
+		20E6822A28F1D2B400B95C00 /* load_psm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820928F1D2B300B95C00 /* load_psm.c */; };
+		20E6822B28F1D2B400B95C00 /* load_xm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820A28F1D2B300B95C00 /* load_xm.c */; };
+		20E6822C28F1D2B400B95C00 /* load_dmf.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820B28F1D2B300B95C00 /* load_dmf.c */; };
+		20E6822D28F1D2B400B95C00 /* load_dsm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820C28F1D2B300B95C00 /* load_dsm.c */; };
+		20E6822E28F1D2B400B95C00 /* load_gdm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820D28F1D2B300B95C00 /* load_gdm.c */; };
+		20E6822F28F1D2B400B95C00 /* libmodplug.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6820E28F1D2B300B95C00 /* libmodplug.h */; };
+		20E6823028F1D2B400B95C00 /* load_mdl.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6820F28F1D2B300B95C00 /* load_mdl.c */; };
+		20E6823128F1D2B400B95C00 /* load_s3m.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821028F1D2B300B95C00 /* load_s3m.c */; };
+		20E6823228F1D2B400B95C00 /* load_669.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821128F1D2B300B95C00 /* load_669.c */; };
+		20E6823328F1D2B400B95C00 /* mmcmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821228F1D2B300B95C00 /* mmcmp.c */; };
+		20E6823428F1D2B400B95C00 /* load_it.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821328F1D2B300B95C00 /* load_it.c */; };
+		20E6823528F1D2B400B95C00 /* snd_fx.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821428F1D2B300B95C00 /* snd_fx.c */; };
+		20E6823628F1D2B400B95C00 /* snd_flt.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821528F1D2B300B95C00 /* snd_flt.c */; };
+		20E6823728F1D2B400B95C00 /* load_ams.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821628F1D2B300B95C00 /* load_ams.c */; };
+		20E6823828F1D2B400B95C00 /* sndmix.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821728F1D2B300B95C00 /* sndmix.c */; };
+		20E6823928F1D2B400B95C00 /* snd_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821828F1D2B300B95C00 /* snd_dsp.c */; };
+		20E6823A28F1D2B400B95C00 /* tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6821928F1D2B300B95C00 /* tables.h */; };
+		20E6823B28F1D2B400B95C00 /* load_dbm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821A28F1D2B300B95C00 /* load_dbm.c */; };
+		20E6823C28F1D2B400B95C00 /* modplug.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821B28F1D2B300B95C00 /* modplug.c */; };
+		20E6823D28F1D2B400B95C00 /* load_umx.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821C28F1D2B300B95C00 /* load_umx.c */; };
+		20E6823E28F1D2B400B95C00 /* load_mod.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821D28F1D2B300B95C00 /* load_mod.c */; };
+		20E6823F28F1D2B400B95C00 /* load_stm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821E28F1D2B300B95C00 /* load_stm.c */; };
+		20E6824028F1D2B400B95C00 /* load_ptm.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6821F28F1D2B300B95C00 /* load_ptm.c */; };
+		20E6824128F1D2B400B95C00 /* fastmix.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6822028F1D2B300B95C00 /* fastmix.c */; };
+		20E6824228F1D2B400B95C00 /* load_med.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6822128F1D2B300B95C00 /* load_med.c */; };
+		20E6824328F1D2B400B95C00 /* load_mt2.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6822228F1D2B300B95C00 /* load_mt2.c */; };
+		20E6825F28F1D2C400B95C00 /* resample.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6824528F1D2C300B95C00 /* resample.h */; };
+		20E6826028F1D2C400B95C00 /* common.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6824628F1D2C300B95C00 /* common.c */; };
+		20E6826228F1D2C400B95C00 /* tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6824828F1D2C300B95C00 /* tables.c */; };
+		20E6826328F1D2C400B95C00 /* mix.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6824928F1D2C300B95C00 /* mix.h */; };
+		20E6826428F1D2C400B95C00 /* readmidi.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6824A28F1D2C300B95C00 /* readmidi.c */; };
+		20E6826728F1D2C400B95C00 /* playmidi.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6824D28F1D2C300B95C00 /* playmidi.h */; };
+		20E6826828F1D2C400B95C00 /* instrum.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6824E28F1D2C300B95C00 /* instrum.c */; };
+		20E6826A28F1D2C400B95C00 /* options.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825028F1D2C300B95C00 /* options.h */; };
+		20E6826B28F1D2C400B95C00 /* timidity.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825128F1D2C300B95C00 /* timidity.h */; };
+		20E6826C28F1D2C400B95C00 /* output.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825228F1D2C300B95C00 /* output.h */; };
+		20E6826F28F1D2C400B95C00 /* tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825528F1D2C300B95C00 /* tables.h */; };
+		20E6827028F1D2C400B95C00 /* resample.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6825628F1D2C400B95C00 /* resample.c */; };
+		20E6827228F1D2C400B95C00 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825828F1D2C400B95C00 /* common.h */; };
+		20E6827328F1D2C400B95C00 /* mix.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6825928F1D2C400B95C00 /* mix.c */; };
+		20E6827428F1D2C400B95C00 /* playmidi.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6825A28F1D2C400B95C00 /* playmidi.c */; };
+		20E6827528F1D2C400B95C00 /* readmidi.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825B28F1D2C400B95C00 /* readmidi.h */; };
+		20E6827628F1D2C400B95C00 /* output.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6825C28F1D2C400B95C00 /* output.c */; };
+		20E6827728F1D2C400B95C00 /* timidity.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6825D28F1D2C400B95C00 /* timidity.c */; };
+		20E6827828F1D2C400B95C00 /* instrum.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6825E28F1D2C400B95C00 /* instrum.h */; };
+		20E6828128F1D32D00B95C00 /* audio_core.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6827928F1D32C00B95C00 /* audio_core.cpp */; };
+		20E6828228F1D32D00B95C00 /* sdldecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6827A28F1D32C00B95C00 /* sdldecoder.cpp */; };
+		20E6828328F1D32D00B95C00 /* audio_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6827B28F1D32C00B95C00 /* audio_core.h */; };
+		20E6828428F1D32D00B95C00 /* audio_system.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6827C28F1D32C00B95C00 /* audio_system.h */; };
+		20E6828528F1D32D00B95C00 /* sdldecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6827D28F1D32D00B95C00 /* sdldecoder.h */; };
+		20E6828628F1D32D00B95C00 /* openalsource.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6827E28F1D32D00B95C00 /* openalsource.h */; };
+		20E6828728F1D32D00B95C00 /* openalsource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6827F28F1D32D00B95C00 /* openalsource.cpp */; };
+		20E6828828F1D32D00B95C00 /* openal.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6828028F1D32D00B95C00 /* openal.h */; };
+		20E6837128F20BFD00B95C00 /* framing.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6836E28F20BFD00B95C00 /* framing.c */; };
+		20E6837228F20BFD00B95C00 /* crctable.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6836F28F20BFD00B95C00 /* crctable.h */; };
+		20E6837328F20BFD00B95C00 /* bitwise.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6837028F20BFD00B95C00 /* bitwise.c */; };
+		20E683C528F20C7200B95C00 /* window.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6837428F20C6200B95C00 /* window.h */; };
+		20E683C628F20C7200B95C00 /* psy.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6837528F20C6200B95C00 /* psy.h */; };
+		20E683C728F20C7200B95C00 /* psy.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6837628F20C6300B95C00 /* psy.c */; };
+		20E683C828F20C7200B95C00 /* lookup_data.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6837728F20C6300B95C00 /* lookup_data.h */; };
+		20E683D128F20C7200B95C00 /* synthesis.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838428F20C6300B95C00 /* synthesis.c */; };
+		20E683D228F20C7200B95C00 /* floor0.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838528F20C6300B95C00 /* floor0.c */; };
+		20E683D328F20C7200B95C00 /* mapping0.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838628F20C6300B95C00 /* mapping0.c */; };
+		20E683D428F20C7200B95C00 /* highlevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6838728F20C6300B95C00 /* highlevel.h */; };
+		20E683D528F20C7200B95C00 /* block.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838828F20C6400B95C00 /* block.c */; };
+		20E683D828F20C7200B95C00 /* smallft.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838C28F20C6400B95C00 /* smallft.c */; };
+		20E683D928F20C7200B95C00 /* lpc.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838D28F20C6500B95C00 /* lpc.c */; };
+		20E683DA28F20C7200B95C00 /* misc.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6838E28F20C6500B95C00 /* misc.c */; };
+		20E683DB28F20C7200B95C00 /* backends.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6838F28F20C6500B95C00 /* backends.h */; };
+		20E683DC28F20C7200B95C00 /* sharedbook.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6839028F20C6500B95C00 /* sharedbook.c */; };
+		20E683DD28F20C7200B95C00 /* res0.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6839128F20C6500B95C00 /* res0.c */; };
+		20E683DE28F20C7200B95C00 /* lookup.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6839228F20C6600B95C00 /* lookup.h */; };
+		20E683E028F20C7200B95C00 /* bitrate.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6839428F20C6600B95C00 /* bitrate.h */; };
+		20E683E128F20C7200B95C00 /* masking.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6839528F20C6600B95C00 /* masking.h */; };
+		20E683F628F20C7300B95C00 /* mdct.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683AB28F20C6600B95C00 /* mdct.c */; };
+		20E683F728F20C7300B95C00 /* floor1.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683AC28F20C6700B95C00 /* floor1.c */; };
+		20E683F828F20C7300B95C00 /* window.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683AD28F20C6700B95C00 /* window.c */; };
+		20E683FA28F20C7300B95C00 /* registry.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683AF28F20C6700B95C00 /* registry.c */; };
+		20E683FB28F20C7300B95C00 /* lookup.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683B028F20C6800B95C00 /* lookup.c */; };
+		20E683FC28F20C7300B95C00 /* scales.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B128F20C6D00B95C00 /* scales.h */; };
+		20E683FD28F20C7300B95C00 /* smallft.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B228F20C6D00B95C00 /* smallft.h */; };
+		20E683FE28F20C7300B95C00 /* lsp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683B328F20C6D00B95C00 /* lsp.c */; };
+		20E683FF28F20C7300B95C00 /* analysis.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683B428F20C6D00B95C00 /* analysis.c */; };
+		20E6840028F20C7300B95C00 /* os.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B528F20C6E00B95C00 /* os.h */; };
+		20E6840228F20C7300B95C00 /* lsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B728F20C6E00B95C00 /* lsp.h */; };
+		20E6840328F20C7300B95C00 /* registry.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B828F20C6E00B95C00 /* registry.h */; };
+		20E6840428F20C7300B95C00 /* mdct.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683B928F20C6E00B95C00 /* mdct.h */; };
+		20E6840528F20C7300B95C00 /* bitrate.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683BA28F20C6F00B95C00 /* bitrate.c */; };
+		20E6840628F20C7300B95C00 /* codec_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683BB28F20C7000B95C00 /* codec_internal.h */; };
+		20E6840728F20C7300B95C00 /* lpc.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683BC28F20C7000B95C00 /* lpc.h */; };
+		20E6840828F20C7300B95C00 /* codebook.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683BD28F20C7000B95C00 /* codebook.c */; };
+		20E6840928F20C7300B95C00 /* envelope.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683BE28F20C7000B95C00 /* envelope.h */; };
+		20E6840A28F20C7300B95C00 /* codebook.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683BF28F20C7100B95C00 /* codebook.h */; };
+		20E6840D28F20C7300B95C00 /* misc.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E683C228F20C7100B95C00 /* misc.h */; };
+		20E6840E28F20C7300B95C00 /* envelope.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683C328F20C7200B95C00 /* envelope.c */; };
+		20E6840F28F20C7300B95C00 /* info.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E683C428F20C7200B95C00 /* info.c */; };
+		20E6847F28F20CC700B95C00 /* huffdec.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6841228F20CBC00B95C00 /* huffdec.h */; };
+		20E6848228F20CC700B95C00 /* fragment.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6841528F20CBD00B95C00 /* fragment.c */; };
+		20E6848628F20CC700B95C00 /* bitpack.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6841928F20CBE00B95C00 /* bitpack.h */; };
+		20E6849A28F20CC700B95C00 /* quant.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6842E28F20CBE00B95C00 /* quant.h */; };
+		20E6849D28F20CC700B95C00 /* internal.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6843128F20CBF00B95C00 /* internal.c */; };
+		20E6849F28F20CC700B95C00 /* idct.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6843328F20CBF00B95C00 /* idct.c */; };
+		20E684A128F20CC700B95C00 /* state.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6843528F20CBF00B95C00 /* state.c */; };
+		20E684AA28F20CC700B95C00 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6843E28F20CC100B95C00 /* huffman.h */; };
+		20E684AB28F20CC700B95C00 /* huffdec.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6843F28F20CC100B95C00 /* huffdec.c */; };
+		20E684AE28F20CC700B95C00 /* bitpack.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6844228F20CC200B95C00 /* bitpack.c */; };
+		20E684AF28F20CC700B95C00 /* state.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6844328F20CC200B95C00 /* state.h */; };
+		20E684B228F20CC700B95C00 /* dequant.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6844628F20CC300B95C00 /* dequant.c */; };
+		20E684B328F20CC700B95C00 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6844728F20CC300B95C00 /* quant.c */; };
+		20E684B428F20CC700B95C00 /* apiwrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6844828F20CC300B95C00 /* apiwrapper.c */; };
+		20E684B928F20CC700B95C00 /* dequant.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6844D28F20CC400B95C00 /* dequant.h */; };
+		20E684BA28F20CC700B95C00 /* apiwrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6844E28F20CC400B95C00 /* apiwrapper.h */; };
+		20E684C328F20CC700B95C00 /* info.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E6845828F20CC500B95C00 /* info.c */; };
+		20E684D128F20CC700B95C00 /* internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6846728F20CC500B95C00 /* internal.h */; };
+		20E684E928F20E0700B95C00 /* decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E684E628F20E0700B95C00 /* decode.c */; };
+		20E684EA28F20E0700B95C00 /* decinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E684E728F20E0700B95C00 /* decinfo.c */; };
+		20E684EB28F20E0700B95C00 /* decapiwrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E684E828F20E0700B95C00 /* decapiwrapper.c */; };
+		20E684F728F2189800B95C00 /* ogg.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E684F128F2189800B95C00 /* ogg.h */; };
+		20E684FC28F2189800B95C00 /* os_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E684F628F2189800B95C00 /* os_types.h */; };
+		20E6852628F2219A00B95C00 /* VariableWidthSpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6850C28F2219A00B95C00 /* VariableWidthSpriteFont.h */; };
+		20E6852728F2219A00B95C00 /* SpriteFontRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6850D28F2219A00B95C00 /* SpriteFontRenderer.h */; };
+		20E6852828F2219A00B95C00 /* VariableWidthFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6850E28F2219A00B95C00 /* VariableWidthFont.h */; };
+		20E6852928F2219B00B95C00 /* SpriteFontRendererClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6850F28F2219A00B95C00 /* SpriteFontRendererClifftopGames.cpp */; };
+		20E6852A28F2219B00B95C00 /* SpriteFontRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851028F2219A00B95C00 /* SpriteFontRenderer.cpp */; };
+		20E6852B28F2219B00B95C00 /* SpriteFontRendererClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851128F2219A00B95C00 /* SpriteFontRendererClifftopGames.h */; };
+		20E6852C28F2219B00B95C00 /* CharacterEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851228F2219A00B95C00 /* CharacterEntry.h */; };
+		20E6852D28F2219B00B95C00 /* color.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851328F2219A00B95C00 /* color.h */; };
+		20E6852E28F2219B00B95C00 /* color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851428F2219A00B95C00 /* color.cpp */; };
+		20E6852F28F2219B00B95C00 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851528F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.cpp */; };
+		20E6853028F2219B00B95C00 /* SpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851628F2219A00B95C00 /* SpriteFont.cpp */; };
+		20E6853128F2219B00B95C00 /* AGSSpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851728F2219A00B95C00 /* AGSSpriteFont.cpp */; };
+		20E6853228F2219B00B95C00 /* SpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851828F2219A00B95C00 /* SpriteFont.h */; };
+		20E6853328F2219B00B95C00 /* CharacterEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851928F2219A00B95C00 /* CharacterEntry.cpp */; };
+		20E6853428F2219B00B95C00 /* VariableWidthSpriteFontClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851A28F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.h */; };
+		20E6853628F2219B00B95C00 /* VariableWidthFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851C28F2219A00B95C00 /* VariableWidthFont.cpp */; };
+		20E6853728F2219B00B95C00 /* VariableWidthSpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6851D28F2219A00B95C00 /* VariableWidthSpriteFont.cpp */; };
+		20E6853828F2219B00B95C00 /* AGSSpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6851E28F2219A00B95C00 /* AGSSpriteFont.h */; };
+		20E6854628F221CA00B95C00 /* palrender.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6853E28F221CA00B95C00 /* palrender.h */; };
+		20E6854728F221CA00B95C00 /* agspalrender.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6853F28F221CA00B95C00 /* agspalrender.h */; };
+		20E6854A28F221CA00B95C00 /* ags_palrender.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6854228F221CA00B95C00 /* ags_palrender.cpp */; };
+		20E6854C28F221CA00B95C00 /* raycast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E6854428F221CA00B95C00 /* raycast.cpp */; };
+		20E6854D28F221CA00B95C00 /* raycast.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E6854528F221CA00B95C00 /* raycast.h */; };
+		20E6856B28F25E2400B95C00 /* libbz2.1.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856A28F25E2400B95C00 /* libbz2.1.0.tbd */; };
+		20E6856D28F25E3B00B95C00 /* libz.1.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856C28F25E3B00B95C00 /* libz.1.tbd */; };
 		521C3BEE1D1E545100BD619E /* AGSKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C3BED1D1E545100BD619E /* AGSKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		521C54C01D1E572B00BD619E /* ags_parallax.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54621D1E572B00BD619E /* ags_parallax.cpp */; };
 		521C54C11D1E572B00BD619E /* ags_parallax.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54631D1E572B00BD619E /* ags_parallax.h */; };
@@ -16,19 +384,6 @@
 		521C54D31D1E572B00BD619E /* agsblend.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54791D1E572B00BD619E /* agsblend.h */; };
 		521C54DB1D1E572B00BD619E /* agsflashlight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54821D1E572B00BD619E /* agsflashlight.cpp */; };
 		521C54DC1D1E572B00BD619E /* agsflashlight.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54831D1E572B00BD619E /* agsflashlight.h */; };
-		521C54E91D1E572B00BD619E /* AGSSpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54951D1E572B00BD619E /* AGSSpriteFont.cpp */; };
-		521C54EB1D1E572B00BD619E /* CharacterEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54971D1E572B00BD619E /* CharacterEntry.cpp */; };
-		521C54EC1D1E572B00BD619E /* CharacterEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54981D1E572B00BD619E /* CharacterEntry.h */; };
-		521C54ED1D1E572B00BD619E /* color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54991D1E572B00BD619E /* color.cpp */; };
-		521C54EE1D1E572B00BD619E /* color.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C549A1D1E572B00BD619E /* color.h */; };
-		521C54EF1D1E572B00BD619E /* SpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C549B1D1E572B00BD619E /* SpriteFont.cpp */; };
-		521C54F01D1E572B00BD619E /* SpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C549C1D1E572B00BD619E /* SpriteFont.h */; };
-		521C54F11D1E572B00BD619E /* SpriteFontRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C549D1D1E572B00BD619E /* SpriteFontRenderer.cpp */; };
-		521C54F21D1E572B00BD619E /* SpriteFontRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C549E1D1E572B00BD619E /* SpriteFontRenderer.h */; };
-		521C54F31D1E572B00BD619E /* VariableWidthFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C549F1D1E572B00BD619E /* VariableWidthFont.cpp */; };
-		521C54F41D1E572B00BD619E /* VariableWidthFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54A01D1E572B00BD619E /* VariableWidthFont.h */; };
-		521C54F51D1E572B00BD619E /* VariableWidthSpriteFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54A11D1E572B00BD619E /* VariableWidthSpriteFont.cpp */; };
-		521C54F61D1E572B00BD619E /* VariableWidthSpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54A21D1E572B00BD619E /* VariableWidthSpriteFont.h */; };
 		521C54FE1D1E572B00BD619E /* agstouch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521C54AB1D1E572B00BD619E /* agstouch.cpp */; };
 		521C54FF1D1E572B00BD619E /* agstouch.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C54AC1D1E572B00BD619E /* agstouch.h */; };
 		521C56911D1E5AAC00BD619E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56901D1E5AAC00BD619E /* Cocoa.framework */; };
@@ -39,16 +394,6 @@
 		521C569B1D1E5ADA00BD619E /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C569A1D1E5ADA00BD619E /* CoreAudio.framework */; };
 		521C569D1D1E5AE300BD619E /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C569C1D1E5AE300BD619E /* AudioUnit.framework */; };
 		521C569F1D1E5AE900BD619E /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C569E1D1E5AE900BD619E /* AudioToolbox.framework */; };
-		521C56A91D1E5B5F00BD619E /* libaldmb.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A01D1E5B5F00BD619E /* libaldmb.a */; };
-		521C56AA1D1E5B5F00BD619E /* liballeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A11D1E5B5F00BD619E /* liballeg.a */; };
-		521C56AB1D1E5B5F00BD619E /* libdumb.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A21D1E5B5F00BD619E /* libdumb.a */; };
-		521C56AC1D1E5B5F00BD619E /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A31D1E5B5F00BD619E /* libfreetype.a */; };
-		521C56AD1D1E5B5F00BD619E /* liblua.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A41D1E5B5F00BD619E /* liblua.a */; };
-		521C56AE1D1E5B5F00BD619E /* libogg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A51D1E5B5F00BD619E /* libogg.a */; };
-		521C56AF1D1E5B5F00BD619E /* libtheoradec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A61D1E5B5F00BD619E /* libtheoradec.a */; };
-		521C56B01D1E5B5F00BD619E /* libvorbis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A71D1E5B5F00BD619E /* libvorbis.a */; };
-		521C56B11D1E5B5F00BD619E /* libvorbisfile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 521C56A81D1E5B5F00BD619E /* libvorbisfile.a */; };
-		526F229E1D3B5C4900EF4E1F /* animationstruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F211B1D3B5C4800EF4E1F /* animationstruct.h */; };
 		526F229F1D3B5C4900EF4E1F /* audiocliptype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F211C1D3B5C4800EF4E1F /* audiocliptype.cpp */; };
 		526F22A01D3B5C4900EF4E1F /* audiocliptype.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F211D1D3B5C4800EF4E1F /* audiocliptype.h */; };
 		526F22A11D3B5C4900EF4E1F /* characterinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F211E1D3B5C4800EF4E1F /* characterinfo.h */; };
@@ -67,15 +412,9 @@
 		526F22AE1D3B5C4900EF4E1F /* interfacebutton.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F212C1D3B5C4800EF4E1F /* interfacebutton.h */; };
 		526F22AF1D3B5C4900EF4E1F /* interfaceelement.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F212D1D3B5C4800EF4E1F /* interfaceelement.h */; };
 		526F22B01D3B5C4900EF4E1F /* inventoryiteminfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F212E1D3B5C4800EF4E1F /* inventoryiteminfo.h */; };
-		526F22B11D3B5C4900EF4E1F /* messageinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F212F1D3B5C4800EF4E1F /* messageinfo.cpp */; };
-		526F22B21D3B5C4900EF4E1F /* messageinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21301D3B5C4800EF4E1F /* messageinfo.h */; };
 		526F22B31D3B5C4900EF4E1F /* mousecursor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F21311D3B5C4800EF4E1F /* mousecursor.cpp */; };
 		526F22B41D3B5C4900EF4E1F /* mousecursor.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21321D3B5C4800EF4E1F /* mousecursor.h */; };
 		526F22B51D3B5C4900EF4E1F /* oldgamesetupstruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21331D3B5C4800EF4E1F /* oldgamesetupstruct.h */; };
-		526F22B61D3B5C4900EF4E1F /* point.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F21341D3B5C4800EF4E1F /* point.cpp */; };
-		526F22B71D3B5C4900EF4E1F /* point.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21351D3B5C4800EF4E1F /* point.h */; };
-		526F22B81D3B5C4900EF4E1F /* roomstruct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F21361D3B5C4800EF4E1F /* roomstruct.cpp */; };
-		526F22B91D3B5C4900EF4E1F /* roomstruct.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21371D3B5C4800EF4E1F /* roomstruct.h */; };
 		526F22BA1D3B5C4900EF4E1F /* spritecache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F21381D3B5C4800EF4E1F /* spritecache.cpp */; };
 		526F22BB1D3B5C4900EF4E1F /* spritecache.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21391D3B5C4800EF4E1F /* spritecache.h */; };
 		526F22BC1D3B5C4900EF4E1F /* view.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F213A1D3B5C4800EF4E1F /* view.cpp */; };
@@ -88,12 +427,9 @@
 		526F22C31D3B5C4900EF4E1F /* assetmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F21431D3B5C4800EF4E1F /* assetmanager.cpp */; };
 		526F22C41D3B5C4900EF4E1F /* assetmanager.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21441D3B5C4800EF4E1F /* assetmanager.h */; };
 		526F22C51D3B5C4900EF4E1F /* def_version.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21451D3B5C4800EF4E1F /* def_version.h */; };
-		526F22C61D3B5C4900EF4E1F /* endianness.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21461D3B5C4800EF4E1F /* endianness.h */; };
 		526F22C71D3B5C4900EF4E1F /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21471D3B5C4800EF4E1F /* types.h */; };
 		526F22C81D3B5C4900EF4E1F /* assert.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21491D3B5C4800EF4E1F /* assert.h */; };
-		526F22C91D3B5C4900EF4E1F /* out.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F214A1D3B5C4800EF4E1F /* out.cpp */; };
 		526F22CA1D3B5C4900EF4E1F /* out.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F214B1D3B5C4800EF4E1F /* out.h */; };
-		526F22CB1D3B5C4900EF4E1F /* outputtarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F214C1D3B5C4800EF4E1F /* outputtarget.h */; };
 		526F22CC1D3B5C4900EF4E1F /* agsfontrenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F214E1D3B5C4800EF4E1F /* agsfontrenderer.h */; };
 		526F22CD1D3B5C4900EF4E1F /* fonts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F214F1D3B5C4800EF4E1F /* fonts.cpp */; };
 		526F22CE1D3B5C4900EF4E1F /* fonts.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21501D3B5C4800EF4E1F /* fonts.h */; };
@@ -131,38 +467,11 @@
 		526F22EE1D3B5C4900EF4E1F /* guitextbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21731D3B5C4800EF4E1F /* guitextbox.h */; };
 		526F22EF1D3B5C4900EF4E1F /* aastr.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21751D3B5C4800EF4E1F /* aastr.h */; };
 		526F22F01D3B5C4900EF4E1F /* aautil.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21761D3B5C4800EF4E1F /* aautil.h */; };
-		526F22F21D3B5C4900EF4E1F /* alfont.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21781D3B5C4800EF4E1F /* alfont.h */; };
-		526F22F31D3B5C4900EF4E1F /* alfontdll.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21791D3B5C4800EF4E1F /* alfontdll.h */; };
-		526F22F41D3B5C4900EF4E1F /* almp3.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217A1D3B5C4800EF4E1F /* almp3.h */; };
-		526F22F51D3B5C4900EF4E1F /* almp3dll.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217B1D3B5C4800EF4E1F /* almp3dll.h */; };
-		526F22F61D3B5C4900EF4E1F /* alogg.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217C1D3B5C4800EF4E1F /* alogg.h */; };
-		526F22F71D3B5C4900EF4E1F /* aloggdll.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217D1D3B5C4800EF4E1F /* aloggdll.h */; };
-		526F22F81D3B5C4900EF4E1F /* apeg.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217E1D3B5C4800EF4E1F /* apeg.h */; };
-		526F22F91D3B5C4900EF4E1F /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F217F1D3B5C4800EF4E1F /* common.h */; };
-		526F22FB1D3B5C4900EF4E1F /* genre.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21811D3B5C4800EF4E1F /* genre.h */; };
-		526F22FC1D3B5C4900EF4E1F /* getbits.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21821D3B5C4800EF4E1F /* getbits.h */; };
-		526F22FD1D3B5C4900EF4E1F /* getblk.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21831D3B5C4900EF4E1F /* getblk.h */; };
-		526F22FE1D3B5C4900EF4E1F /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21841D3B5C4900EF4E1F /* huffman.h */; };
-		526F22FF1D3B5C4900EF4E1F /* l2tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21851D3B5C4900EF4E1F /* l2tables.h */; };
-		526F23001D3B5C4900EF4E1F /* libcda.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21861D3B5C4900EF4E1F /* libcda.h */; };
-		526F23011D3B5C4900EF4E1F /* mpeg1dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21871D3B5C4900EF4E1F /* mpeg1dec.h */; };
-		526F23021D3B5C4900EF4E1F /* mpg123.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21881D3B5C4900EF4E1F /* mpg123.h */; };
-		526F23031D3B5C4900EF4E1F /* mpglib.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21891D3B5C4900EF4E1F /* mpglib.h */; };
-		526F23041D3B5C4900EF4E1F /* config_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F218B1D3B5C4900EF4E1F /* config_types.h */; };
-		526F23051D3B5C4900EF4E1F /* config_types.h.in in Resources */ = {isa = PBXBuildFile; fileRef = 526F218C1D3B5C4900EF4E1F /* config_types.h.in */; };
-		526F23061D3B5C4900EF4E1F /* MAKEFILE.AM in Resources */ = {isa = PBXBuildFile; fileRef = 526F218D1D3B5C4900EF4E1F /* MAKEFILE.AM */; };
-		526F23071D3B5C4900EF4E1F /* MAKEFILE.IN in Resources */ = {isa = PBXBuildFile; fileRef = 526F218E1D3B5C4900EF4E1F /* MAKEFILE.IN */; };
-		526F23081D3B5C4900EF4E1F /* OGG.H in Headers */ = {isa = PBXBuildFile; fileRef = 526F218F1D3B5C4900EF4E1F /* OGG.H */; };
-		526F23091D3B5C4900EF4E1F /* OS_TYPES.H in Headers */ = {isa = PBXBuildFile; fileRef = 526F21901D3B5C4900EF4E1F /* OS_TYPES.H */; };
 		526F230A1D3B5C4900EF4E1F /* codec.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21921D3B5C4900EF4E1F /* codec.h */; };
-		526F230B1D3B5C4900EF4E1F /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 526F21931D3B5C4900EF4E1F /* Makefile.am */; };
-		526F230C1D3B5C4900EF4E1F /* Makefile.in in Resources */ = {isa = PBXBuildFile; fileRef = 526F21941D3B5C4900EF4E1F /* Makefile.in */; };
 		526F230D1D3B5C4900EF4E1F /* theora.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21951D3B5C4900EF4E1F /* theora.h */; };
 		526F230E1D3B5C4900EF4E1F /* theoradec.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21961D3B5C4900EF4E1F /* theoradec.h */; };
 		526F230F1D3B5C4900EF4E1F /* theoraenc.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21971D3B5C4900EF4E1F /* theoraenc.h */; };
 		526F23101D3B5C4900EF4E1F /* codec.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21991D3B5C4900EF4E1F /* codec.h */; };
-		526F23111D3B5C4900EF4E1F /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 526F219A1D3B5C4900EF4E1F /* Makefile.am */; };
-		526F23121D3B5C4900EF4E1F /* Makefile.in in Resources */ = {isa = PBXBuildFile; fileRef = 526F219B1D3B5C4900EF4E1F /* Makefile.in */; };
 		526F23131D3B5C4900EF4E1F /* vorbisenc.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F219C1D3B5C4900EF4E1F /* vorbisenc.h */; };
 		526F23141D3B5C4900EF4E1F /* vorbisfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F219D1D3B5C4900EF4E1F /* vorbisfile.h */; };
 		526F23151D3B5C4900EF4E1F /* AAROT.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F21A01D3B5C4900EF4E1F /* AAROT.c */; };
@@ -170,17 +479,8 @@
 		526F23171D3B5C4900EF4E1F /* aastr.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21A21D3B5C4900EF4E1F /* aastr.h */; };
 		526F23181D3B5C4900EF4E1F /* aautil.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F21A31D3B5C4900EF4E1F /* aautil.c */; };
 		526F23191D3B5C4900EF4E1F /* aautil.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F21A41D3B5C4900EF4E1F /* aautil.h */; };
-		526F231A1D3B5C4900EF4E1F /* vssver2.scc in Resources */ = {isa = PBXBuildFile; fileRef = 526F21A51D3B5C4900EF4E1F /* vssver2.scc */; };
-		526F23BE1D3B5C4900EF4E1F /* cc_error.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F22651D3B5C4900EF4E1F /* cc_error.cpp */; };
-		526F23BF1D3B5C4900EF4E1F /* cc_error.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22661D3B5C4900EF4E1F /* cc_error.h */; };
-		526F23C01D3B5C4900EF4E1F /* cc_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F22671D3B5C4900EF4E1F /* cc_options.cpp */; };
-		526F23C11D3B5C4900EF4E1F /* cc_options.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22681D3B5C4900EF4E1F /* cc_options.h */; };
 		526F23C21D3B5C4900EF4E1F /* cc_script.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F22691D3B5C4900EF4E1F /* cc_script.cpp */; };
 		526F23C31D3B5C4900EF4E1F /* cc_script.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F226A1D3B5C4900EF4E1F /* cc_script.h */; };
-		526F23C41D3B5C4900EF4E1F /* cc_treemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F226B1D3B5C4900EF4E1F /* cc_treemap.cpp */; };
-		526F23C51D3B5C4900EF4E1F /* cc_treemap.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F226C1D3B5C4900EF4E1F /* cc_treemap.h */; };
-		526F23C61D3B5C4900EF4E1F /* script_common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F226D1D3B5C4900EF4E1F /* script_common.cpp */; };
-		526F23C71D3B5C4900EF4E1F /* script_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F226E1D3B5C4900EF4E1F /* script_common.h */; };
 		526F23C81D3B5C4900EF4E1F /* alignedstream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F22701D3B5C4900EF4E1F /* alignedstream.cpp */; };
 		526F23C91D3B5C4900EF4E1F /* alignedstream.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22711D3B5C4900EF4E1F /* alignedstream.h */; };
 		526F23CA1D3B5C4900EF4E1F /* bbop.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22721D3B5C4900EF4E1F /* bbop.h */; };
@@ -204,8 +504,6 @@
 		526F23DC1D3B5C4900EF4E1F /* lzw.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22841D3B5C4900EF4E1F /* lzw.h */; };
 		526F23DD1D3B5C4900EF4E1F /* math.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22851D3B5C4900EF4E1F /* math.h */; };
 		526F23DE1D3B5C4900EF4E1F /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22861D3B5C4900EF4E1F /* memory.h */; };
-		526F23DF1D3B5C4900EF4E1F /* misc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F22871D3B5C4900EF4E1F /* misc.cpp */; };
-		526F23E01D3B5C4900EF4E1F /* misc.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22881D3B5C4900EF4E1F /* misc.h */; };
 		526F23E11D3B5C4900EF4E1F /* multifilelib.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F22891D3B5C4900EF4E1F /* multifilelib.h */; };
 		526F23E21D3B5C4900EF4E1F /* multifilelib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F228A1D3B5C4900EF4E1F /* multifilelib.cpp */; };
 		526F23E31D3B5C4900EF4E1F /* path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F228B1D3B5C4900EF4E1F /* path.cpp */; };
@@ -237,7 +535,6 @@
 		526F26A11D3B5CC300EF4E1F /* cdaudio.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F241D1D3B5CC200EF4E1F /* cdaudio.h */; };
 		526F26A21D3B5CC300EF4E1F /* character.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F241E1D3B5CC200EF4E1F /* character.cpp */; };
 		526F26A31D3B5CC300EF4E1F /* character.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F241F1D3B5CC200EF4E1F /* character.h */; };
-		526F26A41D3B5CC300EF4E1F /* charactercache.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24201D3B5CC200EF4E1F /* charactercache.h */; };
 		526F26A51D3B5CC300EF4E1F /* characterextras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24211D3B5CC200EF4E1F /* characterextras.cpp */; };
 		526F26A61D3B5CC300EF4E1F /* characterextras.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24221D3B5CC200EF4E1F /* characterextras.h */; };
 		526F26A81D3B5CC300EF4E1F /* datetime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24241D3B5CC200EF4E1F /* datetime.cpp */; };
@@ -369,8 +666,6 @@
 		526F27271D3B5CC300EF4E1F /* global_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24A41D3B5CC200EF4E1F /* global_parser.cpp */; };
 		526F27281D3B5CC300EF4E1F /* global_parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24A51D3B5CC200EF4E1F /* global_parser.h */; };
 		526F27291D3B5CC300EF4E1F /* global_plugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24A61D3B5CC200EF4E1F /* global_plugin.h */; };
-		526F272A1D3B5CC300EF4E1F /* global_record.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24A71D3B5CC200EF4E1F /* global_record.cpp */; };
-		526F272B1D3B5CC300EF4E1F /* global_record.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24A81D3B5CC200EF4E1F /* global_record.h */; };
 		526F272C1D3B5CC300EF4E1F /* global_region.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24A91D3B5CC200EF4E1F /* global_region.cpp */; };
 		526F272D1D3B5CC300EF4E1F /* global_region.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24AA1D3B5CC200EF4E1F /* global_region.h */; };
 		526F272E1D3B5CC300EF4E1F /* global_room.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24AB1D3B5CC200EF4E1F /* global_room.cpp */; };
@@ -410,7 +705,6 @@
 		526F27501D3B5CC300EF4E1F /* inventoryitem.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24CD1D3B5CC300EF4E1F /* inventoryitem.h */; };
 		526F27521D3B5CC300EF4E1F /* invwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24CF1D3B5CC300EF4E1F /* invwindow.cpp */; };
 		526F27531D3B5CC300EF4E1F /* invwindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24D01D3B5CC300EF4E1F /* invwindow.h */; };
-		526F27541D3B5CC300EF4E1F /* keycode.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24D11D3B5CC300EF4E1F /* keycode.h */; };
 		526F27551D3B5CC300EF4E1F /* label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24D21D3B5CC300EF4E1F /* label.cpp */; };
 		526F27561D3B5CC300EF4E1F /* label.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24D31D3B5CC300EF4E1F /* label.h */; };
 		526F27571D3B5CC300EF4E1F /* lipsync.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24D41D3B5CC300EF4E1F /* lipsync.h */; };
@@ -424,24 +718,16 @@
 		526F275F1D3B5CC300EF4E1F /* movelist.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24DC1D3B5CC300EF4E1F /* movelist.h */; };
 		526F27601D3B5CC300EF4E1F /* object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24DD1D3B5CC300EF4E1F /* object.cpp */; };
 		526F27611D3B5CC300EF4E1F /* object.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24DE1D3B5CC300EF4E1F /* object.h */; };
-		526F27621D3B5CC300EF4E1F /* objectcache.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24DF1D3B5CC300EF4E1F /* objectcache.h */; };
 		526F27631D3B5CC300EF4E1F /* overlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24E01D3B5CC300EF4E1F /* overlay.cpp */; };
 		526F27641D3B5CC300EF4E1F /* overlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24E11D3B5CC300EF4E1F /* overlay.h */; };
 		526F27651D3B5CC300EF4E1F /* parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24E21D3B5CC300EF4E1F /* parser.cpp */; };
 		526F27661D3B5CC300EF4E1F /* parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24E31D3B5CC300EF4E1F /* parser.h */; };
-		526F27671D3B5CC300EF4E1F /* path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24E41D3B5CC300EF4E1F /* path.cpp */; };
-		526F27681D3B5CC300EF4E1F /* path.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24E51D3B5CC300EF4E1F /* path.h */; };
 		526F27691D3B5CC300EF4E1F /* properties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24E61D3B5CC300EF4E1F /* properties.cpp */; };
 		526F276A1D3B5CC300EF4E1F /* properties.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24E71D3B5CC300EF4E1F /* properties.h */; };
-		526F276B1D3B5CC300EF4E1F /* record.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24E81D3B5CC300EF4E1F /* record.cpp */; };
-		526F276C1D3B5CC300EF4E1F /* record.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24E91D3B5CC300EF4E1F /* record.h */; };
 		526F276D1D3B5CC300EF4E1F /* region.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24EA1D3B5CC300EF4E1F /* region.cpp */; };
 		526F276E1D3B5CC300EF4E1F /* region.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24EB1D3B5CC300EF4E1F /* region.h */; };
-		526F276F1D3B5CC300EF4E1F /* richgamemedia.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24EC1D3B5CC300EF4E1F /* richgamemedia.cpp */; };
-		526F27701D3B5CC300EF4E1F /* richgamemedia.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24ED1D3B5CC300EF4E1F /* richgamemedia.h */; };
 		526F27711D3B5CC300EF4E1F /* room.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24EE1D3B5CC300EF4E1F /* room.cpp */; };
 		526F27721D3B5CC300EF4E1F /* room.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24EF1D3B5CC300EF4E1F /* room.h */; };
-		526F27731D3B5CC300EF4E1F /* room_engine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24F01D3B5CC300EF4E1F /* room_engine.cpp */; };
 		526F27741D3B5CC300EF4E1F /* roomobject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24F11D3B5CC300EF4E1F /* roomobject.cpp */; };
 		526F27751D3B5CC300EF4E1F /* roomobject.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F24F21D3B5CC300EF4E1F /* roomobject.h */; };
 		526F27761D3B5CC300EF4E1F /* roomstatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F24F31D3B5CC300EF4E1F /* roomstatus.cpp */; };
@@ -476,12 +762,8 @@
 		526F27941D3B5CC300EF4E1F /* topbarsettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25121D3B5CC300EF4E1F /* topbarsettings.h */; };
 		526F27951D3B5CC300EF4E1F /* translation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25131D3B5CC300EF4E1F /* translation.cpp */; };
 		526F27961D3B5CC300EF4E1F /* translation.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25141D3B5CC300EF4E1F /* translation.h */; };
-		526F27971D3B5CC300EF4E1F /* tree_map.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25151D3B5CC300EF4E1F /* tree_map.cpp */; };
-		526F27981D3B5CC300EF4E1F /* tree_map.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25161D3B5CC300EF4E1F /* tree_map.h */; };
 		526F27991D3B5CC300EF4E1F /* viewframe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25171D3B5CC300EF4E1F /* viewframe.cpp */; };
 		526F279A1D3B5CC300EF4E1F /* viewframe.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25181D3B5CC300EF4E1F /* viewframe.h */; };
-		526F279B1D3B5CC300EF4E1F /* viewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25191D3B5CC300EF4E1F /* viewport.cpp */; };
-		526F279C1D3B5CC300EF4E1F /* viewport.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F251A1D3B5CC300EF4E1F /* viewport.h */; };
 		526F279D1D3B5CC300EF4E1F /* walkablearea.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F251B1D3B5CC300EF4E1F /* walkablearea.cpp */; };
 		526F279E1D3B5CC300EF4E1F /* walkablearea.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F251C1D3B5CC300EF4E1F /* walkablearea.h */; };
 		526F279F1D3B5CC300EF4E1F /* walkbehind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F251D1D3B5CC300EF4E1F /* walkbehind.cpp */; };
@@ -520,19 +802,14 @@
 		526F27C01D3B5CC300EF4E1F /* gfxfilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25421D3B5CC300EF4E1F /* gfxfilter.h */; };
 		526F27C11D3B5CC300EF4E1F /* gfxfilter_aad3d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25431D3B5CC300EF4E1F /* gfxfilter_aad3d.cpp */; };
 		526F27C21D3B5CC300EF4E1F /* gfxfilter_aad3d.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25441D3B5CC300EF4E1F /* gfxfilter_aad3d.h */; };
-		526F27C31D3B5CC300EF4E1F /* gfxfilter_allegro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25451D3B5CC300EF4E1F /* gfxfilter_allegro.cpp */; };
-		526F27C41D3B5CC300EF4E1F /* gfxfilter_allegro.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25461D3B5CC300EF4E1F /* gfxfilter_allegro.h */; };
 		526F27C51D3B5CC300EF4E1F /* gfxfilter_d3d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25471D3B5CC300EF4E1F /* gfxfilter_d3d.cpp */; };
 		526F27C61D3B5CC300EF4E1F /* gfxfilter_d3d.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25481D3B5CC300EF4E1F /* gfxfilter_d3d.h */; };
-		526F27C71D3B5CC300EF4E1F /* gfxfilter_hqx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25491D3B5CC300EF4E1F /* gfxfilter_hqx.cpp */; };
-		526F27C81D3B5CC300EF4E1F /* gfxfilter_hqx.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F254A1D3B5CC300EF4E1F /* gfxfilter_hqx.h */; };
 		526F27C91D3B5CC300EF4E1F /* gfxfilter_ogl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F254B1D3B5CC300EF4E1F /* gfxfilter_ogl.cpp */; };
 		526F27CA1D3B5CC300EF4E1F /* gfxfilter_ogl.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F254C1D3B5CC300EF4E1F /* gfxfilter_ogl.h */; };
 		526F27CB1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F254D1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp */; };
 		526F27CC1D3B5CC300EF4E1F /* gfxfilter_scaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F254E1D3B5CC300EF4E1F /* gfxfilter_scaling.h */; };
 		526F27CD1D3B5CC300EF4E1F /* gfxmodelist.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F254F1D3B5CC300EF4E1F /* gfxmodelist.h */; };
 		526F27CE1D3B5CC300EF4E1F /* graphicsdriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25501D3B5CC300EF4E1F /* graphicsdriver.h */; };
-		526F27CF1D3B5CC300EF4E1F /* hq2x3x.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25511D3B5CC300EF4E1F /* hq2x3x.h */; };
 		526F27D01D3B5CC300EF4E1F /* animatingguibutton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25531D3B5CC300EF4E1F /* animatingguibutton.cpp */; };
 		526F27D11D3B5CC300EF4E1F /* animatingguibutton.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25541D3B5CC300EF4E1F /* animatingguibutton.h */; };
 		526F27D21D3B5CC300EF4E1F /* cscidialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25551D3B5CC300EF4E1F /* cscidialog.cpp */; };
@@ -553,33 +830,7 @@
 		526F27E11D3B5CC300EF4E1F /* mytextbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25641D3B5CC300EF4E1F /* mytextbox.h */; };
 		526F27E21D3B5CC300EF4E1F /* newcontrol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25651D3B5CC300EF4E1F /* newcontrol.cpp */; };
 		526F27E31D3B5CC300EF4E1F /* newcontrol.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25661D3B5CC300EF4E1F /* newcontrol.h */; };
-		526F27E41D3B5CC300EF4E1F /* alfont.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25691D3B5CC300EF4E1F /* alfont.c */; };
-		526F27E51D3B5CC300EF4E1F /* ALFONT.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F256A1D3B5CC300EF4E1F /* ALFONT.txt */; };
-		526F27E61D3B5CC300EF4E1F /* AUTHORS.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F256B1D3B5CC300EF4E1F /* AUTHORS.txt */; };
-		526F27E71D3B5CC300EF4E1F /* FTL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F256C1D3B5CC300EF4E1F /* FTL.txt */; };
-		526F27E81D3B5CC300EF4E1F /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F256D1D3B5CC300EF4E1F /* README.txt */; };
-		526F27F11D3B5CC300EF4E1F /* almp3.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F257A1D3B5CC300EF4E1F /* almp3.c */; };
-		526F27F21D3B5CC300EF4E1F /* common.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F257D1D3B5CC300EF4E1F /* common.c */; };
-		526F27F31D3B5CC300EF4E1F /* dct64_i386.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F257E1D3B5CC300EF4E1F /* dct64_i386.c */; };
-		526F27F41D3B5CC300EF4E1F /* decode_i386.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F257F1D3B5CC300EF4E1F /* decode_i386.c */; };
-		526F27F51D3B5CC300EF4E1F /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25801D3B5CC300EF4E1F /* huffman.h */; };
-		526F27F61D3B5CC300EF4E1F /* interface.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25811D3B5CC300EF4E1F /* interface.c */; };
-		526F27F71D3B5CC300EF4E1F /* l2tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25821D3B5CC300EF4E1F /* l2tables.h */; };
-		526F27F81D3B5CC300EF4E1F /* layer2.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25831D3B5CC300EF4E1F /* layer2.c */; };
-		526F27F91D3B5CC300EF4E1F /* layer3.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25841D3B5CC300EF4E1F /* layer3.c */; };
-		526F27FA1D3B5CC300EF4E1F /* mpg123.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25851D3B5CC300EF4E1F /* mpg123.h */; };
-		526F27FB1D3B5CC300EF4E1F /* mpglib.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25861D3B5CC300EF4E1F /* mpglib.h */; };
-		526F27FC1D3B5CC300EF4E1F /* README in Resources */ = {isa = PBXBuildFile; fileRef = 526F25871D3B5CC300EF4E1F /* README */; };
-		526F27FD1D3B5CC300EF4E1F /* tabinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25881D3B5CC300EF4E1F /* tabinit.c */; };
-		526F27FE1D3B5CC300EF4E1F /* vssver2.scc in Resources */ = {isa = PBXBuildFile; fileRef = 526F25891D3B5CC300EF4E1F /* vssver2.scc */; };
-		526F27FF1D3B5CC300EF4E1F /* alogg.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F258B1D3B5CC300EF4E1F /* alogg.c */; };
-		526F28001D3B5CC300EF4E1F /* ALOGG.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F258C1D3B5CC300EF4E1F /* ALOGG.txt */; };
-		526F28011D3B5CC300EF4E1F /* AUTHORS.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F258D1D3B5CC300EF4E1F /* AUTHORS.txt */; };
-		526F28021D3B5CC300EF4E1F /* CHANGES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F258E1D3B5CC300EF4E1F /* CHANGES.txt */; };
-		526F28031D3B5CC300EF4E1F /* COPYING.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F258F1D3B5CC300EF4E1F /* COPYING.txt */; };
-		526F28041D3B5CC300EF4E1F /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F25901D3B5CC300EF4E1F /* README.txt */; };
 		526F28051D3B5CC300EF4E1F /* adisplay.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25921D3B5CC300EF4E1F /* adisplay.c */; };
-		526F28061D3B5CC300EF4E1F /* apeg.txt in Resources */ = {isa = PBXBuildFile; fileRef = 526F25931D3B5CC300EF4E1F /* apeg.txt */; };
 		526F28071D3B5CC300EF4E1F /* aaudio.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25951D3B5CC300EF4E1F /* aaudio.c */; };
 		526F28081D3B5CC300EF4E1F /* apegcommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25961D3B5CC300EF4E1F /* apegcommon.c */; };
 		526F28091D3B5CC300EF4E1F /* dct64.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25971D3B5CC300EF4E1F /* dct64.c */; };
@@ -593,7 +844,6 @@
 		526F28111D3B5CC300EF4E1F /* readers.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F259F1D3B5CC300EF4E1F /* readers.c */; };
 		526F28121D3B5CC300EF4E1F /* tabinit.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A01D3B5CC300EF4E1F /* tabinit.c */; };
 		526F28131D3B5CC300EF4E1F /* vbrhead.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A11D3B5CC300EF4E1F /* vbrhead.c */; };
-		526F28141D3B5CC300EF4E1F /* vssver2.scc in Resources */ = {isa = PBXBuildFile; fileRef = 526F25A21D3B5CC300EF4E1F /* vssver2.scc */; };
 		526F28151D3B5CC300EF4E1F /* getbits.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A31D3B5CC300EF4E1F /* getbits.c */; };
 		526F28161D3B5CC300EF4E1F /* getblk.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A41D3B5CC300EF4E1F /* getblk.c */; };
 		526F28171D3B5CC300EF4E1F /* gethdr.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A51D3B5CC300EF4E1F /* gethdr.c */; };
@@ -603,9 +853,6 @@
 		526F281B1D3B5CC300EF4E1F /* mpeg1dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25A91D3B5CC300EF4E1F /* mpeg1dec.c */; };
 		526F281C1D3B5CC300EF4E1F /* ogg.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25AA1D3B5CC300EF4E1F /* ogg.c */; };
 		526F281D1D3B5CC300EF4E1F /* recon.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F25AB1D3B5CC300EF4E1F /* recon.c */; };
-		526F281E1D3B5CC300EF4E1F /* vssver2.scc in Resources */ = {isa = PBXBuildFile; fileRef = 526F25AC1D3B5CC300EF4E1F /* vssver2.scc */; };
-		526F284B1D3B5CC300EF4E1F /* hq2x3x.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25DF1D3B5CC300EF4E1F /* hq2x3x.cpp */; };
-		526F284C1D3B5CC300EF4E1F /* vssver2.scc in Resources */ = {isa = PBXBuildFile; fileRef = 526F25E01D3B5CC300EF4E1F /* vssver2.scc */; };
 		526F285B1D3B5CC300EF4E1F /* config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25F11D3B5CC300EF4E1F /* config.cpp */; };
 		526F285C1D3B5CC300EF4E1F /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25F21D3B5CC300EF4E1F /* config.h */; };
 		526F285D1D3B5CC300EF4E1F /* engine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25F31D3B5CC300EF4E1F /* engine.cpp */; };
@@ -622,10 +869,6 @@
 		526F28681D3B5CC300EF4E1F /* graphics_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F25FE1D3B5CC300EF4E1F /* graphics_mode.h */; };
 		526F28691D3B5CC300EF4E1F /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F25FF1D3B5CC300EF4E1F /* main.cpp */; };
 		526F286A1D3B5CC300EF4E1F /* main.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26001D3B5CC300EF4E1F /* main.h */; };
-		526F286B1D3B5CC300EF4E1F /* main_allegro.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26011D3B5CC300EF4E1F /* main_allegro.h */; };
-		526F286C1D3B5CC300EF4E1F /* maindefines_ex.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26021D3B5CC300EF4E1F /* maindefines_ex.h */; };
-		526F286D1D3B5CC300EF4E1F /* mainheader.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26031D3B5CC300EF4E1F /* mainheader.h */; };
-		526F286E1D3B5CC300EF4E1F /* minidump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26041D3B5CC300EF4E1F /* minidump.cpp */; };
 		526F286F1D3B5CC300EF4E1F /* quit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26051D3B5CC300EF4E1F /* quit.cpp */; };
 		526F28701D3B5CC300EF4E1F /* quit.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26061D3B5CC300EF4E1F /* quit.h */; };
 		526F28711D3B5CC300EF4E1F /* update.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26071D3B5CC300EF4E1F /* update.cpp */; };
@@ -635,48 +878,25 @@
 		526F28771D3B5CC300EF4E1F /* audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F260F1D3B5CC300EF4E1F /* audio.cpp */; };
 		526F28781D3B5CC300EF4E1F /* audio.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26101D3B5CC300EF4E1F /* audio.h */; };
 		526F28791D3B5CC300EF4E1F /* audiodefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26111D3B5CC300EF4E1F /* audiodefines.h */; };
-		526F287B1D3B5CC300EF4E1F /* clip_mydumbmod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26131D3B5CC300EF4E1F /* clip_mydumbmod.cpp */; };
-		526F287C1D3B5CC300EF4E1F /* clip_mydumbmod.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26141D3B5CC300EF4E1F /* clip_mydumbmod.h */; };
-		526F287D1D3B5CC300EF4E1F /* clip_myjgmod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26151D3B5CC300EF4E1F /* clip_myjgmod.cpp */; };
-		526F287E1D3B5CC300EF4E1F /* clip_myjgmod.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26161D3B5CC300EF4E1F /* clip_myjgmod.h */; };
-		526F287F1D3B5CC300EF4E1F /* clip_mymidi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26171D3B5CC300EF4E1F /* clip_mymidi.cpp */; };
-		526F28801D3B5CC300EF4E1F /* clip_mymidi.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26181D3B5CC300EF4E1F /* clip_mymidi.h */; };
-		526F28811D3B5CC300EF4E1F /* clip_mymp3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26191D3B5CC300EF4E1F /* clip_mymp3.cpp */; };
-		526F28821D3B5CC300EF4E1F /* clip_mymp3.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F261A1D3B5CC300EF4E1F /* clip_mymp3.h */; };
-		526F28831D3B5CC300EF4E1F /* clip_myogg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F261B1D3B5CC300EF4E1F /* clip_myogg.cpp */; };
-		526F28841D3B5CC300EF4E1F /* clip_myogg.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F261C1D3B5CC300EF4E1F /* clip_myogg.h */; };
-		526F28851D3B5CC300EF4E1F /* clip_mystaticmp3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F261D1D3B5CC300EF4E1F /* clip_mystaticmp3.cpp */; };
-		526F28861D3B5CC300EF4E1F /* clip_mystaticmp3.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F261E1D3B5CC300EF4E1F /* clip_mystaticmp3.h */; };
-		526F28871D3B5CC300EF4E1F /* clip_mystaticogg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F261F1D3B5CC300EF4E1F /* clip_mystaticogg.cpp */; };
-		526F28881D3B5CC300EF4E1F /* clip_mystaticogg.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26201D3B5CC300EF4E1F /* clip_mystaticogg.h */; };
-		526F28891D3B5CC300EF4E1F /* clip_mywave.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26211D3B5CC300EF4E1F /* clip_mywave.cpp */; };
-		526F288A1D3B5CC300EF4E1F /* clip_mywave.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26221D3B5CC300EF4E1F /* clip_mywave.h */; };
 		526F288B1D3B5CC300EF4E1F /* queuedaudioitem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26231D3B5CC300EF4E1F /* queuedaudioitem.cpp */; };
 		526F288C1D3B5CC300EF4E1F /* queuedaudioitem.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26241D3B5CC300EF4E1F /* queuedaudioitem.h */; };
 		526F288D1D3B5CC300EF4E1F /* sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26251D3B5CC300EF4E1F /* sound.cpp */; };
 		526F288E1D3B5CC300EF4E1F /* sound.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26261D3B5CC300EF4E1F /* sound.h */; };
-		526F288F1D3B5CC300EF4E1F /* soundcache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26271D3B5CC300EF4E1F /* soundcache.cpp */; };
-		526F28901D3B5CC300EF4E1F /* soundcache.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26281D3B5CC300EF4E1F /* soundcache.h */; };
 		526F28911D3B5CC300EF4E1F /* soundclip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26291D3B5CC300EF4E1F /* soundclip.cpp */; };
 		526F28921D3B5CC300EF4E1F /* soundclip.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F262A1D3B5CC300EF4E1F /* soundclip.h */; };
 		526F28931D3B5CC300EF4E1F /* video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F262C1D3B5CC300EF4E1F /* video.cpp */; };
 		526F28941D3B5CC300EF4E1F /* video.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F262D1D3B5CC300EF4E1F /* video.h */; };
-		526F28951D3B5CC300EF4E1F /* VMR9Graph.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F262E1D3B5CC300EF4E1F /* VMR9Graph.h */; };
 		526F28971D3B5CC300EF4E1F /* agsplatformdriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26331D3B5CC300EF4E1F /* agsplatformdriver.cpp */; };
 		526F28981D3B5CC300EF4E1F /* agsplatformdriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26341D3B5CC300EF4E1F /* agsplatformdriver.h */; };
-		526F28991D3B5CC300EF4E1F /* override_defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26351D3B5CC300EF4E1F /* override_defines.h */; };
 		526F28A01D3B5CC300EF4E1F /* acplmac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26411D3B5CC300EF4E1F /* acplmac.cpp */; };
 		526F28A11D3B5CC300EF4E1F /* alplmac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 526F26421D3B5CC300EF4E1F /* alplmac.mm */; };
 		526F28A31D3B5CC300EF4E1F /* libc.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F26461D3B5CC300EF4E1F /* libc.c */; };
-		526F28A41D3B5CC300EF4E1F /* pe.c in Sources */ = {isa = PBXBuildFile; fileRef = 526F26471D3B5CC300EF4E1F /* pe.c */; };
-		526F28A51D3B5CC300EF4E1F /* pe.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26481D3B5CC300EF4E1F /* pe.h */; };
 		526F28AF1D3B5CC300EF4E1F /* agsplugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26591D3B5CC300EF4E1F /* agsplugin.cpp */; };
 		526F28B01D3B5CC300EF4E1F /* agsplugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F265A1D3B5CC300EF4E1F /* agsplugin.h */; };
 		526F28B11D3B5CC300EF4E1F /* global_plugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F265B1D3B5CC300EF4E1F /* global_plugin.cpp */; };
 		526F28B21D3B5CC300EF4E1F /* pluginobjectreader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F265C1D3B5CC300EF4E1F /* pluginobjectreader.cpp */; };
 		526F28B31D3B5CC300EF4E1F /* pluginobjectreader.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F265D1D3B5CC300EF4E1F /* pluginobjectreader.h */; };
 		526F28B41D3B5CC300EF4E1F /* CompileShader.bat in Resources */ = {isa = PBXBuildFile; fileRef = 526F265F1D3B5CC300EF4E1F /* CompileShader.bat */; };
-		526F28B51D3B5CC300EF4E1F /* DefaultGDF.gdf.xml in Resources */ = {isa = PBXBuildFile; fileRef = 526F26601D3B5CC300EF4E1F /* DefaultGDF.gdf.xml */; };
 		526F28B61D3B5CC300EF4E1F /* game-1.ICO in Resources */ = {isa = PBXBuildFile; fileRef = 526F26611D3B5CC300EF4E1F /* game-1.ICO */; };
 		526F28B71D3B5CC300EF4E1F /* resource.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26621D3B5CC300EF4E1F /* resource.h */; };
 		526F28B81D3B5CC300EF4E1F /* tintshader.fx in Resources */ = {isa = PBXBuildFile; fileRef = 526F26631D3B5CC300EF4E1F /* tintshader.fx */; };
@@ -684,7 +904,6 @@
 		526F28BA1D3B5CC300EF4E1F /* tintshaderLegacy.fx in Resources */ = {isa = PBXBuildFile; fileRef = 526F26651D3B5CC300EF4E1F /* tintshaderLegacy.fx */; };
 		526F28BB1D3B5CC300EF4E1F /* tintshaderLegacy.fxo in Resources */ = {isa = PBXBuildFile; fileRef = 526F26661D3B5CC300EF4E1F /* tintshaderLegacy.fxo */; };
 		526F28BC1D3B5CC300EF4E1F /* version.rc in Resources */ = {isa = PBXBuildFile; fileRef = 526F26671D3B5CC300EF4E1F /* version.rc */; };
-		526F28BD1D3B5CC300EF4E1F /* cc_error_engine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26691D3B5CC300EF4E1F /* cc_error_engine.cpp */; };
 		526F28BE1D3B5CC300EF4E1F /* cc_instance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F266A1D3B5CC300EF4E1F /* cc_instance.cpp */; };
 		526F28BF1D3B5CC300EF4E1F /* cc_instance.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F266B1D3B5CC300EF4E1F /* cc_instance.h */; };
 		526F28C01D3B5CC300EF4E1F /* executingscript.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F266C1D3B5CC300EF4E1F /* executingscript.cpp */; };
@@ -698,41 +917,15 @@
 		526F28C81D3B5CC300EF4E1F /* script.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26741D3B5CC300EF4E1F /* script.h */; };
 		526F28C91D3B5CC300EF4E1F /* script_api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26751D3B5CC300EF4E1F /* script_api.cpp */; };
 		526F28CA1D3B5CC300EF4E1F /* script_api.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26761D3B5CC300EF4E1F /* script_api.h */; };
-		526F28CB1D3B5CC300EF4E1F /* script_engine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26771D3B5CC300EF4E1F /* script_engine.cpp */; };
 		526F28CC1D3B5CC300EF4E1F /* script_runtime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26781D3B5CC300EF4E1F /* script_runtime.cpp */; };
 		526F28CD1D3B5CC300EF4E1F /* script_runtime.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26791D3B5CC300EF4E1F /* script_runtime.h */; };
 		526F28CE1D3B5CC300EF4E1F /* systemimports.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F267A1D3B5CC300EF4E1F /* systemimports.cpp */; };
 		526F28CF1D3B5CC300EF4E1F /* systemimports.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F267B1D3B5CC300EF4E1F /* systemimports.h */; };
-		526F28D01D3B5CC300EF4E1F /* test_all.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F267D1D3B5CC300EF4E1F /* test_all.cpp */; };
-		526F28D11D3B5CC300EF4E1F /* test_all.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F267E1D3B5CC300EF4E1F /* test_all.h */; };
-		526F28D21D3B5CC300EF4E1F /* test_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F267F1D3B5CC300EF4E1F /* test_file.cpp */; };
-		526F28D31D3B5CC300EF4E1F /* test_gfx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26801D3B5CC300EF4E1F /* test_gfx.cpp */; };
-		526F28D41D3B5CC300EF4E1F /* test_inifile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26811D3B5CC300EF4E1F /* test_inifile.cpp */; };
-		526F28D51D3B5CC300EF4E1F /* test_math.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26821D3B5CC300EF4E1F /* test_math.cpp */; };
-		526F28D61D3B5CC300EF4E1F /* test_memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26831D3B5CC300EF4E1F /* test_memory.cpp */; };
-		526F28D71D3B5CC300EF4E1F /* test_sprintf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26841D3B5CC300EF4E1F /* test_sprintf.cpp */; };
-		526F28D81D3B5CC300EF4E1F /* test_string.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26851D3B5CC300EF4E1F /* test_string.cpp */; };
-		526F28D91D3B5CC300EF4E1F /* test_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 526F26861D3B5CC300EF4E1F /* test_version.cpp */; };
 		526F28DA1D3B5CC300EF4E1F /* library.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26881D3B5CC300EF4E1F /* library.h */; };
 		526F28DB1D3B5CC300EF4E1F /* library_dummy.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26891D3B5CC300EF4E1F /* library_dummy.h */; };
 		526F28DC1D3B5CC300EF4E1F /* library_posix.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268A1D3B5CC300EF4E1F /* library_posix.h */; };
 		526F28DD1D3B5CC300EF4E1F /* library_psp.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268B1D3B5CC300EF4E1F /* library_psp.h */; };
 		526F28DE1D3B5CC300EF4E1F /* library_windows.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268C1D3B5CC300EF4E1F /* library_windows.h */; };
-		526F28DF1D3B5CC300EF4E1F /* mutex.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268D1D3B5CC300EF4E1F /* mutex.h */; };
-		526F28E01D3B5CC300EF4E1F /* mutex_base.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268E1D3B5CC300EF4E1F /* mutex_base.h */; };
-		526F28E11D3B5CC300EF4E1F /* mutex_lock.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F268F1D3B5CC300EF4E1F /* mutex_lock.h */; };
-		526F28E21D3B5CC300EF4E1F /* mutex_psp.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26901D3B5CC300EF4E1F /* mutex_psp.h */; };
-		526F28E31D3B5CC300EF4E1F /* mutex_pthread.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26911D3B5CC300EF4E1F /* mutex_pthread.h */; };
-		526F28E41D3B5CC300EF4E1F /* mutex_wii.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26921D3B5CC300EF4E1F /* mutex_wii.h */; };
-		526F28E51D3B5CC300EF4E1F /* mutex_windows.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26931D3B5CC300EF4E1F /* mutex_windows.h */; };
-		526F28E61D3B5CC300EF4E1F /* scaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26941D3B5CC300EF4E1F /* scaling.h */; };
-		526F28E71D3B5CC300EF4E1F /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26951D3B5CC300EF4E1F /* thread.h */; };
-		526F28E81D3B5CC300EF4E1F /* thread_psp.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26961D3B5CC300EF4E1F /* thread_psp.h */; };
-		526F28E91D3B5CC300EF4E1F /* thread_pthread.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26971D3B5CC300EF4E1F /* thread_pthread.h */; };
-		526F28EA1D3B5CC300EF4E1F /* thread_wii.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26981D3B5CC300EF4E1F /* thread_wii.h */; };
-		526F28EB1D3B5CC300EF4E1F /* thread_windows.h in Headers */ = {isa = PBXBuildFile; fileRef = 526F26991D3B5CC300EF4E1F /* thread_windows.h */; };
-		52A7D3291D1E644700D88BEE /* libz.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A7D3251D1E641F00D88BEE /* libz.1.dylib */; };
-		52A7D32A1D1E645200D88BEE /* libbz2.1.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A7D3271D1E643800D88BEE /* libbz2.1.0.dylib */; };
 		52D12C1F1D61C0950077B784 /* savegame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D12C1C1D61C0950077B784 /* savegame.cpp */; };
 		52D12C201D61C0950077B784 /* savegame.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D12C1D1D61C0950077B784 /* savegame.h */; };
 		52D12C211D61C0950077B784 /* savegame_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D12C1E1D61C0950077B784 /* savegame_internal.h */; };
@@ -747,14 +940,377 @@
 		52F5D8611DA1219D006F8F4B /* inventoryiteminfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F5D8601DA1219D006F8F4B /* inventoryiteminfo.cpp */; };
 		52F5D8641DA121CC006F8F4B /* version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F5D8621DA121CC006F8F4B /* version.cpp */; };
 		52F5D8651DA121CC006F8F4B /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F5D8631DA121CC006F8F4B /* version.h */; };
-		A3A4659D2866966D00AE0372 /* SpriteFontRendererClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */; };
-		A3A4659E2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */; };
-		A3A4659F2866966D00AE0372 /* AGSSpriteFont.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */; };
-		A3A465A02866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */; };
-		A3A465A12866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2052299228E8EAE500589E91 /* spritefile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spritefile.h; sourceTree = "<group>"; };
+		2052299328E8EAE600589E91 /* keycode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keycode.cpp; sourceTree = "<group>"; };
+		2052299428E8EAE600589E91 /* spritefile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spritefile.cpp; sourceTree = "<group>"; };
+		2052299528E8EAE600589E91 /* keycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keycode.h; sourceTree = "<group>"; };
+		2052299A28E8EB5600589E91 /* platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform.h; sourceTree = "<group>"; };
+		2052299C28E8EBA900589E91 /* debugmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = debugmanager.cpp; sourceTree = "<group>"; };
+		2052299D28E8EBA900589E91 /* debugmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debugmanager.h; sourceTree = "<group>"; };
+		2052299E28E8EBA900589E91 /* outputhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = outputhandler.h; sourceTree = "<group>"; };
+		205229A228E8EBE300589E91 /* room_file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = room_file.cpp; sourceTree = "<group>"; };
+		205229A328E8EBE300589E91 /* room_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = room_file.h; sourceTree = "<group>"; };
+		205229A428E8EBE300589E91 /* tra_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tra_file.h; sourceTree = "<group>"; };
+		205229A528E8EBE400589E91 /* room_file_deprecated.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = room_file_deprecated.cpp; sourceTree = "<group>"; };
+		205229A628E8EBE400589E91 /* room_file_base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = room_file_base.cpp; sourceTree = "<group>"; };
+		205229A728E8EBE400589E91 /* roomstruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roomstruct.h; sourceTree = "<group>"; };
+		205229A828E8EBE400589E91 /* room_version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = room_version.h; sourceTree = "<group>"; };
+		205229A928E8EBE500589E91 /* tra_file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tra_file.cpp; sourceTree = "<group>"; };
+		205229AA28E8EBE500589E91 /* roomstruct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = roomstruct.cpp; sourceTree = "<group>"; };
+		205229BB28E8ECE200589E91 /* alfont.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alfont.c; path = "alfont-2.0.9/alfont.c"; sourceTree = "<group>"; };
+		205229BC28E8ECE200589E91 /* alfont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = alfont.h; path = "alfont-2.0.9/alfont.h"; sourceTree = "<group>"; };
+		205229C128E8ED4400589E91 /* include */ = {isa = PBXFileReference; lastKnownFileType = folder; name = include; path = "freetype-2.1.3/include"; sourceTree = "<group>"; };
+		205229C328E8EDD600589E91 /* ftbdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftbdf.c; path = "freetype-2.1.3/src/base/ftbdf.c"; sourceTree = "<group>"; };
+		205229C428E8EDD600589E91 /* ftbase.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftbase.c; path = "freetype-2.1.3/src/base/ftbase.c"; sourceTree = "<group>"; };
+		205229C528E8EDD600589E91 /* ftdebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftdebug.c; path = "freetype-2.1.3/src/base/ftdebug.c"; sourceTree = "<group>"; };
+		205229C628E8EDD600589E91 /* ftglyph.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftglyph.c; path = "freetype-2.1.3/src/base/ftglyph.c"; sourceTree = "<group>"; };
+		205229C728E8EDD600589E91 /* ftinit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftinit.c; path = "freetype-2.1.3/src/base/ftinit.c"; sourceTree = "<group>"; };
+		205229C828E8EDD600589E91 /* ftbbox.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftbbox.c; path = "freetype-2.1.3/src/base/ftbbox.c"; sourceTree = "<group>"; };
+		205229C928E8EDD700589E91 /* ftpfr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftpfr.c; path = "freetype-2.1.3/src/base/ftpfr.c"; sourceTree = "<group>"; };
+		205229CA28E8EDD700589E91 /* fttype1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fttype1.c; path = "freetype-2.1.3/src/base/fttype1.c"; sourceTree = "<group>"; };
+		205229CB28E8EDD700589E91 /* ftmm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftmm.c; path = "freetype-2.1.3/src/base/ftmm.c"; sourceTree = "<group>"; };
+		205229CC28E8EDD700589E91 /* ftxf86.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftxf86.c; path = "freetype-2.1.3/src/base/ftxf86.c"; sourceTree = "<group>"; };
+		205229D928E8EE3000589E91 /* ftsystem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftsystem.c; path = "freetype-2.1.3/builds/unix/ftsystem.c"; sourceTree = "<group>"; };
+		205229DB28E8EE5300589E91 /* autohint.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = autohint.c; path = "freetype-2.1.3/src/autohint/autohint.c"; sourceTree = "<group>"; };
+		205229DD28E8EE6700589E91 /* bdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bdf.c; path = "freetype-2.1.3/src/bdf/bdf.c"; sourceTree = "<group>"; };
+		205229DF28E8EE7F00589E91 /* ftcache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftcache.c; path = "freetype-2.1.3/src/cache/ftcache.c"; sourceTree = "<group>"; };
+		205229E128E8EE9B00589E91 /* cff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cff.c; path = "freetype-2.1.3/src/cff/cff.c"; sourceTree = "<group>"; };
+		205229E328E8EEAF00589E91 /* type1cid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type1cid.c; path = "freetype-2.1.3/src/cid/type1cid.c"; sourceTree = "<group>"; };
+		205229E528E8EED300589E91 /* ftgzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ftgzip.c; path = "freetype-2.1.3/src/gzip/ftgzip.c"; sourceTree = "<group>"; };
+		205229E728E8EEEA00589E91 /* pcf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcf.c; path = "freetype-2.1.3/src/pcf/pcf.c"; sourceTree = "<group>"; };
+		205229E928E8F23000589E91 /* pfr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pfr.c; path = "freetype-2.1.3/src/pfr/pfr.c"; sourceTree = "<group>"; };
+		205229ED28E8F25A00589E91 /* psaux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = psaux.c; path = "freetype-2.1.3/src/psaux/psaux.c"; sourceTree = "<group>"; };
+		205229EF28E8F27800589E91 /* pshinter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pshinter.c; path = "freetype-2.1.3/src/pshinter/pshinter.c"; sourceTree = "<group>"; };
+		205229F128E8F29900589E91 /* psmodule.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = psmodule.c; path = "freetype-2.1.3/src/psnames/psmodule.c"; sourceTree = "<group>"; };
+		205229F328E8F2B700589E91 /* raster.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = raster.c; path = "freetype-2.1.3/src/raster/raster.c"; sourceTree = "<group>"; };
+		205229F528E8F2CF00589E91 /* sfnt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sfnt.c; path = "freetype-2.1.3/src/sfnt/sfnt.c"; sourceTree = "<group>"; };
+		205229F728E8F2E200589E91 /* smooth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = smooth.c; path = "freetype-2.1.3/src/smooth/smooth.c"; sourceTree = "<group>"; };
+		205229F928E8F51A00589E91 /* truetype.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = truetype.c; path = "freetype-2.1.3/src/truetype/truetype.c"; sourceTree = "<group>"; };
+		205229FB28E8F53000589E91 /* type1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type1.c; path = "freetype-2.1.3/src/type1/type1.c"; sourceTree = "<group>"; };
+		205229FD28E8F53E00589E91 /* type42.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = type42.c; path = "freetype-2.1.3/src/type42/type42.c"; sourceTree = "<group>"; };
+		205229FF28E8F54E00589E91 /* winfnt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = winfnt.c; path = "freetype-2.1.3/src/winfonts/winfnt.c"; sourceTree = "<group>"; };
+		20522A0228E8F7FD00589E91 /* cc_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_common.h; sourceTree = "<group>"; };
+		20522A0328E8F7FD00589E91 /* cc_common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_common.cpp; sourceTree = "<group>"; };
+		20522A0428E8F7FD00589E91 /* cc_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_internal.h; sourceTree = "<group>"; };
+		20522A0828E8F81700589E91 /* stdio_compat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stdio_compat.c; sourceTree = "<group>"; };
+		20522A0928E8F81700589E91 /* stdio_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stdio_compat.h; sourceTree = "<group>"; };
+		20522A0A28E8F81800589E91 /* memorystream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memorystream.h; sourceTree = "<group>"; };
+		20522A0B28E8F81800589E91 /* data_ext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_ext.h; sourceTree = "<group>"; };
+		20522A0C28E8F81800589E91 /* memory_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory_compat.h; sourceTree = "<group>"; };
+		20522A0D28E8F81800589E91 /* error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
+		20522A0E28E8F81900589E91 /* cmdlineopts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cmdlineopts.cpp; sourceTree = "<group>"; };
+		20522A0F28E8F81900589E91 /* android_file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = android_file.cpp; sourceTree = "<group>"; };
+		20522A1028E8F81900589E91 /* bufferedstream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bufferedstream.cpp; sourceTree = "<group>"; };
+		20522A1128E8F81900589E91 /* aasset_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aasset_stream.cpp; sourceTree = "<group>"; };
+		20522A1228E8F81A00589E91 /* memorystream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = memorystream.cpp; sourceTree = "<group>"; };
+		20522A1328E8F81A00589E91 /* string_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_compat.h; sourceTree = "<group>"; };
+		20522A1428E8F81A00589E91 /* string_compat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = string_compat.c; sourceTree = "<group>"; };
+		20522A1528E8F81A00589E91 /* utf8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf8.h; sourceTree = "<group>"; };
+		20522A1628E8F81A00589E91 /* scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scaling.h; sourceTree = "<group>"; };
+		20522A1728E8F81B00589E91 /* path_ex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = path_ex.cpp; sourceTree = "<group>"; };
+		20522A1828E8F81B00589E91 /* data_ext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = data_ext.cpp; sourceTree = "<group>"; };
+		20522A1928E8F81B00589E91 /* cmdlineopts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmdlineopts.h; sourceTree = "<group>"; };
+		20522A1A28E8F81B00589E91 /* android_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = android_file.h; sourceTree = "<group>"; };
+		20522A1B28E8F81B00589E91 /* bufferedstream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bufferedstream.h; sourceTree = "<group>"; };
+		20522A1C28E8F81C00589E91 /* aasset_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aasset_stream.h; sourceTree = "<group>"; };
+		20522A3228E8F86200589E91 /* scriptviewport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scriptviewport.h; sourceTree = "<group>"; };
+		20522A3328E8F86200589E91 /* scriptcamera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scriptcamera.cpp; sourceTree = "<group>"; };
+		20522A3428E8F86200589E91 /* cc_dynamicobject_addr_and_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_dynamicobject_addr_and_manager.h; sourceTree = "<group>"; };
+		20522A3528E8F86200589E91 /* scriptcamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scriptcamera.h; sourceTree = "<group>"; };
+		20522A3628E8F86200589E91 /* scriptcontainers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scriptcontainers.h; sourceTree = "<group>"; };
+		20522A3728E8F86300589E91 /* scriptdict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scriptdict.h; sourceTree = "<group>"; };
+		20522A3828E8F86300589E91 /* scriptset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scriptset.cpp; sourceTree = "<group>"; };
+		20522A3928E8F86300589E91 /* scriptset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scriptset.h; sourceTree = "<group>"; };
+		20522A3A28E8F86300589E91 /* scriptviewport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scriptviewport.cpp; sourceTree = "<group>"; };
+		20522A3B28E8F86400589E91 /* scriptdict.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scriptdict.cpp; sourceTree = "<group>"; };
+		20522A4628E8F8A900589E91 /* draw_software.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = draw_software.h; sourceTree = "<group>"; };
+		20522A4728E8F8A900589E91 /* draw_software.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = draw_software.cpp; sourceTree = "<group>"; };
+		20522A4828E8F8AA00589E91 /* asset_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = asset_helper.h; sourceTree = "<group>"; };
+		20522A4C28E8F8CA00589E91 /* route_finder_impl_legacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_finder_impl_legacy.cpp; sourceTree = "<group>"; };
+		20522A4D28E8F8CA00589E91 /* route_finder_impl_legacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = route_finder_impl_legacy.h; sourceTree = "<group>"; };
+		20522A4E28E8F8CA00589E91 /* path_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = path_helper.h; sourceTree = "<group>"; };
+		20522A4F28E8F8CA00589E91 /* route_finder_jps.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = route_finder_jps.inl; sourceTree = "<group>"; };
+		20522A5028E8F8CA00589E91 /* route_finder_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = route_finder_impl.h; sourceTree = "<group>"; };
+		20522A5128E8F8CA00589E91 /* scriptcontainers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scriptcontainers.cpp; sourceTree = "<group>"; };
+		20522A5228E8F8CB00589E91 /* route_finder_impl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = route_finder_impl.cpp; sourceTree = "<group>"; };
+		20522A5A28E8F8DD00589E91 /* viewport_script.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewport_script.cpp; sourceTree = "<group>"; };
+		20522A5B28E8F8DD00589E91 /* sys_events.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sys_events.h; sourceTree = "<group>"; };
+		20522A5C28E8F8DD00589E91 /* sys_events.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sys_events.cpp; sourceTree = "<group>"; };
+		20522A6028E8F8FC00589E91 /* messagebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagebuffer.h; sourceTree = "<group>"; };
+		20522A6128E8F8FC00589E91 /* messagebuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messagebuffer.cpp; sourceTree = "<group>"; };
+		20522A6428E8F92000589E91 /* viewport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewport.h; sourceTree = "<group>"; };
+		20522A6528E8F92000589E91 /* savegame_components.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = savegame_components.h; sourceTree = "<group>"; };
+		20522A6628E8F92000589E91 /* savegame_components.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = savegame_components.cpp; sourceTree = "<group>"; };
+		20522A6728E8F92000589E91 /* viewport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewport.cpp; sourceTree = "<group>"; };
+		20522A6828E8F92100589E91 /* savegame_v321.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = savegame_v321.cpp; sourceTree = "<group>"; };
+		20522A6E28E8F94000589E91 /* gfxfilter_aaogl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_aaogl.cpp; sourceTree = "<group>"; };
+		20522A6F28E8F94000589E91 /* gfxfilter_aaogl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_aaogl.h; sourceTree = "<group>"; };
+		20522A7028E8F94000589E91 /* gfxfilter_sdl_renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_sdl_renderer.h; sourceTree = "<group>"; };
+		20522A7128E8F94100589E91 /* ogl_headers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ogl_headers.h; sourceTree = "<group>"; };
+		20522A7228E8F94100589E91 /* gfxfilter_sdl_renderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_sdl_renderer.cpp; sourceTree = "<group>"; };
+		20522A7C28E8F98400589E91 /* khrplatform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = khrplatform.h; sourceTree = "<group>"; };
+		20522A7E28E8F98400589E91 /* glad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = glad.h; sourceTree = "<group>"; };
+		20522A8028E8F98400589E91 /* glad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = glad.c; sourceTree = "<group>"; };
+		20522A8528E8F9D600589E91 /* main_sdl2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main_sdl2.cpp; sourceTree = "<group>"; };
+		20522A8728E8FD2B00589E91 /* sdl2_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sdl2_util.h; sourceTree = "<group>"; };
+		20522A8828E8FD2B00589E91 /* sdl2_util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sdl2_util.cpp; sourceTree = "<group>"; };
+		20522A8E28E8FD6000589E91 /* plugin_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = plugin_engine.h; sourceTree = "<group>"; };
+		20522A9128E8FD7600589E91 /* sys_main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sys_main.h; sourceTree = "<group>"; };
+		20522A9228E8FD7700589E91 /* sys_main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sys_main.cpp; sourceTree = "<group>"; };
+		20E67D0A28F1BDDF00B95C00 /* gfx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gfx.c; sourceTree = "<group>"; };
+		20E67D0B28F1BDDF00B95C00 /* unicode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unicode.c; sourceTree = "<group>"; };
+		20E67D0C28F1BDDF00B95C00 /* blit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blit.c; sourceTree = "<group>"; };
+		20E67D0D28F1BDDF00B95C00 /* math.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = math.c; sourceTree = "<group>"; };
+		20E67D0E28F1BDDF00B95C00 /* pcx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pcx.c; sourceTree = "<group>"; };
+		20E67D0F28F1BDDF00B95C00 /* fli.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fli.c; sourceTree = "<group>"; };
+		20E67D1028F1BDDF00B95C00 /* rotate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rotate.c; sourceTree = "<group>"; };
+		20E67D1128F1BDDF00B95C00 /* flood.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = flood.c; sourceTree = "<group>"; };
+		20E67D1228F1BDDF00B95C00 /* vtable32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable32.c; sourceTree = "<group>"; };
+		20E67D1628F1BDDF00B95C00 /* graphics.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = graphics.c; sourceTree = "<group>"; };
+		20E67D1728F1BDDF00B95C00 /* vtable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable.c; sourceTree = "<group>"; };
+		20E67D1828F1BDDF00B95C00 /* libc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = libc.c; sourceTree = "<group>"; };
+		20E67D1928F1BDDF00B95C00 /* polygon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = polygon.c; sourceTree = "<group>"; };
+		20E67D1A28F1BDDF00B95C00 /* vtable16.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable16.c; sourceTree = "<group>"; };
+		20E67D1C28F1BDDF00B95C00 /* ufile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ufile.c; sourceTree = "<group>"; };
+		20E67D1D28F1BDDF00B95C00 /* quantize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quantize.c; sourceTree = "<group>"; };
+		20E67D1E28F1BDDF00B95C00 /* colblend.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = colblend.c; sourceTree = "<group>"; };
+		20E67D1F28F1BDDF00B95C00 /* dither.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dither.c; sourceTree = "<group>"; };
+		20E67D2028F1BDDF00B95C00 /* dataregi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dataregi.c; sourceTree = "<group>"; };
+		20E67D2128F1BDDF00B95C00 /* allegro.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = allegro.c; sourceTree = "<group>"; };
+		20E67D2228F1BDDF00B95C00 /* vtable15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable15.c; sourceTree = "<group>"; };
+		20E67D2328F1BDDF00B95C00 /* readbmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = readbmp.c; sourceTree = "<group>"; };
+		20E67D2428F1BDDF00B95C00 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
+		20E67D2528F1BDDF00B95C00 /* bmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmp.c; sourceTree = "<group>"; };
+		20E67D2628F1BDDF00B95C00 /* vtable8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable8.c; sourceTree = "<group>"; };
+		20E67D2828F1BDDF00B95C00 /* cblit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cblit.h; sourceTree = "<group>"; };
+		20E67D2928F1BDDF00B95C00 /* cspr8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr8.c; sourceTree = "<group>"; };
+		20E67D2A28F1BDDF00B95C00 /* cspr16.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr16.c; sourceTree = "<group>"; };
+		20E67D2B28F1BDDF00B95C00 /* cblit16.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cblit16.c; sourceTree = "<group>"; };
+		20E67D2C28F1BDDF00B95C00 /* cspr24.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr24.c; sourceTree = "<group>"; };
+		20E67D2D28F1BDDF00B95C00 /* cgfx8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cgfx8.c; sourceTree = "<group>"; };
+		20E67D2E28F1BDDF00B95C00 /* cblit24.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cblit24.c; sourceTree = "<group>"; };
+		20E67D2F28F1BDDF00B95C00 /* cdefs32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdefs32.h; sourceTree = "<group>"; };
+		20E67D3028F1BDDF00B95C00 /* cspr15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr15.c; sourceTree = "<group>"; };
+		20E67D3128F1BDDF00B95C00 /* cmisc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmisc.c; sourceTree = "<group>"; };
+		20E67D3228F1BDDF00B95C00 /* cgfx32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cgfx32.c; sourceTree = "<group>"; };
+		20E67D3328F1BDDF00B95C00 /* cgfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cgfx.h; sourceTree = "<group>"; };
+		20E67D3428F1BDDF00B95C00 /* cdefs16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdefs16.h; sourceTree = "<group>"; };
+		20E67D3528F1BDDF00B95C00 /* cgfx16.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cgfx16.c; sourceTree = "<group>"; };
+		20E67D3628F1BDDF00B95C00 /* cstretch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cstretch.c; sourceTree = "<group>"; };
+		20E67D3728F1BDDF00B95C00 /* cdefs24.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdefs24.h; sourceTree = "<group>"; };
+		20E67D3828F1BDDF00B95C00 /* cgfx24.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cgfx24.c; sourceTree = "<group>"; };
+		20E67D3928F1BDDF00B95C00 /* cspr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cspr.h; sourceTree = "<group>"; };
+		20E67D3A28F1BDDF00B95C00 /* cspr32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr32.c; sourceTree = "<group>"; };
+		20E67D3B28F1BDDF00B95C00 /* cblit8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cblit8.c; sourceTree = "<group>"; };
+		20E67D3C28F1BDDF00B95C00 /* cdefs15.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdefs15.h; sourceTree = "<group>"; };
+		20E67D3D28F1BDDF00B95C00 /* cdefs8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdefs8.h; sourceTree = "<group>"; };
+		20E67D3E28F1BDDF00B95C00 /* cblit32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cblit32.c; sourceTree = "<group>"; };
+		20E67D3F28F1BDDF00B95C00 /* cgfx15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cgfx15.c; sourceTree = "<group>"; };
+		20E67D4028F1BDDF00B95C00 /* vtable24.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable24.c; sourceTree = "<group>"; };
+		20E67D4128F1BDDF00B95C00 /* inline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = inline.c; sourceTree = "<group>"; };
+		20E67D4228F1BDDF00B95C00 /* color.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = color.c; sourceTree = "<group>"; };
+		20E67D4528F1BDE000B95C00 /* allegro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = allegro.h; sourceTree = "<group>"; };
+		20E67D4728F1BDE000B95C00 /* datafile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = datafile.h; sourceTree = "<group>"; };
+		20E67D4828F1BDE000B95C00 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
+		20E67D4928F1BDE000B95C00 /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed.h; sourceTree = "<group>"; };
+		20E67D4A28F1BDE000B95C00 /* file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file.h; sourceTree = "<group>"; };
+		20E67D4C28F1BDE000B95C00 /* astdint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = astdint.h; sourceTree = "<group>"; };
+		20E67D4F28F1BDE000B95C00 /* alosxcfg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alosxcfg.h; sourceTree = "<group>"; };
+		20E67D5328F1BDE000B95C00 /* aintern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aintern.h; sourceTree = "<group>"; };
+		20E67D5428F1BDE000B95C00 /* alconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alconfig.h; sourceTree = "<group>"; };
+		20E67D5528F1BDE000B95C00 /* color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = color.h; sourceTree = "<group>"; };
+		20E67D5728F1BDE000B95C00 /* draw.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = draw.inl; sourceTree = "<group>"; };
+		20E67D5828F1BDE000B95C00 /* gfx.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = gfx.inl; sourceTree = "<group>"; };
+		20E67D5928F1BDE000B95C00 /* fmaths.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = fmaths.inl; sourceTree = "<group>"; };
+		20E67D5A28F1BDE000B95C00 /* color.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = color.inl; sourceTree = "<group>"; };
+		20E67D5B28F1BDE000B95C00 /* fix.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = fix.inl; sourceTree = "<group>"; };
+		20E67D5C28F1BDE000B95C00 /* fmaths.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fmaths.h; sourceTree = "<group>"; };
+		20E67D5D28F1BDE000B95C00 /* unicode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unicode.h; sourceTree = "<group>"; };
+		20E67D5E28F1BDE000B95C00 /* palette.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = palette.h; sourceTree = "<group>"; };
+		20E67D5F28F1BDE000B95C00 /* gfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfx.h; sourceTree = "<group>"; };
+		20E67D6028F1BDE000B95C00 /* fli.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fli.h; sourceTree = "<group>"; };
+		20E67D6128F1BDE000B95C00 /* system.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = system.h; sourceTree = "<group>"; };
+		20E67D6228F1BDE000B95C00 /* draw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = draw.h; sourceTree = "<group>"; };
+		20E67D6328F1BDE000B95C00 /* base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
+		20E6810228F1BE5C00B95C00 /* al.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = al.h; sourceTree = "<group>"; };
+		20E6810328F1BE5C00B95C00 /* alc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alc.h; sourceTree = "<group>"; };
+		20E6810428F1BE5D00B95C00 /* mojoal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mojoal.c; path = ../../../../libsrc/mojoAL/mojoal.c; sourceTree = "<group>"; };
+		20E6810A28F1C7D000B95C00 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL2.framework; sourceTree = "<group>"; };
+		20E6810C28F1C98200B95C00 /* apeg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = apeg.h; sourceTree = "<group>"; };
+		20E6810D28F1C98200B95C00 /* l2tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = l2tables.h; sourceTree = "<group>"; };
+		20E6810E28F1C98200B95C00 /* getblk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getblk.h; sourceTree = "<group>"; };
+		20E6810F28F1C98300B95C00 /* mpg123.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpg123.h; sourceTree = "<group>"; };
+		20E6811028F1C98300B95C00 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		20E6811128F1C98300B95C00 /* mpeg1dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpeg1dec.h; sourceTree = "<group>"; };
+		20E6811228F1C98300B95C00 /* huffman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman.h; sourceTree = "<group>"; };
+		20E6811328F1C98300B95C00 /* getbits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getbits.h; sourceTree = "<group>"; };
+		20E681E528F1D2A100B95C00 /* SDL_sound_coreaudio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_coreaudio.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_coreaudio.c; sourceTree = "<group>"; };
+		20E681E628F1D2A200B95C00 /* SDL_sound_modplug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_modplug.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_modplug.c; sourceTree = "<group>"; };
+		20E681E728F1D2A200B95C00 /* SDL_sound_aiff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_aiff.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_aiff.c; sourceTree = "<group>"; };
+		20E681E828F1D2A200B95C00 /* SDL_sound_mp3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_mp3.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_mp3.c; sourceTree = "<group>"; };
+		20E681E928F1D2A200B95C00 /* SDL_sound_voc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_voc.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_voc.c; sourceTree = "<group>"; };
+		20E681EA28F1D2A200B95C00 /* SDL_sound_flac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_flac.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_flac.c; sourceTree = "<group>"; };
+		20E681EB28F1D2A200B95C00 /* SDL_sound_midi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_midi.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_midi.c; sourceTree = "<group>"; };
+		20E681EC28F1D2A200B95C00 /* SDL_sound_au.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_au.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_au.c; sourceTree = "<group>"; };
+		20E681EE28F1D2A300B95C00 /* SDL_sound_raw.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_raw.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_raw.c; sourceTree = "<group>"; };
+		20E681EF28F1D2A700B95C00 /* SDL_sound_vorbis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_vorbis.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_vorbis.c; sourceTree = "<group>"; };
+		20E681F028F1D2A700B95C00 /* SDL_sound_wav.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_wav.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_wav.c; sourceTree = "<group>"; };
+		20E681F128F1D2A800B95C00 /* SDL_sound.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound.c; sourceTree = "<group>"; };
+		20E681F228F1D2A800B95C00 /* SDL_sound_shn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_sound_shn.c; path = ../../../../libsrc/SDL_sound/src/SDL_sound_shn.c; sourceTree = "<group>"; };
+		20E6820228F1D2B300B95C00 /* load_okt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_okt.c; sourceTree = "<group>"; };
+		20E6820328F1D2B300B95C00 /* sndfile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sndfile.c; sourceTree = "<group>"; };
+		20E6820428F1D2B300B95C00 /* load_amf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_amf.c; sourceTree = "<group>"; };
+		20E6820528F1D2B300B95C00 /* modplug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = modplug.h; sourceTree = "<group>"; };
+		20E6820628F1D2B300B95C00 /* load_mtm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_mtm.c; sourceTree = "<group>"; };
+		20E6820728F1D2B300B95C00 /* load_ult.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_ult.c; sourceTree = "<group>"; };
+		20E6820828F1D2B300B95C00 /* load_far.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_far.c; sourceTree = "<group>"; };
+		20E6820928F1D2B300B95C00 /* load_psm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_psm.c; sourceTree = "<group>"; };
+		20E6820A28F1D2B300B95C00 /* load_xm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_xm.c; sourceTree = "<group>"; };
+		20E6820B28F1D2B300B95C00 /* load_dmf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_dmf.c; sourceTree = "<group>"; };
+		20E6820C28F1D2B300B95C00 /* load_dsm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_dsm.c; sourceTree = "<group>"; };
+		20E6820D28F1D2B300B95C00 /* load_gdm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_gdm.c; sourceTree = "<group>"; };
+		20E6820E28F1D2B300B95C00 /* libmodplug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libmodplug.h; sourceTree = "<group>"; };
+		20E6820F28F1D2B300B95C00 /* load_mdl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_mdl.c; sourceTree = "<group>"; };
+		20E6821028F1D2B300B95C00 /* load_s3m.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_s3m.c; sourceTree = "<group>"; };
+		20E6821128F1D2B300B95C00 /* load_669.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_669.c; sourceTree = "<group>"; };
+		20E6821228F1D2B300B95C00 /* mmcmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mmcmp.c; sourceTree = "<group>"; };
+		20E6821328F1D2B300B95C00 /* load_it.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_it.c; sourceTree = "<group>"; };
+		20E6821428F1D2B300B95C00 /* snd_fx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = snd_fx.c; sourceTree = "<group>"; };
+		20E6821528F1D2B300B95C00 /* snd_flt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = snd_flt.c; sourceTree = "<group>"; };
+		20E6821628F1D2B300B95C00 /* load_ams.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_ams.c; sourceTree = "<group>"; };
+		20E6821728F1D2B300B95C00 /* sndmix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sndmix.c; sourceTree = "<group>"; };
+		20E6821828F1D2B300B95C00 /* snd_dsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = snd_dsp.c; sourceTree = "<group>"; };
+		20E6821928F1D2B300B95C00 /* tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tables.h; sourceTree = "<group>"; };
+		20E6821A28F1D2B300B95C00 /* load_dbm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_dbm.c; sourceTree = "<group>"; };
+		20E6821B28F1D2B300B95C00 /* modplug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = modplug.c; sourceTree = "<group>"; };
+		20E6821C28F1D2B300B95C00 /* load_umx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_umx.c; sourceTree = "<group>"; };
+		20E6821D28F1D2B300B95C00 /* load_mod.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_mod.c; sourceTree = "<group>"; };
+		20E6821E28F1D2B300B95C00 /* load_stm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_stm.c; sourceTree = "<group>"; };
+		20E6821F28F1D2B300B95C00 /* load_ptm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_ptm.c; sourceTree = "<group>"; };
+		20E6822028F1D2B300B95C00 /* fastmix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastmix.c; sourceTree = "<group>"; };
+		20E6822128F1D2B300B95C00 /* load_med.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_med.c; sourceTree = "<group>"; };
+		20E6822228F1D2B300B95C00 /* load_mt2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = load_mt2.c; sourceTree = "<group>"; };
+		20E6824528F1D2C300B95C00 /* resample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample.h; sourceTree = "<group>"; };
+		20E6824628F1D2C300B95C00 /* common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common.c; sourceTree = "<group>"; };
+		20E6824828F1D2C300B95C00 /* tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables.c; sourceTree = "<group>"; };
+		20E6824928F1D2C300B95C00 /* mix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mix.h; sourceTree = "<group>"; };
+		20E6824A28F1D2C300B95C00 /* readmidi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = readmidi.c; sourceTree = "<group>"; };
+		20E6824D28F1D2C300B95C00 /* playmidi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playmidi.h; sourceTree = "<group>"; };
+		20E6824E28F1D2C300B95C00 /* instrum.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = instrum.c; sourceTree = "<group>"; };
+		20E6825028F1D2C300B95C00 /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = options.h; sourceTree = "<group>"; };
+		20E6825128F1D2C300B95C00 /* timidity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timidity.h; sourceTree = "<group>"; };
+		20E6825228F1D2C300B95C00 /* output.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = output.h; sourceTree = "<group>"; };
+		20E6825528F1D2C300B95C00 /* tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tables.h; sourceTree = "<group>"; };
+		20E6825628F1D2C400B95C00 /* resample.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample.c; sourceTree = "<group>"; };
+		20E6825828F1D2C400B95C00 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		20E6825928F1D2C400B95C00 /* mix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mix.c; sourceTree = "<group>"; };
+		20E6825A28F1D2C400B95C00 /* playmidi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = playmidi.c; sourceTree = "<group>"; };
+		20E6825B28F1D2C400B95C00 /* readmidi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = readmidi.h; sourceTree = "<group>"; };
+		20E6825C28F1D2C400B95C00 /* output.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = output.c; sourceTree = "<group>"; };
+		20E6825D28F1D2C400B95C00 /* timidity.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = timidity.c; sourceTree = "<group>"; };
+		20E6825E28F1D2C400B95C00 /* instrum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instrum.h; sourceTree = "<group>"; };
+		20E6827928F1D32C00B95C00 /* audio_core.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_core.cpp; sourceTree = "<group>"; };
+		20E6827A28F1D32C00B95C00 /* sdldecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sdldecoder.cpp; sourceTree = "<group>"; };
+		20E6827B28F1D32C00B95C00 /* audio_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_core.h; sourceTree = "<group>"; };
+		20E6827C28F1D32C00B95C00 /* audio_system.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_system.h; sourceTree = "<group>"; };
+		20E6827D28F1D32D00B95C00 /* sdldecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sdldecoder.h; sourceTree = "<group>"; };
+		20E6827E28F1D32D00B95C00 /* openalsource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openalsource.h; sourceTree = "<group>"; };
+		20E6827F28F1D32D00B95C00 /* openalsource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openalsource.cpp; sourceTree = "<group>"; };
+		20E6828028F1D32D00B95C00 /* openal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openal.h; sourceTree = "<group>"; };
+		20E6836E28F20BFD00B95C00 /* framing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = framing.c; path = ../../../../libsrc/ogg/src/framing.c; sourceTree = "<group>"; };
+		20E6836F28F20BFD00B95C00 /* crctable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crctable.h; path = ../../../../libsrc/ogg/src/crctable.h; sourceTree = "<group>"; };
+		20E6837028F20BFD00B95C00 /* bitwise.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bitwise.c; path = ../../../../libsrc/ogg/src/bitwise.c; sourceTree = "<group>"; };
+		20E6837428F20C6200B95C00 /* window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = window.h; path = ../../../../libsrc/vorbis/lib/window.h; sourceTree = "<group>"; };
+		20E6837528F20C6200B95C00 /* psy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = psy.h; path = ../../../../libsrc/vorbis/lib/psy.h; sourceTree = "<group>"; };
+		20E6837628F20C6300B95C00 /* psy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = psy.c; path = ../../../../libsrc/vorbis/lib/psy.c; sourceTree = "<group>"; };
+		20E6837728F20C6300B95C00 /* lookup_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lookup_data.h; path = ../../../../libsrc/vorbis/lib/lookup_data.h; sourceTree = "<group>"; };
+		20E6838428F20C6300B95C00 /* synthesis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = synthesis.c; path = ../../../../libsrc/vorbis/lib/synthesis.c; sourceTree = "<group>"; };
+		20E6838528F20C6300B95C00 /* floor0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = floor0.c; path = ../../../../libsrc/vorbis/lib/floor0.c; sourceTree = "<group>"; };
+		20E6838628F20C6300B95C00 /* mapping0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mapping0.c; path = ../../../../libsrc/vorbis/lib/mapping0.c; sourceTree = "<group>"; };
+		20E6838728F20C6300B95C00 /* highlevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = highlevel.h; path = ../../../../libsrc/vorbis/lib/highlevel.h; sourceTree = "<group>"; };
+		20E6838828F20C6400B95C00 /* block.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = block.c; path = ../../../../libsrc/vorbis/lib/block.c; sourceTree = "<group>"; };
+		20E6838C28F20C6400B95C00 /* smallft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = smallft.c; path = ../../../../libsrc/vorbis/lib/smallft.c; sourceTree = "<group>"; };
+		20E6838D28F20C6500B95C00 /* lpc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lpc.c; path = ../../../../libsrc/vorbis/lib/lpc.c; sourceTree = "<group>"; };
+		20E6838E28F20C6500B95C00 /* misc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = misc.c; path = ../../../../libsrc/vorbis/lib/misc.c; sourceTree = "<group>"; };
+		20E6838F28F20C6500B95C00 /* backends.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = backends.h; path = ../../../../libsrc/vorbis/lib/backends.h; sourceTree = "<group>"; };
+		20E6839028F20C6500B95C00 /* sharedbook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sharedbook.c; path = ../../../../libsrc/vorbis/lib/sharedbook.c; sourceTree = "<group>"; };
+		20E6839128F20C6500B95C00 /* res0.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = res0.c; path = ../../../../libsrc/vorbis/lib/res0.c; sourceTree = "<group>"; };
+		20E6839228F20C6600B95C00 /* lookup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lookup.h; path = ../../../../libsrc/vorbis/lib/lookup.h; sourceTree = "<group>"; };
+		20E6839428F20C6600B95C00 /* bitrate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitrate.h; path = ../../../../libsrc/vorbis/lib/bitrate.h; sourceTree = "<group>"; };
+		20E6839528F20C6600B95C00 /* masking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = masking.h; path = ../../../../libsrc/vorbis/lib/masking.h; sourceTree = "<group>"; };
+		20E683AB28F20C6600B95C00 /* mdct.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mdct.c; path = ../../../../libsrc/vorbis/lib/mdct.c; sourceTree = "<group>"; };
+		20E683AC28F20C6700B95C00 /* floor1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = floor1.c; path = ../../../../libsrc/vorbis/lib/floor1.c; sourceTree = "<group>"; };
+		20E683AD28F20C6700B95C00 /* window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = window.c; path = ../../../../libsrc/vorbis/lib/window.c; sourceTree = "<group>"; };
+		20E683AF28F20C6700B95C00 /* registry.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = registry.c; path = ../../../../libsrc/vorbis/lib/registry.c; sourceTree = "<group>"; };
+		20E683B028F20C6800B95C00 /* lookup.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lookup.c; path = ../../../../libsrc/vorbis/lib/lookup.c; sourceTree = "<group>"; };
+		20E683B128F20C6D00B95C00 /* scales.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scales.h; path = ../../../../libsrc/vorbis/lib/scales.h; sourceTree = "<group>"; };
+		20E683B228F20C6D00B95C00 /* smallft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = smallft.h; path = ../../../../libsrc/vorbis/lib/smallft.h; sourceTree = "<group>"; };
+		20E683B328F20C6D00B95C00 /* lsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lsp.c; path = ../../../../libsrc/vorbis/lib/lsp.c; sourceTree = "<group>"; };
+		20E683B428F20C6D00B95C00 /* analysis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = analysis.c; path = ../../../../libsrc/vorbis/lib/analysis.c; sourceTree = "<group>"; };
+		20E683B528F20C6E00B95C00 /* os.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = os.h; path = ../../../../libsrc/vorbis/lib/os.h; sourceTree = "<group>"; };
+		20E683B728F20C6E00B95C00 /* lsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lsp.h; path = ../../../../libsrc/vorbis/lib/lsp.h; sourceTree = "<group>"; };
+		20E683B828F20C6E00B95C00 /* registry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = registry.h; path = ../../../../libsrc/vorbis/lib/registry.h; sourceTree = "<group>"; };
+		20E683B928F20C6E00B95C00 /* mdct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mdct.h; path = ../../../../libsrc/vorbis/lib/mdct.h; sourceTree = "<group>"; };
+		20E683BA28F20C6F00B95C00 /* bitrate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bitrate.c; path = ../../../../libsrc/vorbis/lib/bitrate.c; sourceTree = "<group>"; };
+		20E683BB28F20C7000B95C00 /* codec_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = codec_internal.h; path = ../../../../libsrc/vorbis/lib/codec_internal.h; sourceTree = "<group>"; };
+		20E683BC28F20C7000B95C00 /* lpc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lpc.h; path = ../../../../libsrc/vorbis/lib/lpc.h; sourceTree = "<group>"; };
+		20E683BD28F20C7000B95C00 /* codebook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = codebook.c; path = ../../../../libsrc/vorbis/lib/codebook.c; sourceTree = "<group>"; };
+		20E683BE28F20C7000B95C00 /* envelope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = envelope.h; path = ../../../../libsrc/vorbis/lib/envelope.h; sourceTree = "<group>"; };
+		20E683BF28F20C7100B95C00 /* codebook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = codebook.h; path = ../../../../libsrc/vorbis/lib/codebook.h; sourceTree = "<group>"; };
+		20E683C228F20C7100B95C00 /* misc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = misc.h; path = ../../../../libsrc/vorbis/lib/misc.h; sourceTree = "<group>"; };
+		20E683C328F20C7200B95C00 /* envelope.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = envelope.c; path = ../../../../libsrc/vorbis/lib/envelope.c; sourceTree = "<group>"; };
+		20E683C428F20C7200B95C00 /* info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = info.c; path = ../../../../libsrc/vorbis/lib/info.c; sourceTree = "<group>"; };
+		20E6841228F20CBC00B95C00 /* huffdec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = huffdec.h; path = ../../../../libsrc/theora/lib/huffdec.h; sourceTree = "<group>"; };
+		20E6841528F20CBD00B95C00 /* fragment.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fragment.c; path = ../../../../libsrc/theora/lib/fragment.c; sourceTree = "<group>"; };
+		20E6841928F20CBE00B95C00 /* bitpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitpack.h; path = ../../../../libsrc/theora/lib/bitpack.h; sourceTree = "<group>"; };
+		20E6842E28F20CBE00B95C00 /* quant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quant.h; path = ../../../../libsrc/theora/lib/quant.h; sourceTree = "<group>"; };
+		20E6843128F20CBF00B95C00 /* internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = internal.c; path = ../../../../libsrc/theora/lib/internal.c; sourceTree = "<group>"; };
+		20E6843328F20CBF00B95C00 /* idct.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = idct.c; path = ../../../../libsrc/theora/lib/idct.c; sourceTree = "<group>"; };
+		20E6843528F20CBF00B95C00 /* state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = state.c; path = ../../../../libsrc/theora/lib/state.c; sourceTree = "<group>"; };
+		20E6843E28F20CC100B95C00 /* huffman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = huffman.h; path = ../../../../libsrc/theora/lib/huffman.h; sourceTree = "<group>"; };
+		20E6843F28F20CC100B95C00 /* huffdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = huffdec.c; path = ../../../../libsrc/theora/lib/huffdec.c; sourceTree = "<group>"; };
+		20E6844228F20CC200B95C00 /* bitpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bitpack.c; path = ../../../../libsrc/theora/lib/bitpack.c; sourceTree = "<group>"; };
+		20E6844328F20CC200B95C00 /* state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = state.h; path = ../../../../libsrc/theora/lib/state.h; sourceTree = "<group>"; };
+		20E6844628F20CC300B95C00 /* dequant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dequant.c; path = ../../../../libsrc/theora/lib/dequant.c; sourceTree = "<group>"; };
+		20E6844728F20CC300B95C00 /* quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant.c; path = ../../../../libsrc/theora/lib/quant.c; sourceTree = "<group>"; };
+		20E6844828F20CC300B95C00 /* apiwrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = apiwrapper.c; path = ../../../../libsrc/theora/lib/apiwrapper.c; sourceTree = "<group>"; };
+		20E6844D28F20CC400B95C00 /* dequant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dequant.h; path = ../../../../libsrc/theora/lib/dequant.h; sourceTree = "<group>"; };
+		20E6844E28F20CC400B95C00 /* apiwrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = apiwrapper.h; path = ../../../../libsrc/theora/lib/apiwrapper.h; sourceTree = "<group>"; };
+		20E6845828F20CC500B95C00 /* info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = info.c; path = ../../../../libsrc/theora/lib/info.c; sourceTree = "<group>"; };
+		20E6846728F20CC500B95C00 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = ../../../../libsrc/theora/lib/internal.h; sourceTree = "<group>"; };
+		20E684E628F20E0700B95C00 /* decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode.c; path = ../../../../libsrc/theora/lib/decode.c; sourceTree = "<group>"; };
+		20E684E728F20E0700B95C00 /* decinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decinfo.c; path = ../../../../libsrc/theora/lib/decinfo.c; sourceTree = "<group>"; };
+		20E684E828F20E0700B95C00 /* decapiwrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decapiwrapper.c; path = ../../../../libsrc/theora/lib/decapiwrapper.c; sourceTree = "<group>"; };
+		20E684F128F2189800B95C00 /* ogg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ogg.h; sourceTree = "<group>"; };
+		20E684F628F2189800B95C00 /* os_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = os_types.h; sourceTree = "<group>"; };
+		20E6850C28F2219A00B95C00 /* VariableWidthSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFont.h; sourceTree = "<group>"; };
+		20E6850D28F2219A00B95C00 /* SpriteFontRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRenderer.h; sourceTree = "<group>"; };
+		20E6850E28F2219A00B95C00 /* VariableWidthFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthFont.h; sourceTree = "<group>"; };
+		20E6850F28F2219A00B95C00 /* SpriteFontRendererClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRendererClifftopGames.cpp; sourceTree = "<group>"; };
+		20E6851028F2219A00B95C00 /* SpriteFontRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRenderer.cpp; sourceTree = "<group>"; };
+		20E6851128F2219A00B95C00 /* SpriteFontRendererClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRendererClifftopGames.h; sourceTree = "<group>"; };
+		20E6851228F2219A00B95C00 /* CharacterEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterEntry.h; sourceTree = "<group>"; };
+		20E6851328F2219A00B95C00 /* color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = color.h; sourceTree = "<group>"; };
+		20E6851428F2219A00B95C00 /* color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = color.cpp; sourceTree = "<group>"; };
+		20E6851528F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFontClifftopGames.cpp; sourceTree = "<group>"; };
+		20E6851628F2219A00B95C00 /* SpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFont.cpp; sourceTree = "<group>"; };
+		20E6851728F2219A00B95C00 /* AGSSpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AGSSpriteFont.cpp; sourceTree = "<group>"; };
+		20E6851828F2219A00B95C00 /* SpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFont.h; sourceTree = "<group>"; };
+		20E6851928F2219A00B95C00 /* CharacterEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CharacterEntry.cpp; sourceTree = "<group>"; };
+		20E6851A28F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFontClifftopGames.h; sourceTree = "<group>"; };
+		20E6851C28F2219A00B95C00 /* VariableWidthFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthFont.cpp; sourceTree = "<group>"; };
+		20E6851D28F2219A00B95C00 /* VariableWidthSpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFont.cpp; sourceTree = "<group>"; };
+		20E6851E28F2219A00B95C00 /* AGSSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSSpriteFont.h; sourceTree = "<group>"; };
+		20E6853E28F221CA00B95C00 /* palrender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = palrender.h; sourceTree = "<group>"; };
+		20E6853F28F221CA00B95C00 /* agspalrender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agspalrender.h; sourceTree = "<group>"; };
+		20E6854228F221CA00B95C00 /* ags_palrender.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ags_palrender.cpp; sourceTree = "<group>"; };
+		20E6854428F221CA00B95C00 /* raycast.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = raycast.cpp; sourceTree = "<group>"; };
+		20E6854528F221CA00B95C00 /* raycast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = raycast.h; sourceTree = "<group>"; };
+		20E6856A28F25E2400B95C00 /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
+		20E6856C28F25E3B00B95C00 /* libz.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.1.tbd; path = usr/lib/libz.1.tbd; sourceTree = SDKROOT; };
 		521C3BEA1D1E545100BD619E /* AGSKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AGSKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		521C3BED1D1E545100BD619E /* AGSKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AGSKit.h; sourceTree = "<group>"; };
 		521C3BEF1D1E545100BD619E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -766,19 +1322,6 @@
 		521C54791D1E572B00BD619E /* agsblend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsblend.h; sourceTree = "<group>"; };
 		521C54821D1E572B00BD619E /* agsflashlight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agsflashlight.cpp; sourceTree = "<group>"; };
 		521C54831D1E572B00BD619E /* agsflashlight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsflashlight.h; sourceTree = "<group>"; };
-		521C54951D1E572B00BD619E /* AGSSpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AGSSpriteFont.cpp; sourceTree = "<group>"; };
-		521C54971D1E572B00BD619E /* CharacterEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CharacterEntry.cpp; sourceTree = "<group>"; };
-		521C54981D1E572B00BD619E /* CharacterEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterEntry.h; sourceTree = "<group>"; };
-		521C54991D1E572B00BD619E /* color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = color.cpp; sourceTree = "<group>"; };
-		521C549A1D1E572B00BD619E /* color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = color.h; sourceTree = "<group>"; };
-		521C549B1D1E572B00BD619E /* SpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFont.cpp; sourceTree = "<group>"; };
-		521C549C1D1E572B00BD619E /* SpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFont.h; sourceTree = "<group>"; };
-		521C549D1D1E572B00BD619E /* SpriteFontRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRenderer.cpp; sourceTree = "<group>"; };
-		521C549E1D1E572B00BD619E /* SpriteFontRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRenderer.h; sourceTree = "<group>"; };
-		521C549F1D1E572B00BD619E /* VariableWidthFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthFont.cpp; sourceTree = "<group>"; };
-		521C54A01D1E572B00BD619E /* VariableWidthFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthFont.h; sourceTree = "<group>"; };
-		521C54A11D1E572B00BD619E /* VariableWidthSpriteFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFont.cpp; sourceTree = "<group>"; };
-		521C54A21D1E572B00BD619E /* VariableWidthSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFont.h; sourceTree = "<group>"; };
 		521C54AB1D1E572B00BD619E /* agstouch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agstouch.cpp; sourceTree = "<group>"; };
 		521C54AC1D1E572B00BD619E /* agstouch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agstouch.h; sourceTree = "<group>"; };
 		521C56901D1E5AAC00BD619E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -789,18 +1332,6 @@
 		521C569A1D1E5ADA00BD619E /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		521C569C1D1E5AE300BD619E /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		521C569E1D1E5AE900BD619E /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		521C56A01D1E5B5F00BD619E /* libaldmb.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libaldmb.a; path = ../../lib/libaldmb.a; sourceTree = "<group>"; };
-		521C56A11D1E5B5F00BD619E /* liballeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liballeg.a; path = ../../lib/liballeg.a; sourceTree = "<group>"; };
-		521C56A21D1E5B5F00BD619E /* libdumb.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdumb.a; path = ../../lib/libdumb.a; sourceTree = "<group>"; };
-		521C56A31D1E5B5F00BD619E /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = ../../lib/libfreetype.a; sourceTree = "<group>"; };
-		521C56A41D1E5B5F00BD619E /* liblua.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblua.a; path = ../../lib/liblua.a; sourceTree = "<group>"; };
-		521C56A51D1E5B5F00BD619E /* libogg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libogg.a; path = ../../lib/libogg.a; sourceTree = "<group>"; };
-		521C56A61D1E5B5F00BD619E /* libtheoradec.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtheoradec.a; path = ../../lib/libtheoradec.a; sourceTree = "<group>"; };
-		521C56A71D1E5B5F00BD619E /* libvorbis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvorbis.a; path = ../../lib/libvorbis.a; sourceTree = "<group>"; };
-		521C56A81D1E5B5F00BD619E /* libvorbisfile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvorbisfile.a; path = ../../lib/libvorbisfile.a; sourceTree = "<group>"; };
-		521C56B21D1E5B7500BD619E /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		521C56B41D1E5B7C00BD619E /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = usr/lib/libbz2.tbd; sourceTree = SDKROOT; };
-		526F211B1D3B5C4800EF4E1F /* animationstruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = animationstruct.h; sourceTree = "<group>"; };
 		526F211C1D3B5C4800EF4E1F /* audiocliptype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audiocliptype.cpp; sourceTree = "<group>"; };
 		526F211D1D3B5C4800EF4E1F /* audiocliptype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audiocliptype.h; sourceTree = "<group>"; };
 		526F211E1D3B5C4800EF4E1F /* characterinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = characterinfo.h; sourceTree = "<group>"; };
@@ -819,15 +1350,9 @@
 		526F212C1D3B5C4800EF4E1F /* interfacebutton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interfacebutton.h; sourceTree = "<group>"; };
 		526F212D1D3B5C4800EF4E1F /* interfaceelement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interfaceelement.h; sourceTree = "<group>"; };
 		526F212E1D3B5C4800EF4E1F /* inventoryiteminfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventoryiteminfo.h; sourceTree = "<group>"; };
-		526F212F1D3B5C4800EF4E1F /* messageinfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messageinfo.cpp; sourceTree = "<group>"; };
-		526F21301D3B5C4800EF4E1F /* messageinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messageinfo.h; sourceTree = "<group>"; };
 		526F21311D3B5C4800EF4E1F /* mousecursor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mousecursor.cpp; sourceTree = "<group>"; };
 		526F21321D3B5C4800EF4E1F /* mousecursor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mousecursor.h; sourceTree = "<group>"; };
 		526F21331D3B5C4800EF4E1F /* oldgamesetupstruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = oldgamesetupstruct.h; sourceTree = "<group>"; };
-		526F21341D3B5C4800EF4E1F /* point.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = point.cpp; sourceTree = "<group>"; };
-		526F21351D3B5C4800EF4E1F /* point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = point.h; sourceTree = "<group>"; };
-		526F21361D3B5C4800EF4E1F /* roomstruct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = roomstruct.cpp; sourceTree = "<group>"; };
-		526F21371D3B5C4800EF4E1F /* roomstruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roomstruct.h; sourceTree = "<group>"; };
 		526F21381D3B5C4800EF4E1F /* spritecache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spritecache.cpp; sourceTree = "<group>"; };
 		526F21391D3B5C4800EF4E1F /* spritecache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spritecache.h; sourceTree = "<group>"; };
 		526F213A1D3B5C4800EF4E1F /* view.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = view.cpp; sourceTree = "<group>"; };
@@ -840,12 +1365,9 @@
 		526F21431D3B5C4800EF4E1F /* assetmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = assetmanager.cpp; sourceTree = "<group>"; };
 		526F21441D3B5C4800EF4E1F /* assetmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assetmanager.h; sourceTree = "<group>"; };
 		526F21451D3B5C4800EF4E1F /* def_version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = def_version.h; sourceTree = "<group>"; };
-		526F21461D3B5C4800EF4E1F /* endianness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endianness.h; sourceTree = "<group>"; };
 		526F21471D3B5C4800EF4E1F /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
 		526F21491D3B5C4800EF4E1F /* assert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assert.h; sourceTree = "<group>"; };
-		526F214A1D3B5C4800EF4E1F /* out.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = out.cpp; sourceTree = "<group>"; };
 		526F214B1D3B5C4800EF4E1F /* out.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = out.h; sourceTree = "<group>"; };
-		526F214C1D3B5C4800EF4E1F /* outputtarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = outputtarget.h; sourceTree = "<group>"; };
 		526F214E1D3B5C4800EF4E1F /* agsfontrenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsfontrenderer.h; sourceTree = "<group>"; };
 		526F214F1D3B5C4800EF4E1F /* fonts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fonts.cpp; sourceTree = "<group>"; };
 		526F21501D3B5C4800EF4E1F /* fonts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fonts.h; sourceTree = "<group>"; };
@@ -883,38 +1405,11 @@
 		526F21731D3B5C4800EF4E1F /* guitextbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guitextbox.h; sourceTree = "<group>"; };
 		526F21751D3B5C4800EF4E1F /* aastr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aastr.h; sourceTree = "<group>"; };
 		526F21761D3B5C4800EF4E1F /* aautil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aautil.h; sourceTree = "<group>"; };
-		526F21781D3B5C4800EF4E1F /* alfont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alfont.h; sourceTree = "<group>"; };
-		526F21791D3B5C4800EF4E1F /* alfontdll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alfontdll.h; sourceTree = "<group>"; };
-		526F217A1D3B5C4800EF4E1F /* almp3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = almp3.h; sourceTree = "<group>"; };
-		526F217B1D3B5C4800EF4E1F /* almp3dll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = almp3dll.h; sourceTree = "<group>"; };
-		526F217C1D3B5C4800EF4E1F /* alogg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alogg.h; sourceTree = "<group>"; };
-		526F217D1D3B5C4800EF4E1F /* aloggdll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aloggdll.h; sourceTree = "<group>"; };
-		526F217E1D3B5C4800EF4E1F /* apeg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = apeg.h; sourceTree = "<group>"; };
-		526F217F1D3B5C4800EF4E1F /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
-		526F21811D3B5C4800EF4E1F /* genre.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = genre.h; sourceTree = "<group>"; };
-		526F21821D3B5C4800EF4E1F /* getbits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getbits.h; sourceTree = "<group>"; };
-		526F21831D3B5C4900EF4E1F /* getblk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getblk.h; sourceTree = "<group>"; };
-		526F21841D3B5C4900EF4E1F /* huffman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman.h; sourceTree = "<group>"; };
-		526F21851D3B5C4900EF4E1F /* l2tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = l2tables.h; sourceTree = "<group>"; };
-		526F21861D3B5C4900EF4E1F /* libcda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libcda.h; sourceTree = "<group>"; };
-		526F21871D3B5C4900EF4E1F /* mpeg1dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpeg1dec.h; sourceTree = "<group>"; };
-		526F21881D3B5C4900EF4E1F /* mpg123.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpg123.h; sourceTree = "<group>"; };
-		526F21891D3B5C4900EF4E1F /* mpglib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpglib.h; sourceTree = "<group>"; };
-		526F218B1D3B5C4900EF4E1F /* config_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config_types.h; sourceTree = "<group>"; };
-		526F218C1D3B5C4900EF4E1F /* config_types.h.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = config_types.h.in; sourceTree = "<group>"; };
-		526F218D1D3B5C4900EF4E1F /* MAKEFILE.AM */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MAKEFILE.AM; sourceTree = "<group>"; };
-		526F218E1D3B5C4900EF4E1F /* MAKEFILE.IN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MAKEFILE.IN; sourceTree = "<group>"; };
-		526F218F1D3B5C4900EF4E1F /* OGG.H */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = OGG.H; sourceTree = "<group>"; };
-		526F21901D3B5C4900EF4E1F /* OS_TYPES.H */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = OS_TYPES.H; sourceTree = "<group>"; };
 		526F21921D3B5C4900EF4E1F /* codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codec.h; sourceTree = "<group>"; };
-		526F21931D3B5C4900EF4E1F /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		526F21941D3B5C4900EF4E1F /* Makefile.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.in; sourceTree = "<group>"; };
 		526F21951D3B5C4900EF4E1F /* theora.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = theora.h; sourceTree = "<group>"; };
 		526F21961D3B5C4900EF4E1F /* theoradec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = theoradec.h; sourceTree = "<group>"; };
 		526F21971D3B5C4900EF4E1F /* theoraenc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = theoraenc.h; sourceTree = "<group>"; };
 		526F21991D3B5C4900EF4E1F /* codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codec.h; sourceTree = "<group>"; };
-		526F219A1D3B5C4900EF4E1F /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		526F219B1D3B5C4900EF4E1F /* Makefile.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.in; sourceTree = "<group>"; };
 		526F219C1D3B5C4900EF4E1F /* vorbisenc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vorbisenc.h; sourceTree = "<group>"; };
 		526F219D1D3B5C4900EF4E1F /* vorbisfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vorbisfile.h; sourceTree = "<group>"; };
 		526F21A01D3B5C4900EF4E1F /* AAROT.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = AAROT.c; sourceTree = "<group>"; };
@@ -922,17 +1417,8 @@
 		526F21A21D3B5C4900EF4E1F /* aastr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aastr.h; sourceTree = "<group>"; };
 		526F21A31D3B5C4900EF4E1F /* aautil.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aautil.c; sourceTree = "<group>"; };
 		526F21A41D3B5C4900EF4E1F /* aautil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aautil.h; sourceTree = "<group>"; };
-		526F21A51D3B5C4900EF4E1F /* vssver2.scc */ = {isa = PBXFileReference; lastKnownFileType = file; path = vssver2.scc; sourceTree = "<group>"; };
-		526F22651D3B5C4900EF4E1F /* cc_error.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_error.cpp; sourceTree = "<group>"; };
-		526F22661D3B5C4900EF4E1F /* cc_error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_error.h; sourceTree = "<group>"; };
-		526F22671D3B5C4900EF4E1F /* cc_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_options.cpp; sourceTree = "<group>"; };
-		526F22681D3B5C4900EF4E1F /* cc_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_options.h; sourceTree = "<group>"; };
 		526F22691D3B5C4900EF4E1F /* cc_script.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_script.cpp; sourceTree = "<group>"; };
 		526F226A1D3B5C4900EF4E1F /* cc_script.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_script.h; sourceTree = "<group>"; };
-		526F226B1D3B5C4900EF4E1F /* cc_treemap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_treemap.cpp; sourceTree = "<group>"; };
-		526F226C1D3B5C4900EF4E1F /* cc_treemap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_treemap.h; sourceTree = "<group>"; };
-		526F226D1D3B5C4900EF4E1F /* script_common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = script_common.cpp; sourceTree = "<group>"; };
-		526F226E1D3B5C4900EF4E1F /* script_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_common.h; sourceTree = "<group>"; };
 		526F22701D3B5C4900EF4E1F /* alignedstream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = alignedstream.cpp; sourceTree = "<group>"; };
 		526F22711D3B5C4900EF4E1F /* alignedstream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alignedstream.h; sourceTree = "<group>"; };
 		526F22721D3B5C4900EF4E1F /* bbop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bbop.h; sourceTree = "<group>"; };
@@ -956,8 +1442,6 @@
 		526F22841D3B5C4900EF4E1F /* lzw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lzw.h; sourceTree = "<group>"; };
 		526F22851D3B5C4900EF4E1F /* math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math.h; sourceTree = "<group>"; };
 		526F22861D3B5C4900EF4E1F /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
-		526F22871D3B5C4900EF4E1F /* misc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = misc.cpp; sourceTree = "<group>"; };
-		526F22881D3B5C4900EF4E1F /* misc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = misc.h; sourceTree = "<group>"; };
 		526F22891D3B5C4900EF4E1F /* multifilelib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multifilelib.h; sourceTree = "<group>"; };
 		526F228A1D3B5C4900EF4E1F /* multifilelib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = multifilelib.cpp; sourceTree = "<group>"; };
 		526F228B1D3B5C4900EF4E1F /* path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = path.cpp; sourceTree = "<group>"; };
@@ -989,7 +1473,6 @@
 		526F241D1D3B5CC200EF4E1F /* cdaudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cdaudio.h; sourceTree = "<group>"; };
 		526F241E1D3B5CC200EF4E1F /* character.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = character.cpp; sourceTree = "<group>"; };
 		526F241F1D3B5CC200EF4E1F /* character.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = character.h; sourceTree = "<group>"; };
-		526F24201D3B5CC200EF4E1F /* charactercache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charactercache.h; sourceTree = "<group>"; };
 		526F24211D3B5CC200EF4E1F /* characterextras.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = characterextras.cpp; sourceTree = "<group>"; };
 		526F24221D3B5CC200EF4E1F /* characterextras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = characterextras.h; sourceTree = "<group>"; };
 		526F24241D3B5CC200EF4E1F /* datetime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = datetime.cpp; sourceTree = "<group>"; };
@@ -1121,8 +1604,6 @@
 		526F24A41D3B5CC200EF4E1F /* global_parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = global_parser.cpp; sourceTree = "<group>"; };
 		526F24A51D3B5CC200EF4E1F /* global_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = global_parser.h; sourceTree = "<group>"; };
 		526F24A61D3B5CC200EF4E1F /* global_plugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = global_plugin.h; sourceTree = "<group>"; };
-		526F24A71D3B5CC200EF4E1F /* global_record.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = global_record.cpp; sourceTree = "<group>"; };
-		526F24A81D3B5CC200EF4E1F /* global_record.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = global_record.h; sourceTree = "<group>"; };
 		526F24A91D3B5CC200EF4E1F /* global_region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = global_region.cpp; sourceTree = "<group>"; };
 		526F24AA1D3B5CC200EF4E1F /* global_region.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = global_region.h; sourceTree = "<group>"; };
 		526F24AB1D3B5CC200EF4E1F /* global_room.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = global_room.cpp; sourceTree = "<group>"; };
@@ -1162,7 +1643,6 @@
 		526F24CD1D3B5CC300EF4E1F /* inventoryitem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventoryitem.h; sourceTree = "<group>"; };
 		526F24CF1D3B5CC300EF4E1F /* invwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = invwindow.cpp; sourceTree = "<group>"; };
 		526F24D01D3B5CC300EF4E1F /* invwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = invwindow.h; sourceTree = "<group>"; };
-		526F24D11D3B5CC300EF4E1F /* keycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keycode.h; sourceTree = "<group>"; };
 		526F24D21D3B5CC300EF4E1F /* label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = label.cpp; sourceTree = "<group>"; };
 		526F24D31D3B5CC300EF4E1F /* label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = label.h; sourceTree = "<group>"; };
 		526F24D41D3B5CC300EF4E1F /* lipsync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lipsync.h; sourceTree = "<group>"; };
@@ -1176,24 +1656,16 @@
 		526F24DC1D3B5CC300EF4E1F /* movelist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = movelist.h; sourceTree = "<group>"; };
 		526F24DD1D3B5CC300EF4E1F /* object.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object.cpp; sourceTree = "<group>"; };
 		526F24DE1D3B5CC300EF4E1F /* object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = object.h; sourceTree = "<group>"; };
-		526F24DF1D3B5CC300EF4E1F /* objectcache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = objectcache.h; sourceTree = "<group>"; };
 		526F24E01D3B5CC300EF4E1F /* overlay.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = overlay.cpp; sourceTree = "<group>"; };
 		526F24E11D3B5CC300EF4E1F /* overlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = overlay.h; sourceTree = "<group>"; };
 		526F24E21D3B5CC300EF4E1F /* parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parser.cpp; sourceTree = "<group>"; };
 		526F24E31D3B5CC300EF4E1F /* parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parser.h; sourceTree = "<group>"; };
-		526F24E41D3B5CC300EF4E1F /* path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = path.cpp; sourceTree = "<group>"; };
-		526F24E51D3B5CC300EF4E1F /* path.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = path.h; sourceTree = "<group>"; };
 		526F24E61D3B5CC300EF4E1F /* properties.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = properties.cpp; sourceTree = "<group>"; };
 		526F24E71D3B5CC300EF4E1F /* properties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = properties.h; sourceTree = "<group>"; };
-		526F24E81D3B5CC300EF4E1F /* record.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = record.cpp; sourceTree = "<group>"; };
-		526F24E91D3B5CC300EF4E1F /* record.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = record.h; sourceTree = "<group>"; };
 		526F24EA1D3B5CC300EF4E1F /* region.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = region.cpp; sourceTree = "<group>"; };
 		526F24EB1D3B5CC300EF4E1F /* region.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = region.h; sourceTree = "<group>"; };
-		526F24EC1D3B5CC300EF4E1F /* richgamemedia.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = richgamemedia.cpp; sourceTree = "<group>"; };
-		526F24ED1D3B5CC300EF4E1F /* richgamemedia.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = richgamemedia.h; sourceTree = "<group>"; };
 		526F24EE1D3B5CC300EF4E1F /* room.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = room.cpp; sourceTree = "<group>"; };
 		526F24EF1D3B5CC300EF4E1F /* room.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = room.h; sourceTree = "<group>"; };
-		526F24F01D3B5CC300EF4E1F /* room_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = room_engine.cpp; sourceTree = "<group>"; };
 		526F24F11D3B5CC300EF4E1F /* roomobject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = roomobject.cpp; sourceTree = "<group>"; };
 		526F24F21D3B5CC300EF4E1F /* roomobject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = roomobject.h; sourceTree = "<group>"; };
 		526F24F31D3B5CC300EF4E1F /* roomstatus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = roomstatus.cpp; sourceTree = "<group>"; };
@@ -1228,12 +1700,8 @@
 		526F25121D3B5CC300EF4E1F /* topbarsettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = topbarsettings.h; sourceTree = "<group>"; };
 		526F25131D3B5CC300EF4E1F /* translation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = translation.cpp; sourceTree = "<group>"; };
 		526F25141D3B5CC300EF4E1F /* translation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = translation.h; sourceTree = "<group>"; };
-		526F25151D3B5CC300EF4E1F /* tree_map.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tree_map.cpp; sourceTree = "<group>"; };
-		526F25161D3B5CC300EF4E1F /* tree_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree_map.h; sourceTree = "<group>"; };
 		526F25171D3B5CC300EF4E1F /* viewframe.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewframe.cpp; sourceTree = "<group>"; };
 		526F25181D3B5CC300EF4E1F /* viewframe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewframe.h; sourceTree = "<group>"; };
-		526F25191D3B5CC300EF4E1F /* viewport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewport.cpp; sourceTree = "<group>"; };
-		526F251A1D3B5CC300EF4E1F /* viewport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewport.h; sourceTree = "<group>"; };
 		526F251B1D3B5CC300EF4E1F /* walkablearea.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = walkablearea.cpp; sourceTree = "<group>"; };
 		526F251C1D3B5CC300EF4E1F /* walkablearea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = walkablearea.h; sourceTree = "<group>"; };
 		526F251D1D3B5CC300EF4E1F /* walkbehind.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = walkbehind.cpp; sourceTree = "<group>"; };
@@ -1272,19 +1740,14 @@
 		526F25421D3B5CC300EF4E1F /* gfxfilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter.h; sourceTree = "<group>"; };
 		526F25431D3B5CC300EF4E1F /* gfxfilter_aad3d.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_aad3d.cpp; sourceTree = "<group>"; };
 		526F25441D3B5CC300EF4E1F /* gfxfilter_aad3d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_aad3d.h; sourceTree = "<group>"; };
-		526F25451D3B5CC300EF4E1F /* gfxfilter_allegro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_allegro.cpp; sourceTree = "<group>"; };
-		526F25461D3B5CC300EF4E1F /* gfxfilter_allegro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_allegro.h; sourceTree = "<group>"; };
 		526F25471D3B5CC300EF4E1F /* gfxfilter_d3d.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_d3d.cpp; sourceTree = "<group>"; };
 		526F25481D3B5CC300EF4E1F /* gfxfilter_d3d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_d3d.h; sourceTree = "<group>"; };
-		526F25491D3B5CC300EF4E1F /* gfxfilter_hqx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_hqx.cpp; sourceTree = "<group>"; };
-		526F254A1D3B5CC300EF4E1F /* gfxfilter_hqx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_hqx.h; sourceTree = "<group>"; };
 		526F254B1D3B5CC300EF4E1F /* gfxfilter_ogl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_ogl.cpp; sourceTree = "<group>"; };
 		526F254C1D3B5CC300EF4E1F /* gfxfilter_ogl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_ogl.h; sourceTree = "<group>"; };
 		526F254D1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gfxfilter_scaling.cpp; sourceTree = "<group>"; };
 		526F254E1D3B5CC300EF4E1F /* gfxfilter_scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxfilter_scaling.h; sourceTree = "<group>"; };
 		526F254F1D3B5CC300EF4E1F /* gfxmodelist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gfxmodelist.h; sourceTree = "<group>"; };
 		526F25501D3B5CC300EF4E1F /* graphicsdriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graphicsdriver.h; sourceTree = "<group>"; };
-		526F25511D3B5CC300EF4E1F /* hq2x3x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hq2x3x.h; sourceTree = "<group>"; };
 		526F25531D3B5CC300EF4E1F /* animatingguibutton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = animatingguibutton.cpp; sourceTree = "<group>"; };
 		526F25541D3B5CC300EF4E1F /* animatingguibutton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = animatingguibutton.h; sourceTree = "<group>"; };
 		526F25551D3B5CC300EF4E1F /* cscidialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cscidialog.cpp; sourceTree = "<group>"; };
@@ -1305,33 +1768,7 @@
 		526F25641D3B5CC300EF4E1F /* mytextbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mytextbox.h; sourceTree = "<group>"; };
 		526F25651D3B5CC300EF4E1F /* newcontrol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = newcontrol.cpp; sourceTree = "<group>"; };
 		526F25661D3B5CC300EF4E1F /* newcontrol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = newcontrol.h; sourceTree = "<group>"; };
-		526F25691D3B5CC300EF4E1F /* alfont.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alfont.c; sourceTree = "<group>"; };
-		526F256A1D3B5CC300EF4E1F /* ALFONT.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ALFONT.txt; sourceTree = "<group>"; };
-		526F256B1D3B5CC300EF4E1F /* AUTHORS.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AUTHORS.txt; sourceTree = "<group>"; };
-		526F256C1D3B5CC300EF4E1F /* FTL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FTL.txt; sourceTree = "<group>"; };
-		526F256D1D3B5CC300EF4E1F /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
-		526F257A1D3B5CC300EF4E1F /* almp3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = almp3.c; sourceTree = "<group>"; };
-		526F257D1D3B5CC300EF4E1F /* common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common.c; sourceTree = "<group>"; };
-		526F257E1D3B5CC300EF4E1F /* dct64_i386.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dct64_i386.c; sourceTree = "<group>"; };
-		526F257F1D3B5CC300EF4E1F /* decode_i386.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_i386.c; sourceTree = "<group>"; };
-		526F25801D3B5CC300EF4E1F /* huffman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman.h; sourceTree = "<group>"; };
-		526F25811D3B5CC300EF4E1F /* interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = interface.c; sourceTree = "<group>"; };
-		526F25821D3B5CC300EF4E1F /* l2tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = l2tables.h; sourceTree = "<group>"; };
-		526F25831D3B5CC300EF4E1F /* layer2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = layer2.c; sourceTree = "<group>"; };
-		526F25841D3B5CC300EF4E1F /* layer3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = layer3.c; sourceTree = "<group>"; };
-		526F25851D3B5CC300EF4E1F /* mpg123.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpg123.h; sourceTree = "<group>"; };
-		526F25861D3B5CC300EF4E1F /* mpglib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpglib.h; sourceTree = "<group>"; };
-		526F25871D3B5CC300EF4E1F /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
-		526F25881D3B5CC300EF4E1F /* tabinit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tabinit.c; sourceTree = "<group>"; };
-		526F25891D3B5CC300EF4E1F /* vssver2.scc */ = {isa = PBXFileReference; lastKnownFileType = file; path = vssver2.scc; sourceTree = "<group>"; };
-		526F258B1D3B5CC300EF4E1F /* alogg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alogg.c; sourceTree = "<group>"; };
-		526F258C1D3B5CC300EF4E1F /* ALOGG.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ALOGG.txt; sourceTree = "<group>"; };
-		526F258D1D3B5CC300EF4E1F /* AUTHORS.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AUTHORS.txt; sourceTree = "<group>"; };
-		526F258E1D3B5CC300EF4E1F /* CHANGES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGES.txt; sourceTree = "<group>"; };
-		526F258F1D3B5CC300EF4E1F /* COPYING.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = COPYING.txt; sourceTree = "<group>"; };
-		526F25901D3B5CC300EF4E1F /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
 		526F25921D3B5CC300EF4E1F /* adisplay.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = adisplay.c; sourceTree = "<group>"; };
-		526F25931D3B5CC300EF4E1F /* apeg.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = apeg.txt; sourceTree = "<group>"; };
 		526F25951D3B5CC300EF4E1F /* aaudio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aaudio.c; sourceTree = "<group>"; };
 		526F25961D3B5CC300EF4E1F /* apegcommon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = apegcommon.c; sourceTree = "<group>"; };
 		526F25971D3B5CC300EF4E1F /* dct64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dct64.c; sourceTree = "<group>"; };
@@ -1345,7 +1782,6 @@
 		526F259F1D3B5CC300EF4E1F /* readers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = readers.c; sourceTree = "<group>"; };
 		526F25A01D3B5CC300EF4E1F /* tabinit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tabinit.c; sourceTree = "<group>"; };
 		526F25A11D3B5CC300EF4E1F /* vbrhead.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vbrhead.c; sourceTree = "<group>"; };
-		526F25A21D3B5CC300EF4E1F /* vssver2.scc */ = {isa = PBXFileReference; lastKnownFileType = file; path = vssver2.scc; sourceTree = "<group>"; };
 		526F25A31D3B5CC300EF4E1F /* getbits.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = getbits.c; sourceTree = "<group>"; };
 		526F25A41D3B5CC300EF4E1F /* getblk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = getblk.c; sourceTree = "<group>"; };
 		526F25A51D3B5CC300EF4E1F /* gethdr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gethdr.c; sourceTree = "<group>"; };
@@ -1355,9 +1791,6 @@
 		526F25A91D3B5CC300EF4E1F /* mpeg1dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mpeg1dec.c; sourceTree = "<group>"; };
 		526F25AA1D3B5CC300EF4E1F /* ogg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ogg.c; sourceTree = "<group>"; };
 		526F25AB1D3B5CC300EF4E1F /* recon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = recon.c; sourceTree = "<group>"; };
-		526F25AC1D3B5CC300EF4E1F /* vssver2.scc */ = {isa = PBXFileReference; lastKnownFileType = file; path = vssver2.scc; sourceTree = "<group>"; };
-		526F25DF1D3B5CC300EF4E1F /* hq2x3x.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hq2x3x.cpp; sourceTree = "<group>"; };
-		526F25E01D3B5CC300EF4E1F /* vssver2.scc */ = {isa = PBXFileReference; lastKnownFileType = file; path = vssver2.scc; sourceTree = "<group>"; };
 		526F25F11D3B5CC300EF4E1F /* config.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = config.cpp; sourceTree = "<group>"; };
 		526F25F21D3B5CC300EF4E1F /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		526F25F31D3B5CC300EF4E1F /* engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = engine.cpp; sourceTree = "<group>"; };
@@ -1374,10 +1807,6 @@
 		526F25FE1D3B5CC300EF4E1F /* graphics_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = graphics_mode.h; sourceTree = "<group>"; };
 		526F25FF1D3B5CC300EF4E1F /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		526F26001D3B5CC300EF4E1F /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
-		526F26011D3B5CC300EF4E1F /* main_allegro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main_allegro.h; sourceTree = "<group>"; };
-		526F26021D3B5CC300EF4E1F /* maindefines_ex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = maindefines_ex.h; sourceTree = "<group>"; };
-		526F26031D3B5CC300EF4E1F /* mainheader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mainheader.h; sourceTree = "<group>"; };
-		526F26041D3B5CC300EF4E1F /* minidump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = minidump.cpp; sourceTree = "<group>"; };
 		526F26051D3B5CC300EF4E1F /* quit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = quit.cpp; sourceTree = "<group>"; };
 		526F26061D3B5CC300EF4E1F /* quit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quit.h; sourceTree = "<group>"; };
 		526F26071D3B5CC300EF4E1F /* update.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = update.cpp; sourceTree = "<group>"; };
@@ -1387,48 +1816,25 @@
 		526F260F1D3B5CC300EF4E1F /* audio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio.cpp; sourceTree = "<group>"; };
 		526F26101D3B5CC300EF4E1F /* audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio.h; sourceTree = "<group>"; };
 		526F26111D3B5CC300EF4E1F /* audiodefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audiodefines.h; sourceTree = "<group>"; };
-		526F26131D3B5CC300EF4E1F /* clip_mydumbmod.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mydumbmod.cpp; sourceTree = "<group>"; };
-		526F26141D3B5CC300EF4E1F /* clip_mydumbmod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mydumbmod.h; sourceTree = "<group>"; };
-		526F26151D3B5CC300EF4E1F /* clip_myjgmod.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_myjgmod.cpp; sourceTree = "<group>"; };
-		526F26161D3B5CC300EF4E1F /* clip_myjgmod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_myjgmod.h; sourceTree = "<group>"; };
-		526F26171D3B5CC300EF4E1F /* clip_mymidi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mymidi.cpp; sourceTree = "<group>"; };
-		526F26181D3B5CC300EF4E1F /* clip_mymidi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mymidi.h; sourceTree = "<group>"; };
-		526F26191D3B5CC300EF4E1F /* clip_mymp3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mymp3.cpp; sourceTree = "<group>"; };
-		526F261A1D3B5CC300EF4E1F /* clip_mymp3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mymp3.h; sourceTree = "<group>"; };
-		526F261B1D3B5CC300EF4E1F /* clip_myogg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_myogg.cpp; sourceTree = "<group>"; };
-		526F261C1D3B5CC300EF4E1F /* clip_myogg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_myogg.h; sourceTree = "<group>"; };
-		526F261D1D3B5CC300EF4E1F /* clip_mystaticmp3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mystaticmp3.cpp; sourceTree = "<group>"; };
-		526F261E1D3B5CC300EF4E1F /* clip_mystaticmp3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mystaticmp3.h; sourceTree = "<group>"; };
-		526F261F1D3B5CC300EF4E1F /* clip_mystaticogg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mystaticogg.cpp; sourceTree = "<group>"; };
-		526F26201D3B5CC300EF4E1F /* clip_mystaticogg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mystaticogg.h; sourceTree = "<group>"; };
-		526F26211D3B5CC300EF4E1F /* clip_mywave.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clip_mywave.cpp; sourceTree = "<group>"; };
-		526F26221D3B5CC300EF4E1F /* clip_mywave.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clip_mywave.h; sourceTree = "<group>"; };
 		526F26231D3B5CC300EF4E1F /* queuedaudioitem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = queuedaudioitem.cpp; sourceTree = "<group>"; };
 		526F26241D3B5CC300EF4E1F /* queuedaudioitem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = queuedaudioitem.h; sourceTree = "<group>"; };
 		526F26251D3B5CC300EF4E1F /* sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sound.cpp; sourceTree = "<group>"; };
 		526F26261D3B5CC300EF4E1F /* sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sound.h; sourceTree = "<group>"; };
-		526F26271D3B5CC300EF4E1F /* soundcache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = soundcache.cpp; sourceTree = "<group>"; };
-		526F26281D3B5CC300EF4E1F /* soundcache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundcache.h; sourceTree = "<group>"; };
 		526F26291D3B5CC300EF4E1F /* soundclip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = soundclip.cpp; sourceTree = "<group>"; };
 		526F262A1D3B5CC300EF4E1F /* soundclip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundclip.h; sourceTree = "<group>"; };
 		526F262C1D3B5CC300EF4E1F /* video.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video.cpp; sourceTree = "<group>"; };
 		526F262D1D3B5CC300EF4E1F /* video.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video.h; sourceTree = "<group>"; };
-		526F262E1D3B5CC300EF4E1F /* VMR9Graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMR9Graph.h; sourceTree = "<group>"; };
 		526F26331D3B5CC300EF4E1F /* agsplatformdriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agsplatformdriver.cpp; sourceTree = "<group>"; };
 		526F26341D3B5CC300EF4E1F /* agsplatformdriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsplatformdriver.h; sourceTree = "<group>"; };
-		526F26351D3B5CC300EF4E1F /* override_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = override_defines.h; sourceTree = "<group>"; };
 		526F26411D3B5CC300EF4E1F /* acplmac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = acplmac.cpp; sourceTree = "<group>"; };
 		526F26421D3B5CC300EF4E1F /* alplmac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = alplmac.mm; sourceTree = "<group>"; };
 		526F26461D3B5CC300EF4E1F /* libc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = libc.c; sourceTree = "<group>"; };
-		526F26471D3B5CC300EF4E1F /* pe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pe.c; sourceTree = "<group>"; };
-		526F26481D3B5CC300EF4E1F /* pe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pe.h; sourceTree = "<group>"; };
 		526F26591D3B5CC300EF4E1F /* agsplugin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agsplugin.cpp; sourceTree = "<group>"; };
 		526F265A1D3B5CC300EF4E1F /* agsplugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agsplugin.h; sourceTree = "<group>"; };
 		526F265B1D3B5CC300EF4E1F /* global_plugin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = global_plugin.cpp; sourceTree = "<group>"; };
 		526F265C1D3B5CC300EF4E1F /* pluginobjectreader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pluginobjectreader.cpp; sourceTree = "<group>"; };
 		526F265D1D3B5CC300EF4E1F /* pluginobjectreader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pluginobjectreader.h; sourceTree = "<group>"; };
 		526F265F1D3B5CC300EF4E1F /* CompileShader.bat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CompileShader.bat; sourceTree = "<group>"; };
-		526F26601D3B5CC300EF4E1F /* DefaultGDF.gdf.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = DefaultGDF.gdf.xml; sourceTree = "<group>"; };
 		526F26611D3B5CC300EF4E1F /* game-1.ICO */ = {isa = PBXFileReference; lastKnownFileType = image.ico; path = "game-1.ICO"; sourceTree = "<group>"; };
 		526F26621D3B5CC300EF4E1F /* resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource.h; sourceTree = "<group>"; };
 		526F26631D3B5CC300EF4E1F /* tintshader.fx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tintshader.fx; sourceTree = "<group>"; };
@@ -1436,7 +1842,6 @@
 		526F26651D3B5CC300EF4E1F /* tintshaderLegacy.fx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tintshaderLegacy.fx; sourceTree = "<group>"; };
 		526F26661D3B5CC300EF4E1F /* tintshaderLegacy.fxo */ = {isa = PBXFileReference; lastKnownFileType = file; path = tintshaderLegacy.fxo; sourceTree = "<group>"; };
 		526F26671D3B5CC300EF4E1F /* version.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = version.rc; sourceTree = "<group>"; };
-		526F26691D3B5CC300EF4E1F /* cc_error_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_error_engine.cpp; sourceTree = "<group>"; };
 		526F266A1D3B5CC300EF4E1F /* cc_instance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cc_instance.cpp; sourceTree = "<group>"; };
 		526F266B1D3B5CC300EF4E1F /* cc_instance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cc_instance.h; sourceTree = "<group>"; };
 		526F266C1D3B5CC300EF4E1F /* executingscript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = executingscript.cpp; sourceTree = "<group>"; };
@@ -1450,41 +1855,15 @@
 		526F26741D3B5CC300EF4E1F /* script.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script.h; sourceTree = "<group>"; };
 		526F26751D3B5CC300EF4E1F /* script_api.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = script_api.cpp; sourceTree = "<group>"; };
 		526F26761D3B5CC300EF4E1F /* script_api.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_api.h; sourceTree = "<group>"; };
-		526F26771D3B5CC300EF4E1F /* script_engine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = script_engine.cpp; sourceTree = "<group>"; };
 		526F26781D3B5CC300EF4E1F /* script_runtime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = script_runtime.cpp; sourceTree = "<group>"; };
 		526F26791D3B5CC300EF4E1F /* script_runtime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = script_runtime.h; sourceTree = "<group>"; };
 		526F267A1D3B5CC300EF4E1F /* systemimports.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = systemimports.cpp; sourceTree = "<group>"; };
 		526F267B1D3B5CC300EF4E1F /* systemimports.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = systemimports.h; sourceTree = "<group>"; };
-		526F267D1D3B5CC300EF4E1F /* test_all.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_all.cpp; sourceTree = "<group>"; };
-		526F267E1D3B5CC300EF4E1F /* test_all.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_all.h; sourceTree = "<group>"; };
-		526F267F1D3B5CC300EF4E1F /* test_file.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_file.cpp; sourceTree = "<group>"; };
-		526F26801D3B5CC300EF4E1F /* test_gfx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_gfx.cpp; sourceTree = "<group>"; };
-		526F26811D3B5CC300EF4E1F /* test_inifile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_inifile.cpp; sourceTree = "<group>"; };
-		526F26821D3B5CC300EF4E1F /* test_math.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_math.cpp; sourceTree = "<group>"; };
-		526F26831D3B5CC300EF4E1F /* test_memory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_memory.cpp; sourceTree = "<group>"; };
-		526F26841D3B5CC300EF4E1F /* test_sprintf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_sprintf.cpp; sourceTree = "<group>"; };
-		526F26851D3B5CC300EF4E1F /* test_string.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_string.cpp; sourceTree = "<group>"; };
-		526F26861D3B5CC300EF4E1F /* test_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_version.cpp; sourceTree = "<group>"; };
 		526F26881D3B5CC300EF4E1F /* library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library.h; sourceTree = "<group>"; };
 		526F26891D3B5CC300EF4E1F /* library_dummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library_dummy.h; sourceTree = "<group>"; };
 		526F268A1D3B5CC300EF4E1F /* library_posix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library_posix.h; sourceTree = "<group>"; };
 		526F268B1D3B5CC300EF4E1F /* library_psp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library_psp.h; sourceTree = "<group>"; };
 		526F268C1D3B5CC300EF4E1F /* library_windows.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = library_windows.h; sourceTree = "<group>"; };
-		526F268D1D3B5CC300EF4E1F /* mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex.h; sourceTree = "<group>"; };
-		526F268E1D3B5CC300EF4E1F /* mutex_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_base.h; sourceTree = "<group>"; };
-		526F268F1D3B5CC300EF4E1F /* mutex_lock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_lock.h; sourceTree = "<group>"; };
-		526F26901D3B5CC300EF4E1F /* mutex_psp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_psp.h; sourceTree = "<group>"; };
-		526F26911D3B5CC300EF4E1F /* mutex_pthread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_pthread.h; sourceTree = "<group>"; };
-		526F26921D3B5CC300EF4E1F /* mutex_wii.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_wii.h; sourceTree = "<group>"; };
-		526F26931D3B5CC300EF4E1F /* mutex_windows.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_windows.h; sourceTree = "<group>"; };
-		526F26941D3B5CC300EF4E1F /* scaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scaling.h; sourceTree = "<group>"; };
-		526F26951D3B5CC300EF4E1F /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
-		526F26961D3B5CC300EF4E1F /* thread_psp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_psp.h; sourceTree = "<group>"; };
-		526F26971D3B5CC300EF4E1F /* thread_pthread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_pthread.h; sourceTree = "<group>"; };
-		526F26981D3B5CC300EF4E1F /* thread_wii.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_wii.h; sourceTree = "<group>"; };
-		526F26991D3B5CC300EF4E1F /* thread_windows.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_windows.h; sourceTree = "<group>"; };
-		52A7D3251D1E641F00D88BEE /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = ../../../../../../../../usr/lib/libz.1.dylib; sourceTree = "<group>"; };
-		52A7D3271D1E643800D88BEE /* libbz2.1.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.dylib; path = ../../../../../../../../usr/lib/libbz2.1.0.dylib; sourceTree = "<group>"; };
 		52D12C1C1D61C0950077B784 /* savegame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = savegame.cpp; sourceTree = "<group>"; };
 		52D12C1D1D61C0950077B784 /* savegame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = savegame.h; sourceTree = "<group>"; };
 		52D12C1E1D61C0950077B784 /* savegame_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = savegame_internal.h; sourceTree = "<group>"; };
@@ -1499,11 +1878,6 @@
 		52F5D8601DA1219D006F8F4B /* inventoryiteminfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inventoryiteminfo.cpp; sourceTree = "<group>"; };
 		52F5D8621DA121CC006F8F4B /* version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = version.cpp; sourceTree = "<group>"; };
 		52F5D8631DA121CC006F8F4B /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
-		A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteFontRendererClifftopGames.h; sourceTree = "<group>"; };
-		A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VariableWidthSpriteFontClifftopGames.h; sourceTree = "<group>"; };
-		A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AGSSpriteFont.h; sourceTree = "<group>"; };
-		A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpriteFontRendererClifftopGames.cpp; sourceTree = "<group>"; };
-		A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VariableWidthSpriteFontClifftopGames.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1511,31 +1885,536 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20E6856D28F25E3B00B95C00 /* libz.1.tbd in Frameworks */,
+				20E6856B28F25E2400B95C00 /* libbz2.1.0.tbd in Frameworks */,
+				521C569B1D1E5ADA00BD619E /* CoreAudio.framework in Frameworks */,
+				521C569F1D1E5AE900BD619E /* AudioToolbox.framework in Frameworks */,
 				521C56911D1E5AAC00BD619E /* Cocoa.framework in Frameworks */,
 				521C56931D1E5AB100BD619E /* AppKit.framework in Frameworks */,
 				521C56951D1E5AB800BD619E /* OpenGL.framework in Frameworks */,
 				521C56971D1E5ABD00BD619E /* CoreVideo.framework in Frameworks */,
-				521C569B1D1E5ADA00BD619E /* CoreAudio.framework in Frameworks */,
-				521C569F1D1E5AE900BD619E /* AudioToolbox.framework in Frameworks */,
 				521C569D1D1E5AE300BD619E /* AudioUnit.framework in Frameworks */,
 				521C56991D1E5AC800BD619E /* IOKit.framework in Frameworks */,
-				52A7D3291D1E644700D88BEE /* libz.1.dylib in Frameworks */,
-				52A7D32A1D1E645200D88BEE /* libbz2.1.0.dylib in Frameworks */,
-				521C56AC1D1E5B5F00BD619E /* libfreetype.a in Frameworks */,
-				521C56AD1D1E5B5F00BD619E /* liblua.a in Frameworks */,
-				521C56AE1D1E5B5F00BD619E /* libogg.a in Frameworks */,
-				521C56B01D1E5B5F00BD619E /* libvorbis.a in Frameworks */,
-				521C56B11D1E5B5F00BD619E /* libvorbisfile.a in Frameworks */,
-				521C56AF1D1E5B5F00BD619E /* libtheoradec.a in Frameworks */,
-				521C56AA1D1E5B5F00BD619E /* liballeg.a in Frameworks */,
-				521C56AB1D1E5B5F00BD619E /* libdumb.a in Frameworks */,
-				521C56A91D1E5B5F00BD619E /* libaldmb.a in Frameworks */,
+				20E6810B28F1C7D000B95C00 /* SDL2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		205229B928E8ECB800589E91 /* alfont-2.0.9 */ = {
+			isa = PBXGroup;
+			children = (
+				205229BB28E8ECE200589E91 /* alfont.c */,
+				205229BC28E8ECE200589E91 /* alfont.h */,
+			);
+			name = "alfont-2.0.9";
+			sourceTree = "<group>";
+		};
+		205229BA28E8ECC700589E91 /* freetype-2.1.3 */ = {
+			isa = PBXGroup;
+			children = (
+				205229FF28E8F54E00589E91 /* winfnt.c */,
+				205229FD28E8F53E00589E91 /* type42.c */,
+				205229FB28E8F53000589E91 /* type1.c */,
+				205229F928E8F51A00589E91 /* truetype.c */,
+				205229F728E8F2E200589E91 /* smooth.c */,
+				205229F528E8F2CF00589E91 /* sfnt.c */,
+				205229F328E8F2B700589E91 /* raster.c */,
+				205229EF28E8F27800589E91 /* pshinter.c */,
+				205229F128E8F29900589E91 /* psmodule.c */,
+				205229ED28E8F25A00589E91 /* psaux.c */,
+				205229E928E8F23000589E91 /* pfr.c */,
+				205229E728E8EEEA00589E91 /* pcf.c */,
+				205229E528E8EED300589E91 /* ftgzip.c */,
+				205229E328E8EEAF00589E91 /* type1cid.c */,
+				205229E128E8EE9B00589E91 /* cff.c */,
+				205229DF28E8EE7F00589E91 /* ftcache.c */,
+				205229DD28E8EE6700589E91 /* bdf.c */,
+				205229DB28E8EE5300589E91 /* autohint.c */,
+				205229D828E8EDFA00589E91 /* unix */,
+				205229CD28E8EDE100589E91 /* base */,
+				205229C128E8ED4400589E91 /* include */,
+			);
+			name = "freetype-2.1.3";
+			sourceTree = "<group>";
+		};
+		205229CD28E8EDE100589E91 /* base */ = {
+			isa = PBXGroup;
+			children = (
+				205229C428E8EDD600589E91 /* ftbase.c */,
+				205229C328E8EDD600589E91 /* ftbdf.c */,
+				205229C528E8EDD600589E91 /* ftdebug.c */,
+				205229CB28E8EDD700589E91 /* ftmm.c */,
+				205229C928E8EDD700589E91 /* ftpfr.c */,
+				205229CA28E8EDD700589E91 /* fttype1.c */,
+				205229CC28E8EDD700589E91 /* ftxf86.c */,
+				205229C828E8EDD600589E91 /* ftbbox.c */,
+				205229C628E8EDD600589E91 /* ftglyph.c */,
+				205229C728E8EDD600589E91 /* ftinit.c */,
+			);
+			name = base;
+			sourceTree = "<group>";
+		};
+		205229D828E8EDFA00589E91 /* unix */ = {
+			isa = PBXGroup;
+			children = (
+				205229D928E8EE3000589E91 /* ftsystem.c */,
+			);
+			name = unix;
+			sourceTree = "<group>";
+		};
+		20522A7828E8F98400589E91 /* glad */ = {
+			isa = PBXGroup;
+			children = (
+				20522A7A28E8F98400589E91 /* include */,
+				20522A7F28E8F98400589E91 /* src */,
+			);
+			path = glad;
+			sourceTree = "<group>";
+		};
+		20522A7A28E8F98400589E91 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				20522A7B28E8F98400589E91 /* KHR */,
+				20522A7D28E8F98400589E91 /* glad */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		20522A7B28E8F98400589E91 /* KHR */ = {
+			isa = PBXGroup;
+			children = (
+				20522A7C28E8F98400589E91 /* khrplatform.h */,
+			);
+			path = KHR;
+			sourceTree = "<group>";
+		};
+		20522A7D28E8F98400589E91 /* glad */ = {
+			isa = PBXGroup;
+			children = (
+				20522A7E28E8F98400589E91 /* glad.h */,
+			);
+			path = glad;
+			sourceTree = "<group>";
+		};
+		20522A7F28E8F98400589E91 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				20522A8028E8F98400589E91 /* glad.c */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		20E67D0428F1BD6400B95C00 /* libsrc */ = {
+			isa = PBXGroup;
+			children = (
+				20E6828B28F20A8800B95C00 /* vorbis */,
+				20E6828A28F20A8200B95C00 /* ogg */,
+				20E6828928F20A7C00B95C00 /* theora */,
+				20E6811E28F1D24F00B95C00 /* SDL_sound */,
+				20E67D0828F1BD9A00B95C00 /* mojoAL */,
+				20E67D0628F1BD8700B95C00 /* allegro */,
+			);
+			name = libsrc;
+			sourceTree = "<group>";
+		};
+		20E67D0628F1BD8700B95C00 /* allegro */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D4328F1BDE000B95C00 /* include */,
+				20E67D0928F1BDDF00B95C00 /* src */,
+			);
+			name = allegro;
+			sourceTree = "<group>";
+		};
+		20E67D0828F1BD9A00B95C00 /* mojoAL */ = {
+			isa = PBXGroup;
+			children = (
+				20E6810128F1BE5C00B95C00 /* AL */,
+				20E6810428F1BE5D00B95C00 /* mojoal.c */,
+			);
+			name = mojoAL;
+			sourceTree = "<group>";
+		};
+		20E67D0928F1BDDF00B95C00 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D0A28F1BDDF00B95C00 /* gfx.c */,
+				20E67D0B28F1BDDF00B95C00 /* unicode.c */,
+				20E67D0C28F1BDDF00B95C00 /* blit.c */,
+				20E67D0D28F1BDDF00B95C00 /* math.c */,
+				20E67D0E28F1BDDF00B95C00 /* pcx.c */,
+				20E67D0F28F1BDDF00B95C00 /* fli.c */,
+				20E67D1028F1BDDF00B95C00 /* rotate.c */,
+				20E67D1128F1BDDF00B95C00 /* flood.c */,
+				20E67D1228F1BDDF00B95C00 /* vtable32.c */,
+				20E67D1628F1BDDF00B95C00 /* graphics.c */,
+				20E67D1728F1BDDF00B95C00 /* vtable.c */,
+				20E67D1828F1BDDF00B95C00 /* libc.c */,
+				20E67D1928F1BDDF00B95C00 /* polygon.c */,
+				20E67D1A28F1BDDF00B95C00 /* vtable16.c */,
+				20E67D1B28F1BDDF00B95C00 /* unix */,
+				20E67D1D28F1BDDF00B95C00 /* quantize.c */,
+				20E67D1E28F1BDDF00B95C00 /* colblend.c */,
+				20E67D1F28F1BDDF00B95C00 /* dither.c */,
+				20E67D2028F1BDDF00B95C00 /* dataregi.c */,
+				20E67D2128F1BDDF00B95C00 /* allegro.c */,
+				20E67D2228F1BDDF00B95C00 /* vtable15.c */,
+				20E67D2328F1BDDF00B95C00 /* readbmp.c */,
+				20E67D2428F1BDDF00B95C00 /* file.c */,
+				20E67D2528F1BDDF00B95C00 /* bmp.c */,
+				20E67D2628F1BDDF00B95C00 /* vtable8.c */,
+				20E67D2728F1BDDF00B95C00 /* c */,
+				20E67D4028F1BDDF00B95C00 /* vtable24.c */,
+				20E67D4128F1BDDF00B95C00 /* inline.c */,
+				20E67D4228F1BDDF00B95C00 /* color.c */,
+			);
+			name = src;
+			path = ../../../../libsrc/allegro/src;
+			sourceTree = "<group>";
+		};
+		20E67D1B28F1BDDF00B95C00 /* unix */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D1C28F1BDDF00B95C00 /* ufile.c */,
+			);
+			path = unix;
+			sourceTree = "<group>";
+		};
+		20E67D2728F1BDDF00B95C00 /* c */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D2828F1BDDF00B95C00 /* cblit.h */,
+				20E67D2928F1BDDF00B95C00 /* cspr8.c */,
+				20E67D2A28F1BDDF00B95C00 /* cspr16.c */,
+				20E67D2B28F1BDDF00B95C00 /* cblit16.c */,
+				20E67D2C28F1BDDF00B95C00 /* cspr24.c */,
+				20E67D2D28F1BDDF00B95C00 /* cgfx8.c */,
+				20E67D2E28F1BDDF00B95C00 /* cblit24.c */,
+				20E67D2F28F1BDDF00B95C00 /* cdefs32.h */,
+				20E67D3028F1BDDF00B95C00 /* cspr15.c */,
+				20E67D3128F1BDDF00B95C00 /* cmisc.c */,
+				20E67D3228F1BDDF00B95C00 /* cgfx32.c */,
+				20E67D3328F1BDDF00B95C00 /* cgfx.h */,
+				20E67D3428F1BDDF00B95C00 /* cdefs16.h */,
+				20E67D3528F1BDDF00B95C00 /* cgfx16.c */,
+				20E67D3628F1BDDF00B95C00 /* cstretch.c */,
+				20E67D3728F1BDDF00B95C00 /* cdefs24.h */,
+				20E67D3828F1BDDF00B95C00 /* cgfx24.c */,
+				20E67D3928F1BDDF00B95C00 /* cspr.h */,
+				20E67D3A28F1BDDF00B95C00 /* cspr32.c */,
+				20E67D3B28F1BDDF00B95C00 /* cblit8.c */,
+				20E67D3C28F1BDDF00B95C00 /* cdefs15.h */,
+				20E67D3D28F1BDDF00B95C00 /* cdefs8.h */,
+				20E67D3E28F1BDDF00B95C00 /* cblit32.c */,
+				20E67D3F28F1BDDF00B95C00 /* cgfx15.c */,
+			);
+			path = c;
+			sourceTree = "<group>";
+		};
+		20E67D4328F1BDE000B95C00 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D4528F1BDE000B95C00 /* allegro.h */,
+				20E67D4628F1BDE000B95C00 /* allegro */,
+			);
+			name = include;
+			path = ../../../../libsrc/allegro/include;
+			sourceTree = "<group>";
+		};
+		20E67D4628F1BDE000B95C00 /* allegro */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D4728F1BDE000B95C00 /* datafile.h */,
+				20E67D4828F1BDE000B95C00 /* debug.h */,
+				20E67D4928F1BDE000B95C00 /* fixed.h */,
+				20E67D4A28F1BDE000B95C00 /* file.h */,
+				20E67D4B28F1BDE000B95C00 /* platform */,
+				20E67D5228F1BDE000B95C00 /* internal */,
+				20E67D5528F1BDE000B95C00 /* color.h */,
+				20E67D5628F1BDE000B95C00 /* inline */,
+				20E67D5C28F1BDE000B95C00 /* fmaths.h */,
+				20E67D5D28F1BDE000B95C00 /* unicode.h */,
+				20E67D5E28F1BDE000B95C00 /* palette.h */,
+				20E67D5F28F1BDE000B95C00 /* gfx.h */,
+				20E67D6028F1BDE000B95C00 /* fli.h */,
+				20E67D6128F1BDE000B95C00 /* system.h */,
+				20E67D6228F1BDE000B95C00 /* draw.h */,
+				20E67D6328F1BDE000B95C00 /* base.h */,
+			);
+			path = allegro;
+			sourceTree = "<group>";
+		};
+		20E67D4B28F1BDE000B95C00 /* platform */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D4C28F1BDE000B95C00 /* astdint.h */,
+				20E67D4F28F1BDE000B95C00 /* alosxcfg.h */,
+			);
+			path = platform;
+			sourceTree = "<group>";
+		};
+		20E67D5228F1BDE000B95C00 /* internal */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D5328F1BDE000B95C00 /* aintern.h */,
+				20E67D5428F1BDE000B95C00 /* alconfig.h */,
+			);
+			path = internal;
+			sourceTree = "<group>";
+		};
+		20E67D5628F1BDE000B95C00 /* inline */ = {
+			isa = PBXGroup;
+			children = (
+				20E67D5728F1BDE000B95C00 /* draw.inl */,
+				20E67D5828F1BDE000B95C00 /* gfx.inl */,
+				20E67D5928F1BDE000B95C00 /* fmaths.inl */,
+				20E67D5A28F1BDE000B95C00 /* color.inl */,
+				20E67D5B28F1BDE000B95C00 /* fix.inl */,
+			);
+			path = inline;
+			sourceTree = "<group>";
+		};
+		20E6810128F1BE5C00B95C00 /* AL */ = {
+			isa = PBXGroup;
+			children = (
+				20E6810228F1BE5C00B95C00 /* al.h */,
+				20E6810328F1BE5C00B95C00 /* alc.h */,
+			);
+			name = AL;
+			path = ../../../../libsrc/mojoAL/AL;
+			sourceTree = "<group>";
+		};
+		20E6811E28F1D24F00B95C00 /* SDL_sound */ = {
+			isa = PBXGroup;
+			children = (
+				20E6824428F1D2C300B95C00 /* timidity */,
+				20E6820128F1D2B300B95C00 /* libmodplug */,
+				20E681E728F1D2A200B95C00 /* SDL_sound_aiff.c */,
+				20E681EC28F1D2A200B95C00 /* SDL_sound_au.c */,
+				20E681E528F1D2A100B95C00 /* SDL_sound_coreaudio.c */,
+				20E681EA28F1D2A200B95C00 /* SDL_sound_flac.c */,
+				20E681EB28F1D2A200B95C00 /* SDL_sound_midi.c */,
+				20E681E628F1D2A200B95C00 /* SDL_sound_modplug.c */,
+				20E681E828F1D2A200B95C00 /* SDL_sound_mp3.c */,
+				20E681EE28F1D2A300B95C00 /* SDL_sound_raw.c */,
+				20E681F228F1D2A800B95C00 /* SDL_sound_shn.c */,
+				20E681E928F1D2A200B95C00 /* SDL_sound_voc.c */,
+				20E681EF28F1D2A700B95C00 /* SDL_sound_vorbis.c */,
+				20E681F028F1D2A700B95C00 /* SDL_sound_wav.c */,
+				20E681F128F1D2A800B95C00 /* SDL_sound.c */,
+			);
+			name = SDL_sound;
+			sourceTree = "<group>";
+		};
+		20E6820128F1D2B300B95C00 /* libmodplug */ = {
+			isa = PBXGroup;
+			children = (
+				20E6822028F1D2B300B95C00 /* fastmix.c */,
+				20E6821128F1D2B300B95C00 /* load_669.c */,
+				20E6820428F1D2B300B95C00 /* load_amf.c */,
+				20E6821628F1D2B300B95C00 /* load_ams.c */,
+				20E6821A28F1D2B300B95C00 /* load_dbm.c */,
+				20E6820B28F1D2B300B95C00 /* load_dmf.c */,
+				20E6820C28F1D2B300B95C00 /* load_dsm.c */,
+				20E6820828F1D2B300B95C00 /* load_far.c */,
+				20E6821328F1D2B300B95C00 /* load_it.c */,
+				20E6820F28F1D2B300B95C00 /* load_mdl.c */,
+				20E6822128F1D2B300B95C00 /* load_med.c */,
+				20E6821D28F1D2B300B95C00 /* load_mod.c */,
+				20E6822228F1D2B300B95C00 /* load_mt2.c */,
+				20E6820628F1D2B300B95C00 /* load_mtm.c */,
+				20E6820228F1D2B300B95C00 /* load_okt.c */,
+				20E6820D28F1D2B300B95C00 /* load_gdm.c */,
+				20E6820928F1D2B300B95C00 /* load_psm.c */,
+				20E6821F28F1D2B300B95C00 /* load_ptm.c */,
+				20E6821028F1D2B300B95C00 /* load_s3m.c */,
+				20E6821E28F1D2B300B95C00 /* load_stm.c */,
+				20E6820728F1D2B300B95C00 /* load_ult.c */,
+				20E6821C28F1D2B300B95C00 /* load_umx.c */,
+				20E6820A28F1D2B300B95C00 /* load_xm.c */,
+				20E6821228F1D2B300B95C00 /* mmcmp.c */,
+				20E6821B28F1D2B300B95C00 /* modplug.c */,
+				20E6821828F1D2B300B95C00 /* snd_dsp.c */,
+				20E6821528F1D2B300B95C00 /* snd_flt.c */,
+				20E6821428F1D2B300B95C00 /* snd_fx.c */,
+				20E6820328F1D2B300B95C00 /* sndfile.c */,
+				20E6821728F1D2B300B95C00 /* sndmix.c */,
+				20E6820528F1D2B300B95C00 /* modplug.h */,
+				20E6820E28F1D2B300B95C00 /* libmodplug.h */,
+				20E6821928F1D2B300B95C00 /* tables.h */,
+			);
+			name = libmodplug;
+			path = ../../../../libsrc/SDL_sound/src/libmodplug;
+			sourceTree = "<group>";
+		};
+		20E6824428F1D2C300B95C00 /* timidity */ = {
+			isa = PBXGroup;
+			children = (
+				20E6824528F1D2C300B95C00 /* resample.h */,
+				20E6824628F1D2C300B95C00 /* common.c */,
+				20E6824828F1D2C300B95C00 /* tables.c */,
+				20E6824928F1D2C300B95C00 /* mix.h */,
+				20E6824A28F1D2C300B95C00 /* readmidi.c */,
+				20E6824D28F1D2C300B95C00 /* playmidi.h */,
+				20E6824E28F1D2C300B95C00 /* instrum.c */,
+				20E6825028F1D2C300B95C00 /* options.h */,
+				20E6825128F1D2C300B95C00 /* timidity.h */,
+				20E6825228F1D2C300B95C00 /* output.h */,
+				20E6825528F1D2C300B95C00 /* tables.h */,
+				20E6825628F1D2C400B95C00 /* resample.c */,
+				20E6825828F1D2C400B95C00 /* common.h */,
+				20E6825928F1D2C400B95C00 /* mix.c */,
+				20E6825A28F1D2C400B95C00 /* playmidi.c */,
+				20E6825B28F1D2C400B95C00 /* readmidi.h */,
+				20E6825C28F1D2C400B95C00 /* output.c */,
+				20E6825D28F1D2C400B95C00 /* timidity.c */,
+				20E6825E28F1D2C400B95C00 /* instrum.h */,
+			);
+			name = timidity;
+			path = ../../../../libsrc/SDL_sound/src/timidity;
+			sourceTree = "<group>";
+		};
+		20E6828928F20A7C00B95C00 /* theora */ = {
+			isa = PBXGroup;
+			children = (
+				20E684E828F20E0700B95C00 /* decapiwrapper.c */,
+				20E684E728F20E0700B95C00 /* decinfo.c */,
+				20E684E628F20E0700B95C00 /* decode.c */,
+				20E6844828F20CC300B95C00 /* apiwrapper.c */,
+				20E6844E28F20CC400B95C00 /* apiwrapper.h */,
+				20E6844228F20CC200B95C00 /* bitpack.c */,
+				20E6841928F20CBE00B95C00 /* bitpack.h */,
+				20E6844628F20CC300B95C00 /* dequant.c */,
+				20E6844D28F20CC400B95C00 /* dequant.h */,
+				20E6841528F20CBD00B95C00 /* fragment.c */,
+				20E6843F28F20CC100B95C00 /* huffdec.c */,
+				20E6841228F20CBC00B95C00 /* huffdec.h */,
+				20E6843E28F20CC100B95C00 /* huffman.h */,
+				20E6843328F20CBF00B95C00 /* idct.c */,
+				20E6845828F20CC500B95C00 /* info.c */,
+				20E6843128F20CBF00B95C00 /* internal.c */,
+				20E6846728F20CC500B95C00 /* internal.h */,
+				20E6844728F20CC300B95C00 /* quant.c */,
+				20E6842E28F20CBE00B95C00 /* quant.h */,
+				20E6843528F20CBF00B95C00 /* state.c */,
+				20E6844328F20CC200B95C00 /* state.h */,
+			);
+			name = theora;
+			sourceTree = "<group>";
+		};
+		20E6828A28F20A8200B95C00 /* ogg */ = {
+			isa = PBXGroup;
+			children = (
+				20E6837028F20BFD00B95C00 /* bitwise.c */,
+				20E6836F28F20BFD00B95C00 /* crctable.h */,
+				20E6836E28F20BFD00B95C00 /* framing.c */,
+			);
+			name = ogg;
+			sourceTree = "<group>";
+		};
+		20E6828B28F20A8800B95C00 /* vorbis */ = {
+			isa = PBXGroup;
+			children = (
+				20E683B428F20C6D00B95C00 /* analysis.c */,
+				20E6838F28F20C6500B95C00 /* backends.h */,
+				20E683BA28F20C6F00B95C00 /* bitrate.c */,
+				20E6839428F20C6600B95C00 /* bitrate.h */,
+				20E6838828F20C6400B95C00 /* block.c */,
+				20E683BD28F20C7000B95C00 /* codebook.c */,
+				20E683BF28F20C7100B95C00 /* codebook.h */,
+				20E683BB28F20C7000B95C00 /* codec_internal.h */,
+				20E683C328F20C7200B95C00 /* envelope.c */,
+				20E683BE28F20C7000B95C00 /* envelope.h */,
+				20E6838528F20C6300B95C00 /* floor0.c */,
+				20E683AC28F20C6700B95C00 /* floor1.c */,
+				20E6838728F20C6300B95C00 /* highlevel.h */,
+				20E683C428F20C7200B95C00 /* info.c */,
+				20E6837728F20C6300B95C00 /* lookup_data.h */,
+				20E683B028F20C6800B95C00 /* lookup.c */,
+				20E6839228F20C6600B95C00 /* lookup.h */,
+				20E6838D28F20C6500B95C00 /* lpc.c */,
+				20E683BC28F20C7000B95C00 /* lpc.h */,
+				20E683B328F20C6D00B95C00 /* lsp.c */,
+				20E683B728F20C6E00B95C00 /* lsp.h */,
+				20E6838628F20C6300B95C00 /* mapping0.c */,
+				20E6839528F20C6600B95C00 /* masking.h */,
+				20E683AB28F20C6600B95C00 /* mdct.c */,
+				20E683B928F20C6E00B95C00 /* mdct.h */,
+				20E6838E28F20C6500B95C00 /* misc.c */,
+				20E683C228F20C7100B95C00 /* misc.h */,
+				20E683B528F20C6E00B95C00 /* os.h */,
+				20E6837628F20C6300B95C00 /* psy.c */,
+				20E6837528F20C6200B95C00 /* psy.h */,
+				20E683AF28F20C6700B95C00 /* registry.c */,
+				20E683B828F20C6E00B95C00 /* registry.h */,
+				20E6839128F20C6500B95C00 /* res0.c */,
+				20E683B128F20C6D00B95C00 /* scales.h */,
+				20E6839028F20C6500B95C00 /* sharedbook.c */,
+				20E6838C28F20C6400B95C00 /* smallft.c */,
+				20E683B228F20C6D00B95C00 /* smallft.h */,
+				20E6838428F20C6300B95C00 /* synthesis.c */,
+				20E683AD28F20C6700B95C00 /* window.c */,
+				20E6837428F20C6200B95C00 /* window.h */,
+			);
+			name = vorbis;
+			sourceTree = "<group>";
+		};
+		20E684F028F2189800B95C00 /* ogg */ = {
+			isa = PBXGroup;
+			children = (
+				20E684F128F2189800B95C00 /* ogg.h */,
+				20E684F628F2189800B95C00 /* os_types.h */,
+			);
+			path = ogg;
+			sourceTree = "<group>";
+		};
+		20E6850728F2219A00B95C00 /* AGSSpriteFont */ = {
+			isa = PBXGroup;
+			children = (
+				20E6850B28F2219A00B95C00 /* AGSSpriteFont */,
+			);
+			path = AGSSpriteFont;
+			sourceTree = "<group>";
+		};
+		20E6850B28F2219A00B95C00 /* AGSSpriteFont */ = {
+			isa = PBXGroup;
+			children = (
+				20E6850C28F2219A00B95C00 /* VariableWidthSpriteFont.h */,
+				20E6850D28F2219A00B95C00 /* SpriteFontRenderer.h */,
+				20E6850E28F2219A00B95C00 /* VariableWidthFont.h */,
+				20E6850F28F2219A00B95C00 /* SpriteFontRendererClifftopGames.cpp */,
+				20E6851028F2219A00B95C00 /* SpriteFontRenderer.cpp */,
+				20E6851128F2219A00B95C00 /* SpriteFontRendererClifftopGames.h */,
+				20E6851228F2219A00B95C00 /* CharacterEntry.h */,
+				20E6851328F2219A00B95C00 /* color.h */,
+				20E6851428F2219A00B95C00 /* color.cpp */,
+				20E6851528F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.cpp */,
+				20E6851628F2219A00B95C00 /* SpriteFont.cpp */,
+				20E6851728F2219A00B95C00 /* AGSSpriteFont.cpp */,
+				20E6851828F2219A00B95C00 /* SpriteFont.h */,
+				20E6851928F2219A00B95C00 /* CharacterEntry.cpp */,
+				20E6851A28F2219A00B95C00 /* VariableWidthSpriteFontClifftopGames.h */,
+				20E6851C28F2219A00B95C00 /* VariableWidthFont.cpp */,
+				20E6851D28F2219A00B95C00 /* VariableWidthSpriteFont.cpp */,
+				20E6851E28F2219A00B95C00 /* AGSSpriteFont.h */,
+			);
+			path = AGSSpriteFont;
+			sourceTree = "<group>";
+		};
+		20E6853D28F221CA00B95C00 /* agspalrender */ = {
+			isa = PBXGroup;
+			children = (
+				20E6853E28F221CA00B95C00 /* palrender.h */,
+				20E6853F28F221CA00B95C00 /* agspalrender.h */,
+				20E6854228F221CA00B95C00 /* ags_palrender.cpp */,
+				20E6854428F221CA00B95C00 /* raycast.cpp */,
+				20E6854528F221CA00B95C00 /* raycast.h */,
+			);
+			path = agspalrender;
+			sourceTree = "<group>";
+		};
 		521C3BE01D1E545100BD619E = {
 			isa = PBXGroup;
 			children = (
@@ -1556,6 +2435,7 @@
 		521C3BEC1D1E545100BD619E /* AGSKit */ = {
 			isa = PBXGroup;
 			children = (
+				20E67D0428F1BD6400B95C00 /* libsrc */,
 				521C550D1D1E579300BD619E /* Common */,
 				521C4F891D1E570D00BD619E /* Engine */,
 				521C54601D1E572B00BD619E /* Plugins */,
@@ -1582,7 +2462,6 @@
 				526F26581D3B5CC300EF4E1F /* plugin */,
 				526F265E1D3B5CC300EF4E1F /* resource */,
 				526F26681D3B5CC300EF4E1F /* script */,
-				526F267C1D3B5CC300EF4E1F /* test */,
 				526F26871D3B5CC300EF4E1F /* util */,
 			);
 			name = Engine;
@@ -1592,11 +2471,12 @@
 		521C54601D1E572B00BD619E /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
+				20E6853D28F221CA00B95C00 /* agspalrender */,
+				20E6850728F2219A00B95C00 /* AGSSpriteFont */,
 				521C54611D1E572B00BD619E /* ags_parallax */,
 				521C546C1D1E572B00BD619E /* ags_snowrain */,
 				521C54771D1E572B00BD619E /* agsblend */,
 				521C54811D1E572B00BD619E /* AGSflashlight */,
-				521C54931D1E572B00BD619E /* AGSSpriteFont */,
 				521C54AA1D1E572B00BD619E /* agstouch */,
 			);
 			name = Plugins;
@@ -1639,39 +2519,6 @@
 			path = AGSflashlight;
 			sourceTree = "<group>";
 		};
-		521C54931D1E572B00BD619E /* AGSSpriteFont */ = {
-			isa = PBXGroup;
-			children = (
-				521C54941D1E572B00BD619E /* AGSSpriteFont */,
-			);
-			path = AGSSpriteFont;
-			sourceTree = "<group>";
-		};
-		521C54941D1E572B00BD619E /* AGSSpriteFont */ = {
-			isa = PBXGroup;
-			children = (
-				A3A4659A2866966D00AE0372 /* AGSSpriteFont.h */,
-				A3A4659B2866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp */,
-				A3A465982866966D00AE0372 /* SpriteFontRendererClifftopGames.h */,
-				A3A4659C2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp */,
-				A3A465992866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h */,
-				521C54951D1E572B00BD619E /* AGSSpriteFont.cpp */,
-				521C54971D1E572B00BD619E /* CharacterEntry.cpp */,
-				521C54981D1E572B00BD619E /* CharacterEntry.h */,
-				521C54991D1E572B00BD619E /* color.cpp */,
-				521C549A1D1E572B00BD619E /* color.h */,
-				521C549B1D1E572B00BD619E /* SpriteFont.cpp */,
-				521C549C1D1E572B00BD619E /* SpriteFont.h */,
-				521C549D1D1E572B00BD619E /* SpriteFontRenderer.cpp */,
-				521C549E1D1E572B00BD619E /* SpriteFontRenderer.h */,
-				521C549F1D1E572B00BD619E /* VariableWidthFont.cpp */,
-				521C54A01D1E572B00BD619E /* VariableWidthFont.h */,
-				521C54A11D1E572B00BD619E /* VariableWidthSpriteFont.cpp */,
-				521C54A21D1E572B00BD619E /* VariableWidthSpriteFont.h */,
-			);
-			path = AGSSpriteFont;
-			sourceTree = "<group>";
-		};
 		521C54AA1D1E572B00BD619E /* agstouch */ = {
 			isa = PBXGroup;
 			children = (
@@ -1704,19 +2551,9 @@
 		521C56B61D1E5BCF00BD619E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				52A7D3271D1E643800D88BEE /* libbz2.1.0.dylib */,
-				52A7D3251D1E641F00D88BEE /* libz.1.dylib */,
-				521C56B41D1E5B7C00BD619E /* libbz2.tbd */,
-				521C56B21D1E5B7500BD619E /* libz.tbd */,
-				521C56A01D1E5B5F00BD619E /* libaldmb.a */,
-				521C56A11D1E5B5F00BD619E /* liballeg.a */,
-				521C56A21D1E5B5F00BD619E /* libdumb.a */,
-				521C56A31D1E5B5F00BD619E /* libfreetype.a */,
-				521C56A41D1E5B5F00BD619E /* liblua.a */,
-				521C56A51D1E5B5F00BD619E /* libogg.a */,
-				521C56A61D1E5B5F00BD619E /* libtheoradec.a */,
-				521C56A71D1E5B5F00BD619E /* libvorbis.a */,
-				521C56A81D1E5B5F00BD619E /* libvorbisfile.a */,
+				20E6856C28F25E3B00B95C00 /* libz.1.tbd */,
+				20E6856A28F25E2400B95C00 /* libbz2.1.0.tbd */,
+				20E6810A28F1C7D000B95C00 /* SDL2.framework */,
 				521C569E1D1E5AE900BD619E /* AudioToolbox.framework */,
 				521C569C1D1E5AE300BD619E /* AudioUnit.framework */,
 				521C569A1D1E5ADA00BD619E /* CoreAudio.framework */,
@@ -1732,7 +2569,7 @@
 		526F211A1D3B5C4800EF4E1F /* ac */ = {
 			isa = PBXGroup;
 			children = (
-				526F211B1D3B5C4800EF4E1F /* animationstruct.h */,
+				526F21231D3B5C4800EF4E1F /* dynobj */,
 				526F211C1D3B5C4800EF4E1F /* audiocliptype.cpp */,
 				526F211D1D3B5C4800EF4E1F /* audiocliptype.h */,
 				52F5D84E1DA120A0006F8F4B /* characterinfo.cpp */,
@@ -1742,7 +2579,6 @@
 				526F21211D3B5C4800EF4E1F /* common_defines.h */,
 				52F5D85C1DA12147006F8F4B /* dialogtopic.cpp */,
 				526F21221D3B5C4800EF4E1F /* dialogtopic.h */,
-				526F21231D3B5C4800EF4E1F /* dynobj */,
 				526F21261D3B5C4800EF4E1F /* game_version.h */,
 				526F21271D3B5C4800EF4E1F /* gamesetupstruct.cpp */,
 				526F21281D3B5C4800EF4E1F /* gamesetupstruct.h */,
@@ -1753,17 +2589,15 @@
 				526F212D1D3B5C4800EF4E1F /* interfaceelement.h */,
 				52F5D8601DA1219D006F8F4B /* inventoryiteminfo.cpp */,
 				526F212E1D3B5C4800EF4E1F /* inventoryiteminfo.h */,
-				526F212F1D3B5C4800EF4E1F /* messageinfo.cpp */,
-				526F21301D3B5C4800EF4E1F /* messageinfo.h */,
+				2052299328E8EAE600589E91 /* keycode.cpp */,
+				2052299528E8EAE600589E91 /* keycode.h */,
 				526F21311D3B5C4800EF4E1F /* mousecursor.cpp */,
 				526F21321D3B5C4800EF4E1F /* mousecursor.h */,
 				526F21331D3B5C4800EF4E1F /* oldgamesetupstruct.h */,
-				526F21341D3B5C4800EF4E1F /* point.cpp */,
-				526F21351D3B5C4800EF4E1F /* point.h */,
-				526F21361D3B5C4800EF4E1F /* roomstruct.cpp */,
-				526F21371D3B5C4800EF4E1F /* roomstruct.h */,
 				526F21381D3B5C4800EF4E1F /* spritecache.cpp */,
 				526F21391D3B5C4800EF4E1F /* spritecache.h */,
+				2052299428E8EAE600589E91 /* spritefile.cpp */,
+				2052299228E8EAE500589E91 /* spritefile.h */,
 				526F213A1D3B5C4800EF4E1F /* view.cpp */,
 				526F213B1D3B5C4800EF4E1F /* view.h */,
 				526F213C1D3B5C4800EF4E1F /* wordsdictionary.cpp */,
@@ -1797,7 +2631,7 @@
 				526F21431D3B5C4800EF4E1F /* assetmanager.cpp */,
 				526F21441D3B5C4800EF4E1F /* assetmanager.h */,
 				526F21451D3B5C4800EF4E1F /* def_version.h */,
-				526F21461D3B5C4800EF4E1F /* endianness.h */,
+				2052299A28E8EB5600589E91 /* platform.h */,
 				526F21471D3B5C4800EF4E1F /* types.h */,
 			);
 			path = core;
@@ -1807,9 +2641,10 @@
 			isa = PBXGroup;
 			children = (
 				526F21491D3B5C4800EF4E1F /* assert.h */,
-				526F214A1D3B5C4800EF4E1F /* out.cpp */,
+				2052299C28E8EBA900589E91 /* debugmanager.cpp */,
+				2052299D28E8EBA900589E91 /* debugmanager.h */,
+				2052299E28E8EBA900589E91 /* outputhandler.h */,
 				526F214B1D3B5C4800EF4E1F /* out.h */,
-				526F214C1D3B5C4800EF4E1F /* outputtarget.h */,
 			);
 			path = debug;
 			sourceTree = "<group>";
@@ -1840,6 +2675,15 @@
 				52F5D8501DA120CB006F8F4B /* main_game_file.cpp */,
 				52F5D8511DA120CB006F8F4B /* main_game_file.h */,
 				52F5D8541DA120D9006F8F4B /* plugininfo.h */,
+				205229A228E8EBE300589E91 /* room_file.cpp */,
+				205229A328E8EBE300589E91 /* room_file.h */,
+				205229A628E8EBE400589E91 /* room_file_base.cpp */,
+				205229A528E8EBE400589E91 /* room_file_deprecated.cpp */,
+				205229A828E8EBE400589E91 /* room_version.h */,
+				205229AA28E8EBE500589E91 /* roomstruct.cpp */,
+				205229A728E8EBE400589E91 /* roomstruct.h */,
+				205229A928E8EBE500589E91 /* tra_file.cpp */,
+				205229A428E8EBE300589E91 /* tra_file.h */,
 			);
 			path = game;
 			sourceTree = "<group>";
@@ -1883,51 +2727,19 @@
 		526F21741D3B5C4800EF4E1F /* libinclude */ = {
 			isa = PBXGroup;
 			children = (
+				20E684F028F2189800B95C00 /* ogg */,
 				526F21751D3B5C4800EF4E1F /* aastr.h */,
 				526F21761D3B5C4800EF4E1F /* aautil.h */,
-				526F21781D3B5C4800EF4E1F /* alfont.h */,
-				526F21791D3B5C4800EF4E1F /* alfontdll.h */,
-				526F217A1D3B5C4800EF4E1F /* almp3.h */,
-				526F217B1D3B5C4800EF4E1F /* almp3dll.h */,
-				526F217C1D3B5C4800EF4E1F /* alogg.h */,
-				526F217D1D3B5C4800EF4E1F /* aloggdll.h */,
-				526F217E1D3B5C4800EF4E1F /* apeg.h */,
-				526F217F1D3B5C4800EF4E1F /* common.h */,
-				526F21811D3B5C4800EF4E1F /* genre.h */,
-				526F21821D3B5C4800EF4E1F /* getbits.h */,
-				526F21831D3B5C4900EF4E1F /* getblk.h */,
-				526F21841D3B5C4900EF4E1F /* huffman.h */,
-				526F21851D3B5C4900EF4E1F /* l2tables.h */,
-				526F21861D3B5C4900EF4E1F /* libcda.h */,
-				526F21871D3B5C4900EF4E1F /* mpeg1dec.h */,
-				526F21881D3B5C4900EF4E1F /* mpg123.h */,
-				526F21891D3B5C4900EF4E1F /* mpglib.h */,
-				526F218A1D3B5C4900EF4E1F /* OGG */,
 				526F21911D3B5C4900EF4E1F /* theora */,
 				526F21981D3B5C4900EF4E1F /* vorbis */,
 			);
 			path = libinclude;
 			sourceTree = "<group>";
 		};
-		526F218A1D3B5C4900EF4E1F /* OGG */ = {
-			isa = PBXGroup;
-			children = (
-				526F218B1D3B5C4900EF4E1F /* config_types.h */,
-				526F218C1D3B5C4900EF4E1F /* config_types.h.in */,
-				526F218D1D3B5C4900EF4E1F /* MAKEFILE.AM */,
-				526F218E1D3B5C4900EF4E1F /* MAKEFILE.IN */,
-				526F218F1D3B5C4900EF4E1F /* OGG.H */,
-				526F21901D3B5C4900EF4E1F /* OS_TYPES.H */,
-			);
-			path = OGG;
-			sourceTree = "<group>";
-		};
 		526F21911D3B5C4900EF4E1F /* theora */ = {
 			isa = PBXGroup;
 			children = (
 				526F21921D3B5C4900EF4E1F /* codec.h */,
-				526F21931D3B5C4900EF4E1F /* Makefile.am */,
-				526F21941D3B5C4900EF4E1F /* Makefile.in */,
 				526F21951D3B5C4900EF4E1F /* theora.h */,
 				526F21961D3B5C4900EF4E1F /* theoradec.h */,
 				526F21971D3B5C4900EF4E1F /* theoraenc.h */,
@@ -1939,8 +2751,6 @@
 			isa = PBXGroup;
 			children = (
 				526F21991D3B5C4900EF4E1F /* codec.h */,
-				526F219A1D3B5C4900EF4E1F /* Makefile.am */,
-				526F219B1D3B5C4900EF4E1F /* Makefile.in */,
 				526F219C1D3B5C4900EF4E1F /* vorbisenc.h */,
 				526F219D1D3B5C4900EF4E1F /* vorbisfile.h */,
 			);
@@ -1950,6 +2760,8 @@
 		526F219E1D3B5C4900EF4E1F /* libsrc */ = {
 			isa = PBXGroup;
 			children = (
+				205229BA28E8ECC700589E91 /* freetype-2.1.3 */,
+				205229B928E8ECB800589E91 /* alfont-2.0.9 */,
 				526F219F1D3B5C4900EF4E1F /* aastr-0.1.1 */,
 			);
 			path = libsrc;
@@ -1963,7 +2775,6 @@
 				526F21A21D3B5C4900EF4E1F /* aastr.h */,
 				526F21A31D3B5C4900EF4E1F /* aautil.c */,
 				526F21A41D3B5C4900EF4E1F /* aautil.h */,
-				526F21A51D3B5C4900EF4E1F /* vssver2.scc */,
 			);
 			path = "aastr-0.1.1";
 			sourceTree = "<group>";
@@ -1971,16 +2782,11 @@
 		526F22641D3B5C4900EF4E1F /* script */ = {
 			isa = PBXGroup;
 			children = (
-				526F22651D3B5C4900EF4E1F /* cc_error.cpp */,
-				526F22661D3B5C4900EF4E1F /* cc_error.h */,
-				526F22671D3B5C4900EF4E1F /* cc_options.cpp */,
-				526F22681D3B5C4900EF4E1F /* cc_options.h */,
+				20522A0328E8F7FD00589E91 /* cc_common.cpp */,
+				20522A0228E8F7FD00589E91 /* cc_common.h */,
+				20522A0428E8F7FD00589E91 /* cc_internal.h */,
 				526F22691D3B5C4900EF4E1F /* cc_script.cpp */,
 				526F226A1D3B5C4900EF4E1F /* cc_script.h */,
-				526F226B1D3B5C4900EF4E1F /* cc_treemap.cpp */,
-				526F226C1D3B5C4900EF4E1F /* cc_treemap.h */,
-				526F226D1D3B5C4900EF4E1F /* script_common.cpp */,
-				526F226E1D3B5C4900EF4E1F /* script_common.h */,
 			);
 			path = script;
 			sourceTree = "<group>";
@@ -1988,6 +2794,27 @@
 		526F226F1D3B5C4900EF4E1F /* util */ = {
 			isa = PBXGroup;
 			children = (
+				20522A1128E8F81900589E91 /* aasset_stream.cpp */,
+				20522A1C28E8F81C00589E91 /* aasset_stream.h */,
+				20522A0F28E8F81900589E91 /* android_file.cpp */,
+				20522A1A28E8F81B00589E91 /* android_file.h */,
+				20522A1028E8F81900589E91 /* bufferedstream.cpp */,
+				20522A1B28E8F81B00589E91 /* bufferedstream.h */,
+				20522A0E28E8F81900589E91 /* cmdlineopts.cpp */,
+				20522A1928E8F81B00589E91 /* cmdlineopts.h */,
+				20522A1828E8F81B00589E91 /* data_ext.cpp */,
+				20522A0B28E8F81800589E91 /* data_ext.h */,
+				20522A0D28E8F81800589E91 /* error.h */,
+				20522A0C28E8F81800589E91 /* memory_compat.h */,
+				20522A1228E8F81A00589E91 /* memorystream.cpp */,
+				20522A0A28E8F81800589E91 /* memorystream.h */,
+				20522A1728E8F81B00589E91 /* path_ex.cpp */,
+				20522A1628E8F81A00589E91 /* scaling.h */,
+				20522A0828E8F81700589E91 /* stdio_compat.c */,
+				20522A0928E8F81700589E91 /* stdio_compat.h */,
+				20522A1428E8F81A00589E91 /* string_compat.c */,
+				20522A1328E8F81A00589E91 /* string_compat.h */,
+				20522A1528E8F81A00589E91 /* utf8.h */,
 				526F22701D3B5C4900EF4E1F /* alignedstream.cpp */,
 				526F22711D3B5C4900EF4E1F /* alignedstream.h */,
 				526F22721D3B5C4900EF4E1F /* bbop.h */,
@@ -2011,8 +2838,6 @@
 				526F22841D3B5C4900EF4E1F /* lzw.h */,
 				526F22851D3B5C4900EF4E1F /* math.h */,
 				526F22861D3B5C4900EF4E1F /* memory.h */,
-				526F22871D3B5C4900EF4E1F /* misc.cpp */,
-				526F22881D3B5C4900EF4E1F /* misc.h */,
 				526F22891D3B5C4900EF4E1F /* multifilelib.h */,
 				526F228A1D3B5C4900EF4E1F /* multifilelib.cpp */,
 				526F228B1D3B5C4900EF4E1F /* path.cpp */,
@@ -2043,17 +2868,31 @@
 		526F24151D3B5CC200EF4E1F /* ac */ = {
 			isa = PBXGroup;
 			children = (
+				526F25041D3B5CC300EF4E1F /* statobj */,
+				526F24331D3B5CC200EF4E1F /* dynobj */,
 				526F24161D3B5CC200EF4E1F /* audiochannel.cpp */,
 				526F24171D3B5CC200EF4E1F /* audiochannel.h */,
 				526F24181D3B5CC200EF4E1F /* audioclip.cpp */,
 				526F24191D3B5CC200EF4E1F /* audioclip.h */,
 				526F241A1D3B5CC200EF4E1F /* button.cpp */,
 				526F241B1D3B5CC200EF4E1F /* button.h */,
+				20522A5C28E8F8DD00589E91 /* sys_events.cpp */,
+				20522A5B28E8F8DD00589E91 /* sys_events.h */,
+				20522A5A28E8F8DD00589E91 /* viewport_script.cpp */,
+				20522A4E28E8F8CA00589E91 /* path_helper.h */,
+				20522A4C28E8F8CA00589E91 /* route_finder_impl_legacy.cpp */,
+				20522A4D28E8F8CA00589E91 /* route_finder_impl_legacy.h */,
+				20522A5228E8F8CB00589E91 /* route_finder_impl.cpp */,
+				20522A5028E8F8CA00589E91 /* route_finder_impl.h */,
+				20522A4F28E8F8CA00589E91 /* route_finder_jps.inl */,
+				20522A5128E8F8CA00589E91 /* scriptcontainers.cpp */,
+				20522A4828E8F8AA00589E91 /* asset_helper.h */,
+				20522A4728E8F8A900589E91 /* draw_software.cpp */,
+				20522A4628E8F8A900589E91 /* draw_software.h */,
 				526F241C1D3B5CC200EF4E1F /* cdaudio.cpp */,
 				526F241D1D3B5CC200EF4E1F /* cdaudio.h */,
 				526F241E1D3B5CC200EF4E1F /* character.cpp */,
 				526F241F1D3B5CC200EF4E1F /* character.h */,
-				526F24201D3B5CC200EF4E1F /* charactercache.h */,
 				526F24211D3B5CC200EF4E1F /* characterextras.cpp */,
 				526F24221D3B5CC200EF4E1F /* characterextras.h */,
 				52F5D85A1DA1211B006F8F4B /* characterinfo_engine.cpp */,
@@ -2071,7 +2910,6 @@
 				526F24301D3B5CC200EF4E1F /* drawingsurface.h */,
 				526F24311D3B5CC200EF4E1F /* dynamicsprite.cpp */,
 				526F24321D3B5CC200EF4E1F /* dynamicsprite.h */,
-				526F24331D3B5CC200EF4E1F /* dynobj */,
 				526F246F1D3B5CC200EF4E1F /* event.cpp */,
 				526F24701D3B5CC200EF4E1F /* event.h */,
 				526F24711D3B5CC200EF4E1F /* file.cpp */,
@@ -2128,8 +2966,6 @@
 				526F24A41D3B5CC200EF4E1F /* global_parser.cpp */,
 				526F24A51D3B5CC200EF4E1F /* global_parser.h */,
 				526F24A61D3B5CC200EF4E1F /* global_plugin.h */,
-				526F24A71D3B5CC200EF4E1F /* global_record.cpp */,
-				526F24A81D3B5CC200EF4E1F /* global_record.h */,
 				526F24A91D3B5CC200EF4E1F /* global_region.cpp */,
 				526F24AA1D3B5CC200EF4E1F /* global_region.h */,
 				526F24AB1D3B5CC200EF4E1F /* global_room.cpp */,
@@ -2169,7 +3005,6 @@
 				526F24CD1D3B5CC300EF4E1F /* inventoryitem.h */,
 				526F24CF1D3B5CC300EF4E1F /* invwindow.cpp */,
 				526F24D01D3B5CC300EF4E1F /* invwindow.h */,
-				526F24D11D3B5CC300EF4E1F /* keycode.h */,
 				526F24D21D3B5CC300EF4E1F /* label.cpp */,
 				526F24D31D3B5CC300EF4E1F /* label.h */,
 				526F24D41D3B5CC300EF4E1F /* lipsync.h */,
@@ -2183,24 +3018,16 @@
 				526F24DC1D3B5CC300EF4E1F /* movelist.h */,
 				526F24DD1D3B5CC300EF4E1F /* object.cpp */,
 				526F24DE1D3B5CC300EF4E1F /* object.h */,
-				526F24DF1D3B5CC300EF4E1F /* objectcache.h */,
 				526F24E01D3B5CC300EF4E1F /* overlay.cpp */,
 				526F24E11D3B5CC300EF4E1F /* overlay.h */,
 				526F24E21D3B5CC300EF4E1F /* parser.cpp */,
 				526F24E31D3B5CC300EF4E1F /* parser.h */,
-				526F24E41D3B5CC300EF4E1F /* path.cpp */,
-				526F24E51D3B5CC300EF4E1F /* path.h */,
 				526F24E61D3B5CC300EF4E1F /* properties.cpp */,
 				526F24E71D3B5CC300EF4E1F /* properties.h */,
-				526F24E81D3B5CC300EF4E1F /* record.cpp */,
-				526F24E91D3B5CC300EF4E1F /* record.h */,
 				526F24EA1D3B5CC300EF4E1F /* region.cpp */,
 				526F24EB1D3B5CC300EF4E1F /* region.h */,
-				526F24EC1D3B5CC300EF4E1F /* richgamemedia.cpp */,
-				526F24ED1D3B5CC300EF4E1F /* richgamemedia.h */,
 				526F24EE1D3B5CC300EF4E1F /* room.cpp */,
 				526F24EF1D3B5CC300EF4E1F /* room.h */,
-				526F24F01D3B5CC300EF4E1F /* room_engine.cpp */,
 				526F24F11D3B5CC300EF4E1F /* roomobject.cpp */,
 				526F24F21D3B5CC300EF4E1F /* roomobject.h */,
 				526F24F31D3B5CC300EF4E1F /* roomstatus.cpp */,
@@ -2219,7 +3046,6 @@
 				526F25001D3B5CC300EF4E1F /* sprite.cpp */,
 				526F25011D3B5CC300EF4E1F /* sprite.h */,
 				526F25021D3B5CC300EF4E1F /* spritecache_engine.cpp */,
-				526F25041D3B5CC300EF4E1F /* statobj */,
 				526F250A1D3B5CC300EF4E1F /* string.cpp */,
 				526F250B1D3B5CC300EF4E1F /* string.h */,
 				526F250C1D3B5CC300EF4E1F /* system.cpp */,
@@ -2231,12 +3057,8 @@
 				526F25121D3B5CC300EF4E1F /* topbarsettings.h */,
 				526F25131D3B5CC300EF4E1F /* translation.cpp */,
 				526F25141D3B5CC300EF4E1F /* translation.h */,
-				526F25151D3B5CC300EF4E1F /* tree_map.cpp */,
-				526F25161D3B5CC300EF4E1F /* tree_map.h */,
 				526F25171D3B5CC300EF4E1F /* viewframe.cpp */,
 				526F25181D3B5CC300EF4E1F /* viewframe.h */,
-				526F25191D3B5CC300EF4E1F /* viewport.cpp */,
-				526F251A1D3B5CC300EF4E1F /* viewport.h */,
 				526F251B1D3B5CC300EF4E1F /* walkablearea.cpp */,
 				526F251C1D3B5CC300EF4E1F /* walkablearea.h */,
 				526F251D1D3B5CC300EF4E1F /* walkbehind.cpp */,
@@ -2248,6 +3070,16 @@
 		526F24331D3B5CC200EF4E1F /* dynobj */ = {
 			isa = PBXGroup;
 			children = (
+				20522A3428E8F86200589E91 /* cc_dynamicobject_addr_and_manager.h */,
+				20522A3328E8F86200589E91 /* scriptcamera.cpp */,
+				20522A3528E8F86200589E91 /* scriptcamera.h */,
+				20522A3628E8F86200589E91 /* scriptcontainers.h */,
+				20522A3B28E8F86400589E91 /* scriptdict.cpp */,
+				20522A3728E8F86300589E91 /* scriptdict.h */,
+				20522A3828E8F86300589E91 /* scriptset.cpp */,
+				20522A3928E8F86300589E91 /* scriptset.h */,
+				20522A3A28E8F86300589E91 /* scriptviewport.cpp */,
+				20522A3228E8F86200589E91 /* scriptviewport.h */,
 				526F24341D3B5CC200EF4E1F /* all_dynamicclasses.h */,
 				526F24351D3B5CC200EF4E1F /* all_scriptclasses.h */,
 				526F24361D3B5CC200EF4E1F /* cc_agsdynamicobject.cpp */,
@@ -2326,6 +3158,8 @@
 		526F251F1D3B5CC300EF4E1F /* debug */ = {
 			isa = PBXGroup;
 			children = (
+				20522A6128E8F8FC00589E91 /* messagebuffer.cpp */,
+				20522A6028E8F8FC00589E91 /* messagebuffer.h */,
 				526F25201D3B5CC300EF4E1F /* agseditordebugger.h */,
 				526F25211D3B5CC300EF4E1F /* consoleoutputtarget.cpp */,
 				526F25221D3B5CC300EF4E1F /* consoleoutputtarget.h */,
@@ -2361,6 +3195,11 @@
 		526F25301D3B5CC300EF4E1F /* gfx */ = {
 			isa = PBXGroup;
 			children = (
+				20522A6E28E8F94000589E91 /* gfxfilter_aaogl.cpp */,
+				20522A6F28E8F94000589E91 /* gfxfilter_aaogl.h */,
+				20522A7228E8F94100589E91 /* gfxfilter_sdl_renderer.cpp */,
+				20522A7028E8F94000589E91 /* gfxfilter_sdl_renderer.h */,
+				20522A7128E8F94100589E91 /* ogl_headers.h */,
 				526F25311D3B5CC300EF4E1F /* ali3dexception.h */,
 				526F25321D3B5CC300EF4E1F /* ali3dogl.cpp */,
 				526F25331D3B5CC300EF4E1F /* ali3dogl.h */,
@@ -2381,19 +3220,14 @@
 				526F25421D3B5CC300EF4E1F /* gfxfilter.h */,
 				526F25431D3B5CC300EF4E1F /* gfxfilter_aad3d.cpp */,
 				526F25441D3B5CC300EF4E1F /* gfxfilter_aad3d.h */,
-				526F25451D3B5CC300EF4E1F /* gfxfilter_allegro.cpp */,
-				526F25461D3B5CC300EF4E1F /* gfxfilter_allegro.h */,
 				526F25471D3B5CC300EF4E1F /* gfxfilter_d3d.cpp */,
 				526F25481D3B5CC300EF4E1F /* gfxfilter_d3d.h */,
-				526F25491D3B5CC300EF4E1F /* gfxfilter_hqx.cpp */,
-				526F254A1D3B5CC300EF4E1F /* gfxfilter_hqx.h */,
 				526F254B1D3B5CC300EF4E1F /* gfxfilter_ogl.cpp */,
 				526F254C1D3B5CC300EF4E1F /* gfxfilter_ogl.h */,
 				526F254D1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp */,
 				526F254E1D3B5CC300EF4E1F /* gfxfilter_scaling.h */,
 				526F254F1D3B5CC300EF4E1F /* gfxmodelist.h */,
 				526F25501D3B5CC300EF4E1F /* graphicsdriver.h */,
-				526F25511D3B5CC300EF4E1F /* hq2x3x.h */,
 			);
 			path = gfx;
 			sourceTree = "<group>";
@@ -2428,82 +3262,24 @@
 		526F25671D3B5CC300EF4E1F /* libsrc */ = {
 			isa = PBXGroup;
 			children = (
-				526F25681D3B5CC300EF4E1F /* alfont-2.0.9 */,
-				526F25791D3B5CC300EF4E1F /* almp3 */,
-				526F257B1D3B5CC300EF4E1F /* almp3-2.0.5 */,
-				526F258A1D3B5CC300EF4E1F /* alogg */,
+				20522A7828E8F98400589E91 /* glad */,
 				526F25911D3B5CC300EF4E1F /* apeg-1.2.1 */,
-				526F25DE1D3B5CC300EF4E1F /* hq2x */,
 			);
 			path = libsrc;
-			sourceTree = "<group>";
-		};
-		526F25681D3B5CC300EF4E1F /* alfont-2.0.9 */ = {
-			isa = PBXGroup;
-			children = (
-				526F25691D3B5CC300EF4E1F /* alfont.c */,
-				526F256A1D3B5CC300EF4E1F /* ALFONT.txt */,
-				526F256B1D3B5CC300EF4E1F /* AUTHORS.txt */,
-				526F256C1D3B5CC300EF4E1F /* FTL.txt */,
-				526F256D1D3B5CC300EF4E1F /* README.txt */,
-			);
-			path = "alfont-2.0.9";
-			sourceTree = "<group>";
-		};
-		526F25791D3B5CC300EF4E1F /* almp3 */ = {
-			isa = PBXGroup;
-			children = (
-				526F257A1D3B5CC300EF4E1F /* almp3.c */,
-			);
-			path = almp3;
-			sourceTree = "<group>";
-		};
-		526F257B1D3B5CC300EF4E1F /* almp3-2.0.5 */ = {
-			isa = PBXGroup;
-			children = (
-				526F257C1D3B5CC300EF4E1F /* decoder */,
-			);
-			path = "almp3-2.0.5";
-			sourceTree = "<group>";
-		};
-		526F257C1D3B5CC300EF4E1F /* decoder */ = {
-			isa = PBXGroup;
-			children = (
-				526F257D1D3B5CC300EF4E1F /* common.c */,
-				526F257E1D3B5CC300EF4E1F /* dct64_i386.c */,
-				526F257F1D3B5CC300EF4E1F /* decode_i386.c */,
-				526F25801D3B5CC300EF4E1F /* huffman.h */,
-				526F25811D3B5CC300EF4E1F /* interface.c */,
-				526F25821D3B5CC300EF4E1F /* l2tables.h */,
-				526F25831D3B5CC300EF4E1F /* layer2.c */,
-				526F25841D3B5CC300EF4E1F /* layer3.c */,
-				526F25851D3B5CC300EF4E1F /* mpg123.h */,
-				526F25861D3B5CC300EF4E1F /* mpglib.h */,
-				526F25871D3B5CC300EF4E1F /* README */,
-				526F25881D3B5CC300EF4E1F /* tabinit.c */,
-				526F25891D3B5CC300EF4E1F /* vssver2.scc */,
-			);
-			path = decoder;
-			sourceTree = "<group>";
-		};
-		526F258A1D3B5CC300EF4E1F /* alogg */ = {
-			isa = PBXGroup;
-			children = (
-				526F258B1D3B5CC300EF4E1F /* alogg.c */,
-				526F258C1D3B5CC300EF4E1F /* ALOGG.txt */,
-				526F258D1D3B5CC300EF4E1F /* AUTHORS.txt */,
-				526F258E1D3B5CC300EF4E1F /* CHANGES.txt */,
-				526F258F1D3B5CC300EF4E1F /* COPYING.txt */,
-				526F25901D3B5CC300EF4E1F /* README.txt */,
-			);
-			path = alogg;
 			sourceTree = "<group>";
 		};
 		526F25911D3B5CC300EF4E1F /* apeg-1.2.1 */ = {
 			isa = PBXGroup;
 			children = (
+				20E6810C28F1C98200B95C00 /* apeg.h */,
+				20E6811028F1C98300B95C00 /* common.h */,
+				20E6811328F1C98300B95C00 /* getbits.h */,
+				20E6810E28F1C98200B95C00 /* getblk.h */,
+				20E6811228F1C98300B95C00 /* huffman.h */,
+				20E6810D28F1C98200B95C00 /* l2tables.h */,
+				20E6811128F1C98300B95C00 /* mpeg1dec.h */,
+				20E6810F28F1C98300B95C00 /* mpg123.h */,
 				526F25921D3B5CC300EF4E1F /* adisplay.c */,
-				526F25931D3B5CC300EF4E1F /* apeg.txt */,
 				526F25941D3B5CC300EF4E1F /* audio */,
 				526F25A31D3B5CC300EF4E1F /* getbits.c */,
 				526F25A41D3B5CC300EF4E1F /* getblk.c */,
@@ -2514,7 +3290,6 @@
 				526F25A91D3B5CC300EF4E1F /* mpeg1dec.c */,
 				526F25AA1D3B5CC300EF4E1F /* ogg.c */,
 				526F25AB1D3B5CC300EF4E1F /* recon.c */,
-				526F25AC1D3B5CC300EF4E1F /* vssver2.scc */,
 			);
 			path = "apeg-1.2.1";
 			sourceTree = "<group>";
@@ -2535,23 +3310,14 @@
 				526F259F1D3B5CC300EF4E1F /* readers.c */,
 				526F25A01D3B5CC300EF4E1F /* tabinit.c */,
 				526F25A11D3B5CC300EF4E1F /* vbrhead.c */,
-				526F25A21D3B5CC300EF4E1F /* vssver2.scc */,
 			);
 			path = audio;
-			sourceTree = "<group>";
-		};
-		526F25DE1D3B5CC300EF4E1F /* hq2x */ = {
-			isa = PBXGroup;
-			children = (
-				526F25DF1D3B5CC300EF4E1F /* hq2x3x.cpp */,
-				526F25E01D3B5CC300EF4E1F /* vssver2.scc */,
-			);
-			path = hq2x;
 			sourceTree = "<group>";
 		};
 		526F25F01D3B5CC300EF4E1F /* main */ = {
 			isa = PBXGroup;
 			children = (
+				20522A8528E8F9D600589E91 /* main_sdl2.cpp */,
 				526F25F11D3B5CC300EF4E1F /* config.cpp */,
 				526F25F21D3B5CC300EF4E1F /* config.h */,
 				526F25F31D3B5CC300EF4E1F /* engine.cpp */,
@@ -2568,10 +3334,6 @@
 				526F25FE1D3B5CC300EF4E1F /* graphics_mode.h */,
 				526F25FF1D3B5CC300EF4E1F /* main.cpp */,
 				526F26001D3B5CC300EF4E1F /* main.h */,
-				526F26011D3B5CC300EF4E1F /* main_allegro.h */,
-				526F26021D3B5CC300EF4E1F /* maindefines_ex.h */,
-				526F26031D3B5CC300EF4E1F /* mainheader.h */,
-				526F26041D3B5CC300EF4E1F /* minidump.cpp */,
 				526F26051D3B5CC300EF4E1F /* quit.cpp */,
 				526F26061D3B5CC300EF4E1F /* quit.h */,
 				526F26071D3B5CC300EF4E1F /* update.cpp */,
@@ -2592,33 +3354,23 @@
 		526F260C1D3B5CC300EF4E1F /* audio */ = {
 			isa = PBXGroup;
 			children = (
+				20E6827928F1D32C00B95C00 /* audio_core.cpp */,
+				20E6827B28F1D32C00B95C00 /* audio_core.h */,
+				20E6827C28F1D32C00B95C00 /* audio_system.h */,
+				20E6828028F1D32D00B95C00 /* openal.h */,
+				20E6827F28F1D32D00B95C00 /* openalsource.cpp */,
+				20E6827E28F1D32D00B95C00 /* openalsource.h */,
+				20E6827A28F1D32C00B95C00 /* sdldecoder.cpp */,
+				20E6827D28F1D32D00B95C00 /* sdldecoder.h */,
 				526F260D1D3B5CC300EF4E1F /* ambientsound.cpp */,
 				526F260E1D3B5CC300EF4E1F /* ambientsound.h */,
 				526F260F1D3B5CC300EF4E1F /* audio.cpp */,
 				526F26101D3B5CC300EF4E1F /* audio.h */,
 				526F26111D3B5CC300EF4E1F /* audiodefines.h */,
-				526F26131D3B5CC300EF4E1F /* clip_mydumbmod.cpp */,
-				526F26141D3B5CC300EF4E1F /* clip_mydumbmod.h */,
-				526F26151D3B5CC300EF4E1F /* clip_myjgmod.cpp */,
-				526F26161D3B5CC300EF4E1F /* clip_myjgmod.h */,
-				526F26171D3B5CC300EF4E1F /* clip_mymidi.cpp */,
-				526F26181D3B5CC300EF4E1F /* clip_mymidi.h */,
-				526F26191D3B5CC300EF4E1F /* clip_mymp3.cpp */,
-				526F261A1D3B5CC300EF4E1F /* clip_mymp3.h */,
-				526F261B1D3B5CC300EF4E1F /* clip_myogg.cpp */,
-				526F261C1D3B5CC300EF4E1F /* clip_myogg.h */,
-				526F261D1D3B5CC300EF4E1F /* clip_mystaticmp3.cpp */,
-				526F261E1D3B5CC300EF4E1F /* clip_mystaticmp3.h */,
-				526F261F1D3B5CC300EF4E1F /* clip_mystaticogg.cpp */,
-				526F26201D3B5CC300EF4E1F /* clip_mystaticogg.h */,
-				526F26211D3B5CC300EF4E1F /* clip_mywave.cpp */,
-				526F26221D3B5CC300EF4E1F /* clip_mywave.h */,
 				526F26231D3B5CC300EF4E1F /* queuedaudioitem.cpp */,
 				526F26241D3B5CC300EF4E1F /* queuedaudioitem.h */,
 				526F26251D3B5CC300EF4E1F /* sound.cpp */,
 				526F26261D3B5CC300EF4E1F /* sound.h */,
-				526F26271D3B5CC300EF4E1F /* soundcache.cpp */,
-				526F26281D3B5CC300EF4E1F /* soundcache.h */,
 				526F26291D3B5CC300EF4E1F /* soundclip.cpp */,
 				526F262A1D3B5CC300EF4E1F /* soundclip.h */,
 			);
@@ -2630,7 +3382,6 @@
 			children = (
 				526F262C1D3B5CC300EF4E1F /* video.cpp */,
 				526F262D1D3B5CC300EF4E1F /* video.h */,
-				526F262E1D3B5CC300EF4E1F /* VMR9Graph.h */,
 			);
 			path = video;
 			sourceTree = "<group>";
@@ -2648,9 +3399,10 @@
 		526F26321D3B5CC300EF4E1F /* base */ = {
 			isa = PBXGroup;
 			children = (
+				20522A9228E8FD7700589E91 /* sys_main.cpp */,
+				20522A9128E8FD7600589E91 /* sys_main.h */,
 				526F26331D3B5CC300EF4E1F /* agsplatformdriver.cpp */,
 				526F26341D3B5CC300EF4E1F /* agsplatformdriver.h */,
-				526F26351D3B5CC300EF4E1F /* override_defines.h */,
 			);
 			path = base;
 			sourceTree = "<group>";
@@ -2668,8 +3420,6 @@
 			isa = PBXGroup;
 			children = (
 				526F26461D3B5CC300EF4E1F /* libc.c */,
-				526F26471D3B5CC300EF4E1F /* pe.c */,
-				526F26481D3B5CC300EF4E1F /* pe.h */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -2677,6 +3427,7 @@
 		526F26581D3B5CC300EF4E1F /* plugin */ = {
 			isa = PBXGroup;
 			children = (
+				20522A8E28E8FD6000589E91 /* plugin_engine.h */,
 				526F26591D3B5CC300EF4E1F /* agsplugin.cpp */,
 				526F265A1D3B5CC300EF4E1F /* agsplugin.h */,
 				526F265B1D3B5CC300EF4E1F /* global_plugin.cpp */,
@@ -2690,7 +3441,6 @@
 			isa = PBXGroup;
 			children = (
 				526F265F1D3B5CC300EF4E1F /* CompileShader.bat */,
-				526F26601D3B5CC300EF4E1F /* DefaultGDF.gdf.xml */,
 				526F26611D3B5CC300EF4E1F /* game-1.ICO */,
 				526F26621D3B5CC300EF4E1F /* resource.h */,
 				526F26631D3B5CC300EF4E1F /* tintshader.fx */,
@@ -2705,7 +3455,6 @@
 		526F26681D3B5CC300EF4E1F /* script */ = {
 			isa = PBXGroup;
 			children = (
-				526F26691D3B5CC300EF4E1F /* cc_error_engine.cpp */,
 				526F266A1D3B5CC300EF4E1F /* cc_instance.cpp */,
 				526F266B1D3B5CC300EF4E1F /* cc_instance.h */,
 				526F266C1D3B5CC300EF4E1F /* executingscript.cpp */,
@@ -2719,7 +3468,6 @@
 				526F26741D3B5CC300EF4E1F /* script.h */,
 				526F26751D3B5CC300EF4E1F /* script_api.cpp */,
 				526F26761D3B5CC300EF4E1F /* script_api.h */,
-				526F26771D3B5CC300EF4E1F /* script_engine.cpp */,
 				526F26781D3B5CC300EF4E1F /* script_runtime.cpp */,
 				526F26791D3B5CC300EF4E1F /* script_runtime.h */,
 				526F267A1D3B5CC300EF4E1F /* systemimports.cpp */,
@@ -2728,44 +3476,16 @@
 			path = script;
 			sourceTree = "<group>";
 		};
-		526F267C1D3B5CC300EF4E1F /* test */ = {
-			isa = PBXGroup;
-			children = (
-				526F267D1D3B5CC300EF4E1F /* test_all.cpp */,
-				526F267E1D3B5CC300EF4E1F /* test_all.h */,
-				526F267F1D3B5CC300EF4E1F /* test_file.cpp */,
-				526F26801D3B5CC300EF4E1F /* test_gfx.cpp */,
-				526F26811D3B5CC300EF4E1F /* test_inifile.cpp */,
-				526F26821D3B5CC300EF4E1F /* test_math.cpp */,
-				526F26831D3B5CC300EF4E1F /* test_memory.cpp */,
-				526F26841D3B5CC300EF4E1F /* test_sprintf.cpp */,
-				526F26851D3B5CC300EF4E1F /* test_string.cpp */,
-				526F26861D3B5CC300EF4E1F /* test_version.cpp */,
-			);
-			path = test;
-			sourceTree = "<group>";
-		};
 		526F26871D3B5CC300EF4E1F /* util */ = {
 			isa = PBXGroup;
 			children = (
+				20522A8828E8FD2B00589E91 /* sdl2_util.cpp */,
+				20522A8728E8FD2B00589E91 /* sdl2_util.h */,
 				526F26881D3B5CC300EF4E1F /* library.h */,
 				526F26891D3B5CC300EF4E1F /* library_dummy.h */,
 				526F268A1D3B5CC300EF4E1F /* library_posix.h */,
 				526F268B1D3B5CC300EF4E1F /* library_psp.h */,
 				526F268C1D3B5CC300EF4E1F /* library_windows.h */,
-				526F268D1D3B5CC300EF4E1F /* mutex.h */,
-				526F268E1D3B5CC300EF4E1F /* mutex_base.h */,
-				526F268F1D3B5CC300EF4E1F /* mutex_lock.h */,
-				526F26901D3B5CC300EF4E1F /* mutex_psp.h */,
-				526F26911D3B5CC300EF4E1F /* mutex_pthread.h */,
-				526F26921D3B5CC300EF4E1F /* mutex_wii.h */,
-				526F26931D3B5CC300EF4E1F /* mutex_windows.h */,
-				526F26941D3B5CC300EF4E1F /* scaling.h */,
-				526F26951D3B5CC300EF4E1F /* thread.h */,
-				526F26961D3B5CC300EF4E1F /* thread_psp.h */,
-				526F26971D3B5CC300EF4E1F /* thread_pthread.h */,
-				526F26981D3B5CC300EF4E1F /* thread_wii.h */,
-				526F26991D3B5CC300EF4E1F /* thread_windows.h */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -2773,6 +3493,11 @@
 		52D12C1B1D61C0950077B784 /* game */ = {
 			isa = PBXGroup;
 			children = (
+				20522A6628E8F92000589E91 /* savegame_components.cpp */,
+				20522A6528E8F92000589E91 /* savegame_components.h */,
+				20522A6828E8F92100589E91 /* savegame_v321.cpp */,
+				20522A6728E8F92000589E91 /* viewport.cpp */,
+				20522A6428E8F92000589E91 /* viewport.h */,
 				52F5D8561DA120F1006F8F4B /* game_init.cpp */,
 				52F5D8571DA120F1006F8F4B /* game_init.h */,
 				52D12C1C1D61C0950077B784 /* savegame.cpp */,
@@ -2791,47 +3516,50 @@
 			files = (
 				526F23CE1D3B5C4900EF4E1F /* datastream.h in Headers */,
 				526F27A51D3B5CC300EF4E1F /* debug_log.h in Headers */,
+				20E6840928F20C7300B95C00 /* envelope.h in Headers */,
 				526F28641D3B5CC300EF4E1F /* game_run.h in Headers */,
 				521C3BEE1D1E545100BD619E /* AGSKit.h in Headers */,
 				526F23E61D3B5C4900EF4E1F /* proxystream.h in Headers */,
 				526F27561D3B5CC300EF4E1F /* label.h in Headers */,
 				526F26EA1D3B5CC300EF4E1F /* scriptregion.h in Headers */,
+				20E67D9B28F1BDE000B95C00 /* allegro.h in Headers */,
 				526F27D61D3B5CC300EF4E1F /* guidialog.h in Headers */,
+				20E684AA28F20CC700B95C00 /* huffman.h in Headers */,
+				20E6840328F20C7300B95C00 /* registry.h in Headers */,
 				526F23F21D3B5C4900EF4E1F /* textstreamwriter.h in Headers */,
 				526F22CC1D3B5C4900EF4E1F /* agsfontrenderer.h in Headers */,
 				526F26D61D3B5CC300EF4E1F /* managedobjectpool.h in Headers */,
+				20E6840728F20C7300B95C00 /* lpc.h in Headers */,
+				20E684FC28F2189800B95C00 /* os_types.h in Headers */,
+				20E6852C28F2219B00B95C00 /* CharacterEntry.h in Headers */,
 				526F27121D3B5CC300EF4E1F /* global_game.h in Headers */,
 				526F27841D3B5CC300EF4E1F /* sprite.h in Headers */,
-				521C54F41D1E572B00BD619E /* VariableWidthFont.h in Headers */,
 				526F275D1D3B5CC300EF4E1F /* mouse.h in Headers */,
-				526F28991D3B5CC300EF4E1F /* override_defines.h in Headers */,
+				20522A0728E8F7FE00589E91 /* cc_internal.h in Headers */,
 				526F27661D3B5CC300EF4E1F /* parser.h in Headers */,
-				526F28821D3B5CC300EF4E1F /* clip_mymp3.h in Headers */,
 				526F273D1D3B5CC300EF4E1F /* global_video.h in Headers */,
-				526F22FD1D3B5C4900EF4E1F /* getblk.h in Headers */,
-				526F23E01D3B5C4900EF4E1F /* misc.h in Headers */,
-				526F22FF1D3B5C4900EF4E1F /* l2tables.h in Headers */,
+				2052299928E8EAE700589E91 /* keycode.h in Headers */,
 				526F27881D3B5CC300EF4E1F /* agsstaticobject.h in Headers */,
+				20522A7528E8F94100589E91 /* gfxfilter_sdl_renderer.h in Headers */,
 				526F22CE1D3B5C4900EF4E1F /* fonts.h in Headers */,
 				526F27CA1D3B5CC300EF4E1F /* gfxfilter_ogl.h in Headers */,
+				20522A9028E8FD6000589E91 /* plugin_engine.h in Headers */,
 				526F278B1D3B5CC300EF4E1F /* staticobject.h in Headers */,
 				526F27AB1D3B5CC300EF4E1F /* logfile.h in Headers */,
 				526F27A11D3B5CC300EF4E1F /* agseditordebugger.h in Headers */,
 				526F28981D3B5CC300EF4E1F /* agsplatformdriver.h in Headers */,
 				526F27041D3B5CC300EF4E1F /* global_datetime.h in Headers */,
 				526F28CF1D3B5CC300EF4E1F /* systemimports.h in Headers */,
+				20522A2F28E8F81C00589E91 /* android_file.h in Headers */,
 				526F23D41D3B5C4900EF4E1F /* filestream.h in Headers */,
-				526F28E71D3B5CC300EF4E1F /* thread.h in Headers */,
 				526F28921D3B5CC300EF4E1F /* soundclip.h in Headers */,
-				526F23001D3B5C4900EF4E1F /* libcda.h in Headers */,
 				526F26CE1D3B5CC300EF4E1F /* cc_inventory.h in Headers */,
 				526F22E41D3B5C4900EF4E1F /* guilabel.h in Headers */,
 				526F27281D3B5CC300EF4E1F /* global_parser.h in Headers */,
-				526F27F71D3B5CC300EF4E1F /* l2tables.h in Headers */,
-				526F276C1D3B5CC300EF4E1F /* record.h in Headers */,
 				526F28DB1D3B5CC300EF4E1F /* library_dummy.h in Headers */,
-				521C54F61D1E572B00BD619E /* VariableWidthSpriteFont.h in Headers */,
+				20E67DA328F1BDE000B95C00 /* alosxcfg.h in Headers */,
 				526F27431D3B5CC300EF4E1F /* global_walkablearea.h in Headers */,
+				20E684D128F20CC700B95C00 /* internal.h in Headers */,
 				526F230D1D3B5C4900EF4E1F /* theora.h in Headers */,
 				526F23101D3B5C4900EF4E1F /* codec.h in Headers */,
 				526F28621D3B5CC300EF4E1F /* game_file.h in Headers */,
@@ -2839,91 +3567,113 @@
 				526F27BC1D3B5CC300EF4E1F /* gfxdriverbase.h in Headers */,
 				526F22AE1D3B5C4900EF4E1F /* interfacebutton.h in Headers */,
 				526F22AC1D3B5C4900EF4E1F /* gamesetupstructbase.h in Headers */,
-				526F22F41D3B5C4900EF4E1F /* almp3.h in Headers */,
 				526F22A01D3B5C4900EF4E1F /* audiocliptype.h in Headers */,
+				20522A4928E8F8AA00589E91 /* draw_software.h in Headers */,
 				526F26C81D3B5CC300EF4E1F /* cc_gui.h in Headers */,
-				A3A4659E2866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.h in Headers */,
+				20522A3F28E8F86400589E91 /* scriptcamera.h in Headers */,
+				20E6840428F20C7300B95C00 /* mdct.h in Headers */,
+				20E67D8A28F1BDE000B95C00 /* cgfx.h in Headers */,
 				526F23D21D3B5C4900EF4E1F /* file.h in Headers */,
 				526F22C81D3B5C4900EF4E1F /* assert.h in Headers */,
-				526F23C11D3B5C4900EF4E1F /* cc_options.h in Headers */,
 				526F26E71D3B5CC300EF4E1F /* scriptobject.h in Headers */,
-				526F28E41D3B5CC300EF4E1F /* mutex_wii.h in Headers */,
-				526F28EA1D3B5CC300EF4E1F /* thread_wii.h in Headers */,
-				526F28E81D3B5CC300EF4E1F /* thread_psp.h in Headers */,
 				526F26CA1D3B5CC300EF4E1F /* cc_guiobject.h in Headers */,
+				20E67DA828F1BDE000B95C00 /* color.h in Headers */,
 				526F27351D3B5CC300EF4E1F /* global_string.h in Headers */,
 				526F26E41D3B5CC300EF4E1F /* scripthotspot.h in Headers */,
+				20E67DA628F1BDE000B95C00 /* aintern.h in Headers */,
+				20E6826328F1D2C400B95C00 /* mix.h in Headers */,
 				526F23F31D3B5C4900EF4E1F /* textwriter.h in Headers */,
+				20E67DA028F1BDE000B95C00 /* astdint.h in Headers */,
 				526F26CC1D3B5CC300EF4E1F /* cc_hotspot.h in Headers */,
 				526F27371D3B5CC300EF4E1F /* global_textbox.h in Headers */,
 				526F26FE1D3B5CC300EF4E1F /* global_audio.h in Headers */,
 				526F23E11D3B5C4900EF4E1F /* multifilelib.h in Headers */,
+				20522A9328E8FD7700589E91 /* sys_main.h in Headers */,
 				526F26F31D3B5CC300EF4E1F /* event.h in Headers */,
-				A3A4659F2866966D00AE0372 /* AGSSpriteFont.h in Headers */,
 				526F27D11D3B5CC300EF4E1F /* animatingguibutton.h in Headers */,
+				20E67DB428F1BDE000B95C00 /* draw.h in Headers */,
 				526F28781D3B5CC300EF4E1F /* audio.h in Headers */,
-				526F28881D3B5CC300EF4E1F /* clip_mystaticogg.h in Headers */,
-				521C54EE1D1E572B00BD619E /* color.h in Headers */,
+				20E6852828F2219A00B95C00 /* VariableWidthFont.h in Headers */,
+				20522A5E28E8F8DD00589E91 /* sys_events.h in Headers */,
+				20E67DB228F1BDE000B95C00 /* fli.h in Headers */,
 				526F23D61D3B5C4900EF4E1F /* geometry.h in Headers */,
 				526F272F1D3B5CC300EF4E1F /* global_room.h in Headers */,
 				526F26BC1D3B5CC300EF4E1F /* cc_audiochannel.h in Headers */,
-				526F28801D3B5CC300EF4E1F /* clip_mymidi.h in Headers */,
 				526F27611D3B5CC300EF4E1F /* object.h in Headers */,
+				20E6825F28F1D2C400B95C00 /* resample.h in Headers */,
 				526F22E81D3B5C4900EF4E1F /* guimain.h in Headers */,
 				526F23191D3B5C4900EF4E1F /* aautil.h in Headers */,
-				526F28D11D3B5CC300EF4E1F /* test_all.h in Headers */,
 				526F27061D3B5CC300EF4E1F /* global_debug.h in Headers */,
+				20E67D9C28F1BDE000B95C00 /* datafile.h in Headers */,
 				526F27221D3B5CC300EF4E1F /* global_object.h in Headers */,
 				526F22AA1D3B5C4900EF4E1F /* gamesetupstruct.h in Headers */,
-				526F22B91D3B5C4900EF4E1F /* roomstruct.h in Headers */,
 				526F27CD1D3B5CC300EF4E1F /* gfxmodelist.h in Headers */,
 				526F27721D3B5CC300EF4E1F /* room.h in Headers */,
+				20E67D8E28F1BDE000B95C00 /* cdefs24.h in Headers */,
+				20522A8928E8FD2B00589E91 /* sdl2_util.h in Headers */,
 				526F28B71D3B5CC300EF4E1F /* resource.h in Headers */,
-				521C54F21D1E572B00BD619E /* SpriteFontRenderer.h in Headers */,
 				526F27641D3B5CC300EF4E1F /* overlay.h in Headers */,
+				20522A4028E8F86400589E91 /* scriptcontainers.h in Headers */,
+				20E67D9328F1BDE000B95C00 /* cdefs15.h in Headers */,
+				20522A0528E8F7FE00589E91 /* cc_common.h in Headers */,
+				20E6828528F1D32D00B95C00 /* sdldecoder.h in Headers */,
+				20E6811928F1C98400B95C00 /* mpeg1dec.h in Headers */,
 				526F26D01D3B5CC300EF4E1F /* cc_object.h in Headers */,
+				20E6852728F2219A00B95C00 /* SpriteFontRenderer.h in Headers */,
 				526F276E1D3B5CC300EF4E1F /* region.h in Headers */,
+				20E6810628F1BE5D00B95C00 /* alc.h in Headers */,
 				526F22A81D3B5C4900EF4E1F /* game_version.h in Headers */,
-				526F28E01D3B5CC300EF4E1F /* mutex_base.h in Headers */,
-				521C54F01D1E572B00BD619E /* SpriteFont.h in Headers */,
 				526F22BF1D3B5C4900EF4E1F /* wordsdictionary.h in Headers */,
+				20E6811528F1C98400B95C00 /* l2tables.h in Headers */,
 				526F27E31D3B5CC300EF4E1F /* newcontrol.h in Headers */,
 				526F22C21D3B5C4900EF4E1F /* asset.h in Headers */,
 				526F22C41D3B5C4900EF4E1F /* assetmanager.h in Headers */,
 				526F26E51D3B5CC300EF4E1F /* scriptinvitem.h in Headers */,
 				526F27B91D3B5CC300EF4E1F /* gfx_util.h in Headers */,
+				20E683E128F20C7200B95C00 /* masking.h in Headers */,
+				20522A3E28E8F86400589E91 /* cc_dynamicobject_addr_and_manager.h in Headers */,
+				20522A3C28E8F86400589E91 /* scriptviewport.h in Headers */,
 				526F27A31D3B5CC300EF4E1F /* consoleoutputtarget.h in Headers */,
+				20522A3128E8F81C00589E91 /* aasset_stream.h in Headers */,
+				20E67DB028F1BDE000B95C00 /* palette.h in Headers */,
 				526F26D21D3B5CC300EF4E1F /* cc_region.h in Headers */,
 				526F269B1D3B5CC300EF4E1F /* audiochannel.h in Headers */,
+				20E6840D28F20C7300B95C00 /* misc.h in Headers */,
 				526F269F1D3B5CC300EF4E1F /* button.h in Headers */,
-				526F28DF1D3B5CC300EF4E1F /* mutex.h in Headers */,
+				20E6823A28F1D2B400B95C00 /* tables.h in Headers */,
 				526F27CC1D3B5CC300EF4E1F /* gfxfilter_scaling.h in Headers */,
 				526F26DA1D3B5CC300EF4E1F /* scriptdialog.h in Headers */,
 				526F26C61D3B5CC300EF4E1F /* cc_dynamicobject.h in Headers */,
 				526F26E91D3B5CC300EF4E1F /* scriptoverlay.h in Headers */,
+				20522A5528E8F8CB00589E91 /* path_helper.h in Headers */,
 				526F276A1D3B5CC300EF4E1F /* properties.h in Headers */,
+				20E6811B28F1C98400B95C00 /* getbits.h in Headers */,
+				20E67D9D28F1BDE000B95C00 /* debug.h in Headers */,
+				20E6811628F1C98400B95C00 /* getblk.h in Headers */,
+				20E683FC28F20C7300B95C00 /* scales.h in Headers */,
 				526F285C1D3B5CC300EF4E1F /* config.h in Headers */,
+				20E6828328F1D32D00B95C00 /* audio_core.h in Headers */,
+				20E6840028F20C7300B95C00 /* os.h in Headers */,
 				526F22E21D3B5C4900EF4E1F /* guiinv.h in Headers */,
+				205229BE28E8ECE200589E91 /* alfont.h in Headers */,
 				526F27571D3B5CC300EF4E1F /* lipsync.h in Headers */,
-				526F22F61D3B5C4900EF4E1F /* alogg.h in Headers */,
+				20E6826728F1D2C400B95C00 /* playmidi.h in Headers */,
 				526F27961D3B5CC300EF4E1F /* translation.h in Headers */,
 				526F22CA1D3B5C4900EF4E1F /* out.h in Headers */,
+				20E6822F28F1D2B400B95C00 /* libmodplug.h in Headers */,
 				526F28701D3B5CC300EF4E1F /* quit.h in Headers */,
 				526F27D31D3B5CC300EF4E1F /* cscidialog.h in Headers */,
 				526F22B41D3B5C4900EF4E1F /* mousecursor.h in Headers */,
-				526F22F51D3B5C4900EF4E1F /* almp3dll.h in Headers */,
-				526F272B1D3B5CC300EF4E1F /* global_record.h in Headers */,
 				526F28721D3B5CC300EF4E1F /* update.h in Headers */,
 				526F28CD1D3B5CC300EF4E1F /* script_runtime.h in Headers */,
 				52F5D8531DA120CB006F8F4B /* main_game_file.h in Headers */,
-				526F279C1D3B5CC300EF4E1F /* viewport.h in Headers */,
+				20E684F728F2189800B95C00 /* ogg.h in Headers */,
 				526F277A1D3B5CC300EF4E1F /* runtime_defines.h in Headers */,
-				526F28901D3B5CC300EF4E1F /* soundcache.h in Headers */,
+				20E6849A28F20CC700B95C00 /* quant.h in Headers */,
 				526F22DC1D3B5C4900EF4E1F /* bitmap.h in Headers */,
-				526F23021D3B5C4900EF4E1F /* mpg123.h in Headers */,
-				526F22B71D3B5C4900EF4E1F /* point.h in Headers */,
 				521C54DC1D1E572B00BD619E /* agsflashlight.h in Headers */,
 				526F22DA1D3B5C4900EF4E1F /* allegrobitmap.h in Headers */,
+				20E6847F28F20CC700B95C00 /* huffdec.h in Headers */,
 				526F27491D3B5CC300EF4E1F /* guicontrol.h in Headers */,
 				526F285E1D3B5CC300EF4E1F /* engine.h in Headers */,
 				526F27311D3B5CC300EF4E1F /* global_screen.h in Headers */,
@@ -2936,68 +3686,73 @@
 				526F27BA1D3B5CC300EF4E1F /* gfxdefines.h in Headers */,
 				526F22C51D3B5C4900EF4E1F /* def_version.h in Headers */,
 				526F28601D3B5CC300EF4E1F /* engine_setup.h in Headers */,
-				526F23011D3B5C4900EF4E1F /* mpeg1dec.h in Headers */,
+				20E6827828F1D2C400B95C00 /* instrum.h in Headers */,
 				526F28681D3B5CC300EF4E1F /* graphics_mode.h in Headers */,
-				526F28861D3B5CC300EF4E1F /* clip_mystaticmp3.h in Headers */,
+				20522A2A28E8F81C00589E91 /* utf8.h in Headers */,
 				526F22AF1D3B5C4900EF4E1F /* interfaceelement.h in Headers */,
 				526F275F1D3B5CC300EF4E1F /* movelist.h in Headers */,
 				526F27161D3B5CC300EF4E1F /* global_hotspot.h in Headers */,
 				526F23CC1D3B5C4900EF4E1F /* compress.h in Headers */,
-				526F27C41D3B5CC300EF4E1F /* gfxfilter_allegro.h in Headers */,
 				526F23C31D3B5C4900EF4E1F /* cc_script.h in Headers */,
 				526F26B41D3B5CC300EF4E1F /* drawingsurface.h in Headers */,
-				526F27681D3B5CC300EF4E1F /* path.h in Headers */,
 				526F23C91D3B5C4900EF4E1F /* alignedstream.h in Headers */,
-				526F22FC1D3B5C4900EF4E1F /* getbits.h in Headers */,
 				526F27201D3B5CC300EF4E1F /* global_mouse.h in Headers */,
+				20E6811A28F1C98400B95C00 /* huffman.h in Headers */,
+				20E67DAE28F1BDE000B95C00 /* fmaths.h in Headers */,
 				526F28DA1D3B5CC300EF4E1F /* library.h in Headers */,
 				526F26F11D3B5CC300EF4E1F /* scriptviewframe.h in Headers */,
-				526F27CF1D3B5CC300EF4E1F /* hq2x3x.h in Headers */,
-				526F27701D3B5CC300EF4E1F /* richgamemedia.h in Headers */,
+				20E683D428F20C7200B95C00 /* highlevel.h in Headers */,
+				20E6811728F1C98400B95C00 /* mpg123.h in Headers */,
 				526F27D91D3B5CC300EF4E1F /* mycontrols.h in Headers */,
+				205229AD28E8EBE500589E91 /* tra_file.h in Headers */,
 				526F27B31D3B5CC300EF4E1F /* ali3dsw.h in Headers */,
+				20E67D9428F1BDE000B95C00 /* cdefs8.h in Headers */,
+				20E67D9028F1BDE000B95C00 /* cspr.h in Headers */,
 				526F22DF1D3B5C4900EF4E1F /* guibutton.h in Headers */,
+				20522A5428E8F8CB00589E91 /* route_finder_impl_legacy.h in Headers */,
+				20E6810528F1BE5D00B95C00 /* al.h in Headers */,
 				526F22C71D3B5C4900EF4E1F /* types.h in Headers */,
 				526F22A71D3B5C4900EF4E1F /* scriptaudioclip.h in Headers */,
-				526F28E91D3B5CC300EF4E1F /* thread_pthread.h in Headers */,
 				526F278D1D3B5CC300EF4E1F /* string.h in Headers */,
 				526F26AB1D3B5CC300EF4E1F /* dialog.h in Headers */,
-				526F286B1D3B5CC300EF4E1F /* main_allegro.h in Headers */,
 				526F27CE1D3B5CC300EF4E1F /* graphicsdriver.h in Headers */,
 				526F27AF1D3B5CC300EF4E1F /* ali3dexception.h in Headers */,
-				521C54EC1D1E572B00BD619E /* CharacterEntry.h in Headers */,
 				526F27291D3B5CC300EF4E1F /* global_plugin.h in Headers */,
-				526F28841D3B5CC300EF4E1F /* clip_myogg.h in Headers */,
 				526F27391D3B5CC300EF4E1F /* global_timer.h in Headers */,
 				526F26C41D3B5CC300EF4E1F /* cc_dynamicarray.h in Headers */,
 				526F27931D3B5CC300EF4E1F /* timer.h in Headers */,
+				205229A128E8EBA900589E91 /* outputhandler.h in Headers */,
+				20522A2B28E8F81C00589E91 /* scaling.h in Headers */,
 				526F23ED1D3B5C4900EF4E1F /* string_utils.h in Headers */,
 				526F279A1D3B5CC300EF4E1F /* viewframe.h in Headers */,
 				526F28791D3B5CC300EF4E1F /* audiodefines.h in Headers */,
 				526F22BD1D3B5C4900EF4E1F /* view.h in Headers */,
 				526F27141D3B5CC300EF4E1F /* global_gui.h in Headers */,
-				526F22FB1D3B5C4900EF4E1F /* genre.h in Headers */,
+				20522A4B28E8F8AA00589E91 /* asset_helper.h in Headers */,
 				526F28661D3B5CC300EF4E1F /* game_start.h in Headers */,
 				526F27531D3B5CC300EF4E1F /* invwindow.h in Headers */,
 				526F278A1D3B5CC300EF4E1F /* staticarray.h in Headers */,
-				526F27F51D3B5CC300EF4E1F /* huffman.h in Headers */,
 				526F26DC1D3B5CC300EF4E1F /* scriptdialogoptionsrendering.h in Headers */,
 				526F27411D3B5CC300EF4E1F /* global_viewport.h in Headers */,
 				526F27331D3B5CC300EF4E1F /* global_slider.h in Headers */,
 				526F22D41D3B5C4900EF4E1F /* wfnfontrenderer.h in Headers */,
+				20E6840228F20C7300B95C00 /* lsp.h in Headers */,
 				526F26D41D3B5CC300EF4E1F /* cc_serializer.h in Headers */,
-				526F28E51D3B5CC300EF4E1F /* mutex_windows.h in Headers */,
 				526F22BB1D3B5C4900EF4E1F /* spritecache.h in Headers */,
+				20522A8228E8F98400589E91 /* khrplatform.h in Headers */,
 				526F279E1D3B5CC300EF4E1F /* walkablearea.h in Headers */,
 				526F28B31D3B5CC300EF4E1F /* pluginobjectreader.h in Headers */,
 				526F26C21D3B5CC300EF4E1F /* cc_dialog.h in Headers */,
-				526F22CB1D3B5C4900EF4E1F /* outputtarget.h in Headers */,
 				526F22D61D3B5C4900EF4E1F /* customproperties.h in Headers */,
-				526F28A51D3B5CC300EF4E1F /* pe.h in Headers */,
 				526F23141D3B5C4900EF4E1F /* vorbisfile.h in Headers */,
 				526F26BA1D3B5CC300EF4E1F /* cc_agsdynamicobject.h in Headers */,
+				20E6840A28F20C7300B95C00 /* codebook.h in Headers */,
 				526F27911D3B5CC300EF4E1F /* textbox.h in Headers */,
+				20E6828628F1D32D00B95C00 /* openalsource.h in Headers */,
+				20522A7428E8F94100589E91 /* gfxfilter_aaogl.h in Headers */,
+				20522A1F28E8F81C00589E91 /* memorystream.h in Headers */,
 				526F26B71D3B5CC300EF4E1F /* all_dynamicclasses.h in Headers */,
+				20E683C528F20C7200B95C00 /* window.h in Headers */,
 				526F22EE1D3B5C4900EF4E1F /* guitextbox.h in Headers */,
 				526F27DB1D3B5CC300EF4E1F /* mylabel.h in Headers */,
 				526F26E21D3B5CC300EF4E1F /* scriptfile.h in Headers */,
@@ -3005,76 +3760,91 @@
 				521C54FF1D1E572B00BD619E /* agstouch.h in Headers */,
 				526F275B1D3B5CC300EF4E1F /* math.h in Headers */,
 				526F230A1D3B5C4900EF4E1F /* codec.h in Headers */,
-				526F23BF1D3B5C4900EF4E1F /* cc_error.h in Headers */,
 				526F286A1D3B5CC300EF4E1F /* main.h in Headers */,
 				526F26E31D3B5CC300EF4E1F /* scriptgui.h in Headers */,
+				20E67DAF28F1BDE000B95C00 /* unicode.h in Headers */,
+				20E6826C28F1D2C400B95C00 /* output.h in Headers */,
 				526F26B21D3B5CC300EF4E1F /* draw.h in Headers */,
 				526F22A31D3B5C4900EF4E1F /* common.h in Headers */,
-				526F288A1D3B5CC300EF4E1F /* clip_mywave.h in Headers */,
-				526F286C1D3B5CC300EF4E1F /* maindefines_ex.h in Headers */,
 				526F22E01D3B5C4900EF4E1F /* guidefines.h in Headers */,
-				A3A4659D2866966D00AE0372 /* SpriteFontRendererClifftopGames.h in Headers */,
+				20E67D8B28F1BDE000B95C00 /* cdefs16.h in Headers */,
+				20E683DE28F20C7200B95C00 /* lookup.h in Headers */,
 				521C54D31D1E572B00BD619E /* agsblend.h in Headers */,
-				526F22F31D3B5C4900EF4E1F /* alfontdll.h in Headers */,
 				526F27821D3B5CC300EF4E1F /* speech.h in Headers */,
 				526F27021D3B5CC300EF4E1F /* global_character.h in Headers */,
 				526F27101D3B5CC300EF4E1F /* global_file.h in Headers */,
 				526F274C1D3B5CC300EF4E1F /* hotspot.h in Headers */,
 				52D12C211D61C0950077B784 /* savegame_internal.h in Headers */,
+				20E683DB28F20C7200B95C00 /* backends.h in Headers */,
 				521C54C11D1E572B00BD619E /* ags_parallax.h in Headers */,
 				526F26B61D3B5CC300EF4E1F /* dynamicsprite.h in Headers */,
 				526F23EE1D3B5C4900EF4E1F /* textreader.h in Headers */,
-				526F286D1D3B5CC300EF4E1F /* mainheader.h in Headers */,
+				20522A6928E8F92100589E91 /* viewport.h in Headers */,
+				20522A3028E8F81C00589E91 /* bufferedstream.h in Headers */,
+				20E67D7F28F1BDE000B95C00 /* cblit.h in Headers */,
+				20E6853428F2219B00B95C00 /* VariableWidthSpriteFontClifftopGames.h in Headers */,
 				52F5D8651DA121CC006F8F4B /* version.h in Headers */,
-				526F28EB1D3B5CC300EF4E1F /* thread_windows.h in Headers */,
-				526F22F71D3B5C4900EF4E1F /* aloggdll.h in Headers */,
+				20E6826F28F1D2C400B95C00 /* tables.h in Headers */,
 				52D12C201D61C0950077B784 /* savegame.h in Headers */,
+				20522A2128E8F81C00589E91 /* memory_compat.h in Headers */,
 				526F26EC1D3B5CC300EF4E1F /* scriptstring.h in Headers */,
 				526F22D81D3B5C4900EF4E1F /* interactions.h in Headers */,
-				526F22B21D3B5C4900EF4E1F /* messageinfo.h in Headers */,
+				20E6822628F1D2B400B95C00 /* modplug.h in Headers */,
+				20E6828428F1D32D00B95C00 /* audio_system.h in Headers */,
+				20E67D8628F1BDE000B95C00 /* cdefs32.h in Headers */,
 				526F26ED1D3B5CC300EF4E1F /* scriptsystem.h in Headers */,
 				526F26E61D3B5CC300EF4E1F /* scriptmouse.h in Headers */,
 				526F27001D3B5CC300EF4E1F /* global_button.h in Headers */,
+				20E683E028F20C7200B95C00 /* bitrate.h in Headers */,
+				20522A8328E8F98400589E91 /* glad.h in Headers */,
 				526F28C41D3B5CC300EF4E1F /* nonblockingscriptfunction.h in Headers */,
 				526F270A1D3B5CC300EF4E1F /* global_display.h in Headers */,
 				526F27C21D3B5CC300EF4E1F /* gfxfilter_aad3d.h in Headers */,
 				526F22EA1D3B5C4900EF4E1F /* guiobject.h in Headers */,
+				20522A6A28E8F92100589E91 /* savegame_components.h in Headers */,
+				20522A7628E8F94100589E91 /* ogl_headers.h in Headers */,
 				526F273B1D3B5CC300EF4E1F /* global_translation.h in Headers */,
 				526F27B51D3B5CC300EF4E1F /* blender.h in Headers */,
 				52F5D8551DA120D9006F8F4B /* plugininfo.h in Headers */,
+				205229B028E8EBE500589E91 /* roomstruct.h in Headers */,
+				20522A6228E8F8FD00589E91 /* messagebuffer.h in Headers */,
 				526F26AD1D3B5CC300EF4E1F /* dialogoptionsrendering.h in Headers */,
 				526F27751D3B5CC300EF4E1F /* roomobject.h in Headers */,
+				20E6853828F2219B00B95C00 /* AGSSpriteFont.h in Headers */,
 				526F27C01D3B5CC300EF4E1F /* gfxfilter.h in Headers */,
 				526F230E1D3B5C4900EF4E1F /* theoradec.h in Headers */,
-				526F229E1D3B5C4900EF4E1F /* animationstruct.h in Headers */,
-				526F22F81D3B5C4900EF4E1F /* apeg.h in Headers */,
+				20522A4128E8F86400589E91 /* scriptdict.h in Headers */,
 				526F28DE1D3B5CC300EF4E1F /* library_windows.h in Headers */,
+				20E67DB128F1BDE000B95C00 /* gfx.h in Headers */,
+				20E6853228F2219B00B95C00 /* SpriteFont.h in Headers */,
 				526F27A01D3B5CC300EF4E1F /* walkbehind.h in Headers */,
 				526F22A41D3B5C4900EF4E1F /* common_defines.h in Headers */,
-				526F23031D3B5C4900EF4E1F /* mpglib.h in Headers */,
+				20522A2E28E8F81C00589E91 /* cmdlineopts.h in Headers */,
 				526F27D71D3B5CC300EF4E1F /* guidialogdefines.h in Headers */,
-				526F28951D3B5CC300EF4E1F /* VMR9Graph.h in Headers */,
+				205229AC28E8EBE500589E91 /* room_file.h in Headers */,
+				20E6848628F20CC700B95C00 /* bitpack.h in Headers */,
 				526F23D81D3B5C4900EF4E1F /* ini_util.h in Headers */,
-				526F27981D3B5CC300EF4E1F /* tree_map.h in Headers */,
+				20E6852B28F2219B00B95C00 /* SpriteFontRendererClifftopGames.h in Headers */,
+				20E67D9F28F1BDE000B95C00 /* file.h in Headers */,
 				526F288C1D3B5CC300EF4E1F /* queuedaudioitem.h in Headers */,
 				526F27A91D3B5CC300EF4E1F /* filebasedagsdebugger.h in Headers */,
 				526F271C1D3B5CC300EF4E1F /* global_label.h in Headers */,
-				526F23081D3B5C4900EF4E1F /* OGG.H in Headers */,
-				526F28E11D3B5CC300EF4E1F /* mutex_lock.h in Headers */,
+				20E6854728F221CA00B95C00 /* agspalrender.h in Headers */,
 				526F26E01D3B5CC300EF4E1F /* scriptdynamicsprite.h in Headers */,
 				526F28C31D3B5CC300EF4E1F /* exports.h in Headers */,
 				526F28C11D3B5CC300EF4E1F /* executingscript.h in Headers */,
 				526F23D01D3B5C4900EF4E1F /* directory.h in Headers */,
 				526F23EB1D3B5C4900EF4E1F /* string_types.h in Headers */,
 				526F27E11D3B5CC300EF4E1F /* mytextbox.h in Headers */,
+				20E6854D28F221CA00B95C00 /* raycast.h in Headers */,
 				526F27771D3B5CC300EF4E1F /* roomstatus.h in Headers */,
 				526F27081D3B5CC300EF4E1F /* global_dialog.h in Headers */,
 				526F22E61D3B5C4900EF4E1F /* guilistbox.h in Headers */,
-				526F22F21D3B5C4900EF4E1F /* alfont.h in Headers */,
 				526F27591D3B5CC300EF4E1F /* listbox.h in Headers */,
 				526F23CA1D3B5C4900EF4E1F /* bbop.h in Headers */,
+				20522A1E28E8F81C00589E91 /* stdio_compat.h in Headers */,
+				20E6827528F1D2C400B95C00 /* readmidi.h in Headers */,
 				526F26B01D3B5CC300EF4E1F /* display.h in Headers */,
-				526F27621D3B5CC300EF4E1F /* objectcache.h in Headers */,
 				526F26DE1D3B5CC300EF4E1F /* scriptdrawingsurface.h in Headers */,
 				521C54CA1D1E572B00BD619E /* ags_snowrain.h in Headers */,
 				526F27B71D3B5CC300EF4E1F /* ddb.h in Headers */,
@@ -3083,86 +3853,99 @@
 				526F26A31D3B5CC300EF4E1F /* character.h in Headers */,
 				526F22D21D3B5C4900EF4E1F /* wfnfont.h in Headers */,
 				526F22A11D3B5C4900EF4E1F /* characterinfo.h in Headers */,
-				526F26A41D3B5CC300EF4E1F /* charactercache.h in Headers */,
 				526F23F01D3B5C4900EF4E1F /* textstreamreader.h in Headers */,
-				526F28E61D3B5CC300EF4E1F /* scaling.h in Headers */,
 				526F22B01D3B5C4900EF4E1F /* inventoryiteminfo.h in Headers */,
-				526F28E21D3B5CC300EF4E1F /* mutex_psp.h in Headers */,
 				526F271E1D3B5CC300EF4E1F /* global_listbox.h in Headers */,
-				526F22C61D3B5C4900EF4E1F /* endianness.h in Headers */,
-				526F23C51D3B5C4900EF4E1F /* cc_treemap.h in Headers */,
+				20E6811428F1C98400B95C00 /* apeg.h in Headers */,
 				526F27181D3B5CC300EF4E1F /* global_inventoryitem.h in Headers */,
+				20522A2228E8F81C00589E91 /* error.h in Headers */,
 				526F27C61D3B5CC300EF4E1F /* gfxfilter_d3d.h in Headers */,
+				20522A2028E8F81C00589E91 /* data_ext.h in Headers */,
 				526F22F01D3B5C4900EF4E1F /* aautil.h in Headers */,
+				2052299B28E8EB5600589E91 /* platform.h in Headers */,
 				526F27BE1D3B5CC300EF4E1F /* gfxdriverfactory.h in Headers */,
 				526F23EA1D3B5C4900EF4E1F /* string.h in Headers */,
 				526F23171D3B5C4900EF4E1F /* aastr.h in Headers */,
+				20E6837228F20BFD00B95C00 /* crctable.h in Headers */,
 				526F270C1D3B5CC300EF4E1F /* global_drawingsurface.h in Headers */,
 				526F288E1D3B5CC300EF4E1F /* sound.h in Headers */,
 				526F28941D3B5CC300EF4E1F /* video.h in Headers */,
 				526F27241D3B5CC300EF4E1F /* global_overlay.h in Headers */,
-				526F27FB1D3B5CC300EF4E1F /* mpglib.h in Headers */,
+				20E6828828F1D32D00B95C00 /* openal.h in Headers */,
 				526F27941D3B5CC300EF4E1F /* topbarsettings.h in Headers */,
-				526F22FE1D3B5C4900EF4E1F /* huffman.h in Headers */,
 				526F277E1D3B5CC300EF4E1F /* screenoverlay.h in Headers */,
 				526F26F51D3B5CC300EF4E1F /* file.h in Headers */,
 				526F277C1D3B5CC300EF4E1F /* screen.h in Headers */,
 				526F22C01D3B5C4900EF4E1F /* stream_api.h in Headers */,
-				526F287E1D3B5CC300EF4E1F /* clip_myjgmod.h in Headers */,
+				20E6827228F1D2C400B95C00 /* common.h in Headers */,
 				526F23E41D3B5C4900EF4E1F /* path.h in Headers */,
+				20E6826A28F1D2C400B95C00 /* options.h in Headers */,
 				526F22DD1D3B5C4900EF4E1F /* gfx_def.h in Headers */,
+				20E683FD28F20C7300B95C00 /* smallft.h in Headers */,
+				20E6854628F221CA00B95C00 /* palrender.h in Headers */,
+				20E684AF28F20CC700B95C00 /* state.h in Headers */,
 				526F26BE1D3B5CC300EF4E1F /* cc_audioclip.h in Headers */,
 				526F26F71D3B5CC300EF4E1F /* game.h in Headers */,
+				20E683C828F20C7200B95C00 /* lookup_data.h in Headers */,
 				526F230F1D3B5C4900EF4E1F /* theoraenc.h in Headers */,
-				526F28E31D3B5CC300EF4E1F /* mutex_pthread.h in Headers */,
+				20E683C628F20C7200B95C00 /* psy.h in Headers */,
 				526F269D1D3B5CC300EF4E1F /* audioclip.h in Headers */,
+				205229B128E8EBE500589E91 /* room_version.h in Headers */,
 				526F27BF1D3B5CC300EF4E1F /* gfxdriverfactorybase.h in Headers */,
+				2052299628E8EAE700589E91 /* spritefile.h in Headers */,
 				526F22EC1D3B5C4900EF4E1F /* guislider.h in Headers */,
-				526F27C81D3B5CC300EF4E1F /* gfxfilter_hqx.h in Headers */,
 				526F22EF1D3B5C4900EF4E1F /* aastr.h in Headers */,
+				205229A028E8EBA900589E91 /* debugmanager.h in Headers */,
 				526F27D81D3B5CC300EF4E1F /* guidialoginternaldefs.h in Headers */,
 				526F27DF1D3B5CC300EF4E1F /* mypushbutton.h in Headers */,
+				20E67DB328F1BDE000B95C00 /* system.h in Headers */,
 				526F23131D3B5C4900EF4E1F /* vorbisenc.h in Headers */,
 				526F27501D3B5CC300EF4E1F /* inventoryitem.h in Headers */,
+				20E6840628F20C7300B95C00 /* codec_internal.h in Headers */,
 				526F23DD1D3B5C4900EF4E1F /* math.h in Headers */,
+				20522A2828E8F81C00589E91 /* string_compat.h in Headers */,
+				20E6852D28F2219B00B95C00 /* color.h in Headers */,
+				20E684B928F20CC700B95C00 /* dequant.h in Headers */,
+				20E6811828F1C98400B95C00 /* common.h in Headers */,
 				526F278F1D3B5CC300EF4E1F /* system.h in Headers */,
-				526F22F91D3B5C4900EF4E1F /* common.h in Headers */,
 				526F27801D3B5CC300EF4E1F /* slider.h in Headers */,
 				526F27471D3B5CC300EF4E1F /* gui.h in Headers */,
 				526F27A61D3B5CC300EF4E1F /* debugger.h in Headers */,
-				526F23C71D3B5C4900EF4E1F /* script_common.h in Headers */,
 				526F272D1D3B5CC300EF4E1F /* global_region.h in Headers */,
 				526F26F91D3B5CC300EF4E1F /* gamesetup.h in Headers */,
 				526F22AD1D3B5C4900EF4E1F /* gamestructdefines.h in Headers */,
+				20E6852628F2219A00B95C00 /* VariableWidthSpriteFont.h in Headers */,
 				526F28DD1D3B5CC300EF4E1F /* library_psp.h in Headers */,
+				20E684BA28F20CC700B95C00 /* apiwrapper.h in Headers */,
 				526F27DD1D3B5CC300EF4E1F /* mylistbox.h in Headers */,
 				526F22B51D3B5C4900EF4E1F /* oldgamesetupstruct.h in Headers */,
 				526F26A91D3B5CC300EF4E1F /* datetime.h in Headers */,
 				526F23DE1D3B5C4900EF4E1F /* memory.h in Headers */,
 				526F26A61D3B5CC300EF4E1F /* characterextras.h in Headers */,
-				526F287C1D3B5CC300EF4E1F /* clip_mydumbmod.h in Headers */,
 				526F28B01D3B5CC300EF4E1F /* agsplugin.h in Headers */,
+				20E6826B28F1D2C400B95C00 /* timidity.h in Headers */,
 				52F5D8591DA120F1006F8F4B /* game_init.h in Headers */,
 				526F26C01D3B5CC300EF4E1F /* cc_character.h in Headers */,
 				526F28761D3B5CC300EF4E1F /* ambientsound.h in Headers */,
-				526F27541D3B5CC300EF4E1F /* keycode.h in Headers */,
+				20E67DA728F1BDE000B95C00 /* alconfig.h in Headers */,
 				526F273F1D3B5CC300EF4E1F /* global_viewframe.h in Headers */,
 				526F26A11D3B5CC300EF4E1F /* cdaudio.h in Headers */,
+				20E67D9E28F1BDE000B95C00 /* fixed.h in Headers */,
 				526F26B81D3B5CC300EF4E1F /* all_scriptclasses.h in Headers */,
 				526F271A1D3B5CC300EF4E1F /* global_invwindow.h in Headers */,
 				526F22A51D3B5C4900EF4E1F /* dialogtopic.h in Headers */,
 				526F28CA1D3B5CC300EF4E1F /* script_api.h in Headers */,
 				526F28C81D3B5CC300EF4E1F /* script.h in Headers */,
+				20522A5728E8F8CB00589E91 /* route_finder_impl.h in Headers */,
 				526F270E1D3B5CC300EF4E1F /* global_dynamicsprite.h in Headers */,
-				526F23041D3B5C4900EF4E1F /* config_types.h in Headers */,
 				526F26D71D3B5CC300EF4E1F /* scriptaudiochannel.h in Headers */,
 				526F23DA1D3B5C4900EF4E1F /* inifile.h in Headers */,
+				20E67DB528F1BDE000B95C00 /* base.h in Headers */,
 				526F27791D3B5CC300EF4E1F /* route_finder.h in Headers */,
 				526F26EF1D3B5CC300EF4E1F /* scriptuserobject.h in Headers */,
-				526F23091D3B5C4900EF4E1F /* OS_TYPES.H in Headers */,
 				526F27A71D3B5CC300EF4E1F /* dummyagsdebugger.h in Headers */,
-				526F27FA1D3B5CC300EF4E1F /* mpg123.h in Headers */,
 				526F23DC1D3B5C4900EF4E1F /* lzw.h in Headers */,
+				20522A4328E8F86400589E91 /* scriptset.h in Headers */,
 				526F23F51D3B5C4900EF4E1F /* wgt2allg.h in Headers */,
 				526F23E81D3B5C4900EF4E1F /* stream.h in Headers */,
 			);
@@ -3195,7 +3978,7 @@
 		521C3BE11D1E545100BD619E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = "Adventure Game Studio";
 				TargetAttributes = {
 					521C3BE91D1E545100BD619E = {
@@ -3226,37 +4009,20 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				526F28031D3B5CC300EF4E1F /* COPYING.txt in Resources */,
-				526F230C1D3B5C4900EF4E1F /* Makefile.in in Resources */,
-				526F28041D3B5CC300EF4E1F /* README.txt in Resources */,
+				20C76AB528F34A1900772CFC /* include in Resources */,
 				526F28BA1D3B5CC300EF4E1F /* tintshaderLegacy.fx in Resources */,
-				526F281E1D3B5CC300EF4E1F /* vssver2.scc in Resources */,
-				526F27E71D3B5CC300EF4E1F /* FTL.txt in Resources */,
 				526F28BB1D3B5CC300EF4E1F /* tintshaderLegacy.fxo in Resources */,
-				526F27FC1D3B5CC300EF4E1F /* README in Resources */,
-				526F28061D3B5CC300EF4E1F /* apeg.txt in Resources */,
-				526F28011D3B5CC300EF4E1F /* AUTHORS.txt in Resources */,
 				526F28B41D3B5CC300EF4E1F /* CompileShader.bat in Resources */,
+				20E67DAB28F1BDE000B95C00 /* fmaths.inl in Resources */,
 				526F28B61D3B5CC300EF4E1F /* game-1.ICO in Resources */,
-				526F27E61D3B5CC300EF4E1F /* AUTHORS.txt in Resources */,
-				526F284C1D3B5CC300EF4E1F /* vssver2.scc in Resources */,
-				526F28001D3B5CC300EF4E1F /* ALOGG.txt in Resources */,
-				526F27E51D3B5CC300EF4E1F /* ALFONT.txt in Resources */,
 				526F28B91D3B5CC300EF4E1F /* tintshader.fxo in Resources */,
+				20E67DA928F1BDE000B95C00 /* draw.inl in Resources */,
+				20E67DAD28F1BDE000B95C00 /* fix.inl in Resources */,
 				526F28B81D3B5CC300EF4E1F /* tintshader.fx in Resources */,
-				526F23071D3B5C4900EF4E1F /* MAKEFILE.IN in Resources */,
+				20E67DAA28F1BDE000B95C00 /* gfx.inl in Resources */,
 				526F28BC1D3B5CC300EF4E1F /* version.rc in Resources */,
-				526F230B1D3B5C4900EF4E1F /* Makefile.am in Resources */,
-				526F27FE1D3B5CC300EF4E1F /* vssver2.scc in Resources */,
-				526F23121D3B5C4900EF4E1F /* Makefile.in in Resources */,
-				526F23111D3B5C4900EF4E1F /* Makefile.am in Resources */,
-				526F231A1D3B5C4900EF4E1F /* vssver2.scc in Resources */,
-				526F23051D3B5C4900EF4E1F /* config_types.h.in in Resources */,
-				526F28B51D3B5CC300EF4E1F /* DefaultGDF.gdf.xml in Resources */,
-				526F27E81D3B5CC300EF4E1F /* README.txt in Resources */,
-				526F28141D3B5CC300EF4E1F /* vssver2.scc in Resources */,
-				526F28021D3B5CC300EF4E1F /* CHANGES.txt in Resources */,
-				526F23061D3B5C4900EF4E1F /* MAKEFILE.AM in Resources */,
+				20522A5628E8F8CB00589E91 /* route_finder_jps.inl in Resources */,
+				20E67DAC28F1BDE000B95C00 /* color.inl in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3269,291 +4035,437 @@
 			files = (
 				526F274A1D3B5CC300EF4E1F /* guiinv.cpp in Sources */,
 				526F274B1D3B5CC300EF4E1F /* hotspot.cpp in Sources */,
+				20E67D6628F1BDE000B95C00 /* blit.c in Sources */,
 				526F23E51D3B5C4900EF4E1F /* proxystream.cpp in Sources */,
 				526F26A81D3B5CC300EF4E1F /* datetime.cpp in Sources */,
-				526F27FD1D3B5CC300EF4E1F /* tabinit.c in Sources */,
+				20E6840828F20C7300B95C00 /* codebook.c in Sources */,
 				526F27871D3B5CC300EF4E1F /* agsstaticobject.cpp in Sources */,
-				526F27F11D3B5CC300EF4E1F /* almp3.c in Sources */,
 				526F23E71D3B5C4900EF4E1F /* stream.cpp in Sources */,
 				526F277D1D3B5CC300EF4E1F /* screenoverlay.cpp in Sources */,
 				526F22BE1D3B5C4900EF4E1F /* wordsdictionary.cpp in Sources */,
-				526F27F21D3B5CC300EF4E1F /* common.c in Sources */,
 				526F26C51D3B5CC300EF4E1F /* cc_dynamicobject.cpp in Sources */,
+				20522A2628E8F81C00589E91 /* aasset_stream.cpp in Sources */,
 				526F28BE1D3B5CC300EF4E1F /* cc_instance.cpp in Sources */,
 				526F28631D3B5CC300EF4E1F /* game_run.cpp in Sources */,
 				526F275A1D3B5CC300EF4E1F /* math.cpp in Sources */,
+				20E683FF28F20C7300B95C00 /* analysis.c in Sources */,
+				20522A5828E8F8CB00589E91 /* scriptcontainers.cpp in Sources */,
 				526F27231D3B5CC300EF4E1F /* global_overlay.cpp in Sources */,
 				52F5D8521DA120CB006F8F4B /* main_game_file.cpp in Sources */,
+				20522A4A28E8F8AA00589E91 /* draw_software.cpp in Sources */,
 				526F26D81D3B5CC300EF4E1F /* scriptdatetime.cpp in Sources */,
-				526F276F1D3B5CC300EF4E1F /* richgamemedia.cpp in Sources */,
 				526F27D21D3B5CC300EF4E1F /* cscidialog.cpp in Sources */,
+				20E67D8928F1BDE000B95C00 /* cgfx32.c in Sources */,
+				20E6823528F1D2B400B95C00 /* snd_fx.c in Sources */,
 				526F285B1D3B5CC300EF4E1F /* config.cpp in Sources */,
-				526F23C61D3B5C4900EF4E1F /* script_common.cpp in Sources */,
 				526F28161D3B5CC300EF4E1F /* getblk.c in Sources */,
-				526F27FF1D3B5CC300EF4E1F /* alogg.c in Sources */,
+				20E67D6528F1BDE000B95C00 /* unicode.c in Sources */,
+				20522A2D28E8F81C00589E91 /* data_ext.cpp in Sources */,
 				526F27DE1D3B5CC300EF4E1F /* mypushbutton.cpp in Sources */,
 				526F229F1D3B5C4900EF4E1F /* audiocliptype.cpp in Sources */,
 				526F23CF1D3B5C4900EF4E1F /* directory.cpp in Sources */,
+				205229B328E8EBE500589E91 /* roomstruct.cpp in Sources */,
 				526F28121D3B5CC300EF4E1F /* tabinit.c in Sources */,
+				205229BD28E8ECE200589E91 /* alfont.c in Sources */,
 				526F28611D3B5CC300EF4E1F /* game_file.cpp in Sources */,
+				20E67D8228F1BDE000B95C00 /* cblit16.c in Sources */,
+				20E6826028F1D2C400B95C00 /* common.c in Sources */,
 				526F28AF1D3B5CC300EF4E1F /* agsplugin.cpp in Sources */,
 				526F27E01D3B5CC300EF4E1F /* mytextbox.cpp in Sources */,
+				20E6840E28F20C7300B95C00 /* envelope.c in Sources */,
 				526F27761D3B5CC300EF4E1F /* roomstatus.cpp in Sources */,
+				20E683DD28F20C7200B95C00 /* res0.c in Sources */,
 				526F26F41D3B5CC300EF4E1F /* file.cpp in Sources */,
+				20522A2528E8F81C00589E91 /* bufferedstream.cpp in Sources */,
 				526F275C1D3B5CC300EF4E1F /* mouse.cpp in Sources */,
+				2052299828E8EAE700589E91 /* spritefile.cpp in Sources */,
 				526F28A11D3B5CC300EF4E1F /* alplmac.mm in Sources */,
 				526F26EB1D3B5CC300EF4E1F /* scriptstring.cpp in Sources */,
 				526F22BA1D3B5C4900EF4E1F /* spritecache.cpp in Sources */,
-				526F287B1D3B5CC300EF4E1F /* clip_mydumbmod.cpp in Sources */,
-				526F27731D3B5CC300EF4E1F /* room_engine.cpp in Sources */,
 				526F28971D3B5CC300EF4E1F /* agsplatformdriver.cpp in Sources */,
+				20522A5328E8F8CB00589E91 /* route_finder_impl_legacy.cpp in Sources */,
 				526F27BD1D3B5CC300EF4E1F /* gfxdriverfactory.cpp in Sources */,
 				526F281C1D3B5CC300EF4E1F /* ogg.c in Sources */,
 				526F27DA1D3B5CC300EF4E1F /* mylabel.cpp in Sources */,
-				A3A465A02866966D00AE0372 /* SpriteFontRendererClifftopGames.cpp in Sources */,
+				20E683D228F20C7200B95C00 /* floor0.c in Sources */,
 				526F273A1D3B5CC300EF4E1F /* global_translation.cpp in Sources */,
 				526F27921D3B5CC300EF4E1F /* timer.cpp in Sources */,
 				526F270D1D3B5CC300EF4E1F /* global_dynamicsprite.cpp in Sources */,
+				20522A5928E8F8CB00589E91 /* route_finder_impl.cpp in Sources */,
 				52F5D8611DA1219D006F8F4B /* inventoryiteminfo.cpp in Sources */,
 				521C54D21D1E572B00BD619E /* AGSBlend.cpp in Sources */,
-				526F287F1D3B5CC300EF4E1F /* clip_mymidi.cpp in Sources */,
+				20522A5F28E8F8DD00589E91 /* sys_events.cpp in Sources */,
 				526F23E21D3B5C4900EF4E1F /* multifilelib.cpp in Sources */,
 				526F26D11D3B5CC300EF4E1F /* cc_region.cpp in Sources */,
+				205229AE28E8EBE500589E91 /* room_file_deprecated.cpp in Sources */,
 				526F28051D3B5CC300EF4E1F /* adisplay.c in Sources */,
 				526F27C11D3B5CC300EF4E1F /* gfxfilter_aad3d.cpp in Sources */,
 				526F27191D3B5CC300EF4E1F /* global_invwindow.cpp in Sources */,
 				526F26E81D3B5CC300EF4E1F /* scriptoverlay.cpp in Sources */,
 				526F280A1D3B5CC300EF4E1F /* decode_1to1.c in Sources */,
+				20E6853128F2219B00B95C00 /* AGSSpriteFont.cpp in Sources */,
 				526F22A21D3B5C4900EF4E1F /* common.cpp in Sources */,
 				526F27361D3B5CC300EF4E1F /* global_textbox.cpp in Sources */,
 				526F28071D3B5CC300EF4E1F /* aaudio.c in Sources */,
 				521C54C91D1E572B00BD619E /* ags_snowrain.cpp in Sources */,
 				526F27C51D3B5CC300EF4E1F /* gfxfilter_d3d.cpp in Sources */,
 				526F276D1D3B5CC300EF4E1F /* region.cpp in Sources */,
-				526F288F1D3B5CC300EF4E1F /* soundcache.cpp in Sources */,
+				2052299728E8EAE700589E91 /* keycode.cpp in Sources */,
 				526F275E1D3B5CC300EF4E1F /* movelist.cpp in Sources */,
 				526F26B51D3B5CC300EF4E1F /* dynamicsprite.cpp in Sources */,
 				526F27AA1D3B5CC300EF4E1F /* logfile.cpp in Sources */,
-				526F28D61D3B5CC300EF4E1F /* test_memory.cpp in Sources */,
 				526F27131D3B5CC300EF4E1F /* global_gui.cpp in Sources */,
 				526F23D71D3B5C4900EF4E1F /* ini_util.cpp in Sources */,
-				526F28851D3B5CC300EF4E1F /* clip_mystaticmp3.cpp in Sources */,
+				205229D528E8EDE100589E91 /* fttype1.c in Sources */,
 				526F278C1D3B5CC300EF4E1F /* string.cpp in Sources */,
+				20E67D6A28F1BDE000B95C00 /* rotate.c in Sources */,
+				20E67D8728F1BDE000B95C00 /* cspr15.c in Sources */,
+				20522A2C28E8F81C00589E91 /* path_ex.cpp in Sources */,
+				20E67D9228F1BDE000B95C00 /* cblit8.c in Sources */,
+				205229AB28E8EBE500589E91 /* room_file.cpp in Sources */,
 				521C54DB1D1E572B00BD619E /* agsflashlight.cpp in Sources */,
 				526F27341D3B5CC300EF4E1F /* global_string.cpp in Sources */,
+				20E6823928F1D2B400B95C00 /* snd_dsp.c in Sources */,
+				20E6824228F1D2B400B95C00 /* load_med.c in Sources */,
 				526F270F1D3B5CC300EF4E1F /* global_file.cpp in Sources */,
 				526F28191D3B5CC300EF4E1F /* idct.c in Sources */,
 				526F27B41D3B5CC300EF4E1F /* blender.cpp in Sources */,
 				526F26AF1D3B5CC300EF4E1F /* display.cpp in Sources */,
-				526F28D91D3B5CC300EF4E1F /* test_version.cpp in Sources */,
-				526F22C91D3B5C4900EF4E1F /* out.cpp in Sources */,
 				526F26B91D3B5CC300EF4E1F /* cc_agsdynamicobject.cpp in Sources */,
-				526F28CB1D3B5CC300EF4E1F /* script_engine.cpp in Sources */,
-				521C54F31D1E572B00BD619E /* VariableWidthFont.cpp in Sources */,
+				20E67D8828F1BDE000B95C00 /* cmisc.c in Sources */,
+				20E684EA28F20E0700B95C00 /* decinfo.c in Sources */,
 				521C54FE1D1E572B00BD619E /* agstouch.cpp in Sources */,
 				526F27251D3B5CC300EF4E1F /* global_palette.cpp in Sources */,
 				526F23EC1D3B5C4900EF4E1F /* string_utils.cpp in Sources */,
 				526F22A61D3B5C4900EF4E1F /* scriptaudioclip.cpp in Sources */,
 				526F26FC1D3B5CC300EF4E1F /* global_api.cpp in Sources */,
+				20E6822428F1D2B400B95C00 /* sndfile.c in Sources */,
 				526F27781D3B5CC300EF4E1F /* route_finder.cpp in Sources */,
 				526F26B31D3B5CC300EF4E1F /* drawingsurface.cpp in Sources */,
+				20E67D8C28F1BDE000B95C00 /* cgfx16.c in Sources */,
 				526F28671D3B5CC300EF4E1F /* graphics_mode.cpp in Sources */,
+				20E683D928F20C7200B95C00 /* lpc.c in Sources */,
+				20E67D7528F1BDE000B95C00 /* quantize.c in Sources */,
+				205229D128E8EDE100589E91 /* ftglyph.c in Sources */,
+				20E6840F28F20C7300B95C00 /* info.c in Sources */,
+				20522A8428E8F98400589E91 /* glad.c in Sources */,
 				526F22E71D3B5C4900EF4E1F /* guimain.cpp in Sources */,
+				205229E828E8EEEA00589E91 /* pcf.c in Sources */,
 				526F22D11D3B5C4900EF4E1F /* wfnfont.cpp in Sources */,
+				20E6828228F1D32D00B95C00 /* sdldecoder.cpp in Sources */,
+				20E67D7128F1BDE000B95C00 /* libc.c in Sources */,
 				526F22E11D3B5C4900EF4E1F /* guiinv.cpp in Sources */,
 				526F26CD1D3B5CC300EF4E1F /* cc_inventory.cpp in Sources */,
 				526F270B1D3B5CC300EF4E1F /* global_drawingsurface.cpp in Sources */,
+				20E6837128F20BFD00B95C00 /* framing.c in Sources */,
 				526F26AC1D3B5CC300EF4E1F /* dialogoptionsrendering.cpp in Sources */,
 				526F272E1D3B5CC300EF4E1F /* global_room.cpp in Sources */,
+				20522A6B28E8F92100589E91 /* savegame_components.cpp in Sources */,
+				20522A6C28E8F92100589E91 /* viewport.cpp in Sources */,
 				526F28C21D3B5CC300EF4E1F /* exports.cpp in Sources */,
+				20E67D7728F1BDE000B95C00 /* dither.c in Sources */,
+				20522A6328E8F8FD00589E91 /* messagebuffer.cpp in Sources */,
 				526F27481D3B5CC300EF4E1F /* guicontrol.cpp in Sources */,
-				526F23C01D3B5C4900EF4E1F /* cc_options.cpp in Sources */,
+				20E684C328F20CC700B95C00 /* info.c in Sources */,
 				526F26A01D3B5CC300EF4E1F /* cdaudio.cpp in Sources */,
+				20E6849D28F20CC700B95C00 /* internal.c in Sources */,
+				20E6823328F1D2B400B95C00 /* mmcmp.c in Sources */,
+				20522A2928E8F81C00589E91 /* string_compat.c in Sources */,
+				20E683FB28F20C7300B95C00 /* lookup.c in Sources */,
+				20E6824128F1D2B400B95C00 /* fastmix.c in Sources */,
+				20E6823128F1D2B400B95C00 /* load_s3m.c in Sources */,
 				526F23161D3B5C4900EF4E1F /* aastr.c in Sources */,
 				526F272C1D3B5CC300EF4E1F /* global_region.cpp in Sources */,
 				526F22C11D3B5C4900EF4E1F /* asset.cpp in Sources */,
-				526F286E1D3B5CC300EF4E1F /* minidump.cpp in Sources */,
+				20522A4228E8F86400589E91 /* scriptset.cpp in Sources */,
+				205229E628E8EED300589E91 /* ftgzip.c in Sources */,
+				20E6824328F1D2B400B95C00 /* load_mt2.c in Sources */,
 				521C54C01D1E572B00BD619E /* ags_parallax.cpp in Sources */,
-				526F23C41D3B5C4900EF4E1F /* cc_treemap.cpp in Sources */,
+				205229B228E8EBE500589E91 /* tra_file.cpp in Sources */,
 				526F22E91D3B5C4900EF4E1F /* guiobject.cpp in Sources */,
+				20E6840528F20C7300B95C00 /* bitrate.c in Sources */,
+				20E6826828F1D2C400B95C00 /* instrum.c in Sources */,
+				20E67D7928F1BDE000B95C00 /* allegro.c in Sources */,
+				20E681F428F1D2A800B95C00 /* SDL_sound_modplug.c in Sources */,
+				20E6823B28F1D2B400B95C00 /* load_dbm.c in Sources */,
 				526F23F41D3B5C4900EF4E1F /* wgt2allg.cpp in Sources */,
 				526F288D1D3B5CC300EF4E1F /* sound.cpp in Sources */,
+				20E67D6728F1BDE000B95C00 /* math.c in Sources */,
 				526F28CE1D3B5CC300EF4E1F /* systemimports.cpp in Sources */,
+				20522A7728E8F94100589E91 /* gfxfilter_sdl_renderer.cpp in Sources */,
+				20E6826228F1D2C400B95C00 /* tables.c in Sources */,
+				20E6828128F1D32D00B95C00 /* audio_core.cpp in Sources */,
+				20E683F628F20C7300B95C00 /* mdct.c in Sources */,
 				526F273E1D3B5CC300EF4E1F /* global_viewframe.cpp in Sources */,
 				526F27651D3B5CC300EF4E1F /* parser.cpp in Sources */,
 				526F26A51D3B5CC300EF4E1F /* characterextras.cpp in Sources */,
-				521C54F51D1E572B00BD619E /* VariableWidthSpriteFont.cpp in Sources */,
-				521C54F11D1E572B00BD619E /* SpriteFontRenderer.cpp in Sources */,
+				20E67D6B28F1BDE000B95C00 /* flood.c in Sources */,
+				20E681FC28F1D2A800B95C00 /* SDL_sound_raw.c in Sources */,
 				526F271F1D3B5CC300EF4E1F /* global_mouse.cpp in Sources */,
 				526F23EF1D3B5C4900EF4E1F /* textstreamreader.cpp in Sources */,
+				205229FE28E8F53E00589E91 /* type42.c in Sources */,
+				20E67D7A28F1BDE000B95C00 /* vtable15.c in Sources */,
+				20E6827728F1D2C400B95C00 /* timidity.c in Sources */,
+				205229EE28E8F25B00589E91 /* psaux.c in Sources */,
+				20E6820028F1D2A800B95C00 /* SDL_sound_shn.c in Sources */,
 				526F28C91D3B5CC300EF4E1F /* script_api.cpp in Sources */,
 				526F22D51D3B5C4900EF4E1F /* customproperties.cpp in Sources */,
+				20E684EB28F20E0700B95C00 /* decapiwrapper.c in Sources */,
 				526F285F1D3B5CC300EF4E1F /* engine_setup.cpp in Sources */,
+				205229D228E8EDE100589E91 /* ftinit.c in Sources */,
+				20522A6D28E8F92100589E91 /* savegame_v321.cpp in Sources */,
+				20E67D7228F1BDE000B95C00 /* polygon.c in Sources */,
+				205229F628E8F2CF00589E91 /* sfnt.c in Sources */,
+				205229DA28E8EE3000589E91 /* ftsystem.c in Sources */,
+				205229F828E8F2E200589E91 /* smooth.c in Sources */,
 				526F27321D3B5CC300EF4E1F /* global_slider.cpp in Sources */,
 				526F27401D3B5CC300EF4E1F /* global_viewport.cpp in Sources */,
+				20E683FA28F20C7300B95C00 /* registry.c in Sources */,
+				20E6822528F1D2B400B95C00 /* load_amf.c in Sources */,
+				20E683F828F20C7300B95C00 /* window.c in Sources */,
+				205229D428E8EDE100589E91 /* ftpfr.c in Sources */,
 				526F269C1D3B5CC300EF4E1F /* audioclip.cpp in Sources */,
+				20E67D7628F1BDE000B95C00 /* colblend.c in Sources */,
 				526F26C91D3B5CC300EF4E1F /* cc_guiobject.cpp in Sources */,
 				526F28151D3B5CC300EF4E1F /* getbits.c in Sources */,
-				526F28D01D3B5CC300EF4E1F /* test_all.cpp in Sources */,
 				526F28771D3B5CC300EF4E1F /* audio.cpp in Sources */,
-				526F284B1D3B5CC300EF4E1F /* hq2x3x.cpp in Sources */,
-				526F22B61D3B5C4900EF4E1F /* point.cpp in Sources */,
 				526F279D1D3B5CC300EF4E1F /* walkablearea.cpp in Sources */,
 				526F280B1D3B5CC300EF4E1F /* decode_2to1.c in Sources */,
 				526F23C21D3B5C4900EF4E1F /* cc_script.cpp in Sources */,
 				526F26F61D3B5CC300EF4E1F /* game.cpp in Sources */,
+				20E681FD28F1D2A800B95C00 /* SDL_sound_vorbis.c in Sources */,
+				20E6822D28F1D2B400B95C00 /* load_dsm.c in Sources */,
+				20E67D9628F1BDE000B95C00 /* cgfx15.c in Sources */,
+				20E6849F28F20CC700B95C00 /* idct.c in Sources */,
+				20522A8628E8F9D600589E91 /* main_sdl2.cpp in Sources */,
+				205229D028E8EDE100589E91 /* ftdebug.c in Sources */,
+				20E6852F28F2219B00B95C00 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */,
+				20E681F528F1D2A800B95C00 /* SDL_sound_aiff.c in Sources */,
 				526F28C01D3B5CC300EF4E1F /* executingscript.cpp in Sources */,
+				20E6823028F1D2B400B95C00 /* load_mdl.c in Sources */,
 				526F26BB1D3B5CC300EF4E1F /* cc_audiochannel.cpp in Sources */,
-				526F27F31D3B5CC300EF4E1F /* dct64_i386.c in Sources */,
-				526F28D51D3B5CC300EF4E1F /* test_math.cpp in Sources */,
 				526F27631D3B5CC300EF4E1F /* overlay.cpp in Sources */,
+				20E6853728F2219B00B95C00 /* VariableWidthSpriteFont.cpp in Sources */,
+				20E67D9528F1BDE000B95C00 /* cblit32.c in Sources */,
 				526F22D91D3B5C4900EF4E1F /* allegrobitmap.cpp in Sources */,
+				20E6823C28F1D2B400B95C00 /* modplug.c in Sources */,
 				52D12C1F1D61C0950077B784 /* savegame.cpp in Sources */,
+				20522A3D28E8F86400589E91 /* scriptcamera.cpp in Sources */,
 				526F26EE1D3B5CC300EF4E1F /* scriptuserobject.cpp in Sources */,
-				526F27C71D3B5CC300EF4E1F /* gfxfilter_hqx.cpp in Sources */,
 				526F22E31D3B5C4900EF4E1F /* guilabel.cpp in Sources */,
 				526F27851D3B5CC300EF4E1F /* spritecache_engine.cpp in Sources */,
+				205229AF28E8EBE500589E91 /* room_file_base.cpp in Sources */,
 				526F28911D3B5CC300EF4E1F /* soundclip.cpp in Sources */,
 				526F22A91D3B5C4900EF4E1F /* gamesetupstruct.cpp in Sources */,
 				526F23D11D3B5C4900EF4E1F /* file.cpp in Sources */,
 				526F22B31D3B5C4900EF4E1F /* mousecursor.cpp in Sources */,
 				526F277B1D3B5CC300EF4E1F /* screen.cpp in Sources */,
+				205229F228E8F29900589E91 /* psmodule.c in Sources */,
 				526F27381D3B5CC300EF4E1F /* global_timer.cpp in Sources */,
 				526F26AA1D3B5CC300EF4E1F /* dialog.cpp in Sources */,
-				526F27F41D3B5CC300EF4E1F /* decode_i386.c in Sources */,
+				20E683D128F20C7200B95C00 /* synthesis.c in Sources */,
+				20E67D8128F1BDE000B95C00 /* cspr16.c in Sources */,
 				526F286F1D3B5CC300EF4E1F /* quit.cpp in Sources */,
 				526F26F01D3B5CC300EF4E1F /* scriptviewframe.cpp in Sources */,
 				526F27E21D3B5CC300EF4E1F /* newcontrol.cpp in Sources */,
 				526F281A1D3B5CC300EF4E1F /* motion.c in Sources */,
+				20E67D8F28F1BDE000B95C00 /* cgfx24.c in Sources */,
 				526F274F1D3B5CC300EF4E1F /* inventoryitem.cpp in Sources */,
+				20E67D7C28F1BDE000B95C00 /* file.c in Sources */,
 				526F28C51D3B5CC300EF4E1F /* runtimescriptvalue.cpp in Sources */,
+				20E6810728F1BE5D00B95C00 /* mojoal.c in Sources */,
 				526F28181D3B5CC300EF4E1F /* getpic.c in Sources */,
+				20E6823F28F1D2B400B95C00 /* load_stm.c in Sources */,
 				526F28B21D3B5CC300EF4E1F /* pluginobjectreader.cpp in Sources */,
-				526F23DF1D3B5C4900EF4E1F /* misc.cpp in Sources */,
 				526F27301D3B5CC300EF4E1F /* global_screen.cpp in Sources */,
 				526F23CB1D3B5C4900EF4E1F /* compress.cpp in Sources */,
 				526F26E11D3B5CC300EF4E1F /* scriptfile.cpp in Sources */,
-				A3A465A12866966D00AE0372 /* VariableWidthSpriteFontClifftopGames.cpp in Sources */,
 				526F22D71D3B5C4900EF4E1F /* interactions.cpp in Sources */,
+				20522A5D28E8F8DD00589E91 /* viewport_script.cpp in Sources */,
 				526F27AC1D3B5CC300EF4E1F /* mousew32.cpp in Sources */,
+				20E67D9828F1BDE000B95C00 /* inline.c in Sources */,
+				20522A2328E8F81C00589E91 /* cmdlineopts.cpp in Sources */,
+				20E6852928F2219B00B95C00 /* SpriteFontRendererClifftopGames.cpp in Sources */,
+				20E6822A28F1D2B400B95C00 /* load_psm.c in Sources */,
 				526F27D41D3B5CC300EF4E1F /* gui_engine.cpp in Sources */,
 				526F280E1D3B5CC300EF4E1F /* layer2.c in Sources */,
-				526F27F61D3B5CC300EF4E1F /* interface.c in Sources */,
+				205229CE28E8EDE100589E91 /* ftbdf.c in Sources */,
 				526F27B61D3B5CC300EF4E1F /* color_engine.cpp in Sources */,
 				526F274E1D3B5CC300EF4E1F /* interfaceelement.cpp in Sources */,
 				526F28101D3B5CC300EF4E1F /* mpg123.c in Sources */,
 				526F26DD1D3B5CC300EF4E1F /* scriptdrawingsurface.cpp in Sources */,
+				20E67D7328F1BDE000B95C00 /* vtable16.c in Sources */,
+				20522A2428E8F81C00589E91 /* android_file.cpp in Sources */,
 				526F27551D3B5CC300EF4E1F /* label.cpp in Sources */,
-				526F28811D3B5CC300EF4E1F /* clip_mymp3.cpp in Sources */,
+				20E67D6C28F1BDE000B95C00 /* vtable32.c in Sources */,
+				20E67D8428F1BDE000B95C00 /* cgfx8.c in Sources */,
 				526F271B1D3B5CC300EF4E1F /* global_label.cpp in Sources */,
 				526F26C71D3B5CC300EF4E1F /* cc_gui.cpp in Sources */,
+				20E683D828F20C7200B95C00 /* smallft.c in Sources */,
 				526F23D51D3B5C4900EF4E1F /* geometry.cpp in Sources */,
 				526F22AB1D3B5C4900EF4E1F /* gamesetupstructbase.cpp in Sources */,
 				526F23D91D3B5C4900EF4E1F /* inifile.cpp in Sources */,
+				20E681F728F1D2A800B95C00 /* SDL_sound_voc.c in Sources */,
+				205229E028E8EE7F00589E91 /* ftcache.c in Sources */,
 				52F5D8581DA120F1006F8F4B /* game_init.cpp in Sources */,
+				20E67D8328F1BDE000B95C00 /* cspr24.c in Sources */,
+				20E67D6928F1BDE000B95C00 /* fli.c in Sources */,
+				20E67D9128F1BDE000B95C00 /* cspr32.c in Sources */,
+				20E681FF28F1D2A800B95C00 /* SDL_sound.c in Sources */,
+				205229E228E8EE9B00589E91 /* cff.c in Sources */,
 				526F28081D3B5CC300EF4E1F /* apegcommon.c in Sources */,
 				526F280F1D3B5CC300EF4E1F /* layer3.c in Sources */,
+				205229DC28E8EE5300589E91 /* autohint.c in Sources */,
 				526F26C31D3B5CC300EF4E1F /* cc_dynamicarray.cpp in Sources */,
-				526F27C31D3B5CC300EF4E1F /* gfxfilter_allegro.cpp in Sources */,
 				526F27011D3B5CC300EF4E1F /* global_character.cpp in Sources */,
+				20E6848228F20CC700B95C00 /* fragment.c in Sources */,
 				526F285D1D3B5CC300EF4E1F /* engine.cpp in Sources */,
 				526F26DF1D3B5CC300EF4E1F /* scriptdynamicsprite.cpp in Sources */,
 				526F22C31D3B5C4900EF4E1F /* assetmanager.cpp in Sources */,
 				526F27441D3B5CC300EF4E1F /* global_walkbehind.cpp in Sources */,
+				20E6827628F1D2C400B95C00 /* output.c in Sources */,
+				20E6823228F1D2B400B95C00 /* load_669.c in Sources */,
 				526F27071D3B5CC300EF4E1F /* global_dialog.cpp in Sources */,
+				20E683DA28F20C7200B95C00 /* misc.c in Sources */,
+				205229FC28E8F53100589E91 /* type1.c in Sources */,
 				526F22ED1D3B5C4900EF4E1F /* guitextbox.cpp in Sources */,
 				526F279F1D3B5CC300EF4E1F /* walkbehind.cpp in Sources */,
 				526F27B81D3B5CC300EF4E1F /* gfx_util.cpp in Sources */,
+				20E6827328F1D2C400B95C00 /* mix.c in Sources */,
 				526F27D51D3B5CC300EF4E1F /* guidialog.cpp in Sources */,
-				526F28BD1D3B5CC300EF4E1F /* cc_error_engine.cpp in Sources */,
+				20E6822828F1D2B400B95C00 /* load_ult.c in Sources */,
 				526F27271D3B5CC300EF4E1F /* global_parser.cpp in Sources */,
 				52F5D85D1DA12147006F8F4B /* dialogtopic.cpp in Sources */,
+				20522A4528E8F86400589E91 /* scriptdict.cpp in Sources */,
+				20E67D8D28F1BDE000B95C00 /* cstretch.c in Sources */,
 				526F280C1D3B5CC300EF4E1F /* decode_4to1.c in Sources */,
+				20E67D7B28F1BDE000B95C00 /* readbmp.c in Sources */,
+				20E67D7828F1BDE000B95C00 /* dataregi.c in Sources */,
+				20E6823D28F1D2B400B95C00 /* load_umx.c in Sources */,
+				20E6852A28F2219B00B95C00 /* SpriteFontRenderer.cpp in Sources */,
+				205229F428E8F2B700589E91 /* raster.c in Sources */,
+				20522A0628E8F7FE00589E91 /* cc_common.cpp in Sources */,
+				20E67D9928F1BDE000B95C00 /* color.c in Sources */,
+				20E67D7428F1BDE000B95C00 /* ufile.c in Sources */,
 				526F23D31D3B5C4900EF4E1F /* filestream.cpp in Sources */,
 				52F5D8641DA121CC006F8F4B /* version.cpp in Sources */,
 				526F278E1D3B5CC300EF4E1F /* system.cpp in Sources */,
+				20E67D6428F1BDE000B95C00 /* gfx.c in Sources */,
 				526F23C81D3B5C4900EF4E1F /* alignedstream.cpp in Sources */,
+				20E681F628F1D2A800B95C00 /* SDL_sound_mp3.c in Sources */,
 				526F27AE1D3B5CC300EF4E1F /* fonts_engine.cpp in Sources */,
 				526F26FA1D3B5CC300EF4E1F /* gamestate.cpp in Sources */,
+				20E684AE28F20CC700B95C00 /* bitpack.c in Sources */,
+				20522A8A28E8FD2B00589E91 /* sdl2_util.cpp in Sources */,
 				526F27A81D3B5CC300EF4E1F /* filebasedagsdebugger.cpp in Sources */,
 				526F22EB1D3B5C4900EF4E1F /* guislider.cpp in Sources */,
 				526F269E1D3B5CC300EF4E1F /* button.cpp in Sources */,
+				20E6822B28F1D2B400B95C00 /* load_xm.c in Sources */,
 				526F23E91D3B5C4900EF4E1F /* string.cpp in Sources */,
 				526F22E51D3B5C4900EF4E1F /* guilistbox.cpp in Sources */,
-				526F28D81D3B5CC300EF4E1F /* test_string.cpp in Sources */,
-				526F287D1D3B5CC300EF4E1F /* clip_myjgmod.cpp in Sources */,
+				205229EA28E8F23000589E91 /* pfr.c in Sources */,
+				20E67D7E28F1BDE000B95C00 /* vtable8.c in Sources */,
+				20E681FE28F1D2A800B95C00 /* SDL_sound_wav.c in Sources */,
+				20E681F928F1D2A800B95C00 /* SDL_sound_midi.c in Sources */,
+				20522A7328E8F94100589E91 /* gfxfilter_aaogl.cpp in Sources */,
+				20E683DC28F20C7200B95C00 /* sharedbook.c in Sources */,
+				20E6822328F1D2B400B95C00 /* load_okt.c in Sources */,
+				20E684E928F20E0700B95C00 /* decode.c in Sources */,
+				20522A9428E8FD7700589E91 /* sys_main.cpp in Sources */,
+				205229D728E8EDE100589E91 /* ftxf86.c in Sources */,
+				2052299F28E8EBA900589E91 /* debugmanager.cpp in Sources */,
+				20E67D9728F1BDE000B95C00 /* vtable24.c in Sources */,
 				526F23CD1D3B5C4900EF4E1F /* datastream.cpp in Sources */,
 				526F274D1D3B5CC300EF4E1F /* interfacebutton.cpp in Sources */,
 				526F27421D3B5CC300EF4E1F /* global_walkablearea.cpp in Sources */,
+				20522A1D28E8F81C00589E91 /* stdio_compat.c in Sources */,
 				526F28091D3B5CC300EF4E1F /* dct64.c in Sources */,
+				20E67D7D28F1BDE000B95C00 /* bmp.c in Sources */,
+				20522A4428E8F86400589E91 /* scriptviewport.cpp in Sources */,
 				526F28651D3B5CC300EF4E1F /* game_start.cpp in Sources */,
+				205229D628E8EDE100589E91 /* ftmm.c in Sources */,
 				526F26BD1D3B5CC300EF4E1F /* cc_audioclip.cpp in Sources */,
+				20E681FA28F1D2A800B95C00 /* SDL_sound_au.c in Sources */,
 				526F22CD1D3B5C4900EF4E1F /* fonts.cpp in Sources */,
-				526F28891D3B5CC300EF4E1F /* clip_mywave.cpp in Sources */,
 				526F26FF1D3B5CC300EF4E1F /* global_button.cpp in Sources */,
 				526F22DE1D3B5C4900EF4E1F /* guibutton.cpp in Sources */,
-				526F27F81D3B5CC300EF4E1F /* layer2.c in Sources */,
+				205229D328E8EDE100589E91 /* ftbbox.c in Sources */,
 				526F26F81D3B5CC300EF4E1F /* gamesetup.cpp in Sources */,
+				20E6822928F1D2B400B95C00 /* load_far.c in Sources */,
 				526F23181D3B5C4900EF4E1F /* aautil.c in Sources */,
 				52F5D84F1DA120A0006F8F4B /* characterinfo.cpp in Sources */,
-				521C54EB1D1E572B00BD619E /* CharacterEntry.cpp in Sources */,
-				526F27E41D3B5CC300EF4E1F /* alfont.c in Sources */,
 				526F27091D3B5CC300EF4E1F /* global_display.cpp in Sources */,
 				526F277F1D3B5CC300EF4E1F /* slider.cpp in Sources */,
 				526F27C91D3B5CC300EF4E1F /* gfxfilter_ogl.cpp in Sources */,
 				526F28691D3B5CC300EF4E1F /* main.cpp in Sources */,
-				526F28D31D3B5CC300EF4E1F /* test_gfx.cpp in Sources */,
-				526F28831D3B5CC300EF4E1F /* clip_myogg.cpp in Sources */,
 				526F271D1D3B5CC300EF4E1F /* global_listbox.cpp in Sources */,
 				526F26D31D3B5CC300EF4E1F /* cc_serializer.cpp in Sources */,
 				526F22BC1D3B5C4900EF4E1F /* view.cpp in Sources */,
+				20E6828728F1D32D00B95C00 /* openalsource.cpp in Sources */,
+				205229DE28E8EE6700589E91 /* bdf.c in Sources */,
 				526F28C71D3B5CC300EF4E1F /* script.cpp in Sources */,
-				526F22B81D3B5C4900EF4E1F /* roomstruct.cpp in Sources */,
+				20E6853028F2219B00B95C00 /* SpriteFont.cpp in Sources */,
 				526F28751D3B5CC300EF4E1F /* ambientsound.cpp in Sources */,
+				20E67D7028F1BDE000B95C00 /* vtable.c in Sources */,
 				526F27991D3B5CC300EF4E1F /* viewframe.cpp in Sources */,
-				526F28D71D3B5CC300EF4E1F /* test_sprintf.cpp in Sources */,
 				526F27BB1D3B5CC300EF4E1F /* gfxdriverbase.cpp in Sources */,
-				526F28A41D3B5CC300EF4E1F /* pe.c in Sources */,
+				20522A2728E8F81C00589E91 /* memorystream.cpp in Sources */,
+				205229F028E8F27800589E91 /* pshinter.c in Sources */,
+				20E684AB28F20CC700B95C00 /* huffdec.c in Sources */,
 				526F27A21D3B5CC300EF4E1F /* consoleoutputtarget.cpp in Sources */,
+				20E684B228F20CC700B95C00 /* dequant.c in Sources */,
 				526F281B1D3B5CC300EF4E1F /* mpeg1dec.c in Sources */,
+				20E6823728F1D2B400B95C00 /* load_ams.c in Sources */,
 				526F23DB1D3B5C4900EF4E1F /* lzw.cpp in Sources */,
-				526F22B11D3B5C4900EF4E1F /* messageinfo.cpp in Sources */,
 				526F28711D3B5CC300EF4E1F /* update.cpp in Sources */,
+				20E6822728F1D2B400B95C00 /* load_mtm.c in Sources */,
 				526F26CF1D3B5CC300EF4E1F /* cc_object.cpp in Sources */,
+				20E684A128F20CC700B95C00 /* state.c in Sources */,
 				526F27901D3B5CC300EF4E1F /* textbox.cpp in Sources */,
+				20E6827028F1D2C400B95C00 /* resample.c in Sources */,
+				20E681F828F1D2A800B95C00 /* SDL_sound_flac.c in Sources */,
+				20E6823E28F1D2B400B95C00 /* load_mod.c in Sources */,
+				20E6837328F20BFD00B95C00 /* bitwise.c in Sources */,
 				526F22DB1D3B5C4900EF4E1F /* bitmap.cpp in Sources */,
-				521C54E91D1E572B00BD619E /* AGSSpriteFont.cpp in Sources */,
-				526F27F91D3B5CC300EF4E1F /* layer3.c in Sources */,
 				526F23E31D3B5C4900EF4E1F /* path.cpp in Sources */,
 				526F27521D3B5CC300EF4E1F /* invwindow.cpp in Sources */,
+				20E6826428F1D2C400B95C00 /* readmidi.c in Sources */,
+				20E681F328F1D2A800B95C00 /* SDL_sound_coreaudio.c in Sources */,
 				526F27461D3B5CC300EF4E1F /* gui.cpp in Sources */,
-				521C54EF1D1E572B00BD619E /* SpriteFont.cpp in Sources */,
 				526F27111D3B5CC300EF4E1F /* global_game.cpp in Sources */,
-				521C54ED1D1E572B00BD619E /* color.cpp in Sources */,
 				526F28A01D3B5CC300EF4E1F /* acplmac.cpp in Sources */,
+				205229CF28E8EDE100589E91 /* ftbase.c in Sources */,
 				526F27581D3B5CC300EF4E1F /* listbox.cpp in Sources */,
+				20E6827428F1D2C400B95C00 /* playmidi.c in Sources */,
 				526F27811D3B5CC300EF4E1F /* speech.cpp in Sources */,
 				526F27051D3B5CC300EF4E1F /* global_debug.cpp in Sources */,
 				526F27B21D3B5CC300EF4E1F /* ali3dsw.cpp in Sources */,
 				526F28CC1D3B5CC300EF4E1F /* script_runtime.cpp in Sources */,
 				526F27741D3B5CC300EF4E1F /* roomobject.cpp in Sources */,
 				526F27891D3B5CC300EF4E1F /* staticarray.cpp in Sources */,
+				20E683F728F20C7300B95C00 /* floor1.c in Sources */,
 				526F27211D3B5CC300EF4E1F /* global_object.cpp in Sources */,
+				20E6823428F1D2B400B95C00 /* load_it.c in Sources */,
 				526F281D1D3B5CC300EF4E1F /* recon.c in Sources */,
+				20E67D8528F1BDE000B95C00 /* cblit24.c in Sources */,
+				20E6852E28F2219B00B95C00 /* color.cpp in Sources */,
 				526F28931D3B5CC300EF4E1F /* video.cpp in Sources */,
+				20E67D6F28F1BDE000B95C00 /* graphics.c in Sources */,
 				526F26C11D3B5CC300EF4E1F /* cc_dialog.cpp in Sources */,
+				20E6823628F1D2B400B95C00 /* snd_flt.c in Sources */,
+				20E683D528F20C7200B95C00 /* block.c in Sources */,
 				526F26CB1D3B5CC300EF4E1F /* cc_hotspot.cpp in Sources */,
+				20E684B428F20CC700B95C00 /* apiwrapper.c in Sources */,
+				20E6822C28F1D2B400B95C00 /* load_dmf.c in Sources */,
 				526F27601D3B5CC300EF4E1F /* object.cpp in Sources */,
-				526F28D41D3B5CC300EF4E1F /* test_inifile.cpp in Sources */,
 				526F280D1D3B5CC300EF4E1F /* layer1.c in Sources */,
 				526F27031D3B5CC300EF4E1F /* global_datetime.cpp in Sources */,
-				526F28D21D3B5CC300EF4E1F /* test_file.cpp in Sources */,
+				20522A0028E8F54E00589E91 /* winfnt.c in Sources */,
 				52F5D85B1DA1211B006F8F4B /* characterinfo_engine.cpp in Sources */,
 				526F22D31D3B5C4900EF4E1F /* wfnfontrenderer.cpp in Sources */,
 				526F27831D3B5CC300EF4E1F /* sprite.cpp in Sources */,
 				526F27A41D3B5CC300EF4E1F /* debug.cpp in Sources */,
 				526F26D51D3B5CC300EF4E1F /* managedobjectpool.cpp in Sources */,
-				526F27971D3B5CC300EF4E1F /* tree_map.cpp in Sources */,
 				526F23F11D3B5C4900EF4E1F /* textstreamwriter.cpp in Sources */,
 				526F26A21D3B5CC300EF4E1F /* character.cpp in Sources */,
 				526F269A1D3B5CC300EF4E1F /* audiochannel.cpp in Sources */,
@@ -3561,29 +4473,38 @@
 				526F27951D3B5CC300EF4E1F /* translation.cpp in Sources */,
 				526F27151D3B5CC300EF4E1F /* global_hotspot.cpp in Sources */,
 				526F26DB1D3B5CC300EF4E1F /* scriptdialogoptionsrendering.cpp in Sources */,
+				20E6853628F2219B00B95C00 /* VariableWidthFont.cpp in Sources */,
+				20E67D8028F1BDE000B95C00 /* cspr8.c in Sources */,
+				20E6854A28F221CA00B95C00 /* ags_palrender.cpp in Sources */,
 				526F28A31D3B5CC300EF4E1F /* libc.c in Sources */,
-				526F23BE1D3B5C4900EF4E1F /* cc_error.cpp in Sources */,
 				526F27691D3B5CC300EF4E1F /* properties.cpp in Sources */,
 				526F27DC1D3B5CC300EF4E1F /* mylistbox.cpp in Sources */,
 				526F27CB1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp in Sources */,
-				526F28871D3B5CC300EF4E1F /* clip_mystaticogg.cpp in Sources */,
+				20E67D6828F1BDE000B95C00 /* pcx.c in Sources */,
 				526F27711D3B5CC300EF4E1F /* room.cpp in Sources */,
 				526F27D01D3B5CC300EF4E1F /* animatingguibutton.cpp in Sources */,
-				526F272A1D3B5CC300EF4E1F /* global_record.cpp in Sources */,
+				20E684B328F20CC700B95C00 /* quant.c in Sources */,
+				20E6854C28F221CA00B95C00 /* raycast.cpp in Sources */,
 				526F27B01D3B5CC300EF4E1F /* ali3dogl.cpp in Sources */,
 				526F273C1D3B5CC300EF4E1F /* global_video.cpp in Sources */,
+				20E6822E28F1D2B400B95C00 /* load_gdm.c in Sources */,
 				526F22CF1D3B5C4900EF4E1F /* ttffontrenderer.cpp in Sources */,
+				205229FA28E8F51A00589E91 /* truetype.c in Sources */,
+				205229E428E8EEAF00589E91 /* type1cid.c in Sources */,
 				526F28B11D3B5CC300EF4E1F /* global_plugin.cpp in Sources */,
 				526F26FD1D3B5CC300EF4E1F /* global_audio.cpp in Sources */,
 				526F28111D3B5CC300EF4E1F /* readers.c in Sources */,
 				526F27171D3B5CC300EF4E1F /* global_inventoryitem.cpp in Sources */,
 				526F26B11D3B5CC300EF4E1F /* draw.cpp in Sources */,
 				526F28131D3B5CC300EF4E1F /* vbrhead.c in Sources */,
+				20E6823828F1D2B400B95C00 /* sndmix.c in Sources */,
+				20E683D328F20C7200B95C00 /* mapping0.c in Sources */,
+				20E6824028F1D2B400B95C00 /* load_ptm.c in Sources */,
 				526F26F21D3B5CC300EF4E1F /* event.cpp in Sources */,
-				526F279B1D3B5CC300EF4E1F /* viewport.cpp in Sources */,
-				526F27671D3B5CC300EF4E1F /* path.cpp in Sources */,
-				526F276B1D3B5CC300EF4E1F /* record.cpp in Sources */,
 				526F28171D3B5CC300EF4E1F /* gethdr.c in Sources */,
+				20E683C728F20C7200B95C00 /* psy.c in Sources */,
+				20E6853328F2219B00B95C00 /* CharacterEntry.cpp in Sources */,
+				20E683FE28F20C7300B95C00 /* lsp.c in Sources */,
 				526F288B1D3B5CC300EF4E1F /* queuedaudioitem.cpp in Sources */,
 				526F26BF1D3B5CC300EF4E1F /* cc_character.cpp in Sources */,
 			);
@@ -3596,19 +4517,32 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -3618,11 +4552,13 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					DISABLE_MPEG_AUDIO,
-					AGS_INVERTED_COLOR_ORDER,
 					MAC_VERSION,
 					BUILTIN_PLUGINS,
+					ZLIB_DEBUG,
 					DEBUG,
 					"$(inherited)",
+					SOUND_SUPPORTS_COREAUDIO,
+					"SOUND_SUPPORTS_MODPLUG=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -3631,9 +4567,20 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"${SOURCE_ROOT}/../../include",
-					"${SOURCE_ROOT}/../../include/freetype2",
+					"${SOURCE_ROOT}/../../../libsrc/glm",
+					"${SOURCE_ROOT}/../../../libsrc/allegro/include",
+					"${SOURCE_ROOT}/../../../libsrc/mojoAL",
 					"${SOURCE_ROOT}/../../../Common/libinclude",
+					"${SOURCE_ROOT}/../../../libsrc/ogg/include",
+					"${SOURCE_ROOT}/../../../libsrc/theora/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/lib",
+					"${SOURCE_ROOT}/../../../Common/libsrc/freetype-2.1.3",
+					"${SOURCE_ROOT}/../../../Common/libsrc/alfont-2.0.9",
+					"${SOURCE_ROOT}/../../../Common/lbsrc/aastr-0.1.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/apeg-1.2.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/glad/include",
+					"${SOURCE_ROOT}/../../../SDL_sound/src",
 				);
 				LIBRARY_SEARCH_PATHS = "${SOURCE_ROOT}/../../lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -3652,19 +4599,32 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3672,9 +4632,10 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					DISABLE_MPEG_AUDIO,
-					AGS_INVERTED_COLOR_ORDER,
 					MAC_VERSION,
 					BUILTIN_PLUGINS,
+					SOUND_SUPPORTS_COREAUDIO,
+					"SOUND_SUPPORTS_MODPLUG=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -3683,9 +4644,20 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"${SOURCE_ROOT}/../../include",
-					"${SOURCE_ROOT}/../../include/freetype2",
+					"${SOURCE_ROOT}/../../../libsrc/glm",
+					"${SOURCE_ROOT}/../../../libsrc/allegro/include",
+					"${SOURCE_ROOT}/../../../libsrc/mojoAL",
 					"${SOURCE_ROOT}/../../../Common/libinclude",
+					"${SOURCE_ROOT}/../../../libsrc/ogg/include",
+					"${SOURCE_ROOT}/../../../libsrc/theora/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/lib",
+					"${SOURCE_ROOT}/../../../Common/libsrc/freetype-2.1.3",
+					"${SOURCE_ROOT}/../../../Common/libsrc/alfont-2.0.9",
+					"${SOURCE_ROOT}/../../../Common/lbsrc/aastr-0.1.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/apeg-1.2.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/glad/include",
+					"${SOURCE_ROOT}/../../../SDL_sound/src",
 				);
 				LIBRARY_SEARCH_PATHS = "${SOURCE_ROOT}/../../lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -3702,15 +4674,48 @@
 		521C3BF31D1E545100BD619E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"${SOURCE_ROOT}/../../lib",
+					"${SOURCE_ROOT}",
+					"$(PROJECT_DIR)",
+				);
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SOUND_SUPPORTS_COREAUDIO=1",
+					DISABLE_MPEG_AUDIO,
+					MAC_VERSION,
+					BUILTIN_PLUGINS,
+					DEBUG,
+					ZLIB_DEBUG,
+				);
+				HEADER_SEARCH_PATHS = (
+					"${SOURCE_ROOT}/../../../Common/libsrc/freetype-2.1.3/include",
+					"${SOURCE_ROOT}/../../../Common/libinclude",
+					"${SOURCE_ROOT}/../../../libsrc/theora/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/include",
+					"${SOURCE_ROOT}/../../../libsrc/ogg/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/lib",
+					"${SOURCE_ROOT}/../../../Common/libsrc/aastr-0.1.1",
+					"${SOURCE_ROOT}/../../../Common/libsrc/alfont-2.0.9",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/apeg-1.2.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/glad/include",
+					"${SOURCE_ROOT}/../../../libsrc/allegro/include",
+					"${SOURCE_ROOT}/../../../libsrc/glm",
+					"${SOURCE_ROOT}/../../../libsrc/mojoAL",
+					"${SOURCE_ROOT}/../../../libsrc/SDL_sound/src",
+					"${SOURCE_ROOT}/SDL2.framework/Headers",
+				);
 				INFOPLIST_FILE = AGSKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.adventuregamestudio.AGSKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3720,15 +4725,46 @@
 		521C3BF41D1E545100BD619E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"${SOURCE_ROOT}/../../lib",
+					"${SOURCE_ROOT}",
+					"$(PROJECT_DIR)",
+				);
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SOUND_SUPPORTS_COREAUDIO=1",
+					DISABLE_MPEG_AUDIO,
+					MAC_VERSION,
+					BUILTIN_PLUGINS,
+				);
+				HEADER_SEARCH_PATHS = (
+					"${SOURCE_ROOT}/../../../Common/libsrc/freetype-2.1.3/include",
+					"${SOURCE_ROOT}/../../../Common/libinclude",
+					"${SOURCE_ROOT}/../../../libsrc/theora/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/include",
+					"${SOURCE_ROOT}/../../../libsrc/ogg/include",
+					"${SOURCE_ROOT}/../../../libsrc/vorbis/lib",
+					"${SOURCE_ROOT}/../../../Common/libsrc/aastr-0.1.1",
+					"${SOURCE_ROOT}/../../../Common/libsrc/alfont-2.0.9",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/apeg-1.2.1",
+					"${SOURCE_ROOT}/../../../Engine/libsrc/glad/include",
+					"${SOURCE_ROOT}/../../../libsrc/allegro/include",
+					"${SOURCE_ROOT}/../../../libsrc/glm",
+					"${SOURCE_ROOT}/../../../libsrc/mojoAL",
+					"${SOURCE_ROOT}/../../../libsrc/SDL_sound/src",
+					"${SOURCE_ROOT}/SDL2.framework/Headers",
+				);
 				INFOPLIST_FILE = AGSKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.adventuregamestudio.AGSKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/OSX/xcode/AGSKit/AGSKit.xcodeproj/xcshareddata/xcschemes/AGSKit.xcscheme
+++ b/OSX/xcode/AGSKit/AGSKit.xcodeproj/xcshareddata/xcschemes/AGSKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -39,7 +37,7 @@
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
@@ -51,15 +49,13 @@
             ReferencedContainer = "container:AGSKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/OSX/xcode/AGSKit/AGSKit/Info.plist
+++ b/OSX/xcode/AGSKit/AGSKit/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2016 Adventure Game Studio. All rights reserved.</string>
+	<string>Copyright © 2022 Adventure Game Studio. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OSX/xcode/ags/ags-Info.plist
+++ b/OSX/xcode/ags/ags-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>ags.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/OSX/xcode/ags/ags.entitlements
+++ b/OSX/xcode/ags/ags.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+</dict>
+</plist>

--- a/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
+++ b/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
@@ -7,21 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		523AB9711D27DA40002B98F0 /* AGSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523AB9701D27DA40002B98F0 /* AGSKit.framework */; };
-		52B8A6221D27785A00FA453F /* libz.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A6141D27785A00FA453F /* libz.1.dylib */; };
-		52B8A6231D27785A00FA453F /* libbz2.1.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A6151D27785A00FA453F /* libbz2.1.0.dylib */; };
-		52B8A6241D27785A00FA453F /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A6161D27785A00FA453F /* CoreVideo.framework */; };
-		52B8A6251D27785A00FA453F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A6171D27785A00FA453F /* Cocoa.framework */; };
-		52B8A6271D27785A00FA453F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A6191D27785A00FA453F /* IOKit.framework */; };
-		52B8A6281D27785A00FA453F /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A61A1D27785A00FA453F /* CoreAudio.framework */; };
-		52B8A6291D27785A00FA453F /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A61B1D27785A00FA453F /* AudioUnit.framework */; };
-		52B8A62A1D27785A00FA453F /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A61C1D27785A00FA453F /* AppKit.framework */; };
-		52B8A62B1D27785A00FA453F /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A61D1D27785A00FA453F /* OpenGL.framework */; };
-		52B8A62C1D27785A00FA453F /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52B8A61E1D27785A00FA453F /* AudioToolbox.framework */; };
-		52C5BFAE1D277B43001E3B10 /* game.ags in Resources */ = {isa = PBXBuildFile; fileRef = 52C5BFAA1D277B43001E3B10 /* game.ags */; };
-		52C5BFAF1D277B43001E3B10 /* acsetup.cfg in Resources */ = {isa = PBXBuildFile; fileRef = 52C5BFAB1D277B43001E3B10 /* acsetup.cfg */; };
-		52C5BFB01D277B43001E3B10 /* audio.vox in Resources */ = {isa = PBXBuildFile; fileRef = 52C5BFAC1D277B43001E3B10 /* audio.vox */; };
-		52C5BFB11D277B43001E3B10 /* speech.vox in Resources */ = {isa = PBXBuildFile; fileRef = 52C5BFAD1D277B43001E3B10 /* speech.vox */; };
+		20E6850228F2202800B95C00 /* acsetup.cfg in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FD28F2202700B95C00 /* acsetup.cfg */; };
+		20E6850328F2202800B95C00 /* game.ags in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FE28F2202700B95C00 /* game.ags */; };
+		20E6850428F2202800B95C00 /* audio.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FF28F2202700B95C00 /* audio.vox */; };
+		20E6850528F2202800B95C00 /* ags.icns in Resources */ = {isa = PBXBuildFile; fileRef = 20E6850028F2202800B95C00 /* ags.icns */; };
+		20E6850628F2202800B95C00 /* speech.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E6850128F2202800B95C00 /* speech.vox */; };
+		20E6855328F225F800B95C00 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; };
+		20E6855428F225F800B95C00 /* SDL2.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		20E6855528F2260100B95C00 /* AGSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523AB9701D27DA40002B98F0 /* AGSKit.framework */; };
+		20E6855628F2260100B95C00 /* AGSKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 523AB9701D27DA40002B98F0 /* AGSKit.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		20E6855828F25AF000B95C00 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855728F25AF000B95C00 /* AudioToolbox.framework */; };
+		20E6855A28F25AF800B95C00 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855928F25AF800B95C00 /* AudioUnit.framework */; };
+		20E6855C28F25B0500B95C00 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855B28F25B0400B95C00 /* CoreAudio.framework */; };
+		20E6856028F25B1D00B95C00 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855F28F25B1D00B95C00 /* CoreVideo.framework */; };
+		20E6856128F25B2600B95C00 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855D28F25B1300B95C00 /* IOKit.framework */; };
+		20E6856328F25B3000B95C00 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856228F25B2F00B95C00 /* OpenGL.framework */; };
+		20E6856528F25B3700B95C00 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856428F25B3700B95C00 /* AppKit.framework */; };
+		20E6856728F25B3F00B95C00 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856628F25B3E00B95C00 /* Cocoa.framework */; };
+		20E6856928F25B5F00B95C00 /* libz.1.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856828F25B5400B95C00 /* libz.1.tbd */; };
+		20E6856F28F25E5B00B95C00 /* libbz2.1.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6856E28F25E5B00B95C00 /* libbz2.1.0.tbd */; };
 		52C5BFB41D277B98001E3B10 /* plugin_registration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52C5BFB21D277B98001E3B10 /* plugin_registration.cpp */; };
 /* End PBXBuildFile section */
 
@@ -32,6 +36,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				20E6855428F225F800B95C00 /* SDL2.framework in Copy Frameworks */,
+				20E6855628F2260100B95C00 /* AGSKit.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -40,23 +46,25 @@
 
 /* Begin PBXFileReference section */
 		1D6058910D05DD3D006BFB54 /* AGS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AGS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		20C76AB428F3488300772CFC /* ags.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ags.entitlements; sourceTree = "<group>"; };
+		20E6811C28F1CA1700B95C00 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = ../AGSKit/SDL2.framework; sourceTree = "<group>"; };
+		20E684FD28F2202700B95C00 /* acsetup.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = acsetup.cfg; path = ../../Resources/acsetup.cfg; sourceTree = "<group>"; };
+		20E684FE28F2202700B95C00 /* game.ags */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = game.ags; path = ../../Resources/game.ags; sourceTree = "<group>"; };
+		20E684FF28F2202700B95C00 /* audio.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = audio.vox; path = ../../Resources/audio.vox; sourceTree = "<group>"; };
+		20E6850028F2202800B95C00 /* ags.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = ags.icns; path = ../../Resources/ags.icns; sourceTree = "<group>"; };
+		20E6850128F2202800B95C00 /* speech.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = speech.vox; path = ../../Resources/speech.vox; sourceTree = "<group>"; };
+		20E6855728F25AF000B95C00 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		20E6855928F25AF800B95C00 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		20E6855B28F25B0400B95C00 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		20E6855D28F25B1300B95C00 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		20E6855F28F25B1D00B95C00 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		20E6856228F25B2F00B95C00 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		20E6856428F25B3700B95C00 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		20E6856628F25B3E00B95C00 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		20E6856828F25B5400B95C00 /* libz.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.1.tbd; path = usr/lib/libz.1.tbd; sourceTree = SDKROOT; };
+		20E6856E28F25E5B00B95C00 /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
 		32CA4F630368D1EE00C91783 /* ags_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ags_Prefix.pch; sourceTree = "<group>"; };
 		523AB9701D27DA40002B98F0 /* AGSKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AGSKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		52B8A6141D27785A00FA453F /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = /usr/lib/libz.1.dylib; sourceTree = "<absolute>"; };
-		52B8A6151D27785A00FA453F /* libbz2.1.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.dylib; path = /usr/lib/libbz2.1.0.dylib; sourceTree = "<absolute>"; };
-		52B8A6161D27785A00FA453F /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
-		52B8A6171D27785A00FA453F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
-		52B8A6181D27785A00FA453F /* QuickTime.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickTime.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/QuickTime.framework; sourceTree = "<absolute>"; };
-		52B8A6191D27785A00FA453F /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = "<absolute>"; };
-		52B8A61A1D27785A00FA453F /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreAudio.framework; sourceTree = "<absolute>"; };
-		52B8A61B1D27785A00FA453F /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/AudioUnit.framework; sourceTree = "<absolute>"; };
-		52B8A61C1D27785A00FA453F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
-		52B8A61D1D27785A00FA453F /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
-		52B8A61E1D27785A00FA453F /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/AudioToolbox.framework; sourceTree = "<absolute>"; };
-		52C5BFAA1D277B43001E3B10 /* game.ags */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = game.ags; path = game_files/game.ags; sourceTree = "<group>"; };
-		52C5BFAB1D277B43001E3B10 /* acsetup.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = acsetup.cfg; path = game_files/acsetup.cfg; sourceTree = "<group>"; };
-		52C5BFAC1D277B43001E3B10 /* audio.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = audio.vox; path = game_files/audio.vox; sourceTree = "<group>"; };
-		52C5BFAD1D277B43001E3B10 /* speech.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = speech.vox; path = game_files/speech.vox; sourceTree = "<group>"; };
 		52C5BFB21D277B98001E3B10 /* plugin_registration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = plugin_registration.cpp; sourceTree = "<group>"; };
 		52C5BFB31D277B98001E3B10 /* plugin_registration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = plugin_registration.hpp; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* ags-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ags-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
@@ -67,17 +75,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52B8A6281D27785A00FA453F /* CoreAudio.framework in Frameworks */,
-				52B8A6231D27785A00FA453F /* libbz2.1.0.dylib in Frameworks */,
-				52B8A6271D27785A00FA453F /* IOKit.framework in Frameworks */,
-				52B8A62C1D27785A00FA453F /* AudioToolbox.framework in Frameworks */,
-				52B8A62B1D27785A00FA453F /* OpenGL.framework in Frameworks */,
-				52B8A6291D27785A00FA453F /* AudioUnit.framework in Frameworks */,
-				52B8A62A1D27785A00FA453F /* AppKit.framework in Frameworks */,
-				52B8A6251D27785A00FA453F /* Cocoa.framework in Frameworks */,
-				52B8A6221D27785A00FA453F /* libz.1.dylib in Frameworks */,
-				523AB9711D27DA40002B98F0 /* AGSKit.framework in Frameworks */,
-				52B8A6241D27785A00FA453F /* CoreVideo.framework in Frameworks */,
+				20E6856928F25B5F00B95C00 /* libz.1.tbd in Frameworks */,
+				20E6856328F25B3000B95C00 /* OpenGL.framework in Frameworks */,
+				20E6856F28F25E5B00B95C00 /* libbz2.1.0.tbd in Frameworks */,
+				20E6856028F25B1D00B95C00 /* CoreVideo.framework in Frameworks */,
+				20E6855528F2260100B95C00 /* AGSKit.framework in Frameworks */,
+				20E6855A28F25AF800B95C00 /* AudioUnit.framework in Frameworks */,
+				20E6856728F25B3F00B95C00 /* Cocoa.framework in Frameworks */,
+				20E6856128F25B2600B95C00 /* IOKit.framework in Frameworks */,
+				20E6855328F225F800B95C00 /* SDL2.framework in Frameworks */,
+				20E6855C28F25B0500B95C00 /* CoreAudio.framework in Frameworks */,
+				20E6856528F25B3700B95C00 /* AppKit.framework in Frameworks */,
+				20E6855828F25AF000B95C00 /* AudioToolbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,6 +111,7 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				20C76AB428F3488300772CFC /* ags.entitlements */,
 				52C5BFB21D277B98001E3B10 /* plugin_registration.cpp */,
 				52C5BFB31D277B98001E3B10 /* plugin_registration.hpp */,
 				080E96DDFE201D6D7F000001 /* Classes */,
@@ -126,11 +136,12 @@
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				20E684FD28F2202700B95C00 /* acsetup.cfg */,
+				20E6850028F2202800B95C00 /* ags.icns */,
+				20E684FF28F2202700B95C00 /* audio.vox */,
+				20E684FE28F2202700B95C00 /* game.ags */,
+				20E6850128F2202800B95C00 /* speech.vox */,
 				8D1107310486CEB800E47090 /* ags-Info.plist */,
-				52C5BFAA1D277B43001E3B10 /* game.ags */,
-				52C5BFAB1D277B43001E3B10 /* acsetup.cfg */,
-				52C5BFAC1D277B43001E3B10 /* audio.vox */,
-				52C5BFAD1D277B43001E3B10 /* speech.vox */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -138,29 +149,20 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				20E6856E28F25E5B00B95C00 /* libbz2.1.0.tbd */,
+				20E6856828F25B5400B95C00 /* libz.1.tbd */,
+				20E6856628F25B3E00B95C00 /* Cocoa.framework */,
+				20E6856428F25B3700B95C00 /* AppKit.framework */,
+				20E6856228F25B2F00B95C00 /* OpenGL.framework */,
+				20E6855F28F25B1D00B95C00 /* CoreVideo.framework */,
+				20E6855D28F25B1300B95C00 /* IOKit.framework */,
+				20E6855B28F25B0400B95C00 /* CoreAudio.framework */,
+				20E6855928F25AF800B95C00 /* AudioUnit.framework */,
+				20E6855728F25AF000B95C00 /* AudioToolbox.framework */,
+				20E6811C28F1CA1700B95C00 /* SDL2.framework */,
 				523AB9701D27DA40002B98F0 /* AGSKit.framework */,
-				52B8A61F1D27785A00FA453F /* System Frameworks */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		52B8A61F1D27785A00FA453F /* System Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				52B8A6141D27785A00FA453F /* libz.1.dylib */,
-				52B8A6151D27785A00FA453F /* libbz2.1.0.dylib */,
-				52B8A6161D27785A00FA453F /* CoreVideo.framework */,
-				52B8A6171D27785A00FA453F /* Cocoa.framework */,
-				52B8A6181D27785A00FA453F /* QuickTime.framework */,
-				52B8A6191D27785A00FA453F /* IOKit.framework */,
-				52B8A61A1D27785A00FA453F /* CoreAudio.framework */,
-				52B8A61B1D27785A00FA453F /* AudioUnit.framework */,
-				52B8A61C1D27785A00FA453F /* AppKit.framework */,
-				52B8A61D1D27785A00FA453F /* OpenGL.framework */,
-				52B8A61E1D27785A00FA453F /* AudioToolbox.framework */,
-			);
-			name = "System Frameworks";
-			path = ../../lib;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -190,7 +192,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 1400;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "ags" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -218,10 +220,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52C5BFAF1D277B43001E3B10 /* acsetup.cfg in Resources */,
-				52C5BFB11D277B43001E3B10 /* speech.vox in Resources */,
-				52C5BFB01D277B43001E3B10 /* audio.vox in Resources */,
-				52C5BFAE1D277B43001E3B10 /* game.ags in Resources */,
+				20E6850428F2202800B95C00 /* audio.vox in Resources */,
+				20E6850628F2202800B95C00 /* speech.vox in Resources */,
+				20E6850328F2202800B95C00 /* game.ags in Resources */,
+				20E6850228F2202800B95C00 /* acsetup.cfg in Resources */,
+				20E6850528F2202800B95C00 /* ags.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -244,14 +247,31 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = ags.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				FRAMEWORK_SEARCH_PATHS = "${SOURCE_ROOT}/../AGSKit";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ags_Prefix.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					DISABLE_MPEG_AUDIO,
+					AGS_INVERTED_COLOR_ORDER,
+					MAC_VERSION,
+					BUILTIN_PLUGINS,
+					DEBUG,
+					ZLIB_DEBUG,
+				);
 				INFOPLIST_FILE = "ags-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.adventuregamestudio.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AGS;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Debug;
 		};
@@ -260,13 +280,22 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = ags.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				FRAMEWORK_SEARCH_PATHS = "${SOURCE_ROOT}/../AGSKit";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ags_Prefix.pch;
 				INFOPLIST_FILE = "ags-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.adventuregamestudio.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = AGS;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 			};
 			name = Release;
 		};
@@ -274,17 +303,30 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -297,6 +339,7 @@
 					MAC_VERSION,
 					BUILTIN_PLUGINS,
 					DEBUG,
+					ZLIB_DEBUG,
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -315,17 +358,30 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/OSX/xcode/ags/ags.xcodeproj/xcshareddata/xcschemes/ags.xcscheme
+++ b/OSX/xcode/ags/ags.xcodeproj/xcshareddata/xcschemes/ags.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:ags.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -48,7 +46,7 @@
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
@@ -61,15 +59,13 @@
             ReferencedContainer = "container:ags.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/OSX/xcode/ags/plugin_registration.cpp
+++ b/OSX/xcode/ags/plugin_registration.cpp
@@ -9,7 +9,7 @@
 #include "plugin_registration.hpp"
 
 #include "plugin/agsplugin.h"
-#include "plugin/plugin_builtin.h"
+//#include "plugin/plugin_builtin.h"
 //#include "example.h"
 
 typedef void (*t_engine_pre_init_callback)(void);


### PR DESCRIPTION
This should make the Xcode project be useable again in macOS. This is useful to figure out the iOS port (#1505), as it will require using Xcode.

It requires some manual steps which I detailed in the README.

I can split the contents of this commit in different ones if necessary.

---

When trying to use Xcode to debug AGS, I could not make AGS work for nothing... Turns out Xcode by default adds some parameters to a debugged executable and AGS was picking up these. 

I configured the debug schemes here to not add these parameters, so things are working. But I think maybe we should print the full argv if there's an unused parameter that is preceded by `-`. I will probably open an issue on this later.