### PR TITLE
Editor: keep ProjectTree's expanded state while doing simple actions

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -204,6 +204,7 @@
     <Compile Include="GUI\SpriteChooser.Designer.cs">
       <DependentUpon>SpriteChooser.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\TreeViewExtensions.cs" />
     <Compile Include="GUI\ViewChooser.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Editor/AGS.Editor/Components/AudioComponent.cs
+++ b/Editor/AGS.Editor/Components/AudioComponent.cs
@@ -805,7 +805,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
             AudioClipTypeConverter.RefreshAudioClipList();
         }
 
@@ -827,15 +827,10 @@ namespace AGS.Editor.Components
             }
             else if (propertyName == "Name")
             {
-                RePopulateTreeView();
-                if (_editor.SelectedItem is AudioClipFolder)
-                {
-                    _guiController.ProjectTree.SelectNode(this, GetNodeIDForFolder((AudioClipFolder)_editor.SelectedItem));
-                }
-                else
-                {
-                    _guiController.ProjectTree.SelectNode(this, AUDIO_TYPES_FOLDER_NODE_ID);
-                }
+                string nodeId = (_editor.SelectedItem is AudioClipFolder) ?
+                    GetNodeIDForFolder(_editor.SelectedItem as AudioClipFolder) :
+                    AUDIO_TYPES_FOLDER_NODE_ID;
+                RePopulateTreeView(nodeId);
             }
         }
 

--- a/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
+++ b/Editor/AGS.Editor/Components/BaseComponentWithFolders.cs
@@ -9,7 +9,9 @@ using System.Windows.Forms;
 
 namespace AGS.Editor.Components
 {
-    public abstract class BaseComponentWithFolders<ItemType,FolderType> : BaseComponent, IRePopulatableComponent
+    public abstract class BaseComponentWithFolders<ItemType,FolderType> :
+            BaseComponent,
+            IRePopulatableComponent
         where ItemType : IToXml
         where FolderType : BaseFolderCollection<ItemType,FolderType>
     {
@@ -460,21 +462,39 @@ namespace AGS.Editor.Components
             return null;
         }
 
+        #region IRePopulatableComponent
+
         public void RePopulateTreeView(string selectedNodeID)
         {
-            RePopulateTreeView();
+            RePopulateTreeViewImpl(true);
             _guiController.ProjectTree.SelectNode(this, selectedNodeID);
         }
 
         public void RePopulateTreeView()
-        {            
+        {
+            RePopulateTreeViewImpl(false);
+        }
+
+        #endregion // IRePopulatableComponent
+
+        private void RePopulateTreeViewImpl(bool restoreNodeStates)
+        {
+            List<string> savedExpansionState = null;
+            if (restoreNodeStates)
+                savedExpansionState = _guiController.ProjectTree.GetExpansionState();
+
             _items.Clear();
             _folders.Clear();
             _folders.Add(TOP_LEVEL_COMMAND_ID, this.GetRootFolder());
+            _guiController.ProjectTree.BeginUpdate();
             _guiController.ProjectTree.RemoveAllChildNodes(this, TOP_LEVEL_COMMAND_ID);
             _guiController.ProjectTree.StartFromNode(this, TOP_LEVEL_COMMAND_ID);
             AddExtraManualNodesToTree();
             PopulateTreeForFolder(this.GetRootFolder(), TOP_LEVEL_COMMAND_ID);
+
+            if (restoreNodeStates)
+                _guiController.ProjectTree.SetExpansionState(savedExpansionState);
+            _guiController.ProjectTree.EndUpdate();
         }
     }
 }

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -308,7 +308,6 @@ namespace AGS.Editor.Components
             {
                 _guiController.ShowMessage("An error occurred importing the character file. The error was: " + Environment.NewLine + Environment.NewLine + ex.Message, MessageBoxIcon.Warning);
             }
-            RePopulateTreeView();
         }        
 
         private Dictionary<string, object> ConstructPropertyObjectList(Character item)

--- a/Editor/AGS.Editor/Components/CharactersComponent.cs
+++ b/Editor/AGS.Editor/Components/CharactersComponent.cs
@@ -186,7 +186,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
             foreach (ContentDocument doc in _documents.Values)
             {

--- a/Editor/AGS.Editor/Components/DialogsComponent.cs
+++ b/Editor/AGS.Editor/Components/DialogsComponent.cs
@@ -129,7 +129,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
             foreach (ContentDocument doc in _documents.Values)
             {

--- a/Editor/AGS.Editor/Components/GuiComponent.cs
+++ b/Editor/AGS.Editor/Components/GuiComponent.cs
@@ -229,7 +229,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
             foreach (ContentDocument doc in _documents.Values)
             {
@@ -341,7 +341,8 @@ namespace AGS.Editor.Components
 
         private void _guiEditor_OnGuiNameChanged()
         {
-            RePopulateTreeView();
+            GUI itemBeingEdited = ((GUIEditor)_guiController.ActivePane.Control).GuiToEdit;
+            RePopulateTreeView(GetNodeID(itemBeingEdited));
         }
 
         private string GetNodeID(GUI item)

--- a/Editor/AGS.Editor/Components/InventoryComponent.cs
+++ b/Editor/AGS.Editor/Components/InventoryComponent.cs
@@ -150,7 +150,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
             foreach (ContentDocument doc in _documents.Values)
             {

--- a/Editor/AGS.Editor/Components/RoomsComponent.cs
+++ b/Editor/AGS.Editor/Components/RoomsComponent.cs
@@ -397,10 +397,10 @@ namespace AGS.Editor.Components
                 }
 
                 UnloadedRoom newRoom = new UnloadedRoom(newRoomNumber);
-                AddSingleItem(newRoom);                
+                var nodeId = AddSingleItem(newRoom);
 				_agsEditor.CurrentGame.FilesAddedOrRemoved = true;
 
-                RePopulateTreeView();
+                RePopulateTreeView(nodeId);
                 RoomListTypeConverter.SetRoomList(_agsEditor.CurrentGame.Rooms);
                 _guiController.ShowMessage("Room file imported successfully as room " + newRoomNumber + ".", MessageBoxIcon.Information);
             }
@@ -1094,7 +1094,7 @@ namespace AGS.Editor.Components
             {
                 UnloadedRoom room = FindRoomByID(_loadedRoom.Number);
                 room.Description = _loadedRoom.Description;
-                RePopulateTreeView();
+                RePopulateTreeView(GetItemNodeID(room));
                 RoomListTypeConverter.RefreshRoomList();
             }
 
@@ -1154,7 +1154,7 @@ namespace AGS.Editor.Components
                 _roomSettings.TreeNodeID = TREE_PREFIX_ROOM_SETTINGS + numberRequested;
 				_guiController.AddOrShowPane(_roomSettings);
 				_agsEditor.CurrentGame.FilesAddedOrRemoved = true;
-				RePopulateTreeView();
+				RePopulateTreeView(GetItemNodeID(oldRoom));
 			}
 		}
 
@@ -1609,6 +1609,11 @@ namespace AGS.Editor.Components
         protected override IList<IRoom> GetFlatList()
         {
             return null;
+        }
+
+        private string GetItemNodeID(UnloadedRoom room)
+        {
+            return TREE_PREFIX_ROOM_NODE + room.Number;
         }
     }
 }

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -137,7 +137,6 @@ namespace AGS.Editor.Components
                 ScriptAndHeader scripts = new ScriptAndHeader(newHeader, newScript);
                 AddSingleItem(scripts);
 				_agsEditor.CurrentGame.FilesAddedOrRemoved = true;
-                RePopulateTreeView(GetNodeID(newScript));
                 _guiController.ProjectTree.BeginLabelEdit(this, ITEM_COMMAND_PREFIX + newScript.NameForLabelEdit);
             }
 			else if (controlID == COMMAND_OPEN_GLOBAL_HEADER)
@@ -238,7 +237,6 @@ namespace AGS.Editor.Components
                 ScriptAndHeader scripts = new ScriptAndHeader(newScripts[0], newScripts[1]);
                 AddSingleItem(scripts);
                 _agsEditor.CurrentGame.FilesAddedOrRemoved = true;
-                RePopulateTreeView(GetNodeID(scripts));
                 foreach (Script script in newScripts)
                     AutoComplete.ConstructCache(script, _agsEditor.GetImportedScriptHeaders(script));
             }

--- a/Editor/AGS.Editor/Components/ViewsComponent.cs
+++ b/Editor/AGS.Editor/Components/ViewsComponent.cs
@@ -191,7 +191,7 @@ namespace AGS.Editor.Components
             if (name_only)
                 ChangeItemLabel(GetNodeID(item), GetNodeLabel(item));
             else
-                RePopulateTreeView(); // currently this is the only way to update tree item ids
+                RePopulateTreeView(GetNodeID(item)); // currently this is the only way to update tree item ids
 
             UpdateOpenWindowTitles();
             ComponentController.Instance.FindComponent<CharactersComponent>()?.UpdateCharacterViews();
@@ -325,8 +325,7 @@ namespace AGS.Editor.Components
 
         protected override ProjectTreeItem CreateTreeItemForItem(View item)
         {
-            string nodeID = GetNodeID(item);
-            ProjectTreeItem treeItem = (ProjectTreeItem)_guiController.ProjectTree.AddTreeLeaf(this, nodeID, item.ID.ToString() + ": " + item.Name, "ViewIcon");
+            ProjectTreeItem treeItem = (ProjectTreeItem)_guiController.ProjectTree.AddTreeLeaf(this, GetNodeID(item), item.ID.ToString() + ": " + item.Name, "ViewIcon");
             treeItem.AllowLabelEdit = true;
             treeItem.LabelTextProperty = item.GetType().GetProperty("Name");
             treeItem.LabelTextDescriptionProperty = item.GetType().GetProperty("NameAndID");

--- a/Editor/AGS.Editor/GUI/ProjectTree.cs
+++ b/Editor/AGS.Editor/GUI/ProjectTree.cs
@@ -59,6 +59,16 @@ namespace AGS.Editor
 		{
             _expandedAtTime = DateTime.Now;
 		}
+
+        public void BeginUpdate()
+        {
+            _projectTree.BeginUpdate();
+        }
+
+        public void EndUpdate()
+        {
+            _projectTree.EndUpdate();
+        }
         
 		public void CollapseAll()
 		{
@@ -208,6 +218,24 @@ namespace AGS.Editor
             {
                 results[0].Expand();
             }
+        }
+
+        /// <summary>
+        /// Returns a list of currently expanded tree nodes.
+        /// </summary>
+        public List<string> GetExpansionState()
+        {
+            return _projectTree.Nodes.GetExpansionState(
+                    (node) => { return node.Name; });
+        }
+
+        /// <summary>
+        /// Applies expanded state to the tree nodes which match given paths.
+        /// </summary>
+        public void SetExpansionState(List<string> state)
+        {
+            _projectTree.Nodes.SetExpansionState(state,
+                (node) => { return state.Contains(node.Name); } );
         }
 
         public void BeginLabelEdit(IEditorComponent plugin, string nodeID)

--- a/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
+++ b/Editor/AGS.Editor/GUI/TreeViewExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+    /// <summary>
+    /// Extender methods for the TreeView control.
+    /// 
+    /// Node state recovery is taken from
+    /// https://stackoverflow.com/a/20081867
+    /// </summary>
+    public static class TreeViewExtensions
+    {
+        public static List<string> GetExpansionState(this TreeNodeCollection nodes)
+        {
+            return nodes.Descendants()
+                        .Where(n => n.IsExpanded)
+                        .Select(n => n.FullPath)
+                        .ToList();
+        }
+
+        public static List<string> GetExpansionState(this TreeNodeCollection nodes, Func<TreeNode, string> selectBy)
+        {
+            return nodes.Descendants()
+                        .Where(n => n.IsExpanded)
+                        .Select(selectBy)
+                        .ToList();
+        }
+
+        public static void SetExpansionState(this TreeNodeCollection nodes, List<string> savedExpansionState)
+        {
+            foreach (var node in nodes.Descendants()
+                                      .Where(n => savedExpansionState.Contains(n.FullPath)))
+            {
+                node.Expand();
+            }
+        }
+
+        public static void SetExpansionState(this TreeNodeCollection nodes, List<string> savedExpansionState,
+            Func<TreeNode, bool> selectBy)
+        {
+            foreach (var node in nodes.Descendants().Where(selectBy))
+            {
+                node.Expand();
+            }
+        }
+
+        public static IEnumerable<TreeNode> Descendants(this TreeNodeCollection c)
+        {
+            foreach (var node in c.OfType<TreeNode>())
+            {
+                yield return node;
+
+                foreach (var child in node.Nodes.Descendants())
+                {
+                    yield return child;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #2105.

Added an ability to keep the expansion state of a project tree inside `RePopulateTreeView()` method.

`RePopulateTreeView` is a part of a IEditorComponent interface, and has 2 variants, where 1st has no args and 2nd accepts a selected item id. I did it so that state-saving is only done in the second variant, because there may be cases where whole tree must be refreshed. This may be reviewed later if necessary.

Also added a pair of BeginUpdate/EndUpdate around tree repopulation, but it does not seem to have much effect (?).

I noticed that there is a number of RePopulateTreeView calls in components, that call the 1st variant without args. I'd check these too and see if some could use the variant with node id in order to keep tree expanded.