### PR TITLE
Small fixes

### DIFF
--- a/Common/font/ttffontrenderer.cpp
+++ b/Common/font/ttffontrenderer.cpp
@@ -114,16 +114,18 @@ bool TTFFontRenderer::LoadFromDiskEx(int fontNumber, int fontSize,
     String filename = String::FromFormat("agsfnt%d.ttf", fontNumber);
     if (fontSize <= 0)
         fontSize = 8; // compatibility fix
-    if (params && params->SizeMultiplier > 1)
-        fontSize *= params->SizeMultiplier;
+    assert(params);
+    FontRenderParams f_params = params ? *params : FontRenderParams();
+    if (f_params.SizeMultiplier > 1)
+        fontSize *= f_params.SizeMultiplier;
 
     ALFONT_FONT *alfptr = LoadTTF(filename, fontSize,
-        GetAlfontFlags(params->LoadMode));
+        GetAlfontFlags(f_params.LoadMode));
     if (!alfptr)
         return false;
 
     _fontData[fontNumber].AlFont = alfptr;
-    _fontData[fontNumber].Params = params ? *params : FontRenderParams();
+    _fontData[fontNumber].Params = f_params;
     if (metrics)
         FillMetrics(alfptr, metrics);
     return true;

--- a/Engine/ac/global_audio.cpp
+++ b/Engine/ac/global_audio.cpp
@@ -374,11 +374,10 @@ void PlayMP3File (const char *filename) {
     int useChan = prepare_for_new_music ();
     bool doLoop = (play.music_repeat > 0);
 
-    SOUNDCLIP *clip = nullptr;
+    SOUNDCLIP *clip = my_load_ogg(asset_name, doLoop);
     int sound_type = 0;
     
     if (!clip) {
-        clip = my_load_ogg(asset_name, doLoop);
         sound_type = MUS_OGG;
     }
 

--- a/libsrc/allegro/src/win/gdi.c
+++ b/libsrc/allegro/src/win/gdi.c
@@ -523,9 +523,9 @@ HBITMAP convert_bitmap_to_hbitmap(BITMAP *bitmap)
    holdpal = SelectPalette(hdc, hpal, TRUE);
    RealizePalette(hdc);
    hbmp = CreateDIBitmap(hdc, &bi->bmiHeader, CBM_INIT, pixels, bi, DIB_RGB_COLORS);
-   ReleaseDC(NULL, hdc);
 
    SelectPalette(hdc, holdpal, TRUE);
+   ReleaseDC(NULL, hdc);
    DeleteObject(hpal);
 
    _AL_FREE(pixels);


### PR DESCRIPTION
- in `Common/font/ttffontrenderer.cpp`, the params of font renderer are checked for null, but also used without checking for null, I moved this check to the top.
- in `libsrc/allegro/src/win/gdi.c` hdc is used after being released, this is only not a problem because the method that uses it is not used anywhere (I thought about deleting all, but it could be useful for adding an image in Winsetup one day as a decoration)
- in `Engine/ac/global_audio.cpp`, there is a logical mistake
