### PR TITLE
Scanline safety check as assert 

### DIFF
--- a/Common/gfx/allegrobitmap.h
+++ b/Common/gfx/allegrobitmap.h
@@ -133,7 +133,8 @@ public:
     // Get scanline for direct reading
 	inline const unsigned char *GetScanLine(int index) const
     {
-        return (index >= 0 && index < GetHeight()) ? _alBitmap->line[index] : nullptr;
+        assert(index >= 0 && index < GetHeight());
+        return _alBitmap->line[index];
     }
 
 	// Get bitmap's mask color (transparent color)


### PR DESCRIPTION
The initial proposal was to redo this using GetData

> This is definitely a mistake that GetScanLine was still in use; it's a remnant of times when Bitmap class was introduced trying to fully mimic Allegro's BITMAP behavior. Allegro's BITMAP could contain different kind of data, starting from simple linear bitmaps, and following with video textures, planar bitmaps, etc. But the engine was mostly using linear memory bitmaps (except for the final render to screen, afaik), and now when Allegro's source is stripped, there are no other bitmap types supported at all.
> 
> So it's correct to assume that Bitmap's data is simply a linear array of pixels with fixed stride calculated as w*h*bpp, do not use GetScanLine at all, and use GetData instead for getting the beginning of array once. The length of the line may be either calculated in place, or retrieved from Bitmap.GetLineLength().

Edit:

ok, so I tried to go this way locally and I still think it's best to just drop the safeties (moved them to an assert) from GetScanline since it's an inline function, I don't think it adds any impact.

Using the additional math in each function was a bit repetitive, so this feels better.