### PR TITLE
Add File::FileCopy function and replace one instance of manual buffer copying

### DIFF
--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -101,7 +101,7 @@ bool File::TestCreateFile(const String &filename)
     if (test_file)
     {
         fclose(test_file);
-        ags_remove(filename.GetCStr());
+        ags_file_remove(filename.GetCStr());
         return true;
     }
     return false;
@@ -109,7 +109,7 @@ bool File::TestCreateFile(const String &filename)
 
 bool File::DeleteFile(const String &filename)
 {
-    if (ags_remove(filename.GetCStr()) != 0)
+    if (ags_file_remove(filename.GetCStr()) != 0)
     {
         int err;
 #if AGS_PLATFORM_OS_WINDOWS
@@ -127,7 +127,12 @@ bool File::DeleteFile(const String &filename)
 
 bool File::RenameFile(const String &old_name, const String &new_name)
 {
-    return ags_rename(old_name.GetCStr(), new_name.GetCStr()) == 0;
+    return ags_file_rename(old_name.GetCStr(), new_name.GetCStr()) == 0;
+}
+
+bool File::CopyFile(const String &src_path, const String &dst_path, bool overwrite)
+{
+    return ags_file_copy(src_path.GetCStr(), dst_path.GetCStr(), overwrite) == 0;
 }
 
 bool File::GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, FileWorkMode &work_mode)

--- a/Common/util/file.h
+++ b/Common/util/file.h
@@ -64,6 +64,8 @@ namespace File
     bool        DeleteFile(const String &filename);
     // Renames existing file to the new name; returns TRUE on success
     bool        RenameFile(const String &old_name, const String &new_name);
+    // Copies a file from src_path to dst_path; returns TRUE on success
+    bool        CopyFile(const String &src_path, const String &dst_path, bool overwrite);
 
     // Sets FileOpenMode and FileWorkMode values corresponding to C-style file open mode string
     bool        GetFileModesFromCMode(const String &cmode, FileOpenMode &open_mode, FileWorkMode &work_mode);

--- a/Common/util/stdio_compat.c
+++ b/Common/util/stdio_compat.c
@@ -22,6 +22,10 @@
 #include "platform/windows/windows.h"
 #include <io.h>
 #include <shlwapi.h>
+#else
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 FILE *ags_fopen(const char *path, const char *mode)
@@ -123,7 +127,7 @@ file_off_t ags_file_size(const char *path)
 #endif
 }
 
-int ags_remove(const char *path)
+int ags_file_remove(const char *path)
 {
 #if AGS_PLATFORM_OS_WINDOWS
     WCHAR wstr[MAX_PATH_SZ];
@@ -134,7 +138,7 @@ int ags_remove(const char *path)
 #endif
 }
 
-int ags_rename(const char *src, const char *dst)
+int ags_file_rename(const char *src, const char *dst)
 {
 #if AGS_PLATFORM_OS_WINDOWS
     WCHAR wsrc[MAX_PATH_SZ], wdst[MAX_PATH_SZ];
@@ -144,4 +148,53 @@ int ags_rename(const char *src, const char *dst)
 #else
     return rename(src, dst);
 #endif
+}
+
+int ags_file_copy(const char *src, const char *dst, int overwrite)
+{
+#if AGS_PLATFORM_OS_WINDOWS
+    WCHAR wsrc[MAX_PATH_SZ], wdst[MAX_PATH_SZ];
+    MultiByteToWideChar(CP_UTF8, 0, src, -1, wsrc, MAX_PATH_SZ);
+    MultiByteToWideChar(CP_UTF8, 0, dst, -1, wdst, MAX_PATH_SZ);
+    return !CopyFileW(wsrc, wdst, !overwrite); // inverse CopyFile's result to match 0 = success
+#else
+    int fd_src, fd_dst;
+    int dst_flags;
+    char buf[4096]; // CHECKME: larger buffer? malloc a bigger one on heap?
+    size_t read_num;
+
+    fd_src = open(src, O_RDONLY);
+    if (fd_src < 0)
+        return -1;
+    dst_flags = O_WRONLY | O_CREAT;
+    if (!overwrite)
+        dst_flags |= O_EXCL;
+    fd_dst = open(dst, dst_flags, 0666);
+    if (fd_dst < 0) {
+        close(fd_src);
+        return -1;
+    }
+
+    while ((read_num = read(fd_src, buf, sizeof(buf))) > 0) {
+        char *out_ptr = buf;
+        size_t wrote_num;
+        do {
+            wrote_num = write(fd_dst, out_ptr, read_num);
+            if (wrote_num >= 0) {
+                read_num -= wrote_num;
+                out_ptr += wrote_num;
+            } else if (errno != EINTR) {
+                close(fd_src);
+                close(fd_dst);
+                return -1;
+            }
+        } while (read_num > 0);
+    }
+
+    close(fd_src);
+    if (close(fd_dst) < 0)
+        return -1;
+    // At this point read_num contains either 0 or -1 as error
+    return read_num;
+#endif // POSIX
 }

--- a/Common/util/stdio_compat.h
+++ b/Common/util/stdio_compat.h
@@ -39,8 +39,9 @@ int ags_directory_exists(const char *path);
 int ags_path_exists(const char *path);
 file_off_t ags_file_size(const char *path);
 
-int ags_remove(const char *path);
-int ags_rename(const char *src, const char *dst);
+int ags_file_remove(const char *path);
+int ags_file_rename(const char *src, const char *dst);
+int ags_file_copy(const char *src, const char *dst, int overwrite);
 
 #ifdef __cplusplus
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -364,22 +364,12 @@ static bool SetSaveGameDirectory(const FSLocation &fsdir)
         return false;
 
     // copy the Restart Game file, if applicable
-    String restartGamePath = Path::ConcatPaths(saveGameDirectory, get_save_game_filename(RESTART_POINT_SAVE_GAME_NUMBER));
-    Stream *restartGameFile = File::OpenFileRead(restartGamePath);
-    if (restartGameFile != nullptr)
+    String old_restart_path = Path::ConcatPaths(saveGameDirectory, get_save_game_filename(RESTART_POINT_SAVE_GAME_NUMBER));
+    if (File::IsFile(old_restart_path))
     {
-        long fileSize = restartGameFile->GetLength();
-        char *mbuffer = (char*)malloc(fileSize);
-        restartGameFile->Read(mbuffer, fileSize);
-        delete restartGameFile;
-
-        restartGamePath = Path::ConcatPaths(newSaveGameDir, get_save_game_filename(RESTART_POINT_SAVE_GAME_NUMBER));
-        restartGameFile = File::CreateFile(restartGamePath);
-        restartGameFile->Write(mbuffer, fileSize);
-        delete restartGameFile;
-        free(mbuffer);
+        String new_restart_path = Path::ConcatPaths(newSaveGameDir, get_save_game_filename(RESTART_POINT_SAVE_GAME_NUMBER));
+        File::CopyFile(old_restart_path, new_restart_path, true);
     }
-
     saveGameDirectory = newSaveGameDir;
     return true;
 }


### PR DESCRIPTION
Been looking for remaining unnecessary `long` and `malloc` in the base engine code, and decided to make a FileCopy function to replace an explicit data read/write in one case.

The function is added to File namespace and stdio_compat.c in compliance with existing similar utils.
Tested this on Win and Linux, but making this pr primarily to make sure the posix variant compiles everywhere.