### PR TITLE
Change the rules of how game objects are updated after sprite's update/deletion

### DIFF
--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -83,7 +83,7 @@ public:
 
 
     SpriteCache(std::vector<SpriteInfo> &sprInfos, const Callbacks &callbacks);
-    ~SpriteCache();
+    ~SpriteCache() = default;
 
     // Loads sprite reference information and inits sprite stream
     HError      InitFile(const String &filename, const String &sprindex_filename);
@@ -135,7 +135,7 @@ public:
     // *Deletes* the previous sprite if one was found at the same index.
     // "flags" are optional SPF_* constants that define sprite's behavior in game.
     bool        SetSprite(sprkey_t index, std::unique_ptr<Bitmap> image, int flags = 0);
-    // Assigns new dummy sprite for the given index, silently remapping it to sprite 0;
+    // Assigns new dummy sprite for the given index, silently remapping it to placeholder;
     // optionally marks it as an asset placeholder.
     // *Deletes* the previous sprite if one was found at the same index.
     void        SetEmptySprite(sprkey_t index, bool as_asset);
@@ -154,10 +154,7 @@ private:
     // Load sprite from game resource and put into the cache
     Bitmap *    LoadSprite(sprkey_t index);
     // Remap the given index to the sprite 0
-    void        RemapSpriteToSprite0(sprkey_t index);
-    // Gets the index of a sprite which data is used for the given slot;
-    // in case of remapped sprite this will return the one given sprite is remapped to
-    sprkey_t    GetDataIndex(sprkey_t index);
+    void        RemapSpriteToPlaceholder(sprkey_t index);
     // Initialize the empty sprite slot
     void        InitNullSprite(sprkey_t index);
     //
@@ -180,8 +177,8 @@ private:
         bool IsValid() const { return Flags != 0u; }
         // Tells if there's a game resource corresponding to this slot
         bool IsAssetSprite() const;
-        // Tells if a sprite is remapped to placeholder (e.g. failed to load)
-        bool IsRemapped() const;
+        // Tells if a sprite failed to load from assets, and should not be used
+        bool IsError() const;
         // Tells if sprite was added externally, not loaded from game resources
         bool IsExternalSprite() const;
         // Tells if sprite is locked and should not be disposed by cache logic
@@ -192,10 +189,11 @@ private:
     std::vector<SpriteInfo> &_sprInfos;
     // Array of sprite references
     std::vector<SpriteData> _spriteData;
+    // Placeholder sprite, returned from operator[] for a non-existing sprite
+    std::unique_ptr<Bitmap> _placeholder;
 
     Callbacks  _callbacks;
     SpriteFile _file;
-
 };
 
 } // namespace Common

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -71,11 +71,11 @@ void detect_roomviewport_overlaps(size_t z_index);
 void on_roomcamera_changed(Camera *cam);
 // Marks particular object as need to update the texture
 void mark_object_changed(int objid);
-// Resets all object caches which reference this sprite
-void reset_objcache_for_sprite(int sprnum, bool deleted);
 // TODO: write a generic drawable/objcache system where each object
 // allocates a drawable for itself, and disposes one if being removed.
 void reset_drawobj_for_overlay(int objnum);
+// Marks all game objects which reference this sprite for redraw
+void notify_sprite_changed(int sprnum, bool deleted);
 
 // Get current texture cache's stats: max size, current normal items size,
 // size of locked items (included into cur_size),

--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -437,6 +437,8 @@ int add_dynamic_sprite(int slot, std::unique_ptr<Bitmap> image, bool has_alpha) 
         return 0; // invalid slot, or reserved for the static sprite
 
     spriteset.SetSprite(slot, std::move(image), SPF_DYNAMICALLOC | (SPF_ALPHACHANNEL * has_alpha));
+    if (play.spritemodified.size() < game.SpriteInfos.size())
+        play.spritemodified.resize(game.SpriteInfos.size());
     return slot;
 }
 
@@ -449,9 +451,9 @@ void free_dynamic_sprite(int slot, bool notify_all) {
 
     spriteset.DisposeSprite(slot);
     if (notify_all)
-        game_sprite_deleted(slot);
+        game_sprite_updated(slot, true);
     else
-        clear_shared_texture(slot);
+        notify_sprite_changed(slot, true);
 }
 
 //=============================================================================

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -194,10 +194,7 @@ void get_message_text (int msnum, char *buffer, char giveErr = 1);
 
 // Notifies the game objects that certain sprite was updated.
 // This make them update their render states, caches, and so on.
-void game_sprite_updated(int sprnum);
-// Notifies the game objects that certain sprite was deleted.
-// Those which used that sprite will reset to dummy sprite 0, update their render states and caches.
-void game_sprite_deleted(int sprnum);
+void game_sprite_updated(int sprnum, bool deleted = false);
 
 extern int in_new_room;
 extern int new_room_pos;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -277,7 +277,16 @@ struct GameState
     // Speech portrait overlay managed handle
     int  speech_face_schandle = 0;
 
-    int shake_screen_yoff = 0; // y offset of the shaking screen
+    // y offset of the shaking screen
+    int shake_screen_yoff = 0;
+
+    // CHECKME: we might consider hiding these in draw unit, but then,
+    // because the drawing system still has standalone parts (GUIs...)
+    // there still may be cases when we may require these accessed elsewhere.
+    // Sprite modified flag, used to detect dynamic sprite modifications
+    std::vector<bool> spritemodified;
+    // Which sprites were modified since the recent drawing pass
+    std::vector<int> spritemodifiedlist;
 
 
     GameState();

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -334,9 +334,8 @@ void unload_old_room() {
 
     croom_ptr_clear();
 
-    // clear the actsps buffers to save memory, since the
-    // objects/characters involved probably aren't on the
-    // new screen. this also ensures all cached data is flushed
+    // clear the draw caches to save memory, since many of the the involved
+    // objects probably aren't on the new screen
     clear_drawobj_cache();
 
     // if Hide Player Character was ticked, restore it to visible

--- a/Engine/gui/gui_engine.cpp
+++ b/Engine/gui/gui_engine.cpp
@@ -34,11 +34,10 @@
 
 using namespace AGS::Common;
 
-// For engine these are defined in ac.cpp
 extern int eip_guiobj;
 extern void replace_macro_tokens(const char*, String&);
 
-extern SpriteCache spriteset; // in ac_runningame
+extern SpriteCache spriteset;
 extern GameSetupStruct game;
 
 bool GUIMain::HasAlphaChannel() const


### PR DESCRIPTION
Fixes #2104 . Please read the ticket and comments for detailed explanation of the problem.

There are following changes done here.

1. SpriteCache now has a "placeholder" field initialized to a 1x1 transparent bitmap by default. operator `[]` is ensured to always return this placeholder if an invalid sprite was requested. This is a safeguard against program exceptions. Note that it's still possible to test for sprite's existence explicitly by calling DoesSpriteExist.
I think it may be feasible to add a method for setting custom placeholder. Possibly a copy of sprite 0 may be assigned as a placeholder. I may add this behavior if someone thinks that's a good idea. At first I thought to just use sprite 0 implicitly, but it's a real possibility that sprite 0 does not exist in game. So I went with a dedicated member instead. After all it's a exception safeguard, so should work regardless of the game data.

2. Deleting dynamic sprite no longer resets Graphic property of objects which had it set, at all. The property values stays as they are, which may result in them referring to non-existing sprite, or another dynamic sprite, would the same ID be assigned to them further.

3. In regards to updating objects on screen after sprite's change or deletion, I implemented a new method that does that. The details may be found in commit called "rewrote dynamic sprite change notification method". In short: for texture-based render updating shared texture seem to be enough. For software mode there's a vector<bool> that tells when the sprites were modified. The elements are marked when the sprite is updated or deleted. The game objects test these flags along with other conditions that tell whether object has been modified and should be redrawn. This is done for all objects except for GUI (see below).


**NOTE:** I found a potential problem with this new method, which is explained in [this comment](https://github.com/adventuregamestudio/ags/issues/2104#issuecomment-1698071807). In short, some object properties or actions may depend on sprite's size, and if they *cache* sprite's size, or any other value derived from the sprite's size, then the objects also have to be updated as soon as sprite is resized. This may currently occur upon DynamicSprite.Resize, Rotate and ChangeCanvasSize.
Examining current objects, it *seems* like this is not an *immediate* problem, as the sprite size is never cached in them (it's only cached in draw caches, but that is still updated properly in this pr). In case this becomes a problem in the future, there remains a solution: track sprite use upon a Graphic property assignment too.

**Potential TODO:**
1. Support setting placeholder to sprite 0, if it exists in game data?
2. GUI: this is the only major problem left. Because they are still drawn differently, sometimes combining a sprite with their own drawing (and some have >1 sprite, like sliders that have base graphic and a handle graphic), they would need a special approach, which I did not invent yet. For now I left them updated as before: whenever a dynamic sprite is changed or deleted it will run through all guis and controls that may have sprites, and marks those that have this sprite assigned. I've got a feeling that GUIs may also use this "sprites modified" vector somehow, but I left this for the future.

For now I'm interested to know if other contributors could see actual flaws in this approach.

Also, this has to be tested for any performance changes. I guess there should be 2 kinds of tests:
1. Regular test with many drawn objects, just to see that drawing itself did not slow down.
2. Test that creating and deleting a lot of dynamic sprites is not slowing things down more than in earlier versions (prior to 3.5.0 probably).
