### PR TITLE
4.0: declare script compiler extension strings as preprocessor macros

### DIFF
--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -17,6 +17,13 @@ std::vector<const char*> defaultHeaderNames;
 
 MacroTable predefinedMacros;
 
+void ccGetExtensions(std::vector<std::string> &exts)
+{
+    // TODO: we may consider creating a managed user object an extension, etc,
+    // although it was introduced years ago when extensions were not declared.
+    return;
+}
+
 int ccAddDefaultHeader(const char* nhead, const char *nName)
 {
     defaultheaders.push_back(nhead);

--- a/Compiler/script/cs_compiler.h
+++ b/Compiler/script/cs_compiler.h
@@ -13,9 +13,14 @@
 #ifndef __CS_COMPILER_H
 #define __CS_COMPILER_H
 
+#include <string>
+#include <vector>
 #include "script/cc_script.h"  // ccScript
 
 // ********* SCRIPT COMPILATION FUNCTIONS **************
+// Get a list of compiler extensions.
+extern void ccGetExtensions(std::vector<std::string> &exts);
+
 // add a script that will be compiled as a header into every compilation
 // 'name' is the name of the header, used in error reports
 // (only the pointer is stored so don't free the memory)

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -11,6 +11,14 @@
 
 #include "cs_parser.h"
 
+void ccGetExtensions2(std::vector<std::string> &exts)
+{
+    // A generic "AGS 4.0" extension, for easier detection
+    // of a new compiler. Feel free to add more, specifying each
+    // new added feature individually.
+    exts.push_back("AGS4");
+}
+
 ccScript *ccCompileText2(std::string const &script, std::string const &scriptName, uint64_t const options, MessageHandler &mh)
 {
     ccCompiledScript *compiled_script =

--- a/Compiler/script2/cs_compiler.h
+++ b/Compiler/script2/cs_compiler.h
@@ -12,9 +12,13 @@
 #ifndef __CS_COMPILER2_H
 #define __CS_COMPILER2_H
 
+#include <string>
+#include <vector>
 #include "script/cc_script.h"
 #include "cs_message_handler.h"
 
+// Get a list of compiler extensions.
+extern void ccGetExtensions2(std::vector<std::string> &exts);
 // compile the script supplied, returns nullptr on failure
 // cc_error() gets called.
 extern ccScript *ccCompileText2(std::string const &script, std::string const &scriptName, uint64_t options, MessageHandler &mh);

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -947,12 +947,21 @@ namespace AGS.Editor
             }
         }
 
-		/// <summary>
-		/// Preprocesses and then compiles the script using the supplied headers.
+        private void DefineMacrosFromCompiler(IPreprocessor preprocessor)
+        {
+            var exts = Factory.NativeProxy.GetCompilerExtensions(_game);
+            foreach (var ext in exts)
+            {
+                preprocessor.DefineMacro("SCRIPT_EXT_" + ext, "1");
+            }
+        }
+
+        /// <summary>
+        /// Preprocesses and then compiles the script using the supplied headers.
         /// Warnings and errors are collected in 'messages'.
-		/// Will _not_ throw whenever compiling results in an error.
-		/// </summary>
-		public void CompileScript(Script script, List<Script> headers, CompileMessages messages)
+        /// Will _not_ throw whenever compiling results in an error.
+        /// </summary>
+        public void CompileScript(Script script, List<Script> headers, CompileMessages messages)
 		{
 			messages = messages ?? new CompileMessages();
             List<string> preProcessedCode;
@@ -971,6 +980,7 @@ namespace AGS.Editor
         {
             IPreprocessor preprocessor = CompilerFactory.CreatePreprocessor(AGS.Types.Version.AGS_EDITOR_VERSION);
             DefineMacrosAccordingToGameSettings(preprocessor);
+            DefineMacrosFromCompiler(preprocessor);
 
             preProcessedCode = new List<string>();
             foreach (Script header in headers)

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -290,6 +290,11 @@ namespace AGS.Editor
             return _native.LoadRoomScript(roomFileName);
         }
 
+        public List<string> GetCompilerExtensions(Game game)
+        {
+            return _native.GetCompilerExtensions(game.Settings.ExtendedCompiler);
+        }
+
         public void CompileScript(Script script, string[] preProcessedData, Game game, CompileMessages messages)
         {
             _native.CompileScript(script, preProcessedData, game, messages);

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -70,6 +70,7 @@ namespace Native
             void ReplaceSpriteFile(String ^srcFileName);
             void SaveDefaultRoomFile(Room ^roomToSave);
 			String ^LoadRoomScript(String ^roomFileName);
+            List<String^>^ GetCompilerExtensions(bool new_compiler);
 			void CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts, Game ^game, CompileMessages ^errors);
 			GameTemplate^ LoadTemplateFile(String ^fileName);
       RoomTemplate^ LoadRoomTemplateFile(String ^fileName);

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -28,6 +28,25 @@ namespace AGS
 {
 	namespace Native
 	{
+
+    List<String^>^ NativeMethods::GetCompilerExtensions(bool new_compiler)
+    {
+        std::vector<std::string> cc_exts;
+        if (new_compiler)
+        {
+            ccGetExtensions2(cc_exts);
+        }
+        else
+        {
+            ccGetExtensions(cc_exts);
+        }
+
+        List<String^>^ exts = gcnew List<String^>();
+        for (const auto &s : cc_exts)
+            exts->Add(gcnew String(s.c_str()));
+        return exts;
+    }
+
     void NativeMethods::CompileScript(Script ^script, cli::array<String^> ^preProcessedScripts,
         Game ^game, CompileMessages ^messages)
     {


### PR DESCRIPTION
Wanted to do this long ago...

This lets compilers to return a list of extension names (arbitrary string IDs). These extensions are taken by the Editor and turned into preprocessor macros, in a form of `SCRIPT_EXT_<NAME>`.

The primary purpose is being able to write scripts meant for both new and old compilers, where some code may only work with the new compiler. This may be useful for module writers, but also if you make a test game and need to switch compilers during the test.

For starters, the new compiler declares one generic "AGS4" extension. But it's possible to add one extension name per new individual syntax feature, if necessary, later.

Example of script:
```
#ifdef SCRIPT_EXT_AGS4
    Display("AGS 4 compiler extensions are ENABLED");
#endif
#ifndef SCRIPT_EXT_AGS4
    Display("AGS 4 compiler extensions are DISABLED");
#endif
```
