### PR TITLE
Editor: export sprites asynchronously with progress count

### DIFF
--- a/Editor/AGS.Editor/Panes/SpriteSelector.cs
+++ b/Editor/AGS.Editor/Panes/SpriteSelector.cs
@@ -1193,50 +1193,37 @@ namespace AGS.Editor
         {
             SpriteExportDialog dialog = new SpriteExportDialog(_currentFolder);
 
-            if (dialog.ShowDialog() == DialogResult.OK)
-            {
-                try
-                {
-                    if (dialog.UseRootFolder)
-                    {
-                        SpriteTools.ExportSprites(dialog.ExportPath, dialog.Recurse,
-                            dialog.SkipIf, dialog.UpdateSpriteSource, dialog.ResetTileSettings);
-                    }
-                    else
-                    {
-                        SpriteTools.ExportSprites(_currentFolder, dialog.ExportPath, dialog.Recurse,
-                            dialog.SkipIf, dialog.UpdateSpriteSource, dialog.ResetTileSettings);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    String message = String.Format("There was an error during the export. The error message was: '{0}'", ex.Message);
-                    Factory.GUIController.ShowMessage(message, MessageBoxIcon.Warning);
-                }
-            }
+            if (dialog.ShowDialog() != DialogResult.OK)
+                return;
 
+            SpriteFolder startFolder = dialog.UseRootFolder ?
+                Factory.AGSEditor.CurrentGame.RootSpriteFolder : _currentFolder;
+            var opts = new SpriteTools.ExportSpritesOptions(
+                dialog.ExportPath,
+                dialog.Recurse,
+                dialog.SkipIf,
+                dialog.UpdateSpriteSource,
+                dialog.ResetTileSettings);
             dialog.Dispose();
+
+            Tasks.ExportSprites(startFolder, opts);
         }
 
         private void ExportFixupSources()
         {
             string folder = Factory.GUIController.ShowSelectFolderOrNoneDialog("Create sprite source in folder...",
                 Factory.AGSEditor.CurrentGame.DirectoryPath);
-            if (folder != null)
-            {
-                try
-                {
-                    SpriteTools.ExportSprites(Path.Combine(folder, "%Number%"), recurse: true,
-                        skipIf: SpriteTools.SkipIf.SourceLocal,
-                        updateSourcePath: true,
-                        resetTileSettings: true);
-                }
-                catch (Exception ex)
-                {
-                    String message = String.Format("There was an error during the export. The error message was: '{0}'", ex.Message);
-                    Factory.GUIController.ShowMessage(message, MessageBoxIcon.Warning);
-                }
-            }
+            if (folder == null)
+                return;
+
+            var opts = new SpriteTools.ExportSpritesOptions(
+                    Path.Combine(folder, "%Number%"),
+                    recurse: true,
+                    skipIf: SpriteTools.SkipIf.SourceLocal,
+                    updateSourcePath: true,
+                    resetTileSettings: true
+                );
+            Tasks.ExportSprites(opts);
         }
 
         private void SortAllSpritesInCurrentFolderByNumber()

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using AGS.Types;
 using AGS.Editor.Preferences;
 using AGS.Editor.Components;
+using AGS.Editor.Utils;
 
 namespace AGS.Editor
 {
@@ -184,7 +185,7 @@ namespace AGS.Editor
         public static void CreateNewSpriteFile()
         {
             string tempFilename = Path.GetTempFileName();
-            Utils.SpriteTools.WriteDummySpriteFile(tempFilename);
+            SpriteTools.WriteDummySpriteFile(tempFilename);
             Factory.NativeProxy.ReplaceSpriteFile(tempFilename);
             File.Delete(tempFilename);
         }
@@ -197,7 +198,7 @@ namespace AGS.Editor
                 tempFilename = Path.GetTempFileName();
                 BusyDialog.Show("Please wait while the sprite file is recreated...",
                     new BusyDialog.ProcessingHandler(
-                        (IWorkProgress progress, object o) => { Utils.SpriteTools.WriteSpriteFileFromSources((string)o, progress); return null; }),
+                        (IWorkProgress progress, object o) => { SpriteTools.WriteSpriteFileFromSources((string)o, progress); return null; }),
                     tempFilename);
             }
             catch (Exception e)
@@ -210,6 +211,26 @@ namespace AGS.Editor
             File.Delete(tempFilename);
 
             Factory.Events.OnSpritesImported(null);
+        }
+
+        public static void ExportSprites(SpriteFolder folder, SpriteTools.ExportSpritesOptions options)
+        {
+            try
+            {
+                BusyDialog.Show("Please wait while the sprites are exported...",
+                    new BusyDialog.ProcessingHandler(
+                        (IWorkProgress progress, object o) => { SpriteTools.ExportSprites(folder, options, progress); return null; }), null);
+            }
+            catch (Exception ex)
+            {
+                String message = String.Format("There was an error during the export. The error message was: '{0}'", ex.Message);
+                Factory.GUIController.ShowMessage(message, MessageBoxIcon.Warning);
+            }
+        }
+
+        public static void ExportSprites(SpriteTools.ExportSpritesOptions options)
+        {
+            ExportSprites(Factory.AGSEditor.CurrentGame.RootSpriteFolder, options);
         }
 
         private void SetDefaultValuesForNewFeatures(Game game)

--- a/Editor/AGS.Editor/Utils/SpriteTools.cs
+++ b/Editor/AGS.Editor/Utils/SpriteTools.cs
@@ -482,10 +482,36 @@ namespace AGS.Editor.Utils
             SourceLocal     = 0x0002
         }
 
-        public static void ExportSprites(SpriteFolder folder, string path, bool recurse,
-            SkipIf skipIf, bool updateSourcePath, bool resetTileSettings)
+        public struct ExportSpritesOptions
         {
-            foreach(Sprite sprite in folder.Sprites)
+            public string ExportPath;
+            public bool Recursive;
+            public SkipIf SkipIf;
+            public bool UpdateSourcePath;
+            public bool ResetTileSettings;
+
+            public ExportSpritesOptions(string path, bool recurse,
+                SkipIf skipIf, bool updateSourcePath, bool resetTileSettings)
+            {
+                ExportPath = path;
+                Recursive = recurse;
+                SkipIf = skipIf;
+                UpdateSourcePath = updateSourcePath;
+                ResetTileSettings = resetTileSettings;
+            }
+        }
+
+        public static void ExportSprites(SpriteFolder folder, ExportSpritesOptions options, IWorkProgress progress)
+        {
+            if (!progress.Total.HasValue)
+            {
+                progress.Total = folder.CountSpritesInAllSubFolders();
+                progress.Current = 0;
+            }
+
+            var skipIf = options.SkipIf;
+
+            foreach (Sprite sprite in folder.Sprites)
             {
                 if (skipIf > 0)
                 {
@@ -495,33 +521,35 @@ namespace AGS.Editor.Utils
 
                     if (skipIf.HasFlag(SkipIf.SourceValid) && File.Exists(checkPath))
                     {
+                        progress.Current++;
                         continue; // skip if source is valid
                     }
                     else if (skipIf.HasFlag(SkipIf.SourceLocal) &&
                         File.Exists(checkPath) &&
                         Utilities.PathsAreSameOrNested(checkPath, Factory.AGSEditor.CurrentGame.DirectoryPath))
                     {
+                        progress.Current++;
                         continue; // skip if source is valid and local (inside the project folder)
                     }
                 }
 
-                ExportSprite(sprite, path, updateSourcePath, resetTileSettings);
+                ExportSprite(sprite, options.ExportPath, options.UpdateSourcePath, options.ResetTileSettings);
+                progress.Current++;
             }
 
-            if (recurse)
+            if (options.Recursive)
             {
                 foreach (SpriteFolder subFolder in folder.SubFolders)
                 {
-                    ExportSprites(subFolder, path, recurse, skipIf, updateSourcePath, resetTileSettings);
+                    ExportSprites(subFolder, options, progress);
                 }
             }
         }
 
-        public static void ExportSprites(string path, bool recurse,
-            SkipIf skipIf, bool updateSourcePath, bool resetTileSettings)
+        public static void ExportSprites(ExportSpritesOptions options, IWorkProgress progress)
         {
             SpriteFolder folder = Factory.AGSEditor.CurrentGame.RootSpriteFolder;
-            ExportSprites(folder, path, recurse, skipIf, updateSourcePath, resetTileSettings);
+            ExportSprites(folder, options, progress);
         }
 
         public static Bitmap GetPlaceHolder(int width = 12, int height = 7)

--- a/Editor/AGS.Types/Interfaces/ISpriteFolder.cs
+++ b/Editor/AGS.Types/Interfaces/ISpriteFolder.cs
@@ -40,6 +40,11 @@ namespace AGS.Types
         SpriteFolder FindFolderThatContainsSprite(int spriteNumber);
 
         /// <summary>
+        /// Returns total number of sprites found in the current folder and sub-folders.
+        /// </summary>
+        int CountSpritesInAllSubFolders();
+
+        /// <summary>
         /// Assembles a list of all the sprites in the current folder and sub-folders
         /// </summary>
         /// <returns>

--- a/Editor/AGS.Types/SpriteFolder.cs
+++ b/Editor/AGS.Types/SpriteFolder.cs
@@ -106,6 +106,19 @@ namespace AGS.Types
         }
 
         /// <summary>
+        /// Returns number of sprites found in the current folder and sub-folders.
+        /// </summary>
+        public int CountSpritesInAllSubFolders()
+        {
+            int count = Sprites.Count;
+            foreach (ISpriteFolder folder in SubFolders)
+            {
+                count += folder.CountSpritesInAllSubFolders();
+            }
+            return count;
+        }
+
+        /// <summary>
         /// Assembles a list of all the sprites in the current folder and sub-folders
         /// </summary>
         /// <returns>


### PR DESCRIPTION
Resolves #2033 

* Export options are passed in a struct ExportSpritesOptions, to save number of function arguments (also in case it will be expanded further)
* Implement a Task ExportSprites which uses BusyDialog for the threaded work.
* ExportSprites uses IWorkProgress interface to report current state.
* Had to add CountSpritesInAllSubFolders method to ISpriteFolder interface, to avoid redundant work with GetAllSpritesFromAllSubFolders.

This helps greatly when exporting all sprites from a big game.