### PR TITLE
Editor: support multiframe and multiloop selection

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Components\TextParserComponent.cs" />
     <Compile Include="Components\ViewsComponent.cs" />
     <Compile Include="Entities\LogBufferEventArgs.cs" />
+    <Compile Include="Entities\MultiSelectAction.cs" />
     <Compile Include="GUI\AssignToView.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/Entities/MultiSelectAction.cs
+++ b/Editor/AGS.Editor/Entities/MultiSelectAction.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// Describes an action in a list control supporting multi-selection.
+    /// CHECKME: does .NET have a standard type for this already?
+    /// </summary>
+    public enum MultiSelectAction
+    {
+        // Set a new single selection
+        Set,
+        // Add a single item to the selection list
+        Add,
+        // Remove a single item from the selection list
+        Remove,
+        // Add a range to the selection list
+        AddRange,
+        // Clear selection
+        ClearAll,
+    }
+}

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -132,11 +132,11 @@ namespace AGS.Editor
             _native.DrawBlockOfColour((int)hdc, x, y, width, height, colourNum);
         }
 
-        public void DrawViewLoop(IntPtr hdc, ViewLoop loop, int x, int y, int sizeInPixels, int selectedFrame)
+        public void DrawViewLoop(IntPtr hdc, ViewLoop loop, int x, int y, int sizeInPixels, List<int> selectedFrames)
         {
 			lock (_spriteSetLock)
 			{
-				_native.DrawViewLoop((int)hdc, loop, x, y, sizeInPixels, selectedFrame);
+				_native.DrawViewLoop((int)hdc, loop, x, y, sizeInPixels, selectedFrames);
 			}
         }
 

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -1,10 +1,8 @@
 using AGS.Types;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Text;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace AGS.Editor
@@ -17,6 +15,10 @@ namespace AGS.Editor
 		private delegate void CorrectAutoScrollDelegate(Point p);
         private GUIController _guiController;
         private bool _processingSelection = false;
+        // Multiframe selection cache, may contain frames from multiple loops too!
+        private List<ViewFrame> _selectedFrames = new List<ViewFrame>();
+        private int _lastSelectedLoop = 0;
+        private int _lastSelectedFrame = 0;
 
         public ViewEditor(AGS.Types.View viewToEdit)
         {
@@ -111,6 +113,7 @@ namespace AGS.Editor
             loopPane.Left = 10 + editorPanel.AutoScrollPosition.X;
             loopPane.ZoomLevel = sldZoomLevel.ZoomScale;
             loopPane.Top = 10 + _loopPanes.Count * loopPane.Height + editorPanel.AutoScrollPosition.Y;
+            loopPane.HandleRangeSelection = false; // we will handle multi-loop selection ourselves
             loopPane.SelectedFrameChanged += new ViewLoopEditor.SelectedFrameChangedHandler(loopPane_SelectedFrameChanged);
 			loopPane.NewFrameAdded += new ViewLoopEditor.NewFrameAddedHandler(loopPane_NewFrameAdded);
             if (loop.ID == _editingView.Loops.Count - 1)
@@ -170,40 +173,110 @@ namespace AGS.Editor
 			}
 		}
 
-        private void loopPane_SelectedFrameChanged(ViewLoop loop, int newSelectedFrame)
+        private void loopPane_SelectedFrameChanged(ViewLoop loop, int newSelectedFrame, MultiSelectAction action)
         {
             _processingSelection = true;
-            if (newSelectedFrame >= 0)
+
+            // If it's not a single frame Add or Remove, then reset all previous selection
+            if (action != MultiSelectAction.Add && action != MultiSelectAction.Remove)
+            {
+                _selectedFrames.Clear();
+                // Deselect all the other loops
+                foreach (ViewLoopEditor pane in _loopPanes)
+                {
+                    if (pane.Loop != loop)
+                    {
+                        pane.SelectedFrames.Clear();
+                        pane.Invalidate();
+                    }
+                }
+            }
+
+            switch (action)
+            {
+                case MultiSelectAction.Add:
+                case MultiSelectAction.Set:
+                    _selectedFrames.Add(loop.Frames[newSelectedFrame]);
+                    break;
+                case MultiSelectAction.Remove:
+                    _selectedFrames.Remove(loop.Frames[newSelectedFrame]);
+                    break;
+                case MultiSelectAction.AddRange:
+                    if (_lastSelectedLoop == loop.ID)
+                    {
+                        // Simplest case: a range within a single loop
+                        ViewLoopEditor loopPane = _loopPanes[loop.ID];
+                        int min = Math.Min(_lastSelectedFrame, newSelectedFrame);
+                        int max = Math.Max(_lastSelectedFrame, newSelectedFrame);
+                        for (int i = min; i <= max; ++i)
+                        {
+                            loopPane.SelectedFrames.Add(i);
+                            _selectedFrames.Add(loop.Frames[i]);
+                        }
+                    }
+                    else
+                    {
+                        // Selection across multiple loops
+                        // Select parts of the first and last loops in range
+                        int minLoop = Math.Min(_lastSelectedLoop, loop.ID);
+                        int maxLoop = Math.Max(_lastSelectedLoop, loop.ID);
+                        int minFrame = Math.Min(_lastSelectedFrame, newSelectedFrame);
+                        int maxFrame = Math.Max(_lastSelectedFrame, newSelectedFrame);
+                        ViewLoop firstLoop = _editingView.Loops[minLoop];
+                        ViewLoop lastLoop = _editingView.Loops[maxLoop];
+                        ViewLoopEditor firstLoopPane = _loopPanes[minLoop];
+                        ViewLoopEditor lastLoopPane = _loopPanes[maxLoop];
+
+                        for (int i = minFrame; i < firstLoop.Frames.Count; ++i)
+                        {
+                            firstLoopPane.SelectedFrames.Add(i);
+                            _selectedFrames.Add(firstLoop.Frames[i]);
+                        }
+                        for (int i = 0; i <= maxFrame; ++i)
+                        {
+                            lastLoopPane.SelectedFrames.Add(i);
+                            _selectedFrames.Add(lastLoop.Frames[i]);
+                        }
+                        firstLoopPane.Invalidate();
+                        lastLoopPane.Invalidate();
+
+                        // Now select all the loops in between
+                        for (int loopIndex = minLoop + 1; loopIndex < maxLoop; ++loopIndex)
+                        {
+                            ViewLoop otherLoop = _editingView.Loops[loopIndex];
+                            ViewLoopEditor otherPane = _loopPanes[loopIndex];
+                            for (int i = 0; i < otherLoop.Frames.Count; ++i)
+                            {
+                                _loopPanes[loopIndex].SelectedFrames.Add(i);
+                                _selectedFrames.Add(otherLoop.Frames[i]);
+                            }
+                            otherPane.Invalidate();
+                        }
+                    }
+                    break;
+            }
+
+            _lastSelectedLoop = loop != null ? loop.ID : 0;
+            _lastSelectedFrame = Math.Max(0, newSelectedFrame);
+
+            // Now refill the Property Grid
+            if (_selectedFrames.Count == 1)
             {
                 _guiController.SetPropertyGridObjectList(ConstructPropertyObjectList(loop));
-                var selection = _loopPanes[loop.ID].SelectedFrames;
-                if (selection.Count == 1)
-                {
-                    _guiController.SetPropertyGridObject(loop.Frames[newSelectedFrame]);
-                }
-                else
-                {
-                    ViewFrame[] frames = new ViewFrame[selection.Count];
-                    for (int i = 0; i < frames.Length; ++i)
-                        frames[i] = loop.Frames[selection[i]];
-                    _guiController.SetPropertyGridObjects(frames);
-                }
+                _guiController.SetPropertyGridObject(loop.Frames[newSelectedFrame]);
+            }
+            else if (_selectedFrames.Count > 1)
+            {
+                // NOTE: we could keep record of number of loops selected, and still
+                // fill loop frames in the objectlist, if all selection is within 1 loop
+                _guiController.SetPropertyGridObjectList(null);
+                var frames = _selectedFrames.Distinct().ToArray();
+                _guiController.SetPropertyGridObjects(frames);
             }
             else
             {
                 _guiController.SetPropertyGridObjectList(null);
                 _guiController.SetPropertyGridObject(_editingView);
-            }
-
-            // deselect all other loops
-            foreach (ViewLoopEditor pane in _loopPanes)
-            {
-                if (pane.Loop != loop)
-                {
-                    // FIXME: find a way to assign a property, with invalidation
-                    pane.SelectedFrames.Clear();
-                    pane.Invalidate();
-                }
             }
 
             // the view's Flipped setting might have changed, ensure
@@ -276,7 +349,7 @@ namespace AGS.Editor
             _loopPanes[_loopPanes.Count - 1].Dispose();
             _loopPanes.RemoveAt(_loopPanes.Count - 1);
 
-            loopPane_SelectedFrameChanged(null, -1);
+            loopPane_SelectedFrameChanged(null, -1, MultiSelectAction.ClearAll);
 
             if (_loopPanes.Count == 0)
             {

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -45,7 +45,7 @@ extern void drawGUI(int hdc, int x,int y, GUI^ gui, int resolutionFactor, float 
 extern void drawSprite(int hdc, int x,int y, int spriteNum, bool flipImage);
 extern void drawSpriteStretch(int hdc, int x,int y, int width, int height, int spriteNum, bool flipImage);
 extern void drawBlockOfColour(int hdc, int x,int y, int width, int height, int colNum);
-extern void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, int cursel);
+extern void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
 extern AGS::Types::SpriteImportResolution SetNewSpriteFromBitmap(int slot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 extern int GetSpriteAsHBitmap(int spriteSlot);
 extern Bitmap^ getSpriteAsBitmap32bit(int spriteNum, int width, int height);
@@ -288,7 +288,7 @@ namespace AGS
 			drawBlockOfColour(hDC, x, y, width, height, colourNum);
 		}
 
-		void NativeMethods::DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, int cursel)
+		void NativeMethods::DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel)
 		{
 			drawViewLoop(hdc, loopToDraw, x, y, size, cursel);
 		}

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -41,7 +41,7 @@ namespace AGS
 			// may be called with hDC = 0 to get required height without drawing anything
 			int  DrawFont(int hDC, int x, int y, int width, int fontNum);
 			void DrawBlockOfColour(int hDC, int x, int y, int width, int height, int colourNum);
-			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, int cursel);
+			void DrawViewLoop(int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<int>^ cursel);
 			Sprite^ SetSpriteFromBitmap(int spriteSlot, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 			void ReplaceSpriteWithBitmap(Sprite ^spr, Bitmap^ bmp, int spriteImportMethod, bool remapColours, bool useRoomBackgroundColours, bool alphaChannel);
 			Bitmap^ GetBitmapForSprite(int spriteSlot, int width, int height);

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -1020,65 +1020,65 @@ void proportionalDraw (int newwid, int sprnum, int*newx, int*newy) {
   newy[0] = newsizy;
 }
 
-static void doDrawViewLoop(int hdc, int numFrames, const std::vector<::ViewFrame> &frames,
-    int x, int y, int size, const std::vector<int> &cursel) {
-  int wtoDraw = size * numFrames;
-  
-  if ((numFrames > 0) && (frames[numFrames-1].pic == -1))
-    wtoDraw -= size;
+static void doDrawViewLoop(int hdc, const std::vector<::ViewFrame> &frames,
+    int x, int y, int size, const std::vector<int> &cursel)
+{
+    int wtoDraw = size * frames.size();
+    if ((frames.size() > 0) && (frames.back().pic == -1))
+        wtoDraw -= size;
 
-  Common::Bitmap *todraw = Common::BitmapHelper::CreateBitmap (wtoDraw, size, thisgame.color_depth*8);
-  todraw->Clear (todraw->GetMaskColor ());
-  int neww, newh;
-  for (int i = 0; i < numFrames; i++) {
-    // don't draw the Go-To-Next-Frame jibble
-    if (frames[i].pic == -1)
-      break;
-    // work out the dimensions to stretch to
-    proportionalDraw (size, frames[i].pic, &neww, &newh);
-    Common::Bitmap *toblt = get_sprite(frames[i].pic);
-    bool freeBlock = false;
-    if (toblt->GetColorDepth () != todraw->GetColorDepth ()) {
-      // 256-col sprite in hi-col game, we need to copy first
-      Common::Bitmap *oldBlt = toblt;
-      toblt = Common::BitmapHelper::CreateBitmap (toblt->GetWidth(), toblt->GetHeight(), todraw->GetColorDepth ());
-      toblt->Blit (oldBlt, 0, 0, 0, 0, oldBlt->GetWidth(), oldBlt->GetHeight());
-      freeBlock = true;
-    }
-    Common::Bitmap *flipped = NULL;
-    if (frames[i].flags & VFLG_FLIPSPRITE) {
-      // mirror the sprite
-      flipped = Common::BitmapHelper::CreateBitmap (toblt->GetWidth(), toblt->GetHeight(), todraw->GetColorDepth ());
-      flipped->Clear (flipped->GetMaskColor ());
-      flipped->FlipBlt(toblt, 0, 0, Common::kFlip_Horizontal);
-      if (freeBlock)
-        delete toblt;
-      toblt = flipped;
-      freeBlock = true;
-    }
-    todraw->StretchBlt(toblt, RectWH(size*i, 0, neww, newh));
-    if (freeBlock)
-      delete toblt;
-    if (i < numFrames-1) {
-      int linecol = makecol_depth(thisgame.color_depth * 8, 0, 64, 200);
-      if (thisgame.color_depth == 1)
+    std::unique_ptr<AGSBitmap> todraw(Common::BitmapHelper::CreateTransparentBitmap(wtoDraw, size, thisgame.GetColorDepth()));
+    std::unique_ptr<AGSBitmap> bmpbuf;
+
+    int linecol = makecol_depth(thisgame.GetColorDepth(), 0, 64, 200);
+    if (thisgame.GetColorDepth() == 8)
         linecol = 12;
+  
+    for (size_t i = 0; i < frames.size(); ++i)
+    {
+        // don't draw the Go-To-Next-Frame jibble
+        if (frames[i].pic == -1)
+            break;
+        // work out the dimensions to stretch to
+        int neww, newh;
+        proportionalDraw (size, frames[i].pic, &neww, &newh);
+        AGSBitmap *toblt = get_sprite(frames[i].pic);
+        if (toblt->GetColorDepth () != todraw->GetColorDepth ())
+        {
+            // Different color depth? make a copy
+            bmpbuf.reset(Common::BitmapHelper::CreateBitmap(toblt->GetWidth(), toblt->GetHeight(), todraw->GetColorDepth()));
+            bmpbuf->Blit (toblt, 0, 0, 0, 0, toblt->GetWidth(), toblt->GetHeight());
+            toblt = bmpbuf.get();
+        }
+        if (frames[i].flags & VFLG_FLIPSPRITE)
+        {
+            // Flipped bitmap? mirror the sprite
+            AGSBitmap *flipped = Common::BitmapHelper::CreateBitmap (toblt->GetWidth(), toblt->GetHeight(), todraw->GetColorDepth ());
+            flipped->Clear (flipped->GetMaskColor ());
+            flipped->FlipBlt(toblt, 0, 0, Common::kFlip_Horizontal);
+            bmpbuf.reset(flipped);
+            toblt = flipped;
+        }
+        todraw->StretchBlt(toblt, RectWH(size*i, 0, neww, newh));
+        bmpbuf.reset();
+        if (i < frames.size() - 1)
+        {
+            // Draw dividing line
+	        todraw->DrawLine (Line(size*(i+1) - 1, 0, size*(i+1) - 1, size-1), linecol);
+        }
+    }
 
-      // Draw dividing line
-	  todraw->DrawLine (Line(size*(i+1) - 1, 0, size*(i+1) - 1, size-1), linecol);
-    }
-    // FIXME optimize this!
-    if (std::count(cursel.begin(), cursel.end(), i) > 0) {
-      // Selected item
-      int linecol = makecol_depth(thisgame.color_depth * 8, 255, 255,255);
-      if (thisgame.color_depth == 1)
+    // Paint selection boxes over selected items
+    linecol = makecol_depth(thisgame.GetColorDepth(), 255, 255,255);
+    if (thisgame.GetColorDepth() == 8)
         linecol = 14;
-      
-      todraw->DrawRect(Rect (size * i, 0, size * (i+1) - 1, size-1), linecol);
+    for (int sel : cursel)
+    {
+        todraw->DrawRect(Rect(size * sel, 0, size * (sel+1) - 1, size-1), linecol);
     }
-  }
-  drawBlock ((HDC)hdc, todraw, x, y);
-  delete todraw;
+
+    // Paint result on the final GDI surface
+    drawBlock((HDC)hdc, todraw.get(), x, y);
 }
 
 // TODO: these functions duplicate ones in the engine, because game struct
@@ -2065,7 +2065,7 @@ void drawViewLoop (int hdc, ViewLoop^ loopToDraw, int x, int y, int size, List<i
     std::vector<int> selected(cursel->Count);
     for (int i = 0; i < cursel->Count; ++i)
         selected[i] = cursel[i];
-    doDrawViewLoop(hdc, loopToDraw->Frames->Count, frames, x, y, size, selected);
+    doDrawViewLoop(hdc, frames, x, y, size, selected);
 }
 
 Common::Bitmap *CreateBlockFromBitmap(System::Drawing::Bitmap ^bmp, RGB *imgpal, bool fixColourDepth, bool keepTransparency, int *originalColDepth)


### PR DESCRIPTION
Resolves #2124.

This adds support for the multi-frame selection to the View editor. This includes *selecting frames in different loops*.
When multiple frames are selected, the Property Grid will display shared values for them, and let set values for all frames at once (this is an existing feature, previously only utilized for Sprites).

Emulates classic selection controls:
* Click - reset selection to the given frame;
* Ctrl + Click - add or remove selection on the given frame;
* Shift + Click - select a range of frames, starting from the last *individually* selected frame and to the clicked one.

Ranged selection is supposed to work across loops too.

In terms of code, I added enum called MultiSelectAction that describes selection type, because I don't know any better. If there's an existing equivalent to this in C#, the I may replace this.