### PR TITLE
Fix Windows Exception handling in 64-bit builds

### DIFF
--- a/Engine/platform/windows/win_ex_handling.cpp
+++ b/Engine/platform/windows/win_ex_handling.cpp
@@ -15,6 +15,7 @@
 
 #if AGS_PLATFORM_OS_WINDOWS
 #include <new.h>
+#include <cinttypes>
 #include <stdio.h>
 #include "ac/common.h" // quit
 #include "ac/common_defines.h"
@@ -50,11 +51,11 @@ extern int miniDumpResultCode;
 static void DisplayException()
 {
     const auto &sc_error = cc_get_error();
-    snprintf(printfworkingspace, PRINT_WORKSPACE_SIZE, "An exception 0x%X occurred in ACWIN.EXE at EIP = 0x%08X; program pointer is %+d, ACI version %s, gtags (%d,%d)\n\n"
+    snprintf(printfworkingspace, PRINT_WORKSPACE_SIZE, "An exception 0x%X occurred in ACWIN.EXE at EIP = 0x%0*" PRIXPTR "; program pointer is %+d, ACI version %s, gtags (%d,%d)\n\n"
         "AGS cannot continue, this exception was fatal. Please note down the numbers above, remember what you were doing at the time and contact the game author for support "
         "or post these details on the AGS Technical Forum.\n\n%s\n\n"
         "Most versions of Windows allow you to press Ctrl+C now to copy this entire message to the clipboard for easy reporting.\n\n%s (code %d)",
-        excinfo.ExceptionCode, (intptr_t)excinfo.ExceptionAddress, our_eip, EngineVersion.LongString.GetCStr(), eip_guinum, eip_guiobj, sc_error.CallStack.GetCStr(),
+        excinfo.ExceptionCode, (int)sizeof(intptr_t) * 2, (intptr_t)excinfo.ExceptionAddress, our_eip, EngineVersion.LongString.GetCStr(), eip_guinum, eip_guiobj, sc_error.CallStack.GetCStr(),
         (miniDumpResultCode == 0) ? "An error file CrashInfo.dmp has been created. You may be asked to upload this file when reporting this problem on the AGS Forums." :
         "Unable to create an error dump file.", miniDumpResultCode);
     MessageBoxA((HWND)sys_win_get_window(), printfworkingspace, "Illegal exception", MB_ICONSTOP | MB_OK);

--- a/Engine/platform/windows/win_ex_handling.cpp
+++ b/Engine/platform/windows/win_ex_handling.cpp
@@ -85,7 +85,7 @@ int malloc_fail_handler(size_t amountwanted)
     CreateMiniDump(NULL);
 #endif
     free(printfworkingspace);
-    snprintf(tempmsg, sizeof(tempmsg), "Out of memory: failed to allocate %ld bytes (at PP=%d)", amountwanted, our_eip);
+    snprintf(tempmsg, sizeof(tempmsg), "Out of memory: failed to allocate %zu bytes (at PP=%d)", amountwanted, our_eip);
     quit(tempmsg);
     return 0;
 }


### PR DESCRIPTION
- size_t requires %zu in format (see #1934)
- on 64-bit , ExceptionAddress, an intptr_t requires a different format string to be readable
  - I looked the PRIxPTR from inttypes.h, but I think this custom format prints nicely as a counterpart of 0x%08X
  - we use 16 zeroes as the fixed length, because of 64 bits (from 8 for 32-bit variant) ((inttypes.h has nothing for this)
  - I64 is windows for unsigned 64-bit int (I think I could also use `ll` here)
  - X is for the hexadecimal, same as the 32-bit variant