### PR TITLE
Editor: LipSync pane with scalable table layout

### DIFF
--- a/Editor/AGS.Editor/Panes/LipSyncEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.Designer.cs
@@ -30,40 +30,128 @@ namespace AGS.Editor
         {
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
+            this.tableLayoutPanelLP = new System.Windows.Forms.TableLayoutPanel();
+            this.splitContainerMain = new System.Windows.Forms.SplitContainer();
+            this.flowLayoutPanelTop = new System.Windows.Forms.FlowLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
+            this.splitContainerMain.Panel1.SuspendLayout();
+            this.splitContainerMain.Panel2.SuspendLayout();
+            this.splitContainerMain.SuspendLayout();
+            this.flowLayoutPanelTop.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 7);
+            this.label1.Location = new System.Drawing.Point(13, 10);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(296, 13);
+            this.label1.Size = new System.Drawing.Size(383, 22);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to enable/disable lip sync.";
+            this.label1.UseCompatibleTextRendering = true;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(9, 30);
-            this.label2.MaximumSize = new System.Drawing.Size(400, 0);
+            this.label2.Location = new System.Drawing.Point(13, 32);
+            this.label2.MaximumSize = new System.Drawing.Size(600, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(367, 26);
+            this.label2.Size = new System.Drawing.Size(567, 34);
             this.label2.TabIndex = 1;
             this.label2.Text = "In the text boxes, type the letters that will cause that frame to be shown. Separ" +
     "ate multiple letters with slashes, eg.   C/D/G/K";
             // 
+            // tableLayoutPanelLP
+            // 
+            this.tableLayoutPanelLP.AutoSize = true;
+            this.tableLayoutPanelLP.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanelLP.ColumnCount = 4;
+            this.tableLayoutPanelLP.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 48F));
+            this.tableLayoutPanelLP.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.tableLayoutPanelLP.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 48F));
+            this.tableLayoutPanelLP.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.tableLayoutPanelLP.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanelLP.MinimumSize = new System.Drawing.Size(364, 240);
+            this.tableLayoutPanelLP.Name = "tableLayoutPanelLP";
+            this.tableLayoutPanelLP.RowCount = 10;
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelLP.Size = new System.Drawing.Size(396, 240);
+            this.tableLayoutPanelLP.TabIndex = 2;
+            // 
+            // splitContainerMain
+            // 
+            this.splitContainerMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerMain.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainerMain.IsSplitterFixed = true;
+            this.splitContainerMain.Location = new System.Drawing.Point(0, 0);
+            this.splitContainerMain.Name = "splitContainerMain";
+            this.splitContainerMain.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerMain.Panel1
+            // 
+            this.splitContainerMain.Panel1.Controls.Add(this.flowLayoutPanelTop);
+            // 
+            // splitContainerMain.Panel2
+            // 
+            this.splitContainerMain.Panel2.Controls.Add(this.flowLayoutPanel1);
+            this.splitContainerMain.Size = new System.Drawing.Size(800, 800);
+            this.splitContainerMain.SplitterDistance = 80;
+            this.splitContainerMain.TabIndex = 3;
+            // 
+            // flowLayoutPanelTop
+            // 
+            this.flowLayoutPanelTop.AutoSize = true;
+            this.flowLayoutPanelTop.Controls.Add(this.label1);
+            this.flowLayoutPanelTop.Controls.Add(this.label2);
+            this.flowLayoutPanelTop.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanelTop.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanelTop.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanelTop.Margin = new System.Windows.Forms.Padding(10);
+            this.flowLayoutPanelTop.Name = "flowLayoutPanelTop";
+            this.flowLayoutPanelTop.Padding = new System.Windows.Forms.Padding(10);
+            this.flowLayoutPanelTop.Size = new System.Drawing.Size(800, 80);
+            this.flowLayoutPanelTop.TabIndex = 2;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoScroll = true;
+            this.flowLayoutPanel1.Controls.Add(this.tableLayoutPanelLP);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(800, 716);
+            this.flowLayoutPanel1.TabIndex = 3;
+            // 
             // LipSyncEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.splitContainerMain);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "LipSyncEditor";
-            this.Size = new System.Drawing.Size(661, 369);
+            this.Size = new System.Drawing.Size(800, 800);
             this.Load += new System.EventHandler(this.LipSyncEditor_Load);
+            this.splitContainerMain.Panel1.ResumeLayout(false);
+            this.splitContainerMain.Panel1.PerformLayout();
+            this.splitContainerMain.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).EndInit();
+            this.splitContainerMain.ResumeLayout(false);
+            this.flowLayoutPanelTop.ResumeLayout(false);
+            this.flowLayoutPanelTop.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -71,5 +159,9 @@ namespace AGS.Editor
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelLP;
+        private System.Windows.Forms.SplitContainer splitContainerMain;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelTop;
     }
 }

--- a/Editor/AGS.Editor/Panes/LipSyncEditor.cs
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.cs
@@ -11,43 +11,65 @@ namespace AGS.Editor
 {
     public partial class LipSyncEditor : EditorContentPanel
     {
-        private const int TEXT_BOX_START_X = 10;
-        private const int TEXT_BOX_START_Y = 65;
         private LipSync _lipSync;
 
         public LipSyncEditor(LipSync lipSync)
         {
             InitializeComponent();
-            _lipSync = lipSync;
-            this.AutoScroll = true;
 
-            int x = TEXT_BOX_START_X, y = TEXT_BOX_START_Y;
+            // This is required for the splitter to look good at both 100% and 200% scaling
+            splitContainerMain.SplitterDistance = 300; // some arbitrary large number so text gets a proper height in flow layout
+            int topSplitHeight = 0;
+            foreach (Control control in flowLayoutPanelTop.Controls)
+            {
+                topSplitHeight += control.Height;
+            }
+            splitContainerMain.SplitterDistance = topSplitHeight + splitContainerMain.SplitterWidth +
+                flowLayoutPanelTop.Margin.Top + flowLayoutPanelTop.Margin.Bottom; // compress the splitter size
+
+            _lipSync = lipSync;
+
+            int textBoxWidth = 150;
+            int labelWidth = 48;
+            int rowHeight = 24;
+
+            int columns = 4;
+            int rows = LipSync.MAX_LIP_SYNC_FRAMES / 2;
+            int cells = columns * rows;
+            tableLayoutPanelLP.ColumnCount = columns;
+            tableLayoutPanelLP.RowCount = rows;
+            tableLayoutPanelLP.SuspendDrawing();
+            tableLayoutPanelLP.SuspendLayout();
 
             for (int i = 0; i < _lipSync.CharactersPerFrame.Length; i++)
             {
                 Label label = new Label();
-                label.Left = x;
-                label.Top = y + 2;
-                label.AutoSize = true;
+                label.Left = 0;
+                label.Top = 0;
+                label.Size = new Size(labelWidth, rowHeight);
                 label.Text = i.ToString();
-                this.Controls.Add(label);
+                label.TextAlign = ContentAlignment.MiddleRight;
 
                 TextBox textBox = new TextBox();
-                textBox.Left = x + 20;
-                textBox.Top = y;
-                textBox.Size = new Size(150, 23);
+                textBox.Left = 0;
+                textBox.Top = 0;
+                textBox.Size = new Size(textBoxWidth, rowHeight);
                 textBox.Tag = i;
                 textBox.Text = _lipSync.CharactersPerFrame[i];
                 textBox.TextChanged += new EventHandler(textBox_TextChanged);
 
-                this.Controls.Add(textBox);
-                y += 25;
-                if (i % 10 == 9)
+                int row = i;
+                int column = 0;
+                if (i >= rows)
                 {
-                    x += 200;
-                    y = TEXT_BOX_START_Y;
+                    row -= rows;
+                    column = 2;
                 }
+                tableLayoutPanelLP.Controls.Add(label, column, row);
+                tableLayoutPanelLP.Controls.Add(textBox, column+1, row);
             }
+            tableLayoutPanelLP.ResumeLayout();
+            tableLayoutPanelLP.ResumeDrawing();
             UpdateControlsEnabled();
         }
 
@@ -79,7 +101,7 @@ namespace AGS.Editor
             {
                 shouldBeEnabled = false;
             }
-            foreach (Control control in this.Controls)
+            foreach (Control control in tableLayoutPanelLP.Controls)
             {
                 if (control is TextBox)
                 {
@@ -92,7 +114,7 @@ namespace AGS.Editor
         {
             t.ControlHelper(this, "lip-sync-editor");
 
-            foreach (Control control in Controls)
+            foreach (Control control in tableLayoutPanelLP.Controls)
             {
                 TextBox textBox = control as TextBox;
 

--- a/Editor/AGS.Editor/Panes/LipSyncEditor.resx
+++ b/Editor/AGS.Editor/Panes/LipSyncEditor.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
This PR adjusts the LipSync pane to use a table layout instead of hardcoded control positions. This makes it work in both 100% and 200% scaling. 

In Windows 10, I need to use the following compatibility setting in the application properties so it's scaling can be tested.

<img src="https://github.com/adventuregamestudio/ags/assets/2244442/95aada97-0102-4466-a87d-d966142b0e80" width=320>

I opened #2087 to list all the various pane that have issues.