### PR TITLE
Support multiple mouse clicks per game frame

### DIFF
--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -933,6 +933,7 @@ bool DialogOptions::Run()
 
     // Handle player's input
     RunControls();
+    ags_clear_input_buffer();
 
     // Post user input, processing changes
     // Handle default rendering changing an active option
@@ -1001,8 +1002,7 @@ bool DialogOptions::RunControls()
             if (run_service_key_controls(ki) && !play.IsIgnoringInput() &&
                 RunKey(ki))
             {
-                ags_clear_input_buffer();
-                return true; // handled by dialog options
+                return true; // handled
             }
         }
         else if (type == kInputMouse)
@@ -1011,8 +1011,7 @@ bool DialogOptions::RunControls()
             if (run_service_mb_controls(mbut) && !play.IsIgnoringInput() &&
                 RunMouse(mbut))
             {
-                ags_clear_input_buffer();
-                return true; // handled by dialog options
+                return true; // handled
             }
         }
     }

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -319,20 +319,25 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
             update_audio_system_on_game_loop();
             UpdateCursorAndDrawables();
             render_graphics();
-            eAGSMouseButton mbut;
-            int mwheelz;
-            if (run_service_mb_controls(mbut, mwheelz) && mbut > kMouseNone) {
-                check_skip_cutscene_mclick(mbut);
-                if (play.fast_forward)
-                    break;
-                if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
-                {
-                    play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
-                    break;
-                }
-            }
 
             bool do_break = false;
+            while (!play.fast_forward && !do_break && ags_mouseevent_ready())
+            {
+                eAGSMouseButton mbut;
+                int mwheelz;
+                if (run_service_mb_controls(mbut, mwheelz) && mbut > kMouseNone)
+                {
+                    check_skip_cutscene_mclick(mbut);
+                    if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
+                    {
+                        play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
+                        do_break = true;
+                    }
+                }
+            }
+            if (do_break)
+                break;
+
             while (!play.fast_forward && !do_break && ags_keyevent_ready())
             {
                 KeyInput ki;

--- a/Engine/ac/display.cpp
+++ b/Engine/ac/display.cpp
@@ -226,6 +226,42 @@ Bitmap *create_textual_image(const char *text, int asspch, int isThought,
     return text_window_ds;
 }
 
+// Handles player's input during blocking display() call;
+// returns if the display loop should break.
+bool display_check_user_input(int skip)
+{
+    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    { // NOTE: must handle them all in case there were engine's hotkeys too
+        if (type == kInputKeyboard)
+        {
+            KeyInput ki;
+            if (!run_service_key_controls(ki) || play.fast_forward)
+                continue;
+            if (check_skip_cutscene_keypress(ki.Key))
+                return true;
+            if ((skip & SKIP_KEYPRESS) && !play.IsIgnoringInput() && !IsAGSServiceKey(ki.Key))
+            {
+                play.SetWaitKeySkip(ki);
+                return true; // stop display
+            }
+        }
+        else if (type == kInputMouse)
+        {
+            eAGSMouseButton mbut;
+            if (!run_service_mb_controls(mbut) || play.fast_forward)
+                continue;
+            if (check_skip_cutscene_mclick(mbut))
+                return true;
+            if (skip & SKIP_MOUSECLICK && !play.IsIgnoringInput())
+            {
+                play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
+                return true; // stop display
+            }
+        }
+    }
+    return false; // continue display loop
+}
+
 // Pass yy = -1 to find Y co-ord automatically
 // allowShrink = 0 for none, 1 for leftwards, 2 for rightwards
 // pass blocking=2 to create permanent overlay
@@ -320,35 +356,9 @@ ScreenOverlay *_display_main(int xx, int yy, int wii, const char *text, int disp
             UpdateCursorAndDrawables();
             render_graphics();
 
-            // Handle player's input
-            bool do_break = false;
-            for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
-            { // NOTE: must handle them all in case there were engine's hotkeys too
-                KeyInput ki;
-                eAGSMouseButton mbut;
-                if ((type == kInputKeyboard) && run_service_key_controls(ki) &&
-                    !play.fast_forward && !do_break)
-                {
-                    check_skip_cutscene_keypress(ki.Key);
-                    if ((skip_setting & SKIP_KEYPRESS) && !play.IsIgnoringInput() &&
-                        !IsAGSServiceKey(ki.Key))
-                    {
-                        play.SetWaitKeySkip(ki);
-                        do_break = true;
-                    }
-                }
-                else if ((type == kInputMouse) && run_service_mb_controls(mbut) &&
-                    !play.fast_forward && !do_break)
-                {
-                    check_skip_cutscene_mclick(mbut);
-                    if (skip_setting & SKIP_MOUSECLICK && !play.IsIgnoringInput())
-                    {
-                        play.SetWaitSkipResult(SKIP_MOUSECLICK, mbut);
-                        do_break = true;
-                    }
-                }
-            }
-
+            // Handle player's input, break the loop if requested
+            bool do_break = display_check_user_input(skip_setting);
+            ags_clear_input_buffer();
             if (do_break)
                 break;
             

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -375,6 +375,7 @@ bool InventoryScreen::Run()
     break_code = 0;
     // Handle player's input
     RunControls(mx, my, isonitem);
+    ags_clear_input_buffer();
 
     // Test if need to break the loop
     if (break_code != 0)
@@ -408,7 +409,6 @@ bool InventoryScreen::RunControls(int mx, int my, int isonitem)
             KeyInput ki;
             if (run_service_key_controls(ki) && !play.IsIgnoringInput())
             {
-                ags_clear_input_buffer();
                 break_code = 1;
                 return true; // always handle for any key
             }
@@ -419,8 +419,7 @@ bool InventoryScreen::RunControls(int mx, int my, int isonitem)
             if (run_service_mb_controls(mbut) && !play.IsIgnoringInput() &&
                 RunMouse(mbut, mx, my, isonitem))
             {
-                ags_clear_input_buffer();
-                return true; // was handled
+                return true; // handled
             }
         }
     }
@@ -474,7 +473,6 @@ bool InventoryScreen::RunMouse(eAGSMouseButton mbut, int mx, int my, int isonite
                 }
 
                 need_redraw = true;
-                return true; // handled
             }
             else
             {

--- a/Engine/ac/invwindow.cpp
+++ b/Engine/ac/invwindow.cpp
@@ -407,7 +407,8 @@ bool InventoryScreen::RunControls(int mx, int my, int isonitem)
         if (type == kInputKeyboard)
         {
             KeyInput ki;
-            if (run_service_key_controls(ki) && !play.IsIgnoringInput())
+            if (run_service_key_controls(ki) && !play.IsIgnoringInput() &&
+                !IsAGSServiceKey(ki.Key))
             {
                 break_code = 1;
                 return true; // always handle for any key

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -54,8 +54,6 @@ Bitmap *dotted_mouse_cursor = nullptr;
 IDriverDependantBitmap *mouseCursor = nullptr;
 Bitmap *blank_mouse_cursor = nullptr;
 
-eAGSMouseButton simulatedClick = kMouseNone;
-
 // The Mouse:: functions are static so the script doesn't pass
 // in an object parameter
 void Mouse_SetVisible(int isOn) {
@@ -319,7 +317,7 @@ int IsModeEnabled(int which) {
 }
 
 void SimulateMouseClick(int button_id) {
-    simulatedClick = static_cast<eAGSMouseButton>(button_id);
+    ags_simulate_mouseclick(static_cast<eAGSMouseButton>(button_id));
 }
 
 void Mouse_EnableControl(bool on)

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -93,7 +93,6 @@ extern unsigned int loopcounter;
 extern IDriverDependantBitmap* roomBackgroundBmp;
 extern IGraphicsDriver *gfxDriver;
 extern RGB palette[256];
-extern int mouse_z_was;
 
 extern CCHotspot ccDynamicHotspot;
 extern CCObject ccDynamicObject;
@@ -976,7 +975,6 @@ void first_room_initialization() {
     starting_room = displayed_room;
     playerchar->prevroom = -1;
     set_loop_counter(0);
-    mouse_z_was = sys_mouse_z;
     // Reset background frame state
     play.bg_frame = 0;
     play.bg_frame_locked = (thisroom.Options.Flags & kRoomFlag_BkgFrameLocked) != 0;

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -41,7 +41,7 @@ eAGSKeyCode sdl_key_to_ags_key(const SDL_KeyboardEvent &kbevt, bool old_keyhandl
 int sdl_mod_to_ags_mod(const SDL_KeyboardEvent &kbevt);
 
 // Converts SDL scan and key codes to the ags keycode
-KeyInput ags_keycode_from_sdl(const SDL_Event &event, bool old_keyhandle)
+KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event, bool old_keyhandle)
 {
     KeyInput ki;
     // Normally SDL_TEXTINPUT is meant for handling the printable characters,
@@ -249,10 +249,6 @@ bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3])
 
 
 
-
-
-
-
 // ----------------------------------------------------------------------------
 // KEYBOARD INPUT
 // ----------------------------------------------------------------------------
@@ -346,9 +342,21 @@ enum eAGSMouseButtonMask
     MouseBitX2       = 0x10
 };
 
+eAGSMouseButton sdl_mbut_to_ags_but(int sdl_mbut)
+{
+    switch (sdl_mbut)
+    {
+    case SDL_BUTTON_LEFT: return kMouseLeft;
+    case SDL_BUTTON_RIGHT: return kMouseRight;
+    case SDL_BUTTON_MIDDLE: return kMouseMiddle;
+    default: return kMouseNone;
+    }
+}
+
 static int sdl_button_to_mask(int button)
 {
-    switch (button) {
+    switch (button)
+    {
     case SDL_BUTTON_LEFT: return MouseBitLeft;
     case SDL_BUTTON_RIGHT: return MouseBitRight;
     case SDL_BUTTON_MIDDLE: return MouseBitMiddle;
@@ -358,15 +366,26 @@ static int sdl_button_to_mask(int button)
     return 0;
 }
 
-/* [sonneveld]
-Button tracking:
-On OSX, some tap to click up/down events happen too quickly to be detected on the polled mouse_b global variable.
-Instead we accumulate button presses over a couple of timer loops.
-// TODO: check again when/if we replace polling with different event handling.
-*/
+static int ags_button_to_sdl(eAGSMouseButton but)
+{
+    switch (but)
+    {
+    case kMouseLeft: return SDL_BUTTON_LEFT;
+    case kMouseRight: return SDL_BUTTON_RIGHT;
+    case kMouseMiddle: return SDL_BUTTON_MIDDLE;
+    default: return 0;
+    }
+}
+
+// Convert mouse button id to flags
+const int MouseButton2Bits[kNumMouseButtons] =
+    { 0, MouseBitLeft, MouseBitRight, MouseBitMiddle };
+
+
+// Because our game engine still uses input polling, we have to accumulate
+// mouse button events for our internal use whenever engine have to query button input.
+static std::deque<SDL_Event> g_mouseEvtQueue;
 static int mouse_button_state = 0;
-static int mouse_accum_button_state = 0;
-static auto mouse_clear_at_time = AGS_Clock::now();
 // Accumulated absolute and relative mouse device motion.
 // May be retrieved by calling *acquire_absxy and *acquire_relxy functions,
 // after which these are reset, until next motion event is received.
@@ -377,17 +396,41 @@ volatile int sys_mouse_z = 0; // mouse wheel position
 static int mouse_accum_relx = 0, mouse_accum_rely = 0;
 // ID of a device, which mouse events will be ignored (for easier testing)
 static int disabled_mouse_device = UINT32_MAX - 10;
+// Cached values, remember old mouse state
+static int mouse_z_was = 0;
 
-// Returns accumulated mouse button state and clears internal cache by timer
-static int mouse_button_poll()
+bool ags_mouseevent_ready()
 {
-    auto now = AGS_Clock::now();
-    int result = mouse_button_state | mouse_accum_button_state;
-    if (now >= mouse_clear_at_time) {
-        mouse_accum_button_state = 0;
-        mouse_clear_at_time = now + std::chrono::milliseconds(50);
+    return g_mouseEvtQueue.size() > 0;
+}
+
+SDL_Event ags_get_next_mouseevent()
+{
+    if (g_mouseEvtQueue.size() > 0)
+    {
+        auto evt = g_mouseEvtQueue.front();
+        g_mouseEvtQueue.pop_front();
+        return evt;
     }
-    return result;
+    SDL_Event empty = {};
+    return empty;
+}
+
+bool ags_misbuttondown(eAGSMouseButton but)
+{
+    return (mouse_button_state & MouseButton2Bits[but]) != 0;
+}
+
+void ags_simulate_mouseclick(eAGSMouseButton but)
+{
+    SDL_Event sdlevent = {};
+    sdlevent.type = SDL_MOUSEBUTTONDOWN;
+    sdlevent.button.button = ags_button_to_sdl(but);
+    sdlevent.button.x = sys_mouse_x; // CHECKME later if this is okay...
+    sdlevent.button.y = sys_mouse_y;
+    SDL_PushEvent(&sdlevent);
+    sdlevent.type = SDL_MOUSEBUTTONUP;
+    SDL_PushEvent(&sdlevent);
 }
 
 // Syncs all the emulated mouse devices with the real sys_mouse_* coords
@@ -405,21 +448,21 @@ static void on_sdl_mouse_motion(const SDL_MouseMotionEvent &event)
     sync_sys_mouse_pos();
 }
 
-static void on_sdl_mouse_button(const SDL_MouseButtonEvent &event)
+static void on_sdl_mouse_down(const SDL_Event &event)
 {
-    if (event.which == disabled_mouse_device)
+    if (event.button.which == disabled_mouse_device)
         return;
 
-    sys_mouse_x = event.x;
-    sys_mouse_y = event.y;
+    sys_mouse_x = event.button.x;
+    sys_mouse_y = event.button.y;
+    g_mouseEvtQueue.push_back(event);
+}
 
-    if (event.type == SDL_MOUSEBUTTONDOWN) {
-        mouse_button_state |= sdl_button_to_mask(event.button);
-        mouse_accum_button_state |= sdl_button_to_mask(event.button);
-    }
-    else {
-        mouse_button_state &= ~sdl_button_to_mask(event.button);
-    }
+static void on_sdl_mouse_up(const SDL_Event &event)
+{
+    sys_mouse_x = event.button.x;
+    sys_mouse_y = event.button.y;
+    g_mouseEvtQueue.push_back(event);
 }
 
 static void on_sdl_mouse_wheel(const SDL_MouseWheelEvent &event)
@@ -430,59 +473,25 @@ static void on_sdl_mouse_wheel(const SDL_MouseWheelEvent &event)
     sys_mouse_z += event.y;
 }
 
-int butwas = 0;
-static eAGSMouseButton mgetbutton()
+void ags_mouse_acquire_relxy(int &x, int &y)
 {
-    const int butis = mouse_button_poll();
-    if ((butis > 0) & (butwas > 0))
-        return kMouseNone;  // don't allow holding button down
-
-    butwas = butis;
-    if (butis & MouseBitLeft)
-        return kMouseLeft;
-    else if (butis & MouseBitRight)
-        return kMouseRight;
-    else if (butis & MouseBitMiddle)
-        return kMouseMiddle;
-    return kMouseNone;
-}
-
-extern eAGSMouseButton simulatedClick;
-int mouse_z_was = 0;
-// Convert mouse button id to flags
-const int MouseButton2Bits[kNumMouseButtons] =
-    { 0, MouseBitLeft, MouseBitRight, MouseBitMiddle };
-
-bool ags_misbuttondown(eAGSMouseButton but)
-{
-    return (mouse_button_poll() & MouseButton2Bits[but]) != 0;
-}
-
-eAGSMouseButton ags_mgetbutton()
-{
-    if (simulatedClick > kMouseNone)
-    {
-        eAGSMouseButton mbut = simulatedClick;
-        simulatedClick = kMouseNone;
-        return mbut;
-    }
-    return mgetbutton();
-}
-
-void ags_mouse_acquire_relxy(int &x, int &y) {
     x = mouse_accum_relx;
     y = mouse_accum_rely;
     mouse_accum_relx = 0;
     mouse_accum_rely = 0;
 }
 
-void ags_domouse() {
+void ags_domouse()
+{
     Mouse::Poll();
 }
 
-int ags_check_mouse_wheel() {
-    if (game.options[OPT_MOUSEWHEEL] == 0) { return 0; }
-    if (sys_mouse_z == mouse_z_was) { return 0; }
+int ags_check_mouse_wheel()
+{
+    if (game.options[OPT_MOUSEWHEEL] == 0)
+        return 0;
+    if (sys_mouse_z == mouse_z_was)
+        return 0;
 
     int result = 0;
     if (sys_mouse_z > mouse_z_was)
@@ -900,8 +909,6 @@ void ags_clear_input_state()
     sys_modkeys = 0;
     sys_modkeys_fired = false;
     mouse_button_state = 0;
-    mouse_accum_button_state = 0;
-    mouse_clear_at_time = AGS_Clock::now();
     ags_clear_mouse_movement();
 }
 
@@ -911,8 +918,6 @@ void ags_clear_input_buffer()
     // accumulated mod keys have to be cleared because they depend on key evt queue
     sys_modkeys = 0;
     sys_modkeys_fired = false;
-    // accumulated state only helps to not miss clicks
-    mouse_accum_button_state = 0;
     // forget about accumulated mouse movement too
     ags_clear_mouse_movement();
 }
@@ -1001,8 +1006,10 @@ void sys_evt_process_one(const SDL_Event &event) {
         on_sdl_mouse_motion(event.motion);
         break;
     case SDL_MOUSEBUTTONDOWN:
+        on_sdl_mouse_down(event);
+        break;
     case SDL_MOUSEBUTTONUP:
-        on_sdl_mouse_button(event.button);
+        on_sdl_mouse_up(event);
         break;
     case SDL_MOUSEWHEEL:
         on_sdl_mouse_wheel(event.wheel);

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -254,27 +254,39 @@ bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3])
 // ----------------------------------------------------------------------------
 
 // Because our game engine still uses input polling, we have to accumulate
-// key events for our internal use whenever engine have to query key input.
-static std::deque<SDL_Event> g_keyEvtQueue;
+// input events for our internal use whenever engine have to query player input.
+static std::deque<SDL_Event> g_inputEvtQueue;
 
 int sys_modkeys = 0; // saved accumulated key mods
 bool sys_modkeys_fired = false; // saved mod key combination already fired
 
-bool ags_keyevent_ready()
+InputType ags_inputevent_ready()
 {
-    return g_keyEvtQueue.size() > 0;
+    if (g_inputEvtQueue.size() == 0)
+        return kInputNone;
+    switch (g_inputEvtQueue.front().type)
+    {
+    case SDL_KEYDOWN:
+    case SDL_KEYUP:
+    case SDL_TEXTINPUT:
+        return kInputKeyboard;
+    case SDL_MOUSEBUTTONDOWN:
+    case SDL_MOUSEBUTTONUP:
+        return kInputMouse;
+    default:
+        return kInputNone;
+    }
 }
 
-SDL_Event ags_get_next_keyevent()
+SDL_Event ags_get_next_inputevent()
 {
-    if (g_keyEvtQueue.size() > 0)
+    if (g_inputEvtQueue.size() > 0)
     {
-        auto evt = g_keyEvtQueue.front();
-        g_keyEvtQueue.pop_front();
+        auto evt = g_inputEvtQueue.front();
+        g_inputEvtQueue.pop_front();
         return evt;
     }
-    SDL_Event empty = {};
-    return empty;
+    return {};
 }
 
 int ags_iskeydown(eAGSKeyCode ags_key)
@@ -312,20 +324,20 @@ static void on_sdl_key_down(const SDL_Event &event)
 {
     // Engine is not structured very well yet, and we cannot pass this event where it's needed;
     // instead we save it in the queue where it will be ready whenever any component asks for one.
-    g_keyEvtQueue.push_back(event);
+    g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_key_up(const SDL_Event &event)
 {
     // Key up events are only used for reacting on mod key combinations at the moment.
-    g_keyEvtQueue.push_back(event);
+    g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_textinput(const SDL_Event &event)
 {
     // We also push text input events to the same queue, as this is only valid way to get proper
     // text interpretation of the pressed key combination based on current system locale.
-    g_keyEvtQueue.push_back(event);
+    g_inputEvtQueue.push_back(event);
 }
 
 
@@ -382,9 +394,7 @@ const int MouseButton2Bits[kNumMouseButtons] =
     { 0, MouseBitLeft, MouseBitRight, MouseBitMiddle };
 
 
-// Because our game engine still uses input polling, we have to accumulate
-// mouse button events for our internal use whenever engine have to query button input.
-static std::deque<SDL_Event> g_mouseEvtQueue;
+// Latest mouse button state
 static int mouse_button_state = 0;
 // Accumulated absolute and relative mouse device motion.
 // May be retrieved by calling *acquire_absxy and *acquire_relxy functions,
@@ -398,23 +408,6 @@ static int mouse_accum_relx = 0, mouse_accum_rely = 0;
 static int disabled_mouse_device = UINT32_MAX - 10;
 // Cached values, remember old mouse state
 static int mouse_z_was = 0;
-
-bool ags_mouseevent_ready()
-{
-    return g_mouseEvtQueue.size() > 0;
-}
-
-SDL_Event ags_get_next_mouseevent()
-{
-    if (g_mouseEvtQueue.size() > 0)
-    {
-        auto evt = g_mouseEvtQueue.front();
-        g_mouseEvtQueue.pop_front();
-        return evt;
-    }
-    SDL_Event empty = {};
-    return empty;
-}
 
 bool ags_misbuttondown(eAGSMouseButton but)
 {
@@ -455,14 +448,15 @@ static void on_sdl_mouse_down(const SDL_Event &event)
 
     sys_mouse_x = event.button.x;
     sys_mouse_y = event.button.y;
-    g_mouseEvtQueue.push_back(event);
+    g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_mouse_up(const SDL_Event &event)
 {
     sys_mouse_x = event.button.x;
     sys_mouse_y = event.button.y;
-    g_mouseEvtQueue.push_back(event);
+    // Uncomment when need to handle mouse up event in the game states
+    //g_inputEvtQueue.push_back(event);
 }
 
 static void on_sdl_mouse_wheel(const SDL_MouseWheelEvent &event)
@@ -905,21 +899,19 @@ static void on_sdl_touch_motion(const SDL_TouchFingerEvent &event)
 void ags_clear_input_state()
 {
     // clear everything related to the input state
-    g_keyEvtQueue.clear();
+    g_inputEvtQueue.clear();
     sys_modkeys = 0;
     sys_modkeys_fired = false;
-    g_mouseEvtQueue.clear();
     mouse_button_state = 0;
     ags_clear_mouse_movement();
 }
 
 void ags_clear_input_buffer()
 {
-    g_keyEvtQueue.clear();
+    g_inputEvtQueue.clear();
     // accumulated mod keys have to be cleared because they depend on key evt queue
     sys_modkeys = 0;
     sys_modkeys_fired = false;
-    g_mouseEvtQueue.clear();
     // forget about accumulated mouse movement too
     ags_clear_mouse_movement();
 }
@@ -928,18 +920,6 @@ void ags_clear_mouse_movement()
 {
     mouse_accum_relx = 0;
     mouse_accum_rely = 0;
-}
-
-// TODO: this is an awful function that should be removed eventually.
-// Must replace with proper updateable game state.
-void ags_wait_until_keypress()
-{
-    do
-    {
-        sys_evt_process_pending();
-        platform->YieldCPU();
-    } while (!ags_keyevent_ready());
-    ags_clear_input_buffer();
 }
 
 

--- a/Engine/ac/sys_events.cpp
+++ b/Engine/ac/sys_events.cpp
@@ -908,6 +908,7 @@ void ags_clear_input_state()
     g_keyEvtQueue.clear();
     sys_modkeys = 0;
     sys_modkeys_fired = false;
+    g_mouseEvtQueue.clear();
     mouse_button_state = 0;
     ags_clear_mouse_movement();
 }
@@ -918,6 +919,7 @@ void ags_clear_input_buffer()
     // accumulated mod keys have to be cleared because they depend on key evt queue
     sys_modkeys = 0;
     sys_modkeys_fired = false;
+    g_mouseEvtQueue.clear();
     // forget about accumulated mouse movement too
     ags_clear_mouse_movement();
 }

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -20,6 +20,17 @@
 #include <SDL_keyboard.h>
 #include "ac/keycode.h"
 
+// Internal AGS device and event type, made as flags
+// NOTE: this matches InputType in script (with a 24-bit shift)
+enum InputType
+{
+    kInputNone      = 0x00,
+    // 0x01 is skipped for a purpose, because it has special meaning in script
+    kInputKeyboard  = 0x02,
+    kInputMouse     = 0x04,
+    kInputAny       = 0xFF
+};
+
 // Keyboard input handling
 //
 // avoid including SDL.h here, at least for now, because that leads to conflicts with allegro
@@ -69,10 +80,11 @@ inline int make_sdl_merged_mod(int mod)
     return m_mod;
 }
 
-// Tells if there are any buffered key events
-bool ags_keyevent_ready();
-// Queries for the next key event in buffer; returns uninitialized data if none was queued
-SDL_Event ags_get_next_keyevent();
+// Tells if there are any buffered input events;
+// return the InputType corresponding to the first queued event.
+InputType ags_inputevent_ready();
+// Queries for the next input event in buffer; returns uninitialized data if none was queued
+SDL_Event ags_get_next_inputevent();
 // Tells if the key is currently down, provided AGS key.
 // NOTE: for particular script codes this function returns positive if either of two keys are down.
 int ags_iskeydown(eAGSKeyCode ags_key);
@@ -88,10 +100,6 @@ extern bool sys_modkeys_fired; // tells whether mod combination had been used fo
 // Mouse input handling
 // Converts SDL mouse button code to AGS code
 eAGSMouseButton sdl_mbut_to_ags_but(int sdl_mbut);
-// Tells if there are any buffered button events
-bool ags_mouseevent_ready();
-// Queries for the next button event in buffer; returns uninitialized data if none was queued
-SDL_Event ags_get_next_mouseevent();
 // Tells if the mouse button is currently down
 bool ags_misbuttondown(eAGSMouseButton but);
 // Returns recent relative mouse movement; resets accumulated values
@@ -140,9 +148,6 @@ void ags_clear_input_state();
 void ags_clear_input_buffer();
 // Clears buffered mouse movement
 void ags_clear_mouse_movement();
-// Halts execution until any user input
-// TODO: seriously not a good design, replace with event listening
-void ags_wait_until_keypress();
 
 
 // Events.

--- a/Engine/ac/sys_events.h
+++ b/Engine/ac/sys_events.h
@@ -28,7 +28,7 @@ union SDL_Event;
 // Converts SDL key data to eAGSKeyCode, which may be also directly used as an ASCII char
 // if it is in proper range, see comments to eAGSKeyCode for details.
 // Optionally works in bacward compatible mode (old_keyhandle)
-KeyInput ags_keycode_from_sdl(const SDL_Event &event, bool old_keyhandle);
+KeyInput sdl_keyevt_to_ags_key(const SDL_Event &event, bool old_keyhandle);
 // Converts eAGSKeyCode to SDL key scans (up to 3 values, because this is not a 1:1 match);
 // NOTE: fails at Ctrl+ or Alt+ AGS keys, or any unknown key codes.
 bool ags_key_to_sdl_scan(eAGSKeyCode key, SDL_Scancode(&scan)[3]);
@@ -86,11 +86,14 @@ extern bool sys_modkeys_fired; // tells whether mod combination had been used fo
 
 
 // Mouse input handling
-//
+// Converts SDL mouse button code to AGS code
+eAGSMouseButton sdl_mbut_to_ags_but(int sdl_mbut);
+// Tells if there are any buffered button events
+bool ags_mouseevent_ready();
+// Queries for the next button event in buffer; returns uninitialized data if none was queued
+SDL_Event ags_get_next_mouseevent();
 // Tells if the mouse button is currently down
 bool ags_misbuttondown(eAGSMouseButton but);
-// Returns last "clicked" mouse button
-eAGSMouseButton ags_mgetbutton();
 // Returns recent relative mouse movement; resets accumulated values
 void ags_mouse_acquire_relxy(int &x, int &y);
 // Updates mouse cursor position in game
@@ -98,6 +101,8 @@ void ags_domouse();
 // Returns -1 for wheel down and +1 for wheel up
 // TODO: introduce constants for this
 int  ags_check_mouse_wheel();
+// Simulates a click with the given mouse button
+void ags_simulate_mouseclick(eAGSMouseButton but);
 
 // TODO: hide these later after refactoring mousew32.cpp
 extern volatile int sys_mouse_x; // mouse x position

--- a/Engine/gui/cscidialog.cpp
+++ b/Engine/gui/cscidialog.cpp
@@ -173,8 +173,7 @@ int CSCIWaitMessage(CSCIMessage * cscim)
         }
 
         eAGSMouseButton mbut;
-        int mwheelz;
-        if (run_service_mb_controls(mbut, mwheelz) && (mbut > kMouseNone) && !play.IsIgnoringInput()) {
+        if (run_service_mb_controls(mbut) && (mbut > kMouseNone) && !play.IsIgnoringInput()) {
             if (checkcontrols()) {
                 cscim->id = controlid;
                 cscim->code = CM_COMMAND;

--- a/Engine/main/game_run.cpp
+++ b/Engine/main/game_run.cpp
@@ -608,6 +608,8 @@ static void check_controls() {
         else if (type == kInputMouse)
             check_mouse_controls();
     }
+
+    ags_clear_input_buffer();
 }
 
 static void check_room_edges(size_t numevents_was)

--- a/Engine/main/game_run.h
+++ b/Engine/main/game_run.h
@@ -49,7 +49,7 @@ float get_current_fps();
 bool run_service_key_controls(KeyInput &kgn);
 // Runs service mouse controls, returns false if mouse input was claimed by the engine,
 // otherwise returns true and provides mouse button code.
-bool run_service_mb_controls(eAGSMouseButton &mbut, int &mwheelz);
+bool run_service_mb_controls(eAGSMouseButton &mbut);
 // Polls few things (exit flag and debugger messages)
 // TODO: refactor this
 void update_polled_stuff();

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -496,10 +496,10 @@ static bool video_check_user_input(VideoSkipType skip)
     {
         if (type == kInputKeyboard)
         {
-            KeyInput key;
-            if (run_service_key_controls(key))
+            KeyInput ki;
+            if (run_service_key_controls(ki) && !IsAGSServiceKey(ki.Key))
             {
-                if ((key.Key == eAGSKeyCodeEscape) && (skip == VideoSkipEscape))
+                if ((ki.Key == eAGSKeyCodeEscape) && (skip == VideoSkipEscape))
                     return true; // skip on Escape key
                 if (skip >= VideoSkipAnyKey)
                     return true;  // skip on any key

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -492,23 +492,25 @@ bool TheoraPlayer::NextFrame()
 // Checks input events, tells if the video should be skipped
 static bool video_check_user_input(VideoSkipType skip)
 {
-    while (ags_keyevent_ready())
+    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
     {
-        KeyInput key;
-        if (run_service_key_controls(key))
+        if (type == kInputKeyboard)
         {
-            if ((key.Key == eAGSKeyCodeEscape) && (skip == VideoSkipEscape))
-                return true; // skip on Escape key
-            if (skip >= VideoSkipAnyKey)
-                return true;  // skip on any key
+            KeyInput key;
+            if (run_service_key_controls(key))
+            {
+                if ((key.Key == eAGSKeyCodeEscape) && (skip == VideoSkipEscape))
+                    return true; // skip on Escape key
+                if (skip >= VideoSkipAnyKey)
+                    return true;  // skip on any key
+            }
         }
-    }
-    while (ags_mouseevent_ready())
-    {
-        eAGSMouseButton mbut;
-        int mwheelz;
-        if (run_service_mb_controls(mbut, mwheelz) && (mbut > kMouseNone) && (skip == VideoSkipKeyOrMouse))
-            return true; // skip on mouse click
+        else if (type == kInputMouse)
+        {
+            eAGSMouseButton mbut;
+            if (run_service_mb_controls(mbut) && (skip == VideoSkipKeyOrMouse))
+                return true; // skip on mouse click
+        }
     }
     return false;
 }

--- a/Engine/media/video/video.cpp
+++ b/Engine/media/video/video.cpp
@@ -492,25 +492,24 @@ bool TheoraPlayer::NextFrame()
 // Checks input events, tells if the video should be skipped
 static bool video_check_user_input(VideoSkipType skip)
 {
-    KeyInput key;
-    eAGSMouseButton mbut;
-    int mwheelz;
-    // Handle all the buffered key events
-    bool do_break = false;
     while (ags_keyevent_ready())
     {
+        KeyInput key;
         if (run_service_key_controls(key))
         {
             if ((key.Key == eAGSKeyCodeEscape) && (skip == VideoSkipEscape))
-                do_break = true;
+                return true; // skip on Escape key
             if (skip >= VideoSkipAnyKey)
-                do_break = true;  // skip on any key
+                return true;  // skip on any key
         }
     }
-    if (do_break)
-        return true; // skip on key press
-    if (run_service_mb_controls(mbut, mwheelz) && (mbut > kMouseNone) && (skip == VideoSkipKeyOrMouse))
-        return true; // skip on mouse click
+    while (ags_mouseevent_ready())
+    {
+        eAGSMouseButton mbut;
+        int mwheelz;
+        if (run_service_mb_controls(mbut, mwheelz) && (mbut > kMouseNone) && (skip == VideoSkipKeyOrMouse))
+            return true; // skip on mouse click
+    }
     return false;
 }
 

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -395,11 +395,11 @@ void IAGSEngine::PollSystem () {
     for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
     {
         eAGSMouseButton mbut;
-        KeyInput kp;
+        KeyInput ki;
         if (type == kInputKeyboard)
         {
-            if (run_service_key_controls(kp) && !play.IsIgnoringInput())
-                pl_run_plugin_hooks(AGSE_KEYPRESS, kp.Key);
+            if (run_service_key_controls(ki) && !play.IsIgnoringInput())
+                pl_run_plugin_hooks(AGSE_KEYPRESS, ki.Key);
         }
         else if (type == kInputMouse)
         {

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -391,14 +391,23 @@ void IAGSEngine::BlitSpriteRotated(int32 x, int32 y, BITMAP *bmp, int32 angle)
 void IAGSEngine::PollSystem () {
     update_polled_stuff();
     ags_domouse();
-    eAGSMouseButton mbut;
-    int mwheelz;
-    if (run_service_mb_controls(mbut, mwheelz) && mbut > kMouseNone && !play.IsIgnoringInput())
-        pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut);
-    KeyInput kp;
-    if (run_service_key_controls(kp) && !play.IsIgnoringInput()) {
-        pl_run_plugin_hooks(AGSE_KEYPRESS, kp.Key);
+    // Handle all the buffered input events
+    for (InputType type = ags_inputevent_ready(); type != kInputNone; type = ags_inputevent_ready())
+    {
+        eAGSMouseButton mbut;
+        KeyInput kp;
+        if (type == kInputKeyboard)
+        {
+            if (run_service_key_controls(kp) && !play.IsIgnoringInput())
+                pl_run_plugin_hooks(AGSE_KEYPRESS, kp.Key);
+        }
+        else if (type == kInputMouse)
+        {
+            if (run_service_mb_controls(mbut) && !play.IsIgnoringInput())
+                pl_run_plugin_hooks(AGSE_MOUSECLICK, mbut);
+        }
     }
+    
 }
 AGSCharacter* IAGSEngine::GetCharacter (int32 charnum) {
     if (charnum >= game.numcharacters)


### PR DESCRIPTION
Implement mouse event buffer similar to key buffer, and process it all in check_controls().
Process Mouse.Click() simulation by sending appropriate events.

This theoretically allows to get multiple number of `on_mouse_click` callbacks per game frame, with different buttons too (in case 2 mouse buttons were pressed simultaneously).

NOTE: I was not able to register more than 1 click with 1 button per game frame, no matter the game speed. ~Possibly this is also restricted by SDL2 somehow (might need to investigate).~ Looks like i'm not clicking fast enough, or my mouse is unable to send clicks fast enough.

It's possible to receive all 3 `on_mouse_click` events with 3 different buttons in a row though.

Also possible to simulate unlimited number of clicks using Mouse.Click() script command.

TODO:
~* investigate why there's no more than 1 event per button in a row; this is either a SDL2 restriction, or some of the engine code is a culprit.~
* update all the special game states by processing all available mouse events in a loop, similar to keys: Dialog options, Inventory, built-in GUI, etc.