### PR TITLE
Record inited SDL subsystems and use this info during uninit

### DIFF
--- a/Engine/media/audio/audio.cpp
+++ b/Engine/media/audio/audio.cpp
@@ -684,7 +684,7 @@ void shutdown_sound()
     stop_all_sound_and_music(); // game logic
     audio_core_shutdown(); // audio core system
     soundcache_clear(); // clear cached data
-    if(usetup.audio_enabled) sys_audio_shutdown(); // backend
+    sys_audio_shutdown(); // backend; NOTE: sys_main will know if it's required
     usetup.audio_enabled = false;
 }
 


### PR DESCRIPTION
This is done after comments in #2166. Unfortunately I realized the problem too late, after merging the pr.

Keep record of the SDL subsystems we init in a static variable inside sys_main, and use this info when shutting SDL subsystems down. The idea is that this is incapsulated in sys_main, so that external code would not interfere with this.
Somewhere in the future we could remake sys_main into a singleton class, for instance.

EDIT: i have a deja vu, because this looks like something I was trying to add a while ago... but maybe this was in a different program.

@ericoporto could you please also try that this still works as expected?

This should be applied to a 3.6.0 branch too.

