### PR TITLE
Android: AGS Player add per game button options

### DIFF
--- a/Android/agsplayer/app/build.gradle
+++ b/Android/agsplayer/app/build.gradle
@@ -46,14 +46,14 @@ dependencies {
     // implementation fileTree(include: ['*.aar'], dir: 'libs')
     // implementation files('libs/uk.co.adventuregamestudio.runtime.aar')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation project(path: ':runtime')
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/Android/agsplayer/app/src/main/AndroidManifest.xml
+++ b/Android/agsplayer/app/src/main/AndroidManifest.xml
@@ -2,10 +2,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Allow reading to external storage -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
+
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"
+        tools:ignore="ScopedStorage"/>
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/AGSPlayerRuntimeActivity.java
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/AGSPlayerRuntimeActivity.java
@@ -3,6 +3,7 @@ package uk.co.adventuregamestudio.agsplayer;
 import android.Manifest;
 import android.app.AlertDialog;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -17,14 +18,15 @@ public class AGSPlayerRuntimeActivity extends AGSRuntimeActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        if(!hasExternalStoragePermission())
-        {
-            showExternalStoragePermissionMissingDialog();
+
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            if (!hasExternalStoragePermission()) {
+                showExternalStoragePermissionMissingDialog();
+            }
         }
 
         super.onCreate(savedInstanceState);
     }
-
 
     public void showExternalStoragePermissionMissingDialog() {
         AlertDialog dialog = new AlertDialog.Builder(mSingleton)
@@ -38,20 +40,20 @@ public class AGSPlayerRuntimeActivity extends AGSRuntimeActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         if (grantResults.length > 0) {
-            Log.d("AGSRuntimeActivity", "Received a request permission result");
+            Log.d("AGSPlayerRuntimeActivit", "Received a request permission result");
 
             switch (requestCode) {
                 case EXTERNAL_STORAGE_REQUEST_CODE: {
                     if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                        Log.d("AGSRuntimeActivity", "Permission granted");
+                        Log.d("AGSPlayerRuntimeActivit", "Permission granted");
                     } else {
-                        Log.d("AGSRuntimeActivity", "Did not get permission.");
+                        Log.d("AGSPlayerRuntimeActivit", "Did not get permission.");
                         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
                             showExternalStoragePermissionMissingDialog();
                         }
                     }
 
-                    Log.d("AGSRuntimeActivity", "Unlocking AGS thread");
+                    Log.d("AGSPlayerRuntimeActivit", "Unlocking AGS thread");
                     synchronized (externalStorageRequestDummy) {
                         externalStorageRequestDummy[0] = grantResults[0];
                         externalStorageRequestDummy.notify();
@@ -73,14 +75,14 @@ public class AGSPlayerRuntimeActivity extends AGSRuntimeActivity {
             return true;
         }
 
-        Log.d("AGSRuntimeActivity", "Requesting permission and locking AGS thread until we have an answer.");
+        Log.d("AGSPlayerRuntimeActivit", "Requesting permission and locking AGS thread until we have an answer.");
         ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, EXTERNAL_STORAGE_REQUEST_CODE);
 
         synchronized (externalStorageRequestDummy) {
             try {
                 externalStorageRequestDummy.wait();
             } catch (InterruptedException e) {
-                Log.d("AGSRuntimeActivity", "requesting external storage permission", e);
+                Log.d("AGSPlayerRuntimeActivit", "requesting external storage permission", e);
                 return false;
             }
         }

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/FileUtil.kt
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/FileUtil.kt
@@ -36,10 +36,10 @@ object FileUtil {
 
     private fun getVolumePath(volumeId: String?, context: Context): String? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null
-//        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) getVolumePathForAndroid11AndAbove(
-//            volumeId,
-//            context
-//        )
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) getVolumePathForAndroid11AndAbove(
+            volumeId,
+            context
+        )
         else return getVolumePathBeforeAndroid11(volumeId, context)
     }
 
@@ -70,27 +70,27 @@ object FileUtil {
         }
     }
 
-//    @TargetApi(Build.VERSION_CODES.R)
-//    private fun getVolumePathForAndroid11AndAbove(volumeId: String?, context: Context): String? {
-//        return try {
-//            val mStorageManager: StorageManager =
-//                context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
-//            val storageVolumes: List<StorageVolume> = mStorageManager.getStorageVolumes()
-//            for (storageVolume in storageVolumes) {
-//                // primary volume?
-//                if (storageVolume.isPrimary() && PRIMARY_VOLUME_NAME == volumeId) return storageVolume.getDirectory()
-//                    .getPath()
-//
-//                // other volumes?
-//                val uuid: String = storageVolume.getUuid()
-//                if (uuid != null && uuid == volumeId) return storageVolume.getDirectory().getPath()
-//            }
-//            // not found.
-//            null
-//        } catch (ex: Exception) {
-//            null
-//        }
-//    }
+    @TargetApi(Build.VERSION_CODES.R)
+    private fun getVolumePathForAndroid11AndAbove(volumeId: String?, context: Context): String? {
+        return try {
+            val mStorageManager: StorageManager =
+                context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
+            val storageVolumes: List<StorageVolume> = mStorageManager.getStorageVolumes()
+            for (storageVolume in storageVolumes) {
+                // primary volume?
+                if (storageVolume.isPrimary() && PRIMARY_VOLUME_NAME == volumeId) return storageVolume.getDirectory()
+                    ?.getPath()
+
+                // other volumes?
+                val uuid: String = storageVolume.getUuid().toString()
+                if (uuid != null && uuid == volumeId) return storageVolume.getDirectory()?.getPath()
+            }
+            // not found.
+            null
+        } catch (ex: Exception) {
+            null
+        }
+    }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private fun getVolumeIdFromTreeUri(treeUri: Uri): String? {

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/GameListRecyclerViewAdapter.kt
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/GameListRecyclerViewAdapter.kt
@@ -4,6 +4,7 @@ import android.view.ContextMenu
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.NonNull
 import androidx.recyclerview.widget.RecyclerView
@@ -18,6 +19,7 @@ internal class GameListRecyclerViewAdapter(private var gamesList: List<GameModel
         View.OnClickListener, View.OnCreateContextMenuListener  {
         var name: TextView = view.findViewById(R.id.tvGameName)
         var filename: TextView = view.findViewById(R.id.tvGameFileName)
+        var game_options: ImageView = view.findViewById(R.id.ivGameOptions)
         override fun onClick(view: View) {
             mClickListener?.onItemClick(view, adapterPosition)
         }
@@ -25,6 +27,10 @@ internal class GameListRecyclerViewAdapter(private var gamesList: List<GameModel
         init {
             itemView.setOnClickListener(this)
             itemView.setOnCreateContextMenuListener(this)
+            game_options.setOnClickListener {
+                // clicked on the item own three dots button
+                itemView.showContextMenu();
+            }
         }
 
         override fun onCreateContextMenu(

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
@@ -267,10 +267,10 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         val tempFilename = searchForGames()
         if(tempFilename != null) {
             filename = tempFilename
-                if (filename.isNotEmpty() && filename.length > 1) {
-                    startGame(filename, false)
-                    return
-                }
+            if (filename.isNotEmpty() && filename.length > 1) {
+                startGame(filename, false)
+                return
+            }
         }
         if (folderList.isNotEmpty() && folderList.size > 0) {
             folderList.forEachIndexed { index, folder ->

--- a/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
+++ b/Android/agsplayer/app/src/main/java/uk/co/adventuregamestudio/agsplayer/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.DocumentsContract
+import android.provider.Settings
 import android.util.Log
 import android.view.*
 import android.widget.AdapterView
@@ -44,6 +45,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
 
     var filename: String = ""
 
+    private var resumedOnce: Boolean = false;
     private var lastSelectedPosition: Int = 0
     private val folderList = ArrayList<String>()
     private val filenameList = ArrayList<String>()
@@ -76,6 +78,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         recyclerView.adapter = gameListRecyclerViewAdapter
 
         // Build game list
+        Log.d("AGSPlayer.MainActivity", "onCreate()")
         buildGamesListIfPossible()
     }
 
@@ -97,6 +100,8 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         // The launcher will accept paths that don't start with a slash, but
         // the engine cannot find the game later.
         if (!baseDirectory!!.startsWith("/")) baseDirectory = "/$baseDirectory"
+
+        Log.d("AGSPlayer.MainActivity", "setAgsBaseDirFromUri()")
         buildGamesListIfPossible()
     }
 
@@ -104,9 +109,10 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == REQUEST_TREE && resultCode == Activity.RESULT_OK) {
-            data?.data?.let { if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                setAgsBaseDirFromUri(it)
-            }
+            data?.data?.let {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    setAgsBaseDirFromUri(it)
+                }
             }
         }
     }
@@ -139,6 +145,8 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
                 // The launcher will accept paths that don't start with a slash, but
                 // the engine cannot find the game later.
                 if (!baseDirectory!!.startsWith("/")) baseDirectory = "/$baseDirectory"
+
+                Log.d("AGSPlayer.MainActivity", "onOptionsItemSelected()")
                 buildGamesListIfPossible()
             }
             alert.setNegativeButton("Cancel",
@@ -193,7 +201,6 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         val intent =
             Intent(this, CreditsActivity::class.java)
         startActivity(intent)
-
     }
 
     private  fun showPreferences(position: Int) {
@@ -235,8 +242,44 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
     }
 
     private fun buildGamesListIfPossible() {
-        if(hasExternalStoragePermission()) {
-            buildGamesList();
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:R:hasAllFilesPermission()")
+            if (hasAllFilesPermission()) {
+                Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:buildGamesList()")
+                buildGamesList();
+            } else {
+                Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:Ask ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION")
+                val uri = Uri.parse("package:${BuildConfig.APPLICATION_ID}")
+
+                // this request is asynchronous, we should really use registerForActivityResult to launch this
+                // but this means we no longer have an action bar for the app since we inherit from CoponentActivity instead
+                startActivity(
+                    Intent(
+                        Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                        uri
+                    )
+                )
+            }
+        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:M:hasStoragePermission()")
+            if (hasStoragePermission()) {
+                Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:buildGamesList()")
+                buildGamesList();
+            } else {
+                Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:Ask READ_EXTERNAL_STORAGE")
+
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                    EXTERNAL_STORAGE_REQUEST_CODE
+                )
+            }
+        } else {
+            Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible::hasExternalStoragePermission()")
+            if(hasExternalStoragePermission()) {
+                Log.d("AGSPlayer.MainActivity", "buildGamesListIfPossible:buildGamesList()")
+                buildGamesList();
+            }
         }
     }
 
@@ -249,7 +292,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         if (searchDirectory.isDirectory) {
             val tempList =
                 searchDirectory.list { dir, filename -> File("$dir/$filename").isDirectory }
-            for (subpath in tempList) {
+            for (subpath in tempList!!) {
                 var entry = subpath
                 if (path != null) {
                     entry = "$path/$entry"
@@ -272,7 +315,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
                 return
             }
         }
-        if (folderList.isNotEmpty() && folderList.size > 0) {
+        if (folderList.isNotEmpty()) {
             folderList.forEachIndexed { index, folder ->
                 val game = GameModel(folder,filenameList[index],folder,false)
                 gameList.add(game)
@@ -324,6 +367,13 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         return null
     }
 
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun hasAllFilesPermission() = Environment.isExternalStorageManager()
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun hasStoragePermission() =
+        checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) ==
+                PackageManager.PERMISSION_GRANTED
 
     fun showExternalStoragePermissionMissingDialog() {
         val dialog =
@@ -340,23 +390,23 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         permissions: Array<String>,
         grantResults: IntArray
     ) {
-        if (grantResults.size > 0) {
-            Log.d("AGSRuntimeActivity", "Received a request permission result")
+        if (grantResults.isNotEmpty()) {
+            Log.d("AGSPlayer.MainActivity", "Received a request permission result")
             when (requestCode) {
                 this.EXTERNAL_STORAGE_REQUEST_CODE -> {
                     if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                        Log.d("AGSRuntimeActivity", "Permission granted")
+                        Log.d("AGSPlayer.MainActivity", "Permission granted")
                     } else {
-                        Log.d("AGSRuntimeActivity", "Did not get permission.")
+                        Log.d("AGSPlayer.MainActivity", "Did not get permission.")
                         if (ActivityCompat.shouldShowRequestPermissionRationale(
                                 this,
-                                Manifest.permission.READ_EXTERNAL_STORAGE
+                                Manifest.permission.WRITE_EXTERNAL_STORAGE
                             )
                         ) {
                             showExternalStoragePermissionMissingDialog()
                         }
                     }
-                    Log.d("AGSRuntimeActivity", "Unlocking AGS thread")
+                    Log.d("AGSPlayer.MainActivity", "Unlocking AGS thread")
                     synchronized(externalStorageRequestDummy) {
                         externalStorageRequestDummy[0] = grantResults[0]
                     }
@@ -369,15 +419,23 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
     override fun onResume() {
         super.onResume()
 
-        buildGamesListIfPossible()
+        Log.d("AGSPlayer.MainActivity", "onResume()")
+        if(resumedOnce) {
+            buildGamesListIfPossible()
+        }
+        resumedOnce = true;
     }
-
 
     @Keep
     fun hasExternalStoragePermission(): Boolean {
+        return hasPermissionSpecific(Manifest.permission.WRITE_EXTERNAL_STORAGE, this.EXTERNAL_STORAGE_REQUEST_CODE, "external storage")
+    }
+
+    @Keep
+    fun hasPermissionSpecific(permission: String, request_code: Int, permission_description: String): Boolean {
         if (ActivityCompat.checkSelfPermission(
                 this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE
+                permission
             )
             == PackageManager.PERMISSION_GRANTED
         ) {
@@ -389,8 +447,8 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         )
         ActivityCompat.requestPermissions(
             this,
-            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-            this.EXTERNAL_STORAGE_REQUEST_CODE
+            arrayOf(permission),
+            request_code
         )
         synchronized(externalStorageRequestDummy) {
             try {
@@ -398,7 +456,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
             } catch (e: InterruptedException) {
                 Log.d(
                     "AGSRuntimeActivity",
-                    "requesting external storage permission",
+                    "requesting $permission_description permission",
                     e
                 )
                 return false
@@ -406,7 +464,7 @@ class MainActivity : AppCompatActivity(), GameListRecyclerViewAdapter.ItemClickL
         }
         return ActivityCompat.checkSelfPermission(
             this,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE
+            permission
         ) == PackageManager.PERMISSION_GRANTED
     }
 

--- a/Android/agsplayer/app/src/main/res/layout/recyclerview_row.xml
+++ b/Android/agsplayer/app/src/main/res/layout/recyclerview_row.xml
@@ -10,24 +10,46 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
-        <TextView
-            android:id="@+id/tvGameName"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="20sp"
-            android:ellipsize="end"
-            android:maxLines="1"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tvGameName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textSize="20sp" />
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                />
+            <ImageView
+                style="?android:attr/actionOverflowButtonStyle"
+                android:id="@+id/ivGameOptions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="true"
+                android:contentDescription="@string/options"
+                android:focusable="true" />
+        </LinearLayout>
+
         <TextView
             android:id="@+id/tvGameFileName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:ellipsize="start"
             android:textAlignment="textEnd"
             android:textSize="10sp"
             android:textStyle="italic"
-            android:ellipsize="start"
             tools:ignore="SmallSp" />
+
 
     </LinearLayout>
 

--- a/Android/agsplayer/app/src/main/res/values/strings.xml
+++ b/Android/agsplayer/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">AGS Player</string>
+    <string name="options">Options</string>
 </resources>


### PR DESCRIPTION
add a button with three dots on each game entry in the ags player to invoke the context menu of the item.

![image](https://user-images.githubusercontent.com/2244442/215295099-407eb767-f80d-499f-9723-c7ea21c08007.png)

following this [comment](https://github.com/adventuregamestudio/ags/issues/1871#issuecomment-1405353587)

> there's no visual indication that you may open them for a particular game (no button/icon besides the game title).
