### PR TITLE
Editor: enhance coordinates hint when moving Objects and Characters around the room

### DIFF
--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/BaseAreasEditorFilter.cs
@@ -383,6 +383,11 @@ namespace AGS.Editor
             return false;
 		}
 
+        public bool KeyReleased(Keys key)
+        {
+            return false;
+        }
+
         public virtual void CommandClick(string command)
         {
             foreach (MenuCommand menuCommand in _toolbarIcons)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -222,6 +222,7 @@ namespace AGS.Editor
 
                 if (_movingCharacterWithMouse || _movingCharacterWithKeyboard)
                 {
+                    Brush shadeBrush = new SolidBrush(Color.FromArgb(200, Color.Black));
                     System.Drawing.Font font = new System.Drawing.Font("Arial", 10.0f);
                     string toDraw = String.Format("X:{0}, Y:{1}", _selectedCharacter.StartX, _selectedCharacter.StartY);
 
@@ -235,6 +236,7 @@ namespace AGS.Editor
                     if (scaledy + textSize.Height >= graphics.VisibleClipBounds.Height)
                         scaledy = (int)(graphics.VisibleClipBounds.Height - textSize.Height);
 
+                    graphics.FillRectangle(shadeBrush, scaledx, scaledy, textSize.Width, textSize.Height);
                     graphics.DrawString(toDraw, font, pen.Brush, scaledx, scaledy);
                 }
             }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -126,21 +126,28 @@ namespace AGS.Editor
         public bool MouseMove(int x, int y, RoomEditorState state)
         {
             if (!_movingCharacterWithMouse) return false;
-            
+
             int newX = state.WindowXToRoom(x) - _mouseOffsetX;
             int newY = state.WindowYToRoom(y) - _mouseOffsetY;
-            return MoveCharacter(newX, newY);                     
+            return MoveCharacter(newX, newY);
         }
 
         private bool MoveCharacter(int newX, int newY)
         {
-            if (_selectedCharacter.StartX == newX &&
-                _selectedCharacter.StartY == newY)
+            if (_selectedCharacter == null)
             {
-                return false;
+                _movingCharacterWithMouse = false;
             }
-            _selectedCharacter.StartX = newX;
-            _selectedCharacter.StartY = newY;
+            else
+            {
+                if ((newX != _selectedCharacter.StartX) ||
+                    (newY != _selectedCharacter.StartY))
+                {
+                    _selectedCharacter.StartX = newX;
+                    _selectedCharacter.StartY = newY;
+                    // NOTE: do not mark room as modified, as characters are not part of room data
+                }
+            }
             return true;
         }
 

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/CharactersEditorFilter.cs
@@ -225,10 +225,15 @@ namespace AGS.Editor
                     System.Drawing.Font font = new System.Drawing.Font("Arial", 10.0f);
                     string toDraw = String.Format("X:{0}, Y:{1}", _selectedCharacter.StartX, _selectedCharacter.StartY);
 
-                    int scaledx = rect.X + (rect.Width / 2) - ((int)graphics.MeasureString(toDraw, font).Width / 2);
-                    int scaledy = rect.Y - (int)graphics.MeasureString(toDraw, font).Height;
+                    var textSize = graphics.MeasureString(toDraw, font);
+                    int scaledx = rect.X + (rect.Width / 2) - ((int)textSize.Width / 2);
+                    int scaledy = rect.Y - (int)textSize.Height;
                     if (scaledx < 0) scaledx = 0;
                     if (scaledy < 0) scaledy = 0;
+                    if (scaledx + textSize.Width >= graphics.VisibleClipBounds.Width)
+                        scaledx = (int)(graphics.VisibleClipBounds.Width - textSize.Width);
+                    if (scaledy + textSize.Height >= graphics.VisibleClipBounds.Height)
+                        scaledy = (int)(graphics.VisibleClipBounds.Height - textSize.Height);
 
                     graphics.DrawString(toDraw, font, pen.Brush, scaledx, scaledy);
                 }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EdgesEditorFilter.cs
@@ -128,6 +128,11 @@ namespace AGS.Editor
             return false;
 		}
 
+        public bool KeyReleased(Keys key)
+        {
+            return false;
+        }
+
         public void Paint(Graphics graphics, RoomEditorState state)
         {
             if (DesignItems[GetItemID(SelectedEdge.Left)].Visible)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/EmptyEditorFilter.cs
@@ -106,6 +106,11 @@ namespace AGS.Editor
             return false;
         }
 
+        public bool KeyReleased(Keys key)
+        {
+            return false;
+        }
+
         public void Dispose()
         {
         }

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/IRoomEditorFilter.cs
@@ -89,6 +89,10 @@ namespace AGS.Editor
         /// </summary>
         bool KeyPressed(Keys keyData);
         /// <summary>
+        /// Notifies key release event. Returns whether event is handled by this filter.
+        /// </summary>
+        bool KeyReleased(Keys keyData);
+        /// <summary>
         /// Gets a human-readable area name.
         /// </summary>
         /// <param name="id"></param>

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -342,17 +342,10 @@ namespace AGS.Editor
         public virtual bool MouseMove(int x, int y, RoomEditorState state)
         {
             if (!_movingObjectWithMouse) return false;
-            int realX = state.WindowXToRoom(x);
-            int realY = state.WindowYToRoom(y);
 
-            if ((_movingObjectWithMouse) && (realY < _room.Height) &&
-                (realX < _room.Width) && (realY >= 0) && (realX >= 0))
-            {
-                int newX = realX - _mouseOffsetX;
-                int newY = realY - _mouseOffsetY;
-                return MoveObject(newX, newY);
-            }
-            return false;
+            int newX = state.WindowXToRoom(x) - _mouseOffsetX;
+            int newY = state.WindowYToRoom(y) - _mouseOffsetY;
+            return MoveObject(newX, newY);
         }
 
         private bool MoveObject(int newX, int newY)
@@ -371,7 +364,7 @@ namespace AGS.Editor
                     _room.Modified = true;
                 }
             }
-            return true;            
+            return true;
         }
 
         private int GetArrowMoveStepSize()

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -188,6 +188,7 @@ namespace AGS.Editor
 
             if (_movingObjectWithMouse || _movingObjectWithKeyboard)
             {
+                Brush shadeBrush = new SolidBrush(Color.FromArgb(200, Color.Black));
                 System.Drawing.Font font = new System.Drawing.Font("Arial", 10.0f);
                 string toDraw = String.Format("X:{0}, Y:{1}", _selectedObject.StartX, _selectedObject.StartY);
 
@@ -201,6 +202,7 @@ namespace AGS.Editor
                 if (scaledy + textSize.Height >= graphics.VisibleClipBounds.Height)
                     scaledy = (int)(graphics.VisibleClipBounds.Height - textSize.Height);
 
+                graphics.FillRectangle(shadeBrush, scaledx, scaledy, textSize.Width, textSize.Height);
                 graphics.DrawString(toDraw, font, pen.Brush, (float)scaledx, (float)scaledy);
             }
             else if (design.Locked)

--- a/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomEditFilters/ObjectsEditorFilter.cs
@@ -191,10 +191,15 @@ namespace AGS.Editor
                 System.Drawing.Font font = new System.Drawing.Font("Arial", 10.0f);
                 string toDraw = String.Format("X:{0}, Y:{1}", _selectedObject.StartX, _selectedObject.StartY);
 
-                int scaledx = xPos + (width / 2) - ((int)graphics.MeasureString(toDraw, font).Width / 2);
-                int scaledy = yPos - (int)graphics.MeasureString(toDraw, font).Height;
+                var textSize = graphics.MeasureString(toDraw, font);
+                int scaledx = xPos + (width / 2) - ((int)textSize.Width / 2);
+                int scaledy = yPos - (int)textSize.Height;
                 if (scaledx < 0) scaledx = 0;
                 if (scaledy < 0) scaledy = 0;
+                if (scaledx + textSize.Width >= graphics.VisibleClipBounds.Width)
+                    scaledx = (int)(graphics.VisibleClipBounds.Width - textSize.Width);
+                if (scaledy + textSize.Height >= graphics.VisibleClipBounds.Height)
+                    scaledy = (int)(graphics.VisibleClipBounds.Height - textSize.Height);
 
                 graphics.DrawString(toDraw, font, pen.Brush, (float)scaledx, (float)scaledy);
             }

--- a/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
+++ b/Editor/AGS.Editor/Panes/Room/RoomSettingsEditor.cs
@@ -866,6 +866,10 @@ namespace AGS.Editor
                 return false;
             }
 
+            if (_layer != null && !IsLocked(_layer) && _layer.KeyReleased(keyData))
+            {
+                return true;
+            }
             return ProcessPanKeyRelease(keyData);
         }
 


### PR DESCRIPTION
Fix #984, addresses a minor problem mentioned in #614.

* Display coordinates hint when Characters or Objects are moved with keys too.
* Fixed hint's position was only constrained by top-left border; made sure it is always visible even if a moved object is out of visible bounds (e.g. if user zoomed into a different part of room).
* Allow to move Objects outside of room bg, similar to Characters.
* Brought Characters and Objects moving code to more consistency (although imo they should get a base class, but that's for separate task).


On a side note, the coordinates may be difficult to see sometimes, depending on background.
For a moment I've been thinking about letting user choose a color in Editor prefs, but even a custom color will still be fixed and have same problem. So this is an open issue.
EDIT: added a black shade under the text.

There is ALOT of code duplication in these two classes, so I opened #2230 as a separate task, don't have spare time for that right now.