### PR TITLE
Engine: Fix malloc/delete mismatch with RoomStatus::tsdata

### DIFF
--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -245,7 +245,7 @@ void save_room_data_segment () {
     
     croom->tsdatasize = roominst->globaldatasize;
     if (croom->tsdatasize > 0) {
-        croom->tsdata=(char*)malloc(croom->tsdatasize+10);
+        croom->tsdata = new char[croom->tsdatasize+10];
         memcpy(croom->tsdata,&roominst->globaldata[0],croom->tsdatasize);
     }
 

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -148,7 +148,7 @@ static void restore_game_room_state(Stream *in)
                 ReadRoomStatus_Aligned(roomstat, in);
                 if (roomstat->tsdatasize > 0)
                 {
-                    roomstat->tsdata=(char*)malloc(roomstat->tsdatasize + 8);  // JJS: Why allocate 8 additional bytes?
+                    roomstat->tsdata = new char[roomstat->tsdatasize + 8];  // JJS: Why allocate 8 additional bytes?
                     in->Read(&roomstat->tsdata[0], roomstat->tsdatasize);
                 }
             }
@@ -370,7 +370,7 @@ static void restore_game_displayed_room_status(Stream *in, RestoredData &r_data)
         ReadRoomStatus_Aligned(&troom, in);
 
         if (troom.tsdatasize > 0) {
-            troom.tsdata=(char*)malloc(troom.tsdatasize+5);
+            troom.tsdata = new char[troom.tsdatasize+5];
             in->Read(&troom.tsdata[0],troom.tsdatasize);
         }
         else


### PR DESCRIPTION
There is a mismatch in the allocation and deallocation of `RoomStatus::tsdata`. In `roomstatus.cpp` `new []` and `delete []`, but in a couple of other files, the memory is allocated with `malloc`. This pull request changes all allocations of `RoomStatus::tsdata` to use `new []`.

Something that is strange, but that I didn't change, is the amount of memory allocated. In `roomstatus.cpp` it allocates `RoomStatus::tsdatasize` chars, which makes sense. But in the other places it allocates 10, 8, or 5 more bytes, depending where the allocation is done, and I see no reason to allocate those additional bytes. So that is also potentially something else that could be changed.