### PR TITLE
3.6.0: support custom acsetup.cfg in the project root

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1692,8 +1692,6 @@ namespace AGS.Editor
 
         private object SaveGameFilesProcess(IWorkProgress progress, object parameter)
         {
-			WriteConfigFile(Path.Combine(OUTPUT_DIRECTORY, DATA_OUTPUT_DIRECTORY));
-
             SaveUserDataFile();
 
             StringWriter sw = new StringWriter();

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -1582,13 +1582,10 @@ namespace AGS.Editor
         }
 
         /// <summary>
-        /// Writes up-to-date game information into configuration file.
-        /// This updates only values that strongly depend on game properties,
-        /// and does not affect user settings.
+        /// Writes the config file using particular game Settings and DefaultSetup options.
         /// </summary>
-		public void WriteConfigFile(string outputDir, bool resetFile = true)
+		public void WriteConfigFile(string configFilePath, bool resetFile = true)
 		{
-            string configFilePath = Path.Combine(outputDir, CONFIG_FILE_NAME);
             if (resetFile)
                 Utilities.TryDeleteFile(configFilePath);
 

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -547,7 +547,7 @@ namespace AGS.Editor
             }
 
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(assetsDir);
+            GenerateConfigFile(assetsDir);
             WriteAndroidCfg(assetsDir);
 
             foreach (KeyValuePair<string, string> pair in GetRequiredLibraryPaths())

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
@@ -125,5 +125,30 @@ namespace AGS.Editor
                 return Path.Combine(Path.Combine(Factory.AGSEditor.CurrentGame.DirectoryPath, AGSEditor.OUTPUT_DIRECTORY), OutputDirectory);
             }
         }
+
+        /// <summary>
+        /// Generates a common config file in two steps:
+        /// 1) copies a custom config from the project root, if one was provided by user;
+        /// 2) writes over DefaultSetup, overwriting any matching entries, but not removing other contents.
+        /// </summary>
+        protected void GenerateConfigFile(string destDir)
+        {
+            string gameDir = AGSEditor.Instance.GameDirectory;
+            destDir = Path.Combine(gameDir, destDir); // resolve to the absolute path for Uri check
+            string customCfg = Path.Combine(gameDir, AGSEditor.CONFIG_FILE_NAME);
+            string destPath = Path.Combine(destDir, AGSEditor.CONFIG_FILE_NAME);
+            if (!Utilities.PathsAreEqual(destDir, gameDir))
+            {
+                try
+                {
+                    if (File.Exists(customCfg))
+                        File.Copy(customCfg, destPath, true);
+                    else
+                        Utilities.TryDeleteFile(destPath);
+                }
+                catch (Exception) { }
+            }
+            AGSEditor.Instance.WriteConfigFile(destPath, false);
+        }
     }
 }

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -182,7 +182,7 @@ namespace AGS.Editor
             Utilities.TryDeleteFile(AGSEditor.COMPILED_DTA_FILE_NAME);
             CreateAudioVOXFile(forceRebuild);
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(GetCompiledPath());
+            GenerateConfigFile(GetCompiledPath());
             return true;
         }
 

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDebug.cs
@@ -105,7 +105,7 @@ namespace AGS.Editor
                 // Copy files from Compiled/Data to Compiled/Windows, because this is currently where game will be looking them up
                 targetWin.CopyAuxiliaryGameFiles(Path.Combine(AGSEditor.OUTPUT_DIRECTORY, AGSEditor.DATA_OUTPUT_DIRECTORY), false);
                 // Update config file with current game parameters
-                Factory.AGSEditor.WriteConfigFile(GetCompiledPath());
+                GenerateConfigFile(GetCompiledPath());
             }
             catch (Exception ex)
             {

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -130,7 +130,7 @@ namespace AGS.Editor
                 }
             }
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(GetCompiledPath(LINUX_DATA_DIR));
+            GenerateConfigFile(GetCompiledPath(LINUX_DATA_DIR));
 
             foreach (KeyValuePair<string, string> pair in GetRequiredLibraryPaths())
             {

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
@@ -58,7 +58,7 @@ namespace AGS.Editor
             my_game_files_text += "];";
 
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(GetCompiledPath(WEB_DIR));
+            GenerateConfigFile(GetCompiledPath(WEB_DIR));
 
             string compiled_web_path = GetCompiledPath(WEB_DIR);
             string editor_web_prebuilt = Path.Combine(Factory.AGSEditor.EditorDirectory, WEB_DIR);

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -137,7 +137,7 @@ namespace AGS.Editor
             // Copy DLLs
             File.Copy(Path.Combine(Factory.AGSEditor.EditorDirectory, "SDL2.dll"), Path.Combine(GetCompiledPath(), "SDL2.dll"), true);
             // Update config file with current game parameters
-            Factory.AGSEditor.WriteConfigFile(GetCompiledPath());
+            GenerateConfigFile(GetCompiledPath());
             // Copy Windows plugins
             CopyPlugins(errors);
             return true;

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -169,6 +169,13 @@ namespace AGS.Editor
             return sourcePath;
         }
 
+        public static bool PathsAreEqual(string path1, string path2)
+        {
+            Uri uri1 = new Uri(path1);
+            Uri uri2 = new Uri(path2);
+            return uri1.Equals(uri2);
+        }
+
         /// <summary>
         /// Tells if the given path equals to or subdirectory of a basepath.
         /// </summary>


### PR DESCRIPTION
This makes Editor copy an optional `acsetup.cfg` from the **project root** into the Compiled folder(s) before applying default config from the game's data.

The purpose is to provide a workaround for the two cases:
1) There's a standard config setting that is not implemented inside the editor itself yet.
2) User wants to add some completely custom settings by default, intending to read them from script or their own setup utility.

IMO the Compiled folder should be assumed to be completely generated output, so having anything persistent inside is not recommended (indeed, this is not 100% true at the moment, but perhaps we will get there eventually).

The suggested change makes Editor generate final `acsetup.cfg` from two "parts": an optional `acsetup.cfg`, if one is provided by the user in the project's root, and data from General Settings and Default Setup components. The latter overwrites any matching settings, but *does not delete* any unknown entries.