### PR TITLE
Allow to change walking speed during walking

### DIFF
--- a/Common/ac/characterinfo.h
+++ b/Common/ac/characterinfo.h
@@ -107,7 +107,7 @@ struct CharacterInfo {
     short pic_xoffs; // this is fixed in screen coordinates
     short walkwaitcounter;
     uint16_t loop, frame;
-    short walking;
+    short walking; // stores movelist index, optionally +TURNING_AROUND
     short animating; // stores CHANIM_* flags in lower byte and delay in upper byte
     short walkspeed, animspeed;
     short inv[MAX_INV];

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1928,7 +1928,7 @@ int doNextCharMoveStep (CharacterInfo *chi, int &char_index, CharacterExtras *ch
 
         if ((chi->walking < 1) || (chi->walking >= TURNING_AROUND)) ;
         else if (mls[chi->walking].onpart > 0) {
-            mls[chi->walking].onpart --;
+            mls[chi->walking].onpart -= itofix(1);
             chi->x = xwas;
             chi->y = ywas;
         }

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -913,20 +913,28 @@ void Character_SetSpeed(CharacterInfo *chaa, int xspeed, int yspeed) {
 
     if ((xspeed == 0) || (yspeed == 0))
         quit("!SetCharacterSpeedEx: invalid speed value");
-    if (chaa->walking)
+    if ((chaa->walking > 0) && (loaded_game_file_version < kGameVersion_350))
     {
         debug_script_warn("Character_SetSpeed: cannot change speed while walking");
         return;
     }
+
     xspeed = Math::Clamp(xspeed, (int)INT16_MIN, (int)INT16_MAX);
     yspeed = Math::Clamp(yspeed, (int)INT16_MIN, (int)INT16_MAX);
 
-    chaa->walkspeed = xspeed;
+    uint16_t old_speedx = chaa->walkspeed;
+    uint16_t old_speedy = ((chaa->walkspeed_y == UNIFORM_WALK_SPEED) ? chaa->walkspeed : chaa->walkspeed_y);
 
+    chaa->walkspeed = xspeed;
     if (yspeed == xspeed) 
         chaa->walkspeed_y = UNIFORM_WALK_SPEED;
     else
         chaa->walkspeed_y = yspeed;
+
+    if (chaa->walking > 0)
+    {
+        recalculate_move_speeds(&mls[chaa->walking % TURNING_AROUND], old_speedx, old_speedy, xspeed, yspeed);
+    }
 }
 
 

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -40,7 +40,7 @@ void MoveList::ReadFromFile_Legacy(Stream *in)
     from.X = in->ReadInt32();
     from.Y = in->ReadInt32();
     onstage = in->ReadInt32();
-    onpart = in->ReadInt32();
+    onpart = itofix(in->ReadInt32());
     in->ReadInt32(); // UNUSED
     in->ReadInt32(); // UNUSED
     doneflag = in->ReadInt8();
@@ -49,6 +49,8 @@ void MoveList::ReadFromFile_Legacy(Stream *in)
 
 HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
 {
+    *this = MoveList();
+
     if (cmp_ver < 1)
     {
         ReadFromFile_Legacy(in);
@@ -56,6 +58,8 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     }
 
     numstage = in->ReadInt32();
+    if ((numstage == 0) && cmp_ver >= 2)
+        return HSaveError::None();
     // TODO: reimplement MoveList stages as vector to avoid these limits
     if (numstage > MAXNEEDSTAGES)
     {
@@ -72,6 +76,9 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 
+    if (cmp_ver < 2)
+        onpart = itofix(onpart); // convert to fixed-point value
+
     for (int i = 0; i < numstage; ++i)
     { // X & Y was packed as high/low shorts, and hence reversed in lo-end
         pos[i].Y = in->ReadInt16();
@@ -82,9 +89,12 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     return HSaveError::None();
 }
 
-void MoveList::WriteToFile(Stream *out)
+void MoveList::WriteToFile(Stream *out) const
 {
     out->WriteInt32(numstage);
+    if (numstage == 0)
+        return;
+
     out->WriteInt32(from.X);
     out->WriteInt32(from.Y);
     out->WriteInt32(onstage);

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -55,7 +55,7 @@ struct MoveList
 
     void ReadFromFile_Legacy(Common::Stream *in);
     AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
-    void WriteToFile(Common::Stream *out);
+    void WriteToFile(Common::Stream *out) const;
 };
 
 #endif // __AGS_EN_AC__MOVELIST_H

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -34,14 +34,18 @@ enum MoveListDoneFlags
 struct MoveList
 {
     int     numstage = 0;
+    // Waypoints, per stage
     Point   pos[MAXNEEDSTAGES];
     // xpermove and ypermove contain number of pixels done per a single step
     // along x and y axes; i.e. this is a movement vector, per path stage
     fixed   xpermove[MAXNEEDSTAGES]{};
     fixed   ypermove[MAXNEEDSTAGES]{};
-    Point   from;
     int     onstage = 0; // current path stage
-    int     onpart = 0; // total number of steps done on this stage
+    Point   from; // current stage's starting position
+    // Steps made during current stage;
+    // distance passed is calculated as xpermove[onstage] * onpart;
+    // made a fractional value to let recalculate movelist dynamically
+    fixed   onpart = 0;
     uint8_t doneflag = 0u;
     uint8_t direct = 0;  // MoveCharDirect was used or not
 

--- a/Engine/ac/roomstatus.h
+++ b/Engine/ac/roomstatus.h
@@ -41,7 +41,8 @@ enum RoomStatSvgVersion
     kRoomStatSvgVersion_Initial  = 0,
     kRoomStatSvgVersion_36025    = 3,
     kRoomStatSvgVersion_36041    = 4,
-    kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_36041
+    kRoomStatSvgVersion_36109    = 5,
+    kRoomStatSvgVersion_Current  = kRoomStatSvgVersion_36109
 };
 
 // RoomStatus contains everything about a room that could change at runtime.

--- a/Engine/ac/route_finder.cpp
+++ b/Engine/ac/route_finder.cpp
@@ -32,6 +32,7 @@ public:
     virtual void set_route_move_speed(int speed_x, int speed_y) = 0;
     virtual int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0) = 0;
     virtual void calculate_move_stage(MoveList * mlsp, int aaa) = 0;
+    virtual void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) = 0;
 };
 
 class AGSRouteFinder : public IRouteFinder 
@@ -69,6 +70,10 @@ public:
     { 
         AGS::Engine::RouteFinder::calculate_move_stage(mlsp, aaa); 
     }
+    void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) override
+    {
+        AGS::Engine::RouteFinder::recalculate_move_speeds(mlsp, old_speed_x, old_speed_y, new_speed_x, new_speed_y);
+    }
 };
 
 class AGSLegacyRouteFinder : public IRouteFinder 
@@ -105,6 +110,10 @@ public:
     void calculate_move_stage(MoveList * mlsp, int aaa) override
     { 
         AGS::Engine::RouteFinderLegacy::calculate_move_stage(mlsp, aaa); 
+    }
+    void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y) override
+    {
+        assert(false); // not supported
     }
 };
 
@@ -160,4 +169,9 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
 void calculate_move_stage(MoveList * mlsp, int aaa)
 {
     route_finder_impl->calculate_move_stage(mlsp, aaa);
+}
+
+void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y)
+{
+    route_finder_impl->recalculate_move_speeds(mlsp, old_speed_x, old_speed_y, new_speed_x, new_speed_y);
 }

--- a/Engine/ac/route_finder.h
+++ b/Engine/ac/route_finder.h
@@ -33,5 +33,6 @@ void set_route_move_speed(int speed_x, int speed_y);
 
 int find_route(short srcx, short srcy, short xx, short yy, AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
 void calculate_move_stage(MoveList * mlsp, int aaa);
+void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
 
 #endif // __AC_ROUTEFND_H

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -258,9 +258,9 @@ void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, i
   if (mlsp->onpart >= 0)
   {
     if (old_stage_xpermove != 0)
-      mlsp->onpart = (int)(fixtof(old_stage_xpermove) * (float)mlsp->onpart) / fixtof(mlsp->xpermove[mlsp->onstage]);
+      mlsp->onpart = fixdiv(fixmul(mlsp->onpart, old_stage_xpermove), mlsp->xpermove[mlsp->onstage]);
     else
-      mlsp->onpart = (int)(fixtof(old_stage_ypermove) * (float)mlsp->onpart) / fixtof(mlsp->ypermove[mlsp->onstage]);
+      mlsp->onpart = fixdiv(fixmul(mlsp->onpart, old_stage_ypermove), mlsp->ypermove[mlsp->onstage]);
   }
 }
 

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -116,22 +116,44 @@ static int find_route_jps(int fromx, int fromy, int destx, int desty)
   return 1;
 }
 
-void set_route_move_speed(int speed_x, int speed_y)
+inline fixed input_speed_to_fixed(int speed_val)
 {
   // negative move speeds like -2 get converted to 1/2
-  if (speed_x < 0) {
-    move_speed_x = itofix(1) / (-speed_x);
+  if (speed_val < 0) {
+    return itofix(1) / (-speed_val);
   }
   else {
-    move_speed_x = itofix(speed_x);
+    return itofix(speed_val);
   }
+}
 
-  if (speed_y < 0) {
-    move_speed_y = itofix(1) / (-speed_y);
+void set_route_move_speed(int speed_x, int speed_y)
+{
+  move_speed_x = input_speed_to_fixed(speed_x);
+  move_speed_y = input_speed_to_fixed(speed_y);
+}
+
+inline fixed calc_move_speed_at_angle(fixed speed_x, fixed speed_y, fixed xdist, fixed ydist)
+{
+  fixed useMoveSpeed;
+  if (speed_x == speed_y) {
+    useMoveSpeed = speed_x;
   }
   else {
-    move_speed_y = itofix(speed_y);
+    // different X and Y move speeds
+    // the X proportion of the movement is (x / (x + y))
+    fixed xproportion = fixdiv(xdist, (xdist + ydist));
+
+    if (speed_x > speed_y) {
+      // speed = y + ((1 - xproportion) * (x - y))
+      useMoveSpeed = speed_y + fixmul(xproportion, speed_x - speed_y);
+    }
+    else {
+      // speed = x + (xproportion * (y - x))
+      useMoveSpeed = speed_x + fixmul(itofix(1) - xproportion, speed_y - speed_x);
+    }
   }
+  return useMoveSpeed;
 }
 
 // Calculates the X and Y per game loop, for this stage of the
@@ -172,25 +194,7 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
   fixed xdist = itofix(abs(ourx - destx));
   fixed ydist = itofix(abs(oury - desty));
 
-  fixed useMoveSpeed;
-
-  if (move_speed_x == move_speed_y) {
-    useMoveSpeed = move_speed_x;
-  }
-  else {
-    // different X and Y move speeds
-    // the X proportion of the movement is (x / (x + y))
-    fixed xproportion = fixdiv(xdist, (xdist + ydist));
-
-    if (move_speed_x > move_speed_y) {
-      // speed = y + ((1 - xproportion) * (x - y))
-      useMoveSpeed = move_speed_y + fixmul(xproportion, move_speed_x - move_speed_y);
-    }
-    else {
-      // speed = x + (xproportion * (y - x))
-      useMoveSpeed = move_speed_x + fixmul(itofix(1) - xproportion, move_speed_y - move_speed_x);
-    }
-  }
+  fixed useMoveSpeed = calc_move_speed_at_angle(move_speed_x, move_speed_y, xdist, ydist);
 
   fixed angl = fixatan(fixdiv(ydist, xdist));
 
@@ -209,6 +213,55 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
 
   mlsp->xpermove[aaa] = newxmove;
   mlsp->ypermove[aaa] = newymove;
+}
+
+void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y)
+{
+  const fixed old_movspeed_x = input_speed_to_fixed(old_speed_x);
+  const fixed old_movspeed_y = input_speed_to_fixed(old_speed_y);
+  const fixed new_movspeed_x = input_speed_to_fixed(new_speed_x);
+  const fixed new_movspeed_y = input_speed_to_fixed(new_speed_y);
+  // save current stage's step lengths, for later onpart's update
+  const fixed old_stage_xpermove = mlsp->xpermove[mlsp->onstage];
+  const fixed old_stage_ypermove = mlsp->ypermove[mlsp->onstage];
+
+  for (int i = 0; (i < mlsp->numstage) && ((mlsp->xpermove[i] != 0) || (mlsp->ypermove[i] != 0)); ++i)
+  {
+    // First three cases where the speed is a plain factor, therefore
+    // we may simply divide on old one and multiple on a new one
+    if ((old_movspeed_x == old_movspeed_y) || // diagonal move at straight 45 degrees
+        (mlsp->xpermove[i] == 0) || // straight vertical move
+        (mlsp->ypermove[i] == 0))   // straight horizontal move
+    {
+      mlsp->xpermove[i] = fixdiv(fixmul(mlsp->xpermove[i], new_movspeed_x), old_movspeed_x);
+      mlsp->ypermove[i] = fixdiv(fixmul(mlsp->ypermove[i], new_movspeed_y), old_movspeed_y);
+    }
+    else
+    {
+      // Move at angle has adjusted speed factor, which we must recalculate first
+      short ourx = mlsp->pos[i].X;
+      short oury = mlsp->pos[i].Y;
+      short destx = mlsp->pos[i + 1].X;
+      short desty = mlsp->pos[i + 1].Y;
+
+      fixed xdist = itofix(abs(ourx - destx));
+      fixed ydist = itofix(abs(oury - desty));
+      fixed old_speed_at_angle = calc_move_speed_at_angle(old_movspeed_x, old_movspeed_y, xdist, ydist);
+      fixed new_speed_at_angle = calc_move_speed_at_angle(new_movspeed_x, new_movspeed_y, xdist, ydist);
+
+      mlsp->xpermove[i] = fixdiv(fixmul(mlsp->xpermove[i], new_speed_at_angle), old_speed_at_angle);
+      mlsp->ypermove[i] = fixdiv(fixmul(mlsp->ypermove[i], new_speed_at_angle), old_speed_at_angle);
+    }
+  }
+
+  // now adjust current passed stage fraction
+  if (mlsp->onpart >= 0)
+  {
+    if (old_stage_xpermove != 0)
+      mlsp->onpart = (int)(fixtof(old_stage_xpermove) * (float)mlsp->onpart) / fixtof(mlsp->xpermove[mlsp->onstage]);
+    else
+      mlsp->onpart = (int)(fixtof(old_stage_ypermove) * (float)mlsp->onpart) / fixtof(mlsp->ypermove[mlsp->onstage]);
+  }
 }
 
 

--- a/Engine/ac/route_finder_impl.h
+++ b/Engine/ac/route_finder_impl.h
@@ -37,6 +37,7 @@ void set_route_move_speed(int speed_x, int speed_y);
 
 int find_route(short srcx, short srcy, short xx, short yy, AGS::Common::Bitmap *onscreen, int movlst, int nocross = 0, int ignore_walls = 0);
 void calculate_move_stage(MoveList * mlsp, int aaa);
+void recalculate_move_speeds(MoveList *mlsp, int old_speed_x, int old_speed_y, int new_speed_x, int new_speed_y);
 
 } // namespace RouteFinder
 } // namespace Engine

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -638,22 +638,21 @@ findroutebk:
   return 1;
 }
 
-void set_route_move_speed(int speed_x, int speed_y)
+inline fixed input_speed_to_fixed(int speed_val)
 {
   // negative move speeds like -2 get converted to 1/2
-  if (speed_x < 0) {
-    move_speed_x = itofix(1) / (-speed_x);
+  if (speed_val < 0) {
+    return itofix(1) / (-speed_val);
   }
   else {
-    move_speed_x = itofix(speed_x);
+    return itofix(speed_val);
   }
+}
 
-  if (speed_y < 0) {
-    move_speed_y = itofix(1) / (-speed_y);
-  }
-  else {
-    move_speed_y = itofix(speed_y);
-  }
+void set_route_move_speed(int speed_x, int speed_y)
+{
+  move_speed_x = input_speed_to_fixed(speed_x);
+  move_speed_y = input_speed_to_fixed(speed_y);
 }
 
 // Calculates the X and Y per game loop, for this stage of the

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -100,14 +100,14 @@ static void movelist_handle_targetfix(const fixed xpermove, const fixed ypermove
 // Handle remaining move along a single axis; uses generic parameters.
 static void movelist_handle_remainer(
     const fixed xpermove, const fixed ypermove,
-    const int xdistance, const float step_length, int &onpart,
-    int &fin_ymove, int &fin_onpart)
+    const int xdistance, const float step_length, fixed &onpart,
+    fixed &fin_ymove, fixed &fin_onpart)
 {
     // Walk along the remaining axis with the full walking speed
     assert(xpermove != 0 && ypermove != 0);
     fin_ymove = ypermove > 0 ? ftofix(step_length) : -ftofix(step_length);
-    float onpart_to_dist = (float)xdistance / fixtof(xpermove);
-    fin_onpart = (int)((float)onpart - onpart_to_dist);
+    fixed onpart_to_dist = ftofix((float)xdistance / fixtof(xpermove));
+    fin_onpart = onpart - onpart_to_dist;
     onpart = onpart_to_dist;
 }
 
@@ -128,7 +128,7 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     int main_onpart = cmls.onpart;
     const bool do_fix_target = loaded_game_file_version < kGameVersion_361;
     fixed fin_xmove = 0, fin_ymove = 0;
-    int fin_onpart = 0;
+    fixed fin_onpart = 0;
 
     // Handle possible move remainers
     if ((ypermove != 0) && (cmls.doneflag & kMoveListDone_X) != 0)
@@ -151,13 +151,13 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     // Calculate next positions, as required
     if ((cmls.doneflag & kMoveListDone_X) == 0)
     {
-        xps = cmls.from.X + (int)(fixtof(xpermove) * (float)main_onpart) +
-          (int)(fixtof(fin_xmove) * (float)fin_onpart);
+        xps = cmls.from.X + (int)(fixtof(xpermove) * fixtof(main_onpart)) +
+          (int)(fixtof(fin_xmove) * fixtof(fin_onpart));
     }
     if ((cmls.doneflag & kMoveListDone_Y) == 0)
     {
-        yps = cmls.from.Y + (int)(fixtof(ypermove) * (float)main_onpart) +
-          (int)(fixtof(fin_ymove) * (float)fin_onpart);
+        yps = cmls.from.Y + (int)(fixtof(ypermove) * fixtof(main_onpart)) +
+          (int)(fixtof(fin_ymove) * fixtof(fin_onpart));
     }
 
     // Check if finished horizontal movement
@@ -196,7 +196,7 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
         // this stage is done, go on to the next stage
         cmls.from = cmls.pos[cmls.onstage + 1];
         cmls.onstage++;
-        cmls.onpart = -1;
+        cmls.onpart = itofix(-1);
         cmls.doneflag = 0;
         if (cmls.onstage < cmls.numstage)
         {
@@ -217,7 +217,7 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     }
 
     // Make a step along the current vector and return
-    cmls.onpart++;
+    cmls.onpart += itofix(1);
     pos_x = xps;
     pos_y = yps;
     return need_to_fix_sprite;


### PR DESCRIPTION
Done after a conversation in #2125 , not directly related, but I wanted to experiment with recalculating movelists.

Try to support changing Character's movement speed while character is moving. This is done by recalculating movelist's stages and updating current stage's distance (`onpart` variable).
Recalculation is done as a rather trivial math, where we divide on the old speed factor and multiply on the new speed factor. This does not involve any pathfinding at all, as we only need to "replace" a speed factor in x/ypermove arrays, so to speak.

I did this only in case of a "new" pathfinder, because old one is used in old games only, where changing walkspeed during walk was prohibited. But technically this code is applicable to both.

Preliminary tests show a good progress, so I decided to put a PR for a test.

Example of a game that may help to test this, contains a slider to change walking speed:
https://github.com/adventuregamestudio/ags/files/12659434/test--361walkspeed.zip

Things to test:
- [x] Changing walk speed works without character jumping back or forth, regardless of the speed difference (old vs new).
- [x] Character keeps walking visibly along the same line after changing speed.
- [x] Destination check, after changing speed during a walk: character should arrive onto exact position where ordered (it should not depend on speed or whether speed has changed).
- [x] Writing and reading saves done in this version with walking character(s).
- [x] Reading saves done in older versions with walking character(s): they should continue walking with the same speed.