### PR TITLE
Scale Character.z and view offsets along with the character

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -116,7 +116,6 @@ struct CharacterInfo {
     char  scrname[MAX_SCRIPT_NAME_LEN];
     char  on;
 
-    int get_effective_y() const;     // return Y - Z
     int get_baseline() const;        // return baseline, or Y if not set
     int get_blocking_top() const;    // return Y - BlockingHeight/2
     int get_blocking_bottom() const; // return Y + BlockingHeight/2

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -83,7 +83,8 @@
 #define OPT_GAMETEXTENCODING 49 // how the text in the game data should be interpreted
 #define OPT_KEYHANDLEAPI    50 // key handling mode (old/new)
 #define OPT_CUSTOMENGINETAG 51 // custom engine tag (for overriding behavior)
-#define OPT_HIGHESTOPTION   OPT_CUSTOMENGINETAG
+#define OPT_SCALECHAROFFSETS 52 // apply character scaling to the sprite offsets (z, locked offs)
+#define OPT_HIGHESTOPTION   OPT_SCALECHAROFFSETS
 #define OPT_NOMODMUSIC      98 // [DEPRECATED]
 #define OPT_LIPSYNCTEXT     99
 

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -101,8 +101,9 @@ namespace AGS.Editor
          * 3.6.0.20       - Settings.GameTextEncoding, Settings.UseOldKeyboardHandling;
          * 3.6.1.2        - GUIListBox.Translated property moved to GUIControl parent
          * 3.6.1.3        - RuntimeSetup.TextureCache, SoundCache
+         * 3.6.1.9        - Settings.ScaleCharacterSpriteOffsets
         */
-        public const int    LATEST_XML_VERSION_INDEX = 3060103;
+        public const int    LATEST_XML_VERSION_INDEX = 3060109;
         /*
          * LATEST_USER_DATA_VERSION is the last version of the user data file that used a
          * 4-point-4-number string to identify the version of AGS that saved the file.

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -547,6 +547,7 @@ namespace AGS.Editor
             options[NativeConstants.GameOptions.OPT_CLIPGUICONTROLS] = (game.Settings.ClipGUIControls ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_GAMETEXTENCODING] = game.TextEncoding.CodePage;
             options[NativeConstants.GameOptions.OPT_KEYHANDLEAPI] = (game.Settings.UseOldKeyboardHandling ? 0 : 1);
+            options[NativeConstants.GameOptions.OPT_SCALECHAROFFSETS] = (game.Settings.ScaleCharacterSpriteOffsets ? 1 : 0);
             options[NativeConstants.GameOptions.OPT_LIPSYNCTEXT] = (game.LipSync.Type == LipSyncType.Text ? 1 : 0);
             for (int i = 0; i < options.Length; ++i) // writing only ints, alignment preserved
             {

--- a/Editor/AGS.Editor/Utils/NativeConstants.cs
+++ b/Editor/AGS.Editor/Utils/NativeConstants.cs
@@ -132,6 +132,7 @@ namespace AGS.Editor
             public static readonly int OPT_CLIPGUICONTROLS = (int)Factory.NativeProxy.GetNativeConstant("OPT_CLIPGUICONTROLS");
             public static readonly int OPT_GAMETEXTENCODING = (int)Factory.NativeProxy.GetNativeConstant("OPT_GAMETEXTENCODING");
             public static readonly int OPT_KEYHANDLEAPI = (int)Factory.NativeProxy.GetNativeConstant("OPT_KEYHANDLEAPI");
+            public static readonly int OPT_SCALECHAROFFSETS = (int)Factory.NativeProxy.GetNativeConstant("OPT_SCALECHAROFFSETS");
             public static readonly int OPT_LIPSYNCTEXT = (int)Factory.NativeProxy.GetNativeConstant("OPT_LIPSYNCTEXT");
         }
     }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -804,6 +804,7 @@ namespace AGS
             if (name->Equals("OPT_CLIPGUICONTROLS")) return OPT_CLIPGUICONTROLS;
             if (name->Equals("OPT_GAMETEXTENCODING")) return OPT_GAMETEXTENCODING;
             if (name->Equals("OPT_KEYHANDLEAPI")) return OPT_KEYHANDLEAPI;
+            if (name->Equals("OPT_SCALECHAROFFSETS")) return OPT_SCALECHAROFFSETS;
             if (name->Equals("OPT_LIPSYNCTEXT")) return OPT_LIPSYNCTEXT;
             return nullptr;
         }

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -3083,6 +3083,7 @@ Game^ import_compiled_game_dta(const AGSString &filename)
     game->Settings->AllowRelativeAssetResolutions = (thisgame.options[OPT_RELATIVEASSETRES] != 0);
     game->Settings->ScaleMovementSpeedWithMaskResolution = (thisgame.options[OPT_WALKSPEEDABSOLUTE] == 0);
     game->Settings->UseOldKeyboardHandling = (thisgame.options[OPT_KEYHANDLEAPI] == 0);
+    game->Settings->ScaleCharacterSpriteOffsets = (thisgame.options[OPT_SCALECHAROFFSETS] != 0);
 
     TextConverter^ tcv = gcnew TextConverter(game->TextEncoding);
 

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -82,6 +82,7 @@ namespace AGS.Types
         private bool _enforceNewAudio = true;
         private bool _oldCustomDlgOptsAPI = false;
         private bool _oldKeyHandling = false;
+        private bool _scaleCharacterSpriteOffsets = true;
         private int _playSoundOnScore = -1;
         private CrossfadeSpeed _crossfadeMusic = CrossfadeSpeed.No;
         private int _dialogOptionsGUI = 0;
@@ -776,6 +777,16 @@ namespace AGS.Types
         {
             get { return _leftToRightPrecedence; }
             set { _leftToRightPrecedence = value; }
+        }
+
+        [DisplayName("Scale Character sprite offsets")]
+        [Description("Scale sprite offsets along with the character sprite, such as Character.z property, and offsets set by Character.LockViewOffset()")]
+        [DefaultValue(true)]
+        [Category("Backwards Compatibility")]
+        public bool ScaleCharacterSpriteOffsets
+        {
+            get { return _scaleCharacterSpriteOffsets; }
+            set { _scaleCharacterSpriteOffsets = value; }
         }
 
         [DisplayName("Play sound when the player gets points")]

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -552,7 +552,7 @@ int Character_IsCollidingWithObject(CharacterInfo *chin, ScriptObject *objid) {
     int charWidth = charpic->GetWidth();
     int charHeight = charpic->GetHeight();
     int o2x = chin->x - game_to_data_coord(charWidth) / 2;
-    int o2y = chin->get_effective_y() - 5;  // only check feet
+    int o2y = charextra[chin->index_id].GetEffectiveY(chin) - 5;  // only check feet
 
     if ((o2x >= o1x - game_to_data_coord(charWidth)) &&
         (o2x <= o1x + game_to_data_coord(objWidth)) &&
@@ -2234,17 +2234,18 @@ void update_character_scale(int charid)
         chin.frame = 0;
     }
 
-    int zoom, scale_width, scale_height;
+    int zoom, zoom_offs, scale_width, scale_height;
     update_object_scale(zoom, scale_width, scale_height,
         chin.x, chin.y, views[chin.view].loops[chin.loop].frames[chin.frame].pic,
         chex.zoom, (chin.flags & CHF_MANUALSCALING) == 0);
+    zoom_offs = (game.options[OPT_SCALECHAROFFSETS] != 0) ? zoom : 100;
 
     // Calculate the X & Y co-ordinates of where the sprite will be;
     // for the character sprite's origin is at the bottom-mid of a sprite.
     const int atxp = (data_to_game_coord(chin.x)) - scale_width / 2;
     const int atyp = (data_to_game_coord(chin.y) - scale_height)
         // adjust the Y positioning for the character's Z co-ord
-        - data_to_game_coord(chin.z);
+        - (data_to_game_coord(chin.z) * zoom_offs / 100);
 
     // Save calculated properties
     chex.width = scale_width;
@@ -2252,6 +2253,7 @@ void update_character_scale(int charid)
     chin.actx = atxp;
     chin.acty = atyp;
     chex.zoom = zoom;
+    chex.zoom_offs = zoom_offs;
 }
 
 int is_pos_on_character(int xx,int yy) {
@@ -2276,7 +2278,7 @@ int is_pos_on_character(int xx,int yy) {
         if (usewid==0) usewid=game.SpriteInfos[sppic].Width;
         if (usehit==0) usehit= game.SpriteInfos[sppic].Height;
         int xxx = chin->x - game_to_data_coord(usewid) / 2;
-        int yyy = chin->get_effective_y() - game_to_data_coord(usehit);
+        int yyy = charextra[cc].GetEffectiveY(chin) - game_to_data_coord(usehit);
         int mirrored = views[chin->view].loops[chin->loop].frames[chin->frame].flags & VFLG_FLIPSPRITE;
 
         bool is_original;
@@ -2565,7 +2567,7 @@ void _displayspeech(const char*texx, int aschar, int xx, int yy, int widd, int i
         {
             int sppic = views[speakingChar->view].loops[speakingChar->loop].frames[0].pic;
             int height = (charextra[aschar].height < 1) ? game.SpriteInfos[sppic].Height : charextra[aschar].height;
-            tdyp = view->RoomToScreen(0, data_to_game_coord(game.chars[aschar].get_effective_y()) - height).first.Y
+            tdyp = view->RoomToScreen(0, data_to_game_coord(charextra[aschar].GetEffectiveY(speakingChar)) - height).first.Y
                     - get_fixed_pixel_size(5);
             if (isThought) // if it's a thought, lift it a bit further up
                 tdyp -= get_fixed_pixel_size(10);
@@ -2949,6 +2951,15 @@ int update_lip_sync(int talkview, int talkloop, int *talkframeptr) {
 
     talkframeptr[0] = talkframe;
     return talkwait;
+}
+
+void restore_characters()
+{
+    for (int i = 0; i < game.numcharacters; ++i)
+    {
+        charextra[i].zoom_offs = (game.options[OPT_SCALECHAROFFSETS] != 0) ?
+            charextra[i].zoom : 100;
+    }
 }
 
 Rect GetCharacterRoomBBox(int charid, bool use_frame_0)

--- a/Engine/ac/character.h
+++ b/Engine/ac/character.h
@@ -214,6 +214,9 @@ int get_character_currently_talking();
 void DisplaySpeech(const char*texx, int aschar);
 int update_lip_sync(int talkview, int talkloop, int *talkframeptr);
 
+// Recalculate dynamic character properties, e.g. after restoring a game save
+void restore_characters();
+
 // Calculates character's bounding box in room coordinates (takes only in-room transform into account)
 // use_frame_0 optionally tells to use frame 0 of current loop instead of current frame.
 Rect GetCharacterRoomBBox(int charid, bool use_frame_0 = false);

--- a/Engine/ac/characterextras.cpp
+++ b/Engine/ac/characterextras.cpp
@@ -17,6 +17,11 @@
 
 using AGS::Common::Stream;
 
+int CharacterExtras::GetEffectiveY(CharacterInfo *chi) const
+{
+    return chi->y - (chi->z * zoom_offs) / 100;
+}
+
 int CharacterExtras::GetFrameSoundVolume(CharacterInfo *chi) const
 {
     return ::CalcFrameSoundVolume(

--- a/Engine/ac/characterextras.h
+++ b/Engine/ac/characterextras.h
@@ -48,6 +48,14 @@ struct CharacterExtras {
     int   anim_volume = 100; // default animation volume (relative factor)
     int   cur_anim_volume = 100; // current animation sound volume (relative factor)
 
+    // Following fields are deriatives of the above (calculated from these
+    // and other factors), and hence are not serialized.
+    //
+    // zoom factor of sprite offsets, fixed at 100 in backwards compatible mode
+    int   zoom_offs = 100;
+
+    int GetEffectiveY(CharacterInfo *chi) const; // return Y - Z
+
     // Calculate wanted frame sound volume based on multiple factors
     int GetFrameSoundVolume(CharacterInfo *chi) const;
     // Process the current animation frame for the character:

--- a/Engine/ac/characterinfo_engine.cpp
+++ b/Engine/ac/characterinfo_engine.cpp
@@ -39,10 +39,6 @@ extern unsigned int loopcounter;
 
 #define Random __Rand
 
-int CharacterInfo::get_effective_y() const {
-    return y - z;
-}
-
 int CharacterInfo::get_baseline() const {
     if (baseline < 1)
         return y;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2080,8 +2080,8 @@ void prepare_characters_for_drawing()
         ObjTexture &actsp = actsps[charid + ACTSP_OBJSOFF];
 
         // Calculate sprite top-left position in the room and baseline
-        const int atx = chin.actx + chin.pic_xoffs;
-        const int aty = chin.acty + chin.pic_yoffs;
+        const int atx = chin.actx + chin.pic_xoffs * chex.zoom_offs / 100;
+        const int aty = chin.acty + chin.pic_yoffs * chex.zoom_offs / 100;
         int usebasel = chin.get_baseline();
 
         // Generate raw bitmap in ObjTexture and store parameters in ObjectCache.

--- a/Engine/ac/global_object.cpp
+++ b/Engine/ac/global_object.cpp
@@ -488,8 +488,8 @@ int GetThingRect(int thing, _Rect *rect) {
         int charwid = game_to_data_coord(GetCharacterWidth(thing));
         rect->x1 = game.chars[thing].x - (charwid / 2);
         rect->x2 = rect->x1 + charwid;
-        rect->y1 = game.chars[thing].get_effective_y() - game_to_data_coord(GetCharacterHeight(thing));
-        rect->y2 = game.chars[thing].get_effective_y();
+        rect->y1 = charextra[thing].GetEffectiveY(&game.chars[thing]) - game_to_data_coord(GetCharacterHeight(thing));
+        rect->y2 = charextra[thing].GetEffectiveY(&game.chars[thing]);
     }
     else if (is_valid_object(thing - OVERLAPPING_OBJECT)) {
         int objid = thing - OVERLAPPING_OBJECT;

--- a/Engine/ac/overlay.cpp
+++ b/Engine/ac/overlay.cpp
@@ -498,7 +498,7 @@ Point get_overlay_position(const ScreenOverlay &over)
         const int height = (charextra[charid].height < 1) ? game.SpriteInfos[charpic].Height : charextra[charid].height;
         const Point screenpt = view->RoomToScreen(
             data_to_game_coord(game.chars[charid].x),
-            data_to_game_coord(game.chars[charid].get_effective_y()) - height).first;
+            data_to_game_coord(charextra[charid].GetEffectiveY(&game.chars[charid])) - height).first;
         const Size pic_size = over.GetGraphicSize();
         int tdxp = std::max(0, screenpt.X - pic_size.Width / 2);
         int tdyp = screenpt.Y - get_fixed_pixel_size(5);

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -672,6 +672,7 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
 
     adjust_fonts_for_render_mode(game.options[OPT_ANTIALIASFONTS] != 0);
 
+    restore_characters();
     restore_overlays();
 
     GUI::MarkAllGUIForUpdate(true, true);


### PR DESCRIPTION
Resolves #1304.

I make this as a draft for now, to have something that may be tested, as I have a uneasy feeling about this (i explain this below).

The purpose of this change is to make 3 Character sprite's offsets scale along with the regular Character's Scaling property, whether manually set, or got from the walkable area. This refers to following offsets:
* [Character.z](https://adventuregamestudio.github.io/ags-manual/Character.html#characterz)
* x and y offsets assigned by [Character.LockViewAligned](https://adventuregamestudio.github.io/ags-manual/Character.html#characterlockviewaligned) and [Character.LockViewOffset](https://adventuregamestudio.github.io/ags-manual/Character.html#characterlockviewoffset) methods.

Please note that properties themselves do not change with scaling, what changes is their effect, e.g.:
`real_z = character.z * character.Scaling / 100`

I added a game setting that enables this, called "Scale Character sprite offsets", in a "Backwards Compatibility" section. First, this is necessary for backwards compatibility, as imported projects would have to adjust their scripts, if they scaled these properties manually. Second, this is a backup option if someone will find themselves unable to achieve wanted effect with the new behavior.

Now, about this problem, which is also a root of my doubts. Thinking about potential uses of Character.z, in particular, I found that there may be 2 main uses for it:
1. Changing sprite's origin along Y axis. In my honest opinion it's a logical mistake to use this property for this, but to be fair, LockViewOffset is currently unusable for this purpose, as it does not apply to clicking and collision tests (as stated in the manual). Thus Character.z is the only option left. What I think is that AGS currently lacks proper "Origin X/Y" setting that would affect every interaction with a sprite. But that's something that has to be solved later (in ags4, perhaps).
2. Applying a "elevation" effect, where character would appear either levitating, or sinking in ground, water, and so forth.

Looking at these uses, use no1 should normally always be scaled along with the sprite itself, otherwise that would defeat the purpose, so no questions there.
Purpose 2 *depends on a visual perspective*. If a scene emulates a side-view, where character is scaled down as it travels "further", and scaled up as it comes "closer", then this "elevation" effect definitely should be scaled along.
However, if the game features a different kind of perspective, where character's scaling is not changed due to it walking "further", then this elevation effect should likely not be scaled either, as it may be considered a property of "terrain" rather than character. In such situation, if character has to be scaled for any special reason, this may cause an issue with Character.z.

The reason I decided to make this PR nevertheless, is that, it seems, the situations where this offset has to scale are much more often, at least in regular adventure games.

There have been an interesting suggestion by @ericoporto in the #1304 thread:
> it's better to introduce a new OffsetY property and make this the behavior of the new property and make a note that the other property is deprecated, because I think updating this behavior in scripts is going to be non-trivial - I imagine a lot of games use this property very intensively, in different use cases, so if we are changing behavior it's best to introduce a new property with the new behavior. Later in ags4 we can remove the old behavior. 

Personally, I think that both such properties may have a purpose, and kept even in ags4 (maybe in a different form and with different names, if desired). Basically, I come to think that there would be a use of 2 offsets: one applied before scaling (and therefore - always scaled), and another applied after scaling (and therefore - never scaled by character's scaling). This is due to the nature of AGS meant to emulate various kinds of environment.

With this PR, as it's done now, it would be possible to get old behavior back by using the aforementioned switch. This is a backup.

I believe that in ags4 the sprite transformation properties should be rethought, especially properties that define sprite origin (and not only for characters).