### PR TITLE
AGS4 new compiler: Fix bug: Forward-declared, unresolved function not reported correctly

### DIFF
--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -88,7 +88,7 @@ void AGS::ccCompiledScript::ReplaceLabels()
             CodeCell value = Label2Value.at(code[loc]);
             code[loc] = value;
         }
-        catch (const std::exception)
+        catch (const std::out_of_range)
         {
             // Can't resolve the label at 'loc', so hang on to this location
             RemainingLabels.push_back(loc);

--- a/Compiler/script2/cs_parser.h
+++ b/Compiler/script2/cs_parser.h
@@ -70,13 +70,16 @@ public:
 
         // Get the label of a function, in order to insert it into the code,
         // this label will be replaced by its value later on
-        CodeCell Function2Label(Symbol func) { return func * _size + _kind; }
+        inline CodeCell Function2Label(Symbol func) { return func * _size + _kind; }
 
         // Keep track of the location of a label that needs to be replaced later on
-        void TrackLabelLoc(Symbol func, CodeLoc loc);
+        inline void TrackLabelLoc(CodeLoc loc) { _scrip.Labels.push_back(loc); }
 
         // Give the label that corresponds to 'func' the value 'val'
-        void SetLabelValue(Symbol func, CodeCell val);
+        inline void SetLabelValue(Symbol func, CodeCell val) { _scrip.Label2Value[Function2Label(func)] = val; }
+
+        // Get the first function that has not been resolved, or kKW_NoSymbol if there isn't any
+        Symbol GetFirstUnresolvedFunction();
     };
 
 private:

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2560,6 +2560,7 @@ TEST_F(Compile1, AssignmentInParameterList1)
     ASSERT_STRNE("Ok", (compile_result >= 0) ? "Ok" : msg.c_str());
     EXPECT_NE(std::string::npos, msg.find("'='"));
 }
+
 TEST_F(Compile1, CrementAsBinary1) {
 
     // Increment operator can't be used as a binary operator.
@@ -2577,4 +2578,24 @@ TEST_F(Compile1, CrementAsBinary1) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     EXPECT_NE(std::string::npos, msg.find("'++'"));
     EXPECT_NE(std::string::npos, msg.find("binary"));
+}
+
+TEST_F(Compile1, ReportMissingFunction) {
+
+    // Function is called, but not defined with body or external
+    // This should be flagged naming the function
+
+    char const *inpl = "\
+        void TpNZaFLjz3ajd();   \n\
+                                \n\
+        int game_start()        \n\
+        {                       \n\
+            TpNZaFLjz3ajd();    \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    EXPECT_NE(std::string::npos, msg.find("pNZaFLjz3ajd"));
 }


### PR DESCRIPTION
This addresses #2066.

If a function was referenced in code but not defined with body, the compiler didn't point out properly the specific function.

I added a googletest that demonstrates the bug and fixed the bug.

Typical code: 
```
void Test();

function game_start()
{
    Test();
}
```