### PR TITLE
Editor: if textbox is focused, edit menu affects it

### DIFF
--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -62,6 +62,7 @@ namespace AGS.Editor
                 if (textBox != null)
                 {
                     textBox.GotFocus += dialogOptionsEditorTextBox_GotFocus;
+                    textBox.MouseUp += dialogOptionsEditorTextBox_MouseUp;
                 }
             }
         }
@@ -74,6 +75,7 @@ namespace AGS.Editor
                 if (textBox != null)
                 {
                     textBox.GotFocus -= dialogOptionsEditorTextBox_GotFocus;
+                    textBox.MouseUp -= dialogOptionsEditorTextBox_MouseUp;
                 }
             }
         }
@@ -238,13 +240,23 @@ namespace AGS.Editor
             UpdateUICommands(force:true);
         }
 
-        private void dialogOptionsEditorTextBox_GotFocus(object sender, EventArgs e)
+        private void dialogOptionsEditorTextBox_Event(object sender, EventArgs e)
         {
             TextBox tbox = sender as TextBox;
             if (tbox == null) return;
 
             bool can_copy_cut = tbox.SelectionLength > 0;
-            EnableStandardEditCommands(copy: can_copy_cut, cut: can_copy_cut, paste: true, undo: tbox.CanUndo, redo:false);
+            EnableStandardEditCommands(copy: can_copy_cut, cut: can_copy_cut, paste: true, undo: tbox.CanUndo, redo: false);
+        }
+
+        private void dialogOptionsEditorTextBox_MouseUp(object sender, EventArgs e)
+        {
+            dialogOptionsEditorTextBox_Event(sender, e);
+        }
+
+        private void dialogOptionsEditorTextBox_GotFocus(object sender, EventArgs e)
+        {
+            dialogOptionsEditorTextBox_Event(sender, e);
         }
 
         protected override void OnCommandClick(string command)

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -240,7 +240,31 @@ namespace AGS.Editor
 
         private void dialogOptionsEditorTextBox_GotFocus(object sender, EventArgs e)
         {
-            EnableAllStandardEditCommands();
+            TextBox tbox = sender as TextBox;
+            if (tbox == null) return;
+
+            bool can_copy_cut = tbox.SelectionLength > 0;
+            EnableStandardEditCommands(copy: can_copy_cut, cut: can_copy_cut, paste: true, undo: tbox.CanUndo, redo:false);
+        }
+
+        protected override void OnCommandClick(string command)
+        {
+            if (IsStandardEditCommand(command))
+            {
+                Control c = Utilities.GetControlThatHasFocus();
+                TextBox tbox = c as TextBox;
+                if (tbox != null)
+                {
+                    if (command == CUT_COMMAND) tbox.Cut();
+                    else if (command == COPY_COMMAND) tbox.Copy();
+                    else if (command == PASTE_COMMAND) tbox.Paste();
+                    else if (command == UNDO_COMMAND) tbox.Undo();
+
+                    return;
+                }
+            }
+
+            base.OnCommandClick(command);
         }
 
         private void btnNewOption_Click(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/DialogEditor.cs
+++ b/Editor/AGS.Editor/Panes/DialogEditor.cs
@@ -63,6 +63,8 @@ namespace AGS.Editor
                 {
                     textBox.GotFocus += dialogOptionsEditorTextBox_GotFocus;
                     textBox.MouseUp += dialogOptionsEditorTextBox_MouseUp;
+                    textBox.TextChanged += dialogOptionsEditorTextBox_TextChanged;
+                    textBox.KeyUp += dialogOptionsEditorTextBox_KeyUp;
                 }
             }
         }
@@ -76,6 +78,8 @@ namespace AGS.Editor
                 {
                     textBox.GotFocus -= dialogOptionsEditorTextBox_GotFocus;
                     textBox.MouseUp -= dialogOptionsEditorTextBox_MouseUp;
+                    textBox.TextChanged -= dialogOptionsEditorTextBox_TextChanged;
+                    textBox.KeyUp -= dialogOptionsEditorTextBox_KeyUp;
                 }
             }
         }
@@ -240,13 +244,18 @@ namespace AGS.Editor
             UpdateUICommands(force:true);
         }
 
+        private void updateEditMenuForTextbox(TextBox tbox)
+        {
+            bool can_copy_cut = tbox.SelectionLength > 0;
+            EnableStandardEditCommands(copy: can_copy_cut, cut: can_copy_cut, paste: true, undo: tbox.CanUndo, redo: false);
+
+        }
+
         private void dialogOptionsEditorTextBox_Event(object sender, EventArgs e)
         {
             TextBox tbox = sender as TextBox;
             if (tbox == null) return;
-
-            bool can_copy_cut = tbox.SelectionLength > 0;
-            EnableStandardEditCommands(copy: can_copy_cut, cut: can_copy_cut, paste: true, undo: tbox.CanUndo, redo: false);
+            updateEditMenuForTextbox(tbox);
         }
 
         private void dialogOptionsEditorTextBox_MouseUp(object sender, EventArgs e)
@@ -255,6 +264,16 @@ namespace AGS.Editor
         }
 
         private void dialogOptionsEditorTextBox_GotFocus(object sender, EventArgs e)
+        {
+            dialogOptionsEditorTextBox_Event(sender, e);
+        }
+
+        private void dialogOptionsEditorTextBox_TextChanged(object sender, EventArgs e)
+        {
+            dialogOptionsEditorTextBox_Event(sender, e);
+        }
+
+        private void dialogOptionsEditorTextBox_KeyUp(object sender, EventArgs e)
         {
             dialogOptionsEditorTextBox_Event(sender, e);
         }
@@ -271,6 +290,8 @@ namespace AGS.Editor
                     else if (command == COPY_COMMAND) tbox.Copy();
                     else if (command == PASTE_COMMAND) tbox.Paste();
                     else if (command == UNDO_COMMAND) tbox.Undo();
+
+                    updateEditMenuForTextbox(tbox);
 
                     return;
                 }

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -278,7 +278,7 @@ namespace AGS.Editor
         /// Updates the state of menu commands (this affects both menu and toolbar icons).
         /// May be overriden in derived classes for their specific commands.
         /// </summary>
-        protected virtual void UpdateUICommands()
+        protected virtual void UpdateUICommands(bool force = false)
         {
             bool canCutAndCopy = _scintilla.CanCutAndCopy();
             bool canPaste = _scintilla.CanPaste();
@@ -287,7 +287,7 @@ namespace AGS.Editor
             if ((_menuCmdCopy.Enabled != canCutAndCopy) ||
                 (_menuCmdPaste.Enabled != canPaste) ||
                 (_menuCmdUndo.Enabled != canUndo) ||
-                (_menuCmdRedo.Enabled != canRedo))
+                (_menuCmdRedo.Enabled != canRedo) || force)
             {
                 _menuCmdCopy.Enabled = canCutAndCopy;
                 _menuCmdCut.Enabled = canCutAndCopy;
@@ -297,6 +297,17 @@ namespace AGS.Editor
                 Factory.ToolBarManager.RefreshCurrentPane();
                 Factory.MenuManager.RefreshCurrentPane();
             }
+        }
+
+        protected void EnableAllStandardEditCommands()
+        {
+            _menuCmdCopy.Enabled = true;
+            _menuCmdCut.Enabled = true;
+            _menuCmdPaste.Enabled = true;
+            _menuCmdUndo.Enabled = true;
+            _menuCmdRedo.Enabled = true;
+            Factory.ToolBarManager.RefreshCurrentPane();
+            Factory.MenuManager.RefreshCurrentPane();
         }
 
         private void scintilla_UpdateUI(object sender, EventArgs e)

--- a/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
+++ b/Editor/AGS.Editor/Panes/ScriptEditorBase.cs
@@ -196,6 +196,18 @@ namespace AGS.Editor
         /// <param name="command"></param>
         protected override void OnCommandClick(string command)
         {
+            Control c = Utilities.GetControlThatHasFocus();
+            TextBox tbox = c as TextBox;
+            if (tbox != null)
+            {
+                if (command == CUT_COMMAND) tbox.Cut();
+                else if (command == COPY_COMMAND) tbox.Copy();
+                else if (command == PASTE_COMMAND) tbox.Paste();
+                else if (command == UNDO_COMMAND) tbox.Undo();
+
+                return;
+            }
+
             if (command == CUT_COMMAND)
             {
                 _scintilla.Cut();


### PR DESCRIPTION
additional for #2231 

There are still small details there, but in this way, using an action in the edit menu won't affect the scintilla editor if a textbox has focus.

Checking for focus in scintilla instead won't work, so this is why it's done in such way.