### PR TITLE
ci: set release-3.6.0 templates branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -362,7 +362,7 @@ windows_packaging_task:
     curl -fLOJ https://github.com/adventuregamestudio/ags-manual/releases/latest/download/ags-help.chm
   get_templates_script: >
     mkdir Windows\Installer\Source\Templates &&
-    curl -fLSs https://github.com/%TEMPLATES_REPOSITORY%/tarball/master |
+    curl -fLSs https://github.com/%TEMPLATES_REPOSITORY%/tarball/release-3.6.0 |
     tar -f - -xvzC Windows\Installer\Source\Templates --strip-components 2
   get_linux_bundle_script: >
     mkdir Windows\Installer\Source\Linux &&


### PR DESCRIPTION
Make sure we are getting the templates from the right branch that is now https://github.com/adventuregamestudio/ags-templates/tree/release-3.6.0