### PR TITLE
4.0 Editor: move translation src migration process to TranslationComponent

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -106,14 +106,16 @@ namespace AGS.Editor
          * 
          * 3.99.99.00     - BlendMode for various objects, Character.Transparency.
          * 3.99.99.01     - Open rooms
+         * 3.99.99.07     - PO translations
          *
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3999901;
+        public const int    LATEST_XML_VERSION_INDEX = 3999907;
         /// <summary>
         /// XML version index on the release of AGS 4.0.0, this constant be used to determine
         /// if upgrade of Rooms/Sprites/etc. to new format have been performed.
         /// </summary>
-        public const int    AGS_4_0_0_XML_VERSION_INDEX = 3999901;
+        public const int    AGS_4_0_0_XML_VERSION_INDEX_OPEN_ROOMS = 3999901;
+        public const int    AGS_4_0_0_XML_VERSION_INDEX_PO_TRANSLATIONS = 3999907;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -2200,7 +2200,7 @@ namespace AGS.Editor.Components
         /// </remarks>
         private async void ConvertAllRoomsFromCrmToOpenFormat()
         {
-            if (_agsEditor.CurrentGame.SavedXmlVersionIndex >= AGSEditor.AGS_4_0_0_XML_VERSION_INDEX)
+            if (_agsEditor.CurrentGame.SavedXmlVersionIndex >= AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_OPEN_ROOMS)
                 return; // Upgrade already completed
 
             IList<IRoom> rooms = _agsEditor.CurrentGame.Rooms;

--- a/Editor/AGS.Editor/Components/TranslationsComponent.cs
+++ b/Editor/AGS.Editor/Components/TranslationsComponent.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
 using AGS.Types;
+using TypeUtils = AGS.Types.Utilities;
 
 namespace AGS.Editor.Components
 {
@@ -21,6 +22,8 @@ namespace AGS.Editor.Components
         private const string COMMAND_UPDATE_ALL = "UpdateAllTranslations";
         private const string COMMAND_COMPILE = "CompileTranslation";
         private const string COMMAND_MAKE_DEFAULT = "MakeDefaultTranslation";
+
+        private const string TRANSLATION_SOURCE_FILE_LEGACY_EXTENSION = ".trs";
 
         private const string COMPILED_TRANSLATION_FILE_SIGNATURE = "AGSTranslation\0";
         private const int TRANSLATION_BLOCK_TRANSLATION_DATA = 1;
@@ -47,6 +50,7 @@ namespace AGS.Editor.Components
             _guiController.RegisterIcon("TranslationsIcon", Resources.ResourceManager.GetIcon("translations.ico"));
             _guiController.RegisterIcon("TranslationIcon", Resources.ResourceManager.GetIcon("translations.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, TOP_LEVEL_COMMAND_ID, "Translations", "TranslationsIcon");
+            Factory.Events.GamePostLoad += ConvertTranslationsToPOFormat;
             RePopulateTreeView();
         }
 
@@ -612,5 +616,105 @@ namespace AGS.Editor.Components
             }
         }
 
+        /// <summary>
+        /// Finishes migration from old translation sources to the new PO format.
+        /// CHECKME: the format conversion itself is currently done within the Translation
+        /// class itself. I'm not entirely convinced this is the optimal way, as AGS.Types
+        /// may be linked by plugins and third-party tools, so maybe think that over later.
+        /// </summary>
+        private void ConvertTranslationsToPOFormat()
+        {
+            if (_agsEditor.CurrentGame.SavedXmlVersionIndex >= AGSEditor.AGS_4_0_0_XML_VERSION_INDEX_PO_TRANSLATIONS)
+                return; // Should be using PO source files at this point
+
+            foreach (var translation in _agsEditor.CurrentGame.Translations)
+            {
+                string legacyFileName = translation.Name + TRANSLATION_SOURCE_FILE_LEGACY_EXTENSION;
+                if (File.Exists(legacyFileName))
+                {
+                    LoadTranslationFromLegacySource(translation, legacyFileName);
+                    translation.SaveData();
+                    Utilities.TryDeleteFile(legacyFileName);
+                }
+            }
+        }
+
+        private void LoadTranslationFromLegacySource(Translation translation, string fileName)
+        {
+            string old_encoding = translation.EncodingHint;
+            using (StreamReader sr = new StreamReader(fileName, translation.Encoding))
+            {
+                string line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    if (line.StartsWith("//"))
+                    {
+                        LegacyReadSpecialTags(translation, line);
+                        if (string.Compare(old_encoding, translation.EncodingHint) != 0)
+                        {
+                            // try again with the new encoding
+                            sr.Close();
+                            LoadTranslationFromLegacySource(translation, fileName);
+                            return;
+                        }
+                        continue;
+                    }
+                    string originalText = line;
+                    string translatedText = sr.ReadLine();
+                    if (translatedText == null)
+                    {
+                        break;
+                    }
+                    // Silently ignore any duplicates, as we can't report warnings here
+                    if (!translation.TranslatedEntries.ContainsKey(originalText))
+                    {
+                        TranslationEntry entry = new TranslationEntry();
+                        entry.Key = originalText;
+                        entry.Value = translatedText;
+                        translation.TranslatedEntries.Add(originalText, entry);
+                    }
+                }
+            }
+        }
+
+        private void LegacyReadSpecialTags(Translation translation, string line)
+        {
+            const string NORMAL_FONT_TAG = "//#NormalFont=";
+            const string SPEECH_FONT_TAG = "//#SpeechFont=";
+            const string TEXT_DIRECTION_TAG = "//#TextDirection=";
+            const string ENCODING_TAG = "//#Encoding=";
+            const string TAG_DEFAULT = "DEFAULT";
+            const string TAG_DIRECTION_LEFT = "LEFT";
+            const string TAG_DIRECTION_RIGHT = "RIGHT";
+
+            if (line.StartsWith(NORMAL_FONT_TAG))
+            {
+                translation.NormalFont = TypeUtils.ParseNullableInt(line.Substring(NORMAL_FONT_TAG.Length), TAG_DEFAULT);
+            }
+            else if (line.StartsWith(SPEECH_FONT_TAG))
+            {
+                translation.SpeechFont = TypeUtils.ParseNullableInt(line.Substring(SPEECH_FONT_TAG.Length), TAG_DEFAULT);
+            }
+            else if (line.StartsWith(TEXT_DIRECTION_TAG))
+            {
+                string directionText = line.Substring(TEXT_DIRECTION_TAG.Length);
+                if (directionText == TAG_DIRECTION_LEFT)
+                {
+                    translation.RightToLeftText = false;
+                }
+                else if (directionText == TAG_DIRECTION_RIGHT)
+                {
+                    translation.RightToLeftText = true;
+                }
+                else
+                {
+                    translation.RightToLeftText = null;
+                }
+            }
+            else if (line.StartsWith(ENCODING_TAG))
+            {
+                translation.EncodingHint = line.Substring(ENCODING_TAG.Length);
+            }
+        }
     }
 }

--- a/Editor/AGS.Types/Translation.cs
+++ b/Editor/AGS.Types/Translation.cs
@@ -67,7 +67,11 @@ namespace AGS.Types
         public string Name
         {
             get { return _name; }
-            set { _name = value; _fileName = _name + TRANSLATION_SOURCE_FILE_EXTENSION; }
+            set
+            {
+                _name = value;
+                _fileName = _name + TRANSLATION_SOURCE_FILE_EXTENSION;
+            }
         }
         
         public string FileName
@@ -100,16 +104,19 @@ namespace AGS.Types
         public int? NormalFont
         {
             get { return _normalFont; }
+            set { _normalFont = value; }
         }
 
         public int? SpeechFont
         {
             get { return _speechFont; }
+            set { _speechFont = value; }
         }
 
         public bool? RightToLeftText
         {
             get { return _rightToLeftText; }
+            set { _rightToLeftText = value; }
         }
 
         public string EncodingHint
@@ -164,9 +171,9 @@ namespace AGS.Types
                 sw.WriteLine("# ** Translation settings are below");
                 sw.WriteLine("# ** Leave them as \"DEFAULT\" to use the game settings");
                 sw.WriteLine("# The normal font to use - DEFAULT or font number");
-                sw.WriteLine("# $NormalFont=" + WriteOptionalInt(_normalFont));
+                sw.WriteLine("# $NormalFont=" + _normalFont.NullableToString(TAG_DEFAULT));
                 sw.WriteLine("# The speech font to use - DEFAULT or font number");
-                sw.WriteLine("# $SpeechFont=" + WriteOptionalInt(_speechFont));
+                sw.WriteLine("# $SpeechFont=" + _speechFont.NullableToString(TAG_DEFAULT));
                 sw.WriteLine("# Text direction - DEFAULT, LEFT or RIGHT");
                 sw.WriteLine("# $TextDirection=" + ((_rightToLeftText == true) ? TAG_DIRECTION_RIGHT : ((_rightToLeftText == null) ? TAG_DEFAULT : TAG_DIRECTION_LEFT)));
                 sw.WriteLine("# Text encoding hint - ASCII or UTF-8");
@@ -244,12 +251,8 @@ namespace AGS.Types
             _translatedEntries = new Dictionary<string, TranslationEntry>();
             string old_encoding = _encodingHint;
 
-            // .po file not found, check for legacy translation format
-            if (!File.Exists(FileName) && File.Exists(_name + ".trs"))
+            if (!File.Exists(FileName))
             {
-                LegacyLoadData();
-                SaveData();
-                File.Delete(_name + ".trs");
                 return;
             }
 
@@ -436,11 +439,11 @@ namespace AGS.Types
         {
             if (line.StartsWith(NORMAL_FONT_TAG))
             {
-                _normalFont = ReadOptionalInt(line.Substring(NORMAL_FONT_TAG.Length));
+                _normalFont = Utilities.ParseNullableInt(line.Substring(NORMAL_FONT_TAG.Length), TAG_DEFAULT);
             }
             else if (line.StartsWith(SPEECH_FONT_TAG))
             {
-                _speechFont = ReadOptionalInt(line.Substring(SPEECH_FONT_TAG.Length));
+                _speechFont = Utilities.ParseNullableInt(line.Substring(SPEECH_FONT_TAG.Length), TAG_DEFAULT);
             }
             else if (line.StartsWith(TEXT_DIRECTION_TAG))
             {
@@ -464,101 +467,5 @@ namespace AGS.Types
                 EncodingHint = line.Substring(ENCODING_TAG.Length);
             }
         }
-
-        private int? ReadOptionalInt(string textToParse)
-        {
-            if (textToParse == TAG_DEFAULT)
-            {
-                return null;
-            }
-            return Convert.ToInt32(textToParse);
-        }
-
-        private string WriteOptionalInt(int? currentValue)
-        {
-            if (currentValue == null)
-            {
-                return TAG_DEFAULT;
-            }
-            return currentValue.Value.ToString();
-        }
-
-        // Migrations from .trs files
-        private void LegacyLoadData()
-        {
-            _translatedEntries = new Dictionary<string, TranslationEntry>();
-            string old_encoding = _encodingHint;
-
-            using (StreamReader sr = new StreamReader(_name + ".trs", _encoding))
-            {
-                string line;
-                while ((line = sr.ReadLine()) != null)
-                {
-                    if (line.StartsWith("//"))
-                    {
-                        LegacyReadSpecialTags(line);
-                        if (string.Compare(old_encoding, _encodingHint) != 0)
-                        {
-                            sr.Close();
-                            LoadData(); // try again with the new encoding
-                            return;
-                        }
-                        continue;
-                    }
-                    string originalText = line;
-                    string translatedText = sr.ReadLine();
-                    if (translatedText == null)
-                    {
-                        break;
-                    }
-                    // Silently ignore any duplicates, as we can't report warnings here
-                    if (!_translatedEntries.ContainsKey(originalText))
-                    {
-                        TranslationEntry entry = new TranslationEntry();
-                        entry.Key = originalText;
-                        entry.Value = translatedText;
-                        _translatedEntries.Add(originalText, entry);
-                    }
-                }
-            }
-        }
-
-        private void LegacyReadSpecialTags(string line)
-        {
-            const string NORMAL_FONT_TAG = "# $NormalFont=";
-            const string SPEECH_FONT_TAG = "# $SpeechFont=";
-            const string TEXT_DIRECTION_TAG = "# $TextDirection=";
-            const string ENCODING_TAG = "# $Encoding=";
-            if (line.StartsWith(NORMAL_FONT_TAG))
-            {
-                _normalFont = ReadOptionalInt(line.Substring(NORMAL_FONT_TAG.Length));
-            }
-            else if (line.StartsWith(SPEECH_FONT_TAG))
-            {
-                _speechFont = ReadOptionalInt(line.Substring(SPEECH_FONT_TAG.Length));
-            }
-            else if (line.StartsWith(TEXT_DIRECTION_TAG))
-            {
-                string directionText = line.Substring(TEXT_DIRECTION_TAG.Length);
-                if (directionText == TAG_DIRECTION_LEFT)
-                {
-                    _rightToLeftText = false;
-                }
-                else if (directionText == TAG_DIRECTION_RIGHT)
-                {
-                    _rightToLeftText = true;
-                }
-                else
-                {
-                    _rightToLeftText = null;
-                }
-            }
-            else if (line.StartsWith(ENCODING_TAG))
-            {
-                EncodingHint = line.Substring(ENCODING_TAG.Length);
-            }
-        }
-
-
     }
 }

--- a/Editor/AGS.Types/Utilities.cs
+++ b/Editor/AGS.Types/Utilities.cs
@@ -84,6 +84,32 @@ namespace AGS.Types
             return v;
         }
 
+        /// <summary>
+        /// Parses a nullable int, treating user-provided string constant
+        /// as a "null value" indicator.
+        /// </summary>
+        public static int? ParseNullableInt(string text, string nullValueString)
+        {
+            if (text == nullValueString)
+            {
+                return null;
+            }
+            return Convert.ToInt32(text);
+        }
+
+        /// <summary>
+        /// Extension method writes a nullable int, using user-provided string constant
+        /// for a "null value".
+        /// </summary>
+        public static string NullableToString(this int? value, string nullValueString)
+        {
+            if (value == null)
+            {
+                return nullValueString;
+            }
+            return value.Value.ToString();
+        }
+
         public static string RemoveInvalidCharactersFromScriptName(string name)
         {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
AGS.Types had been used as a Editor's "API" for a long while now, it's commonly linked to Editor plugins and third-party tools (such as FontEditor app). Therefore we cannot make any assumptions about filesystem around AGS.Types library, and should not implicitly delete or move project files.

Besides that, implicitly loading from legacy format and deleting files in random time is inconsistent with how Editor normally works.

With this change I move migration from old TRS format to the new PO format into the TranslationComponent class, where it runs it triggered by GamePostLoad event.

In addition, rise format index, and add a constant that tells the first version the PO became new translation source format.

Made a PR because I still have concerns that I could miss something.