### PR TITLE
Debugger related commits from Editor Log PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ Engine/ags
 **/.lib
 **/.test
 
+# Force git to NOT ignore this source folder
+!Engine/debug
+
 
 # Tools output and temporary files
 libsrc/*.tar*

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -89,6 +89,25 @@ int first_debug_line = 0, last_debug_line = 0, display_console = 0;
 float fps = std::numeric_limits<float>::quiet_NaN();
 FPSDisplayMode display_fps = kFPS_Hide;
 
+void send_message_to_debugger(const std::vector<std::pair<String, String>>& tag_values, const String& command)
+{
+    String messageToSend = String::FromFormat(R"(<?xml version="1.0" encoding="Windows-1252"?><Debugger Command="%s">)", command.GetCStr());
+#if AGS_PLATFORM_OS_WINDOWS
+    messageToSend.Append(String::FromFormat("  <EngineWindow>%d</EngineWindow> ", (int)sys_win_get_window()));
+#endif
+
+    for(const auto& tag_value : tag_values)
+    {
+        String tag_line = String::FromFormat("  <%s><![CDATA[%s]]></%s> ",
+                                             tag_value.first.GetCStr(), tag_value.second.GetCStr(), tag_value.first.GetCStr());
+        messageToSend.Append(tag_line);
+    }
+
+    messageToSend.Append("</Debugger>\n");
+
+    editor_debugger->SendMessageToEditor(messageToSend.GetCStr());
+}
+
 std::unique_ptr<MessageBuffer> DebugMsgBuff;
 std::unique_ptr<LogFile> DebugLogFile;
 std::unique_ptr<ConsoleOutputTarget> DebugConsole;
@@ -275,6 +294,7 @@ void apply_debug_config(const ConfigTree &cfg)
           DbgGroupOption(kDbgGroup_SDL, kDbgMsg_Info),
         });
     bool legacy_log_enabled = CfgReadBoolInt(cfg, "misc", "log", false);
+
     apply_log_config(cfg, OutputFileID,
         /* defaults */
         legacy_log_enabled,
@@ -397,33 +417,28 @@ struct Breakpoint
 
 std::vector<Breakpoint> breakpoints;
 
-bool send_message_to_editor(const char *msg, const char *errorMsg) 
+bool send_state_to_debugger(const String& msg, const String& errorMsg)
 {
     // Get either saved callstack from a script error, or current execution point
-    String callStack = (errorMsg && cc_has_error()) ?
+    String callStack = (!errorMsg.IsEmpty() && cc_has_error()) ?
         cc_get_error().CallStack : cc_get_callstack();
     if (callStack.IsEmpty())
         return false;
 
-    String message;
-    message.AppendFmt("<?xml version=\"1.0\" encoding=\"Windows-1252\"?><Debugger Command=\"%s\">", msg);
-#if AGS_PLATFORM_OS_WINDOWS
-    message.AppendFmt("  <EngineWindow>%d</EngineWindow> ", (int)sys_win_get_window());
-#endif
-    message.AppendFmt("  <ScriptState><![CDATA[%s]]></ScriptState> ", callStack.GetCStr());
-    if (errorMsg != nullptr)
-    {
-        message.AppendFmt("  <ErrorMessage><![CDATA[%s]]></ErrorMessage> ", errorMsg);
-    }
-    message.Append("</Debugger>");
+    std::vector<std::pair<String, String>> scipt_info = { { "ScriptState", callStack } };
 
-    editor_debugger->SendMessageToEditor(message.GetCStr());
+    if (!errorMsg.IsEmpty())
+    {
+        scipt_info.emplace_back( "ErrorMessage", errorMsg );
+    }
+
+    send_message_to_debugger(scipt_info, msg);
     return true;
 }
 
-bool send_message_to_editor(const char *msg) 
+bool send_state_to_debugger(const char *msg)
 {
-    return send_message_to_editor(msg, nullptr);
+    return send_state_to_debugger(String(msg), String());
 }
 
 bool init_editor_debugging() 
@@ -444,12 +459,12 @@ bool init_editor_debugging()
 
         // Wait for the editor to send the initial breakpoints
         // and then its READY message
-        while (check_for_messages_from_editor() != 2) 
+        while (check_for_messages_from_debugger() != 2)
         {
             platform->Delay(10);
         }
 
-        send_message_to_editor("START");
+        send_state_to_debugger("START");
         Debug::Printf(kDbgMsg_Info, "External debugger initialized");
         return true;
     }
@@ -458,7 +473,7 @@ bool init_editor_debugging()
     return false;
 }
 
-int check_for_messages_from_editor()
+int check_for_messages_from_debugger()
 {
     if (editor_debugger->IsMessageAvailable())
     {
@@ -552,7 +567,7 @@ int check_for_messages_from_editor()
 
 
 
-bool send_exception_to_editor(const char *qmsg)
+bool send_exception_to_debugger(const char *qmsg)
 {
 #if AGS_PLATFORM_OS_WINDOWS
     want_exit = false;
@@ -560,10 +575,10 @@ bool send_exception_to_editor(const char *qmsg)
     if (editor_window_handle != NULL)
         SetForegroundWindow(editor_window_handle);
 
-    if (!send_message_to_editor("ERROR", qmsg))
+    if (!send_state_to_debugger("ERROR", qmsg))
         return false;
 
-    while ((check_for_messages_from_editor() == 0) && (!want_exit))
+    while ((check_for_messages_from_debugger() == 0) && (!want_exit))
     {
         platform->Delay(10);
     }
@@ -581,7 +596,7 @@ void break_into_debugger()
     if (editor_window_handle != NULL)
         SetForegroundWindow(editor_window_handle);
 
-    send_message_to_editor("BREAK");
+    send_state_to_debugger("BREAK");
     game_paused_in_debugger = 1;
 
     while (game_paused_in_debugger) 

--- a/Engine/debug/debug.cpp
+++ b/Engine/debug/debug.cpp
@@ -49,7 +49,6 @@ using namespace AGS::Engine;
 extern char check_dynamic_sprites_at_exit;
 extern int displayed_room;
 extern RoomStruct thisroom;
-extern char pexbuf[STD_BUFFER_SIZE];
 extern volatile bool want_exit, abort_engine;
 extern GameSetupStruct game;
 
@@ -98,9 +97,8 @@ void send_message_to_debugger(const std::vector<std::pair<String, String>>& tag_
 
     for(const auto& tag_value : tag_values)
     {
-        String tag_line = String::FromFormat("  <%s><![CDATA[%s]]></%s> ",
-                                             tag_value.first.GetCStr(), tag_value.second.GetCStr(), tag_value.first.GetCStr());
-        messageToSend.Append(tag_line);
+        messageToSend.AppendFmt("  <%s><![CDATA[%s]]></%s> ",
+                                tag_value.first.GetCStr(), tag_value.second.GetCStr(), tag_value.first.GetCStr());
     }
 
     messageToSend.Append("</Debugger>\n");
@@ -183,12 +181,12 @@ std::vector<String> parse_log_multigroup(const String &group_str)
     {
         switch (group_str[i])
         {
-        case 'm': grplist.push_back("main"); break;
-        case 'g': grplist.push_back("game"); break;
-        case 's': grplist.push_back("script"); break;
-        case 'c': grplist.push_back("sprcache"); break;
-        case 'o': grplist.push_back("manobj"); break;
-        case 'l': grplist.push_back("sdl"); break;
+        case 'm': grplist.emplace_back("main"); break;
+        case 'g': grplist.emplace_back("game"); break;
+        case 's': grplist.emplace_back("script"); break;
+        case 'c': grplist.emplace_back("sprcache"); break;
+        case 'o': grplist.emplace_back("manobj"); break;
+        case 'l': grplist.emplace_back("sdl"); break;
         }
     }
     return grplist;
@@ -226,7 +224,7 @@ void apply_log_config(const ConfigTree &cfg, const String &log_id,
 
     if (value.IsEmpty() || value.CompareNoCase("default") == 0)
     {
-        for (const auto opt : def_opts)
+        for (const auto &opt : def_opts)
             dbgout->SetGroupFilter(opt.first, opt.second);
     }
     else
@@ -638,10 +636,10 @@ void scriptDebugHook (ccInstance *ccinst, int linenum) {
 
     const char *scriptName = ccinst->runningInst->instanceof->GetSectionName(ccinst->pc);
 
-    for (size_t i = 0; i < breakpoints.size(); ++i)
+    for (const auto & breakpoint : breakpoints)
     {
-        if ((breakpoints[i].lineNumber == linenum) &&
-            (strcmp(breakpoints[i].scriptName, scriptName) == 0))
+        if ((breakpoint.lineNumber == linenum) &&
+            (strcmp(breakpoint.scriptName, scriptName) == 0))
         {
             break_into_debugger();
             break;
@@ -655,7 +653,7 @@ void check_debug_keys() {
     if (play.debug_mode) {
         // do the run-time script debugging
 
-        const Uint8 *ks = SDL_GetKeyboardState(NULL);
+        const Uint8 *ks = SDL_GetKeyboardState(nullptr);
         if ((!ks[SDL_SCANCODE_SCROLLLOCK]) && (scrlockWasDown))
             scrlockWasDown = 0;
         else if ((ks[SDL_SCANCODE_SCROLLLOCK]) && (!scrlockWasDown)) {

--- a/Engine/debug/debugger.h
+++ b/Engine/debug/debugger.h
@@ -26,9 +26,13 @@ extern char editor_debugger_instance_token[100];
 extern IAGSEditorDebugger *editor_debugger;
 extern int break_on_next_script_step;
 
-int check_for_messages_from_editor();
-bool send_message_to_editor(const char *msg);
-bool send_exception_to_editor(const char *qmsg);
+int check_for_messages_from_debugger();
+bool send_state_to_debugger(const char *msg);
+bool send_exception_to_debugger(const char *qmsg);
+// Returns current script's location and callstack
+AGS::Common::String get_cur_script(int numberOfLinesOfCallStack);
+bool get_script_position(ScriptPosition &script_pos);
+
 void check_debug_keys();
 
 #define DBG_NOIFACE       1

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -1100,5 +1100,5 @@ void update_polled_stuff()
     }
 
     if (editor_debugging_initialized)
-        check_for_messages_from_editor();
+        check_for_messages_from_debugger();
 }

--- a/Engine/main/game_start.cpp
+++ b/Engine/main/game_start.cpp
@@ -63,7 +63,7 @@ void start_game_init_editor_debugging()
     while (waitUntil > AGS_Clock::now())
     {
         // pick up any breakpoints in game_start
-        check_for_messages_from_editor();
+        check_for_messages_from_debugger();
     }
 
     ccSetDebugHook(scriptDebugHook);

--- a/Engine/main/quit.cpp
+++ b/Engine/main/quit.cpp
@@ -71,8 +71,8 @@ void quit_tell_editor_debugger(const String &qmsg, QuitReason qreason)
     if (editor_debugging_initialized)
     {
         if (qreason & kQuitKind_GameException)
-            handledErrorInEditor = send_exception_to_editor(qmsg.GetCStr());
-        send_message_to_editor("EXIT");
+            handledErrorInEditor = send_exception_to_debugger(qmsg.GetCStr());
+        send_state_to_debugger("EXIT");
         editor_debugger->Shutdown();
     }
 }


### PR DESCRIPTION
**Note:** since the engine part of that PR that actually adds the logging functionality requires a `--log-debugger=` flag, I think we could actually add the Engine [commit](https://github.com/adventuregamestudio/ags/pull/1518/commits/b58b186b05457787e45aafd415b264b1675b0a96) that adds it.

I am not 100% sure, but I think it may be possible to figure out an Editor plugin if the engine parts are taken care. It would require some different set of changes in the Editor to make this possible though.

---

Just picking up some of the debugger related commits from the Editor Log PR. I added a new one to tidy things a bit.