### PR TITLE
Editor: Add sprite selector option "Replace sprite using previous files..."

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -510,6 +510,7 @@ namespace AGS.Editor
 
         private void ReplaceSprite(Sprite sprite, string[] filenames)
         {
+            _lastImportedFilenames = filenames;
             SpriteImportWindow impWin = new SpriteImportWindow(filenames, sprite);
 
             if (impWin.ShowDialog() == DialogResult.OK)
@@ -522,6 +523,7 @@ namespace AGS.Editor
 
         private void ReplaceSprite(Sprite sprite, string filename)
         {
+            _lastImportedFilenames = new string[] { filename };
             SpriteImportWindow impWin = new SpriteImportWindow(new string[] { filename }, sprite);
 
             if (impWin.ShowDialog() == DialogResult.OK)

--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -43,6 +43,7 @@ namespace AGS.Editor
         private const string MENU_ITEM_COPY_TO_CLIPBOARD = "CopyToClipboard";
         private const string MENU_ITEM_EXPORT_SPRITE = "ExportSprite";
         private const string MENU_ITEM_REPLACE_FROM_FILE = "ReplaceFromFile";
+        private const string MENU_ITEM_REPLACE_FROM_PREVIOUS = "ReplaceFromPreviousFiles";
         private const string MENU_ITEM_REPLACE_FROM_CLIPBOARD = "ReplaceFromClipboard";
         private const string MENU_ITEM_OPEN_FILE_EXPLORER = "OpenFileExplorer";
         private const string MENU_ITEM_DELETE_SPRITE = "DeleteSprite";
@@ -507,6 +508,18 @@ namespace AGS.Editor
             impWin.Dispose();
         }
 
+        private void ReplaceSprite(Sprite sprite, string[] filenames)
+        {
+            SpriteImportWindow impWin = new SpriteImportWindow(filenames, sprite);
+
+            if (impWin.ShowDialog() == DialogResult.OK)
+            {
+                RefreshSpriteDisplay();
+            }
+
+            impWin.Dispose();
+        }
+
         private void ReplaceSprite(Sprite sprite, string filename)
         {
             SpriteImportWindow impWin = new SpriteImportWindow(new string[] { filename }, sprite);
@@ -640,6 +653,11 @@ namespace AGS.Editor
                     Sprite sprite = FindSpriteByNumber(_spriteNumberOnMenuActivation);
                     ReplaceSpriteUsingImportWindow(fileName, sprite);
                 }
+            }
+            else if (item.Name == MENU_ITEM_REPLACE_FROM_PREVIOUS)
+            {
+                Sprite sprite = FindSpriteByNumber(_spriteNumberOnMenuActivation);
+                ReplaceSpriteUsingImportWindow(_lastImportedFilenames, sprite);
             }
             else if (item.Name == MENU_ITEM_REPLACE_FROM_CLIPBOARD)
             {
@@ -1186,6 +1204,18 @@ namespace AGS.Editor
             }
         }
 
+        private void ReplaceSpriteUsingImportWindow(string[] fileNames, Sprite sprite)
+        {
+            try
+            {
+                ReplaceSprite(sprite, fileNames);
+            }
+            catch (Exception ex)
+            {
+                Factory.GUIController.ShowMessage("There was an error importing the file. The error message was: '" + ex.Message + "'. Please try again", MessageBoxIcon.Warning);
+            }
+        }
+
         private void ReplaceSpriteUsingImportWindow(string fileName, Sprite sprite)
         {
             try
@@ -1227,7 +1257,11 @@ namespace AGS.Editor
                 menu.Items.Add(new ToolStripMenuItem("Export sprite to file...", null, onClick, MENU_ITEM_EXPORT_SPRITE));
                 menu.Items.Add(new ToolStripSeparator());
                 menu.Items.Add(new ToolStripMenuItem("Replace sprite from file...", null, onClick, MENU_ITEM_REPLACE_FROM_FILE));
-
+                menu.Items.Add(new ToolStripMenuItem("Replace sprite using previous files...", null, onClick, MENU_ITEM_REPLACE_FROM_PREVIOUS));
+                if (_lastImportedFilenames == null)
+                {
+                    menu.Items[menu.Items.Count - 1].Enabled = false;
+                }
                 if (Factory.AGSEditor.CurrentGame.Settings.ColorDepth != GameColorDepth.Palette)
                 {
                     menu.Items.Add(new ToolStripMenuItem("Replace sprite from clipboard...", null, onClick, MENU_ITEM_REPLACE_FROM_CLIPBOARD));


### PR DESCRIPTION
This restores some functionaility that was lost by the removal of "Replace sprite using last sprite" and makes the file tracking more consistent.

Note: There appears to be a separate problem of no error handling when the "previous" files no longer exist, but this was a pre-existing condition which can be looked at separately.

Closes #1911