### PR TITLE
Fixed ResolveScriptPath not handling subdirs correctly

### DIFF
--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -416,8 +416,12 @@ bool ResolveScriptPath(const String &orig_sc_path, bool read_only, ResolvedPath 
         }
     }
 
-    // don't allow write operations for relative paths outside game dir
+    // Create a proper ResolvedPath with FSLocation separating base location
+    // (which the engine is not allowed to create) and sub-dirs (created by the engine).
+    parent_dir = parent_dir.Concat(Path::GetDirectoryPath(child_path));
+    child_path = Path::GetFilename(child_path);
     ResolvedPath test_rp = ResolvedPath(parent_dir, child_path, alt_path);
+    // don't allow write operations for relative paths outside game dir
     if (!read_only)
     {
         if (!Path::IsSameOrSubDir(test_rp.Loc.FullDir, test_rp.FullPath))


### PR DESCRIPTION
Fixes #1822

This fixes engine failing to properly resolve script paths which contain subdirectories. This results in subdirs never created and files failing to open for writing.

Was likely broken somewhere in the middle of 3.6.0 development. But it will be proper to double check that 3.5.1 still works correctly, and if not also apply a corresponding fix there.
EDIT: Tested 3.5.1 and it works fine, so this is only a 3.6.0 bug.

Things to test:
* File.Open with eFileWrite or FileAppend;
* DynamicSprite.SaveToFile;
* Tokens: `$SAVEGAMEDIR$`, `$APPDATADIR$`, no token should remap to `$APPDATADIR$` automatically (with and without subdirs).