### PR TITLE
Made ScriptString store length in data header, use to speed up API functions somewhat

### DIFF
--- a/Engine/ac/audioclip.cpp
+++ b/Engine/ac/audioclip.cpp
@@ -104,8 +104,6 @@ ScriptAudioChannel* AudioClip_PlayOnChannel(ScriptAudioClip *clip, int chan, int
 #include "script/script_api.h"
 #include "script/script_runtime.h"
 
-extern ScriptString myScriptStringImpl;
-
 ScriptAudioClip *AudioClip_GetByName(const char *name)
 {
     return static_cast<ScriptAudioClip*>(ccGetScriptObjectAddress(name, ccDynamicAudioClip.GetType()));

--- a/Engine/ac/button.cpp
+++ b/Engine/ac/button.cpp
@@ -320,8 +320,6 @@ void Button_SetTextAlignment(GUIButton *butt, int align)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // void | GUIButton *butt, int view, int loop, int speed, int repeat
 RuntimeScriptValue Sc_Button_Animate4(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -3030,8 +3030,6 @@ PViewport FindNearestViewport(int charid)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 CharacterInfo *Character_GetByName(const char *name)
 {
     return static_cast<CharacterInfo*>(ccGetScriptObjectAddress(name, ccDynamicCharacter.GetType()));

--- a/Engine/ac/dialog.cpp
+++ b/Engine/ac/dialog.cpp
@@ -1330,7 +1330,6 @@ void do_conversation(int dlgnum)
 #include "ac/dynobj/cc_dialog.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
 extern CCDialog     ccDynamicDialog;
 
 ScriptDialog *Dialog_GetByName(const char *name)

--- a/Engine/ac/dynobj/cc_dynamicarray.cpp
+++ b/Engine/ac/dynobj/cc_dynamicarray.cpp
@@ -14,7 +14,7 @@
 #include "cc_dynamicarray.h"
 #include <string.h>
 #include "ac/dynobj/dynobj_manager.h"
-#include "util/memorystream.h"
+#include "ac/dynobj/scriptstring.h"
 
 using namespace AGS::Common;
 
@@ -58,7 +58,7 @@ size_t CCDynamicArray::CalcSerializeSize(const void *address)
     return hdr.TotalSize + FileHeaderSz;
 }
 
-void CCDynamicArray::Serialize(const void *address, AGS::Common::Stream *out)
+void CCDynamicArray::Serialize(const void *address, Stream *out)
 {
     const Header &hdr = GetHeader(address);
     out->WriteInt32(hdr.ElemCount);
@@ -107,7 +107,7 @@ DynObjectRef DynamicArrayHelpers::CreateStringArray(const std::vector<const char
     int32_t *slots = static_cast<int32_t*>(arr.Obj);
     for (auto s : items)
     {
-        DynObjectRef str = stringClassImpl->CreateString(s);
+        DynObjectRef str = ScriptString::Create(s);
         // We must add reference count, because the string is going to be saved
         // within another object (array), not returned to script directly
         ccAddObjectReference(str.Handle);

--- a/Engine/ac/dynobj/cc_scriptobject.h
+++ b/Engine/ac/dynobj/cc_scriptobject.h
@@ -105,10 +105,4 @@ struct ICCObjectReader
     virtual void Unserialize(int32_t handle, const char *serializedData, int dataSize) = 0;
 };
 
-// The interface of a dynamic String allocator.
-struct ICCStringClass
-{
-    virtual DynObjectRef CreateString(const char *fromText) = 0;
-};
-
 #endif // __CC_SCRIPTOBJECT_H

--- a/Engine/ac/dynobj/cc_scriptobject.h
+++ b/Engine/ac/dynobj/cc_scriptobject.h
@@ -38,6 +38,7 @@ struct DynObjectRef
     DynObjectRef() = default;
     DynObjectRef(int handle, void *obj, IScriptObject *mgr)
         : Handle(handle), Obj(obj), Mgr(mgr) {}
+    inline operator bool() const { return Handle > 0; }
 };
 
 

--- a/Engine/ac/dynobj/cc_serializer.cpp
+++ b/Engine/ac/dynobj/cc_serializer.cpp
@@ -98,8 +98,7 @@ void AGSDeSerializer::Unserialize(int index, const char *objectType, const char 
         ccDynamicObject.Unserialize(index, &mems, data_sz);
     }
     else if (strcmp(objectType, "String") == 0) {
-        ScriptString *scf = new ScriptString();
-        scf->Unserialize(index, &mems, data_sz);
+        myScriptStringImpl.Unserialize(index, &mems, data_sz);
     }
     else if (strcmp(objectType, "File") == 0) {
         // files cannot be restored properly -- so just recreate

--- a/Engine/ac/dynobj/dynobj_manager.cpp
+++ b/Engine/ac/dynobj/dynobj_manager.cpp
@@ -21,13 +21,6 @@
 
 using namespace AGS::Common;
 
-ICCStringClass *stringClassImpl = nullptr;
-
-// set the class that will be used for dynamic strings
-void ccSetStringClassImpl(ICCStringClass *theClass) {
-    stringClassImpl = theClass;
-}
-
 // register a memory handle for the object and allow script
 // pointers to point to it
 int32_t ccRegisterManagedObject(void *object, IScriptObject *callback, ScriptValueType obj_type) {

--- a/Engine/ac/dynobj/dynobj_manager.h
+++ b/Engine/ac/dynobj/dynobj_manager.h
@@ -28,8 +28,6 @@
 namespace AGS { namespace Common { class Stream; } }
 using namespace AGS; // FIXME later
 
-// set the class that will be used for dynamic strings
-extern void  ccSetStringClassImpl(ICCStringClass *theClass);
 // register a memory handle for the object and allow script
 // pointers to point to it
 extern int32_t ccRegisterManagedObject(void *object, IScriptObject *, ScriptValueType obj_type = kScValScriptObject);
@@ -52,7 +50,5 @@ extern ScriptValueType ccGetObjectAddressAndManagerFromHandle(int32_t handle, vo
 
 extern int ccAddObjectReference(int32_t handle);
 extern int ccReleaseObjectReference(int32_t handle);
-
-extern ICCStringClass *stringClassImpl;
 
 #endif // __AGS_EE_DYNOBJ__DYNOBJMANAGER_H

--- a/Engine/ac/dynobj/scriptstring.cpp
+++ b/Engine/ac/dynobj/scriptstring.cpp
@@ -79,6 +79,8 @@ ScriptString::Buffer ScriptString::CreateBuffer(size_t len, size_t ulen)
     auto *header = reinterpret_cast<Header*>(buf.get());
     header->Length = len;
     header->ULength = ulen;
+    header->LastCharIdx = 0;
+    header->LastCharOff = 0;
     return Buffer(std::move(buf), len + 1 + MemHeaderSz);
 }
 

--- a/Engine/ac/dynobj/scriptstring.h
+++ b/Engine/ac/dynobj/scriptstring.h
@@ -23,7 +23,13 @@ public:
     struct Header
     {
         uint32_t Length = 0u;  // string length in bytes (not counting 0)
-        uint32_t ULength = 0u; // UTF-8 compatible length in characters
+        uint32_t ULength = 0u; // Unicode compatible length in characters
+        // Saved last requested character index and buffer offset;
+        // significantly speeds up Unicode string iteration, but adds 4 bytes
+        // per ScriptString object. Replace with a proper str iterator later!
+        // NOTE: intentionally limited to 64k chars/bytes to save bit of mem.
+        uint16_t LastCharIdx = 0u;
+        uint16_t LastCharOff = 0u;
     };
 
     struct Buffer
@@ -53,6 +59,11 @@ public:
     inline static const Header &GetHeader(const void *address)
     {
         return reinterpret_cast<const Header&>(*(static_cast<const uint8_t*>(address) - MemHeaderSz));
+    }
+
+    inline static Header &GetHeader(void *address)
+    {
+        return reinterpret_cast<Header&>(*(static_cast<uint8_t*>(address) - MemHeaderSz));
     }
 
     // Allocates a ScriptString-compatible buffer large enough to accomodate

--- a/Engine/ac/dynobj/scriptstring.h
+++ b/Engine/ac/dynobj/scriptstring.h
@@ -16,29 +16,46 @@
 
 #include "ac/dynobj/cc_agsdynamicobject.h"
 
-struct ScriptString final : AGSCCDynamicObject, ICCStringClass {
-    int Dispose(void *address, bool force) override;
-    const char *GetType() override;
-    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
-
-    DynObjectRef CreateString(const char *fromText) override;
+struct ScriptString final : AGSCCDynamicObject
+{
+public:
+    struct Header
+    {
+        uint32_t Length = 0u;
+    };
 
     ScriptString() = default;
-    ScriptString(const char *text);
-    ScriptString(char *text, bool take_ownership);
-    char *GetTextPtr() const { return _text; }
+    ~ScriptString() = default;
 
-protected:
+    inline static const Header &GetHeader(const void *address)
+    {
+        return reinterpret_cast<const Header&>(*(static_cast<const uint8_t*>(address) - MemHeaderSz));
+    }
+
+    // Create a new script string by copying the given text
+    static DynObjectRef Create(const char *text) { return CreateImpl(text, -1); }
+    // Create a new script string with a buffer of at least the given text length
+    static DynObjectRef Create(size_t buf_len)  { return CreateImpl(nullptr, buf_len); }
+
+    const char *GetType() override;
+    int Dispose(void *address, bool force) override;
+    void Unserialize(int index, AGS::Common::Stream *in, size_t data_sz) override;
+
+private:
+    // The size of the array's header in memory, prepended to the element data
+    static const size_t MemHeaderSz = sizeof(Header);
+    // The size of the serialized header
+    static const size_t FileHeaderSz = sizeof(uint32_t);
+
+    static DynObjectRef CreateImpl(const char *text, size_t buf_len);
+
+    // Savegame serialization
     // Calculate and return required space for serialization, in bytes
     size_t CalcSerializeSize(const void *address) override;
     // Write object data into the provided stream
     void Serialize(const void *address, AGS::Common::Stream *out) override;
-
-private:
-    // TODO: the preallocated text buffer may be assigned externally;
-    // find out if it's possible to refactor while keeping same functionality
-    char *_text = nullptr;
-    size_t _len = 0;
 };
+
+extern ScriptString myScriptStringImpl;
 
 #endif // __AC_SCRIPTSTRING_H

--- a/Engine/ac/dynobj/scriptstring.h
+++ b/Engine/ac/dynobj/scriptstring.h
@@ -22,7 +22,8 @@ struct ScriptString final : AGSCCDynamicObject
 public:
     struct Header
     {
-        uint32_t Length = 0u;
+        uint32_t Length = 0u;  // string length in bytes (not counting 0)
+        uint32_t ULength = 0u; // UTF-8 compatible length in characters
     };
 
     struct Buffer
@@ -32,8 +33,10 @@ public:
         Buffer() = default;
         ~Buffer() = default;
         Buffer(Buffer &&buf) = default;
-        char *Get() { return reinterpret_cast<char*>(_buf.get() - MemHeaderSz); }
-        size_t GetSize() const { return _sz; }
+        // Returns a pointer to the beginning of a text buffer
+        char *Get() { return reinterpret_cast<char*>(_buf.get() + MemHeaderSz); }
+        // Returns size allocated for a text content (includes null pointer)
+        size_t GetSize() const { return _sz - MemHeaderSz; }
 
     private:
         Buffer(std::unique_ptr<uint8_t[]> &&buf, size_t buf_sz)
@@ -70,7 +73,7 @@ private:
     // The size of the serialized header
     static const size_t FileHeaderSz = sizeof(uint32_t);
 
-    static DynObjectRef CreateObject(uint8_t *buf);
+    static DynObjectRef CreateObject(uint8_t *buf, size_t len, size_t ulen);
 
     // Savegame serialization
     // Calculate and return required space for serialization, in bytes

--- a/Engine/ac/dynobj/scriptstring.h
+++ b/Engine/ac/dynobj/scriptstring.h
@@ -55,11 +55,15 @@ public:
         return reinterpret_cast<const Header&>(*(static_cast<const uint8_t*>(address) - MemHeaderSz));
     }
 
-    // 
-    static Buffer CreateBuffer(size_t data_sz);
+    // Allocates a ScriptString-compatible buffer large enough to accomodate
+    // given length in bytes (len). This buffer may be filled by the caller
+    // and then passed into Create(). If ulen is left eq 0, then it will be
+    // recalculated on script string's creation.
+    static Buffer CreateBuffer(size_t len, size_t ulen = 0u);
     // Create a new script string by copying the given text
     static DynObjectRef Create(const char *text);
-    //
+    // Create a new script string by taking ownership over the given buffer;
+    // passed buffer variable becomes invalid after this call.
     static DynObjectRef Create(Buffer &&strbuf);
 
     const char *GetType() override;
@@ -73,7 +77,7 @@ private:
     // The size of the serialized header
     static const size_t FileHeaderSz = sizeof(uint32_t);
 
-    static DynObjectRef CreateObject(uint8_t *buf, size_t len, size_t ulen);
+    static DynObjectRef CreateObject(uint8_t *buf);
 
     // Savegame serialization
     // Calculate and return required space for serialization, in bytes

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -166,16 +166,16 @@ const char* File_ReadStringBack(sc_File *fil) {
     return CreateNewScriptString("");
   }
 
-  size_t lle = (uint32_t)in->ReadInt32();
-  if (lle == 0)
+  size_t data_sz = (uint32_t)in->ReadInt32();
+  if (data_sz == 0)
   {
     debug_script_warn("File.ReadStringBack: file was not written by WriteString");
     return CreateNewScriptString("");;
   }
 
-  char *buffer = CreateNewScriptString(lle);
-  in->Read(buffer, lle);
-  return buffer;
+  auto buf = ScriptString::CreateBuffer(data_sz); // stored len + 1
+  in->Read(buf.Get(), data_sz);
+  return CreateNewScriptString(std::move(buf));
 }
 
 int File_ReadInt(sc_File *fil) {

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -173,7 +173,7 @@ const char* File_ReadStringBack(sc_File *fil) {
     return CreateNewScriptString("");;
   }
 
-  auto buf = ScriptString::CreateBuffer(data_sz); // stored len + 1
+  auto buf = ScriptString::CreateBuffer(data_sz - 1); // stored len + 1
   in->Read(buf.Get(), data_sz);
   return CreateNewScriptString(std::move(buf));
 }

--- a/Engine/ac/file.cpp
+++ b/Engine/ac/file.cpp
@@ -173,10 +173,9 @@ const char* File_ReadStringBack(sc_File *fil) {
     return CreateNewScriptString("");;
   }
 
-  char *retVal = (char*)malloc(lle);
-  in->Read(retVal, lle);
-
-  return CreateNewScriptString(retVal, false);
+  char *buffer = CreateNewScriptString(lle);
+  in->Read(buffer, lle);
+  return buffer;
 }
 
 int File_ReadInt(sc_File *fil) {
@@ -726,7 +725,6 @@ Stream *get_valid_file_stream_from_handle(int32_t handle, const char *operation_
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
 
 // int (const char *fnmm)
 RuntimeScriptValue Sc_File_Delete(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/game.cpp
+++ b/Engine/ac/game.cpp
@@ -128,7 +128,6 @@ CCObject    ccDynamicObject;
 CCDialog    ccDynamicDialog;
 CCAudioClip ccDynamicAudioClip;
 CCAudioChannel ccDynamicAudio;
-ScriptString myScriptStringImpl;
 ScriptObject scrObj[MAX_ROOM_OBJECTS];
 std::vector<ScriptGUI> scrGui;
 ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -70,7 +70,6 @@
 #include "media/audio/audio_system.h"
 
 #include "ac/dynobj/scriptstring.h"
-extern ScriptString myScriptStringImpl;
 
 // void (char*texx, ...)
 RuntimeScriptValue Sc_sc_AbortGame(const RuntimeScriptValue *params, int32_t param_count)

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -668,8 +668,6 @@ void gui_on_mouse_down(const int guin, const int mbut)
 #include "script/script_runtime.h"
 
 
-extern ScriptString myScriptStringImpl;
-
 ScriptGUI *GUI_GetByName(const char *name)
 {
     return static_cast<ScriptGUI*>(ccGetScriptObjectAddress(name, ccDynamicGUI.GetType()));

--- a/Engine/ac/guicontrol.cpp
+++ b/Engine/ac/guicontrol.cpp
@@ -232,8 +232,6 @@ void GUIControl_SetTransparency(GUIObject *guio, int trans) {
 #include "script/script_runtime.h"
 
 
-extern ScriptString myScriptStringImpl;
-
 GUIObject *GUIControl_GetByName(const char *name)
 {
     return static_cast<GUIObject*>(ccGetScriptObjectAddress(name, ccDynamicGUIObject.GetType()));

--- a/Engine/ac/hotspot.cpp
+++ b/Engine/ac/hotspot.cpp
@@ -143,8 +143,6 @@ int get_hotspot_at(int xpp,int ypp) {
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 
 ScriptHotspot *Hotspot_GetByName(const char *name)
 {

--- a/Engine/ac/inventoryitem.cpp
+++ b/Engine/ac/inventoryitem.cpp
@@ -133,8 +133,6 @@ void set_inv_item_cursorpic(int invItemId, int piccy)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 
 ScriptInvItem *InventoryItem_GetByName(const char *name)
 {

--- a/Engine/ac/label.cpp
+++ b/Engine/ac/label.cpp
@@ -99,8 +99,6 @@ void Label_SetFont(GUILabel *guil, int fontnum) {
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // void (GUILabel *labl, char *buffer)
 RuntimeScriptValue Sc_Label_GetText(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/listbox.cpp
+++ b/Engine/ac/listbox.cpp
@@ -352,8 +352,6 @@ GUIListBox* is_valid_listbox (int guin, int objn) {
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // int (GUIListBox *lbb, const char *text)
 RuntimeScriptValue Sc_ListBox_AddItem(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/object.cpp
+++ b/Engine/ac/object.cpp
@@ -781,8 +781,6 @@ bool CycleViewAnim(int view, uint16_t &o_loop, uint16_t &o_frame, bool forwards,
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 
 ScriptObject *Object_GetByName(const char *name)
 {

--- a/Engine/ac/parser.cpp
+++ b/Engine/ac/parser.cpp
@@ -302,8 +302,6 @@ int parse_sentence (const char *src_text, int *numwords, short*wordarray, short*
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // int (const char *wordToFind)
 RuntimeScriptValue Sc_Parser_FindWordID(const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/properties.cpp
+++ b/Engine/ac/properties.cpp
@@ -23,7 +23,6 @@
 using namespace AGS::Common;
 
 extern GameSetupStruct game;
-extern ScriptString myScriptStringImpl;
 
 // begin custom property functions
 

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -1105,8 +1105,6 @@ void convert_move_path_to_room_resolution(MoveList *ml)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // ScriptDrawingSurface* (int backgroundNumber)
 RuntimeScriptValue Sc_Room_GetDrawingSurfaceForBackground(const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/scriptcontainers.cpp
+++ b/Engine/ac/scriptcontainers.cpp
@@ -27,8 +27,6 @@
 #include "script/script_runtime.h"
 #include "util/bbop.h"
 
-extern ScriptString myScriptStringImpl;
-
 //=============================================================================
 //
 // Dictionary of strings script API.

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -32,7 +32,17 @@ using namespace AGS::Common;
 extern GameSetupStruct game;
 extern GameState play;
 extern int longestline;
-extern ScriptString myScriptStringImpl;
+
+const char *CreateNewScriptString(const char *text)
+{
+    return (const char*)ScriptString::Create(text).Obj;
+}
+
+char *CreateNewScriptString(size_t buf_length)
+{
+    return (char*)ScriptString::Create(buf_length).Obj;
+}
+
 
 int String_IsNullOrEmpty(const char *thisString) 
 {
@@ -47,18 +57,20 @@ const char* String_Copy(const char *srcString) {
 }
 
 const char* String_Append(const char *thisString, const char *extrabit) {
-    char *buffer = (char*)malloc(strlen(thisString) + strlen(extrabit) + 1);
+    size_t new_len = strlen(thisString) + strlen(extrabit);
+    char *buffer = CreateNewScriptString(new_len);
     strcpy(buffer, thisString);
     strcat(buffer, extrabit);
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 const char* String_AppendChar(const char *thisString, int extraOne) {
     char chr[5]{};
     size_t chw = usetc(chr, extraOne);
-    char *buffer = (char*)malloc(strlen(thisString) + chw + 1);
+    size_t new_len = strlen(thisString) + chw;
+    char *buffer = CreateNewScriptString(new_len);
     sprintf(buffer, "%s%s", thisString, chr);
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 const char* String_ReplaceCharAt(const char *thisString, int index, int newChar) {
@@ -72,12 +84,12 @@ const char* String_ReplaceCharAt(const char *thisString, int index, int newChar)
     size_t old_sz = ucwidth(uchar);
     char new_chr[5]{};
     size_t new_chw = usetc(new_chr, newChar);
-    size_t total_sz = off + remain_sz + new_chw - old_sz + 1;
-    char *buffer = (char*)malloc(total_sz);
+    size_t new_len = off + remain_sz + new_chw - old_sz;
+    char *buffer = CreateNewScriptString(new_len);
     memcpy(buffer, thisString, off);
     memcpy(buffer + off, new_chr, new_chw);
     memcpy(buffer + off + new_chw, thisString + off + old_sz, remain_sz - old_sz + 1);
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 const char* String_Truncate(const char *thisString, int length) {
@@ -88,10 +100,10 @@ const char* String_Truncate(const char *thisString, int length) {
         return thisString;
 
     size_t sz = uoffset(thisString, length);
-    char *buffer = (char*)malloc(sz + 1);
+    char *buffer = CreateNewScriptString(sz);
     memcpy(buffer, thisString, sz);
     buffer[sz] = 0;
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 const char* String_Substring(const char *thisString, int index, int length) {
@@ -105,10 +117,10 @@ const char* String_Substring(const char *thisString, int index, int length) {
     size_t end = uoffset(thisString + start, sublen) + start;
     size_t copysz = end - start;
 
-    char *buffer = (char*)malloc(copysz + 1);
+    char *buffer = CreateNewScriptString(copysz);
     memcpy(buffer, thisString + start, copysz);
     buffer[copysz] = 0;
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 int String_CompareTo(const char *thisString, const char *otherString, bool caseSensitive) {
@@ -193,19 +205,23 @@ const char* String_Replace(const char *thisString, const char *lookForText, cons
     }
 
     resultBuffer[outputSize] = 0; // terminate
-    return CreateNewScriptString(resultBuffer, true);
+    return CreateNewScriptString(resultBuffer);
 }
 
 const char* String_LowerCase(const char *thisString) {
-    char *buffer = ags_strdup(thisString);
+    size_t len = strlen(thisString);
+    char *buffer = CreateNewScriptString(len);
+    memcpy(buffer, thisString, len);
     ustrlwr(buffer);
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 const char* String_UpperCase(const char *thisString) {
-    char *buffer = ags_strdup(thisString);
+    size_t len = strlen(thisString);
+    char *buffer = CreateNewScriptString(len);
+    memcpy(buffer, thisString, len);
     ustrupr(buffer);
-    return CreateNewScriptString(buffer, false);
+    return buffer;
 }
 
 int String_GetChars(const char *texx, int index) {
@@ -243,37 +259,6 @@ int StrContains (const char *s1, const char *s2) {
 }
 
 //=============================================================================
-
-const char *CreateNewScriptString(const String &fromText) {
-    return (const char*)CreateNewScriptStringObj(fromText.GetCStr(), true).Obj;
-}
-
-const char *CreateNewScriptString(const char *fromText, bool reAllocate) {
-    return (const char*)CreateNewScriptStringObj(fromText, reAllocate).Obj;
-}
-
-DynObjectRef CreateNewScriptStringObj(const String &fromText) {
-    return CreateNewScriptStringObj(fromText.GetCStr(), true);
-}
-
-DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate)
-{
-    ScriptString *str;
-    if (reAllocate) {
-        str = new ScriptString(fromText);
-    }
-    else { // TODO: refactor to avoid const casts!
-        str = new ScriptString((char*)fromText, true);
-    }
-    void *obj_ptr = str->GetTextPtr();
-    int32_t handle = ccRegisterManagedObject(obj_ptr, str);
-    if (handle == 0)
-    {
-        delete str;
-        return DynObjectRef();
-    }
-    return DynObjectRef(handle, obj_ptr, str);
-}
 
 size_t break_up_text_into_lines(const char *todis, bool apply_direction, SplitLines &lines, int wii, int fonnt, size_t max_lines) {
     if (fonnt == -1)

--- a/Engine/ac/string.cpp
+++ b/Engine/ac/string.cpp
@@ -227,9 +227,20 @@ int String_GetChars(const char *thisString, int index) {
     auto &header = ScriptString::GetHeader((void*)thisString);
     if ((index < 0) || (static_cast<uint32_t>(index) >= header.ULength))
         return 0;
-    int off = (header.LastCharIdx <= index) ?
-        (uoffset(thisString + header.LastCharOff, index - header.LastCharIdx) + header.LastCharOff) :
-         uoffset(thisString, index);
+    int off;
+    if (get_uformat() == U_ASCII)
+    {
+        return thisString[index];
+    }
+    else if (header.LastCharIdx <= index)
+    {
+        off = uoffset(thisString + header.LastCharOff, index - header.LastCharIdx) + header.LastCharOff;
+    }
+    // TODO: support faster reverse iteration too? that would require reverse-dir uoffset
+    else
+    {
+        off = uoffset(thisString, index);
+    }
     // NOTE: works up to 64k chars/bytes, then stops; this is intentional to save a bit of mem
     if (off <= UINT16_MAX)
     {

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -30,6 +30,10 @@ inline void VALIDATE_STRING(const char *strin)
         quit("!String argument was null: make sure you pass a valid string as a buffer.");
 }
 
+const char* CreateNewScriptString(const char *text);
+inline const char* CreateNewScriptString(const AGS::Common::String &text) { return CreateNewScriptString(text.GetCStr()); }
+char* CreateNewScriptString(size_t buf_len); // FIXME, unsafe to expose raw buf like this
+
 int String_IsNullOrEmpty(const char *thisString);
 const char* String_Copy(const char *srcString);
 const char* String_Append(const char *thisString, const char *extrabit);
@@ -49,10 +53,6 @@ int StrContains (const char *s1, const char *s2);
 
 //=============================================================================
 
-const char* CreateNewScriptString(const AGS::Common::String &fromText);
-const char* CreateNewScriptString(const char *fromText, bool reAllocate = true);
-DynObjectRef CreateNewScriptStringObj(const AGS::Common::String &fromText);
-DynObjectRef CreateNewScriptStringObj(const char *fromText, bool reAllocate = true);
 class SplitLines;
 // Break up the text into lines restricted by the given width;
 // returns number of lines, or 0 if text cannot be split well to fit in this width.

--- a/Engine/ac/string.h
+++ b/Engine/ac/string.h
@@ -12,7 +12,7 @@
 //
 //=============================================================================
 //
-//
+// Script String API implementation.
 //
 //=============================================================================
 #ifndef __AGS_EE_AC__STRING_H
@@ -20,7 +20,7 @@
 
 #include <stdarg.h>
 #include "ac/common.h" // quit
-#include "ac/dynobj/cc_scriptobject.h"
+#include "ac/dynobj/scriptstring.h"
 #include "util/string.h"
 
 // Check that a supplied buffer from a text script function was not null
@@ -30,9 +30,11 @@ inline void VALIDATE_STRING(const char *strin)
         quit("!String argument was null: make sure you pass a valid string as a buffer.");
 }
 
-const char* CreateNewScriptString(const char *text);
-inline const char* CreateNewScriptString(const AGS::Common::String &text) { return CreateNewScriptString(text.GetCStr()); }
-char* CreateNewScriptString(size_t buf_len); // FIXME, unsafe to expose raw buf like this
+const char *CreateNewScriptString(const char *text);
+inline const char *CreateNewScriptString(const AGS::Common::String &text)
+    { return CreateNewScriptString(text.GetCStr()); }
+inline const char *CreateNewScriptString(ScriptString::Buffer &&buf)
+    { return static_cast<const char*>(ScriptString::Create(std::move(buf)).Obj); }
 
 int String_IsNullOrEmpty(const char *thisString);
 const char* String_Copy(const char *srcString);

--- a/Engine/ac/system.cpp
+++ b/Engine/ac/system.cpp
@@ -228,8 +228,6 @@ void System_SetRenderAtScreenResolution(int enable)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // int ()
 RuntimeScriptValue Sc_System_GetAudioChannelCount(const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/ac/textbox.cpp
+++ b/Engine/ac/textbox.cpp
@@ -89,8 +89,6 @@ void TextBox_SetShowBorder(GUITextBox *guit, bool on)
 #include "script/script_runtime.h"
 #include "ac/dynobj/scriptstring.h"
 
-extern ScriptString myScriptStringImpl;
-
 // void (GUITextBox *texbox, char *buffer)
 RuntimeScriptValue Sc_TextBox_GetText(void *self, const RuntimeScriptValue *params, int32_t param_count)
 {

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -65,7 +65,6 @@ extern CCObject    ccDynamicObject;
 extern CCDialog    ccDynamicDialog;
 extern CCAudioChannel ccDynamicAudio;
 extern CCAudioClip ccDynamicAudioClip;
-extern ScriptString myScriptStringImpl;
 extern ScriptObject scrObj[MAX_ROOM_OBJECTS];
 extern std::vector<ScriptGUI> scrGui;
 extern ScriptHotspot scrHotspot[MAX_ROOM_HOTSPOTS];
@@ -559,7 +558,6 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
     // require access to script API at initialization time.
     //
     ccSetScriptAliveTimer(1000 / 60u, 1000u, 150000u);
-    ccSetStringClassImpl(&myScriptStringImpl);
     setup_script_exports(base_api, compat_api);
 
     //

--- a/Engine/plugin/agsplugin.cpp
+++ b/Engine/plugin/agsplugin.cpp
@@ -91,7 +91,6 @@ extern RGB palette[256];
 extern int displayed_room;
 extern RoomStruct thisroom;
 extern RoomStatus *croom;
-extern ScriptString myScriptStringImpl;
 extern RuntimeScriptValue GlobalReturnValue;
 
 

--- a/Engine/script/cc_instance.cpp
+++ b/Engine/script/cc_instance.cpp
@@ -151,7 +151,6 @@ const char *fixupnames[] = { "null", "fix_gldata", "fix_func", "fix_string", "fi
 
 
 extern new_line_hook_type new_line_hook;
-extern ScriptString myScriptStringImpl;
 
 ccInstance *loadedInstances[MAX_LOADED_INSTANCES] = { nullptr };
 
@@ -1588,20 +1587,9 @@ int ccInstance::Run(int32_t curpc)
         case SCMD_CREATESTRING:
         {
             auto &reg1 = registers[codeOp.Arg1i()];
-            // FIXME: provide a dummy impl to avoid this?
-            // why arrays can be created using global mgr and strings not?
-            if (stringClassImpl == nullptr)
-            {
-                cc_error("No string class implementation set, but opcode was used");
-                return -1;
-            }
-            else
-            {
-                const char *ptr = reinterpret_cast<const char*>(reg1.GetDirectPtr());
-                reg1.SetScriptObject(
-                    stringClassImpl->CreateString(ptr).Obj,
-                    &myScriptStringImpl);
-            }
+            const char *ptr = reinterpret_cast<const char*>(reg1.GetDirectPtr());
+            DynObjectRef ref = ScriptString::Create(ptr);
+            reg1.SetScriptObject(ref.Obj, &myScriptStringImpl);
             break;
         }
         case SCMD_STRINGSEQUAL:

--- a/libsrc/allegro/include/allegro/unicode.h
+++ b/libsrc/allegro/include/allegro/unicode.h
@@ -71,6 +71,7 @@ AL_FUNC(char *, _ustrdup, (AL_CONST char *src, AL_METHOD(void *, malloc_func, (s
 AL_FUNC(char *, ustrzcpy, (char *dest, int size, AL_CONST char *src));
 AL_FUNC(char *, ustrzcat, (char *dest, int size, AL_CONST char *src));
 AL_FUNC(int, ustrlen, (AL_CONST char *s));
+AL_FUNC(void, ustrlen2, (AL_CONST char *s, int *len, int *ulen));
 AL_FUNC(int, ustrcmp, (AL_CONST char *s1, AL_CONST char *s2));
 AL_FUNC(char *, ustrzncpy, (char *dest, int size, AL_CONST char *src, int n));
 AL_FUNC(char *, ustrzncat, (char *dest, int size, AL_CONST char *src, int n));

--- a/libsrc/allegro/src/unicode.c
+++ b/libsrc/allegro/src/unicode.c
@@ -1900,6 +1900,25 @@ int ustrlen(AL_CONST char *s)
 
 
 
+/* ustrlen2:
+ *  Similar to ustrlen, but returns both length in characters
+    and length in bytes.
+ */
+void ustrlen2(AL_CONST char *s, int *len, int *ulen)
+{
+   int c = 0;
+   AL_CONST char *src = s;
+   ASSERT(s);
+
+   while (ugetxc(&s))
+      c++;
+
+   *len = (int)(s - src) - 1;
+   *ulen = c;
+}
+
+
+
 /* ustrcmp:
  *  Unicode-aware version of the ANSI strcmp() function.
  */


### PR DESCRIPTION
Fix #2177 .

Bring ScriptString to the form similar to DynamicArray and UserStruct, where string's meta-info is stored in the same allocated buffer, prepended before the actual text data. This is for general consistency and to be able to retrieve extra info from the received pointer in script functions.

ScriptString's header has two values:
- string length in bytes;
- string length in characters, unicode-compatible.

This is because some operations may require either one or another.

**EDIT:** later added 2 uint16 values which store last requested char index and corresponding char offset. This is done to speed sequential Chars[] iteration up. Because of utf-8 strings the direct access at index is no longer possible, so this seem to be the only possible solution in the absence of a **string iterator** (this is something left for future ags4 dev). Also see comments in code and in this thread for details.

In all the String's member functions assume that the first argument is the ScriptString, and has this info prepended. Therefore, don't call strlen on arg1, but retrieve precalculated values.
Unfortunately we cannot do the same with the second string arg in functions like String.Append, because we do not know where it came from (it could be a string literal, etc). This cannot be resolved unless we either overhaul how strings are handled in script vm, or provide overloaded methods which accept explicit String argument.

---

**UPDATE**

<details><summary>Used following script for a performance test (under spoiler).</summary>

```
bool test_appending;
bool test_iterating;
String test_string;

function room_Load()
{
	test_string = "";
	for (int i = 0; i < 1000; i++)
		test_string = test_string.AppendChar('A');
}

function on_key_press(eKeyCode k)
{
	if (k == eKey1)
		test_appending = !test_appending;
	if (k == eKey2)
		test_iterating = !test_iterating;
}

function noloopcheck room_RepExec()
{
	if (test_appending)
	{
		test_string = "";
		for (int i = 0; i < 1000; i++)
			test_string = test_string.AppendChar('A');
	}
	if (test_iterating)
	{
		for (int c = 0; c < test_string.Length; c++)
		{
			char ch = test_string.Chars[c];
		}
	}
}
```
</details>

After trying couple of variants, the latest fps results look like this:

| Test | 3.6.1 | PR 2187 |
|---|---|---|
| AppendChar | 715 | 1440-1500* |
| Iterate | 128 | 470 |

(*) AppendChar test fps jumps too much, perhaps due to lots of memory reallocations, but later settles at around 1500 fps.
In the end it seems that appending a character in this test became x2 faster and iterating over string x3.6 faster.

---

**UPDATE 2**

After adding a iteration speed up fix, the fps results look like:
| Test | 3.6.1 | PR 2187 |
|---|---|---|
| AppendChar | 715 | ~1440-1500 |
| Iterate | 128 | ~1600 |
