### PR TITLE
Added #include directives that seem to be required

### DIFF
--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -30,6 +30,7 @@
 #define __AGS_CN_CORE__ASSETMANAGER_H
 
 #include <memory>
+#include <functional>
 #include "core/asset.h"
 #include "util/file.h" // TODO: extract filestream mode constants or introduce generic ones
 

--- a/Common/util/string.h
+++ b/Common/util/string.h
@@ -40,6 +40,7 @@
 
 #include <stdarg.h>
 #include <vector>
+#include <string>
 #include "core/platform.h"
 #include "core/types.h"
 #include "debug/assert.h"

--- a/Compiler/script2/cc_compiledscript.cpp
+++ b/Compiler/script2/cc_compiledscript.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string>
+#include <stdexcept>
 #include "cc_compiledscript.h"
 #include "script/cc_common.h"
 #include "script/cc_internal.h"

--- a/Editor/scintilla/src/UniConversion.h
+++ b/Editor/scintilla/src/UniConversion.h
@@ -8,6 +8,8 @@
 #ifndef UNICONVERSION_H
 #define UNICONVERSION_H
 
+#include <string>
+
 namespace Scintilla {
 
 constexpr int UTF8MaxBytes = 4;


### PR DESCRIPTION
Getting the engine and editor to build in windows 10 with vs2022, the IDE wanted to update the SDK to 10 and the platform toolset to 143.
In order for the solutions to build (besides some configuration changes that are probably not retrocompatible), these file changes were required.

If I understand things correctly, they have to do with the fact that some declarations have been moved from `std` to more "specific" headers.
Please, test these out with older toolchains.