### PR TITLE
Editor: more fixes for compiled files cleanup

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -937,15 +937,6 @@ namespace AGS.Editor
             return errorToReturn;
         }
 
-        private void DeleteAnyExistingSplitResourceFiles()
-        {
-            string dir = Path.Combine(OUTPUT_DIRECTORY, DATA_OUTPUT_DIRECTORY);
-            foreach (string fileName in Utilities.GetDirectoryFileList(dir, this.BaseGameFileName + ".0*"))
-            {
-                Utilities.TryDeleteFile(fileName);
-            }
-        }
-
         private void CreateAudioVOXFile(bool forceRebuild)
         {
             List<string> fileListForVox = new List<string>();
@@ -989,6 +980,10 @@ namespace AGS.Editor
             var buildNames = Factory.AGSEditor.CurrentGame.WorkspaceState.GetLastBuildGameFiles();
             foreach (IBuildTarget target in BuildTargetsInfo.GetSelectedBuildTargets())
             {
+                // Primary cleanup
+                target.DeleteMainGameData(Factory.AGSEditor.BaseGameFileName);
+
+                // Old files cleanup (if necessary)
                 string oldName;
                 if (!buildNames.TryGetValue(target.Name, out oldName)) continue;
                 if (!string.IsNullOrWhiteSpace(oldName) && oldName != Factory.AGSEditor.BaseGameFileName)
@@ -1245,6 +1240,9 @@ namespace AGS.Editor
             string oldName;
             if (buildNames.TryGetValue(target.Name, out oldName))
             {
+                // Primary cleanup
+                target.DeleteMainGameData(Factory.AGSEditor.BaseGameFileName);
+                // Old files cleanup (if necessary)
                 if (!string.IsNullOrWhiteSpace(oldName) && oldName != Factory.AGSEditor.BaseGameFileName)
                     target.DeleteMainGameData(oldName);
             }

--- a/Editor/AGS.Editor/AGSEditor.cs
+++ b/Editor/AGS.Editor/AGSEditor.cs
@@ -850,17 +850,6 @@ namespace AGS.Editor
 
 			preProcessedCode.Add(preprocessor.Preprocess(script.Text, script.FileName));
 
-#if DEBUG
-			// TODO: REMOVE BEFORE DISTRIBUTION
-/*			if (true)
-			{
-                string wholeScript = string.Join("\n", preProcessedCode.ToArray());
-				IScriptCompiler compiler = CompilerFactory.CreateScriptCompiler();
-				CompileResults output = compiler.CompileScript(wholeScript);
-				preprocessor.Results.AddRange(output);
-			}*/
-#endif
-
 			if (preprocessor.Results.Count > 0)
 			{
 				foreach (AGS.CScript.Compiler.Error error in preprocessor.Results)
@@ -1538,7 +1527,7 @@ namespace AGS.Editor
             NativeProxy.Instance.WriteIniFile(configFilePath, sections, true);
         }
 
-        private void SaveUserDataFile()
+        public void SaveUserDataFile()
         {
             StringWriter sw = new StringWriter();
             XmlTextWriter writer = new XmlTextWriter(sw);

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetAndroid.cs
@@ -521,9 +521,7 @@ namespace AGS.Editor
 
         public override void DeleteMainGameData(string name)
         {
-            string assetsDir = GetAssetsDir();
-            string filename = Path.Combine(assetsDir, name + ".ags");
-            Utilities.TryDeleteFile(filename);
+            DeleteCommonGameFiles(GetAssetsDir(), name);
         }
 
         public override bool Build(CompileMessages errors, bool forceRebuild)

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetBase.cs
@@ -150,5 +150,22 @@ namespace AGS.Editor
             }
             AGSEditor.Instance.WriteConfigFile(destPath, false);
         }
+
+        /// <summary>
+        /// Deletes all the common game's data files:
+        ///  * primary: <name>.ags,
+        ///  * split resources: <name>.001, <name>.002, etc.
+        /// </summary>
+        protected void DeleteCommonGameFiles(string dir, string gamename)
+        {
+            string filename = Path.Combine(dir, gamename + ".ags");
+            Utilities.TryDeleteFile(filename);
+
+            // Delete split resources (if any)
+            foreach (string fileName in Utilities.GetDirectoryFileList(dir, gamename + ".0*"))
+            {
+                Utilities.TryDeleteFile(fileName);
+            }
+        }
     }
 }

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetDataFile.cs
@@ -20,16 +20,7 @@ namespace AGS.Editor
 
         public override void DeleteMainGameData(string name)
         {
-            string filename = Path.Combine(OutputDirectoryFullPath, name + ".ags");
-            Utilities.TryDeleteFile(filename);
-        }
-
-        private void DeleteAnyExistingSplitResourceFiles()
-        {
-            foreach (string fileName in Utilities.GetDirectoryFileList(GetCompiledPath(), Factory.AGSEditor.BaseGameFileName + ".0*"))
-            {
-                Utilities.TryDeleteFile(fileName);
-            }
+            DeleteCommonGameFiles(OutputDirectoryFullPath, name);
         }
 
         /// <summary>
@@ -167,7 +158,6 @@ namespace AGS.Editor
         {
             if (!base.Build(errors, forceRebuild)) return false;
             Factory.AGSEditor.SetMODMusicFlag();
-            DeleteAnyExistingSplitResourceFiles();
             if (!DataFileWriter.SaveThisGameToFile(AGSEditor.COMPILED_DTA_FILE_NAME, Factory.AGSEditor.CurrentGame, errors))
             {
                 return false;

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetLinux.cs
@@ -67,8 +67,7 @@ namespace AGS.Editor
 
         public override void DeleteMainGameData(string name)
         {
-            string filename = Path.Combine(Path.Combine(OutputDirectoryFullPath, LINUX_DATA_DIR), name + ".ags");
-            Utilities.TryDeleteFile(filename);
+            DeleteCommonGameFiles(Path.Combine(OutputDirectoryFullPath, LINUX_DATA_DIR), name);
 
             string script_filename = Path.Combine(OutputDirectoryFullPath, GetScriptFileNameFromBasename(name));
             Utilities.TryDeleteFile(script_filename);

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWeb.cs
@@ -31,8 +31,7 @@ namespace AGS.Editor
 
         public override void DeleteMainGameData(string name)
         {
-            string filename = Path.Combine(OutputDirectoryFullPath, name + ".ags");
-            Utilities.TryDeleteFile(filename);
+            DeleteCommonGameFiles(OutputDirectoryFullPath, name);
         }
 
         public override bool Build(CompileMessages errors, bool forceRebuild)

--- a/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
+++ b/Editor/AGS.Editor/BuildTargets/BuildTargetWindows.cs
@@ -26,14 +26,10 @@ namespace AGS.Editor
 
         public override void DeleteMainGameData(string name)
         {
+            DeleteCommonGameFiles(OutputDirectoryFullPath, name);
+
             string filename = Path.Combine(OutputDirectoryFullPath, name + ".exe");
             Utilities.TryDeleteFile(filename);
-
-            if (!Factory.AGSEditor.CurrentGame.Settings.AttachDataToExe)
-            {
-                string ags_filename = Path.Combine(OutputDirectoryFullPath, name + ".ags");
-                Utilities.TryDeleteFile(ags_filename);
-            }
         }
 
         public void CopyPlugins(CompileMessages errors)

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -170,7 +170,10 @@ namespace AGS.Editor.Components
             forceRebuild = _agsEditor.NeedsRebuildForDebugMode();
             if (_agsEditor.SaveGameFiles())
             {
-                if (!_agsEditor.CompileGame(forceRebuild, true).HasErrors)
+                var messages = _agsEditor.CompileGame(forceRebuild, true);
+                // The user data may have been amended by the building process
+                _agsEditor.SaveUserDataFile();
+                if (!messages.HasErrors)
                 {
                     _testGameInProgress = true;
                     _guiController.InteractiveTasks.TestGame(withDebugger);
@@ -247,7 +250,10 @@ namespace AGS.Editor.Components
 			forceRebuild = _agsEditor.NeedsRebuildForDebugMode() || forceRebuild;
 			if (_agsEditor.SaveGameFiles())
 			{
-				if (_agsEditor.CompileGame(forceRebuild, false).Count == 0)
+                var messages = _agsEditor.CompileGame(forceRebuild, false);
+                // The user data may have been amended by the building process
+                _agsEditor.SaveUserDataFile();
+                if (messages.Count == 0)
 				{
 					string message = "Compilation successful!";
 					Factory.GUIController.ShowOutputPanel(message);


### PR DESCRIPTION
Fixes #1976, again.

* Picked out DeleteCommonGameFiles(), to be able to call same from any BuildTarget;
* Added cleanup of split resources.
* Call cleanup for the current filename too, just to be sure everything is deleted beforehand. This fixes split resources not being deleted if this option changes in General Settings.

Also:
* Save user data file (aka WorkspaceState) right after game building, to ensure that any information amended during build is always saved on disk regardless whether user saves or not the project itself.

