### PR TITLE
Fix a crash in unavowed when trying to use crossfade channel

### DIFF
--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -177,7 +177,7 @@ int System_GetAudioChannelCount()
 ScriptAudioChannel* System_GetAudioChannels(int index)
 {
     if ((index < 0) || (index >= game.numGameChannels))
-        quitprintf("!System.AudioChannels: invalid sound channel index %d, supported %d - %d", index, 0, game.numGameChannels);
+        quitprintf("!System.AudioChannels: invalid sound channel index %d, supported %d - %d", index, 0, game.numGameChannels - 1);
 
     return &scrAudioChannel[index];
 }

--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -166,7 +166,7 @@ static int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool int
 
     // NOTE: in backward compat mode we allow to place sound on a crossfade channel
     int startAtChannel = reserved_channel_count;
-    int endBeforeChannel = game.numCompatGameChannels;
+    int endBeforeChannel = game.numGameChannels;
 
     if (game.audioClipTypes[clip->type].reservedChannels > 0)
     {
@@ -175,6 +175,7 @@ static int find_free_audio_channel(ScriptAudioClip *clip, int priority, bool int
         {
             startAtChannel += game.audioClipTypes[i].reservedChannels;
         }
+        // NOTE: we allow to place sound on a crossfade channel for backward compatibility
         endBeforeChannel = std::min(game.numCompatGameChannels,
             startAtChannel + game.audioClipTypes[clip->type].reservedChannels);
     }


### PR DESCRIPTION
A user reported to us a crash in the AGS engine in ScummVM, and I have verified that it happens in this standalone ags as well.

In Unavowed, at the Staten Island stage, the game crashes with the following message:
`Error: System.AudioChannels: invalid sound channel index 8, supported 0 - 8`

(the error message is actually incorrect and should read `supported 0 - 7`, and I fixed that as well)

And it is indeed trying to use channel 8, which is `>= game.numGameChannels` (which is also 8). I suspect this is caused by 86564e983572b4ffb3cd12b00c116ae91c6fcbe4. In any case allowing using the crossfade channel  in `System_GetAudioChannels` does fix the issue and the game can continue. I am proposing the fix here first (before committing to scummvm) to hear from AGS experts in case there is a better fix.

For reference: https://bugs.scummvm.org/ticket/14353

AGS savegame to reproduce: 
[agssave.003.zip](https://github.com/adventuregamestudio/ags/files/11094736/agssave.003.zip)

From this savegame, use Eli on the ceiling to open the door, go through the dialogues, and you get to the screen where the crash occurs:
![image](https://user-images.githubusercontent.com/552105/228383310-f0070eed-b34d-45a7-ad74-4decaff078aa.png)

