### PR TITLE
TEST: PNG/Deflate compression option for sprites

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -153,6 +153,8 @@ target_sources(common
     util/path.cpp
     util/path_ex.cpp
     util/path.h
+    util/png.cpp
+    util/png.h
     util/proxystream.cpp
     util/proxystream.h
     util/resourcecache.h

--- a/Common/ac/spritefile.cpp
+++ b/Common/ac/spritefile.cpp
@@ -445,6 +445,8 @@ HError SpriteFile::LoadSprite(sprkey_t index, Common::Bitmap *&sprite)
             break;
         case kSprCompress_LZW: lzw_decompress(im_data.Buf, im_data.Size, im_data.BPP, _stream.get(), in_data_size);
             break;
+        case kSprCompress_PNG: png_decompress(im_data.Buf, im_data.Size, im_data.BPP, _stream.get(), in_data_size);
+            break;
         default: assert(!"Unsupported compression type!"); break;
         }
         // TODO: test that not more than data_size was read!
@@ -698,6 +700,8 @@ void SpriteFileWriter::WriteBitmap(Bitmap *image)
         case kSprCompress_RLE: rle_compress(im_data.Buf, im_data.Size, im_data.BPP, &mems);
             break;
         case kSprCompress_LZW: lzw_compress(im_data.Buf, im_data.Size, im_data.BPP, &mems);
+            break;
+        case kSprCompress_PNG: png_compress(im_data.Buf, im_data.Size, im_data.BPP, &mems);
             break;
         default: assert(!"Unsupported compression type!"); break;
         }

--- a/Common/ac/spritefile.h
+++ b/Common/ac/spritefile.h
@@ -83,7 +83,8 @@ enum SpriteCompression
 {
     kSprCompress_None = 0,
     kSprCompress_RLE,
-    kSprCompress_LZW
+    kSprCompress_LZW,
+    kSprCompress_PNG
 };
 
 typedef int32_t sprkey_t;

--- a/Common/util/compress.cpp
+++ b/Common/util/compress.cpp
@@ -11,11 +11,6 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-#ifdef _MANAGED
-// ensure this doesn't get compiled to .NET IL
-#pragma unmanaged
-#endif
-
 #include "util/compress.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -27,6 +22,7 @@
 #if AGS_PLATFORM_ENDIAN_BIG
 #include "util/bbop.h"
 #endif
+#include "util/png.h"
 
 using namespace AGS::Common;
 
@@ -448,4 +444,21 @@ std::unique_ptr<Bitmap> load_lzw(Stream *in, int dst_bpp, RGB (*pal)[256])
     in->Seek(end_pos, kSeekBegin);
 
   return bmm;
+}
+
+//-----------------------------------------------------------------------------
+// PNG
+//-----------------------------------------------------------------------------
+
+void png_compress(const uint8_t* data, size_t data_sz, int /*image_bpp*/, Stream* out)
+{
+    MemoryStream mem_in(data, data_sz);
+    pngcompress(&mem_in, out);
+}
+
+void png_decompress(uint8_t* data, size_t data_sz, int /*image_bpp*/, Stream* in, size_t in_sz)
+{
+    std::vector<uint8_t> in_buf(in_sz);
+    in->Read(in_buf.data(), in_sz);
+    pngexpand(in_buf.data(), in_sz, data, data_sz);
 }

--- a/Common/util/compress.h
+++ b/Common/util/compress.h
@@ -41,4 +41,9 @@ void save_lzw(Common::Stream *out, const Common::Bitmap *bmpp, const RGB (*pal)[
 // Loads bitmap decompressing
 std::unique_ptr<Common::Bitmap> load_lzw(Common::Stream *in, int dst_bpp, RGB (*pal)[256] = nullptr);
 
+// PNG compression
+void png_compress(const uint8_t* data, size_t data_sz, int image_bpp, Common::Stream* out);
+void png_decompress(uint8_t* data, size_t data_sz, int image_bpp, Common::Stream* in, size_t in_sz);
+
+
 #endif // __AC_COMPRESS_H

--- a/Common/util/lzw.cpp
+++ b/Common/util/lzw.cpp
@@ -22,11 +22,6 @@
 
 using namespace AGS::Common;
 
-#ifdef _MANAGED
-// ensure this doesn't get compiled to .NET IL
-#pragma unmanaged
-#endif
-
 int insert(int, int);
 void _delete(int);
 

--- a/Common/util/png.cpp
+++ b/Common/util/png.cpp
@@ -1,0 +1,103 @@
+//=============================================================================
+//
+// Adventure Game Studio (AGS)
+//
+// Copyright (C) 1999-2011 Chris Jones and 2011-20xx others
+// The full list of copyright holders can be found in the Copyright.txt
+// file, which is part of this source code distribution.
+//
+// The AGS source code is provided under the Artistic License 2.0.
+// A copy of this license can be found in the file License.txt and at
+// http://www.opensource.org/licenses/artistic-license-2.0.php
+//
+//=============================================================================
+//
+// PNG compression.
+//
+//=============================================================================
+#include "util/png.h"
+#include <stdlib.h>
+#include "util/bbop.h"
+#include "util/stream.h"
+#include <algorithm>
+#include <zlib.h>
+#include <iostream>
+
+using namespace AGS::Common;
+
+bool pngcompress(Stream* input, Stream* output) {
+    z_stream stream;
+    memset(&stream, 0, sizeof(stream));
+
+    int ret = deflateInit(&stream, Z_DEFAULT_COMPRESSION);
+    if (ret != Z_OK) {
+        std::cerr << "Error initializing compression" << std::endl;
+        return false;
+    }
+
+    stream.data_type = Z_BINARY;
+
+    char inbuf[1024];
+    char outbuf[1024];
+
+    stream.avail_in = input->Read(inbuf, sizeof(inbuf));
+    while (stream.avail_in > 0) {
+        stream.next_in = (Bytef*)inbuf;
+        int flush = input->EOS() ? Z_FINISH : Z_NO_FLUSH;
+
+        do {
+            stream.next_out = (Bytef*)outbuf;
+            stream.avail_out = sizeof(outbuf);
+            ret = deflate(&stream, flush);
+            assert(ret != Z_STREAM_ERROR);
+            int have = sizeof(outbuf) - stream.avail_out;
+            output->Write(outbuf, have);
+        } while (stream.avail_out == 0);
+
+        stream.avail_in = input->Read(inbuf, sizeof(inbuf));
+    }
+
+    (void)deflateEnd(&stream);
+
+    return true;
+}
+
+bool pngexpand(const uint8_t* src, size_t src_sz, uint8_t* dst, size_t dst_sz) {
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.avail_in = 0;
+    stream.next_in = Z_NULL;
+
+    int ret = inflateInit(&stream);
+    if (ret != Z_OK) {
+        std::cerr << "Error initializing decompression" << std::endl;
+        return false;
+    }
+
+    stream.next_in = (Bytef*)src;
+    stream.avail_in = src_sz;
+    stream.next_out = dst;
+    stream.avail_out = dst_sz;
+
+    do {
+        ret = inflate(&stream, Z_FINISH);
+        switch (ret) {
+        case Z_NEED_DICT:
+        case Z_DATA_ERROR:
+        case Z_MEM_ERROR:
+        case Z_BUF_ERROR:
+            std::cerr << "Error decompressing data" << std::endl;
+            (void)inflateEnd(&stream);
+            return false;
+        default:
+            stream.next_out = dst + (dst_sz - stream.avail_out);
+            break;
+        }
+    } while (stream.avail_out > 0);
+
+    (void)inflateEnd(&stream);
+
+    return true;
+}

--- a/Common/util/png.cpp
+++ b/Common/util/png.cpp
@@ -16,12 +16,13 @@
 //
 //=============================================================================
 #include "util/png.h"
+#include <algorithm>
+#include <iostream>
 #include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
 #include "util/bbop.h"
 #include "util/stream.h"
-#include <algorithm>
-#include <zlib.h>
-#include <iostream>
 
 using namespace AGS::Common;
 

--- a/Common/util/png.h
+++ b/Common/util/png.h
@@ -19,11 +19,9 @@
 #define __AGS_CN_UTIL__PNG_H
 
 #include "core/types.h"
+#include "util/stream.h"
 
-namespace AGS { namespace Common { class Stream; } }
-using namespace AGS; // FIXME later
-
-bool pngcompress(Common::Stream* input, Common::Stream* output);
+bool pngcompress(AGS::Common::Stream* input, AGS::Common::Stream* output);
 // Expands lzw-compressed data from src to dst.
 // the dst buffer should be large enough, or the uncompression will not be complete.
 bool pngexpand(const uint8_t* src, size_t src_sz, uint8_t* dst, size_t dst_sz);

--- a/Common/util/png.h
+++ b/Common/util/png.h
@@ -12,18 +12,20 @@
 //
 //=============================================================================
 //
-// LZW (un)compression functions.
+// PNG (un)compression functions.
 //
 //=============================================================================
-#ifndef __AGS_CN_UTIL__LZW_H
-#define __AGS_CN_UTIL__LZW_H
+#ifndef __AGS_CN_UTIL__PNG_H
+#define __AGS_CN_UTIL__PNG_H
 
 #include "core/types.h"
-#include "util/stream.h"
 
-bool lzwcompress(AGS::Common::Stream *lzw_in, AGS::Common::Stream *out);
+namespace AGS { namespace Common { class Stream; } }
+using namespace AGS; // FIXME later
+
+bool pngcompress(Common::Stream* input, Common::Stream* output);
 // Expands lzw-compressed data from src to dst.
 // the dst buffer should be large enough, or the uncompression will not be complete.
-bool lzwexpand(const uint8_t *src, size_t src_sz, uint8_t *dst, size_t dst_sz);
+bool pngexpand(const uint8_t* src, size_t src_sz, uint8_t* dst, size_t dst_sz);
 
-#endif // __AGS_CN_UTIL__LZW_H
+#endif // __AGS_CN_UTIL__PNG_H

--- a/Editor/AGS.Types/Enums/SpriteCompression.cs
+++ b/Editor/AGS.Types/Enums/SpriteCompression.cs
@@ -6,6 +6,7 @@ namespace AGS.Types
     {
         None,
         RLE,
-        LZW
+        LZW,
+        PNG, // this means DEFLATE
     }
 }

--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -22,6 +22,7 @@ CXXFLAGS := -std=c++11 -Werror=delete-non-virtual-dtor $(CXXFLAGS)
 LIBS += $(FT_LDFLAGS)
 LIBS += $(shell pkg-config --libs ogg)
 LIBS += $(shell pkg-config --libs theora)
+LIBS += $(shell pkg-config --libs zlib)
 
 ifeq ($(USE_TREMOR), 1)
   LIBS += -lvorbisidec

--- a/Solutions/Common.Lib/Common.Lib.vcxproj
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj
@@ -128,39 +128,51 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_MD|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_XP|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_XP|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\zlib.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
@@ -608,6 +620,7 @@
     <ClCompile Include="..\..\Common\util\multifilelib.cpp" />
     <ClCompile Include="..\..\Common\util\path.cpp" />
     <ClCompile Include="..\..\Common\util\path_ex.cpp" />
+    <ClCompile Include="..\..\Common\util\png.cpp" />
     <ClCompile Include="..\..\Common\util\proxystream.cpp" />
     <ClCompile Include="..\..\Common\util\stdio_compat.c" />
     <ClCompile Include="..\..\Common\util\stream.cpp" />
@@ -769,6 +782,7 @@
     <ClInclude Include="..\..\Common\util\memory_compat.h" />
     <ClInclude Include="..\..\Common\util\multifilelib.h" />
     <ClInclude Include="..\..\Common\util\path.h" />
+    <ClInclude Include="..\..\Common\util\png.h" />
     <ClInclude Include="..\..\Common\util\proxystream.h" />
     <ClInclude Include="..\..\Common\util\resourcecache.h" />
     <ClInclude Include="..\..\Common\util\scaling.h" />

--- a/Solutions/Common.Lib/Common.Lib.vcxproj.filters
+++ b/Solutions/Common.Lib/Common.Lib.vcxproj.filters
@@ -512,6 +512,9 @@
     <ClCompile Include="..\..\Common\script\cc_common.cpp">
       <Filter>Source Files\script</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\util\png.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\ac\audiocliptype.h">
@@ -827,6 +830,9 @@
       <Filter>Header Files\util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\util\resourcecache.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\util\png.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Solutions/zlib.props
+++ b/Solutions/zlib.props
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ZLIB_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(ZLIB_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <AdditionalLibraryDirectories>$(ZLIB_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>


### PR DESCRIPTION
WARNING: for test only, not for merging at the moment.

This is a remake of #2098, with properly linked zlib, fixed compilation and logical mistakes.

Introduces a new compression option for sprites, called "PNG" for simplicity sake, which uses Deflate algorithm.

Current implementation requires to link a zlib library. But I'd like to investigate if it's feasible to embed necessary set of functions directly into the engine, similar to how [stb_image library](https://github.com/nothings/stb/blob/master/stb_image.h) does this (for example).

I did not configure CMake scripts yet, so for now here's a compiled Editor & windows engine for testing:
https://www.dropbox.com/scl/fi/frvbx4fbaxuk4ebz098cz/ags-3.6.1-testpng.zip?rlkey=5mmy8vyfasfqhir5rxpywgr9o&dl=0

**WARNING:** do either backup "acsprset.spr" before testing this on a real game, or make sure that you have all the sprite sources to recreate it from them, in case something goes wrong. Because of the new PNG option the spritefile's format will be changed and compression type not recognized by a standard version of AGS.

---

Tests on a real game shows improvement up to x2 in compressed size compared to LZW option (example: 485 MB vs 278 MB). More tests may be required to gather better statistics, but it's already looks very promising in regards to saved disk size.

The question of runtime performance (speed) still remains; I did not do any tests for that so far. Imo it's best to test speed with a high-resolution games, but I don't have an actual project source atm to try different compression options.
(although we could make a standalone tool that recompiles a spritefile, changing compression in a ready game).

But if decompression does not slow gameplay noticeably, the LZW option may actually be deprecated in favor of PNG.

Another potential future option would be to use PNG compression for room files too, in place of LZW, which might reduce game size further.