### PR TITLE
Basic support for "#else" preprocessor in AGS script

### DIFF
--- a/Compiler/preproc/preprocessor.h
+++ b/Compiler/preproc/preprocessor.h
@@ -1,3 +1,4 @@
+#include <stack>
 #include "script/cs_parser_common.h"
 #include "script/cc_macrotable.h"
 #include "util/string.h"
@@ -17,6 +18,7 @@ namespace Preprocessor {
         UserDefinedError,
         EndIfWithoutIf,
         IfWithoutEndIf,
+        ElseIfWithoutIf,
         InvalidVersionNumber,
         UnterminatedString
     };
@@ -28,7 +30,7 @@ namespace Preprocessor {
         int _lineNumber;
         String _scriptName;
         Version _applicationVersion;
-        std::vector<bool> _conditionalStatements = std::vector<bool>();
+        std::stack<bool> _conditionalStatements;
 
         static void LogError(ErrorCode error, const String &message = nullptr);
 

--- a/Compiler/test/preprocessor_test.cpp
+++ b/Compiler/test/preprocessor_test.cpp
@@ -303,6 +303,68 @@ Display("This does");
 }
 
 
+TEST(Preprocess, IfDefElse) {
+    Preprocessor pp = Preprocessor();
+    const char* inpl = R"EOS(
+#define FOO
+#ifdef FOO
+Display("This displays!");
+#else
+Display("This doesn't");
+#endif
+#ifndef FOO
+Display("This doesn't");
+#else
+Display("This displays!");
+#endif
+#undef FOO
+#ifdef FOO
+Display("This doesn't");
+#else
+Display("This displays!");
+#endif
+#ifndef FOO
+Display("This displays!");
+#else
+Display("This doesn't");
+#endif
+)EOS";
+
+    clear_error();
+    String res = pp.Preprocess(inpl, "ScriptIfDefElse");
+
+    EXPECT_STREQ(last_seen_cc_error(), "");
+
+    std::vector<AGSString> lines = SplitLines(res);
+    ASSERT_EQ(lines.size(), 25);
+
+    ASSERT_STREQ(lines[0].GetCStr(), "\"__NEWSCRIPTSTART_ScriptIfDefElse\"");
+    ASSERT_STREQ(lines[1].GetCStr(), "");
+    ASSERT_STREQ(lines[2].GetCStr(), "");
+    ASSERT_STREQ(lines[3].GetCStr(), "");
+    ASSERT_STREQ(lines[4].GetCStr(), "Display(\"This displays!\");");
+    ASSERT_STREQ(lines[5].GetCStr(), "");
+    ASSERT_STREQ(lines[6].GetCStr(), "");
+    ASSERT_STREQ(lines[7].GetCStr(), "");
+    ASSERT_STREQ(lines[8].GetCStr(), "");
+    ASSERT_STREQ(lines[9].GetCStr(), "");
+    ASSERT_STREQ(lines[10].GetCStr(), "");
+    ASSERT_STREQ(lines[11].GetCStr(), "Display(\"This displays!\");");
+    ASSERT_STREQ(lines[12].GetCStr(), "");
+    ASSERT_STREQ(lines[13].GetCStr(), "");
+    ASSERT_STREQ(lines[14].GetCStr(), "");
+    ASSERT_STREQ(lines[15].GetCStr(), "");
+    ASSERT_STREQ(lines[16].GetCStr(), "");
+    ASSERT_STREQ(lines[17].GetCStr(), "Display(\"This displays!\");");
+    ASSERT_STREQ(lines[18].GetCStr(), "");
+    ASSERT_STREQ(lines[19].GetCStr(), "");
+    ASSERT_STREQ(lines[20].GetCStr(), "Display(\"This displays!\");");
+    ASSERT_STREQ(lines[21].GetCStr(), "");
+    ASSERT_STREQ(lines[22].GetCStr(), "");
+    ASSERT_STREQ(lines[23].GetCStr(), "");
+}
+
+
 TEST(Preprocess, IfVer) {
     Preprocessor pp = Preprocessor();
     pp.SetAppVersion("3.6.0.5");
@@ -388,6 +450,21 @@ Display("test");
     String res = pp.Preprocess(inpl, "EndIfWithoutIf");
 
     EXPECT_STREQ(last_seen_cc_error(), "#endif has no matching #if");
+}
+
+TEST(Preprocess, ElseWithoutIf) {
+    Preprocessor pp = Preprocessor();
+    const char* inpl = R"EOS(
+#ifdef BAR
+#endif
+Display("test");
+#else
+)EOS";
+
+    clear_error();
+    String res = pp.Preprocess(inpl, "ElseWithoutIf");
+
+    EXPECT_STREQ(last_seen_cc_error(), "#else has no matching #if");
 }
 
 

--- a/Editor/AGS.CScript.Compiler/Entities/ErrorCode.cs
+++ b/Editor/AGS.CScript.Compiler/Entities/ErrorCode.cs
@@ -15,6 +15,7 @@ namespace AGS.CScript.Compiler
 		UserDefinedError,
 		EndIfWithoutIf,
 		IfWithoutEndIf,
+		ElseWithoutIf,
 		InvalidVersionNumber,
 		UnexpectedToken = 100,
 		InvalidUseOfKeyword,

--- a/Editor/AGS.CScript.Compiler/Preprocessor.cs
+++ b/Editor/AGS.CScript.Compiler/Preprocessor.cs
@@ -239,6 +239,18 @@ namespace AGS.CScript.Compiler
 			{
 				ProcessConditionalDirective(directive, line, _results);
 			}
+			else if (directive == "else")
+			{
+				if (_conditionalStatements.Count > 0)
+				{
+					// Negate previous condition
+					_conditionalStatements.Push(!_conditionalStatements.Pop());
+				}
+				else
+				{
+					RecordError(ErrorCode.ElseWithoutIf, "#else has no matching #if");
+				}
+			}
 			else if (directive == "endif")
 			{
 				if (_conditionalStatements.Count > 0)

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -446,6 +446,20 @@ namespace AGS.Editor
                     state.InsideIfDefBlock = macroName;
                 }
             }
+            else if (preProcessorDirective == "else")
+            {
+                // Negate previous condition
+                if (state.InsideIfDefBlock != null)
+                {
+                    state.InsideIfNDefBlock = state.InsideIfDefBlock;
+                    state.InsideIfDefBlock = null;
+                }
+                else if (state.InsideIfNDefBlock != null)
+                {
+                    state.InsideIfDefBlock = state.InsideIfNDefBlock;
+                    state.InsideIfNDefBlock = null;
+                }
+            }
             else if (preProcessorDirective == "endif")
             {
                 state.InsideIfNDefBlock = null;


### PR DESCRIPTION
I could not find if there was there a ticket for this, maybe I had a false memory about it.

In any case, I got weary of not being able to have ```#ifdef N #else #endif``` kind of construct, and tried to implement basic support  for "#else".

This is a *most trivial and naive* implementation, because it assumes only ifdef/else/endif combination. This won't work with "else if", but these are not supported by AGS preprocessor at the moment.

Added to:
* Editor's preprocessor (C# one);
* Editor's Autocomplete. Although autocomplete seems to break often when preprocessor definitions are around, but that might be a separate issue. At least it seems to work when the `#if/else/endif` are on top of the script (outside of function).
* C++ preprocessor, to sync with the embedded C# one.

If this proves to be working, and merged, then we could also tidy builtin header where declarations depend on SCRIPT_API macros.

PS. I still think we should get a proper complete preprocessor into AGS from somewhere else at some point.