### PR TITLE
CI: Prefer RPATH over RUNPATH for Linux binaries

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,8 +35,8 @@ build_linux_cmake_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:jessie
-        - FROM_DEBIAN: i386/debian:jessie
+        - FROM_DEBIAN: debian:buster
+        - FROM_DEBIAN: i386/debian:buster
   env:
     matrix:
       - BUILD_TYPE: release
@@ -68,8 +68,8 @@ build_linux_debian_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:jessie
-        - FROM_DEBIAN: i386/debian:jessie
+        - FROM_DEBIAN: debian:buster
+        - FROM_DEBIAN: i386/debian:buster
   env:
     matrix:
       - RPATH_PREFIX: lib
@@ -119,8 +119,8 @@ build_linux_make_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:jessie
-        - FROM_DEBIAN: i386/debian:jessie
+        - FROM_DEBIAN: debian:buster
+        - FROM_DEBIAN: i386/debian:buster
   setup_destdir_script: |
     mkdir destdir
     arch=$(dpkg --print-architecture)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,7 +91,7 @@ build_linux_debian_task:
           exit 1
           ;;
       esac
-      DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" fakeroot debian/rules binary
+      DEB_BUILD_OPTIONS="rpath=$RPATH_PREFIX$bit" DEB_LDFLAGS_MAINT_APPEND=-Wl,--disable-new-dtags fakeroot debian/rules binary
       sed -E "/^BI(NDMOUNT|T)=/d" debian/ags+libraries/hooks/B00_copy_libs.sh | BIT=$bit BINDMOUNT=$(pwd) sh
       ar -p ../ags_${version}_$arch.deb data.tar.xz | unxz | tar -f - -xvC data --transform "s/.*ags/ags$bit/" ./usr/bin/ags
       cd data && \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,8 +35,9 @@ build_linux_cmake_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:buster
-        - FROM_DEBIAN: i386/debian:buster
+        - FROM_PLATFORM: linux/i386
+        - FROM_PLATFORM: linux/amd64
+      FROM_DEBIAN: debian/eol:jessie
   env:
     matrix:
       - BUILD_TYPE: release
@@ -68,8 +69,9 @@ build_linux_debian_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:buster
-        - FROM_DEBIAN: i386/debian:buster
+        - FROM_PLATFORM: linux/i386
+        - FROM_PLATFORM: linux/amd64
+      FROM_DEBIAN: debian/eol:jessie
   env:
     matrix:
       - RPATH_PREFIX: lib
@@ -119,8 +121,9 @@ build_linux_make_task:
     dockerfile: ci/linux/Dockerfile
     docker_arguments:
       matrix:
-        - FROM_DEBIAN: debian:buster
-        - FROM_DEBIAN: i386/debian:buster
+        - FROM_PLATFORM: linux/i386
+        - FROM_PLATFORM: linux/amd64
+      FROM_DEBIAN: debian/eol:jessie
   setup_destdir_script: |
     mkdir destdir
     arch=$(dpkg --print-architecture)

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -1,5 +1,6 @@
 ARG FROM_DEBIAN=debian:latest
-FROM $FROM_DEBIAN
+ARG FROM_PLATFORM=$BUILDPLATFORM
+FROM --platform=$FROM_PLATFORM $FROM_DEBIAN
 
 # Take default debconf options
 ENV DEBIAN_FRONTEND noninteractive

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -fLsS "https://github.com/xiph/vorbis/releases/download/v${LIBVORBIS_VE
 ARG SDL2_VERSION=2.24.1
 RUN curl -fLsS "https://github.com/libsdl-org/SDL/archive/refs/tags/release-${SDL2_VERSION}.tar.gz" | tar -f - -xvzC /tmp && \
   cd /tmp/SDL-release-${SDL2_VERSION} && \
-  ./configure --enable-shared --enable-loadso --enable-pulseaudio-shared --enable-sndio-shared --enable-x11-shared --enable-oss=no --enable-libsamplerate-shared --enable-video-wayland=no --enable-directfb-shared && \
+  ./configure --enable-shared --enable-loadso --enable-pulseaudio-shared --enable-sndio-shared --enable-x11-shared --enable-oss=no --enable-libsamplerate-shared --enable-video-wayland=no --enable-directfb-shared --enable-rpath=no && \
   make -j$(getconf _NPROCESSORS_ONLN) && make install && \
   ldconfig -n /usr/local/lib && \
   mkdir -p /usr/local/share/doc/libSDL2-2.0/ && cp /tmp/SDL-release-${SDL2_VERSION}/LICENSE.txt /usr/local/share/doc/libSDL2-2.0/copyright && \


### PR DESCRIPTION
This restores the previous behaviour for library search paths.

I think the problem is the change in the build environment rather than any change in the engine source code, but build artifacts from this PR need to be tested against everything that is known to be failing to be sure.

When testing, be sure to use the binaries that are packaged to go with the Editor rather than the regular make or cmake builds.

P.S. This just restores the previous behaviour. Whether the previous behaviour and directory layout for game files was a good idea is probably another discussion.

Fixes #1864