### PR TITLE
Fix touch controls requiring two touches to activate a gui control

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -866,6 +866,7 @@ bool DialogOptions::Run()
       else
       {
         update_audio_system_on_game_loop();
+        update_cursor_and_dependent();
         render_graphics(ddb, dirtyx, dirtyy);
       }
 

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -316,6 +316,7 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
             sys_evt_process_pending();
 
             update_audio_system_on_game_loop();
+            update_cursor_and_dependent();
             render_graphics();
             eAGSMouseButton mbut;
             int mwheelz;

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -286,7 +286,6 @@ int InventoryScreen::Redraw()
 
     Bitmap *ds = prepare_gui_screen(windowxp, windowyp, windowwid, windowhit, true);
     Draw(ds);
-    //ags_domouse(DOMOUSE_ENABLE);
     set_mouse_cursor(cmode);
     wasonitem = -1;
     return 0;
@@ -395,7 +394,6 @@ bool InventoryScreen::Run()
                 play.used_inv_on = dii[clickedon].num;
 
                 if (cmode==MODE_LOOK) {
-                    //ags_domouse(DOMOUSE_DISABLE);
                     run_event_block_inv(dii[clickedon].num, 0); 
                     // in case the script did anything to the screen, redraw it
                     UpdateGameOnce();
@@ -411,7 +409,6 @@ bool InventoryScreen::Run()
                     int activeinvwas = playerchar->activeinv;
                     playerchar->activeinv = toret;
 
-                    //ags_domouse(DOMOUSE_DISABLE);
                     run_event_block_inv(dii[clickedon].num, 3);
 
                     // if the script didn't change it, then put it back
@@ -445,7 +442,6 @@ bool InventoryScreen::Run()
                     if (my < buttonyp + get_fixed_pixel_size(2) + ARROWBUTTONWID) {
                         if (top_item > 0) {
                             top_item -= ICONSPERLINE;
-                            //ags_domouse(DOMOUSE_DISABLE);
 
                             break_code = Redraw();
                             return break_code == 0;
@@ -453,7 +449,6 @@ bool InventoryScreen::Run()
                     }
                     else if ((my < buttonyp + get_fixed_pixel_size(4) + ARROWBUTTONWID*2) && (top_item + num_visible_items < numitems)) {
                         top_item += ICONSPERLINE;
-                        //ags_domouse(DOMOUSE_DISABLE);
                         
                         break_code = Redraw();
                         return break_code == 0;
@@ -484,9 +479,7 @@ bool InventoryScreen::Run()
         }
         else if (isonitem!=wasonitem)
         {
-            //ags_domouse(DOMOUSE_DISABLE);
             RedrawOverItem(get_gui_screen(), isonitem);
-            //ags_domouse(DOMOUSE_ENABLE);
         }
         wasonitem=isonitem;
 

--- a/Engine/gui/guidialog.cpp
+++ b/Engine/gui/guidialog.cpp
@@ -26,6 +26,7 @@
 #include "gfx/bitmap.h"
 #include "gfx/graphicsdriver.h"
 #include "debug/debug_log.h"
+#include "main/game_run.h"
 #include "util/path.h"
 
 using namespace AGS::Common;
@@ -100,6 +101,7 @@ void clear_gui_screen()
 void refresh_gui_screen()
 {
     gfxDriver->UpdateDDBFromBitmap(dialogDDB, windowBuffer, false);
+    update_cursor_and_dependent();
     render_graphics(dialogDDB, windowPosX, windowPosY);
 }
 

--- a/Engine/gui/mylistbox.cpp
+++ b/Engine/gui/mylistbox.cpp
@@ -117,9 +117,7 @@ extern int smcode;
 
     }
 
-//    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-  //  ags_domouse(DOMOUSE_ENABLE);
     smcode = CM_SELCHANGE;
     return 0;
   }

--- a/Engine/gui/mypushbutton.cpp
+++ b/Engine/gui/mypushbutton.cpp
@@ -76,12 +76,8 @@ int MyPushButton::pressedon(int mx, int my)
         state = mouseisinarea(mx, my);
         update_polled_stuff();
         if (wasstat != state) {
-            //        ags_domouse(DOMOUSE_DISABLE);
             draw(get_gui_screen());
-            //ags_domouse(DOMOUSE_ENABLE);
         }
-
-        //      ags_domouse(DOMOUSE_UPDATE);
 
         refresh_gui_screen();
 
@@ -89,9 +85,7 @@ int MyPushButton::pressedon(int mx, int my)
     }
     wasstat = state;
     state = 0;
-    //    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-    //  ags_domouse(DOMOUSE_ENABLE);
     return wasstat;
 }
 

--- a/Engine/gui/newcontrol.cpp
+++ b/Engine/gui/newcontrol.cpp
@@ -61,7 +61,5 @@ void NewControl::drawifneeded()
 }
 void NewControl::drawandmouse()
 {
-    //    ags_domouse(DOMOUSE_DISABLE);
     draw(get_gui_screen());
-    //  ags_domouse(DOMOUSE_ENABLE);
 }

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -1160,6 +1160,15 @@ void RunGameUntilAborted()
     }
 }
 
+void update_cursor_and_dependent()
+{
+    const int mwasatx = mousex, mwasaty = mousey;
+    ags_domouse();
+    update_cursor_over_gui();
+    update_cursor_over_location(mwasatx, mwasaty);
+    update_cursor_view();
+}
+
 void update_polled_stuff()
 {
     if (want_exit) {

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -44,6 +44,7 @@
 #include "ac/room.h"
 #include "ac/roomobject.h"
 #include "ac/roomstatus.h"
+#include "ac/viewframe.h"
 #include "ac/walkbehind.h"
 #include "debug/debugger.h"
 #include "debug/debug_log.h"
@@ -663,45 +664,96 @@ static void game_loop_update_animated_buttons()
     }
 }
 
-static void game_loop_do_render_and_check_mouse(IDriverDependantBitmap *extraBitmap, int extraX, int extraY)
+// Updates GUI reaction to the cursor position change
+// TODO: possibly may be merged with gui_on_mouse_move()
+static void update_cursor_over_gui()
 {
-    if (!play.fast_forward) {
-        int mwasatx=mousex,mwasaty=mousey;
-
-        // Only do this if we are not skipping a cutscene
-        render_graphics(extraBitmap, extraX, extraY);
-
-        // Check Mouse Moves Over Hotspot event
-        // TODO: move this out of render related function? find out why we remember mwasatx and mwasaty before render
-        // TODO: do not use static variables!
-        // TODO: if we support rotation then we also need to compare full transform!
-        if (displayed_room < 0)
-            return;
-        auto view = play.GetRoomViewportAt(mousex, mousey);
-        auto cam = view ? view->GetCamera() : nullptr;
-        if (cam)
-        {
-        // NOTE: all cameras are in same room right now, so their positions are in same coordinate system;
-        // therefore we may use this as an indication that mouse is over different camera too.
-        static int offsetxWas = -1000, offsetyWas = -1000;
-        int offsetx = cam->GetRect().Left;
-        int offsety = cam->GetRect().Top;
-
-        if (((mwasatx!=mousex) || (mwasaty!=mousey) ||
-            (offsetxWas != offsetx) || (offsetyWas != offsety))) 
-        {
-            // mouse moves over hotspot
-            if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT) {
-                int onhs = getloctype_index;
-
-                setevent(EV_RUNEVBLOCK, EVB_HOTSPOT, onhs, EVHOT_MOUSEOVER);
-            }
-        }
-
-        offsetxWas = offsetx;
-        offsetyWas = offsety;
-        } // camera found under mouse
+    if (((debug_flags & DBG_NOIFACE) != 0) || (displayed_room < 0))
+        return; // GUI is disabled (debug flag) or room is not loaded
+    if (!IsInterfaceEnabled())
+        return; // interface is disabled (by script or blocking action)
+    // Poll guis
+    for (auto &gui : guis)
+    {
+        if (!gui.IsDisplayed()) continue; // not on screen
+        // Don't touch GUI if "GUIs Turn Off When Disabled"
+        if ((game.options[OPT_DISABLEOFF] == kGuiDis_Off) &&
+            (all_buttons_disabled >= 0) &&
+            (gui.PopupStyle != kGUIPopupNoAutoRemove))
+            continue;
+        gui.Poll(mousex, mousey);
     }
+}
+
+extern int lastmx, lastmy;
+extern int mouse_frame, mouse_delay;
+extern std::vector<ViewStruct> views;
+
+static void update_cursor_view()
+{
+    // update animating mouse cursor
+    if (game.mcurs[cur_cursor].view >= 0) {
+        // only on mousemove, and it's not moving
+        if (((game.mcurs[cur_cursor].flags & MCF_ANIMMOVE) != 0) &&
+            (mousex == lastmx) && (mousey == lastmy));
+        // only on hotspot, and it's not on one
+        else if (((game.mcurs[cur_cursor].flags & MCF_HOTSPOT) != 0) &&
+            (GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey)) == 0))
+            set_new_cursor_graphic(game.mcurs[cur_cursor].pic);
+        else if (mouse_delay>0) mouse_delay--;
+        else {
+            int viewnum = game.mcurs[cur_cursor].view;
+            int loopnum = 0;
+            if (loopnum >= views[viewnum].numLoops)
+                quitprintf("An animating mouse cursor is using view %d which has no loops", viewnum + 1);
+            if (views[viewnum].loops[loopnum].numFrames < 1)
+                quitprintf("An animating mouse cursor is using view %d which has no frames in loop %d", viewnum + 1, loopnum);
+
+            mouse_frame++;
+            if (mouse_frame >= views[viewnum].loops[loopnum].numFrames)
+                mouse_frame = 0;
+            set_new_cursor_graphic(views[viewnum].loops[loopnum].frames[mouse_frame].pic);
+            mouse_delay = views[viewnum].loops[loopnum].frames[mouse_frame].speed + game.mcurs[cur_cursor].animdelay;
+            CheckViewFrame(viewnum, loopnum, mouse_frame);
+        }
+        lastmx = mousex; lastmy = mousey;
+    }
+}
+
+static void update_cursor_over_location(int mwasatx, int mwasaty)
+{
+    if (play.fast_forward)
+        return;
+    if (displayed_room < 0)
+        return;
+
+    // Check Mouse Moves Over Hotspot event
+    auto view = play.GetRoomViewportAt(mousex, mousey);
+    auto cam = view ? view->GetCamera() : nullptr;
+    if (!cam)
+        return;
+
+    // NOTE: all cameras are in same room right now, so their positions are in same coordinate system;
+    // therefore we may use this as an indication that mouse is over different camera too.
+    // TODO: do not use static variables!
+    // TODO: if we support rotation then we also need to compare full transform!
+    static int offsetxWas = -1000, offsetyWas = -1000;
+    int offsetx = cam->GetRect().Left;
+    int offsety = cam->GetRect().Top;
+
+    if (((mwasatx!=mousex) || (mwasaty!=mousey) ||
+        (offsetxWas != offsetx) || (offsetyWas != offsety))) 
+    {
+        // mouse moves over hotspot
+        if (__GetLocationType(game_to_data_coord(mousex), game_to_data_coord(mousey), 1) == LOCTYPE_HOTSPOT) {
+            int onhs = getloctype_index;
+
+            setevent(EV_RUNEVBLOCK, EVB_HOTSPOT, onhs, EVHOT_MOUSEOVER);
+        }
+    }
+
+    offsetxWas = offsetx;
+    offsetyWas = offsety;
 }
 
 static void game_loop_update_events()
@@ -818,10 +870,21 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     check_debug_keys();
 
+    // Handle player's input
+    // remember old mouse pos, needed for update_cursor_over_location() later
+    const int mwasatx = mousex, mwasaty = mousey;
+    // update mouse position (mousex, mousey)
+    ags_domouse();
+    // update gui under mouse; this also updates gui control focus;
+    // atm we must call this before "check_controls", because GUI interaction
+    // relies on remembering which control was focused by the cursor prior
+    update_cursor_over_gui();
+    // handle actual input (keys, mouse, and so forth)
     game_loop_check_controls(checkControls);
 
     our_eip=2;
 
+    // do the overall game state update
     game_loop_do_update();
 
     game_loop_update_animated_buttons();
@@ -830,7 +893,12 @@ void UpdateGameOnce(bool checkControls, IDriverDependantBitmap *extraBitmap, int
 
     update_audio_system_on_game_loop();
 
-    game_loop_do_render_and_check_mouse(extraBitmap, extraX, extraY);
+    update_cursor_over_location(mwasatx, mwasaty);
+    update_cursor_view();
+
+    // Only render if we are not skipping a cutscene
+    if (!play.fast_forward)
+        render_graphics(extraBitmap, extraX, extraY);
 
     our_eip=6;
 

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -32,9 +32,9 @@ void GameLoopUntilButAnimEnd(int guin, int objn);
 
 // Run the actual game until it ends, or aborted by player/error; loops GameTick() internally
 void RunGameUntilAborted();
-// Update everything game related
+// Update everything game related; wait for the next frame
 void UpdateGameOnce(bool checkControls = false, IDriverDependantBitmap *extraBitmap = nullptr, int extraX = 0, int extraY = 0);
-// Update minimal required game state: audio, loop counter, etc
+// Update minimal required game state: audio, loop counter, etc; wait for the next frame
 void UpdateGameAudioOnly();
 // Gets current logical game FPS, this is normally a fixed number set in script;
 // in case of "maxed fps" mode this function returns real measured FPS.
@@ -48,5 +48,9 @@ bool run_service_mb_controls(eAGSMouseButton &mbut, int &mwheelz);
 // Polls few things (exit flag and debugger messages)
 // TODO: refactor this
 void update_polled_stuff();
+// Update cursor position and view, poll anything related to cursor position;
+// this function is useful when you don't want to update whole game, but only the cursor.
+void update_cursor_and_dependent();
+
 
 #endif // __AGS_EE_MAIN__GAMERUN_H

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -397,9 +397,8 @@ void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)
 }
 
 void IAGSEngine::PollSystem () {
-
-    ags_domouse();
     update_polled_stuff();
+    ags_domouse();
     eAGSMouseButton mbut;
     int mwheelz;
     if (run_service_mb_controls(mbut, mwheelz) && mbut > kMouseNone && !play.IsIgnoringInput())


### PR DESCRIPTION
The problem at hand is that when using touch-to-mouse emulation, the cursor position cannot be tracked (unlike with real mouse) . It's only updated upon a touch. Unfortunately, the gui reaction to cursor in AGS is a bit overcomplicated, where it must remember the last control the mouse was on in order to trigger an interaction correctly upon a mouse down/up event. At the same time this "mouse-over-control" state is updated too late (for unclear reasons), after the mouse button events were already handled. Because of that, following problems may occur:
* it takes 2 touches to press a button (or interact with some other controls): first sets a "focus" on a control, another triggers a push.
* if the cursor has been over a button, a touch on another control or on an empty place over same gui will cause that previous button activate one more time.

Above is resolved by moving 2 updates up the update order:
* mouse position & cursor update;
* mouse-over-gui update.

(Honestly, I could never understand why the mouse position is updated so late in the order of things; theoretically it should be updated right before the other control inputs such as keys and buttons. OTOH this may also be a missed regression happened at some point in the past, where it could have been updated several times...)

**Potential danger:**
1. Changing order of things may be dangerous, so would need to analyze potential consequences. This move places cursor position and gui "focus" updates *before* a) majority of other game updates, b) script callback `late_repeatedly_execute_always`. (Other script callbacks won't be affected by this, as their relative order won't change).
2. Both of these updates were located inside the game render routine. By moving them out, we likely now require them to be called explicitly whenever this render routine been called explicitly and separately from the rest of the game update. At least this should be true for the mouse cursor update.
EDIT: easiest to observe during Display command.