### PR TITLE
Android: upgrade platform to Android 13, build tools 33

### DIFF
--- a/Android/agsplayer/app/build.gradle
+++ b/Android/agsplayer/app/build.gradle
@@ -4,16 +4,16 @@ plugins {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.1"
     // the android plugin has a bug that requires specifying ndkVersion in every module, even when unused
     // this version should match what is installed in the CI
-    ndkVersion '21.3.6528147'
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "uk.co.adventuregamestudio.agsplayer"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -38,6 +38,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'uk.co.adventuregamestudio.agsplayer'
 }
 
 dependencies {

--- a/Android/agsplayer/app/src/main/AndroidManifest.xml
+++ b/Android/agsplayer/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="uk.co.adventuregamestudio.agsplayer">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Allow reading to external storage -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/Android/agsplayer/build.gradle
+++ b/Android/agsplayer/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.21"
+    ext.kotlin_version = "1.7.21"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Android/agsplayer/gradle.properties
+++ b/Android/agsplayer/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/Android/agsplayer/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/agsplayer/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/Android/library/runtime/build.gradle
+++ b/Android/library/runtime/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
+        classpath "com.android.tools.build:gradle:7.4.0"
     }
 }
 
@@ -23,16 +23,16 @@ else {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.3"
-    ndkVersion '21.3.6528147'
+    compileSdkVersion 33
+    buildToolsVersion "33.0.1"
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         if (buildAsApplication) {
             applicationId "uk.co.adventuregamestudio.runtime"
         }
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 

--- a/Android/library/runtime/src/main/AndroidManifest.xml
+++ b/Android/library/runtime/src/main/AndroidManifest.xml
@@ -39,7 +39,10 @@
             android:launchMode="singleInstance"
             android:exported="true">
         </activity>
-        <activity android:configChanges="orientation|keyboardHidden|screenSize" android:name=".PreferencesActivity">
+        <activity
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:name=".PreferencesActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>

--- a/Android/mygame/app/build.gradle
+++ b/Android/mygame/app/build.gradle
@@ -9,8 +9,8 @@ def projectProperties = new Properties()
 projectProperties.load(new FileInputStream(projectPropertiesFile))
 
 android {
-    compileSdkVersion = 29
-    buildToolsVersion = '30.0.3'
+    compileSdkVersion = 33
+    buildToolsVersion = '33.0.1'
     def appIdParts = projectProperties['applicationId'].split(/\./)
     def nameCount = appIdParts.size()
     def appIdLastPart = appIdParts[nameCount-1]
@@ -21,7 +21,7 @@ android {
         applicationId projectProperties['applicationId']
         archivesBaseName = "app-" + appIdLastPart
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode Integer.parseInt(projectProperties.getProperty('versionCode'))
         versionName projectProperties['versionName']
     }
@@ -46,6 +46,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.mystudioname.mygamename'
 }
 
 dependencies {

--- a/Android/mygame/app/src/main/AndroidManifest.xml
+++ b/Android/mygame/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.mystudioname.mygamename"
     android:installLocation="preferExternal"><!-- TODO: UPDATE PACKAGE NAME -->
 
     <!-- Required to access Google Play Licensing -->

--- a/Android/mygame/build.gradle
+++ b/Android/mygame/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Android/mygame/gradle.properties
+++ b/Android/mygame/gradle.properties
@@ -18,4 +18,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false

--- a/Android/mygame/play_licensing_library/build.gradle
+++ b/Android/mygame/play_licensing_library/build.gradle
@@ -14,12 +14,12 @@ repositories {
 
 android {
     useLibrary 'org.apache.http.legacy'
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion = 33
+    buildToolsVersion = '33.0.1'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 33
     }
 
     buildTypes {
@@ -27,6 +27,7 @@ android {
             minifyEnabled false
         }
     }
+    namespace 'com.google.android.vending.licensing'
 }
 
 dependencies {

--- a/Android/mygame/play_licensing_library/src/main/AndroidManifest.xml
+++ b/Android/mygame/play_licensing_library/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.android.vending.licensing"
     android:versionCode="2"
     android:versionName="1.5">
     <!-- Devices >= 3 have version of Android Market that supports licensing. -->

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -212,7 +212,7 @@ namespace AGS.Editor
         {
             string prjDir = GetAndroidProjectInCompiledDir();
 
-            string packages = "\"build-tools;30.0.3\" \"ndk;21.3.6528147\" \"platforms;android-29\"";
+            string packages = "\"build-tools;33.0.1\" \"ndk;25.1.8937393\" \"platforms;android-33\"";
 
             AndroidUtilities.RunSdkManager(packages, prjDir);
         }

--- a/ci/android/Dockerfile
+++ b/ci/android/Dockerfile
@@ -1,7 +1,7 @@
-FROM cirrusci/android-sdk:30-ndk
-# CirrusCI Android NDK image uses Ubuntu 20.04
-# ANDROID_NDK_VERSION=21.3.6528147
-# ANDROID_BUILD_TOOLS_VERSION=30.0.2
+FROM cirrusci/android-sdk:33-ndk
+# CirrusCI Android NDK image uses Ubuntu 22.04
+# ANDROID_NDK_VERSION=25.1.8937393
+# ANDROID_BUILD_TOOLS_VERSION=33.0.1
 
 ARG APT_CONF_LOCAL=99local
 RUN mkdir -p /etc/apt/apt.conf.d && \
@@ -12,7 +12,7 @@ APT::Get::Install-Suggests "false";\n' > /etc/apt/apt.conf.d/$APT_CONF_LOCAL
 # Upgrade existing packages
 RUN apt-get update && apt-get upgrade
 
-# Get cmake and ninja (this gets cmake 3.16.3 and ninja 1.10)
+# Get cmake and ninja (this gets cmake 3.22.1 and ninja 1.10)
 RUN apt-get install \
                 cmake \
                 ninja-build \


### PR DESCRIPTION
Upgrade versions of target SDK and platform to be compatible with Google Requirements

https://developer.android.com/google/play/requirements/target-sdk

> New apps must target Android 12 (API level 31) or higher

Additionally, Gradle Version is upgraded for compatibility with newer build tools. 

Android Gradle Plugin is upgraded to be compatible with the current Android Studio Electric Eel