### PR TITLE
Common: use Android asset compatible methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ bin/
 gen/
 out/
 
+# ags game in Android single game project used for testing
+Android/mygame/app/src/main/assets
+
 ## end Android related
 
 ## Xcode Build generated

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ out/
 # ags game in Android single game project used for testing
 Android/mygame/app/src/main/assets
 
+# Ignore prebuilt libraries
+Android/library/runtime/libs/
+
 ## end Android related
 
 ## Xcode Build generated

--- a/Common/util/file.cpp
+++ b/Common/util/file.cpp
@@ -284,8 +284,8 @@ String File::FindFileCI(const String &base_dir, const String &file_name,
         return {}; // fail, cannot be handled
 
     // First try exact match
-    if ((is_dir && ags_directory_exists(test.GetCStr())) ||
-        (!is_dir && ags_file_exists(test.GetCStr())))
+    if ((is_dir && File::IsDirectory(test.GetCStr())) ||
+        (!is_dir && File::IsFile(test.GetCStr())))
         return test; // success
 
 #if !defined (AGS_CASE_SENSITIVE_FILESYSTEM)


### PR DESCRIPTION
fixes Android error reported here https://www.adventuregamestudio.co.uk/forums/advanced-technical-forum/ogg-audio-makes-the-game-freeze-android/msg636658856/#msg636658856

> In other news, I seem to have trouble building for Android on this new version. I get the following error every time I try to launch the .apk on my phone :
> "AGSNative
> Loading game failed with error:
> Main game file not found or could not be opened.
> Filename: ac2game.dta..
> 
> The game files may be incomplete, corrupt or from unsupported version of AGS."
> 
> Until I manage to fix that, I won't be able to verify that the issue is fixed in the 3.6.1....

The issue is the previously used methods can't test for file existence inside the Android asset file.