### PR TITLE
Explicitly search for plugins in a game's data dir 

### DIFF
--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -382,12 +382,6 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
     return 0;
 }
 
-void main_set_gamedir()
-{
-    appPath = Path::MakeAbsolutePath(platform->GetCommandArg(0));
-    appDirectory = Path::GetDirectoryPath(appPath);
-}
-
 int ags_entry_point(int argc, char *argv[]) { 
     main_init(argc, argv);
 
@@ -424,7 +418,8 @@ int ags_entry_point(int argc, char *argv[]) {
     init_debug(startup_opts, justTellInfo);
     Debug::Printf(kDbgMsg_Alert, get_engine_string());
 
-    main_set_gamedir();
+    appPath = Path::MakeAbsolutePath(platform->GetCommandArg(0));
+    appDirectory = Path::GetDirectoryPath(appPath);
 
     // Update shell associations and exit
     if (debug_flags & DBG_REGONLY)

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -86,6 +86,7 @@ using namespace AGS::Engine;
 #endif // BUILTIN_PLUGINS
 
 
+extern String appDirectory;
 extern IGraphicsDriver *gfxDriver;
 extern int mousex, mousey;
 extern int displayed_room;
@@ -1012,8 +1013,13 @@ bool pl_use_builtin_plugin(EnginePlugin* apl)
     return false;
 }
 
-Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> &infos)
+Engine::GameInitError pl_register_plugins(const std::vector<PluginInfo> &infos)
 {
+    std::vector<String> lookup_dirs;
+    lookup_dirs.push_back(appDirectory);
+    if (ResPaths.DataDir != appDirectory)
+        lookup_dirs.push_back(ResPaths.DataDir);
+
     numPlugins = 0;
     for (size_t inf_index = 0; inf_index < infos.size(); ++inf_index)
     {
@@ -1048,9 +1054,10 @@ Engine::GameInitError pl_register_plugins(const std::vector<Common::PluginInfo> 
             apl->filename = "ags_snowrain";
         }
 
-        if (apl->library.Load(apl->filename))
+        if (apl->library.Load(apl->filename, lookup_dirs))
         {
-          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' loaded from '%s', resolving imports...", apl->filename.GetCStr(), apl->library.GetFilePath().GetCStr());
+          AGS::Common::Debug::Printf(kDbgMsg_Info, "Plugin '%s' loaded from '%s', resolving imports...",
+              apl->filename.GetCStr(), apl->library.GetPath().GetCStr());
 
           if (apl->library.GetFunctionAddress("AGS_PluginV2") == nullptr) {
               quitprintf("Plugin '%s' is an old incompatible version.", apl->filename.GetCStr());

--- a/Engine/util/library.h
+++ b/Engine/util/library.h
@@ -11,6 +11,10 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
+//
+// BaseLibrary is a virtual parent class for a dynamic library loader.
+//
+//=============================================================================
 #ifndef __AGS_EE_UTIL__LIBRARY_H
 #define __AGS_EE_UTIL__LIBRARY_H
 
@@ -30,17 +34,30 @@ public:
     BaseLibrary() = default;
     virtual ~BaseLibrary() = default;
 
-    String GetName() const { return _name; }
-    String GetFilePath() const { return _path; }
+    // Get library name; returns empty string if not loaded
+    inline String GetName() const { return _name; }
+    // Get actual filename; returns empty string if not loaded
+    inline String GetFileName() const { return _filename; }
+    // Get path used to load the library; or empty string is not loaded.
+    // NOTE: this is NOT a fully qualified path, but a lookup path.
+    inline String GetPath() const { return _path; }
 
+    // Returns expected filename form for the dynamic library of a given name
     virtual String GetFilenameForLib(const String &libname) = 0;
-    virtual bool Load(const String &libname) = 0;
+
+    // Try load a library of a given name, optionally looking it up in the list of paths
+    virtual bool Load(const String &libname,
+        const std::vector<String> &lookup = std::vector<String>()) = 0;
+    // Unload a library; does nothing if was not loaded
     virtual void Unload() = 0;
+    // Tells if library is loaded
     virtual bool IsLoaded() const = 0;
+    // Tries to get a function address from a loaded library
     virtual void *GetFunctionAddress(const String &fn_name) = 0;
 
 protected:
     String _name;
+    String _filename;
     String _path;
 };
 

--- a/Engine/util/library_dummy.h
+++ b/Engine/util/library_dummy.h
@@ -21,7 +21,7 @@ namespace Engine
 
 using AGS::Common::String;
 
-class DummyLibrary : public BaseLibrary
+class DummyLibrary final : public BaseLibrary
 {
 public:
     DummyLibrary() = default;
@@ -32,7 +32,7 @@ public:
         return ""; // not supported
     }
 
-    bool Load(const String &libname) override
+    bool Load(const String &libname, const std::vector<String> &lookup) override
     {
         return false; // always fail
     }


### PR DESCRIPTION
Fix #1707

Modified Library class to accept an optional list of lookup dirs when loading a shared lib.
This is used to find game plugins when running the engine from outside the game dir, passing game path as an argument.

@ericoporto I removed a piece of code from PosixLibrary meant for Android, that looked up in `<android_app_directory> /lib`. This seem to be a very old code, and I don't know if it's still necessary with the current port? If it is, I will find a different way of passing this path.