### PR TITLE
Engine: remember overlay index and try it before looking again

### DIFF
--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -44,6 +44,7 @@ extern IGraphicsDriver *gfxDriver;
 
 
 std::vector<ScreenOverlay> screenover;
+std::vector<int> overlookup(128);
 
 void Overlay_Remove(ScriptOverlay *sco) {
     sco->Remove();
@@ -404,9 +405,16 @@ void remove_screen_overlay(int type)
 
 int find_overlay_of_type(int type)
 {
-    for (size_t i = 0; i < screenover.size(); ++i)
+    int idx = overlookup[type];
+    if (idx >= 0 && idx < screenover.size() && screenover[idx].type == type)
+        return idx;
+    for (idx = 0; idx < screenover.size(); ++idx)
     {
-        if (screenover[i].type == type) return i;
+        if (screenover[idx].type == type)
+        {
+            overlookup[type] = idx;
+            return idx;
+        }
     }
     return -1;
 }
@@ -414,6 +422,9 @@ int find_overlay_of_type(int type)
 size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum, Bitmap *piccy,
     int pic_offx, int pic_offy, bool has_alpha)
 {
+    const auto new_size = screenover.size() + OVER_CUSTOM + 2;
+    if(overlookup.size() < new_size) overlookup.resize(new_size);
+
     if (type == OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
         for (int id = OVER_CUSTOM + 1; (size_t)id <= screenover.size() + OVER_CUSTOM + 1; ++id) {
@@ -461,6 +472,7 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
         play.speech_face_schandle = over.associatedOverlayHandle;
     }
     over.MarkChanged();
+    overlookup[type] = screenover.size();
     screenover.push_back(std::move(over));
     return screenover.size() - 1;
 }
@@ -527,8 +539,11 @@ Point get_overlay_position(const ScreenOverlay &over)
 
 void recreate_overlay_ddbs()
 {
-    for (auto &over : screenover)
+    overlookup.resize(screenover.size() + OVER_CUSTOM + 2);
+    for (size_t i=0; i<screenover.size(); i++)
     {
+        auto &over = screenover[i];
+        overlookup[over.type] = i;
         if (over.ddb)
             gfxDriver->DestroyDDB(over.ddb);
         over.ddb = nullptr; // is generated during first draw pass


### PR DESCRIPTION
Whenever we access an Overlay, we iterate through all overlays until we find the one with the corresponding ID. This has been this way since the origins of AGS, as you can see in [in ac_overlay.cpp in the initial commit](https://github.com/adventuregamestudio/ags/blob/bb1b708965a35da0853878ac4b670234ddeb5b17/Engine/acmain/ac_overlay.cpp).

Overlays touch a lot of things and I am sure there is some smarter way to redo things so we can just access directly what we mean when using the Script Overlays. Still, a minor easy to do optimization is to simply remember the last result and use it, if the result has changed, well then look for it again. This improves FPS in my example game below when running in infinite fps mode (I go from 66fps to 82fps in the Oasis area) and can also reduce hiccups in it. (I didn't prepared a special game, so you need to wait 811 game loops for it to finish loading before using it).

[ExampleGameOverlays.zip](https://github.com/adventuregamestudio/ags/files/11811311/ExampleGameOverlays.zip)

This is a naïve fix for #2042 , but performance wise it suffices, even though the code may not be pretty.
