### PR TITLE
Engine: add plugin stub for agsappopenurl

### DIFF
--- a/Engine/plugin/global_plugin.cpp
+++ b/Engine/plugin/global_plugin.cpp
@@ -70,6 +70,12 @@ bool RegisterPluginStubs(const char* name)
     ccAddExternalStaticFunction("ShellExecute",                 Sc_PluginStub_Void);
     return true;
   }
+  else if (ags_stricmp(name, "agsappopenurl") == 0)
+  {
+    // agsappopenurl.dll
+    ccAddExternalStaticFunction("AppOpenURL",                 Sc_PluginStub_Int0);
+   return true;
+  }
   else if (ags_stricmp(name, "ags_snowrain") == 0)
   {
     // ags_snowrain.dll


### PR DESCRIPTION
I know it's a bit soon, but the idea of this plugin is to be able to remove it when no external url loading is desired. Unfortunately the way for this is stubs.

My hope is to switch out people from `agsshell` as I hope to reduce surface of problems through this url specific plugin. I know this is a bit soon, but I have got an increased number of asks about agsshell in the last days.