### PR TITLE
Editor: slightly perf improve in FastString StartsWith

### DIFF
--- a/Editor/AGS.CScript.Compiler/Entities/FastString.cs
+++ b/Editor/AGS.CScript.Compiler/Entities/FastString.cs
@@ -50,7 +50,7 @@ namespace AGS.CScript.Compiler
 			{
 				return false;
 			}
-            return (_data[_offset] == text[0]) && (_data.Substring(_offset).StartsWith(text));
+            return (_data[_offset] == text[0]) && (_data.Substring(_offset).StartsWith(text, StringComparison.Ordinal));
         }
 
         public int IndexOf(string text, int offset)

--- a/Editor/AGS.CScript.Compiler/Entities/FastString.cs
+++ b/Editor/AGS.CScript.Compiler/Entities/FastString.cs
@@ -12,6 +12,7 @@ namespace AGS.CScript.Compiler
     {
         private string _data;
         private int _offset;
+        private const StringComparison _useComparison = StringComparison.Ordinal;
 
         public FastString(string source)
         {
@@ -50,17 +51,17 @@ namespace AGS.CScript.Compiler
 			{
 				return false;
 			}
-            return (_data[_offset] == text[0]) && (_data.Substring(_offset).StartsWith(text, StringComparison.Ordinal));
+            return (_data[_offset] == text[0]) && (_data.Substring(_offset).StartsWith(text, _useComparison));
         }
 
         public int IndexOf(string text, int offset)
         {
-            return _data.IndexOf(text, _offset + offset) - _offset;
+            return _data.IndexOf(text, _offset + offset, _useComparison) - _offset;
         }
 
         public int IndexOf(string text)
         {
-            return _data.IndexOf(text, _offset) - _offset;
+            return _data.IndexOf(text, _offset, _useComparison) - _offset;
         }
 
         public int IndexOf(char text)


### PR DESCRIPTION
I noticed the StartsWith comparison is using the default `CurrentCulture`, in the `FastString` implementation, which from the [docs here](https://learn.microsoft.com/en-us/dotnet/api/system.string.compare?view=netframework-4.6.2) I think is more meant for regular text, but for variables and other elements in AGS Script, I think we expect binary matches. `FastString` is used only in a context of processing AGS Script language, so I think it's safe to change it's behavior to such.

The motivation is I noticed this makes StartsWith to run a little faster. To profile I used the description of #1926, and just loaded my ImGi script module and typed a lot of things in it's script module to make the ConstructCache run a lot.

I am not super sure of how much this improves because for some reason I had to build the Editor for Debug to actually find the FastString.StartsWith calls in the ones listed.