### PR TITLE
Editor: fix breakpoint on last line hangs editor

### DIFF
--- a/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
+++ b/Editor/AGS.Editor/Panes/ScintillaWrapper.cs
@@ -558,15 +558,15 @@ namespace AGS.Editor
         public int[] GetLineNumbersForAllBreakpoints()
         {
             List<int> breakpointLines = new List<int>();
-            int currentLineOffset = 0;
-            while (currentLineOffset >= 0)
+            int line = 0;
+            while (line >= 0)
             {
-                currentLineOffset = scintillaControl1.Lines[currentLineOffset].MarkerNext(MARKER_MASK_BREAKPOINT);
-                if (currentLineOffset >= 0)
-                {
-                    breakpointLines.Add(currentLineOffset + 1);
-                    currentLineOffset++;
-                }
+                int next_line = scintillaControl1.Lines[line].MarkerNext(MARKER_MASK_BREAKPOINT);
+                if (next_line <= line) break;
+
+                line = next_line + 1;
+                breakpointLines.Add(line);
+
             }
             return breakpointLines.ToArray();
         }


### PR DESCRIPTION
fix #1912 

MarkerNext when reaching the last breakpoint keeps returning the same value, which hangs ags in the loop forever until breakpointLines is big enough to crash for lack of memory.

https://github.com/jacobslusser/ScintillaNET/wiki/Markers-and-Bookmarking-Lines