### PR TITLE
Script API: implemented ScriptName and Type.GetByName() for all applicable types.

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -913,12 +913,16 @@ builtin managed struct InventoryItem {
   import attribute int  Graphic;
   /// Gets the ID number of the inventory item.
   readonly import attribute int ID;
-  /// Gets/sets the name of the inventory item.
+  /// Gets/sets the human-readable name of the inventory item.
   import attribute String Name;
   /// Sets an integer custom property for this item.
   import bool SetProperty(const string property, int value);
   /// Sets a text custom property for this item.
   import bool SetTextProperty(const string property, const string value);
+#ifdef SCRIPT_API_v399
+  /// Gets the script name of the inventory item.
+  import readonly attribute String ScriptName;
+#endif
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 
@@ -1221,6 +1225,10 @@ builtin managed struct GUIControl {
   /// Gets/sets the control's transparency.
   import attribute int  Transparency;
 #endif
+#ifdef SCRIPT_API_v399
+  /// Gets the script name of this control.
+  import readonly attribute String ScriptName;
+#endif
 };
 
 builtin managed struct Label extends GUIControl {
@@ -1431,6 +1439,8 @@ builtin managed struct GUI {
   import readonly attribute bool Shown;
 #endif
 #ifdef SCRIPT_API_v399
+  /// Gets the script name of this GUI.
+  import readonly attribute String ScriptName;
   /// Gets/sets the blending mode for this GUI.
   import attribute BlendMode BlendMode;
   /// Gets/sets the GUI's image rotation in degrees.
@@ -1463,7 +1473,7 @@ builtin managed struct Hotspot {
   import attribute bool Enabled;
   /// Gets the ID of the hotspot.
   readonly import attribute int ID;
-  /// Gets/sets the name of the hotspot.
+  /// Gets/sets the human-readable name of the hotspot.
   import attribute String Name;
   /// Gets the X co-ordinate of the walk-to point for this hotspot.
   readonly import attribute int WalkToX;
@@ -1482,6 +1492,10 @@ builtin managed struct Hotspot {
 #ifdef SCRIPT_API_v360
   /// Gets the drawing surface for the 8-bit hotspots mask
   import static DrawingSurface* GetDrawingSurface();     // $AUTOCOMPLETESTATICONLY$
+#endif
+#ifdef SCRIPT_API_v399
+  /// Gets the script name of this hotspot.
+  import readonly attribute String ScriptName;
 #endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
@@ -1546,6 +1560,10 @@ builtin managed struct Dialog {
   readonly import attribute bool ShowTextParser;
   /// Manually marks whether the option was chosen before or not.
   import void SetHasOptionBeenChosen(int option, bool chosen);
+#ifdef SCRIPT_API_v399
+  /// Gets the script name of this dialog.
+  import readonly attribute String ScriptName;
+#endif
   
   readonly int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
@@ -1703,6 +1721,10 @@ builtin managed struct AudioClip {
   /// Gets the clip's ID number.
   readonly import attribute int ID;
 #endif
+#ifdef SCRIPT_API_v399
+  /// Gets the script name of this clip.
+  import readonly attribute String ScriptName;
+#endif
 };
 
 builtin struct System {
@@ -1813,7 +1835,7 @@ builtin managed struct Object {
   readonly import attribute int  Loop;
   /// Gets whether the object is currently moving.
   readonly import attribute bool Moving;
-  /// Gets/sets the name of the object.
+  /// Gets/sets the human-readable name of the object.
   import attribute String Name;
   /// Gets/sets whether other objects and characters can move through this object.
   import attribute bool Solid;
@@ -1862,6 +1884,8 @@ builtin managed struct Object {
   import attribute int  Scaling;
 #endif
 #ifdef SCRIPT_API_v399
+  /// Gets the script name of this object.
+  import readonly attribute String ScriptName;
   /// Gets/sets the blending mode for this object.
   import attribute BlendMode BlendMode;
   /// Gets/sets the object's sprite rotation in degrees.
@@ -2009,7 +2033,7 @@ builtin managed struct Character {
   import attribute bool MovementLinkedToAnimation;
   /// Gets whether the character is currently moving.
   readonly import attribute bool Moving;
-  /// Gets/sets the character's name.
+  /// Gets/sets the human-readable character's name.
   import attribute String Name;
   /// Gets the character's normal walking view.
   readonly import attribute int NormalView;
@@ -2096,6 +2120,8 @@ builtin managed struct Character {
   /// The character's current Z-position.
   import attribute int  z;
 #ifdef SCRIPT_API_v399
+  /// Gets the script name of this character.
+  import readonly attribute String ScriptName;
   /// Gets/sets the character's current blend mode.
   import attribute BlendMode BlendMode;
   /// Gets/sets the character's sprite rotation in degrees.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -896,6 +896,9 @@ builtin managed struct File {
 builtin managed struct InventoryItem {
   /// Returns the inventory item at the specified location.
   import static InventoryItem* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v399
+  import static InventoryItem* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Gets an integer custom property for this item.
   import int  GetProperty(const string property);
   /// Gets a text custom property for this item.
@@ -1173,6 +1176,9 @@ builtin managed struct GUIControl {
   import void BringToFront();
   /// Gets the GUI Control that is visible at the specified location on the screen, or null.
   import static GUIControl* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$  $AUTOCOMPLETENOINHERIT$
+#ifdef SCRIPT_API_v399
+  import static GUIControl* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Sends this control to the back of the z-order, behind all other controls.
   import void SendToBack();
   /// Moves the control to the specified position within the GUI.
@@ -1372,6 +1378,9 @@ builtin managed struct GUI {
   import void Centre();
   /// Gets the topmost GUI visible on the screen at the specified co-ordinates.
   import static GUI* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v399
+  import static GUI* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Moves the GUI to have its top-left corner at the specified position.
   import void SetPosition(int x, int y);
   /// Changes the size of the GUI.
@@ -1441,6 +1450,9 @@ builtin managed struct TextWindowGUI extends GUI {
 builtin managed struct Hotspot {
   /// Gets the hotspot that is at the specified position on the screen.
   import static Hotspot* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v399
+  import static Hotspot* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Gets an integer Custom Property for this hotspot.
   import int  GetProperty(const string property);
   /// Gets a text Custom Property for this hotspot.
@@ -1511,6 +1523,9 @@ builtin managed struct Region {
 };
 
 builtin managed struct Dialog {
+#ifdef SCRIPT_API_v399
+  import static Dialog* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Displays the options for this dialog and returns which one the player selected.
   import int DisplayOptions(DialogOptionSayStyle = eSayUseOptionSetting);
   /// Gets the enabled state for the specified option in this dialog.
@@ -1663,6 +1678,9 @@ builtin managed struct AudioChannel {
 };
 
 builtin managed struct AudioClip {
+#ifdef SCRIPT_API_v399
+  import static AudioClip* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Plays this audio clip.
   import AudioChannel* Play(AudioPriority=SCR_NO_VALUE, RepeatStyle=SCR_NO_VALUE);
   /// Plays this audio clip, starting from the specified offset.
@@ -1746,6 +1764,9 @@ builtin managed struct Object {
   );
   /// Gets the object that is on the screen at the specified co-ordinates.
   import static Object* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v399
+  import static Object* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Gets an integer Custom Property for this object.
   import function GetProperty(const string property);
   /// Gets a text Custom Property for this object.
@@ -1887,6 +1908,9 @@ builtin managed struct Character {
   import function FollowCharacter(Character*, int dist=10, int eagerness=97);
   /// Returns the character that is at the specified position on the screen.
   import static Character* GetAtScreenXY(int x, int y);    // $AUTOCOMPLETESTATICONLY$
+#ifdef SCRIPT_API_v399
+  import static Character* GetByName(const string scriptName); // $AUTOCOMPLETESTATICONLY$
+#endif
   /// Gets a numeric custom property for this character.
   import function GetProperty(const string property);
   /// Gets a text custom property for this character.

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -16,6 +16,7 @@
 #include "ac/audiochannel.h"
 #include "ac/common.h" // quitprintf
 #include "ac/gamesetupstruct.h"
+#include "ac/string.h"
 #include "ac/dynobj/cc_audioclip.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "core/assetmanager.h"
@@ -31,6 +32,11 @@ extern CCAudioChannel ccDynamicAudio;
 int AudioClip_GetID(ScriptAudioClip *clip)
 {
     return clip->id;
+}
+
+const char *AudioClip_GetScriptName(ScriptAudioClip *clip)
+{
+    return CreateNewScriptString(clip->scriptName);
 }
 
 int AudioClip_GetFileType(ScriptAudioClip *clip)
@@ -93,9 +99,12 @@ ScriptAudioChannel* AudioClip_PlayOnChannel(ScriptAudioClip *clip, int chan, int
 //
 //=============================================================================
 
+#include "ac/dynobj/scriptstring.h"
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
+
+extern ScriptString myScriptStringImpl;
 
 ScriptAudioClip *AudioClip_GetByName(const char *name)
 {
@@ -111,6 +120,11 @@ RuntimeScriptValue Sc_AudioClip_GetByName(const RuntimeScriptValue *params, int3
 RuntimeScriptValue Sc_AudioClip_GetID(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptAudioClip, AudioClip_GetID);
+}
+
+RuntimeScriptValue Sc_AudioClip_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptAudioClip, const char, myScriptStringImpl, AudioClip_GetScriptName);
 }
 
 // int | ScriptAudioClip *clip
@@ -172,6 +186,7 @@ void RegisterAudioClipAPI()
         { "AudioClip::get_ID",            API_FN_PAIR(AudioClip_GetID) },
         { "AudioClip::get_FileType",      API_FN_PAIR(AudioClip_GetFileType) },
         { "AudioClip::get_IsAvailable",   API_FN_PAIR(AudioClip_GetIsAvailable) },
+        { "AudioClip::get_ScriptName",    API_FN_PAIR(AudioClip_GetScriptName) },
         { "AudioClip::get_Type",          API_FN_PAIR(AudioClip_GetType) },
     };
 

--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -16,6 +16,7 @@
 #include "ac/audiochannel.h"
 #include "ac/common.h" // quitprintf
 #include "ac/gamesetupstruct.h"
+#include "ac/dynobj/cc_audioclip.h"
 #include "ac/dynobj/cc_audiochannel.h"
 #include "core/assetmanager.h"
 #include "script/runtimescriptvalue.h"
@@ -24,6 +25,7 @@ using namespace AGS::Common;
 
 extern GameSetupStruct game;
 extern ScriptAudioChannel scrAudioChannel[MAX_GAME_CHANNELS];
+extern CCAudioClip ccDynamicAudioClip;
 extern CCAudioChannel ccDynamicAudio;
 
 int AudioClip_GetID(ScriptAudioClip *clip)
@@ -95,6 +97,17 @@ ScriptAudioChannel* AudioClip_PlayOnChannel(ScriptAudioClip *clip, int chan, int
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
+ScriptAudioClip *AudioClip_GetByName(const char *name)
+{
+    return static_cast<ScriptAudioClip*>(ccGetScriptObjectAddress(name, ccDynamicAudioClip.GetType()));
+}
+
+
+RuntimeScriptValue Sc_AudioClip_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptAudioClip, ccDynamicAudioClip, AudioClip_GetByName, const char);
+}
+
 RuntimeScriptValue Sc_AudioClip_GetID(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptAudioClip, AudioClip_GetID);
@@ -150,6 +163,7 @@ RuntimeScriptValue Sc_AudioClip_PlayOnChannel(void *self, const RuntimeScriptVal
 void RegisterAudioClipAPI()
 {
     ScFnRegister audioclip_api[] = {
+        { "AudioClip::GetByName",         API_FN_PAIR(AudioClip_GetByName) },
         { "AudioClip::Play^2",            API_FN_PAIR(AudioClip_Play) },
         { "AudioClip::PlayFrom^3",        API_FN_PAIR(AudioClip_PlayFrom) },
         { "AudioClip::PlayQueued^2",      API_FN_PAIR(AudioClip_PlayQueued) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3004,6 +3004,17 @@ PViewport FindNearestViewport(int charid)
 
 extern ScriptString myScriptStringImpl;
 
+CharacterInfo *Character_GetByName(const char *name)
+{
+    return static_cast<CharacterInfo*>(ccGetScriptObjectAddress(name, ccDynamicCharacter.GetType()));
+}
+
+
+RuntimeScriptValue Sc_Character_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(CharacterInfo, ccDynamicCharacter, Character_GetByName, const char);
+}
+
 // void | CharacterInfo *chaa, ScriptInvItem *invi, int addIndex
 RuntimeScriptValue Sc_Character_AddInventory(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -3295,12 +3306,6 @@ RuntimeScriptValue Sc_Character_GetTintLuminance(void *self, const RuntimeScript
 {
     API_OBJCALL_INT(CharacterInfo, Character_GetTintLuminance);
 }
-
-/*
-RuntimeScriptValue Sc_Character_SetOption(void *self, const RuntimeScriptValue *params, int32_t param_count)
-{
-}
-*/
 
 // void (CharacterInfo *chaa, int xspeed, int yspeed)
 RuntimeScriptValue Sc_Character_SetSpeed(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -3903,6 +3908,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
     ScFnRegister character_api[] = {
         { "Character::GetAtRoomXY^2",             API_FN_PAIR(GetCharacterAtRoom) },
         { "Character::GetAtScreenXY^2",           API_FN_PAIR(GetCharacterAtScreen) },
+        { "Character::GetByName",                 API_FN_PAIR(Character_GetByName) },
 
         { "Character::AddInventory^2",            API_FN_PAIR(Character_AddInventory) },
         { "Character::AddWaypoint^2",             API_FN_PAIR(Character_AddWaypoint) },

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1239,6 +1239,11 @@ int Character_GetID(CharacterInfo *chaa) {
 
 }
 
+const char *Character_GetScriptName(CharacterInfo *chin)
+{
+    return CreateNewScriptString(chin->scrname);
+}
+
 int Character_GetFrame(CharacterInfo *chaa) {
     return chaa->frame;
 }
@@ -3532,6 +3537,11 @@ RuntimeScriptValue Sc_Character_GetID(void *self, const RuntimeScriptValue *para
     API_OBJCALL_INT(CharacterInfo, Character_GetID);
 }
 
+RuntimeScriptValue Sc_Character_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(CharacterInfo, const char, myScriptStringImpl, Character_GetScriptName);
+}
+
 // int (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_GetIdleView(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -4014,6 +4024,7 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
         { "Character::set_ScaleVolume",           API_FN_PAIR(Character_SetScaleVolume) },
         { "Character::get_Scaling",               API_FN_PAIR(Character_GetScaling) },
         { "Character::set_Scaling",               API_FN_PAIR(Character_SetScaling) },
+        { "Character::get_ScriptName",            API_FN_PAIR(Character_GetScriptName) },
         { "Character::get_Solid",                 API_FN_PAIR(Character_GetSolid) },
         { "Character::set_Solid",                 API_FN_PAIR(Character_SetSolid) },
         { "Character::get_Speaking",              API_FN_PAIR(Character_GetSpeaking) },

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1171,9 +1171,22 @@ void do_conversation(int dlgnum)
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
+#include "ac/dynobj/cc_dialog.h"
 #include "ac/dynobj/scriptstring.h"
 
 extern ScriptString myScriptStringImpl;
+extern CCDialog     ccDynamicDialog;
+
+ScriptDialog *Dialog_GetByName(const char *name)
+{
+    return static_cast<ScriptDialog*>(ccGetScriptObjectAddress(name, ccDynamicDialog.GetType()));
+}
+
+
+RuntimeScriptValue Sc_Dialog_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptDialog, ccDynamicDialog, Dialog_GetByName, const char);
+}
 
 // int (ScriptDialog *sd)
 RuntimeScriptValue Sc_Dialog_GetID(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -1237,6 +1250,7 @@ RuntimeScriptValue Sc_Dialog_Start(void *self, const RuntimeScriptValue *params,
 void RegisterDialogAPI()
 {
     ScFnRegister dialog_api[] = {
+        { "Dialog::GetByName",            API_FN_PAIR(Dialog_GetByName) },
         { "Dialog::get_ID",               API_FN_PAIR(Dialog_GetID) },
         { "Dialog::get_OptionCount",      API_FN_PAIR(Dialog_GetOptionCount) },
         { "Dialog::get_ShowTextParser",   API_FN_PAIR(Dialog_GetShowTextParser) },

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -159,6 +159,11 @@ int Dialog_GetID(ScriptDialog *sd) {
   return sd->id;
 }
 
+const char *Dialog_GetScriptName(ScriptDialog *sd)
+{
+    return CreateNewScriptString(game.dialogScriptNames[sd->id]);
+}
+
 //=============================================================================
 
 #define RUN_DIALOG_STAY          -1
@@ -1194,6 +1199,11 @@ RuntimeScriptValue Sc_Dialog_GetID(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_INT(ScriptDialog, Dialog_GetID);
 }
 
+RuntimeScriptValue Sc_Dialog_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptDialog, const char, myScriptStringImpl, Dialog_GetScriptName);
+}
+
 // int (ScriptDialog *sd)
 RuntimeScriptValue Sc_Dialog_GetOptionCount(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1253,6 +1263,7 @@ void RegisterDialogAPI()
         { "Dialog::GetByName",            API_FN_PAIR(Dialog_GetByName) },
         { "Dialog::get_ID",               API_FN_PAIR(Dialog_GetID) },
         { "Dialog::get_OptionCount",      API_FN_PAIR(Dialog_GetOptionCount) },
+        { "Dialog::get_ScriptName",       API_FN_PAIR(Dialog_GetScriptName) },
         { "Dialog::get_ShowTextParser",   API_FN_PAIR(Dialog_GetShowTextParser) },
         { "Dialog::DisplayOptions^1",     API_FN_PAIR(Dialog_DisplayOptions) },
         { "Dialog::GetOptionState^1",     API_FN_PAIR(Dialog_GetOptionState) },

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -31,6 +31,7 @@
 #include "ac/invwindow.h"
 #include "ac/mouse.h"
 #include "ac/runtime_defines.h"
+#include "ac/string.h"
 #include "ac/system.h"
 #include "ac/dynobj/cc_guiobject.h"
 #include "ac/dynobj/scriptgui.h"
@@ -168,6 +169,11 @@ int GUI_GetClickable(ScriptGUI *tehgui) {
 
 int GUI_GetID(ScriptGUI *tehgui) {
   return tehgui->id;
+}
+
+const char *GUI_GetScriptName(ScriptGUI *tehgui)
+{
+    return CreateNewScriptString(guis[tehgui->id].Name);
 }
 
 GUIObject* GUI_GetiControls(ScriptGUI *tehgui, int idx) {
@@ -662,10 +668,13 @@ void gui_on_mouse_down(const int guin, const int mbut)
 //
 //=============================================================================
 
+#include "ac/dynobj/scriptstring.h"
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
+
+extern ScriptString myScriptStringImpl;
 
 ScriptGUI *GUI_GetByName(const char *name)
 {
@@ -784,6 +793,11 @@ RuntimeScriptValue Sc_GUI_SetHeight(void *self, const RuntimeScriptValue *params
 RuntimeScriptValue Sc_GUI_GetID(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_INT(ScriptGUI, GUI_GetID);
+}
+
+RuntimeScriptValue Sc_GUI_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptGUI, const char, myScriptStringImpl, GUI_GetScriptName);
 }
 
 RuntimeScriptValue Sc_GUI_GetPopupYPos(void *self, const RuntimeScriptValue *params, int32_t param_count)
@@ -953,6 +967,7 @@ void RegisterGUIAPI()
         { "GUI::get_PopupStyle",          API_FN_PAIR(GUI_GetPopupStyle) },
         { "GUI::get_PopupYPos",           API_FN_PAIR(GUI_GetPopupYPos) },
         { "GUI::set_PopupYPos",           API_FN_PAIR(GUI_SetPopupYPos) },
+        { "GUI::get_ScriptName",          API_FN_PAIR(GUI_GetScriptName) },
         { "TextWindowGUI::get_TextColor", API_FN_PAIR(GUI_GetTextColor) },
         { "TextWindowGUI::set_TextColor", API_FN_PAIR(GUI_SetTextColor) },
         { "TextWindowGUI::get_TextPadding", API_FN_PAIR(GUI_GetTextPadding) },

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -666,6 +666,18 @@ void gui_on_mouse_down(const int guin, const int mbut)
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
+
+ScriptGUI *GUI_GetByName(const char *name)
+{
+    return static_cast<ScriptGUI*>(ccGetScriptObjectAddress(name, ccDynamicGUI.GetType()));
+}
+
+
+RuntimeScriptValue Sc_GUI_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptGUI, ccDynamicGUI, GUI_GetByName, const char);
+}
+
 // void GUI_Centre(ScriptGUI *sgui)
 RuntimeScriptValue Sc_GUI_Centre(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -917,6 +929,8 @@ void RegisterGUIAPI()
 {
     ScFnRegister gui_api[] = {
         { "GUI::GetAtScreenXY^2",         API_FN_PAIR(GetGUIAtLocation) },
+        { "GUI::GetByName",               API_FN_PAIR(GUI_GetByName) },
+
         { "GUI::ProcessClick^3",          API_FN_PAIR(GUI_ProcessClick) },
         { "GUI::Centre^0",                API_FN_PAIR(GUI_Centre) },
         { "GUI::Click^1",                 API_FN_PAIR(GUI_Click) },

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -16,6 +16,7 @@
 #include "ac/guicontrol.h"
 #include "ac/global_gui.h"
 #include "ac/mouse.h"
+#include "ac/string.h"
 #include "debug/debug_log.h"
 #include "gui/guibutton.h"
 #include "gui/guiinv.h"
@@ -92,6 +93,11 @@ void GUIControl_SetEnabled(GUIObject *guio, int enabled) {
 
 int GUIControl_GetID(GUIObject *guio) {
   return guio->Id;
+}
+
+const char *GUIControl_GetScriptName(GUIObject *guio)
+{
+    return CreateNewScriptString(guio->Name);
 }
 
 ScriptGUI* GUIControl_GetOwningGUI(GUIObject *guio) {
@@ -225,10 +231,13 @@ void GUIControl_SetTransparency(GUIObject *guio, int trans) {
 //
 //=============================================================================
 
+#include "ac/dynobj/scriptstring.h"
 #include "debug/out.h"
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
+
+extern ScriptString myScriptStringImpl;
 
 GUIObject *GUIControl_GetByName(const char *name)
 {
@@ -349,6 +358,11 @@ RuntimeScriptValue Sc_GUIControl_GetID(void *self, const RuntimeScriptValue *par
     API_OBJCALL_INT(GUIObject, GUIControl_GetID);
 }
 
+RuntimeScriptValue Sc_GUIControl_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(GUIObject, const char, myScriptStringImpl, GUIControl_GetScriptName);
+}
+
 // ScriptGUI* (GUIObject *guio)
 RuntimeScriptValue Sc_GUIControl_GetOwningGUI(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -449,6 +463,7 @@ void RegisterGUIControlAPI()
         { "GUIControl::set_Height",       API_FN_PAIR(GUIControl_SetHeight) },
         { "GUIControl::get_ID",           API_FN_PAIR(GUIControl_GetID) },
         { "GUIControl::get_OwningGUI",    API_FN_PAIR(GUIControl_GetOwningGUI) },
+        { "GUIControl::get_ScriptName",   API_FN_PAIR(GUIControl_GetScriptName) },
         { "GUIControl::get_Visible",      API_FN_PAIR(GUIControl_GetVisible) },
         { "GUIControl::set_Visible",      API_FN_PAIR(GUIControl_SetVisible) },
         { "GUIControl::get_Width",        API_FN_PAIR(GUIControl_GetWidth) },

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -229,6 +229,18 @@ void GUIControl_SetTransparency(GUIObject *guio, int trans) {
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
+
+GUIObject *GUIControl_GetByName(const char *name)
+{
+    return static_cast<GUIObject*>(ccGetScriptObjectAddress(name, ccDynamicGUIObject.GetType()));
+}
+
+
+RuntimeScriptValue Sc_GUIControl_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(GUIObject, ccDynamicGUIObject, GUIControl_GetByName, const char);
+}
+
 // void (GUIObject *guio)
 RuntimeScriptValue Sc_GUIControl_BringToFront(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -417,6 +429,7 @@ void RegisterGUIControlAPI()
 {
     ScFnRegister guicontrol_api[] = {
         { "GUIControl::GetAtScreenXY^2",  API_FN_PAIR(GetGUIControlAtLocation) },
+        { "GUIControl::GetByName",        API_FN_PAIR(GUIControl_GetByName) },
 
         { "GUIControl::BringToFront^0",   API_FN_PAIR(GUIControl_BringToFront) },
         { "GUIControl::SendToBack^0",     API_FN_PAIR(GUIControl_SendToBack) },

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -48,6 +48,11 @@ int Hotspot_GetID(ScriptHotspot *hss) {
     return hss->id;
 }
 
+const char *Hotspot_GetScriptName(ScriptHotspot *hss)
+{
+    return CreateNewScriptString(croom->hotspot[hss->id].Name);
+}
+
 int Hotspot_GetWalkToX(ScriptHotspot *hss) {
     return GetHotspotPointX(hss->id);
 }
@@ -231,6 +236,11 @@ RuntimeScriptValue Sc_Hotspot_GetID(void *self, const RuntimeScriptValue *params
     API_OBJCALL_INT(ScriptHotspot, Hotspot_GetID);
 }
 
+RuntimeScriptValue Sc_Hotspot_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptHotspot, const char, myScriptStringImpl, Hotspot_GetScriptName);
+}
+
 // const char* (ScriptHotspot *hss)
 RuntimeScriptValue Sc_Hotspot_GetName_New(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -277,6 +287,7 @@ void RegisterHotspotAPI()
         { "Hotspot::get_ID",              API_FN_PAIR(Hotspot_GetID) },
         { "Hotspot::get_Name",            API_FN_PAIR(Hotspot_GetName_New) },
         { "Hotspot::set_Name",            API_FN_PAIR(Hotspot_SetName) },
+        { "Hotspot::get_ScriptName",      API_FN_PAIR(Hotspot_GetScriptName) },
         { "Hotspot::get_WalkToX",         API_FN_PAIR(Hotspot_GetWalkToX) },
         { "Hotspot::get_WalkToY",         API_FN_PAIR(Hotspot_GetWalkToY) },
     };

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -140,6 +140,18 @@ int get_hotspot_at(int xpp,int ypp) {
 
 extern ScriptString myScriptStringImpl;
 
+
+ScriptHotspot *Hotspot_GetByName(const char *name)
+{
+    return static_cast<ScriptHotspot*>(ccGetScriptObjectAddress(name, ccDynamicHotspot.GetType()));
+}
+
+
+RuntimeScriptValue Sc_Hotspot_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptHotspot, ccDynamicHotspot, Hotspot_GetByName, const char);
+}
+
 RuntimeScriptValue Sc_GetHotspotAtRoom(const RuntimeScriptValue *params, int32_t param_count)
 {
     API_SCALL_OBJ_PINT2(ScriptHotspot, ccDynamicHotspot, GetHotspotAtRoom);
@@ -249,6 +261,7 @@ void RegisterHotspotAPI()
     ScFnRegister hotspot_api[] = {
         { "Hotspot::GetAtRoomXY^2",       API_FN_PAIR(GetHotspotAtRoom) },
         { "Hotspot::GetAtScreenXY^2",     API_FN_PAIR(GetHotspotAtScreen) },
+        { "Hotspot::GetByName",           API_FN_PAIR(Hotspot_GetByName) },
         { "Hotspot::GetDrawingSurface",   API_FN_PAIR(Hotspot_GetDrawingSurface) },
 
         { "Hotspot::GetName^1",           API_FN_PAIR(Hotspot_GetName) },

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -130,6 +130,18 @@ void set_inv_item_cursorpic(int invItemId, int piccy)
 
 extern ScriptString myScriptStringImpl;
 
+
+ScriptInvItem *InventoryItem_GetByName(const char *name)
+{
+    return static_cast<ScriptInvItem*>(ccGetScriptObjectAddress(name, ccDynamicInv.GetType()));
+}
+
+
+RuntimeScriptValue Sc_InventoryItem_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptInvItem, ccDynamicInv, InventoryItem_GetByName, const char);
+}
+
 // ScriptInvItem *(int xx, int yy)
 RuntimeScriptValue Sc_GetInvAtLocation(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -230,6 +242,7 @@ void RegisterInventoryItemAPI()
 {
     ScFnRegister invitem_api[] = {
         { "InventoryItem::GetAtScreenXY^2",           API_FN_PAIR(GetInvAtLocation) },
+        { "InventoryItem::GetByName",                 API_FN_PAIR(InventoryItem_GetByName) },
 
         { "InventoryItem::IsInteractionAvailable^1",  API_FN_PAIR(InventoryItem_CheckInteractionAvailable) },
         { "InventoryItem::GetName^1",                 API_FN_PAIR(InventoryItem_GetName) },

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -55,6 +55,11 @@ int InventoryItem_GetID(ScriptInvItem *scii) {
     return scii->id;
 }
 
+const char *InventoryItem_GetScriptName(ScriptInvItem *scii)
+{
+    return CreateNewScriptString(game.invScriptNames[scii->id]);
+}
+
 ScriptInvItem *GetInvAtLocation(int xx, int yy) {
   int hsnum = GetInvAt(xx, yy);
   if (hsnum <= 0)
@@ -230,6 +235,11 @@ RuntimeScriptValue Sc_InventoryItem_GetID(void *self, const RuntimeScriptValue *
     API_OBJCALL_INT(ScriptInvItem, InventoryItem_GetID);
 }
 
+RuntimeScriptValue Sc_InventoryItem_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptInvItem, const char, myScriptStringImpl, InventoryItem_GetScriptName);
+}
+
 // const char* (ScriptInvItem *invitem)
 RuntimeScriptValue Sc_InventoryItem_GetName_New(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -260,6 +270,7 @@ void RegisterInventoryItemAPI()
         { "InventoryItem::get_ID",                    API_FN_PAIR(InventoryItem_GetID) },
         { "InventoryItem::get_Name",                  API_FN_PAIR(InventoryItem_GetName_New) },
         { "InventoryItem::set_Name",                  API_FN_PAIR(InventoryItem_SetName) },
+        { "InventoryItem::get_ScriptName",            API_FN_PAIR(InventoryItem_GetScriptName) },
     };
 
     ccAddExternalFunctions(invitem_api);

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -390,6 +390,11 @@ int Object_GetID(ScriptObject *objj) {
     return objj->id;
 }
 
+const char *Object_GetScriptName(ScriptObject *objj)
+{
+    return CreateNewScriptString(thisroom.Objects[objj->id].ScriptName);
+}
+
 void Object_SetIgnoreWalkbehinds(ScriptObject *chaa, int clik) {
     SetObjectIgnoreWalkbehinds(chaa->id, clik);
 }
@@ -1034,6 +1039,11 @@ RuntimeScriptValue Sc_Object_GetID(void *self, const RuntimeScriptValue *params,
     API_OBJCALL_INT(ScriptObject, Object_GetID);
 }
 
+RuntimeScriptValue Sc_Object_GetScriptName(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(ScriptObject, const char, myScriptStringImpl, Object_GetScriptName);
+}
+
 // int (ScriptObject *chaa)
 RuntimeScriptValue Sc_Object_GetIgnoreWalkbehinds(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1242,6 +1252,7 @@ void RegisterObjectAPI()
         { "Object::set_Name",                 API_FN_PAIR(Object_SetName) },
         { "Object::get_Scaling",              API_FN_PAIR(Object_GetScaling) },
         { "Object::set_Scaling",              API_FN_PAIR(Object_SetScaling) },
+        { "Object::get_ScriptName",           API_FN_PAIR(Object_GetScriptName) },
         { "Object::get_Solid",                API_FN_PAIR(Object_GetSolid) },
         { "Object::set_Solid",                API_FN_PAIR(Object_SetSolid) },
         { "Object::get_Transparency",         API_FN_PAIR(Object_GetTransparency) },

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -773,6 +773,18 @@ bool CycleViewAnim(int view, uint16_t &o_loop, uint16_t &o_frame, bool forwards,
 
 extern ScriptString myScriptStringImpl;
 
+
+ScriptObject *Object_GetByName(const char *name)
+{
+    return static_cast<ScriptObject*>(ccGetScriptObjectAddress(name, ccDynamicObject.GetType()));
+}
+
+
+RuntimeScriptValue Sc_Object_GetByName(const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_SCALL_OBJ_POBJ(ScriptObject, ccDynamicObject, Object_GetByName, const char);
+}
+
 // void (ScriptObject *objj, int loop, int delay, int repeat, int blocking, int direction)
 RuntimeScriptValue Sc_Object_Animate5(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1184,6 +1196,8 @@ void RegisterObjectAPI()
     ScFnRegister object_api[] = {
         { "Object::GetAtRoomXY^2",            API_FN_PAIR(GetObjectAtRoom) },
         { "Object::GetAtScreenXY^2",          API_FN_PAIR(GetObjectAtScreen) },
+        { "Object::GetByName",                API_FN_PAIR(Object_GetByName) },
+
         { "Object::Animate^5",                API_FN_PAIR(Object_Animate5) },
         { "Object::Animate^6",                API_FN_PAIR(Object_Animate6) },
         { "Object::Animate^7",                API_FN_PAIR(Object_Animate) },

--- a/Engine/script/script_runtime.cpp
+++ b/Engine/script/script_runtime.cpp
@@ -101,6 +101,18 @@ void *ccGetSymbolAddressForPlugin(const String &name)
     return nullptr;
 }
 
+void *ccGetScriptObjectAddress(const String &name, const String &type)
+{
+    const auto *imp = simp.getByName(name);
+    if (!imp)
+        return nullptr;
+    if (imp->Value.Type != kScValScriptObject && imp->Value.Type != kScValPluginObject)
+        return nullptr;
+    if (type != imp->Value.ObjMgr->GetType())
+        return nullptr;
+    return imp->Value.Ptr;
+}
+
 new_line_hook_type new_line_hook = nullptr;
 
 

--- a/Engine/script/script_runtime.h
+++ b/Engine/script/script_runtime.h
@@ -82,6 +82,8 @@ inline void ccAddExternalFunctions(const ScFnRegister (&arr)[N])
 void *ccGetSymbolAddress(const String &name);
 // Get a registered symbol's direct pointer; this is used solely for plugins
 void *ccGetSymbolAddressForPlugin(const String &name);
+// Get a registered Script Object, optionally restricting to the given type name
+void *ccGetScriptObjectAddress(const String &name, const String &type);
 
 // DEBUG HOOK
 typedef void (*new_line_hook_type) (ccInstance *, int);


### PR DESCRIPTION
This implements readonly ScriptName property and a static GetByName() method for all the object types that have script names. The method looks up for the object of corresponding type with the given script name, and returns its pointer, or null if such object is not found.

NOTE: passing other type's script name will also return null, for example calling Character.GetByName() with a room object's name.

`scriptName` argument is case-sensitive, obviously.

```
static AudioClip* AudioClip.GetByName(const string scriptName);
static Character* Character.GetByName(const string scriptName);
static Dialog* Dialog.GetByName(const string scriptName);
static GUIControl* GUIControl.GetByName(const string scriptName);
static GUI* GUI.GetByName(const string scriptName);
static Hotspot* Hotspot.GetByName(const string scriptName);
static InventoryItem* InventoryItem.GetByName(const string scriptName);
static Object* Object.GetByName(const string scriptName);
```
