### PR TITLE
AGS 4: Implement script RTTI

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -109,6 +109,8 @@ target_sources(common
     script/cc_common.cpp
     script/cc_common.h
     script/cc_internal.h
+    script/cc_reflect.cpp
+    script/cc_reflect.h
     script/cc_script.cpp
     script/cc_script.h
     util/aasset_stream.cpp

--- a/Common/script/cc_common.h
+++ b/Common/script/cc_common.h
@@ -29,8 +29,9 @@
 #define SCOPT_NOIMPORTOVERRIDE 0x0020 // do not allow an import to be re-declared
 //#define SCOPT_LEFTTORIGHT 0x40   // left-to-right operator precedance (DEPRECATED)
 #define SCOPT_OLDSTRINGS    0x0080   // allow old-style strings
-#define SCOPT_UTF8          0x0100  // UTF-8 text mode
-#define SCOPT_HIGHEST       SCOPT_UTF8
+#define SCOPT_UTF8          0x0100   // UTF-8 text mode
+#define SCOPT_RTTI          0x0200   // generate and export RTTI
+#define SCOPT_HIGHEST       SCOPT_RTTI
 
 extern void ccSetOption(int, int);
 extern int ccGetOption(int);

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -18,8 +18,10 @@
 #ifndef __CC_INTERNAL_H
 #define __CC_INTERNAL_H
 
-#define SCOM_VERSION 90
-#define SCOM_VERSIONSTR "0.90"
+#define SCOM_VERSION_OLD  90
+#define SCOM_VERSION_EXT  95
+#define SCOM_VERSION      SCOM_VERSION_EXT
+#define SCOM_VERSIONSTR   "0.95"
 
 // virtual CPU registers
 #define SREG_SP           1     // stack pointer

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -1,0 +1,277 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "script/cc_reflect.h"
+#include <string> // std::string
+#include <string.h> // memcpy etc
+#include "util/stream.h"
+
+namespace AGS
+{
+
+using namespace Common;
+
+// Adds a string into the string table; saves associated offset, at which
+// this sting will be packed, and increases packed length.
+// Returns last saved offset if the string is already in the table.
+static uint32_t StrTableAdd(std::map<std::string, uint32_t> &table,
+    const std::string &str, uint32_t &packed_len)
+{
+    const auto str_it = table.find(str);
+    if (str_it != table.end())
+        return str_it->second;
+    
+    table[str] = packed_len;
+    uint32_t last_len = packed_len;
+    packed_len += str.size() + 1; // count null-terminator
+    return last_len;
+}
+
+//*****************************************************************************
+// RTTI serialization
+//
+// RTTI header:
+// ----------------
+//  uint32 | format                 | for expanding the rtti format
+//  uint32 | header size            | size in bytes (counting from "format")
+//  uint32 | full rtti data size    | size in bytes (counting from "format")
+//  uint32 | type entry size        | fixed size of a type info in bytes
+//  uint32 | types table offset     | a relative pos of a types table
+//  uint32 | num types              | number of types in table
+//  uint32 | field entry size       | fixed size of a type field info in bytes
+//  uint32 | fields table offset    | a relative pos of a type fields table
+//  uint32 | num type fields        | number of fields in table
+//  uint32 | string table offset    | a relative pos of a strings table
+//  uint32 | string table size      | size of a string table, in bytes
+//
+// Type Info:
+// ----------------
+//  uint32 | fully qualified name   | an offset in a string table
+//  uint32 | local id               | local type ID
+//  uint32 | parent type (local id) | local type ID; 0? if no parent
+//  uint32 | type flags             |
+//  uint32 | type size              | in bytes
+//  uint32 | num fields             |
+//  uint32 | field table index      | an index of a first field
+//
+// Type Field Info:
+// ----------------
+//  uint32 | offset                 | relative offset, in bytes
+//  uint32 | name                   | an offset in a string table
+//  uint32 | type (local id)        | local type ID of this field
+//  uint32 | flags                  |
+//  uint32 | number of elements     | for arrays, 0 = single var
+//
+//*****************************************************************************
+
+void RTTI::Read(Stream *in)
+{
+    // RTTI Header
+    const soff_t rtti_soff = in->GetPosition();
+    const uint32_t format = in->ReadInt32();
+    const size_t head_sz = (uint32_t)in->ReadInt32();
+    const size_t full_sz = (uint32_t)in->ReadInt32();
+    const size_t typei_sz = (uint32_t)in->ReadInt32();
+    const uint32_t typei_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t typei_table_len = (uint32_t)in->ReadInt32();
+    const size_t fieldi_sz = (uint32_t)in->ReadInt32();
+    const uint32_t fieldi_table_off = (uint32_t)in->ReadInt32();
+    const uint32_t fieldi_table_len = (uint32_t)in->ReadInt32();
+    const uint32_t str_table_off = (uint32_t)in->ReadInt32();
+    const size_t str_table_sz = (uint32_t)in->ReadInt32();
+
+    const soff_t typei_soff = rtti_soff + typei_table_off;
+    const soff_t fieldi_soff = rtti_soff + fieldi_table_off;
+    const soff_t str_soff = rtti_soff + str_table_off;
+    const soff_t end_soff = rtti_soff + full_sz;
+
+    // Type Infos
+    in->Seek(typei_soff, kSeekBegin);
+    for (size_t i = 0; i < typei_table_len; ++i)
+    {
+        RTTI::Type t;
+        t.fullname_stri = (uint32_t)in->ReadInt32();
+        t.this_id = (uint32_t)in->ReadInt32();
+        t.parent_id = (uint32_t)in->ReadInt32();
+        t.flags = (uint32_t)in->ReadInt32();
+        t.size = (uint32_t)in->ReadInt32();
+        t.field_num = (uint32_t)in->ReadInt32();
+        t.field_index = (uint32_t)in->ReadInt32();
+        _types.push_back(t);
+    }
+
+    // Field Infos
+    in->Seek(fieldi_soff, kSeekBegin);
+    for (size_t i = 0; i < fieldi_table_len; ++i)
+    {
+        RTTI::Field f;
+        f.offset = (uint32_t)in->ReadInt32();
+        f.name_stri = (uint32_t)in->ReadInt32();
+        f.f_typeid = (uint32_t)in->ReadInt32();
+        f.flags = (uint32_t)in->ReadInt32();
+        f.num_elems = (uint32_t)in->ReadInt32();
+        _fields.push_back(f);
+    }
+
+    // String Table
+    in->Seek(str_soff, kSeekBegin);
+    if (str_table_sz > 0)
+    {
+        _strings.resize(str_table_sz);
+        in->Read(&_strings.front(), str_table_sz);
+    }
+
+    // Finish
+    in->Seek(end_soff, kSeekBegin);
+
+    CreateQuickRefs();
+}
+
+void RTTI::Write(Stream *out) const
+{
+    // RTTI Header placeholder
+    const soff_t rtti_soff = out->GetPosition();
+    out->WriteByteCount(0, 11 * sizeof(uint32_t));
+
+    // Type Infos
+    const soff_t typei_soff = out->GetPosition();
+    for (const auto &t : _types)
+    {
+        out->WriteInt32(t.fullname_stri);
+        out->WriteInt32(t.this_id);
+        out->WriteInt32(t.parent_id);
+        out->WriteInt32(t.flags);
+        out->WriteInt32(t.size);
+        out->WriteInt32(t.field_num);
+        out->WriteInt32(t.field_index);
+    }
+
+    // Field Infos
+    const soff_t fieldi_soff = out->GetPosition();
+    for (const auto &f : _fields)
+    {
+        out->WriteInt32(f.offset);
+        out->WriteInt32(f.name_stri);
+        out->WriteInt32(f.f_typeid);
+        out->WriteInt32(f.flags);
+        out->WriteInt32(f.num_elems);
+    }
+
+    // String Table
+    const soff_t str_soff = out->GetPosition();
+    if (_strings.size() > 0)
+    {
+        out->Write(&_strings.front(), _strings.size());
+    }
+
+    // Finalize, write actual RTTI header
+    const soff_t end_soff = out->GetPosition();
+    out->Seek(rtti_soff, kSeekBegin);
+    out->WriteInt32(0); // format
+    out->WriteInt32((uint32_t)(typei_soff - rtti_soff)); // header size
+    out->WriteInt32((uint32_t)(end_soff - rtti_soff)); // full size
+    out->WriteInt32(7 * sizeof(uint32_t)); // type info size
+    out->WriteInt32((uint32_t)(typei_soff - rtti_soff)); // types table offset
+    out->WriteInt32(_types.size()); // number of types
+    out->WriteInt32(5 * sizeof(uint32_t)); // field info size
+    out->WriteInt32((uint32_t)(fieldi_soff - rtti_soff)); // fields table offset
+    out->WriteInt32(_fields.size()); // number of fields
+    out->WriteInt32((uint32_t)(str_soff - rtti_soff)); // strings table offset
+    out->WriteInt32(_strings.size()); // string table size
+    out->Seek(end_soff, kSeekBegin);
+}
+
+void RTTI::CreateQuickRefs()
+{
+    // TODO: keep this map in the RTTI struct, or extended one?
+    // TODO: optimize this out for joint collection, as it has typeid = table index
+    std::unordered_map<uint32_t, size_t> typeid_to_type;
+    for (size_t i = 0; i < _types.size(); ++i)
+    {
+        typeid_to_type[_types[i].this_id] = i;
+    }
+
+    for (auto &ti : _types)
+    {
+        ti.fullname = &_strings[ti.fullname_stri];
+        if (ti.parent_id > 0u)
+            ti.parent = &_types[typeid_to_type[ti.parent_id]];
+        if (ti.field_num > 0u)
+        {
+            ti.first_field = &_fields[ti.field_index];
+            for (uint32_t index = 0; index < ti.field_num; ++index)
+            {
+                auto &fi = _fields[ti.field_index + index];
+                fi.name = &_strings[fi.name_stri];
+                fi.type = &_types[typeid_to_type[fi.f_typeid]];
+                fi.owner = &_types[typeid_to_type[ti.this_id]];
+                fi.prev_field = (index > 0) ? &_fields[ti.field_index + index - 1] : nullptr;
+                fi.next_field = (index + 1 < ti.field_num) ? &_fields[ti.field_index + index + 1] : nullptr;
+            }
+        }
+    }
+}
+
+void RTTIBuilder::AddType(const std::string &name, uint32_t type_id,
+    uint32_t parent_id, uint32_t flags, uint32_t size)
+{
+    RTTI::Type ti;
+    ti.fullname_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    ti.this_id = type_id;
+    ti.parent_id = parent_id;
+    ti.flags = flags;
+    ti.size = size;
+    _rtti._types.push_back(ti);
+}
+
+void RTTIBuilder::AddField(uint32_t owner_id, const std::string &name,
+    uint32_t offset, uint32_t f_typeid, uint32_t flags, uint32_t num_elems)
+{
+    RTTI::Field fi;
+    fi.offset = offset;
+    fi.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    fi.f_typeid = f_typeid;
+    fi.flags = flags;
+    fi.num_elems = num_elems;
+    _fieldIdx.insert(std::make_pair(owner_id, fi)); // match field to owner type
+}
+
+RTTI &&RTTIBuilder::Finalize()
+{
+    // Save complete string data
+    _rtti._strings.resize(_strpackedLen);
+    for (const auto &s : _strtable)
+    { // write strings at the precalculated offsets
+        memcpy(&_rtti._strings.front() + s.second, s.first.c_str(), s.first.size() + 1);
+    }
+
+    // Save complete field data;
+    for (auto &ti : _rtti._types)
+    {
+        auto fi_range = _fieldIdx.equal_range(ti.this_id);
+        if (fi_range.first == _fieldIdx.end())
+            continue; // no fields for this type
+        ti.field_index = _rtti._fields.size(); // save first field index
+        ti.field_num = std::distance(fi_range.first, fi_range.second);
+        for (auto fi_it = fi_range.first; fi_it != fi_range.second; ++fi_it)
+        {
+            _rtti._fields.push_back(fi_it->second);
+        }
+    }
+
+    _rtti.CreateQuickRefs();
+
+    return std::move(_rtti);
+}
+
+} // namespace AGS

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -342,4 +342,47 @@ void JointRTTI::Join(const RTTI &rtti,
     CreateQuickRefs();
 }
 
+
+String PrintRTTI(const RTTI &rtti)
+{
+    const auto &types = rtti.GetTypes();
+
+    const char *hr =   "-------------------------------------------------------------------------------";
+    const char *dbhr = "===============================================================================";
+    String fullstr;
+    fullstr.AppendFmt("%s\nRTTI\n%s\n", dbhr, dbhr);
+
+    for (const auto &ti : types)
+    {
+        fullstr.AppendFmt("%-12s(%-3u) %s\n", "Type:", ti.this_id, ti.fullname);
+        if (ti.parent_id > 0u)
+        {
+            fullstr.AppendFmt("%-12s(%-3u) %s\n", "Parent:", ti.parent->this_id, ti.parent->fullname);
+        }
+        else
+        {
+            fullstr.AppendFmt("%-12snone\n", "Parent:");
+        }
+
+        if (ti.field_num > 0u)
+        {
+            fullstr.Append("Fields:\n");
+            uint32_t index = 0u;
+            for (const auto *fi = ti.first_field; fi; fi = fi->next_field, ++index)
+            {
+                fullstr.AppendFmt("%+4u |%+4u: %-24s: (%-3u) %s\n", index, fi->offset,
+                    fi->name, fi->type->this_id, fi->type->fullname);
+            }
+        }
+        else
+        {
+            fullstr.AppendFmt("%-12snone\n", "Fields:");
+        }
+        fullstr.AppendFmt("%s\n", hr);
+    }
+
+    fullstr.Append(dbhr);
+    return fullstr;
+}
+
 } // namespace AGS

--- a/Common/script/cc_reflect.cpp
+++ b/Common/script/cc_reflect.cpp
@@ -12,6 +12,7 @@
 //
 //=============================================================================
 #include "script/cc_reflect.h"
+#include <algorithm>
 #include <string> // std::string
 #include <string.h> // memcpy etc
 #include "util/stream.h"
@@ -57,6 +58,9 @@ static uint32_t StrTableCopy(std::vector<char> &new_table,
 //  uint32 | format                 | for expanding the rtti format
 //  uint32 | header size            | size in bytes (counting from "format")
 //  uint32 | full rtti data size    | size in bytes (counting from "format")
+//  uint32 | loc entry size         | fixed size of a location info in bytes
+//  uint32 | locs table offset      | a relative pos of a locations table
+//  uint32 | num locations          | number of locations in table
 //  uint32 | type entry size        | fixed size of a type info in bytes
 //  uint32 | types table offset     | a relative pos of a types table
 //  uint32 | num types              | number of types in table
@@ -66,10 +70,16 @@ static uint32_t StrTableCopy(std::vector<char> &new_table,
 //  uint32 | string table offset    | a relative pos of a strings table
 //  uint32 | string table size      | size of a string table, in bytes
 //
+// Location Info:
+// ----------------
+//  uint32 | local id               | local location ID (sic)
+//  uint32 | name                   | an offset in a string table
+//
 // Type Info:
 // ----------------
-//  uint32 | fully qualified name   | an offset in a string table
 //  uint32 | local id               | local type ID
+//  uint32 | name                   | an offset in a string table
+//  uint32 | location id            | local location's ID
 //  uint32 | parent type (local id) | local type ID; 0? if no parent
 //  uint32 | type flags             |
 //  uint32 | type size              | in bytes
@@ -93,6 +103,9 @@ void RTTI::Read(Stream *in)
     const uint32_t format = in->ReadInt32();
     const size_t head_sz = (uint32_t)in->ReadInt32();
     const size_t full_sz = (uint32_t)in->ReadInt32();
+    const size_t loc_sz = (uint32_t)in->ReadInt32();
+    const size_t loc_table_off = (uint32_t)in->ReadInt32();
+    const size_t loc_table_len = (uint32_t)in->ReadInt32();
     const size_t typei_sz = (uint32_t)in->ReadInt32();
     const uint32_t typei_table_off = (uint32_t)in->ReadInt32();
     const uint32_t typei_table_len = (uint32_t)in->ReadInt32();
@@ -102,18 +115,30 @@ void RTTI::Read(Stream *in)
     const uint32_t str_table_off = (uint32_t)in->ReadInt32();
     const size_t str_table_sz = (uint32_t)in->ReadInt32();
 
+    const soff_t loc_soff = rtti_soff + loc_table_off;
     const soff_t typei_soff = rtti_soff + typei_table_off;
     const soff_t fieldi_soff = rtti_soff + fieldi_table_off;
     const soff_t str_soff = rtti_soff + str_table_off;
     const soff_t end_soff = rtti_soff + full_sz;
+
+    // Location Infos
+    in->Seek(loc_soff, kSeekBegin);
+    for (size_t i = 0; i < loc_table_len; ++i)
+    {
+        RTTI::Location l;
+        l.id = (uint32_t)in->ReadInt32();
+        l.name_stri = (uint32_t)in->ReadInt32();
+        _locs.push_back(l);
+    }
 
     // Type Infos
     in->Seek(typei_soff, kSeekBegin);
     for (size_t i = 0; i < typei_table_len; ++i)
     {
         RTTI::Type t;
-        t.fullname_stri = (uint32_t)in->ReadInt32();
         t.this_id = (uint32_t)in->ReadInt32();
+        t.name_stri = (uint32_t)in->ReadInt32();
+        t.loc_id = (uint32_t)in->ReadInt32();
         t.parent_id = (uint32_t)in->ReadInt32();
         t.flags = (uint32_t)in->ReadInt32();
         t.size = (uint32_t)in->ReadInt32();
@@ -153,14 +178,23 @@ void RTTI::Write(Stream *out) const
 {
     // RTTI Header placeholder
     const soff_t rtti_soff = out->GetPosition();
-    out->WriteByteCount(0, 11 * sizeof(uint32_t));
+    out->WriteByteCount(0, 14 * sizeof(uint32_t));
+
+    // Location Infos
+    const soff_t loc_soff = out->GetPosition();
+    for (const auto &l : _locs)
+    {
+        out->WriteInt32(l.id);
+        out->WriteInt32(l.name_stri);
+    }
 
     // Type Infos
     const soff_t typei_soff = out->GetPosition();
     for (const auto &t : _types)
     {
-        out->WriteInt32(t.fullname_stri);
         out->WriteInt32(t.this_id);
+        out->WriteInt32(t.name_stri);
+        out->WriteInt32(t.loc_id);
         out->WriteInt32(t.parent_id);
         out->WriteInt32(t.flags);
         out->WriteInt32(t.size);
@@ -192,7 +226,10 @@ void RTTI::Write(Stream *out) const
     out->WriteInt32(0); // format
     out->WriteInt32((uint32_t)(typei_soff - rtti_soff)); // header size
     out->WriteInt32((uint32_t)(end_soff - rtti_soff)); // full size
-    out->WriteInt32(7 * sizeof(uint32_t)); // type info size
+    out->WriteInt32(2 * sizeof(uint32_t)); // location info size
+    out->WriteInt32((uint32_t)(loc_soff - rtti_soff)); // locations table offset
+    out->WriteInt32(_locs.size()); // number of locations
+    out->WriteInt32(8 * sizeof(uint32_t)); // type info size
     out->WriteInt32((uint32_t)(typei_soff - rtti_soff)); // types table offset
     out->WriteInt32(_types.size()); // number of types
     out->WriteInt32(5 * sizeof(uint32_t)); // field info size
@@ -213,9 +250,15 @@ void RTTI::CreateQuickRefs()
         typeid_to_type[_types[i].this_id] = i;
     }
 
+    for (auto &loc : _locs)
+    {
+        loc.name = &_strings[loc.name_stri];
+    }
+
     for (auto &ti : _types)
     {
-        ti.fullname = &_strings[ti.fullname_stri];
+        ti.name = &_strings[ti.name_stri];
+        ti.location = &_locs[ti.loc_id];
         if (ti.parent_id > 0u)
             ti.parent = &_types[typeid_to_type[ti.parent_id]];
         if (ti.field_num > 0u)
@@ -234,12 +277,21 @@ void RTTI::CreateQuickRefs()
     }
 }
 
+void RTTIBuilder::AddLocation(const std::string &name, uint32_t loc_id)
+{
+    RTTI::Location loc;
+    loc.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    loc.id = loc_id;
+    _rtti._locs.push_back(loc);
+}
+
 void RTTIBuilder::AddType(const std::string &name, uint32_t type_id,
-    uint32_t parent_id, uint32_t flags, uint32_t size)
+    uint32_t loc_id, uint32_t parent_id, uint32_t flags, uint32_t size)
 {
     RTTI::Type ti;
-    ti.fullname_stri = StrTableAdd(_strtable, name, _strpackedLen);
+    ti.name_stri = StrTableAdd(_strtable, name, _strpackedLen);
     ti.this_id = type_id;
+    ti.loc_id = loc_id;
     ti.parent_id = parent_id;
     ti.flags = flags;
     ti.size = size;
@@ -287,15 +339,44 @@ RTTI &&RTTIBuilder::Finalize()
 }
 
 void JointRTTI::Join(const RTTI &rtti,
+    std::unordered_map<uint32_t, uint32_t> &loc_l2g,
     std::unordered_map<uint32_t, uint32_t> &type_l2g)
 {
+    struct CompareLocs : public std::unary_function<const Location&, bool>
+    {
+      explicit CompareLocs(const Location &loc) : _loc(loc) {}
+      bool operator() (const Location &arg) const { return strcmp(arg.name, _loc.name) == 0; }
+      const Location &_loc;
+    };
+
+    // Merge in new locations
+    const size_t new_loc_begin = _locs.size();
+    for (const auto &local_loc : rtti._locs)
+    {
+        auto global_it = std::find_if(_locs.begin(), _locs.end(), CompareLocs(local_loc));
+        if (global_it != _locs.end())
+        { // add a local2global match for existing loc, and skip the rest
+            loc_l2g.insert(std::make_pair(local_loc.id, global_it->id));
+        }
+        else
+        {
+            const uint32_t global_id = _locs.size();
+            Location loc = local_loc;
+            loc.id = global_id;
+            loc_l2g.insert(std::make_pair(local_loc.id, global_id));
+            _locs.push_back(loc);
+        }
+    }
+    const size_t new_loc_end = _locs.size();
+
     // Merge in new types (no overrides!) and assign new global type IDs
     const size_t new_type_begin = _types.size();
     for (const auto &local_type : rtti._types)
     {
         // For the type lookups, construct the "fully qualified name"
         // by combining the location's name, and the type's own name.
-        const String fullname = local_type.fullname;
+        const String fullname = String::FromFormat("%s::%s",
+            rtti._locs[local_type.loc_id].name, local_type.name);
         auto global_it = _rttiLookup.find(fullname);
         if (global_it != _rttiLookup.end())
         { // add a local2global match for existing type, and skip the rest
@@ -323,13 +404,20 @@ void JointRTTI::Join(const RTTI &rtti,
     }
     const size_t new_type_end = _types.size();
 
+    // Resolve strings in the joint locations
+    for (size_t index = new_loc_begin; index < new_loc_end; ++index)
+    {
+        RTTI::Location &loc = _locs[index];
+        loc.name_stri = StrTableCopy(_strings, rtti._strings, loc.name_stri);
+    }
     // Resolve ID refs and string offsets in the newly merged types
     for (size_t index = new_type_begin; index < new_type_end; ++index)
     {
         RTTI::Type &type = _types[index];
+        type.loc_id = loc_l2g[type.loc_id];
         if (type.parent_id > 0)
             type.parent_id = type_l2g[type.parent_id];
-        type.fullname_stri = StrTableCopy(_strings, rtti._strings, type.fullname_stri);
+        type.name_stri = StrTableCopy(_strings, rtti._strings, type.name_stri);
         // Resolve fields too
         for (uint32_t findex = 0; findex < type.field_num; ++findex)
         {
@@ -345,6 +433,7 @@ void JointRTTI::Join(const RTTI &rtti,
 
 String PrintRTTI(const RTTI &rtti)
 {
+    const auto &locs = rtti.GetLocations();
     const auto &types = rtti.GetTypes();
 
     const char *hr =   "-------------------------------------------------------------------------------";
@@ -354,10 +443,11 @@ String PrintRTTI(const RTTI &rtti)
 
     for (const auto &ti : types)
     {
-        fullstr.AppendFmt("%-12s(%-3u) %s\n", "Type:", ti.this_id, ti.fullname);
+        fullstr.AppendFmt("%-12s(%-3u) %s\n", "Type:", ti.this_id, ti.name);
+        fullstr.AppendFmt("%-12s(%-3u) %s\n", "Location:", ti.location->id, ti.location->name);
         if (ti.parent_id > 0u)
         {
-            fullstr.AppendFmt("%-12s(%-3u) %s\n", "Parent:", ti.parent->this_id, ti.parent->fullname);
+            fullstr.AppendFmt("%-12s(%-3u) %s\n", "Parent:", ti.parent->this_id, ti.parent->name);
         }
         else
         {
@@ -371,7 +461,7 @@ String PrintRTTI(const RTTI &rtti)
             for (const auto *fi = ti.first_field; fi; fi = fi->next_field, ++index)
             {
                 fullstr.AppendFmt("%+4u |%+4u: %-24s: (%-3u) %s\n", index, fi->offset,
-                    fi->name, fi->type->this_id, fi->type->fullname);
+                    fi->name, fi->type->this_id, fi->type->name);
             }
         }
         else

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -1,0 +1,133 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Script reflection helpers. Intended to analyze script memory.
+//
+//=============================================================================
+#ifndef __CC_REFLECT_H
+#define __CC_REFLECT_H
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+#include "core/types.h"
+#include "util/string.h"
+#include "util/string_types.h"
+
+namespace AGS
+{
+
+namespace Common { class Stream; }
+
+class RTTIBuilder;
+
+// Runtime type information for the AGS script:
+// contains tables of types and their inner fields.
+class RTTI
+{
+    friend RTTIBuilder;
+public:
+    struct Field;
+
+    // Type's info
+    struct Type
+    {
+        friend RTTI; friend RTTIBuilder;
+    public:
+        uint32_t this_id = 0u; // this type's id (local to current RTTI struct)
+        uint32_t parent_id = 0u; // parent type's id
+        uint32_t flags = 0u; // type flags
+        uint32_t size = 0u; // type size in bytes
+        uint32_t field_num = 0u; // number of fields, if any
+        // Quick-access links
+        const char *fullname = nullptr;
+        const Type *parent = nullptr;
+        const Field *first_field = nullptr;
+    private:
+        // Internal references
+        // Fully qualified name, suitable for uniquely identify this type
+        // in the global scope. Format is "unitname::typename".
+        // TODO: write section index instead, use section name from script data?
+        // (save mem on repeated section name)
+        uint32_t fullname_stri = 0u; // type's name (string table offset)
+        uint32_t field_index = 0u; // first field index in the fields table
+    };
+
+    // Type's field info
+    struct Field
+    {
+        friend RTTI; friend RTTIBuilder;
+    public:
+        uint32_t offset = 0u; // relative offset of this field, in bytes
+        uint32_t f_typeid = 0u; // field's type id
+        uint32_t flags = 0u; // field flags
+        uint32_t num_elems = 0u; // number of elements (for array)
+        // Quick-access links
+        const char *name = nullptr;
+        const Type *type = nullptr;
+        const Type *owner = nullptr;
+        const Field *prev_field = nullptr;
+        const Field *next_field = nullptr;
+    private:
+        // Internal references
+        uint32_t name_stri = 0u; // field's name (string table offset)
+    };
+
+    RTTI() = default;
+
+    bool IsEmpty() const { return _types.empty(); }
+    const std::vector<Type> &GetTypes() const { return _types; }
+
+    void Read(AGS::Common::Stream *in);
+    void Write(AGS::Common::Stream *out) const;
+
+private:
+    // Generates quick reference fields, binding table entries between each other
+    void CreateQuickRefs();
+
+    // The primary RTTI collection
+    // Type descriptions
+    std::vector<Type> _types;
+    // Type fields' descriptions
+    std::vector<Field> _fields;
+    // All RTTI strings packed, separated by null-terminators
+    std::vector<char> _strings;
+};
+
+// A helper class that lets you generate RTTI collection.
+// Use Add* methods to construct list of types and their members,
+// then call Finalize which returns a constructed RTTI object.
+class RTTIBuilder
+{
+public:
+    // Adds a type entry
+    void AddType(const std::string &name, uint32_t type_id, uint32_t parent_id,
+        uint32_t flags, uint32_t size);
+    // Adds a type's field entry
+    void AddField(uint32_t owner_id, const std::string &name, uint32_t offset,
+        uint32_t f_typeid, uint32_t flags, uint32_t num_elems);
+    // Finalizes the RTTI, generates remaining data based on collected one
+    RTTI &&Finalize();
+private:
+    // RTTI that is being built
+    RTTI _rtti;
+    // Helper fields
+    std::multimap<uint32_t, RTTI::Field> _fieldIdx; // type id to fields list
+    std::map<std::string, uint32_t> _strtable; // string to offset
+    uint32_t _strpackedLen = 0u; // packed string table size
+};
+
+} // namespace AGS
+
+#endif // __CC_REFLECT_H

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -173,6 +173,13 @@ private:
     std::unordered_map<AGS::Common::String, uint32_t> _rttiLookup;
 };
 
+
+
+// Prints RTTI types and their fields into the string.
+// TODO: provide TextWriter instead of returning a String,
+// but need to implement a TextWriter that writes into the engine's log
+AGS::Common::String PrintRTTI(const RTTI &rtti);
+
 } // namespace AGS
 
 #endif // __CC_REFLECT_H

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -38,6 +38,18 @@ class RTTI
 {
     friend RTTIBuilder;
 public:
+    enum TypeFlags
+    {
+        kType_Struct      = 0x0001,
+        kType_Managed     = 0x0002
+    };
+
+    enum FieldFlags
+    {
+        kField_ManagedPtr = 0x0001,
+        kField_Array      = 0x0002
+    };
+
     struct Field;
 
     // Type's info

--- a/Common/script/cc_script.h
+++ b/Common/script/cc_script.h
@@ -12,15 +12,16 @@
 //
 //=============================================================================
 //
-// 'C'-style script compiler
+// Compiled script object. A result of AGS script compilation,
+// loaded and run by the engine. A single game may have multiple scripts.
 //
 //=============================================================================
-
 #ifndef __CC_SCRIPT_H
 #define __CC_SCRIPT_H
 
 #include <memory>
 #include "core/types.h"
+#include "script/cc_reflect.h"
 
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
@@ -51,6 +52,8 @@ public:
     int32_t *sectionOffsets;
     int numSections;
     int capacitySections;
+
+    std::unique_ptr<RTTI> rtti;
 
     static ccScript *CreateFromStream(Common::Stream *in);
 

--- a/Compiler/CMakeLists.txt
+++ b/Compiler/CMakeLists.txt
@@ -10,10 +10,13 @@ set_target_properties(compiler PROPERTIES
 target_include_directories(compiler PUBLIC .)
 target_include_directories(compiler PUBLIC ../Common)
 set(COMPILER_COMMON_SOURCES
+        ../Common/debug/debugmanager.cpp
         ../Common/script/cc_common.cpp
         ../Common/script/cc_script.cpp
+        ../Common/script/cc_reflect.cpp
         ../Common/util/bufferedstream.cpp
         ../Common/util/cmdlineopts.cpp
+        ../Common/util/data_ext.cpp
         ../Common/util/datastream.cpp
         ../Common/util/file.cpp
         ../Common/util/path.cpp

--- a/Compiler/Makefile
+++ b/Compiler/Makefile
@@ -23,10 +23,13 @@ LDFLAGS  += -rdynamic -Wl,--as-needed $(addprefix -L,$(LIBDIR))
 CFLAGS   += -Werror=implicit-function-declaration
 
 COMMON_OBJS = \
+	../Common/debug/debugmanager.cpp \
 	../Common/script/cc_common.cpp \
+	../Common/script/cc_reflect.cpp \
 	../Common/script/cc_script.cpp \
 	../Common/util/bufferedstream.cpp \
 	../Common/util/cmdlineopts.cpp \
+	../Common/util/data_ext.cpp \
 	../Common/util/datastream.cpp \
 	../Common/util/file.cpp \
 	../Common/util/path.cpp \

--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -57,6 +57,7 @@ void symbolTable::reset() {
 	nameGenCache.clear();
 
 	entries.clear();
+    sections.clear();
 
     stringStructSym = 0;
     symbolTree.clear();

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -11,6 +11,7 @@
 // So there's another symbol definition in cc_symboldef.h
 struct SymbolTableEntry {
 	std::string sname;
+    int section; // section index this symbol was declared in
 	short stype;
 	long flags;
 	short vartype;
@@ -49,6 +50,8 @@ struct symbolTable {
 
 	// properties for symbols, size is numsymbols
 	std::vector<SymbolTableEntry> entries;
+    // section names filled by tokenizer, required for RTTI
+    std::vector<std::string> sections;
 
     symbolTable();
     void reset();    // clears table

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -1,4 +1,5 @@
-
+#include <algorithm>
+#include <set>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +39,49 @@ void ccRemoveDefaultHeaders() {
 
 void ccSetSoftwareVersion(const char *versionNumber) {
     ccSoftwareVersion = versionNumber;
+}
+
+// Compiles RTTI table for the given script.
+static std::unique_ptr<RTTI> ccCompileRTTI(const symbolTable &sym)
+{
+    RTTIBuilder rtb;
+    std::string buf; // for constructing full qualified names
+
+    // Scan through all the symbols and save type infos,
+    // and gather preliminary data on type fields and strings
+    for (size_t t = 0; t < sym.entries.size(); t++)
+    {
+        const SymbolTableEntry &ste = sym.entries[t];
+
+        if ((ste.stype == SYM_VARTYPE) || ((ste.flags & SFLG_STRUCTTYPE) != 0) ||
+            ((ste.flags & SFLG_MANAGED) != 0))
+        {
+            if (ste.section >= 0)
+                buf.assign(sym.sections[ste.section]).append("::").append(ste.sname);
+            else
+                buf = ste.sname;
+            uint32_t flags = 0u; // TODO
+            if ((ste.flags & SFLG_STRUCTTYPE))
+                flags = RTTI::kType_Struct;
+            if ((ste.flags & SFLG_MANAGED))
+                flags = RTTI::kType_Managed;
+            rtb.AddType(buf, t, ste.extends, flags, ste.ssize);
+        }
+        else if ((ste.stype == SYM_STRUCTMEMBER) && ((ste.flags & SFLG_STRUCTMEMBER) != 0) &&
+            ((ste.flags & SFLG_PROPERTY) == 0))
+        {
+            uint32_t flags = 0u; // TODO
+            if ((ste.flags & SFLG_DYNAMICARRAY) || (ste.flags & SFLG_POINTER))
+                flags |= RTTI::kField_ManagedPtr;
+            if (ste.flags & SFLG_ARRAY)
+                flags |= RTTI::kField_Array;
+            rtb.AddField(ste.extends, ste.sname, ste.soffs, ste.vartype, flags,
+                static_cast<uint32_t>(ste.arrsize));
+        }
+    }
+
+    return std::unique_ptr<RTTI>(
+        new RTTI(std::move(rtb.Finalize())));
 }
 
 ccScript* ccCompileText(const char *texo, const char *scriptName) {
@@ -116,6 +160,9 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
 
         }
     }
+
+    // Construct RTTI
+    cctemp->rtti = ccCompileRTTI(sym);
 
     cctemp->free_extra();
     return cctemp;

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -168,7 +168,9 @@ ccScript* ccCompileText(const char *texo, const char *scriptName) {
     }
 
     // Construct RTTI
-    cctemp->rtti = ccCompileRTTI(sym);
+    if (ccGetOption(SCOPT_RTTI)) {
+        cctemp->rtti = ccCompileRTTI(sym);
+    }
 
     cctemp->free_extra();
     return cctemp;

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -72,12 +72,13 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const symbolTable &sym)
         else if ((ste.stype == SYM_STRUCTMEMBER) && ((ste.flags & SFLG_STRUCTMEMBER) != 0) &&
             ((ste.flags & SFLG_PROPERTY) == 0))
         {
-            uint32_t flags = 0u; // TODO
+            buf = ste.sname.substr(ste.sname.rfind(":") + 1);
+            uint32_t flags = 0u;
             if ((ste.flags & SFLG_DYNAMICARRAY) || (ste.flags & SFLG_POINTER))
                 flags |= RTTI::kField_ManagedPtr;
             if (ste.flags & SFLG_ARRAY)
                 flags |= RTTI::kField_Array;
-            rtb.AddField(ste.extends, ste.sname, ste.soffs, ste.vartype, flags,
+            rtb.AddField(ste.extends, buf, ste.soffs, ste.vartype, flags,
                 static_cast<uint32_t>(ste.arrsize));
         }
     }

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -47,6 +47,8 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const symbolTable &sym)
     RTTIBuilder rtb;
     std::string buf; // for constructing full qualified names
 
+    // Add "no type" with id 0
+    rtb.AddType("", 0u, 0u, 0u, 0u);
     // Scan through all the symbols and save type infos,
     // and gather preliminary data on type fields and strings
     for (size_t t = 0; t < sym.entries.size(); t++)

--- a/Compiler/script2/cc_internallist.cpp
+++ b/Compiler/script2/cc_internallist.cpp
@@ -44,6 +44,15 @@ void AGS::LineHandler::AddLineAt(size_t offset, size_t lineno)
     _cacheLineEnd = 0;
 }
 
+AGS::SectionList AGS::LineHandler::CreateSectionList() const
+{
+    std::vector<std::string> sections = _sections;
+    std::map<size_t, size_t> off2sec;
+    for (const auto &item : _lineStartTable)
+        off2sec[item.first] = item.second.SectionId;
+    return AGS::SectionList(std::move(sections), std::move(off2sec));
+}
+
 AGS::SrcList::SrcList(std::vector<Symbol> &script, LineHandler &line_handler, size_t &cursor)
     : _script(script)
     , _lineHandler(line_handler)

--- a/Compiler/script2/cc_symboltable.cpp
+++ b/Compiler/script2/cc_symboltable.cpp
@@ -653,6 +653,14 @@ AGS::Symbol AGS::SymbolTable::FindStructComponent(Symbol strct, Symbol const com
     return kKW_NoSymbol;
 }
 
+AGS::Vartype AGS::SymbolTable::GetFirstBaseVartype(AGS::Vartype vartype) const
+{
+    // TODO: extra safety checks?
+    for (const auto *ste = &entries[vartype]; ste->VartypeD && (ste->VartypeD->BaseVartype > 0);
+        vartype = ste->VartypeD->BaseVartype, ste = &entries[vartype]) { }
+    return vartype;
+}
+
 AGS::ScopeType AGS::SymbolTable::GetScopeType(Symbol s) const
 {
     if (0 < entries.at(s).Scope)

--- a/Compiler/script2/cc_symboltable.h
+++ b/Compiler/script2/cc_symboltable.h
@@ -494,6 +494,8 @@ public:
     // The vartype of the variable, i.e. "int" or "Dynarray *"
     inline AGS::Vartype GetVartype(Symbol s) const
         { return IsVariable(s) ? entries.at(s).VariableD->Vartype : kKW_NoSymbol; }
+    // Returns the most base vartype that the given vartype originates from
+    AGS::Vartype GetFirstBaseVartype(AGS::Vartype vartype) const;
     ScopeType GetScopeType(Symbol s) const;
 
     // Operators

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -121,7 +121,11 @@ ccScript *ccCompileText2(std::string const &script, std::string const &scriptNam
         return NULL;
     }
 
-    compiled_script->rtti = ccCompileRTTI(symt, seclist);
+    // Construct RTTI
+    if (FlagIsSet(options, SCOPT_RTTI))
+    {
+        compiled_script->rtti = ccCompileRTTI(symt, seclist);
+    }
 
     ccCurScriptName = nullptr;
     cc_clear_error();

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -27,6 +27,8 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
     RTTIBuilder rtb;
     std::string buf; // for constructing full qualified names
 
+    // Add "no type" with id 0
+    rtb.AddType("", 0u, 0u, 0u, 0u);
     // Scan through all the symbols and save type infos,
     // and gather preliminary data on type fields and strings
     for (size_t t = 0; t < symt.entries.size(); t++)

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -11,6 +11,7 @@
 
 #include "cs_parser.h"
 
+
 void ccGetExtensions2(std::vector<std::string> &exts)
 {
     // A generic "AGS 4.0" extension, for easier detection
@@ -19,13 +20,64 @@ void ccGetExtensions2(std::vector<std::string> &exts)
     exts.push_back("AGS4");
 }
 
+
+// Compiles RTTI table for the given script.
+static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
+{
+    RTTIBuilder rtb;
+    std::string buf; // for constructing full qualified names
+
+    // Scan through all the symbols and save type infos,
+    // and gather preliminary data on type fields and strings
+    for (size_t t = 0; t < symt.entries.size(); t++)
+    {
+        const SymbolTableEntry &ste = symt.entries[t];
+
+        // Detect a declared type, atomic or struct (regular and managed);
+        // ignore all the compound types (derived from "real" types).
+        if (ste.VartypeD && (ste.VartypeD->BaseVartype == 0))
+        {
+            // TODO: fully qualified name with section?
+            // token_list.SectionId2Section(token_list.GetSectionIdAt(ste.Declared));
+            buf = ste.Name;
+            uint32_t flags = 0u;
+            if (ste.VartypeD->Flags[VTF::kManaged])
+                flags |= RTTI::kType_Managed;
+            if (ste.VartypeD->Flags[VTF::kStruct])
+                flags |= RTTI::kType_Struct;
+            rtb.AddType(buf, t, ste.VartypeD->Parent, flags, ste.VartypeD->Size);
+        }
+        // Detect a struct's mem field (not function or attribute, etc)
+        else if (ste.ComponentD && ste.VariableD)
+        {
+            uint32_t flags = 0u;
+            const auto &field_type = symt.entries[ste.VariableD->Vartype];
+            if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
+                (field_type.VartypeD->Type == VTT::kDynarray))
+                flags |= RTTI::kField_ManagedPtr;
+            if (field_type.VartypeD->Type == VTT::kArray)
+                flags |= RTTI::kField_Array;
+            uint32_t num_elems = 0u;
+            for (const auto sz : field_type.VartypeD->Dims)
+                num_elems += sz; // CHECKME if correct
+            rtb.AddField(ste.ComponentD->Parent, ste.Name, ste.ComponentD->Offset,
+                symt.GetFirstBaseVartype(ste.VariableD->Vartype), flags, num_elems);
+        }
+    }
+
+    return std::unique_ptr<RTTI>(
+        new RTTI(std::move(rtb.Finalize())));
+}
+
+
 ccScript *ccCompileText2(std::string const &script, std::string const &scriptName, uint64_t const options, MessageHandler &mh)
 {
     ccCompiledScript *compiled_script =
         new ccCompiledScript(FlagIsSet(options, SCOPT_LINENUMBERS));
+    SymbolTable symt; // for gathering rtti
 
     compiled_script->StartNewSection(scriptName.empty() ? scriptName : "Unnamed script");
-    cc_compile(script, options, *compiled_script, mh);
+    cc_compile(script, options, *compiled_script, symt, mh);
     if (mh.HasError())
     {
         auto const &err = mh.GetError();
@@ -56,6 +108,8 @@ ccScript *ccCompileText2(std::string const &script, std::string const &scriptNam
         delete compiled_script; // Note: delete calls the destructor
         return NULL;
     }
+
+    compiled_script->rtti = ccCompileRTTI(symt);
 
     ccCurScriptName = nullptr;
     cc_clear_error();

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -27,8 +27,11 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
     RTTIBuilder rtb;
     std::string buf; // for constructing full qualified names
 
+    // Add "dummy" location for safety
+    rtb.AddLocation("", 0u);
+
     // Add "no type" with id 0
-    rtb.AddType("", 0u, 0u, 0u, 0u);
+    rtb.AddType("", 0u, 0u, 0u, 0u, 0u);
     // Scan through all the symbols and save type infos,
     // and gather preliminary data on type fields and strings
     for (size_t t = 0; t < symt.entries.size(); t++)
@@ -47,7 +50,7 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
                 flags |= RTTI::kType_Managed;
             if (ste.VartypeD->Flags[VTF::kStruct])
                 flags |= RTTI::kType_Struct;
-            rtb.AddType(buf, t, ste.VartypeD->Parent, flags, ste.VartypeD->Size);
+            rtb.AddType(buf, t, 0u, ste.VartypeD->Parent, flags, ste.VartypeD->Size);
         }
         // Detect a struct's mem field (not function or attribute, etc)
         else if (ste.ComponentD && ste.VariableD)

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -52,6 +52,7 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
         // Detect a struct's mem field (not function or attribute, etc)
         else if (ste.ComponentD && ste.VariableD)
         {
+            buf = ste.Name.substr(ste.Name.rfind(":") + 1);
             uint32_t flags = 0u;
             const auto &field_type = symt.entries[ste.VariableD->Vartype];
             if ((field_type.VartypeD->Type == VTT::kDynpointer) ||
@@ -62,7 +63,7 @@ static std::unique_ptr<RTTI> ccCompileRTTI(const SymbolTable &symt)
             uint32_t num_elems = 0u;
             for (const auto sz : field_type.VartypeD->Dims)
                 num_elems += sz; // CHECKME if correct
-            rtb.AddField(ste.ComponentD->Parent, ste.Name, ste.ComponentD->Offset,
+            rtb.AddField(ste.ComponentD->Parent, buf, ste.ComponentD->Offset,
                 symt.GetFirstBaseVartype(ste.VariableD->Vartype), flags, num_elems);
         }
     }

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -6787,11 +6787,12 @@ int cc_parse(AGS::SrcList &src, AGS::FlagSet options, AGS::ccCompiledScript &scr
 int cc_compile(std::string const &inpl, AGS::FlagSet options, AGS::ccCompiledScript &scrip, AGS::MessageHandler &mh)
 {
     AGS::SymbolTable local_symt;
-    return cc_compile(inpl, options, scrip, local_symt, mh);
+    AGS::SectionList local_secs;
+    return cc_compile(inpl, options, scrip, local_symt, local_secs, mh);
 }
 
 int cc_compile(std::string const &inpl, AGS::FlagSet options, AGS::ccCompiledScript &scrip,
-    AGS::SymbolTable &symt, AGS::MessageHandler &mh)
+    AGS::SymbolTable &symt, AGS::SectionList &sections, AGS::MessageHandler &mh)
 {
     std::vector<AGS::Symbol> symbols;
     AGS::LineHandler lh;
@@ -6803,5 +6804,6 @@ int cc_compile(std::string const &inpl, AGS::FlagSet options, AGS::ccCompiledScr
     int error_code = cc_scan(inpl, src, scrip, symt, mh);
     if (error_code >= 0)
         error_code = cc_parse(src, options, scrip, symt, mh);
+    sections = lh.CreateSectionList();
     return error_code;
 }

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -6786,16 +6786,19 @@ int cc_parse(AGS::SrcList &src, AGS::FlagSet options, AGS::ccCompiledScript &scr
 
 int cc_compile(std::string const &inpl, AGS::FlagSet options, AGS::ccCompiledScript &scrip, AGS::MessageHandler &mh)
 {
+    AGS::SymbolTable local_symt;
+    return cc_compile(inpl, options, scrip, local_symt, mh);
+}
+
+int cc_compile(std::string const &inpl, AGS::FlagSet options, AGS::ccCompiledScript &scrip,
+    AGS::SymbolTable &symt, AGS::MessageHandler &mh)
+{
     std::vector<AGS::Symbol> symbols;
     AGS::LineHandler lh;
     size_t cursor = 0u;
     AGS::SrcList src = AGS::SrcList(symbols, lh, cursor);
     src.NewSection("UnnamedSection");
     src.NewLine(1u);
-
-    AGS::SymbolTable symt;
-
-    ccCurScriptName = nullptr;
 
     int error_code = cc_scan(inpl, src, scrip, symt, mh);
     if (error_code >= 0)

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -1049,12 +1049,13 @@ extern int cc_compile(
     AGS::FlagSet options,            // as defined in cc_options 
     AGS::ccCompiledScript &scrip,    // store for the compiled text
     AGS::MessageHandler &mh);        // warnings and the error   
-// Compile the input, additionally return gathered symbol table
+// Compile the input, additionally return gathered symbols and other source info
 extern int cc_compile(
     std::string const &source,  // preprocessed text to be compiled
     AGS::FlagSet options,            // as defined in cc_options 
     AGS::ccCompiledScript &scrip,    // store for the compiled text
     AGS::SymbolTable &symt,          // store for the parsed symbols
+    AGS::SectionList &sections,      // store for the list of sections
     AGS::MessageHandler &mh);        // warnings and the error   
 
 #endif // __CS_PARSER_H

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -1049,5 +1049,12 @@ extern int cc_compile(
     AGS::FlagSet options,            // as defined in cc_options 
     AGS::ccCompiledScript &scrip,    // store for the compiled text
     AGS::MessageHandler &mh);        // warnings and the error   
+// Compile the input, additionally return gathered symbol table
+extern int cc_compile(
+    std::string const &source,  // preprocessed text to be compiled
+    AGS::FlagSet options,            // as defined in cc_options 
+    AGS::ccCompiledScript &scrip,    // store for the compiled text
+    AGS::SymbolTable &symt,          // store for the parsed symbols
+    AGS::MessageHandler &mh);        // warnings and the error   
 
 #endif // __CS_PARSER_H

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -62,6 +62,7 @@ namespace AGS
                 SCOPT_LINENUMBERS |
                 SCOPT_OLDSTRINGS * (!game->Settings->EnforceNewStrings) |
                 SCOPT_UTF8 * (game->UnicodeMode) |
+                SCOPT_RTTI |
                 false;
 
         if (game->Settings->ExtendedCompiler)

--- a/Editor/AGS.Native/Scripting.h
+++ b/Editor/AGS.Native/Scripting.h
@@ -1,5 +1,7 @@
 #include "script/cc_script.h"
 #include "script/cc_internal.h"
+#include "util/file.h"
+#include "util/stream.h"
 
 namespace AGS
 {
@@ -40,65 +42,20 @@ namespace AGS
                 {
                     throw gcnew AGS::Types::CompileError(gcnew System::String("Script has not been compiled: ") + scriptFileName);
                 }
-                System::IO::BinaryWriter ^writer = gcnew System::IO::BinaryWriter(ostream);
-                for (int i = 0; i < 4; ++i)
-                {
-                    // the BinaryWriter seems to be treating CHAR as a 4-byte type here?
-                    writer->Write((System::Byte)scfilesig[i]);
-                }
-                const ccScript *cs = _compiledScript->get();
-                writer->Write(SCOM_VERSION);
-                writer->Write(cs->globaldatasize);
-                writer->Write(cs->codesize);
-                writer->Write(cs->stringssize);
-                for (int i = 0; i < cs->globaldatasize; ++i)
-                {
-                    writer->Write((System::Byte)cs->globaldata[i]);
-                }
-                for (int i = 0; i < cs->codesize; ++i)
-                {
-                    writer->Write((int)cs->code[i]);
-                }
-                for (int i = 0; i < cs->stringssize; ++i)
-                {
-                    writer->Write((System::Byte)cs->strings[i]);
-                }
-                writer->Write(cs->numfixups);
-                for (int i = 0; i < cs->numfixups; ++i)
-                {
-                    writer->Write((System::Byte)cs->fixuptypes[i]);
-                }
-                for (int i = 0; i < cs->numfixups; ++i)
-                {
-                    writer->Write(cs->fixups[i]);
-                }
-                writer->Write(cs->numimports);
-                for (int i = 0; i < cs->numimports; ++i)
-                {
-                    for (int j = 0, len = strlen(cs->imports[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->imports[i][j]);
-                    }
-                }
-                writer->Write(cs->numexports);
-                for (int i = 0; i < cs->numexports; ++i)
-                {
-                    for (int j = 0, len = strlen(cs->exports[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->exports[i][j]);
-                    }
-                    writer->Write(cs->export_addr[i]);
-                }
-                writer->Write(cs->numSections);
-                for (int i = 0; i < cs->numSections; ++i)
-                {
-                    for (int j = 0, len = strlen(cs->sectionNames[i]); j <= len; ++j)
-                    {
-                        writer->Write((System::Byte)cs->sectionNames[i][j]);
-                    }
-                    writer->Write(cs->sectionOffsets[i]);
-                }
-                writer->Write(ENDFILESIG);
+                
+                // NOTE: if using temp files will prove inefficient,
+                // we might switch to writing into a memory buffer instead,
+                // or switching between file and buffer depending on script's size.
+                String ^tempFile = System::IO::Path::GetTempFileName();
+                
+                std::unique_ptr<AGS::Common::Stream> out(
+                    AGS::Common::File::CreateFile(TextHelper::ConvertUTF8(tempFile)));
+                (*_compiledScript)->Write(out.get());
+                out.reset();
+                
+                Utilities::CopyFileContents(tempFile, ostream);
+
+                System::IO::File::Delete(tempFile);
             }
         };
 	}

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -211,5 +211,24 @@ namespace AGS.Types
                 return Utilities.UTF8; // UTF-8 w/o BOM
             return Encoding.GetEncoding(name);
         }
+
+        /// <summary>
+        /// Writes contents of a file into the given stream.
+        /// TODO: we might need another library for utilities that are not related to AGS.Types.
+        /// </summary>
+        public static bool CopyFileContents(string sourceFileName, FileStream output)
+        {
+            FileStream input = File.OpenRead(sourceFileName);
+            if (input == null)
+                return false;
+            byte[] buffer = new byte[65536];
+            int bytesRead;
+            while ((bytesRead = input.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                output.Write(buffer, 0, bytesRead);
+            }
+            input.Close();
+            return true;
+        }
     }
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -95,6 +95,7 @@ extern IGraphicsDriver *gfxDriver;
 extern Bitmap *raw_saved_screen;
 extern RGB palette[256];
 extern int mouse_z_was;
+extern bool logScriptRTTI;
 
 extern CCHotspot ccDynamicHotspot;
 extern CCObject ccDynamicObject;
@@ -409,6 +410,12 @@ void load_new_room(int newnum, CharacterInfo*forchar) {
     if (!err)
         quitprintf("!Unable to load '%s'. Error: %s", room_filename.GetCStr(),
             err->FullMessage().GetCStr());
+
+    // Optionally dump joint RTTI into the log
+    if (logScriptRTTI && ccInstance::GetRTTI())
+    {
+        Debug::Printf(PrintRTTI(ccInstance::GetRTTI()->AsConstRTTI()));
+    }
 
     our_eip=201;
 

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -68,6 +68,7 @@ bool justRunSetup = false;
 bool justTellInfo = false;
 bool attachToParentConsole = false;
 bool hideMessageBoxes = false;
+bool logScriptRTTI = false;
 std::set<String> tellInfoKeys;
 String loadSaveGameOnStartup;
 
@@ -354,6 +355,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
         }
         else if (ags_stricmp(arg, "--console-attach") == 0) attachToParentConsole = true;
         else if (ags_stricmp(arg, "--no-message-box") == 0) hideMessageBoxes = true;
+        else if (ags_stricmp(arg, "--print-rtti") == 0) logScriptRTTI = true;
         //
         // Special case: data file location
         //

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -247,7 +247,7 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
     {
         if (!ccInstance::_rtti)
             ccInstance::_rtti.reset(new JointRTTI());
-        ccInstance::_rtti->Join(*scri->rtti, cinst->_typeidLocal2Global);
+        ccInstance::_rtti->Join(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
     }
     return cinst;
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -213,6 +213,10 @@ struct FunctionCallStack
 };
 
 
+std::unique_ptr<JointRTTI> ccInstance::_rtti;
+std::unordered_map<String, uint32_t> ccInstance::_rttiLookup;
+
+
 unsigned ccInstance::_timeoutCheckMs = 60u;
 unsigned ccInstance::_timeoutAbortMs = 0u;
 unsigned ccInstance::_maxWhileLoops = 0u;
@@ -238,6 +242,13 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
         return nullptr;
     }
 
+    // Join RTTI
+    if (scri->rtti && !scri->rtti->IsEmpty())
+    {
+        if (!ccInstance::_rtti)
+            ccInstance::_rtti.reset(new JointRTTI());
+        ccInstance::_rtti->Join(*scri->rtti, cinst->_typeidLocal2Global);
+    }
     return cinst;
 }
 

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -226,6 +226,8 @@ private:
     static std::unique_ptr<JointRTTI> _rtti;
     // Full name to global id (global id is an actual index in the joint rtti table)
     static std::unordered_map<Common::String, uint32_t> _rttiLookup;
+    // Map local script's location id to global (program-wide)
+    std::unordered_map<uint32_t, uint32_t> _locidLocal2Global;
     // Map local script's type id to global (program-wide)
     std::unordered_map<uint32_t, uint32_t> _typeidLocal2Global;
 

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -151,6 +151,7 @@ public:
     static ccInstance *CreateFromScript(PScript script);
     static ccInstance *CreateEx(PScript scri, ccInstance * joined);
     static void SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
+    static const JointRTTI *GetRTTI() { return _rtti.get(); }
 
     ccInstance();
     ~ccInstance();
@@ -220,6 +221,13 @@ private:
     // Function call stack processing
     void    PushToFuncCallStack(FunctionCallStack &func_callstack, const RuntimeScriptValue &rval);
     void    PopFromFuncCallStack(FunctionCallStack &func_callstack, int32_t num_entries);
+
+    // RTTI tables
+    static std::unique_ptr<JointRTTI> _rtti;
+    // Full name to global id (global id is an actual index in the joint rtti table)
+    static std::unordered_map<Common::String, uint32_t> _rttiLookup;
+    // Map local script's type id to global (program-wide)
+    std::unordered_map<uint32_t, uint32_t> _typeidLocal2Global;
 
     // Minimal timeout: how much time may pass without any engine update
     // before we want to check on the situation and do system poll

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -329,6 +329,7 @@
     <ClCompile Include="..\..\Common\libsrc\freetype-2.1.3\src\type42\type42.c" />
     <ClCompile Include="..\..\Common\libsrc\freetype-2.1.3\src\winfonts\winfnt.c" />
     <ClCompile Include="..\..\Common\script\cc_common.cpp" />
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp" />
     <ClCompile Include="..\..\Common\script\cc_script.cpp" />
     <ClCompile Include="..\..\Common\util\alignedstream.cpp" />
     <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
@@ -472,6 +473,7 @@
     <ClInclude Include="..\..\Common\gui\guitextbox.h" />
     <ClInclude Include="..\..\Common\platform\windows\windows.h" />
     <ClInclude Include="..\..\Common\script\cc_common.h" />
+    <ClInclude Include="..\..\Common\script\cc_reflect.h" />
     <ClInclude Include="..\..\Common\script\cc_script.h" />
     <ClInclude Include="..\..\Common\script\cc_internal.h" />
     <ClInclude Include="..\..\Common\util\alignedstream.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -515,6 +515,9 @@
     <ClCompile Include="..\..\Common\script\cc_common.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\audiocliptype.h">
@@ -831,6 +834,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Common\util\matrix.h">
       <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\script\cc_reflect.h">
+      <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Solutions/Compiler.App/Compiler.App.vcxproj
+++ b/Solutions/Compiler.App/Compiler.App.vcxproj
@@ -191,8 +191,10 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
     <ClCompile Include="..\..\Common\util\bufferedstream.cpp" />
     <ClCompile Include="..\..\Common\util\datastream.cpp" />
+    <ClCompile Include="..\..\Common\util\data_ext.cpp" />
     <ClCompile Include="..\..\Common\util\file.cpp" />
     <ClCompile Include="..\..\Common\util\path.cpp" />
     <ClCompile Include="..\..\Common\util\filestream.cpp" />

--- a/Solutions/Compiler.App/Compiler.App.vcxproj.filters
+++ b/Solutions/Compiler.App/Compiler.App.vcxproj.filters
@@ -83,5 +83,14 @@
     <ClCompile Include="..\..\Common\util\cmdlineopts.cpp">
       <Filter>Common Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\path.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\util\data_ext.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Common Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj
+++ b/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj
@@ -93,8 +93,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
     <ClCompile Include="..\..\Common\libsrc\googletest\src\gtest-all.cc" />
     <ClCompile Include="..\..\Common\libsrc\googletest\src\gtest_main.cc" />
+    <ClCompile Include="..\..\Common\util\data_ext.cpp" />
     <ClCompile Include="..\..\Common\util\stream.cpp" />
     <ClCompile Include="..\..\Common\util\string.cpp" />
     <ClCompile Include="..\..\Common\util\string_compat.c" />

--- a/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj.filters
+++ b/Solutions/Compiler.Lib/Compiler.Lib.Test.vcxproj.filters
@@ -51,6 +51,12 @@
     <ClCompile Include="..\..\Common\util\string_utils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\data_ext.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Compiler\test\cc_test_helper.h">

--- a/Solutions/Compiler.Lib/Compiler.Lib.vcxproj
+++ b/Solutions/Compiler.Lib/Compiler.Lib.vcxproj
@@ -160,6 +160,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\script\cc_common.cpp" />
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp" />
     <ClCompile Include="..\..\Common\util\version.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -176,6 +177,7 @@
     <ClCompile Include="..\..\Compiler\preproc\preprocessor.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Common\script\cc_reflect.h" />
     <ClInclude Include="..\..\Common\util\version.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Compiler.Lib/Compiler.Lib.vcxproj.filters
+++ b/Solutions/Compiler.Lib/Compiler.Lib.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\..\Common\script\cc_common.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\util\version.cpp">
@@ -80,6 +83,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Compiler\preproc\preprocessor.h">
       <Filter>Header Files\preproc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\script\cc_reflect.h">
+      <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj
@@ -93,8 +93,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp" />
     <ClCompile Include="..\..\Common\libsrc\googletest\src\gtest-all.cc" />
     <ClCompile Include="..\..\Common\libsrc\googletest\src\gtest_main.cc" />
+    <ClCompile Include="..\..\Common\util\data_ext.cpp" />
     <ClCompile Include="..\..\Common\util\stream.cpp" />
     <ClCompile Include="..\..\Common\util\string.cpp" />
     <ClCompile Include="..\..\Common\util\string_compat.c" />

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj.filters
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.Test.vcxproj.filters
@@ -60,6 +60,12 @@
     <ClCompile Include="..\..\Common\util\string_utils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\data_ext.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\debug\debugmanager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Compiler\test2\cc_bytecode_test_lib.h">

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj
@@ -161,6 +161,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\script\cc_common.cpp" />
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp" />
     <ClCompile Include="..\..\Common\script\cc_script.cpp" />
     <ClCompile Include="..\..\Common\util\string.cpp" />
     <ClCompile Include="..\..\Compiler\script2\cc_compiledscript.cpp" />
@@ -175,6 +176,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Common\script\cc_error.h" />
     <ClInclude Include="..\..\Common\script\cc_options.h" />
+    <ClInclude Include="..\..\Common\script\cc_reflect.h" />
     <ClInclude Include="..\..\Common\script\cc_script.h" />
     <ClInclude Include="..\..\Common\script\script_common.h" />
     <ClInclude Include="..\..\Common\util\string.h" />

--- a/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj.filters
+++ b/Solutions/Compiler2.Lib/Compiler2.Lib.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="..\..\Common\script\cc_common.cpp">
       <Filter>Source Files\cs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\script\cc_reflect.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\script\cc_error.h">
@@ -76,6 +79,9 @@
       <Filter>Header Files\script</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Compiler\script2\cs_message_handler.h">
+      <Filter>Header Files\script</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\script\cc_reflect.h">
       <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Resolves #1259.

CC @fernewelten , because he is working on a new script compiler, and I added few functions to it.

The detailed description of the purpose is given in the task ticket #1259, here I will give a brief overview.
There are several potential operations within the script interpreter that are impossible to achieve without having an indication and description of object's type and its inner contents:
* Having managed pointers in managed structs and being able to dereference them at runtime when disposing the parent object (thus avoiding memory leaks).
* Dynamic pointer casting (at runtime), parent-to-child type casting specifically.
* Being able to identify the script data in game saves (see #1371).

Following actions would be also potentially easier to implement if we had type indication and content description:
* Virtual methods (would need a runtime type reference mostly, full RTTI tables are probably not needed for this).
* Runtime debugging, such as watching the struct's fields in real-time, for example.

This is where RTTI feature comes from. The idea is to have a table of types and their contents, generated by the script compiler as an extra step, and written either as an extra (optional) part of a script data, or a separate file along with the game project.

This PR does the following:
1. Implements RTTI generation in both supported script compilers (classic ags3 and new ags4 one).
2. Serialize generated RTTI per script, as an extension to the script data.
3. The runtime interpreter creates a joint RTTI collection, updating it after each loaded script.
4. "--print-rtti" command arg, which makes engine print resulting joint collection on the each room load into the log (this seemed to be the most logical place to have this, as room script is the last loaded script).

`--print-rtti` command arg is useful for testing the resulting RTTI table.

Additionally, engine also creates "quick references" within the gathered RTTI, which is basically pointers between type and field structs. This allows for easier traversing of types and respective fields under the debugger.

---

### Generation

Currently the type information consists of an ID, a name, a location (where this type was declared), a parent's ID (if it has a parent), a set of flags which define type's kind, and a collection of fields.
The fully qualified type's name may be generated by combining a location's name (usually header or script name) and a type's name. This is required to be able to distinguish potential unrelated types of same names declared in different scripts.
Fields info contains: relative offset, name, typeid, and a set of flags which define field's kind and qualifiers.
The gathered data may be easily expanded in the future (also see notes to the serialization).

Compilers generate RTTI per each compiled script unit. Because of that the type's ID is a **local ID**, which is relative to this compiled unit only. The engine will have to use fully qualified names to map script's local ID with a global ID in a joint table.

---

### Serialization

The RTTI serialization format is designed having *ease of expansion* in mind. For that purpose it is not done as a single table with types and nested field items inside, but as a number of separate tables, where each table's entry has a *fixed size*. The RTTI header describes tables' offsets, and the fixed sizes of their items. The tables are connected using index references (meaning, an item in table 1 may refer to an item in table 2 using its index).

The advantages of such structure are:
* faster reading;
* faster and easier parsing, if one is e.g. writing a tool that does not read full data, but only wants to find particular item in a file stream;
* **much** easier extension: if you want to expand an existing item then you increase the fixed item's size in header, and even older program will still be able to read new data (although it will only understand old parts of data); if you want to add completely new kind of information then you add a new table, which may be easily skipped by a parser if it does not need it or does not know it.

Following is a format description.

**RTTI header**

field | type / size | comment
--|--|--
format | uint32 | for expanding the rtti format
header size | uint32 | size in bytes of a header (counting from "format" field, until header ends)
full rtti size | uint32 | size in bytes of a rtti data (counting from "format" field, until data ends)
location entry size | uint32 | fixed size of a location's description in bytes (may depend on format)
locations table offset | uint32 | a relative position of a locations table (in file)
num locations | uint32 | total number of location entries
type entry size | uint32 | fixed size of a type's description in bytes (may depend on format)
types table offset | uint32 | a relative position of a types table (in file)
num types | uint32 | total number of type entries
field entry size | uint32 | fixed size of a type field's description in bytes (may depend on format)
fields table offset | uint32 | a relative position of a type fields table (in file)
num type fields | uint32 | total number of all fields in all types
string table offset | uint32 | a relative position of a strings table (in file)
string table size | uint32 | total size of a string table, in bytes

**RTTI tables**
field | type / size | comment
--|--|--
location table | num locs * loc size | see "Location description" below
type table | num types * type size | see "Type description" below
fields table | num type fields * field entry size | see "Field description" below
string table | string table size | all RTTI null-terminated strings packed in a single array (separated by 0s)

**Location description**
field | type / size | comment
--|--|--
local id | uint32 | local ID of this location
name | uint32 | an offset of a name in a string table

**Type description**
field | type / size | comment
--|--|--
local id | uint32 | local ID of this type
name | uint32 | an offset of a name in a string table
location id | uint32 | ID of location this type was declared at
parent type | uint32 | local type ID; 0 if no parent
type flags | uint32 | may contains helper flags which simplify analyzing this type
size | uint32 | in bytes
num fields | uint32 | number of member fields this type has, 0 if none
field table index | uint32 | index of the first field in the fields table

**Field description**
field | type / size | comment
--|--|--
offset | uint32 | relative offset of this field, in bytes
name | uint32 | an offset of a name in a string table
type | uint32 | this field's local type ID
type flags | uint32 | may contains helper flags which simplify analyzing this member
num elements | uint32 | number of (array's) elements

---

### TODO

- [x] Make sure there's type with typeid 0 with a meaning "No Type" generated by each compiler (I think old compiler does not do this atm).
- [x] There's a nasty problem with fully qualified names taking extra space in a file and mem because of the repeated location (script) name. I'm investigating options, but possibly the type desc may contain a "location id" instead, and then either 1) location names are stored separately, 2) location names taken from section names in basic script data, 3) create a new table of "locations" inside RTTI (which may have some extra uses in the future).
- [x] Compiler should only put member name for fields, currently one or both of the compilers put Type::Member there instead, which is redundant.
- [x] Perhaps better format the `--print-rtti` output.
- [x] Might add explicit compiler option for generating & saving rtti.
- [x] I made Fields that are not array save "num elems" as 1, but maybe that's redundant (need to think this over).
