### PR TITLE
Scripting: add object pointer and verb parameters to object interaction functions

### DIFF
--- a/Common/gui/guiobject.h
+++ b/Common/gui/guiobject.h
@@ -124,6 +124,7 @@ protected:
     bool     _hasChanged;
 
     // TODO: explicit event names & handlers for every event
+    // FIXME: these must be static!! per type
     int32_t  _scEventCount;                    // number of supported script events
     String   _scEventNames[MAX_GUIOBJ_EVENTS]; // script event names
     String   _scEventArgs[MAX_GUIOBJ_EVENTS];  // script handler params

--- a/Editor/AGS.Types/Character.cs
+++ b/Editor/AGS.Types/Character.cs
@@ -54,7 +54,8 @@ namespace AGS.Types
                 "$$02 character","$$03 character","Use inventory on character",
                 "Any click on character", "$$05 character","$$08 character", 
                 "$$09 character"}, 
-                new string[] { "Look", "Interact", "Talk", "UseInv", "AnyClick", "PickUp", "Mode8", "Mode9" });
+                new string[] { "Look", "Interact", "Talk", "UseInv", "AnyClick", "PickUp", "Mode8", "Mode9" },
+                "Character *c, CursorMode mode");
         }
 
         public Character()

--- a/Editor/AGS.Types/InteractionSchema.cs
+++ b/Editor/AGS.Types/InteractionSchema.cs
@@ -8,11 +8,22 @@ namespace AGS.Types
     {
         private string[] _eventNames;
         private string[] _functionSuffixes;
+        private string[] _functionParameterLists;
 
-        public InteractionSchema(string[] eventNames, string[] functionSuffixes)
+        public InteractionSchema(string[] eventNames, string[] functionSuffixes, string functionParameterList)
         {
             _eventNames = eventNames;
             _functionSuffixes = functionSuffixes;
+            _functionParameterLists = new string[eventNames.Length];
+            for (int i = 0; i < eventNames.Length; ++i)
+                _functionParameterLists[i] = functionParameterList;
+        }
+
+        public InteractionSchema(string[] eventNames, string[] functionSuffixes, string[] functionParameterLists)
+        {
+            _eventNames = eventNames;
+            _functionSuffixes = functionSuffixes;
+            _functionParameterLists = functionParameterLists;
         }
 
         public string[] EventNames
@@ -23,6 +34,11 @@ namespace AGS.Types
         public string[] FunctionSuffixes
         {
             get { return _functionSuffixes; }
+        }
+
+        public string[] FunctionParameterLists
+        {
+            get { return _functionParameterLists; }
         }
     }
 }

--- a/Editor/AGS.Types/Interactions.cs
+++ b/Editor/AGS.Types/Interactions.cs
@@ -67,6 +67,11 @@ namespace AGS.Types
             get { return _schema.FunctionSuffixes; }
         }
 
+        public string[] FunctionParameterLists
+        {
+            get { return _schema.FunctionParameterLists; }
+        }
+
         public string[] DisplayNames
         {
             get { return _schema.EventNames; }

--- a/Editor/AGS.Types/InventoryItem.cs
+++ b/Editor/AGS.Types/InventoryItem.cs
@@ -28,7 +28,8 @@ namespace AGS.Types
             _interactionSchema = new InteractionSchema(new string[] { "$$01 inventory item", 
                 "$$02 inventory item", "$$03 inventory item", "Use inventory on this item", 
                 "Other click on inventory item" },
-                new string[] { "Look", "Interact", "Talk", "UseInv", "OtherClick" });
+                new string[] { "Look", "Interact", "Talk", "UseInv", "OtherClick" },
+                "InventoryItem *i, CursorMode mode");
         }
 
         public InventoryItem()

--- a/Editor/AGS.Types/PropertyGridExtras/InteractionPropertyDescriptor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/InteractionPropertyDescriptor.cs
@@ -11,13 +11,14 @@ namespace AGS.Types
         private Type _componentType;
         private int _eventIndex;
 
-        public InteractionPropertyDescriptor(object component, int eventIndex, string eventName, string displayName)
+        public InteractionPropertyDescriptor(object component, int eventIndex, string eventName, string displayName,
+                string parameterList)
             :
             base(eventName, new Attribute[]{new DisplayNameAttribute(displayName), 
                 new EditorAttribute(typeof(ScriptFunctionUIEditor), typeof(System.Drawing.Design.UITypeEditor)),
                 new CategoryAttribute("Events"),
                 new DefaultValueAttribute(string.Empty),
-                new ScriptFunctionParametersAttribute(string.Empty)})
+                new ScriptFunctionParametersAttribute(parameterList)})
         {
             _componentType = component.GetType();
             _eventIndex = eventIndex;

--- a/Editor/AGS.Types/PropertyGridExtras/PropertyTabInteractions.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/PropertyTabInteractions.cs
@@ -62,7 +62,8 @@ namespace AGS.Types
 					if (eventName.IndexOf("$$") < 0)
 					{
 						// Only add the event if the cursor mode exists
-						propList.Add(new InteractionPropertyDescriptor(component, i, interactions.FunctionSuffixes[i], eventName));
+						propList.Add(new InteractionPropertyDescriptor(component, i,
+                            interactions.FunctionSuffixes[i], eventName, interactions.FunctionParameterLists[i]));
 					}
                 }
             }

--- a/Editor/AGS.Types/Room.cs
+++ b/Editor/AGS.Types/Room.cs
@@ -73,7 +73,8 @@ namespace AGS.Types
                 "Leaves room after fade-out"
             },
                 new string[] { "LeaveLeft", "LeaveRight", "LeaveBottom", "LeaveTop", 
-                    "FirstLoad", EVENT_SUFFIX_ROOM_LOAD, "RepExec", "AfterFadeIn", "Leave", "Unload" });
+                    "FirstLoad", EVENT_SUFFIX_ROOM_LOAD, "RepExec", "AfterFadeIn", "Leave", "Unload" },
+                    "");
         }
 
         public Room(int roomNumber) : base(roomNumber)

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -29,7 +29,11 @@ namespace AGS.Types
                 "$$03 hotspot", "Any click on hotspot","Mouse moves over hotspot", 
                 "$$05 hotspot", "$$08 hotspot", "$$09 hotspot"},
                 new string[] { "WalkOn", "Look", "Interact", "UseInv", "Talk", "AnyClick", "MouseMove", "PickUp", "Mode8", "Mode9" },
-                "Hotspot *h, CursorMode mode");
+                new string[] { /*WalkOn*/"Hotspot *h", /*Look*/"Hotspot *h, CursorMode mode",
+                    /*Interact*/"Hotspot *h, CursorMode mode", /*UseInv*/"Hotspot *h, CursorMode mode",
+                    /*Talk*/"Hotspot *h, CursorMode mode", /*AnyClick*/"Hotspot *h, CursorMode mode",
+                    /*MouseMove*/"Hotspot *h", /*PickUp*/"Hotspot *h, CursorMode mode",
+                    /*Mode8*/"Hotspot *h, CursorMode mode", /*Mode9*/"Hotspot *h, CursorMode mode" });
         }
 
 		public RoomHotspot(IChangeNotification changeNotifier)

--- a/Editor/AGS.Types/RoomHotspot.cs
+++ b/Editor/AGS.Types/RoomHotspot.cs
@@ -28,7 +28,8 @@ namespace AGS.Types
                 "$$01 hotspot","$$02 hotspot","Use inventory on hotspot",
                 "$$03 hotspot", "Any click on hotspot","Mouse moves over hotspot", 
                 "$$05 hotspot", "$$08 hotspot", "$$09 hotspot"},
-                new string[] { "WalkOn", "Look", "Interact", "UseInv", "Talk", "AnyClick", "MouseMove", "PickUp", "Mode8", "Mode9" });
+                new string[] { "WalkOn", "Look", "Interact", "UseInv", "Talk", "AnyClick", "MouseMove", "PickUp", "Mode8", "Mode9" },
+                "Hotspot *h, CursorMode mode");
         }
 
 		public RoomHotspot(IChangeNotification changeNotifier)

--- a/Editor/AGS.Types/RoomObject.cs
+++ b/Editor/AGS.Types/RoomObject.cs
@@ -35,7 +35,8 @@ namespace AGS.Types
                 "$$02 object", "$$03 object",  "Use inventory on object", 
                 "Any click on object", 
                 "$$05 object", "$$08 object", "$$09 object"},
-                new string[] { "Look", "Interact", "Talk", "UseInv", "AnyClick", "PickUp", "Mode8", "Mode9" });
+                new string[] { "Look", "Interact", "Talk", "UseInv", "AnyClick", "PickUp", "Mode8", "Mode9" },
+                "Object *o, CursorMode mode");
         }
 
 		public RoomObject(IChangeNotification changeNotifier)

--- a/Editor/AGS.Types/RoomRegion.cs
+++ b/Editor/AGS.Types/RoomRegion.cs
@@ -28,7 +28,8 @@ namespace AGS.Types
                 "While standing on region",
                 "Walks onto region", 
                 "Walks off region"},
-                new string[] { "Standing", "WalksOnto", "WalksOff" });
+                new string[] { "Standing", "WalksOnto", "WalksOff" },
+                "Region *r");
         }
 
         [Description("The ID number of the region")]

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -114,18 +114,6 @@ void run_room_event(int id) {
     }
 }
 
-void run_event_block_inv(int invNum, int event) {
-    auto obj_evt = ObjectEvent("inventory%d", invNum);
-    if (loaded_game_file_version > kGameVersion_272)
-    {
-        run_interaction_script(obj_evt, game.invScripts[invNum].get(), event);
-    }
-    else 
-    {
-        run_interaction_event(obj_evt, game.intrInv[invNum].get(), event);
-    }
-}
-
 // event list functions
 void setevent(int evtyp,int ev1,int ev2,int ev3) {
     EventHappened evt;

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -55,9 +55,6 @@ int in_leaves_screen = -1;
 
 std::vector<EventHappened> events;
 
-const char*evblockbasename;
-int evblocknum;
-
 int inside_processevent=0;
 int eventClaimed = EVENT_NONE;
 
@@ -106,29 +103,27 @@ void run_on_event(int evtype, RuntimeScriptValue &wparam)
 }
 
 void run_room_event(int id) {
-    evblockbasename="room";
-
+    auto obj_evt = ObjectEvent("room");
     if (thisroom.EventHandlers != nullptr)
     {
-        run_interaction_script(thisroom.EventHandlers.get(), id);
+        run_interaction_script(obj_evt, thisroom.EventHandlers.get(), id);
     }
     else
     {
-        run_interaction_event (&croom->intrRoom, id);
+        run_interaction_event(obj_evt, &croom->intrRoom, id);
     }
 }
 
 void run_event_block_inv(int invNum, int event) {
-    evblockbasename="inventory%d";
+    auto obj_evt = ObjectEvent("inventory%d", invNum);
     if (loaded_game_file_version > kGameVersion_272)
     {
-        run_interaction_script(game.invScripts[invNum].get(), event);
+        run_interaction_script(obj_evt, game.invScripts[invNum].get(), event);
     }
     else 
     {
-        run_interaction_event(game.intrInv[invNum].get(), event);
+        run_interaction_event(obj_evt, game.intrInv[invNum].get(), event);
     }
-
 }
 
 // event list functions
@@ -171,8 +166,7 @@ void process_event(const EventHappened *evp) {
     else if (evp->type==EV_RUNEVBLOCK) {
         Interaction*evpt=nullptr;
         PInteractionScripts scriptPtr = nullptr;
-        const char *oldbasename = evblockbasename;
-        int   oldblocknum = evblocknum;
+        ObjectEvent obj_evt;
 
         if (evp->data1==EVB_HOTSPOT) {
 
@@ -181,8 +175,7 @@ void process_event(const EventHappened *evp) {
             else
                 evpt=&croom->intrHotspot[evp->data2];
 
-            evblockbasename="hotspot%d";
-            evblocknum=evp->data2;
+            obj_evt = ObjectEvent("hotspot%d", evp->data2);
             //Debug::Printf("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
         }
         else if (evp->data1==EVB_ROOM) {
@@ -192,7 +185,7 @@ void process_event(const EventHappened *evp) {
             else
                 evpt=&croom->intrRoom;
 
-            evblockbasename="room";
+            obj_evt = ObjectEvent("room");
             if (evp->data3 == EVROM_BEFOREFADEIN) {
                 in_enters_screen ++;
                 run_on_event (GE_ENTER_ROOM, RuntimeScriptValue().SetInt32(displayed_room));
@@ -201,20 +194,19 @@ void process_event(const EventHappened *evp) {
             }
             //Debug::Printf("Running room interaction, event %d", evp->data3);
         }
+        else {
+            quit("process_event: RunEvBlock: unknown evb type");
+        }
 
+        assert(scriptPtr || evpt);
         if (scriptPtr != nullptr)
         {
-            run_interaction_script(scriptPtr.get(), evp->data3);
-        }
-        else if (evpt != nullptr)
-        {
-            run_interaction_event(evpt,evp->data3);
+            run_interaction_script(obj_evt, scriptPtr.get(), evp->data3);
         }
         else
-            quit("process_event: RunEvBlock: unknown evb type");
-
-        evblockbasename = oldbasename;
-        evblocknum = oldblocknum;
+        {
+            run_interaction_event(obj_evt, evpt, evp->data3);
+        }
 
         if ((evp->data1 == EVB_ROOM) && (evp->data3 == EVROM_BEFOREFADEIN))
             in_enters_screen --;

--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -23,6 +23,8 @@
 #include "ac/gui.h"
 #include "ac/roomstatus.h"
 #include "ac/screen.h"
+#include "ac/dynobj/scripthotspot.h"
+#include "ac/dynobj/cc_hotspot.h"
 #include "debug/debug_log.h"
 #include "main/game_run.h"
 #include "script/cc_common.h"
@@ -49,6 +51,8 @@ extern IGraphicsDriver *gfxDriver;
 extern AGSPlatformDriver *platform;
 extern RGB old_palette[256];
 extern int displayed_room;
+extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
+extern CCHotspot ccDynamicHotspot;
 
 int in_enters_screen=0,done_es_error = 0;
 int in_leaves_screen = -1;
@@ -157,13 +161,14 @@ void process_event(const EventHappened *evp) {
         ObjectEvent obj_evt;
 
         if (evp->data1==EVB_HOTSPOT) {
-
-            if (thisroom.Hotspots[evp->data2].EventHandlers != nullptr)
-                scriptPtr = thisroom.Hotspots[evp->data2].EventHandlers;
+            const int hotspot_id = evp->data2;
+            if (thisroom.Hotspots[hotspot_id].EventHandlers != nullptr)
+                scriptPtr = thisroom.Hotspots[hotspot_id].EventHandlers;
             else
-                evpt=&croom->intrHotspot[evp->data2];
+                evpt=&croom->intrHotspot[hotspot_id];
 
-            obj_evt = ObjectEvent("hotspot%d", evp->data2);
+            obj_evt = ObjectEvent("hotspot%d", hotspot_id,
+                RuntimeScriptValue().SetScriptObject(&scrHotspot[hotspot_id], &ccDynamicHotspot));
             //Debug::Printf("Running hotspot interaction for hotspot %d, event %d", evp->data2, evp->data3);
         }
         else if (evp->data1==EVB_ROOM) {

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -86,10 +86,15 @@
 // cursor is over hotspot
 #define EVHOT_MOUSEOVER 6
 
-struct EventHappened {
+struct EventHappened
+{
     int type = 0;
     int data1 = 0, data2 = 0, data3 = 0;
     int player = -1;
+
+    EventHappened() = default;
+    EventHappened(int type_, int data1_, int data2_, int data3_, int player_)
+        : type(type_), data1(data1_), data2(data2_), data3(data3_), player(player_) {}
 };
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed);
@@ -110,9 +115,6 @@ extern int in_enters_screen,done_es_error;
 extern int in_leaves_screen;
 
 extern std::vector<EventHappened> events;
-
-extern const char*evblockbasename;
-extern int evblocknum;
 
 extern int eventClaimed;
 

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -101,7 +101,6 @@ int run_claimable_event(const char *tsname, bool includeRoom, int numParams, con
 // runs the global script on_event fnuction
 void run_on_event (int evtype, RuntimeScriptValue &wparam);
 void run_room_event(int id);
-void run_event_block_inv(int invNum, int event);
 // event list functions
 void setevent(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);
 void force_event(int evtyp,int ev1=0,int ev2=-1000,int ev3=-1000);

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -378,18 +378,18 @@ void RunCharacterInteraction (int cc, int mood) {
     else if (mood==MODE_CUSTOM1) passon = 6;
     else if (mood==MODE_CUSTOM2) passon = 7;
 
-    evblockbasename="character%d"; evblocknum=cc;
+    const auto obj_evt = ObjectEvent("character%d", cc);
     if (loaded_game_file_version > kGameVersion_272)
     {
         if (passon>=0)
-            run_interaction_script(game.charScripts[cc].get(), passon, 4);
-        run_interaction_script(game.charScripts[cc].get(), 4);  // any click on char
+            run_interaction_script(obj_evt, game.charScripts[cc].get(), passon, 4);
+        run_interaction_script(obj_evt, game.charScripts[cc].get(), 4);  // any click on char
     }
     else 
     {
         if (passon>=0)
-            run_interaction_event(game.intrChar[cc].get(),passon, 4, (passon == 3));
-        run_interaction_event(game.intrChar[cc].get(),4);  // any click on char
+            run_interaction_event(obj_evt, game.intrChar[cc].get(),passon, 4, (passon == 3));
+        run_interaction_event(obj_evt, game.intrChar[cc].get(), 4);  // any click on char
     }
 }
 

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -366,30 +366,42 @@ void RunCharacterInteraction (int cc, int mood) {
     if (!is_valid_character(cc))
         quit("!RunCharacterInteraction: invalid character");
 
-    int passon=-1,cdata=-1;
-    if (mood==MODE_LOOK) passon=0;
-    else if (mood==MODE_HAND) passon=1;
-    else if (mood==MODE_TALK) passon=2;
-    else if (mood==MODE_USE) { passon=3;
-    cdata=playerchar->activeinv;
-    play.usedinv=cdata;
+    // convert cursor mode to event index (in character event table)
+    // TODO: probably move this conversion table elsewhere? should be a global info
+    int evnt;
+    switch (mood)
+    {
+    case MODE_LOOK: evnt = 0; break;
+    case MODE_HAND: evnt = 1; break;
+    case MODE_TALK: evnt = 2; break;
+    case MODE_USE: evnt = 3; break;
+    case MODE_PICKUP: evnt = 5; break;
+    case MODE_CUSTOM1: evnt = 6; break;
+    case MODE_CUSTOM2: evnt = 7; break;
+    default: evnt = -1; break;
     }
-    else if (mood==MODE_PICKUP) passon = 5;
-    else if (mood==MODE_CUSTOM1) passon = 6;
-    else if (mood==MODE_CUSTOM2) passon = 7;
+    const int anyclick_evt = 4; // TODO: make global constant (character any-click evt)
+
+    // For USE verb: remember active inventory
+    if (mood == MODE_USE)
+    {
+        play.usedinv = playerchar->activeinv;
+    }
 
     const auto obj_evt = ObjectEvent("character%d", cc);
     if (loaded_game_file_version > kGameVersion_272)
     {
-        if (passon>=0)
-            run_interaction_script(obj_evt, game.charScripts[cc].get(), passon, 4);
-        run_interaction_script(obj_evt, game.charScripts[cc].get(), 4);  // any click on char
+        if ((evnt >= 0) &&
+                run_interaction_script(obj_evt, game.charScripts[cc].get(), evnt, anyclick_evt) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_script(obj_evt, game.charScripts[cc].get(), anyclick_evt);  // any click on char
     }
     else 
     {
-        if (passon>=0)
-            run_interaction_event(obj_evt, game.intrChar[cc].get(),passon, 4, (passon == 3));
-        run_interaction_event(obj_evt, game.intrChar[cc].get(), 4);  // any click on char
+        if ((evnt >= 0) &&
+                run_interaction_event(obj_evt, game.intrChar[cc].get(), evnt, anyclick_evt, (mood == MODE_USE)) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_event(obj_evt, game.intrChar[cc].get(), anyclick_evt);  // any click on char
     }
 }
 

--- a/Engine/ac/global_character.cpp
+++ b/Engine/ac/global_character.cpp
@@ -32,6 +32,7 @@
 #include "ac/properties.h"
 #include "ac/screenoverlay.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_character.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
 #include "main/game_run.h"
@@ -47,6 +48,7 @@ extern RoomStruct thisroom;
 extern GameState play;
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern ScriptInvItem scrInv[MAX_INV];
+extern CCCharacter ccDynamicCharacter;
 
 // defined in character unit
 extern CharacterInfo*playerchar;
@@ -388,7 +390,8 @@ void RunCharacterInteraction (int cc, int mood) {
         play.usedinv = playerchar->activeinv;
     }
 
-    const auto obj_evt = ObjectEvent("character%d", cc);
+    const auto obj_evt = ObjectEvent("character%d", cc,
+        RuntimeScriptValue().SetScriptObject(&game.chars[cc], &ccDynamicCharacter), mood);
     if (loaded_game_file_version > kGameVersion_272)
     {
         if ((evnt >= 0) &&

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -88,17 +88,28 @@ void GetHotspotName(int hotspot, char *buffer) {
 
 void RunHotspotInteraction (int hotspothere, int mood) {
 
-    int passon=-1,cdata=-1;
-    if (mood==MODE_TALK) passon=4;
-    else if (mood==MODE_WALK) passon=0;
-    else if (mood==MODE_LOOK) passon=1;
-    else if (mood==MODE_HAND) passon=2;
-    else if (mood==MODE_PICKUP) passon=7;
-    else if (mood==MODE_CUSTOM1) passon = 8;
-    else if (mood==MODE_CUSTOM2) passon = 9;
-    else if (mood==MODE_USE) { passon=3;
-    cdata=playerchar->activeinv;
-    play.usedinv=cdata;
+    // convert cursor mode to event index (in hotspot event table)
+    // TODO: probably move this conversion table elsewhere? should be a global info
+    // TODO: find out what is hotspot event with index 6 (5 is any-click)
+    int evnt;
+    switch (mood)
+    {
+    case MODE_WALK: evnt = 0; break;
+    case MODE_LOOK: evnt = 1; break;
+    case MODE_HAND: evnt = 2; break;
+    case MODE_TALK: evnt = 4; break;
+    case MODE_USE: evnt = 3; break;
+    case MODE_PICKUP: evnt = 7; break;
+    case MODE_CUSTOM1: evnt = 8; break;
+    case MODE_CUSTOM2: evnt = 9; break;
+    default: evnt = -1; break;
+    }
+    const int anyclick_evt = 5; // TODO: make global constant (hotspot any-click evt)
+
+    // For USE verb: remember active inventory
+    if (mood == MODE_USE)
+    {
+        play.usedinv = playerchar->activeinv;
     }
 
     if ((game.options[OPT_WALKONLOOK]==0) & (mood==MODE_LOOK)) ;
@@ -110,21 +121,19 @@ void RunHotspotInteraction (int hotspothere, int mood) {
     // executed once in a eventlist
 
     const auto obj_evt = ObjectEvent("hotspot%d", hotspothere);
-    if (thisroom.Hotspots[hotspothere].EventHandlers != nullptr)
+    if (loaded_game_file_version > kGameVersion_272)
     {
-        if (passon>=0)
-            run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5);
-        run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), 5);  // any click on hotspot
+        if ((evnt >= 0) &&
+                run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), evnt, anyclick_evt) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), anyclick_evt); // any click on hotspot
     }
     else
     {
-        if (passon>=0) {
-            if (run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], passon, 5, (passon == 3))) {
-                return;
-            }
-        }
-        // run the 'any click on hs' event
-        run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], 5);
+        if ((evnt >= 0) &&
+                run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], evnt, anyclick_evt, (mood == MODE_USE)) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], anyclick_evt); // any click on hotspot
     }
 }
 

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -26,6 +26,7 @@
 #include "ac/properties.h"
 #include "ac/roomstatus.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_hotspot.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
 #include "script/script.h"
@@ -36,6 +37,8 @@ extern RoomStruct thisroom;
 extern RoomStatus*croom;
 extern CharacterInfo*playerchar;
 extern GameSetupStruct game;
+extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
+extern CCHotspot ccDynamicHotspot;
 
 
 void DisableHotspot(int hsnum) {
@@ -117,10 +120,8 @@ void RunHotspotInteraction (int hotspothere, int mood) {
     else if ((mood!=MODE_WALK) && (play.check_interaction_only == 0))
         MoveCharacterToHotspot(game.playercharacter,hotspothere);
 
-    // can't use the setevent functions because this ProcessClick is only
-    // executed once in a eventlist
-
-    const auto obj_evt = ObjectEvent("hotspot%d", hotspothere);
+    const auto obj_evt = ObjectEvent("hotspot%d", hotspothere,
+        RuntimeScriptValue().SetScriptObject(&scrHotspot[hotspothere], &ccDynamicHotspot), mood);
     if (loaded_game_file_version > kGameVersion_272)
     {
         if ((evnt >= 0) &&

--- a/Engine/ac/global_hotspot.cpp
+++ b/Engine/ac/global_hotspot.cpp
@@ -108,33 +108,24 @@ void RunHotspotInteraction (int hotspothere, int mood) {
 
     // can't use the setevent functions because this ProcessClick is only
     // executed once in a eventlist
-    const char *oldbasename = evblockbasename;
-    int   oldblocknum = evblocknum;
 
-    evblockbasename="hotspot%d";
-    evblocknum=hotspothere;
-
+    const auto obj_evt = ObjectEvent("hotspot%d", hotspothere);
     if (thisroom.Hotspots[hotspothere].EventHandlers != nullptr)
     {
         if (passon>=0)
-            run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5);
-        run_interaction_script(thisroom.Hotspots[hotspothere].EventHandlers.get(), 5);  // any click on hotspot
+            run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), passon, 5);
+        run_interaction_script(obj_evt, thisroom.Hotspots[hotspothere].EventHandlers.get(), 5);  // any click on hotspot
     }
     else
     {
         if (passon>=0) {
-            if (run_interaction_event(&croom->intrHotspot[hotspothere],passon, 5, (passon == 3))) {
-                evblockbasename = oldbasename;
-                evblocknum = oldblocknum;
+            if (run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], passon, 5, (passon == 3))) {
                 return;
             }
         }
         // run the 'any click on hs' event
-        run_interaction_event(&croom->intrHotspot[hotspothere],5);
+        run_interaction_event(obj_evt, &croom->intrHotspot[hotspothere], 5);
     }
-
-    evblockbasename = oldbasename;
-    evblocknum = oldblocknum;
 }
 
 int GetHotspotProperty (int hss, const char *property)

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -23,6 +23,7 @@
 #include "ac/invwindow.h"
 #include "ac/properties.h"
 #include "ac/string.h"
+#include "ac/dynobj/cc_inventory.h"
 #include "gui/guimain.h"
 #include "gui/guiinv.h"
 #include "script/script.h"
@@ -34,6 +35,8 @@ extern GameState play;
 extern int mousex, mousey;
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern CharacterInfo*playerchar;
+extern ScriptInvItem scrInv[MAX_INV];
+extern CCInventory ccDynamicInv;
 
 
 void set_inv_item_pic(int invi, int piccy) {
@@ -120,7 +123,8 @@ void RunInventoryInteraction (int iit, int mood) {
     if (evnt < 0) // on any non-supported mode - use "other-click"
         evnt = otherclick_evt;
 
-    auto obj_evt = ObjectEvent("inventory%d", iit);
+    const auto obj_evt = ObjectEvent("inventory%d", iit,
+        RuntimeScriptValue().SetScriptObject(&scrInv[iit], &ccDynamicInv), mood);
     if (loaded_game_file_version > kGameVersion_272)
     {
         run_interaction_script(obj_evt, game.invScripts[iit].get(), evnt);

--- a/Engine/ac/global_inventoryitem.cpp
+++ b/Engine/ac/global_inventoryitem.cpp
@@ -32,8 +32,6 @@ extern GameSetupStruct game;
 extern GameState play;
 extern int mousex, mousey;
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
-extern const char*evblockbasename;
-extern int evblocknum;
 extern CharacterInfo*playerchar;
 
 
@@ -99,7 +97,6 @@ void RunInventoryInteraction (int iit, int modd) {
     if ((iit < 0) || (iit >= game.numinvitems))
         quit("!RunInventoryInteraction: invalid inventory number");
 
-    evblocknum = iit;
     if (modd == MODE_LOOK)
         run_event_block_inv(iit, 0);
     else if (modd == MODE_HAND)

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -451,24 +451,24 @@ void RunObjectInteraction (int aa, int mood) {
     else if (mood==MODE_USE) { passon=3;
     cdata=playerchar->activeinv;
     play.usedinv=cdata; }
-    evblockbasename="object%d"; evblocknum=aa;
 
+    const auto obj_evt = ObjectEvent("object%d", aa);
     if (thisroom.Objects[aa].EventHandlers != nullptr)
     {
         if (passon>=0) 
         {
-            if (run_interaction_script(thisroom.Objects[aa].EventHandlers.get(), passon, 4))
+            if (run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), passon, 4))
                 return;
         }
-        run_interaction_script(thisroom.Objects[aa].EventHandlers.get(), 4);  // any click on obj
+        run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), 4);  // any click on obj
     }
     else
     {
         if (passon>=0) {
-            if (run_interaction_event(&croom->intrObject[aa],passon, 4, (passon == 3)))
+            if (run_interaction_event(obj_evt, &croom->intrObject[aa],passon, 4, (passon == 3)))
                 return;
         }
-        run_interaction_event(&croom->intrObject[aa],4);  // any click on obj
+        run_interaction_event(obj_evt, &croom->intrObject[aa],4);  // any click on obj
     }
 }
 

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -30,6 +30,7 @@
 #include "ac/roomstatus.h"
 #include "ac/string.h"
 #include "ac/viewframe.h"
+#include "ac/dynobj/cc_object.h"
 #include "debug/debug_log.h"
 #include "main/game_run.h"
 #include "script/script.h"
@@ -51,6 +52,8 @@ extern CharacterInfo*playerchar;
 extern int displayed_room;
 extern SpriteCache spriteset;
 extern IGraphicsDriver *gfxDriver;
+extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
+extern CCObject ccDynamicObject;
 
 // Used for deciding whether a char or obj was closer
 int obj_lowest_yp;
@@ -464,7 +467,8 @@ void RunObjectInteraction (int aa, int mood) {
         play.usedinv = playerchar->activeinv;
     }
 
-    const auto obj_evt = ObjectEvent("object%d", aa);
+    const auto obj_evt = ObjectEvent("object%d", aa,
+        RuntimeScriptValue().SetScriptObject(&scrObj[aa], &ccDynamicObject), mood);
     if (loaded_game_file_version > kGameVersion_272)
     {
         if ((evnt >= 0) &&

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -441,34 +441,43 @@ void SetObjectIgnoreWalkbehinds (int cha, int clik) {
 void RunObjectInteraction (int aa, int mood) {
     if (!is_valid_object(aa))
         quit("!RunObjectInteraction: invalid object number for current room");
-    int passon=-1,cdata=-1;
-    if (mood==MODE_LOOK) passon=0;
-    else if (mood==MODE_HAND) passon=1;
-    else if (mood==MODE_TALK) passon=2;
-    else if (mood==MODE_PICKUP) passon=5;
-    else if (mood==MODE_CUSTOM1) passon = 6;
-    else if (mood==MODE_CUSTOM2) passon = 7;
-    else if (mood==MODE_USE) { passon=3;
-    cdata=playerchar->activeinv;
-    play.usedinv=cdata; }
+
+    // convert cursor mode to event index (in character event table)
+    // TODO: probably move this conversion table elsewhere? should be a global info
+    int evnt;
+    switch (mood)
+    {
+    case MODE_LOOK: evnt = 0; break;
+    case MODE_HAND: evnt = 1; break;
+    case MODE_TALK: evnt = 2; break;
+    case MODE_USE: evnt = 3; break;
+    case MODE_PICKUP: evnt = 5; break;
+    case MODE_CUSTOM1: evnt = 6; break;
+    case MODE_CUSTOM2: evnt = 7; break;
+    default: evnt = -1; break;
+    }
+    const int anyclick_evt = 4; // TODO: make global constant (character any-click evt)
+
+    // For USE verb: remember active inventory
+    if (mood == MODE_USE)
+    {
+        play.usedinv = playerchar->activeinv;
+    }
 
     const auto obj_evt = ObjectEvent("object%d", aa);
-    if (thisroom.Objects[aa].EventHandlers != nullptr)
+    if (loaded_game_file_version > kGameVersion_272)
     {
-        if (passon>=0) 
-        {
-            if (run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), passon, 4))
-                return;
-        }
-        run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), 4);  // any click on obj
+        if ((evnt >= 0) &&
+                run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), evnt, anyclick_evt) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_script(obj_evt, thisroom.Objects[aa].EventHandlers.get(), anyclick_evt); // any click on obj
     }
     else
     {
-        if (passon>=0) {
-            if (run_interaction_event(obj_evt, &croom->intrObject[aa],passon, 4, (passon == 3)))
-                return;
-        }
-        run_interaction_event(obj_evt, &croom->intrObject[aa],4);  // any click on obj
+        if ((evnt >= 0) &&
+                run_interaction_event(obj_evt, &croom->intrObject[aa], evnt, anyclick_evt, (mood == MODE_USE)) < 0)
+            return; // game state changed, don't do "any click"
+        run_interaction_event(obj_evt, &croom->intrObject[aa], anyclick_evt); // any click on obj
     }
 }
 

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -138,8 +138,10 @@ void RunRegionInteraction (int regnum, int mood) {
     if ((mood < 0) || (mood > 2))
         quit("!RunRegionInteraction: invalid event specified");
 
+    // NOTE: for Regions the mode has specific meanings (NOT verbs):
+    // 0 - stands on region, 1 - walks onto region, 2 - walks off region
     const auto obj_evt = ObjectEvent("region%d", regnum);
-    if (thisroom.Regions[regnum].EventHandlers != nullptr)
+    if (loaded_game_file_version > kGameVersion_272)
     {
         run_interaction_script(obj_evt, thisroom.Regions[regnum].EventHandlers.get(), mood);
     }

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -18,6 +18,7 @@
 #include "ac/region.h"
 #include "ac/room.h"
 #include "ac/roomstatus.h"
+#include "dynobj/cc_region.h"
 #include "debug/debug_log.h"
 #include "game/roomstruct.h"
 #include "gfx/bitmap.h"
@@ -28,6 +29,8 @@ using namespace AGS::Common;
 
 extern RoomStruct thisroom;
 extern RoomStatus*croom;
+extern ScriptRegion scrRegion[MAX_ROOM_REGIONS];
+extern CCRegion ccDynamicRegion;
 
 int GetRegionIDAtRoom(int xxx, int yyy) {
     // if the co-ordinates are off the edge of the screen,
@@ -140,7 +143,8 @@ void RunRegionInteraction (int regnum, int mood) {
 
     // NOTE: for Regions the mode has specific meanings (NOT verbs):
     // 0 - stands on region, 1 - walks onto region, 2 - walks off region
-    const auto obj_evt = ObjectEvent("region%d", regnum);
+    const auto obj_evt = ObjectEvent("region%d", regnum,
+        RuntimeScriptValue().SetScriptObject(&scrRegion[regnum], &ccDynamicRegion), mood);
     if (loaded_game_file_version > kGameVersion_272)
     {
         run_interaction_script(obj_evt, thisroom.Regions[regnum].EventHandlers.get(), mood);

--- a/Engine/ac/global_region.cpp
+++ b/Engine/ac/global_region.cpp
@@ -28,8 +28,6 @@ using namespace AGS::Common;
 
 extern RoomStruct thisroom;
 extern RoomStatus*croom;
-extern const char*evblockbasename;
-extern int evblocknum;
 
 int GetRegionIDAtRoom(int xxx, int yyy) {
     // if the co-ordinates are off the edge of the screen,
@@ -140,25 +138,13 @@ void RunRegionInteraction (int regnum, int mood) {
     if ((mood < 0) || (mood > 2))
         quit("!RunRegionInteraction: invalid event specified");
 
-    // We need a backup, because region interactions can run
-    // while another interaction (eg. hotspot) is in a Wait
-    // command, and leaving our basename would call the wrong
-    // script later on
-    const char *oldbasename = evblockbasename;
-    int   oldblocknum = evblocknum;
-
-    evblockbasename = "region%d";
-    evblocknum = regnum;
-
+    const auto obj_evt = ObjectEvent("region%d", regnum);
     if (thisroom.Regions[regnum].EventHandlers != nullptr)
     {
-        run_interaction_script(thisroom.Regions[regnum].EventHandlers.get(), mood);
+        run_interaction_script(obj_evt, thisroom.Regions[regnum].EventHandlers.get(), mood);
     }
     else
     {
-        run_interaction_event(&croom->intrRegion[regnum], mood);
+        run_interaction_event(obj_evt, &croom->intrRegion[regnum], mood);
     }
-
-    evblockbasename = oldbasename;
-    evblocknum = oldblocknum;
 }

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -622,8 +622,8 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
                     // LEFTINV is 5, RIGHTINV is 6
                     force_event(EV_TEXTSCRIPT,TS_MCLICK, wasbutdown + 4);
                 }
-                else if (wasbutdown==2)  // right-click is always Look
-                    run_event_block_inv(iit, 0);
+                else if (wasbutdown == kMouseRight) // right-click is always Look
+                    RunInventoryInteraction(iit, MODE_LOOK);
                 else if (cur_mode == MODE_HAND)
                     SetActiveInventory(iit);
                 else

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -616,7 +616,6 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
             mouse_ifacebut_yoffs=mousey-(guio->Y)-guis[wasongui].Y;
             int iit=offset_over_inv((GUIInvWindow*)guio);
             if (iit>=0) {
-                evblocknum=iit;
                 play.used_inv_on = iit;
                 if (game.options[OPT_HANDLEINVCLICKS]) {
                     // Let the script handle the click
@@ -629,7 +628,6 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
                     SetActiveInventory(iit);
                 else
                     RunInventoryInteraction (iit, cur_mode);
-                evblocknum=-1;
             }
         }
         else quit("clicked on unknown control type");

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -21,20 +21,21 @@
 #include "ac/gamesetupstruct.h"
 #include "ac/global_character.h"
 #include "ac/global_display.h"
+#include "ac/global_inventoryitem.h"
 #include "ac/global_room.h"
 #include "ac/mouse.h"
+#include "ac/spritecache.h"
 #include "ac/sys_events.h"
+#include "ac/timer.h"
+#include "ac/dynobj/cc_character.h"
+#include "ac/dynobj/cc_inventory.h"
 #include "debug/debug_log.h"
 #include "gui/guidialog.h"
 #include "gui/guimain.h"
 #include "main/game_run.h"
-#include "platform/base/agsplatformdriver.h"
-#include "ac/spritecache.h"
-#include "script/runtimescriptvalue.h"
-#include "ac/dynobj/cc_character.h"
-#include "ac/dynobj/cc_inventory.h"
 #include "media/audio/audio_system.h"
-#include "ac/timer.h"
+#include "platform/base/agsplatformdriver.h"
+#include "script/runtimescriptvalue.h"
 #include "util/wgt2allg.h"
 
 using namespace AGS::Common;
@@ -392,7 +393,7 @@ bool InventoryScreen::Run()
                 play.used_inv_on = dii[clickedon].num;
 
                 if (cmode==MODE_LOOK) {
-                    run_event_block_inv(dii[clickedon].num, 0); 
+                    RunInventoryInteraction(dii[clickedon].num, MODE_LOOK); 
                     // in case the script did anything to the screen, redraw it
                     UpdateGameOnce();
 
@@ -400,14 +401,11 @@ bool InventoryScreen::Run()
                     return break_code == 0;
                 }
                 else if (cmode==MODE_USE) {
-                    // use objects on each other
-                    play.usedinv=toret;
-
                     // set the activeinv so the script can check it
                     int activeinvwas = playerchar->activeinv;
                     playerchar->activeinv = toret;
 
-                    run_event_block_inv(dii[clickedon].num, 3);
+                    RunInventoryInteraction(dii[clickedon].num, MODE_USE);
 
                     // if the script didn't change it, then put it back
                     if (playerchar->activeinv == toret)

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -44,7 +44,6 @@ extern GameState play;
 extern ScriptInvItem scrInv[MAX_INV];
 extern int mouse_ifacebut_xoffs,mouse_ifacebut_yoffs;
 extern SpriteCache spriteset;
-extern int evblocknum;
 extern CharacterInfo*playerchar;
 extern AGSPlatformDriver *platform;
 extern CCCharacter ccDynamicCharacter;
@@ -390,7 +389,6 @@ bool InventoryScreen::Run()
             if (my<buttonyp) {
                 int clickedon=isonitem;
                 if (clickedon<0) return true; // continue inventory screen loop
-                evblocknum=dii[clickedon].num;
                 play.used_inv_on = dii[clickedon].num;
 
                 if (cmode==MODE_LOOK) {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -985,12 +985,7 @@ void first_room_initialization() {
 void check_new_room() {
     // if they're in a new room, run Player Enters Screen and on_event(ENTER_ROOM)
     if ((in_new_room>0) & (in_new_room!=3)) {
-        EventHappened evh;
-        evh.type = EV_RUNEVBLOCK;
-        evh.data1 = EVB_ROOM;
-        evh.data2 = 0;
-        evh.data3 = EVROM_BEFOREFADEIN;
-        evh.player=game.playercharacter;
+        EventHappened evh(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_BEFOREFADEIN, game.playercharacter);
         // make sure that any script calls don't re-call enters screen
         int newroom_was = in_new_room;
         in_new_room = 0;

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -91,6 +91,7 @@ const int LegacyRoomVolumeFactor            = 30;
 #define FONT_SPEECH     play.speech_font
 
 // Standard interaction verbs (aka cursor modes)
+#define MODE_NONE      -1
 #define MODE_WALK       0
 #define MODE_LOOK       1
 #define MODE_HAND       2

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -89,16 +89,21 @@ const int LegacyRoomVolumeFactor            = 30;
 #define FONT_NORMAL     play.normal_font
 //#define FONT_SPEECHBACK 1
 #define FONT_SPEECH     play.speech_font
-#define MODE_WALK 0
-#define MODE_LOOK 1
-#define MODE_HAND 2
-#define MODE_TALK 3
-#define MODE_USE  4
-#define MODE_PICKUP 5
-#define CURS_ARROW  6
-#define CURS_WAIT   7
-#define MODE_CUSTOM1 8
-#define MODE_CUSTOM2 9
+
+// Standard interaction verbs (aka cursor modes)
+#define MODE_WALK       0
+#define MODE_LOOK       1
+#define MODE_HAND       2
+#define MODE_TALK       3
+#define MODE_USE        4
+#define MODE_PICKUP     5
+// aka MODE_POINTER
+#define CURS_ARROW      6
+// aka MODE_WAIT
+#define CURS_WAIT       7
+#define MODE_CUSTOM1    8
+#define MODE_CUSTOM2    9
+#define NUM_STANDARD_VERBS 10
 
 // Fixed Overlay IDs
 #define OVER_TEXTMSG  1

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -152,7 +152,7 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
 // (eg. a room change occured)
-int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
+int run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny, int isInv) {
 
     if (evnt < 0 || (size_t)evnt >= nint->Events.size() ||
         (nint->Events[evnt].Response.get() == nullptr) || (nint->Events[evnt].Response->Cmds.size() == 0)) {
@@ -165,7 +165,7 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
             return 0;
 
         // Otherwise, run unhandled_event
-        run_unhandled_event(evnt);
+        run_unhandled_event(obj_evt, evnt);
 
         return 0;
     }
@@ -177,11 +177,11 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 
     int cmdsrun = 0, retval = 0;
     // Right, so there were some commands defined in response to the event.
-    retval = run_interaction_commandlist (nint->Events[evnt].Response.get(), &nint->Events[evnt].TimesRun, &cmdsrun);
+    retval = run_interaction_commandlist(obj_evt, nint->Events[evnt].Response.get(), &nint->Events[evnt].TimesRun, &cmdsrun);
 
     // An inventory interaction, but the wrong item was used
     if ((isInv) && (cmdsrun == 0))
-        run_unhandled_event (evnt);
+        run_unhandled_event(obj_evt, evnt);
 
     return retval;
 }
@@ -189,7 +189,7 @@ int run_interaction_event (Interaction *nint, int evnt, int chkAny, int isInv) {
 // Returns 0 normally, or -1 to indicate that the NewInteraction has
 // become invalid and don't run another interaction on it
 // (eg. a room change occured)
-int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny) {
+int run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny) {
 
     if ((nint->ScriptFuncNames.size() <= evnt) || nint->ScriptFuncNames[evnt].IsEmpty()) {
         // no response defined for this event
@@ -200,35 +200,31 @@ int run_interaction_script(InteractionScripts *nint, int evnt, int chkAny) {
             return 0;
 
         // Otherwise, run unhandled_event
-        run_unhandled_event(evnt);
-
+        run_unhandled_event(obj_evt, evnt);
         return 0;
     }
 
     if (play.check_interaction_only) {
-        play.check_interaction_only = 2;
+        play.check_interaction_only = 2; // CHECKME: wth is "2"?
         return -1;
     }
 
     int room_was = play.room_changes;
 
-    RuntimeScriptValue rval_null;
+    if ((strstr(obj_evt.BlockName.GetCStr(), "character") != nullptr) ||
+        (strstr(obj_evt.BlockName.GetCStr(), "inventory") != nullptr)) {
+        // Character or Inventory (global script)
+        QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt].GetCStr());
+    }
+    else {
+        // Other (room script)
+        QueueScriptFunction(kScInstRoom, nint->ScriptFuncNames[evnt].GetCStr());
+    }
 
-        if ((strstr(evblockbasename,"character")!=nullptr) || (strstr(evblockbasename,"inventory")!=nullptr)) {
-            // Character or Inventory (global script)
-            QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt].GetCStr());
-        }
-        else {
-            // Other (room script)
-            QueueScriptFunction(kScInstRoom, nint->ScriptFuncNames[evnt].GetCStr());
-        }
-
-            int retval = 0;
-        // if the room changed within the action
-        if (room_was != play.room_changes)
-            retval = -1;
-
-        return retval;
+    // if the room changed within the action
+    if (room_was != play.room_changes)
+        return -1;
+    return 0;
 }
 
 int create_global_script() {
@@ -759,13 +755,13 @@ struct TempEip {
 // the 'cmdsrun' parameter counts how many commands are run.
 // if a 'Inv Item Was Used' check does not pass, it doesn't count
 // so cmdsrun remains 0 if no inventory items matched
-int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, int*cmdsrun) {
-    size_t i;
-
+int run_interaction_commandlist(const ObjectEvent &obj_evt, InteractionCommandList *nicl, int *timesrun, int*cmdsrun) {
     if (nicl == nullptr)
         return -1;
 
-    for (i = 0; i < nicl->Cmds.size(); i++) {
+    const char *evblockbasename = obj_evt.BlockName.GetCStr();
+    const int evblocknum = obj_evt.BlockID;
+    for (size_t i = 0; i < nicl->Cmds.size(); i++) {
         cmdsrun[0] ++;
         int room_was = play.room_changes;
 
@@ -860,7 +856,7 @@ int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, in
           if (play.usedinv == IPARAM1) {
               if (game.options[OPT_NOLOSEINV] == 0)
                   lose_inventory (play.usedinv);
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           }
           else
@@ -868,17 +864,17 @@ int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, in
           break;
       case 21: // if player has inventory item
           if (playerchar->inv[IPARAM1] > 0)
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       case 22: // if a character is moving
           if (game.chars[IPARAM1].walking)
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       case 23: // if two variables are equal
           if (IPARAM1 == IPARAM2)
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       case 24: // Stop character walking
@@ -951,17 +947,17 @@ int run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, in
           break;
       case 45: // If player character is
           if (GetPlayerCharacter() == IPARAM1)
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       case 46: // if cursor mode is
           if (GetCursorMode() == IPARAM1)
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       case 47: // if player has been to room
           if (HasBeenToRoom(IPARAM1))
-              if (run_interaction_commandlist (nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
+              if (run_interaction_commandlist(obj_evt, nicl->Cmds[i].Children.get(), timesrun, cmdsrun))
                   return -1;
           break;
       default:
@@ -984,12 +980,15 @@ void can_run_delayed_command() {
     quit("!This command cannot be used within non-blocking events such as " REP_EXEC_ALWAYS_NAME);
 }
 
-void run_unhandled_event (int evnt) {
+void run_unhandled_event(const ObjectEvent &obj_evt, int evnt) {
 
     if (play.check_interaction_only)
         return;
 
+    const char *evblockbasename = obj_evt.BlockName.GetCStr();
+    const int evblocknum = obj_evt.BlockID;
     int evtype=0;
+
     if (ags_strnicmp(evblockbasename,"hotspot",7)==0) evtype=1;
     else if (ags_strnicmp(evblockbasename,"object",6)==0) evtype=2;
     else if (ags_strnicmp(evblockbasename,"character",9)==0) evtype=3;

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -139,20 +139,7 @@ void run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun) {
     funcToRun->roomHasFunction = DoRunScriptFuncCantBlock(roominstFork.get(), funcToRun, funcToRun->roomHasFunction);
 }
 
-//-----------------------------------------------------------
-// [IKM] 2012-06-22
-//
-// run_interaction_event() and run_interaction_script()
-// are *almost* identical, except for the first parameter
-// type.
-// May these types be made children of the same base?
-//-----------------------------------------------------------
-
-
-// Returns 0 normally, or -1 to indicate that the NewInteraction has
-// become invalid and don't run another interaction on it
-// (eg. a room change occured)
-int run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny, int isInv) {
+int run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny, bool isInv) {
 
     if (evnt < 0 || (size_t)evnt >= nint->Events.size() ||
         (nint->Events[evnt].Response.get() == nullptr) || (nint->Events[evnt].Response->Cmds.size() == 0)) {

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -178,7 +178,8 @@ int run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evn
 // (eg. a room change occured)
 int run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny) {
 
-    if ((nint->ScriptFuncNames.size() <= evnt) || nint->ScriptFuncNames[evnt].IsEmpty()) {
+    if (evnt < 0 || static_cast<size_t>(evnt) >= nint->ScriptFuncNames.size() ||
+            nint->ScriptFuncNames[evnt].IsEmpty()) {
         // no response defined for this event
         // If there is a response for "Any Click", then abort now so as to
         // run that instead
@@ -196,16 +197,29 @@ int run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint,
         return -1;
     }
 
-    int room_was = play.room_changes;
+    const int room_was = play.room_changes;
 
-    if ((strstr(obj_evt.BlockName.GetCStr(), "character") != nullptr) ||
-        (strstr(obj_evt.BlockName.GetCStr(), "inventory") != nullptr)) {
-        // Character or Inventory (global script)
-        QueueScriptFunction(kScInstGame, nint->ScriptFuncNames[evnt].GetCStr());
+    // TODO: find a way to generalize all the following hard-coded behavior
+
+    // Character or Inventory require a global script call
+    const ScriptInstType inst_type =
+        (strstr(obj_evt.BlockName.GetCStr(), "character") != nullptr) ||
+        (strstr(obj_evt.BlockName.GetCStr(), "inventory") != nullptr) ?
+        kScInstGame : kScInstRoom;
+    
+    // Room events do not require additional params
+    if ((strstr(obj_evt.BlockName.GetCStr(), "room") != nullptr)) {
+        QueueScriptFunction(inst_type, nint->ScriptFuncNames[evnt].GetCStr());
     }
+    // Regions only require 1 param - dynobj ref
+    else if ((strstr(obj_evt.BlockName.GetCStr(), "region") != nullptr)) {
+        QueueScriptFunction(inst_type, nint->ScriptFuncNames[evnt].GetCStr(), 1, &obj_evt.DynObj);
+    }
+    // Other types (characters, objects, invitems, hotspots) require
+    // 2 params - dynobj ref and the interaction mode (aka verb)
     else {
-        // Other (room script)
-        QueueScriptFunction(kScInstRoom, nint->ScriptFuncNames[evnt].GetCStr());
+        RuntimeScriptValue params[]{ obj_evt.DynObj, RuntimeScriptValue().SetInt32(obj_evt.Mode) };
+        QueueScriptFunction(inst_type, nint->ScriptFuncNames[evnt].GetCStr(), 2, params);
     }
 
     // if the room changed within the action

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -51,7 +51,7 @@ struct ObjectEvent
     ObjectEvent(const String &block_name, int block_id = 0)
         : BlockName(block_name), BlockID(block_id) {}
     ObjectEvent(const String &block_name, int block_id,
-                const RuntimeScriptValue &dyn_obj, int mode)
+                const RuntimeScriptValue &dyn_obj, int mode = MODE_NONE)
         : BlockName(block_name), BlockID(block_id), DynObj(dyn_obj), Mode(mode) {}
 };
 

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -50,12 +50,20 @@ struct ObjectEvent
 
 int     run_dialog_request (int parmtr);
 void    run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun);
+
+// TODO: run_interaction_event() and run_interaction_script()
+// are in most part duplicating each other, except for the script callback run method.
+// May these types be made children of the same base, or stored in a group struct?
+// This would also let simplify the calling code in RunObjectInteraction, etc.
+//
 // Runs the ObjectEvent using an old interaction callback type of 'evnt' index,
 // or alternatively of 'chkAny' index, if previous does not exist;
 // 'isInv' tells if this is a inventory event (it has a slightly different handling for that)
-int     run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny = -1, int isInv = 0);
+// Returns 0 normally, or -1 telling of a game state change (eg. a room change occured).
+int     run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny = -1, bool isInv = false);
 // Runs the ObjectEvent using a script callback of 'evnt' index,
 // or alternatively of 'chkAny' index, if previous does not exist
+// Returns 0 normally, or -1 telling of a game state change (eg. a room change occured).
 int     run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny = -1);
 int     run_interaction_commandlist(const ObjectEvent &obj_evt, InteractionCommandList *nicl, int *timesrun, int*cmdsrun);
 void    run_unhandled_event(const ObjectEvent &obj_evt, int evnt);

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -42,10 +42,17 @@ struct ObjectEvent
     String BlockName;
     // Script block's ID, commonly corresponds to the object's ID
     int BlockID = 0;
+    // Dynamic object this event was called for (if applicable)
+    RuntimeScriptValue DynObj;
+    // Interaction mode that triggered this event (if applicable)
+    int Mode = MODE_NONE;
 
     ObjectEvent() = default;
     ObjectEvent(const String &block_name, int block_id = 0)
         : BlockName(block_name), BlockID(block_id) {}
+    ObjectEvent(const String &block_name, int block_id,
+                const RuntimeScriptValue &dyn_obj, int mode)
+        : BlockName(block_name), BlockID(block_id), DynObj(dyn_obj), Mode(mode) {}
 };
 
 int     run_dialog_request (int parmtr);

--- a/Engine/script/script.h
+++ b/Engine/script/script.h
@@ -23,6 +23,7 @@
 #include "game/interactions.h"
 #include "util/string.h"
 
+using AGS::Common::String;
 using AGS::Common::Interaction;
 using AGS::Common::InteractionCommandList;
 using AGS::Common::InteractionScripts;
@@ -32,10 +33,33 @@ using AGS::Common::InteractionVariable;
 #define REP_EXEC_ALWAYS_NAME "repeatedly_execute_always"
 #define REP_EXEC_NAME "repeatedly_execute"
 
+// ObjectEvent - a struct holds data of the object's interaction event,
+// such as object's reference and accompanying parameters
+struct ObjectEvent
+{
+    // Name of the script block to run, may be used as a formatting string;
+    // has a form of "objecttype%d"
+    String BlockName;
+    // Script block's ID, commonly corresponds to the object's ID
+    int BlockID = 0;
+
+    ObjectEvent() = default;
+    ObjectEvent(const String &block_name, int block_id = 0)
+        : BlockName(block_name), BlockID(block_id) {}
+};
+
 int     run_dialog_request (int parmtr);
 void    run_function_on_non_blocking_thread(NonBlockingScriptFunction* funcToRun);
-int     run_interaction_event (Interaction *nint, int evnt, int chkAny = -1, int isInv = 0);
-int     run_interaction_script(InteractionScripts *nint, int evnt, int chkAny = -1);
+// Runs the ObjectEvent using an old interaction callback type of 'evnt' index,
+// or alternatively of 'chkAny' index, if previous does not exist;
+// 'isInv' tells if this is a inventory event (it has a slightly different handling for that)
+int     run_interaction_event(const ObjectEvent &obj_evt, Interaction *nint, int evnt, int chkAny = -1, int isInv = 0);
+// Runs the ObjectEvent using a script callback of 'evnt' index,
+// or alternatively of 'chkAny' index, if previous does not exist
+int     run_interaction_script(const ObjectEvent &obj_evt, InteractionScripts *nint, int evnt, int chkAny = -1);
+int     run_interaction_commandlist(const ObjectEvent &obj_evt, InteractionCommandList *nicl, int *timesrun, int*cmdsrun);
+void    run_unhandled_event(const ObjectEvent &obj_evt, int evnt);
+
 int     create_global_script();
 void    cancel_all_scripts();
 
@@ -69,7 +93,7 @@ void    FreeRoomScriptInstance();
 void    FreeGlobalScripts();
 
 
-AGS::Common::String GetScriptName(ccInstance *sci);
+String  GetScriptName(ccInstance *sci);
 
 //=============================================================================
 
@@ -80,15 +104,13 @@ char*   make_ts_func_name(const char*base,int iii,int subd);
 void    post_script_cleanup();
 void    quit_with_script_error(const char *functionName);
 int     get_nivalue (InteractionCommandList *nic, int idx, int parm);
-int     run_interaction_commandlist (InteractionCommandList *nicl, int *timesrun, int*cmdsrun);
 InteractionVariable *get_interaction_variable (int varindx);
 InteractionVariable *FindGraphicalVariable(const char *varName);
-void    run_unhandled_event (int evnt);
 void    can_run_delayed_command();
 
 // Gets current running script position
 bool    get_script_position(ScriptPosition &script_pos);
-AGS::Common::String cc_get_callstack(int max_lines = INT_MAX);
+String  cc_get_callstack(int max_lines = INT_MAX);
 
 
 extern ExecutingScript scripts[MAX_SCRIPT_AT_ONCE];


### PR DESCRIPTION
Resolves #1765

I believe this is decade overdue...
This adds 2 optional parameters to all of the interaction event callbacks in AGS: object's pointer and a verb (aka cursor mode).
The purpose is to be able to distinguish object and interaction type when user links same function to multiple events. This is similar to how GUI events have GUI/Control and mouse button as parameters.
Right now the users have to resort to ugly workarounds, like calling GetAtScreenXY extra time (which is unreliable), or saving the interacted object in a global variable in on_mouse_click.

The event functions will have following prototype for Characters, Objects, Hotspots and InventoryItems:
```
function cEgo_Interact(Character *c, CursorMode mode)
```

Hotspots have 2 special events without CursorMode param, these are "Walk onto" and "Mouse over":
```
function hHotspot2_MouseMove(Hotspot *h)
```

Regions do not have CursorMode parameter, because their event types are different, not related to interaction mode:
```
function region0_WalksOnto(Region *r)
```

Code-wise the PR is ~50% code refactor.

**Backwards compatibility**

This change is fully backwards compatible, in the sense that script will work even if these parameters were omitted. This was achieved by some of the previous changes in 3.6.0 (related to `on_key_press`), which lets engine to ignore superfluous parameters not matching the function declaration in user script. But it's worth testing this of course.