### PR TITLE
Extend Right-to-left text render for GUI and non-wrapping DrawString

### DIFF
--- a/Common/ac/game_version.h
+++ b/Common/ac/game_version.h
@@ -112,6 +112,8 @@ New font load flags, control backward compatible font behavior
 Idle animation speed, modifiable hotspot names, fixed video frame
 3.6.0.21:
 Some adjustments to gui text alignment.
+3.6.1:
+In RTL mode all text is reversed, not only wrappable (labels etc).
 
 */
 
@@ -150,7 +152,8 @@ enum GameDataVersion
     kGameVersion_360_11         = 3060011,
     kGameVersion_360_16         = 3060016,
     kGameVersion_360_21         = 3060021,
-    kGameVersion_Current        = kGameVersion_360_21
+    kGameVersion_361            = 3060100,
+    kGameVersion_Current        = kGameVersion_361
 };
 
 // Data format version of the loaded game

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -23,6 +23,8 @@
 #include "core/assetmanager.h"
 #include "debug/out.h"
 #include "game/main_game_file.h"
+#include "gui/guibutton.h"
+#include "gui/guilabel.h"
 #include "gui/guimain.h"
 #include "script/cc_common.h"
 #include "util/alignedstream.h"
@@ -656,6 +658,18 @@ void UpgradeCharacters(GameSetupStruct &game, GameDataVersion data_ver)
     }
 }
 
+void UpgradeGUI(GameSetupStruct &game, GameDataVersion data_ver)
+{
+    // Previously, Buttons and Labels had a fixed Translated behavior
+    if (data_ver < kGameVersion_361)
+    {
+        for (auto &btn : guibuts)
+            btn.SetTranslated(true); // always translated
+        for (auto &lbl : guilabels)
+            lbl.SetTranslated(true); // always translated
+    }
+}
+
 void UpgradeMouseCursors(GameSetupStruct &game, GameDataVersion data_ver)
 {
     if (data_ver <= kGameVersion_272)
@@ -921,6 +935,7 @@ HGameFileError UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver
     UpgradeFonts(game, data_ver);
     UpgradeAudio(game, ents, data_ver);
     UpgradeCharacters(game, data_ver);
+    UpgradeGUI(game, data_ver);
     UpgradeMouseCursors(game, data_ver);
     SetDefaultGlobalMessages(game);
     // Global talking animation speed

--- a/Common/gui/guibutton.cpp
+++ b/Common/gui/guibutton.cpp
@@ -316,8 +316,6 @@ void GUIButton::ReadFromFile(Stream *in, GuiVersion gui_version)
     if (TextColor == 0)
         TextColor = 16;
     CurrentImage = Image;
-    // All buttons are translated at the moment
-    Flags |= kGUICtrl_Translated;
 }
 
 void GUIButton::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -140,7 +140,8 @@ enum GUIControlFlags
     kGUICtrl_Translated = 0x0080, // 3.3.0.1132
     kGUICtrl_Deleted    = 0x8000, // unused (probably remains from the old editor?)
 
-    kGUICtrl_DefFlags   = kGUICtrl_Enabled | kGUICtrl_Visible | kGUICtrl_Clickable,
+    kGUICtrl_DefFlags   = kGUICtrl_Enabled | kGUICtrl_Visible | kGUICtrl_Clickable |
+                          kGUICtrl_Translated,
     // flags that had inverse meaning in old formats
     kGUICtrl_OldFmtXorMask = kGUICtrl_Enabled | kGUICtrl_Visible | kGUICtrl_Clickable
 };

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -145,8 +145,6 @@ void GUILabel::ReadFromFile(Stream *in, GuiVersion gui_version)
 
     if (TextColor == 0)
         TextColor = 16;
-    // All labels are translated at the moment
-    Flags |= kGUICtrl_Translated;
 
     _textMacro = GUI::FindLabelMacros(Text);
 }

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -61,8 +61,7 @@ Rect GUILabel::CalcGraphicRect(bool clipped)
     // - translation change
     // - macro value change (score, overhotspot etc)
     Rect rc = RectWH(0, 0, Width, Height);
-    PrepareTextToDraw();
-    if (GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), Lines, Font, Width) == 0)
+    if (PrepareTextToDraw() == 0)
         return rc;
     const int linespacing = // Older engine labels used (font height + 1) as linespacing for some reason
         ((loaded_game_file_version < kGameVersion_360) && (get_font_flags(Font) & FFLG_DEFLINESPACING)) ?
@@ -87,8 +86,7 @@ void GUILabel::Draw(Bitmap *ds, int x, int y)
 {
     // TODO: need to find a way to cache text prior to drawing;
     // but that will require to update all gui controls when translation is changed in game
-    PrepareTextToDraw();
-    if (GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), Lines, Font, Width) == 0)
+    if (PrepareTextToDraw() == 0)
         return;
 
     color_t text_color = ds->GetCompatibleColor(TextColor);

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -62,7 +62,7 @@ Rect GUILabel::CalcGraphicRect(bool clipped)
     // - macro value change (score, overhotspot etc)
     Rect rc = RectWH(0, 0, Width, Height);
     PrepareTextToDraw();
-    if (SplitLinesForDrawing(Lines) == 0)
+    if (GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), Lines, Font, Width) == 0)
         return rc;
     const int linespacing = // Older engine labels used (font height + 1) as linespacing for some reason
         ((loaded_game_file_version < kGameVersion_360) && (get_font_flags(Font) & FFLG_DEFLINESPACING)) ?
@@ -88,7 +88,7 @@ void GUILabel::Draw(Bitmap *ds, int x, int y)
     // TODO: need to find a way to cache text prior to drawing;
     // but that will require to update all gui controls when translation is changed in game
     PrepareTextToDraw();
-    if (SplitLinesForDrawing(Lines) == 0)
+    if (GUI::SplitLinesForDrawing(_textToDraw.GetCStr(), Lines, Font, Width) == 0)
         return;
 
     color_t text_color = ds->GetCompatibleColor(TextColor);

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -53,7 +53,9 @@ public:
     HorAlignment TextAlignment;
 
 private:
-    void PrepareTextToDraw();
+    // Transforms the Text property to a drawn text, applies translation,
+    // replaces macros, splits and wraps, etc; returns number of lines.
+    int PrepareTextToDraw();
 
     // Information on macros contained within Text field
     GUILabelMacro _textMacro;

--- a/Common/gui/guilabel.h
+++ b/Common/gui/guilabel.h
@@ -18,8 +18,6 @@
 #include "gui/guiobject.h"
 #include "util/string.h"
 
-class SplitLines;
-
 namespace AGS
 {
 namespace Common
@@ -56,11 +54,11 @@ public:
 
 private:
     void PrepareTextToDraw();
-    size_t SplitLinesForDrawing(SplitLines &lines);
 
     // Information on macros contained within Text field
     GUILabelMacro _textMacro;
     // prepared text buffer/cache
+    // TODO: cache split lines instead?
     String _textToDraw;
 };
 

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -26,8 +26,7 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-// There were issues when including header caused conflicts
-struct GameSetupStruct;
+class SplitLines;
 
 #define LEGACY_MAX_OBJS_ON_GUI             30
 
@@ -218,6 +217,14 @@ namespace GUI
     // Draw text aligned horizontally inside given bounds
     void DrawTextAlignedHor(Bitmap *ds, const char *text, int font, color_t text_color, int x1, int x2, int y, FrameAlignment align);
 
+    // Parses the string and returns combination of label macro flags
+    GUILabelMacro FindLabelMacros(const String &text);
+    // Wraps given text to make it fit into width, stores it in the lines
+    size_t SplitLinesForDrawing(const char *text, SplitLines &lines, int font, int width, size_t max_lines = -1);
+    // Applies text transformation necessary for rendering, in accordance to the
+    // current game settings, such as right-to-left render, and anything else
+    String TransformTextForDrawing(const String &text, bool translate);
+
     // Mark all existing GUI for redraw
     void MarkAllGUIForUpdate(bool redraw, bool reset_over_ctrl);
     // Mark all translatable GUI controls for redraw
@@ -229,9 +236,6 @@ namespace GUI
     void MarkSpecialLabelsForUpdate(GUILabelMacro macro);
     // Mark inventory windows for redraw, optionally only ones linked to given character
     void MarkInventoryForUpdate(int char_id, bool is_player);
-
-    // Parses the string and returns combination of label macro flags
-    GUILabelMacro FindLabelMacros(const String &text);
 
     // Reads all GUIs and their controls.
     // WARNING: the data is read into the global arrays (guis, guibuts, and so on)

--- a/Common/gui/guimain.h
+++ b/Common/gui/guimain.h
@@ -206,6 +206,8 @@ namespace GUI
     extern GuiVersion GameGuiVersion;
     extern GuiOptions Options;
 
+    // Applies current text direction setting (may depend on multiple factors)
+    String ApplyTextDirection(const String &text);
     // Calculates the text's graphical position, given the alignment
     Rect CalcTextPosition(const char *text, int font, const Rect &frame, FrameAlignment align);
     // Calculates the text's graphical position, given the horizontal alignment
@@ -219,11 +221,12 @@ namespace GUI
 
     // Parses the string and returns combination of label macro flags
     GUILabelMacro FindLabelMacros(const String &text);
-    // Wraps given text to make it fit into width, stores it in the lines
-    size_t SplitLinesForDrawing(const char *text, SplitLines &lines, int font, int width, size_t max_lines = -1);
     // Applies text transformation necessary for rendering, in accordance to the
     // current game settings, such as right-to-left render, and anything else
-    String TransformTextForDrawing(const String &text, bool translate);
+    String TransformTextForDrawing(const String &text, bool translate, bool apply_direction);
+    // Wraps given text to make it fit into width, stores it in the lines;
+    // apply_direction param tells whether text direction setting should be applied
+    size_t SplitLinesForDrawing(const char *text, bool apply_direction, SplitLines &lines, int font, int width, size_t max_lines = -1);
 
     // Mark all existing GUI for redraw
     void MarkAllGUIForUpdate(bool redraw, bool reset_over_ctrl);

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -142,6 +142,9 @@ void GUITextBox::ReadFromFile(Stream *in, GuiVersion gui_version)
 
     if (TextColor == 0)
         TextColor = 16;
+    // Text boxes input is never "translated" in regular sense,
+    // but they use this flag to apply text direction
+    Flags |= kGUICtrl_Translated;
 }
 
 void GUITextBox::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)

--- a/Common/gui/guitextbox.cpp
+++ b/Common/gui/guitextbox.cpp
@@ -142,9 +142,6 @@ void GUITextBox::ReadFromFile(Stream *in, GuiVersion gui_version)
 
     if (TextColor == 0)
         TextColor = 16;
-    // Text boxes input is never "translated" in regular sense,
-    // but they use this flag to apply text direction
-    Flags |= kGUICtrl_Translated;
 }
 
 void GUITextBox::ReadFromSavegame(Stream *in, GuiSvgVersion svg_ver)

--- a/Common/gui/guitextbox.h
+++ b/Common/gui/guitextbox.h
@@ -52,6 +52,7 @@ public:
 
 private:
     int32_t TextBoxFlags;
+    String  _textToDraw;
 
     void DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color);
 };

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -100,8 +100,9 @@ namespace AGS.Editor
          *                - Room.BackgroundAnimationEnabled
          *                - RuntimeSetup.FullscreenDesktop
          * 3.6.0.20       - Settings.GameTextEncoding, Settings.UseOldKeyboardHandling;
+         * 3.6.1.2        - GUIListBox.Translated property moved to GUIControl parent
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060020;
+        public const int    LATEST_XML_VERSION_INDEX = 3060102;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -1105,8 +1105,10 @@ namespace AGS.Editor
             {
                 return (control.Clickable ? NativeConstants.GUIF_CLICKABLE : 0) |
                     (control.Enabled ? NativeConstants.GUIF_ENABLED : 0) |
-                    (control.Visible ? NativeConstants.GUIF_VISIBLE : 0)
+                    (control.Visible ? NativeConstants.GUIF_VISIBLE : 0) |
+                    (control.Translated ? NativeConstants.GUIF_TRANSLATED : 0)
                     ;
+                ;
             }
 
             /// <summary>
@@ -1221,8 +1223,7 @@ namespace AGS.Editor
                 writer.Write(GUIListBoxes.Count);
                 foreach (GUIListBox listBox in GUIListBoxes)
                 {
-                    int flags = (listBox.Translated ? NativeConstants.GUIF_TRANSLATED : 0);
-                    WriteGUIControl(listBox, flags, new string[] { listBox.OnSelectionChanged });
+                    WriteGUIControl(listBox, 0, new string[] { listBox.OnSelectionChanged });
                     writer.Write(0); // numItems
                     writer.Write(listBox.Font);
                     writer.Write(listBox.TextColor);

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -241,6 +241,19 @@ namespace AGS.Editor
                 }
             }
 
+            if (xmlVersionIndex < 8)
+            {
+                // GUIListBox Translated property should be false, as they never translated in older games
+                foreach (GUI gui in game.GUIs)
+                {
+                    foreach (GUIControl guic in gui.Controls)
+                    {
+                        if (guic is GUIListBox)
+                            (guic as GUIListBox).Translated = false;
+                    }
+                }
+            }
+
             if (xmlVersionIndex < 12)
             {
                 game.Settings.UseOldCustomDialogOptionsAPI = true;

--- a/Editor/AGS.Types/GUIControl.cs
+++ b/Editor/AGS.Types/GUIControl.cs
@@ -40,6 +40,7 @@ namespace AGS.Types
         private bool _clickable = true;
         private bool _enabled = true;
         private bool _visible = true;
+        private bool _translated = true;
 
         [AGSNoSerialize]
         private GUIControlGroup _memberOf;
@@ -157,6 +158,14 @@ namespace AGS.Types
         {
             get { return _visible; }
             set { _visible = value; }
+        }
+
+        [Description("If true, the Control's text will be affected by game's translation and a text direction setting")]
+        [Category("Appearance")]
+        public bool Translated
+        {
+            get { return _translated; }
+            set { _translated = value; }
         }
 
         [Browsable(false)]

--- a/Editor/AGS.Types/GUIListBox.cs
+++ b/Editor/AGS.Types/GUIListBox.cs
@@ -24,7 +24,6 @@ namespace AGS.Types
             _selectedTextColor = 7;
             _selectedBackgroundColor = 16;
             _textAlignment = HorizontalAlignment.Left;
-            _translated = true;
         }
 
         public GUIListBox(XmlNode node) : base(node)
@@ -41,9 +40,6 @@ namespace AGS.Types
         private bool _showBorder;
         private bool _showScrollArrows;
         private string _selectionChangedEventHandler = string.Empty;
-        // We set _translated to true only when new control is created, because it won't be
-        // deserialized when importing older projects, and we need it to be disabled for backward compatibility
-        private bool _translated;
 
         [Description("Script function to run when the selection is changed")]
         [Category("Events")]
@@ -172,14 +168,6 @@ namespace AGS.Types
         {
             get { return _font; }
             set { _font = value; }
-        }
-
-        [Description("If true, the list box items will be translated to current language")]
-        [Category("Appearance")]
-        public bool Translated
-        {
-            get { return _translated; }
-            set { _translated = value; }
         }
 
         public override string ControlType

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -72,14 +72,14 @@ namespace AGS
 namespace Common
 {
 
-String GUI::TransformTextForDrawing(const String &text, bool /*translate*/)
+String GUI::TransformTextForDrawing(const String &text, bool /*translate*/, bool /*apply_direction*/)
 {
     return text;
 }
 
-size_t GUI::SplitLinesForDrawing(const char *text, SplitLines &lines, int font, int width, size_t max_lines)
+size_t GUI::SplitLinesForDrawing(const char *text, bool /*apply_direction*/, SplitLines &lines, int font, int width, size_t max_lines)
 {
-    return split_lines(text, lines, width, font);
+    return split_lines(text, lines, width, font, max_lines);
 }
 
 bool GUIObject::IsClickable() const
@@ -98,9 +98,10 @@ void GUIObject::NotifyParentChanged()
     // do nothing: in Editor "guis" array is not even guaranteed to be filled!
 }
 
-void GUILabel::PrepareTextToDraw()
+int GUILabel::PrepareTextToDraw()
 {
     _textToDraw = Text;
+    return 0;
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)

--- a/Editor/Native/acgui_agsnative.cpp
+++ b/Editor/Native/acgui_agsnative.cpp
@@ -72,6 +72,16 @@ namespace AGS
 namespace Common
 {
 
+String GUI::TransformTextForDrawing(const String &text, bool /*translate*/)
+{
+    return text;
+}
+
+size_t GUI::SplitLinesForDrawing(const char *text, SplitLines &lines, int font, int width, size_t max_lines)
+{
+    return split_lines(text, lines, width, font);
+}
+
 bool GUIObject::IsClickable() const
 {
     // make sure the button can be selected in the editor
@@ -91,11 +101,6 @@ void GUIObject::NotifyParentChanged()
 void GUILabel::PrepareTextToDraw()
 {
     _textToDraw = Text;
-}
-
-size_t GUILabel::SplitLinesForDrawing(SplitLines &lines)
-{
-    return split_lines(_textToDraw.GetCStr(), lines, Width, Font);
 }
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -335,7 +335,8 @@ void DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int fo
         text_color = ds->GetCompatibleColor(1);
         debug_script_warn ("RawPrint: Attempted to use hi-color on 256-col background");
     }
-    wouttext_outline(ds, xx, yy, font, text_color, text);
+    String res_str = GUI::ApplyTextDirection(text);
+    wouttext_outline(ds, xx, yy, font, text_color, res_str.GetCStr());
     sds->FinishedDrawing();
 }
 

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -275,7 +275,7 @@ DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate)
     return DynObjectRef(handle, obj_ptr, str);
 }
 
-size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
+size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
     if (fonnt == -1)
         fonnt = play.normal_font;
 
@@ -297,7 +297,7 @@ size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, i
 
     // Right-to-left just means reverse the text then
     // write it as normal
-    if (game.options[OPT_RIGHTLEFTWRITE])
+    if (apply_direction && (game.options[OPT_RIGHTLEFTWRITE] != 0))
         for (size_t rr = 0; rr < lines.Count(); rr++) {
             (get_uformat() == U_UTF8) ?
                 lines[rr].ReverseUTF8() :

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -57,7 +57,12 @@ class SplitLines;
 // Break up the text into lines restricted by the given width;
 // returns number of lines, or 0 if text cannot be split well to fit in this width.
 // Does additional processing, like removal of voice-over tags and text reversal if right-to-left text display is on.
-size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1);
+// Optionally applies text direction rules (apply_direction param), otherwise leaves left-to-right always.
+size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1);
+inline size_t break_up_text_into_lines(const char *todis, SplitLines &lines, int wii, int fonnt, size_t max_lines = -1)
+{
+    return break_up_text_into_lines(todis, true, lines, wii, fonnt, max_lines);
+}
 void check_strlen(char*ptt);
 void my_strncpy(char *dest, const char *src, int len);
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -153,13 +153,26 @@ int GUILabel::PrepareTextToDraw()
 
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)
 {
-    wouttext_outline(ds, x + 1 + get_fixed_pixel_size(1), y + 1 + get_fixed_pixel_size(1), Font, text_color, Text.GetCStr());
+    _textToDraw = Text;
+    bool reverse = false;
+    if ((loaded_game_file_version >= kGameVersion_361) && ((Flags & kGUICtrl_Translated) != 0))
+    {
+        _textToDraw = GUI::ApplyTextDirection(Text);
+        reverse = game.options[OPT_RIGHTLEFTWRITE] != 0;
+    }
+
+    Line tpos = GUI::CalcTextPositionHor(_textToDraw.GetCStr(), Font,
+        x + 1 + get_fixed_pixel_size(1), x + Width - 1, y + 1 + get_fixed_pixel_size(1),
+        reverse ? kAlignTopRight : kAlignTopLeft);
+    wouttext_outline(ds, tpos.X1, tpos.Y1, Font, text_color, _textToDraw.GetCStr());
+
     if (IsGUIEnabled(this))
     {
         // draw a cursor
-        int draw_at_x = get_text_width(Text.GetCStr(), Font) + x + 3;
+        const int cursor_width = get_fixed_pixel_size(5);
+        int draw_at_x = reverse ? tpos.X1 - 3 - cursor_width : tpos.X2 + 3;
         int draw_at_y = y + 1 + get_font_height(Font);
-        ds->DrawRect(Rect(draw_at_x, draw_at_y, draw_at_x + get_fixed_pixel_size(5), draw_at_y + (get_fixed_pixel_size(1) - 1)), text_color);
+        ds->DrawRect(Rect(draw_at_x, draw_at_y, draw_at_x + cursor_width, draw_at_y + (get_fixed_pixel_size(1) - 1)), text_color);
     }
 }
 

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -95,6 +95,20 @@ namespace AGS
 namespace Common
 {
 
+String GUI::TransformTextForDrawing(const String &text, bool translate)
+{
+    String res_text = translate ? text : get_translation(text.GetCStr());
+    if (game.options[OPT_RIGHTLEFTWRITE] != 0)
+        (get_uformat() == U_UTF8) ? res_text.ReverseUTF8() : res_text.Reverse();
+    return res_text;
+}
+
+size_t GUI::SplitLinesForDrawing(const char *text, SplitLines &lines, int font, int width, size_t max_lines)
+{
+    // Use the engine's word wrap tool, to have RTL writing and other features
+    return break_up_text_into_lines(text, lines, width, font);
+}
+
 bool GUIObject::IsClickable() const
 {
     return (Flags & kGUICtrl_Clickable) != 0;
@@ -126,12 +140,6 @@ void GUILabel::PrepareTextToDraw()
     replace_macro_tokens(Flags & kGUICtrl_Translated ? get_translation(Text.GetCStr()) : Text.GetCStr(), _textToDraw);
 }
 
-size_t GUILabel::SplitLinesForDrawing(SplitLines &lines)
-{
-    // Use the engine's word wrap tool, to have hebrew-style writing and other features
-    return break_up_text_into_lines(_textToDraw.GetCStr(), lines, Width, Font);
-}
-
 void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_color)
 {
     wouttext_outline(ds, x + 1 + get_fixed_pixel_size(1), y + 1 + get_fixed_pixel_size(1), Font, text_color, Text.GetCStr());
@@ -146,18 +154,12 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_colo
 
 void GUIListBox::PrepareTextToDraw(const String &text)
 {
-    if (Flags & kGUICtrl_Translated)
-        _textToDraw = get_translation(text.GetCStr());
-    else
-        _textToDraw = text;
+     _textToDraw = GUI::TransformTextForDrawing(text, (Flags & kGUICtrl_Translated) != 0);
 }
 
 void GUIButton::PrepareTextToDraw()
 {
-    if (Flags & kGUICtrl_Translated)
-        _textToDraw = get_translation(_text.GetCStr());
-    else
-        _textToDraw = _text;
+    _textToDraw = GUI::TransformTextForDrawing(_text, (Flags & kGUICtrl_Translated) != 0);
 }
 
 } // namespace Common

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -155,6 +155,8 @@ void GUITextBox::DrawTextBoxContents(Bitmap *ds, int x, int y, color_t text_colo
 {
     _textToDraw = Text;
     bool reverse = false;
+    // Text boxes input is never "translated" in regular sense,
+    // but they use this flag to apply text direction
     if ((loaded_game_file_version >= kGameVersion_361) && ((Flags & kGUICtrl_Translated) != 0))
     {
         _textToDraw = GUI::ApplyTextDirection(Text);


### PR DESCRIPTION
I do not know the reasons, but historically AGS only reverses messages (incl speech), labels and wrapped drawn strings in RTL mode.

The purpose of this PR is to expand RTL render to other controls and text drawing operations:
* [x] Buttons,
* [x] List Boxes
* [x] Text Boxes(?)
* [x] Single string drawing command.
* [ ] Anything else I forgot about(?).

Also to decide:
* [x] ~Do we need a per-control setting that tells whether to apply RTL render?~ Alternatively, all GUI controls have a hidden "translated" flag, which is set by default, although only ListBox has a visible property in the editor (because list boxes may be used to store saves and other filenames, which must not be translated). We could make this flag tell whether to apply RTL as well.
* [ ] How to deal with a situation when original text has one RTL mode, translation has another, but is missing an entry. Should the original text be drawn in original mode instead? For example: English game with Hebrew translation. Currently RTL is applied unconditionally. Should it be applied according to whether the text is original or got from translation?
* [x] How to deal with backwards compatibility. If any rtl translation was created earlier, it must have accounted for this original behavior. If the behavior is changed now, that might break these translations.
