### PR TITLE
Editor: compile flag turns alert in log messages

### DIFF
--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -376,6 +376,7 @@
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\ScriptGeneration.cs" />
+    <Compile Include="Utils\StdConsoleWriter.cs" />
     <Compile Include="Utils\Validation.cs" />
     <EmbeddedResource Include="GUI\frmMain.resx">
       <SubType>Designer</SubType>

--- a/Editor/AGS.Editor/AGSEditor.csproj
+++ b/Editor/AGS.Editor/AGSEditor.csproj
@@ -373,6 +373,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AndroidUtilities.cs" />
     <Compile Include="Utils\ArgumentBuilder.cs" />
+    <Compile Include="Utils\CommandLineOptions.cs" />
     <Compile Include="Utils\ConcurrentCircularBuffer.cs" />
     <Compile Include="Utils\MathExtra.cs" />
     <Compile Include="Utils\ScriptGeneration.cs" />

--- a/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
+++ b/Editor/AGS.Editor/Components/BuildCommandsComponent.cs
@@ -246,6 +246,18 @@ namespace AGS.Editor.Components
             }
         }
 
+        public static void ShowCompileSuccessMessage()
+        {
+            string message = "Compilation successful!";
+
+            Factory.GUIController.ShowOutputPanel(message);
+
+            if (Factory.AGSEditor.Settings.MessageBoxOnCompile == MessageBoxOnCompile.Always)
+            {
+                Factory.GUIController.ShowMessage(message, MessageBoxIcon.Information);
+            }
+        }
+
 		private void CompileGame(bool forceRebuild)
 		{
 			forceRebuild = _agsEditor.NeedsRebuildForDebugMode() || forceRebuild;
@@ -256,14 +268,8 @@ namespace AGS.Editor.Components
                 _agsEditor.SaveUserDataFile();
                 if (messages.Count == 0)
 				{
-					string message = "Compilation successful!";
-					Factory.GUIController.ShowOutputPanel(message);
-
-					if (_agsEditor.Settings.MessageBoxOnCompile == MessageBoxOnCompile.Always)
-					{
-						_guiController.ShowMessage(message, MessageBoxIcon.Information);
-					}
-				}
+                    ShowCompileSuccessMessage();
+                }
 			}
 		}
 

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -894,6 +894,11 @@ namespace AGS.Editor
 
 			bool showWelcomeScreen = ProcessCommandLineArgumentsAndReturnWhetherToShowWelcomeScreen();
 
+            if (AGS.Types.Version.IS_BETA_VERSION)
+            {
+                Factory.GUIController.ShowMessage("This is a BETA version of AGS. BE VERY CAREFUL and MAKE SURE YOU BACKUP YOUR GAME before loading it in this editor.", MessageBoxIcon.Warning);
+            }
+
             while (showWelcomeScreen)
             {
 				Directory.SetCurrentDirectory(_agsEditor.EditorDirectory);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -896,6 +896,7 @@ namespace AGS.Editor
                                 _agsEditor.SaveUserDataFile(); // in case pending config is applied
 
                             _batchProcessShutdown = true;
+                            if (messages.Count > 0) Program.SetExitCode(1);
                             this.ExitApplication();
                         }
 						return false;

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -367,18 +367,33 @@ namespace AGS.Editor
             _mainForm.pnlOutput.ErrorsToList = errors;
             if (errors.Count > 0)
             {
+                if (StdConsoleWriter.IsEnabled)
+                {
+                    foreach (CompileError cerr in errors.Errors)
+                    {
+                        StdConsoleWriter.WriteLine(cerr.AsString);
+                    }
+                }
                 _mainForm.pnlOutput.Show();
             }
         }
 
         public void ShowOutputPanel(string[] messages, string imageKey = "BuildIcon")
         {
+            if (StdConsoleWriter.IsEnabled)
+            {
+                foreach(string msg in messages)
+                {
+                    StdConsoleWriter.WriteLine(msg);
+                }
+            }
             _mainForm.pnlOutput.SetMessages(messages, imageKey);
             _mainForm.pnlOutput.Show();
         }
 
         public void ShowOutputPanel(string message, string imageKey = "BuildIcon")
         {
+            StdConsoleWriter.WriteLine(message);
             _mainForm.pnlOutput.SetMessage(message, imageKey);
             _mainForm.pnlOutput.Show();
         }

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -165,6 +165,12 @@ namespace AGS.Editor
 
         public void ShowMessage(string message, MessageBoxIcon icon)
         {
+            if(StdConsoleWriter.IsEnabled)
+            {
+                StdConsoleWriter.WriteLine(message);
+                return;
+            }
+
             if ((Form.ActiveForm == null) || (Form.ActiveForm.InvokeRequired))
             {
                 MessageBox.Show(message, "Adventure Game Studio", MessageBoxButtons.OK, icon);
@@ -853,7 +859,8 @@ namespace AGS.Editor
 				if (arg.ToLower() == "/compile")
 				{
 					compileAndExit = true;
-				}
+                    StdConsoleWriter.Enable();
+                }
 				else if (arg.StartsWith("/") || arg.StartsWith("-"))
 				{
 					this.ShowMessage("Invalid command line argument " + arg, MessageBoxIcon.Warning);

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -877,7 +877,14 @@ namespace AGS.Editor
                     _agsEditor.SaveUserDataFile(); // in case pending config is applied
 
                 _batchProcessShutdown = true;
-                if (messages.Count > 0) error = true;
+                if (messages.Count == 0)
+                {
+                    BuildCommandsComponent.ShowCompileSuccessMessage();
+                }
+                else
+                {
+                    error = true;
+                }
             }
             if(error) Program.SetExitCode(1);
             this.ExitApplication();

--- a/Editor/AGS.Editor/GUI/GUIController.cs
+++ b/Editor/AGS.Editor/GUI/GUIController.cs
@@ -894,12 +894,10 @@ namespace AGS.Editor
                             var messages = _agsEditor.CompileGame(forceRebuild, false);
                             if (forceRebuild)
                                 _agsEditor.SaveUserDataFile(); // in case pending config is applied
-                            if (!messages.HasErrors)
-							{
-								_batchProcessShutdown = true;
-								this.ExitApplication();
-							}
-						}
+
+                            _batchProcessShutdown = true;
+                            this.ExitApplication();
+                        }
 						return false;
 					}
 				}

--- a/Editor/AGS.Editor/GUI/frmMain.cs
+++ b/Editor/AGS.Editor/GUI/frmMain.cs
@@ -413,11 +413,6 @@ namespace AGS.Editor
         private void frmMain_Shown(object sender, EventArgs e)
         {
             this.tabbedDocumentContainer1.Init();
-            
-            if (AGS.Types.Version.IS_BETA_VERSION)
-			{
-				Factory.GUIController.ShowMessage("This is a BETA version of AGS. BE VERY CAREFUL and MAKE SURE YOU BACKUP YOUR GAME before loading it in this editor.", MessageBoxIcon.Warning);
-			}
 
             Factory.GUIController.ShowWelcomeScreen();
         }

--- a/Editor/AGS.Editor/Program.cs
+++ b/Editor/AGS.Editor/Program.cs
@@ -16,12 +16,20 @@ namespace AGS.Editor
     {
         private static ApplicationController _application;
 
+        private static int _exitCode = 0;
+
+        public static void SetExitCode(int exit_code)
+        {
+            _exitCode = exit_code;
+        }
+
         [STAThread]
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             RunApplication(args);
+            return _exitCode;
         }
 
         private static void RunApplication(string[] args)

--- a/Editor/AGS.Editor/Utils/CommandLineOptions.cs
+++ b/Editor/AGS.Editor/Utils/CommandLineOptions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AGS.Editor
+{
+	class CommandLineOptions
+	{
+		private bool _compileAndExit;
+		private string _projectPath;
+
+		private void Parse(string[] args)
+		{
+			_compileAndExit = false;
+
+			foreach (string arg in args)
+			{
+				if (arg.ToLower() == "/compile")
+				{
+					_compileAndExit = true;
+					StdConsoleWriter.Enable();
+				}
+				else if (arg.StartsWith("/") || arg.StartsWith("-"))
+				{
+					Factory.GUIController.ShowMessage("Invalid command line argument " + arg, MessageBoxIcon.Warning);
+				}
+				else
+				{
+					if (!File.Exists(arg))
+					{
+						_compileAndExit = false;
+						Factory.GUIController.ShowMessage("Unable to load the game '" + arg + "' because it does not exist", MessageBoxIcon.Warning);
+					}
+					else
+					{
+						_projectPath = arg;
+					}
+				}
+			}
+			if (string.IsNullOrEmpty(_projectPath)) _compileAndExit = false;
+		}
+
+		public CommandLineOptions(string[] args)
+		{
+			Parse(args);
+		}
+
+		public bool CompileAndExit 
+		{
+			get { return _compileAndExit; }
+		}
+
+		public string ProjectPath
+		{
+			get { return _projectPath; }
+		}
+	}
+}

--- a/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
+++ b/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+
+namespace AGS.Editor
+{
+    // based on the code from the answer here https://stackoverflow.com/a/14199852
+
+    public sealed class StdConsoleWriter
+    {
+        private StdConsoleWriter()
+        {
+            AttachConsole(ATTACH_PARENT_PROCESS);
+        }
+        private void WriteOutLine(string line)
+        {
+            Console.WriteLine("AGS: " + line);
+        }
+
+        private static bool _on;
+        private static StdConsoleWriter _instance;
+        private static StdConsoleWriter GetInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = new StdConsoleWriter();
+            }
+            return _instance;
+        }
+
+        [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+        private static extern bool AttachConsole(int dwProcessId);
+
+        private const int ATTACH_PARENT_PROCESS = -1;
+
+        static public void Enable()
+        {
+            _on = true;
+        }
+
+        static public bool IsEnabled
+        {
+            get { return _on; }
+        }
+
+        static public void WriteLine(string line)
+        {
+            if (_on)
+            {
+                GetInstance().WriteOutLine(line);
+            }
+        }
+
+    }
+}

--- a/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
+++ b/Editor/AGS.Editor/Utils/StdConsoleWriter.cs
@@ -7,13 +7,38 @@ namespace AGS.Editor
 
     public sealed class StdConsoleWriter
     {
+        private readonly bool _attached = false;
+        private bool _firstLine = true;
+
         private StdConsoleWriter()
         {
-            AttachConsole(ATTACH_PARENT_PROCESS);
+            // for some reason Console.IsOutputRedirect is not working for me in the old cmd.exe
+            // we only want to attach if output is not being redirected
+            var stdout = Console.OpenStandardOutput();
+            if (stdout == Stream.Null)
+            {
+                _attached = AttachConsole(ATTACH_PARENT_PROCESS);
+            }
         }
+
         private void WriteOutLine(string line)
         {
-            Console.WriteLine("AGS: " + line);
+            const string prefix = "AGS: ";
+            string msg = prefix + line;
+
+            if (_attached && _firstLine)
+            {
+                // AGSEditor is a Windows Application and not a Console Application
+                // so it will release the console before we attach again and print an unused prompt line (in cmd.exe)
+                // the line below erases this line and prints the first message on top of it
+                // this is only necessary once, in the first line printed, and only if not attached to a console
+                ClearPrint(msg);
+            }
+            else 
+            { 
+                Console.WriteLine(msg);
+            }
+            _firstLine = false;
         }
 
         private static bool _on;
@@ -25,6 +50,11 @@ namespace AGS.Editor
                 _instance = new StdConsoleWriter();
             }
             return _instance;
+        }
+
+        private static void ClearPrint(string msg)
+        {
+            Console.WriteLine($"\r{msg}{new String(' ', Console.BufferWidth - msg.Length)}");
         }
 
         [System.Runtime.InteropServices.DllImport("kernel32.dll")]

--- a/Editor/AGS.Types/Exceptions/CompileMessage.cs
+++ b/Editor/AGS.Types/Exceptions/CompileMessage.cs
@@ -46,5 +46,19 @@ namespace AGS.Types
             get { return _lineNumber; }
         }
 
+        public string AsString
+        {
+            get
+            {
+                if(_lineNumber == 0 && string.IsNullOrEmpty(_scriptName))
+                {
+                    return Message;
+                }
+                else
+                {
+                    return Message + " at line " + _lineNumber.ToString() + " in " + _scriptName + ".";
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
fix #666

The goal here is so that using `/compile` flag the Editor won't show a pop-up or require human input in some way it could hang a continuous integration pipeline - because no one would be there to click the button.

- `/compile` will make the Editor alert messages get logged to the terminal
- Additionally, messages that goes to the output panel also gets logged to the terminal
- The software exit code will be non-zero if the compilation failed when using `/compile`
  - This can be used to fail a pipeline in case we have a build error in a game