### PR TITLE
Script API: implement Overlay.GetAtScreenXY, GetAtRoomXY, Visible

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -1343,6 +1343,14 @@ builtin managed struct Overlay {
   /// Gets/sets the overlay's z-order relative to other overlays and on-screen objects.
   import attribute int ZOrder;
 #endif
+#ifdef SCRIPT_API_v361
+  /// Gets the overlay that is at the specified position on the screen.
+  import static Overlay* GetAtScreenXY(int x, int y, bool roomOverlays = true);  // $AUTOCOMPLETESTATICONLY$
+  /// Gets the overlay that is at the specified position within this room.
+  import static Overlay* GetAtRoomXY(int x, int y);      // $AUTOCOMPLETESTATICONLY$
+  /// Gets/sets whether this Overlay is currently visible.
+  import attribute bool Visible;
+#endif
 };
 
 builtin managed struct DynamicSprite {

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2122,7 +2122,7 @@ static void add_roomovers_for_drawing()
     {
         if (over.type < 0) continue; // empty slot
         if (!over.IsRoomLayer()) continue; // not a room layer
-        if (over.transparency == 255) continue; // skip fully transparent
+        if (!over.IsVisible() || over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
         add_to_sprite_list(over.ddb, pos.X, pos.Y, over.zorder, false);
     }
@@ -2370,7 +2370,7 @@ void draw_gui_and_overlays()
     {
         if (over.type < 0) continue; // empty slot
         if (over.IsRoomLayer()) continue; // not a ui layer
-        if (over.transparency == 255) continue; // skip fully transparent
+        if (!over.IsVisible() || over.transparency == 255) continue; // skip fully transparent
         Point pos = get_overlay_position(over);
         add_to_sprite_list(over.ddb, pos.X, pos.Y, over.zorder, false);
     }
@@ -2604,7 +2604,7 @@ static void construct_overlays()
     {
         auto &over = overs[i];
         if (over.type < 0) continue; // empty slot
-        if (over.transparency == 255) continue; // skip fully transparent
+        if (!over.IsVisible() || over.transparency == 255) continue; // skip fully transparent
 
         bool has_changed = over.HasChanged();
         // If walk behinds are drawn over the cached object sprite, then check if positions were updated

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -240,7 +240,8 @@ struct GameState
     int   gamma_adjustment = 0;
     short temporarily_turned_off_character = 0;  // Hide Player Charactr ticked
     short inv_backwards_compatibility = 0;
-    std::vector<int> gui_draw_order; // used only for hit detection now
+    std::vector<int> gui_draw_order; // used for hit detection
+    std::vector<int> over_draw_order; // used for hit detection
     std::unordered_set<AGS::Common::String> do_once_tokens;
     int   text_min_display_time_ms = 0;
     int   ignore_user_input_after_text_timeout_ms = 0;

--- a/Engine/ac/overlay.h
+++ b/Engine/ac/overlay.h
@@ -49,6 +49,8 @@ void remove_all_overlays();
 // Creates and registers a managed script object for existing overlay object;
 // optionally adds an internal engine reference to prevent object's disposal
 ScriptOverlay* create_scriptoverlay(ScreenOverlay &over, bool internal_ref = false);
+// Updates overlay's sorted position in draw/hit vector
+void update_overlay_sort(const ScreenOverlay &over);
 // Restores overlays, e.g. after restoring a game save
 void restore_overlays();
 

--- a/Engine/ac/screenoverlay.cpp
+++ b/Engine/ac/screenoverlay.cpp
@@ -71,6 +71,7 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     timeout = in->ReadInt32();
     bgSpeechForChar = in->ReadInt32();
     associatedOverlayHandle = in->ReadInt32();
+    // version 3+: read flags as a single int16 set, vs two int8 flag values
     if (cmp_ver >= 3)
     {
         _flags = in->ReadInt16();
@@ -105,6 +106,12 @@ void ScreenOverlay::ReadFromFile(Stream *in, bool &has_bitmap, int32_t cmp_ver)
     {
         _sprnum = -1;
         has_bitmap = pic != 0;
+    }
+
+    // Upgrade flags for earlier versions
+    if (cmp_ver < 4)
+    {
+        _flags |= kOver_Visible;
     }
 }
 

--- a/Engine/ac/screenoverlay.h
+++ b/Engine/ac/screenoverlay.h
@@ -29,19 +29,22 @@ namespace AGS { namespace Common { class Bitmap; class Stream; } }
 namespace AGS { namespace Engine { class IDriverDependantBitmap; }}
 using namespace AGS; // FIXME later
 
+// Flags are currently serialized as int16, so limited to that
 enum OverlayFlags
 {
     kOver_AlphaChannel     = 0x0001,
     kOver_PositionAtRoomXY = 0x0002, // room-relative position, may be in ui
     kOver_RoomLayer        = 0x0004, // work in room layer (as opposed to UI)
     kOver_SpriteReference  = 0x0008, // reference persistent sprite
+    kOver_Visible          = 0x0010,
 };
 
 struct ScreenOverlay
 {
     // Texture
     Engine::IDriverDependantBitmap *ddb = nullptr;
-    int type = -1, timeout = 0;
+    int type = -1;
+    int timeout = 0;
     // Note that x,y are overlay's properties, that define its position in script;
     // but real drawn position is x + offsetX, y + offsetY;
     int x = 0, y = 0;
@@ -54,6 +57,9 @@ struct ScreenOverlay
     int zorder = INT_MIN;
     int transparency = 0;
 
+    // Helper values
+    int zSortIndex = -1; // an index of this overlay in a z-sorted vector
+
     bool HasAlphaChannel() const { return (_flags & kOver_AlphaChannel) != 0; }
     bool IsSpriteReference() const { return (_flags & kOver_SpriteReference) != 0; }
     bool IsRoomRelative() const { return (_flags & kOver_PositionAtRoomXY) != 0; }
@@ -65,6 +71,8 @@ struct ScreenOverlay
         on ? _flags |= (kOver_RoomLayer | kOver_PositionAtRoomXY) :
              _flags &= ~(kOver_RoomLayer | kOver_PositionAtRoomXY);
     }
+    bool IsVisible() const { return (_flags & kOver_Visible) != 0; }
+    void SetVisible(bool on) { on ? (_flags |= kOver_Visible) : _flags &= ~kOver_Visible; }
     // Gets actual overlay's image, whether owned by overlay or by a sprite reference
     Common::Bitmap *GetImage() const;
     // Get sprite reference id, or -1 if none set

--- a/Engine/game/savegame_components.cpp
+++ b/Engine/game/savegame_components.cpp
@@ -1231,7 +1231,7 @@ ComponentHandler ComponentHandlers[] =
     },
     {
         "Overlays",
-        3,
+        4,
         0,
         WriteOverlays,
         ReadOverlays


### PR DESCRIPTION
After numerous user requests...

This adds:
* `Overlay.Visible property;`
* `static Overlay.GetAtScreenXY(x, y, bool room_overlays);`
* `static Overlay.GetAtRoomXY(x, y);`

`Overlay.Visible` property is an explicit way to turn overlays on and off rather than setting transparency to max. This makes overlays close to all the rest of the drawable objects in game in set of properties they use, and their logic. But the main reason to add it here is that GetAtScreen/Room functions historically ignore the transparency and other visual effects, and only check for Enabled/Visible/Clickable properties (where applicable).

For GetAtScreen/Room functions I added a z-sorted vector of overlay indices, which is updated when:
* overlay is added,
* overlay is removed,
* overlay.ZOrder property changes
* save is restored

This vector is used to hit-test overlays in their z-order, as opposed to test them in the order of their storage in memory until the best match is found. This should speed GetAt* functions up to some degree in case of many overlapping overlays. However, I'm not certain if and how updating this vector will affect other actions, like adding/removing overlays.

Still these functions may be slow in case there are many thousands of overlays around. I believe there are potential ways to improve this, such as doing a space partitioning, but I left this for the later. Right now they simply iterate all the existing overlays in the their sorted z-order and test against their bounding rects.
Therefore I don't think they should be used for something complex, such as collision checks, and similar. IMO it's best to limit their use for reacting to user input (like mouse clicks).