### PR TITLE
ScriptAPI: added formatting support to a few text displaying functions

### DIFF
--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -631,6 +631,11 @@ builtin managed struct DrawingSurface {
   import void DrawRectangle(int x1, int y1, int x2, int y2);
   /// Draws the specified text to the surface.
   import void DrawString(int x, int y, FontType, const string text, ...);
+#ifdef SCRIPT_API_v361
+  /// Draws the text to the surface, wrapping it at the specified width.
+  import void DrawStringWrapped(int x, int y, int width, FontType, HorizontalAlignment, const string text, ...);
+#endif
+#ifndef SCRIPT_API_v361
 #ifdef SCRIPT_API_v350
   /// Draws the text to the surface, wrapping it at the specified width.
   import void DrawStringWrapped(int x, int y, int width, FontType, HorizontalAlignment, const string text);
@@ -639,6 +644,7 @@ builtin managed struct DrawingSurface {
   /// Draws the text to the surface, wrapping it at the specified width.
   import void DrawStringWrapped(int x, int y, int width, FontType, Alignment, const string text);
 #endif
+#endif // !SCRIPT_API_v361
   /// Draws a filled triangle onto the surface.
   import void DrawTriangle(int x1, int y1, int x2, int y2, int x3, int y3);
   /// Gets the colour of a single pixel on the surface.
@@ -719,8 +725,14 @@ builtin struct Parser {
 import void Display(const string message, ...);
 /// Displays the text in a standard text window at the specified location.
 import void DisplayAt(int x, int y, int width, const string message, ...);
+#ifdef SCRIPT_API_v361
+/// Displays the text in a standard text window at the specified y-coordinate.
+import void DisplayAtY (int y, const string message, ...);
+#endif
+#ifndef SCRIPT_API_v361
 /// Displays the text in a standard text window at the specified y-coordinate.
 import void DisplayAtY (int y, const string message);
+#endif
 /// Displays a message from the Room Message Editor.
 import void DisplayMessage(int messageNumber);
 /// Displays a message from the Room Message Editor at the specified y-coordinate.
@@ -2582,10 +2594,22 @@ builtin managed struct Character {
   import function RunInteraction(CursorMode);
   /// Says the specified text using the character's speech settings.
   import function Say(const string message, ...);
+#ifdef SCRIPT_API_v361
+  /// Says the specified text at the specified position on the screen using the character's speech settings.
+  import function SayAt(int x, int y, int width, const string message, ...);
+#endif
+#ifndef SCRIPT_API_v361
   /// Says the specified text at the specified position on the screen using the character's speech settings.
   import function SayAt(int x, int y, int width, const string message);
+#endif
+#ifdef SCRIPT_API_v361
+  /// Displays the text as lucasarts-style speech but does not block the game.
+  import Overlay* SayBackground(const string message, ...);
+#endif
+#ifndef SCRIPT_API_v361
   /// Displays the text as lucasarts-style speech but does not block the game.
   import Overlay* SayBackground(const string message);
+#endif
   /// Makes this character the player character.
   import function SetAsPlayer();
   /// Changes the character's idle view.

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3269,19 +3269,20 @@ RuntimeScriptValue Sc_Character_Say(void *self, const RuntimeScriptValue *params
     return RuntimeScriptValue((int32_t)0);
 }
 
-// void (CharacterInfo *chaa, int x, int y, int width, const char *texx)
 RuntimeScriptValue Sc_Character_SayAt(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT3_POBJ(CharacterInfo, Character_SayAt, const char);
+    API_OBJCALL_SCRIPT_SPRINTF(Character_SayAt, 4);
+    Character_SayAt((CharacterInfo*)self, params[0].IValue, params[1].IValue, params[2].IValue, scsf_buffer);
+    return RuntimeScriptValue((int32_t)0);
 }
 
-// ScriptOverlay* (CharacterInfo *chaa, const char *texx)
 RuntimeScriptValue Sc_Character_SayBackground(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_OBJAUTO_POBJ(CharacterInfo, ScriptOverlay, Character_SayBackground, const char);
+    API_OBJCALL_SCRIPT_SPRINTF(Character_SayBackground, 1);
+    auto *ret_obj = Character_SayBackground((CharacterInfo*)self, scsf_buffer);
+    return RuntimeScriptValue().SetScriptObject(ret_obj, ret_obj);
 }
 
-// void (CharacterInfo *chaa)
 RuntimeScriptValue Sc_Character_SetAsPlayer(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
     API_OBJCALL_VOID(CharacterInfo, Character_SetAsPlayer);
@@ -3908,14 +3909,24 @@ RuntimeScriptValue Sc_Character_SetZ(void *self, const RuntimeScriptValue *param
 //
 //=============================================================================
 
-// void (CharacterInfo *chaa, const char *texx, ...)
 void ScPl_Character_Say(CharacterInfo *chaa, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
     Character_Say(chaa, scsf_buffer);
 }
 
-// void (CharacterInfo *chaa, const char *texx, ...)
+void ScPl_Character_SayAt(CharacterInfo *chaa, int x, int y, int width, const char *texx, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
+    Character_SayAt(chaa, x, y, width, scsf_buffer);
+}
+
+ScriptOverlay *ScPl_Character_SayBackground(CharacterInfo *chaa, const char *texx, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
+    return Character_SayBackground(chaa, scsf_buffer);
+}
+
 void ScPl_Character_Think(CharacterInfo *chaa, const char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
@@ -3964,8 +3975,12 @@ void RegisterCharacterAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_a
         { "Character::RemoveTint^0",              API_FN_PAIR(Character_RemoveTint) },
         { "Character::RunInteraction^1",          API_FN_PAIR(Character_RunInteraction) },
         { "Character::Say^101",                   Sc_Character_Say, ScPl_Character_Say },
+        // old non-variadic variants
         { "Character::SayAt^4",                   API_FN_PAIR(Character_SayAt) },
         { "Character::SayBackground^1",           API_FN_PAIR(Character_SayBackground) },
+        // newer variadic variants
+        { "Character::SayAt^104",                 Sc_Character_SayAt, ScPl_Character_SayAt },
+        { "Character::SayBackground^101",         Sc_Character_SayBackground, ScPl_Character_SayBackground },
         { "Character::SetAsPlayer^0",             API_FN_PAIR(Character_SetAsPlayer) },
         { "Character::SetIdleView^2",             API_FN_PAIR(Character_SetIdleView) },
         { "Character::SetLightLevel^1",           API_FN_PAIR(Character_SetLightLevel) },

--- a/Engine/ac/drawingsurface.cpp
+++ b/Engine/ac/drawingsurface.cpp
@@ -516,7 +516,10 @@ RuntimeScriptValue Sc_DrawingSurface_DrawStringWrapped_Old(void *self, const Run
 
 RuntimeScriptValue Sc_DrawingSurface_DrawStringWrapped(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_OBJCALL_VOID_PINT5_POBJ(ScriptDrawingSurface, DrawingSurface_DrawStringWrapped, const char);
+    API_OBJCALL_SCRIPT_SPRINTF(DrawingSurface_DrawString, 6);
+    DrawingSurface_DrawStringWrapped((ScriptDrawingSurface*)self, params[0].IValue, params[1].IValue, params[2].IValue,
+        params[3].IValue, params[4].IValue, scsf_buffer);
+    return RuntimeScriptValue((int32_t)0);
 }
 
 // void (ScriptDrawingSurface* target, ScriptDrawingSurface* source, int translev)
@@ -594,11 +597,16 @@ RuntimeScriptValue Sc_DrawingSurface_GetWidth(void *self, const RuntimeScriptVal
 //
 //=============================================================================
 
-// void (ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
 void ScPl_DrawingSurface_DrawString(ScriptDrawingSurface *sds, int xx, int yy, int font, const char* texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
     DrawingSurface_DrawString(sds, xx, yy, font, scsf_buffer);
+}
+
+void ScPl_DrawingSurface_DrawStringWrapped(ScriptDrawingSurface *sds, int xx, int yy, int wid, int font, int alignment, const char *msg, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF(msg);
+    DrawingSurface_DrawStringWrapped(sds, xx, yy, wid, font, alignment, scsf_buffer);
 }
 
 void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*compat_api*/)
@@ -631,7 +639,12 @@ void RegisterDrawingSurfaceAPI(ScriptAPIVersion base_api, ScriptAPIVersion /*com
 
     // Few functions have to be selected based on API level
     if (base_api < kScriptAPI_v350)
+    {
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", API_FN_PAIR(DrawingSurface_DrawStringWrapped_Old));
+    }
     else
+    { // old non-variadic and new variadic variants
         ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^6", API_FN_PAIR(DrawingSurface_DrawStringWrapped));
+        ccAddExternalObjectFunction("DrawingSurface::DrawStringWrapped^106", Sc_DrawingSurface_DrawStringWrapped, (void*)ScPl_DrawingSurface_DrawStringWrapped);
+    }
 }

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -264,7 +264,9 @@ RuntimeScriptValue Sc_DisplayAt(const RuntimeScriptValue *params, int32_t param_
 // void  (int ypos, char *texx)
 RuntimeScriptValue Sc_DisplayAtY(const RuntimeScriptValue *params, int32_t param_count)
 {
-    API_SCALL_VOID_PINT_POBJ(DisplayAtY, const char);
+    API_SCALL_SCRIPT_SPRINTF(DisplayAtY, 2);
+    DisplayAtY(params[0].IValue, scsf_buffer);
+    return RuntimeScriptValue((int32_t)0);
 }
 
 // void (int msnum)
@@ -2242,18 +2244,22 @@ int ScPl_CreateTextOverlay(int xx, int yy, int wii, int fontid, int clr, char *t
     return CreateTextOverlay(xx, yy, wii, fontid, clr, scsf_buffer, DISPLAYTEXT_NORMALOVERLAY);
 }
 
-// void (char*texx, ...)
 void ScPl_Display(char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
     DisplaySimple(scsf_buffer);
 }
 
-// void (int xxp,int yyp,int widd,char*texx, ...)
 void ScPl_DisplayAt(int xxp, int yyp, int widd, char *texx, ...)
 {
     API_PLUGIN_SCRIPT_SPRINTF(texx);
     DisplayAt(xxp, yyp, widd, scsf_buffer);
+}
+
+void ScPl_DisplayAtY(int ypos, char *texx, ...)
+{
+    API_PLUGIN_SCRIPT_SPRINTF(texx);
+    DisplayAtY(ypos, scsf_buffer);
 }
 
 // void (int chid,char*texx, ...)
@@ -2334,7 +2340,10 @@ void RegisterGlobalAPI()
         { "DisableRegion",            API_FN_PAIR(DisableRegion) },
         { "Display",                  Sc_Display, ScPl_Display },
         { "DisplayAt",                Sc_DisplayAt, ScPl_DisplayAt },
-        { "DisplayAtY",               API_FN_PAIR(DisplayAtY) },
+        // CHECKME: this function was non-variadic prior to 3.6.1, but AGS compiler does
+        // not produce "name^argnum" symbol id for non-member functions for some reason :/
+        // do we have to do anything about this here? like, test vs script API version...
+        { "DisplayAtY",               Sc_DisplayAtY, ScPl_DisplayAtY },
         { "DisplayMessage",           API_FN_PAIR(DisplayMessage) },
         { "DisplayMessageAtY",        API_FN_PAIR(DisplayMessageAtY) },
         { "DisplayMessageBar",        API_FN_PAIR(DisplayMessageBar) },


### PR DESCRIPTION
Users complain regularly about not being able to print variables directly in SayBackground(). I looked around the API, and found there are several functions that display text on screen, but don't support formatting, while their counterparts do. So I turned these functions into variadic with text formatting support.

This refers to:
* DisplayAtY();
* DrawingSurface.DrawStringWrapped();
* Character.SayAt();
* Character.SayBackground();


**Backwards compatibility:**
Old games will always call these functions without extra args. The only problem will occur if the text contains format placeholders. In such case engine's `ScriptSprintf` function prints these placeholders verbatim.