### PR TITLE
libsrc: fix shasum for SDL_sound

### DIFF
--- a/libsrc/sha1sums
+++ b/libsrc/sha1sums
@@ -1,5 +1,5 @@
 16c7c4844d8b5e8027dfb134d2971746bb1382c3  SDL.tar.gz
-1507be95c3605e4fd6a48ea4c527e4aa711a1566  SDL_sound.tar.gz
+d7374080bcb6d346f628c1a59f1492c674558507  SDL_sound.tar.gz
 8085a94164c1eb6cfab245c5b4306c2d3ec847cd  ogg.tar.gz
 beaeae25bc7ace77007f42c33e0b0fa74acf4992  theora.tar.gz
 76f06629562d52a9539818f3b78722fbc9e19ddb  vorbis.tar.gz


### PR DESCRIPTION
broken by 1d6acae994a1bff8fec8b7401f78926ed64d4502

(I broke it by mistake in #2200)