### PR TITLE
Editor: support go-to for GUI controls, Cursors, Audio Types and Fonts

### DIFF
--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -461,7 +461,7 @@ namespace AGS.Editor
             {
                 if (!DoesCurrentLineHaveToken(script, AUTO_COMPLETE_IGNORE))
                 {
-                    insideEnumDefinition.EnumValues.Add(new ScriptEnumValue(lastWord, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex));
+                    insideEnumDefinition.EnumValues.Add(new ScriptEnumValue(lastWord, insideEnumDefinition.Name, state.InsideIfDefBlock, state.InsideIfNDefBlock, state.CurrentScriptCharacterIndex));
                 }
             }
         }

--- a/Editor/AGS.Editor/ComponentController.cs
+++ b/Editor/AGS.Editor/ComponentController.cs
@@ -195,14 +195,14 @@ namespace AGS.Editor
             }
         }
 
-		public IEditorComponent FindComponentThatManageScriptType(string scriptType)
+		public IEditorComponent FindComponentThatManageScriptElement(string scriptType)
 		{
 			foreach (IEditorComponent component in _components)
 			{
 				if (component is Components.BaseComponent)
 				{
 					Components.BaseComponent bComponent = component as Components.BaseComponent;
-					if (bComponent.GetManagedScriptTypes().Contains(scriptType)) return bComponent;
+					if (bComponent.GetManagedScriptElements().Contains(scriptType)) return bComponent;
 				}
 			}
 			return null;

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -288,9 +288,9 @@ namespace AGS.Editor.Components
             AudioClipTypeTypeConverter.RefreshAudioClipTypeList();
         }
 
-        public override IList<string> GetManagedScriptTypes()
+        public override IList<string> GetManagedScriptElements()
         {
-            return new string[] { "AudioClip" };
+            return new string[] { "AudioClip", "AudioType" };
         }
 
         private void ShowPaneForItem(string controlID)
@@ -331,6 +331,17 @@ namespace AGS.Editor.Components
                 {
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(ac));
                     ShowPaneForItem(GetNodeID(ac));
+                    return;
+                }
+            }
+
+            // it can be an AudioType
+            foreach (AudioClipType clipType in _agsEditor.CurrentGame.AudioClipTypes)
+            {
+                if(clipType.ScriptID == name)
+                {
+                    _guiController.ProjectTree.SelectNode(this, GetClipTypeNodeID(clipType));
+                    ShowPaneForItem(GetClipTypeNodeID(clipType));
                     return;
                 }
             }
@@ -870,6 +881,11 @@ namespace AGS.Editor.Components
             return _agsEditor.CurrentGame.AudioClipFlatList;
         }
 
+        private string GetClipTypeNodeID(AudioClipType clipType)
+        {
+            return NODE_ID_PREFIX_CLIP_TYPE + clipType.TypeID;
+        }
+
         private string GetNodeID(AudioClip clip)
         {
             return ITEM_COMMAND_PREFIX + clip.ScriptName;
@@ -926,7 +942,7 @@ namespace AGS.Editor.Components
 
         private string AddTreeNodeForAudioClipType(AudioClipType clipType)
         {
-            string newNodeID = NODE_ID_PREFIX_CLIP_TYPE + clipType.TypeID;
+            string newNodeID = GetClipTypeNodeID(clipType);
             ProjectTreeItem treeItem = (ProjectTreeItem)_guiController.ProjectTree.AddTreeLeaf(this, newNodeID, clipType.Name, AUDIO_CLIP_TYPE_ICON);
             treeItem.AllowLabelEdit = true;
             treeItem.LabelTextProperty = clipType.GetType().GetProperty("Name");

--- a/Editor/AGS.Editor/Components/BaseComponent.cs
+++ b/Editor/AGS.Editor/Components/BaseComponent.cs
@@ -59,7 +59,7 @@ namespace AGS.Editor.Components
         {
         }
 
-        public virtual IList<string> GetManagedScriptTypes()
+        public virtual IList<string> GetManagedScriptElements()
         {
             return new string[] {};
         }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -154,7 +154,7 @@ namespace AGS.Editor.Components
 			_guiController.AddOrShowPane(document);
 		}
 
-        public override IList<string> GetManagedScriptTypes()
+        public override IList<string> GetManagedScriptElements()
         {
             return new string[] { "Character" };
         }

--- a/Editor/AGS.Editor/Components/CursorsComponent.cs
+++ b/Editor/AGS.Editor/Components/CursorsComponent.cs
@@ -93,6 +93,25 @@ namespace AGS.Editor.Components
             _guiController.AddOrShowPane(document);
 		}
 
+        public override IList<string> GetManagedScriptElements()
+        {
+            return new string[] { "CursorMode" };
+        }
+
+        public override void ShowItemPaneByName(string name)
+        {
+            foreach (MouseCursor mc in _agsEditor.CurrentGame.Cursors)
+            {
+                if (mc.ScriptID == name)
+                {
+                    MouseCursor chosenCursor = mc;
+                    _guiController.ProjectTree.SelectNode(this, GetNodeID(chosenCursor));
+                    ShowOrAddPane(chosenCursor);
+                    return;
+                }
+            }
+        }
+
         public override void PropertyChanged(string propertyName, object oldValue)
         {
             if (propertyName == "Name")

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -229,7 +229,7 @@ namespace AGS.Editor.Components
             }
         }
 
-        public override IList<string> GetManagedScriptTypes()
+        public override IList<string> GetManagedScriptElements()
         {
             return new string[] { "Dialog" };
         }

--- a/Editor/AGS.Editor/Components/FontsComponent.cs
+++ b/Editor/AGS.Editor/Components/FontsComponent.cs
@@ -118,6 +118,24 @@ namespace AGS.Editor.Components
             document.TreeNodeID = GetNodeID(chosenFont);
             _guiController.AddOrShowPane(document);
         }
+        public override IList<string> GetManagedScriptElements()
+        {
+            return new string[] { "FontType" };
+        }
+
+        public override void ShowItemPaneByName(string name)
+        {
+            foreach(AGS.Types.Font f in _agsEditor.CurrentGame.Fonts)
+            {
+                if(f.ScriptID == name)
+                {
+                    AGS.Types.Font chosenFont = f;
+                    _guiController.ProjectTree.SelectNode(this, GetNodeID(chosenFont));
+                    ShowOrAddPane(chosenFont);
+                    return;
+                }
+            }
+        }
 
         public override void PropertyChanged(string propertyName, object oldValue)
         {

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -193,7 +193,7 @@ namespace AGS.Editor.Components
             _guiController.AddOrShowPane(document);
 		}
 
-        public override IList<string> GetManagedScriptTypes()
+        public override IList<string> GetManagedScriptElements()
         {
             return new string[] { "GUI" };
         }

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -195,7 +195,7 @@ namespace AGS.Editor.Components
 
         public override IList<string> GetManagedScriptElements()
         {
-            return new string[] { "GUI" };
+            return new string[] { "GUI", "Label", "Button", "Slider", "ListBox", "TextBox", "InvWindow" };
         }
 
         public override void ShowItemPaneByName(string name)
@@ -208,6 +208,17 @@ namespace AGS.Editor.Components
                     _guiController.ProjectTree.SelectNode(this, GetNodeID(g));
                     ShowOrAddPane(g);
                     return;
+                }
+                
+                foreach(GUIControl gctrl in g.Controls)
+                {
+                    if(gctrl.Name == name)
+                    {
+                        _guiController.ProjectTree.SelectNode(this, GetNodeID(g));
+                        ShowOrAddPane(g);
+                        Factory.GUIController.SetPropertyGridObject(gctrl);
+                        return;
+                    }
                 }
             }
         }

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -131,7 +131,7 @@ namespace AGS.Editor.Components
             _guiController.AddOrShowPane(document);
 		}
 
-        public override IList<string> GetManagedScriptTypes()
+        public override IList<string> GetManagedScriptElements()
         {
             return new string[] { "InventoryItem" };
         }

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -553,20 +553,30 @@ namespace AGS.Editor
                 }
                 else if (foundInScript.FileName == Tasks.AUTO_GENERATED_HEADER_NAME)
                 {
+                    string scriptElementType = null, scriptElementName = null;
                     if (found is ScriptVariable)
                     {
                         ScriptVariable sVar = found as ScriptVariable;
-                        string varType = sVar.Type;
-                        string varName = sVar.VariableName;
+                        scriptElementType = sVar.Type;
+                        scriptElementName = sVar.VariableName;
+                    }
+                    else if (found is ScriptEnumValue)
+                    {
+                        ScriptEnumValue sEnum = found as ScriptEnumValue;
+                        scriptElementType = sEnum.Type;
+                        scriptElementName = sEnum.Name;
+                    }
 
-                        BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptType(varType) as BaseComponent;
+                    if (!string.IsNullOrEmpty(scriptElementType))
+                    { 
+                        BaseComponent component = Factory.ComponentController.FindComponentThatManageScriptElement(scriptElementType) as BaseComponent;
                         if(component != null)
                         {
-                            component.ShowItemPaneByName(varName);
+                            component.ShowItemPaneByName(scriptElementName);
                         }
                         else
                         {
-                            Factory.GUIController.ShowMessage("This variable is internally defined by AGS and probably corresponds to an in-game entity such as a GUIControl or Inventory Item.", MessageBoxIcon.Information);
+                            Factory.GUIController.ShowMessage("This variable is internally defined by AGS and probably corresponds to an in-game entity such as a GUIControl or Room Object.", MessageBoxIcon.Information);
                         }
                     }
                     else

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -576,7 +576,7 @@ namespace AGS.Editor
                         }
                         else
                         {
-                            Factory.GUIController.ShowMessage("This variable is internally defined by AGS and probably corresponds to an in-game entity such as a GUIControl or Room Object.", MessageBoxIcon.Information);
+                            Factory.GUIController.ShowMessage("This variable is internally defined by AGS and probably corresponds to an in-game entity which does not support Go to Definition at the moment.", MessageBoxIcon.Information);
                         }
                     }
                     else

--- a/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnumValue.cs
+++ b/Editor/AGS.Types/EditorFeatures/AutoComplete/ScriptEnumValue.cs
@@ -6,14 +6,16 @@ namespace AGS.Types.AutoComplete
 {
     public class ScriptEnumValue : ScriptToken
     {
-        public ScriptEnumValue(string name, string ifDefOnly, string ifNDefOnly, int scriptCharacterIndex)
+        public ScriptEnumValue(string name, string enumtype, string ifDefOnly, string ifNDefOnly, int scriptCharacterIndex)
         {
             Name = name;
+            Type = enumtype;
             IfDefOnly = ifDefOnly;
             IfNDefOnly = ifNDefOnly;
             StartsAtCharacterIndex = scriptCharacterIndex;
         }
 
         public string Name;
+        public string Type;
     }
 }


### PR DESCRIPTION
Btw, I looked into creating a ScriptElement in EditorFeatures/AutoComplete, which both ScriptVariable and ScriptEnumValue could extend from, but ScriptVariable name is VariableName and ScriptEnumValue name is just Name, so I couldn't easily make both extend from the same thing without breaking AGS Types api.

Ah, `#define` macros don't have the concept of what they belong to, so there isn't an easy way to add VIEW macro support (in ags4, we could have view as enum after #1175).

I also noticed the when launching the help, if it detects that the found thing is an enum, it could use it's type to instead search the help for that, because currently the enum values in the built-in header are not index, only their enum type. I am not doing this here because I am thinking if I can add them to the index somehow in the ags-manual.

fix #1685