### PR TITLE
AGS 4: Remove "has alpha channel" sprite flag, and related parameters

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -216,12 +216,8 @@ enum GameGuiAlphaRenderingStyle
 
 
 // Sprite flags (serialized as 8-bit)
-#define SPF_HIRES           0x01  // sized for high native resolution (legacy option)
-#define SPF_HICOLOR         0x02  // is 16-bit
 #define SPF_DYNAMICALLOC    0x04  // created by runtime script
-#define SPF_TRUECOLOR       0x08  // is 32-bit
 #define SPF_ALPHACHANNEL    0x10  // has alpha-channel
-#define SPF_VAR_RESOLUTION  0x20  // variable resolution (refer to SPF_HIRES)
 #define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
 
 // General information about sprite (properties, size)

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -217,8 +217,6 @@ enum GameGuiAlphaRenderingStyle
 
 // Sprite flags (serialized as 8-bit)
 #define SPF_DYNAMICALLOC    0x04  // created by runtime script
-#define SPF_ALPHACHANNEL    0x10  // has alpha-channel
-#define SPF_HADALPHACHANNEL 0x80  // the saved sprite on disk has one
 
 // General information about sprite (properties, size)
 struct SpriteInfo

--- a/Common/game/room_file.cpp
+++ b/Common/game/room_file.cpp
@@ -500,6 +500,13 @@ HRoomFileError UpdateRoomData(RoomStruct *room, RoomFileVersion data_ver, const 
         }
     }
 
+    // Prior to ags4 room backgrounds were ignoring alpha channel
+    if (data_ver < kRoomVersion_399)
+    {
+        for (int i = 0; i < room->BgFrameCount; ++i)
+            BitmapHelper::MakeOpaque(room->BgFrames[i].Graphic.get());
+    }
+
     // sync bpalettes[0] with room.pal
     memcpy(room->BgFrames[0].Palette, room->Palette, sizeof(RGB) * 256);
     return HRoomFileError::None();

--- a/Common/gfx/bitmap.cpp
+++ b/Common/gfx/bitmap.cpp
@@ -108,6 +108,21 @@ Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height)
     return bmp;
 }
 
+void MakeOpaque(Bitmap *bmp)
+{
+    if (bmp->GetColorDepth() < 32)
+        return; // no alpha channel
+
+    for (int i = 0; i < bmp->GetHeight(); ++i)
+    {
+        uint32_t *line = reinterpret_cast<uint32_t*>(bmp->GetScanLineForWriting(i));
+        uint32_t *line_end = line + bmp->GetWidth();
+        for (uint32_t *px = line; px != line_end; ++px)
+            *px = makeacol32(getr32(*px), getg32(*px), getb32(*px), 255);
+    }
+}
+
+
 // Functor that copies the "mask color" pixels from source to dest
 template <class TPx, size_t BPP_>
 struct PixelTransCpy

--- a/Common/gfx/bitmap.h
+++ b/Common/gfx/bitmap.h
@@ -81,6 +81,8 @@ namespace BitmapHelper
     // Stretches bitmap to the requested size. The new bitmap will have same
     // colour depth. Returns original bitmap if no changes are necessary. 
     Bitmap *AdjustBitmapSize(Bitmap *src, int width, int height);
+    // Makes the given bitmap opaque (full alpha), while keeping pixel RGB unchanged.
+    void    MakeOpaque(Bitmap *bmp);
     // Copy transparency mask and/or alpha channel from one bitmap into another.
     // Destination and mask bitmaps must be of the same pixel format.
     // Transparency is merged, meaning that fully transparent pixels on

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -79,12 +79,6 @@ GUIButton::GUIButton()
     _scEventArgs[0] = "GUIControl *control, MouseButton button";
 }
 
-bool GUIButton::HasAlphaChannel() const
-{
-    return ((_currentImage > 0) && is_sprite_alpha(_currentImage)) ||
-        (!_unnamed && is_font_antialiased(Font));
-}
-
 const String &GUIButton::GetText() const
 {
     return _text;

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -389,7 +389,7 @@ void GUIButton::DrawImageButton(Bitmap *ds, int x, int y, bool draw_disabled)
         ds->SetClip(RectWH(x, y, Width, Height));
 
     if (spriteset[_currentImage] != nullptr)
-        draw_gui_sprite_flipped(ds, _currentImage, x, y, true, kBlend_Normal, _imageFlags & VFLG_FLIPSPRITE);
+        draw_gui_sprite_flipped(ds, _currentImage, x, y, kBlend_Normal, _imageFlags & VFLG_FLIPSPRITE);
 
     // Draw active inventory item
     if (_placeholder != kButtonPlace_None && gui_inv_pic >= 0)
@@ -411,8 +411,7 @@ void GUIButton::DrawImageButton(Bitmap *ds, int x, int y, bool draw_disabled)
         {
             draw_gui_sprite(ds, gui_inv_pic,
                 x + Width / 2 - inv_sz.Width / 2,
-                y + Height / 2 - inv_sz.Height / 2,
-                true);
+                y + Height / 2 - inv_sz.Height / 2);
         }
     }
 

--- a/Common/gui/guibutton.h
+++ b/Common/gui/guibutton.h
@@ -57,7 +57,6 @@ class GUIButton : public GUIObject
 public:
     GUIButton();
 
-    bool HasAlphaChannel() const override;
     const String &GetText() const;
     bool IsImageButton() const;
     bool IsClippingImage() const;

--- a/Common/gui/guiinv.h
+++ b/Common/gui/guiinv.h
@@ -27,7 +27,6 @@ class GUIInvWindow : public GUIObject
 public:
     GUIInvWindow();
 
-    bool HasAlphaChannel() const override;
     // This function has distinct implementations in Engine and Editor
     int GetCharacterId() const;
 

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -37,11 +37,6 @@ GUILabel::GUILabel()
     _scEventCount = 0;
 }
 
-bool GUILabel::HasAlphaChannel() const
-{
-    return is_font_antialiased(Font);
-}
-
 String GUILabel::GetText() const
 {
     return Text;

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -30,7 +30,6 @@ class GUILabel : public GUIObject
 public:
     GUILabel();
 
-    bool HasAlphaChannel() const override;
     // Gets label's text property in original set form (with macros etc)
     String       GetText() const;
     // Gets which macro are contained within label's text

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -45,11 +45,6 @@ GUIListBox::GUIListBox()
     _scEventArgs[0] = "GUIControl *control";
 }
 
-bool GUIListBox::HasAlphaChannel() const
-{
-    return is_font_antialiased(Font);
-}
-
 int GUIListBox::GetItemAt(int x, int y) const
 {
     if (RowHeight <= 0 || IsInRightMargin(x))

--- a/Common/gui/guilistbox.h
+++ b/Common/gui/guilistbox.h
@@ -28,7 +28,6 @@ class GUIListBox : public GUIObject
 public:
     GUIListBox();
 
-    bool HasAlphaChannel() const override;
     bool AreArrowsShown() const;
     bool IsBorderShown() const;
     bool IsSvgIndex() const;

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -266,7 +266,7 @@ void GUIMain::DrawSelf(Bitmap *ds)
     SET_EIP(378);
 
     if (BgImage > 0 && spriteset[BgImage] != nullptr)
-        draw_gui_sprite(ds, BgImage, 0, 0, false);
+        draw_gui_sprite(ds, BgImage, 0, 0);
 
     SET_EIP(379);
 }
@@ -305,8 +305,8 @@ void GUIMain::DrawWithControls(Bitmap *ds)
             const Rect rc = objToDraw->CalcGraphicRect(GUI::Options.ClipControls && objToDraw->IsContentClipped());
             tempbmp.CreateTransparent(rc.GetWidth(), rc.GetHeight());
             objToDraw->Draw(&tempbmp, -rc.Left, -rc.Top);
-            draw_gui_sprite(ds, true, objToDraw->X + rc.Left, objToDraw->Y + rc.Top,
-                &tempbmp, objToDraw->HasAlphaChannel(), kBlend_Normal,
+            draw_gui_sprite(ds, objToDraw->X + rc.Left, objToDraw->Y + rc.Top,
+                &tempbmp, kBlend_Normal,
                 GfxDef::LegacyTrans255ToAlpha255(objToDraw->GetTransparency()));
         }
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -269,16 +269,15 @@ extern int get_adjusted_spriteheight(int spr);
 extern bool is_sprite_alpha(int spr);
 
 // This function has distinct implementations in Engine and Editor
-extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y, bool use_alpha = true,
+extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y,
                             Common::BlendMode blend_mode = Common::kBlend_Normal);
-extern void draw_gui_sprite(Common::Bitmap *ds, bool use_alpha, int x, int y,
-                            Common::Bitmap *image, bool src_has_alpha,
+extern void draw_gui_sprite(Common::Bitmap *ds, int x, int y,
+                            Common::Bitmap *image,
                             Common::BlendMode blend_mode, int alpha);
 
-extern void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode, bool is_flipped);
-extern void draw_gui_sprite_flipped(Common::Bitmap *ds, bool use_alpha, int x, int y,
-    Common::Bitmap *image, bool src_has_alpha,
-    Common::BlendMode blend_mode, int alpha, bool is_flipped);
+extern void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, Common::BlendMode blend_mode, bool is_flipped);
+extern void draw_gui_sprite_flipped(Common::Bitmap *ds, int x, int y,
+    Common::Bitmap *image, Common::BlendMode blend_mode, int alpha, bool is_flipped);
 
 // Those function have distinct implementations in Engine and Editor
 extern void wouttext_outline(Common::Bitmap *ds, int xxp, int yyp, int usingfont, color_t text_color, const char *texx);

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -60,8 +60,6 @@ public:
 
     void    InitDefaults();
 
-    // Tells if the gui background supports alpha channel
-    bool    HasAlphaChannel() const;
     // Tells if GUI will react on clicking on it
     bool    IsClickable() const;
     // Tells if GUI's visibility is overridden and it won't be displayed on
@@ -266,7 +264,6 @@ extern int gui_inv_pic;
 
 extern int get_adjusted_spritewidth(int spr);
 extern int get_adjusted_spriteheight(int spr);
-extern bool is_sprite_alpha(int spr);
 
 // This function has distinct implementations in Engine and Editor
 extern void draw_gui_sprite(Common::Bitmap *ds, int spr, int x, int y,

--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -58,8 +58,6 @@ public:
     int             GetTransparency() const { return _transparency; }
     // Compatibility: should the control's graphic be clipped to its x,y,w,h
     virtual bool    IsContentClipped() const { return true; }
-    // Tells if the object image supports alpha channel
-    virtual bool    HasAlphaChannel() const { return false; }
     
     // Operations
     // Returns the (untransformed!) visual rectangle of this control,

--- a/Common/gui/guislider.cpp
+++ b/Common/gui/guislider.cpp
@@ -45,11 +45,6 @@ bool GUISlider::IsHorizontal() const
     return Width > Height;
 }
 
-bool GUISlider::HasAlphaChannel() const
-{
-    return is_sprite_alpha(BgImage) || is_sprite_alpha(HandleImage);
-}
-
 bool GUISlider::IsOverControl(int x, int y, int leeway) const
 {
     // check the overall boundary

--- a/Common/gui/guislider.cpp
+++ b/Common/gui/guislider.cpp
@@ -169,7 +169,7 @@ void GUISlider::Draw(Bitmap *ds, int x, int y)
         // draw the tiled background image
         do
         {
-            draw_gui_sprite(ds, BgImage, cx, cy, true);
+            draw_gui_sprite(ds, BgImage, cx, cy);
             cx += x_inc;
             cy += y_inc;
             // done as a do..while so that at least one of the image is drawn
@@ -193,7 +193,7 @@ void GUISlider::Draw(Bitmap *ds, int x, int y)
     const int handle_im = ((HandleImage > 0) && spriteset[HandleImage]) ? HandleImage : 0;
     if (handle_im > 0) // handle is a sprite
     {
-        draw_gui_sprite(ds, handle_im, handle.Left, handle.Top, true);
+        draw_gui_sprite(ds, handle_im, handle.Left, handle.Top);
     }
     else // handle is a drawn rectangle
     {

--- a/Common/gui/guislider.h
+++ b/Common/gui/guislider.h
@@ -32,7 +32,6 @@ public:
     bool IsOverControl(int x, int y, int leeway) const override;
     // Compatibility: sliders are not clipped as of 3.6.0
     bool IsContentClipped() const override { return false; }
-    bool HasAlphaChannel() const override;
 
     // Operations
     Rect CalcGraphicRect(bool clipped) override;

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -38,11 +38,6 @@ GUITextBox::GUITextBox()
     _scEventArgs[0] = "GUIControl *control";
 }
 
-bool GUITextBox::HasAlphaChannel() const
-{
-    return is_font_antialiased(Font);
-}
-
 bool GUITextBox::IsBorderShown() const
 {
     return (TextBoxFlags & kTextBox_ShowBorder) != 0;

--- a/Common/gui/guitextbox.h
+++ b/Common/gui/guitextbox.h
@@ -28,7 +28,6 @@ class GUITextBox : public GUIObject
 public:
     GUITextBox();
 
-    bool HasAlphaChannel() const override;
     bool IsBorderShown() const;
 
     // Operations

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -640,7 +640,6 @@ namespace AGS.Editor
             {
                 mostTopmost = Math.Max(sprite.Number, mostTopmost);
                 flags[sprite.Number] = 0;
-                if (sprite.AlphaChannel) flags[sprite.Number] |= NativeConstants.SPF_ALPHACHANNEL;
             }
             foreach (SpriteFolder subfolder in folder.SubFolders)
             {

--- a/Editor/AGS.Editor/ImportExport.cs
+++ b/Editor/AGS.Editor/ImportExport.cs
@@ -1421,8 +1421,6 @@ namespace AGS.Editor
                     folderToAddTo.Sprites.Add(newSprite);
                 }
             }
-
-            Factory.NativeProxy.SpriteResolutionsChanged(newSprites.ToArray());
         }
     }
 }

--- a/Editor/AGS.Editor/ImportExport.cs
+++ b/Editor/AGS.Editor/ImportExport.cs
@@ -48,7 +48,6 @@ namespace AGS.Editor
         private const string GUI_XML_SPRITE_HEIGHT = "Height";
         private const string GUI_XML_SPRITE_RESOLUTION = "Resolution";
 
-        private static int SPRITE_FLAG_ALPHA_CHANNEL = NativeConstants.SPF_ALPHACHANNEL;
         private static int EDITOR_DAT_LATEST_FILE_VERSION = 7;
         private static Dictionary<string, ImageFormat> ImageFileTypes = new Dictionary<string, ImageFormat>();
 
@@ -1120,17 +1119,13 @@ namespace AGS.Editor
             return view;
         }
 
+        // [CLNUP] remove old format?
         private static void WriteOldStyleViewFrame(BinaryWriter writer, ViewFrame frame)
         {
             Bitmap bmp = Factory.NativeProxy.GetBitmapForSprite(frame.Image);
             int colDepth = GetColorDepthForPixelFormat(bmp.PixelFormat);
             writer.Write(colDepth);
             int spriteFlags = 0;
-            // TODO: why we are not saving resolution flags?
-            if (bmp.PixelFormat == PixelFormat.Format32bppArgb)
-            {
-                spriteFlags |= SPRITE_FLAG_ALPHA_CHANNEL;
-            }
             writer.Write((byte)spriteFlags);
             writer.Write(bmp.Width);
             writer.Write(bmp.Height);
@@ -1150,6 +1145,7 @@ namespace AGS.Editor
             bmp.Dispose();
         }
 
+        // [CLNUP] remove old format support
         private static Sprite ReadOldStyleViewFrame(BinaryReader reader, ViewLoop loop, ViewFrame frame, Color[] palette)
         {
             int colDepth = reader.ReadInt32();
@@ -1164,7 +1160,7 @@ namespace AGS.Editor
             int height = reader.ReadInt32();
             byte[] spriteData = reader.ReadBytes(width * height * ((colDepth + 1) / 8));
 
-            Sprite newSprite = ImportSpriteFromRawData(colDepth, width, height, (spriteFlags & SPRITE_FLAG_ALPHA_CHANNEL) != 0, spriteData, palette);
+            Sprite newSprite = ImportSpriteFromRawData(colDepth, width, height, false, spriteData, palette);
             return newSprite;
         }
 

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -169,11 +169,6 @@ namespace AGS.Editor
             _native.ChangeSpriteNumber(sprite, newNumber);
         }
 
-        public void SpriteResolutionsChanged(Sprite[] sprites)
-        {
-            _native.SpriteResolutionsChanged(sprites);
-        }
-
         public Bitmap GetBitmapForSprite(int spriteSlot, int width, int height)
         {
 			lock (_spriteSetLock)

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -974,13 +974,13 @@ builtin managed struct Overlay {
 
 builtin managed struct DynamicSprite {
   /// Creates a blank dynamic sprite of the specified size.
-  import static DynamicSprite* Create(int width, int height, bool hasAlphaChannel=false);    // $AUTOCOMPLETESTATICONLY$
+  import static DynamicSprite* Create(int width, int height);    // $AUTOCOMPLETESTATICONLY$
   /// Creates a dynamic sprite as a copy of a room background.
   import static DynamicSprite* CreateFromBackground(int frame=SCR_NO_VALUE, int x=SCR_NO_VALUE, int y=SCR_NO_VALUE, int width=SCR_NO_VALUE, int height=SCR_NO_VALUE);    // $AUTOCOMPLETESTATICONLY$
   /// Creates a dynamic sprite as a copy of a drawing surface.
   import static DynamicSprite* CreateFromDrawingSurface(DrawingSurface* surface, int x, int y, int width, int height);    // $AUTOCOMPLETESTATICONLY$
   /// Creates a dynamic sprite as a copy of an existing sprite.
-  import static DynamicSprite* CreateFromExistingSprite(int slot, bool preserveAlphaChannel=0);    // $AUTOCOMPLETESTATICONLY$
+  import static DynamicSprite* CreateFromExistingSprite(int slot);    // $AUTOCOMPLETESTATICONLY$
   /// Creates a dynamic sprite from a BMP or PCX file.
   import static DynamicSprite* CreateFromFile(const string filename);              // $AUTOCOMPLETESTATICONLY$
   /// Creates a dynamic sprite from a save game screenshot.
@@ -1617,8 +1617,6 @@ builtin managed struct DialogOptionsRenderingInfo {
   import attribute int X;
   /// The Y co-ordinate of the top-left corner of the dialog options
   import attribute int Y;
-  /// Should the drawing surface have alpha channel
-  import attribute bool HasAlphaChannel;
   /// Runs the active dialog option
   import bool RunActiveOption();
   /// Forces dialog options to redraw itself

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -41,7 +41,6 @@ namespace AGS.Editor
         public static readonly int GAME_RESOLUTION_CUSTOM = (int)Factory.NativeProxy.GetNativeConstant("GAME_RESOLUTION_CUSTOM");
         public static readonly int CHUNKSIZE = (int)Factory.NativeProxy.GetNativeConstant("CHUNKSIZE");
         public static readonly string SPRSET_NAME = (string)Factory.NativeProxy.GetNativeConstant("SPRSET_NAME");
-        public static readonly byte SPF_ALPHACHANNEL = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_ALPHACHANNEL");
         public static readonly byte[] PASSWORD_ENC_STRING = (byte[])Factory.NativeProxy.GetNativeConstant("PASSWORD_ENC_STRING");
         public static readonly int LOOPFLAG_RUNNEXTLOOP = (int)Factory.NativeProxy.GetNativeConstant("LOOPFLAG_RUNNEXTLOOP");
         public static readonly int VFLG_FLIPSPRITE = (int)Factory.NativeProxy.GetNativeConstant("VFLG_FLIPSPRITE");

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -41,8 +41,6 @@ namespace AGS.Editor
         public static readonly int GAME_RESOLUTION_CUSTOM = (int)Factory.NativeProxy.GetNativeConstant("GAME_RESOLUTION_CUSTOM");
         public static readonly int CHUNKSIZE = (int)Factory.NativeProxy.GetNativeConstant("CHUNKSIZE");
         public static readonly string SPRSET_NAME = (string)Factory.NativeProxy.GetNativeConstant("SPRSET_NAME");
-        public static readonly byte SPF_VAR_RESOLUTION = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_VAR_RESOLUTION");
-        public static readonly byte SPF_HIRES = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_HIRES");
         public static readonly byte SPF_ALPHACHANNEL = (byte)(int)Factory.NativeProxy.GetNativeConstant("SPF_ALPHACHANNEL");
         public static readonly byte[] PASSWORD_ENC_STRING = (byte[])Factory.NativeProxy.GetNativeConstant("PASSWORD_ENC_STRING");
         public static readonly int LOOPFLAG_RUNNEXTLOOP = (int)Factory.NativeProxy.GetNativeConstant("LOOPFLAG_RUNNEXTLOOP");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -588,7 +588,6 @@ namespace AGS
             if (name->Equals("GAME_RESOLUTION_CUSTOM")) return (int)kGameResolution_Custom;
             if (name->Equals("CHUNKSIZE")) return CHUNKSIZE;
             if (name->Equals("SPRSET_NAME")) return gcnew String(sprsetname);
-            if (name->Equals("SPF_ALPHACHANNEL")) return SPF_ALPHACHANNEL;
             if (name->Equals("PASSWORD_ENC_STRING"))
             {
                 int len = (int)strlen(passwencstring);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -64,7 +64,6 @@ extern bool load_template_file(const AGSString &fileName, AGSString &description
 extern HAGSError extract_template_files(const AGSString &templateFileName);
 extern HAGSError extract_room_template_files(const AGSString &templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
-extern void update_sprite_resolution(int spriteNum);
 extern void SaveNativeSprites(Settings^ gameSettings);
 extern void ReplaceSpriteFile(const AGSString &new_spritefile, const AGSString &new_indexfile, bool fallback_tempfiles);
 extern HAGSError reset_sprite_file();
@@ -367,14 +366,6 @@ namespace AGS
 			sprite->Number = newNumber;
 		}
 
-		void NativeMethods::SpriteResolutionsChanged(cli::array<Sprite^>^ sprites)
-		{
-			for each (Sprite^ sprite in sprites)
-			{
-				update_sprite_resolution(sprite->Number);
-			}
-		}
-
         static int GetCurrentlyLoadedRoomNumber()
         {
             return 0; // FIXME: not working after moved to open room format
@@ -597,8 +588,6 @@ namespace AGS
             if (name->Equals("GAME_RESOLUTION_CUSTOM")) return (int)kGameResolution_Custom;
             if (name->Equals("CHUNKSIZE")) return CHUNKSIZE;
             if (name->Equals("SPRSET_NAME")) return gcnew String(sprsetname);
-            if (name->Equals("SPF_VAR_RESOLUTION")) return SPF_VAR_RESOLUTION;
-            if (name->Equals("SPF_HIRES")) return SPF_HIRES;
             if (name->Equals("SPF_ALPHACHANNEL")) return SPF_ALPHACHANNEL;
             if (name->Equals("PASSWORD_ENC_STRING"))
             {

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -56,7 +56,6 @@ namespace Native
 			bool CropSpriteEdges(System::Collections::Generic::IList<Sprite^>^ sprites, bool symmetric);
 			bool DoesSpriteExist(int spriteNumber);
 			void ChangeSpriteNumber(Sprite^ sprite, int newNumber);
-			void SpriteResolutionsChanged(cli::array<Sprite^>^ sprites);
 			void Shutdown();
 			Game^ ImportOldGameFile(String^ fileName);
 			void ImportSCIFont(String ^fileName, int fontSlot);

--- a/Editor/AGS.Native/NativeRoom.cpp
+++ b/Editor/AGS.Native/NativeRoom.cpp
@@ -12,8 +12,8 @@ using SysBitmap = System::Drawing::Bitmap;
 
 
 AGSBitmap *CreateBlockFromBitmap(SysBitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth);
-extern SysBitmap^ ConvertBlockToBitmap32(AGSBitmap *todraw, int width, int height, bool useAlphaChannel);
-extern SysBitmap^ ConvertBlockToBitmap(AGSBitmap *todraw, bool useAlphaChannel);
+extern SysBitmap^ ConvertBlockToBitmap32(AGSBitmap *todraw, int width, int height);
+extern SysBitmap^ ConvertBlockToBitmap(AGSBitmap *todraw);
 extern void convert_room_from_native(const RoomStruct &rs, AGS::Types::Room ^room, System::Text::Encoding ^defEncoding);
 extern void convert_room_to_native(Room ^room, RoomStruct &rs);
 extern AGSString load_room_file(RoomStruct &rs, const AGSString &filename);
@@ -65,7 +65,7 @@ SysBitmap ^NativeRoom::GetBackground(int bgnum)
         throw gcnew AGSEditorException(System::String::Format(
             "Invalid background number {0}", bgnum));
     }
-    return ConvertBlockToBitmap32(_rs->BgFrames[bgnum].Graphic.get(), _rs->Width, _rs->Height, false);
+    return ConvertBlockToBitmap32(_rs->BgFrames[bgnum].Graphic.get(), _rs->Width, _rs->Height);
 }
 
 SysBitmap ^NativeRoom::GetAreaMask(AGS::Types::RoomAreaMaskType maskType)
@@ -77,7 +77,7 @@ SysBitmap ^NativeRoom::GetAreaMask(AGS::Types::RoomAreaMaskType maskType)
     }
 
     AGSBitmap *mask = _rs->GetMask(nativeType);
-    SysBitmap^ managedMask = ConvertBlockToBitmap(mask, false);
+    SysBitmap^ managedMask = ConvertBlockToBitmap(mask);
     // Palette entry 0 alpha value is hardcoded to 0, probably because it's convenient
     // for rendering area 0 as invisible? However it creates issues when exporting 8-bit
     // image with transparency to different image formats (tested with .png). To make things

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -219,12 +219,6 @@ int find_free_sprite_slot() {
   return spriteset.GetFreeIndex();
 }
 
-// CLNUP probably to remove
-void update_sprite_resolution(int spriteNum)
-{
-	thisgame.SpriteInfos[spriteNum].Flags &= ~(SPF_HIRES | SPF_VAR_RESOLUTION);
-}
-
 void change_sprite_number(int oldNumber, int newNumber) {
 
   if (!spriteset.DoesSpriteExist(oldNumber))

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -113,7 +113,7 @@ bool reload_font(int curFont);
 void drawBlockScaledAt(int hdc, Common::Bitmap *todraw ,int x, int y, float scaleFactor);
 // this is to shut up the linker, it's used by CSRUN.CPP
 void write_log(const char *) { }
-SysBitmap^ ConvertBlockToBitmap(Common::Bitmap *todraw, bool useAlphaChannel);
+SysBitmap^ ConvertBlockToBitmap(Common::Bitmap *todraw);
 
 // jibbles the sprite around to fix hi-color problems, by swapping
 // the red and blue elements
@@ -571,24 +571,23 @@ void draw_gui_sprite_impl(Common::Bitmap *g, int sprnum, Common::Bitmap *blptr, 
   if (needtofree) delete towrite;
 }
 
-void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, bool use_alpha, Common::BlendMode blend_mode)
+void draw_gui_sprite(Common::Bitmap *g, int sprnum, int atxp, int atyp, Common::BlendMode blend_mode)
 {
     draw_gui_sprite_impl(g, sprnum, get_sprite(sprnum), atxp, atyp);
 }
 
-void draw_gui_sprite(Common::Bitmap *g, bool use_alpha, int atxp, int atyp,
-    Common::Bitmap *blptr, bool src_has_alpha, Common::BlendMode blend_mode, int alpha)
+void draw_gui_sprite(Common::Bitmap *g, int atxp, int atyp,
+    Common::Bitmap *blptr, Common::BlendMode blend_mode, int alpha)
 {
     draw_gui_sprite_impl(g, -1, blptr, atxp, atyp);
 }
 
-void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode, bool is_flipped) 
+void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, Common::BlendMode blend_mode, bool is_flipped) 
 {
     draw_gui_sprite_impl(ds, pic, get_sprite(pic), x, y);
 }
-void draw_gui_sprite_flipped(Common::Bitmap *ds, bool use_alpha, int x, int y,
-    Common::Bitmap *image, bool src_has_alpha,
-    Common::BlendMode blend_mode, int alpha, bool is_flipped)
+void draw_gui_sprite_flipped(Common::Bitmap *ds, int x, int y,
+    Common::Bitmap *image, Common::BlendMode blend_mode, int alpha, bool is_flipped)
 {
     draw_gui_sprite_impl(ds, -1, image, x, y);
 }
@@ -1359,11 +1358,8 @@ void UpdateNativeSprites(SpriteFolder ^folder, std::vector<int> &missing)
             missing.push_back(sprite->Number);
             spriteset.SetEmptySprite(sprite->Number, true); // mark as an asset to prevent disposal on reload
         }
-
-        int flags = 0;
-		if (sprite->AlphaChannel)
-            flags |= SPF_ALPHACHANNEL;
-        thisgame.SpriteInfos[sprite->Number].Flags = flags;
+        // Reset/update flags
+        thisgame.SpriteInfos[sprite->Number].Flags = 0;
 	}
 
 	for each (SpriteFolder^ subFolder in folder->SubFolders) 
@@ -1914,14 +1910,13 @@ Common::Bitmap *CreateNativeBitmap(System::Drawing::Bitmap^ bmp, int spriteImpor
     int flags = 0;
     if (alphaChannel)
     {
-        flags |= SPF_ALPHACHANNEL;
         if (tempsprite->GetColorDepth() == 32)
-        {
+        { // change pixels with alpha 0 to MASK_COLOR_32
             set_rgb_mask_from_alpha_channel(tempsprite);
         }
     }
     else if (tempsprite->GetColorDepth() == 32)
-    {
+    { // ensure that every pixel has full alpha (0xFF)
         set_opaque_alpha_channel(tempsprite);
     }
 
@@ -1956,21 +1951,22 @@ void SetBitmapPaletteFromGlobalPalette(System::Drawing::Bitmap ^bmp)
 	//bmp->MakeTransparent(bmpPalette[0]);
 }
 
-System::Drawing::Bitmap^ ConvertBlockToBitmap(Common::Bitmap *todraw, bool useAlphaChannel) 
+System::Drawing::Bitmap^ ConvertBlockToBitmap(Common::Bitmap *todraw) 
 {
   fix_block(todraw);
 
   PixelFormat pixFormat = PixelFormat::Format32bppRgb;
-  if ((todraw->GetColorDepth() == 32) && (useAlphaChannel))
-	  pixFormat = PixelFormat::Format32bppArgb;
-  else if (todraw->GetColorDepth() == 24)
-    pixFormat = PixelFormat::Format24bppRgb;
-  else if (todraw->GetColorDepth() == 16)
-    pixFormat = PixelFormat::Format16bppRgb565;
-  else if (todraw->GetColorDepth() == 15)
-    pixFormat = PixelFormat::Format16bppRgb555;
-  else if (todraw->GetColorDepth() == 8)
-    pixFormat = PixelFormat::Format8bppIndexed;
+  switch (todraw->GetColorDepth())
+  {
+  case 8: pixFormat = PixelFormat::Format8bppIndexed; break;
+  case 15: pixFormat = PixelFormat::Format16bppRgb555; break;
+  case 16: pixFormat = PixelFormat::Format16bppRgb565; break;
+  case 24: pixFormat = PixelFormat::Format24bppRgb; break;
+  case 32:
+  default:
+      pixFormat = PixelFormat::Format32bppArgb; break;
+  }
+
   int bytesPerPixel = (todraw->GetColorDepth() + 1) / 8;
 
   System::Drawing::Bitmap ^bmp = gcnew System::Drawing::Bitmap(todraw->GetWidth(), todraw->GetHeight(), pixFormat);
@@ -1990,7 +1986,7 @@ System::Drawing::Bitmap^ ConvertBlockToBitmap(Common::Bitmap *todraw, bool useAl
   return bmp;
 }
 
-System::Drawing::Bitmap^ ConvertBlockToBitmap32(Common::Bitmap *todraw, int width, int height, bool useAlphaChannel) 
+System::Drawing::Bitmap^ ConvertBlockToBitmap32(Common::Bitmap *todraw, int width, int height) 
 {
   Common::Bitmap *tempBlock = Common::BitmapHelper::CreateBitmap(todraw->GetWidth(), todraw->GetHeight(), 32);
   if (!tempBlock)
@@ -2020,7 +2016,7 @@ System::Drawing::Bitmap^ ConvertBlockToBitmap32(Common::Bitmap *todraw, int widt
   fix_block(tempBlock);
 
   PixelFormat pixFormat = PixelFormat::Format32bppRgb;
-  if ((todraw->GetColorDepth() == 32) && (useAlphaChannel))
+  if (todraw->GetColorDepth() == 32)
 	  pixFormat = PixelFormat::Format32bppArgb;
 
   System::Drawing::Bitmap ^bmp = gcnew System::Drawing::Bitmap(width, height, pixFormat);
@@ -2061,7 +2057,7 @@ System::Drawing::Bitmap^ ConvertAreaMaskToBitmap(Common::Bitmap *mask)
 
 System::Drawing::Bitmap^ getSpriteAsBitmap(int spriteNum) {
   Common::Bitmap *todraw = get_sprite(spriteNum);
-  return ConvertBlockToBitmap(todraw, (thisgame.SpriteInfos[spriteNum].Flags & SPF_ALPHACHANNEL) != 0);
+  return ConvertBlockToBitmap(todraw);
 }
 
 System::Drawing::Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height) {
@@ -2070,7 +2066,7 @@ System::Drawing::Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int he
   {
 	  throw gcnew AGSEditorException(String::Format("getSpriteAsBitmap32bit: Unable to find sprite {0}", spriteNum));
   }
-  return ConvertBlockToBitmap32(todraw, width, height, (thisgame.SpriteInfos[spriteNum].Flags & SPF_ALPHACHANNEL) != 0);
+  return ConvertBlockToBitmap32(todraw, width, height);
 }
 
 void PaletteUpdated(cli::array<PaletteEntry^>^ newPalette) 
@@ -2259,6 +2255,7 @@ void drawGUI(int hdc, int x,int y, GUI^ guiObj, int resolutionFactor, float scal
   drawGUIAt(hdc, x, y, -1, -1, -1, -1, resolutionFactor, scale);
 }
 
+// [CLNUP] remove old game import
 Dictionary<int, Sprite^>^ load_sprite_dimensions()
 {
 	Dictionary<int, Sprite^>^ sprites = gcnew Dictionary<int, Sprite^>();
@@ -2268,8 +2265,7 @@ Dictionary<int, Sprite^>^ load_sprite_dimensions()
 		Common::Bitmap *spr = spriteset[i];
 		if (spr != NULL)
 		{
-			sprites->Add(i, gcnew Sprite(i, spr->GetWidth(), spr->GetHeight(), spr->GetColorDepth(),
-                (thisgame.SpriteInfos[i].Flags & SPF_ALPHACHANNEL) ? true : false));
+			sprites->Add(i, gcnew Sprite(i, spr->GetWidth(), spr->GetHeight(), spr->GetColorDepth(), false));
 		}
 	}
 

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3067,7 +3067,7 @@ void save_default_crm_file(Room ^room)
     convert_room_to_native(room, rs);
     // Insert default backgrounds and masks
     for (size_t i = 0; i < rs.BgFrameCount; ++i) // FIXME use of thisgame.color_depth
-        rs.BgFrames[i].Graphic.reset(BitmapHelper::CreateClearBitmap(rs.Width, rs.Height, thisgame.color_depth * 8));
+        rs.BgFrames[i].Graphic.reset(BitmapHelper::CreateClearBitmap(rs.Width, rs.Height, thisgame.color_depth * 8, makeacol32(0, 0, 0, 255)));
     rs.WalkAreaMask.reset(BitmapHelper::CreateClearBitmap(rs.Width / rs.MaskResolution, rs.Height / rs.MaskResolution, 8));
     rs.HotspotMask.reset(BitmapHelper::CreateClearBitmap(rs.Width / rs.MaskResolution, rs.Height / rs.MaskResolution, 8));
     rs.RegionMask.reset(BitmapHelper::CreateClearBitmap(rs.Width / rs.MaskResolution, rs.Height / rs.MaskResolution, 8));

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -16,22 +16,6 @@
 
 extern GameSetupStruct thisgame;
 
-bool AGS::Common::GUIMain::HasAlphaChannel() const
-{
-    if (this->BgImage > 0)
-    {
-        // alpha state depends on background image
-        return is_sprite_alpha(this->BgImage);
-    }
-    if (this->BgColor > 0)
-    {
-        // not alpha transparent if there is a background color
-        return false;
-    }
-    // transparent background, enable alpha blending
-    return thisgame.color_depth * 8 >= 24;
-}
-
 //=============================================================================
 // AGS.Native-specific implementation split out of acgui.h
 //=============================================================================
@@ -107,11 +91,6 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_colo
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
     _textToDraw = text;
-}
-
-bool GUIInvWindow::HasAlphaChannel() const
-{
-    return false; // don't do alpha in the editor
 }
 
 void GUIInvWindow::Draw(Bitmap *ds, int x, int y)

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2684,7 +2684,6 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
                     tdyp = ovr_yp + get_textwindow_top_border_height(play.speech_textwindow_gui);
             }
             const ViewFrame *vf = &viptr->loops[0].frames[0];
-            const bool closeupface_has_alpha = (game.SpriteInfos[vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
             DrawViewFrame(closeupface, vf, view_frame_x, view_frame_y);
 
             int overlay_x = 10;
@@ -2740,7 +2739,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
             }
             if (game.options[OPT_SPEECHTYPE] == 3)
                 overlay_x = 0;
-            face_talking=add_screen_overlay(false,overlay_x,ovr_yp,ovr_type,closeupface, closeupface_has_alpha);
+            face_talking = add_screen_overlay(false,overlay_x,ovr_yp,ovr_type,closeupface);
             facetalkframe = 0;
             facetalkwait = viptr->loops[0].frames[0].speed + GetCharacterSpeechAnimationDelay(speakingChar);
             facetalkloop = 0;

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -720,9 +720,9 @@ void DialogOptions::Redraw()
     }
     
     if (ddb == nullptr)
-      ddb = gfxDriver->CreateDDBFromBitmap(subBitmap, options_surface_has_alpha, false);
+      ddb = gfxDriver->CreateDDBFromBitmap(subBitmap);
     else
-      gfxDriver->UpdateDDBFromBitmap(ddb, subBitmap, options_surface_has_alpha);
+      gfxDriver->UpdateDDBFromBitmap(ddb, subBitmap);
 
     if (runGameLoopsInBackground)
     {

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -242,7 +242,7 @@ int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, in
     dispyp[ww]=curyp;
     if (game.dialog_bullet > 0)
     {
-        draw_gui_sprite(ds, game.dialog_bullet, dlgxp, curyp, ds_has_alpha);
+        draw_gui_sprite(ds, game.dialog_bullet, dlgxp, curyp);
     }
     if (game.options[OPT_DIALOGNUMBERED] == kDlgOptNumbering) {
       char tempbfr[20];
@@ -686,7 +686,7 @@ void DialogOptions::Redraw()
 
       if (game.dialog_bullet)  // the parser X will get moved in a second
       {
-          draw_gui_sprite(ds, game.dialog_bullet, parserInput->X, parserInput->Y, options_surface_has_alpha);
+          draw_gui_sprite(ds, game.dialog_bullet, parserInput->X, parserInput->Y);
       }
 
       parserInput->Width -= bullet_wid;

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -214,7 +214,7 @@ int run_dialog_script(int dialogID, int offse, int optionIndex) {
   return result;
 }
 
-int write_dialog_options(Bitmap *ds, bool ds_has_alpha, int dlgxp, int curyp, int numdisp, int mouseison, int areawid,
+int write_dialog_options(Bitmap *ds, int dlgxp, int curyp, int numdisp, int mouseison, int areawid,
     int bullet_wid, int usingfont, DialogTopic*dtop, int*disporder, short*dispyp,
     int linespacing, int utextcol, int padding) {
   int ww;
@@ -546,15 +546,11 @@ void DialogOptions::Redraw()
     dlgyp = oriyp;
     const Rect &ui_view = play.GetUIViewport();
 
-    bool options_surface_has_alpha = false;
-
     if (usingCustomRendering)
     {
       ccDialogOptionsRendering.surfaceToRenderTo = dialogOptionsRenderingSurface;
       ccDialogOptionsRendering.surfaceAccessed = false;
       dialogOptionsRenderingSurface->linkedBitmapOnly = tempScrn;
-      dialogOptionsRenderingSurface->hasAlphaChannel = ccDialogOptionsRendering.hasAlphaChannel;
-      options_surface_has_alpha = dialogOptionsRenderingSurface->hasAlphaChannel != 0;
 
       renderDialogOptionsFunc.params[0].SetDynamicObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
       run_function_on_non_blocking_thread(&renderDialogOptionsFunc);
@@ -603,7 +599,6 @@ void DialogOptions::Redraw()
       // needs to draw the right text window, not the default
       Bitmap *text_window_ds = nullptr;
       draw_text_window(&text_window_ds, false, &txoffs,&tyoffs,&xspos,&yspos,&areawid,nullptr,needheight, game.options[OPT_DIALOGIFACE]);
-      options_surface_has_alpha = guis[game.options[OPT_DIALOGIFACE]].HasAlphaChannel();
       // since draw_text_window incrases the width, restore it
       areawid = savedwid;
 
@@ -622,7 +617,7 @@ void DialogOptions::Redraw()
       txoffs += xspos;
       tyoffs += yspos;
       dlgyp = tyoffs;
-      curyp = write_dialog_options(ds, options_surface_has_alpha, txoffs,tyoffs,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
+      curyp = write_dialog_options(ds, txoffs,tyoffs,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
       if (parserInput)
         parserInput->X = txoffs;
     }
@@ -652,13 +647,11 @@ void DialogOptions::Redraw()
         GUIMain* guib = &guis[game.options[OPT_DIALOGIFACE]];
         dirtyheight = guib->Height;
         dirtyy = dlgyp;
-        options_surface_has_alpha = guib->HasAlphaChannel();
       }
       else
       {
         dirtyy = dlgyp - 1;
         dirtyheight = needheight + 1;
-        options_surface_has_alpha = false;
       }
 
       dlgxp += play.dialog_options_x;
@@ -670,7 +663,7 @@ void DialogOptions::Redraw()
         dirtyy = dlgyp;
 
       curyp = dlgyp;
-      curyp = write_dialog_options(ds, options_surface_has_alpha, dlgxp,curyp,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
+      curyp = write_dialog_options(ds, dlgxp,curyp,numdisp,mouseison,areawid,bullet_wid,usingfont,dtop,disporder,dispyp,linespacing,forecol,padding);
 
       if (parserInput)
         parserInput->X = dlgxp;

--- a/Engine/ac/dialogoptionsrendering.cpp
+++ b/Engine/ac/dialogoptionsrendering.cpp
@@ -77,12 +77,15 @@ void DialogOptionsRendering_SetHeight(ScriptDialogOptionsRendering *dlgOptRender
 
 int DialogOptionsRendering_GetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender)
 {
-    return dlgOptRender->hasAlphaChannel;
+    // TODO: remove?
+    debug_script_warn("DialogOptionsRendering.AlphaChannel is deprecated");
+    return 0;
 }
 
 void DialogOptionsRendering_SetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender, bool hasAlphaChannel)
 {
-    dlgOptRender->hasAlphaChannel = hasAlphaChannel;
+    // TODO: remove?
+    debug_script_warn("DialogOptionsRendering.AlphaChannel is deprecated");
 }
 
 int DialogOptionsRendering_GetParserTextboxX(ScriptDialogOptionsRendering *dlgOptRender)

--- a/Engine/ac/dialogoptionsrendering.cpp
+++ b/Engine/ac/dialogoptionsrendering.cpp
@@ -75,19 +75,6 @@ void DialogOptionsRendering_SetHeight(ScriptDialogOptionsRendering *dlgOptRender
     dlgOptRender->height = newHeight;
 }
 
-int DialogOptionsRendering_GetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender)
-{
-    // TODO: remove?
-    debug_script_warn("DialogOptionsRendering.AlphaChannel is deprecated");
-    return 0;
-}
-
-void DialogOptionsRendering_SetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender, bool hasAlphaChannel)
-{
-    // TODO: remove?
-    debug_script_warn("DialogOptionsRendering.AlphaChannel is deprecated");
-}
-
 int DialogOptionsRendering_GetParserTextboxX(ScriptDialogOptionsRendering *dlgOptRender)
 {
     return dlgOptRender->parserTextboxX;
@@ -275,16 +262,6 @@ RuntimeScriptValue Sc_DialogOptionsRendering_SetY(void *self, const RuntimeScrip
     API_OBJCALL_VOID_PINT(ScriptDialogOptionsRendering, DialogOptionsRendering_SetY);
 }
 
-RuntimeScriptValue Sc_DialogOptionsRendering_GetHasAlphaChannel(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_INT(ScriptDialogOptionsRendering, DialogOptionsRendering_GetHasAlphaChannel);
-}
-
-RuntimeScriptValue Sc_DialogOptionsRendering_SetHasAlphaChannel(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_OBJCALL_VOID_PBOOL(ScriptDialogOptionsRendering, DialogOptionsRendering_SetHasAlphaChannel);
-}
-
 
 void RegisterDialogOptionsRenderingAPI()
 {
@@ -308,8 +285,6 @@ void RegisterDialogOptionsRenderingAPI()
     ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_X",                Sc_DialogOptionsRendering_SetX);
     ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_Y",                Sc_DialogOptionsRendering_GetY);
     ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_Y",                Sc_DialogOptionsRendering_SetY);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_HasAlphaChannel",  Sc_DialogOptionsRendering_GetHasAlphaChannel);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_HasAlphaChannel",  Sc_DialogOptionsRendering_SetHasAlphaChannel);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/
 

--- a/Engine/ac/dialogoptionsrendering.h
+++ b/Engine/ac/dialogoptionsrendering.h
@@ -29,8 +29,6 @@ int  DialogOptionsRendering_GetWidth(ScriptDialogOptionsRendering *dlgOptRender)
 void DialogOptionsRendering_SetWidth(ScriptDialogOptionsRendering *dlgOptRender, int newWidth);
 int  DialogOptionsRendering_GetHeight(ScriptDialogOptionsRendering *dlgOptRender);
 void DialogOptionsRendering_SetHeight(ScriptDialogOptionsRendering *dlgOptRender, int newHeight);
-int  DialogOptionsRendering_GetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender);
-void DialogOptionsRendering_SetHasAlphaChannel(ScriptDialogOptionsRendering *dlgOptRender, bool hasAlphaChannel);
 int  DialogOptionsRendering_GetParserTextboxX(ScriptDialogOptionsRendering *dlgOptRender);
 void DialogOptionsRendering_SetParserTextboxX(ScriptDialogOptionsRendering *dlgOptRender, int newX);
 int  DialogOptionsRendering_GetParserTextboxY(ScriptDialogOptionsRendering *dlgOptRender);

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -70,8 +70,7 @@ struct DisplayVars
 
 // Generates a textual image and returns a disposable bitmap
 Bitmap *create_textual_image(const char *text, int asspch, int isThought,
-    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
-    bool &alphaChannel)
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink)
 {
     //
     // Configure the textual image
@@ -80,7 +79,6 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     const bool use_speech_textwindow = (asspch < 0) && (game.options[OPT_SPEECHTYPE] >= 2);
     const bool use_thought_gui = (isThought) && (game.options[OPT_THOUGHTGUI] > 0);
 
-    alphaChannel = false;
     int usingGui = -1;
     if (use_speech_textwindow)
         usingGui = play.speech_textwindow_gui;
@@ -179,13 +177,7 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
         if (drawBackground)
         {
             draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &ttxleft, &ttxtop, &adjustedXX, &adjustedYY, &wii, &text_color, 0, usingGui);
-            if (usingGui > 0)
-            {
-                alphaChannel = guis[usingGui].HasAlphaChannel();
-            }
         }
-        else if ((ShouldAntiAliasText()) && (game.GetColorDepth() >= 24))
-            alphaChannel = true;
 
         for (size_t ee = 0; ee<Lines.Count(); ee++) {
             //int ttxp=wii/2 - get_text_width_outlined(lines[ee], usingfont)/2;
@@ -210,11 +202,6 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     else {
         int xoffs, yoffs, oriwid = wii - padding * 2;
         draw_text_window_and_bar(&text_window_ds, wantFreeScreenop, &xoffs, &yoffs, &adjustedXX, &adjustedYY, &wii, &text_color);
-
-        if (game.options[OPT_TWCUSTOM] > 0)
-        {
-            alphaChannel = guis[game.options[OPT_TWCUSTOM]].HasAlphaChannel();
-        }
 
         adjust_y_coordinate_for_text(&yoffs, usingfont);
 
@@ -270,9 +257,8 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
         remove_screen_overlay(play.text_overlay_on);
 
     int adjustedXX, adjustedYY;
-    bool alphaChannel;
     Bitmap *text_window_ds = create_textual_image(text, asspch, isThought,
-        xx, yy, adjustedXX, adjustedYY, wii, usingfont, allowShrink, alphaChannel);
+        xx, yy, adjustedXX, adjustedYY, wii, usingfont, allowShrink);
 
     //
     // Configure and create an overlay object
@@ -287,7 +273,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     default: ovrtype = disp_type; break; // must be precreated overlay id
     }
 
-    size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
+    size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy);
     // we should not delete text_window_ds here, because it is now owned by Overlay
 
     // If it's a non-blocking overlay type, then we're done here

--- a/Engine/ac/display.h
+++ b/Engine/ac/display.h
@@ -35,8 +35,7 @@ struct ScreenOverlay;
 // Generates a textual image from the given text and parameters;
 // see _display_main's comment below for parameters description
 Common::Bitmap *create_textual_image(const char *text, int asspch, int isThought,
-    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink,
-    bool &alphaChannel);
+    int &xx, int &yy, int &adjustedXX, int &adjustedYY, int wii, int usingfont, int allowShrink);
 // Creates a textual overlay using the given parameters;
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -282,7 +282,7 @@ Bitmap *convert_32_to_32bgr(Bitmap *tempbl) {
 // TODO: make gfxDriver->GetCompatibleBitmapFormat describe all necessary
 // conversions, so that we did not have to guess.
 //
-Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
+Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap)
 {
     const int bmp_col_depth = bitmap->GetColorDepth();
     const int game_col_depth = game.GetColorDepth();
@@ -315,10 +315,10 @@ Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
     //
     // In 32-bit game 32-bit bitmaps should have transparent pixels marked
     // (this adjustment is probably needed for DrawingSurface ops)
-    if (game_col_depth == 32 && bmp_col_depth == 32)
+    if ((game_col_depth == 32) && (bmp_col_depth == 32))
     {
-        if (has_alpha) 
-            set_rgb_mask_using_alpha_channel(new_bitmap);
+        // TODO: find out if this may be removed at some point
+        set_rgb_mask_using_alpha_channel(new_bitmap);
     }
     // In 32-bit game hicolor bitmaps must be converted to the true color
     else if (game_col_depth == 32 && (bmp_col_depth > 8 && bmp_col_depth <= 16))
@@ -326,12 +326,10 @@ Bitmap *AdjustBitmapForUseWithDisplayMode(Bitmap* bitmap, bool has_alpha)
         new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, compat_col_depth);
     }
     // In non-32-bit game truecolor bitmaps must be downgraded
-    else if (game_col_depth <= 16 && bmp_col_depth > 16)
+    else if ((game_col_depth <= 16) && (bmp_col_depth > 16))
     {
-        if (has_alpha) // if has valid alpha channel, convert it to regular transparency mask
-            new_bitmap = remove_alpha_channel(bitmap);
-        else // else simply convert bitmap
-            new_bitmap = BitmapHelper::CreateBitmapCopy(bitmap, compat_col_depth);
+        // convert alpha channel to a 8/16-bit transparency mask
+        new_bitmap = remove_alpha_channel(bitmap);
     }
     
     // Finally, if we did not create a new copy already, - convert to driver compatible format
@@ -355,17 +353,17 @@ Bitmap *ReplaceBitmapWithSupportedFormat(Bitmap *bitmap)
     return GfxUtil::ConvertBitmap(bitmap, gfxDriver->GetCompatibleBitmapFormat(bitmap->GetColorDepth()));
 }
 
-Bitmap *PrepareSpriteForUse(Bitmap* bitmap, bool has_alpha)
+Bitmap *PrepareSpriteForUse(Bitmap* bitmap)
 {
-    Bitmap *new_bitmap = AdjustBitmapForUseWithDisplayMode(bitmap, has_alpha);
+    Bitmap *new_bitmap = AdjustBitmapForUseWithDisplayMode(bitmap);
     if (new_bitmap != bitmap)
         delete bitmap;
     return new_bitmap;
 }
 
-PBitmap PrepareSpriteForUse(PBitmap bitmap, bool has_alpha)
+PBitmap PrepareSpriteForUse(PBitmap bitmap)
 {
-    Bitmap *new_bitmap = AdjustBitmapForUseWithDisplayMode(bitmap.get(), has_alpha);
+    Bitmap *new_bitmap = AdjustBitmapForUseWithDisplayMode(bitmap.get());
     return new_bitmap == bitmap.get() ? bitmap : PBitmap(new_bitmap); // if bitmap is same, don't create new smart ptr!
 }
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -895,20 +895,19 @@ void putpixel_compensate (Bitmap *ds, int xx,int yy, int col) {
     ds->FillRect(Rect(xx, yy, xx, yy), col);
 }
 
-void draw_sprite_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Bitmap *image, bool src_has_alpha,
+void draw_sprite_support_alpha(Bitmap *ds, int xpos, int ypos, Bitmap *image,
                                BlendMode blend_mode, int alpha)
 {
     if (alpha <= 0)
         return;
 
-    GfxUtil::DrawSpriteBlend(ds, Point(xpos, ypos), image, blend_mode, ds_has_alpha, src_has_alpha, alpha);
+    GfxUtil::DrawSpriteBlend(ds, Point(xpos, ypos), image, blend_mode, alpha);
 }
 
-void draw_sprite_slot_support_alpha(Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot,
+void draw_sprite_slot_support_alpha(Bitmap *ds, int xpos, int ypos, int src_slot,
                                     BlendMode blend_mode, int alpha)
 {
-    draw_sprite_support_alpha(ds, ds_has_alpha, xpos, ypos, spriteset[src_slot], (game.SpriteInfos[src_slot].Flags & SPF_ALPHACHANNEL) != 0,
-        blend_mode, alpha);
+    draw_sprite_support_alpha(ds, xpos, ypos, spriteset[src_slot], blend_mode, alpha);
 }
 
 
@@ -1064,22 +1063,20 @@ void repair_alpha_channel(Bitmap *dest, Bitmap *bgpic)
 
 // used by GUI renderer to draw images
 // NOTE: use_alpha arg is for backward compatibility (legacy draw modes)
-void draw_gui_sprite(Bitmap *ds, int pic, int x, int y, bool use_alpha, BlendMode blend_mode)
+void draw_gui_sprite(Bitmap *ds, int pic, int x, int y, BlendMode blend_mode)
 {
-    draw_gui_sprite(ds, use_alpha, x, y, spriteset[pic],
-        (game.SpriteInfos[pic].Flags & SPF_ALPHACHANNEL) != 0, blend_mode);
+    draw_gui_sprite(ds, x, y, spriteset[pic], blend_mode);
 }
 
-void draw_gui_sprite(Bitmap *ds, bool use_alpha, int x, int y, Bitmap *sprite, bool src_has_alpha,
-    BlendMode blend_mode, int alpha)
+void draw_gui_sprite(Bitmap *ds, int x, int y, Bitmap *sprite, BlendMode blend_mode, int alpha)
 {
     if (alpha <= 0)
         return;
 
-    const bool ds_has_alpha = (ds->GetColorDepth() == 32);
+    const bool use_alpha = (ds->GetColorDepth() == 32);
     if (use_alpha)
     {
-        GfxUtil::DrawSpriteBlend(ds, Point(x, y), sprite, blend_mode, ds_has_alpha, src_has_alpha, alpha);
+        GfxUtil::DrawSpriteBlend(ds, Point(x, y), sprite, blend_mode, alpha);
     }
     else
     {
@@ -1087,13 +1084,13 @@ void draw_gui_sprite(Bitmap *ds, bool use_alpha, int x, int y, Bitmap *sprite, b
     }
 }
 
-void draw_gui_sprite_flipped(Bitmap *ds, int pic, int x, int y, bool use_alpha, BlendMode blend_mode, bool is_flipped)
+void draw_gui_sprite_flipped(Bitmap *ds, int pic, int x, int y, BlendMode blend_mode, bool is_flipped)
 {
-    draw_gui_sprite_flipped(ds, use_alpha, x, y, spriteset[pic],
-        (game.SpriteInfos[pic].Flags & SPF_ALPHACHANNEL) != 0, blend_mode, 0xFF, is_flipped);
+    draw_gui_sprite_flipped(ds, x, y, spriteset[pic],
+        blend_mode, 0xFF, is_flipped);
 }
 
-void draw_gui_sprite_flipped(Bitmap *ds, bool use_alpha, int x, int y, Bitmap *sprite, bool src_has_alpha,
+void draw_gui_sprite_flipped(Bitmap *ds, int x, int y, Bitmap *sprite,
     BlendMode blend_mode, int alpha, bool is_flipped)
 {
     if (alpha <= 0)
@@ -1106,10 +1103,9 @@ void draw_gui_sprite_flipped(Bitmap *ds, bool use_alpha, int x, int y, Bitmap *s
         sprite = tempspr.get();
     }
 
-    const bool ds_has_alpha = (ds->GetColorDepth() == 32);
-    if (use_alpha)
+    if (ds->GetColorDepth() == 32) // ds has alpha?
     {
-        GfxUtil::DrawSpriteBlend(ds, Point(x, y), sprite, blend_mode, ds_has_alpha, src_has_alpha, alpha);
+        GfxUtil::DrawSpriteBlend(ds, Point(x, y), sprite, blend_mode, alpha);
     }
     else
     {

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1375,14 +1375,14 @@ int scale_and_flip_sprite(int useindx, int coldept, int zoom_level, float rotati
       if (isMirrored) {
           // TODO: "flip self" function may allow to optimize this
           Bitmap *tempspr = BitmapHelper::CreateTransparentBitmap(newwidth, newheight, coldept);
-          if ((IS_ANTIALIAS_SPRITES) && ((game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) == 0))
+          if ((IS_ANTIALIAS_SPRITES) && (src_sprite->GetColorDepth() < 32))
               tempspr->AAStretchBlt (src_sprite, RectWH(0, 0, newwidth, newheight), Common::kBitmap_Transparency);
           else
               tempspr->StretchBlt (src_sprite, RectWH(0, 0, newwidth, newheight), Common::kBitmap_Transparency);
           active_spr->FlipBlt(tempspr, 0, 0, Common::kFlip_Horizontal);
           delete tempspr;
       }
-      else if ((IS_ANTIALIAS_SPRITES) && ((game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) == 0))
+      else if ((IS_ANTIALIAS_SPRITES) && (src_sprite->GetColorDepth() < 32))
           active_spr->AAStretchBlt(src_sprite,RectWH(0,0,newwidth,newheight), Common::kBitmap_Transparency);
       else
           active_spr->StretchBlt(src_sprite,RectWH(0,0,newwidth,newheight), Common::kBitmap_Transparency);
@@ -1413,7 +1413,7 @@ int scale_and_flip_sprite(int useindx, int coldept, int zoom_level, float rotati
 // * if transformation is necessary - writes into dst and returns dst;
 // * if no transformation is necessary - simply returns src;
 // Used for software render mode only.
-static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr<Bitmap> &dst,
+static Bitmap *transform_sprite(Bitmap *src, std::unique_ptr<Bitmap> &dst,
     const Size dst_sz, GraphicFlip flip = Common::kFlip_None)
 {
     if ((src->GetSize() == dst_sz) && (flip == kFlip_None))
@@ -1435,7 +1435,7 @@ static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr
         {
             Bitmap tempbmp;
             tempbmp.CreateTransparent(dst_sz.Width, dst_sz.Height, src->GetColorDepth());
-            if ((IS_ANTIALIAS_SPRITES) && !src_has_alpha)
+            if ((IS_ANTIALIAS_SPRITES) && (src->GetColorDepth() < 32))
                 tempbmp.AAStretchBlt(src, RectWH(dst_sz), kBitmap_Transparency);
             else
                 tempbmp.StretchBlt(src, RectWH(dst_sz), kBitmap_Transparency);
@@ -1443,7 +1443,7 @@ static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr
         }
         else
         {
-            if ((IS_ANTIALIAS_SPRITES) && !src_has_alpha)
+            if ((IS_ANTIALIAS_SPRITES) && (src->GetColorDepth() < 32))
                 dst->AAStretchBlt(src, RectWH(dst_sz), kBitmap_Transparency);
             else
                 dst->StretchBlt(src, RectWH(dst_sz), kBitmap_Transparency);
@@ -1468,8 +1468,8 @@ static Bitmap *transform_sprite(Bitmap *src, bool src_has_alpha, std::unique_ptr
 static bool scale_and_flip_sprite(int useindx, int sppic, int newwidth, int newheight, bool hmirror)
 {
     Bitmap *src = spriteset[sppic];
-    Bitmap *result = transform_sprite(src, (game.SpriteInfos[sppic].Flags & SPF_ALPHACHANNEL) != 0,
-        actsps[useindx].Bmp, Size(newwidth, newheight), hmirror ? kFlip_Horizontal : kFlip_None);
+    Bitmap *result = transform_sprite(src, actsps[useindx].Bmp, Size(newwidth, newheight),
+        hmirror ? kFlip_Horizontal : kFlip_None);
     return result != src;
 }
 

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -91,9 +91,10 @@ void mark_current_background_dirty();
 Common::Bitmap *recycle_bitmap(Common::Bitmap *bimp, int coldep, int wid, int hit, bool make_transparent = false);
 void recycle_bitmap(std::unique_ptr<Common::Bitmap> &bimp, int coldep, int wid, int hit, bool make_transparent = false);
 Engine::IDriverDependantBitmap* recycle_ddb_sprite(Engine::IDriverDependantBitmap *ddb, uint32_t sprite_id,
-    Common::Bitmap *source, bool has_alpha = false, bool opaque = false);
-inline Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *ddb, Common::Bitmap *source, bool has_alpha = false, bool opaque = false)
-    { return recycle_ddb_sprite(ddb, UINT32_MAX, source, has_alpha, opaque); }
+    Common::Bitmap *source, bool opaque = false);
+inline Engine::IDriverDependantBitmap* recycle_ddb_bitmap(Engine::IDriverDependantBitmap *ddb,
+    Common::Bitmap *source, bool opaque = false)
+    { return recycle_ddb_sprite(ddb, UINT32_MAX, source, opaque); }
 inline Engine::IDriverDependantBitmap* recycle_render_target(Engine::IDriverDependantBitmap *ddb, int width, int height, int col_depth, bool opaque = false);
 // Draw everything 
 void render_graphics(Engine::IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -165,9 +165,9 @@ Common::Bitmap *ReplaceBitmapWithSupportedFormat(Common::Bitmap *bitmap);
 // in AGS sprite operations. Also handles number of certain special cases
 // (old systems or uncommon gfx modes, and similar stuff).
 // Original bitmap **gets deleted** if a new bitmap had to be created.
-Common::Bitmap *PrepareSpriteForUse(Common::Bitmap *bitmap, bool has_alpha);
+Common::Bitmap *PrepareSpriteForUse(Common::Bitmap *bitmap);
 // Same as above, but compatible for std::shared_ptr.
-Common::PBitmap PrepareSpriteForUse(Common::PBitmap bitmap, bool has_alpha);
+Common::PBitmap PrepareSpriteForUse(Common::PBitmap bitmap);
 // Makes a screenshot corresponding to the last screen render and returns it as a bitmap
 // of the requested width and height and game's native color depth.
 Common::Bitmap *CopyScreenIntoBitmap(int width, int height, bool at_native_res = false);

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -109,18 +109,17 @@ void debug_draw_room_mask(RoomAreaMask mask);
 void debug_draw_movelist(int charnum);
 void update_room_debug();
 void tint_image (Common::Bitmap *g, Common::Bitmap *source, int red, int grn, int blu, int light_level, int luminance=255);
-void draw_sprite_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, Common::Bitmap *image, bool src_has_alpha,
+void draw_sprite_support_alpha(Common::Bitmap *ds, int xpos, int ypos, Common::Bitmap *image,
                                Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
-void draw_sprite_slot_support_alpha(Common::Bitmap *ds, bool ds_has_alpha, int xpos, int ypos, int src_slot,
+void draw_sprite_slot_support_alpha(Common::Bitmap *ds, int xpos, int ypos, int src_slot,
                                     Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
 // CLNUP I'd like to put the default parameters to draw_gui_sprite, but the extern from guiman.h prevents it
-void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode);
-//void draw_gui_sprite_v330(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha = true, Common::BlendMode blend_mode = Common::kBlend_Alpha);
-void draw_gui_sprite(Common::Bitmap *ds, bool use_alpha, int xpos, int ypos,
-    Common::Bitmap *image, bool src_has_alpha, Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
-void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, bool use_alpha, Common::BlendMode blend_mode, bool is_flipped);
-void draw_gui_sprite_flipped(Common::Bitmap *ds, bool use_alpha, int xpos, int ypos,
-    Common::Bitmap *image, bool src_has_alpha, Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF, bool is_flipped = false);
+void draw_gui_sprite(Common::Bitmap *ds, int pic, int x, int y, Common::BlendMode blend_mode);
+void draw_gui_sprite(Common::Bitmap *ds, int xpos, int ypos,
+    Common::Bitmap *image, Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF);
+void draw_gui_sprite_flipped(Common::Bitmap *ds, int pic, int x, int y, Common::BlendMode blend_mode, bool is_flipped);
+void draw_gui_sprite_flipped(Common::Bitmap *ds, int xpos, int ypos,
+    Common::Bitmap *image, Common::BlendMode blend_mode = Common::kBlend_Normal, int alpha = 0xFF, bool is_flipped = false);
 
 // Render game on screen
 void render_to_screen();

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -164,8 +164,7 @@ void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src,
             debug_script_warn("DrawImage: Source image colour depth %d-bit not same as background depth %d-bit", src->GetColorDepth(), ds->GetColorDepth());
     }
 
-    draw_sprite_support_alpha(ds, sds->hasAlphaChannel != 0, dst_x, dst_y, src, src_has_alpha,
-        mode, GfxDef::Trans100ToAlpha255(trans));
+    draw_sprite_support_alpha(ds, dst_x, dst_y, src, mode, GfxDef::Trans100ToAlpha255(trans));
 
     sds->FinishedDrawing();
 

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -97,7 +97,6 @@ ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
             dynamicallyCreatedSurfaces[i] = BitmapHelper::CreateBitmapCopy(sourceBitmap);
             ScriptDrawingSurface *newSurface = new ScriptDrawingSurface();
             newSurface->dynamicSurfaceNumber = i;
-            newSurface->hasAlphaChannel = sds->hasAlphaChannel;
             ccRegisterManagedObject(newSurface, newSurface);
             return newSurface;
         }
@@ -107,9 +106,9 @@ ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds)
     return nullptr;
 }
 
-void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src,
+static void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src,
     int dst_x, int dst_y, int trans, BlendMode mode, int dst_width, int dst_height,
-    int src_x, int src_y, int src_width, int src_height, int sprite_id, bool src_has_alpha)
+    int src_x, int src_y, int src_width, int src_height, int sprite_id)
 {
     Bitmap *ds = sds->GetBitmapSurface();
     if (src == ds) {} // ignore for now; bitmap lib supports, and may be used for effects
@@ -180,7 +179,7 @@ void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds,
     if ((slot < 0) || (spriteset[slot] == nullptr))
         quit("!DrawingSurface.DrawImage: invalid sprite slot number specified");
     DrawingSurface_DrawImageImpl(sds, spriteset[slot], dst_x, dst_y, trans, mode, dst_width, dst_height,
-        src_x, src_y, src_width, src_height, slot, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
+        src_x, src_y, src_width, src_height, slot);
 }
 
 void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
@@ -193,7 +192,7 @@ void DrawingSurface_DrawSurfaceEx(ScriptDrawingSurface* target, ScriptDrawingSur
     int src_x, int src_y, int src_width, int src_height)
 {
     DrawingSurface_DrawImageImpl(target, source->GetBitmapSurface(), dst_x, dst_y, trans, mode, dst_width, dst_height,
-        src_x, src_y, src_width, src_height, -1, source->hasAlphaChannel != 0);
+        src_x, src_y, src_width, src_height, -1);
 }
 
 void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans)

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -412,11 +412,6 @@ void add_dynamic_sprite(int gotSlot, Bitmap *redin, bool hasAlpha) {
   spriteset.SetSprite(gotSlot, redin);
 
   game.SpriteInfos[gotSlot].Flags = SPF_DYNAMICALLOC;
-
-  if (redin->GetColorDepth() > 8)
-    game.SpriteInfos[gotSlot].Flags |= SPF_HICOLOR;
-  if (redin->GetColorDepth() > 16)
-    game.SpriteInfos[gotSlot].Flags |= SPF_TRUECOLOR;
   if (hasAlpha)
     game.SpriteInfos[gotSlot].Flags |= SPF_ALPHACHANNEL;
 

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -286,8 +286,8 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
     return new_spr;
 }
 
-ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preserveAlphaChannel) {
-
+ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot)
+{
     int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
         return nullptr;
@@ -299,8 +299,6 @@ ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preser
     Bitmap *newPic = BitmapHelper::CreateBitmapCopy(spriteset[slot]);
     if (newPic == nullptr)
         return nullptr;
-
-    // TODO: preserveAlphaChannel -- edit bitmap and set full opaque alpha
 
     // replace the bitmap in the sprite set
     add_dynamic_sprite(gotSlot, newPic);
@@ -334,8 +332,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface
     return new_spr;
 }
 
-// TODO: remove alphaChannel
-ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChannel) 
+ScriptDynamicSprite* DynamicSprite_Create(int width, int height) 
 {
     int gotSlot = spriteset.GetFreeIndex();
     if (gotSlot <= 0)
@@ -350,11 +347,6 @@ ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChanne
     add_dynamic_sprite(gotSlot, newPic);
     ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(gotSlot);
     return new_spr;
-}
-
-ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite_Old(int slot) 
-{
-    return DynamicSprite_CreateFromExistingSprite(slot, 0);
 }
 
 ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y1, int width, int height) {
@@ -512,10 +504,9 @@ RuntimeScriptValue Sc_DynamicSprite_GetWidth(void *self, const RuntimeScriptValu
     API_OBJCALL_INT(ScriptDynamicSprite, DynamicSprite_GetWidth);
 }
 
-// ScriptDynamicSprite* (int width, int height, int alphaChannel)
 RuntimeScriptValue Sc_DynamicSprite_Create(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJAUTO_PINT3(ScriptDynamicSprite, DynamicSprite_Create);
+    API_SCALL_OBJAUTO_PINT2(ScriptDynamicSprite, DynamicSprite_Create);
 }
 
 // ScriptDynamicSprite* (int frame, int x1, int y1, int width, int height)
@@ -530,16 +521,9 @@ RuntimeScriptValue Sc_DynamicSprite_CreateFromDrawingSurface(const RuntimeScript
     API_SCALL_OBJAUTO_POBJ_PINT4(ScriptDynamicSprite, DynamicSprite_CreateFromDrawingSurface, ScriptDrawingSurface);
 }
 
-// ScriptDynamicSprite* (int slot)
-RuntimeScriptValue Sc_DynamicSprite_CreateFromExistingSprite_Old(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_OBJAUTO_PINT(ScriptDynamicSprite, DynamicSprite_CreateFromExistingSprite_Old);
-}
-
-// ScriptDynamicSprite* (int slot, int preserveAlphaChannel)
 RuntimeScriptValue Sc_DynamicSprite_CreateFromExistingSprite(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJAUTO_PINT2(ScriptDynamicSprite, DynamicSprite_CreateFromExistingSprite);
+    API_SCALL_OBJAUTO_PINT(ScriptDynamicSprite, DynamicSprite_CreateFromExistingSprite);
 }
 
 // ScriptDynamicSprite* (const char *filename)
@@ -577,11 +561,10 @@ void RegisterDynamicSpriteAPI()
     ccAddExternalObjectFunction("DynamicSprite::get_Graphic",               Sc_DynamicSprite_GetGraphic);
     ccAddExternalObjectFunction("DynamicSprite::get_Height",                Sc_DynamicSprite_GetHeight);
     ccAddExternalObjectFunction("DynamicSprite::get_Width",                 Sc_DynamicSprite_GetWidth);
-    ccAddExternalStaticFunction("DynamicSprite::Create^3",                  Sc_DynamicSprite_Create);
+    ccAddExternalStaticFunction("DynamicSprite::Create^2",                  Sc_DynamicSprite_Create);
     ccAddExternalStaticFunction("DynamicSprite::CreateFromBackground",      Sc_DynamicSprite_CreateFromBackground);
     ccAddExternalStaticFunction("DynamicSprite::CreateFromDrawingSurface^5", Sc_DynamicSprite_CreateFromDrawingSurface);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromExistingSprite^1", Sc_DynamicSprite_CreateFromExistingSprite_Old);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromExistingSprite^2", Sc_DynamicSprite_CreateFromExistingSprite);
+    ccAddExternalStaticFunction("DynamicSprite::CreateFromExistingSprite^1", Sc_DynamicSprite_CreateFromExistingSprite);
     ccAddExternalStaticFunction("DynamicSprite::CreateFromFile",            Sc_DynamicSprite_CreateFromFile);
     ccAddExternalStaticFunction("DynamicSprite::CreateFromSaveGame",        Sc_DynamicSprite_CreateFromSaveGame);
     ccAddExternalStaticFunction("DynamicSprite::CreateFromScreenShot",      Sc_DynamicSprite_CreateFromScreenShot);
@@ -602,11 +585,10 @@ void RegisterDynamicSpriteAPI()
     ccAddExternalFunctionForPlugin("DynamicSprite::get_Graphic",               (void*)DynamicSprite_GetGraphic);
     ccAddExternalFunctionForPlugin("DynamicSprite::get_Height",                (void*)DynamicSprite_GetHeight);
     ccAddExternalFunctionForPlugin("DynamicSprite::get_Width",                 (void*)DynamicSprite_GetWidth);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Create^3",                  (void*)DynamicSprite_Create);
+    ccAddExternalFunctionForPlugin("DynamicSprite::Create^2",                  (void*)DynamicSprite_Create);
     ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromBackground",      (void*)DynamicSprite_CreateFromBackground);
     ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromDrawingSurface^5", (void*)DynamicSprite_CreateFromDrawingSurface);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromExistingSprite^1", (void*)DynamicSprite_CreateFromExistingSprite_Old);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromExistingSprite^2", (void*)DynamicSprite_CreateFromExistingSprite);
+    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromExistingSprite^1", (void*)DynamicSprite_CreateFromExistingSprite);
     ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromFile",            (void*)DynamicSprite_CreateFromFile);
     ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromSaveGame",        (void*)DynamicSprite_CreateFromSaveGame);
     ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromScreenShot",      (void*)DynamicSprite_CreateFromScreenShot);

--- a/Engine/ac/dynamicsprite.h
+++ b/Engine/ac/dynamicsprite.h
@@ -38,10 +38,9 @@ int		DynamicSprite_SaveToFile(ScriptDynamicSprite *sds, const char* namm);
 ScriptDynamicSprite* DynamicSprite_CreateFromSaveGame(int sgslot, int width, int height);
 ScriptDynamicSprite* DynamicSprite_CreateFromFile(const char *filename);
 ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height);
-ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot, int preserveAlphaChannel);
+ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite(int slot);
 ScriptDynamicSprite* DynamicSprite_CreateFromDrawingSurface(ScriptDrawingSurface *sds, int x, int y, int width, int height);
-ScriptDynamicSprite* DynamicSprite_Create(int width, int height, int alphaChannel);
-ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite_Old(int slot);
+ScriptDynamicSprite* DynamicSprite_Create(int width, int height);
 ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y1, int width, int height);
 
 

--- a/Engine/ac/dynamicsprite.h
+++ b/Engine/ac/dynamicsprite.h
@@ -45,7 +45,7 @@ ScriptDynamicSprite* DynamicSprite_CreateFromExistingSprite_Old(int slot);
 ScriptDynamicSprite* DynamicSprite_CreateFromBackground(int frame, int x1, int y1, int width, int height);
 
 
-void	add_dynamic_sprite(int gotSlot, Common::Bitmap *redin, bool hasAlpha = false);
+void	add_dynamic_sprite(int gotSlot, Common::Bitmap *redin);
 void	free_dynamic_sprite (int gotSlot);
 
 #endif // __AGS_EE_AC__DYNAMICSPRITE_H

--- a/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
+++ b/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
@@ -39,7 +39,6 @@ void ScriptDialogOptionsRendering::Reset()
     y = 0;
     width = 0;
     height = 0;
-    hasAlphaChannel = false;
     parserTextboxX = 0;
     parserTextboxY = 0;
     parserTextboxWidth = 0;

--- a/Engine/ac/dynobj/scriptdialogoptionsrendering.h
+++ b/Engine/ac/dynobj/scriptdialogoptionsrendering.h
@@ -19,7 +19,6 @@
 
 struct ScriptDialogOptionsRendering final : AGSCCDynamicObject {
     int x, y, width, height;
-    bool hasAlphaChannel;
     int parserTextboxX, parserTextboxY;
     int parserTextboxWidth;
     int dialogID;

--- a/Engine/ac/dynobj/scriptdrawingsurface.cpp
+++ b/Engine/ac/dynobj/scriptdrawingsurface.cpp
@@ -91,7 +91,7 @@ void ScriptDrawingSurface::Serialize(const char* /*address*/, Stream *out) {
     out->WriteInt32(currentColourScript);
     out->WriteInt32(0); // unused, was highResCoordinates
     out->WriteInt32(modified);
-    out->WriteInt32(hasAlphaChannel);
+    out->WriteInt32(0); // unused, was hasAlphaChannel
     out->WriteInt32(isLinkedBitmapOnly ? 1 : 0);
 }
 
@@ -108,7 +108,7 @@ void ScriptDrawingSurface::Unserialize(int index, Stream *in, size_t /*data_sz*/
     currentColourScript = in->ReadInt32();
     in->ReadInt32(); // unused, was highResCoordinates
     modified = in->ReadInt32();
-    hasAlphaChannel = in->ReadInt32();
+    in->ReadInt32(); // unused, was hasAlphaChannel
     isLinkedBitmapOnly = (in->ReadInt32() != 0);
     ccRegisterUnserializedObject(index, this, this);
 }
@@ -124,5 +124,4 @@ ScriptDrawingSurface::ScriptDrawingSurface()
     currentColour = play.raw_color;
     currentColourScript = 0;
     modified = 0;
-    hasAlphaChannel = 0;
 }

--- a/Engine/ac/dynobj/scriptdrawingsurface.h
+++ b/Engine/ac/dynobj/scriptdrawingsurface.h
@@ -32,8 +32,6 @@ struct ScriptDrawingSurface final : AGSCCDynamicObject {
     int currentColour;
     int currentColourScript;
     int modified;
-    int hasAlphaChannel;
-    //Common::Bitmap* abufBackup;
 
     int Dispose(const char *address, bool force) override;
     const char *GetType() override;

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -331,7 +331,7 @@ void process_event(const EventHappened *evp) {
                         saved_viewport_bitmap->PutPixel(bb+pattern[aa]/4, cc+pattern[aa]%4, maskCol);
                     }
                 }
-                gfxDriver->UpdateDDBFromBitmap(ddb, saved_viewport_bitmap, false);
+                gfxDriver->UpdateDDBFromBitmap(ddb, saved_viewport_bitmap);
                 construct_game_scene(true);
                 construct_game_screen_overlay(false);
                 gfxDriver->BeginSpriteBatch(play.GetMainViewport(), SpriteTransform());

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1426,8 +1426,7 @@ bool unserialize_audio_script_object(int index, const char *objectType, Stream *
 void game_sprite_updated(int sprnum)
 {
     // update the shared texture (if exists)
-    gfxDriver->UpdateSharedDDB(sprnum, spriteset[sprnum],
-        (game.SpriteInfos[sprnum].Flags & SPF_ALPHACHANNEL) != 0, false);
+    gfxDriver->UpdateSharedDDB(sprnum, spriteset[sprnum]);
     // character and object draw caches
     reset_objcache_for_sprite(sprnum, false);
     // gui backgrounds

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -984,7 +984,7 @@ bool read_savedgame_screenshot(const String &savedgame, int &want_shot)
         if (slot > 0)
         {
             // add it into the sprite set
-            add_dynamic_sprite(slot, PrepareSpriteForUse(desc.UserImage.release(), false));
+            add_dynamic_sprite(slot, PrepareSpriteForUse(desc.UserImage.release()));
             want_shot = slot;
         }
     }

--- a/Engine/ac/global_dynamicsprite.cpp
+++ b/Engine/ac/global_dynamicsprite.cpp
@@ -56,7 +56,7 @@ int LoadImageFile(const char *filename)
     if (gotSlot <= 0)
         return 0;
 
-    add_dynamic_sprite(gotSlot, PrepareSpriteForUse(loadedFile, false));
+    add_dynamic_sprite(gotSlot, PrepareSpriteForUse(loadedFile));
 
     return gotSlot;
 }

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -305,7 +305,7 @@ void MergeObject(int obn) {
     int xpos = objs[obn].x;
     int ypos = (objs[obn].y - theHeight);
 
-    draw_sprite_support_alpha(bg_frame.get(), false, xpos, ypos, actsp, (game.SpriteInfos[objs[obn].num].Flags & SPF_ALPHACHANNEL) != 0);
+    draw_sprite_support_alpha(bg_frame.get(), xpos, ypos, actsp);
     invalidate_screen();
     mark_current_background_dirty();
 

--- a/Engine/ac/guiinv.cpp
+++ b/Engine/ac/guiinv.cpp
@@ -74,7 +74,7 @@ void GUIInvWindow::Draw(Bitmap *ds, int x, int y)
     for (int item = TopItem; item < lastItem; ++item)
     {
         // draw inv graphic
-        draw_gui_sprite(ds, game.invinfo[charextra[GetCharacterId()].invorder[item]].pic, at_x, at_y, true);
+        draw_gui_sprite(ds, game.invinfo[charextra[GetCharacterId()].invorder[item]].pic, at_x, at_y);
         at_x += ItemWidth;
 
         // go to next row when appropriate

--- a/Engine/ac/guiinv.cpp
+++ b/Engine/ac/guiinv.cpp
@@ -31,13 +31,6 @@ namespace AGS
 namespace Common
 {
 
-bool GUIInvWindow::HasAlphaChannel() const
-{
-    // We would have to test every inventory item's graphic to tell precisely,
-    // so just test game color depth instead:
-    return game.GetColorDepth() == 32;
-}
-
 int GUIInvWindow::GetCharacterId() const
 {
     if (CharId < 0)

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -50,7 +50,6 @@ ScriptMouse scmouse;
 int cur_mode,cur_cursor;
 int mouse_frame=0,mouse_delay=0;
 int lastmx=-1,lastmy=-1;
-char alpha_blend_cursor = 0;
 Bitmap *dotted_mouse_cursor = nullptr;
 IDriverDependantBitmap *mouseCursor = nullptr;
 Bitmap *blank_mouse_cursor = nullptr;
@@ -395,11 +394,6 @@ void set_new_cursor_graphic (int spriteslot) {
         }
         mousecurs[0] = blank_mouse_cursor;
     }
-
-    if (game.SpriteInfos[spriteslot].Flags & SPF_ALPHACHANNEL)
-        alpha_blend_cursor = 1;
-    else
-        alpha_blend_cursor = 0;
 
     update_cached_mouse_cursor();
 }

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -380,7 +380,7 @@ void update_cached_mouse_cursor()
 {
     if (mouseCursor != nullptr)
         gfxDriver->DestroyDDB(mouseCursor);
-    mouseCursor = gfxDriver->CreateDDBFromBitmap(mousecurs[0], alpha_blend_cursor != 0);
+    mouseCursor = gfxDriver->CreateDDBFromBitmap(mousecurs[0]);
 }
 
 void set_new_cursor_graphic (int spriteslot) {

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -134,7 +134,6 @@ void set_mouse_cursor(int newcurs) {
 
             if (game.invhotdotsprite > 0) {
                 draw_sprite_slot_support_alpha(dotted_mouse_cursor,
-                    (game.SpriteInfos[game.mcurs[newcurs].pic].Flags & SPF_ALPHACHANNEL) != 0,
                     hotspotx - game.SpriteInfos[game.invhotdotsprite].Width / 2,
                     hotspoty - game.SpriteInfos[game.invhotdotsprite].Height / 2,
                     game.invhotdotsprite);

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -45,8 +45,8 @@ Point get_overlay_position(const ScreenOverlay &over);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
 size_t add_screen_overlay(int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy,
     bool alphaChannel = false, Common::BlendMode blendMode = Common::kBlend_Normal);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool has_alpha);
-size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy);
+size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy);
 // Creates and registers a managed script object for existing overlay object;
 // optionally adds an internal engine reference to prevent object's disposal
 ScriptOverlay* create_scriptoverlay(ScreenOverlay &over, bool internal_ref = false);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -440,7 +440,7 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     }
 
     for (size_t i = 0; i < thisroom.BgFrameCount; ++i) {
-        thisroom.BgFrames[i].Graphic = PrepareSpriteForUse(thisroom.BgFrames[i].Graphic, false);
+        thisroom.BgFrames[i].Graphic = PrepareSpriteForUse(thisroom.BgFrames[i].Graphic);
     }
 
     our_eip=202;

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -104,7 +104,7 @@ IDriverDependantBitmap* prepare_screen_for_transition_in()
         delete saved_viewport_bitmap;
         saved_viewport_bitmap = clippedBuffer;
     }
-    IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(saved_viewport_bitmap, false);
+    IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(saved_viewport_bitmap);
     return ddb;
 }
 

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -77,8 +77,7 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     }
     else
     {
-        if (in->ReadBool()) // has alpha
-            _flags |= kOver_AlphaChannel;
+        in->ReadBool(); // [DEPRECATED] has alpha
         if (!(in->ReadBool())) // screen relative position
             _flags |= kOver_PositionAtRoomXY;
     }

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -32,7 +32,6 @@ using namespace AGS; // FIXME later
 
 enum OverlayFlags
 {
-    kOver_AlphaChannel     = 0x0001,
     kOver_PositionAtRoomXY = 0x0002, // room-relative position, may be in ui
     kOver_RoomLayer        = 0x0004, // work in room layer (as opposed to UI)
     kOver_SpriteReference  = 0x0008, // reference persistent sprite
@@ -65,11 +64,9 @@ struct ScreenOverlay
 
     // Returns Overlay's graphic space params
     inline const Common::GraphicSpace &GetGraphicSpace() const { return _gs; }
-    bool HasAlphaChannel() const { return (_flags & kOver_AlphaChannel) != 0; }
     bool IsSpriteReference() const { return (_flags & kOver_SpriteReference) != 0; }
     bool IsRoomRelative() const { return (_flags & kOver_PositionAtRoomXY) != 0; }
     bool IsRoomLayer() const { return (_flags & kOver_RoomLayer) != 0; }
-    void SetAlphaChannel(bool on) { on ? _flags |= kOver_AlphaChannel : _flags &= ~kOver_AlphaChannel; }
     void SetRoomRelative(bool on) { on ? _flags |= kOver_PositionAtRoomXY : _flags &= ~kOver_PositionAtRoomXY; }
     void SetRoomLayer(bool on)
     {

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -131,12 +131,6 @@ void initialize_sprite (int ee) {
         int oldeip = our_eip;
         our_eip = 4300;
 
-        if (game.SpriteInfos[ee].Flags & SPF_HADALPHACHANNEL) {
-            // we stripped the alpha channel out last time, put
-            // it back so that we can remove it properly again
-            game.SpriteInfos[ee].Flags |= SPF_ALPHACHANNEL;
-        }
-
         curspr = spriteset[ee];
 
         eip_guinum = ee;
@@ -146,13 +140,6 @@ void initialize_sprite (int ee) {
         game.SpriteInfos[ee].Height=spriteset[ee]->GetHeight();
 
         spriteset.SubstituteBitmap(ee, PrepareSpriteForUse(spriteset[ee]));
-
-        if (game.GetColorDepth() < 32) {
-            game.SpriteInfos[ee].Flags &= ~SPF_ALPHACHANNEL;
-            // save the fact that it had one for the next time this
-            // is re-loaded from disk
-            game.SpriteInfos[ee].Flags |= SPF_HADALPHACHANNEL;
-        }
 
         pl_run_plugin_hooks(AGSE_SPRITELOAD, ee);
 

--- a/Engine/ac/sprite.cpp
+++ b/Engine/ac/sprite.cpp
@@ -145,7 +145,7 @@ void initialize_sprite (int ee) {
         game.SpriteInfos[ee].Width=spriteset[ee]->GetWidth();
         game.SpriteInfos[ee].Height=spriteset[ee]->GetHeight();
 
-        spriteset.SubstituteBitmap(ee, PrepareSpriteForUse(spriteset[ee], (game.SpriteInfos[ee].Flags & SPF_ALPHACHANNEL) != 0));
+        spriteset.SubstituteBitmap(ee, PrepareSpriteForUse(spriteset[ee]));
 
         if (game.GetColorDepth() < 32) {
             game.SpriteInfos[ee].Flags &= ~SPF_ALPHACHANNEL;

--- a/Engine/ac/sprite.h
+++ b/Engine/ac/sprite.h
@@ -20,6 +20,7 @@
 
 // set any alpha-transparent pixels in the image to the appropriate
 // RGB mask value so that the ->Blit calls work correctly
+// TODO: find out if this may be removed at some point
 void set_rgb_mask_using_alpha_channel(Common::Bitmap *image);
 // from is a 32-bit RGBA image, to is a 15/16/24-bit destination image
 Common::Bitmap *remove_alpha_channel(Common::Bitmap *from);

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -146,7 +146,7 @@ void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha
             src = new Bitmap(vf_bmp->GetWidth(), vf_bmp->GetHeight(), vf_bmp->GetColorDepth());
             src->FlipBlt(vf_bmp, 0, 0, Common::kFlip_Horizontal);
         }
-        draw_sprite_support_alpha(ds, true, x, y, src, (game.SpriteInfos[vframe->pic].Flags & SPF_ALPHACHANNEL) != 0);
+        draw_sprite_support_alpha(ds, x, y, src);
         if (src != vf_bmp)
             delete src;
     }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -135,11 +135,11 @@ void CheckViewFrame(int view, int loop, int frame, int sound_volume)
 
 // Note: the following function is only used for speech views in update_sierra_speech() and _displayspeech()
 // draws a view frame, flipped if appropriate
-void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha_blend)
+void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y)
 {
-    if (alpha_blend)
+    Bitmap *vf_bmp = spriteset[vframe->pic];
+    if ((ds->GetColorDepth() == 32) && (vf_bmp->GetColorDepth() == 32))
     {
-        Bitmap *vf_bmp = spriteset[vframe->pic];
         Bitmap *src = vf_bmp;
         if (vframe->flags & VFLG_FLIPSPRITE)
         {
@@ -153,9 +153,9 @@ void DrawViewFrame(Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha
     else
     {
         if (vframe->flags & VFLG_FLIPSPRITE)
-            ds->FlipBlt(spriteset[vframe->pic], x, y, Common::kFlip_Horizontal);
+            ds->FlipBlt(vf_bmp, x, y, Common::kFlip_Horizontal);
         else
-            ds->Blit(spriteset[vframe->pic], x, y, Common::kBitmap_Transparency);
+            ds->Blit(vf_bmp, x, y, Common::kBitmap_Transparency);
     }
 }
 

--- a/Engine/ac/viewframe.h
+++ b/Engine/ac/viewframe.h
@@ -44,6 +44,6 @@ void precache_view(int view);
 // sound_volume is an optional relative factor, -1 means not use
 void CheckViewFrame(int view, int loop, int frame, int sound_volume = -1);
 // draws a view frame, flipped if appropriate
-void DrawViewFrame(Common::Bitmap *ds, const ViewFrame *vframe, int x, int y, bool alpha_blend = false);
+void DrawViewFrame(Common::Bitmap *ds, const ViewFrame *vframe, int x, int y);
 
 #endif // __AGS_EE_AC__VIEWFRAME_H

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -2000,7 +2000,7 @@ void OGLGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   else if (_drawScreenCallback != nullptr)
     _drawScreenCallback();
   Bitmap *blackSquare = BitmapHelper::CreateBitmap(16, 16, 32);
-  blackSquare->Clear(makecol32(targetColourRed, targetColourGreen, targetColourBlue));
+  blackSquare->Clear(makeacol32(targetColourRed, targetColourGreen, targetColourBlue, 0xFF));
   IDriverDependantBitmap *d3db = this->CreateDDBFromBitmap(blackSquare, true);
   delete blackSquare;
   BeginSpriteBatch(_srcRect, SpriteTransform());

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -121,7 +121,6 @@ public:
         _height = height;
         _colDepth = colDepth;
         _flipped = false;
-        _hasAlpha = false;
         _stretchToWidth = width;
         _stretchToHeight = height;
         _originX = _originY = 0.f;
@@ -228,7 +227,7 @@ public:
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
-    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
+    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap) override;
     void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override
          { DrawSprite(x, y, x, y, ddb); }
@@ -262,9 +261,9 @@ protected:
     bool SetVsyncImpl(bool vsync, bool &vsync_res) override;
 
     // Create texture data with the given parameters
-    TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
+    TextureData *CreateTextureData(int width, int height, bool as_render_target) override;
     // Update texture data from the given bitmap
-    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
+    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque) override;
     // Create DDB using preexisting texture data
     IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
         int width, int height, int color_depth, bool opaque) override;
@@ -356,7 +355,7 @@ private:
     // Unset parameters and release resources related to the display mode
     void ReleaseDisplayMode();
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
-    void UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, bool opaque, bool hasAlpha);
+    void UpdateTextureRegion(OGLTextureTile *tile, Bitmap *bitmap, bool opaque);
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void _renderSprite(const OGLDrawListEntry *entry, const glm::mat4 &projection, const glm::mat4 &matGlobal,

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -620,7 +620,7 @@ size_t SDLRendererGraphicsDriver::RenderSpriteBatch(const ALSpriteBatch &batch, 
     }
     else
     {
-        GfxUtil::DrawSpriteBlend(surface, Point(drawAtX, drawAtY), bitmap->_bmp, bitmap->_blendMode, false, true, bitmap->_alpha);
+        GfxUtil::DrawSpriteBlend(surface, Point(drawAtX, drawAtY), bitmap->_bmp, bitmap->_blendMode, bitmap->_alpha);
     }
   }
   return from;

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -315,9 +315,9 @@ IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateDDB(int width, int heig
   return new ALSoftwareBitmap(width, height, color_depth, opaque);
 }
 
-IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque)
+IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, bool opaque)
 {
-  return new ALSoftwareBitmap(bitmap, opaque, hasAlpha);
+  return new ALSoftwareBitmap(bitmap, opaque);
 }
 
 IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque)
@@ -326,11 +326,10 @@ IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateRenderTargetDDB(int wid
     return new ALSoftwareBitmap(width, height, color_depth, opaque);
 }
 
-void SDLRendererGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha)
+void SDLRendererGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap)
 {
   ALSoftwareBitmap* alSwBmp = (ALSoftwareBitmap*)bitmapToUpdate;
   alSwBmp->_bmp = bitmap;
-  alSwBmp->_hasAlpha = hasAlpha;
 }
 
 void SDLRendererGraphicsDriver::DestroyDDB(IDriverDependantBitmap* bitmap)

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -80,7 +80,7 @@ public:
         _stretchToHeight = _height;
     }
 
-    ALSoftwareBitmap(Bitmap *bmp, bool opaque, bool hasAlpha)
+    ALSoftwareBitmap(Bitmap *bmp, bool opaque)
     {
         _bmp = bmp;
         _width = bmp->GetWidth();
@@ -89,7 +89,6 @@ public:
         _stretchToWidth = _width;
         _stretchToHeight = _height;
         _opaque = opaque;
-        _hasAlpha = hasAlpha;
         _stretchToWidth = _width;
         _stretchToHeight = _height;
     }
@@ -172,17 +171,17 @@ public:
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
-    IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+    IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool opaque) override;
     IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
-    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
+    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap) override;
     void DestroyDDB(IDriverDependantBitmap* ddb) override;
 
     IDriverDependantBitmap *GetSharedDDB(uint32_t /*sprite_id*/,
-        Common::Bitmap *bitmap, bool hasAlpha, bool opaque) override
+        Common::Bitmap *bitmap, bool opaque) override
     { // Software renderer does not require a texture cache, because it uses bitmaps directly
-        return CreateDDBFromBitmap(bitmap, hasAlpha, opaque);
+        return CreateDDBFromBitmap(bitmap, opaque);
     }
-    void UpdateSharedDDB(uint32_t /*sprite_id*/, Common::Bitmap * /*bitmap*/, bool /*hasAlpha*/, bool /*opaque*/)
+    void UpdateSharedDDB(uint32_t /*sprite_id*/, Common::Bitmap * /*bitmap*/, bool /*opaque*/)
         override { /* do nothing */ }
     void ClearSharedDDB(uint32_t /*sprite_id*/) override { /* do nothing */ }
 

--- a/Engine/gfx/gfx_util.h
+++ b/Engine/gfx/gfx_util.h
@@ -45,7 +45,7 @@ namespace GfxUtil
     // or fallbacks to common "magic pink" transparency mode;
     // optionally uses blending alpha (overall image transparency).
     void DrawSpriteBlend(Bitmap *ds, const Point &ds_at, Bitmap *sprite,
-        Common::BlendMode blend_mode, bool dst_has_alpha = true, bool src_has_alpha = true, int blend_alpha = 0xFF);
+        Common::BlendMode blend_mode, int alpha = 0xFF);
 
     // Draws a bitmap over another one with given alpha level (0 - 255),
     // takes account of the bitmap's mask color,

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -230,15 +230,15 @@ bool VideoMemoryGraphicsDriver::GetStageMatrixes(RenderMatrixes &rm)
     return true;
 }
 
-IDriverDependantBitmap *VideoMemoryGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque)
+IDriverDependantBitmap *VideoMemoryGraphicsDriver::CreateDDBFromBitmap(Bitmap *bitmap, bool opaque)
 {
     IDriverDependantBitmap *ddb = CreateDDB(bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth(), opaque);
     if (ddb)
-        UpdateDDBFromBitmap(ddb, bitmap, hasAlpha);
+        UpdateDDBFromBitmap(ddb, bitmap);
     return ddb;
 }
 
-IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque)
+IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool opaque)
 {
     const auto found = _txRefs.find(sprite_id);
     if (found != _txRefs.end())
@@ -249,9 +249,9 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_
     }
 
     // Create and add a new element
-    std::shared_ptr<TextureData> txdata(CreateTextureData(bitmap->GetWidth(), bitmap->GetHeight(), opaque));
+    std::shared_ptr<TextureData> txdata(CreateTextureData(bitmap->GetWidth(), bitmap->GetHeight(), false));
     txdata->ID = sprite_id;
-    UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
+    UpdateTextureData(txdata.get(), bitmap, opaque);
     // only add into the map when has valid sprite ID
     if (sprite_id != UINT32_MAX)
     {
@@ -261,14 +261,14 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::GetSharedDDB(uint32_t sprite_
     return CreateDDB(txdata, bitmap->GetWidth(), bitmap->GetHeight(), bitmap->GetColorDepth(), opaque);
 }
 
-void VideoMemoryGraphicsDriver::UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool hasAlpha, bool opaque)
+void VideoMemoryGraphicsDriver::UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool opaque)
 {
     const auto found = _txRefs.find(sprite_id);
     if (found != _txRefs.end())
     {
         auto txdata = found->second.Data.lock();
         if (txdata)
-            UpdateTextureData(txdata.get(), bitmap, opaque, hasAlpha);
+            UpdateTextureData(txdata.get(), bitmap, opaque);
     }
 }
 
@@ -332,7 +332,7 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::UpdateStageScreenDDB(size_t i
         return nullptr;
 
     auto &scr = _stageScreens[index];
-    UpdateDDBFromBitmap(scr.DDB, scr.Raw.get(), true);
+    UpdateDDBFromBitmap(scr.DDB, scr.Raw.get());
     scr.Raw->ClearTransparent();
     x = scr.Position.Left;
     y = scr.Position.Top;
@@ -374,12 +374,12 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::MakeFx(int r, int g, int b)
     if (fx.DDB == nullptr)
     {
         fx.Raw.reset(new Bitmap(16, 16, _mode.ColorDepth));
-        fx.DDB = CreateDDBFromBitmap(fx.Raw.get(), false, true);
+        fx.DDB = CreateDDBFromBitmap(fx.Raw.get(), false);
     }
     if (r != fx.Red || g != fx.Green || b != fx.Blue)
     {
         fx.Raw->Clear(makecol_depth(fx.Raw->GetColorDepth(), r, g, b));
-        this->UpdateDDBFromBitmap(fx.DDB, fx.Raw.get(), false);
+        this->UpdateDDBFromBitmap(fx.DDB, fx.Raw.get());
         fx.Red = r;
         fx.Green = g;
         fx.Blue = b;
@@ -457,7 +457,7 @@ __inline void get_pixel_if_not_transparent32(unsigned int *pixel, unsigned int *
     ( (((a) & 0xFF) << _vmem_a_shift_32) | (((r) & 0xFF) << _vmem_r_shift_32) | (((g) & 0xFF) << _vmem_g_shift_32) | (((b) & 0xFF) << _vmem_b_shift_32) )
 
 
-void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const TextureTile *tile,
     char *dst_ptr, const int dst_pitch, const bool usingLinearFiltering)
 {
     const int src_depth = bitmap->GetColorDepth();
@@ -599,18 +599,9 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                                 memPtrLong[x] = 0;
                         }
                         lastPixelWasTransparent = true;
-                    } else if (has_alpha) {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                                                       algeta32(*srcData));
                     } else {
                         memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                                                       0xFF);
-                        if (lastPixelWasTransparent) {
-                            // update the colour of the previous tranparent pixel, to
-                            // stop black outlines when linear filtering
-                            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
-                            lastPixelWasTransparent = false;
-                        }
+                                                       algeta32(*srcData));
                     }
                 }
                 dst_ptr += dst_pitch;
@@ -622,7 +613,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
     }
 }
 
-void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, const TextureTile *tile,
     char *dst_ptr, const int dst_pitch)
 {
     const int src_depth = bitmap->GetColorDepth();
@@ -658,30 +649,16 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
         }
         break;
         case 32: {
-            if (has_alpha) {
-                for (int y = 0; y < tile->height; y++) {
-                    const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
-                    unsigned int* memPtrLong = (unsigned int*)dst_ptr;
+            for (int y = 0; y < tile->height; y++) {
+                const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
+                unsigned int* memPtrLong = (unsigned int*)dst_ptr;
 
-                    for (int x = 0; x < tile->width; x++) {
-                        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                            algeta32(*srcData));
-                    }
-                    dst_ptr += dst_pitch;
+                for (int x = 0; x < tile->width; x++) {
+                    unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
+                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
+                        0xFF);
                 }
-            } else {
-                for (int y = 0; y < tile->height; y++) {
-                    const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
-                    unsigned int* memPtrLong = (unsigned int*)dst_ptr;
-
-                    for (int x = 0; x < tile->width; x++) {
-                        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                            0xFF);
-                    }
-                    dst_ptr += dst_pitch;
-                }
+                dst_ptr += dst_pitch;
             }
         }
         break;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -378,7 +378,7 @@ IDriverDependantBitmap *VideoMemoryGraphicsDriver::MakeFx(int r, int g, int b)
     }
     if (r != fx.Red || g != fx.Green || b != fx.Blue)
     {
-        fx.Raw->Clear(makecol_depth(fx.Raw->GetColorDepth(), r, g, b));
+        fx.Raw->Clear(makeacol_depth(fx.Raw->GetColorDepth(), r, g, b, 0xFF));
         this->UpdateDDBFromBitmap(fx.DDB, fx.Raw.get());
         fx.Red = r;
         fx.Green = g;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -211,7 +211,6 @@ public:
     int _width = 0, _height = 0;
     float _originX = 0.f, _originY = 0.f;
     int _colDepth = 0;
-    bool _hasAlpha = false; // has meaningful alpha channel
     bool _opaque = false; // no mask color
 
 protected:
@@ -294,13 +293,13 @@ public:
     // Creates new texture using given parameters
     IDriverDependantBitmap *CreateDDB(int width, int height, int color_depth, bool opaque) = 0;
     // Creates new texture and copy bitmap contents over
-    IDriverDependantBitmap *CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque = false) override;
+    IDriverDependantBitmap *CreateDDBFromBitmap(Bitmap *bitmap, bool opaque) override;
     // Get shared texture from cache, or create from bitmap and assign ID
-    IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+    IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool opaque) override;
     // Removes the shared texture reference, will force the texture to recreate next time
     void ClearSharedDDB(uint32_t sprite_id) override;
     // Updates shared texture data, but only if it is present in the cache
-    void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+    void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap, bool opaque) override;
     void DestroyDDB(IDriverDependantBitmap* ddb) override;
 
     // Sets stage screen parameters for the current batch.
@@ -308,9 +307,9 @@ public:
 
 protected:
     // Create texture data with the given parameters
-    virtual TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) = 0;
+    virtual TextureData *CreateTextureData(int width, int height, bool as_render_target) = 0;
     // Update texture data from the given bitmap
-    virtual void UpdateTextureData(TextureData *txdata, Bitmap *bmp, bool opaque, bool hasAlpha) = 0;
+    virtual void UpdateTextureData(TextureData *txdata, Bitmap *bmp, bool opaque) = 0;
     // Create DDB using preexisting texture data
     virtual IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
         int width, int height, int color_depth, bool opaque) = 0;
@@ -344,10 +343,10 @@ protected:
     void DestroyFxPool();
 
     // Prepares bitmap to be applied to the texture, copies pixels to the provided buffer
-    void BitmapToVideoMem(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+    void BitmapToVideoMem(const Bitmap *bitmap, const TextureTile *tile,
                             char *dst_ptr, const int dst_pitch, const bool usingLinearFiltering);
     // Same but optimized for opaque source bitmaps which ignore transparent "mask color"
-    void BitmapToVideoMemOpaque(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+    void BitmapToVideoMemOpaque(const Bitmap *bitmap, const TextureTile *tile,
         char *dst_ptr, const int dst_pitch);
 
     // Stage matrixes are used to let plugins with hardware acceleration know model matrix;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -133,19 +133,22 @@ public:
   // Creates a "raw" DDB, without pixel initialization.
   virtual IDriverDependantBitmap *CreateDDB(int width, int height, int color_depth, bool opaque = false) = 0;
   // Creates DDB, initializes from the given bitmap.
-  virtual IDriverDependantBitmap* CreateDDBFromBitmap(Common::Bitmap *bitmap, bool hasAlpha, bool opaque = false) = 0;
+  virtual IDriverDependantBitmap* CreateDDBFromBitmap(Common::Bitmap *bitmap, bool opaque = false) = 0;
   // Creates DDB intended to be used as a render target (allow render other DDBs on it).
   virtual IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque = false) = 0;
   // Updates DBB using the given bitmap; bitmap must have same size and format
   // as the one that this DDB was initialized with.
-  virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Common::Bitmap *bitmap, bool hasAlpha) = 0;
+  virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Common::Bitmap *bitmap) = 0;
   // Destroy the DDB.
   virtual void DestroyDDB(IDriverDependantBitmap* bitmap) = 0;
 
   // Get shared texture from cache, or create from bitmap and assign ID
-  virtual IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id,
-      Common::Bitmap *bitmap = nullptr, bool hasAlpha = true, bool opaque = false) = 0;
-  virtual void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap = nullptr, bool hasAlpha = true, bool opaque = false) = 0;
+  // FIXME: opaque should be either texture data's flag, - in which case same sprite_id
+  // will be either opaque or not opaque, - or DDB's flag, but in that case it cannot
+  // be applied to the shared texture data. Currently it's possible to share same
+  // texture data, but update it with different "opaque" values, which breaks logic.
+  virtual IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap = nullptr, bool opaque = false) = 0;
+  virtual void UpdateSharedDDB(uint32_t sprite_id, Common::Bitmap *bitmap = nullptr, bool opaque = false) = 0;
   // Removes the shared texture reference, will force the texture to recreate next time
   virtual void ClearSharedDDB(uint32_t sprite_id) = 0;
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -41,22 +41,6 @@ extern void replace_macro_tokens(const char*, String&);
 extern SpriteCache spriteset; // in ac_runningame
 extern GameSetupStruct game;
 
-bool GUIMain::HasAlphaChannel() const
-{
-    if (this->BgImage > 0)
-    {
-        // alpha state depends on background image
-        return is_sprite_alpha(this->BgImage);
-    }
-    if (this->BgColor > 0)
-    {
-        // not alpha transparent if there is a background color
-        return false;
-    }
-    // transparent background, enable alpha blending
-    return game.GetColorDepth() >= 24;
-}
-
 //=============================================================================
 // Engine-specific implementation split out of acgui.cpp
 //=============================================================================
@@ -69,11 +53,6 @@ int get_adjusted_spritewidth(int spr)
 int get_adjusted_spriteheight(int spr)
 {
   return spriteset[spr]->GetHeight();
-}
-
-bool is_sprite_alpha(int spr)
-{
-  return ((game.SpriteInfos[spr].Flags & SPF_ALPHACHANNEL) != 0);
 }
 
 void set_eip_guiobj(int eip)

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -80,7 +80,7 @@ Bitmap *prepare_gui_screen(int x, int y, int width, int height, bool opaque)
     {
         windowBuffer = CreateCompatBitmap(windowPosWidth, windowPosHeight);
     }
-    dialogDDB = recycle_ddb_bitmap(dialogDDB, windowBuffer, false, opaque);
+    dialogDDB = recycle_ddb_bitmap(dialogDDB, windowBuffer, opaque);
     return windowBuffer;
 }
 
@@ -100,7 +100,7 @@ void clear_gui_screen()
 
 void refresh_gui_screen()
 {
-    gfxDriver->UpdateDDBFromBitmap(dialogDDB, windowBuffer, false);
+    gfxDriver->UpdateDDBFromBitmap(dialogDDB, windowBuffer);
     update_cursor_and_dependent();
     render_graphics(dialogDDB, windowPosX, windowPosY);
 }

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -574,7 +574,7 @@ void show_preload()
             delete tsc;
             tsc = stretched;
         }
-        IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(tsc, false, true);
+        IDriverDependantBitmap *ddb = gfxDriver->CreateDDBFromBitmap(tsc, true /*opaque*/);
         ddb->SetStretch(view.GetWidth(), view.GetHeight());
         gfxDriver->ClearDrawLists();
         gfxDriver->BeginSpriteBatch(view);

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -466,7 +466,6 @@ void update_sierra_speech()
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }
 
-      screenover[face_talking].SetAlphaChannel(face_has_alpha);
       screenover[face_talking].MarkChanged();
     }  // end if updatedFrame
   }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -456,14 +456,12 @@ void update_sierra_speech()
       }
 
       const ViewFrame *face_vf = &views[facetalkview].loops[facetalkloop].frames[facetalkframe];
-      bool face_has_alpha = (game.SpriteInfos[face_vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
       DrawViewFrame(frame_pic, face_vf, view_frame_x, view_frame_y);
 
       if ((facetalkchar->blinkview > 0) && (facetalkchar->blinktimer < 0)) {
         ViewFrame *blink_vf = &views[facetalkchar->blinkview].loops[facetalkBlinkLoop].frames[facetalkchar->blinkframe];
-        face_has_alpha |= (game.SpriteInfos[blink_vf->pic].Flags & SPF_ALPHACHANNEL) != 0;
         // draw the blinking sprite on top
-        DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
+        DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y);
       }
 
       screenover[face_talking].MarkChanged();

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -212,18 +212,18 @@ bool VideoPlayer::RenderVideo()
     {
         if (gfxDriver->HasAcceleratedTransform())
         {
-            gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf, false);
+            gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf);
             _videoDDB->SetStretch(_dstRect.GetWidth(), _dstRect.GetHeight(), false);
         }
         else
         {
             _targetBitmap->StretchBlt(usebuf, RectWH(_dstRect.GetSize()));
-            gfxDriver->UpdateDDBFromBitmap(_videoDDB, _targetBitmap.get(), false);
+            gfxDriver->UpdateDDBFromBitmap(_videoDDB, _targetBitmap.get());
         }
     }
     else
     {
-        gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf, false);
+        gfxDriver->UpdateDDBFromBitmap(_videoDDB, usebuf);
     }
     gfxDriver->BeginSpriteBatch(play.GetMainViewport(), SpriteTransform());
     gfxDriver->DrawSprite(_dstRect.Left, _dstRect.Top, _videoDDB);

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1934,7 +1934,7 @@ void D3DGraphicsDriver::do_fade(bool fadingOut, int speed, int targetColourRed, 
   else if (_drawScreenCallback != NULL)
     _drawScreenCallback();
   Bitmap *blackSquare = BitmapHelper::CreateBitmap(16, 16, 32);
-  blackSquare->Clear(makecol32(targetColourRed, targetColourGreen, targetColourBlue));
+  blackSquare->Clear(makeacol32(targetColourRed, targetColourGreen, targetColourBlue, 0xFF));
   IDriverDependantBitmap *d3db = this->CreateDDBFromBitmap(blackSquare, true);
   delete blackSquare;
   BeginSpriteBatch(_srcRect, SpriteTransform());

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -113,7 +113,6 @@ public:
         _height = height;
         _colDepth = colDepth;
         _flipped = false;
-        _hasAlpha = false;
         _stretchToWidth = width;
         _stretchToHeight = height;
         _originX = _originY = 0.f;
@@ -215,7 +214,7 @@ public:
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
-    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
+    void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap) override;
     void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override
          { DrawSprite(x, y, x, y, ddb); }
@@ -252,9 +251,9 @@ protected:
     bool SetVsyncImpl(bool vsync, bool &vsync_res) override;
 
     // Create texture data with the given parameters
-    TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
+    TextureData *CreateTextureData(int width, int height, bool as_render_target) override;
     // Update texture data from the given bitmap
-    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
+    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque) override;
     // Create DDB using preexisting texture data
     IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
         int width, int height, int color_depth, bool opaque) override;
@@ -319,7 +318,7 @@ private:
     void ReleaseDisplayMode();
     void set_up_default_vertices();
     void AdjustSizeToNearestSupportedByCard(int *width, int *height);
-    void UpdateTextureRegion(D3DTextureTile *tile, Bitmap *bitmap, bool opaque, bool hasAlpha);
+    void UpdateTextureRegion(D3DTextureTile *tile, Bitmap *bitmap, bool opaque);
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     bool IsTextureFormatOk( D3DFORMAT TextureFormat, D3DFORMAT AdapterFormat );

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -645,8 +645,8 @@ void IAGSEngine::DeleteDynamicSprite(int32 slot) {
     free_dynamic_sprite(slot);
 }
 int IAGSEngine::IsSpriteAlphaBlended(int32 slot) {
-    if (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL)
-        return 1;
+    // [DEPRECATED] TODO: may test for 32-bit? not sure if this function is necessary
+    debug_script_warn("IsSpriteAlphaBlended: this function is deprecated and won't have any effect.");
     return 0;
 }
 
@@ -678,12 +678,9 @@ void IAGSEngine::NotifySpriteUpdated(int32 slot) {
     game_sprite_updated(slot);
 }
 
-void IAGSEngine::SetSpriteAlphaBlended(int32 slot, int32 isAlphaBlended) {
-
-    game.SpriteInfos[slot].Flags &= ~SPF_ALPHACHANNEL;
-
-    if (isAlphaBlended)
-        game.SpriteInfos[slot].Flags |= SPF_ALPHACHANNEL;
+void IAGSEngine::SetSpriteAlphaBlended(int32 /*slot*/, int32 /*isAlphaBlended*/) {
+    // [DEPRECATED]
+    debug_script_warn("SetSpriteAlphaBlended: this function is deprecated and won't have any effect.");
 }
 
 void IAGSEngine::QueueGameScriptFunction(const char *name, int32 globalScript, int32 numArgs, long arg1, long arg2) {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -386,7 +386,7 @@ void IAGSEngine::BlitSpriteTranslucent(int32 x, int32 y, BITMAP *bmp, int32 tran
     if (gfxDriver->UsesMemoryBackBuffer())
         GfxUtil::DrawSpriteWithTransparency(ds, &wrap, x, y, trans);
     else
-        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlend_Normal, true, false, trans);
+        GfxUtil::DrawSpriteBlend(ds, Point(x,y), &wrap, kBlend_Normal, trans);
 }
 
 void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)


### PR DESCRIPTION
Resolves #1808.

In AGS sprites have a "has alpha channel" flag which tells whether the image's alpha channel should be used or not. Certain drawing operations depend on it; for instance a blending op or conversion from the sprite to texture may be performed in one or another way depending on the combination of source and destination surfaces' alpha flags.

The purpose of this change is to remove this flag and those checks altogether, and imply that 32-bit images always have a valid alpha channel. This will simplify a lot of things internally, and probably will make life easier to user who uses true color graphics by default. The only downside I see is that forcing an opaque image will become a responsibility of game author, either when preparing an image for import, or when generating a dynamic sprite in script (in which case one would have to clear the sprite with some color then blit the image on it to ensure there's no transparency).

**What is done**

1. Removed "has_alpha" and "opaque" parameters internally from textures (DDB) and drawing functions.
2. Removed SPF_ALPHACHANNEL flag from sprites. All 32-bit sprites now assume alpha channel.
3. In Script API removed "preserve alpha" parameter from DynamicSprite.Create and CreateFromExistingSprite functions; removed HasAlphaChannel from DialogOptionsRenderingInfo. **NOTE:** I don't know if we want to keep old-style functions in ags4 to ease the project migration. If yes, then I'd have to put old function variants back.

**What is kept**

Kept "Import alpha channel" in the Sprite Import dialog. For now it works simply: if set then do nothing, if unset then the sprite will be made fully opaque by filling alpha channel with 0xFF.
If not wanted, this setting may be removed later as well.

The "magic pink" color constant is still kept internally even in 32-bit. This is unfortunate, but may be necessary for DrawingSurfaces, because currently there's no way to set alpha for a DrawingColor, or in SetPixel/GetPixel, so people will have to use COLOR_TRANSPARENT (see #1514). Unless I'm missing or misunderstanding something here... I may look afterwards if it's okay to completely remove it and any related conversions for 32-bit.

---

TODO:
- [x] fix Editor compilation;
- [x] blank room template generates with RGB background, it seems, which turns into fully-transparent. Besides that, need to ensure that RGB backgrounds are converted into RGBA with opaque alpha?
- [x] any "has alpha" options in the script API.
- [x] double check that in the sprite import disabled "use alpha channel" should result in filling bitmap with opaque alpha;
- [x] ensure that all special opaque sprites in the engine have proper alpha channel values when created.
- [x] ensure that all the primitive drawing operations in the engine and script use color with opaque alpha.
~- [ ] perhaps merge all the `draw_xxx_sprite` functions, because they seem to do almost same thing now (may be done separately later).~
- [x] investigate what happens when upgrading older project with both "has alpha" and "no alpha" 32-bit sprites.
- [x] investigate what happens to room backgrounds when upgrading older project (from both open rooms and closed rooms 3.6.0).
- [x] ensure that 16-bit / 8-bit games display sprites properly (direct3d/opengl runs always in 32-bit display mode).

> ensure that all special opaque sprites in the engine have proper alpha channel values when created.

This includes:
- room background (currently it must be opaque) [WORKS - but only ags4 editor keeps opaque alpha]
- fadeout surface
- fx (tint) sprite
- default dialog options