### PR TITLE
Remove deprecated inheritance from std::x_function

### DIFF
--- a/Common/core/assetmanager.cpp
+++ b/Common/core/assetmanager.cpp
@@ -39,20 +39,19 @@ bool AssetManager::AssetLibEx::TestFilter(const String &filter) const
         (std::find(Filters.begin(), Filters.end(), filter) != Filters.end());
 }
 
-
-bool AssetManager::LibsByPriority::operator()(const AssetLibInfo *lib1, const AssetLibInfo *lib2) const
+// Asset library sorting function, directories have priority
+bool SortLibsPriorityDir(const AssetLibInfo *lib1, const AssetLibInfo *lib2)
 {
-    const bool lib1dir = IsAssetLibDir(lib1);
-    const bool lib2dir = IsAssetLibDir(lib2);
-    if (lib1dir == lib2dir)
-        return false; // both are equal, none is less
-    if (Priority == kAssetPriorityLib)
-        return !lib1dir; // first element is less if it's library file
-    if (Priority == kAssetPriorityDir)
-        return lib1dir; // first element is less if it's directory
-    return false; // unknown priority, just fail
+    // first element is less if it's a directory while second is a lib
+    return IsAssetLibDir(lib1) && !IsAssetLibDir(lib2);
 }
 
+// Asset library sorting function, packages have priority
+bool SortLibsPriorityLib(const AssetLibInfo *lib1, const AssetLibInfo *lib2)
+{
+    // first element is less if it's a lib while second is a directory
+    return !IsAssetLibDir(lib1) && IsAssetLibDir(lib2);
+}
 
 /* static */ bool AssetManager::IsDataFile(const String &data_file)
 {
@@ -78,20 +77,16 @@ bool AssetManager::LibsByPriority::operator()(const AssetLibInfo *lib1, const As
     return kAssetErrNoLibFile;
 }
 
-AssetManager::AssetManager()
-{
-    _libsByPriority.Priority = kAssetPriorityDir;
-}
-
 void AssetManager::SetSearchPriority(AssetSearchPriority priority)
 {
-    _libsByPriority.Priority = priority;
-    std::sort(_activeLibs.begin(), _activeLibs.end(), _libsByPriority);
+    _libsPriority = priority;
+    _libsSorter = _libsPriority == kAssetPriorityDir ? SortLibsPriorityDir : SortLibsPriorityLib;
+    std::sort(_activeLibs.begin(), _activeLibs.end(), _libsSorter);
 }
 
 AssetSearchPriority AssetManager::GetSearchPriority() const
 {
-    return _libsByPriority.Priority;
+    return _libsPriority;
 }
 
 AssetError AssetManager::AddLibrary(const String &path, const AssetLibInfo **out_lib)
@@ -121,7 +116,7 @@ AssetError AssetManager::AddLibrary(const String &path, const String &filters, c
     if (err != kAssetNoError)
         return err;
     lib->Filters = filters.Split(',');
-    auto place = std::upper_bound(_activeLibs.begin(), _activeLibs.end(), lib, _libsByPriority);
+    auto place = std::upper_bound(_activeLibs.begin(), _activeLibs.end(), lib, _libsSorter);
     _activeLibs.insert(place, lib);
     if (out_lib)
         *out_lib = lib;

--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -69,7 +69,7 @@ struct AssetPath
 class AssetManager
 {
 public:
-    AssetManager();
+    AssetManager() = default;
     ~AssetManager() = default;
 
     // Test if given file is main data file
@@ -128,12 +128,9 @@ private:
 
     std::vector<std::unique_ptr<AssetLibEx>> _libs;
     std::vector<AssetLibEx*> _activeLibs;
-
-    struct LibsByPriority
-    {
-        AssetSearchPriority Priority = kAssetPriorityDir;
-        bool operator()(const AssetLibInfo*, const AssetLibInfo*) const;
-    } _libsByPriority;
+    AssetSearchPriority _libsPriority = kAssetPriorityDir;
+    // Sorting function, depends on priority setting
+    std::function<bool(const AssetLibInfo*, const AssetLibInfo*)> _libsSorter;
 };
 
 

--- a/Common/core/assetmanager.h
+++ b/Common/core/assetmanager.h
@@ -129,7 +129,7 @@ private:
     std::vector<std::unique_ptr<AssetLibEx>> _libs;
     std::vector<AssetLibEx*> _activeLibs;
 
-    struct LibsByPriority : public std::binary_function<const AssetLibInfo*, const AssetLibInfo*, bool>
+    struct LibsByPriority
     {
         AssetSearchPriority Priority = kAssetPriorityDir;
         bool operator()(const AssetLibInfo*, const AssetLibInfo*) const;

--- a/Common/util/string_types.h
+++ b/Common/util/string_types.h
@@ -49,22 +49,15 @@ inline size_t Hash_LowerCase(const char *data, const size_t len)
 // A std::hash specialization for AGS String
 namespace std
 {
-#ifdef AGS_NEEDS_TR1
-namespace tr1
-{
-#endif
 // std::hash for String object
 template<>
-struct hash<AGS::Common::String> : public unary_function<AGS::Common::String, size_t>
+struct hash<AGS::Common::String>
 {
     size_t operator ()(const AGS::Common::String &key) const
     {
         return FNV::Hash(key.GetCStr(), key.GetLength());
     }
 };
-#ifdef AGS_NEEDS_TR1
-}
-#endif
 }
 
 
@@ -78,7 +71,7 @@ namespace Common
 //
 
 // Test case-insensitive String equality
-struct StrEqNoCase : public std::binary_function<String, String, bool>
+struct StrEqNoCase
 {
     bool operator()(const String &s1, const String &s2) const
     {
@@ -87,7 +80,7 @@ struct StrEqNoCase : public std::binary_function<String, String, bool>
 };
 
 // Case-insensitive String less
-struct StrLessNoCase : public std::binary_function<String, String, bool>
+struct StrLessNoCase
 {
     bool operator()(const String &s1, const String &s2) const
     {
@@ -96,7 +89,7 @@ struct StrLessNoCase : public std::binary_function<String, String, bool>
 };
 
 // Compute case-insensitive hash for a String object
-struct HashStrNoCase : public std::unary_function<String, size_t>
+struct HashStrNoCase
 {
     size_t operator ()(const String &key) const
     {


### PR DESCRIPTION
Fix #2247

std::unary_function and std::binary_function have been deprecated in C++11, and removed completely in C++17.
The std algorithms are supposed to accept any functor that defines correct operator.

Additionally, in AssetManager replaced struct LibsByPriority with a function pointer and 2 sorting functions. This is to avoid making redundant checks for a priority type during sort operations.