### PR TITLE
Script API: add Game.PrecacheSprite() and PrecacheView()

### DIFF
--- a/Common/ac/spritecache.cpp
+++ b/Common/ac/spritecache.cpp
@@ -230,7 +230,7 @@ void SpriteCache::DisposeAllCached()
     ResourceCache::DisposeFreeItems();
 }
 
-void SpriteCache::Precache(sprkey_t index)
+void SpriteCache::PrecacheSprite(sprkey_t index)
 {
     assert(index >= 0); // out of positive range indexes are valid to fail
     if (index < 0 || (size_t)index >= _spriteData.size())
@@ -240,11 +240,41 @@ void SpriteCache::Precache(sprkey_t index)
 
     if (!ResourceCache::Exists(index))
         LoadSprite(index);
-
-    // make sure locked sprites can't fill the cache
-    ResourceCache::Lock(index);
-    _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
     SprCacheLog("Precached %d", index);
+}
+
+void SpriteCache::LockSprite(sprkey_t index)
+{
+    assert(index >= 0); // out of positive range indexes are valid to fail
+    if (index < 0 || (size_t)index >= _spriteData.size())
+        return;
+    if (!_spriteData[index].IsAssetSprite())
+        return; // cannot lock a non-asset sprite
+
+    if (ResourceCache::Exists(index))
+    {
+        ResourceCache::Lock(index);
+        _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
+    }
+    else
+    {
+        LoadSprite(index, true);
+    }
+    SprCacheLog("Locked %d", index);
+}
+
+void SpriteCache::UnlockSprite(sprkey_t index)
+{
+    assert(index >= 0); // out of positive range indexes are valid to fail
+    if (index < 0 || (size_t)index >= _spriteData.size())
+        return;
+    if (!_spriteData[index].IsAssetSprite() ||
+        !_spriteData[index].IsLocked())
+        return; // cannot unlock a non-asset sprite, or non-locked sprite
+
+    ResourceCache::Release(index);
+    _spriteData[index].Flags &= ~SPRCACHEFLAG_LOCKED;
+    SprCacheLog("Unlocked %d", index);
 }
 
 size_t SpriteCache::CalcSize(const std::unique_ptr<Bitmap> &item)
@@ -253,7 +283,7 @@ size_t SpriteCache::CalcSize(const std::unique_ptr<Bitmap> &item)
     return item ? (item->GetWidth() * item->GetHeight() * item->GetBPP()) : 0u;
 }
 
-Bitmap *SpriteCache::LoadSprite(sprkey_t index)
+Bitmap *SpriteCache::LoadSprite(sprkey_t index, bool lock)
 {
     assert((index >= 0) && ((size_t)index < _spriteData.size()));
     if (index < 0 || (size_t)index >= _spriteData.size())
@@ -285,12 +315,13 @@ Bitmap *SpriteCache::LoadSprite(sprkey_t index)
     _sprInfos[index].Width = image->GetWidth();
     _sprInfos[index].Height = image->GetHeight();
 
-    // Add to the cache
-    ResourceCache::Put(index, std::unique_ptr<Bitmap>(image));
-    _spriteData[index].Flags = SPRCACHEFLAG_ISASSET;
-    if (index == 0) // keep sprite 0 locked
-        _spriteData[index].Flags |= SPRCACHEFLAG_LOCKED;
-    SprCacheLog("Loaded %d, size now %zu KB", index, _cacheSize / 1024);
+    // Add to the cache, lock if requested or if it's sprite 0
+    const bool should_lock = lock || (index == 0);
+    ResourceCache::Put(index, std::unique_ptr<Bitmap>(image), kCacheItem_Locked * should_lock);
+    _spriteData[index].Flags =
+          SPRCACHEFLAG_ISASSET |
+          SPRCACHEFLAG_LOCKED * should_lock;
+    SprCacheLog("Loaded %d, normal size %zu KB", index, _cacheSize / 1024);
 
     // Let the external user to react to the new sprite;
     // note that this callback is allowed to modify the sprite's pixels,

--- a/Common/ac/spritecache.h
+++ b/Common/ac/spritecache.h
@@ -120,8 +120,21 @@ public:
     // Tells if the given slot is reserved for the asset sprite, that is a "static"
     // sprite cached from the game assets
     bool        IsAssetSprite(sprkey_t index) const;
-    // Loads sprite and and locks in memory (so it cannot get removed implicitly)
-    void        Precache(sprkey_t index);
+    // Loads sprite using SpriteFile if such index is known,
+    // frees the space if cache size reaches the limit
+    void        PrecacheSprite(sprkey_t index);
+    // Locks sprite, preventing it from getting removed by the normal cache limit.
+    // If this is a registered sprite from the game assets, then loads it first.
+    // If this is a sprite with SPRCACHEFLAG_EXTERNAL flag, then does nothing,
+    // as these are always "locked".
+    // If such sprite does not exist, then fails silently.
+    void        LockSprite(sprkey_t index);
+    // Unlocks sprite, putting it back into the cache logic,
+    // where it counts towards normal limit may be deleted to free space.
+    // NOTE: sprites with SPRCACHEFLAG_EXTERNAL flag cannot be unlocked,
+    // only explicitly removed.
+    // If such sprite was not present in memory, then fails silently.
+    void        UnlockSprite(sprkey_t index);
     // Unregisters sprite from the bank and returns the bitmap
     Bitmap*     RemoveSprite(sprkey_t index);
     // Deletes particular sprite, marks slot as unused
@@ -152,7 +165,7 @@ protected:
 
 private:
     // Load sprite from game resource and put into the cache
-    Bitmap *    LoadSprite(sprkey_t index);
+    Bitmap *    LoadSprite(sprkey_t index, bool lock = false);
     // Remap the given index to the sprite 0
     void        RemapSpriteToPlaceholder(sprkey_t index);
     // Initialize the empty sprite slot

--- a/Common/util/resourcecache.h
+++ b/Common/util/resourcecache.h
@@ -26,6 +26,12 @@
 // TODO: support data Priority, which tells which items may be disposed
 // when adding new item and surpassing the cache limit.
 //
+// TODO: as an option, consider to have Locked items separate from the normal
+// cache limit, and probably have their own limit setting as a safety measure.
+// (after reaching this limit ResourceCache would simply ignore any further
+// Lock commands until some items are unlocked.)
+// Rethink this when it's time to design a better resource handling in AGS.
+//
 // TODO: as an option, consider supporting a specialized container type that
 // has an associative container's interface, but is optimized for having most
 // keys allocated in large continious sequences by default.

--- a/Editor/AGS.Editor/Resources/agsdefns.sh
+++ b/Editor/AGS.Editor/Resources/agsdefns.sh
@@ -2949,6 +2949,10 @@ builtin struct Game {
 #ifdef SCRIPT_API_v361
   /// Resets all of the "DoOnceOnly" token states
   import static void   ResetDoOnceOnly();
+  /// Preloads and caches a single sprite.
+  import static void   PrecacheSprite(int sprnum);
+  /// Preloads and caches sprites and linked sounds for a view, within a selected range of loops.
+  import static void   PrecacheView(int view, int first_loop, int last_loop);
 #endif
 };
 

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1024,6 +1024,11 @@ void texturecache_get_state(size_t &max_size, size_t &cur_size, size_t &locked_s
     ext_size = texturecache.GetExternalSize();
 }
 
+size_t texturecache_get_size()
+{
+    return texturecache.GetCacheSize();
+}
+
 void texturecache_clear()
 {
     texturecache.Clear();

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -1054,6 +1054,11 @@ void clear_shared_texture(uint32_t sprite_id)
     texturecache.Dispose(sprite_id);
 }
 
+void texturecache_precache(uint32_t sprite_id)
+{
+    texturecache.GetOrLoad(sprite_id, nullptr, (game.SpriteInfos[sprite_id].Flags & SPF_ALPHACHANNEL) != 0, false);
+}
+
 void mark_screen_dirty()
 {
     drawstate.ScreenIsDirty = true;

--- a/Engine/ac/draw.cpp
+++ b/Engine/ac/draw.cpp
@@ -83,7 +83,7 @@ extern int displayed_room;
 extern CharacterInfo*playerchar;
 extern int eip_guinum;
 extern int cur_mode,cur_cursor;
-extern IDriverDependantBitmap *mouseCursor;
+extern IDriverDependantBitmap *mouse_cur_ddb;
 extern int hotx,hoty;
 extern int bg_just_changed;
 
@@ -2749,8 +2749,8 @@ void construct_game_screen_overlay(bool draw_mouse)
         // Stage: mouse cursor
         if (draw_mouse && !play.mouse_cursor_hidden)
         {
-            gfxDriver->DrawSprite(mousex - hotx, mousey - hoty, mouseCursor);
-            invalidate_sprite(mousex - hotx, mousey - hoty, mouseCursor, false);
+            gfxDriver->DrawSprite(mousex - hotx, mousey - hoty, mouse_cur_ddb);
+            invalidate_sprite(mousex - hotx, mousey - hoty, mouse_cur_ddb, false);
         }
         // Stage: screen fx
         if (play.screen_tint >= 1)

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -87,6 +87,8 @@ void texturecache_clear();
 void update_shared_texture(uint32_t sprite_id);
 // Remove a texture from cache
 void clear_shared_texture(uint32_t sprite_id);
+// Prepares a texture for the given sprite and stores in the cache
+void texturecache_precache(uint32_t sprite_id);
 
 // whether there are currently remnants of a DisplaySpeech
 void mark_screen_dirty();

--- a/Engine/ac/draw.h
+++ b/Engine/ac/draw.h
@@ -81,6 +81,8 @@ void notify_sprite_changed(int sprnum, bool deleted);
 // size of locked items (included into cur_size),
 // size of external items (excluded from cur_size)
 void texturecache_get_state(size_t &max_size, size_t &cur_size, size_t &locked_size, size_t &ext_size);
+// Returns current cache size
+size_t texturecache_get_size();
 // Completely resets texture cache
 void texturecache_clear();
 // Update shared and cached texture from the sprite's pixels

--- a/Engine/ac/game.h
+++ b/Engine/ac/game.h
@@ -195,6 +195,8 @@ void get_message_text (int msnum, char *buffer, char giveErr = 1);
 // Notifies the game objects that certain sprite was updated.
 // This make them update their render states, caches, and so on.
 void game_sprite_updated(int sprnum, bool deleted = false);
+// Precaches sprites for a view, within a selected range of loops.
+void precache_view(int view, int first_loop = 0, int last_loop = INT32_MAX, bool with_sounds = false);
 
 extern int in_new_room;
 extern int new_room_pos;

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -17,6 +17,7 @@
 #include "ac/draw.h"
 #include "ac/dynobj/scriptmouse.h"
 #include "ac/dynobj/scriptsystem.h"
+#include "ac/game.h"
 #include "ac/gamesetup.h"
 #include "ac/gamesetupstruct.h"
 #include "ac/gamestate.h"

--- a/Engine/ac/mouse.cpp
+++ b/Engine/ac/mouse.cpp
@@ -171,7 +171,7 @@ void ChangeCursorGraphic (int curs, int newslot) {
         debug_script_warn("Mouse.ChangeModeGraphic should not be used on the Inventory cursor when the cursor is linked to the active inventory item");
 
     game.mcurs[curs].pic = newslot;
-    spriteset.Precache(newslot);
+    spriteset.PrecacheSprite(newslot);
     if (curs == cur_mode)
         set_mouse_cursor (curs);
 }
@@ -368,7 +368,7 @@ void update_inv_cursor(int invnum) {
 
         game.mcurs[MODE_USE].pic = cursorSprite;
         // all cursor images must be pre-cached
-        spriteset.Precache(cursorSprite);
+        spriteset.PrecacheSprite(cursorSprite);
 
         if ((game.invinfo[invnum].hotx > 0) || (game.invinfo[invnum].hoty > 0)) {
             // if the hotspot was set (unfortunately 0,0 isn't a valid co-ord)

--- a/Engine/ac/mouse.h
+++ b/Engine/ac/mouse.h
@@ -54,7 +54,6 @@ void SimulateMouseClick(int button_id);
 int GetMouseCursor();
 void update_script_mouse_coords();
 void update_inv_cursor(int invnum);
-void update_cached_mouse_cursor();
 void set_new_cursor_graphic (int spriteslot);
 int find_next_enabled_cursor(int startwith);
 int find_previous_enabled_cursor(int startwith);

--- a/Engine/ac/route_finder_impl_legacy.cpp
+++ b/Engine/ac/route_finder_impl_legacy.cpp
@@ -36,10 +36,6 @@ namespace BitmapHelper = AGS::Common::BitmapHelper;
 
 // #define DEBUG_PATHFINDER
 
-#ifdef DEBUG_PATHFINDER
-// extern Bitmap *mousecurs[10];
-#endif
-
 namespace AGS {
 namespace Engine {
 namespace RouteFinderLegacy {
@@ -286,10 +282,6 @@ static int try_this_square(int srcx, int srcy, int tox, int toy)
     pathbackstage = 0;
     return 2;
   }
-
-#ifdef DEBUG_PATHFINDER
-  // wputblock(lastcx, lastcy, mousecurs[C_CROSS], 1);
-#endif
 
   int trydir = DIR_UP;
   int xdiff = abs(srcx - tox), ydiff = abs(srcy - toy);

--- a/Engine/ac/timer.h
+++ b/Engine/ac/timer.h
@@ -29,6 +29,12 @@ using AGS_Clock = std::conditional<
       >::type;
 using AGS_FastClock = std::chrono::system_clock;
 
+template <typename TDur>
+inline int64_t ToMilliseconds(TDur dur)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+}
+
 // Sleeps for time remaining until the next game frame, updates next frame timestamp
 extern void WaitForNextFrame();
 

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -105,18 +105,6 @@ int ViewFrame_GetFrame(ScriptViewFrame *svf) {
 
 //=============================================================================
 
-void precache_view(int view, int max_loops)
-{
-    if (view < 0) 
-        return;
-
-    max_loops = std::min(views[view].numLoops, max_loops);
-    for (int i = 0; i < max_loops; i++) {
-        for (int j = 0; j < views[view].loops[i].numFrames; j++)
-            spriteset.PrecacheSprite(views[view].loops[i].frames[j].pic);
-    }
-}
-
 int CalcFrameSoundVolume(int obj_vol, int anim_vol, int scale)
 {
     // We view the audio property relation as the relation of the entities:

--- a/Engine/ac/viewframe.cpp
+++ b/Engine/ac/viewframe.cpp
@@ -113,7 +113,7 @@ void precache_view(int view, int max_loops)
     max_loops = std::min(views[view].numLoops, max_loops);
     for (int i = 0; i < max_loops; i++) {
         for (int j = 0; j < views[view].loops[i].numFrames; j++)
-            spriteset.Precache(views[view].loops[i].frames[j].pic);
+            spriteset.PrecacheSprite(views[view].loops[i].frames[j].pic);
     }
 }
 

--- a/Engine/ac/viewframe.h
+++ b/Engine/ac/viewframe.h
@@ -39,7 +39,6 @@ int  ViewFrame_GetView(ScriptViewFrame *svf);
 int  ViewFrame_GetLoop(ScriptViewFrame *svf);
 int  ViewFrame_GetFrame(ScriptViewFrame *svf);
 
-void precache_view(int view, int max_loops = INT_MAX);
 // Calculate the frame sound volume from different factors;
 // pass scale as 100 if volume scaling is disabled
 // NOTE: historically scales only in 0-100 range :/

--- a/Engine/device/mousew32.cpp
+++ b/Engine/device/mousew32.cpp
@@ -40,8 +40,7 @@ int mousex = 0, mousey = 0, numcurso = -1, hotx = 0, hoty = 0;
 static int real_mouse_x = 0, real_mouse_y = 0;
 static int boundx1 = 0, boundx2 = 99999, boundy1 = 0, boundy2 = 99999;
 char ignore_bounds = 0;
-extern char alpha_blend_cursor ;
-Bitmap *mousecurs[MAXCURSORS];
+extern char alpha_blend_cursor;
 extern RGB palette[256];
 extern volatile bool switched_away;
 

--- a/Engine/device/mousew32.h
+++ b/Engine/device/mousew32.h
@@ -14,8 +14,6 @@
 #include "ac/sys_events.h"
 #include "util/geometry.h"
 
-#define MAXCURSORS 20
-
 
 namespace AGS { namespace Common { class Bitmap; } }
 using namespace AGS; // FIXME later
@@ -66,5 +64,3 @@ namespace Mouse
 extern int mousex, mousey;
 extern int hotx, hoty;
 extern char currentcursor;
-
-extern Common::Bitmap *mousecurs[MAXCURSORS];

--- a/Engine/game/savegame.cpp
+++ b/Engine/game/savegame.cpp
@@ -569,8 +569,8 @@ HSaveError DoAfterRestore(const PreservedParams &pp, RestoredData &r_data)
     set_mouse_cursor(r_data.CursorID);
     if (r_data.CursorMode == MODE_USE)
         SetActiveInventory(playerchar->activeinv);
-    // ensure that the current cursor is locked
-    spriteset.Precache(game.mcurs[r_data.CursorID].pic);
+    // precache current cursor
+    spriteset.PrecacheSprite(game.mcurs[r_data.CursorID].pic);
 
     sys_window_set_title(play.game_name);
 

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -631,7 +631,7 @@ void engine_init_game_settings()
         // The cursor graphics are assigned to mousecurs[] and so cannot
         // be removed from memory
         if (game.mcurs[ee].pic >= 0)
-            spriteset.Precache(game.mcurs[ee].pic);
+            spriteset.PrecacheSprite(game.mcurs[ee].pic);
 
         // just in case they typed an invalid view number in the editor
         if (game.mcurs[ee].view >= game.numviews)

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -642,7 +642,7 @@ void engine_init_game_settings()
     }
     // may as well preload the character gfx
     if (playerchar->view >= 0)
-        precache_view (playerchar->view, Character_GetDiagonalWalking(playerchar) ? 8 : 4);
+        precache_view(playerchar->view, 0, Character_GetDiagonalWalking(playerchar) ? 8 : 4);
 
     our_eip=-6;
 

--- a/Engine/media/audio/sound.cpp
+++ b/Engine/media/audio/sound.cpp
@@ -97,6 +97,24 @@ void soundcache_clear()
     SndCache.Clear();
 }
 
+void soundcache_precache(const AssetPath &apath)
+{
+    if (SndCache.GetMaxCacheSize() == 0)
+        return; // cache is disabled
+    if (SndCache.Exists(apath.Name))
+        return; // already in cache
+    std::unique_ptr<Stream> s_in(AssetMgr->OpenAsset(apath));
+    if (!s_in)
+        return; // failed to open asset
+    size_t asset_size = static_cast<size_t>(s_in->GetLength());
+    if (asset_size > MaxLoadAtOnce)
+        return; // too big for the cache
+    // Read and put into the cache
+    auto sounddata = std::make_shared<std::vector<uint8_t>>(asset_size);
+    s_in->Read(sounddata->data(), asset_size);
+    SndCache.Put(apath.Name, sounddata);
+}
+
 SOUNDCLIP *load_sound_clip(const AssetPath &apath, const char *extension_hint, bool loop)
 {
     size_t asset_size;

--- a/Engine/media/audio/sound.h
+++ b/Engine/media/audio/sound.h
@@ -31,6 +31,7 @@ const size_t DEFAULT_SOUNDCACHESIZE_KB = 1024u * 32; // 32 MB
 // * max_cachesize - sound cache limit, in bytes
 void soundcache_set_rules(size_t max_loadatonce, size_t max_cachesize);
 void soundcache_clear();
+void soundcache_precache(const AssetPath &apath);
 
 SOUNDCLIP *load_sound_clip(const AssetPath &apath, const char *extension_hint, bool loop);
 


### PR DESCRIPTION
This is the last thing i wanted to try adding in 3.6.1.

It's been always a problem in AGS that game developers have little control over the resource management. That is a big topic, and has to be thought through well before writing a good API, but I wanted to add couple of simple temporary methods, acting as a  replacement for existing hacks that let precache a number of sprites and fix performance in certain scenes.

* Game.PrecacheSprite(int sprnum) precaches a single sprite;
* Game.PrecacheView(int view, int first_loop, int last_loop) precaches sprites and *linked sounds* for all frames in the given range of loops for the view.

Precaching a sprite in both of these methods does not load only a raw sprite, but also prepares a texture for it, since we have a texture cache now too, and converting sprites to textures may also have an impact on performance.

An important note is that these functions work according to the existing cache rules. That is - cached assets are normally counted towards the cache limit, and if the limit is exceeded, then older objects will be freed. In addition, the sounds are only cached if their individual size does not exceed "stream_threshold" value from ags config.

This means that in the end the result of using these functions also depends on active game config, and this has to be honestly stated.