### PR TITLE
Fix android ags player global settings

### DIFF
--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AgsSettingsFragment.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/AgsSettingsFragment.java
@@ -11,6 +11,9 @@ import androidx.preference.PreferenceManager;
 import java.io.File;
 
 public class AgsSettingsFragment extends PreferenceFragmentCompat {
+
+    String configDirectory;
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);
@@ -36,7 +39,8 @@ public class AgsSettingsFragment extends PreferenceFragmentCompat {
                 prefAct.gamePath = prefAct.baseDirectory;
         }
 
-        boolean hasCustomConfig = prefAct.readConfigFile(prefAct.gamePath);
+        configDirectory = prefAct.gamePath;
+        boolean hasCustomConfig = prefAct.readConfigFile(configDirectory);
 
         if (!prefAct.isGlobalConfig) {
             // Get available translations from the engine
@@ -57,5 +61,12 @@ public class AgsSettingsFragment extends PreferenceFragmentCompat {
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getActivity()).edit();
         prefAct.loadPreferencesRecursively(getPreferenceScreen(), editor);
         editor.commit();
+    }
+
+    public void writeContigFile()
+    {
+        PreferencesActivity prefAct = (PreferencesActivity) getActivity();
+        assert prefAct != null;
+        prefAct.writeConfigFile(configDirectory);
     }
 }

--- a/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/PreferencesActivity.java
+++ b/Android/library/runtime/src/main/java/uk/co/adventuregamestudio/runtime/PreferencesActivity.java
@@ -6,23 +6,16 @@ import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
-import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.SeekBarPreference;
-import androidx.preference.SwitchPreference;
-
-import androidx.preference.PreferenceManager;
 
 import androidx.preference.PreferenceScreen;
 
-import java.io.File;
 import java.util.Locale;
-import java.util.Objects;
 
 
 public class PreferencesActivity extends AppCompatActivity
@@ -42,7 +35,7 @@ public class PreferencesActivity extends AppCompatActivity
     public static final int CONFIG_MOUSE_SPEED = 21;
 
     public native boolean readConfigFile(String directory);
-    public native boolean writeConfigFile();
+    public native boolean writeConfigFile(String directory);
 
     public static native int readIntConfigValue(int id);
     public native void setIntConfigValue(int id, int value);
@@ -257,7 +250,7 @@ public class PreferencesActivity extends AppCompatActivity
     {
         savePreferencesRecursively( frag.getPreferenceScreen());
 
-        writeConfigFile();
+        frag.writeContigFile();
 
         frag = null;
 

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -290,7 +290,7 @@ JNIEXPORT jint JNICALL
 }
 
 JNIEXPORT void JNICALL
-Java_uk_co_adventuregamestudio_runtime_AGSRuntimeActivity_nativeSdlShowKeyboard(JNIEnv* env, jobject object, jobjectArray translations)
+Java_uk_co_adventuregamestudio_runtime_AGSRuntimeActivity_nativeSdlShowKeyboard(JNIEnv* env, jclass clazz)
 {
   SDL_StartTextInput();
 }

--- a/Engine/platform/android/acpland.cpp
+++ b/Engine/platform/android/acpland.cpp
@@ -98,19 +98,31 @@ JNIEXPORT jboolean JNICALL
   Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_readConfigFile(JNIEnv* env, jobject object, jstring directory)
 {
   const char* cdirectory = env->GetStringUTFChars(directory, NULL);
-  chdir(cdirectory);
+  String dir = cdirectory;
   env->ReleaseStringUTFChars(directory, cdirectory);
+
+  String config_file_path = ANDROID_CONFIG_FILENAME;
+  if(!dir.IsEmpty())
+    config_file_path = Path::ConcatPaths(dir, config_file_path);
 
   ResetConfiguration(AGSAndroid::GetMobileSetup());
 
-  return ReadConfiguration(AGSAndroid::GetMobileSetup(), ANDROID_CONFIG_FILENAME, true);
+  return ReadConfiguration(AGSAndroid::GetMobileSetup(), config_file_path.GetCStr(), true);
 }
 
 
 JNIEXPORT jboolean JNICALL
-  Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_writeConfigFile(JNIEnv* env, jobject object)
+  Java_uk_co_adventuregamestudio_runtime_PreferencesActivity_writeConfigFile(JNIEnv* env, jobject object, jstring directory)
 {
-  return WriteConfiguration(AGSAndroid::GetMobileSetup(), ANDROID_CONFIG_FILENAME);
+  const char* cdirectory = env->GetStringUTFChars(directory, NULL);
+  String dir = cdirectory;
+  env->ReleaseStringUTFChars(directory, cdirectory);
+
+  String config_file_path = ANDROID_CONFIG_FILENAME;
+  if(!dir.IsEmpty())
+    config_file_path = Path::ConcatPaths(dir, config_file_path);
+
+  return WriteConfiguration(AGSAndroid::GetMobileSetup(), config_file_path.GetCStr());
 }
 
 
@@ -345,20 +357,22 @@ void AGSAndroid::MainInit()
     // Reset configuration.
     ResetConfiguration(setup);
 
-    // Read general configuration.
-    ::ReadConfiguration(setup, ANDROID_CONFIG_FILENAME, true);
+    // Read general configuration. (in single game package, this is the config read)
+    String general_config_file = Path::ConcatPaths(android_base_directory, ANDROID_CONFIG_FILENAME);
+    ::ReadConfiguration(setup, general_config_file.GetCStr(), true);
 
     // Get the games path.
     String path = setup.game_file_name;
     path = Path::GetDirectoryPath(path);
     if(path != "./" && path.GetLength() > 1) {
+      // We are using AGS Player and passing a specific game
+
       chdir(path.GetCStr());
+      // TODO: this is an ancient GUS patch fix for MIDI playback, is this still relevant?
       setenv("ULTRADIR", "..", 1);
-    } else {
-      chdir(_android_base_directory);
     }
 
-    // Read game specific configuration.
+    // Read game specific configuration. (this does nothing in single game package)
     ::ReadConfiguration(setup, ANDROID_CONFIG_FILENAME, false);
 
     setup.load_latest_savegame = loadLastSave;


### PR DESCRIPTION
fix #1871

The fix is what I explained in the issue. I added some comments to clarify what is going on.

- Removed chdir when reading the config, which was confusing. 
- There was also a misleading chdir [here](https://github.com/adventuregamestudio/ags/compare/master...ericoporto:ags:fix-android-ags-player-global-settings#diff-52a453b9246fe11573220e59a7f04e2498bd6cbd37802cf98494faf83dd1d61bL357-L358), because the passed variable was always null it did nothing. 