### PR TITLE
Editor: allow downscale Character preview & make frame preview in View pane fill whole size

### DIFF
--- a/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/CharacterEditor.Designer.cs
@@ -34,8 +34,8 @@ namespace AGS.Editor
             this.btnMakePlayer = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.sldZoomLevel = new AGS.Editor.ZoomTrackbar();
-            this.viewPreview1 = new AGS.Editor.ViewPreview();
             this.viewPreview2 = new AGS.Editor.ViewPreview();
+            this.viewPreview1 = new AGS.Editor.ViewPreview();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -119,31 +119,17 @@ namespace AGS.Editor
             // 
             // sldZoomLevel
             // 
-            this.sldZoomLevel.Location = new System.Drawing.Point(356, 37);
-            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.sldZoomLevel.Location = new System.Drawing.Point(295, 37);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2);
             this.sldZoomLevel.Maximum = 800;
-            this.sldZoomLevel.Minimum = 100;
+            this.sldZoomLevel.Minimum = 20;
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(177, 32);
-            this.sldZoomLevel.Step = 25;
+            this.sldZoomLevel.Size = new System.Drawing.Size(280, 29);
+            this.sldZoomLevel.Step = 10;
             this.sldZoomLevel.TabIndex = 9;
             this.sldZoomLevel.Value = 100;
             this.sldZoomLevel.ZoomScale = 1F;
             this.sldZoomLevel.ValueChanged += new System.EventHandler(this.sldZoomLevel_ValueChanged);
-            // 
-            // viewPreview1
-            // 
-            this.viewPreview1.AutoResize = false;
-            this.viewPreview1.DynamicUpdates = false;
-            this.viewPreview1.IsCharacterView = false;
-            this.viewPreview1.Location = new System.Drawing.Point(3, 3);
-            this.viewPreview1.MinimumSize = new System.Drawing.Size(280, 320);
-            this.viewPreview1.Name = "viewPreview1";
-            this.viewPreview1.Size = new System.Drawing.Size(280, 328);
-            this.viewPreview1.TabIndex = 9;
-            this.viewPreview1.Title = "Normal view";
-            this.viewPreview1.ViewToPreview = null;
-            this.viewPreview1.ZoomLevel = 1F;
             // 
             // viewPreview2
             // 
@@ -158,6 +144,20 @@ namespace AGS.Editor
             this.viewPreview2.Title = "Speech view";
             this.viewPreview2.ViewToPreview = null;
             this.viewPreview2.ZoomLevel = 1F;
+            // 
+            // viewPreview1
+            // 
+            this.viewPreview1.AutoResize = false;
+            this.viewPreview1.DynamicUpdates = false;
+            this.viewPreview1.IsCharacterView = false;
+            this.viewPreview1.Location = new System.Drawing.Point(3, 3);
+            this.viewPreview1.MinimumSize = new System.Drawing.Size(280, 320);
+            this.viewPreview1.Name = "viewPreview1";
+            this.viewPreview1.Size = new System.Drawing.Size(280, 328);
+            this.viewPreview1.TabIndex = 9;
+            this.viewPreview1.Title = "Normal view";
+            this.viewPreview1.ViewToPreview = null;
+            this.viewPreview1.ZoomLevel = 1F;
             // 
             // CharacterEditor
             // 

--- a/Editor/AGS.Editor/Panes/CursorEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/CursorEditor.Designer.cs
@@ -50,10 +50,8 @@ namespace AGS.Editor
             this.currentItemGroupBox.Controls.Add(this.splitContainer1);
             this.currentItemGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.currentItemGroupBox.Location = new System.Drawing.Point(0, 0);
-            this.currentItemGroupBox.Margin = new System.Windows.Forms.Padding(4);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
-            this.currentItemGroupBox.Padding = new System.Windows.Forms.Padding(4);
-            this.currentItemGroupBox.Size = new System.Drawing.Size(647, 418);
+            this.currentItemGroupBox.Size = new System.Drawing.Size(485, 340);
             this.currentItemGroupBox.TabIndex = 2;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected mouse cursor settings";
@@ -63,7 +61,8 @@ namespace AGS.Editor
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(4, 19);
+            this.splitContainer1.Location = new System.Drawing.Point(3, 16);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -76,27 +75,28 @@ namespace AGS.Editor
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.cursorPanelScrollArea);
-            this.splitContainer1.Size = new System.Drawing.Size(639, 395);
+            this.splitContainer1.Size = new System.Drawing.Size(479, 321);
             this.splitContainer1.SplitterDistance = 100;
+            this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 10;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 6);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(3, 5);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(379, 17);
+            this.label1.Size = new System.Drawing.Size(282, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
             // 
             // sldZoomLevel
             // 
-            this.sldZoomLevel.Location = new System.Drawing.Point(149, 50);
+            this.sldZoomLevel.Location = new System.Drawing.Point(112, 41);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2);
             this.sldZoomLevel.Maximum = 800;
             this.sldZoomLevel.Minimum = 100;
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(221, 31);
+            this.sldZoomLevel.Size = new System.Drawing.Size(248, 29);
             this.sldZoomLevel.Step = 25;
             this.sldZoomLevel.TabIndex = 9;
             this.sldZoomLevel.Value = 400;
@@ -106,10 +106,9 @@ namespace AGS.Editor
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 30);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(3, 24);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(320, 17);
+            this.label2.Size = new System.Drawing.Size(241, 13);
             this.label2.TabIndex = 4;
             this.label2.Text = "Click in the image below to set the cursor hotspot:";
             // 
@@ -121,28 +120,27 @@ namespace AGS.Editor
             this.cursorPanelScrollArea.Controls.Add(this.imagePanel);
             this.cursorPanelScrollArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cursorPanelScrollArea.Location = new System.Drawing.Point(0, 0);
+            this.cursorPanelScrollArea.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cursorPanelScrollArea.Name = "cursorPanelScrollArea";
-            this.cursorPanelScrollArea.Size = new System.Drawing.Size(639, 291);
+            this.cursorPanelScrollArea.Size = new System.Drawing.Size(479, 218);
             this.cursorPanelScrollArea.TabIndex = 5;
             // 
             // imagePanel
             // 
-            this.imagePanel.Location = new System.Drawing.Point(4, 4);
-            this.imagePanel.Margin = new System.Windows.Forms.Padding(4);
+            this.imagePanel.Location = new System.Drawing.Point(3, 3);
             this.imagePanel.Name = "imagePanel";
-            this.imagePanel.Size = new System.Drawing.Size(320, 195);
+            this.imagePanel.Size = new System.Drawing.Size(240, 158);
             this.imagePanel.TabIndex = 3;
             this.imagePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.imagePanel_Paint);
             this.imagePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.imagePanel_MouseDown);
             // 
             // CursorEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.currentItemGroupBox);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "CursorEditor";
-            this.Size = new System.Drawing.Size(647, 418);
+            this.Size = new System.Drawing.Size(485, 340);
             this.Load += new System.EventHandler(this.CursorEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/InventoryEditor.Designer.cs
@@ -63,10 +63,8 @@ namespace AGS.Editor
             this.currentItemGroupBox.Controls.Add(this.splitContainer1);
             this.currentItemGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.currentItemGroupBox.Location = new System.Drawing.Point(0, 0);
-            this.currentItemGroupBox.Margin = new System.Windows.Forms.Padding(4);
             this.currentItemGroupBox.Name = "currentItemGroupBox";
-            this.currentItemGroupBox.Padding = new System.Windows.Forms.Padding(4);
-            this.currentItemGroupBox.Size = new System.Drawing.Size(791, 414);
+            this.currentItemGroupBox.Size = new System.Drawing.Size(633, 331);
             this.currentItemGroupBox.TabIndex = 1;
             this.currentItemGroupBox.TabStop = false;
             this.currentItemGroupBox.Text = "Selected inventory item settings";
@@ -76,7 +74,7 @@ namespace AGS.Editor
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(4, 21);
+            this.splitContainer1.Location = new System.Drawing.Point(3, 17);
             this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
             this.splitContainer1.Name = "splitContainer1";
             this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
@@ -89,8 +87,9 @@ namespace AGS.Editor
             // 
             this.splitContainer1.Panel2.AutoScroll = true;
             this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel1);
-            this.splitContainer1.Size = new System.Drawing.Size(783, 389);
+            this.splitContainer1.Size = new System.Drawing.Size(627, 311);
             this.splitContainer1.SplitterDistance = 70;
+            this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 9;
             this.splitContainer1.Layout += new System.Windows.Forms.LayoutEventHandler(this.splitContainer1_Layout);
             // 
@@ -102,8 +101,9 @@ namespace AGS.Editor
             this.flowLayoutPanel2.Controls.Add(this.sldZoomLevel);
             this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(783, 70);
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(627, 70);
             this.flowLayoutPanel2.TabIndex = 10;
             // 
             // flowLayoutPanel1
@@ -111,39 +111,40 @@ namespace AGS.Editor
             this.flowLayoutPanel1.Controls.Add(this.label1);
             this.flowLayoutPanel1.Controls.Add(this.label2);
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 2);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(510, 80);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(408, 64);
             this.flowLayoutPanel1.TabIndex = 9;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 4);
-            this.label1.Margin = new System.Windows.Forms.Padding(4);
+            this.label1.Location = new System.Drawing.Point(3, 3);
+            this.label1.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(370, 17);
+            this.label1.Size = new System.Drawing.Size(292, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Use the property grid on the right to change basic settings.";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 29);
-            this.label2.Margin = new System.Windows.Forms.Padding(4);
+            this.label2.Location = new System.Drawing.Point(3, 22);
+            this.label2.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(314, 17);
+            this.label2.Size = new System.Drawing.Size(247, 13);
             this.label2.TabIndex = 4;
             this.label2.Text = "Click in the Mouse cursor image to set it\'s hotspot.";
             // 
             // sldZoomLevel
             // 
-            this.sldZoomLevel.Location = new System.Drawing.Point(518, 2);
+            this.sldZoomLevel.Location = new System.Drawing.Point(414, 2);
             this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2);
             this.sldZoomLevel.Maximum = 800;
             this.sldZoomLevel.Minimum = 100;
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(221, 40);
+            this.sldZoomLevel.Size = new System.Drawing.Size(211, 35);
             this.sldZoomLevel.Step = 25;
             this.sldZoomLevel.TabIndex = 8;
             this.sldZoomLevel.Value = 400;
@@ -159,12 +160,11 @@ namespace AGS.Editor
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.Controls.Add(this.groupBox2, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 4);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(6, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(678, 308);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(540, 246);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // groupBox2
@@ -172,12 +172,10 @@ namespace AGS.Editor
             this.groupBox2.AutoSize = true;
             this.groupBox2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox2.Controls.Add(this.panelScrollAreaCursor);
-            this.groupBox2.Location = new System.Drawing.Point(354, 4);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
-            this.groupBox2.MinimumSize = new System.Drawing.Size(300, 300);
+            this.groupBox2.Location = new System.Drawing.Point(282, 3);
+            this.groupBox2.MinimumSize = new System.Drawing.Size(240, 240);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox2.Size = new System.Drawing.Size(320, 300);
+            this.groupBox2.Size = new System.Drawing.Size(255, 240);
             this.groupBox2.TabIndex = 7;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Mouse cursor image";
@@ -189,18 +187,17 @@ namespace AGS.Editor
             this.panelScrollAreaCursor.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.panelScrollAreaCursor.Controls.Add(this.pnlCursorImage);
             this.panelScrollAreaCursor.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelScrollAreaCursor.Location = new System.Drawing.Point(4, 21);
+            this.panelScrollAreaCursor.Location = new System.Drawing.Point(3, 17);
             this.panelScrollAreaCursor.Margin = new System.Windows.Forms.Padding(2);
             this.panelScrollAreaCursor.Name = "panelScrollAreaCursor";
-            this.panelScrollAreaCursor.Size = new System.Drawing.Size(312, 275);
+            this.panelScrollAreaCursor.Size = new System.Drawing.Size(249, 220);
             this.panelScrollAreaCursor.TabIndex = 5;
             // 
             // pnlCursorImage
             // 
-            this.pnlCursorImage.Location = new System.Drawing.Point(4, 4);
-            this.pnlCursorImage.Margin = new System.Windows.Forms.Padding(4);
+            this.pnlCursorImage.Location = new System.Drawing.Point(3, 3);
             this.pnlCursorImage.Name = "pnlCursorImage";
-            this.pnlCursorImage.Size = new System.Drawing.Size(304, 244);
+            this.pnlCursorImage.Size = new System.Drawing.Size(243, 195);
             this.pnlCursorImage.TabIndex = 3;
             this.pnlCursorImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlCursorImage_Paint);
             this.pnlCursorImage.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pnlCursorImage_MouseDown);
@@ -211,12 +208,10 @@ namespace AGS.Editor
             this.groupBox1.AutoSize = true;
             this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox1.Controls.Add(this.panelScrollAreaImage);
-            this.groupBox1.Location = new System.Drawing.Point(4, 4);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
-            this.groupBox1.MinimumSize = new System.Drawing.Size(300, 300);
+            this.groupBox1.Location = new System.Drawing.Point(3, 3);
+            this.groupBox1.MinimumSize = new System.Drawing.Size(240, 240);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox1.Size = new System.Drawing.Size(342, 300);
+            this.groupBox1.Size = new System.Drawing.Size(273, 240);
             this.groupBox1.TabIndex = 6;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Image in inventory window";
@@ -228,32 +223,30 @@ namespace AGS.Editor
             this.panelScrollAreaImage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.panelScrollAreaImage.Controls.Add(this.pnlInvWindowImage);
             this.panelScrollAreaImage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelScrollAreaImage.Location = new System.Drawing.Point(4, 21);
+            this.panelScrollAreaImage.Location = new System.Drawing.Point(3, 17);
             this.panelScrollAreaImage.Margin = new System.Windows.Forms.Padding(2);
             this.panelScrollAreaImage.Name = "panelScrollAreaImage";
-            this.panelScrollAreaImage.Size = new System.Drawing.Size(334, 275);
+            this.panelScrollAreaImage.Size = new System.Drawing.Size(267, 220);
             this.panelScrollAreaImage.TabIndex = 6;
             // 
             // pnlInvWindowImage
             // 
-            this.pnlInvWindowImage.Location = new System.Drawing.Point(4, 4);
-            this.pnlInvWindowImage.Margin = new System.Windows.Forms.Padding(4);
+            this.pnlInvWindowImage.Location = new System.Drawing.Point(3, 3);
             this.pnlInvWindowImage.Name = "pnlInvWindowImage";
-            this.pnlInvWindowImage.Size = new System.Drawing.Size(326, 244);
+            this.pnlInvWindowImage.Size = new System.Drawing.Size(261, 195);
             this.pnlInvWindowImage.TabIndex = 5;
             this.pnlInvWindowImage.Paint += new System.Windows.Forms.PaintEventHandler(this.pnlInvWindowImage_Paint);
             this.pnlInvWindowImage.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.pnlInvWindowImage_MouseWheel);
             // 
             // InventoryEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.Controls.Add(this.currentItemGroupBox);
             this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "InventoryEditor";
-            this.Size = new System.Drawing.Size(791, 414);
+            this.Size = new System.Drawing.Size(633, 331);
             this.Load += new System.EventHandler(this.InventoryEditor_Load);
             this.currentItemGroupBox.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);

--- a/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
@@ -105,6 +105,7 @@ namespace AGS.Editor
             // 
             // viewPreview
             // 
+            this.viewPreview.AutoFrameFill = true;
             this.viewPreview.AutoResize = false;
             this.viewPreview.Dock = System.Windows.Forms.DockStyle.Fill;
             this.viewPreview.DynamicUpdates = false;

--- a/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.Designer.cs
@@ -121,12 +121,12 @@ namespace AGS.Editor
             // sldZoomLevel
             // 
             this.sldZoomLevel.Location = new System.Drawing.Point(172, 3);
-            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.sldZoomLevel.Maximum = 600;
-            this.sldZoomLevel.Minimum = 75;
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2);
+            this.sldZoomLevel.Maximum = 800;
+            this.sldZoomLevel.Minimum = 20;
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(221, 31);
-            this.sldZoomLevel.Step = 25;
+            this.sldZoomLevel.Size = new System.Drawing.Size(280, 29);
+            this.sldZoomLevel.Step = 10;
             this.sldZoomLevel.TabIndex = 5;
             this.sldZoomLevel.Value = 100;
             this.sldZoomLevel.ZoomScale = 1F;

--- a/Editor/AGS.Editor/Panes/ViewEditor.cs
+++ b/Editor/AGS.Editor/Panes/ViewEditor.cs
@@ -63,7 +63,6 @@ namespace AGS.Editor
 
         private void sldZoomLevel_ValueChanged(object sender, EventArgs e)
         {
-            viewPreview.ZoomLevel = sldZoomLevel.ZoomScale;
             UpdateLoopVisuals();
         }
 
@@ -302,7 +301,6 @@ namespace AGS.Editor
                 viewPreview.Width = viewPreview.PreferredSize.Width;
                 viewPreview.Height = viewPreview.PreferredSize.Height;
 				viewPreview.ViewToPreview = _editingView;
-                viewPreview.ZoomLevel = sldZoomLevel.ZoomScale;
                 splitContainer1.Panel1Collapsed = false;
             }
 			else

--- a/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ViewPreview.Designer.cs
@@ -169,6 +169,7 @@ namespace AGS.Editor
             this.panelAutoScroll.Name = "panelAutoScroll";
             this.panelAutoScroll.Size = new System.Drawing.Size(240, 179);
             this.panelAutoScroll.TabIndex = 10;
+            this.panelAutoScroll.Resize += new System.EventHandler(this.panelAutoScroll_Resize);
             // 
             // previewPanel
             // 

--- a/Editor/AGS.Editor/Panes/ZoomTrackbar.Designer.cs
+++ b/Editor/AGS.Editor/Panes/ZoomTrackbar.Designer.cs
@@ -37,27 +37,33 @@ namespace AGS.Editor
             // 
             // sldZoomLevel
             // 
-            this.sldZoomLevel.Location = new System.Drawing.Point(45, 0);
+            this.sldZoomLevel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.sldZoomLevel.Location = new System.Drawing.Point(34, 0);
+            this.sldZoomLevel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.sldZoomLevel.Name = "sldZoomLevel";
-            this.sldZoomLevel.Size = new System.Drawing.Size(118, 56);
+            this.sldZoomLevel.Size = new System.Drawing.Size(88, 42);
             this.sldZoomLevel.TabIndex = 0;
             this.sldZoomLevel.ValueChanged += new System.EventHandler(this.sldZoomLevel_ValueChanged);
             // 
             // labelName
             // 
             this.labelName.AutoSize = true;
-            this.labelName.Location = new System.Drawing.Point(3, 10);
+            this.labelName.Location = new System.Drawing.Point(2, 8);
+            this.labelName.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.labelName.Name = "labelName";
-            this.labelName.Size = new System.Drawing.Size(48, 17);
+            this.labelName.Size = new System.Drawing.Size(37, 13);
             this.labelName.TabIndex = 3;
             this.labelName.Text = "Zoom:";
             // 
             // textBoxZoomValue
             // 
-            this.textBoxZoomValue.Location = new System.Drawing.Point(169, 5);
+            this.textBoxZoomValue.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxZoomValue.Location = new System.Drawing.Point(127, 4);
+            this.textBoxZoomValue.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.textBoxZoomValue.MaxLength = 6;
             this.textBoxZoomValue.Name = "textBoxZoomValue";
-            this.textBoxZoomValue.Size = new System.Drawing.Size(47, 22);
+            this.textBoxZoomValue.Size = new System.Drawing.Size(36, 20);
             this.textBoxZoomValue.TabIndex = 4;
             this.textBoxZoomValue.Text = "100%";
             this.textBoxZoomValue.WordWrap = false;
@@ -67,13 +73,14 @@ namespace AGS.Editor
             // 
             // ZoomTrackbar
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.textBoxZoomValue);
             this.Controls.Add(this.sldZoomLevel);
             this.Controls.Add(this.labelName);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "ZoomTrackbar";
-            this.Size = new System.Drawing.Size(221, 31);
+            this.Size = new System.Drawing.Size(166, 25);
             ((System.ComponentModel.ISupportInitialize)(this.sldZoomLevel)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();


### PR DESCRIPTION
Resolves #2020, and suggestion in comments by @ericoporto :
> In the view, originally I meant the left pane to have no relationship to the zoom slider at right, and instead just fill the panel as well as possible. I still think this works best for the animation preview, as it's more a quick preview of an animation that will be only properly viewed in-game, later, in a context. I think the slider should only affect the right pane there.

1. Adjust zoom sliders to allow downscale down to min value of 20%, changed step to 10% mostly to let more precise downscale than with 25% step. Made zoom control wider on existing panels, for convenience (idk why MSVS did so many changes to Designer code everywhere, apparently this happens when regenerating the control looks).
2. Added AutoFrameFill mode to the ViewPreview class. When this mode is enabled the view frame will be stretched to fill any available client size, while keeping aspect ratio (it's actually based on sprite height). The ZoomLevel property is ignored in this mode. This mode is used for preview in the ViewEditor.