### PR TITLE
Editor: add separator in build menu before open folder

### DIFF
--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -62,6 +62,7 @@ namespace AGS.Editor.Components
             debugCommands.Commands.Add(new MenuCommand(COMPILE_GAME_COMMAND, "&Build EXE", Keys.F7, "MenuIconBuildEXE"));
 			debugCommands.Commands.Add(new MenuCommand(REBUILD_GAME_COMMAND, "Rebuild &all files", "RebuildAllMenuIcon"));
 			debugCommands.Commands.Add(new MenuCommand(SETUP_GAME_COMMAND, "Run game setu&p...", "SetupGameMenuIcon"));
+            debugCommands.Commands.Add(MenuCommand.Separator);
             debugCommands.Commands.Add(new MenuCommand(OPEN_BUILD_FILE_EXPLORER_COMMAND, "Open Build Folder in File Explorer", "OpenFolderBuildIcon"));
             _guiController.AddMenuItems(this, debugCommands);
 


### PR DESCRIPTION
minor thing, but it looks much nicer with this separator.

![image](https://github.com/adventuregamestudio/ags/assets/2244442/554889ff-1399-45c1-8b7d-6a7197af4078)

I should have added it when I added these.