### PR TITLE
Add mingw basic support

### DIFF
--- a/CMake/c_flag_overrides.cmake
+++ b/CMake/c_flag_overrides.cmake
@@ -6,3 +6,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "/MT /Zi /O2 /Ob1 /DNDEBUG")
     set(CMAKE_C_FLAGS_MINSIZEREL_INIT     "/MT /O1 /Ob1 /DNDEBUG")
 endif()
+
+if(MINGW)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
+endif ()

--- a/CMake/cxx_flag_overrides.cmake
+++ b/CMake/cxx_flag_overrides.cmake
@@ -6,3 +6,7 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/MT /Zi /O2 /Ob1 /DNDEBUG")
     set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT     "/MT /O1 /Ob1 /DNDEBUG")
 endif()
+
+if(MINGW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+endif ()

--- a/Common/core/platform.h
+++ b/Common/core/platform.h
@@ -123,6 +123,12 @@
     #error "Unknown platform"
 #endif
 
+#if defined(__MINGW32__)
+#define AGS_PLATFORM_WINDOWS_MINGW (1)
+#else
+#define AGS_PLATFORM_WINDOWS_MINGW (0)
+#endif
+
 #if defined(_DEBUG)
     #define AGS_PLATFORM_DEBUG  (1)
 #elif ! defined(NDEBUG)

--- a/Engine/main/main.cpp
+++ b/Engine/main/main.cpp
@@ -43,7 +43,7 @@
 #include "platform/windows/win_ex_handling.h"
 #endif
 
-#if AGS_PLATFORM_OS_WINDOWS && !AGS_PLATFORM_DEBUG
+#if AGS_PLATFORM_OS_WINDOWS && (!AGS_PLATFORM_DEBUG) && !AGS_PLATFORM_WINDOWS_MINGW
 #define USE_CUSTOM_EXCEPTION_HANDLER
 #endif
 
@@ -366,7 +366,7 @@ static int main_process_cmdline(ConfigTree &cfg, int argc, char *argv[])
 int ags_entry_point(int argc, char *argv[]) { 
     main_init(argc, argv);
 
-#if AGS_PLATFORM_OS_WINDOWS
+#if AGS_PLATFORM_OS_WINDOWS && !AGS_PLATFORM_WINDOWS_MINGW
     setup_malloc_handling();
 #endif
     debug_flags=0;

--- a/Engine/platform/windows/acplwin.cpp
+++ b/Engine/platform/windows/acplwin.cpp
@@ -20,7 +20,6 @@
 #include "platform/windows/windows.h"
 #include <shlobj.h>
 #include <shlwapi.h>
-#include <gameux.h>
 #include <libcda.h>
 
 #include "platform/base/agsplatformdriver.h"

--- a/Engine/platform/windows/setup/winsetup.cpp
+++ b/Engine/platform/windows/setup/winsetup.cpp
@@ -882,9 +882,9 @@ void WinSetupDialog::OnGfxModeUpdate()
     DWORD_PTR sel = GetCurItemData(_hGfxModeList);
     switch (sel)
     {
-    case kGfxMode_Desktop:
+    case static_cast<DWORD_PTR>(kGfxMode_Desktop):
         _winCfg.FsSetup = WindowSetup(_desktopSize, kWnd_Fullscreen); break;
-    case kGfxMode_GameRes:
+    case static_cast<DWORD_PTR>(kGfxMode_GameRes):
         _winCfg.FsSetup = WindowSetup(_winCfg.GameResolution, kWnd_Fullscreen); break;
     default:
         {

--- a/Engine/platform/windows/win_ex_handling.cpp
+++ b/Engine/platform/windows/win_ex_handling.cpp
@@ -13,7 +13,8 @@
 //=============================================================================
 #include "core/platform.h"
 
-#if AGS_PLATFORM_OS_WINDOWS
+// TODO: port exception handling to mingw
+#if AGS_PLATFORM_OS_WINDOWS && !AGS_PLATFORM_WINDOWS_MINGW
 #include <new.h>
 #include <cinttypes>
 #include <stdio.h>

--- a/Engine/platform/windows/win_ex_handling.h
+++ b/Engine/platform/windows/win_ex_handling.h
@@ -16,9 +16,11 @@
 
 #include "util/ini_util.h"
 
+#if !AGS_PLATFORM_WINDOWS_MINGW
 void setup_malloc_handling();
 int  initialize_engine_with_exception_handling(
     int (initialize_engine)(const AGS::Common::ConfigTree &startup_opts),
     const AGS::Common::ConfigTree &startup_opts);
+#endif
 
 #endif // __AGS_EE_PLATFORM__WIN_EXCEPTION_HANDLING_H

--- a/Engine/util/library_windows.h
+++ b/Engine/util/library_windows.h
@@ -15,6 +15,7 @@
 #define __AGS_EE_UTIL__LIBRARY_WINDOWS_H
 
 #include <utility>
+#include "core/platform.h"
 #include "debug/out.h"
 #include "platform/windows/winapi_exclusive.h"
 #include "util/path.h"
@@ -103,7 +104,7 @@ public:
     {
         if (!_library)
             return nullptr;
-        return GetProcAddress(_library, fn_name.GetCStr());
+        return reinterpret_cast<void *>(GetProcAddress(_library, fn_name.GetCStr()));
     }
 
 private:

--- a/libsrc/allegro/CMakeLists.txt
+++ b/libsrc/allegro/CMakeLists.txt
@@ -162,6 +162,7 @@ endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # WIN32 is set by CMake for any Windows platform
+    set(ALLEGRO_WINDOWS TRUE)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(ALLEGRO_UNIX TRUE)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
@@ -238,7 +239,7 @@ set(ALLEGRO_NO_ASM 1)
 
 set(PLATFORM_SOURCES)
 
-if(ALLEGRO_MSVC)
+if(ALLEGRO_WINDOWS)
    list(APPEND PLATFORM_SOURCES ${ALLEGRO_SRC_WIN_FILES})
 else()
     # non-windows platforms are use unixy/posix file handling and have no gdi

--- a/libsrc/allegro/include/allegro/internal/alconfig.h
+++ b/libsrc/allegro/include/allegro/internal/alconfig.h
@@ -55,12 +55,15 @@
    #define ALLEGRO_UNIX
 #elif defined(__FreeBSD__)
     #define ALLEGRO_UNIX
+#elif defined(__MINGW32__)
+    #define ALLEGRO_MINGW
+    #define ALLEGRO_WINDOWS
 #endif
 
 
 /* include platform-specific stuff */
 #ifndef SCAN_EXPORT
-   #if defined ALLEGRO_MSVC
+   #if defined ALLEGRO_MSVC || defined(ALLEGRO_MINGW)
       #include "allegro/platform/almsvc.h"
    #elif defined ALLEGRO_MACOSX
       #include "allegro/platform/alosxcfg.h"

--- a/libsrc/allegro/include/allegro/platform/almsvc.h
+++ b/libsrc/allegro/include/allegro/platform/almsvc.h
@@ -71,7 +71,7 @@
 #define INLINE       __inline
 
 #define LONG_LONG    __int64
-#if (_MSC_VER >= 1600)
+#if defined(ALLEGRO_MINGW) || (_MSC_VER >= 1600)
    #define ALLEGRO_HAVE_STDINT_H
 #else
    #define int64_t      signed __int64


### PR DESCRIPTION
This is to be able to build on Windows by using MinGW instead of MSVC. Of course, we will forever use MSVC because of the Editor (and C++/CLR), but still, wanted to investigate possibilities - just to safeguard.

Here is a 64-bit build through MinGW: [ags.zip](https://github.com/adventuregamestudio/ags/files/13062121/ags.zip)
_Known issue:_ SDL2 is statically linked and SDL2 statically linked has some issue with fullscreen on Windows I couldn't yet figure it out (this happens in MSVC too, so it's not mingw specific)

There is no rush here, so this can be reviewed with calm.