### PR TITLE
3.6.0: separate absolute/relative switch for Touch-to-mouse emulation

### DIFF
--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -93,6 +93,12 @@ struct Point
         Y = y;
     }
 
+    inline static Point Clamp(const Point &p, const Point &floor, const Point &ceil)
+    {
+        return Point(AGSMath::Clamp(p.X, floor.X, ceil.X),
+                    AGSMath::Clamp(p.Y, floor.Y, ceil.Y));
+    }
+
     inline bool operator ==(const Point &p) const
     {
         return X == p.X && Y == p.Y;

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1639,8 +1639,12 @@ namespace AGS.Editor
             NativeProxy.WritePrivateProfileString("mouse", "auto_lock", _game.DefaultSetup.AutoLockMouse ? "1" : "0", configFilePath);
             NativeProxy.WritePrivateProfileString("mouse", "speed", _game.DefaultSetup.MouseSpeed.ToString(CultureInfo.InvariantCulture), configFilePath);
 
-            int emulate_mouse = (int) _game.DefaultSetup.TouchToMouseEmulation;
-            NativeProxy.WritePrivateProfileString("touch", "emulate_mouse", emulate_mouse.ToString(), configFilePath);
+            // Touch input
+            string[] emulate_mouse_str = new string[] { "off", "one_finger", "two_fingers" };
+            NativeProxy.WritePrivateProfileString("touch", "emul_mouse_mode",
+                emulate_mouse_str[(int)_game.DefaultSetup.TouchToMouseEmulation], configFilePath);
+            NativeProxy.WritePrivateProfileString("touch", "emul_mouse_relative",
+                ((int)_game.DefaultSetup.TouchToMouseMotionMode).ToString(), configFilePath);
 
             // Note: sprite cache size is written in KB (while we have it in MB on the editor pane)
             NativeProxy.WritePrivateProfileString("misc", "cachemax", (_game.DefaultSetup.SpriteCacheSize * 1024).ToString(), configFilePath);

--- a/Engine/ac/gamesetup.cpp
+++ b/Engine/ac/gamesetup.cpp
@@ -29,6 +29,7 @@ GameSetup::GameSetup()
     mouse_ctrl_enabled = true;
     mouse_speed_def = kMouseSpeed_CurrentDisplay;
     touch_emulate_mouse = kTouchMouse_OneFingerDrag;
+    touch_motion_relative = false;
     RenderAtScreenRes = false;
     Supersampling = 1;
     clear_cache_on_room_change = false;

--- a/Engine/ac/gamesetup.h
+++ b/Engine/ac/gamesetup.h
@@ -14,6 +14,7 @@
 #ifndef __AC_GAMESETUP_H
 #define __AC_GAMESETUP_H
 
+#include "ac/sys_events.h"
 #include "main/graphics_mode.h"
 #include "util/string.h"
 
@@ -42,18 +43,6 @@ enum ScreenRotation
     kScreenRotation_Portrait,         // screen can only be in portrait orientation
     kScreenRotation_Landscape,        // screen can only be in landscape orientation
     kNumScreenRotationOptions
-};
-
-enum TouchMouseEmulation
-{
-    // don't emulate mouse
-    kTouchMouse_None = 0,
-    // copy default SDL2 behavior:
-    // touch down means hold LMB down, no RMB emulation
-    kTouchMouse_OneFingerDrag,
-    // tap 1,2 fingers means LMB/RMB click;
-    // double tap + drag 1 finger would drag the cursor with LMB down
-    kTouchMouse_TwoFingersTap
 };
 
 using AGS::Common::String;
@@ -91,8 +80,10 @@ struct GameSetup
     MouseControlWhen mouse_ctrl_when;
     bool  mouse_ctrl_enabled;
     MouseSpeedDef mouse_speed_def;
-    // touch-to-mouse emulation mode
-    int   touch_emulate_mouse;
+    // touch-to-mouse emulation mode (how the touches are handled overall)
+    TouchMouseEmulation touch_emulate_mouse;
+    // touch control abs/relative mode
+    bool  touch_motion_relative;
     //
     bool  RenderAtScreenRes; // render sprites at screen resolution, as opposed to native one
     int   Supersampling;

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -373,6 +373,8 @@ volatile int sys_mouse_y = 0; // mouse y position
 volatile int sys_mouse_z = 0; // mouse wheel position
 // Relative x and y deltas
 static int mouse_accum_relx = 0, mouse_accum_rely = 0;
+// ID of a device, which mouse events will be ignored (for easier testing)
+static int disabled_mouse_device = UINT32_MAX - 10;
 
 // Returns accumulated mouse button state and clears internal cache by timer
 static int mouse_button_poll()
@@ -387,6 +389,9 @@ static int mouse_button_poll()
 }
 
 static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event) {
+    if (event.which == disabled_mouse_device)
+        return;
+
     sys_mouse_x = event.x;
     sys_mouse_y = event.y;
     mouse_accum_relx += event.xrel;
@@ -395,6 +400,9 @@ static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event) {
 
 static void on_sdl_mouse_button(const SDL_MouseButtonEvent &event)
 {
+    if (event.which == disabled_mouse_device)
+        return;
+
     sys_mouse_x = event.x;
     sys_mouse_y = event.y;
 
@@ -409,6 +417,9 @@ static void on_sdl_mouse_button(const SDL_MouseButtonEvent &event)
 
 static void on_sdl_mouse_wheel(const SDL_MouseWheelEvent &event)
 {
+    if (event.which == disabled_mouse_device)
+        return;
+
     sys_mouse_z += event.y;
 }
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -388,7 +388,11 @@ static int mouse_button_poll()
     return result;
 }
 
-static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event) {
+// Syncs all the emulated mouse devices with the real sys_mouse_* coords
+static void sync_sys_mouse_pos();
+
+static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event)
+{
     if (event.which == disabled_mouse_device)
         return;
 
@@ -396,6 +400,7 @@ static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event) {
     sys_mouse_y = event.y;
     mouse_accum_relx += event.xrel;
     mouse_accum_rely += event.yrel;
+    sync_sys_mouse_pos();
 }
 
 static void on_sdl_mouse_button(const SDL_MouseButtonEvent &event)
@@ -656,7 +661,17 @@ static void set_t2m_pos(float x, float y, float dx, float dy)
         t2m.emul_pos = t2m.pos;
     }
 
+    t2m.emul_pos = Point::Clamp(t2m.emul_pos, Point(), Point(w - 1, h - 1));
     t2m.emul_pos_init = true;
+}
+
+// Syncs all the emulated mouse devices with the real sys_mouse_* coords
+static void sync_sys_mouse_pos()
+{
+    if (t2m.emul_pos_init)
+    {
+        t2m.emul_pos = Point(sys_mouse_x, sys_mouse_y);
+    }
 }
 
 static void on_sdl_touch_down(const SDL_TouchFingerEvent &event)

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -17,8 +17,8 @@
 //=============================================================================
 #ifndef __AGS_EE_AC__SYS_EVENTS_H
 #define __AGS_EE_AC__SYS_EVENTS_H
-#include "ac/keycode.h"
 #include <SDL_keyboard.h>
+#include "ac/keycode.h"
 
 // Keyboard input handling
 //
@@ -104,6 +104,25 @@ int  ags_check_mouse_wheel();
 extern volatile int sys_mouse_x; // mouse x position
 extern volatile int sys_mouse_y; // mouse y position
 extern volatile int sys_mouse_z; // mouse wheel position
+
+// Touch input handling
+// currently only performs touch-to-mouse emulation
+//
+// Touch-to-mouse emulation mode
+enum TouchMouseEmulation
+{
+    // don't emulate mouse
+    kTouchMouse_None = 0,
+    // copy default SDL2 behavior:
+    // touch down means hold LMB down, no RMB emulation
+    kTouchMouse_OneFingerDrag,
+    // tap 1,2 fingers means LMB/RMB click;
+    // double tap + drag 1 finger would drag the cursor with LMB down
+    kTouchMouse_TwoFingersTap
+};
+// Configures touch to mouse emulation
+void ags_touch_set_mouse_emulation(TouchMouseEmulation mode,
+    bool relative, float speed);
 
 
 // Other input utilities

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -118,7 +118,8 @@ enum TouchMouseEmulation
     kTouchMouse_OneFingerDrag,
     // tap 1,2 fingers means LMB/RMB click;
     // double tap + drag 1 finger would drag the cursor with LMB down
-    kTouchMouse_TwoFingersTap
+    kTouchMouse_TwoFingersTap,
+    kNumTouchMouseModes
 };
 // Configures touch to mouse emulation
 void ags_touch_set_mouse_emulation(TouchMouseEmulation mode,

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -92,8 +92,8 @@ extern bool sys_modkeys_fired; // tells whether mod combination had been used fo
 bool ags_misbuttondown(eAGSMouseButton but);
 // Returns mouse button code
 eAGSMouseButton ags_mgetbutton();
-// Returns recent relative mouse movement
-void ags_mouse_get_relxy(int &x, int &y);
+// Returns recent relative mouse movement; resets accumulated values
+void ags_mouse_acquire_relxy(int &x, int &y);
 // Updates mouse cursor position in game
 void ags_domouse();
 // Returns -1 for wheel down and +1 for wheel up

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -39,7 +39,6 @@ int mousex = 0, mousey = 0, numcurso = -1, hotx = 0, hoty = 0;
 // real mouse coordinates and bounds
 static int real_mouse_x = 0, real_mouse_y = 0;
 static int boundx1 = 0, boundx2 = 99999, boundy1 = 0, boundy2 = 99999;
-static int disable_mgetgraphpos = 0;
 char ignore_bounds = 0;
 extern char alpha_blend_cursor ;
 Bitmap *mousecurs[MAXCURSORS];
@@ -68,29 +67,13 @@ namespace Mouse
 
 void mgetgraphpos()
 {
-    // TODO: review and possibly rewrite whole thing;
-    // research what disable_mgetgraphpos does, and is this still necessary?
-
     // TODO: [sonneveld] find out where mgetgraphpos is needed, are events polled before that?
     sys_evt_process_pending();
 
-    if (disable_mgetgraphpos)
-    {
-        // The cursor coordinates are provided from alternate source;
-        // in this case we completely ignore actual cursor movement.
-        if (!ignore_bounds &&
-            // When applying script bounds we only do so while cursor is inside game viewport
-            Mouse::ControlRect.IsInside(mousex, mousey) &&
-            (mousex < boundx1 || mousey < boundy1 || mousex > boundx2 || mousey > boundy2))
-        {
-            mousex = Math::Clamp(mousex, boundx1, boundx2);
-            mousey = Math::Clamp(mousey, boundy1, boundy2);
-            msetgraphpos(mousex, mousey);
-        }
+    if (switched_away)
         return;
-    }
 
-    if (!switched_away && Mouse::ControlEnabled)
+    if (Mouse::ControlEnabled)
     {
         // Use relative mouse movement; speed factor should already be applied by SDL in this mode
         int rel_x, rel_y;

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -73,25 +73,14 @@ void mgetgraphpos()
     if (switched_away)
         return;
 
-    if (Mouse::ControlEnabled)
-    {
-        // Use relative mouse movement; speed factor should already be applied by SDL in this mode
-        int rel_x, rel_y;
-        ags_mouse_get_relxy(rel_x, rel_y);
-        real_mouse_x = Math::Clamp(real_mouse_x + rel_x, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
-        real_mouse_y = Math::Clamp(real_mouse_y + rel_y, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
-    }
-    else
-    {
-        // Save real cursor coordinates provided by system
-        real_mouse_x = Math::Clamp((int)sys_mouse_x, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
-        real_mouse_y = Math::Clamp((int)sys_mouse_y, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
-    }
+    // Save absolute cursor coordinates provided by system
+    // NOTE: relative motion and the speed factor should already be applied by SDL2 or our custom devices.
+    real_mouse_x = Math::Clamp((int)sys_mouse_x, Mouse::ControlRect.Left, Mouse::ControlRect.Right);
+    real_mouse_y = Math::Clamp((int)sys_mouse_y, Mouse::ControlRect.Top, Mouse::ControlRect.Bottom);
 
-    // Set new in-game cursor position
+    // Set new in-game cursor position, convert to the in-game logic coordinates
     mousex = real_mouse_x;
     mousey = real_mouse_y;
-
     if (!ignore_bounds &&
         // When applying script bounds we only do so while cursor is inside game viewport
         Mouse::ControlRect.IsInside(mousex, mousey) &&
@@ -101,7 +90,6 @@ void mgetgraphpos()
         mousey = Math::Clamp(mousey, boundy1, boundy2);
         msetgraphpos(mousex, mousey);
     }
-
     // Convert to virtual coordinates
     Mouse::WindowToGame(mousex, mousey);
 }
@@ -116,6 +104,8 @@ void msetcursorlimit(int x1, int y1, int x2, int y2)
 
 void msetgraphpos(int xa, int ya)
 {
+  sys_mouse_x = xa;
+  sys_mouse_y = ya;
   real_mouse_x = xa;
   real_mouse_y = ya;
   sys_window_set_mouse(real_mouse_x, real_mouse_y);

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -190,6 +190,11 @@ bool Mouse::IsControlEnabled()
     return ControlEnabled;
 }
 
+void Mouse::SetTouch2MouseMode(TouchMouseEmulation mode, bool relative, float speed)
+{
+    ags_touch_set_mouse_emulation(mode, relative, speed);
+}
+
 void Mouse::SetSpeedUnit(float f)
 {
     SpeedUnit = f;

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -11,16 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-//
-// MOUSELIBW32.CPP
-//
-// Library of mouse functions for graphics and text mode
-//
-// (c) 1994 Chris Jones
-// Win32 (allegro) update (c) 1999 Chris Jones
-//
-//=============================================================================
-
+#include "ac/sys_events.h"
 #include "util/geometry.h"
 
 #define MAXCURSORS 20
@@ -51,6 +42,8 @@ namespace Mouse
     void SetMovementControl(bool on);
     // Tell if the mouse movement control is enabled
     bool IsControlEnabled();
+    // Set the touch2mouse motion mode: absolute/relative
+    void SetTouch2MouseMode(TouchMouseEmulation mode, bool relative, float speed);
     // Set base speed factor, which would serve as a mouse speed unit
     void SetSpeedUnit(float f);
     // Get base speed factor

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -373,7 +373,9 @@ void apply_config(const ConfigTree &cfg)
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
         // Touch options
-        usetup.touch_emulate_mouse = (TouchMouseEmulation)CfgReadInt(cfg, "touch", "emulate_mouse", 1);
+        usetup.touch_emulate_mouse = StrUtil::ParseEnum<TouchMouseEmulation>(
+            CfgReadString(cfg, "touch", "emul_mouse_mode", "one_finger"),
+            CstrArr<kNumTouchMouseModes>{ "off", "one_finger", "two_fingers" }, usetup.touch_emulate_mouse);
         usetup.touch_motion_relative = CfgReadBoolInt(cfg, "touch", "emul_mouse_relative");
 
         // Various system options

--- a/Engine/main/config.cpp
+++ b/Engine/main/config.cpp
@@ -373,7 +373,8 @@ void apply_config(const ConfigTree &cfg)
             mouse_str, CstrArr<kNumMouseSpeedDefs>{ "absolute", "current_display" }, usetup.mouse_speed_def);
 
         // Touch options
-        usetup.touch_emulate_mouse = CfgReadInt(cfg, "touch", "emulate_mouse", 1);
+        usetup.touch_emulate_mouse = (TouchMouseEmulation)CfgReadInt(cfg, "touch", "emulate_mouse", 1);
+        usetup.touch_motion_relative = CfgReadBoolInt(cfg, "touch", "emul_mouse_relative");
 
         // Various system options
         usetup.multitasking = CfgReadInt(cfg, "misc", "background", 0) != 0;

--- a/Engine/main/engine_setup.cpp
+++ b/Engine/main/engine_setup.cpp
@@ -251,6 +251,9 @@ void engine_post_gfxmode_mouse_setup(const Size &init_desktop)
     Mouse_EnableControl(usetup.mouse_ctrl_enabled);
     Debug::Printf(kDbgMsg_Info, "Mouse speed control: %s, unit: %f, user value: %f",
         usetup.mouse_ctrl_enabled ? "enabled" : "disabled", Mouse::GetSpeedUnit(), Mouse::GetSpeed());
+    Mouse::SetTouch2MouseMode(usetup.touch_emulate_mouse, usetup.touch_motion_relative, usetup.mouse_speed);
+    Debug::Printf(kDbgMsg_Info, "Touch-to-mouse motion mode: %s",
+        usetup.touch_motion_relative ? "relative" : "absolute");
 
     on_coordinates_scaling_changed();
 

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -159,7 +159,7 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
     // mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls
     //    * 0 - direct touch mouse control
-    CfgWriteInt(cfg, "mouse", "control_enabled", setup.mouse_control_mode);
+    CfgWriteInt(cfg, "touch", "emul_mouse_relative", setup.mouse_control_mode);
     CfgWriteFloat(cfg, "mouse", "speed", (float)std::max(setup.mouse_speed, 1)/10.f);
 
     // translations

--- a/Engine/platform/base/mobile_base.cpp
+++ b/Engine/platform/base/mobile_base.cpp
@@ -155,7 +155,8 @@ void ApplyEngineConfiguration(const MobileSetup &setup, ConfigTree &cfg)
     //    * 0 - off
     //    * 1 - one finger (holding, dragging)
     //    * 2 - two fingers (tapping)
-    CfgWriteInt(cfg, "touch", "emulate_mouse", setup.mouse_emulation);
+    const char *emul_mode_str[] = { "off", "one_finger", "two_fingers" };
+    CfgWriteString(cfg, "touch", "emul_mouse_mode", emul_mode_str[std::max(0, std::min(2, setup.mouse_emulation))]);
     // mouse_control_mode - enable relative mouse mode
     //    * 1 - relative mouse touch controls
     //    * 0 - direct touch mouse control

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -78,6 +78,12 @@ Locations of two latter files differ between running platforms:
     * absolute - use precisely the speed value provided by config;
     * current_display - keep cursor's speed by screen size relation by increasing actual cursor speed when running game in low resolution and decreasing when running in higher than the current user's dekstop resolution (this is default).
   * speed = \[real\] - mouse cursor speed (default is 1.0).
+* **\[touch\]** - touch input options
+  * emul_mouse_mode = \[string | integer\] - touch-to-mouse emulation (whether touch input should emulate the mouse input and how):
+    * off (0) - disabled;
+    * one_finger (1) - one finger maps directly to left click;
+    * two_fingers (2) - tap 1 finger for left click, hold 1st finger and tap 2nd for right click, double tap 1 finger for drag mode.
+  * emul_mouse_relative = \[0; 1\] - enable or disable relative emulated mouse movement.
 * **\[language\]** - language options
   * translation = \[string\] - name of the translation to use. A \<name\>.tra file should be present in the game directory.
 * **\[misc\]** - various options


### PR DESCRIPTION
Resolves #1930.

Support interpreting mouse motion events as absolute or relative, individually per "mouse" device (real or emulated). The inner engine code that assigns a game cursor position no longer relies on config setting, but instead relies on the accumulated mouse position, provided by the event handling unit. Relative motion (movement delta) is currently unused but kept in the code, as it may become useful later for certain purposes.

Event handling assumes that the received mouse position and deltas are generated with all the settings already applied by the sending device (absolute/relative mode, speed, and so forth).

Touch2mouse code is adjusted to have its own absolute/relative option, and calculate new position in the relative mode correspondingly.

Added a separate config setting for touch controls: `[touch] motion_relative` (name may be adjusted, if it looks bad). This setting is applied to event handler "component", which affects how the touch-to-mouse emulated device is handled.
Changed mobile code to write this setting, instead of `[mouse] control_enabled`, which is really unrelated to this.

Additionally (although this was not required) changed how `[touch] emulate_mouse` is written: now it has a string value instead of a number (i'm not sure why I left it like this the last time): "off", "one_finger", "two_fingers".