### PR TITLE
Script API: implemented File.ResolvePath()

### DIFF
--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -252,23 +252,12 @@ Stream *File::OpenStderr()
 String File::FindFileCI(const String &base_dir, const String &file_name,
     bool is_dir, String *most_found, String *not_found)
 {
-#if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)
-    // Simply try a match
-    String path = Path::ConcatPaths(base_dir, file_name);
-    if ((is_dir && ags_directory_exists(path.GetCStr())) ||
-        (!is_dir && ags_file_exists(path.GetCStr())))
-        return path; // success
-    // TODO: this is never used, but for a formal consistency might
-    // support searching for an existing part of the path, and fill
-    // most_found & not_found
-    return {}; // fail
-#else
+    // Case insensitive file find - on case sensitive filesystems
     if (most_found)
         *most_found = base_dir;
     if (not_found)
         *not_found = "";
 
-    // Case insensitive file find - on case sensitive filesystems
     if (file_name.IsEmpty())
         return {}; // fail, no filename provided
 
@@ -299,6 +288,13 @@ String File::FindFileCI(const String &base_dir, const String &file_name,
         (!is_dir && ags_file_exists(test.GetCStr())))
         return test; // success
 
+#if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)
+    // TODO: most_found & not_found are never used in practice with CI fs;
+    // but if becomes necessary, we may reuse most of the CS code below
+    // for this case too, and uncommenting the following condition -
+    /* if (!most_found && !not_found) */
+    return {}; // fail
+#else
     // Begin splitting filename into path sections,
     // for each section open previous dir and search for any case-insensitive
     // match for the next section.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1263,6 +1263,8 @@ builtin managed struct File {
 #ifdef SCRIPT_API_v361
   /// Resolves the script path into the system filepath; for diagnostic purposes only.
   import static String ResolvePath(const string filename);   // $AUTOCOMPLETESTATICONLY$
+  /// Gets the path to opened file.
+  readonly import attribute String Path;
 #endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1260,6 +1260,10 @@ builtin managed struct File {
   /// Writes a raw 32-bit int to the file.
   import void WriteRawInt(int value);
 #endif
+#ifdef SCRIPT_API_v361
+  /// Resolves the script path into the system filepath; for diagnostic purposes only.
+  import static String ResolvePath(const string filename);   // $AUTOCOMPLETESTATICONLY$
+#endif
   int reserved[2];   // $AUTOCOMPLETEIGNORE$
 };
 

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -219,6 +219,14 @@ int File_GetPosition(sc_File *fil)
     return (int)stream->GetPosition();
 }
 
+const char *File_GetPath(sc_File *fil)
+{
+    if (fil->handle <= 0)
+        return nullptr;
+    Stream *stream = get_valid_file_stream_from_handle(fil->handle, "File.Path");
+    return CreateNewScriptString(stream->GetPath());
+}
+
 //=============================================================================
 
 
@@ -842,6 +850,11 @@ RuntimeScriptValue Sc_File_GetPosition(void *self, const RuntimeScriptValue *par
     API_OBJCALL_INT(sc_File, File_GetPosition);
 }
 
+RuntimeScriptValue Sc_File_GetPath(void *self, const RuntimeScriptValue *params, int32_t param_count)
+{
+    API_OBJCALL_OBJ(sc_File, const char, myScriptStringImpl, File_GetPath);
+}
+
 
 void RegisterFileAPI()
 {
@@ -868,6 +881,7 @@ void RegisterFileAPI()
         { "File::get_EOF",            API_FN_PAIR(File_GetEOF) },
         { "File::get_Error",          API_FN_PAIR(File_GetError) },
         { "File::get_Position",       API_FN_PAIR(File_GetPosition) },
+        { "File::get_Path",           API_FN_PAIR(File_GetPath) },
     };
 
     ccAddExternalFunctions(file_api);

--- a/Engine/ac/file.h
+++ b/Engine/ac/file.h
@@ -26,6 +26,7 @@ using AGS::Common::Stream;
 int		File_Exists(const char *fnmm);
 int		File_Delete(const char *fnmm);
 void	*sc_OpenFile(const char *fnmm, int mode);
+const char *File_ResolvePath(const char *fnmm);
 void	File_Close(sc_File *fil);
 void	File_WriteString(sc_File *fil, const char *towrite);
 void	File_WriteInt(sc_File *fil, int towrite);

--- a/Engine/ac/path_helper.h
+++ b/Engine/ac/path_helper.h
@@ -109,7 +109,7 @@ bool ResolveScriptPath(const String &sc_path, bool read_only, ResolvedPath &rp, 
 // if necessary. Fills in the successful ResolvedPath variant.
 // Fails if path could not be resolved, or no matching file was found.
 // WARNING: AssetMgr path is not tested.
-ResolvedPath ResolveScriptPathAndFindFile(const String &sc_path, bool read_only);
+ResolvedPath ResolveScriptPathAndFindFile(const String &sc_path, bool read_only, bool ignore_find_result = false);
 // Resolves a user file path for writing, and makes sure all the sub-directories are
 // created along the actual path.
 // Returns 'true' on success, and 'false' if either path is impossible to resolve,

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -21,6 +21,7 @@
 #include "ac/common.h" // quit
 #include "ac/draw.h"
 #include "ac/dynamicsprite.h"
+#include "ac/file.h"
 #include "ac/game.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"
@@ -805,6 +806,11 @@ void IAGSEngine::NotifyFontUpdated(int fontNumber)
 {
     font_recalc_metrics(fontNumber);
     GUI::MarkForFontUpdate(fontNumber);
+}
+
+const char *IAGSEngine::ResolveFilePath(const char *script_path)
+{
+    return File_ResolvePath(script_path);
 }
 
 void IAGSEngine::GetRenderStageDesc(AGSRenderStageDesc* desc)

--- a/Engine/plugin/agsplugin.h
+++ b/Engine/plugin/agsplugin.h
@@ -545,6 +545,10 @@ public:
   AGSIFUNC(IAGSFontRenderer*) ReplaceFontRenderer2(int fontNumber, IAGSFontRenderer2* newRenderer);
   // notify the engine that certain custom font has been updated
   AGSIFUNC(void)  NotifyFontUpdated(int fontNumber);
+
+  // *** BELOW ARE INTERFACE VERSION 27 AND ABOVE ONLY
+  // Resolves a script path to a system filepath, same way as script command File.Open does.
+  AGSIFUNC(const char*) ResolveFilePath(const char *script_path);
 };
 
 


### PR DESCRIPTION
Resolves #899

File.ResolvePath resolves a script path into the filesystem path, in exact same way as the engine does it when searching for a file.
 (like doing a case-insensitive search on case-sensitive filesystems).

As a bonus, added readonly File.Path property, that returns an opened File's path.