### PR TITLE
Editor: Fix crash for sprite import with bad filestream

### DIFF
--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -18,7 +18,17 @@ namespace AGS.Editor.Utils
         {
             // We have to use this stream code because using "new Bitmap(filename)"
             // keeps the file open until the Bitmap is disposed
-            FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+            FileStream fileStream;
+
+            try
+            {
+                fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+            }
+            catch
+            {
+                throw new Types.InvalidDataException($"Unable to open file '{fileName}'");
+            }
+
             Bitmap loadedBmp;
 
             try


### PR DESCRIPTION
Catch exceptions on the sprite import filestream.

I couldn't see an obvious place to hook some kind of dynamic check on the "previous" file references (which are the most likely cause of the failure) but this is enough to stop the crash.

Fixes #1915