### PR TITLE
Fix "walking on place" bug in 3.6.1

### DIFF
--- a/Common/util/geometry.h
+++ b/Common/util/geometry.h
@@ -118,6 +118,11 @@ struct Point
     {
         return Point(X - p.X, Y - p.Y);
     }
+
+    inline bool Equals(const int x, const int y) const
+    {
+        return X == x && Y == y;
+    }
 };
 
 struct Line

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -1896,7 +1896,7 @@ int has_hit_another_character(int sourceChar) {
 int doNextCharMoveStep (CharacterInfo *chi, int &char_index, CharacterExtras *chex) {
     int ntf=0, xwas = chi->x, ywas = chi->y;
 
-    if (do_movelist_move(&chi->walking,&chi->x,&chi->y) == 2) 
+    if (do_movelist_move(chi->walking, chi->x, chi->y) == 2) 
     {
         if ((chi->flags & CHF_MOVENOTWALK) == 0)
             fix_player_sprite(&mls[chi->walking], chi);

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -182,7 +182,7 @@ void Character_AddWaypoint(CharacterInfo *chaa, int x, int y) {
         return;
     }
 
-    cmls->pos[cmls->numstage] = (x << 16) + y;
+    cmls->pos[cmls->numstage] = { x, y };
     // They're already walking there anyway
     if (cmls->pos[cmls->numstage] == cmls->pos[cmls->numstage - 1])
         return;
@@ -1397,7 +1397,7 @@ int Character_GetMoving(CharacterInfo *chaa) {
 int Character_GetDestinationX(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1] >> 16;
+        return cmls->pos[cmls->numstage - 1].X;
     }
     else
         return chaa->x;
@@ -1406,7 +1406,7 @@ int Character_GetDestinationX(CharacterInfo *chaa) {
 int Character_GetDestinationY(CharacterInfo *chaa) {
     if (chaa->walking) {
         MoveList *cmls = &mls[chaa->walking % TURNING_AROUND];
-        return cmls->pos[cmls->numstage - 1] & 0xFFFF;
+        return cmls->pos[cmls->numstage - 1].Y;
     }
     else
         return chaa->y;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -2866,10 +2866,10 @@ void update_room_debug()
                 mlsnum %= TURNING_AROUND;
             const MoveList &cmls = mls[mlsnum];
             for (int i = 0; i < cmls.numstage - 1; i++) {
-                short srcx = short((cmls.pos[i] >> 16) & 0x00ffff);
-                short srcy = short(cmls.pos[i] & 0x00ffff);
-                short targetx = short((cmls.pos[i + 1] >> 16) & 0x00ffff);
-                short targety = short(cmls.pos[i + 1] & 0x00ffff);
+                short srcx = cmls.pos[i].X;
+                short srcy = cmls.pos[i].Y;
+                short targetx = cmls.pos[i + 1].X;
+                short targety = cmls.pos[i + 1].Y;
                 debugMoveListObj.Bmp->DrawLine(Line(srcx / mult, srcy / mult, targetx / mult, targety / mult),
                     MakeColor(i + 1));
             }

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -19,6 +19,14 @@
 using namespace AGS::Common;
 using namespace AGS::Engine;
 
+float MoveList::GetStepLength() const
+{
+    assert(numstage > 0);
+    float permove_x = fixtof(xpermove[onstage]);
+    float permove_y = fixtof(ypermove[onstage]);
+    return std::sqrt(permove_x * permove_x + permove_y * permove_y);
+}
+
 void MoveList::ReadFromFile_Legacy(Stream *in)
 {
     for (int i = 0; i < MAXNEEDSTAGES_LEGACY; ++i)

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -33,8 +33,8 @@ void MoveList::ReadFromFile_Legacy(Stream *in)
     from.Y = in->ReadInt32();
     onstage = in->ReadInt32();
     onpart = in->ReadInt32();
-    last.X = in->ReadInt32();
-    last.Y = in->ReadInt32();
+    in->ReadInt32(); // UNUSED
+    in->ReadInt32(); // UNUSED
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 }
@@ -59,8 +59,8 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
     from.Y = in->ReadInt32();
     onstage = in->ReadInt32();
     onpart = in->ReadInt32();
-    last.X = in->ReadInt32();
-    last.Y = in->ReadInt32();
+    in->ReadInt32(); // UNUSED
+    in->ReadInt32();
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 
@@ -81,8 +81,8 @@ void MoveList::WriteToFile(Stream *out)
     out->WriteInt32(from.Y);
     out->WriteInt32(onstage);
     out->WriteInt32(onpart);
-    out->WriteInt32(last.X);
-    out->WriteInt32(last.Y);
+    out->WriteInt32(0); // UNUSED
+    out->WriteInt32(0);
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
 

--- a/Engine/ac/movelist.cpp
+++ b/Engine/ac/movelist.cpp
@@ -21,16 +21,20 @@ using namespace AGS::Engine;
 
 void MoveList::ReadFromFile_Legacy(Stream *in)
 {
-    in->ReadArrayOfInt32(pos, MAXNEEDSTAGES_LEGACY);
+    for (int i = 0; i < MAXNEEDSTAGES_LEGACY; ++i)
+    { // X & Y was packed as high/low shorts, and hence reversed in lo-end
+        pos[i].Y = in->ReadInt16();
+        pos[i].X = in->ReadInt16();
+    }
     numstage = in->ReadInt32();
     in->ReadArrayOfInt32(xpermove, MAXNEEDSTAGES_LEGACY);
     in->ReadArrayOfInt32(ypermove, MAXNEEDSTAGES_LEGACY);
-    fromx = in->ReadInt32();
-    fromy = in->ReadInt32();
+    from.X = in->ReadInt32();
+    from.Y = in->ReadInt32();
     onstage = in->ReadInt32();
     onpart = in->ReadInt32();
-    lastx = in->ReadInt32();
-    lasty = in->ReadInt32();
+    last.X = in->ReadInt32();
+    last.Y = in->ReadInt32();
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 }
@@ -51,16 +55,20 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
             String::FromFormat("Incompatible number of movelist steps (count: %d, max : %d).", numstage, MAXNEEDSTAGES));
     }
 
-    fromx = in->ReadInt32();
-    fromy = in->ReadInt32();
+    from.X = in->ReadInt32();
+    from.Y = in->ReadInt32();
     onstage = in->ReadInt32();
     onpart = in->ReadInt32();
-    lastx = in->ReadInt32();
-    lasty = in->ReadInt32();
+    last.X = in->ReadInt32();
+    last.Y = in->ReadInt32();
     doneflag = in->ReadInt8();
     direct = in->ReadInt8();
 
-    in->ReadArrayOfInt32(pos, numstage);
+    for (int i = 0; i < numstage; ++i)
+    { // X & Y was packed as high/low shorts, and hence reversed in lo-end
+        pos[i].Y = in->ReadInt16();
+        pos[i].X = in->ReadInt16();
+    }
     in->ReadArrayOfInt32(xpermove, numstage);
     in->ReadArrayOfInt32(ypermove, numstage);
     return HSaveError::None();
@@ -69,16 +77,20 @@ HSaveError MoveList::ReadFromFile(Stream *in, int32_t cmp_ver)
 void MoveList::WriteToFile(Stream *out)
 {
     out->WriteInt32(numstage);
-    out->WriteInt32(fromx);
-    out->WriteInt32(fromy);
+    out->WriteInt32(from.X);
+    out->WriteInt32(from.Y);
     out->WriteInt32(onstage);
     out->WriteInt32(onpart);
-    out->WriteInt32(lastx);
-    out->WriteInt32(lasty);
+    out->WriteInt32(last.X);
+    out->WriteInt32(last.Y);
     out->WriteInt8(doneflag);
     out->WriteInt8(direct);
 
-    out->WriteArrayOfInt32(pos, numstage);
+    for (int i = 0; i < numstage; ++i)
+    { // X & Y was packed as high/low shorts, and hence reversed in lo-end
+        out->WriteInt16(pos[i].Y);
+        out->WriteInt16(pos[i].X);
+    }
     out->WriteArrayOfInt32(xpermove, numstage);
     out->WriteArrayOfInt32(ypermove, numstage);
 }

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -35,12 +35,13 @@ struct MoveList
 {
     int     numstage = 0;
     Point   pos[MAXNEEDSTAGES];
+    // xpermove and ypermove contain number of pixels done per a single step
+    // along x and y axes; i.e. this is a movement vector, per path stage
     fixed   xpermove[MAXNEEDSTAGES]{};
     fixed   ypermove[MAXNEEDSTAGES]{};
     Point   from;
-    int     onstage = 0;
-    int     onpart = 0;
-    Point   last;
+    int     onstage = 0; // current path stage
+    int     onpart = 0; // total number of steps done on this stage
     uint8_t doneflag = 0u;
     uint8_t direct = 0;  // MoveCharDirect was used or not
 

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -11,10 +11,11 @@
 // http://www.opensource.org/licenses/artistic-license-2.0.php
 //
 //=============================================================================
-#ifndef __AC_MOVE_H
-#define __AC_MOVE_H
+#ifndef __AGS_EN_AC__MOVELIST_H
+#define __AGS_EN_AC__MOVELIST_H
 #include <allegro.h> // fixed math
 #include "game/savegame.h"
+#include "util/geometry.h"
 
 // Forward declaration
 namespace AGS { namespace Common { class Stream; } }
@@ -23,19 +24,29 @@ using namespace AGS; // FIXME later
 #define MAXNEEDSTAGES 256
 #define MAXNEEDSTAGES_LEGACY 40
 
-struct MoveList {
-    int   pos[MAXNEEDSTAGES]{};
-    int   numstage = 0;
-    fixed xpermove[MAXNEEDSTAGES]{}, ypermove[MAXNEEDSTAGES]{};
-    int   fromx = 0, fromy = 0;
-    int   onstage = 0, onpart = 0;
-    int   lastx = 0, lasty = 0;
-    char  doneflag = 0;
-    char  direct = 0;  // MoveCharDirect was used or not
+enum MoveListDoneFlags
+{
+    kMoveListDone_X = 0x01,
+    kMoveListDone_Y = 0x02,
+    kMoveListDone_XY = kMoveListDone_X | kMoveListDone_Y
+};
+
+struct MoveList
+{
+    int     numstage = 0;
+    Point   pos[MAXNEEDSTAGES];
+    fixed   xpermove[MAXNEEDSTAGES]{};
+    fixed   ypermove[MAXNEEDSTAGES]{};
+    Point   from;
+    int     onstage = 0;
+    int     onpart = 0;
+    Point   last;
+    uint8_t doneflag = 0u;
+    uint8_t direct = 0;  // MoveCharDirect was used or not
 
     void ReadFromFile_Legacy(Common::Stream *in);
     AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);
 };
 
-#endif // __AC_MOVE_H
+#endif // __AGS_EN_AC__MOVELIST_H

--- a/Engine/ac/movelist.h
+++ b/Engine/ac/movelist.h
@@ -45,6 +45,10 @@ struct MoveList
     uint8_t doneflag = 0u;
     uint8_t direct = 0;  // MoveCharDirect was used or not
 
+    // Gets a movelist's step length, in coordinate units
+    // (normally the coord unit is a game pixel)
+    float GetStepLength() const;
+
     void ReadFromFile_Legacy(Common::Stream *in);
     AGS::Engine::HSaveError ReadFromFile(Common::Stream *in, int32_t cmp_ver);
     void WriteToFile(Common::Stream *out);

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1078,7 +1078,6 @@ void convert_move_path_to_room_resolution(MoveList *ml)
         return;
 
     ml->from = { mask_to_room_coord(ml->from.X), mask_to_room_coord(ml->from.Y) };
-    ml->last = { mask_to_room_coord(ml->last.X), mask_to_room_coord(ml->last.Y) };
 
     for (int i = 0; i < ml->numstage; i++)
     {

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1077,16 +1077,12 @@ void convert_move_path_to_room_resolution(MoveList *ml)
     if (thisroom.MaskResolution == game.GetDataUpscaleMult())
         return;
 
-    ml->fromx = mask_to_room_coord(ml->fromx);
-    ml->fromy = mask_to_room_coord(ml->fromy);
-    ml->lastx = mask_to_room_coord(ml->lastx);
-    ml->lasty = mask_to_room_coord(ml->lasty);
+    ml->from = { mask_to_room_coord(ml->from.X), mask_to_room_coord(ml->from.Y) };
+    ml->last = { mask_to_room_coord(ml->last.X), mask_to_room_coord(ml->last.Y) };
 
     for (int i = 0; i < ml->numstage; i++)
     {
-        uint16_t low = mask_to_room_coord(ml->pos[i] & 0x0000ffff);
-        uint16_t high = mask_to_room_coord((ml->pos[i] >> 16) & 0x0000ffff);
-        ml->pos[i] = ((int)high << 16) | (low & 0x0000ffff);
+        ml->pos[i] = { mask_to_room_coord(ml->pos[i].X), mask_to_room_coord(ml->pos[i].Y) };
     }
 
     if (game.options[OPT_WALKSPEEDABSOLUTE] == 0)

--- a/Engine/ac/roomobject.cpp
+++ b/Engine/ac/roomobject.cpp
@@ -72,7 +72,7 @@ void RoomObject::UpdateCyclingView(int ref_id)
 {
 	if (on != 1) return;
     if (moving>0) {
-      do_movelist_move(&moving,&x,&y);
+      do_movelist_move(moving, x, y);
       }
     if (cycling==0) return;
     if (view == RoomObject::NoView) return;

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -147,10 +147,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  short ourx = (mlsp->pos[aaa] >> 16) & 0x000ffff;
-  short oury = (mlsp->pos[aaa] & 0x000ffff);
-  short destx = ((mlsp->pos[aaa + 1] >> 16) & 0x000ffff);
-  short desty = (mlsp->pos[aaa + 1] & 0x000ffff);
+  short ourx = mlsp->pos[aaa].X;
+  short oury = mlsp->pos[aaa].Y;
+  short destx = mlsp->pos[aaa + 1].X;
+  short desty = mlsp->pos[aaa + 1].Y;
 
   // Special case for vertical and horizontal movements
   if (ourx == destx) {
@@ -257,13 +257,11 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   for (i=0; i<num_navpoints-1; i++)
     calculate_move_stage(&mls[mlist], i);
 
-  mls[mlist].fromx = srcx;
-  mls[mlist].fromy = srcy;
+  mls[mlist].from = { srcx, srcy };
   mls[mlist].onstage = 0;
   mls[mlist].onpart = 0;
   mls[mlist].doneflag = 0;
-  mls[mlist].lastx = -1;
-  mls[mlist].lasty = -1;
+  mls[mlist].last = { -1, -1 };
   return mlist;
 }
 

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -259,7 +259,6 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   mls[mlist].onstage = 0;
   mls[mlist].onpart = 0;
   mls[mlist].doneflag = 0;
-  mls[mlist].last = { -1, -1 };
   return mlist;
 }
 

--- a/Engine/ac/route_finder_impl.cpp
+++ b/Engine/ac/route_finder_impl.cpp
@@ -39,10 +39,8 @@ namespace AGS {
 namespace Engine {
 namespace RouteFinder {
 
-#define MAKE_INTCOORD(x,y) (((unsigned short)x << 16) | ((unsigned short)y))
-
 static const int MAXNAVPOINTS = MAXNEEDSTAGES;
-static int navpoints[MAXNAVPOINTS];
+static Point navpoints[MAXNAVPOINTS];
 static int num_navpoints;
 static fixed move_speed_x, move_speed_y;
 static Navigation nav;
@@ -112,7 +110,7 @@ static int find_route_jps(int fromx, int fromy, int destx, int desty)
     int x, y;
     nav.UnpackSquare(cpath[i], x, y);
 
-    navpoints[num_navpoints++] = MAKE_INTCOORD(x, y);
+    navpoints[num_navpoints++] = { x, y };
   }
 
   return 1;
@@ -225,8 +223,8 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
   if (ignore_walls || can_see_from(srcx, srcy, xx, yy))
   {
     num_navpoints = 2;
-    navpoints[0] = MAKE_INTCOORD(srcx, srcy);
-    navpoints[1] = MAKE_INTCOORD(xx, yy);
+    navpoints[0] = { srcx, srcy };
+    navpoints[1] = { xx, yy };
   } else {
     if ((nocross == 0) && (wallscreen->GetPixel(xx, yy) == 0))
       return 0; // clicked on a wall
@@ -249,7 +247,7 @@ int find_route(short srcx, short srcy, short xx, short yy, Bitmap *onscreen, int
 
   int mlist = movlst;
   mls[mlist].numstage = num_navpoints;
-  memcpy(&mls[mlist].pos[0], &navpoints[0], sizeof(int) * num_navpoints);
+  memcpy(&mls[mlist].pos[0], &navpoints[0], sizeof(Point) * num_navpoints);
 #ifdef DEBUG_PATHFINDER
   AGS::Common::Debug::Printf("stages: %d\n",num_navpoints);
 #endif

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -875,7 +875,6 @@ stage_again:
     mls[mlist].onstage = 0;
     mls[mlist].onpart = 0;
     mls[mlist].doneflag = 0;
-    mls[mlist].last = { -1, -1 };
 #ifdef DEBUG_PATHFINDER
     // getch();
 #endif

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -669,10 +669,10 @@ void calculate_move_stage(MoveList * mlsp, int aaa)
     return;
   }
 
-  short ourx = (mlsp->pos[aaa] >> 16) & 0x000ffff;
-  short oury = (mlsp->pos[aaa] & 0x000ffff);
-  short destx = ((mlsp->pos[aaa + 1] >> 16) & 0x000ffff);
-  short desty = (mlsp->pos[aaa + 1] & 0x000ffff);
+  short ourx = mlsp->pos[aaa].X;
+  short oury = mlsp->pos[aaa].Y;
+  short destx = mlsp->pos[aaa + 1].X;
+  short desty = mlsp->pos[aaa + 1].Y;
 
   // Special case for vertical and horizontal movements
   if (ourx == destx) {
@@ -871,13 +871,11 @@ stage_again:
       calculate_move_stage(&mls[mlist], aaa);
     }
 
-    mls[mlist].fromx = orisrcx;
-    mls[mlist].fromy = orisrcy;
+    mls[mlist].from = { orisrcx, orisrcy };
     mls[mlist].onstage = 0;
     mls[mlist].onpart = 0;
     mls[mlist].doneflag = 0;
-    mls[mlist].lastx = -1;
-    mls[mlist].lasty = -1;
+    mls[mlist].last = { -1, -1 };
 #ifdef DEBUG_PATHFINDER
     // getch();
 #endif

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -145,6 +145,8 @@ const int LegacyRoomVolumeFactor            = 30;
 
 #define STD_BUFFER_SIZE 3000
 
+// NOTE: these flags are merged with the MoveList index;
+// but this means that the number of MoveList users will be limited by 1000
 #define TURNING_AROUND     1000
 #define TURNING_BACKWARDS 10000
 

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -62,7 +62,10 @@ extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern IGraphicsDriver *gfxDriver;
 
 
-static void movelist_handle_remainer(const fixed &xpermove, const fixed &ypermove, int &targety)
+// Optionally fixes target position, when one axis is left to move along.
+// This is done only for backwards compatibility now.
+// Uses generic parameters.
+static void movelist_handle_targetfix(const fixed xpermove, const fixed ypermove, int &targety)
 {
     // Old comment about ancient behavior:
     // if the X-movement has finished, and the Y-per-move is < 1, finish
@@ -73,6 +76,8 @@ static void movelist_handle_remainer(const fixed &xpermove, const fixed &ypermov
 
     // NEW 2.15 SR-1 plan: if X-movement has finished, and Y-per-move is < 1,
     // allow it to finish more easily by moving target zone
+    // NOTE: interesting fact: this fix was also done for the strictly vertical
+    // move, probably because of the logical mistake in condition.
 
     int tfix = 3;
     // 2.70: if the X permove is also <=1, don't skip as far
@@ -92,6 +97,19 @@ static void movelist_handle_remainer(const fixed &xpermove, const fixed &ypermov
         targety += tfix;
 }
 
+// Handle remaining move along a single axis; uses generic parameters.
+static void movelist_handle_remainer(
+    const fixed xpermove, const fixed ypermove,
+    const int xdistance, const int onpart, const float step_length,
+    int &fin_ymove, int &fin_onpart)
+{
+    // Walk along the remaining axis with the full walking speed
+    assert(xpermove != 0 && ypermove != 0);
+    fin_ymove = ypermove > 0 ? ftofix(step_length) : -ftofix(step_length);
+    float onpart_to_dist = (float)xdistance / fixtof(xpermove);
+    fin_onpart = (int)((float)onpart - onpart_to_dist);
+}
+
 int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
 {
     // TODO: find out why movelist 0 is not being used
@@ -106,28 +124,41 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     int targetx = cmls.pos[cmls.onstage + 1].X;
     int targety = cmls.pos[cmls.onstage + 1].Y;
     int xps = pos_x, yps = pos_y;
+    const bool do_fix_target = loaded_game_file_version < kGameVersion_361;
+    fixed fin_xmove = 0, fin_ymove = 0;
+    int fin_onpart = 0;
 
-    if (cmls.doneflag & kMoveListDone_X)
-    {
-        // X-move has finished, handle the Y-move remainer
-        movelist_handle_remainer(xpermove, ypermove, targety);
+    // Handle possible move remainers
+    if ((ypermove != 0) && (cmls.doneflag & kMoveListDone_X) != 0)
+    { // X-move has finished, handle the Y-move remainer
+        if (do_fix_target)
+            movelist_handle_targetfix(xpermove, ypermove, targety);
+        if (xpermove != 0)
+            movelist_handle_remainer(xpermove, ypermove, targetx - cmls.from.X,
+                cmls.onpart, cmls.GetStepLength(), fin_ymove, fin_onpart);
     }
-    else
-    {
-        xps = cmls.from.X + (int)(fixtof(xpermove)*(float)cmls.onpart);
-    }
-
-    if (cmls.doneflag & kMoveListDone_Y)
-    {
-        // Y-move has finished, handle the X-move remainer
-        movelist_handle_remainer(ypermove, xpermove, targetx);
-    }
-    else
-    {
-        yps = cmls.from.Y + (int)(fixtof(ypermove)*(float)cmls.onpart);
+    if ((xpermove != 0) && (cmls.doneflag & kMoveListDone_Y) != 0)
+    { // Y-move has finished, handle the X-move remainer
+        if (do_fix_target)
+            movelist_handle_targetfix(xpermove, ypermove, targety);
+        if (ypermove != 0)
+            movelist_handle_remainer(ypermove, xpermove, targety - cmls.from.Y,
+                cmls.onpart, cmls.GetStepLength(), fin_xmove, fin_onpart);
     }
 
-    // check if finished horizontal movement
+    // Calculate next positions, as required
+    if ((cmls.doneflag & kMoveListDone_X) == 0)
+    {
+        xps = cmls.from.X + (int)(fixtof(xpermove)*(float)cmls.onpart) +
+          (int)(fixtof(fin_xmove)*(float)fin_onpart);
+    }
+    if ((cmls.doneflag & kMoveListDone_Y) == 0)
+    {
+        yps = cmls.from.Y + (int)(fixtof(ypermove)*(float)cmls.onpart) +
+          (int)(fixtof(fin_ymove)*(float)fin_onpart);
+    }
+
+    // Check if finished horizontal movement
     if (((xpermove > 0) && (xps >= targetx)) ||
         ((xpermove < 0) && (xps <= targetx)))
     {
@@ -144,7 +175,8 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
     { // NOTE: do not snap pos_x to target in this case (?)
         cmls.doneflag |= kMoveListDone_X;
     }
-    // check if finished vertical movement
+
+    // Check if finished vertical movement
     if (((ypermove > 0) && (yps>=targety)) ||
         ((ypermove < 0) & (yps<=targety)))
     {
@@ -156,7 +188,8 @@ int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
         cmls.doneflag |= kMoveListDone_Y;
     }
 
-    if ((cmls.doneflag & kMoveListDone_XY)==kMoveListDone_XY)
+    // Handle end of move stage
+    if ((cmls.doneflag & kMoveListDone_XY) == kMoveListDone_XY)
     {
         // this stage is done, go on to the next stage
         cmls.from = cmls.pos[cmls.onstage + 1];

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -67,10 +67,10 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
   MoveList*cmls; cmls=&mls[mlnum[0]];
   fixed xpermove=cmls->xpermove[cmls->onstage],ypermove=cmls->ypermove[cmls->onstage];
 
-  short targetx=short((cmls->pos[cmls->onstage+1] >> 16) & 0x00ffff);
-  short targety=short(cmls->pos[cmls->onstage+1] & 0x00ffff);
+  int targetx = cmls->pos[cmls->onstage+1].X;
+  int targety = cmls->pos[cmls->onstage+1].Y;
   int xps=xx[0],yps=yy[0];
-  if (cmls->doneflag & 1) {
+  if (cmls->doneflag & kMoveListDone_X) {
     // if the X-movement has finished, and the Y-per-move is < 1, finish
     // This can cause jump at the end, but without it the character will
     // walk on the spot for a while if the Y-per-move is for example 0.2
@@ -97,9 +97,9 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
     else if ((ypermove & 0xffff0000) == 0xffff0000)
       targety += adjAmnt;
   }
-  else xps=cmls->fromx+(int)(fixtof(xpermove)*(float)cmls->onpart);
+  else xps=cmls->from.X+(int)(fixtof(xpermove)*(float)cmls->onpart);
 
-  if (cmls->doneflag & 2) {
+  if (cmls->doneflag & kMoveListDone_Y) {
     // Y-movement has finished
 
     int adjAmnt = 3;
@@ -123,11 +123,11 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
 //    if ((xpmm==0) | (xpmm==0xffff)) cmls->doneflag|=1;
     if (xpmm==0) cmls->doneflag|=1;*/
     }
-  else yps=cmls->fromy+(int)(fixtof(ypermove)*(float)cmls->onpart);
+  else yps=cmls->from.Y+(int)(fixtof(ypermove)*(float)cmls->onpart);
   // check if finished horizontal movement
   if (((xpermove > 0) && (xps >= targetx)) ||
       ((xpermove < 0) && (xps <= targetx))) {
-    cmls->doneflag|=1;
+    cmls->doneflag|=kMoveListDone_X;
     xps = targetx;
     // if the Y is almost there too, finish it
     // this is new in v2.40
@@ -136,31 +136,27 @@ int do_movelist_move(short*mlnum,int*xx,int*yy) {
       yps = targety;*/
   }
   else if (xpermove == 0)
-    cmls->doneflag|=1;
+    cmls->doneflag|=kMoveListDone_X;
   // check if finished vertical movement
   if ((ypermove > 0) & (yps>=targety)) {
-    cmls->doneflag|=2;
+    cmls->doneflag|=kMoveListDone_Y;
     yps = targety;
   }
   else if ((ypermove < 0) & (yps<=targety)) {
-    cmls->doneflag|=2;
+    cmls->doneflag|=kMoveListDone_Y;
     yps = targety;
   }
   else if (ypermove == 0)
-    cmls->doneflag|=2;
+    cmls->doneflag|=kMoveListDone_Y;
 
-  if ((cmls->doneflag & 0x03)==3) {
+  if ((cmls->doneflag & kMoveListDone_XY)==kMoveListDone_XY) {
     // this stage is done, go on to the next stage
-    // signed shorts to ensure that numbers like -20 do not become 65515
-    cmls->fromx=(signed short)((cmls->pos[cmls->onstage+1] >> 16) & 0x000ffff);
-    cmls->fromy=(signed short)(cmls->pos[cmls->onstage+1] & 0x000ffff);
-    if ((cmls->fromx > 65000) || (cmls->fromy > 65000))
-      quit("do_movelist: int to short rounding error");
+    cmls->from=cmls->pos[cmls->onstage+1];
 
-    cmls->onstage++; cmls->onpart=-1; cmls->doneflag&=0xf0;
-    cmls->lastx=-1;
+    cmls->onstage++; cmls->onpart=-1; cmls->doneflag=0;
+    cmls->last.X=-1;
     if (cmls->onstage < cmls->numstage) {
-      xps=cmls->fromx; yps=cmls->fromy; }
+      xps=cmls->from.X; yps=cmls->from.Y; }
     if (cmls->onstage>=cmls->numstage-1) {  // last stage is just dest pos
       cmls->numstage=0;
       mlnum[0]=0;

--- a/Engine/main/update.cpp
+++ b/Engine/main/update.cpp
@@ -61,114 +61,132 @@ extern std::vector<SpeechLipSyncLine> splipsync;
 extern int numLipLines, curLipLine, curLipLinePhoneme;
 extern IGraphicsDriver *gfxDriver;
 
-int do_movelist_move(short*mlnum,int*xx,int*yy) {
-  int need_to_fix_sprite=0;
-  if (mlnum[0]<1) quit("movelist_move: attempted to move on a non-exist movelist");
-  MoveList*cmls; cmls=&mls[mlnum[0]];
-  fixed xpermove=cmls->xpermove[cmls->onstage],ypermove=cmls->ypermove[cmls->onstage];
 
-  int targetx = cmls->pos[cmls->onstage+1].X;
-  int targety = cmls->pos[cmls->onstage+1].Y;
-  int xps=xx[0],yps=yy[0];
-  if (cmls->doneflag & kMoveListDone_X) {
+static void movelist_handle_remainer(const fixed &xpermove, const fixed &ypermove, int &targety)
+{
+    // Old comment about ancient behavior:
     // if the X-movement has finished, and the Y-per-move is < 1, finish
     // This can cause jump at the end, but without it the character will
     // walk on the spot for a while if the Y-per-move is for example 0.2
-//    if ((ypermove & 0xfffff000) == 0) cmls->doneflag|=2;
-//    int ypmm=(ypermove >> 16) & 0x0000ffff;
+    //    if ((ypermove & 0xfffff000) == 0) cmls.doneflag|=2;
+    //    int ypmm=(ypermove >> 16) & 0x0000ffff;
 
     // NEW 2.15 SR-1 plan: if X-movement has finished, and Y-per-move is < 1,
     // allow it to finish more easily by moving target zone
 
-    int adjAmnt = 3;
-    // 2.70: if the X permove is also <=1, don't do the skipping
+    int tfix = 3;
+    // 2.70: if the X permove is also <=1, don't skip as far
     if (((xpermove & 0xffff0000) == 0xffff0000) ||
         ((xpermove & 0xffff0000) == 0x00000000))
-      adjAmnt = 2;
+        tfix = 2;
 
     // 2.61 RC1: correct this to work with > -1 as well as < 1
-    if (ypermove == 0) { }
+    if (ypermove == 0) {}
     // Y per move is < 1, so finish the move
     else if ((ypermove & 0xffff0000) == 0)
-      targety -= adjAmnt;
+        targety -= tfix;
     // Y per move is -1 exactly, don't snap to finish
-    else if (ypermove == 0xffff0000) { }
+    else if (ypermove == 0xffff0000) {}
     // Y per move is > -1, so finish the move
     else if ((ypermove & 0xffff0000) == 0xffff0000)
-      targety += adjAmnt;
-  }
-  else xps=cmls->from.X+(int)(fixtof(xpermove)*(float)cmls->onpart);
+        targety += tfix;
+}
 
-  if (cmls->doneflag & kMoveListDone_Y) {
-    // Y-movement has finished
+int do_movelist_move(short &mslot, int &pos_x, int &pos_y)
+{
+    // TODO: find out why movelist 0 is not being used
+    assert(mslot >= 1);
+    if (mslot < 1)
+        return 0;
 
-    int adjAmnt = 3;
+    int need_to_fix_sprite = 0; // TODO: find out what this value means and refactor
+    MoveList &cmls = mls[mslot];
+    fixed xpermove = cmls.xpermove[cmls.onstage];
+    fixed ypermove = cmls.ypermove[cmls.onstage];
+    int targetx = cmls.pos[cmls.onstage + 1].X;
+    int targety = cmls.pos[cmls.onstage + 1].Y;
+    int xps = pos_x, yps = pos_y;
 
-    // if the Y permove is also <=1, don't skip as far
-    if (((ypermove & 0xffff0000) == 0xffff0000) ||
-        ((ypermove & 0xffff0000) == 0x00000000))
-      adjAmnt = 2;
-
-    if (xpermove == 0) { }
-    // Y per move is < 1, so finish the move
-    else if ((xpermove & 0xffff0000) == 0)
-      targetx -= adjAmnt;
-    // X per move is -1 exactly, don't snap to finish
-    else if (xpermove == 0xffff0000) { }
-    // X per move is > -1, so finish the move
-    else if ((xpermove & 0xffff0000) == 0xffff0000)
-      targetx += adjAmnt;
-
-/*    int xpmm=(xpermove >> 16) & 0x0000ffff;
-//    if ((xpmm==0) | (xpmm==0xffff)) cmls->doneflag|=1;
-    if (xpmm==0) cmls->doneflag|=1;*/
+    if (cmls.doneflag & kMoveListDone_X)
+    {
+        // X-move has finished, handle the Y-move remainer
+        movelist_handle_remainer(xpermove, ypermove, targety);
     }
-  else yps=cmls->from.Y+(int)(fixtof(ypermove)*(float)cmls->onpart);
-  // check if finished horizontal movement
-  if (((xpermove > 0) && (xps >= targetx)) ||
-      ((xpermove < 0) && (xps <= targetx))) {
-    cmls->doneflag|=kMoveListDone_X;
-    xps = targetx;
-    // if the Y is almost there too, finish it
-    // this is new in v2.40
-    // removed in 2.70
-    /*if (abs(yps - targety) <= 2)
-      yps = targety;*/
-  }
-  else if (xpermove == 0)
-    cmls->doneflag|=kMoveListDone_X;
-  // check if finished vertical movement
-  if ((ypermove > 0) & (yps>=targety)) {
-    cmls->doneflag|=kMoveListDone_Y;
-    yps = targety;
-  }
-  else if ((ypermove < 0) & (yps<=targety)) {
-    cmls->doneflag|=kMoveListDone_Y;
-    yps = targety;
-  }
-  else if (ypermove == 0)
-    cmls->doneflag|=kMoveListDone_Y;
-
-  if ((cmls->doneflag & kMoveListDone_XY)==kMoveListDone_XY) {
-    // this stage is done, go on to the next stage
-    cmls->from=cmls->pos[cmls->onstage+1];
-
-    cmls->onstage++; cmls->onpart=-1; cmls->doneflag=0;
-    cmls->last.X=-1;
-    if (cmls->onstage < cmls->numstage) {
-      xps=cmls->from.X; yps=cmls->from.Y; }
-    if (cmls->onstage>=cmls->numstage-1) {  // last stage is just dest pos
-      cmls->numstage=0;
-      mlnum[0]=0;
-      need_to_fix_sprite=1;
-      }
-    else need_to_fix_sprite=2;
+    else
+    {
+        xps = cmls.from.X + (int)(fixtof(xpermove)*(float)cmls.onpart);
     }
-  cmls->onpart++;
-  xx[0]=xps; yy[0]=yps;
-  return need_to_fix_sprite;
-  }
 
+    if (cmls.doneflag & kMoveListDone_Y)
+    {
+        // Y-move has finished, handle the X-move remainer
+        movelist_handle_remainer(ypermove, xpermove, targetx);
+    }
+    else
+    {
+        yps = cmls.from.Y + (int)(fixtof(ypermove)*(float)cmls.onpart);
+    }
+
+    // check if finished horizontal movement
+    if (((xpermove > 0) && (xps >= targetx)) ||
+        ((xpermove < 0) && (xps <= targetx)))
+    {
+        cmls.doneflag |= kMoveListDone_X;
+        xps = targetx;
+        // Comment about old engine behavior:
+        // if the Y is almost there too, finish it
+        // this is new in v2.40
+        // removed in 2.70
+        /*if (abs(yps - targety) <= 2)
+          yps = targety;*/
+    }
+    else if (xpermove == 0)
+    { // NOTE: do not snap pos_x to target in this case (?)
+        cmls.doneflag |= kMoveListDone_X;
+    }
+    // check if finished vertical movement
+    if (((ypermove > 0) && (yps>=targety)) ||
+        ((ypermove < 0) & (yps<=targety)))
+    {
+        cmls.doneflag |= kMoveListDone_Y;
+        yps = targety;
+    }
+    else if (ypermove == 0)
+    { // NOTE: do not snap pos_y to target in this case (?)
+        cmls.doneflag |= kMoveListDone_Y;
+    }
+
+    if ((cmls.doneflag & kMoveListDone_XY)==kMoveListDone_XY)
+    {
+        // this stage is done, go on to the next stage
+        cmls.from = cmls.pos[cmls.onstage + 1];
+        cmls.onstage++;
+        cmls.onpart = -1;
+        cmls.doneflag = 0;
+        if (cmls.onstage < cmls.numstage)
+        {
+            xps = cmls.from.X;
+            yps = cmls.from.Y;
+        }
+
+        if (cmls.onstage >= cmls.numstage - 1)
+        {  // last stage is just dest pos
+            cmls.numstage=0;
+            mslot = 0;
+            need_to_fix_sprite = 1; // TODO: find out what this means
+        }
+        else
+        {
+            need_to_fix_sprite = 2; // TODO: find out what this means
+        }
+    }
+
+    // Make a step along the current vector and return
+    cmls.onpart++;
+    pos_x = xps;
+    pos_y = yps;
+    return need_to_fix_sprite;
+}
 
 void update_script_timers()
 {

--- a/Engine/main/update.h
+++ b/Engine/main/update.h
@@ -18,7 +18,12 @@
 #ifndef __AGS_EE_MAIN__UPDATE_H
 #define __AGS_EE_MAIN__UPDATE_H
 
-int do_movelist_move(short*mlnum,int*xx,int*yy);
+// Update MoveList of certain index, save current position;
+// *resets* mslot to zero if path is complete.
+// returns "need_to_fix_sprite" value, which may be 0,1,2;
+// TODO: find out what this return value means, and refactor.
+// TODO: do not reset mslot in this function, reset externally instead.
+int do_movelist_move(short &mslot, int &pos_x, int &pos_y);
 void update_stuff();
 
 #endif // __AGS_EE_MAIN__UPDATE_H

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -764,8 +764,8 @@ int IAGSEngine::GetMovementPathLastWaypoint(int32 pathId) {
 }
 
 void IAGSEngine::GetMovementPathWaypointLocation(int32 pathId, int32 waypoint, int32 *x, int32 *y) {
-    *x = (mls[pathId % TURNING_AROUND].pos[waypoint] >> 16) & 0x0000ffff;
-    *y = (mls[pathId % TURNING_AROUND].pos[waypoint] & 0x0000ffff);
+    *x = mls[pathId % TURNING_AROUND].pos[waypoint].X;
+    *y = mls[pathId % TURNING_AROUND].pos[waypoint].Y;
 }
 
 void IAGSEngine::GetMovementPathWaypointSpeed(int32 pathId, int32 waypoint, int32 *xSpeed, int32 *ySpeed) {


### PR DESCRIPTION
Fixes #935.

AGS historically has a hidden problem: its pathfinder and walking algorithm uses math with relatively low precision. This may result in rounding mistakes. What this means in practice is that under some circumstances the "movement direction" (vector) is slightly off, e.g. more towards X than Y (or other way). In such case the character may reach the X destination while Y destination is still few pixels away.

How is this issue solved currently in AGS (and for a long time): when AGS finds out that one coordinate is complete, but another is not (for example X done and Y is still not reached), it starts waiting until character reaches Y, but also accepts a certain "mistake", in 2-3 pixels. If character is already within 2-3 pixels from the destination, then it just stops. This makes its real stopping point inaccurate, but nothing else happens. However, if character is further away, then it keeps "walking", but because the movement vector is still pointing in the same direction, usually it takes few moments for it to reach the proper Y coordinate. This results in a buggy effect known as "walking in place".

The most natural way to fix this would be to use floating-point math instead of a fixed-point math, as that would increase precision. But there's a concern about backwards compatibility. Knowing a history of AGS games, there is a non-zero chance that some old game had position checks in script, requiring character to pass or stop at the exact pixel.
I recall someone already found a issue in an old game after we introduced a new pathfinder, so we actually had to return an old one for old games.
This is why I'd rather leave this for ags4 branch (where it is already implemented).

This commit introduces a more "compatible" solution. What it does is: turn the walking vector to make it point right along the unfinished axis, while keeping its length (that means - walking speed), in order to reach the destination faster.
This should make character make some extra short move, properly animating, but this may look more natural than just moving legs in place.

NOTE: I still keep the "destination fix" for the old games, as they may be scripted specifically to test where character has stopped moving.

NOTE 2: This PR also contains MoveList refactor, backported from ags4 branch, but it does not change a save format.
But here I went further and also picked some generic code into a separate function that deals with "finishing move".