### PR TITLE
Engine: refactoring BitmapToVideoMem

### DIFF
--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -393,10 +393,10 @@ template <typename T> void get_pixel_if_not_transparent(const T *pixel, T *red, 
     ( (((a) & 0xFF) << _vmem_a_shift_32) | (((r) & 0xFF) << _vmem_r_shift_32) | (((g) & 0xFF) << _vmem_g_shift_32) | (((b) & 0xFF) << _vmem_b_shift_32) )
 
 
-template <typename T, bool HasAlpha> void
+template <typename T, bool HasAlpha, bool UsingLinearFiltering> void
 VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
         const Bitmap *bitmap, const TextureTile *tile,
-        uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
+        uint8_t *dst_ptr, const int dst_pitch
 )
 {
     bool lastPixelWasTransparent = false;
@@ -413,7 +413,7 @@ VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
 
             if (is_color_mask<T>(*srcData))
             {
-                if (!usingLinearFiltering)
+                if (!UsingLinearFiltering)
                     memPtrLong[x] = 0;
                     // set to transparent, but use the colour from the neighbouring
                     // pixel to stop the linear filter doing black outlines
@@ -467,16 +467,29 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
     switch (src_depth)
     {
         case 8:
-            BitmapToVideoMemImpl<uint8_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            if(usingLinearFiltering) {
+                BitmapToVideoMemImpl<uint8_t, false, true>(bitmap, tile, dst_ptr, dst_pitch);
+            } else {
+                BitmapToVideoMemImpl<uint8_t, false, false>(bitmap, tile, dst_ptr, dst_pitch);
+            }
+
             break;
         case 16:
-            BitmapToVideoMemImpl<uint16_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            if(usingLinearFiltering) {
+                BitmapToVideoMemImpl<uint16_t, false, true>(bitmap, tile, dst_ptr, dst_pitch);
+            } else {
+                BitmapToVideoMemImpl<uint16_t, false, false>(bitmap, tile, dst_ptr, dst_pitch);
+            }
             break;
         case 32:
-            if(has_alpha) {
-                BitmapToVideoMemImpl<uint32_t, true>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            if(has_alpha && usingLinearFiltering) {
+                BitmapToVideoMemImpl<uint32_t, true, true>(bitmap, tile, dst_ptr, dst_pitch);
+            } else if(has_alpha && !usingLinearFiltering) {
+                BitmapToVideoMemImpl<uint32_t, true, false>(bitmap, tile, dst_ptr, dst_pitch);
+            } else if(!has_alpha && usingLinearFiltering) {
+                BitmapToVideoMemImpl<uint32_t, false, true>(bitmap, tile, dst_ptr, dst_pitch);
             } else {
-                BitmapToVideoMemImpl<uint32_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+                BitmapToVideoMemImpl<uint32_t, false, false>(bitmap, tile, dst_ptr, dst_pitch);
             }
             break;
         default:

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -354,51 +354,38 @@ void VideoMemoryGraphicsDriver::DestroyFxPool()
 }
 
 
-#define algetr32(c) getr32(c)
-#define algetg32(c) getg32(c)
-#define algetb32(c) getb32(c)
-#define algeta32(c) geta32(c)
+template <typename T> T algetr(const T);
+template <typename T> T algetg(const T);
+template <typename T> T algetb(const T);
+template <typename T> T algeta(const T);
 
-#define algetr16(c) getr16(c)
-#define algetg16(c) getg16(c)
-#define algetb16(c) getb16(c)
+template <> uint8_t algetr(const uint8_t c) { return getr8(c); }
+template <> uint8_t algetg(const uint8_t c) { return getg8(c); }
+template <> uint8_t algetb(const uint8_t c) { return getb8(c); }
+template <> uint8_t algeta(const uint8_t c) { return 0xFF; }
 
-#define algetr8(c)  getr8(c)
-#define algetg8(c)  getg8(c)
-#define algetb8(c)  getb8(c)
+template <> uint16_t algetr(const uint16_t c) { return getr16(c); }
+template <> uint16_t algetg(const uint16_t c) { return getg16(c); }
+template <> uint16_t algetb(const uint16_t c) { return getb16(c); }
+template <> uint16_t algeta(const uint16_t c) { return 0xFF; }
 
+template <> uint32_t algetr(const uint32_t c) { return getr32(c); }
+template <> uint32_t algetg(const uint32_t c) { return getg32(c); }
+template <> uint32_t algetb(const uint32_t c) { return getb32(c); }
+template <> uint32_t algeta(const uint32_t c) { return geta32(c); }
 
-__inline void get_pixel_if_not_transparent8(unsigned char *pixel, unsigned char *red, unsigned char *green, unsigned char *blue, unsigned char *divisor)
-{
-  if (pixel[0] != MASK_COLOR_8)
-  {
-    *red += algetr8(pixel[0]);
-    *green += algetg8(pixel[0]);
-    *blue += algetb8(pixel[0]);
-    divisor[0]++;
-  }
-}
+template <typename T> bool is_color_mask(const T);
+template <> bool is_color_mask(const uint8_t c) { return c == MASK_COLOR_8;}
+template <> bool is_color_mask(const uint16_t c) { return c == MASK_COLOR_16;}
+template <> bool is_color_mask(const uint32_t c) { return c == MASK_COLOR_32;}
 
-__inline void get_pixel_if_not_transparent16(unsigned short *pixel, unsigned short *red, unsigned short *green, unsigned short *blue, unsigned short *divisor)
-{
-  if (pixel[0] != MASK_COLOR_16)
-  {
-    *red += algetr16(pixel[0]);
-    *green += algetg16(pixel[0]);
-    *blue += algetb16(pixel[0]);
-    divisor[0]++;
-  }
-}
-
-__inline void get_pixel_if_not_transparent32(unsigned int *pixel, unsigned int *red, unsigned int *green, unsigned int *blue, unsigned int *divisor)
-{
-  if (pixel[0] != MASK_COLOR_32)
-  {
-    *red += algetr32(pixel[0]);
-    *green += algetg32(pixel[0]);
-    *blue += algetb32(pixel[0]);
-    divisor[0]++;
-  }
+template <typename T> void get_pixel_if_not_transparent(const T *pixel, T *red, T *green, T *blue, T *divisor) {
+    if (!is_color_mask<T>(pixel[0])) {
+        *red += algetr<T>(pixel[0]);
+        *green += algetg<T>(pixel[0]);
+        *blue += algetb<T>(pixel[0]);
+        divisor[0]++;
+    }
 }
 
 
@@ -424,7 +411,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
 
                 for (int x = 0; x < tile->width; x++) {
                     unsigned char *srcData = (unsigned char *) &scanline_at[(x + tile->x) * sizeof(char)];
-                    if (*srcData == MASK_COLOR_8) {
+                    if (is_color_mask<uint8_t>(*srcData)) {
                         if (!usingLinearFiltering)
                             memPtrLong[x] = 0;
                             // set to transparent, but use the colour from the neighbouring
@@ -432,15 +419,15 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         else {
                             unsigned char red = 0, green = 0, blue = 0, divisor = 0;
                             if (x > 0)
-                                get_pixel_if_not_transparent8(&srcData[-1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint8_t>(&srcData[-1], &red, &green, &blue, &divisor);
                             if (x < tile->width - 1)
-                                get_pixel_if_not_transparent8(&srcData[1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint8_t>(&srcData[1], &red, &green, &blue, &divisor);
                             if (y > 0)
-                                get_pixel_if_not_transparent8(
+                                get_pixel_if_not_transparent<uint8_t>(
                                         (unsigned char *) &scanline_before[(x + tile->x) * sizeof(char)],
                                         &red, &green, &blue, &divisor);
                             if (y < tile->height - 1)
-                                get_pixel_if_not_transparent8(
+                                get_pixel_if_not_transparent<uint8_t>(
                                         (unsigned char *) &scanline_after[(x + tile->x) * sizeof(char)],
                                         &red, &green, &blue, &divisor);
                             if (divisor > 0)
@@ -450,7 +437,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         }
                         lastPixelWasTransparent = true;
                     } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr8(*srcData), algetg8(*srcData), algetb8(*srcData), 0xFF);
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint8_t>(*srcData), algetg<uint8_t>(*srcData), algetb<uint8_t>(*srcData), 0xFF);
                         if (lastPixelWasTransparent) {
                             // update the colour of the previous tranparent pixel, to
                             // stop black outlines when linear filtering
@@ -473,7 +460,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
 
                 for (int x = 0; x < tile->width; x++) {
                     unsigned short *srcData = (unsigned short *) &scanline_at[(x + tile->x) * sizeof(short)];
-                    if (*srcData == MASK_COLOR_16) {
+                    if (is_color_mask<uint16_t>(*srcData)) {
                         if (!usingLinearFiltering)
                             memPtrLong[x] = 0;
                             // set to transparent, but use the colour from the neighbouring
@@ -481,15 +468,15 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         else {
                             unsigned short red = 0, green = 0, blue = 0, divisor = 0;
                             if (x > 0)
-                                get_pixel_if_not_transparent16(&srcData[-1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint16_t>(&srcData[-1], &red, &green, &blue, &divisor);
                             if (x < tile->width - 1)
-                                get_pixel_if_not_transparent16(&srcData[1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint16_t>(&srcData[1], &red, &green, &blue, &divisor);
                             if (y > 0)
-                                get_pixel_if_not_transparent16(
+                                get_pixel_if_not_transparent<uint16_t>(
                                         (unsigned short *) &scanline_before[(x + tile->x) * sizeof(short)], &red,
                                         &green, &blue, &divisor);
                             if (y < tile->height - 1)
-                                get_pixel_if_not_transparent16(
+                                get_pixel_if_not_transparent<uint16_t>(
                                         (unsigned short *) &scanline_after[(x + tile->x) * sizeof(short)], &red, &green,
                                         &blue, &divisor);
                             if (divisor > 0)
@@ -499,7 +486,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         }
                         lastPixelWasTransparent = true;
                     } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr16(*srcData), algetg16(*srcData), algetb16(*srcData),
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint16_t>(*srcData), algetg<uint16_t>(*srcData), algetb<uint16_t>(*srcData),
                                                        0xFF);
                         if (lastPixelWasTransparent) {
                             // update the colour of the previous tranparent pixel, to
@@ -523,7 +510,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
 
                 for (int x = 0; x < tile->width; x++) {
                     unsigned int *srcData = (unsigned int *) &scanline_at[(x + tile->x) * sizeof(int)];
-                    if (*srcData == MASK_COLOR_32) {
+                    if (is_color_mask<uint32_t>(*srcData)) {
                         if (!usingLinearFiltering)
                             memPtrLong[x] = 0;
                             // set to transparent, but use the colour from the neighbouring
@@ -531,15 +518,15 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         else {
                             unsigned int red = 0, green = 0, blue = 0, divisor = 0;
                             if (x > 0)
-                                get_pixel_if_not_transparent32(&srcData[-1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint32_t>(&srcData[-1], &red, &green, &blue, &divisor);
                             if (x < tile->width - 1)
-                                get_pixel_if_not_transparent32(&srcData[1], &red, &green, &blue, &divisor);
+                                get_pixel_if_not_transparent<uint32_t>(&srcData[1], &red, &green, &blue, &divisor);
                             if (y > 0)
-                                get_pixel_if_not_transparent32(
+                                get_pixel_if_not_transparent<uint32_t>(
                                         (unsigned int *) &scanline_before[(x + tile->x) * sizeof(int)], &red, &green,
                                         &blue, &divisor);
                             if (y < tile->height - 1)
-                                get_pixel_if_not_transparent32(
+                                get_pixel_if_not_transparent<uint32_t>(
                                         (unsigned int *) &scanline_after[(x + tile->x) * sizeof(int)], &red, &green,
                                         &blue, &divisor);
                             if (divisor > 0)
@@ -549,10 +536,10 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
                         }
                         lastPixelWasTransparent = true;
                     } else if (has_alpha) {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                                                       algeta32(*srcData));
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
+                                                       algeta<uint32_t>(*srcData));
                     } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
                                                        0xFF);
                         if (lastPixelWasTransparent) {
                             // update the colour of the previous tranparent pixel, to
@@ -585,7 +572,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
 
                 for (int x = 0; x < tile->width; x++) {
                     unsigned char *srcData = (unsigned char *) &scanline_at[(x + tile->x) * sizeof(char)];
-                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr8(*srcData), algetg8(*srcData), algetb8(*srcData), 0xFF);
+                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint8_t>(*srcData), algetg<uint8_t>(*srcData), algetb<uint8_t>(*srcData), 0xFF);
                 }
 
                 dst_ptr += dst_pitch;
@@ -599,7 +586,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
 
                 for (int x = 0; x < tile->width; x++) {
                     unsigned short *srcData = (unsigned short *) &scanline_at[(x + tile->x) * sizeof(short)];
-                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr16(*srcData), algetg16(*srcData), algetb16(*srcData), 0xFF);
+                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint16_t>(*srcData), algetg<uint16_t>(*srcData), algetb<uint16_t>(*srcData), 0xFF);
                 }
 
                 dst_ptr += dst_pitch;
@@ -614,8 +601,8 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
 
                     for (int x = 0; x < tile->width; x++) {
                         unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
-                            algeta32(*srcData));
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
+                            algeta<uint32_t>(*srcData));
                     }
                     dst_ptr += dst_pitch;
                 }
@@ -626,7 +613,7 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
 
                     for (int x = 0; x < tile->width; x++) {
                         unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr32(*srcData), algetg32(*srcData), algetb32(*srcData),
+                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
                             0xFF);
                     }
                     dst_ptr += dst_pitch;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -393,9 +393,9 @@ template <typename T> void get_pixel_if_not_transparent(const T *pixel, T *red, 
     ( (((a) & 0xFF) << _vmem_a_shift_32) | (((r) & 0xFF) << _vmem_r_shift_32) | (((g) & 0xFF) << _vmem_g_shift_32) | (((b) & 0xFF) << _vmem_b_shift_32) )
 
 
-template <typename T> void
+template <typename T, bool HasAlpha> void
 VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
-        const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+        const Bitmap *bitmap, const TextureTile *tile,
         uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
 )
 {
@@ -438,7 +438,7 @@ VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
                 }
                 lastPixelWasTransparent = true;
             }
-            else if (has_alpha)
+            else if (HasAlpha)
             {
                 memPtrLong[x] = VMEMCOLOR_RGBA(algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData),
                                                algeta<T>(*srcData));
@@ -467,13 +467,17 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
     switch (src_depth)
     {
         case 8:
-            BitmapToVideoMemImpl<uint8_t>(bitmap, false, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            BitmapToVideoMemImpl<uint8_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
             break;
         case 16:
-            BitmapToVideoMemImpl<uint16_t>(bitmap, false, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            BitmapToVideoMemImpl<uint16_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
             break;
         case 32:
-            BitmapToVideoMemImpl<uint32_t>(bitmap, has_alpha, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            if(has_alpha) {
+                BitmapToVideoMemImpl<uint32_t, true>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            } else {
+                BitmapToVideoMemImpl<uint32_t, false>(bitmap, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            }
             break;
         default:
             break;
@@ -481,13 +485,13 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const boo
 }
 
 
-template <typename T> void
+template <typename T, bool HasAlpha> void
 VideoMemoryGraphicsDriver::BitmapToVideoMemOpaqueImpl(
-        const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+        const Bitmap *bitmap, const TextureTile *tile,
         uint8_t *dst_ptr, const int dst_pitch
 )
 {
-    if (has_alpha) {
+    if (HasAlpha) {
         for (int y = 0; y < tile->height; y++)
         {
             const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
@@ -528,13 +532,17 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
     switch (src_depth)
     {
         case 8:
-            BitmapToVideoMemOpaqueImpl<uint8_t>(bitmap, false, tile, dst_ptr, dst_pitch);
+            BitmapToVideoMemOpaqueImpl<uint8_t, false>(bitmap, tile, dst_ptr, dst_pitch);
             break;
         case 16:
-            BitmapToVideoMemOpaqueImpl<uint16_t>(bitmap, false, tile, dst_ptr, dst_pitch);
+            BitmapToVideoMemOpaqueImpl<uint16_t, false>(bitmap, tile, dst_ptr, dst_pitch);
             break;
         case 32:
-            BitmapToVideoMemOpaqueImpl<uint32_t>(bitmap, has_alpha, tile, dst_ptr, dst_pitch);
+            if(has_alpha) {
+                BitmapToVideoMemOpaqueImpl<uint32_t, true>(bitmap, tile, dst_ptr, dst_pitch);
+            } else {
+                BitmapToVideoMemOpaqueImpl<uint32_t, false>(bitmap, tile, dst_ptr, dst_pitch);
+            }
             break;
         default:
             break;

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -380,10 +380,11 @@ template <> bool is_color_mask(const uint16_t c) { return c == MASK_COLOR_16;}
 template <> bool is_color_mask(const uint32_t c) { return c == MASK_COLOR_32;}
 
 template <typename T> void get_pixel_if_not_transparent(const T *pixel, T *red, T *green, T *blue, T *divisor) {
-    if (!is_color_mask<T>(pixel[0])) {
-        *red += algetr<T>(pixel[0]);
-        *green += algetg<T>(pixel[0]);
-        *blue += algetb<T>(pixel[0]);
+    const T px_color = pixel[0];
+    if (!is_color_mask<T>(px_color)) {
+        *red += algetr<T>(px_color);
+        *green += algetg<T>(px_color);
+        *blue += algetb<T>(px_color);
         divisor[0]++;
     }
 }
@@ -399,63 +400,73 @@ VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
         uint8_t *dst_ptr, const int dst_pitch
 )
 {
+    // tell the compiler these won't change mid loop execution
+    const int t_width = tile->width;
+    const int t_height = tile->height;
+    const int t_x = tile->x;
+    const int t_y = tile->y;
+
+    const int src_bpp = sizeof(T);
+    const int idst_pitch = dst_pitch * sizeof(uint8_t) / sizeof(uint32_t); // destination is always 32-bit
+    auto idst = reinterpret_cast<uint32_t*>(dst_ptr);
     bool lastPixelWasTransparent = false;
-    for (int y = 0; y < tile->height; y++) {
+
+    for (int y = 0; y < t_height; y++) {
         lastPixelWasTransparent = false;
-        const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + tile->y - 1) : nullptr;
-        const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-        const uint8_t *scanline_after = (y < tile->height - 1) ? bitmap->GetScanLine(y + tile->y + 1) : nullptr;
-        unsigned int *memPtrLong = (unsigned int *) dst_ptr;
+        const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + t_y - 1) : nullptr;
+        const uint8_t *scanline_at = bitmap->GetScanLine(y + t_y);
+        const uint8_t *scanline_after = (y < t_height - 1) ? bitmap->GetScanLine(y + t_y + 1) : nullptr;
 
-        for (int x = 0; x < tile->width; x++)
+        for (int x = 0; x < t_width; x++)
         {
-            auto *srcData = (const T *) &scanline_at[(x + tile->x) * sizeof(T)];
+            auto srcData = (const T *) &scanline_at[(x + t_x) * src_bpp];
+            const T src_color = srcData[0];
 
-            if (is_color_mask<T>(*srcData))
+            if (is_color_mask<T>(src_color))
             {
-                if (!UsingLinearFiltering)
-                    memPtrLong[x] = 0;
+                if (!UsingLinearFiltering) {
+                    idst[x] = 0;
+                }
+                else
+                {
                     // set to transparent, but use the colour from the neighbouring
                     // pixel to stop the linear filter doing black outlines
-                else {
                     T red = 0, green = 0, blue = 0, divisor = 0;
                     if (x > 0)
                         get_pixel_if_not_transparent<T>(&srcData[-1], &red, &green, &blue, &divisor);
-                    if (x < tile->width - 1)
+                    if (x < t_width - 1)
                         get_pixel_if_not_transparent<T>(&srcData[1], &red, &green, &blue, &divisor);
                     if (y > 0)
                         get_pixel_if_not_transparent<T>(
-                                (const T *) &scanline_before[(x + tile->x) * sizeof(T)], &red, &green,
+                                (const T *) &scanline_before[(x + t_x) * src_bpp], &red, &green,
                                 &blue, &divisor);
-                    if (y < tile->height - 1)
+                    if (y < t_height - 1)
                         get_pixel_if_not_transparent<T>(
-                                (const T *) &scanline_after[(x + tile->x) * sizeof(T)], &red, &green,
+                                (const T *) &scanline_after[(x + t_x) * src_bpp], &red, &green,
                                 &blue, &divisor);
                     if (divisor > 0)
-                        memPtrLong[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
+                        idst[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
                     else
-                        memPtrLong[x] = 0;
+                        idst[x] = 0;
                 }
                 lastPixelWasTransparent = true;
             }
-            else if (HasAlpha)
-            {
-                memPtrLong[x] = VMEMCOLOR_RGBA(algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData),
-                                               algeta<T>(*srcData));
+            else if (HasAlpha) {
+                idst[x] = VMEMCOLOR_RGBA(algetr<T>(src_color), algetg<T>(src_color), algetb<T>(src_color),
+                                         algeta<T>(src_color));
             }
             else
             {
-                memPtrLong[x] = VMEMCOLOR_RGBA(algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData),
-                                               0xFF);
+                idst[x] = VMEMCOLOR_RGBA(algetr<T>(src_color), algetg<T>(src_color), algetb<T>(src_color), 0xFF);
                 if (lastPixelWasTransparent) {
-                    // update the colour of the previous tranparent pixel, to
+                    // update the colour of the previous transparent pixel, to
                     // stop black outlines when linear filtering
-                    memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
+                    idst[x - 1] = idst[x] & 0x00FFFFFF;
                     lastPixelWasTransparent = false;
                 }
             }
         }
-        dst_ptr += dst_pitch;
+        idst += idst_pitch;
     }
 }
 
@@ -504,33 +515,39 @@ VideoMemoryGraphicsDriver::BitmapToVideoMemOpaqueImpl(
         uint8_t *dst_ptr, const int dst_pitch
 )
 {
+    const int t_width = tile->width;
+    const int t_height = tile->height;
+    const int t_x = tile->x;
+    const int t_y = tile->y;
     if (HasAlpha) {
-        for (int y = 0; y < tile->height; y++)
+        for (int y = 0; y < t_height; y++)
         {
-            const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
+            const uint8_t* scanline_at = bitmap->GetScanLine(y + t_y);
             unsigned int* memPtrLong = (unsigned int*)dst_ptr;
 
-            for (int x = 0; x < tile->width; x++)
+            for (int x = 0; x < t_width; x++)
             {
-                auto srcData = (const T *)&scanline_at[(x + tile->x) * sizeof(T)];
+                auto srcData = (const T *)&scanline_at[(x + t_x) * sizeof(T)];
+                const T src_color = srcData[0];
                 memPtrLong[x] = VMEMCOLOR_RGBA(
-                        algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData), algeta<T>(*srcData));
+                        algetr<T>(src_color), algetg<T>(src_color), algetb<T>(src_color), algeta<T>(src_color));
             }
             dst_ptr += dst_pitch;
         }
     }
     else
     {
-        for (int y = 0; y < tile->height; y++)
+        for (int y = 0; y < t_height; y++)
         {
-            const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
+            const uint8_t* scanline_at = bitmap->GetScanLine(y + t_y);
             unsigned int* memPtrLong = (unsigned int*)dst_ptr;
 
-            for (int x = 0; x < tile->width; x++)
+            for (int x = 0; x < t_width; x++)
             {
-                auto srcData = (const T *)&scanline_at[(x + tile->x) * sizeof(T)];
+                auto srcData = (const T *)&scanline_at[(x + t_x) * sizeof(T)];
+                const T src_color = srcData[0];
                 memPtrLong[x] = VMEMCOLOR_RGBA(
-                        algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData), 0xFF);
+                        algetr<T>(src_color), algetg<T>(src_color), algetb<T>(src_color), 0xFF);
             }
             dst_ptr += dst_pitch;
         }

--- a/Engine/gfx/gfxdriverbase.cpp
+++ b/Engine/gfx/gfxdriverbase.cpp
@@ -393,168 +393,130 @@ template <typename T> void get_pixel_if_not_transparent(const T *pixel, T *red, 
     ( (((a) & 0xFF) << _vmem_a_shift_32) | (((r) & 0xFF) << _vmem_r_shift_32) | (((g) & 0xFF) << _vmem_g_shift_32) | (((b) & 0xFF) << _vmem_b_shift_32) )
 
 
+template <typename T> void
+VideoMemoryGraphicsDriver::BitmapToVideoMemImpl(
+        const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+        uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
+)
+{
+    bool lastPixelWasTransparent = false;
+    for (int y = 0; y < tile->height; y++) {
+        lastPixelWasTransparent = false;
+        const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + tile->y - 1) : nullptr;
+        const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
+        const uint8_t *scanline_after = (y < tile->height - 1) ? bitmap->GetScanLine(y + tile->y + 1) : nullptr;
+        unsigned int *memPtrLong = (unsigned int *) dst_ptr;
+
+        for (int x = 0; x < tile->width; x++)
+        {
+            auto *srcData = (const T *) &scanline_at[(x + tile->x) * sizeof(T)];
+
+            if (is_color_mask<T>(*srcData))
+            {
+                if (!usingLinearFiltering)
+                    memPtrLong[x] = 0;
+                    // set to transparent, but use the colour from the neighbouring
+                    // pixel to stop the linear filter doing black outlines
+                else {
+                    T red = 0, green = 0, blue = 0, divisor = 0;
+                    if (x > 0)
+                        get_pixel_if_not_transparent<T>(&srcData[-1], &red, &green, &blue, &divisor);
+                    if (x < tile->width - 1)
+                        get_pixel_if_not_transparent<T>(&srcData[1], &red, &green, &blue, &divisor);
+                    if (y > 0)
+                        get_pixel_if_not_transparent<T>(
+                                (const T *) &scanline_before[(x + tile->x) * sizeof(T)], &red, &green,
+                                &blue, &divisor);
+                    if (y < tile->height - 1)
+                        get_pixel_if_not_transparent<T>(
+                                (const T *) &scanline_after[(x + tile->x) * sizeof(T)], &red, &green,
+                                &blue, &divisor);
+                    if (divisor > 0)
+                        memPtrLong[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
+                    else
+                        memPtrLong[x] = 0;
+                }
+                lastPixelWasTransparent = true;
+            }
+            else if (has_alpha)
+            {
+                memPtrLong[x] = VMEMCOLOR_RGBA(algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData),
+                                               algeta<T>(*srcData));
+            }
+            else
+            {
+                memPtrLong[x] = VMEMCOLOR_RGBA(algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData),
+                                               0xFF);
+                if (lastPixelWasTransparent) {
+                    // update the colour of the previous tranparent pixel, to
+                    // stop black outlines when linear filtering
+                    memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
+                    lastPixelWasTransparent = false;
+                }
+            }
+        }
+        dst_ptr += dst_pitch;
+    }
+}
+
 void VideoMemoryGraphicsDriver::BitmapToVideoMem(const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
     uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering)
 {
     const int src_depth = bitmap->GetColorDepth();
-    bool lastPixelWasTransparent = false;
 
     switch (src_depth)
     {
-        case 8: {
-            for (int y = 0; y < tile->height; y++) {
-                lastPixelWasTransparent = false;
-                const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + tile->y - 1) : nullptr;
-                const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-                const uint8_t *scanline_after = (y < tile->height - 1) ? bitmap->GetScanLine(y + tile->y + 1) : nullptr;
-                unsigned int *memPtrLong = (unsigned int *) dst_ptr;
-
-                for (int x = 0; x < tile->width; x++) {
-                    unsigned char *srcData = (unsigned char *) &scanline_at[(x + tile->x) * sizeof(char)];
-                    if (is_color_mask<uint8_t>(*srcData)) {
-                        if (!usingLinearFiltering)
-                            memPtrLong[x] = 0;
-                            // set to transparent, but use the colour from the neighbouring
-                            // pixel to stop the linear filter doing black outlines
-                        else {
-                            unsigned char red = 0, green = 0, blue = 0, divisor = 0;
-                            if (x > 0)
-                                get_pixel_if_not_transparent<uint8_t>(&srcData[-1], &red, &green, &blue, &divisor);
-                            if (x < tile->width - 1)
-                                get_pixel_if_not_transparent<uint8_t>(&srcData[1], &red, &green, &blue, &divisor);
-                            if (y > 0)
-                                get_pixel_if_not_transparent<uint8_t>(
-                                        (unsigned char *) &scanline_before[(x + tile->x) * sizeof(char)],
-                                        &red, &green, &blue, &divisor);
-                            if (y < tile->height - 1)
-                                get_pixel_if_not_transparent<uint8_t>(
-                                        (unsigned char *) &scanline_after[(x + tile->x) * sizeof(char)],
-                                        &red, &green, &blue, &divisor);
-                            if (divisor > 0)
-                                memPtrLong[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
-                            else
-                                memPtrLong[x] = 0;
-                        }
-                        lastPixelWasTransparent = true;
-                    } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint8_t>(*srcData), algetg<uint8_t>(*srcData), algetb<uint8_t>(*srcData), 0xFF);
-                        if (lastPixelWasTransparent) {
-                            // update the colour of the previous tranparent pixel, to
-                            // stop black outlines when linear filtering
-                            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
-                            lastPixelWasTransparent = false;
-                        }
-                    }
-                }
-                dst_ptr += dst_pitch;
-            }
-        }
-        break;
-        case 16: {
-            for (int y = 0; y < tile->height; y++) {
-                lastPixelWasTransparent = false;
-                const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + tile->y - 1) : nullptr;
-                const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-                const uint8_t *scanline_after = (y < tile->height - 1) ? bitmap->GetScanLine(y + tile->y + 1) : nullptr;
-                unsigned int *memPtrLong = (unsigned int *) dst_ptr;
-
-                for (int x = 0; x < tile->width; x++) {
-                    unsigned short *srcData = (unsigned short *) &scanline_at[(x + tile->x) * sizeof(short)];
-                    if (is_color_mask<uint16_t>(*srcData)) {
-                        if (!usingLinearFiltering)
-                            memPtrLong[x] = 0;
-                            // set to transparent, but use the colour from the neighbouring
-                            // pixel to stop the linear filter doing black outlines
-                        else {
-                            unsigned short red = 0, green = 0, blue = 0, divisor = 0;
-                            if (x > 0)
-                                get_pixel_if_not_transparent<uint16_t>(&srcData[-1], &red, &green, &blue, &divisor);
-                            if (x < tile->width - 1)
-                                get_pixel_if_not_transparent<uint16_t>(&srcData[1], &red, &green, &blue, &divisor);
-                            if (y > 0)
-                                get_pixel_if_not_transparent<uint16_t>(
-                                        (unsigned short *) &scanline_before[(x + tile->x) * sizeof(short)], &red,
-                                        &green, &blue, &divisor);
-                            if (y < tile->height - 1)
-                                get_pixel_if_not_transparent<uint16_t>(
-                                        (unsigned short *) &scanline_after[(x + tile->x) * sizeof(short)], &red, &green,
-                                        &blue, &divisor);
-                            if (divisor > 0)
-                                memPtrLong[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
-                            else
-                                memPtrLong[x] = 0;
-                        }
-                        lastPixelWasTransparent = true;
-                    } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint16_t>(*srcData), algetg<uint16_t>(*srcData), algetb<uint16_t>(*srcData),
-                                                       0xFF);
-                        if (lastPixelWasTransparent) {
-                            // update the colour of the previous tranparent pixel, to
-                            // stop black outlines when linear filtering
-                            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
-                            lastPixelWasTransparent = false;
-                        }
-                    }
-                }
-                dst_ptr += dst_pitch;
-            }
-        }
-        break;
-        case 32: {
-            for (int y = 0; y < tile->height; y++) {
-                lastPixelWasTransparent = false;
-                const uint8_t *scanline_before = (y > 0) ? bitmap->GetScanLine(y + tile->y - 1) : nullptr;
-                const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-                const uint8_t *scanline_after = (y < tile->height - 1) ? bitmap->GetScanLine(y + tile->y + 1) : nullptr;
-                unsigned int *memPtrLong = (unsigned int *) dst_ptr;
-
-                for (int x = 0; x < tile->width; x++) {
-                    unsigned int *srcData = (unsigned int *) &scanline_at[(x + tile->x) * sizeof(int)];
-                    if (is_color_mask<uint32_t>(*srcData)) {
-                        if (!usingLinearFiltering)
-                            memPtrLong[x] = 0;
-                            // set to transparent, but use the colour from the neighbouring
-                            // pixel to stop the linear filter doing black outlines
-                        else {
-                            unsigned int red = 0, green = 0, blue = 0, divisor = 0;
-                            if (x > 0)
-                                get_pixel_if_not_transparent<uint32_t>(&srcData[-1], &red, &green, &blue, &divisor);
-                            if (x < tile->width - 1)
-                                get_pixel_if_not_transparent<uint32_t>(&srcData[1], &red, &green, &blue, &divisor);
-                            if (y > 0)
-                                get_pixel_if_not_transparent<uint32_t>(
-                                        (unsigned int *) &scanline_before[(x + tile->x) * sizeof(int)], &red, &green,
-                                        &blue, &divisor);
-                            if (y < tile->height - 1)
-                                get_pixel_if_not_transparent<uint32_t>(
-                                        (unsigned int *) &scanline_after[(x + tile->x) * sizeof(int)], &red, &green,
-                                        &blue, &divisor);
-                            if (divisor > 0)
-                                memPtrLong[x] = VMEMCOLOR_RGBA(red / divisor, green / divisor, blue / divisor, 0);
-                            else
-                                memPtrLong[x] = 0;
-                        }
-                        lastPixelWasTransparent = true;
-                    } else if (has_alpha) {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
-                                                       algeta<uint32_t>(*srcData));
-                    } else {
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
-                                                       0xFF);
-                        if (lastPixelWasTransparent) {
-                            // update the colour of the previous tranparent pixel, to
-                            // stop black outlines when linear filtering
-                            memPtrLong[x - 1] = memPtrLong[x] & 0x00FFFFFF;
-                            lastPixelWasTransparent = false;
-                        }
-                    }
-                }
-                dst_ptr += dst_pitch;
-            }
-        }
-        break;
+        case 8:
+            BitmapToVideoMemImpl<uint8_t>(bitmap, false, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            break;
+        case 16:
+            BitmapToVideoMemImpl<uint16_t>(bitmap, false, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            break;
+        case 32:
+            BitmapToVideoMemImpl<uint32_t>(bitmap, has_alpha, tile, dst_ptr, dst_pitch, usingLinearFiltering);
+            break;
         default:
             break;
+    }
+}
+
+
+template <typename T> void
+VideoMemoryGraphicsDriver::BitmapToVideoMemOpaqueImpl(
+        const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+        uint8_t *dst_ptr, const int dst_pitch
+)
+{
+    if (has_alpha) {
+        for (int y = 0; y < tile->height; y++)
+        {
+            const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
+            unsigned int* memPtrLong = (unsigned int*)dst_ptr;
+
+            for (int x = 0; x < tile->width; x++)
+            {
+                auto srcData = (const T *)&scanline_at[(x + tile->x) * sizeof(T)];
+                memPtrLong[x] = VMEMCOLOR_RGBA(
+                        algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData), algeta<T>(*srcData));
+            }
+            dst_ptr += dst_pitch;
+        }
+    }
+    else
+    {
+        for (int y = 0; y < tile->height; y++)
+        {
+            const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
+            unsigned int* memPtrLong = (unsigned int*)dst_ptr;
+
+            for (int x = 0; x < tile->width; x++)
+            {
+                auto srcData = (const T *)&scanline_at[(x + tile->x) * sizeof(T)];
+                memPtrLong[x] = VMEMCOLOR_RGBA(
+                        algetr<T>(*srcData), algetg<T>(*srcData), algetb<T>(*srcData), 0xFF);
+            }
+            dst_ptr += dst_pitch;
+        }
     }
 }
 
@@ -565,66 +527,20 @@ void VideoMemoryGraphicsDriver::BitmapToVideoMemOpaque(const Bitmap *bitmap, con
 
     switch (src_depth)
     {
-        case 8: {
-            for (int y = 0; y < tile->height; y++) {
-                const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-                unsigned int *memPtrLong = (unsigned int *) dst_ptr;
-
-                for (int x = 0; x < tile->width; x++) {
-                    unsigned char *srcData = (unsigned char *) &scanline_at[(x + tile->x) * sizeof(char)];
-                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint8_t>(*srcData), algetg<uint8_t>(*srcData), algetb<uint8_t>(*srcData), 0xFF);
-                }
-
-                dst_ptr += dst_pitch;
-            }
-        }
-        break;
-        case 16: {
-            for (int y = 0; y < tile->height; y++) {
-                const uint8_t *scanline_at = bitmap->GetScanLine(y + tile->y);
-                unsigned int *memPtrLong = (unsigned int *) dst_ptr;
-
-                for (int x = 0; x < tile->width; x++) {
-                    unsigned short *srcData = (unsigned short *) &scanline_at[(x + tile->x) * sizeof(short)];
-                    memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint16_t>(*srcData), algetg<uint16_t>(*srcData), algetb<uint16_t>(*srcData), 0xFF);
-                }
-
-                dst_ptr += dst_pitch;
-            }
-        }
-        break;
-        case 32: {
-            if (has_alpha) {
-                for (int y = 0; y < tile->height; y++) {
-                    const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
-                    unsigned int* memPtrLong = (unsigned int*)dst_ptr;
-
-                    for (int x = 0; x < tile->width; x++) {
-                        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
-                            algeta<uint32_t>(*srcData));
-                    }
-                    dst_ptr += dst_pitch;
-                }
-            } else {
-                for (int y = 0; y < tile->height; y++) {
-                    const uint8_t* scanline_at = bitmap->GetScanLine(y + tile->y);
-                    unsigned int* memPtrLong = (unsigned int*)dst_ptr;
-
-                    for (int x = 0; x < tile->width; x++) {
-                        unsigned int* srcData = (unsigned int*)&scanline_at[(x + tile->x) * sizeof(int)];
-                        memPtrLong[x] = VMEMCOLOR_RGBA(algetr<uint32_t>(*srcData), algetg<uint32_t>(*srcData), algetb<uint32_t>(*srcData),
-                            0xFF);
-                    }
-                    dst_ptr += dst_pitch;
-                }
-            }
-        }
-        break;
+        case 8:
+            BitmapToVideoMemOpaqueImpl<uint8_t>(bitmap, false, tile, dst_ptr, dst_pitch);
+            break;
+        case 16:
+            BitmapToVideoMemOpaqueImpl<uint16_t>(bitmap, false, tile, dst_ptr, dst_pitch);
+            break;
+        case 32:
+            BitmapToVideoMemOpaqueImpl<uint32_t>(bitmap, has_alpha, tile, dst_ptr, dst_pitch);
+            break;
         default:
             break;
     }
 }
 
-} // namespace Engine
+
+    } // namespace Engine
 } // namespace AGS

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -362,15 +362,15 @@ private:
     size_t _fxIndex; // next free pool item
 
     // specialized method to convert bitmap to video memory depending on bit depth
-    template <typename T> void
+    template <typename T, bool HasAlpha> void
     BitmapToVideoMemImpl(
-            const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+            const Bitmap *bitmap, const TextureTile *tile,
             uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
     );
 
-    template <typename T> void
+    template <typename T, bool HasAlpha> void
     BitmapToVideoMemOpaqueImpl(
-            const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+            const Bitmap *bitmap, const TextureTile *tile,
             uint8_t *dst_ptr, const int dst_pitch
     );
 };

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -362,10 +362,10 @@ private:
     size_t _fxIndex; // next free pool item
 
     // specialized method to convert bitmap to video memory depending on bit depth
-    template <typename T, bool HasAlpha> void
+    template <typename T, bool HasAlpha, bool UsingLinearFiltering> void
     BitmapToVideoMemImpl(
             const Bitmap *bitmap, const TextureTile *tile,
-            uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
+            uint8_t *dst_ptr, const int dst_pitch
     );
 
     template <typename T, bool HasAlpha> void

--- a/Engine/gfx/gfxdriverbase.h
+++ b/Engine/gfx/gfxdriverbase.h
@@ -360,6 +360,19 @@ private:
     };
     std::vector<ScreenFx> _fxPool;
     size_t _fxIndex; // next free pool item
+
+    // specialized method to convert bitmap to video memory depending on bit depth
+    template <typename T> void
+    BitmapToVideoMemImpl(
+            const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+            uint8_t *dst_ptr, const int dst_pitch, const bool usingLinearFiltering
+    );
+
+    template <typename T> void
+    BitmapToVideoMemOpaqueImpl(
+            const Bitmap *bitmap, const bool has_alpha, const TextureTile *tile,
+            uint8_t *dst_ptr, const int dst_pitch
+    );
 };
 
 } // namespace Engine


### PR DESCRIPTION
Hi, tried a bit of moving code around in BitmapToVideoMem. In my tests, this benchmark below that clears fullscreen bitmap and pushes to memory using an Overlay went from 22.6 FPS using what we currently have on master to 26.9 FPS after the modifications from this PR. It's nothing ground breaking, but still somewhat an improvement. Please verify this improvement.

Test Game: [ClearBenchMark.zip](https://github.com/adventuregamestudio/ags/files/13035487/ClearBenchMark.zip)
Project: [ClearBenchmarkProject.zip](https://github.com/adventuregamestudio/ags/files/13035484/ClearBenchmarkProject.zip)

I am not sure about the many commits and how to organize them or if I should merge them in a single one, and also if the code that I got to in the end is acceptable.

Ah, I don't know any 16-bit game, so I didn't test the 16-bit path, it would be nice to get more testing from this branch.

I also noticed that if original source bitmap had a 1 pixel transparent margin, the linear interpolation would not require all checks it has.