### PR TITLE
Engine: System_GetAudioChannels missing index in error message

### DIFF
--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -173,7 +173,7 @@ int System_GetAudioChannelCount()
 ScriptAudioChannel* System_GetAudioChannels(int index)
 {
     if ((index < 0) || (index >= game.numGameChannels))
-        quitprintf("!System.AudioChannels: invalid sound channel index %d, supported %d - %d", 0, game.numGameChannels);
+        quitprintf("!System.AudioChannels: invalid sound channel index %d, supported %d - %d", index, 0, game.numGameChannels);
 
     return &scrAudioChannel[index];
 }


### PR DESCRIPTION
on invalid index, the index is not actually reported because it's missing in the right side of the string format.