### PR TITLE
Feature reimport audio clips

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -107,6 +107,7 @@ namespace AGS.Editor
             foreach (AudioClip audio in game.RootAudioClipFolder.GetAllAudioClipsFromAllSubFolders())
             {
                 audio.SourceFileName = Utilities.GetRelativeToProjectPath(audio.SourceFileName);
+                audio.CacheFileName = AudioComponent.GetCacheFileName(audio);
             }
         }
 

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -11,6 +11,7 @@ namespace AGS.Editor.Components
         private const string COMMAND_ADD_AUDIO = "AddAudioClipCmd";
         private const string COMMAND_PROPERTIES = "PropertiesAudioClip";
         private const string COMMAND_RENAME = "RenameAudioClip";
+        private const string COMMAND_REIMPORT = "ReimportAudioClip";
         private const string COMMAND_DELETE = "DeleteAudioClip";
         private const string COMMAND_CHANGE_ID = "ChangeAudioID";
         private const string SPEECH_NODE_ID = "DummySpeechNode";
@@ -101,6 +102,11 @@ namespace AGS.Editor.Components
                 {
                     DeleteSingleItem(clipToDelete);                    
                 }
+            }
+            else if (controlID == COMMAND_REIMPORT)
+            {
+                AudioClip clipToReimport = _items[_rightClickedID];
+                CommandForceReimportOfAudioClip(clipToReimport);                
             }
             else if (controlID == COMMAND_CHANGE_ID)
             {
@@ -497,6 +503,28 @@ namespace AGS.Editor.Components
             }
         }
 
+        private void CommandForceReimportOfAudioClip(AudioClip clip)
+        {
+            if (!ForceReimportOfAudioClip(clip))
+            {
+                _guiController.ShowMessage("Failed to reimport Audio Clip " + clip.ScriptName + ".", MessageBoxIconType.Warning);
+            }
+        }
+
+        private bool ForceReimportOfAudioClip(string sourceFileName, string cacheFileName)
+        {
+            if (File.Exists(sourceFileName) && !string.IsNullOrEmpty(cacheFileName))
+            {
+                return Utilities.SafeCopyFileOverwrite(sourceFileName, cacheFileName, true);
+            }
+            return false;
+        }
+
+        private bool ForceReimportOfAudioClip(AudioClip clip)
+        {
+            return ForceReimportOfAudioClip(clip.SourceFileName, clip.CacheFileName);
+        }
+
         private void AddAudioClipToListIfFileNeedsToBeCopiedFromSource(AudioClip clip, PreCompileGameEventArgs evArgs, List<AudioClip> filesToCopy, List<string> fileNamesToUpdate)
         {
             string compiledFileName = clip.CacheFileName;
@@ -660,6 +688,8 @@ namespace AGS.Editor.Components
                 menu.Add(new MenuCommand(COMMAND_CHANGE_ID, "Change Clip ID", null));
                 menu.Add(new MenuCommand(COMMAND_RENAME, "Rename", null));
                 menu.Add(new MenuCommand(COMMAND_DELETE, "Delete", null));
+                menu.Add(MenuCommand.Separator);
+                menu.Add(new MenuCommand(COMMAND_REIMPORT, "Force Reimport", null));
                 menu.Add(MenuCommand.Separator);
                 menu.Add(new MenuCommand(COMMAND_PROPERTIES, "Properties", null));
             }

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -683,25 +683,30 @@ namespace AGS.Editor
 			}
 		}
 
-        public string ShowOpenFileDialog(string title, string fileFilter, bool useFileImportPath)
+        public string ShowOpenFileDialog(string title, string fileFilter, string initialDirectory)
         {
-			EnsureLastImportDirectoryIsSet(useFileImportPath);
-
-			OpenFileDialog dialog = new OpenFileDialog();
-			dialog.Title = title;
-			dialog.RestoreDirectory = true;
-			dialog.CheckFileExists = true;
-			dialog.CheckPathExists = true;
-			dialog.InitialDirectory = _lastImportDirectory;
-			dialog.ValidateNames = true;
+            OpenFileDialog dialog = new OpenFileDialog();
+            dialog.Title = title;
+            dialog.RestoreDirectory = true;
+            dialog.CheckFileExists = true;
+            dialog.CheckPathExists = true;
+            dialog.InitialDirectory = initialDirectory == null ? Directory.GetCurrentDirectory() : initialDirectory;
+            dialog.ValidateNames = true;
             dialog.Filter = fileFilter;
 
             if (dialog.ShowDialog() == DialogResult.OK)
             {
-				_lastImportDirectory = Path.GetDirectoryName(dialog.FileName);
+                _lastImportDirectory = Path.GetDirectoryName(dialog.FileName);
                 return dialog.FileName;
             }
             return null;
+        }
+
+        public string ShowOpenFileDialog(string title, string fileFilter, bool useFileImportPath)
+        {
+			EnsureLastImportDirectoryIsSet(useFileImportPath);
+
+            return ShowOpenFileDialog(title, fileFilter, _lastImportDirectory);
         }
 
         public string[] ShowOpenFileDialogMultipleFiles(string title, string fileFilter)
@@ -816,6 +821,7 @@ namespace AGS.Editor
                 RoomMessagesUIEditor.ShowRoomMessagesEditor = new RoomMessagesUIEditor.RoomMessagesEditorType(ShowRoomMessageEditorFromPropertyGrid);
                 CustomResolutionUIEditor.CustomResolutionSetGUI = new CustomResolutionUIEditor.CustomResolutionGUIType(ShowCustomResolutionChooserFromPropertyGrid);
                 ColorUIEditor.ColorGUI = new ColorUIEditor.ColorGUIType(ShowColorDialog);
+                AudioClipSourceFileUIEditor.AudioClipSourceFileGUI = new AudioClipSourceFileUIEditor.AudioClipSourceFileGUIType(ShowAudioClipSourceFileChooserFromPropertyGrid);
             }
         }
 
@@ -1385,6 +1391,12 @@ namespace AGS.Editor
         private void ShowRoomMessageEditorFromPropertyGrid(List<RoomMessage> messages)
         {
             RoomMessagesEditor.ShowEditor(messages);
+        }
+
+        private AudioClip ShowAudioClipSourceFileChooserFromPropertyGrid(AudioClip audioClip)
+        {
+            Factory.ComponentController.FindComponent<AudioComponent>()?.ReplaceAudioClipSource(audioClip);
+            return audioClip;
         }
 
         private int ShowSpriteChooserFromPropertyGrid(int currentSprite)

--- a/Editor/AGS.Editor/GUI/OutputPanel.cs
+++ b/Editor/AGS.Editor/GUI/OutputPanel.cs
@@ -60,11 +60,15 @@ namespace AGS.Editor
 					else
 					{
 						newItem.ImageKey = "CompileWarningIcon";
-					}
-					
-					if (error.ScriptName.Length > 0)
+                    }
+
+                    if (error.ScriptName.Length > 0)
                     {
                         newItem.SubItems.Add(error.ScriptName);
+                    }
+
+                    if (error.ScriptName.Length > 0 && error.LineNumber > 0)
+                    {
                         newItem.SubItems.Add(error.LineNumber.ToString());
                     }
                 }

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -285,6 +285,36 @@ namespace AGS.Editor
             File.SetAttributes(destFileName, FileAttributes.Archive);
         }
 
+        public static bool SafeCopyFileOverwrite(string sourceFileName, string destFileName, bool makeDestinationWritable = false)
+        {
+            string bkpDestFileName = destFileName + ".bkp";
+            if (File.Exists(destFileName))
+            {
+                File.Move(destFileName, bkpDestFileName);
+            }
+            try
+            {
+                File.Copy(sourceFileName, destFileName, true);
+                if (makeDestinationWritable) File.SetAttributes(destFileName, FileAttributes.Archive);
+            }
+            catch
+            {
+                if (File.Exists(bkpDestFileName))
+                {
+                    File.Move(bkpDestFileName, destFileName);
+                }
+                return false;
+            }
+            finally
+            {
+                if (File.Exists(bkpDestFileName))
+                {
+                    File.Delete(bkpDestFileName);
+                }
+            }
+            return true;
+        }
+
         public static void CopyFont(int fromSlot, int toSlot)
         {
             if (fromSlot == toSlot)

--- a/Editor/AGS.Types/AGS.Types.csproj
+++ b/Editor/AGS.Types/AGS.Types.csproj
@@ -190,10 +190,12 @@
     <Compile Include="Plugins\IAGSEditor.cs" />
     <Compile Include="Plugins\IAGSEditorPlugin.cs" />
     <Compile Include="Plugins\RequiredAGSVersionAttribute.cs" />
+    <Compile Include="PropertyGridExtras\AudioClipSourceFileUIEditor.cs" />
     <Compile Include="PropertyGridExtras\ColorUIEditor.cs" />
     <Compile Include="PropertyGridExtras\CustomPropertiesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\InteractionPropertyDescriptor.cs" />
     <Compile Include="PropertyGridExtras\PropertyTabInteractions.cs" />
+    <Compile Include="PropertyGridExtras\ReadOnlyConverter .cs" />
     <Compile Include="PropertyGridExtras\RoomMaskResolutionTypeConverter.cs" />
     <Compile Include="PropertyGridExtras\RoomMessagesUIEditor.cs" />
     <Compile Include="PropertyGridExtras\SpriteFileNameEditor.cs" />

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -43,6 +43,21 @@ namespace AGS.Types
 
         [AGSNoSerialize]
         [Browsable(false)]
+        public static string GetCacheFileNameWithoutPath(int index, string sourceFileName)
+        {
+            return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, index, Path.GetExtension(sourceFileName));
+        }
+
+        [AGSNoSerialize]
+        [Browsable(false)]
+        public static string GetCacheFileName(int index, string sourceFileName)
+        {
+            return Path.Combine(AUDIO_CACHE_DIRECTORY, GetCacheFileNameWithoutPath(index, sourceFileName));
+        }
+
+
+        [AGSNoSerialize]
+        [Browsable(false)]
         public string CacheFileName
         {
             get { return Path.Combine(AUDIO_CACHE_DIRECTORY, this.CacheFileNameWithoutPath) ; }
@@ -54,7 +69,7 @@ namespace AGS.Types
         [DisplayName("Cache File Name")]
         public string CacheFileNameWithoutPath
         {
-            get { return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, _fixedID, Path.GetExtension(_sourceFileName)); }
+            get { return GetCacheFileNameWithoutPath(_fixedID, _sourceFileName); }
         }
 
         [DisplayName("ID")]
@@ -66,8 +81,9 @@ namespace AGS.Types
             set { _id = value; }
         }
 
-        [ReadOnly(true)]
         [Description("The file from which this audio clip was imported")]
+        [Editor(typeof(AudioClipSourceFileUIEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        [TypeConverter(typeof(ReadOnlyConverter))]
         public string SourceFileName
         {
             get { return _sourceFileName; }

--- a/Editor/AGS.Types/AudioClip.cs
+++ b/Editor/AGS.Types/AudioClip.cs
@@ -8,12 +8,12 @@ namespace AGS.Types
     [DefaultProperty("BundlingType")]
     public class AudioClip : IToXml, IComparable<AudioClip>
     {
-        private const string COMPILED_AUDIO_FILENAME_PREFIX = "au";
         public const string AUDIO_CACHE_DIRECTORY = "AudioCache";
         public const int MAX_SCRIPTNAME_LENGTH = 29; // restricted by data format
 
         private int _id;
         private string _sourceFileName;
+        private string _cacheFileName;
         private string _scriptName;
         // FixedID is a clip's UID which never change, even if the list got reordered
         private int _fixedID;
@@ -43,24 +43,10 @@ namespace AGS.Types
 
         [AGSNoSerialize]
         [Browsable(false)]
-        public static string GetCacheFileNameWithoutPath(int index, string sourceFileName)
-        {
-            return string.Format("{0}{1:X6}{2}", COMPILED_AUDIO_FILENAME_PREFIX, index, Path.GetExtension(sourceFileName));
-        }
-
-        [AGSNoSerialize]
-        [Browsable(false)]
-        public static string GetCacheFileName(int index, string sourceFileName)
-        {
-            return Path.Combine(AUDIO_CACHE_DIRECTORY, GetCacheFileNameWithoutPath(index, sourceFileName));
-        }
-
-
-        [AGSNoSerialize]
-        [Browsable(false)]
         public string CacheFileName
         {
-            get { return Path.Combine(AUDIO_CACHE_DIRECTORY, this.CacheFileNameWithoutPath) ; }
+            get { return _cacheFileName; }
+            set { _cacheFileName = value; }
         }
 
         [AGSNoSerialize]
@@ -69,7 +55,7 @@ namespace AGS.Types
         [DisplayName("Cache File Name")]
         public string CacheFileNameWithoutPath
         {
-            get { return GetCacheFileNameWithoutPath(_fixedID, _sourceFileName); }
+            get { return Path.GetFileName(CacheFileName); }
         }
 
         [DisplayName("ID")]

--- a/Editor/AGS.Types/PropertyGridExtras/AudioClipSourceFileUIEditor.cs
+++ b/Editor/AGS.Types/PropertyGridExtras/AudioClipSourceFileUIEditor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Design;
+
+namespace AGS.Types
+{
+    public class AudioClipSourceFileUIEditor : UITypeEditor
+    {
+        public delegate AudioClip AudioClipSourceFileGUIType(AudioClip audioClip);
+        public static AudioClipSourceFileGUIType AudioClipSourceFileGUI;
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        {
+            return UITypeEditorEditStyle.Modal;
+        }
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            AudioClip audioClip = context.Instance as AudioClip;
+
+            if (AudioClipSourceFileGUI != null && audioClip != null)
+            {
+                audioClip = AudioClipSourceFileGUI(audioClip);
+                return audioClip.SourceFileName;
+            }
+            return value;
+        }
+    }
+}

--- a/Editor/AGS.Types/PropertyGridExtras/ReadOnlyConverter .cs
+++ b/Editor/AGS.Types/PropertyGridExtras/ReadOnlyConverter .cs
@@ -1,0 +1,8 @@
+﻿using System.ComponentModel;
+
+namespace AGS.Types
+{
+    public class ReadOnlyConverter : TypeConverter
+    {
+    }
+}


### PR DESCRIPTION
I will start saying that I don't know if this is a good idea, but what this does is it adds a right click option to force reimport of one audio clip or force reimport all audio clips.

The way it works is it uses the clip source file name and copies the file to the clip cache file name, if it exists.

Maybe fix #778 and someone else can write a  better issue for the things that are in that issue that came up later on.

Also fix #2051