### PR TITLE
AlFont: fix accessing cached glyphs beyond the array range

### DIFF
--- a/Common/libsrc/alfont-2.0.9/alfont.c
+++ b/Common/libsrc/alfont-2.0.9/alfont.c
@@ -205,6 +205,9 @@ static void _alfont_uncache_glyphs(ALFONT_FONT *f) {
 
 
 static void _alfont_uncache_glyph_number(ALFONT_FONT *f, int glyph_number) {
+  if ((glyph_number < 0) || (glyph_number >= f->face->num_glyphs))
+    return;
+
   if (f->cached_glyphs) {
     if (f->cached_glyphs[glyph_number].is_cached) {
       f->cached_glyphs[glyph_number].is_cached = 0;
@@ -231,6 +234,9 @@ static void _alfont_delete_glyphs(ALFONT_FONT *f) {
 
 
 static void _alfont_cache_glyph(ALFONT_FONT *f, int glyph_number) {
+  if ((glyph_number < 0) || (glyph_number >= f->face->num_glyphs))
+    return;
+
   /* if glyph not cached yet */
   if (!f->cached_glyphs[glyph_number].is_cached) {
     FT_Glyph new_glyph;
@@ -1032,6 +1038,10 @@ void alfont_textout_aa_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int
 	  else
 		  glyph_index_tmp = character;
 
+	  /* if out of existing glyph range -- skip it */
+	  if ((glyph_index_tmp < 0) || (glyph_index_tmp >= f->face->num_glyphs))
+		  continue;
+
 	  /* cache the glyph */
 	  _alfont_cache_glyph(f, glyph_index_tmp);
 	  cglyph_tmp = f->cached_glyphs[glyph_index_tmp];
@@ -1069,6 +1079,10 @@ void alfont_textout_aa_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int
 		glyph_index = FT_Get_Char_Index(f->face, character);
 	else
 		glyph_index = character;
+
+	/* if out of existing glyph range -- skip it */
+	if ((glyph_index < 0) || (glyph_index >= f->face->num_glyphs))
+		continue;
 
 	/* cache the glyph */
 	_alfont_cache_glyph(f, glyph_index);
@@ -2173,6 +2187,10 @@ void alfont_textout_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int y,
 	  else
 		  glyph_index_tmp = character;
 
+	  /* if out of existing glyph range -- skip it */
+	  if ((glyph_index_tmp < 0) || (glyph_index_tmp >= f->face->num_glyphs))
+		  continue;
+
 	  /* cache the glyph */
 	  _alfont_cache_glyph(f, glyph_index_tmp);
 	  cglyph_tmp = f->cached_glyphs[glyph_index_tmp];
@@ -2209,6 +2227,10 @@ void alfont_textout_ex(BITMAP *bmp, ALFONT_FONT *f, const char *s, int x, int y,
 		glyph_index = FT_Get_Char_Index(f->face, character);
 	else
 		glyph_index = character;
+
+	/* if out of existing glyph range -- skip it */
+	if ((glyph_index < 0) || (glyph_index >= f->face->num_glyphs))
+		continue;
 
 	/* cache the glyph */
 	_alfont_cache_glyph(f, glyph_index);
@@ -2997,6 +3019,10 @@ int alfont_text_length(ALFONT_FONT *f, const char *str) {
 	  else
 		  glyph_index_tmp = character;
 
+	  /* if out of existing glyph range -- skip it */
+	  if ((glyph_index_tmp < 0) || (glyph_index_tmp >= f->face->num_glyphs))
+		  continue;
+
 	  /* cache the glyph */
 	  _alfont_cache_glyph(f, glyph_index_tmp);
 	  if (max_advancex < f->cached_glyphs[glyph_index_tmp].advancex)
@@ -3029,6 +3055,10 @@ int alfont_text_length(ALFONT_FONT *f, const char *str) {
 		total_length += v.x >> 6;
 	}*/
 	last_glyph_index = glyph_index;
+
+	/* if out of existing glyph range -- skip it */
+	if ((glyph_index < 0) || (glyph_index >= f->face->num_glyphs))
+		continue;
 
 	/* cache */
 	_alfont_cache_glyph(f, glyph_index);
@@ -3110,6 +3140,10 @@ int alfont_char_length(ALFONT_FONT *f, int character) {
 	total_length += v.x >> 6;
   }*/
   last_glyph_index = glyph_index;
+
+  /* if out of existing glyph range -- imagine empty char */
+  if ((glyph_index < 0) || (glyph_index >= f->face->num_glyphs))
+    return 0;
 
   if (f->fixed_width == TRUE)
   {


### PR DESCRIPTION
Fixes #1438

This fixes cases when the wanted glyph is not available in the Font and its index is higher than the max glyph number. Potentially fixes incorrect text render, and in the worst case - random memory corruptions.

Frankly, I have no idea how this was supposed to work, but it was like this in the imported alfont 2.0.9 sources, apparently.

For the reference, it *does not seem* like this problem was affecting #1909, as the game does not trigger the safety checks I've added in this commit.