### PR TITLE
Make sprite batch parameters more consistent

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -179,6 +179,7 @@ target_sources(common
     util/bufferedstream.h
     util/string_compat.c
     util/string_compat.h
+    util/matrix.h
 
 	platform/windows/windows.h
 )
@@ -187,7 +188,8 @@ target_link_libraries(common PUBLIC
         ${SDL2_LIBRARY} ${SDL2_LIBRARIES}
         Allegro::Allegro
         AlFont::AlFont
-        AAStr::AAStr)
+        AAStr::AAStr
+        glm::glm)
 
 if (WIN32)
     target_link_libraries(common PUBLIC shlwapi)

--- a/Common/util/matrix.h
+++ b/Common/util/matrix.h
@@ -1,0 +1,106 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Helper matrix functions, to ease use of GLM in a simulated 2D space.
+//
+//=============================================================================
+#ifndef __AGS_CN_UTIL__MATRIX_H
+#define __AGS_CN_UTIL__MATRIX_H
+
+#include <algorithm>
+#include <glm/ext/matrix_transform.hpp>
+#include "util/geometry.h"
+
+namespace AGS
+{
+namespace Common
+{
+
+namespace glmex
+{
+    // Construct a 3D-compatible vec4 from (x, y)
+    inline glm::vec4 vec4(float x, float y) { return glm::vec4(x, y, 0.0, 1.f); }
+
+    // Create identity matrix
+    inline glm::mat4 identity() { return glm::mat4(1.f); }
+    // Translate matrix in 2D plane
+    inline glm::mat4 translate(float x, float y) { return glm::translate(glmex::identity(), { x, y, 0.f }); }
+    inline glm::mat4 translate(const glm::mat4 &m, float x, float y) { return glm::translate(m, {x, y, 0.f}); }
+    // Scale matrix in 2D plane
+    inline glm::mat4 scale(float sx, float sy) { return glm::scale(glmex::identity(), { sx, sy, 1.f }); }
+    inline glm::mat4 scale(const glm::mat4 &m, float sx, float sy) { return glm::scale(m, { sx, sy, 1.f }); }
+    // Rotate matrix in 2D plane (around Z)
+    inline glm::mat4 rotatez(float angle) { return glm::rotate(glmex::identity(), angle, { 0.f, 0.f, 1.f }); }
+    inline glm::mat4 rotatez(const glm::mat4 &m, float angle) { return glm::rotate(m, angle, { 0.f, 0.f, 1.f }); }
+    // Setup full 2D transformation matrix
+    inline glm::mat4 transform2d(const glm::mat4 &m_, float x, float y, float sx, float sy, float anglez, float pivotx = 0.0, float pivoty = 0.0)
+    {
+        glm::mat4 m = glmex::translate(m_, x - pivotx, y - pivoty);
+        m = glmex::rotatez(m, anglez);
+        m = glmex::translate(m, pivotx, pivoty);
+        m = glmex::scale(m, sx, sy);
+        return m;
+    }
+    inline glm::mat4 make_transform2d(float x, float y, float sx, float sy, float anglez, float pivotx = 0.0, float pivoty = 0.0)
+    {
+        return glmex::transform2d(glmex::identity(), x, y, sx, sy, anglez, pivotx, pivoty);
+    }
+    // Setup inverse 2D transformation matrix
+    inline glm::mat4 inv_transform2d(const glm::mat4 &m_, float x, float y, float sx, float sy, float anglez, float pivotx = 0.0, float pivoty = 0.0)
+    {
+        glm::mat4 m = glmex::scale(m_, sx, sy);
+        m = glmex::translate(m, pivotx, pivoty);
+        m = glmex::rotatez(m, anglez);
+        m = glmex::translate(m, x - pivotx, y - pivoty);
+        return m;
+    }
+    inline glm::mat4 make_inv_transform2d(float x, float y, float sx, float sy, float anglez, float pivotx = 0.0, float pivoty = 0.0)
+    {
+        return inv_transform2d(glmex::identity(), x, y, sx, sy, anglez, pivotx, pivoty);
+    }
+
+
+    // Linearly transform a rectangle using the given matrix;
+    // This is an optimized case where rotation is not expected.
+    inline Rect linear_transform(const Rect &r, const glm::mat4 &m)
+    {
+        glm::vec4 v1 = m * vec4((float)r.Left, (float)r.Top);
+        glm::vec4 v2 = m * vec4((float)r.Right, (float)r.Bottom);
+        // TODO: better rounding
+        return Rect((int)v1.x, (int)v1.y, (int)v2.x, (int)v2.y);
+    }
+
+    // Transform a rectangle using the given matrix;
+    // This is a full transform case which assumes rotation may be included.
+    inline Rect full_transform(const Rect &r, const glm::mat4 &m)
+    {
+        // TODO: search for the faster AABB transform algorithm
+        glm::vec4 p1 = m * glmex::vec4((float)r.Left, (float)r.Top);
+        glm::vec4 p2 = m * glmex::vec4((float)r.Right, (float)r.Top);
+        glm::vec4 p3 = m * glmex::vec4((float)r.Left, (float)r.Bottom);
+        glm::vec4 p4 = m * glmex::vec4((float)r.Right, (float)r.Bottom);
+        float xmin = std::min(p1.x, std::min(p2.x, std::min(p3.x, p4.x)));
+        float ymin = std::min(p1.y, std::min(p2.y, std::min(p3.y, p4.y)));
+        float xmax = std::max(p1.x, std::max(p2.x, std::max(p3.x, p4.x)));
+        float ymax = std::max(p1.y, std::max(p2.y, std::max(p3.y, p4.y)));
+        // TODO: better rounding
+        return Rect((int)xmin, (int)ymin, (int)xmax, (int)ymax);
+    }
+
+} // namespace glmex
+
+} // namespace Common
+} // namespace AGS
+
+#endif // __AGS_CN_UTIL__MATRIX_H

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -539,7 +539,6 @@ target_link_libraries(engine PUBLIC
     Threads::Threads 
     Allegro::Allegro 
     Cda::Cda
-    glm::glm
     External::OpenAL
     ${SDL2_LIBRARY}
     ${SDL2_LIBRARIES}

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1312,8 +1312,6 @@ size_t OGLGraphicsDriver::RenderSpriteBatch(const OGLSpriteBatch &batch, size_t 
 
 void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &desc)
 {
-    Rect viewport = desc.Viewport;
-
     // Create transformation matrix for this batch
     // NOTE: in OpenGL order of transformation is REVERSE to the order of commands!
     // Apply node flip: this is implemented as a negative scaling.
@@ -1325,46 +1323,63 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     case kFlip_Both: node_sx = -node_sx; node_sy = -node_sy; break;
     default: break;
     }
-    glm::mat4 model = glmex::scale(node_sx, node_sy);
+    glm::mat4 mflip = glmex::scale(node_sx, node_sy);
+    glm::mat4 model = mflip;
 
-    // NOTE: before node, translate to viewport position; remove this if this
-    // is changed to a separate operation at some point
-    // TODO: find out if this is an optimal way to translate scaled room into Top-Left screen coordinates
+    // Translate scaled node into Top-Left screen coordinates
     float scaled_offx = (_srcRect.GetWidth() - desc.Transform.ScaleX * (float)_srcRect.GetWidth()) / 2.f;
     float scaled_offy = (_srcRect.GetHeight() - desc.Transform.ScaleY * (float)_srcRect.GetHeight()) / 2.f;
-    model = glmex::translate(model, (float)(viewport.Left - scaled_offx), (float)-(viewport.Top - scaled_offy));
-
-    // IMPORTANT: while the sprites are usually transformed in the order of Scale-Rotate-Translate,
-    // the camera's transformation is essentially reverse world transformation. And the operations
-    // are inverse: Translate-Rotate-Scale (here they are double inverse because OpenGL).
-    glm::mat4 msrt = glmex::make_inv_transform2d((float)desc.Transform.X, (float)-desc.Transform.Y,
+    model = glmex::translate(model, -scaled_offx, -(-scaled_offy));
+    // Classic Scale-Rotate-Translate, but inverse, because it's GLM
+    glm::mat4 msrt = glmex::make_transform2d((float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY, 0.f);
     model = model * msrt;
 
+    // Also create separate viewport transformation matrix:
+    // it will use a slightly different set of transforms,
+    // because the viewport's coordinates origin is different from sprites.
+    glm::mat4 mat_viewport = mflip * msrt;
+
     // Apply parent batch's settings, if preset
+    Rect viewport = desc.Viewport;
     if (desc.Parent > 0)
     {
         const auto &parent = _spriteBatches[desc.Parent];
+        // Combine sprite matrix with the parent's
         model = parent.Matrix * model;
-        glm::mat4 parent_m4 = parent.Matrix;
-        // Transform this node's viewport using parent's matrix
-        // FIXME: hack, inverse Y coord, viewport is inv to how sprites are drawn?
-        parent_m4[3][1] = -parent_m4[3][1];
-        viewport = glmex::full_transform(viewport, parent_m4);
-        // FIXME: this silly hack (need an extra translate before parent's neg scale,
-        // changing the centering of flip/scale)
-        if (parent.Matrix[0][0] < 0)
-            viewport.MoveToX(viewport.Left + _srcRect.GetWidth() - 1);
-        if (parent.Matrix[1][1] < 0)
-            viewport.MoveToY(viewport.Top + _srcRect.GetHeight() - 1);
-        // Don't let child viewport go outside the parent's bounds
-        viewport = ClampToRect(parent.Viewport, viewport);
+        // Combine viewport's matrix with the parent's
+        mat_viewport = parent.ViewportMat * mat_viewport;
+
+        // Transform this node's viewport using (only!) parent's matrix
+        if (!viewport.IsEmpty())
+        {
+            glm::mat4 parent_m4 = parent.ViewportMat;
+            // FIXME: hack, inverse Y coord, viewport is inv to how sprites are drawn?
+            parent_m4[3][1] = -parent_m4[3][1];
+            viewport = glmex::full_transform(viewport, parent_m4);
+            // FIXME: this silly hack (need an extra translate before parent's neg scale,
+            // changing the centering of flip/scale)
+            if (parent.ViewportMat[0][0] < 0)
+                viewport.MoveToX(viewport.Left + _srcRect.GetWidth() - 1);
+            if (parent.ViewportMat[1][1] < 0)
+                viewport.MoveToY(viewport.Top + _srcRect.GetHeight() - 1);
+            // Don't let child viewport go outside the parent's bounds
+            viewport = ClampToRect(parent.Viewport, viewport);
+        }
+        else
+        {
+            viewport = parent.Viewport;
+        }
+    }
+    else if (viewport.IsEmpty())
+    {
+        viewport = _srcRect;
     }
 
     // Assign the new spritebatch
     if (_spriteBatches.size() <= index)
         _spriteBatches.resize(index + 1);
-    _spriteBatches[index] = OGLSpriteBatch(index, viewport, model, desc.Transform.Color);
+    _spriteBatches[index] = OGLSpriteBatch(index, viewport, model, mat_viewport, desc.Transform.Color);
 
     // create stage screen for plugin raw drawing
     int src_w = viewport.GetWidth() / desc.Transform.ScaleX;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1381,9 +1381,7 @@ void OGLGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     _spriteBatches[index] = OGLSpriteBatch(index, viewport, model, mat_viewport, desc.Transform.Color);
 
     // create stage screen for plugin raw drawing
-    int src_w = viewport.GetWidth() / desc.Transform.ScaleX;
-    int src_h = viewport.GetHeight() / desc.Transform.ScaleY;
-    CreateStageScreen(index, Size(src_w, src_h));
+    CreateStageScreen(index, viewport.GetSize());
 
     GLenum err;
     for (;;) {

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -130,21 +130,17 @@ public:
     ~OGLBitmap() override = default;
 };
 
-typedef SpriteDrawListEntry<OGLBitmap> OGLDrawListEntry;
-struct OGLSpriteBatch
+// OGL renderer's sprite batch
+struct OGLSpriteBatch : VMSpriteBatch
 {
-    uint32_t ID = 0;
-    // Clipping viewport
-    Rect Viewport;
-    // Transformation matrix, built from the batch description
-    glm::mat4 Matrix;
-    // Batch color transformation
-    SpriteColorTransform Color;
+    // Add anything OGL specific here
 
     OGLSpriteBatch() = default;
-    OGLSpriteBatch(uint32_t id, const Rect view, const glm::mat4 &matrix, const SpriteColorTransform &color)
-        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
+    OGLSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, color) {}
 };
+
+typedef SpriteDrawListEntry<OGLBitmap> OGLDrawListEntry;
 typedef std::vector<OGLSpriteBatch>    OGLSpriteBatches;
 
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -136,8 +136,9 @@ struct OGLSpriteBatch : VMSpriteBatch
     // Add anything OGL specific here
 
     OGLSpriteBatch() = default;
-    OGLSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
-        : VMSpriteBatch(id, view, matrix, color) {}
+    OGLSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix,
+                   const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, vp_matrix, color) {}
 };
 
 typedef SpriteDrawListEntry<OGLBitmap> OGLDrawListEntry;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -66,9 +66,9 @@ Rect GraphicsDriverBase::GetRenderDestination() const
 }
 
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
-    const Point offset, GraphicFlip flip, PBitmap surface)
+    GraphicFlip flip, PBitmap surface)
 {
-    _spriteBatchDesc.push_back(SpriteBatchDesc(_actSpriteBatch, viewport, transform, offset, flip, surface));
+    _spriteBatchDesc.push_back(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface));
     _actSpriteBatch = _spriteBatchDesc.size() - 1;
     InitSpriteBatch(_actSpriteBatch, _spriteBatchDesc[_actSpriteBatch]);
 }

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -201,12 +201,15 @@ struct VMSpriteBatch
     Rect Viewport;
     // Transformation matrix, built from the batch description
     glm::mat4 Matrix;
+    // Viewport transformation matrix, necessary, as the coord origin is different
+    glm::mat4 ViewportMat;
     // Batch color transformation
     SpriteColorTransform Color;
 
     VMSpriteBatch() = default;
-    VMSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
-        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
+    VMSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix,
+                  const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
+        : ID(id), Viewport(view), Matrix(matrix), ViewportMat(vp_matrix), Color(color) {}
 };
 
 // VideoMemoryGraphicsDriver - is the parent class for the graphic drivers

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -196,6 +196,22 @@ struct TextureTile
     int width = 0, height = 0;
 };
 
+// Sprite batch's internal parameters for the hardware-accelerated renderer
+struct VMSpriteBatch
+{
+    uint32_t ID = 0;
+    // Clipping viewport
+    Rect Viewport;
+    // Transformation matrix, built from the batch description
+    glm::mat4 Matrix;
+    // Batch color transformation
+    SpriteColorTransform Color;
+
+    VMSpriteBatch() = default;
+    VMSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
+        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
+};
+
 // VideoMemoryGraphicsDriver - is the parent class for the graphic drivers
 // which drawing method is based on passing the sprite stack into GPU,
 // rather than blitting to flat screen bitmap.

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -43,20 +43,17 @@ struct SpriteBatchDesc
     Rect                     Viewport;
     // Optional model transformation, to be applied to each sprite
     SpriteTransform          Transform;
-    // Global node offset applied to the whole batch as the last transform
-    Point                    Offset;
-    // Global node flip applied to the whole batch as the last transform
+    // Optional flip, applied to the whole batch as the last transform
     Common::GraphicFlip      Flip = Common::kFlip_None;
     // Optional bitmap to draw sprites upon. Used exclusively by the software rendering mode.
     PBitmap                  Surface;
 
     SpriteBatchDesc() = default;
-    SpriteBatchDesc(uint32_t parent, const Rect viewport, const SpriteTransform &transform, const Point offset = Point(),
+    SpriteBatchDesc(uint32_t parent, const Rect viewport, const SpriteTransform &transform,
         Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr)
         : Parent(parent)
         , Viewport(viewport)
         , Transform(transform)
-        , Offset(offset)
         , Flip(flip)
         , Surface(surface)
     {
@@ -101,7 +98,7 @@ public:
     Rect        GetRenderDestination() const override;
 
     void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
-                    const Point offset = Point(), Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) override;
+                    Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) override;
     void        EndSpriteBatch() override;
     void        ClearDrawLists() override;
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -144,8 +144,8 @@ public:
   // sprites to this batch's list.
   // Beginning a batch while the previous was not ended will create a sub-batch
   // (think of it as of a child scene node).
-  virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
-      const Point offset = Point(), Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) = 0;
+  virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform = SpriteTransform(),
+      Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) = 0;
   // Ends current sprite batch
   virtual void EndSpriteBatch() = 0;
   // Adds sprite to the active batch

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1328,9 +1328,7 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
     _spriteBatches[index] = D3DSpriteBatch(index, viewport, model, mat_viewport, desc.Transform.Color);
 
     // create stage screen for plugin raw drawing
-    int src_w = viewport.GetWidth() / desc.Transform.ScaleX;
-    int src_h = viewport.GetHeight() / desc.Transform.ScaleY;
-    CreateStageScreen(index, Size(src_w, src_h));
+    CreateStageScreen(index, viewport.GetSize());
 }
 
 void D3DGraphicsDriver::ResetAllBatches()

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1265,27 +1265,35 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
         (float)desc.Transform.X, (float)-desc.Transform.Y,
         desc.Transform.ScaleX, desc.Transform.ScaleY, 0.f);
     // Translate scaled node into Top-Left screen coordinates
-    float scaled_offx = (_srcRect.GetWidth() - desc.Transform.ScaleX * (float)_srcRect.GetWidth()) / 2.f;
-    float scaled_offy = (_srcRect.GetHeight() - desc.Transform.ScaleY * (float)_srcRect.GetHeight()) / 2.f;
+    float scaled_offx = _srcRect.GetWidth() * ((1.f - desc.Transform.ScaleX) * 0.5f);
+    float scaled_offy = _srcRect.GetHeight() * ((1.f - desc.Transform.ScaleY) * 0.5f);
     glm::mat4 model = glmex::translate(-scaled_offx, -(-scaled_offy));
     model = model * msrt;
 
     // Apply node flip: this is implemented as a negative scaling.
-    float node_sx = 1.f, node_sy = 1.f;
+    // TODO: find out if possible to merge with normal scale
+    float flip_sx = 1.f, flip_sy = 1.f;
     switch (desc.Flip)
     {
-    case kFlip_Vertical: node_sx = -node_sx; break;
-    case kFlip_Horizontal: node_sy = -node_sy; break;
-    case kFlip_Both: node_sx = -node_sx; node_sy = -node_sy; break;
+    case kFlip_Vertical: flip_sx = -flip_sx; break;
+    case kFlip_Horizontal: flip_sy = -flip_sy; break;
+    case kFlip_Both: flip_sx = -flip_sx; flip_sy = -flip_sy; break;
     default: break;
     }
-    glm::mat4 mflip = glmex::scale(node_sx, node_sy);
+    glm::mat4 mflip = glmex::scale(flip_sx, flip_sy);
     model = mflip * model;
 
     // Also create separate viewport transformation matrix:
     // it will use a slightly different set of transforms,
     // because the viewport's coordinates origin is different from sprites.
-    glm::mat4 mat_viewport = mflip * msrt;
+    glm::mat4 mat_viewport = glmex::make_transform2d(
+        (float)desc.Transform.X, (float)desc.Transform.Y,
+        desc.Transform.ScaleX, desc.Transform.ScaleY, 0.f);
+    glm::mat4 vp_flip_off = glmex::translate(
+        _srcRect.GetWidth() * ((1.f - flip_sx) * 0.5f),
+        _srcRect.GetHeight() * ((1.f - flip_sy) * 0.5f));
+    mat_viewport = mflip * mat_viewport;
+    mat_viewport = vp_flip_off * mat_viewport;
 
     // Apply parent batch's settings, if preset
     Rect viewport = desc.Viewport;
@@ -1297,20 +1305,11 @@ void D3DGraphicsDriver::InitSpriteBatch(size_t index, const SpriteBatchDesc &des
         // Combine viewport's matrix with the parent's
         mat_viewport = parent.ViewportMat * mat_viewport;
 
-        // Transform this node's viewport using (only!) parent's matrix
+        // Transform this node's viewport using (only!) parent's matrix,
+        // and don't let child viewport go outside the parent's bounds.
         if (!viewport.IsEmpty())
         {
-            glm::mat4 viewport_m4 = parent.ViewportMat;
-            // FIXME: hack, inverse Y coord, viewport is inv to how sprites are drawn?
-            viewport_m4[3][1] = -viewport_m4[3][1];
-            viewport = glmex::full_transform(viewport, viewport_m4);
-            // FIXME: this silly hack (need an extra translate before parent's neg scale,
-            // changing the centering of flip/scale)
-            if (parent.ViewportMat[0][0] < 0)
-                viewport.MoveToX(viewport.Left + _srcRect.GetWidth() - 1);
-            if (parent.ViewportMat[1][1] < 0)
-                viewport.MoveToY(viewport.Top + _srcRect.GetHeight() - 1);
-            // Don't let child viewport go outside the parent's bounds
+            viewport = glmex::full_transform(viewport, parent.ViewportMat);
             viewport = ClampToRect(parent.Viewport, viewport);
         }
         else

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -163,8 +163,9 @@ struct D3DSpriteBatch : VMSpriteBatch
     // Add anything D3D specific here
 
     D3DSpriteBatch() = default;
-    D3DSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
-        : VMSpriteBatch(id, view, matrix, color) {}
+    D3DSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix,
+                   const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, vp_matrix, color) {}
 };
 
 typedef SpriteDrawListEntry<D3DBitmap> D3DDrawListEntry;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -157,23 +157,17 @@ struct CUSTOMVERTEX
     FLOAT       tu, tv;   // The texture coordinates.
 };
 
-typedef SpriteDrawListEntry<D3DBitmap> D3DDrawListEntry;
 // D3D renderer's sprite batch
-struct D3DSpriteBatch
+struct D3DSpriteBatch : VMSpriteBatch
 {
-    uint32_t ID = 0;
-    // Clipping viewport
-    Rect Viewport;
-    // Transformation matrix, built from the batch description
-    // TODO: investigate possibility of using glm here (might need conversion to D3D matrix format)
-    D3DMATRIX Matrix;
-    // Batch color transformation
-    SpriteColorTransform Color;
+    // Add anything D3D specific here
 
     D3DSpriteBatch() = default;
-    D3DSpriteBatch(uint32_t id, const Rect view, const D3DMATRIX &matrix, const SpriteColorTransform &color)
-        : ID(id), Viewport(view), Matrix(matrix), Color(color) {}
+    D3DSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix, const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, color) {}
 };
+
+typedef SpriteDrawListEntry<D3DBitmap> D3DDrawListEntry;
 typedef std::vector<D3DSpriteBatch>    D3DSpriteBatches;
 
 
@@ -301,7 +295,7 @@ private:
     void SetScissor(const Rect &clip);
     void RenderSpriteBatches();
     size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from);
-    void _renderSprite(const D3DDrawListEntry *entry, const D3DMATRIX &matGlobal, const SpriteColorTransform &color);
+    void _renderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal, const SpriteColorTransform &color);
     void _renderFromTexture();
 };
 

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -142,7 +142,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -162,7 +162,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -184,7 +184,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -204,7 +204,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -225,7 +225,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -244,7 +244,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\Common;..\..\Common\libinclude;..\..\Common\libsrc\alfont-2.0.9;..\..\Common\libsrc\freetype-2.1.3\include;..\..\libsrc\glm;..\..\libsrc\allegro\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WINDOWS;_CRT_SECURE_NO_WARNINGS;ALLEGRO_STATICLINK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -491,6 +491,7 @@
     <ClInclude Include="..\..\Common\util\ini_util.h" />
     <ClInclude Include="..\..\Common\util\lzw.h" />
     <ClInclude Include="..\..\Common\util\math.h" />
+    <ClInclude Include="..\..\Common\util\matrix.h" />
     <ClInclude Include="..\..\Common\util\memory.h" />
     <ClInclude Include="..\..\Common\util\memorystream.h" />
     <ClInclude Include="..\..\Common\util\memory_compat.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -826,5 +826,8 @@
     <ClInclude Include="..\..\Common\util\bufferedstream.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\util\matrix.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves #1708, but also useful while resolving #1838 (which was the main reason to do this now).

1. Use glm in Direct3D renderer as well, to ease sharing the matrix code between OpenGL and Direct3D.
2. Global offset and flip are only set once in the parent sprite batch, instead of applying to every batch on screen.
3. For hw renderers - separate Room Viewport and Room Camera into two nested batches.
4. No longer use sprite batch's `Viewport` field as a source of coordinate translation (also removed extra `Offset` field); use strictly `Transform` field for that. This makes setting up a sprite batch more clear and consistent. `Viewport` will only define a clipping rectangle. Nested batch's `Viewport` will be considered relative to the parent batch, and will be transformed using parent batch's transform too.

Also, this was not necessary, but moved mouse cursor update into a separate function `update_mouse_cursor`, out from `construct_game_screen_overlay`.
