### PR TITLE
Editor: do not load exe in agsnative

### DIFF
--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -131,7 +131,7 @@ namespace AGS
 			char fileNameChars[MAX_PATH];
 			TextHelper::ConvertASCIIFilename(fileToUpdate, fileNameChars, MAX_PATH);
 
-      HMODULE module = LoadLibrary(fileNameChars);
+      HMODULE module = LoadLibraryEx(fileNameChars, NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
       if (module == NULL)
       {
         throw gcnew AGSEditorException("LoadLibrary failed");

--- a/Editor/AGS.Native/agsicons.cpp
+++ b/Editor/AGS.Native/agsicons.cpp
@@ -74,7 +74,7 @@ bool FindResID(const char *exeName, LPCSTR lpType, LPTSTR &lpIconResName, String
 {
     HMODULE hExe;
     // Load the .EXE file
-    hExe = LoadLibrary(exeName); 
+    hExe = LoadLibraryEx(exeName, NULL, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE | LOAD_LIBRARY_AS_IMAGE_RESOURCE);
     if (hExe == NULL) 
     {
         err_msg = "Unable to load executable.";


### PR DESCRIPTION
Just access resources to ensure 64-bit/32-bit compatibility

---

This would allow a current editor to use a custom experimental 64-bit build of acwin.exe, for testing purposes, so it can still rewrite the game icon (otherwise it produces an error at this step, so it's not possible to build the game)