### PR TITLE
Editor: Native use %zd compatible with size_t

### DIFF
--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3608,7 +3608,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		if (rs.DataVersion < kRoomVersion_300a)
 		{
 			char scriptFuncPrefix[100];
-			sprintf(scriptFuncPrefix, "object%d_", i);
+			sprintf(scriptFuncPrefix, "object%zu_", i);
 			ConvertInteractions(obj->Interactions, rs.Objects[i].Interaction.get(), gcnew String(scriptFuncPrefix), nullptr, 2);
 		}
 		else 
@@ -3631,7 +3631,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		if (rs.DataVersion < kRoomVersion_300a)
 		{
 			char scriptFuncPrefix[100];
-			sprintf(scriptFuncPrefix, "hotspot%d_", i);
+			sprintf(scriptFuncPrefix, "hotspot%zu_", i);
 			ConvertInteractions(hotspot->Interactions, rs.Hotspots[i].Interaction.get(), gcnew String(scriptFuncPrefix), nullptr, 1);
 		}
 		else 
@@ -3688,7 +3688,7 @@ void convert_room_from_native(const RoomStruct &rs, Room ^room, System::Text::En
 		if (rs.DataVersion < kRoomVersion_300a)
 		{
 			char scriptFuncPrefix[100];
-			sprintf(scriptFuncPrefix, "region%d_", i);
+			sprintf(scriptFuncPrefix, "region%zu_", i);
 			ConvertInteractions(area->Interactions, rs.Regions[i].Interaction.get(), gcnew String(scriptFuncPrefix), nullptr, 0);
 		}
 		else 


### PR DESCRIPTION
When I was building the Editor for 64-bit, build errors appeared in VS on these lines. Looking into wikipedia I found this

> z | For integer types, causes printf to expect a size_t-sized integer argument.
> -- | --


<!--EndFragment-->
</body>
</html>

https://en.wikipedia.org/wiki/Printf_format_string

The fix is still compatible with win32.