### PR TITLE
Editor: write INI files using IniUtils from AGS.Native

### DIFF
--- a/Common/util/ini_util.h
+++ b/Common/util/ini_util.h
@@ -84,8 +84,6 @@ namespace IniUtil
     // If item already exists, only value is overwrited, if section exists,
     // new items are appended to the end of it; completely new sections are
     // appended to the end of text.
-    // Source and destination streams may refer either to different objects,
-    // or same stream opened for both reading and writing.
     // Returns FALSE if the file could not be opened for writing.
     bool Merge(const String &file, const ConfigTree &tree);
     // Similar to the above, but merges the key-value tree into the provided

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -42,17 +42,19 @@ namespace AGS.Editor
             // These option values are not present in the Setup properties at the moment,
             // so we read them from the file, in case the file has been modified by a user manually
             // (this is a temporary measure, to avoid not letting a user to define these values).
-            string config_enabled = NativeProxy.GetIniString("misc", "config_enabled", "1", configPath);
-            string clear_cache = NativeProxy.GetIniString("compatibility", "clear_cache_on_room_change", "0", configPath);
-            string sound_enabled = NativeProxy.GetIniString("sound", "enabled", "1", configPath);
-            string sound_cache_size = NativeProxy.GetIniString("sound", "cache_size", "32768", configPath);
-            string frame_drop = NativeProxy.GetIniString("video", "framedrop", "0", configPath);
-            string super_sampling = NativeProxy.GetIniString("graphics", "super_sampling", "0", configPath);
-            string logging = NativeProxy.GetIniString("debug", "logging", "0", configPath);
-
             var cfg = new Dictionary<string, Dictionary<string, string>>();
-            cfg.Add("controls", new Dictionary<string, string>());
+            NativeProxy.Instance.ReadIniFile(configPath, cfg);
+            string config_enabled = Utilities.GetConfigString(cfg, "misc", "config_enabled", "1");
+            string clear_cache = Utilities.GetConfigString(cfg, "compatibility", "clear_cache_on_room_change", "0");
+            string sound_enabled = Utilities.GetConfigString(cfg, "sound", "enabled", "1");
+            string sound_cache_size = Utilities.GetConfigString(cfg, "sound", "cache_size", "32768");
+            string frame_drop = Utilities.GetConfigString(cfg, "video", "framedrop", "0");
+            string super_sampling = Utilities.GetConfigString(cfg, "graphics", "super_sampling", "0");
+            string logging = Utilities.GetConfigString(cfg, "debug", "logging", "0");
+
+            cfg = new Dictionary<string, Dictionary<string, string>>();
             cfg.Add("compatibility", new Dictionary<string, string>());
+            cfg.Add("controls", new Dictionary<string, string>());
             cfg.Add("debug", new Dictionary<string, string>());
             cfg.Add("graphics", new Dictionary<string, string>());
             cfg.Add("misc", new Dictionary<string, string>());

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -50,64 +50,75 @@ namespace AGS.Editor
             string super_sampling = NativeProxy.GetIniString("graphics", "super_sampling", "0", configPath);
             string logging = NativeProxy.GetIniString("debug", "logging", "0", configPath);
 
-            NativeProxy.WritePrivateProfileString("misc", "config_enabled", config_enabled, configPath);
+            var cfg = new Dictionary<string, Dictionary<string, string>>();
+            cfg.Add("controls", new Dictionary<string, string>());
+            cfg.Add("compatibility", new Dictionary<string, string>());
+            cfg.Add("debug", new Dictionary<string, string>());
+            cfg.Add("graphics", new Dictionary<string, string>());
+            cfg.Add("misc", new Dictionary<string, string>());
+            cfg.Add("sound", new Dictionary<string, string>());
+            cfg.Add("video", new Dictionary<string, string>());
+
+            cfg["misc"]["config_enabled"] = config_enabled;
 
             // Misc options
             int rotation = (int)setup.Rotation;
-            NativeProxy.WritePrivateProfileString("misc", "rotation", rotation.ToString(), configPath);
-            NativeProxy.WritePrivateProfileString("misc", "translation", setup.Translation, configPath);
-            NativeProxy.WritePrivateProfileString("compatibility", "clear_cache_on_room_change", clear_cache, configPath);
+            cfg["misc"]["rotation"] = rotation.ToString();
+            cfg["misc"]["translation"] = setup.Translation;
+            cfg["compatibility"]["clear_cache_on_room_change"] = clear_cache;
 
             // Touch-to-mouse options
             int mouse_emulation = (int)setup.TouchToMouseEmulation;
             int mouse_speed = (int)Math.Round(setup.MouseSpeed * 10.0f);
             int mouse_control_mode = (int)setup.TouchToMouseMotionMode;
-            NativeProxy.WritePrivateProfileString("controls", "mouse_emulation", mouse_emulation.ToString(), configPath);
-            NativeProxy.WritePrivateProfileString("controls", "mouse_speed", mouse_speed.ToString(), configPath);
-            NativeProxy.WritePrivateProfileString("controls", "mouse_method", mouse_control_mode.ToString(), configPath);
+            cfg["controls"]["mouse_emulation"] = mouse_emulation.ToString();
+            cfg["controls"]["mouse_speed"] = mouse_speed.ToString();
+            cfg["controls"]["mouse_method"] = mouse_control_mode.ToString();
 
             // Sound options
-            NativeProxy.WritePrivateProfileString("sound", "enabled", sound_enabled, configPath);
-            NativeProxy.WritePrivateProfileString("sound", "cache_size", sound_cache_size, configPath);
+            cfg["sound"]["enabled"] = sound_enabled;
+            cfg["sound"]["cache_size"] = sound_cache_size;
 
             // Video options
-            NativeProxy.WritePrivateProfileString("video", "framedrop", frame_drop, configPath);
+            cfg["video"]["framedrop"] = frame_drop;
 
             // Graphic options
             if (setup.GraphicsDriver == GraphicsDriver.Software) {
-                NativeProxy.WritePrivateProfileString("graphics", "renderer", "0", configPath);
+                cfg["graphics"]["renderer"] = "0";
             } else {
-                NativeProxy.WritePrivateProfileString("graphics", "renderer", "1", configPath);
+                cfg["graphics"]["renderer"] = "1";
             }
 
             if (setup.GraphicsFilter == "StdScale") {
-                NativeProxy.WritePrivateProfileString("graphics", "smoothing", "0", configPath);
+                cfg["graphics"]["smoothing"] = "0";
             } else {
-                NativeProxy.WritePrivateProfileString("graphics", "smoothing", "1", configPath);
+                cfg["graphics"]["smoothing"] = "1";
             }
 
             if (setup.FullscreenGameScaling == GameScaling.ProportionalStretch) {
-                NativeProxy.WritePrivateProfileString("graphics", "scaling", "1", configPath);
+                cfg["graphics"]["scaling"] = "1";
             } else if (setup.FullscreenGameScaling == GameScaling.StretchToFit) {
-                NativeProxy.WritePrivateProfileString("graphics", "scaling", "2", configPath);
+                cfg["graphics"]["scaling"] = "2";
             } else {
-                NativeProxy.WritePrivateProfileString("graphics", "scaling", "0", configPath);
+                cfg["graphics"]["scaling"] = "0";
             }
 
-            NativeProxy.WritePrivateProfileString("graphics", "super_sampling", super_sampling, configPath);
-            NativeProxy.WritePrivateProfileString("graphics", "smooth_sprites", setup.AAScaledSprites ? "1" : "0", configPath);
+            cfg["graphics"]["super_sampling"] = super_sampling;
+            cfg["graphics"]["smooth_sprites"] = setup.AAScaledSprites ? "1" : "0";
 
             // Debug options
             if (Factory.AGSEditor.CurrentGame.Settings.DebugMode) // Make sure to not have debug options in production
             {
-                NativeProxy.WritePrivateProfileString("debug", "show_fps", setup.ShowFPS ? "1" : "0", configPath);
-                NativeProxy.WritePrivateProfileString("debug", "logging", logging, configPath);
+                cfg["debug"]["show_fps"] = setup.ShowFPS ? "1" : "0";
+                cfg["debug"]["logging"] = logging;
             } 
             else
             {
-                NativeProxy.WritePrivateProfileString("debug", "show_fps", "0", configPath);
-                NativeProxy.WritePrivateProfileString("debug", "logging", "0", configPath);
+                cfg["debug"]["show_fps"] = "0";
+                cfg["debug"]["logging"] = "0";
             }
+
+            NativeProxy.Instance.WriteIniFile(configPath, cfg, true);
         }
 
         private IconAssetType GetGameIconType()

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -18,8 +18,6 @@ namespace AGS.Editor
         public static extern bool FreeLibrary(IntPtr hModule);
         [DllImport("user32.dll")]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
-		[DllImport("kernel32.dll")]
-		public static extern int GetPrivateProfileString(string section, string key, string def, System.Text.StringBuilder retVal, int size, string filePath);
 
         public const uint WM_MOUSEACTIVATE = 0x21;
         public const uint MA_ACTIVATE = 1;
@@ -473,15 +471,24 @@ namespace AGS.Editor
             return _native.GetNativeConstant(name);
         }
 
-        // Following helper method is required, because Editor is using WinAPI functions for reading
-        // and writing values in INI files. Hopefully this will be reimplemented at some point.
-        static StringBuilder IniBuf = new StringBuilder(1024);
-        public static string GetIniString(string section, string key, string def, string filePath)
+        /// <summary>
+        /// Reads the ini file and stores found options in the provided dictionary.
+        /// The dictionary has 2 levels:
+        /// * sections
+        /// * key-value pairs
+        /// </summary>
+        public void ReadIniFile(string fileName, Dictionary<string, Dictionary<string, string>> sections)
         {
-            NativeProxy.GetPrivateProfileString(section, key, def.ToString(), IniBuf, 4096, filePath);
-            return IniBuf.ToString();
+            _native.ReadIniFile(fileName, sections);
         }
 
+        /// <summary>
+        /// Writes "sections" dictionary into the ini file, optionally either merging or
+        /// completely replacing any existing contents.
+        /// The dictionary has 2 levels:
+        /// * sections
+        /// * key-value pairs
+        /// </summary>
         public void WriteIniFile(string fileName, Dictionary<string, Dictionary<string, string>> sections, bool mergeExisting)
         {
             _native.WriteIniFile(fileName, sections, mergeExisting);

--- a/Editor/AGS.Editor/NativeProxy.cs
+++ b/Editor/AGS.Editor/NativeProxy.cs
@@ -19,8 +19,6 @@ namespace AGS.Editor
         [DllImport("user32.dll")]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
 		[DllImport("kernel32.dll")]
-		public static extern long WritePrivateProfileString(string section, string key, string val, string filePath);
-		[DllImport("kernel32.dll")]
 		public static extern int GetPrivateProfileString(string section, string key, string def, System.Text.StringBuilder retVal, int size, string filePath);
 
         public const uint WM_MOUSEACTIVATE = 0x21;
@@ -482,6 +480,11 @@ namespace AGS.Editor
         {
             NativeProxy.GetPrivateProfileString(section, key, def.ToString(), IniBuf, 4096, filePath);
             return IniBuf.ToString();
+        }
+
+        public void WriteIniFile(string fileName, Dictionary<string, Dictionary<string, string>> sections, bool mergeExisting)
+        {
+            _native.WriteIniFile(fileName, sections, mergeExisting);
         }
 
         public void Dispose()

--- a/Editor/AGS.Editor/Utils/Utilities.cs
+++ b/Editor/AGS.Editor/Utils/Utilities.cs
@@ -690,5 +690,20 @@ namespace AGS.Editor
             }
             return false;
         }
+
+        /// <summary>
+        /// Tries to get a config value stored in particular section, under certain key.
+        /// If either section or key does not exist, then returns provided default value.
+        /// </summary>
+        public static string GetConfigString(Dictionary<string, Dictionary<string, string>> cfg, string section, string key, string def)
+        {
+            Dictionary<string, string> secmap;
+            if (!cfg.TryGetValue(section, out secmap))
+                return def;
+            string value;
+            if (!secmap.TryGetValue(key, out value))
+                return def;
+            return value;
+        }
     }
 }

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -809,6 +809,28 @@ namespace AGS
             return nullptr;
         }
 
+        void NativeMethods::ReadIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections)
+        {
+            AGSString filename = TextHelper::ConvertUTF8(fileName);
+            AGS::Common::ConfigTree cfg;
+            if (!AGS::Common::IniUtil::Read(filename, cfg))
+                return;
+
+            sections->Clear();
+            for (const auto &section : cfg)
+            {
+                String ^secname = TextHelper::ConvertASCII(section.first);
+                Dictionary<String^, String^>^ secmap = gcnew Dictionary<String^, String^>();
+                for (const auto &item : section.second)
+                {
+                    String ^key = TextHelper::ConvertASCII(item.first);
+                    String ^value = TextHelper::ConvertUTF8(item.second);
+                    secmap[key] = value;
+                }
+                sections[secname] = secmap;
+            }
+        }
+
         void NativeMethods::WriteIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections, bool mergeExisting)
         {
             AGSString filename = TextHelper::ConvertUTF8(fileName);

--- a/Editor/AGS.Native/NativeMethods.cpp
+++ b/Editor/AGS.Native/NativeMethods.cpp
@@ -22,6 +22,7 @@ see the license.txt for details.
 #include "game/main_game_file.h"
 #include "game/plugininfo.h"
 #include "util/error.h"
+#include "util/ini_util.h"
 #include "util/multifilelib.h"
 #include "util/string_utils.h"
 
@@ -806,6 +807,29 @@ namespace AGS
             if (name->Equals("OPT_KEYHANDLEAPI")) return OPT_KEYHANDLEAPI;
             if (name->Equals("OPT_LIPSYNCTEXT")) return OPT_LIPSYNCTEXT;
             return nullptr;
+        }
+
+        void NativeMethods::WriteIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections, bool mergeExisting)
+        {
+            AGSString filename = TextHelper::ConvertUTF8(fileName);
+            AGS::Common::ConfigTree cfg;
+            for each (auto section in sections)
+            {
+                AGSString secname = TextHelper::ConvertASCII(section.Key);
+                AGS::Common::StringOrderMap secmap;
+                for each (auto item in section.Value)
+                {
+                    AGSString key = TextHelper::ConvertASCII(item.Key);
+                    AGSString value = TextHelper::ConvertUTF8(item.Value);
+                    secmap[key] = value;
+                }
+                cfg[secname] = std::move(secmap);
+            }
+
+            if (mergeExisting)
+                AGS::Common::IniUtil::Merge(filename, cfg);
+            else
+                AGS::Common::IniUtil::Write(filename, cfg);
         }
 	}
 }

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -101,6 +101,7 @@ namespace AGS
       void UpdateFileVersionInfo(String ^fileToUpdate, cli::array<System::Byte> ^authorNameUnicode, cli::array<System::Byte> ^gameNameUnicode);
 			bool HaveSpritesBeenModified();
             Object^ GetNativeConstant(String ^name);
+            void ReadIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections);
             void WriteIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections, bool mergeExisting);
 		};
 	}

--- a/Editor/AGS.Native/NativeMethods.h
+++ b/Editor/AGS.Native/NativeMethods.h
@@ -101,6 +101,7 @@ namespace AGS
       void UpdateFileVersionInfo(String ^fileToUpdate, cli::array<System::Byte> ^authorNameUnicode, cli::array<System::Byte> ^gameNameUnicode);
 			bool HaveSpritesBeenModified();
             Object^ GetNativeConstant(String ^name);
+            void WriteIniFile(String ^fileName, Dictionary<String^, Dictionary<String^, String^>^>^ sections, bool mergeExisting);
 		};
 	}
 }


### PR DESCRIPTION
Resolves #2137

Because I also wish to patch this in release-3.6.0 branch, I chose the most straightforward method, and used IniUtils from C++ part of the Editor to merge new options with the config file.

Gather up dictionary of sections in C# code, and then pass to NativeProxy, where it converts to the native strings using TextHelper, and writes to ini using IniUtils.

I tested this and confirmed that the resulting file contains "titletext" setting in UTF-8, and that winsetup can successfully display this text in its caption.

Same is done for android.cfg.

I do not think that there are any other options that may contain utf-8 text (?), but will leave to others to comment on this.