### PR TITLE
Ci: macOS Intel images are obsoleted from CirrusCi

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,25 +112,46 @@ build_linux_make_task:
 
 build_macos_task:
   only_if: $CIRRUS_RELEASE == ''
-  osx_instance:
+  macos_instance:
     matrix:
-      - image: mojave-xcode-10.2   # newest minor release of previous version
-      - image: mojave-xcode        # alias to latest xcode (11.x)
+      - image: ghcr.io/cirruslabs/macos-ventura-xcode:latest # newest release of current version
+      - image: ghcr.io/cirruslabs/macos-monterey-xcode:latest # newest release of previous version
   env:
     matrix:
       - BUILD_TYPE: debug
       - BUILD_TYPE: release
-    CMAKE_VERSION: 3.14.5
-  install_cmake_script: |
-    url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Darwin-x86_64.tar.gz"
-    echo "Downloading CMake from $url"
-    curl -fLSs "$url" | bsdtar -f - -xvzC /Applications --strip-components 1
+    CMAKE_VERSION: 3.22.3
+    NINJA_VERSION: 1.11.1
+  macos_dependencies_cache:
+    folder: dep_cache
+    fingerprint_script: echo "$CMAKE_VERSION $NINJA_VERSION"
+    populate_script: |
+      mkdir dep_cache && cd dep_cache && mkdir bin && mkdir app      
+      url="https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-mac.zip"
+      echo "Downloading Ninja from $url"
+      curl -fLSs "$url" --output "ninja-mac.zip" && unzip -d bin ninja-mac.zip && rm ninja-mac.zip
+      url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz"
+      echo "Downloading CMake from $url"
+      curl -fLSs "$url" | bsdtar -f - -xvzC app --strip-components 1
+  install_dependencies_script: |
+    sudo chown $USER /usr/local/bin
+    cd dep_cache
+    pushd app && cp -R CMake.app /Applications/CMake.app && popd
+    cd bin && cp ninja /usr/local/bin/ninja
+  setup_destdir_script: |
+    mkdir destdir
+    xcode=$(xcodebuild -version | awk '{ print $2; exit }')
+    ln -s destdir/bin bin_${xcode}_$BUILD_TYPE
   build_script: |
     xcode=$(xcodebuild -version | awk '{ print $2; exit }')
     mkdir build_${xcode}_$BUILD_TYPE && cd build_${xcode}_$BUILD_TYPE
-    /Applications/CMake.app/Contents/bin/cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. && make
+    /Applications/CMake.app/Contents/bin/cmake -S .. -B . -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+      -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+      -DCMAKE_INSTALL_PREFIX="$(cd ../destdir && pwd)"
+    ninja install
   binaries_artifacts:
-    path: build_*/ags
+    path: bin_*/*
 
 build_android_task:
   container:

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -603,7 +603,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/.. PREFIX "Source Files" FILES ${E
 # -----------------------------------------------------------------------------
 
 add_executable(ags)
-if (LINUX)
+if (LINUX OR MACOS)
     install(TARGETS ags RUNTIME DESTINATION bin)
 endif ()
 


### PR DESCRIPTION
- Equalize build with newer ags releases
- Add install support to macOS on CMake
- Apple Silicon macOS images have different permissions in usr/local
- Newer ninja binaries are built as Universal macOS apps