### PR TITLE
unswitch loops in functions that are hotspot in high definition games

### DIFF
--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -109,17 +109,26 @@ static void UnpackIndexedBitmap(Bitmap *image, const uint8_t *data, size_t data_
     const uint8_t bpp = image->GetBPP();
     const size_t dst_size = image->GetWidth() * image->GetHeight() * image->GetBPP();
     uint8_t *dst = image->GetDataForWriting(), *dst_end = dst + dst_size;
-    for (size_t p = 0; (p < data_size) && (dst < dst_end); ++p, dst += bpp)
+
+    switch (bpp)
     {
-        uint8_t index = data[p];
-        assert(index < pal_count);
-        uint32_t color = (index < pal_count) ? palette[index] : palette[0];
-        switch (bpp)
-        {
-        case 2: *((uint16_t*)dst) = color; break;
-        case 4: *((uint32_t*)dst) = color; break;
+        case 2:
+            for (size_t p = 0; (p < data_size) && (dst < dst_end); ++p, dst += bpp) {
+                uint8_t index = data[p];
+                assert(index < pal_count);
+                uint32_t color = palette[(index < pal_count) ? index : 0];
+                *((uint16_t *) dst) = color;
+            }
+        break;
+        case 4:
+            for (size_t p = 0; (p < data_size) && (dst < dst_end); ++p, dst += bpp) {
+                uint8_t index = data[p];
+                assert(index < pal_count);
+                uint32_t color = palette[(index < pal_count) ? index : 0];
+                *((uint32_t*)dst) = color;
+            }
+        break;
         default: assert(0); return;
-        }
     }
 }
 


### PR DESCRIPTION
Loop Unswitching only in functions that are hotspot signaled by running a profiler in a high definition game (1920x1080) with lots of frames. Used both Very Sleepy and AMDuProf as profilers.

I didn't find any other place where this was relevant in the code, since other places aren't ran nearly as often as these functions can be ran.

Here's a small benchmark, it improves 4-5fps in my computer.

[ClearBenchmark.zip](https://github.com/adventuregamestudio/ags/files/10269431/ClearBenchmark.zip)