### PR TITLE
4.0: Add description field to the Game Template selection page

### DIFF
--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -21,7 +21,6 @@ namespace AGS.Editor
         public const string FILE_MENU_ID = "fileToolStripMenuItem";
         public const string HELP_MENU_ID = "HelpMenu";
         private const string CONTROL_ID_SPLIT = "^!^";
-        private const string TEMPLATE_INTRO_FILE = "template.txt";
 		private const string ROOM_TEMPLATE_ID_FILE = "rtemplate.dat";
 		private const int ROOM_TEMPLATE_ID_FILE_SIGNATURE = 0x74673812;
 
@@ -1052,14 +1051,6 @@ namespace AGS.Editor
                         _agsEditor.CompileGame(true, false);
 
                         Factory.AGSEditor.Settings.MessageBoxOnCompile = oldMessageBoxSetting;
-                    }
-                    if (File.Exists(TEMPLATE_INTRO_FILE))
-                    {
-                        StreamReader sr = new StreamReader(TEMPLATE_INTRO_FILE);
-                        string introText = sr.ReadToEnd();
-                        sr.Close();
-
-                        Factory.GUIController.ShowMessage(introText, MessageBoxIcon.Information);
                     }
                     createdSuccessfully = true;
                 }

--- a/Editor/AGS.Editor/GUI/StartNewGameWizardPage.Designer.cs
+++ b/Editor/AGS.Editor/GUI/StartNewGameWizardPage.Designer.cs
@@ -29,6 +29,7 @@ namespace AGS.Editor
         private void InitializeComponent()
         {
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.tbDescription = new System.Windows.Forms.TextBox();
             this.lstTemplates = new System.Windows.Forms.ListView();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
@@ -36,14 +37,29 @@ namespace AGS.Editor
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.tbDescription);
             this.groupBox1.Controls.Add(this.lstTemplates);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Location = new System.Drawing.Point(9, 7);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(520, 219);
+            this.groupBox1.Size = new System.Drawing.Size(520, 320);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Select Template";
+            // 
+            // tbDescription
+            // 
+            this.tbDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbDescription.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.tbDescription.Location = new System.Drawing.Point(16, 215);
+            this.tbDescription.Multiline = true;
+            this.tbDescription.Name = "tbDescription";
+            this.tbDescription.ReadOnly = true;
+            this.tbDescription.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.tbDescription.Size = new System.Drawing.Size(489, 99);
+            this.tbDescription.TabIndex = 2;
             // 
             // lstTemplates
             // 
@@ -54,6 +70,7 @@ namespace AGS.Editor
             this.lstTemplates.Size = new System.Drawing.Size(491, 167);
             this.lstTemplates.TabIndex = 1;
             this.lstTemplates.UseCompatibleStateImageBehavior = false;
+            this.lstTemplates.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.lstTemplates_ItemSelectionChanged);
             // 
             // label1
             // 
@@ -63,7 +80,7 @@ namespace AGS.Editor
             this.label1.Size = new System.Drawing.Size(425, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Your new game is created based on a template. Please select the one you\'d like to" +
-                " use:";
+    " use:";
             // 
             // StartNewGameWizardPage
             // 
@@ -71,8 +88,9 @@ namespace AGS.Editor
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.groupBox1);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.MinimumSize = new System.Drawing.Size(520, 425);
             this.Name = "StartNewGameWizardPage";
-            this.Size = new System.Drawing.Size(1017, 632);
+            this.Size = new System.Drawing.Size(1504, 580);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
@@ -84,5 +102,6 @@ namespace AGS.Editor
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListView lstTemplates;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox tbDescription;
     }
 }

--- a/Editor/AGS.Editor/GUI/StartNewGameWizardPage.cs
+++ b/Editor/AGS.Editor/GUI/StartNewGameWizardPage.cs
@@ -63,5 +63,14 @@ namespace AGS.Editor
         {
             lstTemplates.Focus();
         }
+
+        private void lstTemplates_ItemSelectionChanged(object sender, ListViewItemSelectionChangedEventArgs e)
+        {
+            if (e.IsSelected && e.ItemIndex >= 0)
+                tbDescription.Text = string.IsNullOrWhiteSpace(_templates[e.ItemIndex].Description)
+                    ? "No description available." : _templates[e.ItemIndex].Description;
+            else
+                tbDescription.Text = "";
+        }
     }
 }

--- a/Editor/AGS.Editor/GUI/StartNewGameWizardPage.resx
+++ b/Editor/AGS.Editor/GUI/StartNewGameWizardPage.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Editor/AGS.Editor/GUI/WizardDialog.Designer.cs
+++ b/Editor/AGS.Editor/GUI/WizardDialog.Designer.cs
@@ -49,7 +49,9 @@ namespace AGS.Editor
             // 
             // groupBox1
             // 
-            this.groupBox1.Location = new System.Drawing.Point(12, 295);
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Location = new System.Drawing.Point(12, 389);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(516, 10);
             this.groupBox1.TabIndex = 0;
@@ -57,7 +59,8 @@ namespace AGS.Editor
             // 
             // btnNext
             // 
-            this.btnNext.Location = new System.Drawing.Point(353, 311);
+            this.btnNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnNext.Location = new System.Drawing.Point(353, 405);
             this.btnNext.Name = "btnNext";
             this.btnNext.Size = new System.Drawing.Size(83, 27);
             this.btnNext.TabIndex = 1;
@@ -67,8 +70,9 @@ namespace AGS.Editor
             // 
             // btnCancel
             // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(445, 311);
+            this.btnCancel.Location = new System.Drawing.Point(445, 405);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(83, 27);
             this.btnCancel.TabIndex = 2;
@@ -77,7 +81,8 @@ namespace AGS.Editor
             // 
             // btnBack
             // 
-            this.btnBack.Location = new System.Drawing.Point(264, 311);
+            this.btnBack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBack.Location = new System.Drawing.Point(264, 405);
             this.btnBack.Name = "btnBack";
             this.btnBack.Size = new System.Drawing.Size(83, 27);
             this.btnBack.TabIndex = 3;
@@ -87,25 +92,29 @@ namespace AGS.Editor
             // 
             // panel1
             // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.BackColor = System.Drawing.Color.White;
             this.panel1.Controls.Add(this.pnlMainPages);
             this.panel1.Controls.Add(this.lblIntroText);
             this.panel1.Controls.Add(this.lblTitle);
             this.panel1.Controls.Add(this.pictureBox1);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel1.Location = new System.Drawing.Point(0, 0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(540, 300);
+            this.panel1.Size = new System.Drawing.Size(540, 394);
             this.panel1.TabIndex = 5;
             // 
             // pnlMainPages
             // 
+            this.pnlMainPages.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.pnlMainPages.BackColor = System.Drawing.SystemColors.Control;
             this.pnlMainPages.Controls.Add(this.pnlHeader);
-            this.pnlMainPages.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlMainPages.Location = new System.Drawing.Point(0, 0);
             this.pnlMainPages.Name = "pnlMainPages";
-            this.pnlMainPages.Size = new System.Drawing.Size(540, 300);
+            this.pnlMainPages.Size = new System.Drawing.Size(540, 394);
             this.pnlMainPages.TabIndex = 8;
             // 
             // pnlHeader
@@ -145,7 +154,7 @@ namespace AGS.Editor
             this.lblIntroText.Size = new System.Drawing.Size(291, 199);
             this.lblIntroText.TabIndex = 7;
             this.lblIntroText.Text = "This wizard will guide you through doing something or other, and if youér lucky s" +
-                "omething else.";
+    "omething else.";
             // 
             // lblTitle
             // 
@@ -173,8 +182,9 @@ namespace AGS.Editor
             this.AcceptButton = this.btnNext;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSize = true;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(540, 343);
+            this.ClientSize = new System.Drawing.Size(540, 437);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.btnBack);
             this.Controls.Add(this.btnCancel);

--- a/Editor/AGS.Editor/GUI/WizardDialog.cs
+++ b/Editor/AGS.Editor/GUI/WizardDialog.cs
@@ -28,6 +28,13 @@ namespace AGS.Editor
             this.btnBack.Enabled = false;
             _pageNumber = 0;
             _pages = pages;
+            foreach (var page in pages)
+            {
+                if (page.MinimumSize.Width > pnlMainPages.Width)
+                    pnlMainPages.Width = page.MinimumSize.Width;
+                if (page.MinimumSize.Height > pnlMainPages.Height - pnlHeader.Height)
+                    pnlMainPages.Height = page.MinimumSize.Height + pnlHeader.Height;
+            }
             Utilities.CheckLabelWidthsOnForm(this);
         }
 

--- a/Editor/AGS.Editor/GUI/WizardDialog.resx
+++ b/Editor/AGS.Editor/GUI/WizardDialog.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         Qk3W5AIAAAAAADYAAAAoAAAA0gAAACwBAAABABgAAAAAAAAAAACIEQAAiBEAAAAAAAAAAAAAHx4eDw8P

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -59,7 +59,8 @@ extern int GetSpriteColorDepth(int slot);
 extern int GetPaletteAsHPalette();
 extern bool DoesSpriteExist(int slot);
 extern int GetMaxSprites();
-extern bool load_template_file(const AGSString &fileName, std::vector<char> &iconDataBuffer, bool isRoomTemplate);
+extern bool load_template_file(const AGSString &fileName, AGSString &description,
+    std::vector<char> &iconDataBuffer, bool isRoomTemplate);
 extern HAGSError extract_template_files(const AGSString &templateFileName);
 extern HAGSError extract_room_template_files(const AGSString &templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
@@ -458,9 +459,10 @@ namespace AGS
     BaseTemplate^ NativeMethods::LoadTemplateFile(String ^fileName, bool isRoomTemplate)
     {
       AGSString fileNameAnsi = TextHelper::ConvertUTF8(fileName);
+      AGSString description;
       std::vector<char> iconDataBuffer;
 
-      int success = load_template_file(fileNameAnsi, iconDataBuffer, isRoomTemplate);
+      int success = load_template_file(fileNameAnsi, description, iconDataBuffer, isRoomTemplate);
 			if (success) 
 			{
 				Icon ^icon = nullptr;
@@ -485,7 +487,7 @@ namespace AGS
         }
         else
         {
-				  return gcnew GameTemplate(fileName, nullptr, icon);
+				  return gcnew GameTemplate(fileName, TextHelper::ConvertUTF8(description), icon);
         }
 			}
 			return nullptr;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -487,7 +487,11 @@ namespace AGS
         }
         else
         {
-				  return gcnew GameTemplate(fileName, TextHelper::ConvertUTF8(description), icon);
+            // Bring linebreaks in description to the uniform "\r\n" format.
+            String ^uniDescription = TextHelper::ConvertUTF8(description);
+            uniDescription = System::Text::RegularExpressions::Regex
+                ::Replace(uniDescription, "(?<!\r)\n", "\r\n");
+            return gcnew GameTemplate(fileName, uniDescription, icon);
         }
 			}
 			return nullptr;

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -59,7 +59,7 @@ extern int GetSpriteColorDepth(int slot);
 extern int GetPaletteAsHPalette();
 extern bool DoesSpriteExist(int slot);
 extern int GetMaxSprites();
-extern int load_template_file(const AGSString &fileName, char **iconDataBuffer, long *iconDataSize, bool isRoomTemplate);
+extern bool load_template_file(const AGSString &fileName, std::vector<char> &iconDataBuffer, bool isRoomTemplate);
 extern HAGSError extract_template_files(const AGSString &templateFileName);
 extern HAGSError extract_room_template_files(const AGSString &templateFileName, int newRoomNumber);
 extern void change_sprite_number(int oldNumber, int newNumber);
@@ -458,18 +458,16 @@ namespace AGS
     BaseTemplate^ NativeMethods::LoadTemplateFile(String ^fileName, bool isRoomTemplate)
     {
       AGSString fileNameAnsi = TextHelper::ConvertUTF8(fileName);
-      char *iconDataBuffer = NULL;
-      long iconDataSize = 0;
+      std::vector<char> iconDataBuffer;
 
-      int success = load_template_file(fileNameAnsi, &iconDataBuffer, &iconDataSize, isRoomTemplate);
+      int success = load_template_file(fileNameAnsi, iconDataBuffer, isRoomTemplate);
 			if (success) 
 			{
 				Icon ^icon = nullptr;
-				if (iconDataBuffer != NULL)
+				if (!iconDataBuffer.empty())
 				{
-          cli::array<unsigned char>^ managedArray = gcnew cli::array<unsigned char>(iconDataSize);
-          Marshal::Copy(IntPtr(iconDataBuffer), managedArray, 0, iconDataSize);
-          ::free(iconDataBuffer);
+          cli::array<unsigned char>^ managedArray = gcnew cli::array<unsigned char>(iconDataBuffer.size());
+          Marshal::Copy(IntPtr(&iconDataBuffer.front()), managedArray, 0, iconDataBuffer.size());
           System::IO::MemoryStream^ ms = gcnew System::IO::MemoryStream(managedArray);
           try 
           {
@@ -487,7 +485,7 @@ namespace AGS
         }
         else
         {
-				  return gcnew GameTemplate(fileName, icon);
+				  return gcnew GameTemplate(fileName, nullptr, icon);
         }
 			}
 			return nullptr;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -91,6 +91,7 @@ const char *old_editor_main_game_file = "ac2game.dta";
 const char *TEMPLATE_LOCK_FILE = "template.dta";
 const char *TEMPLATE_ICON_FILE = "template.ico";
 const char *GAME_ICON_FILE = "user.ico";
+const char *TEMPLATE_DESC_FILE = "template.txt";
 const char *ROOM_TEMPLATE_ID_FILE = "rtemplate.dat";
 const int ROOM_TEMPLATE_ID_FILE_SIGNATURE = 0x74673812;
 bool spritesModified = false;
@@ -451,7 +452,8 @@ static bool load_asset_data(AssetManager *mgr, const char *asset_name, std::vect
     return true;
 }
 
-bool load_template_file(const AGSString &fileName, std::vector<char> &iconDataBuffer, bool isRoomTemplate)
+bool load_template_file(const AGSString &fileName, AGSString &description,
+    std::vector<char> &iconDataBuffer, bool isRoomTemplate)
 {
   const AssetLibInfo *lib = nullptr;
   std::unique_ptr<AssetManager> templateMgr(new AssetManager());
@@ -504,6 +506,13 @@ bool load_template_file(const AGSString &fileName, std::vector<char> &iconDataBu
 		    }
             in.reset();
 	    }
+
+        if (templateMgr->DoesAssetExist(TEMPLATE_DESC_FILE))
+        {
+            std::vector<char> desc_data;
+            load_asset_data(templateMgr.get(), TEMPLATE_DESC_FILE, desc_data);
+            description.SetString(&desc_data.front(), desc_data.size());
+        }
 
       int useIcon = 0;
       const char *iconName = TEMPLATE_ICON_FILE;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -89,6 +89,8 @@ const char *old_editor_data_file = "editor.dat";
 const char *new_editor_data_file = "game.agf";
 const char *old_editor_main_game_file = "ac2game.dta";
 const char *TEMPLATE_LOCK_FILE = "template.dta";
+const char *TEMPLATE_ICON_FILE = "template.ico";
+const char *GAME_ICON_FILE = "user.ico";
 const char *ROOM_TEMPLATE_ID_FILE = "rtemplate.dat";
 const int ROOM_TEMPLATE_ID_FILE_SIGNATURE = 0x74673812;
 bool spritesModified = false;
@@ -435,54 +437,48 @@ HAGSError extract_template_files(const AGSString &templateFileName)
   return HAGSError::None();
 }
 
-void extract_icon_from_template(AssetManager *templateMgr, char *iconName, char **iconDataBuffer, long *bufferSize)
+static bool load_asset_data(AssetManager *mgr, const char *asset_name, std::vector<char> &data, const size_t data_limit = SIZE_MAX)
 {
-  // make sure we get the icon from the file
-  templateMgr->SetSearchPriority(Common::kAssetPriorityLib);
-  Stream* inpu = templateMgr->OpenAsset (iconName);
-  const size_t sizey = inpu->GetLength();
-  if ((inpu != NULL) && (sizey > 0))
-  {
-    char *iconbuffer = (char*)malloc(sizey);
-    inpu->Read (iconbuffer, sizey);
-    delete inpu;
-    *iconDataBuffer = iconbuffer;
-    *bufferSize = sizey;
-  }
-  else
-  {
-    *iconDataBuffer = NULL;
-    *bufferSize = 0;
-  }
+    std::unique_ptr<Stream> in(mgr->OpenAsset(asset_name));
+    if (!in)
+        return false;
+    const size_t data_sz = std::min(static_cast<size_t>(in->GetLength()), data_limit);
+    if (data_sz >= 0)
+    {
+        data.resize(data_sz);
+        in->Read(&data.front(), data_sz);
+    }
+    return true;
 }
 
-int load_template_file(const AGSString &fileName, char **iconDataBuffer, long *iconDataSize, bool isRoomTemplate)
+bool load_template_file(const AGSString &fileName, std::vector<char> &iconDataBuffer, bool isRoomTemplate)
 {
   const AssetLibInfo *lib = nullptr;
   std::unique_ptr<AssetManager> templateMgr(new AssetManager());
+  templateMgr->SetSearchPriority(Common::kAssetPriorityLib);
   if (templateMgr->AddLibrary(fileName, &lib) == Common::kAssetNoError)
   {
     if (isRoomTemplate)
     {
       if (templateMgr->DoesAssetExist(ROOM_TEMPLATE_ID_FILE))
       {
-        Stream *inpu = templateMgr->OpenAsset(ROOM_TEMPLATE_ID_FILE);
-        if (inpu->ReadInt32() != ROOM_TEMPLATE_ID_FILE_SIGNATURE)
-        {
-          delete inpu;
-          return 0;
-        }
-        int roomNumber = inpu->ReadInt32();
-        delete inpu;
+        std::unique_ptr<Stream> in(templateMgr->OpenAsset(ROOM_TEMPLATE_ID_FILE));
+        if (!in)
+            return false;
+        if (in->ReadInt32() != ROOM_TEMPLATE_ID_FILE_SIGNATURE)
+            return false;
+        int roomNumber = in->ReadInt32();
+        in.reset();
+
         char iconName[MAX_PATH];
         sprintf(iconName, "room%d.ico", roomNumber);
         if (templateMgr->DoesAssetExist(iconName))
         {
-          extract_icon_from_template(templateMgr.get(), iconName, iconDataBuffer, iconDataSize);
+          load_asset_data(templateMgr.get(), iconName, iconDataBuffer);
         }
-        return 1;
+        return true;
       }
-      return 0;
+      return false;
     }
 	  else if ((templateMgr->DoesAssetExist(old_editor_data_file)) || (templateMgr->DoesAssetExist(new_editor_data_file)))
 	  {
@@ -492,36 +488,35 @@ int load_template_file(const AGSString &fileName, char **iconDataBuffer, long *i
           (oriname.FindString(".ags") != -1))
       {
         // wasn't originally meant as a template
-	      return 0;
+	      return false;
       }
 
-	    Stream *inpu = templateMgr->OpenAsset(old_editor_main_game_file);
-	    if (inpu != NULL) 
+	    std::unique_ptr<Stream> in(templateMgr->OpenAsset(old_editor_main_game_file));
+	    if (in) 
 	    {
-		    inpu->Seek(30);
-		    int gameVersion = inpu->ReadInt32();
-		    delete inpu;
+		    in->Seek(30);
+		    int gameVersion = in->ReadInt32();
             // TODO: check this out, in theory we still support pre-2.72 game import
-		    if (gameVersion != 32)
+		    if (gameVersion != 32) // CHECKME: why we use `!=` and not `>=` ? also what's 32?
 		    {
 			    // older than 2.72 template
-			    return 0;
+			    return false;
 		    }
+            in.reset();
 	    }
 
       int useIcon = 0;
-      char *iconName = "template.ico";
+      const char *iconName = TEMPLATE_ICON_FILE;
       if (!templateMgr->DoesAssetExist(iconName))
-        iconName = "user.ico";
-      // the file is a CLIB file, so let's extract the icon to display
+        iconName = GAME_ICON_FILE;
       if (templateMgr->DoesAssetExist(iconName))
       {
-        extract_icon_from_template(templateMgr.get(), iconName, iconDataBuffer, iconDataSize);
+        load_asset_data(templateMgr.get(), iconName, iconDataBuffer);
       }
-      return 1;
+      return true;
     }
   }
-  return 0;
+  return false;
 }
 
 void drawBlockDoubleAt (int hdc, Common::Bitmap *todraw ,int x, int y) {

--- a/Editor/AGS.Types/EditorFeatures/BaseTemplate.cs
+++ b/Editor/AGS.Types/EditorFeatures/BaseTemplate.cs
@@ -10,12 +10,14 @@ namespace AGS.Types
 	{
 		protected string _fileName;
 		protected string _friendlyName;
-		protected Icon _icon;
+        protected string _description;
+        protected Icon _icon;
 
-		public BaseTemplate(string fileName, Icon icon)
+        public BaseTemplate(string fileName, string description, Icon icon)
 		{
 			_fileName = fileName;
-			_icon = icon;
+            _description = description;
+            _icon = icon;
 			if (_fileName != null)
 			{
 				_friendlyName = Path.GetFileNameWithoutExtension(_fileName);
@@ -31,6 +33,11 @@ namespace AGS.Types
 		{
 			get { return _friendlyName; }
 		}
+
+        public string Description
+        {
+            get { return _description; }
+        }
 
 		public Icon Icon
 		{

--- a/Editor/AGS.Types/EditorFeatures/GameTemplate.cs
+++ b/Editor/AGS.Types/EditorFeatures/GameTemplate.cs
@@ -8,7 +8,8 @@ namespace AGS.Types
 {
     public class GameTemplate : BaseTemplate
     {
-        public GameTemplate(string fileName, Icon icon) : base(fileName, icon)
+        public GameTemplate(string fileName, string description, Icon icon)
+            : base(fileName, description, icon)
         {
         }
     }

--- a/Editor/AGS.Types/EditorFeatures/RoomTemplate.cs
+++ b/Editor/AGS.Types/EditorFeatures/RoomTemplate.cs
@@ -9,12 +9,12 @@ namespace AGS.Types
 	public class RoomTemplate : BaseTemplate
 	{
 		public RoomTemplate(string fileName, Icon icon)
-			: base(fileName, icon)
+			: base(fileName, null, icon)
 		{
 		}
 
 		public RoomTemplate(string fileName, Icon icon, string friendlyName)
-			: base(fileName, icon)
+			: base(fileName, null, icon)
 		{
 			_friendlyName = friendlyName;
 		}


### PR DESCRIPTION
Resolves #564.

This adds a description field to the template selection page in the New Game wizard. The template descriptions are now preloaded, along with the icons. This lets user read about the template prior to creating a game.

The pr is made against ags4 branch for now. It's simple enough, thus if wanted, this may be backported to some 3.6.* update later.

Example of looks:
![template-preview](https://user-images.githubusercontent.com/1833754/214279580-500fb550-c87d-4b8e-a4ce-b90afede7791.png)


Known issues:
1. There's something strange about how the linebreaks are managed by the text box. Double linebreaks seem to work fine (see the screenshot), but single linebreaks do not cause the line wrap for some reason... This might be a .NET bug, or something that I'm missing in text box setup.
2. I had to make the Wizard dialog to auto-resize based on the "minimal size" property of all the pages. This caused the picture on the "intro" page to not fill the full window height. Don't know what may be the best way to handle this. Is the wizard dialog supposed to stay same size all the time, or may it only increase in size when displaying particular pages? OTOH it may be adjusted later, as this is but a minor annoyance.