### PR TITLE
Performance fixes for script interpreter

### DIFF
--- a/Common/script/cc_internal.h
+++ b/Common/script/cc_internal.h
@@ -112,6 +112,7 @@
 #define EXPORT_FUNCTION   1
 #define EXPORT_DATA       2
 
+#define FIXUP_NOFIXUP     0     // no-op
 #define FIXUP_GLOBALDATA  1     // code[fixup] += &globaldata[0]
 #define FIXUP_FUNCTION    2     // code[fixup] += &code[0]
 #define FIXUP_STRING      3     // code[fixup] += &strings[0]

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -623,18 +623,6 @@ int ccInstance::Run(int32_t curpc)
         /* End ReadOperation */
         //=====================================================================
 
-        // save the arguments for quick access
-        RuntimeScriptValue &arg1 = codeOp.Args[0];
-        RuntimeScriptValue &arg2 = codeOp.Args[1];
-        RuntimeScriptValue &arg3 = codeOp.Args[2];
-        RuntimeScriptValue &reg1 = 
-            registers[arg1.IValue >= 0 && arg1.IValue < CC_NUM_REGISTERS ? arg1.IValue : 0];
-        RuntimeScriptValue &reg2 = 
-            registers[arg2.IValue >= 0 && arg2.IValue < CC_NUM_REGISTERS ? arg2.IValue : 0];
-
-        const char *direct_ptr1;
-        const char *direct_ptr2;
-
 #if (DEBUG_CC_EXEC)
         if (dump_opcodes)
         {
@@ -645,21 +633,25 @@ int ccInstance::Run(int32_t curpc)
         switch (codeOp.Instruction.Code)
         {
       case SCMD_LINENUM:
-          line_number = arg1.IValue;
-          currentline = arg1.IValue;
+          line_number = codeOp.Arg1i();
+          currentline = line_number;
           if (new_line_hook)
               new_line_hook(this, currentline);
           break;
       case SCMD_ADD:
+      {
+          const auto arg_reg = codeOp.Arg1i();
+          const auto arg_lit = codeOp.Arg2i();
+          auto &reg1 = registers[arg_reg];
           // If the the register is SREG_SP, we are allocating new variable on the stack
-          if (arg1.IValue == SREG_SP)
+          if (arg_reg == SREG_SP)
           {
             // Only allocate new data if current stack entry is invalid;
             // in some cases this may be advancing over value that was written by MEMWRITE*
             // FIXME: this is bad, but seemed to be the way to separate PushValue and PushData
             // find if it's possible to do this in a uniform way (always same operation),
             // and don't rely on stack entries being valid/invalid beyond the stack ptr.
-            ASSERT_STACK_SPACE_AVAILABLE(1, arg2.IValue);
+            ASSERT_STACK_SPACE_AVAILABLE(1, arg_lit);
             if (reg1.RValue->IsValid())
             {
               // TODO: perhaps should add a flag here to ensure this happens only after MEMWRITE-ing to stack
@@ -668,16 +660,21 @@ int ccInstance::Run(int32_t curpc)
             }
             else
             {
-              PushDataToStack(arg2.IValue);
+              PushDataToStack(arg_lit);
               ASSERT_CC_ERROR();
             }
           }
           else
           {
-            reg1.IValue += arg2.IValue;
+            reg1.IValue += arg_lit;
           }
           break;
+      }
       case SCMD_SUB:
+      {
+          const auto arg_reg = codeOp.Arg1i();
+          const auto arg_lit = codeOp.Arg2i();
+          auto &reg1 = registers[arg_reg];
           if (reg1.Type == kScValStackPtr)
           {
             // If this is SREG_SP, this is stack pop, which frees local variables;
@@ -686,49 +683,58 @@ int ccInstance::Run(int32_t curpc)
             // // AGS 2.x games also perform relative stack access by copying SREG_SP to SREG_MAR
             // // and then subtracting from that.
             // FIXME: try to do this in uniform way, call same func, save result in reg1
-            if (arg1.IValue == SREG_SP)
+            if (arg_reg == SREG_SP)
             {
-                PopDataFromStack(arg2.IValue);
+                PopDataFromStack(arg_lit);
             }
             else
             {
                 // This is practically LOADSPOFFS
-                reg1 = GetStackPtrOffsetRw(arg2.IValue);
+                reg1 = GetStackPtrOffsetRw(arg_lit);
             }
             ASSERT_CC_ERROR();
           }
           else
           {
-            reg1.IValue -= arg2.IValue;
+            reg1.IValue -= arg_lit;
           }
           break;
+      }
       case SCMD_REGTOREG:
+      {
+          const auto &reg1 = registers[codeOp.Arg1i()];
+          auto       &reg2 = registers[codeOp.Arg2i()];
           reg2 = reg1;
           break;
+      }
       case SCMD_WRITELIT:
+      {
           // Take the data address from reg[MAR] and copy there arg1 bytes from arg2 address
           //
           // NOTE: since it reads directly from arg2 (which originally was
           // long, or rather int32 due x32 build), written value may normally
           // be only up to 4 bytes large;
           // I guess that's an obsolete way to do WRITE, WRITEW and WRITEB
-          switch (arg1.IValue)
+          const auto arg_size = codeOp.Arg1i();
+          const auto &arg_value = codeOp.Arg2();
+          switch (arg_size)
           {
           case sizeof(char):
-              registers[SREG_MAR].WriteByte(arg2.IValue);
+              registers[SREG_MAR].WriteByte(arg_value.IValue);
               break;
           case sizeof(int16_t):
-              registers[SREG_MAR].WriteInt16(arg2.IValue);
+              registers[SREG_MAR].WriteInt16(arg_value.IValue);
               break;
           case sizeof(int32_t):
               // We do not know if this is math integer or some pointer, etc
-              registers[SREG_MAR].WriteValue(arg2);
+              registers[SREG_MAR].WriteValue(arg_value);
               break;
           default:
-              cc_error("unexpected data size for WRITELIT op: %d", arg1.IValue);
+              cc_error("unexpected data size for WRITELIT op: %d", arg_size);
               break;
           }
           break;
+      }
       case SCMD_RET:
           {
           if (loopIterationCheckDisabled > 0)
@@ -747,84 +753,164 @@ int ccInstance::Run(int32_t curpc)
           continue; // continue so that the PC doesn't get overwritten
           }
       case SCMD_LITTOREG:
-          reg1 = arg2;
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
+          const auto &arg_value = codeOp.Arg2();
+          reg1 = arg_value;
           break;
+      }
       case SCMD_MEMREAD:
+      {
           // Take the data address from reg[MAR] and copy int32_t to reg[arg1]
+          auto &reg1 = registers[codeOp.Arg1i()];
           reg1 = registers[SREG_MAR].ReadValue();
           break;
+      }
       case SCMD_MEMWRITE:
+      {
           // Take the data address from reg[MAR] and copy there int32_t from reg[arg1]
+          const auto &reg1 = registers[codeOp.Arg1i()];
           registers[SREG_MAR].WriteValue(reg1);
           break;
+      }
       case SCMD_LOADSPOFFS:
-          registers[SREG_MAR] = GetStackPtrOffsetRw(arg1.IValue);
+      {
+          const auto arg_off = codeOp.Arg1i();
+          registers[SREG_MAR] = GetStackPtrOffsetRw(arg_off);
           ASSERT_CC_ERROR();
           break;
-
-          // 64 bit: Force 32 bit math
+      }
       case SCMD_MULREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue * reg2.IValue);
           break;
+      }
       case SCMD_DIVREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           if (reg2.IValue == 0) {
               cc_error("!Integer divide by zero");
               return -1;
-          } 
+          }
           reg1.SetInt32(reg1.IValue / reg2.IValue);
           break;
+      }
       case SCMD_ADDREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           // This may be pointer arithmetics, in which case IValue stores offset from base pointer
           reg1.IValue += reg2.IValue;
           break;
+      }
       case SCMD_SUBREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           // This may be pointer arithmetics, in which case IValue stores offset from base pointer
           reg1.IValue -= reg2.IValue;
           break;
+      }
       case SCMD_BITAND:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue & reg2.IValue);
           break;
+      }
       case SCMD_BITOR:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue | reg2.IValue);
           break;
+      }
       case SCMD_ISEQUAL:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1 == reg2);
           break;
+      }
       case SCMD_NOTEQUAL:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1 != reg2);
           break;
+      }
       case SCMD_GREATER:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue > reg2.IValue);
           break;
+      }
       case SCMD_LESSTHAN:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue < reg2.IValue);
           break;
+      }
       case SCMD_GTE:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue >= reg2.IValue);
           break;
+      }
       case SCMD_LTE:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue <= reg2.IValue);
           break;
+      }
       case SCMD_AND:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue && reg2.IValue);
           break;
+      }
       case SCMD_OR:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32AsBool(reg1.IValue || reg2.IValue);
           break;
+      }
       case SCMD_XORREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue ^ reg2.IValue);
           break;
+      }
       case SCMD_MODREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           if (reg2.IValue == 0) {
               cc_error("!Integer divide by zero");
               return -1;
-          } 
+          }
           reg1.SetInt32(reg1.IValue % reg2.IValue);
           break;
+      }
       case SCMD_NOTREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1 = !(reg1);
           break;
+      }
       case SCMD_CALL:
+      {
           // Call another function within same script, just save PC
           // and continue from there
           if (curnest >= MAXNEST - 1) {
@@ -837,6 +923,7 @@ int ccInstance::Run(int32_t curpc)
           ASSERT_STACK_SPACE_VALS(1);
           PushValueToStack(RuntimeScriptValue().SetInt32(pc + codeOp.ArgCount + 1));
 
+          const auto &reg1 = registers[codeOp.Arg1i()];
           if (thisbase[curnest] == 0)
               pc = reg1.IValue;
           else {
@@ -853,44 +940,71 @@ int ccInstance::Run(int32_t curpc)
           thisbase[curnest] = 0;
           funcstart[curnest] = pc;
           continue; // continue so that the PC doesn't get overwritten
+      }
       case SCMD_MEMREADB:
+      {
           // Take the data address from reg[MAR] and copy byte to reg[arg1]
+          auto &reg1 = registers[codeOp.Arg1i()];
           reg1.SetUInt8(registers[SREG_MAR].ReadByte());
           break;
+      }
       case SCMD_MEMREADW:
+      {
           // Take the data address from reg[MAR] and copy int16_t to reg[arg1]
+          auto &reg1 = registers[codeOp.Arg1i()];
           reg1.SetInt16(registers[SREG_MAR].ReadInt16());
           break;
+      }
       case SCMD_MEMWRITEB:
+      {
           // Take the data address from reg[MAR] and copy there byte from reg[arg1]
+          const auto &reg1 = registers[codeOp.Arg1i()];
           registers[SREG_MAR].WriteByte(reg1.IValue);
           break;
+      }
       case SCMD_MEMWRITEW:
+      {
           // Take the data address from reg[MAR] and copy there int16_t from reg[arg1]
+          const auto &reg1 = registers[codeOp.Arg1i()];
           registers[SREG_MAR].WriteInt16(reg1.IValue);
           break;
+      }
       case SCMD_JZ:
+      {
+          const auto arg_lit = codeOp.Arg1i();
           if (registers[SREG_AX].IsNull())
-              pc += arg1.IValue;
+              pc += arg_lit;
           break;
+      }
       case SCMD_JNZ:
+      {
+          const auto arg_lit = codeOp.Arg1i();
           if (!registers[SREG_AX].IsNull())
-              pc += arg1.IValue;
+              pc += arg_lit;
           break;
+      }
       case SCMD_PUSHREG:
+      {
           // Push reg[arg1] value to the stack
+          const auto &reg1 = registers[codeOp.Arg1i()];
           ASSERT_STACK_SPACE_VALS(1);
           PushValueToStack(reg1);
           break;
+      }
       case SCMD_POPREG:
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
           ASSERT_STACK_SIZE(1);
           reg1 = PopValueFromStack();
           break;
+      }
       case SCMD_JMP:
-          pc += arg1.IValue;
+      {
+          const auto arg_lit = codeOp.Arg1i();
+          pc += arg_lit;
 
           // Make sure it's not stuck in a While loop
-          if (arg1.IValue < 0)
+          if (arg_lit < 0)
           {
               ++loopIterations;
               if (flags & INSTF_RUNNING)
@@ -915,18 +1029,28 @@ int ccInstance::Run(int32_t curpc)
               }
           }
           break;
+      }
       case SCMD_MUL:
-          reg1.IValue *= arg2.IValue;
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
+          const auto arg_lit = codeOp.Arg2i();
+          reg1.IValue *= arg_lit;
           break;
+      }
       case SCMD_CHECKBOUNDS:
+      {
+          const auto &reg1 = registers[codeOp.Arg1i()];
+          const auto arg_lit = codeOp.Arg2i();
           if ((reg1.IValue < 0) ||
-              (reg1.IValue >= arg2.IValue)) {
-                  cc_error("!Array index out of bounds (index: %d, bounds: 0..%d)", reg1.IValue, arg2.IValue - 1);
+              (reg1.IValue >= arg_lit)) {
+                  cc_error("!Array index out of bounds (index: %d, bounds: 0..%d)", reg1.IValue, arg_lit - 1);
                   return -1;
           }
           break;
+      }
       case SCMD_DYNAMICBOUNDS:
           {
+          const auto &reg1 = registers[codeOp.Arg1i()];
               // TODO: test reg[MAR] type here;
               // That might be dynamic object, but also a non-managed dynamic array, "allocated"
               // on global or local memspace (buffer)
@@ -952,6 +1076,7 @@ int ccInstance::Run(int32_t curpc)
 
       case SCMD_MEMREADPTR:
       {
+          auto &reg1 = registers[codeOp.Arg1i()];
           int32_t handle = registers[SREG_MAR].ReadInt32();
           // FIXME: make pool return a ready RuntimeScriptValue with these set?
           // or another struct, which may be assigned to RSV
@@ -964,6 +1089,7 @@ int ccInstance::Run(int32_t curpc)
       }
       case SCMD_MEMWRITEPTR:
       {
+          const auto &reg1 = registers[codeOp.Arg1i()];
           int32_t handle = registers[SREG_MAR].ReadInt32();
           const char *address;
 
@@ -1002,6 +1128,7 @@ int ccInstance::Run(int32_t curpc)
       case SCMD_MEMINITPTR:
       { 
           char *address;
+          const auto &reg1 = registers[codeOp.Arg1i()];
 
           switch (reg1.Type)
           {
@@ -1060,18 +1187,26 @@ int ccInstance::Run(int32_t curpc)
           }
           break;
       case SCMD_CHECKNULLREG:
+      {
+          const auto &reg1 = registers[codeOp.Arg1i()];
           if (reg1.IsNull()) {
               cc_error("!Null string referenced");
               return -1;
           }
           break;
+      }
       case SCMD_NUMFUNCARGS:
-          num_args_to_func = arg1.IValue;
+      {
+          const auto arg_lit = codeOp.Arg1i();
+          num_args_to_func = arg_lit;
           break;
-      case SCMD_CALLAS:{
+      }
+      case SCMD_CALLAS:
+      {
           PUSH_CALL_STACK;
 
           // Call to a function in another script
+          const auto &reg1 = registers[codeOp.Arg1i()];
 
           // If there are nested CALLAS calls, the stack might
           // contain 2 calls worth of parameters, so only
@@ -1126,6 +1261,8 @@ int ccInstance::Run(int32_t curpc)
                        }
       case SCMD_CALLEXT: {
           // Call to a real 'C' code function
+          const auto &reg1 = registers[codeOp.Arg1i()];
+
           was_just_callas = -1;
           if (num_args_to_func < 0)
           {
@@ -1203,19 +1340,27 @@ int ccInstance::Run(int32_t curpc)
           break;
                          }
       case SCMD_PUSHREAL:
+      {
+          const auto &reg1 = registers[codeOp.Arg1i()];
           PushToFuncCallStack(func_callstack, reg1);
           break;
+      }
       case SCMD_SUBREALSTACK:
-          PopFromFuncCallStack(func_callstack, arg1.IValue);
+      {
+          const auto arg_lit = codeOp.Arg1i();
+          PopFromFuncCallStack(func_callstack, arg_lit);
           if (was_just_callas >= 0)
           {
-              ASSERT_STACK_SIZE(arg1.IValue);
-              PopValuesFromStack(arg1.IValue);
+              ASSERT_STACK_SIZE(arg_lit);
+              PopValuesFromStack(arg_lit);
               was_just_callas = -1;
           }
           break;
+      }
       case SCMD_CALLOBJ:
+      {
           // set the OP register
+          const auto &reg1 = registers[codeOp.Arg1i()];
           if (reg1.IsNull()) {
               cc_error("!Null pointer referenced");
               return -1;
@@ -1249,82 +1394,140 @@ int ccInstance::Run(int32_t curpc)
           }
           next_call_needs_object = 1;
           break;
+      }
       case SCMD_SHIFTLEFT:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue << reg2.IValue);
           break;
+      }
       case SCMD_SHIFTRIGHT:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetInt32(reg1.IValue >> reg2.IValue);
           break;
+      }
       case SCMD_THISBASE:
-          thisbase[curnest] = arg1.IValue;
+      {
+          const auto arg_lit = codeOp.Arg1i();
+          thisbase[curnest] = arg_lit;
           break;
+      }
       case SCMD_NEWARRAY:
           {
+              auto &reg1 = registers[codeOp.Arg1i()];
+              const auto arg_elsize = codeOp.Arg2i();
+              const auto arg_managed = codeOp.Arg3().GetAsBool();
               int numElements = reg1.IValue;
               if (numElements < 1)
               {
                   cc_error("invalid size for dynamic array; requested: %d, range: 1..%d", numElements, INT32_MAX);
                   return -1;
               }
-              DynObjectRef ref = globalDynamicArray.Create(numElements, arg2.IValue, arg3.GetAsBool());
+              DynObjectRef ref = globalDynamicArray.Create(numElements, arg_elsize, arg_managed);
               reg1.SetDynamicObject(ref.second, &globalDynamicArray);
               break;
           }
       case SCMD_NEWUSEROBJECT:
           {
-              const int32_t size = arg2.IValue;
-              if (size < 0)
+              auto &reg1 = registers[codeOp.Arg1i()];
+              const auto arg_size = codeOp.Arg2i();
+              if (arg_size < 0)
               {
-                  cc_error("Invalid size for user object; requested: %d (or %d), range: 0..%d", size, size, INT_MAX);
+                  cc_error("Invalid size for user object; requested: %d (or %d), range: 0..%d", arg_size, arg_size, INT_MAX);
                   return -1;
               }
-              ScriptUserObject *suo = ScriptUserObject::CreateManaged(size);
+              ScriptUserObject *suo = ScriptUserObject::CreateManaged(arg_size);
               reg1.SetDynamicObject(suo, suo);
               break;
           }
       case SCMD_FADD:
-          reg1.SetFloat(reg1.FValue + arg2.IValue); // arg2 was used as int here originally
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
+          const auto arg_lit = codeOp.Arg2i();
+          reg1.SetFloat(reg1.FValue + arg_lit); // arg2 was used as int here originally
           break;
+      }
       case SCMD_FSUB:
-          reg1.SetFloat(reg1.FValue - arg2.IValue); // arg2 was used as int here originally
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
+          const auto arg_lit = codeOp.Arg2i();
+          reg1.SetFloat(reg1.FValue - arg_lit); // arg2 was used as int here originally
           break;
+      }
       case SCMD_FMULREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloat(reg1.FValue * reg2.FValue);
           break;
+      }
       case SCMD_FDIVREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           if (reg2.FValue == 0.0) {
               cc_error("!Floating point divide by zero");
               return -1;
-          } 
+          }
           reg1.SetFloat(reg1.FValue / reg2.FValue);
           break;
+      }
       case SCMD_FADDREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloat(reg1.FValue + reg2.FValue);
           break;
+      }
       case SCMD_FSUBREG:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloat(reg1.FValue - reg2.FValue);
           break;
+      }
       case SCMD_FGREATER:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloatAsBool(reg1.FValue > reg2.FValue);
           break;
+      }
       case SCMD_FLESSTHAN:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloatAsBool(reg1.FValue < reg2.FValue);
           break;
+      }
       case SCMD_FGTE:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloatAsBool(reg1.FValue >= reg2.FValue);
           break;
+      }
       case SCMD_FLTE:
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
           reg1.SetFloatAsBool(reg1.FValue <= reg2.FValue);
           break;
+      }
       case SCMD_ZEROMEMORY:
+      {
+          const auto arg_size = codeOp.Arg1i();
           // Check if we are zeroing at stack tail
           if (registers[SREG_MAR] == registers[SREG_SP]) {
               // creating a local variable -- check the stack to ensure no mem overrun
-              ASSERT_STACK_SPACE_BYTES(arg1.IValue);
+              ASSERT_STACK_SPACE_BYTES(arg_size);
               // NOTE: according to compiler's logic, this is always followed
               // by SCMD_ADD, and that is where the data is "allocated", here we
               // just clean the place.
-              memset(stackdata_ptr, 0, arg1.IValue);
+              memset(stackdata_ptr, 0, arg_size);
           }
           else
           {
@@ -1333,35 +1536,60 @@ int ccInstance::Run(int32_t curpc)
             return -1;
           }
           break;
+      }
       case SCMD_CREATESTRING:
-          if (stringClassImpl == nullptr) {
+      {
+          auto &reg1 = registers[codeOp.Arg1i()];
+          // FIXME: provide a dummy impl to avoid this?
+          // why arrays can be created using global mgr and strings not?
+          if (stringClassImpl == nullptr)
+          {
               cc_error("No string class implementation set, but opcode was used");
               return -1;
           }
-          direct_ptr1 = (const char*)reg1.GetDirectPtr();
-          reg1.SetDynamicObject(
-              stringClassImpl->CreateString(direct_ptr1).second,
-              &myScriptStringImpl);
+          else
+          {
+              const char *ptr = (const char*)reg1.GetDirectPtr();
+              reg1.SetDynamicObject(
+                  stringClassImpl->CreateString(ptr).second,
+                  &myScriptStringImpl);
+          }
           break;
+      }
       case SCMD_STRINGSEQUAL:
-          if ((reg1.IsNull()) || (reg2.IsNull())) {
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
+          if ((reg1.IsNull()) || (reg2.IsNull()))
+          {
               cc_error("!Null pointer referenced");
               return -1;
           }
-          direct_ptr1 = (const char*)reg1.GetDirectPtr();
-          direct_ptr2 = (const char*)reg2.GetDirectPtr();
-          reg1.SetInt32AsBool(strcmp(direct_ptr1, direct_ptr2) == 0);
-          
+          else
+          {
+              const char *ptr1 = (const char*)reg1.GetDirectPtr();
+              const char *ptr2 = (const char*)reg2.GetDirectPtr();
+              reg1.SetInt32AsBool(strcmp(ptr1, ptr2) == 0);
+          }
           break;
+      }
       case SCMD_STRINGSNOTEQ:
-          if ((reg1.IsNull()) || (reg2.IsNull())) {
+      {
+          auto       &reg1 = registers[codeOp.Arg1i()];
+          const auto &reg2 = registers[codeOp.Arg2i()];
+          if ((reg1.IsNull()) || (reg2.IsNull()))
+          {
               cc_error("!Null pointer referenced");
               return -1;
           }
-          direct_ptr1 = (const char*)reg1.GetDirectPtr();
-          direct_ptr2 = (const char*)reg2.GetDirectPtr();
-          reg1.SetInt32AsBool(strcmp(direct_ptr1, direct_ptr2) != 0 );
+          else
+          {
+              const char *ptr1 = (const char*)reg1.GetDirectPtr();
+              const char *ptr2 = (const char*)reg2.GetDirectPtr();
+              reg1.SetInt32AsBool(strcmp(ptr1, ptr2) != 0);
+          }
           break;
+      }
       case SCMD_LOOPCHECKOFF:
           if (loopIterationCheckDisabled == 0)
               loopIterationCheckDisabled++;

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -505,6 +505,74 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
     currentline = line_number
 
 
+// Return stack ptr at given offset from stack head;
+// Offset is in data bytes; program stack ptr is __not__ changed
+inline RuntimeScriptValue GetStackPtrOffsetFw(RuntimeScriptValue *stack, int32_t fw_offset)
+{
+    int32_t total_off = 0;
+    RuntimeScriptValue *stack_entry = stack;
+    while (total_off < fw_offset && (stack_entry - stack) < CC_STACK_SIZE )
+    {
+        stack_entry++;
+        total_off += stack_entry->Size;
+    }
+    CC_ERROR_IF_RETVAL(total_off < fw_offset, RuntimeScriptValue, "accessing address beyond stack's tail");
+    CC_ERROR_IF_RETVAL(total_off > fw_offset, RuntimeScriptValue, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?");
+    RuntimeScriptValue stack_ptr;
+    stack_ptr.SetStackPtr(stack_entry);
+    return stack_ptr;
+}
+
+// Applies a runtime fixup to the given arg;
+// Fixup of type `fixup` is applied to the `code` value,
+// the result is assigned to the `arg`.
+inline bool FixupArgument(RuntimeScriptValue &arg, int fixup, uintptr_t code,
+    RuntimeScriptValue *stack, const char *strings)
+{
+    // could be relative pointer or import address
+    switch (fixup)
+    {
+    case FIXUP_GLOBALDATA:
+        {
+            ScriptVariable *gl_var = (ScriptVariable*)code;
+            arg.SetGlobalVar(&gl_var->RValue);
+        }
+        return true;
+    case FIXUP_FUNCTION:
+        // originally commented -- CHECKME: could this be used in very old versions of AGS?
+        //      code[fixup] += (long)&code[0];
+        // This is a program counter value, presumably will be used as SCMD_CALL argument
+        arg.SetInt32((int32_t)code);
+        return true;
+    case FIXUP_STRING:
+        arg.SetStringLiteral(strings + code);
+        return true;
+    case FIXUP_IMPORT:
+        {
+            const ScriptImport *import = simp.getByIndex(static_cast<uint32_t>(code));
+            if (import)
+            {
+                arg = import->Value;
+            }
+            else
+            {
+                cc_error("cannot resolve import, key = %ld", code);
+                return false;
+            }
+        }
+        return true;
+    case FIXUP_DATADATA:
+        return false; // placeholder, fail at this as not supposed to be here
+    case FIXUP_STACK:
+        arg = GetStackPtrOffsetFw(stack, (int32_t)code);
+        return true;
+    default:
+        cc_error("internal fixup type error: %d", fixup);
+        return false;
+    }
+}
+
+
 #define MAXNEST 50  // number of recursive function calls allowed
 int ccInstance::Run(int32_t curpc)
 {
@@ -545,7 +613,7 @@ int ccInstance::Run(int32_t curpc)
         // may lead to a performance loss in script-heavy games.
         // always compare execution speed before applying any major changes!
         //
-        /* ReadOperation */
+        /* Read operation */
         //=====================================================================
         codeOp.Instruction.Code			= codeInst->code[pc];
         codeOp.Instruction.InstanceId	= (codeOp.Instruction.Code >> INSTANCE_ID_SHIFT) & INSTANCE_ID_MASK;
@@ -559,63 +627,65 @@ int ccInstance::Run(int32_t curpc)
         CC_ERROR_IF_RETCODE(pc + codeOp.ArgCount >= codeInst->codesize,
             "unexpected end of code data (%d; %d)", pc + codeOp.ArgCount, codeInst->codesize);
 
-        int pc_at = pc + 1;
-        for (int i = 0; i < codeOp.ArgCount; ++i, ++pc_at)
+
+        //---------------------------------------------------------------------
+        /* Fixup arguments */
+        switch (codeOp.ArgCount)
         {
-            char fixup = codeInst->code_fixups[pc_at];
+        case 3:
+        {
+            const int pc_at = pc + 3;
+            const uintptr_t code = codeInst->code[pc_at];
+            const char fixup = codeInst->code_fixups[pc_at];
             if (fixup > 0)
-            {
-                /* FixupArgument */
-                //=====================================================================
-                // could be relative pointer or import address
-                switch (fixup)
-                {
-                case FIXUP_GLOBALDATA:
-                    {
-                        ScriptVariable *gl_var = (ScriptVariable*)codeInst->code[pc_at];
-                        codeOp.Args[i].SetGlobalVar(&gl_var->RValue);
-                    }
-                    break;
-                case FIXUP_FUNCTION:
-                    // originally commented -- CHECKME: could this be used in very old versions of AGS?
-                    //      code[fixup] += (long)&code[0];
-                    // This is a program counter value, presumably will be used as SCMD_CALL argument
-                    codeOp.Args[i].SetInt32((int32_t)codeInst->code[pc_at]);
-                    break;
-                case FIXUP_STRING:
-                    codeOp.Args[i].SetStringLiteral(&codeInst->strings[0] + codeInst->code[pc_at]);
-                    break;
-                case FIXUP_IMPORT:
-                    {
-                        const ScriptImport *import = simp.getByIndex(static_cast<uint32_t>(codeInst->code[pc_at]));
-                        if (import)
-                        {
-                            codeOp.Args[i] = import->Value;
-                        }
-                        else
-                        {
-                            cc_error("cannot resolve import, key = %ld", codeInst->code[pc_at]);
-                            return -1;
-                        }
-                    }
-                    break;
-                case FIXUP_STACK:
-                    codeOp.Args[i] = GetStackPtrOffsetFw((int32_t)codeInst->code[pc_at]);
-                    break;
-                default:
-                    cc_error("internal fixup type error: %d", fixup);
+            { // WARNING: passing our own "stack" instead of one from codeInst
+                if (!FixupArgument(codeOp.Args[2], fixup, code, this->stack, codeInst->strings))
                     return -1;
-                }
-                /* End FixupArgument */
-                //=====================================================================
             }
-            else
-            {
-                // should be a numeric literal (int32 or float)
-                codeOp.Args[i].SetInt32( (int32_t)codeInst->code[pc_at] );
+            else // numeric literal
+            { // should be a numeric literal (int32 or float)
+                codeOp.Args[2].SetInt32((int32_t)code);
             }
+            /* fall-through */
         }
-        /* End ReadOperation */
+        case 2:
+        {
+            const int pc_at = pc + 2;
+            const uintptr_t code = codeInst->code[pc_at];
+            const char fixup = codeInst->code_fixups[pc_at];
+            if (fixup > 0)
+            { // WARNING: passing our own "stack" instead of one from codeInst
+                if (!FixupArgument(codeOp.Args[1], fixup, code, this->stack, codeInst->strings))
+                    return -1;
+            }
+            else // numeric literal
+            { // should be a numeric literal (int32 or float)
+                codeOp.Args[1].SetInt32((int32_t)code);
+            }
+            /* fall-through */
+        }
+        case 1:
+        {
+            const int pc_at = pc + 1;
+            const uintptr_t code = codeInst->code[pc_at];
+            const char fixup = codeInst->code_fixups[pc_at];
+            if (fixup > 0)
+            { // WARNING: passing our own "stack" instead of one from codeInst
+                if (!FixupArgument(codeOp.Args[0], fixup, code, this->stack, codeInst->strings))
+                    return -1;
+            }
+            else // numeric literal
+            { // should be a numeric literal (int32 or float)
+                codeOp.Args[0].SetInt32((int32_t)code);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+        /* End fixup arguments */
+        //---------------------------------------------------------------------
+        /* End read operation */
         //=====================================================================
 
 #if (DEBUG_CC_EXEC)
@@ -625,6 +695,8 @@ int ccInstance::Run(int32_t curpc)
         }
 #endif
 
+        /* Perform operation */
+        //=====================================================================
         switch (codeOp.Instruction.Code)
         {
       case SCMD_LINENUM:
@@ -1593,6 +1665,8 @@ int ccInstance::Run(int32_t curpc)
           cc_error("instruction %d is not implemented", codeOp.Instruction.Code);
           return -1;
         }
+        /* End perform operation */
+        //=====================================================================
 
         pc += codeOp.ArgCount + 1;
     }
@@ -2200,22 +2274,6 @@ void ccInstance::PopDataFromStack(int32_t num_bytes)
     }
     CC_ERROR_IF(total_pop < num_bytes, "stack underflow");
     CC_ERROR_IF(total_pop > num_bytes, "stack pointer points inside local variable after pop, stack corrupted?");
-}
-
-RuntimeScriptValue ccInstance::GetStackPtrOffsetFw(int32_t fw_offset)
-{
-    int32_t total_off = 0;
-    RuntimeScriptValue *stack_entry = &stack[0];
-    while (total_off < fw_offset && stack_entry - &stack[0] < CC_STACK_SIZE )
-    {
-        stack_entry++;
-        total_off += stack_entry->Size;
-    }
-    CC_ERROR_IF_RETVAL(total_off < fw_offset, RuntimeScriptValue, "accessing address beyond stack's tail");
-    CC_ERROR_IF_RETVAL(total_off > fw_offset, RuntimeScriptValue, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?");
-    RuntimeScriptValue stack_ptr;
-    stack_ptr.SetStackPtr(stack_entry);
-    return stack_ptr;
 }
 
 RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(int32_t rw_offset)

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -314,7 +314,14 @@ void ccInstance::AbortAndDestroy()
         return; \
     }
 
-#define CC_ERROR_IF_RET(COND, ERROR, T) \
+#define CC_ERROR_IF_RETCODE(COND, ERROR) \
+    if (COND) \
+    { \
+        cc_error(ERROR); \
+        return -1; \
+    }
+
+#define CC_ERROR_IF_RETVAL(COND, ERROR, T) \
     if (COND) \
     { \
         cc_error(ERROR); \
@@ -330,7 +337,8 @@ void ccInstance::AbortAndDestroy()
 #else
 
 #define CC_ERROR_IF(COND, ERROR)
-#define CC_ERROR_IF_RET(COND, ERROR, T)
+#define CC_ERROR_IF_RETCODE(COND, ERROR)
+#define CC_ERROR_IF_RETVAL(COND, ERROR, T)
 #define ASSERT_CC_ERROR()
 
 #endif // DEBUG_CC_EXEC
@@ -942,44 +950,42 @@ int ccInstance::Run(int32_t curpc)
 
           // 64 bit: Handles are always 32 bit values. They are not C pointer.
 
-      case SCMD_MEMREADPTR: {
+      case SCMD_MEMREADPTR:
+      {
           int32_t handle = registers[SREG_MAR].ReadInt32();
+          // FIXME: make pool return a ready RuntimeScriptValue with these set?
+          // or another struct, which may be assigned to RSV
           void *object;
           ICCDynamicObject *manager;
           ScriptValueType obj_type = ccGetObjectAddressAndManagerFromHandle(handle, object, manager);
-          if (obj_type == kScValPluginObject)
-          {
-              reg1.SetPluginObject( object, manager );
-          }
-          else
-          {
-              reg1.SetDynamicObject( object, manager );
-          }
+          reg1.SetDynamicObject(obj_type, object, manager);
           ASSERT_CC_ERROR();
-          break; }
-      case SCMD_MEMWRITEPTR: {
-
+          break;
+      }
+      case SCMD_MEMWRITEPTR:
+      {
           int32_t handle = registers[SREG_MAR].ReadInt32();
-          char *address = nullptr;
+          const char *address;
 
-          if (reg1.Type == kScValStaticArray && reg1.StcArr->GetDynamicManager())
+          switch (reg1.Type)
           {
-              address = (char*)reg1.StcArr->GetElementPtr(reg1.Ptr, reg1.IValue);
-          }
-          else if (reg1.Type == kScValDynamicObject ||
-              reg1.Type == kScValPluginObject)
-          {
+          case kScValStaticArray:
+              CC_ERROR_IF_RETCODE(!reg1.StcArr->GetDynamicManager(), "internal error: MEMWRITEPTR argument is not a dynamic object");
+              address = reg1.StcArr->GetElementPtr(reg1.Ptr, reg1.IValue);
+              break;
+          case kScValDynamicObject:
+          case kScValPluginObject:
               address = reg1.Ptr;
-          }
-          else if (reg1.Type == kScValPluginArg)
-          {// TODO: plugin API is currently strictly 32-bit, so this may break on 64-bit systems
+              break;
+          case kScValPluginArg:
+              // FIXME: plugin API is currently strictly 32-bit, so this may break on 64-bit systems
               address = Int32ToPtr<char>(reg1.IValue);
-          }
-          // There's one possible case when the reg1 is 0, which means writing nullptr
-          else if (!reg1.IsNull())
-          {
-              cc_error("internal error: MEMWRITEPTR argument is not dynamic object");
-              return -1;
+              break;
+          default:
+              // There's one possible case when the reg1 is 0, which means writing nullptr
+              CC_ERROR_IF_RETCODE(!reg1.IsNull(), "internal error: MEMWRITEPTR argument is not a dynamic object");
+              address = nullptr;
+              break;
           }
 
           int32_t newHandle = ccGetObjectHandleFromAddress(address);
@@ -992,29 +998,32 @@ int ccInstance::Run(int32_t curpc)
               registers[SREG_MAR].WriteInt32(newHandle);
           }
           break;
-                             }
-      case SCMD_MEMINITPTR: { 
-          char *address = nullptr;
+      }
+      case SCMD_MEMINITPTR:
+      { 
+          char *address;
 
-          if (reg1.Type == kScValStaticArray && reg1.StcArr->GetDynamicManager())
+          switch (reg1.Type)
           {
+          case kScValStaticArray:
+              CC_ERROR_IF_RETCODE(!reg1.StcArr->GetDynamicManager(), "internal error: SCMD_MEMINITPTR argument is not a dynamic object");
               address = (char*)reg1.StcArr->GetElementPtr(reg1.Ptr, reg1.IValue);
-          }
-          else if (reg1.Type == kScValDynamicObject ||
-              reg1.Type == kScValPluginObject)
-          {
+              break;
+          case kScValDynamicObject:
+          case kScValPluginObject:
               address = reg1.Ptr;
-          }
-          else if (reg1.Type == kScValPluginArg)
-          {// TODO: plugin API is currently strictly 32-bit, so this may break on 64-bit systems
+              break;
+          case kScValPluginArg:
+              // FIXME: plugin API is currently strictly 32-bit, so this may break on 64-bit systems
               address = Int32ToPtr<char>(reg1.IValue);
+              break;
+          default:
+              // There's one possible case when the reg1 is 0, which means writing nullptr
+              CC_ERROR_IF_RETCODE(!reg1.IsNull(), "internal error: SCMD_MEMINITPTR argument is not a dynamic object");
+              address = nullptr;
+              break;
           }
-          // There's one possible case when the reg1 is 0, which means writing nullptr
-          else if (!reg1.IsNull())
-          {
-              cc_error("internal error: SCMD_MEMINITPTR argument is not dynamic object");
-              return -1;
-          }
+
           // like memwriteptr, but doesn't attempt to free the old one
           int32_t newHandle = ccGetObjectHandleFromAddress(address);
           if (newHandle == -1)
@@ -1979,8 +1988,8 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetFw(int32_t fw_offset)
         stack_entry++;
         total_off += stack_entry->Size;
     }
-    CC_ERROR_IF_RET(total_off < fw_offset, "accessing address beyond stack's tail", RuntimeScriptValue);
-    CC_ERROR_IF_RET(total_off > fw_offset, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue);
+    CC_ERROR_IF_RETVAL(total_off < fw_offset, "accessing address beyond stack's tail", RuntimeScriptValue);
+    CC_ERROR_IF_RETVAL(total_off > fw_offset, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue);
     RuntimeScriptValue stack_ptr;
     stack_ptr.SetStackPtr(stack_entry);
     return stack_ptr;
@@ -1995,12 +2004,12 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(int32_t rw_offset)
         stack_entry--;
         total_off += stack_entry->Size;
     }
-    CC_ERROR_IF_RET(total_off < rw_offset, "accessing address before stack's head", RuntimeScriptValue);
+    CC_ERROR_IF_RETVAL(total_off < rw_offset, "accessing address before stack's head", RuntimeScriptValue);
     RuntimeScriptValue stack_ptr;
     stack_ptr.SetStackPtr(stack_entry);
     stack_ptr.IValue += total_off - rw_offset; // possibly offset to the mid-array
     // Could be accessing array element, so state error only if stack entry does not refer to data array
-    CC_ERROR_IF_RET((total_off > rw_offset) && (stack_entry->Type != kScValData), "stack offset backward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue)
+    CC_ERROR_IF_RETVAL((total_off > rw_offset) && (stack_entry->Type != kScValData), "stack offset backward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue)
     return stack_ptr;
 }
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -648,13 +648,15 @@ int ccInstance::Run(int32_t curpc)
           {
             // Only allocate new data if current stack entry is invalid;
             // in some cases this may be advancing over value that was written by MEMWRITE*
-            // FIXME: this is weird, do this in a uniform way (always same operation),
+            // FIXME: this is bad, but seemed to be the way to separate PushValue and PushData
+            // find if it's possible to do this in a uniform way (always same operation),
             // and don't rely on stack entries being valid/invalid beyond the stack ptr.
             ASSERT_STACK_SPACE_AVAILABLE(1, arg2.IValue);
             if (reg1.RValue->IsValid())
             {
               // TODO: perhaps should add a flag here to ensure this happens only after MEMWRITE-ing to stack
               registers[SREG_SP].RValue++;
+              stackdata_ptr += sizeof(int32_t); // formality, to keep data ptr consistent
             }
             else
             {
@@ -1313,7 +1315,6 @@ int ccInstance::Run(int32_t curpc)
               // NOTE: according to compiler's logic, this is always followed
               // by SCMD_ADD, and that is where the data is "allocated", here we
               // just clean the place.
-              // CHECKME -- since we zero memory in PushDataToStack anyway, this is not needed at all?
               memset(stackdata_ptr, 0, arg1.IValue);
           }
           else
@@ -1918,14 +1919,15 @@ void ccInstance::PushValueToStack(const RuntimeScriptValue &rval)
 {
     // Write value to the stack tail and advance stack ptr
     registers[SREG_SP].WriteValue(rval);
+    stackdata_ptr += sizeof(int32_t); // formality, to keep data ptr consistent
     registers[SREG_SP].RValue++;
 }
 
 void ccInstance::PushDataToStack(int32_t num_bytes)
 {
     CC_ERROR_IF(registers[SREG_SP].RValue->IsValid(), "internal error: valid data beyond stack ptr");
-    // Zero memory, assign pointer to data block to the stack tail, advance both stack ptr and stack data ptr
-    memset(stackdata_ptr, 0, num_bytes);
+    // Assign pointer to data block to the stack tail, advance both stack ptr and stack data ptr
+    // NOTE: memory is zeroed by SCMD_ZEROMEMORY
     registers[SREG_SP].RValue->SetData(stackdata_ptr, num_bytes);
     stackdata_ptr += num_bytes;
     registers[SREG_SP].RValue++;
@@ -1935,12 +1937,9 @@ RuntimeScriptValue ccInstance::PopValueFromStack()
 {
     // rewind stack ptr to the last valid value, decrement stack data ptr if needed and invalidate the stack tail
     registers[SREG_SP].RValue--;
-    RuntimeScriptValue rval = *registers[SREG_SP].RValue;
-    if (rval.Type == kScValData)
-    { // FIXME: refactor and add/sub stackdata_ptr always, avoid condition
-        stackdata_ptr -= rval.Size;
-    }
-    registers[SREG_SP].RValue->Invalidate(); // FIXME: don't do this, but this is used in some conditions
+    RuntimeScriptValue rval = *registers[SREG_SP].RValue; // save before invalidating
+    stackdata_ptr -= sizeof(int32_t); // formality, to keep data ptr consistent
+    registers[SREG_SP].RValue->Invalidate(); // FIXME: bad, this is used to separate PushValue and PushData
     return rval;
 }
 
@@ -1950,11 +1949,8 @@ void ccInstance::PopValuesFromStack(int32_t num_entries = 1)
     {
         // rewind stack ptr to the last valid value, decrement stack data ptr if needed and invalidate the stack tail
         registers[SREG_SP].RValue--;
-        if (registers[SREG_SP].RValue->Type == kScValData)
-        { // FIXME: refactor and add/sub stackdata_ptr always, avoid condition
-            stackdata_ptr -= registers[SREG_SP].RValue->Size;
-        }
-        registers[SREG_SP].RValue->Invalidate(); // FIXME: don't do this, but this is used in some conditions
+        stackdata_ptr -= sizeof(int32_t); // formality, to keep data ptr consistent
+        registers[SREG_SP].RValue->Invalidate(); // FIXME: bad, this is used to separate PushValue and PushData
     }
 }
 
@@ -1965,13 +1961,10 @@ void ccInstance::PopDataFromStack(int32_t num_bytes)
     {
         // rewind stack ptr to the last valid value, decrement stack data ptr if needed and invalidate the stack tail
         registers[SREG_SP].RValue--;
+        stackdata_ptr -= registers[SREG_SP].RValue->Size;
         // remember popped bytes count
         total_pop += registers[SREG_SP].RValue->Size;
-        if (registers[SREG_SP].RValue->Type == kScValData)
-        { // FIXME: refactor and add/sub stackdata_ptr always, avoid condition
-            stackdata_ptr -= registers[SREG_SP].RValue->Size;
-        }
-        registers[SREG_SP].RValue->Invalidate(); // FIXME: don't do this, but this is used in some conditions
+        registers[SREG_SP].RValue->Invalidate(); // FIXME: bad, this is used to separate PushValue and PushData
     }
     CC_ERROR_IF(total_pop < num_bytes, "stack underflow");
     CC_ERROR_IF(total_pop > num_bytes, "stack pointer points inside local variable after pop, stack corrupted?");
@@ -2005,12 +1998,8 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(int32_t rw_offset)
     CC_ERROR_IF_RET(total_off < rw_offset, "accessing address before stack's head", RuntimeScriptValue);
     RuntimeScriptValue stack_ptr;
     stack_ptr.SetStackPtr(stack_entry);
+    stack_ptr.IValue += total_off - rw_offset; // possibly offset to the mid-array
     // Could be accessing array element, so state error only if stack entry does not refer to data array
-    // FIXME: refactor and add/sub stackdata_ptr always, avoid condition
-    if (stack_entry->Type == kScValData)
-    {
-        stack_ptr.IValue += total_off - rw_offset;
-    }
     CC_ERROR_IF_RET((total_off > rw_offset) && (stack_entry->Type != kScValData), "stack offset backward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue)
     return stack_ptr;
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -307,24 +307,24 @@ void ccInstance::AbortAndDestroy()
 // returns failure on error
 #if (DEBUG_CC_EXEC)
 
-#define CC_ERROR_IF(COND, ERROR) \
+#define CC_ERROR_IF(COND, ERROR, ...) \
     if (COND) \
     { \
-        cc_error(ERROR); \
+        cc_error(ERROR, ##__VA_ARGS__); \
         return; \
     }
 
-#define CC_ERROR_IF_RETCODE(COND, ERROR) \
+#define CC_ERROR_IF_RETCODE(COND, ERROR, ...) \
     if (COND) \
     { \
-        cc_error(ERROR); \
+        cc_error(ERROR, ##__VA_ARGS__); \
         return -1; \
     }
 
-#define CC_ERROR_IF_RETVAL(COND, ERROR, T) \
+#define CC_ERROR_IF_RETVAL(COND, T, ERROR, ...) \
     if (COND) \
     { \
-        cc_error(ERROR); \
+        cc_error(ERROR, ##__VA_ARGS__); \
         return T(); \
     }
 
@@ -336,9 +336,9 @@ void ccInstance::AbortAndDestroy()
 
 #else
 
-#define CC_ERROR_IF(COND, ERROR)
-#define CC_ERROR_IF_RETCODE(COND, ERROR)
-#define CC_ERROR_IF_RETVAL(COND, ERROR, T)
+#define CC_ERROR_IF(COND, ERROR, ...)
+#define CC_ERROR_IF_RETCODE(COND, ERROR, ...)
+#define CC_ERROR_IF_RETVAL(COND, T, ERROR, ...)
 #define ASSERT_CC_ERROR()
 
 #endif // DEBUG_CC_EXEC
@@ -529,7 +529,7 @@ int ccInstance::Run(int32_t curpc)
     ScriptOperation codeOp;
     FunctionCallStack func_callstack;
 #if DEBUG_CC_EXEC
-    const bool dump_opcodes = ccGetOption(SCOPT_DEBUGRUN);
+    const bool dump_opcodes = ccGetOption(SCOPT_DEBUGRUN) != 0;
 #endif
 
     const auto timeout = std::chrono::milliseconds(_timeoutCheckMs);
@@ -551,18 +551,13 @@ int ccInstance::Run(int32_t curpc)
         codeOp.Instruction.InstanceId	= (codeOp.Instruction.Code >> INSTANCE_ID_SHIFT) & INSTANCE_ID_MASK;
         codeOp.Instruction.Code		   &= INSTANCE_ID_REMOVEMASK; // now this is pure instruction code
 
-        if (codeOp.Instruction.Code < 0 || codeOp.Instruction.Code >= CC_NUM_SCCMDS)
-        {
-            cc_error("invalid instruction %d found in code stream", codeOp.Instruction.Code);
-            return -1;
-        }
+        CC_ERROR_IF_RETCODE((codeOp.Instruction.Code < 0 || codeOp.Instruction.Code >= CC_NUM_SCCMDS),
+            "invalid instruction %d found in code stream", codeOp.Instruction.Code);
 
-        codeOp.ArgCount = sccmd_info[codeOp.Instruction.Code].ArgCount;
-        if (pc + codeOp.ArgCount >= codeInst->codesize)
-        {
-            cc_error("unexpected end of code data (%d; %d)", pc + codeOp.ArgCount, codeInst->codesize);
-            return -1;
-        }
+        codeOp.ArgCount = sccmd_info[codeOp.Instruction.Code].ArgCount & 0x3;
+
+        CC_ERROR_IF_RETCODE(pc + codeOp.ArgCount >= codeInst->codesize,
+            "unexpected end of code data (%d; %d)", pc + codeOp.ArgCount, codeInst->codesize);
 
         int pc_at = pc + 1;
         for (int i = 0; i < codeOp.ArgCount; ++i, ++pc_at)
@@ -2216,8 +2211,8 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetFw(int32_t fw_offset)
         stack_entry++;
         total_off += stack_entry->Size;
     }
-    CC_ERROR_IF_RETVAL(total_off < fw_offset, "accessing address beyond stack's tail", RuntimeScriptValue);
-    CC_ERROR_IF_RETVAL(total_off > fw_offset, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue);
+    CC_ERROR_IF_RETVAL(total_off < fw_offset, RuntimeScriptValue, "accessing address beyond stack's tail");
+    CC_ERROR_IF_RETVAL(total_off > fw_offset, RuntimeScriptValue, "stack offset forward: trying to access stack data inside stack entry, stack corrupted?");
     RuntimeScriptValue stack_ptr;
     stack_ptr.SetStackPtr(stack_entry);
     return stack_ptr;
@@ -2232,12 +2227,13 @@ RuntimeScriptValue ccInstance::GetStackPtrOffsetRw(int32_t rw_offset)
         stack_entry--;
         total_off += stack_entry->Size;
     }
-    CC_ERROR_IF_RETVAL(total_off < rw_offset, "accessing address before stack's head", RuntimeScriptValue);
+    CC_ERROR_IF_RETVAL(total_off < rw_offset, RuntimeScriptValue, "accessing address before stack's head");
     RuntimeScriptValue stack_ptr;
     stack_ptr.SetStackPtr(stack_entry);
     stack_ptr.IValue += total_off - rw_offset; // possibly offset to the mid-array
     // Could be accessing array element, so state error only if stack entry does not refer to data array
-    CC_ERROR_IF_RETVAL((total_off > rw_offset) && (stack_entry->Type != kScValData), "stack offset backward: trying to access stack data inside stack entry, stack corrupted?", RuntimeScriptValue)
+    CC_ERROR_IF_RETVAL((total_off > rw_offset) && (stack_entry->Type != kScValData), RuntimeScriptValue,
+        "stack offset backward: trying to access stack data inside stack entry, stack corrupted?")
     return stack_ptr;
 }
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -62,19 +62,18 @@ enum ScriptOpArgIsReg
 struct ScriptCommandInfo
 {
     ScriptCommandInfo(int32_t code, const char *cmdname, int arg_count, ScriptOpArgIsReg arg_is_reg)
-    {
-        Code        = code;
-        CmdName     = cmdname;
-        ArgCount    = arg_count;
-        ArgIsReg[0] = (arg_is_reg & kScOpArg1IsReg) != 0;
-        ArgIsReg[1] = (arg_is_reg & kScOpArg2IsReg) != 0;
-        ArgIsReg[2] = (arg_is_reg & kScOpArg3IsReg) != 0;
-    }
+        : Code(code), CmdName(cmdname), ArgCount(arg_count)
+        , ArgIsReg {
+            (arg_is_reg & kScOpArg1IsReg) != 0, 
+            (arg_is_reg & kScOpArg2IsReg) != 0, 
+            (arg_is_reg & kScOpArg3IsReg) != 0
+        }
+    {}
 
-    int32_t             Code;
-    const char          *CmdName;
-    int                 ArgCount;
-    bool                ArgIsReg[3];
+    const int32_t   Code = 0;
+    const char     *CmdName = nullptr;
+    const int       ArgCount = 0;
+    const bool      ArgIsReg[3]{};
 };
 
 const ScriptCommandInfo sccmd_info[CC_NUM_SCCMDS] =

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -328,7 +328,7 @@ int ccInstance::CallScriptFunction(const char *funcname, int32_t numargs, const 
         return -1; // TODO: correct error value
     }
 
-    if ((numargs >= 20) || (numargs < 0)) {
+    if ((numargs >= MAX_FUNCTION_PARAMS) || (numargs < 0)) {
         cc_error("too many arguments to function");
         return -3;
     }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -1013,7 +1013,7 @@ int ccInstance::Run(int32_t curpc)
                   cc_error("!Script appears to be hung (a while loop ran %d times). The problem may be in a calling function; check the call stack.", loopIterations);
                   return -1;
               }
-              else if ((loopIterations % 1000) == 0 &&
+              else if ((loopIterations & 0x3FF) == 0 && // test each 1024 loops (arbitrary)
                   (std::chrono::duration_cast<std::chrono::milliseconds>(
                       AGS_FastClock::now() - _lastAliveTs) > timeout))
               { // minimal timeout occured

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -472,9 +472,11 @@ int ccInstance::Run(int32_t curpc)
     thisbase[0] = 0;
     funcstart[0] = pc;
     ccInstance *codeInst = runningInst;
-    int write_debug_dump = ccGetOption(SCOPT_DEBUGRUN);
     ScriptOperation codeOp;
     FunctionCallStack func_callstack;
+#if DEBUG_CC_EXEC
+    const bool dump_opcodes = ccGetOption(SCOPT_DEBUGRUN);
+#endif
 
     const auto timeout = std::chrono::milliseconds(_timeoutCheckMs);
     const auto timeout_abort = std::chrono::milliseconds(_timeoutAbortMs);
@@ -579,10 +581,12 @@ int ccInstance::Run(int32_t curpc)
         const char *direct_ptr1;
         const char *direct_ptr2;
 
-        if (write_debug_dump)
+#if (DEBUG_CC_EXEC)
+        if (dump_opcodes)
         {
             DumpInstruction(codeOp);
         }
+#endif
 
         switch (codeOp.Instruction.Code)
         {

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -33,9 +33,11 @@ using namespace AGS;
 #define INSTF_ABORTED       2
 #define INSTF_FREE          4
 #define INSTF_RUNNING       8   // set by main code to confirm script isn't stuck
-#define CC_STACK_SIZE       250
-#define CC_STACK_DATA_SIZE  (1000 * sizeof(int32_t))
-#define MAX_CALL_STACK      100
+
+#define CC_STACK_SIZE       256
+#define CC_STACK_DATA_SIZE  (1024 * sizeof(int32_t))
+#define MAX_CALL_STACK      128
+#define MAX_FUNCTION_PARAMS 20
 
 // 256 because we use 8 bits to hold instance number
 #define MAX_LOADED_INSTANCES 256

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -48,7 +48,9 @@ using namespace AGS;
 
 // Script executor debugging flag:
 // enables mistake checks, but slows things down!
+#ifndef DEBUG_CC_EXEC
 #define DEBUG_CC_EXEC (AGS_PLATFORM_DEBUG)
+#endif
 
 
 struct ScriptInstruction

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -219,9 +219,6 @@ private:
     // helper function to pop & dump several values
     void    PopValuesFromStack(int32_t num_entries);
     void    PopDataFromStack(int32_t num_bytes);
-    // Return stack ptr at given offset from stack head;
-    // Offset is in data bytes; program stack ptr is __not__ changed
-    RuntimeScriptValue GetStackPtrOffsetFw(int32_t fw_offset);
     // Return stack ptr at given offset from stack tail;
     // Offset is in data bytes; program stack ptr is __not__ changed
     RuntimeScriptValue GetStackPtrOffsetRw(int32_t rw_offset);

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -53,26 +53,28 @@ using namespace AGS;
 
 struct ScriptInstruction
 {
-    ScriptInstruction()
-    {
-        Code		= 0;
-        InstanceId	= 0;
-    }
+    ScriptInstruction() = default;
+    ScriptInstruction(int code, int instid) : Code(code), InstanceId(instid) {}
 
-    int32_t	Code;
-    int32_t	InstanceId;
+    int32_t	Code = 0;
+    int32_t	InstanceId = 0;
 };
 
 struct ScriptOperation
 {
-	ScriptOperation()
-	{
-		ArgCount = 0;
-	}
-
 	ScriptInstruction   Instruction;
 	RuntimeScriptValue	Args[MAX_SCMD_ARGS];
-	int				    ArgCount;
+	int				    ArgCount = 0;
+
+    // Helper functions for clarity of intent:
+    // returns argN, 1-based
+    inline const RuntimeScriptValue &Arg1() const { return Args[0]; }
+    inline const RuntimeScriptValue &Arg2() const { return Args[1]; }
+    inline const RuntimeScriptValue &Arg3() const { return Args[2]; }
+    // returns argN as a integer literal
+    inline int Arg1i() const { return Args[0].IValue; }
+    inline int Arg2i() const { return Args[1].IValue; }
+    inline int Arg3i() const { return Args[2].IValue; }
 };
 
 struct ScriptVariable

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -193,12 +193,9 @@ private:
     bool    AddGlobalVar(const ScriptVariable &glvar);
     ScriptVariable *FindGlobalVar(int32_t var_addr);
     bool    CreateRuntimeCodeFixups(const ccScript *scri);
-	//bool    ReadOperation(ScriptOperation &op, int32_t at_pc);
 
     // Begin executing script starting from the given bytecode index
     int     Run(int32_t curpc);
-    // Runtime fixups
-    //bool    FixupArgument(intptr_t code_value, char fixup_type, RuntimeScriptValue &argument);
 
     // Stack processing
     // Push writes new value and increments stack ptr;

--- a/Engine/script/cc_instance.h
+++ b/Engine/script/cc_instance.h
@@ -46,6 +46,11 @@ using namespace AGS;
 #define INSTANCE_ID_MASK  0x00000000000000ffLL
 #define INSTANCE_ID_REMOVEMASK 0x0000000000ffffffLL
 
+// Script executor debugging flag:
+// enables mistake checks, but slows things down!
+#define DEBUG_CC_EXEC (AGS_PLATFORM_DEBUG)
+
+
 struct ScriptInstruction
 {
     ScriptInstruction()

--- a/Engine/script/runtimescriptvalue.cpp
+++ b/Engine/script/runtimescriptvalue.cpp
@@ -216,62 +216,6 @@ bool RuntimeScriptValue::WriteInt32(int32_t val)
     return true;
 }
 
-// Notice, that there are only two valid cases when a pointer may be written:
-// when the destination is a stack entry or global variable of free type
-// (not kScValData type).
-// In any other case, only the numeric value (integer/float) will be written.
-bool RuntimeScriptValue::WriteValue(const RuntimeScriptValue &rval)
-{
-    if (this->Type == kScValStackPtr)
-    {
-        if (RValue->Type == kScValData)
-        {
-            *(int32_t*)(RValue->GetPtrWithOffset() + this->IValue) = rval.IValue;
-        }
-        else
-        {
-            // NOTE: we cannot just WriteValue here because when an integer
-            // is pushed to the stack, script assumes that it is always 4
-            // bytes and uses that size when calculating offsets to local
-            // variables;
-            // Therefore if pushed value is of integer type, we should rather
-            // act as WriteInt32 (for int8, int16 and int32).
-            if (rval.Type == kScValInteger)
-            {
-                RValue->SetInt32(rval.IValue);
-            }
-            else
-            {
-                *RValue = rval;
-            }
-        }
-    }
-    else if (this->Type == kScValGlobalVar)
-    {
-        if (RValue->Type == kScValData)
-        {
-            Memory::WriteInt32LE(RValue->GetPtrWithOffset() + this->IValue, rval.IValue);
-        }
-        else
-        {
-            *RValue = rval;
-        }
-    }
-    else if (this->Type == kScValStaticObject || this->Type == kScValStaticArray)
-    {
-        this->StcMgr->WriteInt32(this->Ptr, this->IValue, rval.IValue);
-    }
-    else if (this->Type == kScValDynamicObject)
-    {
-        this->DynMgr->WriteInt32(this->Ptr, this->IValue, rval.IValue);
-    }
-    else
-    {
-        *((int32_t*)this->GetPtrWithOffset()) = rval.IValue;
-    }
-    return true;
-}
-
 RuntimeScriptValue &RuntimeScriptValue::DirectPtr()
 {
     if (Type == kScValGlobalVar || Type == kScValStackPtr)

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -126,11 +126,7 @@ public:
     
     inline RuntimeScriptValue &Invalidate()
     {
-        Type    = kScValUndefined;
-        IValue   = 0;
-        Ptr     = nullptr;
-        MgrPtr  = nullptr;
-        Size    = 0;
+        *this = RuntimeScriptValue();
         return *this;
     }
     inline RuntimeScriptValue &SetUInt8(uint8_t val)

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -255,6 +255,15 @@ public:
         Size    = 4;
         return *this;
     }
+    inline RuntimeScriptValue &SetDynamicObject(ScriptValueType type, void *object, ICCDynamicObject *manager)
+    {
+        Type    = type;
+        IValue  = 0;
+        Ptr     = (char*)object;
+        DynMgr  = manager;
+        Size    = 4;
+        return *this;
+    }
     inline RuntimeScriptValue &SetStaticFunction(ScriptAPIFunction *pfn)
     {
         Type    = kScValStaticFunction;

--- a/Engine/script/runtimescriptvalue.h
+++ b/Engine/script/runtimescriptvalue.h
@@ -320,49 +320,105 @@ public:
     // store value differently, otherwise it won't work for 64-bit build.
     inline RuntimeScriptValue ReadValue() const
     {
-        RuntimeScriptValue rval;
-        switch(this->Type) {
+        switch(this->Type)
+        {
         case kScValStackPtr:
         {
-            if (RValue->Type == kScValData)
+            // FIXME: join the kScValStackPtr with kScValData using some flag?
+            switch (RValue->Type)
             {
-                rval.SetInt32(*(int32_t*)(RValue->GetPtrWithOffset() + this->IValue));
-            }
-            else
-            {
-                rval = *RValue;
+            case kScValData:
+                // read from the stack memory buffer
+                return RuntimeScriptValue().SetInt32(*(int32_t*)(RValue->GetPtrWithOffset() + this->IValue));
+            default:
+                // return the stack entry itself
+                return *RValue;
             }
         }
-        break;
         case kScValGlobalVar:
         {
-            if (RValue->Type == kScValData)
+            // FIXME: join the kScValGlobalVar with kScValData using some flag?
+            switch (RValue->Type)
             {
-                rval.SetInt32(AGS::Common::Memory::ReadInt32LE(RValue->GetPtrWithOffset() + this->IValue));
-            }
-            else
-            {
-                rval = *RValue;
+            case kScValData:
+                // read from the global memory buffer
+                return RuntimeScriptValue().SetInt32(AGS::Common::Memory::ReadInt32LE(RValue->GetPtrWithOffset() + this->IValue));
+            default:
+                // return the gvar entry itself
+                return *RValue;
             }
         }
-        break;
-        case kScValStaticObject: case kScValStaticArray:
+        case kScValStaticObject:
+        case kScValStaticArray:
+            return RuntimeScriptValue().SetInt32(this->StcMgr->ReadInt32(this->Ptr, this->IValue));
+        case kScValDynamicObject:
+            return RuntimeScriptValue().SetInt32(this->DynMgr->ReadInt32(this->Ptr, this->IValue));
+        default:
+            return RuntimeScriptValue().SetInt32(*(int32_t*)this->GetPtrWithOffset());
+        }
+    }
+
+    // Notice, that there are only two valid cases when a pointer may be written:
+    // when the destination is a stack entry or global variable of free type
+    // (not kScValData type).
+    // In any other case, only the numeric value (integer/float) will be written.
+    inline void WriteValue(const RuntimeScriptValue &rval)
+    {
+        switch (this->Type)
         {
-            rval.SetInt32(this->StcMgr->ReadInt32(this->Ptr, this->IValue));
+        case kScValStackPtr:
+        {
+            // FIXME: join the kScValStackPtr with kScValData using some flag?
+            switch (RValue->Type)
+            {
+            case kScValData:
+                // write into the stack memory buffer
+                *(int32_t*)(RValue->GetPtrWithOffset() + this->IValue) = rval.IValue;
+                break;
+            default:
+                // write into the stack entry
+                *RValue = rval;
+                // On stack we assume each item has at least 4 bytes (with exception
+                // of arrays - kScValData). This is why we fixup the size in case
+                // the assigned value is less (char, int16).
+                RValue->Size = 4;
+                break;
+            }
+            break;
         }
-        break;
+        case kScValGlobalVar:
+        {
+            // FIXME: join the kScValGlobalVar with kScValData using some flag?
+            switch (RValue->Type)
+            {
+            case kScValData:
+                // write into the global memory buffer
+                AGS::Common::Memory::WriteInt32LE(RValue->GetPtrWithOffset() + this->IValue, rval.IValue);
+                break;
+            default:
+                // write into the gvar entry
+                *RValue = rval;
+                break;
+            }
+            break;
+        }
+        case kScValStaticObject:
+        case kScValStaticArray:
+        {
+            this->StcMgr->WriteInt32(this->Ptr, this->IValue, rval.IValue);
+            break;
+        }
         case kScValDynamicObject:
         {
-            rval.SetInt32(this->DynMgr->ReadInt32(this->Ptr, this->IValue));
+            this->DynMgr->WriteInt32(this->Ptr, this->IValue, rval.IValue);
+            break;
         }
-        break;
         default:
         {
-            // 64 bit: Memory reads are still 32 bit
-            rval.SetInt32(*(int32_t*)this->GetPtrWithOffset());
+            *((int32_t*)this->GetPtrWithOffset()) = rval.IValue;
+            break;
         }
         }
-        return rval;
     }
 
 
@@ -375,7 +431,6 @@ public:
     bool        WriteByte(uint8_t val);
     bool        WriteInt16(int16_t val);
     bool        WriteInt32(int32_t val);
-    bool        WriteValue(const RuntimeScriptValue &rval);
 
     // Convert to most simple pointer type by resolving RValue ptrs and applying offsets;
     // non pointer types are left unmodified


### PR DESCRIPTION
Resolves #843 and #1987.

Contains a number of adjustments to the script interpreter function (ccInstance::Run), increases potential game fps and reduces CPU load for "script heavy" games.

Adds `DEBUG_CC_EXEC` compilation flag, and hides most error checks within the opcode implementations under this flag.
DEBUG_CC_EXEC is enabled if AGS_PLATFORM_DEBUG is enabled, but we may also make it completely separate later if wanted.

The changes were tested against two games with complex scripts in the "infinite fps" mode (where engine runs game loops as fast as it can):
1. First person space sim prototype: https://github.com/ivan-mogilko/ags-wcproto
2. Car racing arcade game: https://github.com/ivan-mogilko/ags-lastfurious

First has generally very slow script; showed a fps rise from ~64-65 to ~75 in idle state.
Second - from ~145-155 fps to 180-190 fps, when idling at the starting grid while 5 ai cars were racing the loop.
which gives an improvement by something like 15-20% depending on a case.
**UPDATE:** after few more commits made since:
First game: rise from ~65 to 80 fps
Second game: rise from 150 to 200 fps
**UPDATE:** after another [sudden idea](https://github.com/adventuregamestudio/ags/pull/1990/commits/719f67e831f7de3da831a957da0cc69a7a4a5026):
First game: rise from ~65 to 84 fps
Second game: rise from 150 to 210 fps
So, this is improvement by ~30% now, or more, depending on a game.


These numbers are of course subjective to an individual system (and game), but probably may give an idea of improvement.