### PR TITLE
New Compiler: Fix bug: '++' and '--' can't be binary op

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -2448,6 +2448,10 @@ void AGS::Parser::ParseExpression_Binary(size_t const op_idx, SrcList &expressio
         WriteCmd(SCMD_JNZ, kDestinationPlaceholder);
         to_exit.AddParam();
     }
+    else if (kKW_Increment == operator_sym || kKW_Decrement == operator_sym)
+    {
+        UserError("Cannot use '%s' as a binary operator", _sym.GetName(operator_sym).c_str());
+    }
     else
     {
         // Hang on to the intermediate result

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2558,6 +2558,23 @@ TEST_F(Compile1, AssignmentInParameterList1)
     int compile_result = cc_compile(inpl, scrip);
     std::string msg = last_seen_cc_error();
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
-    EXPECT_NE(std::string::npos, msg.find("'\='"));
+    EXPECT_NE(std::string::npos, msg.find("'='"));
 }
+TEST_F(Compile1, CrementAsBinary1) {
 
+    // Increment operator can't be used as a binary operator.
+
+    char const *inpl = "\
+        int game_start() {      \n\
+            int a = 10;         \n\
+            int b = 5;          \n\
+            int c = a ++ b;     \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    EXPECT_NE(std::string::npos, msg.find("'++'"));
+    EXPECT_NE(std::string::npos, msg.find("binary"));
+}


### PR DESCRIPTION
This addresses #2019.

This PR makes the compiler throw an error message for expressions that use `++` or `--` as binary operators. These operators can only be used as unary-prefix or unary-postfix operators.

Typical code:
```
function game_start() 
{
            int a = 10;
            int b = 5;
            int c = a ++ b;  \\ ← Compiler will balk here
}
```