### PR TITLE
Engine: use SDL_InitSubSystem for required systems

### DIFF
--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -684,7 +684,7 @@ void shutdown_sound()
     stop_all_sound_and_music(); // game logic
     audio_core_shutdown(); // audio core system
     soundcache_clear(); // clear cached data
-    sys_audio_shutdown(); // backend
+    if(usetup.audio_enabled) sys_audio_shutdown(); // backend
     usetup.audio_enabled = false;
 }
 


### PR DESCRIPTION
- Separate the gamepad system so it's failure doesn't fail all ags engine
- Make sure we only quit the SDL audio subsystem if it's ref count was increased

Fixes the issue reported here: https://www.adventuregamestudio.co.uk/forums/engine-development/ags-engine-web-port/msg636658208/#msg636658208

If sys_main was a singleton, it's instance could hold a variable to identify the successfully loaded systems - currently, only the SDL_GameController subsystem would be necessary. While there are some considerations into account about usage of singletons, they would help us reduce global variables - and have a better track of things the engine has in memory.