### PR TITLE
Allegro: remove bitmap bank stuff

### DIFF
--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -204,8 +204,6 @@ void SDLRendererGraphicsDriver::CreateVirtualScreen()
 
   auto tmpbitmap = create_bitmap_ex(32, 1, 1);
   _fakeTexBitmap->vtable = tmpbitmap->vtable;
-  _fakeTexBitmap->write_bank = tmpbitmap->write_bank;
-  _fakeTexBitmap->read_bank = tmpbitmap->read_bank;
   destroy_bitmap(tmpbitmap);
 
   _lastTexPixels = nullptr;

--- a/libsrc/allegro/include/allegro/gfx.h
+++ b/libsrc/allegro/include/allegro/gfx.h
@@ -58,16 +58,10 @@ struct RGB;
 #define blender_mode_screen         13
 #define blender_mode_alpha          14
 
-
-typedef AL_METHOD(uintptr_t, _BMP_BANK_SWITCHER, (struct BITMAP *bmp, int lyne));
-typedef AL_METHOD(void, _BMP_UNBANK_SWITCHER, (struct BITMAP *bmp));
-
-
 typedef struct GFX_VTABLE        /* functions for drawing onto bitmaps */
 {
    int color_depth;
    int mask_color;
-   _BMP_UNBANK_SWITCHER unwrite_bank;  /* C function on some machines, asm on i386 */
    AL_METHOD(void, set_clip, (struct BITMAP *bmp));
    AL_METHOD(void, acquire, (struct BITMAP *bmp));
    AL_METHOD(void, release, (struct BITMAP *bmp));
@@ -178,8 +172,6 @@ typedef struct BITMAP            /* a bitmap structure */
    int clip;                     /* flag if clipping is turned on */
    int cl, cr, ct, cb;           /* clip left, right, top and bottom values */
    GFX_VTABLE *vtable;           /* drawing functions */
-   _BMP_BANK_SWITCHER write_bank;/* C func on some machines, asm on i386 */
-   _BMP_BANK_SWITCHER read_bank; /* C func on some machines, asm on i386 */
    void *dat;                    /* the memory we allocated for the bitmap */
    unsigned long id;             /* for identifying sub-bitmaps */
    void *extra;                  /* points to a structure with more info */

--- a/libsrc/allegro/include/allegro/inline/gfx.inl
+++ b/libsrc/allegro/include/allegro/inline/gfx.inl
@@ -35,41 +35,23 @@ AL_INLINE(int, _default_ds, (void),
    return 0;
 })
 
-#ifdef ALLEGRO_BCC32
-
-   /* BCC32 is a somewhat unusual platform because it mixes a MSVC/MinGW generated DLL
-    * (for which ALLEGRO_NO_ASM is not defined) with Borland C++ compiled programs for
-    * which ALLEGRO_NO_ASM is defined. As a result, Borland C++ compiled programs can't
-    * use the inlined version of bmp_write_line(), bmp_read_line() and bmp_unwrite_line()
-    * because the write_bank() and read_bank() methods of the BITMAP class don't expect
-    * the same calling convention on both sides.
-    */
-
-AL_FUNC(uintptr_t, bmp_write_line, (BITMAP *bmp, int lyne));
-AL_FUNC(uintptr_t, bmp_read_line, (BITMAP *bmp, int lyne));
-AL_FUNC(void, bmp_unwrite_line, (BITMAP *bmp));
-
-#else
-
 
 AL_INLINE(uintptr_t, bmp_write_line, (BITMAP *bmp, int lyne),
 {
-   return bmp->write_bank(bmp, lyne);
+   return (uintptr_t) bmp->line[lyne];
 })
 
 
 AL_INLINE(uintptr_t, bmp_read_line, (BITMAP *bmp, int lyne),
 {
-   return bmp->read_bank(bmp, lyne);
+   return (uintptr_t) bmp->line[lyne];
 })
 
 
 AL_INLINE(void, bmp_unwrite_line, (BITMAP *bmp),
 {
-   bmp->vtable->unwrite_bank(bmp);
+   //bmp->vtable->unwrite_bank(bmp);
 })
-
-#endif      /* defined ALLEGRO_BCC32 */
 
 #endif      /* C vs. inline asm */
 

--- a/libsrc/allegro/include/allegro/internal/aintern.h
+++ b/libsrc/allegro/include/allegro/internal/aintern.h
@@ -126,19 +126,6 @@ AL_FUNC(void, _al_getdcwd, (int drive, char *buf, int size));
 
 
 
-/* caches and tables for svga bank switching */
-AL_VAR(int, _last_bank_1);
-AL_VAR(int, _last_bank_2); 
-
-AL_VAR(int *, _gfx_bank);
-
-/* bank switching routines (these use a non-C calling convention on i386!) */
-AL_FUNC(uintptr_t, _stub_bank_switch, (BITMAP *bmp, int lyne));
-AL_FUNC(void, _stub_unbank_switch, (BITMAP *bmp));
-AL_FUNC(void, _stub_bank_switch_end, (void));
-
-
-
 /* stuff for setting up bitmaps */
 AL_FUNC(GFX_VTABLE *, _get_vtable, (int color_depth));
 

--- a/libsrc/allegro/src/allegro.c
+++ b/libsrc/allegro/src/allegro.c
@@ -163,13 +163,6 @@ int gui_bg_color = 0;
 void *_scratch_mem = NULL;
 int _scratch_mem_size = 0;
 
-
-/* SVGA bank switching tables */
-int _last_bank_1 = -1;
-int _last_bank_2 = -1;
-int *_gfx_bank = NULL;
-
-
 /* debugging stuff */
 static int debug_assert_virgin = TRUE;
 static int debug_trace_virgin = TRUE;
@@ -283,9 +276,6 @@ static int _install_allegro(int system_id, int *errno_ptr, int (*atexit_ptr)(voi
       desktop_palette[i] = desktop_palette[i & 15];
 
    /* lock some important variables */
-   LOCK_VARIABLE(_last_bank_1);
-   LOCK_VARIABLE(_last_bank_2);
-   LOCK_VARIABLE(_gfx_bank);
    LOCK_VARIABLE(_drawing_mode);
    LOCK_VARIABLE(_drawing_pattern);
    LOCK_VARIABLE(_drawing_x_anchor);

--- a/libsrc/allegro/src/c/cmisc.c
+++ b/libsrc/allegro/src/c/cmisc.c
@@ -22,20 +22,6 @@
 
 
 #ifdef ALLEGRO_NO_ASM
-/* Empty bank switch routines.  Should be used with C calling convention. */
-
-uintptr_t _stub_bank_switch(BITMAP *bmp, int y)
-{
-   return (uintptr_t)bmp->line[y];
-}
-
-void _stub_unbank_switch(BITMAP *bmp)
-{
-}
-
-void _stub_bank_switch_end(void)
-{
-}
 
 #else
 

--- a/libsrc/allegro/src/graphics.c
+++ b/libsrc/allegro/src/graphics.c
@@ -317,7 +317,6 @@ BITMAP *create_bitmap_ex(int color_depth, int width, int height)
    bitmap->clip = TRUE;
    bitmap->cl = bitmap->ct = 0;
    bitmap->vtable = vtable;
-   bitmap->write_bank = bitmap->read_bank = _stub_bank_switch;
    bitmap->id = 0;
    bitmap->extra = NULL;
    bitmap->x_ofs = 0;
@@ -388,8 +387,6 @@ BITMAP *create_sub_bitmap(BITMAP *parent, int x, int y, int width, int height)
    bitmap->clip = TRUE;
    bitmap->cl = bitmap->ct = 0;
    bitmap->vtable = parent->vtable;
-   bitmap->write_bank = parent->write_bank;
-   bitmap->read_bank = parent->read_bank;
    bitmap->dat = NULL;
    bitmap->extra = NULL;
    bitmap->x_ofs = x + parent->x_ofs;

--- a/libsrc/allegro/src/vtable15.c
+++ b/libsrc/allegro/src/vtable15.c
@@ -32,7 +32,6 @@ GFX_VTABLE __linear_vtable15 =
 {
    15,
    MASK_COLOR_15,
-   _stub_unbank_switch,
    NULL,
    NULL,
    NULL,

--- a/libsrc/allegro/src/vtable16.c
+++ b/libsrc/allegro/src/vtable16.c
@@ -32,7 +32,6 @@ GFX_VTABLE __linear_vtable16 =
 {
    16,
    MASK_COLOR_16,
-   _stub_unbank_switch,
    NULL,
    NULL,
    NULL,

--- a/libsrc/allegro/src/vtable24.c
+++ b/libsrc/allegro/src/vtable24.c
@@ -32,7 +32,6 @@ GFX_VTABLE __linear_vtable24 =
 {
    24,
    MASK_COLOR_24,
-   _stub_unbank_switch,
    NULL,
    NULL,
    NULL,

--- a/libsrc/allegro/src/vtable32.c
+++ b/libsrc/allegro/src/vtable32.c
@@ -32,7 +32,6 @@ GFX_VTABLE __linear_vtable32 =
 {
    32,
    MASK_COLOR_32,
-   _stub_unbank_switch,
    NULL,
    NULL,
    NULL,

--- a/libsrc/allegro/src/vtable8.c
+++ b/libsrc/allegro/src/vtable8.c
@@ -32,7 +32,6 @@ GFX_VTABLE __linear_vtable8 =
 {
    8,
    MASK_COLOR_8,
-   _stub_unbank_switch,
    NULL,
    NULL,
    NULL,


### PR DESCRIPTION
the bank switching methods are unused and safe for removal. Maybe just wait the CI build, but I could not find any use for these.