### PR TITLE
New compiler: Don't kill LINENUM pseudo commands when shortcutting code

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -69,7 +69,6 @@ AGS::ccCompiledScript::ccCompiledScript(bool emit_line_numbers)
     sectionOffsets = NULL;
 
     LastEmittedLineno = INT_MAX;
-    EmitLineNumbers = emit_line_numbers;
     Functions = {};
     ImportIdx = {};
 }
@@ -320,7 +319,16 @@ void AGS::RestorePoint::Restore()
     if (_scrip.codesize <= static_cast<int>(_rememberedCodeLocation))
         return; // all done
 
+    bool const starts_with_linenum =
+        (_scrip.codesize > _rememberedCodeLocation + 1) &&
+        (SCMD_LINENUM == _scrip.code[_rememberedCodeLocation]);
+
     _scrip.codesize = _rememberedCodeLocation;
+    // If the code at the remembered location begins with a LINENUM
+    // pseudo-command then keep this pseudo-command so that the system knows
+    // that the line has been visited even though no code has been generated for it.
+    if (starts_with_linenum)
+        _scrip.codesize += 2;
 
     while (_scrip.numfixups > 0)
     {

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2890,5 +2890,31 @@ TEST_F(Bytecode1, Linenum02)
     AGS::ccCompiledScript scrip{ true };
     int compileResult = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
-    WriteOutput("Linenum02", scrip);
+    // WriteOutput("Linenum02", scrip);
+    size_t const codesize = 38;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            4,    6,    3,    2,    // 15
+      29,    3,   51,    8,            7,    3,   30,    4,    // 23
+      11,    3,    4,    8,            3,   36,    5,    6,    // 31
+       3,    0,    2,    1,            4,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
 }

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -2826,3 +2826,69 @@ TEST_F(Bytecode1, LongMin1) {
     size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
+
+TEST_F(Bytecode1, Linenum01)
+{
+    // Linenum directive must be generated for each declaration
+
+    const char *inpl = "\
+    int game_start()            \n\
+    {                           \n\
+        int a = 1;              \n\
+        int b = 1 + 1;          \n\
+    }                           \n\
+    ";
+
+
+    MessageHandler mh;
+    AGS::ccCompiledScript scrip{ true };
+    int compileResult = cc_compile(inpl, 0, scrip, mh);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
+    // WriteOutput("Linenum01", scrip);
+
+    size_t const codesize = 27;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       1,   29,    3,   36,            4,    6,    3,    2,    // 15
+      29,    3,   36,    5,            2,    1,    8,    6,    // 23
+       3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode1, Linenum02)
+{
+    // Linenum directive must be generated for 'c +=' line
+
+    const char *inpl = "\
+    int game_start()            \n\
+    {                           \n\
+        int c = 0;              \n\
+        c += 1 + 1;             \n\
+        return 0;               \n\
+    }                           \n\
+    ";
+
+    MessageHandler mh;
+    AGS::ccCompiledScript scrip{ true };
+    int compileResult = cc_compile(inpl, 0, scrip, mh);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
+    WriteOutput("Linenum02", scrip);
+}


### PR DESCRIPTION
## Don't integrate yet
[Don't integrate yet: I've rerun all the googletests whilst enabling linenum directives and found a test that generated illegal code. Need to investigate this further.]

This addresses #1832.

The new compiler often generates code but then decides to use some shortcut instead. In these cases, it  replaces code that has already be generated. 

Whenever that replaced code started with a LINENUM pseudo-directive then that directive got overwritten. In consequence, the AGS system didn't recognize that the corresponding lines are visited. So the debugger skipped them; and when a runtime error happened on those lines, the runtime system wouldn't show the line of the error but the line in front of that. 

Changed the compiler so that it keeps leading LINENUM directives whenever it replaces code.

Typical AGS code:

```
function game_start()
{
   int a = 1;
   int b = 1 + 1; \\ ←
   int c = a + b;
   c += 1;
   c += 1 + 1; \\ ←
   return 0;
}
```

When tracing this code in the Editor, it should (also) stop on the lines marked `\\ ←`