### PR TITLE
AGS 4: implemented "Leave room after fade-out" callback, and corresponding global event

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1129,7 +1129,10 @@ enum EventType {
   eEventLoseInventory = 8,
   eEventRestoreGame = 9,
 #ifdef SCRIPT_API_v36026
-  eEventEnterRoomAfterFadein = 10
+  eEventEnterRoomAfterFadein = 10,
+#endif
+#ifdef SCRIPT_API_v399
+  eEventLeaveRoomAfterFadeout = 11,
 #endif
 };
 

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -71,10 +71,11 @@ namespace AGS.Types
                 "Enters room before fade-in",
                 "Repeatedly execute",
                 "Enters room after fade-in",
-                "Leaves room",
+                "Leaves room before fade-out",
+                "Leaves room after fade-out"
             },
                 new string[] { "LeaveLeft", "LeaveRight", "LeaveBottom", "LeaveTop", 
-                    "FirstLoad", EVENT_SUFFIX_ROOM_LOAD, "RepExec", "AfterFadeIn", "Leave" });
+                    "FirstLoad", EVENT_SUFFIX_ROOM_LOAD, "RepExec", "AfterFadeIn", "Leave", "Unload" });
         }
 
         public Room(int roomNumber) : base(roomNumber)

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -23,6 +23,7 @@
 #include "ac/gui.h"
 #include "ac/roomstatus.h"
 #include "ac/screen.h"
+#include "debug/debug_log.h"
 #include "main/game_run.h"
 #include "script/cc_common.h"
 #include "platform/base/agsplatformdriver.h"
@@ -47,6 +48,7 @@ extern RGB palette[256];
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
 extern RGB old_palette[256];
+extern int displayed_room;
 
 int in_enters_screen=0,done_es_error = 0;
 int in_leaves_screen = -1;
@@ -200,6 +202,7 @@ void process_event(const EventHappened *evp) {
             in_enters_screen --;
     }
     else if (evp->type==EV_FADEIN) {
+        debug_script_log("Transition-in in room %d", displayed_room);
         // if they change the transition type before the fadein, make
         // sure the screen doesn't freeze up
         play.screen_is_faded_out = 0;

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -22,16 +22,17 @@
 #include "script/runtimescriptvalue.h"
 
 // parameters to run_on_event
-#define GE_LEAVE_ROOM 1
-#define GE_ENTER_ROOM 2
+#define GE_LEAVE_ROOM    1
+#define GE_ENTER_ROOM    2
 // #define GE_MAN_DIES 3 // ancient obsolete event
-#define GE_GOT_SCORE  4
+#define GE_GOT_SCORE     4
 #define GE_GUI_MOUSEDOWN 5
 #define GE_GUI_MOUSEUP   6
 #define GE_ADD_INV       7
 #define GE_LOSE_INV      8
 #define GE_RESTORE_GAME  9
 #define GE_ENTER_ROOM_AFTERFADE 10
+#define GE_LEAVE_ROOM_AFTERFADE 11
 
 // Game event types:
 // common script callback
@@ -74,6 +75,10 @@
 #define EVROM_REPEXEC      6
 // after fade-in
 #define EVROM_AFTERFADEIN  7
+// leave room (before fade-out)
+#define EVROM_LEAVE        8
+// unload room; aka after fade-out
+#define EVROM_AFTERFADEOUT 9
 // Hotspot event types:
 // player stands on hotspot
 #define EVHOT_STANDSON  0

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -225,9 +225,14 @@ void unload_old_room() {
     if (displayed_room < 0)
         return;
 
-    debug_script_log("Unloading room %d", displayed_room);
-
     current_fade_out_effect();
+
+    // room unloaded callback
+    run_room_event(EVROM_AFTERFADEOUT);
+    // global room unloaded event
+    run_on_event(GE_LEAVE_ROOM_AFTERFADE, RuntimeScriptValue().SetInt32(displayed_room));
+
+    debug_script_log("Unloading room %d", displayed_room);
 
     dispose_room_drawdata();
 
@@ -787,7 +792,7 @@ void new_room(int newnum,CharacterInfo*forchar) {
     in_leaves_screen = newnum;
 
     // player leaves screen event
-    run_room_event(8);
+    run_room_event(EVROM_LEAVE);
     // Run the global OnRoomLeave event
     run_on_event (GE_LEAVE_ROOM, RuntimeScriptValue().SetInt32(displayed_room));
 

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -21,6 +21,7 @@
 #include "ac/screen.h"
 #include "ac/dynobj/scriptviewport.h"
 #include "ac/dynobj/scriptuserobject.h"
+#include "debug/debug_log.h"
 #include "script/script_runtime.h"
 #include "platform/base/agsplatformdriver.h"
 #include "plugin/agsplugin.h"
@@ -35,6 +36,7 @@ extern GameSetupStruct game;
 extern GameState play;
 extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
+extern int displayed_room;
 
 void fadein_impl(PALETTE p, int speed) {
     if (game.color_depth > 1) {
@@ -53,6 +55,7 @@ void fadein_impl(PALETTE p, int speed) {
 Bitmap *saved_viewport_bitmap = nullptr;
 RGB old_palette[256];
 void current_fade_out_effect () {
+    debug_script_log("Transition-out in room %d", displayed_room);
     if (pl_run_plugin_hooks(AGSE_TRANSITIONOUT, 0))
         return;
 

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -143,12 +143,12 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
 // (eg. a room change occured)
 int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny) {
 
-    if ((nint->ScriptFuncNames[evnt] == nullptr) || (nint->ScriptFuncNames[evnt][0u] == 0)) {
+    if ((nint->ScriptFuncNames.size() <= evnt) || nint->ScriptFuncNames[evnt].IsEmpty()) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
         if (chkAny < 0) ;
-        else if ((nint->ScriptFuncNames[chkAny] != nullptr) && (nint->ScriptFuncNames[chkAny][0u] != 0))
+        else if (!nint->ScriptFuncNames[chkAny].IsEmpty())
             return 0;
 
         // Otherwise, run unhandled_event


### PR DESCRIPTION
Resolves #1971

1. Adds Room event "Leave room after fade-out", with default function name `room_Unload`, for consistency with `room_Load`.
2. Adds new global event (for `on_event`): `eEventLeaveRoomAfterFadeout`.

The names are chosen for consistency with existing ones, but may be adjusted to something more elegant later perhaps.


Tested with the following room script:
```
function room_Load()
{
    System.Log(eLogInfo, "room_Load, %d", player.Room);
}

function room_AfterFadeIn()
{
    System.Log(eLogInfo, "room_AfterFadeIn, %d", player.Room);
}

function room_Leave()
{
    System.Log(eLogInfo, "room_Leave, %d", player.Room);
}

function room_Unload()
{
    System.Log(eLogInfo, "room_Unload, %d", player.Room);
}
```
And in global script:
```
function on_event(int evt, int data)
{
    System.Log(eLogInfo, "on_event: evt %d, data %d", evt, data);
}
```

Expected engine log (more or less):
```
Game : (room:-10) Loading room 1
Game : (room:1) Now in room 1
Script : on_event: evt 2, data 1
Script : room_Load, 1
Game : (room:1) Transition-in in room 1
Script : on_event: evt 10, data 1
Script : room_AfterFadeIn, 1
...
Script : room_Leave, 1
Script : on_event: evt 1, data 1
Game : (room:1) Transition-out in room 1
Script : room_Unload, 1
Script : on_event: evt 11, data 1
Game : (room:1) Unloading room 1
```