### PR TITLE
Editor: restore proper panel dock fill behavior

### DIFF
--- a/Editor/AGS.Editor/GUI/CallStackPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/CallStackPanel.Designer.cs
@@ -74,7 +74,6 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "CallStackPanel";
-            this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
             this.Load += new System.EventHandler(this.CallStackPanel_Load);
             this.ResumeLayout(false);
 

--- a/Editor/AGS.Editor/GUI/FindResultsPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/FindResultsPanel.Designer.cs
@@ -81,7 +81,6 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FindResultsPanel";
-            this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
             this.Load += new System.EventHandler(this.FindResultsPanel_Load);
             this.ResumeLayout(false);
 

--- a/Editor/AGS.Editor/GUI/OutputPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.Designer.cs
@@ -79,7 +79,6 @@ namespace AGS.Editor
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "OutputPanel";
-            this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
             this.Load += new System.EventHandler(this.OutputPanel_Load);
             this.ResumeLayout(false);
 

--- a/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/ProjectPanel.Designer.cs
@@ -53,7 +53,6 @@
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "ProjectPanel";
-            this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
             this.Load += new System.EventHandler(this.ProjectPanel_Load);
             this.ResumeLayout(false);
 

--- a/Editor/AGS.Editor/GUI/PropertiesPanel.Designer.cs
+++ b/Editor/AGS.Editor/GUI/PropertiesPanel.Designer.cs
@@ -62,7 +62,6 @@
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "PropertiesPanel";
-            this.Padding = new System.Windows.Forms.Padding(1, 20, 1, 1);
             this.Load += new System.EventHandler(this.PropertiesPanel_Load);
             this.VisibleChanged += new System.EventHandler(this.PropertiesPanel_VisibleChanged);
             this.ResumeLayout(false);

--- a/Editor/AGS.Editor/GUI/frmMain.Designer.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.Designer.cs
@@ -143,7 +143,6 @@ namespace AGS.Editor
             // 
             this.pnlCallStack.CallStack = null;
             this.pnlCallStack.ClientSize = new System.Drawing.Size(489, 65);
-            this.pnlCallStack.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlCallStack.DockPanel = this.mainContainer;
             this.pnlCallStack.DockState = WeifenLuo.WinFormsUI.Docking.DockState.Unknown;
             this.pnlCallStack.FloatPane = null;
@@ -163,7 +162,6 @@ namespace AGS.Editor
             // pnlFindResults
             // 
             this.pnlFindResults.ClientSize = new System.Drawing.Size(489, 65);
-            this.pnlFindResults.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlFindResults.DockPanel = this.mainContainer;
             this.pnlFindResults.DockState = WeifenLuo.WinFormsUI.Docking.DockState.Unknown;
             this.pnlFindResults.FloatPane = null;
@@ -184,7 +182,6 @@ namespace AGS.Editor
             // pnlOutput
             // 
             this.pnlOutput.ClientSize = new System.Drawing.Size(489, 65);
-            this.pnlOutput.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlOutput.DockPanel = this.mainContainer;
             this.pnlOutput.DockState = WeifenLuo.WinFormsUI.Docking.DockState.Unknown;
             this.pnlOutput.ErrorsToList = null;
@@ -206,7 +203,6 @@ namespace AGS.Editor
             // 
             this.projectPanel.DockPanel = this.mainContainer;
             this.projectPanel.AllowDrop = true;
-            this.projectPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.projectPanel.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.projectPanel.Location = new System.Drawing.Point(0, 0);
             this.projectPanel.Name = "projectPanel";
@@ -224,7 +220,6 @@ namespace AGS.Editor
             // propertiesPanel
             // 
             this.propertiesPanel.DockPanel = this.mainContainer;
-            this.propertiesPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propertiesPanel.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.propertiesPanel.Location = new System.Drawing.Point(0, 0);
             this.propertiesPanel.Name = "propertiesPanel";


### PR DESCRIPTION
Assigning to the Dock property has side effect. It should only be specified on the components themselves, never from frmMain.