### PR TITLE
AGS 4: properly support managed pointers in managed structs

### DIFF
--- a/Common/script/cc_common.h
+++ b/Common/script/cc_common.h
@@ -31,7 +31,8 @@
 #define SCOPT_OLDSTRINGS    0x0080   // allow old-style strings
 #define SCOPT_UTF8          0x0100   // UTF-8 text mode
 #define SCOPT_RTTI          0x0200   // generate and export RTTI
-#define SCOPT_HIGHEST       SCOPT_RTTI
+#define SCOPT_RTTIOPS       0x0400   // enable syntax & opcodes that require RTTI to work
+#define SCOPT_HIGHEST       SCOPT_RTTIOPS
 
 extern void ccSetOption(int, int);
 extern int ccGetOption(int);

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -107,6 +107,7 @@
 #define SCMD_DYNAMICBOUNDS 71   // check reg1 is between 0 and m[MAR-4]
 #define SCMD_NEWARRAY     72    // reg1 = new array of reg1 elements, each of size arg2 (arg3=managed type?)
 #define SCMD_NEWUSEROBJECT 73   // reg1 = new user object of arg1 size
+#define SCMD_NEWUSEROBJECT2 74  // reg1, reg2 = new user object of arg1 type and arg2 size
 
 #define CC_NUM_SCCMDS     74
 #define MAX_SCMD_ARGS     3     // maximal possible number of arguments

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -106,10 +106,11 @@
 #define SCMD_JNZ          70    // jump to arg1 if ax!=0
 #define SCMD_DYNAMICBOUNDS 71   // check reg1 is between 0 and m[MAR-4]
 #define SCMD_NEWARRAY     72    // reg1 = new array of reg1 elements, each of size arg2 (arg3=managed type?)
-#define SCMD_NEWUSEROBJECT 73   // reg1 = new user object of arg1 size
-#define SCMD_NEWUSEROBJECT2 74  // reg1, reg2 = new user object of arg1 type and arg2 size
+#define SCMD_NEWUSEROBJECT 73   // reg1 = new user object of arg2 size
+#define SCMD_NEWUSEROBJECT2 74  // reg1 = new user object of arg2 type and arg3 size
+#define SCMD_NEWARRAY2    75    // reg1 = new array of reg1 elements, arg2 type and arg3 size
 
-#define CC_NUM_SCCMDS     75
+#define CC_NUM_SCCMDS     76
 #define MAX_SCMD_ARGS     3     // maximal possible number of arguments
 
 #define EXPORT_FUNCTION   1

--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -109,7 +109,7 @@
 #define SCMD_NEWUSEROBJECT 73   // reg1 = new user object of arg1 size
 #define SCMD_NEWUSEROBJECT2 74  // reg1, reg2 = new user object of arg1 type and arg2 size
 
-#define CC_NUM_SCCMDS     74
+#define CC_NUM_SCCMDS     75
 #define MAX_SCMD_ARGS     3     // maximal possible number of arguments
 
 #define EXPORT_FUNCTION   1

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -19,6 +19,7 @@
 #define __CC_REFLECT_H
 
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 #include "core/types.h"
@@ -66,7 +67,10 @@ public:
     enum FieldFlags
     {
         kField_ManagedPtr = 0x0001,
-        kField_Array      = 0x0002
+        kField_Array      = 0x0002,
+        // We use "generated" flag to mark fields that are created at runtime
+        // and are intended to be replaced by "true" fields later
+        kField_Generated  = 0x80000000
     };
 
     // An "undefined type" id value

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -59,6 +59,9 @@ public:
         kField_Array      = 0x0002
     };
 
+    // Size of a "pointer" in the script memory
+    const static size_t PointerSize = sizeof(uint32_t);
+
     struct Field;
 
     // Location info: a context, in which a symbol

--- a/Common/script/cc_reflect.h
+++ b/Common/script/cc_reflect.h
@@ -59,6 +59,8 @@ public:
         kField_Array      = 0x0002
     };
 
+    // An "undefined type" id value
+    const static uint32_t NoType = 0u;
     // Size of a "pointer" in the script memory
     const static size_t PointerSize = sizeof(uint32_t);
 

--- a/Compiler/script/cs_compiler.cpp
+++ b/Compiler/script/cs_compiler.cpp
@@ -22,6 +22,9 @@ void ccGetExtensions(std::vector<std::string> &exts)
 {
     // TODO: we may consider creating a managed user object an extension, etc,
     // although it was introduced years ago when extensions were not declared.
+
+    // Managed ptr in managed structs
+    exts.push_back("NESTEDPOINTERS");
     return;
 }
 

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -2447,7 +2447,9 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
             return -1;
           }
 
-          scrip->write_cmd3(SCMD_NEWARRAY, SREG_AX, size, isManagedType);
+          // TODO: switch between old and new "new", depending on option in compiler
+          //scrip->write_cmd3(SCMD_NEWARRAY, SREG_AX, size, isManagedType);
+          scrip->write_cmd3(SCMD_NEWARRAY2, SREG_AX, arrayType, size);
           scrip->ax_val_type = arrayType | STYPE_DYNARRAY;
 
           if (isManagedType)

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -2461,7 +2461,9 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
             return -1;
           }
           const size_t size = sym.entries[symlist[oploc + 1]].ssize;
-          scrip->write_cmd2(SCMD_NEWUSEROBJECT, SREG_AX, size);
+          // TODO: switch between old and new "new", depending on option in compiler
+          //scrip->write_cmd2(SCMD_NEWUSEROBJECT, SREG_AX, size);
+          scrip->write_cmd3(SCMD_NEWUSEROBJECT2, SREG_AX, symlist[oploc + 1], size);
           scrip->ax_val_type = symlist[oploc + 1] | STYPE_POINTER;
       }
 

--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -2447,9 +2447,11 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
             return -1;
           }
 
-          // TODO: switch between old and new "new", depending on option in compiler
-          //scrip->write_cmd3(SCMD_NEWARRAY, SREG_AX, size, isManagedType);
-          scrip->write_cmd3(SCMD_NEWARRAY2, SREG_AX, arrayType, size);
+          // Choose between "old" and new "new" opcode, depending on RTTI switch
+          if (ccGetOption(SCOPT_RTTIOPS))
+              scrip->write_cmd3(SCMD_NEWARRAY2, SREG_AX, arrayType, size);
+          else
+              scrip->write_cmd3(SCMD_NEWARRAY, SREG_AX, size, isManagedType);
           scrip->ax_val_type = arrayType | STYPE_DYNARRAY;
 
           if (isManagedType)
@@ -2463,9 +2465,11 @@ int parse_sub_expr(long*symlist,int listlen,ccCompiledScript*scrip) {
             return -1;
           }
           const size_t size = sym.entries[symlist[oploc + 1]].ssize;
-          // TODO: switch between old and new "new", depending on option in compiler
-          //scrip->write_cmd2(SCMD_NEWUSEROBJECT, SREG_AX, size);
-          scrip->write_cmd3(SCMD_NEWUSEROBJECT2, SREG_AX, symlist[oploc + 1], size);
+          // Choose between "old" and new "new" opcode, depending on RTTI switch
+          if (ccGetOption(SCOPT_RTTIOPS))
+              scrip->write_cmd3(SCMD_NEWUSEROBJECT2, SREG_AX, symlist[oploc + 1], size);
+          else
+              scrip->write_cmd2(SCMD_NEWUSEROBJECT, SREG_AX, size);
           scrip->ax_val_type = symlist[oploc + 1] | STYPE_POINTER;
       }
 
@@ -3712,8 +3716,9 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                     cc_error("Member variable cannot be struct");
                     return -1;
                 }
-                if ((member_is_pointer) && (sym.entries[stname].flags & SFLG_MANAGED) && (!member_is_import)) {
-                    cc_error("Member variable of managed struct cannot be pointer");
+                if (!ccGetOption(SCOPT_RTTIOPS) &&
+                    ((member_is_pointer) && (sym.entries[stname].flags & SFLG_MANAGED) && (!member_is_import))) {
+                    cc_error("Member variable of managed struct cannot be pointer (RTTI is not enabled)");
                     return -1;
                 }
                 else if ((sym.entries[cursym].flags & SFLG_MANAGED) && (!member_is_pointer)) {
@@ -3897,8 +3902,9 @@ int __cc_compile_file(const char*inpl,ccCompiledScript*scrip) {
                             int array_size;
 
                             if (sym.get_type(nextt) == SYM_CLOSEBRACKET) {
-                                if ((sym.entries[stname].flags & SFLG_MANAGED)) {
-                                    cc_error("Member variable of managed struct cannot be dynamic array");
+                                if (!ccGetOption(SCOPT_RTTIOPS) &&
+                                        (sym.entries[stname].flags & SFLG_MANAGED)) {
+                                    cc_error("Member variable of managed struct cannot be dynamic array  (RTTI is not enabled)");
                                     return -1;
                                 }
                                 sym.entries[stname].flags |= SFLG_HASDYNAMICARRAY;

--- a/Compiler/script2/cs_compiler.cpp
+++ b/Compiler/script2/cs_compiler.cpp
@@ -18,6 +18,8 @@ void ccGetExtensions2(std::vector<std::string> &exts)
     // of a new compiler. Feel free to add more, specifying each
     // new added feature individually.
     exts.push_back("AGS4");
+    // Managed ptr in managed structs
+    exts.push_back("NESTEDPOINTERS");
 }
 
 

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1964,8 +1964,9 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
     else
         WriteCmd(SCMD_NEWUSEROBJECT, SREG_AX, element_size);
     */
+    element_vartype = _sym.GetFirstBaseVartype(element_vartype);
     if (with_bracket_expr)
-        WriteCmd(SCMD_NEWARRAY, SREG_AX, element_size, is_managed); // TODO: array2 cmd
+        WriteCmd(SCMD_NEWARRAY2, SREG_AX, element_vartype, element_size);
     else
         WriteCmd(SCMD_NEWUSEROBJECT2, SREG_AX, element_vartype, element_size);
     _reg_track.SetRegister(SREG_AX);

--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1957,10 +1957,17 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
         // The Engine really doesn't like that (division by zero error)
         InternalError("Trying to emit allocation of zero dynamic memory");
 
+    // TODO: switch between old and new "new", depending on option in compiler
+    /*
     if (with_bracket_expr)
         WriteCmd(SCMD_NEWARRAY, SREG_AX, element_size, is_managed);
     else
         WriteCmd(SCMD_NEWUSEROBJECT, SREG_AX, element_size);
+    */
+    if (with_bracket_expr)
+        WriteCmd(SCMD_NEWARRAY, SREG_AX, element_size, is_managed); // TODO: array2 cmd
+    else
+        WriteCmd(SCMD_NEWUSEROBJECT2, SREG_AX, element_vartype, element_size);
     _reg_track.SetRegister(SREG_AX);
 
     eres.Type = eres.kTY_RunTimeValue;

--- a/Editor/AGS.Native/ScriptCompiler.cpp
+++ b/Editor/AGS.Native/ScriptCompiler.cpp
@@ -63,6 +63,7 @@ namespace AGS
                 SCOPT_OLDSTRINGS * (!game->Settings->EnforceNewStrings) |
                 SCOPT_UTF8 * (game->UnicodeMode) |
                 SCOPT_RTTI |
+                SCOPT_RTTIOPS |
                 false;
 
         if (game->Settings->ExtendedCompiler)

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(engine
     ac/dynobj/cc_audiochannel.h
     ac/dynobj/cc_audioclip.cpp
     ac/dynobj/cc_audioclip.h
+    ac/dynobj/cc_basicobject.h
     ac/dynobj/cc_character.cpp
     ac/dynobj/cc_character.h
     ac/dynobj/cc_dialog.cpp
@@ -74,6 +75,7 @@ target_sources(engine
     ac/dynobj/cc_inventory.h
     ac/dynobj/cc_object.cpp
     ac/dynobj/cc_object.h
+    ac/dynobj/cc_pluginobject.h
     ac/dynobj/cc_region.cpp
     ac/dynobj/cc_region.h
     ac/dynobj/cc_serializer.cpp

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -408,6 +408,8 @@ target_sources(engine
     resource/resource.h
     script/cc_instance.cpp
     script/cc_instance.h
+    script/cc_reflecthelper.cpp
+    script/cc_reflecthelper.h
     script/executingscript.cpp
     script/executingscript.h
     script/exports.cpp

--- a/Engine/ac/dynobj/cc_agsdynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.cpp
@@ -20,11 +20,6 @@ using namespace AGS::Common;
 
 // *** The script serialization routines for built-in types
 
-int AGSCCDynamicObject::Dispose(const char* /*address*/, bool /*force*/) {
-    // cannot be removed from memory
-    return 0;
-}
-
 int AGSCCDynamicObject::Serialize(const char *address, char *buffer, int bufsize) {
     // If the required space is larger than the provided buffer,
     // then return negated required space, notifying the caller that a larger buffer is necessary
@@ -35,59 +30,4 @@ int AGSCCDynamicObject::Serialize(const char *address, char *buffer, int bufsize
     MemoryStream mems(reinterpret_cast<uint8_t*>(buffer), bufsize, kStream_Write);
     Serialize(address, &mems);
     return static_cast<int32_t>(mems.GetPosition());
-}
-
-const char* AGSCCDynamicObject::GetFieldPtr(const char *address, intptr_t offset)
-{
-    return address + offset;
-}
-
-void AGSCCDynamicObject::Read(const char *address, intptr_t offset, void *dest, int size)
-{
-    memcpy(dest, address + offset, size);
-}
-
-uint8_t AGSCCDynamicObject::ReadInt8(const char *address, intptr_t offset)
-{
-    return *(uint8_t*)(address + offset);
-}
-
-int16_t AGSCCDynamicObject::ReadInt16(const char *address, intptr_t offset)
-{
-    return *(int16_t*)(address + offset);
-}
-
-int32_t AGSCCDynamicObject::ReadInt32(const char *address, intptr_t offset)
-{
-    return *(int32_t*)(address + offset);
-}
-
-float AGSCCDynamicObject::ReadFloat(const char *address, intptr_t offset)
-{
-    return *(float*)(address + offset);
-}
-
-void AGSCCDynamicObject::Write(const char *address, intptr_t offset, void *src, int size)
-{
-    memcpy((void*)(address + offset), src, size);
-}
-
-void AGSCCDynamicObject::WriteInt8(const char *address, intptr_t offset, uint8_t val)
-{
-    *(uint8_t*)(address + offset) = val;
-}
-
-void AGSCCDynamicObject::WriteInt16(const char *address, intptr_t offset, int16_t val)
-{
-    *(int16_t*)(address + offset) = val;
-}
-
-void AGSCCDynamicObject::WriteInt32(const char *address, intptr_t offset, int32_t val)
-{
-    *(int32_t*)(address + offset) = val;
-}
-
-void AGSCCDynamicObject::WriteFloat(const char *address, intptr_t offset, float val)
-{
-    *(float*)(address + offset) = val;
 }

--- a/Engine/ac/dynobj/cc_agsdynamicobject.h
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.h
@@ -30,6 +30,9 @@ public:
     int Serialize(const char *address, char *buffer, int bufsize) override;
     // Try unserializing the object from the given input stream
     virtual void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) = 0;
+    // Remap typeid fields using the provided map
+    void RemapTypeids(const char *address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) override { /* do nothing */}
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/cc_agsdynamicobject.h
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.h
@@ -14,40 +14,20 @@
 #ifndef __AC_CCDYNAMICOBJECT_H
 #define __AC_CCDYNAMICOBJECT_H
 
-#include "ac/dynobj/cc_dynamicobject.h"
+#include "ac/dynobj/cc_basicobject.h"
 
 namespace AGS { namespace Common { class Stream; } }
 
 
-struct AGSCCDynamicObject : ICCDynamicObject {
+struct AGSCCDynamicObject : CCBasicObject {
 protected:
     virtual ~AGSCCDynamicObject() = default;
-public:
-    // default implementation
-    int Dispose(const char *address, bool force) override;
 
-    // TODO: pass savegame format version
+public:
+    // TODO: how to pass savegame format version (???)
     int Serialize(const char *address, char *buffer, int bufsize) override;
     // Try unserializing the object from the given input stream
     virtual void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) = 0;
-    // Remap typeid fields using the provided map
-    void RemapTypeids(const char *address,
-        const std::unordered_map<uint32_t, uint32_t> &typeid_map) override { /* do nothing */}
-    // Traverse all managed references in this object, and run callback for each of them
-    void TraverseRefs(const char *address, PfnTraverseRefOp traverse_op) override { /* do nothing */}
-
-    // Legacy support for reading and writing object values by their relative offset
-    const char* GetFieldPtr(const char *address, intptr_t offset) override;
-    void    Read(const char *address, intptr_t offset, void *dest, int size) override;
-    uint8_t ReadInt8(const char *address, intptr_t offset) override;
-    int16_t ReadInt16(const char *address, intptr_t offset) override;
-    int32_t ReadInt32(const char *address, intptr_t offset) override;
-    float   ReadFloat(const char *address, intptr_t offset) override;
-    void    Write(const char *address, intptr_t offset, void *src, int size) override;
-    void    WriteInt8(const char *address, intptr_t offset, uint8_t val) override;
-    void    WriteInt16(const char *address, intptr_t offset, int16_t val) override;
-    void    WriteInt32(const char *address, intptr_t offset, int32_t val) override;
-    void    WriteFloat(const char *address, intptr_t offset, float val) override;
 
 protected:
     // Savegame serialization

--- a/Engine/ac/dynobj/cc_agsdynamicobject.h
+++ b/Engine/ac/dynobj/cc_agsdynamicobject.h
@@ -33,6 +33,8 @@ public:
     // Remap typeid fields using the provided map
     void RemapTypeids(const char *address,
         const std::unordered_map<uint32_t, uint32_t> &typeid_map) override { /* do nothing */}
+    // Traverse all managed references in this object, and run callback for each of them
+    void TraverseRefs(const char *address, PfnTraverseRefOp traverse_op) override { /* do nothing */}
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/cc_audiochannel.cpp
+++ b/Engine/ac/dynobj/cc_audiochannel.cpp
@@ -36,5 +36,5 @@ void CCAudioChannel::Serialize(const char *address, Stream *out) {
 
 void CCAudioChannel::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int id = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrAudioChannel[id], this);
+    ccRegisterUnserializedPersistentObject(index, &scrAudioChannel[id], this);
 }

--- a/Engine/ac/dynobj/cc_audioclip.cpp
+++ b/Engine/ac/dynobj/cc_audioclip.cpp
@@ -36,5 +36,5 @@ void CCAudioClip::Serialize(const char *address, Stream *out) {
 
 void CCAudioClip::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int id = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &game.audioClips[id], this);
+    ccRegisterUnserializedPersistentObject(index, &game.audioClips[id], this);
 }

--- a/Engine/ac/dynobj/cc_basicobject.h
+++ b/Engine/ac/dynobj/cc_basicobject.h
@@ -1,0 +1,116 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Basic implementation of the dynamic object interface,
+// intended to be used as a parent for object/manager classes that do not
+// require specific implementation.
+//
+//=============================================================================
+#ifndef __AGS_EE_DYNOBJ__BASICOBJECT_H
+#define __AGS_EE_DYNOBJ__BASICOBJECT_H
+
+#include <string.h> // memcpy
+#include "ac/dynobj/cc_dynamicobject.h"
+
+
+struct CCBasicObject : ICCDynamicObject
+{
+protected:
+    virtual ~CCBasicObject() = default;
+
+public:
+    // Dispose the object
+    int Dispose(const char* /*address*/, bool /*force*/) override
+    {
+        // cannot be removed from memory
+        return 0;
+    }
+    // Serialize the object into BUFFER (which is BUFSIZE bytes)
+    // return number of bytes used
+    int Serialize(const char* /*address*/, char* /*buffer*/, int /*bufsize*/) override
+    {
+        return 0; // does not save data
+    }
+    // Remap typeid fields using the provided map
+    void RemapTypeids(const char* /*address*/,
+        const std::unordered_map<uint32_t, uint32_t>& /*typeid_map*/) override
+    {
+        /* do nothing */
+    }
+    // Traverse all managed references in this object, and run callback for each of them
+    void TraverseRefs(const char* /*address*/, PfnTraverseRefOp /*traverse_op*/) override
+    {
+        /* do nothing */
+    }
+
+    //
+    // Legacy support for reading and writing object fields by their relative offset
+    //
+    const char* GetFieldPtr(const char* address, intptr_t offset) override
+    {
+        return address + offset;
+    }
+
+    void Read(const char* address, intptr_t offset, void* dest, int size) override
+    {
+        memcpy(dest, address + offset, size);
+    }
+
+    uint8_t ReadInt8(const char* address, intptr_t offset) override
+    {
+        return *(uint8_t*)(address + offset);
+    }
+
+    int16_t ReadInt16(const char* address, intptr_t offset) override
+    {
+        return *(int16_t*)(address + offset);
+    }
+
+    int32_t ReadInt32(const char* address, intptr_t offset) override
+    {
+        return *(int32_t*)(address + offset);
+    }
+
+    float ReadFloat(const char* address, intptr_t offset) override
+    {
+        return *(float*)(address + offset);
+    }
+
+    void Write(const char* address, intptr_t offset, void* src, int size) override
+    {
+        memcpy((void*)(address + offset), src, size);
+    }
+
+    void WriteInt8(const char* address, intptr_t offset, uint8_t val) override
+    {
+        *(uint8_t*)(address + offset) = val;
+    }
+
+    void WriteInt16(const char* address, intptr_t offset, int16_t val) override
+    {
+        *(int16_t*)(address + offset) = val;
+    }
+
+    void WriteInt32(const char* address, intptr_t offset, int32_t val) override
+    {
+        *(int32_t*)(address + offset) = val;
+    }
+
+    void WriteFloat(const char* address, intptr_t offset, float val) override
+    {
+        *(float*)(address + offset) = val;
+    }
+};
+
+#endif // __AGS_EE_DYNOBJ__BASICOBJECT_H

--- a/Engine/ac/dynobj/cc_character.cpp
+++ b/Engine/ac/dynobj/cc_character.cpp
@@ -40,7 +40,7 @@ void CCCharacter::Serialize(const char *address, Stream *out) {
 
 void CCCharacter::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &game.chars[num], this);
+    ccRegisterUnserializedPersistentObject(index, &game.chars[num], this);
 }
 
 uint8_t CCCharacter::ReadInt8(const char *address, intptr_t offset)

--- a/Engine/ac/dynobj/cc_dialog.cpp
+++ b/Engine/ac/dynobj/cc_dialog.cpp
@@ -36,5 +36,5 @@ void CCDialog::Serialize(const char *address, Stream *out) {
 
 void CCDialog::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrDialog[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrDialog[num], this);
 }

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -128,6 +128,15 @@ DynObjectRef CCDynamicArray::CreateImpl(uint32_t type_id, bool is_managed, uint3
     return DynObjectRef(handle, obj_ptr);
 }
 
+void CCDynamicArray::RemapTypeids(const char *address,
+    const std::unordered_map<uint32_t, uint32_t> &typeid_map)
+{
+    Header &hdr = (Header&)GetHeader(address);
+    const auto it = typeid_map.find(hdr.TypeID);
+    assert(it != typeid_map.end());
+    hdr.TypeID = (it != typeid_map.end()) ? it->second : 0u;
+}
+
 
 const char* CCDynamicArray::GetFieldPtr(const char *address, intptr_t offset)
 {

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -105,6 +105,10 @@ void CCDynamicArray::RemapTypeids(const char *address,
 
 void CCDynamicArray::TraverseRefs(const char *address, PfnTraverseRefOp traverse_op)
 {
+    // TODO: may be a bit faster if we make a "runtime type"
+    // struct, merging joint type info and auxiliary helper data,
+    // and store a pointer in the arr data.
+    // might also have a dummy "type" for "unknown type" arrays.
     const Header &hdr = GetHeader(address);
     const uint32_t type_id = hdr.TypeID & (~ARRAY_MANAGED_TYPE_FLAG);
     bool is_managed = (hdr.TypeID & ARRAY_MANAGED_TYPE_FLAG) != 0;

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -99,7 +99,7 @@ void CCDynamicArray::RemapTypeids(const char *address,
 {
     Header &hdr = (Header&)GetHeader(address);
     const auto it = typeid_map.find(hdr.TypeID);
-    assert(it != typeid_map.end());
+    assert(hdr.TypeID == 0u || it != typeid_map.end());
     hdr.TypeID = (it != typeid_map.end()) ? it->second : 0u;
 }
 

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -40,7 +40,10 @@ int CCDynamicArray::Dispose(const char *address, bool force)
         bool is_managed = (hdr.TypeID & ARRAY_MANAGED_TYPE_FLAG) != 0;
         const RTTI::Type *ti = nullptr;
         if (type_id > 0)
-             ti = &ccInstance::GetRTTI()->GetTypes()[type_id];
+        {
+            assert(ccInstance::GetRTTI()->GetTypes().size() > type_id);
+            ti = &ccInstance::GetRTTI()->GetTypes()[type_id];
+        }
 
         if (is_managed)
         { // Dynamic array of managed pointers: subref them directly

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -93,17 +93,14 @@ int CCDynamicArray::Serialize(const char *address, char *buffer, int bufsize)
     return static_cast<int32_t>(mems.GetPosition());
 }
 
-void CCDynamicArray::Unserialize(int index, const char *serializedData, int dataSize)
+void CCDynamicArray::Unserialize(int index, Stream *in, size_t data_sz)
 {
-    // TODO: should we support older save versions here?
-    // might have to use class name (GetType) to distinguish save formats in UnSerializer
-    char *new_arr = new char[(dataSize - FileHeaderSz) + MemHeaderSz];
-    MemoryStream mems(reinterpret_cast<const uint8_t*>(serializedData), dataSize);
+    char *new_arr = new char[(data_sz - FileHeaderSz) + MemHeaderSz];
     Header &hdr = reinterpret_cast<Header&>(*new_arr);
-    hdr.TypeID = mems.ReadInt32();
-    hdr.ElemCount = mems.ReadInt32();
-    hdr.TotalSize = hdr.ElemCount * mems.ReadInt32(); // elem size
-    memcpy(new_arr + MemHeaderSz, serializedData + FileHeaderSz, dataSize - FileHeaderSz);
+    hdr.TypeID = in->ReadInt32();
+    hdr.ElemCount = in->ReadInt32();
+    hdr.TotalSize = hdr.ElemCount * in->ReadInt32(); // elem size
+    in->Read(new_arr + MemHeaderSz, data_sz - FileHeaderSz);
     ccRegisterUnserializedObject(index, &new_arr[MemHeaderSz], this);
 }
 

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -35,7 +35,7 @@ int CCDynamicArray::Dispose(const char *address, bool force)
     // in which case just ignore these.
     if (!force)
     {
-        TraverseRefs(address, [](int handle) { pool.SubRef(handle); });
+        TraverseRefs(address, [](int handle) { pool.SubRefNoCheck(handle); });
     }
 
     delete[] (address - MemHeaderSz);

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -45,7 +45,7 @@ public:
     // serialize the object into BUFFER (which is BUFSIZE bytes)
     // return number of bytes used
     int Serialize(const char *address, char *buffer, int bufsize) override;
-    virtual void Unserialize(int index, const char *serializedData, int dataSize);
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz);
     // Create managed array object and return a pointer to the beginning of a buffer
     DynObjectRef CreateOld(uint32_t elem_count, uint32_t elem_size, bool isManagedType)
         { return CreateImpl(0u, isManagedType, elem_count, elem_size); }

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -15,11 +15,12 @@
 #define __CC_DYNAMICARRAY_H
 
 #include <vector>
+#include <unordered_map>
 #include "ac/dynobj/cc_dynamicobject.h"   // ICCDynamicObject
 
 #define ARRAY_MANAGED_TYPE_FLAG    0x80000000
 
-struct CCDynamicArray final : ICCDynamicObject
+struct CCDynamicArray final : ICCDynamicObject, ICCTypeidBased
 {
 public:
     static const char *TypeName;
@@ -51,6 +52,10 @@ public:
         { return CreateImpl(0u, isManagedType, elem_count, elem_size); }
     DynObjectRef CreateNew(uint32_t type_id, uint32_t elem_count, uint32_t elem_size)
         { return CreateImpl(type_id, false, elem_count, elem_size); }
+
+    // Remap typeid fields using the provided map
+    void RemapTypeids(const char* address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) override;
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -20,7 +20,7 @@
 
 #define ARRAY_MANAGED_TYPE_FLAG    0x80000000
 
-struct CCDynamicArray final : ICCDynamicObject, ICCTypeidBased
+struct CCDynamicArray final : ICCDynamicObject
 {
 public:
     static const char *TypeName;

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -69,7 +69,7 @@ private:
     // The size of the array's header in memory, prepended to the element data
     static const size_t MemHeaderSz = sizeof(uint32_t) * 3;
     // The size of the serialized header
-    static const size_t FileHeaderSz = sizeof(uint32_t) * 2;
+    static const size_t FileHeaderSz = sizeof(uint32_t) * 3;
 
     DynObjectRef CreateImpl(uint32_t type_id, bool is_managed, uint32_t elem_count, uint32_t elem_size);
 };

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -56,6 +56,8 @@ public:
     // Remap typeid fields using the provided map
     void RemapTypeids(const char* address,
         const std::unordered_map<uint32_t, uint32_t> &typeid_map) override;
+    // Traverse all managed references in this object, and run callback for each of them
+    void TraverseRefs(const char *address, PfnTraverseRefOp traverse_op) override;
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/cc_dynamicarray.h
+++ b/Engine/ac/dynobj/cc_dynamicarray.h
@@ -26,7 +26,9 @@ public:
 
     struct Header
     {
+        // Type id of elements, refering the RTTI
         // May contain ARRAY_MANAGED_TYPE_FLAG
+        uint32_t TypeID = 0u;
         uint32_t ElemCount = 0u;
         // TODO: refactor and store "elem size" instead
         uint32_t TotalSize = 0u;
@@ -45,7 +47,10 @@ public:
     int Serialize(const char *address, char *buffer, int bufsize) override;
     virtual void Unserialize(int index, const char *serializedData, int dataSize);
     // Create managed array object and return a pointer to the beginning of a buffer
-    DynObjectRef Create(int numElements, int elementSize, bool isManagedType);
+    DynObjectRef CreateOld(uint32_t elem_count, uint32_t elem_size, bool isManagedType)
+        { return CreateImpl(0u, isManagedType, elem_count, elem_size); }
+    DynObjectRef CreateNew(uint32_t type_id, uint32_t elem_count, uint32_t elem_size)
+        { return CreateImpl(type_id, false, elem_count, elem_size); }
 
     // Legacy support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;
@@ -62,9 +67,11 @@ public:
 
 private:
     // The size of the array's header in memory, prepended to the element data
-    static const size_t MemHeaderSz = sizeof(uint32_t) * 2;
+    static const size_t MemHeaderSz = sizeof(uint32_t) * 3;
     // The size of the serialized header
     static const size_t FileHeaderSz = sizeof(uint32_t) * 2;
+
+    DynObjectRef CreateImpl(uint32_t type_id, bool is_managed, uint32_t elem_count, uint32_t elem_size);
 };
 
 extern CCDynamicArray globalDynamicArray;

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -50,8 +50,13 @@ extern int32_t ccRegisterPersistentObject(const void *object, ICCDynamicObject *
 
 // register a de-serialized object
 int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *callback,
-                                     bool plugin_object, bool persistent) {
-    return pool.AddUnserializedObject((const char*)object, callback, index, plugin_object, persistent);
+                                     bool plugin_object) {
+    return pool.AddUnserializedObject((const char*)object, callback, index, plugin_object, false);
+}
+
+int32_t ccRegisterUnserializedPersistentObject(int index, const void *object, ICCDynamicObject *callback) {
+    return pool.AddUnserializedObject((const char*)object, callback, index, false, true);
+    // don't add ref, as it should come with the save data
 }
 
 // unregister a particular object

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -141,5 +141,5 @@ int ccReleaseObjectReference(int32_t handle) {
         return -1;
     }
 
-    return pool.SubRef(handle);
+    return pool.SubRefCheckDispose(handle);
 }

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -66,7 +66,7 @@ int ccUnRegisterManagedObject(const void *object) {
 
 // remove all registered objects
 void ccUnregisterAllObjects() {
-    pool.reset();
+    pool.Reset();
 }
 
 // serialize all objects to disk

--- a/Engine/ac/dynobj/cc_dynamicobject.cpp
+++ b/Engine/ac/dynobj/cc_dynamicobject.cpp
@@ -33,17 +33,25 @@ void ccSetStringClassImpl(ICCStringClass *theClass) {
 // register a memory handle for the object and allow script
 // pointers to point to it
 int32_t ccRegisterManagedObject(const void *object, ICCDynamicObject *callback, bool plugin_object) {
-    int32_t handl = pool.AddObject((const char*)object, callback, plugin_object);
+    return pool.AddObject((const char*)object, callback, plugin_object, false);
+}
 
-    ManagedObjectLog("Register managed object type '%s' handle=%d addr=%08X",
-        ((callback == NULL) ? "(unknown)" : callback->GetType()), handl, object);
+int32_t ccRegisterManagedObjectAndRef(const void *object, ICCDynamicObject *callback) {
+    int32_t handle = pool.AddObject((const char*)object, callback, false, false);
+    pool.AddRef(handle);
+    return handle;
+}
 
-    return handl;
+extern int32_t ccRegisterPersistentObject(const void *object, ICCDynamicObject *callback) {
+    int32_t handle = pool.AddObject((const char*)object, callback, false, true);
+    pool.AddRef(handle);
+    return handle;
 }
 
 // register a de-serialized object
-int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *callback, bool plugin_object) {
-    return pool.AddUnserializedObject((const char*)object, callback, plugin_object, index);
+int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *callback,
+                                     bool plugin_object, bool persistent) {
+    return pool.AddUnserializedObject((const char*)object, callback, index, plugin_object, persistent);
 }
 
 // unregister a particular object

--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -117,7 +117,9 @@ extern int32_t ccRegisterManagedObjectAndRef(const void *object, ICCDynamicObjec
 // register a new object and mark it persistent (always referenced by the engine)
 extern int32_t ccRegisterPersistentObject(const void *object, ICCDynamicObject *callback);
 // register a de-serialized object
-extern int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *, bool plugin_object = false, bool persistent = true);
+extern int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *, bool plugin_object = false);
+// register a de-serialized object and mark it persistent (always referenced by the engine)
+extern int32_t ccRegisterUnserializedPersistentObject(int index, const void *object, ICCDynamicObject *);
 // unregister a particular object
 extern int   ccUnRegisterManagedObject(const void *object);
 // remove all registered objects

--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -18,6 +18,7 @@
 #ifndef __CC_DYNAMICOBJECT_H
 #define __CC_DYNAMICOBJECT_H
 
+#include <unordered_map>
 #include <utility>
 #include "core/types.h"
 
@@ -77,12 +78,24 @@ protected:
     ~ICCDynamicObject() = default;
 };
 
+// Managed String class interface
+struct ICCStringClass {
+    virtual DynObjectRef CreateString(const char *fromText) = 0;
+};
+
+// Interface of the managed object that contains typeid fields.
+// Provides means for remapping typeid, e.g. upon save restoration.
+struct ICCTypeidBased {
+    // Remap typeid fields using the provided map
+    virtual void RemapTypeids(const char *address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) = 0;
+};
+
+// Managed object deserializer interface.
+// Is supposed to create an object based on object type, and add one to the managed pool
 struct ICCObjectReader {
     // TODO: pass savegame format version
     virtual void Unserialize(int index, const char *objectType, const char *serializedData, int dataSize) = 0;
-};
-struct ICCStringClass {
-    virtual DynObjectRef CreateString(const char *fromText) = 0;
 };
 
 // set the class that will be used for dynamic strings

--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -48,6 +48,13 @@ struct ICCDynamicObject {
     // TODO: pass savegame format version
     virtual int Serialize(const char *address, char *buffer, int bufsize) = 0;
 
+    //
+    // Interface of a managed object that contains typeid fields.
+    // Remap typeid fields using the provided map
+    virtual void RemapTypeids(const char *address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) = 0;
+
+
     // Legacy support for reading and writing object values by their relative offset.
     // WARNING: following were never a part of plugin API, therefore these methods
     // should **never** be called for kScValPluginObject script objects!
@@ -81,14 +88,6 @@ protected:
 // Managed String class interface
 struct ICCStringClass {
     virtual DynObjectRef CreateString(const char *fromText) = 0;
-};
-
-// Interface of the managed object that contains typeid fields.
-// Provides means for remapping typeid, e.g. upon save restoration.
-struct ICCTypeidBased {
-    // Remap typeid fields using the provided map
-    virtual void RemapTypeids(const char *address,
-        const std::unordered_map<uint32_t, uint32_t> &typeid_map) = 0;
 };
 
 // Managed object deserializer interface.

--- a/Engine/ac/dynobj/cc_dynamicobject.h
+++ b/Engine/ac/dynobj/cc_dynamicobject.h
@@ -111,9 +111,13 @@ struct ICCObjectReader {
 extern void  ccSetStringClassImpl(ICCStringClass *theClass);
 // register a memory handle for the object and allow script
 // pointers to point to it
-extern int32_t ccRegisterManagedObject(const void *object, ICCDynamicObject *, bool plugin_object = false);
+extern int32_t ccRegisterManagedObject(const void *object, ICCDynamicObject *callback, bool plugin_object = false);
+// register a new object and add a reference count
+extern int32_t ccRegisterManagedObjectAndRef(const void *object, ICCDynamicObject *callback);
+// register a new object and mark it persistent (always referenced by the engine)
+extern int32_t ccRegisterPersistentObject(const void *object, ICCDynamicObject *callback);
 // register a de-serialized object
-extern int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *, bool plugin_object = false);
+extern int32_t ccRegisterUnserializedObject(int index, const void *object, ICCDynamicObject *, bool plugin_object = false, bool persistent = true);
 // unregister a particular object
 extern int   ccUnRegisterManagedObject(const void *object);
 // remove all registered objects

--- a/Engine/ac/dynobj/cc_gui.cpp
+++ b/Engine/ac/dynobj/cc_gui.cpp
@@ -37,5 +37,5 @@ void CCGUI::Serialize(const char *address, Stream *out) {
 
 void CCGUI::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrGui[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrGui[num], this);
 }

--- a/Engine/ac/dynobj/cc_guiobject.cpp
+++ b/Engine/ac/dynobj/cc_guiobject.cpp
@@ -38,5 +38,5 @@ void CCGUIObject::Serialize(const char *address, Stream *out) {
 void CCGUIObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int guinum = in->ReadInt32();
     int objnum = in->ReadInt32();
-    ccRegisterUnserializedObject(index, guis[guinum].GetControl(objnum), this);
+    ccRegisterUnserializedPersistentObject(index, guis[guinum].GetControl(objnum), this);
 }

--- a/Engine/ac/dynobj/cc_hotspot.cpp
+++ b/Engine/ac/dynobj/cc_hotspot.cpp
@@ -38,5 +38,5 @@ void CCHotspot::Serialize(const char *address, Stream *out) {
 
 void CCHotspot::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrHotspot[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrHotspot[num], this);
 }

--- a/Engine/ac/dynobj/cc_inventory.cpp
+++ b/Engine/ac/dynobj/cc_inventory.cpp
@@ -37,5 +37,5 @@ void CCInventory::Serialize(const char *address, Stream *out) {
 
 void CCInventory::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrInv[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrInv[num], this);
 }

--- a/Engine/ac/dynobj/cc_object.cpp
+++ b/Engine/ac/dynobj/cc_object.cpp
@@ -38,5 +38,5 @@ void CCObject::Serialize(const char *address, Stream *out) {
 
 void CCObject::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrObj[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrObj[num], this);
 }

--- a/Engine/ac/dynobj/cc_pluginobject.h
+++ b/Engine/ac/dynobj/cc_pluginobject.h
@@ -1,0 +1,65 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// A plugin's dynamic manager wrapper.
+// The purpose is to hide the actual plugin's manager behind a proxy,
+// as plugin's interface may not fully comply to our internal one.
+// This prevents errors if one of the extended methods is called by the engine.
+// The base ICCDynamicObject interface currently consists of only few
+// methods, which are used only once in the object's lifetime,
+// and therefore this wrapper should have a small overhead.
+//
+//=============================================================================
+#ifndef __AGS_EE_DYNOBJ__PLUGINOBJECT_H
+#define __AGS_EE_DYNOBJ__PLUGINOBJECT_H
+
+#include "ac/dynobj/cc_basicobject.h"
+
+
+struct CCPluginObject final : CCBasicObject
+{
+private:
+    virtual ~CCPluginObject() = default;
+
+    ICCDynamicObject *_pluginMgr = nullptr;
+
+public:
+    CCPluginObject(ICCDynamicObject *plugin_mgr)
+        : _pluginMgr(plugin_mgr) {}
+
+    // Dispose the object
+    int Dispose(const char *address, bool force) override
+    {
+        // At the moment this wrapper's lifetime is tied to the plugin object
+        if (_pluginMgr->Dispose(address, force) != 0)
+        {
+            delete this;
+            return 1;
+        }
+        return 0;
+    }
+    // Return the type name of the object
+    const char *GetType() override
+    {
+        return _pluginMgr->GetType();
+    }
+    // Serialize the object into BUFFER (which is BUFSIZE bytes)
+    // return number of bytes used
+    int Serialize(const char *address, char *buffer, int bufsize) override
+    {
+        return _pluginMgr->Serialize(address, buffer, bufsize);
+    }
+};
+
+#endif // __AGS_EE_DYNOBJ__PLUGINOBJECT_H

--- a/Engine/ac/dynobj/cc_region.cpp
+++ b/Engine/ac/dynobj/cc_region.cpp
@@ -38,5 +38,5 @@ void CCRegion::Serialize(const char *address, Stream *out) {
 
 void CCRegion::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
     int num = in->ReadInt32();
-    ccRegisterUnserializedObject(index, &scrRegion[num], this);
+    ccRegisterUnserializedPersistentObject(index, &scrRegion[num], this);
 }

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -66,12 +66,10 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     // might have to use older class names to distinguish save formats
     if (strcmp(objectType, CCDynamicArray::TypeName) == 0) {
         globalDynamicArray.Unserialize(index, &mems, data_sz);
-        _typeidBasedObjs.push_back(index);
     }
     else if (strcmp(objectType, ScriptUserObject::TypeName) == 0) {
         ScriptUserObject *suo = new ScriptUserObject();
         suo->Unserialize(index, &mems, data_sz);
-        _typeidBasedObjs.push_back(index);
     }
     else if (strcmp(objectType, "GUIObject") == 0) {
         ccDynamicGUIObject.Unserialize(index, &mems, data_sz);
@@ -162,29 +160,5 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
             }
         }
         quitprintf("Unserialise: unknown object type: '%s'", objectType);
-    }
-}
-
-void AGSDeSerializer::RemapTypeids(ManagedObjectPool &pool,
-    const std::unordered_map<uint32_t, uint32_t> &typeid_map) const
-{
-    // FIXME! Reimplement this in a safer and, possibly, faster way.
-    // Idea: store not the handles, but the object/manager pointer pairs;
-    // add ref to keep these existing as long as deserializer is in use;
-    // sub ref after remapping typeids.
-    // note: ScriptUserObject does not have a global manager? impl one instead??
-    // implement ManagedPool methods that accept vectors, along with single
-    // handles, for faster operations over list of items(?)
-    void *object;
-    ICCDynamicObject *manager;
-    for (auto &handle : _typeidBasedObjs)
-    {
-        pool.HandleToAddressAndManager(handle, object, manager);
-        assert(object);
-        const char *type = manager->GetType();
-        if (strcmp(type, CCDynamicArray::TypeName) == 0)
-            globalDynamicArray.RemapTypeids((const char*)object, typeid_map);
-        else if (strcmp(type, ScriptUserObject::TypeName) == 0)
-            ((ScriptUserObject*)manager)->RemapTypeids((const char*)object, typeid_map);
     }
 }

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -66,10 +66,12 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     // might have to use older class names to distinguish save formats
     if (strcmp(objectType, CCDynamicArray::TypeName) == 0) {
         globalDynamicArray.Unserialize(index, &mems, data_sz);
+        _typeidBasedObjs.push_back(index);
     }
     else if (strcmp(objectType, ScriptUserObject::TypeName) == 0) {
         ScriptUserObject *suo = new ScriptUserObject();
         suo->Unserialize(index, &mems, data_sz);
+        _typeidBasedObjs.push_back(index);
     }
     else if (strcmp(objectType, "GUIObject") == 0) {
         ccDynamicGUIObject.Unserialize(index, &mems, data_sz);
@@ -163,4 +165,26 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     }
 }
 
-AGSDeSerializer ccUnserializer;
+void AGSDeSerializer::RemapTypeids(ManagedObjectPool &pool,
+    const std::unordered_map<uint32_t, uint32_t> &typeid_map) const
+{
+    // FIXME! Reimplement this in a safer and, possibly, faster way.
+    // Idea: store not the handles, but the object/manager pointer pairs;
+    // add ref to keep these existing as long as deserializer is in use;
+    // sub ref after remapping typeids.
+    // note: ScriptUserObject does not have a global manager? impl one instead??
+    // implement ManagedPool methods that accept vectors, along with single
+    // handles, for faster operations over list of items(?)
+    void *object;
+    ICCDynamicObject *manager;
+    for (auto &handle : _typeidBasedObjs)
+    {
+        pool.HandleToAddressAndManager(handle, object, manager);
+        assert(object);
+        const char *type = manager->GetType();
+        if (strcmp(type, CCDynamicArray::TypeName) == 0)
+            globalDynamicArray.RemapTypeids((const char*)object, typeid_map);
+        else if (strcmp(type, ScriptUserObject::TypeName) == 0)
+            ((ScriptUserObject*)manager)->RemapTypeids((const char*)object, typeid_map);
+    }
+}

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -15,10 +15,11 @@
 #include "ac/dynobj/cc_serializer.h"
 #include "ac/dynobj/all_dynamicclasses.h"
 #include "ac/dynobj/all_scriptclasses.h"
+#include "ac/dynobj/cc_dynamicarray.h"
+#include "ac/dynobj/scriptuserobject.h"
 #include "ac/dynobj/scriptcamera.h"
 #include "ac/dynobj/scriptcontainers.h"
 #include "ac/dynobj/scriptfile.h"
-#include "ac/dynobj/scriptuserobject.h"
 #include "ac/dynobj/scriptviewport.h"
 #include "ac/game.h"
 #include "debug/debug_log.h"
@@ -56,7 +57,21 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     size_t data_sz = static_cast<size_t>(dataSize);
     MemoryStream mems(reinterpret_cast<const uint8_t*>(serializedData), dataSize);
 
-    if (strcmp(objectType, "GUIObject") == 0) {
+    // TODO: consider this: there are object types that are part of the
+    // script's foundation, because they are created by the bytecode ops:
+    // such as DynamicArray and UserObject. *Maybe* these should be moved
+    // to certain "base serializer" class which guarantees their restoration.
+    //
+    // TODO: should we support older save versions here (DynArray, UserObj)?
+    // might have to use older class names to distinguish save formats
+    if (strcmp(objectType, CCDynamicArray::TypeName) == 0) {
+        globalDynamicArray.Unserialize(index, &mems, data_sz);
+    }
+    else if (strcmp(objectType, ScriptUserObject::TypeName) == 0) {
+        ScriptUserObject *suo = new ScriptUserObject();
+        suo->Unserialize(index, &mems, data_sz);
+    }
+    else if (strcmp(objectType, "GUIObject") == 0) {
         ccDynamicGUIObject.Unserialize(index, &mems, data_sz);
     }
     else if (strcmp(objectType, "Character") == 0) {
@@ -135,10 +150,6 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     {
         Camera_Unserialize(index, &mems, data_sz);
     }
-    else if (strcmp(objectType, "UserObj2") == 0) {
-        ScriptUserObject *suo = new ScriptUserObject();
-        suo->Unserialize(index, &mems, data_sz);
-    }
     else if (!unserialize_audio_script_object(index, objectType, &mems, data_sz))
     {
         // check if the type is read by a plugin
@@ -153,4 +164,3 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
 }
 
 AGSDeSerializer ccUnserializer;
-

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -135,7 +135,7 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
     {
         Camera_Unserialize(index, &mems, data_sz);
     }
-    else if (strcmp(objectType, "UserObject") == 0) {
+    else if (strcmp(objectType, "UserObj2") == 0) {
         ScriptUserObject *suo = new ScriptUserObject();
         suo->Unserialize(index, &mems, data_sz);
     }

--- a/Engine/ac/dynobj/cc_serializer.h
+++ b/Engine/ac/dynobj/cc_serializer.h
@@ -21,15 +21,6 @@
 struct AGSDeSerializer : ICCObjectReader {
 
     void Unserialize(int index, const char *objectType, const char *serializedData, int dataSize) override;
-
-    // Remaps typeids for the recently deserialized managed objects
-    // that contain typeid fields; uses provided typeid maps
-    void RemapTypeids(ManagedObjectPool &pool, const std::unordered_map<uint32_t, uint32_t> &typeid_map) const;
-
-private:
-    // A list of deserialized typeid-based objects,
-    // that is - objects that might require typeid remap after load
-    std::vector<int> _typeidBasedObjs;
 };
 
 #endif // __AC_SERIALIZER_H

--- a/Engine/ac/dynobj/cc_serializer.h
+++ b/Engine/ac/dynobj/cc_serializer.h
@@ -11,17 +11,25 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
 #ifndef __AC_SERIALIZER_H
 #define __AC_SERIALIZER_H
 
+#include <vector>
 #include "ac/dynobj/cc_dynamicobject.h"
+#include "managedobjectpool.h"
 
 struct AGSDeSerializer : ICCObjectReader {
 
     void Unserialize(int index, const char *objectType, const char *serializedData, int dataSize) override;
-};
 
-extern AGSDeSerializer ccUnserializer;
+    // Remaps typeids for the recently deserialized managed objects
+    // that contain typeid fields; uses provided typeid maps
+    void RemapTypeids(ManagedObjectPool &pool, const std::unordered_map<uint32_t, uint32_t> &typeid_map) const;
+
+private:
+    // A list of deserialized typeid-based objects,
+    // that is - objects that might require typeid remap after load
+    std::vector<int> _typeidBasedObjs;
+};
 
 #endif // __AC_SERIALIZER_H

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -64,6 +64,8 @@ int32_t ManagedObjectPool::SubRef(int32_t handle) {
     auto & o = objects[handle];
     if (!o.isUsed()) { return 0; }
 
+    assert(o.refCount >= 0); // FIXME
+
     o.refCount--;
     auto newRefCount = o.refCount;
     auto canBeDisposed = (o.addr != disableDisposeForObject);

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -286,4 +286,14 @@ ManagedObjectPool::ManagedObjectPool() : objectCreationCounter(0), nextHandle(1)
     handleByAddress.reserve(RESERVED_SIZE);
 }
 
+void ManagedObjectPool::RemapTypeids(const std::unordered_map<uint32_t, uint32_t> &typeid_map)
+{
+    for (const auto &o : objects)
+    {
+        if (!o.isUsed()) continue;
+        o.callback->RemapTypeids(o.addr, typeid_map);
+    }
+}
+
+
 ManagedObjectPool pool;

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -32,19 +32,7 @@ int ManagedObjectPool::Remove(ManagedObject &o, bool force) {
     if (!o.isUsed()) { return 1; } // already removed
 
     o.refCount = 0; // mark as disposing, to avoid any access
-    bool canBeRemovedFromPool = o.callback->Dispose(o.addr, force) != 0;
-    if (!(canBeRemovedFromPool || force)) { return 0; }
-
-    // FIXME: this is VERY inefficient
-    for (auto it = gcUsedList.begin(); it != gcUsedList.end(); ++it)
-    {
-        if (it->handle == o.handle)
-        {
-            gcUsedList.erase(it);
-            break;
-        }
-    }
-
+    o.callback->Dispose(o.addr, force); // we always dispose and remove now!
     available_ids.push(o.handle);
     handleByAddress.erase(o.addr);
     ManagedObjectLog("Line %d Disposed managed object handle=%d", currentline, o.handle);
@@ -67,10 +55,11 @@ int ManagedObjectPool::CheckDispose(int32_t handle) {
     auto & o = objects[handle];
     if (!o.isUsed()) { return 1; }
     if (o.refCount >= 1) { return 0; }
+    gcUsedList.erase(o.gcItUsed);
     return Remove(o);
 }
 
-int32_t ManagedObjectPool::SubRef(int32_t handle) {
+int32_t ManagedObjectPool::SubRefCheckDispose(int32_t handle) {
     if (handle < 0 || (size_t)handle >= objects.size()) { return 0; }
     auto & o = objects[handle];
     if (!o.isUsed()) { return 0; }
@@ -85,6 +74,17 @@ int32_t ManagedObjectPool::SubRef(int32_t handle) {
     // object could be removed at this point, don't use any values.
     ManagedObjectLog("Line %d SubRef: handle=%d new refcount=%d canBeDisposed=%d", currentline, handle, newRefCount, canBeDisposed);
     return newRefCount;
+}
+
+int32_t ManagedObjectPool::SubRefNoCheck(int32_t handle)
+{
+    if (handle < 0 || (size_t)handle >= objects.size()) { return 0; }
+    auto & o = objects[handle];
+    if (!o.isUsed()) { return 0; }
+    if (o.refCount <= 0) { return 0; } // already disposed / disposing
+    o.refCount--;
+    ManagedObjectLog("Line %d SubRefNoCheck: handle=%d new refcount=%d", currentline, handle, o.refCount);
+    return o.refCount;
 }
 
 int32_t ManagedObjectPool::AddressToHandle(const char *addr) {
@@ -122,6 +122,8 @@ int ManagedObjectPool::RemoveObject(const char *address) {
     if (it == handleByAddress.end()) { return 0; }
 
     auto & o = objects[it->second];
+    if ((o.gcRefCount & ManagedObject::GC_FLAG_EXCLUDED) == 0)
+        gcUsedList.erase(o.gcItUsed);
     return Remove(o, true);
 }
 
@@ -139,21 +141,29 @@ void ManagedObjectPool::RunGarbageCollection()
     //
     // Step 0: remove objects that have 0 refs already
     // Step 1: copy current ref counts
-    for (auto &o : objects)
+    for (auto it = gcUsedList.begin(); it != gcUsedList.end(); )
     {
-        if (!o.isUsed()) continue;
-        if (o.refCount == 0)
-            Remove(o);
+        assert(it->handle != 0);
+        auto test_it = it++;
+        auto &obj = objects[test_it->handle];
+        if (obj.refCount == 0)
+        {
+            gcUsedList.erase(test_it);
+            Remove(obj);
+        }
         else
-            o.gcRefCount = o.refCount;
+        {
+            obj.gcRefCount = obj.refCount;
+        }
     }
     // Step 2: remove all internal references: that is references
     // which are stored in objects themselves
     for (auto &gco : gcUsedList)
     {
         auto &objs = objects;
-        assert(gco.handle == 0 || objects[gco.handle].refCount > 0);
-        objects[gco.handle].callback->TraverseRefs(objects[gco.handle].addr,
+        auto &obj = objects[gco.handle];
+        assert((gco.handle != 0) && (obj.refCount > 0));
+        objects[gco.handle].callback->TraverseRefs(obj.addr,
             [&objs](int handle)
         {
             objs[handle].gcRefCount--;
@@ -196,6 +206,7 @@ void ManagedObjectPool::RunGarbageCollection()
             if (objects[test_it->handle].gcRefCount > 0)
             {
                 gcUsedList.splice(gcUsedList.end(), gcRemList, test_it);
+                objects[test_it->handle].gcItUsed = test_it; // ugh... scary
                 objects[test_it->handle].callback->TraverseRefs(objects[test_it->handle].addr,
                     [&objs](int handle)
                 {
@@ -216,6 +227,25 @@ void ManagedObjectPool::RunGarbageCollection()
     ManagedObjectLog("Ran garbage collection");
 }
 
+int ManagedObjectPool::Add(int handle, const char *address, ICCDynamicObject *callback,
+    bool plugin_object, bool persistent)
+{
+    auto & o = objects[handle];
+    if (o.isUsed()) { cc_error("used: %d", handle); return 0; }
+
+    o = ManagedObject(plugin_object ? kScValPluginObject : kScValDynamicObject, handle, address, callback);
+
+    handleByAddress.insert({address, o.handle});
+    if (persistent) { // mark persistent object as excluded from GC
+        o.gcRefCount = ManagedObject::GC_FLAG_EXCLUDED;
+    } else { // if regular - then add to the GC scan
+        o.gcItUsed = gcUsedList.insert(gcUsedList.end(), GCObject(o.handle));
+        objectCreationCounter++;
+    }
+    ManagedObjectLog("Allocated managed object type=%s, handle=%d, addr=%08X", callback->GetType(), handle, address);
+    return handle;
+}
+
 int ManagedObjectPool::AddObject(const char *address, ICCDynamicObject *callback,
     bool plugin_object, bool persistent) 
 {
@@ -231,18 +261,7 @@ int ManagedObjectPool::AddObject(const char *address, ICCDynamicObject *callback
         }
     }
 
-    auto & o = objects[handle];
-    if (o.isUsed()) { cc_error("used: %d", handle); return 0; }
-
-    o = ManagedObject(plugin_object ? kScValPluginObject : kScValDynamicObject, handle, address, callback);
-
-    handleByAddress.insert({address, o.handle});
-    if (!persistent) { // if persistent - do not add to the GC scan
-        gcUsedList.push_back(GCObject(o.handle));
-        objectCreationCounter++;
-    }
-    ManagedObjectLog("Allocated managed object type=%s, handle=%d, addr=%08X", callback->GetType(), handle, address);
-    return o.handle;
+    return Add(handle, address, callback, plugin_object, persistent);
 }
 
 
@@ -254,18 +273,7 @@ int ManagedObjectPool::AddUnserializedObject(const char *address, ICCDynamicObje
         objects.resize(handle + 1024, ManagedObject());
     }
 
-    auto & o = objects[handle];
-    if (o.isUsed()) { cc_error("bad save. used: %d", o.handle); return 0; }
-
-    o = ManagedObject(plugin_object ? kScValPluginObject : kScValDynamicObject, handle, address, callback);
-
-    handleByAddress.insert({address, o.handle});
-    if (!persistent) { // if persistent - do not add to the GC scan
-        gcUsedList.push_back(GCObject(o.handle));
-        objectCreationCounter++;
-    }
-    ManagedObjectLog("Allocated unserialized managed object handle=%d, type=%s", o.handle, callback->GetType());
-    return o.handle;
+    return Add(handle, address, callback, plugin_object, persistent);
 }
 
 void ManagedObjectPool::WriteToDisk(Stream *out) {
@@ -372,6 +380,8 @@ void ManagedObjectPool::reset() {
         Remove(o, true);
     }
     while (!available_ids.empty()) { available_ids.pop(); }
+    gcUsedList.clear();
+    gcRemList.clear();
     nextHandle = 1;
 }
 

--- a/Engine/ac/dynobj/managedobjectpool.cpp
+++ b/Engine/ac/dynobj/managedobjectpool.cpp
@@ -146,6 +146,7 @@ void ManagedObjectPool::RunGarbageCollection()
         assert(it->handle != 0);
         auto test_it = it++;
         auto &obj = objects[test_it->handle];
+        assert((obj.refCount & ManagedObject::GC_FLAG_EXCLUDED) == 0);
         if (obj.refCount == 0)
         {
             gcUsedList.erase(test_it);

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -73,6 +73,10 @@ public:
     void reset();
     ManagedObjectPool();
 
+    // Remaps typeids for the managed objects that contain typeid fields;
+    // uses provided typeid maps
+    void RemapTypeids(const std::unordered_map<uint32_t, uint32_t> &typeid_map);
+
     const char* disableDisposeForObject {nullptr};
 };
 

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -53,9 +53,7 @@ private:
     std::vector<ManagedObject> objects;
     std::unordered_map<const char *, int32_t> handleByAddress;
 
-    void Init(int32_t theHandle, const char *theAddress, ICCDynamicObject *theCallback, ScriptValueType objType);
-    int Remove(ManagedObject &o, bool force = false); 
-
+    int Remove(ManagedObject &o, bool force = false);
     void RunGarbageCollection();
 
 public:

--- a/Engine/ac/dynobj/managedobjectpool.h
+++ b/Engine/ac/dynobj/managedobjectpool.h
@@ -66,8 +66,9 @@ public:
     ScriptValueType HandleToAddressAndManager(int32_t handle, void *&object, ICCDynamicObject *&manager);
     int RemoveObject(const char *address);
     void RunGarbageCollectionIfAppropriate();
-    int AddObject(const char *address, ICCDynamicObject *callback, bool plugin_object);
-    int AddUnserializedObject(const char *address, ICCDynamicObject *callback, bool plugin_object, int handle);
+    int AddObject(const char *address, ICCDynamicObject *callback, bool plugin_object, bool persistent);
+    int AddUnserializedObject(const char *address, ICCDynamicObject *callback, int handle,
+        bool plugin_object, bool persistent);
     void WriteToDisk(Common::Stream *out);
     int ReadFromDisk(Common::Stream *in, ICCObjectReader *reader);
     void reset();

--- a/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
+++ b/Engine/ac/dynobj/scriptdialogoptionsrendering.cpp
@@ -30,7 +30,7 @@ void ScriptDialogOptionsRendering::Serialize(const char* /*address*/, Stream* /*
 }
 
 void ScriptDialogOptionsRendering::Unserialize(int index, Stream* /*in*/, size_t /*data_sz*/) {
-    ccRegisterUnserializedObject(index, this, this);
+    ccRegisterUnserializedPersistentObject(index, this, this);
 }
 
 void ScriptDialogOptionsRendering::Reset()

--- a/Engine/ac/dynobj/scriptfile.h
+++ b/Engine/ac/dynobj/scriptfile.h
@@ -41,6 +41,8 @@ struct sc_File final : ICCDynamicObject {
     // Remap typeid fields using the provided map
     void RemapTypeids(const char *address,
         const std::unordered_map<uint32_t, uint32_t> &typeid_map) override { /* do nothing */ }
+    // Traverse all managed references in this object, and run callback for each of them
+    void TraverseRefs(const char *address, PfnTraverseRefOp traverse_op) { /* do nothing */ }
 
     int OpenFile(const char *filename, int mode);
     void Close();

--- a/Engine/ac/dynobj/scriptfile.h
+++ b/Engine/ac/dynobj/scriptfile.h
@@ -38,6 +38,9 @@ struct sc_File final : ICCDynamicObject {
     const char *GetType() override;
 
     int Serialize(const char *address, char *buffer, int bufsize) override;
+    // Remap typeid fields using the provided map
+    void RemapTypeids(const char *address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) override { /* do nothing */ }
 
     int OpenFile(const char *filename, int mode);
     void Close();

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -21,10 +21,12 @@
 
 using namespace AGS::Common;
 
+const char *ScriptUserObject::TypeName = "UserObj2";
+
 // return the type name of the object
 const char *ScriptUserObject::GetType()
 {
-    return "UserObj2";
+    return TypeName;
 }
 
 ScriptUserObject::~ScriptUserObject()

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -64,12 +64,16 @@ void ScriptUserObject::Create(const char *data, Stream *in, uint32_t type_id, si
 int ScriptUserObject::Dispose(const char* /*address*/, bool /*force*/)
 {
     // Unref all managed pointers within the struct
-    const auto *helper = ccInstance::GetRTTIHelper();
-    const auto fref = helper->GetManagedOffsetsForType(_typeid);
-    for (auto it = fref.first; it < fref.second; ++it)
+    if (_typeid > 0)
     {
-        int32_t handle = *(int32_t*)(_data + *it);
-        pool.SubRef(handle);
+        assert(ccInstance::GetRTTI()->GetTypes().size() > _typeid);
+        const auto *helper = ccInstance::GetRTTIHelper();
+        const auto fref = helper->GetManagedOffsetsForType(_typeid);
+        for (auto it = fref.first; it < fref.second; ++it)
+        {
+            int32_t handle = *(int32_t*)(_data + *it);
+            pool.SubRef(handle);
+        }
     }
 
     delete this;

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -114,6 +114,10 @@ void ScriptUserObject::RemapTypeids(const char* /*address*/,
 
 void ScriptUserObject::TraverseRefs(const char *address, PfnTraverseRefOp traverse_op)
 {
+    // TODO: may be a bit faster if we make a "runtime type"
+    // struct, merging joint type info and auxiliary helper data,
+    // and store a pointer in the arr data.
+    // might also have a dummy "type" for "unknown type" arrays.
     if (_typeid == 0u) return;
     assert(ccInstance::GetRTTI()->GetTypes().size() > _typeid);
     const auto *helper = ccInstance::GetRTTIHelper();

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -107,6 +107,14 @@ void ScriptUserObject::Unserialize(int index, Stream *in, size_t data_sz)
     ccRegisterUnserializedObject(index, this, this);
 }
 
+void ScriptUserObject::RemapTypeids(const char* /*address*/,
+    const std::unordered_map<uint32_t, uint32_t> &typeid_map)
+{
+    const auto it = typeid_map.find(_typeid);
+    assert(it != typeid_map.end());
+    _typeid = (it != typeid_map.end()) ? it->second : 0u;
+}
+
 const char* ScriptUserObject::GetFieldPtr(const char* /*address*/, intptr_t offset)
 {
     return _data + offset;

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -108,7 +108,7 @@ void ScriptUserObject::RemapTypeids(const char* /*address*/,
     const std::unordered_map<uint32_t, uint32_t> &typeid_map)
 {
     const auto it = typeid_map.find(_typeid);
-    assert(it != typeid_map.end());
+    assert(_typeid == 0u || it != typeid_map.end());
     _typeid = (it != typeid_map.end()) ? it->second : 0u;
 }
 

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -66,7 +66,7 @@ int ScriptUserObject::Dispose(const char* address, bool force)
     // Unref all managed pointers within the struct
     if (!force && (_typeid > 0))
     {
-        TraverseRefs(address, [](int handle) { pool.SubRef(handle); });
+        TraverseRefs(address, [](int handle) { pool.SubRefNoCheck(handle); });
     }
 
     delete this;

--- a/Engine/ac/dynobj/scriptuserobject.cpp
+++ b/Engine/ac/dynobj/scriptuserobject.cpp
@@ -114,6 +114,7 @@ void ScriptUserObject::RemapTypeids(const char* /*address*/,
 
 void ScriptUserObject::TraverseRefs(const char *address, PfnTraverseRefOp traverse_op)
 {
+    if (_typeid == 0u) return;
     assert(ccInstance::GetRTTI()->GetTypes().size() > _typeid);
     const auto *helper = ccInstance::GetRTTIHelper();
     const auto fref = helper->GetManagedOffsetsForType(_typeid);

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -18,11 +18,13 @@
 #ifndef __AGS_EE_DYNOBJ__SCRIPTUSERSTRUCT_H
 #define __AGS_EE_DYNOBJ__SCRIPTUSERSTRUCT_H
 
-#include "ac/dynobj/cc_agsdynamicobject.h"
+#include "ac/dynobj/cc_dynamicobject.h"
 
 struct ScriptUserObject final : ICCDynamicObject
 {
 public:
+    static const char *TypeName;
+
     ScriptUserObject() = default;
     
 protected:

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -20,7 +20,7 @@
 
 #include "ac/dynobj/cc_dynamicobject.h"
 
-struct ScriptUserObject final : ICCDynamicObject, ICCTypeidBased
+struct ScriptUserObject final : ICCDynamicObject
 {
 public:
     static const char *TypeName;

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -20,7 +20,7 @@
 
 #include "ac/dynobj/cc_dynamicobject.h"
 
-struct ScriptUserObject final : ICCDynamicObject
+struct ScriptUserObject final : ICCDynamicObject, ICCTypeidBased
 {
 public:
     static const char *TypeName;
@@ -41,6 +41,10 @@ public:
     // return number of bytes used
     int Serialize(const char *address, char *buffer, int bufsize) override;
     void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz);
+
+    // Remap typeid fields using the provided map
+    void RemapTypeids(const char *address,
+        const std::unordered_map<uint32_t, uint32_t> &typeid_map) override;
 
     // Support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -45,6 +45,8 @@ public:
     // Remap typeid fields using the provided map
     void RemapTypeids(const char *address,
         const std::unordered_map<uint32_t, uint32_t> &typeid_map) override;
+    // Traverse all managed references in this object, and run callback for each of them
+    void TraverseRefs(const char *address, PfnTraverseRefOp traverse_op) override;
 
     // Support for reading and writing object values by their relative offset
     const char* GetFieldPtr(const char *address, intptr_t offset) override;

--- a/Engine/ac/dynobj/scriptuserobject.h
+++ b/Engine/ac/dynobj/scriptuserobject.h
@@ -23,14 +23,14 @@
 struct ScriptUserObject final : ICCDynamicObject
 {
 public:
-    ScriptUserObject();
+    ScriptUserObject() = default;
     
 protected:
     virtual ~ScriptUserObject();
 
 public:
-    static ScriptUserObject *CreateManaged(size_t size);
-    void Create(const char *data, AGS::Common::Stream *in, size_t size);
+    static ScriptUserObject *CreateManaged(uint32_t type_id, size_t size);
+    void Create(const char *data, AGS::Common::Stream *in, uint32_t type_id, size_t size);
 
     // return the type name of the object
     const char *GetType() override;
@@ -54,14 +54,15 @@ public:
     void    WriteFloat(const char *address, intptr_t offset, float val) override;
 
 private:
-    // NOTE: we use signed int for Size at the moment, because the managed
-    // object interface's Serialize() function requires the object to return
-    // negative value of size in case the provided buffer was not large
-    // enough. Since this interface is also a part of Plugin API, we would
-    // need more significant change to program before we could use different
-    // approach.
-    int32_t  _size;
-    char    *_data;
+    uint32_t _typeid = 0u; // type id from rtti
+    // NOTE: the managed object interface's Serialize() function requires
+    // the object to return negative value of size in case the provided
+    // buffer was not large enough. Since this interface is also a part of
+    // Plugin API, we cannot modify that without more significant changes.
+    // This means that if the size is larger than INT32_MAX, Serialize()
+    // will work unreliably.
+    size_t   _size = 0u;
+    char    *_data = nullptr;
 };
 
 

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -278,8 +278,7 @@ ScriptViewport *GameState::RegisterRoomViewport(int index, int32_t handle)
     auto scview = new ScriptViewport(index);
     if (handle == 0)
     {
-        handle = ccRegisterManagedObject(scview, scview);
-        ccAddObjectReference(handle); // one reference for the GameState
+        handle = ccRegisterManagedObjectAndRef(scview, scview); // one ref for GameState
     }
     else
     {
@@ -348,8 +347,7 @@ ScriptCamera *GameState::RegisterRoomCamera(int index, int32_t handle)
     auto sccamera = new ScriptCamera(index);
     if (handle == 0)
     {
-        handle = ccRegisterManagedObject(sccamera, sccamera);
-        ccAddObjectReference(handle); // one reference for the GameState
+        handle = ccRegisterManagedObjectAndRef(sccamera, sccamera); // one ref for GameState
     }
     else
     {

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -472,7 +472,7 @@ void export_gui_controls(int ee)
         GUIObject *guio = guis[ee].GetControl(ff);
         if (!guio->Name.IsEmpty())
             ccAddExternalDynamicObject(guio->Name, guio, &ccDynamicGUIObject);
-        ccRegisterManagedObject(guio, &ccDynamicGUIObject);
+        ccRegisterPersistentObject(guio, &ccDynamicGUIObject); // add ref for engine
     }
 }
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -298,6 +298,7 @@ void unload_old_room() {
         play.temporarily_turned_off_character = -1;
     }
 
+    pool.PrintStats();
 }
 
 void update_letterbox_mode()

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -137,7 +137,7 @@ void InitAndRegisterAudioObjects(GameSetupStruct &game)
     for (int i = 0; i < game.numCompatGameChannels; ++i)
     {
         scrAudioChannel[i].id = i;
-        ccRegisterManagedObject(&scrAudioChannel[i], &ccDynamicAudio);
+        ccRegisterPersistentObject(&scrAudioChannel[i], &ccDynamicAudio); // add internal ref
     }
 
     for (size_t i = 0; i < game.audioClips.size(); ++i)
@@ -146,7 +146,7 @@ void InitAndRegisterAudioObjects(GameSetupStruct &game)
         // to actual item index in array, so we don't make any difference
         // between game versions, for now.
         game.audioClips[i].id = i;
-        ccRegisterManagedObject(&game.audioClips[i], &ccDynamicAudioClip);
+        ccRegisterPersistentObject(&game.audioClips[i], &ccDynamicAudioClip); // add internal ref
         ccAddExternalDynamicObject(game.audioClips[i].scriptName, &game.audioClips[i], &ccDynamicAudioClip);
     }
 }
@@ -170,7 +170,7 @@ void InitAndRegisterCharacters(const LoadedGameEntities &ents)
         game.chars[i].loop = 0;
         game.chars[i].frame = 0;
         game.chars[i].walkwait = -1;
-        ccRegisterManagedObject(&game.chars[i], &ccDynamicCharacter);
+        ccRegisterPersistentObject(&game.chars[i], &ccDynamicCharacter); // add internal ref
 
         // export the character's script object
         ccAddExternalDynamicObject(game.chars[i].scrname, &game.chars[i], &ccDynamicCharacter);
@@ -194,7 +194,7 @@ void InitAndRegisterDialogs(const GameSetupStruct &game)
     {
         scrDialog[i].id = i;
         scrDialog[i].reserved = 0;
-        ccRegisterManagedObject(&scrDialog[i], &ccDynamicDialog);
+        ccRegisterPersistentObject(&scrDialog[i], &ccDynamicDialog); // add internal ref
 
         if (!game.dialogScriptNames[i].IsEmpty())
             ccAddExternalDynamicObject(game.dialogScriptNames[i], &scrDialog[i], &ccDynamicDialog);
@@ -204,12 +204,11 @@ void InitAndRegisterDialogs(const GameSetupStruct &game)
 // Initializes dialog options rendering objects and registers them in the script system
 void InitAndRegisterDialogOptions()
 {
-    ccRegisterManagedObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering);
+    ccRegisterPersistentObject(&ccDialogOptionsRendering, &ccDialogOptionsRendering); // add internal ref
 
     dialogOptionsRenderingSurface = new ScriptDrawingSurface();
     dialogOptionsRenderingSurface->isLinkedBitmapOnly = true;
-    long dorsHandle = ccRegisterManagedObject(dialogOptionsRenderingSurface, dialogOptionsRenderingSurface);
-    ccAddObjectReference(dorsHandle);
+    ccRegisterPersistentObject(dialogOptionsRenderingSurface, dialogOptionsRenderingSurface); // add internal ref
 }
 
 // Initializes gui and registers them in the script system
@@ -231,7 +230,7 @@ HError InitAndRegisterGUI(const GameSetupStruct &game)
         export_gui_controls(i);
         scrGui[i].id = i;
         ccAddExternalDynamicObject(guis[i].Name, &scrGui[i], &ccDynamicGUI);
-        ccRegisterManagedObject(&scrGui[i], &ccDynamicGUI);
+        ccRegisterPersistentObject(&scrGui[i], &ccDynamicGUI); // add internal ref
     }
     return HError::None();
 }
@@ -243,7 +242,7 @@ void InitAndRegisterInvItems(const GameSetupStruct &game)
     {
         scrInv[i].id = i;
         scrInv[i].reserved = 0;
-        ccRegisterManagedObject(&scrInv[i], &ccDynamicInv);
+        ccRegisterPersistentObject(&scrInv[i], &ccDynamicInv); // add internal ref
 
         if (!game.invScriptNames[i].IsEmpty())
             ccAddExternalDynamicObject(game.invScriptNames[i], &scrInv[i], &ccDynamicInv);
@@ -257,7 +256,7 @@ void InitAndRegisterHotspots()
     {
         scrHotspot[i].id = i;
         scrHotspot[i].reserved = 0;
-        ccRegisterManagedObject(&scrHotspot[i], &ccDynamicHotspot);
+        ccRegisterPersistentObject(&scrHotspot[i], &ccDynamicHotspot); // add internal ref
     }
 }
 
@@ -266,7 +265,7 @@ void InitAndRegisterRoomObjects()
 {
     for (int i = 0; i < MAX_ROOM_OBJECTS; ++i)
     {
-        ccRegisterManagedObject(&scrObj[i], &ccDynamicObject);
+        ccRegisterPersistentObject(&scrObj[i], &ccDynamicObject); // add internal ref
     }
 }
 
@@ -277,7 +276,7 @@ void InitAndRegisterRegions()
     {
         scrRegion[i].id = i;
         scrRegion[i].reserved = 0;
-        ccRegisterManagedObject(&scrRegion[i], &ccDynamicRegion);
+        ccRegisterPersistentObject(&scrRegion[i], &ccDynamicRegion); // add internal ref
     }
 }
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -357,7 +357,7 @@ void DoBeforeRestore(PreservedParams &pp)
     free_do_once_tokens();
 
     // unregister gui controls from API exports
-    // CHECKME: find out why are we doing this here? why only to gui controls?
+    // FIXME: find out why are we doing this here??! why only to gui controls??!
     for (int i = 0; i < game.numgui; ++i)
     {
         unexport_gui_controls(i);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -476,7 +476,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
     // remap typeids in the deserialized managed objects, where necessary
     std::unordered_map<uint32_t, uint32_t> loc_l2g, type_l2g;
     ccInstance::JoinRTTI(r_data.GenRTTI, loc_l2g, type_l2g);
-    r_data.ManObjReader.RemapTypeids(pool, type_l2g);
+    pool.RemapTypeids(type_l2g);
 
     play.gscript_timer=gstimer;
 

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -31,6 +31,7 @@
 #include "ac/spritecache.h"
 #include "ac/system.h"
 #include "ac/timer.h"
+#include "ac/dynobj/cc_serializer.h"
 #include "debug/debugger.h"
 #include "debug/out.h"
 #include "device/mousew32.h"
@@ -470,6 +471,12 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
         load_new_room(displayed_room, nullptr);
     else
         set_room_placeholder();
+
+    // Apply restored RTTI placeholder, after current room was loaded;
+    // remap typeids in the deserialized managed objects, where necessary
+    std::unordered_map<uint32_t, uint32_t> loc_l2g, type_l2g;
+    ccInstance::JoinRTTI(r_data.GenRTTI, loc_l2g, type_l2g);
+    r_data.ManObjReader.RemapTypeids(pool, type_l2g);
 
     play.gscript_timer=gstimer;
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1051,6 +1051,13 @@ HSaveError ReadPluginData(Stream *in, int32_t /*cmp_ver*/, const PreservedParams
 }
 
 
+// TODO: move elsewhere later
+enum ManagedPoolSavegameVersion
+{
+    kManagedPoolSvgVersion_Initial = 0,
+    kManagedPoolSvgVersion_39999   = 10
+};
+
 // Description of a supported game state serialization component
 struct ComponentHandler
 {
@@ -1164,8 +1171,8 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Managed Pool",
-        0,
-        0,
+        kManagedPoolSvgVersion_39999,
+        kManagedPoolSvgVersion_Initial,
         WriteManagedPool,
         ReadManagedPool
     },

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -49,6 +49,7 @@
 #include "script/cc_common.h"
 #include "script/script.h"
 #include "util/filestream.h" // TODO: needed only because plugins expect file handle
+#include "util/string_utils.h"
 #include "media/audio/audio_system.h"
 
 using namespace Common;
@@ -1021,14 +1022,81 @@ HSaveError WriteManagedPool(Stream *out)
     return HSaveError::None();
 }
 
-HSaveError ReadManagedPool(Stream *in, int32_t /*cmp_ver*/, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
+HSaveError ReadManagedPool(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
 {
-    if (ccUnserializeAllObjects(in, &ccUnserializer))
+    if (ccUnserializeAllObjects(in, &r_data.ManObjReader))
     {
         return new SavegameError(kSvgErr_GameObjectInitFailed,
             String::FromFormat("Managed pool deserialization failed: %s",
                 cc_get_error().ErrorString.GetCStr()));
     }
+    return HSaveError::None();
+}
+
+HSaveError WriteRTTI(Stream *out)
+{
+    // Write the minimal necessary RTTI data, enough to resolve types when restoring a save;
+    // NOTE: we might just dump whole RTTI here, if it's necessary to keep all field descs and names
+    const auto &rtti = ccInstance::GetRTTI()->AsConstRTTI();
+    const auto &helper = ccInstance::GetRTTIHelper();
+    const auto &locs = rtti.GetLocations();
+    const auto &types = rtti.GetTypes();
+    // NOTE: we don't write IDs here, as the Joint RTTI assumes to have them strcitly sequential
+    out->WriteInt32(locs.size());
+    for (const auto &loc : locs)
+    {
+        StrUtil::WriteCStr(loc.name, out);
+        out->WriteInt32(loc.flags);
+    }
+    out->WriteInt32(types.size());
+    for (const auto &type : types)
+    {
+        StrUtil::WriteCStr(type.name, out);
+        out->WriteInt32(type.loc_id);
+        out->WriteInt32(type.parent_id);
+        out->WriteInt32(type.flags);
+        out->WriteInt32(type.size);
+        // Managed ptrs offsets
+        const auto man_offs = helper->GetManagedOffsetsForType(type.this_id);
+        out->WriteInt32(man_offs.second - man_offs.first);
+        for (auto off = man_offs.first; off < man_offs.second; ++off)
+            out->WriteInt32(*off);
+    }
+    return HSaveError::None();
+}
+
+HSaveError ReadRTTI(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData &r_data)
+{
+    // Restore the minimal necessary RTTI data, enough to resolve types when restoring a save
+    // Create a pseudo-RTTI with "generated" types, and fields only for managed pointers
+    RTTIBuilder rb;
+    char buf[256];
+    uint32_t num_locs = in->ReadInt32();
+    for (uint32_t i = 0; i < num_locs; ++i)
+    {
+        StrUtil::ReadCStr(buf, in, sizeof(buf));
+        uint32_t flags = in->ReadInt32();
+        rb.AddLocation(buf, i, flags | RTTI::kLoc_Generated);
+    }
+    uint32_t num_types = in->ReadInt32();
+    for (uint32_t i = 0; i < num_types; ++i)
+    {
+        StrUtil::ReadCStr(buf, in, sizeof(buf));
+        uint32_t loc_id = in->ReadInt32();
+        uint32_t parent_id = in->ReadInt32();
+        uint32_t flags = in->ReadInt32();
+        uint32_t size = in->ReadInt32();
+        rb.AddType(buf, i, loc_id, parent_id, flags | RTTI::kType_Generated, size);
+        // Read managed ptrs offsets and generate pseudo-fields for these
+        uint32_t num_offs = in->ReadInt32();
+        for (uint32_t oi = 0; oi < num_offs; ++oi)
+        {
+            uint32_t off = in->ReadInt32();
+            rb.AddField(i, "", off, 0u, RTTI::kField_ManagedPtr | RTTI::kType_Generated, 0u);
+        }
+    }
+
+    r_data.GenRTTI = std::move(rb.Finalize());
     return HSaveError::None();
 }
 
@@ -1175,6 +1243,13 @@ ComponentHandler ComponentHandlers[] =
         kManagedPoolSvgVersion_Initial,
         WriteManagedPool,
         ReadManagedPool
+    },
+    {
+        "RTTI",
+        0,
+        0,
+        WriteRTTI,
+        ReadRTTI
     },
     {
         "Plugin Data",

--- a/Engine/game/savegame_internal.h
+++ b/Engine/game/savegame_internal.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 #include "ac/common_defines.h"
+#include "ac/dynobj/cc_serializer.h"
 #include "game/roomstruct.h"
 #include "gfx/bitmap.h"
 #include "media/audio/audiodefines.h"
@@ -79,6 +80,12 @@ struct RestoredData
     };
     ScriptData              GlobalScript;
     std::vector<ScriptData> ScriptModules;
+    // Generated RTTI is meant for remapping typeids
+    // (in case they were changed in game), and provides placeholders
+    // for types that were declared in unloaded (room) scripts
+    RTTI                    GenRTTI;
+    // Managed objects unserializer
+    AGSDeSerializer         ManObjReader;
     // Room data (has to be be preserved until room is loaded)
     PBitmap                 RoomBkgScene[MAX_ROOM_BGFRAMES];
     short                   RoomLightLevels[MAX_ROOM_REGIONS];

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -516,7 +516,7 @@ void export_missing_audiochans()
     {
         int h = ccGetObjectHandleFromAddress(&scrAudioChannel[i]);
         if (h <= 0)
-            ccRegisterManagedObject(&scrAudioChannel[i], &ccDynamicAudio);
+            ccRegisterPersistentObject(&scrAudioChannel[i], &ccDynamicAudio); // add internal ref
     }
 }
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -246,6 +246,10 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
     }
 
     // Join RTTI
+    if (!ccInstance::_rtti)
+        ccInstance::_rtti.reset(new JointRTTI());
+    if (!ccInstance::_rttiHelper)
+        ccInstance::_rttiHelper.reset(new RTTIHelper());
     if (scri->rtti && !scri->rtti->IsEmpty())
     {
         JoinRTTI(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
@@ -257,11 +261,7 @@ void ccInstance::JoinRTTI(const RTTI &rtti,
     std::unordered_map<uint32_t, uint32_t> &loc_l2g,
     std::unordered_map<uint32_t, uint32_t> &type_l2g)
 {
-    if (!ccInstance::_rtti)
-        ccInstance::_rtti.reset(new JointRTTI());
     ccInstance::_rtti->Join(rtti, loc_l2g, type_l2g);
-    if (!ccInstance::_rttiHelper)
-        ccInstance::_rttiHelper.reset(new RTTIHelper());
     // TODO: optimize by updating only newly joint types
     ccInstance::_rttiHelper->Generate(ccInstance::_rtti->AsConstRTTI());
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -40,6 +40,7 @@
 
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
+using namespace AGS::Engine;
 
 extern ccInstance *loadedInstances[MAX_LOADED_INSTANCES]; // in script/script_runtime
 extern int gameHasBeenRestored; // in ac/game
@@ -214,6 +215,7 @@ struct FunctionCallStack
 
 std::unique_ptr<JointRTTI> ccInstance::_rtti;
 std::unordered_map<String, uint32_t> ccInstance::_rttiLookup;
+std::unique_ptr<RTTIHelper> ccInstance::_rttiHelper;
 
 
 unsigned ccInstance::_timeoutCheckMs = 60u;
@@ -247,6 +249,11 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
         if (!ccInstance::_rtti)
             ccInstance::_rtti.reset(new JointRTTI());
         ccInstance::_rtti->Join(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
+        if (!ccInstance::_rttiHelper)
+            ccInstance::_rttiHelper.reset(new RTTIHelper());
+        // TODO: optimize by either generating only after all scripts are loaded,
+        // or updating only newly joint types
+        ccInstance::_rttiHelper->Generate(ccInstance::_rtti->AsConstRTTI());
     }
     return cinst;
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -170,6 +170,7 @@ std::deque<ccInstance*> InstThreads;
 // NOTE: This is temporary solution (*sigh*, one of many) which allows certain
 // exported functions return value as a RuntimeScriptValue object;
 // Of 2012-12-20: now used only for plugin exports
+// FIXME: re-investigate this, find if it's possible to get rid of this.
 RuntimeScriptValue GlobalReturnValue;
 
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -248,16 +248,22 @@ ccInstance *ccInstance::CreateEx(PScript scri, ccInstance * joined)
     // Join RTTI
     if (scri->rtti && !scri->rtti->IsEmpty())
     {
-        if (!ccInstance::_rtti)
-            ccInstance::_rtti.reset(new JointRTTI());
-        ccInstance::_rtti->Join(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
-        if (!ccInstance::_rttiHelper)
-            ccInstance::_rttiHelper.reset(new RTTIHelper());
-        // TODO: optimize by either generating only after all scripts are loaded,
-        // or updating only newly joint types
-        ccInstance::_rttiHelper->Generate(ccInstance::_rtti->AsConstRTTI());
+        JoinRTTI(*scri->rtti, cinst->_locidLocal2Global, cinst->_typeidLocal2Global);
     }
     return cinst;
+}
+
+void ccInstance::JoinRTTI(const RTTI &rtti,
+    std::unordered_map<uint32_t, uint32_t> &loc_l2g,
+    std::unordered_map<uint32_t, uint32_t> &type_l2g)
+{
+    if (!ccInstance::_rtti)
+        ccInstance::_rtti.reset(new JointRTTI());
+    ccInstance::_rtti->Join(rtti, loc_l2g, type_l2g);
+    if (!ccInstance::_rttiHelper)
+        ccInstance::_rttiHelper.reset(new RTTIHelper());
+    // TODO: optimize by updating only newly joint types
+    ccInstance::_rttiHelper->Generate(ccInstance::_rtti->AsConstRTTI());
 }
 
 void ccInstance::SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms,

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1505,6 +1505,9 @@ int ccInstance::Run(int32_t curpc)
                   cc_error("invalid size for dynamic array; requested: %d, range: 1..%d", arg_elnum, INT32_MAX);
                   return -1;
               }
+              // TODO: this likely may be optimized by doing a fixup,
+              // which would replace a local typeid with a global one once the script is loaded;
+              // but we need to implement such fixup in a compiler first.
               assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
               const uint32_t global_tid = runningInst->_typeidLocal2Global[arg_typeid];
               DynObjectRef ref = globalDynamicArray.CreateNew(global_tid, static_cast<uint32_t>(arg_elnum), arg_elsize);
@@ -1534,6 +1537,9 @@ int ccInstance::Run(int32_t curpc)
                   cc_error("Invalid size for user object; requested: %u, range: 0..%d", arg_size, INT32_MAX);
                   return -1;
               }
+              // TODO: this likely may be optimized by doing a fixup,
+              // which would replace a local typeid with a global one once the script is loaded;
+              // but we need to implement such fixup in a compiler first.
               assert(ccInstance::_rtti && !ccInstance::_rtti->IsEmpty());
               const uint32_t global_tid = runningInst->_typeidLocal2Global[arg_typeid];
               ScriptUserObject *suo = ScriptUserObject::CreateManaged(global_tid, arg_size);

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -166,6 +166,7 @@ public:
     static ccInstance *CreateEx(PScript scri, ccInstance * joined);
     static void SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
     static const JointRTTI *GetRTTI() { return _rtti.get(); }
+    static const Engine::RTTIHelper *GetRTTIHelper() { return _rttiHelper.get(); }
 
     ccInstance();
     ~ccInstance();

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -167,6 +167,13 @@ public:
     static void SetExecTimeout(unsigned sys_poll_ms, unsigned abort_ms, unsigned abort_loops);
     static const JointRTTI *GetRTTI() { return _rtti.get(); }
     static const Engine::RTTIHelper *GetRTTIHelper() { return _rttiHelper.get(); }
+    // Joins custom provided RTTI into the global collection;
+    // fills in maps for locid and typeid remap which may be used to know
+    // which *global* ids were assigned to this particular rtti's entries.
+    // Updates RTTIHelper correspondingly.
+    static void JoinRTTI(const RTTI &rtti,
+        std::unordered_map<uint32_t, uint32_t> &loc_l2g,
+        std::unordered_map<uint32_t, uint32_t> &type_l2g);
 
     ccInstance();
     ~ccInstance();

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 
 #include "ac/timer.h"
+#include "script/cc_reflecthelper.h"
 #include "script/cc_script.h"  // ccScript
 #include "script/cc_internal.h"  // bytecode constants
 #include "script/nonblockingscriptfunction.h"
@@ -234,6 +235,8 @@ private:
     static std::unique_ptr<JointRTTI> _rtti;
     // Full name to global id (global id is an actual index in the joint rtti table)
     static std::unordered_map<Common::String, uint32_t> _rttiLookup;
+    // Helper data for quicker RTTI analyzis
+    static std::unique_ptr<Engine::RTTIHelper> _rttiHelper;
     // Map local script's location id to global (program-wide)
     std::unordered_map<uint32_t, uint32_t> _locidLocal2Global;
     // Map local script's type id to global (program-wide)

--- a/Engine/script/cc_reflecthelper.cpp
+++ b/Engine/script/cc_reflecthelper.cpp
@@ -1,0 +1,111 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+#include "script/cc_reflecthelper.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+static void ResolvePtrsInStruct(const RTTI::Type &ti, const std::vector<RTTI::Type> &types,
+    const std::unordered_map<uint32_t, uint32_t> &typeid_to_type,
+    const std::vector<RTTIHelper::TypeFieldsRef> &field_refs,
+    std::vector<uint32_t> &offsets, uint32_t start_off)
+{
+    for (const auto *fi = ti.first_field; fi; fi = fi->next_field)
+    {
+        const uint32_t field_off = start_off + fi->offset;
+        if (fi->flags & RTTI::kField_ManagedPtr)
+        { // either a pointer to managed struct, or dynamic array
+            offsets.push_back(field_off);
+            continue;
+        }
+        
+        auto it_type = typeid_to_type.find(fi->f_typeid);
+        assert(it_type != typeid_to_type.end());
+        if (it_type == typeid_to_type.end())
+            continue;
+
+        const auto &ti = types[it_type->second];
+        if ((fi->flags & RTTI::kField_Array) && (ti.flags & RTTI::kType_Managed))
+        { // regular array of managed pointers
+            for (uint32_t el = 0; el < fi->num_elems; ++el)
+                offsets.push_back(field_off + el * RTTI::PointerSize);
+            continue;
+        }
+
+        if (ti.flags & RTTI::kType_Struct)
+        { // a struct or an array of structs
+            // First try if this struct was already calculated
+            if (it_type->second < field_refs.size())
+            {
+                const auto &fref = field_refs[it_type->second];
+                for (uint32_t el = 0; el < fi->num_elems; ++el)
+                    for (uint32_t foff = 0; foff < fref.field_num; ++foff)
+                        offsets.push_back(field_off + (el * ti.size) + offsets[fref.field_index + foff]);
+            }
+            // Otherwise, calculate nested structs recursively
+            else if (fi->num_elems == 0)
+            {
+                ResolvePtrsInStruct(ti, types, typeid_to_type, field_refs, offsets, field_off);
+            }
+            else
+            {
+                for (uint32_t el = 0; el < fi->num_elems; ++el)
+                    ResolvePtrsInStruct(ti, types, typeid_to_type, field_refs, offsets, field_off + el * ti.size);
+            }
+        }
+    }
+}
+
+// TODO: optimize this by (optionally?) keeping previously generated data
+// of the known types, and only generating for new types
+void RTTIHelper::Generate(const RTTI &rtti)
+{
+    // TODO: keep this map in the RTTI struct, or extended one?
+    // TODO: optimize this out for joint collection, as it has typeid = table index
+    std::unordered_map<uint32_t, uint32_t> typeid_to_type;
+    const auto &types = rtti.GetTypes();
+    for (size_t i = 0; i < types.size(); ++i)
+    {
+        typeid_to_type[types[i].this_id] = i;
+    }
+
+    _managedFieldsRef.clear();
+    _managedOffsets.clear();
+    for (const auto &ti : types)
+    {
+        uint32_t man_findex = _managedOffsets.size();
+        ResolvePtrsInStruct(ti, types, typeid_to_type, _managedFieldsRef, _managedOffsets, 0);
+        RTTIHelper::TypeFieldsRef ref;
+        ref.field_index = man_findex;
+        ref.field_num = _managedOffsets.size() - man_findex;
+        _managedFieldsRef.push_back(ref);
+    }
+}
+
+std::pair<std::vector<uint32_t>::const_iterator, std::vector<uint32_t>::const_iterator>
+    RTTIHelper::GetManagedOffsetsForType(uint32_t type_id) const
+{
+    assert(type_id < _managedFieldsRef.size());
+    assert(!_managedFieldsRef.empty());
+    if (type_id >= _managedFieldsRef.size() || _managedFieldsRef.empty())
+        return std::make_pair(_managedOffsets.end(), _managedOffsets.end());
+    const auto &fref = _managedFieldsRef[type_id];
+    return std::make_pair(_managedOffsets.begin() + fref.field_index,
+        _managedOffsets.begin() + fref.field_index + fref.field_num);
+}
+
+} // namespace Engine
+} // namespace AGS

--- a/Engine/script/cc_reflecthelper.h
+++ b/Engine/script/cc_reflecthelper.h
@@ -35,11 +35,13 @@ public:
         uint32_t field_index = 0u; // first field index in the fields table
     };
 
+    // Generate data based on full RTTI; this overwrite whole data
+    // WARNING: assumes RTTI has sequential type ids (joint RTTI); FIXME: enforce this?
+    // FIXME: allow to skip existing non-GENERATED types
     void Generate(const RTTI &rtti);
 
     // Returns a range of managed offsets (as a pair of [begin;end) iterators),
     // containing a list of managed fields offsets for the given type
-    // TODO: move to separate runtime-RTTI-helper... class?
     std::pair<std::vector<uint32_t>::const_iterator, std::vector<uint32_t>::const_iterator>
         GetManagedOffsetsForType(uint32_t type_id) const;
 

--- a/Engine/script/cc_reflecthelper.h
+++ b/Engine/script/cc_reflecthelper.h
@@ -1,0 +1,55 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// Helper classes for easier working with the runtime reflection (RTTI etc).
+//
+//=============================================================================
+#ifndef __AGS_EE_SCRIPT__REFLECTHELPER_H
+#define __AGS_EE_SCRIPT__REFLECTHELPER_H
+
+#include "script/cc_reflect.h"
+
+namespace AGS
+{
+namespace Engine
+{
+
+class RTTIHelper
+{
+public:
+    // Helper struct for referencing a range of type's fields
+    struct TypeFieldsRef
+    {
+        uint32_t field_num = 0u; // number of fields, if any
+        uint32_t field_index = 0u; // first field index in the fields table
+    };
+
+    void Generate(const RTTI &rtti);
+
+    // Returns a range of managed offsets (as a pair of [begin;end) iterators),
+    // containing a list of managed fields offsets for the given type
+    // TODO: move to separate runtime-RTTI-helper... class?
+    std::pair<std::vector<uint32_t>::const_iterator, std::vector<uint32_t>::const_iterator>
+        GetManagedOffsetsForType(uint32_t type_id) const;
+
+private:
+    // Quick-reference for the managed pointer fields in types
+    std::vector<TypeFieldsRef> _managedFieldsRef;
+    std::vector<uint32_t> _managedOffsets; // includes nested regular structs!
+};
+
+}
+}
+
+#endif // __AGS_EE_SCRIPT__REFLECTHELPER_H

--- a/Engine/script/cc_reflecthelper.h
+++ b/Engine/script/cc_reflecthelper.h
@@ -14,6 +14,10 @@
 //
 // Helper classes for easier working with the runtime reflection (RTTI etc).
 //
+// TODO: frankly, we just need a proper runtime Type class, with both
+// constant type info loaded from RTTI, and any additional generated data
+// and methods for easier/faster use.
+//
 //=============================================================================
 #ifndef __AGS_EE_SCRIPT__REFLECTHELPER_H
 #define __AGS_EE_SCRIPT__REFLECTHELPER_H

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -712,6 +712,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_agsdynamicobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_audiochannel.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_audioclip.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_basicobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_character.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_dialog.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_dynamicarray.h" />
@@ -721,6 +722,7 @@
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_hotspot.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_inventory.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_object.h" />
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_pluginobject.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_region.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\cc_serializer.h" />
     <ClInclude Include="..\..\Engine\ac\dynobj\managedobjectpool.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj
+++ b/Solutions/Engine.App/Engine.App.vcxproj
@@ -648,6 +648,7 @@
     <ClCompile Include="..\..\Engine\plugin\global_plugin.cpp" />
     <ClCompile Include="..\..\Engine\plugin\pluginobjectreader.cpp" />
     <ClCompile Include="..\..\Engine\script\cc_instance.cpp" />
+    <ClCompile Include="..\..\Engine\script\cc_reflecthelper.cpp" />
     <ClCompile Include="..\..\Engine\script\executingscript.cpp" />
     <ClCompile Include="..\..\Engine\script\exports.cpp" />
     <ClCompile Include="..\..\Engine\script\runtimescriptvalue.cpp" />
@@ -911,6 +912,7 @@
     <ClInclude Include="..\..\Engine\plugin\plugin_engine.h" />
     <ClInclude Include="..\..\Engine\resource\resource.h" />
     <ClInclude Include="..\..\Engine\script\cc_instance.h" />
+    <ClInclude Include="..\..\Engine\script\cc_reflecthelper.h" />
     <ClInclude Include="..\..\Engine\script\executingscript.h" />
     <ClInclude Include="..\..\Engine\script\exports.h" />
     <ClInclude Include="..\..\Engine\script\nonblockingscriptfunction.h" />

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -789,6 +789,9 @@
     <ClCompile Include="..\..\Engine\util\sdl2_util.cpp">
       <Filter>Source Files\util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Engine\script\cc_reflecthelper.cpp">
+      <Filter>Source Files\script</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Engine\ac\asset_helper.h">
@@ -1588,6 +1591,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Engine\util\sdl2_util.h">
       <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\script\cc_reflecthelper.h">
+      <Filter>Header Files\script</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Engine.App/Engine.App.vcxproj.filters
+++ b/Solutions/Engine.App/Engine.App.vcxproj.filters
@@ -1595,6 +1595,12 @@
     <ClInclude Include="..\..\Engine\script\cc_reflecthelper.h">
       <Filter>Header Files\script</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_pluginobject.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Engine\ac\dynobj\cc_basicobject.h">
+      <Filter>Header Files\ac\dynobj</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\Engine\resource\game-1.ico">


### PR DESCRIPTION
**WARNING:** this requires #1922 to work.
(pr's branch is based on top of that pr for easier testing)

This resolves a long existing problem of AGS script not supporting managed pointers inside user's managed structs.
Such syntax feature was explicitly disabled, because the runtime interpreter did not have any information on the struct's contents, only about it's size. When the user's managed object is disposed, engine cannot unreference the pointers contained in such struct, which leads to nested objects never disposed, occupying program memory (sort of "memory leak").

With addition of RTTI it is now possible to gather information about pointers contained within a type, and correctly unref all them on type's instance's disposal.

This PR introduces new script op code: `SCMD_NEWUSEROBJECT2`, which has 2 args: typeid and size.
The typeid is a local type id from the script's RTTI table.
Runtime interpreter converts local type id to a global one when creating a user object.

After loading scripts, engine generates a "flat" table of managed pointer offsets per struct. This speeds up user object disposal, as we don't have to analyze all the nested types all the time. Instead we do that only once the script is loaded, and then use a plain list of offsets.

Managed pointers in managed structs are enabled in both compilers, old and new one.

Both compilers declare extension "NESTEDPOINTERS", and a script author can use SCRIPT_EXT_NESTEDPOINTERS macro to test whether this feature is supported.

**TESTING**

The idea is that a structure of any complexity should be correctly disposed and removed from the memory when all references to it are gone. For example, you may have a managed struct that contains a particularly large dynamic array, and continuously create instances of that struct, observing program's memory usage.

```
#ifdef SCRIPT_EXT_NESTEDPOINTERS
managed struct ManagedStruct
{
    String Name;
    int BigArray[];
};

managed struct NestedPointers
{
    ManagedStruct* sp;
    ManagedStruct* sparr[];
};

function on_key_press(eKeyCode k)
{
    if (k == eKeySpace) {
        NestedPointers *t = new NestedPointers;
        t.sp = new ManagedStruct;
        t.sp.BigArray = new int[1000000];
        t.sp.Name = "some name";
        t.sparr = new ManagedStruct[10];
        for (int i = 0; i < 10; i++)
        {
            t.sparr[i] = new ManagedStruct;
            t.sparr[i].BigArray = new int[1000000];
            t.sparr[i].Name = String.Format("name %d", i);
        }
        // NestedPointers should be fully disposed here
    }
}
#endif // SCRIPT_EXT_NESTEDPOINTERS
```

**ISSUES / TODO:**
- [x] Also might need a new op code for creating a dynamic array with typeid, for knowing which type does they store. This may potentially allow dynamic arrays of *regular structs*, as they may contain nested managed pointers with more pointers inside, but neither compiler nor engine won't know how to properly unref these.
- [x] Must update the savegame format of a "user object", right now these will loose the type id when restoring a save.
- [x] Must update new compiler's tests.
- [x] Might add explicit compiler option for generating & saving rtti / allowing pointers in man structs.
- [x] Save game problem (see explanation [in comments below](https://github.com/adventuregamestudio/ags/pull/1923#issuecomment-1444370882)).