### PR TITLE
Allegro cleanup bmp related methods

### DIFF
--- a/Common/libsrc/aastr-0.1.1/aarot.c
+++ b/Common/libsrc/aastr-0.1.1/aarot.c
@@ -557,8 +557,6 @@ _aa_rotate_bitmap (BITMAP *_src, BITMAP *_dst, int _x, int _y, fixed _angle,
       aa_ADVANCE (*rsc, rscinc, rscdd, rsci1, rsci2);
       aa_ADVANCE (rdx, rdxinc, rdxdd, rdxi1, rdxi2);
     }
-
-  bmp_unwrite_line (_dst);
 }
 
 /*

--- a/Common/libsrc/aastr-0.1.1/aastr.c
+++ b/Common/libsrc/aastr-0.1.1/aastr.c
@@ -181,8 +181,6 @@ _aa_stretch_blit (BITMAP *_src, BITMAP *_dst,
 
       aa_ADVANCE (sy, yinc, ydd, yi1, yi2);
     }
-
-  bmp_unwrite_line (_dst);
 }
 
 /*

--- a/Editor/AGS.Native/cstretch.cpp
+++ b/Editor/AGS.Native/cstretch.cpp
@@ -410,8 +410,7 @@ static void _al_stretch_blit(BITMAP *src, BITMAP *dst,
       else
 	    yc -= ycdec;
    }
-   
-   bmp_unwrite_line(dst);
+
 }
 
 

--- a/libsrc/allegro/include/allegro/inline/draw.inl
+++ b/libsrc/allegro/include/allegro/inline/draw.inl
@@ -282,7 +282,6 @@ AL_INLINE(void, _putpixel, (BITMAP *bmp, int x, int y, int color),
    bmp_select(bmp);
    addr = bmp_write_line(bmp, y);
    bmp_write8(addr+x, color);
-   bmp_unwrite_line(bmp);
 })
 
 
@@ -294,7 +293,6 @@ AL_INLINE(int, _getpixel, (BITMAP *bmp, int x, int y),
    bmp_select(bmp);
    addr = bmp_read_line(bmp, y);
    c = bmp_read8(addr+x);
-   bmp_unwrite_line(bmp);
 
    return c;
 })
@@ -307,7 +305,6 @@ AL_INLINE(void, _putpixel15, (BITMAP *bmp, int x, int y, int color),
    bmp_select(bmp);
    addr = bmp_write_line(bmp, y);
    bmp_write15(addr+x*sizeof(short), color);
-   bmp_unwrite_line(bmp);
 })
 
 
@@ -319,7 +316,6 @@ AL_INLINE(int, _getpixel15, (BITMAP *bmp, int x, int y),
    bmp_select(bmp);
    addr = bmp_read_line(bmp, y);
    c = bmp_read15(addr+x*sizeof(short));
-   bmp_unwrite_line(bmp);
 
    return c;
 })
@@ -332,7 +328,6 @@ AL_INLINE(void, _putpixel16, (BITMAP *bmp, int x, int y, int color),
    bmp_select(bmp);
    addr = bmp_write_line(bmp, y);
    bmp_write16(addr+x*sizeof(short), color);
-   bmp_unwrite_line(bmp);
 })
 
 
@@ -344,7 +339,6 @@ AL_INLINE(int, _getpixel16, (BITMAP *bmp, int x, int y),
    bmp_select(bmp);
    addr = bmp_read_line(bmp, y);
    c = bmp_read16(addr+x*sizeof(short));
-   bmp_unwrite_line(bmp);
 
    return c;
 })
@@ -357,7 +351,6 @@ AL_INLINE(void, _putpixel24, (BITMAP *bmp, int x, int y, int color),
    bmp_select(bmp);
    addr = bmp_write_line(bmp, y);
    bmp_write24(addr+x*3, color);
-   bmp_unwrite_line(bmp);
 })
 
 
@@ -369,7 +362,6 @@ AL_INLINE(int, _getpixel24, (BITMAP *bmp, int x, int y),
    bmp_select(bmp);
    addr = bmp_read_line(bmp, y);
    c = bmp_read24(addr+x*3);
-   bmp_unwrite_line(bmp);
 
    return c;
 })
@@ -382,7 +374,6 @@ AL_INLINE(void, _putpixel32, (BITMAP *bmp, int x, int y, int color),
    bmp_select(bmp);
    addr = bmp_write_line(bmp, y);
    bmp_write32(addr+x*sizeof(int32_t), color);
-   bmp_unwrite_line(bmp);
 })
 
 
@@ -394,7 +385,6 @@ AL_INLINE(int, _getpixel32, (BITMAP *bmp, int x, int y),
    bmp_select(bmp);
    addr = bmp_read_line(bmp, y);
    c = bmp_read32(addr+x*sizeof(int32_t));
-   bmp_unwrite_line(bmp);
 
    return c;
 })

--- a/libsrc/allegro/include/allegro/inline/gfx.inl
+++ b/libsrc/allegro/include/allegro/inline/gfx.inl
@@ -48,11 +48,6 @@ AL_INLINE(uintptr_t, bmp_read_line, (BITMAP *bmp, int lyne),
 })
 
 
-AL_INLINE(void, bmp_unwrite_line, (BITMAP *bmp),
-{
-   //bmp->vtable->unwrite_bank(bmp);
-})
-
 #endif      /* C vs. inline asm */
 
 

--- a/libsrc/allegro/src/blit.c
+++ b/libsrc/allegro/src/blit.c
@@ -100,7 +100,6 @@ static void blit_from_256(BITMAP *src, BITMAP *dest, int s_x, int s_y, int d_x, 
             }                                                                \
          }                                                                   \
                                                                              \
-         bmp_unwrite_line(dest);                                             \
       }                                                                      \
       else {                                                                 \
          /* slower version when reading from the screen */                   \
@@ -120,8 +119,6 @@ static void blit_from_256(BITMAP *src, BITMAP *dest, int s_x, int s_y, int d_x, 
             }                                                                \
          }                                                                   \
                                                                              \
-         bmp_unwrite_line(src);                                              \
-         bmp_unwrite_line(dest);                                             \
       }                                                                      \
    }
 
@@ -213,8 +210,6 @@ static void blit_from_256(BITMAP *src, BITMAP *dest, int s_x, int s_y, int d_x, 
       }                                                                      \
    }                                                                         \
                                                                              \
-   bmp_unwrite_line(src);                                                    \
-   bmp_unwrite_line(dest);                                                   \
 }
 
 #define CONVERT_BLIT(sbits, ssize, dbits, dsize) \

--- a/libsrc/allegro/src/c/cblit.h
+++ b/libsrc/allegro/src/c/cblit.h
@@ -47,10 +47,8 @@ void FUNC_LINEAR_CLEAR_TO_COLOR(BITMAP *dst, int color)
 
    w = dst->cr - dst->cl;
 
-   bmp_select(dst);
-
    for (y = dst->ct; y < dst->cb; y++) {
-      PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, y), dst->cl);
+      PIXEL_PTR d = OFFSET_PIXEL_PTR(dst->line[y], dst->cl);
 
       for (x = w - 1; x >= 0; INC_PIXEL_PTR(d), x--) {
 	 PUT_PIXEL(d, color);
@@ -76,17 +74,15 @@ void FUNC_LINEAR_BLIT(BITMAP *src, BITMAP *dst, int sx, int sy,
    ASSERT(dst);
 
    for (y = 0; y < h; y++) {
-      PIXEL_PTR s = OFFSET_PIXEL_PTR(bmp_read_line(src, sy + y), sx);
-      PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, dy + y), dx);
+      PIXEL_PTR s = OFFSET_PIXEL_PTR(src->line[sy + y], sx);
+      PIXEL_PTR d = OFFSET_PIXEL_PTR(dst->line[dy + y], dx);
 
 #ifndef USE_MEMMOVE
       for (x = w - 1; x >= 0; INC_PIXEL_PTR(s), INC_PIXEL_PTR(d), x--) {
 	 unsigned long c;
 
-	 bmp_select(src);
 	 c = GET_PIXEL(s);
 
-	 bmp_select(dst);
 	 PUT_PIXEL(d, c);
       }
 #else
@@ -114,21 +110,19 @@ void FUNC_LINEAR_BLIT_BACKWARD(BITMAP *src, BITMAP *dst, int sx, int sy,
 
    for (y = h - 1; y >= 0; y--) {
 #ifndef USE_MEMMOVE
-      PIXEL_PTR s = OFFSET_PIXEL_PTR(bmp_read_line(src, sy + y), sx + w - 1);
-      PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, dy + y), dx + w - 1);
+      PIXEL_PTR s = OFFSET_PIXEL_PTR(src->line[sy + y], sx + w - 1);
+      PIXEL_PTR d = OFFSET_PIXEL_PTR(dst->line[dy + y], dx + w - 1);
 
       for (x = w - 1; x >= 0; DEC_PIXEL_PTR(s), DEC_PIXEL_PTR(d), x--) {
 	 unsigned long c;
 
-	 bmp_select(src);
 	 c = GET_PIXEL(s);
 
-	 bmp_select(dst);
 	 PUT_PIXEL(d, c);
       }
 #else
-      PIXEL_PTR s = OFFSET_PIXEL_PTR(bmp_read_line(src, sy + y), sx);
-      PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, dy + y), dx);
+      PIXEL_PTR s = OFFSET_PIXEL_PTR(src->line[sy + y], sx);
+      PIXEL_PTR d = OFFSET_PIXEL_PTR(dst->line[dy + y], dx);
 
       memmove(d, s, w * sizeof(*s) * PTR_PER_PIXEL);
 #endif
@@ -155,17 +149,15 @@ void FUNC_LINEAR_MASKED_BLIT(BITMAP *src, BITMAP *dst, int sx, int sy,
    mask_color = bitmap_mask_color(dst);
 
    for (y = 0; y < h; y++) {
-      PIXEL_PTR s = OFFSET_PIXEL_PTR(bmp_read_line(src, sy + y), sx);
-      PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, dy + y), dx);
+      PIXEL_PTR s = OFFSET_PIXEL_PTR(src->line[sy + y], sx);
+      PIXEL_PTR d = OFFSET_PIXEL_PTR(dst->line[dy + y], dx);
 
       for (x = w - 1; x >= 0; INC_PIXEL_PTR(s), INC_PIXEL_PTR(d), x--) {
 	 unsigned long c;
 
-	 bmp_select(src);
 	 c = GET_PIXEL(s);
 
 	 if (c != mask_color) {
-	    bmp_select(dst);
 	    PUT_PIXEL(d, c);
 	 }
       }

--- a/libsrc/allegro/src/c/cblit.h
+++ b/libsrc/allegro/src/c/cblit.h
@@ -57,7 +57,6 @@ void FUNC_LINEAR_CLEAR_TO_COLOR(BITMAP *dst, int color)
       }
    }
 
-   bmp_unwrite_line(dst);
 }
 
 
@@ -95,8 +94,6 @@ void FUNC_LINEAR_BLIT(BITMAP *src, BITMAP *dst, int sx, int sy,
 #endif
    }
 
-   bmp_unwrite_line(src);
-   bmp_unwrite_line(dst);
 }
 
 
@@ -137,8 +134,6 @@ void FUNC_LINEAR_BLIT_BACKWARD(BITMAP *src, BITMAP *dst, int sx, int sy,
 #endif
    }
 
-   bmp_unwrite_line(src);
-   bmp_unwrite_line(dst);
 }
 
 void FUNC_LINEAR_BLIT_END(void) { }
@@ -176,8 +171,6 @@ void FUNC_LINEAR_MASKED_BLIT(BITMAP *src, BITMAP *dst, int sx, int sy,
       }
    }
 
-   bmp_unwrite_line(src);
-   bmp_unwrite_line(dst);
 }
 
 #endif /* !__bma_cblit_h */

--- a/libsrc/allegro/src/c/cgfx.h
+++ b/libsrc/allegro/src/c/cgfx.h
@@ -69,7 +69,6 @@ void FUNC_LINEAR_PUTPIXEL(BITMAP *dst, int dx, int dy, int color)
       }
    }
 
-   bmp_unwrite_line(dst);
 }
 
 
@@ -89,7 +88,6 @@ int FUNC_LINEAR_GETPIXEL(BITMAP *src, int sx, int sy)
 
       bmp_select(src);
       c = GET_PIXEL(s);
-      bmp_unwrite_line(src);
 
       return c;
    }
@@ -213,7 +211,6 @@ void FUNC_LINEAR_HLINE(BITMAP *dst, int dx1, int dy, int dx2, int color)
       }
    }
 
-   bmp_unwrite_line(dst);
 }
 
 
@@ -247,7 +244,6 @@ void FUNC_LINEAR_VLINE(BITMAP *dst, int dx, int dy1, int dy2, int color)
 	 PIXEL_PTR d = OFFSET_PIXEL_PTR(bmp_write_line(dst, y), dx);
 	 PUT_PIXEL(d, color);
       }
-      bmp_unwrite_line(dst);
    }
    else {
       int clip = dst->clip;

--- a/libsrc/allegro/src/c/cspr.h
+++ b/libsrc/allegro/src/c/cspr.h
@@ -405,7 +405,6 @@ void FUNC_LINEAR_DRAW_TRANS_SPRITE(BITMAP *dst, BITMAP *src, int dx, int dy)
 	 }
       }
 
-      bmp_unwrite_line(dst);
    }
    else {
       for (y = 0; y < h; y++) {
@@ -494,7 +493,6 @@ void FUNC_LINEAR_DRAW_TRANS_RGBA_SPRITE(BITMAP *dst, BITMAP *src, int dx, int dy
       }
    }
 
-   bmp_unwrite_line(dst);
 }
 
 #endif

--- a/libsrc/allegro/src/c/cstretch.c
+++ b/libsrc/allegro/src/c/cstretch.c
@@ -409,8 +409,7 @@ static void _al_stretch_blit(BITMAP *src, BITMAP *dst,
       else
 	    yc -= ycdec;
    }
-   
-   bmp_unwrite_line(dst);
+
 }
 
 

--- a/libsrc/allegro/src/flood.c
+++ b/libsrc/allegro/src/flood.c
@@ -110,7 +110,6 @@ static int flooder(BITMAP *bmp, int x, int y, int src_color, int dest_color)
 	 #endif
       }
 
-      bmp_unwrite_line(bmp);
    }
    else {                           /* have to use getpixel() for mode-X */
       /* check start pixel */

--- a/libsrc/allegro/src/rotate.c
+++ b/libsrc/allegro/src/rotate.c
@@ -626,7 +626,6 @@ void _parallelogram_map(BITMAP *bmp, BITMAP *spr, fixed xs[4], fixed ys[4],
       #endif
    }
 
-   bmp_unwrite_line(bmp);
 }
 
 


### PR DESCRIPTION
- remove bmp_unwrite_line, this was related to the removed bank stuff, so we don't need it anymore
- minor adjustments to cblit so it's a bit more lean, but without logic change