### PR TITLE
Fix macos icon

### DIFF
--- a/OSX/README.md
+++ b/OSX/README.md
@@ -27,7 +27,11 @@ After you build your game with the Editor, your own game `.ags` and additional f
 In this port, all game resources are taken from `OSX/Resources`, remove the stub files that exist there and replace them with your game files taken from `Compiled/Data/`.
 
 
-## Building your game with CMake and Xcode
+## Building with CMake
+
+Building with CMake is detailed in [`../CMAKE.md`](../CMAKE.md). Follow below for macOS specifics to create your own `.app` bundle with your own game.
+
+### Building your game with CMake and Xcode
 
 At the AGS project root, use CMake to generate the needed Xcode project.
 ```
@@ -43,7 +47,7 @@ The produced binary will be in the `ags/buildXcode/Debug/` directory or `ags/bui
 By default, the name is `AGS.app`.
 
 
-## Building your game with CMake and make
+### Building your game with CMake and make
 
 You can also use CMake and make to build AGS. 
 

--- a/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
+++ b/OSX/xcode/AGSKit/AGSKit.xcodeproj/project.pbxproj
@@ -128,7 +128,6 @@
 		20E67D6528F1BDE000B95C00 /* unicode.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0B28F1BDDF00B95C00 /* unicode.c */; };
 		20E67D6628F1BDE000B95C00 /* blit.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0C28F1BDDF00B95C00 /* blit.c */; };
 		20E67D6728F1BDE000B95C00 /* math.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0D28F1BDDF00B95C00 /* math.c */; };
-		20E67D6828F1BDE000B95C00 /* pcx.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0E28F1BDDF00B95C00 /* pcx.c */; };
 		20E67D6928F1BDE000B95C00 /* fli.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D0F28F1BDDF00B95C00 /* fli.c */; };
 		20E67D6A28F1BDE000B95C00 /* rotate.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1028F1BDDF00B95C00 /* rotate.c */; };
 		20E67D6B28F1BDE000B95C00 /* flood.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1128F1BDDF00B95C00 /* flood.c */; };
@@ -142,12 +141,10 @@
 		20E67D7528F1BDE000B95C00 /* quantize.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1D28F1BDDF00B95C00 /* quantize.c */; };
 		20E67D7628F1BDE000B95C00 /* colblend.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1E28F1BDDF00B95C00 /* colblend.c */; };
 		20E67D7728F1BDE000B95C00 /* dither.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D1F28F1BDDF00B95C00 /* dither.c */; };
-		20E67D7828F1BDE000B95C00 /* dataregi.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2028F1BDDF00B95C00 /* dataregi.c */; };
 		20E67D7928F1BDE000B95C00 /* allegro.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2128F1BDDF00B95C00 /* allegro.c */; };
 		20E67D7A28F1BDE000B95C00 /* vtable15.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2228F1BDDF00B95C00 /* vtable15.c */; };
 		20E67D7B28F1BDE000B95C00 /* readbmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2328F1BDDF00B95C00 /* readbmp.c */; };
 		20E67D7C28F1BDE000B95C00 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2428F1BDDF00B95C00 /* file.c */; };
-		20E67D7D28F1BDE000B95C00 /* bmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2528F1BDDF00B95C00 /* bmp.c */; };
 		20E67D7E28F1BDE000B95C00 /* vtable8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2628F1BDDF00B95C00 /* vtable8.c */; };
 		20E67D7F28F1BDE000B95C00 /* cblit.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D2828F1BDDF00B95C00 /* cblit.h */; };
 		20E67D8028F1BDE000B95C00 /* cspr8.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D2928F1BDDF00B95C00 /* cspr8.c */; };
@@ -177,7 +174,6 @@
 		20E67D9828F1BDE000B95C00 /* inline.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D4128F1BDDF00B95C00 /* inline.c */; };
 		20E67D9928F1BDE000B95C00 /* color.c in Sources */ = {isa = PBXBuildFile; fileRef = 20E67D4228F1BDDF00B95C00 /* color.c */; };
 		20E67D9B28F1BDE000B95C00 /* allegro.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4528F1BDE000B95C00 /* allegro.h */; };
-		20E67D9C28F1BDE000B95C00 /* datafile.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4728F1BDE000B95C00 /* datafile.h */; };
 		20E67D9D28F1BDE000B95C00 /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4828F1BDE000B95C00 /* debug.h */; };
 		20E67D9E28F1BDE000B95C00 /* fixed.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4928F1BDE000B95C00 /* fixed.h */; };
 		20E67D9F28F1BDE000B95C00 /* file.h in Headers */ = {isa = PBXBuildFile; fileRef = 20E67D4A28F1BDE000B95C00 /* file.h */; };
@@ -1064,7 +1060,6 @@
 		20E67D0B28F1BDDF00B95C00 /* unicode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unicode.c; sourceTree = "<group>"; };
 		20E67D0C28F1BDDF00B95C00 /* blit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blit.c; sourceTree = "<group>"; };
 		20E67D0D28F1BDDF00B95C00 /* math.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = math.c; sourceTree = "<group>"; };
-		20E67D0E28F1BDDF00B95C00 /* pcx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pcx.c; sourceTree = "<group>"; };
 		20E67D0F28F1BDDF00B95C00 /* fli.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fli.c; sourceTree = "<group>"; };
 		20E67D1028F1BDDF00B95C00 /* rotate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rotate.c; sourceTree = "<group>"; };
 		20E67D1128F1BDDF00B95C00 /* flood.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = flood.c; sourceTree = "<group>"; };
@@ -1078,12 +1073,10 @@
 		20E67D1D28F1BDDF00B95C00 /* quantize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quantize.c; sourceTree = "<group>"; };
 		20E67D1E28F1BDDF00B95C00 /* colblend.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = colblend.c; sourceTree = "<group>"; };
 		20E67D1F28F1BDDF00B95C00 /* dither.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dither.c; sourceTree = "<group>"; };
-		20E67D2028F1BDDF00B95C00 /* dataregi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dataregi.c; sourceTree = "<group>"; };
 		20E67D2128F1BDDF00B95C00 /* allegro.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = allegro.c; sourceTree = "<group>"; };
 		20E67D2228F1BDDF00B95C00 /* vtable15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable15.c; sourceTree = "<group>"; };
 		20E67D2328F1BDDF00B95C00 /* readbmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = readbmp.c; sourceTree = "<group>"; };
 		20E67D2428F1BDDF00B95C00 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
-		20E67D2528F1BDDF00B95C00 /* bmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmp.c; sourceTree = "<group>"; };
 		20E67D2628F1BDDF00B95C00 /* vtable8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vtable8.c; sourceTree = "<group>"; };
 		20E67D2828F1BDDF00B95C00 /* cblit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cblit.h; sourceTree = "<group>"; };
 		20E67D2928F1BDDF00B95C00 /* cspr8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cspr8.c; sourceTree = "<group>"; };
@@ -1113,7 +1106,6 @@
 		20E67D4128F1BDDF00B95C00 /* inline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = inline.c; sourceTree = "<group>"; };
 		20E67D4228F1BDDF00B95C00 /* color.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = color.c; sourceTree = "<group>"; };
 		20E67D4528F1BDE000B95C00 /* allegro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = allegro.h; sourceTree = "<group>"; };
-		20E67D4728F1BDE000B95C00 /* datafile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = datafile.h; sourceTree = "<group>"; };
 		20E67D4828F1BDE000B95C00 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
 		20E67D4928F1BDE000B95C00 /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed.h; sourceTree = "<group>"; };
 		20E67D4A28F1BDE000B95C00 /* file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file.h; sourceTree = "<group>"; };
@@ -2044,7 +2036,6 @@
 				20E67D0B28F1BDDF00B95C00 /* unicode.c */,
 				20E67D0C28F1BDDF00B95C00 /* blit.c */,
 				20E67D0D28F1BDDF00B95C00 /* math.c */,
-				20E67D0E28F1BDDF00B95C00 /* pcx.c */,
 				20E67D0F28F1BDDF00B95C00 /* fli.c */,
 				20E67D1028F1BDDF00B95C00 /* rotate.c */,
 				20E67D1128F1BDDF00B95C00 /* flood.c */,
@@ -2058,12 +2049,10 @@
 				20E67D1D28F1BDDF00B95C00 /* quantize.c */,
 				20E67D1E28F1BDDF00B95C00 /* colblend.c */,
 				20E67D1F28F1BDDF00B95C00 /* dither.c */,
-				20E67D2028F1BDDF00B95C00 /* dataregi.c */,
 				20E67D2128F1BDDF00B95C00 /* allegro.c */,
 				20E67D2228F1BDDF00B95C00 /* vtable15.c */,
 				20E67D2328F1BDDF00B95C00 /* readbmp.c */,
 				20E67D2428F1BDDF00B95C00 /* file.c */,
-				20E67D2528F1BDDF00B95C00 /* bmp.c */,
 				20E67D2628F1BDDF00B95C00 /* vtable8.c */,
 				20E67D2728F1BDDF00B95C00 /* c */,
 				20E67D4028F1BDDF00B95C00 /* vtable24.c */,
@@ -2126,7 +2115,6 @@
 		20E67D4628F1BDE000B95C00 /* allegro */ = {
 			isa = PBXGroup;
 			children = (
-				20E67D4728F1BDE000B95C00 /* datafile.h */,
 				20E67D4828F1BDE000B95C00 /* debug.h */,
 				20E67D4928F1BDE000B95C00 /* fixed.h */,
 				20E67D4A28F1BDE000B95C00 /* file.h */,
@@ -3604,7 +3592,6 @@
 				526F22E81D3B5C4900EF4E1F /* guimain.h in Headers */,
 				526F23191D3B5C4900EF4E1F /* aautil.h in Headers */,
 				526F27061D3B5CC300EF4E1F /* global_debug.h in Headers */,
-				20E67D9C28F1BDE000B95C00 /* datafile.h in Headers */,
 				526F27221D3B5CC300EF4E1F /* global_object.h in Headers */,
 				526F22AA1D3B5C4900EF4E1F /* gamesetupstruct.h in Headers */,
 				526F27CD1D3B5CC300EF4E1F /* gfxmodelist.h in Headers */,
@@ -4340,7 +4327,6 @@
 				20E67D8D28F1BDE000B95C00 /* cstretch.c in Sources */,
 				526F280C1D3B5CC300EF4E1F /* decode_4to1.c in Sources */,
 				20E67D7B28F1BDE000B95C00 /* readbmp.c in Sources */,
-				20E67D7828F1BDE000B95C00 /* dataregi.c in Sources */,
 				20E6823D28F1D2B400B95C00 /* load_umx.c in Sources */,
 				20E6852A28F2219B00B95C00 /* SpriteFontRenderer.cpp in Sources */,
 				205229F428E8F2B700589E91 /* raster.c in Sources */,
@@ -4380,7 +4366,6 @@
 				526F27421D3B5CC300EF4E1F /* global_walkablearea.cpp in Sources */,
 				20522A1D28E8F81C00589E91 /* stdio_compat.c in Sources */,
 				526F28091D3B5CC300EF4E1F /* dct64.c in Sources */,
-				20E67D7D28F1BDE000B95C00 /* bmp.c in Sources */,
 				20522A4428E8F86400589E91 /* scriptviewport.cpp in Sources */,
 				526F28651D3B5CC300EF4E1F /* game_start.cpp in Sources */,
 				205229D628E8EDE100589E91 /* ftmm.c in Sources */,
@@ -4480,7 +4465,6 @@
 				526F27691D3B5CC300EF4E1F /* properties.cpp in Sources */,
 				526F27DC1D3B5CC300EF4E1F /* mylistbox.cpp in Sources */,
 				526F27CB1D3B5CC300EF4E1F /* gfxfilter_scaling.cpp in Sources */,
-				20E67D6828F1BDE000B95C00 /* pcx.c in Sources */,
 				526F27711D3B5CC300EF4E1F /* room.cpp in Sources */,
 				526F27D01D3B5CC300EF4E1F /* animatingguibutton.cpp in Sources */,
 				20E684B328F20CC700B95C00 /* quant.c in Sources */,

--- a/OSX/xcode/ags/ags-Info.plist
+++ b/OSX/xcode/ags/ags-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>ags.icns</string>
+	<string>ags</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
+++ b/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
@@ -8,14 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		2097967128FA32510065C91B /* ags.iconset in Resources */ = {isa = PBXBuildFile; fileRef = 2097967028FA2F7F0065C91B /* ags.iconset */; };
+		2097967628FA35940065C91B /* AGSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2097967528FA35940065C91B /* AGSKit.framework */; };
 		20E6850228F2202800B95C00 /* acsetup.cfg in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FD28F2202700B95C00 /* acsetup.cfg */; };
 		20E6850328F2202800B95C00 /* game.ags in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FE28F2202700B95C00 /* game.ags */; };
 		20E6850428F2202800B95C00 /* audio.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FF28F2202700B95C00 /* audio.vox */; };
 		20E6850628F2202800B95C00 /* speech.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E6850128F2202800B95C00 /* speech.vox */; };
 		20E6855328F225F800B95C00 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; };
 		20E6855428F225F800B95C00 /* SDL2.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		20E6855528F2260100B95C00 /* AGSKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523AB9701D27DA40002B98F0 /* AGSKit.framework */; };
-		20E6855628F2260100B95C00 /* AGSKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 523AB9701D27DA40002B98F0 /* AGSKit.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		20E6855828F25AF000B95C00 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855728F25AF000B95C00 /* AudioToolbox.framework */; };
 		20E6855A28F25AF800B95C00 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855928F25AF800B95C00 /* AudioUnit.framework */; };
 		20E6855C28F25B0500B95C00 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6855B28F25B0400B95C00 /* CoreAudio.framework */; };
@@ -37,7 +36,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				20E6855428F225F800B95C00 /* SDL2.framework in Copy Frameworks */,
-				20E6855628F2260100B95C00 /* AGSKit.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -47,6 +45,7 @@
 /* Begin PBXFileReference section */
 		1D6058910D05DD3D006BFB54 /* AGS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AGS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2097967028FA2F7F0065C91B /* ags.iconset */ = {isa = PBXFileReference; lastKnownFileType = folder.iconset; name = ags.iconset; path = ../../ags.iconset; sourceTree = "<group>"; };
+		2097967528FA35940065C91B /* AGSKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AGSKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		20C76AB428F3488300772CFC /* ags.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ags.entitlements; sourceTree = "<group>"; };
 		20E6811C28F1CA1700B95C00 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = ../AGSKit/SDL2.framework; sourceTree = "<group>"; };
 		20E684FD28F2202700B95C00 /* acsetup.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = acsetup.cfg; path = ../../Resources/acsetup.cfg; sourceTree = "<group>"; };
@@ -64,7 +63,6 @@
 		20E6856828F25B5400B95C00 /* libz.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.1.tbd; path = usr/lib/libz.1.tbd; sourceTree = SDKROOT; };
 		20E6856E28F25E5B00B95C00 /* libbz2.1.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.1.0.tbd; path = usr/lib/libbz2.1.0.tbd; sourceTree = SDKROOT; };
 		32CA4F630368D1EE00C91783 /* ags_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ags_Prefix.pch; sourceTree = "<group>"; };
-		523AB9701D27DA40002B98F0 /* AGSKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AGSKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52C5BFB21D277B98001E3B10 /* plugin_registration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = plugin_registration.cpp; sourceTree = "<group>"; };
 		52C5BFB31D277B98001E3B10 /* plugin_registration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = plugin_registration.hpp; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* ags-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ags-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
@@ -75,11 +73,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2097967628FA35940065C91B /* AGSKit.framework in Frameworks */,
 				20E6856928F25B5F00B95C00 /* libz.1.tbd in Frameworks */,
 				20E6856328F25B3000B95C00 /* OpenGL.framework in Frameworks */,
 				20E6856F28F25E5B00B95C00 /* libbz2.1.0.tbd in Frameworks */,
 				20E6856028F25B1D00B95C00 /* CoreVideo.framework in Frameworks */,
-				20E6855528F2260100B95C00 /* AGSKit.framework in Frameworks */,
 				20E6855A28F25AF800B95C00 /* AudioUnit.framework in Frameworks */,
 				20E6856728F25B3F00B95C00 /* Cocoa.framework in Frameworks */,
 				20E6856128F25B2600B95C00 /* IOKit.framework in Frameworks */,
@@ -149,6 +147,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2097967528FA35940065C91B /* AGSKit.framework */,
 				20E6856E28F25E5B00B95C00 /* libbz2.1.0.tbd */,
 				20E6856828F25B5400B95C00 /* libz.1.tbd */,
 				20E6856628F25B3E00B95C00 /* Cocoa.framework */,
@@ -160,7 +159,6 @@
 				20E6855928F25AF800B95C00 /* AudioUnit.framework */,
 				20E6855728F25AF000B95C00 /* AudioToolbox.framework */,
 				20E6811C28F1CA1700B95C00 /* SDL2.framework */,
-				523AB9701D27DA40002B98F0 /* AGSKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
+++ b/OSX/xcode/ags/ags.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2097967128FA32510065C91B /* ags.iconset in Resources */ = {isa = PBXBuildFile; fileRef = 2097967028FA2F7F0065C91B /* ags.iconset */; };
 		20E6850228F2202800B95C00 /* acsetup.cfg in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FD28F2202700B95C00 /* acsetup.cfg */; };
 		20E6850328F2202800B95C00 /* game.ags in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FE28F2202700B95C00 /* game.ags */; };
 		20E6850428F2202800B95C00 /* audio.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E684FF28F2202700B95C00 /* audio.vox */; };
-		20E6850528F2202800B95C00 /* ags.icns in Resources */ = {isa = PBXBuildFile; fileRef = 20E6850028F2202800B95C00 /* ags.icns */; };
 		20E6850628F2202800B95C00 /* speech.vox in Resources */ = {isa = PBXBuildFile; fileRef = 20E6850128F2202800B95C00 /* speech.vox */; };
 		20E6855328F225F800B95C00 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; };
 		20E6855428F225F800B95C00 /* SDL2.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 20E6811C28F1CA1700B95C00 /* SDL2.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -46,12 +46,12 @@
 
 /* Begin PBXFileReference section */
 		1D6058910D05DD3D006BFB54 /* AGS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AGS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2097967028FA2F7F0065C91B /* ags.iconset */ = {isa = PBXFileReference; lastKnownFileType = folder.iconset; name = ags.iconset; path = ../../ags.iconset; sourceTree = "<group>"; };
 		20C76AB428F3488300772CFC /* ags.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ags.entitlements; sourceTree = "<group>"; };
 		20E6811C28F1CA1700B95C00 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = ../AGSKit/SDL2.framework; sourceTree = "<group>"; };
 		20E684FD28F2202700B95C00 /* acsetup.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = acsetup.cfg; path = ../../Resources/acsetup.cfg; sourceTree = "<group>"; };
 		20E684FE28F2202700B95C00 /* game.ags */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = game.ags; path = ../../Resources/game.ags; sourceTree = "<group>"; };
 		20E684FF28F2202700B95C00 /* audio.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = audio.vox; path = ../../Resources/audio.vox; sourceTree = "<group>"; };
-		20E6850028F2202800B95C00 /* ags.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = ags.icns; path = ../../Resources/ags.icns; sourceTree = "<group>"; };
 		20E6850128F2202800B95C00 /* speech.vox */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = speech.vox; path = ../../Resources/speech.vox; sourceTree = "<group>"; };
 		20E6855728F25AF000B95C00 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		20E6855928F25AF800B95C00 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
@@ -128,6 +128,7 @@
 		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
 			isa = PBXGroup;
 			children = (
+				2097967028FA2F7F0065C91B /* ags.iconset */,
 				32CA4F630368D1EE00C91783 /* ags_Prefix.pch */,
 			);
 			name = "Other Sources";
@@ -137,7 +138,6 @@
 			isa = PBXGroup;
 			children = (
 				20E684FD28F2202700B95C00 /* acsetup.cfg */,
-				20E6850028F2202800B95C00 /* ags.icns */,
 				20E684FF28F2202700B95C00 /* audio.vox */,
 				20E684FE28F2202700B95C00 /* game.ags */,
 				20E6850128F2202800B95C00 /* speech.vox */,
@@ -222,9 +222,9 @@
 			files = (
 				20E6850428F2202800B95C00 /* audio.vox in Resources */,
 				20E6850628F2202800B95C00 /* speech.vox in Resources */,
+				2097967128FA32510065C91B /* ags.iconset in Resources */,
 				20E6850328F2202800B95C00 /* game.ags in Resources */,
 				20E6850228F2202800B95C00 /* acsetup.cfg in Resources */,
-				20E6850528F2202800B95C00 /* ags.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -246,7 +246,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "${SOURCE_ROOT}/../../Resources/ags.icns";
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = ags.entitlements;
 				CODE_SIGN_IDENTITY = "-";
@@ -279,7 +280,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "${SOURCE_ROOT}/../../Resources/ags.icns";
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = ags.entitlements;
 				CODE_SIGN_IDENTITY = "-";


### PR DESCRIPTION
Minor fix for macOS port

- README includes CMake main usage link
- Xcode links the app statically to the engine library and doesn't embed the AGSKit framework, reducing 17 MB in `.app` size (an ags macOS app now starts at around 7MB)
- Xcode project correctly shows icon in the app when using the archive build scheme