### PR TITLE
Don't confuse param delimiters `,` and array index delimiters `,` in calls to function

### DIFF
--- a/Compiler/test2/cc_bytecode_test_0.cpp
+++ b/Compiler/test2/cc_bytecode_test_0.cpp
@@ -5049,6 +5049,65 @@ TEST_F(Bytecode0, Func18) {
     EXPECT_EQ(stringssize, scrip.stringssize);
 }
 
+TEST_F(Bytecode0, Func19) {
+
+    // Call function with an element of a multidimensional array as a parameter
+    // One dimension is a CTC
+    // The way that the array index is written must not interfere
+    // with the way function parameters are delimited
+
+    char const *inpl = "\
+        int Foo(int t)                  \n\
+        {                               \n\
+            int Arr[2, 3, 5];           \n\
+            return Foo(Arr[t][1, t]);   \n\
+        }";
+
+    int compileResult = cc_compile(inpl, scrip);
+
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+
+    // WriteOutput("Func19", scrip);
+    size_t const codesize = 66;
+    EXPECT_EQ(codesize, scrip.codesize);
+
+    int32_t code[] = {
+      36,    2,   38,    0,           36,    3,   51,    0,    // 7
+      63,  120,    1,    1,          120,   36,    4,   51,    // 15
+     128,    7,    3,   46,            3,    2,   32,    3,    // 23
+      60,   51,  120,   11,            2,    3,   29,    2,    // 31
+      51,  132,    7,    3,           30,    2,   46,    3,    // 39
+       5,   32,    3,    4,            1,    2,   20,   11,    // 47
+       2,    3,    7,    3,           29,    3,    6,    3,    // 55
+       0,   23,    3,    2,            1,    4,    2,    1,    // 63
+     120,    5,  -999
+    };
+    CompareCode(&scrip, codesize, code);
+
+    size_t const numfixups = 1;
+    EXPECT_EQ(numfixups, scrip.numfixups);
+
+    int32_t fixups[] = {
+      56,  -999
+    };
+    char fixuptypes[] = {
+      2,  '\0'
+    };
+    CompareFixups(&scrip, numfixups, fixups, fixuptypes);
+
+    int const numimports = 0;
+    std::string imports[] = {
+     "[[SENTINEL]]"
+    };
+    CompareImports(&scrip, numimports, imports);
+
+    size_t const numexports = 0;
+    EXPECT_EQ(numexports, scrip.numexports);
+
+    size_t const stringssize = 0;
+    EXPECT_EQ(stringssize, scrip.stringssize);
+}
+
 TEST_F(Bytecode0, Export) {
     
     char const *inpl = "\

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -1105,6 +1105,26 @@ TEST_F(Compile1, FuncUndeclaredStruct2) {
     ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
 }
 
+TEST_F(Compile1, FuncCall_MultidimensionalArray) {
+
+    // Function parameter should be recognized as 1 parameter
+    // even though it is an element of a 3-dimensional array.
+
+    char const *inpl = "\
+        int arr[10, 10, 10];        \n\
+        import void Test(int x);    \n\
+                                    \n\
+        int game_start()            \n\
+        {                           \n\
+            Test(arr[1, 2, 3]);     \n\
+        }                           \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+}
+
 TEST_F(Compile1, TypeEqComponent) {
 
     // A struct component may have the same name as a type.
@@ -2599,3 +2619,4 @@ TEST_F(Compile1, ReportMissingFunction) {
     ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
     EXPECT_NE(std::string::npos, msg.find("pNZaFLjz3ajd"));
 }
+


### PR DESCRIPTION
This addresses #2068. 

Fix bug: Commas `,`within array indexes within function calls were mis-interpreted as parameter delimiters.

Add googletests

Typical code: 

```
int arr[10, 10, 10];
void Test(int x) {}

function game_start()
{
	Test(arr[1, 2, 3]); // ← mis-interpreted as three parameters for call to `Test`
}
```