### PR TITLE
3.6.0: improve how vsync is changed at runtime

### DIFF
--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -932,7 +932,10 @@ void render_to_screen()
     // Stage: engine overlay
     construct_engine_overlay();
 
-    gfxDriver->SetVsync(scsystem.vsync > 0);
+    // Try set new vsync value, and remember the actual result
+    bool new_vsync = gfxDriver->SetVsync(scsystem.vsync > 0);
+    if (new_vsync != scsystem.vsync)
+        System_SetVSyncInternal(new_vsync);
 
     bool succeeded = false;
     while (!succeeded && !want_exit && !abort_engine)

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -129,9 +129,13 @@ int System_GetVsync() {
 
 void System_SetVsync(int newValue) {
     if (gfxDriver->DoesSupportVsyncToggle()) {
-        scsystem.vsync = newValue;
-        usetup.Screen.Params.VSync = newValue != 0;
+        System_SetVSyncInternal(newValue != 0);
     }
+}
+
+void System_SetVSyncInternal(bool vsync) {
+    scsystem.vsync = vsync;
+    usetup.Screen.Params.VSync = vsync;
 }
 
 int System_GetWindowed() {

--- a/Engine/ac/system.h
+++ b/Engine/ac/system.h
@@ -33,6 +33,7 @@ int     System_GetCapsLock();
 int     System_GetScrollLock();
 int     System_GetVsync();
 void    System_SetVsync(int newValue);
+void    System_SetVSyncInternal(bool vsync);
 int     System_GetWindowed();
 int     System_GetSupportsGammaControl();
 int     System_GetGamma();

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -2047,14 +2047,15 @@ void OGLGraphicsDriver::SetScreenTint(int red, int green, int blue)
 }
 
 
-bool OGLGraphicsDriver::SetVsync(bool enabled)
+bool OGLGraphicsDriver::SetVsyncImpl(bool enabled, bool &vsync_res)
 {
-    if (SDL_GL_SetSwapInterval(enabled) == 0)
+    if (SDL_GL_SetSwapInterval(enabled) != 0)
     {
-        _mode.Vsync = enabled;
+        Debug::Printf(kDbgMsg_Error, "OGL: SetVsync (%d) failed: %s", enabled, SDL_GetError());
+        return false;
     }
-
-    return _mode.Vsync;
+    vsync_res = SDL_GL_GetSwapInterval() != 0;
+    return true;
 }
 
 OGLGraphicsFactory *OGLGraphicsFactory::_factory = nullptr;

--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -269,9 +269,9 @@ void OGLGraphicsDriver::InitGlParams(const DisplayMode &mode)
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 
-  bool vsyncEnabled = SDL_GL_SetSwapInterval(mode.Vsync ? 1 : 0) == 0;
-  if (mode.Vsync && !vsyncEnabled)
-    Debug::Printf(kDbgMsg_Warn, "WARNING: Vertical sync could not be enabled. Setting will be kept at driver default.");
+  _capsVsync = SDL_GL_SetSwapInterval(mode.Vsync ? 1 : 0) == 0;
+  if (mode.Vsync && !_capsVsync)
+    Debug::Printf(kDbgMsg_Warn, "OGL: SetVsync (%d) failed: %s", mode.Vsync, SDL_GetError());
 
 #if AGS_PLATFORM_OS_IOS
   // Setup library mouse to have 1:1 coordinate transformation.
@@ -2051,7 +2051,7 @@ bool OGLGraphicsDriver::SetVsyncImpl(bool enabled, bool &vsync_res)
 {
     if (SDL_GL_SetSwapInterval(enabled) != 0)
     {
-        Debug::Printf(kDbgMsg_Error, "OGL: SetVsync (%d) failed: %s", enabled, SDL_GetError());
+        Debug::Printf(kDbgMsg_Warn, "OGL: SetVsync (%d) failed: %s", enabled, SDL_GetError());
         return false;
     }
     vsync_res = SDL_GL_GetSwapInterval() != 0;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -227,7 +227,7 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    bool DoesSupportVsyncToggle() override { return true; }
+    bool DoesSupportVsyncToggle() override { return _capsVsync; }
     void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override;
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -228,7 +228,6 @@ public:
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
     bool DoesSupportVsyncToggle() override { return true; }
-    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool enabled, int supersampling) override;
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
@@ -250,6 +249,8 @@ public:
     ~OGLGraphicsDriver() override;
 
 protected:
+    bool SetVsyncImpl(bool vsync, bool &vsync_res) override;
+
     // Create texture data with the given parameters
     TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
     // Update texture data from the given bitmap
@@ -259,8 +260,6 @@ protected:
         int width, int height, int color_depth, bool opaque) override;
     // Retrieve shared texture data object from the given DDB
     std::shared_ptr<TextureData> GetTextureData(IDriverDependantBitmap *ddb) override;
-
-protected:
     size_t GetLastDrawEntryIndex() override { return _spriteList.size(); }
 
 private:

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -189,7 +189,7 @@ public:
     bool SupportsGammaControl() override ;
     void SetGamma(int newGamma) override;
     void UseSmoothScaling(bool /*enabled*/) override { }
-    bool DoesSupportVsyncToggle() override { return SDL_VERSION_ATLEAST(2, 0, 18); }
+    bool DoesSupportVsyncToggle() override { return (SDL_VERSION_ATLEAST(2, 0, 18)) && _capsVsync; }
     void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
     bool RequiresFullRedrawEachFrame() override { return false; }
     bool HasAcceleratedTransform() override { return false; }

--- a/Engine/gfx/ali3dsw.h
+++ b/Engine/gfx/ali3dsw.h
@@ -190,7 +190,6 @@ public:
     void SetGamma(int newGamma) override;
     void UseSmoothScaling(bool /*enabled*/) override { }
     bool DoesSupportVsyncToggle() override { return SDL_VERSION_ATLEAST(2, 0, 18); }
-    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool /*enabled*/, int /*supersampling*/) override { }
     bool RequiresFullRedrawEachFrame() override { return false; }
     bool HasAcceleratedTransform() override { return false; }
@@ -208,6 +207,7 @@ public:
     void SetGraphicsFilter(PSDLRenderFilter filter);
 
 protected:
+    bool SetVsyncImpl(bool vsync, bool &vsync_res) override;
     size_t GetLastDrawEntryIndex() override { return _spriteList.size(); }
 
 private:

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -64,6 +64,21 @@ Rect GraphicsDriverBase::GetRenderDestination() const
     return _dstRect;
 }
 
+bool GraphicsDriverBase::SetVsync(bool enabled)
+{
+    if (_mode.Vsync == enabled)
+    {
+        return _mode.Vsync;
+    }
+
+    bool new_value;
+    if (SetVsyncImpl(enabled, new_value))
+    {
+        _mode.Vsync = new_value;
+    }
+    return _mode.Vsync;
+}
+
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
     GraphicFlip flip, PBitmap surface)
 {

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -86,6 +86,11 @@ bool GraphicsDriverBase::SetVsync(bool enabled)
     return _mode.Vsync;
 }
 
+bool GraphicsDriverBase::GetVsync() const
+{
+    return _mode.Vsync;
+}
+
 void GraphicsDriverBase::BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
     GraphicFlip flip, PBitmap surface)
 {

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -11,10 +11,11 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include "gfx/gfxdriverbase.h"
+#include "debug/out.h"
 #include "gfx/ali3dexception.h"
 #include "gfx/bitmap.h"
 #include "gfx/gfxfilter.h"
-#include "gfx/gfxdriverbase.h"
 #include "gfx/gfx_util.h"
 
 using namespace AGS::Common;
@@ -66,15 +67,21 @@ Rect GraphicsDriverBase::GetRenderDestination() const
 
 bool GraphicsDriverBase::SetVsync(bool enabled)
 {
-    if (_mode.Vsync == enabled)
+    if (!_capsVsync || (_mode.Vsync == enabled))
     {
         return _mode.Vsync;
     }
 
     bool new_value;
-    if (SetVsyncImpl(enabled, new_value))
+    if (SetVsyncImpl(enabled, new_value) && new_value == enabled)
     {
+        Debug::Printf("SetVsync: switched to %d", new_value);
         _mode.Vsync = new_value;
+    }
+    else
+    {
+        Debug::Printf("SetVsync: failed, stay at %d", new_value);
+        _capsVsync = false; // mark as non-capable (at least in current mode)
     }
     return _mode.Vsync;
 }
@@ -128,6 +135,8 @@ void GraphicsDriverBase::OnUnInit()
 void GraphicsDriverBase::OnModeSet(const DisplayMode &mode)
 {
     _mode = mode;
+    // Adjust some generic parameters as necessary
+    _mode.Vsync &= _capsVsync;
 }
 
 void GraphicsDriverBase::OnModeReleased()

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -111,6 +111,8 @@ public:
     Size        GetNativeSize() const override;
     Rect        GetRenderDestination() const override;
 
+    bool        SetVsync(bool enabled) override;
+
     void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
                     Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) override;
     virtual void BeginSpriteBatch(IDriverDependantBitmap *render_target, const Rect &viewport, const SpriteTransform &transform,
@@ -145,6 +147,11 @@ protected:
     virtual void OnSetRenderFrame(const Rect &dst_rect);
     // Called when the new filter is set
     virtual void OnSetFilter();
+
+    // Try changing vsync setting; fills new current mode in vsync_res,
+    // returns whether the new setting was set successfully.
+    virtual bool SetVsyncImpl(bool vsync, bool &vsync_res) { return false; }
+
     // Initialize sprite batch and allocate necessary resources
     virtual void InitSpriteBatch(size_t index, const SpriteBatchDesc &desc) = 0;
     // Gets the index of a last draw entry (sprite)

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -169,6 +169,9 @@ protected:
     Rect                _filterRect;    // filter scaling destination rect (before final scaling)
     PlaneScaling        _scaling;       // native -> render dest coordinate transformation
 
+    // Capability flags
+    bool                _capsVsync = false; // is vsync available
+
     // Callbacks
     GFXDRV_CLIENTCALLBACK _pollingCallback;
     GFXDRV_CLIENTCALLBACK _drawScreenCallback;

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -112,6 +112,7 @@ public:
     Rect        GetRenderDestination() const override;
 
     bool        SetVsync(bool enabled) override;
+    bool        GetVsync() const override;
 
     void        BeginSpriteBatch(const Rect &viewport, const SpriteTransform &transform,
                     Common::GraphicFlip flip = Common::kFlip_None, PBitmap surface = nullptr) override;

--- a/Engine/gfx/graphicsdriver.h
+++ b/Engine/gfx/graphicsdriver.h
@@ -187,8 +187,10 @@ public:
   virtual bool GetCopyOfScreenIntoBitmap(Common::Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt = nullptr) = 0;
   // Tells if the renderer supports toggling vsync after initializing the mode.
   virtual bool DoesSupportVsyncToggle() = 0;
-  // Toggles vertical sync mode, if renderer supports one; returns the new state.
+  // Toggles vertical sync mode, if renderer supports one; returns the *new state*.
   virtual bool SetVsync(bool enabled) = 0;
+  // Tells if the renderer currently has vsync enabled.
+  virtual bool GetVsync() const = 0;
   // Enables or disables rendering mode that draws sprite list directly into
   // the final resolution, as opposed to drawing to native-resolution buffer
   // and scaling to final frame. The effect may be that sprites that are

--- a/Engine/main/graphics_mode.cpp
+++ b/Engine/main/graphics_mode.cpp
@@ -429,6 +429,8 @@ bool graphics_mode_init_any(const GraphicResolution &game_res, const DisplayMode
         setup.Windowed ? "yes" : "no",
         ws.Size.Width, ws.Size.Height,
         scale_option.GetCStr());
+    Debug::Printf(kDbgMsg_Info, "Graphic settings: refresh rate (optional): %d, vsync: %d",
+        setup.Params.RefreshRate, setup.Params.VSync);
 
     // Prepare the list of available gfx factories, having the one requested by user at first place
     // TODO: make factory & driver IDs case-insensitive!
@@ -519,6 +521,7 @@ bool graphics_mode_set_dm(const DisplayMode &dm)
     Debug::Printf(kDbgMsg_Info, "Graphics mode set: %d x %d (%d-bit) %s",
         rdm.Width, rdm.Height, rdm.ColorDepth,
         rdm.IsWindowed() ? "windowed" : (rdm.IsRealFullscreen() ? "fullscreen" : "fullscreen desktop"));
+    Debug::Printf(kDbgMsg_Info, "Graphics mode set: refresh rate (optional): %d, vsync: %d", rdm.RefreshRate, rdm.Vsync);
     return true;
 }
 

--- a/Engine/platform/windows/gfx/ali3dd3d.cpp
+++ b/Engine/platform/windows/gfx/ali3dd3d.cpp
@@ -452,6 +452,12 @@ bool D3DGraphicsDriver::CreateDisplayMode(const DisplayMode &mode)
     sys_window_create("", mode.Width, mode.Height, mode.Mode);
   }
 
+  D3DCAPS9 caps;
+  direct3ddevice->GetDeviceCaps(&caps);
+  _capsVsync = (caps.PresentationIntervals & D3DPRESENT_INTERVAL_ONE) != 0;
+  if (mode.Vsync && !_capsVsync)
+    Debug::Printf(kDbgMsg_Warn, "WARNING: Vertical sync is not supported. Setting will be kept at driver default.");
+
   HWND hwnd = (HWND)sys_win_get_window();
   memset( &d3dpp, 0, sizeof(d3dpp) );
   d3dpp.BackBufferWidth = mode.Width;
@@ -466,7 +472,7 @@ bool D3DGraphicsDriver::CreateDisplayMode(const DisplayMode &mode)
   d3dpp.EnableAutoDepthStencil = FALSE;
   d3dpp.Flags = D3DPRESENTFLAG_LOCKABLE_BACKBUFFER; // we need this flag to access the backbuffer with lockrect
   d3dpp.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
-  if(mode.Vsync)
+  if (_capsVsync && mode.Vsync)
     d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_ONE;
   else
     d3dpp.PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -214,7 +214,7 @@ public:
     void Render() override;
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
-    bool DoesSupportVsyncToggle() override { return true; }
+    bool DoesSupportVsyncToggle() override { return _capsVsync; }
     void RenderSpritesAtScreenResolution(bool enabled, int /*supersampling*/) override { _renderSprAtScreenRes = enabled; };
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;

--- a/Engine/platform/windows/gfx/ali3dd3d.h
+++ b/Engine/platform/windows/gfx/ali3dd3d.h
@@ -215,7 +215,6 @@ public:
     void Render(int xoff, int yoff, Common::GraphicFlip flip) override;
     bool GetCopyOfScreenIntoBitmap(Bitmap *destination, bool at_native_res, GraphicResolution *want_fmt) override;
     bool DoesSupportVsyncToggle() override { return true; }
-    bool SetVsync(bool enabled) override;
     void RenderSpritesAtScreenResolution(bool enabled, int /*supersampling*/) override { _renderSprAtScreenRes = enabled; };
     void FadeOut(int speed, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
     void FadeIn(int speed, PALETTE p, int targetColourRed, int targetColourGreen, int targetColourBlue) override;
@@ -238,6 +237,8 @@ public:
     ~D3DGraphicsDriver() override;
 
 protected:
+    bool SetVsyncImpl(bool vsync, bool &vsync_res) override;
+
     // Create texture data with the given parameters
     TextureData *CreateTextureData(int width, int height, bool opaque, bool as_render_target = false) override;
     // Update texture data from the given bitmap


### PR DESCRIPTION
This is a reaction to #1949, but I cannot tell whether this is enough to fix it at the moment.

This does two things:
1. Small refactor that ensures that VSync is not necessarily reset when using a gfxdriver's interface if it's already set to the given value. This is to reduce code duplication and unify behavior a little.
2. Gfx driver will try to detect when vsync is not supported, and also remember when changing vsync at runtime fails. In this case it won't try to set it again, until the display mode changes.