### PR TITLE
Editor: added readonly Length property to AudioClip

### DIFF
--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -281,6 +281,7 @@ namespace AGS.Editor.Components
                 _editor.SelectedItem = itemToEdit;
                 _document.SelectedPropertyGridObject = itemToEdit;
                 _document.TreeNodeID = _rightClickedID;
+                UpdateAudioClipFromPreview(itemToEdit as AudioClip, _editor);
                 _guiController.AddOrShowPane(_document);
             }
         }
@@ -324,6 +325,7 @@ namespace AGS.Editor.Components
                 newClip.SourceFileName = Utilities.GetRelativeToProjectPath(sourceFileName);
                 newClip.FileType = _fileTypeMappings[fileExtension];
                 newClip.FileLastModifiedDate = File.GetLastWriteTimeUtc(sourceFileName);
+                newClip.Length = TimeSpan.MinValue;
                 Utilities.CopyFileAndSetDestinationWritable(sourceFileName, newClip.CacheFileName);
                 Utilities.TryDeleteFile(Path.Combine(AGSEditor.OUTPUT_DIRECTORY,
                     Path.Combine(AGSEditor.DATA_OUTPUT_DIRECTORY, AGSEditor.AUDIO_VOX_FILE_NAME)));
@@ -331,6 +333,15 @@ namespace AGS.Editor.Components
                 return newClip;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Updates certain preview-only properties from the AudioEditor,
+        /// for displaying them in the property grid.
+        /// </summary>
+        private void UpdateAudioClipFromPreview(AudioClip clip, AudioEditor editor)
+        {
+            clip.Length = TimeSpan.FromMilliseconds(editor.LengthMs);
         }
 
         private string EnsureScriptNameIsUnique(string nameToTry, int truncateToLength = Int32.MaxValue)

--- a/Editor/AGS.Editor/Panes/AudioEditor.cs
+++ b/Editor/AGS.Editor/Panes/AudioEditor.cs
@@ -36,6 +36,16 @@ namespace AGS.Editor
             set { _selectedItem = value; SetupForNewItem(value); }
         }
 
+        public int LengthMs
+        {
+            get
+            {
+                if (_selectedItem != null && _previewer != null)
+                    return _previewer.GetLengthMs();
+                return 0;
+            }
+        }
+
         private AudioClip SelectedClip
         {
             get { return (AudioClip)_selectedItem; }

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -21,6 +21,7 @@ namespace AGS.Types
         private AudioFileBundlingType _bundlingType = AudioFileBundlingType.InGameEXE;
         private AudioClipFileType _fileType;
         private DateTime _fileLastModifiedDate = DateTime.MinValue;
+        private TimeSpan _fileLength = TimeSpan.MinValue;
         private int _volume = -1;
         private AudioClipPriority _priority = AudioClipPriority.Inherit;
         private InheritableBool _repeat = InheritableBool.Inherit;
@@ -122,6 +123,15 @@ namespace AGS.Types
         {
             get { return _fileLastModifiedDate; }
             set { _fileLastModifiedDate = value; }
+        }
+
+        [AGSNoSerialize]
+        [Description("The audio file's length (hh:mm:ss.ms)")]
+        [ReadOnly(true)]
+        public TimeSpan Length
+        {
+            get { return _fileLength; }
+            set { _fileLength = value; }
         }
 
         [Description("The volume (0..100) that this clip will play at, if the script does not specify it. -1 inherits from parent folder.")]


### PR DESCRIPTION
Resolves #566

This lets users to see Length on the clips' property grid.
The Length is taken from the previewer currently, so relies on its work. If previewer failed, will be assigned 0.
This field is not serialized, and is only updated when the preview pane opens (there's no other way to see clip's properties at the moment anyway).