### PR TITLE
AGS 4: Remove built-in Score functionality

### DIFF
--- a/Common/ac/gamesetupstruct.cpp
+++ b/Common/ac/gamesetupstruct.cpp
@@ -22,7 +22,6 @@ using namespace AGS::Common;
 GameSetupStruct::GameSetupStruct()
     : filever(0)
     , roomCount(0)
-    , scoreClipID(0)
 {
     memset(invinfo, 0, sizeof(invinfo));
     memset(lipSyncFrameLetters, 0, sizeof(lipSyncFrameLetters));
@@ -235,7 +234,7 @@ HGameFileError GameSetupStruct::read_audio(Common::Stream *in, GameDataVersion d
     audioClips.resize(audioclip_count);
     ReadAudioClips(in, audioclip_count);
 
-    scoreClipID = in->ReadInt32();
+    in->ReadInt32(); // [DEPRECATED]
     return HGameFileError::None();
 }
 

--- a/Common/ac/gamesetupstruct.h
+++ b/Common/ac/gamesetupstruct.h
@@ -80,9 +80,6 @@ struct GameSetupStruct : public GameSetupStructBase
     std::vector<Common::String> roomNames;
     std::vector<ScriptAudioClip> audioClips;
     std::vector<AudioClipType> audioClipTypes;
-    // A clip to play when player gains score in game
-    // TODO: find out why OPT_SCORESOUND option cannot be used to store this in >=3.2 games
-    int               scoreClipID;
     // number of accessible game audio channels (the ones under direct user control)
     int               numGameChannels = 0;
     // backward-compatible channel limit that may be exported to script and reserved by audiotypes

--- a/Common/ac/gamesetupstructbase.cpp
+++ b/Common/ac/gamesetupstructbase.cpp
@@ -25,7 +25,6 @@ GameSetupStructBase::GameSetupStructBase()
     : numviews(0)
     , numcharacters(0)
     , playercharacter(-1)
-    , totalscore(0)
     , numinvitems(0)
     , numdialog(0)
     , numdlgmessage(0)
@@ -86,7 +85,7 @@ void GameSetupStructBase::ReadFromFile(Stream *in, GameDataVersion game_ver, Ser
     numviews = in->ReadInt32();
     numcharacters = in->ReadInt32();
     playercharacter = in->ReadInt32();
-    totalscore = in->ReadInt32();
+    in->ReadInt32(); // [DEPRECATED]
     numinvitems = in->ReadInt16();
     in->ReadInt16(); // alignment padding to int32
     numdialog = in->ReadInt32();
@@ -132,7 +131,7 @@ void GameSetupStructBase::WriteToFile(Stream *out, const SerializeInfo &info) co
     out->WriteInt32(numviews);
     out->WriteInt32(numcharacters);
     out->WriteInt32(playercharacter);
-    out->WriteInt32(totalscore);
+    out->WriteInt32(0); // [DEPRECATED]
     out->WriteInt16(numinvitems);
     out->WriteInt16(0); // alignment padding to int32
     out->WriteInt32(numdialog);

--- a/Common/ac/gamesetupstructbase.h
+++ b/Common/ac/gamesetupstructbase.h
@@ -49,7 +49,6 @@ struct GameSetupStructBase
     int               numviews;
     int               numcharacters;
     int               playercharacter;
-    int               totalscore;
     short             numinvitems;
     int               numdialog, numdlgmessage;
     int               numfonts;

--- a/Common/ac/gamestructdefines.h
+++ b/Common/ac/gamestructdefines.h
@@ -31,7 +31,7 @@
 
 // General game options
 #define OPT_DEBUGMODE       0
-#define OPT_SCORESOUND      1
+#define OPT_OBSOLETE_SCORESOUND     1 // [DEPRECATED]
 #define OPT_WALKONLOOK      2
 #define OPT_DIALOGIFACE     3
 #define OPT_ANTIGLIDE       4

--- a/Common/game/main_game_file.cpp
+++ b/Common/game/main_game_file.cpp
@@ -380,11 +380,6 @@ void UpgradeMouseCursors(GameSetupStruct &game, GameDataVersion data_ver)
 {
 }
 
-// Adjusts score clip id, depending on game data version
-void RemapLegacySoundNums(GameSetupStruct &game, std::vector<ViewStruct> &views, GameDataVersion data_ver)
-{
-}
-
 void FixupSaveDirectory(GameSetupStruct &game)
 {
     // If the save game folder was not specified by game author, create one of

--- a/Common/game/main_game_file.h
+++ b/Common/game/main_game_file.h
@@ -149,8 +149,6 @@ void               PreReadGameData(GameSetupStruct &game, Stream *in, GameDataVe
 HGameFileError     UpdateGameData(LoadedGameEntities &ents, GameDataVersion data_ver);
 // Ensures that the game saves directory path is valid
 void               FixupSaveDirectory(GameSetupStruct &game);
-// Maps legacy sound numbers to real audio clips
-void               RemapLegacySoundNums(GameSetupStruct &game, std::vector<ViewStruct> &views, GameDataVersion data_ver);
 
 } // namespace Common
 } // namespace AGS

--- a/Common/gui/guidefines.h
+++ b/Common/gui/guidefines.h
@@ -119,11 +119,7 @@ enum GUILabelMacro
     kLabelMacro_None        = 0,
     kLabelMacro_Gamename    = 0x01,
     kLabelMacro_Overhotspot = 0x02,
-    kLabelMacro_Score       = 0x04,
-    kLabelMacro_ScoreText   = 0x08,
-    kLabelMacro_TotalScore  = 0x10,
 
-    kLabelMacro_AllScore    = kLabelMacro_Score | kLabelMacro_ScoreText,
     kLabelMacro_All         = 0xFFFF
 };
 

--- a/Common/gui/guilabel.cpp
+++ b/Common/gui/guilabel.cpp
@@ -52,7 +52,7 @@ Rect GUILabel::CalcGraphicRect(bool clipped)
     // TODO: need to find a way to text position, or there'll be some repetition
     // have to precache text and size on some events:
     // - translation change
-    // - macro value change (score, overhotspot etc)
+    // - macro value change (overhotspot etc)
     Rect rc = RectWH(0, 0, _width, _height);
     if (PrepareTextToDraw() == 0)
         return rc;

--- a/Common/gui/guilistbox.cpp
+++ b/Common/gui/guilistbox.cpp
@@ -85,7 +85,7 @@ Rect GUIListBox::CalcGraphicRect(bool clipped)
     // TODO: need to find a way to text position, or there'll be some repetition
     // have to precache text and size on some events:
     // - translation change
-    // - macro value change (score, overhotspot etc)
+    // - macro value change (overhotspot etc)
     Rect rc = RectWH(0, 0, _width, _height);
     UpdateMetrics();
     const int width = _width - 1;

--- a/Common/gui/guimain.cpp
+++ b/Common/gui/guimain.cpp
@@ -881,12 +881,6 @@ GUILabelMacro FindLabelMacros(const String &text)
                     macro_flags |= kLabelMacro_Gamename;
                 else if (ags_strnicmp(macro_at, "overhotspot", macro_len) == 0)
                     macro_flags |= kLabelMacro_Overhotspot;
-                else if (ags_strnicmp(macro_at, "score", macro_len) == 0)
-                    macro_flags |= kLabelMacro_Score;
-                else if (ags_strnicmp(macro_at, "scoretext", macro_len) == 0)
-                    macro_flags |= kLabelMacro_ScoreText;
-                else if (ags_strnicmp(macro_at, "totalscore", macro_len) == 0)
-                    macro_flags |= kLabelMacro_TotalScore;
                 macro_at = nullptr;
             }
         }

--- a/Editor/AGS.Editor/DataFileWriter.cs
+++ b/Editor/AGS.Editor/DataFileWriter.cs
@@ -561,7 +561,7 @@ namespace AGS.Editor
             writer.Write(game.ViewCount);
             writer.Write(game.Characters.Count);
             writer.Write(game.PlayerCharacter.ID);
-            writer.Write(game.Settings.MaximumScore);
+            writer.Write(0); // [DEPRECATED]
             writer.Write((short)(game.InventoryItems.Count + 1));
             writer.Write(new byte[2]); // alignment padding
             writer.Write(game.Dialogs.Count);
@@ -1680,7 +1680,7 @@ namespace AGS.Editor
                 writer.Write(new byte[2]); // struct alignment padding
                 writer.Write(0); // reserved
             }
-            writer.Write(game.GetAudioArrayIDFromFixedIndex(game.Settings.PlaySoundOnScore));
+            writer.Write(0); // [DEPRECATED]
             if (game.Settings.DebugMode)
             {
                 writer.Write(game.Rooms.Count);

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -878,8 +878,6 @@ import int  GetTextHeight(const string text, FontType, int width);
 import int  GetFontHeight(FontType);
 /// Gets the default step between two lines of text for the specified font
 import int  GetFontLineSpacing(FontType);
-/// Adds to the player's score and plays the score sound, if set.
-import void GiveScore(int points);
 /// Refreshes the on-screen inventory display.
 import void UpdateInventory();
 /// From within dialog_request, tells AGS not to return to the dialog after this function ends.
@@ -1193,7 +1191,7 @@ enum EventType {
   eEventLeaveRoom = 1,
   eEventEnterRoomBeforeFadein = 2,
   // 3 is reserved by an obsolete "death" event
-  eEventGotScore = 4,
+  // 4 is reserved by an obsolete "got score" event
   eEventGUIMouseDown = 5,
   eEventGUIMouseUp = 6,
   eEventAddInventory = 7,
@@ -2335,7 +2333,7 @@ builtin struct Game {
 };
 
 builtin struct GameState {
-  int  score;
+  readonly int  reserved__11; // $AUTOCOMPLETEIGNORE$
   int  used_mode;
   int  disabled_user_interface;
   int  gscript_timer;
@@ -2353,7 +2351,7 @@ builtin struct GameState {
   int  swap_portrait;
   int  speech_text_gui;
   int  following_room_timer;
-  int  total_score;
+  int  reserved__12;  // $AUTOCOMPLETEIGNORE$
   int  skip_display;
   int  no_multiloop_repeat;
   int  roomscript_finished;
@@ -2371,7 +2369,7 @@ builtin struct GameState {
   readonly int  room_width;
   readonly int  room_height;
   int  game_speed_modifier;  // $AUTOCOMPLETEIGNORE$
-  int  score_sound;
+  int  reserved__13;  // $AUTOCOMPLETEIGNORE$
   int  previous_game_data;
   readonly readonly int unused__041; // $AUTOCOMPLETEIGNORE$
   int  dialog_options_x;

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -410,7 +410,6 @@ namespace AGS.Editor
                     audioIDToIndex.Add(clip.ID, clip.Index);
                 }
 
-                game.Settings.PlaySoundOnScore = RemapAudioClipIDToFixedIndex(game.Settings.PlaySoundOnScore, audioIDToIndex);
                 foreach (Types.View view in game.RootViewFolder.AllItemsFlat)
                 {
                     foreach (Types.ViewLoop loop in view.Loops)

--- a/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
+++ b/Editor/AGS.Editor/Utils/DialogScriptConverter.cs
@@ -252,10 +252,6 @@ namespace AGS.Editor
                     convertedScriptLine = ProcessSingleIntParameterCommand(dlgScriptCommand, "new-room", "player.ChangeRoom({0}); return RUN_DIALOG_STOP_DIALOG;") + "}";
                     _currentlyInsideCodeArea = false;
                 }
-                else if (dlgScriptCommand.StartsWith("give-score"))
-                {
-                    convertedScriptLine = ProcessSingleIntParameterCommand(dlgScriptCommand, "give-score", "GiveScore({0});");
-                }
                 else
                 {
                     RaiseDialogScriptCompileError("Unknown command: " + dlgScriptCommand + ". The command may require parameters which you have not supplied.");

--- a/Editor/AGS.Native/agsnative.cpp
+++ b/Editor/AGS.Native/agsnative.cpp
@@ -2360,10 +2360,8 @@ Game^ import_compiled_game_dta(const AGSString &filename)
 	game->Settings->UseGlobalSpeechAnimationDelay = true; // this was always on in pre-3.0 games
 	game->Settings->HandleInvClicksInScript = (thisgame.options[OPT_HANDLEINVCLICKS] != 0);
 	game->Settings->InventoryCursors = !thisgame.options[OPT_FIXEDINVCURSOR];
-	game->Settings->MaximumScore = thisgame.totalscore;
     game->Settings->NumberDialogOptions = (thisgame.options[OPT_DIALOGNUMBERED] != 0) ? DialogOptionsNumbering::Normal : DialogOptionsNumbering::KeyShortcutsOnly;
 	game->Settings->PixelPerfect = (thisgame.options[OPT_PIXPERFECT] != 0);
-	game->Settings->PlaySoundOnScore = thisgame.options[OPT_SCORESOUND];
 	game->Settings->RoomTransition = (RoomTransitionStyle)thisgame.options[OPT_FADETYPE];
 	game->Settings->SaveScreenshots = (thisgame.options[OPT_SAVESCREENSHOT] != 0);
 	game->Settings->SkipSpeech = (SkipSpeechStyle)thisgame.options[OPT_NOSKIPTEXT];

--- a/Editor/AGS.Types/Settings.cs
+++ b/Editor/AGS.Types/Settings.cs
@@ -75,7 +75,6 @@ namespace AGS.Types
         private ScriptAPIVersion _scriptCompatLevelReal = Utilities.GetActualAPI(ScriptAPIVersion.Highest);
         private bool _oldKeyHandling = false;
         private bool _scaleCharacterSpriteOffsets = true;
-        private int _playSoundOnScore = -1;
         private int _dialogOptionsGUI = 0;
         private int _dialogOptionsGap = 0;
         private int _dialogBulletImage = 0;
@@ -97,7 +96,6 @@ namespace AGS.Types
         private bool _backwardsText = false;
         private int _uniqueID;
 		private Guid _guid;
-        private int _totalScore = 0;
         private bool _runGameLoopsWhileDialogOptionsDisplayed = false;
         private InventoryHotspotMarker _inventoryHotspotMarker = new InventoryHotspotMarker();
         private int _defRoomMaskResolution = 1;
@@ -653,16 +651,9 @@ namespace AGS.Types
             set { _oldKeyHandling = value; }
         }
 
-        [DisplayName("Play sound when the player gets points")]
-        [Description("This sound number will be played whenever the player scores points (0 to disable)")]
-        [DefaultValue(AudioClip.FixedIndexNoValue)]
-        [Category("Sound")]
-        [TypeConverter(typeof(AudioClipTypeConverter))]
-        public int PlaySoundOnScore
-        {
-            get { return _playSoundOnScore; }
-            set { _playSoundOnScore = value; }
-        }
+        [Obsolete]
+        [Browsable(false)]
+        public int PlaySoundOnScore { get; }
 
         [Obsolete]
         [Browsable(false)]
@@ -882,14 +873,9 @@ namespace AGS.Types
             set { _backwardsText = value; }
         }
 
-        [DisplayName("Maximum possible score")]
-        [Description("The maximum score that the player can achieve (displayed by @TOTALSCORE@ on GUI labels)")]
-        [Category("(Basic properties)")]
-        public int MaximumScore
-        {
-            get { return _totalScore; }
-            set { _totalScore = value; }
-        }
+        [Obsolete]
+        [Browsable(false)]
+        public int MaximumScore { get; }
 
         [DisplayName("Default mask resolution")]
         [Description("What resolution do room region masks have relative to the room size")]
@@ -1065,7 +1051,6 @@ namespace AGS.Types
 
         public void FromXml(XmlNode node)
         {
-            _totalScore = 0;
 			_guid = Guid.Empty;
 			_description = string.Empty;
 			_releaseDate = DateTime.Now;

--- a/Engine/ac/dynobj/scriptgame.cpp
+++ b/Engine/ac/dynobj/scriptgame.cpp
@@ -33,7 +33,7 @@ int32_t CCScriptGame::ReadInt32(void *address, intptr_t offset)
 
     switch (index)
     {
-    case 0: return play.score;
+    case 0: return 0;// [DEPRECATED]
     case 1: return play.usedmode;
     case 2: return play.disabled_user_interface;
     case 3: return play.gscript_timer;
@@ -54,7 +54,7 @@ int32_t CCScriptGame::ReadInt32(void *address, intptr_t offset)
     case 67: return play.swap_portrait_side;
     case 68: return play.speech_textwindow_gui;
     case 69: return play.follow_change_room_timer;
-    case 70: return play.totalscore;
+    case 70: return 0;// [DEPRECATED]
     case 71: return play.skip_display;
     case 72: return play.no_multiloop_repeat;
     case 73: return play.roomscript_finished;
@@ -72,7 +72,7 @@ int32_t CCScriptGame::ReadInt32(void *address, intptr_t offset)
     case 85: return play.room_width;
     case 86: return play.room_height;
     case 87: return play.game_speed_modifier;
-    case 88: return play.score_sound;
+    case 88: return 0;// [DEPRECATED]
     case 89: return play.takeover_data;
     case 90: return 0;// [DEPRECATED]
     case 91: return play.dialog_options_x;
@@ -127,7 +127,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
 
     switch (index)
     {
-    case 0:  play.score = val; break;
+    case 0:  break; // [DEPRECATED]
     case 1:  play.usedmode = val; break;
     case 2:  play.disabled_user_interface = val; break;
     case 3:  play.gscript_timer = val; break;
@@ -148,7 +148,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
     case 67:  play.swap_portrait_side = val; break;
     case 68:  play.speech_textwindow_gui = val; break;
     case 69:  play.follow_change_room_timer = val; break;
-    case 70:  play.totalscore = val; break;
+    case 70:  break; // [DEPRECATED]
     case 71:  play.skip_display = val; break;
     case 72:  play.no_multiloop_repeat = val; break;
     case 73:  play.roomscript_finished = val; break;
@@ -168,7 +168,7 @@ void CCScriptGame::WriteInt32(void *address, intptr_t offset, int32_t val)
         debug_script_warn("ScriptGame: attempt to write in readonly variable at offset %d, value %d", offset, val);
         break;
     case 87:  play.game_speed_modifier = val; break;
-    case 88:  play.score_sound = val; break;
+    case 88:  break; // [DEPRECATED]
     case 89:  play.takeover_data = val; break;
     case 90:  break; // [DEPRECATED]
     case 91:  play.dialog_options_x = val; break;

--- a/Engine/ac/event.h
+++ b/Engine/ac/event.h
@@ -25,7 +25,7 @@
 #define GE_LEAVE_ROOM    1
 #define GE_ENTER_ROOM    2
 // #define GE_MAN_DIES 3 // ancient obsolete event
-#define GE_GOT_SCORE     4
+// #define GE_GOT_SCORE 4 // deprecated
 #define GE_GUI_MOUSEDOWN 5
 #define GE_GUI_MOUSEUP   6
 #define GE_ADD_INV       7

--- a/Engine/ac/gamestate.cpp
+++ b/Engine/ac/gamestate.cpp
@@ -442,7 +442,7 @@ bool GameState::ShouldPlayVoiceSpeech() const
 
 void GameState::ReadFromSavegame(Common::Stream *in, GameDataVersion data_ver, GameStateSvgVersion svg_ver, RestoredData &r_data)
 {
-    score = in->ReadInt32();
+    in->ReadInt32(); // [DEPRECATED]
     usedmode = in->ReadInt32();
     disabled_user_interface = in->ReadInt32();
     gscript_timer = in->ReadInt32();
@@ -463,7 +463,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameDataVersion data_ver, G
     swap_portrait_side = in->ReadInt32();
     speech_textwindow_gui = in->ReadInt32();
     follow_change_room_timer = in->ReadInt32();
-    totalscore = in->ReadInt32();
+    in->ReadInt32(); // [DEPRECATED]
     skip_display = in->ReadInt32();
     no_multiloop_repeat = in->ReadInt32();
     roomscript_finished = in->ReadInt32();
@@ -481,7 +481,7 @@ void GameState::ReadFromSavegame(Common::Stream *in, GameDataVersion data_ver, G
     room_width = in->ReadInt32();
     room_height = in->ReadInt32();
     game_speed_modifier = in->ReadInt32();
-    score_sound = in->ReadInt32();
+    in->ReadInt32(); // [DEPRECATED]
     takeover_data = in->ReadInt32();
     replay_hotkey_unused = in->ReadInt32();
     dialog_options_x = in->ReadInt32();
@@ -641,7 +641,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
 {
     // NOTE: following parameters are never saved:
     // recording, playback, gamestep, screen_is_faded_out, room_changes
-    out->WriteInt32(score);
+    out->WriteInt32(0); // [DEPRECATED]
     out->WriteInt32(usedmode);
     out->WriteInt32(disabled_user_interface);
     out->WriteInt32(gscript_timer);
@@ -662,7 +662,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32(swap_portrait_side);
     out->WriteInt32(speech_textwindow_gui);
     out->WriteInt32(follow_change_room_timer);
-    out->WriteInt32(totalscore);
+    out->WriteInt32(0); // [DEPRECATED]
     out->WriteInt32(skip_display);
     out->WriteInt32(no_multiloop_repeat);
     out->WriteInt32(roomscript_finished);
@@ -680,7 +680,7 @@ void GameState::WriteForSavegame(Common::Stream *out) const
     out->WriteInt32(room_width);
     out->WriteInt32(room_height);
     out->WriteInt32(game_speed_modifier);
-    out->WriteInt32(score_sound);
+    out->WriteInt32(0);// [DEPRECATED]
     out->WriteInt32(takeover_data);
     out->WriteInt32(replay_hotkey_unused);         // StartRecording: not supported
     out->WriteInt32(dialog_options_x);

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -65,7 +65,6 @@ struct GameState {
     static const int LEGACY_MAXGSVALUES = 500;
     static const int LEGACY_MAXGLOBALSTRINGS = 51;
 
-    int  score = 0;                 // player's current score
     int  usedmode = 0;              // set by ProcessClick to last cursor mode used
     int  disabled_user_interface = 0;  // >0 while in cutscene/etc
     int  gscript_timer = 0;         // obsolete
@@ -80,7 +79,6 @@ struct GameState {
     int  swap_portrait_side = 0;         // sierra-style speech swap sides
     int  speech_textwindow_gui = 0;      // textwindow used for sierra-style speech
     int  follow_change_room_timer = 0;   // delay before moving following characters into new room
-    int  totalscore = 0;            // maximum possible score
     int  skip_display = 0;          // how the user can skip normal Display windows
     int  no_multiloop_repeat = 0;   // for backwards compatibility
     int  roomscript_finished = 0;   // on_call finished in room
@@ -97,7 +95,6 @@ struct GameState {
     int  room_width = 0;            // width of current room
     int  room_height = 0;           // height of current room
     int  game_speed_modifier = 0;
-    int  score_sound = 0;
     int  takeover_data = 0;         // value passed to RunAGSGame in previous game
     int  replay_hotkey_unused = 0;  // (UNUSED!) StartRecording: not supported
     int  dialog_options_x = 0;

--- a/Engine/ac/global_api.cpp
+++ b/Engine/ac/global_api.cpp
@@ -528,12 +528,6 @@ RuntimeScriptValue Sc_GetDrawingSurfaceForWalkbehind(const RuntimeScriptValue *p
     API_SCALL_OBJAUTO(ScriptDrawingSurface, GetDrawingSurfaceForWalkbehind);
 }
 
-// void (int amnt) 
-RuntimeScriptValue Sc_GiveScore(const RuntimeScriptValue *params, int32_t param_count)
-{
-    API_SCALL_VOID_PINT(GiveScore);
-}
-
 // int (int roomnum)
 RuntimeScriptValue Sc_HasPlayerBeenInRoom(const RuntimeScriptValue *params, int32_t param_count)
 {
@@ -1264,7 +1258,6 @@ void RegisterGlobalAPI()
         { "GetWalkableAreaAtScreen",  API_FN_PAIR(GetWalkableAreaAtScreen) },
         { "GetDrawingSurfaceForWalkableArea", API_FN_PAIR(GetDrawingSurfaceForWalkableArea) },
         { "GetDrawingSurfaceForWalkbehind", API_FN_PAIR(GetDrawingSurfaceForWalkbehind) },
-        { "GiveScore",                API_FN_PAIR(GiveScore) },
         { "HasPlayerBeenInRoom",      API_FN_PAIR(HasPlayerBeenInRoom) },
         { "InputBox",                 API_FN_PAIR(sc_inputbox) },
         { "InterfaceOff",             API_FN_PAIR(InterfaceOff) },

--- a/Engine/ac/global_game.cpp
+++ b/Engine/ac/global_game.cpp
@@ -88,17 +88,6 @@ void AbortGame()
     cancel_all_scripts();
 }
 
-void GiveScore(int amnt) 
-{
-    GUI::MarkSpecialLabelsForUpdate(kLabelMacro_AllScore);
-    play.score += amnt;
-
-    if ((amnt > 0) && (play.score_sound >= 0))
-        play_audio_clip_by_index(play.score_sound);
-
-    run_on_event (GE_GOT_SCORE, RuntimeScriptValue().SetInt32(amnt));
-}
-
 void restart_game() {
     can_run_delayed_command();
     if (inside_script) {

--- a/Engine/ac/global_game.h
+++ b/Engine/ac/global_game.h
@@ -40,7 +40,6 @@ struct SaveListItem
 
 // Notify the running game that the engine requested immediate stop
 void AbortGame();
-void GiveScore(int amnt);
 void restart_game();
 void RestoreGameSlot(int slnum);
 void DeleteSaveSlot (int slnum);

--- a/Engine/ac/gui.cpp
+++ b/Engine/ac/gui.cpp
@@ -416,7 +416,7 @@ void replace_macro_tokens(const char *text, String &fixed_text) {
                     curptr++;
                     break;
                 }
-                // unterminated macro (eg. "@SCORETEXT"), so abort
+                // unterminated macro (eg. "@OVERHOTSPOT"), so abort
                 if (curptr[0] == 0)
                     break;
                 macroname[idd]=curptr[0];
@@ -424,13 +424,7 @@ void replace_macro_tokens(const char *text, String &fixed_text) {
             }
             macroname[idd]=0; 
             tempo[0]=0;
-            if (ags_stricmp(macroname,"score")==0)
-                snprintf(tempo, sizeof(tempo), "%d",play.score);
-            else if (ags_stricmp(macroname,"totalscore")==0)
-                snprintf(tempo, sizeof(tempo), "%d",MAXSCORE);
-            else if (ags_stricmp(macroname,"scoretext")==0)
-                snprintf(tempo, sizeof(tempo), "%d of %d",play.score,MAXSCORE);
-            else if (ags_stricmp(macroname,"gamename")==0)
+            if (ags_stricmp(macroname,"gamename")==0)
                 snprintf(tempo, sizeof(tempo), "%s", play.game_name);
             else if (ags_stricmp(macroname,"overhotspot")==0) {
                 // While game is in Wait mode, no overhotspot text

--- a/Engine/ac/runtime_defines.h
+++ b/Engine/ac/runtime_defines.h
@@ -72,10 +72,6 @@ enum LegacyScriptAlignment
 #define SCR_NO_VALUE   31998
 #define SCR_COLOR_TRANSPARENT -1
 
-
-#define TXT_SCOREBAR        29
-#define MAXSCORE play.totalscore
-
 #define FONT_STATUSBAR  0
 #define FONT_NORMAL     play.normal_font
 //#define FONT_SPEECHBACK 1

--- a/Engine/game/game_init.cpp
+++ b/Engine/game/game_init.cpp
@@ -452,7 +452,6 @@ HGameInitError InitGameState(const LoadedGameEntities &ents, GameDataVersion dat
         svg_suffix.Format(".%s", game.saveGameFileExtension);
     set_save_game_suffix(svg_suffix);
 
-    play.score_sound = game.scoreClipID;
     play.fade_effect = game.options[OPT_FADETYPE];
 
     //

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -419,9 +419,6 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
         play.new_music_queue[i].cachedClip = nullptr;
     }
 
-    // Remap old sound nums in case we restored a save having a different list of audio clips
-    RemapLegacySoundNums(game, views, loaded_game_file_version);
-
     // Restore Overlay bitmaps (older save format, which stored them along with overlays)
     auto &overs = get_overlays();
     for (auto &over_im : r_data.OverlayImages)

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -681,7 +681,6 @@ void engine_init_game_settings()
 
     //
     // TODO: following big initialization sequence could be in GameState ctor
-    play.score=0;
     play.sierra_inv_color=7;
     // copy the value set by the editor
     if (game.options[OPT_GLOBALTALKANIMSPD] >= 0)
@@ -753,7 +752,6 @@ void engine_init_game_settings()
     play.no_multiloop_repeat = 0;
     play.in_cutscene = 0;
     play.fast_forward = 0;
-    play.totalscore = game.totalscore;
     play.roomscript_finished = 0;
     play.no_textbg_when_voice = 0;
     play.max_dialogoption_width = 180;


### PR DESCRIPTION
This is a suggestion, but I think that it goes in line with the general idea of cutting built-in functionality that is
* may be easily implemented in game script;
* has narrow use in contemporary games.

This PR completely removes Score functionality, which includes:
- Total score / current score variables;
- GiveScore script command, and associated sound setting;
- "give-score" command in dialog script;
- `@SCORE@` and related label macros.

