### PR TITLE
Script API: implement eEventGameSaved

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1130,6 +1130,7 @@ enum EventType {
 #endif
 #ifdef SCRIPT_API_v399
   eEventLeaveRoomAfterFadeout = 11,
+  eEventGameSaved = 12,
 #endif
 };
 

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -33,6 +33,7 @@
 #define GE_RESTORE_GAME  9
 #define GE_ENTER_ROOM_AFTERFADE 10
 #define GE_LEAVE_ROOM_AFTERFADE 11
+#define GE_SAVE_GAME     12
 
 // Game event types:
 // common script callback

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -919,6 +919,8 @@ void save_game(int slotn, const char*descript) {
 
     // Save dynamic game data
     SaveGameState(out.get());
+    // call "After Save" event callback
+    run_on_event(GE_SAVE_GAME, RuntimeScriptValue().SetInt32(slotn));
 }
 
 int gameHasBeenRestored = 0;


### PR DESCRIPTION
Resolves #1295

By a user's request, this adds a `eEventSaveGame` event which is run after a game was saved.
Similar to other events, this is scheduled to run after the current script callback is completed.
