### PR TITLE
New compiler: Accept & skip '()' after 'new'

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -1908,7 +1908,7 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
     ParseExpression_CheckArgOfNew(argument_vartype);
     
     bool const is_managed = _sym.IsManagedVartype(argument_vartype);
-    bool const with_bracket_expr = !expression.ReachedEOF(); // "new FOO[BAR]"
+    bool const with_bracket_expr = kKW_OpenBracket == expression.PeekNext(); // "new FOO[BAR]"
 
     Vartype element_vartype = kKW_NoSymbol;
     if (with_bracket_expr)
@@ -1936,6 +1936,14 @@ void AGS::Parser::ParseExpression_New(SrcList &expression, EvaluationResult &ere
             UserError("Expected '[' after the built-in type '%s'", _sym.GetName(argument_vartype).c_str());
         if (!is_managed)
             UserError("Expected '[' after the integer type '%s'", _sym.GetName(argument_vartype).c_str());
+
+        if (kKW_OpenParenthesis == expression.PeekNext())
+        {
+            Warning("'()' after 'new' isn't implemented, is currently ignored");
+            expression.GetNext();
+            SkipTo(SymbolList{}, expression);
+            expression.GetNext();
+        }
 
         // Only do this check for new, not for new[]. 
         if (0 == _sym.GetSize(argument_vartype))

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2620,3 +2620,26 @@ TEST_F(Compile1, ReportMissingFunction) {
     EXPECT_NE(std::string::npos, msg.find("pNZaFLjz3ajd"));
 }
 
+TEST_F(Compile1, ParensAfterNew) {
+
+    // Function is called, but not defined with body or external
+    // This should be flagged naming the function
+
+    char const *inpl = "\
+        managed struct Struct       \n\
+        {                           \n\
+            int Payload;            \n\
+        };                          \n\
+                                    \n\
+        int game_start()            \n\
+        {                           \n\
+            Struct *s = new Struct();   \n\
+        }                           \n\
+        ";
+
+
+    AGS::MessageHandler mh;
+    int compileResult = cc_compile(inpl, 0u, scrip, mh);
+    ASSERT_STREQ("Ok", (compileResult >= 0) ? "Ok" : mh.GetError().Message.c_str());
+    ASSERT_EQ(1u, mh.GetMessages().size());
+}


### PR DESCRIPTION
This is a preliminary fix for #2174.

Accept expressions such as `new S()` where a parameter list follows the type. The parameter list is ignored. A warning is issued.