### PR TITLE
New compiler: Don't omit LINENUM directive with CTC; improved Googletests

### DIFF
--- a/Compiler/script2/cc_compiledscript.h
+++ b/Compiler/script2/cc_compiledscript.h
@@ -44,6 +44,9 @@ public:
     std::unordered_map<std::string, int> ImportIdx = {};
     std::unordered_map<std::string, int> ExportIdx = {};
 
+    std::vector<CodeLoc> Labels; // Code locations that will receive their actual value later on
+    std::unordered_map<CodeCell, CodeCell> Label2Value; // map labels to actual values
+
     // Number of bytes that have been PUSHED onto the stack. Local variables begin below that
     size_t OffsetToLocalVarBlock = 0u;
 
@@ -98,26 +101,44 @@ public:
     inline void WriteCmd(CodeCell op, CodeCell p1, CodeCell p2, CodeCell p3)
         { WriteCode(op); WriteCode(p1); WriteCode(p2); WriteCode(p3); };
 
-    // Write Bytecode that couples this point of the Bytecode with the source code line lno
+    // Write a Linenum pseudo-command, coupling this point of the Bytecode with the source code line 'lno'
     void WriteLineno(size_t lno);
     // Only write Bytecode for source line no if it differs from the last emitted
     inline void RefreshLineno(size_t lno) { if (LastEmittedLineno != lno) WriteLineno(lno); }
 
-    // write a PUSH command; track in OffsetToLocalVarBlock the number of bytes pushed to the stack
+    // write a 'push' command; track in 'OffsetToLocalVarBlock' the number of bytes pushed to the stack
     void PushReg(CodeCell regg);
-    // write a POP command; track in OffsetToLocalVarBlock the number of bytes pushed to the stack
+    // write a 'pop' command; track in 'OffsetToLocalVarBlock' the number of bytes pushed to the stack
     void PopReg(CodeCell regg);
 
     // Returns the relative distance in a jump instruction
-    // "here" is the location of the bytecode that will contain
-    // the (relative) destination.It is not the location of the
-    // start of the command but the location of its first parameter
+    // 'here' is the location of the bytecode that will contain the (relative) destination. 
+    // It is not the location of the start of the command but the location of its first parameter
     inline static CodeLoc RelativeJumpDist(CodeLoc here, CodeLoc dest) { return dest - here - 1; }
 
     inline void InvalidateLastEmittedLineno() { LastEmittedLineno = INT_MAX; }
 
+    // In code, replace those labels whose value is known.
+    void ReplaceLabels();
+
     ccCompiledScript(bool emit_line_numbers = true);
     virtual ~ccCompiledScript();
+};
+
+// A section of compiled code that needs to be moved or copied to a new location
+class Snippet
+{
+public:
+    std::vector<CodeCell> Code;
+    std::vector<CodeLoc> Fixups;
+    std::vector<char> FixupTypes;
+    std::vector<CodeLoc> Labels; // Locations of code cells that will receive their true value later
+
+    // Paste this snippet to the end of the code of 'script' 
+    void Paste(ccCompiledScript &scrip);
+
+    // Whether code is in the snippet, ignoring starting linenum directives
+    bool IsEmpty();
 };
 
 // Encapusulates a point of generated code.
@@ -125,7 +146,7 @@ class RestorePoint
 {
 private:
     ccCompiledScript &_scrip;
-    size_t _rememberedCodeLocation;
+    CodeLoc _rememberedCodeLocation;
 
 public:
     RestorePoint(ccCompiledScript &scrip)
@@ -133,12 +154,17 @@ public:
         , _rememberedCodeLocation(scrip.codesize)
     { }
 
-    // Discard all code that has been generated since the object was created
-    // Also discard the corresponding fixups
-    // This is useful if code is generated and it turns out later that it was in vain.
-    void Restore();
+    // Cut the code that has been generated since the object has been created into the snippet
+    // However, if 'keep_starting_linum' and the generated code begins with a 'linenum' pseudo-directive
+    // then don't discard this directive.
+    void Cut(Snippet &snippet, bool keep_starting_linum = true);
 
-    inline bool IsEmpty() const { return _scrip.codesize <= static_cast<int>(_rememberedCodeLocation); }
+    // Discard all code that has been generated since the object has been created
+    // However, if 'keep_starting_linum' and the generated code starts with a 'linenum' directive,
+    // then don't cut out this directive.
+    inline void Restore(bool keep_starting_linum = true) { Snippet _dummy; Cut(_dummy, keep_starting_linum); }
+
+    inline bool IsEmpty() const { return _scrip.codesize <= _rememberedCodeLocation; }
     inline CodeLoc CodeLocation() const { return _rememberedCodeLocation; }
 };
 
@@ -162,7 +188,10 @@ public:
     void AddParam(int offset = -1);
 
     // Patch all the forward jump parameters to point to _scrip.codesize
-    void Patch(size_t cur_line);
+    // If not 'keep_linenum' then the patch command will determine whether
+    // there can be more than one path to the next statement; if it can,
+    // then it will force a 'linenum' directive to be emitted next.
+    void Patch(size_t cur_line, bool keep_linenum = false);
 };
 
 // Remember a point of the bytecode that is going to be the destination

--- a/Compiler/script2/cc_compiledscript.h
+++ b/Compiler/script2/cc_compiledscript.h
@@ -114,6 +114,8 @@ public:
     // start of the command but the location of its first parameter
     inline static CodeLoc RelativeJumpDist(CodeLoc here, CodeLoc dest) { return dest - here - 1; }
 
+    inline void InvalidateLastEmittedLineno() { LastEmittedLineno = INT_MAX; }
+
     ccCompiledScript(bool emit_line_numbers = true);
     virtual ~ccCompiledScript();
 };

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -306,13 +306,10 @@ AGS::Parser::NestingStack::NestingInfo::NestingInfo(NSType stype, ccCompiledScri
     , SwitchCaseStart(std::vector<BackwardJumpDest>{})
     , SwitchDefaultIdx(kNoDefault)
     , SwitchJumptable(ForwardJump{ scrip })
-    , Chunks(std::vector<Chunk>{})
+    , Snippets(std::vector<Snippet>{})
     , OldDefinitions({})
 {
 }
-
-// For assigning unique IDs to chunks
-int AGS::Parser::NestingStack::_chunkIdCtr = 0;
 
 AGS::Parser::NestingStack::NestingStack(ccCompiledScript &scrip)
     :_scrip(scrip)
@@ -330,172 +327,21 @@ bool AGS::Parser::NestingStack::AddOldDefinition(Symbol s, SymbolTableEntry cons
     return false;
 }
 
-// Rip the code that has already been generated, starting from codeoffset, out of scrip
-// and move it into the vector at list, instead.
-void AGS::Parser::NestingStack::YankChunk(size_t src_line, CodeLoc code_start, size_t fixups_start, int &id)
-{
-    Chunk item;
-    item.SrcLine = src_line;
-
-    size_t const codesize = std::max<int>(0, _scrip.codesize);
-    for (size_t code_idx = code_start; code_idx < codesize; code_idx++)
-        item.Code.push_back(_scrip.code[code_idx]);
-
-    size_t numfixups = std::max<int>(0, _scrip.numfixups);
-    for (size_t fixups_idx = fixups_start; fixups_idx < numfixups; fixups_idx++)
-    {
-        CodeLoc const code_idx = _scrip.fixups[fixups_idx];
-        item.Fixups.push_back(code_idx - code_start);
-        item.FixupTypes.push_back(_scrip.fixuptypes[fixups_idx]);
-    }
-    item.Id = id = ++_chunkIdCtr;
-
-    _stack.back().Chunks.push_back(item);
-
-    // Cut out the code that has been pushed
-    _scrip.codesize = code_start;
-    _scrip.numfixups = static_cast<decltype(_scrip.numfixups)>(fixups_start);
-}
-
-// Copy the code in the chunk to the end of the bytecode vector 
-void AGS::Parser::NestingStack::WriteChunk(size_t level, size_t chunk_idx, int &id)
-{
-    Chunk const item = Chunks(level).at(chunk_idx);
-    id = item.Id;
-
-    // Add a line number opcode so that runtime errors
-// can show the correct originating source line.
-    if (0u < item.Code.size() && SCMD_LINENUM != item.Code[0u] && 0u < item.SrcLine)
-        _scrip.WriteLineno(item.SrcLine);
-
-    // The fixups are stored relative to the start of the insertion,
-    // so remember what that is
-    size_t const start_of_insert = _scrip.codesize;
-    size_t const code_size = item.Code.size();
-    for (size_t code_idx = 0u; code_idx < code_size; code_idx++)
-        _scrip.WriteCode(item.Code[code_idx]);
-
-    size_t const fixups_size = item.Fixups.size();
-    for (size_t fixups_idx = 0u; fixups_idx < fixups_size; fixups_idx++)
-        _scrip.AddFixup(
-            item.Fixups[fixups_idx] + start_of_insert,
-            item.FixupTypes[fixups_idx]);
-
-    _scrip.InvalidateLastEmittedLineno();
-}
-
-AGS::Parser::FuncCallpointMgr::FuncCallpointMgr(Parser &parser)
-    : _parser(parser)
+AGS::Parser::FuncLabelMgr::FuncLabelMgr(ccCompiledScript &scrip, int kind)
+    : _scrip(scrip)
+    , _kind(kind)
 { }
 
-void AGS::Parser::FuncCallpointMgr::Reset()
+void AGS::Parser::FuncLabelMgr::TrackLabelLoc(Symbol func, CodeLoc loc)
 {
-    _funcCallpointMap.clear();
+    _scrip.Labels.push_back(loc);
 }
 
-void AGS::Parser::FuncCallpointMgr::TrackForwardDeclFuncCall(Symbol func, CodeLoc loc, size_t in_source)
-{
-    // Patch callpoint in when known
-    CodeCell const callpoint = _funcCallpointMap[func].Callpoint;
-    if (callpoint >= 0)
-    {
-        _parser._scrip.code[loc] = callpoint;
-        return;
-    }
 
-    // Callpoint not known, so remember this location
-    PatchInfo pinfo{ kCodeBaseId, loc, in_source };
-    _funcCallpointMap[func].List.push_back(pinfo);
+void AGS::Parser::FuncLabelMgr::SetLabelValue(Symbol const func, CodeCell const val)
+{
+    _scrip.Label2Value[Function2Label(func)] = val;
 }
-
-void AGS::Parser::FuncCallpointMgr::UpdateCallListOnYanking(CodeLoc chunk_start, size_t chunk_len, int id)
-{
-    size_t const chunk_end = chunk_start + chunk_len;
-
-    for (CallMap::iterator func_it = _funcCallpointMap.begin();
-        func_it != _funcCallpointMap.end();
-        ++func_it)
-    {
-        PatchList &pl = func_it->second.List;
-        size_t const pl_size = pl.size();
-        for (size_t pl_idx = 0; pl_idx < pl_size; ++pl_idx)
-        {
-            PatchInfo &patch_info = pl[pl_idx];
-            if (kCodeBaseId != patch_info.ChunkId)
-                continue;
-            if (patch_info.Offset < chunk_start || patch_info.Offset >= static_cast<decltype(patch_info.Offset)>(chunk_end))
-                continue; // This address isn't yanked
-
-            patch_info.ChunkId = id;
-            patch_info.Offset -= chunk_start;
-        }
-    }
-    }
-
-void AGS::Parser::FuncCallpointMgr::UpdateCallListOnWriting(CodeLoc start, int id)
-{
-    for (CallMap::iterator func_it = _funcCallpointMap.begin();
-        func_it != _funcCallpointMap.end();
-        ++func_it)
-    {
-        PatchList &pl = func_it->second.List;
-        size_t const size = pl.size();
-        for (size_t pl_idx = 0; pl_idx < size; ++pl_idx)
-        {
-            PatchInfo &patch_info = pl[pl_idx];
-            if (patch_info.ChunkId != id)
-                continue; // Not our concern this time
-
-            // We cannot repurpose patch_info since it may be written multiple times.
-            PatchInfo cb_patch_info;
-            cb_patch_info.ChunkId = kCodeBaseId;
-            cb_patch_info.Offset = patch_info.Offset + start;
-            pl.push_back(cb_patch_info);
-        }
-    }
-}
-
-void AGS::Parser::FuncCallpointMgr::SetFuncCallpoint(Symbol func, CodeLoc dest)
-{
-    _funcCallpointMap[func].Callpoint = dest;
-    PatchList &pl = _funcCallpointMap[func].List;
-    size_t const pl_size = pl.size();
-    bool yanked_patches_exist = false;
-    for (size_t pl_idx = 0; pl_idx < pl_size; ++pl_idx)
-        if (kCodeBaseId == pl[pl_idx].ChunkId)
-        {
-            _parser._scrip.code[pl[pl_idx].Offset] = dest;
-            pl[pl_idx].ChunkId = kPatchedId;
-        }
-        else if (kPatchedId != pl[pl_idx].ChunkId)
-        {
-            yanked_patches_exist = true;
-        }
-    if (!yanked_patches_exist)
-        pl.clear();
-}
-
-void AGS::Parser::FuncCallpointMgr::CheckForUnresolvedFuncs()
-{
-    for (auto fcm_it = _funcCallpointMap.begin(); fcm_it != _funcCallpointMap.end(); ++fcm_it)
-    {
-        PatchList &pl = fcm_it->second.List;
-        size_t const pl_size = pl.size();
-        for (size_t pl_idx = 0; pl_idx < pl_size; ++pl_idx)
-        {
-            if (kCodeBaseId != pl[pl_idx].ChunkId)
-                continue;
-            _parser._src.SetCursor(pl[pl_idx].InSource);
-            _parser.UserError(
-                _parser.ReferenceMsgSym("The called function '%s()' isn't defined with body nor imported", fcm_it->first).c_str(),
-                _parser._sym.GetName(fcm_it->first).c_str());
-        }
-    }
-}
-
-AGS::Parser::FuncCallpointMgr::CallpointInfo::CallpointInfo()
-    : Callpoint(-1)
-{ }
 
 AGS::Parser::MarMgr::MarMgr(Parser &parser)
     : _parser(parser)
@@ -613,8 +459,8 @@ AGS::Parser::Parser(SrcList &src, FlagSet options, ccCompiledScript &scrip, Symb
     , _options(options)
     , _scrip(scrip)
     , _msgHandler(mh)
-    , _fcm(*this)
-    , _fim(*this)
+    , _callpointLabels(scrip, 0)
+    , _importLabels(scrip, 1)
     , _structRefs({})
 {
     _givm.clear();
@@ -964,22 +810,21 @@ void AGS::Parser::HandleEndOfSwitch()
     CodeCell const eq_opcode =
         _sym.IsAnyStringVartype(_nest.SwitchExprVartype()) ? SCMD_STRINGSEQUAL : SCMD_ISEQUAL;
 
-    const size_t number_of_cases = _nest.Chunks().size();
+    const size_t number_of_cases = _nest.Snippets().size();
     const size_t default_idx = _nest.SwitchDefaultIdx();
     for (size_t cases_idx = 0; cases_idx < number_of_cases; ++cases_idx)
     {
         if (cases_idx == default_idx)
             continue;
 
-        int id;
         CodeLoc const codesize = _scrip.codesize;
         // Emit the code for the case expression of the current case. Result will be in AX
-        _nest.WriteChunk(cases_idx, id);
-        _fcm.UpdateCallListOnWriting(codesize, id);
-        _fim.UpdateCallListOnWriting(codesize, id);
-        
+        _nest.Snippets().at(cases_idx).Paste(_scrip);
+
         // "If switch expression equals case expression, jump to case"
-        WriteCmd(eq_opcode, SREG_AX, SREG_BX);
+        // Don't auto-generate a 'linenum' directive here: It will point to the end of the switch
+        // construct instead of to the respective 'case'/'default', and that is incorrect.
+        _scrip.WriteCmd(eq_opcode, SREG_AX, SREG_BX);
         _nest.SwitchCaseStart().at(cases_idx).WriteJump(SCMD_JNZ, _src.GetLineno());
     }
 
@@ -1478,7 +1323,7 @@ void AGS::Parser::ParseFuncdecl_EnterAsImportOrFunc(Symbol name_of_func, bool bo
         if (function_soffs < 0)
             UserError("Max. number of functions exceeded");
 		
-        _fcm.SetFuncCallpoint(name_of_func, function_soffs);
+        _callpointLabels.SetLabelValue(name_of_func, function_soffs);
         return;
     }
 
@@ -1576,7 +1421,7 @@ void AGS::Parser::ParseFuncdecl_HandleFunctionOrImportIndex(TypeQualifierSet tqs
         strcat(_scrip.imports[imports_idx], appendage);
     }
 
-    _fim.SetFuncCallpoint(name_of_func, imports_idx);
+    _importLabels.SetLabelValue(name_of_func, imports_idx);
 }
 
 void AGS::Parser::ParseFuncdecl(TypeQualifierSet tqs, Vartype return_vartype, Symbol struct_of_func, Symbol name_of_func, bool no_loop_check, bool body_follows)
@@ -2555,7 +2400,7 @@ void AGS::Parser::ParseExpression_Ternary(size_t tern_idx, SrcList &expression, 
     eres.Modifiable = false;
 }
 
-void AGS::Parser::ParseExpression_Binary(size_t op_idx, SrcList &expression, EvaluationResult &eres)
+void AGS::Parser::ParseExpression_Binary(size_t const op_idx, SrcList &expression, EvaluationResult &eres)
 {
     RestorePoint start_of_term(_scrip);
     Symbol const operator_sym = expression[op_idx];
@@ -2570,47 +2415,60 @@ void AGS::Parser::ParseExpression_Binary(size_t op_idx, SrcList &expression, Eva
     EvaluationResultToAx(eres);
    
     ForwardJump to_exit(_scrip);
-    
+
+    bool lazy_evaluation = false;
     if (kKW_And == operator_sym)
     {
-        // "&&" operator lazy evaluation: if AX is 0 then the AND has failed, 
-        // so just jump directly to the end of the term; 
+        // if AX is 0 then the AND has failed, so just jump directly to the end of the term
         // AX will still be 0 so that will do as the result of the calculation
+        lazy_evaluation = true;
+        expression.SetCursor(op_idx + 1);
         WriteCmd(SCMD_JZ, kDestinationPlaceholder);
         to_exit.AddParam();
     }
     else if (kKW_Or == operator_sym)
     {
-        // "||" operator lazy evaluation: if AX is non-zero then the OR has succeeded, 
-        // so just jump directly to the end of the term; 
+        // If AX is non-zero then the OR has succeeded, so just jump directly to the end of the term; 
         // AX will still be non-zero so that will do as the result of the calculation
+        lazy_evaluation = true;
+        expression.SetCursor(op_idx + 1);
         WriteCmd(SCMD_JNZ, kDestinationPlaceholder);
         to_exit.AddParam();
     }
+    else
+    {
+        // Hang on to the intermediate result
+        PushReg(SREG_AX);
+    }
 
-    PushReg(SREG_AX);
     SrcList rhs = SrcList(expression, op_idx + 1, expression.Length());
     if (0 == rhs.Length())
+    {
         // there is no right hand side for the expression
+        expression.SetCursor(op_idx + 1);
         UserError("Binary operator '%s' doesn't have a right hand side", _sym.GetName(operator_sym).c_str());
+    }
 
     ParseExpression_Term(rhs, eres);
+    size_t const expression_end_idx = expression.GetCursor();
 
     EvaluationResult eres_rhs = eres;
     EvaluationResultToAx(eres);
 
-    PopReg(SREG_BX); // Note, we pop to BX although we have pushed AX
-    _reg_track.SetRegister(SREG_BX);
-    // now the result of the left side is in BX, of the right side is in AX
+    if (!lazy_evaluation)
+    {
+        expression.SetCursor(op_idx + 1);
+        PopReg(SREG_BX); // Note, we pop to BX although we have pushed AX
+        _reg_track.SetRegister(SREG_BX);
+        // now the result of the left side is in BX, of the right side is in AX
+        CodeCell const opcode = GetOpcode(operator_sym, eres_lhs.Vartype, eres_rhs.Vartype);
+        WriteCmd(opcode, SREG_BX, SREG_AX);
+        WriteCmd(SCMD_REGTOREG, SREG_BX, SREG_AX);
+    }
 
-    CodeCell const opcode = GetOpcode(operator_sym, eres_lhs.Vartype, eres_rhs.Vartype);
-    
-    WriteCmd(opcode, SREG_BX, SREG_AX);
-    WriteCmd(SCMD_REGTOREG, SREG_BX, SREG_AX);
-    _reg_track.SetRegister(SREG_BX);
     _reg_track.SetRegister(SREG_AX);
     eres.Location = EvaluationResult::kLOC_AX;
-
+    expression.SetCursor(expression_end_idx);
     to_exit.Patch(_src.GetLineno());
 
     if (_sym.IsBooleanOperator(operator_sym))
@@ -2623,11 +2481,11 @@ void AGS::Parser::ParseExpression_Binary(size_t op_idx, SrcList &expression, Eva
 
     if (kKW_And == operator_sym || kKW_Or == operator_sym)
     {
-        bool const left = (0 != _sym[eres_lhs.Symbol].LiteralD->Value);
+        bool const condition = (0 != _sym[eres_lhs.Symbol].LiteralD->Value);
         if (kKW_And == operator_sym)
-            eres = left ? eres_rhs : eres_lhs;
+            eres = condition ? eres_rhs : eres_lhs;
         else // kKW_Or
-            eres = left ? eres_lhs : eres_rhs;
+            eres = condition ? eres_lhs : eres_rhs;
         
         if (!_sym.IsAnyIntegerVartype(_sym[eres.Symbol].LiteralD->Vartype))
         {   // Swap an int literal in (note: Don't change the vartype of the pre-existing literal)
@@ -2878,8 +2736,13 @@ void AGS::Parser::AccessData_GenerateFunctionCall(Symbol name_of_func, size_t nu
     {   
         _scrip.FixupPrevious(kFx_Import);
         if (!_scrip.IsImport(_sym.GetName(name_of_func)))
-            _fim.TrackForwardDeclFuncCall(name_of_func, _scrip.codesize - 1, _src.GetCursor());
-        
+        {
+            // We don't know the import number of this function yet, so put a label here
+            // and keep track of the location in order to patch in the proper import number later on
+            _scrip.code[_scrip.codesize - 1] = _importLabels.Function2Label(name_of_func);
+            _importLabels.TrackLabelLoc(name_of_func, _scrip.codesize - 1);
+        }
+
         WriteCmd(SCMD_CALLEXT, SREG_AX); // Do the call
         _reg_track.SetAllRegisters();
         // At runtime, we will arrive here when the function call has returned: Restore the stack
@@ -2891,8 +2754,12 @@ void AGS::Parser::AccessData_GenerateFunctionCall(Symbol name_of_func, size_t nu
     // Func is non-import
     _scrip.FixupPrevious(kFx_Code);
     if (_sym[name_of_func].FunctionD->Offset < 0)
-        _fcm.TrackForwardDeclFuncCall(name_of_func, _scrip.codesize - 1, _src.GetCursor());
-    
+    {
+        // We don't know yet at which address the function is going to start, so put a label here
+        // and keep track of the location in order to patch in the correct address later on
+        _scrip.code[_scrip.codesize - 1] = _callpointLabels.Function2Label(name_of_func);
+        _callpointLabels.TrackLabelLoc(name_of_func, _scrip.codesize - 1);
+    }
     WriteCmd(SCMD_CALL, SREG_AX);  // Do the call
     _reg_track.SetAllRegisters();
 
@@ -3523,12 +3390,15 @@ void AGS::Parser::AccessData_FirstClause(VariableAccess access_type, SrcList &ex
     if (_sym.IsVartype(this_vartype) && _sym[this_vartype].VartypeD->Components.count(first_sym))
     {
         // Fake a "this." here
+        // Eat the component, pretend that it is 'this'. We need to do this in order 
+        // to force the code that will be emitted to be connected to the proper place in the source.
+        expression.GetNext(); 
         AccessData_This(eres);
 
         // Going forward, the code should imply "this."
         // with the '.' already read in.
         implied_this_dot = true;
-        // Then the component needs to be read again.
+        // Then back up so that the component will be read again as the next symbol.
         expression.BackUp();
         return;
     }
@@ -3788,7 +3658,6 @@ void AGS::Parser::AccessData_AssignTo(SrcList &expression, EvaluationResult eres
     EvaluationResult rhs_eres = eres;
     if (EvaluationResult::kTY_Literal != rhs_eres.Type)
         EvaluationResultToAx(rhs_eres);
-
 
     // Get the LHS of the assignment for writing.
     // Protect the register from being clobbered that contains the result of the RHS.
@@ -5995,23 +5864,13 @@ void AGS::Parser::ParseWhile()
 
 void AGS::Parser::HandleEndOfWhile()
 {
-    // if it's the inner level of a 'for' loop,
-    // drop the yanked chunk (loop increment) back in
-    if (_nest.ChunksExist())
-    {
-        int id;
-        CodeLoc const write_start = _scrip.codesize;
-        _nest.WriteChunk(0u, id);
-        _fcm.UpdateCallListOnWriting(write_start, id);
-        _fim.UpdateCallListOnWriting(write_start, id);
-        _nest.Chunks().clear();
-    }
-
     // jump back to the start location
     _nest.Start().WriteJump(SCMD_JMP, _src.GetLineno());
 
-    // This ends the loop
-    _nest.JumpOut().Patch(_src.GetLineno());
+    // This ends the loop.
+    // Don't emit a 'linenum' directive: We can guarantee that we will only reach this place
+    // from the 'while' clause line of the 'for', which has been emitted in the last 'linenum'.
+    _nest.JumpOut().Patch(_src.GetLineno(), true);
     _nest.Pop();
 
     if (NSType::kFor != _nest.Type())
@@ -6122,21 +5981,20 @@ void AGS::Parser::ParseFor_InitClause(Symbol peeksym)
 
 void AGS::Parser::ParseFor_WhileClause()
 {
-    // Make the last emitted line number invalid so that a linenumber bytecode is emitted
-    _scrip.LastEmittedLineno = INT_MAX;
     if (kKW_Semicolon == _src.PeekNext())
-    {
-        // Not having a while clause is tantamount to the while condition "true".
-        // So let's write "true" to the AX register.
-        WriteCmd(SCMD_LITTOREG, SREG_AX, 1);
-        _reg_track.SetRegister(SREG_AX);
+        // Not having a while clause means no check
         return;
-    }
 
+    // Make sure that a linenumber bytecode is emitted
+    _scrip.InvalidateLastEmittedLineno();
     EvaluationResult eres;
     ParseExpression(_src, eres);
     EvaluationResultToAx(eres);
-    CheckVartypeMismatch(eres.Vartype, kKW_Int, true, "Second clause in 'for' statement");
+    CheckVartypeMismatch(
+        eres.Vartype,
+        kKW_Int,
+        true,
+        "Second clause in 'for' statement");
 }
 
 void AGS::Parser::ParseFor_IterateClause()
@@ -6144,17 +6002,23 @@ void AGS::Parser::ParseFor_IterateClause()
     if (kKW_CloseParenthesis == _src.PeekNext())
         return; // iterate clause is empty
 
+    // Make sure that a linenum pseudo-directive is emitted
+    _scrip.InvalidateLastEmittedLineno();
     return ParseAssignmentOrExpression();
 }
 
 void AGS::Parser::ParseFor()
 {
     // "for (I; E; C) {...}" is equivalent to "{ I; while (E) {...; C} }"
-    // We implement this with TWO levels of the nesting stack.
+    // We implement this with TWO levels of the nesting stack: an outer and an inner level.
     // The outer level contains "I"
-    // The inner level contains "while (E) { ...; C}"
+    // Then execution jumps to E
+    // The inner level starts with C E
+    // If E fails, execution exits the inner level to the rest of the outer level.
+    // At the end of the inner level, execution jumps back up to C
+    // The rest of the outer level frees I.
 
-    // Outer level
+    // Outer nesting level
     _nest.Push(NSType::kFor);
 
     Expect(kKW_OpenParenthesis, _src.GetNext());
@@ -6165,44 +6029,67 @@ void AGS::Parser::ParseFor()
 
     // Initialization clause (I)
     ParseFor_InitClause(peeksym);
-    Expect(kKW_Semicolon, _src.GetNext(), "Expected ';' after for loop initializer clause");
-
-    // Remember where the code of the while condition starts.
-    CodeLoc const while_cond_loc = _scrip.codesize;
-
-    ParseFor_WhileClause();
-    Expect(kKW_Semicolon, _src.GetNext(), "Expected ';' after for loop while clause");
-
-    // Remember where the code of the iterate clause starts.
-    CodeLoc const iterate_clause_loc = _scrip.codesize;
-    size_t const iterate_clause_fixups_start = _scrip.numfixups;
-    size_t const iterate_clause_lineno = _src.GetLineno();
-    
-    ParseFor_IterateClause();
-    Expect(kKW_CloseParenthesis, _src.GetNext(), "Expected ')' after for loop iterate clause");
+    Expect(
+        kKW_Semicolon,
+        _src.GetNext(),
+        "Expected ';' after the initializer clause of the 'for' loop ");
 
     // Inner nesting level
     _nest.Push(NSType::kWhile);
-    _nest.Start().Set(while_cond_loc);
+    _nest.Start().Set();
 
-    // We've just generated code for getting to the next loop iteration.
-     // But we don't need that code right here; we need it at the bottom of the loop.
-     // So rip it out of the bytecode base and save it into our nesting stack.
-    int id;
-    size_t const yank_size = _scrip.codesize - iterate_clause_loc;
-    _nest.YankChunk(iterate_clause_lineno, iterate_clause_loc, iterate_clause_fixups_start, id);
-    _fcm.UpdateCallListOnYanking(iterate_clause_loc, yank_size, id);
-    _fim.UpdateCallListOnYanking(iterate_clause_loc, yank_size, id);
-        
-        // Code for "If the expression we just evaluated is false, jump over the loop body."
-        WriteCmd(SCMD_JZ, kDestinationPlaceholder);
+    // Parse the 'while' clause, then cut out its code and save it
+    RestorePoint while_clause_start(_scrip);
+    Snippet while_clause_snippet;
+    ParseFor_WhileClause();
+    Expect(
+        kKW_Semicolon,
+        _src.GetNext(),
+        "Expected ';' after the condition clause of the 'for' loop");
+    while_clause_start.Cut(while_clause_snippet, false);
+
+    // Parse the 'iterate' clause, then cut out its code and save it
+    RestorePoint iterate_clause_start(_scrip);
+    Snippet iterate_clause_snippet;
+    ParseFor_IterateClause();
+    Expect(
+        kKW_CloseParenthesis,
+        _src.GetNext(),
+        "Expected ')' after the iterator clause of the 'for' loop ");
+    iterate_clause_start.Cut(iterate_clause_snippet, false);
+
+    if (iterate_clause_snippet.IsEmpty())
+    {
+        // At the end of the 'for' construct or at a 'continue', 
+        // we need to jump directly to the code of the 'while' clause (which will be inserted _here_).
+        _nest.Start().Set();
+    }
+    else
+    {
+        // We need to insert a jump over the code for the 'iterate' clause
+        // so that it won't be executed the first time that the 'for' construct runs.
+        ForwardJump after_iterate_clause(_scrip);
+        WriteCmd(SCMD_JMP, kDestinationPlaceholder);
+        after_iterate_clause.AddParam();
+
+        // At the end of the 'for' construct or at a 'continue',
+        // we need to jump to the start of the 'iterate' clause (which will be inserted _here_)
+        _nest.Start().Set();
+        iterate_clause_snippet.Paste(_scrip);
+        after_iterate_clause.Patch(_src.GetCursor()); 
+    }
+
+    // An empty 'while' clause is tantamount to a no-op, so only do things if it isn't empty.
+    if (!while_clause_snippet.IsEmpty())
+    {
+        while_clause_snippet.Paste(_scrip);
+        _scrip.WriteCmd(SCMD_JZ, kDestinationPlaceholder); // Don't emit a 'linenum' here
         _nest.JumpOut().AddParam();
+    }
 }
 
 void AGS::Parser::ParseSwitch()
 {
-    RestorePoint rp{ _scrip };
-
     // Get the switch expression
     EvaluationResult eres;
     ParseDelimitedExpression(_src, kKW_OpenParenthesis, eres);
@@ -6211,7 +6098,8 @@ void AGS::Parser::ParseSwitch()
     if (kKW_CloseBrace == _src.PeekNext())
     {
         // A switch without any clauses, tantamount to a NOP
-        rp.Restore();
+        // Don't throw away the code that was generated for the switch expression:
+        // It might have side effects!
         _src.GetNext(); // Eat '}'
         return;
     }
@@ -6241,6 +6129,7 @@ void AGS::Parser::ParseSwitchFallThrough()
 
 void AGS::Parser::ParseSwitchLabel(Symbol case_or_default)
 {
+    RestorePoint switch_label_start(_scrip);
     CodeLoc const start_of_code_loc = _scrip.codesize;
     size_t const start_of_fixups = _scrip.numfixups;
     size_t const start_of_code_lineno = _src.GetLineno();
@@ -6293,12 +6182,15 @@ void AGS::Parser::ParseSwitchLabel(Symbol case_or_default)
     }
 
     // Rip out the already generated code for the case expression and store it with the switch
-    int id;
-    size_t const yank_size = _scrip.codesize - start_of_code_loc;
-    _nest.YankChunk(start_of_code_lineno, start_of_code_loc, start_of_fixups, id);
-    _fcm.UpdateCallListOnYanking(start_of_code_loc, yank_size, id);
-    _fim.UpdateCallListOnYanking(start_of_code_loc, yank_size, id);
-    
+    // In order to process sequences of 'case'/'default' statements without intervening code,
+    //      don't keep the starting 'linenum' directive in the code
+    //          that the 'case'/'default' may have generated,
+    //      but do invalidate line numbers so that a 'linenum' directive
+    //          will be generated as soon as "real" code comes up.
+    Snippet snippet;
+    switch_label_start.Cut(snippet, false);
+    _nest.Snippets().push_back(snippet);
+    _scrip.InvalidateLastEmittedLineno();
     return Expect(kKW_Colon, _src.GetNext());
 }
 
@@ -6350,7 +6242,7 @@ void AGS::Parser::ParseBreak()
     Expect(kKW_Semicolon, _src.GetNext());
     
     // Find the (level of the) looping construct to which the break applies
-    // Note that this is similar, but _different_ from "continue".
+    // Note that this is similar, but _different_ from what happens at 'continue'.
     size_t nesting_level;
     for (nesting_level = _nest.TopLevel(); nesting_level > 0; nesting_level--)
     {
@@ -6372,8 +6264,8 @@ void AGS::Parser::ParseBreak()
     WriteCmd(SCMD_JMP, kDestinationPlaceholder);
     _nest.JumpOut(nesting_level).AddParam();
 
-    // The locals only disappear if control flow actually follows the "break"
-    // statement. Otherwise, below the statement, the locals remain on the stack.
+    // The locals only disappear if control flow actually follows the 'break' statement. 
+    // Otherwise, i.e., below the statement, the locals remain on the stack.
     // So restore the OffsetToLocalVarBlock.
     _scrip.OffsetToLocalVarBlock = save_offset;
 }
@@ -6382,8 +6274,8 @@ void AGS::Parser::ParseContinue()
 {
     Expect(kKW_Semicolon, _src.GetNext());
     
-    // Find the level of the looping construct to which the break applies
-    // Note that this is similar, but _different_ from "break".
+    // Find the level of the looping construct to which the 'continue' applies
+    // Note that this is similar, but _different_ from what happens at 'break'.
     size_t nesting_level;
     for (nesting_level = _nest.TopLevel(); nesting_level > 0; nesting_level--)
     {
@@ -6401,22 +6293,12 @@ void AGS::Parser::ParseContinue()
     FreeDynpointersOfLocals(nesting_level + 1);
     RemoveLocalsFromStack(nesting_level + 1);
 
-    // if it's a for loop, drop the yanked loop increment chunk in
-    if (_nest.ChunksExist(nesting_level))
-    {
-        int id;
-        CodeLoc const write_start = _scrip.codesize;
-        _nest.WriteChunk(nesting_level, 0u, id);
-        _fcm.UpdateCallListOnWriting(write_start, id);
-        _fim.UpdateCallListOnWriting(write_start, id);
-    }
-
     // Jump to the start of the loop
     _nest.Start(nesting_level).WriteJump(SCMD_JMP, _src.GetLineno());
 
-    // The locals only disappear if control flow actually follows the "continue"
-    // statement. Otherwise, below the statement, the locals remain on the stack.
-     // So restore the OffsetToLocalVarBlock.
+    // The locals only disappear if control flow actually follows the 'continue' statement. 
+    // Otherwise, i.e., below the statement, the locals remain on the stack.
+    // So restore the OffsetToLocalVarBlock.
     _scrip.OffsetToLocalVarBlock = save_offset;
 }
 
@@ -6534,7 +6416,7 @@ void AGS::Parser::RegisterGuard(RegisterList const &guarded_registers, std::func
     // Save the current MAR manager in case it gets clobbered and needs to be restored
     MarMgr save_mar_state(_marMgr);
 
-    RegisterTracking::TickT register_set_point[CC_NUM_REGISTERS];
+    RegisterTracking::TickT register_set_point[CC_NUM_REGISTERS] = {};
     for (auto it = guarded_registers.begin(); it != guarded_registers.end(); ++it)
         register_set_point[*it] = _reg_track.GetRegister(*it);
 
@@ -6781,8 +6663,6 @@ void AGS::Parser::Parse_PreAnalyzePhase()
 
     _pp = PP::kPreAnalyze;
     ParseInput();
-    
-    _fcm.Reset();
 
     // Keep (just) the headers of functions that have a body to the main symbol table
     // Reset everything else in the symbol table,
@@ -6856,9 +6736,15 @@ void AGS::Parser::Parse()
         
         _src.SetCursor(start_of_input);
         Parse_MainPhase();
-        
-        _fcm.CheckForUnresolvedFuncs();
-        _fim.CheckForUnresolvedFuncs();
+
+        _scrip.ReplaceLabels();
+        if (!_scrip.Labels.empty())
+        {
+            UserError(
+                "Function '%s' has been referenced in this file but never defined",
+                _sym.GetName(_scrip.Labels[0] / 10).c_str());
+        }
+
         Parse_CheckForUnresolvedStructForwardDecls();
         if (FlagIsSet(_options, SCOPT_EXPORTALL))
 			Parse_ExportAllFunctions();

--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -44,7 +44,7 @@
 TEST_F(Bytecode0, P_r_o_t_o_t_y_p_e) {
     
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Foo(int a)      \n\
         {                   \n\
             return a*a;     \n\
@@ -65,13 +65,13 @@ TEST_F(Bytecode0, P_r_o_t_o_t_y_p_e) {
 class Bytecode0 : public ::testing::Test
 {
 protected:
-    AGS::ccCompiledScript scrip{ false };
+    AGS::ccCompiledScript scrip{ true };    // enable emitting line numbers
 
     Bytecode0()
     {
         // Initializations, will be done at the start of each test
+        // Note, the parser doesn't react to SCOPT_LINENUMBERS, that's on ccCompiledScript
         ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
-        ccSetOption(SCOPT_LINENUMBERS, false);
         clear_error();
     }
 };
@@ -80,7 +80,7 @@ TEST_F(Bytecode0, UnaryMinus1) {
 
     // Accept a unary minus in front of parens
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Foo()              \n\
         {                       \n\
             int bar = 5;        \n\
@@ -93,31 +93,32 @@ TEST_F(Bytecode0, UnaryMinus1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("UnaryMinus1", scrip);
-    const size_t codesize = 35;
+    size_t const codesize = 43;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,   51,    // 7
-       4,    7,    3,    6,            4,    0,   12,    4,    // 15
-       3,    3,    4,    3,            6,    4,    0,   12,    // 23
-       4,    3,    3,    4,            3,   29,    3,    2,    // 31
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   29,    3,   36,            4,   51,    4,    7,    // 15
+       3,    6,    4,    0,           12,    4,    3,    3,    // 23
+       4,    3,    6,    4,            0,   12,    4,    3,    // 31
+       3,    4,    3,   29,            3,   36,    5,    2,    // 39
        1,    8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -125,7 +126,7 @@ TEST_F(Bytecode0, UnaryMinus2) {
 
     // Unary minus binds more than multiply
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                      \n\
         {                               \n\
             int five = 5;               \n\
@@ -138,16 +139,17 @@ TEST_F(Bytecode0, UnaryMinus2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("UnaryMinus2", scrip);
-    size_t const codesize = 52;
+    size_t const codesize = 60;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,    6,    // 7
-       3,    7,   29,    3,           51,    8,    7,    3,    // 15
-       6,    4,    0,   12,            4,    3,    3,    4,    // 23
-       3,   29,    3,   51,            8,    7,    3,    6,    // 31
-       4,    0,   12,    4,            3,    3,    4,    3,    // 39
-      30,    4,    9,    4,            3,    3,    4,    3,    // 47
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   29,    3,   36,            4,    6,    3,    7,    // 15
+      29,    3,   36,    5,           51,    8,    7,    3,    // 23
+       6,    4,    0,   12,            4,    3,    3,    4,    // 31
+       3,   29,    3,   51,            8,    7,    3,    6,    // 39
+       4,    0,   12,    4,            3,    3,    4,    3,    // 47
+      30,    4,    9,    4,            3,    3,    4,    3,    // 55
        2,    1,    8,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
@@ -171,7 +173,8 @@ TEST_F(Bytecode0, UnaryMinus2) {
 TEST_F(Bytecode0, NotNot) {
 
     // !!a should be interpreted as !(!a)
-    const char *inpl = "\
+
+    char const *inpl = "\
         int main()                  \n\
         {                           \n\
             int five = 5;           \n\
@@ -182,13 +185,15 @@ TEST_F(Bytecode0, NotNot) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Notnot", scrip);
-    size_t const codesize = 21;
+
+    size_t const codesize = 27;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,   51,    // 7
-       4,    7,    3,   42,            3,   42,    3,   42,    // 15
-       3,    2,    1,    4,            5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   29,    3,   36,            4,   51,    4,    7,    // 15
+       3,   42,    3,   42,            3,   42,    3,    2,    // 23
+       1,    4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -211,8 +216,9 @@ TEST_F(Bytecode0, NotNot) {
 TEST_F(Bytecode0, Float01) {   
 
     // Float values
+    // Note that the code behind the 'return' statement is unreachable.
 
-    const char inpl[] = "\
+    char const *inpl = "\
         float Test0 = -9.9;                 \n\
         float main()                        \n\
         {                                   \n\
@@ -238,30 +244,35 @@ TEST_F(Bytecode0, Float01) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(0).Message.find("reach this point"));
 
     // WriteOutput("Float01", scrip);
-    size_t const codesize = 155;
+
+    size_t const codesize = 189;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,         -1059061760,   29,    3,    6,    // 7
-       3, 1143930880,   29,    3,            6,    3, -1114678231,   29,    // 15
-       3,    6,    3, -1057593754,           29,    3,    6,    3,    // 23
-    1088421888,   29,    3,    6,            3, 893118370,   29,    3,    // 31
-       6,    3, 893118370,   29,            3,    6,    3, 1061494456,    // 39
-      29,    3,   51,   32,            7,    3,   29,    3,    // 47
-      51,   32,    7,    3,           30,    4,   57,    4,    // 55
-       3,    3,    4,    3,           29,    3,   51,   28,    // 63
-       7,    3,   30,    4,           57,    4,    3,    3,    // 71
-       4,    3,   29,    3,           51,   24,    7,    3,    // 79
-      30,    4,   57,    4,            3,    3,    4,    3,    // 87
-      29,    3,   51,   20,            7,    3,   30,    4,    // 95
-      57,    4,    3,    3,            4,    3,   29,    3,    // 103
-      51,   16,    7,    3,           30,    4,   57,    4,    // 111
-       3,    3,    4,    3,           29,    3,   51,   12,    // 119
-       7,    3,   30,    4,           57,    4,    3,    3,    // 127
-       4,    3,   29,    3,           51,    8,    7,    3,    // 135
-      30,    4,   57,    4,            3,    3,    4,    3,    // 143
-       2,    1,   32,    5,            6,    3, 1117388800,   51,    // 151
-      32,    8,    3,  -999
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+    -1059061760,   29,    3,   36,            5,    6,    3, 1143930880,    // 15
+      29,    3,   36,    6,            6,    3, -1114678231,   29,    // 23
+       3,   36,    7,    6,            3, -1057593754,   29,    3,    // 31
+      36,    8,    6,    3,         1088421888,   29,    3,   36,    // 39
+       9,    6,    3, 893118370,           29,    3,   36,   10,    // 47
+       6,    3, 893118370,   29,            3,   36,   11,    6,    // 55
+       3, 1061494456,   29,    3,           36,   12,   51,   32,    // 63
+       7,    3,   29,    3,           51,   32,    7,    3,    // 71
+      30,    4,   57,    4,            3,    3,    4,    3,    // 79
+      29,    3,   51,   28,            7,    3,   30,    4,    // 87
+      57,    4,    3,    3,            4,    3,   29,    3,    // 95
+      36,   13,   51,   24,            7,    3,   36,   12,    // 103
+      30,    4,   57,    4,            3,    3,    4,    3,    // 111
+      36,   13,   29,    3,           51,   20,    7,    3,    // 119
+      30,    4,   57,    4,            3,    3,    4,    3,    // 127
+      29,    3,   51,   16,            7,    3,   30,    4,    // 135
+      57,    4,    3,    3,            4,    3,   29,    3,    // 143
+      36,   14,   51,   12,            7,    3,   36,   13,    // 151
+      30,    4,   57,    4,            3,    3,    4,    3,    // 159
+      36,   14,   29,    3,           51,    8,    7,    3,    // 167
+      30,    4,   57,    4,            3,    3,    4,    3,    // 175
+       2,    1,   32,    5,           36,   15,    6,    3,    // 183
+    1117388800,   51,   32,    8,            3,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -285,7 +296,7 @@ TEST_F(Bytecode0, Float02) {
 
     // Positive and negative float parameter defaults
 
-    const char inpl[] = "\
+    char const *inpl = "\
         float sub (float p1 = 7.2,          \n\
                    float p2 = -2.7)         \n\
         {                                   \n\
@@ -301,16 +312,18 @@ TEST_F(Bytecode0, Float02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Float02", scrip);
-    size_t const codesize = 55;
+
+    size_t const codesize = 63;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,         -1059061760,   29,    3,   51,    // 7
-      12,    7,    3,   30,            4,   57,    4,    3,    // 15
-       3,    4,    3,   29,            3,   51,   16,    7,    // 23
-       3,   30,    4,   58,            4,    3,    3,    4,    // 31
-       3,    5,   38,   34,            6,    3, -1070805811,   29,    // 39
-       3,    6,    3, 1088841318,           29,    3,    6,    3,    // 47
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+    -1059061760,   29,    3,   51,           12,    7,    3,   30,    // 15
+       4,   57,    4,    3,            3,    4,    3,   29,    // 23
+       3,   51,   16,    7,            3,   30,    4,   58,    // 31
+       4,    3,    3,    4,            3,    5,   36,    7,    // 39
+      38,   38,   36,    8,            6,    3, -1070805811,   29,    // 47
+       3,    6,    3, 1088841318,           29,    3,    6,    3,    // 55
        0,   23,    3,    2,            1,    8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -319,7 +332,7 @@ TEST_F(Bytecode0, Float02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      48,  -999
+      56,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -341,7 +354,7 @@ TEST_F(Bytecode0, Float02) {
 
 TEST_F(Bytecode0, Float03) { 
 
-    const char *inpl = "\
+    char const *inpl = "\
         float a = 15.0;     \n\
         float Foo()         \n\
         {                   \n\
@@ -354,14 +367,16 @@ TEST_F(Bytecode0, Float03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Float03", scrip);
-    size_t const codesize = 30;
+
+    size_t const codesize = 36;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,         1078523331,   29,    3,    6,    // 7
-       2,    0,    7,    3,           29,    3,   51,    8,    // 15
-       7,    3,   30,    4,           57,    4,    3,    3,    // 23
-       4,    3,    2,    1,            4,    5,  -999
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+    1078523331,   29,    3,   36,            5,    6,    2,    0,    // 15
+       7,    3,   29,    3,           51,    8,    7,    3,    // 23
+      30,    4,   57,    4,            3,    3,    4,    3,    // 31
+       2,    1,    4,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -369,7 +384,7 @@ TEST_F(Bytecode0, Float03) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,  -999
+      15,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -391,7 +406,7 @@ TEST_F(Bytecode0, Float03) {
 
 TEST_F(Bytecode0, Float04) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         float a = 15.0;                             \n\
         float Foo()                                 \n\
         {                                           \n\
@@ -408,30 +423,32 @@ TEST_F(Bytecode0, Float04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Float04", scrip);
-    size_t const codesize = 156;
+
+    size_t const codesize = 162;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,         1102158234,   29,    3,    6,    // 7
-       3,    0,   29,    3,            6,    3,    0,   51,    // 15
-       0,   27,    3,    1,            1,    2,    6,    2,    // 23
-       0,    7,    3,   29,            3,    6,    3, 1110546842,    // 31
-      30,    4,   62,    4,            3,    3,    4,    3,    // 39
-      29,    3,    6,    3,            1,   51,    0,   26,    // 47
-       3,    1,    1,    1,            6,    2,    0,    7,    // 55
-       3,   29,    3,   51,           19,    7,    3,   30,    // 63
-       4,   15,    4,    3,            3,    4,    3,   70,    // 71
-      29,   29,    3,    6,            2,    0,    7,    3,    // 79
-      29,    3,   51,   23,            7,    3,   30,    4,    // 87
-      16,    4,    3,    3,            4,    3,   30,    4,    // 95
-      22,    4,    3,    3,            4,    3,   29,    3,    // 103
-       6,    2,    0,    7,            3,   29,    3,   51,    // 111
-      23,    7,    3,   29,            3,    6,    2,    0,    // 119
-       7,    3,   29,    3,           51,   31,    7,    3,    // 127
-      30,    4,   56,    4,            3,    3,    4,    3,    // 135
-      30,    4,   55,    4,            3,    3,    4,    3,    // 143
-      30,    4,   58,    4,            3,    3,    4,    3,    // 151
-       2,    1,   19,    5,          -999
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+    1102158234,   29,    3,   36,            5,    6,    3,    0,    // 15
+      29,    3,   36,    6,            6,    3,    0,   51,    // 23
+       0,   27,    3,    1,            1,    2,   36,    7,    // 31
+       6,    2,    0,    7,            3,   29,    3,    6,    // 39
+       3, 1110546842,   30,    4,           62,    4,    3,    3,    // 47
+       4,    3,   29,    3,           36,    8,    6,    3,    // 55
+       1,   51,    0,   26,            3,    1,    1,    1,    // 63
+      36,    9,    6,    2,            0,    7,    3,   29,    // 71
+       3,   51,   19,    7,            3,   30,    4,   15,    // 79
+       4,    3,    3,    4,            3,   70,   19,    6,    // 87
+       2,    0,    7,    3,           29,    3,   51,   19,    // 95
+       7,    3,   30,    4,           16,    4,    3,    3,    // 103
+       4,    3,   29,    3,           36,   10,    6,    2,    // 111
+       0,    7,    3,   29,            3,   51,   23,    7,    // 119
+       3,   29,    3,    6,            2,    0,    7,    3,    // 127
+      29,    3,   51,   31,            7,    3,   30,    4,    // 135
+      56,    4,    3,    3,            4,    3,   30,    4,    // 143
+      55,    4,    3,    3,            4,    3,   30,    4,    // 151
+      58,    4,    3,    3,            4,    3,    2,    1,    // 159
+      19,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -439,7 +456,7 @@ TEST_F(Bytecode0, Float04) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      24,   54,   77,  106,        119,  -999
+      34,   68,   89,  112,        125,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,  '\0'
@@ -461,7 +478,7 @@ TEST_F(Bytecode0, Float04) {
 
 TEST_F(Bytecode0, FlowIfThenElse1) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo()               \n\
     {                       \n\
         readonly int vier = 4; \n\
@@ -477,23 +494,26 @@ TEST_F(Bytecode0, FlowIfThenElse1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowIfThenElse1", scrip);
-    size_t const codesize = 100;
+
+    size_t const codesize = 114;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            4,   29,    3,    6,    // 7
-       3,   15,   29,    3,           51,    8,    7,    3,    // 15
-      29,    3,    6,    3,            2,   30,    4,    9,    // 23
-       4,    3,    3,    4,            3,   30,    4,   12,    // 31
-       4,    3,    3,    4,            3,   29,    3,   51,    // 39
-       4,    7,    3,   29,            3,    6,    3,    5,    // 47
-      30,    4,   18,    4,            3,    3,    4,    3,    // 55
-      28,   18,    6,    3,            2,   29,    3,   51,    // 63
-       8,    7,    3,   30,            4,   44,    3,    4,    // 71
-       8,    3,   31,   16,            6,    3,    3,   29,    // 79
-       3,   51,    8,    7,            3,   30,    4,   43,    // 87
-       3,    4,    8,    3,           51,    4,    7,    3,    // 95
-       2,    1,    8,    5,          -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       4,   29,    3,   36,            4,    6,    3,   15,    // 15
+      29,    3,   51,    8,            7,    3,   29,    3,    // 23
+       6,    3,    2,   30,            4,    9,    4,    3,    // 31
+       3,    4,    3,   30,            4,   12,    4,    3,    // 39
+       3,    4,    3,   29,            3,   36,    5,   51,    // 47
+       4,    7,    3,   29,            3,    6,    3,    5,    // 55
+      30,    4,   18,    4,            3,    3,    4,    3,    // 63
+      28,   20,   36,    6,            6,    3,    2,   29,    // 71
+       3,   51,    8,    7,            3,   30,    4,   44,    // 79
+       3,    4,    8,    3,           31,   18,   36,    8,    // 87
+       6,    3,    3,   29,            3,   51,    8,    7,    // 95
+       3,   30,    4,   43,            3,    4,    8,    3,    // 103
+      36,    9,   51,    4,            7,    3,    2,    1,    // 111
+       8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -515,7 +535,7 @@ TEST_F(Bytecode0, FlowIfThenElse1) {
 
 TEST_F(Bytecode0, FlowIfThenElse2) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo()               \n\
     {                       \n\
         readonly int deux = 2; \n\
@@ -531,23 +551,26 @@ TEST_F(Bytecode0, FlowIfThenElse2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowIfThenElse2", scrip);
-    size_t const codesize = 100;
+
+    size_t const codesize = 114;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            2,   29,    3,    6,    // 7
-       3,   15,   29,    3,            6,    3,    4,   29,    // 15
-       3,   51,   12,    7,            3,   30,    4,   40,    // 23
-       4,    3,    3,    4,            3,   30,    4,   12,    // 31
-       4,    3,    3,    4,            3,   29,    3,   51,    // 39
-       4,    7,    3,   29,            3,    6,    3,    5,    // 47
-      30,    4,   19,    4,            3,    3,    4,    3,    // 55
-      28,   18,    6,    3,            2,   29,    3,   51,    // 63
-       8,    7,    3,   30,            4,   12,    3,    4,    // 71
-       8,    3,   31,   16,            6,    3,    3,   29,    // 79
-       3,   51,    8,    7,            3,   30,    4,   11,    // 87
-       3,    4,    8,    3,           51,    4,    7,    3,    // 95
-       2,    1,    8,    5,          -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       2,   29,    3,   36,            4,    6,    3,   15,    // 15
+      29,    3,    6,    3,            4,   29,    3,   51,    // 23
+      12,    7,    3,   30,            4,   40,    4,    3,    // 31
+       3,    4,    3,   30,            4,   12,    4,    3,    // 39
+       3,    4,    3,   29,            3,   36,    5,   51,    // 47
+       4,    7,    3,   29,            3,    6,    3,    5,    // 55
+      30,    4,   19,    4,            3,    3,    4,    3,    // 63
+      28,   20,   36,    6,            6,    3,    2,   29,    // 71
+       3,   51,    8,    7,            3,   30,    4,   12,    // 79
+       3,    4,    8,    3,           31,   18,   36,    8,    // 87
+       6,    3,    3,   29,            3,   51,    8,    7,    // 95
+       3,   30,    4,   11,            3,    4,    8,    3,    // 103
+      36,    9,   51,    4,            7,    3,    2,    1,    // 111
+       8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -569,7 +592,7 @@ TEST_F(Bytecode0, FlowIfThenElse2) {
 
 TEST_F(Bytecode0, FlowWhile) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         char c = 'x';             \n\
         int Foo(int i, float f)   \n\
         {                         \n\
@@ -578,7 +601,8 @@ TEST_F(Bytecode0, FlowWhile) {
             {                     \n\
                 sum += (500 & c); \n\
                 c--;              \n\
-                if (c == 1) continue; \n\
+                if (c == 1)       \n\
+                    continue;     \n\
             }                     \n\
             return sum;           \n\
         }";
@@ -587,23 +611,26 @@ TEST_F(Bytecode0, FlowWhile) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowWhile", scrip);
-    size_t const codesize = 100;
+
+    size_t const codesize = 114;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       2,    0,   24,    3,           29,    3,    6,    3,    // 15
-       0,   30,    4,   19,            4,    3,    3,    4,    // 23
-       3,   28,   65,    6,            3,  500,   29,    3,    // 31
-       6,    2,    0,   24,            3,   30,    4,   13,    // 39
-       4,    3,    3,    4,            3,   29,    3,   51,    // 47
-       8,    7,    3,   30,            4,   11,    3,    4,    // 55
-       8,    3,    6,    2,            0,   24,    3,    2,    // 63
-       3,    1,   26,    3,            6,    2,    0,   24,    // 71
-       3,   29,    3,    6,            3,    1,   30,    4,    // 79
-      15,    4,    3,    3,            4,    3,   28,    2,    // 87
-      31,  -83,   31,  -85,           51,    4,    7,    3,    // 95
-       2,    1,    4,    5,          -999
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+       0,   29,    3,   36,            5,    6,    2,    0,    // 15
+      24,    3,   29,    3,            6,    3,    0,   30,    // 23
+       4,   19,    4,    3,            3,    4,    3,   28,    // 31
+      71,   36,    7,    6,            3,  500,   29,    3,    // 39
+       6,    2,    0,   24,            3,   30,    4,   13,    // 47
+       4,    3,    3,    4,            3,   29,    3,   51,    // 55
+       8,    7,    3,   30,            4,   11,    3,    4,    // 63
+       8,    3,   36,    8,            6,    2,    0,   24,    // 71
+       3,    2,    3,    1,           26,    3,   36,    9,    // 79
+       6,    2,    0,   24,            3,   29,    3,    6,    // 87
+       3,    1,   30,    4,           15,    4,    3,    3,    // 95
+       4,    3,   28,    2,           31,  -91,   31,  -93,    // 103
+      36,   12,   51,    4,            7,    3,    2,    1,    // 111
+       4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -611,7 +638,7 @@ TEST_F(Bytecode0, FlowWhile) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,   34,   60,   70,        -999
+      15,   42,   70,   82,        -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,     '\0'
@@ -633,9 +660,10 @@ TEST_F(Bytecode0, FlowWhile) {
 
 TEST_F(Bytecode0, FlowWhileTrue)
 {
+
     // Mustn't short-circuit the 'while()' body
 
-    const char *inpl = "\n\
+    char const *inpl = "\
         enum bool { false = 0, true }; \n\
         int main()          \n\
         {                   \n\
@@ -645,16 +673,19 @@ TEST_F(Bytecode0, FlowWhileTrue)
             }               \n\
         }                   \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowWhileTrue", scrip);
-    size_t const codesize = 16;
+
+    size_t const codesize = 24;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,    2,    // 7
-       1,    4,   31,  -10,            6,    3,    0,    5,    // 15
+      36,    3,   38,    0,           36,    6,    6,    3,    // 7
+       5,   29,    3,   36,            7,    2,    1,    4,    // 15
+      31,  -14,   36,    8,            6,    3,    0,    5,    // 23
      -999
     };
     CompareCode(&scrip, codesize, code);
@@ -677,9 +708,10 @@ TEST_F(Bytecode0, FlowWhileTrue)
 
 TEST_F(Bytecode0, FlowDoWhileFalse)
 {
+
     // Don't emit back jump
 
-    const char *inpl = "\n\
+    char const *inpl = "\
         enum bool { false = 0, true }; \n\
         int main()              \n\
         {                       \n\
@@ -690,17 +722,20 @@ TEST_F(Bytecode0, FlowDoWhileFalse)
             } while (false);    \n\
         }                       \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowDoWhileFalse", scrip);
-    size_t const codesize = 19;
+
+    size_t const codesize = 29;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,    2,    // 7
-       1,    4,   31,  -10,            2,    1,    4,    6,    // 15
-       3,    0,    5,  -999
+      36,    3,   38,    0,           36,    6,    6,    3,    // 7
+       5,   29,    3,   36,            7,    2,    1,    4,    // 15
+      31,  -14,   36,    8,            2,    1,    4,   36,    // 23
+       9,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -722,7 +757,7 @@ TEST_F(Bytecode0, FlowDoWhileFalse)
 
 TEST_F(Bytecode0, FlowDoNCall) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         char c = 'x';             \n\
         int Foo(int i)            \n\
         {                         \n\
@@ -746,23 +781,26 @@ TEST_F(Bytecode0, FlowDoNCall) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowDoNCall", scrip);
-    size_t const codesize = 107;
+
+    size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,  500,   29,    3,            6,    2,    0,   24,    // 15
-       3,   30,    4,   14,            4,    3,    3,    4,    // 23
-       3,   29,    3,   51,            8,    7,    3,   30,    // 31
-       4,   12,    3,    4,            8,    3,    6,    2,    // 39
-       0,   24,    3,    2,            3,    1,   26,    3,    // 47
-       6,    2,    0,   24,            3,   29,    3,    6,    // 55
-       3,    0,   30,    4,           17,    4,    3,    3,    // 63
-       4,    3,   70,  -61,           51,    4,    7,    3,    // 71
-       2,    1,    4,    5,           38,   76,   51,    8,    // 79
-       7,    3,   29,    3,           51,   12,    7,    3,    // 87
-      30,    4,   41,    4,            3,    3,    4,    3,    // 95
-      29,    3,    6,    3,            0,   23,    3,    2,    // 103
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+       0,   29,    3,   36,            7,    6,    3,  500,    // 15
+      29,    3,    6,    2,            0,   24,    3,   30,    // 23
+       4,   14,    4,    3,            3,    4,    3,   29,    // 31
+       3,   51,    8,    7,            3,   30,    4,   12,    // 39
+       3,    4,    8,    3,           36,    8,    6,    2,    // 47
+       0,   24,    3,    2,            3,    1,   26,    3,    // 55
+      36,   10,    6,    2,            0,   24,    3,   29,    // 63
+       3,    6,    3,    0,           30,    4,   17,    4,    // 71
+       3,    3,    4,    3,           70,  -67,   36,   11,    // 79
+      51,    4,    7,    3,            2,    1,    4,    5,    // 87
+      36,   15,   38,   88,           36,   16,   51,    8,    // 95
+       7,    3,   29,    3,           51,   12,    7,    3,    // 103
+      30,    4,   41,    4,            3,    3,    4,    3,    // 111
+      29,    3,    6,    3,            0,   23,    3,    2,    // 119
        1,    4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -771,7 +809,7 @@ TEST_F(Bytecode0, FlowDoNCall) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      14,   40,   50,  100,        -999
+      20,   48,   60,  116,        -999
     };
     char fixuptypes[] = {
       1,   1,   1,   2,     '\0'
@@ -793,7 +831,7 @@ TEST_F(Bytecode0, FlowDoNCall) {
 
 TEST_F(Bytecode0, FlowDoUnbracedIf) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
     void noloopcheck main()   \n\
     {                         \n\
         int sum = 0;          \n\
@@ -810,77 +848,82 @@ TEST_F(Bytecode0, FlowDoUnbracedIf) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowDoUnbracedIf", scrip);
-    const size_t codesize = 70;
+
+    size_t const codesize = 84;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   68,    6,            3,    0,   29,    3,    // 7
-      51,    4,    7,    3,           29,    3,    6,    3,    // 15
-     100,   30,    4,   18,            4,    3,    3,    4,    // 23
-       3,   28,   18,    6,            3,   10,   29,    3,    // 31
-      51,    8,    7,    3,           30,    4,   11,    3,    // 39
-       4,    8,    3,   31,            2,   31,   19,   51,    // 47
-       4,    7,    3,   29,            3,    6,    3,   -1,    // 55
-      30,    4,   19,    4,            3,    3,    4,    3,    // 63
-      70,  -58,    2,    1,            4,    5,  -999
+      36,    2,   38,    0,           68,   36,    3,    6,    // 7
+       3,    0,   29,    3,           36,    5,   51,    4,    // 15
+       7,    3,   29,    3,            6,    3,  100,   30,    // 23
+       4,   18,    4,    3,            3,    4,    3,   28,    // 31
+      20,   36,    6,    6,            3,   10,   29,    3,    // 39
+      51,    8,    7,    3,           30,    4,   11,    3,    // 47
+       4,    8,    3,   31,            4,   36,    8,   31,    // 55
+      21,   36,    9,   51,            4,    7,    3,   29,    // 63
+       3,    6,    3,   -1,           30,    4,   19,    4,    // 71
+       3,    3,    4,    3,           70,  -66,   36,   10,    // 79
+       2,    1,    4,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 
 TEST_F(Bytecode0, FlowFor1) {  
 
-    const char *inpl = "\
-    int loop;                       \n\
-    int Foo(int i, float f)         \n\
-    {                               \n\
-        for (loop = 0; loop < 10; loop += 3)  \n\
-        {                           \n\
-            int sum = loop - 4 - 7; \n\
-            if (loop == 6)          \n\
-                break;              \n\
-        }                           \n\
-        return 0;                   \n\
-    }";
+    char const *inpl = "\
+        int loop;                       \n\
+        int Foo(int i, float f)         \n\
+        {                               \n\
+            for (loop = 0; loop < 10; loop += 3)  \n\
+            {                           \n\
+                int sum = loop - 4 - 7; \n\
+                if (loop == 6)          \n\
+                    break;              \n\
+            }                           \n\
+            return 0;                   \n\
+        }";
     
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor1", scrip);
-    size_t const codesize = 114;
+    size_t const codesize = 134;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,    6,    2,    0,    // 7
-       8,    3,    6,    2,            0,    7,    3,   29,    // 15
-       3,    6,    3,   10,           30,    4,   18,    4,    // 23
-       3,    3,    4,    3,           28,   80,    6,    2,    // 31
-       0,    7,    3,   29,            3,    6,    3,    4,    // 39
-      30,    4,   12,    4,            3,    3,    4,    3,    // 47
-      29,    3,    6,    3,            7,   30,    4,   12,    // 55
-       4,    3,    3,    4,            3,   29,    3,    6,    // 63
-       2,    0,    7,    3,           29,    3,    6,    3,    // 71
-       6,   30,    4,   15,            4,    3,    3,    4,    // 79
-       3,   28,    5,    2,            1,    4,   31,   22,    // 87
-       2,    1,    4,    6,            3,    3,   29,    3,    // 95
-       6,    2,    0,    7,            3,   30,    4,   11,    // 103
-       3,    4,    8,    3,           31, -100,    6,    3,    // 111
-       0,    5,  -999
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+       0,    6,    2,    0,            8,    3,   31,   19,    // 15
+      36,    4,    6,    3,            3,   29,    3,    6,    // 23
+       2,    0,    7,    3,           30,    4,   11,    3,    // 31
+       4,    8,    3,   36,            4,    6,    2,    0,    // 39
+       7,    3,   29,    3,            6,    3,   10,   30,    // 47
+       4,   18,    4,    3,            3,    4,    3,   28,    // 55
+      71,   36,    6,    6,            2,    0,    7,    3,    // 63
+      29,    3,    6,    3,            4,   30,    4,   12,    // 71
+       4,    3,    3,    4,            3,   29,    3,    6,    // 79
+       3,    7,   30,    4,           12,    4,    3,    3,    // 87
+       4,    3,   29,    3,           36,    7,    6,    2,    // 95
+       0,    7,    3,   29,            3,    6,    3,    6,    // 103
+      30,    4,   15,    4,            3,    3,    4,    3,    // 111
+      28,    7,   36,    8,            2,    1,    4,   31,    // 119
+       7,   36,    9,    2,            1,    4,   31, -112,    // 127
+      36,   10,    6,    3,            0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -888,7 +931,7 @@ TEST_F(Bytecode0, FlowFor1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   12,   32,   65,         98,  -999
+      11,   25,   39,   61,         96,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,  '\0'
@@ -910,7 +953,7 @@ TEST_F(Bytecode0, FlowFor1) {
 
 TEST_F(Bytecode0, FlowFor2) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo(int i, float f)         \n\
     {                               \n\
         int lp, sum;                \n\
@@ -935,47 +978,51 @@ TEST_F(Bytecode0, FlowFor2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor2", scrip);
-    size_t const codesize = 300;
+
+    size_t const codesize = 324;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,    0,   29,    3,            6,    3,    1,   28,    // 15
-      35,   51,    8,    7,            3,   29,    3,   51,    // 23
-       8,    7,    3,   30,            4,   11,    3,    4,    // 31
-       8,    3,    6,    3,            1,   29,    3,   51,    // 39
-      12,    7,    3,   30,            4,   11,    3,    4,    // 47
-       8,    3,   31,  -40,            6,    3,    1,   28,    // 55
-      19,   51,    8,    7,            3,   29,    3,   51,    // 63
-       8,    7,    3,   30,            4,   12,    3,    4,    // 71
-       8,    3,   31,  -24,           51,    8,    7,    3,    // 79
-      29,    3,    6,    3,            2,   30,    4,   18,    // 87
-       4,    3,    3,    4,            3,   28,   35,   51,    // 95
-       8,    7,    3,   29,            3,   51,    8,    7,    // 103
-       3,   30,    4,    9,            3,    4,    8,    3,    // 111
-       6,    3,    3,   29,            3,   51,   12,    7,    // 119
-       3,   30,    4,   11,            3,    4,    8,    3,    // 127
-      31,  -54,   51,    8,            7,    3,   29,    3,    // 135
-       6,    3,    4,   30,            4,   18,    4,    3,    // 143
-       3,    4,    3,   28,           19,   51,    8,    7,    // 151
-       3,   29,    3,   51,            8,    7,    3,   30,    // 159
-       4,   10,    3,    4,            8,    3,   31,  -38,    // 167
-       6,    3,    5,   51,            8,    8,    3,    6,    // 175
-       3,    1,   28,   35,           51,    8,    7,    3,    // 183
-      29,    3,   51,    8,            7,    3,   30,    4,    // 191
-      10,    3,    4,    8,            3,    6,    3,    6,    // 199
-      29,    3,   51,   12,            7,    3,   30,    4,    // 207
-      11,    3,    4,    8,            3,   31,  -40,    6,    // 215
-       3,    7,   29,    3,            6,    3,    1,   28,    // 223
-      19,   51,    4,    7,            3,   29,    3,   51,    // 231
-      12,    7,    3,   30,            4,   13,    3,    4,    // 239
-       8,    3,   31,  -24,            2,    1,    4,    6,    // 247
-       3,    8,   29,    3,           51,    4,    7,    3,    // 255
-      29,    3,    6,    3,            9,   30,    4,   18,    // 263
-       4,    3,    3,    4,            3,   28,   19,   51,    // 271
-       4,    7,    3,   29,            3,   51,   12,    7,    // 279
-       3,   30,    4,   14,            3,    4,    8,    3,    // 287
-      31,  -38,    2,    1,            4,    6,    3,    0,    // 295
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,    6,            3,    0,   29,    3,    // 15
+      31,   18,   36,    4,            6,    3,    1,   29,    // 23
+       3,   51,   12,    7,            3,   30,    4,   11,    // 31
+       3,    4,    8,    3,           36,    5,   51,    8,    // 39
+       7,    3,   29,    3,           51,    8,    7,    3,    // 47
+      30,    4,   11,    3,            4,    8,    3,   31,    // 55
+     -39,   36,    7,   51,            8,    7,    3,   29,    // 63
+       3,   51,    8,    7,            3,   30,    4,   12,    // 71
+       3,    4,    8,    3,           31,  -21,   31,   18,    // 79
+      36,    8,    6,    3,            3,   29,    3,   51,    // 87
+      12,    7,    3,   30,            4,   11,    3,    4,    // 95
+       8,    3,   36,    8,           51,    8,    7,    3,    // 103
+      29,    3,    6,    3,            2,   30,    4,   18,    // 111
+       4,    3,    3,    4,            3,   28,   21,   36,    // 119
+       9,   51,    8,    7,            3,   29,    3,   51,    // 127
+       8,    7,    3,   30,            4,    9,    3,    4,    // 135
+       8,    3,   31,  -60,           36,   10,   51,    8,    // 143
+       7,    3,   29,    3,            6,    3,    4,   30,    // 151
+       4,   18,    4,    3,            3,    4,    3,   28,    // 159
+      21,   36,   11,   51,            8,    7,    3,   29,    // 167
+       3,   51,    8,    7,            3,   30,    4,   10,    // 175
+       3,    4,    8,    3,           31,  -42,   36,   12,    // 183
+       6,    3,    5,   51,            8,    8,    3,   31,    // 191
+      18,   36,   12,    6,            3,    6,   29,    3,    // 199
+      51,   12,    7,    3,           30,    4,   11,    3,    // 207
+       4,    8,    3,   36,           13,   51,    8,    7,    // 215
+       3,   29,    3,   51,            8,    7,    3,   30,    // 223
+       4,   10,    3,    4,            8,    3,   31,  -39,    // 231
+      36,   14,    6,    3,            7,   29,    3,   36,    // 239
+      15,   51,    4,    7,            3,   29,    3,   51,    // 247
+      12,    7,    3,   30,            4,   13,    3,    4,    // 255
+       8,    3,   31,  -21,            2,    1,    4,   36,    // 263
+      16,    6,    3,    8,           29,    3,   36,   16,    // 271
+      51,    4,    7,    3,           29,    3,    6,    3,    // 279
+       9,   30,    4,   18,            4,    3,    3,    4,    // 287
+       3,   28,   21,   36,           17,   51,    4,    7,    // 295
+       3,   29,    3,   51,           12,    7,    3,   30,    // 303
+       4,   14,    3,    4,            8,    3,   31,  -42,    // 311
+       2,    1,    4,   36,           18,    6,    3,    0,    // 319
        2,    1,    8,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
@@ -998,7 +1045,7 @@ TEST_F(Bytecode0, FlowFor2) {
 
 TEST_F(Bytecode0, FlowFor3) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct           \n\
     {                               \n\
         float Payload[1];           \n\
@@ -1019,17 +1066,19 @@ TEST_F(Bytecode0, FlowFor3) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor3", scrip);
-    size_t const codesize = 51;
+    size_t const codesize = 56;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           49,    1,    1,    4,    // 7
-       6,    3,    1,   28,           28,   51,    4,   48,    // 15
-       3,   29,    3,    6,            2,    0,   48,    3,    // 23
-      30,    4,   15,    4,            3,    3,    4,    3,    // 31
-      51,    4,   49,    2,            1,    4,    5,   31,    // 39
-     -33,   51,    4,   49,            2,    1,    4,    6,    // 47
-       3,   -7,    5,  -999
+      36,    8,   38,    0,
+      36,    9,   51,    0,    // 7
+      49,    1,    1,    4,           36,   11,   51,    4,    // 15
+      48,    3,   29,    3,            6,    2,    0,   48,    // 23
+       3,   30,    4,   15,            4,    3,    3,    4,    // 31
+       3,   51,    4,   49,            2,    1,    4,    5,    // 39
+      31,  -30,   36,   12,           51,    4,   49,    2,    // 47
+       1,    4,   36,   13,            6,    3,   -7,    5,    // 55
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1037,7 +1086,7 @@ TEST_F(Bytecode0, FlowFor3) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      21,  -999
+      22,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -1059,7 +1108,7 @@ TEST_F(Bytecode0, FlowFor3) {
 
 TEST_F(Bytecode0, FlowFor4) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     void main()                     \n\
     {                               \n\
         for (int Loop = 0; Loop < 10; Loop++)  \n\
@@ -1072,41 +1121,43 @@ TEST_F(Bytecode0, FlowFor4) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor4", scrip);
-    const size_t codesize = 71;
+
+    size_t const codesize = 78;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,   51,    // 7
-       4,    7,    3,   29,            3,    6,    3,   10,    // 15
-      30,    4,   18,    4,            3,    3,    4,    3,    // 23
-      28,   41,   51,    4,            7,    3,   29,    3,    // 31
-       6,    3,    5,   30,            4,   15,    4,    3,    // 39
-       3,    4,    3,   28,           11,   51,    4,    7,    // 47
-       3,    1,    3,    1,            8,    3,   31,  -49,    // 55
-      51,    4,    7,    3,            1,    3,    1,    8,    // 63
-       3,   31,  -60,    2,            1,    4,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   31,           11,   36,    3,   51,    // 15
+       4,    7,    3,    1,            3,    1,    8,    3,    // 23
+      36,    3,   51,    4,            7,    3,   29,    3,    // 31
+       6,    3,   10,   30,            4,   18,    4,    3,    // 39
+       3,    4,    3,   28,           25,   36,    4,   51,    // 47
+       4,    7,    3,   29,            3,    6,    3,    5,    // 55
+      30,    4,   15,    4,            3,    3,    4,    3,    // 63
+      28,    2,   31,  -55,           31,  -57,   36,    5,    // 71
+       2,    1,    4,   36,            6,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode0, FlowFor5) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Start()                     \n\
         {                               \n\
             return 1;                   \n\
@@ -1133,37 +1184,39 @@ TEST_F(Bytecode0, FlowFor5) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor5", scrip);
-    size_t const codesize = 125;
+
+    size_t const codesize = 135;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            1,    5,   38,    6,    // 7
-       6,    3,   10,    5,           38,   12,   51,    8,    // 15
-       7,    3,   29,    3,            6,    3,    1,   30,    // 23
-       4,   11,    4,    3,            3,    4,    3,    5,    // 31
-      38,   32,    6,    3,            0,   23,    3,   29,    // 39
-       3,   51,    4,    7,            3,   29,    3,    6,    // 47
-       3,    6,   23,    3,           30,    4,   18,    4,    // 55
-       3,    3,    4,    3,           28,   59,   51,    4,    // 63
-       7,    3,   29,    3,            6,    3,    0,   30,    // 71
-       4,   19,    4,    3,            3,    4,    3,   28,    // 79
-      20,   51,    4,    7,            3,   29,    3,    6,    // 87
-       3,   12,   23,    3,            2,    1,    4,   51,    // 95
-       4,    8,    3,   31,          -60,   51,    4,    7,    // 103
-       3,   29,    3,    6,            3,   12,   23,    3,    // 111
-       2,    1,    4,   51,            4,    8,    3,   31,    // 119
-     -80,    2,    1,    4,            5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       1,    5,   36,    6,           38,   10,   36,    7,    // 15
+       6,    3,   10,    5,           36,   10,   38,   20,    // 23
+      36,   11,   51,    8,            7,    3,   29,    3,    // 31
+       6,    3,    1,   30,            4,   11,    4,    3,    // 39
+       3,    4,    3,    5,           36,   15,   38,   44,    // 47
+      36,   16,    6,    3,            0,   23,    3,   29,    // 55
+       3,   31,   20,   36,           16,   51,    4,    7,    // 63
+       3,   29,    3,    6,            3,   20,   23,    3,    // 71
+       2,    1,    4,   51,            4,    8,    3,   36,    // 79
+      16,   51,    4,    7,            3,   29,    3,    6,    // 87
+       3,   10,   23,    3,           30,    4,   18,    4,    // 95
+       3,    3,    4,    3,           28,   25,   36,   17,    // 103
+      51,    4,    7,    3,           29,    3,    6,    3,    // 111
+       0,   30,    4,   19,            4,    3,    3,    4,    // 119
+       3,   28,    2,   31,          -66,   31,  -68,   36,    // 127
+      18,    2,    1,    4,           36,   19,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    size_t const numfixups = 4;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      36,   49,   89,  109,        -999
+      52,   69,   89,  -999
     };
     char fixuptypes[] = {
-      2,   2,   2,   2,     '\0'
+      2,   2,   2,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
@@ -1182,7 +1235,7 @@ TEST_F(Bytecode0, FlowFor5) {
 
 TEST_F(Bytecode0, FlowFor6) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         void main()                     \n\
         {                               \n\
             for(int i = Start();        \n\
@@ -1210,37 +1263,39 @@ TEST_F(Bytecode0, FlowFor6) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor6", scrip);
-    size_t const codesize = 125;
+
+    size_t const codesize = 135;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           93,   23,    3,   29,    // 7
-       3,   51,    4,    7,            3,   29,    3,    6,    // 15
-       3,   99,   23,    3,           30,    4,   18,    4,    // 23
-       3,    3,    4,    3,           28,   59,   51,    4,    // 31
-       7,    3,   29,    3,            6,    3,    0,   30,    // 39
-       4,   19,    4,    3,            3,    4,    3,   28,    // 47
-      20,   51,    4,    7,            3,   29,    3,    6,    // 55
-       3,  105,   23,    3,            2,    1,    4,   51,    // 63
-       4,    8,    3,   31,          -60,   51,    4,    7,    // 71
-       3,   29,    3,    6,            3,  105,   23,    3,    // 79
-       2,    1,    4,   51,            4,    8,    3,   31,    // 87
-     -80,    2,    1,    4,            5,   38,   93,    6,    // 95
-       3,    1,    5,   38,           99,    6,    3,   10,    // 103
-       5,   38,  105,   51,            8,    7,    3,   29,    // 111
-       3,    6,    3,    1,           30,    4,   11,    4,    // 119
-       3,    3,    4,    3,            5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      91,   23,    3,   29,            3,   31,   20,   36,    // 15
+       5,   51,    4,    7,            3,   29,    3,    6,    // 23
+       3,  111,   23,    3,            2,    1,    4,   51,    // 31
+       4,    8,    3,   36,            4,   51,    4,    7,    // 39
+       3,   29,    3,    6,            3,  101,   23,    3,    // 47
+      30,    4,   18,    4,            3,    3,    4,    3,    // 55
+      28,   25,   36,    6,           51,    4,    7,    3,    // 63
+      29,    3,    6,    3,            0,   30,    4,   19,    // 71
+       4,    3,    3,    4,            3,   28,    2,   31,    // 79
+     -66,   31,  -68,   36,            7,    2,    1,    4,    // 87
+      36,    8,    5,   36,           10,   38,   91,   36,    // 95
+      11,    6,    3,    1,            5,   36,   14,   38,    // 103
+     101,   36,   15,    6,            3,   10,    5,   36,    // 111
+      18,   38,  111,   36,           19,   51,    8,    7,    // 119
+       3,   29,    3,    6,            3,    1,   30,    4,    // 127
+      11,    4,    3,    3,            4,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    size_t const numfixups = 4;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   17,   57,   77,        -999
+       8,   25,   45,  -999
     };
     char fixuptypes[] = {
-      2,   2,   2,   2,     '\0'
+      2,   2,   2,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
@@ -1261,12 +1316,15 @@ TEST_F(Bytecode0, FlowFor7) {
 
     // Initializer and iterator of a for() need not be assignments,
     // they can be func calls.
+    // Note, an error happened when 'Check()' and 'Cont()' were on
+    // the same line, so leave them on the same line in this test
 
-    const char *inpl = "\
+    char const *inpl = "\
         int i;                          \n\
         void main()                     \n\
         {                               \n\
-            for(Start(); Check(); Cont())   \n\
+            for (Start();               \n\
+                 Check(); Cont())       \n\
                 if (i >= 5)             \n\
                     i = 100 - i;        \n\
         }                               \n\
@@ -1290,24 +1348,29 @@ TEST_F(Bytecode0, FlowFor7) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowFor7", scrip);
-    size_t const codesize = 113;
+
+    size_t const codesize = 145;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           65,   23,    3,    6,    // 7
-       3,   79,   23,    3,           28,   50,    6,    2,    // 15
-       0,    7,    3,   29,            3,    6,    3,    5,    // 23
-      30,    4,   19,    4,            3,    3,    4,    3,    // 31
-      28,   23,    6,    3,          100,   29,    3,    6,    // 39
-       2,    0,    7,    3,           30,    4,   12,    4,    // 47
-       3,    3,    4,    3,            6,    2,    0,    8,    // 55
-       3,    6,    3,  100,           23,    3,   31,  -57,    // 63
-       5,   38,   65,    6,            3,    1,    6,    2,    // 71
-       0,    8,    3,    6,            3,  -77,    5,   38,    // 79
-      79,    6,    2,    0,            7,    3,   29,    3,    // 87
-       6,    3,   10,   30,            4,   18,    4,    3,    // 95
-       3,    4,    3,    5,           38,  100,    6,    2,    // 103
-       0,    7,    3,    1,            3,    1,    8,    3,    // 111
+      36,    3,   38,    0,           36,    4,    6,    3,    // 7
+      81,   23,    3,   31,            7,   36,    5,    6,    // 15
+       3,  126,   23,    3,           36,    5,    6,    3,    // 23
+     101,   23,    3,   28,           49,   36,    6,    6,    // 31
+       2,    0,    7,    3,           29,    3,    6,    3,    // 39
+       5,   30,    4,   19,            4,    3,    3,    4,    // 47
+       3,   28,   25,   36,            7,    6,    3,  100,    // 55
+      29,    3,    6,    2,            0,    7,    3,   30,    // 63
+       4,   12,    4,    3,            3,    4,    3,    6,    // 71
+       2,    0,    8,    3,           31,  -65,   36,    8,    // 79
+       5,   36,   10,   38,           81,   36,   11,    6,    // 87
+       3,    1,    6,    2,            0,    8,    3,   36,    // 95
+      12,    6,    3,  -77,            5,   36,   15,   38,    // 103
+     101,   36,   16,    6,            2,    0,    7,    3,    // 111
+      29,    3,    6,    3,           10,   30,    4,   18,    // 119
+       4,    3,    3,    4,            3,    5,   36,   19,    // 127
+      38,  126,   36,   20,            6,    2,    0,    7,    // 135
+       3,    1,    3,    1,            8,    3,   36,   21,    // 143
        5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -1316,11 +1379,11 @@ TEST_F(Bytecode0, FlowFor7) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,    9,   16,   41,         54,   59,   72,   83,    // 7
-     104,  -999
+       8,   17,   24,   33,         60,   73,   92,  109,    // 7
+     134,  -999
     };
     char fixuptypes[] = {
-      2,   2,   1,   1,      1,   2,   1,   1,    // 7
+      2,   2,   2,   1,      1,   1,   1,   1,    // 7
       1,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
@@ -1344,7 +1407,7 @@ TEST_F(Bytecode0, FlowContinue1) {
     // they remain valid, and so the offset to start of the local block
     // must not be reduced.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                      \n\
         {                               \n\
             int I;                      \n\
@@ -1365,24 +1428,27 @@ TEST_F(Bytecode0, FlowContinue1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowContinue1", scrip);
-    size_t const codesize = 104;
+
+    size_t const codesize = 121;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,   -1,   51,    4,            8,    3,   51,    4,    // 15
-       7,    3,   29,    3,            6,    3,    1,   30,    // 23
-       4,   18,    4,    3,            3,    4,    3,   28,    // 31
-      63,    6,    3,    7,           29,    3,    6,    3,    // 39
-      77,   29,    3,   51,           12,    7,    3,   29,    // 47
-       3,    6,    3,    0,           30,    4,   19,    4,    // 55
-       3,    3,    4,    3,           28,   14,    2,    1,    // 63
-       8,   51,    4,    7,            3,    1,    3,    1,    // 71
-       8,    3,   31,  -62,           51,    8,    7,    3,    // 79
-      29,    3,    2,    1,           12,   51,    4,    7,    // 87
-       3,    1,    3,    1,            8,    3,   31,  -82,    // 95
-      51,    4,    7,    3,            2,    1,    4,    5,    // 103
-     -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            4,    6,    3,   -1,    // 15
+      51,    4,    8,    3,           31,   11,   36,    4,    // 23
+      51,    4,    7,    3,            1,    3,    1,    8,    // 31
+       3,   36,    4,   51,            4,    7,    3,   29,    // 39
+       3,    6,    3,    1,           30,    4,   18,    4,    // 47
+       3,    3,    4,    3,           28,   57,   36,    6,    // 55
+       6,    3,    7,   29,            3,   36,    7,    6,    // 63
+       3,   77,   29,    3,           36,    8,   51,   12,    // 71
+       7,    3,   29,    3,            6,    3,    0,   30,    // 79
+       4,   19,    4,    3,            3,    4,    3,   28,    // 87
+       7,   36,    9,    2,            1,    8,   31,  -74,    // 95
+      36,   10,   51,    8,            7,    3,   29,    3,    // 103
+      36,   11,    2,    1,           12,   31,  -89,   36,    // 111
+      12,   51,    4,    7,            3,    2,    1,    4,    // 119
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1404,7 +1470,7 @@ TEST_F(Bytecode0, FlowContinue1) {
 
 TEST_F(Bytecode0, FlowIfDoWhile) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo(int i, float f)                      \n\
     {                                            \n\
         int five = 5, sum, loop = -2;            \n\
@@ -1423,32 +1489,35 @@ TEST_F(Bytecode0, FlowIfDoWhile) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowIfDoWhile", scrip);
-    size_t const codesize = 168;
+
+    size_t const codesize = 190;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,    6,    // 7
-       3,    0,   29,    3,            6,    3,   -2,   29,    // 15
-       3,   51,   12,    7,            3,   29,    3,    6,    // 23
-       3,   10,   30,    4,           18,    4,    3,    3,    // 31
-       4,    3,   28,   90,            6,    3,    0,   51,    // 39
-       4,    8,    3,   51,            4,    7,    3,   29,    // 47
-       3,    6,    3,   10,           30,    4,   18,    4,    // 55
-       3,    3,    4,    3,           28,   62,   51,    4,    // 63
-       7,    3,   29,    3,           51,   12,    7,    3,    // 71
-      30,    4,   11,    3,            4,    8,    3,   51,    // 79
-       4,    7,    3,   29,            3,    6,    3,    6,    // 87
-      30,    4,   15,    4,            3,    3,    4,    3,    // 95
-      28,    8,   51,    4,            7,    3,    2,    1,    // 103
-      12,    5,    6,    3,            3,   29,    3,   51,    // 111
-       8,    7,    3,   30,            4,   11,    3,    4,    // 119
-       8,    3,   31,  -81,           31,   35,    6,    3,    // 127
-       1,   29,    3,   51,            8,    7,    3,   30,    // 135
-       4,   11,    3,    4,            8,    3,   51,    4,    // 143
-       7,    3,   29,    3,            6,    3,  100,   30,    // 151
-       4,   18,    4,    3,            3,    4,    3,   70,    // 159
-     -35,    6,    3,    0,            2,    1,   12,    5,    // 167
-     -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   29,    3,    6,            3,    0,   29,    3,    // 15
+       6,    3,   -2,   29,            3,   36,    4,   51,    // 23
+      12,    7,    3,   29,            3,    6,    3,   10,    // 31
+      30,    4,   18,    4,            3,    3,    4,    3,    // 39
+      28,  102,   36,    5,            6,    3,    0,   51,    // 47
+       4,    8,    3,   31,           18,   36,    5,    6,    // 55
+       3,    3,   29,    3,           51,    8,    7,    3,    // 63
+      30,    4,   11,    3,            4,    8,    3,   36,    // 71
+       5,   51,    4,    7,            3,   29,    3,    6,    // 79
+       3,   10,   30,    4,           18,    4,    3,    3,    // 87
+       4,    3,   28,   50,           36,    7,   51,    4,    // 95
+       7,    3,   29,    3,           51,   12,    7,    3,    // 103
+      30,    4,   11,    3,            4,    8,    3,   36,    // 111
+       8,   51,    4,    7,            3,   29,    3,    6,    // 119
+       3,    6,   30,    4,           15,    4,    3,    3,    // 127
+       4,    3,   28,    8,           51,    4,    7,    3,    // 135
+       2,    1,   12,    5,           31,  -89,   31,   37,    // 143
+      36,   11,    6,    3,            1,   29,    3,   51,    // 151
+       8,    7,    3,   30,            4,   11,    3,    4,    // 159
+       8,    3,   51,    4,            7,    3,   29,    3,    // 167
+       6,    3,  100,   30,            4,   18,    4,    3,    // 175
+       3,    4,    3,   70,          -37,   36,   12,    6,    // 183
+       3,    0,    2,    1,           12,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1472,7 +1541,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
 
     // The "break;" in line 6 is unreachable code
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo(int i, float f)         \n\
     {                               \n\
         switch (i * i)              \n\
@@ -1489,8 +1558,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
     }";
 
     MessageHandler mh;
-    FlagSet options = SCOPT_LINENUMBERS;
-    int compileResult = cc_compile(inpl, options, scrip, mh);
+    int compileResult = cc_compile(inpl, AGS::FlagSet{ 0 }, scrip, mh);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
     // Line 6: Can't reach this point.
     ASSERT_LE(2u, mh.GetMessages().size());
@@ -1501,28 +1569,33 @@ TEST_F(Bytecode0, FlowSwitch01) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(1).Message.find("break"));
 
     // WriteOutput("FlowSwitch01", scrip);
-    size_t const codesize = 142;
+
+    size_t const codesize = 170;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-      51,   12,    7,    3,           30,    4,    9,    4,    // 15
-       3,    3,    4,    3,            3,    3,    4,   31,    // 23
-      79,    6,    3,   10,            5,   31,  107,    6,    // 31
-       3,    2,   29,    3,           51,   12,    7,    3,    // 39
-      30,    4,    9,    3,            4,    8,    3,   51,    // 47
-       8,    7,    3,    5,            6,    3,    0,   51,    // 55
-       8,    8,    3,    6,            3,    5,   29,    3,    // 63
-      51,   12,    7,    3,           30,    4,   12,    4,    // 71
-       3,    3,    4,    3,           29,    3,    6,    3,    // 79
-       4,   30,    4,   12,            4,    3,    3,    4,    // 87
-       3,   29,    3,   51,           12,    7,    3,   30,    // 95
-       4,   11,    3,    4,            8,    3,   31,   34,    // 103
-       6,    3,    2,   15,            3,    4,   70,  -87,    // 111
-       6,    3,    3,   15,            3,    4,   70,  -68,    // 119
-       6,    3,    4,   15,            3,    4,   70,  -76,    // 127
-       6,    3,    5,   15,            3,    4,   70,  -77,    // 135
-      31, -107,    6,    3,            0,    5,  -999
+      36,    2,   38,    0,           36,    3,   51,    8,    // 7
+       7,    3,   29,    3,           51,   12,    7,    3,    // 15
+      30,    4,    9,    4,            3,    3,    4,    3,    // 23
+      36,    4,    3,    3,            4,   31,   91,   36,    // 31
+       5,    6,    3,   10,            5,   36,    6,   31,    // 39
+     123,   36,    7,    6,            3,    2,   29,    3,    // 47
+      51,   12,    7,    3,           30,    4,    9,    3,    // 55
+       4,    8,    3,   51,            8,    7,    3,    5,    // 63
+      36,    9,    6,    3,            0,   51,    8,    8,    // 71
+       3,   36,   10,    6,            3,    5,   29,    3,    // 79
+      51,   12,    7,    3,           30,    4,   12,    4,    // 87
+       3,    3,    4,    3,           29,    3,    6,    3,    // 95
+       4,   30,    4,   12,            4,    3,    3,    4,    // 103
+       3,   29,    3,   51,           12,    7,    3,   30,    // 111
+       4,   11,    3,    4,            8,    3,   36,   11,    // 119
+      31,   42,   36,    5,            6,    3,    2,   15,    // 127
+       3,    4,   70, -101,           36,    8,    6,    3,    // 135
+       3,   15,    3,    4,           70,  -78,   36,    9,    // 143
+       6,    3,    4,   15,            3,    4,   70,  -88,    // 151
+      36,   10,    6,    3,            5,   15,    3,    4,    // 159
+      70,  -89,   31, -123,           36,   13,    6,    3,    // 167
+       0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1545,7 +1618,7 @@ TEST_F(Bytecode0, FlowSwitch01) {
 TEST_F(Bytecode0, FlowSwitch02) {
 
     // Last switch clause no "break"
-    const char *inpl = "\
+    char const *inpl = "\
         void main()                     \n\
         {                               \n\
             int i = 5;                  \n\
@@ -1562,15 +1635,18 @@ TEST_F(Bytecode0, FlowSwitch02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch02", scrip);
-    size_t const codesize = 41;
+
+    size_t const codesize = 57;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,   51,    // 7
-       4,    7,    3,    3,            3,    4,   31,   11,    // 15
-      31,   19,    6,    3,            0,   51,    4,    8,    // 23
-       3,   31,   10,    6,            3,    5,   15,    3,    // 31
-       4,   70,  -17,   31,          -21,    2,    1,    4,    // 39
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   29,    3,   36,            5,   51,    4,    7,    // 15
+       3,    3,    3,    4,           31,   17,   36,    6,    // 23
+      31,   25,   36,    7,            6,    3,    0,   51,    // 31
+       4,    8,    3,   36,            8,   31,   12,   36,    // 39
+       7,    6,    3,    5,           15,    3,    4,   70,    // 47
+     -23,   31,  -29,   36,            9,    2,    1,    4,    // 55
        5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -1593,7 +1669,7 @@ TEST_F(Bytecode0, FlowSwitch02) {
 
 TEST_F(Bytecode0, FlowSwitch03) {
     // Last case clause an empty pair of braces
-    const char *inpl = "\
+    char const *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 0;   \n\
@@ -1610,15 +1686,17 @@ TEST_F(Bytecode0, FlowSwitch03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch03", scrip);
-    size_t const codesize = 33;
+
+    size_t const codesize = 45;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,   51,    // 7
-       4,    7,    3,    3,            3,    4,   31,    2,    // 15
-      31,    8,    6,    3,            0,   15,    3,    4,    // 23
-      70,  -10,    2,    1,            4,    6,    3,    0,    // 31
-       5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            5,   51,    4,    7,    // 15
+       3,    3,    3,    4,           31,    4,   36,    9,    // 23
+      31,   10,   36,    6,            6,    3,    0,   15,    // 31
+       3,    4,   70,  -14,           36,   10,    2,    1,    // 39
+       4,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1642,7 +1720,7 @@ TEST_F(Bytecode0, FlowSwitch04) {
 
     // Last case clause an empty pair of braces
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 7;   \n\
@@ -1659,14 +1737,16 @@ TEST_F(Bytecode0, FlowSwitch04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch04", scrip);
-    size_t const codesize = 27;
+
+    size_t const codesize = 37;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   29,    3,   51,    // 7
-       4,    7,    3,    3,            3,    4,   31,    2,    // 15
-      31,    2,   31,   -4,            2,    1,    4,    6,    // 23
-       3,    0,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       7,   29,    3,   36,            5,   51,    4,    7,    // 15
+       3,    3,    3,    4,           31,    4,   36,    9,    // 23
+      31,    2,   31,   -6,           36,   10,    2,    1,    // 31
+       4,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1688,9 +1768,9 @@ TEST_F(Bytecode0, FlowSwitch04) {
 
 TEST_F(Bytecode0, FlowSwitch05) {
 
-    // No default/case clauses (zany but allowed)
+    // No 'default'/'case' clauses (zany but allowed)
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()          \n\
         {                   \n\
             int test = 0;   \n\
@@ -1704,12 +1784,14 @@ TEST_F(Bytecode0, FlowSwitch05) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch05", scrip);
-    size_t const codesize = 14;
+
+    size_t const codesize = 20;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    2,    // 7
-       1,    4,    6,    3,            0,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            7,    2,    1,    4,    // 15
+       6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1733,7 +1815,7 @@ TEST_F(Bytecode0, FlowSwitch06) {
 
     // 'Default' and 'case 77' fall through, compiler should warn about the latter
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()              \n\
         {                       \n\
             int test = 7;       \n\
@@ -1758,19 +1840,22 @@ TEST_F(Bytecode0, FlowSwitch06) {
     EXPECT_EQ(11u, mh.GetMessages().at(0u).Lineno);
 
     // WriteOutput("FlowSwitch06", scrip);
-    size_t const codesize = 65;
+
+    size_t const codesize = 85;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   29,    3,   51,    // 7
-       4,    7,    3,    3,            3,    4,   31,   16,    // 15
-       6,    3,    6,   51,            4,    8,    3,    6,    // 23
-       3,    5,   51,    4,            8,    3,   31,   26,    // 31
-       6,    3,    7,   15,            3,    4,   70,  -17,    // 39
-       6,    3,   77,   15,            3,    4,   70,  -25,    // 47
-       6,    3,  777,   15,            3,    4,   70,  -26,    // 55
-      31,  -42,    2,    1,            4,    6,    3,    0,    // 63
-       5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       7,   29,    3,   36,            5,   51,    4,    7,    // 15
+       3,    3,    3,    4,           31,   22,   36,    7,    // 23
+       6,    3,    6,   51,            4,    8,    3,   36,    // 31
+      11,    6,    3,    5,           51,    4,    8,    3,    // 39
+      36,   13,   31,   32,           36,    9,    6,    3,    // 47
+       7,   15,    3,    4,           70,  -23,   36,   10,    // 55
+       6,    3,   77,   15,            3,    4,   70,  -33,    // 63
+      36,   12,    6,    3,          777,   15,    3,    4,    // 71
+      70,  -34,   31,  -54,           36,   14,    2,    1,    // 79
+       4,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1794,7 +1879,7 @@ TEST_F(Bytecode0, FlowSwitch07) {
 
     // Expression in switch clause
 
-    const char *inpl = "\
+    char const *inpl = "\
         readonly int two = 2;   \n\
         int main()              \n\
         {                       \n\
@@ -1814,20 +1899,23 @@ TEST_F(Bytecode0, FlowSwitch07) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FlowSwitch07", scrip);
-    size_t const codesize = 75;
+
+    size_t const codesize = 93;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,    3,    3,    4,    // 7
-      31,   10,    6,    3,            7,    5,    6,    3,    // 15
-      11,    5,   31,   51,           29,    4,    6,    2,    // 23
-       0,    7,    3,   29,            3,    6,    3,    3,    // 31
-      30,    4,   11,    4,            3,    3,    4,    3,    // 39
-      30,    4,   15,    3,            4,   70,  -37,   29,    // 47
-       4,    6,    3,    0,           23,    3,   30,    4,    // 55
-      15,    3,    4,   70,          -47,    6,    2,    0,    // 63
-       7,    3,   15,    3,            4,   70,  -53,    6,    // 71
-       3,    0,    5,  -999
+      36,    3,   38,    0,           36,    5,    6,    3,    // 7
+       7,    3,    3,    4,           31,   16,   36,    7,    // 15
+       6,    3,    7,    5,           36,    9,    6,    3,    // 23
+      11,    5,   36,   11,           31,   57,   36,    6,    // 31
+      29,    4,    6,    2,            0,    7,    3,   29,    // 39
+       3,    6,    3,    3,           30,    4,   11,    4,    // 47
+       3,    3,    4,    3,           30,    4,   15,    3,    // 55
+       4,   70,  -45,   36,            8,   29,    4,    6,    // 63
+       3,    0,   23,    3,           30,    4,   15,    3,    // 71
+       4,   70,  -55,   36,           10,    6,    2,    0,    // 79
+       7,    3,   15,    3,            4,   70,  -61,   36,    // 87
+      13,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1835,7 +1923,7 @@ TEST_F(Bytecode0, FlowSwitch07) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      24,   51,   63,  -999
+      36,   65,   79,  -999
     };
     char fixuptypes[] = {
       1,   2,   1,  '\0'
@@ -1857,7 +1945,7 @@ TEST_F(Bytecode0, FlowSwitch07) {
 
 TEST_F(Bytecode0, FreeLocalPtr) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct S                  \n\
     {                                 \n\
         int i;                        \n\
@@ -1876,41 +1964,43 @@ TEST_F(Bytecode0, FreeLocalPtr) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("FreeLocalPtr", scrip);
-    const size_t codesize = 67;
+    size_t const codesize = 83;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,            4,   51,    0,   47,    // 7
-       3,    1,    1,    4,            6,    3,    0,   29,    // 15
-       3,   51,    4,    7,            3,   29,    3,    6,    // 23
-       3,   10,   30,    4,           18,    4,    3,    3,    // 31
-       4,    3,   28,   18,           73,    3,    4,   51,    // 39
-       8,   47,    3,   51,            4,    7,    3,    1,    // 47
-       3,    1,    8,    3,           31,  -37,    2,    1,    // 55
-       4,   51,    4,   49,            2,    1,    4,    6,    // 63
+      36,    7,   38,    0,           36,    8,   73,    3,    // 7
+       4,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   10,    6,    3,            0,   29,    3,   31,    // 23
+      11,   36,   10,   51,            4,    7,    3,    1,    // 31
+       3,    1,    8,    3,           36,   10,   51,    4,    // 39
+       7,    3,   29,    3,            6,    3,   10,   30,    // 47
+       4,   18,    4,    3,            3,    4,    3,   28,    // 55
+      11,   36,   11,   73,            3,    4,   51,    8,    // 63
+      47,    3,   31,  -43,            2,    1,    4,   36,    // 71
+      12,   51,    4,   49,            2,    1,    4,    6,    // 79
        3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 0;
+    size_t const numfixups = 0;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode0, Struct01) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     	struct Struct                       \n\
 		{                                   \n\
 			float Float;                    \n\
@@ -1938,26 +2028,30 @@ TEST_F(Bytecode0, Struct01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct01", scrip);
-    size_t const codesize = 123;
+
+    size_t const codesize = 145;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           49,    1,    1,    4,    // 7
-       3,    6,    2,   52,            6,    3,    0,    8,    // 15
-       3,    6,    3,    5,           72,    3,    4,    0,    // 23
-      51,    4,   47,    3,           51,    4,   48,    2,    // 31
-      52,    6,    3,   77,            1,    2,   12,    8,    // 39
-       3,   51,    4,   48,            3,   29,    3,   51,    // 47
-       4,   50,    3,   51,            8,   49,   51,    4,    // 55
-      48,    3,   69,   30,            4,    2,    1,    4,    // 63
-       5,   38,   65,    6,            3,    0,   29,    3,    // 71
-      51,    4,   29,    2,            6,    3,   -1,   29,    // 79
-       3,   51,    8,    7,            2,   45,    2,    6,    // 87
-       3,    0,   23,    3,            2,    1,    4,   30,    // 95
-       2,   51,    0,   47,            3,    1,    1,    4,    // 103
-      51,    4,   48,    2,           52,    1,    2,   12,    // 111
-       7,    3,   29,    3,           51,    8,   49,    2,    // 119
-       1,   12,    5,  -999
+      36,    8,   38,    0,           36,    9,   51,    0,    // 7
+      49,    1,    1,    4,           36,   10,    3,    6,    // 15
+       2,   52,    6,    3,            0,    8,    3,   36,    // 23
+      11,    6,    3,    5,           72,    3,    4,    0,    // 31
+      51,    4,   47,    3,           36,   12,   51,    4,    // 39
+      48,    2,   52,    6,            3,   77,    1,    2,    // 47
+      12,    8,    3,   36,           13,   51,    4,   48,    // 55
+       3,   29,    3,   51,            4,   50,    3,   51,    // 63
+       8,   49,   51,    4,           48,    3,   69,   30,    // 71
+       4,    2,    1,    4,            5,   36,   17,   38,    // 79
+      77,   36,   18,    6,            3,    0,   29,    3,    // 87
+      36,   19,   51,    4,           29,    2,    6,    3,    // 95
+      -1,   29,    3,   51,            8,    7,    2,   45,    // 103
+       2,    6,    3,    0,           23,    3,    2,    1,    // 111
+       4,   30,    2,   51,            0,   47,    3,    1,    // 119
+       1,    4,   36,   20,           51,    4,   48,    2,    // 127
+      52,    1,    2,   12,            7,    3,   29,    3,    // 135
+      36,   21,   51,    8,           49,    2,    1,   12,    // 143
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1965,7 +2059,7 @@ TEST_F(Bytecode0, Struct01) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      89,  -999
+     107,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -1990,7 +2084,7 @@ TEST_F(Bytecode0, Struct02) {
     // test arrays; arrays in structs;
     // whether the namespace in structs is independent of the global namespace
 
-    const char *inpl = "\
+    char const *inpl = "\
     struct Struct1                  \n\
     {                               \n\
         int Array[17], Ix;          \n\
@@ -2012,18 +2106,21 @@ TEST_F(Bytecode0, Struct02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct02", scrip);
-    size_t const codesize = 63;
+
+    size_t const codesize = 75;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,    6,    2,   68,    // 7
-       8,    3,    6,    3,            3,    6,    2,   80,    // 15
-       8,    3,    6,    2,           80,    7,    3,   46,    // 23
-       3,   17,   32,    3,            4,    6,    2,    0,    // 31
-      11,    2,    3,    6,            3,   42,    8,    3,    // 39
-       6,    2,   68,    7,            3,   46,    3,   17,    // 47
-      32,    3,    4,    6,            2,    0,   11,    2,    // 55
-       3,    6,    3,   19,            8,    3,    5,  -999
+      36,   10,   38,    0,           36,   11,    6,    3,    // 7
+       5,    6,    2,   68,            8,    3,   36,   12,    // 15
+       6,    3,    3,    6,            2,   80,    8,    3,    // 23
+      36,   13,    6,    2,           80,    7,    3,   46,    // 31
+       3,   17,   32,    3,            4,    6,    2,    0,    // 39
+      11,    2,    3,    6,            3,   42,    8,    3,    // 47
+      36,   14,    6,    2,           68,    7,    3,   46,    // 55
+       3,   17,   32,    3,            4,    6,    2,    0,    // 63
+      11,    2,    3,    6,            3,   19,    8,    3,    // 71
+      36,   15,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2031,7 +2128,7 @@ TEST_F(Bytecode0, Struct02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   15,   20,   31,         42,   53,  -999
+      11,   21,   28,   39,         52,   63,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,   1,  '\0'
@@ -2056,7 +2153,7 @@ TEST_F(Bytecode0, Struct03) {
     // test arrays; arrays in structs;
     // whether the namespace in structs is independent of the global namespace
 
-    const char *inpl = "\
+    char const *inpl = "\
     struct Struct1                  \n\
     {                               \n\
         int Array[17], Ix;          \n\
@@ -2076,18 +2173,21 @@ TEST_F(Bytecode0, Struct03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct03", scrip);
-    size_t const codesize = 63;
+
+    size_t const codesize = 75;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,    6,    2,   68,    // 7
-       8,    3,    6,    3,            3,    6,    2,   80,    // 15
-       8,    3,    6,    2,           80,    7,    3,   46,    // 23
-       3,   17,   32,    3,            4,    6,    2,    0,    // 31
-      11,    2,    3,    6,            3,   42,    8,    3,    // 39
-       6,    2,   68,    7,            3,   46,    3,   17,    // 47
-      32,    3,    4,    6,            2,    0,   11,    2,    // 55
-       3,    6,    3,   19,            8,    3,    5,  -999
+      36,    8,   38,    0,           36,    9,    6,    3,    // 7
+       5,    6,    2,   68,            8,    3,   36,   10,    // 15
+       6,    3,    3,    6,            2,   80,    8,    3,    // 23
+      36,   11,    6,    2,           80,    7,    3,   46,    // 31
+       3,   17,   32,    3,            4,    6,    2,    0,    // 39
+      11,    2,    3,    6,            3,   42,    8,    3,    // 47
+      36,   12,    6,    2,           68,    7,    3,   46,    // 55
+       3,   17,   32,    3,            4,    6,    2,    0,    // 63
+      11,    2,    3,    6,            3,   19,    8,    3,    // 71
+      36,   13,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2095,7 +2195,7 @@ TEST_F(Bytecode0, Struct03) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   15,   20,   31,         42,   53,  -999
+      11,   21,   28,   39,         52,   63,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,   1,  '\0'
@@ -2117,7 +2217,7 @@ TEST_F(Bytecode0, Struct03) {
 
 TEST_F(Bytecode0, Struct04) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct StructI                               \n\
         {                                                    \n\
             int k;                                           \n\
@@ -2143,22 +2243,25 @@ TEST_F(Bytecode0, Struct04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct04", scrip);
-    size_t const codesize = 92;
+
+    size_t const codesize = 106;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,   16,    1,    1,    // 7
-      16,   73,    3,    4,           51,   16,   47,    3,    // 15
-      51,   16,   48,    2,           52,    6,    3, 12345,    // 23
-       8,    3,   51,    0,           63,   48,    1,    1,    // 31
-      48,   73,    3,    4,           51,   16,   47,    3,    // 39
-      51,   64,   49,    1,            2,    4,   49,    1,    // 47
-       2,    4,   49,    1,            2,    4,   49,   51,    // 55
-      48,    6,    3,    3,           29,    2,   49,    1,    // 63
-       2,    4,   49,    1,            2,    4,   49,    1,    // 71
-       2,    4,   49,   30,            2,    1,    2,   16,    // 79
-       2,    3,    1,   70,          -25,    2,    1,   64,    // 87
-       6,    3,    0,    5,          -999
+      36,   13,   38,    0,           36,   14,   51,    0,    // 7
+      63,   16,    1,    1,           16,   36,   15,   73,    // 15
+       3,    4,   51,   16,           47,    3,   36,   16,    // 23
+      51,   16,   48,    2,           52,    6,    3, 12345,    // 31
+       8,    3,   36,   17,           51,    0,   63,   48,    // 39
+       1,    1,   48,   36,           18,   73,    3,    4,    // 47
+      51,   16,   47,    3,           36,   19,   51,   64,    // 55
+      49,    1,    2,    4,           49,    1,    2,    4,    // 63
+      49,    1,    2,    4,           49,   51,   48,    6,    // 71
+       3,    3,   29,    2,           49,    1,    2,    4,    // 79
+      49,    1,    2,    4,           49,    1,    2,    4,    // 87
+      49,   30,    2,    1,            2,   16,    2,    3,    // 95
+       1,   70,  -25,    2,            1,   64,    6,    3,    // 103
+       0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2178,9 +2281,14 @@ TEST_F(Bytecode0, Struct04) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, Struct05) {   
+TEST_F(Bytecode0, Struct05) {
 
-    const char *inpl = "\
+    // The struct 'Struct0' has zero size, its only component is a function.
+    // Allow this, but warn whenever a variable of type 'Struct0' is declared.
+    // Note that AGS currently doesn't offer any possibility to compare
+    // non-dynamic structs as a whole.
+
+    char const *inpl = "\
         struct StructO                                       \n\
         {                                                    \n\
             static import int StInt(int i);                  \n\
@@ -2202,14 +2310,16 @@ TEST_F(Bytecode0, Struct05) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(1u).Message.find("zero"));
 
     // WriteOutput("Struct05", scrip);
-    size_t const codesize = 28;
+
+    size_t const codesize = 32;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   34,    3,   39,    // 7
-       1,    6,    3,    0,           33,    3,   35,    1,    // 15
-      34,    3,   39,    1,            6,    3,    0,   33,    // 23
-       3,   35,    1,    5,          -999
+      36,    8,   38,    0,           36,   10,    6,    3,    // 7
+       7,   34,    3,   39,            1,    6,    3,    0,    // 15
+      33,    3,   35,    1,           34,    3,   39,    1,    // 23
+       6,    3,    0,   33,            3,   35,    1,    5,    // 31
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2217,7 +2327,7 @@ TEST_F(Bytecode0, Struct05) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      11,   22,  -999
+      15,   26,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
@@ -2242,7 +2352,7 @@ TEST_F(Bytecode0, Struct06) {
     // NOTE: S1.Array[3] is null, so S1.Array[3].Payload should dump
     // when executed in real.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct0;                             \n\
                                                             \n\
         struct Struct1                                      \n\
@@ -2268,16 +2378,18 @@ TEST_F(Bytecode0, Struct06) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct06", scrip);
-    size_t const codesize = 44;
+
+    size_t const codesize = 54;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,    5,   72,    3,            4,    1,   51,    4,    // 15
-      47,    3,   51,    4,           48,    2,   52,    1,    // 23
-       2,   12,   48,    2,           52,    6,    3,   77,    // 31
-       8,    3,   51,    4,           49,    2,    1,    4,    // 39
-       6,    3,    0,    5,          -999
+      36,   14,   38,    0,           36,   15,    6,    3,    // 7
+       0,   29,    3,   36,           16,    6,    3,    5,    // 15
+      72,    3,    4,    1,           51,    4,   47,    3,    // 23
+      36,   17,   51,    4,           48,    2,   52,    1,    // 31
+       2,   12,   48,    2,           52,    6,    3,   77,    // 39
+       8,    3,   36,   18,           51,    4,   49,    2,    // 47
+       1,    4,    6,    3,            0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2299,7 +2411,7 @@ TEST_F(Bytecode0, Struct06) {
 
 TEST_F(Bytecode0, Struct07) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct1                                       \n\
         {                                                    \n\
             int IPayload;                                    \n\
@@ -2322,17 +2434,20 @@ TEST_F(Bytecode0, Struct07) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct07", scrip);
-    size_t const codesize = 55;
+
+    size_t const codesize = 67;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,    6,    2,    8,    // 7
-       8,    3,    6,    3,           65,    6,    2,   12,    // 15
-      26,    3,    6,    2,           12,   24,    3,   29,    // 23
-       3,    6,    3,   65,           30,    4,   12,    4,    // 31
-       3,    3,    4,    3,            6,    2,   13,   26,    // 39
-       3,    6,    2,   12,           24,    3,    2,    3,    // 47
-       1,   26,    3,    6,            3,    0,    5,  -999
+      36,   10,   38,    0,           36,   11,    6,    3,    // 7
+       0,    6,    2,    8,            8,    3,   36,   12,    // 15
+       6,    3,   65,    6,            2,   12,   26,    3,    // 23
+      36,   13,    6,    2,           12,   24,    3,   29,    // 31
+       3,    6,    3,   65,           30,    4,   12,    4,    // 39
+       3,    3,    4,    3,            6,    2,   13,   26,    // 47
+       3,   36,   14,    6,            2,   12,   24,    3,    // 55
+       2,    3,    1,   26,            3,   36,   15,    6,    // 63
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2340,7 +2455,7 @@ TEST_F(Bytecode0, Struct07) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   15,   20,   38,         43,  -999
+      11,   21,   28,   46,         53,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,      1,  '\0'
@@ -2362,41 +2477,51 @@ TEST_F(Bytecode0, Struct07) {
 
 TEST_F(Bytecode0, Struct08) {   
 
-    const char *inpl = "\
-        struct Struct                                        \n\
-        {                                                    \n\
-            int k;                                           \n\
-        };                                                   \n\
-                                                             \n\
-        struct Sub extends Struct                            \n\
-        {                                                    \n\
-            int l;                                           \n\
-        };                                                   \n\
-                                                             \n\
-        int Func(this Sub *, int i, int j)                   \n\
-        {                                                    \n\
-            return !i || !(j) && this.k || (0 != this.l);    \n\
-        }                                                    \n\
-    ";
+    char const *inpl = "\
+        struct Struct                           \n\
+        {                                       \n\
+            int k;                              \n\
+        };                                      \n\
+                                                \n\
+        struct Sub extends Struct               \n\
+        {                                       \n\
+            int l;                              \n\
+        };                                      \n\
+                                                \n\
+        int Func(this Sub *, int i, int j)      \n\
+        {                                       \n\
+            return !i                           \n\
+                   ||                           \n\
+                   !(j)                         \n\
+                   &&                           \n\
+                   this.k                       \n\
+                   ||                           \n\
+                    (0                          \n\
+                     !=                         \n\
+                     this.l                     \n\
+                    )                           \n\
+                   ;                            \n\
+        }                                       \n\
+        ";
    
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct08", scrip);
-    size_t const codesize = 79;
+
+    size_t const codesize = 71;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   42,    3,    // 7
-      70,   34,   29,    3,           51,   16,    7,    3,    // 15
-      42,    3,   28,   16,           29,    3,    3,    6,    // 23
-       2,   52,    7,    3,           30,    4,   21,    4,    // 31
-       3,    3,    4,    3,           30,    4,   22,    4,    // 39
-       3,    3,    4,    3,           70,   32,   29,    3,    // 47
-       6,    3,    0,   29,            3,    3,    6,    2,    // 55
-      52,    1,    2,    4,            7,    3,   30,    4,    // 63
-      16,    4,    3,    3,            4,    3,   30,    4,    // 71
-      22,    4,    3,    3,            4,    3,    5,  -999
+      36,   12,   38,    0,           36,   13,   51,    8,    // 7
+       7,    3,   42,    3,           36,   14,   70,   20,    // 15
+      36,   15,   51,   12,            7,    3,   42,    3,    // 23
+      36,   16,   28,    8,           36,   17,    3,    6,    // 31
+       2,   52,    7,    3,           36,   18,   70,   28,    // 39
+      36,   19,    6,    3,            0,   29,    3,   36,    // 47
+      21,    3,    6,    2,           52,    1,    2,    4,    // 55
+       7,    3,   36,   20,           30,    4,   16,    4,    // 63
+       3,    3,    4,    3,           36,   23,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2422,7 +2547,7 @@ TEST_F(Bytecode0, Struct09) {
     // VehicleBase as an extension of Vehicle Cars[5];
     // should generate call of VehicleBase::SetCharacter()
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum CharacterDirection                                     \n\
         {                                                           \n\
             eDirectionUp = 3                                        \n\
@@ -2465,35 +2590,39 @@ TEST_F(Bytecode0, Struct09) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("Struct09", scrip);
-    size_t const codesize = 185;
+
+    size_t const codesize = 205;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            6,   72,    3,    4,    // 7
-       0,   51,    0,   47,            3,    1,    1,    4,    // 15
-       6,    3,    5,   29,            3,   51,    4,    7,    // 23
-       3,   46,    3,    6,           32,    3,    4,    6,    // 31
-       2,    4,   11,    2,            3,   29,    2,    6,    // 39
-       3,    0,   34,    3,            6,    3,    0,   34,    // 47
-       3,    6,    3,    3,           29,    3,   51,   12,    // 55
-       7,    3,   30,    4,           11,    4,    3,    3,    // 63
-       4,    3,   34,    3,            6,    3,    3,   34,    // 71
-       3,    6,    3,    7,           29,    3,   51,   16,    // 79
-      48,    2,   52,   29,            2,   51,   16,    7,    // 87
-       3,   30,    2,   32,            3,    4,   71,    3,    // 95
-      11,    2,    3,    7,            3,   30,    4,   11,    // 103
-       4,    3,    3,    4,            3,   34,    3,    6,    // 111
-       2,    2,   29,    6,           45,    2,   39,    0,    // 119
-       6,    3,    0,   33,            3,   30,    6,   29,    // 127
-       3,   51,   12,    7,            3,   30,    4,   11,    // 135
-       4,    3,    3,    4,            3,   46,    3,    7,    // 143
-      32,    3,    0,    6,            2,    1,   11,    2,    // 151
-       3,    3,    2,    3,           34,    3,   51,    4,    // 159
-       7,    2,   45,    2,           39,    6,    6,    3,    // 167
-       3,   33,    3,   35,            6,   30,    2,   51,    // 175
-       8,   49,    2,    1,            8,    6,    3,    0,    // 183
-       5,  -999
+      36,   30,   38,    0,           36,   31,    6,    3,    // 7
+       6,   72,    3,    4,            0,   51,    0,   47,    // 15
+       3,    1,    1,    4,           36,   32,    6,    3,    // 23
+       5,   29,    3,   36,           33,   51,    4,    7,    // 31
+       3,   46,    3,    6,           32,    3,    4,    6,    // 39
+       2,    4,   11,    2,            3,   29,    2,   36,    // 47
+      37,    6,    3,    0,           34,    3,    6,    3,    // 55
+       0,   34,    3,    6,            3,    3,   29,    3,    // 63
+      51,   12,    7,    3,           30,    4,   11,    4,    // 71
+       3,    3,    4,    3,           34,    3,   36,   36,    // 79
+       6,    3,    3,   34,            3,   36,   35,    6,    // 87
+       3,    7,   29,    3,           51,   16,   48,    2,    // 95
+      52,   29,    2,   51,           16,    7,    3,   30,    // 103
+       2,   32,    3,    4,           71,    3,   11,    2,    // 111
+       3,    7,    3,   30,            4,   11,    4,    3,    // 119
+       3,    4,    3,   34,            3,   36,   34,    6,    // 127
+       2,    2,   29,    6,           45,    2,   39,    0,    // 135
+       6,    3,    0,   33,            3,   30,    6,   29,    // 143
+       3,   51,   12,    7,            3,   30,    4,   11,    // 151
+       4,    3,    3,    4,            3,   46,    3,    7,    // 159
+      32,    3,    0,    6,            2,    1,   11,    2,    // 167
+       3,    3,    2,    3,           34,    3,   36,   37,    // 175
+      51,    4,    7,    2,           45,    2,   39,    6,    // 183
+       6,    3,    3,   33,            3,   35,    6,   30,    // 191
+       2,   36,   38,   51,            8,   49,    2,    1,    // 199
+       8,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2501,7 +2630,7 @@ TEST_F(Bytecode0, Struct09) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      33,  113,  122,  149,        168,  -999
+      41,  129,  138,  165,        186,  -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,      4,  '\0'
@@ -2528,7 +2657,7 @@ TEST_F(Bytecode0, Struct10) {
     // the import variable must be read first so that the fixup can be
     // applied. Only then may the offset be added to it.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import struct Struct                                 \n\
         {                                                    \n\
             int fluff;                                       \n\
@@ -2545,12 +2674,13 @@ TEST_F(Bytecode0, Struct10) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct10", scrip);
-    size_t const codesize = 11;
+
+    size_t const codesize = 15;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    1,    2,    4,    // 7
-       7,    3,    5,  -999
+      36,    8,   38,    0,           36,    9,    6,    2,    // 7
+       0,    1,    2,    4,            7,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2558,7 +2688,7 @@ TEST_F(Bytecode0, Struct10) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,  -999
+       8,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -2581,9 +2711,9 @@ TEST_F(Bytecode0, Struct10) {
 TEST_F(Bytecode0, Struct11) {
 
     // Structs may contain variables that are structs themselves.
-    // Since Inner1 is managed, In1 will convert into an Inner1 *.
+    // Since 'Inner1' is managed, 'In1' will convert into an 'Inner1 *'.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Inner1                               \n\
         {                                                   \n\
             short Fluff;                                    \n\
@@ -2609,23 +2739,26 @@ TEST_F(Bytecode0, Struct11) {
             return SS.In1.Payload + SS.In2.Payload;         \n\
         }                                                   \n\
     ";
+
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct11", scrip);
-    size_t const codesize = 65;
+
+    size_t const codesize = 75;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,            8,    6,    2,    1,    // 7
-      47,    3,    6,    2,            1,   48,    2,   52,    // 15
-       6,    3,   77,    1,            2,    2,    8,    3,    // 23
-       6,    3,  777,    6,            2,    1,    1,    2,    // 31
-       6,    8,    3,    6,            2,    1,   48,    2,    // 39
-      52,    1,    2,    2,            7,    3,   29,    3,    // 47
-       6,    2,    1,    1,            2,    6,    7,    3,    // 55
-      30,    4,   11,    4,            3,    3,    4,    3,    // 63
-       5,  -999
+      36,   19,   38,    0,           36,   20,   73,    3,    // 7
+       8,    6,    2,    1,           47,    3,   36,   21,    // 15
+       6,    2,    1,   48,            2,   52,    6,    3,    // 23
+      77,    1,    2,    2,            8,    3,   36,   22,    // 31
+       6,    3,  777,    6,            2,    1,    1,    2,    // 39
+       6,    8,    3,   36,           23,    6,    2,    1,    // 47
+      48,    2,   52,    1,            2,    2,    7,    3,    // 55
+      29,    3,    6,    2,            1,    1,    2,    6,    // 63
+       7,    3,   30,    4,           11,    4,    3,    3,    // 71
+       4,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2633,7 +2766,7 @@ TEST_F(Bytecode0, Struct11) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   12,   29,   37,         50,  -999
+      11,   18,   37,   47,         60,  -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,      4,  '\0'
@@ -2656,20 +2789,50 @@ TEST_F(Bytecode0, Struct11) {
 TEST_F(Bytecode0, Struct12) {
 
     // Can have managed components in non-managed struct.
+    // 'SS.IntArray[i]' requires run time calculations.
+    // 'SS.IntArray[3]' can largely be evaluated at compile time.
 
-    const char *inpl = "\
-        struct NonManaged           \n\
-        {                           \n\
-            long Dummy;             \n\
-            int  IntArray[];        \n\
-        } SS;                       \n\
-                                    \n\
-        int main()                  \n\
-        {                           \n\
-            SS.IntArray = new int[10];  \n\
-            SS.IntArray[3] = 7;     \n\
-            return SS.IntArray[3];  \n\
-        }                           \n\
+    char const *inpl = "\
+        struct NonManaged               \n\
+        {                               \n\
+            long Dummy;                 \n\
+            int  IntArray[];            \n\
+        } SS;                           \n\
+                                        \n\
+        int main()                      \n\
+        {                               \n\
+           int i;                       \n\
+           SS.IntArray = new int[10];   \n\
+           SS                           \n\
+             .                          \n\
+              IntArray                  \n\
+                      [                 \n\
+                       3                \n\
+                        ] = 7;          \n\
+           SS                           \n\
+             .                          \n\
+              IntArray                  \n\
+                      [                 \n\
+                       i                \n\
+                        ]               \n\
+                         = 7;           \n\
+            i =                         \n\
+                SS                      \n\
+                  .                     \n\
+                   IntArray             \n\
+                           [            \n\
+                            i           \n\
+                             ]          \n\
+                              ;         \n\
+            return                      \n\
+                SS                      \n\
+                  .                     \n\
+                   IntArray             \n\
+                           [            \n\
+                            3           \n\
+                             ]          \n\
+                              ;         \n\
+        }                               \n\
         ";
 
     int compileResult = cc_compile(inpl, scrip);
@@ -2677,27 +2840,39 @@ TEST_F(Bytecode0, Struct12) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Struct12", scrip);
-    size_t const codesize = 40;
+
+    size_t const codesize = 133;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           10,   72,    3,    4,    // 7
-       0,    6,    2,    4,           47,    3,    6,    2,    // 15
-       4,   48,    2,   52,            6,    3,    7,    1,    // 23
-       2,   12,    8,    3,            6,    2,    4,   48,    // 31
-       2,   52,    1,    2,           12,    7,    3,    5,    // 39
-     -999
+      36,    8,   38,    0,           36,    9,    6,    3,    // 7
+       0,   29,    3,   36,           10,    6,    3,   10,    // 15
+      72,    3,    4,    0,            6,    2,    4,   47,    // 23
+       3,   36,   14,    6,            2,    4,   48,    2,    // 31
+      52,   36,   16,    6,            3,    7,    1,    2,    // 39
+      12,    8,    3,   36,           20,    6,    2,    4,    // 47
+      48,    2,   52,   36,           21,   29,    2,   51,    // 55
+       8,    7,    3,   30,            2,   32,    3,    4,    // 63
+      71,    3,   11,    2,            3,   36,   22,    6,    // 71
+       3,    7,    8,    3,           36,   28,    6,    2,    // 79
+       4,   48,    2,   52,           36,   29,   29,    2,    // 87
+      51,    8,    7,    3,           30,    2,   32,    3,    // 95
+       4,   71,    3,   11,            2,    3,   36,   30,    // 103
+       7,    3,   36,   24,           51,    4,    8,    3,    // 111
+      36,   36,    6,    2,            4,   48,    2,   52,    // 119
+       1,    2,   12,   36,           38,    7,    3,   36,    // 127
+      39,    2,    1,    4,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    size_t const numfixups = 3;
+    size_t const numfixups = 5;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      11,   16,   30,  -999
+      22,   29,   47,   80,        116,  -999
     };
     char fixuptypes[] = {
-      1,   1,   1,  '\0'
+      1,   1,   1,   1,      1,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
@@ -2714,9 +2889,9 @@ TEST_F(Bytecode0, Struct12) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, StructArray01) {
+TEST_F(Bytecode0, Struct13) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         int Int[10];                     \n\
@@ -2728,18 +2903,21 @@ TEST_F(Bytecode0, StructArray01) {
         S.Int[4] =  1;                   \n\
     }                                    \n\
     ";
+
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("StructArray01", scrip);
-    size_t const codesize = 35;
+    // WriteOutput("Struct13", scrip);
+
+    size_t const codesize = 43;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,           40,   51,    0,   47,    // 7
-       3,    1,    1,    4,           51,    4,   48,    2,    // 15
-      52,    6,    3,    1,            1,    2,   16,    8,    // 23
-       3,   51,    4,   49,            2,    1,    4,    6,    // 31
+      36,    7,   38,    0,           36,    8,   73,    3,    // 7
+      40,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,    9,   51,    4,           48,    2,   52,    6,    // 23
+       3,    1,    1,    2,           16,    8,    3,   36,    // 31
+      10,   51,    4,   49,            2,    1,    4,    6,    // 39
        3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -2760,11 +2938,11 @@ TEST_F(Bytecode0, StructArray01) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, StructArray02) {
+TEST_F(Bytecode0, Struct14) {
 
     // Static arrays can be multidimensional
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         int Int1[5, 4];                  \n\
@@ -2782,18 +2960,21 @@ TEST_F(Bytecode0, StructArray02) {
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("StructArray02", scrip);
-    size_t const codesize = 55;
+    // WriteOutput("Struct14", scrip);
+
+    size_t const codesize = 65;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,          104,   51,    0,   47,    // 7
-       3,    1,    1,    4,           51,    4,   48,    2,    // 15
-      52,    6,    3,    1,            1,    2,   72,    8,    // 23
-       3,   51,    4,   48,            2,   52,    1,    2,    // 31
-      72,    7,    3,   51,            4,   48,    2,   52,    // 39
-       1,    2,  100,    8,            3,   51,    4,   49,    // 47
-       2,    1,    4,    6,            3,    0,    5,  -999
+      36,    8,   38,    0,           36,    9,   73,    3,    // 7
+     104,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   10,   51,    4,           48,    2,   52,    6,    // 23
+       3,    1,    1,    2,           72,    8,    3,   36,    // 31
+      11,   51,    4,   48,            2,   52,    1,    2,    // 39
+      72,    7,    3,   51,            4,   48,    2,   52,    // 47
+       1,    2,  100,    8,            3,   36,   12,   51,    // 55
+       4,   49,    2,    1,            4,    6,    3,    0,    // 63
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2815,21 +2996,24 @@ TEST_F(Bytecode0, StructArray02) {
 
 TEST_F(Bytecode0, Func01) {
 
-    const char *inpl = "\
-        int Foo()      \n\
-    {                  \n\
-        return 15;     \n\
-    }";
+    char const *inpl = "\
+        int Foo()       \n\
+        {               \n\
+            return 15;  \n\
+        }               \n\
+        ";
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func01", scrip);
-    size_t const codesize = 6;
+
+    size_t const codesize = 10;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           15,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      15,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2851,7 +3035,7 @@ TEST_F(Bytecode0, Func01) {
 
 TEST_F(Bytecode0, Func02) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct1          \n\
         {                               \n\
             float Payload1;             \n\
@@ -2876,17 +3060,19 @@ TEST_F(Bytecode0, Func02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func02", scrip);
-    size_t const codesize = 51;
+
+    size_t const codesize = 61;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           49,    1,    1,    4,    // 7
-      51,    0,   49,    1,            1,    4,   51,    4,    // 15
-      48,    3,   34,    3,           51,    8,   48,    3,    // 23
-      34,    3,   39,    2,            6,    3,    0,   33,    // 31
-       3,   35,    2,   29,            3,   51,    4,    7,    // 39
-       3,   51,   12,   49,           51,    8,   49,    2,    // 47
-       1,   12,    5,  -999
+      36,   13,   38,    0,           36,   14,   51,    0,    // 7
+      49,    1,    1,    4,           36,   15,   51,    0,    // 15
+      49,    1,    1,    4,           36,   16,   51,    4,    // 23
+      48,    3,   34,    3,           51,    8,   48,    3,    // 31
+      34,    3,   39,    2,            6,    3,    0,   33,    // 39
+       3,   35,    2,   29,            3,   36,   17,   51,    // 47
+       4,    7,    3,   51,           12,   49,   51,    8,    // 55
+      49,    2,    1,   12,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2894,7 +3080,7 @@ TEST_F(Bytecode0, Func02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      30,  -999
+      38,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -2916,7 +3102,7 @@ TEST_F(Bytecode0, Func02) {
 
 TEST_F(Bytecode0, Func03) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -2941,17 +3127,19 @@ TEST_F(Bytecode0, Func03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func03", scrip);
-    size_t const codesize = 51;
+
+    size_t const codesize = 61;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           49,    1,    1,    4,    // 7
-      51,    0,   49,    1,            1,    4,   51,    4,    // 15
-      48,    3,   34,    3,           51,    8,   48,    3,    // 23
-      34,    3,   39,    2,            6,    3,    0,   33,    // 31
-       3,   35,    2,   29,            3,   51,    4,    7,    // 39
-       3,   51,   12,   49,           51,    8,   49,    2,    // 47
-       1,   12,    5,  -999
+      36,   11,   38,    0,           36,   12,   51,    0,    // 7
+      49,    1,    1,    4,           36,   13,   51,    0,    // 15
+      49,    1,    1,    4,           36,   14,   51,    4,    // 23
+      48,    3,   34,    3,           51,    8,   48,    3,    // 31
+      34,    3,   39,    2,            6,    3,    0,   33,    // 39
+       3,   35,    2,   29,            3,   36,   15,   51,    // 47
+       4,    7,    3,   51,           12,   49,   51,    8,    // 55
+      49,    2,    1,   12,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2959,7 +3147,7 @@ TEST_F(Bytecode0, Func03) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      30,  -999
+      38,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -2981,7 +3169,7 @@ TEST_F(Bytecode0, Func03) {
 
 TEST_F(Bytecode0, Func04) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -3011,20 +3199,23 @@ TEST_F(Bytecode0, Func04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func04", scrip);
-    size_t const codesize = 74;
+
+    size_t const codesize = 88;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   50,    3,    // 7
-      51,   12,    7,    3,           50,    3,    6,    3,    // 15
-       0,   51,    8,   49,           51,   12,   49,    5,    // 23
-      38,   24,   51,    0,           49,    1,    1,    4,    // 31
-      51,    0,   49,    1,            1,    4,   51,    4,    // 39
-      48,    3,   29,    3,           51,   12,   48,    3,    // 47
-      29,    3,    6,    3,            0,   23,    3,    2,    // 55
-       1,    8,   29,    3,           51,    4,    7,    3,    // 63
-      51,   12,   49,   51,            8,   49,    2,    1,    // 71
-      12,    5,  -999
+      36,   13,   38,    0,           51,    8,    7,    3,    // 7
+      50,    3,   51,   12,            7,    3,   50,    3,    // 15
+      36,   14,    6,    3,            0,   51,    8,   49,    // 23
+      51,   12,   49,    5,           36,   18,   38,   28,    // 31
+      36,   19,   51,    0,           49,    1,    1,    4,    // 39
+      36,   20,   51,    0,           49,    1,    1,    4,    // 47
+      36,   21,   51,    4,           48,    3,   29,    3,    // 55
+      51,   12,   48,    3,           29,    3,    6,    3,    // 63
+       0,   23,    3,    2,            1,    8,   29,    3,    // 71
+      36,   22,   51,    4,            7,    3,   51,   12,    // 79
+      49,   51,    8,   49,            2,    1,   12,    5,    // 87
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3032,7 +3223,7 @@ TEST_F(Bytecode0, Func04) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      52,  -999
+      64,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -3054,7 +3245,7 @@ TEST_F(Bytecode0, Func04) {
 
 TEST_F(Bytecode0, Func05) {
     
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -3076,15 +3267,18 @@ TEST_F(Bytecode0, Func05) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func05", scrip);
-    size_t const codesize = 38;
+
+    size_t const codesize = 48;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   29,    3,    6,    // 7
-       3,   32,   23,    3,            2,    1,    4,   51,    // 15
-       0,   47,    3,    1,            1,    4,    6,    3,    // 23
-      -1,   51,    4,   49,            2,    1,    4,    5,    // 31
-      38,   32,   73,    3,            4,    5,  -999
+      36,    7,   38,    0,           36,    8,    6,    3,    // 7
+       5,   29,    3,    6,            3,   38,   23,    3,    // 15
+       2,    1,    4,   51,            0,   47,    3,    1,    // 23
+       1,    4,   36,    9,            6,    3,   -1,   51,    // 31
+       4,   49,    2,    1,            4,    5,   36,   13,    // 39
+      38,   38,   36,   14,           73,    3,    4,    5,    // 47
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3092,7 +3286,7 @@ TEST_F(Bytecode0, Func05) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,  -999
+      13,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -3114,7 +3308,7 @@ TEST_F(Bytecode0, Func05) {
 
 TEST_F(Bytecode0, Func06) {
    
-    const char *inpl = "\
+    char const *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         int Func(int P1, int P2)     \n\
@@ -3133,16 +3327,19 @@ TEST_F(Bytecode0, Func06) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func06", scrip);
-    size_t const codesize = 47;
+
+    size_t const codesize = 57;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-      51,   16,    7,    3,           30,    4,   11,    4,    // 15
-       3,    3,    4,    3,            5,   38,   21,    6,    // 23
-       3,    5,   29,    3,            6,    3,    4,   29,    // 31
-       3,    6,    3,    0,           23,    3,    2,    1,    // 39
-       8,   29,    3,    2,            1,    4,    5,  -999
+      36,    4,   38,    0,           36,    5,   51,    8,    // 7
+       7,    3,   29,    3,           51,   16,    7,    3,    // 15
+      30,    4,   11,    4,            3,    3,    4,    3,    // 23
+       5,   36,    9,   38,           25,   36,   10,    6,    // 31
+       3,    5,   29,    3,            6,    3,    4,   29,    // 39
+       3,    6,    3,    0,           23,    3,    2,    1,    // 47
+       8,   29,    3,   36,           11,    2,    1,    4,    // 55
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3150,7 +3347,7 @@ TEST_F(Bytecode0, Func06) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      35,  -999
+      43,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -3172,7 +3369,7 @@ TEST_F(Bytecode0, Func06) {
 
 TEST_F(Bytecode0, Func07) {  
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         void main()                  \n\
@@ -3187,47 +3384,49 @@ TEST_F(Bytecode0, Func07) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func07", scrip);
-    const size_t codesize = 48;
+
+    size_t const codesize = 56;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   34,    3,    6,    // 7
-       3,    4,   34,    3,           39,    2,    6,    3,    // 15
-       0,   33,    3,   35,            2,   29,    3,    6,    // 23
-       3,    1,   34,    3,            6,    3,    4,   34,    // 31
-       3,   39,    2,    6,            3,    0,   33,    3,    // 39
-      35,    2,   29,    3,            2,    1,    8,    5,    // 47
+      36,    4,   38,    0,           36,    5,    6,    3,    // 7
+       5,   34,    3,    6,            3,    4,   34,    3,    // 15
+      39,    2,    6,    3,            0,   33,    3,   35,    // 23
+       2,   29,    3,   36,            6,    6,    3,    1,    // 31
+      34,    3,    6,    3,            4,   34,    3,   39,    // 39
+       2,    6,    3,    0,           33,    3,   35,    2,    // 47
+      29,    3,   36,    7,            2,    1,    8,    5,    // 55
      -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 2;
+    size_t const numfixups = 2;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      16,   37,  -999
+      20,   43,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 1;
+    int const numimports = 1;
     std::string imports[] = {
     "Func",         "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode0, Func08) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         void main()                  \n\
         {                            \n\
             int Int1 = Func(4);      \n\
@@ -3242,47 +3441,49 @@ TEST_F(Bytecode0, Func08) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func08", scrip);
-    const size_t codesize = 48;
+
+    size_t const codesize = 56;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   34,    3,    6,    // 7
-       3,    4,   34,    3,           39,    2,    6,    3,    // 15
-       0,   33,    3,   35,            2,   29,    3,    6,    // 23
-       3,    1,   34,    3,            6,    3,    4,   34,    // 31
-       3,   39,    2,    6,            3,    0,   33,    3,    // 39
-      35,    2,   29,    3,            2,    1,    8,    5,    // 47
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       5,   34,    3,    6,            3,    4,   34,    3,    // 15
+      39,    2,    6,    3,            0,   33,    3,   35,    // 23
+       2,   29,    3,   36,            4,    6,    3,    1,    // 31
+      34,    3,    6,    3,            4,   34,    3,   39,    // 39
+       2,    6,    3,    0,           33,    3,   35,    2,    // 47
+      29,    3,   36,    5,            2,    1,    8,    5,    // 55
      -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 2;
+    size_t const numfixups = 2;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      16,   37,  -999
+      20,   43,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 1;
+    int const numimports = 1;
     std::string imports[] = {
     "Func",         "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode0, Func09) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Func(int f, int = 5); \n\
         import int Func(int, int = 5); \n\
                                      \n\
@@ -3298,16 +3499,18 @@ TEST_F(Bytecode0, Func09) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func09", scrip);
-    size_t const codesize = 48;
+
+    size_t const codesize = 56;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   34,    3,    6,    // 7
-       3,    4,   34,    3,           39,    2,    6,    3,    // 15
-       0,   33,    3,   35,            2,   29,    3,    6,    // 23
-       3,    1,   34,    3,            6,    3,    4,   34,    // 31
-       3,   39,    2,    6,            3,    0,   33,    3,    // 39
-      35,    2,   29,    3,            2,    1,    8,    5,    // 47
+      36,    5,   38,    0,           36,    6,    6,    3,    // 7
+       5,   34,    3,    6,            3,    4,   34,    3,    // 15
+      39,    2,    6,    3,            0,   33,    3,   35,    // 23
+       2,   29,    3,   36,            7,    6,    3,    1,    // 31
+      34,    3,    6,    3,            4,   34,    3,   39,    // 39
+       2,    6,    3,    0,           33,    3,   35,    2,    // 47
+      29,    3,   36,    8,            2,    1,    8,    5,    // 55
      -999
     };
     CompareCode(&scrip, codesize, code);
@@ -3316,7 +3519,7 @@ TEST_F(Bytecode0, Func09) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      16,   37,  -999
+      20,   43,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
@@ -3338,7 +3541,7 @@ TEST_F(Bytecode0, Func09) {
 
 TEST_F(Bytecode0, Func10) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         import int Func(int, int = 5); \n\
                                      \n\
         int Func(int P1, int P2)     \n\
@@ -3357,16 +3560,19 @@ TEST_F(Bytecode0, Func10) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func10", scrip);
-    size_t const codesize = 47;
+
+    size_t const codesize = 57;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-      51,   16,    7,    3,           30,    4,   11,    4,    // 15
-       3,    3,    4,    3,            5,   38,   21,    6,    // 23
-       3,  -99,   29,    3,            6,    3,    4,   29,    // 31
-       3,    6,    3,    0,           23,    3,    2,    1,    // 39
-       8,   29,    3,    2,            1,    4,    5,  -999
+      36,    4,   38,    0,           36,    5,   51,    8,    // 7
+       7,    3,   29,    3,           51,   16,    7,    3,    // 15
+      30,    4,   11,    4,            3,    3,    4,    3,    // 23
+       5,   36,    9,   38,           25,   36,   10,    6,    // 31
+       3,  -99,   29,    3,            6,    3,    4,   29,    // 39
+       3,    6,    3,    0,           23,    3,    2,    1,    // 47
+       8,   29,    3,   36,           11,    2,    1,    4,    // 55
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3374,7 +3580,7 @@ TEST_F(Bytecode0, Func10) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      35,  -999
+      43,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -3396,7 +3602,7 @@ TEST_F(Bytecode0, Func10) {
 
 TEST_F(Bytecode0, Func11) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
     struct Struct                   \n\
     {                               \n\
         float Float;                \n\
@@ -3420,16 +3626,19 @@ TEST_F(Bytecode0, Func11) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func11", scrip);
-    size_t const codesize = 45;
+
+    size_t const codesize = 57;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,    5,   38,    6,    // 7
-       6,    3,    0,   29,            3,   51,    4,   45,    // 15
-       2,    6,    3,    0,           23,    3,   29,    3,    // 23
-       6,    3,    3,   30,            4,   40,    4,    3,    // 31
-       3,    4,    3,   29,            3,   51,    4,    7,    // 39
-       3,    2,    1,    8,            5,  -999
+      36,    8,   38,    0,           36,    9,    6,    3,    // 7
+       5,    5,   36,   13,           38,   10,   36,   14,    // 15
+       6,    3,    0,   29,            3,   36,   15,   51,    // 23
+       4,   45,    2,    6,            3,    0,   23,    3,    // 31
+      29,    3,    6,    3,            3,   30,    4,   40,    // 39
+       4,    3,    3,    4,            3,   29,    3,   36,    // 47
+      16,   51,    4,    7,            3,    2,    1,    8,    // 55
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3437,7 +3646,7 @@ TEST_F(Bytecode0, Func11) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      19,  -999
+      29,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -3462,7 +3671,7 @@ TEST_F(Bytecode0, Func12) {
     // Function with float default, or default "0", for float parameter
     // The latter will make the compiler slightly unhappy
 
-    const char *inpl = "\
+    char const *inpl = "\
     float Func1(float F = 7.2)          \n\
     {                                   \n\
         return F;                       \n\
@@ -3486,17 +3695,20 @@ TEST_F(Bytecode0, Func12) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(0u).Message.find("'0'"));
 
     // WriteOutput("Func12", scrip);
-    size_t const codesize = 53;
+
+    size_t const codesize = 65;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,    5,   38,    // 7
-       7,   51,    8,    7,            3,    5,   38,   14,    // 15
-       6,    3, 1088841318,   29,            3,    6,    3,    0,    // 23
-      23,    3,    2,    1,            4,   29,    3,    6,    // 31
-       3,    0,   29,    3,            6,    3,    7,   23,    // 39
-       3,    2,    1,    4,           30,    4,   57,    4,    // 47
-       3,    3,    4,    3,            5,  -999
+      36,    2,   38,    0,           36,    3,   51,    8,    // 7
+       7,    3,    5,   36,            7,   38,   11,   36,    // 15
+       8,   51,    8,    7,            3,    5,   36,   12,    // 23
+      38,   22,   36,   13,            6,    3, 1088841318,   29,    // 31
+       3,    6,    3,    0,           23,    3,    2,    1,    // 39
+       4,   29,    3,    6,            3,    0,   29,    3,    // 47
+       6,    3,   11,   23,            3,    2,    1,    4,    // 55
+      30,    4,   57,    4,            3,    3,    4,    3,    // 63
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3504,7 +3716,7 @@ TEST_F(Bytecode0, Func12) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      23,   38,  -999
+      35,   50,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -3529,7 +3741,7 @@ TEST_F(Bytecode0, Func13) {
     // Function with default null or 0 for managed parameter
     // The latter will make the compiler slightly unhappy
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct S                    \n\
     {                                   \n\
         float f;                        \n\
@@ -3545,7 +3757,7 @@ TEST_F(Bytecode0, Func13) {
         return s;                       \n\
     }                                   \n\
                                         \n\
-    int Call()                           \n\
+    int Call()                          \n\
     {                                   \n\
         return Func1() == Func2();      \n\
     }                                   \n\
@@ -3558,23 +3770,25 @@ TEST_F(Bytecode0, Func13) {
     EXPECT_NE(std::string::npos, mh.GetMessages().at(0u).Message.find("'0'"));
 
     // WriteOutput("Func13", scrip);
-    size_t const codesize = 97;
+
+    size_t const codesize = 109;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   50,    3,    // 7
-      51,    8,   48,    3,           29,    3,   51,    4,    // 15
-      50,    3,   51,   12,           49,   51,    4,   48,    // 23
-       3,   69,   30,    4,            5,   38,   29,   51,    // 31
-       8,    7,    3,   50,            3,   51,    8,   48,    // 39
-       3,   29,    3,   51,            4,   50,    3,   51,    // 47
-      12,   49,   51,    4,           48,    3,   69,   30,    // 55
-       4,    5,   38,   58,            6,    3,    0,   29,    // 63
-       3,    6,    3,    0,           23,    3,    2,    1,    // 71
-       4,   29,    3,    6,            3,    0,   29,    3,    // 79
-       6,    3,   29,   23,            3,    2,    1,    4,    // 87
-      30,    4,   15,    4,            3,    3,    4,    3,    // 95
-       5,  -999
+      36,    7,   38,    0,           51,    8,    7,    3,    // 7
+      50,    3,   36,    8,           51,    8,   48,    3,    // 15
+      29,    3,   51,    4,           50,    3,   51,   12,    // 23
+      49,   51,    4,   48,            3,   69,   30,    4,    // 31
+       5,   36,   12,   38,           33,   51,    8,    7,    // 39
+       3,   50,    3,   36,           13,   51,    8,   48,    // 47
+       3,   29,    3,   51,            4,   50,    3,   51,    // 55
+      12,   49,   51,    4,           48,    3,   69,   30,    // 63
+       4,    5,   36,   17,           38,   66,   36,   18,    // 71
+       6,    3,    0,   29,            3,    6,    3,    0,    // 79
+      23,    3,    2,    1,            4,   29,    3,    6,    // 87
+       3,    0,   29,    3,            6,    3,   33,   23,    // 95
+       3,    2,    1,    4,           30,    4,   15,    4,    // 103
+       3,    3,    4,    3,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3582,7 +3796,7 @@ TEST_F(Bytecode0, Func13) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      67,   82,  -999
+      79,   94,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -3606,7 +3820,7 @@ TEST_F(Bytecode0, Func14) {
 
     // Strange misalignment due to bad function protocol
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct               \n\
         {                           \n\
             int A[];                \n\
@@ -3638,26 +3852,30 @@ TEST_F(Bytecode0, Func14) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func14", scrip);
-    size_t const codesize = 135;
+
+    size_t const codesize = 159;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            1,   72,    3,    4,    // 7
-       0,    3,    6,    2,           52,   47,    3,    6,    // 15
-       3,    1,   72,    3,            4,    0,    3,    6,    // 23
-       2,   52,    1,    2,            4,   47,    3,    3,    // 31
-       6,    2,   52,    1,            2,    4,   48,    2,    // 39
-      52,    6,    3,  123,            8,    3,   29,    6,    // 47
-       3,    6,    2,   52,            1,    2,    4,   48,    // 55
-       2,   52,    7,    3,           29,    3,    3,    6,    // 63
-       2,   52,   48,    2,           52,    7,    3,   29,    // 71
-       3,    6,    3,   84,           23,    3,    2,    1,    // 79
-       8,   30,    6,    5,           38,   84,    5,   38,    // 87
-      87,   51,    0,   63,            8,    1,    1,    8,    // 95
-      51,    8,   29,    2,            6,    3,    7,   29,    // 103
-       3,   51,    8,    7,            2,   45,    2,    6,    // 111
-       3,    0,   23,    3,            2,    1,    4,   30,    // 119
-       2,   51,    8,   49,            1,    2,    4,   49,    // 127
+      36,   10,   38,    0,           36,   11,    6,    3,    // 7
+       1,   72,    3,    4,            0,    3,    6,    2,    // 15
+      52,   47,    3,   36,           12,    6,    3,    1,    // 23
+      72,    3,    4,    0,            3,    6,    2,   52,    // 31
+       1,    2,    4,   47,            3,   36,   13,    3,    // 39
+       6,    2,   52,    1,            2,    4,   48,    2,    // 47
+      52,    6,    3,  123,            8,    3,   36,   14,    // 55
+      29,    6,    3,    6,            2,   52,    1,    2,    // 63
+       4,   48,    2,   52,            7,    3,   29,    3,    // 71
+       3,    6,    2,   52,           48,    2,   52,    7,    // 79
+       3,   29,    3,    6,            3,   96,   23,    3,    // 87
+       2,    1,    8,   30,            6,   36,   15,    5,    // 95
+      36,   18,   38,   96,           36,   19,    5,   36,    // 103
+      22,   38,  103,   36,           23,   51,    0,   63,    // 111
+       8,    1,    1,    8,           36,   24,   51,    8,    // 119
+      29,    2,    6,    3,            7,   29,    3,   51,    // 127
+       8,    7,    2,   45,            2,    6,    3,    0,    // 135
+      23,    3,    2,    1,            4,   30,    2,   36,    // 143
+      25,   51,    8,   49,            1,    2,    4,   49,    // 151
        2,    1,    8,    6,            3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -3666,7 +3884,7 @@ TEST_F(Bytecode0, Func14) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      75,  113,  -999
+      85,  135,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -3688,23 +3906,80 @@ TEST_F(Bytecode0, Func14) {
 
 TEST_F(Bytecode0, Func15) {
 
-    const char *inpl = "\
-        int a = 15;    \n\
-        int Foo( )     \n\
-        {              \n\
-            return a;  \n\
+    // Simple void function
+
+    char const *inpl = "\
+        void Foo()          \n\
+        {                   \n\
+            return;         \n\
         }";
+
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("Func15", scrip);
+
+    size_t const codesize = 7;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode0, Func16) {
+
+    char const *inpl = "\
+        int a = 15;     \n\
+        int Foo1( )     \n\
+        {               \n\
+            return a;   \n\
+        }               \n\
+                        \n\
+        int Foo2(int a) \n\
+        {               \n\
+            return a;   \n\
+        }               \n\
+                        \n\
+        int Foo3()      \n\
+        {               \n\
+            int a = 15; \n\
+            return a;   \n\
+        }               \n\
+        ";
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("Func15", scrip);
-    size_t const codesize = 8;
+    // WriteOutput("Func16", scrip);
+
+    size_t const codesize = 44;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    7,    3,    5,    // 7
-     -999
+      36,    3,   38,    0,           36,    4,    6,    2,    // 7
+       0,    7,    3,    5,           36,    8,   38,   12,    // 15
+      36,    9,   51,    8,            7,    3,    5,   36,    // 23
+      13,   38,   23,   36,           14,    6,    3,   15,    // 31
+      29,    3,   36,   15,           51,    4,    7,    3,    // 39
+       2,    1,    4,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3712,7 +3987,7 @@ TEST_F(Bytecode0, Func15) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,  -999
+       8,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -3732,66 +4007,50 @@ TEST_F(Bytecode0, Func15) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, Func16) {
-
-    const char *inpl = "\
-        int Foo(int a) \n\
-        {              \n\
-            return a;  \n\
-        }";
-
-    int compileResult = cc_compile(inpl, scrip);
-    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    // WriteOutput("Func16", scrip);
-    size_t const codesize = 7;
-    EXPECT_EQ(codesize, scrip.codesize);
-
-    int32_t code[] = {
-      38,    0,   51,    8,            7,    3,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.numfixups);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.numexports);
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
-
 TEST_F(Bytecode0, Func17) {
 
-    const char *inpl = "\
-        int Foo()       \n\
-        {               \n\
-            int a = 15; \n\
-            return a;   \n\
-        }";
+    // NON-managed dynpointers must be read/rewritten at function start, too.
+
+    char const *inpl = "\
+        int Random(int X)                       \n\
+        {                                       \n\
+            Shuffle(new int[15], 10);           \n\
+        }                                       \n\
+                                                \n\
+        void Shuffle(int Ints[], int Length)    \n\
+        {                                       \n\
+        }                                       \n\
+        ";
 
     int compileResult = cc_compile(inpl, scrip);
-    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Func17", scrip);
-    size_t const codesize = 15;
+
+    size_t const codesize = 50;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           15,   29,    3,   51,    // 7
-       4,    7,    3,    2,            1,    4,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      10,   29,    3,    6,            3,   15,   72,    3,    // 15
+       4,    0,   29,    3,            6,    3,   34,   23,    // 23
+       3,    2,    1,    8,           36,    4,    6,    3,    // 31
+       0,    5,   36,    7,           38,   34,   51,    8,    // 39
+       7,    3,   50,    3,           36,    8,   51,    8,    // 47
+      49,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    size_t const numfixups = 0;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      22,  -999
+    };
+    char fixuptypes[] = {
+      2,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
     int const numimports = 0;
     std::string imports[] = {
@@ -3808,102 +4067,9 @@ TEST_F(Bytecode0, Func17) {
 
 TEST_F(Bytecode0, Func18) {
 
-    // NON-managed dynpointers must be read/rewritten at function start, too.
-
-    char inpl[] = "\
-        int Random(int X)                       \n\
-        {                                       \n\
-            Shuffle(new int[15], 10);           \n\
-        }                                       \n\
-        void Shuffle(int Ints[], int Length)    \n\
-        {                                       \n\
-        }                                       \n\
-        ";
-
-    int compileResult = cc_compile(inpl, scrip);
-    EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    // WriteOutput("Func18", scrip);
-    const size_t codesize = 40;
-    EXPECT_EQ(codesize, scrip.codesize);
-
-    int32_t code[] = {
-      38,    0,    6,    3,           10,   29,    3,    6,    // 7
-       3,   15,   72,    3,            4,    0,   29,    3,    // 15
-       6,    3,   28,   23,            3,    2,    1,    8,    // 23
-       6,    3,    0,    5,           38,   28,   51,    8,    // 31
-       7,    3,   50,    3,           51,    8,   49,    5,    // 39
-     -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    const size_t numfixups = 1;
-    EXPECT_EQ(numfixups, scrip.numfixups);
-
-    int32_t fixups[] = {
-      18,  -999
-    };
-    char fixuptypes[] = {
-      2,  '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    const int numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    const size_t numexports = 0;
-    EXPECT_EQ(numexports, scrip.numexports);
-
-    const size_t stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
-
-TEST_F(Bytecode0, Function19) {
-
-    // Simple void function
-    const char *inpl = "\
-        void Foo()          \n\
-        {                   \n\
-            return;         \n\
-        }";
-
-    int compileResult = cc_compile(inpl, scrip);
-
-    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    // WriteOutput("Function19", scrip);
-    size_t const codesize = 3;
-    EXPECT_EQ(codesize, scrip.codesize);
-
-    int32_t code[] = {
-      38,    0,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.numfixups);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.numexports);
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
-
-TEST_F(Bytecode0, Func20) {
-
     // Multiple forward calls should _all_ resolve to the correct function address
 
-    char inpl[] = "\
+    char const *inpl = "\
         int main()                      \n\
         {                               \n\
             MKB(0, 7);                  \n\
@@ -3913,6 +4079,7 @@ TEST_F(Bytecode0, Func20) {
             MKB(4, 9);                  \n\
             MKB(5, 8);                  \n\
         }                               \n\
+                                        \n\
         int MKB(int cp, int lastbook)   \n\
         {                               \n\
             return cp + lastbook;       \n\
@@ -3922,28 +4089,32 @@ TEST_F(Bytecode0, Func20) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("Func20", scrip);
-    size_t const codesize = 135;
+    // WriteOutput("Func18", scrip);
+
+    size_t const codesize = 155;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   29,    3,    6,    // 7
-       3,    0,   29,    3,            6,    3,  114,   23,    // 15
-       3,    2,    1,    8,            6,    3,    9,   29,    // 23
-       3,    6,    3,    1,           29,    3,    6,    3,    // 31
-     114,   23,    3,    2,            1,    8,    6,    3,    // 39
-       7,   29,    3,    6,            3,    2,   29,    3,    // 47
-       6,    3,  114,   23,            3,    2,    1,    8,    // 55
-       6,    3,   11,   29,            3,    6,    3,    3,    // 63
-      29,    3,    6,    3,          114,   23,    3,    2,    // 71
-       1,    8,    6,    3,            9,   29,    3,    6,    // 79
-       3,    4,   29,    3,            6,    3,  114,   23,    // 87
-       3,    2,    1,    8,            6,    3,    8,   29,    // 95
-       3,    6,    3,    5,           29,    3,    6,    3,    // 103
-     114,   23,    3,    2,            1,    8,    6,    3,    // 111
-       0,    5,   38,  114,           51,    8,    7,    3,    // 119
-      29,    3,   51,   16,            7,    3,   30,    4,    // 127
-      11,    4,    3,    3,            4,    3,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       7,   29,    3,    6,            3,    0,   29,    3,    // 15
+       6,    3,  130,   23,            3,    2,    1,    8,    // 23
+      36,    4,    6,    3,            9,   29,    3,    6,    // 31
+       3,    1,   29,    3,            6,    3,  130,   23,    // 39
+       3,    2,    1,    8,           36,    5,    6,    3,    // 47
+       7,   29,    3,    6,            3,    2,   29,    3,    // 55
+       6,    3,  130,   23,            3,    2,    1,    8,    // 63
+      36,    6,    6,    3,           11,   29,    3,    6,    // 71
+       3,    3,   29,    3,            6,    3,  130,   23,    // 79
+       3,    2,    1,    8,           36,    7,    6,    3,    // 87
+       9,   29,    3,    6,            3,    4,   29,    3,    // 95
+       6,    3,  130,   23,            3,    2,    1,    8,    // 103
+      36,    8,    6,    3,            8,   29,    3,    6,    // 111
+       3,    5,   29,    3,            6,    3,  130,   23,    // 119
+       3,    2,    1,    8,           36,    9,    6,    3,    // 127
+       0,    5,   36,   12,           38,  130,   36,   13,    // 135
+      51,    8,    7,    3,           29,    3,   51,   16,    // 143
+       7,    3,   30,    4,           11,    4,    3,    3,    // 151
+       4,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -3951,7 +4122,7 @@ TEST_F(Bytecode0, Func20) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      14,   32,   50,   68,         86,  104,  -999
+      18,   38,   58,   78,         98,  118,  -999
     };
     char fixuptypes[] = {
       2,   2,   2,   2,      2,   2,  '\0'
@@ -3973,7 +4144,7 @@ TEST_F(Bytecode0, Func20) {
 
 TEST_F(Bytecode0, Export) {
     
-    const char *inpl = "\
+    char const *inpl = "\
     struct Struct                   \n\
     {                               \n\
         float Float;                \n\
@@ -4000,14 +4171,17 @@ TEST_F(Bytecode0, Export) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Export", scrip);
-    size_t const codesize = 30;
+
+    size_t const codesize = 40;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,    8,    1,    1,    // 7
-       8,    6,    3,    3,           51,    4,    8,    3,    // 15
-       6,    3, 1056964608,   51,            8,    8,    3,    6,    // 23
-       3,   -2,    2,    1,            8,    5,  -999
+      36,   14,   38,    0,           36,   15,   51,    0,    // 7
+      63,    8,    1,    1,            8,   36,   16,    6,    // 15
+       3,    3,   51,    4,            8,    3,   36,   17,    // 23
+       6,    3, 1056964608,   51,            8,    8,    3,   36,    // 31
+      18,    6,    3,   -2,            2,    1,    8,    5,    // 39
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -4039,7 +4213,7 @@ TEST_F(Bytecode0, Export) {
 
 TEST_F(Bytecode0, ArrayOfPointers1) {
    
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         float Float;                     \n\
@@ -4060,21 +4234,23 @@ TEST_F(Bytecode0, ArrayOfPointers1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("ArrayOfPointers1", scrip);
-    size_t const codesize = 92;
+    size_t const codesize = 108;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,   51,    // 7
-       4,    7,    3,   29,            3,    6,    3,    9,    // 15
-      30,    4,   18,    4,            3,    3,    4,    3,    // 23
-      28,   36,   73,    3,            8,   29,    3,   51,    // 31
-       8,    7,    3,   46,            3,   50,   32,    3,    // 39
-       4,    6,    2,    0,           11,    2,    3,   30,    // 47
-       3,   47,    3,   51,            4,    7,    3,    1,    // 55
-       3,    1,    8,    3,           31,  -55,    2,    1,    // 63
-       4,    6,    2,   40,           48,    3,   29,    3,    // 71
-       6,    3,    0,   30,            4,   15,    4,    3,    // 79
-       3,    4,    3,   29,            3,    2,    1,    4,    // 87
+      36,    9,   38,    0,           36,   10,    6,    3,    // 7
+       0,   29,    3,   31,           11,   36,   10,   51,    // 15
+       4,    7,    3,    1,            3,    1,    8,    3,    // 23
+      36,   10,   51,    4,            7,    3,   29,    3,    // 31
+       6,    3,    9,   30,            4,   18,    4,    3,    // 39
+       3,    4,    3,   28,           29,   36,   11,   73,    // 47
+       3,    8,   29,    3,           51,    8,    7,    3,    // 55
+      46,    3,   50,   32,            3,    4,    6,    2,    // 63
+       0,   11,    2,    3,           30,    3,   47,    3,    // 71
+      31,  -61,    2,    1,            4,   36,   13,    6,    // 79
+       2,   40,   48,    3,           29,    3,    6,    3,    // 87
+       0,   30,    4,   15,            4,    3,    3,    4,    // 95
+       3,   29,    3,   36,           14,    2,    1,    4,    // 103
        6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
@@ -4083,7 +4259,7 @@ TEST_F(Bytecode0, ArrayOfPointers1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      43,   67,  -999
+      64,   81,  -999
     };
     char fixuptypes[] = {
       1,   1,  '\0'
@@ -4105,7 +4281,7 @@ TEST_F(Bytecode0, ArrayOfPointers1) {
 
 TEST_F(Bytecode0, ArrayOfPointers2) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct                \n\
     {                                    \n\
         float Float;                     \n\
@@ -4127,24 +4303,27 @@ TEST_F(Bytecode0, ArrayOfPointers2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("ArrayOfPointers2", scrip);
-    size_t const codesize = 109;
+    size_t const codesize = 131;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,  200,    1,    1,    // 7
-     200,    6,    3,    0,           29,    3,   51,    4,    // 15
-       7,    3,   29,    3,            6,    3,   20,   30,    // 23
-       4,   18,    4,    3,            3,    4,    3,   28,    // 31
-      35,   73,    3,    8,           29,    3,   51,    8,    // 39
-       7,    3,   46,    3,           50,   32,    3,    4,    // 47
-      51,  208,   11,    2,            3,   30,    3,   47,    // 55
-       3,   51,    4,    7,            3,    1,    3,    1,    // 63
-       8,    3,   31,  -54,            2,    1,    4,   51,    // 71
-     180,   48,    2,   52,            6,    3, 1074580685,    8,    // 79
-       3,    6,    3,    0,           51,  184,   47,    3,    // 87
-      51,  200,    6,    3,           50,   49,    1,    2,    // 95
-       4,    2,    3,    1,           70,   -9,    2,    1,    // 103
-     200,    6,    3,    0,            5,  -999
+      36,    8,   38,    0,           36,    9,   51,    0,    // 7
+      63,  200,    1,    1,          200,   36,   10,    6,    // 15
+       3,    0,   29,    3,           31,   11,   36,   10,    // 23
+      51,    4,    7,    3,            1,    3,    1,    8,    // 31
+       3,   36,   10,   51,            4,    7,    3,   29,    // 39
+       3,    6,    3,   20,           30,    4,   18,    4,    // 47
+       3,    3,    4,    3,           28,   28,   36,   11,    // 55
+      73,    3,    8,   29,            3,   51,    8,    7,    // 63
+       3,   46,    3,   50,           32,    3,    4,   51,    // 71
+     208,   11,    2,    3,           30,    3,   47,    3,    // 79
+      31,  -60,   36,   12,            2,    1,    4,   36,    // 87
+      13,   51,  180,   48,            2,   52,    6,    3,    // 95
+    1074580685,    8,    3,   36,           14,    6,    3,    0,    // 103
+      51,  184,   47,    3,           36,   15,   51,  200,    // 111
+       6,    3,   50,   49,            1,    2,    4,    2,    // 119
+       3,    1,   70,   -9,            2,    1,  200,    6,    // 127
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -4168,7 +4347,7 @@ TEST_F(Bytecode0, Writeprotected) {
     
     // Directly taken from the doc on writeprotected, simplified.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                         \n\
             short Beauty;                       \n\
             writeprotected int Damage;          \n\
@@ -4191,14 +4370,16 @@ TEST_F(Bytecode0, Writeprotected) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Writeprotected", scrip);
-    size_t const codesize = 27;
+
+    size_t const codesize = 37;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,    3,    6,    // 7
-       2,   52,    1,    2,            2,    8,    3,    6,    // 15
-       3,    0,    5,   38,           19,    6,    2,    2,    // 23
-       7,    3,    5,  -999
+      36,    8,   38,    0,           36,    9,   51,    8,    // 7
+       7,    3,    3,    6,            2,   52,    1,    2,    // 15
+       2,    8,    3,   36,           10,    6,    3,    0,    // 23
+       5,   36,   14,   38,           25,   36,   15,    6,    // 31
+       2,    2,    7,    3,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -4206,7 +4387,7 @@ TEST_F(Bytecode0, Writeprotected) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      23,  -999
+      33,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -4230,7 +4411,7 @@ TEST_F(Bytecode0, Protected1) {
 
     // Directly taken from the doc on protected, simplified.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int SetDamage(int damage);  \n\
@@ -4249,13 +4430,14 @@ TEST_F(Bytecode0, Protected1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Protected1", scrip);
-    size_t const codesize = 16;
+
+    size_t const codesize = 22;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,    3,    6,    // 7
-       2,   52,    8,    3,            6,    3,    0,    5,    // 15
-     -999
+      36,    9,   38,    0,           36,   10,   51,    8,    // 7
+       7,    3,    3,    6,            2,   52,    8,    3,    // 15
+      36,   11,    6,    3,            0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -4275,48 +4457,101 @@ TEST_F(Bytecode0, Protected1) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, Static1) {   
+TEST_F(Bytecode0, Protected2) {
 
-    const char *inpl = "\
-        struct Weapon {                         \n\
-            import static int CalcDamage(       \n\
-            int Lifepoints, int Hitpoints = 5); \n\
-        };                                      \n\
-                                                \n\
+    // In a struct func, a variable that can't be found otherwise
+    // should be taken to be out of the current struct.
+
+    char const *inpl = "\
+        struct Weapon {                        \n\
+            protected int Damage;              \n\
+            import int SetDamage(int damage);  \n\
+        };                                     \n\
+                                               \n\
+        Weapon wp;                             \n\
+                                               \n\
+        int Weapon::SetDamage(int damage)      \n\
+        {                                      \n\
+            Damage = damage;                   \n\
+            return 0;                          \n\
+        }                                      \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("Protected2", scrip);
+
+    size_t const codesize = 22;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    9,   38,    0,           36,   10,   51,    8,    // 7
+       7,    3,    3,    6,            2,   52,    8,    3,    // 15
+      36,   11,    6,    3,            0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode0, Static1) {
+
+    char const *inpl = "\
+        struct Weapon {                             \n\
+            import static int CalcDamage(           \n\
+            int Lifepoints, int Hitpoints = 5);     \n\
+        };                                          \n\
+                                                    \n\
         static int Weapon::CalcDamage(int Lifepoints, int Hitpoints)  \n\
-        {                                       \n\
-            return Lifepoints - Hitpoints;      \n\
-        }                                       \n\
-                                                \n\
-        int main()                              \n\
-        {                                       \n\
+        {                                           \n\
+            return Lifepoints - Hitpoints;          \n\
+        }                                           \n\
+                                                    \n\
+        int main()                                  \n\
+        {                                           \n\
             int hp = Weapon.CalcDamage(9) + Weapon.CalcDamage(9, 40);  \n\
             return hp + Weapon.CalcDamage(100);     \n\
-        }                                       \n\
+        }                                           \n\
         ";
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Static1", scrip);
-    size_t const codesize = 107;
+
+    size_t const codesize = 117;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-      51,   16,    7,    3,           30,    4,   12,    4,    // 15
-       3,    3,    4,    3,            5,   38,   21,    6,    // 23
-       3,    5,   29,    3,            6,    3,    9,   29,    // 31
-       3,    6,    3,    0,           23,    3,    2,    1,    // 39
-       8,   29,    3,    6,            3,   40,   29,    3,    // 47
-       6,    3,    9,   29,            3,    6,    3,    0,    // 55
-      23,    3,    2,    1,            8,   30,    4,   11,    // 63
-       4,    3,    3,    4,            3,   29,    3,   51,    // 71
-       4,    7,    3,   29,            3,    6,    3,    5,    // 79
-      29,    3,    6,    3,          100,   29,    3,    6,    // 87
-       3,    0,   23,    3,            2,    1,    8,   30,    // 95
-       4,   11,    4,    3,            3,    4,    3,    2,    // 103
-       1,    4,    5,  -999
+      36,    7,   38,    0,           36,    8,   51,    8,    // 7
+       7,    3,   29,    3,           51,   16,    7,    3,    // 15
+      30,    4,   12,    4,            3,    3,    4,    3,    // 23
+       5,   36,   12,   38,           25,   36,   13,    6,    // 31
+       3,    5,   29,    3,            6,    3,    9,   29,    // 39
+       3,    6,    3,    0,           23,    3,    2,    1,    // 47
+       8,   29,    3,    6,            3,   40,   29,    3,    // 55
+       6,    3,    9,   29,            3,    6,    3,    0,    // 63
+      23,    3,    2,    1,            8,   30,    4,   11,    // 71
+       4,    3,    3,    4,            3,   29,    3,   36,    // 79
+      14,   51,    4,    7,            3,   29,    3,    6,    // 87
+       3,    5,   29,    3,            6,    3,  100,   29,    // 95
+       3,    6,    3,    0,           23,    3,    2,    1,    // 103
+       8,   30,    4,   11,            4,    3,    3,    4,    // 111
+       3,    2,    1,    4,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -4324,7 +4559,7 @@ TEST_F(Bytecode0, Static1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      35,   55,   89,  -999
+      43,   63,   99,  -999
     };
     char fixuptypes[] = {
       2,   2,   2,  '\0'
@@ -4346,7 +4581,7 @@ TEST_F(Bytecode0, Static1) {
 
 TEST_F(Bytecode0, Static2) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
         };                                     \n\
                                                \n\
@@ -4365,15 +4600,17 @@ TEST_F(Bytecode0, Static2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Static2", scrip);
-    size_t const codesize = 42;
+
+    size_t const codesize = 50;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-      51,   16,    7,    3,           30,    4,   12,    4,    // 15
-       3,    3,    4,    3,            5,   38,   21,    6,    // 23
-       3,   40,   29,    3,            6,    3,    9,   29,    // 31
-       3,    6,    3,    0,           23,    3,    2,    1,    // 39
+      36,    5,   38,    0,           36,    6,   51,    8,    // 7
+       7,    3,   29,    3,           51,   16,    7,    3,    // 15
+      30,    4,   12,    4,            3,    3,    4,    3,    // 23
+       5,   36,   10,   38,           25,   36,   11,    6,    // 31
+       3,   40,   29,    3,            6,    3,    9,   29,    // 39
+       3,    6,    3,    0,           23,    3,    2,    1,    // 47
        8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -4382,7 +4619,7 @@ TEST_F(Bytecode0, Static2) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      35,  -999
+      43,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -4402,46 +4639,63 @@ TEST_F(Bytecode0, Static2) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
-TEST_F(Bytecode0, Protected2) {
+TEST_F(Bytecode0, Import) {    
 
-    // In a struct func, a variable that can't be found otherwise
-    // should be taken to be out of the current struct.
-
-    const char *inpl = "\
-        struct Weapon {                        \n\
-            protected int Damage;              \n\
-            import int SetDamage(int damage);  \n\
-        };                                     \n\
-                                               \n\
-        Weapon wp;                             \n\
-                                               \n\
-        int Weapon::SetDamage(int damage)      \n\
-        {                                      \n\
-            Damage = damage;                   \n\
-            return 0;                          \n\
-        }                                      \n\
+    char const *inpl = "\
+        import int Weapon;                      \n\
+                                                \n\
+        int Func(int damage)                    \n\
+        {                                       \n\
+            int Int = 0;                        \n\
+            Weapon = 77;                        \n\
+            if (Weapon < 0)                     \n\
+                Weapon =                        \n\
+                    damage -                    \n\
+                    (Int - Weapon) / Int;       \n\
+        }                                       \n\
         ";
-   
+
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("Protected2", scrip);
-    size_t const codesize = 16;
+    // WriteOutput("Import", scrip);
+
+    size_t const codesize = 112;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,    3,    6,    // 7
-       2,   52,    8,    3,            6,    3,    0,    5,    // 15
+      36,    4,   38,    0,           36,    5,    6,    3,    // 7
+       0,   29,    3,   36,            6,    6,    3,   77,    // 15
+       6,    2,    0,    8,            3,   36,    7,    6,    // 23
+       2,    0,    7,    3,           29,    3,    6,    3,    // 31
+       0,   30,    4,   18,            4,    3,    3,    4,    // 39
+       3,   28,   60,   36,            9,   51,   12,    7,    // 47
+       3,   29,    3,   36,           10,   51,    8,    7,    // 55
+       3,   29,    3,    6,            2,    0,    7,    3,    // 63
+      30,    4,   12,    4,            3,    3,    4,    3,    // 71
+      29,    3,   51,   12,            7,    3,   30,    4,    // 79
+      10,    4,    3,    3,            4,    3,   36,    9,    // 87
+      30,    4,   12,    4,            3,    3,    4,    3,    // 95
+      36,    8,    6,    2,            0,    8,    3,   36,    // 103
+      11,    2,    1,    4,            6,    3,    0,    5,    // 111
      -999
     };
     CompareCode(&scrip, codesize, code);
 
-    size_t const numfixups = 0;
+    size_t const numfixups = 4;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
-    int const numimports = 0;
+    int32_t fixups[] = {
+      18,   25,   61,  100,        -999
+    };
+    char fixuptypes[] = {
+      4,   4,   4,   4,     '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 1;
     std::string imports[] = {
-     "[[SENTINEL]]"
+    "Weapon",       "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
@@ -4449,66 +4703,4 @@ TEST_F(Bytecode0, Protected2) {
     EXPECT_EQ(numexports, scrip.numexports);
 
     size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
-
-TEST_F(Bytecode0, Import) {    
-
-    const char *inpl = "\
-        import int Weapon;                     \n\
-                                               \n\
-        int Func(int damage)                   \n\
-        {                                      \n\
-            int Int = 0;                       \n\
-            Weapon = 77;                       \n\
-            if (Weapon < 0)                    \n\
-                Weapon = damage - (Int - Weapon) / Int; \n\
-        }                                      \n\
-        ";
-
-    int compileResult = cc_compile(inpl, scrip);
-    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    // WriteOutput("Import", scrip);
-    const size_t codesize = 94;
-    EXPECT_EQ(codesize, scrip.codesize);
-
-    int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,   77,    6,    2,            0,    8,    3,    6,    // 15
-       2,    0,    7,    3,           29,    3,    6,    3,    // 23
-       0,   30,    4,   18,            4,    3,    3,    4,    // 31
-       3,   28,   52,   51,           12,    7,    3,   29,    // 39
-       3,   51,    8,    7,            3,   29,    3,    6,    // 47
-       2,    0,    7,    3,           30,    4,   12,    4,    // 55
-       3,    3,    4,    3,           29,    3,   51,   12,    // 63
-       7,    3,   30,    4,           10,    4,    3,    3,    // 71
-       4,    3,   30,    4,           12,    4,    3,    3,    // 79
-       4,    3,    6,    2,            0,    8,    3,    2,    // 87
-       1,    4,    6,    3,            0,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    const size_t numfixups = 4;
-    EXPECT_EQ(numfixups, scrip.numfixups);
-
-    int32_t fixups[] = {
-      12,   17,   49,   84,        -999
-    };
-    char fixuptypes[] = {
-      4,   4,   4,   4,     '\0'
-    };
-    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
-
-    const int numimports = 1;
-    std::string imports[] = {
-    "Weapon",       "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    const size_t numexports = 0;
-    EXPECT_EQ(numexports, scrip.numexports);
-
-    const size_t stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
+    EXPECT_EQ(stringssize, scrip.stringssize);}

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -18,13 +18,13 @@
 class Bytecode1 : public ::testing::Test
 {
 protected:
-    AGS::ccCompiledScript scrip{ false };
+    AGS::ccCompiledScript scrip{ true }; // enable LINUM directives
 
     Bytecode1()
     {
         // Initializations, will be done at the start of each test
+        // Note, the parser doesn't react to SCOPT_LINENUMBERS, that's on ccCompiledScript
         ccSetOption(SCOPT_NOIMPORTOVERRIDE, false);
-        ccSetOption(SCOPT_LINENUMBERS, false);
         clear_error();
     }
 };
@@ -32,7 +32,7 @@ protected:
 TEST_F(Bytecode1, StringOldstyle01) {
     ccSetOption(SCOPT_OLDSTRINGS, true);
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Sentinel1;              \n\
         string GLOBAL;              \n\
         int Sentinel2;              \n\
@@ -49,13 +49,15 @@ TEST_F(Bytecode1, StringOldstyle01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringOldstyle01", scrip);
-    size_t const codesize = 26;
+
+    size_t const codesize = 34;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,  200,    1,    1,    // 7
-     200,   51,    0,   63,            1,    1,    1,    1,    // 15
-       6,    2,    4,    3,            2,    3,    2,    1,    // 23
+      36,    6,   38,    0,           36,    7,   51,    0,    // 7
+      63,  200,    1,    1,          200,   36,    8,   51,    // 15
+       0,   63,    1,    1,            1,    1,   36,    9,    // 23
+       6,    2,    4,    3,            2,    3,    2,    1,    // 31
      201,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -64,7 +66,7 @@ TEST_F(Bytecode1, StringOldstyle01) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      18,  -999
+      26,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -86,7 +88,7 @@ TEST_F(Bytecode1, StringOldstyle01) {
 
 TEST_F(Bytecode1, StringOldstyle02) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int sub(const string s) \n\
         {                       \n\
             return;             \n\
@@ -104,14 +106,16 @@ TEST_F(Bytecode1, StringOldstyle02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringOldstyle02", scrip);
-    size_t const codesize = 25;
+
+    size_t const codesize = 35;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,    5,   38,    6,    // 7
-       6,    3,    0,   29,            3,    6,    3,    0,    // 15
-      23,    3,    2,    1,            4,    6,    3,    0,    // 23
-       5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,    5,   36,    7,           38,   10,   36,    8,    // 15
+       6,    3,    0,   29,            3,    6,    3,    0,    // 23
+      23,    3,    2,    1,            4,   36,    9,    6,    // 31
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -119,7 +123,7 @@ TEST_F(Bytecode1, StringOldstyle02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      10,   15,  -999
+      18,   23,  -999
     };
     char fixuptypes[] = {
       3,   2,  '\0'
@@ -146,7 +150,7 @@ TEST_F(Bytecode1, StringOldstyle02) {
 
 TEST_F(Bytecode1, StringOldstyle03) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         int Sentinel1;                  \n\
         string Global;                  \n\
         int Sentinel2;                  \n\
@@ -168,44 +172,47 @@ TEST_F(Bytecode1, StringOldstyle03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringOldstyle03", scrip);
-    const size_t codesize = 76;
+
+    size_t const codesize = 88;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   51,    8,    3,    // 7
-       3,    5,    3,    2,            4,    6,    7,  199,    // 15
-       3,    4,    2,    7,            3,    3,    5,    2,    // 23
-       8,    3,   28,   25,            1,    4,    1,    1,    // 31
-       5,    1,    2,    7,            1,    3,    7,    3,    // 39
-      70,  -26,    1,    5,            1,    3,    5,    2,    // 47
-       6,    3,    0,    8,            3,    5,   38,   54,    // 55
-       6,    2,    4,    3,            2,    3,   29,    3,    // 63
-       6,    3,    0,   23,            3,    2,    1,    4,    // 71
-       6,    3,    0,    5,          -999
+      36,    6,   38,    0,           36,    7,    6,    3,    // 7
+       0,   51,    8,    3,            3,    5,    3,    2,    // 15
+       4,    6,    7,  199,            3,    4,    2,    7,    // 23
+       3,    3,    5,    2,            8,    3,   28,   25,    // 31
+       1,    4,    1,    1,            5,    1,    2,    7,    // 39
+       1,    3,    7,    3,           70,  -26,    1,    5,    // 47
+       1,    3,    5,    2,            6,    3,    0,    8,    // 55
+       3,   36,    8,    5,           36,   11,   38,   60,    // 63
+      36,   12,    6,    2,            4,    3,    2,    3,    // 71
+      29,    3,    6,    3,            0,   23,    3,    2,    // 79
+       1,    4,   36,   13,            6,    3,    0,    5,    // 87
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 3;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   58,   66,  -999
+       8,   68,   76,  -999
     };
     char fixuptypes[] = {
       3,   1,   2,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 10;
+    size_t const stringssize = 10;
     EXPECT_EQ(stringssize, scrip.stringssize);
 
     char strings[] = {
@@ -217,7 +224,7 @@ TEST_F(Bytecode1, StringOldstyle03) {
 
 TEST_F(Bytecode1, StringOldstyle04) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         int Sentinel;                   \n\
         string Global;                  \n\
         int main()                      \n\
@@ -236,21 +243,23 @@ TEST_F(Bytecode1, StringOldstyle04) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringOldstyle04", scrip);
-    size_t const codesize = 84;
+
+    size_t const codesize = 94;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            4,    3,    2,    3,    // 7
-      29,    3,    6,    3,           76,   23,    3,    2,    // 15
-       1,    4,   51,    0,            3,    3,    5,    3,    // 23
-       2,    4,    6,    7,          199,    3,    4,    2,    // 31
-       7,    3,    3,    5,            2,    8,    3,   28,    // 39
-      25,    1,    4,    1,            1,    5,    1,    2,    // 47
-       7,    1,    3,    7,            3,   70,  -26,    1,    // 55
-       5,    1,    3,    5,            2,    6,    3,    0,    // 63
-       8,    3,    1,    1,          200,    2,    1,  200,    // 71
-       6,    3,    0,    5,           38,   76,   51,    8,    // 79
-       3,    2,    3,    5,          -999
+      36,    4,   38,    0,           36,    5,    6,    2,    // 7
+       4,    3,    2,    3,           29,    3,    6,    3,    // 15
+      82,   23,    3,    2,            1,    4,   51,    0,    // 23
+       3,    3,    5,    3,            2,    4,    6,    7,    // 31
+     199,    3,    4,    2,            7,    3,    3,    5,    // 39
+       2,    8,    3,   28,           25,    1,    4,    1,    // 47
+       1,    5,    1,    2,            7,    1,    3,    7,    // 55
+       3,   70,  -26,    1,            5,    1,    3,    5,    // 63
+       2,    6,    3,    0,            8,    3,    1,    1,    // 71
+     200,   36,    6,    2,            1,  200,    6,    3,    // 79
+       0,    5,   36,    8,           38,   82,   36,    9,    // 87
+      51,    8,    3,    2,            3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -258,7 +267,7 @@ TEST_F(Bytecode1, StringOldstyle04) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   12,  -999
+       8,   16,  -999
     };
     char fixuptypes[] = {
       1,   2,  '\0'
@@ -280,7 +289,7 @@ TEST_F(Bytecode1, StringOldstyle04) {
 
 TEST_F(Bytecode1, StringOldstyle05) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                  \n\
         {                           \n\
             string S3 = \"Holz-\";  \n\
@@ -295,50 +304,52 @@ TEST_F(Bytecode1, StringOldstyle05) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringOldstyle05", scrip);
-    const size_t codesize = 121;
+
+    size_t const codesize = 131;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   51,    0,    3,    // 7
-       3,    5,    3,    2,            4,    6,    7,  199,    // 15
-       3,    4,    2,    7,            3,    3,    5,    2,    // 23
-       8,    3,   28,   25,            1,    4,    1,    1,    // 31
-       5,    1,    2,    7,            1,    3,    7,    3,    // 39
-      70,  -26,    1,    5,            1,    3,    5,    2,    // 47
-       6,    3,    0,    8,            3,    1,    1,  200,    // 55
-      51,    0,   63,  200,            1,    1,  200,    6,    // 63
-       3,    6,   51,  200,            3,    3,    5,    3,    // 71
-       2,    4,    6,    7,          199,    3,    4,    2,    // 79
-       7,    3,    3,    5,            2,    8,    3,   28,    // 87
-      25,    1,    4,    1,            1,    5,    1,    2,    // 95
-       7,    1,    3,    7,            3,   70,  -26,    1,    // 103
-       5,    1,    3,    5,            2,    6,    3,    0,    // 111
-       8,    3,    2,    1,          400,    6,    3,    0,    // 119
-       5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   51,    0,    3,            3,    5,    3,    2,    // 15
+       4,    6,    7,  199,            3,    4,    2,    7,    // 23
+       3,    3,    5,    2,            8,    3,   28,   25,    // 31
+       1,    4,    1,    1,            5,    1,    2,    7,    // 39
+       1,    3,    7,    3,           70,  -26,    1,    5,    // 47
+       1,    3,    5,    2,            6,    3,    0,    8,    // 55
+       3,    1,    1,  200,           36,    4,   51,    0,    // 63
+      63,  200,    1,    1,          200,   36,    5,    6,    // 71
+       3,    6,   51,  200,            3,    3,    5,    3,    // 79
+       2,    4,    6,    7,          199,    3,    4,    2,    // 87
+       7,    3,    3,    5,            2,    8,    3,   28,    // 95
+      25,    1,    4,    1,            1,    5,    1,    2,    // 103
+       7,    1,    3,    7,            3,   70,  -26,    1,    // 111
+       5,    1,    3,    5,            2,    6,    3,    0,    // 119
+       8,    3,   36,    6,            2,    1,  400,    6,    // 127
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 2;
+    size_t const numfixups = 2;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   65,  -999
+       8,   73,  -999
     };
     char fixuptypes[] = {
       3,   3,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 13;
+    size_t const stringssize = 13;
     EXPECT_EQ(stringssize, scrip.stringssize);
 
     char strings[] = {
@@ -350,7 +361,7 @@ TEST_F(Bytecode1, StringOldstyle05) {
 
 TEST_F(Bytecode1, StringStandard01) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         int main()                         \n\
         {                                  \n\
             String s = \"Hello, world!\";  \n\
@@ -359,6 +370,7 @@ TEST_F(Bytecode1, StringStandard01) {
             return 0;                      \n\
         }                                  \n\
         ";
+
     std::string input = "";
     input += g_Input_Bool;
     input += g_Input_String;
@@ -369,17 +381,19 @@ TEST_F(Bytecode1, StringStandard01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringStandard01", scrip);
-    size_t const codesize = 53;
+
+    size_t const codesize = 63;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   64,    3,   51,    // 7
-       0,   47,    3,    1,            1,    4,   51,    4,    // 15
-      48,    3,   29,    3,            6,    3,   14,   30,    // 23
-       4,   66,    4,    3,            3,    4,    3,   28,    // 31
-      10,    6,    3,    1,           51,    4,   49,    2,    // 39
-       1,    4,    5,    6,            3,    0,   51,    4,    // 47
-      49,    2,    1,    4,            5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   64,    3,   51,            0,   47,    3,    1,    // 15
+       1,    4,   36,    4,           51,    4,   48,    3,    // 23
+      29,    3,    6,    3,           14,   30,    4,   66,    // 31
+       4,    3,    3,    4,            3,   28,   12,   36,    // 39
+       5,    6,    3,    1,           51,    4,   49,    2,    // 47
+       1,    4,    5,   36,            6,    6,    3,    0,    // 55
+      51,    4,   49,    2,            1,    4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -387,7 +401,7 @@ TEST_F(Bytecode1, StringStandard01) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   22,  -999
+       8,   28,  -999
     };
     char fixuptypes[] = {
       3,   3,  '\0'
@@ -416,7 +430,7 @@ TEST_F(Bytecode1, StringStandard01) {
 
 TEST_F(Bytecode1, StringStandard02) {
     
-    const char inpl[] = "\
+    char const *inpl = "\
         String S;                           \n\
         import String I;                    \n\
         String Func1()                      \n\
@@ -437,6 +451,7 @@ TEST_F(Bytecode1, StringStandard02) {
             return \"Hello!\";              \n\
         }                                   \n\
         ";
+
     std::string input = "";
     input += g_Input_Bool;
     input += g_Input_String;
@@ -447,21 +462,24 @@ TEST_F(Bytecode1, StringStandard02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringStandard02", scrip);
-    size_t const codesize = 83;
+
+    size_t const codesize = 101;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    3,    5,    // 7
-      38,    8,   51,    8,            7,    3,   50,    3,    // 15
-      51,    8,   48,    3,           29,    3,   51,    4,    // 23
-      50,    3,   51,   12,           49,   51,    4,   48,    // 31
-       3,   69,   30,    4,            5,   38,   37,    6,    // 39
-       3,    7,   64,    3,           51,    0,   47,    3,    // 47
-       1,    1,    4,   51,            4,   48,    3,   29,    // 55
-       3,   51,    4,   50,            3,   51,    8,   49,    // 63
-      51,    4,   48,    3,           69,   30,    4,    2,    // 71
-       1,    4,    5,   38,           75,    6,    3,    7,    // 79
-      64,    3,    5,  -999
+      36,    4,   38,    0,           36,    5,    6,    2,    // 7
+       0,   48,    3,    5,           36,    8,   38,   12,    // 15
+      51,    8,    7,    3,           50,    3,   36,    9,    // 23
+      51,    8,   48,    3,           29,    3,   51,    4,    // 31
+      50,    3,   51,   12,           49,   51,    4,   48,    // 39
+       3,   69,   30,    4,            5,   36,   12,   38,    // 47
+      45,   36,   13,    6,            3,    7,   64,    3,    // 55
+      51,    0,   47,    3,            1,    1,    4,   36,    // 63
+      14,   51,    4,   48,            3,   29,    3,   51,    // 71
+       4,   50,    3,   51,            8,   49,   51,    4,    // 79
+      48,    3,   69,   30,            4,    2,    1,    4,    // 87
+       5,   36,   17,   38,           89,   36,   18,    6,    // 95
+       3,    7,   64,    3,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -469,7 +487,7 @@ TEST_F(Bytecode1, StringStandard02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   41,   79,  -999
+       8,   53,   97,  -999
     };
     char fixuptypes[] = {
       1,   3,   3,  '\0'
@@ -497,7 +515,7 @@ TEST_F(Bytecode1, StringStandard02) {
 
 TEST_F(Bytecode1, StringStandardOldstyle) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         string OS;                          \n\
         String Func1()                      \n\
         {                                   \n\
@@ -517,6 +535,7 @@ TEST_F(Bytecode1, StringStandardOldstyle) {
             Func3(S);                       \n\
         }                                   \n\
         ";
+
     std::string input = "";
     input += g_Input_Bool;
     input += g_Input_String;
@@ -528,23 +547,27 @@ TEST_F(Bytecode1, StringStandardOldstyle) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StringStandardOldstyle", scrip);
-    size_t const codesize = 98;
+
+    size_t const codesize = 120;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    3,    2,    3,    // 7
-      64,    3,    5,   38,           11,   51,    8,    7,    // 15
-       3,   50,    3,   51,            8,   48,    3,   29,    // 23
-       3,   51,    4,   50,            3,   51,   12,   49,    // 31
-      51,    4,   48,    3,           69,   30,    4,    5,    // 39
-      38,   40,    6,    3,            6,   64,    3,   29,    // 47
-       3,    6,    3,   11,           23,    3,    2,    1,    // 55
-       4,    6,    3,    0,            5,   38,   61,    6,    // 63
-       3,    6,   64,    3,           51,    0,   47,    3,    // 71
-       1,    1,    4,   51,            4,   48,    3,   67,    // 79
-       3,   29,    3,    6,            3,   40,   23,    3,    // 87
-       2,    1,    4,   51,            4,   49,    2,    1,    // 95
-       4,    5,  -999
+      36,    3,   38,    0,           36,    4,    6,    2,    // 7
+       0,    3,    2,    3,           64,    3,    5,   36,    // 15
+       7,   38,   15,   51,            8,    7,    3,   50,    // 23
+       3,   36,    8,   51,            8,   48,    3,   29,    // 31
+       3,   51,    4,   50,            3,   51,   12,   49,    // 39
+      51,    4,   48,    3,           69,   30,    4,    5,    // 47
+      36,   11,   38,   48,           36,   12,    6,    3,    // 55
+       6,   64,    3,   29,            3,    6,    3,   15,    // 63
+      23,    3,    2,    1,            4,   36,   13,    6,    // 71
+       3,    0,    5,   36,           15,   38,   75,   36,    // 79
+      16,    6,    3,    6,           64,    3,   51,    0,    // 87
+      47,    3,    1,    1,            4,   36,   17,   51,    // 95
+       4,   48,    3,   67,            3,   29,    3,    6,    // 103
+       3,   48,   23,    3,            2,    1,    4,   36,    // 111
+      18,   51,    4,   49,            2,    1,    4,    5,    // 119
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -552,7 +575,7 @@ TEST_F(Bytecode1, StringStandardOldstyle) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   44,   51,   65,         85,  -999
+       8,   56,   63,   83,        105,  -999
     };
     char fixuptypes[] = {
       1,   3,   2,   3,      2,  '\0'
@@ -585,7 +608,7 @@ TEST_F(Bytecode1, AccessStructAsPointer01) {
     // - the struct is "builtin" as well as "managed".
     // Such structs can be used as a parameter of a function that expects a pointered struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Object {                 \n\
         };                                              \n\
         import Object oCleaningCabinetDoor;             \n\
@@ -604,41 +627,44 @@ TEST_F(Bytecode1, AccessStructAsPointer01) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("AccessStructAsPointer01", scrip);
-    const size_t codesize = 39;
+
+    size_t const codesize = 45;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            2,   48,    2,   52,    // 7
-      29,    2,    6,    2,            0,    3,    2,    3,    // 15
-      34,    3,   51,    4,            7,    2,   45,    2,    // 23
-      39,    1,    6,    3,            1,   33,    3,   35,    // 31
-       1,   30,    2,    6,            3,    0,    5,  -999
+      36,   12,   38,    0,           36,   13,    6,    2,    // 7
+       2,   48,    2,   52,           29,    2,    6,    2,    // 15
+       0,    3,    2,    3,           34,    3,   51,    4,    // 23
+       7,    2,   45,    2,           39,    1,    6,    3,    // 31
+       1,   33,    3,   35,            1,   30,    2,   36,    // 39
+      14,    6,    3,    0,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 3;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   12,   28,  -999
+       8,   16,   32,  -999
     };
     char fixuptypes[] = {
       4,   4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 3;
+    int const numimports = 3;
     std::string imports[] = {
     "oCleaningCabinetDoor",       "Character::FaceObject^1",    "player",      // 2
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -647,7 +673,7 @@ TEST_F(Bytecode1, AccessStructAsPointer02) {
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Object { };              \n\
         import Object oCleaningCabinetDoor;             \n\
                                                         \n\
@@ -666,44 +692,47 @@ TEST_F(Bytecode1, AccessStructAsPointer02) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("AccessStructAsPointer02", scrip);
-    const size_t codesize = 56;
+
+    size_t const codesize = 64;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    3,    2,    3,    // 7
-      51,    0,   47,    3,            1,    1,    4,    6,    // 15
-       2,    2,   48,    2,           52,   29,    2,   51,    // 23
-       8,   48,    3,   34,            3,   51,    4,    7,    // 31
-       2,   45,    2,   39,            1,    6,    3,    1,    // 39
-      33,    3,   35,    1,           30,    2,   51,    4,    // 47
-      49,    2,    1,    4,            6,    3,    0,    5,    // 55
+      36,   11,   38,    0,           36,   12,    6,    2,    // 7
+       0,    3,    2,    3,           51,    0,   47,    3,    // 15
+       1,    1,    4,   36,           13,    6,    2,    2,    // 23
+      48,    2,   52,   29,            2,   51,    8,   48,    // 31
+       3,   34,    3,   51,            4,    7,    2,   45,    // 39
+       2,   39,    1,    6,            3,    1,   33,    3,    // 47
+      35,    1,   30,    2,           36,   14,   51,    4,    // 55
+      49,    2,    1,    4,            6,    3,    0,    5,    // 63
      -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 3;
+    size_t const numfixups = 3;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   17,   39,  -999
+       8,   23,   45,  -999
     };
     char fixuptypes[] = {
       4,   4,   4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 3;
+    int const numimports = 3;
     std::string imports[] = {
     "oCleaningCabinetDoor",       "Character::FaceObject^1",    "player",      // 2
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -712,7 +741,7 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
     // Managed structs can be declared without (implicit) pointer in certain circumstances.
     // Such structs can be assigned to a variable that is a pointered struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Object {                 \n\
             readonly int Reserved;                      \n\
         };                                              \n\
@@ -732,45 +761,48 @@ TEST_F(Bytecode1, AccessStructAsPointer03) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("AccessStructAsPointer03", scrip);
-    const size_t codesize = 28;
+
+    size_t const codesize = 34;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    1,    2,   20,    // 7
-       3,    2,    3,   51,            0,   47,    3,    1,    // 15
-       1,    4,   51,    4,           49,    2,    1,    4,    // 23
-       6,    3,    0,    5,          -999
+      36,   13,   38,    0,           36,   14,    6,    2,    // 7
+       0,    1,    2,   20,            3,    2,    3,   51,    // 15
+       0,   47,    3,    1,            1,    4,   36,   15,    // 23
+      51,    4,   49,    2,            1,    4,    6,    3,    // 31
+       0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 1;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,  -999
+       8,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 3;
+    int const numimports = 1;
     std::string imports[] = {
-    "object",      "Character::FaceObject^1",    "player",       "[[SENTINEL]]"
+    "object",       "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
 TEST_F(Bytecode1, Attributes01) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1, };              \n\
         builtin managed struct ViewFrame {              \n\
             readonly import attribute bool Flipped;     \n\
@@ -796,29 +828,32 @@ TEST_F(Bytecode1, Attributes01) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Attributes01", scrip);
-    size_t const codesize = 154;
+
+    size_t const codesize = 170;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           49,    1,    1,    4,    // 7
-      51,    4,   48,    2,           52,   29,    6,   45,    // 15
-       2,   39,    0,    6,            3,    0,   33,    3,    // 23
-      30,    6,   28,  101,           51,    4,   48,    2,    // 31
-      52,    6,    3,   17,           29,    6,   34,    3,    // 39
-      45,    2,   39,    1,            6,    3,    2,   33,    // 47
-       3,   35,    1,   30,            6,   51,    4,   48,    // 55
-       2,   52,   29,    6,           45,    2,   39,    0,    // 63
-       6,    3,    3,   33,            3,   30,    6,   29,    // 71
-       3,   51,    8,   48,            2,   52,   29,    6,    // 79
-      45,    2,   39,    0,            6,    3,    3,   33,    // 87
-       3,   30,    6,   30,            4,   57,    4,    3,    // 95
-       3,    4,    3,   29,            3,   51,    8,   48,    // 103
-       2,   52,   29,    6,           45,    2,   39,    0,    // 111
-       6,    3,    1,   33,            3,   30,    6,   51,    // 119
-       8,   49,    2,    1,            8,    5,    2,    1,    // 127
-       4,   51,    4,   48,            2,   52,   29,    6,    // 135
-      45,    2,   39,    0,            6,    3,    0,   33,    // 143
-       3,   30,    6,   51,            4,   49,    2,    1,    // 151
+      36,    9,   38,    0,           36,   10,   51,    0,    // 7
+      49,    1,    1,    4,           36,   11,   51,    4,    // 15
+      48,    2,   52,   29,            6,   45,    2,   39,    // 23
+       0,    6,    3,    0,           33,    3,   30,    6,    // 31
+      28,  109,   36,   13,           51,    4,   48,    2,    // 39
+      52,    6,    3,   17,           29,    6,   34,    3,    // 47
+      45,    2,   39,    1,            6,    3,    2,   33,    // 55
+       3,   35,    1,   30,            6,   36,   14,   51,    // 63
+       4,   48,    2,   52,           29,    6,   45,    2,    // 71
+      39,    0,    6,    3,            3,   33,    3,   30,    // 79
+       6,   29,    3,   51,            8,   48,    2,   52,    // 87
+      29,    6,   45,    2,           39,    0,    6,    3,    // 95
+       3,   33,    3,   30,            6,   30,    4,   57,    // 103
+       4,    3,    3,    4,            3,   29,    3,   36,    // 111
+      15,   51,    8,   48,            2,   52,   29,    6,    // 119
+      45,    2,   39,    0,            6,    3,    1,   33,    // 127
+       3,   30,    6,   51,            8,   49,    2,    1,    // 135
+       8,    5,   36,   16,            2,    1,    4,   36,    // 143
+      17,   51,    4,   48,            2,   52,   29,    6,    // 151
+      45,    2,   39,    0,            6,    3,    0,   33,    // 159
+       3,   30,    6,   51,            4,   49,    2,    1,    // 167
        4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -827,7 +862,7 @@ TEST_F(Bytecode1, Attributes01) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      21,   46,   66,   86,        114,  142,  -999
+      27,   54,   76,   96,        126,  158,  -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,      4,   4,  '\0'
@@ -854,9 +889,9 @@ TEST_F(Bytecode1, Attributes02) {
     // they ought to be exported instead of imported.
     // Assigning to the attribute should generate the same call
     // as calling the setter; reading the same as calling the getter.
-    // Armor:: functions should be allowed to access _Damage.
+    // 'Armor::' functions should be allowed to access '_Damage'.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Armor {                          \n\
             attribute int Damage;                       \n\
             writeprotected short _Aura;                 \n\
@@ -886,25 +921,29 @@ TEST_F(Bytecode1, Attributes02) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Attributes02", scrip);
-    size_t const codesize = 119;
+
+    size_t const codesize = 139;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,            8,   51,    0,   47,    // 7
-       3,    1,    1,    4,           51,    4,   48,    2,    // 15
-      52,    6,    3,   17,           29,    6,   29,    3,    // 23
-      45,    2,    6,    3,           72,   23,    3,    2,    // 31
-       1,    4,   30,    6,           51,    4,   48,    2,    // 39
-      52,   29,    6,   45,            2,    6,    3,  107,    // 47
-      23,    3,   30,    6,           29,    3,    6,    3,    // 55
-      10,   30,    4,   17,            4,    3,    3,    4,    // 63
-       3,   51,    4,   49,            2,    1,    4,    5,    // 71
-      38,   72,   51,    8,            7,    3,   29,    3,    // 79
-       6,    3,    0,   30,            4,   19,    4,    3,    // 87
-       3,    4,    3,   28,           13,   51,    8,    7,    // 95
-       3,    3,    6,    2,           52,    1,    2,    2,    // 103
-       8,    3,    5,   38,          107,    3,    6,    2,    // 111
-      52,    1,    2,    2,            7,    3,    5,  -999
+      36,    8,   38,    0,           36,    9,   73,    3,    // 7
+       8,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   10,   51,    4,           48,    2,   52,    6,    // 23
+       3,   17,   29,    6,           29,    3,   45,    2,    // 31
+       6,    3,   80,   23,            3,    2,    1,    4,    // 39
+      30,    6,   36,   11,           51,    4,   48,    2,    // 47
+      52,   29,    6,   45,            2,    6,    3,  123,    // 55
+      23,    3,   30,    6,           29,    3,    6,    3,    // 63
+      10,   30,    4,   17,            4,    3,    3,    4,    // 71
+       3,   51,    4,   49,            2,    1,    4,    5,    // 79
+      36,   15,   38,   80,           36,   16,   51,    8,    // 87
+       7,    3,   29,    3,            6,    3,    0,   30,    // 95
+       4,   19,    4,    3,            3,    4,    3,   28,    // 103
+      15,   36,   17,   51,            8,    7,    3,    3,    // 111
+       6,    2,   52,    1,            2,    2,    8,    3,    // 119
+      36,   18,    5,   36,           21,   38,  123,   36,    // 127
+      22,    3,    6,    2,           52,    1,    2,    2,    // 135
+       7,    3,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -912,7 +951,7 @@ TEST_F(Bytecode1, Attributes02) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      28,   47,  -999
+      34,   55,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -938,7 +977,7 @@ TEST_F(Bytecode1, Attributes03) {
     // so import decls should be generated for them.
     // The getters and setters should be called as import funcs.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Armor {                          \n\
             attribute int Damage;                       \n\
             writeprotected short _aura;                 \n\
@@ -956,19 +995,21 @@ TEST_F(Bytecode1, Attributes03) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Attributes03", scrip);
-    size_t const codesize = 75;
+
+    size_t const codesize = 83;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,            8,   51,    0,   47,    // 7
-       3,    1,    1,    4,           51,    4,   48,    2,    // 15
-      52,    6,    3,   17,           29,    6,   34,    3,    // 23
-      45,    2,   39,    1,            6,    3,    1,   33,    // 31
-       3,   35,    1,   30,            6,   51,    4,   48,    // 39
-       2,   52,   29,    6,           45,    2,   39,    0,    // 47
-       6,    3,    0,   33,            3,   30,    6,   29,    // 55
-       3,    6,    3,   10,           30,    4,   17,    4,    // 63
-       3,    3,    4,    3,           51,    4,   49,    2,    // 71
+      36,    8,   38,    0,           36,    9,   73,    3,    // 7
+       8,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   10,   51,    4,           48,    2,   52,    6,    // 23
+       3,   17,   29,    6,           34,    3,   45,    2,    // 31
+      39,    1,    6,    3,            1,   33,    3,   35,    // 39
+       1,   30,    6,   36,           11,   51,    4,   48,    // 47
+       2,   52,   29,    6,           45,    2,   39,    0,    // 55
+       6,    3,    0,   33,            3,   30,    6,   29,    // 63
+       3,    6,    3,   10,           30,    4,   17,    4,    // 71
+       3,    3,    4,    3,           51,    4,   49,    2,    // 79
        1,    4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -977,7 +1018,7 @@ TEST_F(Bytecode1, Attributes03) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      30,   50,  -999
+      36,   58,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
@@ -1001,7 +1042,7 @@ TEST_F(Bytecode1, Attributes04) {
     
     // Attribute func was not called properly
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Character {      \n\
             import attribute int  x;            \n\
         };                                      \n\
@@ -1015,44 +1056,47 @@ TEST_F(Bytecode1, Attributes04) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("Attributes04", scrip);
-    const size_t codesize = 58;
+
+    size_t const codesize = 64;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           77,   29,    3,    6,    // 7
-       2,    2,   48,    2,           52,   29,    6,   45,    // 15
-       2,   39,    0,    6,            3,    0,   33,    3,    // 23
-      30,    6,   30,    4,           11,    3,    4,    6,    // 31
-       2,    2,   48,    2,           52,   29,    6,   34,    // 39
-       3,   45,    2,   39,            1,    6,    3,    1,    // 47
-      33,    3,   35,    1,           30,    6,    6,    3,    // 55
-       0,    5,  -999
+      36,    7,   38,    0,           36,    8,    6,    3,    // 7
+      77,   29,    3,    6,            2,    2,   48,    2,    // 15
+      52,   29,    6,   45,            2,   39,    0,    6,    // 23
+       3,    0,   33,    3,           30,    6,   30,    4,    // 31
+      11,    3,    4,    6,            2,    2,   48,    2,    // 39
+      52,   29,    6,   34,            3,   45,    2,   39,    // 47
+       1,    6,    3,    1,           33,    3,   35,    1,    // 55
+      30,    6,   36,    9,            6,    3,    0,    5,    // 63
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 4;
+    size_t const numfixups = 4;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,   21,   33,   47,        -999
+      13,   25,   37,   51,        -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,     '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 3;
+    int const numimports = 3;
     std::string imports[] = {
     "Character::get_x^0",         "Character::set_x^1",         "player",      // 2
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1060,7 +1104,7 @@ TEST_F(Bytecode1, Attributes05) {
     
     // Test static attribute
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool                               \n\
         {                                       \n\
             false = 0,                          \n\
@@ -1084,38 +1128,41 @@ TEST_F(Bytecode1, Attributes05) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("Attributes05", scrip);
-    const size_t codesize = 20;
+
+    size_t const codesize = 30;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   39,    0,            6,    3,    0,   33,    // 7
-       3,   28,    8,    6,            3,   99,   29,    3,    // 15
-       2,    1,    4,    5,          -999
+      36,   14,   38,    0,           36,   15,   39,    0,    // 7
+       6,    3,    0,   33,            3,   28,   12,   36,    // 15
+      17,    6,    3,   99,           29,    3,   36,   18,    // 23
+       2,    1,    4,   36,           19,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 1;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       6,  -999
+      10,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 1;
+    int const numimports = 1;
     std::string imports[] = {
     "Game::get_SkippingCutscene^0",               "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1123,7 +1170,7 @@ TEST_F(Bytecode1, Attributes06) {
     
     // Indexed static attribute -- must return an int
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Game             \n\
         {                                       \n\
             readonly import static attribute    \n\
@@ -1138,38 +1185,41 @@ TEST_F(Bytecode1, Attributes06) {
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("Attributes06", scrip);
-    const size_t codesize = 22;
+
+    size_t const codesize = 28;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            9,   34,    3,   39,    // 7
-       1,    6,    3,    0,           33,    3,   35,    1,    // 15
-      29,    3,    2,    1,            4,    5,  -999
+      36,    8,   38,    0,           36,    9,    6,    3,    // 7
+       9,   34,    3,   39,            1,    6,    3,    0,    // 15
+      33,    3,   35,    1,           29,    3,   36,   10,    // 23
+       2,    1,    4,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 1;
+    size_t const numfixups = 1;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      11,  -999
+      15,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 1;
+    int const numimports = 1;
     std::string imports[] = {
     "Game::geti_SpriteWidth^1",    "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1194,15 +1244,18 @@ TEST_F(Bytecode1, Attributes07) {
     int compileResult = cc_compile(input, scrip);
 
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("Attributes07", scrip);
-    size_t const codesize = 28;
+
+    size_t const codesize = 34;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,    6,    2,   22,    // 7
-      64,    3,   29,    6,           34,    3,   45,    2,    // 15
-      39,    1,    6,    3,           21,   33,    3,   35,    // 23
-       1,   30,    6,    5,          -999
+      36,    7,   38,    0,           36,    8,    6,    3,    // 7
+       0,    6,    2,   22,           64,    3,   29,    6,    // 15
+      34,    3,   45,    2,           39,    1,    6,    3,    // 23
+      21,   33,    3,   35,            1,   30,    6,   36,    // 31
+       9,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1210,7 +1263,7 @@ TEST_F(Bytecode1, Attributes07) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,    7,   20,  -999
+       8,   11,   24,  -999
     };
     char fixuptypes[] = {
       3,   4,   4,  '\0'
@@ -1237,7 +1290,7 @@ TEST_F(Bytecode1, Attributes07) {
 
 TEST_F(Bytecode1, Attributes08) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed autoptr struct String           \n\
         {                                               \n\
             char Payload;                               \n\
@@ -1268,25 +1321,29 @@ TEST_F(Bytecode1, Attributes08) {
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+
     // WriteOutput("Attributes08", scrip);
-    size_t const codesize = 105;
+
+    size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,   12,            7,    3,   50,    3,    // 7
-      51,   12,   49,    5,           38,   12,    6,    3,    // 15
-       0,    5,   38,   18,           51,    0,   49,    1,    // 23
-       1,    4,   51,    4,           48,    2,   52,   29,    // 31
-       6,   29,    2,    6,            3,    7,   30,    2,    // 39
-      29,    3,   45,    2,            6,    3,   12,   23,    // 47
-       3,    2,    1,    4,           30,    6,   51,    0,    // 55
-      47,    3,    1,    1,            4,   51,    4,   48,    // 63
-       3,   51,    8,   48,            2,   52,   29,    6,    // 71
-      29,    3,   29,    2,            6,    3,    8,   30,    // 79
-       2,   29,    3,   45,            2,    6,    3,    0,    // 87
-      23,    3,    2,    1,            8,   30,    6,   51,    // 95
-       8,   49,   51,    4,           49,    2,    1,    8,    // 103
-       5,  -999
+      36,   12,   38,    0,           51,   12,    7,    3,    // 7
+      50,    3,   36,   13,           51,   12,   49,    5,    // 15
+      36,   16,   38,   16,           36,   17,    6,    3,    // 23
+       0,    5,   36,   21,           38,   26,   36,   22,    // 31
+      51,    0,   49,    1,            1,    4,   36,   23,    // 39
+      51,    4,   48,    2,           52,   29,    6,   29,    // 47
+       2,    6,    3,    7,           30,    2,   29,    3,    // 55
+      45,    2,    6,    3,           16,   23,    3,    2,    // 63
+       1,    4,   30,    6,           51,    0,   47,    3,    // 71
+       1,    1,    4,   36,           24,   51,    4,   48,    // 79
+       3,   51,    8,   48,            2,   52,   29,    6,    // 87
+      29,    3,   29,    2,            6,    3,    8,   30,    // 95
+       2,   29,    3,   45,            2,    6,    3,    0,    // 103
+      23,    3,    2,    1,            8,   30,    6,   36,    // 111
+      25,   51,    8,   49,           51,    4,   49,    2,    // 119
+       1,    8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1294,7 +1351,7 @@ TEST_F(Bytecode1, Attributes08) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      46,   87,  -999
+      60,  103,  -999
     };
     char fixuptypes[] = {
       2,   2,  '\0'
@@ -1319,7 +1376,7 @@ TEST_F(Bytecode1, Attributes09) {
     // Function call to 'set_Visible()' mustn't go awry
     // After loading 'true' to AX´, must protect AX from being clobbered (push it)
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true };                  \n\
         builtin managed struct GUIControl               \n\
         {                                               \n\
@@ -1341,16 +1398,19 @@ TEST_F(Bytecode1, Attributes09) {
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
+
     // WriteOutput("Attributes09", scrip);
-    size_t const codesize = 37;
+
+    size_t const codesize = 43;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   39,    0,            6,    3,    2,   33,    // 7
-       3,    3,    3,    2,           52,    6,    3,    1,    // 15
-      29,    6,   34,    3,           45,    2,   39,    1,    // 23
-       6,    3,    1,   33,            3,   35,    1,   30,    // 31
-       6,    6,    3,    0,            5,  -999
+      36,   14,   38,    0,           36,   15,   39,    0,    // 7
+       6,    3,    2,   33,            3,    3,    3,    2,    // 15
+      52,    6,    3,    1,           29,    6,   34,    3,    // 23
+      45,    2,   39,    1,            6,    3,    1,   33,    // 31
+       3,   35,    1,   30,            6,   36,   16,    6,    // 39
+       3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1358,7 +1418,7 @@ TEST_F(Bytecode1, Attributes09) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       6,   26,  -999
+      10,   30,  -999
     };
     char fixuptypes[] = {
       4,   4,  '\0'
@@ -1387,49 +1447,56 @@ TEST_F(Bytecode1, Attributes10) {
     inpl += g_Input_String;
 
     inpl += "\
-    builtin managed struct Character                    \n\
-    {                                                   \n\
-        int payload;                                    \n\
-    };                                                  \n\
-    import attribute float Weight(this Character *);    \n\
-    import attribute String Weapon[](this Character);   \n\
-    Character *player;                                  \n\
-                                                        \n\
-    int game_start()                                    \n\
-    {                                                   \n\
-        float weight = player.Weight;                   \n\
-        player.Weight = weight ?: 9.9;                  \n\
-        String weapon = player.Weapon[3];               \n\
-        player.Weapon[9] = \"Rotten tomato\";           \n\
-    }                                                   \n\
-    ";
+        builtin managed struct Character                    \n\
+        {                                                   \n\
+            int payload;                                    \n\
+        };                                                  \n\
+        import attribute float Weight(this Character *);    \n\
+        import attribute String Weapon[](this Character);   \n\
+        Character *player;                                  \n\
+                                                            \n\
+        int game_start()                                    \n\
+        {                                                   \n\
+            float weight = player.Weight;                   \n\
+            player.Weight                                   \n\
+                          =                                 \n\
+                            weight                          \n\
+                                   ?:                       \n\
+                                      9.9;                  \n\
+            String weapon = player.Weapon[3];               \n\
+            player.Weapon[9] = \"Rotten tomato\";           \n\
+        }                                                   \n\
+        ";
 
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 
     // WriteOutput("Attributes10", scrip);
-    size_t const codesize = 139;
+
+    size_t const codesize = 155;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    2,   52,    // 7
-      29,    6,   45,    2,           39,    0,    6,    3,    // 15
-      20,   33,    3,   30,            6,   29,    3,   51,    // 23
-       4,    7,    3,   70,            3,    6,    3, 1092511334,    // 31
-       6,    2,    0,   48,            2,   52,   29,    6,    // 39
-      34,    3,   45,    2,           39,    1,    6,    3,    // 47
-      21,   33,    3,   35,            1,   30,    6,    6,    // 55
-       2,    0,   48,    2,           52,   29,    6,   29,    // 63
-       2,    6,    3,    3,           30,    2,   34,    3,    // 71
-      45,    2,   39,    1,            6,    3,   22,   33,    // 79
-       3,   35,    1,   30,            6,   51,    0,   47,    // 87
-       3,    1,    1,    4,            6,    3,    0,    6,    // 95
-       2,    0,   48,    2,           52,   64,    3,   29,    // 103
-       6,   34,    3,   29,            2,    6,    3,    9,    // 111
-      30,    2,   34,    3,           45,    2,   39,    2,    // 119
-       6,    3,   23,   33,            3,   35,    2,   30,    // 127
-       6,   51,    4,   49,            2,    1,    8,    6,    // 135
+      36,   10,   38,    0,           36,   11,    6,    2,    // 7
+       0,   48,    2,   52,           29,    6,   45,    2,    // 15
+      39,    0,    6,    3,           20,   33,    3,   30,    // 23
+       6,   29,    3,   36,           14,   51,    4,    7,    // 31
+       3,   70,    5,   36,           16,    6,    3, 1092511334,    // 39
+      36,   12,    6,    2,            0,   48,    2,   52,    // 47
+      29,    6,   34,    3,           45,    2,   39,    1,    // 55
+       6,    3,   21,   33,            3,   35,    1,   30,    // 63
+       6,   36,   17,    6,            2,    0,   48,    2,    // 71
+      52,   29,    6,   29,            2,    6,    3,    3,    // 79
+      30,    2,   34,    3,           45,    2,   39,    1,    // 87
+       6,    3,   22,   33,            3,   35,    1,   30,    // 95
+       6,   51,    0,   47,            3,    1,    1,    4,    // 103
+      36,   18,    6,    3,            0,    6,    2,    0,    // 111
+      48,    2,   52,   64,            3,   29,    6,   34,    // 119
+       3,   29,    2,    6,            3,    9,   30,    2,    // 127
+      34,    3,   45,    2,           39,    2,    6,    3,    // 135
+      23,   33,    3,   35,            2,   30,    6,   36,    // 143
+      19,   51,    4,   49,            2,    1,    8,    6,    // 151
        3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -1438,8 +1505,8 @@ TEST_F(Bytecode1, Attributes10) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   16,   34,   48,         57,   78,   94,   97,    // 7
-     122,  -999
+       8,   20,   44,   58,         69,   90,  108,  111,    // 7
+     136,  -999
     };
     char fixuptypes[] = {
       1,   4,   1,   4,      1,   4,   3,   1,    // 7
@@ -1471,7 +1538,7 @@ TEST_F(Bytecode1, Attributes11) {
 
     // Accept static extender attributes
 
-    const char inpl[] = "\
+    char const *inpl = "\
     builtin managed struct Character                    \n\
     {                                                   \n\
         int payload;                                    \n\
@@ -1493,19 +1560,22 @@ TEST_F(Bytecode1, Attributes11) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
 
     // WriteOutput("Attributes11", scrip);
-    size_t const codesize = 68;
+
+    size_t const codesize = 80;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   39,    0,            6,    3,    0,   33,    // 7
-       3,   29,    3,    6,            3, 1117480550,   34,    3,    // 15
-      39,    1,    6,    3,            1,   33,    3,   35,    // 23
-       1,    6,    3,    3,           34,    3,   39,    1,    // 31
-       6,    3,    2,   33,            3,   35,    1,   29,    // 39
-       3,   51,    4,    7,            3,   34,    3,    6,    // 47
-       3,   33,   34,    3,           39,    2,    6,    3,    // 55
-       3,   33,    3,   35,            2,    2,    1,    8,    // 63
-       6,    3,    0,    5,          -999
+      36,    9,   38,    0,           36,   10,   39,    0,    // 7
+       6,    3,    0,   33,            3,   29,    3,   36,    // 15
+      11,    6,    3, 1117480550,           34,    3,   39,    1,    // 23
+       6,    3,    1,   33,            3,   35,    1,   36,    // 31
+      12,    6,    3,    3,           34,    3,   39,    1,    // 39
+       6,    3,    2,   33,            3,   35,    1,   29,    // 47
+       3,   36,   13,   51,            4,    7,    3,   34,    // 55
+       3,    6,    3,   33,           34,    3,   39,    2,    // 63
+       6,    3,    3,   33,            3,   35,    2,   36,    // 71
+      14,    2,    1,    8,            6,    3,    0,    5,    // 79
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1513,7 +1583,7 @@ TEST_F(Bytecode1, Attributes11) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       6,   20,   34,   56,        -999
+      10,   26,   42,   66,        -999
     };
     char fixuptypes[] = {
       4,   4,   4,   4,     '\0'
@@ -1534,58 +1604,11 @@ TEST_F(Bytecode1, Attributes11) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
         
-TEST_F(Bytecode1, DynArrayOfPrimitives) {
-    
-    // Dynamic arrays of primitives are allowed.
-
-    const char *inpl = "\
-        int main()                              \n\
-        {                                       \n\
-            short PrmArray[] = new short[10];   \n\
-            PrmArray[7] = 0;                    \n\
-            PrmArray[3] = PrmArray[7];          \n\
-        }                                       \n\
-    ";
-
-    int compileResult = cc_compile(inpl, scrip);
-    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
-
-    // WriteOutput("DynArrayOfPrimitives", scrip);
-    size_t const codesize = 59;
-    EXPECT_EQ(codesize, scrip.codesize);
-
-    int32_t code[] = {
-      38,    0,    6,    3,           10,   72,    3,    2,    // 7
-       0,   51,    0,   47,            3,    1,    1,    4,    // 15
-      51,    4,   48,    2,           52,    6,    3,    0,    // 23
-       1,    2,   14,   27,            3,   51,    4,   48,    // 31
-       2,   52,    1,    2,           14,   25,    3,   51,    // 39
-       4,   48,    2,   52,            1,    2,    6,   27,    // 47
-       3,   51,    4,   49,            2,    1,    4,    6,    // 55
-       3,    0,    5,  -999
-    };
-    CompareCode(&scrip, codesize, code);
-
-    size_t const numfixups = 0;
-    EXPECT_EQ(numfixups, scrip.numfixups);
-
-    int const numimports = 0;
-    std::string imports[] = {
-     "[[SENTINEL]]"
-    };
-    CompareImports(&scrip, numimports, imports);
-
-    size_t const numexports = 0;
-    EXPECT_EQ(numexports, scrip.numexports);
-
-    size_t const stringssize = 0;
-    EXPECT_EQ(stringssize, scrip.stringssize);
-}
-
 TEST_F(Bytecode1, ManagedDerefZerocheck) {
     
     // Bytecode ought to check that S isn't initialized yet
-    const char *inpl = "\
+
+    char const *inpl = "\
         managed struct Struct           \n\
         {                               \n\
             int Int[10];                \n\
@@ -1596,16 +1619,20 @@ TEST_F(Bytecode1, ManagedDerefZerocheck) {
             S.Int[4] = 1;               \n\
         }                               \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("ManagedDerefZerocheck", scrip);
-    size_t const codesize = 20;
+
+    size_t const codesize = 26;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    2,   52,    // 7
-       6,    3,    1,    1,            2,   16,    8,    3,    // 15
-       6,    3,    0,    5,          -999
+      36,    7,   38,    0,           36,    8,    6,    2,    // 7
+       0,   48,    2,   52,            6,    3,    1,    1,    // 15
+       2,   16,    8,    3,           36,    9,    6,    3,    // 23
+       0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1613,7 +1640,7 @@ TEST_F(Bytecode1, ManagedDerefZerocheck) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,  -999
+       8,  -999
     };
     char fixuptypes[] = {
       1,  '\0'
@@ -1637,52 +1664,56 @@ TEST_F(Bytecode1, MemInitPtr1) {
     
     // Check that pointer vars are pushed correctly in func calls
 
-    const char *inpl = "\
-        managed struct Struct1          \n\
-        {                               \n\
-            float Payload1;             \n\
-        };                              \n\
-        managed struct Struct2          \n\
-        {                               \n\
-            char Payload2;              \n\
-        };                              \n\
-                                        \n\
-        int main()                      \n\
-        {                               \n\
-            Struct1 SS1 = new Struct1;  \n\
-            SS1.Payload1 = 0.7;         \n\
-            Struct2 SS2 = new Struct2;  \n\
-            SS2.Payload2 = 4;           \n\
-            int Val = Func(SS1, SS2);   \n\
-        }                               \n\
-                                        \n\
-        int Func(Struct1 S1, Struct2 S2) \n\
-        {                               \n\
-            return S2.Payload2;         \n\
-        }                               \n\
+    char const *inpl = "\
+        managed struct Struct1              \n\
+        {                                   \n\
+            float Payload1;                 \n\
+        };                                  \n\
+        managed struct Struct2              \n\
+        {                                   \n\
+            char Payload2;                  \n\
+        };                                  \n\
+                                            \n\
+        int main()                          \n\
+        {                                   \n\
+            Struct1 SS1 = new Struct1;      \n\
+            SS1.Payload1 = 0.7;             \n\
+            Struct2 SS2 = new Struct2;      \n\
+            SS2.Payload2 = 4;               \n\
+            int Val = Func(SS1, SS2);       \n\
+        }                                   \n\
+                                            \n\
+        int Func(Struct1 S1, Struct2 S2)    \n\
+        {                                   \n\
+            return S2.Payload2;             \n\
+        }                                   \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("MemInitPtr1", scrip);
-    size_t const codesize = 105;
+    WriteOutput("MemInitPtr1", scrip);
+
+    size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,            4,   51,    0,   47,    // 7
-       3,    1,    1,    4,           51,    4,   48,    2,    // 15
-      52,    6,    3, 1060320051,            8,    3,   73,    3,    // 23
-       4,   51,    0,   47,            3,    1,    1,    4,    // 31
-      51,    4,   48,    2,           52,    6,    3,    4,    // 39
-      26,    3,   51,    4,           48,    3,   29,    3,    // 47
-      51,   12,   48,    3,           29,    3,    6,    3,    // 55
-      77,   23,    3,    2,            1,    8,   29,    3,    // 63
-      51,   12,   49,   51,            8,   49,    2,    1,    // 71
-      12,    6,    3,    0,            5,   38,   77,   51,    // 79
-       8,    7,    3,   50,            3,   51,   12,    7,    // 87
-       3,   50,    3,   51,           12,   48,    2,   52,    // 95
-      24,    3,   51,    8,           49,   51,   12,   49,    // 103
-       5,  -999
+      36,   11,   38,    0,           36,   12,   73,    3,    // 7
+       4,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   13,   51,    4,           48,    2,   52,    6,    // 23
+       3, 1060320051,    8,    3,           36,   14,   73,    3,    // 31
+       4,   51,    0,   47,            3,    1,    1,    4,    // 39
+      36,   15,   51,    4,           48,    2,   52,    6,    // 47
+       3,    4,   26,    3,           36,   16,   51,    4,    // 55
+      48,    3,   29,    3,           51,   12,   48,    3,    // 63
+      29,    3,    6,    3,           91,   23,    3,    2,    // 71
+       1,    8,   29,    3,           36,   17,   51,   12,    // 79
+      49,   51,    8,   49,            2,    1,   12,    6,    // 87
+       3,    0,    5,   36,           20,   38,   91,   51,    // 95
+       8,    7,    3,   50,            3,   51,   12,    7,    // 103
+       3,   50,    3,   36,           21,   51,   12,   48,    // 111
+       2,   52,   24,    3,           51,    8,   49,   51,    // 119
+      12,   49,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1690,7 +1721,7 @@ TEST_F(Bytecode1, MemInitPtr1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      56,  -999
+      68,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
@@ -1713,12 +1744,16 @@ TEST_F(Bytecode1, MemInitPtr1) {
 TEST_F(Bytecode1, Ternary1) {
 
     // Accept a simple ternary expression
-    // The 'return' in line 4 isn't reachable
+    // The 'return' in line 8 isn't reachable
     
-    const char *inpl = "\
+    char const *inpl = "\
     int Foo(int i)              \n\
     {                           \n\
-        return i > 0 ? 1 : -1;  \n\
+        return i > 0            \n\
+                     ?          \n\
+                       1        \n\
+                         :      \n\
+                           -1;  \n\
         return 9;               \n\
     }                           \n\
     ";
@@ -1727,19 +1762,21 @@ TEST_F(Bytecode1, Ternary1) {
     int compileResult = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
     ASSERT_LE(1u, mh.GetMessages().size());
-    EXPECT_EQ(4, mh.GetMessages().at(0).Lineno);
+    EXPECT_EQ(8, mh.GetMessages().at(0).Lineno);
     EXPECT_NE(std::string::npos, mh.GetMessages().at(0).Message.find("reach"));
 
     // WriteOutput("Ternary1", scrip);
-    size_t const codesize = 34;
+
+    size_t const codesize = 46;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    8,            7,    3,   29,    3,    // 7
-       6,    3,    0,   30,            4,   17,    4,    3,    // 15
-       3,    4,    3,   28,            5,    6,    3,    1,    // 23
-      31,    3,    6,    3,           -1,    5,    6,    3,    // 31
-       9,    5,  -999
+      36,    2,   38,    0,           36,    3,   51,    8,    // 7
+       7,    3,   29,    3,            6,    3,    0,   30,    // 15
+       4,   17,    4,    3,            3,    4,    3,   28,    // 23
+       7,   36,    5,    6,            3,    1,   31,    5,    // 31
+      36,    7,    6,    3,           -1,   36,    7,    5,    // 39
+      36,    8,    6,    3,            9,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1763,7 +1800,7 @@ TEST_F(Bytecode1, Ternary2) {
     
     // Accept Elvis operator expression
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct       \n\
     {                           \n\
         int Payload;            \n\
@@ -1773,7 +1810,9 @@ TEST_F(Bytecode1, Ternary2) {
     {                           \n\
         S = null;               \n\
         T = new Struct;         \n\
-        Struct Res = S ?: T;    \n\
+        Struct Res = S          \n\
+                       ?:       \n\
+                          T;    \n\
     }                           \n\
     ";
 
@@ -1781,40 +1820,43 @@ TEST_F(Bytecode1, Ternary2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Ternary2", scrip);
-    const size_t codesize = 44;
+
+    size_t const codesize = 58;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,    6,    2,    0,    // 7
-      47,    3,   73,    3,            4,    6,    2,    4,    // 15
-      47,    3,    6,    2,            0,   48,    3,   70,    // 23
-       5,    6,    2,    4,           48,    3,   51,    0,    // 31
-      47,    3,    1,    1,            4,   51,    4,   49,    // 39
-       2,    1,    4,    5,          -999
+      36,    7,   38,    0,           36,    8,    6,    3,    // 7
+       0,    6,    2,    0,           47,    3,   36,    9,    // 15
+      73,    3,    4,    6,            2,    4,   47,    3,    // 23
+      36,   10,    6,    2,            0,   48,    3,   70,    // 31
+       7,   36,   12,    6,            2,    4,   48,    3,    // 39
+      36,   12,   51,    0,           47,    3,    1,    1,    // 47
+       4,   36,   13,   51,            4,   49,    2,    1,    // 55
+       4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
-    const size_t numfixups = 4;
+    size_t const numfixups = 4;
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       7,   15,   20,   27,        -999
+      11,   21,   28,   37,        -999
     };
     char fixuptypes[] = {
       1,   1,   1,   1,     '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
 
-    const int numimports = 0;
+    int const numimports = 0;
     std::string imports[] = {
      "[[SENTINEL]]"
     };
     CompareImports(&scrip, numimports, imports);
 
-    const size_t numexports = 0;
+    size_t const numexports = 0;
     EXPECT_EQ(numexports, scrip.numexports);
 
-    const size_t stringssize = 0;
+    size_t const stringssize = 0;
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
@@ -1822,7 +1864,7 @@ TEST_F(Bytecode1, Ternary3) {
     
     // Accept nested expression
 
-    const char *inpl = "\
+    char const *inpl = "\
     int main()                  \n\
     {                           \n\
         int t1 = 15;            \n\
@@ -1834,19 +1876,21 @@ TEST_F(Bytecode1, Ternary3) {
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    //WriteOutput("Ternary3", scrip);
-    size_t const codesize = 69;
+    // WriteOutput("Ternary3", scrip);
+
+    size_t const codesize = 77;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           15,   29,    3,    6,    // 7
-       3,   16,   29,    3,           51,    8,    7,    3,    // 15
-      29,    3,    6,    3,            0,   30,    4,   18,    // 23
-       4,    3,    3,    4,            3,   28,   31,   51,    // 31
-       8,    7,    3,   29,            3,    6,    3,   15,    // 39
-      30,    4,   17,    4,            3,    3,    4,    3,    // 47
-      28,    6,   51,    4,            7,    3,   31,    4,    // 55
-      51,    8,    7,    3,           31,    3,    6,    3,    // 63
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      15,   29,    3,   36,            4,    6,    3,   16,    // 15
+      29,    3,   36,    5,           51,    8,    7,    3,    // 23
+      29,    3,    6,    3,            0,   30,    4,   18,    // 31
+       4,    3,    3,    4,            3,   28,   31,   51,    // 39
+       8,    7,    3,   29,            3,    6,    3,   15,    // 47
+      30,    4,   17,    4,            3,    3,    4,    3,    // 55
+      28,    6,   51,    4,            7,    3,   31,    4,    // 63
+      51,    8,    7,    3,           31,    3,    6,    3,    // 71
       99,    2,    1,    8,            5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -1871,7 +1915,7 @@ TEST_F(Bytecode1, Ternary4) {
     
     // String / literal string and conversion.
 
-    char inpl[] = "\
+    char const *inpl = "\
         String main()                       \n\
         {                                   \n\
             String test = \"Test\";         \n\
@@ -1879,6 +1923,7 @@ TEST_F(Bytecode1, Ternary4) {
             return zajin ? test : \"Foo\";  \n\
         }                                   \n\
         ";
+
     std::string input = g_Input_Bool;
     input += g_Input_String;
     input += inpl;
@@ -1887,17 +1932,19 @@ TEST_F(Bytecode1, Ternary4) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Ternary4", scrip);
-    size_t const codesize = 56;
+
+    size_t const codesize = 64;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   64,    3,   51,    // 7
-       0,   47,    3,    1,            1,    4,    6,    3,    // 15
-       7,   29,    3,   51,            4,    7,    3,   28,    // 23
-       6,   51,    8,   48,            3,   31,    5,    6,    // 31
-       3,    5,   64,    3,           29,    3,   51,    4,    // 39
-      50,    3,   51,   12,           49,   51,    4,   48,    // 47
-       3,   69,   30,    4,            2,    1,    8,    5,    // 55
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   64,    3,   51,            0,   47,    3,    1,    // 15
+       1,    4,   36,    4,            6,    3,    7,   29,    // 23
+       3,   36,    5,   51,            4,    7,    3,   28,    // 31
+       6,   51,    8,   48,            3,   31,    5,    6,    // 39
+       3,    5,   64,    3,           29,    3,   51,    4,    // 47
+      50,    3,   51,   12,           49,   51,    4,   48,    // 55
+       3,   69,   30,    4,            2,    1,    8,    5,    // 63
      -999
     };
     CompareCode(&scrip, codesize, code);
@@ -1906,7 +1953,7 @@ TEST_F(Bytecode1, Ternary4) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   33,  -999
+       8,   41,  -999
     };
     char fixuptypes[] = {
       3,   3,  '\0'
@@ -1936,43 +1983,47 @@ TEST_F(Bytecode1, Ternary5) {
 
     // Compile-time evaluation
 
-    const char inpl[] = "\
-        float main()                    \n\
-        {                               \n\
-            int I1a = 0 ? 10 : 20;      \n\
-            int I1b = 2 ? 30 : 40;      \n\
-            int I2a = 0 ?: 50;          \n\
-            int I2b = 3 ?: 60;          \n\
-            int I3a = 0 ? I1a : (7 + I1b);    \n\
-            int I3b = 4 ? I2a : (7 + I2b);    \n\
-            int I4a = 0 ? 70 : I3a;     \n\
-            int I4b = 4 ? 80 : I3b;     \n\
-            int I5a = 0 ? I4a : 90;     \n\
-            int I5b = 5 ? I4b : 100;    \n\
-            int I6 = 0 ? : I5a;         \n\
-            return 0.;                  \n\
-        }                               \n\
+    char const *inpl = "\
+        float main()                        \n\
+        {                                   \n\
+            int I1a = 0 ? 10 : 20;          \n\
+            int I1b = 2 ? 30 : 40;          \n\
+            int I2a = 0 ?: 50;              \n\
+            int I2b = 3 ?: 60;              \n\
+            int I3a = 0 ? I1a : (7 + I1b);  \n\
+            int I3b = 4 ? I2a : (7 + I2b);  \n\
+            int I4a = 0 ? 70 : I3a;         \n\
+            int I4b = 4 ? 80 : I3b;         \n\
+            int I5a = 0 ? I4a : 90;         \n\
+            int I5b = 5 ? I4b : 100;        \n\
+            int I6 = 0 ? : I5a;             \n\
+            return 0.;                      \n\
+        }                                   \n\
         ";
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("Ternary5", scrip);
-    size_t const codesize = 82;
+
+    size_t const codesize = 108;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           20,   29,    3,    6,    // 7
-       3,   30,   29,    3,            6,    3,   50,   29,    // 15
-       3,    6,    3,    3,           29,    3,    6,    3,    // 23
-       7,   29,    3,   51,           16,    7,    3,   30,    // 31
-       4,   11,    4,    3,            3,    4,    3,   29,    // 39
-       3,   51,   12,    7,            3,   29,    3,   51,    // 47
-       8,    7,    3,   29,            3,    6,    3,   80,    // 55
-      29,    3,    6,    3,           90,   29,    3,   51,    // 63
-       8,    7,    3,   29,            3,   51,    8,    7,    // 71
-       3,   29,    3,    6,            3,    0,    2,    1,    // 79
-      44,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      20,   29,    3,   36,            4,    6,    3,   30,    // 15
+      29,    3,   36,    5,            6,    3,   50,   29,    // 23
+       3,   36,    6,    6,            3,    3,   29,    3,    // 31
+      36,    7,    6,    3,            7,   29,    3,   51,    // 39
+      16,    7,    3,   30,            4,   11,    4,    3,    // 47
+       3,    4,    3,   29,            3,   36,    8,   51,    // 55
+      12,    7,    3,   29,            3,   36,    9,   51,    // 63
+       8,    7,    3,   29,            3,   36,   10,    6,    // 71
+       3,   80,   29,    3,           36,   11,    6,    3,    // 79
+      90,   29,    3,   36,           12,   51,    8,    7,    // 87
+       3,   29,    3,   36,           13,   51,    8,    7,    // 95
+       3,   29,    3,   36,           14,    6,    3,    0,    // 103
+       2,    1,   44,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -1996,7 +2047,7 @@ TEST_F(Bytecode1, AssignToString) {
     
     // Definition of global string with assignment
 
-    const char inpl[] = "\
+    char const *inpl = "\
         string Payload = \"Holzschuh\";     \n\
         readonly int una = 1;               \n\
         String main()                       \n\
@@ -2005,6 +2056,7 @@ TEST_F(Bytecode1, AssignToString) {
             return (~~una == 2) ? test : Payload;  \n\
         }                                   \n\
         ";
+
     std::string input = g_Input_Bool;
     input += g_Input_String;
     input += "\n\"__NEWSCRIPTSTART_MAIN\"\n";
@@ -2016,22 +2068,23 @@ TEST_F(Bytecode1, AssignToString) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("AssignToString", scrip);
-    size_t const codesize = 89;
+
+    size_t const codesize = 95;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,    3,    2,    3,    // 7
-      64,    3,   51,    0,           47,    3,    1,    1,    // 15
-       4,    6,    2,  200,            7,    3,    6,    4,    // 23
-      -1,   12,    4,    3,            3,    4,    3,    6,    // 31
-       4,   -1,   12,    4,            3,    3,    4,    3,    // 39
-      29,    3,    6,    3,            2,   30,    4,   15,    // 47
-       4,    3,    3,    4,            3,   28,    6,   51,    // 55
-       4,   48,    3,   31,            8,    6,    2,    0,    // 63
-       3,    2,    3,   64,            3,   29,    3,   51,    // 71
-       4,   50,    3,   51,            8,   49,   51,    4,    // 79
-      48,    3,   69,   30,            4,    2,    1,    4,    // 87
-       5,  -999
+      36,    4,   38,    0,           36,    5,    6,    2,    // 7
+       0,    3,    2,    3,           64,    3,   51,    0,    // 15
+      47,    3,    1,    1,            4,   36,    6,    6,    // 23
+       2,  200,    7,    3,            6,    4,   -1,   12,    // 31
+       4,    3,    3,    4,            3,    6,    4,   -1,    // 39
+      12,    4,    3,    3,            4,    3,   29,    3,    // 47
+       6,    3,    2,   30,            4,   15,    4,    3,    // 55
+       3,    4,    3,   28,            6,   51,    4,   48,    // 63
+       3,   31,    8,    6,            2,    0,    3,    2,    // 71
+       3,   64,    3,   29,            3,   51,    4,   50,    // 79
+       3,   51,    8,   49,           51,    4,   48,    3,    // 87
+      69,   30,    4,    2,            1,    4,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2039,7 +2092,7 @@ TEST_F(Bytecode1, AssignToString) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   19,   63,  -999
+       8,   25,   69,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,  '\0'
@@ -2069,7 +2122,7 @@ TEST_F(Bytecode1, StructWOldstyleString1) {
     
     // Unmanaged structs containing strings
 
-    const char inpl[] = "\
+    char const *inpl = "\
         struct Struct               \n\
         {                           \n\
             short Pad1;             \n\
@@ -2093,27 +2146,29 @@ TEST_F(Bytecode1, StructWOldstyleString1) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StructWOldstyleString1", scrip);
-    size_t const codesize = 131;
+
+    size_t const codesize = 139;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,           10,    6,    2,    2,    // 7
-       3,    3,    5,    3,            2,    4,    6,    7,    // 15
-     199,    3,    4,    2,            7,    3,    3,    5,    // 23
-       2,    8,    3,   28,           25,    1,    4,    1,    // 31
-       1,    5,    1,    2,            7,    1,    3,    7,    // 39
-       3,   70,  -26,    1,            5,    1,    3,    5,    // 47
-       2,    6,    3,    0,            8,    3,    6,    2,    // 55
-       2,    3,    2,    3,           29,    3,    6,    2,    // 63
-    1816,    7,    3,   46,            3,    3,   32,    3,    // 71
-     404,    6,    2,  404,           11,    2,    3,   30,    // 79
-       3,    1,    2,    2,            3,    3,    5,    3,    // 87
-       2,    4,    6,    7,          199,    3,    4,    2,    // 95
-       7,    3,    3,    5,            2,    8,    3,   28,    // 103
-      25,    1,    4,    1,            1,    5,    1,    2,    // 111
-       7,    1,    3,    7,            3,   70,  -26,    1,    // 119
-       5,    1,    3,    5,            2,    6,    3,    0,    // 127
-       8,    3,    5,  -999
+      36,   12,   38,    0,           36,   13,    6,    3,    // 7
+      10,    6,    2,    2,            3,    3,    5,    3,    // 15
+       2,    4,    6,    7,          199,    3,    4,    2,    // 23
+       7,    3,    3,    5,            2,    8,    3,   28,    // 31
+      25,    1,    4,    1,            1,    5,    1,    2,    // 39
+       7,    1,    3,    7,            3,   70,  -26,    1,    // 47
+       5,    1,    3,    5,            2,    6,    3,    0,    // 55
+       8,    3,   36,   14,            6,    2,    2,    3,    // 63
+       2,    3,   29,    3,            6,    2, 1816,    7,    // 71
+       3,   46,    3,    3,           32,    3,  404,    6,    // 79
+       2,  404,   11,    2,            3,   30,    3,    1,    // 87
+       2,    2,    3,    3,            5,    3,    2,    4,    // 95
+       6,    7,  199,    3,            4,    2,    7,    3,    // 103
+       3,    5,    2,    8,            3,   28,   25,    1,    // 111
+       4,    1,    1,    5,            1,    2,    7,    1,    // 119
+       3,    7,    3,   70,          -26,    1,    5,    1,    // 127
+       3,    5,    2,    6,            3,    0,    8,    3,    // 135
+      36,   15,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2121,7 +2176,7 @@ TEST_F(Bytecode1, StructWOldstyleString1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,    7,   56,   64,         75,  -999
+       8,   11,   62,   70,         81,  -999
     };
     char fixuptypes[] = {
       3,   1,   1,   1,      1,  '\0'
@@ -2152,22 +2207,22 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
     
     // Managed structs containing strings
 
-    const char inpl[] = "\
-        managed struct Struct       \n\
-        {                           \n\
-            short Pad1;             \n\
-            string ST1;             \n\
-            short Pad2;             \n\
-            string ST2;             \n\
-        };                          \n\
-                                    \n\
-        void main()                 \n\
-        {                           \n\
-            Struct S1 = new Struct; \n\
-            Struct S2[] = new Struct[3];     \n\
-            S1.ST1 = \"-schuh\";    \n\
-            S2[2].ST1 = S1.ST1;     \n\
-        }                           \n\
+    char const *inpl = "\
+        managed struct Struct               \n\
+        {                                   \n\
+            short Pad1;                     \n\
+            string ST1;                     \n\
+            short Pad2;                     \n\
+            string ST2;                     \n\
+        };                                  \n\
+                                            \n\
+        void main()                         \n\
+        {                                   \n\
+            Struct S1 = new Struct;         \n\
+            Struct S2[] = new Struct[3];    \n\
+            S1.ST1 = \"-schuh\";            \n\
+            S2[2].ST1 = S1.ST1;             \n\
+        }                                   \n\
         ";
 
     ccSetOption(SCOPT_OLDSTRINGS, true);
@@ -2176,31 +2231,34 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("StructWOldstyleString2", scrip);
-    size_t const codesize = 164;
+
+    size_t const codesize = 176;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   73,    3,          404,   51,    0,   47,    // 7
-       3,    1,    1,    4,            6,    3,    3,   72,    // 15
-       3,    4,    1,   51,            0,   47,    3,    1,    // 23
-       1,    4,    6,    3,            0,   51,    8,   48,    // 31
-       2,   52,    1,    2,            2,    3,    3,    5,    // 39
-       3,    2,    4,    6,            7,  199,    3,    4,    // 47
-       2,    7,    3,    3,            5,    2,    8,    3,    // 55
-      28,   25,    1,    4,            1,    1,    5,    1,    // 63
-       2,    7,    1,    3,            7,    3,   70,  -26,    // 71
-       1,    5,    1,    3,            5,    2,    6,    3,    // 79
-       0,    8,    3,   51,            8,   48,    2,   52,    // 87
-       1,    2,    2,    3,            2,    3,   51,    4,    // 95
-      48,    2,   52,    1,            2,    8,   48,    2,    // 103
-      52,    1,    2,    2,            3,    3,    5,    3,    // 111
-       2,    4,    6,    7,          199,    3,    4,    2,    // 119
-       7,    3,    3,    5,            2,    8,    3,   28,    // 127
-      25,    1,    4,    1,            1,    5,    1,    2,    // 135
-       7,    1,    3,    7,            3,   70,  -26,    1,    // 143
-       5,    1,    3,    5,            2,    6,    3,    0,    // 151
-       8,    3,   51,    8,           49,   51,    4,   49,    // 159
-       2,    1,    8,    5,          -999
+      36,   10,   38,    0,           36,   11,   73,    3,    // 7
+     404,   51,    0,   47,            3,    1,    1,    4,    // 15
+      36,   12,    6,    3,            3,   72,    3,    4,    // 23
+       1,   51,    0,   47,            3,    1,    1,    4,    // 31
+      36,   13,    6,    3,            0,   51,    8,   48,    // 39
+       2,   52,    1,    2,            2,    3,    3,    5,    // 47
+       3,    2,    4,    6,            7,  199,    3,    4,    // 55
+       2,    7,    3,    3,            5,    2,    8,    3,    // 63
+      28,   25,    1,    4,            1,    1,    5,    1,    // 71
+       2,    7,    1,    3,            7,    3,   70,  -26,    // 79
+       1,    5,    1,    3,            5,    2,    6,    3,    // 87
+       0,    8,    3,   36,           14,   51,    8,   48,    // 95
+       2,   52,    1,    2,            2,    3,    2,    3,    // 103
+      51,    4,   48,    2,           52,    1,    2,    8,    // 111
+      48,    2,   52,    1,            2,    2,    3,    3,    // 119
+       5,    3,    2,    4,            6,    7,  199,    3,    // 127
+       4,    2,    7,    3,            3,    5,    2,    8,    // 135
+       3,   28,   25,    1,            4,    1,    1,    5,    // 143
+       1,    2,    7,    1,            3,    7,    3,   70,    // 151
+     -26,    1,    5,    1,            3,    5,    2,    6,    // 159
+       3,    0,    8,    3,           36,   15,   51,    8,    // 167
+      49,   51,    4,   49,            2,    1,    8,    5,    // 175
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2208,7 +2266,7 @@ TEST_F(Bytecode1, StructWOldstyleString2) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      28,  -999
+      36,  -999
     };
     char fixuptypes[] = {
       3,  '\0'
@@ -2237,7 +2295,7 @@ TEST_F(Bytecode1, ThisExpression1) {
 
     // "this" must be handled correctly as an expression term
 
-    const char inpl[] = "\
+    char const *inpl = "\
         builtin managed struct Character    \n\
         {                                   \n\
         };                                  \n\
@@ -2256,18 +2314,20 @@ TEST_F(Bytecode1, ThisExpression1) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("ThisExpression1", scrip);
-    size_t const codesize = 60;
+
+    size_t const codesize = 70;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    3,    6,            2,   52,    3,    2,    // 7
-       3,   51,    0,   47,            3,    1,    1,    4,    // 15
-       3,    6,    2,   52,            3,    2,    3,   29,    // 23
-       3,    6,    2,    0,           48,    3,   30,    4,    // 31
-      15,    4,    3,    3,            4,    3,   28,   10,    // 39
-       6,    3,    1,   51,            4,   49,    2,    1,    // 47
-       4,    5,   51,    4,           49,    2,    1,    4,    // 55
-       6,    3,    0,    5,          -999
+      36,    8,   38,    0,           36,    9,    3,    6,    // 7
+       2,   52,    3,    2,            3,   51,    0,   47,    // 15
+       3,    1,    1,    4,           36,   10,    3,    6,    // 23
+       2,   52,    3,    2,            3,   29,    3,    6,    // 31
+       2,    0,   48,    3,           30,    4,   15,    4,    // 39
+       3,    3,    4,    3,           28,   12,   36,   11,    // 47
+       6,    3,    1,   51,            4,   49,    2,    1,    // 55
+       4,    5,   36,   12,           51,    4,   49,    2,    // 63
+       1,    4,    6,    3,            0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2275,7 +2335,7 @@ TEST_F(Bytecode1, ThisExpression1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      27,  -999
+      33,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -2297,7 +2357,7 @@ TEST_F(Bytecode1, ThisExpression1) {
 
 TEST_F(Bytecode1, CrementAttribute1) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             import attribute int Graphic;   \n\
@@ -2314,17 +2374,18 @@ TEST_F(Bytecode1, CrementAttribute1) {
 
     // WriteOutput("CrementAttribute1", scrip);
 
-    size_t const codesize = 51;
+    size_t const codesize = 57;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    2,   52,    // 7
-      29,    6,   45,    2,           39,    0,    6,    3,    // 15
-       0,   33,    3,   30,            6,    1,    3,    1,    // 23
-       6,    2,    0,   48,            2,   52,   29,    6,    // 31
-      34,    3,   45,    2,           39,    1,    6,    3,    // 39
-       1,   33,    3,   35,            1,   30,    6,    6,    // 47
-       3,    0,    5,  -999
+      36,    7,   38,    0,           36,    8,    6,    2,    // 7
+       0,   48,    2,   52,           29,    6,   45,    2,    // 15
+      39,    0,    6,    3,            0,   33,    3,   30,    // 23
+       6,    1,    3,    1,            6,    2,    0,   48,    // 31
+       2,   52,   29,    6,           34,    3,   45,    2,    // 39
+      39,    1,    6,    3,            1,   33,    3,   35,    // 47
+       1,   30,    6,   36,            9,    6,    3,    0,    // 55
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2332,7 +2393,7 @@ TEST_F(Bytecode1, CrementAttribute1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   16,   26,   40,        -999
+       8,   20,   30,   44,        -999
     };
     char fixuptypes[] = {
       1,   4,   1,   4,     '\0'
@@ -2354,7 +2415,7 @@ TEST_F(Bytecode1, CrementAttribute1) {
 
 TEST_F(Bytecode1, CrementAttribute2) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             import attribute int Graphic;   \n\
@@ -2370,17 +2431,19 @@ TEST_F(Bytecode1, CrementAttribute2) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("CrementAttribute2", scrip);
-    size_t const codesize = 52;
+
+    size_t const codesize = 56;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    2,   52,    // 7
-      29,    6,   45,    2,           39,    0,    6,    3,    // 15
-       0,   33,    3,   30,            6,   29,    3,    1,    // 23
-       3,    1,    6,    2,            0,   48,    2,   52,    // 31
-      29,    6,   34,    3,           45,    2,   39,    1,    // 39
-       6,    3,    1,   33,            3,   35,    1,   30,    // 47
-       6,   30,    3,    5,          -999
+      36,    7,   38,    0,           36,    8,    6,    2,    // 7
+       0,   48,    2,   52,           29,    6,   45,    2,    // 15
+      39,    0,    6,    3,            0,   33,    3,   30,    // 23
+       6,   29,    3,    1,            3,    1,    6,    2,    // 31
+       0,   48,    2,   52,           29,    6,   34,    3,    // 39
+      45,    2,   39,    1,            6,    3,    1,   33,    // 47
+       3,   35,    1,   30,            6,   30,    3,    5,    // 55
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2388,7 +2451,7 @@ TEST_F(Bytecode1, CrementAttribute2) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   16,   28,   42,        -999
+       8,   20,   32,   46,        -999
     };
     char fixuptypes[] = {
       1,   4,   1,   4,     '\0'
@@ -2410,7 +2473,7 @@ TEST_F(Bytecode1, CrementAttribute2) {
 
 TEST_F(Bytecode1, CrementInExpression1) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         int foo ()                          \n\
         {                                   \n\
             int I;                          \n\
@@ -2422,15 +2485,17 @@ TEST_F(Bytecode1, CrementInExpression1) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("CementInExpression1", scrip);
-    size_t const codesize = 35;
+
+    size_t const codesize = 41;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,    1,   29,    3,           51,    8,    7,    3,    // 15
-       2,    3,    1,    8,            3,    7,    3,   30,    // 23
-       4,   11,    4,    3,            3,    4,    3,    2,    // 31
-       1,    4,    5,  -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            4,    6,    3,    1,    // 15
+      29,    3,   51,    8,            7,    3,    2,    3,    // 23
+       1,    8,    3,    7,            3,   30,    4,   11,    // 31
+       4,    3,    3,    4,            3,    2,    1,    4,    // 39
+       5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2452,7 +2517,7 @@ TEST_F(Bytecode1, CrementInExpression1) {
 
 TEST_F(Bytecode1, CrementInExpression2) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         int foo ()                          \n\
         {                                   \n\
             char Ch;                        \n\
@@ -2464,15 +2529,17 @@ TEST_F(Bytecode1, CrementInExpression2) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("CrementInExpression2", scrip);
-    size_t const codesize = 38;
+
+    size_t const codesize = 44;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,   51,    0,           63,    1,    1,    1,    // 7
-       1,   51,    1,   24,            3,    2,    3,    1,    // 15
-      26,    3,    1,    3,            1,   29,    3,    6,    // 23
-       3,    1,   30,    4,           12,    4,    3,    3,    // 31
-       4,    3,    2,    1,            1,    5,  -999
+      36,    2,   38,    0,           36,    3,   51,    0,    // 7
+      63,    1,    1,    1,            1,   36,    4,   51,    // 15
+       1,   24,    3,    2,            3,    1,   26,    3,    // 23
+       1,    3,    1,   29,            3,    6,    3,    1,    // 31
+      30,    4,   12,    4,            3,    3,    4,    3,    // 39
+       2,    1,    1,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2494,12 +2561,11 @@ TEST_F(Bytecode1, CrementInExpression2) {
 
 TEST_F(Bytecode1, CrementInExpression3) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         int foo ()                          \n\
         {                                   \n\
             int I = 7;                      \n\
             short J = 9;                    \n\
-                                            \n\
             if (++I == (J)--)               \n\
                 --J;                        \n\
         }                                   \n\
@@ -2509,19 +2575,22 @@ TEST_F(Bytecode1, CrementInExpression3) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("CrementInExpression3", scrip);
-    size_t const codesize = 68;
+
+    size_t const codesize = 80;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   29,    3,    6,    // 7
-       3,    9,   51,    0,           27,    3,    1,    1,    // 15
-       2,   51,    6,    7,            3,    1,    3,    1,    // 23
-       8,    3,    7,    3,           29,    3,   51,    6,    // 31
-      25,    3,    2,    3,            1,   27,    3,    1,    // 39
-       3,    1,   30,    4,           15,    4,    3,    3,    // 47
-       4,    3,   28,    9,           51,    2,   25,    3,    // 55
-       2,    3,    1,   27,            3,    2,    1,    6,    // 63
-       6,    3,    0,    5,          -999
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       7,   29,    3,   36,            4,    6,    3,    9,    // 15
+      51,    0,   27,    3,            1,    1,    2,   36,    // 23
+       5,   51,    6,    7,            3,    1,    3,    1,    // 31
+       8,    3,    7,    3,           29,    3,   51,    6,    // 39
+      25,    3,    2,    3,            1,   27,    3,    1,    // 47
+       3,    1,   30,    4,           15,    4,    3,    3,    // 55
+       4,    3,   28,   11,           36,    6,   51,    2,    // 63
+      25,    3,    2,    3,            1,   27,    3,   36,    // 71
+       7,    2,    1,    6,            6,    3,    0,    5,    // 79
+     -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2546,7 +2615,7 @@ TEST_F(Bytecode1, CompareStringToNull) {
     // If a String is compared to 'null', the pointer opcodes must be used,
     // not the String opcodes.
 
-    const char inpl[] = "\
+    char const *inpl = "\
         String S;                           \n\
         bool func()                         \n\
         {                                   \n\
@@ -2555,6 +2624,7 @@ TEST_F(Bytecode1, CompareStringToNull) {
             bool b3 = null != S;            \n\
         }                                   \n\
         ";
+
     std::string input = "";
     input += g_Input_Bool;
     input += g_Input_String;
@@ -2564,19 +2634,21 @@ TEST_F(Bytecode1, CompareStringToNull) {
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
     // WriteOutput("CompareStringToNull", scrip);
-    size_t const codesize = 69;
+
+    size_t const codesize = 79;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    2,            0,   48,    3,   29,    // 7
-       3,    6,    3,    0,           30,    4,   16,    4,    // 15
-       3,    3,    4,    3,           29,    3,    6,    2,    // 23
-       0,   48,    3,   29,            3,    6,    3,    0,    // 31
-      30,    4,   15,    4,            3,    3,    4,    3,    // 39
-      29,    3,    6,    3,            0,   29,    3,    6,    // 47
-       2,    0,   48,    3,           30,    4,   16,    4,    // 55
-       3,    3,    4,    3,           29,    3,    2,    1,    // 63
-      12,    6,    3,    0,            5,  -999
+      36,    3,   38,    0,           36,    4,    6,    2,    // 7
+       0,   48,    3,   29,            3,    6,    3,    0,    // 15
+      30,    4,   16,    4,            3,    3,    4,    3,    // 23
+      29,    3,   36,    5,            6,    2,    0,   48,    // 31
+       3,   29,    3,    6,            3,    0,   30,    4,    // 39
+      15,    4,    3,    3,            4,    3,   29,    3,    // 47
+      36,    6,    6,    3,            0,   29,    3,    6,    // 55
+       2,    0,   48,    3,           30,    4,   16,    4,    // 63
+       3,    3,    4,    3,           29,    3,   36,    7,    // 71
+       2,    1,   12,    6,            3,    0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2584,7 +2656,7 @@ TEST_F(Bytecode1, CompareStringToNull) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       4,   24,   49,  -999
+       8,   30,   57,  -999
     };
     char fixuptypes[] = {
       1,   1,   1,  '\0'
@@ -2606,7 +2678,7 @@ TEST_F(Bytecode1, CompareStringToNull) {
 
 TEST_F(Bytecode1, DynarrayLength1) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         managed struct Struct               \n\
         {                                   \n\
             int Payload;                    \n\
@@ -2622,16 +2694,17 @@ TEST_F(Bytecode1, DynarrayLength1) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("DynarrayLength1", scrip);
-    size_t const codesize = 32;
+    WriteOutput("DynarrayLength1", scrip);
+
+    size_t const codesize = 38;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            5,   72,    3,    4,    // 7
-       1,    6,    2,    0,           47,    3,    6,    2,    // 15
-       0,   48,    2,   52,           34,    2,   39,    1,    // 23
-       6,    3,    0,   33,            3,   35,    1,    5,    // 31
-     -999
+      36,    7,   38,    0,           36,    8,    6,    3,    // 7
+       5,   72,    3,    4,            1,    6,    2,    0,    // 15
+      47,    3,   36,    9,            6,    2,    0,   48,    // 23
+       2,   52,   34,    2,           39,    1,    6,    3,    // 31
+       0,   33,    3,   35,            1,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2639,7 +2712,7 @@ TEST_F(Bytecode1, DynarrayLength1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      11,   16,   26,  -999
+      15,   22,   32,  -999
     };
     char fixuptypes[] = {
       1,   1,   4,  '\0'
@@ -2661,7 +2734,7 @@ TEST_F(Bytecode1, DynarrayLength1) {
 
 TEST_F(Bytecode1, DynarrayLength2) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         int foo ()                          \n\
         {                                   \n\
             int Dynarray[] = new int[7];    \n\
@@ -2672,17 +2745,18 @@ TEST_F(Bytecode1, DynarrayLength2) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    // WriteOutput("DynarrayLength2", scrip);
+    WriteOutput("DynarrayLength2", scrip);
 
-    size_t const codesize = 44;
+    size_t const codesize = 52;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            7,   72,    3,    4,    // 7
-       0,   51,    0,   47,            3,    1,    1,    4,    // 15
-      51,    4,   48,    2,           52,   34,    2,   39,    // 23
-       1,    6,    3,    0,           33,    3,   35,    1,    // 31
-      29,    3,   51,    8,           49,    2,    1,    8,    // 39
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       7,   72,    3,    4,            0,   51,    0,   47,    // 15
+       3,    1,    1,    4,           36,    4,   51,    4,    // 23
+      48,    2,   52,   34,            2,   39,    1,    6,    // 31
+       3,    0,   33,    3,           35,    1,   29,    3,    // 39
+      36,    5,   51,    8,           49,    2,    1,    8,    // 47
        6,    3,    0,    5,          -999
     };
     CompareCode(&scrip, codesize, code);
@@ -2691,7 +2765,7 @@ TEST_F(Bytecode1, DynarrayLength2) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      27,  -999
+      33,  -999
     };
     char fixuptypes[] = {
       4,  '\0'
@@ -2711,22 +2785,72 @@ TEST_F(Bytecode1, DynarrayLength2) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
+TEST_F(Bytecode1, DynarrayOfPrimitives) {
+
+    // Dynamic arrays of primitives are allowed.
+
+    char const *inpl = "\
+        int main()                              \n\
+        {                                       \n\
+            short PrmArray[] = new short[10];   \n\
+            PrmArray[7] = 0;                    \n\
+            PrmArray[3] = PrmArray[7];          \n\
+        }                                       \n\
+    ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("DynarrayOfPrimitives", scrip);
+
+    size_t const codesize = 69;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+      10,   72,    3,    2,            0,   51,    0,   47,    // 15
+       3,    1,    1,    4,           36,    4,   51,    4,    // 23
+      48,    2,   52,    6,            3,    0,    1,    2,    // 31
+      14,   27,    3,   36,            5,   51,    4,   48,    // 39
+       2,   52,    1,    2,           14,   25,    3,   51,    // 47
+       4,   48,    2,   52,            1,    2,    6,   27,    // 55
+       3,   36,    6,   51,            4,   49,    2,    1,    // 63
+       4,    6,    3,    0,            5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
 TEST_F(Bytecode1, StringLiteral2String) {
 
-    const char inpl[] = "\
+    char const *inpl = "\
         internalstring autoptr builtin managed struct String    \n\
-        {};                     \n\
-                                \n\
-        struct StructWithString \n\
-        {                       \n\
-            String Txt;         \n\
-        };                      \n\
-                                \n\
-        int func1()             \n\
-        {                       \n\
-            StructWithString a; \n\
+        {};                         \n\
+                                    \n\
+        struct StructWithString     \n\
+        {                           \n\
+            String Txt;             \n\
+        };                          \n\
+                                    \n\
+        int func1()                 \n\
+        {                           \n\
+            StructWithString a;     \n\
             a.Txt = \"Cause bug!\"; \n\
-        }                       \n\
+        }                           \n\
         ";
 
     int compileResult = cc_compile(inpl, scrip);
@@ -2734,13 +2858,14 @@ TEST_F(Bytecode1, StringLiteral2String) {
 
     // WriteOutput("StringLiteral2String", scrip);
 
-    size_t const codesize = 26;
+    size_t const codesize = 34;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,            0,   29,    3,    6,    // 7
-       3,    0,   51,    4,           64,    3,   47,    3,    // 15
-      51,    4,   49,    2,            1,    4,    6,    3,    // 23
+      36,   10,   38,    0,           36,   11,    6,    3,    // 7
+       0,   29,    3,   36,           12,    6,    3,    0,    // 15
+      51,    4,   64,    3,           47,    3,   36,   13,    // 23
+      51,    4,   49,    2,            1,    4,    6,    3,    // 31
        0,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
@@ -2749,7 +2874,7 @@ TEST_F(Bytecode1, StringLiteral2String) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-       9,  -999
+      15,  -999
     };
     char fixuptypes[] = {
       3,  '\0'
@@ -2778,28 +2903,34 @@ TEST_F(Bytecode1, StringLiteral2String) {
 TEST_F(Bytecode1, LongMin1) {
 
     // Accept LONG_MIN written in decimal, generate appropriate code
-    char *inpl = "\
-        int I = - 2147483648;                   \n\
+
+    char const *inpl = "\
+        int i = - 2147483648;                   \n\
                                                 \n\
         int test(int foo = -2147483648)         \n\
         {                                       \n\
+            int i1 = - 2147483648;              \n\
             int i2 = -1 - -2147483648;          \n\
             return test() + (2 + -2147483648);  \n\
-        }\n\
+        }                                       \n\
     ";
 
     int compileResult = cc_compile(inpl, scrip);
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
     // WriteOutput("LongMin1", scrip);
-    size_t const codesize = 37;
+
+    size_t const codesize = 50;
     EXPECT_EQ(codesize, scrip.codesize);
 
     int32_t code[] = {
-      38,    0,    6,    3,         2147483647,   29,    3,    6,    // 7
-       3, -2147483648,   29,    3,            6,    3,    0,   23,    // 15
-       3,    2,    1,    4,           29,    3,    6,    3,    // 23
-    -2147483646,   30,    4,   11,            4,    3,    3,    4,    // 31
-       3,    2,    1,    4,            5,  -999
+      36,    4,   38,    0,           36,    5,    6,    3,    // 7
+    LONG_MIN,   29,    3,   36,            6,    6,    3, 2147483647,    // 15
+      29,    3,   36,    7,            6,    3, LONG_MIN,   29,    // 23
+       3,    6,    3,    0,           23,    3,    2,    1,    // 31
+       4,   29,    3,    6,            3, -2147483646,   30,    4,    // 39
+      11,    4,    3,    3,            4,    3,    2,    1,    // 47
+       8,    5,  -999
     };
     CompareCode(&scrip, codesize, code);
 
@@ -2807,12 +2938,107 @@ TEST_F(Bytecode1, LongMin1) {
     EXPECT_EQ(numfixups, scrip.numfixups);
 
     int32_t fixups[] = {
-      14,  -999
+      27,  -999
     };
     char fixuptypes[] = {
       2,  '\0'
     };
     CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode1, Linenum01)
+{
+    // Linenum directive must be generated for each declaration
+
+    char const *inpl = "\
+    int game_start()            \n\
+    {                           \n\
+        int a = 1;              \n\
+        int b = 1 + 1;          \n\
+    }                           \n\
+    ";
+
+
+    MessageHandler mh;
+    AGS::ccCompiledScript scrip{ true };
+    int compileResult = cc_compile(inpl, 0, scrip, mh);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
+
+    // WriteOutput("Linenum01", scrip);
+
+    size_t const codesize = 27;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       1,   29,    3,   36,            4,    6,    3,    2,    // 15
+      29,    3,   36,    5,            2,    1,    8,    6,    // 23
+       3,    0,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
+TEST_F(Bytecode1, Linenum02)
+{
+    // Linenum directive must be generated for 'c +=' line
+
+    char const *inpl = "\
+    int game_start()            \n\
+    {                           \n\
+        int c = 0;              \n\
+        c += 1 + 1;             \n\
+        return 0;               \n\
+    }                           \n\
+    ";
+
+    MessageHandler mh;
+    AGS::ccCompiledScript scrip{ true };
+    int compileResult = cc_compile(inpl, 0, scrip, mh);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
+
+    // WriteOutput("Linenum02", scrip);
+
+    size_t const codesize = 38;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,    6,    3,    // 7
+       0,   29,    3,   36,            4,    6,    3,    2,    // 15
+      29,    3,   51,    8,            7,    3,   30,    4,    // 23
+      11,    3,    4,    8,            3,   36,    5,    6,    // 31
+       3,    0,    2,    1,            4,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 0;
+    EXPECT_EQ(numfixups, scrip.numfixups);
 
     int const numimports = 0;
     std::string imports[] = {

--- a/Compiler/test2/cc_bytecode_test_1.cpp
+++ b/Compiler/test2/cc_bytecode_test_1.cpp
@@ -1692,7 +1692,7 @@ TEST_F(Bytecode1, MemInitPtr1) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    WriteOutput("MemInitPtr1", scrip);
+    // WriteOutput("MemInitPtr1", scrip);
 
     size_t const codesize = 123;
     EXPECT_EQ(codesize, scrip.codesize);
@@ -2694,7 +2694,7 @@ TEST_F(Bytecode1, DynarrayLength1) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    WriteOutput("DynarrayLength1", scrip);
+    // WriteOutput("DynarrayLength1", scrip);
 
     size_t const codesize = 38;
     EXPECT_EQ(codesize, scrip.codesize);
@@ -2745,7 +2745,7 @@ TEST_F(Bytecode1, DynarrayLength2) {
     int compileResult = cc_compile(inpl, scrip);
     EXPECT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 
-    WriteOutput("DynarrayLength2", scrip);
+    // WriteOutput("DynarrayLength2", scrip);
 
     size_t const codesize = 52;
     EXPECT_EQ(codesize, scrip.codesize);

--- a/Compiler/test2/cc_parser_test_0.cpp
+++ b/Compiler/test2/cc_parser_test_0.cpp
@@ -71,7 +71,7 @@ TEST_F(Compile0, UnknownVartypeAfterReadonly) {
 
     // Must have a known vartype in struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct MyStruct     \n\
         {                   \n\
           readonly int2 a;  \n\
@@ -90,7 +90,7 @@ TEST_F(Compile0, DynamicArrayReturnValueErrorText) {
 
     // Can't convert DynamicSprite[] to int[]
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct DynamicSprite { };   \n\
                                             \n\
         int[] Func()                        \n\
@@ -112,7 +112,7 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
     // Note, AGS doesn't feature static struct variables.
     // Can only use one of "protected", "writeprotected" and "readonly".
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct BothOrders {                                 \n\
             protected static int something();               \n\
             static import readonly attribute int another;   \n\
@@ -127,7 +127,7 @@ TEST_F(Compile0, StructMemberQualifierOrder) {
 
 TEST_F(Compile0, ParsingIntSuccess) {  
 
-    const char *inpl = "\
+    char const *inpl = "\
         import  int  importedfunc(int data1 = 1, int data2=2, int data3=3); \n\
         int testfunc(int x ) { int y = 42; } \n\
         ";
@@ -138,7 +138,7 @@ TEST_F(Compile0, ParsingIntSuccess) {
 
 TEST_F(Compile0, ParsingIntLimits) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int int_limits(int param_min = -2147483648, int param_max = 2147483647); \n\
         int int_limits(int param_min, int param_max)    \n\
         {                                               \n\
@@ -153,7 +153,7 @@ TEST_F(Compile0, ParsingIntLimits) {
 
 TEST_F(Compile0, ParsingIntDefaultOverflowPositive) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int importedfunc(int data1 = 9999999999999999999999, int data2=2, int data3=3);    \n\
         ";
 
@@ -167,7 +167,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowPositive) {
 
 TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         import  int  importedfunc(int data1 = -9999999999999999999999, int data2=2, int data3=3);   \n\
         ";
 
@@ -180,7 +180,7 @@ TEST_F(Compile0, ParsingIntDefaultOverflowNegative) {
 
 TEST_F(Compile0, ParsingIntOverflow) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         int testfunc(int x ) { int y = 4200000000000000000000; }    \n\
         ";
 
@@ -193,7 +193,7 @@ TEST_F(Compile0, ParsingIntOverflow) {
 
 TEST_F(Compile0, ParsingNegIntOverflow) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         int testfunc(int x ) { int y = -4200000000000000000000; }   \n\
         ";
 
@@ -206,7 +206,7 @@ TEST_F(Compile0, ParsingNegIntOverflow) {
 
 TEST_F(Compile0, ParsingHexSuccess) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         import  int  importedfunc(int data1 = 0x01, int data2=0x20, int data3=0x400); \n\
         int testfunc(int x ) { int y = 0xABCDEF; int z = 0xabcdef; } \n\
         ";
@@ -217,7 +217,7 @@ TEST_F(Compile0, ParsingHexSuccess) {
 
 TEST_F(Compile0, ParsingHexLimits) {
     // Try some edge values (convert to INT32_MAX, INT32_MIN and -1)
-    const char *inpl = "\
+    char const *inpl = "\
         import int int_limits(int param_hex1 = 0x7FFFFFFF, int param_hex2 = 0x80000000, int param_hex3 = 0xFFFFFFFF); \n\
         int int_limits(int param_hex1, int param_hex2, int param_hex3) \n\
         {                                               \n\
@@ -241,7 +241,7 @@ TEST_F(Compile0, EnumNegative) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum TestMyEnums {      \n\
             cat,                \n\
             dog,                \n\
@@ -291,7 +291,7 @@ TEST_F(Compile0, DefaultParametersLargeInts) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int importedfunc(    \n\
             int data1 = 0,          \n\
             int data2 = 1,          \n\
@@ -350,7 +350,7 @@ TEST_F(Compile0, ImportFunctionReturningDynamicArray) {
     AGS::MessageHandler mh;
     AGS::FlagSet const options = ~SCOPT_NOIMPORTOVERRIDE | SCOPT_LINENUMBERS;
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct A                            \n\
         {                                   \n\
             import static int[] MyFunc();   \n\
@@ -373,7 +373,7 @@ TEST_F(Compile0, DoubleNegatedConstant) {
     
     // Parameter default can be evaluated at compile time
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int MyFunction(  \n\
             int data0 = - -69   \n\
             );                  \n\
@@ -385,7 +385,7 @@ TEST_F(Compile0, DoubleNegatedConstant) {
 
 TEST_F(Compile0, SubtractionWithoutSpaces) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int MyFunction()        \n\
         {                       \n\
             int data0 = 2-4;    \n\
@@ -398,7 +398,7 @@ TEST_F(Compile0, SubtractionWithoutSpaces) {
 
 TEST_F(Compile0, NegationLHSOfExpression) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum MyEnum         \n\
         {                   \n\
             cat             \n\
@@ -425,7 +425,7 @@ TEST_F(Compile0, NegationLHSOfExpression) {
 
 TEST_F(Compile0, NegationRHSOfExpression) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum MyEnum\
         {\
             cat\
@@ -455,7 +455,7 @@ TEST_F(Compile0, Writeprotected) {
     // Directly taken from the doc on writeprotected, simplified.
     // Should fail, no modifying of writeprotected components from the outside.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             writeprotected int Damage;         \n\
         };                                     \n\
@@ -480,7 +480,7 @@ TEST_F(Compile0, Protected1) {
     // Directly taken from the doc on protected, simplified.
     // Should fail, no reading protected components from the outside.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
         };                                     \n\
@@ -506,7 +506,7 @@ TEST_F(Compile0, Protected2) {
     // Is still an attempt to modify a protected component from the outside
     // ('this.Damage = 7;' or even 'Damage = 7;' would be legal, however.)
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int DoDamage();             \n\
@@ -530,7 +530,7 @@ TEST_F(Compile0, Protected3) {
 
     // Should succeed; protected is allowed for struct component functions.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -556,7 +556,7 @@ TEST_F(Compile0, Protected4) {
     
     // Should succeed
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -582,7 +582,7 @@ TEST_F(Compile0, Protected5) {
 
     // Should succeed; protected is allowed for extender functions.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct VectorF                      \n\
         {                                           \n\
             float x, y;                             \n\
@@ -599,7 +599,7 @@ TEST_F(Compile0, Protected5) {
 
 TEST_F(Compile0, Do1Wrong) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
     void main()                     \n\
     {                               \n\
         do                          \n\
@@ -619,7 +619,7 @@ TEST_F(Compile0, Do2Wrong) {
 
     // Should balk because the "while" clause is missing.
 
-    const char *inpl = "\
+    char const *inpl = "\
     void main()                     \n\
     {                               \n\
         int I;                      \n\
@@ -636,7 +636,7 @@ TEST_F(Compile0, Do2Wrong) {
 
 TEST_F(Compile0, Do3Wrong) {
     
-    const char *inpl = "\
+    char const *inpl = "\
     void main()                     \n\
     {                               \n\
         int i;                      \n\
@@ -655,7 +655,7 @@ TEST_F(Compile0, Do3Wrong) {
 
 TEST_F(Compile0, Do4Wrong) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
     void main()                     \n\
     {                               \n\
         int i;                      \n\
@@ -676,7 +676,7 @@ TEST_F(Compile0, Protected0) {
 
     // Should fail, no modifying of protected components from the outside.
     
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             protected int Damage;              \n\
             import int DoDamage();             \n\
@@ -700,7 +700,7 @@ TEST_F(Compile0, ParamVoid) {
 
     // Can't have a parameter of type 'void'.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Foo(int bar, void bazz)            \n\
         {                                      \n\
             return 1;                          \n\
@@ -717,7 +717,7 @@ TEST_F(Compile0, LocalGlobalSeq2) {
 
     // Should garner a warning for line 7 because the re-definition hides the func
 
-    const char *inpl = "\
+    char const *inpl = "\
         float Func(void) { return 7.7; }    \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -750,7 +750,7 @@ TEST_F(Compile0, VartypeLocalSeq1) {
 
     // Can't redefine a vartype as a local variable
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true, };     \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -768,7 +768,7 @@ TEST_F(Compile0, VartypeLocalSeq2) {
 
     // Can't redefine an enum constant as a local variable
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true };      \n\
         int Foo(void)                       \n\
         {                                   \n\
@@ -786,7 +786,7 @@ TEST_F(Compile0, StructMemberImport) {
 
     // Struct variables must not be 'import'
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Parent                   \n\
         {                               \n\
             import int Payload;         \n\
@@ -801,7 +801,7 @@ TEST_F(Compile0, StructMemberImport) {
 
 TEST_F(Compile0, StructExtend1) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Parent                   \n\
         {                               \n\
             int Payload;                \n\
@@ -820,7 +820,7 @@ TEST_F(Compile0, StructExtend1) {
 
 TEST_F(Compile0, StructExtend2) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Grandparent              \n\
         {                               \n\
             int Payload;                \n\
@@ -844,7 +844,7 @@ TEST_F(Compile0, StructExtend2) {
 
 TEST_F(Compile0, StructExtend3) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Parent           \n\
         {                               \n\
             int Wage;                   \n\
@@ -867,7 +867,7 @@ TEST_F(Compile0, StructExtend4) {
 
     // Can't assign Parent * to Child *: Parent doesn't necessarily have all the fields
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Parent           \n\
         {                               \n\
             int Wage;                   \n\
@@ -892,7 +892,7 @@ TEST_F(Compile0, StructStaticFunc) {
 
     // Okay, a struct that is being defined is automatically forward-declared
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct GUI {                          \n\
             import static GUI* GetAtScreenXY(int x, int y);   \n\
         };                                                    \n\
@@ -906,7 +906,7 @@ TEST_F(Compile0, StructForwardDeclare1) {
 
     // GUI is forward-defined, but the definition will show up later so this is okay.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct GUI;     \n\
         GUI *Var;               \n\
         managed struct GUI {    \n\
@@ -921,7 +921,7 @@ TEST_F(Compile0, StructForwardDeclare2) {
 
     // Forward-declared structs must be "managed".
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct GUI;     \n\
         ";
 
@@ -935,7 +935,7 @@ TEST_F(Compile0, StructForwardDeclare3) {
 
     // GUI only has a forward definition
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct GUI;     \n\
         GUI *Var;               \n\
         ";
@@ -951,7 +951,7 @@ TEST_F(Compile0, StructForwardDeclareNew) {
     // "new" on a forward-declared struct mustn't work
     // even when the struct is defined after the reference
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Bang;        \n\
         int main()                  \n\
         {                           \n\
@@ -974,7 +974,7 @@ TEST_F(Compile0, StructManaged1a)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Managed1 \n\
         { };                    \n\
         managed struct Managed  \n\
@@ -995,7 +995,7 @@ TEST_F(Compile0, StructManaged1b)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Managed1 \n\
         { };                    \n\
         managed struct Managed  \n\
@@ -1015,7 +1015,7 @@ TEST_F(Compile0, StructManaged2)
     // Cannot have managed components in managed struct.
     // This is an Engine restriction.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Managed  \n\
         {                       \n\
             int *compo;         \n\
@@ -1033,7 +1033,7 @@ TEST_F(Compile0, StructRecursiveComponent01)
     // Cannot have a component that has the same type as the struct;
     // this construct would be infinitively large
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Foo              \n\
         {                       \n\
             Foo magic;          \n\
@@ -1052,7 +1052,7 @@ TEST_F(Compile0, StructRecursiveComponent02)
     // Cannot have a component that has the same type as the struct;
     // this construct would be infinitively large
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Foo              \n\
         {                       \n\
             int magic;          \n\
@@ -1073,7 +1073,7 @@ TEST_F(Compile0, StructRecursiveComponent02)
 
 TEST_F(Compile0, Undefined) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         Supercalifragilisticexpialidocious! \n\
         ";
 
@@ -1086,7 +1086,7 @@ TEST_F(Compile0, Undefined) {
 
 TEST_F(Compile0, ImportOverride1) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     import int Func(int i = 5);     \n\
     int Func(int i)                 \n\
     {                               \n\
@@ -1105,7 +1105,7 @@ TEST_F(Compile0, DynamicNonManaged1) {
 
     // Dynamic array of non-managed struct not allowed
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1126,7 +1126,7 @@ TEST_F(Compile0, DynamicNonManaged2) {
 
     // Dynamic array of non-managed struct not allowed
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1147,7 +1147,7 @@ TEST_F(Compile0, DynamicNonManaged3) {
 
     // Dynamic array of non-managed struct not allowed
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Inner                                        \n\
         {                                                   \n\
             short Payload;                                  \n\
@@ -1165,7 +1165,7 @@ TEST_F(Compile0, BuiltinStructMember) {
 
     // Builtin (non-managed) components not allowed 
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin struct Inner                                \n\
         {                                                   \n\
             short Fluff;                                    \n\
@@ -1184,7 +1184,7 @@ TEST_F(Compile0, BuiltinStructMember) {
 
 TEST_F(Compile0, ImportOverride2) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func(int i = 5);    \n\
         int Func(int i)         \n\
         {                       \n\
@@ -1200,7 +1200,7 @@ TEST_F(Compile0, ImportOverride2) {
 
 TEST_F(Compile0, ImportOverride3) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
     int Func(int i)                 \n\
     {                               \n\
         return 2 * i;               \n\
@@ -1219,7 +1219,7 @@ TEST_F(Compile0, LocalSeq1) {
 
     // The  { ... } must NOT invalidate Var1 but they MUST invalidate Var2.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func()                 \n\
         {                           \n\
             int Var1 = 0;           \n\
@@ -1237,7 +1237,7 @@ TEST_F(Compile0, LocalSeq2) {
 
     // The  while() { ... } must NOT invalidate Var1 but MUST invalidate Var2.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1255,7 +1255,7 @@ TEST_F(Compile0, LocalSeq3) {
     
     // The  do { ... } while() must NOT invalidate Var1 but MUST invalidate Var2.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1273,7 +1273,7 @@ TEST_F(Compile0, LocalSeq4) {
    
     // The  for() { ... } must NOT invalidate Var1 but MUST invalidate Var2 and Var3.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func()                     \n\
         {                               \n\
             int Var1 = 0;               \n\
@@ -1295,7 +1295,7 @@ TEST_F(Compile0, LocalParameterSeq1) {
 
     // Must fail because definitions of I collide
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int I)                \n\
         {                               \n\
             int I;                      \n\
@@ -1312,7 +1312,7 @@ TEST_F(Compile0, LocalParameterSeq2) {
 
     // Fine
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int I)            \n\
         {                           \n\
             { int I; }              \n\
@@ -1325,7 +1325,7 @@ TEST_F(Compile0, LocalParameterSeq2) {
 
 TEST_F(Compile0, LocalGlobalSeq1) {   
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func()                     \n\
         {                               \n\
             short Var = 5;              \n\
@@ -1340,7 +1340,7 @@ TEST_F(Compile0, LocalGlobalSeq1) {
 
 TEST_F(Compile0, Void1) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Parser {                             \n\
 	        import static int    FindWordID(const string wordToFind);   \n\
 	        import static void   ParseText(const string text);      \n\
@@ -1359,7 +1359,7 @@ TEST_F(Compile0, Void1) {
 
 TEST_F(Compile0, RetLengthNoMatch) { 
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct GUI {                                \n\
             import void Centre();                                   \n\
             import static GUI* GetAtScreenXY(int x, int y);         \n\
@@ -1376,7 +1376,7 @@ TEST_F(Compile0, RetLengthNoMatch) {
 
 TEST_F(Compile0, ImportVar1) {    
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         int Var;            \n\
@@ -1389,7 +1389,7 @@ TEST_F(Compile0, ImportVar1) {
 
 TEST_F(Compile0, ImportVar2) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         int Var;            \n\
@@ -1406,7 +1406,7 @@ TEST_F(Compile0, ImportVar2) {
 
 TEST_F(Compile0, ImportVar3) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Var;     \n\
         import int Var;     \n\
         short Var;          \n\
@@ -1421,7 +1421,7 @@ TEST_F(Compile0, ImportVar3) {
 
 TEST_F(Compile0, ImportVar4) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Var;            \n\
         import int Var;     \n\
         ";
@@ -1437,7 +1437,7 @@ TEST_F(Compile0, ImportVar5) {
     // "import int Var" is treated as a forward declaration
     // for the "int Var" that follows, not as an import proper.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Var;     \n\
         int main()          \n\
         {                   \n\
@@ -1455,7 +1455,7 @@ TEST_F(Compile0, ExtenderFuncDifference) {
     
     // Same func name, should be okay since they extend different structs
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct A            \n\
         {                   \n\
             int A_Payload;  \n\
@@ -1483,7 +1483,7 @@ TEST_F(Compile0, StaticFuncCall) {
     
     // Static function call, should work.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct GUI                                  \n\
         {                                                           \n\
             import static void ProcessClick(int x, int y, int z);   \n\
@@ -1504,7 +1504,7 @@ TEST_F(Compile0, Import2GlobalAllocation) {
     // Imported var I becomes a global var; must be allocated only once.
     // This means that J ought to be allocated at 4.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int I;   \n\
         int I;          \n\
         int J;          \n\
@@ -1529,7 +1529,7 @@ TEST_F(Compile0, Import2GlobalAllocation) {
 
 TEST_F(Compile0, LocalImportVar) {
     
-    const char *inpl = "\
+    char const *inpl = "\
         import int Var;     \n\
         int Var;            \n\
         export Var;         \n\
@@ -1541,7 +1541,7 @@ TEST_F(Compile0, LocalImportVar) {
 
 TEST_F(Compile0, Recursive1) {
 
-  const char *agscode = "\
+  char const *agscode = "\
         import int Foo2 (int);    \n\
                                   \n\
         int Foo1(int a)           \n\
@@ -1562,7 +1562,7 @@ TEST_F(Compile0, Recursive1) {
 
 TEST_F(Compile0, GlobalFuncStructFunc) {
 
-    const char *agscode = "\
+    char const *agscode = "\
         import int Foo2 (int);      \n\
                                     \n\
         struct Struct               \n\
@@ -1593,6 +1593,7 @@ TEST_F(Compile0, VariadicFunc) {
             return;                     \n\
         }                               \n\
         ";
+
     agscode = g_Input_String + agscode;
     agscode = g_Input_Bool + agscode;
 
@@ -1634,6 +1635,7 @@ TEST_F(Compile0, AssignPtr2ArrayOfPtr) {
             sprites[0] = spr;                   \n\
         }                                       \n\
         ";
+
     agscode = g_Input_Bool + agscode;
     
     int compileResult = cc_compile(agscode, scrip);
@@ -1644,7 +1646,7 @@ TEST_F(Compile0, Attributes01) {
     
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             float get_Flipped;                          \n\
@@ -1662,7 +1664,7 @@ TEST_F(Compile0, Attributes02) {
 
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             import bool get_Flipped(int Holzschuh);     \n\
@@ -1680,7 +1682,7 @@ TEST_F(Compile0, Attributes03) {
 
     // get_Flipped is implicitly declared with attribute Flipped so defns clash
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };              \n\
         builtin managed struct ViewFrame {              \n\
             readonly import attribute bool Flipped;     \n\
@@ -1698,7 +1700,7 @@ TEST_F(Compile0, Attributes04) {
 
     // Components may have the same name as vartypes.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Character {  \n\
             readonly import attribute int Room;     \n\
         };                                  \n\
@@ -1721,7 +1723,7 @@ TEST_F(Compile0, Attributes05) {
 
     // Assignment to static attribute should call the setter.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Game {       \n\
             import static attribute int MinimumTextDisplayTimeMs;     \n\
         };                                  \n\
@@ -1740,7 +1742,7 @@ TEST_F(Compile0, Attributes06) {
 
     // Assignment to static indexed attribute
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Dialog {                             \n\
             readonly import attribute int OptionCount;              \n\
         };                                                          \n\
@@ -1766,7 +1768,7 @@ TEST_F(Compile0, Attributes07) {
     // Reading an import static attribute should not trigger
     //  a Not Declared error since it is declared.
 
-    const char *inpl = "\
+    char const *inpl = "\
 		enum bool { false = 0, true };                              \n\
 		builtin managed struct Game {                               \n\
 			readonly import static attribute bool Foo;              \n\
@@ -1788,7 +1790,7 @@ TEST_F(Compile0, Attributes08) {
 
     // Accept a readonly attribute and a non-readonly getter
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1810,7 +1812,7 @@ TEST_F(Compile0, Attributes09) {
 
     // Do not accept a static attribute and a non-static getter
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1833,7 +1835,7 @@ TEST_F(Compile0, Attributes10) {
 
     // Call non-indexed attribute with index, is error
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1856,7 +1858,7 @@ TEST_F(Compile0, Attributes11) {
 
     // Call indexed attribute without index, is error
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1878,7 +1880,7 @@ TEST_F(Compile0, Attributes12) {
 
     // No local attributes
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1900,7 +1902,7 @@ TEST_F(Compile0, Attributes13) {
 
     // No attributes defined as 'static'
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1919,7 +1921,7 @@ TEST_F(Compile0, Attributes14) {
 
     // Setting a readonly attribute, is error
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1943,7 +1945,7 @@ TEST_F(Compile0, Attributes15) {
 
     // Setting a readonly attribute, is error
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Cam                      \n\
         {                                       \n\
             int payload;                        \n\
@@ -1967,7 +1969,7 @@ TEST_F(Compile0, Attributes16) {
 
     // Import decls of autopointered variables must be processed correctly.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             import attribute int Graphic;   \n\
@@ -1978,6 +1980,7 @@ TEST_F(Compile0, Attributes16) {
             obj.Graphic++;                  \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1988,7 +1991,7 @@ TEST_F(Compile0, Attributes17)
 
     // This attribute is type 'float' and assigned an 'int'. This should fail.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Character            \n\
         {                                           \n\
             import attribute float GraphicRotation; \n\
@@ -1998,6 +2001,7 @@ TEST_F(Compile0, Attributes17)
             player.GraphicRotation = 10;            \n\
         }                                           \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2010,7 +2014,7 @@ TEST_F(Compile0, StructPtrFunc) {
     // Func is ptr to managed, but it is a function not a variable
     // so ought to be let through.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct MS {     \n\
             MS *Func();         \n\
         };                      \n\
@@ -2029,7 +2033,7 @@ TEST_F(Compile0, StringOldstyle01) {
     // Can't return a local string because it will be already de-allocated when
     // the function returns
 
-    const char *inpl = "\
+    char const *inpl = "\
         string MyFunction(int a)    \n\
         {                           \n\
             string x;               \n\
@@ -2049,7 +2053,7 @@ TEST_F(Compile0, StringOldstyle02) {
     
     // If a function expects a non-const string, it mustn't be passed a const string
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(string s)         \n\
         {                           \n\
             Func(\"Holzschuh\");    \n\
@@ -2069,7 +2073,7 @@ TEST_F(Compile0, StringOldstyle03) {
     // A string literal is a constant string, so you should not be able to
     // return it as a string.
 
-    const char *inpl = "\
+    char const *inpl = "\
         string Func()                   \n\
         {                               \n\
             return \"Parameter\";       \n\
@@ -2089,12 +2093,13 @@ TEST_F(Compile0, ConstOldstringReturn)
     // A 'const string' should be a valid return
     // from a 'const string' function.
 
-    const char *inpl = "\
+    char const *inpl = "\
         const string GetLiteral()       \n\
         {                               \n\
             return \"string literal\";  \n\
         }                               \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2105,7 +2110,7 @@ TEST_F(Compile0, ConstOldstringReturn2)
     // Must not pass a const string return as a
     // non-const parameter of another function.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import const string GetConstString();   \n\
         import void UseString(string s);        \n\
                                                 \n\
@@ -2114,6 +2119,7 @@ TEST_F(Compile0, ConstOldstringReturn2)
             UseString(GetConstString());        \n\
         }                                       \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2124,7 +2130,7 @@ TEST_F(Compile0, StructPointerAttribute) {
 
     // It's okay for a managed struct to have a pointer import attribute.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct AudioClip {          \n\
             import void Stop();                     \n\
         };                                          \n\
@@ -2141,7 +2147,7 @@ TEST_F(Compile0, StringNullCompare) {
 
     // It's okay to compare strings to null
 
-    const char inpl[] = "\
+    char const *inpl = "\
         void main()                         \n\
         {                                   \n\
             String SS;                      \n\
@@ -2163,7 +2169,7 @@ TEST_F(Compile0, Decl) {
     // Should complain about the "+="
     // Note, there are many more legal possibilites than just "," ";" "=".
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()          \n\
         {                   \n\
             int Sum +=4;    \n\
@@ -2183,7 +2189,7 @@ TEST_F(Compile0, DynamicArrayCompare) {
     // The pointers, not the array components are compared.
     // May have a '*' after a struct defn.
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct               \n\
         {                                   \n\
         } *Arr1[];                          \n\
@@ -2206,7 +2212,7 @@ TEST_F(Compile0, DoubleLocalDecl) {
     // A local definition may hide an outer local definition or a global definition;
     // those will be uncovered when the scope of the local definition ends.
 
-    const char *inpl = "\
+    char const *inpl = "\
         float Bang1 = 7.7;                              \n\
         int room_AfterFadeIn()                          \n\
         {                                               \n\
@@ -2229,7 +2235,7 @@ TEST_F(Compile0, NewEnumArray) {
     
     // dynamic array of enum should work
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool                               \n\
         {                                       \n\
             false = 0,                          \n\
@@ -2250,7 +2256,7 @@ TEST_F(Compile0, Readonly01) {
     
     // Declaring a readonly variable with initialization is okay.
 
-    const char *inpl = "\
+    char const *inpl = "\
 		int room_RepExec()                  \n\
         {                                   \n\
             readonly int Constant = 835;    \n\
@@ -2265,7 +2271,7 @@ TEST_F(Compile0, Ternary01) {
 
     // case labels accept expressions in AGS, so ternary expressions should work, too.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void main()                     \n\
         {                               \n\
             int i = 15;                 \n\
@@ -2287,7 +2293,7 @@ TEST_F(Compile0, Ternary02) {
 
     // Values of ternary must have compatible vartypes
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                      \n\
         {                               \n\
             return 2 < 1 ? 1 : 2.0;     \n\
@@ -2307,7 +2313,7 @@ TEST_F(Compile0, FlowPointerExpressions1) {
     // The parenthesized expression after 'if', 'while', 'do ... while'
     // may evaluate to a pointer 
 
-    const char *inpl = "\
+    char const *inpl = "\
         import builtin managed struct Character     \n\
         {                                           \n\
         } *player;                                  \n\
@@ -2331,7 +2337,7 @@ TEST_F(Compile0, FlowPointerExpressions2) {
 
     // The parenthesized expression after 'if' must not be float
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()              \n\
         {                       \n\
             if (1.0)            \n\
@@ -2349,7 +2355,7 @@ TEST_F(Compile0, FlowPointerExpressions3) {
 
     // The parenthesized expression after 'while' must not be float
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()              \n\
         {                       \n\
             while (0.0)         \n\
@@ -2367,7 +2373,7 @@ TEST_F(Compile0, FlowPointerExpressions4) {
 
     // The parenthesized expression after 'do ... while' must not be float
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()              \n\
         {                       \n\
             do                  \n\

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -35,7 +35,7 @@ TEST_F(Compile1, Sections) {
     // "__NEWSCRIPTSTART..." begins a line #0,
     // so the error must be reported on line 3.
 
-    const char *inpl = "\
+    char const *inpl = "\
         \"__NEWSCRIPTSTART_globalscript.ash\"   \n\
         int main()                              \n\
         {                                       \n\
@@ -54,7 +54,7 @@ TEST_F(Compile1, Autoptr) {
 
     // String is autoptr so should not print as "String *"
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed autoptr builtin struct String   \n\
         {};                                     \n\
         int main()                              \n\
@@ -74,7 +74,7 @@ TEST_F(Compile1, BinaryNot)
 
     // '!' can't be binary
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = 15 ! 2;                   \n\
@@ -91,7 +91,7 @@ TEST_F(Compile1, UnaryDivideBy) {
 
     // '/' can't be unary
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = (/ 2);                    \n\
@@ -108,7 +108,7 @@ TEST_F(Compile1, UnaryPlus) {
 
     // '/' can't be unary
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return +42;                         \n\
@@ -124,7 +124,7 @@ TEST_F(Compile1, FloatInt1) {
 
     // Can't mix float and int
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = 4 / 2.0;                  \n\
@@ -141,7 +141,7 @@ TEST_F(Compile1, FloatInt2) {
 
     // Can't negate float
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = !2.0;                     \n\
@@ -158,7 +158,7 @@ TEST_F(Compile1, StringInt1) {
 
     // Can't mix string and int
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int Var = (\"Holzschuh\" == 2);     \n\
@@ -175,7 +175,7 @@ TEST_F(Compile1, ExpressionVoid) {
 
     // Can't mix void
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -193,7 +193,7 @@ TEST_F(Compile1, ExpressionLoneUnary1) {
 
     // Unary -, nothing following
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -212,7 +212,7 @@ TEST_F(Compile1, ExpressionLoneUnary2) {
 
     // Unary ~, nothing following
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -231,7 +231,7 @@ TEST_F(Compile1, ExpressionBinaryWithoutRHS) {
 
     // Binary %, nothing following
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -248,7 +248,7 @@ TEST_F(Compile1, ExpressionBinaryWithoutRHS) {
 
 TEST_F(Compile1, LocalTypes1)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         void Test1()            \n\
         {                       \n\
             struct MyStruct     \n\
@@ -257,6 +257,7 @@ TEST_F(Compile1, LocalTypes1)
             };                  \n\
         }                       \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
@@ -265,7 +266,7 @@ TEST_F(Compile1, LocalTypes1)
 
 TEST_F(Compile1, LocalTypes2)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         void Test1()            \n\
         {                       \n\
             enum Foo            \n\
@@ -274,6 +275,7 @@ TEST_F(Compile1, LocalTypes2)
             };                  \n\
         }                       \n\
         ";
+
     int compileResult = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : msg.c_str());
@@ -284,7 +286,7 @@ TEST_F(Compile1, StaticArrayIndex1) {
 
     // Constant array index, is out ouf bounds
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum E                          \n\
         {                               \n\
             MinusFive = -5,             \n\
@@ -306,7 +308,7 @@ TEST_F(Compile1, StaticArrayIndex2) {
 
     // Constant array index, is out ouf bounds
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum E                          \n\
         {                               \n\
             MinusFive = -5,             \n\
@@ -328,7 +330,7 @@ TEST_F(Compile1, ExpressionArray1) {
 
     // Can't mix void
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func();                     \n\
         int main()                              \n\
         {                                       \n\
@@ -347,7 +349,7 @@ TEST_F(Compile1, FuncTypeClash1) {
 
     // Can't use func here except in a func call
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -368,7 +370,7 @@ TEST_F(Compile1, FloatOutOfBounds) {
 
     // Too small
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -389,7 +391,7 @@ TEST_F(Compile1, DoWhileSemicolon) {
 
     // ';' missing
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int I = 1;                          \n\
@@ -409,7 +411,7 @@ TEST_F(Compile1, ExtenderExtender1) {
 
     // No extending a struct with a compound function
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct1                      \n\
         {                                   \n\
             void Func();                    \n\
@@ -432,7 +434,7 @@ TEST_F(Compile1, ExtenderExtender2) {
 
     // No extending a struct with a compound function
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct1                      \n\
         {                                   \n\
         };                                  \n\
@@ -452,7 +454,7 @@ TEST_F(Compile1, NonManagedStructParameter) {
 
     // Can't pass a non-managed struct as a function parameter
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct                           \n\
         {                                       \n\
         };                                      \n\
@@ -471,7 +473,7 @@ TEST_F(Compile1, StrangeParameterName) {
 
     // Can't use keyword as parameter name
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int while)                    \n\
         {                                       \n\
         }                                       \n\
@@ -487,7 +489,7 @@ TEST_F(Compile1, DoubleParameterName) {
 
     // Can't use keyword as parameter name
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int PI, float PI)             \n\
         {                                       \n\
         }                                       \n\
@@ -503,7 +505,7 @@ TEST_F(Compile1, FuncParamDefaults1) {
 
     // Either give no defaults or give them all
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int i = 5, float j = 6.0);    \n\
         void Func(int i = 5, float j)           \n\
         {                                       \n\
@@ -520,7 +522,7 @@ TEST_F(Compile1, FuncParamDefaults2) {
 
     // All parameters that follow a default parameter must have a default
 
-    const char *inpl = "\
+    char const *inpl = "\
         import void Func(int i = 5, float j);   \n\
         ";
     
@@ -534,7 +536,7 @@ TEST_F(Compile1, FuncParamDefaults3) {
 
     // Can't give a parameter a default here, not a default there
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int i, float j);          \n\
         void Func(int i, float j = 6.0)     \n\
         {                                       \n\
@@ -551,7 +553,7 @@ TEST_F(Compile1, FuncParamDefaults4) {
 
     // Can't give a parameter differing defaults
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(float J = -6.0);              \n\
         void Func(float J = 6.0)                \n\
         {                                       \n\
@@ -568,7 +570,7 @@ TEST_F(Compile1, FuncParamNumber1) {
 
     // Differing number of parameters
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int, float);                  \n\
         void Func(int I, float J, short K)      \n\
         {                                       \n\
@@ -585,7 +587,7 @@ TEST_F(Compile1, FuncParamNumber2) {
 
     // Instantiation has number of parameters than is different from declaration
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Test                                         \n\
         {                                                   \n\
             import void Func(int a, int b, int c, int d);   \n\
@@ -606,7 +608,7 @@ TEST_F(Compile1, FuncVariadicCollision) {
 
     // Variadic / non-variadic
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Func(int, float, short, ...);      \n\
         void Func(int I, float J, short K)      \n\
         {                                       \n\
@@ -623,7 +625,7 @@ TEST_F(Compile1, FuncReturnVartypes) {
 
     // Return vartypes
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func(int, float, short);            \n\
         short Func(int I, float J, short K)     \n\
         {                                       \n\
@@ -640,7 +642,7 @@ TEST_F(Compile1, FuncReturnStruct1) {
 
     // Return vartype must be managed when it is a struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct {  };                     \n\
         Struct Func()                           \n\
         {                                       \n\
@@ -658,7 +660,7 @@ TEST_F(Compile1, FuncReturnStruct2) {
     // Compiler will imply the '*'
     // but should be slightly unhappy about the missing return statement
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct {  }; \n\
         Struct Func()               \n\
         {                           \n\
@@ -676,7 +678,7 @@ TEST_F(Compile1, FuncReturnStruct3) {
 
     // Compiler should be slightly unhappy about the missing return statement
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct {  };             \n\
         Struct[] Func()                         \n\
         {                                       \n\
@@ -695,7 +697,7 @@ TEST_F(Compile1, FuncReturn1) {
     // Should detect that the 'I' define can't be reached
     // Should not warn about a missing return at end of function body.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Random(int); \n\
         float Func()            \n\
         {                       \n\
@@ -719,7 +721,7 @@ TEST_F(Compile1, FuncReturn2) {
     // Should detect that the 'I' assignment can't be reached
     // Should warn about a missing return at end of function body.
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Random(int); \n\
         float Func()            \n\
         {                       \n\
@@ -745,7 +747,7 @@ TEST_F(Compile1, FuncDouble) {
 
     // No two equally-named functions with body
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func()                              \n\
         {                                       \n\
         }                                       \n\
@@ -764,7 +766,7 @@ TEST_F(Compile1, FuncProtected) {
 
     // Protected functions must be part of a struct
 
-    const char *inpl = "\
+    char const *inpl = "\
         protected void Func(int I = 6)          \n\
         {                                       \n\
         }                                       \n\
@@ -780,7 +782,7 @@ TEST_F(Compile1, FuncNameClash1) {
 
     // Function name mustn't equal a variable name.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Func;                               \n\
         void Func(int I = 6)                    \n\
         {                                       \n\
@@ -795,7 +797,7 @@ TEST_F(Compile1, FuncNameClash1) {
 
 TEST_F(Compile1, FuncDeclWrong1) {
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -828,7 +830,7 @@ TEST_F(Compile1, FuncDeclWrong1) {
 TEST_F(Compile1, FuncDeclWrong2) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct Struct1          \n\
     {                               \n\
         float Payload1;             \n\
@@ -862,7 +864,7 @@ TEST_F(Compile1, FuncDeclReturnVartype) {
 
     // Should compile.
 
-    const char *inpl = "\
+    char const *inpl = "\
     managed struct DynamicSprite                                    \n\
     {                                                               \n\
     };                                                              \n\
@@ -888,7 +890,7 @@ TEST_F(Compile1, FuncHeader1) {
 
     // Can't have a specific array size in func parameters
 
-    const char *inpl = "\
+    char const *inpl = "\
         void main(int a[15])                   \n\
         {                                      \n\
              return;                           \n\
@@ -905,7 +907,7 @@ TEST_F(Compile1, FuncHeader2) {
 
     // Default for float parameter, an int value. Should fail
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Foo(float Param = 7);              \n\
         {                                      \n\
              return;                           \n\
@@ -921,7 +923,7 @@ TEST_F(Compile1, FuncHeader2) {
 TEST_F(Compile1, FuncHeader3) {
 
     // Integer default for managed parameter. Should fail
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Payload                  \n\
         {                                       \n\
             float foo;                          \n\
@@ -941,7 +943,7 @@ TEST_F(Compile1, FuncHeader3) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault1a) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -962,7 +964,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1b) {
 
     // A comma or paren should follow 'Weapon'
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -981,7 +983,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1b) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault1c) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -1000,7 +1002,7 @@ TEST_F(Compile1, FuncExtenderHeaderFault1c) {
 
 TEST_F(Compile1, FuncExtenderHeaderFault2) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                        \n\
             int Damage;                        \n\
         };                                     \n\
@@ -1022,7 +1024,7 @@ TEST_F(Compile1, FuncDoubleExtender) {
 
     // Must not define a function with body twice.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Weapon {                         \n\
             int Damage;                         \n\
         };                                      \n\
@@ -1046,7 +1048,7 @@ TEST_F(Compile1, FuncDoubleExtender) {
 
 TEST_F(Compile1, FuncDoubleNonExtender) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int Foo(int Bar)                       \n\
         {                                      \n\
             return 1;                          \n\
@@ -1067,7 +1069,7 @@ TEST_F(Compile1, FuncUndeclaredStruct1) {
 
     // Should fail, Struct doesn't have Func
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct                       \n\
         {                                           \n\
             int Component;                          \n\
@@ -1088,7 +1090,7 @@ TEST_F(Compile1, FuncUndeclaredStruct2) {
 
     // Should succeed, Struct has Func
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Struct::Func(int Param)                \n\
         {                                           \n\
         }                                           \n\
@@ -1107,7 +1109,7 @@ TEST_F(Compile1, TypeEqComponent) {
 
     // A struct component may have the same name as a type.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Room             \n\
         {                                       \n\
         };                                      \n\
@@ -1127,7 +1129,7 @@ TEST_F(Compile1, ExtenderFuncClash) {
 
     // Don't remember the struct of extender functions past their definition (and body, if applicable)
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin struct Maths 							\n\
         { 												\n\
         }; 												\n\
@@ -1144,7 +1146,7 @@ TEST_F(Compile1, MissingSemicolonAfterStruct1) {
 
     // Missing ";" after struct declaration; isn't a var decl either
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum bool { false = 0, true = 1 };      \n\
         struct CameraEx                         \n\
         {                                       \n\
@@ -1167,7 +1169,7 @@ TEST_F(Compile1, NewBuiltin1) {
 
     // Cannot do "new X;" when X is a builtin type
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct DynamicSprite            \n\
         {                                               \n\
         };                                              \n\
@@ -1195,7 +1197,7 @@ TEST_F(Compile1, NewArrayBuiltin1) {
     // Can do "new X[77];" when X is a builtin type because this will only
     // allocate a dynarray of pointers, not of X chunks
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct DynamicSprite            \n\
         {                                               \n\
         };                                              \n\
@@ -1222,7 +1224,7 @@ TEST_F(Compile1, MissingFunc) {
     // Must either import or define a function with body if you want to call it.
     // Also, check that the section is set correctly.
 
-    const char *inpl = "\
+    char const *inpl = "\
 \"__NEWSCRIPTSTART_HauntedHouse\"                       \n\
         int main()                                      \n\
         {                                               \n\
@@ -1243,7 +1245,7 @@ TEST_F(Compile1, FixupMismatch) {
     // Code cells that have an "import" fixup must point to the corresponding imports.
     // (This used to fail in combination with linenumbers turned on)
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct InventoryItem    \n\
         {                                       \n\
             readonly int reserved[2];           \n\
@@ -1292,7 +1294,7 @@ TEST_F(Compile1, ComponentOfNonStruct1) {
     // If a '.' follows something other than a struct then complain about that fact.
     // Do not complain about expecting and not finding a component.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct MyStruct             \n\
         {                           \n\
             int i;                  \n\
@@ -1316,7 +1318,7 @@ TEST_F(Compile1, ComponentOfNonStruct2) {
     // If a '.' follows something other than a struct then complain about that fact.
     // Do not complain about expecting and not finding a component.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void Test()     \n\
         {               \n\
             int i;      \n\
@@ -1334,7 +1336,7 @@ TEST_F(Compile1, EmptySection) {
 
     // An empty last section should not result in an endless loop.
 
-    const char *inpl = "\
+    char const *inpl = "\
 \"__NEWSCRIPTSTART_FOO\"     \n\
 \"__NEWSCRIPTSTART_BAR\"      \n\
         ";
@@ -1347,7 +1349,7 @@ TEST_F(Compile1, EmptySection) {
 TEST_F(Compile1, AutoptrDisplay) {
 
     // Autopointered types should not be shown with trailing ' ' in messages
-    const char *inpl = "\
+    char const *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1367,7 +1369,7 @@ TEST_F(Compile1, ReadonlyObjectWritableAttribute)
 {
     // player is readonly, but player.InventoryQuantity[...] can be written to.
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Character                \n\
         {                                               \n\
             import attribute int InventoryQuantity[];   \n\
@@ -1380,6 +1382,7 @@ TEST_F(Compile1, ReadonlyObjectWritableAttribute)
             player.InventoryQuantity[15] = 0;           \n\
         }                                               \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1389,7 +1392,7 @@ TEST_F(Compile1, ImportAutoptr1) {
 
     // Import decls of funcs with autopointered returns must be processed correctly.
 
-    const char *inpl = "\
+    char const *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1402,6 +1405,7 @@ TEST_F(Compile1, ImportAutoptr1) {
             return null;                    \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1411,7 +1415,7 @@ TEST_F(Compile1, ImportAutoptr2) {
 
     // Import decls of autopointered variables must be processed correctly.
 
-    const char *inpl = "\
+    char const *inpl = "\
         internalstring autoptr builtin      \n\
             managed struct String           \n\
         {                                   \n\
@@ -1420,6 +1424,7 @@ TEST_F(Compile1, ImportAutoptr2) {
         import String foo;                  \n\
         String foo;                         \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1429,7 +1434,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1)
 {
     // It is an error to assign a Dynpointer to a Dynarray variable
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1440,6 +1445,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1)
             Strct *o[] = new Strct;         \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1450,7 +1456,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1a)
 {
     // It is an error to assign a Dynpointer to a Dynarray variable
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1462,6 +1468,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch1a)
             o= new Strct;                   \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1472,7 +1479,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch2)
 {
     // It is an error to assign a Dynarray to a Dynpointer variable
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Object       \n\
         {                                   \n\
             int Payload;                    \n\
@@ -1483,6 +1490,7 @@ TEST_F(Compile1, DynptrDynarrayMismatch2)
             Object *o = new Object[10];     \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1496,7 +1504,7 @@ TEST_F(Compile1, ZeroMemoryAllocation1)
     // to allocate. However, it _is_ legal to allocate a dynarray for the
     // struct. (Its elements could be initialized via other means than new.)
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -1506,6 +1514,7 @@ TEST_F(Compile1, ZeroMemoryAllocation1)
             Strct *o[] = new Strct[10];     \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1516,7 +1525,7 @@ TEST_F(Compile1, ZeroMemoryAllocation2)
     // If a struct type doesn't contain any variables then there are zero
     // bytes to allocate. The Engine really doesn't like allocating 0 bytes
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -1526,6 +1535,7 @@ TEST_F(Compile1, ZeroMemoryAllocation2)
             Strct *o = new Strct;           \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1537,13 +1547,14 @@ TEST_F(Compile1,ForwardStructManaged)
     // Forward-declared structs must be 'managed', so the
     // actual declaration must have the 'managed' keyword
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Object;              \n\
         struct Object                       \n\
         {                                   \n\
             import attribute int Graphic;   \n\
         } obj;                              \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1555,23 +1566,25 @@ TEST_F(Compile1, ForwardStructBuiltin)
     // Either the forward decl and the actual decl must both be 'builtin'
     // or both be non-'builtin'.
 
-    const char *inpl1 = "\
+    char const *inpl1 = "\
         managed struct Object;              \n\
         managed builtin struct Object       \n\
         {                                   \n\
         };                                  \n\
         ";
+
     int compile_result1 = cc_compile(inpl1, scrip);
     std::string msg1 = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result1 >= 0) ? "Ok" : msg1.c_str());
     EXPECT_NE(std::string::npos, msg1.find("'builtin'"));
 
-    const char *inpl2 = "\
+    char const *inpl2 = "\
         builtin managed struct Object;      \n\
         managed struct Object               \n\
         {                                   \n\
         };                                  \n\
         ";
+
     int compile_result2 = cc_compile(inpl2, scrip);
     std::string msg2 = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
@@ -1583,23 +1596,25 @@ TEST_F(Compile1, ForwardStructAutoptr)
     // Either the forward decl and the actual decl must both be 'autoptr'
     // or both be non-'autoptr'.
 
-    const char *inpl1 = "\
+    char const *inpl1 = "\
         managed struct Object;              \n\
         managed builtin struct Object       \n\
         {                                   \n\
         };                                  \n\
         ";
+
     int compile_result1 = cc_compile(inpl1, scrip);
     std::string msg1 = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result1 >= 0) ? "Ok" : msg1.c_str());
     EXPECT_NE(std::string::npos, msg1.find("'builtin'"));
 
-    const char *inpl2 = "\
+    char const *inpl2 = "\
         builtin managed struct Object;      \n\
         managed struct Object               \n\
         {                                   \n\
         };                                  \n\
         ";
+
     int compile_result2 = cc_compile(inpl2, scrip);
     std::string msg2 = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
@@ -1611,7 +1626,7 @@ TEST_F(Compile1, FuncThenAssign)
     // A function symbol in front of an assignment
     // The compiler should complain about a missing '('  
 
-    const char *inpl2 = "\
+    char const *inpl2 = "\
         import int GetTextHeight                    \n\
             (const string text, int, int width);    \n\
                                                     \n\
@@ -1628,6 +1643,7 @@ TEST_F(Compile1, FuncThenAssign)
             player.Baseline = 1;                    \n\
         }                                           \n\
         ";
+
     int compile_result2 = cc_compile(inpl2, scrip);
     std::string msg2 = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result2 >= 0) ? "Ok" : msg2.c_str());
@@ -1638,12 +1654,13 @@ TEST_F(Compile1, BuiltinForbidden)
 {
     // Function names must not start with '__Builtin_'.
 
-    const char *inpl = "\
+    char const *inpl = "\
         void __Builtin_TestFunc()   \n\
         {                           \n\
             return;                 \n\
         }                           \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1655,7 +1672,7 @@ TEST_F(Compile1, ReadonlyParameters1) {
     // Parameters may be declared "readonly" so that they cannot be
     // assigned to within the function.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int foo(readonly int bar)           \n\
         {                                   \n\
             bar++;                          \n\
@@ -1667,6 +1684,7 @@ TEST_F(Compile1, ReadonlyParameters1) {
             return foo(5);                  \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1684,7 +1702,7 @@ TEST_F(Compile1, ReadonlyParameters2) {
     // "Readonly" does NOT imply "const".
     // All the assignments in the function should be allowed.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int ReadonlyTest2(readonly int ReadOnly)    \n\
         {                                   \n\
             readonly int A = ReadOnly;      \n\
@@ -1694,6 +1712,7 @@ TEST_F(Compile1, ReadonlyParameters2) {
             return ReadOnly;                \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -1703,7 +1722,7 @@ TEST_F(Compile1, BinaryCompileTimeEval1) {
 
     // Checks binary compile time evaluations for integers.
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (4 + 3) / 0;                 \n\
@@ -1742,7 +1761,7 @@ TEST_F(Compile1, BinaryCompileTimeEval1) {
 TEST_F(Compile1, CTEvalIntPlus) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (4 + 3) / 0;                 \n\
@@ -1781,7 +1800,7 @@ TEST_F(Compile1, CTEvalIntPlus) {
 TEST_F(Compile1, CTEvalIntMinus) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (83 - 95) / 0;               \n\
@@ -1820,7 +1839,7 @@ TEST_F(Compile1, CTEvalIntMinus) {
 TEST_F(Compile1, CTEvalIntMultiply) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (33 * -39) / 0;              \n\
@@ -1859,7 +1878,7 @@ TEST_F(Compile1, CTEvalIntMultiply) {
 TEST_F(Compile1, CTEvalIntDivide) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (52 / 8) / 0;                \n\
@@ -1875,7 +1894,7 @@ TEST_F(Compile1, CTEvalIntDivide) {
 TEST_F(Compile1, CTEvalIntModulo) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (95 % 17) / 0;               \n\
@@ -1893,6 +1912,7 @@ TEST_F(Compile1, CTEvalIntModulo) {
             return (46341 % -0);                \n\
         }                                       \n\
         ";
+
     compileResult = cc_compile(inpl, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok2", (compileResult >= 0) ? "Ok2" : msg.c_str());
@@ -1902,7 +1922,7 @@ TEST_F(Compile1, CTEvalIntModulo) {
 TEST_F(Compile1, CTEvalIntShiftLeft) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (60 << 3) / 0;               \n\
@@ -1966,7 +1986,7 @@ TEST_F(Compile1, CTEvalIntShiftLeft) {
 TEST_F(Compile1, CTEvalIntShiftRight) {
 
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (60 >> 3) / 0;               \n\
@@ -2019,7 +2039,7 @@ TEST_F(Compile1, CTEvalIntComparisons) {
 
     // Will fail as soon as any one of those comparisons go awry
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                          \n\
         {                                   \n\
             return                          \n\
@@ -2052,7 +2072,7 @@ TEST_F(Compile1, CTEvalIntComparisons) {
 
 TEST_F(Compile1, CTEvalBitOps) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                        \n\
         {                                 \n\
             return                        \n\
@@ -2079,7 +2099,7 @@ TEST_F(Compile1, CTEvalBitOps) {
 
 TEST_F(Compile1, CTEvalBitNeg) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                        \n\
         {                                 \n\
             return (~660753869) / 0;      \n\
@@ -2094,7 +2114,7 @@ TEST_F(Compile1, CTEvalBitNeg) {
 
 TEST_F(Compile1, CTEvalLogicalOps) {
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             return (  100000000 *   (!!7) +     \n\
@@ -2119,7 +2139,7 @@ TEST_F(Compile1, EnumConstantExpressions)
 {
     // Enum values to be evaluated at compile time
 
-    const char *inpl = "\
+    char const *inpl = "\
         enum Bytes              \n\
         {                       \n\
             zero = 1 << 0,      \n\
@@ -2131,6 +2151,7 @@ TEST_F(Compile1, EnumConstantExpressions)
             int i = two / 0;    \n\
         }                       \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2141,13 +2162,14 @@ TEST_F(Compile1, IncrementReadonly)
 {
     // No incrementing readonly vars
 
-    const char *inpl = "\
+    char const *inpl = "\
         readonly int I;         \n\
                                 \n\
         int main() {            \n\
             return ++I;         \n\
         }                       \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2158,11 +2180,12 @@ TEST_F(Compile1, SpuriousExpression)
 {
     // Warn that '77' doesn't have any effect
 
-    const char *inpl = "\
+    char const *inpl = "\
         int main() {            \n\
             77;                 \n\
         }                       \n\
         ";
+
     MessageHandler mh;
     int compile_result = cc_compile(inpl, 0, scrip, mh);
     std::string msg = last_seen_cc_error();
@@ -2172,12 +2195,13 @@ TEST_F(Compile1, SpuriousExpression)
 
 TEST_F(Compile1, CompileTimeConstant1)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         const int CI = 4711;                    \n\
         const float Euler = 2.718281828459045;  \n\
         const float AroundOne = Euler / Euler;  \n\
         float Array[CI];                        \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2185,7 +2209,7 @@ TEST_F(Compile1, CompileTimeConstant1)
 
 TEST_F(Compile1, CompileTimeConstant2)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         int main() {                            \n\
             while (1)                           \n\
             {                                   \n\
@@ -2194,6 +2218,7 @@ TEST_F(Compile1, CompileTimeConstant2)
             float CI2;                          \n\
         }                                       \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2201,7 +2226,7 @@ TEST_F(Compile1, CompileTimeConstant2)
 
 TEST_F(Compile1, CompileTimeConstant3)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         struct Str                          \n\
         {                                   \n\
             int stuff;                      \n\
@@ -2214,6 +2239,7 @@ TEST_F(Compile1, CompileTimeConstant3)
             return s.foo;                   \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2221,17 +2247,19 @@ TEST_F(Compile1, CompileTimeConstant3)
 
 TEST_F(Compile1, CompileTimeConstant4)
 {
-    const char *inpl = "\
+    char const *inpl = "\
         import const int C = 42; \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("import"));
 
-    const char *inpl2 = "\
+    char const *inpl2 = "\
         readonly const int C = 42; \n\
         ";
+
     compile_result = cc_compile(inpl2, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2242,27 +2270,30 @@ TEST_F(Compile1, CompileTimeConstant5)
 {
     // Cannot define a compile-time constant of type 'short'
 
-    const char *inpl = "\
+    char const *inpl = "\
         const short S = 42; \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'short'"));
 
     // Cannot define a compile-time constant array
-    const char *inpl2 = "\
+    char const *inpl2 = "\
         const int C[]; \n\
         ";
+
     compile_result = cc_compile(inpl2, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("array"));
 
     // Misplaced '[]'
-    const char *inpl3 = "\
+    char const *inpl3 = "\
         const int[] C; \n\
         ";
+
     compile_result = cc_compile(inpl3, scrip);
     msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2271,12 +2302,13 @@ TEST_F(Compile1, CompileTimeConstant5)
 
 TEST_F(Compile1, CompileTimeConstant6)
 {
-    const char *inpl = "\
+    char const *inpl = "\
             const float pi = 3.14;  \n\
         int main() {                \n\
             float pi = 3.141;       \n\
         }                           \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2289,13 +2321,14 @@ TEST_F(Compile1, StaticThisExtender)
     // This declaration should be written
     //     "import int foo (static Struct);"
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Struct                   \n\
         {                                       \n\
             int Payload;                        \n\
         };                                      \n\
         import static int Foo(this Struct *);   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2306,7 +2339,7 @@ TEST_F(Compile1, ReachabilityAndSwitch1)
 {
     // Mustn't complain about unreachable code at the end of a switch case
 
-    const char *inpl = "\n\
+    char const *inpl = "\
         int main()          \n\
         {                   \n\
             int i;          \n\
@@ -2321,6 +2354,7 @@ TEST_F(Compile1, ReachabilityAndSwitch1)
             }               \n\
         }                   \n\
         ";
+
     AGS::MessageHandler mh;
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     std::string msg = last_seen_cc_error();
@@ -2332,7 +2366,7 @@ TEST_F(Compile1, IfClauseFloat)
 {
     // Should complain that the if clause isn't vartype 'int'
 
-    const char *inpl = "\
+    char const *inpl = "\
         managed struct Strct                \n\
         {                                   \n\
         };                                  \n\
@@ -2344,6 +2378,7 @@ TEST_F(Compile1, IfClauseFloat)
             return 0.1;                     \n\
         }                                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2356,7 +2391,7 @@ TEST_F(Compile1, SideEffectExpression1)
     // the expression has a side effect.
     // Compiler shouldn't warn about an expression without side effects
 
-    const char *inpl = "\
+    char const *inpl = "\
         builtin managed struct Character {              \n\
             int Payload;                                \n\
         };                                              \n\
@@ -2368,6 +2403,7 @@ TEST_F(Compile1, SideEffectExpression1)
             character[i++].Payload;                     \n\
         }                                               \n\
         ";
+
     AGS::MessageHandler mh;
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STREQ("Ok", (compile_result >= 0) ? "Ok" : mh.GetError().Message.c_str());
@@ -2380,7 +2416,7 @@ TEST_F(Compile1, SideEffectExpression2)
     // that should have side effects.
     // Compiler should complain about 'SaveTheWorld;'
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int SaveTheWorld();      \n\
                                         \n\
         int game_start()                \n\
@@ -2388,6 +2424,7 @@ TEST_F(Compile1, SideEffectExpression2)
             SaveTheWorld;               \n\
         }                               \n\
         ";
+
     AGS::MessageHandler mh;
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : mh.GetError().Message.c_str());
@@ -2400,7 +2437,7 @@ TEST_F(Compile1, SideEffectExpression3)
     // that should have side effects.
     // Compiler should complain about 'Initialize;' in the 'for' loop
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Initialize();        \n\
                                         \n\
         int game_start()                \n\
@@ -2409,6 +2446,7 @@ TEST_F(Compile1, SideEffectExpression3)
             { }                         \n\
         }                               \n\
         ";
+
     AGS::MessageHandler mh;
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : mh.GetError().Message.c_str());
@@ -2421,7 +2459,7 @@ TEST_F(Compile1, SideEffectExpression4)
     // that should have side effects.
     // Compiler should complain about 'Increment' in the 'for' loop
 
-    const char *inpl = "\
+    char const *inpl = "\
         import int Increment();         \n\
                                         \n\
         int game_start()                \n\
@@ -2430,6 +2468,7 @@ TEST_F(Compile1, SideEffectExpression4)
             { }                         \n\
         }                               \n\
         ";
+
     AGS::MessageHandler mh;
     int const compile_result = cc_compile(inpl, 0, scrip, mh);
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : mh.GetError().Message.c_str());
@@ -2439,12 +2478,13 @@ TEST_F(Compile1, DisallowStaticVariables)
 {
     // AGS does not have static variables.
 
-    const char *inpl = "\
+    char const *inpl = "\
         struct Struct       \n\
         {                   \n\
             static int Var; \n\
         };                  \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
@@ -2456,7 +2496,7 @@ TEST_F(Compile1, LongMin01) {
 
     // LONG_MAX + 1 is too large (when there isn't a '-' in front)
 
-    char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int i = 2147483648;                 \n\
@@ -2473,7 +2513,7 @@ TEST_F(Compile1, LongMin02) {
 
     // LONG_MAX + 1 is too large (when there isn't a UNARY '-' in front)
 
-    char *inpl = "\
+    char const *inpl = "\
         int main()                              \n\
         {                                       \n\
             int i = (5 - 2147483648);           \n\
@@ -2490,7 +2530,7 @@ TEST_F(Compile1, LongMin03) {
 
     // Can subtract LONG_MIN from LONG_MIN (result is 0)
 
-    char *inpl = "\
+    char const *inpl = "\
         int main()                                  \n\
         {                                           \n\
             int i = (- 2147483648 - -2147483648);   \n\
@@ -2507,13 +2547,14 @@ TEST_F(Compile1, AssignmentInParameterList1)
     // An expression cannot contain an assignment symbol '='.
     // Each parameter must comprise an expression, no trailing symbols
 
-    const char *inpl = "\
+    char const *inpl = "\
         int test(int x)     \n\
         {                   \n\
             int i = 0;      \n\
             test(i = 99);   \n\
         }                   \n\
         ";
+
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());

--- a/Compiler/test2/cc_parser_test_lib.cpp
+++ b/Compiler/test2/cc_parser_test_lib.cpp
@@ -12,7 +12,7 @@ void clear_error()
     last_cc_error_buf.clear();
 }
 
-const char *last_seen_cc_error()
+char const *last_seen_cc_error()
 {
     return last_cc_error_buf.c_str();
 }

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -106,7 +106,7 @@ TEST_F(Scan, ShortInputString1) {
 
     // String literal isn't ended
 
-    const char *Input = "\"Supercalifragilisticexpialidocious";
+    char const *Input = "\"Supercalifragilisticexpialidocious";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -118,7 +118,7 @@ TEST_F(Scan, ShortInputString2) {
 
     // String literal isn't ended
 
-    const char *Input = "\"Donaudampfschiffahrtskapitaen\\";
+    char const *Input = "\"Donaudampfschiffahrtskapitaen\\";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -130,7 +130,7 @@ TEST_F(Scan, ShortInputString3) {
 
     // String literal isn't ended
 
-    const char *Input = "\"Aldiborontiphoscophornio!\nWhere left you...";
+    char const *Input = "\"Aldiborontiphoscophornio!\nWhere left you...";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     EXPECT_GT(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -238,6 +238,7 @@ TEST_F(Scan, Strings)
     std::string Input =
         "\"ABC\"\n'G' \
          \"\nH\" flurp";
+
     AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
     size_t lno;
     std::string errorstring;
@@ -299,7 +300,7 @@ TEST_F(Scan, StringCollect)
 
 TEST_F(Scan, LiteralInt1)
 {
-    const char *inp = "15 3 05 ";
+    char const *inp = "15 3 05 ";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -322,7 +323,7 @@ TEST_F(Scan, LiteralInt1)
 TEST_F(Scan, LiteralInt2)
 {
     // Accept LONG_MIN written in decimal (will yield 2 symbols)
-    const char *inp = "-2147483648";
+    char const *inp = "-2147483648";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -333,7 +334,7 @@ TEST_F(Scan, LiteralInt2)
 TEST_F(Scan, LiteralInt3)
 {
     // Accept large hexadecimal, treat as negative number (will yield 1 symbol)
-    const char *inp = "0XFF000000";
+    char const *inp = "0XFF000000";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -346,7 +347,7 @@ TEST_F(Scan, LiteralInt3)
 TEST_F(Scan, LiteralInt4)
 {
     // Accept LONG_MIN written as hexadecimal (will yield 1 symbol)
-    const char *inp = "0x80000000";
+    char const *inp = "0x80000000";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -358,7 +359,7 @@ TEST_F(Scan, LiteralInt4)
 TEST_F(Scan, LiteralInt5)
 {
     // Leading zeroes in hex literal
-    const char *inp = "0x000000001234";
+    char const *inp = "0x000000001234";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -370,7 +371,7 @@ TEST_F(Scan, LiteralInt5)
 TEST_F(Scan, LiteralInt6a)
 {
     // Huge hexadecimal, too many significant hex digits
-    const char *inp = "0x000123456789";
+    char const *inp = "0x000123456789";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -380,7 +381,7 @@ TEST_F(Scan, LiteralInt6a)
 TEST_F(Scan, LiteralInt6b)
 {
     // Huge decimal 
-    const char *inp = "1234567890123456789012345678901234567890123456789012345678901234567890"
+    char const *inp = "1234567890123456789012345678901234567890123456789012345678901234567890"
                       "1234567890123456789012345678901234567890123456789012345678901234567890"
                       "1234567890123456789012345678901234567890123456789012345678901234567890";
 
@@ -393,7 +394,7 @@ TEST_F(Scan, LiteralInt7)
 {
     // Accept number that begins with '0' but not '0x';
     // interpret such a number in decimal (!) notation
-    const char *inp = "0123";
+    char const *inp = "0123";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -405,7 +406,7 @@ TEST_F(Scan, LiteralInt7)
 TEST_F(Scan, LiteralIntLimits)
 {
     // Should correctly parse INT32_MAX and INT32_MIN
-    const char *inp1 = "-2147483648 2147483647";
+    char const *inp1 = "-2147483648 2147483647";
 
     AGS::Scanner scanner(inp1, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -427,14 +428,14 @@ TEST_F(Scan, LiteralIntLimits)
 TEST_F(Scan, LiteralIntOverflow)
 {
     // Should detect int32 overflow
-    const char *inp1 = "-2147483649";
+    char const *inp1 = "-2147483649";
     
     AGS::Scanner scanner1(inp1, token_list, string_collector, sym, mh);
     scanner1.Scan();
     ASSERT_TRUE(mh.HasError());
 
     // The scanner won't catch this, but the parser will.
-    // const char *inp2 = "2147483648";
+    // char const *inp2 = "2147483648";
     // AGS::Scanner scanner2(inp2, token_list, string_collector, sym, mh);
     // scanner2.Scan();
     // ASSERT_TRUE(mh.HasError());
@@ -442,7 +443,7 @@ TEST_F(Scan, LiteralIntOverflow)
 
 TEST_F(Scan, LiteralIntHex)
 {
-    const char *inp = "0x7FFFFFFF 0xFFFFFFFF";
+    char const *inp = "0x7FFFFFFF 0xFFFFFFFF";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -460,7 +461,7 @@ TEST_F(Scan, LiteralIntHex)
 TEST_F(Scan, LiteralFloat)
 {
     //           0u 1u  2u  3u  4u   5u    6u   7u    8u   9u    10u
-    const char *inp = "3. 3.0 0.0 0.3 33E5 3e-15 3.E5 3.E-5 .3E5 .3E-5 3.14E+2";
+    char const *inp = "3. 3.0 0.0 0.3 33E5 3e-15 3.E5 3.E-5 .3E5 .3E-5 3.14E+2";
 
     AGS::Scanner scanner(inp, token_list, string_collector, sym, mh);
     scanner.Scan();
@@ -602,7 +603,7 @@ TEST_F(Scan, BackslashBracketInChar) {
 
     // Character literal '\[' is forbidden ('[' is okay)
 
-    const char *Input = "int i = '\\[';";
+    char const *Input = "int i = '\\[';";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     scanner.Scan();
@@ -615,7 +616,7 @@ TEST_F(Scan, BackslashOctal1) {
 
     // "\19" is equivalent to "\1" + "9" because 9 isn't an octal digit
 
-    const char *Input = "String s = \"Boom\\19 Box\";";
+    char const *Input = "String s = \"Boom\\19 Box\";";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -635,7 +636,7 @@ TEST_F(Scan, BackslashOctal2) {
     // '/' is just below the lowest digit '0'; "\7/" is equivalent to "\7" + "/"
     // Octal 444 is too large for a character, so this is equivalent to "\44" + "4"
 
-    const char *Input = "String s = \"Boom\\7/Box\\444/Borg\";";
+    char const *Input = "String s = \"Boom\\7/Box\\444/Borg\";";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -652,7 +653,7 @@ TEST_F(Scan, BackslashOctal3) {
 
     // '\102' is 66 corresponds to 'B'; '\234' is 156u is -100
 
-    const char *Input = "\"b\\102b\" '\\234'";
+    char const *Input = "\"b\\102b\" '\\234'";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
     
@@ -668,7 +669,7 @@ TEST_F(Scan, BackslashHex1) {
 
     // Expect a hex digit after '\x'
 
-    const char *Input = "\"Le\\xicon\"";
+    char const *Input = "\"Le\\xicon\"";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -685,7 +686,7 @@ TEST_F(Scan, BackslashHex2) {
     // End hex when 'g' is encountered; that's directly after 'F'
     // End hex after two hex digits
 
-    const char *Input = "\"He\\xA/meter \\xC@fe Nicolas C\\xAGE \\xFACE \"";
+    char const *Input = "\"He\\xA/meter \\xC@fe Nicolas C\\xAGE \\xFACE \"";
 
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
@@ -700,7 +701,7 @@ TEST_F(Scan, BackslashOctHex) {
     
     // Test all combinations of upper and lower letters and numbers
 
-    const char *Input =
+    char const *Input =
         "\" \\x19 \\x2a \\x3A \\xb4 \\xcd \\xeB \\xC5 \\xDf \\xEF \""
         "\" \\31 \\52 \\72 \\264 \\315 \\353 \\305 \\337 \\357 \"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
@@ -718,7 +719,7 @@ TEST_F(Scan, BackslashCSym) {
     
     // Test different symbol characters after '\'
 
-    const char *Input = "\" Is \\'Java\\' \\equal to \\\"Ja\\va\\\" \\? \"";
+    char const *Input = "\" Is \\'Java\\' \\equal to \\\"Ja\\va\\\" \\? \"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -731,7 +732,7 @@ TEST_F(Scan, BackslashBackslash) {
     
     // Backslash Backslash in strings or char literals converts to backslash.
 
-    const char *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
+    char const *Input = "'\\\\' \"\\\\a\\\\b\\\\\"";
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
@@ -763,7 +764,7 @@ TEST_F(Scan, UnknownKeywordAfterReadonly) {
     // Now, semantic struct parsing has been completely relocated into the parser,
     // and thus this sequence should not pose problems.
 
-    const char *inpl =   "struct MyStruct \
+    char const *inpl =   "struct MyStruct \
                     {\
                       readonly int2 a; \
                       readonly int2 b; \
@@ -885,7 +886,7 @@ TEST_F(Scan, MatchBraceParen5)
     // The scanner checks that nested (), [], {} match.
     // Opener without closer
 
-    const char *Input = "\
+    char const *Input = "\
             struct MyStruct \n\
             {               \n\
                 int i;      \n\
@@ -894,6 +895,7 @@ TEST_F(Scan, MatchBraceParen5)
             {               \n\
                 S.          \n\
         ";
+
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
@@ -907,7 +909,7 @@ TEST_F(Scan, MatchBraceParen6)
     // The scanner checks that nested (), [], {} match.
     // Opener without closer
 
-    const char *Input = "\
+    char const *Input = "\
             struct MyStruct \n\
             {               \n\
                 int i;      \n\
@@ -916,6 +918,7 @@ TEST_F(Scan, MatchBraceParen6)
                 S.          \n\
             }               \n\
         ";
+
     AGS::Scanner scanner = { Input, token_list, string_collector, sym, mh };
     scanner.Scan();
     ASSERT_TRUE(mh.HasError());
@@ -946,11 +949,12 @@ TEST_F(Scan, ConsecutiveStringLiterals2)
     // Literals that start with __NEWSCRIPTSTART_ are section start markers
     // and must NOT be concatenated.
 
-    const char *input = " \
+    char const *input = " \
         \"__NEWSCRIPTSTART_File1\" \
         \"xyzzy\" \
         \"__NEWSCRIPTSTART_File2\" \
         ";
+
     AGS::Scanner scanner(input, token_list, string_collector, sym, mh);
 
     EXPECT_EQ(0, scanner.GetNextSymstringT(symstring, sct, value));


### PR DESCRIPTION
This addresses #1832 and #1836.
This replaces #1835.

Bug 1: When using compile-time compilations, the compiler emitted some `Linenum` pseudo-directives but cut them out afterwards so that the generated code didn't know about the affected lines any longer. This meant that breakpoints couldn't be set on such lines. (`Linenum` directives link specific points of generated code to specific source lines.)

This bug had been able to creep in because the Bytecode tests of the compiler ran without emitting `Linenum` directives. (The Bytecode tests make the compiler emit actual code for small AGS snippets and check whether the code is as expected.) So in particular, the Bytecode tests did not check whether these directives were correctly set. In my opinion, I had made a bad design decision when I decided this.

Thus I enabled the directives and redid all the tests, checking manually whether the directives were now emitted correctly. 

Bug 2: It now turned out that in one Googletest, the compiler had emitted correct code when `Linenum` directives were turned __off__, but now that the directives had been turned __on__, the compiler suddenly emitted incorrect code. 

This  bug happened when the compiler was cutting out code that had already been generated and pasting it into a different place. This code could sometimes contain cells that needed to be patched later on, and the bug was that some specific cells weren't patched correctly when `Linenum` directives where __on__.

The compiler code that used that functionality and had the bug was messy. So I cleaned up: I isolated the cutting, pasting, and patching functionality into classes and rewrote the compiler to use these classes. This fixed the bug.

As part of these changes, `for` loops are now generated in a slightly more space efficient way.

Typical AGS code:  All kinds of `for` loops. And:
```
function game_start()
{
   int a = 1;
   int b = 1 + 1; \\ ←
   int c = a + b;
   c += 1;
   c += 1 + 1; \\ ←
   return 0;
}
```
When breakpoints are set on the lines marked `←` then execution should stop when reaching those lines.