### PR TITLE
Engine: draw fix, true means texture don't change

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1508,7 +1508,7 @@ bool construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool always
     if ((hardwareAccelerated) && (walkBehindMethod != DrawOverCharSprite))
     {
         // HW acceleration
-        bool has_texture_change = objcache[aa].sppic != objs[aa].num;
+        bool is_texture_intact = objcache[aa].sppic == objs[aa].num;
         objcache[aa].sppic = objs[aa].num;
         objcache[aa].tintamnt = tint_level;
         objcache[aa].tintr = tint_red;
@@ -1518,7 +1518,7 @@ bool construct_object_gfx(int aa, int *drawnWidth, int *drawnHeight, bool always
         objcache[aa].lightlev = light_level;
         objcache[aa].zoom = zoom_level;
         objcache[aa].mirrored = isMirrored;
-        return has_texture_change;
+        return is_texture_intact;
     }
 
     //


### PR DESCRIPTION
https://github.com/adventuregamestudio/ags/blob/b327011f0cd07a2d02f7fcafaee967b024f8c2f7/Engine/ac/draw.cpp#L1620

the `construct_object_gfx` should return `true` if the texture doesn't change, and `false` if it doesn't, but the logic was inverted in the commit https://github.com/adventuregamestudio/ags/commit/cca997fe83ec5f7014677a69095a7c9ec1494cd9 , only for the hardware accelerated renderer.

For some reason this doesn't break any small test game I made, but it does break some animations in a bigger game.

Edit: ok, I think I understand why it doesn't break my test games, the delay has to be 1 frame.