### PR TITLE
Editor: turn dpi aware on

### DIFF
--- a/Editor/AGS.Editor/app.config
+++ b/Editor/AGS.Editor/app.config
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+  </appSettings>
 <startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Editor/AGS.Editor/app.manifest
+++ b/Editor/AGS.Editor/app.manifest
@@ -49,13 +49,13 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>
-  -->
+
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--


### PR DESCRIPTION
Turns dpi-aware on, this makes ags not blurred in Windows 10 by default. I couldn't find any side effect, so I ask people to test this. The text becomes sharp and it's much nicer to code like this.

With dpi-aware on
![image](https://user-images.githubusercontent.com/2244442/235564557-a36158b1-43de-44b1-9fb0-4b8dde628f91.png)
![image](https://user-images.githubusercontent.com/2244442/235564606-c9fea910-99ef-4621-8840-3adaeb865144.png)

Without dpi-aware on (commented)
![image](https://user-images.githubusercontent.com/2244442/235564671-ee57a643-9d97-4b32-8122-35add8b52b5a.png)
![image](https://user-images.githubusercontent.com/2244442/235564691-a4910781-bb6b-49a5-8be9-b82a8e1150fe.png)
