### PR TITLE
Emscripten: use same Freetype from AGS internal sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(EMSCRIPTEN)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Emscripten")
 
     set(AGS_OPENGLES2 TRUE)
-    set(USE_FLAGS " -sUSE_SDL=2  -sUSE_FREETYPE=1  -sUSE_VORBIS=1  -sUSE_OGG=1 ")
+    set(USE_FLAGS " -sUSE_SDL=2  -sUSE_VORBIS=1  -sUSE_OGG=1 ")
     set(AGS_DISABLE_THREADS TRUE)
     if(AGS_DISABLE_THREADS)
         add_compile_definitions("AGS_DISABLE_THREADS=1")
@@ -313,10 +313,10 @@ add_subdirectory(libsrc/glm                     EXCLUDE_FROM_ALL)
 add_subdirectory(libsrc/tinyxml2                EXCLUDE_FROM_ALL)
 
 add_subdirectory(Common/libsrc/aastr-0.1.1      EXCLUDE_FROM_ALL)
-if(NOT EMSCRIPTEN)
-    add_subdirectory(Common/libsrc/freetype-2.1.3   EXCLUDE_FROM_ALL)
-    set(FREETYPE_LIBRARIES FreeType::FreeType)
-endif()
+
+add_subdirectory(Common/libsrc/freetype-2.1.3   EXCLUDE_FROM_ALL)
+set(FREETYPE_LIBRARIES FreeType::FreeType)
+
 add_subdirectory(Common/libsrc/alfont-2.0.9     EXCLUDE_FROM_ALL)
 add_subdirectory(Common)
 

--- a/Emscripten/README.md
+++ b/Emscripten/README.md
@@ -118,8 +118,6 @@ If you want to fully integrate the IDE to the Chrome tools, the only one current
   - If you enable threads, editing the `CMakeLists.txt` to have `set(AGS_DISABLE_THREADS FALSE)`, you are going to fall in Emscripten Pthreads
     - Your browser need to be served both COOP, COEP and also the webpage has to be HTTPS with a valid certificate! This requires a webserver you are fully in control currently.
     - see more info here: https://emscripten.org/docs/porting/pthreads.html
-- Alt+tab/out of focus: I had to hide the existing mechanism for this because it halted the webpage running the game, it does work now, but AGS Script won't detect it's out of focus.
-- FreeType version used is not the one in the AGS repository, instead the current version used is the one from [Emscripten ports](https://github.com/emscripten-ports/FreeType), latest FreeType is compatible too with Emscripten and could easily be swapped in too. Some fonts may present with slightly differences (`LucasFan-Font.ttf` won't work correctly).
 
 It's important to think of the browser tab with the game and the JS/WASM machine to be running in a single thread, so this means at some point the browser must be in focus so it can process inputs and draw in the screen!
 

--- a/ci/emscripten/Dockerfile
+++ b/ci/emscripten/Dockerfile
@@ -8,5 +8,5 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Install required tools
 RUN apt-get update && apt-get install -y tzdata libarchive-tools git pkg-config curl build-essential cmake ninja-build bash python3 python3-pip
 
-RUN embuilder.py build --lto libstubs libc libc++ libc++abi sdl2 freetype ogg vorbis
-RUN embuilder.py build libstubs libc libc++ libc++abi sdl2 freetype ogg vorbis
+RUN embuilder.py build --lto libstubs libc libc++ libc++abi sdl2 ogg vorbis
+RUN embuilder.py build libstubs libc libc++ libc++abi sdl2 ogg vorbis


### PR DESCRIPTION
I didn't notice before, but with the current version of Emscripten we are using, the Freetype source files we have in AGS repository builds without problems!

I still have this bottom of the font being cut off problem with Kathy Rain running in the web port, that I am not sure yet what that would be.

I also updated the build in agsjs to use this version: https://ericoporto.github.io/agsjs/ (just remember to make sure to clear the cache when testing)

![image](https://user-images.githubusercontent.com/2244442/220395904-9c4fd95e-fd9f-459f-b902-483a3c7bd8de.png)
