### PR TITLE
Emscripten: upgrade to 3.1.28

### DIFF
--- a/CMake/Emscripten/FindSDL2.cmake
+++ b/CMake/Emscripten/FindSDL2.cmake
@@ -1,8 +1,0 @@
-set(SDL2_FOUND TRUE)
-set(SDL2_INCLUDE_DIRS "${EMSCRIPTEN_ROOT_PATH}/sysroot/include" "${EMSCRIPTEN_ROOT_PATH}/sysroot/include/SDL2/")
-set(SDL2_LIBRARIES "nul")
-
-mark_as_advanced(SDL2_LIBRARY
-        SDL2_RUNTIME_LIBRARY
-        SDL2_INCLUDE_DIR
-        SDL2_SDLMAIN_LIBRARY) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,11 +173,8 @@ if(EMSCRIPTEN)
 		-s EXIT_RUNTIME=1  \
 		-s EMULATE_FUNCTION_POINTER_CASTS=1 ")
 
-    #    set(EMSDK_FLAGS "${EMSDK_FLAGS} \
-    #        -g4 \
-    #        -fsanitize=null -fsanitize-minimal-runtime \
-    #        --emit-symbol-map \
-    #        --source-map-base http://0.0.0.0:8000/../ ")
+    # set(EMSDK_DEBUG_CFLAGS "-gsource-map -fsanitize=null -fsanitize-minimal-runtime ")
+    # set(EMSDK_DEBUG_LINKER_FLAGS "--emit-symbol-map --source-map-base http://127.0.0.1:8000/../ ")
 
     set(EMSDK_FLAGS_LINKER "${EMSDK_FLAGS_LINKER} \
         -s FULL_ES2=1 \
@@ -185,11 +182,11 @@ if(EMSCRIPTEN)
         -s EXPORTED_FUNCTIONS=['_main'] \
         -s EXTRA_EXPORTED_RUNTIME_METHODS=['ccall','callMain']")
 
-    set(EMSDK_FLAGS_LINKER "${EMSDK_FLAGS_LINKER} --shell-file ${CMAKE_SOURCE_DIR}/Emscripten/launcher_index.html ")
+    set(EMSDK_FLAGS_LINKER "${EMSDK_FLAGS_LINKER} ${EMSDK_DEBUG_LINKER_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/Emscripten/launcher_index.html ")
 
     set(CMAKE_EXECUTABLE_SUFFIX ".html")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS} ${EMSDK_FLAGS_COMPILER}")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${USE_FLAGS} ${EMSDK_FLAGS_COMPILER}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS} ${EMSDK_FLAGS_COMPILER} ${EMSDK_DEBUG_CFLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${USE_FLAGS} ${EMSDK_FLAGS_COMPILER} ${EMSDK_DEBUG_CFLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${USE_FLAGS} ${EMSDK_FLAGS_LINKER}")
 
     add_compile_options(-fexceptions)
@@ -269,9 +266,7 @@ endif()
 ###############################################################################
 # dependencies we download the source or not depending on settings
 
-if(EMSCRIPTEN)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Emscripten")
-elseif(NOT AGS_USE_LOCAL_SDL2)
+if(NOT AGS_USE_LOCAL_SDL2 AND NOT EMSCRIPTEN)
     include(FetchSDL2)
 else()
     find_package(SDL2 REQUIRED)

--- a/Emscripten/install_dependencies.sh
+++ b/Emscripten/install_dependencies.sh
@@ -7,8 +7,8 @@ mkdir emscripten
 pushd emscripten
 git clone https://github.com/emscripten-core/emsdk.git
 pushd emsdk
-./emsdk install 3.1.2
-./emsdk activate 3.1.2
+./emsdk install 3.1.28
+./emsdk activate 3.1.28
 source ./emsdk_env.sh
 popd
 popd

--- a/Emscripten/launcher_index.html
+++ b/Emscripten/launcher_index.html
@@ -20,16 +20,17 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <style>
   body {
-    font-family: arial;
+    font-family: arial,serif;
     margin: 0;
-    padding: none background-color: #000
+    padding: 0;
+    background-color: #000;
   }
 
   .emscripten {
     padding-right: 0;
     margin-left: auto;
     margin-right: auto;
-    display: block
+    display: block;
   }
 
   div.emscripten {
@@ -244,7 +245,7 @@
 
           file_read_count = file_read_count + 1;
 
-          if (file_read_count == file_total_count) {
+          if (file_read_count === file_total_count) {
             hideAll();
             Module.callMain(['/' + game_file, '--windowed']);
           } else {
@@ -256,7 +257,7 @@
     }
 
     for (var i = 0; i < file_total_count; i++) {
-      if ((gamefiles[i] != "winsetup.exe") &&
+      if ((gamefiles[i] !== "winsetup.exe") &&
         (gamefiles[i].endsWith(".exe") ||
           gamefiles[i].endsWith(".ags"))) {
         game_file = gamefiles[i];
@@ -273,12 +274,12 @@
     if (typeof gamefiles !== 'undefined')
       return;
 
-    if (fileInput.files.length == 0)
+    if (fileInput.files.length === 0)
       return;
 
     file_total_count = fileInput.files.length;
     for (var i = 0; i < file_total_count; i++) {
-      if ((fileInput.files[i].name != "winsetup.exe") &&
+      if ((fileInput.files[i].name !== "winsetup.exe") &&
         (fileInput.files[i].name.endsWith(".exe") ||
           fileInput.files[i].name.endsWith(".ags"))) {
         game_file = fileInput.files[i];
@@ -288,7 +289,7 @@
 
     file_read_count = 0;
 
-    if (file_reader_fr == 0) {
+    if (file_reader_fr === 0) {
       file_reader_fr = new FileReader();
     }
 
@@ -301,7 +302,7 @@
 
       file_read_count = file_read_count + 1;
 
-      if (file_read_count == file_total_count) {
+      if (file_read_count === file_total_count) {
         hideAll();
         Module.callMain(['/' + game_file.name, '--windowed']);
       } else {

--- a/ci/emscripten/Dockerfile
+++ b/ci/emscripten/Dockerfile
@@ -1,5 +1,9 @@
 # The current used version of emsdk
-FROM emscripten/emsdk:3.1.2
+FROM emscripten/emsdk:3.1.28
+
+#fix TZ docker hang
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install required tools
 RUN apt-get update && apt-get install -y tzdata libarchive-tools git pkg-config curl build-essential cmake ninja-build bash python3 python3-pip


### PR DESCRIPTION
- SDL2 in Emscripten was 2.0.20, this version of Emscripten comes with 2.24.2
- additional minor fixes in the launcher html (non-related, but felt like a good opportunity to do it, they don't functionally alter anything)
- in the dockerfile, an additional non-related TZ data fix is applied, to prevent possible hanging when the docker image is updating packages 

I had upgraded the SDL2 to 2.24.2 in Emscripten https://github.com/emscripten-core/emscripten/pull/18026, forgot to upgrade here too.