### PR TITLE
3.6.1: improve ScreenOverlays storage performance

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -748,7 +748,7 @@ void Character_SayAt(CharacterInfo *chaa, int x, int y, int width, const char *t
 ScriptOverlay* Character_SayBackground(CharacterInfo *chaa, const char *texx) {
 
     int ovltype = DisplaySpeechBackground(chaa->index_id, texx);
-    auto *over = find_overlay_of_type(ovltype);
+    auto *over = get_overlay(ovltype);
     if (!over)
         quit("!SayBackground internal error: no overlay");
     // Create script object with an internal ref, keep at least until internal timeout
@@ -2442,11 +2442,10 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
     {
         // remove any background speech
         auto &overs = get_overlays();
-        for (size_t i = 0; i < overs.size();) {
-            if (overs[i].timeout > 0)
-                remove_screen_overlay(overs[i].type);
-            else
-                i++;
+        for (auto &over : overs)
+        {
+            if (over.timeout > 0)
+                remove_screen_overlay(over.type);
         }
     }
     said_text = 1;

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -748,11 +748,11 @@ void Character_SayAt(CharacterInfo *chaa, int x, int y, int width, const char *t
 ScriptOverlay* Character_SayBackground(CharacterInfo *chaa, const char *texx) {
 
     int ovltype = DisplaySpeechBackground(chaa->index_id, texx);
-    int ovri = find_overlay_of_type(ovltype);
-    if (ovri<0)
+    auto *over = find_overlay_of_type(ovltype);
+    if (!over)
         quit("!SayBackground internal error: no overlay");
     // Create script object with an internal ref, keep at least until internal timeout
-    return create_scriptoverlay(screenover[ovri], true);
+    return create_scriptoverlay(*over, true);
 }
 
 void Character_SetAsPlayer(CharacterInfo *chaa) {
@@ -2438,11 +2438,13 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
 
     said_speech_line = 1;
 
-    if (play.bgspeech_stay_on_display == 0) {
+    if (play.bgspeech_stay_on_display == 0)
+    {
         // remove any background speech
-        for (size_t i = 0; i < screenover.size();) {
-            if (screenover[i].timeout > 0)
-                remove_screen_overlay(screenover[i].type);
+        auto &overs = get_overlays();
+        for (size_t i = 0; i < overs.size();) {
+            if (overs[i].timeout > 0)
+                remove_screen_overlay(overs[i].type);
             else
                 i++;
         }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -289,11 +289,12 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     }
 
     size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
+    auto &over = get_overlay(nse); // FIXME: optimize return value
     // we should not delete text_window_ds here, because it is now owned by Overlay
 
     // If it's a non-blocking overlay type, then we're done here
     if (disp_type >= DISPLAYTEXT_NORMALOVERLAY) {
-        return &screenover[nse];
+        return &over;
     }
 
     //
@@ -389,10 +390,10 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
 
         if (!overlayPositionFixed)
         {
-            screenover[nse].SetRoomRelative(true);
-            VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(screenover[nse].x, screenover[nse].y, false);
-            screenover[nse].x = vpt.first.X;
-            screenover[nse].y = vpt.first.Y;
+            over.SetRoomRelative(true);
+            VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(over.x, over.y, false);
+            over.x = vpt.first.X;
+            over.y = vpt.first.Y;
         }
 
         GameLoopUntilNoOverlay();

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -289,12 +289,12 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
     }
 
     size_t nse = add_screen_overlay(roomlayer, xx, yy, ovrtype, text_window_ds, adjustedXX - xx, adjustedYY - yy, alphaChannel);
-    auto &over = get_overlay(nse); // FIXME: optimize return value
+    auto *over = get_overlay(nse); // FIXME: optimize return value
     // we should not delete text_window_ds here, because it is now owned by Overlay
 
     // If it's a non-blocking overlay type, then we're done here
     if (disp_type >= DISPLAYTEXT_NORMALOVERLAY) {
-        return &over;
+        return over;
     }
 
     //
@@ -390,10 +390,10 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
 
         if (!overlayPositionFixed)
         {
-            over.SetRoomRelative(true);
-            VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(over.x, over.y, false);
-            over.x = vpt.first.X;
-            over.y = vpt.first.Y;
+            over->SetRoomRelative(true);
+            VpPoint vpt = play.GetRoomViewport(0)->ScreenToRoom(over->x, over->y, false);
+            over->x = vpt.first.X;
+            over->y = vpt.first.Y;
         }
 
         GameLoopUntilNoOverlay();

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1898,9 +1898,9 @@ void add_walkbehind_image(size_t index, Common::Bitmap *bmp, int x, int y)
 // Add active room overlays to the sprite list
 static void add_roomovers_for_drawing()
 {
-    for (size_t i = 0; i < screenover.size(); ++i)
+    const auto &overs = get_overlays();
+    for (const auto &over : overs)
     {
-        auto &over = screenover[i];
         if (!over.IsRoomLayer()) continue; // not a room layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
@@ -2146,9 +2146,9 @@ void draw_gui_and_overlays()
 
     const bool is_software_mode = !gfxDriver->HasAcceleratedTransform();
     // Add active overlays to the sprite list
-    for (size_t i = 0; i < screenover.size(); ++i)
+    const auto &overs = get_overlays();
+    for (const auto &over : overs)
     {
-        auto &over = screenover[i];
         if (over.IsRoomLayer()) continue; // not a ui layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
@@ -2372,14 +2372,15 @@ static void construct_ui_view()
 static void construct_overlays()
 {
     const bool is_software_mode = !gfxDriver->HasAcceleratedTransform();
-    if (overlaybmp.size() < screenover.size())
+    auto &overs = get_overlays();
+    if (overlaybmp.size() < overs.size())
     {
-        overlaybmp.resize(screenover.size());
-        screenovercache.resize(screenover.size());
+        overlaybmp.resize(overs.size());
+        screenovercache.resize(overs.size());
     }
-    for (size_t i = 0; i < screenover.size(); ++i)
+    for (size_t i = 0; i < overs.size(); ++i)
     {
-        auto &over = screenover[i];
+        auto &over = overs[i];
         if (over.transparency == 255) continue; // skip fully transparent
 
         bool has_changed = over.HasChanged();

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1901,6 +1901,7 @@ static void add_roomovers_for_drawing()
     const auto &overs = get_overlays();
     for (const auto &over : overs)
     {
+        if (over.type < 0) continue; // empty slot
         if (!over.IsRoomLayer()) continue; // not a room layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
@@ -2149,6 +2150,7 @@ void draw_gui_and_overlays()
     const auto &overs = get_overlays();
     for (const auto &over : overs)
     {
+        if (over.type < 0) continue; // empty slot
         if (over.IsRoomLayer()) continue; // not a ui layer
         if (over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
@@ -2381,6 +2383,7 @@ static void construct_overlays()
     for (size_t i = 0; i < overs.size(); ++i)
     {
         auto &over = overs[i];
+        if (over.type < 0) continue; // empty slot
         if (over.transparency == 255) continue; // skip fully transparent
 
         bool has_changed = over.HasChanged();

--- a/Engine/ac/dynobj/scriptoverlay.cpp
+++ b/Engine/ac/dynobj/scriptoverlay.cpp
@@ -29,10 +29,10 @@ int ScriptOverlay::Dispose(void* /*address*/, bool force)
     // with that handle later
     if (overlayId >= 0)
     {
-        int overlayIndex = find_overlay_of_type(overlayId);
-        if (overlayIndex >= 0)
+        auto *over = find_overlay_of_type(overlayId);
+        if (over)
         {
-            screenover[overlayIndex].associatedOverlayHandle = 0;
+            over->associatedOverlayHandle = 0;
         }
     }
 
@@ -74,7 +74,7 @@ void ScriptOverlay::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
 
 void ScriptOverlay::Remove() 
 {
-    int overlayIndex = find_overlay_of_type(overlayId);
+    int overlayIndex = find_overlay_index(overlayId);
     if (overlayIndex < 0)
     {
         debug_script_warn("Overlay.Remove: overlay is invalid, could have been removed earlier.");

--- a/Engine/ac/dynobj/scriptoverlay.cpp
+++ b/Engine/ac/dynobj/scriptoverlay.cpp
@@ -29,7 +29,7 @@ int ScriptOverlay::Dispose(void* /*address*/, bool force)
     // with that handle later
     if (overlayId >= 0)
     {
-        auto *over = find_overlay_of_type(overlayId);
+        auto *over = get_overlay(overlayId);
         if (over)
         {
             over->associatedOverlayHandle = 0;
@@ -74,12 +74,11 @@ void ScriptOverlay::Unserialize(int index, Stream *in, size_t /*data_sz*/) {
 
 void ScriptOverlay::Remove() 
 {
-    int overlayIndex = find_overlay_index(overlayId);
-    if (overlayIndex < 0)
+    if (overlayId < 0)
     {
         debug_script_warn("Overlay.Remove: overlay is invalid, could have been removed earlier.");
         return;
     }
-    remove_screen_overlay_index(overlayIndex);
+    remove_screen_overlay(overlayId);
     overlayId = -1;
 }

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -1424,7 +1424,8 @@ void game_sprite_updated(int sprnum)
         }
     }
     // overlays
-    for (auto &over : screenover)
+    auto &overs = get_overlays();
+    for (auto &over : overs)
     {
         if (over.GetSpriteNum() == sprnum)
             over.MarkChanged();
@@ -1507,7 +1508,8 @@ void game_sprite_deleted(int sprnum)
         }
     }
     // overlays
-    for (auto &over : screenover)
+    auto &overs = get_overlays();
+    for (auto &over : overs)
     {
         if (over.GetSpriteNum() == sprnum)
             over.SetSpriteNum(0);

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -531,18 +531,21 @@ void DisplaySpeechAt (int xx, int yy, int wii, int aschar, const char*spch) {
 
 int DisplaySpeechBackground(int charid, const char*speel) {
     // remove any previous background speech for this character
-    for (size_t i = 0; i < screenover.size();) {
-        if (screenover[i].bgSpeechForChar == charid)
+    const auto &overs = get_overlays();
+    for (size_t i = 0; i < overs.size(); ++i)
+    {
+        if (overs[i].bgSpeechForChar == charid)
+        {
             remove_screen_overlay_index(i);
-        else
-            i++;
+            break;
+        }
     }
 
     int ovrl=CreateTextOverlay(OVR_AUTOPLACE,charid,play.GetUIViewport().GetWidth()/2,FONT_SPEECH,
         -game.chars[charid].talkcolor, get_translation(speel), DISPLAYTEXT_NORMALOVERLAY);
 
-    int scid = find_overlay_of_type(ovrl);
-    screenover[scid].bgSpeechForChar = charid;
-    screenover[scid].timeout = GetTextDisplayTime(speel, 1);
+    auto *over = find_overlay_of_type(ovrl);
+    over->bgSpeechForChar = charid;
+    over->timeout = GetTextDisplayTime(speel, 1);
     return ovrl;
 }

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -531,12 +531,13 @@ void DisplaySpeechAt (int xx, int yy, int wii, int aschar, const char*spch) {
 
 int DisplaySpeechBackground(int charid, const char*speel) {
     // remove any previous background speech for this character
+    // TODO: have a map character -> bg speech over?
     const auto &overs = get_overlays();
     for (size_t i = 0; i < overs.size(); ++i)
     {
         if (overs[i].bgSpeechForChar == charid)
         {
-            remove_screen_overlay_index(i);
+            remove_screen_overlay(i);
             break;
         }
     }
@@ -544,7 +545,7 @@ int DisplaySpeechBackground(int charid, const char*speel) {
     int ovrl=CreateTextOverlay(OVR_AUTOPLACE,charid,play.GetUIViewport().GetWidth()/2,FONT_SPEECH,
         -game.chars[charid].talkcolor, get_translation(speel), DISPLAYTEXT_NORMALOVERLAY);
 
-    auto *over = find_overlay_of_type(ovrl);
+    auto *over = get_overlay(ovrl);
     over->bgSpeechForChar = charid;
     over->timeout = GetTextDisplayTime(speel, 1);
     return ovrl;

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -55,10 +55,11 @@ void SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int text_col
 void MoveOverlay(int ovrid, int newx,int newy) {
     data_to_game_coords(&newx, &newy);
 
-    int ovri=find_overlay_of_type(ovrid);
-    if (ovri<0) quit("!MoveOverlay: invalid overlay ID specified");
-    screenover[ovri].x=newx;
-    screenover[ovri].y=newy;
+    auto *over = find_overlay_of_type(ovrid);
+    if (!over)
+        quit("!MoveOverlay: invalid overlay ID specified");
+    over->x = newx;
+    over->y = newy;
 }
 
 int IsOverlayValid(int ovrid) {

--- a/Engine/ac/global_overlay.cpp
+++ b/Engine/ac/global_overlay.cpp
@@ -19,7 +19,8 @@
 
 
 void RemoveOverlay(int ovrid) {
-    if (find_overlay_of_type(ovrid) < 0) quit("!RemoveOverlay: invalid overlay id passed");
+    if (!get_overlay(ovrid))
+        quit("!RemoveOverlay: invalid overlay id passed");
     remove_screen_overlay(ovrid);
 }
 
@@ -55,7 +56,7 @@ void SetTextOverlay(int ovrid, int xx, int yy, int wii, int fontid, int text_col
 void MoveOverlay(int ovrid, int newx,int newy) {
     data_to_game_coords(&newx, &newy);
 
-    auto *over = find_overlay_of_type(ovrid);
+    auto *over = get_overlay(ovrid);
     if (!over)
         quit("!MoveOverlay: invalid overlay ID specified");
     over->x = newx;
@@ -63,8 +64,5 @@ void MoveOverlay(int ovrid, int newx,int newy) {
 }
 
 int IsOverlayValid(int ovrid) {
-    if (find_overlay_of_type(ovrid) < 0)
-        return 0;
-
-    return 1;
+    return (get_overlay(ovrid) != nullptr) ? 1 : 0;
 }

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -361,9 +361,8 @@ static void dispose_overlay(ScreenOverlay &over)
 
 void remove_screen_overlay(int type)
 {
-    assert(type >= 0 && type < screenover.size());
-    if (type < 0 || type >= screenover.size() || screenover[type].type < 0)
-        return; // something is wrong
+    if (type < 0 || static_cast<uint32_t>(type) >= screenover.size() || screenover[type].type < 0)
+        return; // requested non-existing overlay
 
     ScreenOverlay &over = screenover[type];
     // TODO: move these custom settings outside of this function
@@ -397,14 +396,14 @@ void remove_screen_overlay(int type)
 
 void remove_all_overlays()
 {
-    for (int i = 0; i < screenover.size(); ++i)
-        remove_screen_overlay(i);
+    for (auto &over : screenover)
+        remove_screen_overlay(over.type);
 }
 
-ScreenOverlay *get_overlay(int index)
+ScreenOverlay *get_overlay(int type)
 {
-    assert(index >= 0 && index < screenover.size());
-    return (index >= 0 && index < screenover.size()) ? &screenover[index] : nullptr;
+    return (type >= 0 && static_cast<uint32_t>(type) < screenover.size() &&
+        screenover[type].type >= 0) ? &screenover[type] : nullptr;
 }
 
 size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum, Bitmap *piccy,
@@ -424,7 +423,7 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
         }
     }
 
-    if (screenover.size() <= type)
+    if (screenover.size() <= static_cast<uint32_t>(type))
         screenover.resize(type + 1);
 
     ScreenOverlay over;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -52,12 +52,11 @@ void Overlay_Remove(ScriptOverlay *sco) {
 
 void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_color, const char *text)
 {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!Overlay.SetText: invalid overlay ID specified");
-    auto &over = screenover[ovri];
-    const int x = over.x;
-    const int y = over.y;
+    const int x = over->x;
+    const int y = over->y;
 
     // TODO: find a nice way to refactor and share these code pieces
     // from CreateTextOverlay
@@ -78,50 +77,50 @@ void Overlay_SetText(ScriptOverlay *scover, int width, int fontid, int text_colo
         width, fontid, allow_shrink, has_alpha);
 
     // Update overlay properties
-    over.SetImage(std::unique_ptr<Bitmap>(image), adj_x - dummy_x, adj_y - dummy_y);
-    over.SetAlphaChannel(has_alpha);
-    over.ddb = nullptr; // is generated during first draw pass
+    over->SetImage(std::unique_ptr<Bitmap>(image), adj_x - dummy_x, adj_y - dummy_y);
+    over->SetAlphaChannel(has_alpha);
+    over->ddb = nullptr; // is generated during first draw pass
 }
 
 int Overlay_GetX(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    Point pos = get_overlay_position(screenover[ovri]);
+    Point pos = get_overlay_position(*over);
     return game_to_data_coord(pos.X);
 }
 
 void Overlay_SetX(ScriptOverlay *scover, int newx) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    screenover[ovri].x = data_to_game_coord(newx);
+    over->x = data_to_game_coord(newx);
 }
 
 int Overlay_GetY(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    Point pos = get_overlay_position(screenover[ovri]);
+    Point pos = get_overlay_position(*over);
     return game_to_data_coord(pos.Y);
 }
 
 void Overlay_SetY(ScriptOverlay *scover, int newy) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    screenover[ovri].y = data_to_game_coord(newy);
+    over->y = data_to_game_coord(newy);
 }
 
 int Overlay_GetGraphic(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return screenover[ovri].GetSpriteNum();
+    return over->GetSpriteNum();
 }
 
 void Overlay_SetGraphic(ScriptOverlay *scover, int slot) {
@@ -130,45 +129,45 @@ void Overlay_SetGraphic(ScriptOverlay *scover, int slot) {
         debug_script_warn("Overlay.SetGraphic: sprite %d is invalid", slot);
         slot = 0;
     }
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    screenover[ovri].SetSpriteNum(slot);
+    over->SetSpriteNum(slot);
 }
 
 bool Overlay_InRoom(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return screenover[ovri].IsRoomLayer();
+    return over->IsRoomLayer();
 }
 
 int Overlay_GetWidth(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].scaleWidth);
+    return game_to_data_coord(over->scaleWidth);
 }
 
 int Overlay_GetHeight(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].scaleHeight);
+    return game_to_data_coord(over->scaleHeight);
 }
 
 int Overlay_GetGraphicWidth(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].GetImage()->GetWidth());
+    return game_to_data_coord(over->GetImage()->GetWidth());
 }
 
 int Overlay_GetGraphicHeight(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    return game_to_data_coord(screenover[ovri].GetImage()->GetHeight());
+    return game_to_data_coord(over->GetImage()->GetHeight());
 }
 
 void Overlay_SetScaledSize(ScreenOverlay &over, int width, int height) {
@@ -186,17 +185,17 @@ void Overlay_SetScaledSize(ScreenOverlay &over, int width, int height) {
 }
 
 void Overlay_SetWidth(ScriptOverlay *scover, int width) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    Overlay_SetScaledSize(screenover[ovri], width, game_to_data_coord(screenover[ovri].scaleHeight));
+    Overlay_SetScaledSize(*over, width, game_to_data_coord(over->scaleHeight));
 }
 
 void Overlay_SetHeight(ScriptOverlay *scover, int height) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
-    Overlay_SetScaledSize(screenover[ovri], game_to_data_coord(screenover[ovri].scaleWidth), height);
+    Overlay_SetScaledSize(*over, game_to_data_coord(over->scaleWidth), height);
 }
 
 int Overlay_GetValid(ScriptOverlay *scover) {
@@ -277,37 +276,37 @@ ScriptOverlay* Overlay_CreateRoomTextual(int x, int y, int width, int font, int 
 }
 
 int Overlay_GetTransparency(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    return GfxDef::LegacyTrans255ToTrans100(screenover[ovri].transparency);
+    return GfxDef::LegacyTrans255ToTrans100(over->transparency);
 }
 
 void Overlay_SetTransparency(ScriptOverlay *scover, int trans) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
     if ((trans < 0) | (trans > 100))
         quit("!SetTransparency: transparency value must be between 0 and 100");
 
-    screenover[ovri].transparency = GfxDef::Trans100ToLegacyTrans255(trans);
+    over->transparency = GfxDef::Trans100ToLegacyTrans255(trans);
 }
 
 int Overlay_GetZOrder(ScriptOverlay *scover) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    return screenover[ovri].zorder;
+    return over->zorder;
 }
 
 void Overlay_SetZOrder(ScriptOverlay *scover, int zorder) {
-    int ovri = find_overlay_of_type(scover->overlayId);
-    if (ovri < 0)
+    auto *over = find_overlay_of_type(scover->overlayId);
+    if (!over)
         quit("!invalid overlay ID specified");
 
-    screenover[ovri].zorder = zorder;
+    over->zorder = zorder;
 }
 
 //=============================================================================
@@ -403,7 +402,13 @@ void remove_screen_overlay(int type)
     }
 }
 
-int find_overlay_of_type(int type)
+ScreenOverlay &get_overlay(int index)
+{
+    assert(index >= 0 && index < screenover.size());
+    return screenover[index];
+}
+
+int find_overlay_index(int type)
 {
     assert(type >= 0);
     int idx = overlookup[type];
@@ -420,6 +425,12 @@ int find_overlay_of_type(int type)
     return -1;
 }
 
+ScreenOverlay *find_overlay_of_type(int type)
+{
+    int idx = find_overlay_index(type);
+    return idx >= 0 ? &screenover[idx] : nullptr;
+}
+
 size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnum, Bitmap *piccy,
     int pic_offx, int pic_offy, bool has_alpha)
 {
@@ -429,7 +440,7 @@ size_t add_screen_overlay_impl(bool roomlayer, int x, int y, int type, int sprnu
     if (type == OVER_CUSTOM) {
         // find an unused custom ID; TODO: find a better approach!
         for (int id = OVER_CUSTOM + 1; (size_t)id <= screenover.size() + OVER_CUSTOM + 1; ++id) {
-            if (find_overlay_of_type(id) == -1) { type=id; break; }
+            if (find_overlay_of_type(id) == nullptr) { type=id; break; }
         }
     }
     ScreenOverlay over;
@@ -550,6 +561,11 @@ void recreate_overlay_ddbs()
         over.ddb = nullptr; // is generated during first draw pass
         over.MarkChanged();
     }
+}
+
+std::vector<ScreenOverlay> &get_overlays()
+{
+    return screenover;
 }
 
 //=============================================================================

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -38,7 +38,9 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
     const char *text, int disp_type, int allow_shrink);
 
-int  find_overlay_of_type(int type);
+ScreenOverlay &get_overlay(int index);
+ScreenOverlay *find_overlay_of_type(int type);
+int find_overlay_index(int type);
 void remove_screen_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)
 Point get_overlay_position(const ScreenOverlay &over);
@@ -51,6 +53,7 @@ void remove_screen_overlay_index(size_t over_idx);
 ScriptOverlay* create_scriptoverlay(ScreenOverlay &over, bool internal_ref = false);
 void recreate_overlay_ddbs();
 
+std::vector<ScreenOverlay> &get_overlays();
 
-extern std::vector<ScreenOverlay> screenover;
+
 #endif // __AGS_EE_AC__OVERLAY_H

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -38,20 +38,19 @@ ScreenOverlay *Overlay_CreateGraphicCore(bool room_layer, int x, int y, int slot
 ScreenOverlay *Overlay_CreateTextCore(bool room_layer, int x, int y, int width, int font, int text_color,
     const char *text, int disp_type, int allow_shrink);
 
-ScreenOverlay &get_overlay(int index);
-ScreenOverlay *find_overlay_of_type(int type);
-int find_overlay_index(int type);
-void remove_screen_overlay(int type);
+ScreenOverlay *get_overlay(int type);
 // Calculates overlay position in its respective layer (screen or room)
 Point get_overlay_position(const ScreenOverlay &over);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, int sprnum);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, bool has_alpha);
 size_t add_screen_overlay(bool roomlayer, int x, int y, int type, Common::Bitmap *piccy, int pic_offx, int pic_offy, bool has_alpha);
-void remove_screen_overlay_index(size_t over_idx);
+void remove_screen_overlay(int type);
+void remove_all_overlays();
 // Creates and registers a managed script object for existing overlay object;
 // optionally adds an internal engine reference to prevent object's disposal
 ScriptOverlay* create_scriptoverlay(ScreenOverlay &over, bool internal_ref = false);
-void recreate_overlay_ddbs();
+// Restores overlays, e.g. after restoring a game save
+void restore_overlays();
 
 std::vector<ScreenOverlay> &get_overlays();
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -304,7 +304,7 @@ void unload_old_room() {
     memset(&play.walkable_areas_on[0],1,MAX_WALK_AREAS+1);
     play.bg_frame = 0;
     play.bg_frame_locked = 0;
-    remove_screen_overlay(-1);
+    remove_all_overlays();
     delete raw_saved_screen;
     raw_saved_screen = nullptr;
     for (int ff = 0; ff < MAX_ROOM_BGFRAMES; ff++)

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -100,15 +100,20 @@ const int LegacyRoomVolumeFactor            = 30;
 #define MODE_CUSTOM1 8
 #define MODE_CUSTOM2 9
 
+// Fixed Overlay IDs
 #define OVER_TEXTMSG  1
 #define OVER_COMPLETE 2
 #define OVER_PICTURE  3
 #define OVER_TEXTSPEECH 4
-#define OVER_CUSTOM   100
+#define OVER_FIRSTFREE 5
+#define OVER_CUSTOM   -1
+// Overlay parameters
 #define OVR_AUTOPLACE 30000
+
 #define FOR_ANIMATION 1
 #define FOR_SCRIPT    2
 #define FOR_EXITLOOP  3
+
 // an actsps index offset for characters
 #define ACTSP_OBJSOFF (MAX_ROOM_OBJECTS)
 // a 1-based movelist index offset for characters

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -41,7 +41,7 @@ struct ScreenOverlay
 {
     // Texture
     Engine::IDriverDependantBitmap *ddb = nullptr;
-    int type = 0, timeout = 0;
+    int type = -1, timeout = 0;
     // Note that x,y are overlay's properties, that define its position in script;
     // but real drawn position is x + offsetX, y + offsetY;
     int x = 0, y = 0;

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -374,7 +374,7 @@ void DoBeforeRestore(PreservedParams &pp)
     unload_old_room();
     delete raw_saved_screen;
     raw_saved_screen = nullptr;
-    remove_screen_overlay(-1);
+    remove_all_overlays();
     play.complete_overlay_on = 0;
     play.text_overlay_on = 0;
 
@@ -658,7 +658,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, const RestoredData &r_data)
 
     adjust_fonts_for_render_mode(game.options[OPT_ANTIALIASFONTS] != 0);
 
-    recreate_overlay_ddbs();
+    restore_overlays();
 
     GUI::MarkAllGUIForUpdate(true, true);
 

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -886,7 +886,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
             over.scaleWidth = over.GetImage()->GetWidth();
             over.scaleHeight = over.GetImage()->GetHeight();
         }
-        if (overs.size() <= over.type)
+        if (overs.size() <= static_cast<uint32_t>(over.type))
             overs.resize(over.type + 1);
         overs[over.type] = std::move(over);
     }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -877,7 +877,8 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
         ScreenOverlay over;
         bool has_bitmap;
         over.ReadFromFile(in, has_bitmap, cmp_ver);
-        assert(over.type >= 0);
+        if (over.type < 0)
+            continue; // safety abort
         if (has_bitmap)
             over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)), over.offsetX, over.offsetY);
         if (has_bitmap && (over.scaleWidth <= 0 || over.scaleHeight <= 0))

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -867,7 +867,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
         over.ReadFromFile(in, has_bitmap, cmp_ver);
         if (has_bitmap)
             over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)), over.offsetX, over.offsetY);
-        if (over.scaleWidth <= 0 || over.scaleHeight <= 0)
+        if (has_bitmap && (over.scaleWidth <= 0 || over.scaleHeight <= 0))
         {
             over.scaleWidth = over.GetImage()->GetWidth();
             over.scaleHeight = over.GetImage()->GetHeight();

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -846,25 +846,38 @@ HSaveError ReadDynamicSprites(Stream *in, int32_t /*cmp_ver*/, const PreservedPa
 HSaveError WriteOverlays(Stream *out)
 {
     const auto &overs = get_overlays();
-    out->WriteInt32(overs.size());
+    // Calculate and save valid overlays only
+    uint32_t valid_count = 0;
+    soff_t count_off = out->GetPosition();
+    out->WriteInt32(0);
     for (const auto &over : overs)
     {
+        if (over.type < 0)
+            continue;
+        valid_count++;
         over.WriteToFile(out);
         if (!over.IsSpriteReference())
             serialize_bitmap(over.GetImage(), out);
     }
+    out->Seek(count_off, kSeekBegin);
+    out->WriteInt32(valid_count);
+    out->Seek(0, kSeekEnd);
     return HSaveError::None();
 }
 
 HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
+    // Remember that overlay indexes may be non-sequential
+    // the vector may be resized during read
     size_t over_count = in->ReadInt32();
     auto &overs = get_overlays();
+    overs.resize(over_count); // reserve minimal size
     for (size_t i = 0; i < over_count; ++i)
     {
         ScreenOverlay over;
         bool has_bitmap;
         over.ReadFromFile(in, has_bitmap, cmp_ver);
+        assert(over.type >= 0);
         if (has_bitmap)
             over.SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)), over.offsetX, over.offsetY);
         if (has_bitmap && (over.scaleWidth <= 0 || over.scaleHeight <= 0))
@@ -872,7 +885,9 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
             over.scaleWidth = over.GetImage()->GetWidth();
             over.scaleHeight = over.GetImage()->GetHeight();
         }
-        overs.push_back(std::move(over));
+        if (overs.size() <= over.type)
+            overs.resize(over.type + 1);
+        overs[over.type] = std::move(over);
     }
     return HSaveError::None();
 }

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -845,8 +845,9 @@ HSaveError ReadDynamicSprites(Stream *in, int32_t /*cmp_ver*/, const PreservedPa
 
 HSaveError WriteOverlays(Stream *out)
 {
-    out->WriteInt32(screenover.size());
-    for (const auto &over : screenover)
+    const auto &overs = get_overlays();
+    out->WriteInt32(overs.size());
+    for (const auto &over : overs)
     {
         over.WriteToFile(out);
         if (!over.IsSpriteReference())
@@ -858,6 +859,7 @@ HSaveError WriteOverlays(Stream *out)
 HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp*/, RestoredData& /*r_data*/)
 {
     size_t over_count = in->ReadInt32();
+    auto &overs = get_overlays();
     for (size_t i = 0; i < over_count; ++i)
     {
         ScreenOverlay over;
@@ -870,7 +872,7 @@ HSaveError ReadOverlays(Stream *in, int32_t cmp_ver, const PreservedParams& /*pp
             over.scaleWidth = over.GetImage()->GetWidth();
             over.scaleHeight = over.GetImage()->GetHeight();
         }
-        screenover.push_back(std::move(over));
+        overs.push_back(std::move(over));
     }
     return HSaveError::None();
 }

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -312,6 +312,9 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
         bool has_bm;
         ScreenOverlay over;
         over.ReadFromFile(&align_s, has_bm, 0);
+        align_s.Reset();
+        if (over.type < 0)
+            continue; // safety abort
         if (overs.size() <= over.type)
         {
             overs.resize(over.type + 1);
@@ -319,7 +322,6 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
         }
         overs[over.type] = std::move(over);
         has_bitmap[over.type] = has_bm;
-        align_s.Reset();
     }
 }
 

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -315,7 +315,7 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
         align_s.Reset();
         if (over.type < 0)
             continue; // safety abort
-        if (overs.size() <= over.type)
+        if (overs.size() <= static_cast<uint32_t>(over.type))
         {
             overs.resize(over.type + 1);
             has_bitmap.resize(over.type + 1);

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -305,12 +305,20 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
 {
     AlignedStream align_s(in, Common::kAligned_Read);
     has_bitmap.resize(num_overs);
+    // Remember that overlay indexes may be non-sequential
     auto &overs = get_overlays();
     for (size_t i = 0; i < num_overs; ++i)
     {
         bool has_bm;
-        overs[i].ReadFromFile(&align_s, has_bm, 0);
-        has_bitmap[i] = has_bm;
+        ScreenOverlay over;
+        over.ReadFromFile(&align_s, has_bm, 0);
+        if (overs.size() <= over.type)
+        {
+            overs.resize(over.type + 1);
+            has_bitmap.resize(over.type + 1);
+        }
+        overs[over.type] = std::move(over);
+        has_bitmap[over.type] = has_bm;
         align_s.Reset();
     }
 }
@@ -318,11 +326,13 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
 static void restore_game_overlays(Stream *in)
 {
     size_t num_overs = in->ReadInt32();
+    // Remember that overlay indexes may be not sequential,
+    // the vector may be resized during read
     auto &overs = get_overlays();
     overs.resize(num_overs);
-    std::vector<bool> has_bitmap;
+    std::vector<bool> has_bitmap(num_overs);
     ReadOverlays_Aligned(in, has_bitmap, num_overs);
-    for (size_t i = 0; i < num_overs; ++i) {
+    for (size_t i = 0; i < overs.size(); ++i) {
         if (has_bitmap[i])
             overs[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)),
                 overs[i].offsetX, overs[i].offsetY);

--- a/Engine/game/savegame_v321.cpp
+++ b/Engine/game/savegame_v321.cpp
@@ -305,10 +305,11 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
 {
     AlignedStream align_s(in, Common::kAligned_Read);
     has_bitmap.resize(num_overs);
+    auto &overs = get_overlays();
     for (size_t i = 0; i < num_overs; ++i)
     {
         bool has_bm;
-        screenover[i].ReadFromFile(&align_s, has_bm, 0);
+        overs[i].ReadFromFile(&align_s, has_bm, 0);
         has_bitmap[i] = has_bm;
         align_s.Reset();
     }
@@ -317,13 +318,14 @@ static void ReadOverlays_Aligned(Stream *in, std::vector<bool> &has_bitmap, size
 static void restore_game_overlays(Stream *in)
 {
     size_t num_overs = in->ReadInt32();
-    screenover.resize(num_overs);
+    auto &overs = get_overlays();
+    overs.resize(num_overs);
     std::vector<bool> has_bitmap;
     ReadOverlays_Aligned(in, has_bitmap, num_overs);
     for (size_t i = 0; i < num_overs; ++i) {
         if (has_bitmap[i])
-            screenover[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)),
-                screenover[i].offsetX, screenover[i].offsetY);
+            overs[i].SetImage(std::unique_ptr<Bitmap>(read_serialized_bitmap(in)),
+                overs[i].offsetX, overs[i].offsetY);
     }
 }
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -235,10 +235,13 @@ void update_following_exactly_characters(const std::vector<int> &followingAsShee
 void update_overlay_timers()
 {
 	// update overlay timers
-  for (size_t i = 0; i < screenover.size();) {
-    if (screenover[i].timeout > 0) {
-      screenover[i].timeout--;
-      if (screenover[i].timeout == 0)
+  auto &overs = get_overlays();
+  for (size_t i = 0; i < overs.size();)
+  {
+    auto &over = overs[i];
+    if (over.timeout > 0) {
+      over.timeout--;
+      if (over.timeout == 0)
       {
         remove_screen_overlay_index(i);
         continue;
@@ -423,7 +426,8 @@ void update_sierra_speech()
       int view_frame_x = 0;
       int view_frame_y = 0;
 
-      Bitmap *frame_pic = screenover[face_talking].GetImage();
+      auto &face_over = get_overlay(face_talking);
+      Bitmap *frame_pic = face_over.GetImage();
       if (game.options[OPT_SPEECHTYPE] == 3) {
         // QFG4-style fullscreen dialog
         if (facetalk_qfg4_override_placement_x)
@@ -455,8 +459,8 @@ void update_sierra_speech()
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }
 
-      screenover[face_talking].SetAlphaChannel(face_has_alpha);
-      screenover[face_talking].MarkChanged();
+      face_over.SetAlphaChannel(face_has_alpha);
+      face_over.MarkChanged();
     }  // end if updatedFrame
   }
 }

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -236,18 +236,15 @@ void update_overlay_timers()
 {
 	// update overlay timers
   auto &overs = get_overlays();
-  for (size_t i = 0; i < overs.size();)
+  for (auto &over : overs)
   {
-    auto &over = overs[i];
     if (over.timeout > 0) {
       over.timeout--;
       if (over.timeout == 0)
       {
-        remove_screen_overlay_index(i);
-        continue;
+        remove_screen_overlay(over.type);
       }
     }
-    i++;
   }
 }
 
@@ -426,8 +423,9 @@ void update_sierra_speech()
       int view_frame_x = 0;
       int view_frame_y = 0;
 
-      auto &face_over = get_overlay(face_talking);
-      Bitmap *frame_pic = face_over.GetImage();
+      auto *face_over = get_overlay(face_talking);
+      assert(face_over != nullptr);
+      Bitmap *frame_pic = face_over->GetImage();
       if (game.options[OPT_SPEECHTYPE] == 3) {
         // QFG4-style fullscreen dialog
         if (facetalk_qfg4_override_placement_x)
@@ -459,8 +457,8 @@ void update_sierra_speech()
         DrawViewFrame(frame_pic, blink_vf, view_frame_x, view_frame_y, face_has_alpha);
       }
 
-      face_over.SetAlphaChannel(face_has_alpha);
-      face_over.MarkChanged();
+      face_over->SetAlphaChannel(face_has_alpha);
+      face_over->MarkChanged();
     }  // end if updatedFrame
   }
 }


### PR DESCRIPTION
Fixes #2045.

Implemented variant 2, mentioned in the issue ticket.
I might also try variant 1 (hashmap) later to see if that makes things faster or more convenient.

In variant 2, we keep ScreenOverlays in std::vector, but do not erase elements in the middle and invalidate them instead. Record free indexes in a helper stack. When creating a new overlay, first check for the recorded free indexes.
Overlay's type now equals storage index, thus no need to search for overlay of certain type anymore.

This speeds up both creation/deletion of overlays, and their access.

Removed the gap between "fixed" overlay types and custom ones, to save space. If we ever need more special overlays, these could be created as custom and their ids saved in a variable (similar to how background speech works).
Previously present special overlay types are left for backwards compatibility (and to simplify the transition).

Was testing with this game:
[test--361-overlayperformance.zip](https://github.com/adventuregamestudio/ags/files/11851527/test--361-overlayperformance.zip)
[test--361-overlayperformance-project.zip](https://github.com/adventuregamestudio/ags/files/11851528/test--361-overlayperformance-project.zip)
On startup it creates 1000 overlays, then starts randomly moving them around, thus accessing X,Y properties.
On "Space" press it toggles the "recreation" mode, where it deletes 1 random overlay and creates new 1 overlay each game frame. (Another test was done adjusting this to 10 recreated overlays per frame)

FPS comparison (in the "infinite fps" mode):

Engine | Moving 100 per frame | Recreating 1 per frame | Recreating 10 per frame
---|---|---|---
3.6.1.1 | 600 | 560 | 340
recent master | 650 | 600 | 380
this PR | 650 | 645 | 615
hashmap | 640 | 630 | 610

Needs more testing, as certain algorithms have changed.

UPDATE: Made a hashmap variant: https://github.com/ivan-mogilko/ags-refactoring/tree/361--overlayperf3-hashmap
So far it looks like hashmap works slightly slower in this case. Also it possibly breaks backward-compatible z-order when drawing too, because the order of overlays in container is undefined.

