### PR TITLE
Fix incorrectly linked mbstowcs() and wcstombs() placeholders

### DIFF
--- a/Engine/platform/util/libc.c
+++ b/Engine/platform/util/libc.c
@@ -26,26 +26,37 @@
 #include <wchar.h>
 #include <ctype.h>
 
+// This is a pure mbstowcs placeholder that copies src to dest,
+// not a real implementation
 size_t mbstowcs(wchar_t *wcstr, const char *mbstr, size_t max)
 {
   size_t count = 0;
+  // Copy until reached the end of dest buffer, or 0
   while ((count < max) && (*mbstr != 0))
   {
     *wcstr++ = *mbstr++;
     count++;
   }
+  // Terminate the string, if possible
+  if (count < max)
+    *wcstr = 0;
   return count;
-
 }
 
+// This is a pure wcstombs placeholder that copies src to dest,
+// not a real implementation
 size_t wcstombs(char* mbstr, const wchar_t *wcstr, size_t max)
 {
   size_t count = 0;
+  // Copy until reached the end of dest buffer, or 0
   while ((count < max) && (*wcstr != 0))
   {
     *mbstr++ = *wcstr++;
     count++;
   }
+  // Terminate the string, if possible
+  if (count < max)
+    *mbstr = 0;
   return count;
 }
 

--- a/Engine/platform/util/libc.c
+++ b/Engine/platform/util/libc.c
@@ -12,13 +12,16 @@
 //
 //=============================================================================
 //
-// Implementations for missing libc functions
+// Implementations for missing libc functions.
+// Some of these were required for old mobile SDK/NDKs, which missed
+// particular string functions. Make certain to keep this updated,
+// and link STRICTLY on platforms that require these.
 //
 //=============================================================================
 
 #include "core/platform.h"
 
-#if ! AGS_PLATFORM_OS_WINDOWS
+#if (0)
 
 #include <string.h>
 #include <stdio.h>
@@ -60,4 +63,4 @@ size_t wcstombs(char* mbstr, const wchar_t *wcstr, size_t max)
   return count;
 }
 
-#endif // ! AGS_PLATFORM_OS_WINDOWS
+#endif // ! 0


### PR DESCRIPTION
This is a weird issue; there were number of libc function placeholders added to the engine, mainly for Android, as its older versions of NDK were missing these. Some were not real implementations, but emulations; e.g. mbstowcs() and wcstombs() were simply copying the strings char by char without any actual conversion.

For unknown reasons (oversight?),  these functions were also included into Linux build, and later - OSX. This was many years ago (see 67447accbdcfb73af0b2c44c9cb9e6bcace965e0).

Now we do have a limited use of wcstombs() in the engine, and these placeholders prevent from using proper functions from libc.

This PR does two things:
* Fixed the mbstowcs() and wcstombs() placeholders to ensure they properly terminate output string, as per specs.
* Disable them for now. If they will be necessary on some devices (Android, iOS?), - then they may be reenabled, but *only* on these particular systems.

PS. Actually, alfont is using both of these functions under *specific* conditions. I don't have any proof, but wonder if the missing string terminator bug could have any effect in #835 / #1909.