### PR TITLE
CI: add ccache in macOS builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 # Global defaults
-skip: "changesIncludeOnly('**.md')"
+skip: "changesIncludeOnly('**.md', '**.txt', '.gitignore', '.gitattributes')"
 env:
   CIRRUS_CLONE_DEPTH: 1
 
@@ -167,9 +167,14 @@ build_macos_task:
   env:
     CMAKE_VERSION: 3.22.3
     NINJA_VERSION: 1.11.1
+    CCACHE_VERSION: 4.8.2
+    CCACHE_MAXSIZE: "180M"
+    CCACHE_DIR: "/tmp/ccache_dir"
+    CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    CMAKE_C_COMPILER_LAUNCHER: ccache
   macos_dependencies_cache:
     folder: dep_cache
-    fingerprint_script: echo "$CMAKE_VERSION $NINJA_VERSION"
+    fingerprint_script: echo "$CMAKE_VERSION $NINJA_VERSION $CCACHE_VERSION"
     populate_script: |
       mkdir dep_cache && cd dep_cache && mkdir bin && mkdir app      
       url="https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-mac.zip"
@@ -178,11 +183,18 @@ build_macos_task:
       url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz"
       echo "Downloading CMake from $url"
       curl -fLSs "$url" | bsdtar -f - -xvzC app --strip-components 1
+      url="https://github.com/ccache/ccache/releases/download/v$CCACHE_VERSION/ccache-$CCACHE_VERSION-darwin.tar.gz"
+      echo "Downloading CCache from $url"
+      curl -fLSs "$url" | bsdtar -f - -xvzC bin --strip-components 1
   install_dependencies_script: |
     sudo chown $USER /usr/local/bin
     cd dep_cache
     pushd app && cp -R CMake.app /Applications/CMake.app && popd
-    cd bin && cp ninja /usr/local/bin/ninja
+    pushd bin && cp ninja /usr/local/bin/ninja && cp ccache /usr/local/bin/ccache && popd
+    chmod +x /usr/local/bin/ccache
+  ccache_cache:
+    folder: "/tmp/ccache_dir"
+    reupload_on_changes: true
   setup_destdir_script: |
     mkdir destdir_debug
     mkdir destdir_release


### PR DESCRIPTION
- this PR has an addition that excludes a few more files for triggering the CI when they are the sole things in the commit.

But the main thing here is CCache is included in macOS builds. I kept a fairly small cache size, a regular macOS builds uses ~110MB, and the cache size at 180MB - the reason for this is downloading and specially uploading is not that fast.

Using CCache, I could cut the macOS build time to around half of it, so this should help lower the Apple Silicon usage significantly, which should help us cut on Compute Credits. In my tests CCache didn't cause any issue and it was fairly stable.

