### PR TITLE
A cleaner method of script API registration

### DIFF
--- a/Common/util/memory_compat.h
+++ b/Common/util/memory_compat.h
@@ -11,6 +11,11 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+//
+// For compatibility with different compilers that may or not support
+// particular new C++ and STL functions.
+//
+//=============================================================================
 #ifndef __AGS_CN_UTIL__MEMORY_COMPAT_H
 #define __AGS_CN_UTIL__MEMORY_COMPAT_H
 #include <memory>
@@ -25,6 +30,24 @@ namespace std
         return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 } // std
+#endif
+
+// C++17 features
+#if __cplusplus < 201703L && !((defined(_MSC_VER) && _MSC_VER >= 1900))
+namespace std
+{
+    template <class C> 
+    constexpr auto size(const C& c) -> decltype(c.size())
+    {
+        return c.size();
+    }
+
+    template <class T, std::size_t N>
+    constexpr std::size_t size(const T (&array)[N]) noexcept
+    {
+        return N;
+    }
+}
 #endif
 
 #endif // __AGS_CN_UTIL__MEMORY_COMPAT_H

--- a/Engine/ac/audiochannel.cpp
+++ b/Engine/ac/audiochannel.cpp
@@ -352,41 +352,29 @@ RuntimeScriptValue Sc_AudioChannel_GetIsPaused(void *self, const RuntimeScriptVa
 
 void RegisterAudioChannelAPI()
 {
-    ccAddExternalObjectFunction("AudioChannel::Pause^0",            Sc_AudioChannel_Pause);
-    ccAddExternalObjectFunction("AudioChannel::Resume^0",           Sc_AudioChannel_Resume);
-    ccAddExternalObjectFunction("AudioChannel::Seek^1",             Sc_AudioChannel_Seek);
-    ccAddExternalObjectFunction("AudioChannel::SeekMs^1",           Sc_AudioChannel_SeekMs);
-    ccAddExternalObjectFunction("AudioChannel::SetRoomLocation^2",  Sc_AudioChannel_SetRoomLocation);
-    ccAddExternalObjectFunction("AudioChannel::Stop^0",             Sc_AudioChannel_Stop);
-    ccAddExternalObjectFunction("AudioChannel::get_ID",             Sc_AudioChannel_GetID);
-    ccAddExternalObjectFunction("AudioChannel::get_IsPaused",       Sc_AudioChannel_GetIsPaused);
-    ccAddExternalObjectFunction("AudioChannel::get_IsPlaying",      Sc_AudioChannel_GetIsPlaying);
-    ccAddExternalObjectFunction("AudioChannel::get_LengthMs",       Sc_AudioChannel_GetLengthMs);
-    ccAddExternalObjectFunction("AudioChannel::get_Panning",        Sc_AudioChannel_GetPanning);
-    ccAddExternalObjectFunction("AudioChannel::set_Panning",        Sc_AudioChannel_SetPanning);
-    ccAddExternalObjectFunction("AudioChannel::get_PlayingClip",    Sc_AudioChannel_GetPlayingClip);
-    ccAddExternalObjectFunction("AudioChannel::get_Position",       Sc_AudioChannel_GetPosition);
-    ccAddExternalObjectFunction("AudioChannel::get_PositionMs",     Sc_AudioChannel_GetPositionMs);
-    ccAddExternalObjectFunction("AudioChannel::get_Volume",         Sc_AudioChannel_GetVolume);
-    ccAddExternalObjectFunction("AudioChannel::set_Volume",         Sc_AudioChannel_SetVolume);
-    ccAddExternalObjectFunction("AudioChannel::get_Speed",          Sc_AudioChannel_GetSpeed);
-    ccAddExternalObjectFunction("AudioChannel::set_Speed",          Sc_AudioChannel_SetSpeed);
-    // For compatibility with  Ahmet Kamil's (aka Gord10) custom engine
-    ccAddExternalObjectFunction("AudioChannel::SetSpeed^1",         Sc_AudioChannel_SetSpeed);
+    ScFnRegister audiochan_api[] = {
+        { "AudioChannel::Pause^0",            API_FN_PAIR(AudioChannel_Pause) },
+        { "AudioChannel::Resume^0",           API_FN_PAIR(AudioChannel_Resume) },
+        { "AudioChannel::Seek^1",             API_FN_PAIR(AudioChannel_Seek) },
+        { "AudioChannel::SeekMs^1",           API_FN_PAIR(AudioChannel_SeekMs) },
+        { "AudioChannel::SetRoomLocation^2",  API_FN_PAIR(AudioChannel_SetRoomLocation) },
+        { "AudioChannel::Stop^0",             API_FN_PAIR(AudioChannel_Stop) },
+        { "AudioChannel::get_ID",             API_FN_PAIR(AudioChannel_GetID) },
+        { "AudioChannel::get_IsPaused",       API_FN_PAIR(AudioChannel_GetIsPaused) },
+        { "AudioChannel::get_IsPlaying",      API_FN_PAIR(AudioChannel_GetIsPlaying) },
+        { "AudioChannel::get_LengthMs",       API_FN_PAIR(AudioChannel_GetLengthMs) },
+        { "AudioChannel::get_Panning",        API_FN_PAIR(AudioChannel_GetPanning) },
+        { "AudioChannel::set_Panning",        API_FN_PAIR(AudioChannel_SetPanning) },
+        { "AudioChannel::get_PlayingClip",    API_FN_PAIR(AudioChannel_GetPlayingClip) },
+        { "AudioChannel::get_Position",       API_FN_PAIR(AudioChannel_GetPosition) },
+        { "AudioChannel::get_PositionMs",     API_FN_PAIR(AudioChannel_GetPositionMs) },
+        { "AudioChannel::get_Volume",         API_FN_PAIR(AudioChannel_GetVolume) },
+        { "AudioChannel::set_Volume",         API_FN_PAIR(AudioChannel_SetVolume) },
+        { "AudioChannel::get_Speed",          API_FN_PAIR(AudioChannel_GetSpeed) },
+        { "AudioChannel::set_Speed",          API_FN_PAIR(AudioChannel_SetSpeed) },
+        // For compatibility with  Ahmet Kamil's (aka Gord10) custom engine
+        { "AudioChannel::SetSpeed^1",         API_FN_PAIR(AudioChannel_SetSpeed) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("AudioChannel::Seek^1",             (void*)AudioChannel_Seek);
-    ccAddExternalFunctionForPlugin("AudioChannel::SetRoomLocation^2",  (void*)AudioChannel_SetRoomLocation);
-    ccAddExternalFunctionForPlugin("AudioChannel::Stop^0",             (void*)AudioChannel_Stop);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_ID",             (void*)AudioChannel_GetID);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_IsPlaying",      (void*)AudioChannel_GetIsPlaying);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_LengthMs",       (void*)AudioChannel_GetLengthMs);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_Panning",        (void*)AudioChannel_GetPanning);
-    ccAddExternalFunctionForPlugin("AudioChannel::set_Panning",        (void*)AudioChannel_SetPanning);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_PlayingClip",    (void*)AudioChannel_GetPlayingClip);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_Position",       (void*)AudioChannel_GetPosition);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_PositionMs",     (void*)AudioChannel_GetPositionMs);
-    ccAddExternalFunctionForPlugin("AudioChannel::get_Volume",         (void*)AudioChannel_GetVolume);
-    ccAddExternalFunctionForPlugin("AudioChannel::set_Volume",         (void*)AudioChannel_SetVolume);
+    ccAddExternalFunctions(audiochan_api);
 }

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -149,23 +149,17 @@ RuntimeScriptValue Sc_AudioClip_PlayOnChannel(void *self, const RuntimeScriptVal
 
 void RegisterAudioClipAPI()
 {
-    ccAddExternalObjectFunction("AudioClip::Play^2",            Sc_AudioClip_Play);
-    ccAddExternalObjectFunction("AudioClip::PlayFrom^3",        Sc_AudioClip_PlayFrom);
-    ccAddExternalObjectFunction("AudioClip::PlayQueued^2",      Sc_AudioClip_PlayQueued);
-    ccAddExternalObjectFunction("AudioClip::PlayOnChannel^3",   Sc_AudioClip_PlayOnChannel);
-    ccAddExternalObjectFunction("AudioClip::Stop^0",            Sc_AudioClip_Stop);
-    ccAddExternalObjectFunction("AudioClip::get_ID",            Sc_AudioClip_GetID);
-    ccAddExternalObjectFunction("AudioClip::get_FileType",      Sc_AudioClip_GetFileType);
-    ccAddExternalObjectFunction("AudioClip::get_IsAvailable",   Sc_AudioClip_GetIsAvailable);
-    ccAddExternalObjectFunction("AudioClip::get_Type",          Sc_AudioClip_GetType);
+    ScFnRegister audioclip_api[] = {
+        { "AudioClip::Play^2",            API_FN_PAIR(AudioClip_Play) },
+        { "AudioClip::PlayFrom^3",        API_FN_PAIR(AudioClip_PlayFrom) },
+        { "AudioClip::PlayQueued^2",      API_FN_PAIR(AudioClip_PlayQueued) },
+        { "AudioClip::PlayOnChannel^3",   API_FN_PAIR(AudioClip_PlayOnChannel) },
+        { "AudioClip::Stop^0",            API_FN_PAIR(AudioClip_Stop) },
+        { "AudioClip::get_ID",            API_FN_PAIR(AudioClip_GetID) },
+        { "AudioClip::get_FileType",      API_FN_PAIR(AudioClip_GetFileType) },
+        { "AudioClip::get_IsAvailable",   API_FN_PAIR(AudioClip_GetIsAvailable) },
+        { "AudioClip::get_Type",          API_FN_PAIR(AudioClip_GetType) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("AudioClip::Play^2",            (void*)AudioClip_Play);
-    ccAddExternalFunctionForPlugin("AudioClip::PlayFrom^3",        (void*)AudioClip_PlayFrom);
-    ccAddExternalFunctionForPlugin("AudioClip::PlayQueued^2",      (void*)AudioClip_PlayQueued);
-    ccAddExternalFunctionForPlugin("AudioClip::Stop^0",            (void*)AudioClip_Stop);
-    ccAddExternalFunctionForPlugin("AudioClip::get_FileType",      (void*)AudioClip_GetFileType);
-    ccAddExternalFunctionForPlugin("AudioClip::get_IsAvailable",   (void*)AudioClip_GetIsAvailable);
-    ccAddExternalFunctionForPlugin("AudioClip::get_Type",          (void*)AudioClip_GetType);
+    ccAddExternalFunctions(audioclip_api);
 }

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -353,7 +353,7 @@ RuntimeScriptValue Sc_Button_Animate7(void *self, const RuntimeScriptValue *para
     API_OBJCALL_VOID_PINT7(GUIButton, Button_Animate7);
 }
 
-RuntimeScriptValue Sc_Button_Animate8(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Button_Animate(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT8(GUIButton, Button_Animate);
 }
@@ -493,7 +493,7 @@ void RegisterButtonAPI()
 {
     ccAddExternalObjectFunction("Button::Animate^4",            Sc_Button_Animate4);
     ccAddExternalObjectFunction("Button::Animate^7",            Sc_Button_Animate7);
-    ccAddExternalObjectFunction("Button::Animate^8",            Sc_Button_Animate8);
+    ccAddExternalObjectFunction("Button::Animate^8",            Sc_Button_Animate);
     ccAddExternalObjectFunction("Button::Click^1",              Sc_Button_Click);
     ccAddExternalObjectFunction("Button::GetText^1",            Sc_Button_GetText);
     ccAddExternalObjectFunction("Button::SetText^1",            Sc_Button_SetText);

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -459,7 +459,7 @@ RuntimeScriptValue Sc_Button_Click(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_VOID_PINT(GUIButton, Button_Click);
 }
 
-RuntimeScriptValue Sc_Button_GetAnimating(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Button_IsAnimating(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_BOOL(GUIButton, Button_IsAnimating);
 }
@@ -474,69 +474,52 @@ RuntimeScriptValue Sc_Button_SetTextAlignment(void *self, const RuntimeScriptVal
     API_OBJCALL_VOID_PINT(GUIButton, Button_SetTextAlignment);
 }
 
-RuntimeScriptValue Sc_Button_GetFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Button_GetAnimFrame(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(GUIButton, Button_GetAnimFrame);
 }
 
-RuntimeScriptValue Sc_Button_GetLoop(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Button_GetAnimLoop(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(GUIButton, Button_GetAnimLoop);
 }
 
-RuntimeScriptValue Sc_Button_GetView(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Button_GetAnimView(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(GUIButton, Button_GetAnimView);
 }
 
 void RegisterButtonAPI()
 {
-    ccAddExternalObjectFunction("Button::Animate^4",            Sc_Button_Animate4);
-    ccAddExternalObjectFunction("Button::Animate^7",            Sc_Button_Animate7);
-    ccAddExternalObjectFunction("Button::Animate^8",            Sc_Button_Animate);
-    ccAddExternalObjectFunction("Button::Click^1",              Sc_Button_Click);
-    ccAddExternalObjectFunction("Button::GetText^1",            Sc_Button_GetText);
-    ccAddExternalObjectFunction("Button::SetText^1",            Sc_Button_SetText);
-    ccAddExternalObjectFunction("Button::get_TextAlignment",    Sc_Button_GetTextAlignment);
-    ccAddExternalObjectFunction("Button::set_TextAlignment",    Sc_Button_SetTextAlignment);
-    ccAddExternalObjectFunction("Button::get_Animating",        Sc_Button_GetAnimating);
-    ccAddExternalObjectFunction("Button::get_ClipImage",        Sc_Button_GetClipImage);
-    ccAddExternalObjectFunction("Button::set_ClipImage",        Sc_Button_SetClipImage);
-    ccAddExternalObjectFunction("Button::get_Font",             Sc_Button_GetFont);
-    ccAddExternalObjectFunction("Button::set_Font",             Sc_Button_SetFont);
-    ccAddExternalObjectFunction("Button::get_Frame",            Sc_Button_GetFrame);
-    ccAddExternalObjectFunction("Button::get_Graphic",          Sc_Button_GetGraphic);
-    ccAddExternalObjectFunction("Button::get_Loop",             Sc_Button_GetLoop);
-    ccAddExternalObjectFunction("Button::get_MouseOverGraphic", Sc_Button_GetMouseOverGraphic);
-    ccAddExternalObjectFunction("Button::set_MouseOverGraphic", Sc_Button_SetMouseOverGraphic);
-    ccAddExternalObjectFunction("Button::get_NormalGraphic",    Sc_Button_GetNormalGraphic);
-    ccAddExternalObjectFunction("Button::set_NormalGraphic",    Sc_Button_SetNormalGraphic);
-    ccAddExternalObjectFunction("Button::get_PushedGraphic",    Sc_Button_GetPushedGraphic);
-    ccAddExternalObjectFunction("Button::set_PushedGraphic",    Sc_Button_SetPushedGraphic);
-    ccAddExternalObjectFunction("Button::get_Text",             Sc_Button_GetText_New);
-    ccAddExternalObjectFunction("Button::set_Text",             Sc_Button_SetText);
-    ccAddExternalObjectFunction("Button::get_TextColor",        Sc_Button_GetTextColor);
-    ccAddExternalObjectFunction("Button::set_TextColor",        Sc_Button_SetTextColor);
-    ccAddExternalObjectFunction("Button::get_View",             Sc_Button_GetView);
+    ScFnRegister button_api[] = {
+        { "Button::Animate^4",            API_FN_PAIR(Button_Animate4) },
+        { "Button::Animate^7",            API_FN_PAIR(Button_Animate7) },
+        { "Button::Animate^8",            API_FN_PAIR(Button_Animate) },
+        { "Button::Click^1",              API_FN_PAIR(Button_Click) },
+        { "Button::GetText^1",            API_FN_PAIR(Button_GetText) },
+        { "Button::SetText^1",            API_FN_PAIR(Button_SetText) },
+        { "Button::get_TextAlignment",    API_FN_PAIR(Button_GetTextAlignment) },
+        { "Button::set_TextAlignment",    API_FN_PAIR(Button_SetTextAlignment) },
+        { "Button::get_Animating",        API_FN_PAIR(Button_IsAnimating) },
+        { "Button::get_ClipImage",        API_FN_PAIR(Button_GetClipImage) },
+        { "Button::set_ClipImage",        API_FN_PAIR(Button_SetClipImage) },
+        { "Button::get_Font",             API_FN_PAIR(Button_GetFont) },
+        { "Button::set_Font",             API_FN_PAIR(Button_SetFont) },
+        { "Button::get_Frame",            API_FN_PAIR(Button_GetAnimFrame) },
+        { "Button::get_Graphic",          API_FN_PAIR(Button_GetGraphic) },
+        { "Button::get_Loop",             API_FN_PAIR(Button_GetAnimLoop) },
+        { "Button::get_MouseOverGraphic", API_FN_PAIR(Button_GetMouseOverGraphic) },
+        { "Button::set_MouseOverGraphic", API_FN_PAIR(Button_SetMouseOverGraphic) },
+        { "Button::get_NormalGraphic",    API_FN_PAIR(Button_GetNormalGraphic) },
+        { "Button::set_NormalGraphic",    API_FN_PAIR(Button_SetNormalGraphic) },
+        { "Button::get_PushedGraphic",    API_FN_PAIR(Button_GetPushedGraphic) },
+        { "Button::set_PushedGraphic",    API_FN_PAIR(Button_SetPushedGraphic) },
+        { "Button::get_Text",             API_FN_PAIR(Button_GetText_New) },
+        { "Button::set_Text",             API_FN_PAIR(Button_SetText) },
+        { "Button::get_TextColor",        API_FN_PAIR(Button_GetTextColor) },
+        { "Button::set_TextColor",        API_FN_PAIR(Button_SetTextColor) },
+        { "Button::get_View",             API_FN_PAIR(Button_GetAnimView) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Button::Animate^4",            (void*)Button_Animate4);
-    ccAddExternalFunctionForPlugin("Button::GetText^1",            (void*)Button_GetText);
-    ccAddExternalFunctionForPlugin("Button::SetText^1",            (void*)Button_SetText);
-    ccAddExternalFunctionForPlugin("Button::get_ClipImage",        (void*)Button_GetClipImage);
-    ccAddExternalFunctionForPlugin("Button::set_ClipImage",        (void*)Button_SetClipImage);
-    ccAddExternalFunctionForPlugin("Button::get_Font",             (void*)Button_GetFont);
-    ccAddExternalFunctionForPlugin("Button::set_Font",             (void*)Button_SetFont);
-    ccAddExternalFunctionForPlugin("Button::get_Graphic",          (void*)Button_GetGraphic);
-    ccAddExternalFunctionForPlugin("Button::get_MouseOverGraphic", (void*)Button_GetMouseOverGraphic);
-    ccAddExternalFunctionForPlugin("Button::set_MouseOverGraphic", (void*)Button_SetMouseOverGraphic);
-    ccAddExternalFunctionForPlugin("Button::get_NormalGraphic",    (void*)Button_GetNormalGraphic);
-    ccAddExternalFunctionForPlugin("Button::set_NormalGraphic",    (void*)Button_SetNormalGraphic);
-    ccAddExternalFunctionForPlugin("Button::get_PushedGraphic",    (void*)Button_GetPushedGraphic);
-    ccAddExternalFunctionForPlugin("Button::set_PushedGraphic",    (void*)Button_SetPushedGraphic);
-    ccAddExternalFunctionForPlugin("Button::get_Text",             (void*)Button_GetText_New);
-    ccAddExternalFunctionForPlugin("Button::set_Text",             (void*)Button_SetText);
-    ccAddExternalFunctionForPlugin("Button::get_TextColor",        (void*)Button_GetTextColor);
-    ccAddExternalFunctionForPlugin("Button::set_TextColor",        (void*)Button_SetTextColor);
+    ccAddExternalFunctions(button_api);
 }

--- a/Engine/ac/button.h
+++ b/Engine/ac/button.h
@@ -21,7 +21,7 @@ struct AnimatingGUIButton;
 
 void        Button_Animate(GUIButton *butt, int view, int loop, int speed, int repeat,
                            int blocking, int direction, int sframe = 0, int volume = 100);
-void		Button_Animate4(GUIButton *butt, int view, int loop, int speed, int repeat);
+void        Button_Animate4(GUIButton *butt, int view, int loop, int speed, int repeat);
 const char* Button_GetText_New(GUIButton *butt);
 void		Button_GetText(GUIButton *butt, char *buffer);
 void		Button_SetText(GUIButton *butt, const char *newtx);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3841,7 +3841,7 @@ RuntimeScriptValue Sc_Character_SetZ(void *self, const RuntimeScriptValue *param
 
 //=============================================================================
 //
-// Exclusive API for Plugins
+// Exclusive variadic API implementation for Plugins
 //
 //=============================================================================
 

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -192,7 +192,11 @@ void Character_Animate(CharacterInfo *chaa, int loop, int delay, int repeat,
 }
 
 void Character_Animate5(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction) {
-    Character_Animate(chaa, loop, delay, repeat, blocking, direction, 0, 100 /* full volume */);
+    Character_Animate(chaa, loop, delay, repeat, blocking, direction, 0 /* first frame */, 100 /* full volume */);
+}
+
+void Character_Animate6(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction, int sframe) {
+    Character_Animate(chaa, loop, delay, repeat, blocking, direction, sframe, 100 /* full volume */);
 }
 
 void Character_ChangeRoomAutoPosition(CharacterInfo *chaa, int room, int newPos) 
@@ -2993,10 +2997,10 @@ RuntimeScriptValue Sc_Character_Animate5(void *self, const RuntimeScriptValue *p
 
 RuntimeScriptValue Sc_Character_Animate6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT6(CharacterInfo, Character_Animate);
+    API_OBJCALL_VOID_PINT6(CharacterInfo, Character_Animate6);
 }
 
-RuntimeScriptValue Sc_Character_Animate7(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Character_Animate(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT7(CharacterInfo, Character_Animate);
 }
@@ -3861,7 +3865,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
 	ccAddExternalObjectFunction("Character::AddWaypoint^2",             Sc_Character_AddWaypoint);
 	ccAddExternalObjectFunction("Character::Animate^5",                 Sc_Character_Animate5);
     ccAddExternalObjectFunction("Character::Animate^6",                 Sc_Character_Animate6);
-    ccAddExternalObjectFunction("Character::Animate^7",                 Sc_Character_Animate7);
+    ccAddExternalObjectFunction("Character::Animate^7",                 Sc_Character_Animate);
 	ccAddExternalObjectFunction("Character::ChangeRoom^3",              Sc_Character_ChangeRoom);
     ccAddExternalObjectFunction("Character::ChangeRoom^4",              Sc_Character_ChangeRoomSetLoop);
 	ccAddExternalObjectFunction("Character::ChangeRoomAutoPosition^2",  Sc_Character_ChangeRoomAutoPosition);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3229,7 +3229,7 @@ RuntimeScriptValue Sc_Character_SetIdleView(void *self, const RuntimeScriptValue
     API_OBJCALL_VOID_PINT2(CharacterInfo, Character_SetIdleView);
 }
 
-RuntimeScriptValue Sc_Character_HasExplicitLight(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Character_GetHasExplicitLight(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_BOOL(CharacterInfo, Character_GetHasExplicitLight);
 }
@@ -3861,316 +3861,178 @@ void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
 
 void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
-    ccAddExternalObjectFunction("Character::AddInventory^2",            Sc_Character_AddInventory);
-	ccAddExternalObjectFunction("Character::AddWaypoint^2",             Sc_Character_AddWaypoint);
-	ccAddExternalObjectFunction("Character::Animate^5",                 Sc_Character_Animate5);
-    ccAddExternalObjectFunction("Character::Animate^6",                 Sc_Character_Animate6);
-    ccAddExternalObjectFunction("Character::Animate^7",                 Sc_Character_Animate);
-	ccAddExternalObjectFunction("Character::ChangeRoom^3",              Sc_Character_ChangeRoom);
-    ccAddExternalObjectFunction("Character::ChangeRoom^4",              Sc_Character_ChangeRoomSetLoop);
-	ccAddExternalObjectFunction("Character::ChangeRoomAutoPosition^2",  Sc_Character_ChangeRoomAutoPosition);
-	ccAddExternalObjectFunction("Character::ChangeView^1",              Sc_Character_ChangeView);
-	ccAddExternalObjectFunction("Character::FaceCharacter^2",           Sc_Character_FaceCharacter);
-	ccAddExternalObjectFunction("Character::FaceDirection^2",           Sc_Character_FaceDirection);
-	ccAddExternalObjectFunction("Character::FaceLocation^3",            Sc_Character_FaceLocation);
-	ccAddExternalObjectFunction("Character::FaceObject^2",              Sc_Character_FaceObject);
-	ccAddExternalObjectFunction("Character::FollowCharacter^3",         Sc_Character_FollowCharacter);
-	ccAddExternalObjectFunction("Character::GetProperty^1",             Sc_Character_GetProperty);
-	ccAddExternalObjectFunction("Character::GetPropertyText^2",         Sc_Character_GetPropertyText);
-	ccAddExternalObjectFunction("Character::GetTextProperty^1",         Sc_Character_GetTextProperty);
-    ccAddExternalObjectFunction("Character::SetProperty^2",             Sc_Character_SetProperty);
-    ccAddExternalObjectFunction("Character::SetTextProperty^2",         Sc_Character_SetTextProperty);
-	ccAddExternalObjectFunction("Character::HasInventory^1",            Sc_Character_HasInventory);
-	ccAddExternalObjectFunction("Character::IsCollidingWithChar^1",     Sc_Character_IsCollidingWithChar);
-	ccAddExternalObjectFunction("Character::IsCollidingWithObject^1",   Sc_Character_IsCollidingWithObject);
-    ccAddExternalObjectFunction("Character::IsInteractionAvailable^1",  Sc_Character_IsInteractionAvailable);
-	ccAddExternalObjectFunction("Character::LockView^1",                Sc_Character_LockView);
-	ccAddExternalObjectFunction("Character::LockView^2",                Sc_Character_LockViewEx);
+    ScFnRegister character_api[] = {
+        { "Character::GetAtRoomXY^2",             API_FN_PAIR(GetCharacterAtRoom) },
+        { "Character::GetAtScreenXY^2",           API_FN_PAIR(GetCharacterAtScreen) },
+
+        { "Character::AddInventory^2",            API_FN_PAIR(Character_AddInventory) },
+        { "Character::AddWaypoint^2",             API_FN_PAIR(Character_AddWaypoint) },
+        { "Character::Animate^5",                 API_FN_PAIR(Character_Animate5) },
+        { "Character::Animate^6",                 API_FN_PAIR(Character_Animate6) },
+        { "Character::Animate^7",                 API_FN_PAIR(Character_Animate) },
+        { "Character::ChangeRoom^3",              API_FN_PAIR(Character_ChangeRoom) },
+        { "Character::ChangeRoom^4",              API_FN_PAIR(Character_ChangeRoomSetLoop) },
+        { "Character::ChangeRoomAutoPosition^2",  API_FN_PAIR(Character_ChangeRoomAutoPosition) },
+        { "Character::ChangeView^1",              API_FN_PAIR(Character_ChangeView) },
+        { "Character::FaceCharacter^2",           API_FN_PAIR(Character_FaceCharacter) },
+        { "Character::FaceDirection^2",           API_FN_PAIR(Character_FaceDirection) },
+        { "Character::FaceLocation^3",            API_FN_PAIR(Character_FaceLocation) },
+        { "Character::FaceObject^2",              API_FN_PAIR(Character_FaceObject) },
+        { "Character::FollowCharacter^3",         API_FN_PAIR(Character_FollowCharacter) },
+        { "Character::GetProperty^1",             API_FN_PAIR(Character_GetProperty) },
+        { "Character::GetPropertyText^2",         API_FN_PAIR(Character_GetPropertyText) },
+        { "Character::GetTextProperty^1",         API_FN_PAIR(Character_GetTextProperty) },
+        { "Character::SetProperty^2",             API_FN_PAIR(Character_SetProperty) },
+        { "Character::SetTextProperty^2",         API_FN_PAIR(Character_SetTextProperty) },
+        { "Character::HasInventory^1",            API_FN_PAIR(Character_HasInventory) },
+        { "Character::IsCollidingWithChar^1",     API_FN_PAIR(Character_IsCollidingWithChar) },
+        { "Character::IsCollidingWithObject^1",   API_FN_PAIR(Character_IsCollidingWithObject) },
+        { "Character::IsInteractionAvailable^1",  API_FN_PAIR(Character_IsInteractionAvailable) },
+        { "Character::LockView^1",                API_FN_PAIR(Character_LockView) },
+        { "Character::LockView^2",                API_FN_PAIR(Character_LockViewEx) },
+        { "Character::LockViewFrame^3",           API_FN_PAIR(Character_LockViewFrame) },
+        { "Character::LockViewFrame^4",           API_FN_PAIR(Character_LockViewFrameEx) },
+        { "Character::LockViewOffset^3",          API_FN_PAIR(Character_LockViewOffset) },
+        { "Character::LockViewOffset^4",          API_FN_PAIR(Character_LockViewOffsetEx) },
+        { "Character::LoseInventory^1",           API_FN_PAIR(Character_LoseInventory) },
+        { "Character::Move^4",                    API_FN_PAIR(Character_Move) },
+        { "Character::PlaceOnWalkableArea^0",     API_FN_PAIR(Character_PlaceOnWalkableArea) },
+        { "Character::RemoveTint^0",              API_FN_PAIR(Character_RemoveTint) },
+        { "Character::RunInteraction^1",          API_FN_PAIR(Character_RunInteraction) },
+        { "Character::Say^101",                   Sc_Character_Say, ScPl_Character_Say },
+        { "Character::SayAt^4",                   API_FN_PAIR(Character_SayAt) },
+        { "Character::SayBackground^1",           API_FN_PAIR(Character_SayBackground) },
+        { "Character::SetAsPlayer^0",             API_FN_PAIR(Character_SetAsPlayer) },
+        { "Character::SetIdleView^2",             API_FN_PAIR(Character_SetIdleView) },
+        { "Character::SetLightLevel^1",           API_FN_PAIR(Character_SetLightLevel) },
+        { "Character::SetWalkSpeed^2",            API_FN_PAIR(Character_SetSpeed) },
+        { "Character::StopMoving^0",              API_FN_PAIR(Character_StopMoving) },
+        { "Character::Think^101",                 Sc_Character_Think, ScPl_Character_Think },
+        { "Character::Tint^5",                    API_FN_PAIR(Character_Tint) },
+        { "Character::UnlockView^0",              API_FN_PAIR(Character_UnlockView) },
+        { "Character::UnlockView^1",              API_FN_PAIR(Character_UnlockViewEx) },
+        { "Character::Walk^4",                    API_FN_PAIR(Character_Walk) },
+        { "Character::WalkStraight^3",            API_FN_PAIR(Character_WalkStraight) },
+        
+        { "Character::get_ActiveInventory",       API_FN_PAIR(Character_GetActiveInventory) },
+        { "Character::set_ActiveInventory",       API_FN_PAIR(Character_SetActiveInventory) },
+        { "Character::get_Animating",             API_FN_PAIR(Character_GetAnimating) },
+        { "Character::get_AnimationSpeed",        API_FN_PAIR(Character_GetAnimationSpeed) },
+        { "Character::set_AnimationSpeed",        API_FN_PAIR(Character_SetAnimationSpeed) },
+        { "Character::get_AnimationVolume",       API_FN_PAIR(Character_GetAnimationVolume) },
+        { "Character::set_AnimationVolume",       API_FN_PAIR(Character_SetAnimationVolume) },
+        { "Character::get_Baseline",              API_FN_PAIR(Character_GetBaseline) },
+        { "Character::set_Baseline",              API_FN_PAIR(Character_SetBaseline) },
+        { "Character::get_BlinkInterval",         API_FN_PAIR(Character_GetBlinkInterval) },
+        { "Character::set_BlinkInterval",         API_FN_PAIR(Character_SetBlinkInterval) },
+        { "Character::get_BlinkView",             API_FN_PAIR(Character_GetBlinkView) },
+        { "Character::set_BlinkView",             API_FN_PAIR(Character_SetBlinkView) },
+        { "Character::get_BlinkWhileThinking",    API_FN_PAIR(Character_GetBlinkWhileThinking) },
+        { "Character::set_BlinkWhileThinking",    API_FN_PAIR(Character_SetBlinkWhileThinking) },
+        { "Character::get_BlockingHeight",        API_FN_PAIR(Character_GetBlockingHeight) },
+        { "Character::set_BlockingHeight",        API_FN_PAIR(Character_SetBlockingHeight) },
+        { "Character::get_BlockingWidth",         API_FN_PAIR(Character_GetBlockingWidth) },
+        { "Character::set_BlockingWidth",         API_FN_PAIR(Character_SetBlockingWidth) },
+        { "Character::get_Clickable",             API_FN_PAIR(Character_GetClickable) },
+        { "Character::set_Clickable",             API_FN_PAIR(Character_SetClickable) },
+        { "Character::get_DestinationX",          API_FN_PAIR(Character_GetDestinationX) },
+        { "Character::get_DestinationY",          API_FN_PAIR(Character_GetDestinationY) },
+        { "Character::get_DiagonalLoops",         API_FN_PAIR(Character_GetDiagonalWalking) },
+        { "Character::set_DiagonalLoops",         API_FN_PAIR(Character_SetDiagonalWalking) },
+        { "Character::get_Frame",                 API_FN_PAIR(Character_GetFrame) },
+        { "Character::set_Frame",                 API_FN_PAIR(Character_SetFrame) },
+        { "Character::get_ID",                    API_FN_PAIR(Character_GetID) },
+        { "Character::get_IdleView",              API_FN_PAIR(Character_GetIdleView) },
+        { "Character::get_IdleAnimationDelay",    API_FN_PAIR(Character_GetIdleAnimationDelay) },
+        { "Character::set_IdleAnimationDelay",    API_FN_PAIR(Character_SetIdleAnimationDelay) },
+        { "Character::geti_InventoryQuantity",    API_FN_PAIR(Character_GetIInventoryQuantity) },
+        { "Character::seti_InventoryQuantity",    API_FN_PAIR(Character_SetIInventoryQuantity) },
+        { "Character::get_IgnoreLighting",        API_FN_PAIR(Character_GetIgnoreLighting) },
+        { "Character::set_IgnoreLighting",        API_FN_PAIR(Character_SetIgnoreLighting) },
+        { "Character::get_IgnoreScaling",         API_FN_PAIR(Character_GetIgnoreScaling) },
+        { "Character::set_IgnoreScaling",         API_FN_PAIR(Character_SetIgnoreScaling) },
+        { "Character::get_IgnoreWalkbehinds",     API_FN_PAIR(Character_GetIgnoreWalkbehinds) },
+        { "Character::set_IgnoreWalkbehinds",     API_FN_PAIR(Character_SetIgnoreWalkbehinds) },
+        { "Character::get_Loop",                  API_FN_PAIR(Character_GetLoop) },
+        { "Character::set_Loop",                  API_FN_PAIR(Character_SetLoop) },
+        { "Character::get_ManualScaling",         API_FN_PAIR(Character_GetIgnoreScaling) },
+        { "Character::set_ManualScaling",         API_FN_PAIR(Character_SetManualScaling) },
+        { "Character::get_MovementLinkedToAnimation",API_FN_PAIR(Character_GetMovementLinkedToAnimation) },
+        { "Character::set_MovementLinkedToAnimation",API_FN_PAIR(Character_SetMovementLinkedToAnimation) },
+        { "Character::get_Moving",                API_FN_PAIR(Character_GetMoving) },
+        { "Character::get_Name",                  API_FN_PAIR(Character_GetName) },
+        { "Character::set_Name",                  API_FN_PAIR(Character_SetName) },
+        { "Character::get_NormalView",            API_FN_PAIR(Character_GetNormalView) },
+        { "Character::get_PreviousRoom",          API_FN_PAIR(Character_GetPreviousRoom) },
+        { "Character::get_Room",                  API_FN_PAIR(Character_GetRoom) },
+        { "Character::get_ScaleMoveSpeed",        API_FN_PAIR(Character_GetScaleMoveSpeed) },
+        { "Character::set_ScaleMoveSpeed",        API_FN_PAIR(Character_SetScaleMoveSpeed) },
+        { "Character::get_ScaleVolume",           API_FN_PAIR(Character_GetScaleVolume) },
+        { "Character::set_ScaleVolume",           API_FN_PAIR(Character_SetScaleVolume) },
+        { "Character::get_Scaling",               API_FN_PAIR(Character_GetScaling) },
+        { "Character::set_Scaling",               API_FN_PAIR(Character_SetScaling) },
+        { "Character::get_Solid",                 API_FN_PAIR(Character_GetSolid) },
+        { "Character::set_Solid",                 API_FN_PAIR(Character_SetSolid) },
+        { "Character::get_Speaking",              API_FN_PAIR(Character_GetSpeaking) },
+        { "Character::get_SpeakingFrame",         API_FN_PAIR(Character_GetSpeakingFrame) },
+        { "Character::get_SpeechAnimationDelay",  API_FN_PAIR(GetCharacterSpeechAnimationDelay) },
+        { "Character::set_SpeechAnimationDelay",  API_FN_PAIR(Character_SetSpeechAnimationDelay) },
+        { "Character::get_SpeechColor",           API_FN_PAIR(Character_GetSpeechColor) },
+        { "Character::set_SpeechColor",           API_FN_PAIR(Character_SetSpeechColor) },
+        { "Character::get_SpeechView",            API_FN_PAIR(Character_GetSpeechView) },
+        { "Character::set_SpeechView",            API_FN_PAIR(Character_SetSpeechView) },
+        { "Character::get_Thinking",              API_FN_PAIR(Character_GetThinking) },
+        { "Character::get_ThinkingFrame",         API_FN_PAIR(Character_GetThinkingFrame) },
+        { "Character::get_ThinkView",             API_FN_PAIR(Character_GetThinkView) },
+        { "Character::set_ThinkView",             API_FN_PAIR(Character_SetThinkView) },
+        { "Character::get_Transparency",          API_FN_PAIR(Character_GetTransparency) },
+        { "Character::set_Transparency",          API_FN_PAIR(Character_SetTransparency) },
+        { "Character::get_TurnBeforeWalking",     API_FN_PAIR(Character_GetTurnBeforeWalking) },
+        { "Character::set_TurnBeforeWalking",     API_FN_PAIR(Character_SetTurnBeforeWalking) },
+        { "Character::get_View",                  API_FN_PAIR(Character_GetView) },
+        { "Character::get_WalkSpeedX",            API_FN_PAIR(Character_GetWalkSpeedX) },
+        { "Character::get_WalkSpeedY",            API_FN_PAIR(Character_GetWalkSpeedY) },
+        { "Character::get_X",                     API_FN_PAIR(Character_GetX) },
+        { "Character::set_X",                     API_FN_PAIR(Character_SetX) },
+        { "Character::get_x",                     API_FN_PAIR(Character_GetX) },
+        { "Character::set_x",                     API_FN_PAIR(Character_SetX) },
+        { "Character::get_Y",                     API_FN_PAIR(Character_GetY) },
+        { "Character::set_Y",                     API_FN_PAIR(Character_SetY) },
+        { "Character::get_y",                     API_FN_PAIR(Character_GetY) },
+        { "Character::set_y",                     API_FN_PAIR(Character_SetY) },
+        { "Character::get_Z",                     API_FN_PAIR(Character_GetZ) },
+        { "Character::set_Z",                     API_FN_PAIR(Character_SetZ) },
+        { "Character::get_z",                     API_FN_PAIR(Character_GetZ) },
+        { "Character::set_z",                     API_FN_PAIR(Character_SetZ) },
+        { "Character::get_HasExplicitLight",      API_FN_PAIR(Character_GetHasExplicitLight) },
+        { "Character::get_LightLevel",            API_FN_PAIR(Character_GetLightLevel) },
+        { "Character::get_TintBlue",              API_FN_PAIR(Character_GetTintBlue) },
+        { "Character::get_TintGreen",             API_FN_PAIR(Character_GetTintGreen) },
+        { "Character::get_TintRed",               API_FN_PAIR(Character_GetTintRed) },
+        { "Character::get_TintSaturation",        API_FN_PAIR(Character_GetTintSaturation) },
+        { "Character::get_TintLuminance",         API_FN_PAIR(Character_GetTintLuminance) },
+    };
+
+    ccAddExternalFunctions(character_api);
+
+    // Few functions have to be selected based on API level
     if (base_api < kScriptAPI_v350)
     {
-        ccAddExternalObjectFunction("Character::LockViewAligned^3", Sc_Character_LockViewAligned_Old);
-        ccAddExternalObjectFunction("Character::LockViewAligned^4", Sc_Character_LockViewAlignedEx_Old);
+        ccAddExternalObjectFunction("Character::LockViewAligned^3", API_FN_PAIR(Character_LockViewAligned_Old));
+        ccAddExternalObjectFunction("Character::LockViewAligned^4", API_FN_PAIR(Character_LockViewAlignedEx_Old));
     }
     else
     {
-        ccAddExternalObjectFunction("Character::LockViewAligned^3", Sc_Character_LockViewAligned);
-        ccAddExternalObjectFunction("Character::LockViewAligned^4", Sc_Character_LockViewAlignedEx);
+        ccAddExternalObjectFunction("Character::LockViewAligned^3", API_FN_PAIR(Character_LockViewAligned));
+        ccAddExternalObjectFunction("Character::LockViewAligned^4", API_FN_PAIR(Character_LockViewAlignedEx));
     }
-	ccAddExternalObjectFunction("Character::LockViewFrame^3",           Sc_Character_LockViewFrame);
-	ccAddExternalObjectFunction("Character::LockViewFrame^4",           Sc_Character_LockViewFrameEx);
-	ccAddExternalObjectFunction("Character::LockViewOffset^3",          Sc_Character_LockViewOffset);
-	ccAddExternalObjectFunction("Character::LockViewOffset^4",          Sc_Character_LockViewOffsetEx);
-	ccAddExternalObjectFunction("Character::LoseInventory^1",           Sc_Character_LoseInventory);
-	ccAddExternalObjectFunction("Character::Move^4",                    Sc_Character_Move);
-	ccAddExternalObjectFunction("Character::PlaceOnWalkableArea^0",     Sc_Character_PlaceOnWalkableArea);
-	ccAddExternalObjectFunction("Character::RemoveTint^0",              Sc_Character_RemoveTint);
-	ccAddExternalObjectFunction("Character::RunInteraction^1",          Sc_Character_RunInteraction);
-	ccAddExternalObjectFunction("Character::Say^101",                   Sc_Character_Say);
-	ccAddExternalObjectFunction("Character::SayAt^4",                   Sc_Character_SayAt);
-	ccAddExternalObjectFunction("Character::SayBackground^1",           Sc_Character_SayBackground);
-	ccAddExternalObjectFunction("Character::SetAsPlayer^0",             Sc_Character_SetAsPlayer);
-	ccAddExternalObjectFunction("Character::SetIdleView^2",             Sc_Character_SetIdleView);
-    ccAddExternalObjectFunction("Character::SetLightLevel^1",           Sc_Character_SetLightLevel);
-	//ccAddExternalObjectFunction("Character::SetOption^2",             Sc_Character_SetOption);
-	ccAddExternalObjectFunction("Character::SetWalkSpeed^2",            Sc_Character_SetSpeed);
-	ccAddExternalObjectFunction("Character::StopMoving^0",              Sc_Character_StopMoving);
-	ccAddExternalObjectFunction("Character::Think^101",                 Sc_Character_Think);
-	ccAddExternalObjectFunction("Character::Tint^5",                    Sc_Character_Tint);
-	ccAddExternalObjectFunction("Character::UnlockView^0",              Sc_Character_UnlockView);
-	ccAddExternalObjectFunction("Character::UnlockView^1",              Sc_Character_UnlockViewEx);
-	ccAddExternalObjectFunction("Character::Walk^4",                    Sc_Character_Walk);
-	ccAddExternalObjectFunction("Character::WalkStraight^3",            Sc_Character_WalkStraight);
 
-    ccAddExternalStaticFunction("Character::GetAtRoomXY^2",             Sc_GetCharacterAtRoom);
-	ccAddExternalStaticFunction("Character::GetAtScreenXY^2",           Sc_GetCharacterAtScreen);
-
-	ccAddExternalObjectFunction("Character::get_ActiveInventory",       Sc_Character_GetActiveInventory);
-	ccAddExternalObjectFunction("Character::set_ActiveInventory",       Sc_Character_SetActiveInventory);
-	ccAddExternalObjectFunction("Character::get_Animating",             Sc_Character_GetAnimating);
-	ccAddExternalObjectFunction("Character::get_AnimationSpeed",        Sc_Character_GetAnimationSpeed);
-	ccAddExternalObjectFunction("Character::set_AnimationSpeed",        Sc_Character_SetAnimationSpeed);
-    ccAddExternalObjectFunction("Character::get_AnimationVolume",       Sc_Character_GetAnimationVolume);
-    ccAddExternalObjectFunction("Character::set_AnimationVolume",       Sc_Character_SetAnimationVolume);
-	ccAddExternalObjectFunction("Character::get_Baseline",              Sc_Character_GetBaseline);
-	ccAddExternalObjectFunction("Character::set_Baseline",              Sc_Character_SetBaseline);
-	ccAddExternalObjectFunction("Character::get_BlinkInterval",         Sc_Character_GetBlinkInterval);
-	ccAddExternalObjectFunction("Character::set_BlinkInterval",         Sc_Character_SetBlinkInterval);
-	ccAddExternalObjectFunction("Character::get_BlinkView",             Sc_Character_GetBlinkView);
-	ccAddExternalObjectFunction("Character::set_BlinkView",             Sc_Character_SetBlinkView);
-	ccAddExternalObjectFunction("Character::get_BlinkWhileThinking",    Sc_Character_GetBlinkWhileThinking);
-	ccAddExternalObjectFunction("Character::set_BlinkWhileThinking",    Sc_Character_SetBlinkWhileThinking);
-	ccAddExternalObjectFunction("Character::get_BlockingHeight",        Sc_Character_GetBlockingHeight);
-	ccAddExternalObjectFunction("Character::set_BlockingHeight",        Sc_Character_SetBlockingHeight);
-	ccAddExternalObjectFunction("Character::get_BlockingWidth",         Sc_Character_GetBlockingWidth);
-	ccAddExternalObjectFunction("Character::set_BlockingWidth",         Sc_Character_SetBlockingWidth);
-	ccAddExternalObjectFunction("Character::get_Clickable",             Sc_Character_GetClickable);
-	ccAddExternalObjectFunction("Character::set_Clickable",             Sc_Character_SetClickable);
-	ccAddExternalObjectFunction("Character::get_DestinationX",          Sc_Character_GetDestinationX);
-	ccAddExternalObjectFunction("Character::get_DestinationY",          Sc_Character_GetDestinationY);
-	ccAddExternalObjectFunction("Character::get_DiagonalLoops",         Sc_Character_GetDiagonalWalking);
-	ccAddExternalObjectFunction("Character::set_DiagonalLoops",         Sc_Character_SetDiagonalWalking);
-	ccAddExternalObjectFunction("Character::get_Frame",                 Sc_Character_GetFrame);
-	ccAddExternalObjectFunction("Character::set_Frame",                 Sc_Character_SetFrame);
-    if (base_api < kScriptAPI_v341)
-        ccAddExternalObjectFunction("Character::get_HasExplicitTint",       Sc_Character_GetHasExplicitTint_Old);
-    else
-	    ccAddExternalObjectFunction("Character::get_HasExplicitTint",       Sc_Character_GetHasExplicitTint);
-	ccAddExternalObjectFunction("Character::get_ID",                    Sc_Character_GetID);
-	ccAddExternalObjectFunction("Character::get_IdleView",              Sc_Character_GetIdleView);
-    ccAddExternalObjectFunction("Character::get_IdleAnimationDelay",    Sc_Character_GetIdleAnimationDelay);
-    ccAddExternalObjectFunction("Character::set_IdleAnimationDelay",    Sc_Character_SetIdleAnimationDelay);
-	ccAddExternalObjectFunction("Character::geti_InventoryQuantity",    Sc_Character_GetIInventoryQuantity);
-	ccAddExternalObjectFunction("Character::seti_InventoryQuantity",    Sc_Character_SetIInventoryQuantity);
-	ccAddExternalObjectFunction("Character::get_IgnoreLighting",        Sc_Character_GetIgnoreLighting);
-	ccAddExternalObjectFunction("Character::set_IgnoreLighting",        Sc_Character_SetIgnoreLighting);
-	ccAddExternalObjectFunction("Character::get_IgnoreScaling",         Sc_Character_GetIgnoreScaling);
-	ccAddExternalObjectFunction("Character::set_IgnoreScaling",         Sc_Character_SetIgnoreScaling);
-	ccAddExternalObjectFunction("Character::get_IgnoreWalkbehinds",     Sc_Character_GetIgnoreWalkbehinds);
-	ccAddExternalObjectFunction("Character::set_IgnoreWalkbehinds",     Sc_Character_SetIgnoreWalkbehinds);
-	ccAddExternalObjectFunction("Character::get_Loop",                  Sc_Character_GetLoop);
-	ccAddExternalObjectFunction("Character::set_Loop",                  Sc_Character_SetLoop);
-	ccAddExternalObjectFunction("Character::get_ManualScaling",         Sc_Character_GetIgnoreScaling);
-	ccAddExternalObjectFunction("Character::set_ManualScaling",         Sc_Character_SetManualScaling);
-	ccAddExternalObjectFunction("Character::get_MovementLinkedToAnimation",Sc_Character_GetMovementLinkedToAnimation);
-	ccAddExternalObjectFunction("Character::set_MovementLinkedToAnimation",Sc_Character_SetMovementLinkedToAnimation);
-	ccAddExternalObjectFunction("Character::get_Moving",                Sc_Character_GetMoving);
-	ccAddExternalObjectFunction("Character::get_Name",                  Sc_Character_GetName);
-	ccAddExternalObjectFunction("Character::set_Name",                  Sc_Character_SetName);
-	ccAddExternalObjectFunction("Character::get_NormalView",            Sc_Character_GetNormalView);
-	ccAddExternalObjectFunction("Character::get_PreviousRoom",          Sc_Character_GetPreviousRoom);
-	ccAddExternalObjectFunction("Character::get_Room",                  Sc_Character_GetRoom);
-	ccAddExternalObjectFunction("Character::get_ScaleMoveSpeed",        Sc_Character_GetScaleMoveSpeed);
-	ccAddExternalObjectFunction("Character::set_ScaleMoveSpeed",        Sc_Character_SetScaleMoveSpeed);
-	ccAddExternalObjectFunction("Character::get_ScaleVolume",           Sc_Character_GetScaleVolume);
-	ccAddExternalObjectFunction("Character::set_ScaleVolume",           Sc_Character_SetScaleVolume);
-	ccAddExternalObjectFunction("Character::get_Scaling",               Sc_Character_GetScaling);
-	ccAddExternalObjectFunction("Character::set_Scaling",               Sc_Character_SetScaling);
-	ccAddExternalObjectFunction("Character::get_Solid",                 Sc_Character_GetSolid);
-	ccAddExternalObjectFunction("Character::set_Solid",                 Sc_Character_SetSolid);
-	ccAddExternalObjectFunction("Character::get_Speaking",              Sc_Character_GetSpeaking);
-	ccAddExternalObjectFunction("Character::get_SpeakingFrame",         Sc_Character_GetSpeakingFrame);
-	ccAddExternalObjectFunction("Character::get_SpeechAnimationDelay",  Sc_GetCharacterSpeechAnimationDelay);
-	ccAddExternalObjectFunction("Character::set_SpeechAnimationDelay",  Sc_Character_SetSpeechAnimationDelay);
-	ccAddExternalObjectFunction("Character::get_SpeechColor",           Sc_Character_GetSpeechColor);
-	ccAddExternalObjectFunction("Character::set_SpeechColor",           Sc_Character_SetSpeechColor);
-	ccAddExternalObjectFunction("Character::get_SpeechView",            Sc_Character_GetSpeechView);
-	ccAddExternalObjectFunction("Character::set_SpeechView",            Sc_Character_SetSpeechView);
-    ccAddExternalObjectFunction("Character::get_Thinking",              Sc_Character_GetThinking);
-    ccAddExternalObjectFunction("Character::get_ThinkingFrame",         Sc_Character_GetThinkingFrame);
-	ccAddExternalObjectFunction("Character::get_ThinkView",             Sc_Character_GetThinkView);
-	ccAddExternalObjectFunction("Character::set_ThinkView",             Sc_Character_SetThinkView);
-	ccAddExternalObjectFunction("Character::get_Transparency",          Sc_Character_GetTransparency);
-	ccAddExternalObjectFunction("Character::set_Transparency",          Sc_Character_SetTransparency);
-	ccAddExternalObjectFunction("Character::get_TurnBeforeWalking",     Sc_Character_GetTurnBeforeWalking);
-	ccAddExternalObjectFunction("Character::set_TurnBeforeWalking",     Sc_Character_SetTurnBeforeWalking);
-	ccAddExternalObjectFunction("Character::get_View",                  Sc_Character_GetView);
-	ccAddExternalObjectFunction("Character::get_WalkSpeedX",            Sc_Character_GetWalkSpeedX);
-	ccAddExternalObjectFunction("Character::get_WalkSpeedY",            Sc_Character_GetWalkSpeedY);
-	ccAddExternalObjectFunction("Character::get_X",                     Sc_Character_GetX);
-	ccAddExternalObjectFunction("Character::set_X",                     Sc_Character_SetX);
-	ccAddExternalObjectFunction("Character::get_x",                     Sc_Character_GetX);
-	ccAddExternalObjectFunction("Character::set_x",                     Sc_Character_SetX);
-	ccAddExternalObjectFunction("Character::get_Y",                     Sc_Character_GetY);
-	ccAddExternalObjectFunction("Character::set_Y",                     Sc_Character_SetY);
-	ccAddExternalObjectFunction("Character::get_y",                     Sc_Character_GetY);
-	ccAddExternalObjectFunction("Character::set_y",                     Sc_Character_SetY);
-	ccAddExternalObjectFunction("Character::get_Z",                     Sc_Character_GetZ);
-	ccAddExternalObjectFunction("Character::set_Z",                     Sc_Character_SetZ);
-	ccAddExternalObjectFunction("Character::get_z",                     Sc_Character_GetZ);
-	ccAddExternalObjectFunction("Character::set_z",                     Sc_Character_SetZ);
-
-    ccAddExternalObjectFunction("Character::get_HasExplicitLight",      Sc_Character_HasExplicitLight);
-    ccAddExternalObjectFunction("Character::get_LightLevel",            Sc_Character_GetLightLevel);
-    ccAddExternalObjectFunction("Character::get_TintBlue",              Sc_Character_GetTintBlue);
-    ccAddExternalObjectFunction("Character::get_TintGreen",             Sc_Character_GetTintGreen);
-    ccAddExternalObjectFunction("Character::get_TintRed",               Sc_Character_GetTintRed);
-    ccAddExternalObjectFunction("Character::get_TintSaturation",        Sc_Character_GetTintSaturation);
-    ccAddExternalObjectFunction("Character::get_TintLuminance",         Sc_Character_GetTintLuminance);
-
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Character::AddInventory^2",            (void*)Character_AddInventory);
-    ccAddExternalFunctionForPlugin("Character::AddWaypoint^2",             (void*)Character_AddWaypoint);
-    ccAddExternalFunctionForPlugin("Character::Animate^5",                 (void*)Character_Animate5);
-    ccAddExternalFunctionForPlugin("Character::ChangeRoom^3",              (void*)Character_ChangeRoom);
-    ccAddExternalFunctionForPlugin("Character::ChangeRoomAutoPosition^2",  (void*)Character_ChangeRoomAutoPosition);
-    ccAddExternalFunctionForPlugin("Character::ChangeView^1",              (void*)Character_ChangeView);
-    ccAddExternalFunctionForPlugin("Character::FaceCharacter^2",           (void*)Character_FaceCharacter);
-    ccAddExternalFunctionForPlugin("Character::FaceDirection^2",           (void*)Character_FaceDirection);
-    ccAddExternalFunctionForPlugin("Character::FaceLocation^3",            (void*)Character_FaceLocation);
-    ccAddExternalFunctionForPlugin("Character::FaceObject^2",              (void*)Character_FaceObject);
-    ccAddExternalFunctionForPlugin("Character::FollowCharacter^3",         (void*)Character_FollowCharacter);
-    ccAddExternalFunctionForPlugin("Character::GetProperty^1",             (void*)Character_GetProperty);
-    ccAddExternalFunctionForPlugin("Character::GetPropertyText^2",         (void*)Character_GetPropertyText);
-    ccAddExternalFunctionForPlugin("Character::GetTextProperty^1",         (void*)Character_GetTextProperty);
-    ccAddExternalFunctionForPlugin("Character::SetProperty^2",             (void*)Character_SetProperty);
-    ccAddExternalFunctionForPlugin("Character::SetTextProperty^2",         (void*)Character_SetTextProperty);
-    ccAddExternalFunctionForPlugin("Character::HasInventory^1",            (void*)Character_HasInventory);
-    ccAddExternalFunctionForPlugin("Character::IsCollidingWithChar^1",     (void*)Character_IsCollidingWithChar);
-    ccAddExternalFunctionForPlugin("Character::IsCollidingWithObject^1",   (void*)Character_IsCollidingWithObject);
-    ccAddExternalFunctionForPlugin("Character::LockView^1",                (void*)Character_LockView);
-    ccAddExternalFunctionForPlugin("Character::LockView^2",                (void*)Character_LockViewEx);
     if (base_api < kScriptAPI_v341)
     {
-        ccAddExternalFunctionForPlugin("Character::LockViewAligned^3", (void*)Character_LockViewAligned_Old);
-        ccAddExternalFunctionForPlugin("Character::LockViewAligned^4", (void*)Character_LockViewAlignedEx_Old);
+        ccAddExternalObjectFunction("Character::get_HasExplicitTint", API_FN_PAIR(Character_GetHasExplicitTint_Old));
     }
     else
     {
-        ccAddExternalFunctionForPlugin("Character::LockViewAligned^3", (void*)Character_LockViewAligned);
-        ccAddExternalFunctionForPlugin("Character::LockViewAligned^4", (void*)Character_LockViewAlignedEx);
+        ccAddExternalObjectFunction("Character::get_HasExplicitTint", API_FN_PAIR(Character_GetHasExplicitTint));
     }
-    ccAddExternalFunctionForPlugin("Character::LockViewFrame^3",           (void*)Character_LockViewFrame);
-    ccAddExternalFunctionForPlugin("Character::LockViewFrame^4",           (void*)Character_LockViewFrameEx);
-    ccAddExternalFunctionForPlugin("Character::LockViewOffset^3",          (void*)Character_LockViewOffset);
-    ccAddExternalFunctionForPlugin("Character::LockViewOffset^4",          (void*)Character_LockViewOffset);
-    ccAddExternalFunctionForPlugin("Character::LoseInventory^1",           (void*)Character_LoseInventory);
-    ccAddExternalFunctionForPlugin("Character::Move^4",                    (void*)Character_Move);
-    ccAddExternalFunctionForPlugin("Character::PlaceOnWalkableArea^0",     (void*)Character_PlaceOnWalkableArea);
-    ccAddExternalFunctionForPlugin("Character::RemoveTint^0",              (void*)Character_RemoveTint);
-    ccAddExternalFunctionForPlugin("Character::RunInteraction^1",          (void*)Character_RunInteraction);
-    ccAddExternalFunctionForPlugin("Character::Say^101",                   (void*)ScPl_Character_Say);
-    ccAddExternalFunctionForPlugin("Character::SayAt^4",                   (void*)Character_SayAt);
-    ccAddExternalFunctionForPlugin("Character::SayBackground^1",           (void*)Character_SayBackground);
-    ccAddExternalFunctionForPlugin("Character::SetAsPlayer^0",             (void*)Character_SetAsPlayer);
-    ccAddExternalFunctionForPlugin("Character::SetIdleView^2",             (void*)Character_SetIdleView);
-    //ccAddExternalFunctionForPlugin("Character::SetOption^2",             (void*)Character_SetOption);
-    ccAddExternalFunctionForPlugin("Character::SetWalkSpeed^2",            (void*)Character_SetSpeed);
-    ccAddExternalFunctionForPlugin("Character::StopMoving^0",              (void*)Character_StopMoving);
-    ccAddExternalFunctionForPlugin("Character::Think^101",                 (void*)ScPl_Character_Think);
-    ccAddExternalFunctionForPlugin("Character::Tint^5",                    (void*)Character_Tint);
-    ccAddExternalFunctionForPlugin("Character::UnlockView^0",              (void*)Character_UnlockView);
-    ccAddExternalFunctionForPlugin("Character::UnlockView^1",              (void*)Character_UnlockViewEx);
-    ccAddExternalFunctionForPlugin("Character::Walk^4",                    (void*)Character_Walk);
-    ccAddExternalFunctionForPlugin("Character::WalkStraight^3",            (void*)Character_WalkStraight);
-    ccAddExternalFunctionForPlugin("Character::GetAtRoomXY^2",             (void*)GetCharacterAtRoom);
-    ccAddExternalFunctionForPlugin("Character::GetAtScreenXY^2",           (void*)GetCharacterAtScreen);
-    ccAddExternalFunctionForPlugin("Character::get_ActiveInventory",       (void*)Character_GetActiveInventory);
-    ccAddExternalFunctionForPlugin("Character::set_ActiveInventory",       (void*)Character_SetActiveInventory);
-    ccAddExternalFunctionForPlugin("Character::get_Animating",             (void*)Character_GetAnimating);
-    ccAddExternalFunctionForPlugin("Character::get_AnimationSpeed",        (void*)Character_GetAnimationSpeed);
-    ccAddExternalFunctionForPlugin("Character::set_AnimationSpeed",        (void*)Character_SetAnimationSpeed);
-    ccAddExternalFunctionForPlugin("Character::get_Baseline",              (void*)Character_GetBaseline);
-    ccAddExternalFunctionForPlugin("Character::set_Baseline",              (void*)Character_SetBaseline);
-    ccAddExternalFunctionForPlugin("Character::get_BlinkInterval",         (void*)Character_GetBlinkInterval);
-    ccAddExternalFunctionForPlugin("Character::set_BlinkInterval",         (void*)Character_SetBlinkInterval);
-    ccAddExternalFunctionForPlugin("Character::get_BlinkView",             (void*)Character_GetBlinkView);
-    ccAddExternalFunctionForPlugin("Character::set_BlinkView",             (void*)Character_SetBlinkView);
-    ccAddExternalFunctionForPlugin("Character::get_BlinkWhileThinking",    (void*)Character_GetBlinkWhileThinking);
-    ccAddExternalFunctionForPlugin("Character::set_BlinkWhileThinking",    (void*)Character_SetBlinkWhileThinking);
-    ccAddExternalFunctionForPlugin("Character::get_BlockingHeight",        (void*)Character_GetBlockingHeight);
-    ccAddExternalFunctionForPlugin("Character::set_BlockingHeight",        (void*)Character_SetBlockingHeight);
-    ccAddExternalFunctionForPlugin("Character::get_BlockingWidth",         (void*)Character_GetBlockingWidth);
-    ccAddExternalFunctionForPlugin("Character::set_BlockingWidth",         (void*)Character_SetBlockingWidth);
-    ccAddExternalFunctionForPlugin("Character::get_Clickable",             (void*)Character_GetClickable);
-    ccAddExternalFunctionForPlugin("Character::set_Clickable",             (void*)Character_SetClickable);
-    ccAddExternalFunctionForPlugin("Character::get_DestinationX",          (void*)Character_GetDestinationX);
-    ccAddExternalFunctionForPlugin("Character::get_DestinationY",          (void*)Character_GetDestinationY);
-    ccAddExternalFunctionForPlugin("Character::get_DiagonalLoops",         (void*)Character_GetDiagonalWalking);
-    ccAddExternalFunctionForPlugin("Character::set_DiagonalLoops",         (void*)Character_SetDiagonalWalking);
-    ccAddExternalFunctionForPlugin("Character::get_Frame",                 (void*)Character_GetFrame);
-    ccAddExternalFunctionForPlugin("Character::set_Frame",                 (void*)Character_SetFrame);
-    if (base_api < kScriptAPI_v341)
-        ccAddExternalFunctionForPlugin("Character::get_HasExplicitTint",       (void*)Character_GetHasExplicitTint_Old);
-    else
-        ccAddExternalFunctionForPlugin("Character::get_HasExplicitTint",       (void*)Character_GetHasExplicitTint);
-    ccAddExternalFunctionForPlugin("Character::get_ID",                    (void*)Character_GetID);
-    ccAddExternalFunctionForPlugin("Character::get_IdleView",              (void*)Character_GetIdleView);
-    ccAddExternalFunctionForPlugin("Character::geti_InventoryQuantity",    (void*)Character_GetIInventoryQuantity);
-    ccAddExternalFunctionForPlugin("Character::seti_InventoryQuantity",    (void*)Character_SetIInventoryQuantity);
-    ccAddExternalFunctionForPlugin("Character::get_IgnoreLighting",        (void*)Character_GetIgnoreLighting);
-    ccAddExternalFunctionForPlugin("Character::set_IgnoreLighting",        (void*)Character_SetIgnoreLighting);
-    ccAddExternalFunctionForPlugin("Character::get_IgnoreScaling",         (void*)Character_GetIgnoreScaling);
-    ccAddExternalFunctionForPlugin("Character::set_IgnoreScaling",         (void*)Character_SetIgnoreScaling);
-    ccAddExternalFunctionForPlugin("Character::get_IgnoreWalkbehinds",     (void*)Character_GetIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("Character::set_IgnoreWalkbehinds",     (void*)Character_SetIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("Character::get_Loop",                  (void*)Character_GetLoop);
-    ccAddExternalFunctionForPlugin("Character::set_Loop",                  (void*)Character_SetLoop);
-    ccAddExternalFunctionForPlugin("Character::get_ManualScaling",         (void*)Character_GetIgnoreScaling);
-    ccAddExternalFunctionForPlugin("Character::set_ManualScaling",         (void*)Character_SetManualScaling);
-    ccAddExternalFunctionForPlugin("Character::get_MovementLinkedToAnimation",(void*)Character_GetMovementLinkedToAnimation);
-    ccAddExternalFunctionForPlugin("Character::set_MovementLinkedToAnimation",(void*)Character_SetMovementLinkedToAnimation);
-    ccAddExternalFunctionForPlugin("Character::get_Moving",                (void*)Character_GetMoving);
-    ccAddExternalFunctionForPlugin("Character::get_Name",                  (void*)Character_GetName);
-    ccAddExternalFunctionForPlugin("Character::set_Name",                  (void*)Character_SetName);
-    ccAddExternalFunctionForPlugin("Character::get_NormalView",            (void*)Character_GetNormalView);
-    ccAddExternalFunctionForPlugin("Character::get_PreviousRoom",          (void*)Character_GetPreviousRoom);
-    ccAddExternalFunctionForPlugin("Character::get_Room",                  (void*)Character_GetRoom);
-    ccAddExternalFunctionForPlugin("Character::get_ScaleMoveSpeed",        (void*)Character_GetScaleMoveSpeed);
-    ccAddExternalFunctionForPlugin("Character::set_ScaleMoveSpeed",        (void*)Character_SetScaleMoveSpeed);
-    ccAddExternalFunctionForPlugin("Character::get_ScaleVolume",           (void*)Character_GetScaleVolume);
-    ccAddExternalFunctionForPlugin("Character::set_ScaleVolume",           (void*)Character_SetScaleVolume);
-    ccAddExternalFunctionForPlugin("Character::get_Scaling",               (void*)Character_GetScaling);
-    ccAddExternalFunctionForPlugin("Character::set_Scaling",               (void*)Character_SetScaling);
-    ccAddExternalFunctionForPlugin("Character::get_Solid",                 (void*)Character_GetSolid);
-    ccAddExternalFunctionForPlugin("Character::set_Solid",                 (void*)Character_SetSolid);
-    ccAddExternalFunctionForPlugin("Character::get_Speaking",              (void*)Character_GetSpeaking);
-    ccAddExternalFunctionForPlugin("Character::get_SpeakingFrame",         (void*)Character_GetSpeakingFrame);
-    ccAddExternalFunctionForPlugin("Character::get_SpeechAnimationDelay",  (void*)GetCharacterSpeechAnimationDelay);
-    ccAddExternalFunctionForPlugin("Character::set_SpeechAnimationDelay",  (void*)Character_SetSpeechAnimationDelay);
-    ccAddExternalFunctionForPlugin("Character::get_SpeechColor",           (void*)Character_GetSpeechColor);
-    ccAddExternalFunctionForPlugin("Character::set_SpeechColor",           (void*)Character_SetSpeechColor);
-    ccAddExternalFunctionForPlugin("Character::get_SpeechView",            (void*)Character_GetSpeechView);
-    ccAddExternalFunctionForPlugin("Character::set_SpeechView",            (void*)Character_SetSpeechView);
-    ccAddExternalFunctionForPlugin("Character::get_ThinkView",             (void*)Character_GetThinkView);
-    ccAddExternalFunctionForPlugin("Character::set_ThinkView",             (void*)Character_SetThinkView);
-    ccAddExternalFunctionForPlugin("Character::get_Transparency",          (void*)Character_GetTransparency);
-    ccAddExternalFunctionForPlugin("Character::set_Transparency",          (void*)Character_SetTransparency);
-    ccAddExternalFunctionForPlugin("Character::get_TurnBeforeWalking",     (void*)Character_GetTurnBeforeWalking);
-    ccAddExternalFunctionForPlugin("Character::set_TurnBeforeWalking",     (void*)Character_SetTurnBeforeWalking);
-    ccAddExternalFunctionForPlugin("Character::get_View",                  (void*)Character_GetView);
-    ccAddExternalFunctionForPlugin("Character::get_WalkSpeedX",            (void*)Character_GetWalkSpeedX);
-    ccAddExternalFunctionForPlugin("Character::get_WalkSpeedY",            (void*)Character_GetWalkSpeedY);
-    ccAddExternalFunctionForPlugin("Character::get_X",                     (void*)Character_GetX);
-    ccAddExternalFunctionForPlugin("Character::set_X",                     (void*)Character_SetX);
-    ccAddExternalFunctionForPlugin("Character::get_x",                     (void*)Character_GetX);
-    ccAddExternalFunctionForPlugin("Character::set_x",                     (void*)Character_SetX);
-    ccAddExternalFunctionForPlugin("Character::get_Y",                     (void*)Character_GetY);
-    ccAddExternalFunctionForPlugin("Character::set_Y",                     (void*)Character_SetY);
-    ccAddExternalFunctionForPlugin("Character::get_y",                     (void*)Character_GetY);
-    ccAddExternalFunctionForPlugin("Character::set_y",                     (void*)Character_SetY);
-    ccAddExternalFunctionForPlugin("Character::get_Z",                     (void*)Character_GetZ);
-    ccAddExternalFunctionForPlugin("Character::set_Z",                     (void*)Character_SetZ);
-    ccAddExternalFunctionForPlugin("Character::get_z",                     (void*)Character_GetZ);
-    ccAddExternalFunctionForPlugin("Character::set_z",                     (void*)Character_SetZ);
 }

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -30,8 +30,8 @@
 
 void    Character_AddInventory(CharacterInfo *chaa, ScriptInvItem *invi, int addIndex);
 void    Character_AddWaypoint(CharacterInfo *chaa, int x, int y);
-void    Character_Animate(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction,
-                          int sframe = 0, int volume = 100);
+void    Character_Animate(CharacterInfo *chaa, int loop, int delay, int repeat,
+                          int blocking, int direction, int sframe = 0, int volume = 100);
 void    Character_Animate5(CharacterInfo *chaa, int loop, int delay, int repeat, int blocking, int direction);
 void    Character_ChangeRoomAutoPosition(CharacterInfo *chaa, int room, int newPos);
 void    Character_ChangeRoom(CharacterInfo *chaa, int room, int x, int y);

--- a/Engine/ac/datetime.cpp
+++ b/Engine/ac/datetime.cpp
@@ -118,23 +118,17 @@ RuntimeScriptValue Sc_DateTime_GetRawTime(void *self, const RuntimeScriptValue *
 
 void RegisterDateTimeAPI()
 {
-    ccAddExternalStaticFunction("DateTime::get_Now",        Sc_DateTime_Now);
-    ccAddExternalObjectFunction("DateTime::get_DayOfMonth", Sc_DateTime_GetDayOfMonth);
-    ccAddExternalObjectFunction("DateTime::get_Hour",       Sc_DateTime_GetHour);
-    ccAddExternalObjectFunction("DateTime::get_Minute",     Sc_DateTime_GetMinute);
-    ccAddExternalObjectFunction("DateTime::get_Month",      Sc_DateTime_GetMonth);
-    ccAddExternalObjectFunction("DateTime::get_RawTime",    Sc_DateTime_GetRawTime);
-    ccAddExternalObjectFunction("DateTime::get_Second",     Sc_DateTime_GetSecond);
-    ccAddExternalObjectFunction("DateTime::get_Year",       Sc_DateTime_GetYear);
+    ScFnRegister datetime_api[] = {
+        { "DateTime::get_Now",        API_FN_PAIR(DateTime_Now) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "DateTime::get_DayOfMonth", API_FN_PAIR(DateTime_GetDayOfMonth) },
+        { "DateTime::get_Hour",       API_FN_PAIR(DateTime_GetHour) },
+        { "DateTime::get_Minute",     API_FN_PAIR(DateTime_GetMinute) },
+        { "DateTime::get_Month",      API_FN_PAIR(DateTime_GetMonth) },
+        { "DateTime::get_RawTime",    API_FN_PAIR(DateTime_GetRawTime) },
+        { "DateTime::get_Second",     API_FN_PAIR(DateTime_GetSecond) },
+        { "DateTime::get_Year",       API_FN_PAIR(DateTime_GetYear) },
+    };
 
-    ccAddExternalFunctionForPlugin("DateTime::get_Now",        (void*)DateTime_Now);
-    ccAddExternalFunctionForPlugin("DateTime::get_DayOfMonth", (void*)DateTime_GetDayOfMonth);
-    ccAddExternalFunctionForPlugin("DateTime::get_Hour",       (void*)DateTime_GetHour);
-    ccAddExternalFunctionForPlugin("DateTime::get_Minute",     (void*)DateTime_GetMinute);
-    ccAddExternalFunctionForPlugin("DateTime::get_Month",      (void*)DateTime_GetMonth);
-    ccAddExternalFunctionForPlugin("DateTime::get_RawTime",    (void*)DateTime_GetRawTime);
-    ccAddExternalFunctionForPlugin("DateTime::get_Second",     (void*)DateTime_GetSecond);
-    ccAddExternalFunctionForPlugin("DateTime::get_Year",       (void*)DateTime_GetYear);
+    ccAddExternalFunctions(datetime_api);
 }

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1367,26 +1367,18 @@ RuntimeScriptValue Sc_Dialog_Start(void *self, const RuntimeScriptValue *params,
 
 void RegisterDialogAPI()
 {
-    ccAddExternalObjectFunction("Dialog::get_ID",               Sc_Dialog_GetID);
-    ccAddExternalObjectFunction("Dialog::get_OptionCount",      Sc_Dialog_GetOptionCount);
-    ccAddExternalObjectFunction("Dialog::get_ShowTextParser",   Sc_Dialog_GetShowTextParser);
-    ccAddExternalObjectFunction("Dialog::DisplayOptions^1",     Sc_Dialog_DisplayOptions);
-    ccAddExternalObjectFunction("Dialog::GetOptionState^1",     Sc_Dialog_GetOptionState);
-    ccAddExternalObjectFunction("Dialog::GetOptionText^1",      Sc_Dialog_GetOptionText);
-    ccAddExternalObjectFunction("Dialog::HasOptionBeenChosen^1", Sc_Dialog_HasOptionBeenChosen);
-    ccAddExternalObjectFunction("Dialog::SetHasOptionBeenChosen^2", Sc_Dialog_SetHasOptionBeenChosen);
-    ccAddExternalObjectFunction("Dialog::SetOptionState^2",     Sc_Dialog_SetOptionState);
-    ccAddExternalObjectFunction("Dialog::Start^0",              Sc_Dialog_Start);
+    ScFnRegister dialog_api[] = {
+        { "Dialog::get_ID",               API_FN_PAIR(Dialog_GetID) },
+        { "Dialog::get_OptionCount",      API_FN_PAIR(Dialog_GetOptionCount) },
+        { "Dialog::get_ShowTextParser",   API_FN_PAIR(Dialog_GetShowTextParser) },
+        { "Dialog::DisplayOptions^1",     API_FN_PAIR(Dialog_DisplayOptions) },
+        { "Dialog::GetOptionState^1",     API_FN_PAIR(Dialog_GetOptionState) },
+        { "Dialog::GetOptionText^1",      API_FN_PAIR(Dialog_GetOptionText) },
+        { "Dialog::HasOptionBeenChosen^1", API_FN_PAIR(Dialog_HasOptionBeenChosen) },
+        { "Dialog::SetHasOptionBeenChosen^2", API_FN_PAIR(Dialog_SetHasOptionBeenChosen) },
+        { "Dialog::SetOptionState^2",     API_FN_PAIR(Dialog_SetOptionState) },
+        { "Dialog::Start^0",              API_FN_PAIR(Dialog_Start) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Dialog::get_ID",               (void*)Dialog_GetID);
-    ccAddExternalFunctionForPlugin("Dialog::get_OptionCount",      (void*)Dialog_GetOptionCount);
-    ccAddExternalFunctionForPlugin("Dialog::get_ShowTextParser",   (void*)Dialog_GetShowTextParser);
-    ccAddExternalFunctionForPlugin("Dialog::DisplayOptions^1",     (void*)Dialog_DisplayOptions);
-    ccAddExternalFunctionForPlugin("Dialog::GetOptionState^1",     (void*)Dialog_GetOptionState);
-    ccAddExternalFunctionForPlugin("Dialog::GetOptionText^1",      (void*)Dialog_GetOptionText);
-    ccAddExternalFunctionForPlugin("Dialog::HasOptionBeenChosen^1", (void*)Dialog_HasOptionBeenChosen);
-    ccAddExternalFunctionForPlugin("Dialog::SetOptionState^2",     (void*)Dialog_SetOptionState);
-    ccAddExternalFunctionForPlugin("Dialog::Start^0",              (void*)Dialog_Start);
+    ccAddExternalFunctions(dialog_api);
 }

--- a/Engine/ac/dialogoptionsrendering.cpp
+++ b/Engine/ac/dialogoptionsrendering.cpp
@@ -285,47 +285,30 @@ RuntimeScriptValue Sc_DialogOptionsRendering_SetHasAlphaChannel(void *self, cons
 
 void RegisterDialogOptionsRenderingAPI()
 {
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::Update^0",             Sc_DialogOptionsRendering_Update);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::RunActiveOption^0",    Sc_DialogOptionsRendering_RunActiveOption);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_ActiveOptionID",   Sc_DialogOptionsRendering_GetActiveOptionID);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_ActiveOptionID",   Sc_DialogOptionsRendering_SetActiveOptionID);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_DialogToRender",   Sc_DialogOptionsRendering_GetDialogToRender);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_Height",           Sc_DialogOptionsRendering_GetHeight);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_Height",           Sc_DialogOptionsRendering_SetHeight);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_ParserTextBoxX",   Sc_DialogOptionsRendering_GetParserTextboxX);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_ParserTextBoxX",   Sc_DialogOptionsRendering_SetParserTextboxX);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_ParserTextBoxY",   Sc_DialogOptionsRendering_GetParserTextboxY);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_ParserTextBoxY",   Sc_DialogOptionsRendering_SetParserTextboxY);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_ParserTextBoxWidth", Sc_DialogOptionsRendering_GetParserTextboxWidth);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_ParserTextBoxWidth", Sc_DialogOptionsRendering_SetParserTextboxWidth);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_Surface",          Sc_DialogOptionsRendering_GetSurface);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_Width",            Sc_DialogOptionsRendering_GetWidth);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_Width",            Sc_DialogOptionsRendering_SetWidth);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_X",                Sc_DialogOptionsRendering_GetX);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_X",                Sc_DialogOptionsRendering_SetX);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_Y",                Sc_DialogOptionsRendering_GetY);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_Y",                Sc_DialogOptionsRendering_SetY);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::get_HasAlphaChannel",  Sc_DialogOptionsRendering_GetHasAlphaChannel);
-    ccAddExternalObjectFunction("DialogOptionsRenderingInfo::set_HasAlphaChannel",  Sc_DialogOptionsRendering_SetHasAlphaChannel);
+    ScFnRegister dialogopt_api[] = {
+        { "DialogOptionsRenderingInfo::Update^0",             API_FN_PAIR(DialogOptionsRendering_Update) },
+        { "DialogOptionsRenderingInfo::RunActiveOption^0",    API_FN_PAIR(DialogOptionsRendering_RunActiveOption) },
+        { "DialogOptionsRenderingInfo::get_ActiveOptionID",   API_FN_PAIR(DialogOptionsRendering_GetActiveOptionID) },
+        { "DialogOptionsRenderingInfo::set_ActiveOptionID",   API_FN_PAIR(DialogOptionsRendering_SetActiveOptionID) },
+        { "DialogOptionsRenderingInfo::get_DialogToRender",   API_FN_PAIR(DialogOptionsRendering_GetDialogToRender) },
+        { "DialogOptionsRenderingInfo::get_Height",           API_FN_PAIR(DialogOptionsRendering_GetHeight) },
+        { "DialogOptionsRenderingInfo::set_Height",           API_FN_PAIR(DialogOptionsRendering_SetHeight) },
+        { "DialogOptionsRenderingInfo::get_ParserTextBoxX",   API_FN_PAIR(DialogOptionsRendering_GetParserTextboxX) },
+        { "DialogOptionsRenderingInfo::set_ParserTextBoxX",   API_FN_PAIR(DialogOptionsRendering_SetParserTextboxX) },
+        { "DialogOptionsRenderingInfo::get_ParserTextBoxY",   API_FN_PAIR(DialogOptionsRendering_GetParserTextboxY) },
+        { "DialogOptionsRenderingInfo::set_ParserTextBoxY",   API_FN_PAIR(DialogOptionsRendering_SetParserTextboxY) },
+        { "DialogOptionsRenderingInfo::get_ParserTextBoxWidth", API_FN_PAIR(DialogOptionsRendering_GetParserTextboxWidth) },
+        { "DialogOptionsRenderingInfo::set_ParserTextBoxWidth", API_FN_PAIR(DialogOptionsRendering_SetParserTextboxWidth) },
+        { "DialogOptionsRenderingInfo::get_Surface",          API_FN_PAIR(DialogOptionsRendering_GetSurface) },
+        { "DialogOptionsRenderingInfo::get_Width",            API_FN_PAIR(DialogOptionsRendering_GetWidth) },
+        { "DialogOptionsRenderingInfo::set_Width",            API_FN_PAIR(DialogOptionsRendering_SetWidth) },
+        { "DialogOptionsRenderingInfo::get_X",                API_FN_PAIR(DialogOptionsRendering_GetX) },
+        { "DialogOptionsRenderingInfo::set_X",                API_FN_PAIR(DialogOptionsRendering_SetX) },
+        { "DialogOptionsRenderingInfo::get_Y",                API_FN_PAIR(DialogOptionsRendering_GetY) },
+        { "DialogOptionsRenderingInfo::set_Y",                API_FN_PAIR(DialogOptionsRendering_SetY) },
+        { "DialogOptionsRenderingInfo::get_HasAlphaChannel",  API_FN_PAIR(DialogOptionsRendering_GetHasAlphaChannel) },
+        { "DialogOptionsRenderingInfo::set_HasAlphaChannel",  API_FN_PAIR(DialogOptionsRendering_SetHasAlphaChannel) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_ActiveOptionID",   (void*)DialogOptionsRendering_GetActiveOptionID);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_ActiveOptionID",   (void*)DialogOptionsRendering_SetActiveOptionID);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_DialogToRender",   (void*)DialogOptionsRendering_GetDialogToRender);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_Height",           (void*)DialogOptionsRendering_GetHeight);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_Height",           (void*)DialogOptionsRendering_SetHeight);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_ParserTextBoxX",   (void*)DialogOptionsRendering_GetParserTextboxX);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_ParserTextBoxX",   (void*)DialogOptionsRendering_SetParserTextboxX);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_ParserTextBoxY",   (void*)DialogOptionsRendering_GetParserTextboxY);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_ParserTextBoxY",   (void*)DialogOptionsRendering_SetParserTextboxY);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_ParserTextBoxWidth", (void*)DialogOptionsRendering_GetParserTextboxWidth);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_ParserTextBoxWidth", (void*)DialogOptionsRendering_SetParserTextboxWidth);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_Surface",          (void*)DialogOptionsRendering_GetSurface);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_Width",            (void*)DialogOptionsRendering_GetWidth);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_Width",            (void*)DialogOptionsRendering_SetWidth);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_X",                (void*)DialogOptionsRendering_GetX);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_X",                (void*)DialogOptionsRendering_SetX);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::get_Y",                (void*)DialogOptionsRendering_GetY);
-    ccAddExternalFunctionForPlugin("DialogOptionsRenderingInfo::set_Y",                (void*)DialogOptionsRendering_SetY);
+    ccAddExternalFunctions(dialogopt_api);
 }

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -604,55 +604,35 @@ void ScPl_DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, i
 
 void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
-    ccAddExternalObjectFunction("DrawingSurface::Clear^1",              Sc_DrawingSurface_Clear);
-    ccAddExternalObjectFunction("DrawingSurface::CreateCopy^0",         Sc_DrawingSurface_CreateCopy);
-    ccAddExternalObjectFunction("DrawingSurface::DrawCircle^3",         Sc_DrawingSurface_DrawCircle);
-    ccAddExternalObjectFunction("DrawingSurface::DrawImage^6",          Sc_DrawingSurface_DrawImage6);
-    ccAddExternalObjectFunction("DrawingSurface::DrawImage^10",         Sc_DrawingSurface_DrawImage);
-    ccAddExternalObjectFunction("DrawingSurface::DrawLine^5",           Sc_DrawingSurface_DrawLine);
-    ccAddExternalObjectFunction("DrawingSurface::DrawMessageWrapped^5", Sc_DrawingSurface_DrawMessageWrapped);
-    ccAddExternalObjectFunction("DrawingSurface::DrawPixel^2",          Sc_DrawingSurface_DrawPixel);
-    ccAddExternalObjectFunction("DrawingSurface::DrawRectangle^4",      Sc_DrawingSurface_DrawRectangle);
-    ccAddExternalObjectFunction("DrawingSurface::DrawString^104",       Sc_DrawingSurface_DrawString);
-    if (base_api < kScriptAPI_v350)
-        ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped_Old);
-    else
-        ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped);
-    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^2",        Sc_DrawingSurface_DrawSurface2);
-    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^10",       Sc_DrawingSurface_DrawSurface);
-    ccAddExternalObjectFunction("DrawingSurface::DrawTriangle^6",       Sc_DrawingSurface_DrawTriangle);
-    ccAddExternalObjectFunction("DrawingSurface::GetPixel^2",           Sc_DrawingSurface_GetPixel);
-    ccAddExternalObjectFunction("DrawingSurface::Release^0",            Sc_DrawingSurface_Release);
-    ccAddExternalObjectFunction("DrawingSurface::get_DrawingColor",     Sc_DrawingSurface_GetDrawingColor);
-    ccAddExternalObjectFunction("DrawingSurface::set_DrawingColor",     Sc_DrawingSurface_SetDrawingColor);
-    ccAddExternalObjectFunction("DrawingSurface::get_Height",           Sc_DrawingSurface_GetHeight);
-    ccAddExternalObjectFunction("DrawingSurface::get_UseHighResCoordinates", Sc_DrawingSurface_GetUseHighResCoordinates);
-    ccAddExternalObjectFunction("DrawingSurface::set_UseHighResCoordinates", Sc_DrawingSurface_SetUseHighResCoordinates);
-    ccAddExternalObjectFunction("DrawingSurface::get_Width",            Sc_DrawingSurface_GetWidth);
+    ScFnRegister drawsurf_api[] = {
+        { "DrawingSurface::Clear^1",              API_FN_PAIR(DrawingSurface_Clear) },
+        { "DrawingSurface::CreateCopy^0",         API_FN_PAIR(DrawingSurface_CreateCopy) },
+        { "DrawingSurface::DrawCircle^3",         API_FN_PAIR(DrawingSurface_DrawCircle) },
+        { "DrawingSurface::DrawImage^6",          API_FN_PAIR(DrawingSurface_DrawImage6) },
+        { "DrawingSurface::DrawImage^10",         API_FN_PAIR(DrawingSurface_DrawImage) },
+        { "DrawingSurface::DrawLine^5",           API_FN_PAIR(DrawingSurface_DrawLine) },
+        { "DrawingSurface::DrawMessageWrapped^5", API_FN_PAIR(DrawingSurface_DrawMessageWrapped) },
+        { "DrawingSurface::DrawPixel^2",          API_FN_PAIR(DrawingSurface_DrawPixel) },
+        { "DrawingSurface::DrawRectangle^4",      API_FN_PAIR(DrawingSurface_DrawRectangle) },
+        { "DrawingSurface::DrawString^104",       Sc_DrawingSurface_DrawString, ScPl_DrawingSurface_DrawString },
+        { "DrawingSurface::DrawSurface^2",        API_FN_PAIR(DrawingSurface_DrawSurface2) },
+        { "DrawingSurface::DrawSurface^10",       API_FN_PAIR(DrawingSurface_DrawSurface) },
+        { "DrawingSurface::DrawTriangle^6",       API_FN_PAIR(DrawingSurface_DrawTriangle) },
+        { "DrawingSurface::GetPixel^2",           API_FN_PAIR(DrawingSurface_GetPixel) },
+        { "DrawingSurface::Release^0",            API_FN_PAIR(DrawingSurface_Release) },
+        { "DrawingSurface::get_DrawingColor",     API_FN_PAIR(DrawingSurface_GetDrawingColor) },
+        { "DrawingSurface::set_DrawingColor",     API_FN_PAIR(DrawingSurface_SetDrawingColor) },
+        { "DrawingSurface::get_Height",           API_FN_PAIR(DrawingSurface_GetHeight) },
+        { "DrawingSurface::get_UseHighResCoordinates", API_FN_PAIR(DrawingSurface_GetUseHighResCoordinates) },
+        { "DrawingSurface::set_UseHighResCoordinates", API_FN_PAIR(DrawingSurface_SetUseHighResCoordinates) },
+        { "DrawingSurface::get_Width",            API_FN_PAIR(DrawingSurface_GetWidth) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+    ccAddExternalFunctions(drawsurf_api);
 
-    ccAddExternalFunctionForPlugin("DrawingSurface::Clear^1",              (void*)DrawingSurface_Clear);
-    ccAddExternalFunctionForPlugin("DrawingSurface::CreateCopy^0",         (void*)DrawingSurface_CreateCopy);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawCircle^3",         (void*)DrawingSurface_DrawCircle);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawImage^6",          (void*)DrawingSurface_DrawImage);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawLine^5",           (void*)DrawingSurface_DrawLine);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawMessageWrapped^5", (void*)DrawingSurface_DrawMessageWrapped);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawPixel^2",          (void*)DrawingSurface_DrawPixel);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawRectangle^4",      (void*)DrawingSurface_DrawRectangle);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawString^104",       (void*)ScPl_DrawingSurface_DrawString);
+    // Few functions have to be selected based on API level
     if (base_api < kScriptAPI_v350)
-        ccAddExternalFunctionForPlugin("DrawingSurface::DrawStringWrapped^6", (void*)DrawingSurface_DrawStringWrapped_Old);
+        ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", API_FN_PAIR(DrawingSurface_DrawStringWrapped_Old));
     else
-        ccAddExternalFunctionForPlugin("DrawingSurface::DrawStringWrapped^6", (void*)DrawingSurface_DrawStringWrapped);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawSurface^2",        (void*)DrawingSurface_DrawSurface);
-    ccAddExternalFunctionForPlugin("DrawingSurface::DrawTriangle^6",       (void*)DrawingSurface_DrawTriangle);
-    ccAddExternalFunctionForPlugin("DrawingSurface::GetPixel^2",           (void*)DrawingSurface_GetPixel);
-    ccAddExternalFunctionForPlugin("DrawingSurface::Release^0",            (void*)DrawingSurface_Release);
-    ccAddExternalFunctionForPlugin("DrawingSurface::get_DrawingColor",     (void*)DrawingSurface_GetDrawingColor);
-    ccAddExternalFunctionForPlugin("DrawingSurface::set_DrawingColor",     (void*)DrawingSurface_SetDrawingColor);
-    ccAddExternalFunctionForPlugin("DrawingSurface::get_Height",           (void*)DrawingSurface_GetHeight);
-    ccAddExternalFunctionForPlugin("DrawingSurface::get_UseHighResCoordinates", (void*)DrawingSurface_GetUseHighResCoordinates);
-    ccAddExternalFunctionForPlugin("DrawingSurface::set_UseHighResCoordinates", (void*)DrawingSurface_SetUseHighResCoordinates);
-    ccAddExternalFunctionForPlugin("DrawingSurface::get_Width",            (void*)DrawingSurface_GetWidth);
+        ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", API_FN_PAIR(DrawingSurface_DrawStringWrapped));
 }

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -591,7 +591,7 @@ RuntimeScriptValue Sc_DrawingSurface_GetWidth(void *self, const RuntimeScriptVal
 
 //=============================================================================
 //
-// Exclusive API for Plugins
+// Exclusive variadic API implementation for Plugins
 //
 //=============================================================================
 

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -200,7 +200,7 @@ void DrawingSurface_DrawImageImpl(ScriptDrawingSurface* sds, Bitmap* src,
         delete src;
 }
 
-void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds,
+void DrawingSurface_DrawImage(ScriptDrawingSurface* sds,
     int dst_x, int dst_y, int slot, int trans,
     int dst_width, int dst_height,
     int src_x, int src_y, int src_width, int src_height)
@@ -211,12 +211,12 @@ void DrawingSurface_DrawImageEx(ScriptDrawingSurface* sds,
         src_x, src_y, src_width, src_height, slot, (game.SpriteInfos[slot].Flags & SPF_ALPHACHANNEL) != 0);
 }
 
-void DrawingSurface_DrawImage(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
+void DrawingSurface_DrawImage6(ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
 {
-    DrawingSurface_DrawImageEx(sds, xx, yy, slot, trans, width, height, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
+    DrawingSurface_DrawImage(sds, xx, yy, slot, trans, width, height, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
 }
 
-void DrawingSurface_DrawSurfaceEx(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans,
+void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans,
     int dst_x, int dst_y, int dst_width, int dst_height,
     int src_x, int src_y, int src_width, int src_height)
 {
@@ -224,9 +224,9 @@ void DrawingSurface_DrawSurfaceEx(ScriptDrawingSurface* target, ScriptDrawingSur
         src_x, src_y, src_width, src_height, -1, source->hasAlphaChannel != 0);
 }
 
-void DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans)
+void DrawingSurface_DrawSurface2(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans)
 {
-    DrawingSurface_DrawSurfaceEx(target, source, trans, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
+    DrawingSurface_DrawSurface(target, source, trans, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE, 0, 0, SCR_NO_VALUE, SCR_NO_VALUE);
 }
 
 void DrawingSurface_SetDrawingColor(ScriptDrawingSurface *sds, int newColour) 
@@ -464,15 +464,15 @@ RuntimeScriptValue Sc_DrawingSurface_DrawCircle(void *self, const RuntimeScriptV
 }
 
 // void (ScriptDrawingSurface* sds, int xx, int yy, int slot, int trans, int width, int height)
-RuntimeScriptValue Sc_DrawingSurface_DrawImage_6(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_DrawingSurface_DrawImage6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT6(ScriptDrawingSurface, DrawingSurface_DrawImage);
+    API_OBJCALL_VOID_PINT6(ScriptDrawingSurface, DrawingSurface_DrawImage6);
 }
 
 RuntimeScriptValue Sc_DrawingSurface_DrawImage(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     ASSERT_OBJ_PARAM_COUNT(METHOD, 10);
-    DrawingSurface_DrawImageEx((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue,
+    DrawingSurface_DrawImage((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue,
         params[6].IValue, params[7].IValue, params[8].IValue, params[9].IValue);
     return RuntimeScriptValue((int32_t)0);
 }
@@ -521,15 +521,15 @@ RuntimeScriptValue Sc_DrawingSurface_DrawStringWrapped(void *self, const Runtime
 }
 
 // void (ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev)
-RuntimeScriptValue Sc_DrawingSurface_DrawSurface_2(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_DrawingSurface_DrawSurface2(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_POBJ_PINT(ScriptDrawingSurface, DrawingSurface_DrawSurface, ScriptDrawingSurface);
+    API_OBJCALL_VOID_POBJ_PINT(ScriptDrawingSurface, DrawingSurface_DrawSurface2, ScriptDrawingSurface);
 }
 
 RuntimeScriptValue Sc_DrawingSurface_DrawSurface(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     ASSERT_OBJ_PARAM_COUNT(METHOD, 10);
-    DrawingSurface_DrawSurfaceEx((ScriptDrawingSurface*)self, (ScriptDrawingSurface*)params[0].Ptr,
+    DrawingSurface_DrawSurface((ScriptDrawingSurface*)self, (ScriptDrawingSurface*)params[0].Ptr,
         params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue, params[5].IValue,
         params[6].IValue, params[7].IValue, params[8].IValue, params[9].IValue);
     return RuntimeScriptValue((int32_t)0);
@@ -607,7 +607,7 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*com
     ccAddExternalObjectFunction("DrawingSurface::Clear^1",              Sc_DrawingSurface_Clear);
     ccAddExternalObjectFunction("DrawingSurface::CreateCopy^0",         Sc_DrawingSurface_CreateCopy);
     ccAddExternalObjectFunction("DrawingSurface::DrawCircle^3",         Sc_DrawingSurface_DrawCircle);
-    ccAddExternalObjectFunction("DrawingSurface::DrawImage^6",          Sc_DrawingSurface_DrawImage_6);
+    ccAddExternalObjectFunction("DrawingSurface::DrawImage^6",          Sc_DrawingSurface_DrawImage6);
     ccAddExternalObjectFunction("DrawingSurface::DrawImage^10",         Sc_DrawingSurface_DrawImage);
     ccAddExternalObjectFunction("DrawingSurface::DrawLine^5",           Sc_DrawingSurface_DrawLine);
     ccAddExternalObjectFunction("DrawingSurface::DrawMessageWrapped^5", Sc_DrawingSurface_DrawMessageWrapped);
@@ -618,7 +618,7 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*com
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped_Old);
     else
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", Sc_DrawingSurface_DrawStringWrapped);
-    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^2",        Sc_DrawingSurface_DrawSurface_2);
+    ccAddExternalObjectFunction("DrawingSurface::DrawSurface^2",        Sc_DrawingSurface_DrawSurface2);
     ccAddExternalObjectFunction("DrawingSurface::DrawSurface^10",       Sc_DrawingSurface_DrawSurface);
     ccAddExternalObjectFunction("DrawingSurface::DrawTriangle^6",       Sc_DrawingSurface_DrawTriangle);
     ccAddExternalObjectFunction("DrawingSurface::GetPixel^2",           Sc_DrawingSurface_GetPixel);

--- a/Engine/ac/drawingsurface.h
+++ b/Engine/ac/drawingsurface.h
@@ -23,7 +23,9 @@
 void	DrawingSurface_Release(ScriptDrawingSurface* sds);
 // convert actual co-ordinate back to what the script is expecting
 ScriptDrawingSurface* DrawingSurface_CreateCopy(ScriptDrawingSurface *sds);
-void	DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev);
+void    DrawingSurface_DrawSurface(ScriptDrawingSurface* target, ScriptDrawingSurface* source, int trans,
+    int dst_x, int dst_y, int dst_width, int dst_height,
+    int src_x, int src_y, int src_width, int src_height);
 void	DrawingSurface_SetDrawingColor(ScriptDrawingSurface *sds, int newColour);
 int		DrawingSurface_GetDrawingColor(ScriptDrawingSurface *sds);
 void	DrawingSurface_SetUseHighResCoordinates(ScriptDrawingSurface *sds, int highRes);

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -628,51 +628,31 @@ RuntimeScriptValue Sc_DynamicSprite_CreateFromScreenShot(const RuntimeScriptValu
 
 void RegisterDynamicSpriteAPI()
 {
-    ccAddExternalObjectFunction("DynamicSprite::ChangeCanvasSize^4",        Sc_DynamicSprite_ChangeCanvasSize);
-    ccAddExternalObjectFunction("DynamicSprite::CopyTransparencyMask^1",    Sc_DynamicSprite_CopyTransparencyMask);
-    ccAddExternalObjectFunction("DynamicSprite::Crop^4",                    Sc_DynamicSprite_Crop);
-    ccAddExternalObjectFunction("DynamicSprite::Delete",                    Sc_DynamicSprite_Delete);
-    ccAddExternalObjectFunction("DynamicSprite::Flip^1",                    Sc_DynamicSprite_Flip);
-    ccAddExternalObjectFunction("DynamicSprite::GetDrawingSurface^0",       Sc_DynamicSprite_GetDrawingSurface);
-    ccAddExternalObjectFunction("DynamicSprite::Resize^2",                  Sc_DynamicSprite_Resize);
-    ccAddExternalObjectFunction("DynamicSprite::Rotate^3",                  Sc_DynamicSprite_Rotate);
-    ccAddExternalObjectFunction("DynamicSprite::SaveToFile^1",              Sc_DynamicSprite_SaveToFile);
-    ccAddExternalObjectFunction("DynamicSprite::Tint^5",                    Sc_DynamicSprite_Tint);
-    ccAddExternalObjectFunction("DynamicSprite::get_ColorDepth",            Sc_DynamicSprite_GetColorDepth);
-    ccAddExternalObjectFunction("DynamicSprite::get_Graphic",               Sc_DynamicSprite_GetGraphic);
-    ccAddExternalObjectFunction("DynamicSprite::get_Height",                Sc_DynamicSprite_GetHeight);
-    ccAddExternalObjectFunction("DynamicSprite::get_Width",                 Sc_DynamicSprite_GetWidth);
-    ccAddExternalStaticFunction("DynamicSprite::Create^3",                  Sc_DynamicSprite_Create);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromBackground",      Sc_DynamicSprite_CreateFromBackground);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromDrawingSurface^5", Sc_DynamicSprite_CreateFromDrawingSurface);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromExistingSprite^1", Sc_DynamicSprite_CreateFromExistingSprite_Old);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromExistingSprite^2", Sc_DynamicSprite_CreateFromExistingSprite);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromFile",            Sc_DynamicSprite_CreateFromFile);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromSaveGame",        Sc_DynamicSprite_CreateFromSaveGame);
-    ccAddExternalStaticFunction("DynamicSprite::CreateFromScreenShot",      Sc_DynamicSprite_CreateFromScreenShot);
+    ScFnRegister dynsprite_api[] = {
+        { "DynamicSprite::Create^3",                  API_FN_PAIR(DynamicSprite_Create) },
+        { "DynamicSprite::CreateFromBackground",      API_FN_PAIR(DynamicSprite_CreateFromBackground) },
+        { "DynamicSprite::CreateFromDrawingSurface^5", API_FN_PAIR(DynamicSprite_CreateFromDrawingSurface) },
+        { "DynamicSprite::CreateFromExistingSprite^1", API_FN_PAIR(DynamicSprite_CreateFromExistingSprite_Old) },
+        { "DynamicSprite::CreateFromExistingSprite^2", API_FN_PAIR(DynamicSprite_CreateFromExistingSprite) },
+        { "DynamicSprite::CreateFromFile",            API_FN_PAIR(DynamicSprite_CreateFromFile) },
+        { "DynamicSprite::CreateFromSaveGame",        API_FN_PAIR(DynamicSprite_CreateFromSaveGame) },
+        { "DynamicSprite::CreateFromScreenShot",      API_FN_PAIR(DynamicSprite_CreateFromScreenShot) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "DynamicSprite::ChangeCanvasSize^4",        API_FN_PAIR(DynamicSprite_ChangeCanvasSize) },
+        { "DynamicSprite::CopyTransparencyMask^1",    API_FN_PAIR(DynamicSprite_CopyTransparencyMask) },
+        { "DynamicSprite::Crop^4",                    API_FN_PAIR(DynamicSprite_Crop) },
+        { "DynamicSprite::Delete",                    API_FN_PAIR(DynamicSprite_Delete) },
+        { "DynamicSprite::Flip^1",                    API_FN_PAIR(DynamicSprite_Flip) },
+        { "DynamicSprite::GetDrawingSurface^0",       API_FN_PAIR(DynamicSprite_GetDrawingSurface) },
+        { "DynamicSprite::Resize^2",                  API_FN_PAIR(DynamicSprite_Resize) },
+        { "DynamicSprite::Rotate^3",                  API_FN_PAIR(DynamicSprite_Rotate) },
+        { "DynamicSprite::SaveToFile^1",              API_FN_PAIR(DynamicSprite_SaveToFile) },
+        { "DynamicSprite::Tint^5",                    API_FN_PAIR(DynamicSprite_Tint) },
+        { "DynamicSprite::get_ColorDepth",            API_FN_PAIR(DynamicSprite_GetColorDepth) },
+        { "DynamicSprite::get_Graphic",               API_FN_PAIR(DynamicSprite_GetGraphic) },
+        { "DynamicSprite::get_Height",                API_FN_PAIR(DynamicSprite_GetHeight) },
+        { "DynamicSprite::get_Width",                 API_FN_PAIR(DynamicSprite_GetWidth) },
+    };
 
-    ccAddExternalFunctionForPlugin("DynamicSprite::ChangeCanvasSize^4",        (void*)DynamicSprite_ChangeCanvasSize);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CopyTransparencyMask^1",    (void*)DynamicSprite_CopyTransparencyMask);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Crop^4",                    (void*)DynamicSprite_Crop);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Delete",                    (void*)DynamicSprite_Delete);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Flip^1",                    (void*)DynamicSprite_Flip);
-    ccAddExternalFunctionForPlugin("DynamicSprite::GetDrawingSurface^0",       (void*)DynamicSprite_GetDrawingSurface);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Resize^2",                  (void*)DynamicSprite_Resize);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Rotate^3",                  (void*)DynamicSprite_Rotate);
-    ccAddExternalFunctionForPlugin("DynamicSprite::SaveToFile^1",              (void*)DynamicSprite_SaveToFile);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Tint^5",                    (void*)DynamicSprite_Tint);
-    ccAddExternalFunctionForPlugin("DynamicSprite::get_ColorDepth",            (void*)DynamicSprite_GetColorDepth);
-    ccAddExternalFunctionForPlugin("DynamicSprite::get_Graphic",               (void*)DynamicSprite_GetGraphic);
-    ccAddExternalFunctionForPlugin("DynamicSprite::get_Height",                (void*)DynamicSprite_GetHeight);
-    ccAddExternalFunctionForPlugin("DynamicSprite::get_Width",                 (void*)DynamicSprite_GetWidth);
-    ccAddExternalFunctionForPlugin("DynamicSprite::Create^3",                  (void*)DynamicSprite_Create);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromBackground",      (void*)DynamicSprite_CreateFromBackground);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromDrawingSurface^5", (void*)DynamicSprite_CreateFromDrawingSurface);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromExistingSprite^1", (void*)DynamicSprite_CreateFromExistingSprite_Old);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromExistingSprite^2", (void*)DynamicSprite_CreateFromExistingSprite);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromFile",            (void*)DynamicSprite_CreateFromFile);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromSaveGame",        (void*)DynamicSprite_CreateFromSaveGame);
-    ccAddExternalFunctionForPlugin("DynamicSprite::CreateFromScreenShot",      (void*)DynamicSprite_CreateFromScreenShot);
+    ccAddExternalFunctions(dynsprite_api);
 }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -750,44 +750,29 @@ RuntimeScriptValue Sc_File_GetPosition(void *self, const RuntimeScriptValue *par
 
 void RegisterFileAPI()
 {
-    ccAddExternalStaticFunction("File::Delete^1",           Sc_File_Delete);
-    ccAddExternalStaticFunction("File::Exists^1",           Sc_File_Exists);
-    ccAddExternalStaticFunction("File::Open^2",             Sc_sc_OpenFile);
-    ccAddExternalObjectFunction("File::Close^0",            Sc_File_Close);
-    ccAddExternalObjectFunction("File::ReadInt^0",          Sc_File_ReadInt);
-    ccAddExternalObjectFunction("File::ReadRawChar^0",      Sc_File_ReadRawChar);
-    ccAddExternalObjectFunction("File::ReadRawInt^0",       Sc_File_ReadRawInt);
-    ccAddExternalObjectFunction("File::ReadRawLine^1",      Sc_File_ReadRawLine);
-    ccAddExternalObjectFunction("File::ReadRawLineBack^0",  Sc_File_ReadRawLineBack);
-    ccAddExternalObjectFunction("File::ReadString^1",       Sc_File_ReadString);
-    ccAddExternalObjectFunction("File::ReadStringBack^0",   Sc_File_ReadStringBack);
-    ccAddExternalObjectFunction("File::WriteInt^1",         Sc_File_WriteInt);
-    ccAddExternalObjectFunction("File::WriteRawChar^1",     Sc_File_WriteRawChar);
-    ccAddExternalObjectFunction("File::WriteRawInt^1",      Sc_File_WriteRawInt);
-    ccAddExternalObjectFunction("File::WriteRawLine^1",     Sc_File_WriteRawLine);
-    ccAddExternalObjectFunction("File::WriteString^1",      Sc_File_WriteString);
-    ccAddExternalObjectFunction("File::Seek^2",             Sc_File_Seek);
-    ccAddExternalObjectFunction("File::get_EOF",            Sc_File_GetEOF);
-    ccAddExternalObjectFunction("File::get_Error",          Sc_File_GetError);
-    ccAddExternalObjectFunction("File::get_Position",       Sc_File_GetPosition);
+    ScFnRegister file_api[] = {
+        { "File::Delete^1",           API_FN_PAIR(File_Delete) },
+        { "File::Exists^1",           API_FN_PAIR(File_Exists) },
+        { "File::Open^2",             API_FN_PAIR(sc_OpenFile) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "File::Close^0",            API_FN_PAIR(File_Close) },
+        { "File::ReadInt^0",          API_FN_PAIR(File_ReadInt) },
+        { "File::ReadRawChar^0",      API_FN_PAIR(File_ReadRawChar) },
+        { "File::ReadRawInt^0",       API_FN_PAIR(File_ReadRawInt) },
+        { "File::ReadRawLine^1",      API_FN_PAIR(File_ReadRawLine) },
+        { "File::ReadRawLineBack^0",  API_FN_PAIR(File_ReadRawLineBack) },
+        { "File::ReadString^1",       API_FN_PAIR(File_ReadString) },
+        { "File::ReadStringBack^0",   API_FN_PAIR(File_ReadStringBack) },
+        { "File::WriteInt^1",         API_FN_PAIR(File_WriteInt) },
+        { "File::WriteRawChar^1",     API_FN_PAIR(File_WriteRawChar) },
+        { "File::WriteRawInt^1",      API_FN_PAIR(File_WriteRawInt) },
+        { "File::WriteRawLine^1",     API_FN_PAIR(File_WriteRawLine) },
+        { "File::WriteString^1",      API_FN_PAIR(File_WriteString) },
+        { "File::Seek^2",             API_FN_PAIR(File_Seek) },
+        { "File::get_EOF",            API_FN_PAIR(File_GetEOF) },
+        { "File::get_Error",          API_FN_PAIR(File_GetError) },
+        { "File::get_Position",       API_FN_PAIR(File_GetPosition) },
+    };
 
-    ccAddExternalFunctionForPlugin("File::Delete^1",           (void*)File_Delete);
-    ccAddExternalFunctionForPlugin("File::Exists^1",           (void*)File_Exists);
-    ccAddExternalFunctionForPlugin("File::Open^2",             (void*)sc_OpenFile);
-    ccAddExternalFunctionForPlugin("File::Close^0",            (void*)File_Close);
-    ccAddExternalFunctionForPlugin("File::ReadInt^0",          (void*)File_ReadInt);
-    ccAddExternalFunctionForPlugin("File::ReadRawChar^0",      (void*)File_ReadRawChar);
-    ccAddExternalFunctionForPlugin("File::ReadRawInt^0",       (void*)File_ReadRawInt);
-    ccAddExternalFunctionForPlugin("File::ReadRawLine^1",      (void*)File_ReadRawLine);
-    ccAddExternalFunctionForPlugin("File::ReadRawLineBack^0",  (void*)File_ReadRawLineBack);
-    ccAddExternalFunctionForPlugin("File::ReadString^1",       (void*)File_ReadString);
-    ccAddExternalFunctionForPlugin("File::ReadStringBack^0",   (void*)File_ReadStringBack);
-    ccAddExternalFunctionForPlugin("File::WriteInt^1",         (void*)File_WriteInt);
-    ccAddExternalFunctionForPlugin("File::WriteRawChar^1",     (void*)File_WriteRawChar);
-    ccAddExternalFunctionForPlugin("File::WriteRawLine^1",     (void*)File_WriteRawLine);
-    ccAddExternalFunctionForPlugin("File::WriteString^1",      (void*)File_WriteString);
-    ccAddExternalFunctionForPlugin("File::get_EOF",            (void*)File_GetEOF);
-    ccAddExternalFunctionForPlugin("File::get_Error",          (void*)File_GetError);
+    ccAddExternalFunctions(file_api);
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -789,6 +789,11 @@ bool Game_ChangeSpeechVox(const char *newFilename)
     return true;
 }
 
+int Game_GetAudioClipCount()
+{
+    return game.audioClips.size();
+}
+
 ScriptAudioClip *Game_GetAudioClip(int index)
 {
     if (index < 0 || (size_t)index >= game.audioClips.size())
@@ -1837,7 +1842,7 @@ RuntimeScriptValue Sc_Game_GetViewCount(const RuntimeScriptValue *params, int32_
 
 RuntimeScriptValue Sc_Game_GetAudioClipCount(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(game.audioClips.size());
+    API_SCALL_INT(Game_GetAudioClipCount);
 }
 
 RuntimeScriptValue Sc_Game_GetAudioClip(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1887,114 +1887,67 @@ RuntimeScriptValue Sc_Game_BlockingWaitSkipped(const RuntimeScriptValue *params,
 
 void RegisterGameAPI()
 {
-    ccAddExternalStaticFunction("Game::IsAudioPlaying^1",                       Sc_Game_IsAudioPlaying);
-    ccAddExternalStaticFunction("Game::SetAudioTypeSpeechVolumeDrop^2",         Sc_Game_SetAudioTypeSpeechVolumeDrop);
-    ccAddExternalStaticFunction("Game::SetAudioTypeVolume^3",                   Sc_Game_SetAudioTypeVolume);
-    ccAddExternalStaticFunction("Game::StopAudio^1",                            Sc_Game_StopAudio);
-    ccAddExternalStaticFunction("Game::ChangeTranslation^1",                    Sc_Game_ChangeTranslation);
-    ccAddExternalStaticFunction("Game::DoOnceOnly^1",                           Sc_Game_DoOnceOnly);
-    ccAddExternalStaticFunction("Game::GetColorFromRGB^3",                      Sc_Game_GetColorFromRGB);
-    ccAddExternalStaticFunction("Game::GetFrameCountForLoop^2",                 Sc_Game_GetFrameCountForLoop);
-    ccAddExternalStaticFunction("Game::GetLocationName^2",                      Sc_Game_GetLocationName);
-    ccAddExternalStaticFunction("Game::GetLoopCountForView^1",                  Sc_Game_GetLoopCountForView);
-    ccAddExternalStaticFunction("Game::GetMODPattern^0",                        Sc_Game_GetMODPattern);
-    ccAddExternalStaticFunction("Game::GetRunNextSettingForLoop^2",             Sc_Game_GetRunNextSettingForLoop);
-    ccAddExternalStaticFunction("Game::GetSaveSlotDescription^1",               Sc_Game_GetSaveSlotDescription);
-    ccAddExternalStaticFunction("Game::GetViewFrame^3",                         Sc_Game_GetViewFrame);
-    ccAddExternalStaticFunction("Game::InputBox^1",                             Sc_Game_InputBox);
-    ccAddExternalStaticFunction("Game::SetSaveGameDirectory^1",                 Sc_Game_SetSaveGameDirectory);
-    ccAddExternalStaticFunction("Game::StopSound^1",                            Sc_StopAllSounds);
-    ccAddExternalStaticFunction("Game::get_CharacterCount",                     Sc_Game_GetCharacterCount);
-    ccAddExternalStaticFunction("Game::get_DialogCount",                        Sc_Game_GetDialogCount);
-    ccAddExternalStaticFunction("Game::get_FileName",                           Sc_Game_GetFileName);
-    ccAddExternalStaticFunction("Game::get_FontCount",                          Sc_Game_GetFontCount);
-    ccAddExternalStaticFunction("Game::geti_GlobalMessages",                    Sc_Game_GetGlobalMessages);
-    ccAddExternalStaticFunction("Game::geti_GlobalStrings",                     Sc_Game_GetGlobalStrings);
-    ccAddExternalStaticFunction("Game::seti_GlobalStrings",                     Sc_SetGlobalString);
-    ccAddExternalStaticFunction("Game::get_GUICount",                           Sc_Game_GetGUICount);
-    ccAddExternalStaticFunction("Game::get_IgnoreUserInputAfterTextTimeoutMs",  Sc_Game_GetIgnoreUserInputAfterTextTimeoutMs);
-    ccAddExternalStaticFunction("Game::set_IgnoreUserInputAfterTextTimeoutMs",  Sc_Game_SetIgnoreUserInputAfterTextTimeoutMs);
-    ccAddExternalStaticFunction("Game::get_InSkippableCutscene",                Sc_Game_GetInSkippableCutscene);
-    ccAddExternalStaticFunction("Game::get_InventoryItemCount",                 Sc_Game_GetInventoryItemCount);
-    ccAddExternalStaticFunction("Game::get_MinimumTextDisplayTimeMs",           Sc_Game_GetMinimumTextDisplayTimeMs);
-    ccAddExternalStaticFunction("Game::set_MinimumTextDisplayTimeMs",           Sc_Game_SetMinimumTextDisplayTimeMs);
-    ccAddExternalStaticFunction("Game::get_MouseCursorCount",                   Sc_Game_GetMouseCursorCount);
-    ccAddExternalStaticFunction("Game::get_Name",                               Sc_Game_GetName);
-    ccAddExternalStaticFunction("Game::set_Name",                               Sc_Game_SetName);
-    ccAddExternalStaticFunction("Game::get_NormalFont",                         Sc_Game_GetNormalFont);
-    ccAddExternalStaticFunction("Game::set_NormalFont",                         Sc_SetNormalFont);
-    ccAddExternalStaticFunction("Game::get_SkippingCutscene",                   Sc_Game_GetSkippingCutscene);
-    ccAddExternalStaticFunction("Game::get_SpeechFont",                         Sc_Game_GetSpeechFont);
-    ccAddExternalStaticFunction("Game::set_SpeechFont",                         Sc_SetSpeechFont);
-    ccAddExternalStaticFunction("Game::geti_SpriteWidth",                       Sc_Game_GetSpriteWidth);
-    ccAddExternalStaticFunction("Game::geti_SpriteHeight",                      Sc_Game_GetSpriteHeight);
-    ccAddExternalStaticFunction("Game::get_TextReadingSpeed",                   Sc_Game_GetTextReadingSpeed);
-    ccAddExternalStaticFunction("Game::set_TextReadingSpeed",                   Sc_Game_SetTextReadingSpeed);
-    ccAddExternalStaticFunction("Game::get_TranslationFilename",                Sc_Game_GetTranslationFilename);
-    ccAddExternalStaticFunction("Game::get_UseNativeCoordinates",               Sc_Game_GetUseNativeCoordinates);
-    ccAddExternalStaticFunction("Game::get_ViewCount",                          Sc_Game_GetViewCount);
-    ccAddExternalStaticFunction("Game::get_AudioClipCount",                     Sc_Game_GetAudioClipCount);
-    ccAddExternalStaticFunction("Game::geti_AudioClips",                        Sc_Game_GetAudioClip);
-    ccAddExternalStaticFunction("Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded);
-    ccAddExternalStaticFunction("Game::ChangeSpeechVox",                        Sc_Game_ChangeSpeechVox);
-    ccAddExternalStaticFunction("Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip);
-    ccAddExternalStaticFunction("Game::SimulateKeyPress",                       Sc_Game_SimulateKeyPress);
-    ccAddExternalStaticFunction("Game::get_BlockingWaitSkipped",                Sc_Game_BlockingWaitSkipped);
-    ccAddExternalStaticFunction("Game::get_SpeechVoxFilename",                  Sc_Game_GetSpeechVoxFilename);
+    ScFnRegister game_api[] = {
+        { "Game::IsAudioPlaying^1",                       API_FN_PAIR(Game_IsAudioPlaying) },
+        { "Game::SetAudioTypeSpeechVolumeDrop^2",         API_FN_PAIR(Game_SetAudioTypeSpeechVolumeDrop) },
+        { "Game::SetAudioTypeVolume^3",                   API_FN_PAIR(Game_SetAudioTypeVolume) },
+        { "Game::StopAudio^1",                            API_FN_PAIR(Game_StopAudio) },
+        { "Game::ChangeTranslation^1",                    API_FN_PAIR(Game_ChangeTranslation) },
+        { "Game::DoOnceOnly^1",                           API_FN_PAIR(Game_DoOnceOnly) },
+        { "Game::GetColorFromRGB^3",                      API_FN_PAIR(Game_GetColorFromRGB) },
+        { "Game::GetFrameCountForLoop^2",                 API_FN_PAIR(Game_GetFrameCountForLoop) },
+        { "Game::GetLocationName^2",                      API_FN_PAIR(Game_GetLocationName) },
+        { "Game::GetLoopCountForView^1",                  API_FN_PAIR(Game_GetLoopCountForView) },
+        { "Game::GetMODPattern^0",                        API_FN_PAIR(Game_GetMODPattern) },
+        { "Game::GetRunNextSettingForLoop^2",             API_FN_PAIR(Game_GetRunNextSettingForLoop) },
+        { "Game::GetSaveSlotDescription^1",               API_FN_PAIR(Game_GetSaveSlotDescription) },
+        { "Game::GetViewFrame^3",                         API_FN_PAIR(Game_GetViewFrame) },
+        { "Game::InputBox^1",                             API_FN_PAIR(Game_InputBox) },
+        { "Game::SetSaveGameDirectory^1",                 API_FN_PAIR(Game_SetSaveGameDirectory) },
+        { "Game::StopSound^1",                            API_FN_PAIR(StopAllSounds) },
+        { "Game::get_CharacterCount",                     API_FN_PAIR(Game_GetCharacterCount) },
+        { "Game::get_DialogCount",                        API_FN_PAIR(Game_GetDialogCount) },
+        { "Game::get_FileName",                           API_FN_PAIR(Game_GetFileName) },
+        { "Game::get_FontCount",                          API_FN_PAIR(Game_GetFontCount) },
+        { "Game::geti_GlobalMessages",                    API_FN_PAIR(Game_GetGlobalMessages) },
+        { "Game::geti_GlobalStrings",                     API_FN_PAIR(Game_GetGlobalStrings) },
+        { "Game::seti_GlobalStrings",                     API_FN_PAIR(SetGlobalString) },
+        { "Game::get_GUICount",                           API_FN_PAIR(Game_GetGUICount) },
+        { "Game::get_IgnoreUserInputAfterTextTimeoutMs",  API_FN_PAIR(Game_GetIgnoreUserInputAfterTextTimeoutMs) },
+        { "Game::set_IgnoreUserInputAfterTextTimeoutMs",  API_FN_PAIR(Game_SetIgnoreUserInputAfterTextTimeoutMs) },
+        { "Game::get_InSkippableCutscene",                API_FN_PAIR(Game_GetInSkippableCutscene) },
+        { "Game::get_InventoryItemCount",                 API_FN_PAIR(Game_GetInventoryItemCount) },
+        { "Game::get_MinimumTextDisplayTimeMs",           API_FN_PAIR(Game_GetMinimumTextDisplayTimeMs) },
+        { "Game::set_MinimumTextDisplayTimeMs",           API_FN_PAIR(Game_SetMinimumTextDisplayTimeMs) },
+        { "Game::get_MouseCursorCount",                   API_FN_PAIR(Game_GetMouseCursorCount) },
+        { "Game::get_Name",                               API_FN_PAIR(Game_GetName) },
+        { "Game::set_Name",                               API_FN_PAIR(Game_SetName) },
+        { "Game::get_NormalFont",                         API_FN_PAIR(Game_GetNormalFont) },
+        { "Game::set_NormalFont",                         API_FN_PAIR(SetNormalFont) },
+        { "Game::get_SkippingCutscene",                   API_FN_PAIR(Game_GetSkippingCutscene) },
+        { "Game::get_SpeechFont",                         API_FN_PAIR(Game_GetSpeechFont) },
+        { "Game::set_SpeechFont",                         API_FN_PAIR(SetSpeechFont) },
+        { "Game::geti_SpriteWidth",                       API_FN_PAIR(Game_GetSpriteWidth) },
+        { "Game::geti_SpriteHeight",                      API_FN_PAIR(Game_GetSpriteHeight) },
+        { "Game::get_TextReadingSpeed",                   API_FN_PAIR(Game_GetTextReadingSpeed) },
+        { "Game::set_TextReadingSpeed",                   API_FN_PAIR(Game_SetTextReadingSpeed) },
+        { "Game::get_TranslationFilename",                API_FN_PAIR(Game_GetTranslationFilename) },
+        { "Game::get_UseNativeCoordinates",               API_FN_PAIR(Game_GetUseNativeCoordinates) },
+        { "Game::get_ViewCount",                          API_FN_PAIR(Game_GetViewCount) },
+        { "Game::get_AudioClipCount",                     API_FN_PAIR(Game_GetAudioClipCount) },
+        { "Game::geti_AudioClips",                        API_FN_PAIR(Game_GetAudioClip) },
+        { "Game::IsPluginLoaded",                         Sc_Game_IsPluginLoaded, pl_is_plugin_loaded },
+        { "Game::ChangeSpeechVox",                        API_FN_PAIR(Game_ChangeSpeechVox) },
+        { "Game::PlayVoiceClip",                          Sc_Game_PlayVoiceClip, PlayVoiceClip },
+        { "Game::SimulateKeyPress",                       API_FN_PAIR(Game_SimulateKeyPress) },
+        { "Game::get_BlockingWaitSkipped",                API_FN_PAIR(Game_BlockingWaitSkipped) },
+        { "Game::get_SpeechVoxFilename",                  API_FN_PAIR(Game_GetSpeechVoxFilename) },
+        { "Game::get_Camera",                             API_FN_PAIR(Game_GetCamera) },
+        { "Game::get_CameraCount",                        API_FN_PAIR(Game_GetCameraCount) },
+        { "Game::geti_Cameras",                           API_FN_PAIR(Game_GetAnyCamera) },
+    };
 
-    ccAddExternalStaticFunction("Game::get_Camera",                             Sc_Game_GetCamera);
-    ccAddExternalStaticFunction("Game::get_CameraCount",                        Sc_Game_GetCameraCount);
-    ccAddExternalStaticFunction("Game::geti_Cameras",                           Sc_Game_GetAnyCamera);
-
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Game::IsAudioPlaying^1",                       (void*)Game_IsAudioPlaying);
-    ccAddExternalFunctionForPlugin("Game::SetAudioTypeSpeechVolumeDrop^2",         (void*)Game_SetAudioTypeSpeechVolumeDrop);
-    ccAddExternalFunctionForPlugin("Game::SetAudioTypeVolume^3",                   (void*)Game_SetAudioTypeVolume);
-    ccAddExternalFunctionForPlugin("Game::StopAudio^1",                            (void*)Game_StopAudio);
-    ccAddExternalFunctionForPlugin("Game::ChangeTranslation^1",                    (void*)Game_ChangeTranslation);
-    ccAddExternalFunctionForPlugin("Game::DoOnceOnly^1",                           (void*)Game_DoOnceOnly);
-    ccAddExternalFunctionForPlugin("Game::GetColorFromRGB^3",                      (void*)Game_GetColorFromRGB);
-    ccAddExternalFunctionForPlugin("Game::GetFrameCountForLoop^2",                 (void*)Game_GetFrameCountForLoop);
-    ccAddExternalFunctionForPlugin("Game::GetLocationName^2",                      (void*)Game_GetLocationName);
-    ccAddExternalFunctionForPlugin("Game::GetLoopCountForView^1",                  (void*)Game_GetLoopCountForView);
-    ccAddExternalFunctionForPlugin("Game::GetMODPattern^0",                        (void*)Game_GetMODPattern);
-    ccAddExternalFunctionForPlugin("Game::GetRunNextSettingForLoop^2",             (void*)Game_GetRunNextSettingForLoop);
-    ccAddExternalFunctionForPlugin("Game::GetSaveSlotDescription^1",               (void*)Game_GetSaveSlotDescription);
-    ccAddExternalFunctionForPlugin("Game::GetViewFrame^3",                         (void*)Game_GetViewFrame);
-    ccAddExternalFunctionForPlugin("Game::InputBox^1",                             (void*)Game_InputBox);
-    ccAddExternalFunctionForPlugin("Game::SetSaveGameDirectory^1",                 (void*)Game_SetSaveGameDirectory);
-    ccAddExternalFunctionForPlugin("Game::StopSound^1",                            (void*)StopAllSounds);
-    ccAddExternalFunctionForPlugin("Game::get_CharacterCount",                     (void*)Game_GetCharacterCount);
-    ccAddExternalFunctionForPlugin("Game::get_DialogCount",                        (void*)Game_GetDialogCount);
-    ccAddExternalFunctionForPlugin("Game::get_FileName",                           (void*)Game_GetFileName);
-    ccAddExternalFunctionForPlugin("Game::get_FontCount",                          (void*)Game_GetFontCount);
-    ccAddExternalFunctionForPlugin("Game::geti_GlobalMessages",                    (void*)Game_GetGlobalMessages);
-    ccAddExternalFunctionForPlugin("Game::geti_GlobalStrings",                     (void*)Game_GetGlobalStrings);
-    ccAddExternalFunctionForPlugin("Game::seti_GlobalStrings",                     (void*)SetGlobalString);
-    ccAddExternalFunctionForPlugin("Game::get_GUICount",                           (void*)Game_GetGUICount);
-    ccAddExternalFunctionForPlugin("Game::get_IgnoreUserInputAfterTextTimeoutMs",  (void*)Game_GetIgnoreUserInputAfterTextTimeoutMs);
-    ccAddExternalFunctionForPlugin("Game::set_IgnoreUserInputAfterTextTimeoutMs",  (void*)Game_SetIgnoreUserInputAfterTextTimeoutMs);
-    ccAddExternalFunctionForPlugin("Game::get_InSkippableCutscene",                (void*)Game_GetInSkippableCutscene);
-    ccAddExternalFunctionForPlugin("Game::get_InventoryItemCount",                 (void*)Game_GetInventoryItemCount);
-    ccAddExternalFunctionForPlugin("Game::get_MinimumTextDisplayTimeMs",           (void*)Game_GetMinimumTextDisplayTimeMs);
-    ccAddExternalFunctionForPlugin("Game::set_MinimumTextDisplayTimeMs",           (void*)Game_SetMinimumTextDisplayTimeMs);
-    ccAddExternalFunctionForPlugin("Game::get_MouseCursorCount",                   (void*)Game_GetMouseCursorCount);
-    ccAddExternalFunctionForPlugin("Game::get_Name",                               (void*)Game_GetName);
-    ccAddExternalFunctionForPlugin("Game::set_Name",                               (void*)Game_SetName);
-    ccAddExternalFunctionForPlugin("Game::get_NormalFont",                         (void*)Game_GetNormalFont);
-    ccAddExternalFunctionForPlugin("Game::set_NormalFont",                         (void*)SetNormalFont);
-    ccAddExternalFunctionForPlugin("Game::get_SkippingCutscene",                   (void*)Game_GetSkippingCutscene);
-    ccAddExternalFunctionForPlugin("Game::get_SpeechFont",                         (void*)Game_GetSpeechFont);
-    ccAddExternalFunctionForPlugin("Game::set_SpeechFont",                         (void*)SetSpeechFont);
-    ccAddExternalFunctionForPlugin("Game::geti_SpriteWidth",                       (void*)Game_GetSpriteWidth);
-    ccAddExternalFunctionForPlugin("Game::geti_SpriteHeight",                      (void*)Game_GetSpriteHeight);
-    ccAddExternalFunctionForPlugin("Game::get_TextReadingSpeed",                   (void*)Game_GetTextReadingSpeed);
-    ccAddExternalFunctionForPlugin("Game::set_TextReadingSpeed",                   (void*)Game_SetTextReadingSpeed);
-    ccAddExternalFunctionForPlugin("Game::get_TranslationFilename",                (void*)Game_GetTranslationFilename);
-    ccAddExternalFunctionForPlugin("Game::get_UseNativeCoordinates",               (void*)Game_GetUseNativeCoordinates);
-    ccAddExternalFunctionForPlugin("Game::get_ViewCount",                          (void*)Game_GetViewCount);
-    ccAddExternalFunctionForPlugin("Game::PlayVoiceClip",                          (void*)PlayVoiceClip);
+    ccAddExternalFunctions(game_api);
 }
 
 void RegisterStaticObjects()

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -372,7 +372,7 @@ RuntimeScriptValue Sc_FadeIn(const RuntimeScriptValue *params, int32_t param_cou
 }
 
 // void (int spdd)
-RuntimeScriptValue Sc_my_fade_out(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_FadeOut(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID_PINT(FadeOut);
 }
@@ -1189,7 +1189,7 @@ RuntimeScriptValue Sc_PlayAmbientSound(const RuntimeScriptValue *params, int32_t
 }
 
 // void (int numb,int playflags)
-RuntimeScriptValue Sc_play_flc_file(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PlayFlic(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID_PINT2(PlayFlic);
 }
@@ -1231,7 +1231,7 @@ RuntimeScriptValue Sc_PlaySoundEx(const RuntimeScriptValue *params, int32_t para
 }
 
 // void (const char* name, int skip, int flags)
-RuntimeScriptValue Sc_scrPlayVideo(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_PlayVideo(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_VOID_POBJ_PINT2(PlayVideo, const char);
 }
@@ -2301,746 +2301,378 @@ void ScPl_sc_sprintf(char *destt, const char *texx, ...)
 
 void RegisterGlobalAPI()
 {
-    ccAddExternalStaticFunction("AbortGame",                Sc_sc_AbortGame);
-	ccAddExternalStaticFunction("AddInventory",             Sc_add_inventory);
-	ccAddExternalStaticFunction("AddInventoryToCharacter",  Sc_AddInventoryToCharacter);
-	ccAddExternalStaticFunction("AnimateButton",            Sc_AnimateButton);
-	ccAddExternalStaticFunction("AnimateCharacter",         Sc_AnimateCharacter4);
-	ccAddExternalStaticFunction("AnimateCharacterEx",       Sc_AnimateCharacter6);
-	ccAddExternalStaticFunction("AnimateObject",            Sc_AnimateObject4);
-	ccAddExternalStaticFunction("AnimateObjectEx",          Sc_AnimateObject6);
-	ccAddExternalStaticFunction("AreCharactersColliding",   Sc_AreCharactersColliding);
-	ccAddExternalStaticFunction("AreCharObjColliding",      Sc_AreCharObjColliding);
-	ccAddExternalStaticFunction("AreObjectsColliding",      Sc_AreObjectsColliding);
-	ccAddExternalStaticFunction("AreThingsOverlapping",     Sc_AreThingsOverlapping);
-	ccAddExternalStaticFunction("CallRoomScript",           Sc_CallRoomScript);
-	ccAddExternalStaticFunction("CDAudio",                  Sc_cd_manager);
-	ccAddExternalStaticFunction("CentreGUI",                Sc_CentreGUI);
-	ccAddExternalStaticFunction("ChangeCharacterView",      Sc_ChangeCharacterView);
-	ccAddExternalStaticFunction("ChangeCursorGraphic",      Sc_ChangeCursorGraphic);
-	ccAddExternalStaticFunction("ChangeCursorHotspot",      Sc_ChangeCursorHotspot);
-	ccAddExternalStaticFunction("ClaimEvent",               Sc_ClaimEvent);
-	ccAddExternalStaticFunction("CreateGraphicOverlay",     Sc_CreateGraphicOverlay);
-	ccAddExternalStaticFunction("CreateTextOverlay",        Sc_CreateTextOverlay);
-	ccAddExternalStaticFunction("CyclePalette",             Sc_CyclePalette);
-	ccAddExternalStaticFunction("Debug",                    Sc_script_debug);
-	ccAddExternalStaticFunction("DeleteSaveSlot",           Sc_DeleteSaveSlot);
-	ccAddExternalStaticFunction("DeleteSprite",             Sc_free_dynamic_sprite);
-	ccAddExternalStaticFunction("DisableCursorMode",        Sc_disable_cursor_mode);
-	ccAddExternalStaticFunction("DisableGroundLevelAreas",  Sc_DisableGroundLevelAreas);
-	ccAddExternalStaticFunction("DisableHotspot",           Sc_DisableHotspot);
-	ccAddExternalStaticFunction("DisableInterface",         Sc_DisableInterface);
-	ccAddExternalStaticFunction("DisableRegion",            Sc_DisableRegion);
-	ccAddExternalStaticFunction("Display",                  Sc_Display);
-	ccAddExternalStaticFunction("DisplayAt",                Sc_DisplayAt);
-	ccAddExternalStaticFunction("DisplayAtY",               Sc_DisplayAtY);
-	ccAddExternalStaticFunction("DisplayMessage",           Sc_DisplayMessage);
-	ccAddExternalStaticFunction("DisplayMessageAtY",        Sc_DisplayMessageAtY);
-	ccAddExternalStaticFunction("DisplayMessageBar",        Sc_DisplayMessageBar);
-	ccAddExternalStaticFunction("DisplaySpeech",            Sc_sc_displayspeech);
-	ccAddExternalStaticFunction("DisplaySpeechAt",          Sc_DisplaySpeechAt);
-	ccAddExternalStaticFunction("DisplaySpeechBackground",  Sc_DisplaySpeechBackground);
-	ccAddExternalStaticFunction("DisplayThought",           Sc_DisplayThought);
-	ccAddExternalStaticFunction("DisplayTopBar",            Sc_DisplayTopBar);
-	ccAddExternalStaticFunction("EnableCursorMode",         Sc_enable_cursor_mode);
-	ccAddExternalStaticFunction("EnableGroundLevelAreas",   Sc_EnableGroundLevelAreas);
-	ccAddExternalStaticFunction("EnableHotspot",            Sc_EnableHotspot);
-	ccAddExternalStaticFunction("EnableInterface",          Sc_EnableInterface);
-	ccAddExternalStaticFunction("EnableRegion",             Sc_EnableRegion);
-	ccAddExternalStaticFunction("EndCutscene",              Sc_EndCutscene);
-	ccAddExternalStaticFunction("FaceCharacter",            Sc_FaceCharacter);
-	ccAddExternalStaticFunction("FaceLocation",             Sc_FaceLocation);
-	ccAddExternalStaticFunction("FadeIn",                   Sc_FadeIn);
-	ccAddExternalStaticFunction("FadeOut",                  Sc_my_fade_out);
-	ccAddExternalStaticFunction("FileClose",                Sc_FileClose);
-	ccAddExternalStaticFunction("FileIsEOF",                Sc_FileIsEOF);
-	ccAddExternalStaticFunction("FileIsError",              Sc_FileIsError);
-    // NOTE: FileOpenCMode is a backwards-compatible replacement for old-style global script function FileOpen
-	ccAddExternalStaticFunction("FileOpen",                 Sc_FileOpenCMode);
-	ccAddExternalStaticFunction("FileRead",                 Sc_FileRead);
-	ccAddExternalStaticFunction("FileReadInt",              Sc_FileReadInt);
-	ccAddExternalStaticFunction("FileReadRawChar",          Sc_FileReadRawChar);
-	ccAddExternalStaticFunction("FileReadRawInt",           Sc_FileReadRawInt);
-	ccAddExternalStaticFunction("FileWrite",                Sc_FileWrite);
-	ccAddExternalStaticFunction("FileWriteInt",             Sc_FileWriteInt);
-	ccAddExternalStaticFunction("FileWriteRawChar",         Sc_FileWriteRawChar);
-	ccAddExternalStaticFunction("FileWriteRawLine",         Sc_FileWriteRawLine);
-	ccAddExternalStaticFunction("FindGUIID",                Sc_FindGUIID);
-	ccAddExternalStaticFunction("FlipScreen",               Sc_FlipScreen);
-	ccAddExternalStaticFunction("FloatToInt",               Sc_FloatToInt);
-	ccAddExternalStaticFunction("FollowCharacter",          Sc_FollowCharacter);
-	ccAddExternalStaticFunction("FollowCharacterEx",        Sc_FollowCharacterEx);
-	ccAddExternalStaticFunction("GetBackgroundFrame",       Sc_GetBackgroundFrame);
-	ccAddExternalStaticFunction("GetButtonPic",             Sc_GetButtonPic);
-	ccAddExternalStaticFunction("GetCharacterAt",           Sc_GetCharIDAtScreen);
-	ccAddExternalStaticFunction("GetCharacterProperty",     Sc_GetCharacterProperty);
-	ccAddExternalStaticFunction("GetCharacterPropertyText", Sc_GetCharacterPropertyText);
-	ccAddExternalStaticFunction("GetCurrentMusic",          Sc_GetCurrentMusic);
-	ccAddExternalStaticFunction("GetCursorMode",            Sc_GetCursorMode);
-	ccAddExternalStaticFunction("GetDialogOption",          Sc_GetDialogOption);
-	ccAddExternalStaticFunction("GetGameOption",            Sc_GetGameOption);
-	ccAddExternalStaticFunction("GetGameParameter",         Sc_GetGameParameter);
-	ccAddExternalStaticFunction("GetGameSpeed",             Sc_GetGameSpeed);
-	ccAddExternalStaticFunction("GetGlobalInt",             Sc_GetGlobalInt);
-	ccAddExternalStaticFunction("GetGlobalString",          Sc_GetGlobalString);
-	ccAddExternalStaticFunction("GetGraphicalVariable",     Sc_GetGraphicalVariable);
-	ccAddExternalStaticFunction("GetGUIAt",                 Sc_GetGUIAt);
-	ccAddExternalStaticFunction("GetGUIObjectAt",           Sc_GetGUIObjectAt);
-	ccAddExternalStaticFunction("GetHotspotAt",             Sc_GetHotspotIDAtScreen);
-	ccAddExternalStaticFunction("GetHotspotName",           Sc_GetHotspotName);
-	ccAddExternalStaticFunction("GetHotspotPointX",         Sc_GetHotspotPointX);
-	ccAddExternalStaticFunction("GetHotspotPointY",         Sc_GetHotspotPointY);
-	ccAddExternalStaticFunction("GetHotspotProperty",       Sc_GetHotspotProperty);
-	ccAddExternalStaticFunction("GetHotspotPropertyText",   Sc_GetHotspotPropertyText);
-	ccAddExternalStaticFunction("GetInvAt",                 Sc_GetInvAt);
-	ccAddExternalStaticFunction("GetInvGraphic",            Sc_GetInvGraphic);
-	ccAddExternalStaticFunction("GetInvName",               Sc_GetInvName);
-	ccAddExternalStaticFunction("GetInvProperty",           Sc_GetInvProperty);
-	ccAddExternalStaticFunction("GetInvPropertyText",       Sc_GetInvPropertyText);
-	//ccAddExternalStaticFunction("GetLanguageString",      Sc_GetLanguageString);
-	ccAddExternalStaticFunction("GetLocationName",          Sc_GetLocationName);
-	ccAddExternalStaticFunction("GetLocationType",          Sc_GetLocationType);
-	ccAddExternalStaticFunction("GetMessageText",           Sc_GetMessageText);
-	ccAddExternalStaticFunction("GetMIDIPosition",          Sc_GetMIDIPosition);
-	ccAddExternalStaticFunction("GetMP3PosMillis",          Sc_GetMP3PosMillis);
-	ccAddExternalStaticFunction("GetObjectAt",              Sc_GetObjectIDAtScreen);
-	ccAddExternalStaticFunction("GetObjectBaseline",        Sc_GetObjectBaseline);
-	ccAddExternalStaticFunction("GetObjectGraphic",         Sc_GetObjectGraphic);
-	ccAddExternalStaticFunction("GetObjectName",            Sc_GetObjectName);
-	ccAddExternalStaticFunction("GetObjectProperty",        Sc_GetObjectProperty);
-	ccAddExternalStaticFunction("GetObjectPropertyText",    Sc_GetObjectPropertyText);
-	ccAddExternalStaticFunction("GetObjectX",               Sc_GetObjectX);
-	ccAddExternalStaticFunction("GetObjectY",               Sc_GetObjectY);
-	//  ccAddExternalStaticFunction("GetPalette",           Sc_scGetPal);
-	ccAddExternalStaticFunction("GetPlayerCharacter",       Sc_GetPlayerCharacter);
-	ccAddExternalStaticFunction("GetRawTime",               Sc_GetRawTime);
-	ccAddExternalStaticFunction("GetRegionAt",              Sc_GetRegionIDAtRoom);
-	ccAddExternalStaticFunction("GetRoomProperty",          Sc_Room_GetProperty);
-	ccAddExternalStaticFunction("GetRoomPropertyText",      Sc_GetRoomPropertyText);
-	ccAddExternalStaticFunction("GetSaveSlotDescription",   Sc_GetSaveSlotDescription);
-	ccAddExternalStaticFunction("GetScalingAt",             Sc_GetScalingAt);
-	ccAddExternalStaticFunction("GetSliderValue",           Sc_GetSliderValue);
-	ccAddExternalStaticFunction("GetTextBoxText",           Sc_GetTextBoxText);
-	ccAddExternalStaticFunction("GetTextHeight",            Sc_GetTextHeight);
-	ccAddExternalStaticFunction("GetTextWidth",             Sc_GetTextWidth);
-	ccAddExternalStaticFunction("GetFontHeight",            Sc_GetFontHeight);
-	ccAddExternalStaticFunction("GetFontLineSpacing",       Sc_GetFontLineSpacing);
-	ccAddExternalStaticFunction("GetTime",                  Sc_sc_GetTime);
-	ccAddExternalStaticFunction("GetTranslation",           Sc_get_translation);
-	ccAddExternalStaticFunction("GetTranslationName",       Sc_GetTranslationName);
-	ccAddExternalStaticFunction("GetViewportX",             Sc_GetViewportX);
-	ccAddExternalStaticFunction("GetViewportY",             Sc_GetViewportY);
-    ccAddExternalStaticFunction("GetWalkableAreaAtRoom",    Sc_GetWalkableAreaAtRoom);
-	ccAddExternalStaticFunction("GetWalkableAreaAt",        Sc_GetWalkableAreaAtScreen);
-    ccAddExternalStaticFunction("GetWalkableAreaAtScreen",  Sc_GetWalkableAreaAtScreen);
-    ccAddExternalStaticFunction("GetDrawingSurfaceForWalkableArea", Sc_GetDrawingSurfaceForWalkableArea);
-    ccAddExternalStaticFunction("GetDrawingSurfaceForWalkbehind", Sc_GetDrawingSurfaceForWalkbehind);
-	ccAddExternalStaticFunction("GiveScore",                Sc_GiveScore);
-	ccAddExternalStaticFunction("HasPlayerBeenInRoom",      Sc_HasPlayerBeenInRoom);
-	ccAddExternalStaticFunction("HideMouseCursor",          Sc_HideMouseCursor);
-	ccAddExternalStaticFunction("InputBox",                 Sc_sc_inputbox);
-	ccAddExternalStaticFunction("InterfaceOff",             Sc_InterfaceOff);
-	ccAddExternalStaticFunction("InterfaceOn",              Sc_InterfaceOn);
-	ccAddExternalStaticFunction("IntToFloat",               Sc_IntToFloat);
-	ccAddExternalStaticFunction("InventoryScreen",          Sc_sc_invscreen);
-	ccAddExternalStaticFunction("IsButtonDown",             Sc_IsButtonDown);
-	ccAddExternalStaticFunction("IsChannelPlaying",         Sc_IsChannelPlaying);
-	ccAddExternalStaticFunction("IsGamePaused",             Sc_IsGamePaused);
-	ccAddExternalStaticFunction("IsGUIOn",                  Sc_IsGUIOn);
-	ccAddExternalStaticFunction("IsInteractionAvailable",   Sc_IsInteractionAvailable);
-	ccAddExternalStaticFunction("IsInventoryInteractionAvailable", Sc_IsInventoryInteractionAvailable);
-	ccAddExternalStaticFunction("IsInterfaceEnabled",       Sc_IsInterfaceEnabled);
-	ccAddExternalStaticFunction("IsKeyPressed",             Sc_IsKeyPressed);
-	ccAddExternalStaticFunction("IsMusicPlaying",           Sc_IsMusicPlaying);
-	ccAddExternalStaticFunction("IsMusicVoxAvailable",      Sc_IsMusicVoxAvailable);
-	ccAddExternalStaticFunction("IsObjectAnimating",        Sc_IsObjectAnimating);
-	ccAddExternalStaticFunction("IsObjectMoving",           Sc_IsObjectMoving);
-	ccAddExternalStaticFunction("IsObjectOn",               Sc_IsObjectOn);
-	ccAddExternalStaticFunction("IsOverlayValid",           Sc_IsOverlayValid);
-	ccAddExternalStaticFunction("IsSoundPlaying",           Sc_IsSoundPlaying);
-	ccAddExternalStaticFunction("IsTimerExpired",           Sc_IsTimerExpired);
-	ccAddExternalStaticFunction("IsTranslationAvailable",   Sc_IsTranslationAvailable);
-	ccAddExternalStaticFunction("IsVoxAvailable",           Sc_IsVoxAvailable);
-	ccAddExternalStaticFunction("ListBoxAdd",               Sc_ListBoxAdd);
-	ccAddExternalStaticFunction("ListBoxClear",             Sc_ListBoxClear);
-	ccAddExternalStaticFunction("ListBoxDirList",           Sc_ListBoxDirList);
-	ccAddExternalStaticFunction("ListBoxGetItemText",       Sc_ListBoxGetItemText);
-	ccAddExternalStaticFunction("ListBoxGetNumItems",       Sc_ListBoxGetNumItems);
-	ccAddExternalStaticFunction("ListBoxGetSelected",       Sc_ListBoxGetSelected);
-	ccAddExternalStaticFunction("ListBoxRemove",            Sc_ListBoxRemove);
-	ccAddExternalStaticFunction("ListBoxSaveGameList",      Sc_ListBoxSaveGameList);
-	ccAddExternalStaticFunction("ListBoxSetSelected",       Sc_ListBoxSetSelected);
-	ccAddExternalStaticFunction("ListBoxSetTopItem",        Sc_ListBoxSetTopItem);
-	ccAddExternalStaticFunction("LoadImageFile",            Sc_LoadImageFile);
-	ccAddExternalStaticFunction("LoadSaveSlotScreenshot",   Sc_LoadSaveSlotScreenshot);
-	ccAddExternalStaticFunction("LoseInventory",            Sc_lose_inventory);
-	ccAddExternalStaticFunction("LoseInventoryFromCharacter", Sc_LoseInventoryFromCharacter);
-	ccAddExternalStaticFunction("MergeObject",              Sc_MergeObject);
-	ccAddExternalStaticFunction("MoveCharacter",            Sc_MoveCharacter);
-	ccAddExternalStaticFunction("MoveCharacterBlocking",    Sc_MoveCharacterBlocking);
-	ccAddExternalStaticFunction("MoveCharacterDirect",      Sc_MoveCharacterDirect);
-	ccAddExternalStaticFunction("MoveCharacterPath",        Sc_MoveCharacterPath);
-	ccAddExternalStaticFunction("MoveCharacterStraight",    Sc_MoveCharacterStraight);
-	ccAddExternalStaticFunction("MoveCharacterToHotspot",   Sc_MoveCharacterToHotspot);
-	ccAddExternalStaticFunction("MoveCharacterToObject",    Sc_MoveCharacterToObject);
-	ccAddExternalStaticFunction("MoveObject",               Sc_MoveObject);
-	ccAddExternalStaticFunction("MoveObjectDirect",         Sc_MoveObjectDirect);
-	ccAddExternalStaticFunction("MoveOverlay",              Sc_MoveOverlay);
-	ccAddExternalStaticFunction("MoveToWalkableArea",       Sc_MoveToWalkableArea);
-	ccAddExternalStaticFunction("NewRoom",                  Sc_NewRoom);
-	ccAddExternalStaticFunction("NewRoomEx",                Sc_NewRoomEx);
-	ccAddExternalStaticFunction("NewRoomNPC",               Sc_NewRoomNPC);
-	ccAddExternalStaticFunction("ObjectOff",                Sc_ObjectOff);
-	ccAddExternalStaticFunction("ObjectOn",                 Sc_ObjectOn);
-	ccAddExternalStaticFunction("ParseText",                Sc_ParseText);
-	ccAddExternalStaticFunction("PauseGame",                Sc_PauseGame);
-	ccAddExternalStaticFunction("PlayAmbientSound",         Sc_PlayAmbientSound);
-	ccAddExternalStaticFunction("PlayFlic",                 Sc_play_flc_file);
-	ccAddExternalStaticFunction("PlayMP3File",              Sc_PlayMP3File);
-	ccAddExternalStaticFunction("PlayMusic",                Sc_PlayMusicResetQueue);
-	ccAddExternalStaticFunction("PlayMusicQueued",          Sc_PlayMusicQueued);
-	ccAddExternalStaticFunction("PlaySilentMIDI",           Sc_PlaySilentMIDI);
-	ccAddExternalStaticFunction("PlaySound",                Sc_play_sound);
-	ccAddExternalStaticFunction("PlaySoundEx",              Sc_PlaySoundEx);
-	ccAddExternalStaticFunction("PlayVideo",                Sc_scrPlayVideo);
-	ccAddExternalStaticFunction("QuitGame",                 Sc_QuitGame);
-	ccAddExternalStaticFunction("Random",                   Sc_Rand);
-	ccAddExternalStaticFunction("RawClearScreen",           Sc_RawClear);
-	ccAddExternalStaticFunction("RawDrawCircle",            Sc_RawDrawCircle);
-	ccAddExternalStaticFunction("RawDrawFrameTransparent",  Sc_RawDrawFrameTransparent);
-	ccAddExternalStaticFunction("RawDrawImage",             Sc_RawDrawImage);
-	ccAddExternalStaticFunction("RawDrawImageOffset",       Sc_RawDrawImageOffset);
-	ccAddExternalStaticFunction("RawDrawImageResized",      Sc_RawDrawImageResized);
-	ccAddExternalStaticFunction("RawDrawImageTransparent",  Sc_RawDrawImageTransparent);
-	ccAddExternalStaticFunction("RawDrawLine",              Sc_RawDrawLine);
-	ccAddExternalStaticFunction("RawDrawRectangle",         Sc_RawDrawRectangle);
-	ccAddExternalStaticFunction("RawDrawTriangle",          Sc_RawDrawTriangle);
-	ccAddExternalStaticFunction("RawPrint",                 Sc_RawPrint);
-	ccAddExternalStaticFunction("RawPrintMessageWrapped",   Sc_RawPrintMessageWrapped);
-	ccAddExternalStaticFunction("RawRestoreScreen",         Sc_RawRestoreScreen);
-	ccAddExternalStaticFunction("RawRestoreScreenTinted",   Sc_RawRestoreScreenTinted);
-	ccAddExternalStaticFunction("RawSaveScreen",            Sc_RawSaveScreen);
-	ccAddExternalStaticFunction("RawSetColor",              Sc_RawSetColor);
-	ccAddExternalStaticFunction("RawSetColorRGB",           Sc_RawSetColorRGB);
-	ccAddExternalStaticFunction("RefreshMouse",             Sc_RefreshMouse);
-	ccAddExternalStaticFunction("ReleaseCharacterView",     Sc_ReleaseCharacterView);
-	ccAddExternalStaticFunction("ReleaseViewport",          Sc_ReleaseViewport);
-	ccAddExternalStaticFunction("RemoveObjectTint",         Sc_RemoveObjectTint);
-	ccAddExternalStaticFunction("RemoveOverlay",            Sc_RemoveOverlay);
-	ccAddExternalStaticFunction("RemoveWalkableArea",       Sc_RemoveWalkableArea);
-	ccAddExternalStaticFunction("ResetRoom",                Sc_ResetRoom);
-	ccAddExternalStaticFunction("RestartGame",              Sc_restart_game);
-	ccAddExternalStaticFunction("RestoreGameDialog",        Sc_restore_game_dialog);
-	ccAddExternalStaticFunction("RestoreGameSlot",          Sc_RestoreGameSlot);
-	ccAddExternalStaticFunction("RestoreWalkableArea",      Sc_RestoreWalkableArea);
-	ccAddExternalStaticFunction("RunAGSGame",               Sc_RunAGSGame);
-	ccAddExternalStaticFunction("RunCharacterInteraction",  Sc_RunCharacterInteraction);
-	ccAddExternalStaticFunction("RunDialog",                Sc_RunDialog);
-	ccAddExternalStaticFunction("RunHotspotInteraction",    Sc_RunHotspotInteraction);
-	ccAddExternalStaticFunction("RunInventoryInteraction",  Sc_RunInventoryInteraction);
-	ccAddExternalStaticFunction("RunObjectInteraction",     Sc_RunObjectInteraction);
-	ccAddExternalStaticFunction("RunRegionInteraction",     Sc_RunRegionInteraction);
-	ccAddExternalStaticFunction("Said",                     Sc_Said);
-	ccAddExternalStaticFunction("SaidUnknownWord",          Sc_SaidUnknownWord);
-	ccAddExternalStaticFunction("SaveCursorForLocationChange", Sc_SaveCursorForLocationChange);
-	ccAddExternalStaticFunction("SaveGameDialog",           Sc_save_game_dialog);
-	ccAddExternalStaticFunction("SaveGameSlot",             Sc_save_game);
-	ccAddExternalStaticFunction("SaveScreenShot",           Sc_SaveScreenShot);
-	ccAddExternalStaticFunction("SeekMIDIPosition",         Sc_SeekMIDIPosition);
-	ccAddExternalStaticFunction("SeekMODPattern",           Sc_SeekMODPattern);
-	ccAddExternalStaticFunction("SeekMP3PosMillis",         Sc_SeekMP3PosMillis);
-	ccAddExternalStaticFunction("SetActiveInventory",       Sc_SetActiveInventory);
-	ccAddExternalStaticFunction("SetAmbientTint",           Sc_SetAmbientTint);
-    ccAddExternalStaticFunction("SetAmbientLightLevel",     Sc_SetAmbientLightLevel);
-	ccAddExternalStaticFunction("SetAreaLightLevel",        Sc_SetAreaLightLevel);
-	ccAddExternalStaticFunction("SetAreaScaling",           Sc_SetAreaScaling);
-	ccAddExternalStaticFunction("SetBackgroundFrame",       Sc_SetBackgroundFrame);
-	ccAddExternalStaticFunction("SetButtonPic",             Sc_SetButtonPic);
-	ccAddExternalStaticFunction("SetButtonText",            Sc_SetButtonText);
-	ccAddExternalStaticFunction("SetChannelVolume",         Sc_SetChannelVolume);
-	ccAddExternalStaticFunction("SetCharacterBaseline",     Sc_SetCharacterBaseline);
-	ccAddExternalStaticFunction("SetCharacterClickable",    Sc_SetCharacterClickable);
-	ccAddExternalStaticFunction("SetCharacterFrame",        Sc_SetCharacterFrame);
-	ccAddExternalStaticFunction("SetCharacterIdle",         Sc_SetCharacterIdle);
-	ccAddExternalStaticFunction("SetCharacterIgnoreLight",  Sc_SetCharacterIgnoreLight);
-	ccAddExternalStaticFunction("SetCharacterIgnoreWalkbehinds", Sc_SetCharacterIgnoreWalkbehinds);
-	ccAddExternalStaticFunction("SetCharacterProperty",     Sc_SetCharacterProperty);
-	ccAddExternalStaticFunction("SetCharacterBlinkView",    Sc_SetCharacterBlinkView);
-	ccAddExternalStaticFunction("SetCharacterSpeechView",   Sc_SetCharacterSpeechView);
-	ccAddExternalStaticFunction("SetCharacterSpeed",        Sc_SetCharacterSpeed);
-	ccAddExternalStaticFunction("SetCharacterSpeedEx",      Sc_SetCharacterSpeedEx);
-	ccAddExternalStaticFunction("SetCharacterTransparency", Sc_SetCharacterTransparency);
-	ccAddExternalStaticFunction("SetCharacterView",         Sc_SetCharacterView);
-	ccAddExternalStaticFunction("SetCharacterViewEx",       Sc_SetCharacterViewEx);
-	ccAddExternalStaticFunction("SetCharacterViewOffset",   Sc_SetCharacterViewOffset);
-	ccAddExternalStaticFunction("SetCursorMode",            Sc_set_cursor_mode);
-	ccAddExternalStaticFunction("SetDefaultCursor",         Sc_set_default_cursor);
-	ccAddExternalStaticFunction("SetDialogOption",          Sc_SetDialogOption);
-	ccAddExternalStaticFunction("SetDigitalMasterVolume",   Sc_SetDigitalMasterVolume);
-	ccAddExternalStaticFunction("SetFadeColor",             Sc_SetFadeColor);
-	ccAddExternalStaticFunction("SetFrameSound",            Sc_SetFrameSound);
-	ccAddExternalStaticFunction("SetGameOption",            Sc_SetGameOption);
-	ccAddExternalStaticFunction("SetGameSpeed",             Sc_SetGameSpeed);
-	ccAddExternalStaticFunction("SetGlobalInt",             Sc_SetGlobalInt);
-	ccAddExternalStaticFunction("SetGlobalString",          Sc_SetGlobalString);
-	ccAddExternalStaticFunction("SetGraphicalVariable",     Sc_SetGraphicalVariable);
-	ccAddExternalStaticFunction("SetGUIBackgroundPic",      Sc_SetGUIBackgroundPic);
-	ccAddExternalStaticFunction("SetGUIClickable",          Sc_SetGUIClickable);
-	ccAddExternalStaticFunction("SetGUIObjectEnabled",      Sc_SetGUIObjectEnabled);
-	ccAddExternalStaticFunction("SetGUIObjectPosition",     Sc_SetGUIObjectPosition);
-	ccAddExternalStaticFunction("SetGUIObjectSize",         Sc_SetGUIObjectSize);
-	ccAddExternalStaticFunction("SetGUIPosition",           Sc_SetGUIPosition);
-	ccAddExternalStaticFunction("SetGUISize",               Sc_SetGUISize);
-	ccAddExternalStaticFunction("SetGUITransparency",       Sc_SetGUITransparency);
-	ccAddExternalStaticFunction("SetGUIZOrder",             Sc_SetGUIZOrder);
-	ccAddExternalStaticFunction("SetInvItemName",           Sc_SetInvItemName);
-	ccAddExternalStaticFunction("SetInvItemPic",            Sc_set_inv_item_pic);
-	ccAddExternalStaticFunction("SetInvDimensions",         Sc_SetInvDimensions);
-	ccAddExternalStaticFunction("SetLabelColor",            Sc_SetLabelColor);
-	ccAddExternalStaticFunction("SetLabelFont",             Sc_SetLabelFont);
-	ccAddExternalStaticFunction("SetLabelText",             Sc_SetLabelText);
-	ccAddExternalStaticFunction("SetMouseBounds",           Sc_SetMouseBounds);
-	ccAddExternalStaticFunction("SetMouseCursor",           Sc_set_mouse_cursor);
-	ccAddExternalStaticFunction("SetMousePosition",         Sc_SetMousePosition);
-	ccAddExternalStaticFunction("SetMultitaskingMode",      Sc_SetMultitasking);
-	ccAddExternalStaticFunction("SetMusicMasterVolume",     Sc_SetMusicMasterVolume);
-	ccAddExternalStaticFunction("SetMusicRepeat",           Sc_SetMusicRepeat);
-	ccAddExternalStaticFunction("SetMusicVolume",           Sc_SetMusicVolume);
-	ccAddExternalStaticFunction("SetNextCursorMode",        Sc_SetNextCursor);
-	ccAddExternalStaticFunction("SetNextScreenTransition",  Sc_SetNextScreenTransition);
-	ccAddExternalStaticFunction("SetNormalFont",            Sc_SetNormalFont);
-	ccAddExternalStaticFunction("SetObjectBaseline",        Sc_SetObjectBaseline);
-	ccAddExternalStaticFunction("SetObjectClickable",       Sc_SetObjectClickable);
-	ccAddExternalStaticFunction("SetObjectFrame",           Sc_SetObjectFrame);
-	ccAddExternalStaticFunction("SetObjectGraphic",         Sc_SetObjectGraphic);
-	ccAddExternalStaticFunction("SetObjectIgnoreWalkbehinds", Sc_SetObjectIgnoreWalkbehinds);
-	ccAddExternalStaticFunction("SetObjectPosition",        Sc_SetObjectPosition);
-	ccAddExternalStaticFunction("SetObjectTint",            Sc_SetObjectTint);
-	ccAddExternalStaticFunction("SetObjectTransparency",    Sc_SetObjectTransparency);
-	ccAddExternalStaticFunction("SetObjectView",            Sc_SetObjectView);
-	//  ccAddExternalStaticFunction("SetPalette",           scSetPal);
-	ccAddExternalStaticFunction("SetPalRGB",                Sc_SetPalRGB);
-	ccAddExternalStaticFunction("SetPlayerCharacter",       Sc_SetPlayerCharacter);
-	ccAddExternalStaticFunction("SetRegionTint",            Sc_SetRegionTint);
-	ccAddExternalStaticFunction("SetRestartPoint",          Sc_SetRestartPoint);
-	ccAddExternalStaticFunction("SetScreenTransition",      Sc_SetScreenTransition);
-	ccAddExternalStaticFunction("SetSkipSpeech",            Sc_SetSkipSpeech);
-	ccAddExternalStaticFunction("SetSliderValue",           Sc_SetSliderValue);
-	ccAddExternalStaticFunction("SetSoundVolume",           Sc_SetSoundVolume);
-	ccAddExternalStaticFunction("SetSpeechFont",            Sc_SetSpeechFont);
-	ccAddExternalStaticFunction("SetSpeechStyle",           Sc_SetSpeechStyle);
-	ccAddExternalStaticFunction("SetSpeechVolume",          Sc_SetSpeechVolume);
-	ccAddExternalStaticFunction("SetTalkingColor",          Sc_SetTalkingColor);
-	ccAddExternalStaticFunction("SetTextBoxFont",           Sc_SetTextBoxFont);
-	ccAddExternalStaticFunction("SetTextBoxText",           Sc_SetTextBoxText);
-	ccAddExternalStaticFunction("SetTextOverlay",           Sc_SetTextOverlay);
-	ccAddExternalStaticFunction("SetTextWindowGUI",         Sc_SetTextWindowGUI);
-	ccAddExternalStaticFunction("SetTimer",                 Sc_script_SetTimer);
-	ccAddExternalStaticFunction("SetViewport",              Sc_SetViewport);
-	ccAddExternalStaticFunction("SetVoiceMode",             Sc_SetVoiceMode);
-	ccAddExternalStaticFunction("SetWalkBehindBase",        Sc_SetWalkBehindBase);
-	ccAddExternalStaticFunction("ShakeScreen",              Sc_ShakeScreen);
-	ccAddExternalStaticFunction("ShakeScreenBackground",    Sc_ShakeScreenBackground);
-	ccAddExternalStaticFunction("ShowMouseCursor",          Sc_ShowMouseCursor);
-    ccAddExternalStaticFunction("SkipCutscene",             Sc_SkipCutscene);
-	ccAddExternalStaticFunction("SkipUntilCharacterStops",  Sc_SkipUntilCharacterStops);
-	ccAddExternalStaticFunction("StartCutscene",            Sc_StartCutscene);
-	ccAddExternalStaticFunction("StartRecording",           Sc_scStartRecording);
-	ccAddExternalStaticFunction("StopAmbientSound",         Sc_StopAmbientSound);
-	ccAddExternalStaticFunction("StopChannel",              Sc_stop_and_destroy_channel);
-	ccAddExternalStaticFunction("StopDialog",               Sc_StopDialog);
-	ccAddExternalStaticFunction("StopMoving",               Sc_StopMoving);
-	ccAddExternalStaticFunction("StopMusic",                Sc_scr_StopMusic);
-	ccAddExternalStaticFunction("StopObjectMoving",         Sc_StopObjectMoving);
-	ccAddExternalStaticFunction("StrCat",                   Sc_sc_strcat);
-	ccAddExternalStaticFunction("StrCaseComp",              Sc_stricmp);
-	ccAddExternalStaticFunction("StrComp",                  Sc_strcmp);
-	ccAddExternalStaticFunction("StrContains",              Sc_StrContains);
-	ccAddExternalStaticFunction("StrCopy",                  Sc_sc_strcpy);
-	ccAddExternalStaticFunction("StrFormat",                Sc_sc_sprintf);
-	ccAddExternalStaticFunction("StrGetCharAt",             Sc_StrGetCharAt);
-	ccAddExternalStaticFunction("StringToInt",              Sc_StringToInt);
-	ccAddExternalStaticFunction("StrLen",                   Sc_strlen);
-	ccAddExternalStaticFunction("StrSetCharAt",             Sc_StrSetCharAt);
-	ccAddExternalStaticFunction("StrToLowerCase",           Sc_sc_strlower);
-	ccAddExternalStaticFunction("StrToUpperCase",           Sc_sc_strupper);
-	ccAddExternalStaticFunction("TintScreen",               Sc_TintScreen);
-	ccAddExternalStaticFunction("UnPauseGame",              Sc_UnPauseGame);
-	ccAddExternalStaticFunction("UpdateInventory",          Sc_update_invorder);
-	ccAddExternalStaticFunction("UpdatePalette",            Sc_UpdatePalette);
-	ccAddExternalStaticFunction("Wait",                     Sc_scrWait);
-	ccAddExternalStaticFunction("WaitKey",                  Sc_WaitKey);
-	ccAddExternalStaticFunction("WaitMouse",                Sc_WaitMouse);
-	ccAddExternalStaticFunction("WaitMouseKey",             Sc_WaitMouseKey);
-	ccAddExternalStaticFunction("WaitInput",                Sc_WaitInput);
-	ccAddExternalStaticFunction("SkipWait",                 Sc_SkipWait);
+    ScFnRegister global_api[] = {
+        { "AbortGame",                Sc_sc_AbortGame, ScPl_sc_AbortGame },
+        { "AddInventory",             API_FN_PAIR(add_inventory) },
+        { "AddInventoryToCharacter",  API_FN_PAIR(AddInventoryToCharacter) },
+        { "AnimateButton",            API_FN_PAIR(AnimateButton) },
+        { "AnimateCharacter",         API_FN_PAIR(AnimateCharacter4) },
+        { "AnimateCharacterEx",       API_FN_PAIR(AnimateCharacter6) },
+        { "AnimateObject",            API_FN_PAIR(AnimateObject4) },
+        { "AnimateObjectEx",          API_FN_PAIR(AnimateObject6) },
+        { "AreCharactersColliding",   API_FN_PAIR(AreCharactersColliding) },
+        { "AreCharObjColliding",      API_FN_PAIR(AreCharObjColliding) },
+        { "AreObjectsColliding",      API_FN_PAIR(AreObjectsColliding) },
+        { "AreThingsOverlapping",     API_FN_PAIR(AreThingsOverlapping) },
+        { "CallRoomScript",           API_FN_PAIR(CallRoomScript) },
+        { "CDAudio",                  API_FN_PAIR(cd_manager) },
+        { "CentreGUI",                API_FN_PAIR(CentreGUI) },
+        { "ChangeCharacterView",      API_FN_PAIR(ChangeCharacterView) },
+        { "ChangeCursorGraphic",      API_FN_PAIR(ChangeCursorGraphic) },
+        { "ChangeCursorHotspot",      API_FN_PAIR(ChangeCursorHotspot) },
+        { "ClaimEvent",               API_FN_PAIR(ClaimEvent) },
+        { "CreateGraphicOverlay",     API_FN_PAIR(CreateGraphicOverlay) },
+        { "CreateTextOverlay",        Sc_CreateTextOverlay, ScPl_CreateTextOverlay },
+        { "CyclePalette",             API_FN_PAIR(CyclePalette) },
+        { "Debug",                    API_FN_PAIR(script_debug) },
+        { "DeleteSaveSlot",           API_FN_PAIR(DeleteSaveSlot) },
+        { "DeleteSprite",             API_FN_PAIR(free_dynamic_sprite) },
+        { "DisableCursorMode",        API_FN_PAIR(disable_cursor_mode) },
+        { "DisableGroundLevelAreas",  API_FN_PAIR(DisableGroundLevelAreas) },
+        { "DisableHotspot",           API_FN_PAIR(DisableHotspot) },
+        { "DisableInterface",         API_FN_PAIR(DisableInterface) },
+        { "DisableRegion",            API_FN_PAIR(DisableRegion) },
+        { "Display",                  Sc_Display, ScPl_Display },
+        { "DisplayAt",                Sc_DisplayAt, ScPl_DisplayAt },
+        { "DisplayAtY",               API_FN_PAIR(DisplayAtY) },
+        { "DisplayMessage",           API_FN_PAIR(DisplayMessage) },
+        { "DisplayMessageAtY",        API_FN_PAIR(DisplayMessageAtY) },
+        { "DisplayMessageBar",        API_FN_PAIR(DisplayMessageBar) },
+        { "DisplaySpeech",            Sc_sc_displayspeech, ScPl_sc_displayspeech },
+        { "DisplaySpeechAt",          API_FN_PAIR(DisplaySpeechAt) },
+        { "DisplaySpeechBackground",  API_FN_PAIR(DisplaySpeechBackground) },
+        { "DisplayThought",           Sc_DisplayThought, ScPl_DisplayThought },
+        { "DisplayTopBar",            Sc_DisplayTopBar, ScPl_DisplayTopBar },
+        { "EnableCursorMode",         API_FN_PAIR(enable_cursor_mode) },
+        { "EnableGroundLevelAreas",   API_FN_PAIR(EnableGroundLevelAreas) },
+        { "EnableHotspot",            API_FN_PAIR(EnableHotspot) },
+        { "EnableInterface",          API_FN_PAIR(EnableInterface) },
+        { "EnableRegion",             API_FN_PAIR(EnableRegion) },
+        { "EndCutscene",              API_FN_PAIR(EndCutscene) },
+        { "FaceCharacter",            API_FN_PAIR(FaceCharacter) },
+        { "FaceLocation",             API_FN_PAIR(FaceLocation) },
+        { "FadeIn",                   API_FN_PAIR(FadeIn) },
+        { "FadeOut",                  API_FN_PAIR(FadeOut) },
+        { "FileClose",                API_FN_PAIR(FileClose) },
+        { "FileIsEOF",                API_FN_PAIR(FileIsEOF) },
+        { "FileIsError",              API_FN_PAIR(FileIsError) },
+        // NOTE: FileOpenCMode is a backwards-compatible replacement for old-style global script function FileOpen
+        { "FileOpen",                 API_FN_PAIR(FileOpenCMode) },
+        { "FileRead",                 API_FN_PAIR(FileRead) },
+        { "FileReadInt",              API_FN_PAIR(FileReadInt) },
+        { "FileReadRawChar",          API_FN_PAIR(FileReadRawChar) },
+        { "FileReadRawInt",           API_FN_PAIR(FileReadRawInt) },
+        { "FileWrite",                API_FN_PAIR(FileWrite) },
+        { "FileWriteInt",             API_FN_PAIR(FileWriteInt) },
+        { "FileWriteRawChar",         API_FN_PAIR(FileWriteRawChar) },
+        { "FileWriteRawLine",         API_FN_PAIR(FileWriteRawLine) },
+        { "FindGUIID",                API_FN_PAIR(FindGUIID) },
+        { "FlipScreen",               API_FN_PAIR(FlipScreen) },
+        { "FloatToInt",               API_FN_PAIR(FloatToInt) },
+        { "FollowCharacter",          API_FN_PAIR(FollowCharacter) },
+        { "FollowCharacterEx",        API_FN_PAIR(FollowCharacterEx) },
+        { "GetBackgroundFrame",       API_FN_PAIR(GetBackgroundFrame) },
+        { "GetButtonPic",             API_FN_PAIR(GetButtonPic) },
+        { "GetCharacterAt",           API_FN_PAIR(GetCharIDAtScreen) },
+        { "GetCharacterProperty",     API_FN_PAIR(GetCharacterProperty) },
+        { "GetCharacterPropertyText", API_FN_PAIR(GetCharacterPropertyText) },
+        { "GetCurrentMusic",          API_FN_PAIR(GetCurrentMusic) },
+        { "GetCursorMode",            API_FN_PAIR(GetCursorMode) },
+        { "GetDialogOption",          API_FN_PAIR(GetDialogOption) },
+        { "GetGameOption",            API_FN_PAIR(GetGameOption) },
+        { "GetGameParameter",         API_FN_PAIR(GetGameParameter) },
+        { "GetGameSpeed",             API_FN_PAIR(GetGameSpeed) },
+        { "GetGlobalInt",             API_FN_PAIR(GetGlobalInt) },
+        { "GetGlobalString",          API_FN_PAIR(GetGlobalString) },
+        { "GetGraphicalVariable",     API_FN_PAIR(GetGraphicalVariable) },
+        { "GetGUIAt",                 API_FN_PAIR(GetGUIAt) },
+        { "GetGUIObjectAt",           API_FN_PAIR(GetGUIObjectAt) },
+        { "GetHotspotAt",             API_FN_PAIR(GetHotspotIDAtScreen) },
+        { "GetHotspotName",           API_FN_PAIR(GetHotspotName) },
+        { "GetHotspotPointX",         API_FN_PAIR(GetHotspotPointX) },
+        { "GetHotspotPointY",         API_FN_PAIR(GetHotspotPointY) },
+        { "GetHotspotProperty",       API_FN_PAIR(GetHotspotProperty) },
+        { "GetHotspotPropertyText",   API_FN_PAIR(GetHotspotPropertyText) },
+        { "GetInvAt",                 API_FN_PAIR(GetInvAt) },
+        { "GetInvGraphic",            API_FN_PAIR(GetInvGraphic) },
+        { "GetInvName",               API_FN_PAIR(GetInvName) },
+        { "GetInvProperty",           API_FN_PAIR(GetInvProperty) },
+        { "GetInvPropertyText",       API_FN_PAIR(GetInvPropertyText) },
+        { "GetLocationName",          API_FN_PAIR(GetLocationName) },
+        { "GetLocationType",          API_FN_PAIR(GetLocationType) },
+        { "GetMessageText",           API_FN_PAIR(GetMessageText) },
+        { "GetMIDIPosition",          API_FN_PAIR(GetMIDIPosition) },
+        { "GetMP3PosMillis",          API_FN_PAIR(GetMP3PosMillis) },
+        { "GetObjectAt",              API_FN_PAIR(GetObjectIDAtScreen) },
+        { "GetObjectBaseline",        API_FN_PAIR(GetObjectBaseline) },
+        { "GetObjectGraphic",         API_FN_PAIR(GetObjectGraphic) },
+        { "GetObjectName",            API_FN_PAIR(GetObjectName) },
+        { "GetObjectProperty",        API_FN_PAIR(GetObjectProperty) },
+        { "GetObjectPropertyText",    API_FN_PAIR(GetObjectPropertyText) },
+        { "GetObjectX",               API_FN_PAIR(GetObjectX) },
+        { "GetObjectY",               API_FN_PAIR(GetObjectY) },
+        { "GetPlayerCharacter",       API_FN_PAIR(GetPlayerCharacter) },
+        { "GetRawTime",               API_FN_PAIR(GetRawTime) },
+        { "GetRegionAt",              API_FN_PAIR(GetRegionIDAtRoom) },
+        { "GetRoomProperty",          API_FN_PAIR(Room_GetProperty) },
+        { "GetRoomPropertyText",      API_FN_PAIR(GetRoomPropertyText) },
+        { "GetSaveSlotDescription",   API_FN_PAIR(GetSaveSlotDescription) },
+        { "GetScalingAt",             API_FN_PAIR(GetScalingAt) },
+        { "GetSliderValue",           API_FN_PAIR(GetSliderValue) },
+        { "GetTextBoxText",           API_FN_PAIR(GetTextBoxText) },
+        { "GetTextHeight",            API_FN_PAIR(GetTextHeight) },
+        { "GetTextWidth",             API_FN_PAIR(GetTextWidth) },
+        { "GetFontHeight",            API_FN_PAIR(GetFontHeight) },
+        { "GetFontLineSpacing",       API_FN_PAIR(GetFontLineSpacing) },
+        { "GetTime",                  API_FN_PAIR(sc_GetTime) },
+        { "GetTranslation",           API_FN_PAIR(get_translation) },
+        { "GetTranslationName",       API_FN_PAIR(GetTranslationName) },
+        { "GetViewportX",             API_FN_PAIR(GetViewportX) },
+        { "GetViewportY",             API_FN_PAIR(GetViewportY) },
+        { "GetWalkableAreaAtRoom",    API_FN_PAIR(GetWalkableAreaAtRoom) },
+        { "GetWalkableAreaAt",        API_FN_PAIR(GetWalkableAreaAtScreen) },
+        { "GetWalkableAreaAtScreen",  API_FN_PAIR(GetWalkableAreaAtScreen) },
+        { "GetDrawingSurfaceForWalkableArea", API_FN_PAIR(GetDrawingSurfaceForWalkableArea) },
+        { "GetDrawingSurfaceForWalkbehind", API_FN_PAIR(GetDrawingSurfaceForWalkbehind) },
+        { "GiveScore",                API_FN_PAIR(GiveScore) },
+        { "HasPlayerBeenInRoom",      API_FN_PAIR(HasPlayerBeenInRoom) },
+        { "HideMouseCursor",          API_FN_PAIR(HideMouseCursor) },
+        { "InputBox",                 API_FN_PAIR(sc_inputbox) },
+        { "InterfaceOff",             API_FN_PAIR(InterfaceOff) },
+        { "InterfaceOn",              API_FN_PAIR(InterfaceOn) },
+        { "IntToFloat",               API_FN_PAIR(IntToFloat) },
+        { "InventoryScreen",          API_FN_PAIR(sc_invscreen) },
+        { "IsButtonDown",             API_FN_PAIR(IsButtonDown) },
+        { "IsChannelPlaying",         API_FN_PAIR(IsChannelPlaying) },
+        { "IsGamePaused",             API_FN_PAIR(IsGamePaused) },
+        { "IsGUIOn",                  API_FN_PAIR(IsGUIOn) },
+        { "IsInteractionAvailable",   API_FN_PAIR(IsInteractionAvailable) },
+        { "IsInventoryInteractionAvailable", API_FN_PAIR(IsInventoryInteractionAvailable) },
+        { "IsInterfaceEnabled",       API_FN_PAIR(IsInterfaceEnabled) },
+        { "IsKeyPressed",             API_FN_PAIR(IsKeyPressed) },
+        { "IsMusicPlaying",           API_FN_PAIR(IsMusicPlaying) },
+        { "IsMusicVoxAvailable",      API_FN_PAIR(IsMusicVoxAvailable) },
+        { "IsObjectAnimating",        API_FN_PAIR(IsObjectAnimating) },
+        { "IsObjectMoving",           API_FN_PAIR(IsObjectMoving) },
+        { "IsObjectOn",               API_FN_PAIR(IsObjectOn) },
+        { "IsOverlayValid",           API_FN_PAIR(IsOverlayValid) },
+        { "IsSoundPlaying",           API_FN_PAIR(IsSoundPlaying) },
+        { "IsTimerExpired",           API_FN_PAIR(IsTimerExpired) },
+        { "IsTranslationAvailable",   API_FN_PAIR(IsTranslationAvailable) },
+        { "IsVoxAvailable",           API_FN_PAIR(IsVoxAvailable) },
+        { "ListBoxAdd",               API_FN_PAIR(ListBoxAdd) },
+        { "ListBoxClear",             API_FN_PAIR(ListBoxClear) },
+        { "ListBoxDirList",           API_FN_PAIR(ListBoxDirList) },
+        { "ListBoxGetItemText",       API_FN_PAIR(ListBoxGetItemText) },
+        { "ListBoxGetNumItems",       API_FN_PAIR(ListBoxGetNumItems) },
+        { "ListBoxGetSelected",       API_FN_PAIR(ListBoxGetSelected) },
+        { "ListBoxRemove",            API_FN_PAIR(ListBoxRemove) },
+        { "ListBoxSaveGameList",      API_FN_PAIR(ListBoxSaveGameList) },
+        { "ListBoxSetSelected",       API_FN_PAIR(ListBoxSetSelected) },
+        { "ListBoxSetTopItem",        API_FN_PAIR(ListBoxSetTopItem) },
+        { "LoadImageFile",            API_FN_PAIR(LoadImageFile) },
+        { "LoadSaveSlotScreenshot",   API_FN_PAIR(LoadSaveSlotScreenshot) },
+        { "LoseInventory",            API_FN_PAIR(lose_inventory) },
+        { "LoseInventoryFromCharacter", API_FN_PAIR(LoseInventoryFromCharacter) },
+        { "MergeObject",              API_FN_PAIR(MergeObject) },
+        { "MoveCharacter",            API_FN_PAIR(MoveCharacter) },
+        { "MoveCharacterBlocking",    API_FN_PAIR(MoveCharacterBlocking) },
+        { "MoveCharacterDirect",      API_FN_PAIR(MoveCharacterDirect) },
+        { "MoveCharacterPath",        API_FN_PAIR(MoveCharacterPath) },
+        { "MoveCharacterStraight",    API_FN_PAIR(MoveCharacterStraight) },
+        { "MoveCharacterToHotspot",   API_FN_PAIR(MoveCharacterToHotspot) },
+        { "MoveCharacterToObject",    API_FN_PAIR(MoveCharacterToObject) },
+        { "MoveObject",               API_FN_PAIR(MoveObject) },
+        { "MoveObjectDirect",         API_FN_PAIR(MoveObjectDirect) },
+        { "MoveOverlay",              API_FN_PAIR(MoveOverlay) },
+        { "MoveToWalkableArea",       API_FN_PAIR(MoveToWalkableArea) },
+        { "NewRoom",                  API_FN_PAIR(NewRoom) },
+        { "NewRoomEx",                API_FN_PAIR(NewRoomEx) },
+        { "NewRoomNPC",               API_FN_PAIR(NewRoomNPC) },
+        { "ObjectOff",                API_FN_PAIR(ObjectOff) },
+        { "ObjectOn",                 API_FN_PAIR(ObjectOn) },
+        { "ParseText",                API_FN_PAIR(ParseText) },
+        { "PauseGame",                API_FN_PAIR(PauseGame) },
+        { "PlayAmbientSound",         API_FN_PAIR(PlayAmbientSound) },
+        { "PlayFlic",                 API_FN_PAIR(PlayFlic) },
+        { "PlayMP3File",              API_FN_PAIR(PlayMP3File) },
+        { "PlayMusic",                API_FN_PAIR(PlayMusicResetQueue) },
+        { "PlayMusicQueued",          API_FN_PAIR(PlayMusicQueued) },
+        { "PlaySilentMIDI",           API_FN_PAIR(PlaySilentMIDI) },
+        { "PlaySound",                API_FN_PAIR(play_sound) },
+        { "PlaySoundEx",              API_FN_PAIR(PlaySoundEx) },
+        { "PlayVideo",                API_FN_PAIR(PlayVideo) },
+        { "QuitGame",                 API_FN_PAIR(QuitGame) },
+        { "Random",                   Sc_Rand, __Rand },
+        { "RawClearScreen",           API_FN_PAIR(RawClear) },
+        { "RawDrawCircle",            API_FN_PAIR(RawDrawCircle) },
+        { "RawDrawFrameTransparent",  API_FN_PAIR(RawDrawFrameTransparent) },
+        { "RawDrawImage",             API_FN_PAIR(RawDrawImage) },
+        { "RawDrawImageOffset",       API_FN_PAIR(RawDrawImageOffset) },
+        { "RawDrawImageResized",      API_FN_PAIR(RawDrawImageResized) },
+        { "RawDrawImageTransparent",  API_FN_PAIR(RawDrawImageTransparent) },
+        { "RawDrawLine",              API_FN_PAIR(RawDrawLine) },
+        { "RawDrawRectangle",         API_FN_PAIR(RawDrawRectangle) },
+        { "RawDrawTriangle",          API_FN_PAIR(RawDrawTriangle) },
+        { "RawPrint",                 Sc_RawPrint, ScPl_RawPrint },
+        { "RawPrintMessageWrapped",   API_FN_PAIR(RawPrintMessageWrapped) },
+        { "RawRestoreScreen",         API_FN_PAIR(RawRestoreScreen) },
+        { "RawRestoreScreenTinted",   API_FN_PAIR(RawRestoreScreenTinted) },
+        { "RawSaveScreen",            API_FN_PAIR(RawSaveScreen) },
+        { "RawSetColor",              API_FN_PAIR(RawSetColor) },
+        { "RawSetColorRGB",           API_FN_PAIR(RawSetColorRGB) },
+        { "RefreshMouse",             API_FN_PAIR(RefreshMouse) },
+        { "ReleaseCharacterView",     API_FN_PAIR(ReleaseCharacterView) },
+        { "ReleaseViewport",          API_FN_PAIR(ReleaseViewport) },
+        { "RemoveObjectTint",         API_FN_PAIR(RemoveObjectTint) },
+        { "RemoveOverlay",            API_FN_PAIR(RemoveOverlay) },
+        { "RemoveWalkableArea",       API_FN_PAIR(RemoveWalkableArea) },
+        { "ResetRoom",                API_FN_PAIR(ResetRoom) },
+        { "RestartGame",              API_FN_PAIR(restart_game) },
+        { "RestoreGameDialog",        API_FN_PAIR(restore_game_dialog) },
+        { "RestoreGameSlot",          API_FN_PAIR(RestoreGameSlot) },
+        { "RestoreWalkableArea",      API_FN_PAIR(RestoreWalkableArea) },
+        { "RunAGSGame",               API_FN_PAIR(RunAGSGame) },
+        { "RunCharacterInteraction",  API_FN_PAIR(RunCharacterInteraction) },
+        { "RunDialog",                API_FN_PAIR(RunDialog) },
+        { "RunHotspotInteraction",    API_FN_PAIR(RunHotspotInteraction) },
+        { "RunInventoryInteraction",  API_FN_PAIR(RunInventoryInteraction) },
+        { "RunObjectInteraction",     API_FN_PAIR(RunObjectInteraction) },
+        { "RunRegionInteraction",     API_FN_PAIR(RunRegionInteraction) },
+        { "Said",                     API_FN_PAIR(Said) },
+        { "SaidUnknownWord",          API_FN_PAIR(SaidUnknownWord) },
+        { "SaveCursorForLocationChange", API_FN_PAIR(SaveCursorForLocationChange) },
+        { "SaveGameDialog",           API_FN_PAIR(save_game_dialog) },
+        { "SaveGameSlot",             API_FN_PAIR(save_game) },
+        { "SaveScreenShot",           API_FN_PAIR(SaveScreenShot) },
+        { "SeekMIDIPosition",         API_FN_PAIR(SeekMIDIPosition) },
+        { "SeekMODPattern",           API_FN_PAIR(SeekMODPattern) },
+        { "SeekMP3PosMillis",         API_FN_PAIR(SeekMP3PosMillis) },
+        { "SetActiveInventory",       API_FN_PAIR(SetActiveInventory) },
+        { "SetAmbientTint",           API_FN_PAIR(SetAmbientTint) },
+        { "SetAmbientLightLevel",     API_FN_PAIR(SetAmbientLightLevel) },
+        { "SetAreaLightLevel",        API_FN_PAIR(SetAreaLightLevel) },
+        { "SetAreaScaling",           API_FN_PAIR(SetAreaScaling) },
+        { "SetBackgroundFrame",       API_FN_PAIR(SetBackgroundFrame) },
+        { "SetButtonPic",             API_FN_PAIR(SetButtonPic) },
+        { "SetButtonText",            API_FN_PAIR(SetButtonText) },
+        { "SetChannelVolume",         API_FN_PAIR(SetChannelVolume) },
+        { "SetCharacterBaseline",     API_FN_PAIR(SetCharacterBaseline) },
+        { "SetCharacterClickable",    API_FN_PAIR(SetCharacterClickable) },
+        { "SetCharacterFrame",        API_FN_PAIR(SetCharacterFrame) },
+        { "SetCharacterIdle",         API_FN_PAIR(SetCharacterIdle) },
+        { "SetCharacterIgnoreLight",  API_FN_PAIR(SetCharacterIgnoreLight) },
+        { "SetCharacterIgnoreWalkbehinds", API_FN_PAIR(SetCharacterIgnoreWalkbehinds) },
+        { "SetCharacterProperty",     API_FN_PAIR(SetCharacterProperty) },
+        { "SetCharacterBlinkView",    API_FN_PAIR(SetCharacterBlinkView) },
+        { "SetCharacterSpeechView",   API_FN_PAIR(SetCharacterSpeechView) },
+        { "SetCharacterSpeed",        API_FN_PAIR(SetCharacterSpeed) },
+        { "SetCharacterSpeedEx",      API_FN_PAIR(SetCharacterSpeedEx) },
+        { "SetCharacterTransparency", API_FN_PAIR(SetCharacterTransparency) },
+        { "SetCharacterView",         API_FN_PAIR(SetCharacterView) },
+        { "SetCharacterViewEx",       API_FN_PAIR(SetCharacterViewEx) },
+        { "SetCharacterViewOffset",   API_FN_PAIR(SetCharacterViewOffset) },
+        { "SetCursorMode",            API_FN_PAIR(set_cursor_mode) },
+        { "SetDefaultCursor",         API_FN_PAIR(set_default_cursor) },
+        { "SetDialogOption",          API_FN_PAIR(SetDialogOption) },
+        { "SetDigitalMasterVolume",   API_FN_PAIR(SetDigitalMasterVolume) },
+        { "SetFadeColor",             API_FN_PAIR(SetFadeColor) },
+        { "SetFrameSound",            API_FN_PAIR(SetFrameSound) },
+        { "SetGameOption",            API_FN_PAIR(SetGameOption) },
+        { "SetGameSpeed",             API_FN_PAIR(SetGameSpeed) },
+        { "SetGlobalInt",             API_FN_PAIR(SetGlobalInt) },
+        { "SetGlobalString",          API_FN_PAIR(SetGlobalString) },
+        { "SetGraphicalVariable",     API_FN_PAIR(SetGraphicalVariable) },
+        { "SetGUIBackgroundPic",      API_FN_PAIR(SetGUIBackgroundPic) },
+        { "SetGUIClickable",          API_FN_PAIR(SetGUIClickable) },
+        { "SetGUIObjectEnabled",      API_FN_PAIR(SetGUIObjectEnabled) },
+        { "SetGUIObjectPosition",     API_FN_PAIR(SetGUIObjectPosition) },
+        { "SetGUIObjectSize",         API_FN_PAIR(SetGUIObjectSize) },
+        { "SetGUIPosition",           API_FN_PAIR(SetGUIPosition) },
+        { "SetGUISize",               API_FN_PAIR(SetGUISize) },
+        { "SetGUITransparency",       API_FN_PAIR(SetGUITransparency) },
+        { "SetGUIZOrder",             API_FN_PAIR(SetGUIZOrder) },
+        { "SetInvItemName",           API_FN_PAIR(SetInvItemName) },
+        { "SetInvItemPic",            API_FN_PAIR(set_inv_item_pic) },
+        { "SetInvDimensions",         API_FN_PAIR(SetInvDimensions) },
+        { "SetLabelColor",            API_FN_PAIR(SetLabelColor) },
+        { "SetLabelFont",             API_FN_PAIR(SetLabelFont) },
+        { "SetLabelText",             API_FN_PAIR(SetLabelText) },
+        { "SetMouseBounds",           API_FN_PAIR(SetMouseBounds) },
+        { "SetMouseCursor",           API_FN_PAIR(set_mouse_cursor) },
+        { "SetMousePosition",         API_FN_PAIR(SetMousePosition) },
+        { "SetMultitaskingMode",      API_FN_PAIR(SetMultitasking) },
+        { "SetMusicMasterVolume",     API_FN_PAIR(SetMusicMasterVolume) },
+        { "SetMusicRepeat",           API_FN_PAIR(SetMusicRepeat) },
+        { "SetMusicVolume",           API_FN_PAIR(SetMusicVolume) },
+        { "SetNextCursorMode",        API_FN_PAIR(SetNextCursor) },
+        { "SetNextScreenTransition",  API_FN_PAIR(SetNextScreenTransition) },
+        { "SetNormalFont",            API_FN_PAIR(SetNormalFont) },
+        { "SetObjectBaseline",        API_FN_PAIR(SetObjectBaseline) },
+        { "SetObjectClickable",       API_FN_PAIR(SetObjectClickable) },
+        { "SetObjectFrame",           API_FN_PAIR(SetObjectFrame) },
+        { "SetObjectGraphic",         API_FN_PAIR(SetObjectGraphic) },
+        { "SetObjectIgnoreWalkbehinds", API_FN_PAIR(SetObjectIgnoreWalkbehinds) },
+        { "SetObjectPosition",        API_FN_PAIR(SetObjectPosition) },
+        { "SetObjectTint",            API_FN_PAIR(SetObjectTint) },
+        { "SetObjectTransparency",    API_FN_PAIR(SetObjectTransparency) },
+        { "SetObjectView",            API_FN_PAIR(SetObjectView) },
+        { "SetPalRGB",                API_FN_PAIR(SetPalRGB) },
+        { "SetPlayerCharacter",       API_FN_PAIR(SetPlayerCharacter) },
+        { "SetRegionTint",            API_FN_PAIR(SetRegionTint) },
+        { "SetRestartPoint",          API_FN_PAIR(SetRestartPoint) },
+        { "SetScreenTransition",      API_FN_PAIR(SetScreenTransition) },
+        { "SetSkipSpeech",            API_FN_PAIR(SetSkipSpeech) },
+        { "SetSliderValue",           API_FN_PAIR(SetSliderValue) },
+        { "SetSoundVolume",           API_FN_PAIR(SetSoundVolume) },
+        { "SetSpeechFont",            API_FN_PAIR(SetSpeechFont) },
+        { "SetSpeechStyle",           API_FN_PAIR(SetSpeechStyle) },
+        { "SetSpeechVolume",          API_FN_PAIR(SetSpeechVolume) },
+        { "SetTalkingColor",          API_FN_PAIR(SetTalkingColor) },
+        { "SetTextBoxFont",           API_FN_PAIR(SetTextBoxFont) },
+        { "SetTextBoxText",           API_FN_PAIR(SetTextBoxText) },
+        { "SetTextOverlay",           Sc_SetTextOverlay, ScPl_SetTextOverlay },
+        { "SetTextWindowGUI",         API_FN_PAIR(SetTextWindowGUI) },
+        { "SetTimer",                 API_FN_PAIR(script_SetTimer) },
+        { "SetViewport",              API_FN_PAIR(SetViewport) },
+        { "SetVoiceMode",             API_FN_PAIR(SetVoiceMode) },
+        { "SetWalkBehindBase",        API_FN_PAIR(SetWalkBehindBase) },
+        { "ShakeScreen",              API_FN_PAIR(ShakeScreen) },
+        { "ShakeScreenBackground",    API_FN_PAIR(ShakeScreenBackground) },
+        { "ShowMouseCursor",          API_FN_PAIR(ShowMouseCursor) },
+        { "SkipCutscene",             API_FN_PAIR(SkipCutscene) },
+        { "SkipUntilCharacterStops",  API_FN_PAIR(SkipUntilCharacterStops) },
+        { "StartCutscene",            API_FN_PAIR(StartCutscene) },
+        { "StartRecording",           API_FN_PAIR(scStartRecording) },
+        { "StopAmbientSound",         API_FN_PAIR(StopAmbientSound) },
+        { "StopChannel",              API_FN_PAIR(stop_and_destroy_channel) },
+        { "StopDialog",               API_FN_PAIR(StopDialog) },
+        { "StopMoving",               API_FN_PAIR(StopMoving) },
+        { "StopMusic",                API_FN_PAIR(scr_StopMusic) },
+        { "StopObjectMoving",         API_FN_PAIR(StopObjectMoving) },
+        { "StrCat",                   Sc_sc_strcat, _sc_strcat },
+        { "StrCaseComp",              Sc_stricmp, ags_stricmp },
+        { "StrComp",                  API_FN_PAIR(strcmp) },
+        { "StrContains",              API_FN_PAIR(StrContains) },
+        { "StrCopy",                  Sc_sc_strcpy, _sc_strcpy },
+        { "StrFormat",                Sc_sc_sprintf, ScPl_sc_sprintf },
+        { "StrGetCharAt",             API_FN_PAIR(StrGetCharAt) },
+        { "StringToInt",              API_FN_PAIR(StringToInt) },
+        { "StrLen",                   API_FN_PAIR(strlen) },
+        { "StrSetCharAt",             API_FN_PAIR(StrSetCharAt) },
+        { "StrToLowerCase",           Sc_sc_strlower, _sc_strlower },
+        { "StrToUpperCase",           Sc_sc_strupper, _sc_strupper },
+        { "TintScreen",               API_FN_PAIR(TintScreen) },
+        { "UnPauseGame",              API_FN_PAIR(UnPauseGame) },
+        { "UpdateInventory",          API_FN_PAIR(update_invorder) },
+        { "UpdatePalette",            API_FN_PAIR(UpdatePalette) },
+        { "Wait",                     API_FN_PAIR(scrWait) },
+        { "WaitKey",                  API_FN_PAIR(WaitKey) },
+        { "WaitMouse",                API_FN_PAIR(WaitMouse) },
+        { "WaitMouseKey",             API_FN_PAIR(WaitMouseKey) },
+        { "WaitInput",                API_FN_PAIR(WaitInput) },
+        { "SkipWait",                 API_FN_PAIR(SkipWait) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("AbortGame",                (void*)ScPl_sc_AbortGame);
-    ccAddExternalFunctionForPlugin("AddInventory",             (void*)add_inventory);
-    ccAddExternalFunctionForPlugin("AddInventoryToCharacter",  (void*)AddInventoryToCharacter);
-    ccAddExternalFunctionForPlugin("AnimateButton",            (void*)AnimateButton);
-    ccAddExternalFunctionForPlugin("AnimateCharacter",         (void*)AnimateCharacter4);
-    ccAddExternalFunctionForPlugin("AnimateCharacterEx",       (void*)AnimateCharacter6);
-    ccAddExternalFunctionForPlugin("AnimateObject",            (void*)AnimateObject4);
-    ccAddExternalFunctionForPlugin("AnimateObjectEx",          (void*)AnimateObject6);
-    ccAddExternalFunctionForPlugin("AreCharactersColliding",   (void*)AreCharactersColliding);
-    ccAddExternalFunctionForPlugin("AreCharObjColliding",      (void*)AreCharObjColliding);
-    ccAddExternalFunctionForPlugin("AreObjectsColliding",      (void*)AreObjectsColliding);
-    ccAddExternalFunctionForPlugin("AreThingsOverlapping",     (void*)AreThingsOverlapping);
-    ccAddExternalFunctionForPlugin("CallRoomScript",           (void*)CallRoomScript);
-    ccAddExternalFunctionForPlugin("CDAudio",                  (void*)cd_manager);
-    ccAddExternalFunctionForPlugin("CentreGUI",                (void*)CentreGUI);
-    ccAddExternalFunctionForPlugin("ChangeCharacterView",      (void*)ChangeCharacterView);
-    ccAddExternalFunctionForPlugin("ChangeCursorGraphic",      (void*)ChangeCursorGraphic);
-    ccAddExternalFunctionForPlugin("ChangeCursorHotspot",      (void*)ChangeCursorHotspot);
-    ccAddExternalFunctionForPlugin("ClaimEvent",               (void*)ClaimEvent);
-    ccAddExternalFunctionForPlugin("CreateGraphicOverlay",     (void*)CreateGraphicOverlay);
-    ccAddExternalFunctionForPlugin("CreateTextOverlay",        (void*)ScPl_CreateTextOverlay);
-    ccAddExternalFunctionForPlugin("CyclePalette",             (void*)CyclePalette);
-    ccAddExternalFunctionForPlugin("Debug",                    (void*)script_debug);
-    ccAddExternalFunctionForPlugin("DeleteSaveSlot",           (void*)DeleteSaveSlot);
-    ccAddExternalFunctionForPlugin("DeleteSprite",             (void*)free_dynamic_sprite);
-    ccAddExternalFunctionForPlugin("DisableCursorMode",        (void*)disable_cursor_mode);
-    ccAddExternalFunctionForPlugin("DisableGroundLevelAreas",  (void*)DisableGroundLevelAreas);
-    ccAddExternalFunctionForPlugin("DisableHotspot",           (void*)DisableHotspot);
-    ccAddExternalFunctionForPlugin("DisableInterface",         (void*)DisableInterface);
-    ccAddExternalFunctionForPlugin("DisableRegion",            (void*)DisableRegion);
-    ccAddExternalFunctionForPlugin("Display",                  (void*)ScPl_Display);
-    ccAddExternalFunctionForPlugin("DisplayAt",                (void*)ScPl_DisplayAt);
-    ccAddExternalFunctionForPlugin("DisplayAtY",               (void*)DisplayAtY);
-    ccAddExternalFunctionForPlugin("DisplayMessage",           (void*)DisplayMessage);
-    ccAddExternalFunctionForPlugin("DisplayMessageAtY",        (void*)DisplayMessageAtY);
-    ccAddExternalFunctionForPlugin("DisplayMessageBar",        (void*)DisplayMessageBar);
-    ccAddExternalFunctionForPlugin("DisplaySpeech",            (void*)ScPl_sc_displayspeech);
-    ccAddExternalFunctionForPlugin("DisplaySpeechAt",          (void*)DisplaySpeechAt);
-    ccAddExternalFunctionForPlugin("DisplaySpeechBackground",  (void*)DisplaySpeechBackground);
-    ccAddExternalFunctionForPlugin("DisplayThought",           (void*)ScPl_DisplayThought);
-    ccAddExternalFunctionForPlugin("DisplayTopBar",            (void*)ScPl_DisplayTopBar);
-    ccAddExternalFunctionForPlugin("EnableCursorMode",         (void*)enable_cursor_mode);
-    ccAddExternalFunctionForPlugin("EnableGroundLevelAreas",   (void*)EnableGroundLevelAreas);
-    ccAddExternalFunctionForPlugin("EnableHotspot",            (void*)EnableHotspot);
-    ccAddExternalFunctionForPlugin("EnableInterface",          (void*)EnableInterface);
-    ccAddExternalFunctionForPlugin("EnableRegion",             (void*)EnableRegion);
-    ccAddExternalFunctionForPlugin("EndCutscene",              (void*)EndCutscene);
-    ccAddExternalFunctionForPlugin("FaceCharacter",            (void*)FaceCharacter);
-    ccAddExternalFunctionForPlugin("FaceLocation",             (void*)FaceLocation);
-    ccAddExternalFunctionForPlugin("FadeIn",                   (void*)FadeIn);
-    ccAddExternalFunctionForPlugin("FadeOut",                  (void*)FadeOut);
-    ccAddExternalFunctionForPlugin("FileClose",                (void*)FileClose);
-    ccAddExternalFunctionForPlugin("FileIsEOF",                (void*)FileIsEOF);
-    ccAddExternalFunctionForPlugin("FileIsError",              (void*)FileIsError);
-    // NOTE: FileOpenCMode is a backwards-compatible replacement for old-style global script function FileOpen
-    ccAddExternalFunctionForPlugin("FileOpen",                 (void*)FileOpenCMode);
-    ccAddExternalFunctionForPlugin("FileRead",                 (void*)FileRead);
-    ccAddExternalFunctionForPlugin("FileReadInt",              (void*)FileReadInt);
-    ccAddExternalFunctionForPlugin("FileReadRawChar",          (void*)FileReadRawChar);
-    ccAddExternalFunctionForPlugin("FileReadRawInt",           (void*)FileReadRawInt);
-    ccAddExternalFunctionForPlugin("FileWrite",                (void*)FileWrite);
-    ccAddExternalFunctionForPlugin("FileWriteInt",             (void*)FileWriteInt);
-    ccAddExternalFunctionForPlugin("FileWriteRawChar",         (void*)FileWriteRawChar);
-    ccAddExternalFunctionForPlugin("FileWriteRawLine",         (void*)FileWriteRawLine);
-    ccAddExternalFunctionForPlugin("FindGUIID",                (void*)FindGUIID);
-    ccAddExternalFunctionForPlugin("FlipScreen",               (void*)FlipScreen);
-    ccAddExternalFunctionForPlugin("FloatToInt",               (void*)FloatToInt);
-    ccAddExternalFunctionForPlugin("FollowCharacter",          (void*)FollowCharacter);
-    ccAddExternalFunctionForPlugin("FollowCharacterEx",        (void*)FollowCharacterEx);
-    ccAddExternalFunctionForPlugin("GetBackgroundFrame",       (void*)GetBackgroundFrame);
-    ccAddExternalFunctionForPlugin("GetButtonPic",             (void*)GetButtonPic);
-    ccAddExternalFunctionForPlugin("GetCharacterAt",           (void*)GetCharIDAtScreen);
-    ccAddExternalFunctionForPlugin("GetCharacterProperty",     (void*)GetCharacterProperty);
-    ccAddExternalFunctionForPlugin("GetCharacterPropertyText", (void*)GetCharacterPropertyText);
-    ccAddExternalFunctionForPlugin("GetCurrentMusic",          (void*)GetCurrentMusic);
-    ccAddExternalFunctionForPlugin("GetCursorMode",            (void*)GetCursorMode);
-    ccAddExternalFunctionForPlugin("GetDialogOption",          (void*)GetDialogOption);
-    ccAddExternalFunctionForPlugin("GetGameOption",            (void*)GetGameOption);
-    ccAddExternalFunctionForPlugin("GetGameParameter",         (void*)GetGameParameter);
-    ccAddExternalFunctionForPlugin("GetGameSpeed",             (void*)GetGameSpeed);
-    ccAddExternalFunctionForPlugin("GetGlobalInt",             (void*)GetGlobalInt);
-    ccAddExternalFunctionForPlugin("GetGlobalString",          (void*)GetGlobalString);
-    ccAddExternalFunctionForPlugin("GetGraphicalVariable",     (void*)GetGraphicalVariable);
-    ccAddExternalFunctionForPlugin("GetGUIAt",                 (void*)GetGUIAt);
-    ccAddExternalFunctionForPlugin("GetGUIObjectAt",           (void*)GetGUIObjectAt);
-    ccAddExternalFunctionForPlugin("GetHotspotAt",             (void*)GetHotspotIDAtScreen);
-    ccAddExternalFunctionForPlugin("GetHotspotName",           (void*)GetHotspotName);
-    ccAddExternalFunctionForPlugin("GetHotspotPointX",         (void*)GetHotspotPointX);
-    ccAddExternalFunctionForPlugin("GetHotspotPointY",         (void*)GetHotspotPointY);
-    ccAddExternalFunctionForPlugin("GetHotspotProperty",       (void*)GetHotspotProperty);
-    ccAddExternalFunctionForPlugin("GetHotspotPropertyText",   (void*)GetHotspotPropertyText);
-    ccAddExternalFunctionForPlugin("GetInvAt",                 (void*)GetInvAt);
-    ccAddExternalFunctionForPlugin("GetInvGraphic",            (void*)GetInvGraphic);
-    ccAddExternalFunctionForPlugin("GetInvName",               (void*)GetInvName);
-    ccAddExternalFunctionForPlugin("GetInvProperty",           (void*)GetInvProperty);
-    ccAddExternalFunctionForPlugin("GetInvPropertyText",       (void*)GetInvPropertyText);
-    //ccAddExternalFunctionForPlugin("GetLanguageString",      (void*)GetLanguageString);
-    ccAddExternalFunctionForPlugin("GetLocationName",          (void*)GetLocationName);
-    ccAddExternalFunctionForPlugin("GetLocationType",          (void*)GetLocationType);
-    ccAddExternalFunctionForPlugin("GetMessageText",           (void*)GetMessageText);
-    ccAddExternalFunctionForPlugin("GetMIDIPosition",          (void*)GetMIDIPosition);
-    ccAddExternalFunctionForPlugin("GetMP3PosMillis",          (void*)GetMP3PosMillis);
-    ccAddExternalFunctionForPlugin("GetObjectAt",              (void*)GetObjectIDAtScreen);
-    ccAddExternalFunctionForPlugin("GetObjectBaseline",        (void*)GetObjectBaseline);
-    ccAddExternalFunctionForPlugin("GetObjectGraphic",         (void*)GetObjectGraphic);
-    ccAddExternalFunctionForPlugin("GetObjectName",            (void*)GetObjectName);
-    ccAddExternalFunctionForPlugin("GetObjectProperty",        (void*)GetObjectProperty);
-    ccAddExternalFunctionForPlugin("GetObjectPropertyText",    (void*)GetObjectPropertyText);
-    ccAddExternalFunctionForPlugin("GetObjectX",               (void*)GetObjectX);
-    ccAddExternalFunctionForPlugin("GetObjectY",               (void*)GetObjectY);
-    //  ccAddExternalFunctionForPlugin("GetPalette",           (void*)scGetPal);
-    ccAddExternalFunctionForPlugin("GetPlayerCharacter",       (void*)GetPlayerCharacter);
-    ccAddExternalFunctionForPlugin("GetRawTime",               (void*)GetRawTime);
-    ccAddExternalFunctionForPlugin("GetRegionAt",              (void*)GetRegionIDAtRoom);
-    ccAddExternalFunctionForPlugin("GetRoomProperty",          (void*)Room_GetProperty);
-    ccAddExternalFunctionForPlugin("GetRoomPropertyText",      (void*)GetRoomPropertyText);
-    ccAddExternalFunctionForPlugin("GetSaveSlotDescription",   (void*)GetSaveSlotDescription);
-    ccAddExternalFunctionForPlugin("GetScalingAt",             (void*)GetScalingAt);
-    ccAddExternalFunctionForPlugin("GetSliderValue",           (void*)GetSliderValue);
-    ccAddExternalFunctionForPlugin("GetTextBoxText",           (void*)GetTextBoxText);
-    ccAddExternalFunctionForPlugin("GetTextHeight",            (void*)GetTextHeight);
-    ccAddExternalFunctionForPlugin("GetTextWidth",             (void*)GetTextWidth);
-    ccAddExternalFunctionForPlugin("GetTime",                  (void*)sc_GetTime);
-    ccAddExternalFunctionForPlugin("GetTranslation",           (void*)get_translation);
-    ccAddExternalFunctionForPlugin("GetTranslationName",       (void*)GetTranslationName);
-    ccAddExternalFunctionForPlugin("GetViewportX",             (void*)GetViewportX);
-    ccAddExternalFunctionForPlugin("GetViewportY",             (void*)GetViewportY);
-    ccAddExternalFunctionForPlugin("GetWalkableAreaAtRoom",    (void*)GetWalkableAreaAtRoom);
-    ccAddExternalFunctionForPlugin("GetWalkableAreaAt",        (void*)GetWalkableAreaAtScreen);
-    ccAddExternalFunctionForPlugin("GetWalkableAreaAtScreen",  (void*)GetWalkableAreaAtScreen);
-    ccAddExternalFunctionForPlugin("GiveScore",                (void*)GiveScore);
-    ccAddExternalFunctionForPlugin("HasPlayerBeenInRoom",      (void*)HasPlayerBeenInRoom);
-    ccAddExternalFunctionForPlugin("HideMouseCursor",          (void*)HideMouseCursor);
-    ccAddExternalFunctionForPlugin("InputBox",                 (void*)sc_inputbox);
-    ccAddExternalFunctionForPlugin("InterfaceOff",             (void*)InterfaceOff);
-    ccAddExternalFunctionForPlugin("InterfaceOn",              (void*)InterfaceOn);
-    ccAddExternalFunctionForPlugin("IntToFloat",               (void*)IntToFloat);
-    ccAddExternalFunctionForPlugin("InventoryScreen",          (void*)sc_invscreen);
-    ccAddExternalFunctionForPlugin("IsButtonDown",             (void*)IsButtonDown);
-    ccAddExternalFunctionForPlugin("IsChannelPlaying",         (void*)IsChannelPlaying);
-    ccAddExternalFunctionForPlugin("IsGamePaused",             (void*)IsGamePaused);
-    ccAddExternalFunctionForPlugin("IsGUIOn",                  (void*)IsGUIOn);
-    ccAddExternalFunctionForPlugin("IsInteractionAvailable",   (void*)IsInteractionAvailable);
-    ccAddExternalFunctionForPlugin("IsInventoryInteractionAvailable", (void*)IsInventoryInteractionAvailable);
-    ccAddExternalFunctionForPlugin("IsInterfaceEnabled",       (void*)IsInterfaceEnabled);
-    ccAddExternalFunctionForPlugin("IsKeyPressed",             (void*)IsKeyPressed);
-    ccAddExternalFunctionForPlugin("IsMusicPlaying",           (void*)IsMusicPlaying);
-    ccAddExternalFunctionForPlugin("IsMusicVoxAvailable",      (void*)IsMusicVoxAvailable);
-    ccAddExternalFunctionForPlugin("IsObjectAnimating",        (void*)IsObjectAnimating);
-    ccAddExternalFunctionForPlugin("IsObjectMoving",           (void*)IsObjectMoving);
-    ccAddExternalFunctionForPlugin("IsObjectOn",               (void*)IsObjectOn);
-    ccAddExternalFunctionForPlugin("IsOverlayValid",           (void*)IsOverlayValid);
-    ccAddExternalFunctionForPlugin("IsSoundPlaying",           (void*)IsSoundPlaying);
-    ccAddExternalFunctionForPlugin("IsTimerExpired",           (void*)IsTimerExpired);
-    ccAddExternalFunctionForPlugin("IsTranslationAvailable",   (void*)IsTranslationAvailable);
-    ccAddExternalFunctionForPlugin("IsVoxAvailable",           (void*)IsVoxAvailable);
-    ccAddExternalFunctionForPlugin("ListBoxAdd",               (void*)ListBoxAdd);
-    ccAddExternalFunctionForPlugin("ListBoxClear",             (void*)ListBoxClear);
-    ccAddExternalFunctionForPlugin("ListBoxDirList",           (void*)ListBoxDirList);
-    ccAddExternalFunctionForPlugin("ListBoxGetItemText",       (void*)ListBoxGetItemText);
-    ccAddExternalFunctionForPlugin("ListBoxGetNumItems",       (void*)ListBoxGetNumItems);
-    ccAddExternalFunctionForPlugin("ListBoxGetSelected",       (void*)ListBoxGetSelected);
-    ccAddExternalFunctionForPlugin("ListBoxRemove",            (void*)ListBoxRemove);
-    ccAddExternalFunctionForPlugin("ListBoxSaveGameList",      (void*)ListBoxSaveGameList);
-    ccAddExternalFunctionForPlugin("ListBoxSetSelected",       (void*)ListBoxSetSelected);
-    ccAddExternalFunctionForPlugin("ListBoxSetTopItem",        (void*)ListBoxSetTopItem);
-    ccAddExternalFunctionForPlugin("LoadImageFile",            (void*)LoadImageFile);
-    ccAddExternalFunctionForPlugin("LoadSaveSlotScreenshot",   (void*)LoadSaveSlotScreenshot);
-    ccAddExternalFunctionForPlugin("LoseInventory",            (void*)lose_inventory);
-    ccAddExternalFunctionForPlugin("LoseInventoryFromCharacter", (void*)LoseInventoryFromCharacter);
-    ccAddExternalFunctionForPlugin("MergeObject",              (void*)MergeObject);
-    ccAddExternalFunctionForPlugin("MoveCharacter",            (void*)MoveCharacter);
-    ccAddExternalFunctionForPlugin("MoveCharacterBlocking",    (void*)MoveCharacterBlocking);
-    ccAddExternalFunctionForPlugin("MoveCharacterDirect",      (void*)MoveCharacterDirect);
-    ccAddExternalFunctionForPlugin("MoveCharacterPath",        (void*)MoveCharacterPath);
-    ccAddExternalFunctionForPlugin("MoveCharacterStraight",    (void*)MoveCharacterStraight);
-    ccAddExternalFunctionForPlugin("MoveCharacterToHotspot",   (void*)MoveCharacterToHotspot);
-    ccAddExternalFunctionForPlugin("MoveCharacterToObject",    (void*)MoveCharacterToObject);
-    ccAddExternalFunctionForPlugin("MoveObject",               (void*)MoveObject);
-    ccAddExternalFunctionForPlugin("MoveObjectDirect",         (void*)MoveObjectDirect);
-    ccAddExternalFunctionForPlugin("MoveOverlay",              (void*)MoveOverlay);
-    ccAddExternalFunctionForPlugin("MoveToWalkableArea",       (void*)MoveToWalkableArea);
-    ccAddExternalFunctionForPlugin("NewRoom",                  (void*)NewRoom);
-    ccAddExternalFunctionForPlugin("NewRoomEx",                (void*)NewRoomEx);
-    ccAddExternalFunctionForPlugin("NewRoomNPC",               (void*)NewRoomNPC);
-    ccAddExternalFunctionForPlugin("ObjectOff",                (void*)ObjectOff);
-    ccAddExternalFunctionForPlugin("ObjectOn",                 (void*)ObjectOn);
-    ccAddExternalFunctionForPlugin("ParseText",                (void*)ParseText);
-    ccAddExternalFunctionForPlugin("PauseGame",                (void*)PauseGame);
-    ccAddExternalFunctionForPlugin("PlayAmbientSound",         (void*)PlayAmbientSound);
-    ccAddExternalFunctionForPlugin("PlayFlic",                 (void*)PlayFlic);
-    ccAddExternalFunctionForPlugin("PlayMP3File",              (void*)PlayMP3File);
-    ccAddExternalFunctionForPlugin("PlayMusic",                (void*)PlayMusicResetQueue);
-    ccAddExternalFunctionForPlugin("PlayMusicQueued",          (void*)PlayMusicQueued);
-    ccAddExternalFunctionForPlugin("PlaySilentMIDI",           (void*)PlaySilentMIDI);
-    ccAddExternalFunctionForPlugin("PlaySound",                (void*)play_sound);
-    ccAddExternalFunctionForPlugin("PlaySoundEx",              (void*)PlaySoundEx);
-    ccAddExternalFunctionForPlugin("PlayVideo",                (void*)PlayVideo);
-    ccAddExternalFunctionForPlugin("ProcessClick",             (void*)RoomProcessClick);
-    ccAddExternalFunctionForPlugin("QuitGame",                 (void*)QuitGame);
-    ccAddExternalFunctionForPlugin("Random",                   (void*)__Rand);
-    ccAddExternalFunctionForPlugin("RawClearScreen",           (void*)RawClear);
-    ccAddExternalFunctionForPlugin("RawDrawCircle",            (void*)RawDrawCircle);
-    ccAddExternalFunctionForPlugin("RawDrawFrameTransparent",  (void*)RawDrawFrameTransparent);
-    ccAddExternalFunctionForPlugin("RawDrawImage",             (void*)RawDrawImage);
-    ccAddExternalFunctionForPlugin("RawDrawImageOffset",       (void*)RawDrawImageOffset);
-    ccAddExternalFunctionForPlugin("RawDrawImageResized",      (void*)RawDrawImageResized);
-    ccAddExternalFunctionForPlugin("RawDrawImageTransparent",  (void*)RawDrawImageTransparent);
-    ccAddExternalFunctionForPlugin("RawDrawLine",              (void*)RawDrawLine);
-    ccAddExternalFunctionForPlugin("RawDrawRectangle",         (void*)RawDrawRectangle);
-    ccAddExternalFunctionForPlugin("RawDrawTriangle",          (void*)RawDrawTriangle);
-    ccAddExternalFunctionForPlugin("RawPrint",                 (void*)ScPl_RawPrint);
-    ccAddExternalFunctionForPlugin("RawPrintMessageWrapped",   (void*)RawPrintMessageWrapped);
-    ccAddExternalFunctionForPlugin("RawRestoreScreen",         (void*)RawRestoreScreen);
-    ccAddExternalFunctionForPlugin("RawRestoreScreenTinted",   (void*)RawRestoreScreenTinted);
-    ccAddExternalFunctionForPlugin("RawSaveScreen",            (void*)RawSaveScreen);
-    ccAddExternalFunctionForPlugin("RawSetColor",              (void*)RawSetColor);
-    ccAddExternalFunctionForPlugin("RawSetColorRGB",           (void*)RawSetColorRGB);
-    ccAddExternalFunctionForPlugin("RefreshMouse",             (void*)RefreshMouse);
-    ccAddExternalFunctionForPlugin("ReleaseCharacterView",     (void*)ReleaseCharacterView);
-    ccAddExternalFunctionForPlugin("ReleaseViewport",          (void*)ReleaseViewport);
-    ccAddExternalFunctionForPlugin("RemoveObjectTint",         (void*)RemoveObjectTint);
-    ccAddExternalFunctionForPlugin("RemoveOverlay",            (void*)RemoveOverlay);
-    ccAddExternalFunctionForPlugin("RemoveWalkableArea",       (void*)RemoveWalkableArea);
-    ccAddExternalFunctionForPlugin("ResetRoom",                (void*)ResetRoom);
-    ccAddExternalFunctionForPlugin("RestartGame",              (void*)restart_game);
-    ccAddExternalFunctionForPlugin("RestoreGameDialog",        (void*)restore_game_dialog);
-    ccAddExternalFunctionForPlugin("RestoreGameSlot",          (void*)RestoreGameSlot);
-    ccAddExternalFunctionForPlugin("RestoreWalkableArea",      (void*)RestoreWalkableArea);
-    ccAddExternalFunctionForPlugin("RunAGSGame",               (void*)RunAGSGame);
-    ccAddExternalFunctionForPlugin("RunCharacterInteraction",  (void*)RunCharacterInteraction);
-    ccAddExternalFunctionForPlugin("RunDialog",                (void*)RunDialog);
-    ccAddExternalFunctionForPlugin("RunHotspotInteraction",    (void*)RunHotspotInteraction);
-    ccAddExternalFunctionForPlugin("RunInventoryInteraction",  (void*)RunInventoryInteraction);
-    ccAddExternalFunctionForPlugin("RunObjectInteraction",     (void*)RunObjectInteraction);
-    ccAddExternalFunctionForPlugin("RunRegionInteraction",     (void*)RunRegionInteraction);
-    ccAddExternalFunctionForPlugin("Said",                     (void*)Said);
-    ccAddExternalFunctionForPlugin("SaidUnknownWord",          (void*)SaidUnknownWord);
-    ccAddExternalFunctionForPlugin("SaveCursorForLocationChange", (void*)SaveCursorForLocationChange);
-    ccAddExternalFunctionForPlugin("SaveGameDialog",           (void*)save_game_dialog);
-    ccAddExternalFunctionForPlugin("SaveGameSlot",             (void*)save_game);
-    ccAddExternalFunctionForPlugin("SaveScreenShot",           (void*)SaveScreenShot);
-    ccAddExternalFunctionForPlugin("SeekMIDIPosition",         (void*)SeekMIDIPosition);
-    ccAddExternalFunctionForPlugin("SeekMODPattern",           (void*)SeekMODPattern);
-    ccAddExternalFunctionForPlugin("SeekMP3PosMillis",         (void*)SeekMP3PosMillis);
-    ccAddExternalFunctionForPlugin("SetActiveInventory",       (void*)SetActiveInventory);
-    ccAddExternalFunctionForPlugin("SetAmbientTint",           (void*)SetAmbientTint);
-    ccAddExternalFunctionForPlugin("SetAreaLightLevel",        (void*)SetAreaLightLevel);
-    ccAddExternalFunctionForPlugin("SetAreaScaling",           (void*)SetAreaScaling);
-    ccAddExternalFunctionForPlugin("SetBackgroundFrame",       (void*)SetBackgroundFrame);
-    ccAddExternalFunctionForPlugin("SetButtonPic",             (void*)SetButtonPic);
-    ccAddExternalFunctionForPlugin("SetButtonText",            (void*)SetButtonText);
-    ccAddExternalFunctionForPlugin("SetChannelVolume",         (void*)SetChannelVolume);
-    ccAddExternalFunctionForPlugin("SetCharacterBaseline",     (void*)SetCharacterBaseline);
-    ccAddExternalFunctionForPlugin("SetCharacterClickable",    (void*)SetCharacterClickable);
-    ccAddExternalFunctionForPlugin("SetCharacterFrame",        (void*)SetCharacterFrame);
-    ccAddExternalFunctionForPlugin("SetCharacterIdle",         (void*)SetCharacterIdle);
-    ccAddExternalFunctionForPlugin("SetCharacterIgnoreLight",  (void*)SetCharacterIgnoreLight);
-    ccAddExternalFunctionForPlugin("SetCharacterIgnoreWalkbehinds", (void*)SetCharacterIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("SetCharacterProperty",     (void*)SetCharacterProperty);
-    ccAddExternalFunctionForPlugin("SetCharacterBlinkView",    (void*)SetCharacterBlinkView);
-    ccAddExternalFunctionForPlugin("SetCharacterSpeechView",   (void*)SetCharacterSpeechView);
-    ccAddExternalFunctionForPlugin("SetCharacterSpeed",        (void*)SetCharacterSpeed);
-    ccAddExternalFunctionForPlugin("SetCharacterSpeedEx",      (void*)SetCharacterSpeedEx);
-    ccAddExternalFunctionForPlugin("SetCharacterTransparency", (void*)SetCharacterTransparency);
-    ccAddExternalFunctionForPlugin("SetCharacterView",         (void*)SetCharacterView);
-    ccAddExternalFunctionForPlugin("SetCharacterViewEx",       (void*)SetCharacterViewEx);
-    ccAddExternalFunctionForPlugin("SetCharacterViewOffset",   (void*)SetCharacterViewOffset);
-    ccAddExternalFunctionForPlugin("SetCursorMode",            (void*)set_cursor_mode);
-    ccAddExternalFunctionForPlugin("SetDefaultCursor",         (void*)set_default_cursor);
-    ccAddExternalFunctionForPlugin("SetDialogOption",          (void*)SetDialogOption);
-    ccAddExternalFunctionForPlugin("SetDigitalMasterVolume",   (void*)SetDigitalMasterVolume);
-    ccAddExternalFunctionForPlugin("SetFadeColor",             (void*)SetFadeColor);
-    ccAddExternalFunctionForPlugin("SetFrameSound",            (void*)SetFrameSound);
-    ccAddExternalFunctionForPlugin("SetGameOption",            (void*)SetGameOption);
-    ccAddExternalFunctionForPlugin("SetGameSpeed",             (void*)SetGameSpeed);
-    ccAddExternalFunctionForPlugin("SetGlobalInt",             (void*)SetGlobalInt);
-    ccAddExternalFunctionForPlugin("SetGlobalString",          (void*)SetGlobalString);
-    ccAddExternalFunctionForPlugin("SetGraphicalVariable",     (void*)SetGraphicalVariable);
-    ccAddExternalFunctionForPlugin("SetGUIBackgroundPic",      (void*)SetGUIBackgroundPic);
-    ccAddExternalFunctionForPlugin("SetGUIClickable",          (void*)SetGUIClickable);
-    ccAddExternalFunctionForPlugin("SetGUIObjectEnabled",      (void*)SetGUIObjectEnabled);
-    ccAddExternalFunctionForPlugin("SetGUIObjectPosition",     (void*)SetGUIObjectPosition);
-    ccAddExternalFunctionForPlugin("SetGUIObjectSize",         (void*)SetGUIObjectSize);
-    ccAddExternalFunctionForPlugin("SetGUIPosition",           (void*)SetGUIPosition);
-    ccAddExternalFunctionForPlugin("SetGUISize",               (void*)SetGUISize);
-    ccAddExternalFunctionForPlugin("SetGUITransparency",       (void*)SetGUITransparency);
-    ccAddExternalFunctionForPlugin("SetGUIZOrder",             (void*)SetGUIZOrder);
-    ccAddExternalFunctionForPlugin("SetInvItemName",           (void*)SetInvItemName);
-    ccAddExternalFunctionForPlugin("SetInvItemPic",            (void*)set_inv_item_pic);
-    ccAddExternalFunctionForPlugin("SetInvDimensions",         (void*)SetInvDimensions);
-    ccAddExternalFunctionForPlugin("SetLabelColor",            (void*)SetLabelColor);
-    ccAddExternalFunctionForPlugin("SetLabelFont",             (void*)SetLabelFont);
-    ccAddExternalFunctionForPlugin("SetLabelText",             (void*)SetLabelText);
-    ccAddExternalFunctionForPlugin("SetMouseBounds",           (void*)SetMouseBounds);
-    ccAddExternalFunctionForPlugin("SetMouseCursor",           (void*)set_mouse_cursor);
-    ccAddExternalFunctionForPlugin("SetMousePosition",         (void*)SetMousePosition);
-    ccAddExternalFunctionForPlugin("SetMultitaskingMode",      (void*)SetMultitasking);
-    ccAddExternalFunctionForPlugin("SetMusicMasterVolume",     (void*)SetMusicMasterVolume);
-    ccAddExternalFunctionForPlugin("SetMusicRepeat",           (void*)SetMusicRepeat);
-    ccAddExternalFunctionForPlugin("SetMusicVolume",           (void*)SetMusicVolume);
-    ccAddExternalFunctionForPlugin("SetNextCursorMode",        (void*)SetNextCursor);
-    ccAddExternalFunctionForPlugin("SetNextScreenTransition",  (void*)SetNextScreenTransition);
-    ccAddExternalFunctionForPlugin("SetNormalFont",            (void*)SetNormalFont);
-    ccAddExternalFunctionForPlugin("SetObjectBaseline",        (void*)SetObjectBaseline);
-    ccAddExternalFunctionForPlugin("SetObjectClickable",       (void*)SetObjectClickable);
-    ccAddExternalFunctionForPlugin("SetObjectFrame",           (void*)SetObjectFrame);
-    ccAddExternalFunctionForPlugin("SetObjectGraphic",         (void*)SetObjectGraphic);
-    ccAddExternalFunctionForPlugin("SetObjectIgnoreWalkbehinds", (void*)SetObjectIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("SetObjectPosition",        (void*)SetObjectPosition);
-    ccAddExternalFunctionForPlugin("SetObjectTint",            (void*)SetObjectTint);
-    ccAddExternalFunctionForPlugin("SetObjectTransparency",    (void*)SetObjectTransparency);
-    ccAddExternalFunctionForPlugin("SetObjectView",            (void*)SetObjectView);
-    //  ccAddExternalFunctionForPlugin("SetPalette",           (void*)scSetPal);
-    ccAddExternalFunctionForPlugin("SetPalRGB",                (void*)SetPalRGB);
-    ccAddExternalFunctionForPlugin("SetPlayerCharacter",       (void*)SetPlayerCharacter);
-    ccAddExternalFunctionForPlugin("SetRegionTint",            (void*)SetRegionTint);
-    ccAddExternalFunctionForPlugin("SetRestartPoint",          (void*)SetRestartPoint);
-    ccAddExternalFunctionForPlugin("SetScreenTransition",      (void*)SetScreenTransition);
-    ccAddExternalFunctionForPlugin("SetSkipSpeech",            (void*)SetSkipSpeech);
-    ccAddExternalFunctionForPlugin("SetSliderValue",           (void*)SetSliderValue);
-    ccAddExternalFunctionForPlugin("SetSoundVolume",           (void*)SetSoundVolume);
-    ccAddExternalFunctionForPlugin("SetSpeechFont",            (void*)SetSpeechFont);
-    ccAddExternalFunctionForPlugin("SetSpeechStyle",           (void*)SetSpeechStyle);
-    ccAddExternalFunctionForPlugin("SetSpeechVolume",          (void*)SetSpeechVolume);
-    ccAddExternalFunctionForPlugin("SetTalkingColor",          (void*)SetTalkingColor);
-    ccAddExternalFunctionForPlugin("SetTextBoxFont",           (void*)SetTextBoxFont);
-    ccAddExternalFunctionForPlugin("SetTextBoxText",           (void*)SetTextBoxText);
-    ccAddExternalFunctionForPlugin("SetTextOverlay",           (void*)ScPl_SetTextOverlay);
-    ccAddExternalFunctionForPlugin("SetTextWindowGUI",         (void*)SetTextWindowGUI);
-    ccAddExternalFunctionForPlugin("SetTimer",                 (void*)script_SetTimer);
-    ccAddExternalFunctionForPlugin("SetViewport",              (void*)SetViewport);
-    ccAddExternalFunctionForPlugin("SetVoiceMode",             (void*)SetVoiceMode);
-    ccAddExternalFunctionForPlugin("SetWalkBehindBase",        (void*)SetWalkBehindBase);
-    ccAddExternalFunctionForPlugin("ShakeScreen",              (void*)ShakeScreen);
-    ccAddExternalFunctionForPlugin("ShakeScreenBackground",    (void*)ShakeScreenBackground);
-    ccAddExternalFunctionForPlugin("ShowMouseCursor",          (void*)ShowMouseCursor);
-    ccAddExternalFunctionForPlugin("SkipUntilCharacterStops",  (void*)SkipUntilCharacterStops);
-    ccAddExternalFunctionForPlugin("StartCutscene",            (void*)StartCutscene);
-    ccAddExternalFunctionForPlugin("StartRecording",           (void*)scStartRecording);
-    ccAddExternalFunctionForPlugin("StopAmbientSound",         (void*)StopAmbientSound);
-    ccAddExternalFunctionForPlugin("StopChannel",              (void*)stop_and_destroy_channel);
-    ccAddExternalFunctionForPlugin("StopDialog",               (void*)StopDialog);
-    ccAddExternalFunctionForPlugin("StopMoving",               (void*)StopMoving);
-    ccAddExternalFunctionForPlugin("StopMusic",                (void*)scr_StopMusic);
-    ccAddExternalFunctionForPlugin("StopObjectMoving",         (void*)StopObjectMoving);
-    ccAddExternalFunctionForPlugin("StrCat",                   (void*)_sc_strcat);
-    ccAddExternalFunctionForPlugin("StrCaseComp",              (void*)ags_stricmp);
-    ccAddExternalFunctionForPlugin("StrComp",                  (void*)strcmp);
-    ccAddExternalFunctionForPlugin("StrContains",              (void*)StrContains);
-    ccAddExternalFunctionForPlugin("StrCopy",                  (void*)_sc_strcpy);
-    ccAddExternalFunctionForPlugin("StrFormat",                (void*)ScPl_sc_sprintf);
-    ccAddExternalFunctionForPlugin("StrGetCharAt",             (void*)StrGetCharAt);
-    ccAddExternalFunctionForPlugin("StringToInt",              (void*)StringToInt);
-    ccAddExternalFunctionForPlugin("StrLen",                   (void*)strlen);
-    ccAddExternalFunctionForPlugin("StrSetCharAt",             (void*)StrSetCharAt);
-    ccAddExternalFunctionForPlugin("StrToLowerCase",           (void*)_sc_strlower);
-    ccAddExternalFunctionForPlugin("StrToUpperCase",           (void*)_sc_strupper);
-    ccAddExternalFunctionForPlugin("TintScreen",               (void*)TintScreen);
-    ccAddExternalFunctionForPlugin("UnPauseGame",              (void*)UnPauseGame);
-    ccAddExternalFunctionForPlugin("UpdateInventory",          (void*)update_invorder);
-    ccAddExternalFunctionForPlugin("UpdatePalette",            (void*)UpdatePalette);
-    ccAddExternalFunctionForPlugin("Wait",                     (void*)scrWait);
-    ccAddExternalFunctionForPlugin("WaitKey",                  (void*)WaitKey);
-    ccAddExternalFunctionForPlugin("WaitMouseKey",             (void*)WaitMouseKey);
-    ccAddExternalFunctionForPlugin("WaitInput",                (void*)WaitInput);
+    ccAddExternalFunctions(global_api);
 }

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -828,16 +828,12 @@ RuntimeScriptValue Sc_GetWalkableAreaAtScreen(const RuntimeScriptValue *params, 
 
 RuntimeScriptValue Sc_GetDrawingSurfaceForWalkableArea(const RuntimeScriptValue *params, int32_t param_count)
 {
-    (void)params; (void)param_count;
-    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkable);
-    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+    API_SCALL_OBJAUTO(ScriptDrawingSurface, GetDrawingSurfaceForWalkableArea);
 }
 
 RuntimeScriptValue Sc_GetDrawingSurfaceForWalkbehind(const RuntimeScriptValue *params, int32_t param_count)
 {
-    (void)params; (void)param_count;
-    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaWalkBehind);
-    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+    API_SCALL_OBJAUTO(ScriptDrawingSurface, GetDrawingSurfaceForWalkbehind);
 }
 
 // void (int amnt) 

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -2224,7 +2224,7 @@ RuntimeScriptValue Sc_SkipWait(const RuntimeScriptValue *params, int32_t param_c
 
 //=============================================================================
 //
-// Exclusive API for Plugins
+// Exclusive variadic API implementation for Plugins
 //
 //=============================================================================
 

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -882,72 +882,49 @@ RuntimeScriptValue Sc_GUI_GetShown(void *self, const RuntimeScriptValue *params,
 
 void RegisterGUIAPI()
 {
-    ccAddExternalObjectFunction("GUI::Centre^0",                Sc_GUI_Centre);
-    ccAddExternalObjectFunction("GUI::Click^1",                 Sc_GUI_Click);
-    ccAddExternalStaticFunction("GUI::GetAtScreenXY^2",         Sc_GetGUIAtLocation);
-    ccAddExternalStaticFunction("GUI::ProcessClick^3",          Sc_GUI_ProcessClick);
-    ccAddExternalObjectFunction("GUI::SetPosition^2",           Sc_GUI_SetPosition);
-    ccAddExternalObjectFunction("GUI::SetSize^2",               Sc_GUI_SetSize);
-    ccAddExternalObjectFunction("GUI::get_BackgroundGraphic",   Sc_GUI_GetBackgroundGraphic);
-    ccAddExternalObjectFunction("GUI::set_BackgroundGraphic",   Sc_GUI_SetBackgroundGraphic);
-    ccAddExternalObjectFunction("GUI::get_BackgroundColor",     Sc_GUI_GetBackgroundColor);
-    ccAddExternalObjectFunction("GUI::set_BackgroundColor",     Sc_GUI_SetBackgroundColor);
-    ccAddExternalObjectFunction("GUI::get_BorderColor",         Sc_GUI_GetBorderColor);
-    ccAddExternalObjectFunction("GUI::set_BorderColor",         Sc_GUI_SetBorderColor);
-    ccAddExternalObjectFunction("GUI::get_Clickable",           Sc_GUI_GetClickable);
-    ccAddExternalObjectFunction("GUI::set_Clickable",           Sc_GUI_SetClickable);
-    ccAddExternalObjectFunction("GUI::get_ControlCount",        Sc_GUI_GetControlCount);
-    ccAddExternalObjectFunction("GUI::geti_Controls",           Sc_GUI_GetiControls);
-    ccAddExternalObjectFunction("GUI::get_Height",              Sc_GUI_GetHeight);
-    ccAddExternalObjectFunction("GUI::set_Height",              Sc_GUI_SetHeight);
-    ccAddExternalObjectFunction("GUI::get_ID",                  Sc_GUI_GetID);
-    ccAddExternalObjectFunction("GUI::get_AsTextWindow",        Sc_GUI_AsTextWindow);
-    ccAddExternalObjectFunction("GUI::get_PopupStyle",          Sc_GUI_GetPopupStyle);
-    ccAddExternalObjectFunction("GUI::get_PopupYPos",           Sc_GUI_GetPopupYPos);
-    ccAddExternalObjectFunction("GUI::set_PopupYPos",           Sc_GUI_SetPopupYPos);
-    ccAddExternalObjectFunction("TextWindowGUI::get_TextColor", Sc_GUI_GetTextColor);
-    ccAddExternalObjectFunction("TextWindowGUI::set_TextColor", Sc_GUI_SetTextColor);
-    ccAddExternalObjectFunction("TextWindowGUI::get_TextPadding", Sc_GUI_GetTextPadding);
-    ccAddExternalObjectFunction("TextWindowGUI::set_TextPadding", Sc_GUI_SetTextPadding);
-    ccAddExternalObjectFunction("GUI::get_Transparency",        Sc_GUI_GetTransparency);
-    ccAddExternalObjectFunction("GUI::set_Transparency",        Sc_GUI_SetTransparency);
-    ccAddExternalObjectFunction("GUI::get_Visible",             Sc_GUI_GetVisible);
-    ccAddExternalObjectFunction("GUI::set_Visible",             Sc_GUI_SetVisible);
-    ccAddExternalObjectFunction("GUI::get_Width",               Sc_GUI_GetWidth);
-    ccAddExternalObjectFunction("GUI::set_Width",               Sc_GUI_SetWidth);
-    ccAddExternalObjectFunction("GUI::get_X",                   Sc_GUI_GetX);
-    ccAddExternalObjectFunction("GUI::set_X",                   Sc_GUI_SetX);
-    ccAddExternalObjectFunction("GUI::get_Y",                   Sc_GUI_GetY);
-    ccAddExternalObjectFunction("GUI::set_Y",                   Sc_GUI_SetY);
-    ccAddExternalObjectFunction("GUI::get_ZOrder",              Sc_GUI_GetZOrder);
-    ccAddExternalObjectFunction("GUI::set_ZOrder",              Sc_GUI_SetZOrder);
-    ccAddExternalObjectFunction("GUI::get_Shown",               Sc_GUI_GetShown);
+    ScFnRegister gui_api[] = {
+        { "GUI::GetAtScreenXY^2",         API_FN_PAIR(GetGUIAtLocation) },
+        { "GUI::ProcessClick^3",          API_FN_PAIR(GUI_ProcessClick) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "GUI::Centre^0",                API_FN_PAIR(GUI_Centre) },
+        { "GUI::Click^1",                 API_FN_PAIR(GUI_Click) },
+        { "GUI::SetPosition^2",           API_FN_PAIR(GUI_SetPosition) },
+        { "GUI::SetSize^2",               API_FN_PAIR(GUI_SetSize) },
+        { "GUI::get_BackgroundGraphic",   API_FN_PAIR(GUI_GetBackgroundGraphic) },
+        { "GUI::set_BackgroundGraphic",   API_FN_PAIR(GUI_SetBackgroundGraphic) },
+        { "GUI::get_BackgroundColor",     API_FN_PAIR(GUI_GetBackgroundColor) },
+        { "GUI::set_BackgroundColor",     API_FN_PAIR(GUI_SetBackgroundColor) },
+        { "GUI::get_BorderColor",         API_FN_PAIR(GUI_GetBorderColor) },
+        { "GUI::set_BorderColor",         API_FN_PAIR(GUI_SetBorderColor) },
+        { "GUI::get_Clickable",           API_FN_PAIR(GUI_GetClickable) },
+        { "GUI::set_Clickable",           API_FN_PAIR(GUI_SetClickable) },
+        { "GUI::get_ControlCount",        API_FN_PAIR(GUI_GetControlCount) },
+        { "GUI::geti_Controls",           API_FN_PAIR(GUI_GetiControls) },
+        { "GUI::get_Height",              API_FN_PAIR(GUI_GetHeight) },
+        { "GUI::set_Height",              API_FN_PAIR(GUI_SetHeight) },
+        { "GUI::get_ID",                  API_FN_PAIR(GUI_GetID) },
+        { "GUI::get_AsTextWindow",        API_FN_PAIR(GUI_AsTextWindow) },
+        { "GUI::get_PopupStyle",          API_FN_PAIR(GUI_GetPopupStyle) },
+        { "GUI::get_PopupYPos",           API_FN_PAIR(GUI_GetPopupYPos) },
+        { "GUI::set_PopupYPos",           API_FN_PAIR(GUI_SetPopupYPos) },
+        { "TextWindowGUI::get_TextColor", API_FN_PAIR(GUI_GetTextColor) },
+        { "TextWindowGUI::set_TextColor", API_FN_PAIR(GUI_SetTextColor) },
+        { "TextWindowGUI::get_TextPadding", API_FN_PAIR(GUI_GetTextPadding) },
+        { "TextWindowGUI::set_TextPadding", API_FN_PAIR(GUI_SetTextPadding) },
+        { "GUI::get_Transparency",        API_FN_PAIR(GUI_GetTransparency) },
+        { "GUI::set_Transparency",        API_FN_PAIR(GUI_SetTransparency) },
+        { "GUI::get_Visible",             API_FN_PAIR(GUI_GetVisible) },
+        { "GUI::set_Visible",             API_FN_PAIR(GUI_SetVisible) },
+        { "GUI::get_Width",               API_FN_PAIR(GUI_GetWidth) },
+        { "GUI::set_Width",               API_FN_PAIR(GUI_SetWidth) },
+        { "GUI::get_X",                   API_FN_PAIR(GUI_GetX) },
+        { "GUI::set_X",                   API_FN_PAIR(GUI_SetX) },
+        { "GUI::get_Y",                   API_FN_PAIR(GUI_GetY) },
+        { "GUI::set_Y",                   API_FN_PAIR(GUI_SetY) },
+        { "GUI::get_ZOrder",              API_FN_PAIR(GUI_GetZOrder) },
+        { "GUI::set_ZOrder",              API_FN_PAIR(GUI_SetZOrder) },
+        { "GUI::get_Shown",               API_FN_PAIR(GUI_GetShown) },
+    };
 
-    ccAddExternalFunctionForPlugin("GUI::Centre^0",                (void*)GUI_Centre);
-    ccAddExternalFunctionForPlugin("GUI::GetAtScreenXY^2",         (void*)GetGUIAtLocation);
-    ccAddExternalFunctionForPlugin("GUI::SetPosition^2",           (void*)GUI_SetPosition);
-    ccAddExternalFunctionForPlugin("GUI::SetSize^2",               (void*)GUI_SetSize);
-    ccAddExternalFunctionForPlugin("GUI::get_BackgroundGraphic",   (void*)GUI_GetBackgroundGraphic);
-    ccAddExternalFunctionForPlugin("GUI::set_BackgroundGraphic",   (void*)GUI_SetBackgroundGraphic);
-    ccAddExternalFunctionForPlugin("GUI::get_Clickable",           (void*)GUI_GetClickable);
-    ccAddExternalFunctionForPlugin("GUI::set_Clickable",           (void*)GUI_SetClickable);
-    ccAddExternalFunctionForPlugin("GUI::get_ControlCount",        (void*)GUI_GetControlCount);
-    ccAddExternalFunctionForPlugin("GUI::geti_Controls",           (void*)GUI_GetiControls);
-    ccAddExternalFunctionForPlugin("GUI::get_Height",              (void*)GUI_GetHeight);
-    ccAddExternalFunctionForPlugin("GUI::set_Height",              (void*)GUI_SetHeight);
-    ccAddExternalFunctionForPlugin("GUI::get_ID",                  (void*)GUI_GetID);
-    ccAddExternalFunctionForPlugin("GUI::get_Transparency",        (void*)GUI_GetTransparency);
-    ccAddExternalFunctionForPlugin("GUI::set_Transparency",        (void*)GUI_SetTransparency);
-    ccAddExternalFunctionForPlugin("GUI::get_Visible",             (void*)GUI_GetVisible);
-    ccAddExternalFunctionForPlugin("GUI::set_Visible",             (void*)GUI_SetVisible);
-    ccAddExternalFunctionForPlugin("GUI::get_Width",               (void*)GUI_GetWidth);
-    ccAddExternalFunctionForPlugin("GUI::set_Width",               (void*)GUI_SetWidth);
-    ccAddExternalFunctionForPlugin("GUI::get_X",                   (void*)GUI_GetX);
-    ccAddExternalFunctionForPlugin("GUI::set_X",                   (void*)GUI_SetX);
-    ccAddExternalFunctionForPlugin("GUI::get_Y",                   (void*)GUI_GetY);
-    ccAddExternalFunctionForPlugin("GUI::set_Y",                   (void*)GUI_SetY);
-    ccAddExternalFunctionForPlugin("GUI::get_ZOrder",              (void*)GUI_GetZOrder);
-    ccAddExternalFunctionForPlugin("GUI::set_ZOrder",              (void*)GUI_SetZOrder);
+    ccAddExternalFunctions(gui_api);
 }

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -416,65 +416,40 @@ RuntimeScriptValue Sc_GUIControl_SetTransparency(void *self, const RuntimeScript
 
 void RegisterGUIControlAPI()
 {
-    ccAddExternalObjectFunction("GUIControl::BringToFront^0",   Sc_GUIControl_BringToFront);
-    ccAddExternalStaticFunction("GUIControl::GetAtScreenXY^2",  Sc_GetGUIControlAtLocation);
-    ccAddExternalObjectFunction("GUIControl::SendToBack^0",     Sc_GUIControl_SendToBack);
-    ccAddExternalObjectFunction("GUIControl::SetPosition^2",    Sc_GUIControl_SetPosition);
-    ccAddExternalObjectFunction("GUIControl::SetSize^2",        Sc_GUIControl_SetSize);
-    ccAddExternalObjectFunction("GUIControl::get_AsButton",     Sc_GUIControl_GetAsButton);
-    ccAddExternalObjectFunction("GUIControl::get_AsInvWindow",  Sc_GUIControl_GetAsInvWindow);
-    ccAddExternalObjectFunction("GUIControl::get_AsLabel",      Sc_GUIControl_GetAsLabel);
-    ccAddExternalObjectFunction("GUIControl::get_AsListBox",    Sc_GUIControl_GetAsListBox);
-    ccAddExternalObjectFunction("GUIControl::get_AsSlider",     Sc_GUIControl_GetAsSlider);
-    ccAddExternalObjectFunction("GUIControl::get_AsTextBox",    Sc_GUIControl_GetAsTextBox);
-    ccAddExternalObjectFunction("GUIControl::get_Clickable",    Sc_GUIControl_GetClickable);
-    ccAddExternalObjectFunction("GUIControl::set_Clickable",    Sc_GUIControl_SetClickable);
-    ccAddExternalObjectFunction("GUIControl::get_Enabled",      Sc_GUIControl_GetEnabled);
-    ccAddExternalObjectFunction("GUIControl::set_Enabled",      Sc_GUIControl_SetEnabled);
-    ccAddExternalObjectFunction("GUIControl::get_Height",       Sc_GUIControl_GetHeight);
-    ccAddExternalObjectFunction("GUIControl::set_Height",       Sc_GUIControl_SetHeight);
-    ccAddExternalObjectFunction("GUIControl::get_ID",           Sc_GUIControl_GetID);
-    ccAddExternalObjectFunction("GUIControl::get_OwningGUI",    Sc_GUIControl_GetOwningGUI);
-    ccAddExternalObjectFunction("GUIControl::get_Visible",      Sc_GUIControl_GetVisible);
-    ccAddExternalObjectFunction("GUIControl::set_Visible",      Sc_GUIControl_SetVisible);
-    ccAddExternalObjectFunction("GUIControl::get_Width",        Sc_GUIControl_GetWidth);
-    ccAddExternalObjectFunction("GUIControl::set_Width",        Sc_GUIControl_SetWidth);
-    ccAddExternalObjectFunction("GUIControl::get_X",            Sc_GUIControl_GetX);
-    ccAddExternalObjectFunction("GUIControl::set_X",            Sc_GUIControl_SetX);
-    ccAddExternalObjectFunction("GUIControl::get_Y",            Sc_GUIControl_GetY);
-    ccAddExternalObjectFunction("GUIControl::set_Y",            Sc_GUIControl_SetY);
-    ccAddExternalObjectFunction("GUIControl::get_ZOrder",       Sc_GUIControl_GetZOrder);
-    ccAddExternalObjectFunction("GUIControl::set_ZOrder",       Sc_GUIControl_SetZOrder);
-    ccAddExternalObjectFunction("GUIControl::get_Transparency", Sc_GUIControl_GetTransparency);
-    ccAddExternalObjectFunction("GUIControl::set_Transparency", Sc_GUIControl_SetTransparency);
+    ScFnRegister guicontrol_api[] = {
+        { "GUIControl::GetAtScreenXY^2",  API_FN_PAIR(GetGUIControlAtLocation) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "GUIControl::BringToFront^0",   API_FN_PAIR(GUIControl_BringToFront) },
+        { "GUIControl::SendToBack^0",     API_FN_PAIR(GUIControl_SendToBack) },
+        { "GUIControl::SetPosition^2",    API_FN_PAIR(GUIControl_SetPosition) },
+        { "GUIControl::SetSize^2",        API_FN_PAIR(GUIControl_SetSize) },
+        { "GUIControl::get_AsButton",     API_FN_PAIR(GUIControl_GetAsButton) },
+        { "GUIControl::get_AsInvWindow",  API_FN_PAIR(GUIControl_GetAsInvWindow) },
+        { "GUIControl::get_AsLabel",      API_FN_PAIR(GUIControl_GetAsLabel) },
+        { "GUIControl::get_AsListBox",    API_FN_PAIR(GUIControl_GetAsListBox) },
+        { "GUIControl::get_AsSlider",     API_FN_PAIR(GUIControl_GetAsSlider) },
+        { "GUIControl::get_AsTextBox",    API_FN_PAIR(GUIControl_GetAsTextBox) },
+        { "GUIControl::get_Clickable",    API_FN_PAIR(GUIControl_GetClickable) },
+        { "GUIControl::set_Clickable",    API_FN_PAIR(GUIControl_SetClickable) },
+        { "GUIControl::get_Enabled",      API_FN_PAIR(GUIControl_GetEnabled) },
+        { "GUIControl::set_Enabled",      API_FN_PAIR(GUIControl_SetEnabled) },
+        { "GUIControl::get_Height",       API_FN_PAIR(GUIControl_GetHeight) },
+        { "GUIControl::set_Height",       API_FN_PAIR(GUIControl_SetHeight) },
+        { "GUIControl::get_ID",           API_FN_PAIR(GUIControl_GetID) },
+        { "GUIControl::get_OwningGUI",    API_FN_PAIR(GUIControl_GetOwningGUI) },
+        { "GUIControl::get_Visible",      API_FN_PAIR(GUIControl_GetVisible) },
+        { "GUIControl::set_Visible",      API_FN_PAIR(GUIControl_SetVisible) },
+        { "GUIControl::get_Width",        API_FN_PAIR(GUIControl_GetWidth) },
+        { "GUIControl::set_Width",        API_FN_PAIR(GUIControl_SetWidth) },
+        { "GUIControl::get_X",            API_FN_PAIR(GUIControl_GetX) },
+        { "GUIControl::set_X",            API_FN_PAIR(GUIControl_SetX) },
+        { "GUIControl::get_Y",            API_FN_PAIR(GUIControl_GetY) },
+        { "GUIControl::set_Y",            API_FN_PAIR(GUIControl_SetY) },
+        { "GUIControl::get_ZOrder",       API_FN_PAIR(GUIControl_GetZOrder) },
+        { "GUIControl::set_ZOrder",       API_FN_PAIR(GUIControl_SetZOrder) },
+        { "GUIControl::get_Transparency", API_FN_PAIR(GUIControl_GetTransparency) },
+        { "GUIControl::set_Transparency", API_FN_PAIR(GUIControl_SetTransparency) },
+    };
 
-    ccAddExternalFunctionForPlugin("GUIControl::BringToFront^0",   (void*)GUIControl_BringToFront);
-    ccAddExternalFunctionForPlugin("GUIControl::GetAtScreenXY^2",  (void*)GetGUIControlAtLocation);
-    ccAddExternalFunctionForPlugin("GUIControl::SendToBack^0",     (void*)GUIControl_SendToBack);
-    ccAddExternalFunctionForPlugin("GUIControl::SetPosition^2",    (void*)GUIControl_SetPosition);
-    ccAddExternalFunctionForPlugin("GUIControl::SetSize^2",        (void*)GUIControl_SetSize);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsButton",     (void*)GUIControl_GetAsButton);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsInvWindow",  (void*)GUIControl_GetAsInvWindow);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsLabel",      (void*)GUIControl_GetAsLabel);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsListBox",    (void*)GUIControl_GetAsListBox);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsSlider",     (void*)GUIControl_GetAsSlider);
-    ccAddExternalFunctionForPlugin("GUIControl::get_AsTextBox",    (void*)GUIControl_GetAsTextBox);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Clickable",    (void*)GUIControl_GetClickable);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Clickable",    (void*)GUIControl_SetClickable);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Enabled",      (void*)GUIControl_GetEnabled);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Enabled",      (void*)GUIControl_SetEnabled);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Height",       (void*)GUIControl_GetHeight);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Height",       (void*)GUIControl_SetHeight);
-    ccAddExternalFunctionForPlugin("GUIControl::get_ID",           (void*)GUIControl_GetID);
-    ccAddExternalFunctionForPlugin("GUIControl::get_OwningGUI",    (void*)GUIControl_GetOwningGUI);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Visible",      (void*)GUIControl_GetVisible);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Visible",      (void*)GUIControl_SetVisible);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Width",        (void*)GUIControl_GetWidth);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Width",        (void*)GUIControl_SetWidth);
-    ccAddExternalFunctionForPlugin("GUIControl::get_X",            (void*)GUIControl_GetX);
-    ccAddExternalFunctionForPlugin("GUIControl::set_X",            (void*)GUIControl_SetX);
-    ccAddExternalFunctionForPlugin("GUIControl::get_Y",            (void*)GUIControl_GetY);
-    ccAddExternalFunctionForPlugin("GUIControl::set_Y",            (void*)GUIControl_SetY);
+    ccAddExternalFunctions(guicontrol_api);
 }

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -246,40 +246,27 @@ RuntimeScriptValue Sc_Hotspot_GetWalkToY(void *self, const RuntimeScriptValue *p
 
 void RegisterHotspotAPI()
 {
-    ccAddExternalStaticFunction("Hotspot::GetAtRoomXY^2",       Sc_GetHotspotAtRoom);
-    ccAddExternalStaticFunction("Hotspot::GetAtScreenXY^2",     Sc_GetHotspotAtScreen);
-    ccAddExternalStaticFunction("Hotspot::GetDrawingSurface",   Sc_Hotspot_GetDrawingSurface);
-    ccAddExternalObjectFunction("Hotspot::GetName^1",           Sc_Hotspot_GetName);
-    ccAddExternalObjectFunction("Hotspot::GetProperty^1",       Sc_Hotspot_GetProperty);
-    ccAddExternalObjectFunction("Hotspot::GetPropertyText^2",   Sc_Hotspot_GetPropertyText);
-    ccAddExternalObjectFunction("Hotspot::GetTextProperty^1",   Sc_Hotspot_GetTextProperty);
-    ccAddExternalObjectFunction("Hotspot::SetProperty^2",       Sc_Hotspot_SetProperty);
-    ccAddExternalObjectFunction("Hotspot::SetTextProperty^2",   Sc_Hotspot_SetTextProperty);
-    ccAddExternalObjectFunction("Hotspot::IsInteractionAvailable^1", Sc_Hotspot_IsInteractionAvailable);
-    ccAddExternalObjectFunction("Hotspot::RunInteraction^1",    Sc_Hotspot_RunInteraction);
-    ccAddExternalObjectFunction("Hotspot::get_Enabled",         Sc_Hotspot_GetEnabled);
-    ccAddExternalObjectFunction("Hotspot::set_Enabled",         Sc_Hotspot_SetEnabled);
-    ccAddExternalObjectFunction("Hotspot::get_ID",              Sc_Hotspot_GetID);
-    ccAddExternalObjectFunction("Hotspot::get_Name",            Sc_Hotspot_GetName_New);
-    ccAddExternalObjectFunction("Hotspot::set_Name",            Sc_Hotspot_SetName);
-    ccAddExternalObjectFunction("Hotspot::get_WalkToX",         Sc_Hotspot_GetWalkToX);
-    ccAddExternalObjectFunction("Hotspot::get_WalkToY",         Sc_Hotspot_GetWalkToY);
+    ScFnRegister hotspot_api[] = {
+        { "Hotspot::GetAtRoomXY^2",       API_FN_PAIR(GetHotspotAtRoom) },
+        { "Hotspot::GetAtScreenXY^2",     API_FN_PAIR(GetHotspotAtScreen) },
+        { "Hotspot::GetDrawingSurface",   API_FN_PAIR(Hotspot_GetDrawingSurface) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "Hotspot::GetName^1",           API_FN_PAIR(Hotspot_GetName) },
+        { "Hotspot::GetProperty^1",       API_FN_PAIR(Hotspot_GetProperty) },
+        { "Hotspot::GetPropertyText^2",   API_FN_PAIR(Hotspot_GetPropertyText) },
+        { "Hotspot::GetTextProperty^1",   API_FN_PAIR(Hotspot_GetTextProperty) },
+        { "Hotspot::SetProperty^2",       API_FN_PAIR(Hotspot_SetProperty) },
+        { "Hotspot::SetTextProperty^2",   API_FN_PAIR(Hotspot_SetTextProperty) },
+        { "Hotspot::IsInteractionAvailable^1", API_FN_PAIR(Hotspot_IsInteractionAvailable) },
+        { "Hotspot::RunInteraction^1",    API_FN_PAIR(Hotspot_RunInteraction) },
+        { "Hotspot::get_Enabled",         API_FN_PAIR(Hotspot_GetEnabled) },
+        { "Hotspot::set_Enabled",         API_FN_PAIR(Hotspot_SetEnabled) },
+        { "Hotspot::get_ID",              API_FN_PAIR(Hotspot_GetID) },
+        { "Hotspot::get_Name",            API_FN_PAIR(Hotspot_GetName_New) },
+        { "Hotspot::set_Name",            API_FN_PAIR(Hotspot_SetName) },
+        { "Hotspot::get_WalkToX",         API_FN_PAIR(Hotspot_GetWalkToX) },
+        { "Hotspot::get_WalkToY",         API_FN_PAIR(Hotspot_GetWalkToY) },
+    };
 
-    ccAddExternalFunctionForPlugin("Hotspot::GetAtRoomXY^2",       (void*)GetHotspotAtRoom);
-    ccAddExternalFunctionForPlugin("Hotspot::GetAtScreenXY^2",     (void*)GetHotspotAtScreen);
-    ccAddExternalFunctionForPlugin("Hotspot::GetName^1",           (void*)Hotspot_GetName);
-    ccAddExternalFunctionForPlugin("Hotspot::GetProperty^1",       (void*)Hotspot_GetProperty);
-    ccAddExternalFunctionForPlugin("Hotspot::GetPropertyText^2",   (void*)Hotspot_GetPropertyText);
-    ccAddExternalFunctionForPlugin("Hotspot::GetTextProperty^1",   (void*)Hotspot_GetTextProperty);
-    ccAddExternalFunctionForPlugin("Hotspot::SetProperty^2",       (void*)Hotspot_SetProperty);
-    ccAddExternalFunctionForPlugin("Hotspot::SetTextProperty^2",   (void*)Hotspot_SetTextProperty);
-    ccAddExternalFunctionForPlugin("Hotspot::RunInteraction^1",    (void*)Hotspot_RunInteraction);
-    ccAddExternalFunctionForPlugin("Hotspot::get_Enabled",         (void*)Hotspot_GetEnabled);
-    ccAddExternalFunctionForPlugin("Hotspot::set_Enabled",         (void*)Hotspot_SetEnabled);
-    ccAddExternalFunctionForPlugin("Hotspot::get_ID",              (void*)Hotspot_GetID);
-    ccAddExternalFunctionForPlugin("Hotspot::get_Name",            (void*)Hotspot_GetName_New);
-    ccAddExternalFunctionForPlugin("Hotspot::get_WalkToX",         (void*)Hotspot_GetWalkToX);
-    ccAddExternalFunctionForPlugin("Hotspot::get_WalkToY",         (void*)Hotspot_GetWalkToY);
+    ccAddExternalFunctions(hotspot_api);
 }

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -153,9 +153,7 @@ RuntimeScriptValue Sc_GetHotspotAtScreen(const RuntimeScriptValue *params, int32
 
 RuntimeScriptValue Sc_Hotspot_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
-    (void)params; (void)param_count;
-    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaHotspot);
-    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+    API_SCALL_OBJAUTO(ScriptDrawingSurface, Hotspot_GetDrawingSurface);
 }
 
 // void (ScriptHotspot *hss, char *buffer)

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -228,41 +228,26 @@ RuntimeScriptValue Sc_InventoryItem_GetName_New(void *self, const RuntimeScriptV
 
 void RegisterInventoryItemAPI()
 {
-    ccAddExternalStaticFunction("InventoryItem::GetAtScreenXY^2",           Sc_GetInvAtLocation);
-    ccAddExternalObjectFunction("InventoryItem::IsInteractionAvailable^1",  Sc_InventoryItem_CheckInteractionAvailable);
-    ccAddExternalObjectFunction("InventoryItem::GetName^1",                 Sc_InventoryItem_GetName);
-    ccAddExternalObjectFunction("InventoryItem::GetProperty^1",             Sc_InventoryItem_GetProperty);
-    ccAddExternalObjectFunction("InventoryItem::GetPropertyText^2",         Sc_InventoryItem_GetPropertyText);
-    ccAddExternalObjectFunction("InventoryItem::GetTextProperty^1",         Sc_InventoryItem_GetTextProperty);
-    ccAddExternalObjectFunction("InventoryItem::SetProperty^2",             Sc_InventoryItem_SetProperty);
-    ccAddExternalObjectFunction("InventoryItem::SetTextProperty^2",         Sc_InventoryItem_SetTextProperty);
-    ccAddExternalObjectFunction("InventoryItem::RunInteraction^1",          Sc_InventoryItem_RunInteraction);
-    ccAddExternalObjectFunction("InventoryItem::SetName^1",                 Sc_InventoryItem_SetName);
-    ccAddExternalObjectFunction("InventoryItem::get_CursorGraphic",         Sc_InventoryItem_GetCursorGraphic);
-    ccAddExternalObjectFunction("InventoryItem::set_CursorGraphic",         Sc_InventoryItem_SetCursorGraphic);
-    ccAddExternalObjectFunction("InventoryItem::get_Graphic",               Sc_InventoryItem_GetGraphic);
-    ccAddExternalObjectFunction("InventoryItem::set_Graphic",               Sc_InventoryItem_SetGraphic);
-    ccAddExternalObjectFunction("InventoryItem::get_ID",                    Sc_InventoryItem_GetID);
-    ccAddExternalObjectFunction("InventoryItem::get_Name",                  Sc_InventoryItem_GetName_New);
-    ccAddExternalObjectFunction("InventoryItem::set_Name",                  Sc_InventoryItem_SetName);
+    ScFnRegister invitem_api[] = {
+        { "InventoryItem::GetAtScreenXY^2",           API_FN_PAIR(GetInvAtLocation) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "InventoryItem::IsInteractionAvailable^1",  API_FN_PAIR(InventoryItem_CheckInteractionAvailable) },
+        { "InventoryItem::GetName^1",                 API_FN_PAIR(InventoryItem_GetName) },
+        { "InventoryItem::GetProperty^1",             API_FN_PAIR(InventoryItem_GetProperty) },
+        { "InventoryItem::GetPropertyText^2",         API_FN_PAIR(InventoryItem_GetPropertyText) },
+        { "InventoryItem::GetTextProperty^1",         API_FN_PAIR(InventoryItem_GetTextProperty) },
+        { "InventoryItem::SetProperty^2",             API_FN_PAIR(InventoryItem_SetProperty) },
+        { "InventoryItem::SetTextProperty^2",         API_FN_PAIR(InventoryItem_SetTextProperty) },
+        { "InventoryItem::RunInteraction^1",          API_FN_PAIR(InventoryItem_RunInteraction) },
+        { "InventoryItem::SetName^1",                 API_FN_PAIR(InventoryItem_SetName) },
+        { "InventoryItem::get_CursorGraphic",         API_FN_PAIR(InventoryItem_GetCursorGraphic) },
+        { "InventoryItem::set_CursorGraphic",         API_FN_PAIR(InventoryItem_SetCursorGraphic) },
+        { "InventoryItem::get_Graphic",               API_FN_PAIR(InventoryItem_GetGraphic) },
+        { "InventoryItem::set_Graphic",               API_FN_PAIR(InventoryItem_SetGraphic) },
+        { "InventoryItem::get_ID",                    API_FN_PAIR(InventoryItem_GetID) },
+        { "InventoryItem::get_Name",                  API_FN_PAIR(InventoryItem_GetName_New) },
+        { "InventoryItem::set_Name",                  API_FN_PAIR(InventoryItem_SetName) },
+    };
 
-    ccAddExternalFunctionForPlugin("InventoryItem::GetAtScreenXY^2",           (void*)GetInvAtLocation);
-    ccAddExternalFunctionForPlugin("InventoryItem::IsInteractionAvailable^1",  (void*)InventoryItem_CheckInteractionAvailable);
-    ccAddExternalFunctionForPlugin("InventoryItem::GetName^1",                 (void*)InventoryItem_GetName);
-    ccAddExternalFunctionForPlugin("InventoryItem::GetProperty^1",             (void*)InventoryItem_GetProperty);
-    ccAddExternalFunctionForPlugin("InventoryItem::GetPropertyText^2",         (void*)InventoryItem_GetPropertyText);
-    ccAddExternalFunctionForPlugin("InventoryItem::GetTextProperty^1",         (void*)InventoryItem_GetTextProperty);
-    ccAddExternalFunctionForPlugin("InventoryItem::SetProperty^2",             (void*)InventoryItem_SetProperty);
-    ccAddExternalFunctionForPlugin("InventoryItem::SetTextProperty^2",         (void*)InventoryItem_SetTextProperty);
-    ccAddExternalFunctionForPlugin("InventoryItem::RunInteraction^1",          (void*)InventoryItem_RunInteraction);
-    ccAddExternalFunctionForPlugin("InventoryItem::SetName^1",                 (void*)InventoryItem_SetName);
-    ccAddExternalFunctionForPlugin("InventoryItem::get_CursorGraphic",         (void*)InventoryItem_GetCursorGraphic);
-    ccAddExternalFunctionForPlugin("InventoryItem::set_CursorGraphic",         (void*)InventoryItem_SetCursorGraphic);
-    ccAddExternalFunctionForPlugin("InventoryItem::get_Graphic",               (void*)InventoryItem_GetGraphic);
-    ccAddExternalFunctionForPlugin("InventoryItem::set_Graphic",               (void*)InventoryItem_SetGraphic);
-    ccAddExternalFunctionForPlugin("InventoryItem::get_ID",                    (void*)InventoryItem_GetID);
-    ccAddExternalFunctionForPlugin("InventoryItem::get_Name",                  (void*)InventoryItem_GetName_New);
-    ccAddExternalFunctionForPlugin("InventoryItem::set_Name",                  (void*)InventoryItem_SetName);
+    ccAddExternalFunctions(invitem_api);
 }

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -627,35 +627,22 @@ RuntimeScriptValue Sc_InvWindow_SetTopItem(void *self, const RuntimeScriptValue 
 
 void RegisterInventoryWindowAPI()
 {
-    ccAddExternalObjectFunction("InvWindow::ScrollDown^0",          Sc_InvWindow_ScrollDown);
-    ccAddExternalObjectFunction("InvWindow::ScrollUp^0",            Sc_InvWindow_ScrollUp);
-    ccAddExternalObjectFunction("InvWindow::get_CharacterToUse",    Sc_InvWindow_GetCharacterToUse);
-    ccAddExternalObjectFunction("InvWindow::set_CharacterToUse",    Sc_InvWindow_SetCharacterToUse);
-    ccAddExternalObjectFunction("InvWindow::geti_ItemAtIndex",      Sc_InvWindow_GetItemAtIndex);
-    ccAddExternalObjectFunction("InvWindow::get_ItemCount",         Sc_InvWindow_GetItemCount);
-    ccAddExternalObjectFunction("InvWindow::get_ItemHeight",        Sc_InvWindow_GetItemHeight);
-    ccAddExternalObjectFunction("InvWindow::set_ItemHeight",        Sc_InvWindow_SetItemHeight);
-    ccAddExternalObjectFunction("InvWindow::get_ItemWidth",         Sc_InvWindow_GetItemWidth);
-    ccAddExternalObjectFunction("InvWindow::set_ItemWidth",         Sc_InvWindow_SetItemWidth);
-    ccAddExternalObjectFunction("InvWindow::get_ItemsPerRow",       Sc_InvWindow_GetItemsPerRow);
-    ccAddExternalObjectFunction("InvWindow::get_RowCount",          Sc_InvWindow_GetRowCount);
-    ccAddExternalObjectFunction("InvWindow::get_TopItem",           Sc_InvWindow_GetTopItem);
-    ccAddExternalObjectFunction("InvWindow::set_TopItem",           Sc_InvWindow_SetTopItem);
+    ScFnRegister invwindow_api[] = {
+        { "InvWindow::ScrollDown^0",          API_FN_PAIR(InvWindow_ScrollDown) },
+        { "InvWindow::ScrollUp^0",            API_FN_PAIR(InvWindow_ScrollUp) },
+        { "InvWindow::get_CharacterToUse",    API_FN_PAIR(InvWindow_GetCharacterToUse) },
+        { "InvWindow::set_CharacterToUse",    API_FN_PAIR(InvWindow_SetCharacterToUse) },
+        { "InvWindow::geti_ItemAtIndex",      API_FN_PAIR(InvWindow_GetItemAtIndex) },
+        { "InvWindow::get_ItemCount",         API_FN_PAIR(InvWindow_GetItemCount) },
+        { "InvWindow::get_ItemHeight",        API_FN_PAIR(InvWindow_GetItemHeight) },
+        { "InvWindow::set_ItemHeight",        API_FN_PAIR(InvWindow_SetItemHeight) },
+        { "InvWindow::get_ItemWidth",         API_FN_PAIR(InvWindow_GetItemWidth) },
+        { "InvWindow::set_ItemWidth",         API_FN_PAIR(InvWindow_SetItemWidth) },
+        { "InvWindow::get_ItemsPerRow",       API_FN_PAIR(InvWindow_GetItemsPerRow) },
+        { "InvWindow::get_RowCount",          API_FN_PAIR(InvWindow_GetRowCount) },
+        { "InvWindow::get_TopItem",           API_FN_PAIR(InvWindow_GetTopItem) },
+        { "InvWindow::set_TopItem",           API_FN_PAIR(InvWindow_SetTopItem) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("InvWindow::ScrollDown^0",          (void*)InvWindow_ScrollDown);
-    ccAddExternalFunctionForPlugin("InvWindow::ScrollUp^0",            (void*)InvWindow_ScrollUp);
-    ccAddExternalFunctionForPlugin("InvWindow::get_CharacterToUse",    (void*)InvWindow_GetCharacterToUse);
-    ccAddExternalFunctionForPlugin("InvWindow::set_CharacterToUse",    (void*)InvWindow_SetCharacterToUse);
-    ccAddExternalFunctionForPlugin("InvWindow::geti_ItemAtIndex",      (void*)InvWindow_GetItemAtIndex);
-    ccAddExternalFunctionForPlugin("InvWindow::get_ItemCount",         (void*)InvWindow_GetItemCount);
-    ccAddExternalFunctionForPlugin("InvWindow::get_ItemHeight",        (void*)InvWindow_GetItemHeight);
-    ccAddExternalFunctionForPlugin("InvWindow::set_ItemHeight",        (void*)InvWindow_SetItemHeight);
-    ccAddExternalFunctionForPlugin("InvWindow::get_ItemWidth",         (void*)InvWindow_GetItemWidth);
-    ccAddExternalFunctionForPlugin("InvWindow::set_ItemWidth",         (void*)InvWindow_SetItemWidth);
-    ccAddExternalFunctionForPlugin("InvWindow::get_ItemsPerRow",       (void*)InvWindow_GetItemsPerRow);
-    ccAddExternalFunctionForPlugin("InvWindow::get_RowCount",          (void*)InvWindow_GetRowCount);
-    ccAddExternalFunctionForPlugin("InvWindow::get_TopItem",           (void*)InvWindow_GetTopItem);
-    ccAddExternalFunctionForPlugin("InvWindow::set_TopItem",           (void*)InvWindow_SetTopItem);
+    ccAddExternalFunctions(invwindow_api);
 }

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -158,25 +158,18 @@ RuntimeScriptValue Sc_Label_SetColor(void *self, const RuntimeScriptValue *param
 
 void RegisterLabelAPI()
 {
-    ccAddExternalObjectFunction("Label::GetText^1",     Sc_Label_GetText);
-    ccAddExternalObjectFunction("Label::SetText^1",     Sc_Label_SetText);
-    ccAddExternalObjectFunction("Label::get_TextAlignment", Sc_Label_GetTextAlignment);
-    ccAddExternalObjectFunction("Label::set_TextAlignment", Sc_Label_SetTextAlignment);
-    ccAddExternalObjectFunction("Label::get_Font",      Sc_Label_GetFont);
-    ccAddExternalObjectFunction("Label::set_Font",      Sc_Label_SetFont);
-    ccAddExternalObjectFunction("Label::get_Text",      Sc_Label_GetText_New);
-    ccAddExternalObjectFunction("Label::set_Text",      Sc_Label_SetText);
-    ccAddExternalObjectFunction("Label::get_TextColor", Sc_Label_GetColor);
-    ccAddExternalObjectFunction("Label::set_TextColor", Sc_Label_SetColor);
+    ScFnRegister label_api[] = {
+        { "Label::GetText^1",     API_FN_PAIR(Label_GetText) },
+        { "Label::SetText^1",     API_FN_PAIR(Label_SetText) },
+        { "Label::get_TextAlignment", API_FN_PAIR(Label_GetTextAlignment) },
+        { "Label::set_TextAlignment", API_FN_PAIR(Label_SetTextAlignment) },
+        { "Label::get_Font",      API_FN_PAIR(Label_GetFont) },
+        { "Label::set_Font",      API_FN_PAIR(Label_SetFont) },
+        { "Label::get_Text",      API_FN_PAIR(Label_GetText_New) },
+        { "Label::set_Text",      API_FN_PAIR(Label_SetText) },
+        { "Label::get_TextColor", API_FN_PAIR(Label_GetColor) },
+        { "Label::set_TextColor", API_FN_PAIR(Label_SetColor) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Label::GetText^1",     (void*)Label_GetText);
-    ccAddExternalFunctionForPlugin("Label::SetText^1",     (void*)Label_SetText);
-    ccAddExternalFunctionForPlugin("Label::get_Font",      (void*)Label_GetFont);
-    ccAddExternalFunctionForPlugin("Label::set_Font",      (void*)Label_SetFont);
-    ccAddExternalFunctionForPlugin("Label::get_Text",      (void*)Label_GetText_New);
-    ccAddExternalFunctionForPlugin("Label::set_Text",      (void*)Label_SetText);
-    ccAddExternalFunctionForPlugin("Label::get_TextColor", (void*)Label_GetColor);
-    ccAddExternalFunctionForPlugin("Label::set_TextColor", (void*)Label_SetColor);
+    ccAddExternalFunctions(label_api);
 }

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -568,73 +568,48 @@ RuntimeScriptValue Sc_ListBox_SetTopItem(void *self, const RuntimeScriptValue *p
 
 void RegisterListBoxAPI()
 {
-    ccAddExternalObjectFunction("ListBox::AddItem^1",           Sc_ListBox_AddItem);
-    ccAddExternalObjectFunction("ListBox::Clear^0",             Sc_ListBox_Clear);
-    ccAddExternalObjectFunction("ListBox::FillDirList^1",       Sc_ListBox_FillDirList);
-    ccAddExternalObjectFunction("ListBox::FillSaveGameList^0",  Sc_ListBox_FillSaveGameList);
-    ccAddExternalObjectFunction("ListBox::GetItemAtLocation^2", Sc_ListBox_GetItemAtLocation);
-    ccAddExternalObjectFunction("ListBox::GetItemText^2",       Sc_ListBox_GetItemText);
-    ccAddExternalObjectFunction("ListBox::InsertItemAt^2",      Sc_ListBox_InsertItemAt);
-    ccAddExternalObjectFunction("ListBox::RemoveItem^1",        Sc_ListBox_RemoveItem);
-    ccAddExternalObjectFunction("ListBox::ScrollDown^0",        Sc_ListBox_ScrollDown);
-    ccAddExternalObjectFunction("ListBox::ScrollUp^0",          Sc_ListBox_ScrollUp);
-    ccAddExternalObjectFunction("ListBox::SetItemText^2",       Sc_ListBox_SetItemText);
-    ccAddExternalObjectFunction("ListBox::get_Font",            Sc_ListBox_GetFont);
-    ccAddExternalObjectFunction("ListBox::set_Font",            Sc_ListBox_SetFont);
-    ccAddExternalObjectFunction("ListBox::get_ShowBorder",      Sc_ListBox_GetShowBorder);
-    ccAddExternalObjectFunction("ListBox::set_ShowBorder",      Sc_ListBox_SetShowBorder);
-    ccAddExternalObjectFunction("ListBox::get_ShowScrollArrows", Sc_ListBox_GetShowScrollArrows);
-    ccAddExternalObjectFunction("ListBox::set_ShowScrollArrows", Sc_ListBox_SetShowScrollArrows);
-    // old "inverted" properties
-    ccAddExternalObjectFunction("ListBox::get_HideBorder",      Sc_ListBox_GetHideBorder);
-    ccAddExternalObjectFunction("ListBox::set_HideBorder",      Sc_ListBox_SetHideBorder);
-    ccAddExternalObjectFunction("ListBox::get_HideScrollArrows", Sc_ListBox_GetHideScrollArrows);
-    ccAddExternalObjectFunction("ListBox::set_HideScrollArrows", Sc_ListBox_SetHideScrollArrows);
-    //
-    ccAddExternalObjectFunction("ListBox::get_ItemCount",       Sc_ListBox_GetItemCount);
-    ccAddExternalObjectFunction("ListBox::geti_Items",          Sc_ListBox_GetItems);
-    ccAddExternalObjectFunction("ListBox::seti_Items",          Sc_ListBox_SetItemText);
-    ccAddExternalObjectFunction("ListBox::get_RowCount",        Sc_ListBox_GetRowCount);
-    ccAddExternalObjectFunction("ListBox::geti_SaveGameSlots",  Sc_ListBox_GetSaveGameSlots);
-    ccAddExternalObjectFunction("ListBox::get_SelectedBackColor", Sc_ListBox_GetSelectedBackColor);
-    ccAddExternalObjectFunction("ListBox::set_SelectedBackColor", Sc_ListBox_SetSelectedBackColor);
-    ccAddExternalObjectFunction("ListBox::get_SelectedIndex",   Sc_ListBox_GetSelectedIndex);
-    ccAddExternalObjectFunction("ListBox::set_SelectedIndex",   Sc_ListBox_SetSelectedIndex);
-    ccAddExternalObjectFunction("ListBox::get_SelectedTextColor", Sc_ListBox_GetSelectedTextColor);
-    ccAddExternalObjectFunction("ListBox::set_SelectedTextColor", Sc_ListBox_SetSelectedTextColor);
-    ccAddExternalObjectFunction("ListBox::get_TextAlignment",   Sc_ListBox_GetTextAlignment);
-    ccAddExternalObjectFunction("ListBox::set_TextAlignment",   Sc_ListBox_SetTextAlignment);
-    ccAddExternalObjectFunction("ListBox::get_TextColor",       Sc_ListBox_GetTextColor);
-    ccAddExternalObjectFunction("ListBox::set_TextColor",       Sc_ListBox_SetTextColor);
-    ccAddExternalObjectFunction("ListBox::get_TopItem",         Sc_ListBox_GetTopItem);
-    ccAddExternalObjectFunction("ListBox::set_TopItem",         Sc_ListBox_SetTopItem);
+    ScFnRegister listbox_api[] = {
+        { "ListBox::AddItem^1",           API_FN_PAIR(ListBox_AddItem) },
+        { "ListBox::Clear^0",             API_FN_PAIR(ListBox_Clear) },
+        { "ListBox::FillDirList^1",       API_FN_PAIR(ListBox_FillDirList) },
+        { "ListBox::FillSaveGameList^0",  API_FN_PAIR(ListBox_FillSaveGameList) },
+        { "ListBox::GetItemAtLocation^2", API_FN_PAIR(ListBox_GetItemAtLocation) },
+        { "ListBox::GetItemText^2",       API_FN_PAIR(ListBox_GetItemText) },
+        { "ListBox::InsertItemAt^2",      API_FN_PAIR(ListBox_InsertItemAt) },
+        { "ListBox::RemoveItem^1",        API_FN_PAIR(ListBox_RemoveItem) },
+        { "ListBox::ScrollDown^0",        API_FN_PAIR(ListBox_ScrollDown) },
+        { "ListBox::ScrollUp^0",          API_FN_PAIR(ListBox_ScrollUp) },
+        { "ListBox::SetItemText^2",       API_FN_PAIR(ListBox_SetItemText) },
+        { "ListBox::get_Font",            API_FN_PAIR(ListBox_GetFont) },
+        { "ListBox::set_Font",            API_FN_PAIR(ListBox_SetFont) },
+        { "ListBox::get_ShowBorder",      API_FN_PAIR(ListBox_GetShowBorder) },
+        { "ListBox::set_ShowBorder",      API_FN_PAIR(ListBox_SetShowBorder) },
+        { "ListBox::get_ShowScrollArrows", API_FN_PAIR(ListBox_GetShowScrollArrows) },
+        { "ListBox::set_ShowScrollArrows", API_FN_PAIR(ListBox_SetShowScrollArrows) },
+        // old { "inverted" properties
+        { "ListBox::get_HideBorder",      API_FN_PAIR(ListBox_GetHideBorder) },
+        { "ListBox::set_HideBorder",      API_FN_PAIR(ListBox_SetHideBorder) },
+        { "ListBox::get_HideScrollArrows", API_FN_PAIR(ListBox_GetHideScrollArrows) },
+        { "ListBox::set_HideScrollArrows", API_FN_PAIR(ListBox_SetHideScrollArrows) },
+        //
+        { "ListBox::get_ItemCount",       API_FN_PAIR(ListBox_GetItemCount) },
+        { "ListBox::geti_Items",          API_FN_PAIR(ListBox_GetItems) },
+        { "ListBox::seti_Items",          API_FN_PAIR(ListBox_SetItemText) },
+        { "ListBox::get_RowCount",        API_FN_PAIR(ListBox_GetRowCount) },
+        { "ListBox::geti_SaveGameSlots",  API_FN_PAIR(ListBox_GetSaveGameSlots) },
+        { "ListBox::get_SelectedBackColor", API_FN_PAIR(ListBox_GetSelectedBackColor) },
+        { "ListBox::set_SelectedBackColor", API_FN_PAIR(ListBox_SetSelectedBackColor) },
+        { "ListBox::get_SelectedIndex",   API_FN_PAIR(ListBox_GetSelectedIndex) },
+        { "ListBox::set_SelectedIndex",   API_FN_PAIR(ListBox_SetSelectedIndex) },
+        { "ListBox::get_SelectedTextColor", API_FN_PAIR(ListBox_GetSelectedTextColor) },
+        { "ListBox::set_SelectedTextColor", API_FN_PAIR(ListBox_SetSelectedTextColor) },
+        { "ListBox::get_TextAlignment",   API_FN_PAIR(ListBox_GetTextAlignment) },
+        { "ListBox::set_TextAlignment",   API_FN_PAIR(ListBox_SetTextAlignment) },
+        { "ListBox::get_TextColor",       API_FN_PAIR(ListBox_GetTextColor) },
+        { "ListBox::set_TextColor",       API_FN_PAIR(ListBox_SetTextColor) },
+        { "ListBox::get_TopItem",         API_FN_PAIR(ListBox_GetTopItem) },
+        { "ListBox::set_TopItem",         API_FN_PAIR(ListBox_SetTopItem) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("ListBox::AddItem^1",           (void*)ListBox_AddItem);
-    ccAddExternalFunctionForPlugin("ListBox::Clear^0",             (void*)ListBox_Clear);
-    ccAddExternalFunctionForPlugin("ListBox::FillDirList^1",       (void*)ListBox_FillDirList);
-    ccAddExternalFunctionForPlugin("ListBox::FillSaveGameList^0",  (void*)ListBox_FillSaveGameList);
-    ccAddExternalFunctionForPlugin("ListBox::GetItemAtLocation^2", (void*)ListBox_GetItemAtLocation);
-    ccAddExternalFunctionForPlugin("ListBox::GetItemText^2",       (void*)ListBox_GetItemText);
-    ccAddExternalFunctionForPlugin("ListBox::InsertItemAt^2",      (void*)ListBox_InsertItemAt);
-    ccAddExternalFunctionForPlugin("ListBox::RemoveItem^1",        (void*)ListBox_RemoveItem);
-    ccAddExternalFunctionForPlugin("ListBox::ScrollDown^0",        (void*)ListBox_ScrollDown);
-    ccAddExternalFunctionForPlugin("ListBox::ScrollUp^0",          (void*)ListBox_ScrollUp);
-    ccAddExternalFunctionForPlugin("ListBox::SetItemText^2",       (void*)ListBox_SetItemText);
-    ccAddExternalFunctionForPlugin("ListBox::get_Font",            (void*)ListBox_GetFont);
-    ccAddExternalFunctionForPlugin("ListBox::set_Font",            (void*)ListBox_SetFont);
-    ccAddExternalFunctionForPlugin("ListBox::get_HideBorder",      (void*)ListBox_GetHideBorder);
-    ccAddExternalFunctionForPlugin("ListBox::set_HideBorder",      (void*)ListBox_SetHideBorder);
-    ccAddExternalFunctionForPlugin("ListBox::get_HideScrollArrows", (void*)ListBox_GetHideScrollArrows);
-    ccAddExternalFunctionForPlugin("ListBox::set_HideScrollArrows", (void*)ListBox_SetHideScrollArrows);
-    ccAddExternalFunctionForPlugin("ListBox::get_ItemCount",       (void*)ListBox_GetItemCount);
-    ccAddExternalFunctionForPlugin("ListBox::geti_Items",          (void*)ListBox_GetItems);
-    ccAddExternalFunctionForPlugin("ListBox::seti_Items",          (void*)ListBox_SetItemText);
-    ccAddExternalFunctionForPlugin("ListBox::get_RowCount",        (void*)ListBox_GetRowCount);
-    ccAddExternalFunctionForPlugin("ListBox::geti_SaveGameSlots",  (void*)ListBox_GetSaveGameSlots);
-    ccAddExternalFunctionForPlugin("ListBox::get_SelectedIndex",   (void*)ListBox_GetSelectedIndex);
-    ccAddExternalFunctionForPlugin("ListBox::set_SelectedIndex",   (void*)ListBox_SetSelectedIndex);
-    ccAddExternalFunctionForPlugin("ListBox::get_TopItem",         (void*)ListBox_GetTopItem);
-    ccAddExternalFunctionForPlugin("ListBox::set_TopItem",         (void*)ListBox_SetTopItem);
+    ccAddExternalFunctions(listbox_api);
 }

--- a/Engine/ac/math.cpp
+++ b/Engine/ac/math.cpp
@@ -266,43 +266,26 @@ RuntimeScriptValue Sc_Math_GetPi(const RuntimeScriptValue *params, int32_t param
 
 void RegisterMathAPI()
 {
-    ccAddExternalStaticFunction("Maths::ArcCos^1",              Sc_Math_ArcCos);
-    ccAddExternalStaticFunction("Maths::ArcSin^1",              Sc_Math_ArcSin);
-    ccAddExternalStaticFunction("Maths::ArcTan^1",              Sc_Math_ArcTan);
-    ccAddExternalStaticFunction("Maths::ArcTan2^2",             Sc_Math_ArcTan2);
-    ccAddExternalStaticFunction("Maths::Cos^1",                 Sc_Math_Cos);
-    ccAddExternalStaticFunction("Maths::Cosh^1",                Sc_Math_Cosh);
-    ccAddExternalStaticFunction("Maths::DegreesToRadians^1",    Sc_Math_DegreesToRadians);
-    ccAddExternalStaticFunction("Maths::Exp^1",                 Sc_Math_Exp);
-    ccAddExternalStaticFunction("Maths::Log^1",                 Sc_Math_Log);
-    ccAddExternalStaticFunction("Maths::Log10^1",               Sc_Math_Log10);
-    ccAddExternalStaticFunction("Maths::RadiansToDegrees^1",    Sc_Math_RadiansToDegrees);
-    ccAddExternalStaticFunction("Maths::RaiseToPower^2",        Sc_Math_RaiseToPower);
-    ccAddExternalStaticFunction("Maths::Sin^1",                 Sc_Math_Sin);
-    ccAddExternalStaticFunction("Maths::Sinh^1",                Sc_Math_Sinh);
-    ccAddExternalStaticFunction("Maths::Sqrt^1",                Sc_Math_Sqrt);
-    ccAddExternalStaticFunction("Maths::Tan^1",                 Sc_Math_Tan);
-    ccAddExternalStaticFunction("Maths::Tanh^1",                Sc_Math_Tanh);
-    ccAddExternalStaticFunction("Maths::get_Pi",                Sc_Math_GetPi);
+    ScFnRegister math_api[] = {
+        { "Maths::ArcCos^1",              API_FN_PAIR(Math_ArcCos) },
+        { "Maths::ArcSin^1",              API_FN_PAIR(Math_ArcSin) },
+        { "Maths::ArcTan^1",              API_FN_PAIR(Math_ArcTan) },
+        { "Maths::ArcTan2^2",             API_FN_PAIR(Math_ArcTan2) },
+        { "Maths::Cos^1",                 API_FN_PAIR(Math_Cos) },
+        { "Maths::Cosh^1",                API_FN_PAIR(Math_Cosh) },
+        { "Maths::DegreesToRadians^1",    API_FN_PAIR(Math_DegreesToRadians) },
+        { "Maths::Exp^1",                 API_FN_PAIR(Math_Exp) },
+        { "Maths::Log^1",                 API_FN_PAIR(Math_Log) },
+        { "Maths::Log10^1",               API_FN_PAIR(Math_Log10) },
+        { "Maths::RadiansToDegrees^1",    API_FN_PAIR(Math_RadiansToDegrees) },
+        { "Maths::RaiseToPower^2",        API_FN_PAIR(Math_RaiseToPower) },
+        { "Maths::Sin^1",                 API_FN_PAIR(Math_Sin) },
+        { "Maths::Sinh^1",                API_FN_PAIR(Math_Sinh) },
+        { "Maths::Sqrt^1",                API_FN_PAIR(Math_Sqrt) },
+        { "Maths::Tan^1",                 API_FN_PAIR(Math_Tan) },
+        { "Maths::Tanh^1",                API_FN_PAIR(Math_Tanh) },
+        { "Maths::get_Pi",                API_FN_PAIR(Math_GetPi) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Maths::ArcCos^1",              (void*)Math_ArcCos);
-    ccAddExternalFunctionForPlugin("Maths::ArcSin^1",              (void*)Math_ArcSin);
-    ccAddExternalFunctionForPlugin("Maths::ArcTan^1",              (void*)Math_ArcTan);
-    ccAddExternalFunctionForPlugin("Maths::ArcTan2^2",             (void*)Math_ArcTan2);
-    ccAddExternalFunctionForPlugin("Maths::Cos^1",                 (void*)Math_Cos);
-    ccAddExternalFunctionForPlugin("Maths::Cosh^1",                (void*)Math_Cosh);
-    ccAddExternalFunctionForPlugin("Maths::DegreesToRadians^1",    (void*)Math_DegreesToRadians);
-    ccAddExternalFunctionForPlugin("Maths::Exp^1",                 (void*)Math_Exp);
-    ccAddExternalFunctionForPlugin("Maths::Log^1",                 (void*)Math_Log);
-    ccAddExternalFunctionForPlugin("Maths::Log10^1",               (void*)Math_Log10);
-    ccAddExternalFunctionForPlugin("Maths::RadiansToDegrees^1",    (void*)Math_RadiansToDegrees);
-    ccAddExternalFunctionForPlugin("Maths::RaiseToPower^2",        (void*)Math_RaiseToPower);
-    ccAddExternalFunctionForPlugin("Maths::Sin^1",                 (void*)Math_Sin);
-    ccAddExternalFunctionForPlugin("Maths::Sinh^1",                (void*)Math_Sinh);
-    ccAddExternalFunctionForPlugin("Maths::Sqrt^1",                (void*)Math_Sqrt);
-    ccAddExternalFunctionForPlugin("Maths::Tan^1",                 (void*)Math_Tan);
-    ccAddExternalFunctionForPlugin("Maths::Tanh^1",                (void*)Math_Tanh);
-    ccAddExternalFunctionForPlugin("Maths::get_Pi",                (void*)Math_GetPi);
+    ccAddExternalFunctions(math_api);
 }

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -193,7 +193,7 @@ void ChangeCursorHotspot (int curs, int x, int y) {
         set_mouse_cursor (cur_cursor);
 }
 
-void Mouse_ChangeModeViewEx(int curs, int newview, int delay) {
+void Mouse_ChangeModeView(int curs, int newview, int delay) {
     if ((curs < 0) || (curs >= game.numcursors))
         quit("!Mouse.ChangeModeView: invalid mouse cursor");
 
@@ -212,8 +212,8 @@ void Mouse_ChangeModeViewEx(int curs, int newview, int delay) {
         mouse_delay = 0;  // force update
 }
 
-void Mouse_ChangeModeView(int curs, int newview) {
-    Mouse_ChangeModeViewEx(curs, newview, SCR_NO_VALUE);
+void Mouse_ChangeModeView2(int curs, int newview) {
+    Mouse_ChangeModeView(curs, newview, SCR_NO_VALUE);
 }
 
 void SetNextCursor () {
@@ -480,14 +480,14 @@ RuntimeScriptValue Sc_ChangeCursorHotspot(const RuntimeScriptValue *params, int3
 }
 
 // void (int curs, int newview)
-RuntimeScriptValue Sc_Mouse_ChangeModeView_2(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Mouse_ChangeModeView2(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_VOID_PINT2(Mouse_ChangeModeView);
+    API_SCALL_VOID_PINT2(Mouse_ChangeModeView2);
 }
 
 RuntimeScriptValue Sc_Mouse_ChangeModeView(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_VOID_PINT3(Mouse_ChangeModeViewEx);
+    API_SCALL_VOID_PINT3(Mouse_ChangeModeView);
 }
 
 // void (int modd)
@@ -634,7 +634,7 @@ void RegisterMouseAPI()
 {
     ccAddExternalStaticFunction("Mouse::ChangeModeGraphic^2",       Sc_ChangeCursorGraphic);
     ccAddExternalStaticFunction("Mouse::ChangeModeHotspot^3",       Sc_ChangeCursorHotspot);
-    ccAddExternalStaticFunction("Mouse::ChangeModeView^2",          Sc_Mouse_ChangeModeView_2);
+    ccAddExternalStaticFunction("Mouse::ChangeModeView^2",          Sc_Mouse_ChangeModeView2);
     ccAddExternalStaticFunction("Mouse::ChangeModeView^3",          Sc_Mouse_ChangeModeView);
     ccAddExternalStaticFunction("Mouse::Click^1",                   Sc_Mouse_Click);
     ccAddExternalStaticFunction("Mouse::DisableMode^1",             Sc_disable_cursor_mode);

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -326,7 +326,7 @@ void Mouse_EnableControl(bool on)
     usetup.mouse_ctrl_enabled = on; // remember setting in config
 }
 
-bool Mouse_IsAutoLocking()
+bool Mouse_GetAutoLock()
 {
     return usetup.mouse_auto_lock;
 }
@@ -609,7 +609,7 @@ RuntimeScriptValue Sc_Mouse_SetControlEnabled(const RuntimeScriptValue *params, 
 
 RuntimeScriptValue Sc_Mouse_GetAutoLock(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_BOOL(Mouse_IsAutoLocking);
+    API_SCALL_BOOL(Mouse_GetAutoLock);
 }
 
 RuntimeScriptValue Sc_Mouse_SetAutoLock(const RuntimeScriptValue *params, int32_t param_count)
@@ -625,62 +625,43 @@ RuntimeScriptValue Sc_Mouse_GetSpeed(const RuntimeScriptValue *params, int32_t p
 
 RuntimeScriptValue Sc_Mouse_SetSpeed(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_VARIABLE_VALUE("Mouse::Speed");
+    ASSERT_PARAM_COUNT("Mouse::Speed", 1);
     Mouse::SetSpeed(params[0].FValue);
     return RuntimeScriptValue();
 }
 
 void RegisterMouseAPI()
 {
-    ccAddExternalStaticFunction("Mouse::ChangeModeGraphic^2",       Sc_ChangeCursorGraphic);
-    ccAddExternalStaticFunction("Mouse::ChangeModeHotspot^3",       Sc_ChangeCursorHotspot);
-    ccAddExternalStaticFunction("Mouse::ChangeModeView^2",          Sc_Mouse_ChangeModeView2);
-    ccAddExternalStaticFunction("Mouse::ChangeModeView^3",          Sc_Mouse_ChangeModeView);
-    ccAddExternalStaticFunction("Mouse::Click^1",                   Sc_Mouse_Click);
-    ccAddExternalStaticFunction("Mouse::DisableMode^1",             Sc_disable_cursor_mode);
-    ccAddExternalStaticFunction("Mouse::EnableMode^1",              Sc_enable_cursor_mode);
-    ccAddExternalStaticFunction("Mouse::GetModeGraphic^1",          Sc_Mouse_GetModeGraphic);
-    ccAddExternalStaticFunction("Mouse::IsButtonDown^1",            Sc_IsButtonDown);
-    ccAddExternalStaticFunction("Mouse::IsModeEnabled^1",           Sc_IsModeEnabled);
-    ccAddExternalStaticFunction("Mouse::SaveCursorUntilItLeaves^0", Sc_SaveCursorForLocationChange);
-    ccAddExternalStaticFunction("Mouse::SelectNextMode^0",          Sc_SetNextCursor);
-    ccAddExternalStaticFunction("Mouse::SelectPreviousMode^0",      Sc_SetPreviousCursor);
-    ccAddExternalStaticFunction("Mouse::SetBounds^4",               Sc_SetMouseBounds);
-    ccAddExternalStaticFunction("Mouse::SetPosition^2",             Sc_SetMousePosition);
-    ccAddExternalStaticFunction("Mouse::Update^0",                  Sc_RefreshMouse);
-    ccAddExternalStaticFunction("Mouse::UseDefaultGraphic^0",       Sc_set_default_cursor);
-    ccAddExternalStaticFunction("Mouse::UseModeGraphic^1",          Sc_set_mouse_cursor);
-    ccAddExternalStaticFunction("Mouse::get_AutoLock",              Sc_Mouse_GetAutoLock);
-    ccAddExternalStaticFunction("Mouse::set_AutoLock",              Sc_Mouse_SetAutoLock);
-    ccAddExternalStaticFunction("Mouse::get_ControlEnabled",        Sc_Mouse_GetControlEnabled);
-    ccAddExternalStaticFunction("Mouse::set_ControlEnabled",        Sc_Mouse_SetControlEnabled);
-    ccAddExternalStaticFunction("Mouse::get_Mode",                  Sc_GetCursorMode);
-    ccAddExternalStaticFunction("Mouse::set_Mode",                  Sc_set_cursor_mode);
-    ccAddExternalStaticFunction("Mouse::get_Speed",                 Sc_Mouse_GetSpeed);
-    ccAddExternalStaticFunction("Mouse::set_Speed",                 Sc_Mouse_SetSpeed);
-    ccAddExternalStaticFunction("Mouse::get_Visible",               Sc_Mouse_GetVisible);
-    ccAddExternalStaticFunction("Mouse::set_Visible",               Sc_Mouse_SetVisible);
+    ScFnRegister mouse_api[] = {
+        { "Mouse::ChangeModeGraphic^2",       API_FN_PAIR(ChangeCursorGraphic) },
+        { "Mouse::ChangeModeHotspot^3",       API_FN_PAIR(ChangeCursorHotspot) },
+        { "Mouse::ChangeModeView^2",          API_FN_PAIR(Mouse_ChangeModeView2) },
+        { "Mouse::ChangeModeView^3",          API_FN_PAIR(Mouse_ChangeModeView) },
+        { "Mouse::Click^1",                   Sc_Mouse_Click, PluginSimulateMouseClick },
+        { "Mouse::DisableMode^1",             API_FN_PAIR(disable_cursor_mode) },
+        { "Mouse::EnableMode^1",              API_FN_PAIR(enable_cursor_mode) },
+        { "Mouse::GetModeGraphic^1",          API_FN_PAIR(Mouse_GetModeGraphic) },
+        { "Mouse::IsButtonDown^1",            API_FN_PAIR(IsButtonDown) },
+        { "Mouse::IsModeEnabled^1",           API_FN_PAIR(IsModeEnabled) },
+        { "Mouse::SaveCursorUntilItLeaves^0", API_FN_PAIR(SaveCursorForLocationChange) },
+        { "Mouse::SelectNextMode^0",          API_FN_PAIR(SetNextCursor) },
+        { "Mouse::SelectPreviousMode^0",      API_FN_PAIR(SetPreviousCursor) },
+        { "Mouse::SetBounds^4",               API_FN_PAIR(SetMouseBounds) },
+        { "Mouse::SetPosition^2",             API_FN_PAIR(SetMousePosition) },
+        { "Mouse::Update^0",                  API_FN_PAIR(RefreshMouse) },
+        { "Mouse::UseDefaultGraphic^0",       API_FN_PAIR(set_default_cursor) },
+        { "Mouse::UseModeGraphic^1",          API_FN_PAIR(set_mouse_cursor) },
+        { "Mouse::get_AutoLock",              API_FN_PAIR(Mouse_GetAutoLock) },
+        { "Mouse::set_AutoLock",              API_FN_PAIR(Mouse_SetAutoLock) },
+        { "Mouse::get_ControlEnabled",        Sc_Mouse_GetControlEnabled, Mouse::IsControlEnabled },
+        { "Mouse::set_ControlEnabled",        Sc_Mouse_SetControlEnabled, Mouse_EnableControl },
+        { "Mouse::get_Mode",                  API_FN_PAIR(GetCursorMode) },
+        { "Mouse::set_Mode",                  API_FN_PAIR(set_cursor_mode) },
+        { "Mouse::get_Speed",                 Sc_Mouse_GetSpeed, Mouse::GetSpeed },
+        { "Mouse::set_Speed",                 Sc_Mouse_SetSpeed, Mouse::SetSpeed },
+        { "Mouse::get_Visible",               API_FN_PAIR(Mouse_GetVisible) },
+        { "Mouse::set_Visible",               API_FN_PAIR(Mouse_SetVisible) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Mouse::ChangeModeGraphic^2",       (void*)ChangeCursorGraphic);
-    ccAddExternalFunctionForPlugin("Mouse::ChangeModeHotspot^3",       (void*)ChangeCursorHotspot);
-    ccAddExternalFunctionForPlugin("Mouse::ChangeModeView^2",          (void*)Mouse_ChangeModeView);
-    ccAddExternalFunctionForPlugin("Mouse::DisableMode^1",             (void*)disable_cursor_mode);
-    ccAddExternalFunctionForPlugin("Mouse::EnableMode^1",              (void*)enable_cursor_mode);
-    ccAddExternalFunctionForPlugin("Mouse::GetModeGraphic^1",          (void*)Mouse_GetModeGraphic);
-    ccAddExternalFunctionForPlugin("Mouse::IsButtonDown^1",            (void*)IsButtonDown);
-    ccAddExternalFunctionForPlugin("Mouse::IsModeEnabled^1",           (void*)IsModeEnabled);
-    ccAddExternalFunctionForPlugin("Mouse::SaveCursorUntilItLeaves^0", (void*)SaveCursorForLocationChange);
-    ccAddExternalFunctionForPlugin("Mouse::SelectNextMode^0",          (void*)SetNextCursor);
-    ccAddExternalFunctionForPlugin("Mouse::SelectPreviousMode^0",      (void*)SetPreviousCursor);
-    ccAddExternalFunctionForPlugin("Mouse::SetBounds^4",               (void*)SetMouseBounds);
-    ccAddExternalFunctionForPlugin("Mouse::SetPosition^2",             (void*)SetMousePosition);
-    ccAddExternalFunctionForPlugin("Mouse::Update^0",                  (void*)RefreshMouse);
-    ccAddExternalFunctionForPlugin("Mouse::UseDefaultGraphic^0",       (void*)set_default_cursor);
-    ccAddExternalFunctionForPlugin("Mouse::UseModeGraphic^1",          (void*)set_mouse_cursor);
-    ccAddExternalFunctionForPlugin("Mouse::get_Mode",                  (void*)GetCursorMode);
-    ccAddExternalFunctionForPlugin("Mouse::set_Mode",                  (void*)set_cursor_mode);
-    ccAddExternalFunctionForPlugin("Mouse::get_Visible",               (void*)Mouse_GetVisible);
-    ccAddExternalFunctionForPlugin("Mouse::set_Visible",               (void*)Mouse_SetVisible);
+    ccAddExternalFunctions(mouse_api);
 }

--- a/Engine/ac/mouse.h
+++ b/Engine/ac/mouse.h
@@ -23,7 +23,7 @@
 void Mouse_SetVisible(int isOn);
 int Mouse_GetVisible();
 int Mouse_GetModeGraphic(int curs);
-void Mouse_ChangeModeView(int curs, int newview);
+void Mouse_ChangeModeView(int curs, int newview, int delay);
 // The Mouse:: functions are static so the script doesn't pass
 // in an object parameter
 void SetMousePosition (int newx, int newy);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -124,7 +124,11 @@ void Object_Animate(ScriptObject *objj, int loop, int delay, int repeat,
 }
 
 void Object_Animate5(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction) {
-    Object_Animate(objj, loop, delay, repeat, blocking, direction, 0, 100 /* full volume */);
+    Object_Animate(objj, loop, delay, repeat, blocking, direction, 0 /* frame */, 100 /* full volume */);
+}
+
+void Object_Animate6(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction, int sframe) {
+    Object_Animate(objj, loop, delay, repeat, blocking, direction, sframe, 100 /* full volume */);
 }
 
 void Object_StopAnimating(ScriptObject *objj) {
@@ -725,10 +729,10 @@ RuntimeScriptValue Sc_Object_Animate5(void *self, const RuntimeScriptValue *para
 
 RuntimeScriptValue Sc_Object_Animate6(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT6(ScriptObject, Object_Animate);
+    API_OBJCALL_VOID_PINT6(ScriptObject, Object_Animate6);
 }
 
-RuntimeScriptValue Sc_Object_Animate7(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Object_Animate(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID_PINT7(ScriptObject, Object_Animate);
 }
@@ -1101,7 +1105,7 @@ void RegisterObjectAPI()
 {
     ccAddExternalObjectFunction("Object::Animate^5",                Sc_Object_Animate5);
     ccAddExternalObjectFunction("Object::Animate^6",                Sc_Object_Animate6);
-    ccAddExternalObjectFunction("Object::Animate^7",                Sc_Object_Animate7);
+    ccAddExternalObjectFunction("Object::Animate^7",                Sc_Object_Animate);
     ccAddExternalObjectFunction("Object::IsCollidingWithObject^1",  Sc_Object_IsCollidingWithObject);
     ccAddExternalObjectFunction("Object::GetName^1",                Sc_Object_GetName);
     ccAddExternalObjectFunction("Object::GetProperty^1",            Sc_Object_GetProperty);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -1103,129 +1103,77 @@ RuntimeScriptValue Sc_Object_SetY(void *self, const RuntimeScriptValue *params, 
 
 void RegisterObjectAPI()
 {
-    ccAddExternalObjectFunction("Object::Animate^5",                Sc_Object_Animate5);
-    ccAddExternalObjectFunction("Object::Animate^6",                Sc_Object_Animate6);
-    ccAddExternalObjectFunction("Object::Animate^7",                Sc_Object_Animate);
-    ccAddExternalObjectFunction("Object::IsCollidingWithObject^1",  Sc_Object_IsCollidingWithObject);
-    ccAddExternalObjectFunction("Object::GetName^1",                Sc_Object_GetName);
-    ccAddExternalObjectFunction("Object::GetProperty^1",            Sc_Object_GetProperty);
-    ccAddExternalObjectFunction("Object::GetPropertyText^2",        Sc_Object_GetPropertyText);
-    ccAddExternalObjectFunction("Object::GetTextProperty^1",        Sc_Object_GetTextProperty);
-    ccAddExternalObjectFunction("Object::SetProperty^2",            Sc_Object_SetProperty);
-    ccAddExternalObjectFunction("Object::SetTextProperty^2",        Sc_Object_SetTextProperty);
-    ccAddExternalObjectFunction("Object::IsInteractionAvailable^1", Sc_Object_IsInteractionAvailable);
-    ccAddExternalObjectFunction("Object::MergeIntoBackground^0",    Sc_Object_MergeIntoBackground);
-    ccAddExternalObjectFunction("Object::Move^5",                   Sc_Object_Move);
-    ccAddExternalObjectFunction("Object::RemoveTint^0",             Sc_Object_RemoveTint);
-    ccAddExternalObjectFunction("Object::RunInteraction^1",         Sc_Object_RunInteraction);
-    ccAddExternalObjectFunction("Object::SetLightLevel^1",          Sc_Object_SetLightLevel);
-    ccAddExternalObjectFunction("Object::SetPosition^2",            Sc_Object_SetPosition);
-    ccAddExternalObjectFunction("Object::SetView^3",                Sc_Object_SetView);
-    ccAddExternalObjectFunction("Object::StopAnimating^0",          Sc_Object_StopAnimating);
-    ccAddExternalObjectFunction("Object::StopMoving^0",             Sc_Object_StopMoving);
-    ccAddExternalObjectFunction("Object::Tint^5",                   Sc_Object_Tint);
+    ScFnRegister object_api[] = {
+        { "Object::GetAtRoomXY^2",            API_FN_PAIR(GetObjectAtRoom) },
+        { "Object::GetAtScreenXY^2",          API_FN_PAIR(GetObjectAtScreen) },
 
-    // static
-    ccAddExternalStaticFunction("Object::GetAtRoomXY^2",            Sc_GetObjectAtRoom);
-    ccAddExternalStaticFunction("Object::GetAtScreenXY^2",          Sc_GetObjectAtScreen);
+        { "Object::Animate^5",                API_FN_PAIR(Object_Animate5) },
+        { "Object::Animate^6",                API_FN_PAIR(Object_Animate6) },
+        { "Object::Animate^7",                API_FN_PAIR(Object_Animate) },
+        { "Object::IsCollidingWithObject^1",  API_FN_PAIR(Object_IsCollidingWithObject) },
+        { "Object::GetName^1",                API_FN_PAIR(Object_GetName) },
+        { "Object::GetProperty^1",            API_FN_PAIR(Object_GetProperty) },
+        { "Object::GetPropertyText^2",        API_FN_PAIR(Object_GetPropertyText) },
+        { "Object::GetTextProperty^1",        API_FN_PAIR(Object_GetTextProperty) },
+        { "Object::SetProperty^2",            API_FN_PAIR(Object_SetProperty) },
+        { "Object::SetTextProperty^2",        API_FN_PAIR(Object_SetTextProperty) },
+        { "Object::IsInteractionAvailable^1", API_FN_PAIR(Object_IsInteractionAvailable) },
+        { "Object::MergeIntoBackground^0",    API_FN_PAIR(Object_MergeIntoBackground) },
+        { "Object::Move^5",                   API_FN_PAIR(Object_Move) },
+        { "Object::RemoveTint^0",             API_FN_PAIR(Object_RemoveTint) },
+        { "Object::RunInteraction^1",         API_FN_PAIR(Object_RunInteraction) },
+        { "Object::SetLightLevel^1",          API_FN_PAIR(Object_SetLightLevel) },
+        { "Object::SetPosition^2",            API_FN_PAIR(Object_SetPosition) },
+        { "Object::SetView^3",                API_FN_PAIR(Object_SetView) },
+        { "Object::StopAnimating^0",          API_FN_PAIR(Object_StopAnimating) },
+        { "Object::StopMoving^0",             API_FN_PAIR(Object_StopMoving) },
+        { "Object::Tint^5",                   API_FN_PAIR(Object_Tint) },
+        { "Object::get_Animating",            API_FN_PAIR(Object_GetAnimating) },
+        { "Object::get_Baseline",             API_FN_PAIR(Object_GetBaseline) },
+        { "Object::set_Baseline",             API_FN_PAIR(Object_SetBaseline) },
+        { "Object::get_BlockingHeight",       API_FN_PAIR(Object_GetBlockingHeight) },
+        { "Object::set_BlockingHeight",       API_FN_PAIR(Object_SetBlockingHeight) },
+        { "Object::get_BlockingWidth",        API_FN_PAIR(Object_GetBlockingWidth) },
+        { "Object::set_BlockingWidth",        API_FN_PAIR(Object_SetBlockingWidth) },
+        { "Object::get_Clickable",            API_FN_PAIR(Object_GetClickable) },
+        { "Object::set_Clickable",            API_FN_PAIR(Object_SetClickable) },
+        { "Object::get_Frame",                API_FN_PAIR(Object_GetFrame) },
+        { "Object::get_Graphic",              API_FN_PAIR(Object_GetGraphic) },
+        { "Object::set_Graphic",              API_FN_PAIR(Object_SetGraphic) },
+        { "Object::get_ID",                   API_FN_PAIR(Object_GetID) },
+        { "Object::get_IgnoreScaling",        API_FN_PAIR(Object_GetIgnoreScaling) },
+        { "Object::set_IgnoreScaling",        API_FN_PAIR(Object_SetIgnoreScaling) },
+        { "Object::get_IgnoreWalkbehinds",    API_FN_PAIR(Object_GetIgnoreWalkbehinds) },
+        { "Object::set_IgnoreWalkbehinds",    API_FN_PAIR(Object_SetIgnoreWalkbehinds) },
+        { "Object::get_Loop",                 API_FN_PAIR(Object_GetLoop) },
+        { "Object::get_ManualScaling",        API_FN_PAIR(Object_GetIgnoreScaling) },
+        { "Object::set_ManualScaling",        API_FN_PAIR(Object_SetManualScaling) },
+        { "Object::get_Moving",               API_FN_PAIR(Object_GetMoving) },
+        { "Object::get_Name",                 API_FN_PAIR(Object_GetName_New) },
+        { "Object::set_Name",                 API_FN_PAIR(Object_SetName) },
+        { "Object::get_Scaling",              API_FN_PAIR(Object_GetScaling) },
+        { "Object::set_Scaling",              API_FN_PAIR(Object_SetScaling) },
+        { "Object::get_Solid",                API_FN_PAIR(Object_GetSolid) },
+        { "Object::set_Solid",                API_FN_PAIR(Object_SetSolid) },
+        { "Object::get_Transparency",         API_FN_PAIR(Object_GetTransparency) },
+        { "Object::set_Transparency",         API_FN_PAIR(Object_SetTransparency) },
+        { "Object::get_View",                 API_FN_PAIR(Object_GetView) },
+        { "Object::get_Visible",              API_FN_PAIR(Object_GetVisible) },
+        { "Object::set_Visible",              API_FN_PAIR(Object_SetVisible) },
+        { "Object::get_X",                    API_FN_PAIR(Object_GetX) },
+        { "Object::set_X",                    API_FN_PAIR(Object_SetX) },
+        { "Object::get_Y",                    API_FN_PAIR(Object_GetY) },
+        { "Object::set_Y",                    API_FN_PAIR(Object_SetY) },
+        { "Object::get_HasExplicitLight",     API_FN_PAIR(Object_HasExplicitLight) },
+        { "Object::get_HasExplicitTint",      API_FN_PAIR(Object_HasExplicitTint) },
+        { "Object::get_LightLevel",           API_FN_PAIR(Object_GetLightLevel) },
+        { "Object::set_LightLevel",           API_FN_PAIR(Object_SetLightLevel) },
+        { "Object::get_TintBlue",             API_FN_PAIR(Object_GetTintBlue) },
+        { "Object::get_TintGreen",            API_FN_PAIR(Object_GetTintGreen) },
+        { "Object::get_TintRed",              API_FN_PAIR(Object_GetTintRed) },
+        { "Object::get_TintSaturation",       API_FN_PAIR(Object_GetTintSaturation) },
+        { "Object::get_TintLuminance",        API_FN_PAIR(Object_GetTintLuminance) },
+    };
 
-    ccAddExternalObjectFunction("Object::get_Animating",            Sc_Object_GetAnimating);
-    ccAddExternalObjectFunction("Object::get_Baseline",             Sc_Object_GetBaseline);
-    ccAddExternalObjectFunction("Object::set_Baseline",             Sc_Object_SetBaseline);
-    ccAddExternalObjectFunction("Object::get_BlockingHeight",       Sc_Object_GetBlockingHeight);
-    ccAddExternalObjectFunction("Object::set_BlockingHeight",       Sc_Object_SetBlockingHeight);
-    ccAddExternalObjectFunction("Object::get_BlockingWidth",        Sc_Object_GetBlockingWidth);
-    ccAddExternalObjectFunction("Object::set_BlockingWidth",        Sc_Object_SetBlockingWidth);
-    ccAddExternalObjectFunction("Object::get_Clickable",            Sc_Object_GetClickable);
-    ccAddExternalObjectFunction("Object::set_Clickable",            Sc_Object_SetClickable);
-    ccAddExternalObjectFunction("Object::get_Frame",                Sc_Object_GetFrame);
-    ccAddExternalObjectFunction("Object::get_Graphic",              Sc_Object_GetGraphic);
-    ccAddExternalObjectFunction("Object::set_Graphic",              Sc_Object_SetGraphic);
-    ccAddExternalObjectFunction("Object::get_ID",                   Sc_Object_GetID);
-    ccAddExternalObjectFunction("Object::get_IgnoreScaling",        Sc_Object_GetIgnoreScaling);
-    ccAddExternalObjectFunction("Object::set_IgnoreScaling",        Sc_Object_SetIgnoreScaling);
-    ccAddExternalObjectFunction("Object::get_IgnoreWalkbehinds",    Sc_Object_GetIgnoreWalkbehinds);
-    ccAddExternalObjectFunction("Object::set_IgnoreWalkbehinds",    Sc_Object_SetIgnoreWalkbehinds);
-    ccAddExternalObjectFunction("Object::get_Loop",                 Sc_Object_GetLoop);
-    ccAddExternalObjectFunction("Object::get_ManualScaling",        Sc_Object_GetIgnoreScaling);
-    ccAddExternalObjectFunction("Object::set_ManualScaling",        Sc_Object_SetManualScaling);
-    ccAddExternalObjectFunction("Object::get_Moving",               Sc_Object_GetMoving);
-    ccAddExternalObjectFunction("Object::get_Name",                 Sc_Object_GetName_New);
-    ccAddExternalObjectFunction("Object::set_Name",                 Sc_Object_SetName);
-    ccAddExternalObjectFunction("Object::get_Scaling",              Sc_Object_GetScaling);
-    ccAddExternalObjectFunction("Object::set_Scaling",              Sc_Object_SetScaling);
-    ccAddExternalObjectFunction("Object::get_Solid",                Sc_Object_GetSolid);
-    ccAddExternalObjectFunction("Object::set_Solid",                Sc_Object_SetSolid);
-    ccAddExternalObjectFunction("Object::get_Transparency",         Sc_Object_GetTransparency);
-    ccAddExternalObjectFunction("Object::set_Transparency",         Sc_Object_SetTransparency);
-    ccAddExternalObjectFunction("Object::get_View",                 Sc_Object_GetView);
-    ccAddExternalObjectFunction("Object::get_Visible",              Sc_Object_GetVisible);
-    ccAddExternalObjectFunction("Object::set_Visible",              Sc_Object_SetVisible);
-    ccAddExternalObjectFunction("Object::get_X",                    Sc_Object_GetX);
-    ccAddExternalObjectFunction("Object::set_X",                    Sc_Object_SetX);
-    ccAddExternalObjectFunction("Object::get_Y",                    Sc_Object_GetY);
-    ccAddExternalObjectFunction("Object::set_Y",                    Sc_Object_SetY);
-
-    ccAddExternalObjectFunction("Object::get_HasExplicitLight",     Sc_Object_HasExplicitLight);
-    ccAddExternalObjectFunction("Object::get_HasExplicitTint",      Sc_Object_HasExplicitTint);
-    ccAddExternalObjectFunction("Object::get_LightLevel",           Sc_Object_GetLightLevel);
-    ccAddExternalObjectFunction("Object::set_LightLevel",           Sc_Object_SetLightLevel);
-    ccAddExternalObjectFunction("Object::get_TintBlue",             Sc_Object_GetTintBlue);
-    ccAddExternalObjectFunction("Object::get_TintGreen",            Sc_Object_GetTintGreen);
-    ccAddExternalObjectFunction("Object::get_TintRed",              Sc_Object_GetTintRed);
-    ccAddExternalObjectFunction("Object::get_TintSaturation",       Sc_Object_GetTintSaturation);
-    ccAddExternalObjectFunction("Object::get_TintLuminance",        Sc_Object_GetTintLuminance);
-
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Object::Animate^5",                (void*)Object_Animate5);
-    ccAddExternalFunctionForPlugin("Object::IsCollidingWithObject^1",  (void*)Object_IsCollidingWithObject);
-    ccAddExternalFunctionForPlugin("Object::GetName^1",                (void*)Object_GetName);
-    ccAddExternalFunctionForPlugin("Object::GetProperty^1",            (void*)Object_GetProperty);
-    ccAddExternalFunctionForPlugin("Object::GetPropertyText^2",        (void*)Object_GetPropertyText);
-    ccAddExternalFunctionForPlugin("Object::GetTextProperty^1",        (void*)Object_GetTextProperty);
-    ccAddExternalFunctionForPlugin("Object::SetProperty^2",            (void*)Object_SetProperty);
-    ccAddExternalFunctionForPlugin("Object::SetTextProperty^2",        (void*)Object_SetTextProperty);
-    ccAddExternalFunctionForPlugin("Object::MergeIntoBackground^0",    (void*)Object_MergeIntoBackground);
-    ccAddExternalFunctionForPlugin("Object::Move^5",                   (void*)Object_Move);
-    ccAddExternalFunctionForPlugin("Object::RemoveTint^0",             (void*)Object_RemoveTint);
-    ccAddExternalFunctionForPlugin("Object::RunInteraction^1",         (void*)Object_RunInteraction);
-    ccAddExternalFunctionForPlugin("Object::SetPosition^2",            (void*)Object_SetPosition);
-    ccAddExternalFunctionForPlugin("Object::SetView^3",                (void*)Object_SetView);
-    ccAddExternalFunctionForPlugin("Object::StopAnimating^0",          (void*)Object_StopAnimating);
-    ccAddExternalFunctionForPlugin("Object::StopMoving^0",             (void*)Object_StopMoving);
-    ccAddExternalFunctionForPlugin("Object::Tint^5",                   (void*)Object_Tint);
-    ccAddExternalFunctionForPlugin("Object::GetAtRoomXY^2",            (void*)GetObjectAtRoom);
-    ccAddExternalFunctionForPlugin("Object::GetAtScreenXY^2",          (void*)GetObjectAtScreen);
-    ccAddExternalFunctionForPlugin("Object::get_Animating",            (void*)Object_GetAnimating);
-    ccAddExternalFunctionForPlugin("Object::get_Baseline",             (void*)Object_GetBaseline);
-    ccAddExternalFunctionForPlugin("Object::set_Baseline",             (void*)Object_SetBaseline);
-    ccAddExternalFunctionForPlugin("Object::get_BlockingHeight",       (void*)Object_GetBlockingHeight);
-    ccAddExternalFunctionForPlugin("Object::set_BlockingHeight",       (void*)Object_SetBlockingHeight);
-    ccAddExternalFunctionForPlugin("Object::get_BlockingWidth",        (void*)Object_GetBlockingWidth);
-    ccAddExternalFunctionForPlugin("Object::set_BlockingWidth",        (void*)Object_SetBlockingWidth);
-    ccAddExternalFunctionForPlugin("Object::get_Clickable",            (void*)Object_GetClickable);
-    ccAddExternalFunctionForPlugin("Object::set_Clickable",            (void*)Object_SetClickable);
-    ccAddExternalFunctionForPlugin("Object::get_Frame",                (void*)Object_GetFrame);
-    ccAddExternalFunctionForPlugin("Object::get_Graphic",              (void*)Object_GetGraphic);
-    ccAddExternalFunctionForPlugin("Object::set_Graphic",              (void*)Object_SetGraphic);
-    ccAddExternalFunctionForPlugin("Object::get_ID",                   (void*)Object_GetID);
-    ccAddExternalFunctionForPlugin("Object::get_IgnoreScaling",        (void*)Object_GetIgnoreScaling);
-    ccAddExternalFunctionForPlugin("Object::set_IgnoreScaling",        (void*)Object_SetIgnoreScaling);
-    ccAddExternalFunctionForPlugin("Object::get_IgnoreWalkbehinds",    (void*)Object_GetIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("Object::set_IgnoreWalkbehinds",    (void*)Object_SetIgnoreWalkbehinds);
-    ccAddExternalFunctionForPlugin("Object::get_Loop",                 (void*)Object_GetLoop);
-    ccAddExternalFunctionForPlugin("Object::get_Moving",               (void*)Object_GetMoving);
-    ccAddExternalFunctionForPlugin("Object::get_Name",                 (void*)Object_GetName_New);
-    ccAddExternalFunctionForPlugin("Object::get_Solid",                (void*)Object_GetSolid);
-    ccAddExternalFunctionForPlugin("Object::set_Solid",                (void*)Object_SetSolid);
-    ccAddExternalFunctionForPlugin("Object::get_Transparency",         (void*)Object_GetTransparency);
-    ccAddExternalFunctionForPlugin("Object::set_Transparency",         (void*)Object_SetTransparency);
-    ccAddExternalFunctionForPlugin("Object::get_View",                 (void*)Object_GetView);
-    ccAddExternalFunctionForPlugin("Object::get_Visible",              (void*)Object_GetVisible);
-    ccAddExternalFunctionForPlugin("Object::set_Visible",              (void*)Object_SetVisible);
-    ccAddExternalFunctionForPlugin("Object::get_X",                    (void*)Object_GetX);
-    ccAddExternalFunctionForPlugin("Object::set_X",                    (void*)Object_SetX);
-    ccAddExternalFunctionForPlugin("Object::get_Y",                    (void*)Object_GetY);
-    ccAddExternalFunctionForPlugin("Object::set_Y",                    (void*)Object_SetY);
+    ccAddExternalFunctions(object_api);
 }

--- a/Engine/ac/object.h
+++ b/Engine/ac/object.h
@@ -36,8 +36,8 @@ void    Object_SetTransparency(ScriptObject *objj, int trans);
 int     Object_GetTransparency(ScriptObject *objj);
 void    Object_SetBaseline(ScriptObject *objj, int basel);
 int     Object_GetBaseline(ScriptObject *objj);
-void    Object_Animate(ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction,
-    int sframe = 0, int volume = 100);
+void    Object_Animate(ScriptObject *objj, int loop, int delay, int repeat,
+                       int blocking, int direction, int sframe = 0, int volume = 100);
 void    Object_StopAnimating(ScriptObject *objj);
 void    Object_MergeIntoBackground(ScriptObject *objj);
 void    Object_StopMoving(ScriptObject *objj);

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -717,41 +717,34 @@ void ScPl_Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, c
 
 void RegisterOverlayAPI()
 {
-    ccAddExternalStaticFunction("Overlay::CreateGraphical^4",   Sc_Overlay_CreateGraphical4);
-    ccAddExternalStaticFunction("Overlay::CreateGraphical^5",   Sc_Overlay_CreateGraphical);
-    ccAddExternalStaticFunction("Overlay::CreateTextual^106",   Sc_Overlay_CreateTextual);
-    ccAddExternalStaticFunction("Overlay::CreateRoomGraphical^5", Sc_Overlay_CreateRoomGraphical);
-    ccAddExternalStaticFunction("Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual);
-    ccAddExternalObjectFunction("Overlay::SetText^104",         Sc_Overlay_SetText);
-    ccAddExternalObjectFunction("Overlay::Remove^0",            Sc_Overlay_Remove);
-    ccAddExternalObjectFunction("Overlay::get_Valid",           Sc_Overlay_GetValid);
-    ccAddExternalObjectFunction("Overlay::get_X",               Sc_Overlay_GetX);
-    ccAddExternalObjectFunction("Overlay::set_X",               Sc_Overlay_SetX);
-    ccAddExternalObjectFunction("Overlay::get_Y",               Sc_Overlay_GetY);
-    ccAddExternalObjectFunction("Overlay::set_Y",               Sc_Overlay_SetY);
-    ccAddExternalObjectFunction("Overlay::get_Graphic",         Sc_Overlay_GetGraphic);
-    ccAddExternalObjectFunction("Overlay::set_Graphic",         Sc_Overlay_SetGraphic);
-    ccAddExternalObjectFunction("Overlay::get_InRoom",          Sc_Overlay_InRoom);
-    ccAddExternalObjectFunction("Overlay::get_Width",           Sc_Overlay_GetWidth);
-    ccAddExternalObjectFunction("Overlay::set_Width",           Sc_Overlay_SetWidth);
-    ccAddExternalObjectFunction("Overlay::get_Height",          Sc_Overlay_GetHeight);
-    ccAddExternalObjectFunction("Overlay::set_Height",          Sc_Overlay_SetHeight);
-    ccAddExternalObjectFunction("Overlay::get_GraphicWidth",    Sc_Overlay_GetGraphicWidth);
-    ccAddExternalObjectFunction("Overlay::get_GraphicHeight",   Sc_Overlay_GetGraphicHeight);
-    ccAddExternalObjectFunction("Overlay::get_Transparency",    Sc_Overlay_GetTransparency);
-    ccAddExternalObjectFunction("Overlay::set_Transparency",    Sc_Overlay_SetTransparency);
-    ccAddExternalObjectFunction("Overlay::get_ZOrder",          Sc_Overlay_GetZOrder);
-    ccAddExternalObjectFunction("Overlay::set_ZOrder",          Sc_Overlay_SetZOrder);
+    ScFnRegister overlay_api[] = {
+        { "Overlay::CreateGraphical^4",   API_FN_PAIR(Overlay_CreateGraphical4) },
+        { "Overlay::CreateGraphical^5",   API_FN_PAIR(Overlay_CreateGraphical) },
+        { "Overlay::CreateTextual^106",   Sc_Overlay_CreateTextual, ScPl_Overlay_CreateTextual },
+        { "Overlay::CreateRoomGraphical^5", API_FN_PAIR(Overlay_CreateRoomGraphical) },
+        { "Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual, ScPl_Overlay_CreateRoomTextual },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "Overlay::SetText^104",         Sc_Overlay_SetText, ScPl_Overlay_SetText },
+        { "Overlay::Remove^0",            API_FN_PAIR(Overlay_Remove) },
+        { "Overlay::get_Valid",           API_FN_PAIR(Overlay_GetValid) },
+        { "Overlay::get_X",               API_FN_PAIR(Overlay_GetX) },
+        { "Overlay::set_X",               API_FN_PAIR(Overlay_SetX) },
+        { "Overlay::get_Y",               API_FN_PAIR(Overlay_GetY) },
+        { "Overlay::set_Y",               API_FN_PAIR(Overlay_SetY) },
+        { "Overlay::get_Graphic",         API_FN_PAIR(Overlay_GetGraphic) },
+        { "Overlay::set_Graphic",         API_FN_PAIR(Overlay_SetGraphic) },
+        { "Overlay::get_InRoom",          API_FN_PAIR(Overlay_InRoom) },
+        { "Overlay::get_Width",           API_FN_PAIR(Overlay_GetWidth) },
+        { "Overlay::set_Width",           API_FN_PAIR(Overlay_SetWidth) },
+        { "Overlay::get_Height",          API_FN_PAIR(Overlay_GetHeight) },
+        { "Overlay::set_Height",          API_FN_PAIR(Overlay_SetHeight) },
+        { "Overlay::get_GraphicWidth",    API_FN_PAIR(Overlay_GetGraphicWidth) },
+        { "Overlay::get_GraphicHeight",   API_FN_PAIR(Overlay_GetGraphicHeight) },
+        { "Overlay::get_Transparency",    API_FN_PAIR(Overlay_GetTransparency) },
+        { "Overlay::set_Transparency",    API_FN_PAIR(Overlay_SetTransparency) },
+        { "Overlay::get_ZOrder",          API_FN_PAIR(Overlay_GetZOrder) },
+        { "Overlay::set_ZOrder",          API_FN_PAIR(Overlay_SetZOrder) },
+    };
 
-    ccAddExternalFunctionForPlugin("Overlay::CreateGraphical^4",   (void*)Overlay_CreateGraphical);
-    ccAddExternalFunctionForPlugin("Overlay::CreateTextual^106",   (void*)ScPl_Overlay_CreateTextual);
-    ccAddExternalFunctionForPlugin("Overlay::SetText^104",         (void*)ScPl_Overlay_SetText);
-    ccAddExternalFunctionForPlugin("Overlay::Remove^0",            (void*)Overlay_Remove);
-    ccAddExternalFunctionForPlugin("Overlay::get_Valid",           (void*)Overlay_GetValid);
-    ccAddExternalFunctionForPlugin("Overlay::get_X",               (void*)Overlay_GetX);
-    ccAddExternalFunctionForPlugin("Overlay::set_X",               (void*)Overlay_SetX);
-    ccAddExternalFunctionForPlugin("Overlay::get_Y",               (void*)Overlay_GetY);
-    ccAddExternalFunctionForPlugin("Overlay::set_Y",               (void*)Overlay_SetY);
+    ccAddExternalFunctions(overlay_api);
 }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -238,19 +238,28 @@ ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, 
     return _display_main(x, y, width, text, disp_type, font, -text_color, 0, allow_shrink, false, room_layer);
 }
 
-ScriptOverlay* Overlay_CreateGraphicalEx(bool room_layer, int x, int y, int slot, int transparent, bool clone)
+ScriptOverlay* Overlay_CreateGraphicalImpl(bool room_layer, int x, int y, int slot, bool transparent, bool clone)
 {
-    auto *over = Overlay_CreateGraphicCore(room_layer, x, y, slot, transparent != 0, clone);
+    auto *over = Overlay_CreateGraphicCore(room_layer, x, y, slot, transparent, clone);
     return over ? create_scriptoverlay(*over) : nullptr;
 }
 
-ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent)
+ScriptOverlay* Overlay_CreateGraphical4(int x, int y, int slot, bool transparent)
 {
-    auto *over = Overlay_CreateGraphicCore(false, x, y, slot, transparent != 0, true); // always clone
-    return over ? create_scriptoverlay(*over) : nullptr;
+    return Overlay_CreateGraphical(x, y, slot, transparent, true /* clone */);
 }
 
-ScriptOverlay* Overlay_CreateTextualEx(bool room_layer, int x, int y, int width, int font, int colour, const char* text)
+ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool transparent, bool clone)
+{
+    return Overlay_CreateGraphicalImpl(false, x, y, slot, transparent, clone);
+}
+
+ScriptOverlay* Overlay_CreateRoomGraphical(int x, int y, int slot, bool transparent, bool clone)
+{
+    return Overlay_CreateGraphicalImpl(true, x, y, slot, transparent, clone);
+}
+
+ScriptOverlay* Overlay_CreateTextualImpl(bool room_layer, int x, int y, int width, int font, int colour, const char* text)
 {
     data_to_game_coords(&x, &y);
     width = data_to_game_coord(width);
@@ -259,7 +268,11 @@ ScriptOverlay* Overlay_CreateTextualEx(bool room_layer, int x, int y, int width,
 }
 
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text) {
-    return Overlay_CreateTextualEx(false, x, y, width, font, colour, text);
+    return Overlay_CreateTextualImpl(false, x, y, width, font, colour, text);
+}
+
+ScriptOverlay* Overlay_CreateRoomTextual(int x, int y, int width, int font, int colour, const char* text) {
+    return Overlay_CreateTextualImpl(true, x, y, width, font, colour, text);
 }
 
 int Overlay_GetTransparency(ScriptOverlay *scover) {
@@ -534,35 +547,26 @@ void recreate_overlay_ddbs()
 #include "script/script_runtime.h"
 
 // ScriptOverlay* (int x, int y, int slot, int transparent)
-RuntimeScriptValue Sc_Overlay_CreateGraphical(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Overlay_CreateGraphical4(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_PARAM_COUNT(FUNCTION, 4);
-    ScriptOverlay *overlay = Overlay_CreateGraphicalEx(false, params[0].IValue, params[1].IValue, params[2].IValue,
-        params[3].IValue, true); // always clone image
-    return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
+    API_SCALL_OBJAUTO_PINT3_PBOOL(ScriptOverlay, Overlay_CreateGraphical4);
 }
 
-RuntimeScriptValue Sc_Overlay_CreateGraphicalRef(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Overlay_CreateGraphical(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_PARAM_COUNT(FUNCTION, 5);
-    ScriptOverlay *overlay = Overlay_CreateGraphicalEx(false, params[0].IValue, params[1].IValue, params[2].IValue,
-        params[3].IValue, params[4].GetAsBool());
-    return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
+    API_SCALL_OBJAUTO_PINT3_PBOOL2(ScriptOverlay, Overlay_CreateGraphical);
 }
 
 RuntimeScriptValue Sc_Overlay_CreateRoomGraphical(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_PARAM_COUNT(FUNCTION, 5);
-    ScriptOverlay *overlay = Overlay_CreateGraphicalEx(true, params[0].IValue, params[1].IValue, params[2].IValue,
-        params[3].IValue, params[4].GetAsBool());
-    return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
+    API_SCALL_OBJAUTO_PINT3_PBOOL2(ScriptOverlay, Overlay_CreateRoomGraphical);
 }
 
 // ScriptOverlay* (int x, int y, int width, int font, int colour, const char* text, ...)
 RuntimeScriptValue Sc_Overlay_CreateTextual(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(Overlay_CreateTextual, 6);
-    ScriptOverlay *overlay = Overlay_CreateTextualEx(false, params[0].IValue, params[1].IValue, params[2].IValue,
+    ScriptOverlay *overlay = Overlay_CreateTextual(params[0].IValue, params[1].IValue, params[2].IValue,
                                                    params[3].IValue, params[4].IValue, scsf_buffer);
     return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
 }
@@ -570,7 +574,7 @@ RuntimeScriptValue Sc_Overlay_CreateTextual(const RuntimeScriptValue *params, in
 RuntimeScriptValue Sc_Overlay_CreateRoomTextual(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_SCRIPT_SPRINTF(Overlay_CreateRoomTextual, 6);
-    ScriptOverlay *overlay = Overlay_CreateTextualEx(true, params[0].IValue, params[1].IValue, params[2].IValue,
+    ScriptOverlay *overlay = Overlay_CreateRoomTextual(params[0].IValue, params[1].IValue, params[2].IValue,
         params[3].IValue, params[4].IValue, scsf_buffer);
     return RuntimeScriptValue().SetDynamicObject(overlay, overlay);
 }
@@ -707,8 +711,8 @@ void ScPl_Overlay_SetText(ScriptOverlay *scover, int wii, int fontid, int clr, c
 
 void RegisterOverlayAPI()
 {
-    ccAddExternalStaticFunction("Overlay::CreateGraphical^4",   Sc_Overlay_CreateGraphical);
-    ccAddExternalStaticFunction("Overlay::CreateGraphical^5",   Sc_Overlay_CreateGraphicalRef);
+    ccAddExternalStaticFunction("Overlay::CreateGraphical^4",   Sc_Overlay_CreateGraphical4);
+    ccAddExternalStaticFunction("Overlay::CreateGraphical^5",   Sc_Overlay_CreateGraphical);
     ccAddExternalStaticFunction("Overlay::CreateTextual^106",   Sc_Overlay_CreateTextual);
     ccAddExternalStaticFunction("Overlay::CreateRoomGraphical^5", Sc_Overlay_CreateRoomGraphical);
     ccAddExternalStaticFunction("Overlay::CreateRoomTextual^106", Sc_Overlay_CreateRoomTextual);

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -691,7 +691,7 @@ RuntimeScriptValue Sc_Overlay_SetZOrder(void *self, const RuntimeScriptValue *pa
 
 //=============================================================================
 //
-// Exclusive API for Plugins
+// Exclusive variadic API implementation for Plugins
 //
 //=============================================================================
 
@@ -700,6 +700,12 @@ ScriptOverlay* ScPl_Overlay_CreateTextual(int x, int y, int width, int font, int
 {
     API_PLUGIN_SCRIPT_SPRINTF(text);
     return Overlay_CreateTextual(x, y, width, font, colour, scsf_buffer);
+}
+
+ScriptOverlay* ScPl_Overlay_CreateRoomTextual(int x, int y, int width, int font, int colour, const char *text, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF(text);
+    return Overlay_CreateRoomTextual(x, y, width, font, colour, scsf_buffer);
 }
 
 // void (ScriptOverlay *scover, int wii, int fontid, int clr, char*texx, ...)

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -32,9 +32,9 @@ void Overlay_SetX(ScriptOverlay *scover, int newx);
 int  Overlay_GetY(ScriptOverlay *scover);
 void Overlay_SetY(ScriptOverlay *scover, int newy);
 int  Overlay_GetValid(ScriptOverlay *scover);
-ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, int transparent);
+ScriptOverlay* Overlay_CreateGraphical(int x, int y, int slot, bool transparent = true, bool clone = false);
 ScriptOverlay* Overlay_CreateTextual(int x, int y, int width, int font, int colour, const char* text);
-ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent, bool clone);
+ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot, bool transparent = true, bool clone = false);
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
     const char *text, int disp_type, int allow_shrink);
 

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -332,15 +332,12 @@ RuntimeScriptValue Sc_Said(const RuntimeScriptValue *params, int32_t param_count
 
 void RegisterParserAPI()
 {
-    ccAddExternalStaticFunction("Parser::FindWordID^1",     Sc_Parser_FindWordID);
-    ccAddExternalStaticFunction("Parser::ParseText^1",      Sc_ParseText);
-    ccAddExternalStaticFunction("Parser::SaidUnknownWord^0",Sc_Parser_SaidUnknownWord);
-    ccAddExternalStaticFunction("Parser::Said^1",           Sc_Said);
+    ScFnRegister parser_api[] = {
+        { "Parser::FindWordID^1",     API_FN_PAIR(Parser_FindWordID) },
+        { "Parser::ParseText^1",      API_FN_PAIR(ParseText) },
+        { "Parser::SaidUnknownWord^0",API_FN_PAIR(Parser_SaidUnknownWord) },
+        { "Parser::Said^1",           API_FN_PAIR(Said) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Parser::FindWordID^1",     (void*)Parser_FindWordID);
-    ccAddExternalFunctionForPlugin("Parser::ParseText^1",      (void*)ParseText);
-    ccAddExternalFunctionForPlugin("Parser::SaidUnknownWord^0",(void*)Parser_SaidUnknownWord);
-    ccAddExternalFunctionForPlugin("Parser::Said^1",           (void*)Said);
+    ccAddExternalFunctions(parser_api);
 }

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -149,9 +149,7 @@ RuntimeScriptValue Sc_GetRegionAtScreen(const RuntimeScriptValue *params, int32_
 
 RuntimeScriptValue Sc_Region_GetDrawingSurface(const RuntimeScriptValue *params, int32_t param_count)
 {
-    (void)params; (void)param_count;
-    ScriptDrawingSurface* ret_obj = Room_GetDrawingSurfaceForMask(kRoomAreaRegion);
-    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj);
+    API_SCALL_OBJAUTO(ScriptDrawingSurface, Region_GetDrawingSurface);
 }
 
 RuntimeScriptValue Sc_Region_Tint(void *self, const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/region.cpp
+++ b/Engine/ac/region.cpp
@@ -238,38 +238,26 @@ RuntimeScriptValue Sc_Region_GetTintLuminance(void *self, const RuntimeScriptVal
 
 void RegisterRegionAPI()
 {
-    ccAddExternalStaticFunction("Region::GetAtRoomXY^2",        Sc_GetRegionAtRoom);
-    ccAddExternalStaticFunction("Region::GetAtScreenXY^2",      Sc_GetRegionAtScreen);
-    ccAddExternalStaticFunction("Region::GetDrawingSurface",    Sc_Region_GetDrawingSurface);
-    ccAddExternalObjectFunction("Region::Tint^4",               Sc_Region_TintNoLum);
-    ccAddExternalObjectFunction("Region::Tint^5",               Sc_Region_Tint);
-    ccAddExternalObjectFunction("Region::RunInteraction^1",     Sc_Region_RunInteraction);
-    ccAddExternalObjectFunction("Region::get_Enabled",          Sc_Region_GetEnabled);
-    ccAddExternalObjectFunction("Region::set_Enabled",          Sc_Region_SetEnabled);
-    ccAddExternalObjectFunction("Region::get_ID",               Sc_Region_GetID);
-    ccAddExternalObjectFunction("Region::get_LightLevel",       Sc_Region_GetLightLevel);
-    ccAddExternalObjectFunction("Region::set_LightLevel",       Sc_Region_SetLightLevel);
-    ccAddExternalObjectFunction("Region::get_TintEnabled",      Sc_Region_GetTintEnabled);
-    ccAddExternalObjectFunction("Region::get_TintBlue",         Sc_Region_GetTintBlue);
-    ccAddExternalObjectFunction("Region::get_TintGreen",        Sc_Region_GetTintGreen);
-    ccAddExternalObjectFunction("Region::get_TintRed",          Sc_Region_GetTintRed);
-    ccAddExternalObjectFunction("Region::get_TintSaturation",   Sc_Region_GetTintSaturation);
-    ccAddExternalObjectFunction("Region::get_TintLuminance",    Sc_Region_GetTintLuminance);
+    ScFnRegister region_api[] = {
+        { "Region::GetAtRoomXY^2",        API_FN_PAIR(GetRegionAtRoom) },
+        { "Region::GetAtScreenXY^2",      API_FN_PAIR(GetRegionAtScreen) },
+        { "Region::GetDrawingSurface",    API_FN_PAIR(Region_GetDrawingSurface) },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "Region::Tint^4",               API_FN_PAIR(Region_TintNoLum) },
+        { "Region::Tint^5",               API_FN_PAIR(Region_Tint) },
+        { "Region::RunInteraction^1",     API_FN_PAIR(Region_RunInteraction) },
+        { "Region::get_Enabled",          API_FN_PAIR(Region_GetEnabled) },
+        { "Region::set_Enabled",          API_FN_PAIR(Region_SetEnabled) },
+        { "Region::get_ID",               API_FN_PAIR(Region_GetID) },
+        { "Region::get_LightLevel",       API_FN_PAIR(Region_GetLightLevel) },
+        { "Region::set_LightLevel",       API_FN_PAIR(Region_SetLightLevel) },
+        { "Region::get_TintEnabled",      API_FN_PAIR(Region_GetTintEnabled) },
+        { "Region::get_TintBlue",         API_FN_PAIR(Region_GetTintBlue) },
+        { "Region::get_TintGreen",        API_FN_PAIR(Region_GetTintGreen) },
+        { "Region::get_TintRed",          API_FN_PAIR(Region_GetTintRed) },
+        { "Region::get_TintSaturation",   API_FN_PAIR(Region_GetTintSaturation) },
+        { "Region::get_TintLuminance",    API_FN_PAIR(Region_GetTintLuminance) },
+    };
 
-    ccAddExternalFunctionForPlugin("Region::GetAtRoomXY^2",        (void*)GetRegionAtRoom);
-    ccAddExternalFunctionForPlugin("Region::GetAtScreenXY^2",      (void*)GetRegionAtScreen);
-    ccAddExternalFunctionForPlugin("Region::Tint^4",               (void*)Region_TintNoLum);
-    ccAddExternalFunctionForPlugin("Region::RunInteraction^1",     (void*)Region_RunInteraction);
-    ccAddExternalFunctionForPlugin("Region::get_Enabled",          (void*)Region_GetEnabled);
-    ccAddExternalFunctionForPlugin("Region::set_Enabled",          (void*)Region_SetEnabled);
-    ccAddExternalFunctionForPlugin("Region::get_ID",               (void*)Region_GetID);
-    ccAddExternalFunctionForPlugin("Region::get_LightLevel",       (void*)Region_GetLightLevel);
-    ccAddExternalFunctionForPlugin("Region::set_LightLevel",       (void*)Region_SetLightLevel);
-    ccAddExternalFunctionForPlugin("Region::get_TintEnabled",      (void*)Region_GetTintEnabled);
-    ccAddExternalFunctionForPlugin("Region::get_TintBlue",         (void*)Region_GetTintBlue);
-    ccAddExternalFunctionForPlugin("Region::get_TintGreen",        (void*)Region_GetTintGreen);
-    ccAddExternalFunctionForPlugin("Region::get_TintRed",          (void*)Region_GetTintRed);
-    ccAddExternalFunctionForPlugin("Region::get_TintSaturation",   (void*)Region_GetTintSaturation);
+    ccAddExternalFunctions(region_api);
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1229,41 +1229,26 @@ RuntimeScriptValue Sc_Room_Exists(const RuntimeScriptValue *params, int32_t para
 
 void RegisterRoomAPI()
 {
-    ccAddExternalStaticFunction("Room::GetDrawingSurfaceForBackground^1",   Sc_Room_GetDrawingSurfaceForBackground);
-    ccAddExternalStaticFunction("Room::GetProperty^1",                      Sc_Room_GetProperty);
-    ccAddExternalStaticFunction("Room::GetTextProperty^1",                  Sc_Room_GetTextProperty);
-    ccAddExternalStaticFunction("Room::SetProperty^2",                      Sc_Room_SetProperty);
-    ccAddExternalStaticFunction("Room::SetTextProperty^2",                  Sc_Room_SetTextProperty);
-    ccAddExternalStaticFunction("Room::ProcessClick^3",                     Sc_RoomProcessClick);
-    ccAddExternalStaticFunction("ProcessClick",                             Sc_RoomProcessClick);
-    ccAddExternalStaticFunction("Room::get_BottomEdge",                     Sc_Room_GetBottomEdge);
-    ccAddExternalStaticFunction("Room::get_ColorDepth",                     Sc_Room_GetColorDepth);
-    ccAddExternalStaticFunction("Room::get_Height",                         Sc_Room_GetHeight);
-    ccAddExternalStaticFunction("Room::get_LeftEdge",                       Sc_Room_GetLeftEdge);
-    ccAddExternalStaticFunction("Room::geti_Messages",                      Sc_Room_GetMessages);
-    ccAddExternalStaticFunction("Room::get_MusicOnLoad",                    Sc_Room_GetMusicOnLoad);
-    ccAddExternalStaticFunction("Room::get_ObjectCount",                    Sc_Room_GetObjectCount);
-    ccAddExternalStaticFunction("Room::get_RightEdge",                      Sc_Room_GetRightEdge);
-    ccAddExternalStaticFunction("Room::get_TopEdge",                        Sc_Room_GetTopEdge);
-    ccAddExternalStaticFunction("Room::get_Width",                          Sc_Room_GetWidth);
-    ccAddExternalStaticFunction("Room::Exists",                             Sc_Room_Exists);
+    ScFnRegister room_api[] = {
+        { "Room::GetDrawingSurfaceForBackground^1",   API_FN_PAIR(Room_GetDrawingSurfaceForBackground) },
+        { "Room::GetProperty^1",                      API_FN_PAIR(Room_GetProperty) },
+        { "Room::GetTextProperty^1",                  API_FN_PAIR(Room_GetTextProperty) },
+        { "Room::SetProperty^2",                      API_FN_PAIR(Room_SetProperty) },
+        { "Room::SetTextProperty^2",                  API_FN_PAIR(Room_SetTextProperty) },
+        { "Room::ProcessClick^3",                     API_FN_PAIR(RoomProcessClick) },
+        { "ProcessClick",                             API_FN_PAIR(RoomProcessClick) },
+        { "Room::get_BottomEdge",                     API_FN_PAIR(Room_GetBottomEdge) },
+        { "Room::get_ColorDepth",                     API_FN_PAIR(Room_GetColorDepth) },
+        { "Room::get_Height",                         API_FN_PAIR(Room_GetHeight) },
+        { "Room::get_LeftEdge",                       API_FN_PAIR(Room_GetLeftEdge) },
+        { "Room::geti_Messages",                      API_FN_PAIR(Room_GetMessages) },
+        { "Room::get_MusicOnLoad",                    API_FN_PAIR(Room_GetMusicOnLoad) },
+        { "Room::get_ObjectCount",                    API_FN_PAIR(Room_GetObjectCount) },
+        { "Room::get_RightEdge",                      API_FN_PAIR(Room_GetRightEdge) },
+        { "Room::get_TopEdge",                        API_FN_PAIR(Room_GetTopEdge) },
+        { "Room::get_Width",                          API_FN_PAIR(Room_GetWidth) },
+        { "Room::Exists",                             API_FN_PAIR(Room_Exists) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Room::GetDrawingSurfaceForBackground^1",   (void*)Room_GetDrawingSurfaceForBackground);
-    ccAddExternalFunctionForPlugin("Room::GetProperty^1",                      (void*)Room_GetProperty);
-    ccAddExternalFunctionForPlugin("Room::GetTextProperty^1",                  (void*)Room_GetTextProperty);
-    ccAddExternalFunctionForPlugin("Room::SetProperty^2",                      (void*)Room_SetProperty);
-    ccAddExternalFunctionForPlugin("Room::SetTextProperty^2",                  (void*)Room_SetTextProperty);
-    ccAddExternalFunctionForPlugin("Room::get_BottomEdge",                     (void*)Room_GetBottomEdge);
-    ccAddExternalFunctionForPlugin("Room::get_ColorDepth",                     (void*)Room_GetColorDepth);
-    ccAddExternalFunctionForPlugin("Room::get_Height",                         (void*)Room_GetHeight);
-    ccAddExternalFunctionForPlugin("Room::get_LeftEdge",                       (void*)Room_GetLeftEdge);
-    ccAddExternalFunctionForPlugin("Room::geti_Messages",                      (void*)Room_GetMessages);
-    ccAddExternalFunctionForPlugin("Room::get_MusicOnLoad",                    (void*)Room_GetMusicOnLoad);
-    ccAddExternalFunctionForPlugin("Room::get_ObjectCount",                    (void*)Room_GetObjectCount);
-    ccAddExternalFunctionForPlugin("Room::get_RightEdge",                      (void*)Room_GetRightEdge);
-    ccAddExternalFunctionForPlugin("Room::get_TopEdge",                        (void*)Room_GetTopEdge);
-    ccAddExternalFunctionForPlugin("Room::get_Width",                          (void*)Room_GetWidth);
-    ccAddExternalFunctionForPlugin("Room::Exists",                             (void*)Room_Exists);
+    ccAddExternalFunctions(room_api);
 }

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -207,6 +207,26 @@ bool Room_Exists(int room)
     return AssetMgr->DoesAssetExist(room_filename);
 }
 
+ScriptDrawingSurface *GetDrawingSurfaceForWalkableArea()
+{
+    return Room_GetDrawingSurfaceForMask(kRoomAreaWalkable);
+}
+
+ScriptDrawingSurface *GetDrawingSurfaceForWalkbehind()
+{
+    return Room_GetDrawingSurfaceForMask(kRoomAreaWalkBehind);
+}
+
+ScriptDrawingSurface *Hotspot_GetDrawingSurface()
+{
+    return Room_GetDrawingSurfaceForMask(kRoomAreaHotspot);
+}
+
+ScriptDrawingSurface *Region_GetDrawingSurface()
+{
+    return Room_GetDrawingSurfaceForMask(kRoomAreaRegion);
+}
+
 //=============================================================================
 
 // Makes sure that room background and walk-behind mask are matching room size

--- a/Engine/ac/room.h
+++ b/Engine/ac/room.h
@@ -38,6 +38,10 @@ const char* Room_GetTextProperty(const char *property);
 int Room_GetProperty(const char *property);
 const char* Room_GetMessages(int index);
 RuntimeScriptValue Sc_Room_GetProperty(const RuntimeScriptValue *params, int32_t param_count);
+ScriptDrawingSurface *GetDrawingSurfaceForWalkableArea();
+ScriptDrawingSurface *GetDrawingSurfaceForWalkbehind();
+ScriptDrawingSurface *Hotspot_GetDrawingSurface();
+ScriptDrawingSurface *Region_GetDrawingSurface();
 
 //=============================================================================
 

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -160,6 +160,11 @@ ScriptUserObject* Screen_ScreenToRoomPoint(int scrx, int scry, bool restrict)
     return ScriptStructHelpers::CreatePoint(vpt.first.X, vpt.first.Y);
 }
 
+ScriptUserObject* Screen_ScreenToRoomPoint2(int scrx, int scry)
+{
+    return Screen_ScreenToRoomPoint(scrx, scry, true);
+}
+
 ScriptUserObject *Screen_RoomToScreenPoint(int roomx, int roomy)
 {
     data_to_game_coords(&roomx, &roomy);
@@ -205,14 +210,12 @@ RuntimeScriptValue Sc_Screen_GetAnyViewport(const RuntimeScriptValue *params, in
 
 RuntimeScriptValue Sc_Screen_ScreenToRoomPoint2(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_PARAM_COUNT(FUNCTION, 2);
-    ScriptUserObject* obj = Screen_ScreenToRoomPoint(params[0].IValue, params[1].IValue, true);
-    return RuntimeScriptValue().SetDynamicObject(obj, obj);
+    API_SCALL_OBJAUTO_PINT2(ScriptUserObject, Screen_ScreenToRoomPoint2);
 }
 
-RuntimeScriptValue Sc_Screen_ScreenToRoomPoint3(const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Screen_ScreenToRoomPoint(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_OBJAUTO_PINT3(ScriptUserObject, Screen_ScreenToRoomPoint);
+    API_SCALL_OBJAUTO_PINT2_PBOOL(ScriptUserObject, Screen_ScreenToRoomPoint);
 }
 
 RuntimeScriptValue Sc_Screen_RoomToScreenPoint(const RuntimeScriptValue *params, int32_t param_count)
@@ -230,7 +233,7 @@ void RegisterScreenAPI()
     ccAddExternalStaticFunction("Screen::get_ViewportCount", Sc_Screen_GetViewportCount);
     ccAddExternalStaticFunction("Screen::geti_Viewports", Sc_Screen_GetAnyViewport);
     ccAddExternalStaticFunction("Screen::ScreenToRoomPoint^2", Sc_Screen_ScreenToRoomPoint2);
-    ccAddExternalStaticFunction("Screen::ScreenToRoomPoint^3", Sc_Screen_ScreenToRoomPoint3);
+    ccAddExternalStaticFunction("Screen::ScreenToRoomPoint^3", Sc_Screen_ScreenToRoomPoint);
     ccAddExternalStaticFunction("Screen::RoomToScreenPoint", Sc_Screen_RoomToScreenPoint);
 
     /* ----------------------- Registering unsafe exports for plugins -----------------------*/

--- a/Engine/ac/screen.cpp
+++ b/Engine/ac/screen.cpp
@@ -225,25 +225,18 @@ RuntimeScriptValue Sc_Screen_RoomToScreenPoint(const RuntimeScriptValue *params,
 
 void RegisterScreenAPI()
 {
-    ccAddExternalStaticFunction("Screen::get_Height", Sc_Screen_GetScreenHeight);
-    ccAddExternalStaticFunction("Screen::get_Width", Sc_Screen_GetScreenWidth);
-    ccAddExternalStaticFunction("Screen::get_AutoSizeViewportOnRoomLoad", Sc_Screen_GetAutoSizeViewport);
-    ccAddExternalStaticFunction("Screen::set_AutoSizeViewportOnRoomLoad", Sc_Screen_SetAutoSizeViewport);
-    ccAddExternalStaticFunction("Screen::get_Viewport", Sc_Screen_GetViewport);
-    ccAddExternalStaticFunction("Screen::get_ViewportCount", Sc_Screen_GetViewportCount);
-    ccAddExternalStaticFunction("Screen::geti_Viewports", Sc_Screen_GetAnyViewport);
-    ccAddExternalStaticFunction("Screen::ScreenToRoomPoint^2", Sc_Screen_ScreenToRoomPoint2);
-    ccAddExternalStaticFunction("Screen::ScreenToRoomPoint^3", Sc_Screen_ScreenToRoomPoint);
-    ccAddExternalStaticFunction("Screen::RoomToScreenPoint", Sc_Screen_RoomToScreenPoint);
+    ScFnRegister screen_api[] = {
+        { "Screen::get_Height",             API_FN_PAIR(Screen_GetScreenHeight) },
+        { "Screen::get_Width",              API_FN_PAIR(Screen_GetScreenWidth) },
+        { "Screen::get_AutoSizeViewportOnRoomLoad", API_FN_PAIR(Screen_GetAutoSizeViewport) },
+        { "Screen::set_AutoSizeViewportOnRoomLoad", API_FN_PAIR(Screen_SetAutoSizeViewport) },
+        { "Screen::get_Viewport",           API_FN_PAIR(Screen_GetViewport) },
+        { "Screen::get_ViewportCount",      API_FN_PAIR(Screen_GetViewportCount) },
+        { "Screen::geti_Viewports",         API_FN_PAIR(Screen_GetAnyViewport) },
+        { "Screen::ScreenToRoomPoint^2",    API_FN_PAIR(Screen_ScreenToRoomPoint2) },
+        { "Screen::ScreenToRoomPoint^3",    API_FN_PAIR(Screen_ScreenToRoomPoint) },
+        { "Screen::RoomToScreenPoint",      API_FN_PAIR(Screen_RoomToScreenPoint) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Screen::get_Height", (void*)Screen_GetScreenHeight);
-    ccAddExternalFunctionForPlugin("Screen::get_Width", (void*)Screen_GetScreenWidth);
-    ccAddExternalFunctionForPlugin("Screen::get_AutoSizeViewportOnRoomLoad", (void*)Screen_GetAutoSizeViewport);
-    ccAddExternalFunctionForPlugin("Screen::set_AutoSizeViewportOnRoomLoad", (void*)Screen_SetAutoSizeViewport);
-    ccAddExternalFunctionForPlugin("Screen::get_Viewport", (void*)Screen_GetViewport);
-    ccAddExternalFunctionForPlugin("Screen::get_ViewportCount", (void*)Screen_GetViewportCount);
-    ccAddExternalFunctionForPlugin("Screen::geti_Viewports", (void*) Screen_GetAnyViewport);
-    ccAddExternalFunctionForPlugin("Screen::RoomToScreenPoint", (void*)Screen_RoomToScreenPoint);
+    ccAddExternalFunctions(screen_api);
 }

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -320,7 +320,7 @@ RuntimeScriptValue Sc_Set_GetItemCount(void *self, const RuntimeScriptValue *par
     API_OBJCALL_INT(ScriptSetBase, Set_GetItemCount);
 }
 
-RuntimeScriptValue Sc_Set_GetItemAsArray(void *self, const RuntimeScriptValue *params, int32_t param_count)
+RuntimeScriptValue Sc_Set_GetItemsAsArray(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_OBJ(ScriptSetBase, void, globalDynamicArray, Set_GetItemsAsArray);
 }
@@ -329,25 +329,30 @@ RuntimeScriptValue Sc_Set_GetItemAsArray(void *self, const RuntimeScriptValue *p
 
 void RegisterContainerAPI()
 {
-    ccAddExternalStaticFunction("Dictionary::Create", Sc_Dict_Create);
-    ccAddExternalObjectFunction("Dictionary::Clear", Sc_Dict_Clear);
-    ccAddExternalObjectFunction("Dictionary::Contains", Sc_Dict_Contains);
-    ccAddExternalObjectFunction("Dictionary::Get", Sc_Dict_Get);
-    ccAddExternalObjectFunction("Dictionary::Remove", Sc_Dict_Remove);
-    ccAddExternalObjectFunction("Dictionary::Set", Sc_Dict_Set);
-    ccAddExternalObjectFunction("Dictionary::get_CompareStyle", Sc_Dict_GetCompareStyle);
-    ccAddExternalObjectFunction("Dictionary::get_SortStyle", Sc_Dict_GetSortStyle);
-    ccAddExternalObjectFunction("Dictionary::get_ItemCount", Sc_Dict_GetItemCount);
-    ccAddExternalObjectFunction("Dictionary::GetKeysAsArray", Sc_Dict_GetKeysAsArray);
-    ccAddExternalObjectFunction("Dictionary::GetValuesAsArray", Sc_Dict_GetValuesAsArray);
+    ScFnRegister container_api[] = {
+        // Dictionary
+        { "Dictionary::Create",         API_FN_PAIR(Dict_Create) },
+        { "Dictionary::Clear",          API_FN_PAIR(Dict_Clear) },
+        { "Dictionary::Contains",       API_FN_PAIR(Dict_Contains) },
+        { "Dictionary::Get",            API_FN_PAIR(Dict_Get) },
+        { "Dictionary::Remove",         API_FN_PAIR(Dict_Remove) },
+        { "Dictionary::Set",            API_FN_PAIR(Dict_Set) },
+        { "Dictionary::get_CompareStyle", API_FN_PAIR(Dict_GetCompareStyle) },
+        { "Dictionary::get_SortStyle",  API_FN_PAIR(Dict_GetSortStyle) },
+        { "Dictionary::get_ItemCount",  API_FN_PAIR(Dict_GetItemCount) },
+        { "Dictionary::GetKeysAsArray", API_FN_PAIR(Dict_GetKeysAsArray) },
+        { "Dictionary::GetValuesAsArray", API_FN_PAIR(Dict_GetValuesAsArray) },
+        // Set
+        { "Set::Create",                API_FN_PAIR(Set_Create) },
+        { "Set::Add",                   API_FN_PAIR(Set_Add) },
+        { "Set::Clear",                 API_FN_PAIR(Set_Clear) },
+        { "Set::Contains",              API_FN_PAIR(Set_Contains) },
+        { "Set::Remove",                API_FN_PAIR(Set_Remove) },
+        { "Set::get_CompareStyle",      API_FN_PAIR(Set_GetCompareStyle) },
+        { "Set::get_SortStyle",         API_FN_PAIR(Set_GetSortStyle) },
+        { "Set::get_ItemCount",         API_FN_PAIR(Set_GetItemCount) },
+        { "Set::GetItemsAsArray",       API_FN_PAIR(Set_GetItemsAsArray) },
+    };
 
-    ccAddExternalStaticFunction("Set::Create", Sc_Set_Create);
-    ccAddExternalObjectFunction("Set::Add", Sc_Set_Add);
-    ccAddExternalObjectFunction("Set::Clear", Sc_Set_Clear);
-    ccAddExternalObjectFunction("Set::Contains", Sc_Set_Contains);
-    ccAddExternalObjectFunction("Set::Remove", Sc_Set_Remove);
-    ccAddExternalObjectFunction("Set::get_CompareStyle", Sc_Set_GetCompareStyle);
-    ccAddExternalObjectFunction("Set::get_SortStyle", Sc_Set_GetSortStyle);
-    ccAddExternalObjectFunction("Set::get_ItemCount", Sc_Set_GetItemCount);
-    ccAddExternalObjectFunction("Set::GetItemsAsArray", Sc_Set_GetItemAsArray);
+    ccAddExternalFunctions(container_api);
 }

--- a/Engine/ac/slider.cpp
+++ b/Engine/ac/slider.cpp
@@ -190,31 +190,20 @@ RuntimeScriptValue Sc_Slider_SetValue(void *self, const RuntimeScriptValue *para
 
 void RegisterSliderAPI()
 {
-    ccAddExternalObjectFunction("Slider::get_BackgroundGraphic",    Sc_Slider_GetBackgroundGraphic);
-    ccAddExternalObjectFunction("Slider::set_BackgroundGraphic",    Sc_Slider_SetBackgroundGraphic);
-    ccAddExternalObjectFunction("Slider::get_HandleGraphic",        Sc_Slider_GetHandleGraphic);
-    ccAddExternalObjectFunction("Slider::set_HandleGraphic",        Sc_Slider_SetHandleGraphic);
-    ccAddExternalObjectFunction("Slider::get_HandleOffset",         Sc_Slider_GetHandleOffset);
-    ccAddExternalObjectFunction("Slider::set_HandleOffset",         Sc_Slider_SetHandleOffset);
-    ccAddExternalObjectFunction("Slider::get_Max",                  Sc_Slider_GetMax);
-    ccAddExternalObjectFunction("Slider::set_Max",                  Sc_Slider_SetMax);
-    ccAddExternalObjectFunction("Slider::get_Min",                  Sc_Slider_GetMin);
-    ccAddExternalObjectFunction("Slider::set_Min",                  Sc_Slider_SetMin);
-    ccAddExternalObjectFunction("Slider::get_Value",                Sc_Slider_GetValue);
-    ccAddExternalObjectFunction("Slider::set_Value",                Sc_Slider_SetValue);
+    ScFnRegister slider_api[] = {
+        { "Slider::get_BackgroundGraphic",    API_FN_PAIR(Slider_GetBackgroundGraphic) },
+        { "Slider::set_BackgroundGraphic",    API_FN_PAIR(Slider_SetBackgroundGraphic) },
+        { "Slider::get_HandleGraphic",        API_FN_PAIR(Slider_GetHandleGraphic) },
+        { "Slider::set_HandleGraphic",        API_FN_PAIR(Slider_SetHandleGraphic) },
+        { "Slider::get_HandleOffset",         API_FN_PAIR(Slider_GetHandleOffset) },
+        { "Slider::set_HandleOffset",         API_FN_PAIR(Slider_SetHandleOffset) },
+        { "Slider::get_Max",                  API_FN_PAIR(Slider_GetMax) },
+        { "Slider::set_Max",                  API_FN_PAIR(Slider_SetMax) },
+        { "Slider::get_Min",                  API_FN_PAIR(Slider_GetMin) },
+        { "Slider::set_Min",                  API_FN_PAIR(Slider_SetMin) },
+        { "Slider::get_Value",                API_FN_PAIR(Slider_GetValue) },
+        { "Slider::set_Value",                API_FN_PAIR(Slider_SetValue) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("Slider::get_BackgroundGraphic",    (void*)Slider_GetBackgroundGraphic);
-    ccAddExternalFunctionForPlugin("Slider::set_BackgroundGraphic",    (void*)Slider_SetBackgroundGraphic);
-    ccAddExternalFunctionForPlugin("Slider::get_HandleGraphic",        (void*)Slider_GetHandleGraphic);
-    ccAddExternalFunctionForPlugin("Slider::set_HandleGraphic",        (void*)Slider_SetHandleGraphic);
-    ccAddExternalFunctionForPlugin("Slider::get_HandleOffset",         (void*)Slider_GetHandleOffset);
-    ccAddExternalFunctionForPlugin("Slider::set_HandleOffset",         (void*)Slider_SetHandleOffset);
-    ccAddExternalFunctionForPlugin("Slider::get_Max",                  (void*)Slider_GetMax);
-    ccAddExternalFunctionForPlugin("Slider::set_Max",                  (void*)Slider_SetMax);
-    ccAddExternalFunctionForPlugin("Slider::get_Min",                  (void*)Slider_GetMin);
-    ccAddExternalFunctionForPlugin("Slider::set_Min",                  (void*)Slider_SetMin);
-    ccAddExternalFunctionForPlugin("Slider::get_Value",                (void*)Slider_GetValue);
-    ccAddExternalFunctionForPlugin("Slider::set_Value",                (void*)Slider_SetValue);
+    ccAddExternalFunctions(slider_api);
 }

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -417,35 +417,39 @@ extern RuntimeScriptValue Sc_SetVoiceMode(const RuntimeScriptValue *params, int3
 
 void RegisterSpeechAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
 {
-    ccAddExternalStaticFunction("Speech::get_AnimationStopTimeMargin", Sc_Speech_GetAnimationStopTimeMargin);
-    ccAddExternalStaticFunction("Speech::set_AnimationStopTimeMargin", Sc_Speech_SetAnimationStopTimeMargin);
-    ccAddExternalStaticFunction("Speech::get_CustomPortraitPlacement", Sc_Speech_GetCustomPortraitPlacement);
-    ccAddExternalStaticFunction("Speech::set_CustomPortraitPlacement", Sc_Speech_SetCustomPortraitPlacement);
-    ccAddExternalStaticFunction("Speech::get_DisplayPostTimeMs",      Sc_Speech_GetDisplayPostTimeMs);
-    ccAddExternalStaticFunction("Speech::set_DisplayPostTimeMs",      Sc_Speech_SetDisplayPostTimeMs);
-	ccAddExternalStaticFunction("Speech::get_GlobalSpeechAnimationDelay", Sc_Speech_GetGlobalSpeechAnimationDelay);
-	ccAddExternalStaticFunction("Speech::set_GlobalSpeechAnimationDelay", Sc_Speech_SetGlobalSpeechAnimationDelay);
-    ccAddExternalStaticFunction("Speech::get_PortraitOverlay",        Sc_Speech_GetPortraitOverlay);
-    ccAddExternalStaticFunction("Speech::get_PortraitXOffset",        Sc_Speech_GetPortraitXOffset);
-    ccAddExternalStaticFunction("Speech::set_PortraitXOffset",        Sc_Speech_SetPortraitXOffset);
-    ccAddExternalStaticFunction("Speech::get_PortraitY",              Sc_Speech_GetPortraitY);
-    ccAddExternalStaticFunction("Speech::set_PortraitY",              Sc_Speech_SetPortraitY);
-    ccAddExternalStaticFunction("Speech::get_SkipKey",                Sc_Speech_GetSkipKey);
-    ccAddExternalStaticFunction("Speech::set_SkipKey",                Sc_Speech_SetSkipKey);
-    ccAddExternalStaticFunction("Speech::get_SkipStyle",              Sc_Speech_GetSkipStyle);
-    ccAddExternalStaticFunction("Speech::set_SkipStyle",              Sc_SetSkipSpeech);
-    ccAddExternalStaticFunction("Speech::get_Style",                  Sc_Speech_GetStyle);
-    ccAddExternalStaticFunction("Speech::set_Style",                  Sc_SetSpeechStyle);
-    ccAddExternalStaticFunction("Speech::get_TextAlignment",          Sc_Speech_GetTextAlignment);
-    if (base_api < kScriptAPI_v350)
-        ccAddExternalStaticFunction("Speech::set_TextAlignment",      Sc_Speech_SetTextAlignment_Old);
-    else
-        ccAddExternalStaticFunction("Speech::set_TextAlignment",      Sc_Speech_SetTextAlignment);
-    ccAddExternalStaticFunction("Speech::get_TextOverlay",            Sc_Speech_GetTextOverlay);
-	ccAddExternalStaticFunction("Speech::get_UseGlobalSpeechAnimationDelay", Sc_Speech_GetUseGlobalSpeechAnimationDelay);
-	ccAddExternalStaticFunction("Speech::set_UseGlobalSpeechAnimationDelay", Sc_Speech_SetUseGlobalSpeechAnimationDelay);
-    ccAddExternalStaticFunction("Speech::get_VoiceMode",              Sc_Speech_GetVoiceMode);
-    ccAddExternalStaticFunction("Speech::set_VoiceMode",              Sc_SetVoiceMode);
+    ScFnRegister speech_api[] = {
+        { "Speech::get_AnimationStopTimeMargin", API_FN_PAIR(Speech_GetAnimationStopTimeMargin) },
+        { "Speech::set_AnimationStopTimeMargin", API_FN_PAIR(Speech_SetAnimationStopTimeMargin) },
+        { "Speech::get_CustomPortraitPlacement", API_FN_PAIR(Speech_GetCustomPortraitPlacement) },
+        { "Speech::set_CustomPortraitPlacement", API_FN_PAIR(Speech_SetCustomPortraitPlacement) },
+        { "Speech::get_DisplayPostTimeMs",      API_FN_PAIR(Speech_GetDisplayPostTimeMs) },
+        { "Speech::set_DisplayPostTimeMs",      API_FN_PAIR(Speech_SetDisplayPostTimeMs) },
+        { "Speech::get_GlobalSpeechAnimationDelay", API_FN_PAIR(Speech_GetGlobalSpeechAnimationDelay) },
+        { "Speech::set_GlobalSpeechAnimationDelay", API_FN_PAIR(Speech_SetGlobalSpeechAnimationDelay) },
+        { "Speech::get_PortraitOverlay",        API_FN_PAIR(Speech_GetPortraitOverlay) },
+        { "Speech::get_PortraitXOffset",        API_FN_PAIR(Speech_GetPortraitXOffset) },
+        { "Speech::set_PortraitXOffset",        API_FN_PAIR(Speech_SetPortraitXOffset) },
+        { "Speech::get_PortraitY",              API_FN_PAIR(Speech_GetPortraitY) },
+        { "Speech::set_PortraitY",              API_FN_PAIR(Speech_SetPortraitY) },
+        { "Speech::get_SkipKey",                API_FN_PAIR(Speech_GetSkipKey) },
+        { "Speech::set_SkipKey",                API_FN_PAIR(Speech_SetSkipKey) },
+        { "Speech::get_SkipStyle",              Sc_Speech_GetSkipStyle, GetSkipSpeech },
+        { "Speech::set_SkipStyle",              API_FN_PAIR(SetSkipSpeech) },
+        { "Speech::get_Style",                  API_FN_PAIR(Speech_GetStyle) },
+        { "Speech::set_Style",                  API_FN_PAIR(SetSpeechStyle) },
+        { "Speech::get_TextAlignment",          API_FN_PAIR(Speech_GetTextAlignment) },
+        { "Speech::get_TextOverlay",            API_FN_PAIR(Speech_GetTextOverlay) },
+        { "Speech::get_UseGlobalSpeechAnimationDelay", API_FN_PAIR(Speech_GetUseGlobalSpeechAnimationDelay) },
+        { "Speech::set_UseGlobalSpeechAnimationDelay", API_FN_PAIR(Speech_SetUseGlobalSpeechAnimationDelay) },
+        { "Speech::get_VoiceMode",              Sc_Speech_GetVoiceMode, GetVoiceMode },
+        { "Speech::set_VoiceMode",              API_FN_PAIR(SetVoiceMode) },
+    };
 
-    /* -- Don't register more unsafe plugin symbols until new plugin interface is designed --*/
+    ccAddExternalFunctions(speech_api);
+
+    // Few functions have to be selected based on API level
+    if (base_api < kScriptAPI_v350)
+        ccAddExternalStaticFunction("Speech::set_TextAlignment", API_FN_PAIR(Speech_SetTextAlignment_Old));
+    else
+        ccAddExternalStaticFunction("Speech::set_TextAlignment", API_FN_PAIR(Speech_SetTextAlignment));
 }

--- a/Engine/ac/speech.cpp
+++ b/Engine/ac/speech.cpp
@@ -182,86 +182,188 @@ ScriptOverlay* Speech_GetPortraitOverlay()
     return (ScriptOverlay*)ccGetObjectAddressFromHandle(play.speech_face_schandle);
 }
 
-RuntimeScriptValue Sc_Speech_GetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
+int Speech_GetAnimationStopTimeMargin()
 {
-    API_VARGET_INT(play.close_mouth_speech_time);
+    return play.close_mouth_speech_time;
 }
 
-RuntimeScriptValue Sc_Speech_SetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
+void Speech_SetAnimationStopTimeMargin(int time)
 {
-    API_VARSET_PINT(play.close_mouth_speech_time);
+    play.close_mouth_speech_time = time;
 }
 
-RuntimeScriptValue Sc_Speech_GetCustomPortraitPlacement(const RuntimeScriptValue *params, int32_t param_count)
+int Speech_GetCustomPortraitPlacement()
 {
-    API_VARGET_INT(play.speech_portrait_placement);
+    return play.speech_portrait_placement;
 }
 
-RuntimeScriptValue Sc_Speech_SetCustomPortraitPlacement(const RuntimeScriptValue *params, int32_t param_count)
+void Speech_SetCustomPortraitPlacement(int placement)
 {
-    API_VARSET_PINT(play.speech_portrait_placement);
+    play.speech_portrait_placement = placement;
 }
 
-RuntimeScriptValue Sc_Speech_GetDisplayPostTimeMs(const RuntimeScriptValue *params, int32_t param_count)
+int Speech_GetDisplayPostTimeMs()
 {
-    API_VARGET_INT(play.speech_display_post_time_ms);
+    return play.speech_display_post_time_ms;
 }
 
-RuntimeScriptValue Sc_Speech_SetDisplayPostTimeMs(const RuntimeScriptValue *params, int32_t param_count)
+void Speech_SetDisplayPostTimeMs(int time_ms)
 {
-    API_VARSET_PINT(play.speech_display_post_time_ms);
+    play.speech_display_post_time_ms = time_ms;
 }
 
-RuntimeScriptValue Sc_Speech_GetGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
+int Speech_GetGlobalSpeechAnimationDelay()
 {
-	API_VARGET_INT(play.talkanim_speed);
+	return play.talkanim_speed;
 }
 
-RuntimeScriptValue Sc_Speech_SetGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
+void Speech_SetGlobalSpeechAnimationDelay(int delay)
 {
     if (game.options[OPT_GLOBALTALKANIMSPD] == 0)
     {
         debug_script_warn("Speech.GlobalSpeechAnimationDelay cannot be set when global speech animation speed is not enabled; set Speech.UseGlobalSpeechAnimationDelay first!");
-        return RuntimeScriptValue();
+        return;
     }
-	API_VARSET_PINT(play.talkanim_speed);
+    play.talkanim_speed = delay;
+}
+
+int Speech_GetPortraitXOffset()
+{
+    return play.speech_portrait_x;
+}
+
+void Speech_SetPortraitXOffset(int x)
+{
+    play.speech_portrait_x = x;
+}
+
+int Speech_GetPortraitY()
+{
+    return play.speech_portrait_y;
+}
+
+void Speech_SetPortraitY(int y)
+{
+    play.speech_portrait_y = y;
+}
+
+int Speech_GetStyle()
+{
+    return game.options[OPT_SPEECHTYPE];
+}
+
+int Speech_GetSkipKey()
+{
+    return play.skip_speech_specific_key;
+}
+
+void Speech_SetSkipKey(int key)
+{
+    play.skip_speech_specific_key = key;
+}
+
+int Speech_GetTextAlignment()
+{
+    return play.speech_text_align;
+}
+
+void Speech_SetTextAlignment_Old(int alignment)
+{
+    play.speech_text_align = ReadScriptAlignment(alignment);
+}
+
+void Speech_SetTextAlignment(int alignment)
+{
+    play.speech_text_align = (HorAlignment)alignment;
+}
+
+int Speech_GetUseGlobalSpeechAnimationDelay()
+{
+	return game.options[OPT_GLOBALTALKANIMSPD];
+}
+
+void Speech_SetUseGlobalSpeechAnimationDelay(int delay)
+{
+	game.options[OPT_GLOBALTALKANIMSPD] = delay;
+}
+
+//-----------------------------------------------------------------------------
+
+RuntimeScriptValue Sc_Speech_GetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Speech_GetAnimationStopTimeMargin);
+}
+
+RuntimeScriptValue Sc_Speech_SetAnimationStopTimeMargin(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Speech_SetAnimationStopTimeMargin);
+}
+
+RuntimeScriptValue Sc_Speech_GetCustomPortraitPlacement(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Speech_GetCustomPortraitPlacement);
+}
+
+RuntimeScriptValue Sc_Speech_SetCustomPortraitPlacement(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Speech_SetCustomPortraitPlacement);
+}
+
+RuntimeScriptValue Sc_Speech_GetDisplayPostTimeMs(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Speech_GetDisplayPostTimeMs);
+}
+
+RuntimeScriptValue Sc_Speech_SetDisplayPostTimeMs(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Speech_SetDisplayPostTimeMs);
+}
+
+RuntimeScriptValue Sc_Speech_GetGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_INT(Speech_GetGlobalSpeechAnimationDelay);
+}
+
+RuntimeScriptValue Sc_Speech_SetGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_VOID_PINT(Speech_SetGlobalSpeechAnimationDelay);
 }
 
 RuntimeScriptValue Sc_Speech_GetPortraitXOffset(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(play.speech_portrait_x);
+    API_SCALL_INT(Speech_GetPortraitXOffset);
 }
 
 RuntimeScriptValue Sc_Speech_SetPortraitXOffset(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARSET_PINT(play.speech_portrait_x);
+    API_SCALL_VOID_PINT(Speech_SetPortraitXOffset);
 }
 
 RuntimeScriptValue Sc_Speech_GetPortraitY(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(play.speech_portrait_y);
+    API_SCALL_INT(Speech_GetPortraitY);
 }
 
 RuntimeScriptValue Sc_Speech_SetPortraitY(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARSET_PINT(play.speech_portrait_y);
+    API_SCALL_VOID_PINT(Speech_SetPortraitY);
 }
 
 RuntimeScriptValue Sc_Speech_GetStyle(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(game.options[OPT_SPEECHTYPE]);
+    API_SCALL_INT(Speech_GetStyle);
 }
 
 extern RuntimeScriptValue Sc_SetSpeechStyle(const RuntimeScriptValue *params, int32_t param_count);
 
 RuntimeScriptValue Sc_Speech_GetSkipKey(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(play.skip_speech_specific_key);
+    API_SCALL_INT(Speech_GetSkipKey);
 }
 
 RuntimeScriptValue Sc_Speech_SetSkipKey(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARSET_PINT(play.skip_speech_specific_key);
+    API_SCALL_VOID_PINT(Speech_SetSkipKey);
 }
 
 RuntimeScriptValue Sc_Speech_GetSkipStyle(const RuntimeScriptValue *params, int32_t param_count)
@@ -273,31 +375,27 @@ extern RuntimeScriptValue Sc_SetSkipSpeech(const RuntimeScriptValue *params, int
 
 RuntimeScriptValue Sc_Speech_GetTextAlignment(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_VARGET_INT(play.speech_text_align);
+    API_SCALL_INT(Speech_GetTextAlignment);
 }
 
 RuntimeScriptValue Sc_Speech_SetTextAlignment_Old(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_VARIABLE_VALUE(play.speech_text_align);
-    play.speech_text_align = ReadScriptAlignment(params[0].IValue);
-    return RuntimeScriptValue();
+    API_SCALL_VOID_PINT(Speech_SetTextAlignment_Old);
 }
 
 RuntimeScriptValue Sc_Speech_SetTextAlignment(const RuntimeScriptValue *params, int32_t param_count)
 {
-    ASSERT_VARIABLE_VALUE(play.speech_text_align);
-    play.speech_text_align = (HorAlignment)params[0].IValue;
-    return RuntimeScriptValue();
+    API_SCALL_VOID_PINT(Speech_SetTextAlignment);
 }
 
 RuntimeScriptValue Sc_Speech_GetUseGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
 {
-	API_VARGET_INT(game.options[OPT_GLOBALTALKANIMSPD]);
+    API_SCALL_INT(Speech_GetUseGlobalSpeechAnimationDelay);
 }
 
 RuntimeScriptValue Sc_Speech_SetUseGlobalSpeechAnimationDelay(const RuntimeScriptValue *params, int32_t param_count)
 {
-	API_VARSET_PINT(game.options[OPT_GLOBALTALKANIMSPD]);
+    API_SCALL_VOID_PINT(Speech_SetUseGlobalSpeechAnimationDelay);
 }
 
 RuntimeScriptValue Sc_Speech_GetVoiceMode(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -489,47 +489,29 @@ const char *ScPl_String_Format(const char *texx, ...)
 
 void RegisterStringAPI()
 {
-    ccAddExternalStaticFunction("String::IsNullOrEmpty^1",  Sc_String_IsNullOrEmpty);
-    ccAddExternalObjectFunction("String::Append^1",         Sc_String_Append);
-    ccAddExternalObjectFunction("String::AppendChar^1",     Sc_String_AppendChar);
-    ccAddExternalObjectFunction("String::CompareTo^2",      Sc_String_CompareTo);
-    ccAddExternalObjectFunction("String::Contains^1",       Sc_StrContains);
-    ccAddExternalObjectFunction("String::Copy^0",           Sc_String_Copy);
-    ccAddExternalObjectFunction("String::EndsWith^2",       Sc_String_EndsWith);
-    ccAddExternalStaticFunction("String::Format^101",       Sc_String_Format);
-    ccAddExternalObjectFunction("String::IndexOf^1",        Sc_StrContains);
-    ccAddExternalObjectFunction("String::LowerCase^0",      Sc_String_LowerCase);
-    ccAddExternalObjectFunction("String::Replace^3",        Sc_String_Replace);
-    ccAddExternalObjectFunction("String::ReplaceCharAt^2",  Sc_String_ReplaceCharAt);
-    ccAddExternalObjectFunction("String::StartsWith^2",     Sc_String_StartsWith);
-    ccAddExternalObjectFunction("String::Substring^2",      Sc_String_Substring);
-    ccAddExternalObjectFunction("String::Truncate^1",       Sc_String_Truncate);
-    ccAddExternalObjectFunction("String::UpperCase^0",      Sc_String_UpperCase);
-    ccAddExternalObjectFunction("String::get_AsFloat",      Sc_StringToFloat);
-    ccAddExternalObjectFunction("String::get_AsInt",        Sc_StringToInt);
-    ccAddExternalObjectFunction("String::geti_Chars",       Sc_String_GetChars);
-    ccAddExternalObjectFunction("String::get_Length",       Sc_strlen);
+    ScFnRegister string_api[] = {
+        { "String::IsNullOrEmpty^1",  API_FN_PAIR(String_IsNullOrEmpty) },
+        { "String::Format^101",       Sc_String_Format, ScPl_String_Format },
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
+        { "String::Append^1",         API_FN_PAIR(String_Append) },
+        { "String::AppendChar^1",     API_FN_PAIR(String_AppendChar) },
+        { "String::CompareTo^2",      API_FN_PAIR(String_CompareTo) },
+        { "String::Contains^1",       API_FN_PAIR(StrContains) },
+        { "String::Copy^0",           API_FN_PAIR(String_Copy) },
+        { "String::EndsWith^2",       API_FN_PAIR(String_EndsWith) },
+        { "String::IndexOf^1",        API_FN_PAIR(StrContains) },
+        { "String::LowerCase^0",      API_FN_PAIR(String_LowerCase) },
+        { "String::Replace^3",        API_FN_PAIR(String_Replace) },
+        { "String::ReplaceCharAt^2",  API_FN_PAIR(String_ReplaceCharAt) },
+        { "String::StartsWith^2",     API_FN_PAIR(String_StartsWith) },
+        { "String::Substring^2",      API_FN_PAIR(String_Substring) },
+        { "String::Truncate^1",       API_FN_PAIR(String_Truncate) },
+        { "String::UpperCase^0",      API_FN_PAIR(String_UpperCase) },
+        { "String::get_AsFloat",      API_FN_PAIR(StringToFloat) },
+        { "String::get_AsInt",        API_FN_PAIR(StringToInt) },
+        { "String::geti_Chars",       API_FN_PAIR(String_GetChars) },
+        { "String::get_Length",       API_FN_PAIR(strlen) },
+    };
 
-    ccAddExternalFunctionForPlugin("String::IsNullOrEmpty^1",  (void*)String_IsNullOrEmpty);
-    ccAddExternalFunctionForPlugin("String::Append^1",         (void*)String_Append);
-    ccAddExternalFunctionForPlugin("String::AppendChar^1",     (void*)String_AppendChar);
-    ccAddExternalFunctionForPlugin("String::CompareTo^2",      (void*)String_CompareTo);
-    ccAddExternalFunctionForPlugin("String::Contains^1",       (void*)StrContains);
-    ccAddExternalFunctionForPlugin("String::Copy^0",           (void*)String_Copy);
-    ccAddExternalFunctionForPlugin("String::EndsWith^2",       (void*)String_EndsWith);
-    ccAddExternalFunctionForPlugin("String::Format^101",       (void*)ScPl_String_Format);
-    ccAddExternalFunctionForPlugin("String::IndexOf^1",        (void*)StrContains);
-    ccAddExternalFunctionForPlugin("String::LowerCase^0",      (void*)String_LowerCase);
-    ccAddExternalFunctionForPlugin("String::Replace^3",        (void*)String_Replace);
-    ccAddExternalFunctionForPlugin("String::ReplaceCharAt^2",  (void*)String_ReplaceCharAt);
-    ccAddExternalFunctionForPlugin("String::StartsWith^2",     (void*)String_StartsWith);
-    ccAddExternalFunctionForPlugin("String::Substring^2",      (void*)String_Substring);
-    ccAddExternalFunctionForPlugin("String::Truncate^1",       (void*)String_Truncate);
-    ccAddExternalFunctionForPlugin("String::UpperCase^0",      (void*)String_UpperCase);
-    ccAddExternalFunctionForPlugin("String::get_AsFloat",      (void*)StringToFloat);
-    ccAddExternalFunctionForPlugin("String::get_AsInt",        (void*)StringToInt);
-    ccAddExternalFunctionForPlugin("String::geti_Chars",       (void*)String_GetChars);
-    ccAddExternalFunctionForPlugin("String::get_Length",       (void*)strlen);
+    ccAddExternalFunctions(string_api);
 }

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -475,7 +475,7 @@ RuntimeScriptValue Sc_strlen(void *self, const RuntimeScriptValue *params, int32
 
 //=============================================================================
 //
-// Exclusive API for Plugins
+// Exclusive variadic API implementation for Plugins
 //
 //=============================================================================
 

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -46,7 +46,7 @@ extern IGraphicsDriver *gfxDriver;
 extern CCAudioChannel ccDynamicAudio;
 extern volatile bool switched_away;
 
-bool System_HasInputFocus()
+bool System_GetHasInputFocus()
 {
     return !switched_away;
 }
@@ -274,7 +274,7 @@ RuntimeScriptValue Sc_System_GetHardwareAcceleration(const RuntimeScriptValue *p
 
 RuntimeScriptValue Sc_System_GetHasInputFocus(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_BOOL(System_HasInputFocus);
+    API_SCALL_BOOL(System_GetHasInputFocus);
 }
 
 // int ()
@@ -408,60 +408,38 @@ void ScPl_System_Log(CharacterInfo *chaa, int message_type, const char *texx, ..
 
 void RegisterSystemAPI()
 {
-    ccAddExternalStaticFunction("System::get_AudioChannelCount",    Sc_System_GetAudioChannelCount);
-    ccAddExternalStaticFunction("System::geti_AudioChannels",       Sc_System_GetAudioChannels);
-    ccAddExternalStaticFunction("System::get_CapsLock",             Sc_System_GetCapsLock);
-    ccAddExternalStaticFunction("System::get_ColorDepth",           Sc_System_GetColorDepth);
-    ccAddExternalStaticFunction("System::get_Gamma",                Sc_System_GetGamma);
-    ccAddExternalStaticFunction("System::set_Gamma",                Sc_System_SetGamma);
-    ccAddExternalStaticFunction("System::get_HardwareAcceleration", Sc_System_GetHardwareAcceleration);
-    ccAddExternalStaticFunction("System::get_HasInputFocus",        Sc_System_GetHasInputFocus);
-    ccAddExternalStaticFunction("System::get_NumLock",              Sc_System_GetNumLock);
-    ccAddExternalStaticFunction("System::get_OperatingSystem",      Sc_System_GetOS);
-    ccAddExternalStaticFunction("System::get_RenderAtScreenResolution", Sc_System_GetRenderAtScreenResolution);
-    ccAddExternalStaticFunction("System::set_RenderAtScreenResolution", Sc_System_SetRenderAtScreenResolution);
-    ccAddExternalStaticFunction("System::get_RuntimeInfo",          Sc_System_GetRuntimeInfo);
-    ccAddExternalStaticFunction("System::get_ScreenHeight",         Sc_System_GetScreenHeight);
-    ccAddExternalStaticFunction("System::get_ScreenWidth",          Sc_System_GetScreenWidth);
-    ccAddExternalStaticFunction("System::get_ScrollLock",           Sc_System_GetScrollLock);
-    ccAddExternalStaticFunction("System::get_SupportsGammaControl", Sc_System_GetSupportsGammaControl);
-    ccAddExternalStaticFunction("System::get_Version",              Sc_System_GetVersion);
-    ccAddExternalStaticFunction("SystemInfo::get_Version",          Sc_System_GetVersion);
-    ccAddExternalStaticFunction("System::get_ViewportHeight",       Sc_System_GetViewportHeight);
-    ccAddExternalStaticFunction("System::get_ViewportWidth",        Sc_System_GetViewportWidth);
-    ccAddExternalStaticFunction("System::get_Volume",               Sc_System_GetVolume);
-    ccAddExternalStaticFunction("System::set_Volume",               Sc_System_SetVolume);
-    ccAddExternalStaticFunction("System::get_VSync",                Sc_System_GetVsync);
-    ccAddExternalStaticFunction("System::set_VSync",                Sc_System_SetVsync);
-    ccAddExternalStaticFunction("System::get_Windowed",             Sc_System_GetWindowed);
-    ccAddExternalStaticFunction("System::set_Windowed",             Sc_System_SetWindowed);
+    ScFnRegister system_api[] = {
+        { "System::get_AudioChannelCount",    API_FN_PAIR(System_GetAudioChannelCount) },
+        { "System::geti_AudioChannels",       API_FN_PAIR(System_GetAudioChannels) },
+        { "System::get_CapsLock",             API_FN_PAIR(System_GetCapsLock) },
+        { "System::get_ColorDepth",           API_FN_PAIR(System_GetColorDepth) },
+        { "System::get_Gamma",                API_FN_PAIR(System_GetGamma) },
+        { "System::set_Gamma",                API_FN_PAIR(System_SetGamma) },
+        { "System::get_HardwareAcceleration", API_FN_PAIR(System_GetHardwareAcceleration) },
+        { "System::get_HasInputFocus",        API_FN_PAIR(System_GetHasInputFocus) },
+        { "System::get_NumLock",              API_FN_PAIR(System_GetNumLock) },
+        { "System::get_OperatingSystem",      API_FN_PAIR(System_GetOS) },
+        { "System::get_RenderAtScreenResolution", API_FN_PAIR(System_GetRenderAtScreenResolution) },
+        { "System::set_RenderAtScreenResolution", API_FN_PAIR(System_SetRenderAtScreenResolution) },
+        { "System::get_RuntimeInfo",          API_FN_PAIR(System_GetRuntimeInfo) },
+        { "System::get_ScreenHeight",         API_FN_PAIR(System_GetScreenHeight) },
+        { "System::get_ScreenWidth",          API_FN_PAIR(System_GetScreenWidth) },
+        { "System::get_ScrollLock",           API_FN_PAIR(System_GetScrollLock) },
+        { "System::get_SupportsGammaControl", API_FN_PAIR(System_GetSupportsGammaControl) },
+        { "System::get_Version",              API_FN_PAIR(System_GetVersion) },
+        { "SystemInfo::get_Version",          API_FN_PAIR(System_GetVersion) },
+        { "System::get_ViewportHeight",       API_FN_PAIR(System_GetViewportHeight) },
+        { "System::get_ViewportWidth",        API_FN_PAIR(System_GetViewportWidth) },
+        { "System::get_Volume",               API_FN_PAIR(System_GetVolume) },
+        { "System::set_Volume",               API_FN_PAIR(System_SetVolume) },
+        { "System::get_VSync",                API_FN_PAIR(System_GetVsync) },
+        { "System::set_VSync",                API_FN_PAIR(System_SetVsync) },
+        { "System::get_Windowed",             API_FN_PAIR(System_GetWindowed) },
+        { "System::set_Windowed",             API_FN_PAIR(System_SetWindowed) },
+        
+        { "System::SaveConfigToFile",         Sc_System_SaveConfigToFile, save_config_file },
+        { "System::Log^102",                  Sc_System_Log, ScPl_System_Log },
+    };
 
-    ccAddExternalStaticFunction("System::SaveConfigToFile",         Sc_System_SaveConfigToFile);
-    ccAddExternalStaticFunction("System::Log^102",                  Sc_System_Log);
-
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("System::get_AudioChannelCount",    (void*)System_GetAudioChannelCount);
-    ccAddExternalFunctionForPlugin("System::geti_AudioChannels",       (void*)System_GetAudioChannels);
-    ccAddExternalFunctionForPlugin("System::get_CapsLock",             (void*)System_GetCapsLock);
-    ccAddExternalFunctionForPlugin("System::get_ColorDepth",           (void*)System_GetColorDepth);
-    ccAddExternalFunctionForPlugin("System::get_Gamma",                (void*)System_GetGamma);
-    ccAddExternalFunctionForPlugin("System::set_Gamma",                (void*)System_SetGamma);
-    ccAddExternalFunctionForPlugin("System::get_HardwareAcceleration", (void*)System_GetHardwareAcceleration);
-    ccAddExternalFunctionForPlugin("System::get_NumLock",              (void*)System_GetNumLock);
-    ccAddExternalFunctionForPlugin("System::get_OperatingSystem",      (void*)System_GetOS);
-    ccAddExternalFunctionForPlugin("System::get_RuntimeInfo",          (void*)System_GetRuntimeInfo);
-    ccAddExternalFunctionForPlugin("System::get_ScreenHeight",         (void*)System_GetScreenHeight);
-    ccAddExternalFunctionForPlugin("System::get_ScreenWidth",          (void*)System_GetScreenWidth);
-    ccAddExternalFunctionForPlugin("System::get_ScrollLock",           (void*)System_GetScrollLock);
-    ccAddExternalFunctionForPlugin("System::get_SupportsGammaControl", (void*)System_GetSupportsGammaControl);
-    ccAddExternalFunctionForPlugin("System::get_Version",              (void*)System_GetVersion);
-    ccAddExternalFunctionForPlugin("SystemInfo::get_Version",          (void*)System_GetVersion);
-    ccAddExternalFunctionForPlugin("System::get_ViewportHeight",       (void*)System_GetViewportHeight);
-    ccAddExternalFunctionForPlugin("System::get_ViewportWidth",        (void*)System_GetViewportWidth);
-    ccAddExternalFunctionForPlugin("System::get_Volume",               (void*)System_GetVolume);
-    ccAddExternalFunctionForPlugin("System::set_Volume",               (void*)System_SetVolume);
-    ccAddExternalFunctionForPlugin("System::get_VSync",                (void*)System_GetVsync);
-    ccAddExternalFunctionForPlugin("System::set_VSync",                (void*)System_SetVsync);
-    ccAddExternalFunctionForPlugin("System::get_Windowed",             (void*)System_GetWindowed);
+    ccAddExternalFunctions(system_api);
 }

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -393,6 +393,17 @@ RuntimeScriptValue Sc_System_Log(const RuntimeScriptValue *params, int32_t param
     return RuntimeScriptValue((int32_t)0);
 }
 
+//=============================================================================
+//
+// Exclusive variadic API implementation for Plugins
+//
+//=============================================================================
+
+void ScPl_System_Log(CharacterInfo *chaa, int message_type, const char *texx, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF_PURE(texx);
+    Debug::Printf(kDbgGroup_Script, (MessageType)message_type, scsf_buffer);
+}
 
 
 void RegisterSystemAPI()

--- a/Engine/ac/textbox.cpp
+++ b/Engine/ac/textbox.cpp
@@ -147,25 +147,18 @@ RuntimeScriptValue Sc_TextBox_SetTextColor(void *self, const RuntimeScriptValue 
 
 void RegisterTextBoxAPI()
 {
-    ccAddExternalObjectFunction("TextBox::GetText^1",       Sc_TextBox_GetText);
-    ccAddExternalObjectFunction("TextBox::SetText^1",       Sc_TextBox_SetText);
-    ccAddExternalObjectFunction("TextBox::get_Font",        Sc_TextBox_GetFont);
-    ccAddExternalObjectFunction("TextBox::set_Font",        Sc_TextBox_SetFont);
-    ccAddExternalObjectFunction("TextBox::get_ShowBorder",  Sc_TextBox_GetShowBorder);
-    ccAddExternalObjectFunction("TextBox::set_ShowBorder",  Sc_TextBox_SetShowBorder);
-    ccAddExternalObjectFunction("TextBox::get_Text",        Sc_TextBox_GetText_New);
-    ccAddExternalObjectFunction("TextBox::set_Text",        Sc_TextBox_SetText);
-    ccAddExternalObjectFunction("TextBox::get_TextColor",   Sc_TextBox_GetTextColor);
-    ccAddExternalObjectFunction("TextBox::set_TextColor",   Sc_TextBox_SetTextColor);
+    ScFnRegister textbox_api[] = {
+        { "TextBox::GetText^1",       API_FN_PAIR(TextBox_GetText) },
+        { "TextBox::SetText^1",       API_FN_PAIR(TextBox_SetText) },
+        { "TextBox::get_Font",        API_FN_PAIR(TextBox_GetFont) },
+        { "TextBox::set_Font",        API_FN_PAIR(TextBox_SetFont) },
+        { "TextBox::get_ShowBorder",  API_FN_PAIR(TextBox_GetShowBorder) },
+        { "TextBox::set_ShowBorder",  API_FN_PAIR(TextBox_SetShowBorder) },
+        { "TextBox::get_Text",        API_FN_PAIR(TextBox_GetText_New) },
+        { "TextBox::set_Text",        API_FN_PAIR(TextBox_SetText) },
+        { "TextBox::get_TextColor",   API_FN_PAIR(TextBox_GetTextColor) },
+        { "TextBox::set_TextColor",   API_FN_PAIR(TextBox_SetTextColor) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("TextBox::GetText^1",       (void*)TextBox_GetText);
-    ccAddExternalFunctionForPlugin("TextBox::SetText^1",       (void*)TextBox_SetText);
-    ccAddExternalFunctionForPlugin("TextBox::get_Font",        (void*)TextBox_GetFont);
-    ccAddExternalFunctionForPlugin("TextBox::set_Font",        (void*)TextBox_SetFont);
-    ccAddExternalFunctionForPlugin("TextBox::get_Text",        (void*)TextBox_GetText_New);
-    ccAddExternalFunctionForPlugin("TextBox::set_Text",        (void*)TextBox_SetText);
-    ccAddExternalFunctionForPlugin("TextBox::get_TextColor",   (void*)TextBox_GetTextColor);
-    ccAddExternalFunctionForPlugin("TextBox::set_TextColor",   (void*)TextBox_SetTextColor);
+    ccAddExternalFunctions(textbox_api);
 }

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -259,29 +259,19 @@ RuntimeScriptValue Sc_ViewFrame_GetView(void *self, const RuntimeScriptValue *pa
 
 void RegisterViewFrameAPI()
 {
-    ccAddExternalObjectFunction("ViewFrame::get_Flipped",       Sc_ViewFrame_GetFlipped);
-    ccAddExternalObjectFunction("ViewFrame::get_Frame",         Sc_ViewFrame_GetFrame);
-    ccAddExternalObjectFunction("ViewFrame::get_Graphic",       Sc_ViewFrame_GetGraphic);
-    ccAddExternalObjectFunction("ViewFrame::set_Graphic",       Sc_ViewFrame_SetGraphic);
-    ccAddExternalObjectFunction("ViewFrame::get_LinkedAudio",   Sc_ViewFrame_GetLinkedAudio);
-    ccAddExternalObjectFunction("ViewFrame::set_LinkedAudio",   Sc_ViewFrame_SetLinkedAudio);
-    ccAddExternalObjectFunction("ViewFrame::get_Loop",          Sc_ViewFrame_GetLoop);
-    ccAddExternalObjectFunction("ViewFrame::get_Sound",         Sc_ViewFrame_GetSound);
-    ccAddExternalObjectFunction("ViewFrame::set_Sound",         Sc_ViewFrame_SetSound);
-    ccAddExternalObjectFunction("ViewFrame::get_Speed",         Sc_ViewFrame_GetSpeed);
-    ccAddExternalObjectFunction("ViewFrame::get_View",          Sc_ViewFrame_GetView);
+    ScFnRegister viewframe_api[] = {
+        { "ViewFrame::get_Flipped",       API_FN_PAIR(ViewFrame_GetFlipped) },
+        { "ViewFrame::get_Frame",         API_FN_PAIR(ViewFrame_GetFrame) },
+        { "ViewFrame::get_Graphic",       API_FN_PAIR(ViewFrame_GetGraphic) },
+        { "ViewFrame::set_Graphic",       API_FN_PAIR(ViewFrame_SetGraphic) },
+        { "ViewFrame::get_LinkedAudio",   API_FN_PAIR(ViewFrame_GetLinkedAudio) },
+        { "ViewFrame::set_LinkedAudio",   API_FN_PAIR(ViewFrame_SetLinkedAudio) },
+        { "ViewFrame::get_Loop",          API_FN_PAIR(ViewFrame_GetLoop) },
+        { "ViewFrame::get_Sound",         API_FN_PAIR(ViewFrame_GetSound) },
+        { "ViewFrame::set_Sound",         API_FN_PAIR(ViewFrame_SetSound) },
+        { "ViewFrame::get_Speed",         API_FN_PAIR(ViewFrame_GetSpeed) },
+        { "ViewFrame::get_View",          API_FN_PAIR(ViewFrame_GetView) },
+    };
 
-    /* ----------------------- Registering unsafe exports for plugins -----------------------*/
-
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Flipped",       (void*)ViewFrame_GetFlipped);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Frame",         (void*)ViewFrame_GetFrame);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Graphic",       (void*)ViewFrame_GetGraphic);
-    ccAddExternalFunctionForPlugin("ViewFrame::set_Graphic",       (void*)ViewFrame_SetGraphic);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_LinkedAudio",   (void*)ViewFrame_GetLinkedAudio);
-    ccAddExternalFunctionForPlugin("ViewFrame::set_LinkedAudio",   (void*)ViewFrame_SetLinkedAudio);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Loop",          (void*)ViewFrame_GetLoop);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Sound",         (void*)ViewFrame_GetSound);
-    ccAddExternalFunctionForPlugin("ViewFrame::set_Sound",         (void*)ViewFrame_SetSound);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_Speed",         (void*)ViewFrame_GetSpeed);
-    ccAddExternalFunctionForPlugin("ViewFrame::get_View",          (void*)ViewFrame_GetView);
+    ccAddExternalFunctions(viewframe_api);
 }

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -41,12 +41,6 @@
 using namespace AGS::Common;
 using namespace AGS::Common::Memory;
 
-extern ccInstance *loadedInstances[MAX_LOADED_INSTANCES]; // in script/script_runtime
-extern int gameHasBeenRestored; // in ac/game
-extern ExecutingScript*curscript; // in script/script
-extern new_line_hook_type new_line_hook;
-
-extern ScriptString myScriptStringImpl;
 
 enum ScriptOpArgIsReg
 {
@@ -155,8 +149,13 @@ const ScriptCommandInfo sccmd_info[CC_NUM_SCCMDS] =
 };
 
 const char *regnames[] = { "null", "sp", "mar", "ax", "bx", "cx", "op", "dx" };
-
 const char *fixupnames[] = { "null", "fix_gldata", "fix_func", "fix_string", "fix_import", "fix_datadata", "fix_stack" };
+
+
+extern new_line_hook_type new_line_hook;
+extern ScriptString myScriptStringImpl;
+
+ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = { nullptr };
 
 // Instance thread stack holds a list of running or suspended script instances;
 // In AGS currently only one thread is running, others are waiting in the queue.
@@ -1945,8 +1944,10 @@ void ccInstance::Free()
 
     if ((flags & INSTF_SHAREDATA) == 0)
     {
-        nullfree(globaldata);
-        nullfree(code);
+        if (globaldata)
+            free(globaldata);
+        if (code)
+            free(code);
     }
     globalvars.reset();
     globaldata = nullptr;

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -48,6 +48,11 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     return ScriptSprintf(buffer, buf_length, format, nullptr, 0, &arg_ptr);
 }
 
+// Helper macro for registering an API function for both script and plugin,
+// for the common case where they have similar names: the script's "translator"
+// function's name is derived from the real one by adding a "Sc_" prefix.
+#define API_FN_PAIR(FN_NAME) Sc_##FN_NAME, (void*)FN_NAME
+
 // Helper macros for script functions;
 // asserting for internal mistakes; supressing "unused param" warnings
 #define ASSERT_SELF(METHOD) \

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -64,18 +64,6 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     ASSERT_PARAM_COUNT(METHOD, X)
 
 //-----------------------------------------------------------------------------
-// Get/set variables
-
-#define API_VARGET_INT(VARIABLE) \
-    (void)params; (void)param_count; \
-    return RuntimeScriptValue().SetInt32(VARIABLE)
-
-#define API_VARSET_PINT(VARIABLE) \
-    ASSERT_VARIABLE_VALUE(VARIABLE); \
-    VARIABLE = params[0].IValue; \
-    return RuntimeScriptValue()
-
-//-----------------------------------------------------------------------------
 // Calls to ScriptSprintf with automatic translation
 
 #define API_SCALL_SCRIPT_SPRINTF(FUNCTION, PARAM_COUNT) \

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -348,6 +348,21 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].IValue, params[4].IValue); \
     return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
 
+#define API_SCALL_OBJAUTO_PINT2_PBOOL(RET_CLASS, FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 3); \
+    RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].GetAsBool()); \
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
+
+#define API_SCALL_OBJAUTO_PINT3_PBOOL(RET_CLASS, FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 4); \
+    RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].GetAsBool()); \
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
+
+#define API_SCALL_OBJAUTO_PINT3_PBOOL2(RET_CLASS, FUNCTION) \
+    ASSERT_PARAM_COUNT(FUNCTION, 5); \
+    RET_CLASS* ret_obj = FUNCTION(params[0].IValue, params[1].IValue, params[2].IValue, params[3].GetAsBool(), params[4].GetAsBool()); \
+    return RuntimeScriptValue().SetDynamicObject(ret_obj, ret_obj)
+
 #define API_SCALL_OBJAUTO_PBOOL2(RET_CLASS, FUNCTION) \
     ASSERT_PARAM_COUNT(FUNCTION, 2); \
     RET_CLASS* ret_obj = FUNCTION(params[0].GetAsBool(), params[1].GetAsBool()); \

--- a/Engine/script/script_api.h
+++ b/Engine/script/script_api.h
@@ -94,6 +94,13 @@ inline const char *ScriptVSprintf(char *buffer, size_t buf_length, const char *f
     const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, STD_BUFFER_SIZE, get_translation(FORMAT_STR), args); \
     va_end(args)
 
+#define API_PLUGIN_SCRIPT_SPRINTF_PURE(FORMAT_STR) \
+    va_list args; \
+    va_start(args, FORMAT_STR); \
+    char ScSfBuffer[STD_BUFFER_SIZE]; \
+    const char *scsf_buffer = ScriptVSprintf(ScSfBuffer, STD_BUFFER_SIZE, FORMAT_STR, args); \
+    va_end(args)
+
 //-----------------------------------------------------------------------------
 // Calls to static functions
 //

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -21,19 +21,26 @@
 #include "script/systemimports.h"
 
 
-bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *pfn)
+bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *scfn, void *dirfn)
 {
-    return simp.add(name, RuntimeScriptValue().SetStaticFunction(pfn), nullptr) != UINT32_MAX;
+    return simp.add(name, RuntimeScriptValue().SetStaticFunction(scfn), nullptr) != UINT32_MAX &&
+        (!dirfn ||
+        simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(dirfn), nullptr) != UINT32_MAX);
 }
 
-bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn)
+bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *scfn, void *dirfn)
 {
-    return simp.add(name, RuntimeScriptValue().SetObjectFunction(pfn), nullptr) != UINT32_MAX;
+    return simp.add(name, RuntimeScriptValue().SetObjectFunction(scfn), nullptr) != UINT32_MAX &&
+        (!dirfn ||
+        simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(dirfn), nullptr) != UINT32_MAX);
 }
 
-bool ccAddExternalFunctionForPlugin(const String &name, void *pfn)
+bool ccAddExternalFunction(const ScFnRegister &scfnreg)
 {
-    return simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(pfn), nullptr) != UINT32_MAX;
+    String name = String::Wrapper(scfnreg.Name);
+    return simp.add(name, scfnreg.Fn, nullptr) != UINT32_MAX &&
+        (scfnreg.PlFn.IsNull() ||
+        simp_for_plugin.add(name, scfnreg.PlFn, nullptr) != UINT32_MAX);
 }
 
 bool ccAddExternalPluginFunction(const String &name, void *pfn)

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -11,7 +11,7 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
+#include "script/script_runtime.h"
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
@@ -19,11 +19,21 @@
 #include "ac/statobj/staticobject.h"
 #include "script/cc_common.h"
 #include "script/systemimports.h"
-#include "script/script_runtime.h"
+
 
 bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *pfn)
 {
     return simp.add(name, RuntimeScriptValue().SetStaticFunction(pfn), nullptr) != UINT32_MAX;
+}
+
+bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn)
+{
+    return simp.add(name, RuntimeScriptValue().SetObjectFunction(pfn), nullptr) != UINT32_MAX;
+}
+
+bool ccAddExternalFunctionForPlugin(const String &name, void *pfn)
+{
+    return simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(pfn), nullptr) != UINT32_MAX;
 }
 
 bool ccAddExternalPluginFunction(const String &name, void *pfn)
@@ -46,11 +56,6 @@ bool ccAddExternalDynamicObject(const String &name, void *ptr, ICCDynamicObject 
     return simp.add(name, RuntimeScriptValue().SetDynamicObject(ptr, manager), nullptr) != UINT32_MAX;
 }
 
-bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn)
-{
-    return simp.add(name, RuntimeScriptValue().SetObjectFunction(pfn), nullptr) != UINT32_MAX;
-}
-
 bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst)
 {
     return simp.add(name, prval, inst) != UINT32_MAX;
@@ -66,16 +71,6 @@ void ccRemoveAllSymbols()
     simp.clear();
 }
 
-ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = {nullptr,
-nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 
-nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-
-void nullfree(void *data)
-{
-    if (data != nullptr)
-        free(data);
-}
-
 void *ccGetSymbolAddress(const String &name)
 {
     const ScriptImport *import = simp.getByName(name);
@@ -84,11 +79,6 @@ void *ccGetSymbolAddress(const String &name)
         return import->Value.Ptr;
     }
     return nullptr;
-}
-
-bool ccAddExternalFunctionForPlugin(const String &name, void *pfn)
-{
-    return simp_for_plugin.add(name, RuntimeScriptValue().SetPluginFunction(pfn), nullptr) == 0;
 }
 
 void *ccGetSymbolAddressForPlugin(const String &name)

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -40,6 +40,16 @@ struct ScFnRegister
         : Name(name)
         , Fn(RuntimeScriptValue().SetObjectFunction(fn))
         , PlFn(RuntimeScriptValue().SetPluginFunction(plfn)) {}
+    template <typename TPlFn>
+    ScFnRegister(const char *name, ScriptAPIFunction *fn, TPlFn plfn)
+        : Name(name)
+        , Fn(RuntimeScriptValue().SetStaticFunction(fn))
+        , PlFn(RuntimeScriptValue().SetPluginFunction(reinterpret_cast<void*>(plfn))) {}
+    template <typename TPlFn>
+    ScFnRegister(const char *name, ScriptAPIObjectFunction *fn, TPlFn plfn)
+        : Name(name)
+        , Fn(RuntimeScriptValue().SetObjectFunction(fn))
+        , PlFn(RuntimeScriptValue().SetPluginFunction(reinterpret_cast<void*>(plfn))) {}
 };
 
 // Following two functions register engine API symbols for script and plugins.

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -14,6 +14,7 @@
 #ifndef __AGS_EE_CC__SCRIPTRUNTIME_H
 #define __AGS_EE_CC__SCRIPTRUNTIME_H
 
+#include "util/memory_compat.h"    // std::size
 #include "script/cc_script.h"      // ccScript
 #include "script/cc_instance.h"    // ccInstance
 

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -11,9 +11,8 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-
-#ifndef __CS_RUNTIME_H
-#define __CS_RUNTIME_H
+#ifndef __AGS_EE_CC__SCRIPTRUNTIME_H
+#define __AGS_EE_CC__SCRIPTRUNTIME_H
 
 #include "script/cc_script.h"      // ccScript
 #include "script/cc_instance.h"    // ccInstance
@@ -23,44 +22,46 @@ struct ICCDynamicObject;
 struct StaticArray;
 
 using AGS::Common::String;
-using AGS::Common::String;
 
-// ************ SCRIPT LOADING AND RUNNING FUNCTIONS ************
 
-// give the script access to a variable or function in your program
-extern bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *pfn);
-// temporary workaround for plugins
-extern bool ccAddExternalPluginFunction(const String &name, void *pfn);
-extern bool ccAddExternalStaticObject(const String &name, void *ptr, ICCStaticObject *manager);
-extern bool ccAddExternalStaticArray(const String &name, void *ptr, StaticArray *array_mgr);
-extern bool ccAddExternalDynamicObject(const String &name, void *ptr, ICCDynamicObject *manager);
-extern bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn);
-extern bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst);
-// remove the script access to a variable or function in your program
-extern void ccRemoveExternalSymbol(const String &name);
-// removes all external symbols, allowing you to start from scratch
-extern void ccRemoveAllSymbols();
+// Following functions register engine API symbols for script and plugins.
+// Calls from script is handled by specific "translator" functions, which
+// unpack script interpreter's values into the real arguments and call the
+// actual engine's function. For plugins we have to provide actual engine
+// function directly.
+bool ccAddExternalStaticFunction(const String &name, ScriptAPIFunction *pfn);
+bool ccAddExternalObjectFunction(const String &name, ScriptAPIObjectFunction *pfn);
+bool ccAddExternalFunctionForPlugin(const String &name, void *pfn);
+// Register a function, exported from a plugin. Requires direct function pointer only.
+bool ccAddExternalPluginFunction(const String &name, void *pfn);
+// Register engine objects for script's access.
+bool ccAddExternalStaticObject(const String &name, void *ptr, ICCStaticObject *manager);
+bool ccAddExternalStaticArray(const String &name, void *ptr, StaticArray *array_mgr);
+bool ccAddExternalDynamicObject(const String &name, void *ptr, ICCDynamicObject *manager);
+// Register script own functions (defined in the linked scripts)
+bool ccAddExternalScriptSymbol(const String &name, const RuntimeScriptValue &prval, ccInstance *inst);
+// Remove the script access to a variable or function in your program
+void ccRemoveExternalSymbol(const String &name);
+// Remove all external symbols, allowing you to start from scratch
+void ccRemoveAllSymbols();
 
-// get the address of an exported variable in the script
-extern void *ccGetSymbolAddress(const String &name);
-
-// registering functions, compatible with old unsafe call style;
-// this is to be used solely by plugins until plugin inteface is redone
-extern bool ccAddExternalFunctionForPlugin(const String &name, void *pfn);
-extern void *ccGetSymbolAddressForPlugin(const String &name);
+// Get the address of an exported variable in the script
+void *ccGetSymbolAddress(const String &name);
+// Get a registered symbol's direct pointer; this is used solely for plugins
+void *ccGetSymbolAddressForPlugin(const String &name);
 
 // DEBUG HOOK
 typedef void (*new_line_hook_type) (ccInstance *, int);
-extern void ccSetDebugHook(new_line_hook_type jibble);
-#endif
+void ccSetDebugHook(new_line_hook_type jibble);
 
 // Set the script interpreter timeout values:
 // * sys_poll_timeout - defines the timeout (ms) at which the interpreter will run system events poll;
 // * abort_timeout - [temp disabled] defines the timeout (ms) at which the interpreter will cancel with error.
 // * abort_loops - max script loops without an engine update after which the interpreter will error;
-extern void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout, unsigned abort_loops);
+void ccSetScriptAliveTimer(unsigned sys_poll_timeout, unsigned abort_timeout, unsigned abort_loops);
 // reset the current while loop counter
-extern void ccNotifyScriptStillAlive();
+void ccNotifyScriptStillAlive();
 // for calling exported plugin functions old-style
-extern int call_function(intptr_t addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
-extern void nullfree(void *data); // in script/script_runtime
+int call_function(intptr_t addr, const RuntimeScriptValue *object, int numparm, const RuntimeScriptValue *parms);
+
+#endif // __AGS_EE_CC__SCRIPTRUNTIME_H


### PR DESCRIPTION
This does not change any actual functionality, only the way script API are registered, from function call per entry to array initializers. As a side effect this should fix any script API not exported for plugins.

The benefits are:
1. Cleaner registration view, an array initializer instead of myriads of function calls.
2. Implicit distinction between static and object member functions based on prototype detection, no need to explicitly pass a parameter or call respective registration function.
3. Enforced function registration for plugins, now combined with the regular registration in one table entry, so more difficult to miss a plugin variant.

Had to add plain Speech API functions for plugins; and rename few functions for clarity and consistency.