### PR TITLE
Removes special cases for [ as a newline character

### DIFF
--- a/Compiler/script/cc_compiledscript.cpp
+++ b/Compiler/script/cc_compiledscript.cpp
@@ -68,10 +68,6 @@ int ccCompiledScript::add_string(const char*strr) {
             ch = strr[src];
             if (ch == 'n') {ch = '\n';}
             else if (ch == 'r') {ch = '\r';}
-            else if (ch == '[') { // pass through as \[
-                *write_ptr = '\\';
-                write_ptr++;
-            }
         }
         *write_ptr = ch;
         write_ptr++;

--- a/Compiler/script2/cs_scanner.cpp
+++ b/Compiler/script2/cs_scanner.cpp
@@ -432,10 +432,6 @@ void AGS::Scanner::ReadInCharLit(std::string &symstring, CodeCell &value)
             if (Failed())
                 break; // to error processing
 
-            if ('[' == lit_char)
-                // "\\[" is equivalent to two characters, so can't be used as a single character
-                UserError("'\\[' is not allowed in single quotes, use '[' instead");
-
             EscapedChar2Char(lit_char, symstring, lit_char);
         }
 
@@ -557,16 +553,11 @@ void AGS::Scanner::ReadInStringLit(std::string &symstring, std::string &valstrin
             symstring.push_back(ch);
             if (EOFReached() || Failed() || '\n' == ch || '\r' == ch)
                 break; // to error msg
-            if ('[' == ch)
-            {
-                valstring.append("\\[");
-            }
-            else
-            {
-                int converted;
-                EscapedChar2Char(ch, symstring, converted);
-                valstring.push_back(converted);
-            }
+            
+            int converted;
+            EscapedChar2Char(ch, symstring, converted);
+            valstring.push_back(converted);
+
             continue;
         }
 
@@ -621,7 +612,7 @@ void AGS::Scanner::ReadInStringLit(std::string &symstring, std::string &valstrin
     else if (Failed())
         UserError("Read error while scanning a string literal (file corrupt?)");
     else  
-        UserError("Line ended within a string literal, this isn't allowed (use '[' for newline)");
+        UserError("Line ended within a string literal, this isn't allowed.");
 }
 
 void AGS::Scanner::ReadInIdentifier(std::string &symstring)

--- a/Compiler/test2/cc_scanner_test.cpp
+++ b/Compiler/test2/cc_scanner_test.cpp
@@ -750,13 +750,13 @@ TEST_F(Scan, String1)
 {
     // Should scan advanced escape sequences within string.
 
-    std::string Input = "\"Oh, \\the \\brow\\n \\fo\\x5e jumps \\[ove\\r] the \\100\\azy dog.\"";
+    std::string Input = "\"Oh, \\the \\brow\\n \\fo\\x5e jumps [ove\\r] the \\100\\azy dog.\"";
     AGS::Scanner scanner(Input, token_list, string_collector, sym, mh);
 
     ASSERT_LE(0, scanner.GetNextSymstringT(symstring, sct, value));
     ASSERT_LE(0, value);
-    EXPECT_STREQ("Oh, \the \brow\n \fo^ jumps \\[ove\r] the @\azy dog.", &(string_collector.strings[value]));
-    EXPECT_STREQ("\"Oh, \\the \\brow\\n \\fo\\x5e jumps \\[ove\\r] the \\100\\azy dog.\"", symstring.c_str());
+    EXPECT_STREQ("Oh, \the \brow\n \fo^ jumps [ove\r] the @\azy dog.", &(string_collector.strings[value]));
+    EXPECT_STREQ("\"Oh, \\the \\brow\\n \\fo\\x5e jumps [ove\\r] the \\100\\azy dog.\"", symstring.c_str());
 }
 
 TEST_F(Scan, UnknownKeywordAfterReadonly) {


### PR DESCRIPTION
This PR removes the ability for the `[` character to be used as a newline.

It also means that it won't be possible to add newlines to GUI Labels until another PR to unescape the escaped "\n" in their Text properties from the Editor (when set from script they will work as usual).