### PR TITLE
Engine: use enum for Text script callback types

### DIFF
--- a/Engine/ac/event.cpp
+++ b/Engine/ac/event.cpp
@@ -62,7 +62,7 @@ std::vector<EventHappened> events;
 int inside_processevent=0;
 int eventClaimed = EVENT_NONE;
 
-const char *tsnames[TS_NUM] = { nullptr, REP_EXEC_NAME, "on_key_press", "on_mouse_click", "on_text_input" };
+const char *tsnames[kTS_Num] = {nullptr, REP_EXEC_NAME, "on_key_press", "on_mouse_click", "on_text_input" };
 
 
 int run_claimable_event(const char *tsname, bool includeRoom, int numParams, const RuntimeScriptValue *params, bool *eventWasClaimed) {

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -47,16 +47,20 @@
 // new room event
 #define EV_NEWROOM    5
 // Text script callback types:
+enum kTS_CallbackTypes {
+    kTS_None = 0,
 // repeatedly execute
-#define TS_REPEAT     1
+    kTS_Repeat,
 // on key press
-#define TS_KEYPRESS   2
+    kTS_KeyPress,
 // mouse click
-#define TS_MCLICK     3
+    kTS_MouseClick,
 // on text input
-#define TS_TEXTINPUT  4
+    kTS_TextInput,
 // script callback types number
-#define TS_NUM        5
+    kTS_Num
+};
+
 // Room event types:
 // hotspot event
 #define EVB_HOTSPOT   1
@@ -117,7 +121,7 @@ extern std::vector<EventHappened> events;
 
 extern int eventClaimed;
 
-extern const char*tsnames[TS_NUM];
+extern const char*tsnames[kTS_Num];
 
 #endif // __AGS_EE_AC__EVENT_H
 

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -637,7 +637,7 @@ void gui_on_mouse_up(const int wasongui, const int wasbutdown)
                 if (game.options[OPT_HANDLEINVCLICKS]) {
                     // Let the script handle the click
                     // LEFTINV is 5, RIGHTINV is 6
-                    force_event(EV_TEXTSCRIPT,TS_MCLICK, wasbutdown + 4);
+                    force_event(EV_TEXTSCRIPT, kTS_MouseClick, wasbutdown + 4);
                 }
                 else if (wasbutdown == kMouseRight) // right-click is always Look
                     RunInventoryInteraction(iit, MODE_LOOK);

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -149,7 +149,7 @@ static void game_loop_do_early_script_update()
     if (in_new_room == 0) {
         // Run the room and game script repeatedly_execute
         run_function_on_non_blocking_thread(&repExecAlways);
-        setevent(EV_TEXTSCRIPT, TS_REPEAT);
+        setevent(EV_TEXTSCRIPT, kTS_Repeat);
         setevent(EV_RUNEVBLOCK, EVB_ROOM, 0, EVROM_REPEXEC);
     }
 }
@@ -280,13 +280,13 @@ static void check_mouse_controls()
             wasongui=mongu;
             wasbutdown= mbut;
         }
-        else setevent(EV_TEXTSCRIPT,TS_MCLICK, mbut);
+        else setevent(EV_TEXTSCRIPT, kTS_MouseClick, mbut);
     }
 
     if (mwheelz < 0)
-        setevent (EV_TEXTSCRIPT, TS_MCLICK, 9);
+        setevent (EV_TEXTSCRIPT, kTS_MouseClick, 9);
     else if (mwheelz > 0)
-        setevent (EV_TEXTSCRIPT, TS_MCLICK, 8);
+        setevent (EV_TEXTSCRIPT, kTS_MouseClick, 8);
 }
 
 // Runs service key controls, returns false if service key combinations were handled
@@ -577,12 +577,12 @@ static void check_keyboard_controls()
     if (old_keyhandle || (ki.UChar == 0))
     {
         debug_script_log("Running on_key_press keycode %d, mod %d", sckey, sckeymod);
-        setevent(EV_TEXTSCRIPT, TS_KEYPRESS, sckey, sckeymod);
+        setevent(EV_TEXTSCRIPT, kTS_KeyPress, sckey, sckeymod);
     }
     if (!old_keyhandle && (ki.UChar > 0))
     {
         debug_script_log("Running on_text_input char %s (%d)", ki.Text, ki.UChar);
-        setevent(EV_TEXTSCRIPT, TS_TEXTINPUT, ki.UChar);
+        setevent(EV_TEXTSCRIPT, kTS_TextInput, ki.UChar);
     }
 }
 

--- a/Engine/script/script.cpp
+++ b/Engine/script/script.cpp
@@ -465,8 +465,8 @@ int RunScriptFunctionAuto(ScriptInstType sc_inst, const char *tsname, size_t par
     }
     // Claimable event is run in all the script modules and room script,
     // before running in the globalscript instance
-    if ((strcmp(tsname, tsnames[TS_KEYPRESS]) == 0) || (strcmp(tsname, tsnames[TS_MCLICK]) == 0) ||
-        (strcmp(tsname, tsnames[TS_TEXTINPUT]) == 0) || (strcmp(tsname, "on_event") == 0))
+    if ((strcmp(tsname, tsnames[kTS_KeyPress]) == 0) || (strcmp(tsname, tsnames[kTS_MouseClick]) == 0) ||
+        (strcmp(tsname, tsnames[kTS_TextInput]) == 0) || (strcmp(tsname, "on_event") == 0))
     {
         return RunClaimableEvent(tsname, param_count, params);
     }


### PR DESCRIPTION
I think reducing a bit the macros and using enums instead in a few parts may be useful, in this case, just wanted to replace the callback types since adding something for `on_touch` may be something we do in the future.

I made it in ags4 but if master is preferred I can rebase to it.