### PR TITLE
Linux: Makefile uses pkgconfig for SDL2_sound

### DIFF
--- a/Engine/Makefile-defs.linux
+++ b/Engine/Makefile-defs.linux
@@ -31,11 +31,14 @@ else
 endif
 LIBS += $(shell pkg-config --libs vorbisfile)
 
+SDL2_SOUND_CFLAGS = $(shell pkg-config --cflags SDL2_sound)
+SDL2_SOUND_LIBS = $(shell pkg-config --libs SDL2_sound)
+
 SDL2_CFLAGS = $(shell sdl2-config --cflags)
 SDL2_LIBS = $(shell sdl2-config --libs)
 
-CFLAGS += $(SDL2_CFLAGS)
-LIBS += $(SDL2_LIBS) -lSDL2_sound
+CFLAGS += $(SDL2_CFLAGS) $(SDL2_SOUND_CFLAGS)
+LIBS += $(SDL2_LIBS) $(SDL2_SOUND_LIBS)
 
 LIBS += -ldl -lpthread -lm
 


### PR DESCRIPTION
Marking this as draft because I am not sure if this fixes the issue 

https://github.com/icculus/SDL_sound/blob/main/cmake/SDL2_sound.pc.in

You can see it's intended that the included file is in SDL2 directory, but from what I understand it could support two SDL2 directories.

fix #2049