### PR TITLE
Render GUIs on a texture, then render that texture on screen

### DIFF
--- a/Common/util/matrix.h
+++ b/Common/util/matrix.h
@@ -70,6 +70,17 @@ namespace glmex
         return inv_transform2d(glmex::identity(), x, y, sx, sy, anglez, pivotx, pivoty);
     }
 
+    // Setup Direct3D-compatible orthographic projection
+    // CHECKME: glm seem to supply some ortho variants meant for Direct3D,
+    // but none of them worked right in the engine.
+    inline glm::mat4 ortho_d3d(float width, float height)
+    {
+        return glm::mat4((2.f / width), 0.f, 0.f, 0.f,
+                         0.f, (2.f / height), 0.f, 0.f,
+                         0.f, 0.f, 0.f, 0.f,
+                         0.f, 0.f, 0.f, 1.f);
+    }
+
 
     // Linearly transform a rectangle using the given matrix;
     // This is an optimized case where rotation is not expected.

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2377,10 +2377,10 @@ void draw_gui_and_overlays()
             if (!gui_ddb) continue;
             if (draw_controls_as_textures)
             {
-                // FIXME: our render-to-texures are filling the whole native res
+                // FIXME: recycle render target (recreate if different size)
                 if (!gui_render_tex[index])
                     gui_render_tex[index] = gfxDriver->CreateRenderTargetDDB(
-                        game.GetGameRes().Width, game.GetGameRes().Height, game.GetColorDepth(), false);
+                        gui_ddb->GetWidth(), gui_ddb->GetHeight(), gui_ddb->GetColorDepth(), false);
                 // Render control textures onto the GUI texture
                 draw_gui_controls_batch(index);
                 // Replace gui bg ddb with a render target texture,

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -638,6 +638,20 @@ void clear_drawobj_cache()
     dispose_debug_room_drawdata();
 }
 
+void release_drawobj_rendertargets()
+{
+    if ((gui_render_tex.size() == 0) ||
+        !gfxDriver->ShouldReleaseRenderTargets())
+        return;
+
+    for (auto &tex : gui_render_tex)
+    {
+        if (tex)
+            gfxDriver->DestroyDDB(tex);
+        tex = nullptr;
+    }
+}
+
 void on_mainviewport_changed()
 {
     if (!gfxDriver->RequiresFullRedrawEachFrame())

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -53,6 +53,9 @@ void dispose_game_drawdata();
 void dispose_room_drawdata();
 // Releases all the cached textures of game objects
 void clear_drawobj_cache();
+// Releases all the textures used as render targets, if necessary;
+// (this is primarily for resetting display mode of certain renderers).
+void release_drawobj_rendertargets();
 // Updates drawing settings depending on main viewport's size and position on screen
 void on_mainviewport_changed();
 // Notifies that a new room viewport was created

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1406,6 +1406,7 @@ void OGLGraphicsDriver::ResetAllBatches()
 void OGLGraphicsDriver::ClearDrawBackups()
 {
     _backupBatchDescs.clear();
+    _backupBatchRange.clear();
     _backupBatches.clear();
     _backupSpriteList.clear();
 }
@@ -1413,6 +1414,7 @@ void OGLGraphicsDriver::ClearDrawBackups()
 void OGLGraphicsDriver::BackupDrawLists()
 {
     _backupBatchDescs = _spriteBatchDesc;
+    _backupBatchRange = _spriteBatchRange;
     _backupBatches = _spriteBatches;
     _backupSpriteList = _spriteList;
 }
@@ -1420,6 +1422,7 @@ void OGLGraphicsDriver::BackupDrawLists()
 void OGLGraphicsDriver::RestoreDrawLists()
 {
     _spriteBatchDesc = _backupBatchDescs;
+    _spriteBatchRange = _backupBatchRange;
     _spriteBatches = _backupBatches;
     _spriteList = _backupSpriteList;
     _actSpriteBatch = 0;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -1335,6 +1335,7 @@ void OGLGraphicsDriver::RenderSpriteBatches(const glm::mat4 &projection)
             glEnable(GL_SCISSOR_TEST);
             surface_sz = Size(batch.RenderTarget->GetWidth(),
                 batch.RenderTarget->GetHeight());
+            glViewport(0, 0, surface_sz.Width, surface_sz.Height);
 
             // Configure rules for merging sprite alpha values onto a
             // render target, which also contains alpha channel.
@@ -1358,6 +1359,10 @@ void OGLGraphicsDriver::RenderSpriteBatches(const glm::mat4 &projection)
             cur_rt = render_fbos.top();
             render_fbos.pop();
             glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, cur_rt.second);
+            if (_do_render_to_texture)
+                glViewport(0, 0, _backRenderSize.Width, _backRenderSize.Height);
+            else
+                glViewport(_viewportRect.Left, _viewportRect.Top, _viewportRect.GetWidth(), _viewportRect.GetHeight());
 
             // Disable alpha merging rules, return back to default settings
             SetBlendOpUniform(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -136,11 +136,17 @@ public:
 struct OGLSpriteBatch : VMSpriteBatch
 {
     // Add anything OGL specific here
+    // Optional render target (for rendering on texture)
+    OGLBitmap *RenderTarget = nullptr;
 
     OGLSpriteBatch() = default;
     OGLSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix,
                    const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
         : VMSpriteBatch(id, view, matrix, vp_matrix, color) {}
+    OGLSpriteBatch(uint32_t id, OGLBitmap *render_target, const Rect view,
+        const glm::mat4 &matrix, const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, vp_matrix, color)
+        , RenderTarget(render_target) {}
 };
 
 typedef SpriteDrawListEntry<OGLBitmap> OGLDrawListEntry;
@@ -348,7 +354,10 @@ private:
     // Deletes draw list backups
     void ClearDrawBackups();
     void _render(bool clearDrawListAfterwards);
-    void SetScissor(const Rect &clip);
+    // Sets the scissor (render clip), clip rect is passed in the "native" coordinates.
+    // Optionally pass surface_size if the rendering is done to texture, in native coords,
+    // otherwise we assume it is set on a whole screen, scaled to the screen coords.
+    void SetScissor(const Rect &clip, bool render_on_texture, const Size &surface_size);
     void RenderSpriteBatches(const glm::mat4 &projection);
     size_t RenderSpriteBatch(const OGLSpriteBatch &batch, size_t from, const glm::mat4 &projection);
     void _reDrawLastFrame();

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -351,7 +351,7 @@ private:
     void CreateVirtualScreen();
     void do_fade(bool fadingOut, int speed, int targetColourRed, int targetColourGreen, int targetColourBlue);
     void _renderSprite(const OGLDrawListEntry *entry, const glm::mat4 &projection, const glm::mat4 &matGlobal,
-        const SpriteColorTransform &color);
+        const SpriteColorTransform &color, const Size &surface_size);
     void SetupViewport();
     // Converts rectangle in top->down coordinates into OpenGL's native bottom->up coordinates
     Rect ConvertTopDownRect(const Rect &top_down_rect, int surface_height);
@@ -375,7 +375,8 @@ private:
     // otherwise we assume it is set on a whole screen, scaled to the screen coords.
     void SetScissor(const Rect &clip, bool render_on_texture, const Size &surface_size);
     void RenderSpriteBatches(const glm::mat4 &projection);
-    size_t RenderSpriteBatch(const OGLSpriteBatch &batch, size_t from, const glm::mat4 &projection);
+    size_t RenderSpriteBatch(const OGLSpriteBatch &batch, size_t from, const glm::mat4 &projection,
+        const Size &surface_size);
     void _reDrawLastFrame();
 };
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -99,6 +99,7 @@ public:
     std::shared_ptr<OGLTextureData> _data;
     // Optional frame buffer object (for rendering onto a texture)
     unsigned int _fbo {};
+    TextureHint _renderHint = kTxHint_Normal;
 
     // Drawing parameters
     bool _flipped;
@@ -314,6 +315,13 @@ private:
     OGLSpriteBatches _backupBatches;
     std::vector<OGLDrawListEntry> _backupSpriteList;
 
+    // Saved blend settings exclusive for alpha channel; for convenience,
+    // because GL does not have functions for setting ONLY RGB or ONLY alpha ops.
+    GLenum _blendOpAlpha{};
+    GLenum _blendSrcAlpha{};
+    GLenum _blendDstAlpha{};
+
+
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
     void ResetAllBatches() override;
 
@@ -346,6 +354,13 @@ private:
     void SetupViewport();
     // Converts rectangle in top->down coordinates into OpenGL's native bottom->up coordinates
     Rect ConvertTopDownRect(const Rect &top_down_rect, int surface_height);
+    // Sets uniform GL blend settings, same for both RGB and alpha component
+    void SetBlendOpUniform(GLenum blend_op, GLenum src_factor, GLenum dst_factor);
+    // Sets GL blend settings for RGB only, and keeps saved alpha blend settings
+    void SetBlendOpRGB(GLenum rgb_op, GLenum srgb_factor, GLenum drgb_factor);
+    // Sets GL blend settings with separate op for alpha, and saves used alpha params
+    void SetBlendOpRGBAlpha(GLenum rgb_op, GLenum srgb_factor, GLenum drgb_factor,
+        GLenum alpha_op, GLenum sa_factor, GLenum da_factor);
 
     // Backup all draw lists in the temp storage
     void BackupDrawLists();

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -252,6 +252,9 @@ protected:
     // Retrieve shared texture data object from the given DDB
     std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
 
+protected:
+    size_t GetLastDrawEntryIndex() override { return _spriteList.size(); }
+
 private:
     POGLFilter _filter {};
 
@@ -299,7 +302,9 @@ private:
     std::vector<OGLDrawListEntry> _spriteList;
     // TODO: these draw list backups are needed only for the fade-in/out effects
     // find out if it's possible to reimplement these effects in main drawing routine.
+    // TODO: if not above, refactor and implement Desc backup in the base class
     SpriteBatchDescs _backupBatchDescs;
+    std::vector<std::pair<size_t, size_t>> _backupBatchRange;
     OGLSpriteBatches _backupBatches;
     std::vector<OGLDrawListEntry> _backupSpriteList;
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -238,6 +238,7 @@ public:
     void UseSmoothScaling(bool enabled) override { _smoothScaling = enabled; }
     bool RequiresFullRedrawEachFrame() override { return true; }
     bool HasAcceleratedTransform() override { return true; }
+    bool ShouldReleaseRenderTargets() override { return false; }
     void SetScreenFade(int red, int green, int blue) override;
     void SetScreenTint(int red, int green, int blue) override;
 

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -97,6 +97,8 @@ public:
 
     // OpenGL texture data
     std::shared_ptr<OGLTextureData> _data;
+    // Optional frame buffer object (for rendering onto a texture)
+    unsigned int _fbo {};
 
     // Drawing parameters
     bool _flipped;
@@ -127,7 +129,7 @@ public:
     int GetWidthToRender() const { return _stretchToWidth; }
     int GetHeightToRender() const { return _stretchToHeight; }
 
-    ~OGLBitmap() override = default;
+    ~OGLBitmap() override;
 };
 
 // OGL renderer's sprite batch
@@ -210,15 +212,7 @@ public:
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
-    // Create texture data with the given parameters
-    TextureData *CreateTextureData(int width, int height, bool opaque) override;
-    // Update texture data from the given bitmap
-    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
-    // Create DDB using preexisting texture data
-    IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
-        int width, int height, int color_depth, bool opaque) override;
-    // Retrieve shared texture data object from the given DDB
-    std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
+    IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
     void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
@@ -246,6 +240,17 @@ public:
 
     OGLGraphicsDriver();
     ~OGLGraphicsDriver() override;
+
+protected:
+    // Create texture data with the given parameters
+    TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
+    // Update texture data from the given bitmap
+    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
+    // Create DDB using preexisting texture data
+    IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
+        int width, int height, int color_depth, bool opaque) override;
+    // Retrieve shared texture data object from the given DDB
+    std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
 
 private:
     POGLFilter _filter {};

--- a/Engine/gfx/ali3dsw.cpp
+++ b/Engine/gfx/ali3dsw.cpp
@@ -308,6 +308,12 @@ IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateDDBFromBitmap(Bitmap *b
   return new ALSoftwareBitmap(bitmap, opaque, hasAlpha);
 }
 
+IDriverDependantBitmap* SDLRendererGraphicsDriver::CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque)
+{
+    // For software renderer there's no difference between "texture" types.
+    return new ALSoftwareBitmap(width, height, color_depth, opaque);
+}
+
 void SDLRendererGraphicsDriver::UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Bitmap *bitmap, bool hasAlpha)
 {
   ALSoftwareBitmap* alSwBmp = (ALSoftwareBitmap*)bitmapToUpdate;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -193,6 +193,7 @@ public:
     bool RequiresFullRedrawEachFrame() override { return false; }
     bool HasAcceleratedTransform() override { return false; }
     bool UsesMemoryBackBuffer() override { return true; }
+    bool ShouldReleaseRenderTargets() override { return false; }
     Bitmap *GetMemoryBackBuffer() override;
     void SetMemoryBackBuffer(Bitmap *backBuffer) override;
     Bitmap *GetStageBackBuffer(bool mark_dirty) override;

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -203,6 +203,9 @@ public:
 
     void SetGraphicsFilter(PSDLRenderFilter filter);
 
+protected:
+    size_t GetLastDrawEntryIndex() override { return _spriteList.size(); }
+
 private:
     PSDLRenderFilter _filter;
 

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -156,6 +156,7 @@ public:
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
     IDriverDependantBitmap* CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque) override;
+    IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
     void DestroyDDB(IDriverDependantBitmap* ddb) override;
 

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -69,7 +69,19 @@ Rect GraphicsDriverBase::GetRenderDestination() const
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
     GraphicFlip flip, PBitmap surface)
 {
-    _spriteBatchDesc.push_back(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface));
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface));
+}
+
+void GraphicsDriverBase::BeginSpriteBatch(IDriverDependantBitmap *render_target,
+    const Rect &viewport, const SpriteTransform &transform,
+    GraphicFlip flip)
+{
+    BeginSpriteBatch(SpriteBatchDesc(_actSpriteBatch, render_target, viewport, transform, flip));
+}
+
+void GraphicsDriverBase::BeginSpriteBatch(const SpriteBatchDesc &desc)
+{
+    _spriteBatchDesc.push_back(desc);
     _spriteBatchRange.push_back(std::make_pair(GetLastDrawEntryIndex(), SIZE_MAX));
     _actSpriteBatch = _spriteBatchDesc.size() - 1;
     InitSpriteBatch(_actSpriteBatch, _spriteBatchDesc[_actSpriteBatch]);

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -33,6 +33,7 @@ GraphicsDriverBase::GraphicsDriverBase()
     // Initialize default sprite batch, it will be used when no other batch was activated
     _actSpriteBatch = 0;
     _spriteBatchDesc.push_back(SpriteBatchDesc());
+    _spriteBatchRange.push_back(std::make_pair(0, 0));
 }
 
 bool GraphicsDriverBase::IsModeSet() const
@@ -69,12 +70,14 @@ void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTran
     GraphicFlip flip, PBitmap surface)
 {
     _spriteBatchDesc.push_back(SpriteBatchDesc(_actSpriteBatch, viewport, transform, flip, surface));
+    _spriteBatchRange.push_back(std::make_pair(GetLastDrawEntryIndex(), SIZE_MAX));
     _actSpriteBatch = _spriteBatchDesc.size() - 1;
     InitSpriteBatch(_actSpriteBatch, _spriteBatchDesc[_actSpriteBatch]);
 }
 
 void GraphicsDriverBase::EndSpriteBatch()
 {
+    _spriteBatchRange[_actSpriteBatch].second = GetLastDrawEntryIndex();
     _actSpriteBatch = _spriteBatchDesc[_actSpriteBatch].Parent;
 }
 
@@ -82,7 +85,10 @@ void GraphicsDriverBase::ClearDrawLists()
 {
     ResetAllBatches();
     _actSpriteBatch = 0;
-    _spriteBatchDesc.resize(1);
+    _spriteBatchDesc.clear();
+    _spriteBatchRange.clear();
+    _spriteBatchDesc.push_back(SpriteBatchDesc());
+    _spriteBatchRange.push_back(std::make_pair(0, 0));
 }
 
 void GraphicsDriverBase::OnInit()

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -227,7 +227,9 @@ public:
     Bitmap* GetStageBackBuffer(bool mark_dirty) override;
     bool GetStageMatrixes(RenderMatrixes &rm) override;
 
+    // Creates new texture using given parameters
     IDriverDependantBitmap *CreateDDB(int width, int height, int color_depth, bool opaque) = 0;
+    // Creates new texture and copy bitmap contents over
     IDriverDependantBitmap *CreateDDBFromBitmap(Bitmap *bitmap, bool hasAlpha, bool opaque = false) override;
     // Get shared texture from cache, or create from bitmap and assign ID
     IDriverDependantBitmap *GetSharedDDB(uint32_t sprite_id, Bitmap *bitmap, bool hasAlpha, bool opaque) override;
@@ -239,7 +241,7 @@ public:
 
 protected:
     // Create texture data with the given parameters
-    virtual TextureData *CreateTextureData(int width, int height, bool opaque) = 0;
+    virtual TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) = 0;
     // Update texture data from the given bitmap
     virtual void UpdateTextureData(TextureData *txdata, Bitmap *bmp, bool opaque, bool hasAlpha) = 0;
     // Create DDB using preexisting texture data

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -197,6 +197,7 @@ protected:
     virtual ~BaseDDB() = default;
 };
 
+
 // A base parent for the otherwise opaque texture data object;
 // TextureData refers to the pixel data itself, with no additional
 // properties. It may be shared between multiple sprites if necessary.
@@ -213,6 +214,13 @@ struct TextureTile
 {
     int x = 0, y = 0;
     int width = 0, height = 0;
+};
+
+// Special render hints for textures
+enum TextureHint
+{
+    kTxHint_Normal,
+    kTxHint_PremulAlpha  // texture pixels contain premultiplied alpha
 };
 
 // Sprite batch's internal parameters for the hardware-accelerated renderer
@@ -233,6 +241,7 @@ struct VMSpriteBatch
                   const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
         : ID(id), Viewport(view), Matrix(matrix), ViewportMat(vp_matrix), Color(color) {}
 };
+
 
 // VideoMemoryGraphicsDriver - is the parent class for the graphic drivers
 // which drawing method is based on passing the sprite stack into GPU,

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -131,6 +131,8 @@ protected:
     virtual void OnSetFilter();
     // Initialize sprite batch and allocate necessary resources
     virtual void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) = 0;
+    // Gets the index of a last draw entry (sprite)
+    virtual size_t GetLastDrawEntryIndex() = 0;
     // Clears sprite lists
     virtual void ResetAllBatches() = 0;
 
@@ -151,7 +153,10 @@ protected:
     GFXDRV_CLIENTCALLBACKINITGFX _initGfxCallback;
 
     // Sprite batch parameters
-    SpriteBatchDescs _spriteBatchDesc; // sprite batches list
+    SpriteBatchDescs _spriteBatchDesc;
+    // The range of sprites in this sprite batch (counting nested sprites):
+    // the last of the previous batch, and the last of the current.
+    std::vector<std::pair<size_t, size_t>> _spriteBatchRange;
     size_t _actSpriteBatch; // active batch index
 };
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -216,9 +216,15 @@ public:
   // These matrixes will be filled in accordance to the renderer's compatible format;
   // returns false if renderer does not use matrixes (not a 3D renderer).
   virtual bool GetStageMatrixes(RenderMatrixes &rm) = 0;
+  // Tells if this gfx driver has to redraw whole scene each time
   virtual bool RequiresFullRedrawEachFrame() = 0;
+  // Tells if this gfx driver uses GPU to transform sprites
   virtual bool HasAcceleratedTransform() = 0;
+  // Tells if this gfx driver draws on a virtual screen before rendering on real screen.
   virtual bool UsesMemoryBackBuffer() = 0;
+  // Tells if this gfx driver requires releasing render targets
+  // in case of display mode change or reset.
+  virtual bool ShouldReleaseRenderTargets() = 0;
   virtual ~IGraphicsDriver() = default;
 };
 

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -125,11 +125,17 @@ public:
   // Gets closest recommended bitmap format (currently - only color depth) for the given original format.
   // Engine needs to have game bitmaps brought to the certain range of formats, easing conversion into the video bitmaps.
   virtual int  GetCompatibleBitmapFormat(int color_depth) = 0;
-  // Creates a "raw" DDB, without pixel initialization
+
+  // Creates a "raw" DDB, without pixel initialization.
   virtual IDriverDependantBitmap *CreateDDB(int width, int height, int color_depth, bool opaque = false) = 0;
-  // Creates DDB, initializes from the given bitmap
+  // Creates DDB, initializes from the given bitmap.
   virtual IDriverDependantBitmap* CreateDDBFromBitmap(Common::Bitmap *bitmap, bool hasAlpha, bool opaque = false) = 0;
+  // Creates DDB intended to be used as a render target (allow render other DDBs on it).
+  virtual IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque = false) = 0;
+  // Updates DBB using the given bitmap; bitmap must have same size and format
+  // as the one that this DDB was initialized with.
   virtual void UpdateDDBFromBitmap(IDriverDependantBitmap* bitmapToUpdate, Common::Bitmap *bitmap, bool hasAlpha) = 0;
+  // Destroy the DDB.
   virtual void DestroyDDB(IDriverDependantBitmap* bitmap) = 0;
 
   // Get shared texture from cache, or create from bitmap and assign ID

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -150,8 +150,14 @@ public:
   // sprites to this batch's list.
   // Beginning a batch while the previous was not ended will create a sub-batch
   // (think of it as of a child scene node).
+  // TODO: can we merge PBitmap surface and render_target from overriden method?
   virtual void BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform = SpriteTransform(),
       Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) = 0;
+  // Begins a sprite batch which will be rendered on a target texture.
+  // This batch will ignore any parent transforms, regardless whether it's nested
+  // or not. Its common child batches will also be rendered on the same texture.
+  virtual void BeginSpriteBatch(IDriverDependantBitmap *render_target, const Rect &viewport, const SpriteTransform &transform,
+      Common::GraphicFlip flip = Common::kFlip_None) = 0;
   // Ends current sprite batch
   virtual void EndSpriteBatch() = 0;
   // Adds sprite to the active batch

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1369,16 +1369,15 @@ bool engine_try_switch_windowed_gfxmode()
         // If failed, try switching back to previous gfx mode
         res = graphics_mode_set_dm(old_dm) &&
               graphics_mode_set_render_frame(old_frame);
+        if (!res)
+            quitprintf("Failed to restore graphics mode.");
     }
 
-    if (res)
-    {
-        // If succeeded (with any case), update engine objects that rely on
-        // active display mode.
-        if (!gfxDriver->GetDisplayMode().IsRealFullscreen())
-            init_desktop = get_desktop_size();
-        engine_post_gfxmode_setup(init_desktop);
-    }
+    // If succeeded (with any case), update engine objects that rely on
+    // active display mode.
+    if (!gfxDriver->GetDisplayMode().IsRealFullscreen())
+        init_desktop = get_desktop_size();
+    engine_post_gfxmode_setup(init_desktop);
     // Make sure that we don't receive window events queued during init
     sys_flush_events();
     return res;

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -175,6 +175,8 @@ void engine_pre_gfxmode_driver_cleanup()
     gfxDriver->SetCallbackToDrawScreen(nullptr, nullptr);
     gfxDriver->SetCallbackForNullSprite(nullptr);
     gfxDriver->SetMemoryBackBuffer(nullptr);
+
+    release_drawobj_rendertargets();
 }
 
 // Setup color conversion parameters

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -601,6 +601,7 @@ void graphics_mode_on_window_changed(const Size &sz)
 {
     if (!gfxDriver)
         return; // nothing to update
+    release_drawobj_rendertargets();
     gfxDriver->UpdateDeviceScreen(sz);
     graphics_mode_update_render_frame();
 }

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -1346,6 +1346,7 @@ void D3DGraphicsDriver::ResetAllBatches()
 void D3DGraphicsDriver::ClearDrawBackups()
 {
     _backupBatchDescs.clear();
+    _backupBatchRange.clear();
     _backupBatches.clear();
     _backupSpriteList.clear();
 }
@@ -1353,6 +1354,7 @@ void D3DGraphicsDriver::ClearDrawBackups()
 void D3DGraphicsDriver::BackupDrawLists()
 {
     _backupBatchDescs = _spriteBatchDesc;
+    _backupBatchRange = _spriteBatchRange;
     _backupBatches = _spriteBatches;
     _backupSpriteList = _spriteList;
 }
@@ -1360,6 +1362,7 @@ void D3DGraphicsDriver::BackupDrawLists()
 void D3DGraphicsDriver::RestoreDrawLists()
 {
     _spriteBatchDesc = _backupBatchDescs;
+    _spriteBatchRange = _backupBatchRange;
     _spriteBatches = _backupBatches;
     _spriteList = _backupSpriteList;
     _actSpriteBatch = 0;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -87,6 +87,8 @@ public:
 
     // Direct3D texture data
     std::shared_ptr<D3DTextureData> _data;
+    // Optional surface for rendering onto a texture
+    IDirect3DSurface9 *_renderSurface {};
 
     // Drawing parameters
     bool _flipped;
@@ -117,7 +119,7 @@ public:
     int GetWidthToRender() { return _stretchToWidth; }
     int GetHeightToRender() { return _stretchToHeight; }
 
-    ~D3DBitmap() override = default;
+    ~D3DBitmap() override;
 };
 
 class D3DGfxModeList : public IGfxModeList
@@ -190,15 +192,7 @@ public:
     void ClearRectangle(int x1, int y1, int x2, int y2, RGB *colorToUse) override;
     int  GetCompatibleBitmapFormat(int color_depth) override;
     IDriverDependantBitmap* CreateDDB(int width, int height, int color_depth, bool opaque) override;
-    // Create texture data with the given parameters
-    TextureData *CreateTextureData(int width, int height, bool opaque) override;
-    // Update texture data from the given bitmap
-    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
-    // Create DDB using preexisting texture data
-    IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
-        int width, int height, int color_depth, bool opaque) override;
-    // Retrieve shared texture data object from the given DDB
-    std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
+    IDriverDependantBitmap* CreateRenderTargetDDB(int width, int height, int color_depth, bool opaque) override;
     void UpdateDDBFromBitmap(IDriverDependantBitmap* ddb, Bitmap *bitmap, bool hasAlpha) override;
     void DestroyDDBImpl(IDriverDependantBitmap* ddb) override;
     void DrawSprite(int x, int y, IDriverDependantBitmap* ddb) override;
@@ -229,6 +223,17 @@ public:
 
     D3DGraphicsDriver(IDirect3D9 *d3d);
     ~D3DGraphicsDriver() override;
+
+protected:
+    // Create texture data with the given parameters
+    TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
+    // Update texture data from the given bitmap
+    void UpdateTextureData(TextureData *txdata, Bitmap *bitmap, bool opaque, bool hasAlpha) override;
+    // Create DDB using preexisting texture data
+    IDriverDependantBitmap *CreateDDB(std::shared_ptr<TextureData> txdata,
+        int width, int height, int color_depth, bool opaque) override;
+    // Retrieve shared texture data object from the given DDB
+    std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
 
 private:
     PD3DFilter _filter;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -281,8 +281,6 @@ private:
     D3DSpriteBatches _backupBatches;
     std::vector<D3DDrawListEntry> _backupSpriteList;
 
-    D3DVIEWPORT9 _d3dViewport;
-
     // Called after new mode was successfully initialized
     void OnModeSet(const DisplayMode &mode) override;
     void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) override;
@@ -312,6 +310,8 @@ private:
     void _renderAndPresent(bool clearDrawListAfterwards);
     void _render(bool clearDrawListAfterwards);
     void _reDrawLastFrame();
+    // Sets a Direct3D viewport for the current render target.
+    void SetD3DViewport(const Rect &rc);
     // Sets the scissor (render clip), clip rect is passed in the "native" coordinates.
     // Optionally pass render_on_texture if the rendering is done to texture, in native coords,
     // otherwise we assume it is set on a whole screen, scaled to the screen coords.

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -163,11 +163,18 @@ struct CUSTOMVERTEX
 struct D3DSpriteBatch : VMSpriteBatch
 {
     // Add anything D3D specific here
+    // Optional render target (for rendering on texture)
+    D3DBitmap *RenderTarget = nullptr;
 
     D3DSpriteBatch() = default;
     D3DSpriteBatch(uint32_t id, const Rect &view, const glm::mat4 &matrix,
-                   const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
+        const glm::mat4 &vp_matrix, const SpriteColorTransform &color)
         : VMSpriteBatch(id, view, matrix, vp_matrix, color) {}
+    D3DSpriteBatch(uint32_t id, D3DBitmap *render_target, const Rect &view,
+        const glm::mat4 &matrix, const glm::mat4 &vp_matrix,
+        const SpriteColorTransform &color)
+        : VMSpriteBatch(id, view, matrix, vp_matrix, color)
+        , RenderTarget(render_target) {}
 };
 
 typedef SpriteDrawListEntry<D3DBitmap> D3DDrawListEntry;
@@ -303,7 +310,10 @@ private:
     void _renderAndPresent(bool clearDrawListAfterwards);
     void _render(bool clearDrawListAfterwards);
     void _reDrawLastFrame();
-    void SetScissor(const Rect &clip);
+    // Sets the scissor (render clip), clip rect is passed in the "native" coordinates.
+    // Optionally pass render_on_texture if the rendering is done to texture, in native coords,
+    // otherwise we assume it is set on a whole screen, scaled to the screen coords.
+    void SetScissor(const Rect &clip, bool render_on_texture = false);
     void RenderSpriteBatches();
     size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from);
     void _renderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal, const SpriteColorTransform &color);

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -221,6 +221,7 @@ public:
     void UseSmoothScaling(bool enabled) override { _smoothScaling = enabled; }
     bool RequiresFullRedrawEachFrame() override { return true; }
     bool HasAcceleratedTransform() override { return true; }
+    bool ShouldReleaseRenderTargets() override { return true; }
 
     typedef std::shared_ptr<D3DGfxFilter> PD3DFilter;
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -235,6 +235,9 @@ protected:
     // Retrieve shared texture data object from the given DDB
     std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
 
+protected:
+    size_t GetLastDrawEntryIndex() override { return _spriteList.size(); }
+
 private:
     PD3DFilter _filter;
 
@@ -263,7 +266,9 @@ private:
     std::vector<D3DDrawListEntry> _spriteList;
     // TODO: these draw list backups are needed only for the fade-in/out effects
     // find out if it's possible to reimplement these effects in main drawing routine.
+    // TODO: if not above, refactor and implement Desc backup in the base class
     SpriteBatchDescs _backupBatchDescs;
+    std::vector<std::pair<size_t, size_t>> _backupBatchRange;
     D3DSpriteBatches _backupBatches;
     std::vector<D3DDrawListEntry> _backupSpriteList;
 

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -317,8 +317,9 @@ private:
     // otherwise we assume it is set on a whole screen, scaled to the screen coords.
     void SetScissor(const Rect &clip, bool render_on_texture = false);
     void RenderSpriteBatches();
-    size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from);
-    void _renderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal, const SpriteColorTransform &color);
+    size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from, const Size &surface_size);
+    void _renderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal,
+        const SpriteColorTransform &color, const Size &surface_size);
     void _renderFromTexture();
     // Helper method for setting blending parameters
     void SetBlendOp(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -89,6 +89,7 @@ public:
     std::shared_ptr<D3DTextureData> _data;
     // Optional surface for rendering onto a texture
     IDirect3DSurface9 *_renderSurface {};
+    TextureHint _renderHint = kTxHint_Normal;
 
     // Drawing parameters
     bool _flipped;
@@ -318,6 +319,10 @@ private:
     size_t RenderSpriteBatch(const D3DSpriteBatch &batch, size_t from);
     void _renderSprite(const D3DDrawListEntry *entry, const glm::mat4 &matGlobal, const SpriteColorTransform &color);
     void _renderFromTexture();
+    // Helper method for setting blending parameters
+    void SetBlendOp(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
+    // Helper method for setting exclusive alpha blending parameters
+    void SetBlendOpAlpha(D3DBLENDOP blend_op, D3DBLEND src_factor, D3DBLEND dst_factor);
 };
 
 


### PR DESCRIPTION
Resolves #1838 and will potentially help #1837 after merged/ported to ags4.

After implementing rendering GUI controls as separate textures (see #988 and #1393 for details), it turned out that the implementation has a serious mistake: any additional visual effect applied to a whole GUI, such as Transparency, would apply incorrectly, as controls would blend with GUI background using same effect, producing different visual result.

I guess there may be different approaches for resolving this problem. But we also assume that in the future GUI may be assigned more various properties, such as rotation (already exists in ags4), which makes it more difficult to clip controls to GUI borders on screen, or custom shaders, which would be expected to be applied to GUI & controls in whole, while each control might also have its own individual effect, making things more complicated.

Therefore the chosen solution is to render whole GUI on a texture and then render that texture on screen. This is kind of similar in logic to what is done in software rendering, except still done as a scene render by GPU, without bitmap operations.

Additionally, same technique may be used later for anything, if necessary (maybe for room viewports, if we decide to support translucent viewports sorted among GUIs, etc).

What this PR includes:
* Direct3D and OpenGL renderers support creating a DDB object (texture) with a purpose of being used as a render target.
* Both support rendering a Sprite Batch to a custom render target, instead of a backbuffer. This resets all parent transforms for that batch, starting clean on a new target, but all the nested batches will be also drawn on same render target, and have merged parent-child transforms.
* In "draw controls as textures" mode engine will now render GUIs each on its own texture buffer, then render resulting buffers as common sprites on screen. The GUI parent transparency will be applied to that final buffer (not the contents).
* For Direct3D we have to reset all these buffer textures when changing display mode, unfortunately. This is required for D3D to be able to reset its mode. They will be recreated on fly during the very next game redraw.