### PR TITLE
Fix: don't compress `.ags` and `.vox` in android assets

### DIFF
--- a/Android/agsplayer/build.gradle
+++ b/Android/agsplayer/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Android/library/runtime/build.gradle
+++ b/Android/library/runtime/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:8.1.1"
+        classpath "com.android.tools.build:gradle:8.1.3"
     }
 }
 

--- a/Android/mygame/app/build.gradle
+++ b/Android/mygame/app/build.gradle
@@ -26,6 +26,10 @@ android {
         versionName projectProperties['versionName']
     }
 
+    androidResources {
+        noCompress = ['ags', 'vox']
+    }
+
     signingConfigs {
         release {
             storeFile file(keyStoreProperties['storeFile'])

--- a/Android/mygame/build.gradle
+++ b/Android/mygame/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -199,7 +199,7 @@ if(ANDROID)
 endif()
 
 # NOTE: You can optionally create case sensitive filesystems on Macos and Windows now.
-if (LINUX)
+if (LINUX OR ANDROID)
     target_compile_definitions(common PRIVATE AGS_CASE_SENSITIVE_FILESYSTEM)
 endif()
 

--- a/Common/util/android_file.cpp
+++ b/Common/util/android_file.cpp
@@ -107,7 +107,8 @@ AndroidADir::AndroidADir(const String &dirname)
 {
     AAssetManager* mgr = GetAAssetManager();
     if(mgr == nullptr) {_dir = nullptr; return; }
-    _dir = AAssetManager_openDir(mgr, dirname.GetCStr());
+    String assetDirName = Path::GetPathInForeignAsset(dirname);
+    _dir = AAssetManager_openDir(mgr, assetDirName.GetCStr());
 }
 
 AndroidADir::~AndroidADir()


### PR DESCRIPTION
This is made on top of #2214 to make it easy to test. What it does is it specifically disable the additional compression Android does, only for `.ags` and `.vox` packages.

Added some extra things

- Added also fix #2219
- Defined Case Sensitive Filesystem macro in Android build
- Upgraded gradle Android plugin just to keep it updated.

To-do: check if unpacking an .ags and .vox package in the asset dir makes it run faster - these will still be compressed, but seeking to the file should be faster without the package indirection.