### PR TITLE
Editor: do not repopulate the tree when adding new folders

### DIFF
--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -161,7 +161,6 @@ namespace AGS.Editor.Components
             FolderType newFolder = CreateFolderObject("New folder", parentFolder);
             parentFolder.SubFolders.Add(newFolder);
             string newNodeID = AddNodeForFolder(newFolder);
-            RePopulateTreeView();
             _guiController.ProjectTree.BeginLabelEdit(this, newNodeID);
         }
 

--- a/Editor/AGS.Editor/GUI/ProjectTree.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTree.cs
@@ -90,13 +90,26 @@ namespace AGS.Editor
             RegisterTreeNode(id, component);
 
             iconKey = SetDefaultIconIfNoneProvided(iconKey);
-            if (_lastAddedNode != null)
+            TreeNodeCollection nodes = (_lastAddedNode != null) ? _lastAddedNode.Nodes : this._projectTree.Nodes;
+            
+            // only audiocomponent requires manual arrangement, and only in the main folder
+            bool foldersOnTop = !(component is Components.AudioComponent && _lastAddedNode != null && _lastAddedNode.Level == 0);
+
+            if (foldersOnTop && iconKey == "GenericFolderIcon")
             {
-                _lastAddedNode = _lastAddedNode.Nodes.Add(id, name, iconKey, iconKey);
+                // find last folder index so we can insert right below it, but above other entries
+                // speech icon canonically stays above
+                int index = 0;
+                
+                for (; index < nodes.Count;index++)
+                {
+                    if (nodes[index].ImageKey != iconKey) break;
+                }
+                _lastAddedNode = nodes.Insert(index, id, name, iconKey, iconKey);
             }
             else
             {
-                _lastAddedNode = this._projectTree.Nodes.Add(id, name, iconKey, iconKey);
+                _lastAddedNode = nodes.Add(id, name, iconKey, iconKey);
             }
             ProjectTreeItem newItem = new ProjectTreeItem(id, _lastAddedNode);
             _lastAddedNode.Tag = newItem;


### PR DESCRIPTION
The tree view was entirely repopulated in order to sort folders before other entries, but doing so could break focusing on the newly created item due to keys being recreated from scratch.

I added a check to directly insert folders where appropriate, along with an exception for the Audio where the speech icon stays above.

Fixes #1811