### PR TITLE
Editor: recreate GeneralSettings and DefaultSetup documents when a new game is opened

### DIFF
--- a/Editor/AGS.Editor/ApplicationController.cs
+++ b/Editor/AGS.Editor/ApplicationController.cs
@@ -88,10 +88,8 @@ namespace AGS.Editor
             DataFileWriter.TextEncoding = _agsEditor.CurrentGame.TextEncoding;
         }
 
-        private void _events_GamePostLoad()
+        private void _events_GamePostLoad(Game game)
         {
-            Game game = Factory.AGSEditor.CurrentGame;
-
             // TODO: this may be noticably slow especially for sprites. Display some kind of
             // progress window to notify user.
             // Convert absolute paths to relative paths. This is an automatic fixup from when the

--- a/Editor/AGS.Editor/Components/DefaultSetupComponent.cs
+++ b/Editor/AGS.Editor/Components/DefaultSetupComponent.cs
@@ -14,10 +14,20 @@ namespace AGS.Editor.Components
         public DefaultSetupComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _settingsPane = new DefaultRuntimeSetupPane();
-            _document = new ContentDocument(_settingsPane, "Default Setup", this, ICON_KEY);
+            RecreateDocument();
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("iconsett.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, ComponentID, "Default Setup", ICON_KEY);
+        }
+
+        private void RecreateDocument()
+        {
+            if (_document != null)
+            {
+                _guiController.RemovePaneIfExists(_document);
+                _document.Dispose();
+            }
+            _settingsPane = new DefaultRuntimeSetupPane();
+            _document = new ContentDocument(_settingsPane, "Default Setup", this, ICON_KEY);
         }
 
         public override string ComponentID
@@ -38,7 +48,7 @@ namespace AGS.Editor.Components
 
         public override void RefreshDataFromGame()
         {
-            _settingsPane.RefreshData();
+            RecreateDocument();
         }
     }
 }

--- a/Editor/AGS.Editor/Components/ScriptsComponent.cs
+++ b/Editor/AGS.Editor/Components/ScriptsComponent.cs
@@ -654,9 +654,8 @@ namespace AGS.Editor.Components
             return null;
         }
 
-        private void Events_GamePostLoad()
+        private void Events_GamePostLoad(Game game)
         {
-            var game = _agsEditor.CurrentGame;
             if (game.SavedXmlVersionIndex >= 3060110)
                 return; // no upgrade necessary
 
@@ -664,7 +663,7 @@ namespace AGS.Editor.Components
             // emulate legacy behavior where its call was hardcoded in the engine.
             if (game.SavedXmlVersionIndex < 3060110)
             {
-                Script script = AGSEditor.Instance.CurrentGame.RootScriptFolder.GetScriptByFileName(Script.GLOBAL_SCRIPT_FILE_NAME, true);
+                Script script = game.RootScriptFolder.GetScriptByFileName(Script.GLOBAL_SCRIPT_FILE_NAME, true);
                 if (script != null)
                 {
                     script.Text = 

--- a/Editor/AGS.Editor/Components/SettingsComponent.cs
+++ b/Editor/AGS.Editor/Components/SettingsComponent.cs
@@ -18,10 +18,20 @@ namespace AGS.Editor.Components
         public SettingsComponent(GUIController guiController, AGSEditor agsEditor)
             : base(guiController, agsEditor)
         {
-            _settingsPane = new GeneralSettingsPane();
-            _document = new ContentDocument(_settingsPane, "General Settings", this, ICON_KEY);
+            RecreateDocument();
             _guiController.RegisterIcon(ICON_KEY, Resources.ResourceManager.GetIcon("iconsett.ico"));
             _guiController.ProjectTree.AddTreeRoot(this, "GeneralSettings", "General Settings", ICON_KEY);
+        }
+
+        private void RecreateDocument()
+        {
+            if (_document != null)
+            {
+                _guiController.RemovePaneIfExists(_document);
+                _document.Dispose();
+            }
+            _settingsPane = new GeneralSettingsPane();
+            _document = new ContentDocument(_settingsPane, "General Settings", this, ICON_KEY);
         }
 
         public override string ComponentID
@@ -37,13 +47,12 @@ namespace AGS.Editor.Components
 
         public override void RefreshDataFromGame()
         {
-            _settingsPane.RefreshData();
+            RecreateDocument();
 
 			if (Factory.AGSEditor.Settings.StartupPane == StartupPane.GeneralSettings)
 			{
 				_guiController.AddOrShowPane(_document);
 			}
         }
-
     }
 }

--- a/Editor/AGS.Editor/EditorEvents.cs
+++ b/Editor/AGS.Editor/EditorEvents.cs
@@ -15,7 +15,7 @@ namespace AGS.Editor
         public event ParameterlessDelegate RefreshAllComponentsFromGame;
         public delegate void GameLoadHandler(XmlNode rootNode);
         public event GameLoadHandler GameLoad;
-        public delegate void GamePostLoadHandler();
+        public delegate void GamePostLoadHandler(Game game);
         public event GamePostLoadHandler GamePostLoad;
         public delegate void SavingGameHandler(XmlTextWriter writer);
         public event SavingGameHandler SavingGame;
@@ -56,11 +56,11 @@ namespace AGS.Editor
             }
         }
 
-        public void OnGamePostLoad()
+        public void OnGamePostLoad(Game game)
         {
             if (GamePostLoad != null)
             {
-                GamePostLoad();
+                GamePostLoad(game);
             }
         }
 

--- a/Editor/AGS.Editor/Tasks.cs
+++ b/Editor/AGS.Editor/Tasks.cs
@@ -170,8 +170,10 @@ namespace AGS.Editor
             }
             Factory.AGSEditor.Settings.RecentGames.Insert(0, recentGame);
 
-            Factory.Events.OnGamePostLoad();
+            Factory.Events.OnGamePostLoad(game);
 
+            // WARNING: this is where the "global" Factory.AGSEditor.CurrentGame is set;
+            // any tasks and events that expect to reference it must be called after!
             Factory.AGSEditor.RefreshEditorAfterGameLoad(game, errors);
             if (needToSave)
             {


### PR DESCRIPTION
Fix #1005

This makes GeneralSettings and DefaultSetup behave consistently with the other unique persistent panels (such as GlobalVariables, LipSync, etc), and get recreated when the new game is opened. This fixes them in case CurrentGame reference has changed in the editor.

In practice this fixes editor not acting properly after importing a pre-3.* game.