### PR TITLE
WFN Renderer supports utf-8 texts

### DIFF
--- a/Common/font/wfnfont.cpp
+++ b/Common/font/wfnfont.cpp
@@ -83,13 +83,16 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
     //    referenced by many characters.
     WFNError err = kWFNErr_NoError;
 
+    if (total_char_data == 0u || char_count == 0u)
+        return kWFNErr_NoError; // no items
+
     // Read character data array
-    uint8_t *raw_data = new uint8_t[total_char_data];
-    in->Read(raw_data, total_char_data);
+    std::vector<uint8_t> raw_data; raw_data.resize(total_char_data);
+    in->Read(&raw_data.front(), total_char_data);
 
     // Read offset table
-    uint16_t *offset_table = new uint16_t[char_count];
-    in->ReadArrayOfInt16((int16_t*)offset_table, char_count);
+    std::vector<uint16_t> offset_table; offset_table.resize(char_count);
+    in->ReadArrayOfInt16(reinterpret_cast<int16_t*>(&offset_table.front()), char_count);
 
     // Read all referenced offsets in an unsorted vector
     std::vector<uint16_t> offs;
@@ -116,7 +119,7 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
     size_t total_pixel_size = 0;
     for (size_t i = 0; i < _items.size(); ++i)
     {
-        const uint8_t *p_data = raw_data + offs[i] - raw_data_offset;
+        const uint8_t *p_data = &raw_data[offs[i] - raw_data_offset];
         init_ch.Width  = Memory::ReadInt16LE(p_data);
         init_ch.Height = Memory::ReadInt16LE(p_data + sizeof(uint16_t));
         total_pixel_size += init_ch.GetRequiredPixelSize();
@@ -157,7 +160,7 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
         _items[i].RestrictToBytes(src_size);
 
         assert(pixel_it + pixel_data_size <= _pixelData.end()); // should not normally fail
-        std::copy(raw_data + raw_off, raw_data + raw_off + src_size, pixel_it);
+        std::copy(raw_data.begin() + raw_off, raw_data.begin() + (raw_off + src_size), pixel_it);
         _items[i].Data = &(*pixel_it);
         pixel_it += pixel_data_size;
     }
@@ -188,7 +191,5 @@ WFNError WFNFont::ReadFromFile(Stream *in, const soff_t data_size)
         }
     }
 
-    delete [] raw_data;
-    delete [] offset_table;
     return err;
 }

--- a/Common/font/wfnfont.h
+++ b/Common/font/wfnfont.h
@@ -81,7 +81,7 @@ public:
     }
 
     // Get WFN character for the given code; if the character is missing, returns empty character
-    inline const WFNChar &GetChar(uint8_t code) const
+    inline const WFNChar &GetChar(uint16_t code) const
     {
         return code < _refs.size() ? *_refs[code] : _emptyChar;
     }

--- a/Common/font/wfnfontrenderer.cpp
+++ b/Common/font/wfnfontrenderer.cpp
@@ -22,57 +22,41 @@
 
 using namespace AGS::Common;
 
-static unsigned char GetCharCode(unsigned char wanted_code, const WFNFont* font)
-{
-    return wanted_code < font->GetCharCount() ? wanted_code : '?';
-}
-
 void WFNFontRenderer::AdjustYCoordinateForFont(int * /*ycoord*/, int /*fontNumber*/)
 {
-  // Do nothing
+    // Do nothing
 }
 
 void WFNFontRenderer::EnsureTextValidForFont(char *text, int fontNumber)
 {
-  const WFNFont* font = _fontData[fontNumber].Font;
-  // replace any extended characters with question marks
-  for (; *text; ++text)
-  {
-    if ((unsigned char)*text >= font->GetCharCount()) 
-    {
-      *text = '?';
-    }
-  }
+    // Do nothing
 }
 
 int WFNFontRenderer::GetTextWidth(const char *text, int fontNumber)
 {
-  const WFNFont* font = _fontData[fontNumber].Font;
-  const FontRenderParams &params = _fontData[fontNumber].Params;
-  int text_width = 0;
+    const WFNFont* font = _fontData[fontNumber].Font;
+    const FontRenderParams &params = _fontData[fontNumber].Params;
+    int text_width = 0;
 
-  for (; *text; ++text)
-  {
-    const WFNChar &wfn_char = font->GetChar(GetCharCode(*text, font));
-    text_width += wfn_char.Width;
-  }
-  return text_width * params.SizeMultiplier;
+    for (int code = ugetxc(&text); code; code = ugetxc(&text))
+    {
+        text_width += font->GetChar(code).Width;
+    }
+    return text_width * params.SizeMultiplier;
 }
 
 int WFNFontRenderer::GetTextHeight(const char *text, int fontNumber)
 {
-  const WFNFont* font = _fontData[fontNumber].Font;
-  const FontRenderParams &params = _fontData[fontNumber].Params;
-  int max_height = 0;
+    const WFNFont* font = _fontData[fontNumber].Font;
+    const FontRenderParams &params = _fontData[fontNumber].Params;
+    int max_height = 0;
 
-  for (; *text; ++text) 
-  {
-    const WFNChar &wfn_char = font->GetChar(GetCharCode(*text, font));
-    const uint16_t height = wfn_char.Height;
-    if (height > max_height)
-      max_height = height;
-  }
-  return max_height * params.SizeMultiplier;
+    for (int code = ugetxc(&text); code; code = ugetxc(&text))
+    {
+        const uint16_t height = font->GetChar(code).Height;
+        max_height = std::max(max_height, static_cast<int>(height));
+    }
+    return max_height * params.SizeMultiplier;
 }
 
 static int RenderChar(Bitmap *ds, const int at_x, const int at_y, Rect clip,
@@ -90,8 +74,8 @@ void WFNFontRenderer::RenderText(const char *text, int fontNumber, BITMAP *desti
   // NOTE: allegro's putpixel ignores clipping (optimization),
   // so we'll have to accomodate for that ourselves
   Rect clip = ds.GetClip();
-  for (; *text; ++text)
-    x += RenderChar(&ds, x, y, clip, font->GetChar(GetCharCode(*text, font)), params.SizeMultiplier, colour);
+  for (int code = ugetxc(&text); code; code = ugetxc(&text))
+    x += RenderChar(&ds, x, y, clip, font->GetChar(code), params.SizeMultiplier, colour);
 
   set_our_eip(oldeip);
 }


### PR DESCRIPTION
Resolves #2002.

Added support for unicode texts in utf-8 format in WFNRenderer class.

---

In regards to testing...

Current WFN font format does not have a limitation on character indices, but has a limitation on the total size of the glyph data: 64k - (size of header). This is because the TOC has only 2 bytes per glyph offset, so higher address cannot be written.
That still may be enough to write several alphabets in, as the glyphs themselves do not have to be sequential: you can write standard ascii glyphs with codes 1-127 and then, say, Greek letters corresponding to codes 884 - 1023. This will make a large offset table (because it has to have entries from 0 to 1023), but only 128 + 141 = 269 glyphs. If each glyph will have a size of, say 9x14 pixels, with the WFN format that would require 28 bytes per glyph and 7532 bytes total (compare to 64k limit).

If there's a need to support more data, WFN format may be expanded to store 32-bit offsets, which should be more than enough to store full unicode table. But that's a separate matter.

Unfortunately, existing WFN editors do not support editing full unicode range of letters. For a quick test I adjusted the old Radiant's FontEditor for this purpose. ~The modified sources may be found here:
https://www.dropbox.com/s/gwsa0s5a3sxs7zl/RadiantFontEditUni.zip?dl=0
(requires MSVS 2019 or higher with MFC SDK installed)~ (EDIT: Removed the sources, as the original program's license is not clear)
The executable binaries may be downloaded here:
https://www.dropbox.com/s/xth28bfzu78vtqi/FontEditUni.zip?dl=0
Please be aware that I do not have plans on maintaining this editor; this is only to be able to test WFN with higher glyph indices.
NOTE: I also tried to modify [Rulaman's font editor](https://github.com/Rulaman/WFN-FontEditor), but gave up, because it would require much more changes to make it work with chars above id 255 (besides it had other problems).

For example here's a WFN containing capital Greek letters:
[AGSFNT0_UNI.zip](https://github.com/adventuregamestudio/ags/files/11540578/AGSFNT0_UNI.zip)


You may test it in game by displaying following text:
`Display("ΟΙ ΘΕΟΙ ΤΟΥ ΟΛΥΜΠΟΥ"); // THE GODS OF OLYMPUS`