### PR TITLE
[in doubt] Implement a "Right-to-left (reversed)" text direction, as a workaround for Arabic and Persian translations

### DIFF
--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -56,7 +56,7 @@
 #define OPT_ANTIALIASFONTS  25
 #define OPT_THOUGHTGUI      26
 #define OPT_TURNTOFACELOC   27
-#define OPT_RIGHTLEFTWRITE  28  // right-to-left text writing
+#define OPT_TEXTDIRECTION   28  // text direction (LTR, RTL, extra modes)
 #define OPT_DUPLICATEINV    29  // if they have 2 of the item, draw it twice
 #define OPT_SAVESCREENSHOT  30
 #define OPT_PORTRAITSIDE    31

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 //
-//
+// Various global game constants
 //
 //=============================================================================
 #ifndef __AGS_CN_AC__GAMESTRUCTDEFINES_H
@@ -215,6 +215,27 @@ enum GameGuiAlphaRenderingStyle
     kGuiAlphaRender_AdditiveAlpha,
     kGuiAlphaRender_Proper
 };
+
+// Text display direction (used in OPT_TEXTDIRECTION)
+enum TextDirection
+{
+    kTextDir_LeftToRight = 0, 
+    kTextDir_RightToLeft = 1,
+    kTextDir_RightToLeftRev = 2, // pre-reversed R2L text
+};
+
+// Convert TextDirection to the suggested text alignment
+inline HorAlignment TextDirectionToAlign(TextDirection dir)
+{
+    switch (dir)
+    {
+    case kTextDir_RightToLeft:
+    case kTextDir_RightToLeftRev:
+        return kHAlignRight;
+    default:
+        return kHAlignLeft;
+    }
+}
 
 
 // Sprite flags (serialized as 8-bit)

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -371,7 +371,7 @@ int get_text_lines_surf_height(size_t fontNumber, size_t numlines)
 namespace AGS { namespace Common { SplitLines Lines; } }
 
 // Replaces AGS-specific linebreak tags with common '\n'
-void unescape_script_string(const char *cstr, std::vector<char> &out)
+static void unescape_script_string(const char *cstr, std::string &out)
 {
     out.clear();
     // Handle the special case of the first char
@@ -417,29 +417,42 @@ size_t split_lines(const char *todis, bool read_reverse,
     wii -= 1;
 
     lines.Reset();
-    unescape_script_string(todis, lines.LineBuf);
+
+    // Do all necessary preliminary conversions: unescape, etc
+    unescape_script_string(todis, lines.LineBuf[0]);
     if (read_reverse)
     {
-        /* FIXME !!! -- optimize, by refactoring line split instead */
-        std::vector<char> buf; buf.resize(lines.LineBuf.size());
-        Utf8::Reverse(&lines.LineBuf.front(), lines.LineBuf.size() - 1, &buf.front(), buf.size());
-        memcpy(&lines.LineBuf.front(), &buf.front(), lines.LineBuf.size());
+        /* FIXME !!! -- optimize, by doing a reverse line split (need a very good refactor) */
+        lines.LineBuf[1].resize(lines.LineBuf[0].size());
+        Utf8::Reverse(&lines.LineBuf[0].front(), lines.LineBuf[0].size() - 1,
+            &lines.LineBuf[1].front(), lines.LineBuf[1].size());
     }
 
-    char *theline = &lines.LineBuf.front();
-    char *scan_ptr = theline;
-    char *prev_ptr = theline;
-    char *last_whitespace = nullptr;
-    while (1) {
-        char *split_at = nullptr;
+    // TODO: we NEED a proper utf8 string class, and refact all this mess!!
+    // in this case we perhaps could use custom ITERATOR types that read
+    // and write utf8 chars in std::strings or similar containers.
+    std::string &line_buf = read_reverse ? lines.LineBuf[1] : lines.LineBuf[0];
+    std::string &test_buf = lines.LineBuf[2];
+    test_buf.clear();
+    const char *end_ptr = &line_buf.back(); // buffer end ptr
+    const char *theline = &line_buf.front(); // sub-line ptr
+    const char *scan_ptr = theline; // a moving scan pos
+    const char *prev_ptr = scan_ptr; // previous scan pos
+    const char *last_whitespace = nullptr; // last found whitespace
 
-        if (*scan_ptr == 0) {
+    while (true) {
+        const char *split_at = nullptr;
+
+        if (scan_ptr == end_ptr) {
             // end of the text, add the last line if necessary
             if (scan_ptr > theline) {
-                lines.Add(theline);
+                lines.Add(&test_buf.front());
             }
             break;
         }
+
+        // Save "previous scan pos" before possibly moving the scan_ptr
+        prev_ptr = scan_ptr;
 
         if (*scan_ptr == ' ')
             last_whitespace = scan_ptr;
@@ -447,15 +460,14 @@ size_t split_lines(const char *todis, bool read_reverse,
         // force end of line with the \n character
         if (*scan_ptr == '\n') {
             split_at = scan_ptr;
+            ugetxc(&scan_ptr); // advance by char
         // otherwise, see if we are too wide
         } else {
-            // temporarily terminate the line in the *next* char and test its width
-            char *next_ptr = scan_ptr;
-            ugetx(&next_ptr);
-            const int next_chwas = ugetc(next_ptr);
-            *next_ptr = 0;
-
-            if (get_text_width_outlined(theline, fonnt) > wii) {
+            // copy next character to the test buffer and calculate its width
+            char uch[Utf8::UtfSz + 1]{};
+            usetc(uch, ugetxc(&scan_ptr));
+            test_buf.append(uch);
+            if (get_text_width_outlined(&test_buf.front(), fonnt) > wii) {
                 // line is too wide, order the split
                 if (last_whitespace)
                     // revert to the last whitespace
@@ -464,26 +476,19 @@ size_t split_lines(const char *todis, bool read_reverse,
                     // single very wide word, display as much as possible
                     split_at = prev_ptr;
             }
-
-            // restore the character that was there before
-            usetc(next_ptr, next_chwas);
         }
 
-        if (split_at == nullptr) {
-            prev_ptr = scan_ptr;
-            ugetx(&scan_ptr);
-        } else {
+        if (split_at != nullptr) {
             // check if even one char cannot fit...
             if (split_at == theline && !((*theline == ' ') || (*theline == '\n'))) {
-              // cannot split with current width restriction
-              lines.Reset();
-              break;
+                // cannot split with current width restriction
+                lines.Reset();
+                break;
             }
-            // add this line; do the temporary terminator trick again
-            const int next_chwas = ugetc(split_at);
-            *split_at = 0;
-            lines.Add(theline);
-            usetc(split_at, next_chwas);
+            // add this line, saved into the test buffer
+            test_buf.resize(split_at - theline); // cut the buffer at the split index
+            lines.Add(&test_buf.front());
+            test_buf.clear();
             // check if too many lines
             if (lines.Count() >= max_lines) {
                 lines[lines.Count() - 1].Append("...");
@@ -493,7 +498,7 @@ size_t split_lines(const char *todis, bool read_reverse,
             theline = split_at;
             // skip the space or new line that caused the line break
             if ((*theline == ' ') || (*theline == '\n'))
-                theline++;
+                ugetxc(&theline); // advance by char
             scan_ptr = theline;
             prev_ptr = theline;
             last_whitespace = nullptr;

--- a/Common/font/fonts.cpp
+++ b/Common/font/fonts.cpp
@@ -23,6 +23,7 @@
 #include "gfx/bitmap.h"
 #include "gui/guidefines.h" // MAXLINE
 #include "util/string_utils.h"
+#include "util/utf8.h"
 
 
 extern int get_fixed_pixel_size(int pixels);
@@ -404,7 +405,8 @@ void unescape_script_string(const char *cstr, std::vector<char> &out)
 }
 
 // Break up the text into lines
-size_t split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
+size_t split_lines(const char *todis, bool read_reverse,
+    SplitLines &lines, int wii, int fonnt, size_t max_lines) {
     // NOTE: following hack accomodates for the legacy math mistake in split_lines.
     // It's hard to tell how cruicial it is for the game looks, so research may be needed.
     // TODO: IMHO this should rely not on game format, but script API level, because it
@@ -416,8 +418,15 @@ size_t split_lines(const char *todis, SplitLines &lines, int wii, int fonnt, siz
 
     lines.Reset();
     unescape_script_string(todis, lines.LineBuf);
-    char *theline = &lines.LineBuf.front();
+    if (read_reverse)
+    {
+        /* FIXME !!! -- optimize, by refactoring line split instead */
+        std::vector<char> buf; buf.resize(lines.LineBuf.size());
+        Utf8::Reverse(&lines.LineBuf.front(), lines.LineBuf.size() - 1, &buf.front(), buf.size());
+        memcpy(&lines.LineBuf.front(), &buf.front(), lines.LineBuf.size());
+    }
 
+    char *theline = &lines.LineBuf.front();
     char *scan_ptr = theline;
     char *prev_ptr = theline;
     char *last_whitespace = nullptr;

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -111,7 +111,7 @@ bool ShouldAntiAliasText();
 // subsequent memory (de)allocations if used often during game loops
 // and drawing. For that reason it is not equivalent to std::vector,
 // but keeps constructed String buffers intact for most time.
-// TODO: implement proper strings pool.
+// TODO: implement proper strings pool, with std iterator support.
 class SplitLines
 {
 public:
@@ -135,8 +135,10 @@ private:
 };
 
 // Break up the text into lines restricted by the given width;
-// returns number of lines, or 0 if text cannot be split well to fit in this width
-size_t split_lines(const char *texx, SplitLines &lines, int width, int fontNumber, size_t max_lines = -1);
+// returns number of lines, or 0 if text cannot be split well to fit in this width;
+// * read_reverse - scan the text in reverse (right-to-left)
+size_t split_lines(const char *texx, bool read_reverse,
+    SplitLines &lines, int width, int fontNumber, size_t max_lines = -1);
 
 namespace AGS { namespace Common { extern SplitLines Lines; } }
 

--- a/Common/font/fonts.h
+++ b/Common/font/fonts.h
@@ -14,6 +14,7 @@
 #ifndef __AC_FONT_H
 #define __AC_FONT_H
 
+#include <string>
 #include <vector>
 #include "ac/gamestructdefines.h"
 #include "util/string.h"
@@ -126,8 +127,8 @@ public:
         _pool[_count++].SetString(cstr);
     }
 
-    // An auxiliary line processing buffer
-    std::vector<char> LineBuf;
+    // Auxiliary line processing buffers
+    std::string LineBuf[3];
 
 private:
     std::vector<Common::String> _pool;

--- a/Common/game/tra_file.cpp
+++ b/Common/game/tra_file.cpp
@@ -100,7 +100,7 @@ HError ReadTraBlock(Translation &tra, Stream *in, TraFileBlock block, const Stri
     case kTraFblk_TextOpts:
         tra.NormalFont = in->ReadInt32();
         tra.SpeechFont = in->ReadInt32();
-        tra.RightToLeft = in->ReadInt32();
+        tra.TextDirection = in->ReadInt32();
         return HError::None();
     case kTraFblk_None:
         // continue reading extensions with string ID
@@ -236,7 +236,7 @@ void WriteTextOpts(const Translation &tra, Stream *out)
 {
     out->WriteInt32(tra.NormalFont);
     out->WriteInt32(tra.SpeechFont);
-    out->WriteInt32(tra.RightToLeft);
+    out->WriteInt32(tra.TextDirection);
 }
 
 void WriteStrOptions(const Translation &tra, Stream *out)

--- a/Common/game/tra_file.h
+++ b/Common/game/tra_file.h
@@ -64,7 +64,7 @@ struct Translation
     // Localization parameters
     int NormalFont = -1; // replacement for normal font, or -1 for default
     int SpeechFont = -1; // replacement for speech font, or -1 for default
-    int RightToLeft = -1; // r2l text mode (1, 2), or -1 for default
+    int TextDirection = -1; // l2r / r2l text mode (1, 2, ...), or -1 for default
     StringMap StrOptions; // to store extended options with string values
 };
 

--- a/Common/util/string.cpp
+++ b/Common/util/string.cpp
@@ -11,14 +11,15 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+#include "util/string.h"
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <cctype>
 #include "util/math.h"
 #include "util/stream.h"
-#include "util/string.h"
 #include "util/string_compat.h"
+#include "util/utf8.h"
 
 namespace AGS
 {
@@ -853,23 +854,7 @@ void String::ReverseUTF8()
     // TODO: may this be optimized to not alloc new buffer?
     // otherwise, allocate a proper String data buf and replace existing
     char *newstr = new char[_len + 1];
-    for (char *fw = _cstr, *fw2 = _cstr + 1,
-              *bw = _cstr + _len - 1, *bw2 = _cstr + _len;
-        fw <= bw; // FIXME: <= catches odd middle char, optimize?
-        fw = fw2++, bw2 = bw--)
-    {
-        // find end of next character forwards
-        for (; (fw2 < bw) && ((*fw2 & 0xC0) == 0x80); ++fw2);
-        // find beginning of the prev character backwards
-        for (; (bw > fw) && ((*bw & 0xC0) == 0x80); --bw);
-        // put these in opposite sides on the new buffer
-        char *fw_place = newstr + (_cstr + _len - bw2);
-        char *bw_place = newstr + _len - (fw2 - _cstr);
-        memcpy(fw_place, bw, bw2 - bw);
-        if (fw != bw) // FIXME, optimize?
-            memcpy(bw_place, fw, fw2 - fw);
-    }
-    newstr[_len] = 0;
+    Utf8::Reverse(_cstr, _len, newstr, _len + 1);
     SetString(newstr);
     delete[] newstr;
 }

--- a/Common/util/utf8.h
+++ b/Common/util/utf8.h
@@ -106,6 +106,30 @@ inline size_t GetLength(const char *c)
     return len;
 }
 
+// Reverses utf8 string, reads from src, writes into dst which is limited by dst_sz bytes;
+// ensures null-terminator in the end
+// FIXME: use dst_sz!
+inline void Reverse(const char *src, size_t src_len, char *dst, size_t dst_sz)
+{
+    for (const char *fw = src, *fw2 = src + 1,
+              *bw = src + src_len - 1, *bw2 = src + src_len;
+        fw <= bw; // FIXME: <= catches odd middle char, optimize?
+        fw = fw2++, bw2 = bw--)
+    {
+        // find end of next character forwards
+        for (; (fw2 < bw) && ((*fw2 & 0xC0) == 0x80); ++fw2);
+        // find beginning of the prev character backwards
+        for (; (bw > fw) && ((*bw & 0xC0) == 0x80); --bw);
+        // put these in opposite sides on the new buffer
+        char *fw_place = dst + (src + src_len - bw2);
+        char *bw_place = dst + src_len - (fw2 - src);
+        memcpy(fw_place, bw, bw2 - bw);
+        if (fw != bw) // FIXME, optimize?
+            memcpy(bw_place, fw, fw2 - fw);
+    }
+    dst[dst_sz - 1] = 0; // ensure terminator
+}
+
 } // namespace Utf8
 
 #endif // __AGS_CN_UTIL__UTF8_H

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -100,8 +100,9 @@ namespace AGS.Editor
          *                - Room.BackgroundAnimationEnabled
          *                - RuntimeSetup.FullscreenDesktop
          * 3.6.0.20       - Settings.GameTextEncoding, Settings.UseOldKeyboardHandling;
+         * 3.6.1          - Settings.TextDirection
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060020;
+        public const int    LATEST_XML_VERSION_INDEX = 3060100;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -154,7 +154,15 @@ namespace AGS.Editor.Components
                 bw.Write((int)12);
                 bw.Write(translation.NormalFont ?? -1);
                 bw.Write(translation.SpeechFont ?? -1);
-                bw.Write((translation.RightToLeftText == true) ? 2 : ((translation.RightToLeftText == false) ? 1 : -1));
+                if (translation.TextDirection.HasValue)
+                {
+                    // convert from TextDir enum to TRA format
+                    bw.Write((int)translation.TextDirection + 1);
+                }
+                else
+                {
+                    bw.Write(-1);
+                }
 
                 bw.Write((int)0); // required for compatibility
                 DataFileWriter.WriteString(TRANSLATION_BLOCK_STROPTIONS, 16, bw);

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -535,7 +535,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_ANTIALIASFONTS] = (game.Settings.AntiAliasFonts ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_ANTIGLIDE] = (game.Settings.AntiGlideMode ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_NOWALKMODE] = (game.Settings.AutoMoveInWalkMode ? 0 : 1);
-            options[NativeConstants.GameOptions.OPT_RIGHTLEFTWRITE] = (game.Settings.BackwardsText ? 1 : 0);
+            options[NativeConstants.GameOptions.OPT_TEXTDIRECTION] = (int)game.Settings.TextDirection;
             options[NativeConstants.GameOptions.OPT_COMPRESSSPRITES] = (int)game.Settings.CompressSpritesType;
             options[NativeConstants.GameOptions.OPT_DEBUGMODE] = (game.Settings.DebugMode ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_DIALOGUPWARDS] = (game.Settings.DialogOptionsBackwards ? 1 : 0);

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -111,7 +111,7 @@ namespace AGS.Editor
             public static readonly int OPT_ANTIALIASFONTS = (int)Factory.NativeProxy.GetNativeConstant("OPT_ANTIALIASFONTS");
             public static readonly int OPT_THOUGHTGUI = (int)Factory.NativeProxy.GetNativeConstant("OPT_THOUGHTGUI");
             public static readonly int OPT_TURNTOFACELOC = (int)Factory.NativeProxy.GetNativeConstant("OPT_TURNTOFACELOC");
-            public static readonly int OPT_RIGHTLEFTWRITE = (int)Factory.NativeProxy.GetNativeConstant("OPT_RIGHTLEFTWRITE");
+            public static readonly int OPT_TEXTDIRECTION = (int)Factory.NativeProxy.GetNativeConstant("OPT_TEXTDIRECTION");
             public static readonly int OPT_DUPLICATEINV = (int)Factory.NativeProxy.GetNativeConstant("OPT_DUPLICATEINV");
             public static readonly int OPT_SAVESCREENSHOT = (int)Factory.NativeProxy.GetNativeConstant("OPT_SAVESCREENSHOT");
             public static readonly int OPT_PORTRAITSIDE = (int)Factory.NativeProxy.GetNativeConstant("OPT_PORTRAITSIDE");

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -773,7 +773,7 @@ namespace AGS
             if (name->Equals("OPT_ANTIALIASFONTS")) return OPT_ANTIALIASFONTS;
             if (name->Equals("OPT_THOUGHTGUI")) return OPT_THOUGHTGUI;
             if (name->Equals("OPT_TURNTOFACELOC")) return OPT_TURNTOFACELOC;
-            if (name->Equals("OPT_RIGHTLEFTWRITE")) return OPT_RIGHTLEFTWRITE;
+            if (name->Equals("OPT_TEXTDIRECTION")) return OPT_TEXTDIRECTION;
             if (name->Equals("OPT_DUPLICATEINV")) return OPT_DUPLICATEINV;
             if (name->Equals("OPT_SAVESCREENSHOT")) return OPT_SAVESCREENSHOT;
             if (name->Equals("OPT_PORTRAITSIDE")) return OPT_PORTRAITSIDE;

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3069,7 +3069,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 	game->Settings->AntiAliasFonts = (thisgame.options[OPT_ANTIALIASFONTS] != 0);
 	game->Settings->AntiGlideMode = (thisgame.options[OPT_ANTIGLIDE] != 0);
 	game->Settings->AutoMoveInWalkMode = !thisgame.options[OPT_NOWALKMODE];
-	game->Settings->BackwardsText = (thisgame.options[OPT_RIGHTLEFTWRITE] != 0);
+	game->Settings->TextDirection = (AGS::Types::TextDirection)thisgame.options[OPT_TEXTDIRECTION];
 	game->Settings->ColorDepth = (GameColorDepth)thisgame.color_depth;
 	game->Settings->CompressSpritesType = (SpriteCompression)thisgame.options[OPT_COMPRESSSPRITES];
 	game->Settings->CrossfadeMusic = (CrossfadeSpeed)thisgame.options[OPT_CROSSFADEMUSIC];

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -119,6 +119,7 @@
     <Compile Include="EditorFeatures\RoomTemplate.cs" />
     <Compile Include="Enums\AndroidBuildFormat.cs" />
     <Compile Include="Enums\InputMotionMode.cs" />
+    <Compile Include="Enums\TextDirection.cs" />
     <Compile Include="Enums\TouchToMouseEmulationType.cs" />
     <Compile Include="Enums\FontAutoOutlineStyle.cs" />
     <Compile Include="Enums\CrossfadeSpeed.cs" />

--- a/Editor/AGS.Types/Enums/TextDirection.cs
+++ b/Editor/AGS.Types/Enums/TextDirection.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace AGS.Types
+{
+    public enum TextDirection
+    {
+        LeftToRight = 0,
+        RightToLeft = 1,
+        RightToLeftReversed = 2
+    }
+}

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -103,7 +103,7 @@ namespace AGS.Types
         private FontHeightDefinition _ttfHeightDefinedBy = FontHeightDefinition.NominalHeight;
         private FontMetricsFixup _ttfMetricsFixup = FontMetricsFixup.None;
         private int _thoughtGUI = 0;
-        private bool _backwardsText = false;
+        private TextDirection _textDirection = TextDirection.LeftToRight;
         private int _uniqueID;
 		private Guid _guid;
         private bool _hasMODMusic = false;
@@ -1009,14 +1009,22 @@ namespace AGS.Types
             set { _thoughtGUI = value; }
         }
 
-        [DisplayName("Write game text Right-to-Left")]
-        [Description("The game will draw text right-to-left, used by languages such as Hebrew")]
-        [DefaultValue(false)]
-        [Category("Text output")]
+        [Obsolete]
+        [Browsable(false)]
         public bool BackwardsText
         {
-            get { return _backwardsText; }
-            set { _backwardsText = value; }
+            get { return _textDirection != TextDirection.LeftToRight; }
+            set { TextDirection = value ? TextDirection.RightToLeft : TextDirection.LeftToRight; }
+        }
+
+        [DisplayName("Text direction")]
+        [Description("Which direction the game will draw texts (left-to-right, right-to-left)")]
+        [DefaultValue(TextDirection.LeftToRight)]
+        [Category("Text output")]
+        public TextDirection TextDirection
+        {
+            get { return _textDirection; }
+            set { _textDirection = value; }
         }
 
         [DisplayName("Maximum possible score")]

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -18,13 +18,14 @@ namespace AGS.Types
         private const string TAG_DEFAULT = "DEFAULT";
         private const string TAG_DIRECTION_LEFT = "LEFT";
         private const string TAG_DIRECTION_RIGHT = "RIGHT";
+        private const string TAG_DIRECTION_RIGHTREV = "RIGHTREV";
 
         private string _name;
         private string _fileName;
         private bool _modified;
         private int? _normalFont;
         private int? _speechFont;
-        private bool? _rightToLeftText;
+        private TextDirection? _textDirection;
         private string _encodingHint;
         private Encoding _encoding;
         private Dictionary<string, string> _translatedLines;
@@ -35,7 +36,7 @@ namespace AGS.Types
             _modified = false;
             _normalFont = null;
             _speechFont = null;
-            _rightToLeftText = null;
+            _textDirection = null;
             EncodingHint = "UTF-8";
         }
 
@@ -71,9 +72,9 @@ namespace AGS.Types
             get { return _speechFont; }
         }
 
-        public bool? RightToLeftText
+        public TextDirection? TextDirection
         {
-            get { return _rightToLeftText; }
+            get { return _textDirection; }
         }
 
         public string EncodingHint
@@ -108,7 +109,7 @@ namespace AGS.Types
             _modified = false;
             _normalFont = null;
             _speechFont = null;
-            _rightToLeftText = null;
+            _textDirection = null;
             _encodingHint = null;
             _encoding = Encoding.Default;
             LoadData();
@@ -138,8 +139,16 @@ namespace AGS.Types
                 sw.WriteLine("//#NormalFont=" + WriteOptionalInt(_normalFont));
                 sw.WriteLine("// The speech font to use - DEFAULT or font number");
                 sw.WriteLine("//#SpeechFont=" + WriteOptionalInt(_speechFont));
-                sw.WriteLine("// Text direction - DEFAULT, LEFT or RIGHT");
-                sw.WriteLine("//#TextDirection=" + ((_rightToLeftText == true) ? TAG_DIRECTION_RIGHT : ((_rightToLeftText == null) ? TAG_DEFAULT : TAG_DIRECTION_LEFT)));
+                sw.WriteLine("// Text direction - DEFAULT, LEFT, RIGHT, RIGHTREV");
+                string dirText;
+                switch (_textDirection)
+                {
+                    case Types.TextDirection.LeftToRight: dirText = TAG_DIRECTION_LEFT; break;
+                    case Types.TextDirection.RightToLeft: dirText = TAG_DIRECTION_RIGHT; break;
+                    case Types.TextDirection.RightToLeftReversed: dirText = TAG_DIRECTION_RIGHTREV; break;
+                    default: dirText = TAG_DEFAULT; break;
+                }
+                sw.WriteLine("//#TextDirection=" + dirText);
                 sw.WriteLine("// Text encoding hint - ASCII or UTF-8");
                 sw.WriteLine("//#Encoding=" + (_encodingHint ?? "ASCII"));
                 sw.WriteLine("//  ");
@@ -206,15 +215,19 @@ namespace AGS.Types
                 string directionText = line.Substring(TEXT_DIRECTION_TAG.Length);
                 if (directionText == TAG_DIRECTION_LEFT)
                 {
-                    _rightToLeftText = false;
+                    _textDirection = Types.TextDirection.LeftToRight;
                 }
                 else if (directionText == TAG_DIRECTION_RIGHT)
                 {
-                    _rightToLeftText = true;
+                    _textDirection = Types.TextDirection.RightToLeft;
+                }
+                else if (directionText == TAG_DIRECTION_RIGHTREV)
+                {
+                    _textDirection = Types.TextDirection.RightToLeftReversed;
                 }
                 else
                 {
-                    _rightToLeftText = null;
+                    _textDirection = null;
                 }
             }
             // TODO: make a generic dictionary instead and save any option

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -95,7 +95,7 @@ void GUILabel::PrepareTextToDraw()
 
 size_t GUILabel::SplitLinesForDrawing(SplitLines &lines)
 {
-    return split_lines(_textToDraw.GetCStr(), lines, Width, Font);
+    return split_lines(_textToDraw.GetCStr(), false, lines, Width, Font);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -16,12 +16,6 @@
 
 #include "ac/common_defines.h"
 
-// xalleg.h pulls in an Allegro-internal definition of MAX_TIMERS which
-// conflicts with the definition in runtime_defines.h. Forget it.
-#ifdef MAX_TIMERS
-#undef MAX_TIMERS
-#endif
-
 // Max old-style script string length
 #define MAX_MAXSTRLEN 200
 #define MAXGLOBALVARS 50

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -299,27 +299,28 @@ size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, i
     if (wii < 3)
         return 0;
 
-    int line_length;
+    const TextDirection text_dir = (TextDirection)game.options[OPT_TEXTDIRECTION];
 
-    split_lines(todis, lines, wii, fonnt, max_lines);
+    split_lines(todis, text_dir == kTextDir_RightToLeftRev, lines, wii, fonnt, max_lines);
 
-    // Right-to-left just means reverse the text then
-    // write it as normal
-    if (game.options[OPT_RIGHTLEFTWRITE])
-        for (size_t rr = 0; rr < lines.Count(); rr++) {
+    switch (text_dir) {
+    case kTextDir_LeftToRight:
+    /* case kTextDir_RightToLeftRev: */
+        for (size_t rr = 0; rr < lines.Count(); ++rr) {
+            longestline = std::max(longestline, get_text_width_outlined(lines[rr].GetCStr(), fonnt));
+        }
+        break;
+    case kTextDir_RightToLeft:
+    case kTextDir_RightToLeftRev: /* FIXME !!! -- optimize, by refactoring line split instead */
+        // Reverse each split line
+        for (size_t rr = 0; rr < lines.Count(); ++rr) {
             (get_uformat() == U_UTF8) ?
                 lines[rr].ReverseUTF8() :
                 lines[rr].Reverse();
-            line_length = get_text_width_outlined(lines[rr].GetCStr(), fonnt);
-            if (line_length > longestline)
-                longestline = line_length;
+            longestline = std::max(longestline, get_text_width_outlined(lines[rr].GetCStr(), fonnt));
         }
-    else
-        for (size_t rr = 0; rr < lines.Count(); rr++) {
-            line_length = get_text_width_outlined(lines[rr].GetCStr(), fonnt);
-            if (line_length > longestline)
-                longestline = line_length;
-        }
+        break;
+    }
     return lines.Count();
 }
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -713,11 +713,8 @@ void engine_init_game_settings()
     play.rtint_level = 0;
     play.rtint_light = 0;
     play.text_speed_modifier = 0;
-    play.text_align = kHAlignLeft;
     // Make the default alignment to the right with right-to-left text
-    if (game.options[OPT_RIGHTLEFTWRITE])
-        play.text_align = kHAlignRight;
-
+    play.text_align = TextDirectionToAlign((TextDirection)game.options[OPT_TEXTDIRECTION]);
     play.speech_bubble_width = get_fixed_pixel_size(100);
     play.bg_frame=0;
     play.bg_frame_locked=0;

--- a/Tools/data/tra_utils.cpp
+++ b/Tools/data/tra_utils.cpp
@@ -35,6 +35,7 @@ const String GAMEENCODING_TAG("//#GameEncoding=");
 const char *TAG_DEFAULT = "DEFAULT";
 const char *TAG_DIRECTION_LEFT = "LEFT";
 const char *TAG_DIRECTION_RIGHT = "RIGHT";
+const char *TAG_DIRECTION_RIGHTREV = "RIGHTREV";
 
 static int ReadOptionalInt(const String &text)
 {
@@ -58,15 +59,19 @@ static void ReadSpecialTags(Translation &tra, const String &line)
         String directionText = line.Mid(TEXT_DIRECTION_TAG.GetLength());
         if (directionText == TAG_DIRECTION_LEFT)
         {
-            tra.RightToLeft = 1;
+            tra.TextDirection = 1;
         }
         else if (directionText == TAG_DIRECTION_RIGHT)
         {
-            tra.RightToLeft = 2;
+            tra.TextDirection = 2;
+        }
+        else if (directionText == TAG_DIRECTION_RIGHTREV)
+        {
+            tra.TextDirection = 3;
         }
         else
         {
-            tra.RightToLeft = -1;
+            tra.TextDirection = -1;
         }
     }
     // TODO: make a generic dictionary instead and save any option


### PR DESCRIPTION
**THIS IS A DRAFT**; in theory this problem may be resolved using a scripting module. I'll postpone this PR until it becomes more clear whether the scripting solution works and convenient enough for users.

**Problem**

Currently AGS's font renderer does not support drawing ligatures correctly for languages like Arabic, Persian, and maybe few more. It draws the letters, but does not connect them, which makes the text look incorrect.

One of the known existing workarounds is to use a converter program, that converts text by joining multiple glyphs into one "special" glyph. The resulting text may be displayed using corresponding TTF fonts that support this.

A problem about this conversion is that the resulting text ends up reversed in memory. Normally the RTL texts which are supposed to be displayed right-to-left are stored in memory in the order of their *reading*. But with the above workaround it is stored in memory opposite to how it's read.

For this reason, the existing text wrapping algorithm in AGS does not work for them, as the syntactical beginning of the phrase will appear on the last line, and the end of the phrase on the first line.

**Proposed solution**

Add a new selection to the text direction game option, called "Right-to-left reversed". Allow both game and translations select this mode. When AGS is in this text mode, the text wrapping function accounts for this and scans & splits the text in reverse order.

1. Replaced "Right-to-left" (boolean) property in the Editor with "Text direction" property, having 3 options now ("Left-to-right", "Right-to-left" and "Right-to-left reversed"). When upgrading an older project "Text direction" will be correctly set from "Right-to-left".
2. Translation source (TRS) supports new tag for this direction: "RIGHTREV".
3. Both Editor and standalone translation compiler (trac) taught about this new tag.
4. Engine already had OPT_RIGHTLEFTWRITE option in game data, I renamed it to OPT_TEXTDIRECTION; as it was an integer, it's possible to store any new values there already.
5. For the time being I solved the reverse wrapping by completely reversing the text before doing line split. This could be optimized, but that would require refactoring split_lines() again, and I don't have spare time for that yet. I don't think that current implementation will cause any impact on performance, as majority of displayed texts in the games are not more than 2-3 lines long.

Runtime game and save formats was not changed.