### PR TITLE
Engine: fail when reading game data should return error

### DIFF
--- a/Engine/main/game_file.cpp
+++ b/Engine/main/game_file.cpp
@@ -188,6 +188,8 @@ HError load_game_file()
     if (!err)
         return err;
     err = (HError)ReadGameData(ents, src.InputStream.get(), src.DataVersion);
+    if (!err)
+        return err;
     src.InputStream.reset();
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
After the Clifftop mod commit (https://github.com/adventuregamestudio/ags/commit/6a238e9cb4acda222898dd4b597cf20581b401f6) in `Engine/main/game_file.cpp`, the error returned from `ReadGameData` is not actioned upon, and it's later rewritten by the error from `UpdateGameData`.

This just adds an error check, where it returns it in case of error.