### PR TITLE
CI: add irrKlang 64-bit and vcredist 64 in docker

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -283,7 +283,7 @@ build_editor_task:
   build_debug_script: >
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
     set "UseEnv=true" &&
-    copy C:\Lib\irrKlang\*.dll Editor\References\ &&
+    copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
     set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&
@@ -291,7 +291,7 @@ build_editor_task:
   build_release_script: >
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86 &&
     set "UseEnv=true" &&
-    copy C:\Lib\irrKlang\*.dll Editor\References\ &&
+    copy C:\Lib\irrKlang\x86\*.dll Editor\References\ &&
     cd Solutions &&
     cmd /v:on /c "set "LIB=C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6\Lib\um\x86;!LIB!" &&
     set "PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;!PATH!" &&

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -45,14 +45,24 @@ RUN pushd %TEMP% && \
   rd /s /q %TEMP%\Lib
 
 ARG IRRKLANG_VERSION=1.6.0
-RUN curl -fLSs http://www.ambiera.at/downloads/irrKlang-32bit-%IRRKLANG_VERSION%.zip | tar -f - -xvzC %TEMP% irrKlang-%IRRKLANG_VERSION%/bin/dotnet-4/*.dll && \
-  mkdir Lib\irrKlang && \
-  move %TEMP%\irrKlang-%IRRKLANG_VERSION%\bin\dotnet-4\*.dll Lib\irrKlang\ && \
-  rd /s /q %TEMP%\irrKlang-%IRRKLANG_VERSION%
+RUN mkdir Lib\irrKlang && \
+  mkdir Lib\irrKlang\x86 && \
+  mkdir Lib\irrKlang\x64 && \
+  pushd %TEMP% && \
+  curl -fLOJ https://www.ambiera.at/downloads/irrKlang-32bit-%IRRKLANG_VERSION%.zip && \
+  curl -fLOJ https://www.ambiera.at/downloads/irrKlang-64bit-%IRRKLANG_VERSION%.zip && \
+  popd && \
+  tar -f %TEMP%\irrKlang-32bit-%IRRKLANG_VERSION%.zip -xvzC %TEMP% irrKlang-%IRRKLANG_VERSION%/bin/dotnet-4/*.dll && \
+  move %TEMP%\irrKlang-%IRRKLANG_VERSION%\bin\dotnet-4\*.dll Lib\irrKlang\x86\ && \
+  rd /s /q %TEMP%\irrKlang-%IRRKLANG_VERSION% && \
+  tar -f %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%.zip -xvzC %TEMP% irrKlang-64bit-%IRRKLANG_VERSION%/bin/dotnet-4-64/*.dll && \
+  move %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%\bin\dotnet-4-64\*.dll Lib\irrKlang\x64\ && \
+  rd /s /q %TEMP%\irrKlang-64bit-%IRRKLANG_VERSION%
 
 RUN mkdir Redist && \
   cd Redist && \
-  curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe
+  curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe && \
+  curl -fLOJ https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x64.exe
 
 ARG SDL_VERSION=2.24.1
 RUN mkdir Lib\SDL2 && \


### PR DESCRIPTION
- include x64 irrKlang for WinVSDevDependencies downloads
- additionally add vcredist 64 so we can track it

The idea here is just to have dependencies tracked for a future Editor build as 64-bit, described in #2088. By having the irrKlang dependencies there already, they would be in the `WinDevDependenciesVS` for next releases.