### PR TITLE
Engine: ali3dogl iOS fix for SDL renderbuffer

### DIFF
--- a/Engine/gfx/ali3dogl.cpp
+++ b/Engine/gfx/ali3dogl.cpp
@@ -53,6 +53,7 @@ const char* fbo_extension_string = "GL_OES_framebuffer_object";
 const void (*glSwapIntervalEXT)(int) = NULL;
 
 #define GL_FRAMEBUFFER_EXT GL_FRAMEBUFFER
+#define GL_FRAMEBUFFER_COMPLETE_EXT GL_FRAMEBUFFER_COMPLETE
 #define GL_COLOR_ATTACHMENT0_EXT GL_COLOR_ATTACHMENT0
 
 #endif //AGS_OPENGL_ES2
@@ -299,6 +300,11 @@ bool OGLGraphicsDriver::CreateWindowAndGlContext(const DisplayMode &mode)
   if (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1) != 0)
     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Error occured setting attribute SDL_GL_CONTEXT_MINOR_VERSION: %s", SDL_GetError());
 #endif
+#if AGS_PLATFORM_OS_IOS
+  // minimum number of bits for the depth buffer
+  if (SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0) != 0)
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Error occured setting attribute SDL_GL_DEPTH_SIZE: %s", SDL_GetError());
+#endif
   if (SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1) != 0)
     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Error occured setting attribute SDL_GL_DOUBLEBUFFER: %s", SDL_GetError());
 
@@ -334,6 +340,11 @@ bool OGLGraphicsDriver::CreateWindowAndGlContext(const DisplayMode &mode)
 #endif
   _sdlWindow = sdl_window;
   _sdlGlContext = sdlgl_ctx;
+#if AGS_PLATFORM_OS_IOS
+  // The SDL implementation of the iOS OpenGL view (SDL_uikitopenglview.m) generates its own framebuffer to target the renderbuffer
+  // Instead of using framebuffer 0, we ask OpenGL to get the current framebuffer.
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_screenFramebuffer);
+#endif
   return true;
 }
 
@@ -726,8 +737,12 @@ void OGLGraphicsDriver::SetupBackbufferTexture()
   glGenFramebuffersEXT(1, &_fbo);
   glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _fbo);
   glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, _backbuffer, 0);
+  
+  GLenum status  = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+  if (status != GL_FRAMEBUFFER_COMPLETE_EXT)
+    Debug::Printf(kDbgMsg_Error, "Error while setting OpenGL backbuffer: %x", status);
 
-  glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+  glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _screenFramebuffer);
 
   // Assign vertices of the backbuffer texture position in the scene
   _backbuffer_vertices[0] = _backbuffer_vertices[4] = 0;
@@ -1206,7 +1221,7 @@ void OGLGraphicsDriver::_render(bool clearDrawListAfterwards)
     glUniform1f(program.Alpha, 1.0f);
 
     // Texture is ready, now create rectangle in the world space and draw texture upon it
-    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _screenFramebuffer);
 
     glViewport(_viewportRect.Left, _viewportRect.Top, _viewportRect.GetWidth(), _viewportRect.GetHeight());
 
@@ -1299,7 +1314,7 @@ void OGLGraphicsDriver::SetRenderTarget(const OGLSpriteBatch *batch, Size &surfa
         else
         {
             surface_sz = _srcRect.GetSize();
-            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0u);
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _screenFramebuffer);
             glViewport(_viewportRect.Left, _viewportRect.Top, _viewportRect.GetWidth(), _viewportRect.GetHeight());
         }
         projection = glm::ortho(0.0f, (float)surface_sz.Width, 0.0f, (float)surface_sz.Height, 0.0f, 1.0f);
@@ -1764,7 +1779,7 @@ IDriverDependantBitmap* OGLGraphicsDriver::CreateRenderTargetDDB(int width, int 
     // FIXME: this ugly accessing internal texture members
     unsigned int tex = ddb->_data->_tiles[0].texture;
     glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, tex, 0);
-    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _screenFramebuffer);
     ddb->_renderHint = kTxHint_PremulAlpha;
     return ddb;
 }

--- a/Engine/gfx/ali3dogl.h
+++ b/Engine/gfx/ali3dogl.h
@@ -322,6 +322,7 @@ private:
     int _super_sampling {};
     unsigned int _backbuffer {};
     unsigned int _fbo {};
+    GLint _screenFramebuffer = 0;
     // Size of the backbuffer drawing area, equals to native size
     // multiplied by _super_sampling
     Size _backRenderSize {};


### PR DESCRIPTION
- SDL iOS OpenGL view ([SDL_uikitopenglview.m](https://github.com/libsdl-org/SDL/blob/SDL2/src/video/uikit/SDL_uikitopenglview.m)) generates its own framebuffer, use it instead of 0
- Ensure that iOS is initialized with a 0 depth size to avoid generated depth framebuffers
- Add missing GL_FRAMEBUFFER_COMPLETE_EXT definition

@edmundito is working on the iOS port I left unfinished. Most of the changes are in the `iOS` directory. I want to pick the ones that aren't in small bits to make it easier to review, as there isn't a lot of stuff.