### PR TITLE
Common: Fixed new[]/delete mistmatch

### DIFF
--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -301,7 +301,7 @@ void ReadDialogs(std::vector<DialogTopic> &dialog,
     for (int i = 0; i < dlg_count; ++i)
     {
         // NOTE: originally this was read into dialog[i].optionscripts
-        old_dialog_scripts[i].reset(new unsigned char[dialog[i].codesize]);
+        old_dialog_scripts[i].reset(new unsigned char[dialog[i].codesize], std::default_delete<unsigned char[]>());
         in->Read(old_dialog_scripts[i].get(), dialog[i].codesize);
 
         // Encrypted text script


### PR DESCRIPTION
By default `std::shared_ptr` uses `delete` to delete its data. When using it to store an array we need to pass a custom deleter that uses `delete []` instead. The easiest way to do this is to use the partial specialisation of `std::default_delete` for arrays.