### PR TITLE
mismatched free in cc_dynamicarray

### DIFF
--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -42,7 +42,7 @@ int CCDynamicArray::Dispose(const char *address, bool force) {
         }
     }
 
-    delete address;
+    delete[] address;
     return 1;
 }
 


### PR DESCRIPTION
A minor mismatched free picked in `cc_dynamicarray.cpp`, it uses new char[...] but frees it using a delete instead of delete[]. I am trying to learn how to use valgrind and picked this.

I am leaving it as draft because I want to run a simple game that allocates and deallocates a dynamic array to verify this is correct. There isn't many things in AGS code in valgrind, it generates a bunch of false positives when using my intel video card with the opengl driver.