### PR TITLE
Engine: only clear _stageScreen after it's dirty

### DIFF
--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -290,7 +290,6 @@ bool VideoMemoryGraphicsDriver::DoNullSpriteCallback(int x, int y)
     if (!_nullSpriteCallback)
         throw Ali3DException("Unhandled attempt to draw null sprite");
     _stageScreenDirty = false;
-    _stageScreen.Bitmap->ClearTransparent();
     // NOTE: this is not clear whether return value of callback may be
     // relied on. Existing plugins do not seem to return anything but 0,
     // even if they handle this event.
@@ -298,6 +297,7 @@ bool VideoMemoryGraphicsDriver::DoNullSpriteCallback(int x, int y)
     if (_stageScreenDirty)
     {
         UpdateDDBFromBitmap(_stageScreen.DDB, _stageScreen.Bitmap.get(), true);
+        _stageScreen.Bitmap->ClearTransparent();
         return true;
     }
     return false;


### PR DESCRIPTION
> Perhaps it should be made a plugin's responsibility to clear if it needs to. Because now engine will still do certain action without knowing whether plugin needs it at all (plugin may be performing a 3D rendering without using raw stage surface).

For the last point, in this case the plugin can simply return false, right?

https://github.com/monkey0506/ags2client/blob/7db4df8baccf955b0ff9fb496d9779a2fb90bf25/main.cpp#L136

The above is used in agsteam plugin, so it currently affects all AGS games on Steam. 

---

I think this is safe to be applied, but perhaps the responsibility change has to be something for a next version change.

TO-DO: figure out if there is any plugin besides SnowRain that uses this call for **drawing** edit: ags_parallax and palrender in this repository also use the `AGSE_PREGUIDRAW` which I believe is for RawDraw too. I don't understand how Snow Rain plugin works in this case as in the code it's returning 0, but it does manage to trigger the clear?

https://github.com/adventuregamestudio/ags/blob/78aa08036b9f245aef1a078d7ed71cb322edc1bd/Plugins/ags_snowrain/ags_snowrain.cpp#L826

From what I understand the int x, int y is actually int event, int data from `pl_run_plugin_hooks`.