### PR TITLE
New compiler: Better error msg. for forward declaration of local functions

### DIFF
--- a/Compiler/script2/cs_parser.cpp
+++ b/Compiler/script2/cs_parser.cpp
@@ -6780,13 +6780,21 @@ void AGS::Parser::Parse()
         _scrip.ReplaceLabels();
         Symbol first_unresolved_function = _callpointLabels.GetFirstUnresolvedFunction();
         if (kKW_NoSymbol != first_unresolved_function)
+        {
+            // We're at the end of the file, so set the cursor to the loc of the function
+            size_t const error_loc = _sym[first_unresolved_function].Declared;
+            if (error_loc != SymbolTable::kNoSrcLocation)
+                _src.SetCursor(error_loc);
             UserError(
-                "Local function '%s' has been referenced in this file but never defined with body",
+                "The local function '%s' is never defined with body (did you forget 'import'?)",
                 _sym.GetName(first_unresolved_function).c_str());
+        }
+
         first_unresolved_function = _importLabels.GetFirstUnresolvedFunction();
         if (kKW_NoSymbol != first_unresolved_function)
-            UserError(
-                "Imported function '%s' has been referenced in this file but never defined",
+            // This shouldn't be possible.
+            InternalError(
+                "The 'import' function '%s' has been referenced in this file but never defined",
                 _sym.GetName(first_unresolved_function).c_str());
 
         Parse_CheckForUnresolvedStructForwardDecls();

--- a/Compiler/test2/cc_parser_test_1.cpp
+++ b/Compiler/test2/cc_parser_test_1.cpp
@@ -2581,6 +2581,30 @@ TEST_F(Compile1, AssignmentInParameterList1)
     EXPECT_NE(std::string::npos, msg.find("'='"));
 }
 
+TEST_F(Compile1, CallUndefinedFunc) {
+
+    // Function is called, but not defined with body or external
+    // This should be flagged naming the function
+
+    char const *inpl = "\
+        struct Test             \n\
+        {                       \n\
+            static int F();     \n\
+        };                      \n\
+                                \n\
+        int game_start()        \n\
+        {                       \n\
+            Test.F();           \n\
+        }                       \n\
+        ";
+
+    int compileResult = cc_compile(inpl, scrip);
+    std::string msg = last_seen_cc_error();
+    ASSERT_STRNE("Ok", (compileResult >= 0) ? "Ok" : last_seen_cc_error());
+    EXPECT_NE(std::string::npos, msg.find("'Test::F'"));
+    EXPECT_NE(std::string::npos, msg.find("never defined"));
+}
+
 TEST_F(Compile1, CrementAsBinary1) {
 
     // Increment operator can't be used as a binary operator.


### PR DESCRIPTION
Fixes #1921

When a local function is forward-declared but not locally defined with body then calls to that function can't be resolved. The compiler catches that but it flagged it with a nonsensical error message (which is a bug)

This same situation can also come up when a programmer forgets the `import` keyword when declaring an external function. 

Change the error message so that both cases are covered.

Typical code: 
```
struct Test
{
    static int F(); // might be a local function, might be external but 'import' forgotten
};

function game_start()
{
    Test.F();
}
```

The compiler will now flag line 3 and give the error message:
> > The local function 'Test::F' is never defined with body (did you forget 'import'?)
