### PR TITLE
Emscripten: Fix Safari can't Fullscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,7 @@
 *.iml
 .idea/
 # CLion
-cmake-build-debug/
-cmake-build-release/
+cmake-build-*/
 
 # Android Studio 3 in .gitignore file.
 .idea/caches

--- a/Emscripten/README.md
+++ b/Emscripten/README.md
@@ -13,14 +13,16 @@ You will also need to install and add to your path
 - [cmake](https://cmake.org/), any CMake above 3.16.3 should be fine, but the newer, the better on Windows
 - [ninja](https://ninja-build.org/), this is a portable binary so just put it in an empty directory for your user and add that directory to your path
 
-### Linux
-On Linux you will need Python3, anything above 3.6.5 should be fine, [see this for more info](https://github.com/emscripten-core/emscripten/issues/6275)
+### Linux or macOS
+On Linux or macOS you will need Python3, anything above 3.6.5 should be fine, [see this for more info](https://github.com/emscripten-core/emscripten/issues/6275)
 
 You will also need
 
 - git
 - cmake, any CMake above 3.16.3 should be fine.
 - make
+
+You can install these using your system package manager on Linux or brew on macOS.
 
 ### Other OSes
 
@@ -74,6 +76,10 @@ If you are on Windows, just use ninja
 	
 This may take a while, the first time you run this it will also download and build all Emscripten STD library and dependencies. After it's done you should see an `ags.wasm`, `ags.js` and `ags.html` file in `build-web-release` directory. 
 
+## Using IDE with CMake support
+
+You may pass the Emscripten toolchain file in a new profile where you set the CMake variables, using 
+`-DCMAKE_TOOLCHAIN_FILE=./Emscripten/emscripten/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake`.
 
 ## Running
 

--- a/Emscripten/launcher_index.html
+++ b/Emscripten/launcher_index.html
@@ -338,26 +338,54 @@
   // capture focus for websites serving game in iframe
   window.onload = function () { window.focus(); };
   
-  document.addEventListener('fullscreenchange', exitHandler);
-  document.addEventListener('webkitfullscreenchange', exitHandler);
-  document.addEventListener('mozfullscreenchange', exitHandler);
-  document.addEventListener('MSFullscreenChange', exitHandler);
-  
   // when exiting fullscreen, if it's by Esc key, we send a toggle so the engine knows it's windowed
-  function exitHandler() {
-    if (!document.fullscreenElement && !document.webkitIsFullscreen && !document.mozFullScreen && !document.msFullscreenElement) {
-      if(Module['_ext_get_windowed']() == 0) {
-        Module['_ext_toggle_fullscreen']();
-        Module.canvas.dispatchEvent(new Event("resize"));
-      }
+  function fscrExitHandler() {
+    // we exited fullscreen, but windowed is false! Probably exited by ESC key
+    if(Module['_ext_get_windowed']() == 0) {
+      Module['_ext_toggle_fullscreen']();
+      Module.canvas.dispatchEvent(new Event("resize"));
     }
   }
 
-  btnToggleFS.onclick = function() {
-    if(game_file !== "") {
-      Module['_ext_toggle_fullscreen']();
-      closeCfg();
-      Module.canvas.dispatchEvent(new Event("resize"));
+  function fscrChangeHandler() {
+    if (!document.fullscreenElement && !document.webkitIsFullscreen && !document.mozFullScreen && !document.msFullscreenElement) {
+      fscrExitHandler();
+    }
+  }
+
+  function initializeFullscreenControlHandling() {
+    // we really need a better way to detect this, but other browsers have webkit polyfills...
+    if ('webkitFullscreenEnabled' in document && !Module['_ext_fullscreen_supported']()) {
+      // it's webkit/safari, lets check if it has Fullscreen enabled
+      if (document.webkitFullscreenEnabled) {
+        // we are doing a very simple fullscreen here, AGS won't know that the game is fullscreen
+        btnToggleFS.onclick = function () {
+          if (game_file !== "") {
+            if (!document.fullscreenElement) {
+              document.getElementById('canvas').requestFullscreen();
+              closeCfg();
+              Module.canvas.dispatchEvent(new Event("resize"));
+            } else if (document.exitFullscreen) {
+              document.exitFullscreen();
+            }
+          }
+        }
+      } else {
+        btnToggleFS.hidden = true;
+        btnToggleFS.style.display = "none";
+      }
+    } else {
+      if ('mozFullScreenEnabled' in document) document.addEventListener('mozfullscreenchange', fscrChangeHandler);
+      else if ('msFullscreenEnabled' in document) document.addEventListener('MSFullscreenChange', fscrChangeHandler);
+      else if ('fullscreenEnabled' in document) document.addEventListener('fullscreenchange', fscrChangeHandler);
+
+      btnToggleFS.onclick = function () {
+        if (game_file !== "") {
+          Module['_ext_toggle_fullscreen']();
+          closeCfg();
+          Module.canvas.dispatchEvent(new Event("resize"));
+        }
+      }
     }
   }
 
@@ -454,6 +482,7 @@
   }
 
   function doPostRun() {
+    initializeFullscreenControlHandling();
     mountSavedGamesDir(function() {
       if (typeof gamefiles === 'undefined') 
         return;

--- a/Emscripten/launcher_index.html
+++ b/Emscripten/launcher_index.html
@@ -345,10 +345,10 @@
   
   // when exiting fullscreen, if it's by Esc key, we send a toggle so the engine knows it's windowed
   function exitHandler() {
-    if (!document.fullscreenElement && !document.webkitIsFullScreen && !document.mozFullScreen && !document.msFullscreenElement) {
+    if (!document.fullscreenElement && !document.webkitIsFullscreen && !document.mozFullScreen && !document.msFullscreenElement) {
       if(Module['_ext_get_windowed']() == 0) {
         Module['_ext_toggle_fullscreen']();
-        canvas.dispatchEvent(new Event("resize"));
+        Module.canvas.dispatchEvent(new Event("resize"));
       }
     }
   }
@@ -357,7 +357,7 @@
     if(game_file !== "") {
       Module['_ext_toggle_fullscreen']();
       closeCfg();
-      canvas.dispatchEvent(new Event("resize"));
+      Module.canvas.dispatchEvent(new Event("resize"));
     }
   }
 
@@ -557,7 +557,7 @@
 
   window.addEventListener("orientationchange", function() {
     // Generate a resize event if the device doesn't do it
-    canvas.dispatchEvent(new Event("resize"));
+    Module.canvas.dispatchEvent(new Event("resize"));
   }, false);
 </script>
 
@@ -586,7 +586,7 @@
         arguments.length > 1 && (e = Array.prototype.slice.call(arguments).join(" ")), console.error(e)
       },
       canvas: function() {
-        var e = document.getElementById("canvas");
+        var cnvs = document.getElementById("canvas");
         return window.addEventListener("resize", (function(t) {
           if(game_file === '') return;
         
@@ -600,11 +600,11 @@
             Module.canvas.height = fs_h;
             Module.canvas.style.width = fs_w + 'px';
             Module.canvas.style.height = fs_h + 'px';
-            canvas.dispatchEvent(new Event("resize"));
+            Module.canvas.dispatchEvent(new Event("resize"));
           }, 200);
-        }), !0), e.addEventListener("webglcontextlost", (function(e) {
+        }), !0), cnvs.addEventListener("webglcontextlost", (function(e) {
           alert("WebGL context lost. You will need to reload the page."), e.preventDefault()
-        }), !1), e
+        }), !1), cnvs
       }(),
       setStatus: function(e) {
         if (Module.setStatus.last || (Module.setStatus.last = {
@@ -631,7 +631,7 @@
   }
 </script>
 <!-- If you want to manually edit this file, comment SCRIPT and uncomment the line below -->
-<!-- <script async src=ags.js></script> -->
+<!-- <script async type="text/javascript" src="ags.js"></script> -->
 {{{ SCRIPT }}}
 </body>
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1308,7 +1308,7 @@ bool engine_try_set_gfxmode_any(const DisplayModeSetup &setup)
 
 bool engine_try_switch_windowed_gfxmode()
 {
-    if (!gfxDriver || !gfxDriver->IsModeSet())
+    if (!gfxDriver || !gfxDriver->IsModeSet() || !platform->FullscreenSupported())
         return false;
 
     // Keep previous mode in case we need to revert back

--- a/Engine/platform/base/agsplatformdriver.h
+++ b/Engine/platform/base/agsplatformdriver.h
@@ -124,6 +124,7 @@ public:
     virtual int  InitializeCDPlayer() = 0;  // return 0 on success
     virtual int  CDPlayerCommand(int cmdd, int datt) = 0;
     virtual void ShutdownCDPlayer() = 0;
+    virtual bool FullscreenSupported() { return true; }
 
     // Returns command line argument in a UTF-8 format
     virtual Common::String GetCommandArg(size_t arg_index);

--- a/Engine/platform/base/sys_main.cpp
+++ b/Engine/platform/base/sys_main.cpp
@@ -193,6 +193,7 @@ SDL_Window *sys_get_window() {
 
 void sys_window_set_style(WindowMode mode, Size size) {
     if (!window) return;
+    if(mode != kWnd_Windowed && !platform->FullscreenSupported()) mode = kWnd_Windowed;
     // NOTE: depending on which mode we are switching to, the order of
     // actions may be different; e.g. if we are going windowed mode, then
     // we first should disable fullscreen and set new size only after;

--- a/Engine/platform/emscripten/acpemscripten.cpp
+++ b/Engine/platform/emscripten/acpemscripten.cpp
@@ -25,19 +25,11 @@
 #include "SDL.h"
 #include "main/graphics_mode.h"
 #include "main/engine.h"
-#include "ac/runtime_defines.h"
 #include "ac/system.h"
 #include "ac/timer.h"
-#include "gfx/gfxdefines.h"
 #include "gfx/graphicsdriver.h"
 #include "platform/base/agsplatformdriver.h"
-#include "plugin/agsplugin.h"
 #include "util/filestream.h"
-#include "util/path.h"
-#include "util/string.h"
-
-#include <pwd.h>
-#include <sys/stat.h>
 
 using AGS::Common::String;
 using AGS::Common::FileStream;


### PR DESCRIPTION
opening as a draft to discuss the problem. I can't quite fix the complex layers of abstractions in Emscripten and SDL2 to make it work with Safari, but I can just ignore all that and just do the 4 lines of JS that are needed to make it work...

I added a new method in platform driver where I can tell if changing to fullscreen is supported or not, and if not, I just don't do anything in the engine.

This means that you can only enter fullscreen in Safari by using the "Toggle Fullscreen" button in the HTML launcher, and you can exit by press Esc (or Swiping down in iPhone). Additionally, in iPhone there is no way to remove this gesture so if your game has swipes (like my ManaMatch game), it's basically impossible to keep it fullscreen on iPhone...

(this all really gives me an urge to remove the fullscreen from the gear and add it separately in its own button!)

https://www.adventuregamestudio.co.uk/forums/engine-development/ags-engine-web-port/msg636656123/#msg636656123