### PR TITLE
Engine: csci gui messages uses intptr_t insted of long

### DIFF
--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -237,11 +237,11 @@ void CSCIDeleteControl(int haa)
     vobjs[haa] = nullptr;
 }
 
-int CSCISendControlMessage(int haa, int mess, int wPar, long lPar)
+int CSCISendControlMessage(int haa, int mess, int wPar, intptr_t ipPar)
 {
     if (vobjs[haa] == nullptr)
         return -1;
-    return vobjs[haa]->processmessage(mess, wPar, lPar);
+    return vobjs[haa]->processmessage(mess, wPar, ipPar);
 }
 
 void multiply_up_to_game_res(int *x, int *y)

--- a/Engine/gui/cscidialog.h
+++ b/Engine/gui/cscidialog.h
@@ -26,7 +26,7 @@ void CSCIEraseWindow(int handl);
 int  CSCIWaitMessage(CSCIMessage * cscim);
 int  CSCICreateControl(int typeandflags, int xx, int yy, int wii, int hii, const char *title);
 void CSCIDeleteControl(int haa);
-int  CSCISendControlMessage(int haa, int mess, int wPar, long lPar);
+int  CSCISendControlMessage(int haa, int mess, int wPar, intptr_t ipPar);
 void multiply_up_to_game_res(int *x, int *y);
 void multiply_up(int *x1, int *y1, int *x2, int *y2);
 int  checkcontrols();

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -189,11 +189,11 @@ int savegamedialog()
 
   lpTemp = nullptr;
   if (numsaves > 0)
-    CSCISendControlMessage(ctrllist, CLB_GETTEXT, 0, (long)&buffer2[0]);
+    CSCISendControlMessage(ctrllist, CLB_GETTEXT, 0, (intptr_t)&buffer2[0]);
   else
     buffer2[0] = 0;
 
-  CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);
+  CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (intptr_t)&buffer2[0]);
 
   int toret = -1;
   while (1) {
@@ -201,10 +201,10 @@ int savegamedialog()
     if (mes.code == CM_COMMAND) {
       if (mes.id == ctrlok) {
         int cursell = CSCISendControlMessage(ctrllist, CLB_GETCURSEL, 0, 0);
-        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (long)&buffer2[0]);
+        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (intptr_t)&buffer2[0]);
 
         if (numsaves > 0)
-          CSCISendControlMessage(ctrllist, CLB_GETTEXT, cursell, (long)&bufTemp[0]);
+          CSCISendControlMessage(ctrllist, CLB_GETTEXT, cursell, (intptr_t)&bufTemp[0]);
         else
           strcpy(bufTemp, "_NOSAVEGAMENAME");
 
@@ -228,7 +228,7 @@ int savegamedialog()
             CSCIWaitMessage(&cmes);
           } while (cmes.code != CM_COMMAND);
 
-          CSCISendControlMessage(txt1, CTB_GETTEXT, 0, (long)&buffer2[0]);
+          CSCISendControlMessage(txt1, CTB_GETTEXT, 0, (intptr_t)&buffer2[0]);
           CSCIDeleteControl(btnCancel);
           CSCIDeleteControl(btnOk);
           CSCIDeleteControl(txt1);
@@ -279,8 +279,8 @@ int savegamedialog()
     } else if (mes.code == CM_SELCHANGE) {
       int cursel = CSCISendControlMessage(ctrllist, CLB_GETCURSEL, 0, 0);
       if (cursel >= 0) {
-        CSCISendControlMessage(ctrllist, CLB_GETTEXT, cursel, (long)&buffer2[0]);
-        CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);
+        CSCISendControlMessage(ctrllist, CLB_GETTEXT, cursel, (intptr_t)&buffer2[0]);
+        CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (intptr_t)&buffer2[0]);
       }
     }
   }
@@ -304,7 +304,7 @@ void preparesavegamelist(int ctrllist)
   // fill in the list box and global savegameindex[] array for backward compatibilty
   for (numsaves = 0; (size_t)numsaves < saves.size(); ++numsaves)
   {
-      CSCISendControlMessage(ctrllist, CLB_ADDITEM, 0, (long)saves[numsaves].Description.GetCStr());
+      CSCISendControlMessage(ctrllist, CLB_ADDITEM, 0, (intptr_t)saves[numsaves].Description.GetCStr());
       filenumbers[numsaves] = saves[numsaves].Slot;
       filedates[numsaves] = (long int)saves[numsaves].FileTime;
   }
@@ -339,7 +339,7 @@ void enterstringwindow(const char *prompttext, char *stouse)
       if (mes.id == ctrlcancel)
         buffer2[0] = 0;
       else
-        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (long)&buffer2[0]);
+        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (intptr_t)&buffer2[0]);
       break;
     }
   }
@@ -382,7 +382,7 @@ int roomSelectorWindow(int currentRoom, int numRooms,
   for (int aa = 0; aa < numRooms; aa++)
   {
     snprintf(buff, sizeof(buff), "%3d %s", roomNumbers[aa], roomNames[aa].GetCStr());
-    CSCISendControlMessage(ctrllist, CLB_ADDITEM, 0, (long)&buff[0]);
+    CSCISendControlMessage(ctrllist, CLB_ADDITEM, 0, (intptr_t)&buff[0]);
     if (roomNumbers[aa] == currentRoom)
     {
       CSCISendControlMessage(ctrllist, CLB_SETCURSEL, aa, 0);
@@ -397,7 +397,7 @@ int roomSelectorWindow(int currentRoom, int numRooms,
   buffer2[0] = 0;
 
   int ctrltbox = CSCICreateControl(CNT_TEXTBOX, 10, 29, 120, 0, nullptr);
-  CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);
+  CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (intptr_t)&buffer2[0]);
 
   int toret = -1;
   while (1) {
@@ -406,7 +406,7 @@ int roomSelectorWindow(int currentRoom, int numRooms,
     {
       if (mes.id == ctrlok) 
       {
-        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (long)&buffer2[0]);
+        CSCISendControlMessage(ctrltbox, CTB_GETTEXT, 0, (intptr_t)&buffer2[0]);
         if (isdigit(buffer2[0]))
         {
           toret = atoi(buffer2);
@@ -423,7 +423,7 @@ int roomSelectorWindow(int currentRoom, int numRooms,
       if (cursel >= 0) 
       {
         snprintf(buffer2, sizeof(buffer2), "%d", roomNumbers[cursel]);
-        CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (long)&buffer2[0]);
+        CSCISendControlMessage(ctrltbox, CTB_SETTEXT, 0, (intptr_t)&buffer2[0]);
       }
     }
   }

--- a/Engine/gui/mylabel.cpp
+++ b/Engine/gui/mylabel.cpp
@@ -54,7 +54,7 @@ int MyLabel::pressedon(int /*mx*/, int /*my*/)
     return 0;
 }
 
-int MyLabel::processmessage(int /*mcode*/, int /*wParam*/, long /*lParam*/)
+int MyLabel::processmessage(int /*mcode*/, int /*wParam*/, intptr_t /*lParam*/)
 {
     return -1;                  // doesn't support messages
 }

--- a/Engine/gui/mylabel.h
+++ b/Engine/gui/mylabel.h
@@ -26,7 +26,7 @@ struct MyLabel:public NewControl
 
   int pressedon(int mx, int my) override;
 
-  int processmessage(int mcode, int wParam, long lParam) override;
+  int processmessage(int mcode, int wParam, intptr_t ipParam) override;
 };
 
 #endif // __AC_MYLABEL_H

--- a/Engine/gui/mylistbox.cpp
+++ b/Engine/gui/mylistbox.cpp
@@ -134,10 +134,10 @@ extern int smcode;
     needredraw = 1;
   }
 
-  int MyListBox::processmessage(int mcode, int wParam, long lParam)
+  int MyListBox::processmessage(int mcode, int wParam, intptr_t ipParam)
   {
     if (mcode == CLB_ADDITEM) {
-      additem((char *)lParam);
+      additem((char *)ipParam);
     } else if (mcode == CLB_CLEAR)
       clearlist();
     else if (mcode == CLB_GETCURSEL)
@@ -153,12 +153,12 @@ extern int smcode;
         topitem = (selected + 1) - numonscreen;
     }
     else if (mcode == CLB_GETTEXT)
-      strcpy((char *)lParam, itemnames[wParam]);
+      strcpy((char *)ipParam, itemnames[wParam]);
     else if (mcode == CLB_SETTEXT) {
       if (wParam < items)
         free(itemnames[wParam]);
 
-      char *newstri = (char *)lParam;
+      char *newstri = (char *)ipParam;
       itemnames[wParam] = (char *)malloc(strlen(newstri) + 2);
       strcpy(itemnames[wParam], newstri);
 

--- a/Engine/gui/mylistbox.h
+++ b/Engine/gui/mylistbox.h
@@ -31,7 +31,7 @@ struct MyListBox:public NewControl
   void draw(Common::Bitmap *ds) override;
   int pressedon(int mx, int my) override;
   void additem(char *texx);
-  int processmessage(int mcode, int wParam, long lParam) override;
+  int processmessage(int mcode, int wParam, intptr_t ipParam) override;
 };
 
 #endif // __AC_MYLISTBOX_H

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -95,7 +95,7 @@ int MyPushButton::pressedon(int mx, int my)
     return wasstat;
 }
 
-int MyPushButton::processmessage(int /*mcode*/, int /*wParam*/, long /*lParam*/)
+int MyPushButton::processmessage(int /*mcode*/, int /*wParam*/, intptr_t /*lParam*/)
 {
     return -1;                  // doesn't support messages
 }

--- a/Engine/gui/mypushbutton.h
+++ b/Engine/gui/mypushbutton.h
@@ -23,7 +23,7 @@ struct MyPushButton:public NewControl
   MyPushButton(int xx, int yy, int wi, int hi, const char *tex);
   void draw(Common::Bitmap *ds) override;
   int pressedon(int mx, int my) override;
-  int processmessage(int mcode, int wParam, long lParam) override;
+  int processmessage(int mcode, int wParam, intptr_t ipParam) override;
 };
 
 #endif // __AC_PUSHBUTTON_H

--- a/Engine/gui/mytextbox.cpp
+++ b/Engine/gui/mytextbox.cpp
@@ -55,17 +55,17 @@ int MyTextBox::pressedon(int /*mx*/, int /*my*/)
     return 0;
 }
 
-int MyTextBox::processmessage(int mcode, int wParam, long lParam)
+int MyTextBox::processmessage(int mcode, int wParam, intptr_t ipParam)
 {
     if (mcode == CTB_SETTEXT) {
-        snprintf(text, sizeof(text), "%s", (const char*)lParam);
+        snprintf(text, sizeof(text), "%s", (const char*)ipParam);
         needredraw = 1;
     } else if (mcode == CTB_GETTEXT)
-        strcpy((char *)lParam, text); // FIXME! dangerous
+        strcpy((char *)ipParam, text); // FIXME! dangerous
     else if (mcode == CTB_KEYPRESS) {
         // NOTE: this deprecated control does not support UTF-8
         int key = wParam;
-        int uchar = lParam;
+        int uchar = static_cast<int>(ipParam);
         size_t len = strlen(text);
         if (key == eAGSKeyCodeBackspace) {
             if (len > 0)

--- a/Engine/gui/mytextbox.h
+++ b/Engine/gui/mytextbox.h
@@ -24,7 +24,7 @@ struct MyTextBox:public NewControl
   MyTextBox(int xx, int yy, int wii, const char *tee);
   void draw(Common::Bitmap *ds) override;
   int pressedon(int mx, int my) override;
-  int processmessage(int mcode, int wParam, long lParam) override;
+  int processmessage(int mcode, int wParam, intptr_t ipParam) override;
 };
 
 #endif // __AC_MYTEXTBOX_H

--- a/Engine/gui/newcontrol.h
+++ b/Engine/gui/newcontrol.h
@@ -29,7 +29,7 @@ struct NewControl
   char needredraw;
   virtual void draw(Common::Bitmap *ds) = 0;
   virtual int pressedon(int mx, int my) = 0;
-  virtual int processmessage(int, int, long) = 0;
+  virtual int processmessage(int, int, intptr_t) = 0;
 
   NewControl(int xx, int yy, int wi, int hi);
   NewControl();


### PR DESCRIPTION
fix #1875 

It's a good idea to let the CI build on all platforms. I tested and [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint) was not needed for [`intptr_t`](https://en.cppreference.com/w/cpp/types/integer) in any platform locally, apparently the compilers somehow already include.