### PR TITLE
Engine: font width of empty text should be zero

### DIFF
--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -260,6 +260,9 @@ int get_text_width_outlined(const char *text, size_t font_number)
 {
     if (font_number >= fonts.size() || !fonts[font_number].Renderer)
         return 0;
+    if(text == nullptr || text[0] == 0) // we ignore outline width since the text is empty
+        return 0;
+
     int self_width = fonts[font_number].Renderer->GetTextWidth(text, font_number);
     int outline = fonts[font_number].Info.Outline;
     if (outline < 0 || static_cast<size_t>(outline) > fonts.size())


### PR DESCRIPTION
fix #1892 