### PR TITLE
Alfont: fix leak, release before freeing last reference

### DIFF
--- a/Common/libsrc/alfont-2.0.9/alfont.c
+++ b/Common/libsrc/alfont-2.0.9/alfont.c
@@ -947,8 +947,11 @@ void alfont_textout_aa_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int
 
   /* is it under or over or too far to the right of the clipping rect then
      we can assume the string is clipped */
-  if ((y + f->face_h < bmp->ct) || (y > bmp->cb) || (x > bmp->cr))
-    return;
+  if ((y + f->face_h < bmp->ct) || (y > bmp->cb) || (x > bmp->cr)) {
+      if(s_pointer) free(s_pointer);
+      s_pointer = NULL;
+      return;
+  }
 
   //build transparency
   if (f->transparency!=255) {
@@ -2110,8 +2113,11 @@ void alfont_textout_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int y,
 
   /* is it under or over or too far to the right of the clipping rect then
      we can assume the string is clipped */
-  if ((y + f->face_h < bmp->ct) || (y > bmp->cb) || (x > bmp->cr))
-    return;
+  if ((y + f->face_h < bmp->ct) || (y > bmp->cb) || (x > bmp->cr)) {
+      if(s_pointer) free(s_pointer);
+      s_pointer = NULL;
+      return;
+  }
 
   //build transparency
   if (f->transparency!=255) {


### PR DESCRIPTION
In Alfont, `s_pointer` holds a copy of the string we are drawing, but in case it's completely clipped, we return. But in this case, we don't free `s_pointer`, which is incorrect. You can see that later on, incase the string is not completely clipped, the `s_pointer` is freed.

Because the templates use wfn fonts, made a small game that draws text with a truetype font that gets clipped. You can run it using the build from master and see the RAM usage grow in realtime! :)

[TestClip.zip](https://github.com/adventuregamestudio/ags/files/10369913/TestClip.zip)

